### PR TITLE
fix(voice-agent): add language switch to direct-answer whitelist

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -446,6 +446,7 @@ const mainAgent: MainAgent = {
 		'- Self-introduction ("who are you", "introduce yourself", "what can you do") — use the context above',
 		'- Yes/no acknowledgments',
 		'- Asking the user a clarifying question',
+		'- Language/conversation mode questions ("can you speak Chinese?", "说中文", "switch to English", "speak French") — just say yes and switch, no need to delegate',
 		'- get_current_time (current date/time)',
 		'- Google Search (quick factual lookups)',
 		`- ${inlineTools.map(t => t.name).join(', ')} — call these directly, not through work. Instant.`,


### PR DESCRIPTION
## Summary
- Voice agent was delegating language/conversation mode questions (e.g. `can you speak Chinese`) to the task bridge via `work` tool instead of answering inline
- Added language/conversation mode questions to the `ONLY answer directly` whitelist in `mainAgent.instructions`
- One line change in `src/voice-agent.ts`

## Root cause
`DEFAULT BEHAVIOR: Call work for almost everything` — language switch questions didn't match any whitelist item, so Gemini delegated them

## Test
Verified locally: restarted voice agent, Chinese language questions answered directly without task delegation

🤖 — Maddy-MBP-susanliubot