### PR TITLE
fix(sync-memory): assert + self-heal to main branch before sync work

### DIFF
--- a/src/sync-memory.sh
+++ b/src/sync-memory.sh
@@ -54,6 +54,24 @@ fi
 
 cd "$SYNC_DIR" || { log "Failed to cd $SYNC_DIR"; exit 1; }
 
+# --- Assert on main before doing any sync work ---
+# If the sync repo has drifted to a feature/test branch (e.g. after a
+# manual `git checkout` in that dir), pull-rebase + commit + push will
+# operate on the wrong branch, silently stop propagating to origin/main,
+# and leave both nodes quietly diverging. Hit this 2026-04-21 pass 874
+# when my sync repo was on a stale `fix/startup-...` branch from a
+# cd-drift incident. Detect and self-heal.
+CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    log "sync repo on non-main branch '$CURRENT_BRANCH' — switching to main"
+    echo "sync-memory: sync repo was on '$CURRENT_BRANCH', switching to main."
+    if ! git checkout main 2>/dev/null; then
+        log "Failed to checkout main in sync repo — manual intervention needed"
+        echo "sync-memory: could not switch to main in $SYNC_DIR — aborting sync."
+        exit 1
+    fi
+fi
+
 # --- Pull latest, detect conflicts ---
 PULL_OUT=$(git pull --rebase 2>&1)
 PULL_RC=$?


### PR DESCRIPTION
## Summary
- After cd'ing into `$HOME/.sutando-memory-sync`, verify current branch is `main`. If not, `git checkout main`. Bail loudly if that fails.
- Self-heal pattern — recovers from accidental branch drift without manual cleanup.

## Why now

Hit this 2026-04-21 pass 874 on Mini: my sync repo was sitting on a stale `fix/startup-sutando-drain-loop` branch (cd-drift artifact from pass 842). For hours, sync-memory.sh kept reporting "Pushed changes" but those pushes were:
1. Going to origin/stale-branch (never existed on GitHub), OR  
2. Being rejected silently after divergence grew.

Meanwhile: shared `origin/main` stopped advancing from Mini, MacBook never saw Mini's writes, concurrent-edit races got worse because "Mini always thinks it pushed."

The fix is structural, not an if-you-remember: branch-assert at the top of every sync run.

## Test plan
- [x] Syntax check (bash -n clean)
- [x] Smoke: run on a fresh main sync repo — no-op, unchanged behavior
- [ ] Smoke: manually `git checkout -b test-drift` in sync repo, run sync, confirm it warns, switches to main, proceeds
- [ ] Smoke: make the sync repo unrecoverable (detached HEAD with uncommitted garbage), confirm the script fails loudly with a message pointing at $SYNC_DIR

## Scope
Single file, 18 lines. No behavior change on happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)