### PR TITLE
fix(security): add file send allowlist to Telegram bridge

### DIFF
--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -48,6 +48,10 @@ def _is_path_sendable(fpath: str) -> bool:
         if real.startswith(prefix):
             return True
     return False
+
+
+# --- Config loading (independent of _is_path_sendable above) ---
+
 try:
     from dotenv import load_dotenv
     load_dotenv(REPO / ".env")

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -14,6 +14,40 @@ import urllib.error
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
+TASKS_DIR = REPO / "tasks"
+RESULTS_DIR = REPO / "results"
+
+# Allowlist for paths that may be sent via Telegram [file: /path] markers.
+# Mirrors _is_path_sendable() in discord-bridge.py.
+SEND_ALLOWED_ROOTS = (
+    str(REPO / "results"),
+    str(REPO / "notes"),
+    str(REPO / "docs"),
+)
+SEND_ALLOWED_PREFIXES = (
+    "/tmp/sutando-",
+    "/private/tmp/sutando-",
+    "/tmp/echo-",
+    "/private/tmp/echo-",
+)
+
+
+def _is_path_sendable(fpath: str) -> bool:
+    """True iff `fpath` is a real file AND resolves under an allowed root."""
+    if not os.path.isfile(fpath):
+        return False
+    try:
+        real = os.path.realpath(fpath)
+    except OSError:
+        return False
+    for root in SEND_ALLOWED_ROOTS:
+        root_real = os.path.realpath(root)
+        if real == root_real or real.startswith(root_real + os.sep):
+            return True
+    for prefix in SEND_ALLOWED_PREFIXES:
+        if real.startswith(prefix):
+            return True
+    return False
 try:
     from dotenv import load_dotenv
     load_dotenv(REPO / ".env")
@@ -198,12 +232,15 @@ def send_reply(chat_id, text):
         for i in range(0, len(clean_text), 4000):
             api("sendMessage", chat_id=chat_id, text=clean_text[i:i+4000])
 
-    # Send files
+    # Send files (allowlist-gated; see _is_path_sendable)
     for fpath in files:
         fpath = fpath.strip()
-        if os.path.isfile(fpath):
+        if _is_path_sendable(fpath):
             send_file(chat_id, fpath)
             print(f"  Sent file: {fpath}")
+        elif os.path.isfile(fpath):
+            api("sendMessage", chat_id=chat_id, text=f"(file access denied: {fpath})")
+            print(f"  BLOCKED file: {fpath}")
         else:
             api("sendMessage", chat_id=chat_id, text=f"(file not found: {fpath})")
 


### PR DESCRIPTION
## Summary

The Discord bridge has `_is_path_sendable()` — an allowlist that prevents arbitrary file exfiltration via `[file: /path]` markers in agent output. The Telegram bridge has **no such check** — it will send any file referenced in result text.

If the core agent produces a response containing `[file: /etc/shadow]` or `[file: ~/.ssh/id_rsa]`, the Telegram bridge sends it without question.

## Fix

Port `_is_path_sendable()` from `discord-bridge.py` to `telegram-bridge.py`:

- Same allowlist: `results/`, `notes/`, `docs/` under the repo, plus `/tmp/sutando-*` and `/tmp/echo-*` prefixes
- `os.path.realpath()` to collapse symlinks and `..` traversal
- Denied files get a `"(file access denied: /path)"` message instead of the file contents

## Testing

```python
# Files under repo/results/ → allowed
assert _is_path_sendable("/path/to/sutando/results/task-1.txt")

# Arbitrary paths → denied
assert not _is_path_sendable("/etc/passwd")
assert not _is_path_sendable("/etc/shadow")
assert not _is_path_sendable("~/.ssh/id_rsa")

# Symlink escape → denied (realpath check)
assert not _is_path_sendable("/path/to/sutando/results/../../etc/passwd")
```

## Impact

Without this fix, a malicious or compromised agent output can exfiltrate any readable file on the system via Telegram.