### PR TITLE
feat(watcher): streaming watch-tasks-stream.sh for Monitor-tool invocation

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Streaming task watcher — companion to watch-tasks.sh.
+#
+# Runs fswatch indefinitely and emits ONE line per new task file appearance.
+# Designed to be invoked via Claude Code's `Monitor` tool, which streams
+# stdout lines as per-event notifications without process-restart cycles.
+#
+# Compared to watch-tasks.sh (one-shot, exits on first event so the caller
+# can be notified via process-exit): this script never exits during normal
+# operation. Migration is gated by which invocation pattern the agent uses
+# (Bash run_in_background vs Monitor), not by removing the old script.
+#
+# Output format per event:
+#   TASK_FILE: <basename>
+# Plus an INITIAL_SCAN block at startup for any pre-existing files:
+#   TASK_FILE: <basename>  (one per line)
+#
+# The agent reads the named files via the Read tool when notifications
+# arrive — no need to inline file contents in stdout (Monitor's 200ms
+# batching window would group multi-line content awkwardly).
+
+set -u
+
+TASKS_DIR="${1:-$(dirname "$0")/../tasks}"
+mkdir -p "$TASKS_DIR"
+
+# Initial sweep — surface any pre-existing tasks that arrived during a
+# restart gap.
+shopt -s nullglob
+for f in "$TASKS_DIR"/*.txt; do
+  echo "TASK_FILE: $(basename "$f")"
+done
+shopt -u nullglob
+
+# Stream subsequent events. -l 0.5 = 500ms latency batch (fswatch coalesces
+# burst events). --event Created --event Renamed catches new file
+# appearance whether it lands as a fresh write or a rename-into-place.
+fswatch \
+  -l 0.5 \
+  --event Created \
+  --event Renamed \
+  "$TASKS_DIR" 2>/dev/null \
+| while IFS= read -r path; do
+  case "$path" in
+    *.txt) echo "TASK_FILE: $(basename "$path")" ;;
+  esac
+done


### PR DESCRIPTION
## Summary

- Adds `src/watch-tasks-stream.sh` — companion to `src/watch-tasks.sh`, runs `fswatch` indefinitely and emits one line per new task file (`TASK_FILE: <basename>`) without exiting.
- Designed to be invoked via Claude Code's `Monitor` tool, which streams stdout lines as per-event notifications without process-restart cycles.
- Both scripts coexist; migration is gated by which invocation pattern the proactive-loop skill prompt uses, not by removing the old script. **No behavior change until that skill prompt is updated** — old `bash run_in_background` pattern keeps working.

## Why

The current pattern (`bash src/watch-tasks.sh` with `run_in_background: true`) is one-shot: fswatch exits on first event, the agent processes tasks, then restarts the watcher. Each cycle has a small gap during which a freshly-written task file can be missed (mitigated by initial-sweep on restart, but still adds churn). The Monitor-tool path eliminates the restart cycle entirely.

## Test plan

- [ ] Pull this branch and run `bash src/watch-tasks-stream.sh tasks/` directly. Drop a `.txt` file into `tasks/`. Verify a `TASK_FILE: <name>` line is emitted within ~500ms (fswatch latency batch).
- [ ] Verify the initial-sweep block prints any pre-existing `tasks/*.txt` on startup.
- [ ] Verify the script does NOT exit between events (existing `watch-tasks.sh` does).
- [ ] No proactive-loop skill change in this PR — the existing one-shot pattern continues working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)