### PR TITLE
Web UI: keep retrying + specific errors; watcher pre-check fix

### DIFF
--- a/src/watch-tasks.sh
+++ b/src/watch-tasks.sh
@@ -7,16 +7,17 @@
 
 TASKS_DIR="${1:-$(dirname "$0")/../tasks}"
 
-# Exit if another fswatch process is already watching tasks/
-# Use pgrep -x to match only the fswatch binary, not this script
-if pgrep -x fswatch >/dev/null 2>&1; then
-  exit 0
-fi
-
 # Wait for a new .txt file — loop until one actually appears
 while true; do
+  # Check for existing files BEFORE waiting (catches files written during restarts)
+  if ls "$TASKS_DIR"/*.txt >/dev/null 2>&1; then
+    echo "TASK_DETECTED: Process ALL .txt files in tasks/."
+    ls "$TASKS_DIR"/*.txt
+    break
+  fi
+  # Wait for next filesystem event
   fswatch -1 -l 1 "$TASKS_DIR" >/dev/null 2>&1
-  # Only exit if .txt files actually exist
+  # Check again after event
   if ls "$TASKS_DIR"/*.txt >/dev/null 2>&1; then
     echo "TASK_DETECTED: Process ALL .txt files in tasks/."
     ls "$TASKS_DIR"/*.txt

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -974,22 +974,24 @@ function connectWs() {
       // Unexpected drop (Gemini timeout) — auto-reconnect with limit
       reconnectAttempts++;
       if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
-        addSystem('Could not connect to the voice agent after ' + MAX_RECONNECT_ATTEMPTS + ' attempts.');
-        addSystem('Check the terminal where you ran startup.sh — that is the Sutando core CLI. You can type commands there directly.');
-        addSystem('To restart all services: bash src/restart.sh');
-        setStatus('Disconnected', 'error');
-        connected = false;
-        reconnectAttempts = 0;
+        addSystem('Still trying to connect. Common causes:');
+        addSystem('1. GEMINI_API_KEY not set — edit .env and add your key from ai.google.dev');
+        addSystem('2. Voice agent not running — run: bash src/startup.sh');
+        addSystem('3. Port 9900 blocked — check: lsof -i :9900');
+        addSystem('You can type commands below while reconnecting.');
+        setStatus('Reconnecting...', 'error');
+        reconnectAttempts = 0;  // reset counter and keep retrying
       } else {
         addSystem('Connection lost — reconnecting (' + reconnectAttempts + '/' + MAX_RECONNECT_ATTEMPTS + ')...');
         setStatus('Reconnecting...', 'error');
-        setTimeout(() => {
-          if (!connected) {
-            dbg('Auto-reconnecting (attempt ' + reconnectAttempts + ')...');
-            toggle();
-          }
-        }, 3000);
       }
+      // Always retry
+      setTimeout(() => {
+        if (!connected) {
+          dbg('Auto-reconnecting (attempt ' + reconnectAttempts + ')...');
+          toggle();
+        }
+      }, 3000);
     }
   };
 


### PR DESCRIPTION
## Summary
- **Web UI reconnect**: Shows specific troubleshooting causes after 5 attempts (GEMINI_API_KEY, startup.sh, port) but keeps retrying forever instead of stopping
- **Watcher**: Removed pgrep dedup guard that blocked the pre-check from running, causing missed tasks

## Test plan
- [ ] Disconnect voice agent — web UI keeps retrying with helpful messages
- [ ] Create task file while watcher running — should detect
- [ ] Create task file, restart watcher — pre-check should find it immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)