### PR TITLE
fix(recording-tools): use execFileSync for ffmpeg/open/ffprobe in subtitle burn + open_file

### DIFF
--- a/src/recording-tools.ts
+++ b/src/recording-tools.ts
@@ -489,12 +489,18 @@ export const openFileTool: ToolDefinition = {
 			if (recPath.includes('sutando-recording')) {
 				writeFileSync('/tmp/sutando-playback-path', recPath);
 			}
-			execSync(`open "${recPath}"`, { timeout: 5_000 });
+			// execFileSync — no shell interpolation of caller-controlled recPath
+			// (same CodeQL js/command-line-injection class as #27).
+			execFileSync('open', [recPath], { timeout: 5_000 });
 			try { execSync(`osascript -e 'tell application "QuickTime Player" to activate'`, { timeout: 3_000 }); } catch {}
 			const size = statSync(recPath).size;
 			let duration_seconds: number | null = null;
 			try {
-				const dur = execSync(`/opt/homebrew/bin/ffprobe -v error -show_entries format=duration -of csv=p=0 "${recPath}"`, { timeout: 5_000 }).toString().trim();
+				const dur = execFileSync(
+					'/opt/homebrew/bin/ffprobe',
+					['-v', 'error', '-show_entries', 'format=duration', '-of', 'csv=p=0', recPath],
+					{ timeout: 5_000 }
+				).toString().trim();
 				duration_seconds = Math.round(parseFloat(dur));
 			} catch {}
 			console.log(`${ts()} [OpenFile] opened ${recPath} (${(size / 1024 / 1024).toFixed(1)}MB, ${duration_seconds ?? '?'}s)`);

--- a/src/recording-tools.ts
+++ b/src/recording-tools.ts
@@ -192,8 +192,19 @@ function burnLiveTranscriptSubtitles(videoPath: string): string | null {
 			console.log(`${ts()} [ScreenRecord] no ffmpeg with subtitles filter — skipping burn. Install: brew install ffmpeg-full`);
 			return null;
 		}
-		execSync(
-			`${ffmpegBin} -y -i "${videoPath}" -vf "subtitles=${LIVE_TRANSCRIPT_SRT_PATH}:force_style='FontSize=20,PrimaryColour=&H00FFFFFF,OutlineColour=&H00000000,Outline=2,MarginV=30'" -c:v h264_videotoolbox -b:v 500k -c:a aac "${outPath}"`,
+		// Use execFileSync argv array to avoid shell interpolation of $ffmpegBin,
+		// $videoPath, and $outPath (same CodeQL #27 class fixed for sips below).
+		execFileSync(
+			ffmpegBin,
+			[
+				'-y',
+				'-i', videoPath,
+				'-vf', `subtitles=${LIVE_TRANSCRIPT_SRT_PATH}:force_style='FontSize=20,PrimaryColour=&H00FFFFFF,OutlineColour=&H00000000,Outline=2,MarginV=30'`,
+				'-c:v', 'h264_videotoolbox',
+				'-b:v', '500k',
+				'-c:a', 'aac',
+				outPath,
+			],
 			{ timeout: 120_000 }
 		);
 		if (existsSync(outPath)) {


### PR DESCRIPTION
## Summary

Three call sites in \`src/recording-tools.ts\` interpolated caller-supplied paths into shell strings via \`execSync\`. Same CodeQL js/command-line-injection class as #27 (already fixed for sips at line 239 in this same file).

| Line | Old | New |
|------|-----|-----|
| ~195 | \`execSync(\\\`\${ffmpegBin} -y -i \"\${videoPath}\" -vf \"subtitles=...:force_style='...'\" -c:v ... -c:a aac \"\${outPath}\"\\\`)\` | \`execFileSync(ffmpegBin, ['-y','-i',videoPath,'-vf',\\\`subtitles=...\\\`, ..., outPath])\` |
| ~492 | \`execSync(\\\`open \"\${recPath}\"\\\`)\` | \`execFileSync('open', [recPath])\` |
| ~497 | \`execSync(\\\`/opt/homebrew/bin/ffprobe ... \"\${recPath}\"\\\`)\` | \`execFileSync('/opt/homebrew/bin/ffprobe', ['-v','error','-show_entries','format=duration','-of','csv=p=0', recPath])\` |

\`ffmpegBin\` comes from \`\$FFMPEG_SUBTITLE_BIN\` env var; \`videoPath\`/\`outPath\`/\`recPath\` are all caller-controlled. A path containing a \`\"\` (or arbitrary shell meta-chars) would inject. After this PR, no shell parsing happens — argv arrays are passed directly to the binary.

## Notes

- The ffmpeg \`-vf\` argument keeps its single-quoted force_style block intact; ffmpeg's own \`-vf\` parser handles the single quotes (verified by the unchanged subtitle-rendering behavior).
- \`open\` and \`ffprobe\` are macOS binaries; same argv semantics.
- typecheck clean.

## Origin

Cold-review finding from \`notes/cold-review-log.md\` PR #392 row. Originally flagged the ffmpeg site only; expanded to \`open\` and \`ffprobe\` after auditing the full file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)