### PR TITLE
fix: scrollDown uses widest-element heuristic for recording

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -378,7 +378,9 @@ async function captureScreen(): Promise<string | null> {
 }
 
 function scrollDown(pixels: number = 600) {
-	execSync(`osascript -e 'tell application "Google Chrome" to tell active tab of front window to execute javascript "window.scrollBy(0, ${pixels})"'`, { timeout: 5_000 });
+	// Use widest-element heuristic (same as scrollTool) so embedded/nested scrollable containers work
+	const js = `(function(){var best=document.scrollingElement||document.documentElement,bw=0;document.querySelectorAll("*").forEach(function(el){var d=el.scrollHeight-el.clientHeight;if(d>50&&el.clientHeight>200){var w=el.getBoundingClientRect().width;if(w>bw){best=el;bw=w}}});best.scrollBy(0,${pixels})})()`;
+	execSync(`osascript -e 'tell application "Google Chrome" to tell active tab of front window to execute javascript "${js.replace(/"/g, '\\"')}"'`, { timeout: 5_000 });
 }
 
 let demoState: 'idle' | 'recording' | 'done' = 'idle';
@@ -437,7 +439,7 @@ export const scrollAndDescribeTool: ToolDefinition = {
 			let scrolledTotal = 0;
 			const scrollInterval = setInterval(() => {
 				if (scrolledTotal >= pageHeight) return; // stop at bottom
-				try { scrollDown(pxPerStep); } catch {}
+				try { scrollDown(pxPerStep); } catch (e) { console.error(`${ts()} [ScrollAndDescribe] scroll failed:`, e); }
 				scrolledTotal += pxPerStep;
 			}, SCROLL_INTERVAL_MS);
 


### PR DESCRIPTION
## Summary
- `scrollDown()` helper (used by `scroll_and_describe` during narration recording) used naive `window.scrollBy()` which only scrolls the main document
- Pages with nested scrollable containers (Vimeo embeds, chat UIs) wouldn't scroll during recording, even though the interactive `scroll` tool worked fine
- Now uses the same widest-element heuristic as `scrollTool`: finds the widest scrollable element and scrolls that
- Also adds `console.error` logging to the previously silent `catch {}` in the scroll interval

## Root cause
Two different scroll implementations: `scrollTool` (interactive) found the best container, `scrollDown()` (recording) just did `window.scrollBy`. Reported by Susan in #dev — scroll works via direct osascript but fails silently during narration recording.

## Test plan
- [x] TypeScript compiles clean
- [ ] Test scroll_and_describe on a page with nested scrollable content (Vimeo, chat UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #375