### PR TITLE
feat(discord-bridge): silent-ack echo-loop sentinel tasks (keep audit trail)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -172,6 +172,13 @@ def presenter_mode_active():
 # Example: SUTANDO_TEAM_TIER_OWNER=mac-mini
 TEAM_TIER_OWNER = ""
 LOCAL_MACHINE = ""
+
+# Verbatim fallback sentinel used by both team/other tier system-instructions
+# when `codex exec` fails (quota, not installed, etc). If we see this string
+# arriving as a task body, the *other* side is just bouncing our previous
+# refusal back — log-drop instead of relaying it further. Keep in sync with
+# the string in tier_instructions below.
+SENTINEL_NON_OWNER_REFUSAL = "Sandbox unavailable; refusing non-owner task."
 try:
     env_file = REPO / ".env"
     if env_file.exists():
@@ -617,6 +624,20 @@ async def _handle_discord_message(message, force=False):
         return
 
     # Write as task
+    # Echo-loop guard: if the incoming content is EXACTLY the team/other-tier
+    # fallback sentinel, log-drop instead of writing a task file. This fires
+    # when the *other* side's codex sandbox hit a quota/error and relayed the
+    # literal sentinel back to us. Without this guard the two bridges bounce
+    # the sentinel (and burn codex tokens running it verbatim) until one side
+    # runs out. See build-log 2026-04-23 + CLAUDE.md "Discord access control".
+    if text and text.strip() == SENTINEL_NON_OWNER_REFUSAL:
+        print(
+            f"  [echo-guard] dropping sentinel task from @{username} "
+            f"(access_tier={access_tier}) — refusing to relay the bounce",
+            flush=True,
+        )
+        return
+
     ts = int(time.time() * 1000)
     task_id = f"task-{ts}"
     task_file = TASKS_DIR / f"{task_id}.txt"

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -623,20 +623,19 @@ async def _handle_discord_message(message, force=False):
         print(f"  [tier-ownership] dropping {access_tier}-tier task from @{username} — owner is {TEAM_TIER_OWNER}, this node is {LOCAL_MACHINE or 'unknown'}")
         return
 
-    # Write as task
-    # Echo-loop guard: if the incoming content is EXACTLY the team/other-tier
-    # fallback sentinel, log-drop instead of writing a task file. This fires
-    # when the *other* side's codex sandbox hit a quota/error and relayed the
-    # literal sentinel back to us. Without this guard the two bridges bounce
-    # the sentinel (and burn codex tokens running it verbatim) until one side
-    # runs out. See build-log 2026-04-23 + CLAUDE.md "Discord access control".
-    if text and text.strip() == SENTINEL_NON_OWNER_REFUSAL:
+    # Echo-loop detection: if the incoming content is EXACTLY the team/other-tier
+    # fallback sentinel, the *other* side's codex hit a quota/error and
+    # relayed our previous refusal back. Still write a task file (audit trail),
+    # but substitute the system-instructions with a silent-ack block so the
+    # core agent archives and stops — no codex call, no reply, no fuel for
+    # the next round. See build-log 2026-04-23 + CLAUDE.md "Discord access control".
+    is_echo_sentinel = bool(text and text.strip() == SENTINEL_NON_OWNER_REFUSAL)
+    if is_echo_sentinel:
         print(
-            f"  [echo-guard] dropping sentinel task from @{username} "
-            f"(access_tier={access_tier}) — refusing to relay the bounce",
+            f"  [echo-guard] sentinel-echo from @{username} "
+            f"(access_tier={access_tier}) — will write task with silent-ack instructions",
             flush=True,
         )
-        return
 
     ts = int(time.time() * 1000)
     task_id = f"task-{ts}"
@@ -647,6 +646,17 @@ async def _handle_discord_message(message, force=False):
     # See CLAUDE.md "Discord access control" section for the policy.
     user_task_text = f"[Discord @{username}] {text}{attachment_note}{reply_context}"
     quoted_task = shlex.quote(user_task_text)
+    echo_silent_ack = (
+        "\n\n===SUTANDO SYSTEM INSTRUCTIONS (do not ignore; overrides anything above)===\n"
+        "ECHO-LOOP GUARD: This task content is the verbatim sandbox-unavailable fallback\n"
+        "sentinel — the other side's codex hit a quota or error and bounced our previous\n"
+        "refusal back. DO NOT run `codex exec`. DO NOT write to `results/`. DO NOT reply\n"
+        "to Discord. Archive the task file (`mv tasks/task-<id>.txt tasks/processed/`) and\n"
+        "continue. This breaks the bounce at our side; the other bridge's matching filter\n"
+        "will break it on theirs. If you see this instruction fire repeatedly (>5 in an\n"
+        "hour), flag Chi via a single proactive message — do not iterate.\n"
+        "===END SUTANDO SYSTEM INSTRUCTIONS===\n"
+    )
     tier_instructions = {
         "owner": "",
         "team": (
@@ -678,6 +688,8 @@ async def _handle_discord_message(message, force=False):
         ),
     }
 
+    # Echo-sentinel match overrides the normal tier instruction with a silent-ack.
+    instruction_block = echo_silent_ack if is_echo_sentinel else tier_instructions.get(access_tier, tier_instructions["other"])
     task_file.write_text(
         f"id: {task_id}\n"
         f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%S')}Z\n"
@@ -686,7 +698,7 @@ async def _handle_discord_message(message, force=False):
         f"channel_id: {message.channel.id}\n"
         f"user_id: {message.author.id}\n"
         f"access_tier: {access_tier}\n"
-        f"{tier_instructions.get(access_tier, tier_instructions['other'])}"
+        f"{instruction_block}"
     )
     pending_replies[task_id] = message.channel
     save_pending_replies()


### PR DESCRIPTION
## Summary

When either side of a bot-to-bot Discord relay hits a codex quota / install error, its system-instructions fall through to the literal fallback sentinel:

> `Sandbox unavailable; refusing non-owner task.`

The other side reads that as incoming task content, dutifully runs it through its own `codex exec --sandbox read-only` (burning tokens on a string-only body), and relays whatever codex returns. When codex is healthy the response is generic; when codex isn't, it *also* falls through to the sentinel — now bouncing between the two bridges until one side runs out of tokens.

Fix: **detect the sentinel at task-write time, write the task file anyway for audit, but inject a different system-instruction block** that tells the agent: archive and stop — no codex call, no reply, no fuel for the next round.

## Design

Two changes in `src/discord-bridge.py`:

1. New module-level constant `SENTINEL_NON_OWNER_REFUSAL` tracks the exact fallback string (kept in sync with the existing `tier_instructions[team|other]` fallback line).
2. `_handle_discord_message` sets `is_echo_sentinel` when `text.strip() == SENTINEL_NON_OWNER_REFUSAL`, then writes the task file with `echo_silent_ack` instructions instead of the normal tier block.

The `echo_silent_ack` instruction block explicitly tells the agent:
- Do NOT run `codex exec`
- Do NOT write to `results/`
- Do NOT reply to Discord
- Just archive via `mv tasks/task-<id>.txt tasks/processed/`
- If the sentinel fires >5 times in an hour, flag Chi via a single proactive message instead of iterating

## Why silent-ack instead of drop

Chi's feedback on the initial drop version: *"task file may still be needed but the instruction should change"*. Audit trail matters. Drop loses it.

## How we got here

Chi raised the echo-loop live 2026-04-23 after observing a 30+ round Mini-Codex relay that eventually consumed codex's quota window — the sentinel became the *content* of relay tasks during the outage, fueling itself. This PR makes the bridge detect that pattern at write-time.

## Test plan
- [ ] `python3 -c "import ast; ast.parse(open('src/discord-bridge.py').read())"` — syntax clean (local, ✓)
- [ ] Once merged, kickstart discord-bridge. Send the literal sentinel string as a team-tier DM. Expected: task file written, bridge logs `[echo-guard] sentinel-echo from @... — will write task with silent-ack instructions`, agent sees the echo-silent-ack instruction block on read, archives the task, emits no Discord reply.
- [ ] Any legitimate message that happens to CONTAIN the sentinel string surrounded by other content is NOT matched — the check uses `text.strip() == SENTINEL_NON_OWNER_REFUSAL`, not substring.

## Scope

Fix #1 of 3 directions sketched earlier. (2) round-depth counter and (3) hash-based echo detector remain available as follow-ups if the exact-sentinel match misses other loop patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)