### PR TITLE
fix(web-client): core-agent working wins over browser listening

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -2231,19 +2231,22 @@ function effectiveAgentState(): AgentState {
 		_preSeeingToolState = 'idle';
 	}
 	if (_toolState !== 'idle') return _toolState;
-	if (_browserState !== 'idle') return _browserState;
-	// No explicit state — fall through to core-status. If the proactive loop
-	// or any Claude Code pass is active, surface that as `working`.
+	// Core-agent work (proactive-loop / CLI pass) takes precedence over
+	// browser state. When the user is speaking (browser=listening) AND
+	// the core agent is actively running a pass, "working" is the true
+	// state — speaking is transient input, the pass is the real activity.
+	// Chi UX ask 2026-04-19: working-while-listening must show working.
 	const core = readCoreStatus();
 	if (core.running) return 'working';
-	// Core is idle OR the file is stale. If stale, ask the tmux scrape for a
-	// hint — useful when a pass crashed before writing idle, or when the CLI
-	// is actively doing something but forgot to write. Fresh-idle file wins
-	// over tmux to prevent the scrape from spuriously lighting up the pulse.
+	// Stale core-status falls back to the tmux scrape — useful when a
+	// pass crashed before writing idle, or when the CLI is active but
+	// forgot to write. Fresh-idle file wins over tmux to prevent the
+	// scrape from spuriously lighting up the pulse.
 	if (core.stale) {
 		const scrape = readTmuxStatus();
 		if (scrape.state === 'working') return 'working';
 	}
+	if (_browserState !== 'idle') return _browserState;
 	return 'idle';
 }
 


### PR DESCRIPTION
## Summary
- `effectiveAgentState()` used to return the browser-derived state (`listening`/`speaking`) **before** checking core-status.json.
- So when Chi spoke to the voice-agent while the core-agent Claude Code session was mid-pass, the UI showed `listening` instead of `working` — the louder signal but not the truer one.
- Hoist the core-status check (and its stale-file tmux-scrape fallback) above the browser-state check.

## New precedence

```
tool > core-running > core-stale+tmux-working > browser > idle
```

Tool track (voice-agent onToolCall) is unchanged at the top — only the gap between tool and browser changed.

Semantics: a user's speech is transient input; a running core-agent pass is ongoing activity. Surface the activity.

## Context
- User ask from #bot2bot 2026-04-19 17:29Z: "when 'working' and 'listening' at the same time, 'working' should be the state" — clarifying that the `working` in question is the core-agent (proactive-loop), not voice-agent tool calls.
- Complementary to #461 (PNG state-ring animations).

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Reload web UI with this branch running; speak into voice; verify halo stays `working` (blue) when a proactive-loop pass is active, `listening` (violet) otherwise
- [ ] Idle + speaking-with-no-core-pass path still returns listening
- [ ] Stale-core-status + tmux-scrape=working path still trips (regression check for #448)

🤖 Generated with [Claude Code](https://claude.com/claude-code)