### PR TITLE
Fix subtitle transcript picker for phone vs voice

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -436,12 +436,18 @@ export const scrollAndDescribeTool: ToolDefinition = {
 			const captureRes = await fetch('http://localhost:7845/capture');
 			const captureData = await captureRes.json() as { status: string; path?: string };
 			const firstDesc = captureData.path ? await describeScreenshot(captureData.path) : '';
-			// Set subtitle baseline AFTER first description — so subtitles align with audio.
-			// Use voice transcript directly — the symlink may point to a phone call transcript.
+			// Set subtitle baseline — pick whichever transcript was updated more recently.
+			// Voice agent writes to -voice.txt; phone conversation-server writes to -CA{sid}.txt via symlink.
 			const voiceTranscript = '/tmp/sutando-live-transcript-voice.txt';
-			liveTranscriptResolvedPath = existsSync(voiceTranscript) ? voiceTranscript : '';
-			if (!liveTranscriptResolvedPath) {
-				try { liveTranscriptResolvedPath = readlinkSync(LIVE_TRANSCRIPT_SYMLINK); } catch { liveTranscriptResolvedPath = ''; }
+			let phoneTranscript = '';
+			try { phoneTranscript = readlinkSync(LIVE_TRANSCRIPT_SYMLINK); } catch {}
+			if (existsSync(voiceTranscript) && phoneTranscript && existsSync(phoneTranscript)) {
+				// Both exist — use whichever was modified more recently
+				const vMtime = statSync(voiceTranscript).mtimeMs;
+				const pMtime = statSync(phoneTranscript).mtimeMs;
+				liveTranscriptResolvedPath = pMtime > vMtime ? phoneTranscript : voiceTranscript;
+			} else {
+				liveTranscriptResolvedPath = (phoneTranscript && existsSync(phoneTranscript)) ? phoneTranscript : (existsSync(voiceTranscript) ? voiceTranscript : '');
 			}
 			liveTranscriptRecordingStart = Date.now();
 			liveTranscriptBaselineLines = countTranscriptLines();


### PR DESCRIPTION
## Summary
- PR #292 always preferred voice transcript, breaking phone-initiated recordings
- Now compares mtime of voice vs phone transcripts and picks the more recent one
- Phone recordings write to symlink → call-specific file; voice writes to -voice.txt

## Test plan
- [ ] Phone call recording with scroll_and_describe → subtitles should work
- [ ] Voice recording with scroll_and_describe → subtitles should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #371