### PR TITLE
feat(avatar-state): per-state visuals for menu-bar + web-UI

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -185,14 +185,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     } else {
                         button.title = "S"
                     }
-                    // Drive animation from semantic state. `listening`/`speaking`/`working`
-                    // all animate ("any non-idle" per owner's 07:38Z B-option decision).
+                    // Drive animation from semantic state. Each non-idle state gets
+                    // a distinct pulse shape (period + min opacity) so "working",
+                    // "speaking", "listening", "seeing" are distinguishable at a
+                    // glance. Decided 2026-04-18 at owner's request (supersedes
+                    // the earlier 07:38Z B-option collapsing).
                     if self.currentAgentState != agentState {
                         self.currentAgentState = agentState
                         if agentState == "idle" {
                             self.stopAnimation()
                         } else {
-                            self.startAnimation()
+                            self.startAnimation(for: agentState)
                         }
                     }
                 }
@@ -201,17 +204,42 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         task.resume()
     }
 
-    /// Start a slow opacity pulse on the menu-bar icon. Visible motion, but
-    /// not distracting — ~0.6s fade cycle, dropping to 55% opacity then back.
+    /// Start a per-state opacity pulse on the menu-bar icon.
+    ///
+    /// Each non-idle state has a distinct (period, minOpacity) so the four
+    /// states are distinguishable at a glance:
+    ///   - `listening` — 600ms cycle, min 55%  (slow gentle pulse — default)
+    ///   - `speaking`  — 300ms cycle, min 40%  (fast+deep — active output)
+    ///   - `working`   — 1200ms cycle, min 65% (slow heartbeat — processing)
+    ///   - `seeing`    — no pulse, static 100% (stands out against the moving ones)
     /// Called only on idle → non-idle transition from pollMuteState.
-    func startAnimation() {
+    func startAnimation(for state: String) {
         animationTimer?.invalidate()
         animationPhase = 1.0
-        animationTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: true) { [weak self] _ in
+        // seeing: static bright — no pulse; deliberately distinct from the others
+        if state == "seeing" {
+            statusItem?.button?.alphaValue = 1.0
+            return
+        }
+        // (halfPeriodSeconds, minOpacity) per state
+        let halfPeriod: Double
+        let minOpacity: CGFloat
+        switch state {
+        case "speaking":
+            halfPeriod = 0.15  // 300ms full cycle
+            minOpacity = 0.40
+        case "working":
+            halfPeriod = 0.6   // 1200ms full cycle (slow heartbeat)
+            minOpacity = 0.65
+        default:
+            // listening + any future non-idle falls through to the default slow pulse
+            halfPeriod = 0.3   // 600ms full cycle
+            minOpacity = 0.55
+        }
+        animationTimer = Timer.scheduledTimer(withTimeInterval: halfPeriod, repeats: true) { [weak self] _ in
             guard let self = self, let button = self.statusItem.button else { return }
-            // Toggle between 1.0 and 0.55 every tick → 600ms cycle
-            self.animationPhase = self.animationPhase > 0.75 ? 0.55 : 1.0
-            button.alphaValue = self.animationPhase
+            self.animationPhase = self.animationPhase > (1.0 + Double(minOpacity)) / 2.0 ? Double(minOpacity) : 1.0
+            button.alphaValue = CGFloat(self.animationPhase)
         }
     }
 

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -172,6 +172,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     // dim until the NEXT semantic state change).
                     button.title = "🔇"
                     button.image = nil
+                    button.toolTip = "Sutando: muted"
                     self.stopAnimation()
                     self.currentAgentState = "idle"
                 } else {
@@ -198,6 +199,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                             self.startAnimation(for: agentState)
                         }
                     }
+                    // Hover-tooltip shows the current state as a sanity-check
+                    // that the animation users see matches the backend. Updates
+                    // every poll regardless of state-change to keep it fresh.
+                    button.toolTip = "Sutando: \(agentState)"
                 }
             }
         }

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -38,6 +38,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var currentAgentState: String = "idle"
     var animationTimer: Timer?
     var animationPhase: CGFloat = 1.0
+    // Cached proactive-loop status from /core-status. Updated by a parallel
+    // poll alongside /sse-status so the menu-bar can show the "working" pulse
+    // when the loop is running even if voice is disconnected (agent-state
+    // alone isn't enough — voice disconnect forces agent-state=idle).
+    var loopRunning: Bool = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Request notification permission — only when running as .app bundle
@@ -154,6 +159,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func pollMuteState() {
+        // Parallel poll of /core-status to track proactive-loop "running" state.
+        // Cached into self.loopRunning for the union below; no-op on failure
+        // (pre-#441 servers or no core-status endpoint → stays at last value).
+        if let coreURL = URL(string: "http://localhost:7843/core-status") {
+            URLSession.shared.dataTask(with: coreURL) { [weak self] data, _, _ in
+                guard let self = self, let data = data,
+                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+                let running = (json["status"] as? String) == "running"
+                DispatchQueue.main.async { self.loopRunning = running }
+            }.resume()
+        }
         guard let url = URL(string: "http://localhost:8080/sse-status") else { return }
         let task = URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
             guard let data = data, error == nil,
@@ -161,9 +177,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let isMuted = json["muted"] as? Bool ?? false
             let isVoiceConnected = json["voiceConnected"] as? Bool ?? false
             // `state` added by PR #418. Absent on pre-#418 servers → default 'idle'.
-            let agentState = (json["state"] as? String) ?? "idle"
+            let rawAgentState = (json["state"] as? String) ?? "idle"
             DispatchQueue.main.async {
                 guard let self = self, let button = self.statusItem.button else { return }
+                // Union with proactive-loop: if agent is idle but the loop
+                // is running a pass, show the "working" pulse anyway. Reads
+                // self.loopRunning on main-thread (cache is only ever written
+                // there, avoiding a data race). Closes the gap reported at
+                // 09:37Z ("voice disconnected + loop running = menu-bar
+                // static while web UI shows blue").
+                let agentState: String = (rawAgentState == "idle" && self.loopRunning) ? "working" : rawAgentState
                 if isVoiceConnected && isMuted {
                     // Voice active + muted: show mute indicator; stop any animation.
                     // Reset cache so un-mute re-triggers animation if agent is

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -61,6 +61,20 @@ const HTML = /* html */ `<!DOCTYPE html>
     50% { box-shadow: 0 0 16px rgba(96,165,250,0.5), 0 0 0 4px rgba(96,165,250,0.2); }
     100% { box-shadow: 0 0 8px rgba(96,165,250,0.3), 0 0 0 2px rgba(96,165,250,0.1); }
   }
+  /* listening — slow amber pulse */
+  .header .avatar.listening:not(.speaking):not(.working) {
+    border-color: #fbbf24;
+    animation: avatar-listen 1.6s ease-in-out infinite;
+  }
+  @keyframes avatar-listen {
+    0%, 100% { box-shadow: 0 0 6px rgba(251,191,36,0.25); }
+    50%      { box-shadow: 0 0 14px rgba(251,191,36,0.45); }
+  }
+  /* seeing — purple with a static outer ring (no pulse, calls attention differently) */
+  .header .avatar.seeing:not(.speaking):not(.working) {
+    border-color: #c084fc;
+    box-shadow: 0 0 0 3px rgba(192,132,252,0.3), 0 0 12px rgba(192,132,252,0.35);
+  }
   .header .info { flex: 1; }
   .header h1 { color: #fff; font-size: 1.1em; font-weight: 500; }
   .header .meta { font-size: 11px; color: #555; display: flex; gap: 12px; align-items: center; margin-top: 2px; }
@@ -269,6 +283,14 @@ const HTML = /* html */ `<!DOCTYPE html>
     border-color: #60a5fa;
     box-shadow: 0 0 14px rgba(96,165,250,0.4);
     animation: avatar-work 2s linear infinite;
+  }
+  .hero .avatar-hero.listening:not(.speaking):not(.working) {
+    border-color: #fbbf24;
+    animation: avatar-listen 1.6s ease-in-out infinite;
+  }
+  .hero .avatar-hero.seeing:not(.speaking):not(.working) {
+    border-color: #c084fc;
+    box-shadow: 0 0 0 4px rgba(192,132,252,0.3), 0 0 16px rgba(192,132,252,0.35);
   }
   .hero h2 { color: #fff; font-size: 1.3em; font-weight: 500; margin-bottom: 4px; transition: all 0.6s ease; }
   .hero .tagline { color: #555; font-size: 13px; margin-bottom: 24px; transition: all 0.6s ease; }
@@ -1865,15 +1887,16 @@ document.addEventListener('keydown', function(e) {
   }
 });
 
-// Poll dynamic-content + core-status
+// Poll dynamic-content + core-status + sse-status
 (function pollDynamicContent() {
   setInterval(() => {
     Promise.all([
       fetch(API_BASE + '/dynamic-content').then(r => r.json()).catch(() => ({})),
       fetch(API_BASE + '/core-status').then(r => r.json()).catch(() => ({status:'idle'})),
       fetch('http://' + window.location.hostname + ':7844/notes').then(r => r.json()).catch(() => []),
-      fetch(API_BASE + '/contextual-chips').then(r => r.json()).catch(() => ({chips:[]}))
-    ]).then(([dc, loopData, notes, ctx]) => {
+      fetch(API_BASE + '/contextual-chips').then(r => r.json()).catch(() => ({chips:[]})),
+      fetch('/sse-status').then(r => r.json()).catch(() => ({state:'idle'}))
+    ]).then(([dc, loopData, notes, ctx, sseData]) => {
       window._contextualChips = (ctx && ctx.chips) || [];
       window._drNoteCount = Array.isArray(notes) ? notes.length : 0;
       // Only overwrite content if API has real content; preserve local content (e.g. notes browser)
@@ -1898,12 +1921,23 @@ document.addEventListener('keydown', function(e) {
         var expandBtn = '';
         csBar.innerHTML = statusText + expandBtn;
       }
-      // Avatar working state — blue spin when core is active
+      // Avatar per-state visuals — each semantic state lights a distinct class.
+      // The .working class is the union of proactive-loop-running AND voice-
+      // agent-state=working so both meanings of "busy" still fire the blue
+      // border (fixes the earlier gap where voice-side tool calls didn't
+      // trigger the UI's working visual).
       var av = document.getElementById('stand-avatar');
       var hav = document.getElementById('hero-avatar');
-      var isWorking = loopData.status === 'running';
-      if (av) av.classList.toggle('working', isWorking);
-      if (hav) hav.classList.toggle('working', isWorking);
+      var agentState = (sseData && sseData.state) || 'idle';
+      var isLoopRunning = loopData.status === 'running';
+      var isWorking = isLoopRunning || agentState === 'working';
+      [av, hav].forEach(function(el) {
+        if (!el) return;
+        el.classList.toggle('working',   isWorking);
+        el.classList.toggle('listening', agentState === 'listening');
+        el.classList.toggle('seeing',    agentState === 'seeing');
+        // .speaking is already driven by the voice client (TTS events); don't fight it here.
+      });
     });
   }, 3000);
 })();

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -2021,7 +2021,18 @@ const server = createServer((req, res) => {
 		const vState = url.searchParams.get('voice');
 		const aState = url.searchParams.get('state');
 		if (mState !== null) _muteState = mState === 'true';
-		if (vState !== null) _voiceState = vState === 'true';
+		if (vState !== null) {
+			const prev = _voiceState;
+			_voiceState = vState === 'true';
+			// When voice disconnects, force agentState back to 'idle'. Without
+			// this reset, _agentState keeps its last value (e.g. 'listening')
+			// and /sse-status keeps reporting non-idle state even though the
+			// client is gone — which drives the menu-bar pulse indefinitely.
+			// Fixes "voice disconnected but icon still blinking".
+			if (prev && !_voiceState) {
+				_agentState = 'idle';
+			}
+		}
 		if (aState === 'idle' || aState === 'listening' || aState === 'speaking' || aState === 'working' || aState === 'seeing') {
 			// Special handling for 'seeing': remember pre-seeing state so we can
 			// auto-revert. Default flash window is 1.5s unless caller specifies.


### PR DESCRIPTION
## Summary

Supersedes the earlier "any non-idle = same pulse" B-option collapsing (decided 2026-04-17 07:38Z) with distinct visuals per semantic state, so `listening` / `speaking` / `working` / `seeing` are distinguishable at a glance in both the macOS menu-bar app and the web UI.

Requested by @sonichi in Discord at 08:47Z — "I want it."

## Menu-bar (`src/Sutando/main.swift`)

`startAnimation(for: String)` now branches on agent state:

| State | Period | Min opacity | Character |
|-------|--------|-------------|-----------|
| `listening` | 600ms | 55% | Slow gentle pulse (current default) |
| `speaking`  | 300ms | 40% | Fast+deep — active output |
| `working`   | 1200ms | 65% | Slow heartbeat — processing |
| `seeing`    | — | static 100% | Bright, no pulse — stands out |

## Web UI (`src/web-client.ts`)

1. The polling loop now fetches `/sse-status` alongside `/core-status` and toggles `.listening` / `.seeing` classes on both `stand-avatar` and `hero-avatar`.

2. **Fixes a real bug**: the existing `.working` class was toggled only on `loopData.status === 'running'` (proactive-loop), so voice-side tool calls that flipped `sseData.state` to "working" never lit the blue border. Now `.working` is the union of both signals:

```js
var isWorking = isLoopRunning || agentState === 'working';
```

3. New CSS:
   - `.listening` — amber `#fbbf24` with slow ease-in-out pulse
   - `.seeing` — purple `#c084fc` with static 3px outer ring (no pulse)
   - `.speaking` (unchanged) — green `#6ee7b7`
   - `.working` (unchanged colors) — blue `#60a5fa` with pulsing glow

## Safety

**No voice-path risk.** Pure menu-bar Swift + web-client JS/CSS. No transport layer, no bodhi, no Gemini Live touched. Pre-ICLR (Apr 26, 8 days out) safe.

## Test plan

- [x] `npm run typecheck` — clean
- [x] Swift syntax — no new SourceKit issues beyond pre-existing `main.swift:399:13` warning (unrelated)
- [ ] Reviewer: reload web UI, trigger each state, verify visual distinction
- [ ] Reviewer: relaunch Sutando menu-bar app (not just launchctl — the Swift app itself needs to reload), verify each state shows distinct pulse

## Related

- Supersedes pass-194 B-option decision
- Fixes the `.working` / `sseData.state` gap Chi reported at 08:29Z
- Design specifics follow from `results/task-1776525767829.txt` (the period/opacity table), approved in full by Chi at 08:47Z