### PR TITLE
discord-bridge: SUTANDO_TEAM_TIER_OWNER deterministic ownership

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,16 @@ PORT=9900
 # sync-memory.sh skips silently if this is unset.
 # SUTANDO_MEMORY_REPO=git@github.com:youruser/sutando-memory.git
 
+# Optional: Deterministic ownership for team/other-tier Discord tasks
+# When set, only the node whose stand-identity.json `machine` field matches
+# SUTANDO_TEAM_TIER_OWNER will accept non-owner-tier tasks. Other nodes drop
+# them silently. Prevents the dup-processing that otherwise burns 2× codex
+# quota and posts 2 replies whenever both bots receive the same team @mention.
+#
+# Set the SAME value on both nodes' .env. Owner-tier tasks are unaffected
+# (always processed locally).
+# SUTANDO_TEAM_TIER_OWNER=mac-mini
+
 # ============================================================
 # MODEL CONFIGURATION — override defaults for cost/quality tuning
 # ============================================================

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -70,8 +70,16 @@ except Exception:
 if TEAM_TIER_OWNER:
     if LOCAL_MACHINE == TEAM_TIER_OWNER:
         print(f"[tier-ownership] this node ({LOCAL_MACHINE}) owns team/other-tier processing")
+    elif not LOCAL_MACHINE:
+        # Misconfiguration: TEAM_TIER_OWNER is set but stand-identity.json is
+        # missing/unreadable. We'll silently drop ALL non-owner tasks, which
+        # looks like a complete outage from the Discord side. Flag loudly at
+        # startup so the operator notices.
+        print(f"[tier-ownership] ⚠ WARNING: SUTANDO_TEAM_TIER_OWNER={TEAM_TIER_OWNER} but local machine identity is EMPTY")
+        print(f"[tier-ownership] ⚠ stand-identity.json missing or has no 'machine' field — ALL non-owner tier tasks will be DROPPED silently")
+        print(f"[tier-ownership] ⚠ Fix: populate stand-identity.json with machine='<your-node-id>' or unset SUTANDO_TEAM_TIER_OWNER")
     else:
-        print(f"[tier-ownership] this node ({LOCAL_MACHINE or 'unknown'}) will DROP team/other-tier tasks (owner: {TEAM_TIER_OWNER})")
+        print(f"[tier-ownership] this node ({LOCAL_MACHINE}) will DROP team/other-tier tasks (owner: {TEAM_TIER_OWNER})")
 
 # Dedup: skip duplicate messages (Discord gateway can replay events on reconnect)
 seen_message_ids = set()  # Discord message IDs already processed

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -37,6 +37,42 @@ TASKS_DIR.mkdir(exist_ok=True)
 RESULTS_DIR.mkdir(exist_ok=True)
 INBOX_DIR.mkdir(exist_ok=True)
 
+# Optional: deterministic ownership for team/other-tier tasks across nodes.
+# When set, only the node whose stand-identity.json `machine` field matches
+# SUTANDO_TEAM_TIER_OWNER will accept non-owner-tier tasks. The other nodes
+# silently drop them. Prevents the dup-processing that otherwise burns 2x
+# codex quota and posts 2x replies to the Discord channel whenever Mac Mini
+# and MacBook both receive the same team-tier @mention.
+#
+# Unset → both nodes process (legacy behavior, no regression).
+# Set same value on both nodes' .env → only the matching node processes.
+#
+# Example: SUTANDO_TEAM_TIER_OWNER=mac-mini
+TEAM_TIER_OWNER = ""
+LOCAL_MACHINE = ""
+try:
+    env_file = REPO / ".env"
+    if env_file.exists():
+        for line in env_file.read_text().splitlines():
+            if line.startswith("SUTANDO_TEAM_TIER_OWNER="):
+                TEAM_TIER_OWNER = line.split("=", 1)[1].strip().strip('"').strip("'")
+                break
+except Exception:
+    pass
+
+try:
+    identity_file = REPO / "stand-identity.json"
+    if identity_file.exists():
+        LOCAL_MACHINE = json.loads(identity_file.read_text()).get("machine", "")
+except Exception:
+    pass
+
+if TEAM_TIER_OWNER:
+    if LOCAL_MACHINE == TEAM_TIER_OWNER:
+        print(f"[tier-ownership] this node ({LOCAL_MACHINE}) owns team/other-tier processing")
+    else:
+        print(f"[tier-ownership] this node ({LOCAL_MACHINE or 'unknown'}) will DROP team/other-tier tasks (owner: {TEAM_TIER_OWNER})")
+
 # Dedup: skip duplicate messages (Discord gateway can replay events on reconnect)
 seen_message_ids = set()  # Discord message IDs already processed
 
@@ -423,6 +459,14 @@ async def _handle_discord_message(message, force=False):
     # Cap set size to prevent unbounded growth
     if len(seen_message_ids) > 10000:
         seen_message_ids.clear()
+
+    # Deterministic tier ownership: if SUTANDO_TEAM_TIER_OWNER is configured
+    # and this node's machine does NOT match, drop non-owner-tier tasks so the
+    # designated owner node handles them exclusively. Owner-tier tasks are
+    # always processed locally regardless of this setting.
+    if access_tier != "owner" and TEAM_TIER_OWNER and LOCAL_MACHINE != TEAM_TIER_OWNER:
+        print(f"  [tier-ownership] dropping {access_tier}-tier task from @{username} — owner is {TEAM_TIER_OWNER}, this node is {LOCAL_MACHINE or 'unknown'}")
+        return
 
     # Write as task
     ts = int(time.time() * 1000)


### PR DESCRIPTION
## Summary
Adds optional `SUTANDO_TEAM_TIER_OWNER` env var that pins team/other-tier Discord task processing to a single designated node. Prevents the dup-work pattern that burns 2× codex quota and posts 2 replies whenever both bots receive the same non-owner @mention.

## Why
Observed 4 distinct dup-work incidents in today's session (2026-04-14) all from the same root cause:
- 7 of Susan's hostile sandbox probes → both Mini + MacBook processed each → 2× codex per probe
- PR #328 (my dup of MacBook's reply-context fix, closed as dup)
- Wenjix invite drafted by both bots
- "What do you think" state-of-play duplicated 3×

## Design
- Read `SUTANDO_TEAM_TIER_OWNER` from workspace `.env` at bridge startup
- Read local machine identity from `stand-identity.json[machine]`
- Before writing a task file for team/other tier, compare. If set AND not matching, drop silently (log only)
- Owner tier always processes (unaffected)
- Unset → both nodes process (legacy, no regression)

## Trade-offs
- **Loses backup capability**: if the designated owner node is down, team-tier tasks get dropped by everyone. Mitigation: unset the var on the backup node when the owner is known to be offline.
- **Manual config**: per-machine `.env` config is intentionally divergent (see `feedback_two_bot_collaboration.md`), so this isn't synced via `sutando-memory.git`. Owner runs `echo SUTANDO_TEAM_TIER_OWNER=mac-mini >> .env` on both nodes after merge.

## Test plan
- [ ] Merge + restart discord-bridge on both nodes with env var set
- [ ] Susan sends a team-tier probe → only Mac Mini processes it → only 1 reply in #dev (not 2)
- [ ] Owner sends an owner-tier message → still processed on whichever node has the session
- [ ] Unset on one node → regression test that everything works without the var (legacy)

## Related
- Build log #237 (the gap surfaced)
- Memory: `feedback_two_bot_collaboration.md` (per-node config divergence is intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)