### PR TITLE
fix(watcher): skip rename-out-of-tasks events in streaming watcher

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -35,6 +35,15 @@ shopt -u nullglob
 # Stream subsequent events. -l 0.5 = 500ms latency batch (fswatch coalesces
 # burst events). --event Created --event Renamed catches new file
 # appearance whether it lands as a fresh write or a rename-into-place.
+#
+# Existence check after match: fswatch fires Renamed events on BOTH ends of
+# a rename (source path AND destination path). For tasks/ that means
+# `mv tasks/X.txt tasks/archive/Y/` triggers a Renamed event for the source
+# `tasks/X.txt` AFTER the file has moved out — emitting a spurious
+# `TASK_FILE: X.txt` for a file no longer in the watched dir. The
+# `[ -f "$path" ]` test filters out those rename-OUT-of-watched-dir events
+# while still letting rename-INTO-place events through (file does exist at
+# the watched path). Caught 2026-05-03 during the live Monitor-mode rollout.
 fswatch \
   -l 0.5 \
   --event Created \
@@ -42,6 +51,10 @@ fswatch \
   "$TASKS_DIR" 2>/dev/null \
 | while IFS= read -r path; do
   case "$path" in
-    *.txt) echo "TASK_FILE: $(basename "$path")" ;;
+    *.txt)
+      if [ -f "$path" ]; then
+        echo "TASK_FILE: $(basename "$path")"
+      fi
+      ;;
   esac
 done


### PR DESCRIPTION
## Summary

PR #567 added the streaming watcher. Bug found during live rollout 2026-05-03: every task archive (`mv tasks/X.txt tasks/archive/...`) fires a spurious `TASK_FILE: X.txt` event because fswatch reports Renamed events for BOTH ends of a rename — including the source path that has already moved.

Effect: the agent re-receives an event for a file it just archived. With Monitor mode + persistent loop, this surfaces as ~3 events per real task file (initial drop + archive). Wastes notifications and risks reprocessing.

## Fix

3-line change in `src/watch-tasks-stream.sh`: add `[ -f \"$path\" ]` existence check after the `*.txt` match. Renames INTO the watched dir still fire (file exists at the destination). Renames OUT (the bug) are filtered.

## Test plan

- [x] Drop `tasks/test.txt` → fires `TASK_FILE: test.txt` (file exists)
- [x] `mv tasks/test.txt tasks/archive/` → no spurious event (file no longer at path)
- [x] Bash syntax check passes (`bash -n src/watch-tasks-stream.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)