### PR TITLE
fix(sutando-app): remove unused dropFile var

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -924,7 +924,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         lastDropTime = now
 
         let timestamp = ISO8601DateFormatter.string(from: Date(), timeZone: .current, formatOptions: [.withFullDate, .withTime, .withSpaceBetweenDateAndTime, .withColonSeparatorInTime])
-        let dropFile = workspace + "/context-drop.txt"
         let logFile = workspace + "/logs/context-drop.log"
         let tasksDir = workspace + "/tasks"
         let epoch = Int(Date().timeIntervalSince1970 * 1000)


### PR DESCRIPTION
## Summary

One-line cleanup. `dropFile` was declared at `main.swift:927` but never used — `swiftc` reported the warning on tonight's rebuild. Pre-existing, not introduced by recent work.

## Test plan

- [x] `swiftc -O ...` compiles cleanly with no warnings
- [ ] After merge: rebuild Sutando.app, verify hotkeys ⌃C/⌃V/⌃M still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)