### PR TITLE
feat(skills): add macos-use — GUI control via mediar-ai MCP server (#65)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,18 @@ python3 ~/.claude/skills/macos-tools/scripts/reminders.py complete "Call Bob"  #
 ```
 Use for "add a reminder", "what's on my todo list", "remind me to...", "mark X as done".
 
+**macOS GUI control** — click, type, scroll, press keys in any Mac app via `macos-use` MCP skill. Works in non-interactive mode (which is how the proactive loop runs), unlike Claude's built-in computer-use. Accessibility-tree based — no screenshots leave the machine.
+
+Tools (after `bash skills/macos-use/scripts/build.sh && bash skills/macos-use/scripts/install-mcp.sh`):
+- `mcp__macos-use__open_application_and_traverse` — open/activate an app, return its a11y tree
+- `mcp__macos-use__click_and_traverse` — click at coordinates in a target PID
+- `mcp__macos-use__type_and_traverse` — type text into the focused element
+- `mcp__macos-use__press_key_and_traverse` — press a named key (Return, Tab, arrows, ...)
+- `mcp__macos-use__scroll_and_traverse` — scroll in a direction
+- `mcp__macos-use__refresh_traversal` — re-read the a11y tree without acting
+
+Prefer this for any "open X and do Y" task in a native app (Zoom join, Mail compose, Finder navigation). For web pages, prefer Browser automation (below). Full doc in `skills/macos-use/SKILL.md`.
+
 **Browser automation** — navigate, read, fill forms, screenshot web pages:
 
 Preferred (interactive): Use **Playwright MCP tools** (`mcp__playwright__*`) or **Chrome plugin** (`mcp__claude-in-chrome__*`). These provide real browser control with live DOM access, screenshots, and form interaction.

--- a/skills/macos-use/SKILL.md
+++ b/skills/macos-use/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: macos-use
+description: "GUI control for macOS apps via mediar-ai's mcp-server-macos-use. Click, type, scroll, key-press, open apps — driven by accessibility tree, works in non-interactive Claude Code mode. Use this for any Sutando task that needs to drive another macOS application (Safari, Zoom, Mail, Finder, etc.)."
+user-invocable: false
+---
+
+# macos-use
+
+Drive macOS applications from Claude Code via mediar-ai's [mcp-server-macos-use](https://github.com/mediar-ai/mcp-server-macos-use). A Swift MCP server that wraps the macOS Accessibility API. Unlike Claude's built-in `computer-use`, this works in non-interactive mode (which is how Sutando's proactive loop and task bridge run), does not hold a machine-wide lock, and does not require a Pro/Max subscription.
+
+## When to use
+
+- "Open Safari and navigate to github.com" — anything requiring real GUI interaction with an app
+- "Click the Join button on the Zoom invite dialog"
+- "Type this into the Discord message box"
+- "Scroll the frontmost window to the bottom"
+- Any task that currently falls back to AppleScript + Quartz mouse events in `src/inline-tools.ts`
+
+Prefer this skill over:
+- `bash src/screen-capture.sh` — that captures screenshots; `macos-use` actually *interacts*
+- AppleScript `tell application` blocks — more reliable, better error handling
+- `cliclick` — lower-level, no accessibility context
+- Claude's built-in `computer-use` — that mode requires interactive sessions and holds a lock that contends with Sutando's own loop
+
+## Tools exposed
+
+After install, these appear as `mcp__macos-use__*` in Claude Code:
+
+| Tool | Parameters | Purpose |
+|------|------------|---------|
+| `open_application_and_traverse` | `identifier` (name/bundle ID/path) | Launch or activate an app, return its a11y tree |
+| `click_and_traverse` | `pid`, `x`, `y` | Click at coordinates in a target app, return updated tree |
+| `type_and_traverse` | `pid`, `text` | Type into the frontmost element |
+| `press_key_and_traverse` | `pid`, `key` | Press a named key (Return, Tab, Escape, arrows, ...) |
+| `scroll_and_traverse` | `pid`, `direction`, `amount` | Scroll in a direction |
+| `refresh_traversal` | `pid` | Re-read the a11y tree without acting |
+
+Every tool returns an accessibility-tree snapshot of the target app — structured UI elements with roles, titles, positions, and identifiers. No pixels. Model reasons over the tree, not over screenshots.
+
+## Install
+
+Two steps, one-time:
+
+```bash
+# 1. Build the Swift binary (~35s)
+bash skills/macos-use/scripts/build.sh
+
+# 2. Register with Claude Code's MCP config (writes ~/.claude.json)
+bash skills/macos-use/scripts/install-mcp.sh
+
+# 3. Grant Accessibility permission
+#    System Settings → Privacy & Security → Accessibility
+#    Click +, navigate to ~/.macos-use-mcp/.build/release/mcp-server-macos-use, enable.
+```
+
+Restart Claude Code after install for the MCP tools to appear.
+
+## Gotchas
+
+- **Swift 6 build fragility**: the `swift-sdk` transitive dep has data-race errors that Swift 6.3+ strict-concurrency trips on. `build.sh` uses `-Xswiftc -swift-version -Xswiftc 5` as a workaround. When upstream fixes this, remove the flag.
+- **Accessibility permission**: the binary must be added to System Settings → Privacy & Security → Accessibility, or every tool call will return "not authorized". First-run error is obvious; owner must click through once.
+- **Apps without good a11y trees**: Canvas / Electron / games degrade badly. For those, fall back to `screen-capture.sh` + Claude vision.
+- **Build dep pulled from GitHub**: air-gapped Macs won't work. No prebuilt releases yet.
+- **Multi-node**: each node builds its own binary. Not synced via `sutando-memory.git` (binaries are machine-specific). Run `build.sh` + `install-mcp.sh` on Mac Mini and MacBook separately.
+
+## Quick self-test
+
+After install + restart:
+
+```
+Sutando, open Safari and navigate to https://github.com/sonichi/sutando
+```
+
+You should see Claude invoke `mcp__macos-use__open_application_and_traverse` with `identifier: "Safari"`, then `type_and_traverse` into the URL bar, then `press_key_and_traverse` with `Return`.
+
+## Related
+- Research + decision memo: `notes/issue-65-computer-use-research.md`
+- Issue: [#65 Add Claude Computer Use support](https://github.com/sonichi/sutando/issues/65)
+- Upstream: https://github.com/mediar-ai/mcp-server-macos-use

--- a/skills/macos-use/scripts/build.sh
+++ b/skills/macos-use/scripts/build.sh
@@ -10,9 +10,10 @@
 # Usage:
 #   bash skills/macos-use/scripts/build.sh [--force]
 #
-# Idempotent: if the binary exists and is newer than the repo mtime, skips.
+# Idempotent: if the binary already exists, skips unless --force is passed.
 
 set -euo pipefail
+set -o pipefail  # fail if any command in a pipe errors (catches swift build | tail)
 
 REPO_URL="https://github.com/mediar-ai/mcp-server-macos-use.git"
 CLONE_DIR="${HOME}/.macos-use-mcp"
@@ -51,10 +52,18 @@ fi
 
 echo "→ building $BIN_NAME (~35s, release mode, swift-version 5 workaround)"
 cd "$CLONE_DIR"
-xcrun swift build -c release -Xswiftc -swift-version -Xswiftc 5 2>&1 | tail -5
+BUILD_LOG="/tmp/macos-use-mcp-build-$(date +%s).log"
+if ! xcrun swift build -c release -Xswiftc -swift-version -Xswiftc 5 >"$BUILD_LOG" 2>&1; then
+    echo "✗ build failed — last 20 lines of $BUILD_LOG:" >&2
+    tail -20 "$BUILD_LOG" >&2
+    exit 1
+fi
+# Show concise success summary (last link line)
+tail -3 "$BUILD_LOG"
 
 if [[ ! -f "$BINARY" ]]; then
-    echo "✗ build failed — binary not produced at $BINARY" >&2
+    echo "✗ build reported success but binary not produced at $BINARY" >&2
+    echo "  full log: $BUILD_LOG" >&2
     exit 1
 fi
 

--- a/skills/macos-use/scripts/build.sh
+++ b/skills/macos-use/scripts/build.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Build mediar-ai mcp-server-macos-use from source with the Swift 5 workaround.
+#
+# Why the flag: mcp-server-macos-use's transitive dep `swift-sdk` has
+# data-race errors that Swift 6.3+ strict-concurrency trips on, even
+# though Package.swift pins tools-version 5.9. `-Xswiftc -swift-version
+# -Xswiftc 5` forces the compiler back into Swift 5 mode for the build.
+# When upstream fixes the races, drop the flag.
+#
+# Usage:
+#   bash skills/macos-use/scripts/build.sh [--force]
+#
+# Idempotent: if the binary exists and is newer than the repo mtime, skips.
+
+set -euo pipefail
+
+REPO_URL="https://github.com/mediar-ai/mcp-server-macos-use.git"
+CLONE_DIR="${HOME}/.macos-use-mcp"
+BIN_NAME="mcp-server-macos-use"
+FORCE=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=true ;;
+        *) ;;
+    esac
+done
+
+if ! command -v xcrun >/dev/null 2>&1; then
+    echo "build.sh: xcrun not found — install Xcode command line tools: xcode-select --install" >&2
+    exit 2
+fi
+
+if [[ ! -d "$CLONE_DIR/.git" ]]; then
+    echo "→ cloning $REPO_URL to $CLONE_DIR"
+    git clone --depth=1 "$REPO_URL" "$CLONE_DIR"
+else
+    if $FORCE; then
+        echo "→ updating $CLONE_DIR"
+        (cd "$CLONE_DIR" && git fetch --depth=1 origin && git reset --hard origin/HEAD)
+    fi
+fi
+
+BINARY="$CLONE_DIR/.build/release/$BIN_NAME"
+
+if [[ -f "$BINARY" ]] && ! $FORCE; then
+    echo "✓ $BIN_NAME already built at $BINARY"
+    echo "  (use --force to rebuild)"
+    exit 0
+fi
+
+echo "→ building $BIN_NAME (~35s, release mode, swift-version 5 workaround)"
+cd "$CLONE_DIR"
+xcrun swift build -c release -Xswiftc -swift-version -Xswiftc 5 2>&1 | tail -5
+
+if [[ ! -f "$BINARY" ]]; then
+    echo "✗ build failed — binary not produced at $BINARY" >&2
+    exit 1
+fi
+
+echo "✓ $BIN_NAME built at $BINARY"
+echo ""
+echo "Next steps:"
+echo "  1. Grant Accessibility permission: System Settings → Privacy & Security → Accessibility"
+echo "     Add $BINARY (drag from Finder or click +)"
+echo "  2. Register the MCP server in Claude Code:"
+echo "     bash skills/macos-use/scripts/install-mcp.sh"
+echo "  3. Restart Claude Code for the MCP tools to appear"

--- a/skills/macos-use/scripts/install-mcp.sh
+++ b/skills/macos-use/scripts/install-mcp.sh
@@ -35,15 +35,21 @@ if ! command -v python3 >/dev/null 2>&1; then
     exit 2
 fi
 
-python3 - <<PY
+# Pass values via env vars instead of heredoc interpolation so quotes /
+# special characters in $CONFIG_FILE or $BINARY can't break the Python source.
+MACOS_USE_CONFIG="$CONFIG_FILE" \
+MACOS_USE_BINARY="$BINARY" \
+MACOS_USE_SCOPE="$SCOPE" \
+python3 - <<'PY'
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 
-config_path = Path("$CONFIG_FILE")
-binary = "$BINARY"
-scope = "$SCOPE"
+config_path = Path(os.environ["MACOS_USE_CONFIG"])
+binary = os.environ["MACOS_USE_BINARY"]
+scope = os.environ["MACOS_USE_SCOPE"]
 
 if config_path.exists():
     try:
@@ -66,7 +72,22 @@ if existing == desired:
 else:
     cfg["mcpServers"]["macos-use"] = desired
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(json.dumps(cfg, indent=2) + "\n")
+    # Atomic write: tmp file in same dir + rename, so a crash mid-write
+    # can't leave a corrupted ~/.claude.json.
+    new_text = json.dumps(cfg, indent=2) + "\n"
+    tmp_fd, tmp_path = tempfile.mkstemp(
+        prefix=config_path.name + ".", suffix=".tmp", dir=str(config_path.parent)
+    )
+    try:
+        with os.fdopen(tmp_fd, "w") as fh:
+            fh.write(new_text)
+        os.replace(tmp_path, config_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
     action = "updated" if existing else "added"
     print(f"✓ macos-use {action} in {config_path} ({scope} scope)")
     print()

--- a/skills/macos-use/scripts/install-mcp.sh
+++ b/skills/macos-use/scripts/install-mcp.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Register mcp-server-macos-use as an MCP server in Claude Code's settings.
+#
+# Adds the binary under ~/.macos-use-mcp/.build/release/mcp-server-macos-use
+# to ~/.claude.json's mcpServers map. Idempotent — won't duplicate entries.
+#
+# Usage:
+#   bash skills/macos-use/scripts/install-mcp.sh [--user|--project]
+#
+# --user    (default) registers in ~/.claude.json
+# --project registers in ./.mcp.json (current repo only)
+
+set -euo pipefail
+
+BINARY="${HOME}/.macos-use-mcp/.build/release/mcp-server-macos-use"
+SCOPE="user"
+CONFIG_FILE="${HOME}/.claude.json"
+
+for arg in "$@"; do
+    case "$arg" in
+        --project) SCOPE="project"; CONFIG_FILE="$(pwd)/.mcp.json" ;;
+        --user) SCOPE="user"; CONFIG_FILE="${HOME}/.claude.json" ;;
+        *) ;;
+    esac
+done
+
+if [[ ! -x "$BINARY" ]]; then
+    echo "install-mcp: binary not found at $BINARY" >&2
+    echo "  Run bash skills/macos-use/scripts/build.sh first." >&2
+    exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "install-mcp: python3 required for JSON manipulation" >&2
+    exit 2
+fi
+
+python3 - <<PY
+import json
+import os
+import sys
+from pathlib import Path
+
+config_path = Path("$CONFIG_FILE")
+binary = "$BINARY"
+scope = "$SCOPE"
+
+if config_path.exists():
+    try:
+        cfg = json.loads(config_path.read_text())
+    except json.JSONDecodeError as e:
+        print(f"install-mcp: cannot parse {config_path}: {e}", file=sys.stderr)
+        sys.exit(3)
+else:
+    cfg = {}
+
+cfg.setdefault("mcpServers", {})
+existing = cfg["mcpServers"].get("macos-use")
+desired = {
+    "command": binary,
+    "args": [],
+}
+
+if existing == desired:
+    print(f"✓ macos-use already registered in {config_path}")
+else:
+    cfg["mcpServers"]["macos-use"] = desired
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(cfg, indent=2) + "\n")
+    action = "updated" if existing else "added"
+    print(f"✓ macos-use {action} in {config_path} ({scope} scope)")
+    print()
+    print("Restart Claude Code for the new MCP server to load.")
+    print("Tools will appear as mcp__macos-use__*:")
+    print("  - mcp__macos-use__open_application_and_traverse")
+    print("  - mcp__macos-use__click_and_traverse")
+    print("  - mcp__macos-use__type_and_traverse")
+    print("  - mcp__macos-use__press_key_and_traverse")
+    print("  - mcp__macos-use__scroll_and_traverse")
+    print("  - mcp__macos-use__refresh_traversal")
+PY


### PR DESCRIPTION
## Summary

Adds a new skill `skills/macos-use/` that wraps [mediar-ai/mcp-server-macos-use](https://github.com/mediar-ai/mcp-server-macos-use), giving Sutando real GUI control (click/type/scroll/press + open_application) in non-interactive Claude Code mode. This is the non-interactive-safe alternative to Claude's built-in `computer-use` discussed in issue #65.

Decision memo + hands-on build validation: [notes/issue-65-computer-use-research.md](../notes/issue-65-computer-use-research.md).

## Why mediar-ai over Claude's built-in
- **Claude's `computer-use`** requires interactive sessions (explicitly blocked in `-p` / non-interactive mode — which is how Sutando's proactive loop runs), holds a machine-wide lock that contends with the owner's own sessions, and is Pro/Max gated.
- **mediar-ai's `mcp-server-macos-use`** is a plain stdio MCP server, works in any Claude Code mode, no lock, no plan gating, accessibility-tree (not screenshots) so no pixels ever leave the machine.

## Files
- **`SKILL.md`** — user-facing doc, tool list (6 tools), install steps, gotchas
- **`scripts/build.sh`** — clones to `~/.macos-use-mcp`, runs `swift build -c release` with `-Xswiftc -swift-version -Xswiftc 5` workaround for the swift-sdk transitive data-race errors. Idempotent (`--force` to rebuild)
- **`scripts/install-mcp.sh`** — writes `~/.claude.json` `mcpServers.macos-use` entry (or `./.mcp.json` with `--project`). Idempotent.

## Verified end-to-end on Mac Mini (2026-04-14)
- Clone: success
- Build: 54.6s, `swiftc` -> linker clean
- Binary: ~14MB Mach-O arm64 at `~/.macos-use-mcp/.build/release/mcp-server-macos-use`
- Server startup: stdio handshake logs show **6 tools loaded**, version 1.6.0 (`SwiftMacOSServerDirect`)
- `install-mcp.sh` JSON logic: dry-tested on `/tmp` config, preserves existing `mcpServers` entries

## NOT done in this PR
- **`install-mcp.sh` not run against live `~/.claude.json`** on Mac Mini — would disrupt the current Sutando session. Owner should run it post-merge + restart Claude Code.
- **Accessibility permission grant** — owner step (System Settings → Privacy & Security → Accessibility → add the binary)
- **CLAUDE.md tool table update** — follow-up PR once the skill is activated in the next session so I can test the actual MCP tool names end-to-end.

## Test plan
- [ ] Merge, then on Mac Mini: `bash skills/macos-use/scripts/install-mcp.sh`
- [ ] Grant Accessibility to `~/.macos-use-mcp/.build/release/mcp-server-macos-use`
- [ ] Restart Claude Code, confirm `mcp__macos-use__*` tools appear in the tool list
- [ ] Smoke test: "Sutando, open Safari and navigate to https://github.com/sonichi/sutando"
- [ ] Expected: Claude invokes `mcp__macos-use__open_application_and_traverse` → `type_and_traverse` → `press_key_and_traverse`

## Related
- Issue: #65 (Add Claude Computer Use support)
- Decision memo: `notes/issue-65-computer-use-research.md`
- Session handoff: `notes/session-2026-04-14-handoff.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)