### PR TITLE
Fix subtitle burn: use voice transcript file

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -437,8 +437,12 @@ export const scrollAndDescribeTool: ToolDefinition = {
 			const captureData = await captureRes.json() as { status: string; path?: string };
 			const firstDesc = captureData.path ? await describeScreenshot(captureData.path) : '';
 			// Set subtitle baseline AFTER first description — so subtitles align with audio.
-			// Resolve the symlink NOW so a concurrent call (Zoom join) can't overwrite it.
-			try { liveTranscriptResolvedPath = readlinkSync(LIVE_TRANSCRIPT_SYMLINK); } catch { liveTranscriptResolvedPath = ''; }
+			// Use voice transcript directly — the symlink may point to a phone call transcript.
+			const voiceTranscript = '/tmp/sutando-live-transcript-voice.txt';
+			liveTranscriptResolvedPath = existsSync(voiceTranscript) ? voiceTranscript : '';
+			if (!liveTranscriptResolvedPath) {
+				try { liveTranscriptResolvedPath = readlinkSync(LIVE_TRANSCRIPT_SYMLINK); } catch { liveTranscriptResolvedPath = ''; }
+			}
 			liveTranscriptRecordingStart = Date.now();
 			liveTranscriptBaselineLines = countTranscriptLines();
 


### PR DESCRIPTION
## Summary
- Subtitle burn was reading from symlink → empty phone transcript instead of voice transcript
- Voice transcript lives at `/tmp/sutando-live-transcript-voice.txt`
- Now prefers voice transcript directly, falls back to symlink for phone recordings

## Test plan
- [ ] scroll_and_describe → should produce -narrated-subtitled.mov with burned subtitles
- [ ] Phone recording subtitles should still work via symlink fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #370