### PR TITLE
fix(archive-stale-results): case-insensitive DRY_RUN env check

### DIFF
--- a/src/archive-stale-results.py
+++ b/src/archive-stale-results.py
@@ -35,7 +35,10 @@ REPO = Path(__file__).resolve().parent.parent
 RESULTS = REPO / "results"
 
 RETENTION_HOURS = int(os.environ.get("RETENTION_HOURS", "24"))
-DRY_RUN = os.environ.get("DRY_RUN", "").strip() not in ("", "0", "false", "no")
+# Case-insensitive compare — without `.lower()`, `DRY_RUN=No` or `DRY_RUN=FALSE`
+# would silently evaluate truthy (dry-run mode) because "No"/"FALSE" aren't in
+# the lowercase reject list. Found in cold-review of #354.
+DRY_RUN = os.environ.get("DRY_RUN", "").strip().lower() not in ("", "0", "false", "no")
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
One-line fix + 3-line comment. Adds `.lower()` before the case-sensitive reject-list comparison on `DRY_RUN` environment variable.

**Bug**: `DRY_RUN=No` or `DRY_RUN=FALSE` (uppercase falsy forms) silently evaluate truthy because "No" / "FALSE" aren't in the lowercase reject list — user types "No" expecting non-dry-run, gets dry-run silently, files never archived.

**Fix**: `.strip().lower()` before `not in ("", "0", "false", "no")`.

## Why now
- Identified in cold-review of #354, logged at `notes/cold-review-log.md:17` as "1-line follow-up PR candidate".
- Owner pushed "find work to do" this afternoon — this is exactly the kind of latent-but-trivially-fixable reliability gap that's worth clearing rather than letting accumulate.

## Scope
- Currently latent: `startup.sh` doesn't set `DRY_RUN` so the empty-string path is taken, which was the motivation for not fixing earlier under PR-restraint.
- Anyone manually invoking with mixed-case falsy (common mistake) silently gets dry-run.

## Test plan
- [x] All 4 cases verified manually:
  - `DRY_RUN=No` → False ✓
  - `DRY_RUN=FALSE` → False ✓
  - `DRY_RUN=1` → True ✓
  - `DRY_RUN=yes` → True ✓
- [x] Python syntax check clean.
- [x] 1-file diff, +4/-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)