### PR TITLE
fix: point bodhi-realtime-agent dep at sonichi (liususan091219 repo deleted)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@google/genai": "^1.49.0",
     "@types/ws": "^8.18.1",
     "ai": "^6.0.149",
-    "bodhi-realtime-agent": "github:liususan091219/bodhi_realtime_agent",
+    "bodhi-realtime-agent": "github:sonichi/bodhi_realtime_agent",
     "dotenv": "^17.4.1",
     "playwright": "^1.58.2",
     "ws": "^8.20.0",


### PR DESCRIPTION
## Summary

Fresh \`npm install\` from main is currently broken because \`package.json\` depends on \`github:liususan091219/bodhi_realtime_agent\` and Susan took down that repo (banned). One-line fix to point at the sonichi mirror.

I verified \`dist/\` IS committed in \`sonichi/bodhi_realtime_agent\` (same files as Susan's: index.cjs, index.d.cts, etc.), so the github: install will work out of the box — no need for the postinstall build fallback to fire.

## Test plan

- [ ] \`rm -rf node_modules package-lock.json && npm install\` → succeeds, bodhi-realtime-agent shows up under node_modules/
- [ ] \`npm run typecheck\` (or whatever) still passes
- [ ] Voice agent boots and connects to Gemini Live without errors

This unblocks any new contributor running the Quick start in README.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #361