### PR TITLE
phone: skip summary tasks for calls with no real dialogue

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -896,8 +896,11 @@ function cleanupCall(callSid: string): void {
 			.on('close', (code) => { if (code === 0) console.log(`${ts()} [Phone] call scan complete`); });
 	} catch { /* best effort */ }
 
-	// If top-level call (no parent) with a transcript, write a summary task for Claude to pick up
-	if (!session.parentCallSid && session.transcript.length > 0) {
+	// If top-level call (no parent) with a real conversation, write a summary task for Claude to pick up
+	// Skip calls with only IVR/system prompts and no actual dialogue (e.g. failed Zoom dial-ins)
+	const hasSutandoTurn = session.transcript.some(t => t.role === 'sutando');
+	const hasCallerTurn = session.transcript.some(t => t.role !== 'sutando');
+	if (!session.parentCallSid && hasSutandoTurn && hasCallerTurn && session.transcript.length >= 2) {
 		const summaryTaskId = `task-summary-${Date.now()}`;
 		const formatted = session.transcript.map(t => {
 			const label = t.role === 'sutando' ? 'Sutando' : 'Caller';


### PR DESCRIPTION
## Summary
- Failed Zoom dial-ins (IVR-only transcripts like "Please re-enter your meeting ID") were generating summary tasks with no useful content
- Now requires at least one Sutando turn AND one caller turn (minimum 2 transcript lines) before creating a summary task
- Prevents wasted processing on dead-end calls

## Root cause
Two back-to-back failed Zoom dial-in attempts from an external caller generated `task-summary-*` files with only a single IVR prompt line. The proactive loop processed them but had nothing meaningful to summarize.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Normal call with dialogue still generates summary
- [ ] Failed dial-in (IVR only) does NOT generate summary
- [ ] Meeting with full transcript generates summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)