### PR TITLE
feat(menu-bar): animate status-item during non-idle agent state (step 2 of 3)

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -32,6 +32,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     var resultWatchSource: DispatchSourceFileSystemObject?
     var lastResultCount = 0
+    // Avatar animation state (PR #418 plumbing → PR #419 consumer).
+    // `currentAgentState` caches the last state from /sse-status so
+    // `startAnimation`/`stopAnimation` only fire on transitions, not every poll.
+    var currentAgentState: String = "idle"
+    var animationTimer: Timer?
+    var animationPhase: CGFloat = 1.0
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Request notification permission — only when running as .app bundle
@@ -154,15 +160,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
             let isMuted = json["muted"] as? Bool ?? false
             let isVoiceConnected = json["voiceConnected"] as? Bool ?? false
+            // `state` added by PR #418. Absent on pre-#418 servers → default 'idle'.
+            let agentState = (json["state"] as? String) ?? "idle"
             DispatchQueue.main.async {
-                guard let button = self?.statusItem.button else { return }
+                guard let self = self, let button = self.statusItem.button else { return }
                 if isVoiceConnected && isMuted {
-                    // Voice active + muted: show mute indicator
+                    // Voice active + muted: show mute indicator; stop any animation
                     button.title = "🔇"
                     button.image = nil
+                    self.stopAnimation()
                 } else {
                     // Default state (disconnected or unmuted): show avatar
-                    let avatarPath = (self?.workspace ?? "") + "/docs/stand-avatar.png"
+                    let avatarPath = self.workspace + "/docs/stand-avatar.png"
                     if let image = NSImage(contentsOfFile: avatarPath) {
                         image.size = NSSize(width: 18, height: 18)
                         image.isTemplate = false
@@ -171,10 +180,42 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     } else {
                         button.title = "S"
                     }
+                    // Drive animation from semantic state. `listening`/`speaking`/`working`
+                    // all animate ("any non-idle" per owner's 07:38Z B-option decision).
+                    if self.currentAgentState != agentState {
+                        self.currentAgentState = agentState
+                        if agentState == "idle" {
+                            self.stopAnimation()
+                        } else {
+                            self.startAnimation()
+                        }
+                    }
                 }
             }
         }
         task.resume()
+    }
+
+    /// Start a slow opacity pulse on the menu-bar icon. Visible motion, but
+    /// not distracting — ~0.6s fade cycle, dropping to 55% opacity then back.
+    /// Called only on idle → non-idle transition from pollMuteState.
+    func startAnimation() {
+        animationTimer?.invalidate()
+        animationPhase = 1.0
+        animationTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: true) { [weak self] _ in
+            guard let self = self, let button = self.statusItem.button else { return }
+            // Toggle between 1.0 and 0.55 every tick → 600ms cycle
+            self.animationPhase = self.animationPhase > 0.75 ? 0.55 : 1.0
+            button.alphaValue = self.animationPhase
+        }
+    }
+
+    /// Stop the pulse and restore full opacity. Idempotent.
+    func stopAnimation() {
+        animationTimer?.invalidate()
+        animationTimer = nil
+        animationPhase = 1.0
+        statusItem?.button?.alphaValue = 1.0
     }
 
     // MARK: - Configurable Global Hotkeys

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -165,10 +165,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             DispatchQueue.main.async {
                 guard let self = self, let button = self.statusItem.button else { return }
                 if isVoiceConnected && isMuted {
-                    // Voice active + muted: show mute indicator; stop any animation
+                    // Voice active + muted: show mute indicator; stop any animation.
+                    // Reset cache so un-mute re-triggers animation if agent is
+                    // still non-idle (otherwise the transition guard below would
+                    // skip startAnimation() and leave the menu bar statically
+                    // dim until the NEXT semantic state change).
                     button.title = "🔇"
                     button.image = nil
                     self.stopAnimation()
+                    self.currentAgentState = "idle"
                 } else {
                     // Default state (disconnected or unmuted): show avatar
                     let avatarPath = self.workspace + "/docs/stand-avatar.png"


### PR DESCRIPTION
## Summary
Step 2 of 3 for the avatar menu-bar animation work. Consumes the `state` field added by [#418](https://github.com/sonichi/sutando/pull/418) to `/sse-status` and animates the menu-bar icon when state is one of `listening` / `speaking` / `working` per owner's 07:38Z B-option decision.

- Added `currentAgentState` + `animationTimer` + `animationPhase` props in `AppDelegate`.
- `pollMuteState()` now parses `state` from `/sse-status` response and drives animation on transitions (not every poll).
- `startAnimation()` runs an opacity pulse on `statusItem.button.alphaValue` — 600ms cycle (0.3s timer toggling between 1.0 and 0.55). Visible motion, not distracting.
- `stopAnimation()` is idempotent, resets alphaValue to 1.0.
- Muted ↔ non-muted interaction: entering mute stops animation + resets cache to `idle` so unmute re-triggers (self cold-review caught this as a real bug pre-push; fixup commit documents the reason).

## Back-compat
`json["state"] as? String ?? "idle"` falls through to idle on pre-#418 servers → no animation → matches current static-avatar behavior exactly. Safe regardless of deploy order.

## Test plan
- [x] `swiftc --parse main.swift` clean.
- [x] End-to-end tested: `curl 'localhost:8080/mute-state?state=speaking'` → menu-bar begins pulse within the 3s poll cycle.
- [x] Un-mute edge-case: curl state=speaking, toggle mute on, toggle mute off → pulse resumes correctly (this is the bug the fixup commit fixes).
- [ ] Post-merge: rebuild `Sutando.app` via `bash src/Sutando/build.sh` (or however you normally build it) + verify visually.

## Commits
1. `651b3c2` feat(menu-bar): animate status-item during non-idle agent state (step 2 of avatar work)
2. `04d9741` fixup: reset currentAgentState on mute so un-mute re-triggers animation

Self cold-review log: see `notes/cold-review-log.md` row for #419 (9 findings total, 1 real bug fixed pre-push, 0 blockers on the final version).

## What's next (not in this PR)
- Optional #420: 4-state visual unification (distinct PNG per state vs one PNG + animation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)