### PR TITLE
feat(sync-memory): opt-in sync of state/presenter-mode.sentinel

### DIFF
--- a/src/sync-memory.sh
+++ b/src/sync-memory.sh
@@ -99,6 +99,16 @@ if [ -d "$NOTES_DIR" ]; then
     rsync -a --update --exclude='.gitkeep' "$NOTES_DIR/" notes/ 2>/dev/null
 fi
 
+# presenter-mode.sentinel: cross-node mute for the ICLR talk window.
+# `state/` is otherwise per-node (heartbeats, activity log), but this one
+# file is the global talk-day mute signal — if flipped on one Mac it
+# should mute the other. Opt-in single file, not the whole state/ dir.
+PRESENTER_SENTINEL="$REPO_DIR/state/presenter-mode.sentinel"
+if [ -f "$PRESENTER_SENTINEL" ]; then
+    mkdir -p state
+    copy_if_newer "$PRESENTER_SENTINEL" "state/presenter-mode.sentinel" || true
+fi
+
 # --- Commit and push if anything changed ---
 if git diff --quiet && git diff --cached --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
     log "Nothing to push"
@@ -123,6 +133,12 @@ if [ -d "$MEMORY_DIR" ]; then
 fi
 if [ -d "$NOTES_DIR" ]; then
     rsync -a --update --exclude='.gitkeep' notes/ "$NOTES_DIR/" 2>/dev/null
+fi
+
+# Reverse: pull presenter-mode.sentinel from sync (other node flipped it on).
+if [ -f "state/presenter-mode.sentinel" ]; then
+    mkdir -p "$REPO_DIR/state"
+    copy_if_newer "state/presenter-mode.sentinel" "$PRESENTER_SENTINEL" || true
 fi
 
 NOTES_COUNT=$(find notes -type f 2>/dev/null | wc -l | tr -d ' ')


### PR DESCRIPTION
## Summary
- Add state/presenter-mode.sentinel to sync-memory.sh rsync set, both push + pull direction
- Rest of state/ stays per-node (heartbeats, activity log, etc.)
- Addresses the cross-node presenter-mode gap flagged in pass-853 of the Apr 21 Mini build-log

## Why now
Presenter mode mutes discord-bridge proactive DMs + check-pending-questions cron — it's how Chi stops Discord distractions during a talk. Today, flipping on MacBook at T-5 leaves Mini's bridge chattering because state/ isn't synced. For the Apr 22 dry-run + Apr 26 talk, that's a known distraction.

## Scope choice
`skills/cross-node-sync/` (MacBook WIP on rsync-over-ssh) explicitly excludes `state/`. I'm taking the simpler path: piggyback on the existing git-repo-backed `sync-memory.sh`, sync just the single sentinel file opt-in. Not pulling in the whole state/ dir.

If MacBook's cross-node-sync later adds presenter-mode coverage, the two paths become redundant — but not conflicting. rsync mtime-wins resolves race. Redundant-but-safe is a fine intermediate.

## Timing caveat
sync runs hourly at `:27`. Cross-node propagation is up to 60 min. For the ICLR dry-run + talk, the T-5 flip should be paired with a manual `bash src/sync-memory.sh` on the flipping node for immediate propagation. Documented in `notes/iclr-dryrun-precheck-2026-04-21.md` already.

## Test plan
- [ ] Run sync with no sentinel on either node: no-op as before
- [ ] Flip sentinel on Mini, run sync twice (Mini + MacBook): sentinel appears on MacBook, other files unchanged
- [ ] Concurrent flip (both Macs): mtime-wins resolves, no conflict
- [ ] Expire sentinel manually (rm), run sync: other node's rm propagates (via git's tracking of deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)