### PR TITLE
fix: two stale src/*.log references missed by PR #251

### DIFF
--- a/src/context-drop-inline.txt
+++ b/src/context-drop-inline.txt
@@ -1,7 +1,7 @@
 WORKSPACE="$HOME/Desktop/sutando"
 DROP_FILE="$WORKSPACE/context-drop.txt"
 DROP_IMAGE="$WORKSPACE/tasks/image-$(date +%s%3N).png"
-LOG_FILE="$WORKSPACE/src/context-drop.log"
+LOG_FILE="$WORKSPACE/logs/context-drop.log"
 TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
 
 # Check for Finder file selection ONLY if Finder is frontmost

--- a/src/verify-gemini-31.sh
+++ b/src/verify-gemini-31.sh
@@ -145,7 +145,7 @@ echo "voice-agent transport state:"
 if python3 src/health-check.py --quiet 2>&1 | grep -q "voice-transport .*ok"; then
   pass "voice-transport probe: no recent abnormal closes"
 elif lsof -iTCP:9900 -sTCP:LISTEN >/dev/null 2>&1; then
-  warn "voice-transport probe not green — check src/voice-agent.log for recent 1007/1011/1006 close codes"
+  warn "voice-transport probe not green — check logs/voice-agent.log for recent 1007/1011/1006 close codes"
 else
   warn "voice-agent not running — start it before testing 3.1"
 fi


### PR DESCRIPTION
## Summary

Small cleanup — post-PR #251 grep audit turned up two loose ends that missed the \`logs/\` refactor.

## Changes

### 1. \`src/context-drop-inline.txt:4\`

The Automator paste template still had \`LOG_FILE=\"\$WORKSPACE/src/context-drop.log\"\`. \`src/context-drop.sh\` (the real script) was updated by #251 but the inline/template copy wasn't. Anyone pasting this into a fresh Automator \"Run Shell Script\" action would write logs to the old path.

Flagged during the original #251 review as \"update or delete\" — updating since it's still a copy-paste source for Automator setup docs, not referenced at runtime.

### 2. \`src/verify-gemini-31.sh:148\`

The warn message said \"check \`src/voice-agent.log\` for recent 1007/1011/1006 close codes\" — point at nothing useful after the refactor. Updated to \`logs/\`.

## Blast radius

Zero behavior change for running services — both are display/template strings. Verified \`verify-gemini-31.sh\` still runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #387