### PR TITLE
fix(stage-readiness): reject malformed presenter-mode sentinel (4th call site of PR #432 bug class)

### DIFF
--- a/scripts/stage-readiness.sh
+++ b/scripts/stage-readiness.sh
@@ -99,11 +99,17 @@ else
 fi
 
 # 5) presenter-mode sentinel
+# Same fail-open bug class as the Python helpers in discord-bridge / telegram-bridge /
+# check-pending-questions (PR #432 fixup). String comparison treats "garbage" as
+# GREATER than any real ISO timestamp — without the digit-prefix guard, malformed
+# sentinel content would appear active forever.
 SENT="$REPO/state/presenter-mode.sentinel"
 if [ -f "$SENT" ]; then
     expire_iso=$(cat "$SENT")
     now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    if [[ "$now_iso" < "$expire_iso" ]]; then
+    if [[ ! "$expire_iso" =~ ^[0-9] ]]; then
+        warn "presenter-mode" "sentinel content malformed — run 'bash scripts/presenter-mode.sh stop' to reset"
+    elif [[ "$now_iso" < "$expire_iso" ]]; then
         pass "presenter-mode" "ACTIVE until $expire_iso (notifications silenced)"
     else
         warn "presenter-mode" "sentinel expired — run 'bash scripts/presenter-mode.sh start' before talk"


### PR DESCRIPTION
## Summary

Same fail-open bug class as [PR #432](../pull/432)'s fixup — the 4th call site of the shared presenter-mode sentinel pattern.

`scripts/stage-readiness.sh` line 106 used `[[ "\$now_iso" < "\$expire_iso" ]]`. The bash string comparison treats any `expire_iso` starting with a non-digit as GREATER than any real ISO timestamp, so a sentinel containing "garbage" would appear to keep presenter-mode ACTIVE forever in the readiness summary.

Caught by exercising `stage-readiness.sh` end-to-end as part of the ongoing ICLR tooling audit (9 days out).

## Fix

Bash regex guard (`=~ ^[0-9]`). On malformed content, emits a WARN instructing the operator to run `presenter-mode.sh stop` to reset.

## Test plan

```bash
echo "garbage" > state/presenter-mode.sentinel
bash scripts/stage-readiness.sh  # → WARN "sentinel content malformed"

rm state/presenter-mode.sentinel
bash scripts/stage-readiness.sh  # → WARN "INACTIVE"
```

Both exercised locally on Mac Mini pass 685.

## Related

- PR #432 — fixes the Python side (discord-bridge, telegram-bridge, check-pending-questions) of the same bug class
- `feedback_unit_test_copied_helpers.md` in memory — codifies the lesson (string-comparison on data that might not be lexicographic-safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)