### PR TITLE
Wire narration-tee into voice agent (fixes missing narration + subtitles)

### DIFF
--- a/skills/screen-record/scripts/narration-tee.ts
+++ b/skills/screen-record/scripts/narration-tee.ts
@@ -39,7 +39,7 @@ export function teeAudio(pcmBuf: Buffer): void {
 					// -map 1:v -map 0:a: use video from the recording (input 1) and audio from
 					// the narration tee (input 0). Without -map, ffmpeg defaults to the video's
 					// own audio track which is silent mic ambient — not the Gemini narration.
-					execSync(`ffmpeg -y -f s16le -ar 24000 -ac 1 -i "${audioFile}" -i "${videoFile}" -map 1:v -map 0:a -c:v copy -c:a aac -shortest "${outPath}"`, { timeout: 60_000 });
+					execSync(`/opt/homebrew/bin/ffmpeg -y -f s16le -ar 24000 -ac 1 -i "${audioFile}" -i "${videoFile}" -map 1:v -map 0:a -c:v copy -c:a aac -shortest "${outPath}"`, { timeout: 60_000 });
 					console.log(`${ts()} [NarrationTee] muxed → ${outPath}`);
 				} catch (e) {
 					console.log(`${ts()} [NarrationTee] mux failed: ${e instanceof Error ? e.message : e}`);
@@ -65,7 +65,7 @@ export function cleanup(): void {
 				// -map 1:v -map 0:a: use video from the recording (input 1) and audio from
 				// the narration tee (input 0). Without -map, ffmpeg defaults to the video's
 				// own audio track which is silent mic ambient — not the Gemini narration.
-				execSync(`ffmpeg -y -f s16le -ar 24000 -ac 1 -i "${audioFile}" -i "${videoFile}" -map 1:v -map 0:a -c:v copy -c:a aac -shortest "${outPath}"`, { timeout: 60_000 });
+				execSync(`/opt/homebrew/bin/ffmpeg -y -f s16le -ar 24000 -ac 1 -i "${audioFile}" -i "${videoFile}" -map 1:v -map 0:a -c:v copy -c:a aac -shortest "${outPath}"`, { timeout: 60_000 });
 				console.log(`${ts()} [NarrationTee] muxed on cleanup → ${outPath}`);
 			} catch (e) {
 				console.log(`${ts()} [NarrationTee] mux on cleanup failed: ${e instanceof Error ? e.message : e}`);

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -575,6 +575,19 @@ async function main() {
 
 	sessionRef = session;
 
+	// Wire narration-tee: capture Gemini's outbound audio for screen recordings
+	try {
+		const { teeAudio } = await import('../skills/screen-record/scripts/narration-tee.js');
+		const origHandleAudioOutput = (session as any).handleAudioOutput.bind(session);
+		(session as any).handleAudioOutput = (data: string) => {
+			origHandleAudioOutput(data);
+			try { teeAudio(Buffer.from(data, 'base64')); } catch {}
+		};
+		console.log(`${ts()} [NarrationTee] wired into voice agent audio output`);
+	} catch (e) {
+		console.log(`${ts()} [NarrationTee] not available: ${e instanceof Error ? e.message : e}`);
+	}
+
 	// Watch for results from the Claude Code session and deliver to user
 	// Only delivers when a client is connected — otherwise keeps files queued
 	// Watch for context drops (keyboard shortcut)


### PR DESCRIPTION
## Summary
- `narration-tee.ts` was built but never imported by `voice-agent.ts`
- This caused scroll_and_describe recordings to have no narration audio and no subtitles
- Fix: monkey-patch `session.handleAudioOutput` to tee outbound audio to narration capture
- Also fixed bare `ffmpeg` → `/opt/homebrew/bin/ffmpeg` in narration-tee.ts

## Test plan
- [ ] Run scroll_and_describe with duration — should produce 3 files: raw, narrated, subtitled
- [ ] Check narrated.mov has Gemini's voice narration
- [ ] Check subtitled.mov has burned-in SRT subtitles

🤖 Generated with [Claude Code](https://claude.com/claude-code)