### PR TITLE
fix(fullscreen): correct QuickTime detection AppleScript syntax

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -477,10 +477,14 @@ export const fullscreenTool: ToolDefinition = {
 			// means that video, not the slide deck.
 			let qtHasDoc = false;
 			try {
-				const out = execSync(
-					`osascript -e 'tell application "QuickTime Player" to if it is running then return (count of documents) else return 0'`,
-					{ timeout: 2_000 }
-				).toString().trim();
+				const out = execSync(`osascript -e '
+tell application "QuickTime Player"
+	if it is running then
+		return (count of documents)
+	else
+		return 0
+	end if
+end tell'`, { timeout: 2_000 }).toString().trim();
 				qtHasDoc = parseInt(out, 10) > 0;
 			} catch {}
 


### PR DESCRIPTION
## Summary
- PR #524's QT-has-doc check used inline `if X then return Y else return Z`, which AppleScript rejects: `"A 'else' can't go after this ')'"`. osascript exited 1, JS try/catch swallowed it, `qtHasDoc` stayed false.
- Tool fell through to slide-deck path even when QT had a video open. Tool returned "completed" → user saw nothing fullscreen → model hallucinated "there was an error".
- Switch to multi-line block syntax. Verified with osascript directly.

## Test plan
- [x] TS clean
- [x] `osascript -e '...if it is running then return (count of documents) else return 0...'` → exit 0, returns count

🤖 Generated with [Claude Code](https://claude.com/claude-code)