### PR TITLE
fix(screen-capture): sanitize display index (CodeQL #33 RCE)

### DIFF
--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -97,7 +97,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
             from urllib.parse import urlparse, parse_qs
             query = parse_qs(urlparse(self.path).query)
             display_raw = query.get("display", [None])[0]
-            display = display_raw if display_raw and display_raw.isdigit() else None
+            # Coerce to int to short-circuit taint flow into the subprocess
+            # argument list. Display index constrained to 1..9 (macOS never has
+            # more than a handful of displays).
+            display = int(display_raw) if display_raw and display_raw.isdigit() and 1 <= int(display_raw) <= 9 else None
             capture_all = query.get("all", ["false"])[0] == "true"
             try:
                 if capture_all:


### PR DESCRIPTION
## Summary
- CodeQL alert [#33](https://github.com/sonichi/sutando/security/code-scanning/33) (py/command-line-injection, severity error): the `display` query parameter flowed from user input to `subprocess.run`'s argv in `src/screen-capture-server.py:124`.
- Existing `isdigit()` guard was a real sanitizer, but CodeQL's taint analysis didn't recognize it.
- Fix: coerce to `int` (recognized sanitizer) + constrain to `1..9` (no Mac has more than a handful of displays).

## Test plan
- [x] Edge-case table (non-digit, empty, `0`, `10`, `99`, whitespace, `"2.0"`) → all return `None`; valid `1..9` return the int.
- [ ] Verify CodeQL alert #33 auto-closes after merge.

## Related
- Highest-severity RCE alert on the list; 14 path-traversal alerts in `agent-api.py`/`dashboard.py` + 2 clear-text-logging alerts in voice-agent/conversation-server remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)