### PR TITLE
fix: only owner calls update the global subtitle symlink

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -640,8 +640,12 @@ async function createCallSession(params: {
 	const liveTranscriptPath = `/tmp/sutando-live-transcript-${params.callSid}.txt`;
 	try {
 		writeFileSync(liveTranscriptPath, `--- Live Transcript: ${new Date().toISOString()} ---\nCall: ${params.callSid}\n\n`);
-		try { unlinkSync('/tmp/sutando-live-transcript.txt'); } catch {}
-		symlinkSync(liveTranscriptPath, '/tmp/sutando-live-transcript.txt');
+		// Only owner calls update the global symlink — non-owner calls (Zoom IVR)
+		// would overwrite it and break subtitle generation for the owner's recording.
+		if (callSession.isOwner) {
+			try { unlinkSync('/tmp/sutando-live-transcript.txt'); } catch {}
+			symlinkSync(liveTranscriptPath, '/tmp/sutando-live-transcript.txt');
+		}
 	} catch {}
 
 	const agent = buildAgent(callSession);


### PR DESCRIPTION
## Summary
Non-owner calls (e.g. Zoom IVR) overwrite the global transcript symlink, breaking subtitle generation for the owner's active recording. Now guarded with callSession.isOwner.

From PR #274 commits e30c2c4 + 36d6a00 (Apr 10).

## Test plan
- [ ] Owner call: symlink updated normally
- [ ] Non-owner call during owner recording: subtitles not broken

Generated with [Claude Code](https://claude.com/claude-code)

Fixes #368