### PR TITLE
Fix bridge heartbeat: time-based instead of counter-based

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -299,13 +299,16 @@ def save_to_allowlist(sender_id):
 async def poll_results():
     """Poll results/ for replies to send back to Discord."""
     heartbeat_file = REPO / "src" / "discord-bridge.heartbeat"
-    heartbeat_counter = 0
+    last_heartbeat = 0
     while True:
-        # Write heartbeat every 60 iterations (~60s)
-        heartbeat_counter += 1
-        if heartbeat_counter >= 60:
-            heartbeat_file.write_text(str(int(time.time())))
-            heartbeat_counter = 0
+        # Write heartbeat at most once per 60 seconds
+        now = time.time()
+        if now - last_heartbeat >= 60:
+            try:
+                heartbeat_file.write_text(str(int(now)))
+                last_heartbeat = now
+            except Exception:
+                pass
         for task_id in list(pending_replies.keys()):
             result_file = RESULTS_DIR / f"{task_id}.txt"
             if result_file.exists():

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -141,19 +141,22 @@ def send_reply(chat_id, text):
             api("sendMessage", chat_id=chat_id, text=f"(file not found: {fpath})")
 
 def main():
-    print(f"Telegram bridge started. Polling for messages...")
+    print(f"Telegram bridge started. Polling for messages...", flush=True)
     offset = None
     allowed = load_allowed()
     pending_replies = {}  # task_id -> chat_id
 
     heartbeat_file = REPO / "src" / "telegram-bridge.heartbeat"
-    heartbeat_counter = 0
+    last_heartbeat = 0
     while True:
-        # Write heartbeat every 6 iterations (~60s with 10s timeout)
-        heartbeat_counter += 1
-        if heartbeat_counter >= 6:
-            heartbeat_file.write_text(str(int(time.time())))
-            heartbeat_counter = 0
+        # Write heartbeat at most once per 60 seconds
+        now = time.time()
+        if now - last_heartbeat >= 60:
+            try:
+                heartbeat_file.write_text(str(int(now)))
+                last_heartbeat = now
+            except Exception:
+                pass
         # Poll for new messages
         params = {"timeout": 10, "limit": 10}
         if offset:
@@ -161,7 +164,7 @@ def main():
         try:
             result = api("getUpdates", **params)
         except Exception as e:
-            print(f"[Telegram] Poll error: {e}")
+            print(f"[Telegram] Poll error: {e}", flush=True)
             time.sleep(5)
             continue
 


### PR DESCRIPTION
## Summary
- Replace counter-based heartbeat with time.time() check in both telegram and discord bridges
- Writes heartbeat at most once per 60s regardless of loop speed
- Fixes missing telegram heartbeat when DNS errors cause fast error loops
- Combined with PR #108 (health check heartbeat override), eliminates all false "log stale" warnings

## Root cause
Counter-based heartbeat (write every N iterations) assumed consistent loop timing. DNS errors made loops unpredictably fast, counter never reached threshold in expected time.

## Test plan
- [x] Telegram bridge writes heartbeat within 3s of startup
- [x] Discord bridge heartbeat unchanged (already working, now more robust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)