### PR TITLE
feat(bridges): archive task+result files instead of deleting

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -33,6 +33,38 @@ if not TOKEN:
 
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
+ARCHIVE_TASKS_DIR = REPO / "tasks" / "archive"
+ARCHIVE_RESULTS_DIR = REPO / "results" / "archive"
+
+
+def archive_path(kind: str, task_id: str) -> "Path":
+    """Return archive destination for a task or result file, partitioned by
+    year-month so the archive stays browsable.
+
+    kind: "tasks" or "results". task_id: e.g. "task-1776538911450"."""
+    from datetime import datetime
+    ym = datetime.now().strftime("%Y-%m")
+    base = ARCHIVE_TASKS_DIR if kind == "tasks" else ARCHIVE_RESULTS_DIR
+    month_dir = base / ym
+    month_dir.mkdir(parents=True, exist_ok=True)
+    return month_dir / f"{task_id}.txt"
+
+
+def archive_file(src: "Path", kind: str, task_id: str) -> None:
+    """Move src into the archive. Silent on failure — archive is for later
+    analysis, not critical path. Chi's 2026-04-18 ask: "instead of deleting
+    we should archive the tasks. It can be useful for self-improving"."""
+    try:
+        if src.exists():
+            import shutil
+            shutil.move(str(src), str(archive_path(kind, task_id)))
+    except Exception as e:
+        print(f"  archive_file({kind}, {task_id}) failed: {e}", flush=True)
+        # Fall back to unlink so we don't leave stale files.
+        try:
+            src.unlink(missing_ok=True)
+        except Exception:
+            pass
 INBOX_DIR = Path("/tmp/discord-inbox")
 TASKS_DIR.mkdir(exist_ok=True)
 RESULTS_DIR.mkdir(exist_ok=True)
@@ -663,9 +695,9 @@ async def poll_results():
                 # skipped the cleanup block at the bottom of this loop.
                 if reply_text.startswith('[no-send]') or reply_text.startswith('[REPLIED]'):
                     print(f"  Skipped (already replied): {task_id}")
-                    result_file.unlink(missing_ok=True)
+                    archive_file(result_file, "results", task_id)
                     task_file = TASKS_DIR / f"{task_id}.txt"
-                    task_file.unlink(missing_ok=True)
+                    archive_file(task_file, "tasks", task_id)
                     continue
                 try:
                     # Extract file paths: [file: /path] or [send: /path]
@@ -690,10 +722,10 @@ async def poll_results():
                     print(f"  Replied: {reply_text[:80]}...")
                 except Exception as e:
                     print(f"  Reply failed: {e}")
-                # Clean up
-                result_file.unlink(missing_ok=True)
+                # Archive (not delete) so we can mine patterns later.
+                archive_file(result_file, "results", task_id)
                 task_file = TASKS_DIR / f"{task_id}.txt"
-                task_file.unlink(missing_ok=True)
+                archive_file(task_file, "tasks", task_id)
         await asyncio.sleep(1)
 
 

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -8,7 +8,7 @@
  * injects the result into the Gemini conversation.
  */
 
-import { writeFileSync, readFileSync, existsSync, unlinkSync, mkdirSync, readdirSync, appendFileSync } from 'node:fs';
+import { writeFileSync, readFileSync, existsSync, unlinkSync, mkdirSync, readdirSync, appendFileSync, renameSync } from 'node:fs';
 import { join } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
@@ -17,6 +17,22 @@ const REPO_DIR = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
 const TASK_DIR = join(REPO_DIR, 'tasks');
 const RESULT_DIR = join(REPO_DIR, 'results');
 const CONVERSATION_LOG = join(REPO_DIR, 'conversation.log');
+
+/** Archive a task/result file into archive/<kind>/YYYY-MM/ instead of
+ * deleting. Chi's 2026-04-18 ask: "instead of deleting we should archive
+ * the tasks. It can be useful for self-improving". Silent on failure;
+ * fall back to unlink so the system never leaves stale files behind. */
+function archiveFile(srcPath: string, kind: 'tasks' | 'results', taskId: string): void {
+	try {
+		if (!existsSync(srcPath)) return;
+		const ym = new Date().toISOString().slice(0, 7); // YYYY-MM
+		const destDir = join(REPO_DIR, kind, 'archive', ym);
+		mkdirSync(destDir, { recursive: true });
+		renameSync(srcPath, join(destDir, `${taskId}.txt`));
+	} catch (err) {
+		try { unlinkSync(srcPath); } catch { /* ignore */ }
+	}
+}
 
 // Ensure dirs exist
 mkdirSync(TASK_DIR, { recursive: true });
@@ -134,7 +150,7 @@ export const cancelTask: ToolDefinition = {
 			}
 			const mostRecent = files[files.length - 1];
 			const taskId = mostRecent.replace('.txt', '');
-			unlinkSync(join(TASK_DIR, mostRecent));
+			archiveFile(join(TASK_DIR, mostRecent), 'tasks', taskId);
 			_pendingTasks.delete(taskId);
 			console.log(`${ts()} [TaskBridge] Cancelled task ${taskId}`);
 			_sendTaskStatus?.(taskId, 'cancelled', 'Task cancelled by user');
@@ -343,7 +359,7 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 							body: JSON.stringify({ taskId, result }),
 						}).catch(() => {});
 					} catch {}
-					setTimeout(() => { try { unlinkSync(path); } catch {} }, 10_000);
+					setTimeout(() => { archiveFile(path, 'results', path.split('/').pop()!.replace('.txt', '')); }, 10_000);
 				}
 			}
 		} catch {

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -38,8 +38,32 @@ if not TOKEN:
 
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
+ARCHIVE_TASKS_DIR = REPO / "tasks" / "archive"
+ARCHIVE_RESULTS_DIR = REPO / "results" / "archive"
 TASKS_DIR.mkdir(exist_ok=True)
 RESULTS_DIR.mkdir(exist_ok=True)
+
+
+def archive_file(src: "Path", kind: str, task_id: str) -> None:
+    """Move src into archive/<tasks|results>/YYYY-MM/ instead of deleting.
+    Silent on failure. Chi's ask 2026-04-18: archive tasks + results for
+    later pattern-mining / self-improvement analysis."""
+    try:
+        if not src.exists():
+            return
+        from datetime import datetime
+        import shutil
+        ym = datetime.now().strftime("%Y-%m")
+        base = ARCHIVE_TASKS_DIR if kind == "tasks" else ARCHIVE_RESULTS_DIR
+        dest_dir = base / ym
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
+    except Exception as e:
+        print(f"[Telegram] archive_file({kind}, {task_id}) failed: {e}")
+        try:
+            src.unlink(missing_ok=True)
+        except Exception:
+            pass
 
 # Presenter mode: silence proactive DMs during ICLR/talk windows. Sentinel
 # is written by scripts/presenter-mode.sh with an ISO-8601 expiry. Matches
@@ -292,19 +316,19 @@ def main():
                 # task — same bug class as discord-bridge had.
                 if reply_text.startswith('[no-send]') or reply_text.startswith('[REPLIED]'):
                     print(f"  Skipped (already replied): {task_id}")
-                    result_file.unlink(missing_ok=True)
+                    archive_file(result_file, "results", task_id)
                     task_file = TASKS_DIR / f"{task_id}.txt"
-                    task_file.unlink(missing_ok=True)
+                    archive_file(task_file, "tasks", task_id)
                     continue
                 try:
                     send_reply(chat_id, reply_text)
                     print(f"  Replied to {chat_id}: {reply_text[:80]}...")
                 except Exception as e:
                     print(f"[Telegram] Reply error: {e}")
-                # Clean up
-                result_file.unlink(missing_ok=True)
+                # Archive (not delete) so we can mine patterns later.
+                archive_file(result_file, "results", task_id)
                 task_file = TASKS_DIR / f"{task_id}.txt"
-                task_file.unlink(missing_ok=True)
+                archive_file(task_file, "tasks", task_id)
 
         time.sleep(1)
 


### PR DESCRIPTION
## Summary

Chi in voice (2026-04-18): *"instead of deleting we should archive the tasks. It can be useful for self-improving."* Confirmed with "yes" after I sketched the plan.

All three bridges now move delivered task + result files into `archive/<tasks|results>/YYYY-MM/` instead of calling `unlink`. Partitioned by year-month so the tree stays browsable as volume grows (1k/month is realistic).

## Changes

- **`src/discord-bridge.py`** — new `archive_file(src, kind, task_id)` helper. Replaces `unlink` in 4 cleanup sites (the `[no-send]`/`[REPLIED]` skip path + the successful-send path).
- **`src/telegram-bridge.py`** — mirror helper + 4 matching sites.
- **`src/task-bridge.ts`** (voice-agent) — TS `archiveFile()` helper. Replaces `unlinkSync` at the cancel path (line 137) and the voice-result cleanup path (line 346).
- All helpers fall back to `unlink` if `mkdir`/`move` fails so the system never leaves stale files behind.

## Scope intentionally NOT touched

- Orphan cleanup paths in discord-bridge (lines 592, 728, 741, 754, 773, 821, 830, 852) — those unlink junk files (non-task, non-result) that shouldn't pollute the archive.
- `CONTEXT_DROP_FILE` unlink (task-bridge.ts:222) — transient one-shot, not worth archiving.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `python3 -c "import ast; ast.parse(...)"` clean on both Python files
- [ ] Manual post-merge: send a Discord DM, verify after delivery that `tasks/archive/YYYY-MM/task-<id>.txt` + `results/archive/YYYY-MM/task-<id>.txt` exist and the original paths are gone.

## Follow-ups (not in this PR)

- Add to `.gitignore`: `tasks/archive/` + `results/archive/` (already ignored via parent `tasks/` and `results/` entries).
- Disk-pressure purge script (weekly?) that gzips and removes archive subdirs older than N days.
- Pattern-mining analysis script over the corpus (count tasks per channel, top tools invoked, most-deduped threads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)