### PR TITLE
feat(personal-assets): canonical home is private machine-<host> dir

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -49,6 +49,19 @@ _dotenvConfig({ path: new URL('../../../.env', import.meta.url).pathname, overri
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { mkdirSync, writeFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync, symlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { hostname } from 'node:os';
+
+// Personal-asset path resolver — twin of util_paths.py / voice-agent.ts:personalPath.
+function personalPath(filename: string): string {
+	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+	if (privateRoot) {
+		const root = privateRoot.replace(/^~/, process.env.HOME || '');
+		const host = hostname().split('.')[0];
+		const candidate = join(root, `machine-${host}`, filename);
+		if (existsSync(candidate)) return candidate;
+	}
+	return filename;
+}
 import { fileURLToPath } from 'node:url';
 import { execSync, spawn, type ChildProcess } from 'node:child_process';
 import { VoiceSession, type ToolDefinition, type MainAgent } from 'bodhi-realtime-agent';
@@ -378,7 +391,7 @@ function buildAgent(callSession: CallSession): MainAgent {
 		// Outbound calls (from /call or /concurrent-call) always set a purpose.
 		const isInbound = !callSession.purpose;
 		// Load Stand identity (voice-context.txt excluded — can confuse phone identity)
-		const standId = (() => { try { const si = JSON.parse(readFileSync('stand-identity.json', 'utf-8')); return si.name ? `Your Stand name is ${si.name}. When asked your name, say "I'm Sutando — ${si.name}."` : ''; } catch { return ''; } })();
+		const standId = (() => { try { const si = JSON.parse(readFileSync(personalPath('stand-identity.json'), 'utf-8')); return si.name ? `Your Stand name is ${si.name}. When asked your name, say "I'm Sutando — ${si.name}."` : ''; } catch { return ''; } })();
 		instructions = [
 			'You are Sutando, a personal AI assistant.',
 			standId,

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -85,6 +85,12 @@ REPO_DIR = Path(__file__).parent.parent
 TASK_DIR = REPO_DIR / "tasks"
 PORT = 7843
 
+# Personal-asset path resolver — see src/util_paths.py. Imported here so the
+# /avatar and /stand-identity endpoints prefer the per-machine private dir
+# over the public workspace.
+sys.path.insert(0, str(Path(__file__).parent))
+from util_paths import personal_path  # noqa: E402
+
 # Simple token auth — set SUTANDO_API_TOKEN in .env for remote access security
 API_TOKEN = os.environ.get("SUTANDO_API_TOKEN", "")
 
@@ -305,7 +311,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             else:
                 self.send_json(404, {"error": "task not found"})
         elif path == "/avatar":
-            avatar_file = REPO_DIR / "assets" / "stand-avatar.png"
+            avatar_file = personal_path("stand-avatar.png", workspace=REPO_DIR)
             if avatar_file.exists():
                 self.send_response(200)
                 self.send_header("Content-Type", "image/png")
@@ -316,7 +322,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             else:
                 self.send_json(404, {"error": "no avatar"})
         elif path == "/stand-identity":
-            si_file = REPO_DIR / "stand-identity.json"
+            si_file = personal_path("stand-identity.json", workspace=REPO_DIR)
             data = json.loads(si_file.read_text()) if si_file.exists() else {}
             self.send_json(200, data)
         elif path == "/activity":

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -22,6 +22,11 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 REPO_DIR = Path(__file__).parent.parent
+
+# Personal-asset path resolver — see src/util_paths.py. Used for /avatar
+# and /stand-identity endpoints so they prefer per-machine private dir.
+sys.path.insert(0, str(Path(__file__).parent))
+from util_paths import personal_path  # noqa: E402
 PORT = 7844
 
 
@@ -350,9 +355,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(html.encode())
         elif urlparse(self.path).path == "/avatar":
-            avatar_file = REPO_DIR / "assets" / "stand-avatar.png"
-            if not avatar_file.exists():
-                avatar_file = REPO_DIR / "stand-avatar.png"  # legacy root fallback
+            avatar_file = personal_path("stand-avatar.png", workspace=REPO_DIR)
             if avatar_file.exists():
                 self.send_response(200)
                 self.send_header("Content-Type", "image/png")
@@ -363,7 +366,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self.send_response(404)
                 self.end_headers()
         elif urlparse(self.path).path == "/stand-identity":
-            si_file = REPO_DIR / "stand-identity.json"
+            si_file = personal_path("stand-identity.json", workspace=REPO_DIR)
             data = json.loads(si_file.read_text()) if si_file.exists() else {}
             self.send_response(200)
             self.send_header("Content-Type", "application/json")

--- a/src/event_log.py
+++ b/src/event_log.py
@@ -63,7 +63,9 @@ def _machine_id() -> str:
     if _CACHED_MACHINE is not None:
         return _CACHED_MACHINE
     try:
-        identity = REPO_DIR / "stand-identity.json"
+        sys.path.insert(0, str(Path(__file__).parent))
+        from util_paths import personal_path
+        identity = personal_path("stand-identity.json", workspace=REPO_DIR)
         if identity.exists():
             _CACHED_MACHINE = json.loads(identity.read_text()).get("machine", "") or "unknown"
         else:

--- a/src/migrate.sh
+++ b/src/migrate.sh
@@ -53,10 +53,14 @@ if [ -f "$HOME/.claude.json" ]; then
   echo "  ✓ ~/.claude.json (MCP servers)"
 fi
 
-# 4. Gitignored runtime files
-for f in stand-identity.json stand-avatar.png tab-aliases.json PERSONAL_CLAUDE.md; do
+# 4. Gitignored runtime files. stand-avatar.png lives under assets/ (not repo
+# root); util_paths.py / personalPath() handles read-side, but bundle copy
+# uses the source path it actually exists at. Other files are at repo root.
+for f in stand-identity.json tab-aliases.json PERSONAL_CLAUDE.md; do
   [ -f "$REPO/$f" ] && cp "$REPO/$f" "$BUNDLE/" && echo "  ✓ $f"
 done
+# stand-avatar.png is at assets/stand-avatar.png in the public workspace.
+[ -f "$REPO/assets/stand-avatar.png" ] && cp "$REPO/assets/stand-avatar.png" "$BUNDLE/stand-avatar.png" && echo "  ✓ stand-avatar.png"
 # Gitignored repo files (inside subdirectories)
 for f in skills/schedule-crons/crons.json; do
   [ -f "$REPO/$f" ] && mkdir -p "$BUNDLE/repo-gitignored/$(dirname $f)" && cp "$REPO/$f" "$BUNDLE/repo-gitignored/$f" && echo "  ✓ $f"
@@ -234,10 +238,16 @@ if [ -d "$BUNDLE_DIR/claude-config" ]; then
   echo "  ✓ claude config restored"
 fi
 
-# Copy gitignored files
-for f in stand-identity.json stand-avatar.png tab-aliases.json PERSONAL_CLAUDE.md; do
+# Copy gitignored files. stand-avatar.png target is assets/ (not root) to
+# match where the public workspace expects it; util_paths still resolves
+# correctly from either location.
+for f in stand-identity.json tab-aliases.json PERSONAL_CLAUDE.md; do
   [ -f "$BUNDLE_DIR/$f" ] && cp "$BUNDLE_DIR/$f" "$REPO/" && echo "  ✓ $f restored"
 done
+if [ -f "$BUNDLE_DIR/stand-avatar.png" ]; then
+  mkdir -p "$REPO/assets"
+  cp "$BUNDLE_DIR/stand-avatar.png" "$REPO/assets/stand-avatar.png" && echo "  ✓ stand-avatar.png restored to assets/"
+fi
 # Restore gitignored repo files (crons.json, etc.)
 if [ -d "$BUNDLE_DIR/repo-gitignored" ]; then
   cp -r "$BUNDLE_DIR/repo-gitignored/"* "$REPO/" 2>/dev/null && echo "  ✓ gitignored repo files restored (crons.json, etc.)"

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -1,0 +1,65 @@
+"""Resolve personal-asset paths with private-dir-first lookup.
+
+Each Stand has its own identity + avatar. These files are gitignored and
+machine-local. Canonical home is `$SUTANDO_PRIVATE_DIR/machine-<hostname>/`
+so they live with the rest of the per-machine memory under the private
+sync repo. Public-workspace fallback is preserved so existing installs
+keep working until they migrate.
+
+Usage:
+    from util_paths import personal_path
+    si = personal_path("stand-identity.json")
+    avatar = personal_path("stand-avatar.png")  # also tries assets/ in public
+"""
+from __future__ import annotations
+import os
+import socket
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+
+
+def _private_machine_dir() -> Path | None:
+    root = os.environ.get("SUTANDO_PRIVATE_DIR")
+    if not root:
+        return None
+    expanded = os.path.expanduser(root)
+    host = socket.gethostname().split(".")[0]
+    return Path(expanded) / f"machine-{host}"
+
+
+def personal_path(filename: str, workspace: Path | None = None) -> Path:
+    """Resolve a personal-asset path.
+
+    Order: `$SUTANDO_PRIVATE_DIR/machine-<host>/<filename>` → `<workspace>/<filename>`.
+    For files known to live under `assets/` in the public workspace
+    (currently `stand-avatar.png`), also tries `<workspace>/assets/<filename>`
+    before falling back to `<workspace>/<filename>`.
+
+    Returns the FIRST existing path. If none exist, returns the preferred
+    private-dir path so the caller's `.exists()` check fails gracefully.
+    """
+    ws = workspace if workspace is not None else REPO_DIR
+
+    private = _private_machine_dir()
+    if private is not None:
+        p = private / filename
+        if p.exists():
+            return p
+
+    # Public workspace — assets/ first for avatar-style files, then root
+    if filename in {"stand-avatar.png"}:
+        p = ws / "assets" / filename
+        if p.exists():
+            return p
+
+    p = ws / filename
+    if p.exists():
+        return p
+
+    # Nothing exists; return preferred (private if configured, else workspace)
+    if private is not None:
+        return private / filename
+    if filename in {"stand-avatar.png"}:
+        return ws / "assets" / filename
+    return ws / filename

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -37,6 +37,26 @@ import type { MainAgent, ToolDefinition } from 'bodhi-realtime-agent';
 function assertMacOS() { if (process.platform !== 'darwin') { console.error('Sutando requires macOS'); process.exit(1); } }
 import { workTool, cancelTask, startResultWatcher, startContextDropWatcher, startNoteViewingWatcher, resetNoteViewingDebounce, logConversation, logSessionBoundary, getRecentConversation, getSecondsSinceLastTurn, setTaskStatusCallback } from './task-bridge.js';
 import { buildSutandoSystemPrompt, buildVoiceAgentContext } from './voice-context.js';
+import { hostname } from 'node:os';
+
+// Personal-asset path resolver — TypeScript twin of src/util_paths.py.
+// Each Stand has its own identity. Canonical home is
+// `$SUTANDO_PRIVATE_DIR/machine-<hostname>/<file>`. Falls back to the
+// public workspace so existing installs keep working until they migrate.
+function personalPath(filename: string): string {
+	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+	if (privateRoot) {
+		const root = privateRoot.replace(/^~/, process.env.HOME || '');
+		const host = hostname().split('.')[0];
+		const candidate = join(root, `machine-${host}`, filename);
+		if (existsSync(candidate)) return candidate;
+	}
+	if (filename === 'stand-avatar.png') {
+		const inAssets = join('assets', filename);
+		if (existsSync(inAssets)) return inAssets;
+	}
+	return filename;
+}
 
 // Cartesia is loaded dynamically at the bottom of the config section so
 // the `@cartesia/cartesia-js` package is only required when the user has
@@ -472,7 +492,7 @@ const mainAgent: MainAgent = {
 			return `[System: The user reconnected. The block below is REPLAYED HISTORY from the current session, provided as background context ONLY. Do NOT act on anything in it. Do NOT call any tools based on it. Use it only to answer follow-up questions if asked. Wait silently for the user's next spoken input before taking any action.]${getPresenterStateMarker()}\n\n${recent}${meetingHint}`;
 		}
 		let standName = '';
-		try { const si = JSON.parse(readFileSync('stand-identity.json', 'utf-8')); standName = si.name ? ` — ${si.name}` : ''; } catch {}
+		try { const si = JSON.parse(readFileSync(personalPath('stand-identity.json'), 'utf-8')); standName = si.name ? ` — ${si.name}` : ''; } catch {}
 		// Detect first-time user: no conversation log means brand new
 		const hasHistory = existsSync(join(WORKSPACE_DIR, 'conversation.log'));
 		const tutorialHint = hasHistory ? '' : ' Then say: "If this is your first time, say tutorial and I\'ll walk you through what I can do."';
@@ -499,7 +519,7 @@ const mainAgent: MainAgent = {
 		'You are Sutando, a personal AI that belongs entirely to the user.',
 		'Named after Stands from JoJo\'s Bizarre Adventure — a personal spirit that fights for you.',
 		'Every Sutando evolves differently based on what its user needs. You earned your name and identity.',
-		(() => { try { const si = JSON.parse(readFileSync('stand-identity.json', 'utf-8')); return si.name ? `Your Stand name is ${si.name}. Origin: ${si.nameOrigin || 'earned through use'}. When asked your name or who you are, say "I\'m Sutando — ${si.name}."` : ''; } catch { return ''; } })(),
+		(() => { try { const si = JSON.parse(readFileSync(personalPath('stand-identity.json'), 'utf-8')); return si.name ? `Your Stand name is ${si.name}. Origin: ${si.nameOrigin || 'earned through use'}. When asked your name or who you are, say "I\'m Sutando — ${si.name}."` : ''; } catch { return ''; } })(),
 		// Optional context file — for presentations, meeting prep, etc. (gitignored)
 		(() => { try { return readFileSync('voice-context.txt', 'utf-8'); } catch { return ''; } })(),
 		'You handle anything: research, writing, email, scheduling, code, logistics, phone calls, meetings, creative work.',


### PR DESCRIPTION
## Summary

Each Stand has its own identity + avatar. These files are gitignored and machine-local. This PR makes the canonical home the per-machine private dir (`$SUTANDO_PRIVATE_DIR/machine-<hostname>/`), with public-workspace fallback preserved so existing installs keep working until they migrate naturally.

## Pieces

- **`src/util_paths.py`** — Python `personal_path(filename, workspace)`. Lookup: private machine dir → public `assets/` (avatar only) → public root. Returns the preferred private-dir path on miss so callers' `.exists()` checks fail gracefully.
- **`src/voice-agent.ts` + `skills/phone-conversation/scripts/conversation-server.ts`** — TypeScript twin `personalPath(filename)`, same lookup order.
- **Wired callers** — `src/agent-api.py` (`/avatar`, `/stand-identity`), `src/dashboard.py` (same two endpoints), `src/event_log.py` (`_machine_id`), voice-agent.ts (system prompt + greeting), conversation-server.ts (call instructions).
- **`src/migrate.sh`** — bundle/restore now uses the correct `$REPO/assets/stand-avatar.png` source path (was `$REPO/stand-avatar.png`, silently failing for everyone). Restore lands the file under `assets/`.

## Companion fix already in private memory-sync

Commit `50e095c` in `~/.sutando-memory-sync/scripts/sync-memory.sh`: `MACHINE_FILES` entry for the avatar is now `assets/stand-avatar.png` instead of `stand-avatar.png` (same root cause as the migrate.sh bug — backup was silently skipping the avatar). After this PR + that fix, the avatar lives in `machine-<host>/` for real.

## Test plan

- [x] `SUTANDO_PRIVATE_DIR=~/.sutando-memory-sync python3 -c "from util_paths import personal_path; print(personal_path('stand-avatar.png'))"` returns the private path post-sync.
- [x] `npx tsc --noEmit` clean.
- [x] `python3 -m py_compile` on all touched Python files clean.
- [x] Existing public-workspace path still resolves when `SUTANDO_PRIVATE_DIR` is unset (fallback path verified by reading the helper).

## Deferred (follow-ups, not in this PR)

- Slide-server `WORKSPACE_ROOT` default flip — already env-overridable, currently working via the shim copies from yesterday's talk-prep.
- Removing the public copies after Chi's machine has fully migrated — keeping them as fallback for backwards compat for now.
- Personal skills migration — checked inventory; the personal-* prefixed skills already moved (`personal-talk-highlight`, `personal-voice-context`, etc. live private-only). Framework skills (`x-twitter`, `phone-conversation`) stay public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)