### PR TITLE
fix(discord-bridge): silent-drop missing-file marker to bridge log

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -799,7 +799,11 @@ async def poll_results():
                             await channel.send(file=discord.File(fpath))
                             print(f"  Sent file: {fpath}")
                         elif not os.path.isfile(fpath):
-                            await channel.send(f"(file not found: {fpath})")
+                            # Silent-drop to bridge log: marker-shaped prose
+                            # (e.g., regex examples in a summary) used to emit
+                            # "(file not found:)" to Discord, spamming the DM.
+                            # The log keeps the debug signal.
+                            print(f"  (file not found, dropped): {fpath}", flush=True)
                         else:
                             await channel.send(f"(file not allowed: {fpath})")
                             print(f"  REJECTED file (not in allowlist): {fpath}", flush=True)
@@ -901,7 +905,9 @@ async def poll_proactive():
                             if _is_path_sendable(fpath):
                                 await dm.send(file=discord.File(fpath))
                             elif not os.path.isfile(fpath):
-                                await dm.send(f"(file not found: {fpath})")
+                                # Silent-drop to bridge log (see reply-path
+                                # comment above for rationale).
+                                print(f"  [proactive] (file not found, dropped): {fpath}", flush=True)
                             else:
                                 await dm.send(f"(file not allowed: {fpath})")
                                 print(f"  [proactive] REJECTED file: {fpath}", flush=True)


### PR DESCRIPTION
## Summary
- Route the `(file not found:)` not-found branch of the reply + proactive-DM file-send loops to `print(... flush=True)` instead of `channel.send`/`dm.send`.
- Keeps the `(file not allowed:)` allowlist-violation branch visible to Discord — that one is a security signal worth surfacing.

## Why now

PR #494 added the allowlist-gated file-send pipeline. PR #496 tightened the file-marker regex to reject prose with inner colons or non-absolute paths. But a well-formed marker pointing at a non-existent file still flows through this path:

1. Regex matches → path extracted
2. `_is_path_sendable` calls `os.path.isfile` → False
3. Bridge emits `(file not found: PATH)` to Discord

On 2026-04-21 I self-triggered this 3× writing about PR #496's fix — my DM summaries contained bracketed regex examples that looked like real markers to the wide regex, didn't point at real files, and each produced a `(file not found:)` pile-on in the same DM as the reply. Chi called it out twice. Captured the self-inflicted behavior in `feedback_no_marker_prose_while_496_open.md`, but the real fix is to not spam the human over it.

The debug signal is preserved in `logs/discord-bridge.log`; `grep "file not found, dropped"` surfaces every rejection for later analysis.

## Alternatives considered
- Broader silent-drop (including `(file not allowed:)`) — rejected. Allowlist failures are a security signal; worth keeping visible.
- Suffix heuristic (match only known extensions) — rejected. Doesn't help non-existent files with valid extensions.

## Test plan
- [ ] `python3 tests/discord-bridge-allowlist.test.py` still passes (no allowlist semantic changed)
- [ ] Smoke: write a result file with `[file: /nonexistent/foo.png]`, confirm nothing appears in Discord, a `(file not found, dropped)` line shows in `logs/discord-bridge.log`
- [ ] Smoke: write a result file with `[file: /etc/passwd]`, confirm `(file not allowed:)` still emits to Discord (security path preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)