### PR TITLE
test(agent-state): integration coverage for /sse-status + /mute-state (PR #418/#419 follow-up)

### DIFF
--- a/tests/agent-state-endpoint.test.ts
+++ b/tests/agent-state-endpoint.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn, ChildProcess } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+
+// Integration test for PR #418 / #419 agent-state plumbing.
+// Spawns web-client.ts on a random port, exercises /sse-status + /mute-state,
+// asserts the `state` field flows through the 4-value enum + rejects invalid
+// values. Prevents regression of the avatar-animation chain that shipped
+// 2026-04-17 (web-client step 1 of 3, no test coverage at merge time).
+
+const PORT = 18081; // well above the 8080 dev server + 9900 voice-agent
+
+let child: ChildProcess;
+
+async function fetchJson(path: string): Promise<any> {
+	const res = await fetch(`http://localhost:${PORT}${path}`);
+	return res.json();
+}
+
+describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
+	before(async () => {
+		child = spawn(
+			'npx',
+			['tsx', 'src/web-client.ts'],
+			{
+				env: { ...process.env, CLIENT_PORT: String(PORT), PORT: '19900', CLIENT_HOST: '127.0.0.1' },
+				stdio: 'pipe',
+			}
+		);
+		// Wait up to 10s for server to start listening.
+		const deadline = Date.now() + 10_000;
+		while (Date.now() < deadline) {
+			try {
+				const res = await fetch(`http://localhost:${PORT}/sse-status`);
+				if (res.ok) return;
+			} catch { /* not ready */ }
+			await delay(200);
+		}
+		throw new Error('web-client did not start within 10s');
+	});
+
+	after(() => {
+		if (child && !child.killed) child.kill('SIGTERM');
+	});
+
+	it('default /sse-status returns state:"idle"', async () => {
+		const body = await fetchJson('/sse-status');
+		assert.equal(body.state, 'idle');
+		assert.equal(body.muted, false);
+		assert.equal(body.voiceConnected, false);
+		assert.equal(typeof body.clients, 'number');
+	});
+
+	it('accepts all 4 valid agent states', async () => {
+		for (const state of ['idle', 'listening', 'speaking', 'working']) {
+			const body = await fetchJson(`/mute-state?state=${state}`);
+			assert.equal(body.state, state, `POST state=${state} should echo back`);
+			// Verify persistence: /sse-status returns the same.
+			const status = await fetchJson('/sse-status');
+			assert.equal(status.state, state, `/sse-status should reflect ${state}`);
+		}
+	});
+
+	it('rejects invalid agent state (keeps previous value)', async () => {
+		// Set a known baseline
+		await fetchJson('/mute-state?state=listening');
+		// Try invalid
+		const body = await fetchJson('/mute-state?state=bogus');
+		assert.equal(body.state, 'listening', 'invalid value should not overwrite');
+		const status = await fetchJson('/sse-status');
+		assert.equal(status.state, 'listening');
+	});
+
+	it('mute/voice params continue working independently of state', async () => {
+		const body = await fetchJson('/mute-state?muted=true&voice=true&state=working');
+		assert.equal(body.muted, true);
+		assert.equal(body.voiceConnected, true);
+		assert.equal(body.state, 'working');
+	});
+});


### PR DESCRIPTION
## Summary
PR #418/#419 shipped the avatar-animation chain with zero test coverage. This adds a spawn-based integration test on a private port (18081) covering the full `state` endpoint contract the menu-bar consumer depends on.

Owner's "find work to do" task this afternoon — concrete reliability work that directly hardens yesterday's ship.

## Coverage

4 test cases, ~450ms total:
- default `/sse-status` returns `state:"idle"` + expected fields
- all 4 valid states (`idle`/`listening`/`speaking`/`working`) echo + persist across `/mute-state` → `/sse-status`
- invalid state value (e.g. `bogus`) is rejected; previous value preserved
- mute + voice query params remain independent of state

## Shape

- Uses `node:test` + `node:assert/strict` matching the existing `tests/twilio-signature.test.ts` pattern.
- Spawns `npx tsx src/web-client.ts` as a subprocess with `CLIENT_PORT=18081` + `PORT=19900` to avoid collision with the dev server on 8080/9900.
- Readiness poll: up to 10s for server to start listening.
- `after()` kills the child with SIGTERM.

## Test plan
- [x] `npx tsx --test tests/agent-state-endpoint.test.ts` → 4/4 pass, ~450ms.
- [x] Full suite still green: `npx tsx --test tests/*.test.ts` → 75/75 pass, no regressions.
- [x] `npx tsc --noEmit` clean.

## Why it matters
If the web-client ever drops or mistypes the `state` field (e.g. refactor changes the query-param enum or drops validation), this catches it in CI instead of in production via a silent menu-bar static-avatar that only manifests when you engage voice + watch the menu bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)