### PR TITLE
Fix health check: fresh heartbeat overrides stale log

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -201,11 +201,14 @@ def run_all_checks() -> list[dict]:
                 status = "warn"
                 detail = f"running but log stale ({int(age_sec)}s old)"
 
-        # Check 3: Heartbeat file freshness
+        # Check 3: Heartbeat file freshness (overrides log staleness if fresh)
         heartbeat_file = REPO_DIR / "src" / f"{name}.heartbeat"
         if heartbeat_file.exists():
             hb_age = time.time() - heartbeat_file.stat().st_mtime
-            if hb_age > 120:  # 2 minutes
+            if hb_age <= 120:  # heartbeat is fresh — bridge is alive
+                status = "ok"
+                detail = "running"
+            else:
                 status = "warn"
                 detail = f"running but heartbeat stale ({int(hb_age)}s old)"
 


### PR DESCRIPTION
## Summary
- When a bridge has a fresh heartbeat but stale log, it's alive but idle
- Previously: always warned about stale log even when heartbeat confirmed alive
- Now: fresh heartbeat (<120s) clears the log staleness warning

Fixes the recurring false "running but log stale" warnings during quiet periods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)