### PR TITLE
feat(personal-paths): notes/ + per-machine files private-canonical

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -275,7 +275,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             tasks = [{"id": tid, **tdata} for tid, tdata in sorted_tasks]
             # Parse pending questions
             questions = []
-            pq_file = REPO_DIR / "pending-questions.md"
+            pq_file = Path(personal_path("pending-questions.md", REPO_DIR))
             if pq_file.exists():
                 import re
                 content = pq_file.read_text()
@@ -587,7 +587,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 if not qid or not answer:
                     self.send_json(400, {"error": "id and answer required"})
                     return
-                pq_file = REPO_DIR / "pending-questions.md"
+                pq_file = Path(personal_path("pending-questions.md", REPO_DIR))
                 if pq_file.exists():
                     content = pq_file.read_text()
                     # Update status from unanswered to answered

--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -14,8 +14,11 @@ import sys
 import time
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent))
+from util_paths import personal_path  # noqa: E402
+
 WORKSPACE = Path(__file__).parent.parent
-PQ_FILE = WORKSPACE / "pending-questions.md"
+PQ_FILE = Path(personal_path("pending-questions.md", WORKSPACE))
 RESULTS_DIR = WORKSPACE / "results"
 LAST_NOTIFY_FILE = WORKSPACE / ".last-pq-notify"
 VOICE_LOG = WORKSPACE / "logs" / "voice-agent.log"

--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -12,11 +12,14 @@ from collections import Counter, defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent))
+from util_paths import shared_personal_path  # noqa: E402
+
 WORKSPACE = Path(__file__).parent.parent
 CALLS_FILE = WORKSPACE / "results" / "calls" / "calls.jsonl"
 RESULTS_DIR = WORKSPACE / "results"
 STATE_DIR = WORKSPACE / "state"
-NOTES_DIR = WORKSPACE / "notes"
+NOTES_DIR = Path(shared_personal_path("notes", WORKSPACE))
 
 
 def load_calls():

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -26,7 +26,7 @@ REPO_DIR = Path(__file__).parent.parent
 # Personal-asset path resolver — see src/util_paths.py. Used for /avatar
 # and /stand-identity endpoints so they prefer per-machine private dir.
 sys.path.insert(0, str(Path(__file__).parent))
-from util_paths import personal_path  # noqa: E402
+from util_paths import personal_path, shared_personal_path  # noqa: E402
 PORT = 7844
 
 
@@ -45,7 +45,7 @@ def _resolve_note_path(raw_slug: str):
     slug = re.sub(r"[^\w-]", "", raw_slug)
     if not slug or slug != raw_slug:
         return None
-    notes_real = os.path.realpath(REPO_DIR / "notes")
+    notes_real = os.path.realpath(shared_personal_path("notes", REPO_DIR))
     note_file_str = os.path.realpath(os.path.join(notes_real, f"{slug}.md"))
     if not note_file_str.startswith(notes_real + os.sep):
         return None
@@ -97,7 +97,7 @@ def get_activity(max_items: int = 10) -> list[dict]:
 
 
 def get_pending_count() -> dict:
-    pending_file = REPO_DIR / "pending-questions.md"
+    pending_file = Path(personal_path("pending-questions.md", REPO_DIR))
     if not pending_file.exists():
         return {"open": 0, "done": 0}
     content = pending_file.read_text()
@@ -434,7 +434,7 @@ load()
             self.end_headers()
             self.wfile.write(html.encode())
         elif urlparse(self.path).path == "/notes":
-            notes_dir = REPO_DIR / "notes"
+            notes_dir = Path(shared_personal_path("notes", REPO_DIR))
             notes = []
             for f in sorted(notes_dir.glob("*.md"), key=lambda p: p.stat().st_mtime, reverse=True):
                 title = f.stem.replace("-", " ").title()

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -18,6 +18,8 @@ from pathlib import Path
 import discord
 
 REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from util_paths import shared_personal_path  # noqa: E402
 
 # Load token from channels config
 TOKEN = ""
@@ -45,6 +47,10 @@ OWNER_ACTIVITY_FILE = STATE_DIR / "last-owner-activity.json"
 SEND_ALLOWED_ROOTS = (
     str(REPO / "results"),
     str(REPO / "notes"),
+    # Notes canonical home (private dir) — once saved by save_note, paths
+    # reference the private location. Both old and new paths allowed during
+    # the transition; the resolver picks whichever exists.
+    str(shared_personal_path("notes", REPO)),
     str(REPO / "docs"),
     str(Path.home() / "Desktop" / "iclr-backups"),
     str(Path.home() / "Documents" / "sutando-launch-assets"),

--- a/src/friction-detector.py
+++ b/src/friction-detector.py
@@ -18,6 +18,9 @@ import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent))
+from util_paths import personal_path, shared_personal_path  # noqa: E402
+
 WORKSPACE = Path(__file__).parent.parent
 RESULTS_DIR = WORKSPACE / "results"
 
@@ -35,7 +38,7 @@ def check_pending_questions():
     which never matched the actual format, so it always returned an empty
     list and friction-detector silently missed every unanswered question.
     """
-    pq = WORKSPACE / "pending-questions.md"
+    pq = Path(personal_path("pending-questions.md", WORKSPACE))
     if not pq.exists():
         return []
     content = pq.read_text()
@@ -155,7 +158,7 @@ def check_stale_results():
 def check_notes_without_follow_up():
     """Find notes tagged 'action' or 'todo' that are >7 days old."""
     issues = []
-    notes_dir = WORKSPACE / "notes"
+    notes_dir = Path(shared_personal_path("notes", WORKSPACE))
     if not notes_dir.exists():
         return []
     now = datetime.now().timestamp()

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import Optional
 
 REPO_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(Path(__file__).parent))
+from util_paths import shared_personal_path  # noqa: E402
 
 def _default_memory_dir() -> str:
     """Auto-detect Claude Code memory dir from repo path."""
@@ -559,8 +561,8 @@ def run_all_checks() -> list[dict]:
     else:
         checks.append({"name": "memory-dir", "status": "ok", "detail": "not yet created (normal for new installs)"})
 
-    # Notes
-    checks.append(check_directory(REPO_DIR / "notes", "notes-dir"))
+    # Notes — canonical home is shared private dir post-migration
+    checks.append(check_directory(Path(shared_personal_path("notes", REPO_DIR)), "notes-dir"))
 
     # Memory sync
     checks.append(check_memory_sync())

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -518,7 +518,11 @@ return frontApp`;
 
 /** All inline tools — import and spread into your tools list */
 // ─── Notes tools ─────────────────────────────────────────
-const NOTES_DIR = join(process.cwd(), 'notes');
+// Resolve at module-init: $SUTANDO_PRIVATE_DIR/notes (canonical) when set,
+// else cwd/notes (legacy fallback). Notes are SHARED across the fleet so
+// they live at the top-level private dir, not under machine-<host>/.
+import { sharedPersonalPath } from './util_paths.js';
+const NOTES_DIR = sharedPersonalPath('notes', process.cwd());
 
 export const showViewTool: ToolDefinition = {
 	name: 'show_view',

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -33,10 +33,17 @@ TRANSCRIPT="$1"  # Passed by PreCompact hook as $TRANSCRIPT_PATH
   gh pr list --repo sonichi/sutando --state open --limit 5 2>/dev/null || echo "(couldn't fetch)"
   echo ""
 
-  # Pending questions
+  # Pending questions — canonical home is private machine-<host>/ post-migration.
+  # Resolves via util_paths.personal_path() with cwd fallback.
+  PQ_PATH=$(SUTANDO_PRIVATE_DIR="${SUTANDO_PRIVATE_DIR:-}" python3 -c "
+import sys; sys.path.insert(0, '$REPO/src')
+from util_paths import personal_path
+from pathlib import Path
+print(personal_path('pending-questions.md', Path('$REPO')))
+" 2>/dev/null || echo "$REPO/pending-questions.md")
   echo "## Pending Questions"
-  if [ -f "$REPO/pending-questions.md" ]; then
-    grep -A1 "^## Q" "$REPO/pending-questions.md" | head -20
+  if [ -f "$PQ_PATH" ]; then
+    grep -A1 "^## Q" "$PQ_PATH" | head -20
   else
     echo "None"
   fi

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -63,3 +63,34 @@ def personal_path(filename: str, workspace: Path | None = None) -> Path:
     if filename in {"stand-avatar.png"}:
         return ws / "assets" / filename
     return ws / filename
+
+
+def shared_personal_path(filename: str, workspace: Path | None = None) -> Path:
+    """Resolve a shared-private path (notes, build_log, etc.) — files that
+    sync across all of an owner's machines, not per-machine state.
+
+    Order: `$SUTANDO_PRIVATE_DIR/<filename>` (top-level, shared) → `<workspace>/<filename>`.
+
+    Difference vs `personal_path`: this resolves to the top-level private dir,
+    NOT `machine-<host>/`. Use for files like notes/, where every Mac in
+    Chi's fleet should see the same content.
+
+    Returns the FIRST existing path. If none exist, returns the preferred
+    private path so the caller's `.exists()` check fails gracefully.
+    """
+    ws = workspace if workspace is not None else REPO_DIR
+
+    root = os.environ.get("SUTANDO_PRIVATE_DIR")
+    if root:
+        private = Path(os.path.expanduser(root)) / filename
+        if private.exists():
+            return private
+        # Fall back to workspace if private doesn't have it, but remember
+        # the preferred private path for the "nothing exists" branch.
+        p = ws / filename
+        if p.exists():
+            return p
+        return private
+
+    p = ws / filename
+    return p

--- a/src/util_paths.ts
+++ b/src/util_paths.ts
@@ -1,0 +1,65 @@
+// TypeScript twin of src/util_paths.py — personal-asset path resolution.
+//
+// Two helpers, one for per-machine state, one for shared-across-fleet state:
+//
+//   personalPath(filename)          — `$SUTANDO_PRIVATE_DIR/machine-<host>/<filename>`
+//                                     For files where each Mac has its own copy
+//                                     (stand-identity.json, pending-questions.md).
+//
+//   sharedPersonalPath(filename)    — `$SUTANDO_PRIVATE_DIR/<filename>`
+//                                     For files synced across the whole fleet
+//                                     (notes/, build_log.md).
+//
+// Both fall back to `<workspace>/<filename>` so existing installs keep working
+// until they migrate.
+
+import { existsSync } from 'node:fs';
+import { hostname } from 'node:os';
+import { join } from 'node:path';
+
+function expandHome(p: string): string {
+	return p.replace(/^~/, process.env.HOME || '');
+}
+
+/** Per-machine resolver. */
+export function personalPath(filename: string, workspace?: string): string {
+	const ws = workspace ?? process.cwd();
+	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+	if (privateRoot) {
+		const root = expandHome(privateRoot);
+		const host = hostname().split('.')[0];
+		const candidate = join(root, `machine-${host}`, filename);
+		if (existsSync(candidate)) return candidate;
+	}
+	// stand-avatar.png lives under assets/ in the public workspace.
+	if (filename === 'stand-avatar.png') {
+		const inAssets = join(ws, 'assets', filename);
+		if (existsSync(inAssets)) return inAssets;
+	}
+	const wsPath = join(ws, filename);
+	if (existsSync(wsPath)) return wsPath;
+	// Nothing exists; return preferred private path so caller's existsSync()
+	// check fails gracefully.
+	if (privateRoot) {
+		const root = expandHome(privateRoot);
+		const host = hostname().split('.')[0];
+		return join(root, `machine-${host}`, filename);
+	}
+	if (filename === 'stand-avatar.png') return join(ws, 'assets', filename);
+	return wsPath;
+}
+
+/** Shared-across-fleet resolver (top-level private dir, not per-machine). */
+export function sharedPersonalPath(filename: string, workspace?: string): string {
+	const ws = workspace ?? process.cwd();
+	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+	if (privateRoot) {
+		const root = expandHome(privateRoot);
+		const candidate = join(root, filename);
+		if (existsSync(candidate)) return candidate;
+		const wsPath = join(ws, filename);
+		if (existsSync(wsPath)) return wsPath;
+		return candidate;
+	}
+	return join(ws, filename);
+}

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -37,26 +37,8 @@ import type { MainAgent, ToolDefinition } from 'bodhi-realtime-agent';
 function assertMacOS() { if (process.platform !== 'darwin') { console.error('Sutando requires macOS'); process.exit(1); } }
 import { workTool, cancelTask, startResultWatcher, startContextDropWatcher, startNoteViewingWatcher, resetNoteViewingDebounce, logConversation, logSessionBoundary, getRecentConversation, getSecondsSinceLastTurn, setTaskStatusCallback } from './task-bridge.js';
 import { buildSutandoSystemPrompt, buildVoiceAgentContext } from './voice-context.js';
-import { hostname } from 'node:os';
 
-// Personal-asset path resolver — TypeScript twin of src/util_paths.py.
-// Each Stand has its own identity. Canonical home is
-// `$SUTANDO_PRIVATE_DIR/machine-<hostname>/<file>`. Falls back to the
-// public workspace so existing installs keep working until they migrate.
-function personalPath(filename: string): string {
-	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
-	if (privateRoot) {
-		const root = privateRoot.replace(/^~/, process.env.HOME || '');
-		const host = hostname().split('.')[0];
-		const candidate = join(root, `machine-${host}`, filename);
-		if (existsSync(candidate)) return candidate;
-	}
-	if (filename === 'stand-avatar.png') {
-		const inAssets = join('assets', filename);
-		if (existsSync(inAssets)) return inAssets;
-	}
-	return filename;
-}
+import { personalPath, sharedPersonalPath } from './util_paths.js';
 
 // Cartesia is loaded dynamically at the bottom of the config section so
 // the `@cartesia/cartesia-js` package is only required when the user has
@@ -300,7 +282,7 @@ const saveMeetingNoteTool: ToolDefinition = {
 		const { content, type } = args as { content: string; type?: 'point' | 'summary' };
 		const today = new Date().toISOString().slice(0, 10);
 		const time = new Date().toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
-		const notePath = join(WORKSPACE_DIR, 'notes', `meeting-${today}.md`);
+		const notePath = sharedPersonalPath(`notes/meeting-${today}.md`, WORKSPACE_DIR);
 		const isSummary = type === 'summary';
 
 		if (!existsSync(notePath)) {


### PR DESCRIPTION
## Summary

Migration #4 + #5 in the private-repo plan, bundled per Chi's "bundle is ok" call.

Two resolver families now in play:

- **`personal_path()`** (#548) — per-machine: `$SUTANDO_PRIVATE_DIR/machine-<host>/<file>`
- **`shared_personal_path()`** (new) — fleet-shared: `$SUTANDO_PRIVATE_DIR/<file>`

Notes are SHARED (every Mac in the fleet sees the same content), so they live at the top-level private dir. Per-machine state files (pending-questions, PERSONAL_CLAUDE, tab-aliases) stay under `machine-<host>/`.

## Changes

**New file:** `src/util_paths.ts` (TS twin of `util_paths.py`) — exports `personalPath` + `sharedPersonalPath`. `voice-agent.ts` drops its inline `personalPath` and imports from here.

**Wired callers — notes (`shared_personal_path`):**
- `src/inline-tools.ts` `NOTES_DIR` → save_note / read_note / list_notes / delete_note
- `src/voice-agent.ts` meeting-note save path (line 285)
- `src/dashboard.py` `/notes/{slug}` route + `/notes` index (lines 48, 437)
- `src/daily-insight.py` `NOTES_DIR`
- `src/friction-detector.py` `notes_dir`
- `src/discord-bridge.py` `SEND_ALLOWED_ROOTS` adds private notes path (transition-friendly: both old + new paths permitted)
- `src/health-check.py` notes-dir check now points at canonical home

**Wired callers — per-machine (`personal_path`):**
- `src/dashboard.py` `get_pending_count`
- `src/agent-api.py` `pq_file` (2 sites)
- `src/friction-detector.py` `pending-questions.md`
- `src/check-pending-questions.py` `PQ_FILE`
- `src/session-handoff.sh` (inline python3 to call the resolver)

**No-op for runtime:** `PERSONAL_CLAUDE.md` and `tab-aliases.json` have no runtime readers — only referenced in `migrate.sh` bundle/restore, which #548 already covered. They ride along on the same per-machine path semantics.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] All touched Python files compile (`ast.parse`)
- [x] Resolver behavior verified with `SUTANDO_PRIVATE_DIR` set:
  - `shared_personal_path("notes")` → `/Users/wangchi/.sutando-memory-sync/notes`
  - `personal_path("pending-questions.md")` → `.../machine-Chis-MacBook-Air/pending-questions.md`
- [ ] After merge: voice-tool save_note → verify file lands in private dir
- [ ] Open note in dashboard → verify `/notes/{slug}` reads from private dir
- [ ] Run `check-pending-questions.py` → verify it reads the private PQ file

## Restart sequence after merge

Same as #548:
- voice-agent (touches voice-agent.ts + inline-tools.ts)
- web-client / dashboard / agent-api / discord-bridge (Python services)
- conversation-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)