### PR TITLE
Fix agent-api Python 3.9 compatibility

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -86,7 +86,7 @@ def get_status() -> dict:
     }
 
 
-def get_task_result(task_id: str) -> dict | None:
+def get_task_result(task_id: str):
     """Check if a task result exists."""
     result_file = RESULT_DIR / f"{task_id}.txt"
     if result_file.exists():


### PR DESCRIPTION
## Summary
- Remove `dict | None` union type hint in `get_task_result()` — this syntax requires Python 3.10+, but the owner runs Python 3.9
- The function return type is inferred correctly without the annotation

## Test plan
- [ ] Verify `agent-api.py` starts without `SyntaxError` on Python 3.9
- [ ] Confirm `/status` and task result endpoints still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)