### PR TITLE
Cap scroll_and_describe duration at 60s

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -249,11 +249,14 @@ export const scrollAndDescribeTool: ToolDefinition = {
 		'New descriptions will be pushed as the page scrolls — speak each one. NEVER repeat earlier narration. ' +
 		'Recording auto-stops. Do NOT call this more than once per recording.',
 	parameters: z.object({
-		duration_seconds: z.number().optional().describe('Target duration in seconds (default 15). ALWAYS seconds, never minutes.'),
+		duration_seconds: z.number().optional().describe('Target duration in seconds (default 15, max 60). ALWAYS seconds, never minutes.'),
 	}),
 	execution: 'inline',
 	async execute(args) {
-		const { duration_seconds = 15 } = args as { duration_seconds?: number };
+		const MAX_DURATION = 60;
+		const rawDuration = (args as { duration_seconds?: number }).duration_seconds ?? 15;
+		const duration_seconds = Math.min(rawDuration, MAX_DURATION);
+		if (rawDuration > MAX_DURATION) console.log(`${ts()} [ScrollAndDescribe] capped duration from ${rawDuration}s to ${MAX_DURATION}s`);
 		try {
 			// Prevent duplicate recordings
 			if (demoState === 'recording') return { status: 'already_recording', message: 'Already recording.' };


### PR DESCRIPTION
## Summary
- Caps `scroll_and_describe` duration at 60 seconds max, matching existing `screen_record` cap
- Prevents runaway recordings when Gemini misrecognizes "30 seconds" as "30 minutes" (duration_seconds=1800)
- Logs when capping occurs for debugging

Closes #94

## Test plan
- [ ] Call with "record for 30 minutes" — verify it caps at 60s
- [ ] Call with "record for 15 seconds" — verify it runs normally
- [ ] Verify mouse is returned after recording stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)