### PR TITLE
Notify on ⌃V Chrome permission failure

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -294,7 +294,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             end if
         end tell
         """)
-        script?.executeAndReturnError(nil)
+        var error: NSDictionary?
+        script?.executeAndReturnError(&error)
+        if let error = error {
+            let msg = error[NSAppleScript.errorMessage] as? String ?? ""
+            if msg.contains("not allowed") || msg.contains("JavaScript") || msg.contains("permission") {
+                notify("Sutando", "⌃V needs: Chrome → View → Developer → Allow JavaScript from Apple Events")
+            }
+        }
         NSSound.beep()
     }
 


### PR DESCRIPTION
Shows actionable notification instead of silent failure.