### PR TITLE
fix(watcher): skip recursive subdir events (follow-up to #572)

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -23,6 +23,12 @@ set -u
 
 TASKS_DIR="${1:-$(dirname "$0")/../tasks}"
 mkdir -p "$TASKS_DIR"
+# Canonicalize watched dir for the parent-dir filter below. fswatch always
+# emits PHYSICAL paths (e.g. /private/tmp/... not /tmp/...), so we resolve
+# symlinks with `pwd -P` to match. Without -P, on macOS the comparison
+# `dirname "$path"` == `$TASKS_DIR_ABS` fails when /tmp is symlinked to
+# /private/tmp — which is the default.
+TASKS_DIR_ABS="$(cd "$TASKS_DIR" && pwd -P)"
 
 # Initial sweep — surface any pre-existing tasks that arrived during a
 # restart gap.
@@ -36,14 +42,22 @@ shopt -u nullglob
 # burst events). --event Created --event Renamed catches new file
 # appearance whether it lands as a fresh write or a rename-into-place.
 #
-# Existence check after match: fswatch fires Renamed events on BOTH ends of
-# a rename (source path AND destination path). For tasks/ that means
-# `mv tasks/X.txt tasks/archive/Y/` triggers a Renamed event for the source
-# `tasks/X.txt` AFTER the file has moved out — emitting a spurious
-# `TASK_FILE: X.txt` for a file no longer in the watched dir. The
-# `[ -f "$path" ]` test filters out those rename-OUT-of-watched-dir events
-# while still letting rename-INTO-place events through (file does exist at
-# the watched path). Caught 2026-05-03 during the live Monitor-mode rollout.
+# TWO filters before emit:
+#
+# 1. Parent-dir match: the macOS FSEvents monitor (fswatch's default) is
+#    recursive even without `-r`, so a rename from `tasks/X.txt` to
+#    `tasks/archive/.../X.txt` fires events for BOTH the source AND the
+#    destination — and the destination path is in a subdir we don't care
+#    about. We only want events for files that landed AS A DIRECT CHILD
+#    of $TASKS_DIR. `dirname "$path"` against the absolute watched dir
+#    catches this. Caught 2026-05-03 #2: archives in tasks/archive/2026-05/
+#    were re-firing TASK_FILE: <name> with a different path but the same
+#    basename, making the agent re-process every just-archived task.
+#
+# 2. Existence check: fswatch fires Renamed events on BOTH ends of a
+#    rename — including the source path AFTER the file has moved out.
+#    `[ -f "$path" ]` filters those rename-OUT-of-watched-dir events.
+#    Caught 2026-05-03 #1 (PR #572).
 fswatch \
   -l 0.5 \
   --event Created \
@@ -52,7 +66,8 @@ fswatch \
 | while IFS= read -r path; do
   case "$path" in
     *.txt)
-      if [ -f "$path" ]; then
+      parent="$(dirname "$path")"
+      if [ "$parent" = "$TASKS_DIR_ABS" ] && [ -f "$path" ]; then
         echo "TASK_FILE: $(basename "$path")"
       fi
       ;;


### PR DESCRIPTION
## Summary

Follow-up to #572. The `[ -f "$path" ]` check there caught rename-OUT events but MISSED rename-INTO-subdir destination events, because:

1. **fswatch's macOS FSEvents monitor is recursive by default** (despite `-r` being a flag), so `mv tasks/X.txt tasks/archive/2026-05/X.txt` fires events for BOTH the source AND the destination.
2. The destination path is in a subdir whose file does exist — so `[ -f "$path" ]` returns true and bash emits `TASK_FILE: X.txt` again with the same basename.

Net effect under live Monitor mode (caught 2026-05-03 ~13:25 PT during active-loop rollout): every task archive surfaced a duplicate event for the just-archived file, making the agent re-process the same task.

## Fix

Parent-dir filter. Resolve `TASKS_DIR_ABS` with `pwd -P` (physical path) at startup. In the loop, only emit when `dirname "$path"` matches the watched dir exactly.

`pwd -P` matters because macOS symlinks `/tmp` → `/private/tmp`. fswatch emits physical paths; the comparison fails without `-P`.

## Test plan

- [x] `mktemp -d` → drop `a.txt` → fires `TASK_FILE: a.txt`
- [x] Same dir → mkdir archive + mv `a.txt` → NO spurious event
- [x] Pre-fix: same test fired both events (original + archive)
- [x] Bash syntax check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)