### PR TITLE
redesign(web-client): task-card collapse-by-default + typography polish

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -208,13 +208,13 @@ const HTML = /* html */ `<!DOCTYPE html>
   .hero-svg-wrap { width: 80px; height: 80px; margin-bottom: 16px; display: none; }
 
   .header .info { flex: 1; }
-  .header h1 { color: #fff; font-size: 1.1em; font-weight: 500; }
-  .header .meta { font-size: 11px; color: #555; display: flex; gap: 12px; align-items: center; margin-top: 2px; }
-  .header .meta a { color: #555; text-decoration: none; border-bottom: 1px dotted #333; }
-  .header .meta a:hover { color: #888; }
+  .header h1 { color: #fff; font-size: 1.15em; font-weight: 500; }
+  .header .meta { font-size: 14px; color: #777; display: flex; gap: 14px; align-items: center; margin-top: 4px; }
+  .header .meta a { color: #888; text-decoration: none; border-bottom: 1px dotted #444; }
+  .header .meta a:hover { color: #bbb; }
   .status-pill {
     display: inline-flex; align-items: center; gap: 5px;
-    padding: 2px 8px; border-radius: 10px; font-size: 10px; font-weight: 500;
+    padding: 3px 10px; border-radius: 11px; font-size: 12px; font-weight: 500;
   }
   .status-pill.voice-on { background: #1a2e24; color: #4ecca3; }
   .status-pill.voice-off { background: #1a1a2e; color: #666; }
@@ -249,7 +249,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   #transcript {
     min-height: 80px; max-height: 30vh;
     background: #0e0e18; border-radius: 12px; padding: 10px 14px;
-    overflow-y: auto; font-size: 18px; line-height: 1.6;
+    overflow-y: auto; font-size: 16px; line-height: 1.6;
     margin-bottom: 6px;
   }
   .t-entry { margin-bottom: 8px; position: relative; user-select: text; }
@@ -264,8 +264,8 @@ const HTML = /* html */ `<!DOCTYPE html>
   .t-user::before { content: 'You: '; font-weight: 600; color: #5a9fd4; }
   .t-assistant { color: #a8d8b0; }
   .t-assistant::before { content: 'Sutando: '; font-weight: 600; color: #6dbe82; }
-  .t-system { color: #999; font-size: 16px; }
-  .t-interim { color: #7fb3e0; opacity: 0.5; font-size: 18px; }
+  .t-system { color: #888; font-size: 14px; }
+  .t-interim { color: #7fb3e0; opacity: 0.5; font-size: 16px; }
   .t-interim::before { content: 'You: '; font-weight: 600; }
 
   /* Input bar */
@@ -321,7 +321,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   .task-expand:hover { background: #3a5075; color: #ffffff; }
 
   /* Dynamic region */
-  #dynamic-region { padding: 0 16px 8px; width: 100%; box-sizing: border-box; user-select: text; -webkit-user-select: text; }
+  #dynamic-region { padding: 14px 16px 8px; width: 100%; box-sizing: border-box; user-select: text; -webkit-user-select: text; }
   #dynamic-region:empty { display: none; }
   #core-status-bar { font-size: 11px; color: #555; }
   #core-status-bar:empty { display: none; }
@@ -349,12 +349,12 @@ const HTML = /* html */ `<!DOCTYPE html>
     border: 1px solid #2e2818; background: #12100a; color: #ccc; outline: none;
   }
   #dynamic-region .q-input:focus { border-color: #f0ad4e66; }
-  #dynamic-region .dr-proactive { text-align: center; padding: 10px; font-size: 18px; color: #a8b8c6; }
+  #dynamic-region .dr-proactive { text-align: center; padding: 10px; font-size: 16px; color: #a8b8c6; }
   #dynamic-region .dr-chips { text-align: center; }
   #dynamic-region .dr-chips .suggestions-label { margin-bottom: 8px; }
   #dynamic-region .dr-chips .suggestion {
     display: inline-block; background: #1a1a2e; border: 1px solid #2a2a4e;
-    border-radius: 18px; padding: 8px 18px; margin: 4px; font-size: 18px;
+    border-radius: 16px; padding: 7px 15px; margin: 4px; font-size: 15px;
     color: #8899a6; cursor: pointer; transition: all 0.2s;
   }
   #dynamic-region .dr-chips .suggestion:hover { background: #2a2a4e; color: #ccc; border-color: #4a4a6e; }
@@ -367,7 +367,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   #dynamic-region .dr-document {
     background: #12121e; border: 1px solid #1e1e30; border-radius: 10px; padding: 12px 16px;
   }
-  #dynamic-region .dr-doc-body { color: #ccc; font-size: 18px; line-height: 1.6; white-space: pre-wrap; }
+  #dynamic-region .dr-doc-body { color: #ccc; font-size: 15px; line-height: 1.6; white-space: pre-wrap; }
 
   /* Section labels */
   .section-label {
@@ -1975,7 +1975,7 @@ function updateTabHighlights() {
     var border = isActive ? '#4a4a6e' : '#2a2a3e';
     if (t.id === 'questions' && questions.length > 0 && !isActive) fg = '#f0ad4e';
     if (t.id === 'tasks' && hasNewTasks && !isActive) fg = '#4ecca3';
-    return '<span onclick="switchDRTab(&quot;' + t.id + '&quot;)" style="cursor:pointer;padding:8px 0;border-radius:14px;font-size:18px;border:1px solid ' + border + ';background:' + bg + ';color:' + fg + ';flex:1;text-align:center">' + t.label + '</span>';
+    return '<span onclick="switchDRTab(&quot;' + t.id + '&quot;)" style="cursor:pointer;padding:6px 0;border-radius:12px;font-size:14px;border:1px solid ' + border + ';background:' + bg + ';color:' + fg + ';flex:1;text-align:center">' + t.label + '</span>';
   }).join('');
 }
 

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -307,7 +307,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   .task-status.working { background: #1e3a5f; color: #60a5fa; animation: pulse 1.5s infinite; }
   .task-status.done { background: #1e4028; color: #4ecca3; }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
-  .task-text { color: #d0d0d8; flex: 1; word-break: break-word; font-size: 18px; line-height: 1.4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .task-text { color: #d0d0d8; flex: 1; word-break: break-word; font-size: 18px; line-height: 1.65; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .task-text.expanded { white-space: normal; }
   .task-time { color: #777; font-size: 13px; flex-shrink: 0; }
   .task-expand {
@@ -2005,10 +2005,10 @@ function renderTabContent() {
       var html = '';
       window._allNotes = notes;
       notes.forEach(function(n) {
-        html += '<div class="note-item" data-title="' + esc(n.title).toLowerCase() + '" data-slug="' + n.slug + '" style="padding:6px 0;border-bottom:1px solid #2a2a3e;display:flex;align-items:center">' +
+        html += '<div class="note-item" data-title="' + esc(n.title).toLowerCase() + '" data-slug="' + n.slug + '" style="padding:12px 0;border-bottom:1px solid #2a2a3e;display:flex;align-items:center;font-size:18px;line-height:1.65">' +
           '<span style="color:#7c83ff;cursor:pointer;flex:1" onclick="showNoteContent(&quot;' + n.slug + '&quot;)">' + n.title + '</span>' +
-          '<span style="color:#666;font-size:11px;margin-right:8px">' + new Date(n.modified*1000).toLocaleDateString() + '</span>' +
-          '<span style="color:#e94560;font-size:11px;cursor:pointer;opacity:0.5" onclick="event.stopPropagation();deleteNoteFromUI(&quot;' + n.slug + '&quot;)">x</span></div>';
+          '<span style="color:#666;font-size:13px;margin-right:8px">' + new Date(n.modified*1000).toLocaleDateString() + '</span>' +
+          '<span style="color:#e94560;font-size:13px;cursor:pointer;opacity:0.5" onclick="event.stopPropagation();deleteNoteFromUI(&quot;' + n.slug + '&quot;)">x</span></div>';
       });
       if (!html) html = '<div style="color:#666;font-size:12px;text-align:center;padding:12px">No notes</div>';
       container.innerHTML = searchHtml + html;

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -952,10 +952,10 @@ function summarizeTaskText(raw) {
   const cuts = [' (', ' — ', ' - ', ': ', '. ', ', '];
   for (const c of cuts) {
     const idx = s.indexOf(c);
-    if (idx > 0 && idx < 60) { s = s.slice(0, idx); break; }
+    if (idx > 0 && idx < 90) { s = s.slice(0, idx); break; }
   }
-  // Final safety: never let a single phrase exceed ~50 chars
-  if (s.length > 50) s = s.slice(0, 47) + '…';
+  // Final safety: never let a single phrase exceed ~85 chars
+  if (s.length > 85) s = s.slice(0, 82) + '…';
   return s;
 }
 

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -295,27 +295,27 @@ const HTML = /* html */ `<!DOCTYPE html>
   }
   #tasks:empty { display: none; }
   .task-item {
-    display: flex; align-items: center; gap: 10px;
-    padding: 9px 0; border-bottom: 1px solid #141420;
+    display: flex; align-items: center; gap: 13px;
+    padding: 15px 0; border-bottom: 1px solid #141420;
   }
   .task-item:last-child { border-bottom: none; }
   .task-status {
-    width: 20px; height: 20px; border-radius: 50%;
+    width: 22px; height: 22px; border-radius: 50%;
     display: flex; align-items: center; justify-content: center;
-    font-size: 11px; flex-shrink: 0;
+    font-size: 12px; flex-shrink: 0;
   }
   .task-status.working { background: #1e3a5f; color: #60a5fa; animation: pulse 1.5s infinite; }
   .task-status.done { background: #1e4028; color: #4ecca3; }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
-  .task-text { color: #c0c0c8; flex: 1; word-break: break-word; font-size: 16px; line-height: 1.4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .task-text { color: #d0d0d8; flex: 1; word-break: break-word; font-size: 18px; line-height: 1.4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .task-text.expanded { white-space: normal; }
-  .task-time { color: #666; font-size: 12px; flex-shrink: 0; }
+  .task-time { color: #777; font-size: 13px; flex-shrink: 0; }
   .task-expand {
-    flex-shrink: 0; padding: 3px 9px; border-radius: 10px;
-    background: #1a2030; color: #8ab4c8; font-size: 12px; cursor: pointer;
-    border: 1px solid #2a3344; user-select: none;
+    flex-shrink: 0; padding: 5px 12px; border-radius: 12px;
+    background: #2a4060; color: #d8e8f8; font-size: 13px; font-weight: 500;
+    cursor: pointer; border: 1px solid #3a5075; user-select: none;
   }
-  .task-expand:hover { background: #233045; color: #aac4d8; }
+  .task-expand:hover { background: #3a5075; color: #ffffff; }
 
   /* Dynamic region */
   #dynamic-region { padding: 0 16px 8px; width: 100%; box-sizing: border-box; user-select: text; -webkit-user-select: text; }
@@ -878,17 +878,18 @@ function updateTask(taskId, status, text, result) {
   if (isNew && window._drActiveTab === 'starter') { switchDRTab('tasks'); }
   // Auto-expand ONLY ongoing tasks (working/pending) so the user sees progress.
   // Done tasks stay collapsed by default — user clicks the "Show details" chip.
-  // (Was: auto-expand every newly-done task, which filled the pane with walls of text.)
   if (status === 'working' && !expandedTasks.has(taskId)) {
     expandedTasks.add(taskId);
   }
-  // When a task transitions done, explicitly collapse it (done → fold).
-  if (status === 'done' && !wasDone) {
+  // When a task transitions done, auto-collapse — UNLESS the user manually
+  // expanded it (userExpanded set). Prevents the "2s flash then close" bug.
+  if (status === 'done' && !wasDone && !userExpanded.has(taskId)) {
     expandedTasks.delete(taskId);
   }
   renderTasks();
 }
 const expandedTasks = window.expandedTasks = new Set();
+const userExpanded = window.userExpanded = new Set(); // user-initiated expands — never auto-collapse these
 let userCollapsed = false; // user manually collapsed — suppress auto-expand
 // Listen for external collapse/expand commands (from inline tools via AppleScript)
 new MutationObserver(() => {
@@ -896,7 +897,7 @@ new MutationObserver(() => {
   if (document.body.dataset.taskAction === 'expand') { Object.keys(taskMap).forEach(id => { if (taskMap[id].result) expandedTasks.add(id); }); userCollapsed = false; renderTasks(); document.body.dataset.taskAction = ''; }
 }).observe(document.body, { attributes: true, attributeFilter: ['data-task-action'] });
 function toggleResult(taskId) {
-  if (expandedTasks.has(taskId)) { expandedTasks.delete(taskId); } else { expandedTasks.add(taskId); userCollapsed = false; }
+  if (expandedTasks.has(taskId)) { expandedTasks.delete(taskId); userExpanded.delete(taskId); } else { expandedTasks.add(taskId); userExpanded.add(taskId); userCollapsed = false; }
   const el = document.getElementById('result-' + taskId);
   if (el) el.style.display = expandedTasks.has(taskId) ? 'block' : 'none';
 }
@@ -915,6 +916,22 @@ document.addEventListener('click', function(e) {
   const item = e.target.closest && e.target.closest('.task-item[data-taskid]');
   if (item) toggleResult(item.dataset.taskid);
 });
+// Strip clauses / parens / colons and keep the head of the first sentence.
+// "Polymarket research summary (pulled from Studio…" → "Polymarket research summary"
+function summarizeTaskText(raw) {
+  if (!raw) return '';
+  let s = String(raw).trim();
+  // Cut at first strong boundary
+  const cuts = [' (', ' — ', ' - ', ': ', '. ', ', '];
+  for (const c of cuts) {
+    const idx = s.indexOf(c);
+    if (idx > 0 && idx < 60) { s = s.slice(0, idx); break; }
+  }
+  // Final safety: never let a single phrase exceed ~50 chars
+  if (s.length > 50) s = s.slice(0, 47) + '…';
+  return s;
+}
+
 function renderTasks() {
   const container = $('tasks');
   const entries = Object.entries(taskMap);
@@ -933,7 +950,7 @@ function renderTasks() {
     const resultDisplay = isExpanded ? 'block' : 'none';
     const resultHtml = hasResult ? '<div id="result-' + id + '" style="display:' + resultDisplay + ';padding:8px 12px;color:#b8c8d8;font-size:12px;line-height:1.5;white-space:pre-wrap;word-break:break-word;background:#0d1520;border-radius:8px;margin:4px 0 6px 30px">' + t.result.replace(/</g,'&lt;') + '</div>' : '';
     const rawText = t.text || id;
-    const displayText = rawText.length > 40 && !isExpanded ? rawText.slice(0, 37) + '…' : rawText;
+    const displayText = isExpanded ? rawText : summarizeTaskText(rawText);
     const textClass = isExpanded ? 'task-text expanded' : 'task-text';
     const expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide ▾' : 'Show details ▸') + '</span>' : '';
     return '<div class="task-item"' + clickAttr + '>' +
@@ -981,11 +998,12 @@ function startTaskPolling() {
         if (t.status === 'done' && existing.status && existing.status !== 'done') {
           showToast('<span class="toast-label">Done</span> ' + (t.text || t.id).slice(0, 60));
         }
-        // Auto-expand ONLY working tasks (progress visibility). Done = collapse.
+        // Auto-expand ONLY working tasks (progress visibility). Done = collapse,
+        // unless the user manually expanded it via the chip (userExpanded set).
         if (t.status === 'working' && !expandedTasks.has(t.id)) {
           expandedTasks.add(t.id);
         }
-        if (t.status === 'done' && existing.status !== 'done') {
+        if (t.status === 'done' && existing.status !== 'done' && !userExpanded.has(t.id)) {
           expandedTasks.delete(t.id);
         }
         taskMap[t.id] = { status: t.status, text: t.text, time: new Date(t.time * 1000), result: t.result || existing.result || '' };

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -1983,11 +1983,15 @@ function renderTabContent() {
 
   if (tab === 'starter') {
     // Cap at 5 chips per Susan's "show fewer cards rather than shrink" rule.
+    // Also cap each chip's visible label at ~32 chars so "PR 470 — task-card
+    // redesign" stays terse — full text still available via title tooltip.
     container.innerHTML = '<div class="dr-chips">' +
       '<div class="suggestions-label" style="font-size:14px;color:#999;margin-bottom:6px">Try saying or typing</div>' +
       getSuggestionChips().slice(0, 5).map(function(c) {
-        return '<span class="suggestion" onclick="trySuggestion(this)">' +
-          c.label + (c.desc ? ' — ' + c.desc : '') + '</span>';
+        var full = c.label + (c.desc ? ' — ' + c.desc : '');
+        var short = full.length > 32 ? full.slice(0, 30) + '…' : full;
+        return '<span class="suggestion" title="' + esc(full) + '" onclick="trySuggestion(this)">' +
+          esc(short) + '</span>';
       }).join('') + '</div>';
     window._drLocalContent = false;
 

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -279,8 +279,8 @@ const HTML = /* html */ `<!DOCTYPE html>
     display: flex; gap: 8px;
   }
   .input-bar input {
-    flex: 1; padding: 10px 14px; border-radius: 10px;
-    border: 1px solid #1e1e30; background: #0e0e18; color: #fff; font-size: 13px;
+    flex: 1; padding: 12px 16px; border-radius: 10px;
+    border: 1px solid #1e1e30; background: #0e0e18; color: #fff; font-size: 16px;
     outline: none;
   }
   .input-bar input:focus { border-color: #4ecca3; }
@@ -329,14 +329,14 @@ const HTML = /* html */ `<!DOCTYPE html>
   #core-status-bar .core-idle { color: #444; }
   #dynamic-region .dr-questions {
     background: linear-gradient(135deg, #1e1a12, #2a2218); border: 1px solid #f0ad4e44;
-    border-radius: 10px; padding: 12px 16px; font-size: 13px; box-shadow: 0 0 12px #f0ad4e22;
+    border-radius: 10px; padding: 14px 18px; font-size: 16px; box-shadow: 0 0 12px #f0ad4e22;
   }
-  #dynamic-region .dr-questions .q-title { color: #f0ad4e; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }
-  #dynamic-region .dr-questions .q-item { color: #ddd; padding: 8px 0; border-bottom: 1px solid #2e281844; }
+  #dynamic-region .dr-questions .q-title { color: #f0ad4e; font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+  #dynamic-region .dr-questions .q-item { color: #ddd; padding: 10px 0; border-bottom: 1px solid #2e281844; }
   #dynamic-region .dr-questions .q-item:last-child { border-bottom: none; }
-  #dynamic-region .q-actions { margin-top: 8px; display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+  #dynamic-region .q-actions { margin-top: 10px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
   #dynamic-region .q-btn {
-    padding: 4px 14px; border-radius: 14px; font-size: 11px; cursor: pointer;
+    padding: 6px 16px; border-radius: 14px; font-size: 15px; cursor: pointer;
     border: 1px solid #2e2818; background: #1e1a12; color: #ccc; transition: all 0.15s;
   }
   #dynamic-region .q-btn:hover { background: #2e2818; border-color: #f0ad4e66; }
@@ -345,7 +345,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   #dynamic-region .q-btn.q-no { border-color: #e9456066; color: #e94560; }
   #dynamic-region .q-btn.q-no:hover { background: #3a1520; }
   #dynamic-region .q-input {
-    flex: 1; min-width: 120px; padding: 4px 10px; border-radius: 14px; font-size: 11px;
+    flex: 1; min-width: 120px; padding: 6px 12px; border-radius: 14px; font-size: 15px;
     border: 1px solid #2e2818; background: #12100a; color: #ccc; outline: none;
   }
   #dynamic-region .q-input:focus { border-color: #f0ad4e66; }

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -349,7 +349,7 @@ const HTML = /* html */ `<!DOCTYPE html>
     border: 1px solid #2e2818; background: #12100a; color: #ccc; outline: none;
   }
   #dynamic-region .q-input:focus { border-color: #f0ad4e66; }
-  #dynamic-region .dr-proactive { text-align: center; padding: 8px; font-size: 13px; color: #8899a6; }
+  #dynamic-region .dr-proactive { text-align: center; padding: 10px; font-size: 18px; color: #a8b8c6; }
   #dynamic-region .dr-chips { text-align: center; }
   #dynamic-region .dr-chips .suggestions-label { margin-bottom: 8px; }
   #dynamic-region .dr-chips .suggestion {
@@ -367,7 +367,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   #dynamic-region .dr-document {
     background: #12121e; border: 1px solid #1e1e30; border-radius: 10px; padding: 12px 16px;
   }
-  #dynamic-region .dr-doc-body { color: #bbb; font-size: 13px; line-height: 1.5; white-space: pre-wrap; }
+  #dynamic-region .dr-doc-body { color: #ccc; font-size: 18px; line-height: 1.6; white-space: pre-wrap; }
 
   /* Section labels */
   .section-label {

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -1978,7 +1978,10 @@ function renderTabContent() {
     window._drLocalContent = false;
 
   } else if (tab === 'tasks') {
-    // Render tasks directly from taskMap
+    // Render tasks using the shared .task-item classes + renderTasks()
+    // template (summarizeTaskText / userExpanded / hover / 18px). Previous
+    // inline-styled path was dead-code that bypassed all CSS work — see
+    // Maddy's 2026-04-19 16:07 ET root-cause writeup.
     var entries = Object.entries(taskMap);
     if (entries.length === 0) {
       container.innerHTML = '<div style="color:#666;font-size:12px;text-align:center;padding:12px">No recent tasks</div>';
@@ -1991,11 +1994,18 @@ function renderTabContent() {
         var timeStr = ago < 60 ? ago + 's ago' : Math.round(ago / 60) + 'm ago';
         var hasResult = t.result && t.status === 'done';
         var isExpanded = expandedTasks.has(id);
-        var resultHtml = hasResult ? '<div style="display:' + (isExpanded ? 'block' : 'none') + ';padding:6px 12px;color:#8ab4c8;font-size:11px;white-space:pre-wrap;word-break:break-word;overflow-wrap:break-word;background:#0d1520;border-radius:6px;margin:4px 0;max-width:100%;box-sizing:border-box">' + esc(t.result) + '</div>' : '';
-        return '<div style="padding:4px 0;border-bottom:1px solid #1a2a3a;cursor:' + (hasResult ? 'pointer' : 'default') + '" onclick="if(this.nextElementSibling)this.nextElementSibling.style.display=this.nextElementSibling.style.display===&quot;none&quot;?&quot;block&quot;:&quot;none&quot;">' +
-          '<span style="color:' + (t.status==='done' ? '#4ecca3' : t.status==='working' ? '#f0ad4e' : '#666') + ';font-size:12px">' + (icons[t.status] || '?') + '</span> ' +
-          '<span style="font-size:12px;color:#ccc">' + esc(t.text || id) + '</span>' +
-          '<span style="float:right;font-size:10px;color:#555">' + timeStr + '</span>' +
+        var clickAttr = hasResult ? ' data-taskid="' + id + '" style="cursor:pointer"' : '';
+        var resultDisplay = isExpanded ? 'block' : 'none';
+        var resultHtml = hasResult ? '<div id="result-' + id + '" style="display:' + resultDisplay + ';padding:8px 12px;color:#b8c8d8;font-size:12px;line-height:1.5;white-space:pre-wrap;word-break:break-word;background:#0d1520;border-radius:8px;margin:4px 0 6px 30px">' + esc(t.result) + '</div>' : '';
+        var rawText = t.text || id;
+        var displayText = isExpanded ? rawText : summarizeTaskText(rawText);
+        var textClass = isExpanded ? 'task-text expanded' : 'task-text';
+        var expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide &#9662;' : 'Show details &#9656;') + '</span>' : '';
+        return '<div class="task-item"' + clickAttr + '>' +
+          '<div class="task-status ' + t.status + '">' + (icons[t.status] || '?') + '</div>' +
+          '<span class="' + textClass + '">' + displayText + '</span>' +
+          '<span class="task-time">' + timeStr + '</span>' +
+          expandChip +
           '</div>' + resultHtml;
       }).join('');
     }

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -1997,7 +1997,7 @@ function renderTabContent() {
     // Also cap each chip's visible label at ~32 chars so "PR 470 — task-card
     // redesign" stays terse — full text still available via title tooltip.
     container.innerHTML = '<div class="dr-chips">' +
-      '<div class="suggestions-label" style="font-size:14px;color:#999;margin-bottom:16px">Try saying or typing</div>' +
+      '<div class="suggestions-label" style="font-size:14px;color:#999;margin-bottom:28px">Try saying or typing</div>' +
       getSuggestionChips().slice(0, 5).map(function(c) {
         var full = c.label + (c.desc ? ' — ' + c.desc : '');
         var short = full.length > 32 ? full.slice(0, 30) + '…' : full;

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -307,7 +307,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   .task-status.working { background: #1e3a5f; color: #60a5fa; animation: pulse 1.5s infinite; }
   .task-status.done { background: #1e4028; color: #4ecca3; }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
-  .task-text { color: #c0c0c8; flex: 1; word-break: break-word; font-size: 13px; line-height: 1.4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .task-text { color: #c0c0c8; flex: 1; word-break: break-word; font-size: 14px; line-height: 1.4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .task-text.expanded { white-space: normal; }
   .task-time { color: #666; font-size: 11px; flex-shrink: 0; }
   .task-expand {
@@ -930,7 +930,7 @@ function renderTasks() {
     const resultDisplay = isExpanded ? 'block' : 'none';
     const resultHtml = hasResult ? '<div id="result-' + id + '" style="display:' + resultDisplay + ';padding:8px 12px;color:#b8c8d8;font-size:12px;line-height:1.5;white-space:pre-wrap;word-break:break-word;background:#0d1520;border-radius:8px;margin:4px 0 6px 30px">' + t.result.replace(/</g,'&lt;') + '</div>' : '';
     const rawText = t.text || id;
-    const displayText = rawText.length > 60 && !isExpanded ? rawText.slice(0, 57) + '…' : rawText;
+    const displayText = rawText.length > 100 && !isExpanded ? rawText.slice(0, 97) + '…' : rawText;
     const textClass = isExpanded ? 'task-text expanded' : 'task-text';
     const expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide ▾' : 'Show details ▸') + '</span>' : '';
     return '<div class="task-item"' + clickAttr + '>' +

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -919,23 +919,24 @@ document.addEventListener('click', function(e) {
   const item = e.target.closest && e.target.closest('.task-item[data-taskid]');
   if (item) toggleResult(item.dataset.taskid);
 });
-// Strip routing prefixes ([Discord @handle], [Replying to ...], [File attached: ...])
-// and clause fragments; keep a short semantic label.
+// Collapse routing prefixes to a short category badge + clause head.
 // "[Discord @susanliu_] maybe make it look more like this, add emoji in front"
-//   → "maybe make it look more like this"
+//   → "[Discord] maybe make it look more like this"
+// Keeps the origin channel visible per Susan's 16:53 ask while still
+// dropping the noisy handle+replyTo+file-attached chunks.
 // NOTE: regex literals live inside the HTML template string — single \ is
 // eaten by the template literal parser (so /\s+/g turns into /s+/g in the
 // browser and strips s characters!). Double-escape every backslash.
 function summarizeTaskText(raw) {
   if (!raw) return '';
   let s = String(raw).trim();
-  // Strip leading routing / reply / attachment brackets (iteratively — a task
-  // may have multiple: "[Discord @X] [Replying to Y] actual content").
+  // Collapse "[Discord @handle]" → "[Discord]", "[Voice foo]" → "[Voice]", etc.
+  // Iterate because a task may have multiple stacked prefixes.
   for (let i = 0; i < 4; i++) {
     const before = s;
-    s = s.replace(/^\\[Discord[^\\]]*\\]\\s*/i, '');
-    s = s.replace(/^\\[Replying to[^\\]]*\\]\\s*/i, '');
-    s = s.replace(/^\\[Voice[^\\]]*\\]\\s*/i, '');
+    s = s.replace(/^\\[(Discord|Voice|Replying to|Reply)[^\\]]*\\]\\s*/i, function(_, kind) {
+      return '[' + (kind.toLowerCase() === 'replying to' || kind.toLowerCase() === 'reply' ? 'Reply' : kind.charAt(0).toUpperCase() + kind.slice(1).toLowerCase()) + '] ';
+    });
     if (s === before) break;
   }
   // Strip inline "[File attached: ...]" chunks anywhere in the text.

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -249,10 +249,10 @@ const HTML = /* html */ `<!DOCTYPE html>
   #transcript {
     min-height: 80px; max-height: 30vh;
     background: #0e0e18; border-radius: 12px; padding: 10px 14px;
-    overflow-y: auto; font-size: 13px; line-height: 1.6;
+    overflow-y: auto; font-size: 18px; line-height: 1.6;
     margin-bottom: 6px;
   }
-  .t-entry { margin-bottom: 6px; position: relative; user-select: text; }
+  .t-entry { margin-bottom: 8px; position: relative; user-select: text; }
   .t-entry .copy-btn {
     display: none; position: absolute; right: 0; top: 0;
     background: #1e1e30; border: 1px solid #2a2a40; color: #666; font-size: 10px;
@@ -264,8 +264,8 @@ const HTML = /* html */ `<!DOCTYPE html>
   .t-user::before { content: 'You: '; font-weight: 600; color: #5a9fd4; }
   .t-assistant { color: #a8d8b0; }
   .t-assistant::before { content: 'Sutando: '; font-weight: 600; color: #6dbe82; }
-  .t-system { color: #666; font-size: 12px; }
-  .t-interim { color: #7fb3e0; opacity: 0.5; font-size: 13px; }
+  .t-system { color: #999; font-size: 16px; }
+  .t-interim { color: #7fb3e0; opacity: 0.5; font-size: 18px; }
   .t-interim::before { content: 'You: '; font-weight: 600; }
 
   /* Input bar */
@@ -351,10 +351,10 @@ const HTML = /* html */ `<!DOCTYPE html>
   #dynamic-region .q-input:focus { border-color: #f0ad4e66; }
   #dynamic-region .dr-proactive { text-align: center; padding: 8px; font-size: 13px; color: #8899a6; }
   #dynamic-region .dr-chips { text-align: center; }
-  #dynamic-region .dr-chips .suggestions-label { margin-bottom: 6px; }
+  #dynamic-region .dr-chips .suggestions-label { margin-bottom: 8px; }
   #dynamic-region .dr-chips .suggestion {
     display: inline-block; background: #1a1a2e; border: 1px solid #2a2a4e;
-    border-radius: 16px; padding: 6px 14px; margin: 3px; font-size: 11px;
+    border-radius: 18px; padding: 8px 18px; margin: 4px; font-size: 18px;
     color: #8899a6; cursor: pointer; transition: all 0.2s;
   }
   #dynamic-region .dr-chips .suggestion:hover { background: #2a2a4e; color: #ccc; border-color: #4a4a6e; }
@@ -919,12 +919,25 @@ document.addEventListener('click', function(e) {
   const item = e.target.closest && e.target.closest('.task-item[data-taskid]');
   if (item) toggleResult(item.dataset.taskid);
 });
-// Strip clauses / parens / colons and keep the head of the first sentence.
-// "Polymarket research summary (pulled from Studio…" → "Polymarket research summary"
+// Strip routing prefixes ([Discord @handle], [Replying to ...], [File attached: ...])
+// and clause fragments; keep a short semantic label.
+// "[Discord @susanliu_] maybe make it look more like this, add emoji in front"
+//   → "maybe make it look more like this"
 function summarizeTaskText(raw) {
   if (!raw) return '';
   let s = String(raw).trim();
-  // Cut at first strong boundary
+  // Strip leading routing / reply / attachment brackets (iteratively — a task
+  // may have multiple: "[Discord @X] [Replying to Y] actual content").
+  for (let i = 0; i < 4; i++) {
+    const before = s;
+    s = s.replace(/^\[Discord[^\]]*\]\s*/i, '');
+    s = s.replace(/^\[Replying to[^\]]*\]\s*/i, '');
+    s = s.replace(/^\[Voice[^\]]*\]\s*/i, '');
+    if (s === before) break;
+  }
+  // Strip inline "[File attached: ...]" chunks anywhere in the text.
+  s = s.replace(/\[File attached:[^\]]*\]/gi, '').replace(/\s+/g, ' ').trim();
+  // Now cut at first strong boundary to keep the head of the first sentence.
   const cuts = [' (', ' — ', ' - ', ': ', '. ', ', '];
   for (const c of cuts) {
     const idx = s.indexOf(c);
@@ -1959,7 +1972,7 @@ function updateTabHighlights() {
     var border = isActive ? '#4a4a6e' : '#2a2a3e';
     if (t.id === 'questions' && questions.length > 0 && !isActive) fg = '#f0ad4e';
     if (t.id === 'tasks' && hasNewTasks && !isActive) fg = '#4ecca3';
-    return '<span onclick="switchDRTab(&quot;' + t.id + '&quot;)" style="cursor:pointer;padding:4px 0;border-radius:12px;font-size:11px;border:1px solid ' + border + ';background:' + bg + ';color:' + fg + ';flex:1;text-align:center">' + t.label + '</span>';
+    return '<span onclick="switchDRTab(&quot;' + t.id + '&quot;)" style="cursor:pointer;padding:8px 0;border-radius:14px;font-size:18px;border:1px solid ' + border + ';background:' + bg + ';color:' + fg + ';flex:1;text-align:center">' + t.label + '</span>';
   }).join('');
 }
 
@@ -1969,9 +1982,10 @@ function renderTabContent() {
   var tab = window._drActiveTab;
 
   if (tab === 'starter') {
+    // Cap at 5 chips per Susan's "show fewer cards rather than shrink" rule.
     container.innerHTML = '<div class="dr-chips">' +
-      '<div class="suggestions-label" style="font-size:11px;color:#666;margin-bottom:4px">Try saying or typing</div>' +
-      getSuggestionChips().map(function(c) {
+      '<div class="suggestions-label" style="font-size:14px;color:#999;margin-bottom:6px">Try saying or typing</div>' +
+      getSuggestionChips().slice(0, 5).map(function(c) {
         return '<span class="suggestion" onclick="trySuggestion(this)">' +
           c.label + (c.desc ? ' — ' + c.desc : '') + '</span>';
       }).join('') + '</div>';
@@ -2018,7 +2032,8 @@ function renderTabContent() {
       var html = '';
       window._allNotes = notes;
       notes.forEach(function(n) {
-        html += '<div class="note-item" data-title="' + esc(n.title).toLowerCase() + '" data-slug="' + n.slug + '" style="padding:12px 0;border-bottom:1px solid #2a2a3e;display:flex;align-items:center;font-size:18px;line-height:1.65">' +
+        html += '<div class="note-item" data-title="' + esc(n.title).toLowerCase() + '" data-slug="' + n.slug + '" style="padding:12px 10px;margin:0 -10px;border-bottom:1px solid #2a2a3e;display:flex;align-items:center;font-size:18px;line-height:1.65;border-radius:6px">' +
+          '<span style="margin-right:10px;flex-shrink:0">&#128221;</span>' +
           '<span style="color:#7c83ff;cursor:pointer;flex:1" onclick="showNoteContent(&quot;' + n.slug + '&quot;)">' + n.title + '</span>' +
           '<span style="color:#666;font-size:13px;margin-right:8px">' + new Date(n.modified*1000).toLocaleDateString() + '</span>' +
           '<span style="color:#e94560;font-size:13px;cursor:pointer;opacity:0.5" onclick="event.stopPropagation();deleteNoteFromUI(&quot;' + n.slug + '&quot;)">x</span></div>';

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -295,20 +295,27 @@ const HTML = /* html */ `<!DOCTYPE html>
   }
   #tasks:empty { display: none; }
   .task-item {
-    display: flex; align-items: center; gap: 8px;
-    padding: 5px 0; border-bottom: 1px solid #141420;
+    display: flex; align-items: center; gap: 10px;
+    padding: 9px 0; border-bottom: 1px solid #141420;
   }
   .task-item:last-child { border-bottom: none; }
   .task-status {
-    width: 16px; height: 16px; border-radius: 50%;
+    width: 20px; height: 20px; border-radius: 50%;
     display: flex; align-items: center; justify-content: center;
-    font-size: 9px; flex-shrink: 0;
+    font-size: 11px; flex-shrink: 0;
   }
   .task-status.working { background: #1e3a5f; color: #60a5fa; animation: pulse 1.5s infinite; }
   .task-status.done { background: #1e4028; color: #4ecca3; }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
-  .task-text { color: #888; flex: 1; word-break: break-word; }
-  .task-time { color: #444; font-size: 10px; }
+  .task-text { color: #c0c0c8; flex: 1; word-break: break-word; font-size: 13px; line-height: 1.4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .task-text.expanded { white-space: normal; }
+  .task-time { color: #666; font-size: 11px; flex-shrink: 0; }
+  .task-expand {
+    flex-shrink: 0; padding: 2px 8px; border-radius: 10px;
+    background: #1a2030; color: #8ab4c8; font-size: 11px; cursor: pointer;
+    border: 1px solid #2a3344; user-select: none;
+  }
+  .task-expand:hover { background: #233045; color: #aac4d8; }
 
   /* Dynamic region */
   #dynamic-region { padding: 0 16px 8px; width: 100%; box-sizing: border-box; user-select: text; -webkit-user-select: text; }
@@ -921,11 +928,16 @@ function renderTasks() {
     const clickAttr = hasResult ? ' data-taskid="' + id + '" style="cursor:pointer"' : '';
     const isExpanded = expandedTasks.has(id);
     const resultDisplay = isExpanded ? 'block' : 'none';
-    const resultHtml = hasResult ? '<div id="result-' + id + '" style="display:' + resultDisplay + ';padding:6px 26px;color:#8ab4c8;font-size:11px;white-space:pre-wrap;word-break:break-word;background:#0d1520;border-radius:6px;margin:4px 0 4px 26px">' + t.result.replace(/</g,'&lt;') + '</div>' : '';
+    const resultHtml = hasResult ? '<div id="result-' + id + '" style="display:' + resultDisplay + ';padding:8px 12px;color:#b8c8d8;font-size:12px;line-height:1.5;white-space:pre-wrap;word-break:break-word;background:#0d1520;border-radius:8px;margin:4px 0 6px 30px">' + t.result.replace(/</g,'&lt;') + '</div>' : '';
+    const rawText = t.text || id;
+    const displayText = rawText.length > 60 && !isExpanded ? rawText.slice(0, 57) + '…' : rawText;
+    const textClass = isExpanded ? 'task-text expanded' : 'task-text';
+    const expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide ▾' : 'Show details ▸') + '</span>' : '';
     return '<div class="task-item"' + clickAttr + '>' +
       '<div class="task-status ' + t.status + '">' + (icons[t.status] || '?') + '</div>' +
-      '<span class="task-text">' + (t.text || id) + (hasResult ? (isExpanded ? ' ▾' : ' ▸') : '') + '</span>' +
+      '<span class="' + textClass + '">' + displayText + '</span>' +
       '<span class="task-time">' + timeStr + '</span>' +
+      expandChip +
       '</div>' + resultHtml;
   }).join('');
 }

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -923,6 +923,9 @@ document.addEventListener('click', function(e) {
 // and clause fragments; keep a short semantic label.
 // "[Discord @susanliu_] maybe make it look more like this, add emoji in front"
 //   → "maybe make it look more like this"
+// NOTE: regex literals live inside the HTML template string — single \ is
+// eaten by the template literal parser (so /\s+/g turns into /s+/g in the
+// browser and strips s characters!). Double-escape every backslash.
 function summarizeTaskText(raw) {
   if (!raw) return '';
   let s = String(raw).trim();
@@ -930,13 +933,13 @@ function summarizeTaskText(raw) {
   // may have multiple: "[Discord @X] [Replying to Y] actual content").
   for (let i = 0; i < 4; i++) {
     const before = s;
-    s = s.replace(/^\[Discord[^\]]*\]\s*/i, '');
-    s = s.replace(/^\[Replying to[^\]]*\]\s*/i, '');
-    s = s.replace(/^\[Voice[^\]]*\]\s*/i, '');
+    s = s.replace(/^\\[Discord[^\\]]*\\]\\s*/i, '');
+    s = s.replace(/^\\[Replying to[^\\]]*\\]\\s*/i, '');
+    s = s.replace(/^\\[Voice[^\\]]*\\]\\s*/i, '');
     if (s === before) break;
   }
   // Strip inline "[File attached: ...]" chunks anywhere in the text.
-  s = s.replace(/\[File attached:[^\]]*\]/gi, '').replace(/\s+/g, ' ').trim();
+  s = s.replace(/\\[File attached:[^\\]]*\\]/gi, '').replace(/\\s+/g, ' ').trim();
   // Now cut at first strong boundary to keep the head of the first sentence.
   const cuts = [' (', ' — ', ' - ', ': ', '. ', ', '];
   for (const c of cuts) {

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -296,9 +296,12 @@ const HTML = /* html */ `<!DOCTYPE html>
   #tasks:empty { display: none; }
   .task-item {
     display: flex; align-items: center; gap: 13px;
-    padding: 15px 0; border-bottom: 1px solid #141420;
+    padding: 15px 10px; margin: 0 -10px; border-bottom: 1px solid #141420;
+    transition: background 0.12s; border-radius: 6px;
   }
   .task-item:last-child { border-bottom: none; }
+  .task-item:hover { background: #1a1a2a; cursor: pointer; }
+  .note-item:hover { background: #1a1a2a; }
   .task-status {
     width: 22px; height: 22px; border-radius: 50%;
     display: flex; align-items: center; justify-content: center;

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -1997,7 +1997,7 @@ function renderTabContent() {
     // Also cap each chip's visible label at ~32 chars so "PR 470 — task-card
     // redesign" stays terse — full text still available via title tooltip.
     container.innerHTML = '<div class="dr-chips">' +
-      '<div class="suggestions-label" style="font-size:14px;color:#999;margin-bottom:6px">Try saying or typing</div>' +
+      '<div class="suggestions-label" style="font-size:14px;color:#999;margin-bottom:16px">Try saying or typing</div>' +
       getSuggestionChips().slice(0, 5).map(function(c) {
         var full = c.label + (c.desc ? ' — ' + c.desc : '');
         var short = full.length > 32 ? full.slice(0, 30) + '…' : full;
@@ -2082,15 +2082,15 @@ function renderTabContent() {
     fetch(API_BASE + '/activity').then(function(r){return r.json()}).then(function(data) {
       var items = data.activity || [];
       if (items.length === 0) {
-        container.innerHTML = '<div style="color:#666;font-size:12px;text-align:center;padding:12px">No recent activity</div>';
+        container.innerHTML = '<div style="color:#666;font-size:16px;text-align:center;padding:12px">No recent activity</div>';
         return;
       }
       var html = '';
       items.forEach(function(item) {
         if (item.type === 'commit') {
-          html += '<div style="padding:3px 0;font-size:12px"><span style="color:#555;font-family:monospace">' + item.hash + '</span> <span style="color:#7c83ff">' + esc(item.message) + '</span></div>';
+          html += '<div style="padding:6px 0;font-size:16px;line-height:1.5"><span style="color:#888;font-family:monospace;font-size:14px">' + item.hash + '</span> <span style="color:#7c83ff">' + esc(item.message) + '</span></div>';
         } else if (item.type === 'task') {
-          html += '<div style="padding:3px 0;font-size:12px;color:#4ecca3">' + esc(item.preview) + '</div>';
+          html += '<div style="padding:6px 0;font-size:16px;line-height:1.5;color:#4ecca3">' + esc(item.preview) + '</div>';
         }
       });
       container.innerHTML = html;

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -977,7 +977,9 @@ function renderTasks() {
     const resultDisplay = isExpanded ? 'block' : 'none';
     const resultHtml = hasResult ? '<div id="result-' + id + '" style="display:' + resultDisplay + ';padding:8px 12px;color:#b8c8d8;font-size:12px;line-height:1.5;white-space:pre-wrap;word-break:break-word;background:#0d1520;border-radius:8px;margin:4px 0 6px 30px">' + t.result.replace(/</g,'&lt;') + '</div>' : '';
     const rawText = t.text || id;
-    const displayText = isExpanded ? rawText : summarizeTaskText(rawText);
+    // Default-tag bare tasks (no [Channel] prefix) as [Sutando-core].
+    const taggedRaw = /^\\[/.test(rawText) ? rawText : '[Sutando-core] ' + rawText;
+    const displayText = isExpanded ? taggedRaw : summarizeTaskText(taggedRaw);
     const textClass = isExpanded ? 'task-text expanded' : 'task-text';
     const expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide ▾' : 'Show details ▸') + '</span>' : '';
     return '<div class="task-item"' + clickAttr + '>' +
@@ -2027,7 +2029,11 @@ function renderTabContent() {
         var resultDisplay = isExpanded ? 'block' : 'none';
         var resultHtml = hasResult ? '<div id="result-' + id + '" style="display:' + resultDisplay + ';padding:8px 12px;color:#b8c8d8;font-size:12px;line-height:1.5;white-space:pre-wrap;word-break:break-word;background:#0d1520;border-radius:8px;margin:4px 0 6px 30px">' + esc(t.result) + '</div>' : '';
         var rawText = t.text || id;
-        var displayText = isExpanded ? rawText : summarizeTaskText(rawText);
+        // Default-tag bare tasks (no [Channel] prefix) as [Sutando-core]
+        // so every row in the list shows a channel badge per Susan's
+        // 2026-04-19 17:04 ask.
+        var taggedRaw = /^\\[/.test(rawText) ? rawText : '[Sutando-core] ' + rawText;
+        var displayText = isExpanded ? taggedRaw : summarizeTaskText(taggedRaw);
         var textClass = isExpanded ? 'task-text expanded' : 'task-text';
         var expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide &#9662;' : 'Show details &#9656;') + '</span>' : '';
         return '<div class="task-item"' + clickAttr + '>' +

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -310,7 +310,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   .task-status.working { background: #1e3a5f; color: #60a5fa; animation: pulse 1.5s infinite; }
   .task-status.done { background: #1e4028; color: #4ecca3; }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
-  .task-text { color: #d0d0d8; flex: 1; word-break: break-word; font-size: 18px; line-height: 1.65; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .task-text { color: #d0d0d8; flex: 1; word-break: break-word; font-size: 16px; line-height: 1.6; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .task-text.expanded { white-space: normal; }
   .task-time { color: #777; font-size: 13px; flex-shrink: 0; }
   .task-expand {
@@ -2039,7 +2039,7 @@ function renderTabContent() {
       var html = '';
       window._allNotes = notes;
       notes.forEach(function(n) {
-        html += '<div class="note-item" data-title="' + esc(n.title).toLowerCase() + '" data-slug="' + n.slug + '" style="padding:12px 10px;margin:0 -10px;border-bottom:1px solid #2a2a3e;display:flex;align-items:center;font-size:18px;line-height:1.65;border-radius:6px">' +
+        html += '<div class="note-item" data-title="' + esc(n.title).toLowerCase() + '" data-slug="' + n.slug + '" style="padding:12px 10px;margin:0 -10px;border-bottom:1px solid #2a2a3e;display:flex;align-items:center;font-size:16px;line-height:1.6;border-radius:6px">' +
           '<span style="margin-right:10px;flex-shrink:0">&#128221;</span>' +
           '<span style="color:#7c83ff;cursor:pointer;flex:1" onclick="showNoteContent(&quot;' + n.slug + '&quot;)">' + n.title + '</span>' +
           '<span style="color:#666;font-size:13px;margin-right:8px">' + new Date(n.modified*1000).toLocaleDateString() + '</span>' +

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -209,12 +209,12 @@ const HTML = /* html */ `<!DOCTYPE html>
 
   .header .info { flex: 1; }
   .header h1 { color: #fff; font-size: 1.15em; font-weight: 500; }
-  .header .meta { font-size: 14px; color: #777; display: flex; gap: 14px; align-items: center; margin-top: 4px; }
-  .header .meta a { color: #888; text-decoration: none; border-bottom: 1px dotted #444; }
+  .header .meta { font-size: 16px; color: #888; display: flex; gap: 14px; align-items: center; margin-top: 4px; }
+  .header .meta a { color: #999; text-decoration: none; border-bottom: 1px dotted #555; }
   .header .meta a:hover { color: #bbb; }
   .status-pill {
-    display: inline-flex; align-items: center; gap: 5px;
-    padding: 3px 10px; border-radius: 11px; font-size: 12px; font-weight: 500;
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 4px 12px; border-radius: 12px; font-size: 16px; font-weight: 500;
   }
   .status-pill.voice-on { background: #1a2e24; color: #4ecca3; }
   .status-pill.voice-off { background: #1a1a2e; color: #666; }
@@ -321,7 +321,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   .task-expand:hover { background: #3a5075; color: #ffffff; }
 
   /* Dynamic region */
-  #dynamic-region { padding: 14px 16px 8px; width: 100%; box-sizing: border-box; user-select: text; -webkit-user-select: text; }
+  #dynamic-region { padding: 26px 16px 8px; width: 100%; box-sizing: border-box; user-select: text; -webkit-user-select: text; }
   #dynamic-region:empty { display: none; }
   #core-status-bar { font-size: 11px; color: #555; }
   #core-status-bar:empty { display: none; }

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -2545,7 +2545,12 @@ const server = createServer((req, res) => {
 		return;
 	}
 
-	res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+	res.writeHead(200, {
+		'Content-Type': 'text/html; charset=utf-8',
+		'Cache-Control': 'no-cache, no-store, must-revalidate',
+		'Pragma': 'no-cache',
+		'Expires': '0',
+	});
 	res.end(HTML);
 });
 

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -307,12 +307,12 @@ const HTML = /* html */ `<!DOCTYPE html>
   .task-status.working { background: #1e3a5f; color: #60a5fa; animation: pulse 1.5s infinite; }
   .task-status.done { background: #1e4028; color: #4ecca3; }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
-  .task-text { color: #c0c0c8; flex: 1; word-break: break-word; font-size: 15px; line-height: 1.4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .task-text { color: #c0c0c8; flex: 1; word-break: break-word; font-size: 16px; line-height: 1.4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .task-text.expanded { white-space: normal; }
-  .task-time { color: #666; font-size: 11px; flex-shrink: 0; }
+  .task-time { color: #666; font-size: 12px; flex-shrink: 0; }
   .task-expand {
-    flex-shrink: 0; padding: 2px 8px; border-radius: 10px;
-    background: #1a2030; color: #8ab4c8; font-size: 11px; cursor: pointer;
+    flex-shrink: 0; padding: 3px 9px; border-radius: 10px;
+    background: #1a2030; color: #8ab4c8; font-size: 12px; cursor: pointer;
     border: 1px solid #2a3344; user-select: none;
   }
   .task-expand:hover { background: #233045; color: #aac4d8; }

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -323,7 +323,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   /* Dynamic region */
   #dynamic-region { padding: 26px 16px 8px; width: 100%; box-sizing: border-box; user-select: text; -webkit-user-select: text; }
   #dynamic-region:empty { display: none; }
-  #core-status-bar { font-size: 11px; color: #555; }
+  #core-status-bar { font-size: 16px; color: #888; }
   #core-status-bar:empty { display: none; }
   #core-status-bar .core-running { color: #4ecca3; }
   #core-status-bar .core-idle { color: #444; }
@@ -406,7 +406,7 @@ const HTML = /* html */ `<!DOCTYPE html>
 
   /* Hidden URL input */
   #wsUrl { display: none; }
-  .stats { font-size: 10px; color: #444; }
+  .stats { font-size: 14px; color: #777; }
 
   /* Hero connect screen — shown when voice is disconnected */
   .hero {
@@ -595,13 +595,13 @@ fetch('http://localhost:7844/stand-identity').then(r=>r.json()).then(s=>{
   <button class="btn-hero" onclick="toggle()">Start Voice</button>
 </div>
 
-<div id="status-bar" style="text-align:center;font-size:11px;color:#556;letter-spacing:0.5px;padding:12px 16px">
-  <kbd style="background:#1a1a2e;padding:2px 6px;border-radius:3px;border:1px solid #333;font-family:monospace;color:#8af">⌃C</kbd> drop context
-  <span style="margin:0 6px;color:#333">|</span>
-  <kbd style="background:#1a1a2e;padding:2px 6px;border-radius:3px;border:1px solid #333;font-family:monospace;color:#8af">⌃V</kbd> voice
-  <span style="margin:0 6px;color:#333">|</span>
-  <kbd style="background:#1a1a2e;padding:2px 6px;border-radius:3px;border:1px solid #333;font-family:monospace;color:#8af">⌃M</kbd> mute
-  <span style="margin:0 6px;color:#333">|</span>
+<div id="status-bar" style="text-align:center;font-size:16px;color:#888;letter-spacing:0.3px;padding:12px 16px">
+  <kbd style="background:#1a1a2e;padding:3px 8px;border-radius:4px;border:1px solid #333;font-family:monospace;color:#8af;font-size:14px">⌃C</kbd> drop context
+  <span style="margin:0 8px;color:#444">|</span>
+  <kbd style="background:#1a1a2e;padding:3px 8px;border-radius:4px;border:1px solid #333;font-family:monospace;color:#8af;font-size:14px">⌃V</kbd> voice
+  <span style="margin:0 8px;color:#444">|</span>
+  <kbd style="background:#1a1a2e;padding:3px 8px;border-radius:4px;border:1px solid #333;font-family:monospace;color:#8af;font-size:14px">⌃M</kbd> mute
+  <span style="margin:0 8px;color:#444">|</span>
   <span id="core-status-bar" style="display:inline"></span>
 </div>
 
@@ -934,8 +934,15 @@ function summarizeTaskText(raw) {
   // Iterate because a task may have multiple stacked prefixes.
   for (let i = 0; i < 4; i++) {
     const before = s;
-    s = s.replace(/^\\[(Discord|Voice|Replying to|Reply)[^\\]]*\\]\\s*/i, function(_, kind) {
-      return '[' + (kind.toLowerCase() === 'replying to' || kind.toLowerCase() === 'reply' ? 'Reply' : kind.charAt(0).toUpperCase() + kind.slice(1).toLowerCase()) + '] ';
+    s = s.replace(/^\\[(Discord|Voice|Replying to|Reply|Phone|Sutando-core|Sutando-Lucy|Sutando-Maddy|Task|Context drop)[^\\]]*\\]\\s*/i, function(_, kind) {
+      var k = kind.toLowerCase();
+      var short = k === 'replying to' || k === 'reply' ? 'Reply'
+                : k === 'sutando-core' ? 'Sutando-core'
+                : k === 'sutando-lucy' ? 'Sutando-Lucy'
+                : k === 'sutando-maddy' ? 'Sutando-Maddy'
+                : k === 'context drop' ? 'Context drop'
+                : kind.charAt(0).toUpperCase() + kind.slice(1).toLowerCase();
+      return '[' + short + '] ';
     });
     if (s === before) break;
   }

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -307,7 +307,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   .task-status.working { background: #1e3a5f; color: #60a5fa; animation: pulse 1.5s infinite; }
   .task-status.done { background: #1e4028; color: #4ecca3; }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
-  .task-text { color: #c0c0c8; flex: 1; word-break: break-word; font-size: 14px; line-height: 1.4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .task-text { color: #c0c0c8; flex: 1; word-break: break-word; font-size: 15px; line-height: 1.4; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .task-text.expanded { white-space: normal; }
   .task-time { color: #666; font-size: 11px; flex-shrink: 0; }
   .task-expand {
@@ -876,12 +876,15 @@ function updateTask(taskId, status, text, result) {
   taskMap[taskId] = { status, text: text || existing.text, time: new Date(), result: result || existing.result || '' };
   // Auto-switch to tasks tab if new task arrives and user is on starter
   if (isNew && window._drActiveTab === 'starter') { switchDRTab('tasks'); }
-  // Auto-expand the latest completed task (collapse others if user had collapsed)
-  if (status === 'done' && !wasDone && (result || existing.result)) {
-    if (userCollapsed) expandedTasks.clear(); // keep old ones collapsed
+  // Auto-expand ONLY ongoing tasks (working/pending) so the user sees progress.
+  // Done tasks stay collapsed by default — user clicks the "Show details" chip.
+  // (Was: auto-expand every newly-done task, which filled the pane with walls of text.)
+  if (status === 'working' && !expandedTasks.has(taskId)) {
     expandedTasks.add(taskId);
-    userCollapsed = false;
-    setTimeout(() => { const el = document.getElementById('result-' + taskId); if (el) el.scrollIntoView({ behavior: 'smooth', block: 'nearest' }); }, 100);
+  }
+  // When a task transitions done, explicitly collapse it (done → fold).
+  if (status === 'done' && !wasDone) {
+    expandedTasks.delete(taskId);
   }
   renderTasks();
 }
@@ -930,7 +933,7 @@ function renderTasks() {
     const resultDisplay = isExpanded ? 'block' : 'none';
     const resultHtml = hasResult ? '<div id="result-' + id + '" style="display:' + resultDisplay + ';padding:8px 12px;color:#b8c8d8;font-size:12px;line-height:1.5;white-space:pre-wrap;word-break:break-word;background:#0d1520;border-radius:8px;margin:4px 0 6px 30px">' + t.result.replace(/</g,'&lt;') + '</div>' : '';
     const rawText = t.text || id;
-    const displayText = rawText.length > 100 && !isExpanded ? rawText.slice(0, 97) + '…' : rawText;
+    const displayText = rawText.length > 40 && !isExpanded ? rawText.slice(0, 37) + '…' : rawText;
     const textClass = isExpanded ? 'task-text expanded' : 'task-text';
     const expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide ▾' : 'Show details ▸') + '</span>' : '';
     return '<div class="task-item"' + clickAttr + '>' +
@@ -978,11 +981,12 @@ function startTaskPolling() {
         if (t.status === 'done' && existing.status && existing.status !== 'done') {
           showToast('<span class="toast-label">Done</span> ' + (t.text || t.id).slice(0, 60));
         }
-        // Auto-expand latest completed task (collapse others if user had collapsed)
-        if (t.status === 'done' && existing.status !== 'done' && (t.result || existing.result)) {
-          if (userCollapsed) expandedTasks.clear();
+        // Auto-expand ONLY working tasks (progress visibility). Done = collapse.
+        if (t.status === 'working' && !expandedTasks.has(t.id)) {
           expandedTasks.add(t.id);
-          userCollapsed = false;
+        }
+        if (t.status === 'done' && existing.status !== 'done') {
+          expandedTasks.delete(t.id);
         }
         taskMap[t.id] = { status: t.status, text: t.text, time: new Date(t.time * 1000), result: t.result || existing.result || '' };
       }


### PR DESCRIPTION
## Summary

Task-card redesign addressing Susan's 3 asks. The **fold-by-default** fix is the core — the typography polish is secondary.

### The main fix: fold-by-default (`632e6f1`)
`renderTasks()` previously auto-expanded every newly-`done` task in two separate sites (WS handler + `/tasks/active` poll). Result: the tasks pane filled with walls of text by default, which was exactly what Susan flagged.

Now:
- **Only WORKING tasks auto-expand** — keeps in-progress work visible while it runs.
- **On `done` transition → `expandedTasks.delete(id)`** — explicit collapse as soon as the task finishes.
- User's manual expand via the new "Show details" chip still persists as before.

### Typography polish
- `.task-text` font-size → **15px** (was ~11-12px default, glanceable)
- Truncation at **40 chars + ellipsis** (row is a short label; chip click reveals full text)
- Status bubble 20px, row padding 9px, gap 10px — ~50% taller, comfortable for reading
- Text color `#c0c0c8` (was dim `#888`)

### New expand affordance
- Rounded pill: **"Show details ▸"** / **"Hide ▾"** with hover state — discoverable vs the old inline arrow
- Only renders when the task has a result to show

## Test plan

- [ ] Load the web client with a mix of `working` and `done` tasks
- [ ] Confirm done tasks render collapsed (40-char truncated text + "Show details" chip)
- [ ] Click the chip — full text + result panel appear
- [ ] Transition a task from `working` → `done`, observe it auto-collapses
- [ ] Working tasks with progress output stay auto-expanded

Iterated with Maddy-bot via local test; Susan greenlit the push + PR open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)