### PR TITLE
chore(gitignore): ignore skills/post-preview/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ tests/*
 !tests/*.test.ts
 !tests/*.test.py
 skills/personal-*/
+skills/post-preview/
 tests/security/*.md
 !tests/security/*.md.example
 skills/schedule-crons/crons.json


### PR DESCRIPTION
## Summary

- Adds `skills/post-preview/` to `.gitignore` (one-line change after the `skills/personal-*/` entry).
- Follow-through on Chi's "(b) + gitignore for now" call from yesterday after the post-preview skill was recovered from session JSONL on 2026-04-26.
- Files stay at the existing path (`skills/post-preview/`) since the skill loader reads from there; durability backup already lives in `~/.sutando-memory-sync/machine-Chis-MacBook-Air/skills/post-preview/`. This change just stops the untracked-file warning and prevents accidental commit via `git add .`.

## Test plan

- [x] `git check-ignore skills/post-preview/SKILL.md` → matches the new pattern (verified locally).
- [ ] Confirm `git status` no longer shows `skills/post-preview/` as untracked after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)