### PR TITLE
health-check: accurate phrasing when voice-agent is stale (not 'not running')

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -227,10 +227,12 @@ def check_voice_watchers(voice_check: dict) -> dict:
     appears after it.
     """
     check = {"name": "voice-watchers", "status": "ok", "detail": "all 3 watchers active"}
-    # Only run if voice-agent itself is up; otherwise the check is moot
-    if voice_check.get("status") != "ok":
+    # Only run if voice-agent itself is ok; otherwise the check is moot.
+    # Distinguish "stale" (process running, old code) from absent.
+    vs = voice_check.get("status")
+    if vs != "ok":
         check["status"] = "warn"
-        check["detail"] = "voice-agent not running"
+        check["detail"] = f"voice-agent {vs}" if vs else "voice-agent status unknown"
         return check
     log_file = REPO_DIR / "logs" / "voice-agent.log"
     if not log_file.exists():
@@ -304,9 +306,10 @@ def check_voice_transport(voice_check: dict) -> dict:
     to whoever manually tails the log.
     """
     check = {"name": "voice-transport", "status": "ok", "detail": "no recent transport errors"}
-    if voice_check.get("status") != "ok":
+    vs = voice_check.get("status")
+    if vs != "ok":
         check["status"] = "warn"
-        check["detail"] = "voice-agent not running"
+        check["detail"] = f"voice-agent {vs}" if vs else "voice-agent status unknown"
         return check
     log_file = REPO_DIR / "logs" / "voice-agent.log"
     if not log_file.exists():


### PR DESCRIPTION
## Summary
When `voice-agent` is stale (process running but code is newer than the process boot time), the dependent checks `voice-watchers` and `voice-transport` were reporting `detail = "voice-agent not running"` — misleading because the process was actually alive.

Observed today: voice-agent has been stale for 250+ minutes (scroll-tool update + PR #181 merge both waiting on restart). Health output was:

```
♻ voice-agent     stale   running but code is 204 min newer than process — restart needed
⚠ voice-watchers  warn    voice-agent not running    ← wrong
⚠ voice-transport warn    voice-agent not running    ← wrong
```

## Fix
Two call sites (`check_voice_watchers`, `check_voice_transport`) use `detail = f"voice-agent {vs}"` so stale renders as "voice-agent stale", unknown renders as "voice-agent unknown", and genuine absence still works correctly.

After the fix:
```
♻ voice-agent     stale   running but code is 204 min newer than process — restart needed
⚠ voice-watchers  warn    voice-agent stale          ← accurate
⚠ voice-transport warn    voice-agent stale          ← accurate
```

## Test plan
- [x] Local run: `python3 src/health-check.py` — reports "voice-agent stale" when the process is stale
- [ ] (Regression) When voice-agent is actually absent (pkill + wait), dependent checks still surface the absence clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #363