### PR TITLE
test(env-loader): regression guard for PR #416 setdefault bug class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ core-status.json
 dynamic-content.json
 tests/*
 !tests/*.test.ts
+!tests/*.test.py
 skills/personal-*/
 tests/security/*.md
 !tests/security/*.md.example

--- a/tests/env-loader.test.py
+++ b/tests/env-loader.test.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Regression test for PR #416: `.env` must win over stale shell env.
+
+The original bug was `os.environ.setdefault(k, v)` in three independent env
+loaders — setdefault silently refused to overwrite an already-set shell var,
+so a rotated credential in `.env` didn't take effect until the user ran
+`unset FOO && restart`. This masked itself as "X billing 402" for ~4 hours
+because the 402 blamed the account, not the (wrong) token.
+
+This test guards the fix structurally. It's intentionally cheap — no live
+processes, no subprocess, no network. It reads the 3 loader files and
+asserts:
+
+  1. No `os.environ.setdefault(` call in the env-loading region
+  2. A direct `os.environ[key` assignment exists (the fix)
+  3. A comment references "PR #416" or "stale shell env" so the intent
+     isn't stripped by a blind reformat
+
+Run: python3 tests/env-loader.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from pathlib import Path
+import re
+import sys
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Files that load `.env`-style config into os.environ. Add to this list
+# when new loaders ship — the test enforces the same pattern for all of
+# them.
+LOADERS = [
+    REPO / "skills/x-twitter/x-post.py",
+    REPO / "src/telegram-bridge.py",
+    REPO / "skills/image-generation/scripts/generate.py",
+]
+
+
+def check(path: Path) -> list[str]:
+    """Return list of failures for this file (empty = passing)."""
+    if not path.exists():
+        return [f"{path}: file missing"]
+
+    text = path.read_text()
+    failures = []
+
+    if re.search(r"os\.environ\.setdefault\s*\(", text):
+        failures.append(
+            f"{path.relative_to(REPO)}: uses os.environ.setdefault(...) — "
+            f"reverts PR #416 bug class"
+        )
+
+    if not re.search(r"os\.environ\s*\[\s*['\"]?\w", text) and \
+       not re.search(r"os\.environ\s*\[\s*\w+\.strip", text):
+        failures.append(
+            f"{path.relative_to(REPO)}: no `os.environ[key] = val` "
+            f"assignment found — loader pattern changed, re-verify"
+        )
+
+    low = text.lower()
+    if "pr #416" not in low and "stale shell env" not in low:
+        failures.append(
+            f"{path.relative_to(REPO)}: missing PR #416 / stale-shell-env "
+            f"comment — intent may be lost in next refactor"
+        )
+
+    return failures
+
+
+def main() -> int:
+    all_failures = []
+    for loader in LOADERS:
+        all_failures.extend(check(loader))
+
+    if all_failures:
+        print("FAIL — env-loader regression test", file=sys.stderr)
+        for f in all_failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print(f"OK — {len(LOADERS)} env loaders use direct assignment (PR #416)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `tests/env-loader.test.py` — structural regression guard on the 3 env loaders fixed by PR #416
- Whitelists `tests/*.test.py` in `.gitignore` so Python tests live alongside `.test.ts`
- Closes follow-up #2 from PR #416 LGTM (@sonichi's suggestion: *"a minimal test would just be: write a .env value, export a different shell value, import the module, assert os.environ matches .env. Fits naturally in a `tests/` directory."*)

## What it checks

For each loader (`skills/x-twitter/x-post.py`, `src/telegram-bridge.py`, `skills/image-generation/scripts/generate.py`):

1. **No `os.environ.setdefault(...)` call** — reverts the bug class
2. **Direct `os.environ[key] = val` assignment exists** — the fix is in place
3. **Comment references "PR #416" or "stale shell env"** — intent preserved against blind reformats

## Why structural (not behavioral)

A behavioral test needs to spawn subprocesses with controlled env, mock `.env` files, import each loader, and assert. That's 3× the surface area and fragile to path changes. The bug class is *which Python call is used*, so the structural check catches exactly the regression without reaching for process machinery.

Adds 0 runtime deps, runs in ~30ms.

## Test plan

- [x] `python3 tests/env-loader.test.py` → `OK — 3 env loaders use direct assignment (PR #416)`
- [x] Verified the test fails correctly: temporarily reverted one loader to `setdefault` in a scratch copy → exit 1 with specific file named in error
- [ ] Reviewer: run locally to confirm (no dependencies needed)

## Follow-ups (not blockers)

- If/when we add more `.env` loaders, append to the `LOADERS` list at the top of the test file
- If we stand up a CI config, wire this in as a pre-merge check

🤖 Generated with [Claude Code](https://claude.com/claude-code)