### PR TITLE
feat(cross-node-sync): add docs/ scope for owner personal assets

### DIFF
--- a/skills/cross-node-sync/SKILL.md
+++ b/skills/cross-node-sync/SKILL.md
@@ -25,6 +25,7 @@ Syncthing would still be the right call if: scope grew past a few hundred files,
 **Syncs (both directions, union semantics via `rsync --update`):**
 - `~/.claude/projects/-Users-xueqingliu-Documents-sutando-sutando/memory/` — cross-session bot memory
 - `<repo>/notes/` — user's second-brain notes
+- `<repo>/docs/` — owner's personal assets (e.g. gitignored `stand-avatar.png`); git handles tracked files, rsync picks up the gitignored personal ones
 
 **Excluded (per-node state):**
 - `state/`, `tasks/`, `results/`, `logs/` — per-bot queues + histories

--- a/skills/cross-node-sync/scripts/list-sync-files.sh
+++ b/skills/cross-node-sync/scripts/list-sync-files.sh
@@ -25,6 +25,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 
 MEM_DIR="$HOME/.claude/projects/-Users-xueqingliu-Documents-sutando-sutando/memory"
 NOTES_DIR="$REPO_ROOT/notes"
+DOCS_DIR="$REPO_ROOT/docs"
 
 list_dir() {
     local root="$1"
@@ -57,4 +58,5 @@ list_dir() {
 {
     list_dir "$MEM_DIR"    "memory"
     list_dir "$NOTES_DIR"  "notes"
+    list_dir "$DOCS_DIR"   "docs"
 } | sort

--- a/skills/cross-node-sync/scripts/setup-rsync-sync.sh
+++ b/skills/cross-node-sync/scripts/setup-rsync-sync.sh
@@ -17,6 +17,10 @@
 #     (cross-session bot memory — MEMORY.md index + feedback/project/ref
 #     markdown files)
 #   - <repo>/notes/             (user's second-brain notes)
+#   - <repo>/docs/              (owner's personal assets — stand-avatar.png
+#     is gitignored so it only converges across nodes via this rsync. The
+#     tracked avatar-default.html is a no-op here since git already keeps
+#     it in sync.)
 #
 # What does NOT sync (per-node, excluded via rsync --exclude):
 #   - state/, tasks/, results/, logs/
@@ -61,6 +65,7 @@ PEER="${SUTANDO_SYNC_PEER:-}"
 MEM_LOCAL="${SUTANDO_MEM_LOCAL_DIR:-$HOME/.claude/projects/$(echo "$REPO_ROOT" | tr '/' '-')/memory/}"
 NOTES_LOCAL="$REPO_ROOT/notes/"
 DATA_LOCAL="$REPO_ROOT/data/"
+DOCS_LOCAL="$REPO_ROOT/docs/"
 
 # Peer-side paths — default to the same literal paths as local so users only
 # need to set SUTANDO_SYNC_PEER (per owner's 2026-04-17 simplification: "only
@@ -70,6 +75,7 @@ DATA_LOCAL="$REPO_ROOT/data/"
 # otherwise leave unset.
 MEM_PEER="${SUTANDO_PEER_MEM_DIR:-$MEM_LOCAL}"
 NOTES_PEER="${SUTANDO_PEER_NOTES_DIR:-$NOTES_LOCAL}"
+DOCS_PEER="${SUTANDO_PEER_DOCS_DIR:-$DOCS_LOCAL}"
 # Data dir peer path: derive from NOTES_PEER (repo/notes/ → repo/data/) if no
 # explicit override. Covers call-metrics.jsonl, voice-metrics.jsonl,
 # subtitle-metrics.jsonl, latency.json, scanned-calls.json, etc. Owner's
@@ -190,6 +196,14 @@ say ""
 say "Syncing notes/ ..."
 run rsync "${RSYNC_FLAGS[@]}" ${DRYFLAG[@]+"${DRYFLAG[@]}"} "$NOTES_LOCAL" "$PEER:$NOTES_PEER"
 run rsync "${RSYNC_FLAGS[@]}" ${DRYFLAG[@]+"${DRYFLAG[@]}"} "$PEER:$NOTES_PEER" "$NOTES_LOCAL"
+
+# 3b) Docs sync (both directions) — converges owner's personal assets like
+# stand-avatar.png. avatar-default.html is tracked so git already syncs it;
+# the meaningful cross-node diff here is the gitignored PNG(s).
+say ""
+say "Syncing docs/ ..."
+run rsync "${RSYNC_FLAGS[@]}" ${DRYFLAG[@]+"${DRYFLAG[@]}"} "$DOCS_LOCAL" "$PEER:$DOCS_PEER"
+run rsync "${RSYNC_FLAGS[@]}" ${DRYFLAG[@]+"${DRYFLAG[@]}"} "$PEER:$DOCS_PEER" "$DOCS_LOCAL"
 
 # 4) Data dir sync — covers all data/* files (call-metrics.jsonl,
 # voice-metrics.jsonl, subtitle-metrics.jsonl, latency.json,


### PR DESCRIPTION
## Summary
- Extends cross-node-sync to include `<repo>/docs/`
- Syncs gitignored personal assets (e.g. `stand-avatar.png`) across Mini ↔ MacBook via rsync
- Tracked files in `docs/` already converge via git — no duplication, no conflict

## Why
Chi asked whether `stand-avatar.png` should move to a private repo. Mini pushed back: separate repo is overkill for 1-2 files; cross-node-sync already rsyncs memory/ and notes/ across nodes, adding docs/ is a one-line scope change. Agreed.

## Scope
- `setup-rsync-sync.sh` — add `DOCS_LOCAL` + `DOCS_PEER` + 2 rsync legs after notes/
- `list-sync-files.sh` — include docs/ in manifest
- `SKILL.md` — document the new scope

## Test plan
- [x] `bash -n` both scripts
- [x] `--dry-run` shows docs/ rsync command
- [ ] Verify with live peer: `SUTANDO_SYNC_PEER=... bash setup-rsync-sync.sh --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)