### PR TITLE
Discord: fix auto-pair security + forwarded message support

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -98,7 +98,12 @@ async def on_message(message):
     is_dm = isinstance(message.channel, discord.DMChannel)
     channel_name = getattr(message.channel, 'name', 'DM')
 
-    print(f"  [msg] #{channel_name} @{username}: {text[:80]} (mentions: {[str(m) for m in message.mentions]}, is_dm: {is_dm})", flush=True)
+    print(f"  [msg] #{channel_name} @{username}: {text[:80]} (mentions: {[str(m) for m in message.mentions]}, is_dm: {is_dm}, embeds: {len(message.embeds)}, type: {message.type}, ref: {message.reference is not None})", flush=True)
+    # Debug: log message snapshots for forwarded messages
+    if hasattr(message, 'message_snapshots') and message.message_snapshots:
+        print(f"  [debug] message_snapshots: {message.message_snapshots}", flush=True)
+    if message.type != discord.MessageType.default and message.type != discord.MessageType.reply:
+        print(f"  [debug] non-default message type: {message.type}", flush=True)
 
     # In channels, check if mention is required
     if not is_dm:
@@ -155,11 +160,50 @@ async def on_message(message):
                 return
 
     if policy == "pairing" and sender_id not in allowed:
-        # Auto-pair: save their ID and notify
-        save_to_allowlist(sender_id)
-        await message.channel.send(f"Paired! Your ID `{sender_id}` has been added. Say hi to Sutando.")
-        print(f"  Auto-paired @{username} ({sender_id})")
+        # Generate pairing code — user must approve via /discord:access pair <code>
+        import random, string
+        code = ''.join(random.choices(string.ascii_lowercase + string.digits, k=6))
+        pending = access.get("pending", {})
+        pending[code] = {
+            "senderId": sender_id,
+            "chatId": str(message.channel.id),
+            "createdAt": int(time.time() * 1000),
+            "expiresAt": int(time.time() * 1000) + 3600000,  # 1 hour
+        }
+        access["pending"] = pending
+        ACCESS_FILE.write_text(json.dumps(access, indent=2))
+        await message.channel.send(f"Pairing required. Ask the owner to run:\n`/discord:access pair {code}`")
+        print(f"  Pairing requested: @{username} ({sender_id}) code={code}")
         return
+
+    # Handle forwarded messages (message_snapshots) — Discord's forwarding feature
+    if hasattr(message, 'message_snapshots') and message.message_snapshots:
+        for snapshot in message.message_snapshots:
+            snap_msg = snapshot.message if hasattr(snapshot, 'message') else snapshot
+            snap_content = getattr(snap_msg, 'content', '') or ''
+            snap_author = ''
+            if hasattr(snap_msg, 'author') and snap_msg.author:
+                snap_author = f"[Forwarded from {snap_msg.author}] "
+            if snap_content:
+                text = (text + "\n" + snap_author + snap_content).strip() if text else (snap_author + snap_content).strip()
+                print(f"  [forward] extracted: {text[:100]}", flush=True)
+
+    # Handle embeds (link previews, rich content)
+    embed_text = ""
+    for embed in message.embeds:
+        parts = []
+        if embed.author and embed.author.name:
+            parts.append(f"[From {embed.author.name}]")
+        if embed.title:
+            parts.append(embed.title)
+        if embed.description:
+            parts.append(embed.description)
+        for field in embed.fields:
+            parts.append(f"{field.name}: {field.value}")
+        if parts:
+            embed_text += "\n".join(parts) + "\n"
+    if embed_text:
+        text = (text + "\n" + embed_text).strip() if text else embed_text.strip()
 
     # Handle attachments
     attachment_note = ""

--- a/src/watch-tasks.sh
+++ b/src/watch-tasks.sh
@@ -2,23 +2,19 @@
 # Watch for new task files in tasks/ directory.
 # Usage: bash src/watch-tasks.sh (run_in_background: true)
 #
-# Uses fswatch -1 (one-shot) to detect new files, then exits with a message.
-# The caller restarts this after processing tasks.
-# Dedup: kills any existing fswatch watcher before starting.
+# Uses fswatch -1 to detect one new file, then exits.
+# The caller processes tasks and restarts.
 
 TASKS_DIR="${1:-$(dirname "$0")/../tasks}"
 
-# Kill any existing fswatch watchers to prevent duplicates
-# Use grep -v $$ to avoid killing ourselves
-for pid in $(pgrep -f "fswatch.*tasks" 2>/dev/null); do
-  if [ "$pid" != "$$" ] && [ "$pid" != "$PPID" ]; then
-    kill "$pid" 2>/dev/null
-  fi
-done
+# Exit if another watcher is already running (don't kill it)
+if pgrep -f "fswatch.*tasks" >/dev/null 2>&1; then
+  exit 0
+fi
 
-# Watch for new files (blocks until a change is detected)
-fswatch -1 --event Created --event Updated "$TASKS_DIR" >/dev/null 2>&1
+# Wait for a new file event
+fswatch -1 --event Created --event Updated --include '\.txt$' --exclude '.*' "$TASKS_DIR" >/dev/null 2>&1
 
-# Output what was found
-echo "TASK_DETECTED: Process ALL .txt files in tasks/ before restarting the watcher."
+# Report what's there
+echo "TASK_DETECTED: Process ALL .txt files in tasks/."
 ls "$TASKS_DIR"/*.txt 2>/dev/null || true


### PR DESCRIPTION
## Summary
- **Security fix**: Auto-pair removed — was silently adding anyone who DMed to allowlist. Now generates pairing code requiring owner approval via `/discord:access pair <code>`
- **Forwarded messages**: Extract content from `message_snapshots` (Discord's forwarding feature). Also parses embeds for rich content
- **Watcher**: Simplified script — removed dedup kill logic, added duplicate guard + .txt filter

## Test plan
- [ ] DM the bot from a new account — should get pairing code, NOT auto-added
- [ ] Forward a message to the bot — content should come through as task
- [ ] Watcher: verify only one fswatch runs at a time

🤖 Generated with [Claude Code](https://claude.com/claude-code)