### PR TITLE
fix(web-client): allow copying text from task titles

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -945,6 +945,11 @@ function toggleAllTasks() {
 document.addEventListener('click', function(e) {
   // Don't toggle if clicking inside the result text (allow text selection)
   if (e.target.closest && e.target.closest('[id^="result-"]')) return;
+  // Don't toggle if the click ended a drag-to-select on the task title.
+  // Without this, the mouseup at the end of a text-select fires the click
+  // handler and toggles before the user can copy.
+  const sel = window.getSelection && window.getSelection();
+  if (sel && sel.toString().length > 0) return;
   const item = e.target.closest && e.target.closest('.task-item[data-taskid]');
   if (item) toggleResult(item.dataset.taskid);
 });


### PR DESCRIPTION
## Summary
The doc click handler at `web-client.ts:945` already skipped toggle when clicking inside `[id^="result-"]` (commit f09c302) — result text was selectable. But the task TITLE (`<span class="task-text">`) sits inside the `<div class="task-item">` itself, so a drag-to-select on the title triggered the toggle before the user could copy.

Add a `window.getSelection()` guard: if the click ends a non-empty selection, skip toggle. Plain single clicks still toggle as before.

## Test plan
- [x] TS clean
- [ ] Drag-to-select task title text → copy works (post-merge)
- [ ] Single click on task → still toggles (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)