### PR TITLE
feat(mode-indicator): always-visible 3-mode text (active/meeting/presenter)

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -38,6 +38,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var currentAgentState: String = "idle"
     var animationTimer: Timer?
     var animationPhase: CGFloat = 1.0
+    // Cached mode from /sse-status (one of "active" / "meeting" / "presenter").
+    // Updated every pollMuteState tick. Drives the always-visible mode label
+    // shown alongside the avatar in the menu bar so Chi can tell at a glance
+    // whether Sutando is in normal (active), silent-note-taker (meeting), or
+    // live-co-presenter (presenter) mode without opening the menu or web UI.
+    var currentMode: String = "active"
 
     /// Fixed tmux socket path for the sutando-core session. The shell
     /// (via startup.sh -S flag) and the app (launched by macOS with a
@@ -382,29 +388,44 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // `label` added 2026-04-18 per Chi's "running a tool is not precise":
             // optional specific tool name or core-status step.
             let label = (json["label"] as? String) ?? ""
+            // `mode` added 2026-04-24 — three-mode indicator
+            // (active/meeting/presenter). Always visible alongside avatar
+            // so Chi can tell at a glance which mode Sutando is in. Default
+            // 'active' on pre-mode-field servers; web-client builds the
+            // unified mode from voice-agent's meeting flag + iclr-highlight's
+            // presenter flag.
+            let mode = (json["mode"] as? String) ?? "active"
             DispatchQueue.main.async {
                 guard let self = self, let button = self.statusItem.button else { return }
+                self.currentMode = mode
+                let modeLabel: String = {
+                    switch mode {
+                    case "presenter": return "PRESENTER"
+                    case "meeting":   return "MEETING"
+                    default:          return "ACTIVE"
+                    }
+                }()
                 if isVoiceConnected && isMuted {
-                    // Voice active + muted: show mute indicator; stop any animation.
-                    // Reset cache so un-mute re-triggers animation if agent is
-                    // still non-idle (otherwise the transition guard below would
-                    // skip startAnimation() and leave the menu bar statically
+                    // Voice active + muted: show mute indicator + mode; stop animation.
+                    // Reset agent-state cache so un-mute re-triggers animation if
+                    // agent is still non-idle (otherwise the transition guard below
+                    // would skip startAnimation() and leave the menu bar statically
                     // dim until the NEXT semantic state change).
-                    button.title = "🔇"
+                    button.title = "🔇 \(modeLabel)"
                     button.image = nil
-                    button.toolTip = "Sutando — muted"
+                    button.toolTip = "Sutando — muted (\(mode))"
                     self.stopAnimation()
                     self.currentAgentState = "idle"
                 } else {
-                    // Default state (disconnected or unmuted): show avatar
+                    // Default state (disconnected or unmuted): show avatar + mode label
                     let avatarPath = self.workspace + "/assets/stand-avatar.png"
                     if let image = NSImage(contentsOfFile: avatarPath) {
                         image.size = NSSize(width: 18, height: 18)
                         image.isTemplate = false
                         button.image = image
-                        button.title = ""
+                        button.title = " \(modeLabel)"
                     } else {
-                        button.title = "S"
+                        button.title = "S \(modeLabel)"
                     }
                     button.toolTip = self.tooltipFor(state: agentState, muted: isMuted, voiceConnected: isVoiceConnected, label: label)
                     // When voice is disconnected, only tool-track states

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -216,6 +216,15 @@ const switchModeTool: ToolDefinition = {
 		const { mode } = args as { mode: 'active' | 'meeting' };
 		meetingActive = mode === 'meeting';
 		console.log(`${ts()} [Meeting] Mode switched to: ${mode}`);
+		// Persist for cross-process reads — web-client builds the unified
+		// `mode` field for /sse-status from this sentinel + iclr-highlight's
+		// presenter sentinel. voice-agent has no HTTP server, so a flag
+		// file is the cheapest cross-process channel.
+		try {
+			writeFileSync(join(WORKSPACE_DIR, 'state', 'meeting-mode.flag'), mode);
+		} catch (err) {
+			console.warn(`${ts()} [Meeting] flag write failed: ${err instanceof Error ? err.message : err}`);
+		}
 		if (mode === 'meeting') {
 			return { status: 'meeting_mode', instruction: 'You are now in meeting mode. Listen and track the discussion internally. Produce ZERO audio output unless someone says "Sutando." The ONLY tool you may call unprompted is save_meeting_note — call it every 5-10 minutes to capture key decisions, action items, and discussion points. When you exit meeting mode, call save_meeting_note with type "summary" for a final recap. Do not call work or any other tools unless explicitly addressed.' };
 		}

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -222,6 +222,10 @@ const HTML = /* html */ `<!DOCTYPE html>
     width: 6px; height: 6px; border-radius: 50%; background: #333;
   }
   .status-pill.voice-on .dot { background: #4ecca3; box-shadow: 0 0 4px #4ecca3; }
+  /* Mode pill — three states. ACTIVE is muted (default), MEETING is amber, PRESENTER is purple. Always visible per "regardless of mode" spec. */
+  .status-pill.mode-active    { background: #1a1a2e; color: #888; }
+  .status-pill.mode-meeting   { background: #2e251a; color: #f0a040; }
+  .status-pill.mode-presenter { background: #2a1a3e; color: #b8a0ff; box-shadow: 0 0 6px rgba(184,160,255,0.3); }
   .header .controls { display: flex; gap: 6px; }
   button {
     padding: 7px 14px; border-radius: 8px; border: none;
@@ -550,6 +554,7 @@ const HTML = /* html */ `<!DOCTYPE html>
     <h1 id="stand-name">Sutando</h1>
     <div class="meta">
       <span class="status-pill voice-off" id="voice-status"><span class="dot" id="dot"></span> <span id="status">Text only</span></span>
+      <span class="status-pill mode-active" id="mode-pill" title="Sutando mode (active / meeting / presenter)">MODE: <span id="mode-text">ACTIVE</span></span>
       <a href="http://localhost:7844" target="_blank">Dashboard</a>
       <span class="stats" id="stats"></span>
     </div>
@@ -2459,6 +2464,29 @@ document.addEventListener('keydown', function(e) {
   }, 2000);
 })();
 
+// Mode pill poll — hits /sse-status for the unified mode field
+// (active / meeting / presenter). Always-visible per spec. Updates the
+// pill class + text on every tick. 1.5s cadence — server-side cache is
+// 800ms so this is sub-second-stale at worst.
+// (No backticks in this comment — they would close the parent HTML
+// template literal that wraps this entire script block.)
+(function() {
+  setInterval(function() {
+    fetch('/sse-status')
+      .then(function(r) { return r.ok ? r.json() : null; })
+      .then(function(data) {
+        var pill = document.getElementById('mode-pill');
+        var text = document.getElementById('mode-text');
+        if (!pill || !text) return;
+        var mode = (data && data.mode) || 'active';
+        text.textContent = mode.toUpperCase();
+        pill.classList.remove('mode-active', 'mode-meeting', 'mode-presenter');
+        pill.classList.add('mode-' + mode);
+      })
+      .catch(function() {});
+  }, 1500);
+})();
+
 // Initial render
 updateDynamicRegion();
 
@@ -2539,6 +2567,36 @@ function readCoreStatus(): { running: boolean; step: string; stale: boolean } {
 	}
 }
 function coreIsRunning(): boolean { return readCoreStatus().running; }
+
+// Resolve the unified app mode from two cross-process signals:
+//   - state/meeting-mode.flag (written by voice-agent's switch_mode tool)
+//   - :7877/presenter (iclr-highlight server's presenter-mode flag)
+// Priority: presenter > meeting > active. The presenter half is fetched
+// asynchronously by a 1s background refresher; the meeting half is read
+// synchronously from disk. /sse-status reads the cached presenter result
+// + the live meeting-flag and returns the resolved mode without blocking.
+type AppMode = 'active' | 'meeting' | 'presenter';
+let _presenterActive = false;
+function readModeSync(): AppMode {
+	let meeting = false;
+	try {
+		const flag = readFileSync(new URL('../state/meeting-mode.flag', import.meta.url), 'utf-8').trim();
+		meeting = flag === 'meeting';
+	} catch { /* sentinel absent → meeting off (default) */ }
+	return _presenterActive ? 'presenter' : meeting ? 'meeting' : 'active';
+}
+function refreshPresenterCache(): void {
+	fetch('http://localhost:7877/presenter', { signal: AbortSignal.timeout(800) })
+		.then((r) => (r.ok ? r.json() : null))
+		.then((data) => {
+			_presenterActive = !!(data && (data as { active?: boolean }).active);
+		})
+		.catch(() => { /* presenter server down → leave cache as-is */ });
+}
+// Initial fetch + 1s refresh loop. Skipped only if web-client is run
+// outside an event loop context (it always has one in production).
+refreshPresenterCache();
+setInterval(refreshPresenterCache, 1000);
 
 const VOICE_STATE_STALE_SECONDS = 120;
 function readVoiceState(): boolean | null {
@@ -2657,6 +2715,7 @@ const server = createServer((req, res) => {
 		// if the file is missing or stale (see readVoiceState doc).
 		const vs = readVoiceState();
 		const voiceConnected = vs !== null ? vs : _voiceState;
+		const mode = readModeSync();
 		res.writeHead(200, { 'Content-Type': 'application/json' });
 		res.end(JSON.stringify({
 			clients: sseClients.length,
@@ -2664,6 +2723,7 @@ const server = createServer((req, res) => {
 			voiceConnected,
 			state: eff,
 			label,
+			mode,
 		}));
 		return;
 	}


### PR DESCRIPTION
## Summary

Always-visible 3-mode text indicator in both the Sutando.app menu bar and the web UI. Rebuilt from scratch after the prior implementation was lost (uncommitted edits overwritten by today's `startup.sh` rerun — exhaustive search of git/stash/dangling/binary `strings` confirmed unrecoverable).

Three modes:

| mode | trigger | menu-bar title | web-pill style |
|---|---|---|---|
| `active` | default | `[avatar] ACTIVE` | dim (default) |
| `meeting` | `switch_mode("meeting")` | `[avatar] MEETING` | amber |
| `presenter` | `presenter_mode("on")` | `[avatar] PRESENTER` | purple-glow |

Priority: presenter > meeting > active.

## Wiring

- **`src/voice-agent.ts`** — `switchModeTool.execute` now writes `state/meeting-mode.flag` ("active" or "meeting"). Cross-process exposure since voice-agent has no HTTP server.
- **`src/web-client.ts`** — adds `mode` field to `/sse-status`. Resolved synchronously: read `state/meeting-mode.flag` from disk + check a cached `_presenterActive` boolean refreshed every 1s in the background from `:7877/presenter`. Non-blocking; silent-fail when iclr-highlight server is down.
- **`src/Sutando/main.swift`** — parses `mode` from `/sse-status`, sets `statusItem.button.title` to ` ACTIVE` / ` MEETING` / ` PRESENTER`. Also includes mode in muted state ("🔇 PRESENTER") so the indicator survives a voice mute.
- **HTML/JS in `src/web-client.ts`** — `<span id="mode-pill">` next to voice-status. CSS for 3 variants. 1.5s poll updates class + text.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Manual: default state → menu bar shows `ACTIVE`, web pill dim
- [ ] Manual: voice trigger `switch_mode("meeting")` → flag file written → menu bar `MEETING`, web pill amber within 1.5s
- [ ] Manual: `bash scripts/presenter-mode.sh on` → menu bar `PRESENTER`, web pill purple-glow within 2.5s (1s presenter cache + 1.5s poll)
- [ ] Manual: presenter takes priority over meeting (both flags set → mode reports "presenter")
- [ ] Manual: muted state shows `🔇 ACTIVE` / `🔇 MEETING` / `🔇 PRESENTER`

## Notes

- Sutando.app rebuild required after merge — `startup.sh` auto-recompiles when `main.swift` is newer than the binary (per #459 logic).
- Voice-agent kickstart picks up the new `switchModeTool.execute` write path on next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)