### PR TITLE
fix(bridges): flush reply-success/fail prints for live log visibility

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -719,9 +719,9 @@ async def poll_results():
                         else:
                             await channel.send(f"(file not found: {fpath})")
 
-                    print(f"  Replied: {reply_text[:80]}...")
+                    print(f"  Replied: {reply_text[:80]}...", flush=True)
                 except Exception as e:
-                    print(f"  Reply failed: {e}")
+                    print(f"  Reply failed: {e}", flush=True)
                 # Archive (not delete) so we can mine patterns later.
                 archive_file(result_file, "results", task_id)
                 task_file = TASKS_DIR / f"{task_id}.txt"

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -322,9 +322,9 @@ def main():
                     continue
                 try:
                     send_reply(chat_id, reply_text)
-                    print(f"  Replied to {chat_id}: {reply_text[:80]}...")
+                    print(f"  Replied to {chat_id}: {reply_text[:80]}...", flush=True)
                 except Exception as e:
-                    print(f"[Telegram] Reply error: {e}")
+                    print(f"[Telegram] Reply error: {e}", flush=True)
                 # Archive (not delete) so we can mine patterns later.
                 archive_file(result_file, "results", task_id)
                 task_file = TASKS_DIR / f"{task_id}.txt"


### PR DESCRIPTION
## Summary

The `Replied:` and `Reply failed:` prints in both `discord-bridge.py` and `telegram-bridge.py` were block-buffered to stdout. When the bridge runs under launchd/nohup with stdout redirected to a log file, Python uses 4–8 KB full buffering instead of line buffering, so reply lines can sit in memory 5–10 minutes before hitting disk.

## Symptom

After `task-1776544342870` delivery at ~20:33Z today (Chi's "did you receive the updates?" in #dev), I grepped `logs/discord-bridge.log` to verify the send landed — the `Replied:` line was absent for 8+ minutes. Task + result files were already unlinked (normal cleanup path), so the send must have succeeded, but there was no way to confirm from logs alone. Cost me ~5 min of "is this delivery broken or just buffered?" diagnosis before I walked the print statements.

Same class is latent in `telegram-bridge.py` — same buffering, same risk.

## Fix

Add `flush=True` to 4 prints (2 per bridge):
- `discord-bridge.py:722` `Replied: …`
- `discord-bridge.py:724` `Reply failed: …`
- `telegram-bridge.py:325` `Replied to <chat_id>: …`
- `telegram-bridge.py:327` `[Telegram] Reply error: …`

This matches the pattern already used in both files for the `[msg]` ingest print, the `[skip]` prints, the `[dm-fallback]` prints — all already `flush=True`. The reply-success/fail prints were the odd ones out.

## Scope

4 lines changed. Does NOT touch `[proactive]`/file-send/API-error prints — those don't see the same diagnosis pain and scope-creep risk outweighs the benefit for this PR.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` clean on both files
- [ ] Post-merge: restart bridges, send a test Discord DM, `tail -f logs/discord-bridge.log` should show `Replied:` within 1-2s of send (not 5-10min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)