### PR TITLE
fix(brightness): remove rogue dark-mode-off osascript flipping theme

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -305,9 +305,6 @@ export const brightnessTool: ToolDefinition = {
 		if (level <= 1 && level > 0) level = Math.round(level * 100);
 		const bLevel = (level / 100).toFixed(2);
 		try {
-			execSync(`osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to false'`, { timeout: 1_000 }).toString();
-		} catch {} // ignore — just trying to ensure display is active
-		try {
 			execSync(`brightness ${bLevel}`, { timeout: 5_000 });
 			console.log(`${ts()} [Brightness] set to ${level}%`);
 			return { status: 'set', level };


### PR DESCRIPTION
## Summary

`brightnessTool` in `src/inline-tools.ts` ran an osascript that **disables macOS dark mode** before every brightness adjustment, with the misleading comment \"ensure display is active.\" The line literally toggles macOS Appearance to Light — has nothing to do with display power state or brightness.

Every voice command like \"make it brighter\" or \"set brightness to 50%\" silently flipped the user's macOS theme to light mode.

## Repro (live, just now)

Chi tried voice brightness adjustment at ~19:50 PT 2026-04-30. Brightness change failed AND theme flipped to Light. Manual revert via:

\`\`\`bash
osascript -e 'tell app \"System Events\" to tell appearance preferences to set dark mode to true'
\`\`\`

restored the theme.

## Fix

Remove the rogue try-block (3 lines). Brightness adjustment continues via the \`brightness\` CLI (line 311) and key-code fallback (lines 316-322) — both unaffected.

## Test plan

- [x] Type-check clean (`npx tsc --noEmit` — no errors in inline-tools.ts)
- [ ] Voice agent restart on merged main, verify \"make screen brighter\" doesn't flip Appearance
- [ ] Theme remains as user set it

🤖 Generated with [Claude Code](https://claude.com/claude-code)