### PR TITLE
docs(README): add "Claude subscription is enough" line above Quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ They communicate through files: voice agent writes tasks, the core agent execute
 
 ## Quick start
 
+You don't need to buy extra usage — Sutando runs on your existing Claude subscription.
+
 **Prerequisites:**
 - macOS 15+
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) (run `claude` once to complete login)


### PR DESCRIPTION
## Summary
Adds one-line reassurance above the Prerequisites block per owner + Susan's 18:45Z discussion in #dev. Susan proposed the line; owner picked the tighter variant.

**Added line** (above Prerequisites, just after `## Quick start`):

> You don't need to buy extra usage — Sutando runs on your existing Claude subscription.

## Why
Addresses a common cost objection during setup — new users often assume they need to budget extra API spend beyond their existing Claude Max/Pro plan.

## Test plan
- [x] `git diff --stat` → 1 file changed, 2 insertions.
- [ ] Render check: line appears above `**Prerequisites:**` on GitHub README view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)