### PR TITLE
fix(daily-insight): survive dm-fallback unlink via state/ sentinel

### DIFF
--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -15,6 +15,7 @@ from pathlib import Path
 WORKSPACE = Path(__file__).parent.parent
 CALLS_FILE = WORKSPACE / "results" / "calls" / "calls.jsonl"
 RESULTS_DIR = WORKSPACE / "results"
+STATE_DIR = WORKSPACE / "state"
 NOTES_DIR = WORKSPACE / "notes"
 
 
@@ -185,15 +186,21 @@ def generate_insight():
 def main():
     today = datetime.now().strftime("%Y-%m-%d")
     output_path = RESULTS_DIR / f"insight-{today}.txt"
+    # Sentinel survives discord-bridge's `dm-fallback` unlink of the
+    # results file, so repeat invocations (morning-briefing, cron, manual
+    # test) on the same day don't regenerate + re-DM the insight.
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    sentinel = STATE_DIR / f"daily-insight-{today}.sentinel"
 
-    # Don't regenerate if already done today
-    if output_path.exists():
-        print(f"Insight already generated today: {output_path}")
-        print(output_path.read_text())
+    if sentinel.exists():
+        cached = sentinel.read_text()
+        print(f"Insight already generated today (sentinel: {sentinel})")
+        print(cached)
         return
 
     insight = generate_insight()
     output_path.write_text(insight)
+    sentinel.write_text(insight)
     print(f"Daily insight → {output_path}")
     print(insight)
 


### PR DESCRIPTION
## Summary
- Observed today: owner received **3 duplicate DMs** of the same daily insight within a couple of hours because `discord-bridge.py:poll_dm_fallback` unlinks the results file after successful DM — and `daily-insight.py:190` used that file as its idempotency marker.
- Fix: write a sentinel to `state/daily-insight-{date}.sentinel` which no other service touches. Results file remains the delivery payload; sentinel is the "already ran today" marker.
- `state/` is already in use for `presenter-mode.sentinel` + `discord-pending-replies.json`.

## Test plan
- [x] First invocation: writes both `results/insight-{today}.txt` + `state/daily-insight-{today}.sentinel`, exits 0 with insight on stdout.
- [x] Second invocation same day: sees sentinel, prints cached content, exits 0, does NOT rewrite results file.
- [x] Syntax check: `python3 -c "import ast; ast.parse(...)"` clean.
- [ ] End-to-end on production: after merge + cron re-fires tomorrow, confirm a single DM per day (not 3).

## Context
Caught during pass-560 of Mini's proactive loop while investigating why `results/insight-2026-04-17.txt` appeared twice in `discord-bridge.log`'s `[dm-fallback] sent` lines. Root cause is straightforward: cache invalidation via unlink defeats the existing idempotency check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)