### PR TITLE
startup.sh: auto-install npm dependencies

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -10,6 +10,9 @@ cd "$REPO"
 echo "Sutando startup..."
 echo ""
 
+# Install dependencies if needed
+[ -d node_modules ] || npm install
+
 # Check prerequisites
 missing=0
 if ! command -v node > /dev/null 2>&1; then echo "  ✗ node not found — brew install node"; missing=1; fi


### PR DESCRIPTION
## Summary
- Adds `[ -d node_modules ] || npm install` to startup.sh
- Skips if already installed, runs automatically for new users
- Saves one step in the quick start flow

## Test plan
- [ ] `rm -rf node_modules && bash src/startup.sh` — should auto-install
- [ ] `bash src/startup.sh` with existing node_modules — should skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)