### PR TITLE
fix: add isOwner guard + pendingTasks tracking to concat fast path

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -240,7 +240,7 @@ let nextBodhiPort = 9910; // Dynamic ports for per-call VoiceSessions
 // Returns null if no fast path matches — caller should fall back to delegateTask.
 function tryFastPath(callSession: CallSession, task: string): Promise<unknown> | null {
 	const concatMatch = /\b(prepend|concatenat|concat|image.*video|video.*image)\b/i.test(task);
-	if (concatMatch) {
+	if (concatMatch && callSession.isOwner) {
 		console.log(`${ts()} [Task] fast path: concat`);
 		try {
 			const image = execSync('ls -t /tmp/discord-inbox/*.jpg /tmp/discord-inbox/*.png 2>/dev/null | head -1', { timeout: 3000 }).toString().trim();
@@ -248,7 +248,11 @@ function tryFastPath(callSession: CallSession, task: string): Promise<unknown> |
 			if (image && video) {
 				const result = execSync(`bash ~/.claude/skills/video-concat/scripts/prepend-image.sh "${image}" "${video}" 3`, { timeout: 60000 }).toString().trim();
 				const parsed = JSON.parse(result);
-				callSession.resultQueue.push({ text: `[Task result] Video with image prepended: ${parsed.output} (${parsed.size_mb}MB). Report this to the caller.` });
+				callSession.pendingTasks++;
+				setTimeout(() => {
+					callSession.pendingTasks = Math.max(0, callSession.pendingTasks - 1);
+					callSession.resultQueue.push({ text: `[Task result] Video with image prepended: ${parsed.output} (${parsed.size_mb}MB). Report this to the caller.` });
+				}, 100);
 				return Promise.resolve({ status: 'processing', message: 'Creating the combined video now.' });
 			}
 		} catch (e) { console.log(`${ts()} [Task] fast path concat failed: ${e}`); }


### PR DESCRIPTION
## Summary
Two fixes to `tryFastPath()` in conversation-server.ts:

1. **Security: add `isOwner` check** — the concat fast path runs `execSync` shell commands (file listing, skill execution) without checking `callSession.isOwner`. A non-owner caller saying "concat my video" triggers file system access and shell execution directly. Non-owner callers now fall through to the regular task bridge which enforces `access_tier` downstream.

2. **Add `pendingTasks` tracking** — the fast path pushed results to `resultQueue` but never incremented/decremented `pendingTasks`. The agent didn't know a task was in progress, causing it to not report "working on it" to the caller.

## Changes
```diff
-if (concatMatch) {
+if (concatMatch && callSession.isOwner) {
```
```diff
+callSession.pendingTasks++;
+setTimeout(() => {
+    callSession.pendingTasks = Math.max(0, callSession.pendingTasks - 1);
+    callSession.resultQueue.push({ text: ... });
+}, 100);
```

## Context
- The `isOwner` check was flagged in sonichi's review of PR #274 (comment 4230768578)
- PR #302/#303 extracted `tryFastPath` but didn't add the guard
- `pendingTasks` tracking was present in the original PR #274 implementation but missing from #302/#303

## Test plan
- [x] Non-owner call with "concat" keyword → falls through to delegateTask (no shell execution)
- [x] Owner call with "concat" keyword → fast path executes, pendingTasks tracked
- [ ] Verify agent says "working on it" during concat (pendingTasks > 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)