### PR TITLE
fix(web-client): extend note renderer with italic, blockquote, images, links, hr

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -1768,7 +1768,14 @@ function showNoteContent(slug) {
     text = text.replace(codeBlockRe, '<pre style="background:#1a1a2e;padding:8px;border-radius:4px;font-size:12px;overflow-x:auto"><code>$1</code></pre>');
     var inlineCodeRe = new RegExp(String.fromCharCode(96) + '([^' + String.fromCharCode(96) + ']+)' + String.fromCharCode(96), 'g');
     text = text.replace(inlineCodeRe, '<code style="background:#1a1a2e;padding:1px 4px;border-radius:2px">$1</code>');
+    // Images before links: ![alt](url) — else the link regex below eats the alt-text form.
+    text = text.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1" style="max-width:100%;border-radius:4px;margin:8px 0">');
+    text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" style="color:#7c83ff">$1</a>');
+    // Bold before italic: the bold regex eats two asterisks so the italic one sees none.
     text = text.replace(/[*][*](.+?)[*][*]/g, '<strong>$1</strong>');
+    text = text.replace(/(^|[^*])\*([^*\n]+)\*/g, '$1<em>$2</em>');
+    text = text.replace(/^> ?(.+)$/gm, '<blockquote style="border-left:3px solid #7c83ff;padding-left:10px;color:#a0a0b0;margin:8px 0;font-style:italic">$1</blockquote>');
+    text = text.replace(/^---+$/gm, '<hr style="border:none;border-top:1px solid #2a2a3e;margin:12px 0">');
     text = text.replace(/^- (.+)$/gm, '<li>$1</li>');
     text = text.replace(new RegExp('\\n\\n', 'g'), '<br><br>');
     container.innerHTML = '<span class="suggestion" onclick="renderTabContent()" style="font-size:11px;cursor:pointer;margin-bottom:8px;display:inline-block">&larr; Back</span>' +


### PR DESCRIPTION
## Summary

`showNoteContent()` in `src/web-client.ts` shipped a minimal regex markdown → HTML converter: H1–H3, code blocks, inline code, bold, and lists. **Italic, blockquotes, images, links, and horizontal rules all fell through as raw markdown** in the browser.

Hit in practice by the in-progress LinkedIn draft note — its italic signature line and blockquote pull-quotes showed up with literal `*` and `>` characters in the notes drawer.

## What's added

| Pattern | Regex | Output |
|---|---|---|
| `![alt](url)` | `/!\[([^\]]*)\]\(([^)]+)\)/g` | `<img>` |
| `[text](url)` | `/\[([^\]]+)\]\(([^)]+)\)/g` | `<a target="_blank">` |
| `*foo*` | `/(^|[^*])\*([^*\n]+)\*/g` | `<em>` |
| `> line` | `/^> ?(.+)$/gm` | `<blockquote>` (accent border) |
| `---` | `/^---+$/gm` | `<hr>` |

## Order matters

- Images before links — else the link regex matches the `[alt]` portion of `![alt](url)` and eats it.
- Bold before italic — bold consumes its two `*`s, so italic doesn't see them. The italic regex also has a negative lookbehind (`[^*]`) as a belt-and-suspenders guard for any stray `**` the bold pass didn't catch.

## Test plan

- [x] 6-input node --eval check (bold, italic, img, link, blockquote, hr) — all 6 produce expected HTML
- [x] `npm run typecheck` — clean
- [x] `npm test` — 75/75 still pass
- [ ] Reviewer: open the Sutando web UI, click the Notes tab, pick any note with italic / links / quotes — should render, not show raw markdown

## Blast radius

Append-only in the notes drawer renderer — existing patterns unchanged, no new deps. The notes drawer is the only code path that calls `showNoteContent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)