### PR TITLE
fix(web-client): clamp seeing-TTL to 60s (CodeQL #43 resource-exhaustion)

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -2527,7 +2527,13 @@ const server = createServer((req, res) => {
 					if (labelParam) _toolLabel = labelParam;
 					const ttlParam = url.searchParams.get('ttl_ms');
 					const ttl = ttlParam ? parseInt(ttlParam, 10) : 3000;
-					const ttlMs = isFinite(ttl) && ttl > 0 ? ttl : 3000;
+					// Clamp upper bound to 60s to break CodeQL #43
+					// (js/resource-exhaustion). The "seeing" overlay is UI
+					// flash feedback (1.5-3s typical); nothing legitimate
+					// needs a minute-plus timer, and an unbounded ttl_ms would
+					// schedule a long-lived setTimeout per request.
+					const MAX_TTL_MS = 60000;
+					const ttlMs = isFinite(ttl) && ttl > 0 ? Math.min(ttl, MAX_TTL_MS) : 3000;
 					_seeingUntil = Date.now() + ttlMs;
 					// Schedule an auto-revert broadcast so the browser clears
 					// .seeing even if nothing else POSTs a state update.


### PR DESCRIPTION
## Summary
- CodeQL alert [#43](https://github.com/sonichi/sutando/security/code-scanning/43) (js/resource-exhaustion, warning): \`ttl_ms\` query param on \`/mute-state?state=seeing\` flowed directly into \`setTimeout\` duration.
- Existing guard only checked \`isFinite(ttl) && ttl > 0\` — no upper bound. Unbounded \`ttl_ms\` would schedule a long-lived timer per request (cheap-to-allocate DoS).
- Fix: clamp with \`Math.min(ttl, 60000)\`. The "seeing" UI overlay is flash feedback (1.5-3s typical from \`screen-capture-server.py\`); nothing legitimate needs a minute-plus timer.

## Test plan
- [x] \`npx tsc --noEmit\` → clean
- [ ] Verify CodeQL #43 auto-closes after merge
- [ ] Live test: \`curl http://localhost:8080/mute-state?state=seeing&ttl_ms=999999999&source=tool\` — overlay should clear after 60s, not 11 days

## Closes the CodeQL queue
15 alerts total across 5 PRs:
- #485 — #33 RCE (screen-capture display index)
- #486 — #24 + #44 clear-text-logging (env var substrings)
- #487 — #28-31, #35, #36 path-injection (dashboard.py)
- #488 — #7, #16-23 path-injection (agent-api.py)
- **#489** (this PR) — #43 resource-exhaustion (web-client.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)