### PR TITLE
fix(web-client): stop Questions tab stealing focus after clicking Starter

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -2115,13 +2115,28 @@ function updateDynamicRegion() {
   // Ensure tab structure exists
   ensureTabStructure();
 
-  // Auto-switch to questions tab if new questions arrive
+  // Auto-switch to questions tab ONCE per new-question arrival.
+  // Track which qids we've already auto-switched for so that clicking back to
+  // Starter doesn't get stolen on every poll. A NEW qid re-arms the switch.
   var questions = window._drQuestions || [];
-  if (questions.length > 0 && window._drActiveTab === 'starter') {
+  window._drAutoSwitchedQids = window._drAutoSwitchedQids || {};
+  var hasNewQuestion = false;
+  for (var i = 0; i < questions.length; i++) {
+    if (!window._drAutoSwitchedQids[questions[i].id]) { hasNewQuestion = true; break; }
+  }
+  if (hasNewQuestion && window._drActiveTab === 'starter') {
     window._drActiveTab = 'questions';
+    for (var j = 0; j < questions.length; j++) {
+      window._drAutoSwitchedQids[questions[j].id] = true;
+    }
     updateTabHighlights();
     renderTabContent();
     return;
+  }
+  // Even if we don't switch (user already on another tab, or set is known),
+  // record current qids so we don't double-fire when they land on Starter.
+  for (var k = 0; k < questions.length; k++) {
+    window._drAutoSwitchedQids[questions[k].id] = true;
   }
 
   // Update tab badges (task count, question count) without re-rendering content


### PR DESCRIPTION
## Summary
- Owner reports clicking **Starter** tab, then getting bounced back to **Questions** within a second.
- Root cause: `renderDynamicContent()` re-fires on every poll and line 2120 force-switched to Questions whenever `questions.length > 0 && active === 'starter'`. Clicking Starter was overwritten on the next tick.
- Fix: track which qids we've already auto-switched for in `window._drAutoSwitchedQids`. Only fire the switch when a **new** qid appears. Clicking back to Starter now persists.

## Test plan
- [ ] Open web UI with 1+ pending questions
- [ ] Verify first auto-switch to Questions on question arrival
- [ ] Click Starter — stays on Starter across polls ✓ (was bouncing)
- [ ] Add a new pending question — auto-switches to Questions (one-shot)
- [ ] Answer all questions — tab state unaffected

No TS-only syntax in the embedded `<script>` block (plain `var` / `for`). `tsc --noEmit` clean.

Reported by owner via Discord 06:53Z Apr 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)