### PR TITLE
discord-bridge: poll_proactive picks first non-bot owner (fixes 50007 on multi-bot allowFrom)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -670,13 +670,32 @@ async def poll_proactive():
                     if not text:
                         f.unlink(missing_ok=True)
                         continue
-                    # Send to first owner in allowFrom
+                    # Send to first non-bot user in allowFrom.
+                    # `allowFrom` typically contains multiple bot IDs
+                    # (MacBook bot, Mac Mini bot) plus the human owner.
+                    # `next(iter(allowed))` picked bots ~50% of the time
+                    # based on set iteration, and Discord rejects bot→bot
+                    # DMs with HTTP 400 code 50007 ("Cannot send messages
+                    # to this user"). See `src/dm-result.py` which has
+                    # the matching `_resolve_owner_id()` for the CLI path.
                     allowed = load_allowed()
                     if not allowed:
                         print(f"  [proactive] no owner in allowFrom, skipping {f.name}")
                         f.unlink(missing_ok=True)
                         continue
-                    owner_id = next(iter(allowed))
+                    owner_id = None
+                    for uid in allowed:
+                        try:
+                            u = await client.fetch_user(int(uid))
+                            if not u.bot:
+                                owner_id = str(uid)
+                                break
+                        except Exception:
+                            continue
+                    if owner_id is None:
+                        print(f"  [proactive] no human user in allowFrom, skipping {f.name}")
+                        f.unlink(missing_ok=True)
+                        continue
                     try:
                         user = await client.fetch_user(int(owner_id))
                         dm = await user.create_dm()


### PR DESCRIPTION
## Summary
Fixes 18+ HTTP 400 `code=50007` "Cannot send messages to this user" errors in today's `logs/discord-bridge.log`. Every Mini proactive (pending-questions cron output, flood-prevention pings) was failing silently.

## Root cause
`poll_proactive()` at line 679 previously did:
```python
allowed = load_allowed()          # set()
owner_id = next(iter(allowed))     # arbitrary set iteration order
```

On Mini, `~/.claude/channels/discord/access.json` has:
```json
"allowFrom": ["1485364006297534584", "1022910063620390932"]
```
- `1485364006297534584` → `sutando#9708` (MacBook bot) — confirmed via today's log mention-resolution
- `1022910063620390932` → `sonichi` (human owner)

Python `set()` iteration order is not stable across runs, and on Mini it was consistently picking the MacBook bot's ID. Discord blocks bot→bot DMs with HTTP 400 `50007`.

## Fix
Walk `allowFrom` and pick the first user where `u.bot == False`. This matches the logic already in `src/dm-result.py::_resolve_owner_id()` for the CLI path — lifting it inline so `poll_proactive` and `dm-result` agree.

```python
owner_id = None
for uid in allowed:
    try:
        u = await client.fetch_user(int(uid))
        if not u.bot:
            owner_id = str(uid)
            break
    except Exception:
        continue
if owner_id is None:
    print(f"  [proactive] no human user in allowFrom, skipping {f.name}")
    f.unlink(missing_ok=True)
    continue
```

## Impact
- **Before:** Mini proactive delivery was ~50% broken depending on set iteration order. All Mini proactives today failed → 0% delivery.
- **After:** First human in `allowFrom` wins deterministically.
- No behaviour change when `allowFrom` contains only a human (single-human setup).

## Test plan
- [x] `ast.parse` clean on `src/discord-bridge.py`
- [x] Re-read `allowed = load_allowed()` + surrounding control flow — early-return path when no humans are configured, unlinks the proactive file to avoid infinite retry
- [ ] After merge: restart discord-bridge, write a test `results/proactive-*.txt`, confirm it lands in owner's DM (not silently dropped)

## Related
- Fixes the pending-questions-cron delivery path (`src/check-pending-questions.py` writes `proactive-pending-q-*.txt` on each fire — all 18 of today's 50007 errors were from those)
- Parallel design to `src/dm-result.py::_resolve_owner_id()` — consider extracting the shared logic into a utility if this recurs elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)