### PR TITLE
fix(bridges): honor presenter-mode sentinel in proactive DM polls

### DIFF
--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -32,6 +32,13 @@ def presenter_mode_active():
         return False
     try:
         expire_iso = PRESENTER_SENTINEL.read_text().strip()
+        # Require an ISO-8601-ish prefix (starts with a digit). Without
+        # this guard, malformed sentinel content like "garbage" compares
+        # LESS than any real now_iso ("2" < "g" in ASCII) and the mode
+        # fails OPEN — appears active forever. The same guard is in
+        # src/discord-bridge.py and src/telegram-bridge.py.
+        if not expire_iso or not expire_iso[0].isdigit():
+            return False
         # Compare as ISO-8601 with Z suffix — sorts correctly as strings.
         now_iso = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
         return now_iso < expire_iso

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -38,6 +38,24 @@ TASKS_DIR.mkdir(exist_ok=True)
 RESULTS_DIR.mkdir(exist_ok=True)
 INBOX_DIR.mkdir(exist_ok=True)
 
+# Presenter mode: when scripts/presenter-mode.sh is active, the bridge
+# must not send proactive DMs to the owner. The sentinel contains an
+# ISO-8601 expiry; see scripts/presenter-mode.sh for the contract.
+# Matches the check in src/check-pending-questions.py — both scripts
+# share the same sentinel path + comparison logic.
+PRESENTER_SENTINEL = REPO / "state" / "presenter-mode.sentinel"
+
+
+def presenter_mode_active():
+    if not PRESENTER_SENTINEL.exists():
+        return False
+    try:
+        expire_iso = PRESENTER_SENTINEL.read_text().strip()
+        now_iso = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+        return now_iso < expire_iso
+    except Exception:
+        return False
+
 # Optional: deterministic ownership for team/other-tier tasks across nodes.
 # When set, only the node whose stand-identity.json `machine` field matches
 # SUTANDO_TEAM_TIER_OWNER will accept non-owner-tier tasks. The other nodes
@@ -667,10 +685,29 @@ async def poll_results():
 
 
 async def poll_proactive():
-    """Poll results/ for proactive messages and send to owner's DM."""
+    """Poll results/ for proactive messages and send to owner's DM.
+
+    When presenter-mode is active, proactive files are retained (not sent,
+    not deleted) so they flush after the talk window ends. This honors
+    the presenter-mode contract: no owner DMs during the presenter window.
+    """
     import re
+    _presenter_log_throttle = 0
     while True:
         try:
+            # Skip sends while presenter-mode is active. Files remain on
+            # disk and are sent on a later tick once the sentinel clears.
+            if presenter_mode_active():
+                _presenter_log_throttle += 1
+                if _presenter_log_throttle % 20 == 1:  # ~once per 60s
+                    pending = sum(
+                        1 for f in RESULTS_DIR.iterdir()
+                        if f.name.startswith("proactive-") and f.suffix == ".txt"
+                    )
+                    print(f"  [proactive] presenter-mode active, {pending} proactive file(s) queued")
+                await asyncio.sleep(3)
+                continue
+            _presenter_log_throttle = 0
             for f in RESULTS_DIR.iterdir():
                 if f.name.startswith("proactive-") and f.suffix == ".txt":
                     text = f.read_text().strip()

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -51,6 +51,12 @@ def presenter_mode_active():
         return False
     try:
         expire_iso = PRESENTER_SENTINEL.read_text().strip()
+        # Require an ISO-8601-ish prefix (starts with a digit). Without
+        # this guard, malformed sentinel content like "garbage" compares
+        # LESS than any real now_iso ("2" < "g" in ASCII) and the mode
+        # fails OPEN — appears active forever.
+        if not expire_iso or not expire_iso[0].isdigit():
+            return False
         now_iso = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
         return now_iso < expire_iso
     except Exception:

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -41,6 +41,22 @@ RESULTS_DIR = REPO / "results"
 TASKS_DIR.mkdir(exist_ok=True)
 RESULTS_DIR.mkdir(exist_ok=True)
 
+# Presenter mode: silence proactive DMs during ICLR/talk windows. Sentinel
+# is written by scripts/presenter-mode.sh with an ISO-8601 expiry. Matches
+# the check in src/check-pending-questions.py and src/discord-bridge.py.
+PRESENTER_SENTINEL = REPO / "state" / "presenter-mode.sentinel"
+
+
+def presenter_mode_active():
+    if not PRESENTER_SENTINEL.exists():
+        return False
+    try:
+        expire_iso = PRESENTER_SENTINEL.read_text().strip()
+        now_iso = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+        return now_iso < expire_iso
+    except Exception:
+        return False
+
 # Load access config
 ACCESS_FILE = Path.home() / ".claude" / "channels" / "telegram" / "access.json"
 def load_allowed():
@@ -236,23 +252,26 @@ def main():
                 # Send typing indicator
                 api("sendChatAction", chat_id=chat_id, action="typing")
 
-        # Check for proactive messages to send to owner
+        # Check for proactive messages to send to owner.
+        # Presenter-mode: retain files (don't unlink, don't send) so they
+        # flush after the talk window ends. See presenter-mode.sh contract.
         try:
-            for f in RESULTS_DIR.iterdir():
-                if f.name.startswith("proactive-") and f.suffix == ".txt":
-                    text = f.read_text().strip()
-                    if not text:
+            if not presenter_mode_active():
+                for f in RESULTS_DIR.iterdir():
+                    if f.name.startswith("proactive-") and f.suffix == ".txt":
+                        text = f.read_text().strip()
+                        if not text:
+                            f.unlink(missing_ok=True)
+                            continue
+                        owner_ids = load_allowed()
+                        if owner_ids:
+                            owner_id = next(iter(owner_ids))
+                            try:
+                                send_reply(int(owner_id), text)
+                                print(f"  [proactive] sent to {owner_id}: {text[:80]}")
+                            except Exception as e:
+                                print(f"  [proactive] failed: {e}")
                         f.unlink(missing_ok=True)
-                        continue
-                    owner_ids = load_allowed()
-                    if owner_ids:
-                        owner_id = next(iter(owner_ids))
-                        try:
-                            send_reply(int(owner_id), text)
-                            print(f"  [proactive] sent to {owner_id}: {text[:80]}")
-                        except Exception as e:
-                            print(f"  [proactive] failed: {e}")
-                    f.unlink(missing_ok=True)
         except Exception as e:
             print(f"  [proactive] poll error: {e}")
 

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -52,6 +52,12 @@ def presenter_mode_active():
         return False
     try:
         expire_iso = PRESENTER_SENTINEL.read_text().strip()
+        # Require an ISO-8601-ish prefix (starts with a digit). Without
+        # this guard, malformed sentinel content like "garbage" compares
+        # LESS than any real now_iso ("2" < "g" in ASCII) and the mode
+        # fails OPEN — appears active forever.
+        if not expire_iso or not expire_iso[0].isdigit():
+            return False
         now_iso = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
         return now_iso < expire_iso
     except Exception:


### PR DESCRIPTION
## Summary

`scripts/presenter-mode.sh`'s docstring promises the bridges go silent during an active presenter window:

> Muted: discord-bridge proactive, check-pending-questions, voice proactive

Only `check-pending-questions.py` actually implemented the check. **Both bridges would still DM the owner mid-talk** if a `results/proactive-*.txt` landed during the presenter window — exactly the audience-visible popup the script was designed to prevent.

Caught by exercising presenter-mode.sh end-to-end as part of the ICLR Apr 26 pre-talk tooling audit (9 days out). Same silent-failure-in-tooling pattern described in [`feedback_exercise_gitignored_tooling.md`](../blob/main/notes/MEMORY.md).

## What changed

- `src/discord-bridge.py`: added `presenter_mode_active()` helper + gated `poll_proactive()` on it. Emits a throttled status log (~once/60s) while muted showing the queued count.
- `src/telegram-bridge.py`: same helper + same gate around the proactive block in the main poll loop.
- Both helpers copied verbatim from `src/check-pending-questions.py:25` so the three call sites share behavior.

**Scope: proactive poll only.** Task replies (results of user-initiated work) and DM processing still run normally — those aren't the popups the contract is trying to prevent.

**Semantics: retain, don't drop.** When presenter-mode is active, proactive files stay on disk and flush on the next poll after the sentinel clears. On a 40-min talk with a 10-min loop interval, that caps the queued backlog at ~4 files.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` — both files syntax-clean
- [x] Manual end-to-end of `presenter-mode.sh` (pass 678 of today's loop): `status` → `start 1` → `status ACTIVE` → `stop` → `status inactive`; stale-sentinel auto-cleanup confirmed by writing a past-dated expiry
- [ ] Reviewer: start presenter-mode, write a `results/proactive-test.txt`, verify Discord doesn't send; stop; verify it flushes
- [ ] Nice-to-have: a behavioral test under `tests/` that stands up the sentinel + triggers the gate. Could piggyback on the PR #431 Python test file whitelist if that lands first

## Non-blockers

- Voice-agent.ts doesn't appear in this PR — it reads `results/question-*.txt` (not proactive) which is written by `check-pending-questions.py`, and that path already honors presenter-mode. The docstring's "voice proactive" line is indirect but correct.
- Same copy-paste `presenter_mode_active()` in 3 files is slightly awkward. A future refactor could pull it into `src/presenter_mode.py` — out of scope for a fix branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)