### PR TITLE
Add pnpm-workspace.yaml for pnpm compatibility

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - "bodhi-realtime-agent"


### PR DESCRIPTION
Allows pnpm install to work by allowlisting bodhi-realtime-agent build scripts.