### PR TITLE
feat: add close_tab tool for closing the active Chrome tab

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -181,6 +181,25 @@ end tell`;
 	},
 };
 
+// --- Close current Chrome tab ---
+
+export const closeTabTool: ToolDefinition = {
+	name: 'close_tab',
+	description:
+		'Close the current Chrome tab (the active/frontmost tab). Use for: "close it", "close this tab", "close the tab", "close the page". Note: this is for closing browser tabs, NOT for ending the call (use hang_up for that) and NOT for closing video (use close_video).',
+	parameters: z.object({}),
+	execution: 'inline',
+	async execute() {
+		try {
+			execSync(`osascript -e 'tell application "Google Chrome" to tell front window to close active tab'`, { timeout: 5_000 });
+			console.log(`${ts()} [CloseTab] closed active tab`);
+			return { status: 'closed' };
+		} catch (err) {
+			return { error: `Failed to close tab: ${err instanceof Error ? err.message : err}` };
+		}
+	},
+};
+
 // --- Open URL ---
 
 export const openUrlTool: ToolDefinition = {

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -14,8 +14,8 @@ import type { ToolDefinition } from 'bodhi-realtime-agent';
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 
 // Re-export recording/screen/browser tools from browser-tools
-export { describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, scrollTool } from './browser-tools.js';
-import { describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, scrollTool } from './browser-tools.js';
+export { describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool } from './browser-tools.js';
+import { describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool } from './browser-tools.js';
 
 // --- Keyboard tool ---
 
@@ -1351,7 +1351,7 @@ export const deleteNoteTool: ToolDefinition = {
 // recording workflow (narration + REC indicator + subtitles). Registering screenRecordTool
 // caused Gemini to pick the bare recorder over scroll_and_describe, breaking narration.
 export const inlineTools = [
-	pressKeyTool, scrollTool, switchTabTool, openUrlTool,
+	pressKeyTool, scrollTool, switchTabTool, closeTabTool, openUrlTool,
 	switchAppTool, captureScreenTool, typeTextTool,
 	volumeTool, brightnessTool, clipboardTool,
 	cancelTaskTool, toggleTasksTool, getCurrentTimeTool, summonTool, dismissTool,
@@ -1367,7 +1367,7 @@ export const anyCallerTools = [
 /** Owner-only tools (require isOwner) */
 export const ownerOnlyTools = [
 	volumeTool, brightnessTool,
-	pressKeyTool, scrollTool, switchTabTool, openUrlTool,
+	pressKeyTool, scrollTool, switchTabTool, closeTabTool, openUrlTool,
 	switchAppTool, captureScreenTool, typeTextTool,
 	clipboardTool, cancelTaskTool, toggleTasksTool, summonTool, dismissTool,
 	joinZoomTool, joinGmeetTool, callContactTool, slideControlTool, fullscreenTool,


### PR DESCRIPTION
## Summary
Adds a dedicated \`close_tab\` inline tool for closing the active Chrome tab.

## Background
Voice testing tonight showed friction when owner said \"close it\" meaning \"close this Chrome tab\":
- No dedicated tool existed
- Agent had to guess workarounds (sometimes opening new tabs, sometimes typing keystrokes)
- STT misrecognized \"close it\" as \"cold it\", \"clouded\", \"Call them\", causing loops

## Fix
New \`close_tab\` tool:
- Closes the active tab in Chrome's front window via AppleScript
- Description explicitly distinguishes from \`hang_up\` (call) and \`close_video\` (QuickTime)
- Owner-only (in ownerOnlyTools)

## Test plan
- [x] \`tsc --noEmit\` passes
- [ ] Voice: \"close this tab\" → closes active Chrome tab
- [ ] Voice: \"close it\" with Chrome focused → closes active tab (not video, not call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)