### PR TITLE
voice: instruct agent to delegate complex operations to core

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -350,6 +350,7 @@ const mainAgent: MainAgent = {
 		'- NEVER pretend you called a tool. NEVER say "done" without actually calling work.',
 		'- NEVER say "I can\'t do that", "I\'m not able to", or "I don\'t think I can" — you CAN do almost anything by calling work. If you\'re unsure, call work and let the core agent handle it. The core agent has full system access. Your job is to relay requests, not gatekeep them.',
 		'- For SIMPLE actions (press enter, clear input, select all), use press_key or type_text — do NOT use work for keystrokes.',
+		'- For COMPLEX operations (git commands, code changes, file operations, installing packages), ALWAYS delegate to work — do NOT try to type commands into a terminal. The core agent executes these directly and reliably.',
 		'- If you KNOW the answer from your instructions or context, answer directly. Only delegate to work for questions you genuinely cannot answer.',
 		'- MISSING CONTEXT: When the user references something you don\'t have context for ("the draft", "what we discussed", "type that", "send what I asked for"), ALWAYS delegate to work. The core agent has the full conversation history and knows what was discussed. Never guess or ask the user to repeat — just call work.',
 		'- When in doubt, call work.',

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -334,7 +334,7 @@ const mainAgent: MainAgent = {
 		'- Anything you\'re not 100% certain about',
 		'',
 		'TOOLS:',
-		'- work: THE default tool. Call it for any non-trivial request. Also called "core", "submit a task", or "send to core" — these all mean call this tool.',
+		'- work: THE default tool. Call it for any non-trivial request. Also called "core", "submit a task", "send to core", "ask the core", "tell the core", "delegate to core", "have the core do it" — these all mean call this tool.',
 		'  Returns status "pending" — say "Working on it" and wait for the result.',
 		'- get_task_status: Check if a background task is still running.',
 		'- join_zoom: Join a Zoom meeting with computer audio (no screen sharing). Use when user says "join the zoom" or gives a Zoom ID.',


### PR DESCRIPTION
## Summary
- Voice agent was typing git commands literally into Terminal instead of delegating to core via `work` tool
- Added explicit instruction that complex operations (git, code, file ops) should always go through `work`
- Simple keystrokes (enter, select all) still use `type_text`/`press_key` as before

## Root cause
In a voice session, owner asked to switch git branch. Voice agent typed `git checkout Students PR branch` into Terminal multiple times instead of calling `work` to delegate to core. The existing instruction "for SIMPLE actions use type_text" was being over-applied.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Voice agent delegates "switch to branch X" to core instead of typing into Terminal
- [ ] Simple keystrokes (press enter, clear) still work via type_text

🤖 Generated with [Claude Code](https://claude.com/claude-code)