### PR TITLE
feat(bot2bot-post): new skill for cross-bot coord messages in #bot2bot

### DIFF
--- a/skills/bot2bot-post/SKILL.md
+++ b/skills/bot2bot-post/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: bot2bot-post
+description: Post a coordination message from this bot to the shared bot2bot channel, @-mentioning the other Sutando node.
+---
+
+# Bot-to-Bot Post
+
+Post a coordination message from this Sutando node to the other in the shared `#bot2bot` Discord channel. The receiving bot's bridge processes `@-mention` messages from other bots as tasks (see `src/discord-bridge.py:244`), so prefixing with `<@other-bot>` routes the post to the other bot's loop.
+
+## Usage
+
+```bash
+python3 skills/bot2bot-post/post.py <kind> <text>
+```
+
+Kinds:
+- `claim` — "I'm taking this work, ETA X"
+- `blocked` — "I'm stuck on X, need eyes"
+- `done` — "shipped X, FYI"
+- `ping` — "you there?"
+- `opinion` — "what do you think about X?"
+
+Examples:
+```bash
+python3 skills/bot2bot-post/post.py claim "refactor task-bridge task-file schema ETA 20m"
+python3 skills/bot2bot-post/post.py done "shipped PR #472 — kickstart web-client after merge"
+python3 skills/bot2bot-post/post.py opinion "is Discord-as-state better than files for coord?"
+```
+
+## Configuration
+
+- **Channel**: resolved from `~/.claude/channels/discord/access.json` — pick the `groups` entry tagged `{"role": "bot2bot", ...}`, fallback to any entry with value `true`.
+- **Token**: `DISCORD_BOT_TOKEN` read from `~/.claude/channels/discord/.env`.
+- **Other bot ID**: picked from the `allowFrom` list, excluding this bot's own ID (fetched via Discord `/users/@me`).
+
+## Why
+
+Before this skill: bot A could reply in a task-triggered channel (existing `pending_replies` path) and DM the owner (`poll_proactive`), but had no way to initiate a channel post. That made cross-bot coord invisible to Chi and impossible without going through him. Now bots can claim/block/done in the open.
+
+## See also
+
+- `src/discord-bridge.py:244` — the exception that routes bot-to-bot @-mentions as tasks
+- `feedback_cross_bot_mention.md` — memory note on @-mention conventions
+- `notes/team-proposal-coord-loop-2026-04-20.md` — the joint proposal that motivated this skill

--- a/skills/bot2bot-post/post.py
+++ b/skills/bot2bot-post/post.py
@@ -68,11 +68,17 @@ def resolve_bot2bot_channel(access: dict) -> str:
     sys.exit("ERROR: no bot2bot channel found in access.json.groups")
 
 
+USER_AGENT = "DiscordBot (https://github.com/sonichi/sutando, 1.0)"
+
+
 def get_self_id(token: str) -> str:
     """Discord GET /users/@me → this bot's user ID."""
     req = urllib.request.Request(
         "https://discord.com/api/v10/users/@me",
-        headers={"Authorization": f"Bot {token}"},
+        headers={
+            "Authorization": f"Bot {token}",
+            "User-Agent": USER_AGENT,
+        },
     )
     with urllib.request.urlopen(req, timeout=10) as r:
         return json.loads(r.read())["id"]
@@ -102,6 +108,7 @@ def post(channel_id: str, text: str, token: str):
         headers={
             "Authorization": f"Bot {token}",
             "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
         },
     )
     try:

--- a/skills/bot2bot-post/post.py
+++ b/skills/bot2bot-post/post.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Post a coordination message from this bot to the #bot2bot channel.
+
+Usage:
+    python3 skills/bot2bot-post/post.py <kind> <text>
+    python3 skills/bot2bot-post/post.py claim "refactor X, ETA 20m"
+    python3 skills/bot2bot-post/post.py blocked "Twilio credentials expired"
+    python3 skills/bot2bot-post/post.py done "shipped PR #472"
+    python3 skills/bot2bot-post/post.py ping "need your take on the IV halo"
+
+Kinds: claim | blocked | done | ping | opinion
+
+The target channel ID is read from `~/.claude/channels/discord/access.json`:
+entries tagged with `{"role": "bot2bot", ...}` in `groups` are candidates. We
+pick the first such channel. If none is tagged, we fall back to the first
+group whose value is just `true` (legacy convention), or error out.
+
+The other bot's user ID is read from the same file's `allowFrom` list,
+excluding this bot (identified via Discord GET /users/@me). The resulting
+`<@id>` mention is prepended so the receiving bot's bridge will process it
+as a task (discord-bridge.py line 244 exception).
+
+Requires DISCORD_BOT_TOKEN in ~/.claude/channels/discord/.env.
+"""
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+ACCESS_JSON = Path.home() / ".claude" / "channels" / "discord" / "access.json"
+ENV_FILE = Path.home() / ".claude" / "channels" / "discord" / ".env"
+VALID_KINDS = {"claim", "blocked", "done", "ping", "opinion"}
+
+
+def load_token() -> str:
+    """Load DISCORD_BOT_TOKEN from the Discord channel's .env."""
+    if not ENV_FILE.exists():
+        sys.exit(f"ERROR: {ENV_FILE} not found")
+    for line in ENV_FILE.read_text().splitlines():
+        if line.startswith("DISCORD_BOT_TOKEN="):
+            return line.split("=", 1)[1].strip().strip("'\"")
+    sys.exit("ERROR: DISCORD_BOT_TOKEN not in env")
+
+
+def load_access() -> dict:
+    if not ACCESS_JSON.exists():
+        sys.exit(f"ERROR: {ACCESS_JSON} not found")
+    return json.loads(ACCESS_JSON.read_text())
+
+
+def resolve_bot2bot_channel(access: dict) -> str:
+    """Pick the bot2bot channel from access.json.
+
+    Preferred: groups entries with `{"role": "bot2bot", ...}`.
+    Fallback: groups entries whose value is literal `true` (legacy).
+    """
+    groups = access.get("groups", {})
+    # Preferred: explicitly tagged
+    for cid, cfg in groups.items():
+        if isinstance(cfg, dict) and cfg.get("role") == "bot2bot":
+            return cid
+    # Fallback: first `true`-valued group (legacy — likely the bot2bot one)
+    for cid, cfg in groups.items():
+        if cfg is True:
+            return cid
+    sys.exit("ERROR: no bot2bot channel found in access.json.groups")
+
+
+def get_self_id(token: str) -> str:
+    """Discord GET /users/@me → this bot's user ID."""
+    req = urllib.request.Request(
+        "https://discord.com/api/v10/users/@me",
+        headers={"Authorization": f"Bot {token}"},
+    )
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return json.loads(r.read())["id"]
+
+
+def resolve_other_bot(access: dict, self_id: str):
+    """Find the other bot's user ID from allowFrom, excluding self."""
+    allow = access.get("allowFrom", [])
+    others = [uid for uid in allow if uid != self_id]
+    if not others:
+        return None
+    # Heuristic: there should typically be exactly one other bot + the human
+    # owner. We can't tell them apart from access.json alone without an API
+    # call. For now, prefer IDs that are not obviously the human (access.json
+    # doesn't annotate; assume all allowFrom entries other than self are
+    # candidate recipients, and let the receiving bridge filter).
+    # Pick the first one; if multiple bots + human, caller should pass --to.
+    return others[0]
+
+
+def post(channel_id: str, text: str, token: str):
+    url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
+    body = json.dumps({"content": text}).encode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Authorization": f"Bot {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        sys.exit(f"ERROR: Discord API {e.code}: {e.read().decode()}")
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(1)
+    kind = sys.argv[1]
+    text = " ".join(sys.argv[2:])
+    if kind not in VALID_KINDS:
+        sys.exit(f"ERROR: kind must be one of {sorted(VALID_KINDS)}, got {kind!r}")
+
+    token = load_token()
+    access = load_access()
+    channel_id = resolve_bot2bot_channel(access)
+    self_id = get_self_id(token)
+    other_id = resolve_other_bot(access, self_id)
+
+    prefix = f"<@{other_id}> " if other_id else ""
+    message = f"{prefix}{kind}: {text}"
+
+    result = post(channel_id, message, token)
+    print(f"Posted to #{channel_id} (msg_id {result.get('id')}): {message[:80]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
New skill `skills/bot2bot-post/post.py` — lets either Sutando node initiate a channel post in `#bot2bot` (not just react to tasks).

- 5 kinds: `claim` / `blocked` / `done` / `ping` / `opinion`
- Prepends `<@other-bot>` so the receiving bridge processes it as a task via the existing `discord-bridge.py:244` exception (bot-authored + mentioning this bot = allowed).
- Channel resolved from `~/.claude/channels/discord/access.json` — prefer `groups` entries tagged `{"role": "bot2bot", ...}`, fallback to entries with value `true`. No hardcoded ID.
- Other-bot ID resolved from `allowFrom` list minus self (via Discord `/users/@me`).
- Token from `~/.claude/channels/discord/.env`.

## Motivation
Part of the joint Mini+MacBook proposal (`notes/team-proposal-coord-loop-2026-04-20.md`) addressing owner's feedback that bots "stop communicating with each other" when he's offline. Before this skill, the only bridge send-paths were `pending_replies` (reply to task-triggered channel) and `poll_proactive` (DM to owner). Neither could initiate a channel post, so cross-bot coord was invisible.

## What's NOT in this PR
- `requireMention=true` stays. No `access.json` edit to flip it.
- No `discord-bridge.py` edits.
- The channel-tagging convention (`"role": "bot2bot"`) is documented in SKILL.md but not applied to `access.json` here — owner can flip when ready; fallback to the current `true`-valued entry works today.

## Test plan
- [x] `python3 -m py_compile skills/bot2bot-post/post.py` passes
- [x] `python3 skills/bot2bot-post/post.py` (no args) prints usage
- [ ] Live test: post an `opinion` msg, verify MacBook's bridge sees it as a task
- [ ] MacBook concurrence (they're shipping PR #B next)

Usage example: `python3 skills/bot2bot-post/post.py claim "shipping #A ETA 10m"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)