### PR TITLE
fix(voice-agent): drop redundant sttProvider — use Gemini Live native transcription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,9 +119,6 @@ PORT=9900
 # Native audio model (STT+LLM+TTS in one round trip for real-time voice)
 # VOICE_NATIVE_AUDIO_MODEL=gemini-3.1-flash-live-preview
 
-# Batch STT model (web voice path, used when STT_PROVIDER=gemini)
-# STT_MODEL=gemini-3-flash-preview
-
 # Screen vision model (20-word screenshot descriptions — flash-lite is cheapest)
 # VISION_MODEL=gemini-3.1-flash-lite-preview
 
@@ -131,8 +128,6 @@ PORT=9900
 # Video generation model
 # VIDEO_MODEL=veo-3.1-generate-preview
 
-# Cartesia (STT + TTS) — set CARTESIA_API_KEY to enable
-# Free credits? Set the key and STT/TTS auto-enable.
+# Cartesia (TTS) — set CARTESIA_API_KEY to enable post-task result audio
 # CARTESIA_API_KEY=your-cartesia-key
 # CARTESIA_VOICE_ID=f786b574-daa5-4673-aa0c-cbe3e8534c02
-# STT_PROVIDER=cartesia

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -29,10 +29,7 @@ import { execSync as execSyncTop } from 'node:child_process';
 import { inlineTools } from './inline-tools.js';
 import { injectText } from './browser-tools.js';
 import { join } from 'node:path';
-import {
-	VoiceSession,
-	GeminiBatchSTTProvider,
-} from 'bodhi-realtime-agent';
+import { VoiceSession } from 'bodhi-realtime-agent';
 import type { MainAgent, ToolDefinition } from 'bodhi-realtime-agent';
 function assertMacOS() { if (process.platform !== 'darwin') { console.error('Sutando requires macOS'); process.exit(1); } }
 import { workTool, startResultWatcher, startContextDropWatcher, startNoteViewingWatcher, resetNoteViewingDebounce, logConversation, logSessionBoundary, getRecentConversation, getSecondsSinceLastTurn, setTaskStatusCallback } from './task-bridge.js';
@@ -62,8 +59,6 @@ function personalPath(filename: string): string {
 // the `@cartesia/cartesia-js` package is only required when the user has
 // set CARTESIA_API_KEY. Gemini-only setups (the default) skip the import
 // entirely — no install cost, no type-check cost (see tsconfig `exclude`).
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let CartesiaSTTProvider: any = null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let generateSpeech: ((text: string, opts: { category: string; label: string }) => Promise<string>) | null = null;
 
@@ -123,8 +118,6 @@ const CALL_RESULTS_DIR = join(new URL('.', import.meta.url).pathname, '..', 'res
 // Model configuration — override via .env for cost/quality tuning
 const VOICE_MODEL = process.env.VOICE_MODEL || 'gemini-2.5-flash';
 const VOICE_NATIVE_AUDIO_MODEL = process.env.VOICE_NATIVE_AUDIO_MODEL || 'gemini-3.1-flash-live-preview';
-// STT_MODEL is the model name passed to GeminiBatchSTTProvider. Only used when STT_PROVIDER=gemini.
-const STT_MODEL = process.env.STT_MODEL || 'gemini-3-flash-preview';
 // Google Search grounding — MUST be false under gemini-3.1-flash-live-preview
 // native audio. Combining googleSearch: true + 3.1 native audio causes the
 // transport to reject setup with close code 1011 "exceeded your current
@@ -135,27 +128,22 @@ const STT_MODEL = process.env.STT_MODEL || 'gemini-3-flash-preview';
 // in .env when unpinning VOICE_NATIVE_AUDIO_MODEL to 3.1.
 const VOICE_GOOGLE_SEARCH = (process.env.VOICE_GOOGLE_SEARCH ?? 'true').toLowerCase() !== 'false';
 const CARTESIA_API_KEY = process.env.CARTESIA_API_KEY || '';
-const STT_PROVIDER = process.env.STT_PROVIDER || (CARTESIA_API_KEY ? 'cartesia' : 'gemini');
 
-// Lazy-load Cartesia modules only when a key is set. This means Gemini-only
+// Lazy-load Cartesia TTS only when a key is set. This means Gemini-only
 // users don't need `@cartesia/cartesia-js` installed at all — the
 // cartesia-*.ts files are excluded from tsc via tsconfig and never loaded
 // by tsx at runtime unless this branch runs.
 if (CARTESIA_API_KEY) {
 	try {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const sttMod: any = await import('./cartesia-stt-provider.js');
-		CartesiaSTTProvider = sttMod.CartesiaSTTProvider;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const ttsMod: any = await import('./cartesia-tts.js');
 		generateSpeech = ttsMod.generateSpeech;
 	} catch (err) {
 		console.error(
-			`[Cartesia] failed to load modules — is @cartesia/cartesia-js installed?`,
+			`[Cartesia] failed to load TTS module — is @cartesia/cartesia-js installed?`,
 			err instanceof Error ? err.message : err
 		);
-		// CartesiaSTTProvider and generateSpeech stay null; guards below
-		// will fall back to Gemini paths.
+		// generateSpeech stays null; the Cartesia TTS branch below will be skipped.
 	}
 }
 
@@ -786,9 +774,6 @@ async function main() {
 		host: HOST,
 		model: google(VOICE_MODEL),
 		geminiModel: VOICE_NATIVE_AUDIO_MODEL,
-		sttProvider: STT_PROVIDER === 'cartesia' && CARTESIA_API_KEY && CartesiaSTTProvider
-			? new CartesiaSTTProvider({ apiKey: CARTESIA_API_KEY })
-			: new GeminiBatchSTTProvider({ apiKey: GEMINI_VOICE_API_KEY, model: STT_MODEL }),
 		speechConfig: { voiceName: 'Puck' },
 		hooks: {
 			onSessionStart: (e) => {
@@ -1145,7 +1130,7 @@ async function main() {
 	console.log(`  Models:`);
 	console.log(`    Voice LLM:       ${VOICE_MODEL}`);
 	console.log(`    Native audio:    ${VOICE_NATIVE_AUDIO_MODEL}`);
-	console.log(`    STT:             ${STT_PROVIDER} (${STT_PROVIDER === 'cartesia' ? 'ink-whisper' : STT_MODEL})`);
+	console.log(`    STT:             native Gemini Live inputAudioTranscription`);
 	console.log(`    Cartesia TTS:    ${CARTESIA_API_KEY ? 'sonic-3' : 'disabled'}`);
 	console.log();
 	console.log('Start the web client:');

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -775,6 +775,7 @@ async function main() {
 		model: google(VOICE_MODEL),
 		geminiModel: VOICE_NATIVE_AUDIO_MODEL,
 		speechConfig: { voiceName: 'Puck' },
+		inputAudioTranscription: true,
 		hooks: {
 			onSessionStart: (e) => {
 				userTurnCount = 0; userHasInterrupted = false; sessionEnding = false;


### PR DESCRIPTION
## Summary

- Bodhi's Gemini Live transport (and OpenAI Realtime) both ship native `inputAudioTranscription`. The separate `sttProvider` running `gemini-3-flash-preview` was producing garbage on short non-English utterances (e.g. Chinese → \"ወይ\"), landing wrong text in `conversation.log`.
- Web subtitles already used Gemini Live's native transcription, so users saw correct text on screen but wrong text in logs (Susan's #554).
- When `sttProvider` is absent, bodhi's `voice-session.ts` falls into the no-external-STT branch that wires `transport.onInputTranscription` → `TranscriptManager.handleInput` directly. Gemini Live's native (multilingual) transcription becomes authoritative.
- Result: one source of truth, no duplicate STT cost, no garbled logs.

## What changed

- `src/voice-agent.ts` — removed `GeminiBatchSTTProvider` import, `STT_PROVIDER`/`STT_MODEL` consts, `CartesiaSTTProvider` lazy-load, and the `sttProvider` field on `VoiceSession`. Updated startup-log line.
- `.env.example` — removed `STT_MODEL` / `STT_PROVIDER` blocks. Cartesia section now describes TTS-only (which is what `CARTESIA_API_KEY` actually drives).

## What's preserved

- `CARTESIA_API_KEY` still drives `generateSpeech` for post-task result audio (line ~870).
- `src/cartesia-stt-provider.ts` is left in place since `tests/cartesia-stt-provider.test.ts` references it. Follow-up cleanup PR can delete both together.

## Test plan

- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] Voice session starts; Chinese audio produces correct transcript in both web subtitle AND `conversation.log`
- [ ] English audio still works (regression check)
- [ ] Phone-call path (Twilio + bodhi VoiceSession) still produces correct transcripts
- [ ] Cartesia TTS post-task audio still generates when `CARTESIA_API_KEY` is set

## Closes

#554

🤖 Generated with [Claude Code](https://claude.com/claude-code)