### PR TITLE
Fix scan-call-logs.py Python 3.9 compat

### DIFF
--- a/src/scan-call-logs.py
+++ b/src/scan-call-logs.py
@@ -171,7 +171,7 @@ ALL_DETECTORS = [
 ]
 
 
-def scan_entry(entry: dict) -> dict | None:
+def scan_entry(entry: dict):
     """Scan a single call log entry. Returns issues dict or None if clean."""
     transcript = entry.get("transcript", "")
     if not transcript or len(transcript) < 20:


### PR DESCRIPTION
## Summary
- Remove `dict | None` type hint on line 174 that requires Python 3.10+
- Scanner crashes on import for Python 3.9 users
- Blocks PR #107 auto-scan feature from working

## Test plan
- [x] `python3 src/scan-call-logs.py --all` runs successfully (180 calls scanned)
- [x] No other Python 3.10+ syntax in src/*.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)