### PR TITLE
fix(health-check): stop sutando-app auto-fix from leaking duplicates

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -787,10 +787,19 @@ def main():
                                      stderr=subprocess.STDOUT, start_new_session=True)
                     print(f"  {c['name']}: {'restarted (stale code)' if c['status'] == 'stale' else 'restarted'}")
                 elif c["name"] == "sutando-app":
-                    sutando_bin = REPO_DIR / "src" / "Sutando" / "Sutando"
-                    subprocess.Popen([str(sutando_bin)], start_new_session=True,
-                                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                    print(f"  {c['name']}: restarted")
+                    # Stale here means main.swift is newer than the binary's
+                    # process start time. The bare Popen below was leaking
+                    # duplicates (macOS doesn't enforce singleton on this
+                    # bundle — observed 3 concurrent on 2026-04-19) AND it
+                    # was relaunching the same stale binary, so the stale
+                    # signal kept re-firing every cron pass.
+                    #
+                    # Real fix needs (a) pkill the existing PID, (b) swiftc
+                    # rebuild if source > binary, (c) `open src/Sutando/Sutando`.
+                    # Until that lands, surface the warning instead of
+                    # pretending we fixed it. Chi rebuilds + relaunches
+                    # manually per feedback_sutando_app_launch_method.md.
+                    print(f"  {c['name']}: not auto-fixed — needs manual rebuild + relaunch (see memory feedback_sutando_app_launch_method.md)")
                 elif c["name"] == "ngrok":
                     # Read ngrok domain from .env if set, otherwise use default
                     env_path = REPO_DIR / ".env"


### PR DESCRIPTION
## Summary
- The `--fix` path was calling `subprocess.Popen([sutando_bin], ...)` whenever `main.swift` was newer than the running sutando-app process. macOS doesn't enforce singleton on this bundle, so each "fix" leaked another instance (memory `feedback_sutando_app_launch_method.md` recorded 3 concurrent on 2026-04-19).
- Worse: the relaunched binary is the same stale compiled artifact. The next health-check pass detects stale again → another --fix → another leaked instance, every cron tick.
- Stop pretending we fixed it. Print a warning instead. Real fix needs pkill + `swiftc` rebuild + `open` — out of scope for this small change.

## Test plan
- [x] `python3 src/health-check.py --fix` with stale state → prints "not auto-fixed — needs manual rebuild + relaunch"
- [x] No new sutando-app instance spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)