### PR TITLE
fix(sutando-app): watcher dedup recognizes empty current prompt

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -576,13 +576,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         cap.waitUntilExit()
         if cap.terminationStatus != 0 { return false }
         let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        // Find the LAST line starting with "❯ " — that's the current prompt.
+        // Find the LAST line starting with "❯" — that's the current prompt.
         // Past prompts in scrollback don't represent queued input.
+        //
+        // Match "❯" without requiring a trailing space: an EMPTY prompt is
+        // rendered as `❯ ` (prompt + space), but `trimmingCharacters` strips
+        // the trailing space → we'd miss the empty prompt and fall back to
+        // an earlier prompt-with-text in scrollback. Bug from PR #559 that
+        // caused continuous "queued in pane — skipping send" even on empty
+        // prompt. Fix: trim only LEADING whitespace; check `❯` prefix; the
+        // input portion is whatever follows.
         var lastPromptInput: String? = nil
         for line in out.split(separator: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("❯ ") {
-                lastPromptInput = String(trimmed.dropFirst(2))
+            // Trim only leading whitespace (not trailing) so empty prompt
+            // `❯ ` is preserved as `❯ ` (prompt + space + nothing).
+            let leading = line.drop(while: { $0 == " " || $0 == "\t" })
+            if leading.hasPrefix("❯") {
+                // Drop the prompt char + any single space that follows it.
+                var rest = leading.dropFirst()  // drop "❯"
+                if rest.hasPrefix(" ") { rest = rest.dropFirst() }  // drop one space if present
+                lastPromptInput = String(rest)
             }
         }
         guard let input = lastPromptInput else { return false }


### PR DESCRIPTION
## Summary

Third fix in the watcher-dedup saga. Sorry for the regression chain — diagnosed by Chi observing continuous \"queued in pane — skipping send\" with an empty prompt visible.

## Bug

PR #559 walked lines + matched `\`❯ \`` (with trailing space). But:
- An empty prompt renders as `\`❯ \`` (prompt char + space + nothing)
- `\`trimmingCharacters(in: .whitespaces)\`` strips both leading AND trailing whitespace
- After trim: `\`❯\`` (no trailing space)
- `\`hasPrefix(\"❯ \")\`` (with required trailing space) → FALSE
- Loop skips the empty prompt, falls back to an earlier `\`❯ <text-with-watcher>\`` in scrollback
- Dedup fires → reminder never sends

## Fix

Trim only LEADING whitespace, check `\`❯\`` without requiring trailing space, then drop the prompt char + one optional space. Empty prompts are now correctly identified as empty.

```swift
let leading = line.drop(while: { $0 == \" \" || $0 == \"\\t\" })
if leading.hasPrefix(\"❯\") {
    var rest = leading.dropFirst()
    if rest.hasPrefix(\" \") { rest = rest.dropFirst() }
    lastPromptInput = String(rest)
}
```

## Regression history (final, hopefully)

- **PR #553**: `\\bwatcher\\b` over bottom 5 lines → over-fired on prose like \"Ensure the watcher is running\"
- **PR #557**: filtered to lines starting with `\`❯ \`` → over-fired because `-S -3` includes scrollback
- **PR #559**: walk all lines, use LAST `\`❯ \`` → over-fired because trim strips trailing space from empty prompt
- **This PR**: trim leading-only, match `\`❯\`` prefix → empty prompts correctly handled

## Test plan

- [x] swiftc compiles cleanly
- [ ] After merge: rebuild + relaunch
- [ ] Empty prompt + watcher dead: app sends `\`watcher\`` keystroke
- [ ] `\`❯ watcher\`` typed (not submitted): app skips, no double-send
- [ ] Past prompts in scrollback containing \"watcher\": should NOT cause skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)