### PR TITLE
Fix phone agent duplicate responses on reconnect

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -612,6 +612,7 @@ async function createCallSession(params: {
 	// Bypasses ClientTransport's internal WebSocket for lower latency
 	const sessionAny = session as any;
 	let isReplaying = false; // suppress audio during reconnect replay
+	let turnCountBeforeDisconnect = 0; // track turns to know when replay is done
 	let _isRecordingMuted: (() => boolean) | null = null;
 	import('../../../src/browser-tools.js').then(bt => { _isRecordingMuted = bt.isRecordingMuted; }).catch(() => {});
 	sessionAny.handleAudioOutput = (data: string) => {
@@ -640,6 +641,12 @@ async function createCallSession(params: {
 	let lastProcessedIdx = 0;
 	session.eventBus.subscribe('turn.end', () => {
 		const items = session.conversationContext.items;
+		// Detect end of reconnect replay: when items catch up to pre-disconnect count
+		if (isReplaying && items.length >= turnCountBeforeDisconnect) {
+			console.log(`${ts()} [Phone] replay complete (${items.length}/${turnCountBeforeDisconnect} turns) — unmuting`);
+			isReplaying = false;
+			import('../../../src/browser-tools.js').then(bt => bt.onReconnect(session)).catch(() => {});
+		}
 		// Guard: if items shrunk (reconnect reset context), re-scan from start but skip already-seen text
 		if (items.length < lastProcessedIdx) lastProcessedIdx = 0;
 		const lastTranscriptText = callSession.transcript.length > 0
@@ -703,11 +710,18 @@ async function createCallSession(params: {
 				if (!callSession.hangingUp && activeCalls.has(callSession.callSid)) {
 					console.log(`${ts()} [Phone] reconnecting Gemini for ${callSession.callSid}`);
 					isReplaying = true; // mute audio while Gemini replays history
+					turnCountBeforeDisconnect = session.conversationContext.items.length;
+					console.log(`${ts()} [Phone] replay suppression: ${turnCountBeforeDisconnect} turns to replay`);
 					sessionAny.handleClientConnected();
-					setTimeout(() => {
-						isReplaying = false;
-						import('../../../src/browser-tools.js').then(bt => bt.onReconnect(session)).catch(() => {});
-					}, 6000);
+					// Fallback: unmute after max(10s, 2s per turn) in case turn detection fails
+					const fallbackMs = Math.max(10000, turnCountBeforeDisconnect * 2000);
+					const fallbackTimer = setTimeout(() => {
+						if (isReplaying) {
+							console.log(`${ts()} [Phone] replay suppression fallback (${fallbackMs}ms)`);
+							isReplaying = false;
+							import('../../../src/browser-tools.js').then(bt => bt.onReconnect(session)).catch(() => {});
+						}
+					}, fallbackMs);
 				}
 			}, 1500);
 		}


### PR DESCRIPTION
## Summary
- Replace fixed 6-second replay suppression with turn-count-based detection
- Track conversation turn count before disconnect, unmute only after Gemini replays all previous turns
- Fallback timeout scales with conversation length (max of 10s or 2s per turn)

## Root cause
For longer calls (>3 turns), the fixed 6s timeout expired before Gemini finished replaying conversation history, causing duplicate audio output.

Call log scanner (PR #104) found **217 duplicate response instances** across 57/158 calls — this was the #1 detected issue.

## Test plan
- [ ] Make a call, have 5+ turns, then trigger a Gemini reconnect — verify no duplicate audio
- [ ] Short call (<3 turns) still works with the fallback timer
- [ ] Verify `[Phone] replay complete` log message appears on reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)