### PR TITLE
fix(migrate.sh): clone the canonical repo, not the stale fork

### DIFF
--- a/src/migrate.sh
+++ b/src/migrate.sh
@@ -151,7 +151,7 @@ cp -r "$BUNDLE_DIR"/* "$SAVED/" 2>/dev/null || true
 cp "$BUNDLE_DIR"/.env "$SAVED/" 2>/dev/null || true
 
 if [ ! -d "$REPO/.git" ]; then
-  git clone https://github.com/liususan091219/sutando.git "$REPO"
+  git clone https://github.com/sonichi/sutando.git "$REPO"
 fi
 cd "$REPO"
 # Re-source nvm in case shell lost it after cd


### PR DESCRIPTION
## Summary
One-line fix: `src/migrate.sh:154` was cloning `liususan091219/sutando` for new-Mac setup. The canonical repo — the `origin` remote on every active node and the one `README.md` Quick Start instructs contributors to clone — is `sonichi/sutando`. A user following the documented migration flow ends up on the wrong fork, diverging from everyone else's tree.

## How it was surfaced
Susan (`@susanliu_`) asked in #dev today for documentation on setting up Sutando on a second computer. I relayed the codex-sandboxed answer pointing at `README.md` + `src/migrate.sh`, and codex flagged the inconsistency in its response: README says one repo, migrate.sh says another.

## History
The flip to `liususan091219` happened in commits `32b0a54` ("Migrate repo references from sonichi to liususan091219") and its follow-up `8efb5d5`. README Quick Start was never flipped, so it's been inconsistent ever since.

## Scope note
README also references `github.com/liususan091219/sutando/issues` for bug reports (lines 50 and 260). **Not touching those in this PR** because they may be intentional (issue tracker split between repos). If not, a follow-up can reconcile.

## Test plan
- [ ] Merge
- [ ] On a fresh Mac: `bash src/migrate.sh` → bundle → `bash setup-new-mac.sh` → verify the clone lands at `sonichi/sutando`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #379