### PR TITLE
fix(fullscreen): route keystroke through Chrome process during Zoom share

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -487,8 +487,14 @@ tell application "Google Chrome"
 	end repeat
 end tell
 delay 0.3
+-- Target Chrome process directly. When Zoom is screen-sharing, Zoom's
+-- floating control bar steals global keystroke focus, so a plain
+-- keystroke f to System Events lands in Zoom instead of Chrome.
+-- Routing through tell process Google Chrome bypasses the focus race.
 tell application "System Events"
-	keystroke "f"
+	tell process "Google Chrome"
+		keystroke "f"
+	end tell
 end tell'`, { timeout: 5_000 });
 			console.log(`${ts()} [Fullscreen] Toggled`);
 			return { status: 'toggled' };


### PR DESCRIPTION
## Summary
- The `fullscreen` inline tool sends a plain `keystroke "f"` to System Events. Zoom's floating control bar grabs global keystroke focus during screen-share and intercepts it before Chrome sees it — slide deck's F → requestFullscreen() never fires.
- Mirror the fix already in `skills/personal-iclr-highlight/tools.ts`: route through `tell process "Google Chrome"`.
- Two tools shared this bug. The model preferred `fullscreen` over `fullscreen_presenter`, so the patched skill tool never ran.

## Test plan
- [x] TS clean
- [ ] Voice "fullscreen" with Zoom mid-share → slide deck enters fullscreen
- [ ] Voice "fullscreen" without Zoom → still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)