### PR TITLE
feat: generalize open_video → open_file with reliability improvements

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -408,7 +408,7 @@ function buildAgent(callSession: CallSession): MainAgent {
 				'TOOL EXCLUSIVITY: If an inline tool can handle the request, use ONLY the inline tool. NEVER also call work. They are mutually exclusive — calling both causes duplicate responses. Only use work when no inline tool fits.',
 				'SUMMON: Before calling summon, ALWAYS say "Summoning your screen now" FIRST — the user is on the phone and cannot see what is happening. The tool takes several seconds.',
 				'PLAYBACK RULES (CRITICAL):',
-				'0. Video tools: open_video (open), play_video (play from start), pause_video (pause), resume_video (resume/continue), replay_video (start over), close_video (close). NEVER use work for video.',
+				'0. Video tools: open_file (open), play_video (play from start), pause_video (pause), resume_video (resume/continue), replay_video (start over), close_video (close). NEVER use work for video.',
 				'1. After calling play_video or resume_video, say NOTHING. Audio streams to the phone.',
 				'2. "pause", "stop", "hold" → call pause_video, then say "Paused."',
 				'3. "play" → play_video. "resume"/"continue" → resume_video. "start over"/"replay" → replay_video.',
@@ -674,7 +674,7 @@ async function createCallSession(params: {
 				callSession.toolCalls.push({ name: toolName, durationMs: e.durationMs, timestamp: new Date().toISOString() });
 				callSession.events.push({ event: `tool_result:${toolName}:${e.durationMs}ms`, timestamp: new Date().toISOString() });
 				// Log REC indicator status for recording tools
-				if (toolName === 'scroll_and_describe' || toolName === 'screen_record' || toolName === 'open_video') {
+				if (toolName === 'scroll_and_describe' || toolName === 'screen_record' || toolName === 'open_file') {
 					const hasIndicator = existsSync('/tmp/sutando-rec-indicator.pid');
 					callSession.events.push({ event: `rec_indicator:${hasIndicator ? 'on' : 'off'}`, timestamp: new Date().toISOString() });
 				}

--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -452,7 +452,7 @@ export const clickTool: ToolDefinition = {
 // Re-export recording/video tools from recording-tools
 export {
 	scrollAndDescribeTool,
-	openVideoTool,
+	openFileTool,
 	playVideoTool,
 	resumeVideoTool,
 	replayVideoTool,

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -14,8 +14,8 @@ import type { ToolDefinition } from 'bodhi-realtime-agent';
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 
 // Re-export recording/screen/browser tools from browser-tools
-export { describeScreenTool, clickTool, scrollAndDescribeTool, openVideoTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool } from './browser-tools.js';
-import { describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, openVideoTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool } from './browser-tools.js';
+export { describeScreenTool, clickTool, scrollAndDescribeTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool } from './browser-tools.js';
+import { describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool } from './browser-tools.js';
 
 // Re-export meeting tools from meeting-tools
 export { summonTool, dismissTool, joinZoomTool, joinGmeetTool, lookupMeetingIdTool, callContactTool } from './meeting-tools.js';
@@ -552,7 +552,7 @@ export const inlineTools = [
 	volumeTool, brightnessTool, clipboardTool,
 	cancelTaskTool, toggleTasksTool, getCurrentTimeTool, summonTool, dismissTool,
 	joinZoomTool, joinGmeetTool, lookupMeetingIdTool, callContactTool,
-	describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, openVideoTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, slideControlTool, fullscreenTool,
+	describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, slideControlTool, fullscreenTool,
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool, ];
 
 /** Tools available to any caller (including unverified) */
@@ -568,7 +568,7 @@ export const ownerOnlyTools = [
 	clipboardTool, cancelTaskTool, toggleTasksTool, summonTool, dismissTool,
 	joinZoomTool, joinGmeetTool, callContactTool, slideControlTool, fullscreenTool,
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
-	describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, openVideoTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool,
+	describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool,
 ];
 
 /** Configurable tools — default to owner-only, can be opened to verified callers */

--- a/src/recording-tools.ts
+++ b/src/recording-tools.ts
@@ -409,25 +409,44 @@ export const scrollAndDescribeTool: ToolDefinition = {
 // single-purpose tools. Gemini selects more reliably with narrow descriptions than
 // with one tool that has an "action" enum. The old tool caused persistent confusion
 // between "open" and "play" (42% of calls in diagnostics had wrong action selection).
-export const openVideoTool: ToolDefinition = {
-	name: 'open_video',
+export const openFileTool: ToolDefinition = {
+	name: 'open_file',
 	description:
-		'Open the latest screen recording in QuickTime. Finds the best available version (subtitled > narrated > raw). ' +
-		'Use when user says "open the video", "open the recording", "can you open it".',
+		'Open a file with the default macOS app. Pass a path, or omit to open the latest screen recording. ' +
+		'Use when user says "open the video", "open the file", "open that", "can you open it". ' +
+		'Do NOT call play_video after this — wait for user to explicitly say "play". ' +
+		'Known files: "diagnostic tracker" or "diagnostics" = /tmp/phone-diagnostics-tracker.html, ' +
+		'"voice diagnostics" = /tmp/voice-diagnostics-tracker.html.',
 	parameters: z.object({
-		path: z.string().optional().describe('File path. Omit for latest recording.'),
+		path: z.string().optional().describe('File path to open. Omit to open the latest screen recording. Use known file aliases for diagnostic tracker etc.'),
 	}),
 	execution: 'inline',
 	async execute(args) {
 		const { path: filePath } = args as { path?: string };
-		console.log(`${ts()} [OpenVideo] called`);
+		console.log(`${ts()} [OpenFile] called`);
 		demoStateRef.value = 'idle';
 		try {
 			let recPath = filePath ? filePath.replace(/^~/, process.env.HOME || '') : null;
-			if (!recPath) recPath = findRecording();
-			if (!recPath) { await new Promise(r => setTimeout(r, 3000)); recPath = findRecording(); }
-			if (!recPath || !isReadableFile(recPath)) return { error: 'No recording found. Try again in a few seconds.' };
-			writeFileSync('/tmp/sutando-playback-path', recPath);
+			// If Gemini hallucinated a path that doesn't exist, fall back to findRecording
+			if (recPath && !existsSync(recPath)) {
+				console.log(`${ts()} [OpenFile] path "${recPath}" does not exist, falling back to findRecording`);
+				recPath = null;
+			}
+			// Fallback: find latest recording if no path given or path invalid
+			// Poll up to 18s — subtitle burn happens async after recording stops
+			if (!recPath) {
+				for (let i = 0; i < 10; i++) {
+					recPath = findRecording();
+					if (recPath && recPath.includes('-subtitled')) break;
+					if (recPath && i < 6) { await new Promise(r => setTimeout(r, 3000)); continue; }
+					if (!recPath) { await new Promise(r => setTimeout(r, 2000)); }
+					else break;
+				}
+			}
+			if (!recPath || !isReadableFile(recPath)) return { error: 'No file found. Try again in a few seconds.' };
+			if (recPath.includes('sutando-recording')) {
+				writeFileSync('/tmp/sutando-playback-path', recPath);
+			}
 			execSync(`open "${recPath}"`, { timeout: 5_000 });
 			try { execSync(`osascript -e 'tell application "QuickTime Player" to activate'`, { timeout: 3_000 }); } catch {}
 			const size = statSync(recPath).size;
@@ -436,10 +455,10 @@ export const openVideoTool: ToolDefinition = {
 				const dur = execSync(`/opt/homebrew/bin/ffprobe -v error -show_entries format=duration -of csv=p=0 "${recPath}"`, { timeout: 5_000 }).toString().trim();
 				duration_seconds = Math.round(parseFloat(dur));
 			} catch {}
-			console.log(`${ts()} [OpenVideo] opened ${recPath} (${(size / 1024 / 1024).toFixed(1)}MB, ${duration_seconds ?? '?'}s)`);
+			console.log(`${ts()} [OpenFile] opened ${recPath} (${(size / 1024 / 1024).toFixed(1)}MB, ${duration_seconds ?? '?'}s)`);
 			return { status: 'opened', path: recPath, size_mb: +(size / 1024 / 1024).toFixed(1), duration_seconds, instruction: 'File opened. When user says play, call play_video.' };
 		} catch (err) {
-			return { error: `open_video failed: ${err instanceof Error ? err.message : err}` };
+			return { error: `open_file failed: ${err instanceof Error ? err.message : err}` };
 		}
 	},
 };
@@ -531,12 +550,12 @@ export const pauseVideoTool: ToolDefinition = {
 export const closeVideoTool: ToolDefinition = {
 	name: 'close_video',
 	description:
-		'Close the video player. Use when user says "close the video", "close it".',
+		'"close the video" (Cmd+W, app=QuickTime Player). Instant — do NOT use work for simple keystrokes. NEVER use Cmd+Q to close QuickTime — use Cmd+W to close the window only.',
 	parameters: z.object({}),
 	execution: 'inline',
 	async execute() {
 		console.log(`${ts()} [CloseVideo] called`);
-		try { execSync(`osascript -e 'tell application "QuickTime Player" to quit'`, { timeout: 5_000 }); } catch {}
+		try { execSync(`osascript -e 'tell application "QuickTime Player"' -e 'activate' -e 'end tell' -e 'delay 0.3' -e 'tell application "System Events" to keystroke "w" using command down'`, { timeout: 5_000 }); } catch {}
 		try { unlinkSync('/tmp/sutando-playback-pause'); } catch {}
 		try { unlinkSync('/tmp/sutando-playback-path'); } catch {}
 		return { status: 'closed' };


### PR DESCRIPTION
## Summary
Rename open_video to open_file (opens any file, not just recordings) plus 5 improvements:
1. Anti-autoplay guardrail
2. findRecording fallback for hallucinated paths
3. Subtitle polling (18s instead of 3s)
4. Diagnostic tracker aliases
5. Cmd+W close instead of Cmd+Q

From PR #274 commits f88ec6e + d372da6 + 2f4fefb + 9684d69 + 0cf79b7 (Apr 10-11).

## Test plan
- [ ] open the diagnostic tracker opens HTML file
- [ ] open the video after recording waits for subtitled version
- [ ] close the video uses Cmd+W

Generated with [Claude Code](https://claude.com/claude-code)