### PR TITLE
fix: scroll AppleScript quoting + directive greeting prefix

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -564,11 +564,13 @@ function buildAgent(callSession: CallSession): MainAgent {
 		instructions,
 		tools,
 		googleSearch: true,
+		// Greeting is injected as role:"user" by bodhi to trigger Gemini to speak.
+		// Use directive prefix so Gemini speaks the text verbatim instead of responding to it.
 		greeting: callSession.isMeeting
 			? ''  // No greeting for meetings — listen to IVR first
 			: !callSession.purpose
-			? 'Hi, this is Sutando. How can I help?'
-			: 'Hi, this is Sutando calling.',
+			? '[Speak this greeting to the caller now]: Hi, this is Sutando. How can I help?'
+			: '[Speak this greeting to the caller now]: Hi, this is Sutando calling.',
 	};
 }
 

--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -49,9 +49,10 @@ export const scrollTool: ToolDefinition = {
 				: '';
 			// Use Chrome's JavaScript scroll. If target specified, find matching scrollable element.
 			// Otherwise find the WIDEST scrollable container (main content over sidebars).
+			// Use single quotes in JS to avoid double-quote escaping issues inside AppleScript
 			const scrollFn = (cmd: string) => targetSelector
-				? `(function(){var sel="${targetSelector}";var e=null;document.querySelectorAll(sel).forEach(function(el){if(!e&&el.scrollHeight-el.clientHeight>50)e=el});if(!e){var best=null,bh=0;document.querySelectorAll("*").forEach(function(el){var d=el.scrollHeight-el.clientHeight;if(d>50&&el.clientHeight>100&&el.getBoundingClientRect().width<500){if(d>bh){best=el;bh=d}}});e=best}if(e){${cmd}}})()`
-				: `(function(){var best=document.scrollingElement||document.documentElement,bw=0;document.querySelectorAll("*").forEach(function(el){var d=el.scrollHeight-el.clientHeight;if(d>50&&el.clientHeight>200){var w=el.getBoundingClientRect().width;if(w>bw){best=el;bw=w}}});var e=best;${cmd}})()`;
+				? `(function(){var sel='${targetSelector}';var e=null;document.querySelectorAll(sel).forEach(function(el){if(!e&&el.scrollHeight-el.clientHeight>50)e=el});if(!e){var best=null,bh=0;document.querySelectorAll('*').forEach(function(el){var d=el.scrollHeight-el.clientHeight;if(d>50&&el.clientHeight>100&&el.getBoundingClientRect().width<500){if(d>bh){best=el;bh=d}}});e=best}if(e){${cmd}}})()`
+				: `(function(){var best=document.scrollingElement||document.documentElement,bw=0;document.querySelectorAll('*').forEach(function(el){var d=el.scrollHeight-el.clientHeight;if(d>50&&el.clientHeight>200){var w=el.getBoundingClientRect().width;if(w>bw){best=el;bw=w}}});var e=best;${cmd}})()`;
 			let js: string;
 			if (direction === 'top') {
 				js = scrollFn('e.scrollTop=0');

--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -392,8 +392,12 @@ async function captureScreen(): Promise<string | null> {
 
 function scrollDown(pixels: number = 600) {
 	// Use widest-element heuristic (same as scrollTool) so embedded/nested scrollable containers work
-	const js = `(function(){var best=document.scrollingElement||document.documentElement,bw=0;document.querySelectorAll("*").forEach(function(el){var d=el.scrollHeight-el.clientHeight;if(d>50&&el.clientHeight>200){var w=el.getBoundingClientRect().width;if(w>bw){best=el;bw=w}}});best.scrollBy(0,${pixels})})()`;
-	execSync(`osascript -e 'tell application "Google Chrome" to tell active tab of front window to execute javascript "${js.replace(/"/g, '\\"')}"'`, { timeout: 5_000 });
+	// Use single quotes in JS to avoid double-quote escaping issues inside AppleScript
+	const js = `(function(){var best=document.scrollingElement||document.documentElement,bw=0;document.querySelectorAll('*').forEach(function(el){var d=el.scrollHeight-el.clientHeight;if(d>50&&el.clientHeight>200){var w=el.getBoundingClientRect().width;if(w>bw){best=el;bw=w}}});best.scrollBy(0,${pixels})})()`;
+	const tmpScroll = `/tmp/sutando-scroll-rec-${Date.now()}.scpt`;
+	writeFileSync(tmpScroll, `tell application "Google Chrome" to tell active tab of front window to execute javascript "${js.replace(/"/g, '\\"')}"`);
+	execSync(`osascript ${tmpScroll}`, { timeout: 5_000 });
+	try { unlinkSync(tmpScroll); } catch {}
 	// Keyboard fallback: Chrome skips visual repaints during Zoom screen share.
 	// Page Down forces a repaint through the OS input pipeline.
 	try {

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -718,6 +718,27 @@ export const summonTool: ToolDefinition = {
 				console.log(`${ts()} [Summon] Could not mute Zoom audio`);
 			}
 
+			// Close the zoom.us tab that Chrome opened during join (prevents scroll
+			// targeting the wrong tab and reduces user confusion)
+			try {
+				execSync(`osascript -e '
+					tell application "Google Chrome"
+						repeat with w in windows
+							set tabCount to count of tabs of w
+							repeat with i from tabCount to 1 by -1
+								set t to tab i of w
+								if URL of t contains "zoom.us" then
+									close t
+								end if
+							end repeat
+						end repeat
+					end tell
+				'`, { timeout: 5_000 });
+				console.log(`${ts()} [Summon] Closed zoom.us tab(s) in Chrome`);
+			} catch {
+				console.log(`${ts()} [Summon] No zoom.us tabs to close`);
+			}
+
 			return {
 				status: 'summoned',
 				meetingId: cleanId,


### PR DESCRIPTION
## Summary
- **Scroll fix**: `querySelectorAll("*")` caused AppleScript error -2741 (broken quote escaping). Changed to single quotes `querySelectorAll('*')` which are safe inside AppleScript's double-quoted string
- **Greeting fix**: bodhi sends greeting as `role:"user"` to trigger Gemini to speak. Added `[Speak this greeting to the caller now]:` prefix so Gemini treats it as an instruction rather than responding to it

## Root cause
1. Scroll: The widest-element heuristic (PR #280) introduced `querySelectorAll("*")` — double quotes inside JS inside AppleScript's double-quoted string caused `\"` → `\\"` escaping that AppleScript couldn't parse
2. Greeting: Gemini occasionally interprets the greeting text ("Hi, this is Sutando") as the caller introducing themselves, responding "I think you might have misspoken — I'm Sutando" instead of speaking the greeting

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Scroll works during Zoom screen share (no more -2741 error)
- [ ] Phone greeting speaks correctly on first call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #374