### PR TITLE
fix(friction-detector): drop "action:" prose-marker, anchor others to line start

### DIFF
--- a/src/friction-detector.py
+++ b/src/friction-detector.py
@@ -173,7 +173,18 @@ def check_notes_without_follow_up():
                 continue
             if body_start or not line.startswith("---"):
                 low = line.lower()
-                if any(marker in low for marker in ["- [ ]", "todo:", "action:", "follow-up:", "followup:"]):
+                # Match markers only at the start of the line (after optional
+                # leading whitespace and a list bullet). The previous "any
+                # marker anywhere in line" rule false-positived on
+                # documentation prose like "- Action: Get Contents of URL"
+                # in the Apple Shortcuts research note (the word "Action:"
+                # is shortcut-terminology, not a TODO directive).
+                stripped = low.lstrip(" \t-*")
+                # "action:" was dropped: too noisy. It's standard prose-label
+                # vocabulary (e.g. "Action: Get Contents of URL" in shortcut
+                # docs, "Action items:" as a section header, etc.). The other
+                # three are unambiguously directive.
+                if "- [ ]" in low or any(stripped.startswith(m) for m in ("todo:", "follow-up:", "followup:")):
                     has_todo = True
                     break
                 # Also match tags line with explicit 'todo' tag


### PR DESCRIPTION
## Summary
Two false-positive sources in the note-with-action-items heuristic:
1. `action:` matched anywhere in any line — but it's standard prose vocabulary (Apple Shortcuts research note has "- Action: **Get Contents of URL**", post-draft note has "Action items:" header). Dropped entirely.
2. Other markers (`todo:`, `follow-up:`, `followup:`) matched anywhere in line. Anchor to line start (after optional bullet) so they only fire as directives.

`- [ ]` stays anywhere-match — unambiguous.

## Test
- Before: 12 friction items (incl. apple-shortcuts-integration, post-draft-sandbox-model, linkedin-autogen-3yr-draft as prose false-positives)
- After: 8 items, all genuine

🤖 Generated with [Claude Code](https://claude.com/claude-code)