### PR TITLE
Fix dotenv: override stale env vars

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -42,7 +42,8 @@
  *   - Transcript persistence
  */
 
-import 'dotenv/config';
+import { config } from 'dotenv';
+config({ override: true });
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { mkdirSync, writeFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -18,7 +18,8 @@
  *   HOST                — Bind address (default: 0.0.0.0)
  */
 
-import 'dotenv/config';
+import { config } from 'dotenv';
+config({ override: true });
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { z } from 'zod';
 import { existsSync, readFileSync, readdirSync, unlinkSync, mkdirSync } from 'node:fs';


### PR DESCRIPTION
Shell env vars took precedence over .env, causing wrong API key. override: true fixes it.