### PR TITLE
Gemini 3.1 compatibility: deduplicate tools + upgrade SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "@ai-sdk/google": "^1.2.0",
         "@anthropic-ai/claude-agent-sdk": "^0.1.0",
-        "@cartesia/cartesia-js": "^3.0.0",
-        "@google/genai": "^1.48.0",
+        "@google/genai": "^1.49.0",
         "@types/ws": "^8.18.1",
         "ai": "^6.0.149",
         "bodhi-realtime-agent": "github:sonichi/bodhi_realtime_agent",
@@ -27,6 +26,9 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@cartesia/cartesia-js": "^3.0.0"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -188,6 +190,7 @@
       "resolved": "https://registry.npmmirror.com/@cartesia/cartesia-js/-/cartesia-js-3.0.0.tgz",
       "integrity": "sha512-NGbnUd1OYxaQ8LOCAqjEQWnwkzEJftIkDZiQLI2b2KXI+4zciInJpWxeDXCE6A7pVK69QP1+U4QHc9mumwpntQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "peerDependencies": {
         "ws": "^8.18.0"
       },
@@ -640,9 +643,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmmirror.com/@google/genai/-/genai-1.48.0.tgz",
-      "integrity": "sha512-plonYK4ML2PrxsRD9SeqmFt76eREWkQdPCglOA6aYDzL1AAbE+7PUnT54SvpWGfws13L0AZEqGSpL7+1IPnTxQ==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.49.0.tgz",
+      "integrity": "sha512-hO69Zl0H3x+L0KL4stl1pLYgnqnwHoLqtKy6MRlNnW8TAxjqMdOUVafomKd4z1BePkzoxJWbYILny9a2Zk43VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^10.3.0",
@@ -1152,7 +1155,7 @@
     },
     "node_modules/bodhi-realtime-agent": {
       "version": "0.1.5",
-      "resolved": "git+ssh://git@github.com/sonichi/bodhi_realtime_agent.git#44172b80254fc9f93b18272eb222056573d5f342",
+      "resolved": "git+ssh://git@github.com/sonichi/bodhi_realtime_agent.git#26992e35733454b2c42f7998ff0328a1169aa170",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1865,7 +1868,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1887,7 +1889,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@ai-sdk/google": "^1.2.0",
     "@anthropic-ai/claude-agent-sdk": "^0.1.0",
-    "@google/genai": "^1.48.0",
+    "@google/genai": "^1.49.0",
     "@types/ws": "^8.18.1",
     "ai": "^6.0.149",
     "bodhi-realtime-agent": "github:sonichi/bodhi_realtime_agent",

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -535,7 +535,13 @@ function buildAgent(callSession: CallSession): MainAgent {
 				return delegateTask(callSession, task);
 			},
 		});
-		tools.push(...inlineTools);
+		// Deduplicate by name — Gemini 3.1 rejects duplicate function declarations
+		// (2.5 silently accepted them). getCurrentTimeTool is in both anyCallerTools
+		// and inlineTools, so pushing both creates a duplicate that causes 1011.
+		const seen = new Set(tools.map(t => t.name));
+		for (const t of inlineTools) {
+			if (!seen.has(t.name)) { tools.push(t); seen.add(t.name); }
+		}
 		tools.push({
 			name: 'get_task_status',
 			description: 'Check whether a delegated task is still in progress. Use when someone asks "are you still working on that?"',


### PR DESCRIPTION
## Summary
- Deduplicate tool declarations in phone server — `getCurrentTimeTool` appeared in both `anyCallerTools` and `inlineTools`, causing Gemini 3.1 to reject with 1011 "Internal error" (2.5 silently accepted duplicates)
- Upgrade `@google/genai` from 1.48.0 to 1.49.0
- Upgrade `bodhi-realtime-agent` to commit `26992e35` (sendClientContent → sendRealtimeInput migration)

## Root cause
Gemini 3.1 is stricter than 2.5:
1. **Duplicate function declarations** → 1011 during WebSocket setup
2. **`media_chunks` wire format** → 1007 (requires `audio` key in sendRealtimeInput)
3. **`sendClientContent` for text** → 1011 (requires `sendRealtimeInput({ text })`)

Items 2-3 fixed in bodhi fork. This PR fixes item 1 in sutando.

## Depends on
- sonichi/bodhi_realtime_agent `fix/sendAudio-media-to-audio` (1-line: `media` → `audio` in sendAudio)

## Test plan
- [x] Voice agent on gemini-3.1-flash-live-preview — working
- [x] Phone agent on 3.1 with dedup — working (test call connected)
- [x] Reproduced: duplicate tool → 1011; deduplicated → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)