### PR TITLE
fix(restart): drain stopped services before exec-ing startup.sh

### DIFF
--- a/src/restart.sh
+++ b/src/restart.sh
@@ -26,7 +26,25 @@ if [ "$1" = "--stop-only" ]; then
     exit 0
 fi
 
-sleep 1
+# Wait for shutdown to drain before exec-ing startup.sh. Fixed `sleep 1`
+# raced the pkill'd processes: if Sutando.app (or any SIGTERM-respecting
+# service) took >1s to exit cleanly, startup.sh's `if ! pgrep ...` guard
+# skipped the relaunch and the user saw "restart did nothing."
+# See feedback_pkill_then_open_race.md and PR #499 for the same class on
+# startup.sh's recompile-replace path.
+STOP_PATTERNS=(
+    "voice-agent" "web-client.ts" "dashboard.py" "agent-api.py"
+    "screen-capture-server" "telegram-bridge" "discord-bridge" "watch-tasks"
+    "conversation-server" "ngrok" "credential-proxy" "src/Sutando/Sutando"
+)
+for _ in $(seq 1 30); do
+    still=0
+    for pat in "${STOP_PATTERNS[@]}"; do
+        if pgrep -f "$pat" >/dev/null 2>&1; then still=1; break; fi
+    done
+    [ $still -eq 0 ] && break
+    sleep 0.1
+done
 
 echo "Starting..."
 exec bash "$REPO/src/startup.sh"


### PR DESCRIPTION
## Summary
- Replace `sleep 1` after the pkill block with a bounded drain loop (up to 3s, 30 × 0.1s)
- Fixes the same race PR #499 addressed for startup.sh's recompile path, now for restart.sh's stop→start handoff

## Why

`restart.sh` does `pkill -f <pattern>` for 12 services (SIGTERM) and then `exec bash startup.sh`. SIGTERM-respecting services (Sutando.app in particular) can take >1s to exit cleanly. If they're still alive when startup.sh runs, its `if ! pgrep ...` guards skip the relaunch — user sees "restart did nothing" for that service, and has to re-run `restart.sh` or kill the laggard by hand.

The new drain loop waits for all 12 stop-patterns to go empty before exec-ing startup.sh. Exits early when done (most shutdowns finish in <500ms); falls through after 3s so a hung process can't deadlock the script.

## Stacked with PR #499

PR #499 fixes the same class of race on `startup.sh`'s recompile-replace path (pkill + sleep 1 there too). This PR covers the user-initiated restart.sh path. They're independent files and review cleanly on their own.

## Test plan
- [ ] `bash src/restart.sh` with all services running: confirm each one restarts (no "restart did nothing")
- [ ] `bash src/restart.sh --stop-only`: confirm early exit (drain loop must not run)
- [ ] Send SIGSTOP to one service to simulate hang: confirm restart.sh exits drain after ~3s rather than spinning
- [ ] No regression on fresh shell with no services running

🤖 Generated with [Claude Code](https://claude.com/claude-code)