### PR TITLE
Phone: fix duplicate voice responses on Gemini reconnect

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -605,8 +605,10 @@ async function createCallSession(params: {
 	// [Outbound audio chain] Override to send Gemini audio directly to Twilio
 	// Bypasses ClientTransport's internal WebSocket for lower latency
 	const sessionAny = session as any;
+	let isReplaying = false; // suppress audio during reconnect replay
 	sessionAny.handleAudioOutput = (data: string) => {
 		sessionAny.notificationQueue?.markAudioReceived?.();
+		if (isReplaying) return; // skip replayed audio from reconnect
 		if (params.twilioWs.readyState === WebSocket.OPEN) {
 			const pcmBuf = Buffer.from(data, 'base64');
 			const mulawBuf = pcm24kToMulaw8k(pcmBuf);
@@ -676,7 +678,9 @@ async function createCallSession(params: {
 			setTimeout(() => {
 				if (!callSession.hangingUp && activeCalls.has(callSession.callSid)) {
 					console.log(`${ts()} [Phone] reconnecting Gemini for ${callSession.callSid}`);
+					isReplaying = true; // mute audio while Gemini replays history
 					sessionAny.handleClientConnected();
+					setTimeout(() => { isReplaying = false; }, 3000); // unmute after replay
 				}
 			}, 1500);
 		}


### PR DESCRIPTION
## Summary
- When Gemini transport crashes (code 1008) and reconnects, conversation history is replayed, causing Gemini to regenerate audio for previously spoken responses
- The `handleAudioOutput` override sends every chunk to Twilio with no dedup, so callers hear the same response 2-4 times
- Fix: add `isReplaying` flag that mutes audio output during the 3s reconnect replay window

## Example (before fix)

Real call — Sutando repeats the same response **4 times** after Gemini reconnects:

```
Sutando: Hi, please join the Zoom meeting. The meeting ID is XXXXXXXXXX.
Caller:  Can you say again?
Sutando: Certainly. The meeting ID is XXXXXXXXXX.
Caller:  Does the meeting have a passcode?
Sutando: I'm back. Hi, please join the Zoom meeting. The meeting ID is XXXXXXXXXX.   ← duplicate (reconnect 1)
Sutando: Hi, this is Sutando calling. Please join the Zoom meeting...                  ← duplicate (reconnect 2)
Sutando: Hi, this is Sutando calling. Please join the Zoom meeting...                  ← duplicate (reconnect 3)
```

Each "I'm back" is a Gemini reconnect replaying conversation history and regenerating audio.

## Test results
- Manual phone call test after fix: no duplicate responses observed across 2 calls
- Transcript dedup check on call log: zero duplicates found

## Test plan
- [x] Call in, ask for a task (e.g. "find latest file in downloads") — passed, response heard once
- [x] Wait for response — should hear it once only — passed across 2 test calls
- [ ] If Gemini reconnects (check logs for "transport closed"), confirm no repeated audio — not triggered naturally
- [x] Check results/calls/calls.jsonl for duplicate transcript entries — passed, zero duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)