### PR TITLE
chore(startup): auto-install tmux via Homebrew when missing

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -295,7 +295,7 @@ else
   # watcher-auto-restart (PR #444) depends on a tmux-wrapped CLI pane,
   # so a first-run user without tmux silently loses that feature.
   if ! command -v tmux > /dev/null 2>&1 && command -v brew > /dev/null 2>&1; then
-    echo "tmux not found — installing via Homebrew (required for Sutando.app watcher-auto-restart)..."
+    echo "tmux not found — installing via Homebrew (~30s, required for Sutando.app watcher-auto-restart)..."
     brew install tmux 2>&1 | tail -3
   fi
   # Fall back to a bare `exec claude` if tmux is still missing.

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -291,7 +291,14 @@ else
   # AppDelegate.checkWatcher). `tmux new-session -A -s sutando-core …`
   # creates the session if it doesn't exist and attaches if it does,
   # so the user sees the Claude Code prompt exactly as before.
-  # Fall back to a bare `exec claude` if tmux is missing.
+  # Auto-install tmux via Homebrew if missing. Sutando.app's
+  # watcher-auto-restart (PR #444) depends on a tmux-wrapped CLI pane,
+  # so a first-run user without tmux silently loses that feature.
+  if ! command -v tmux > /dev/null 2>&1 && command -v brew > /dev/null 2>&1; then
+    echo "tmux not found — installing via Homebrew (required for Sutando.app watcher-auto-restart)..."
+    brew install tmux 2>&1 | tail -3
+  fi
+  # Fall back to a bare `exec claude` if tmux is still missing.
   if command -v tmux > /dev/null 2>&1; then
     # Explicit socket path so Sutando.app (which runs under a different
     # TMPDIR due to macOS sandboxing when launched via `open`) can reach


### PR DESCRIPTION
## Summary

Per your "y" at 21:00Z in #dev: Sutando.app's watcher-auto-restart (PR #444) depends on a tmux-wrapped CLI pane to send `watcher` keystrokes when the task-watcher dies. If tmux is missing on a first-run machine, `startup.sh` falls back to a bare `exec claude` — functional, but silently drops the auto-restart feature.

## Change

5-line guard in `src/startup.sh:294`: if tmux is missing AND Homebrew is available, install tmux before wrapping the CLI. Preserves the existing bare-exec fallback when both are absent.

```bash
  if ! command -v tmux > /dev/null 2>&1 && command -v brew > /dev/null 2>&1; then
    echo "tmux not found — installing via Homebrew (required for Sutando.app watcher-auto-restart)..."
    brew install tmux 2>&1 | tail -3
  fi
```

## Test plan

- [x] `bash -n src/startup.sh` clean
- [ ] Manual: on a machine without tmux + with Homebrew, `bash src/startup.sh` should auto-install then proceed to tmux wrap (no user prompt, no failed step)
- [ ] Manual: existing-tmux machines should see zero behavior change

## Scope

Doesn't touch the "neither tmux nor brew" path — that branch already has a helpful warning pointing at `brew install tmux`, just skipped now by the Homebrew short-circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)