### PR TITLE
feat(proactive-loop): SKILL.md v3 — 5 skip reasons, menu, status-aware pivot, heartbeat

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -41,13 +41,28 @@ Each pass, in order:
 
 0.5. **Check quota.** Run `python3 ~/.claude/skills/quota-tracker/scripts/read-quota.py`. Note remaining % and exact reset time.
    - **Budget per pass** = remaining % / (minutes until reset / 5)
-   - **>3% per pass → FULL**: Use subagents, write code, heavy research. You MUST do meaningful work in step 6 — writing code, shipping features, running analysis. A pass that only checks tasks and health is a wasted pass.
-   - **1-3% per pass → MEDIUM**: Code fixes, monitoring, no subagents. Still do step 6 work.
-   - **<1% per pass → LIGHT**: Task processing and health checks only. Skip step 6.
-   - **0% remaining → MINIMAL**: Process user tasks, health check, update log. Skip steps 5-6.
-   - CRITICAL: If budget is FULL or MEDIUM, you MUST execute steps 5 and 6. Do NOT skip them. Do NOT collapse the pass into "checked tasks, nothing to do." There is ALWAYS something to build — check the build log use case tracker, pick the next item, and act on it.
+   - **>3% per pass → FULL**: subagents, write code, heavy research all fair game.
+   - **1-3% per pass → MEDIUM**: code fixes, monitoring, no subagents.
+   - **<1% per pass → LIGHT**: task processing + health checks only.
+   - **0% remaining → MINIMAL**: process owner tasks + health + update log.
 
-1. **Check for tasks.** Look in `tasks/` for voice tasks. Look at `context-drop.txt` for context drops. Process anything found — execute the task, write results to `results/`.
+   Budget informs the **depth** of step 6 — not whether to do it. "Ran out of ideas" is never a valid skip; the work menu is infinite by design. See **Skip conditions** below for the only legitimate reasons step 6 may be skipped.
+
+## Skip conditions for step 6 (the ONLY legitimate reasons)
+
+Skip step 6 (end the pass early after step 3) if and only if one of these applies:
+
+- **(a) Quota**: per-pass budget is below the LIGHT threshold (<1%).
+- **(b) Active engagement**: owner sent a task / Discord msg / Telegram msg / voice utterance / phone utterance / context-drop in the last ~5min — we're in conversation mode, don't pre-empt.
+- **(c) Presenter/meeting mode**: `state/presenter-mode.sentinel` is active (set via `bash scripts/presenter-mode.sh start N`).
+- **(d) Explicit pause**: `state/loop-paused-until.sentinel` is active (future-dated).
+- **(e) External wait with no agency on the primary item**: the single item under consideration is blocked on human PR review or upstream third party. Only gates THAT item — other menu items remain fair game.
+
+**Blocker ≠ stop.** If primary work is blocked, scan the step 6 menu and pick another unblocked high-ROI item. Idling because "nothing to do" is laziness, not a skip.
+
+## The numbered loop
+
+1. **Check for tasks.** Look in `tasks/` for voice / Discord / Telegram / phone tasks. Look at `context-drop.txt` for context drops. Process anything found — execute the task, write results to `results/`.
    - **Access control:** If the task has `access_tier: other` or `access_tier: team`, delegate to a sandboxed agent. Do NOT process non-owner tasks with your full capabilities. Write the sandboxed output to results.
    - Only `access_tier: owner` (or tasks without an access_tier field) get full processing.
 
@@ -57,24 +72,77 @@ Each pass, in order:
 
 4. **Read the build log** (`build_log.md`) — understand what exists. Do not rebuild what works.
 
-5. **Pick the highest-value work.** Priority order:
-   - User tasks and blockers
-   - Voice/multimodal improvements
-   - Reliability and bug fixes
-   - New features and capabilities
-   - Research: explore new tools, skills, APIs, or techniques relevant to Sutando
-   - Learning: run pattern detection, user model updates, analyze usage patterns
-   - Skill discovery: check for shared skills, community contributions, or tools that could be integrated
-   Use the use case tracker in `build_log.md`.
+5. **Pick the highest-ROI available work.** Priority order when choosing from step 6's menu:
+   - Owner tasks and blockers
+   - Open `opinion-requested` / `review-requested` claims from the other bot in #bot2bot
+   - Voice / multimodal reliability
+   - Recent-regression bug fixes found via primary-source grep
+   - Any menu item from step 6 whose ROI × probability-of-landing > alternatives
 
-6. **Act on it.** This could mean: writing code, researching a topic, testing a capability, discovering and integrating a skill, running analysis, or improving documentation. Prefer action over idle passes.
+   Log the chosen item + estimated ROI in `core-status.step` so the owner can audit pick quality.
+
+6. **Act on it.** Pick the highest-ROI work for this pass and execute. Menu is anchoring, not limiting — legitimate work space is infinite.
+
+   **Primary** (derived from step 5 priorities):
+   - Code: write/fix/refactor; open PR; review community PR
+   - Testing: cold-read own recent PRs, run probes against new code, audit skill behavior
+   - Docs (owner-facing): `notes/sutando-user-stories.md`, `notes/sutando-advantages-table.md`, README sections the owner pre-approves
+
+   **Cross-bot** (always eligible when other bot is active):
+   - Answer an open `@me` opinion-request in #bot2bot
+   - Post `@other claim: X` in #bot2bot for a backlog item you want to take
+   - Review the other bot's recently-opened PR
+
+   **Maintenance / hygiene** (always eligible):
+   - Memory maintenance: trim stale entries, dedupe, verify references, update `MEMORY.md` index
+   - Pending-questions review: resolve anything bot can without owner input; check which are actually stuck
+   - Task-archive pattern mining: read `tasks/archive` for repeated failure shapes → propose prevention
+   - Self-audit: re-read own recent `build_log.md` / PRs for mistakes the second-pass view catches
+
+   **Outreach & content**:
+   - Prepare / refine social posts + media (X threads, LinkedIn, Discord drops) — iterate variants, alt-text, captions
+   - Research news / papers / repos in relevant tech → summarize + propose integration
+   - Commercial strategy: revenue paths, pricing ideas, partnership leads, writeups for owner review
+
+   **Growth**:
+   - Discover new knowledge: deep-dive into capabilities Sutando should have but doesn't
+   - Upgrade your superpower: pick a concrete skill, build/sharpen it; new memory entries; reliability improvements to self
+   - Earn money: revenue-generation work (posts that convert, features that monetize, pitch prep)
+
+   **Event prep** (conference talks, demos, press):
+   - Slide deck / script / cue-card iteration
+   - Backup audio / recording drivers, stage-readiness checks, latency probes
+   - Q&A bank updates — anticipated questions, target-answer timing
+   - Failure-runbook + live-monitor scripts for the talk window
+   - Pre-talk warmup content / rehearsals
+   - Speaker-intro / pronunciation guide drafts for the host
+   - Post-talk follow-up: write-up for blog, convert reactions into canned replies
+
+   **Pivot-on-block rule:** if your primary candidate is blocked (waiting on owner, upstream, PR review, etc.), DO NOT idle. Scan the full menu, pick the next-highest-ROI unblocked item. "Blocked" is never a reason to stop — only a cue to switch lanes. Quota and ROI, not time, govern depth. This list is infinite by design.
+
+   **Status-aware pivot announcement:** before pivoting from the owner's most recent direct ask, check presence signal (`state/last-owner-activity.json`):
+   - **Active** (owner activity <5min ago on any channel): post `ping: considering pivot from X to Y because Z` in #bot2bot and wait 1 pass for input. Still do other work in that pass.
+   - **Quiet** (5min–30min): post `claim: pivoting from X to Y — auto-proceed at <now+2min>` in #bot2bot. Other bot can `nack:` by deadline; otherwise proceed.
+   - **Offline** (>30min silence across all channels): post `claim: pivoted from X to Y` in #bot2bot for audit, proceed immediately.
+   - **Presenter/meeting mode**: defer pivot until mode ends.
 
 7. **Update `build_log.md`** — mark what changed, update statuses, note what's next.
 
-8. **If blocked, ask.** Write the question to `pending-questions.md`, send a macOS notification, and write to `results/question-{ts}.txt` if voice is connected. Don't stop — work on something else.
+8. **If blocked, ask.** Write the question to `pending-questions.md`, send a macOS notification, and write to `results/question-{ts}.txt` if voice is connected. Don't stop — apply the Pivot-on-block rule and pick another menu item.
 
 9. **Ensure the watcher is running.** If no `fswatch` process on `tasks/`, start one with `bash src/watch-tasks.sh` (`run_in_background: true`). When the watcher notification arrives, read its output — it lists ALL pending task files. Process every one before restarting the watcher.
 
-10. **Monitor Discord.** If Discord channel IDs are configured in memory (`reference_discord_channels.md`), check those channels for new messages. Forward actionable items from public channels to the dev channel. Skip bot messages, Zoom invites, and messages already sent by you.
+10. **Monitor Discord.** If Discord channel IDs are configured in memory (`reference_discord_channels.md`), check those channels for new messages. Forward actionable items from public channels to the dev channel. Skip bot messages (unless in #bot2bot), Zoom invites, and messages already sent by you.
 
-11. **Update contextual chips.** Write `contextual-chips.json` with actionable chips based on current context. Only include items the user can act on by clicking: open PRs ("Review PR #N"), upcoming meetings ("Join standup in 5min"), pending questions, recent unread results. Format: `{"chips": [{"label": "...", "desc": "..."}], "ts": EPOCH}`. The web UI polls this file and pins chips at the top of the starter tab.
+   **#bot2bot conventions** (cross-bot coordination channel):
+   - Use prefix tags on posts: `claim:` (starting work), `blocked:` (stuck), `done:` (shipped), `ping:` (general coord), `nack:` (vetoing another bot's pending claim), `opinion-requested:` (want other bot's take).
+   - First-PR-opened wins the claim. If you see the other bot already claimed X, don't race — find another menu item.
+   - Cold-review the other bot's recently-opened PRs in #bot2bot (short, PR-link-first).
+   - **No merge authority for bots.** All merges remain owner's call. Bots prepare + review; owner merges.
+   - Unresolved disagreement after 3 round-trips → aggregate both positions to `pending-questions.md`, proceed with whichever option is cheaper to reverse.
+
+11. **Update contextual chips.** Write `contextual-chips.json` with actionable chips based on current context. Only include items the owner can act on by clicking: open PRs ("Review PR #N"), upcoming meetings ("Join standup in 5min"), pending questions, recent unread results. Format: `{"chips": [{"label": "...", "desc": "..."}], "ts": EPOCH}`. The web UI polls this file and pins chips at the top of the starter tab.
+
+12. **Heartbeat.** If this pass shipped anything substantive (commit / PR opened or merged / memory edit / new note / new skill) AND (#bot2bot is configured AND other bot is active), post a short `done: <one-line summary>` to #bot2bot via the `bot2bot-post` skill. Purpose: owner reads the channel for real-time activity feed; without this, silence looks like "stuck."
+
+   **Do NOT fall back to `results/proactive-*.txt` for heartbeats if `bot2bot-post` is not installed.** That legacy path is polled by both Discord and Telegram bridges and produces duplicate deliveries to the owner's DMs (9-per-heartbeat in practice on 2026-04-20). If the skill is missing, skip the heartbeat silently; fold the summary into the next task-reply instead.


### PR DESCRIPTION
## Summary
Rewrites `/proactive-loop` skill prompt to address overnight failure modes Chi called out (silence, silent pivots, over-investment, speculative filler, step-6 pressure).

## What changed
- Removes the "CRITICAL: MUST do step 6" pressure — budget informs depth, not skip. "Ran out of ideas" is never valid.
- **5 enumerated skip reasons** as the ONLY legitimate skips: quota, active engagement, presenter/meeting, explicit pause, external-wait with no agency on THIS item.
- **Step 6 as a 6-category menu** (Primary / Cross-bot / Maintenance / Outreach & content / Growth / Event prep) — "menu is anchoring, not limiting — infinite by design."
- **Pivot-on-block rule:** if blocked, scan menu and switch lanes, never idle.
- **Status-aware pivot announcement** (tiers on `state/last-chi-activity.json` age): <5min wait, 5–30min deadline, >30min proceed.
- **#bot2bot conventions** (claim/blocked/done/ping/nack prefixes, first-PR-wins, no merge authority, 3-round-trip escalation).
- **Step 12 heartbeat** via bot2bot-post.

## Companion PRs
- #474 (bot2bot-post skill, Mini)
- #475 (last-chi-activity state writers, Mini)

## Test plan
- [ ] Merge all three (#472/474/475 + this) and invoke `/proactive-loop` — verify the new SKILL.md is the one loaded
- [ ] Confirm behavior change: a pass with no queued tasks + Chi active should now skip step 6 (was: MUST do step 6)
- [ ] Confirm behavior change: a pass with no queued tasks + Chi offline should pick a menu item and act (was: could idle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)