### PR TITLE
feat: add local skills path to CLAUDE.md + delegateTask hint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,8 @@ npx tsx -e "import 'dotenv/config'; import { summonTool } from './src/inline-too
 - Look up contacts and calendar for numbers/PINs before calling
 - The voice agent delegates "call X" and "join my meeting" requests to core via `work`
 
+**Local skills** — check `~/.claude/skills/` for user-installed skills (video processing, etc.). Always prefer a local skill over raw commands when one exists for the task.
+
 **App launcher** — open any macOS app:
 ```bash
 open -a "Safari"                    # open by name

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -281,7 +281,7 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 	const fullTranscript = callSession.transcript.slice(-20)
 		.map(t => `${t.role === 'sutando' ? 'Sutando' : 'Caller'}: ${t.text}`)
 		.join('\n');
-	const content = `id: ${taskId}\ntimestamp: ${new Date().toISOString()}\ncallSid: ${callSession.callSid}\ncaller: ${callSession.callerNumber || 'unknown'}\naccess_tier: ${callSession.isOwner ? 'owner' : 'other'}\ntask: ${taskDescription}\ntranscript:\n${fullTranscript}\n`;
+	const content = `id: ${taskId}\ntimestamp: ${new Date().toISOString()}\ncallSid: ${callSession.callSid}\ncaller: ${callSession.callerNumber || 'unknown'}\naccess_tier: ${callSession.isOwner ? 'owner' : 'other'}\ntask: ${taskDescription}\nhint: Check ~/.claude/skills/ for a matching skill before using raw commands.\ntranscript:\n${fullTranscript}\n`;
 	writeFileSync(taskPath, content);
 
 	// Poll for result in background, inject when ready — don't block Gemini


### PR DESCRIPTION
## Summary
1. CLAUDE.md: document ~/.claude/skills/ for user-installed skills
2. delegateTask: add hint to task files to check skills before raw commands

From PR #274 commits f3bbfb3 + d64f05d (Apr 11).

## Test plan
- [ ] Phone task file contains hint about skills
- [ ] Core agent uses video-concat skill instead of raw ffmpeg

Generated with [Claude Code](https://claude.com/claude-code)