### PR TITLE
fix(open-file): block fullscreen=true when QuickTime already has a video

### DIFF
--- a/src/recording-tools.ts
+++ b/src/recording-tools.ts
@@ -503,6 +503,28 @@ export const openFileTool: ToolDefinition = {
 		console.log(`${ts()} [OpenFile] called (path=${filePath || 'none'}, find_latest=${find_recording || false}, fullscreen=${fullscreen || false})`);
 		demoStateRef.value = 'idle';
 		try {
+			// Runtime guard: if `fullscreen=true` was requested AND QuickTime
+			// already has a video open, the user almost certainly meant
+			// "fullscreen the playing video" — not "find some recording on
+			// disk and open a fresh copy in present mode". Block and direct
+			// to the fullscreen tool. Catches the model rationalising past
+			// the description warning.
+			if (fullscreen) {
+				try {
+					const out = execSync(`osascript -e '
+tell application "QuickTime Player"
+	if it is running then
+		return (count of documents)
+	else
+		return 0
+	end if
+end tell'`, { timeout: 2_000 }).toString().trim();
+					if (parseInt(out, 10) > 0) {
+						console.log(`${ts()} [OpenFile] BLOCKED fullscreen=true while QT already has document(s) — directing to fullscreen tool`);
+						return { error: 'A video is already open in QuickTime. Call the `fullscreen` tool to enter fullscreen on it instead of opening a new file.' };
+					}
+				} catch {}
+			}
 			let recPath = filePath ? filePath.replace(/^~/, process.env.HOME || '') : null;
 			if (recPath && !existsSync(recPath)) {
 				console.log(`${ts()} [OpenFile] path "${recPath}" does not exist`);


### PR DESCRIPTION
## Summary
- After PR #524 tightened `open_file`'s description, the model still picked `open_file(find_recording=true, fullscreen=true)` for "fullscreen the video" — opened a fresh recording over the one Chi was watching.
- The model rationalises past description-only guards. Add a runtime check: if `fullscreen=true` AND QuickTime already has a document, refuse with an error message directing to the `fullscreen` tool.

## Local-only paired change (gitignored skill)
- `skills/personal-iclr-highlight/tools.ts`: deregistered `fullscreen_presenter` so the model only sees one fullscreen tool. The new generic `fullscreen` already branches QT-vs-slides automatically.

## Test plan
- [x] TS clean
- [ ] Voice "fullscreen" with QT video open → tool errors → model retries with `fullscreen` → QT fullscreens
- [ ] `open_file(path=..., fullscreen=true)` with QT NOT running → opens normally (not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)