### PR TITLE
Fix type_text, SSE resilience, scroll targeting, Discord images

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -127,6 +127,41 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem(title: "Stop All Services", action: #selector(stopServices), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
         statusItem.menu = menu
+
+        // Poll mute/voice state every 3 seconds for menu bar indicator
+        Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self] _ in
+            self?.pollMuteState()
+        }
+    }
+
+    func pollMuteState() {
+        guard let url = URL(string: "http://localhost:8080/sse-status") else { return }
+        let task = URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
+            guard let data = data, error == nil,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+            let isMuted = json["muted"] as? Bool ?? false
+            let isVoiceConnected = json["voiceConnected"] as? Bool ?? false
+            DispatchQueue.main.async {
+                guard let button = self?.statusItem.button else { return }
+                if isVoiceConnected && isMuted {
+                    // Voice active + muted: show mute indicator
+                    button.title = "🔇"
+                    button.image = nil
+                } else {
+                    // Default state (disconnected or unmuted): show avatar
+                    let avatarPath = (self?.workspace ?? "") + "/docs/stand-avatar.png"
+                    if let image = NSImage(contentsOfFile: avatarPath) {
+                        image.size = NSSize(width: 18, height: 18)
+                        image.isTemplate = false
+                        button.image = image
+                        button.title = ""
+                    } else {
+                        button.title = "S"
+                    }
+                }
+            }
+        }
+        task.resume()
     }
 
     // MARK: - Global Hotkey (Ctrl+Shift+D)

--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -34,23 +34,37 @@ const VISION_MODEL = process.env.VISION_MODEL || 'gemini-3.1-flash-lite-preview'
 export const scrollTool: ToolDefinition = {
 	name: 'scroll',
 	description:
-		'Scroll the Chrome browser page. Use for: "scroll down", "scroll up", "scroll to top", "scroll to bottom".',
+		'Scroll the Chrome browser page. Use for: "scroll down", "scroll up", "scroll to top", "scroll to bottom". Use target for specific areas: "sidebar", "chat history", "code block".',
 	parameters: z.object({
 		direction: z.enum(['down', 'up', 'top', 'bottom']).describe('Scroll direction. Use "top" or "bottom" to jump to start/end of page.'),
+		target: z.string().optional().describe('Optional: which area to scroll. E.g. "sidebar", "chat history", "nav", "code". Omit for main content.'),
 	}),
 	execution: 'inline',
 	async execute(args) {
-		const { direction } = args as { direction: 'down' | 'up' | 'top' | 'bottom' };
+		const { direction, target } = args as { direction: 'down' | 'up' | 'top' | 'bottom'; target?: string };
 		try {
-			// Use Chrome's JavaScript scrollBy to avoid focus issues (Zoom steals keystrokes)
+			// Target-specific selectors for common areas
+			const targetSelector = target
+				? (target.match(/side|nav|history|menu/i) ? 'nav' : target.match(/code/i) ? 'pre,code' : target)
+				: '';
+			// Use Chrome's JavaScript scroll. If target specified, find matching scrollable element.
+			// Otherwise find the WIDEST scrollable container (main content over sidebars).
+			const scrollFn = (cmd: string) => targetSelector
+				? `(function(){var sel="${targetSelector}";var e=null;document.querySelectorAll(sel).forEach(function(el){if(!e&&el.scrollHeight-el.clientHeight>50)e=el});if(!e){var best=null,bh=0;document.querySelectorAll("*").forEach(function(el){var d=el.scrollHeight-el.clientHeight;if(d>50&&el.clientHeight>100&&el.getBoundingClientRect().width<500){if(d>bh){best=el;bh=d}}});e=best}if(e){${cmd}}})()`
+				: `(function(){var best=document.scrollingElement||document.documentElement,bw=0;document.querySelectorAll("*").forEach(function(el){var d=el.scrollHeight-el.clientHeight;if(d>50&&el.clientHeight>200){var w=el.getBoundingClientRect().width;if(w>bw){best=el;bw=w}}});var e=best;${cmd}})()`;
+			let js: string;
 			if (direction === 'top') {
-				execSync(`osascript -e 'tell application "Google Chrome" to tell active tab of front window to execute javascript "window.scrollTo(0, 0)"'`, { timeout: 5_000 });
+				js = scrollFn('e.scrollTop=0');
 			} else if (direction === 'bottom') {
-				execSync(`osascript -e 'tell application "Google Chrome" to tell active tab of front window to execute javascript "window.scrollTo(0, document.body.scrollHeight)"'`, { timeout: 5_000 });
+				js = scrollFn('e.scrollTop=e.scrollHeight');
 			} else {
 				const amount = direction === 'down' ? 600 : -600;
-				execSync(`osascript -e 'tell application "Google Chrome" to tell active tab of front window to execute javascript "window.scrollBy(0, ${amount})"'`, { timeout: 5_000 });
+				js = scrollFn(`e.scrollBy(0,${amount})`);
 			}
+			const tmpScroll = `/tmp/sutando-scroll-${Date.now()}.scpt`;
+			writeFileSync(tmpScroll, `tell application "Google Chrome" to tell active tab of front window to execute javascript "${js.replace(/"/g, '\\"')}"`);
+			execSync(`osascript ${tmpScroll}`, { timeout: 5_000 });
+			try { unlinkSync(tmpScroll); } catch {}
 			console.log(`${ts()} [Scroll] ${direction}`);
 			return { status: 'scrolled', direction };
 		} catch (err) {
@@ -213,7 +227,42 @@ export const typeTextTool: ToolDefinition = {
 	execution: 'inline',
 	async execute(args) {
 		const { text } = args as { text: string };
-		// Fixes CodeQL #27 (js/command-line-injection): write to temp file instead of shell interpolation
+		// Debug: log exactly what arrives from Gemini so we can trace newline issues
+		console.log(`${ts()} [TypeText] input: ${JSON.stringify(text).slice(0, 200)} len=${text.length}`);
+		// Multi-line or special-char text: use clipboard paste instead of
+		// keystroke. AppleScript `keystroke` can't handle newlines, parens,
+		// or other chars that break the osascript string. Clipboard approach:
+		// save current clipboard → write text → Cmd+V → restore clipboard.
+		// Check for actual newlines OR literal backslash-n (Gemini sends the latter)
+		const hasNewline = text.includes('\n') || text.includes('\r') || /\\n/.test(text) || text.length > 80;
+		console.log(`${ts()} [TypeText] hasNewline=${hasNewline} path=${hasNewline ? 'paste' : 'keystroke'}`);
+		if (hasNewline) {
+			try {
+				let savedClipboard = '';
+				try { savedClipboard = execSync('pbpaste', { encoding: 'utf-8', timeout: 2_000 }); } catch {}
+				const tmpClip = `/tmp/sutando-typetext-clip-${Date.now()}.txt`;
+				// Convert literal \n to actual newlines (Gemini sometimes sends escaped)
+				const pasteText = text.replace(/\\n/g, '\n').replace(/\\t/g, '\t')
+					.replace(/\\\\n/g, '\n').replace(/\\\\t/g, '\t');
+				writeFileSync(tmpClip, pasteText);
+				execSync(`pbcopy < ${tmpClip}`, { timeout: 2_000 });
+				execSync(`osascript -e 'tell application "System Events" to keystroke "v" using command down'`, { timeout: 5_000 });
+				// Brief delay for paste to complete, then restore clipboard
+				execSync('sleep 0.3');
+				if (savedClipboard) {
+					const tmpRestore = `/tmp/sutando-typetext-restore-${Date.now()}.txt`;
+					writeFileSync(tmpRestore, savedClipboard);
+					execSync(`pbcopy < ${tmpRestore}`, { timeout: 2_000 });
+					try { unlinkSync(tmpRestore); } catch {}
+				}
+				try { unlinkSync(tmpClip); } catch {}
+				console.log(`${ts()} [TypeText] pasted (multi-line): ${text.slice(0, 40)}...`);
+				return { status: 'typed', text };
+			} catch (err) {
+				return { error: `Paste failed: ${err instanceof Error ? err.message : err}` };
+			}
+		}
+		// Single-line short text: use keystroke (faster, no clipboard disruption)
 		const tmpFile = `/tmp/sutando-typetext-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.scpt`;
 		try {
 			const safeText = text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
@@ -968,4 +1017,5 @@ export const clickTool: ToolDefinition = {
 };
 
 // --- Screen recording ---
+
 

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -252,15 +252,22 @@ async def _handle_discord_message(message, force=False):
             for embed in getattr(snap_msg, 'embeds', []):
                 if embed.title: parts.append(embed.title)
                 if embed.description: parts.append(embed.description)
-            # Extract snapshot attachment names
+            # Download snapshot attachments (forwarded images/files)
             for att in getattr(snap_msg, 'attachments', []):
-                parts.append(f"[Attachment: {att.filename}]")
+                local_path = INBOX_DIR / f"{int(time.time()*1000)}_{att.filename}"
+                try:
+                    await att.save(local_path)
+                    parts.append(f"[File attached: {local_path}]")
+                    print(f"  [forward] downloaded: {att.filename} → {local_path}", flush=True)
+                except Exception as e:
+                    parts.append(f"[Attachment: {att.filename} (download failed: {e})]")
+                    print(f"  [forward] download failed: {att.filename}: {e}", flush=True)
             if parts:
                 fwd_text = "\n".join(parts)
                 text = (text + "\n" + fwd_text).strip() if text else fwd_text.strip()
                 print(f"  [forward] extracted: {text[:100]}", flush=True)
 
-    # Handle embeds (link previews, rich content)
+    # Handle embeds (link previews, rich content, pasted images)
     embed_text = ""
     for embed in message.embeds:
         parts = []
@@ -272,6 +279,26 @@ async def _handle_discord_message(message, force=False):
             parts.append(embed.description)
         for field in embed.fields:
             parts.append(f"{field.name}: {field.value}")
+        # Download embedded images (pasted via Cmd+V — not in attachments)
+        img_url = None
+        if embed.image and embed.image.url:
+            img_url = embed.image.url
+        elif embed.thumbnail and embed.thumbnail.url:
+            img_url = embed.thumbnail.url
+        if img_url:
+            try:
+                import aiohttp
+                ext = img_url.split("?")[0].rsplit(".", 1)[-1][:4] if "." in img_url else "png"
+                local_path = INBOX_DIR / f"{int(time.time()*1000)}_embed.{ext}"
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(img_url) as resp:
+                        if resp.status == 200:
+                            local_path.write_bytes(await resp.read())
+                            parts.append(f"[File attached: {local_path}]")
+                            print(f"  [embed] downloaded image: {local_path}", flush=True)
+            except Exception as e:
+                parts.append(f"[Embed image: {img_url} (download failed: {e})]")
+                print(f"  [embed] image download failed: {e}", flush=True)
         if parts:
             embed_text += "\n".join(parts) + "\n"
     if embed_text:

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -168,6 +168,34 @@ export const typeTextTool: ToolDefinition = {
 	execution: 'inline',
 	async execute(args) {
 		const { text } = args as { text: string };
+		// Multi-line or long text: use clipboard paste (keystroke can't handle newlines)
+		// Gemini sends literal \n (two chars backslash+n), not actual newlines
+		const hasNewline = text.includes('\n') || text.includes('\r') || /\\n/.test(text) || text.length > 80;
+		if (hasNewline) {
+			try {
+				let savedClipboard = '';
+				try { savedClipboard = execSync('pbpaste', { encoding: 'utf-8', timeout: 2_000 }); } catch {}
+				// Convert literal \n to actual newlines
+				const pasteText = text.replace(/\\n/g, '\n').replace(/\\t/g, '\t');
+				const tmpClip = `/tmp/sutando-typetext-clip-${Date.now()}.txt`;
+				writeFileSync(tmpClip, pasteText);
+				execSync(`pbcopy < ${tmpClip}`, { timeout: 2_000 });
+				execSync(`osascript -e 'tell application "System Events" to keystroke "v" using command down'`, { timeout: 5_000 });
+				execSync('sleep 0.3');
+				if (savedClipboard) {
+					const tmpRestore = `/tmp/sutando-typetext-restore-${Date.now()}.txt`;
+					writeFileSync(tmpRestore, savedClipboard);
+					execSync(`pbcopy < ${tmpRestore}`, { timeout: 2_000 });
+					try { unlinkSync(tmpRestore); } catch {}
+				}
+				try { unlinkSync(tmpClip); } catch {}
+				console.log(`${ts()} [TypeText] pasted (multi-line): ${text.slice(0, 40)}...`);
+				return { status: 'typed', text };
+			} catch (err) {
+				return { error: `Paste failed: ${err instanceof Error ? err.message : err}` };
+			}
+		}
+		// Single-line short text: use keystroke
 		const safeText = text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 		try {
 			execSync(`osascript -e 'tell application "System Events" to keystroke "${safeText}"'`, { timeout: 5_000 });

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -407,12 +407,21 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 // ─── Remote toggle via SSE ────────────────────────────────
-(function initRemoteToggle() {
-  const evtSource = new EventSource('/sse');
-  evtSource.addEventListener('toggle-voice', () => toggle());
-  evtSource.addEventListener('toggle-mute', () => toggleMute());
-  evtSource.onerror = () => setTimeout(() => initRemoteToggle(), 5000);
-})();
+// Chrome throttles/suspends background tabs after ~5 min, killing SSE event
+// processing. On visibility change (tab returns to foreground), reconnect
+// the EventSource so ⌃V/⌃M hotkeys work immediately after tab wake-up.
+let _sseSource = null;
+function initRemoteToggle() {
+  if (_sseSource) { try { _sseSource.close(); } catch {} }
+  _sseSource = new EventSource('/sse');
+  _sseSource.addEventListener('toggle-voice', () => toggle());
+  _sseSource.addEventListener('toggle-mute', () => toggleMute());
+  _sseSource.onerror = () => setTimeout(() => initRemoteToggle(), 5000);
+}
+initRemoteToggle();
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') initRemoteToggle();
+});
 
 // ─── State ────────────────────────────────────────────────
 let ws = null;
@@ -1130,6 +1139,7 @@ function doCleanup() {
   setStatus('Text only', '');
   connected = false;
   muted = false;
+  fetch('/mute-state?muted=false&voice=false').catch(() => {}); // Reset state on disconnect
   document.body.classList.remove('voice-active');
   $('hero').style.display = '';
   $('btn').style.display = 'none';
@@ -1149,6 +1159,8 @@ function toggleMute() {
   btn.textContent = muted ? 'Unmute' : 'Mute';
   btn.className = muted ? 'btn-mute muted' : 'btn-mute';
   addSystem(muted ? 'Microphone muted.' : 'Microphone unmuted.');
+  // Report actual mute state to server for menu bar indicator
+  fetch('/mute-state?muted=' + muted).catch(() => {});
 }
 
 // ─── UI toggle (user gesture context!) ────────────────────
@@ -1174,6 +1186,7 @@ function toggle() {
 
     connected = true;
     muted = false;
+    fetch('/mute-state?muted=false&voice=true').catch(() => {}); // Report connected + unmuted
     document.body.classList.add('voice-active');
     $('hero').style.display = 'none';
     $('btn').style.display = '';
@@ -1726,6 +1739,20 @@ updateDynamicRegion();
 
 // SSE clients for remote toggle
 const sseClients: import('node:http').ServerResponse[] = [];
+// Server-side state tracking for menu bar indicator
+let _muteState = false;
+let _voiceState = false;
+
+// Heartbeat: ping every 30s, remove clients that fail to write (stale connections)
+setInterval(() => {
+	for (let i = sseClients.length - 1; i >= 0; i--) {
+		try {
+			sseClients[i].write(':\n\n'); // SSE comment = keep-alive ping
+		} catch {
+			sseClients.splice(i, 1);
+		}
+	}
+}, 30_000);
 
 const server = createServer((req, res) => {
 	const url = new URL(req.url || '/', `http://${req.headers.host}`);
@@ -1743,6 +1770,24 @@ const server = createServer((req, res) => {
 			const idx = sseClients.indexOf(res);
 			if (idx >= 0) sseClients.splice(idx, 1);
 		});
+		return;
+	}
+
+	// SSE client count + mute/voice state (safe for diagnostics + menu bar indicator)
+	if (url.pathname === '/sse-status') {
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ clients: sseClients.length, muted: _muteState, voiceConnected: _voiceState }));
+		return;
+	}
+
+	// Mute + voice state report from browser client
+	if (url.pathname === '/mute-state') {
+		const mState = url.searchParams.get('muted');
+		const vState = url.searchParams.get('voice');
+		if (mState !== null) _muteState = mState === 'true';
+		if (vState !== null) _voiceState = vState === 'true';
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ muted: _muteState, voiceConnected: _voiceState }));
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- **type_text multi-line**: clipboard paste path for newlines/long text (inline-tools + browser-tools)
- **SSE resilience**: reconnect on tab wake, 30s heartbeat, stale client cleanup
- **Mute indicator**: menu bar shows mute emoji when voice active + muted, polls /sse-status
- **Scroll targeting**: pick widest scrollable element (fixes ChatGPT), optional `target` param
- **Discord images**: download forwarded attachments + pasted/embedded images via aiohttp

## Test plan
- [ ] Voice: type multi-line text via voice command, verify clipboard restored
- [ ] SSE: switch away from web client tab for 5+ min, switch back, verify ⌃V works
- [ ] Mute: connect voice, mute → menu bar shows 🔇, unmute → shows avatar
- [ ] Scroll: test on ChatGPT page (should scroll main content, not sidebar)
- [ ] Discord: forward a message with image attachment, paste image with Cmd+V

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #381