### PR TITLE
feat(agent-state): add 'seeing' for screen-capture visibility

### DIFF
--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -11,6 +11,7 @@ import http.server
 import subprocess
 import json
 import os
+import threading
 import urllib.request
 from datetime import datetime
 
@@ -22,14 +23,22 @@ DIR = "/tmp/sutando-screenshots"
 WEB_CLIENT_STATE_URL = "http://localhost:8080/mute-state?state=seeing&ttl_ms=1500"
 
 
-def _signal_seeing():
-    """Best-effort POST to web-client signaling agent is looking at the screen.
-    Silent on any failure — this is a UI signal, not a critical path."""
+def _signal_seeing_blocking():
     try:
         req = urllib.request.Request(WEB_CLIENT_STATE_URL, method="GET")
         urllib.request.urlopen(req, timeout=0.3)
     except Exception:
         pass  # Web-client may not be running; that's fine.
+
+
+def _signal_seeing():
+    """True fire-and-forget POST to web-client signaling agent is looking
+    at the screen. Spawns a daemon thread so the capture handler isn't
+    blocked by web-client latency. Silent on any failure — this is a UI
+    signal, not a critical path. Without threading, urllib.request.urlopen
+    is synchronous and can block the caller up to the 300ms timeout if the
+    web-client is slow (flagged in #428 cold-review)."""
+    threading.Thread(target=_signal_seeing_blocking, daemon=True).start()
 
 class Handler(http.server.BaseHTTPRequestHandler):
     def log_message(self, fmt, *args): pass

--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -11,16 +11,34 @@ import http.server
 import subprocess
 import json
 import os
+import urllib.request
 from datetime import datetime
 
 PORT = 7845
 DIR = "/tmp/sutando-screenshots"
+# Web-client endpoint for agent-state reporting. When a /capture happens we
+# flash state=seeing on the menu-bar avatar for ~1.5s — makes screen-capture
+# visible to the user without them needing to watch the web UI.
+WEB_CLIENT_STATE_URL = "http://localhost:8080/mute-state?state=seeing&ttl_ms=1500"
+
+
+def _signal_seeing():
+    """Best-effort POST to web-client signaling agent is looking at the screen.
+    Silent on any failure — this is a UI signal, not a critical path."""
+    try:
+        req = urllib.request.Request(WEB_CLIENT_STATE_URL, method="GET")
+        urllib.request.urlopen(req, timeout=0.3)
+    except Exception:
+        pass  # Web-client may not be running; that's fine.
 
 class Handler(http.server.BaseHTTPRequestHandler):
     def log_message(self, fmt, *args): pass
 
     def do_GET(self):
         if self.path.startswith("/capture"):
+            # Flash agent-state=seeing on the menu-bar avatar for ~1.5s.
+            # Non-blocking fire-and-forget; capture succeeds regardless.
+            _signal_seeing()
             os.makedirs(DIR, exist_ok=True)
             ts = datetime.now().strftime("%Y%m%d-%H%M%S")
             # Parse display number from query: /capture?display=2 or /capture?all=true

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -1917,8 +1917,14 @@ let _voiceState = false;
 // to decide when to animate (any non-'idle' value). Derivation happens in
 // the browser where the signals live (audio RMS, core-status, mute, voice);
 // the server just caches the last-reported value.
-type AgentState = 'idle' | 'listening' | 'speaking' | 'working';
+type AgentState = 'idle' | 'listening' | 'speaking' | 'working' | 'seeing';
 let _agentState: AgentState = 'idle';
+// Timestamp of the last transition INTO 'seeing'. Screen capture is transient
+// (sub-second), so we want the 'seeing' state to flash briefly then auto-revert
+// to whatever the prior state was. Without auto-revert, a single /capture call
+// pins state=seeing forever if nothing else POSTs.
+let _seeingUntil = 0;
+let _preSeeingState: AgentState = 'idle';
 
 // Heartbeat: ping every 30s, remove clients that fail to write (stale connections)
 setInterval(() => {
@@ -1952,6 +1958,12 @@ const server = createServer((req, res) => {
 
 	// SSE client count + mute/voice/agent state (safe for diagnostics + menu bar indicator)
 	if (url.pathname === '/sse-status') {
+		// Auto-revert from 'seeing' to the prior state if the flash window expired.
+		// Screen capture + take_screenshot calls are transient; without this,
+		// a single /capture call would pin state=seeing until the next browser POST.
+		if (_agentState === 'seeing' && Date.now() > _seeingUntil) {
+			_agentState = _preSeeingState;
+		}
 		res.writeHead(200, { 'Content-Type': 'application/json' });
 		res.end(JSON.stringify({
 			clients: sseClients.length,
@@ -1969,7 +1981,17 @@ const server = createServer((req, res) => {
 		const aState = url.searchParams.get('state');
 		if (mState !== null) _muteState = mState === 'true';
 		if (vState !== null) _voiceState = vState === 'true';
-		if (aState === 'idle' || aState === 'listening' || aState === 'speaking' || aState === 'working') {
+		if (aState === 'idle' || aState === 'listening' || aState === 'speaking' || aState === 'working' || aState === 'seeing') {
+			// Special handling for 'seeing': remember pre-seeing state so we can
+			// auto-revert. Default flash window is 1.5s unless caller specifies.
+			if (aState === 'seeing') {
+				if (_agentState !== 'seeing') {
+					_preSeeingState = _agentState;
+				}
+				const ttlParam = url.searchParams.get('ttl_ms');
+				const ttl = ttlParam ? parseInt(ttlParam, 10) : 1500;
+				_seeingUntil = Date.now() + (isFinite(ttl) && ttl > 0 ? ttl : 1500);
+			}
 			_agentState = aState;
 		}
 		res.writeHead(200, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
## Summary
Extends `AgentState` enum from 4 to 5 values: adds `'seeing'` — fires when Sutando is actively looking at the screen. Closes the gap that menu-bar avatar (#419) had: pulse works for listening/speaking/working, screen-capture was invisible.

**Scope**: "Full" implementation per owner's 2026-04-17 #dev "Full" greenlight. Not enum-only.

## Changes

1. **`src/web-client.ts`** — AgentState type gains `'seeing'`. `/mute-state` validates the new value. `/sse-status` auto-reverts from `seeing` to `_preSeeingState` when `Date.now() > _seeingUntil`. Default flash TTL 1500ms; callers can override via `?ttl_ms=N`.

2. **`src/screen-capture-server.py`** — `/capture` handler fires a non-blocking best-effort GET to `http://localhost:8080/mute-state?state=seeing&ttl_ms=1500` before running screencapture. 300ms timeout, silent-on-failure.

## Design notes

- **Transient-flash semantics** (vs held state): screen capture is sub-second. Without auto-revert, state=seeing would pin after a single /capture until the next browser POST. Pre-seeing state is captured so the flash "falls back" cleanly.
- **Client-side TTL override** (`?ttl_ms=N`): callers that know their operation is longer than 1.5s (e.g. long browser-automation-with-screenshot) can extend the flash window.
- **Best-effort signal**: screen-capture-server failing to POST doesn't break capture. UI signal is a polish, not a critical path.

## Test plan
- [x] Manual end-to-end on :18082:
  - default → `state:"idle"` ✓
  - POST `?state=listening` → `"listening"` ✓
  - POST `?state=seeing&ttl_ms=500` → `"seeing"` ✓
  - `/sse-status` immediately → `"seeing"` (still in TTL) ✓
  - 600ms wait + `/sse-status` → `"listening"` (auto-reverted) ✓
- [x] `npx tsc --noEmit` clean.
- [x] `python3 -c "import ast; ast.parse(...)"` clean.
- [ ] Post-merge: extend `tests/agent-state-endpoint.test.ts` with 5th-state + TTL-revert case (easier as follow-up on merged #423 lineage than cross-branch now).

## Merge order
1. **#423 first** (tests for 4-state plumbing).
2. **This PR** second. Test extension lands as a follow-up commit on the #423 lineage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)