### PR TITLE
health-check --fix: use sys.executable + logs/ path for restart

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -741,8 +741,13 @@ def main():
                             import time as _t; _t.sleep(1)
                         except Exception:
                             pass
-                    subprocess.Popen(["python3", str(REPO_DIR / "src" / f"{c['name']}.py")],
-                                     stdout=open(str(REPO_DIR / "src" / f"{c['name']}.log"), "a"),
+                    # Use sys.executable to avoid launchd's minimal PATH
+                    # resolving `python3` to /usr/bin/python3 (3.9), which
+                    # doesn't have the homebrew site-packages (discord,
+                    # dotenv, etc.) — restart would crash on import.
+                    # Log path uses logs/ (post-PR #251 refactor).
+                    subprocess.Popen([sys.executable, str(REPO_DIR / "src" / f"{c['name']}.py")],
+                                     stdout=open(str(REPO_DIR / "logs" / f"{c['name']}.log"), "a"),
                                      stderr=subprocess.STDOUT, start_new_session=True)
                     print(f"  {c['name']}: {'restarted (stale code)' if c['status'] == 'stale' else 'restarted'}")
                 elif c["name"] == "sutando-app":


### PR DESCRIPTION
## Summary

Two latent bugs in the stale-code restart path of \`health-check.py --fix\`, caught during a grep audit after PR #265.

## Bug 1: bare \`python3\` in subprocess.Popen

Same pattern that PR #265 fixed in dashboard/agent-api. Under launchd's minimal PATH, bare \`python3\` resolves to \`/usr/bin/python3\` (3.9.6 here), which doesn't see homebrew's site-packages. A \`health-check --fix\` run that tries to restart \`discord-bridge\` would crash immediately on \`ModuleNotFoundError: discord\` because the 3.9 tree has no discord package.

**Fix:** \`sys.executable\` — inherits whatever Python runs health-check itself (homebrew 3.11 per the com.sutando.health-check plist).

## Bug 2: stale log path

Log redirect still wrote to \`REPO_DIR / "src" / f"{name}.log"\` after PR #251 moved runtime artifacts to \`logs/\`. A restarted-by-fix service would write to the old path while launchd's \`StandardOutPath\` points at the new one → split-brain logging.

**Fix:** Hardcode the new \`logs/\` path.

## Blast radius

No behavior change unless \`--fix\` actually triggers a stale-code restart. Verified:
- \`py_compile\` clean
- \`python3 src/health-check.py\` still runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #383