### PR TITLE
Fix bridge double-post when core replies directly

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -315,6 +315,10 @@ async def poll_results():
                 import re
                 reply_text = result_file.read_text().strip()
                 channel = pending_replies.pop(task_id)
+                # Skip sending if already replied directly (core agent used MCP)
+                if reply_text.startswith('[no-send]') or reply_text.startswith('[REPLIED]'):
+                    print(f"  Skipped (already replied): {task_id}")
+                    continue
                 try:
                     # Extract file paths: [file: /path] or [send: /path]
                     file_pattern = re.compile(r'\[(?:file|send|attach):\s*([^\]]+)\]')

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -232,6 +232,10 @@ def main():
             if result_file.exists():
                 reply_text = result_file.read_text().strip()
                 chat_id = pending_replies.pop(task_id)
+                # Skip sending if already replied directly
+                if reply_text.startswith('[no-send]') or reply_text.startswith('[REPLIED]'):
+                    print(f"  Skipped (already replied): {task_id}")
+                    continue
                 try:
                     send_reply(chat_id, reply_text)
                     print(f"  Replied to {chat_id}: {reply_text[:80]}...")


### PR DESCRIPTION
Skip results starting with [no-send] or [REPLIED] in both Discord and Telegram bridges.