### PR TITLE
feat(proactive-loop): migrate to Monitor + watch-tasks-stream.sh

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -19,11 +19,7 @@ If an interval is provided in ARGUMENTS (e.g. "5m", "10m", "30m"), use it. Other
 ## On activation
 
 1. Run `/schedule-crons` to set up all recurring cron jobs (morning briefing, Zacks, etc.)
-2. Start the task watcher if not running:
-```
-bash src/watch-tasks.sh
-```
-Run this with `run_in_background: true` so it watches for voice tasks right away (don't wait for the first cron pass). When the watcher fires, read its output — it lists ALL pending task files.
+2. Start the streaming task watcher via the `Monitor` tool — pass `command: 'bash src/watch-tasks-stream.sh'`, `persistent: true`, `description: 'Streaming task watcher'`. The script emits one `TASK_FILE: <basename>` line per new task file (initial sweep + each subsequent event). Read the named file via the Read tool when notifications arrive.
 
 ## Start the loop
 
@@ -91,7 +87,7 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 
 8. **If blocked, ask.** Write the question to `pending-questions.md`, send a macOS notification, and write to `results/question-{ts}.txt` if voice is connected. Don't stop — apply the Pivot-on-block rule and pick another menu item.
 
-9. **Ensure the watcher is running.** If no `fswatch` process on `tasks/`, start one with `bash src/watch-tasks.sh` (`run_in_background: true`). When the watcher notification arrives, read its output — it lists ALL pending task files. Process every one before restarting the watcher.
+9. **Ensure the streaming watcher is running.** If no `fswatch` process on `tasks/` (check via `pgrep -f watch-tasks`), restart it with the `Monitor` tool: `command: 'bash src/watch-tasks-stream.sh'`, `persistent: true`. When notifications arrive (`TASK_FILE: <basename>`), Read the named file. Each event represents one new task — process all queued tasks before continuing.
 
 10. **Monitor Discord.** If Discord channel IDs are configured in memory (`reference_discord_channels.md`), check those channels for new messages. Forward actionable items from public channels to the dev channel. Skip bot messages (unless in #bot2bot), Zoom invites, and messages already sent by you.
 


### PR DESCRIPTION
## Summary

Updates the proactive-loop skill prompt to invoke the streaming watcher via Claude Code's `Monitor` tool instead of the one-shot `bash src/watch-tasks.sh (run_in_background)` pattern.

Two blocks change in `skills/proactive-loop/SKILL.md`:

- **Step 2 (On activation):** start with `Monitor` — `command: 'bash src/watch-tasks-stream.sh'`, `persistent: true`. Each new task file emits `TASK_FILE: <basename>` once.
- **Step 9 (Ensure watcher running):** check `pgrep -f watch-tasks`; if empty, restart via Monitor with the same args.

The old `src/watch-tasks.sh` stays for compatibility. Only the skill prompt switched.

## Why now

- #567 added `watch-tasks-stream.sh`.
- #572 + #573 fixed the two false-positive event classes (rename-OUT source events; rename-INTO-subdir destination events). Live-verified today: drop fires 1 event, archive fires 0.
- Persistent Monitor stays alive across the loop's idle windows — the fswatch+restart-cycle of the old pattern caused intermittent watcher death between sessions.

## Test plan

- [x] Drop test task → 1 event fired through Monitor (correct)
- [x] Archive task → 0 spurious events (post-#573 confirmed)
- [x] Skill prompt parses correctly (re-ran `/proactive-loop` after edit)

## Sister-node migration

`~/.claude/skills/proactive-loop/SKILL.md` is hard-linked to `skills/proactive-loop/SKILL.md` in this repo (verified via inode), so a normal `git pull` propagates the migration to any node with the repo checked out under `~/.claude/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)