### PR TITLE
fix(bridges): clean up task+result files on [no-send]/[REPLIED] skip

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -632,9 +632,16 @@ async def poll_results():
                 reply_text = result_file.read_text().strip()
                 channel = pending_replies.pop(task_id)
                 save_pending_replies()
-                # Skip sending if already replied directly (core agent used MCP)
+                # Skip sending if already replied directly (core agent used MCP).
+                # Clean up the result AND task files so the watcher doesn't
+                # re-fire infinitely on the leftover task. Observed 2026-04-17:
+                # `[no-send]` tasks persisted in tasks/ because `continue`
+                # skipped the cleanup block at the bottom of this loop.
                 if reply_text.startswith('[no-send]') or reply_text.startswith('[REPLIED]'):
                     print(f"  Skipped (already replied): {task_id}")
+                    result_file.unlink(missing_ok=True)
+                    task_file = TASKS_DIR / f"{task_id}.txt"
+                    task_file.unlink(missing_ok=True)
                     continue
                 try:
                     # Extract file paths: [file: /path] or [send: /path]

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -262,9 +262,14 @@ def main():
             if result_file.exists():
                 reply_text = result_file.read_text().strip()
                 chat_id = pending_replies.pop(task_id)
-                # Skip sending if already replied directly
+                # Skip sending if already replied directly.
+                # Clean up both files so watcher doesn't re-fire on leftover
+                # task — same bug class as discord-bridge had.
                 if reply_text.startswith('[no-send]') or reply_text.startswith('[REPLIED]'):
                     print(f"  Skipped (already replied): {task_id}")
+                    result_file.unlink(missing_ok=True)
+                    task_file = TASKS_DIR / f"{task_id}.txt"
+                    task_file.unlink(missing_ok=True)
                     continue
                 try:
                     send_reply(chat_id, reply_text)


### PR DESCRIPTION
## Summary
Both Discord + Telegram bridges had the same bug: `[no-send]` / `[REPLIED]` result markers were correctly skipped (no Discord/Telegram send), but `continue` landed ABOVE the cleanup block so the task + result files persisted. Watcher (`fswatch tasks/`) re-fires on every stale task file, so the core agent re-reads and re-processes the same task indefinitely.

## Fix
5 lines added to each bridge before the `continue` — same `unlink()` pair that runs on the normal send path.

**Before:**
```python
if reply_text.startswith('[no-send]') or reply_text.startswith('[REPLIED]'):
    print(f"  Skipped (already replied): {task_id}")
    continue  # ← `continue` skips the cleanup block at loop end
```

**After:**
```python
if reply_text.startswith('[no-send]') or reply_text.startswith('[REPLIED]'):
    print(f"  Skipped (already replied): {task_id}")
    result_file.unlink(missing_ok=True)
    task_file = TASKS_DIR / f"{task_id}.txt"
    task_file.unlink(missing_ok=True)
    continue
```

## Impact
Discovered 2026-04-17 in pass 557 (deferred at the time under PR-restraint). Worked around manually this session via `rm tasks/task-*.txt` on known-processed tasks. Landing this fix removes the manual cleanup.

## Test plan
- [x] Syntax check both files (`python3 -c "import ast; ast.parse(...)"`).
- [x] Branch diff reviewed: 14 insertions / 2 deletions across 2 files, nothing else touched.
- [ ] Post-merge: verify next `[no-send]` task cleans up automatically (e.g., task routed to Mini via bridge where access-tier mismatch + owner answers directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)