### PR TITLE
self-diagnose: fix -newer meta.txt bug in gather.sh (followup to #396)

### DIFF
--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -71,7 +71,10 @@ if [ -f "$REPO/src/health-check.py" ]; then
 fi
 
 # 7) Recent result files — what did the agent actually reply to?
-find "$REPO/results" -maxdepth 1 -type f -name "*.txt" -newer "$OUT/meta.txt" 2>/dev/null | head -20 > "$OUT/results-recent-paths.txt" || true
+# Use -mmin against SECONDS_AGO (not `-newer meta.txt` — meta.txt was created
+# at gather-start, so that would only match files written DURING the gather,
+# not files in the last $WINDOW).
+find "$REPO/results" -maxdepth 1 -type f -name "*.txt" -mmin "-$((SECONDS_AGO/60))" 2>/dev/null | head -20 > "$OUT/results-recent-paths.txt" || true
 
 # 8) Quota state
 if [ -f "$HOME/.claude/skills/quota-tracker/scripts/read-quota.py" ]; then

--- a/skills/self-diagnose/scripts/test-gather.sh
+++ b/skills/self-diagnose/scripts/test-gather.sh
@@ -63,6 +63,28 @@ else
 	fail "3d window: gather exited non-zero"
 fi
 
+# Test 8: results-recent-paths captures files mtime-newer than SINCE_EPOCH.
+# This catches the "-newer meta.txt" bug that made this file empty on every run.
+# Touch a fake result file to 1 hour old, then gather with 24h window.
+mkdir -p results 2>/dev/null
+FAKE_RESULT="results/sutando-test-recent-$(date +%s).txt"
+echo "fake" > "$FAKE_RESULT"
+# Backdate to 1 hour ago (BSD touch on macOS, GNU touch on linux — support both)
+if date -v -1H >/dev/null 2>&1; then
+	touch -t "$(date -v -1H +%Y%m%d%H%M.%S)" "$FAKE_RESULT"
+else
+	touch -d "1 hour ago" "$FAKE_RESULT"
+fi
+if OUT8=$(bash skills/self-diagnose/scripts/gather.sh 24h 2>/dev/null); then
+	if grep -q "sutando-test-recent" "$OUT8/results-recent-paths.txt" 2>/dev/null; then
+		pass "results-recent-paths captures 1h-old file in 24h window"
+	else
+		fail "results-recent-paths empty despite 1h-old file (regression of -newer meta.txt bug)"
+	fi
+	rm -rf "$OUT8" 2>/dev/null
+fi
+rm -f "$FAKE_RESULT" 2>/dev/null
+
 # Cleanup
 [ -n "${OUT:-}" ] && rm -rf "$OUT" 2>/dev/null || true
 


### PR DESCRIPTION
## Summary
Followup to #396. `gather.sh` section 7 used `find -newer "$OUT/meta.txt"` to list recent result files, but `meta.txt` is created at gather-start. That meant the find only matched files written *during* the few-second gather run — never files within `$WINDOW`. `results-recent-paths.txt` was empty in every real run.

Switch to `-mmin -$((SECONDS_AGO/60))` so "recent" actually means recent.

## Test
Added test #8 to `test-gather.sh`: touch a fake `results/` file to 1 hour old, gather with `24h` window, assert the file appears in `results-recent-paths.txt`. Full suite 15/15 pass locally. BSD `date -v` (macOS) + GNU `date -d` (linux) both handled.

## Owner context
Flagged in cross-review of #396; owner replied "fix?" after seeing the merge summary. This ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)