### PR TITLE
Auto-scan call logs after each call ends

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -769,6 +769,13 @@ function cleanupCall(callSid: string): void {
 	}
 	console.log(`${ts()} [Phone] call finalized: ${callSid}`);
 
+	// Auto-scan the latest call for issues (async, best effort)
+	try {
+		const scanScript = join(WORKSPACE_DIR, 'src', 'scan-call-logs.py');
+		spawn('python3', [scanScript, '--last', '1', '--json'], { stdio: 'pipe', detached: true })
+			.on('close', (code) => { if (code === 0) console.log(`${ts()} [Phone] call scan complete`); });
+	} catch { /* best effort */ }
+
 	// If top-level call (no parent) with a transcript, write a summary task for Claude to pick up
 	if (!session.parentCallSid && session.transcript.length > 0) {
 		const summaryTaskId = `task-summary-${Date.now()}`;


### PR DESCRIPTION
## Summary
- Spawns `scan-call-logs.py --last 1` asynchronously after each call finalization
- Non-blocking (detached child process), best-effort (try/catch)
- Completes the loop from PR #104 (scanner) — now runs automatically, not just manually

## Test plan
- [ ] Make a test call — verify `[Phone] call scan complete` appears in logs
- [ ] Scanner doesn't block call cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)