### PR TITLE
Fix outbound owner calls + add subtitle tool

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -347,11 +347,9 @@ function buildAgent(callSession: CallSession): MainAgent {
 				: isInbound
 				? 'Someone is calling you. Be helpful and conversational. You CAN answer general knowledge questions, do translations, and have conversations — but you cannot access files, control the screen, or delegate tasks. Greet them with "Hello, this is Sutando. How can I help?"'
 				: callSession.isOwner
-				? `You are calling your owner${OWNER_NAME ? ` ${OWNER_NAME}` : ''}. The person who picks up IS your owner.`
+				? `You are calling your owner${OWNER_NAME ? ` ${OWNER_NAME}` : ''}. The person who picks up IS your owner. You have full capabilities — use the work tool for anything: check the screen, send emails, look things up, make calls, browse the web, or check results of previous tasks. After delivering your message, ask if there is anything else you can help with.${(() => { const ctx = getSafeContext(); return ctx ? `\n\nRecent voice conversation (for context — do NOT repeat or bring up unless asked):\n${ctx}` : ''; })()}`
 				: 'You initiated this call on behalf of your owner.',
 			callSession.purpose && !isInbound ? `Purpose of this call: "${callSession.purpose}"` : '',
-			// Context only for outbound calls to owner
-			!isInbound && callSession.isOwner ? (() => { const ctx = getSafeContext(); return ctx ? `\nRecent context (for reference — use only if relevant):\n${ctx}` : ''; })() : '',
 			'Be natural, warm, and conversational. Keep responses to 1-2 sentences.',
 			'NEVER say "I\'m back", "Welcome back", "Working on it", or "task is queued". If the conversation resumes after a pause, just continue naturally from where you left off.',
 			'When the other person wants to wrap up, say a warm goodbye, then call the hang_up tool to end the call.',
@@ -1336,13 +1334,15 @@ wss.on('connection', (ws: WebSocket) => {
 					}
 
 					// Owner detection: number match + STIR/SHAKEN verification.
-					// A spoofed caller ID will fail STIR/SHAKEN (StirVerstat != TN-Validation-Passed-A).
-					// If StirVerstat is present and NOT A-level, downgrade owner to verified-only.
 					const ownerNumbers = OWNER_NUMBER ? OWNER_NUMBER.split(',').map(n => normalizePhone(n.trim())) : [];
 					const numberMatchesOwner = ownerNumbers.length > 0 && ownerNumbers.includes(normalizePhone(personOnLine));
+					const isOutbound = !!recipientNumber; // we initiated the call — trust the recipient number
 					let isOwner: boolean;
-					if (numberMatchesOwner && stirVerstat && stirVerstat !== 'TN-Validation-Passed-A') {
-						// Number matches but caller ID not cryptographically verified — possible spoof
+					if (isOutbound && numberMatchesOwner) {
+						// Outbound call to owner — we initiated it, skip STIR/SHAKEN check
+						isOwner = true;
+					} else if (numberMatchesOwner && stirVerstat && stirVerstat !== 'TN-Validation-Passed-A') {
+						// Inbound: number matches but caller ID not cryptographically verified — possible spoof
 						isOwner = false;
 						console.log(`${ts()} [Security] Owner number matched but StirVerstat=${stirVerstat} (not A-level) — downgrading to verified`);
 					} else {

--- a/skills/screen-record/scripts/subtitle.py
+++ b/skills/screen-record/scripts/subtitle.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Add subtitles to a screen recording by transcribing its audio with Whisper."""
+
+import subprocess
+import sys
+import os
+import json
+import tempfile
+
+def find_latest_recording():
+    """Find the most recent sutando recording."""
+    result = subprocess.run(
+        ["bash", "-c", "ls -t /tmp/sutando-recording-*.mov 2>/dev/null | grep -v subtitled | head -1"],
+        capture_output=True, text=True, timeout=3
+    )
+    path = result.stdout.strip()
+    if path and os.path.exists(path):
+        return path
+    return None
+
+def transcribe(video_path):
+    """Transcribe audio from video using Whisper with word timestamps."""
+    # Extract audio to temp wav
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+        wav_path = f.name
+
+    try:
+        subprocess.run(
+            ["ffmpeg", "-y", "-i", video_path, "-vn", "-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", wav_path],
+            capture_output=True, timeout=30
+        )
+
+        # Run whisper with word-level timestamps, output SRT
+        srt_dir = tempfile.mkdtemp()
+        subprocess.run(
+            ["whisper", wav_path, "--model", "base", "--output_format", "srt", "--output_dir", srt_dir,
+             "--language", "en", "--word_timestamps", "True"],
+            capture_output=True, timeout=120
+        )
+
+        srt_path = os.path.join(srt_dir, os.path.basename(wav_path).replace(".wav", ".srt"))
+        if os.path.exists(srt_path):
+            with open(srt_path) as f:
+                return f.read(), srt_path
+        return None, None
+    finally:
+        if os.path.exists(wav_path):
+            os.unlink(wav_path)
+
+def burn_subtitles(video_path, srt_path):
+    """Burn SRT subtitles into video with ffmpeg."""
+    out_path = video_path.replace(".mov", "-subtitled.mov")
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-i", video_path,
+            "-vf", f"subtitles={srt_path}:force_style='FontSize=24,PrimaryColour=&H00FFFFFF,OutlineColour=&H00000000,Outline=2,MarginV=30'",
+            "-c:v", "libx264", "-crf", "23", "-c:a", "aac", out_path
+        ],
+        capture_output=True, timeout=120
+    )
+
+    if os.path.exists(out_path):
+        size_mb = round(os.path.getsize(out_path) / 1024 / 1024, 1)
+        return out_path, size_mb
+    return None, 0
+
+def main():
+    video_path = sys.argv[1] if len(sys.argv) > 1 else find_latest_recording()
+    if not video_path:
+        print(json.dumps({"error": "No recording found"}))
+        return
+
+    print(f"Transcribing {video_path}...", file=sys.stderr)
+    srt_content, srt_path = transcribe(video_path)
+    if not srt_content:
+        print(json.dumps({"error": "Transcription failed — no speech detected or Whisper error"}))
+        return
+
+    print(f"Burning subtitles...", file=sys.stderr)
+    out_path, size_mb = burn_subtitles(video_path, srt_path)
+    if not out_path:
+        print(json.dumps({"error": "ffmpeg subtitle burn failed"}))
+        return
+
+    print(json.dumps({"status": "done", "path": out_path, "size_mb": size_mb, "srt": srt_path}))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **Outbound owner calls**: full capabilities (summon, work, screen share) — was missing
- **STIR/SHAKEN bypass for outbound**: we initiated the call, skip attestation check
- **Unified context**: outbound owner calls get same voice history as inbound
- **Subtitle tool**: `skills/screen-record/scripts/subtitle.py` — Whisper transcribe + ffmpeg burn-in

## Root cause
Outbound calls got STIR/SHAKEN B-level attestation (not A), causing owner → verified downgrade. The prompt also lacked the "full capabilities" instruction.

## Test plan
- [x] Outbound call: `owner: true` confirmed in logs despite B-level STIR/SHAKEN
- [x] Full capabilities: tasks delegated, subtitle processed, reminder delivered
- [x] Subtitle: Whisper + ffmpeg burn-in tested on narrated recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)