### PR TITLE
feat(init): idempotent bootstrap script + preflight summary

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# Sutando init — idempotent first-run + every-start bootstrap.
+# Usage:
+#   bash src/init.sh             # Tier 1 + Tier 2 (verbose)
+#   bash src/init.sh --auto      # Tier 1 only (silent, called from startup.sh)
+#   bash src/init.sh --preflight # Tier 2 only (env + perms + tools)
+#
+# Tier 1: create-if-missing files and dirs. Never clobbers existing content.
+# Tier 2: preflight checks. Warns loudly but never blocks startup.
+
+set -e
+
+REPO="${SUTANDO_REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
+MODE="${1:-full}"
+
+case "$MODE" in
+  --auto|--preflight|--full|full) ;;
+  *) echo "Usage: bash src/init.sh [--auto | --preflight]"; exit 2;;
+esac
+
+log() {
+  # Quiet under --auto unless we're actually creating something
+  if [ "$MODE" != "--auto" ]; then echo "$@"; fi
+}
+
+create_file_if_missing() {
+  local path="$1"; local body="$2"
+  if [ ! -f "$REPO/$path" ]; then
+    mkdir -p "$(dirname "$REPO/$path")"
+    printf '%s' "$body" > "$REPO/$path"
+    echo "  ✓ created $path"
+  fi
+}
+
+create_dir_if_missing() {
+  local path="$1"
+  if [ ! -d "$REPO/$path" ]; then
+    mkdir -p "$REPO/$path"
+    echo "  ✓ created $path/"
+  fi
+}
+
+copy_if_missing() {
+  local src="$1"; local dst="$2"
+  if [ ! -f "$REPO/$dst" ] && [ -f "$REPO/$src" ]; then
+    cp "$REPO/$src" "$REPO/$dst"
+    echo "  ✓ created $dst (from $src)"
+  fi
+}
+
+# --- Tier 1: auto-bootstrap (always safe to run) ---
+tier1() {
+  log "Tier 1 — auto-bootstrap..."
+
+  # Directories
+  create_dir_if_missing "logs"
+  create_dir_if_missing "state"
+  create_dir_if_missing "tasks"
+  create_dir_if_missing "results"
+  create_dir_if_missing "results/archive"
+  create_dir_if_missing "results/calls"
+  create_dir_if_missing "notes"
+  create_dir_if_missing "data"
+
+  # Files — placeholders only, content added by the agent later
+  create_file_if_missing "build_log.md" \
+    "# Sutando build log
+
+Notes on what's built, what's next, and known issues. The proactive loop reads + updates this each pass.
+"
+
+  create_file_if_missing "pending-questions.md" \
+    "# Pending Questions
+
+_(none open)_
+"
+
+  create_file_if_missing "contextual-chips.json" \
+    "{\"chips\":[],\"ts\":$(date +%s)}
+"
+
+  create_file_if_missing "core-status.json" \
+    "{\"status\":\"idle\",\"ts\":$(date +%s)}
+"
+
+  create_file_if_missing "voice-state.json" \
+    "{\"connected\":false,\"ts\":$(date +%s)}
+"
+
+  # crons.json — copy from the example if present
+  copy_if_missing "skills/schedule-crons/crons.example.json" "skills/schedule-crons/crons.json"
+}
+
+# --- Tier 2: preflight (warn, don't block) ---
+preflight() {
+  log "Tier 2 — preflight checks..."
+
+  local required_ok=0
+  local required_total=0
+  local optional_ok=0
+  local optional_total=0
+  local cli_missing=()
+
+  # .env required keys
+  required_total=$((required_total + 1))
+  if [ -f "$REPO/.env" ]; then
+    if grep -qE '^GEMINI_API_KEY=.+' "$REPO/.env"; then
+      required_ok=$((required_ok + 1))
+    else
+      log "  ✗ GEMINI_API_KEY missing from .env (required for voice)"
+    fi
+  else
+    log "  ✗ .env missing (cp .env.example .env if it exists)"
+  fi
+
+  # .env optional keys — count what's set in the repo .env
+  local optional_keys="TWILIO_ACCOUNT_SID NGROK_DOMAIN CARTESIA_API_KEY X_API_KEY ANTHROPIC_API_KEY GOOGLE_APPLICATION_CREDENTIALS"
+  for key in $optional_keys; do
+    optional_total=$((optional_total + 1))
+    if [ -f "$REPO/.env" ] && grep -qE "^${key}=.+" "$REPO/.env"; then
+      optional_ok=$((optional_ok + 1))
+    fi
+  done
+
+  # External channel envs — Discord / Telegram bot tokens live outside the repo .env
+  optional_total=$((optional_total + 1))
+  if [ -f "$HOME/.claude/channels/discord/.env" ] && grep -qE '^DISCORD_BOT_TOKEN=.+' "$HOME/.claude/channels/discord/.env"; then
+    optional_ok=$((optional_ok + 1))
+  fi
+  optional_total=$((optional_total + 1))
+  if [ -f "$HOME/.claude/channels/telegram/.env" ] && grep -qE '^TELEGRAM_BOT_TOKEN=.+' "$HOME/.claude/channels/telegram/.env"; then
+    optional_ok=$((optional_ok + 1))
+  fi
+
+  # CLI tools
+  for tool in node npx python3 fswatch claude gh; do
+    if ! command -v "$tool" > /dev/null 2>&1; then
+      cli_missing+=("$tool")
+    fi
+  done
+
+  # macOS permissions — non-fatal, just a hint
+  local perms_warn=0
+  if ! screencapture -x /tmp/sutando-permcheck.png 2>/dev/null; then
+    log "  ⚠ Screen Recording not granted (System Settings → Privacy → Screen Recording)"
+    perms_warn=1
+  else
+    rm -f /tmp/sutando-permcheck.png
+  fi
+  if ! osascript -e 'tell application "System Events" to get name of first process whose frontmost is true' > /dev/null 2>&1; then
+    log "  ⚠ Accessibility not granted (System Settings → Privacy → Accessibility)"
+    perms_warn=1
+  fi
+
+  # One-line summary regardless of mode (this is the value-add)
+  local cli_str="all-ok"
+  if [ ${#cli_missing[@]} -gt 0 ]; then cli_str="missing: ${cli_missing[*]}"; fi
+  local perms_str="ok"
+  if [ "$perms_warn" -eq 1 ]; then perms_str="incomplete"; fi
+  echo "[Preflight] required=${required_ok}/${required_total}  optional=${optional_ok}/${optional_total}  cli=${cli_str}  perms=${perms_str}"
+}
+
+case "$MODE" in
+  --auto)       tier1 ;;
+  --preflight)  preflight ;;
+  *)            tier1; preflight ;;
+esac

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -7,11 +7,20 @@ set -e
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO"
 
-# Ensure runtime directories exist (gitignored; created on fresh clones)
-mkdir -p logs state
+# Auto-bootstrap: create-if-missing files and dirs that the agent + skills
+# expect to exist (logs, state, tasks, results, notes, contextual-chips.json,
+# pending-questions.md, build_log.md, crons.json, …). Idempotent — safe to
+# run on every start. Replaces the bare `mkdir -p logs state` that used to
+# live here. See src/init.sh for the full list.
+bash "$REPO/src/init.sh" --auto
 
 echo "Sutando startup..."
 echo ""
+
+# Preflight summary line — what env / CLI / perms are missing. One line, no
+# blocking; problems are surfaced but startup continues so the user can fix
+# things piece by piece.
+bash "$REPO/src/init.sh" --preflight | tail -1
 
 # Install dependencies if needed
 if [ ! -d node_modules ]; then

--- a/tests/init-script.test.ts
+++ b/tests/init-script.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync, existsSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Tests for src/init.sh — the auto-bootstrap + preflight script.
+ *
+ * Each test runs the actual shell script against a fresh tmpdir treated
+ * as a synthetic Sutando repo (we point the script at it via SUTANDO_REPO).
+ * That gives us real coverage without trampling the developer's actual
+ * repo state.
+ */
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const INIT_SH = join(REPO_ROOT, 'src', 'init.sh');
+
+interface RunResult { stdout: string; stderr: string; status: number | null }
+
+function runInit(repoDir: string, mode?: '--auto' | '--preflight'): RunResult {
+	const args = ['bash', INIT_SH];
+	if (mode) args.push(mode);
+	const proc = spawnSync(args[0]!, args.slice(1), {
+		env: { ...process.env, SUTANDO_REPO: repoDir, HOME: repoDir + '/.fake-home' },
+		encoding: 'utf-8',
+	});
+	return { stdout: proc.stdout, stderr: proc.stderr, status: proc.status };
+}
+
+let scratch: string;
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), 'sutando-init-'));
+});
+
+afterEach(() => {
+	try { rmSync(scratch, { recursive: true, force: true }); } catch {}
+});
+
+describe('init.sh --auto (Tier 1: directories)', () => {
+	it('creates every expected directory in an empty repo', () => {
+		const out = runInit(scratch, '--auto');
+		assert.equal(out.status, 0, `script exit non-zero: stderr=${out.stderr}`);
+		for (const d of ['logs', 'state', 'tasks', 'results', 'results/archive', 'results/calls', 'notes', 'data']) {
+			assert.equal(existsSync(join(scratch, d)), true, `expected directory ${d}`);
+		}
+	});
+
+	it('is idempotent — second invocation does not error or recreate', () => {
+		runInit(scratch, '--auto');
+		const before = statSync(join(scratch, 'logs')).birthtimeMs;
+		const second = runInit(scratch, '--auto');
+		assert.equal(second.status, 0);
+		const after = statSync(join(scratch, 'logs')).birthtimeMs;
+		assert.equal(before, after, 'logs/ should not be recreated on second run');
+	});
+});
+
+describe('init.sh --auto (Tier 1: placeholder files)', () => {
+	it('creates build_log.md with a header pointing at the proactive loop', () => {
+		runInit(scratch, '--auto');
+		const body = readFileSync(join(scratch, 'build_log.md'), 'utf-8');
+		assert.match(body, /^# Sutando build log/);
+		assert.match(body, /proactive loop/i);
+	});
+
+	it('creates pending-questions.md with an empty placeholder', () => {
+		runInit(scratch, '--auto');
+		const body = readFileSync(join(scratch, 'pending-questions.md'), 'utf-8');
+		assert.match(body, /^# Pending Questions/);
+		assert.match(body, /none open/);
+	});
+
+	it('creates contextual-chips.json with a parseable shape', () => {
+		runInit(scratch, '--auto');
+		const body = readFileSync(join(scratch, 'contextual-chips.json'), 'utf-8');
+		const parsed = JSON.parse(body);
+		assert.equal(Array.isArray(parsed.chips), true);
+		assert.equal(typeof parsed.ts, 'number');
+	});
+
+	it('creates core-status.json initialised to idle', () => {
+		runInit(scratch, '--auto');
+		const body = readFileSync(join(scratch, 'core-status.json'), 'utf-8');
+		const parsed = JSON.parse(body);
+		assert.equal(parsed.status, 'idle');
+	});
+
+	it('creates voice-state.json initialised to disconnected', () => {
+		runInit(scratch, '--auto');
+		const body = readFileSync(join(scratch, 'voice-state.json'), 'utf-8');
+		const parsed = JSON.parse(body);
+		assert.equal(parsed.connected, false);
+	});
+
+	it('does NOT clobber an existing build_log.md', () => {
+		writeFileSync(join(scratch, 'build_log.md'), '# my custom log\n\nimportant content\n');
+		runInit(scratch, '--auto');
+		const body = readFileSync(join(scratch, 'build_log.md'), 'utf-8');
+		assert.equal(body, '# my custom log\n\nimportant content\n');
+	});
+
+	it('does NOT clobber an existing contextual-chips.json', () => {
+		writeFileSync(join(scratch, 'contextual-chips.json'), '{"chips":[{"label":"x","desc":"y"}],"ts":1}');
+		runInit(scratch, '--auto');
+		const body = readFileSync(join(scratch, 'contextual-chips.json'), 'utf-8');
+		assert.match(body, /"label":"x"/);
+	});
+});
+
+describe('init.sh --auto (Tier 1: crons.json copy)', () => {
+	it('copies crons.example.json → crons.json when example exists and target is missing', () => {
+		const exampleDir = join(scratch, 'skills', 'schedule-crons');
+		mkdirSync(exampleDir, { recursive: true });
+		writeFileSync(join(exampleDir, 'crons.example.json'), '[{"name":"foo","cron":"* * * * *"}]');
+		runInit(scratch, '--auto');
+		const body = readFileSync(join(exampleDir, 'crons.json'), 'utf-8');
+		assert.match(body, /"foo"/);
+	});
+
+	it('does NOT copy when the target already exists', () => {
+		const exampleDir = join(scratch, 'skills', 'schedule-crons');
+		mkdirSync(exampleDir, { recursive: true });
+		writeFileSync(join(exampleDir, 'crons.example.json'), '[{"name":"example"}]');
+		writeFileSync(join(exampleDir, 'crons.json'), '[{"name":"my-custom"}]');
+		runInit(scratch, '--auto');
+		const body = readFileSync(join(exampleDir, 'crons.json'), 'utf-8');
+		assert.match(body, /my-custom/);
+	});
+
+	it('skips silently when no example file exists (fresh template install case)', () => {
+		const out = runInit(scratch, '--auto');
+		assert.equal(out.status, 0);
+		assert.equal(existsSync(join(scratch, 'skills/schedule-crons/crons.json')), false);
+	});
+});
+
+describe('init.sh --preflight (Tier 2: missing-env detection)', () => {
+	it('reports required=0/1 when .env is missing', () => {
+		const out = runInit(scratch, '--preflight');
+		assert.equal(out.status, 0);
+		assert.match(out.stdout, /\[Preflight\] required=0\/1/);
+	});
+
+	it('reports required=1/1 when GEMINI_API_KEY is set', () => {
+		writeFileSync(join(scratch, '.env'), 'GEMINI_API_KEY=fake-key-for-test\n');
+		const out = runInit(scratch, '--preflight');
+		assert.match(out.stdout, /\[Preflight\] required=1\/1/);
+	});
+
+	it('counts optional keys when set in .env', () => {
+		writeFileSync(join(scratch, '.env'), [
+			'GEMINI_API_KEY=k',
+			'TWILIO_ACCOUNT_SID=t',
+			'NGROK_DOMAIN=n',
+		].join('\n') + '\n');
+		const out = runInit(scratch, '--preflight');
+		assert.match(out.stdout, /optional=2\/8/);
+	});
+
+	it('counts external Discord/Telegram envs at $HOME/.claude/channels/...', () => {
+		writeFileSync(join(scratch, '.env'), 'GEMINI_API_KEY=k\n');
+		const fakeHome = join(scratch, '.fake-home');
+		mkdirSync(join(fakeHome, '.claude/channels/discord'), { recursive: true });
+		mkdirSync(join(fakeHome, '.claude/channels/telegram'), { recursive: true });
+		writeFileSync(join(fakeHome, '.claude/channels/discord/.env'), 'DISCORD_BOT_TOKEN=d\n');
+		writeFileSync(join(fakeHome, '.claude/channels/telegram/.env'), 'TELEGRAM_BOT_TOKEN=t\n');
+		const out = runInit(scratch, '--preflight');
+		assert.match(out.stdout, /optional=2\/8/);
+	});
+
+	it('always emits a single [Preflight] summary line on stdout', () => {
+		const out = runInit(scratch, '--preflight');
+		const summaries = out.stdout.split('\n').filter(l => l.startsWith('[Preflight]'));
+		assert.equal(summaries.length, 1);
+	});
+});
+
+describe('init.sh argument parsing', () => {
+	it('rejects unknown flags with a non-zero exit', () => {
+		const proc = spawnSync('bash', [INIT_SH, '--bogus'], {
+			env: { ...process.env, SUTANDO_REPO: scratch, HOME: scratch + '/.fake-home' },
+			encoding: 'utf-8',
+		});
+		assert.notEqual(proc.status, 0);
+		assert.match(proc.stderr + proc.stdout, /Usage:/);
+	});
+
+	it('runs both tiers by default (no flag)', () => {
+		const out = runInit(scratch);
+		assert.equal(out.status, 0);
+		assert.equal(existsSync(join(scratch, 'logs')), true, 'Tier 1 should have created logs/');
+		assert.match(out.stdout, /\[Preflight\]/, 'Tier 2 should have emitted summary line');
+	});
+});


### PR DESCRIPTION
## Summary

Implements proposals **P1 + P2** from today's system-design review (the audit you requested via voice). Closes the same class of "the spec mentions a file but nothing creates it" gap that #570 closed for the memory dir, but at the repo level instead of the user's home dir.

## What it does

`src/init.sh` (new):
- `--auto` (Tier 1): create-if-missing files and dirs that the agent + skills expect — `logs/`, `state/`, `tasks/`, `results/{archive,calls}/`, `notes/`, `data/`, `build_log.md`, `pending-questions.md`, `contextual-chips.json`, `core-status.json`, `voice-state.json`, and `skills/schedule-crons/crons.json` (copied from `crons.example.json`). Idempotent — never clobbers existing content.
- `--preflight` (Tier 2): single-line summary `[Preflight] required=N/M optional=N/M cli=… perms=…` covering required + optional `.env` keys (including the external Discord/Telegram envs at `$HOME/.claude/channels/…`), missing CLI tools, and macOS Screen Recording / Accessibility grants. Warns but never blocks.
- No flag (default): both tiers, verbose.

`src/startup.sh` (modified):
- Replaces the bare `mkdir -p logs state` with `bash src/init.sh --auto` so every start ensures the agent-expected files exist on a fresh clone.
- Pipes a single `[Preflight]` summary line into the existing startup log so missing keys / perms / tools are visible at-a-glance every boot.

## Why this matters

While auditing the install today I found three already-referenced files were silently missing from the running install: `crons.json`, `stand-identity.json`, and `notes/first-time-tutorial.md`. Each is referenced by code/skills but never created automatically. This is the same root cause as #570 (memory dir) — the spec assumes the file exists, the agent stays passive, the user never knows.

`init.sh` covers the auto-creatable pieces. The interactive ones (Stand identity, OAuth flows, tutorial content) are deliberately left to follow-up PRs (P3/P4/P5) since they need real UX design, not just `mkdir -p`.

## Test plan

- [x] 19 new tests in `tests/init-script.test.ts`, all green
- [x] Full suite 132/132 (was 113), tsc clean
- [x] Each test runs the actual `bash src/init.sh` against a fresh `mkdtempSync` tmpdir treated as a synthetic Sutando repo (via `SUTANDO_REPO` + `HOME` env overrides) — no trampling of dev repo state
- [x] Coverage: dir creation, placeholder content shape, JSON parseability, idempotency on re-run, no-clobber on existing files, `crons.example.json → crons.json` copy semantics, required/optional env detection (including external channel envs), single-line `[Preflight]` summary contract, unknown-flag rejection, no-flag default runs both tiers
- [ ] Manual: rm a known file → run `bash src/startup.sh` → file reappears, no other side effects

## Out of scope (separate PRs)

- **P3** voice-agent first-run interactive onboarding (Stand identity prompt, integration OAuth flows)
- **P4** ship `notes/first-time-tutorial.md` content
- **P5** auto-draft `user_profile.md` after N substantive turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)