### PR TITLE
fix(check-pending-questions): skip voice notify when client disconnected

### DIFF
--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -18,6 +18,28 @@ WORKSPACE = Path(__file__).parent.parent
 PQ_FILE = WORKSPACE / "pending-questions.md"
 RESULTS_DIR = WORKSPACE / "results"
 LAST_NOTIFY_FILE = WORKSPACE / ".last-pq-notify"
+VOICE_LOG = WORKSPACE / "logs" / "voice-agent.log"
+
+
+def voice_client_connected():
+    """True if the most recent [Health] line in voice-agent.log shows client=true.
+    When the voice client is offline, dm-fallback already delivers question-*.txt
+    files via Discord DM — writing one would double-DM with notify_discord_dm."""
+    if not VOICE_LOG.exists():
+        return False
+    try:
+        # Read the tail efficiently: open at end, walk back ~16KB
+        with VOICE_LOG.open('rb') as f:
+            f.seek(0, 2)
+            size = f.tell()
+            f.seek(max(0, size - 16384))
+            tail = f.read().decode('utf-8', errors='replace')
+        for line in reversed(tail.splitlines()):
+            if '[Health]' in line and 'client=' in line:
+                return 'client=true' in line
+    except Exception:
+        pass
+    return False
 
 
 def get_waiting_questions():
@@ -107,8 +129,11 @@ def main():
     # macOS notification
     notify_macos(count, titles)
 
-    # Voice result (if voice is connected, agent will speak it)
-    notify_voice(questions)
+    # Voice result — only when voice is actually connected. When offline, the
+    # discord-bridge dm-fallback would deliver question-*.txt as a duplicate
+    # of notify_discord_dm below. Skipping cuts the spam in half.
+    if voice_client_connected():
+        notify_voice(questions)
 
     # Discord DM to owner (via discord-bridge poll_proactive)
     notify_discord_dm(questions)


### PR DESCRIPTION
## Summary

Pending-question DMs to Discord were arriving in pairs every cooldown cycle:
- One ⚠️-formatted message from `notify_discord_dm` (writes `proactive-pending-q-{ts}.txt` → discord-bridge poll_proactive)
- One \"You have N pending questions...\" message from `notify_voice` (writes `question-{ts}.txt` → discord-bridge dm-fallback when voice client is offline)

Both fire on the same cron tick when the voice client is disconnected. Result: 2× the intended Discord noise per notify.

Empirical: 5 visible duplicate-pair hours in DM history on 2026-04-16 (23:34, 01:04, 01:06, 02:35, 02:37 ET — note also 1-second-apart pairs from both files being written within the same notify cycle).

## Fix

Parse the most recent `[Health] state= client=` line from `logs/voice-agent.log` (efficient tail read, last 16 KB) and only call `notify_voice()` if `client=true`. The Discord DM path (`notify_discord_dm`) stays unchanged — owner asked for DM pings while traveling per `feedback_dm_pending_questions.md`, so that remains the primary delivery channel.

When the voice client IS connected, behavior is unchanged: both paths fire (voice agent speaks the question, Discord DM as backup).

## Verification

- New helper `voice_client_connected()` returns False on the current voice-offline state (verified via inline import). On future runs with a connected client it'll return True (string match `client=true` in the latest [Health] line).
- The existing 1-hour cooldown is preserved; this fix only halves the per-cooldown delivery count when voice is offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)