### PR TITLE
dashboard + agent-api: use sys.executable for health-check subprocess

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -104,8 +104,11 @@ voice_desired_state = "disconnected"
 
 def get_status() -> dict:
     try:
+        # Use sys.executable — under launchd, bare `python3` resolves to
+        # /usr/bin/python3 (3.9) which can't parse health-check.py's 3.10+
+        # union syntax. Same regression source as dashboard.get_health().
         result = subprocess.run(
-            ["python3", str(REPO_DIR / "src/health-check.py"), "--json"],
+            [sys.executable, str(REPO_DIR / "src/health-check.py"), "--json"],
             capture_output=True, text=True, timeout=15,
         )
         health = json.loads(result.stdout.strip())

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -25,9 +25,15 @@ PORT = 7844
 
 
 def get_health() -> list[dict]:
+    # Use sys.executable so the subprocess uses the same Python that's
+    # running dashboard itself (typically homebrew 3.11). When launchd
+    # spawns dashboard with a minimal PATH, bare `python3` resolves to
+    # /usr/bin/python3 (3.9.6), which can't parse 3.10+ union syntax
+    # (str | None) in health-check.py — causing a silent TypeError that
+    # empties the services panel. Regression introduced by PR #263.
     try:
         result = subprocess.run(
-            ["python3", str(REPO_DIR / "src/health-check.py"), "--json"],
+            [sys.executable, str(REPO_DIR / "src/health-check.py"), "--json"],
             capture_output=True, text=True, timeout=15,
         )
         data = json.loads(result.stdout.strip())


### PR DESCRIPTION
## Summary

Fixes an empty services panel on the dashboard, regressed by PR #263 earlier tonight.

## Root cause

- \`dashboard.get_health()\` and \`agent-api.get_status()\` both invoke \`health-check.py\` via \`subprocess.run([\"python3\", ...])\`.
- Under launchd, these services run with a minimal PATH. Bare \`python3\` resolves to \`/usr/bin/python3\` (Python 3.9.6 on this machine).
- PR #263 introduced \`str | None\` union syntax in \`health-check.py\`'s close-code helpers — valid in 3.10+, \`TypeError\` on import in 3.9.
- Both callers catch \`Exception\` and return empty, so the UI silently went blank with no error.

## Fix

Invoke via \`sys.executable\` — uses whatever Python is running dashboard/agent-api itself (homebrew 3.11 on this box). Keeps the two code paths locked to the same version so this class of drift can't recur.

## Verification

- \`/json\` endpoint returns 16 checks (previously 0)
- Dashboard HTML: \`9/9 Services OK\` card populated
- All 3 voice + bodhi-dist probes visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #388