### PR TITLE
fix(web-client): stop Questions-tab auto-switch loop after manual tab click

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -2198,9 +2198,15 @@ function updateDynamicRegion() {
   // Ensure tab structure exists
   ensureTabStructure();
 
-  // Auto-switch to questions tab if new questions arrive
+  // Auto-switch to questions tab if NEW questions arrive. Compare against
+  // the last-seen count (tracked by updateTabHighlights on visit to the
+  // questions tab) rather than 0 — otherwise every SSE/poll cycle re-fires
+  // the switch and drags the user back to questions immediately after they
+  // click Starter. User clicking Starter = "I've acknowledged the badge,
+  // don't pull me in until something new arrives."
   var questions = window._drQuestions || [];
-  if (questions.length > 0 && window._drActiveTab === 'starter') {
+  var seen = window._lastSeenCounts = window._lastSeenCounts || {};
+  if (questions.length > (seen.questions || 0) && window._drActiveTab === 'starter') {
     window._drActiveTab = 'questions';
     updateTabHighlights();
     renderTabContent();


### PR DESCRIPTION
## Summary
- Auto-switch at \`src/web-client.ts:2203\` fired on \`questions.length > 0\` with no threshold, so every SSE / poll cycle re-fired the switch and pulled the user back to Questions immediately after they clicked Starter.
- Compare against \`_lastSeenCounts.questions\` (already tracked by \`updateTabHighlights\` when the user visits the Questions tab) so the switch only fires on genuinely new questions.

## Repro
1. Have any pending question in \`pending-questions.md\`.
2. Open the web UI. It auto-lands on Questions (correct — first arrival).
3. Click the Starter tab.
4. Within ~1s the next SSE/poll event yanks you back to Questions.

After fix: Starter stays Starter. If a *new* question arrives, auto-switch still fires once. User explicitly clicking Questions resets the seen-count so the badge works as before.

## Test plan
- [ ] Reload web UI with existing pending questions, click Starter, stay on Starter through at least one SSE cycle (\`core-status\` update) + 10s.
- [ ] Add a new question to \`pending-questions.md\`, confirm auto-switch still fires.
- [ ] Click Questions, then back to Starter, ensure it doesn't bounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)