### PR TITLE
health-check: voice-transport tolerates GoAway idle-timeout closes

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -324,22 +324,39 @@ def check_voice_transport(voice_check: dict) -> dict:
             check["detail"] = "no startup banner found in log"
             return check
         # Walk from the banner forward. Track the most recent transport
-        # event: either "setup complete" (healthy) or "Transport closed"
-        # (potentially problematic). If the tail is an abnormal close
-        # that was NOT followed by a successful setup, flag.
+        # event and a few state flags so we can distinguish real failures
+        # from expected idle-timeout closes.
+        #
+        # Expected idle path: Gemini Live fires a `GoAway` (60s warning),
+        # then ~60s later closes the transport with code=1011
+        # "The service is currently unavailable." Bodhi transitions the
+        # session to CLOSED waiting for the next client connect. That's
+        # a normal lifecycle event, not a failure — the session
+        # reconnects fresh when a client comes back. If we flag every
+        # 1011-after-GoAway as a fail, the probe reports a false
+        # positive every time voice sits idle for 10+ minutes.
         most_recent_abnormal: str | None = None
         abnormal_recovered = False
+        goaway_before_close = False  # GoAway seen since the last setup/close
         for line in lines[banner_idx:]:
             if "Gemini setup complete" in line or "LLM transport connected and setup complete" in line:
                 if most_recent_abnormal is not None:
                     abnormal_recovered = True
                     most_recent_abnormal = None
+                goaway_before_close = False
+            elif "GoAway from Gemini" in line:
+                goaway_before_close = True
             elif "[VoiceSession] Transport closed" in line:
                 m_code = _extract_close_code(line)
                 if m_code is None:
                     continue
                 if m_code in VOICE_TRANSPORT_HEALTHY_CLOSE_CODES:
                     most_recent_abnormal = None
+                    goaway_before_close = False
+                elif goaway_before_close:
+                    # Idle timeout path — Google warned, then closed. Not an error.
+                    most_recent_abnormal = None
+                    goaway_before_close = False
                 else:
                     most_recent_abnormal = line
                     abnormal_recovered = False


### PR DESCRIPTION
## Summary

Fixes a false positive in the voice-transport probe I added in #258. Observed live at 03:30 this evening after voice-agent sat idle for ~10 minutes:

\`\`\`
03:29:46 [VoiceSession] GoAway from Gemini (timeLeft=50s)
03:30:46 [VoiceSession] Transport closed (state=ACTIVE code=1011
  reason="The service is currently unavailable.")
03:30:46 [VoiceSession] Gemini disconnected — will reconnect fresh
  when client connects
\`\`\`

This is Google's normal idle-timeout path: Gemini Live fires a \`GoAway\` 60s warning, then closes the transport with code=1011 and a "service is currently unavailable" reason. The bodhi session transitions to CLOSED and waits for the next client connect. When a client comes back, \`handleClientConnected\` reconnects fresh.

The probe was flagging every idle 1011 as \`fail\` with "unrecovered transport close". That trains users to ignore the signal exactly when we need them to trust it — real 1011s from #259 duplicate-tool or #262 googleSearch misconfig get lost in the noise.

## Fix

Track a \`goaway_before_close\` flag that flips true on \`GoAway\` and false on \`setup complete\`. Abnormal closes while the flag is true get reclassified as expected idle-timeouts (not flagged). The flag resets on successful setup complete so a *recovered* idle timeout followed by a *fresh unrelated* 1011 still correctly fails.

State machine:

| Event | \`goaway_before_close\` |
|---|---|
| GoAway | → true |
| Transport closed (any code) | → false (consumed) |
| setup complete | → false (session healthy) |

Abnormal close decision:

| goaway_before_close at close time | Classification |
|---|---|
| true | idle timeout, not flagged |
| false | real failure, flagged |

## Test plan

- [x] Live probe on current log (has the 03:30 idle-timeout 1011): \`voice-transport ok\`
- [x] 4-case simulated-log harness (all pass):
  1. \`GoAway → 1011 "service unavailable"\` unrecovered → **ok** (was fail)
  2. Unrecovered 1011 quota, no GoAway preceding → **fail** (as before)
  3. \`GoAway → 1011 → setup complete\` (reconnected) → **ok**
  4. Recovered idle-timeout + fresh 1011 with no new GoAway → **fail** (proves the flag correctly resets on setup complete)

## Related

- #258 — the original voice-transport probe (merged)
- #259 — Gemini 3.1 duplicate-tool 1011 (merged)
- #262 — Gemini 3.1 googleSearch 1011 (open)

Both #259 and #262 produce a **connection-setup 1011** with no GoAway preceding — those still fail correctly under this fix. Only the *idle after successful session* 1011s get the tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #389