### PR TITLE
fix(fullscreen): route keystroke to frontmost process, not hardcoded Chrome

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -487,12 +487,16 @@ tell application "Google Chrome"
 	end repeat
 end tell
 delay 0.3
--- Target Chrome process directly. When Zoom is screen-sharing, Zoom's
--- floating control bar steals global keystroke focus, so a plain
--- keystroke f to System Events lands in Zoom instead of Chrome.
--- Routing through tell process Google Chrome bypasses the focus race.
+-- Target the frontmost process directly. When Zoom is screen-sharing,
+-- Zoom's floating control bar steals global keystroke focus, so a plain
+-- keystroke f to System Events lands in Zoom instead of the foreground
+-- app. Routing through tell process <frontmost> bypasses the focus race
+-- while keeping this tool generic — if Chrome was activated above (slide
+-- tab found) frontmost is Chrome, otherwise keystroke goes to whatever
+-- the user actually has up.
 tell application "System Events"
-	tell process "Google Chrome"
+	set frontApp to name of first application process whose frontmost is true
+	tell process frontApp
 		keystroke "f"
 	end tell
 end tell'`, { timeout: 5_000 });


### PR DESCRIPTION
## Summary
- PR #521 hardcoded `tell process "Google Chrome"`, but this tool is generic — its description doesn't promise Chrome.
- Detect the frontmost process inside System Events and target it. If the Chrome-slide-tab activation block above ran, frontmost is Chrome (unchanged). Otherwise the keystroke goes to whatever the user actually has up.
- Still survives Zoom screen-share — process-level routing bypasses Zoom's focus grab.

## Test plan
- [x] TS clean
- [ ] Voice "fullscreen" with Chrome+slide deck → slides go fullscreen
- [ ] Voice "fullscreen" with another foreground app (e.g. Safari, Preview) → that app fullscreens

🤖 Generated with [Claude Code](https://claude.com/claude-code)