### PR TITLE
Fix OWNER_NUMBER parsing, tighten phone access, improve skills

### DIFF
--- a/skills/macos-tools/scripts/contacts.py
+++ b/skills/macos-tools/scripts/contacts.py
@@ -89,6 +89,39 @@ def main():
                 print(f"    email: {e}")
             for p in c["phones"]:
                 print(f"    phone: {p}")
+    elif cmd == "add" and len(sys.argv) >= 3:
+        name = sys.argv[2]
+        phone = None
+        email = None
+        i = 3
+        while i < len(sys.argv):
+            if sys.argv[i] == "--phone" and i + 1 < len(sys.argv):
+                phone = sys.argv[i + 1]; i += 2
+            elif sys.argv[i] == "--email" and i + 1 < len(sys.argv):
+                email = sys.argv[i + 1]; i += 2
+            else:
+                i += 1
+        parts = name.split(" ", 1)
+        first = parts[0]
+        last = parts[1] if len(parts) > 1 else ""
+        import time
+        subprocess.run(["open", "-ga", "Contacts"], capture_output=True, timeout=5)
+        time.sleep(1)
+        props = f'first name:"{first}"'
+        if last:
+            props += f', last name:"{last}"'
+        lines = [f'set newPerson to make new person with properties {{{props}}}']
+        if phone:
+            lines.append(f'make new phone at end of phones of newPerson with properties {{label:"mobile", value:"{phone}"}}')
+        if email:
+            lines.append(f'make new email at end of emails of newPerson with properties {{label:"home", value:"{email}"}}')
+        lines.append("save")
+        script = 'tell application "Contacts"\n' + "\n".join(lines) + '\nend tell'
+        result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True, timeout=15)
+        if result.returncode != 0:
+            print(f"Error: {result.stderr.strip()}")
+            sys.exit(1)
+        print(f"Added {name}" + (f" phone:{phone}" if phone else "") + (f" email:{email}" if email else ""))
     elif cmd == "all":
         results = search_contacts("")
         if not results:
@@ -97,6 +130,7 @@ def main():
         print(json.dumps(results, indent=2))
     else:
         print("Usage: python3 src/contacts.py search 'name'")
+        print("       python3 src/contacts.py add 'Name' --phone 123 --email a@b.com")
         sys.exit(1)
 
 

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -324,9 +324,9 @@ function buildAgent(callSession: CallSession): MainAgent {
 			isInbound && callSession.isOwner
 				? `Your owner${OWNER_NAME ? ` ${OWNER_NAME}` : ''} is calling you. YOU are Sutando — the AI assistant. The person on the phone is your OWNER, a human. Do NOT confuse yourself with the caller. You have full capabilities — use the work tool for anything: check the screen, send emails, look things up, make calls, browse the web, or check results of previous tasks. Say exactly: "Hi, this is Sutando. How can I help?" then WAIT for them to speak. Do NOT say anything else before they talk. Do NOT make up tasks, scenarios, or pretend you were doing something.${(() => { const ctx = getSafeContext(); return ctx ? `\n\nRecent voice conversation (for context — do NOT repeat or bring up unless asked):\n${ctx}` : ''; })()}`
 				: isInbound && callSession.callerVerified
-				? 'A verified caller is calling you. Be helpful and conversational. You have limited tools — you can look up meeting IDs, check the time, and adjust volume/brightness. You cannot delegate tasks, access files, or make calls on their behalf. Say "Hello, this is Sutando. How can I help?"'
+				? 'A verified caller is calling you. Be helpful and conversational. You can look up meeting IDs and check the time. You CAN answer general knowledge questions, do translations, and have conversations. You cannot access files, control the screen, or delegate tasks. Say "Hello, this is Sutando. How can I help?"'
 				: isInbound
-				? 'Someone is calling you. Be helpful and conversational. Greet them with "Hello, this is Sutando. How can I help?"'
+				? 'Someone is calling you. Be helpful and conversational. You CAN answer general knowledge questions, do translations, and have conversations — but you cannot access files, control the screen, or delegate tasks. Greet them with "Hello, this is Sutando. How can I help?"'
 				: callSession.isOwner
 				? `You are calling your owner${OWNER_NAME ? ` ${OWNER_NAME}` : ''}. The person who picks up IS your owner.`
 				: 'You initiated this call on behalf of your owner.',
@@ -1149,7 +1149,8 @@ wss.on('connection', (ws: WebSocket) => {
 					// Owner detection: number match + STIR/SHAKEN verification.
 					// A spoofed caller ID will fail STIR/SHAKEN (StirVerstat != TN-Validation-Passed-A).
 					// If StirVerstat is present and NOT A-level, downgrade owner to verified-only.
-					const numberMatchesOwner = OWNER_NUMBER ? normalizePhone(personOnLine) === normalizePhone(OWNER_NUMBER) : false;
+					const ownerNumbers = OWNER_NUMBER ? OWNER_NUMBER.split(',').map(n => normalizePhone(n.trim())) : [];
+					const numberMatchesOwner = ownerNumbers.length > 0 && ownerNumbers.includes(normalizePhone(personOnLine));
 					let isOwner: boolean;
 					if (numberMatchesOwner && stirVerstat && stirVerstat !== 'TN-Validation-Passed-A') {
 						// Number matches but caller ID not cryptographically verified — possible spoof

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -1072,11 +1072,12 @@ export const inlineTools = [
 
 /** Tools available to any caller (including unverified) */
 export const anyCallerTools = [
-	volumeTool, brightnessTool, getCurrentTimeTool,
+	getCurrentTimeTool,
 ];
 
 /** Owner-only tools (require isOwner) */
 export const ownerOnlyTools = [
+	volumeTool, brightnessTool,
 	scrollTool, switchTabTool, openUrlTool,
 	switchAppTool, captureScreenTool, typeTextTool,
 	clipboardTool, cancelTaskTool, toggleTasksTool, summonTool,


### PR DESCRIPTION
## Summary
- **OWNER_NUMBER**: Split on comma so multiple owner numbers work (was comparing entire comma-separated string)
- **Phone access**: Volume/brightness removed from unverified+verified callers (owner-only now)
- **Unverified callers**: Told they CAN answer knowledge questions (stops Gemini from refusing)
- **Contacts skill**: Added `add` command
- **Calendar skill**: Shows Google Meet links in event output

## Test plan
- [ ] Call from owner number — should be recognized as owner
- [ ] Call from unverified number — no volume/brightness, can answer questions
- [ ] `python3 contacts.py add "Test" --phone 123` — should add contact
- [ ] Calendar event with Meet link — should show in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)