### PR TITLE
gitignore: NativeMic.swift (prevent re-regression from sweeps)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,11 @@ tests/security/*.md
 !tests/security/*.md.example
 skills/schedule-crons/crons.json
 src/Sutando/Sutando
+# NativeMic.swift was removed in PR #329 and keeps getting re-added by
+# search-and-replace sweeps that leave a stale copy in the working tree
+# (regressed in #341, re-deleted in #342). Ignore it so a casual `git add .`
+# can't resurrect it.
+src/Sutando/NativeMic.swift
 voice-context.txt
 tab-aliases.json
 session-state.md


### PR DESCRIPTION
## Summary
- Add `src/Sutando/NativeMic.swift` to `.gitignore` so stale working-tree copies can't be resurrected by a casual `git add .`

## Why
PR #329 removed `NativeMic.swift`. PR #341's search-and-replace sweep accidentally restored it (a stale file existed in the working tree at run time), and PR #342 had to re-delete it. This adds one line so the pattern can't recur.

No runtime effect — file is already deleted from the tree.

Owner-approved via Discord after I flagged the gap.

## Test plan
- [x] `git check-ignore -v src/Sutando/NativeMic.swift` matches the new rule
- [x] No existing tracked file at that path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #385