### PR TITLE
fix(schedule-crons): drop dangling cross-node-sync entry from crons.example.json

### DIFF
--- a/skills/schedule-crons/crons.example.json
+++ b/skills/schedule-crons/crons.example.json
@@ -23,10 +23,5 @@
     "name": "sync-memory",
     "cron": "*/30 * * * *",
     "prompt": "Run bash src/sync-memory.sh to sync memory and notes to the private memory repo (requires SUTANDO_MEMORY_REPO in .env)."
-  },
-  {
-    "name": "cross-node-sync",
-    "cron": "*/7 * * * *",
-    "prompt": "Run bash skills/cross-node-sync/scripts/setup-rsync-sync.sh to sync memory/ + notes/ with the peer node (requires SUTANDO_SYNC_PEER in .env). Then regenerate MEMORY.md from frontmatter."
   }
 ]


### PR DESCRIPTION
## Summary

Follow-up to #447. That PR removed `skills/cross-node-sync/` entirely but left the `"name": "cross-node-sync"` entry in `crons.example.json` — which points at `skills/cross-node-sync/scripts/setup-rsync-sync.sh` (no longer on main). A first-time `cp crons.example.json crons.json` would wire up a 7-minute cron that fails silently every fire. This PR drops that entry.

## Changes

- `skills/schedule-crons/crons.example.json`: remove the cross-node-sync entry (5 lines).

## Test plan

- [x] `python3 -c "import json; json.load(open('skills/schedule-crons/crons.example.json'))"` → valid JSON.
- [x] Remaining 5 entries (main-loop, morning-briefing, daily-insight, pending-questions, sync-memory) all point at paths present on main.
- [x] `grep -rn cross-node-sync skills/schedule-crons/` → empty.

Flagged as "non-blocking follow-up" in my #447 approval. Now actionable since #447 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)