### PR TITLE
Add keyboard shortcuts hint to web UI

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -293,6 +293,13 @@ fetch('http://localhost:7844/stand-identity').then(r=>r.json()).then(s=>{
   <h2 id="hero-name">Sutando</h2>
   <p class="tagline">Summon your AI superpower</p>
   <button class="btn-hero" onclick="toggle()">Start Voice</button>
+  <div style="margin-top:16px;font-size:11px;color:#556;letter-spacing:0.5px">
+    <kbd style="background:#1a1a2e;padding:2px 6px;border-radius:3px;border:1px solid #333;font-family:monospace;color:#8af">⌃C</kbd> drop context
+    <span style="margin:0 6px;color:#333">|</span>
+    <kbd style="background:#1a1a2e;padding:2px 6px;border-radius:3px;border:1px solid #333;font-family:monospace;color:#8af">⌃V</kbd> voice
+    <span style="margin:0 6px;color:#333">|</span>
+    <kbd style="background:#1a1a2e;padding:2px 6px;border-radius:3px;border:1px solid #333;font-family:monospace;color:#8af">⌃M</kbd> mute
+  </div>
 </div>
 
 <div id="dynamic-region"></div>


### PR DESCRIPTION
## Summary
Shows ⌃C / ⌃V / ⌃M keyboard shortcuts below the Start Voice button in the hero section, so users discover the menu bar app shortcuts.

## Test plan
- [ ] Open localhost:8080 — shortcuts visible below "Start Voice"

🤖 Generated with [Claude Code](https://claude.com/claude-code)