### PR TITLE
fix(slide-control): URL match localhost:7877 + visual-position addressing

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -434,20 +434,24 @@ export const slideControlTool: ToolDefinition = {
 	async execute(args) {
 		const { action, slideNumber } = args as { action: 'next' | 'previous' | 'goto'; slideNumber?: number };
 		try {
-			// All slide navigation uses DOM manipulation for reliability
+			// All slide navigation uses DOM manipulation for reliability.
+			// IMPORTANT: address slides by VISUAL POSITION (1-indexed) — querySelectorAll('.slide')[N-1] —
+			// NOT by id="s"+N. The deck's slide IDs are non-contiguous (s1, s1b, s2, s2b, s3, s4, s5, s6,
+			// s65, s7, s8 — 11 slides where the visual-7th is s5, not s7). Using id="s"+N silently misroutes
+			// every "go to slide N" cue once any inter-slide (s1b/s2b/s65) is present.
 			let js: string;
 			if (action === 'goto' && slideNumber) {
-				js = `var ss=document.querySelectorAll(\\".slide\\");for(var j=0;j<ss.length;j++){ss[j].classList.remove(\\"active\\")};document.getElementById(\\"s${slideNumber}\\").classList.add(\\"active\\");document.getElementById(\\"cur\\").textContent=\\"${slideNumber}\\"`;
+				js = `var ss=document.querySelectorAll(\\".slide\\");for(var j=0;j<ss.length;j++){ss[j].classList.remove(\\"active\\")};var idx=${slideNumber}-1;if(idx>=0&&idx<ss.length){ss[idx].classList.add(\\"active\\");document.getElementById(\\"cur\\").textContent=String(${slideNumber})}`;
 			} else {
-				// next/previous: read current slide number, compute target, set it
+				// next/previous: read current slide number, compute target visual position, set it.
 				const dir = action === 'next' ? 1 : -1;
-				js = `var cur=parseInt(document.getElementById(\\"cur\\").textContent)||1;var total=document.querySelectorAll(\\".slide\\").length;var next=((cur-1+${dir}+total)%total)+1;var ss=document.querySelectorAll(\\".slide\\");for(var j=0;j<ss.length;j++){ss[j].classList.remove(\\"active\\")};document.getElementById(\\"s\\"+next).classList.add(\\"active\\");document.getElementById(\\"cur\\").textContent=String(next)`;
+				js = `var cur=parseInt(document.getElementById(\\"cur\\").textContent)||1;var ss=document.querySelectorAll(\\".slide\\");var total=ss.length;var next=((cur-1+${dir}+total)%total)+1;for(var j=0;j<ss.length;j++){ss[j].classList.remove(\\"active\\")};ss[next-1].classList.add(\\"active\\");document.getElementById(\\"cur\\").textContent=String(next)`;
 			}
 			const script = `tell application "Google Chrome"
 	repeat with w in windows
 		set tabList to tabs of w
 		repeat with i from 1 to count of tabList
-			if URL of item i of tabList contains "index-sutando" or URL of item i of tabList contains "localhost:8888" then
+			if URL of item i of tabList contains "index-sutando" or URL of item i of tabList contains "localhost:8888" or URL of item i of tabList contains "localhost:7877" or URL of item i of tabList contains "iclr-slides" then
 				tell item i of tabList to execute javascript "${js}"
 				return "done"
 			end if


### PR DESCRIPTION
## Summary

Two bugs Chi reported in voice slide-navigation during talk-prep:

### Bug 1: prev/next voice cmd doesn't work

URL matcher only knew `index-sutando` / `localhost:8888`. Chi's deck is now served at `localhost:7877/slides`. The osascript repeat loop walked all tabs without matching, the inner `tell ... execute javascript` never fired, and the tool returned `{status: 'done'}` falsely. Same gap class as PR #542's fullscreen-tool fix earlier today.

**Fix:** added `localhost:7877` + `iclr-slides` to the OR chain.

### Bug 2: \"Go to slide 7\" lands on the wrong slide

The JS used `document.getElementById(\"s\" + N)` to find the Nth slide, assuming contiguous integer IDs. The deck's actual ids are non-contiguous:

\`\`\`
s1, s1b, s2, s2b, s3, s4, s5, s6, s65, s7, s8
\`\`\`

11 slides where the **visual-7th is `s5`, not `s7`**. So Chi's \"go to slide 7\" silently mis-navigated to S7-the-id (visual position 10) instead of S5 (visual position 7).

**Fix:** address by visual position via `querySelectorAll('.slide')[N-1]` instead of `getElementById('s' + N)`. Both `goto` and `next/previous` branches updated. prev/next math unchanged (still on `cur` text + total count), only the element selector changed.

## Verification

- DOM trace: `curl http://localhost:7877/slides | grep 'id=\"s'` — confirmed the 11 non-contiguous ids.
- Reload-test: `goto 7` should land on S5 visually after merge.

## Test plan

- [ ] Voice cue \"go to slide 7\" → visual S5 highlighted (was: S7).
- [ ] \"next slide\" / \"previous slide\" voice cues fire (was: silent no-op).
- [ ] Voice-agent restart needed after merge — `bash scripts/restart-voice-agent.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)