### PR TITLE
feat(voice-agent): bootstrap memory dir + MEMORY.md on startup

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -29,6 +29,7 @@ import { execSync as execSyncTop } from 'node:child_process';
 import { inlineTools } from './inline-tools.js';
 import { injectText } from './browser-tools.js';
 import { join } from 'node:path';
+import { homedir } from 'node:os';
 import { VoiceSession } from 'bodhi-realtime-agent';
 import type { MainAgent, ToolDefinition } from 'bodhi-realtime-agent';
 function assertMacOS() { if (process.platform !== 'darwin') { console.error('Sutando requires macOS'); process.exit(1); } }
@@ -700,8 +701,30 @@ const mainAgent: MainAgent = {
 // Main
 // =============================================================================
 
+// Ensure the long-term memory directory exists at startup so the agent can
+// proactively write user_profile / feedback / project / reference files
+// without first having to remember to mkdir. Honours $SUTANDO_MEMORY_DIR
+// when set; otherwise uses the Claude Code default
+// (~/.claude/projects/-{slug}/memory). Failure-silent: a missing memory
+// dir should never block voice startup.
+function bootstrapMemoryDir(): void {
+	const slug = '-' + WORKSPACE_DIR.replace(/\/$/, '').split('/').filter(Boolean).join('-');
+	const memDir = process.env.SUTANDO_MEMORY_DIR || join(homedir(), '.claude', 'projects', slug, 'memory');
+	try {
+		mkdirSync(memDir, { recursive: true });
+		const indexPath = join(memDir, 'MEMORY.md');
+		if (!existsSync(indexPath)) {
+			writeFileSync(indexPath, '# Sutando memory index\n\nDurable facts about the user, project, and references. One line per entry: `- [Title](file.md) — one-line hook`. See CLAUDE.md `## Memory` for the schema.\n');
+			console.log(`${ts()} [Memory] Initialized ${memDir}`);
+		}
+	} catch (err) {
+		console.log(`${ts()} [Memory] bootstrap failed (non-fatal): ${err instanceof Error ? err.message : err}`);
+	}
+}
+
 async function main() {
 	assertMacOS();
+	bootstrapMemoryDir();
 
 	// --- Voice agent observability ---
 	// Same format as phone agent's call-metrics.jsonl so diagnose.py can analyze both.

--- a/tests/memory-bootstrap.test.ts
+++ b/tests/memory-bootstrap.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync, existsSync, readFileSync, mkdtempSync, rmSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir, tmpdir } from 'node:os';
+
+/**
+ * Tests for bootstrapMemoryDir() in src/voice-agent.ts.
+ *
+ * The predicate is replicated locally rather than imported because pulling
+ * voice-agent.ts loads the entire bodhi runtime + ts-side env reads — same
+ * pattern as end-session-gate.test.ts and replay-gate.test.ts.
+ *
+ * Coverage: directory creation, placeholder MEMORY.md content, no-clobber
+ * on existing index, SUTANDO_MEMORY_DIR env override, silent failure when
+ * the parent is unwritable.
+ */
+
+function bootstrapMemoryDir(workspaceDir: string, envOverride?: string): { memDir: string; created: boolean; error?: string } {
+	const slug = '-' + workspaceDir.replace(/\/$/, '').split('/').filter(Boolean).join('-');
+	const memDir = envOverride || join(homedir(), '.claude', 'projects', slug, 'memory');
+	let created = false;
+	try {
+		mkdirSync(memDir, { recursive: true });
+		const indexPath = join(memDir, 'MEMORY.md');
+		if (!existsSync(indexPath)) {
+			writeFileSync(indexPath, '# Sutando memory index\n\nDurable facts about the user, project, and references. One line per entry: `- [Title](file.md) — one-line hook`. See CLAUDE.md `## Memory` for the schema.\n');
+			created = true;
+		}
+	} catch (err) {
+		return { memDir, created: false, error: err instanceof Error ? err.message : String(err) };
+	}
+	return { memDir, created };
+}
+
+let scratch: string;
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), 'sutando-mem-bootstrap-'));
+});
+
+afterEach(() => {
+	try { chmodSync(scratch, 0o755); } catch {}
+	try { rmSync(scratch, { recursive: true, force: true }); } catch {}
+});
+
+describe('bootstrapMemoryDir — directory creation', () => {
+	it('creates memDir and MEMORY.md when nothing exists', () => {
+		const memDir = join(scratch, 'memory');
+		const out = bootstrapMemoryDir('/Users/test/GitHub/sutando', memDir);
+		assert.equal(out.error, undefined);
+		assert.equal(out.created, true);
+		assert.equal(existsSync(memDir), true);
+		assert.equal(existsSync(join(memDir, 'MEMORY.md')), true);
+	});
+
+	it('writes the placeholder header pointing to CLAUDE.md schema', () => {
+		const memDir = join(scratch, 'memory');
+		bootstrapMemoryDir('/Users/test/GitHub/sutando', memDir);
+		const body = readFileSync(join(memDir, 'MEMORY.md'), 'utf-8');
+		assert.match(body, /^# Sutando memory index/);
+		assert.match(body, /CLAUDE\.md `## Memory`/);
+	});
+
+	it('is idempotent on re-run with no MEMORY.md changes', () => {
+		const memDir = join(scratch, 'memory');
+		const first = bootstrapMemoryDir('/Users/test/GitHub/sutando', memDir);
+		const second = bootstrapMemoryDir('/Users/test/GitHub/sutando', memDir);
+		assert.equal(first.created, true);
+		assert.equal(second.created, false, 'second call should NOT recreate MEMORY.md');
+	});
+});
+
+describe('bootstrapMemoryDir — no-clobber on existing index', () => {
+	it('leaves existing MEMORY.md untouched', () => {
+		const memDir = join(scratch, 'memory');
+		mkdirSync(memDir, { recursive: true });
+		const custom = '# My existing memory\n\n- [user_profile](user_profile.md) — Chi\n';
+		writeFileSync(join(memDir, 'MEMORY.md'), custom);
+		const out = bootstrapMemoryDir('/Users/test/GitHub/sutando', memDir);
+		assert.equal(out.created, false);
+		const after = readFileSync(join(memDir, 'MEMORY.md'), 'utf-8');
+		assert.equal(after, custom, 'existing MEMORY.md must be preserved verbatim');
+	});
+
+	it('still ensures the dir exists even if MEMORY.md is the only thing missing inside an existing dir', () => {
+		const memDir = join(scratch, 'memory');
+		mkdirSync(memDir, { recursive: true });
+		const out = bootstrapMemoryDir('/Users/test/GitHub/sutando', memDir);
+		assert.equal(out.created, true);
+		assert.equal(existsSync(join(memDir, 'MEMORY.md')), true);
+	});
+});
+
+describe('bootstrapMemoryDir — env override', () => {
+	it('uses SUTANDO_MEMORY_DIR when provided instead of the slug-derived default', () => {
+		const customDir = join(scratch, 'custom-memory');
+		const out = bootstrapMemoryDir('/Users/test/GitHub/sutando', customDir);
+		assert.equal(out.memDir, customDir, 'override path must be honoured');
+		assert.equal(existsSync(customDir), true);
+	});
+
+	it('derives slug from workspace dir when no override is given', () => {
+		const out = bootstrapMemoryDir('/Users/test/GitHub/sutando');
+		const expected = join(homedir(), '.claude', 'projects', '-Users-test-GitHub-sutando', 'memory');
+		assert.equal(out.memDir, expected);
+	});
+
+	it('strips a trailing slash from the workspace dir before slugging', () => {
+		const out = bootstrapMemoryDir('/Users/test/GitHub/sutando/');
+		const expected = join(homedir(), '.claude', 'projects', '-Users-test-GitHub-sutando', 'memory');
+		assert.equal(out.memDir, expected);
+	});
+});
+
+describe('bootstrapMemoryDir — failure-silent', () => {
+	it('returns an error string instead of throwing when the parent is unwritable', () => {
+		const lockedParent = join(scratch, 'locked');
+		mkdirSync(lockedParent, { recursive: true });
+		chmodSync(lockedParent, 0o500); // r-x — cannot create children
+		const memDir = join(lockedParent, 'memory');
+		const out = bootstrapMemoryDir('/Users/test/GitHub/sutando', memDir);
+		assert.notEqual(out.error, undefined, 'unwritable parent should be reported as an error');
+		assert.equal(out.created, false);
+		assert.equal(existsSync(memDir), false);
+	});
+});


### PR DESCRIPTION
## Summary

The agent's system prompt + CLAUDE.md both expect a long-term memory store at `$SUTANDO_MEMORY_DIR` (default `~/.claude/projects/-{slug}/memory`). On a fresh install the dir doesn't exist, so the first time the agent infers a durable fact about the user it has nowhere to write — and tends to skip the write entirely. Onboarding looks silent: the agent says "I have no memory yet" but never creates the place to store it.

This patch adds a single `bootstrapMemoryDir()` call right after `assertMacOS()` in `src/voice-agent.ts`:

- Computes the memory dir path (env override `SUTANDO_MEMORY_DIR`; otherwise the canonical Claude Code project path)
- `mkdirSync(memDir, { recursive: true })` — no-op if exists
- If `MEMORY.md` is missing, writes a placeholder header pointing at the schema in CLAUDE.md
- Failure-silent: a missing memory dir should never block voice startup; logs `[Memory] bootstrap failed (non-fatal)` if anything goes wrong

This is part 2 of a three-part proactive-memory fix. Part 1 (drafts of `user_profile.md` / `feedback_response_style.md` / `MEMORY.md`) and part 3 (add a memory-hygiene step to `skills/proactive-loop/SKILL.md`) are tracked separately and gated on owner approval.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Path computation verified externally — slug `-Users-vasiliyr-GitHub-sutando` resolves to `/Users/vasiliyr/.claude/projects/-Users-vasiliyr-GitHub-sutando/memory`, matching CLAUDE.md `## Memory`
- [ ] On next voice-agent restart, expect `[Memory] Initialized <path>` log line on first run; subsequent runs no-op silently
- [ ] Verify `MEMORY.md` is created with the placeholder header and is editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)