### PR TITLE
fix(logging): stop echoing sensitive env-var substrings (CodeQL #24, #44)

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -1618,11 +1618,12 @@ async function start(): Promise<void> {
 		console.log(`╠════════════════════════════════════════════════════╣`);
 		console.log(`║  Local:    http://localhost:${String(PORT).padEnd(27)}║`);
 		console.log(`║  Tunnel:   ${WEBHOOK_BASE_URL.slice(0, 40).padEnd(40)}║`);
-		// Mask phone number for logging (CodeQL #15, #37: js/clear-text-logging)
-		const maskedPhone = TWILIO_PHONE_NUMBER.length > 6
-			? TWILIO_PHONE_NUMBER.slice(0, 2) + '***' + TWILIO_PHONE_NUMBER.slice(-2)
-			: '***';
-		console.log(`║  Phone:    ${maskedPhone.padEnd(40)}║`);
+		// Don't echo any portion of TWILIO_PHONE_NUMBER — CodeQL #24 / #15 /
+		// #37 treat any substring as clear-text-logging of a sensitive env
+		// var. Presence-only signal is enough for startup diagnostics; use
+		// `env | grep TWILIO_PHONE_NUMBER` to inspect.
+		const phoneStatus = TWILIO_PHONE_NUMBER.length > 6 ? 'configured' : 'MISSING';
+		console.log(`║  Phone:    ${phoneStatus.padEnd(40)}║`);
 		console.log(`╠════════════════════════════════════════════════════╣`);
 		console.log(`║  POST /call              — outbound call           ║`);
 		console.log(`║  POST /concurrent-call   — child call (for Claude) ║`);

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -62,9 +62,14 @@ function assertGeminiKey(name: string, value: string): void {
 	// tight bound would fail-fast on legitimate future keys.
 	const looksValid = value.startsWith('AIza') && value.length >= 35 && value.length <= 60;
 	if (!looksValid) {
+		// Note: we do NOT echo any portion of the key value back into the log,
+		// not even the 4-char prefix — CodeQL flags clear-text-logging of any
+		// substring of a secret env var. Length + pass/fail-on-prefix is
+		// enough to diagnose a truncated-paste or wrong-var misconfig.
+		const prefixOk = value.startsWith('AIza') ? 'yes' : 'no';
 		console.error(
 			`Error: ${name} does not look like a Google AI Studio key ` +
-			`(expected "AIza..." ~39 chars, got ${value.length} chars starting "${value.slice(0, 4)}"). ` +
+			`(expected "AIza..." ~39 chars, got ${value.length} chars; prefix="AIza"? ${prefixOk}). ` +
 			`Rotate at https://ai.google.dev → "Get API key" and update .env.`
 		);
 		process.exit(1);


### PR DESCRIPTION
## Summary
- Two clear-text-logging alerts, both slice()-ing a sensitive env var + printing the substring. CodeQL treats any substring as clear-text-logging of the secret, even when bytes are trivial.
- **#44** (voice-agent.ts:66): GEMINI_API_KEY / GEMINI_VOICE_API_KEY startup assertion printed first 4 chars (\`AIza\`). Now: prefix-matches boolean (same diagnostic, no taint).
- **#24** (conversation-server.ts:1625): phone-server banner printed a masked TWILIO_PHONE_NUMBER (first 2 + last 2). Now: presence-only \`configured\` / \`MISSING\`.

Both are startup-banner context; no runtime or debugging impact.

## Test plan
- [x] \`npx tsc --noEmit\` → clean
- [ ] Verify CodeQL #24 + #44 auto-close after merge
- [ ] Voice-agent startup still logs sensible error text on misconfig

## Related
- #485 (CodeQL #33 RCE fix — queued)
- 15 path-injection alerts in dashboard.py + agent-api.py — batched next

🤖 Generated with [Claude Code](https://claude.com/claude-code)