### PR TITLE
feat(voice-agent): wire bodhi onTurnLatency for ICLR observability

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -624,6 +624,19 @@ async function main() {
 				voiceEvents.push({ event: `error:${e.component}:${e.error.message}`, timestamp: new Date().toISOString() });
 				console.error(`${ts()} [Error] ${e.component}: ${e.error.message} (${e.severity})`);
 			},
+			onTurnLatency: (e) => {
+				const total = e.segments.totalE2EMs;
+				const slow = total > 1500;
+				const tag = slow ? '[Latency:SLOW]' : '[Latency]';
+				const parts = [`t=${total}ms`];
+				if (e.segments.geminiProcessingMs != null) parts.push(`gemini=${e.segments.geminiProcessingMs}ms`);
+				if (e.segments.clientToBackendMs != null) parts.push(`c2b=${e.segments.clientToBackendMs}ms`);
+				if (e.segments.backendToGeminiMs != null) parts.push(`b2g=${e.segments.backendToGeminiMs}ms`);
+				if (e.segments.geminiToBackendMs != null) parts.push(`g2b=${e.segments.geminiToBackendMs}ms`);
+				if (e.segments.backendToClientMs != null) parts.push(`b2c=${e.segments.backendToClientMs}ms`);
+				console.log(`${ts()} ${tag} turn=${e.turnId} ${parts.join(' ')}`);
+				if (slow) voiceEvents.push({ event: `slow_turn:${total}ms`, timestamp: new Date().toISOString() });
+			},
 		},
 	});
 


### PR DESCRIPTION
## Summary
- Wire bodhi's `onTurnLatency` hook into VoiceSession hooks
- Emit per-turn `[Latency]` / `[Latency:SLOW]` log lines (threshold 1500ms)
- Record `slow_turn:{ms}` into voiceEvents for session metrics
- 13-line addition, zero behavior change to existing paths

## Motivation
Deliverable #4 from the Mini overnight-ICLR split (pass 429 of build_log). Original phrasing was "1-minute tail script flagging round-trips >1.5s"; in practice the missing piece was the log format, not the tail. Grep on the `Latency:SLOW` tag is enough for live triage during the talk.

Current voice-agent.log has no latency instrumentation of any kind — 0 lines match `latency|round.?trip|response.?time`. Bodhi already computes full segment breakdowns (`totalE2EMs`, `geminiProcessingMs`, `clientToBackendMs`, `backendToGeminiMs`, `geminiToBackendMs`, `backendToClientMs`) but until now the hook was unwired.

## Example output
```
04:12:03.451 [Latency] turn=t_8fj3 t=842ms gemini=720ms c2b=18ms b2g=12ms g2b=9ms b2c=83ms
04:13:11.109 [Latency:SLOW] turn=t_9ak1 t=2103ms gemini=1980ms c2b=22ms b2g=14ms g2b=11ms b2c=76ms
```

Live triage during the talk:
```
tail -f logs/voice-agent.log | grep --line-buffered 'Latency:SLOW'
```

Post-talk analysis:
```
grep Latency logs/voice-agent.log | awk -F't=' '{print $2}' | awk '{print $1}' | sort -n | tail
```

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 71/71 passing
- [x] Hook is additive; zero impact on existing hooks (onError etc still function)
- [ ] Post-merge: restart voice-agent, confirm `[Latency]` line appears on first turn

## Out of scope (possible follow-ups)
- Configurable threshold (1500ms hard-coded — revisit if owner wants tighter bar for rehearsal)
- Phone path observability (`conversation-server.ts` does not import this hook — separate PR if needed; phone is tighter anyway)
- Structured JSON logging (keep plaintext for grep-friendliness)

## Mini overnight ICLR progress
- #411: presenter-mode.sh (awaiting merge)
- #412: stage-readiness.sh (awaiting merge)
- #413 (this): latency observability
- Opener audio pre-cache — deferred (voice-mismatch problem: Cartesia fallback wouldn't match Gemini native audio voice, likely noticed by audience; not an improvement over live failure handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)