### PR TITLE
fix(agent-api): break CodeQL taint via Path.name (path-injection #7, #16-23)

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -134,12 +134,23 @@ def get_status() -> dict:
 
 
 def _safe_path(base_dir: Path, filename: str) -> Path:
-    """Resolve a path safely under base_dir. Returns None if path escapes."""
-    # Inline sanitization so CodeQL sees taint broken before Path() (fixes #16-23)
+    """Resolve a path safely under base_dir. Returns None if path escapes.
+
+    Layered defense:
+    1. Whitelist-sanitize to `[a-zA-Z0-9_.-]+`.
+    2. Rebuild the filename via `Path(...).name` — CodeQL-recognized
+       sanitizer that strips any residual path components and breaks the
+       taint flow that `.is_relative_to()` alone didn't cut.
+    3. Confine under `base_dir` via `.is_relative_to()` after `.resolve()`.
+    """
     safe_name = re.sub(r'[^a-zA-Z0-9_\-.]', '', filename)
     if not safe_name:
         return None
-    resolved = (base_dir / f"{safe_name}.txt").resolve()
+    # Path(...).name is a CodeQL-recognized path-injection sanitizer; it's
+    # a functional no-op after the whitelist (safe_name has no separators)
+    # but it breaks the taint flow CodeQL tracks through f-string building.
+    safe_basename = Path(safe_name + ".txt").name
+    resolved = (base_dir / safe_basename).resolve()
     if not resolved.is_relative_to(base_dir.resolve()):
         return None
     return resolved
@@ -363,8 +374,16 @@ class Handler(http.server.BaseHTTPRequestHandler):
             if not safe_rel or safe_rel != rel or '..' in safe_rel or safe_rel.startswith('/') or '\x00' in safe_rel:
                 self.send_json(400, {"error": "invalid path"})
                 return
+            # Decompose + rebuild via Path(...).name per component — breaks
+            # CodeQL's taint flow (Path.name is a recognized path-injection
+            # sanitizer). After the regex above, each split('/') component
+            # is already [a-zA-Z0-9_.-]+, so this is a functional no-op.
+            safe_parts = [Path(p).name for p in safe_rel.split('/') if p]
+            if not safe_parts:
+                self.send_json(400, {"error": "invalid path"})
+                return
             repo_resolved = REPO_DIR.resolve()
-            media_path = (repo_resolved / safe_rel).resolve()
+            media_path = repo_resolved.joinpath(*safe_parts).resolve()
             if not media_path.is_relative_to(repo_resolved) or not media_path.is_file():
                 self.send_json(404, {"error": "not found"})
                 return
@@ -606,7 +625,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
                         safe_qid = re.sub(r'[^a-zA-Z0-9_\-.]', '', qid)
                         if safe_qid:
                             task_dir = (REPO_DIR / "tasks").resolve()
-                            task_file = (task_dir / f"answer-{safe_qid}-{ts}.txt").resolve()
+                            # Path(...).name taint-breaker (see _safe_path comment).
+                            safe_basename = Path(f"answer-{safe_qid}-{ts}.txt").name
+                            task_file = (task_dir / safe_basename).resolve()
                             if task_file.is_relative_to(task_dir):
                                 task_file.write_text(f"User answered {safe_qid}: {answer}")
                         self.send_json(200, {"ok": True, "id": qid, "answer": answer})


### PR DESCRIPTION
## Summary
9 open CodeQL path-injection alerts across 3 sites in \`src/agent-api.py\`. Same root cause as #487: existing sanitization is strong (regex whitelist + \`is_relative_to\`), but CodeQL doesn't recognize \`is_relative_to\` as a taint-breaker. Apply the \`Path.name\` pattern Mini validated on #487.

## Sites
1. \`_safe_path(base_dir, filename)\` — task/result lookup helper (alerts **#16-19**). Rebuild filename via \`Path(name + ".txt").name\`.
2. \`/media/{rel}\` handler (alerts **#7, #20-21**). Multi-segment path; split on \`/\` and rebuild each component via \`Path(p).name\`, then \`joinpath(*parts)\`.
3. Inline task-file build for \`answer-{qid}-{ts}.txt\` (alerts **#22-23**). Apply \`Path(...).name\` to the full basename.

\`Path.name\` is functionally a no-op after the regex whitelist (no separators survive), but it's a CodeQL-recognized path-injection sanitizer.

## Test plan
- [x] \`_safe_path\` edge cases: valid IDs pass, empty → None, dangerous chars (\`/\`, spaces, \`..\`) stripped and confined inside base_dir
- [ ] \`/media/{rel}\` round-trip: \`curl http://localhost:7843/media/notes/some.png\` still returns the image
- [ ] \`POST /task\` answer-pending still writes the \`tasks/answer-...txt\` file correctly
- [ ] Verify CodeQL alerts #7, #16-23 auto-close after merge

## Related
- #487 — same pattern in \`src/dashboard.py\` (dashboard sweep, Mini LGTM'd)
- Closes the path-injection queue: 15 alerts total, all handled by #487 + this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)