### PR TITLE
fix(open-file): move out of recording-tools, fully decouple

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -458,7 +458,6 @@ export const clickTool: ToolDefinition = {
 // Re-export recording/video tools from recording-tools
 export {
 	scrollAndDescribeTool,
-	openFileTool,
 	playVideoTool,
 	resumeVideoTool,
 	replayVideoTool,

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -5,8 +5,8 @@
  * Add new tools here and they auto-appear in both voice and phone agents.
  */
 
-import { execSync } from 'node:child_process';
-import { writeFileSync, unlinkSync, readdirSync, readFileSync, existsSync } from 'node:fs';
+import { execSync, execFileSync } from 'node:child_process';
+import { writeFileSync, unlinkSync, readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
@@ -14,8 +14,48 @@ import type { ToolDefinition } from 'bodhi-realtime-agent';
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 
 // Re-export recording/screen/browser tools from browser-tools
-export { describeScreenTool, clickTool, scrollAndDescribeTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool } from './browser-tools.js';
-import { describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool } from './browser-tools.js';
+export { describeScreenTool, clickTool, scrollAndDescribeTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool } from './browser-tools.js';
+import { describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool } from './browser-tools.js';
+
+// --- File-open tool (moved out of recording-tools as part of recording decoupling) ---
+
+export const openFileTool: ToolDefinition = {
+	name: 'open_file',
+	description:
+		'Open a file with the default macOS app. ALWAYS pass an absolute `path`. ' +
+		'Use for: "open the file", "open that", "can you open it". ' +
+		'If the user says "open the log" or similar, ASK which log they mean (voice-agent, discord-bridge, etc.) — do NOT guess. ' +
+		'Known files: "diagnostic tracker" or "diagnostics" = /tmp/phone-diagnostics-tracker.html, ' +
+		'"voice diagnostics" = /tmp/voice-diagnostics-tracker.html.',
+	parameters: z.object({
+		path: z.string().describe('Absolute file path to open.'),
+	}),
+	execution: 'inline',
+	async execute(args) {
+		const { path } = args as { path: string };
+		console.log(`${ts()} [OpenFile] called (path=${path || 'none'})`);
+		try {
+			if (!path) return { error: 'No path provided. Pass an absolute file path.' };
+			const filePath = path.replace(/^~/, process.env.HOME || '');
+			if (!existsSync(filePath)) {
+				console.log(`${ts()} [OpenFile] path "${filePath}" does not exist`);
+				return { error: `File not found: ${filePath}.` };
+			}
+			// execFileSync — no shell interpolation of caller-controlled filePath
+			// (same CodeQL js/command-line-injection class as #27).
+			execFileSync('open', [filePath], { timeout: 5_000 });
+			const size = statSync(filePath).size;
+			console.log(`${ts()} [OpenFile] opened ${filePath} (${(size / 1024 / 1024).toFixed(1)}MB)`);
+			return {
+				status: 'opened',
+				path: filePath,
+				size_mb: +(size / 1024 / 1024).toFixed(1),
+			};
+		} catch (err) {
+			return { error: `open_file failed: ${err instanceof Error ? err.message : err}` };
+		}
+	},
+};
 
 // Re-export meeting tools from meeting-tools
 export { summonTool, dismissTool, joinZoomTool, joinGmeetTool, lookupMeetingIdTool, callContactTool } from './meeting-tools.js';

--- a/src/recording-tools.ts
+++ b/src/recording-tools.ts
@@ -446,76 +446,7 @@ export const scrollAndDescribeTool: ToolDefinition = {
 	},
 };
 
-// Video playback tools — split from a single polymorphic playRecordingTool into 6
-// single-purpose tools. Gemini selects more reliably with narrow descriptions than
-// with one tool that has an "action" enum. The old tool caused persistent confusion
-// between "open" and "play" (42% of calls in diagnostics had wrong action selection).
-export const openFileTool: ToolDefinition = {
-	name: 'open_file',
-	description:
-		'Open a file with the default macOS app. ALWAYS pass a `path` — get it from the recording tool\'s return value or ask the user. ' +
-		'Use for: "open the video/recording", "open the file", "open that", "can you open it". ' +
-		'If the user says "open the log" or similar, ASK which log they mean (voice-agent, discord-bridge, etc.) — do NOT default to a recording. ' +
-		'Do NOT call play_video after this — wait for user to explicitly say "play". ' +
-		'Known files: "diagnostic tracker" or "diagnostics" = /tmp/phone-diagnostics-tracker.html, ' +
-		'"voice diagnostics" = /tmp/voice-diagnostics-tracker.html. ' +
-		'If you need to find the latest recording but lost the path, pass find_recording=true.',
-	parameters: z.object({
-		path: z.string().optional().describe('File path to open. Get this from the recording tool result. Use known file aliases for diagnostic tracker etc.'),
-		find_recording: z.boolean().optional().describe('If true and no path given, find and open the latest screen recording. Only use as a fallback when you lost the recording path.'),
-	}),
-	execution: 'inline',
-	async execute(args) {
-		const { path: filePath, find_recording } = args as { path?: string; find_recording?: boolean };
-		console.log(`${ts()} [OpenFile] called (path=${filePath || 'none'}, find_latest=${find_recording || false})`);
-		demoStateRef.value = 'idle';
-		try {
-			let recPath = filePath ? filePath.replace(/^~/, process.env.HOME || '') : null;
-			if (recPath && !existsSync(recPath)) {
-				console.log(`${ts()} [OpenFile] path "${recPath}" does not exist`);
-				return { error: `File not found: ${recPath}. Ask the user for the correct path or use "work" to locate it.` };
-			}
-			// Only find latest recording if explicitly requested — not as a silent default.
-			// The recording tool should have already told you the path.
-			if (!recPath && find_recording) {
-				recPath = findRecording();
-			}
-			if (!recPath) {
-				return { error: 'No path provided. Pass the file path from the recording tool result, or set find_recording=true to search.' };
-			}
-			if (!isReadableFile(recPath)) {
-				return { error: `File not readable or too small: ${recPath}. It may still be writing — try again in a few seconds.` };
-			}
-			if (recPath.includes('sutando-recording')) {
-				writeFileSync('/tmp/sutando-playback-path', recPath);
-			}
-			// execFileSync — no shell interpolation of caller-controlled recPath
-			// (same CodeQL js/command-line-injection class as #27).
-			execFileSync('open', [recPath], { timeout: 5_000 });
-			try { execSync(`osascript -e 'tell application "QuickTime Player" to activate'`, { timeout: 3_000 }); } catch {}
-			const size = statSync(recPath).size;
-			let duration_seconds: number | null = null;
-			try {
-				const dur = execFileSync(
-					'/opt/homebrew/bin/ffprobe',
-					['-v', 'error', '-show_entries', 'format=duration', '-of', 'csv=p=0', recPath],
-					{ timeout: 5_000 }
-				).toString().trim();
-				duration_seconds = Math.round(parseFloat(dur));
-			} catch {}
-			console.log(`${ts()} [OpenFile] opened ${recPath} (${(size / 1024 / 1024).toFixed(1)}MB, ${duration_seconds ?? '?'}s)`);
-			return {
-				status: 'opened',
-				path: recPath,
-				size_mb: +(size / 1024 / 1024).toFixed(1),
-				duration_seconds,
-				instruction: 'File opened. When user says play, call play_video.',
-			};
-		} catch (err) {
-			return { error: `open_file failed: ${err instanceof Error ? err.message : err}` };
-		}
-	},
-};
+// openFileTool moved to ./inline-tools.ts — generic file open is not recording-specific.
 
 /** Helper: start QuickTime playback + stream audio to phone */
 async function startPlayback(seekSec: number = 0): Promise<{ status: string; path?: string; error?: string; instruction?: string }> {
@@ -715,9 +646,17 @@ export const screenRecordTool: ToolDefinition = {
 					try {
 						const stopResult = execSync('python3 skills/screen-record/scripts/record.py stop', { timeout: 10_000 }).toString().trim();
 						const stopParsed = JSON.parse(stopResult);
-						if (liveTranscriptRecordingStart > 0 && stopParsed.path && stopParsed.exists) {
+						if (stopParsed.path && stopParsed.exists) {
 							const narrated = stopParsed.path.replace('.mov', '-narrated.mov');
-							burnLiveTranscriptSubtitles(isReadableFile(narrated) ? narrated : stopParsed.path);
+							const burnedSubtitled = liveTranscriptRecordingStart > 0
+								? burnLiveTranscriptSubtitles(isReadableFile(narrated) ? narrated : stopParsed.path)
+								: null;
+							// Persist playback-path so play_video can find this recording after auto-stop,
+							// without depending on open_file (which is now generic / not recording-specific).
+							const recommended = burnedSubtitled || (isReadableFile(narrated) ? narrated : stopParsed.path);
+							if (recommended) {
+								try { writeFileSync('/tmp/sutando-playback-path', recommended); } catch {}
+							}
 						}
 					} catch {}
 					demoStateRef.value = 'done';
@@ -731,6 +670,7 @@ export const screenRecordTool: ToolDefinition = {
 				// Build explicit file list so the model knows exactly what's available.
 				// The model should pass the recommended path to open_file — no findRecording guessing.
 				const files: { raw?: string; narrated?: string; subtitled?: string; recommended?: string } = {};
+				let duration_seconds: number | null = null;
 				if (parsed.path && parsed.exists) {
 					files.raw = parsed.path;
 					const narrated = parsed.path.replace('.mov', '-narrated.mov');
@@ -745,14 +685,31 @@ export const screenRecordTool: ToolDefinition = {
 					}
 					// Recommend best available: subtitled > narrated > raw
 					files.recommended = files.subtitled || files.narrated || files.raw;
+					// Persist playback-path so play_video knows what to play after the model
+					// calls open_file. Used to live in openFileTool; moved here so open_file can
+					// stay generic / decoupled from recording.
+					if (files.recommended) {
+						try { writeFileSync('/tmp/sutando-playback-path', files.recommended); } catch {}
+					}
+					// Probe duration once, here, so we can report it back to the model and
+					// avoid repeating the ffprobe call in open_file (which is now generic).
+					try {
+						const dur = execFileSync(
+							'/opt/homebrew/bin/ffprobe',
+							['-v', 'error', '-show_entries', 'format=duration', '-of', 'csv=p=0', files.recommended!],
+							{ timeout: 5_000 }
+						).toString().trim();
+						duration_seconds = Math.round(parseFloat(dur));
+					} catch {}
 				}
 				liveTranscriptRecordingStart = 0;
-				console.log(`${ts()} [ScreenRecord] ${action}: ${JSON.stringify({ ...parsed, files })}`);
+				console.log(`${ts()} [ScreenRecord] ${action}: ${JSON.stringify({ ...parsed, files, duration_seconds })}`);
 				return {
 					...parsed,
 					files,
+					duration_seconds,
 					instruction: files.recommended
-						? `Recording stopped. Available files: ${Object.entries(files).map(([k,v]) => `${k}=${v}`).join(', ')}. To open, call open_file with path="${files.recommended}". If user wants a different version, use the appropriate path from the list.`
+						? `Recording stopped (${duration_seconds ?? '?'}s). Available files: ${Object.entries(files).map(([k,v]) => `${k}=${v}`).join(', ')}. To open, call open_file with path="${files.recommended}". If user wants a different version, use the appropriate path from the list. When user says play, call play_video.`
 						: 'Recording stopped but no files found.',
 				};
 			}


### PR DESCRIPTION
## Summary

`openFileTool` has lived in `src/recording-tools.ts` since #274 with recording-flavored helpers baked into the function body. Prior fixes adjusted *behavior* but never *location* — and with the function sitting next to recording state, every new recording-demo bug had natural pull to drop more recording logic on top of `open_file`. This is the structural fix.

## What changed

**Moved `openFileTool` to `src/inline-tools.ts`** — generic body, only accepts `path`, calls `open <path>`, returns `{status, path, size_mb}`. No recording references.

**Re-export chain fixed across the four tool files:**
- `inline-tools.ts` — dropped `openFileTool` from the line-17 re-export-from-`browser-tools` and line-18 import; now defined locally.
- `browser-tools.ts` — dropped `openFileTool` from the recording-tools re-export block.
- `recording-tools.ts` — dropped the definition + the misleading "polymorphic playRecordingTool" comment block above it. One-line marker pointing to the new location.
- `meeting-tools.ts` — never imported it; verified.

**Recording-related work relocated to functions that already needed it:**

| Old `openFileTool` behavior | New owner |
|---|---|
| `findRecording()` fallback when path lost | `startPlayback()` (line 455) and `playVideoTool` already had it |
| Read `/tmp/sutando-playback-path` | `startPlayback()` already does (line 454) |
| Activate QuickTime Player after open | `startPlayback()` already does (line 478) |
| Eager **write** to `/tmp/sutando-playback-path` for `sutando-recording-*` paths | **Moved** to `screenRecordTool` stop handler + auto-stop `setTimeout` callback. Recording tool now stamps the playback hint itself; no model courier through `open_file` needed. |
| ffprobe duration extraction | **Moved** to `screenRecordTool` stop result (`duration_seconds` field). |
| `instruction: "When user says play, call play_video"` | **Folded** into `screen_record` stop instruction string. |
| `demoStateRef.value = 'idle'` reset on file-open | **Removed** — `screenRecordTool` already manages demo state on start (line 633) and stop (line 660). |

## Why prior PRs didn't fix this

| PR | Title | Outcome |
|---|---|---|
| #274 | *Refactor: split inline tools into 4 focused modules* | Filed `openFileTool` under `recording-tools.ts` based on its-then-current "open the recording" coupling. Structural mistake. |
| #315 | *generalize open_video → open_file with reliability improvements* | Generalized the API; kept the location and the recording-flavored defaults. |
| `cbdeaa4` | *Fix open_file: error on missing path instead of fallback to recording* | Fixed the silent fallback; left the recording-flavored params and helpers in place. |
| #353 | *open_file: return immediately with best-available recording* | **Re-coupled.** Re-introduced the find-latest-recording fallback under demo pressure. |
| #392 | *refactor: decouple open_file from recording logic* | The most ambitious decouple. Made `find_recording` opt-in instead of silent — but its own commit message states: *"Kept: known file aliases, QuickTime activation, playback-path write, duration/size metadata."* The recording-flavored helpers stayed. |
| #408 | *use execFileSync for ffmpeg/open/ffprobe in subtitle burn + open_file* | Security hardening (CodeQL #27 class). Reinforced the "this lives with recording" mental model. |
| #516 / #520 / #524 / #526 | fullscreen + QuickTime-state fixes | Each fix accumulated more video/QuickTime branching inside the function — pure cruft from a generic-file-open POV. |

I scanned all 35 refs (every local branch + every remote-tracking ref + tags) and every commit that has ever modified `openFileTool`. **At every single one**, the function body contained at least the markers `findRecording`, `sutando-recording`, `sutando-playback-path`, `demoStateRef`, `ffprobe`, `QuickTime …activate`. This commit is the first time the body goes recording-clean.

## README demo flow preserved

`screen_record → open_file(path) → play_video` continues to work end-to-end with no model-side change:

1. `screen_record stop` (or auto-stop) returns the file list AND now writes `/tmp/sutando-playback-path` AND reports `duration_seconds`.
2. `open_file(path)` — `open <path>` routes `.mov` to QuickTime as before.
3. `play_video` — reads `/tmp/sutando-playback-path` (still there), falls back to `findRecording()` if missing, activates QuickTime, plays. **No code change in `playVideoTool` / `startPlayback`.**

## Test plan

- [x] `npx tsc --noEmit` exit=0
- [x] `grep -rn "openFileTool" src/` shows definition only in `inline-tools.ts:22`; references at lines 637/654 resolve to the local symbol.
- [x] No grep hits for any of the 6 recording markers in `inline-tools.ts` `openFileTool`.
- [ ] Manual smoke test of the demo flow on a fresh recording — owner to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)