### PR TITLE
fix(startup): auto-attach to running sutando-core in interactive shells

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -303,8 +303,17 @@ open "http://localhost:8080"
 # Check if a sutando-core session is already running
 if pgrep -f "claude.*--name.*sutando-core" > /dev/null 2>&1; then
   echo "Claude Code (sutando-core) is already running."
+  # Auto-attach when invoked from an interactive terminal — saves the user
+  # the copy-paste of the long `tmux -S /tmp/sutando-tmux.sock attach -t
+  # sutando-core` command. Falls back to printing the instruction in
+  # non-interactive contexts (launchd, cron, CI) where exec'ing into an
+  # attach would hang without a tty.
+  if [ -t 1 ] && command -v tmux > /dev/null 2>&1; then
+    echo "Attaching... (Ctrl-b d to detach)"
+    exec tmux -S /tmp/sutando-tmux.sock attach -t sutando-core
+  fi
   echo "To restart: kill it first, then re-run this script."
-  echo "To attach to the running session: tmux attach -t sutando-core"
+  echo "To attach to the running session: tmux -S /tmp/sutando-tmux.sock attach -t sutando-core"
   echo ""
 else
   echo "Starting Claude Code (sutando-core) inside tmux..."


### PR DESCRIPTION
## Summary

Two friction-fixes in `src/startup.sh` for the "Claude Code (sutando-core) is already running" path:

1. **Wrong attach command in printed instruction.** The session is launched on `/tmp/sutando-tmux.sock` (custom socket — needed so `Sutando.app`'s watcher-auto-restart can reach the same tmux server across the macOS sandbox), but startup.sh told the user to run `tmux attach -t sutando-core` (default socket). That always returns *no sessions* / *no server running* and looks like sutando-core is somehow running outside tmux. Updated to print `tmux -S /tmp/sutando-tmux.sock attach -t sutando-core`.

2. **Auto-attach when interactive.** `bash src/startup.sh` from a terminal now `exec`s into the attach automatically — user lands inside the live session, no copy-paste. Gated on `[ -t 1 ] && command -v tmux` so launchd / cron / CI callers (no tty) fall through to the print path instead of hanging.

## Why now

Chi tried `tmux attach -t sutando-core` exactly as the script said, hit "no sessions", and lost ~5 minutes diagnosing what looked like an inconsistent state. The misleading instruction was the bug; the auto-attach is the UX win that keeps the next user from hitting the same wall.

## Test plan

- [x] `bash -n src/startup.sh` syntax clean
- [ ] Manual: with sutando-core running, `bash src/startup.sh` from a terminal → auto-attaches
- [ ] Manual: with no tty (e.g. `bash src/startup.sh < /dev/null`) → prints the instruction, doesn't hang
- [ ] Manual: with sutando-core running and tmux uninstalled (uncommon edge) → prints the instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)