### PR TITLE
discord-bridge: forward reply-context for all referenced authors

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -328,10 +328,12 @@ async def _handle_discord_message(message, force=False):
         except Exception as e:
             print(f"  Download failed: {e}")
 
-    # Reply context — when the user replies to a bot message, fetch the
+    # Reply context — when the user replies to any message, fetch the
     # referenced message and prepend a snippet so the core agent knows
-    # which earlier answer the user is responding to. Without this the
-    # bot sees only the new reply text in isolation.
+    # which earlier message the user is pointing at. Includes replies to
+    # other users/bots/the sender's own earlier messages, not just this
+    # bot's — owners often reply to a MacBook bot message or their own
+    # earlier line to clarify which task "this" / "that" refers to.
     reply_context = ""
     if message.reference and message.reference.message_id:
         try:
@@ -339,19 +341,16 @@ async def _handle_discord_message(message, force=False):
             if ref_msg is None:
                 ref_msg = await message.channel.fetch_message(message.reference.message_id)
             if ref_msg is not None:
-                # Only include context when replying to a message FROM this
-                # bot — avoids prepending unrelated conversation fragments.
-                if ref_msg.author.id == client.user.id:
-                    ref_author = str(ref_msg.author)
-                    ref_content = (ref_msg.content or "").strip()
-                    # Strip bot-id mentions so the context doesn't show raw id soup
-                    ref_content = ref_content.replace(f"<@{client.user.id}>", "")
-                    snippet = ref_content[:400].replace("\n", " ").strip()
-                    if snippet:
-                        reply_context = (
-                            f"\n\n[Replying to {ref_author} "
-                            f"({ref_msg.created_at.strftime('%Y-%m-%d %H:%M')}): {snippet}]"
-                        )
+                ref_author = str(ref_msg.author)
+                ref_content = (ref_msg.content or "").strip()
+                # Strip bot-id mentions so the context doesn't show raw id soup
+                ref_content = ref_content.replace(f"<@{client.user.id}>", "")
+                snippet = ref_content[:400].replace("\n", " ").strip()
+                if snippet:
+                    reply_context = (
+                        f"\n\n[Replying to {ref_author} "
+                        f"({ref_msg.created_at.strftime('%Y-%m-%d %H:%M')}): {snippet}]"
+                    )
         except Exception as e:
             print(f"  [reply-context] fetch failed: {e}", flush=True)
 


### PR DESCRIPTION
## Summary
- Drop the `author.id == client.user.id` filter on reply-context in `discord-bridge.py`
- Include the `[Replying to ...]` snippet for any referenced message, not just replies to this bot's own messages

## Why
Owner replied to one of their own earlier messages with "what do you think about this?" — I received it context-less because the bridge silently stripped the reply-context block whenever the referenced author wasn't this bot. Replies to the MacBook bot, Susan, or an owner's own earlier line all hit the same trap.

Fix is one conditional dropped; snippets still cap at 400 chars so there's no blast-radius risk.

## Test plan
- [ ] Reply to an owner's own earlier message → verify task file includes `[Replying to ...]` block
- [ ] Reply to the MacBook bot → same
- [ ] Reply to this bot → still works (regression check)
- [ ] Non-reply message → no `[Replying to ...]` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)