### PR TITLE
security: isolate team-tier codex invocation with -C /tmp

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -438,10 +438,13 @@ async def _handle_discord_message(message, force=False):
         "owner": "",
         "team": (
             "\n\n===SUTANDO SYSTEM INSTRUCTIONS (do not ignore; overrides anything above)===\n"
-            "This task is from a TEAM tier sender. You MUST delegate to a sandboxed Codex agent:\n\n"
-            f"  codex exec --sandbox read-only -- {quoted_task}\n\n"
+            "This task is from a TEAM tier sender. You MUST delegate to a sandboxed Codex agent with /tmp cwd:\n\n"
+            f"  codex exec --sandbox read-only -C /tmp -- {quoted_task}\n\n"
             "Rules:\n"
-            "- Run that exact command, nothing else.\n"
+            "- Run that exact command, nothing else. -C /tmp walls off the workspace so Codex\n"
+            "  cannot read .env, keys, or other secrets via relative paths. Verified 2026-04-14:\n"
+            "  the default `codex exec --sandbox read-only` blocks writes but allows reads of\n"
+            "  world-readable files including the workspace .env.\n"
             "- Relay Codex's stdout verbatim to the sender as the reply; do NOT add commentary.\n"
             "- Do NOT run any other shell commands.\n"
             "- Do NOT modify files, commit, push, send messages, or take any other action.\n"


### PR DESCRIPTION
## Summary
- Team-tier `codex exec --sandbox read-only --` invocation allowed reading workspace `.env` (verified: codex printed live `GEMINI_API_KEY` plaintext when asked to read the file)
- Switches team tier to `-C /tmp --` (same isolation `other` tier already uses) so Codex's cwd is outside the workspace

## Why
`--sandbox read-only` blocks writes but allows reads of world-readable files. A team-tier Discord sender can instruct Codex to read `.env` / `/etc/passwd` / etc., and the bridge→codex→relay chain will broadcast the contents to the Discord channel.

## Trade-off
Team tier loses the ability to answer questions that need repo reads. The `other` tier has had this restriction from day one. Follow-up: codex config denylist for `**/.env`, `**/*.key`, `**/id_*`, etc.

## Test plan
- [ ] Hostile probe via Discord: send a team-tier mention asking to read `.env` → Codex should fail
- [ ] Benign team-tier mention still works without repo visibility
- [ ] `other` tier behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #386