### PR TITLE
fix(startup): auto-rebuild Sutando.app when source is newer than binary

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -694,7 +694,9 @@ def run_all_checks() -> list[dict]:
         except:
             pids = []
         if pids:
-            checks.append({"name": "sutando-app", "status": "ok", "detail": f"running (⌃C/⌃V/⌃M)"})
+            check = {"name": "sutando-app", "status": "ok", "detail": f"running (⌃C/⌃V/⌃M)"}
+            mark_stale_if_outdated(check, REPO_DIR / "src" / "Sutando" / "main.swift", "src/Sutando/Sutando")
+            checks.append(check)
         else:
             checks.append({"name": "sutando-app", "status": "warn", "detail": "not running — hotkeys disabled"})
 

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -155,19 +155,31 @@ else
 fi
 
 # 5b. Sutando context drop app (global hotkey ⌃C)
-if ! pgrep -f "Sutando" > /dev/null 2>&1; then
-  if [ -f "$REPO/src/Sutando/Sutando" ]; then
-    echo "  Starting Sutando..."
-    "$REPO/src/Sutando/Sutando" > /dev/null 2>&1 &
-    echo "  ✓ Sutando (⌃C/⌃V/⌃M)"
-  elif [ -f "$REPO/src/Sutando/main.swift" ]; then
-    echo "  Compiling Sutando..."
-    if (cd "$REPO/src/Sutando" && swiftc -O -o Sutando main.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation 2>/dev/null); then
-      "$REPO/src/Sutando/Sutando" > /dev/null 2>&1 &
-      echo "  ✓ Sutando compiled and started"
-    else
-      echo "  ⚠ Sutando compile failed — hotkeys disabled"
+SUT_SRC="$REPO/src/Sutando/main.swift"
+SUT_BIN="$REPO/src/Sutando/Sutando"
+
+# Rebuild if source is newer than binary, or binary is missing.
+# Kill any running instance so the fresh binary can take over.
+if [ -f "$SUT_SRC" ] && { [ ! -f "$SUT_BIN" ] || [ "$SUT_SRC" -nt "$SUT_BIN" ]; }; then
+  echo "  Compiling Sutando (source newer than binary)..."
+  if (cd "$REPO/src/Sutando" && swiftc -O -o Sutando main.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation 2>/dev/null); then
+    echo "  ✓ Sutando compiled"
+    if pgrep -f "src/Sutando/Sutando" > /dev/null 2>&1; then
+      pkill -f "src/Sutando/Sutando" 2>/dev/null || true
+      sleep 1
     fi
+  else
+    echo "  ⚠ Sutando compile failed — keeping existing binary if any"
+  fi
+fi
+
+if ! pgrep -f "src/Sutando/Sutando" > /dev/null 2>&1; then
+  if [ -f "$SUT_BIN" ]; then
+    echo "  Starting Sutando..."
+    "$SUT_BIN" > /dev/null 2>&1 &
+    echo "  ✓ Sutando (⌃C/⌃V/⌃M)"
+  else
+    echo "  ⚠ Sutando binary missing — hotkeys disabled"
   fi
 else
   echo "  ✓ Sutando (already running)"


### PR DESCRIPTION
## Summary
- `startup.sh` only compiled `Sutando.app` when the binary was absent, so after #443 (avatar-state menu-bar animations) and #444 (watcher-death notifier) landed, the Apr 6 binary kept running — hotkeys and menu-bar UX were 12 days behind HEAD on my Mini until I manually `rm Sutando && swiftc ...`.
- Compare `main.swift` mtime against the binary. If source is newer (or the binary is missing), recompile and `pkill` the running stale instance so the fresh binary launches cleanly on the next line of the script.
- Tightens the running-instance `pgrep` from `Sutando` to `src/Sutando/Sutando` — the old pattern false-matches other processes in this repo with "Sutando" in their command line.

## Motivation
Caught while Chi asked "is sutando app up to date" — diff between `main.swift` (Apr 18 13:20) and the installed binary (Apr 6 22:05) showed 12 days of missed features. Automating the rebuild check closes that gap without adding new moving parts.

## Test plan
- [x] `bash -n src/startup.sh` — syntax check passes
- [x] Dry-run the mtime compare: `[ src/Sutando/main.swift -nt src/Sutando/Sutando ]` → no-rebuild branch when binary is fresh
- [x] Manually exercised the full path on Mini: rebuilt from source, killed + relaunched, hotkeys still working (PID 64036)
- [ ] Next full `bash src/startup.sh` run should be a no-op for the Sutando block (binary fresher than source)
- [ ] After any future `main.swift` edit, next startup should auto-rebuild + restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)