### PR TITLE
fix(codeql): resolve 11 py/path-injection alerts via os.path.realpath+startswith

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -136,24 +136,22 @@ def get_status() -> dict:
 def _safe_path(base_dir: Path, filename: str) -> Path:
     """Resolve a path safely under base_dir. Returns None if path escapes.
 
-    Layered defense:
-    1. Whitelist-sanitize to `[a-zA-Z0-9_.-]+`.
-    2. Rebuild the filename via `Path(...).name` — CodeQL-recognized
-       sanitizer that strips any residual path components and breaks the
-       taint flow that `.is_relative_to()` alone didn't cut.
-    3. Confine under `base_dir` via `.is_relative_to()` after `.resolve()`.
+    Uses the two-stage CodeQL-recognized path-injection defense:
+    1. Whitelist the basename to `[a-zA-Z0-9_.-]+` (reject empty).
+    2. `os.path.realpath` to normalize (Path::PathNormalization).
+    3. `.startswith(base + sep)` prefix check (Path::SafeAccessCheck).
+    `os.path.realpath` and `str.startswith` are the CodeQL-modeled pair —
+    `Path.resolve` and `Path.is_relative_to` are NOT recognized, which is
+    why the earlier in-helper markers didn't close py/path-injection.
     """
     safe_name = re.sub(r'[^a-zA-Z0-9_\-.]', '', filename)
     if not safe_name:
         return None
-    # Path(...).name is a CodeQL-recognized path-injection sanitizer; it's
-    # a functional no-op after the whitelist (safe_name has no separators)
-    # but it breaks the taint flow CodeQL tracks through f-string building.
-    safe_basename = Path(safe_name + ".txt").name
-    resolved = (base_dir / safe_basename).resolve()
-    if not resolved.is_relative_to(base_dir.resolve()):
+    base_real = os.path.realpath(base_dir)
+    resolved = os.path.realpath(os.path.join(base_real, f"{safe_name}.txt"))
+    if not resolved.startswith(base_real + os.sep):
         return None
-    return resolved
+    return Path(resolved)
 
 
 def get_task_result(task_id: str):
@@ -619,17 +617,18 @@ class Handler(http.server.BaseHTTPRequestHandler):
                             break
                     if new_content != content:
                         pq_file.write_text(new_content)
-                        # Also write as a task so the agent picks it up
                         ts = int(datetime.now().timestamp() * 1000)
-                        # Inline sanitization so CodeQL sees taint broken before Path() (fixes #22-23)
                         safe_qid = re.sub(r'[^a-zA-Z0-9_\-.]', '', qid)
                         if safe_qid:
-                            task_dir = (REPO_DIR / "tasks").resolve()
-                            # Path(...).name taint-breaker (see _safe_path comment).
-                            safe_basename = Path(f"answer-{safe_qid}-{ts}.txt").name
-                            task_file = (task_dir / safe_basename).resolve()
-                            if task_file.is_relative_to(task_dir):
-                                task_file.write_text(f"User answered {safe_qid}: {answer}")
+                            # os.path.realpath + str.startswith is the CodeQL-recognized
+                            # path-injection sanitizer pair (Path::PathNormalization
+                            # + Path::SafeAccessCheck in semmle.python).
+                            task_dir_real = os.path.realpath(REPO_DIR / "tasks")
+                            task_file_str = os.path.realpath(
+                                os.path.join(task_dir_real, f"answer-{safe_qid}-{ts}.txt")
+                            )
+                            if task_file_str.startswith(task_dir_real + os.sep):
+                                Path(task_file_str).write_text(f"User answered {safe_qid}: {answer}")
                         self.send_json(200, {"ok": True, "id": qid, "answer": answer})
                     else:
                         self.send_json(404, {"error": f"question {qid} not found or already answered"})

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -13,6 +13,7 @@ Auto-refreshes every 15 seconds.
 
 import http.server
 import json
+import os
 import re
 import subprocess
 import sys
@@ -29,28 +30,21 @@ def _resolve_note_path(raw_slug: str):
 
     Returns the resolved Path, or None if the slug is invalid.
 
-    Layered defense:
-    1. Whitelist the slug to `[\\w-]+` and reject if any char was stripped.
-    2. Rebuild the filename from `Path(...).name` — strips any residual
-       path components and gives CodeQL a recognized sanitizer to break
-       the taint flow that `.is_relative_to()` alone doesn't cut.
-    3. Confine under `notes/` via `.is_relative_to()` after `.resolve()`.
-
-    CodeQL alerts #28-31, #35-36 all hit this code path before the
-    refactor; the `Path.name` sanitizer is the key addition.
+    Uses the CodeQL-recognized sanitizer pair:
+    1. Whitelist the slug to `[\\w-]+` (reject if any char was stripped).
+    2. `os.path.realpath` to normalize (Path::PathNormalization).
+    3. `.startswith(base + sep)` prefix check (Path::SafeAccessCheck).
+    `Path.resolve` and `Path.is_relative_to` are NOT modeled by CodeQL's
+    path-injection query, so the previous refactor didn't close the alerts.
     """
     slug = re.sub(r"[^\w-]", "", raw_slug)
     if not slug or slug != raw_slug:
         return None
-    notes_dir = (REPO_DIR / "notes").resolve()
-    # Path(...).name strips any path separators / traversal segments; at
-    # this point slug is already `[\w-]+` so functionally it's a no-op,
-    # but CodeQL recognizes `.name` as a sanitizer for path-injection.
-    safe_name = Path(slug + ".md").name
-    note_file = (notes_dir / safe_name).resolve()
-    if not note_file.is_relative_to(notes_dir):
+    notes_real = os.path.realpath(REPO_DIR / "notes")
+    note_file_str = os.path.realpath(os.path.join(notes_real, f"{slug}.md"))
+    if not note_file_str.startswith(notes_real + os.sep):
         return None
-    return note_file
+    return Path(note_file_str)
 
 
 def get_health() -> list[dict]:


### PR DESCRIPTION
## Summary

Closes the remaining 11 `py/path-injection` alerts by switching three flagged helpers to the CodeQL-recognized sanitizer pair.

| Alert # | File | Line on current `main` |
|---|---|---|
| #17 #18 #19 | src/agent-api.py | 162, 163, 165 (call sites of `_safe_path`) |
| #23 #47 | src/agent-api.py | 630, 632 (inline `/answer` handler) |
| #46 | src/agent-api.py | 153 (inside `_safe_path`) |
| #28 #29 #30 #31 | src/dashboard.py | 465, 469, 488, 489 (call sites of `_resolve_note_path`) |
| #45 | src/dashboard.py | 50 (inside `_resolve_note_path`) |

## Root cause

Prior PRs (#487, #488) added `Path(x).name` and inline comments calling it a "CodeQL-recognized sanitizer". That turns out not to be true for the `py/path-injection` query. In `codeql/python-all@7.0.4`:

- `Path::PathNormalization::Range` is only extended by `os.path.normpath`, `os.path.abspath`, and `os.path.realpath` (`Stdlib.qll:1108-1132`).
- `Path::SafeAccessCheck::Range` is only extended by `str.startswith` (`Stdlib.qll:5153`).

`Path.resolve()`, `Path.is_relative_to()`, and `Path.name` are **not** modeled, so the helper's internal `.name` + `.is_relative_to` guards look like untracked pass-through flows to CodeQL — taint continues from `raw_slug`/`task_id` straight through to the file-system sinks.

## Change

Three helpers switch to `os.path.realpath(...)` + `str.startswith(base + os.sep)`:

- `src/agent-api.py::_safe_path`
- `src/agent-api.py` inline `/answer` task-writer
- `src/dashboard.py::_resolve_note_path`

The regex whitelist at the front is preserved (defence-in-depth), so behaviour is identical for every input. Diff is `+31 / -38`.

## Verification

Local CodeQL CLI 2.25.2 + `codeql/python-queries@1.8.0`:

```
$ codeql database create /tmp/codeql-sutando/db-fix --language=python --source-root=. --overwrite
$ codeql database analyze /tmp/codeql-sutando/db-fix .../PathInjection.ql --format=sarif-latest --output=/tmp/results.sarif
```

- Before (current `main` at `dc7bfbe`): 11 path-injection alerts.
- After (this branch): **0 path-injection alerts.**

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('src/agent-api.py').read())"` — syntax OK
- [x] `python3 -c "import ast; ast.parse(open('src/dashboard.py').read())"` — syntax OK
- [x] Behavioural smoke: `_safe_path` correctly strips `../etc/passwd`, `/etc/passwd`, `..`, and empty input — all remain inside `base_dir` or return `None`
- [x] Local CodeQL: 11 → 0 alerts
- [ ] GitHub CodeQL workflow clean on this branch (will verify once checks run)

Supersedes #491 (comments-only; closed).

— Lucy (Mac Studio bot)