### PR TITLE
chore(cross-node-sync): exclude self_identity.md from rsync

### DIFF
--- a/skills/cross-node-sync/scripts/setup-rsync-sync.sh
+++ b/skills/cross-node-sync/scripts/setup-rsync-sync.sh
@@ -91,6 +91,7 @@ RSYNC_FLAGS=(-az --update
     --exclude '.DS_Store' --exclude '*.swp' --exclude '*.swo'
     --exclude '.stversions' --exclude '.stfolder'
     --exclude 'MEMORY.md' --exclude 'INDEX.md'
+    --exclude 'self_identity.md'
     --exclude 'core-status.json')
 # core-status.json is per-node proactive-loop state that occasionally lands
 # in the memory dir (voice-agent + proactive-loop both write to it and


### PR DESCRIPTION
## Summary
- Adds `--exclude 'self_identity.md'` to the cross-node rsync flags.
- Each node now keeps its own per-node identity file (Lucy on Mac Studio, Maddy on MacBook) without overwriting the other side's during sync.

## Why
Sessions on different nodes were misidentifying themselves. Reading "I (core)" in synced memory like `reference_identities.md` is ambiguous after sync — the writing node's "I" gets read as "you" on the receiver. Today (2026-05-02) the Mac Studio session mistakenly self-identified as Maddy after reading a synced memory line written from the MacBook side. Per-node `self_identity.md` files (resolved against `hostname`) fix this, but only if sync doesn't clobber them.

## Test plan
- [x] Run `setup-rsync-sync.sh --dry-run` — confirm `--exclude self_identity.md` appears in both legs.
- [x] Run live sync from Mac Studio (this node has Lucy's `self_identity.md`). Verify MacBook's `self_identity.md` still says "You are Maddy" after sync. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)