### PR TITLE
phone: stricter hang_up prompt to prevent mid-call hangups

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -344,7 +344,7 @@ function buildAgent(callSession: CallSession): MainAgent {
 			callSession.purpose ? `Purpose of this call: "${callSession.purpose}"` : '',
 			'Be natural, warm, and conversational. Have a full conversation — do NOT rush to hang up.',
 			'Ask follow-up questions to get complete information.',
-			'When the conversation is done and both sides have said goodbye, call the hang_up tool to end the call.',
+			'ONLY call hang_up when the caller says goodbye/bye/farewell/"I\'m done"/"that\'s all". Closing a video, ending a task, or saying "close it"/"stop" is NOT a goodbye — those are about the current action, not the call.',
 			'Keep responses to 1-2 sentences.',
 			availableTools.length > 0 ? `You have these tools available: ${availableTools.join(', ')}. Use them when relevant to help the caller.` : '',
 			'You can ONLY fulfill the stated purpose of this call. If the person asks you to do something outside your available tools, politely decline.',
@@ -371,7 +371,7 @@ function buildAgent(callSession: CallSession): MainAgent {
 			callSession.purpose && !isInbound ? `Purpose of this call: "${callSession.purpose}"` : '',
 			'Be natural, warm, and conversational. Keep responses to 1-2 sentences.',
 			'NEVER say "I\'m back", "Welcome back", "Working on it", or "task is queued". If the conversation resumes after a pause, just continue naturally from where you left off.',
-			'When the other person wants to wrap up, say a warm goodbye, then call the hang_up tool to end the call.',
+			'ONLY call hang_up when the caller says goodbye/bye/farewell/"I\'m done"/"that\'s all". Closing a video, ending a task, or saying "close it"/"stop" is NOT a goodbye — those are about the current action, not the call.',
 		];
 
 		// Owner-only sections
@@ -402,7 +402,7 @@ function buildAgent(callSession: CallSession): MainAgent {
 				'',
 				'## Style',
 				'Be natural, warm, and conversational. Keep responses to 1-2 sentences.',
-				'When the conversation is done and both sides have said goodbye, call the hang_up tool.',
+				'ONLY call hang_up when the caller says goodbye/bye/farewell/"I\'m done"/"that\'s all". Closing a video, ending a task, or saying "close it"/"stop" is NOT a goodbye — those are about the current action, not the call.',
 			);
 		}
 


### PR DESCRIPTION
## Summary
Phone agent was hanging up too eagerly when callers said things like \"close it\" or \"stop\" — those are about the current action, not the call.

## Background
Observed in tonight's voice testing session: when owner said \"close other tabs\" or similar mid-call commands, the phone agent could interpret \"close\" as goodbye and call hang_up prematurely.

## Fix
New prompt explicitly distinguishes:
- **Goodbye signals** (trigger hang_up): \"goodbye\", \"bye\", \"farewell\", \"I'm done\", \"that's all\"
- **Action signals** (do NOT trigger hang_up): \"close it\", \"stop\", \"end this\" — about current task

Applied to all 3 hang_up prompt locations (verified caller, unverified caller, meeting purpose).

Extracted from PR #274 (the prompt change part). Credit to @liususan091219.

## Test plan
- [x] \`tsc --noEmit\` passes
- [ ] \"Close this tab\" mid-call → does NOT hang up
- [ ] \"Bye\" / \"Goodbye\" → hangs up

🤖 Generated with [Claude Code](https://claude.com/claude-code)