### PR TITLE
skills: Added Whatsapp wacli as a skill and verfication test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,11 @@ PORT=9900
 # Token is saved to ~/.claude/channels/discord/.env (not here).
 # Setup: /discord:configure <token>
 # Access: /discord:access policy allowlist
+
+# Optional: WhatsApp via wacli (CLI — not used by Node startup, for agent/docs)
+# Install: brew install steipete/tap/wacli
+# Auth: wacli auth (QR code). Session + sync DB: ~/.wacli (see wacli --help --store)
+# Skill: skills/whatsapp/SKILL.md (after: bash skills/install.sh)
+# Optional — linked device label/platform shown in WhatsApp:
+# WACLI_DEVICE_LABEL=Sutando
+# WACLI_DEVICE_PLATFORM=CHROME

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,12 +149,14 @@ imsg messages --chat "+14155551234" --limit 10    # read messages
 ```
 Always confirm message content with user before sending.
 
-**WhatsApp** — send messages via WhatsApp (requires `wacli auth` first):
+**WhatsApp** — send/search via [wacli](https://github.com/steipete/wacli) (`brew install steipete/tap/wacli`). Full commands and setup: `~/.claude/skills/whatsapp/SKILL.md` (install skill: `bash skills/install.sh`). Requires `wacli auth` first; session is under `~/.wacli`.
 ```bash
 wacli send text --to "+14155551234" --message "Hello!"
 wacli chats list --limit 20
 wacli messages search "keyword" --limit 10
 ```
+Optional: `WACLI_DEVICE_LABEL`, `WACLI_DEVICE_PLATFORM` in `.env` — see `.env.example`.
+Always confirm message content with user before sending.
 
 **X (Twitter)** — post, search, read, and monitor:
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "tsx src/voice-agent.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bash scripts/verify-whatsapp-skill.sh"
   },
   "dependencies": {
     "@ai-sdk/google": "^1.2.0",

--- a/scripts/verify-whatsapp-skill.sh
+++ b/scripts/verify-whatsapp-skill.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Automated checks for the WhatsApp (wacli) skill — no network or wacli required.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+SKILL="skills/whatsapp/SKILL.md"
+fail() { echo "verify-whatsapp-skill: $*" >&2; exit 1; }
+
+[[ -f "$SKILL" ]] || fail "missing $SKILL"
+
+grep -qE '^name:[[:space:]]*whatsapp[[:space:]]*$' "$SKILL" || fail "SKILL.md must declare name: whatsapp"
+grep -qE '^description:' "$SKILL" || fail "SKILL.md must have a description"
+grep -q 'wacli auth' "$SKILL" || fail "SKILL.md should document wacli auth"
+grep -q 'wacli send text' "$SKILL" || fail "SKILL.md should document wacli send text"
+grep -q 'confirm message content' "$SKILL" || fail "SKILL.md should require confirming before send"
+
+grep -q 'skills/whatsapp' .env.example || fail ".env.example should reference skills/whatsapp"
+grep -q 'WACLI_DEVICE_LABEL' .env.example || fail ".env.example should document WACLI_DEVICE_LABEL"
+grep -q 'steipete/tap/wacli' .env.example || fail ".env.example should document brew install steipete/tap/wacli"
+
+grep -q 'skills/whatsapp/SKILL.md' CLAUDE.md || fail "CLAUDE.md should reference the whatsapp skill"
+
+echo "verify-whatsapp-skill: ok"

--- a/skills/whatsapp/SKILL.md
+++ b/skills/whatsapp/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: whatsapp
+description: "Send and search WhatsApp messages via wacli (local sync, WhatsApp Web protocol). Use after the user has run wacli auth."
+---
+
+# WhatsApp (wacli)
+
+Send messages, list chats, and search history using [wacli](https://github.com/steipete/wacli) — a local CLI backed by a synced store at `~/.wacli` (override with `--store DIR`).
+
+## When to use
+
+- The user asks to message someone on WhatsApp, list chats, or search their WhatsApp history.
+- **Not** available until `wacli auth` has completed successfully on this Mac.
+
+## Setup
+
+1. Install: `brew install steipete/tap/wacli`
+2. Authenticate (QR code): `wacli auth`
+3. Optional: keep syncing in the background: `wacli sync --follow` (in a terminal or via your process manager)
+4. Optional env (device label in WhatsApp): see `.env.example` — `WACLI_DEVICE_LABEL`, `WACLI_DEVICE_PLATFORM`
+
+Diagnostics: `wacli doctor`
+
+## Usage
+
+```bash
+# Send (use E.164 for phone numbers, e.g. +14155551234)
+wacli send text --to "+14155551234" --message "Hello!"
+
+# Send a file
+wacli send file --to "+14155551234" --file /path/to/file.jpg --caption "Optional caption"
+
+# List chats (JSON for scripting)
+wacli chats list --limit 20
+wacli --json chats list --limit 50
+
+# Search messages
+wacli messages search "keyword" --limit 10
+
+# Groups
+wacli groups list
+```
+
+Pass `--json` on supported commands for machine-readable output.
+
+## Safety
+
+- **Always confirm message content with the user before sending** (same as iMessage/SMS).
+- wacli is a third-party tool; the user accepts WhatsApp ToS and linked-device risk.
+
+## Notes
+
+- Session and history live under `~/.wacli` by default — not in Sutando `.env`.
+- Human-readable output by default; use `--json` when parsing in scripts.


### PR DESCRIPTION
This PR adds a whatsapp skill that documents using [wacli](https://github.com/steipete/wacli) for WhatsApp send/search flows after wacli auth, including install via Homebrew, optional WACLI_DEVICE_LABEL / WACLI_DEVICE_PLATFORM, and a confirm-before-send note consistent with other messaging integrations.

Docs / config: .env.example gains an optional WhatsApp section; CLAUDE.md points to the skill and bash skills/install.sh so the symlink lands under ~/.claude/skills/whatsapp.


