### PR TITLE
fix(startup): drain Sutando.app shutdown before relaunch

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -166,7 +166,13 @@ if [ -f "$SUT_SRC" ] && { [ ! -f "$SUT_BIN" ] || [ "$SUT_SRC" -nt "$SUT_BIN" ]; 
     echo "  ✓ Sutando compiled"
     if pgrep -f "src/Sutando/Sutando" > /dev/null 2>&1; then
       pkill -f "src/Sutando/Sutando" 2>/dev/null || true
-      sleep 1
+      # Wait for kernel cleanup to drain before relaunch — fixed sleep 1
+      # raced with slow shutdown on 2026-04-21, leaving dual Sutando.app
+      # instances with ghost menu-bar icons.
+      for _ in $(seq 1 30); do
+        pgrep -f "src/Sutando/Sutando" >/dev/null 2>&1 || break
+        sleep 0.1
+      done
     fi
   else
     echo "  ⚠ Sutando compile failed — keeping existing binary if any"


### PR DESCRIPTION
## Summary
- Replace `pkill` + fixed `sleep 1` with a bounded drain loop (up to 3s, 0.1s poll) before relaunching Sutando.app
- Prevents dual-instance + ghost menu-bar icon when Sutando's teardown takes longer than 1 second

## Context
On 2026-04-21 this pattern bit during Swift-side work: the 1-second sleep expired while the old process was still releasing its `NSStatusItem`. `open` relaunched, and both instances coexisted until Chi manually quit the zombie via the menu. Captured in `feedback_pkill_then_open_race.md` (memory, gitignored).

The affected path only fires during recompile-replace (inside `if SUT_SRC -nt SUT_BIN`), so the blast radius is small. The bounded loop still exits after 3 seconds if the process genuinely won't die, so a hung Sutando can't deadlock `startup.sh`.

## Test plan
- [ ] Recompile Sutando.app while an instance is running; confirm only one process remains after startup.sh completes
- [ ] Kill -STOP a Sutando process to simulate hang, confirm startup.sh exits the drain after ~3s rather than spinning forever
- [ ] Cold-start (no existing Sutando): confirm no regression (loop is skipped via outer `pgrep` gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)