### PR TITLE
feat(web-client): tmux-pane status fallback for stale core-status.json

### DIFF
--- a/src/tmux-status.ts
+++ b/src/tmux-status.ts
@@ -1,0 +1,115 @@
+// Tmux-pane status scraper. Fallback signal for `effectiveAgentState()` when
+// `core-status.json` is stale or missing (e.g. a proactive-loop pass crashed
+// before writing idle). Scrapes the CLI's tmux pane via `tmux capture-pane`
+// and categorizes the rendered state.
+//
+// Disabled by setting `SUTANDO_TMUX_SCRAPE=0`. Tmux session name override via
+// `SUTANDO_TMUX_SESSION` (default `sutando-core`).
+//
+// All failure modes (tmux missing, timeout, parse error) return `idle` — this
+// is a best-effort hint, never ground-truth, never throws.
+
+import { execSync } from 'node:child_process';
+
+export type TmuxParseResult = {
+	state: 'idle' | 'working';
+	label: string;
+};
+
+const DEFAULT_SESSION = 'sutando-core';
+const CACHE_TTL_MS = 3_000;
+const CAPTURE_TIMEOUT_MS = 500;
+const LINES_BACK = 30;
+
+let _cache: { ts: number; result: TmuxParseResult } | null = null;
+let _lastLogAt = 0; // throttled logging
+
+function logOnce(msg: string): void {
+	const now = Date.now();
+	if (now - _lastLogAt < 60_000) return;
+	_lastLogAt = now;
+	console.error(`[tmux-status] ${msg}`);
+}
+
+// Tool invocation: "⏺ ToolName(" at the start of a line. Claude Code renders
+// this marker on every tool call; the tool name is the stable label for the
+// most recent call in the pane.
+const RE_TOOL = /^\s*(?:⏺|●)\s*(\w+)\(/m;
+// Inline "Running…" inside a tool block = tool currently executing.
+const RE_RUNNING_INLINE = /⎿\s+Running…/;
+// Background task indicator: tool launched with run_in_background.
+const RE_RUNNING_BG = /Running in the background/;
+// Thinking spinner: "(thought for Ns)" or "Cogitated for Ns". Verb rotates
+// ("Flummoxing", "Pondering", "Nebulizing", …) but the suffix is stable.
+const RE_THOUGHT = /\(thought for \d+s\)|Cogitated for [\dm\s]+s/;
+// Empty prompt: `❯ ` alone on a line (typical idle end-of-pane).
+const RE_IDLE_PROMPT = /^❯\s*$/m;
+
+/**
+ * Parse a captured tmux pane into an agent state hint.
+ *
+ * Contract:
+ * - Never throws. On malformed/unexpected input, returns `{state: 'idle', label: ''}`.
+ * - Tool detection takes priority over thinking detection.
+ * - Background-task markers still count as `working` — the CLI has an
+ *   outstanding tool invocation and the user wants to see that signal.
+ * - An unrelated pane (empty, non-Claude-Code output) → `idle`.
+ */
+export function parseTmuxPane(text: string): TmuxParseResult {
+	if (!text || typeof text !== 'string') return { state: 'idle', label: '' };
+
+	// Find the MOST RECENT tool call — Claude Code writes these in order, so
+	// the last match in the pane is the freshest.
+	let lastTool: string | null = null;
+	const lines = text.split('\n');
+	for (const line of lines) {
+		const m = line.match(RE_TOOL);
+		if (m) lastTool = m[1];
+	}
+
+	const toolInline = RE_RUNNING_INLINE.test(text);
+	const toolBg = RE_RUNNING_BG.test(text);
+	const thinking = RE_THOUGHT.test(text);
+
+	if (toolInline && lastTool) return { state: 'working', label: lastTool };
+	if (toolBg && lastTool) return { state: 'working', label: lastTool };
+	if (thinking) return { state: 'working', label: 'thinking' };
+	// Recent tool but no active-run marker → already finished, idle.
+	if (RE_IDLE_PROMPT.test(text)) return { state: 'idle', label: '' };
+	// Ambiguous / unknown format → silent fallback.
+	return { state: 'idle', label: '' };
+}
+
+/**
+ * Capture the pane and parse it. Cached for CACHE_TTL_MS to avoid shelling
+ * out on every `/sse-status` poll. Respects `SUTANDO_TMUX_SCRAPE=0` kill-switch.
+ * Returns `{state:'idle', label:''}` on any error (tmux missing, timeout, etc.).
+ */
+export function readTmuxStatus(): TmuxParseResult {
+	if (process.env.SUTANDO_TMUX_SCRAPE === '0') return { state: 'idle', label: '' };
+
+	const now = Date.now();
+	if (_cache && now - _cache.ts < CACHE_TTL_MS) return _cache.result;
+
+	const session = process.env.SUTANDO_TMUX_SESSION || DEFAULT_SESSION;
+	try {
+		const out = execSync(
+			`tmux capture-pane -t ${session} -pS -${LINES_BACK}`,
+			{ encoding: 'utf-8', timeout: CAPTURE_TIMEOUT_MS, stdio: ['ignore', 'pipe', 'ignore'] },
+		);
+		const result = parseTmuxPane(out);
+		_cache = { ts: now, result };
+		return result;
+	} catch (err) {
+		logOnce(`capture failed: ${err instanceof Error ? err.message : String(err)}`);
+		const result: TmuxParseResult = { state: 'idle', label: '' };
+		_cache = { ts: now, result };
+		return result;
+	}
+}
+
+/** Test-only: reset the capture cache between tests. */
+export function _resetTmuxCacheForTests(): void {
+	_cache = null;
+	_lastLogAt = 0;
+}

--- a/src/tmux-status.ts
+++ b/src/tmux-status.ts
@@ -39,9 +39,11 @@ const RE_TOOL = /^\s*(?:⏺|●)\s*(\w+)\(/m;
 const RE_RUNNING_INLINE = /⎿\s+Running…/;
 // Background task indicator: tool launched with run_in_background.
 const RE_RUNNING_BG = /Running in the background/;
-// Thinking spinner: "(thought for Ns)" or "Cogitated for Ns". Verb rotates
-// ("Flummoxing", "Pondering", "Nebulizing", …) but the suffix is stable.
-const RE_THOUGHT = /\(thought for \d+s\)|Cogitated for [\dm\s]+s/;
+// Thinking spinner: "thought for Ns" (embedded in a richer parenthesized
+// block — e.g. "(16s · ↓ 111 tokens · thought for 5s)") or "Cogitated for
+// Ns" (separate format). Verb rotates ("Flummoxing", "Pondering",
+// "Nebulizing", …) but the suffix is stable.
+const RE_THOUGHT = /thought for \d+s|Cogitated for [\dm\s]+s/;
 // Empty prompt: `❯ ` alone on a line (typical idle end-of-pane).
 const RE_IDLE_PROMPT = /^❯\s*$/m;
 

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -9,7 +9,8 @@
  */
 
 import { createServer } from 'node:http';
-import { writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { writeFileSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { readTmuxStatus } from './tmux-status.js';
 
 const HTTP_PORT = Number(process.env.CLIENT_PORT) || 8080;
 const HTTP_HOST = process.env.CLIENT_HOST || '0.0.0.0'; // '0.0.0.0' binds to all interfaces for EC2
@@ -1992,17 +1993,35 @@ let _seeingUntil = 0;
 // Without this, the menu bar stays solid while Claude Code is processing a
 // Discord/voice task even though the user would want to see that signal.
 // Lightweight: just a file read (one syscall) per /sse-status poll every 3s.
-// Read core-status.json and return { running, step }. step (if present)
-// becomes the tooltip label when no tool label is set.
-function readCoreStatus(): { running: boolean; step: string } {
+// Read core-status.json and return { running, step, stale }.
+// - `running`: CLI is mid-pass (status == "running" and ts within grace).
+// - `step`: tooltip label when no tool label is set.
+// - `stale`: the file is unreliable — either older than 60s on disk, or
+//   status=="running" with ts older than 60s (a proactive-loop pass that
+//   crashed between step 0 write and idle write leaves a "running" sentinel
+//   that mtime moves but content lies). When stale, consumers should fall
+//   back to the tmux pane scrape for a fresh signal.
+const CORE_STATUS_STALE_SECONDS = 60;
+function readCoreStatus(): { running: boolean; step: string; stale: boolean } {
 	try {
-		const raw = readFileSync(new URL('../core-status.json', import.meta.url), 'utf-8');
+		const url = new URL('../core-status.json', import.meta.url);
+		const raw = readFileSync(url, 'utf-8');
 		const s = JSON.parse(raw) as { status?: string; ts?: number; step?: string };
-		if (s.status !== 'running') return { running: false, step: '' };
-		if (typeof s.ts === 'number' && Date.now() / 1000 - s.ts > 600) return { running: false, step: '' };
-		return { running: true, step: typeof s.step === 'string' ? s.step : '' };
+		const nowSec = Date.now() / 1000;
+		let stale = false;
+		try {
+			const mtimeSec = statSync(url).mtimeMs / 1000;
+			if (nowSec - mtimeSec > CORE_STATUS_STALE_SECONDS) stale = true;
+		} catch { stale = true; }
+		// "Running with old ts" → loop likely crashed mid-pass, treat as stale.
+		if (s.status === 'running' && typeof s.ts === 'number' && nowSec - s.ts > CORE_STATUS_STALE_SECONDS) {
+			stale = true;
+		}
+		if (s.status !== 'running') return { running: false, step: '', stale };
+		if (typeof s.ts === 'number' && nowSec - s.ts > 600) return { running: false, step: '', stale };
+		return { running: true, step: typeof s.step === 'string' ? s.step : '', stale };
 	} catch {
-		return { running: false, step: '' };
+		return { running: false, step: '', stale: true };
 	}
 }
 function coreIsRunning(): boolean { return readCoreStatus().running; }
@@ -2019,7 +2038,17 @@ function effectiveAgentState(): AgentState {
 	if (_browserState !== 'idle') return _browserState;
 	// No explicit state — fall through to core-status. If the proactive loop
 	// or any Claude Code pass is active, surface that as `working`.
-	return coreIsRunning() ? 'working' : 'idle';
+	const core = readCoreStatus();
+	if (core.running) return 'working';
+	// Core is idle OR the file is stale. If stale, ask the tmux scrape for a
+	// hint — useful when a pass crashed before writing idle, or when the CLI
+	// is actively doing something but forgot to write. Fresh-idle file wins
+	// over tmux to prevent the scrape from spuriously lighting up the pulse.
+	if (core.stale) {
+		const scrape = readTmuxStatus();
+		if (scrape.state === 'working') return 'working';
+	}
+	return 'idle';
 }
 
 // Heartbeat: ping every 30s, remove clients that fail to write (stale connections)
@@ -2073,7 +2102,14 @@ const server = createServer((req, res) => {
 		if (_toolState !== 'idle') {
 			label = _toolLabel;
 		} else if (_browserState === 'idle' && eff === 'working') {
-			label = readCoreStatus().step;
+			const core = readCoreStatus();
+			label = core.step;
+			// If core is stale and we're in fallback territory, prefer the
+			// tmux-scrape label (usually a tool name) over the stale step.
+			if (core.stale && !core.step) {
+				const scrape = readTmuxStatus();
+				if (scrape.state === 'working') label = scrape.label;
+			}
 		}
 		res.writeHead(200, { 'Content-Type': 'application/json' });
 		res.end(JSON.stringify({

--- a/tests/tmux-status.test.ts
+++ b/tests/tmux-status.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseTmuxPane, _resetTmuxCacheForTests } from '../src/tmux-status.js';
+
+/**
+ * Tests for `parseTmuxPane` — the pane-capture parser used as a fallback
+ * signal for `effectiveAgentState()` when `core-status.json` is stale.
+ *
+ * Observer-effect aside (noted in the design collab 2026-04-18): any harness
+ * that calls the parser while itself running under Claude Code's tmux pane
+ * will find the harness's own Bash invocation in the capture. Canned
+ * fixtures sidestep that entirely — each test passes a synthesized pane
+ * string and asserts the parser's return shape, no live CLI needed.
+ *
+ * Fixtures are inlined as TS string constants (tests/fixtures/ is gitignored
+ * per repo convention; see discussion on feat/tmux-status-fallback).
+ */
+
+// ── Fixtures (synthesized pane captures) ────────────────────────────────────
+
+const TOOL_IN_PROGRESS = `⏺ Bash(npm install 2>&1 | tail -6)
+  ⎿  Running…
+✳ Nebulizing… (16s · ↓ 111 tokens · thought for 5s)
+──── sutando-core ──
+❯ `;
+
+const TOOL_BG = `⏺ Bash(bash src/watch-tasks.sh)
+  ⎿  Running in the background (↓ to manage)
+──── sutando-core ──
+❯ `;
+
+const TOOL_JUST_FINISHED = `⏺ Read(~/Desktop/sutando/README.md)
+  ⎿  Read 23 lines
+⏺ All done.
+  Read 1 file, listed 1 directory (ctrl+o to expand)
+──── sutando-core ──
+❯ `;
+
+const IDLE_PROMPT = `⏺ All done.
+  Read 1 file, listed 1 directory (ctrl+o to expand)
+──── sutando-core ──
+❯ `;
+
+const THINKING_ONLY = `✳ Cogitated for 7s
+──── sutando-core ──
+❯ `;
+
+const THINKING_THOUGHT_FOR = `✳ Pondering… (8s · ↓ 42 tokens · thought for 4s)
+──── sutando-core ──
+❯ `;
+
+const MULTIPLE_TOOLS_LAST_WINS = `⏺ Read(foo.ts)
+  ⎿  Read 12 lines
+⏺ Grep(pattern=\"hello\")
+  ⎿  1 match
+⏺ Edit(foo.ts)
+  ⎿  Running…
+──── sutando-core ──
+❯ `;
+
+const ALT_BULLET_GLYPH = `● WebSearch(query=\"gemini pricing\")
+  ⎿  Running in the background
+──── sutando-core ──
+❯ `;
+
+const AMBIGUOUS_UNRELATED = `some random shell output
+not a claude-code pane at all
+$ ls foo bar
+foo: no such file
+`;
+
+const EMPTY = '';
+const WHITESPACE_ONLY = '   \n\t\n  \n';
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('parseTmuxPane', () => {
+	beforeEach(() => _resetTmuxCacheForTests());
+
+	it('tool-in-progress → working with tool name', () => {
+		const r = parseTmuxPane(TOOL_IN_PROGRESS);
+		assert.equal(r.state, 'working');
+		assert.equal(r.label, 'Bash');
+	});
+
+	it('background tool → working with tool name (not label=thinking)', () => {
+		const r = parseTmuxPane(TOOL_BG);
+		assert.equal(r.state, 'working');
+		assert.equal(r.label, 'Bash');
+	});
+
+	it('tool just finished (no Running/BG marker) → idle', () => {
+		const r = parseTmuxPane(TOOL_JUST_FINISHED);
+		assert.equal(r.state, 'idle');
+		assert.equal(r.label, '');
+	});
+
+	it('idle prompt with no tool markers → idle', () => {
+		const r = parseTmuxPane(IDLE_PROMPT);
+		assert.equal(r.state, 'idle');
+		assert.equal(r.label, '');
+	});
+
+	it('thinking (Cogitated for Ns) → working label=thinking', () => {
+		const r = parseTmuxPane(THINKING_ONLY);
+		assert.equal(r.state, 'working');
+		assert.equal(r.label, 'thinking');
+	});
+
+	it('thinking (thought for Ns) → working label=thinking', () => {
+		const r = parseTmuxPane(THINKING_THOUGHT_FOR);
+		assert.equal(r.state, 'working');
+		assert.equal(r.label, 'thinking');
+	});
+
+	it('multiple tools → label is the LAST tool in the pane', () => {
+		const r = parseTmuxPane(MULTIPLE_TOOLS_LAST_WINS);
+		assert.equal(r.state, 'working');
+		assert.equal(r.label, 'Edit');
+	});
+
+	it('alt bullet glyph (●) recognized as tool marker', () => {
+		const r = parseTmuxPane(ALT_BULLET_GLYPH);
+		assert.equal(r.state, 'working');
+		assert.equal(r.label, 'WebSearch');
+	});
+
+	it('ambiguous / non-Claude-Code output → idle (silent fallback)', () => {
+		const r = parseTmuxPane(AMBIGUOUS_UNRELATED);
+		assert.equal(r.state, 'idle');
+		assert.equal(r.label, '');
+	});
+
+	it('empty string → idle (never throws)', () => {
+		const r = parseTmuxPane(EMPTY);
+		assert.equal(r.state, 'idle');
+		assert.equal(r.label, '');
+	});
+
+	it('whitespace-only → idle', () => {
+		const r = parseTmuxPane(WHITESPACE_ONLY);
+		assert.equal(r.state, 'idle');
+		assert.equal(r.label, '');
+	});
+
+	it('null input → idle (defensive)', () => {
+		// @ts-expect-error — contract explicitly says never throw on malformed input
+		const r = parseTmuxPane(null);
+		assert.equal(r.state, 'idle');
+		assert.equal(r.label, '');
+	});
+
+	it('undefined input → idle (defensive)', () => {
+		// @ts-expect-error
+		const r = parseTmuxPane(undefined);
+		assert.equal(r.state, 'idle');
+		assert.equal(r.label, '');
+	});
+
+	it('non-string input → idle (defensive)', () => {
+		// @ts-expect-error
+		const r = parseTmuxPane(42);
+		assert.equal(r.state, 'idle');
+		assert.equal(r.label, '');
+	});
+});


### PR DESCRIPTION
## Summary

Adds a best-effort status reader that scrapes the CLI's tmux pane when \`core-status.json\` is stale or crashed. Wired into \`effectiveAgentState()\` as a fallback — explicit core-status writes still win when fresh.

Design + scope discussion: Mini (Mac Mini bot) and I coordinated on this; Mini is taking the unit tests on the same branch.

## Motivation

CLI can forget to write idle/running transitions on crash or early exit, leaving \`core-status.json\` lying about current state. Menu-bar pulse reflects that stale state until the next pass. Tmux-scrape gives a cheap second source of truth.

## Design

**Parser (\`src/tmux-status.ts\`)**:
- \`parseTmuxPane(text)\` → \`{state, label}\`. Never throws. Returns \`idle\` on ambiguous input — conservative posture so a flaky scrape can't spuriously light up the avatar pulse.
- Detects: tool invocation (\`⏺ ToolName(\`), tool in progress (\`⎿  Running…\`), thinking (\`(thought for Ns)\`), idle prompt (\`❯\`).

**Capture (\`readTmuxStatus\`)**:
- Shells to \`tmux capture-pane -pS -30\`, cached 3s to avoid shelling on every \`/sse-status\` poll.
- \`SUTANDO_TMUX_SESSION=<name>\` overrides default \`sutando-core\`.
- \`SUTANDO_TMUX_SCRAPE=0\` kill-switch.
- 500ms subprocess timeout. Throttled log (once/min) on failure. All errors → \`idle\`, never throw.

**Stale detection (\`web-client.ts\`)**:
- File mtime > 60s old, OR \`status==\"running\"\` with \`ts > 60s\` old (Mini's catch — a crashed pass leaves a \"running\" lie that mtime alone doesn't detect).
- \`readCoreStatus()\` now returns \`{running, step, stale}\`.
- Fresh-idle file wins; only stale triggers the scrape.

## Test plan

Mini is writing unit tests against the parser contract (signature doc in commit message). In-progress on this branch.

- [ ] Unit tests for each state: tool-in-progress, tool-bg, thinking, idle-prompt, ambiguous, empty.
- [ ] Assert parser never throws on malformed input.
- [ ] Verify kill-switch (\`SUTANDO_TMUX_SCRAPE=0\`) short-circuits.
- [ ] Manual verification: simulate a stale core-status.json + observe /sse-status returns scrape-derived state.

## Not shipping

- No Swift-side changes; the menu bar keeps polling \`/sse-status\` as before.
- No behavior change when \`core-status.json\` is fresh (pure-additive fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)