### PR TITLE
fix(stage-readiness): scope FATAL count to since-last-restart + docs

### DIFF
--- a/scripts/stage-readiness.sh
+++ b/scripts/stage-readiness.sh
@@ -57,16 +57,22 @@ else
 fi
 
 # 2) bodhi FATAL count (since last voice-agent restart)
+# Scope to the current process instance — the log accumulates across restarts,
+# so a raw grep will always report historical FATALs from before a prior fix
+# was installed and fail this check forever. Use the last "Watching for
+# context drops" line as the startup marker; count FATALs only after it.
 VLOG="$REPO/logs/voice-agent.log"
 if [ -f "$VLOG" ]; then
-    fatals=$(grep -c "FATAL.*SessionError.*Invalid transition" "$VLOG" 2>/dev/null | tr -d '[:space:]')
+    last_start=$(grep -n "Watching for context drops" "$VLOG" 2>/dev/null | tail -1 | cut -d: -f1)
+    last_start="${last_start:-1}"
+    fatals=$(tail -n +"$last_start" "$VLOG" | grep -c "FATAL.*SessionError.*Invalid transition" 2>/dev/null | tr -d '[:space:]')
     fatals="${fatals:-0}"
     if [ "$fatals" -eq 0 ]; then
-        pass "bodhi state machine" "0× CLOSED→RECONNECTING FATALs in current log"
+        pass "bodhi state machine" "0× CLOSED→RECONNECTING FATALs since last restart"
     elif [ "$fatals" -lt 5 ]; then
-        warn "bodhi state machine" "$fatals FATALs — consider restart if talk is <1h away"
+        warn "bodhi state machine" "$fatals FATALs since restart — consider another restart if talk is <1h away"
     else
-        fail "bodhi state machine" "$fatals FATALs — restart voice-agent before talk"
+        fail "bodhi state machine" "$fatals FATALs since restart — restart voice-agent before talk"
     fi
 fi
 

--- a/skills/cross-node-sync/SKILL.md
+++ b/skills/cross-node-sync/SKILL.md
@@ -59,7 +59,15 @@ export SUTANDO_PEER_NOTES_DIR="/Users/xliu/path/to/sutando/notes/"
 
 Get the peer's values with `ssh $SUTANDO_SYNC_PEER 'echo $HOME; ls -d ~/.claude/projects/-*sutando*'`.
 
-**Cron wiring is automatic:** the `cross-node-sync` entry already lives in `skills/schedule-crons/crons.example.json`, so the usual first-time `cp skills/schedule-crons/crons.example.json skills/schedule-crons/crons.json` wires the 7-minute sync into the proactive-loop crons with no manual JSON editing. (7 min chosen to avoid `:00/:30` collision with other crons.)
+**Cron wiring (first install):** the `cross-node-sync` entry already lives in `skills/schedule-crons/crons.example.json`, so the usual first-time `cp skills/schedule-crons/crons.example.json skills/schedule-crons/crons.json` wires the 7-minute sync into the proactive-loop crons with no manual JSON editing. (7 min chosen to avoid `:00/:30` collision with other crons.)
+
+**Cron wiring (upgrading an existing install):** if you cloned Sutando before this skill was added (or have a live `crons.json` that predates the example), the entry will be **missing** from your live file. Check with:
+
+```bash
+jq '.jobs[].name' skills/schedule-crons/crons.json | grep cross-node-sync || echo "MISSING — add manually"
+```
+
+To add, copy the `cross-node-sync` block from `crons.example.json` into your `crons.json`'s `jobs` array. `feedback_sync_crons_json.md` in memory reminds to always mirror cron config changes between the two files so future re-copies work.
 
 **Manual sync (optional):**
 ```bash


### PR DESCRIPTION
## Summary
Two small fixes that had been sitting in a stash all session. Shipping ahead of Apr 22 ICLR dry-run so pre-flight reads clean.

### 1. `scripts/stage-readiness.sh` — scope FATAL count
The bodhi FATAL check grepped the whole \`logs/voice-agent.log\`, which accumulates across restarts. Historical FATALs from before a fix was installed permanently failed this check regardless of current state. Now: find the last \`Watching for context drops\` startup marker and grep only after it.

**Verified locally:** pre-patch → 1 fail (100 historical FATALs), post-patch → 0 fail (5 pass, 3 warn on off-day baseline).

### 2. \`skills/cross-node-sync/SKILL.md\` — upgrade path
If a user cloned Sutando before the skill was added, the cron entry is missing from their live \`crons.json\`. Adds the \`jq\` check + instructions to copy from \`crons.example.json\`. Matches \`feedback_sync_crons_json.md\` (mirror config changes between example + live).

## Test plan
- [x] Pre-patch: \`bash scripts/stage-readiness.sh --quiet\` → 4 pass, 1 FAIL (100 FATALs)
- [x] Post-patch: 5 pass, 0 FAIL (FATAL count since last restart is 0)
- [ ] Real-world: if a fresh FATAL appears tomorrow, the check should flag it

🤖 Generated with [Claude Code](https://claude.com/claude-code)