### PR TITLE
conversation-server: reliable .env loading

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -42,7 +42,10 @@
  *   - Transcript persistence
  */
 
-import 'dotenv/config';
+// Load .env from the project root (3 levels up from this script), not cwd —
+// override: true ensures .env values win over stale shell env vars
+import { config as _dotenvConfig } from 'dotenv';
+_dotenvConfig({ path: new URL('../../../.env', import.meta.url).pathname, override: true });
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { mkdirSync, writeFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync, symlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';


### PR DESCRIPTION
## Summary
- Load .env from project root (relative to script location), not cwd
- Use `override: true` so .env values always win over stale shell env
- Fixes the issue where TWILIO_WEBHOOK_URL picked up ngrok instead of Tailscale

## Test plan
- [ ] Start conversation-server from any directory → should use Tailscale URL from .env
- [ ] Phone call → should route through Tailscale, not ngrok

🤖 Generated with [Claude Code](https://claude.com/claude-code)