### PR TITLE
health-check: suppress stale-detection false positives from git mtime bumps

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -161,10 +161,48 @@ def mark_stale_if_outdated(check: dict, src_file: Path, pgrep_pattern: str, thre
         proc_start = min(starts)
         src_mtime = src_file.stat().st_mtime
         if src_mtime - proc_start > threshold_sec:
+            # Before flagging stale, cross-check with git: mtime gets bumped by
+            # `git checkout`/`pull`/`rebase` even when the file content is
+            # identical, which produced a steady stream of false positives
+            # whenever a branch switch left the working tree unchanged on a
+            # specific file. Ask git for the last commit time that actually
+            # touched this file. If that's older than proc_start AND there
+            # are no uncommitted changes to the file, it's a mtime-only
+            # bump — the running code is still current.
+            if _file_unchanged_since(src_file, proc_start):
+                return
             check["status"] = "stale"
             check["detail"] = f"running but code is {int((src_mtime - proc_start) / 60)} min newer than process — restart needed"
     except (subprocess.TimeoutExpired, OSError):
         pass
+
+
+def _file_unchanged_since(src_file: Path, proc_start: float) -> bool:
+    """Return True if git's last-commit-time for src_file predates proc_start
+    AND the file has no uncommitted changes. Used to suppress stale-detection
+    false positives from git operations that bump mtime without changing
+    content. Silent-failure: returns False on any git error so real stale
+    deploys aren't hidden.
+    """
+    try:
+        log = subprocess.run(
+            ["git", "log", "-1", "--format=%ct", "HEAD", "--", str(src_file)],
+            cwd=REPO_DIR, capture_output=True, text=True, timeout=5
+        )
+        if log.returncode != 0 or not log.stdout.strip():
+            return False
+        commit_time = int(log.stdout.strip())
+        if commit_time >= proc_start:
+            # Real commit landed after proc_start — genuinely stale
+            return False
+        # No commits since proc_start; check for uncommitted edits
+        diff = subprocess.run(
+            ["git", "diff", "--quiet", "HEAD", "--", str(src_file)],
+            cwd=REPO_DIR, capture_output=True, timeout=5
+        )
+        return diff.returncode == 0  # 0 = no diff
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return False
 
 
 # Watchers task-bridge starts at voice-agent boot. If any of these is


### PR DESCRIPTION
## Summary

`mark_stale_if_outdated` was nagging all day with messages like *"voice-agent stale — running but code is 32 min newer than process, restart needed"* even though voice-agent.ts hadn't actually changed since the running process started. Root cause: every \`git checkout\`, \`git pull\`, or \`git stash pop\` I did during PR review work bumped the file mtime, even when the content was byte-identical. The check fired on the mtime bump, not on real code drift.

This is the exact failure mode that trains a user to ignore stale-warnings, which hides *real* stale deploys when they happen.

## Fix

When mtime says stale, cross-check with git:

1. \`git log -1 --format=%ct HEAD -- <file>\` — the timestamp of the last commit that actually touched the file
2. \`git diff --quiet HEAD -- <file>\` — are there uncommitted edits?

If (1) is older than \`proc_start\` **and** (2) reports no diff, the file content hasn't actually changed — suppress the stale flag. Otherwise keep the original behavior.

Silent-failure on any git error so real stale deploys aren't hidden when git is unreachable.

## Test plan

- [x] Live voice-agent case that produced repeated false positives this afternoon → now \`ok\`
- [x] Simulated \`proc_start = 0\` (epoch) on a real tracked file → correctly still flagged stale (git commit timestamp is after epoch)
- [x] Simulated uncommitted local changes on a tracked file → correctly still flagged stale (\`git diff --quiet\` returns non-zero)
- [x] All three paths verified in a short Python harness that imports health-check.py and calls \`_file_unchanged_since\` directly

## Related

- Pairs with #250 (voice-watchers probe) — that fix added a new signal, this fix reduces noise on an old one. Both aim at the same goal: make health-check output trustworthy so failures aren't lost in noise.
- The bodhi PR #1 migration work this morning is what exposed the problem — lots of git-checkout traffic while testing/reviewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)