### PR TITLE
fix: discord send uses REST API — stops duplicate replies

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -492,6 +492,10 @@ async def poll_results():
             if result_file.exists():
                 import re
                 reply_text = result_file.read_text().strip()
+                # Delete result file immediately to prevent duplicate sends
+                result_file.unlink(missing_ok=True)
+                task_file = TASKS_DIR / f"{task_id}.txt"
+                task_file.unlink(missing_ok=True)
                 channel = pending_replies.pop(task_id)
                 save_pending_replies()
                 # Skip sending if already replied directly (core agent used MCP)
@@ -521,10 +525,6 @@ async def poll_results():
                     print(f"  Replied: {reply_text[:80]}...")
                 except Exception as e:
                     print(f"  Reply failed: {e}")
-                # Clean up
-                result_file.unlink(missing_ok=True)
-                task_file = TASKS_DIR / f"{task_id}.txt"
-                task_file.unlink(missing_ok=True)
         await asyncio.sleep(1)
 
 

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -9,6 +9,7 @@ Usage: python3 src/discord-bridge.py
 import asyncio
 import json
 import os
+import sys
 import time
 from pathlib import Path
 
@@ -568,5 +569,26 @@ async def poll_proactive():
         await asyncio.sleep(3)
 
 
+def _send_via_rest(channel_id: str, message: str):
+    """Send a message via Discord REST API (no gateway connection). Exits after sending."""
+    import urllib.request
+    url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
+    data = json.dumps({"content": message}).encode()
+    req = urllib.request.Request(url, data=data, headers={
+        "Authorization": f"Bot {TOKEN}",
+        "Content-Type": "application/json",
+        "User-Agent": "DiscordBot (sutando, 1.0)",
+    })
+    try:
+        urllib.request.urlopen(req)
+        print(f"Sent to {channel_id}: {message[:80]}...")
+    except Exception as e:
+        print(f"Send failed: {e}")
+        sys.exit(1)
+
+
 if __name__ == "__main__":
-    client.run(TOKEN, log_handler=None)
+    if len(sys.argv) >= 4 and sys.argv[1] == "send":
+        _send_via_rest(sys.argv[2], " ".join(sys.argv[3:]))
+    else:
+        client.run(TOKEN, log_handler=None)


### PR DESCRIPTION
## Summary
- `discord-bridge.py send <channel> <msg>` was starting a full Discord bot gateway connection that never exits
- Multiple callers spawned dozens of zombie bot instances (37 observed), all receiving events and sending duplicate replies (up to 10x)
- Now uses Discord REST API directly and exits immediately after sending

## Root cause
The `__main__` block only had `client.run(TOKEN)` — no handling for the `send` subcommand. Every `send` invocation started a full bot that stayed alive forever.

## Test plan
- [x] Verified `send` subcommand sends and exits with code 0
- [x] Verified no hanging processes after send
- [x] Killed 37 existing zombie `discord-bridge.py send` processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)