### PR TITLE
chore: remove stale sync-memory.sh references (post #511)

### DIFF
--- a/scripts/stage-readiness.sh
+++ b/scripts/stage-readiness.sh
@@ -175,7 +175,7 @@ if [ -f "$SYNC_HEAD" ]; then
     if [ "$age_h" -lt 6 ]; then
         pass "memory-sync" "last sync ${age_h}h ago"
     elif [ "$age_h" -lt 48 ]; then
-        warn "memory-sync" "last sync ${age_h}h ago — run 'bash src/sync-memory.sh'"
+        warn "memory-sync" "last sync ${age_h}h ago — run 'bash ~/.sutando-memory-sync/scripts/sync-memory.sh'"
     else
         fail "memory-sync" "last sync ${age_h}h ago — stale, sync before talk"
     fi

--- a/skills/schedule-crons/crons.example.json
+++ b/skills/schedule-crons/crons.example.json
@@ -22,7 +22,7 @@
   {
     "name": "sync-memory",
     "cron": "*/30 * * * *",
-    "prompt": "Run bash src/sync-memory.sh to sync memory and notes to the private memory repo (requires SUTANDO_MEMORY_REPO in .env)."
+    "prompt": "Run bash ~/.sutando-memory-sync/scripts/sync-memory.sh to sync memory and notes to the private memory repo (requires SUTANDO_MEMORY_REPO in .env)."
   },
   {
     "name": "cross-node-sync",

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -101,7 +101,7 @@ def check_memory_sync() -> dict:
         return {"name": name, "status": "warn", "detail": "SUTANDO_MEMORY_REPO not set — cross-machine sync disabled"}
     sync_dir = Path.home() / ".sutando-memory-sync"
     if not sync_dir.exists():
-        return {"name": name, "status": "warn", "detail": "repo configured but never synced — run bash src/sync-memory.sh"}
+        return {"name": name, "status": "warn", "detail": "repo configured but never synced — run bash ~/.sutando-memory-sync/scripts/sync-memory.sh"}
     git_dir = sync_dir / ".git" / "FETCH_HEAD"
     if git_dir.exists():
         age_h = (time.time() - git_dir.stat().st_mtime) / 3600


### PR DESCRIPTION
## Summary

PR #511 removed `src/sync-memory.sh` from the public repo. Lucy-Studio-Susan identified 3 string references left behind in warning/template text. None are runtime failures (nothing was actually calling the missing file), but they'd confuse anyone reading the warnings or copy-pasting the suggested command post-merge.

- `scripts/stage-readiness.sh:178` — memory-sync 6h-to-48h warn message
- `src/health-check.py:104` — "repo configured but never synced" warn detail
- `skills/schedule-crons/crons.example.json:25` — sync-memory cron template

All 3 updated to `bash ~/.sutando-memory-sync/scripts/sync-memory.sh`, matching the actual script location and the live `crons.json` pattern.

## Test plan

- [ ] `grep -rn 'src/sync-memory.sh' scripts/ src/ skills/` returns nothing (historical mentions in `build_log.md` intentionally preserved)
- [ ] `bash scripts/stage-readiness.sh` — warn message now shows correct path when memory-sync is >6h stale
- [ ] `python3 src/health-check.py` — memory-sync probe still passes; warn detail (if triggered) shows correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)