### PR TITLE
chore(deps): bump bodhi-realtime-agent to pick up GoAway CLOSED-state guard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1155,7 +1155,7 @@
     },
     "node_modules/bodhi-realtime-agent": {
       "version": "0.1.5",
-      "resolved": "git+ssh://git@github.com/sonichi/bodhi_realtime_agent.git#33a08c0be6a8d05124dfbb0266d6da4d5c017829",
+      "resolved": "git+ssh://git@github.com/sonichi/bodhi_realtime_agent.git#de6433314826ea270a8b8266c9b9cf304ff9bfe6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
Bumps \`bodhi-realtime-agent\` lockfile pin from \`33a08c0\` → **\`de64333\`** to pick up upstream PR [bodhi#4](https://github.com/sonichi/bodhi_realtime_agent/pull/4) (just merged): \`handleGoAway\` now early-returns when \`sessionManager.state !== 'ACTIVE'\`, preventing the unhandled \`SessionError: Invalid transition: CLOSED → RECONNECTING\` FATAL when a late GoAway arrives after the reconnect has already torn down the transport.

## Why
Per \`notes/bodhi-closed-reconnecting-fatal.md\`, current logs show **71× CLOSED → RECONNECTING + 2× RECONNECTING → RECONNECTING** FATALs. These are "staying alive" rejections — they don't crash the process, but each represents a silent transport churn that likely contributes to "Gemini didn't respond" latency spikes even when voice-agent looks healthy. All resolved upstream in \`de64333\`.

## Scope
Lockfile-only change. \`package.json\` pin is \`github:sonichi/bodhi_realtime_agent\` (unchanged, no version pin). \`npm install bodhi-realtime-agent\` re-resolved to the new HEAD commit. **+1/-1**.

Note per \`feedback_no_npm_install_during_rename_sweeps\`: this is an intentional lockfile bump of a single known dependency, not a sweep — no other lockfile entries changed.

## Test plan
- [x] \`npm install bodhi-realtime-agent\` completes cleanly
- [x] Lockfile diff is a single \`resolved\` SHA change on the bodhi entry
- [ ] Post-merge: restart voice-agent + conversation-server, watch for 0× \`FATAL.*CLOSED → RECONNECTING\` in the next hour of voice-agent.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)