### PR TITLE
fix(fullscreen): branch on QuickTime-has-doc, stop open_file hijack

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -463,15 +463,45 @@ end tell`;
 	},
 };
 
-// Toggle fullscreen on the presentation slides
+// Toggle fullscreen on whatever the user is currently viewing.
+// Branches: if a QuickTime video is open → fullscreen QuickTime; else slide deck.
 export const fullscreenTool: ToolDefinition = {
 	name: 'fullscreen',
 	description:
-		'Toggle fullscreen mode on the presentation slides. Use when user says "fullscreen", "enter fullscreen", "exit fullscreen", "make it full screen".',
+		'Toggle fullscreen on whatever the user is currently viewing. If a QuickTime video is open it fullscreens QuickTime; otherwise it fullscreens the slide deck. Use when user says "fullscreen", "enter fullscreen", "exit fullscreen", "make it full screen". DO NOT call open_file with fullscreen=true to enter fullscreen on an already-open video — call this tool instead.',
 	parameters: z.object({}),
 	execution: 'inline',
 	async execute() {
 		try {
+			// Detect whether QuickTime is showing a video. If so, "fullscreen"
+			// means that video, not the slide deck.
+			let qtHasDoc = false;
+			try {
+				const out = execSync(
+					`osascript -e 'tell application "QuickTime Player" to if it is running then return (count of documents) else return 0'`,
+					{ timeout: 2_000 }
+				).toString().trim();
+				qtHasDoc = parseInt(out, 10) > 0;
+			} catch {}
+
+			if (qtHasDoc) {
+				// QuickTime fullscreen via Ctrl+Cmd+F routed through tell process —
+				// bypasses Zoom screen-share keystroke focus grab, same pattern as
+				// the QuickTime open_file fix.
+				execSync(`osascript -e '
+tell application "QuickTime Player" to activate
+delay 0.3
+tell application "System Events"
+	tell process "QuickTime Player"
+		set frontmost to true
+		keystroke "f" using {command down, control down}
+	end tell
+end tell'`, { timeout: 5_000 });
+				console.log(`${ts()} [Fullscreen] Toggled QuickTime`);
+				return { status: 'toggled', target: 'quicktime' };
+			}
+
+			// No QT video open — fullscreen the slide deck in Chrome.
 			execSync(`osascript -e '
 tell application "Google Chrome"
 	activate
@@ -487,21 +517,18 @@ tell application "Google Chrome"
 	end repeat
 end tell
 delay 0.3
--- Target the frontmost process directly. When Zoom is screen-sharing,
--- Zoom's floating control bar steals global keystroke focus, so a plain
--- keystroke f to System Events lands in Zoom instead of the foreground
--- app. Routing through tell process <frontmost> bypasses the focus race
--- while keeping this tool generic — if Chrome was activated above (slide
--- tab found) frontmost is Chrome, otherwise keystroke goes to whatever
--- the user actually has up.
+-- Target the frontmost process directly so Zoom screen-share's floating
+-- control bar can not intercept the keystroke. If Chrome was activated
+-- above (slide tab found) frontmost is Chrome; otherwise the keystroke
+-- goes to whatever the user actually has up.
 tell application "System Events"
 	set frontApp to name of first application process whose frontmost is true
 	tell process frontApp
 		keystroke "f"
 	end tell
 end tell'`, { timeout: 5_000 });
-			console.log(`${ts()} [Fullscreen] Toggled`);
-			return { status: 'toggled' };
+			console.log(`${ts()} [Fullscreen] Toggled slides`);
+			return { status: 'toggled', target: 'slides' };
 		} catch (err) {
 			return { error: `Fullscreen toggle failed: ${err instanceof Error ? err.message : err}` };
 		}

--- a/src/recording-tools.ts
+++ b/src/recording-tools.ts
@@ -486,10 +486,11 @@ export const openFileTool: ToolDefinition = {
 		'Use for: "open the video/recording", "open the file", "open that", "can you open it". ' +
 		'If the user says "open the log" or similar, ASK which log they mean (voice-agent, discord-bridge, etc.) — do NOT default to a recording. ' +
 		'Do NOT call play_video after this — wait for user to explicitly say "play". ' +
+		'NEVER call this tool to enter fullscreen on a video that is already open — call the `fullscreen` tool instead. ' +
 		'Known files: "diagnostic tracker" or "diagnostics" = /tmp/phone-diagnostics-tracker.html, ' +
 		'"voice diagnostics" = /tmp/voice-diagnostics-tracker.html. ' +
 		'If you need to find the latest recording but lost the path, pass find_recording=true. ' +
-		'For video files (.mp4 / .mov) that should play as a presentation, pass fullscreen=true — ' +
+		'For OPENING A NEW video file (.mp4 / .mov) that should play as a presentation, pass fullscreen=true — ' +
 		'QuickTime will activate fullscreen "present" mode after opening.',
 	parameters: z.object({
 		path: z.string().optional().describe('File path to open. Get this from the recording tool result. Use known file aliases for diagnostic tracker etc.'),


### PR DESCRIPTION
## Summary
- When a QuickTime video was already open and Chi asked to fullscreen it, the model picked `open_file(find_recording=true, fullscreen=true)` — opened a *new* recording in QT present mode instead of fullscreening the existing video. Talk-day visible regression.
- `fullscreen` tool now branches: if QuickTime has documents open, target QT with Ctrl+Cmd+F via `tell process` (also survives Zoom screen-share). Else falls back to slide-deck flow.
- `open_file` description: explicit "NEVER call this to enter fullscreen on a video that is already open — call the `fullscreen` tool instead." `fullscreen=true` reframed for OPENING A NEW video file.

## Test plan
- [x] TS clean
- [ ] Voice "fullscreen" with QT video open → that video fullscreens (no new file opens)
- [ ] Voice "fullscreen" with no QT video → slide deck fullscreens (existing behavior)
- [ ] Voice "open the video" → still opens (not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)