### PR TITLE
health-check: anchor --fix kill path to \.py$ (consistent with #243 detect)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -414,8 +414,16 @@ def main():
                     # so the new process doesn't conflict with a still-running zombie.
                     if c["status"] == "stale":
                         try:
+                            # Anchor to `\.py$` to match the detect path at
+                            # line ~277. Without this, a bare `pgrep -f
+                            # discord-bridge` also catches grep pipelines
+                            # and shell invocations whose command line
+                            # contains the bridge name, and we'd kill them
+                            # instead of (or in addition to) the real
+                            # bridge process. PR #243 fixed the detect
+                            # side; this keeps the kill side consistent.
                             old_pids = subprocess.run(
-                                ["pgrep", "-f", c["name"]], capture_output=True, text=True
+                                ["pgrep", "-f", f"{c['name']}\\.py$"], capture_output=True, text=True
                             ).stdout.strip().split("\n")
                             for pid in old_pids:
                                 if pid:


### PR DESCRIPTION
## Summary
Follow-up to #243. That PR anchored the bridge **detect** pgrep to `\.py$` to stop false-positive multi-process warnings from shell invocations and grep pipelines whose command line happened to contain "discord-bridge"/"telegram-bridge". But the auto-fix **kill** path in the same file at line 418 was still doing `pgrep -f discord-bridge` (bare name).

Result: during an auto-restart, the kill could have matched unrelated processes — grep/ps/less windows with the literal string in their argv, or a reviewer's `tail -f discord-bridge.log` running in a pane.

This patch makes the kill path use the same anchored pattern as the detect path.

## Changes
- `src/health-check.py:418` — `pgrep -f c["name"]` → `pgrep -f f"{c['name']}\\.py$"`
- Added a comment pointing at the detect anchor (~line 277) so future readers see both sides move together.

## Why not also fix shell scripts?
Audited the other pgrep/kill patterns in the repo:
- `src/restart.sh` uses `pkill -f` everywhere → already robust (pkill handles the pid list directly)
- `src/startup.sh` uses `pgrep -f ... > /dev/null` as a guard, not a kill target → safe
- `src/agent-api.py` and `src/dashboard.py` only use pgrep for health probes → safe

The only inconsistency was this one kill path in `health-check.py --fix`. Nothing universal to fix in shell land.

## Test plan
- [ ] `python3 src/health-check.py --quiet` still clean (no new false warnings)
- [ ] `python3 src/health-check.py --fix` on a stale bridge correctly kills only the real `discord-bridge.py` process
- [ ] Regression: no change in normal case (one bridge, no false matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)