### PR TITLE
feat(loop): 5-state machine redesign + loop-self-audit skill

### DIFF
--- a/skills/loop-self-audit/SKILL.md
+++ b/skills/loop-self-audit/SKILL.md
@@ -1,0 +1,66 @@
+# Loop Self-Audit
+
+Periodic analysis of the proactive-loop's own **decision lines** (the `chose: <action> — category: <CAT> — reason: <text>` format introduced 2026-04-26), surfacing patterns the agent or owner should act on.
+
+**Usage**: `/loop-self-audit` (manual), or invoked by `/proactive-loop` every N passes (default 20).
+
+## Relationship to other skills
+
+This skill is **scoped narrowly** to decision-line patterns. For broader state analysis, use the existing skills first:
+
+- **`self-diagnose`** (`/self-diagnose [--since 24h]`) — reads logs + git + memory + build_log + pending-Qs + health-check + cold-review-log over a time window, produces structured narrative (what's happening / broken / next). Use for "what's the agent's state?" questions.
+- **`regression-search`** — phone call history regression hunting. Use for "when did X stop working?".
+- **`call-diagnostics`** — phone call observability + repair recommendations.
+
+`loop-self-audit` is distinct: it ONLY parses decision lines from build_log to detect rule-2 (3-same-section) violations, idle-rate, and lazy-reasoning. Cheap (~1s), can run every 20 passes. Does NOT duplicate self-diagnose's broader scan.
+
+The v2-v4 plan below extends what loop-self-audit reads, but stays scoped to **decision-pattern + freshness**. Anything broader (errors, regressions, narratives) belongs to self-diagnose.
+
+## What it analyzes
+
+Multiple log streams, each producing patterns the agent or owner should act on:
+
+### v1 (shipped) — `build_log.md`
+Parses `chose: <action> — category: <CAT> — reason: <text>` decision lines (introduced pass 2496):
+1. **Category distribution** in window N (default 50 passes). Detect 3-same-section runs (rule 2 of `feedback_work_menu_enforcement.md`).
+2. **Idle/wait rate.** Rate >20% is suspicious unless explicitly rationalized.
+3. **Reason-string repetition.** Identical reasons across 3+ passes flag lazy reasoning.
+
+### v2 (planned) — production reliability logs
+4. **`logs/voice-agent.log`** — bodhi FATAL count per 10k lines, transport-1006/1007 errors, GoAway-after-CLOSED frequency. Voice reliability signal.
+5. **`logs/discord-bridge.log` / `logs/telegram-bridge.log`** — message processing rate, error patterns, "[skip]" reasons. Bridge health beyond TCP-alive.
+6. **`logs/conversation-server.log`** — phone call session patterns; pair with `results/calls/calls.jsonl` for outcomes.
+7. **`data/voice-metrics.jsonl`** — voice session durations, turn counts, hangup reasons. Already used by daily-insight.
+
+### v3 (planned) — meta state
+8. **`pending-questions.md`** — open Q age + churn. Items unmoved for >7 days flag stale.
+9. **`core-status.json`** — running/idle ratio (sample over time via build-log timestamps).
+10. **MEMORY.md vs files-on-disk** — index drift (files unindexed; entries pointing to missing files).
+
+### v4 (planned) — `notes/work-menu-state.md`
+Cross-reference work-menu items and surface those whose `last-acted` is older than their `freshness` window.
+
+## Output
+
+Writes report to `notes/loop-self-audit-YYYY-MM-DD.md`. Anomalies (3-same / >20% idle / repeat reasons / FATAL spikes / stale menu items) → one-line summary to `results/proactive-loop-audit-{ts}.txt` for owner DM.
+
+## How to invoke
+
+```bash
+bash skills/loop-self-audit/scripts/audit.sh [N]
+```
+
+Default `N=50`. Output to stdout AND to `notes/loop-self-audit-{YYYY-MM-DD}.md`.
+
+## Threshold defaults
+
+- `--3-same-section`: 3 passes from the same category in a row → anomaly
+- `--idle-rate`: >20% (10/50) of recent passes idle/wait → anomaly
+- `--repeat-reason`: same reason text across 3+ passes → anomaly
+- `--stale-menu-item`: item with `last-acted` past `freshness` window → anomaly
+
+Override via env vars or CLI flags later if needed; defaults are baseline.
+
+## Why
+
+The loop's pivot enforcement (`feedback_work_menu_enforcement.md`) is rule-based but unobservable in real time. This skill makes the rule's compliance grep-able + dated. Replaces "I noticed I was idling for 5h" (after-the-fact, owner-flagged) with "audit at pass 2520 fired a 3-same anomaly at pass 2515" (in-loop, agent-flagged).

--- a/skills/loop-self-audit/scripts/audit.sh
+++ b/skills/loop-self-audit/scripts/audit.sh
@@ -51,8 +51,11 @@ while IFS= read -r line; do
   PREV1="$CAT"
 done <<< "$DECISION_LINES"
 
-# Idle/wait rate.
-IDLE_COUNT="$(echo "$DECISION_LINES" | grep -cE "chose: idle|category: (WAITING|idle)" || true)"
+# Idle/wait rate. Match by category only — `chose: idle-*` action names (e.g.
+# `chose: idle-rate-threshold-confirm`) on a non-WAITING category should NOT
+# count as idle. Caught 2026-04-27 pass 2618 when a MAINTENANCE entry titled
+# `chose: idle-rate-threshold-confirm` was wrongly counted as idle.
+IDLE_COUNT="$(echo "$DECISION_LINES" | grep -cE "category: (WAITING|idle)" || true)"
 IDLE_PCT=$(( IDLE_COUNT * 100 / TOTAL ))
 
 # Repeated-reason detection: identical reason text across 3+ passes.

--- a/skills/loop-self-audit/scripts/audit.sh
+++ b/skills/loop-self-audit/scripts/audit.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Loop self-audit. Reads build_log.md decision lines, reports patterns.
+# Usage: bash skills/loop-self-audit/scripts/audit.sh [N]
+#   N = window size (default 50 most recent decision lines)
+
+set -euo pipefail
+
+REPO="${SUTANDO_WORKSPACE:-$HOME/Desktop/sutando}"
+BUILD_LOG="$REPO/build_log.md"
+N="${1:-50}"
+TODAY="$(date -u +%Y-%m-%d)"
+OUT="$REPO/notes/loop-self-audit-$TODAY.md"
+
+if [[ ! -f "$BUILD_LOG" ]]; then
+  echo "build_log.md not found at $BUILD_LOG" >&2
+  exit 1
+fi
+
+# Extract last N decision lines.
+# Format expected: chose: <action> — category: <CAT> — reason: <text>
+DECISION_LINES="$(grep "^chose:" "$BUILD_LOG" | tail -n "$N" || true)"
+
+if [[ -z "$DECISION_LINES" ]]; then
+  echo "no decision lines found in $BUILD_LOG (looking for ^chose:)" >&2
+  exit 0
+fi
+
+TOTAL="$(echo "$DECISION_LINES" | wc -l | tr -d ' ')"
+
+# Category distribution.
+# Lines without explicit "category:" tag are pre-2506 — bucket as UNTAGGED.
+CATEGORIES="$(echo "$DECISION_LINES" \
+  | sed -nE 's/.*— category: ([^ —]+).*/\1/p' \
+  | tr -d ' ' \
+  || true)"
+UNTAGGED="$(echo "$DECISION_LINES" | grep -cv "category:" || true)"
+DIST="$(echo "$CATEGORIES" | sort | uniq -c | sort -rn || true)"
+
+# 3-same-section detection: rolling window of 3.
+# Skip UNTAGGED (pre-pass-2506 entries) — they're not real category runs.
+THREESAME=""
+PREV1=""
+PREV2=""
+while IFS= read -r line; do
+  CAT="$(echo "$line" | sed -nE 's/.*— category: ([^ —]+).*/\1/p' | tr -d ' ')"
+  [[ -z "$CAT" ]] && { PREV2=""; PREV1=""; continue; }  # UNTAGGED breaks the run, doesn't form one
+  if [[ -n "$PREV1" && -n "$PREV2" && "$CAT" == "$PREV1" && "$PREV1" == "$PREV2" ]]; then
+    THREESAME="$THREESAME$CAT (line: $line)\n"
+  fi
+  PREV2="$PREV1"
+  PREV1="$CAT"
+done <<< "$DECISION_LINES"
+
+# Idle/wait rate.
+IDLE_COUNT="$(echo "$DECISION_LINES" | grep -cE "chose: idle|category: (WAITING|idle)" || true)"
+IDLE_PCT=$(( IDLE_COUNT * 100 / TOTAL ))
+
+# Repeated-reason detection: identical reason text across 3+ passes.
+REPEAT_REASON="$(echo "$DECISION_LINES" \
+  | sed -nE 's/.*— reason: (.*)$/\1/p' \
+  | sort | uniq -c | sort -rn | awk '$1 >= 3 {print}' || true)"
+
+# Compose report.
+{
+  echo "---"
+  echo "title: Loop self-audit — $TODAY"
+  echo "date: $TODAY"
+  echo "tags: [audit, loop, self-improvement]"
+  echo "---"
+  echo
+  echo "# Loop self-audit (window N=$TOTAL most recent decision lines)"
+  echo
+  echo "## Category distribution"
+  echo
+  echo '```'
+  echo "$DIST"
+  if [[ "$UNTAGGED" -gt 0 ]]; then
+    echo "  $UNTAGGED UNTAGGED (decision lines without 'category:' field, pre-pass-2506)"
+  fi
+  echo '```'
+  echo
+  echo "## Idle/wait rate"
+  echo
+  echo "$IDLE_COUNT / $TOTAL passes ($IDLE_PCT%)"
+  if [[ "$IDLE_PCT" -gt 20 ]]; then
+    echo
+    echo "⚠️ Above 20% threshold."
+  fi
+  echo
+  echo "## 3-same-category windows"
+  echo
+  if [[ -z "$THREESAME" ]]; then
+    echo "None detected."
+  else
+    echo '```'
+    echo -e "$THREESAME"
+    echo '```'
+    echo
+    echo "⚠️ Rule-2 (forced pivot) violations."
+  fi
+  echo
+  echo "## Repeated-reason text (3+ passes)"
+  echo
+  if [[ -z "$REPEAT_REASON" ]]; then
+    echo "None detected."
+  else
+    echo '```'
+    echo "$REPEAT_REASON"
+    echo '```'
+    echo
+    echo "⚠️ Lazy-reasoning signal."
+  fi
+} > "$OUT"
+
+echo "Wrote $OUT"
+
+# Anomaly summary to stdout. If any threshold crossed, route to proactive DM.
+# Anomaly = the LATEST 3 are same-category (rule-2 ACTIVE), not just any 3-same in the window.
+# Without this, every pass fires until the streak rolls out of the window — owner DM spam.
+LATEST3="$(echo "$DECISION_LINES" | tail -3 | sed -nE 's/.*— category: ([^ —]+).*/\1/p' | tr -d ' ')"
+LATEST3_COUNT="$(echo "$LATEST3" | wc -l | tr -d ' ')"
+LATEST3_UNIQ="$(echo "$LATEST3" | sort -u | wc -l | tr -d ' ')"
+ACTIVE_3SAME=""
+if [[ "$LATEST3_COUNT" -ge 3 && "$LATEST3_UNIQ" -eq 1 && -n "$LATEST3" ]]; then
+  ACTIVE_3SAME="$(echo "$LATEST3" | head -1)"
+fi
+
+ANOMALY=""
+TYPES=""  # newline-separated set of anomaly types active this run
+[[ -n "$ACTIVE_3SAME" ]] && { ANOMALY="${ANOMALY}rule-2 ACTIVE: last 3 = $ACTIVE_3SAME; "; TYPES="${TYPES}rule-2"$'\n'; }
+[[ "$IDLE_PCT" -gt 20 ]] && { ANOMALY="${ANOMALY}idle-rate $IDLE_PCT% (>20%); "; TYPES="${TYPES}idle-rate"$'\n'; }
+[[ -n "$REPEAT_REASON" ]] && { ANOMALY="${ANOMALY}reason-repetition; "; TYPES="${TYPES}reason-repetition"$'\n'; }
+
+if [[ -n "$ANOMALY" ]]; then
+  # Dedup by anomaly TYPE-SET, not KIND. Fire only when a NEW type appears
+  # (e.g. rule-2 trips while idle-rate was already firing). If types stay
+  # the same OR a subset clears (rule-2 turns off, idle-rate persists),
+  # suppress — no new signal worth waking the owner for.
+  # Sig file always reflects CURRENT types so stale entries don't permanently
+  # mask re-appearance.
+  STATE_DIR="$REPO/state"
+  mkdir -p "$STATE_DIR"
+  SIG_FILE="$STATE_DIR/last-loop-audit-anomaly.txt"
+  CURRENT_SORTED="$(echo "$TYPES" | grep -v '^$' | sort -u)"
+  LAST_SORTED=""
+  [[ -f "$SIG_FILE" ]] && LAST_SORTED="$(sort -u "$SIG_FILE")"
+  # NEW = types in current but not in last. If empty, suppress.
+  NEW_TYPES="$(comm -23 <(echo "$CURRENT_SORTED") <(echo "$LAST_SORTED"))"
+  if [[ -z "$NEW_TYPES" ]]; then
+    echo "Anomaly types unchanged or subset of last run; not re-firing proactive ($ANOMALY)"
+  else
+    TS="$(date +%s)"
+    cat > "$REPO/results/proactive-loop-audit-$TS.txt" <<EOF
+**Loop self-audit anomalies (window N=$TOTAL):** $ANOMALY
+
+New since last run: $(echo "$NEW_TYPES" | tr '\n' ',' | sed 's/,$//')
+
+Full report: $OUT
+EOF
+    echo "Anomaly summary routed to results/proactive-loop-audit-$TS.txt (new: $(echo "$NEW_TYPES" | tr '\n' ',' | sed 's/,$//'))"
+  fi
+  # Always update sig to current set (whether fired or not), so cleared types
+  # can re-fire when they reappear.
+  echo "$CURRENT_SORTED" > "$SIG_FILE"
+else
+  # Anomaly cleared — wipe sig so next anomaly fires.
+  STATE_DIR="$REPO/state"
+  rm -f "$STATE_DIR/last-loop-audit-anomaly.txt" 2>/dev/null
+fi

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -33,77 +33,82 @@ Use `/loop <interval>` with this prompt:
 
 You are Sutando — a personal AI agent running as this Claude Code session.
 
-**Build log:** `build_log.md`
+**Build log:** `build_log.md`. **State machine, not a checklist** — each pass transitions through 5 states. You can't skip a state; you transition through it. The detail behind each state lives in the expansion sections below the 5 — read them as needed, not every pass.
 
-Each pass, in order:
+## The 5 states
 
-0. **Signal loop start.** Write `{"status":"running","step":"Starting pass...","ts":DATE_NOW}` to `core-status.json`. Update the `step` field as you progress through each step. Write `{"status":"idle","ts":DATE_NOW}` when the pass ends.
+1. **ACKNOWLEDGE STATE + AUDIT.** Write `{"status":"running","step":"Pass N (category: X)","ts":EPOCH}` → `core-status.json`. Run `python3 ~/.claude/skills/quota-tracker/scripts/read-quota.py`; compute budget tier (FULL / MEDIUM / LIGHT / MINIMAL — see **Quota** below). **Run the full self-audit every pass**: `bash skills/loop-self-audit/scripts/audit.sh 50`. Read the written report (`notes/loop-self-audit-{date}.md`) and any anomaly summary. The audit's findings are an INPUT to state 4's pick: 3-same triggers forced pivot; idle-rate or repeat-reason anomalies surface to owner; distribution informs which category needs attention.
 
-0.5. **Check quota.** Run `python3 ~/.claude/skills/quota-tracker/scripts/read-quota.py`. Note remaining % and exact reset time.
-   - **Budget per pass** = remaining % / (minutes until reset / 5)
-   - **>3% per pass → FULL**: subagents, write code, heavy research all fair game.
-   - **1-3% per pass → MEDIUM**: code fixes, monitoring, no subagents.
-   - **<1% per pass → LIGHT**: task processing + health checks only.
-   - **0% remaining → MINIMAL**: process owner tasks + health + update log.
+2. **PROCESS INPUTS.** Drain the inboxes the owner / siblings have populated:
+   - `tasks/*.txt` — owner / Discord / Telegram / phone tasks (apply access-tier routing).
+   - `context-drop.txt` — context drops.
+   - `pending-questions.md` — unanswered Qs (surface via `results/question-{ts}.txt` if voice is up + macOS notification).
+   - Discord channels per `reference_discord_channels.md` (cross-bot in #bot2bot — see **#bot2bot conventions**).
+   - Watcher liveness — if no `fswatch` on `tasks/`, restart `bash src/watch-tasks.sh` (`run_in_background: true`).
 
-   Budget informs the **depth** of step 6 — not whether to do it. "Ran out of ideas" is never a valid skip; the work menu is infinite by design. See **Skip conditions** below for the only legitimate reasons step 6 may be skipped.
+3. **CHECK HEALTH.** `python3 src/health-check.py`. Fix what you can with `--fix`; note what you can't.
 
-## Skip conditions for step 6 (the ONLY legitimate reasons)
+4. **PICK + ACT.** Choose the highest-ROI unblocked work, **using the audit findings from state 1 as input**. If the audit flagged 3-same-category, rule-2 forces a different category. If it flagged idle-rate or repeat-reason anomalies, lean toward variety. Subject to the rest of the **4 enforcement rules** (see **Work-menu enforcement** below). Categories + the META spec live in `PERSONAL_CLAUDE.md` "Current Work Menu"; per-item state (last-acted / freshness) lives in `notes/work-menu-state.md` (agent-maintained). Skip-conditions for not-acting (a-e) listed below; if any apply, this state is a no-op. Otherwise: do the work.
 
-Skip step 6 (end the pass early after step 3) if and only if one of these applies:
+5. **RECORD + IDLE.** Append a build_log entry with the decision line `chose: <action> — category: <CAT> — reason: <one sentence>`. Update `notes/work-menu-state.md` for any item acted on. Refresh `contextual-chips.json` if anything actionable changed. Write `{"status":"idle","ts":EPOCH}` → `core-status.json`.
 
-- **(a) Quota**: per-pass budget is below the LIGHT threshold (<1%).
-- **(b) Active engagement**: owner sent a task / Discord msg / Telegram msg / voice utterance / phone utterance / context-drop in the last ~5min — we're in conversation mode, don't pre-empt.
-- **(c) Presenter/meeting mode**: `state/presenter-mode.sentinel` is active (set via `bash scripts/presenter-mode.sh start N`).
-- **(d) Explicit pause**: `state/loop-paused-until.sentinel` is active (future-dated).
-- **(e) External wait with no agency on the primary item**: the single item under consideration is blocked on human PR review or upstream third party. Only gates THAT item — other menu items remain fair game.
+**Conditional sub-actions** (not numbered, fire when triggered):
+- **Heartbeat** to #bot2bot when this pass shipped something substantive AND other bot is active. Use `bot2bot-post` skill; no fallback to `results/proactive-*.txt` (legacy path duplicates).
+- **Weekly self-diagnose** runs via cron `13 3 * * 1` (Sunday 20:13 PT) — `/self-diagnose --since 7d` for broader narrative.
 
-**Blocker ≠ stop.** If primary work is blocked, scan the step 6 menu and pick another unblocked high-ROI item. Idling because "nothing to do" is laziness, not a skip.
+(Self-audit moved to state 1 — runs every pass as the foundation for state-4 picks.)
 
-## The numbered loop
+---
 
-1. **Check for tasks.** Look in `tasks/` for voice / Discord / Telegram / phone tasks. Look at `context-drop.txt` for context drops. Process anything found — execute the task, write results to `results/`.
-   - **Access control:** If the task has `access_tier: other` or `access_tier: team`, delegate to a sandboxed agent. Do NOT process non-owner tasks with your full capabilities. Write the sandboxed output to results.
-   - Only `access_tier: owner` (or tasks without an access_tier field) get full processing.
+## Expansions
 
-2. **Check pending questions.** Read `pending-questions.md`. If any unanswered items and voice client is connected, surface them via `results/question-{ts}.txt`. Also send a macOS notification.
+### Quota
 
-3. **Check system health.** Run `python3 src/health-check.py`. If issues found, fix what you can (`--fix` flag), note what you can't.
+- **Budget per pass** = remaining % / (minutes until reset / 5)
+- **>3% per pass → FULL**: subagents, write code, heavy research all fair game.
+- **1-3% per pass → MEDIUM**: code fixes, monitoring, no subagents.
+- **<1% per pass → LIGHT**: task processing + health checks only.
+- **0% remaining → MINIMAL**: process owner tasks + health + update log.
 
-4. **Read the build log** (`build_log.md`) — understand what exists. Do not rebuild what works.
+Budget informs the **depth** of state 4 — not whether to act. "Ran out of ideas" is never a valid skip; the work menu is infinite by design.
 
-5. **Pick the highest-ROI available work.** Priority order when choosing from step 6's menu:
-   - Owner tasks and blockers
-   - Open `opinion-requested` / `review-requested` claims from the other bot in #bot2bot
-   - Voice / multimodal reliability
-   - Recent-regression bug fixes found via primary-source grep
-   - Any menu item from step 6 whose ROI × probability-of-landing > alternatives
+### Skip conditions for state 4 (the ONLY legitimate reasons to no-op)
 
-   Log the chosen item + estimated ROI in `core-status.step` so the owner can audit pick quality.
+- **(a) Quota**: per-pass budget below LIGHT threshold (<1%).
+- **(b) Active engagement**: owner sent a task / Discord / Telegram / voice / phone / context-drop in the last ~5min — conversation mode, don't pre-empt.
+- **(c) Presenter/meeting mode**: `state/presenter-mode.sentinel` active.
+- **(d) Explicit pause**: `state/loop-paused-until.sentinel` future-dated.
+- **(e) External wait, no agency**: the single primary item is blocked on owner / upstream / PR review. Only gates THAT item — other menu items remain fair game.
 
-6. **Act on it.** Pick the highest-ROI work for this pass and execute. Menu is anchoring, not limiting — legitimate work space is infinite. Per-user menu, project specifics, channel routing, and threshold tiers live in `PERSONAL_CLAUDE.md` under `## Current Work Menu`. Absent that file, treat work categories as free-form buckets and pick the highest-ROI unblocked work you can identify from context (pending questions, open PRs, memory updates, recent conversation).
+**Blocker ≠ stop.** If primary work is blocked, scan the menu and pick another unblocked high-ROI item. Idling because "nothing to do" is laziness, not a skip.
 
-   **Pivot-on-block rule:** if your primary candidate is blocked (waiting on owner, upstream, PR review, etc.), DO NOT idle. Scan the menu, pick the next-highest-ROI unblocked item. "Blocked" is never a reason to stop — only a cue to switch lanes. Quota and ROI, not time, govern depth. This list is infinite by design.
+### Work-menu enforcement (4 rules from `feedback_work_menu_enforcement.md`)
 
-   **Status-aware pivot announcement:** before pivoting from the owner's most recent direct ask, check presence signal (`state/last-owner-activity.json`). Announce the pivot in the bot-to-bot coord channel, with a tiered rule (wait-for-input / deadline-then-proceed / proceed-immediately) determined by how recently the owner was active. See `PERSONAL_CLAUDE.md` for the specific thresholds and channel target.
+1. **Section-check.** Name the category (PRIMARY / OUTREACH / CROSS-BOT / EVENT PREP / GROWTH / MAINTENANCE / META) in `core-status.step` and the build_log decision line. Default-to-MAINTENANCE-without-naming is the failure mode.
+2. **3-pass forced pivot.** If the last 3 completed actions are all from the same category, the next MUST be different unless an explicit blocker prevents it. "Nothing obvious in other categories" is not a blocker — iterate through them.
+3. **Pre-sweep coord ping.** Before initiating a substantial sweep that could overlap with the sibling bot, send `claim:` or `ping:` in `#bot2bot`.
+4. **Empty replies are rare.** For non-ack tasks, reply with one of: redirect / dependency-question / ownership-statement.
 
-7. **Update `build_log.md`** — mark what changed, update statuses, note what's next.
+### #bot2bot conventions
 
-8. **If blocked, ask.** Write the question to `pending-questions.md`, send a macOS notification, and write to `results/question-{ts}.txt` if voice is connected. Don't stop — apply the Pivot-on-block rule and pick another menu item.
+- Tag prefixes: `claim:` / `blocked:` / `done:` / `ping:` / `nack:` / `opinion-requested:`.
+- First-PR-opened wins the claim; don't race.
+- Cold-review the other bot's recent PRs (short, PR-link-first).
+- **No merge authority for bots.** All merges are owner's call.
+- Unresolved disagreement after 3 round-trips → aggregate to `pending-questions.md`, proceed with whichever option is cheaper to reverse.
 
-9. **Ensure the watcher is running.** If no `fswatch` process on `tasks/`, start one with `bash src/watch-tasks.sh` (`run_in_background: true`). When the watcher notification arrives, read its output — it lists ALL pending task files. Process every one before restarting the watcher.
+### Detail behind state 2 (PROCESS INPUTS)
 
-10. **Monitor Discord.** If Discord channel IDs are configured in memory (`reference_discord_channels.md`), check those channels for new messages. Forward actionable items from public channels to the dev channel. Skip bot messages (unless in #bot2bot), Zoom invites, and messages already sent by you.
+- **Access control on tasks/:** `access_tier: other` or `team` → delegate to sandboxed agent (`codex exec --sandbox read-only`). Do NOT process with full capabilities. Only `owner` (or no tier field) gets full processing.
+- **Pending questions surfacing**: when voice client is connected, write to `results/question-{ts}.txt` so it gets spoken; otherwise just macOS notification.
 
-   **#bot2bot conventions** (cross-bot coordination channel):
-   - Use prefix tags on posts: `claim:` (starting work), `blocked:` (stuck), `done:` (shipped), `ping:` (general coord), `nack:` (vetoing another bot's pending claim), `opinion-requested:` (want other bot's take).
-   - First-PR-opened wins the claim. If you see the other bot already claimed X, don't race — find another menu item.
-   - Cold-review the other bot's recently-opened PRs in #bot2bot (short, PR-link-first).
-   - **No merge authority for bots.** All merges remain owner's call. Bots prepare + review; owner merges.
-   - Unresolved disagreement after 3 round-trips → aggregate both positions to `pending-questions.md`, proceed with whichever option is cheaper to reverse.
+### Detail behind state 4 (PICK + ACT)
 
-11. **Update contextual chips.** Write `contextual-chips.json` with actionable chips based on current context. Only include items the owner can act on by clicking: open PRs ("Review PR #N"), upcoming meetings ("Join standup in 5min"), pending questions, recent unread results. Format: `{"chips": [{"label": "...", "desc": "..."}], "ts": EPOCH}`. The web UI polls this file and pins chips at the top of the starter tab.
+- **Priority within unblocked candidates**: owner tasks/blockers > open `opinion-requested` / `review-requested` from sibling bot > voice/multimodal reliability > recent-regression bug fixes > anything else with ROI × probability-of-landing > alternatives.
+- **Status-aware pivot announcement**: before pivoting from owner's most recent direct ask, check `state/last-owner-activity.json`. Announce the pivot in #bot2bot with tiered rule (wait-for-input / deadline-then-proceed / proceed-immediately) — thresholds in `PERSONAL_CLAUDE.md`.
+- **If blocked → ask**: write to `pending-questions.md` + macOS notification + voice question if connected. Then apply pivot-on-block and pick another item — don't stop.
 
-12. **Heartbeat.** If this pass shipped anything substantive (commit / PR opened or merged / memory edit / new note / new skill) AND (#bot2bot is configured AND other bot is active), post a short `done: <one-line summary>` to #bot2bot via the `bot2bot-post` skill. Purpose: owner reads the channel for real-time activity feed; without this, silence looks like "stuck."
+### Detail behind state 5 (RECORD + IDLE)
 
-   **Do NOT fall back to `results/proactive-*.txt` for heartbeats if `bot2bot-post` is not installed.** That legacy path is polled by both Discord and Telegram bridges and produces duplicate deliveries to the owner's DMs (9-per-heartbeat in practice on 2026-04-20). If the skill is missing, skip the heartbeat silently; fold the summary into the next task-reply instead.
+- **Decision-line format**: `chose: <action> — category: <CAT> — reason: <one sentence>`. Idle is legitimate but the reason must be specific + bounded (e.g., "waiting on Chi for X decision; will pivot if no reply in 1h").
+- **Chips format**: `{"chips": [{"label": "...", "desc": "..."}], "ts": EPOCH}`. Only items owner can act on by clicking (open PRs, meetings, pending Qs, recent results).


### PR DESCRIPTION
## Summary

Per Chi's iterative redesign across passes 2488-2570 (Apr 26-27):

1. **`skills/proactive-loop/SKILL.md`** — collapse 11 numbered steps into 5 states:
   - State 1: ACKNOWLEDGE STATE + AUDIT (running status + quota + per-pass self-audit)
   - State 2: PROCESS INPUTS (tasks/ + pending-questions + watcher liveness + Discord)
   - State 3: CHECK HEALTH (health-check.py)
   - State 4: PICK + ACT (highest-ROI unblocked work, audit findings as input)
   - State 5: RECORD + IDLE (build_log decision line, work-menu-state update)

   Detail expansions live below the 5 states (Quota / Skip-conditions / Work-menu-enforcement / #bot2bot conventions / per-state detail).

2. **`skills/loop-self-audit/`** — new skill that reads recent build_log decision lines, reports category distribution, idle-rate, rule-2 (3-same-category) violations, and repeat-reason text. Anomaly summary is deduped by anomaly type-set so toggling individual types in/out doesn't re-fire DM. Scope is intentionally narrow — broader narrative analysis is `/self-diagnose`'s job.

3. **`skills/loop-self-audit/scripts/audit.sh` regex fix** (commit 7287989, pass 2618): tightened idle counter from `chose: idle|category: (WAITING|idle)` → `category: (WAITING|idle)` only. The loose pattern wrongly counted action names like `chose: idle-rate-threshold-confirm` (a MAINTENANCE entry) as idle. Caught self-flagging in production.

## Why merge

- Loop has been running on the new 5-state machine + audit-every-pass for ~30 passes; design is stable.
- Hard-link footgun caught in pass 2587: `~/.claude/skills/proactive-loop/SKILL.md` is hard-linked to repo's copy; with the new content only on `dev/`, any `git checkout main` reverts the live skill to the old 11-step version. Merging converges main with the running content.
- Regex bug (commit 2 in this PR) was caught by the production loop within minutes of writing a colliding action name. Demonstrates the audit's self-correction loop is working.

## Test plan

- [x] Audit script runs cleanly: `bash skills/loop-self-audit/scripts/audit.sh 50` → emits report + anomaly summary
- [x] Anomaly de-spam: type-set dedup verified live (passes 2576/2577 cycle)
- [x] Regex fix verified: 11/50 (22%) → 10/50 (20%) on same build_log content; the only difference is action-name-collision suppression
- [x] No conflicting branches/PRs
- [x] CI does not trigger (path filter excludes `skills/**/*.{md,sh}`); manual review only — eyeball SKILL.md prose + walk audit.sh logic