### PR TITLE
fix(discord-bridge): route _send_via_rest through _chunk_for_discord

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -1141,21 +1141,36 @@ async def poll_dm_fallback():
 
 
 def _send_via_rest(channel_id: str, message: str):
-    """Send a message via Discord REST API (no gateway connection). Exits after sending."""
+    """Send a message via Discord REST API (no gateway connection).
+
+    Chunks via `_chunk_for_discord` so messages over Discord's 2000-char limit
+    (or with code fences spanning chunk boundaries) deliver intact across N
+    sequential POSTs. Without chunking the API returns 400 and the message
+    is silently dropped — this caused codex-output replies (often >2KB) to
+    never reach the channel.
+    """
     import urllib.request
     url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
-    data = json.dumps({"content": message}).encode()
-    req = urllib.request.Request(url, data=data, headers={
+    headers = {
         "Authorization": f"Bot {TOKEN}",
         "Content-Type": "application/json",
         "User-Agent": "DiscordBot (sutando, 1.0)",
-    })
-    try:
-        urllib.request.urlopen(req)
-        print(f"Sent to {channel_id}: {message[:80]}...")
-    except Exception as e:
-        print(f"Send failed: {e}")
-        sys.exit(1)
+    }
+    chunks = list(_chunk_for_discord(message))
+    if not chunks:
+        # Empty message — nothing to send. Treat as no-op rather than error.
+        return
+    for i, chunk in enumerate(chunks, 1):
+        data = json.dumps({"content": chunk}).encode()
+        req = urllib.request.Request(url, data=data, headers=headers)
+        try:
+            urllib.request.urlopen(req)
+        except Exception as e:
+            print(f"Send failed (chunk {i}/{len(chunks)}): {e}")
+            sys.exit(1)
+    suffix = "..." if len(message) > 80 else ""
+    chunk_note = f" ({len(chunks)} chunks)" if len(chunks) > 1 else ""
+    print(f"Sent to {channel_id}: {message[:80]}{suffix}{chunk_note}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`python3 src/discord-bridge.py send <channel> <msg>` posted the message verbatim, so any payload >2000 chars hit Discord's API limit and silently 400'd. The gateway-driven send paths at `src/discord-bridge.py:936` and `:1041` already iterate `_chunk_for_discord(text)` correctly — `_send_via_rest` was the outlier.

## Caught how

2026-05-02: a 13.5KB codex-generated cost-estimate reply (`@qingyunwu` cost question) was written to `results/task-1777769275190.txt` and dispatched via the convenience send path. Bridge log showed no send entry, no log error — message was simply 400'd into the void. Sutando-Mini had to re-deliver via direct REST in 2 chunks.

## Fix

3-line change of substance in `_send_via_rest`:
- List-materialize `_chunk_for_discord(message)` output
- Send each chunk sequentially with the same headers
- Empty input → no-op (no spurious POST)
- Print line gains a `(N chunks)` suffix when N > 1

Identical fence-preserving behavior as the gateway path (PR #563). Includes which-chunk diagnostics on failure.

## Test plan

- [x] `python3 -c 'import ast; ast.parse(open("src/discord-bridge.py").read())'` — parses clean
- [x] Smoke: mocked `urllib.request.urlopen`, sent a synthetic 5.6KB message → 4 chunks, each ≤1900 chars, content preserved
- [x] Empty string → 0 POSTs, no error
- [ ] Live: send a >2000-char message via the CLI to a test channel, verify multi-chunk delivery (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)