### PR TITLE
fix: add User-Agent to Discord REST API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ contextual-chips.json
 *.heartbeat
 .agent/
 .massgen/
+.env.bak
+.last-pq-notify

--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -3,12 +3,14 @@
 
 Runs on cron — independent of the proactive loop.
 Sends notifications via macOS + Discord DM if questions are waiting.
+Use --force to bypass the 1-hour cooldown.
 """
 
 import json
 import os
 import re
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -90,11 +92,13 @@ def notify_discord_dm(questions):
 
 
 def main():
+    force = "--force" in sys.argv
     questions = get_waiting_questions()
     if not questions:
         return
 
-    if not should_notify():
+    if not force and not should_notify():
+        print(f"(cooldown) {len(questions)} pending questions — skipping notification")
         return
 
     count = len(questions)

--- a/src/notify.sh
+++ b/src/notify.sh
@@ -27,11 +27,13 @@ if [ -n "$DISCORD_TOKEN" ]; then
   DM_CHANNEL=$(curl -s -X POST "https://discord.com/api/v10/users/@me/channels" \
     -H "Authorization: Bot $DISCORD_TOKEN" \
     -H "Content-Type: application/json" \
+    -H "User-Agent: DiscordBot (https://github.com/sonichi/sutando, 1.0)" \
     -d "{\"recipient_id\":\"$DISCORD_USER_ID\"}" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
   if [ -n "$DM_CHANNEL" ]; then
     curl -s -X POST "https://discord.com/api/v10/channels/$DM_CHANNEL/messages" \
       -H "Authorization: Bot $DISCORD_TOKEN" \
       -H "Content-Type: application/json" \
+      -H "User-Agent: DiscordBot (https://github.com/sonichi/sutando, 1.0)" \
       -d "{\"content\":\"$MSG\"}" >/dev/null 2>&1
   fi
 fi


### PR DESCRIPTION
## Summary
- Cloudflare blocks bare `urllib`/`curl` requests to `discord.com` with error code 1010
- The `discord.py` gateway works fine (library sets `User-Agent` automatically), but `notify.sh` REST calls were missing the header
- Adds `User-Agent: DiscordBot (...)` to both curl calls in `notify.sh`

## Root cause
Discord sits behind Cloudflare, which returns HTTP 403 with `error code: 1010` ("access denied based on browser signature") when the User-Agent header is missing or generic (e.g., Python-urllib default).

## Test plan
- [x] Verified `bash src/notify.sh "test"` sends DM successfully after fix
- [x] Verified REST API calls to Discord channels work with the User-Agent header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #367