### PR TITLE
scroll: keyboard fallback for Zoom screen share rendering bug

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -65,6 +65,18 @@ export const scrollTool: ToolDefinition = {
 			writeFileSync(tmpScroll, `tell application "Google Chrome" to tell active tab of front window to execute javascript "${js.replace(/"/g, '\\"')}"`);
 			execSync(`osascript ${tmpScroll}`, { timeout: 5_000 });
 			try { unlinkSync(tmpScroll); } catch {}
+			// Also send keyboard scroll — Chrome may skip visual repaints during
+			// Zoom screen share even though JS scrollBy updates scrollY. Keyboard
+			// input forces a repaint through the OS input pipeline.
+			if (!target) {
+				const keyMap: Record<string, string> = { down: 'page down', up: 'page up', top: 'home', bottom: 'end' };
+				const key = keyMap[direction];
+				if (key) {
+					try {
+						execSync(`osascript -e 'tell application "Google Chrome" to activate' -e 'delay 0.1' -e 'tell application "System Events" to key code ${direction === 'down' ? '121' : direction === 'up' ? '116' : direction === 'top' ? '115 using command down' : '119 using command down'}'`, { timeout: 3_000 });
+					} catch { /* keyboard fallback is best-effort */ }
+				}
+			}
 			console.log(`${ts()} [Scroll] ${direction}`);
 			return { status: 'scrolled', direction };
 		} catch (err) {


### PR DESCRIPTION
## Summary
- Chrome skips visual repaints during Zoom screen share — `scrollBy` updates `scrollY` in memory but nothing moves on screen
- Adds keyboard Page Down/Up after JS scroll to force a repaint through the OS input pipeline
- Only for non-targeted scrolls (main content); targeted scrolls remain JS-only

## Root cause
Chrome optimizes rendering when another app captures the screen. JS-triggered scroll changes the position but Chrome defers the paint. Keyboard input goes through the OS, which forces Chrome to repaint.

Reported by Susan's bot during demo recording — scroll JS ran, browser reported scrolled position, but page didn't visually move.

## Test plan
- [ ] Scroll during Zoom screen share — should now visually move
- [ ] Scroll without Zoom — should still work (keyboard is additive, not disruptive)
- [ ] Targeted scroll ("scroll sidebar") — should use JS only, no keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)