### PR TITLE
Fix health check to detect stuck bridges (#70)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -298,7 +298,14 @@ def save_to_allowlist(sender_id):
 
 async def poll_results():
     """Poll results/ for replies to send back to Discord."""
+    heartbeat_file = REPO / "src" / "discord-bridge.heartbeat"
+    heartbeat_counter = 0
     while True:
+        # Write heartbeat every 60 iterations (~60s)
+        heartbeat_counter += 1
+        if heartbeat_counter >= 60:
+            heartbeat_file.write_text(str(int(time.time())))
+            heartbeat_counter = 0
         for task_id in list(pending_replies.keys()):
             result_file = RESULTS_DIR / f"{task_id}.txt"
             if result_file.exists():

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -169,17 +169,48 @@ def run_all_checks() -> list[dict]:
     # Messaging bridges (optional — only check if configured)
     channels_dir = Path.home() / ".claude" / "channels"
     for name, proc_name in [("telegram-bridge", "telegram-bridge"), ("discord-bridge", "discord-bridge")]:
-        env_file = channels_dir / name.replace("-bridge", "") / ".env"
-        if env_file.exists():
-            try:
-                result = subprocess.run(["pgrep", "-f", proc_name], capture_output=True)
-                running = result.returncode == 0
-            except:
-                running = False
-            if running:
-                checks.append({"name": name, "status": "ok", "detail": "running"})
-            else:
-                checks.append({"name": name, "status": "warn", "detail": "configured but not running"})
+        channel_name = name.replace("-bridge", "")
+        env_file = channels_dir / channel_name / ".env"
+        access_file = channels_dir / channel_name / "access.json"
+        # Check if configured via either .env or access.json
+        if not env_file.exists() and not access_file.exists():
+            continue
+        try:
+            result = subprocess.run(["pgrep", "-f", proc_name], capture_output=True, text=True)
+            pids = result.stdout.strip().split("\n") if result.returncode == 0 else []
+            pids = [p for p in pids if p]
+        except:
+            pids = []
+
+        if not pids:
+            checks.append({"name": name, "status": "warn", "detail": "configured but not running"})
+            continue
+
+        # Check 1: Multiple processes (zombie/duplicate)
+        if len(pids) > 1:
+            checks.append({"name": name, "status": "warn", "detail": f"multiple processes ({len(pids)} PIDs: {','.join(pids)})"})
+            continue
+
+        # Check 2: Log file freshness
+        import time
+        log_file = REPO_DIR / "src" / f"{name}.log"
+        detail = "running"
+        status = "ok"
+        if log_file.exists():
+            age_sec = time.time() - log_file.stat().st_mtime
+            if age_sec > 300:  # 5 minutes
+                status = "warn"
+                detail = f"running but log stale ({int(age_sec)}s old)"
+
+        # Check 3: Heartbeat file freshness
+        heartbeat_file = REPO_DIR / "src" / f"{name}.heartbeat"
+        if heartbeat_file.exists():
+            hb_age = time.time() - heartbeat_file.stat().st_mtime
+            if hb_age > 120:  # 2 minutes
+                status = "warn"
+                detail = f"running but heartbeat stale ({int(hb_age)}s old)"
+
+        checks.append({"name": name, "status": status, "detail": detail})
 
     return checks
 

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -146,7 +146,14 @@ def main():
     allowed = load_allowed()
     pending_replies = {}  # task_id -> chat_id
 
+    heartbeat_file = REPO / "src" / "telegram-bridge.heartbeat"
+    heartbeat_counter = 0
     while True:
+        # Write heartbeat every 6 iterations (~60s with 10s timeout)
+        heartbeat_counter += 1
+        if heartbeat_counter >= 6:
+            heartbeat_file.write_text(str(int(time.time())))
+            heartbeat_counter = 0
         # Poll for new messages
         params = {"timeout": 10, "limit": 10}
         if offset:


### PR DESCRIPTION
## Summary
- Health check now detects stuck bridges, not just running processes
- Log file freshness check: stale log (>5 min) = warning
- Heartbeat file support: bridges write heartbeat every 60s, health check verifies
- Duplicate process detection: alerts if multiple bridge instances running
- Discord and Telegram bridges both write heartbeat files

## Test plan
- [x] Health check correctly flags Telegram bridge as stale (log 4.7 days old)
- [x] Discord bridge shows as healthy (log is fresh)
- [ ] Restart bridges to verify heartbeat files are created
- [ ] Kill bridge and verify health check detects it

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)