### PR TITLE
Web UI: help links + copy logs; watcher debug output

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -255,6 +255,14 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.send_header("Cache-Control", "public, max-age=300")
             self.end_headers()
             self.wfile.write(media_path.read_bytes())
+        elif path == "/logs/voice":
+            # Return last 30 lines of voice-agent.log for debugging
+            log_file = REPO_DIR / "src" / "voice-agent.log"
+            if log_file.exists():
+                lines = log_file.read_text().splitlines()[-30:]
+                self.send_json(200, {"lines": lines})
+            else:
+                self.send_json(404, {"error": "voice-agent.log not found"})
         elif path == "/":
             # Serve task submission form (works from phone on same Wi-Fi)
             self.send_response(200)

--- a/src/watch-tasks.sh
+++ b/src/watch-tasks.sh
@@ -12,15 +12,16 @@ while true; do
   # Check for existing files BEFORE waiting (catches files written during restarts)
   if ls "$TASKS_DIR"/*.txt >/dev/null 2>&1; then
     echo "TASK_DETECTED: Process ALL .txt files in tasks/."
-    ls "$TASKS_DIR"/*.txt
+    for f in "$TASKS_DIR"/*.txt; do echo "--- $(basename "$f") ---"; cat "$f"; done
     break
   fi
   # Wait for next filesystem event
-  fswatch -1 -l 1 "$TASKS_DIR" >/dev/null 2>&1
+  CHANGED=$(fswatch -1 -l 1 "$TASKS_DIR" 2>/dev/null)
+  echo "fswatch triggered: $CHANGED"
   # Check again after event
   if ls "$TASKS_DIR"/*.txt >/dev/null 2>&1; then
     echo "TASK_DETECTED: Process ALL .txt files in tasks/."
-    ls "$TASKS_DIR"/*.txt
+    for f in "$TASKS_DIR"/*.txt; do echo "--- $(basename "$f") ---"; cat "$f"; done
     break
   fi
   # False trigger — keep watching

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -457,10 +457,10 @@ function handleTranscript(role, text, partial) {
   $('transcript').scrollTop = $('transcript').scrollHeight;
 }
 
-function addSystem(text) {
+function addSystem(text, isHtml) {
   const el = document.createElement('div');
   el.className = 't-entry t-system';
-  el.textContent = text;
+  if (isHtml) { el.innerHTML = text; } else { el.textContent = text; }
   $('transcript').appendChild(el);
   $('transcript').scrollTop = $('transcript').scrollHeight;
 }
@@ -979,6 +979,7 @@ function connectWs() {
         addSystem('2. Voice agent not running — run: bash src/startup.sh');
         addSystem('3. Port 9900 blocked — check: lsof -i :9900');
         addSystem('You can type commands below while reconnecting.');
+        addSystem('<a href="https://discord.gg/uZHWXXmrCS" target="_blank" style="color:#5865F2">Ask for help on Discord</a> · <a href="https://github.com/sonichi/sutando/issues" target="_blank" style="color:#4ecca3">Report an issue</a> · <span style="color:#8899a6;cursor:pointer;text-decoration:underline" onclick="copyLogs()">Copy logs</span>', true);
         setStatus('Reconnecting...', 'error');
         reconnectAttempts = 0;  // reset counter and keep retrying
       } else {
@@ -1069,6 +1070,16 @@ function toggle() {
 }
 
 // ─── Suggestion chips ─────────────────────────────────────
+function copyLogs() {
+  var apiBase = 'http://' + location.hostname + ':7843';
+  fetch(apiBase + '/logs/voice').then(function(r) { return r.json(); }).then(function(d) {
+    var text = (d.lines || []).join(String.fromCharCode(10));
+    navigator.clipboard.writeText(text).then(function() {
+      addSystem('Logs copied to clipboard (last 30 lines). Paste in Discord or GitHub issue.');
+    });
+  }).catch(function() { addSystem('Could not fetch logs — is the agent API running?'); });
+}
+
 function answerQuestion(qid, answer) {
   if (!answer || !answer.trim()) return;
   const apiBase = 'http://' + location.hostname + ':7843';


### PR DESCRIPTION
## Summary
- **Help links**: Discord + GitHub Issues links in reconnect error messages
- **Copy logs**: One-click button fetches voice-agent.log tail via `/logs/voice` API, copies to clipboard
- **Watcher**: Outputs full task content on detection, shows fswatch trigger path

## Test plan
- [ ] Disconnect voice agent — after 5 attempts see help links + copy logs
- [ ] Click "Copy logs" — clipboard should have voice-agent.log tail
- [ ] Watcher output shows task content when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)