### PR TITLE
health-check: anchor bridge pgrep to .py$ to kill false positives

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -251,7 +251,12 @@ def run_all_checks() -> list[dict]:
         if not env_file.exists() and not access_file.exists():
             continue
         try:
-            result = subprocess.run(["pgrep", "-f", proc_name], capture_output=True, text=True)
+            # Anchor on the .py suffix so we don't match unrelated processes
+            # whose command line happens to contain "discord-bridge" (shell
+            # invocations, ps/grep pipelines, etc). Otherwise pgrep -f bare
+            # name produces false-positive "multiple processes" warnings
+            # that scared us into thinking the bridges were zombied today.
+            result = subprocess.run(["pgrep", "-f", f"{proc_name}\\.py$"], capture_output=True, text=True)
             pids = result.stdout.strip().split("\n") if result.returncode == 0 else []
             pids = [p for p in pids if p]
         except:


### PR DESCRIPTION
## Bug
Several times today \`python3 src/health-check.py\` reported:
\`\`\`
⚠ discord-bridge  warn  multiple processes (2 PIDs: 26680,26758)
\`\`\`
…when in reality there was exactly one bridge running. The phantom second PID was always different each time, and disappeared on the next check.

## Root cause
\`pgrep -f discord-bridge\` (bare name) matches ANY process whose full command line contains the substring "discord-bridge" — transient shell commands, ps/grep pipelines, notification payloads, or this session running \`pgrep\` with the name in its own argv are all match candidates. The result is a flicker of false-positive warnings.

## Fix
Anchor the pattern to \`<name>.py$\` so pgrep only matches the actual Python bridge process:

\`\`\`python
subprocess.run(["pgrep", "-f", f"{proc_name}\\.py$"], ...)
\`\`\`

Now \`discord-bridge\` and \`telegram-bridge\` only match when the command line literally ends in \`discord-bridge.py\` or \`telegram-bridge.py\` (modulo escaping for the regex dot).

## Test plan
- [x] \`python3 src/health-check.py\` reports exactly one running discord-bridge
- [x] Ran in a loop 10 times — no transient multiple-processes warnings
- [x] Syntax check clean
- [ ] Reviewer: run in a loop and confirm no false positives

Small, contained, one-line fix + comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)