### PR TITLE
fix(startup): portable in-place sed for .env rewrite

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -230,9 +230,13 @@ elif grep -q "TWILIO_ACCOUNT_SID=" .env 2>/dev/null; then
     sleep 3
     NGROK_URL=$(curl -s http://localhost:4040/api/tunnels 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['tunnels'][0]['public_url'])" 2>/dev/null || echo "")
     if [ -n "$NGROK_URL" ]; then
-      # Update WEBHOOK_BASE_URL in .env
+      # Update WEBHOOK_BASE_URL in .env — portable in-place edit.
+      # `sed -i ''` is BSD-only; on Macs with Homebrew gnu-sed in PATH it
+      # silently fails (treats '' as an input filename). tmpfile + mv works
+      # on both. See #412 cold-review for the coreutils-in-PATH context.
       if grep -q "WEBHOOK_BASE_URL=" .env; then
-        sed -i '' "s|WEBHOOK_BASE_URL=.*|WEBHOOK_BASE_URL=$NGROK_URL|" .env
+        tmpfile=$(mktemp)
+        sed "s|WEBHOOK_BASE_URL=.*|WEBHOOK_BASE_URL=$NGROK_URL|" .env > "$tmpfile" && mv "$tmpfile" .env
       else
         echo "WEBHOOK_BASE_URL=$NGROK_URL" >> .env
       fi


### PR DESCRIPTION
## Summary
- `sed -i '' ...` at `src/startup.sh:235` is BSD-only — silently fails on Macs with Homebrew gnu-sed in PATH
- Replace with `tmpfile + mv` pattern, portable across BSD and GNU sed
- 1 file, +6/-2

## Context
Same class as PR #412 cold-review findings (`stat -f %m`, `df -g`). On a Mac with Homebrew coreutils + gnu-sed in PATH ahead of BSD sed, `sed -i ''` interprets `''` as an input filename rather than the in-place argument, so the `.env` WEBHOOK_BASE_URL rewrite silently doesn't happen. Next `src/startup.sh` run would launch services pointed at a stale ngrok URL.

## Fix
```diff
-        sed -i '' "s|WEBHOOK_BASE_URL=.*|WEBHOOK_BASE_URL=$NGROK_URL|" .env
+        tmpfile=$(mktemp)
+        sed "s|WEBHOOK_BASE_URL=.*|WEBHOOK_BASE_URL=$NGROK_URL|" .env > "$tmpfile" && mv "$tmpfile" .env
```

No `-i` flag at all — tmpfile + mv is portable everywhere.

## Cross-repo audit
Grepped `sed -i ''` and `stat -f` across `**/*.sh`:
- ✅ `scripts/stage-readiness.sh` — already fixed in `5d7eaaf` (the `stat_mtime()` helper).
- 🔴 `src/startup.sh:235` — **this PR**.
- ⚠️ `src/migrate-plists-to-logs-dir.sh:69-70, 111` — MacBook flagged dormant in their pass 175 cold-review. One-shot migration already run, no active callers. Not bundling per `feedback_pr_restraint`; fix when the file is next touched.

## Test plan
- [x] `bash -n src/startup.sh` — syntax clean
- [ ] Post-merge: run `bash src/startup.sh` on a machine with gnu-sed in PATH (either Mac), verify `.env` gets rewritten with the new NGROK_URL
- [ ] (Optional) mini regression test: `cat > /tmp/env.test <<< 'WEBHOOK_BASE_URL=old' && tmpfile=$(mktemp) && sed 's|WEBHOOK_BASE_URL=.*|WEBHOOK_BASE_URL=new|' /tmp/env.test > "$tmpfile" && mv "$tmpfile" /tmp/env.test && cat /tmp/env.test` should print `WEBHOOK_BASE_URL=new`

🤖 Generated with [Claude Code](https://claude.com/claude-code)