### PR TITLE
health-check: add voice-transport probe for Gemini Live close errors

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -266,6 +266,96 @@ def check_voice_watchers(voice_check: dict) -> dict:
     return check
 
 
+# Close codes that indicate a healthy voice-agent → Gemini Live transport
+# state. Anything else after a startup banner suggests upstream failure
+# (quota, auth, network blip, bodhi state-machine wedge).
+#   1000 = normal closure
+#   4000 = sutando custom goodbye disconnect (bodhi fork commit 44172b8)
+VOICE_TRANSPORT_HEALTHY_CLOSE_CODES = {"1000", "4000"}
+
+
+def _extract_close_code(line: str) -> str | None:
+    import re
+    m = re.search(r"code=(\d+)", line)
+    return m.group(1) if m else None
+
+
+def _extract_close_reason(line: str) -> str | None:
+    import re
+    m = re.search(r'reason="([^"]*)"', line)
+    return m.group(1) if m else None
+
+
+def check_voice_transport(voice_check: dict) -> dict:
+    """Scan voice-agent.log from the most recent startup banner forward
+    for abnormal Gemini transport closes. Flags things like:
+        code=1011 "exceeded your current quota"    (the 3.1 tier issue)
+        code=1007 "Request contains an invalid argument" (CLOSED→CLOSED)
+        code=1006 abnormal / network drop
+    Returns ok if the latest transport event since the most recent boot
+    is "setup complete", or if an abnormal close was followed by a
+    successful "setup complete" (auto-recovery worked).
+
+    Added 2026-04-09 after the Gemini 3.1 dry-run produced a 1011 that
+    health-check couldn't see — voice-agent port was up, bodhi was up,
+    every existing probe said ok, but the transport was rejected
+    server-side. Without this check, that failure mode is only visible
+    to whoever manually tails the log.
+    """
+    check = {"name": "voice-transport", "status": "ok", "detail": "no recent transport errors"}
+    if voice_check.get("status") != "ok":
+        check["status"] = "warn"
+        check["detail"] = "voice-agent not running"
+        return check
+    log_file = REPO_DIR / "src" / "voice-agent.log"
+    if not log_file.exists():
+        check["status"] = "warn"
+        check["detail"] = "voice-agent.log not found"
+        return check
+    try:
+        lines = log_file.read_text(errors="replace").splitlines()
+        banner_idx = -1
+        for i in range(len(lines) - 1, -1, -1):
+            if "Sutando — Voice Interface" in lines[i]:
+                banner_idx = i
+                break
+        if banner_idx < 0:
+            check["status"] = "warn"
+            check["detail"] = "no startup banner found in log"
+            return check
+        # Walk from the banner forward. Track the most recent transport
+        # event: either "setup complete" (healthy) or "Transport closed"
+        # (potentially problematic). If the tail is an abnormal close
+        # that was NOT followed by a successful setup, flag.
+        most_recent_abnormal: str | None = None
+        abnormal_recovered = False
+        for line in lines[banner_idx:]:
+            if "Gemini setup complete" in line or "LLM transport connected and setup complete" in line:
+                if most_recent_abnormal is not None:
+                    abnormal_recovered = True
+                    most_recent_abnormal = None
+            elif "[VoiceSession] Transport closed" in line:
+                m_code = _extract_close_code(line)
+                if m_code is None:
+                    continue
+                if m_code in VOICE_TRANSPORT_HEALTHY_CLOSE_CODES:
+                    most_recent_abnormal = None
+                else:
+                    most_recent_abnormal = line
+                    abnormal_recovered = False
+        if most_recent_abnormal is not None:
+            reason = _extract_close_reason(most_recent_abnormal) or "unknown"
+            code = _extract_close_code(most_recent_abnormal) or "?"
+            check["status"] = "fail"
+            check["detail"] = f"unrecovered transport close: code={code} reason={reason[:80]}"
+        elif abnormal_recovered:
+            check["detail"] = "transport recovered after earlier error"
+    except OSError as e:
+        check["status"] = "warn"
+        check["detail"] = f"log read failed: {e}"
+    return check
+
+
 def run_all_checks() -> list[dict]:
     checks = []
 
@@ -275,6 +365,7 @@ def run_all_checks() -> list[dict]:
         mark_stale_if_outdated(voice_check, REPO_DIR / "src" / "voice-agent.ts", "voice-agent.ts")
     checks.append(voice_check)
     checks.append(check_voice_watchers(voice_check))
+    checks.append(check_voice_transport(voice_check))
 
     web_check = check_port(8080, "web-client")
     if web_check["status"] == "ok":


### PR DESCRIPTION
## Summary

Closes a visibility gap exposed by the Gemini 3.1 dry-run earlier today. When I unpinned \`VOICE_NATIVE_AUDIO_MODEL\` to \`gemini-3.1-flash-live-preview\`, bodhi hit close code **1011 "exceeded your current quota"** within 12 seconds of boot. Every existing health check still said ok: port 9900 listening, watchers registered (#250), bodhi uptime normal, startup banner present. The probe layer couldn't see the upstream transport failure. I found it only by manually tailing \`voice-agent.log\`.

This PR adds \`check_voice_transport\` that scans the log from the most recent \`Sutando — Voice Interface\` banner forward and reports the tail state of the Gemini transport.

## Reports

| State | Status | Detail |
|---|---|---|
| Latest event is \`Gemini setup complete\` | \`ok\` | no recent transport errors |
| Abnormal close followed by \`setup complete\` | \`ok\` | transport recovered after earlier error |
| Abnormal close with no recovery | \`fail\` | unrecovered transport close: code=N reason=... |

## Healthy close codes (don't flag)

- \`1000\` — normal closure
- \`4000\` — sutando custom goodbye disconnect ([bodhi fork commit 44172b8](https://github.com/sonichi/bodhi_realtime_agent/commit/44172b8))

## Failure modes it catches

- **\`1011\` Gemini quota exhaustion / tier restriction** (the 3.1 case I hit today)
- **\`1007\` "Request contains an invalid argument"** — the CLOSED→CLOSED state-machine wedge I saw in the log this morning before the bodhi PR #1 fixes landed
- **\`1006\` abnormal / network drop**

## Wiring

Placed right after \`check_voice_watchers\` so the voice-agent block in the health report is contiguous:

\`\`\`
✓ voice-agent          ok   port 9900
✓ voice-watchers       ok   all 3 watchers active
✓ voice-transport      ok   no recent transport errors
\`\`\`

Same degradation as \`check_voice_watchers\`: \`warn\` when voice-agent is down, \`warn\` if log is missing, \`warn\` if no banner found.

## Test plan

- [x] Live check on current clean-boot voice-agent → \`ok\`
- [x] 6-case simulated-log harness (all pass):
  1. Clean boot with \`setup complete\` → \`ok\`
  2. Boot → 1011 unrecovered → \`fail\` with code+reason in detail
  3. Boot → 1011 → \`setup complete\` (auto-recovery) → \`ok "recovered after earlier error"\`
  4. Normal \`code=1000\` close → \`ok\` (not flagged)
  5. Custom \`code=4000\` goodbye → \`ok\` (not flagged)
  6. \`code=1007\` wedge unrecovered → \`fail\` with code+reason

## Related

- **#250** added \`voice-watchers\` — this PR is the companion probe for a different failure class
- **#253** and **#255** are the stale-detection false-positive cleanup — those reduced noise, this adds a new signal
- Pairs naturally with Wenjix's **#181** (resilient voice-agent): when that merges, abnormal closes trigger auto-reconnect, and \`voice-transport\` will report \`transport recovered after earlier error\` so you can still see that something happened

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #390