### PR TITLE
fix: use CGEvent scroll wheel for recording repaint (no focus steal)

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -398,11 +398,12 @@ function scrollDown(pixels: number = 600) {
 	writeFileSync(tmpScroll, `tell application "Google Chrome" to tell active tab of front window to execute javascript "${js.replace(/"/g, '\\"')}"`);
 	execSync(`osascript ${tmpScroll}`, { timeout: 5_000 });
 	try { unlinkSync(tmpScroll); } catch {}
-	// Keyboard fallback: Chrome skips visual repaints during Zoom screen share.
-	// Page Down forces a repaint through the OS input pipeline.
+	// Repaint trigger: Chrome defers visual repaints during Zoom screen share.
+	// CGEvent scroll wheel events force a repaint through the OS input pipeline
+	// without stealing focus (unlike keyboard fallback which breaks narration).
 	try {
-		execSync(`osascript -e 'tell application "Google Chrome" to activate' -e 'delay 0.1' -e 'tell application "System Events" to key code 121'`, { timeout: 3_000 });
-	} catch { /* best-effort */ }
+		execSync(`swift src/scroll-wheel.swift 1`, { timeout: 3_000 });
+	} catch { /* best-effort — scroll already happened via JS */ }
 }
 
 let demoState: 'idle' | 'recording' | 'done' = 'idle';

--- a/src/scroll-wheel.swift
+++ b/src/scroll-wheel.swift
@@ -1,0 +1,20 @@
+// scroll-wheel.swift — Send OS-level scroll wheel events to Chrome
+// Usage: swift scroll-wheel.swift <pixels> [direction]
+// Positive pixels = scroll down, negative = scroll up
+// This forces Chrome to visually repaint during Zoom screen share
+// without stealing focus from other processes (narration recording).
+
+import CoreGraphics
+import Foundation
+
+let args = CommandLine.arguments
+let pixels = args.count > 1 ? Int(args[1]) ?? -600 : -600
+
+// CGEvent scroll uses line units by default; pixel units give finer control
+let event = CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 1, wheel1: Int32(pixels), wheel2: 0, wheel3: 0)
+if let event = event {
+    event.post(tap: .cghidEventTap)
+} else {
+    fputs("Failed to create scroll event\n", stderr)
+    exit(1)
+}


### PR DESCRIPTION
## Summary
- **Problem**: Chrome defers visual repaints during Zoom screen share. The keyboard fallback (Page Down) forces a repaint but steals focus, breaking narration audio tee and corrupting subtitle generation
- **Solution**: Use macOS CGEvent scroll wheel event (1px) via Swift helper. Goes through the OS input pipeline (forces Chrome repaint) without activating Chrome — narration stays uninterrupted
- **New file**: `src/scroll-wheel.swift` — lightweight CGEvent helper

## Context
This is the "third option" discussed in #dev by Susan and the owner. Neither JS scroll (no visual repaint during screen share) nor keyboard fallback (focus steal) works for recordings. CGEvent scroll wheel events go through the same OS input pipeline as trackpad gestures, forcing Chrome to repaint without changing focus.

## Test plan
- [x] `swift src/scroll-wheel.swift 300` sends scroll events (verified)
- [x] `tsc --noEmit` passes
- [ ] Recording with scrolling on Vimeo — visual repaint without narration corruption
- [ ] Non-recording scroll still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #373