### PR TITLE
health-check: extend #253's git cross-check to bridge stale path

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -434,8 +434,12 @@ def run_all_checks() -> list[dict]:
                     # so 30 min comfortably catches them while tolerating routine
                     # branch switching.
                     if src_mtime - proc_start > 1800:  # source >30 min newer
-                        status = "stale"
-                        detail = f"running but code is {int((src_mtime - proc_start) / 60)} min newer than process — restart needed"
+                        # Cross-check with git before flagging — #253 added this
+                        # for voice-agent + web-client via mark_stale_if_outdated,
+                        # this path does the same check inline to reach bridges.
+                        if not _file_unchanged_since(src_file, proc_start):
+                            status = "stale"
+                            detail = f"running but code is {int((src_mtime - proc_start) / 60)} min newer than process — restart needed"
         except (subprocess.TimeoutExpired, ValueError, OSError):
             pass
 


### PR DESCRIPTION
## Summary

Follow-up to #253. That PR suppressed the git-checkout-bumps-mtime false positive for voice-agent and web-client by cross-checking \`src_mtime\` against \`git log\` and \`git diff\`. But there are **two separate stale-detection code paths** in \`src/health-check.py\`:

1. **\`mark_stale_if_outdated()\`** (line 124) — used for voice-agent and web-client. **Patched by #253.**
2. **Inline bridge check** (line ~436) — used for telegram-bridge and discord-bridge. **Not patched.**

Result on Mini today: telegram-bridge was showing a false-positive stale warning all afternoon even though \`git log -1 --format=%ct\` confirmed the last commit to \`telegram-bridge.py\` predates the running process and \`git diff --quiet\` reports no uncommitted changes.

## Fix

Call \`_file_unchanged_since\` (the helper #253 added) inline at the bridge check point. Same silent-failure semantics: if git is unreachable, the helper returns False and we still flag stale (conservative default keeps real stale deploys visible).

## Alternative considered

Refactoring both paths to share a common helper. Not done because the bridge path has extra logic (heartbeat freshness, log staleness) that \`mark_stale_if_outdated\` doesn't handle. A proper unification would be a bigger refactor, deferred as a future cleanup. This 6-line patch addresses the immediate false-positive bug cleanly.

## Verification

Before: \`telegram-bridge: stale (running but code is 1416 min newer than process — restart needed)\`
After: \`python3 src/health-check.py --quiet\` reports no issues.

Git facts on the bridge file:
\`\`\`
$ git log -1 --format='%ci' -- src/telegram-bridge.py
2026-04-06 23:37:23 -0700

$ ps -o lstart= -p \$(pgrep -f telegram-bridge.py | head -1)
Wed Apr  8 12:26:25 2026

$ git diff --quiet HEAD -- src/telegram-bridge.py && echo "no diff"
no diff
\`\`\`

Commit (Apr 6) predates proc_start (Apr 8), no diff → \`_file_unchanged_since\` returns True → stale flag suppressed.

## Test plan
- [x] \`python3 -m py_compile src/health-check.py\` → ok
- [x] \`python3 src/health-check.py --quiet\` → no output (was flagging telegram-bridge)
- [ ] After merge: real stale deploy case (commit touching a bridge, don't restart) still flagged correctly
- [ ] After merge: false-positive case (git checkout with no content change) stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #391