### PR TITLE
web-client: formant-weighted radial waveform for speaking state

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -882,6 +882,29 @@ function startSpeakingDetection() {
   var smoothed = 0;
   var NUM_BARS = 24;
   var CX = 30, CY = 30, INNER = 24, OUTER = 30; // canvas center and radii
+  // Formant-weighting: find top-3 peak bins (approximate F1/F2/F3) per frame,
+  // then boost bars near those bins so the ring shape visibly shifts with
+  // vowel changes instead of just pulsing louder.
+  var K = 3;
+  var peakIdx = new Int16Array(K);
+  var peakVal = new Uint8Array(K);
+  function findPeaks() {
+    for (var k = 0; k < K; k++) { peakIdx[k] = -1; peakVal[k] = 0; }
+    // Skip bin 0 (DC) and last bin (Nyquist) — noisy, not formant-bearing.
+    for (var i = 1; i < buf.length - 1; i++) {
+      if (buf[i] < buf[i - 1] || buf[i] <= buf[i + 1]) continue;
+      var v = buf[i];
+      for (var k = 0; k < K; k++) {
+        if (v > peakVal[k]) {
+          for (var j = K - 1; j > k; j--) {
+            peakVal[j] = peakVal[j - 1]; peakIdx[j] = peakIdx[j - 1];
+          }
+          peakVal[k] = v; peakIdx[k] = i;
+          break;
+        }
+      }
+    }
+  }
   function tick() {
     speakingRAF = requestAnimationFrame(tick);
     if (!analyserNode) return;
@@ -897,9 +920,22 @@ function startSpeakingDetection() {
     if (ctx && canvas) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       if (speaking) {
+        findPeaks();
         var step = buf.length / NUM_BARS;
         for (var i = 0; i < NUM_BARS; i++) {
-          var val = buf[Math.floor(i * step)] / 255;
+          var binIdx = Math.floor(i * step);
+          var raw = buf[binIdx] / 255;
+          // Bars within 6 bins of any peak get up to 1.8x their raw height.
+          // Bars far from any peak stay at their raw value. Fall back to
+          // pure amplitude (boost=1.0) when no peaks were found (silence).
+          var minDist = 999;
+          for (var k = 0; k < K; k++) {
+            if (peakIdx[k] < 0) continue;
+            var d = Math.abs(binIdx - peakIdx[k]);
+            if (d < minDist) minDist = d;
+          }
+          var boost = minDist >= 6 ? 1.0 : 1.0 + (1 - minDist / 6) * 0.8;
+          var val = Math.min(1.0, raw * boost);
           var barLen = 2 + val * 6; // 2px min, 8px max
           var angle = (i / NUM_BARS) * Math.PI * 2 - Math.PI / 2;
           var x1 = CX + Math.cos(angle) * INNER;


### PR DESCRIPTION
## Summary
Stacks on merged #338. Makes the 24-bar radial waveform respond to *phoneme* changes, not just overall amplitude. Top-3 peak bins in the frequency spectrum act as formant proxies (F1/F2/F3); bars within 6 bins of a peak get up to 1.8× their raw height. The ring shape visibly rotates/morphs when the vowel changes ("ahhh" → "eee"), which reads as "the avatar is articulating" rather than "a VU meter next to the avatar."

## Why this approach
Converged with @sutando#9708 in #dev today after discussing three scope options:
1. **Bump hero avatar to 200–300px and do an SVG overlay** — unblocked a bigger hero-screen redesign. Deferred as follow-up.
2. **SVG overlay on current avatar sizes** — rejected: at 44×44/80×80 an overlay drawn *on* the image competes with character art at ~5% scale and doesn't visually resolve.
3. **Formant-weighted radial waveform** ← this PR. Ring lives in the 24–30 radius margin outside the image, proven visible from #338.

## What changes
- `src/web-client.ts` — inside existing `startSpeakingDetection()` closure: add `findPeaks()` (linear top-K local-max scan, K=3), and replace the bar-draw loop's `val = buf[…]/255` with a formant-weighted value.
- **No new deps, no CSS edits, no new files, no asset changes.**
- +37/-1 lines total.

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` clean
- [x] Embedded browser-JS extracted via python and `node --check`-ed clean (per `feedback_web_client_embedded_js_no_ts`)
- [ ] Manual: hard-refresh, start voice, speak sustained "ahhh" vs "eee" — ring shape visibly differs
- [ ] Silence: `speaking=false` gates the draw — existing behavior preserved (no peaks found → `boost=1.0` → raw amplitude → same as today)

## Graceful degradation
When the spectrum is low (silence) `findPeaks` leaves all `peakIdx[k] = -1`, `minDist` stays 999, `boost = 1.0`, `val = raw`. Output is byte-identical to the pre-PR behavior. If the whole analyser pipeline fails, `speaking = false` still toggles the border CSS on the `<img>` — the visor keeps its color animation even without the canvas overlay.

## Scope explicitly NOT in this PR
- Full SVG-overlay avatar redesign on a larger hero surface (Option 1 in the scope discussion). MacBook is filing a follow-up issue to track it.
- Working-state redesign (Option G from the research memo). Separate PR if/when owner wants it.

## References
- Research memo: `notes/avatar-animation-research.md` — Option D
- Pre-written spec: `notes/avatar-formant-waveform-spec.md`
- Two-bot convergence thread: today in #dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)