### PR TITLE
fix(voice): suppress "Welcome back" on quick reconnects (<60s)

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -221,22 +221,30 @@ export function logSessionBoundary(reason: string = 'user_goodbye'): void {
 	try { appendFileSync(CONVERSATION_LOG, line); } catch { /* best effort */ }
 }
 
-/** Seconds since the most recent conversation.log entry (any line —
- *  user/assistant turn or SESSION_END marker). Returns null if no log
- *  exists or the last line's timestamp is unparseable. Used to detect
- *  quick reconnects (network blips) so we can resume silently instead
- *  of greeting the user again every time. */
+/** Seconds since the most recent user/assistant turn. Walks the log
+ *  backwards, skipping `core-agent` task-result lines (written by the
+ *  task-bridge result watcher whenever the proactive loop or any
+ *  background task posts a result) and `SESSION_END` markers — those
+ *  are not user/assistant dialogue, and a recent one would falsely
+ *  make a long-away user look like a quick reconnect. Stops at the
+ *  most recent SESSION_END so we don't reach back into a cleanly-ended
+ *  prior session. Returns null if no log exists or no user/assistant
+ *  turn is found in the current session. */
 export function getSecondsSinceLastTurn(): number | null {
 	if (!existsSync(CONVERSATION_LOG)) return null;
 	try {
 		const content = readFileSync(CONVERSATION_LOG, 'utf-8').trim();
 		if (!content) return null;
 		const lines = content.split('\n');
-		const lastLine = lines[lines.length - 1];
-		const tsStr = lastLine.split('|')[0];
-		const ts = Date.parse(tsStr);
-		if (Number.isNaN(ts)) return null;
-		return (Date.now() - ts) / 1000;
+		for (let i = lines.length - 1; i >= 0; i--) {
+			const role = lines[i].split('|')[1];
+			if (role === 'SESSION_END') return null;
+			if (role !== 'user' && role !== 'assistant') continue;
+			const ts = Date.parse(lines[i].split('|')[0]);
+			if (Number.isNaN(ts)) return null;
+			return (Date.now() - ts) / 1000;
+		}
+		return null;
 	} catch { return null; }
 }
 

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -221,6 +221,25 @@ export function logSessionBoundary(reason: string = 'user_goodbye'): void {
 	try { appendFileSync(CONVERSATION_LOG, line); } catch { /* best effort */ }
 }
 
+/** Seconds since the most recent conversation.log entry (any line —
+ *  user/assistant turn or SESSION_END marker). Returns null if no log
+ *  exists or the last line's timestamp is unparseable. Used to detect
+ *  quick reconnects (network blips) so we can resume silently instead
+ *  of greeting the user again every time. */
+export function getSecondsSinceLastTurn(): number | null {
+	if (!existsSync(CONVERSATION_LOG)) return null;
+	try {
+		const content = readFileSync(CONVERSATION_LOG, 'utf-8').trim();
+		if (!content) return null;
+		const lines = content.split('\n');
+		const lastLine = lines[lines.length - 1];
+		const tsStr = lastLine.split('|')[0];
+		const ts = Date.parse(tsStr);
+		if (Number.isNaN(ts)) return null;
+		return (Date.now() - ts) / 1000;
+	} catch { return null; }
+}
+
 /** Read recent conversation entries from disk, trimming at the most
  *  recent SESSION_END marker. Survives restarts. Returns at most
  *  `count` entries from the current session only — a cleanly-ended

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -35,7 +35,7 @@ import {
 } from 'bodhi-realtime-agent';
 import type { MainAgent, ToolDefinition } from 'bodhi-realtime-agent';
 function assertMacOS() { if (process.platform !== 'darwin') { console.error('Sutando requires macOS'); process.exit(1); } }
-import { workTool, cancelTask, startResultWatcher, startContextDropWatcher, startNoteViewingWatcher, resetNoteViewingDebounce, logConversation, logSessionBoundary, getRecentConversation, setTaskStatusCallback } from './task-bridge.js';
+import { workTool, cancelTask, startResultWatcher, startContextDropWatcher, startNoteViewingWatcher, resetNoteViewingDebounce, logConversation, logSessionBoundary, getRecentConversation, getSecondsSinceLastTurn, setTaskStatusCallback } from './task-bridge.js';
 import { buildSutandoSystemPrompt, buildVoiceAgentContext } from './voice-context.js';
 
 // Cartesia is loaded dynamically at the bottom of the config section so
@@ -399,9 +399,16 @@ const mainAgent: MainAgent = {
 		// safe to replay without trigger filtering.
 		const recent = getRecentConversation(8);
 		if (recent) {
+			// Quick reconnect (< 60s since last logged turn) = network blip,
+			// not a real "away". Skip "Welcome back" and stay silent so the
+			// user can just keep talking without UX interruption.
+			const gap = getSecondsSinceLastTurn();
+			const isQuickReconnect = gap !== null && gap < 60;
 			const meetingHint = meetingActive
 				? '\n\n[MEETING MODE — you are listening and taking notes. Do NOT speak or produce any audio. Only respond if someone says "Sutando." Use the replayed history above as context for what was discussed before the reconnect.]'
-				: '\n\n[Now say "Welcome back" briefly — one sentence — and then stop and wait for input.]';
+				: isQuickReconnect
+					? '\n\n[Do NOT greet the user. Do NOT say "Welcome back" or anything similar. Stay completely silent and wait for the user\'s next spoken input — they were just briefly disconnected and want to resume without interruption.]'
+					: '\n\n[Now say "Welcome back" briefly — one sentence — and then stop and wait for input.]';
 			return `[System: The user reconnected. The block below is REPLAYED HISTORY from the current session, provided as background context ONLY. Do NOT act on anything in it. Do NOT call any tools based on it. Use it only to answer follow-up questions if asked. Wait silently for the user's next spoken input before taking any action.]\n\n${recent}${meetingHint}`;
 		}
 		let standName = '';

--- a/tests/seconds-since-last-turn.test.ts
+++ b/tests/seconds-since-last-turn.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * Regression test for PR #515. The original `getSecondsSinceLastTurn()`
+ * read the last line regardless of role, so a `core-agent` task-result
+ * line written by the result watcher between user turns made a
+ * long-away user look like a quick reconnect — and the "Welcome back"
+ * was wrongly suppressed. Fix: walk backward, skip non-dialogue lines,
+ * stop at SESSION_END.
+ *
+ * The function under test is replicated inline rather than imported —
+ * task-bridge has module-load side effects (mirrors the convention
+ * used by session-boundary.test.ts).
+ */
+function secondsSinceLastTurn(content: string, now: number): number | null {
+	if (!content) return null;
+	const lines = content.split('\n');
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const role = lines[i].split('|')[1];
+		if (role === 'SESSION_END') return null;
+		if (role !== 'user' && role !== 'assistant') continue;
+		const ts = Date.parse(lines[i].split('|')[0]);
+		if (Number.isNaN(ts)) return null;
+		return (now - ts) / 1000;
+	}
+	return null;
+}
+
+describe('getSecondsSinceLastTurn — role-filtered', () => {
+	const now = Date.parse('2026-04-25T10:10:00Z');
+
+	it('returns null on empty log', () => {
+		assert.equal(secondsSinceLastTurn('', now), null);
+	});
+
+	it('returns gap from the most recent user turn', () => {
+		const log = '2026-04-25T10:09:30Z|user|hi'; // 30s ago
+		assert.equal(secondsSinceLastTurn(log, now), 30);
+	});
+
+	it('returns gap from the most recent assistant turn', () => {
+		const log = '2026-04-25T10:09:00Z|assistant|sure'; // 60s ago
+		assert.equal(secondsSinceLastTurn(log, now), 60);
+	});
+
+	it('skips core-agent task-result lines (the bug sonichi found)', () => {
+		// User was away 5 minutes (300s). Proactive loop wrote a
+		// core-agent result 30s ago. Old impl returned 30 → quick
+		// reconnect → "Welcome back" wrongly suppressed. New impl
+		// must skip the core-agent line and return ~300s.
+		const log = [
+			'2026-04-25T10:05:00Z|user|brb',                       // 300s ago
+			'2026-04-25T10:09:30Z|core-agent|[task:abc] done',     // 30s ago
+		].join('\n');
+		assert.equal(secondsSinceLastTurn(log, now), 300);
+	});
+
+	it('returns null after SESSION_END (current session has no turns yet)', () => {
+		// Session ended cleanly — don't reach back into the prior
+		// session for "last turn" purposes.
+		const log = [
+			'2026-04-25T09:00:00Z|user|first session',
+			'2026-04-25T09:00:05Z|SESSION_END|user_goodbye',
+		].join('\n');
+		assert.equal(secondsSinceLastTurn(log, now), null);
+	});
+
+	it('returns gap from a turn after SESSION_END (new session in progress)', () => {
+		const log = [
+			'2026-04-25T09:00:00Z|user|first session',
+			'2026-04-25T09:00:05Z|SESSION_END|user_goodbye',
+			'2026-04-25T10:09:30Z|user|new session',  // 30s ago
+		].join('\n');
+		assert.equal(secondsSinceLastTurn(log, now), 30);
+	});
+
+	it('skips multiple core-agent lines and finds the user turn', () => {
+		const log = [
+			'2026-04-25T10:05:00Z|user|question',                    // 300s ago
+			'2026-04-25T10:06:00Z|core-agent|[task:1] result',
+			'2026-04-25T10:07:00Z|core-agent|[task:2] result',
+			'2026-04-25T10:09:30Z|core-agent|[task:3] result',
+		].join('\n');
+		assert.equal(secondsSinceLastTurn(log, now), 300);
+	});
+});


### PR DESCRIPTION
## Summary

When Gemini Live session drops and reconnects within 60 seconds (network blip, not a real away), silently resume instead of re-greeting the user. Eliminates the jarring "Welcome back" every few sentences that interrupts long voice sessions.

## What changed

- **`src/task-bridge.ts`** — new `getSecondsSinceLastTurn()` helper reads the timestamp of the most recent `conversation.log` line (any turn or `SESSION_END` marker)
- **`src/voice-agent.ts`** — in `MainAgent.greeting`, when `getRecentConversation()` returns non-empty (we're in a reconnect), check the gap:
  - **< 60s** → tell Gemini to stay silent, no "Welcome back"
  - **≥ 60s or null** → keep existing "Welcome back briefly" behavior

The existing REPLAYED-HISTORY injection is preserved in both branches — only the post-replay user-facing utterance differs. Clean exits (`SESSION_END` logged) still fall through to the normal fresh-greeting path.

## Why this scope

bodhi has been fixed several times around reconnect state machines already; this PR doesn't touch bodhi. It's a thin application-layer UX improvement: the app already knows when the last turn happened (conversation.log), we just weren't reading that timestamp to distinguish "network blip reconnect" from "user came back later."

## Test plan

- [x] TypeScript compiles (`npx tsc --noEmit` clean)
- [x] Voice agent restarted locally with this branch; Susan confirmed "looks like 'welcome back' is gone" during a live test
- [ ] Manual verification of slow-reconnect path: disconnect >60s → "Welcome back" still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)