### PR TITLE
feat(skills): add /self-diagnose for 24h introspection

### DIFF
--- a/skills/self-diagnose/SKILL.md
+++ b/skills/self-diagnose/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: self-diagnose
+description: "Sutando introspection — read logs + git + memory + build log for a chosen time window and produce a concise narrative of what the agent has been doing, what's broken, and what to prioritize next."
+user-invocable: true
+---
+
+# Self-Diagnose
+
+Read Sutando's own observable state (logs, git, memory, build log, pending questions, health check, cold-review log) over a chosen window and produce a structured narrative:
+
+- **What's been happening** — significant events, PRs shipped, tasks processed, user interactions
+- **What's broken** — errors in logs, pending questions, health-check failures, 1006/1011/1007 transport events, unresolved bugs surfaced in logs
+- **What I'd do next** — concrete prioritized actions grounded in what was observed
+
+**Usage**: `/self-diagnose [--since 24h]`
+
+ARGUMENTS: `$ARGUMENTS`
+
+## Flow
+
+1. **Gather.** Run `bash skills/self-diagnose/scripts/gather.sh [window]` — collects log tails, git log, build_log.md tail, pending-questions, health-check output, cold-review-log, and recent Discord activity into `/tmp/sutando-diagnose-<ts>/`.
+2. **Synthesize.** Read each gathered file. Group findings under the three headings above. Be concrete: cite log lines, PR numbers, timestamps. Skip speculation.
+3. **Save.** Write the report to `notes/diagnose-YYYY-MM-DD-HHMM.md` with frontmatter (`title`, `date`, `tags: [diagnose, self]`).
+4. **Summarize.** Reply to the caller with a 5–10 line executive summary + path to the full report.
+
+## Default window
+
+24 hours if unspecified. Accept: `24h`, `3d`, `1w`. Longer windows = broader scope, higher token cost.
+
+## What a good report looks like
+
+- Cites specific log timestamps (`18:28:16 — transport 1006 after NoteView injection`) rather than "some errors happened"
+- Lists PRs by number + status (`#394 mergeable no reviews`, `#354 retention sweep open`)
+- Separates recurring from one-off issues
+- Prioritizes "what I'd do next" by impact and blocking, not by what's most recent
+
+## What to skip
+
+- Verbose log dumps — the gathered files are on disk already; just reference them
+- Speculation without log evidence — "maybe the Gemini server is..." should be backed by a log line showing the close code and preceding event
+- Restating CLAUDE.md / build_log.md content — those are already durable; only surface what's NEW in the window
+
+## Related
+
+- `notes/cold-review-capability.md` — sister capability for PR-level review
+- `notes/voice-transport-1006-hypothesis.md` — example of the depth of analysis a self-diagnose report should match
+- `build_log.md` — the canonical "what has been built" log; complements but doesn't replace

--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Collect observable state from the last <window> into a temp directory.
+# Usage: gather.sh [window]       # e.g. gather.sh 24h, gather.sh 3d
+# Default window: 24h.
+# Prints the output directory path on stdout as the last line.
+
+set -euo pipefail
+
+WINDOW="${1:-24h}"
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+TS="$(date +%s)"
+OUT="/tmp/sutando-diagnose-$TS"
+mkdir -p "$OUT"
+
+# Convert window to seconds for log filtering
+case "$WINDOW" in
+	*h) SECONDS_AGO=$((${WINDOW%h} * 3600)) ;;
+	*d) SECONDS_AGO=$((${WINDOW%d} * 86400)) ;;
+	*w) SECONDS_AGO=$((${WINDOW%w} * 604800)) ;;
+	*) echo "Unknown window format: $WINDOW (use h/d/w)" >&2; exit 1 ;;
+esac
+SINCE_EPOCH=$(( $(date +%s) - SECONDS_AGO ))
+SINCE_ISO="$(date -r $SINCE_EPOCH +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -d "@$SINCE_EPOCH" +%Y-%m-%dT%H:%M:%S)"
+
+echo "window: $WINDOW (since $SINCE_ISO)" > "$OUT/meta.txt"
+echo "repo: $REPO" >> "$OUT/meta.txt"
+
+# 1) Git activity
+git -C "$REPO" log --since="$SINCE_ISO" --pretty=format:'%h %ad %s' --date=short > "$OUT/git-log.txt" 2>/dev/null || true
+git -C "$REPO" status --short > "$OUT/git-status.txt" 2>/dev/null || true
+
+# 2) Open PRs + recently merged (last 14d) — cheap, already cached by gh
+if command -v gh >/dev/null; then
+	gh pr list --state open --limit 20 --json number,title,mergeable,headRefName,author,updatedAt \
+		--jq '.[] | "#\(.number) \(.headRefName) [@\(.author.login)] \(.title) — \(.mergeable)"' \
+		> "$OUT/prs-open.txt" 2>/dev/null || true
+	gh pr list --state merged --search "merged:>$(date -v -14d +%Y-%m-%d 2>/dev/null || date -d '14 days ago' +%Y-%m-%d)" \
+		--limit 30 --json number,title,mergedAt,author \
+		--jq '.[] | "#\(.number) \(.mergedAt[:10]) [@\(.author.login)] \(.title)"' \
+		> "$OUT/prs-recent-merged.txt" 2>/dev/null || true
+fi
+
+# 3) Build log tail + pending questions + cold-review log (small files, copy whole)
+tail -150 "$REPO/build_log.md" > "$OUT/build_log-tail.md" 2>/dev/null || true
+cp "$REPO/pending-questions.md" "$OUT/pending-questions.md" 2>/dev/null || true
+cp "$REPO/notes/cold-review-log.md" "$OUT/cold-review-log.md" 2>/dev/null || true
+
+# 4) Voice-agent log — filter to window, grep for signal lines, keep it bounded.
+# Signals: transport closes (1006/1011/1007/1008), errors, GoAway, setup complete, 1006/1011 numeric.
+VLOG="$REPO/logs/voice-agent.log"
+if [ -f "$VLOG" ]; then
+	awk -v since="$SINCE_ISO" '
+		# Approximate filter: log lines start with HH:MM:SS — we can'"'"'t easily compare dates,
+		# so we simply take the last ~5000 lines and filter by signal inside that window.
+		{ buf[NR % 5000] = $0 }
+		END { for (i = (NR>=5000?NR-4999:1); i <= NR; i++) print buf[i % 5000] }
+	' "$VLOG" 2>/dev/null | grep -E "code=1006|code=1011|code=1007|code=1008|code=4000|GoAway|Transport error|Transport closed|setup complete|Gemini disconnected|reconnect|Error: " \
+		> "$OUT/voice-agent-signals.txt" || true
+	wc -l "$VLOG" > "$OUT/voice-agent-size.txt"
+fi
+
+# 5) Discord bridge log — last 200 non-dm-fallback lines
+DLOG="$REPO/logs/discord-bridge.log"
+if [ -f "$DLOG" ]; then
+	grep -v "\[dm-fallback\]" "$DLOG" 2>/dev/null | tail -200 > "$OUT/discord-bridge-recent.txt" || true
+fi
+
+# 6) Health check current state
+if [ -f "$REPO/src/health-check.py" ]; then
+	python3 "$REPO/src/health-check.py" 2>&1 | tail -40 > "$OUT/health.txt" || true
+fi
+
+# 7) Recent result files — what did the agent actually reply to?
+find "$REPO/results" -maxdepth 1 -type f -name "*.txt" -newer "$OUT/meta.txt" 2>/dev/null | head -20 > "$OUT/results-recent-paths.txt" || true
+
+# 8) Quota state
+if [ -f "$HOME/.claude/skills/quota-tracker/scripts/read-quota.py" ]; then
+	python3 "$HOME/.claude/skills/quota-tracker/scripts/read-quota.py" 2>&1 | head -10 > "$OUT/quota.txt" || true
+fi
+
+# Print size summary to stderr and path to stdout
+echo "Gathered to $OUT:" >&2
+du -h "$OUT"/* 2>/dev/null | sort -rh | head -15 >&2
+echo "$OUT"

--- a/skills/self-diagnose/scripts/test-gather.sh
+++ b/skills/self-diagnose/scripts/test-gather.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Smoke tests for gather.sh.
+# Validates: expected output files exist, are non-empty when source exists,
+# valid windows parse cleanly, invalid windows reject.
+
+set -euo pipefail
+cd "$(dirname "$0")/../../.."
+
+PASS=0
+FAIL=0
+pass() { echo "  ✅ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL + 1)); }
+
+echo "━━━ gather.sh smoke tests ━━━"
+
+# Test 1: valid window → non-zero exit + output dir
+if OUT=$(bash skills/self-diagnose/scripts/gather.sh 24h 2>/dev/null); then
+	[ -d "$OUT" ] && pass "24h window: output dir created at $OUT" || fail "24h window: no output dir"
+else
+	fail "24h window: gather exited non-zero"
+	OUT=""
+fi
+
+# Test 2: expected files present
+if [ -n "$OUT" ]; then
+	for f in meta.txt git-log.txt git-status.txt build_log-tail.md pending-questions.md health.txt quota.txt; do
+		[ -f "$OUT/$f" ] && pass "expected file exists: $f" || fail "missing file: $f"
+	done
+fi
+
+# Test 3: meta.txt contains window + repo
+if [ -n "$OUT" ] && [ -f "$OUT/meta.txt" ]; then
+	grep -q "window:" "$OUT/meta.txt" && pass "meta.txt has window line" || fail "meta.txt missing window line"
+	grep -q "repo:" "$OUT/meta.txt" && pass "meta.txt has repo line" || fail "meta.txt missing repo line"
+fi
+
+# Test 4: git-log non-empty when commits exist in window
+if [ -n "$OUT" ] && [ -f "$OUT/git-log.txt" ]; then
+	if git log --since="24 hours ago" --oneline | head -1 >/dev/null; then
+		[ -s "$OUT/git-log.txt" ] && pass "git-log.txt non-empty (commits exist in window)" || fail "git-log.txt empty despite commits in window"
+	else
+		pass "git-log.txt: no commits in window, expected empty (skip non-empty check)"
+	fi
+fi
+
+# Test 5: stdout last line equals output dir path
+if [ -n "$OUT" ]; then
+	[ -d "$OUT" ] && pass "stdout returns valid path" || fail "stdout path invalid"
+fi
+
+# Test 6: invalid window → non-zero exit
+if bash skills/self-diagnose/scripts/gather.sh invalid-window 2>/dev/null 1>/dev/null; then
+	fail "invalid window: gather should have rejected but exited 0"
+else
+	pass "invalid window: gather correctly rejected"
+fi
+
+# Test 7: 3d window format works
+if OUT3=$(bash skills/self-diagnose/scripts/gather.sh 3d 2>/dev/null); then
+	[ -d "$OUT3" ] && pass "3d window: output dir created" || fail "3d window: no output dir"
+	rm -rf "$OUT3" 2>/dev/null
+else
+	fail "3d window: gather exited non-zero"
+fi
+
+# Cleanup
+[ -n "${OUT:-}" ] && rm -rf "$OUT" 2>/dev/null || true
+
+echo ""
+echo "━━━ Results: $PASS passed, $FAIL failed ━━━"
+[ $FAIL -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- New skill `skills/self-diagnose/` — invokable via `/self-diagnose [--since 24h]`.
- `scripts/gather.sh` pulls logs, git, PR state, build log tail, pending questions, cold-review log, health output, and quota into a `/tmp/sutando-diagnose-<ts>/` directory. ~80 lines, no new deps.
- SKILL.md describes the three-heading report format: **What's been happening / What's broken / What I'd do next**. Output lands at `notes/diagnose-YYYY-MM-DD-HHMM.md`.

## Motivation
Health checks pass when services are up. They don't catch transport-layer bugs that only show up inside the logs. We need a second signal that reads the logs and thinks about them.

## Proof point
First test run (see `notes/diagnose-2026-04-16-1204.md`) surfaced a bodhi state-machine FATAL at `voice-session.ts:705` — `Invalid transition: CLOSED → RECONNECTING`. The health-check was passing at the same moment. That's the class of bug this skill is for.

## Not in this PR
- Automated cadence (a proactive-loop integration that runs `/self-diagnose` once a day and DMs findings). Deferred — wire it up once the report format is stable.
- The report writing is done by Claude via the SKILL.md instructions — no model invocation is baked into the gather script.

## Test plan
- [x] `bash skills/self-diagnose/scripts/gather.sh 24h` produces a non-empty output dir with all expected files.
- [x] Manually ran the full skill flow; output at `notes/diagnose-2026-04-16-1204.md`.
- [x] Surfaced at least one bug the existing health-check missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)