### PR TITLE
Add schedule-crons skill + contacts update command

### DIFF
--- a/skills/macos-tools/scripts/contacts.py
+++ b/skills/macos-tools/scripts/contacts.py
@@ -3,9 +3,12 @@
 Sutando contacts reader — search macOS Contacts via AppleScript.
 
 Usage:
-  python3 src/contacts.py search "Bob"         # search by name
-  python3 src/contacts.py search "bob@x.com"   # search by email
-  python3 src/contacts.py all                   # list all (first 50)
+  python3 contacts.py search "Bob"                          # search by name
+  python3 contacts.py search "bob@x.com"                    # search by email
+  python3 contacts.py add "Bob Smith" --phone 123 --email a@b.com  # add
+  python3 contacts.py update "Bob" --phone 456              # update phone
+  python3 contacts.py update "Bob" --email new@x.com        # update email
+  python3 contacts.py all                                   # list all (first 50)
 
 Output: name, email, phone for matching contacts.
 """
@@ -122,6 +125,48 @@ def main():
             print(f"Error: {result.stderr.strip()}")
             sys.exit(1)
         print(f"Added {name}" + (f" phone:{phone}" if phone else "") + (f" email:{email}" if email else ""))
+    elif cmd == "update" and len(sys.argv) >= 3:
+        name = sys.argv[2]
+        phone = None
+        email = None
+        i = 3
+        while i < len(sys.argv):
+            if sys.argv[i] == "--phone" and i + 1 < len(sys.argv):
+                phone = sys.argv[i + 1]; i += 2
+            elif sys.argv[i] == "--email" and i + 1 < len(sys.argv):
+                email = sys.argv[i + 1]; i += 2
+            else:
+                i += 1
+        if not phone and not email:
+            print("Error: provide --phone and/or --email to update")
+            sys.exit(1)
+        import time
+        subprocess.run(["open", "-ga", "Contacts"], capture_output=True, timeout=5)
+        time.sleep(1)
+        lines = [f'set results to (every person whose name contains "{name}")']
+        lines.append('if (count of results) = 0 then')
+        lines.append(f'    return "NOT_FOUND: no contact matching {name}"')
+        lines.append('end if')
+        lines.append('set p to item 1 of results')
+        if phone:
+            lines.append('-- Remove existing phones and add new one')
+            lines.append(f'repeat while (count of phones of p) > 0')
+            lines.append(f'    delete (item 1 of phones of p)')
+            lines.append(f'end repeat')
+            lines.append(f'make new phone at end of phones of p with properties {{label:"mobile", value:"{phone}"}}')
+        if email:
+            lines.append('repeat while (count of emails of p) > 0')
+            lines.append('    delete (item 1 of emails of p)')
+            lines.append('end repeat')
+            lines.append(f'make new email at end of emails of p with properties {{label:"home", value:"{email}"}}')
+        lines.append("save")
+        lines.append('return "OK: updated " & (name of p)')
+        script = 'tell application "Contacts"\n' + "\n".join(lines) + '\nend tell'
+        result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True, timeout=15)
+        if result.returncode != 0:
+            print(f"Error: {result.stderr.strip()}")
+            sys.exit(1)
+        print(result.stdout.strip())
     elif cmd == "all":
         results = search_contacts("")
         if not results:
@@ -129,8 +174,9 @@ def main():
             return
         print(json.dumps(results, indent=2))
     else:
-        print("Usage: python3 src/contacts.py search 'name'")
-        print("       python3 src/contacts.py add 'Name' --phone 123 --email a@b.com")
+        print("Usage: python3 contacts.py search 'name'")
+        print("       python3 contacts.py add 'Name' --phone 123 --email a@b.com")
+        print("       python3 contacts.py update 'Name' --phone 456 --email new@x.com")
         sys.exit(1)
 
 

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -18,7 +18,8 @@ If an interval is provided in ARGUMENTS (e.g. "5m", "10m", "30m"), use it. Other
 
 ## On activation
 
-Before starting the loop, immediately start the task watcher:
+1. Run `/schedule-crons` to set up all recurring cron jobs (reactive, proactive, morning briefing, Zacks)
+2. Start the task watcher if not running:
 ```
 bash src/watch-tasks.sh
 ```

--- a/skills/schedule-crons/SKILL.md
+++ b/skills/schedule-crons/SKILL.md
@@ -1,0 +1,28 @@
+# Schedule Crons
+
+Re-create all session cron jobs for Sutando. Run this on startup or after a session restart.
+
+**Usage**: `/schedule-crons`
+
+## How It Works
+
+Jobs are defined in `skills/schedule-crons/crons.json`. Each entry has:
+- `name` — unique identifier (used to avoid duplicates)
+- `cron` — 5-field cron expression
+- `prompt` — the prompt to run (direct text)
+- `prompt_skill` — OR a skill to invoke (e.g. "morning-briefing" → `/morning-briefing`)
+
+## On Activation
+
+1. Read `skills/schedule-crons/crons.json`
+2. Check existing cron jobs with CronList
+3. For each job in the config:
+   - Skip if a job with matching prompt/name already exists
+   - If `prompt_skill` is set, invoke it as `/skill-name`
+   - Call CronCreate with the cron expression and prompt
+4. Start the task watcher if not running: `bash src/watch-tasks.sh` (run_in_background)
+5. Confirm what was scheduled
+
+## Adding New Crons
+
+Edit `crons.json` to add/remove jobs. No need to change this skill file.

--- a/skills/schedule-crons/crons.json
+++ b/skills/schedule-crons/crons.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "reactive-check",
+    "cron": "*/5 * * * *",
+    "prompt": "REACTIVE CHECK — fast, no heavy work.\n1. Check tasks/ for files. Process any found, write results, delete task files.\n2. Check context-drop.txt. Process if present.\n3. Ensure fswatch watcher is running (1 process). If dead, restart with run_in_background: true.\n4. Check Discord channels (reference_discord_channels.md) for new actionable messages. Forward to #dev.\n5. GUARDRAIL: Read core-status.json. If the last proactive pass was more than 45 minutes ago (check ts field) and status is idle, the proactive loop may have stalled. Do one proactive action: pick an item from notes/todo.md and work on it.\n6. Signal core-status.json throughout."
+  },
+  {
+    "name": "proactive-loop",
+    "cron": "*/10 * * * *",
+    "prompt_skill": "proactive-loop"
+  },
+  {
+    "name": "morning-briefing",
+    "cron": "57 6 * * *",
+    "prompt_skill": "morning-briefing"
+  },
+  {
+    "name": "zacks-check",
+    "cron": "3 6 * * 1-5",
+    "prompt": "Run the Zacks stock ranking check: python3 ~/scripts/sutando-personal/zacks-check.py"
+  }
+]


### PR DESCRIPTION
## Summary
- **schedule-crons skill**: reads `crons.json` config to restore session cron jobs on restart. Jobs defined in config, not hardcoded in the skill.
- **contacts.py update command**: modify existing contact phone/email via AppleScript (inspired by Orion's Swift pattern)
- **proactive-loop**: now invokes `/schedule-crons` on activation to auto-restore all cron jobs

## Cron jobs restored on startup
- Reactive check (5 min)
- Proactive loop (10 min)
- Morning briefing (daily 6:57am)
- Zacks stock check (weekdays 6:03am)

## Test plan
- [ ] `/schedule-crons` creates all 4 cron jobs from crons.json
- [ ] `contacts.py update "Bob" --phone 123` modifies existing contact
- [ ] Proactive loop startup triggers schedule-crons

🤖 Generated with [Claude Code](https://claude.com/claude-code)