### PR TITLE
Revert dotenv override — broke env loading

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -42,8 +42,7 @@
  *   - Transcript persistence
  */
 
-import { config } from 'dotenv';
-config({ override: true });
+import 'dotenv/config';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { mkdirSync, writeFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -18,8 +18,7 @@
  *   HOST                — Bind address (default: 0.0.0.0)
  */
 
-import { config } from 'dotenv';
-config({ override: true });
+import 'dotenv/config';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { z } from 'zod';
 import { existsSync, readFileSync, readdirSync, unlinkSync, mkdirSync } from 'node:fs';


### PR DESCRIPTION
ESM hoists imports before runtime config(). Reverted to import 'dotenv/config'.