### PR TITLE
fix(voice-agent): fail-fast on malformed GEMINI_*_API_KEY at startup

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -57,7 +57,10 @@ let generateSpeech: ((text: string, opts: { category: string; label: string }) =
 // instead of letting the voice session fail silently on connect.
 function assertGeminiKey(name: string, value: string): void {
 	if (!value) { console.error(`Error: ${name} is required`); process.exit(1); }
-	const looksValid = value.startsWith('AIza') && value.length >= 35 && value.length <= 50;
+	// Upper bound of 60 (vs canonical ~39) gives headroom for Google key
+	// format rotations — Mini flagged they rotated once (2020→2023) and a
+	// tight bound would fail-fast on legitimate future keys.
+	const looksValid = value.startsWith('AIza') && value.length >= 35 && value.length <= 60;
 	if (!looksValid) {
 		console.error(
 			`Error: ${name} does not look like a Google AI Studio key ` +

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -51,12 +51,34 @@ let generateSpeech: ((text: string, opts: { category: string; label: string }) =
 // Config
 // =============================================================================
 
+// Shape check: a valid Google AI Studio key starts with "AIza" and is
+// typically 39 chars (v1 format). Catches common misconfigurations
+// (truncated paste, wrong variable, stale template value) at startup
+// instead of letting the voice session fail silently on connect.
+function assertGeminiKey(name: string, value: string): void {
+	if (!value) { console.error(`Error: ${name} is required`); process.exit(1); }
+	const looksValid = value.startsWith('AIza') && value.length >= 35 && value.length <= 50;
+	if (!looksValid) {
+		console.error(
+			`Error: ${name} does not look like a Google AI Studio key ` +
+			`(expected "AIza..." ~39 chars, got ${value.length} chars starting "${value.slice(0, 4)}"). ` +
+			`Rotate at https://ai.google.dev → "Get API key" and update .env.`
+		);
+		process.exit(1);
+	}
+}
+
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY ?? '';
-if (!GEMINI_API_KEY) { console.error('Error: GEMINI_API_KEY is required'); process.exit(1); }
+assertGeminiKey('GEMINI_API_KEY', GEMINI_API_KEY);
 // Optional: separate key for the Gemini Live voice session. Lets users put voice
 // on a free-tier key (unlimited on free tier, rate-limited) while keeping text/
 // vision/STT on a paid-tier key. Falls back to GEMINI_API_KEY when unset.
 const GEMINI_VOICE_API_KEY = process.env.GEMINI_VOICE_API_KEY || GEMINI_API_KEY;
+// Only shape-check the voice key if user opted in — silent fallback to the
+// main key is the backward-compatible path.
+if (process.env.GEMINI_VOICE_API_KEY) {
+	assertGeminiKey('GEMINI_VOICE_API_KEY', process.env.GEMINI_VOICE_API_KEY);
+}
 
 const PORT = Number(process.env.PORT) || 9900;
 const HOST = process.env.HOST || '0.0.0.0';


### PR DESCRIPTION
## Summary

Follow-up to #452 (Mini's deferred review item #3). A wrong `GEMINI_VOICE_API_KEY` currently lets voice-agent start up "healthy" but every voice session fails silently inside bodhi's first API call. Same silent-fail mode for `GEMINI_API_KEY` if misconfigured.

## Change

- Adds `assertGeminiKey(name, value)` helper:
  - Fails startup with a clear error + fix URL if the key is empty.
  - Shape-checks that the key starts with `AIza` and is 35-50 chars (Google AI Studio v1 format, typically 39).
  - Catches: truncated paste, stale template values (`your-gemini-key`), wrong-variable misconfigurations.
- `GEMINI_API_KEY` — always required + shape-checked.
- `GEMINI_VOICE_API_KEY` — only validated when user explicitly opts in via env. Unset stays the silent-fallback-to-`GEMINI_API_KEY` default, preserving #452 backward compat.

## Scope

**Only startup guards, no runtime probing.** A valid-looking key that's actually revoked will still fail silently on first use. A real Gemini ping on startup would catch that but also costs quota. Left as a follow-up if shape-check misses turn out to be a real problem.

Diff: +23/-1 in one file (`src/voice-agent.ts`).

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `bun test tests/` 91/91 pass (no behavioral change to existing paths).
- [ ] Manual: set `GEMINI_VOICE_API_KEY=foo` → voice-agent fails startup with the helpful error. Clear the var → starts normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)