### PR TITLE
Reset recording state between phone calls

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -1389,6 +1389,8 @@ wss.on('connection', (ws: WebSocket) => {
 					break;
 
 				case 'start': {
+					// Reset recording state from previous call (demoState may be stuck at 'done' or 'recording')
+					try { const { resetDemoState } = await import('../../../src/browser-tools.js'); resetDemoState(); } catch {}
 					callSid = msg.start.callSid;
 					const streamSid = msg.start.streamSid;
 					const cp = msg.start.customParameters ?? {};

--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -404,6 +404,14 @@ function scrollDown(pixels: number = 600) {
 
 let demoState: 'idle' | 'recording' | 'done' = 'idle';
 
+/** Reset recording state — call when a new phone call starts or previous recording is stuck */
+export function resetDemoState(): void {
+	if (demoState !== 'idle') {
+		console.log(`${ts()} [DemoState] Reset from '${demoState}' → 'idle'`);
+		demoState = 'idle';
+	}
+}
+
 export const scrollAndDescribeTool: ToolDefinition = {
 	name: 'scroll_and_describe',
 	description:


### PR DESCRIPTION
## Summary
- `demoState` stuck at 'done' after first phone recording, blocking subsequent recordings
- New `resetDemoState()` export from browser-tools.ts
- Called on each new call start in conversation-server.ts

## Test plan
- [ ] First phone call: scroll_and_describe → recording works
- [ ] Second phone call: scroll_and_describe → recording should also work (not blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #372