### PR TITLE
task-bridge: de-spam note-view detection log

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -197,6 +197,12 @@ export function startContextDropWatcher(onContextDrop: (content: string) => void
  * note doesn't re-inject.
  */
 let lastNoteViewingTs = '';
+// Track the last event we *logged* separately from the last we *handled*,
+// so that when the keep-pending-on-disconnect path (PR #246) retries an
+// event every 2s, we emit only one "Note view detected" line per unique
+// event.ts. Without this, voice-agent.log fills with ~30 identical lines
+// per minute whenever the user opens a note while voice is disconnected.
+let lastNoteViewingLoggedTs = '';
 /**
  * Read the current note-viewing event from disk, if any. Used for
  * on-reconnect delivery so the voice agent can catch up on what the user
@@ -223,7 +229,10 @@ export function startNoteViewingWatcher(
 		const event = readCurrentNoteViewing();
 		if (!event) return;
 		if (event.ts === lastNoteViewingTs) return;  // already handled
-		console.log(`${ts()} [TaskBridge] Note view detected: ${event.slug}`);
+		if (event.ts !== lastNoteViewingLoggedTs) {
+			console.log(`${ts()} [TaskBridge] Note view detected: ${event.slug}`);
+			lastNoteViewingLoggedTs = event.ts;
+		}
 		const handled = onNoteView(event.slug, event.content);
 		// Only mark as handled if the callback actually delivered it. This
 		// lets a voice-disconnected callback return false/void-with-falsy
@@ -240,6 +249,9 @@ export function startNoteViewingWatcher(
  */
 export function resetNoteViewingDebounce(): void {
 	lastNoteViewingTs = '';
+	// Also reset the logged-ts so the next delivery attempt logs again —
+	// a reconnect is a meaningful event that should show up in the log.
+	lastNoteViewingLoggedTs = '';
 }
 
 export function startResultWatcher(onResult: (result: string) => void, isClientConnected: () => boolean): void {


### PR DESCRIPTION
## Summary

PR #246 changed `startNoteViewingWatcher` so an unhandled event (client disconnected) stays pending and gets retried every 2s until it's delivered. That's the right behavior, but the **detection log line** was firing every retry, producing ~30 identical lines per minute in \`voice-agent.log\` whenever the user opened a note while voice was disconnected.

Noticed this afternoon — the log was eating itself with:
\`\`\`
21:46:28 [TaskBridge] Note view detected: uiuc-trip-conflicts
21:46:30 [TaskBridge] Note view detected: uiuc-trip-conflicts
21:46:32 [TaskBridge] Note view detected: uiuc-trip-conflicts
... (continues at 2s intervals forever)
\`\`\`

## Fix

Track \`lastNoteViewingLoggedTs\` separately from \`lastNoteViewingTs\` (which tracks *handled*, not *logged*). The detection log line now fires once per unique \`event.ts\`. \`resetNoteViewingDebounce()\` (called on client reconnect) resets both, so a reconnect is still a visible event in the log.

The underlying retry behavior is unchanged — still polling every 2s, still calling \`onNoteView\` on each retry, still picking up the event on reconnect. Only the log-write side is quieter.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 48/48 passing (note: bodhi bump from today's #1 fork merge pulled the cartesia optional dep, so that previously-failing test now passes; unrelated to this PR but a nice baseline)
- [x] Restarted voice-agent against a live \`/tmp/sutando-note-viewing.json\` with client disconnected → exactly **1** detection log line in a 20s tail. Before this fix: 10+ lines in the same window.

## Related

- PR #241 added the watcher
- PR #246 added the keep-pending-on-disconnect retry (this is where the log-spam was introduced)
- This PR: close the loop so the retry doesn't spam the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)