### PR TITLE
fix(pause/resume): use freshest transcript (voice or phone), not stale symlink

### DIFF
--- a/src/recording-tools.ts
+++ b/src/recording-tools.ts
@@ -89,8 +89,37 @@ export function isRecordingMuted(): boolean {
 // Symlink points to the active call's transcript (phone or voice agent)
 const LIVE_TRANSCRIPT_SYMLINK = '/tmp/sutando-live-transcript.txt';
 const LIVE_TRANSCRIPT_SRT_PATH = '/tmp/sutando-live-transcript-subtitle.srt';
+const VOICE_TRANSCRIPT_PATH = '/tmp/sutando-live-transcript-voice.txt';
 let liveTranscriptRecordingStart = 0;
 let liveTranscriptBaselineLines = 0;
+
+// Pick the freshest user-speech transcript (voice-agent or phone) and return
+// the last few user-spoken lines as lowercase. Returns '' if neither is
+// reasonably fresh (≥60s old) so callers fail-open rather than blocking on
+// stale data — e.g. a phone-call symlink left over from hours ago when the
+// current session is voice-agent.
+function getRecentUserSpeech(): string {
+	const candidates: string[] = [];
+	if (existsSync(VOICE_TRANSCRIPT_PATH)) candidates.push(VOICE_TRANSCRIPT_PATH);
+	try {
+		const phonePath = readlinkSync(LIVE_TRANSCRIPT_SYMLINK);
+		if (existsSync(phonePath)) candidates.push(phonePath);
+	} catch {}
+	let bestPath = '';
+	let bestMtime = 0;
+	for (const p of candidates) {
+		try {
+			const m = statSync(p).mtimeMs;
+			if (m > bestMtime) { bestMtime = m; bestPath = p; }
+		} catch {}
+	}
+	if (!bestPath || Date.now() - bestMtime > 60_000) return '';
+	try {
+		const lines = readFileSync(bestPath, 'utf8').split('\n');
+		const userLines = lines.filter(l => /\b(Caller|User):/i.test(l));
+		return userLines.slice(-3).join(' ').toLowerCase();
+	} catch { return ''; }
+}
 // Resolved path to the call-specific transcript file, captured at recording start.
 // A concurrent call (e.g. Zoom join) can overwrite the symlink, so we resolve it
 // once and use the resolved path for the entire recording lifecycle.
@@ -629,17 +658,13 @@ export const resumeVideoTool: ToolDefinition = {
 	execution: 'inline',
 	async execute() {
 		console.log(`${ts()} [ResumeVideo] called`);
-		// Only resume if caller said "resume"/"continue"/"go on"/"play" in recent transcript
-		try {
-			const transcriptPath = readlinkSync('/tmp/sutando-live-transcript.txt');
-			const lines = readFileSync(transcriptPath, 'utf8').split('\n');
-			const callerLines = lines.filter(l => l.includes('Caller:'));
-			const recent = callerLines.slice(-3).join(' ').toLowerCase();
-			if (!/\b(resume|continue|go on|play it|play the)\b/.test(recent)) {
-				console.log(`${ts()} [ResumeVideo] BLOCKED — no resume keyword in recent caller speech: "${recent.slice(-80)}"`);
-				return { status: 'paused', instruction: 'Video is still paused. Only resume when user explicitly says "resume" or "play".' };
-			}
-		} catch {}
+		// Only resume if user said "resume"/"continue"/"go on"/"play" in recent transcript.
+		// Picks freshest of voice-agent vs phone transcript; fail-open if neither is fresh.
+		const recent = getRecentUserSpeech();
+		if (recent && !/\b(resume|continue|go on|play it|play the)\b/.test(recent)) {
+			console.log(`${ts()} [ResumeVideo] BLOCKED — no resume keyword in recent user speech: "${recent.slice(-80)}"`);
+			return { status: 'paused', instruction: 'Video is still paused. Only resume when user explicitly says "resume" or "play".' };
+		}
 		try {
 			try { unlinkSync('/tmp/sutando-playback-pause'); } catch {}
 			lastResumeTime = Date.now();
@@ -690,19 +715,15 @@ export const pauseVideoTool: ToolDefinition = {
 			console.log(`${ts()} [PauseVideo] BLOCKED — ${sinceLast}ms since play/resume (cooldown 8s)`);
 			return { status: 'playing', instruction: 'Video is still playing. Do NOT pause unless user explicitly says "pause" or "stop".' };
 		}
-		// Mirror resume_video's runtime guard: only pause if the caller actually
+		// Mirror resume_video's runtime guard: only pause if the user actually
 		// said a pause keyword recently. Without this, a Gemini hallucination
 		// outside the 8s cooldown still fires (Susan's 2026-04-16 report).
-		try {
-			const transcriptPath = readlinkSync('/tmp/sutando-live-transcript.txt');
-			const lines = readFileSync(transcriptPath, 'utf8').split('\n');
-			const callerLines = lines.filter(l => l.includes('Caller:'));
-			const recent = callerLines.slice(-3).join(' ').toLowerCase();
-			if (!/\b(pause|stop|hold|wait)\b/.test(recent)) {
-				console.log(`${ts()} [PauseVideo] BLOCKED — no pause keyword in recent caller speech: "${recent.slice(-80)}"`);
-				return { status: 'playing', instruction: 'Video is still playing. Only pause when user explicitly says "pause" or "stop".' };
-			}
-		} catch {}
+		// Picks freshest of voice-agent vs phone transcript; fail-open if neither is fresh.
+		const recent = getRecentUserSpeech();
+		if (recent && !/\b(pause|stop|hold|wait)\b/.test(recent)) {
+			console.log(`${ts()} [PauseVideo] BLOCKED — no pause keyword in recent user speech: "${recent.slice(-80)}"`);
+			return { status: 'playing', instruction: 'Video is still playing. Only pause when user explicitly says "pause" or "stop".' };
+		}
 		try { writeFileSync('/tmp/sutando-playback-pause', '1'); } catch {}
 		try { execSync(`osascript -e 'tell application "QuickTime Player"' -e 'if (count of documents) > 0 then' -e 'pause document 1' -e 'end if' -e 'end tell'`, { timeout: 5_000 }); } catch {}
 		return { status: 'paused', instruction: 'Paused. When user says play/resume, call play_video.' };


### PR DESCRIPTION
## Summary
- `pause_video` / `resume_video` guards read `/tmp/sutando-live-transcript.txt`, a symlink that phone-conversation writes on call start and never clears on call end.
- In voice-agent sessions the symlink points to the last phone call's transcript (often hours old), guard filters for `Caller:` lines from a stale phone session, blocks every pause.

Symptom from voice-agent.log:
```
[PauseVideo] BLOCKED — no pause keyword in recent caller speech:
"[07:40:37] caller: dismiss [07:40:44] caller: hi. [07:40:48] caller: bye."
```
That phone session ended ~14h before the talk-day pause attempt.

## Fix
- Add `getRecentUserSpeech()` helper: pick the freshest of `-voice.txt` (voice-agent) vs the symlink target (phone), match both `Caller:` and `User:` line prefixes, return '' if neither is fresh (<60s).
- Use it in both pause and resume guards. Empty result = fail open.
- Susan's hallucination guard (2026-04-16) stays intact when the picked transcript is fresh.

## Test plan
- [x] TS clean
- [ ] Voice "pause" mid-demo → pauses
- [ ] Voice "resume" → resumes
- [ ] Same flow on phone-conversation context still blocks hallucinated pause/resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)