### PR TITLE
fix: discord send subcommand uses REST API instead of gateway

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -9,6 +9,7 @@ Usage: python3 src/discord-bridge.py
 import asyncio
 import json
 import os
+import sys
 import time
 from pathlib import Path
 
@@ -595,5 +596,26 @@ async def poll_proactive():
         await asyncio.sleep(3)
 
 
+def _send_via_rest(channel_id: str, message: str):
+    """Send a message via Discord REST API (no gateway connection). Exits after sending."""
+    import urllib.request
+    url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
+    data = json.dumps({"content": message}).encode()
+    req = urllib.request.Request(url, data=data, headers={
+        "Authorization": f"Bot {TOKEN}",
+        "Content-Type": "application/json",
+        "User-Agent": "DiscordBot (sutando, 1.0)",
+    })
+    try:
+        urllib.request.urlopen(req)
+        print(f"Sent to {channel_id}: {message[:80]}...")
+    except Exception as e:
+        print(f"Send failed: {e}")
+        sys.exit(1)
+
+
 if __name__ == "__main__":
-    client.run(TOKEN, log_handler=None)
+    if len(sys.argv) >= 4 and sys.argv[1] == "send":
+        _send_via_rest(sys.argv[2], " ".join(sys.argv[3:]))
+    else:
+        client.run(TOKEN, log_handler=None)


### PR DESCRIPTION
## Summary
Clean version of PR #273 — just the core discord-bridge.py fix, no URL/lockfile changes.

Credit to Susan (@liususan091219) for the original fix. Cherry-picked commit 6cf7a7b to avoid:
- Repo URL changes across READMEs/docs (would redirect users to wrong fork)
- package-lock.json dependency hash change (supply chain concern)
- Reverting tons of other merged work (PR branch was massively stale)

## The fix
Previously \`python3 discord-bridge.py send <channel> <msg>\` started a full Discord bot gateway connection that never exited. Multiple callers spawned dozens of zombie bot instances (37 hanging processes observed, 10x duplicate messages).

Now the \`send\` subcommand uses Discord REST API directly and exits immediately.

## Test plan
- [x] \`python3 src/discord-bridge.py send <channel> <msg>\` sends and exits
- [x] No zombie processes after send
- [x] Typescript compiles (no-op, python change)
- [ ] Existing bridge gateway still works for task routing

Closes the concern raised in PR #273 — the core fix is solid, but the PR had scope creep that made it unsafe to merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #364