### PR TITLE
Remove redundant video tools + scroll error logging

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -385,10 +385,10 @@ function buildAgent(callSession: CallSession): MainAgent {
 				'TOOL EXCLUSIVITY: If an inline tool can handle the request, use ONLY the inline tool. NEVER also call work. They are mutually exclusive — calling both causes duplicate responses. Only use work when no inline tool fits.',
 				'SUMMON: Before calling summon, ALWAYS say "Summoning your screen now" FIRST — the user is on the phone and cannot see what is happening. The tool takes several seconds.',
 				'PLAYBACK RULES (CRITICAL):',
-				'0. Video tools: open_video (open), play_video (play from start), pause_video (pause), resume_video (resume/continue), replay_video (start over), close_video (close). NEVER use work for video.',
+				'0. Video tools: open_video (open), play_video (play from start or replay), resume_video (resume/continue). For pause use press_key("space"). For close use press_key("cmd+q"). NEVER use work for video.',
 				'1. After calling play_video or resume_video, say NOTHING. Audio streams to the phone.',
-				'2. "pause", "stop", "hold" → call pause_video, then say "Paused."',
-				'3. "play" → play_video. "resume"/"continue" → resume_video. "start over"/"replay" → replay_video.',
+				'2. "pause", "stop", "hold" → call press_key with "space", then say "Paused."',
+				'3. "play"/"start over"/"replay" → play_video. "resume"/"continue" → resume_video.',
 				'4. Do NOT use describe_screen, scroll, or work while a recording is playing.',
 				'5. Do NOT guess or hallucinate about the video (duration, content, etc). You cannot see or hear it.',
 				'You can make concurrent calls — stay on the line while calling someone else.',
@@ -657,7 +657,7 @@ async function createCallSession(params: {
 					callSession.events.push({ event: `rec_indicator:${hasIndicator ? 'on' : 'off'}`, timestamp: new Date().toISOString() });
 				}
 				// After video play/pause, inject context reminder
-				if (['play_video', 'pause_video', 'resume_video', 'replay_video'].includes(toolName)) {
+				if (['play_video', 'resume_video'].includes(toolName)) {
 					setTimeout(() => {
 						try {
 							if (existsSync('/tmp/sutando-playback-pause')) {
@@ -666,7 +666,7 @@ async function createCallSession(params: {
 								], true);
 							} else {
 								(session as any).transport.sendContent([
-									{ role: 'user', text: '[System: Video PLAYING. Say NOTHING. ONLY call pause_video when user says "pause"/"stop"/"continue", or close_video when user says "close". Ignore ALL other speech.]' },
+									{ role: 'user', text: '[System: Video PLAYING. Say NOTHING. ONLY call press_key("space") when user says "pause"/"stop", or press_key("cmd+q") when user says "close". Ignore ALL other speech.]' },
 								], true);
 							}
 						} catch {}

--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -674,47 +674,10 @@ export const resumeVideoTool: ToolDefinition = {
 	},
 };
 
-export const replayVideoTool: ToolDefinition = {
-	name: 'replay_video',
-	description: 'Replay the video from the beginning. Use when user says "start over", "replay", "play again".',
-	parameters: z.object({}),
-	execution: 'inline',
-	async execute() {
-		console.log(`${ts()} [ReplayVideo] called`);
-		try { return await startPlayback(0); } catch (err) { return { error: `${err}` }; }
-	},
-};
-
-// "continue" intentionally NOT in pause_video — it belongs on resume_video.
-// Adding it here caused Gemini to pause when user said "continue".
-export const pauseVideoTool: ToolDefinition = {
-	name: 'pause_video',
-	description:
-		'Pause the video. Use when user says "pause", "stop", or "hold".',
-	parameters: z.object({}),
-	execution: 'inline',
-	async execute() {
-		console.log(`${ts()} [PauseVideo] called`);
-		try { writeFileSync('/tmp/sutando-playback-pause', '1'); } catch {}
-		try { execSync(`osascript -e 'tell application "QuickTime Player"' -e 'if (count of documents) > 0 then' -e 'pause document 1' -e 'end if' -e 'end tell'`, { timeout: 5_000 }); } catch {}
-		return { status: 'paused', instruction: 'Paused. When user says play/resume, call play_video.' };
-	},
-};
-
-export const closeVideoTool: ToolDefinition = {
-	name: 'close_video',
-	description:
-		'Close the video player. Use when user says "close the video", "close it".',
-	parameters: z.object({}),
-	execution: 'inline',
-	async execute() {
-		console.log(`${ts()} [CloseVideo] called`);
-		try { execSync(`osascript -e 'tell application "QuickTime Player" to quit'`, { timeout: 5_000 }); } catch {}
-		try { unlinkSync('/tmp/sutando-playback-pause'); } catch {}
-		try { unlinkSync('/tmp/sutando-playback-path'); } catch {}
-		return { status: 'closed' };
-	},
-};
+// Removed: replayVideoTool (identical to play_video), pauseVideoTool (Space key
+// pauses QuickTime, press_key handles it), closeVideoTool (Cmd+Q quits QuickTime,
+// press_key handles it). Kept play_video and resume_video because they need phone
+// audio streaming side effects that keyboard shortcuts can't provide.
 
 // --- Screen recording ---
 

--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -387,7 +387,11 @@ export const scrollAndDescribeTool: ToolDefinition = {
 			let scrolledTotal = 0;
 			const scrollInterval = setInterval(() => {
 				if (scrolledTotal >= pageHeight) return; // stop at bottom
-				try { scrollDown(pxPerStep); } catch {}
+				try { scrollDown(pxPerStep); } catch (err) {
+					// Scroll can fail if Chrome lost focus (Zoom overlay) or tab changed.
+					// Log but don't stop — next interval may succeed.
+					console.log(`${ts()} [ScrollAndDescribe] scroll failed: ${err}`);
+				}
 				scrolledTotal += pxPerStep;
 			}, SCROLL_INTERVAL_MS);
 

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -14,8 +14,8 @@ import type { ToolDefinition } from 'bodhi-realtime-agent';
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 
 // Re-export recording/screen/browser tools from browser-tools
-export { describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, scrollTool } from './browser-tools.js';
-import { describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, scrollTool } from './browser-tools.js';
+export { describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, resumeVideoTool, switchTabTool, scrollTool } from './browser-tools.js';
+import { describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, resumeVideoTool, switchTabTool, scrollTool } from './browser-tools.js';
 
 // --- Keyboard tool ---
 
@@ -1358,7 +1358,7 @@ export const inlineTools = [
 	volumeTool, brightnessTool, clipboardTool,
 	cancelTaskTool, toggleTasksTool, getCurrentTimeTool, summonTool, dismissTool,
 	joinZoomTool, joinGmeetTool, lookupMeetingIdTool, callContactTool,
-	describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, slideControlTool, fullscreenTool,
+	describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, resumeVideoTool, slideControlTool, fullscreenTool,
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool, ];
 
 /** Tools available to any caller (including unverified) */
@@ -1374,7 +1374,7 @@ export const ownerOnlyTools = [
 	clipboardTool, cancelTaskTool, toggleTasksTool, summonTool, dismissTool,
 	joinZoomTool, joinGmeetTool, callContactTool, slideControlTool, fullscreenTool,
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
-	describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool,
+	describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, resumeVideoTool,
 ];
 
 /** Configurable tools — default to owner-only, can be opened to verified callers */


### PR DESCRIPTION
## Summary
- **Remove 3 redundant video tools**: `replay_video` (identical to `play_video`), `pause_video` (replaced by `press_key("space")`), `close_video` (replaced by `press_key("cmd+q")`)
- **Add scroll error logging**: log intermittent scroll failures during recording (~10% of calls, likely Zoom overlay stealing Chrome focus)

## Why remove video tools?
Reduces Gemini's tool count by 3, lowering confusion risk. `press_key` already handles pause (Space) and close (Cmd+Q). `replay_video` was identical to `play_video` (both call `startPlayback(0)`). Kept `open_video` (needs `findRecording`), `play_video` (needs phone audio streaming), `resume_video` (needs phone audio resume).

## Test plan
- [ ] Test pause via press_key("space") during phone call
- [ ] Test close via press_key("cmd+q") during phone call
- [ ] Verify scroll error appears in logs when scroll fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)