### PR TITLE
fix(discord-bridge): fence-aware chunker preserves triple-backtick code blocks

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -63,6 +63,92 @@ SEND_ALLOWED_PREFIXES = (
 )
 
 
+def _chunk_for_discord(text: str, max_len: int = 1900):
+    """Yield Discord-safe chunks <= max_len chars, preserving triple-backtick code fences.
+
+    The naive `range(0, len, max_len)` chunker breaks code blocks: if a triple-backtick
+    fence opens before the chunk boundary and closes after, the first chunk renders as
+    a half-open code block on Discord and the second chunk leaks the literal trailing
+    backticks as plain text.
+
+    This chunker walks line-by-line, tracking fence state (open/closed). When a new
+    line would push the buffer past max_len, it closes the current fence (if open),
+    yields the buffer, and reopens the fence in the next chunk.
+
+    Single-line content longer than max_len gets hard-split mid-line (rare); fence
+    state is still preserved across the split.
+    """
+    if not text:
+        return
+    in_fence = False
+    buf = []
+    buf_len = 0
+
+    def flush():
+        nonlocal buf, buf_len
+        if not buf:
+            return None
+        chunk = "\n".join(buf)
+        # If we're mid-fence at chunk boundary, close it so Discord renders cleanly
+        if in_fence:
+            chunk = chunk + "\n```"
+        buf = []
+        buf_len = 0
+        return chunk
+
+    for line in text.split("\n"):
+        # Toggle fence state for any triple-backtick on this line (paired)
+        fences_on_line = line.count("```")
+
+        # Pessimistic length check: assume we may need to add a closing fence
+        line_overhead = len(line) + 1  # +1 for newline
+        reserve = 4 if in_fence else 0  # space for "\n```" close
+        if buf_len + line_overhead + reserve > max_len and buf:
+            chunk = flush()
+            if chunk is not None:
+                yield chunk
+            # Reopen fence in next chunk if we were inside one
+            if in_fence:
+                buf.append("```")
+                buf_len = 4
+
+        # Single line longer than max_len → hard-split
+        if line_overhead + reserve > max_len:
+            remaining = line
+            while len(remaining) + reserve > max_len:
+                take = max_len - reserve - buf_len - 1
+                if take <= 0:
+                    chunk = flush()
+                    if chunk is not None:
+                        yield chunk
+                    if in_fence:
+                        buf.append("```")
+                        buf_len = 4
+                    take = max_len - reserve - buf_len - 1
+                buf.append(remaining[:take])
+                buf_len += take + 1
+                remaining = remaining[take:]
+                chunk = flush()
+                if chunk is not None:
+                    yield chunk
+                if in_fence:
+                    buf.append("```")
+                    buf_len = 4
+            buf.append(remaining)
+            buf_len += len(remaining) + 1
+        else:
+            buf.append(line)
+            buf_len += line_overhead
+
+        # Update fence state AFTER we've placed the line (the line itself is intact)
+        if fences_on_line % 2 == 1:
+            in_fence = not in_fence
+
+    chunk = flush()
+    if chunk is not None:
+        yield chunk
+
+
 def _is_path_sendable(fpath: str) -> bool:
     """True iff `fpath` is a real file AND resolves under an allowed root.
 
@@ -800,10 +886,10 @@ async def poll_results():
                     files = file_pattern.findall(reply_text)
                     clean_text = file_pattern.sub('', reply_text).strip()
 
-                    # Send text
+                    # Send text — fence-aware chunker preserves triple-backtick code blocks
                     if clean_text:
-                        for i in range(0, len(clean_text), 1900):
-                            await channel.send(clean_text[i:i+1900])
+                        for chunk in _chunk_for_discord(clean_text):
+                            await channel.send(chunk)
 
                     # Send files (allowlist-gated; see _is_path_sendable)
                     for fpath in files:
@@ -907,8 +993,8 @@ async def poll_proactive():
                         files = file_pattern.findall(text)
                         clean_text = file_pattern.sub('', text).strip()
                         if clean_text:
-                            for i in range(0, len(clean_text), 1900):
-                                await dm.send(clean_text[i:i+1900])
+                            for chunk in _chunk_for_discord(clean_text):
+                                await dm.send(chunk)
                         for fpath in files:
                             fpath = os.path.expanduser(fpath.strip())
                             if _is_path_sendable(fpath):

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -9,6 +9,7 @@ Usage: python3 src/discord-bridge.py
 import asyncio
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -63,26 +64,61 @@ SEND_ALLOWED_PREFIXES = (
 )
 
 
+_FENCE_LINE = re.compile(r"^\s{0,3}(`{3,}|~{3,})\s*([^\s`~][^`~]*)?\s*$")
+
+
+def _is_fence_open_line(line: str):
+    """Return the fence opener string if `line` is a real Markdown block-fence line.
+
+    A fence line is one whose stripped content is just a backtick/tilde run of >=3
+    optionally followed by a language/info string. Lines like `print("```")`,
+    shell heredocs, or `use ```js inline` do NOT match — they have non-fence
+    content before the fence chars on the same line.
+
+    Returns the full fence opener (e.g. "```python", "~~~", "````markdown")
+    so the chunker can reopen the SAME opener after a chunk boundary, preserving
+    the language tag and the fence-token kind/length.
+
+    Returns None if the line is not a fence line.
+    """
+    m = _FENCE_LINE.match(line)
+    if not m:
+        return None
+    return line.strip()
+
+
 def _chunk_for_discord(text: str, max_len: int = 1900):
-    """Yield Discord-safe chunks <= max_len chars, preserving triple-backtick code fences.
+    """Yield Discord-safe chunks <= max_len chars, preserving Markdown code fences.
 
-    The naive `range(0, len, max_len)` chunker breaks code blocks: if a triple-backtick
-    fence opens before the chunk boundary and closes after, the first chunk renders as
-    a half-open code block on Discord and the second chunk leaks the literal trailing
-    backticks as plain text.
+    The naive `range(0, len, max_len)` chunker breaks code blocks: if a fence
+    opens before the chunk boundary and closes after, the first chunk renders as
+    a half-open code block on Discord and the second chunk leaks the literal
+    trailing backticks as plain text.
 
-    This chunker walks line-by-line, tracking fence state (open/closed). When a new
-    line would push the buffer past max_len, it closes the current fence (if open),
-    yields the buffer, and reopens the fence in the next chunk.
+    This chunker walks line-by-line, tracks fence state (the exact opener string
+    when inside a fence; None when outside). When a new line would push the
+    buffer past max_len, it closes the current fence (if open) with a matching
+    closer, yields the buffer, and reopens the SAME opener in the next chunk —
+    preserving language tags and fence-token length.
 
-    Single-line content longer than max_len gets hard-split mid-line (rare); fence
-    state is still preserved across the split.
+    Fence detection only matches real block-fence lines (regex-anchored). Inline
+    backticks in code or prose (`print("```")`, `use ```js`) do NOT toggle state.
+
+    Single-line content longer than max_len is hard-split mid-line; fence state
+    is preserved across the split.
     """
     if not text:
         return
-    in_fence = False
+    fence_opener = None  # full opener string when inside a fence; None when outside
     buf = []
     buf_len = 0
+
+    def fence_closer(opener):
+        # Match the fence-token kind (` or ~) and use 3 of them. Discord's
+        # parser closes on >=3 matching chars, so a 3-char closer suffices
+        # even if opener was 4+ chars (the literal opener length doesn't have
+        # to match for closure, only the char kind).
+        return opener[0] * 3 if opener else "```"
 
     def flush():
         nonlocal buf, buf_len
@@ -90,27 +126,31 @@ def _chunk_for_discord(text: str, max_len: int = 1900):
             return None
         chunk = "\n".join(buf)
         # If we're mid-fence at chunk boundary, close it so Discord renders cleanly
-        if in_fence:
-            chunk = chunk + "\n```"
+        if fence_opener:
+            chunk = chunk + "\n" + fence_closer(fence_opener)
         buf = []
         buf_len = 0
         return chunk
 
     for line in text.split("\n"):
-        # Toggle fence state for any triple-backtick on this line (paired)
-        fences_on_line = line.count("```")
+        # Real fence-line detection (only at start of stripped line, not anywhere)
+        opener_on_line = _is_fence_open_line(line)
+        # If we're outside a fence and this line is a fence-open, treat as opening.
+        # If we're inside a fence and this line matches the fence-token kind,
+        # treat as closing (we don't require exact length match for close).
 
-        # Pessimistic length check: assume we may need to add a closing fence
         line_overhead = len(line) + 1  # +1 for newline
-        reserve = 4 if in_fence else 0  # space for "\n```" close
+        # Reserve space for closing fence if we'd cut mid-fence
+        reserve = (len(fence_closer(fence_opener)) + 1) if fence_opener else 0
+
         if buf_len + line_overhead + reserve > max_len and buf:
             chunk = flush()
             if chunk is not None:
                 yield chunk
             # Reopen fence in next chunk if we were inside one
-            if in_fence:
-                buf.append("```")
-                buf_len = 4
+            if fence_opener:
+                buf.append(fence_opener)
+                buf_len = len(fence_opener) + 1
 
         # Single line longer than max_len → hard-split
         if line_overhead + reserve > max_len:
@@ -121,9 +161,9 @@ def _chunk_for_discord(text: str, max_len: int = 1900):
                     chunk = flush()
                     if chunk is not None:
                         yield chunk
-                    if in_fence:
-                        buf.append("```")
-                        buf_len = 4
+                    if fence_opener:
+                        buf.append(fence_opener)
+                        buf_len = len(fence_opener) + 1
                     take = max_len - reserve - buf_len - 1
                 buf.append(remaining[:take])
                 buf_len += take + 1
@@ -131,18 +171,23 @@ def _chunk_for_discord(text: str, max_len: int = 1900):
                 chunk = flush()
                 if chunk is not None:
                     yield chunk
-                if in_fence:
-                    buf.append("```")
-                    buf_len = 4
+                if fence_opener:
+                    buf.append(fence_opener)
+                    buf_len = len(fence_opener) + 1
             buf.append(remaining)
             buf_len += len(remaining) + 1
         else:
             buf.append(line)
             buf_len += line_overhead
 
-        # Update fence state AFTER we've placed the line (the line itself is intact)
-        if fences_on_line % 2 == 1:
-            in_fence = not in_fence
+        # Update fence state AFTER placing the line (the line itself is intact)
+        if opener_on_line is not None:
+            if fence_opener is None:
+                fence_opener = opener_on_line
+            else:
+                # Fence-line at this position closes the active fence
+                # (Discord/CommonMark allows any close-fence of the same kind to close)
+                fence_opener = None
 
     chunk = flush()
     if chunk is not None:

--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -27,6 +27,7 @@ Per-node correctness:
 
 import json
 import os
+import re
 import sys
 import urllib.request
 from pathlib import Path
@@ -34,6 +35,95 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 ACCESS_JSON = Path.home() / ".claude" / "channels" / "discord" / "access.json"
 SSE_STATUS_URL = "http://localhost:8080/sse-status"
+
+
+_FENCE_LINE = re.compile(r"^\s{0,3}(`{3,}|~{3,})\s*([^\s`~][^`~]*)?\s*$")
+
+
+def _is_fence_open_line(line: str):
+    """Return the fence opener string if `line` is a real Markdown fence line, else None."""
+    if not _FENCE_LINE.match(line):
+        return None
+    return line.strip()
+
+
+def _chunk_for_discord(text: str, max_len: int = 1900):
+    """Yield Discord-safe chunks <= max_len, preserving Markdown code fences.
+
+    Mirrors src/discord-bridge.py:_chunk_for_discord. Tracks the exact fence
+    opener (so language tag and fence-token kind are preserved across chunk
+    boundaries) and uses anchored fence-line detection so inline backticks
+    in code/prose don't toggle state.
+    """
+    if not text:
+        return
+    fence_opener = None
+    buf = []
+    buf_len = 0
+
+    def fence_closer(opener):
+        return opener[0] * 3 if opener else "```"
+
+    def flush():
+        nonlocal buf, buf_len
+        if not buf:
+            return None
+        chunk = "\n".join(buf)
+        if fence_opener:
+            chunk = chunk + "\n" + fence_closer(fence_opener)
+        buf = []
+        buf_len = 0
+        return chunk
+
+    for line in text.split("\n"):
+        opener_on_line = _is_fence_open_line(line)
+        line_overhead = len(line) + 1
+        reserve = (len(fence_closer(fence_opener)) + 1) if fence_opener else 0
+
+        if buf_len + line_overhead + reserve > max_len and buf:
+            chunk = flush()
+            if chunk is not None:
+                yield chunk
+            if fence_opener:
+                buf.append(fence_opener)
+                buf_len = len(fence_opener) + 1
+
+        if line_overhead + reserve > max_len:
+            remaining = line
+            while len(remaining) + 1 + reserve > max_len - buf_len:
+                take = max_len - reserve - buf_len - 1
+                if take <= 0:
+                    chunk = flush()
+                    if chunk is not None:
+                        yield chunk
+                    if fence_opener:
+                        buf.append(fence_opener)
+                        buf_len = len(fence_opener) + 1
+                    take = max_len - reserve - buf_len - 1
+                buf.append(remaining[:take])
+                buf_len += take + 1
+                remaining = remaining[take:]
+                chunk = flush()
+                if chunk is not None:
+                    yield chunk
+                if fence_opener:
+                    buf.append(fence_opener)
+                    buf_len = len(fence_opener) + 1
+            buf.append(remaining)
+            buf_len += len(remaining) + 1
+        else:
+            buf.append(line)
+            buf_len += line_overhead
+
+        if opener_on_line is not None:
+            if fence_opener is None:
+                fence_opener = opener_on_line
+            else:
+                fence_opener = None
+
+    chunk = flush()
+    if chunk is not None:
+        yield chunk
 
 
 def voice_connected() -> bool:
@@ -149,17 +239,21 @@ def send_dm(text: str) -> bool:
         print(f"dm-result: failed to open DM channel with {owner_id}: {e}", file=sys.stderr)
         return False
 
-    # Truncate if too long for Discord (2000 char limit; leave room for suffix).
-    if len(text) > 1900:
-        text = text[:1900] + "\n... (truncated)"
+    # Chunk into Discord-safe pieces, preserving code fences across boundaries.
+    chunks = list(_chunk_for_discord(text)) or [text]
+    for i, chunk in enumerate(chunks):
+        try:
+            _discord_api("POST", f"/channels/{channel_id}/messages", token, {"content": chunk})
+        except Exception as e:
+            print(
+                f"dm-result: failed to send DM chunk {i+1}/{len(chunks)} to channel {channel_id}: {e}",
+                file=sys.stderr,
+            )
+            return False
 
-    try:
-        _discord_api("POST", f"/channels/{channel_id}/messages", token, {"content": text})
-    except Exception as e:
-        print(f"dm-result: failed to send DM to channel {channel_id}: {e}", file=sys.stderr)
-        return False
-
-    print(f"dm-result: sent to DM ({len(text)} chars) via channel {channel_id}")
+    print(
+        f"dm-result: sent to DM ({len(text)} chars in {len(chunks)} chunk(s)) via channel {channel_id}"
+    )
     return True
 
 

--- a/tests/discord-chunker.test.py
+++ b/tests/discord-chunker.test.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Unit tests for _chunk_for_discord — covers MacBook PR #563 review findings.
+
+Both src/discord-bridge.py and src/dm-result.py carry copies of the chunker;
+test both. Loads via importlib because filenames contain hyphens.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+bridge = _load("dbridge", REPO / "src" / "discord-bridge.py")
+dm = _load("dm_result", REPO / "src" / "dm-result.py")
+
+
+def _run_against(mod, label):
+    # Test 1: empty/short
+    assert list(mod._chunk_for_discord("")) == []
+    assert list(mod._chunk_for_discord("hi")) == ["hi"]
+
+    # Test 2: long plain text → multiple chunks, all <= max_len
+    src = "\n".join(["line " + str(i) * 40 for i in range(200)])
+    chunks = list(mod._chunk_for_discord(src, max_len=300))
+    assert all(len(c) <= 300 for c in chunks), f"{label}: chunk too long"
+    assert len(chunks) > 1
+
+    # Test 3: code block spanning multiple chunks preserves opener with language tag
+    src = "intro\n```python\n" + ("x = 1\n" * 400) + "```\nouter"
+    chunks = list(mod._chunk_for_discord(src, max_len=300))
+    assert len(chunks) >= 3, f"{label}: expected multi-chunk, got {len(chunks)}"
+    # All but last must end with ``` (closer)
+    for i, c in enumerate(chunks[:-1]):
+        assert c.endswith("```"), f"{label}: chunk {i} missing closer: {c[-30:]!r}"
+    # Inner chunks must reopen with the SAME opener (preserves "python" tag)
+    assert "```python" in chunks[1], f"{label}: language tag dropped"
+
+    # Test 4: print("```") inside fenced block must NOT close the fence early
+    src = '```python\nprint("```")\nx = 1\nmore = 2\n```'
+    chunks = list(mod._chunk_for_discord(src))
+    # Single chunk — but more important: fence is balanced (one opener, one closer)
+    full = "\n".join(chunks)
+    fence_lines = [
+        ln for ln in full.split("\n") if mod._is_fence_open_line(ln) is not None
+    ]
+    assert len(fence_lines) == 2, (
+        f"{label}: print(```) misclassified as fence "
+        f"(found {len(fence_lines)} fence-lines, expected 2)"
+    )
+
+    # Test 5: nested 4-tick outer fence preserved (Markdown allows ```` to wrap ```)
+    src = "````markdown\n```python\ninner\n```\nstill outer\n````"
+    chunks = list(mod._chunk_for_discord(src))
+    # Outer ```` opener present in first chunk
+    assert "````markdown" in chunks[0], f"{label}: outer 4-tick opener lost"
+
+    # Test 6: regex correctness for _is_fence_open_line
+    cases = [
+        ("```python", "```python"),
+        ("```", "```"),
+        ("``` ", "```"),
+        ("```py extra", "```py extra"),
+        ("~~~js", "~~~js"),
+        ('print("```")', None),
+        ("    print('```')", None),  # 4-space indent makes it not a fence
+        ("foo ```inline``` bar", None),
+        ("``", None),  # only 2 backticks
+    ]
+    for inp, exp in cases:
+        got = mod._is_fence_open_line(inp)
+        assert got == exp, f"{label}: {inp!r} -> got {got!r}, expected {exp!r}"
+
+    # Test 7: tilde fence closes with tildes (not backticks) — token-kind preservation
+    src = "~~~python\n" + ("x = 1\n" * 400) + "~~~"
+    chunks = list(mod._chunk_for_discord(src, max_len=300))
+    assert len(chunks) >= 2
+    # First chunk closes with ~~~ (matching opener kind), not ```
+    assert chunks[0].rstrip().endswith("~~~"), (
+        f"{label}: tilde fence closed with wrong token: {chunks[0][-30:]!r}"
+    )
+
+    print(f"[{label}] all 7 cases OK")
+
+
+def main():
+    _run_against(bridge, "discord-bridge.py")
+    _run_against(dm, "dm-result.py")
+    print("All chunker tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes the bridge format-breakage MacBook + Mini chased through `<@id>` empty-body false-leads. Root cause is in `src/discord-bridge.py` — the chunker hard-splits at fixed 1900-char boundaries, breaking any reply > 1900 chars that contains a triple-backtick code block.

```python
# before
for i in range(0, len(clean_text), 1900):
    await channel.send(clean_text[i:i+1900])
```

When a `\`\`\`` fence opens before the chunk boundary and closes after, the first chunk renders as a half-open code block on Discord; the second chunk leaks the literal trailing backticks as plain text. Affects both bots' outbound through this same code path.

## Fix

New helper `_chunk_for_discord(text, max_len=1900)`:

- Walks line-by-line, tracking triple-backtick fence state (open/closed).
- When a new line would push the buffer past `max_len`, closes the current fence (if open), yields the buffer, and reopens the fence in the next chunk.
- Single-line content longer than `max_len` gets hard-split mid-line with fence preservation.
- Returns no chunks for empty/None input.

Replaces both call sites (channel reply at L805, DM proactive at L910).

## Test plan

Local tests in commit message verified:

- [x] Short text → 1 chunk
- [x] 3000-char plain text with newlines → splits at line boundaries, all chunks ≤ max_len
- [x] Code block spanning multiple chunk boundaries → 5 chunks, ALL with balanced (even) fence counts
- [x] Empty/None input → no chunks
- [ ] Live Discord rendering check (Mini's bridge restarted with the fix)
- [ ] After Chi confirms working on Mini, MacBook merges on its side

## Coordination

Owner authorized fix-now via DM. Owner won't merge MacBook-side until tested on Mini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)