### PR TITLE
discord-bridge: include replied-to bot message in task context

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -287,6 +287,33 @@ async def _handle_discord_message(message, force=False):
         except Exception as e:
             print(f"  Download failed: {e}")
 
+    # Reply context — when the user replies to a bot message, fetch the
+    # referenced message and prepend a snippet so the core agent knows
+    # which earlier answer the user is responding to. Without this the
+    # bot sees only the new reply text in isolation.
+    reply_context = ""
+    if message.reference and message.reference.message_id:
+        try:
+            ref_msg = message.reference.resolved
+            if ref_msg is None:
+                ref_msg = await message.channel.fetch_message(message.reference.message_id)
+            if ref_msg is not None:
+                # Only include context when replying to a message FROM this
+                # bot — avoids prepending unrelated conversation fragments.
+                if ref_msg.author.id == client.user.id:
+                    ref_author = str(ref_msg.author)
+                    ref_content = (ref_msg.content or "").strip()
+                    # Strip bot-id mentions so the context doesn't show raw id soup
+                    ref_content = ref_content.replace(f"<@{client.user.id}>", "")
+                    snippet = ref_content[:400].replace("\n", " ").strip()
+                    if snippet:
+                        reply_context = (
+                            f"\n\n[Replying to {ref_author} "
+                            f"({ref_msg.created_at.strftime('%Y-%m-%d %H:%M')}): {snippet}]"
+                        )
+        except Exception as e:
+            print(f"  [reply-context] fetch failed: {e}", flush=True)
+
     if not text and not attachment_note:
         # Bare mention — user deliberately pinged the bot with no content.
         # Don't drop: fetch the last few messages of channel history so the
@@ -364,7 +391,7 @@ async def _handle_discord_message(message, force=False):
     task_file.write_text(
         f"id: {task_id}\n"
         f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%S')}Z\n"
-        f"task: [Discord @{username}] {text}{attachment_note}\n"
+        f"task: [Discord @{username}] {text}{attachment_note}{reply_context}\n"
         f"source: discord\n"
         f"channel_id: {message.channel.id}\n"
         f"user_id: {message.author.id}\n"


### PR DESCRIPTION
## Summary
When a user hits Discord's reply button on one of the bot's earlier messages, the bridge previously saw only the new reply text in isolation. The reference was logged (`ref: true`) but never included in the task, so the core agent had no idea which of its earlier answers the user was responding to.

This matters when the reply is terse ("wrong — try again") or implicit ("no that's about X not Y"): without the parent message, the agent has to guess.

## Changes
`src/discord-bridge.py` — after attachment handling, before the empty-text filter:

- Fetch `message.reference.resolved` (or fall back to `channel.fetch_message(message.reference.message_id)`) when `message.reference` is set
- Filter: only include context when the referenced message is FROM THIS BOT (so we don't prepend unrelated fragments when a user replies to someone else and happens to mention us)
- Strip the bot's self-mention from the parent content
- Prepend `[Replying to {author} ({ts}): {snippet}]` (max 400 chars) to the task text
- Fetch errors logged but non-fatal

## Why filter to replies-to-bot only?
If owner replies to Susan's message in #dev and mentions the bot in that reply, we DON'T want to inject Susan's message as our context — the bot's task is the new text, not Susan's. Replying-to-bot is the specific pattern where parent context is load-bearing.

## Why not also capture replies to Sutando in general (incl. other bots)?
The inter-machine channel has MacBook-Sutando and Mac-Mini-Sutando as distinct bot accounts. Today if Mini replies to MacBook's post, the filter (`author.id == client.user.id`) requires it to be MINI's own earlier post, not MacBook's. If you want cross-bot reply context, change `author.id == client.user.id` to `author.bot` — but that risks capturing non-Sutando bots too. Leaving the strict filter for now, can loosen if the inter-bot case matters.

## Why not include full parent history?
`#245` already handles the bare-mention-with-history case for implicit questions. This PR handles the explicit reply case. They're complementary — a reply IS a direct reference to one specific parent; channel history is for the "I didn't tag the bot" case.

## Test plan
- [ ] Send a normal message (no reply) → task unchanged
- [ ] Reply to one of Sutando's earlier messages with text → task includes `[Replying to Sutando-Mini (YYYY-MM-DD HH:MM): {snippet}]`
- [ ] Reply to a non-bot user's message → task DOES NOT include reply context (filter blocks)
- [ ] Reply to a very old message that falls out of discord.py's cache → `fetch_message` fallback should still work; if it fails, task still writes without reply_context (graceful)
- [ ] Reply to a bot message of >400 chars → snippet is truncated, newlines collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)