### PR TITLE
fix(tests): hang-safe teardown for agent-state-endpoint integration test

### DIFF
--- a/tests/agent-state-endpoint.test.ts
+++ b/tests/agent-state-endpoint.test.ts
@@ -25,11 +25,14 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 			['tsx', 'src/web-client.ts'],
 			{
 				env: { ...process.env, CLIENT_PORT: String(PORT), PORT: '19900', CLIENT_HOST: '127.0.0.1' },
-				stdio: 'pipe',
+				// 'ignore' prevents the pipe buffer from filling in CI (stdout isn't drained),
+				// which would block the child and cause the /sse-status poll to time out.
+				stdio: 'ignore',
 			}
 		);
-		// Wait up to 10s for server to start listening.
-		const deadline = Date.now() + 10_000;
+		// Wait up to 20s for server to start listening. CI cold-start on `npx tsx`
+		// with fresh node_modules can take significantly longer than a dev machine.
+		const deadline = Date.now() + 20_000;
 		while (Date.now() < deadline) {
 			try {
 				const res = await fetch(`http://localhost:${PORT}/sse-status`);
@@ -37,11 +40,22 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 			} catch { /* not ready */ }
 			await delay(200);
 		}
-		throw new Error('web-client did not start within 10s');
+		throw new Error('web-client did not start within 20s');
 	});
 
-	after(() => {
-		if (child && !child.killed) child.kill('SIGTERM');
+	after(async () => {
+		// Hang-safe teardown: SIGTERM, wait up to 2s, SIGKILL fallback. Without
+		// awaiting exit, the live child-process handle keeps node --test alive
+		// past the CI job timeout (observed: 9m43s hangs after #423 merged).
+		if (!child || child.killed) return;
+		await new Promise<void>((resolve) => {
+			const hardKill = setTimeout(() => {
+				try { child.kill('SIGKILL'); } catch { /* already dead */ }
+				resolve();
+			}, 2_000);
+			child.once('exit', () => { clearTimeout(hardKill); resolve(); });
+			child.kill('SIGTERM');
+		});
 	});
 
 	it('default /sse-status returns state:"idle"', async () => {


### PR DESCRIPTION
## Summary

PR #423's new integration test hangs in CI — job times out at the 10-minute cap during `npm test` (previously ~1s wall time). Same hang hits every new PR and every subsequent push to main, because all CI runs include this test.

## Diagnosis

```
Run tests: 22:28:38 → 22:38:21   # main run 24589421743 — post-#423
Run tests: 22:28:38 → 22:28:39   # main run 24581693108 — pre-#423
```

Two hang paths combine:

1. **`stdio: 'pipe'` without draining** — CI is noisier than local dev (npm ci, warmup logs). Stdout pipe buffer fills → child blocks → `/sse-status` poll times out. `before()` throws but the child is still alive.
2. **Synchronous `after()`** sends SIGTERM without awaiting exit. The live child-process handle keeps `node --test` alive until CI kills the job.

## Fix

- `stdio: 'ignore'` — buffer can't fill because nothing is captured.
- `after()` becomes async: SIGTERM, wait up to 2s for graceful exit, SIGKILL fallback.
- Bump cold-start wait 10s → 20s. `npx tsx` on fresh node_modules is slower than warm dev; extra 10s is cheap vs. a 10-min job timeout.

## Test plan

- [x] `time npx tsx --test tests/agent-state-endpoint.test.ts` → 4/4 pass, ~0.9s wall, clean exit
- [x] `time npm test` → 75/75 pass, ~0.97s wall, clean exit
- [ ] CI: this PR's own run should now complete in <1 min. If it does, the hypothesis is confirmed.

## Blast radius

Tests-only. No runtime behavior change. Test still exercises exactly the same endpoints with the same assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)