### PR TITLE
fix(recording-tools): add transcript keyword guard to pause_video

### DIFF
--- a/src/recording-tools.ts
+++ b/src/recording-tools.ts
@@ -613,6 +613,19 @@ export const pauseVideoTool: ToolDefinition = {
 			console.log(`${ts()} [PauseVideo] BLOCKED — ${sinceLast}ms since play/resume (cooldown 8s)`);
 			return { status: 'playing', instruction: 'Video is still playing. Do NOT pause unless user explicitly says "pause" or "stop".' };
 		}
+		// Mirror resume_video's runtime guard: only pause if the caller actually
+		// said a pause keyword recently. Without this, a Gemini hallucination
+		// outside the 8s cooldown still fires (Susan's 2026-04-16 report).
+		try {
+			const transcriptPath = readlinkSync('/tmp/sutando-live-transcript.txt');
+			const lines = readFileSync(transcriptPath, 'utf8').split('\n');
+			const callerLines = lines.filter(l => l.includes('Caller:'));
+			const recent = callerLines.slice(-3).join(' ').toLowerCase();
+			if (!/\b(pause|stop|hold|wait)\b/.test(recent)) {
+				console.log(`${ts()} [PauseVideo] BLOCKED — no pause keyword in recent caller speech: "${recent.slice(-80)}"`);
+				return { status: 'playing', instruction: 'Video is still playing. Only pause when user explicitly says "pause" or "stop".' };
+			}
+		} catch {}
 		try { writeFileSync('/tmp/sutando-playback-pause', '1'); } catch {}
 		try { execSync(`osascript -e 'tell application "QuickTime Player"' -e 'if (count of documents) > 0 then' -e 'pause document 1' -e 'end if' -e 'end tell'`, { timeout: 5_000 }); } catch {}
 		return { status: 'paused', instruction: 'Paused. When user says play/resume, call play_video.' };


### PR DESCRIPTION
## Summary

\`pause_video\` previously had only an 8-second cooldown after play/resume, while \`resume_video\` (in the same file) carries a runtime transcript-keyword guard that checks the last 3 caller lines for resume/continue/go-on/play-it/play-the.

This asymmetry means a Gemini hallucination outside the 8s pause cooldown still fires a pause the user never asked for. Susan flagged this on 2026-04-16.

## Fix

Mirror \`resume_video\`'s existing guard in \`pause_video\` — same try/catch + symlink read + last-3-caller-lines slice + keyword regex shape, but with pause-intent keywords (\`pause|stop|hold|wait\`):

\`\`\`ts
try {
    const transcriptPath = readlinkSync('/tmp/sutando-live-transcript.txt');
    const lines = readFileSync(transcriptPath, 'utf8').split('\n');
    const callerLines = lines.filter(l => l.includes('Caller:'));
    const recent = callerLines.slice(-3).join(' ').toLowerCase();
    if (!/\b(pause|stop|hold|wait)\b/.test(recent)) {
        console.log(\`\${ts()} [PauseVideo] BLOCKED — no pause keyword in recent caller speech: "\${recent.slice(-80)}"\`);
        return { status: 'playing', instruction: 'Video is still playing. Only pause when user explicitly says "pause" or "stop".' };
    }
} catch {}
\`\`\`

The 8s cooldown is kept as belt-and-suspenders for the \"Gemini hears its own audio output\" case. Falls through to actually pause if the symlink is unreadable — symmetric with resume's behavior.

## Trade-offs

- \`hold\` and \`wait\` are common conversational filler (\"hold on, what?\", \"wait, hmm\"). False-positive blocks would just keep video playing — better than over-pausing.
- No automated test (no test infra exists for recording-tools yet). Manual test: write \`Caller: pause this\` then \`Caller: hello there\` to the transcript symlink target, observe pause/blocked.

## Verification

- typecheck clean (\`npx tsc --noEmit\`)
- mirrors resume_video's existing guard exactly (verified line-by-line against src/recording-tools.ts:548-567)

🤖 Generated with [Claude Code](https://claude.com/claude-code)