### PR TITLE
switch_tab: prefer URL matches over title matches

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -90,12 +90,54 @@ export const switchTabTool: ToolDefinition = {
 			allTerms.push(...words);
 		}
 		const uniqueTerms = [...new Set(allTerms)];
-		const conditions = uniqueTerms.map(t => {
-			const safe = t.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-			return `title of t contains "${safe}" or URL of t contains "${safe}"`;
-		}).join(' or ');
+		const safeTerms = uniqueTerms.map(t => t.replace(/\\/g, '\\\\').replace(/"/g, '\\"'));
+		const urlConditions = safeTerms.map(t => `URL of t contains "${t}"`).join(' or ');
+		const titleConditions = safeTerms.map(t => `title of t contains "${t}"`).join(' or ');
 		try {
-			const script = `tell application "Google Chrome"\nset tabIndex to 0\nrepeat with w in windows\nset tabIndex to 0\nrepeat with t in tabs of w\nset tabIndex to tabIndex + 1\nignoring case\nif ${conditions} then\nset active tab index of w to tabIndex\nset index of w to 1\nactivate\nreturn title of t\nend if\nend ignoring\nend repeat\nend repeat\nreturn "not found"\nend tell`;
+			// Two-pass match: URL first, then title.
+			//
+			// The naive `title OR URL contains keyword` returns the first tab
+			// in window-walk order that matches ANYTHING — which is wrong when
+			// a user says "switch to dashboard" and the walk order puts a
+			// random X tweet that happens to contain the word "Sutando" in its
+			// body text ahead of the actual Sutando Dashboard tab. URL is a
+			// stronger signal than title: aliases in TAB_ALIASES are URL
+			// patterns, and the user almost always means the app/site, not a
+			// random tab whose body text mentions it. If no URL matches, fall
+			// back to title.
+			const script = `tell application "Google Chrome"
+set tabIndex to 0
+repeat with w in windows
+set tabIndex to 0
+repeat with t in tabs of w
+set tabIndex to tabIndex + 1
+ignoring case
+if ${urlConditions} then
+set active tab index of w to tabIndex
+set index of w to 1
+activate
+return title of t
+end if
+end ignoring
+end repeat
+end repeat
+set tabIndex to 0
+repeat with w in windows
+set tabIndex to 0
+repeat with t in tabs of w
+set tabIndex to tabIndex + 1
+ignoring case
+if ${titleConditions} then
+set active tab index of w to tabIndex
+set index of w to 1
+activate
+return title of t
+end if
+end ignoring
+end repeat
+end repeat
+return "not found"
+end tell`;
 			const tmpFile = `/tmp/sutando-switchtab-${Date.now()}.scpt`;
 			writeFileSync(tmpFile, script);
 			const result = execSync(`osascript ${tmpFile}`, { timeout: 5_000 }).toString().trim();


### PR DESCRIPTION
## Problem

Every recent \`switch_tab\` call has been landing on an X tweet whose title contains the word "Sutando" — not on the actual Sutando Dashboard / Sutando Web UI tabs the user was asking for. Voice-agent log tonight shows 5 calls in a row all ending up on:
\`\`\`
(5) Chi Wang on X: "...Sutando..." / X
\`\`\`

## Root cause

The AppleScript joined \`title contains X OR URL contains X\` for every keyword term and returned the first match in window-walk order. Whichever tab comes first in the iteration wins, regardless of how good a match it is. A tweet with "Sutando" anywhere in its body text beats the actual Sutando tabs because it sits earlier in the tab list.

## Fix

Split the match into two passes:

1. **URL pass** — only \`URL of t contains "X"\`. Runs through every window/tab.
2. **Title pass** — falls back to \`title of t contains "X"\` if the URL pass found nothing.

Rationale: \`TAB_ALIASES\` is already URL-pattern-based (\`localhost:7844\`, \`localhost:8080\`, \`github.com\`, \`mail.google.com\`, …). The user almost always means the app/site, not a random tab whose body text mentions it.

## Verified against the live tab list

| keyword      | before            | after                |
| ------------ | ----------------- | -------------------- |
| \`sutando\`    | X tweet           | Sutando Web UI       |
| \`dashboard\`  | X tweet           | Sutando Dashboard    |
| \`github\`     | (unchanged)       | (unchanged)          |

Title-only matches (e.g. a YouTube video title, a Google Doc name) still work via the second pass.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Manual AppleScript test with the current Chrome tab list — "sutando" lands on Sutando Web UI, "dashboard" lands on Sutando Dashboard
- [ ] Voice test: "switch to dashboard" — should hit localhost:7844, not the tweet

🤖 Generated with [Claude Code](https://claude.com/claude-code)