### PR TITLE
web-client: show note's frontmatter title in note view

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -1576,6 +1576,12 @@ function showNoteContent(slug) {
         body: JSON.stringify({ slug: slug, content: text })
       }).catch(function(){});
     } catch (e) {}
+    // Extract the frontmatter title before stripping, so we can render it
+    // above the body. Without this, the only visible title on the page is
+    // the global stand-name H1 ("Sutando — <stand>"), which confused users
+    // into thinking that was the note's title.
+    var titleMatch = text.match(new RegExp('^---[\\s\\S]*?\\ntitle:\\s*([^\\n]+)'));
+    var noteTitle = titleMatch ? titleMatch[1].trim() : slug;
     text = text.replace(new RegExp('^---[\\s\\S]*?---\\n'), '');
     text = text.replace(/^### (.+)$/gm, '<h3>$1</h3>');
     text = text.replace(/^## (.+)$/gm, '<h2>$1</h2>');
@@ -1588,6 +1594,7 @@ function showNoteContent(slug) {
     text = text.replace(/^- (.+)$/gm, '<li>$1</li>');
     text = text.replace(new RegExp('\\n\\n', 'g'), '<br><br>');
     container.innerHTML = '<span class="suggestion" onclick="renderTabContent()" style="font-size:11px;cursor:pointer;margin-bottom:8px;display:inline-block">&larr; Back</span>' +
+      '<h2 style="font-size:15px;color:#7c83ff;margin:8px 0 10px 0;border-bottom:1px solid #2a2a3e;padding-bottom:6px">' + esc(noteTitle) + '</h2>' +
       '<div style="font-size:13px;line-height:1.5">' + text + '</div>';
   });
 }


### PR DESCRIPTION
## Summary

Fixes the user-reported bug: *"the title of the research note page is wrong"*.

When you click a note in the web UI, `showNoteContent(slug)` rendered the body but never surfaced the note's frontmatter title. The only visible heading on the page was the global stand-name H1 (*"Sutando — \<stand\>"*), which reasonably reads as the title of whatever you're looking at. Voice agent's `describe_screen` faithfully reported that as *the title of the note*, leading to hallucination loops when asked to correct it.

## Change

Before stripping the YAML frontmatter in `showNoteContent`, extract the \`title:\` line and render it as an \`<h2>\` above the body, with a subtle bottom border and the \`#7c83ff\` accent. Falls back to the slug when a note has no frontmatter title.

```
← Back
Stand Identity — research on personalized agent identity   ← NEW (h2, accent)
────────────────────────────────────────
# Stand Identity Research    ← existing H1 in body

Stand identity awakened 2026-03-25 as Echo Act IV.
...
```

## Safety

- Title passes through the existing \`esc()\` helper, so user-controlled content can't inject markup.
- Inline-JS: uses \`new RegExp(...)\` (not a regex literal, per \`feedback_inline_js_escaping.md\`), validated via tsc + manual node-check. Strings use single quotes and \`&quot;\` where needed.

## Test plan

- [x] tsc clean (\`npx tsc --noEmit\`)
- [x] \`curl localhost:8080/\` confirms the new code is in the served bundle
- [x] web-client restart + browser reload renders the frontmatter title cleanly above the body for sampled notes
- [ ] Hard-reload the tab and click a note to confirm the title shows what you expect

## Related

- Companion to the mid-day forensics on why voice was hallucinating note titles (note-view watcher was silently dead for 9 hours; fixed by restarting voice-agent, see build log 2026-04-09). That restored the voice-side "what note am I viewing" context. This PR fixes the UI side — now both surfaces agree on what the title is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)