### PR TITLE
feat(voice-agent): dynamic voice-context loader via private-dir pointer

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -400,7 +400,7 @@ async def _handle_discord_message(message, force=False):
                 # channel set to `true` — open to all, skip access check
                 channel_authorized = True
             elif len(ch_allowed) > 0 and sender_id not in ch_allowed:
-                print(f"  [skip] @{username} not in channel allowlist", flush=True)
+                print(f"  [skip] @{username} (id={sender_id}) not in channel allowlist", flush=True)
                 return
             else:
                 # sender is in ch_allowed (or ch_allowed is empty + requireMention)

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -513,7 +513,11 @@ const mainAgent: MainAgent = {
 					const root = privateRoot.replace(/^~/, process.env.HOME || '');
 					const pointerPath = join(root, 'voice-contexts', 'active');
 					const name = readFileSync(pointerPath, 'utf-8').trim();
-					if (name) {
+					// Whitelist the pointer content to a safe basename. Reject any
+					// path-like input — `../../foo` could otherwise escape the
+					// voice-contexts/ dir via join() and load arbitrary `.txt`
+					// content into the system prompt.
+					if (name && /^[A-Za-z0-9._-]+$/.test(name)) {
 						return readFileSync(join(root, 'voice-contexts', `${name}.txt`), 'utf-8');
 					}
 				}

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -501,7 +501,25 @@ const mainAgent: MainAgent = {
 		'Every Sutando evolves differently based on what its user needs. You earned your name and identity.',
 		(() => { try { const si = JSON.parse(readFileSync('stand-identity.json', 'utf-8')); return si.name ? `Your Stand name is ${si.name}. Origin: ${si.nameOrigin || 'earned through use'}. When asked your name or who you are, say "I\'m Sutando — ${si.name}."` : ''; } catch { return ''; } })(),
 		// Optional context file — for presentations, meeting prep, etc. (gitignored)
-		(() => { try { return readFileSync('voice-context.txt', 'utf-8'); } catch { return ''; } })(),
+		// Reads $SUTANDO_PRIVATE_DIR/voice-contexts/<active>.txt where <active> is
+		// the trimmed contents of $SUTANDO_PRIVATE_DIR/voice-contexts/active.
+		// Falls back to public-repo voice-context.txt when the env var is unset
+		// or the pointer/file is missing. Switcher tool: set_voice_context(name)
+		// from skills/personal-voice-context/ writes the pointer.
+		(() => {
+			try {
+				const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+				if (privateRoot) {
+					const root = privateRoot.replace(/^~/, process.env.HOME || '');
+					const pointerPath = join(root, 'voice-contexts', 'active');
+					const name = readFileSync(pointerPath, 'utf-8').trim();
+					if (name) {
+						return readFileSync(join(root, 'voice-contexts', `${name}.txt`), 'utf-8');
+					}
+				}
+			} catch {}
+			try { return readFileSync('voice-context.txt', 'utf-8'); } catch { return ''; }
+		})(),
 		'You handle anything: research, writing, email, scheduling, code, logistics, phone calls, meetings, creative work.',
 		'You can join Google Meet and Zoom meetings, make phone calls, see the user\'s screen, and reach them on Telegram, Discord, web, or phone.',
 		'You can summon a Zoom meeting with screen sharing so the user can work remotely from their phone.',


### PR DESCRIPTION
## Summary

- `src/voice-agent.ts:501` — replace the static `readFileSync('voice-context.txt')` with a dynamic loader: read `$SUTANDO_PRIVATE_DIR/voice-contexts/<active>.txt` where `<active>` is the trimmed contents of `voice-contexts/active`. Falls back to public-repo `voice-context.txt` when the env var is unset or the pointer/file is missing.
- `src/discord-bridge.py:403` — include `sender_id` in the channel-allowlist-skip log so we can capture new-collaborator user IDs without tracing through Discord's UI (used last night to capture qingyunwu's ID for the AG2 form brainstorm channel).

## Why

Lets one Sutando carry many talk-specific contexts (iclr, lf-ai, future talks) without juggling files in the public workspace. The personal `set_voice_context(name)` skill (private repo) writes the pointer; the launchd plist's `WatchPaths` includes the pointer + voice-contexts dir, so any switch or content edit auto-restarts the voice-agent and a fresh WS connect picks up the new context.

Migration #3 from `notes/migration-private-repo-2026-04-26.md`.

## Test plan

- [x] Validated on the LF AI talk on 2026-04-29 — voice-agent loaded `lf-ai.txt` correctly via the pointer; multiple iterations of the context (Q1d-bridge addition) auto-reloaded without manual restart.
- [x] Fallback path verified — when `SUTANDO_PRIVATE_DIR` is unset, behaviour reverts to old `voice-context.txt` read.
- [x] Discord-bridge sender_id log verified during talk-prep collaboration setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)