### PR TITLE
docs(proactive-loop): split specific menu items to PERSONAL_CLAUDE.md

### DIFF
--- a/PERSONAL_CLAUDE.md.example
+++ b/PERSONAL_CLAUDE.md.example
@@ -6,3 +6,58 @@
 
 # Never modify `src/startup.sh` or `src/restart.sh`. These are owner-maintained scripts.
 # Never push without my explicit approval.
+
+# ---------------------------------------------------------------------------
+# ## Current Work Menu
+# ---------------------------------------------------------------------------
+# The proactive-loop skill's step 6 reads this section for your specific
+# current items under each category. Categories (Primary / Cross-bot /
+# Maintenance / Outreach & content / Growth / Event prep) are defined in
+# the shared `skills/proactive-loop/SKILL.md`; fill in the specifics here
+# so they stay per-user and don't leak into the public repo.
+#
+# Uncomment + edit to match your current projects. Keep it short — this is
+# anchoring examples, not an exhaustive plan.
+
+# ## Current Work Menu
+#
+# ### Primary
+# - Examples:
+#   - `notes/<your-positioning-docs>.md` — keep current
+#   - Community PRs on `<your-repo>` — triage + cold-review
+#   - Current-deadline project (e.g., "ICLR prep until 2026-04-26")
+#
+# ### Cross-bot
+# - Examples:
+#   - Answer open `opinion-requested:` claims in `#bot2bot` (channel ID in `~/.claude/channels/discord/access.json`)
+#   - Review the other bot's recently-opened PRs
+#
+# ### Maintenance / hygiene
+# - Examples:
+#   - Curate memory files under `~/.claude/projects/<your-project>/memory/`
+#   - Resolve any `pending-questions.md` items the bot can handle without you
+#
+# ### Outreach & content
+# - Examples:
+#   - Social post iteration for <your-launch>
+#   - Research digest on <tech-you-care-about>
+#
+# ### Growth
+# - Examples:
+#   - Deep-dive: <capability you want the agent to have but it doesn't yet>
+#   - Upgrade skill: <skill-name> (sharpen, add tests, extend)
+#
+# ### Event prep
+# - Examples:
+#   - <Conference or talk> — deck, cue cards, backup clips, Q&A bank
+#
+# ---------------------------------------------------------------------------
+# ## Channel overrides (optional)
+# ---------------------------------------------------------------------------
+# If your multi-bot coord channel isn't the default, or your personal
+# identity shouldn't be "Sutando," override here. The skill stays generic;
+# this file names the specifics.
+#
+# - bot-to-bot coord channel: <Discord channel ID> (set `role: "bot2bot"` in access.json)
+# - owner Discord user_id: <your ID>
+# - owner Telegram chat_id: <your ID>

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -81,42 +81,28 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 
    Log the chosen item + estimated ROI in `core-status.step` so the owner can audit pick quality.
 
-6. **Act on it.** Pick the highest-ROI work for this pass and execute. Menu is anchoring, not limiting — legitimate work space is infinite.
+6. **Act on it.** Pick the highest-ROI work for this pass and execute. Menu is anchoring, not limiting — legitimate work space is infinite. Specific menu items live in `PERSONAL_CLAUDE.md` under `## Current Work Menu` (gitignored, per-user); the shared categories below are the skeleton.
 
-   **Primary** (derived from step 5 priorities):
-   - Code: write/fix/refactor; open PR; review community PR
-   - Testing: cold-read own recent PRs, run probes against new code, audit skill behavior
-   - Docs (owner-facing): `notes/sutando-user-stories.md`, `notes/sutando-advantages-table.md`, README sections the owner pre-approves
+   **Primary** — hands-on implementation, review, testing. Code / tests / owner-facing docs.
 
-   **Cross-bot** (always eligible when other bot is active):
-   - Answer an open `@me` opinion-request in #bot2bot
-   - Post `@other claim: X` in #bot2bot for a backlog item you want to take
-   - Review the other bot's recently-opened PR
+   **Cross-bot** (always eligible when another bot is active) — peer coord in the bot-to-bot channel.
+   - Answer an open `@me` opinion-request.
+   - Post `@other claim: X` for a backlog item you want to take.
+   - Review the other bot's recently-opened PR.
 
    **Maintenance / hygiene** (always eligible):
-   - Memory maintenance: trim stale entries, dedupe, verify references, update `MEMORY.md` index
-   - Pending-questions review: resolve anything bot can without owner input; check which are actually stuck
-   - Task-archive pattern mining: read `tasks/archive` for repeated failure shapes → propose prevention
-   - Self-audit: re-read own recent `build_log.md` / PRs for mistakes the second-pass view catches
+   - Memory maintenance: trim stale entries, dedupe, verify references, update `MEMORY.md` index.
+   - Pending-questions review: resolve anything bot can without owner input; check which are actually stuck.
+   - Task-archive pattern mining: read `tasks/archive` for repeated failure shapes → propose prevention.
+   - Self-audit: re-read own recent `build_log.md` / PRs for mistakes the second-pass view catches.
 
-   **Outreach & content**:
-   - Prepare / refine social posts + media (X threads, LinkedIn, Discord drops) — iterate variants, alt-text, captions
-   - Research news / papers / repos in relevant tech → summarize + propose integration
-   - Commercial strategy: revenue paths, pricing ideas, partnership leads, writeups for owner review
+   **Outreach & content** — social posts + media iteration, research digests, commercial strategy writeups.
 
-   **Growth**:
-   - Discover new knowledge: deep-dive into capabilities Sutando should have but doesn't
-   - Upgrade your superpower: pick a concrete skill, build/sharpen it; new memory entries; reliability improvements to self
-   - Earn money: revenue-generation work (posts that convert, features that monetize, pitch prep)
+   **Growth** — deep-dives into missing capabilities, self-skill improvements, revenue-generation work.
 
-   **Event prep** (conference talks, demos, press):
-   - Slide deck / script / cue-card iteration
-   - Backup audio / recording drivers, stage-readiness checks, latency probes
-   - Q&A bank updates — anticipated questions, target-answer timing
-   - Failure-runbook + live-monitor scripts for the talk window
-   - Pre-talk warmup content / rehearsals
-   - Speaker-intro / pronunciation guide drafts for the host
-   - Post-talk follow-up: write-up for blog, convert reactions into canned replies
+   **Event prep** — conference talks, demos, press. Slide deck / script / cue-card iteration, backup clips, Q&A bank, failure-runbook, pre-talk warmup, speaker-intro drafts, post-talk follow-up artifacts.
+
+   For the owner's current specific items under each category — projects in flight, file paths, upcoming events — read `PERSONAL_CLAUDE.md`. Absent that file, treat the categories above as free-form buckets and pick the highest-ROI unblocked work you can identify from context (pending questions, open PRs, memory updates, recent conversation).
 
    **Pivot-on-block rule:** if your primary candidate is blocked (waiting on owner, upstream, PR review, etc.), DO NOT idle. Scan the full menu, pick the next-highest-ROI unblocked item. "Blocked" is never a reason to stop — only a cue to switch lanes. Quota and ROI, not time, govern depth. This list is infinite by design.
 


### PR DESCRIPTION
## Summary
- Split Chi-specific example items out of `skills/proactive-loop/SKILL.md` step 6 — move them to `PERSONAL_CLAUDE.md` (gitignored, per-user).
- Shared skill keeps category headers + 1-2 line generic descriptions + the meta-frame ("menu is anchoring, not limiting; infinite by design").
- `PERSONAL_CLAUDE.md.example` grows from a 2-rule stub to a fleshed-out template with commented-out `## Current Work Menu` sections per category + optional channel-override block.

## Why
Chi: "the example work items in step 6 should live in a personal file." Specific items (`notes/sutando-user-stories.md` paths, "capabilities Sutando should have," Echo Act IV post-talk workflows, ICLR speaker-intro drafts) are project-specific and leak into anyone who clones the repo. Categories are the portable abstraction; items are per-user.

## Structure
Follows the `PERSONAL_CLAUDE.md` precedent already established at `CLAUDE.md:42`:
> "If PERSONAL_CLAUDE.md exists in the workspace root, read and follow it. It contains user-specific rules, preferences, and configuration that override or extend these shared instructions."

New adopters get a commented-out template to fill in; absent any `PERSONAL_CLAUDE.md` the skill falls back to "treat categories as free-form buckets."

## Test plan
- [ ] Re-invoke `/proactive-loop` after merge, verify the reformatted SKILL.md loads without errors
- [ ] Confirm the skill still references `state/last-owner-activity.json` (no regression from the earlier rename)
- [ ] Verify step-6 pivot-on-block + status-aware-pivot rules are unchanged (they were generic, should not have moved)
- [ ] Optional: copy the `.example` to `PERSONAL_CLAUDE.md` locally, fill in `## Current Work Menu`, confirm the skill references it correctly on the next pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)