### PR TITLE
fix: screen-record handles missing audio device (headless Mac)

### DIFF
--- a/skills/screen-record/scripts/record.py
+++ b/skills/screen-record/scripts/record.py
@@ -51,6 +51,22 @@ def _hide_indicator():
     )
 
 
+def _has_audio_device():
+    """Check if avfoundation reports any audio device. Headless Macs (no mic) have none."""
+    try:
+        result = subprocess.run(
+            ["/opt/homebrew/bin/ffmpeg", "-f", "avfoundation", "-list_devices", "true", "-i", ""],
+            capture_output=True, text=True, timeout=5,
+        )
+        out = result.stderr
+        if "AVFoundation audio devices:" in out:
+            audio_section = out.split("AVFoundation audio devices:", 1)[1]
+            return "[0]" in audio_section.split("Error", 1)[0]
+        return False
+    except Exception:
+        return False
+
+
 def start():
     if os.path.exists(PID_FILE):
         with open(PID_FILE) as f:
@@ -64,10 +80,19 @@ def start():
 
     path = f"/tmp/sutando-recording-{int(time.time())}.mov"
 
+    # Detect audio device — headless Macs (no mic) have none, ffmpeg fails if we ask for audio.
+    screen = os.environ.get('RECORD_SCREEN', 'Capture screen 0')
+    audio_env = os.environ.get('RECORD_AUDIO', '')
+    if audio_env:
+        # Explicit override: RECORD_AUDIO=none for video-only, or specify a device
+        input_spec = screen if audio_env == 'none' else f"{screen}:{audio_env}"
+    else:
+        input_spec = f"{screen}:default" if _has_audio_device() else screen
+
     # Use ffmpeg instead of screencapture -v (which requires TTY)
     proc = subprocess.Popen(
         ["/opt/homebrew/bin/ffmpeg", "-f", "avfoundation",
-         "-i", f"{os.environ.get('RECORD_SCREEN', 'Capture screen 0')}:{os.environ.get('RECORD_AUDIO', 'default')}",
+         "-i", input_spec,
          "-r", "15", "-pix_fmt", "yuv420p", "-y", path],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary
Mac Mini (headless) has no audio input device. Previously \`record.py\` always asked for \`:default\` audio, causing ffmpeg to fail with \"Audio device not found\" / \"Input/output error\". The script reported \"recording started\" but no .mov file was actually created — owner discovered this during PR #307 testing when \"open the recording\" failed.

## Root cause
\`\`\`python
\"-i\", f\"{screen}:{os.environ.get('RECORD_AUDIO', 'default')}\"
\`\`\`
Always included \`:default\` audio. On Mac Mini, \`ffmpeg -f avfoundation -list_devices true\` shows zero audio devices — \`default\` doesn't exist. ffmpeg's stderr was redirected to DEVNULL so the failure was silent.

## Fix
Detect audio device via \`ffmpeg -list_devices true\` and fall back to video-only when none is found. Preserves existing \`RECORD_AUDIO\` env var behavior; adds \`RECORD_AUDIO=none\` for explicit video-only override.

## Test plan
- [x] Verified failing case: \`record.py start\` → \`stop\` → \`exists: false, size_mb: 0.0\`
- [x] Applied fix → \`exists: true, size_mb: 0.5\` (530KB .mov file)
- [x] ffmpeg can capture video-only on Mac Mini

## Context
This is the bug owner reported as \"open the recording failed\" during the PR #307 tool refactor test. Not related to the refactor itself — pre-existing screen-record skill bug exposed by Mac Mini's headless audio config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #365