### PR TITLE
fix(security): validate GitHub webhook signature to prevent task injection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,3 +136,8 @@ PORT=9900
 # CARTESIA_API_KEY=your-cartesia-key
 # CARTESIA_VOICE_ID=f786b574-daa5-4673-aa0c-cbe3e8534c02
 # STT_PROVIDER=cartesia
+
+# GitHub webhook bridge — signature verification secret.
+# Must match the secret configured in GitHub repo Settings → Webhooks → Secret.
+# If not set, all webhook payloads are rejected (fail-closed).
+# GITHUB_WEBHOOK_SECRET=your-webhook-secret-here

--- a/src/github-webhook.py
+++ b/src/github-webhook.py
@@ -17,7 +17,10 @@ Usage:
   python3 src/github-webhook.py --port 7846  # custom port
 """
 
+import hashlib
+import hmac
 import json
+import os
 import sys
 import time
 from http.server import HTTPServer, BaseHTTPRequestHandler
@@ -26,6 +29,33 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 TASKS_DIR = REPO / "tasks"
 PORT = int(sys.argv[sys.argv.index("--port") + 1]) if "--port" in sys.argv else 7847
+
+# GitHub webhook secret for payload signature verification.
+# Set GITHUB_WEBHOOK_SECRET in your .env to match the secret configured in
+# GitHub repo Settings → Webhooks → (your webhook) → Secret.
+# If not set, all webhook payloads are rejected (fail-closed).
+WEBHOOK_SECRET = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
+
+
+def verify_github_signature(body: bytes, signature_header: str) -> bool:
+    """Verify X-Hub-Signature-256 from GitHub webhook payload.
+
+    GitHub signs every webhook delivery with HMAC-SHA256 using the shared
+    webhook secret.  See:
+    https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+
+    Returns True if the signature is valid, False otherwise.
+    """
+    if not WEBHOOK_SECRET:
+        return False
+    if not signature_header:
+        return False
+    if not signature_header.startswith("sha256="):
+        return False
+    expected = "sha256=" + hmac.new(
+        WEBHOOK_SECRET.encode("utf-8"), body, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
 
 # Events we care about and how to summarize them
 def format_event(event_type: str, payload: dict):
@@ -65,6 +95,17 @@ class WebhookHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         length = int(self.headers.get("Content-Length", 0))
         body = self.rfile.read(length)
+
+        # Verify webhook signature — reject unauthenticated payloads
+        signature = self.headers.get("X-Hub-Signature-256", "")
+        if not verify_github_signature(body, signature):
+            self.send_response(403)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "invalid signature"}).encode())
+            print(f"[{time.strftime('%H:%M:%S')}] REJECTED: invalid or missing webhook signature")
+            return
+
         event_type = self.headers.get("X-GitHub-Event", "unknown")
 
         try:

--- a/src/github-webhook.py
+++ b/src/github-webhook.py
@@ -30,6 +30,14 @@ REPO = Path(__file__).resolve().parent.parent
 TASKS_DIR = REPO / "tasks"
 PORT = int(sys.argv[sys.argv.index("--port") + 1]) if "--port" in sys.argv else 7847
 
+# Load .env before reading secrets so launchctl / systemd managed restarts
+# pick up GITHUB_WEBHOOK_SECRET without needing it in the plist/unit file.
+try:
+    from dotenv import load_dotenv
+    load_dotenv(REPO / ".env")
+except ImportError:
+    pass
+
 # GitHub webhook secret for payload signature verification.
 # Set GITHUB_WEBHOOK_SECRET in your .env to match the secret configured in
 # GitHub repo Settings → Webhooks → (your webhook) → Secret.

--- a/src/github-webhook.py
+++ b/src/github-webhook.py
@@ -36,6 +36,14 @@ PORT = int(sys.argv[sys.argv.index("--port") + 1]) if "--port" in sys.argv else 
 # If not set, all webhook payloads are rejected (fail-closed).
 WEBHOOK_SECRET = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
 
+# Track whether we've logged a successful verification (per process lifetime)
+_verification_confirmed = False
+
+# Warn at startup if no secret is configured
+if not WEBHOOK_SECRET:
+    print("⚠️  WARNING: GITHUB_WEBHOOK_SECRET not set — all webhooks will be rejected.")
+    print("   Set this in .env to match your GitHub webhook secret.")
+
 
 def verify_github_signature(body: bytes, signature_header: str) -> bool:
     """Verify X-Hub-Signature-256 from GitHub webhook payload.
@@ -105,6 +113,12 @@ class WebhookHandler(BaseHTTPRequestHandler):
             self.wfile.write(json.dumps({"error": "invalid signature"}).encode())
             print(f"[{time.strftime('%H:%M:%S')}] REJECTED: invalid or missing webhook signature")
             return
+
+        # Log first successful verification so operators can confirm auth is wired
+        global _verification_confirmed
+        if not _verification_confirmed:
+            print(f"[{time.strftime('%H:%M:%S')}] ✓ Webhook signature verified (first successful)")
+            _verification_confirmed = True
 
         event_type = self.headers.get("X-GitHub-Event", "unknown")
 

--- a/src/github-webhook.py
+++ b/src/github-webhook.py
@@ -36,7 +36,7 @@ try:
     from dotenv import load_dotenv
     load_dotenv(REPO / ".env")
 except ImportError:
-    pass
+    print("⚠️ python-dotenv not installed — relying on shell env for GITHUB_WEBHOOK_SECRET")
 
 # GitHub webhook secret for payload signature verification.
 # Set GITHUB_WEBHOOK_SECRET in your .env to match the secret configured in
@@ -161,6 +161,9 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
 
 def main():
+    # NOTE: binds to all interfaces (0.0.0.0). For production, consider
+    # binding to 127.0.0.1 and placing behind a reverse proxy (nginx, ngrok)
+    # for defense-in-depth on top of the HMAC signature check.
     server = HTTPServer(("0.0.0.0", PORT), WebhookHandler)
     print(f"GitHub webhook bridge listening on port {PORT}")
     print(f"Events: issues.opened, pull_request.opened/merged, star.created, issue_comment.created")


### PR DESCRIPTION
## Summary

The GitHub webhook bridge (`src/github-webhook.py`) accepts webhook payloads without any signature verification. Anyone who discovers the ngrok/funnel URL can forge GitHub events, which get written to `tasks/` and executed by the core agent — effectively **remote task injection**.

## Fix

Add `X-Hub-Signature-256` HMAC-SHA256 verification before processing any payload:

- Reads `GITHUB_WEBHOOK_SECRET` from environment (set in `.env` or GitHub webhook settings)
- **Fail-closed**: if no secret is configured, all webhooks are rejected with 403
- Uses `hmac.compare_digest()` to prevent timing attacks
- Follows the [official GitHub validation guide](https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries)

## Setup

After merging, add to your `.env`:
```
GITHUB_WEBHOOK_SECRET=<your-secret>
```
And set the same secret in GitHub repo Settings → Webhooks → Secret.

## Testing

Without secret set:
```
curl -X POST http://localhost:7847 -d '{"test":1}' → 403 {"error": "invalid signature"}
```

With valid signature:
```
SECRET="mysecret"
BODY='{"action":"opened","issue":{"number":1,"title":"test","body":""},"repository":{"full_name":"test/repo"},"sender":{"login":"test"}}'
SIG="sha256=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk "{print \$2}")"
curl -X POST http://localhost:7847 \
  -H "X-GitHub-Event: issues" \
  -H "X-Hub-Signature-256: $SIG" \
  -d "$BODY" → 200 {"ok":true}
```

## Impact

Without this fix, an attacker who discovers the webhook URL can:
- Inject arbitrary tasks that the agent executes with full capabilities
- Forge issue comments, PR reviews, or other events
- Exfiltrate data via crafted task descriptions