### PR TITLE
docs(security): add inline CodeQL sanitizer comments at 5 path-injection sites

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -134,12 +134,22 @@ def get_status() -> dict:
 
 
 def _safe_path(base_dir: Path, filename: str) -> Path:
-    """Resolve a path safely under base_dir. Returns None if path escapes."""
-    # Inline sanitization so CodeQL sees taint broken before Path() (fixes #16-23)
+    """Resolve a path safely under base_dir. Returns None if path escapes.
+
+    CodeQL py/path-injection: every reachable path-sink in the codebase that
+    accepts user input flows through this helper or an equivalent inline pattern.
+    Two-layer defense: (1) regex allowlist strips everything except
+    [a-zA-Z0-9_\\-.] (so `../etc/passwd` becomes `etcpasswd`), (2) resolved-path
+    must stay within base_dir.resolve() (catches symlink/case-folding edge cases
+    on macOS APFS). CodeQL doesn't recognize `is_relative_to` as a sanitizer,
+    so alerts persist on call-sites — they're tracked + dismissed as won't-fix.
+    """
+    # CodeQL sanitizer: regex allowlist breaks taint before Path() construction
     safe_name = re.sub(r'[^a-zA-Z0-9_\-.]', '', filename)
     if not safe_name:
         return None
     resolved = (base_dir / f"{safe_name}.txt").resolve()
+    # CodeQL sanitizer: bound check rejects anything that escapes base_dir
     if not resolved.is_relative_to(base_dir.resolve()):
         return None
     return resolved
@@ -356,15 +366,19 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self.send_json(200, {})
         elif path.startswith("/media/"):
             # Serve local files for dynamic region (images, audio, video, docs)
-            # Note: mimetypes import removed — replaced by SAFE_TYPES allowlist (CodeQL #19-23 mitigation)
+            # CodeQL py/path-injection: this handler reads user-supplied path; flagged
+            # but sanitized end-to-end. Three layers below; alerts dismissed as won't-fix.
             rel = path[len("/media/"):]
-            # Sanitize: strip everything except safe filename characters (fixes CodeQL #20-21)
+            # CodeQL sanitizer (1/3): regex allowlist strips everything except
+            # [a-zA-Z0-9_./-]. Anything stripped → safe_rel != rel → reject.
             safe_rel = re.sub(r'[^a-zA-Z0-9_./-]', '', rel)
+            # CodeQL sanitizer (2/3): reject `..`, leading `/`, null byte, or any change.
             if not safe_rel or safe_rel != rel or '..' in safe_rel or safe_rel.startswith('/') or '\x00' in safe_rel:
                 self.send_json(400, {"error": "invalid path"})
                 return
             repo_resolved = REPO_DIR.resolve()
             media_path = (repo_resolved / safe_rel).resolve()
+            # CodeQL sanitizer (3/3): bound check + must be a file (rejects directories/symlinks).
             if not media_path.is_relative_to(repo_resolved) or not media_path.is_file():
                 self.send_json(404, {"error": "not found"})
                 return
@@ -602,11 +616,14 @@ class Handler(http.server.BaseHTTPRequestHandler):
                         pq_file.write_text(new_content)
                         # Also write as a task so the agent picks it up
                         ts = int(datetime.now().timestamp() * 1000)
-                        # Inline sanitization so CodeQL sees taint broken before Path() (fixes #22-23)
+                        # CodeQL py/path-injection sanitizer (1/2): regex allowlist strips
+                        # all non-safe chars from the user-supplied question id.
                         safe_qid = re.sub(r'[^a-zA-Z0-9_\-.]', '', qid)
                         if safe_qid:
                             task_dir = (REPO_DIR / "tasks").resolve()
                             task_file = (task_dir / f"answer-{safe_qid}-{ts}.txt").resolve()
+                            # CodeQL py/path-injection sanitizer (2/2): bound check —
+                            # write only if resolved path stays within tasks/.
                             if task_file.is_relative_to(task_dir):
                                 task_file.write_text(f"User answered {safe_qid}: {answer}")
                         self.send_json(200, {"ok": True, "id": qid, "answer": answer})

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -428,15 +428,19 @@ load()
             self.wfile.write(json.dumps(notes).encode())
         elif urlparse(self.path).path.startswith("/notes/"):
             raw_slug = urlparse(self.path).path.split("/notes/", 1)[1]
-            # Sanitize: strip all non-safe chars, reject if changed (fixes CodeQL #28-31, #35-36)
+            # CodeQL py/path-injection: GET handler reads user-supplied note slug.
+            # Three-layer sanitization below; alerts dismissed as won't-fix.
             import re
+            # CodeQL sanitizer (1/3): \w-only allowlist (no `.`, no `/`, no `..`).
             slug = re.sub(r'[^\w-]', '', raw_slug)
+            # CodeQL sanitizer (2/3): reject if anything was stripped.
             if not slug or slug != raw_slug:
                 self.send_response(400)
                 self.end_headers()
                 return
             notes_dir = (REPO_DIR / "notes").resolve()
             note_file = (notes_dir / f"{slug}.md").resolve()
+            # CodeQL sanitizer (3/3): bound check on resolved path.
             if not note_file.is_relative_to(notes_dir):
                 self.send_response(400)
                 self.end_headers()
@@ -459,15 +463,19 @@ load()
         path = urlparse(self.path).path
         if path.startswith("/notes/"):
             raw_slug = path.split("/notes/", 1)[1]
-            # Sanitize: strip all non-safe chars, reject if changed (fixes CodeQL #28-31, #35-36)
+            # CodeQL py/path-injection: DELETE handler reads user-supplied note slug.
+            # Three-layer sanitization below; alerts dismissed as won't-fix.
             import re
+            # CodeQL sanitizer (1/3): \w-only allowlist (no `.`, no `/`, no `..`).
             slug = re.sub(r'[^\w-]', '', raw_slug)
+            # CodeQL sanitizer (2/3): reject if anything was stripped.
             if not slug or slug != raw_slug:
                 self.send_response(400)
                 self.end_headers()
                 return
             notes_dir = (REPO_DIR / "notes").resolve()
             note_file = (notes_dir / f"{slug}.md").resolve()
+            # CodeQL sanitizer (3/3): bound check on resolved path.
             if not note_file.is_relative_to(notes_dir):
                 self.send_response(400)
                 self.end_headers()


### PR DESCRIPTION
## Summary

Adds explicit comment markers at every sanitization layer (regex strip + `is_relative_to` bound check) so the won't-fix dismissal rationale for the open `py/path-injection` alerts is visible directly in the source.

**No code logic change** — comments only. Both files parse cleanly.

## Sites covered

- `src/agent-api.py` — `_safe_path` helper docstring + 2 sanitizer markers; `/media/` handler 3-of-3 markers; answer-task POST handler 2-of-2 markers
- `src/dashboard.py` — GET `/notes/` handler 3-of-3 markers; DELETE `/notes/` handler 3-of-3 markers

Each marker reads e.g.:
```python
# CodeQL sanitizer (1/3): regex allowlist strips everything except [a-zA-Z0-9_./-]
```

## Background

After the post-merge audit on Chi's #485-#488 closed 9 of 18 alerts, 11 path-injection alerts remained open (#17, #18, #19, #23, #28, #29, #30, #31, #45, #46, #47). Local CodeQL re-run on 2026-04-21 (codeql 2.25.2 + custom model-pack experiments) confirmed:

1. The remaining alerts are real taint flows — not false positives
2. Every flagged sink already has inline sanitization: regex allowlist + `is_relative_to` bound check
3. CodeQL's `py/path-injection` query doesn't recognize `Path.is_relative_to` as a sanitizer
4. Custom model-pack `barrierGuardModel` + `barrierModel` experiments didn't close the alerts (likely needs custom QL extension, not just YAML)

Per Susan's direction, dismissing these 11 alerts as won't-fix once this PR merges, with each dismissal referencing the comment-marker line. The comments make the inline sanitization explicitly visible to future readers + auditors so the dismissal isn't blind.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('src/agent-api.py').read()); ast.parse(open('src/dashboard.py').read())"` passes
- [x] `git diff --stat` confirms +32/-7 (comments only)
- [x] No behavioral change — handler logic untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)