### PR TITLE
fix(health-check): use correct pgrep pattern for web-client stale check

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -513,7 +513,7 @@ def run_all_checks() -> list[dict]:
 
     web_check = check_port(8080, "web-client")
     if web_check["status"] == "ok":
-        mark_stale_if_outdated(web_check, REPO_DIR / "src" / "web-client.ts", "voice-agent")
+        mark_stale_if_outdated(web_check, REPO_DIR / "src" / "web-client.ts", "web-client.ts")
     checks.append(web_check)
 
     # Optional services (downgrade missing to warning, not failure)


### PR DESCRIPTION
## Summary

One-char fix: `mark_stale_if_outdated(web_check, ..., "voice-agent")` → `"web-client.ts"`.

The web-client stale-check was comparing `src/web-client.ts`'s mtime against the **voice-agent** process's start time. So whenever voice-agent started earlier than a recent web-client edit (virtually always during active development), the check reported web-client stale even when it was fresh.

## Evidence

Just now, post-web-client-restart (3 new PIDs, <5 min old):

```
♻ web-client     stale    running but code is 1166 min newer than process — restart needed
```

1166 min = ~19h, which matches voice-agent's 10:08 PM Apr 16 start time, **not** any web-client process. Changing the pattern to `"web-client.ts"` clears the false positive:

```
✓ web-client     ok       port 8080
```

## Impact

- The false positive has been a persistent noise source — `stage-readiness.sh`, chip updates, `check-pending-questions` surfacing all got misled.
- Live bug, not historical — I hit it in pass 694 while restarting web-client to pick up PR #434's note-renderer fix.
- Voice-agent's own stale check (line 508) already uses `"voice-agent.ts"` correctly; no behavior change there.

## Test plan

- [x] `python3 src/health-check.py` before fix: reports stale with 1166-min delta
- [x] After fix: reports `ok`
- [ ] Reviewer: confirm voice-agent's stale path still flags correctly when voice-agent source is edited + process un-restarted

🤖 Generated with [Claude Code](https://claude.com/claude-code)