### PR TITLE
Narrow task-bridge screen filter (fixes silent task rejection)

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -62,11 +62,12 @@ export const workTool: ToolDefinition = {
 	async execute(args) {
 		const { task } = args as { task: string };
 
-		// Reject screen-viewing tasks — these should use inline tools directly
-		// Only reject "describe/view/look at screen" type tasks, not "fix screen" or "screen sharing" requests
-		const screenViewKeywords = /\b(describe.*(screen|page)|what.s on.*screen|look at.*screen|scroll.*(down|up|page)|capture.*screen|screenshot|narrat.*screen)\b/i;
-		if (screenViewKeywords.test(task)) {
-			return { status: 'rejected', message: 'Use inline tools directly: describe_screen, scroll. Do NOT use work for this.' };
+		// Redirect pure screen-viewing tasks to inline tools (faster, no round-trip)
+		// Narrow match: only "describe/look at my screen" — not scroll, screenshot,
+		// or screen-related tasks that the brain should handle.
+		const screenViewOnly = /\b(describe\s+(my\s+)?screen|what.s on\s+(my\s+)?screen|look at\s+(my\s+)?screen)\b/i;
+		if (screenViewOnly.test(task)) {
+			return { status: 'rejected', message: 'Use describe_screen inline tool directly for screen viewing.' };
 		}
 
 		// Check if the watcher (Claude Code brain) is running


### PR DESCRIPTION
## Summary
- Narrows the `screenViewKeywords` regex in task-bridge to only match pure screen-viewing tasks ("describe my screen", "what's on my screen", "look at my screen")
- Previously the regex matched `scroll`, `screenshot`, `narrate screen`, `capture screen` — all of which are valid tasks the brain should handle when inline tools fail
- When Gemini sent these through the `work` tool, the task-bridge silently rejected them and the voice agent kept saying "working on it" with no result

## Root cause
The regex `/\b(describe.*(screen|page)|what.s on.*screen|look at.*screen|scroll.*(down|up|page)|capture.*screen|screenshot|narrat.*screen)\b/i` was overly broad. `scroll.*(down|up|page)` matched any scroll task, even when the user retried via `work` because the inline scroll tool didn't work (e.g., on ChatGPT with custom scroll containers).

## Test plan
- [ ] Say "scroll down" via voice when inline scroll fails — should queue as brain task, not silently reject
- [ ] Say "describe my screen" — should still use inline describe_screen (rejected from work)
- [ ] Say "take a screenshot and send it" — should pass through to brain

🤖 Generated with [Claude Code](https://claude.com/claude-code)