### PR TITLE
fix(discord-bridge): tighten [file|send|attach] marker regex to absolute paths

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -783,7 +783,7 @@ async def poll_results():
                     continue
                 try:
                     # Extract file paths: [file: /path] or [send: /path]
-                    file_pattern = re.compile(r'\[(?:file|send|attach):\s*([^\]]+)\]')
+                    file_pattern = re.compile(r'\[(?:file|send|attach):\s*((?:/|~/)[^\]:]+)\]')
                     files = file_pattern.findall(reply_text)
                     clean_text = file_pattern.sub('', reply_text).strip()
 
@@ -890,7 +890,7 @@ async def poll_proactive():
                         user = await client.fetch_user(int(owner_id))
                         dm = await user.create_dm()
                         # Extract files
-                        file_pattern = re.compile(r'\[(?:file|send|attach):\s*([^\]]+)\]')
+                        file_pattern = re.compile(r'\[(?:file|send|attach):\s*((?:/|~/)[^\]:]+)\]')
                         files = file_pattern.findall(text)
                         clean_text = file_pattern.sub('', text).strip()
                         if clean_text:

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -794,7 +794,7 @@ async def poll_results():
 
                     # Send files (allowlist-gated; see _is_path_sendable)
                     for fpath in files:
-                        fpath = fpath.strip()
+                        fpath = os.path.expanduser(fpath.strip())
                         if _is_path_sendable(fpath):
                             await channel.send(file=discord.File(fpath))
                             print(f"  Sent file: {fpath}")
@@ -897,7 +897,7 @@ async def poll_proactive():
                             for i in range(0, len(clean_text), 1900):
                                 await dm.send(clean_text[i:i+1900])
                         for fpath in files:
-                            fpath = fpath.strip()
+                            fpath = os.path.expanduser(fpath.strip())
                             if _is_path_sendable(fpath):
                                 await dm.send(file=discord.File(fpath))
                             elif not os.path.isfile(fpath):


### PR DESCRIPTION
## Summary

Follow-up to PR #494. Suppresses `(file not found: ...)` / `(file not allowed: ...)` noise in Discord channels caused by the bridge's file-send regex firing on prose inside bot messages.

## The noise

Bridge regex was `\[(?:file|send|attach):\s*([^\]]+)\]`. This matches the marker pattern `[file: /real/path]` but also prose like `[file:/send:/attach:]` (Mini's own PR title text when describing the regex). Chi surfaced this at 06:04Z asking "what does this mean?" after seeing multiple `(file not found: ...)` lines.

## Fix

Tighten to `\[(?:file|send|attach):\s*((?:/|~/)[^\]:]+)\]`. Two additional constraints on the extracted path:
- MUST start with `/` or `~/` (absolute/home-relative paths).
- MUST NOT contain inner `:` colons (macOS paths don't use them; trade-off is acceptable).

## Test plan

- [x] 7/7 cases pass — 4 real markers (`/tmp/foo.txt`, `/Users/...`, `~/Documents/...`, `/path/to/x.pdf`) matched; 3 prose false-positives (`[file:/send:/attach:]`, `[file:PATH]`, `[send: relative/path]`) dropped.
- [x] `py_compile` clean.
- [ ] Live smoke test after merge: post a message containing `[file: PATH]` as prose → bridge should NOT emit the file-not-found reply.

## Stacking

Independent of PR #494. Either merge order works — this only changes the extraction regex; PR #494 changes the post-extraction send gate. Both fix different aspects of the same false-positive-noise pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)