### PR TITLE
telegram-bridge: success-gated heartbeat to catch 32h-zombie class of outage

### DIFF
--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -149,14 +149,6 @@ def main():
     heartbeat_file = REPO / "state" / "telegram-bridge.heartbeat"
     last_heartbeat = 0
     while True:
-        # Write heartbeat at most once per 60 seconds
-        now = time.time()
-        if now - last_heartbeat >= 60:
-            try:
-                heartbeat_file.write_text(str(int(now)))
-                last_heartbeat = now
-            except Exception:
-                pass
         # Poll for new messages
         params = {"timeout": 10, "limit": 10}
         if offset:
@@ -167,6 +159,19 @@ def main():
             print(f"[Telegram] Poll error: {e}", flush=True)
             time.sleep(5)
             continue
+        # Heartbeat advances only on a successful getUpdates. A bumped
+        # heartbeat now means "the Telegram API round-trip is working,"
+        # not just "the asyncio loop is alive." Lets health-check
+        # distinguish a zombie (process up, API dead) from a healthy
+        # bridge. See: 2026-04-16 32h DNS-error zombie that had a fresh
+        # heartbeat throughout because it was written before the try.
+        now = time.time()
+        if now - last_heartbeat >= 60:
+            try:
+                heartbeat_file.write_text(str(int(now)))
+                last_heartbeat = now
+            except Exception:
+                pass
 
         if result.get("ok"):
             for update in result.get("result", []):

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -159,21 +159,23 @@ def main():
             print(f"[Telegram] Poll error: {e}", flush=True)
             time.sleep(5)
             continue
-        # Heartbeat advances only on a successful getUpdates. A bumped
-        # heartbeat now means "the Telegram API round-trip is working,"
-        # not just "the asyncio loop is alive." Lets health-check
+        # Heartbeat advances only on a response Telegram actually accepted.
+        # A bumped heartbeat now means "the Telegram API round-trip is
+        # working," not just "the asyncio loop is alive." Gated on
+        # `result.get("ok")` because `api()` silently swallows HTTPError
+        # (auth/rate-limit/500s) and returns `{"ok": False}`; without the
+        # gate, those would still bump the heartbeat. Lets health-check
         # distinguish a zombie (process up, API dead) from a healthy
         # bridge. See: 2026-04-16 32h DNS-error zombie that had a fresh
         # heartbeat throughout because it was written before the try.
-        now = time.time()
-        if now - last_heartbeat >= 60:
-            try:
-                heartbeat_file.write_text(str(int(now)))
-                last_heartbeat = now
-            except Exception:
-                pass
-
         if result.get("ok"):
+            now = time.time()
+            if now - last_heartbeat >= 60:
+                try:
+                    heartbeat_file.write_text(str(int(now)))
+                    last_heartbeat = now
+                except Exception:
+                    pass
             for update in result.get("result", []):
                 offset = update["update_id"] + 1
                 msg = update.get("message")


### PR DESCRIPTION
## Summary
On Mac Mini today, caught a **32-hour Telegram outage** hiding behind a fresh heartbeat. PID 17372 had `etime=4d 20h` but `logs/telegram-bridge.log` mtime was Apr 15 03:02:12 — 32h old — with 48 consecutive `urlopen error [Errno 8] nodename nor servname provided, or not known` entries followed by `[Errno 54] Connection reset by peer` and then silence. DNS had long since recovered (\`host api.telegram.org\` + \`curl https://api.telegram.org\` both clean), but the bridge never broke out of the error-and-retry loop. `health-check.py` reported "telegram-bridge ok running" the entire time.

Root cause: the heartbeat was written at the top of the poll loop, before the API call:

```python
while True:
    now = time.time()
    if now - last_heartbeat >= 60:
        heartbeat_file.write_text(str(int(now)))   # ← bumps unconditionally
        last_heartbeat = now
    try:
        result = api("getUpdates", **params)
    except Exception as e:
        print(f"[Telegram] Poll error: {e}", flush=True)
        time.sleep(5)
        continue
```

Every failed poll tick still bumped the heartbeat, so the file stayed fresh indefinitely. Health-check's 120s threshold trusted it.

## Fix
Move the heartbeat write to **after** `api("getUpdates")` succeeds. Semantic shift: heartbeat now means "the Telegram round-trip is working," not "the asyncio loop is alive." Health-check's existing freshness check then catches this class of zombie on the first tick after a sustained outage.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('src/telegram-bridge.py').read())"` — parse clean
- [x] Restarted the bridge today (pre-PR, from existing main) — confirmed heartbeat still bumps under normal operation (PID 49212, ESTABLISHED TCP to \`[2001:67c:4e8:f004::9]:443\`, log active)
- [x] Read the rest of the loop — no path writes heartbeat except the one I moved; `continue` on error skips the bump as intended
- [ ] Post-merge: restart bridge on Mini + MacBook, watch for missed-message reports

## Non-goals
`discord-bridge.py` has the same shape — heartbeat written at the top of `poll_results` before anything is attempted — but the fix is less clean because `poll_results` only iterates local files. There's no single "the API is working" signal to gate on (the real health signal lives in `on_message`, which is handled by discord.py internally). Separate follow-up; flagging here so it isn't lost.

## Related memory
- \`feedback_asyncio_liveness.md\` (this is exactly the class of bug it warned about)
- \`feedback_restart_semantics_check.md\` (written earlier today for the DM-flood family — same "fresh signal hides a dead subsystem" shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)