### PR TITLE
CLAUDE.md: fix two stale command examples (calendar + screen capture)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,14 +115,17 @@ Keep each step conversational and brief — this is spoken, not read. Focus on w
 
 ## Built-in capabilities
 
-**Calendar** — read Google Calendar events (preferred) or macOS Calendar:
+**Calendar** — read Google Calendar events via `gws calendar`:
 ```bash
-~/.claude/skills/google-calendar/scripts/google-calendar.py events list --time-min 2026-03-23T00:00:00Z --time-max 2026-03-30T23:59:59Z
+gws calendar +agenda --today            # today's events (table format by default)
+gws calendar +agenda --week              # this week
+gws calendar +agenda --days 7 --format json   # next 7 days, JSON for parsing
 ```
 
-**Screen capture** — see what's on the user's screen:
+**Screen capture** — see what's on the user's screen. The screen-capture server runs on port 7845 (started by `src/startup.sh`):
 ```bash
-bash src/screen-capture.sh              # full screen → PNG path
+curl -s http://localhost:7845/capture | python3 -c 'import json,sys; print(json.load(sys.stdin)["path"])'
+# Multi-display: add ?all=true to capture every display, or ?display=N for a specific one.
 ```
 Then use the Read tool on the returned path to view the screenshot. Use this for any screen-related question: "what am I looking at", "help me with this", "what's on my screen", etc.
 


### PR DESCRIPTION
## Summary
Two examples in CLAUDE.md reference paths that don't exist, so any agent following them hits \`No such file or directory\`:

1. **Calendar** — example referenced \`~/.claude/skills/google-calendar/scripts/google-calendar.py\`. The working command on this (Mac Mini) install is \`gws calendar +agenda\`. Updated to show \`--today\`, \`--week\`, and \`--days N --format json\` variants.
2. **Screen capture** — example referenced \`bash src/screen-capture.sh\`. The actual capture goes through the HTTP server \`src/screen-capture-server.py\` on port 7845, which is already started by \`src/startup.sh\`. Replaced with a curl-based invocation.

No code change. Docs only. Caught by spot-checking every CLI in CLAUDE.md against the filesystem, after the \`docs-sync\` skill I wanted to install turned out to be vapourware (registry entry points at a path that doesn't exist in its repo).

## Test plan
- [x] \`gws calendar +agenda --today\` — returns live calendar (verified)
- [x] \`curl -s http://localhost:7845/capture\` — returns \`{"status":"ok","path":"..."}\` (verified)
- [x] Both original paths confirmed missing (\`src/screen-capture.sh\`, \`~/.claude/skills/google-calendar/\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)