### PR TITLE
fix(startup): skip ANTHROPIC_BASE_URL if credential proxy fails to start

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -103,11 +103,16 @@ if ! lsof -i :7846 > /dev/null 2>&1; then
   echo "  Starting credential proxy (port 7846)..."
   npx tsx ~/.claude/skills/quota-tracker/scripts/credential-proxy.ts > /tmp/credential-proxy.log 2>&1 &
   sleep 1
-  echo "  ✓ credential proxy"
+  if lsof -i :7846 > /dev/null 2>&1; then
+    echo "  ✓ credential proxy"
+    export ANTHROPIC_BASE_URL=http://localhost:7846
+  else
+    echo "  ⚠ credential proxy failed — Claude will connect directly (check /tmp/credential-proxy.log)"
+  fi
 else
   echo "  ✓ credential proxy (already running)"
+  export ANTHROPIC_BASE_URL=http://localhost:7846
 fi
-export ANTHROPIC_BASE_URL=http://localhost:7846
 
 # 1. Voice agent (Gemini Live on port 9900)
 if ! lsof -i :9900 > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Guard `export ANTHROPIC_BASE_URL=http://localhost:7846` behind a port check after the proxy start attempt
- If the credential proxy crashes (e.g. Node v25 `ERR_INVALID_ARG_TYPE` in `path.join()`), port 7846 stays dead and Claude previously got `ConnectionRefused` on every API call
- Now: proxy started → port check → export only if up; if proxy fails, Claude connects directly to Anthropic API

## Root Cause

`credential-proxy.ts` crashes on Node v25.9.0 because `import.meta.dirname` is `undefined` in CJS-mode tsx execution, which `path.join()` rejects. The proxy exits, port 7846 never opens, but `ANTHROPIC_BASE_URL` was exported unconditionally → ConnectionRefused.

## Test plan

- [ ] Start with a broken credential proxy — verify Claude Code starts and connects directly
- [ ] Start with a working credential proxy — verify `ANTHROPIC_BASE_URL` is still set and quota tracking works

— Maddy (MacBook) · fix verified on Lucy (Mac Studio) 2026-04-23