### PR TITLE
fix(open_file): unresolved env-var diagnostic + path.extname over slice math

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -7,7 +7,7 @@
 
 import { execSync, execFileSync } from 'node:child_process';
 import { writeFileSync, unlinkSync, readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, extname } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 
@@ -41,10 +41,23 @@ export const openFileTool: ToolDefinition = {
 			if (!path) return { error: 'No path provided. Pass an absolute file path. (For the most recent recording, call play_video — it auto-finds the file.)' };
 			// Expand $VAR / ${VAR} env-var references and ~ in the path so Sutando
 			// can pass paths like "$SUTANDO_PRIVATE_DIR/voice-contexts/X.txt"
-			// without us hardcoding a fallback root.
+			// without us hardcoding a fallback root. Track any unset variables so
+			// we can surface them as a clear diagnostic rather than letting the
+			// silently-empty substitution flow through to a generic "file not
+			// found" error below.
+			const unresolvedVars: string[] = [];
 			const filePath = path
 				.replace(/^~/, process.env.HOME || '')
-				.replace(/\$\{([A-Z_][A-Z0-9_]*)\}|\$([A-Z_][A-Z0-9_]*)/g, (_, a, b) => process.env[a || b] || '');
+				.replace(/\$\{([A-Z_][A-Z0-9_]*)\}|\$([A-Z_][A-Z0-9_]*)/g, (_, a, b) => {
+					const name = a || b;
+					const val = process.env[name];
+					if (val === undefined) unresolvedVars.push(name);
+					return val || '';
+				});
+			if (unresolvedVars.length > 0) {
+				console.log(`${ts()} [OpenFile] path "${path}" has unset env var(s): ${unresolvedVars.join(', ')}`);
+				return { error: `Unresolved env var(s) in path: ${unresolvedVars.join(', ')}. Set them before calling open_file, or pass a fully-expanded absolute path.` };
+			}
 			if (!existsSync(filePath)) {
 				console.log(`${ts()} [OpenFile] path "${filePath}" does not exist`);
 				return { error: `File not found: ${filePath}. Do not invent paths — use the exact path returned by the tool that produced the file (e.g. record_screen_with_narration returns subtitled_path/narrated_path/recording_path). For the most recent recording without a known path, call play_video instead.` };
@@ -78,7 +91,7 @@ export const openFileTool: ToolDefinition = {
 			// "No video to play". This makes the existing tool surface QuickTime-
 			// aware, regardless of whether the video came from a phone-call
 			// recording or open_file.
-			const ext = filePath.toLowerCase().slice(filePath.lastIndexOf('.'));
+			const ext = extname(filePath).toLowerCase();
 			if (['.mp4', '.mov', '.webm', '.m4v'].includes(ext)) {
 				try {
 					const fs = await import('node:fs');


### PR DESCRIPTION
## Summary

Two cosmetic followups from the #574 cold review, applied as a single small PR since the file was just touched and both fit naturally together.

## 1. Unresolved env var → clear diagnostic

#574's path expansion replaces unset env vars with an empty string and falls through to `existsSync`. The user-facing error was *"File not found: <truncated-path>. Do not invent paths…"* — but the actual problem is an unset env var, not an invented path. Rare-but-real failure mode for paths like `\$SUTANDO_PRIVATE_DIR/voice-contexts/X.txt` when the env var hasn't propagated to a freshly-restarted voice-agent.

Fix: collect unresolved variable names during the `.replace` callback (when `process.env[name] === undefined`), and if any were captured, return a targeted error before `existsSync` runs.

Verified detection logic:
| Input | Expanded | Unresolved |
|---|---|---|
| `\$UNSET_FOO/file.txt` | `/file.txt` | `["UNSET_FOO"]` |
| `\$HOME/file.txt` | `/Users/wangchi/file.txt` | `[]` |
| `\$HOME/\$UNSET_BAR/x.txt` | `/Users/wangchi//x.txt` | `["UNSET_BAR"]` |
| `\${UNSET_BRACED}/x.txt` | `/x.txt` | `["UNSET_BRACED"]` |

Doesn't change the happy path: when every var resolves, behavior is identical to #574.

## 2. Extension extraction — `path.extname` over slice math

\`filePath.toLowerCase().slice(filePath.lastIndexOf('.'))\` works for most paths but is fragile: when there's no dot, `lastIndexOf` returns -1 and `slice(-1)` returns the last character of the path — meaning a dotless path ending in \`4\` or \`v\` would incidentally match `.mp4`/`.m4v`.

Standard form: `extname()` returns `""` for dotless paths and the `.ext` form for valid extensions.

No observed bug, but `extname` is the standard form and removes the foot-gun entirely.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Manual verify env-var detection cases (table above)
- [x] `extname('/foo/bar.MP4').toLowerCase()` → `.mp4`; `extname('/no-ext')` → `''`
- [ ] Live: pass an unset-env-var path → expect "Unresolved env var(s) in path:" error (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)