### PR TITLE
fix: Python 3.9 compat for health-check + pending-questions parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ tab-aliases.json
 session-state.md
 src/web-client.js
 context-drop-image.png
+generated-*.png
 contextual-chips.json
 *.heartbeat
 .agent/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ It belongs entirely to you.
 
 Unmute to hear the real-time conversation. In this demo, the user controls their Mac entirely from a phone call — sharing the screen to Zoom, recording a narrated video, adding subtitles, and playing it back. No keyboard, no mouse. [Watch on YouTube →](https://youtu.be/kpdSC3e7tM4)
 
+📺 [Watch the vision talk at UC Berkeley →](https://youtu.be/c39fJ2WAj6A?t=7719) — the idea behind Sutando, before it existed.
+
 ---
 
 ## What can you do with it?

--- a/skills/regression-search/scripts/diagnose-call.py
+++ b/skills/regression-search/scripts/diagnose-call.py
@@ -19,6 +19,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import Optional
 
 REPO = Path(__file__).resolve().parent.parent.parent.parent
 CALLS_FILE = REPO / "results" / "calls" / "calls.jsonl"
@@ -51,7 +52,7 @@ def parse_transcript(transcript: str) -> list[tuple[str, str]]:
     return turns
 
 
-def find_call(sid_query: str) -> dict | None:
+def find_call(sid_query: str) -> Optional[dict]:
     """Match by full SID or by suffix (12 chars is enough to disambiguate)."""
     if not CALLS_FILE.exists():
         return None
@@ -76,7 +77,7 @@ def find_call(sid_query: str) -> dict | None:
     return candidates[-1]
 
 
-def find_metrics(call_sid: str) -> dict | None:
+def find_metrics(call_sid: str) -> Optional[dict]:
     if not METRICS_FILE.exists():
         return None
     with METRICS_FILE.open() as f:

--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -19,16 +19,26 @@ LAST_NOTIFY_FILE = WORKSPACE / ".last-pq-notify"
 
 
 def get_waiting_questions():
+    """Parse pending-questions.md — matches both legacy `## Q1 — Title` and
+    the current `## Title` / `- **Status:** unanswered` format."""
     if not PQ_FILE.exists():
         return []
     content = PQ_FILE.read_text()
     questions = []
-    for m in re.finditer(r'## (Q\d+) — (.+?)\n', content):
-        # Check if this question's status is Waiting
-        qid = m.group(1)
-        title = m.group(2)
-        if f"**Status:** Waiting" in content[m.start():m.start() + 500]:
-            questions.append({"id": qid, "title": title})
+    # Walk each ## section; a section is waiting if its body contains
+    # `Status: unanswered` or `Status: Waiting`.
+    sections = re.split(r'^## ', content, flags=re.MULTILINE)
+    for sec in sections[1:]:  # skip pre-header
+        title_line, _, body = sec.partition('\n')
+        title = title_line.strip()
+        if not title:
+            continue
+        status_m = re.search(r'\*\*Status:\*\*\s*(.+)', body)
+        if not status_m:
+            continue
+        status = status_m.group(1).strip().lower()
+        if status.startswith('unanswered') or status.startswith('waiting'):
+            questions.append({"id": title[:40], "title": title})
     return questions
 
 
@@ -60,6 +70,25 @@ def notify_voice(questions):
     )
 
 
+def notify_discord_dm(questions):
+    """Write a proactive-*.txt file so discord-bridge DMs the owner.
+    Owner asked (2026-04-09, while traveling) to receive pending-question
+    pings as DMs instead of just macOS notifications."""
+    ts = int(time.time())
+    path = RESULTS_DIR / f"proactive-pending-q-{ts}.txt"
+    lines = [
+        f"⚠️ {len(questions)} pending question{'s' if len(questions) > 1 else ''} waiting:",
+        "",
+    ]
+    for q in questions[:5]:
+        lines.append(f"• {q['title']}")
+    if len(questions) > 5:
+        lines.append(f"…and {len(questions) - 5} more")
+    lines.append("")
+    lines.append("Reply here or edit pending-questions.md on the Mini to resolve.")
+    path.write_text("\n".join(lines))
+
+
 def main():
     questions = get_waiting_questions()
     if not questions:
@@ -76,6 +105,9 @@ def main():
 
     # Voice result (if voice is connected, agent will speak it)
     notify_voice(questions)
+
+    # Discord DM to owner (via discord-bridge poll_proactive)
+    notify_discord_dm(questions)
 
     # Update last notify time
     LAST_NOTIFY_FILE.write_text(str(int(time.time())))

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -20,6 +20,7 @@ import socket
 import subprocess
 import sys
 from pathlib import Path
+from typing import Optional
 
 REPO_DIR = Path(__file__).parent.parent
 
@@ -274,13 +275,13 @@ def check_voice_watchers(voice_check: dict) -> dict:
 VOICE_TRANSPORT_HEALTHY_CLOSE_CODES = {"1000", "4000"}
 
 
-def _extract_close_code(line: str) -> str | None:
+def _extract_close_code(line: str) -> Optional[str]:
     import re
     m = re.search(r"code=(\d+)", line)
     return m.group(1) if m else None
 
 
-def _extract_close_reason(line: str) -> str | None:
+def _extract_close_reason(line: str) -> Optional[str]:
     import re
     m = re.search(r'reason="([^"]*)"', line)
     return m.group(1) if m else None
@@ -335,7 +336,7 @@ def check_voice_transport(voice_check: dict) -> dict:
         # reconnects fresh when a client comes back. If we flag every
         # 1011-after-GoAway as a fail, the probe reports a false
         # positive every time voice sits idle for 10+ minutes.
-        most_recent_abnormal: str | None = None
+        most_recent_abnormal: Optional[str] = None
         abnormal_recovered = False
         goaway_before_close = False  # GoAway seen since the last setup/close
         for line in lines[banner_idx:]:


### PR DESCRIPTION
## Summary
- health-check.py used `str | None` union syntax (Python 3.10+), crashing on Mac Mini (Python 3.9.6). Replaced with `Optional[str]`.
- check-pending-questions.py: rewrote parser to match current `## Title` / `Status: unanswered` format + added Discord DM notification for pending questions.

## Test plan
- [x] `python3 src/health-check.py` runs without error on Python 3.9.6
- [x] All services show green after restart
- [ ] Verify `python3 src/check-pending-questions.py` detects unanswered items

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #382