### PR TITLE
feat(cross-node-sync): add assets/ scope for owner personal assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ archive/
 assets/
 stand-identity.json
 stand-avatar.png
-docs/stand-avatar.png
 docs/youtube/
 core-status.json
 dynamic-content.json

--- a/skills/cross-node-sync/SKILL.md
+++ b/skills/cross-node-sync/SKILL.md
@@ -25,6 +25,7 @@ Syncthing would still be the right call if: scope grew past a few hundred files,
 **Syncs (both directions, union semantics via `rsync --update`):**
 - `~/.claude/projects/-Users-xueqingliu-Documents-sutando-sutando/memory/` — cross-session bot memory
 - `<repo>/notes/` — user's second-brain notes
+- `<repo>/assets/` — owner personal runtime assets (e.g. gitignored `stand-avatar.png`); `/assets` is entirely gitignored, rsync is the only transport
 
 **Excluded (per-node state):**
 - `state/`, `tasks/`, `results/`, `logs/` — per-bot queues + histories

--- a/skills/cross-node-sync/scripts/list-sync-files.sh
+++ b/skills/cross-node-sync/scripts/list-sync-files.sh
@@ -25,6 +25,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 
 MEM_DIR="$HOME/.claude/projects/-Users-xueqingliu-Documents-sutando-sutando/memory"
 NOTES_DIR="$REPO_ROOT/notes"
+ASSETS_DIR="$REPO_ROOT/assets"
 
 list_dir() {
     local root="$1"
@@ -55,6 +56,7 @@ list_dir() {
 }
 
 {
-    list_dir "$MEM_DIR"    "memory"
-    list_dir "$NOTES_DIR"  "notes"
+    list_dir "$MEM_DIR"     "memory"
+    list_dir "$NOTES_DIR"   "notes"
+    list_dir "$ASSETS_DIR"  "assets"
 } | sort

--- a/skills/cross-node-sync/scripts/setup-rsync-sync.sh
+++ b/skills/cross-node-sync/scripts/setup-rsync-sync.sh
@@ -17,6 +17,9 @@
 #     (cross-session bot memory — MEMORY.md index + feedback/project/ref
 #     markdown files)
 #   - <repo>/notes/             (user's second-brain notes)
+#   - <repo>/assets/            (owner personal runtime assets — e.g.
+#     gitignored stand-avatar.png. `/assets` is entirely gitignored so
+#     git never sees these, and rsync keeps the nodes converged.)
 #
 # What does NOT sync (per-node, excluded via rsync --exclude):
 #   - state/, tasks/, results/, logs/
@@ -61,6 +64,7 @@ PEER="${SUTANDO_SYNC_PEER:-}"
 MEM_LOCAL="${SUTANDO_MEM_LOCAL_DIR:-$HOME/.claude/projects/$(echo "$REPO_ROOT" | tr '/' '-')/memory/}"
 NOTES_LOCAL="$REPO_ROOT/notes/"
 DATA_LOCAL="$REPO_ROOT/data/"
+ASSETS_LOCAL="$REPO_ROOT/assets/"
 
 # Peer-side paths — default to the same literal paths as local so users only
 # need to set SUTANDO_SYNC_PEER (per owner's 2026-04-17 simplification: "only
@@ -70,6 +74,7 @@ DATA_LOCAL="$REPO_ROOT/data/"
 # otherwise leave unset.
 MEM_PEER="${SUTANDO_PEER_MEM_DIR:-$MEM_LOCAL}"
 NOTES_PEER="${SUTANDO_PEER_NOTES_DIR:-$NOTES_LOCAL}"
+ASSETS_PEER="${SUTANDO_PEER_ASSETS_DIR:-$ASSETS_LOCAL}"
 # Data dir peer path: derive from NOTES_PEER (repo/notes/ → repo/data/) if no
 # explicit override. Covers call-metrics.jsonl, voice-metrics.jsonl,
 # subtitle-metrics.jsonl, latency.json, scanned-calls.json, etc. Owner's
@@ -190,6 +195,14 @@ say ""
 say "Syncing notes/ ..."
 run rsync "${RSYNC_FLAGS[@]}" ${DRYFLAG[@]+"${DRYFLAG[@]}"} "$NOTES_LOCAL" "$PEER:$NOTES_PEER"
 run rsync "${RSYNC_FLAGS[@]}" ${DRYFLAG[@]+"${DRYFLAG[@]}"} "$PEER:$NOTES_PEER" "$NOTES_LOCAL"
+
+# 3b) Assets sync (both directions) — converges owner personal runtime
+# assets (e.g. stand-avatar.png) across nodes. /assets is entirely
+# gitignored; rsync is the only transport.
+say ""
+say "Syncing assets/ ..."
+run rsync "${RSYNC_FLAGS[@]}" ${DRYFLAG[@]+"${DRYFLAG[@]}"} "$ASSETS_LOCAL" "$PEER:$ASSETS_PEER"
+run rsync "${RSYNC_FLAGS[@]}" ${DRYFLAG[@]+"${DRYFLAG[@]}"} "$PEER:$ASSETS_PEER" "$ASSETS_LOCAL"
 
 # 4) Data dir sync — covers all data/* files (call-metrics.jsonl,
 # voice-metrics.jsonl, subtitle-metrics.jsonl, latency.json,

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -117,7 +117,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func setupMenuBar() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem.button {
-            let avatarPath = workspace + "/docs/stand-avatar.png"
+            let avatarPath = workspace + "/assets/stand-avatar.png"
             if let image = NSImage(contentsOfFile: avatarPath) {
                 image.size = NSSize(width: 18, height: 18)
                 image.isTemplate = false
@@ -374,7 +374,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     self.currentAgentState = "idle"
                 } else {
                     // Default state (disconnected or unmuted): show avatar
-                    let avatarPath = self.workspace + "/docs/stand-avatar.png"
+                    let avatarPath = self.workspace + "/assets/stand-avatar.png"
                     if let image = NSImage(contentsOfFile: avatarPath) {
                         image.size = NSSize(width: 18, height: 18)
                         image.isTemplate = false

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -296,7 +296,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             else:
                 self.send_json(404, {"error": "task not found"})
         elif path == "/avatar":
-            avatar_file = REPO_DIR / "docs" / "stand-avatar.png"
+            avatar_file = REPO_DIR / "assets" / "stand-avatar.png"
             if avatar_file.exists():
                 self.send_response(200)
                 self.send_header("Content-Type", "image/png")

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -327,9 +327,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(html.encode())
         elif urlparse(self.path).path == "/avatar":
-            avatar_file = REPO_DIR / "stand-avatar.png"
+            avatar_file = REPO_DIR / "assets" / "stand-avatar.png"
             if not avatar_file.exists():
-                avatar_file = REPO_DIR / "docs" / "stand-avatar.png"
+                avatar_file = REPO_DIR / "stand-avatar.png"  # legacy root fallback
             if avatar_file.exists():
                 self.send_response(200)
                 self.send_header("Content-Type", "image/png")


### PR DESCRIPTION
## Summary
Follow-up to **#463** (the `docs/` → `assets/` move). Extends cross-node-sync to include `<repo>/assets/` so the gitignored `stand-avatar.png` converges between MacBook ↔ Mini automatically.

**Depends on:** #463 (must merge first — this PR bases on that branch)

**Replaces:** #462 (closed — targeted the weirder `docs/` scope)

## Changes
- `setup-rsync-sync.sh` — add `ASSETS_LOCAL` + `ASSETS_PEER` + 2 rsync legs (matching notes/ pattern, union-with-update conflict semantics)
- `list-sync-files.sh` — include `assets/` in manifest
- `SKILL.md` — document new scope

## Test plan
- [x] `bash -n` both scripts
- [x] `--dry-run` shows `Syncing assets/` block with correct rsync args
- [ ] Live: `SUTANDO_SYNC_PEER=... bash setup-rsync-sync.sh --dry-run` with real peer

## Merge order
Merge **#463 first** (makes `assets/stand-avatar.png` live on main), then rebase + merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)