### PR TITLE
scan-call-logs: detect consecutive duplicates only (fix false positive #299 missed)

### DIFF
--- a/src/scan-call-logs.py
+++ b/src/scan-call-logs.py
@@ -35,31 +35,33 @@ def detect_duplicate_responses(transcript: str) -> list[dict]:
             if len(text) >= 15:
                 sutando_turns.append((idx, text[:60]))
 
-    # Find adjacent duplicates (same text within MAX_GAP turns of previous occurrence)
-    MAX_GAP = 3  # turns; reconnect leaks are typically immediately consecutive
-    last_seen = {}  # key -> (turn_position_in_sutando_turns, count)
-    flagged = {}   # key -> count of adjacent occurrences
+    # Find consecutive duplicates: same response in IMMEDIATELY adjacent
+    # Sutando turns (gap = 1, no other Sutando response between them).
+    # This catches reconnect replay leaks while ignoring alternating
+    # patterns like summon→dismiss→summon→dismiss (intentional stress tests).
+    last_seen = {}  # key -> (turn_position, run_length)
+    flagged = {}   # key -> max run length seen
     for turn_pos, (_, key) in enumerate(sutando_turns):
         if key in last_seen:
-            prev_pos, prev_count = last_seen[key]
-            if turn_pos - prev_pos <= MAX_GAP:
-                # Adjacent — likely reconnect leak
-                flagged[key] = flagged.get(key, prev_count) + 1
-                last_seen[key] = (turn_pos, flagged[key])
+            prev_pos, prev_run = last_seen[key]
+            if turn_pos - prev_pos == 1:
+                run = prev_run + 1
+                last_seen[key] = (turn_pos, run)
+                if run > flagged.get(key, 0):
+                    flagged[key] = run
             else:
-                # Spread out — reset (intentional repeat, not a bug)
                 last_seen[key] = (turn_pos, 1)
         else:
             last_seen[key] = (turn_pos, 1)
 
     for key, count in flagged.items():
-        if count >= 2:  # at least one adjacent dup pair
+        if count >= 2:
             issues.append({
                 "pattern": "duplicate_response",
                 "severity": "medium",
                 "category": "team-fixable",
-                "summary": f"Adjacent repeated response ({count}x within {MAX_GAP} turns): \"{key[:50]}...\"",
-                "fix_hint": "Likely reconnect bug — duplicate audio on WebSocket reconnect. Spread-out repeats (intentional) are not flagged.",
+                "summary": f"Consecutive repeated response ({count}x in a row): \"{key[:50]}...\"",
+                "fix_hint": "Likely reconnect bug — duplicate audio on WebSocket reconnect. Alternating patterns (intentional repeats) are not flagged.",
             })
     return issues
 


### PR DESCRIPTION
## Summary
Tighter version of #299. Previous heuristic (within 3 turns) still flagged the owner's alternating summon→dismiss stress test as duplicates because each \"Summoning\" was 2 sutando-turns apart from the previous.

Now only flags **IMMEDIATELY consecutive** duplicates (gap = 1, no other Sutando response between them). This is the actual signature of a reconnect replay leak.

## Test
Re-ran scan on 15 recent calls:
- **Before**: stress test (10x summon, 9x dismiss) flagged as duplicate_response bug
- **After**: stress test correctly ignored, real reconnect leak in CA2071a1 ('I'm back' after reconnect) still detected

This is the third iteration of the duplicate detector — should be the right shape now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)