### PR TITLE
Fix ffmpeg PATH for launchd (recording + subtitles)

### DIFF
--- a/skills/screen-record/scripts/record.py
+++ b/skills/screen-record/scripts/record.py
@@ -66,7 +66,7 @@ def start():
 
     # Use ffmpeg instead of screencapture -v (which requires TTY)
     proc = subprocess.Popen(
-        ["ffmpeg", "-f", "avfoundation",
+        ["/opt/homebrew/bin/ffmpeg", "-f", "avfoundation",
          "-i", f"{os.environ.get('RECORD_SCREEN', 'Capture screen 0')}:{os.environ.get('RECORD_AUDIO', 'default')}",
          "-r", "15", "-pix_fmt", "yuv420p", "-y", path],
         stdin=subprocess.DEVNULL,

--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -897,7 +897,7 @@ function burnLiveTranscriptSubtitles(videoPath: string): string | null {
 		const outPath = videoPath.replace('.mov', '-subtitled.mov');
 		execSync(
 			// Match source bitrate to avoid 6x size inflation (narrated ~400kbps, subtitle burn was 2300kbps with -q:v 65)
-			`ffmpeg -y -i "${videoPath}" -vf "subtitles=${LIVE_TRANSCRIPT_SRT_PATH}:force_style='FontSize=20,PrimaryColour=&H00FFFFFF,OutlineColour=&H00000000,Outline=2,MarginV=30'" -c:v h264_videotoolbox -b:v 500k -c:a aac "${outPath}"`,
+			`/opt/homebrew/bin/ffmpeg -y -i "${videoPath}" -vf "subtitles=${LIVE_TRANSCRIPT_SRT_PATH}:force_style='FontSize=20,PrimaryColour=&H00FFFFFF,OutlineColour=&H00000000,Outline=2,MarginV=30'" -c:v h264_videotoolbox -b:v 500k -c:a aac "${outPath}"`,
 			{ timeout: 120_000 }
 		);
 		if (existsSync(outPath)) {


### PR DESCRIPTION
## Summary
- Use full path `/opt/homebrew/bin/ffmpeg` instead of bare `ffmpeg`
- launchd services have minimal PATH that doesn't include Homebrew
- Fixes screen recording failing silently and demoState getting stuck at 'recording'
- Fixed in both record.py (avfoundation capture) and browser-tools.ts (subtitle burn)

## Test plan
- [ ] Start a screen recording via voice — should record successfully
- [ ] Stop recording — should produce valid .mov file
- [ ] scroll_and_describe with subtitles — should burn subtitles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #366