### PR TITLE
fix(subprocess): use sys.executable instead of bare python3 in launchd-managed services

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -781,9 +781,12 @@ async def poll_dm_fallback():
                     continue
                 # Subprocess out to the shared CLI tool so there's only one
                 # code path for the voiceConnected check + DM send.
+                # Use sys.executable: under launchd (discord-bridge is launchd-managed),
+                # bare `python3` may resolve to a different interpreter than the one
+                # running the bridge, or fail with "command not found" on minimal PATH.
                 try:
                     result = subprocess.run(
-                        ["python3", str(REPO / "src" / "dm-result.py"), "--file", str(f)],
+                        [sys.executable, str(REPO / "src" / "dm-result.py"), "--file", str(f)],
                         capture_output=True, text=True, timeout=15,
                     )
                 except Exception as e:

--- a/src/friction-detector.py
+++ b/src/friction-detector.py
@@ -13,6 +13,7 @@ Output: results/friction-{date}.txt
 
 import json
 import os
+import sys
 import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -129,8 +130,11 @@ def check_overdue_reminders():
         script = WORKSPACE.parent.parent / ".claude" / "skills" / "macos-tools" / "scripts" / "reminders.py"
         if not script.exists():
             return []
+        # Use sys.executable: friction-detector runs via cron (launchd-managed);
+        # bare `python3` can resolve to a different interpreter on minimal PATH.
+        # See feedback_subprocess_sys_executable.md.
         result = subprocess.run(
-            ["python3", str(script), "list"],
+            [sys.executable, str(script), "list"],
             capture_output=True, text=True, timeout=10
         )
         if result.returncode == 0:


### PR DESCRIPTION
## Summary
Two Python files invoked subprocess with bare `python3`, which can fail or resolve to the wrong interpreter under launchd-managed services:

- `src/discord-bridge.py:786` → invokes `dm-result.py` (DM fallback when voice is disconnected). discord-bridge IS launchd-managed.
- `src/friction-detector.py:133` → invokes `macos-tools/scripts/reminders.py` list command. friction-detector fires via launchd cron.

## Fix
Pass `sys.executable` to `subprocess.run` instead of bare `"python3"`. Same pattern established in `src/agent-api.py`, `src/dashboard.py`, `src/health-check.py`.

## Diff
+9/-2, 2 files.

## Motivation
Following [Mini's PR #414](https://github.com/sonichi/sutando/pull/414) pattern on portability-under-launchd. Same class: a script that works in the dev shell (where PATH is rich) can silently fail under launchd (where PATH is minimal) or use a different Python version than the parent process.

This enforces the rule in `feedback_subprocess_sys_executable.md`: "Use sys.executable not bare python3 in subprocess calls from launchd-managed services."

Also audited the rest of `src/*.py` for the same pattern — these were the only 2 sites that needed fixing.

## Test plan
- [x] `ast.parse` clean on both modified files
- [x] Inline comments explain why `sys.executable` instead of `python3` at each site
- [ ] Post-merge: launchd-managed discord-bridge continues to process DM fallback tasks (empirical — if you're getting DMs from Sutando when voice is disconnected, the fix works)
- [ ] Post-merge: friction-detector cron continues to list overdue reminders (cron fires every ~30min)

## Not in scope
- `src/migrate-plists-to-logs-dir.sh:69,111` flagged as dormant in pass 175 cold-review (one-shot migration, no active callers). Leaving for bundling with future script-touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)