### PR TITLE
refactor: move stand-avatar.png from docs/ to assets/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ archive/
 assets/
 stand-identity.json
 stand-avatar.png
-docs/stand-avatar.png
 docs/youtube/
 core-status.json
 dynamic-content.json

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -117,7 +117,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func setupMenuBar() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem.button {
-            let avatarPath = workspace + "/docs/stand-avatar.png"
+            let avatarPath = workspace + "/assets/stand-avatar.png"
             if let image = NSImage(contentsOfFile: avatarPath) {
                 image.size = NSSize(width: 18, height: 18)
                 image.isTemplate = false
@@ -374,7 +374,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     self.currentAgentState = "idle"
                 } else {
                     // Default state (disconnected or unmuted): show avatar
-                    let avatarPath = self.workspace + "/docs/stand-avatar.png"
+                    let avatarPath = self.workspace + "/assets/stand-avatar.png"
                     if let image = NSImage(contentsOfFile: avatarPath) {
                         image.size = NSSize(width: 18, height: 18)
                         image.isTemplate = false

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -296,7 +296,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             else:
                 self.send_json(404, {"error": "task not found"})
         elif path == "/avatar":
-            avatar_file = REPO_DIR / "docs" / "stand-avatar.png"
+            avatar_file = REPO_DIR / "assets" / "stand-avatar.png"
             if avatar_file.exists():
                 self.send_response(200)
                 self.send_header("Content-Type", "image/png")

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -327,9 +327,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(html.encode())
         elif urlparse(self.path).path == "/avatar":
-            avatar_file = REPO_DIR / "stand-avatar.png"
+            avatar_file = REPO_DIR / "assets" / "stand-avatar.png"
             if not avatar_file.exists():
-                avatar_file = REPO_DIR / "docs" / "stand-avatar.png"
+                avatar_file = REPO_DIR / "stand-avatar.png"  # legacy root fallback
             if avatar_file.exists():
                 self.send_response(200)
                 self.send_header("Content-Type", "image/png")


### PR DESCRIPTION
## Summary
Moves `docs/stand-avatar.png` → `assets/stand-avatar.png`. Chi's "cross-node-sync docs/ is weird" + Mini's push: `stand-avatar.png` is a runtime asset (consumed by 4 readers), not documentation. It ended up in `docs/` by accident.

## Changes
- File move (untracked; `assets/` already gitignored via `.gitignore:36`, same semantics as before, no leak)
- `.gitignore`: drop obsolete `docs/stand-avatar.png` entry
- `src/Sutando/main.swift` (2 sites), `src/agent-api.py` (1), `src/dashboard.py` (1 + fallback reorder): read from `assets/` now

`docs/` now contains only `avatar-default.html` (actual documentation, per Mini's "keep the design reference").

## Verification
- `/avatar` on agent-api (7843) and dashboard (7844) both return 200 OK after restart
- Sutando.app rebuilt + restarted — menu bar loads from new path
- `npx tsc --noEmit` + `python3 -c ast.parse` pass

## Follow-up
PR B will update `skills/cross-node-sync/` to sync `assets/` (closes #462 which targeted the weirder `docs/` scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)