### PR TITLE
Simplify reconnect error message

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -938,8 +938,7 @@ function connectWs() {
       reconnectAttempts++;
       if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
         addSystem('Could not connect to the voice agent after ' + MAX_RECONNECT_ATTEMPTS + ' attempts.');
-        addSystem('Run: bash src/startup.sh — this restarts all services.');
-        addSystem('Then run claude in the sutando directory to start the core agent.');
+        addSystem('Run: bash src/startup.sh — this restarts all services including Claude Code.');
         setStatus('Disconnected', 'error');
         connected = false;
         reconnectAttempts = 0;


### PR DESCRIPTION
startup.sh already starts Claude Code, so no need for separate instruction.