### PR TITLE
fix(bridges): claim proactive-*.txt by atomic rename before send

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -755,6 +755,22 @@ async def poll_proactive():
             _presenter_log_throttle = 0
             for f in RESULTS_DIR.iterdir():
                 if f.name.startswith("proactive-") and f.suffix == ".txt":
+                    # Claim-by-rename: atomically move the file to a
+                    # `.sending` suffix so a concurrent poll iteration
+                    # (this coroutine, a race with the same-node telegram
+                    # bridge, or a process restart picking up a leftover)
+                    # can't pick it up and resend. 2026-04-20 saw one
+                    # proactive file delivered 9× to the owner's DM
+                    # because the prior `read → send → unlink` pattern
+                    # had no exclusive claim. Rename is atomic on POSIX
+                    # same-filesystem; FileNotFoundError from the rename
+                    # means another iteration already claimed it.
+                    claim = f.with_suffix(".sending")
+                    try:
+                        f.rename(claim)
+                    except FileNotFoundError:
+                        continue
+                    f = claim  # subsequent reads + unlink operate on the claim path
                     text = f.read_text().strip()
                     if not text:
                         f.unlink(missing_ok=True)

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -289,6 +289,18 @@ def main():
             if not presenter_mode_active():
                 for f in RESULTS_DIR.iterdir():
                     if f.name.startswith("proactive-") and f.suffix == ".txt":
+                        # Claim-by-rename: atomic move to a `.sending`
+                        # suffix before reading, so a concurrent poll
+                        # (same bridge, or a race with discord-bridge)
+                        # can't pick it up and resend. See
+                        # discord-bridge.py for the same fix + the
+                        # 2026-04-20 bug-scenario that motivated it.
+                        claim = f.with_suffix(".sending")
+                        try:
+                            f.rename(claim)
+                        except FileNotFoundError:
+                            continue
+                        f = claim
                         text = f.read_text().strip()
                         if not text:
                             f.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- Replace \`read → send → unlink\` with \`rename → read → send → unlink\` in both Discord + Telegram bridges' \`poll_proactive\` loops
- Rename is atomic on POSIX same-filesystem: only one iteration wins, losers see \`FileNotFoundError\` and skip
- Eliminates the duplicate-delivery class of bug regardless of underlying cause

## The bug this fixes
2026-04-20: one proactive file was delivered to Chi's Discord DM **9 times back-to-back** (verified via \`logs/discord-bridge.log\`). Root cause not fully pinned — candidates:
- Silent \`unlink\` failure (masked by \`missing_ok=True\`) → next poll sees the file again
- Write tool producing multiple rename events the poll loop saw as separate files
- Bridge restarted mid-send, leaving the file intact for next startup

This patch is defensive against all three: claiming the file exclusively before reading makes duplicate delivery impossible regardless of which mechanism triggered it.

## Test plan
- [ ] Manually drop a \`results/proactive-test.txt\`, watch the bridge log for a single \`[proactive] sent\` line
- [ ] Verify the file is cleaned up (no leftover \`.sending\` orphan)
- [ ] Verify empty proactive files still get unlinked without a send
- [ ] Verify send failures don't re-deliver (the claim gets unlinked either way)

## Related
Motivated by Chi's Discord feedback 2026-04-20 — "you sent multiple heartbeat msgs with identical content" + "Letter for letter" confirmation. Follow-up commitment from that thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)