### PR TITLE
fix(voice-agent): surface non-retryable Gemini Live close reasons to user

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -34,6 +34,7 @@ import type { MainAgent, ToolDefinition } from 'bodhi-realtime-agent';
 function assertMacOS() { if (process.platform !== 'darwin') { console.error('Sutando requires macOS'); process.exit(1); } }
 import { workTool, startResultWatcher, startContextDropWatcher, startNoteViewingWatcher, resetNoteViewingDebounce, logConversation, logSessionBoundary, getRecentConversation, getSecondsSinceLastTurn, setTaskStatusCallback } from './task-bridge.js';
 import { buildSutandoSystemPrompt, buildVoiceAgentContext } from './voice-context.js';
+import { classifyTransportClose, type ClassifiedClose } from './voice-error-classifier.js';
 
 import { personalPath, sharedPersonalPath } from './util_paths.js';
 
@@ -807,6 +808,65 @@ async function main() {
 	});
 
 	sessionRef = session;
+
+	// Wire voice-failure classifier: when the Gemini Live transport closes
+	// with a non-retryable reason (credits depleted, quota exceeded, key
+	// invalid, model not found), surface an actionable message via the
+	// proactive-result channel + an OS notification. Throttled per category
+	// so the 30s reconnect loop doesn't spam.
+	(() => {
+		const transport = (session as any).transport;
+		if (!transport || typeof transport !== 'object') {
+			console.error(`${ts()} [VoiceFailure] no transport on session — classifier not wired`);
+			return;
+		}
+		const origOnClose = typeof transport.onClose === 'function'
+			? transport.onClose.bind(transport)
+			: null;
+		const notifiedCategories = new Set<string>();
+		const handleClose = (c: ClassifiedClose): void => {
+			if (c.retryable) return;
+			if (notifiedCategories.has(c.category)) return;
+			notifiedCategories.add(c.category);
+			console.error(`${ts()} [VoiceFailure] ${c.category}: ${c.userMessage} (raw="${c.rawReason}")`);
+			// Surface via proactive-result channel — picked up by web-client
+			// task feed and the Discord/Telegram bridges if configured.
+			try {
+				const tsMs = Date.now();
+				const path = join(WORKSPACE_DIR, 'results', `proactive-voice-${c.category}-${tsMs}.txt`);
+				const body = c.userActionUrl
+					? `${c.userMessage} ${c.userActionUrl}`
+					: c.userMessage;
+				writeFileSync(path, body);
+			} catch (e) {
+				console.error(`${ts()} [VoiceFailure] proactive write failed: ${(e as Error)?.message ?? e}`);
+			}
+			// OS notification — visible even if no browser tab is open.
+			// Sanitize the message for the AppleScript string literal: drop
+			// double-quotes and backslashes so the shell command can't break.
+			try {
+				const safe = c.userMessage.replace(/["\\]/g, '');
+				execSyncTop(
+					`osascript -e 'display notification "${safe}" with title "Sutando — voice offline"'`,
+					{ stdio: 'ignore' } as any,
+				);
+			} catch {}
+		};
+		transport.onClose = (code?: number, reason?: string) => {
+			if (origOnClose) {
+				try { origOnClose(code, reason); } catch (e) {
+					console.error(`${ts()} [VoiceFailure] origOnClose threw: ${(e as Error)?.message ?? e}`);
+				}
+			}
+			try {
+				const c = classifyTransportClose(code, reason);
+				handleClose(c);
+			} catch (e) {
+				console.error(`${ts()} [VoiceFailure] classifier threw: ${(e as Error)?.message ?? e}`);
+			}
+		};
+		console.log(`${ts()} [VoiceFailure] classifier wired into transport.onClose`);
+	})();
 
 	// Wire narration-tee: capture Gemini's outbound audio for screen recordings
 	try {

--- a/src/voice-error-classifier.ts
+++ b/src/voice-error-classifier.ts
@@ -1,0 +1,106 @@
+/**
+ * Classify Gemini Live transport close events into actionable categories.
+ *
+ * The Gemini Live WebSocket closes with code 1011 and a human-readable
+ * `reason` string for several distinct failure modes that look identical to
+ * the user ("Disconnected") today. We pattern-match on the reason text to
+ * tell them apart so the voice agent can surface a useful message and stop
+ * silently retrying.
+ *
+ * Default behavior is conservative: anything we don't recognize is treated
+ * as `retryable` so existing reconnect logic is preserved. The classifier
+ * only flips `retryable: false` when the reason text matches a known
+ * action-required pattern.
+ */
+
+export type FailureCategory =
+	| 'quota_exceeded'      // Free-tier RPM/RPD cap with no billing on the project
+	| 'credits_depleted'    // Paid-tier prepayment balance hit zero
+	| 'auth_invalid'        // Key revoked, expired, or malformed
+	| 'model_not_found'     // Configured model name no longer valid
+	| 'rate_limit'          // Transient 429 — bodhi will retry, no user action
+	| 'transient'           // Normal close (1000) or other expected closures
+	| 'unknown';            // Did not match any pattern — assume transient
+
+export interface ClassifiedClose {
+	category: FailureCategory;
+	retryable: boolean;
+	userMessage: string;
+	userActionUrl?: string;
+	rawCode?: number;
+	rawReason: string;
+}
+
+const PATTERNS: Array<{
+	rx: RegExp;
+	category: FailureCategory;
+	retryable: boolean;
+	userMessage: string;
+	userActionUrl: string;
+}> = [
+	{
+		rx: /prepayment.{0,20}credits.{0,20}depleted|prepayment.{0,20}depleted/i,
+		category: 'credits_depleted',
+		retryable: false,
+		userMessage: 'Voice is offline — Gemini prepayment credits are depleted. Top up to restore voice.',
+		userActionUrl: 'https://ai.studio/projects',
+	},
+	{
+		rx: /exceeded your current quota|quota.{0,20}exceeded|quota.{0,20}exhausted/i,
+		category: 'quota_exceeded',
+		retryable: false,
+		userMessage: 'Voice is offline — Gemini quota exceeded. Enable billing on the linked GCP project to restore voice.',
+		userActionUrl: 'https://console.cloud.google.com/billing',
+	},
+	{
+		rx: /api.?key.{0,20}(not valid|invalid)|invalid.{0,20}api.?key|api_key_invalid|permission_denied|unauthorized|\b401\b|\b403\b/i,
+		category: 'auth_invalid',
+		retryable: false,
+		userMessage: 'Voice is offline — Gemini API key is invalid or revoked. Update GEMINI_API_KEY in .env.',
+		userActionUrl: 'https://aistudio.google.com/apikey',
+	},
+	{
+		// Real Gemini API errors put the full model path between "model" and
+		// "not found" (e.g. "models/gemini-3.1-flash-live-preview is not
+		// found for API version v1beta") — match on the API's verbatim
+		// phrasing rather than requiring tight proximity.
+		rx: /is not found for API version|not supported for|\bmodels?\/\S+\s+(is\s+)?not\s+found|\b404\b|\bdeprecated\b/i,
+		category: 'model_not_found',
+		retryable: false,
+		userMessage: 'Voice is offline — configured Gemini voice model is unavailable. Update VOICE_NATIVE_AUDIO_MODEL in .env.',
+		userActionUrl: 'https://ai.google.dev/gemini-api/docs/models',
+	},
+	{
+		rx: /rate.?limit|too many requests|\b429\b/i,
+		category: 'rate_limit',
+		retryable: true,
+		userMessage: 'Voice is briefly rate-limited; reconnecting.',
+		userActionUrl: '',
+	},
+];
+
+export function classifyTransportClose(
+	code: number | undefined,
+	reason: string | undefined,
+): ClassifiedClose {
+	const text = (reason ?? '').trim();
+	for (const p of PATTERNS) {
+		if (p.rx.test(text)) {
+			return {
+				category: p.category,
+				retryable: p.retryable,
+				userMessage: p.userMessage,
+				userActionUrl: p.userActionUrl || undefined,
+				rawCode: code,
+				rawReason: text,
+			};
+		}
+	}
+	return {
+		category: code === 1000 ? 'transient' : 'unknown',
+		retryable: true,
+		userMessage: '',
+		rawCode: code,
+		rawReason: text,
+	};
+}

--- a/tests/voice-error-classifier.test.ts
+++ b/tests/voice-error-classifier.test.ts
@@ -1,0 +1,81 @@
+// Unit tests for the Gemini Live transport-close classifier.
+// Patterns derived from real Gemini API close-reason texts observed in
+// production logs (see commit message for the failure incident that
+// motivated this).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyTransportClose } from '../src/voice-error-classifier.ts';
+
+test('credits_depleted: paid-tier prepayment exhausted', () => {
+	const r = classifyTransportClose(
+		1011,
+		'Your prepayment credits are depleted. Please go to AI Studio at https://ai.studio/projects to manage your project and billi',
+	);
+	assert.equal(r.category, 'credits_depleted');
+	assert.equal(r.retryable, false);
+	assert.match(r.userMessage, /credits/i);
+	assert.equal(r.userActionUrl, 'https://ai.studio/projects');
+});
+
+test('quota_exceeded: free-tier RPM/RPD cap with no billing', () => {
+	const r = classifyTransportClose(
+		1011,
+		'You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: h',
+	);
+	assert.equal(r.category, 'quota_exceeded');
+	assert.equal(r.retryable, false);
+	assert.match(r.userActionUrl ?? '', /billing/);
+});
+
+test('auth_invalid: revoked or malformed key', () => {
+	const r1 = classifyTransportClose(1011, 'API key not valid. Please pass a valid API key.');
+	assert.equal(r1.category, 'auth_invalid');
+	assert.equal(r1.retryable, false);
+
+	const r2 = classifyTransportClose(undefined, 'PERMISSION_DENIED: caller does not have access');
+	assert.equal(r2.category, 'auth_invalid');
+});
+
+test('model_not_found: configured model unavailable', () => {
+	const r = classifyTransportClose(
+		1011,
+		'models/gemini-3.1-flash-live-preview is not found for API version v1beta',
+	);
+	assert.equal(r.category, 'model_not_found');
+	assert.equal(r.retryable, false);
+});
+
+test('rate_limit: transient 429 stays retryable', () => {
+	const r = classifyTransportClose(1011, 'Too Many Requests: rate-limit exceeded');
+	assert.equal(r.category, 'rate_limit');
+	assert.equal(r.retryable, true);
+});
+
+test('transient: normal close (1000) keeps retrying', () => {
+	const r = classifyTransportClose(1000, 'normal close');
+	assert.equal(r.category, 'transient');
+	assert.equal(r.retryable, true);
+});
+
+test('unknown: unrecognized 1011 reason defaults to retryable', () => {
+	// Conservative default — unknown close reasons must not stop the
+	// existing reconnect loop. The caller will keep retrying; only
+	// matched patterns flip retryable to false.
+	const r = classifyTransportClose(1011, 'something we have not seen before');
+	assert.equal(r.category, 'unknown');
+	assert.equal(r.retryable, true);
+});
+
+test('missing reason and code: still produces a result', () => {
+	const r = classifyTransportClose(undefined, undefined);
+	assert.equal(r.category, 'unknown');
+	assert.equal(r.retryable, true);
+	assert.equal(r.rawReason, '');
+});
+
+test('rawCode and rawReason are preserved', () => {
+	const r = classifyTransportClose(1011, 'Your prepayment credits are depleted.');
+	assert.equal(r.rawCode, 1011);
+	assert.match(r.rawReason, /prepayment/);
+});


### PR DESCRIPTION
## Issue

When Gemini Live closes the WebSocket with code 1011 for a non-retryable reason (paid-tier credits depleted, free-tier quota exhausted, key invalid, model not found), `voice-agent` retried silently every 30s and the user had no surface signal beyond "Disconnected" in the browser. Observed twice in one session: free-tier quota, then again hours later when prepayment credits depleted.

## Root cause

bodhi's `GeminiLiveTransport` delivers the close `code` + `reason` via `transport.onClose`, but `voice-agent` only consumed the high-level `FrameworkHooks.onError`, which carries the symptom (`"Gemini connect timed out"`) rather than the underlying reason text. The 1011 reason string distinguishing the failure modes never reached any user-facing channel — only the per-session console log.

## Fix

- New `src/voice-error-classifier.ts`: pure function that pattern-matches the close reason against four known non-retryable categories (`credits_depleted`, `quota_exceeded`, `auth_invalid`, `model_not_found`) plus `rate_limit`. Anything else stays retryable so existing reconnect logic is preserved.
- `voice-agent.ts` wraps `(session as any).transport.onClose` using the same monkey-patch pattern already used for `handleAudioOutput`. On a non-retryable category it writes `results/proactive-voice-<category>-<ts>.txt` with an actionable message and action URL, then fires one `osascript` notification. Throttled per category so the 30s reconnect loop doesn't spam.

No changes to prompts, tools, or web-client — the proactive-result channel already surfaces in the browser task feed and the Discord/Telegram bridges.

## Test

- **Unit**: 9 cases in `tests/voice-error-classifier.test.ts` covering each real Gemini close reason verbatim, plus default-retryable for unknown reasons and missing input. `npm test` = 122/122 pass.
- **Type check**: `tsc --noEmit` clean.
- **Side-effect smoke**: replicated `handleClose` body against all four non-retryable categories — proactive files written with correct messages and URLs, `osascript` fired.
- **In-vivo**: voice-agent restart logs `[VoiceFailure] classifier wired into transport.onClose` — wrapper installed, no impact on the healthy path (existing voice connect succeeded).