### PR TITLE
feat(ax-read): Swift CLI for frontmost-app AX snapshot — deictic foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ done/
 
 # Runtime state file written by the voice client. Pure cruft, no commit value.
 voice-state.json
+src/ax-read/ax-read

--- a/src/ax-read/README.md
+++ b/src/ax-read/README.md
@@ -1,0 +1,48 @@
+# ax-read
+
+Minimal CLI that returns frontmost-app accessibility data as JSON.
+
+```
+$ ./ax-read
+{"app":"Cursor","cursor":[1421.0,398.0],"selected":"the previous paragraph"}
+```
+
+Used by the voice agent's deictic edit-mode (see
+`notes/deictic-edit-mode-design-2026-04-30.md`): when the interim
+transcript hits a deictic word ("this", "that", "here"), the voice
+agent shells out to this binary and stamps the snapshot into the
+turn's deictic-refs context for the LLM to resolve.
+
+## Build
+
+```
+swiftc -O -o ax-read ax-read.swift -framework Cocoa -framework ApplicationServices
+```
+
+## Output schema
+
+```json
+{
+  "app": "<localized frontmost app name, or '' if none>",
+  "selected": "<AXSelectedText of the focused element, or '' if no selection>",
+  "cursor": [x, y]   // NSEvent.mouseLocation, bottom-left Cocoa coords; null on failure
+}
+```
+
+Errors keep the schema (empty strings / null cursor) so callers can use it
+uniformly without branching on stderr.
+
+## Why a separate binary
+
+AX read via `osascript`/AppleScript has gaps across apps — e.g. `tell
+process P to value of attribute "AXSelectedText" of focused element`
+returns "Can't get attribute AXFocused" on Cursor. The C-level AX API
+(`AXUIElementCopyAttributeValue`) reads cleanly and consistently.
+
+A Node/TS binding would also work but requires native deps; a 60KB
+Swift binary is simpler to ship.
+
+## Permissions
+
+The first call needs Accessibility permission for whatever process is
+invoking it (`tsx`/`node` for voice-agent). macOS prompts on first run.

--- a/src/ax-read/ax-read.swift
+++ b/src/ax-read/ax-read.swift
@@ -1,0 +1,73 @@
+// ax-read — minimal CLI that returns frontmost-app accessibility data as JSON.
+//
+// Output schema: {"app": "<frontmostAppName>", "selected": "<text>", "cursor": [x,y]}
+// Errors keep the schema (empty strings / null cursor) so callers can use it
+// uniformly without branching on stderr.
+//
+// Used by deictic edit-mode (notes/deictic-edit-mode-design-2026-04-30.md):
+// when the voice agent's interim transcript hits a deictic word, it shells
+// out to this binary and snapshots the result. The snapshot then enters the
+// LLM's per-turn context as numbered deictic refs.
+//
+// Build:  swiftc -O -o ax-read ax-read.swift -framework Cocoa -framework ApplicationServices
+// Test:   ./ax-read    (focus an app with selected text; expect JSON)
+//
+// Why a separate Swift binary vs osascript/AppleScript: AX read via
+// AppleScript has reliability gaps across apps (e.g. Cursor returns
+// "Can't get attribute AXFocused"). The C-level AX API does it cleanly
+// and consistently.
+
+import Cocoa
+import ApplicationServices
+import Foundation
+
+// MARK: - JSON output
+
+func emit(app: String, selected: String, cursor: NSPoint?) -> Never {
+    var json: [String: Any] = ["app": app, "selected": selected]
+    if let c = cursor { json["cursor"] = [c.x, c.y] }
+    else { json["cursor"] = NSNull() }
+    if let data = try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]),
+       let str = String(data: data, encoding: .utf8) {
+        print(str)
+    } else {
+        print("{\"app\":\"\",\"selected\":\"\",\"cursor\":null}")
+    }
+    exit(0)
+}
+
+// MARK: - Frontmost app
+
+let workspace = NSWorkspace.shared
+let frontmostApp = workspace.frontmostApplication
+let appName = frontmostApp?.localizedName ?? ""
+let pid = frontmostApp?.processIdentifier ?? -1
+
+if pid < 0 {
+    emit(app: "", selected: "", cursor: nil)
+}
+
+// MARK: - AX selected text via the focused element
+
+let appRef = AXUIElementCreateApplication(pid)
+
+var focused: AnyObject?
+let focusedErr = AXUIElementCopyAttributeValue(appRef, kAXFocusedUIElementAttribute as CFString, &focused)
+
+var selected = ""
+if focusedErr == .success, let element = focused {
+    var selValue: AnyObject?
+    let selErr = AXUIElementCopyAttributeValue(element as! AXUIElement, kAXSelectedTextAttribute as CFString, &selValue)
+    if selErr == .success, let s = selValue as? String {
+        selected = s
+    }
+}
+
+// MARK: - Cursor position (global coordinates, screen-pixel)
+
+// NSEvent.mouseLocation: bottom-left origin, Cocoa coords. The deictic
+// design treats this as "where 'here' points" — the consumer can convert
+// to whatever coordinate space it needs.
+let mouse = NSEvent.mouseLocation
+
+emit(app: appName, selected: selected, cursor: mouse)


### PR DESCRIPTION
## Summary

First building block of the deictic edit-mode for voice agent. Design at `notes/deictic-edit-mode-design-2026-04-30.md` (Mini, after passes 3393–3406 with you).

`src/ax-read/ax-read` is a 60KB Swift CLI that prints frontmost-app accessibility data as JSON:

```json
{"app":"Cursor","cursor":[1421.0,398.0],"selected":"the previous paragraph"}
```

Schema is uniform across success/failure (empty strings, `null` cursor) so the caller doesn't have to branch on stderr.

## Why Swift over osascript

AppleScript AX read has reliability gaps:
```
$ osascript -e 'tell application "System Events" to ... value of attribute "AXSelectedText" of (first UI element of process "Cursor" whose value of attribute "AXFocused" is true)'
AX error: System Events got an error: Can't get attribute "AXFocused".
```

The C-level AX API reads cleanly:
```swift
AXUIElementCopyAttributeValue(appRef, kAXFocusedUIElementAttribute as CFString, &focused)
AXUIElementCopyAttributeValue(focused, kAXSelectedTextAttribute as CFString, &selValue)
```

A 60KB Swift binary is simpler to ship than a Node native module.

## Build

```
cd src/ax-read && swiftc -O -o ax-read ax-read.swift -framework Cocoa -framework ApplicationServices
```

Binary is gitignored.

## Test plan (manual, needs Chi)

- [ ] Focus an app, select some text → `./ax-read` returns the selection
- [ ] Click somewhere without selecting → `./ax-read` returns `selected: ""` + cursor at the click point
- [ ] Run with no app focused → returns `{app:"", selected:"", cursor:[...]}` (still valid JSON)
- [ ] First run prompts for Accessibility permission → grant, subsequent runs work

## What's next (separate PRs)

1. Wire ax-read into voice-agent interim-transcript hook (deictic detection)
2. Per-turn deictic buffer + LLM context injection
3. Edit-mode toggle (voice command + ⌃E hotkey + state file)
4. Visual-flash overlay via Sutando.app menu-bar IPC
5. Echoback gate for multi-deictic turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)