### PR TITLE
fix(web-client): render Tasks header label inside renderTasks()

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -941,8 +941,6 @@ function toggleAllTasks() {
   if (hasExpanded) { expandedTasks.clear(); userCollapsed = true; }
   else { Object.entries(taskMap).forEach(([id, t]) => { if (t.result) expandedTasks.add(id); }); userCollapsed = false; }
   renderTasks();
-  const link = document.querySelector('#tasks-header span:last-child');
-  if (link) link.textContent = hasExpanded ? 'expand all' : 'collapse all';
 }
 document.addEventListener('click', function(e) {
   // Don't toggle if clicking inside the result text (allow text selection)
@@ -996,7 +994,13 @@ function renderTasks() {
   window._drTaskCount = entries.length;
   const hdr = $('tasks-header');
   if (entries.length === 0) { container.innerHTML = ''; if (hdr) hdr.style.display = 'none'; return; }
-  if (hdr) hdr.style.display = 'flex';
+  if (hdr) {
+    const hasExpanded = expandedTasks.size > 0;
+    hdr.style.display = 'flex';
+    hdr.innerHTML = '<span>Tasks</span><span onclick="toggleAllTasks()" style="cursor:pointer">' +
+      (hasExpanded ? 'collapse all' : 'expand all') +
+      '</span>';
+  }
   const sorted = entries.sort((a, b) => b[1].time - a[1].time).slice(0, 8);
   container.innerHTML = sorted.map(([id, t]) => {
     const icons = { pending: '&#8987;', working: '&#9881;', done: '&#10003;', error: '&#10007;' };


### PR DESCRIPTION
## Summary

- `toggleAllTasks()` was mutating `#tasks-header span:last-child.textContent` after calling `renderTasks()`, but `renderTasks()` never wrote the inner markup of that header — so the "expand all / collapse all" label could drift from actual state (stale DOM or `null` selector).
- Move header rendering into `renderTasks()` so it's derived from `expandedTasks.size` on every render. Drop the post-render DOM swap from `toggleAllTasks()`.
- HTML uses string concat instead of a template literal — the whole client HTML is already a backtick template at src/web-client.ts:20, so nested backticks would terminate the outer string (per `feedback_inline_js_escaping.md`).

## How we got here

Mini + Codex converged on this direction across ~25 rounds in #bot2bot today. Diff shape is Mini's; quote form adjusted for the embedded-JS constraint. No behavioral change to the state machine — `expandedTasks` and `userCollapsed` still work the same, just the header label is now derived rather than stored.

## Test plan
- [ ] `npm run typecheck` (passes locally)
- [ ] Open http://localhost:8080, run a task, verify "expand all / collapse all" link updates correctly on every toggle
- [ ] Verify `document.body.dataset.taskAction = 'collapse'/'expand'` (inline-tool path) still works
- [ ] Verify `gui.command: 'collapse_tasks' / 'expand_tasks'` — note: `gui.command collapse_tasks` still calls the undefined `collapseAllTasks()` at :1547, which is a dormant pre-existing bug outside this PR's scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)