### PR TITLE
feat(state): record last-chi-activity from 3 bridges for status-aware-pivot

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -33,8 +33,32 @@ if not TOKEN:
 
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
+STATE_DIR = REPO / "state"
 ARCHIVE_TASKS_DIR = REPO / "tasks" / "archive"
 ARCHIVE_RESULTS_DIR = REPO / "results" / "archive"
+OWNER_ACTIVITY_FILE = STATE_DIR / "last-owner-activity.json"
+
+
+def write_owner_activity(channel: str, summary: str) -> None:
+    """Record that the owner was active on <channel> right now.
+
+    Writes atomically via tmp-then-rename so a concurrent reader never sees
+    a partial file. Schema: {"ts": EPOCH, "channel": str, "summary": str}.
+    Read by the proactive-loop status-aware-pivot rule — see
+    `notes/team-proposal-coord-loop-2026-04-20.md`.
+    """
+    try:
+        STATE_DIR.mkdir(exist_ok=True)
+        payload = {
+            "ts": int(time.time()),
+            "channel": channel,
+            "summary": summary[:80],
+        }
+        tmp = OWNER_ACTIVITY_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload))
+        tmp.rename(OWNER_ACTIVITY_FILE)
+    except Exception as e:
+        print(f"  [owner-activity] write failed: {e}", flush=True)
 
 
 def archive_path(kind: str, task_id: str) -> "Path":
@@ -502,6 +526,8 @@ async def _handle_discord_message(message, force=False):
     access_tier = "other"
     if sender_id in allowed:
         access_tier = "owner"
+        # Record owner activity for status-aware-pivot in proactive loop
+        write_owner_activity("discord", text)
     else:
         # Check if team member (from channel allowlists)
         try:

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -16,7 +16,29 @@ import type { ToolDefinition } from 'bodhi-realtime-agent';
 const REPO_DIR = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
 const TASK_DIR = join(REPO_DIR, 'tasks');
 const RESULT_DIR = join(REPO_DIR, 'results');
+const STATE_DIR = join(REPO_DIR, 'state');
 const CONVERSATION_LOG = join(REPO_DIR, 'conversation.log');
+const OWNER_ACTIVITY_FILE = join(STATE_DIR, 'last-owner-activity.json');
+
+/** Record that the owner was active on <channel> right now. Atomic write
+ * via tmp-then-rename. Read by the proactive-loop status-aware-pivot rule.
+ * See notes/team-proposal-coord-loop-2026-04-20.md. */
+function writeOwnerActivity(channel: string, summary: string): void {
+	try {
+		mkdirSync(STATE_DIR, { recursive: true });
+		const payload = {
+			ts: Math.floor(Date.now() / 1000),
+			channel,
+			summary: summary.slice(0, 80),
+		};
+		const tmp = OWNER_ACTIVITY_FILE + '.tmp';
+		writeFileSync(tmp, JSON.stringify(payload));
+		renameSync(tmp, OWNER_ACTIVITY_FILE);
+	} catch (e) {
+		// Non-fatal — activity-state is best-effort
+		console.log(`${ts()} [TaskBridge] owner-activity write failed: ${e}`);
+	}
+}
 
 /** Archive a task/result file into archive/<kind>/YYYY-MM/ instead of
  * deleting. Chi's 2026-04-18 ask: "instead of deleting we should archive
@@ -128,6 +150,8 @@ export const workTool: ToolDefinition = {
 			`access_tier: owner\n`;
 		writeFileSync(join(TASK_DIR, `${taskId}.txt`), content);
 		_pendingTasks.set(taskId, Date.now());
+		// Record owner activity for status-aware-pivot in proactive loop
+		writeOwnerActivity('voice', task);
 		console.log(`${ts()} [TaskBridge] Task ${taskId}: ${task.slice(0, 100)}`);
 		_sendTaskStatus?.(taskId, 'working', task.slice(0, 60));
 		return {

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -38,10 +38,28 @@ if not TOKEN:
 
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
+STATE_DIR = REPO / "state"
 ARCHIVE_TASKS_DIR = REPO / "tasks" / "archive"
 ARCHIVE_RESULTS_DIR = REPO / "results" / "archive"
+OWNER_ACTIVITY_FILE = STATE_DIR / "last-owner-activity.json"
 TASKS_DIR.mkdir(exist_ok=True)
 RESULTS_DIR.mkdir(exist_ok=True)
+
+
+def write_owner_activity(channel: str, summary: str) -> None:
+    """Record owner activity — see src/discord-bridge.py for schema."""
+    try:
+        STATE_DIR.mkdir(exist_ok=True)
+        payload = {
+            "ts": int(time.time()),
+            "channel": channel,
+            "summary": summary[:80],
+        }
+        tmp = OWNER_ACTIVITY_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload))
+        tmp.rename(OWNER_ACTIVITY_FILE)
+    except Exception as e:
+        print(f"  [owner-activity] write failed: {e}")
 
 
 def archive_file(src: "Path", kind: str, task_id: str) -> None:
@@ -241,6 +259,9 @@ def main():
                 if sender_id not in allowed:
                     print(f"  Dropped message from non-allowed @{username}")
                     continue
+
+                # Record owner activity for status-aware-pivot
+                write_owner_activity("telegram", text)
 
                 # Handle attachments (photos, documents, voice)
                 attachment_note = ""


### PR DESCRIPTION
## Summary
Writes `state/last-chi-activity.json` atomically from 3 bridges whenever the owner sends a message:

- `src/discord-bridge.py` — owner-tier incoming msg (after allowFrom match)
- `src/telegram-bridge.py` — allowed-sender incoming msg
- `src/task-bridge.ts` — voice / web / hotkey / phone task-creation

Schema: `{"ts": EPOCH, "channel": str, "summary": str}`. First 80 chars of msg preserved for hinting which bridge was used.

## Why
Addresses part 2 of Chi's pushback (13:58Z Apr 20): "given the multiple channels the status needs to consider my activity in all". The proactive-loop status-aware-pivot rule (shipping in PR #B via MacBook) reads this file to decide whether to stay responsive vs. full-pivot to self-initiated work.

## Test plan
- [x] Inline smoke test: write payload → rename → read back. Works.
- [x] `tsc --noEmit` clean (task-bridge.ts).
- [x] `python3 -m py_compile` clean on both Python bridges.
- [ ] Live: owner msg via each bridge → verify `state/last-chi-activity.json` updates with correct `channel` field.

## What's NOT in this PR
- No consumer — the read side lives in PR #B (skill doc).
- iMessage omitted — no event-driven hook available today without polling the Messages DB.
- Voice-agent speech events (bodhi VoiceSession.onSpeech) not hooked — task-bridge already catches voice tasks, which is the useful signal. Speech-without-task is rare and low-value.

## Coord
`state/` is gitignored already (line 1 of .gitignore matches `state/*`). File is best-effort, non-gating — bot defaults to "no recent activity" (full pivot OK) if the file is missing.

Part of team proposal `notes/team-proposal-coord-loop-2026-04-20.md`. MacBook is shipping PR #B next (skill-doc rewrite that reads this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)