### PR TITLE
Phone access: remove volume/brightness from unverified callers

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -465,8 +465,8 @@ function buildAgent(callSession: CallSession): MainAgent {
 
 	// --- 3-tier access control ---
 	// Owner (isOwner): work tool + all inline tools + get_task_status
-	// Verified (!isOwner + callerVerified): any-caller tools + configurable tools
-	// Unverified: any-caller tools only (volume, brightness, time, toggle_tasks)
+	// Verified (!isOwner + callerVerified): any-caller tools + configurable tools (volume, brightness, meeting ID)
+	// Unverified: any-caller tools only (time) + google search
 	// Access is determined entirely by the caller/callee phone number, not call type.
 
 	// Any-caller tools available to everyone (including unverified)

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -1072,7 +1072,7 @@ export const inlineTools = [
 
 /** Tools available to any caller (including unverified) */
 export const anyCallerTools = [
-	volumeTool, brightnessTool, getCurrentTimeTool,
+	getCurrentTimeTool,
 ];
 
 /** Owner-only tools (require isOwner) */
@@ -1085,5 +1085,5 @@ export const ownerOnlyTools = [
 
 /** Configurable tools — default to owner-only, can be opened to verified callers */
 export const configurableTools = [
-	lookupMeetingIdTool,
+	lookupMeetingIdTool, volumeTool, brightnessTool,
 ];


### PR DESCRIPTION
## Summary
- Move `volumeTool` and `brightnessTool` from `anyCallerTools` to `configurableTools`
- Unverified callers now only get `get_current_time` + google search (already enabled for all tiers via `googleSearch: true`)
- Verified callers and owner retain volume/brightness control

## Test plan
- [ ] Call as unverified number — confirm volume/brightness commands are rejected
- [ ] Call as verified number — confirm volume/brightness still work
- [ ] Call as owner — confirm all tools still available

🤖 Generated with [Claude Code](https://claude.com/claude-code)