### PR TITLE
fix(health-check): Optional[Path] for Python 3.9 compat

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -147,7 +147,7 @@ def fix_launchd(label: str) -> str:
 # Main
 # ---------------------------------------------------------------------------
 
-def mark_stale_if_outdated(check: dict, src_file: Path, pgrep_pattern: str, threshold_sec: int = 1800, binary_path: Path | None = None) -> None:
+def mark_stale_if_outdated(check: dict, src_file: Path, pgrep_pattern: str, threshold_sec: int = 1800, binary_path: Optional[Path] = None) -> None:
     """Mark `check` as 'stale' in place if a process matching `pgrep_pattern`
     started more than `threshold_sec` before `src_file`'s mtime.
 


### PR DESCRIPTION
## Summary
- PR #529 introduced `Path | None` (PEP 604) which crashes on Python 3.9
- Mac Mini system Python is 3.9.6 → `health-check.py` fails to import
- Switch to `Optional[Path]` (`typing.Optional` already imported at line 24)

## Repro
On Python 3.9:
```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

## Test plan
- [x] `python3 src/health-check.py` runs cleanly on Mini (Python 3.9.6)
- [ ] CI green on main test workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)