### PR TITLE
fix: drop deleted NativeMic.swift from swiftc commands

### DIFF
--- a/src/migrate.sh
+++ b/src/migrate.sh
@@ -243,7 +243,7 @@ fi
 # Compile Sutando app
 echo "Compiling Sutando menu bar app..."
 cd "$REPO/src/Sutando"
-swiftc -O -o Sutando main.swift NativeMic.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation 2>/dev/null && echo "  ✓ Sutando compiled" || echo "  ⚠ Compile failed — run manually"
+swiftc -O -o Sutando main.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation 2>/dev/null && echo "  ✓ Sutando compiled" || echo "  ⚠ Compile failed — run manually"
 cd "$REPO"
 
 # Python deps

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -155,7 +155,7 @@ if ! pgrep -f "Sutando" > /dev/null 2>&1; then
     echo "  ✓ Sutando (⌃C/⌃V/⌃M)"
   elif [ -f "$REPO/src/Sutando/main.swift" ]; then
     echo "  Compiling Sutando..."
-    if (cd "$REPO/src/Sutando" && swiftc -O -o Sutando main.swift NativeMic.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation 2>/dev/null); then
+    if (cd "$REPO/src/Sutando" && swiftc -O -o Sutando main.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation 2>/dev/null); then
       "$REPO/src/Sutando/Sutando" > /dev/null 2>&1 &
       echo "  ✓ Sutando compiled and started"
     else


### PR DESCRIPTION
The file no longer exists. Build silently failed through `2>/dev/null` mask, leaving `Sutando.app` binary stale (no hotkey updates took effect).

### Changes
- `src/startup.sh:158` — removed `NativeMic.swift` from swiftc invocation
- `src/migrate.sh:246` — same

### Verification
Local test compile succeeds with only pre-existing unused-var warnings:
```
cd src/Sutando && swiftc -O -o Sutando.test main.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation
```

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>