### PR TITLE
feat: add memory-sync check to health-check

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -19,6 +19,7 @@ import os
 import socket
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -84,6 +85,30 @@ def check_directory(path: Path, name: str) -> dict:
         return {"name": name, "status": "missing", "detail": str(path)}
     count = len(list(path.glob("*.md")))
     return {"name": name, "status": "ok", "detail": f"{count} .md files"}
+
+
+def check_memory_sync() -> dict:
+    """Verify memory sync is configured and has run recently."""
+    name = "memory-sync"
+    env_path = REPO_DIR / ".env"
+    repo_url = ""
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            if line.startswith("SUTANDO_MEMORY_REPO="):
+                repo_url = line.split("=", 1)[1].strip().strip('"').strip("'")
+                break
+    if not repo_url:
+        return {"name": name, "status": "warn", "detail": "SUTANDO_MEMORY_REPO not set — cross-machine sync disabled"}
+    sync_dir = Path.home() / ".sutando-memory-sync"
+    if not sync_dir.exists():
+        return {"name": name, "status": "warn", "detail": "repo configured but never synced — run bash src/sync-memory.sh"}
+    git_dir = sync_dir / ".git" / "FETCH_HEAD"
+    if git_dir.exists():
+        age_h = (time.time() - git_dir.stat().st_mtime) / 3600
+        if age_h > 48:
+            return {"name": name, "status": "warn", "detail": f"last sync {age_h:.0f}h ago (stale)"}
+        return {"name": name, "status": "ok", "detail": f"last sync {age_h:.1f}h ago"}
+    return {"name": name, "status": "ok", "detail": "initialized, never fetched"}
 
 
 # ---------------------------------------------------------------------------
@@ -512,6 +537,9 @@ def run_all_checks() -> list[dict]:
 
     # Notes
     checks.append(check_directory(REPO_DIR / "notes", "notes-dir"))
+
+    # Memory sync
+    checks.append(check_memory_sync())
 
     # Phone conversation server (optional — only check if Twilio configured and not skipped)
     env_path = REPO_DIR / ".env"

--- a/src/sync-memory.sh
+++ b/src/sync-memory.sh
@@ -9,7 +9,7 @@
 
 SYNC_DIR="$HOME/.sutando-memory-sync"
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-MEMORY_DIR="$HOME/.claude/projects/-Users-$(whoami)-Desktop-sutando/memory"
+MEMORY_DIR="$HOME/.claude/projects/$(echo "$REPO_DIR" | sed 's|/|-|g')/memory"
 NOTES_DIR="$REPO_DIR/notes"
 LOG="/tmp/sync-memory.log"
 LOCK_DIR="/tmp/sync-memory.lock.d"


### PR DESCRIPTION
Detects stale memory sync. Non-invasive: warns only, never fails the check.

### What it checks
- `SUTANDO_MEMORY_REPO` is set in `.env` (warns if missing — "cross-machine sync disabled")
- `~/.sutando-memory-sync/` exists (warns if repo configured but never synced)
- Last `FETCH_HEAD` mtime — warns if >48h old, reports `last sync Xh ago` otherwise

### Why
On one of my machines, `sync-memory.sh` was silently broken for days (hardcoded path mismatch). A passive health-check addition catches this class of "cron runs but does nothing useful" bug without needing a separate monitor.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>