### PR TITLE
WIP: fix(task-bridge): timeout title carries original task text

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -39,6 +39,7 @@ import re
 import socket
 import subprocess
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlparse
@@ -85,6 +86,13 @@ def validate_twilio_signature(handler, body: str) -> bool:
 REPO_DIR = Path(__file__).parent.parent
 TASK_DIR = REPO_DIR / "tasks"
 PORT = 7843
+
+# Task timeout for the /tasks/active polling endpoint. Must mirror
+# TASK_TIMEOUT_MS in src/task-bridge.ts so the web-client polled status
+# matches the bodhi-pushed status (otherwise the poll silently overwrites
+# the timeout badge back to "working" every 2s). Override with
+# SUTANDO_TASK_TIMEOUT_S at start time, e.g. for shorter dev/test loops.
+TASK_TIMEOUT_S = int(os.environ.get("SUTANDO_TASK_TIMEOUT_S", "600"))
 
 # Personal-asset path resolver — see src/util_paths.py. Imported here so the
 # /avatar and /stand-identity endpoints prefer the per-machine private dir
@@ -300,7 +308,12 @@ class Handler(http.server.BaseHTTPRequestHandler):
                         task_line = line[5:].strip()
                         break
                 result_file = RESULT_DIR / f.name
-                status = "done" if result_file.exists() else "working"
+                if result_file.exists():
+                    status = "done"
+                elif (time.time() - f.stat().st_mtime) > TASK_TIMEOUT_S:
+                    status = "timeout"
+                else:
+                    status = "working"
                 result_text = result_file.read_text().strip() if result_file.exists() else ""
                 existing = task_history.get(task_id, {})
                 task_history[task_id] = {"status": status, "text": task_line or existing.get("text", task_id), "time": f.stat().st_mtime, "result": result_text or existing.get("result", "")}

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -298,28 +298,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
             # List active tasks + system status for the web client
             watcher_ok = subprocess.run(["pgrep", "-f", "watch-tasks"], capture_output=True).returncode == 0
             claude_ok = subprocess.run(["pgrep", "-f", "claude.*sutando-core"], capture_output=True).returncode == 0
-            # Build a parent_task_id → nudge count map by scanning TASK_DIR for
-            # status-check nudge files. task-bridge writes them with a
-            # `parent_task_id:` field; we count how many children each task has
-            # so the web-client can show "+N nudges sent" beside the TIMEOUT
-            # badge. Cheap O(N) scan — N is bounded (we cap visible tasks at 10).
-            nudge_counts: dict[str, int] = {}
-            for nf in TASK_DIR.glob("task-*-nudge-*.txt"):
-                try:
-                    for line in nf.read_text().splitlines():
-                        if line.startswith("parent_task_id:"):
-                            pid = line.split(":", 1)[1].strip()
-                            nudge_counts[pid] = nudge_counts.get(pid, 0) + 1
-                            break
-                except Exception:
-                    pass
             # Scan disk for active tasks, update history (preserve existing text).
-            # Skip status-check nudge children — they're status pings task-bridge
-            # writes for stuck parents; surface them as a counter pill on the
-            # parent row, not as new rows.
             for f in sorted(TASK_DIR.glob("*.txt"), key=lambda p: p.stat().st_mtime, reverse=True):
-                if "-nudge-" in f.name:
-                    continue
                 task_id = f.stem
                 content = f.read_text()
                 task_line = ""
@@ -341,7 +321,6 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     "text": task_line or existing.get("text", task_id),
                     "time": f.stat().st_mtime,
                     "result": result_text or existing.get("result", ""),
-                    "nudges": nudge_counts.get(task_id, 0),
                 }
             # Also check for result files without task files (already cleaned up)
             for f in sorted(RESULT_DIR.glob("task-*.txt"), key=lambda p: p.stat().st_mtime, reverse=True)[:10]:

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -298,8 +298,28 @@ class Handler(http.server.BaseHTTPRequestHandler):
             # List active tasks + system status for the web client
             watcher_ok = subprocess.run(["pgrep", "-f", "watch-tasks"], capture_output=True).returncode == 0
             claude_ok = subprocess.run(["pgrep", "-f", "claude.*sutando-core"], capture_output=True).returncode == 0
-            # Scan disk for active tasks, update history (preserve existing text)
-            for f in sorted(TASK_DIR.glob("*.txt"), key=lambda p: p.stat().st_mtime, reverse=True)[:10]:
+            # Build a parent_task_id → nudge count map by scanning TASK_DIR for
+            # status-check nudge files. task-bridge writes them with a
+            # `parent_task_id:` field; we count how many children each task has
+            # so the web-client can show "+N nudges sent" beside the TIMEOUT
+            # badge. Cheap O(N) scan — N is bounded (we cap visible tasks at 10).
+            nudge_counts: dict[str, int] = {}
+            for nf in TASK_DIR.glob("task-*-nudge-*.txt"):
+                try:
+                    for line in nf.read_text().splitlines():
+                        if line.startswith("parent_task_id:"):
+                            pid = line.split(":", 1)[1].strip()
+                            nudge_counts[pid] = nudge_counts.get(pid, 0) + 1
+                            break
+                except Exception:
+                    pass
+            # Scan disk for active tasks, update history (preserve existing text).
+            # Skip status-check nudge children — they're status pings task-bridge
+            # writes for stuck parents; surface them as a counter pill on the
+            # parent row, not as new rows.
+            for f in sorted(TASK_DIR.glob("*.txt"), key=lambda p: p.stat().st_mtime, reverse=True):
+                if "-nudge-" in f.name:
+                    continue
                 task_id = f.stem
                 content = f.read_text()
                 task_line = ""
@@ -316,7 +336,13 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     status = "working"
                 result_text = result_file.read_text().strip() if result_file.exists() else ""
                 existing = task_history.get(task_id, {})
-                task_history[task_id] = {"status": status, "text": task_line or existing.get("text", task_id), "time": f.stat().st_mtime, "result": result_text or existing.get("result", "")}
+                task_history[task_id] = {
+                    "status": status,
+                    "text": task_line or existing.get("text", task_id),
+                    "time": f.stat().st_mtime,
+                    "result": result_text or existing.get("result", ""),
+                    "nudges": nudge_counts.get(task_id, 0),
+                }
             # Also check for result files without task files (already cleaned up)
             for f in sorted(RESULT_DIR.glob("task-*.txt"), key=lambda p: p.stat().st_mtime, reverse=True)[:10]:
                 task_id = f.stem

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -69,8 +69,31 @@ function ts(): string { return new Date().toISOString().slice(11, 23); }
 let _sendTaskStatus: ((taskId: string, status: string, text: string, result?: string) => void) | null = null;
 const _deliveredResults = new Set<string>();
 
-const TASK_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
-const _pendingTasks = new Map<string, number>(); // taskId → submission epoch ms
+export const TASK_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+type PendingTask = { submittedAt: number; task: string };
+export const _pendingTasks = new Map<string, PendingTask>(); // taskId → entry
+
+/**
+ * Pure timeout check, extracted from startResultWatcher's setInterval so it
+ * can be unit-tested without the 2s timer or the fs.readdir loop. Mutates
+ * `pending` (deletes timed-out entries) and invokes the two callbacks for
+ * each timed-out task.
+ */
+export function _checkPendingTimeouts(
+	now: number,
+	pending: Map<string, PendingTask>,
+	sendStatus: ((taskId: string, status: string, text: string, result?: string) => void) | null,
+	onResult: (result: string) => void,
+): void {
+	for (const [taskId, entry] of pending) {
+		if (now - entry.submittedAt > TASK_TIMEOUT_MS) {
+			pending.delete(taskId);
+			console.error(`${ts()} [TaskBridge] Task ${taskId} timed out after ${TASK_TIMEOUT_MS / 1000}s`);
+			sendStatus?.(taskId, 'timeout', `Timed out: ${entry.task.slice(0, 60)}`);
+			onResult(`[Task timed out after ${Math.floor(TASK_TIMEOUT_MS / 60000)} minutes. The processing engine may need to be restarted.]`);
+		}
+	}
+}
 const _apiToken = process.env.SUTANDO_API_TOKEN || '';
 function _apiHeaders(): Record<string, string> {
 	const h: Record<string, string> = { 'Content-Type': 'application/json' };
@@ -149,7 +172,7 @@ export const workTool: ToolDefinition = {
 			`user_id: ${ownerId}\n` +
 			`access_tier: owner\n`;
 		writeFileSync(join(TASK_DIR, `${taskId}.txt`), content);
-		_pendingTasks.set(taskId, Date.now());
+		_pendingTasks.set(taskId, { submittedAt: Date.now(), task });
 		// Record owner activity for status-aware-pivot in proactive loop
 		writeOwnerActivity('voice', task);
 		console.log(`${ts()} [TaskBridge] Task ${taskId}: ${task.slice(0, 100)}`);
@@ -359,15 +382,7 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 
 	// Check every 2 seconds for new result files
 	setInterval(() => {
-		// Check for timed-out tasks — runs every interval regardless of result files
-		for (const [taskId, submittedAt] of _pendingTasks) {
-			if (Date.now() - submittedAt > TASK_TIMEOUT_MS) {
-				_pendingTasks.delete(taskId);
-				console.error(`${ts()} [TaskBridge] Task ${taskId} timed out after ${TASK_TIMEOUT_MS / 1000}s`);
-				_sendTaskStatus?.(taskId, 'timeout', 'Task timed out — core agent may be unresponsive');
-				onResult(`[Task timed out after ${Math.floor(TASK_TIMEOUT_MS / 60000)} minutes. The processing engine may need to be restarted.]`);
-			}
-		}
+		_checkPendingTimeouts(Date.now(), _pendingTasks, _sendTaskStatus, onResult);
 
 		try {
 			const files = readdirSync(RESULT_DIR).filter(f => f.endsWith('.txt')).sort();

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -70,22 +70,62 @@ let _sendTaskStatus: ((taskId: string, status: string, text: string, result?: st
 const _deliveredResults = new Set<string>();
 
 export const TASK_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+// Send a status-check nudge task to core once a task has been pending this
+// long without a result. Higher than TASK_TIMEOUT_MS so we don't nudge for
+// every slow-but-progressing task — only ones that look genuinely stuck.
+export const NUDGE_AT_MS = 3 * TASK_TIMEOUT_MS;
 type PendingTask = { submittedAt: number; task: string };
 export const _pendingTasks = new Map<string, PendingTask>(); // taskId → entry
 
 // Track which pending entries have already had their timeout badge fired so
 // we don't re-emit the same status event every 2s after the deadline passes.
 const _timeoutBadgeFired = new Set<string>();
+// Per-task once-per-task nudge dedupe. Cleared when a result arrives (so the
+// SAME task being re-submitted later can nudge again, but the still-pending
+// one only nudges once).
+const _nudgeFired = new Set<string>();
+
+/** Default nudge-writer: drops a status-check task file in TASK_DIR. The
+ * watcher will pick it up like any other task. Injected via a parameter on
+ * `_checkPendingTimeouts` so tests can capture the call without writing
+ * to disk. */
+function _defaultWriteNudge(nudgeId: string, content: string): void {
+	writeFileSync(join(TASK_DIR, `${nudgeId}.txt`), content);
+}
+
+function _buildNudgeContent(nudgeId: string, originalTaskId: string, originalTask: string, ageMs: number): string {
+	const ageMin = Math.floor(ageMs / 60000);
+	const ownerId = process.env.SUTANDO_DM_OWNER_ID || 'voice-local';
+	const truncated = originalTask.slice(0, 80);
+	return (
+		`id: ${nudgeId}\n` +
+		`timestamp: ${new Date().toISOString()}\n` +
+		`task: [Sutando-status-check] ${ageMin} min ago I queued: "${truncated}". Are you still working on it? If yes, post a brief status (what you've done so far). If you're stuck, name the blocker. If the task is no longer relevant, just say so. Don't restart the original task — only report status.\n` +
+		`source: voice\n` +
+		`channel_id: local-voice\n` +
+		`user_id: ${ownerId}\n` +
+		`access_tier: owner\n` +
+		`parent_task_id: ${originalTaskId}\n`
+	);
+}
 
 /**
  * Pure timeout check, extracted from startResultWatcher's setInterval so it
  * can be unit-tested without the 2s timer or the fs.readdir loop.
  *
- * UI-only / silent: marks each timed-out row with a `timeout` badge in the
- * Tasks tab and does NOT fire `onResult`, so the voice agent stays silent.
- * The pending entry is intentionally LEFT IN PLACE — if the core agent
- * eventually returns a result, `_processResult` will flip the row to `done`
- * the normal way. The `firedSet` arg dedupes the badge across timer ticks.
+ * Two effects, both deduped per task:
+ *
+ * 1. UI-only / silent timeout badge once age > TASK_TIMEOUT_MS — marks the
+ *    Tasks-tab row yellow. Does NOT fire `onResult`, so the voice agent
+ *    stays silent. The pending entry is intentionally LEFT IN PLACE — if
+ *    core eventually returns a result, `_processResult` will flip the row
+ *    to `done` the normal way.
+ *
+ * 2. Status-check nudge once age > NUDGE_AT_MS (3× timeout) — writes a new
+ *    task file asking core to report status on the still-pending original
+ *    task. Status-check, not re-submit, so an in-flight task doesn't get
+ *    duplicated; only fires once per pending task (cleared when the result
+ *    finally arrives).
  */
 export function _checkPendingTimeouts(
 	now: number,
@@ -93,13 +133,25 @@ export function _checkPendingTimeouts(
 	sendStatus: ((taskId: string, status: string, text: string, result?: string) => void) | null,
 	_onResult: (result: string) => void,
 	firedSet: Set<string> = _timeoutBadgeFired,
+	nudgeSet: Set<string> = _nudgeFired,
+	writeNudge: (nudgeId: string, content: string) => void = _defaultWriteNudge,
 ): void {
 	for (const [taskId, entry] of pending) {
-		if (firedSet.has(taskId)) continue;
-		if (now - entry.submittedAt > TASK_TIMEOUT_MS) {
+		const age = now - entry.submittedAt;
+		if (age > TASK_TIMEOUT_MS && !firedSet.has(taskId)) {
 			firedSet.add(taskId);
 			console.error(`${ts()} [TaskBridge] Task ${taskId} timed out after ${TASK_TIMEOUT_MS / 1000}s (silent — UI badge only)`);
 			sendStatus?.(taskId, 'timeout', `Timed out: ${entry.task.slice(0, 60)}`);
+		}
+		if (age > NUDGE_AT_MS && !nudgeSet.has(taskId)) {
+			nudgeSet.add(taskId);
+			const nudgeId = `task-${now}-nudge`;
+			try {
+				writeNudge(nudgeId, _buildNudgeContent(nudgeId, taskId, entry.task, age));
+				console.error(`${ts()} [TaskBridge] Status-check nudge ${nudgeId} sent for ${taskId} (${Math.floor(age / 60000)} min old)`);
+			} catch (e) {
+				console.error(`${ts()} [TaskBridge] Nudge write failed:`, e);
+			}
 		}
 	}
 }
@@ -413,6 +465,7 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					_deliveredResults.add(file);
 					_pendingTasks.delete(taskId);
 					_timeoutBadgeFired.delete(taskId);
+					_nudgeFired.delete(taskId);
 					logConversation('core-agent', `[task:${taskId}] ${result.slice(0, 200)}`);
 					onResult(result);
 					// Notify agent-api directly, then delete file

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -70,20 +70,28 @@ let _sendTaskStatus: ((taskId: string, status: string, text: string, result?: st
 const _deliveredResults = new Set<string>();
 
 export const TASK_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
-// Send a status-check nudge task to core once a task has been pending this
-// long without a result. Higher than TASK_TIMEOUT_MS so we don't nudge for
-// every slow-but-progressing task — only ones that look genuinely stuck.
+// First status-check nudge fires once a task has been pending this long
+// without a result. Higher than TASK_TIMEOUT_MS so we don't nudge for every
+// slow-but-progressing task — only ones that look genuinely stuck.
+// Subsequent nudges fire every NUDGE_AT_MS thereafter (so nudge #N fires at
+// N × NUDGE_AT_MS).
 export const NUDGE_AT_MS = 3 * TASK_TIMEOUT_MS;
+// Stop after this many unanswered nudges. After the last one fires, the
+// task is escalated via Discord DM to the owner so they know core looks
+// genuinely stuck. We don't keep spamming nudges past this — N status
+// checks unanswered is enough signal.
+export const MAX_NUDGES = 3;
 type PendingTask = { submittedAt: number; task: string };
 export const _pendingTasks = new Map<string, PendingTask>(); // taskId → entry
 
 // Track which pending entries have already had their timeout badge fired so
 // we don't re-emit the same status event every 2s after the deadline passes.
 const _timeoutBadgeFired = new Set<string>();
-// Per-task once-per-task nudge dedupe. Cleared when a result arrives (so the
-// SAME task being re-submitted later can nudge again, but the still-pending
-// one only nudges once).
-const _nudgeFired = new Set<string>();
+// Per-task nudge counter (0..MAX_NUDGES). Cleared when a result arrives so
+// the SAME task re-submitted later restarts the cycle.
+const _nudgeCount = new Map<string, number>();
+// Flag: did this task already get its post-MAX_NUDGES Discord escalation?
+const _escalated = new Set<string>();
 
 /** Default nudge-writer: drops a status-check task file in TASK_DIR. The
  * watcher will pick it up like any other task. Injected via a parameter on
@@ -93,14 +101,26 @@ function _defaultWriteNudge(nudgeId: string, content: string): void {
 	writeFileSync(join(TASK_DIR, `${nudgeId}.txt`), content);
 }
 
-function _buildNudgeContent(nudgeId: string, originalTaskId: string, originalTask: string, ageMs: number): string {
+/** Default escalator: writes a `results/proactive-stuck-{ts}.txt` file. The
+ * Discord bridge watches that prefix and DMs the owner. Per CLAUDE.md
+ * "Proactive messages: write to `results/proactive-{ts}.txt` to speak to
+ * the user". Injected so tests can capture without DM-ing. */
+function _defaultEscalate(taskId: string, originalTask: string, ageMs: number, nudgeCount: number): void {
+	const ageMin = Math.floor(ageMs / 60000);
+	const truncated = originalTask.slice(0, 80);
+	const ts = Date.now();
+	const body = `[Sutando-stuck-alert] Core looks stuck on task ${taskId}: "${truncated}" (${ageMin} min old, ${nudgeCount} status-check nudges unanswered). You may want to check core's logs or run /pull-and-restart.`;
+	writeFileSync(join(RESULT_DIR, `proactive-stuck-${ts}.txt`), body);
+}
+
+function _buildNudgeContent(nudgeId: string, originalTaskId: string, originalTask: string, ageMs: number, attempt: number): string {
 	const ageMin = Math.floor(ageMs / 60000);
 	const ownerId = process.env.SUTANDO_DM_OWNER_ID || 'voice-local';
 	const truncated = originalTask.slice(0, 80);
 	return (
 		`id: ${nudgeId}\n` +
 		`timestamp: ${new Date().toISOString()}\n` +
-		`task: [Sutando-status-check] ${ageMin} min ago I queued: "${truncated}". Are you still working on it? If yes, post a brief status (what you've done so far). If you're stuck, name the blocker. If the task is no longer relevant, just say so. Don't restart the original task — only report status.\n` +
+		`task: [Sutando-status-check #${attempt}] ${ageMin} min ago I queued: "${truncated}". Are you still working on it? If yes, post a brief status (what you've done so far). If you're stuck, name the blocker. If the task is no longer relevant, just say so. Don't restart the original task — only report status.\n` +
 		`source: voice\n` +
 		`channel_id: local-voice\n` +
 		`user_id: ${ownerId}\n` +
@@ -113,7 +133,7 @@ function _buildNudgeContent(nudgeId: string, originalTaskId: string, originalTas
  * Pure timeout check, extracted from startResultWatcher's setInterval so it
  * can be unit-tested without the 2s timer or the fs.readdir loop.
  *
- * Two effects, both deduped per task:
+ * Three escalating effects, each deduped per task:
  *
  * 1. UI-only / silent timeout badge once age > TASK_TIMEOUT_MS — marks the
  *    Tasks-tab row yellow. Does NOT fire `onResult`, so the voice agent
@@ -121,11 +141,15 @@ function _buildNudgeContent(nudgeId: string, originalTaskId: string, originalTas
  *    core eventually returns a result, `_processResult` will flip the row
  *    to `done` the normal way.
  *
- * 2. Status-check nudge once age > NUDGE_AT_MS (3× timeout) — writes a new
- *    task file asking core to report status on the still-pending original
- *    task. Status-check, not re-submit, so an in-flight task doesn't get
- *    duplicated; only fires once per pending task (cleared when the result
- *    finally arrives).
+ * 2. Status-check nudges starting at age > NUDGE_AT_MS, then every
+ *    NUDGE_AT_MS thereafter, up to MAX_NUDGES total. Each nudge writes a
+ *    new status-check task file (not a re-submit) so the in-flight task
+ *    isn't duplicated. nudgeCount per task is cleared when the result
+ *    arrives.
+ *
+ * 3. Discord DM escalation once nudgeCount reaches MAX_NUDGES — writes
+ *    `results/proactive-stuck-{ts}.txt` which the Discord bridge picks up
+ *    and DMs the owner. Fires exactly once per task per result-cycle.
  */
 export function _checkPendingTimeouts(
 	now: number,
@@ -133,8 +157,10 @@ export function _checkPendingTimeouts(
 	sendStatus: ((taskId: string, status: string, text: string, result?: string) => void) | null,
 	_onResult: (result: string) => void,
 	firedSet: Set<string> = _timeoutBadgeFired,
-	nudgeSet: Set<string> = _nudgeFired,
+	nudgeCount: Map<string, number> = _nudgeCount,
 	writeNudge: (nudgeId: string, content: string) => void = _defaultWriteNudge,
+	escalated: Set<string> = _escalated,
+	escalate: (taskId: string, originalTask: string, ageMs: number, nudgeCount: number) => void = _defaultEscalate,
 ): void {
 	for (const [taskId, entry] of pending) {
 		const age = now - entry.submittedAt;
@@ -143,14 +169,34 @@ export function _checkPendingTimeouts(
 			console.error(`${ts()} [TaskBridge] Task ${taskId} timed out after ${TASK_TIMEOUT_MS / 1000}s (silent — UI badge only)`);
 			sendStatus?.(taskId, 'timeout', `Timed out: ${entry.task.slice(0, 60)}`);
 		}
-		if (age > NUDGE_AT_MS && !nudgeSet.has(taskId)) {
-			nudgeSet.add(taskId);
-			const nudgeId = `task-${now}-nudge`;
+
+		// Periodic nudges: nudge #N fires at age >= N × NUDGE_AT_MS, capped at
+		// MAX_NUDGES total. Compute the highest nudge number this age qualifies
+		// for, then fire any not-yet-fired ones in order (in steady state we'll
+		// only fire one per tick, but this also handles long sleeps).
+		const fired = nudgeCount.get(taskId) ?? 0;
+		const target = Math.min(MAX_NUDGES, Math.floor(age / NUDGE_AT_MS));
+		if (target > fired) {
+			for (let attempt = fired + 1; attempt <= target; attempt++) {
+				const nudgeId = `task-${now}-nudge-${attempt}`;
+				try {
+					writeNudge(nudgeId, _buildNudgeContent(nudgeId, taskId, entry.task, age, attempt));
+					console.error(`${ts()} [TaskBridge] Status-check nudge #${attempt}/${MAX_NUDGES} ${nudgeId} sent for ${taskId} (${Math.floor(age / 60000)} min old)`);
+				} catch (e) {
+					console.error(`${ts()} [TaskBridge] Nudge write failed:`, e);
+				}
+			}
+			nudgeCount.set(taskId, target);
+		}
+
+		// Escalate via Discord DM after the MAX_NUDGES'th nudge has fired.
+		if ((nudgeCount.get(taskId) ?? 0) >= MAX_NUDGES && !escalated.has(taskId)) {
+			escalated.add(taskId);
 			try {
-				writeNudge(nudgeId, _buildNudgeContent(nudgeId, taskId, entry.task, age));
-				console.error(`${ts()} [TaskBridge] Status-check nudge ${nudgeId} sent for ${taskId} (${Math.floor(age / 60000)} min old)`);
+				escalate(taskId, entry.task, age, MAX_NUDGES);
+				console.error(`${ts()} [TaskBridge] Escalated stuck-task ${taskId} to owner DM (${Math.floor(age / 60000)} min old, ${MAX_NUDGES} nudges unanswered)`);
 			} catch (e) {
-				console.error(`${ts()} [TaskBridge] Nudge write failed:`, e);
+				console.error(`${ts()} [TaskBridge] Escalation failed:`, e);
 			}
 		}
 	}
@@ -465,7 +511,8 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					_deliveredResults.add(file);
 					_pendingTasks.delete(taskId);
 					_timeoutBadgeFired.delete(taskId);
-					_nudgeFired.delete(taskId);
+					_nudgeCount.delete(taskId);
+					_escalated.delete(taskId);
 					logConversation('core-agent', `[task:${taskId}] ${result.slice(0, 200)}`);
 					onResult(result);
 					// Notify agent-api directly, then delete file

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -73,24 +73,33 @@ export const TASK_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 type PendingTask = { submittedAt: number; task: string };
 export const _pendingTasks = new Map<string, PendingTask>(); // taskId → entry
 
+// Track which pending entries have already had their timeout badge fired so
+// we don't re-emit the same status event every 2s after the deadline passes.
+const _timeoutBadgeFired = new Set<string>();
+
 /**
  * Pure timeout check, extracted from startResultWatcher's setInterval so it
- * can be unit-tested without the 2s timer or the fs.readdir loop. Mutates
- * `pending` (deletes timed-out entries) and invokes the two callbacks for
- * each timed-out task.
+ * can be unit-tested without the 2s timer or the fs.readdir loop.
+ *
+ * UI-only / silent: marks each timed-out row with a `timeout` badge in the
+ * Tasks tab and does NOT fire `onResult`, so the voice agent stays silent.
+ * The pending entry is intentionally LEFT IN PLACE — if the core agent
+ * eventually returns a result, `_processResult` will flip the row to `done`
+ * the normal way. The `firedSet` arg dedupes the badge across timer ticks.
  */
 export function _checkPendingTimeouts(
 	now: number,
 	pending: Map<string, PendingTask>,
 	sendStatus: ((taskId: string, status: string, text: string, result?: string) => void) | null,
-	onResult: (result: string) => void,
+	_onResult: (result: string) => void,
+	firedSet: Set<string> = _timeoutBadgeFired,
 ): void {
 	for (const [taskId, entry] of pending) {
+		if (firedSet.has(taskId)) continue;
 		if (now - entry.submittedAt > TASK_TIMEOUT_MS) {
-			pending.delete(taskId);
-			console.error(`${ts()} [TaskBridge] Task ${taskId} timed out after ${TASK_TIMEOUT_MS / 1000}s`);
+			firedSet.add(taskId);
+			console.error(`${ts()} [TaskBridge] Task ${taskId} timed out after ${TASK_TIMEOUT_MS / 1000}s (silent — UI badge only)`);
 			sendStatus?.(taskId, 'timeout', `Timed out: ${entry.task.slice(0, 60)}`);
-			onResult(`[Task timed out after ${Math.floor(TASK_TIMEOUT_MS / 60000)} minutes. The processing engine may need to be restarted.]`);
 		}
 	}
 }
@@ -403,6 +412,7 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					_sendTaskStatus?.(taskId, 'done', result.slice(0, 60), result);
 					_deliveredResults.add(file);
 					_pendingTasks.delete(taskId);
+					_timeoutBadgeFired.delete(taskId);
 					logConversation('core-agent', `[task:${taskId}] ${result.slice(0, 200)}`);
 					onResult(result);
 					// Notify agent-api directly, then delete file

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -492,7 +492,14 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 		_checkPendingTimeouts(Date.now(), _pendingTasks, _sendTaskStatus, onResult);
 
 		try {
-			const files = readdirSync(RESULT_DIR).filter(f => f.endsWith('.txt')).sort();
+			// Skip `proactive-*.txt` — those are outbound messages we WROTE
+			// (e.g. stuck-task escalations). The Discord bridge picks them up
+			// from results/, but the voice-agent's own result-watcher must NOT
+			// re-deliver them as task results: that would (a) inject the alert
+			// into the Gemini context (voice narrates it, breaking silent
+			// timeout) and (b) bodhi-push it as task.status='done' for a
+			// synthetic taskId, which spawns an extra row in the Tasks tab.
+			const files = readdirSync(RESULT_DIR).filter(f => f.endsWith('.txt') && !f.startsWith('proactive-')).sort();
 			if (files.length === 0) return;
 
 			// Only deliver if a client is connected — otherwise keep files queued

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -69,87 +69,23 @@ function ts(): string { return new Date().toISOString().slice(11, 23); }
 let _sendTaskStatus: ((taskId: string, status: string, text: string, result?: string) => void) | null = null;
 const _deliveredResults = new Set<string>();
 
-export const TASK_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
-// First status-check nudge fires once a task has been pending this long
-// without a result. Higher than TASK_TIMEOUT_MS so we don't nudge for every
-// slow-but-progressing task — only ones that look genuinely stuck.
-// Subsequent nudges fire every NUDGE_AT_MS thereafter (so nudge #N fires at
-// N × NUDGE_AT_MS).
-export const NUDGE_AT_MS = 3 * TASK_TIMEOUT_MS;
-// Stop after this many unanswered nudges. After the last one fires, the
-// task is escalated via Discord DM to the owner so they know core looks
-// genuinely stuck. We don't keep spamming nudges past this — N status
-// checks unanswered is enough signal.
-export const MAX_NUDGES = 3;
+export const TASK_TIMEOUT_MS = 10 * 60 * 1000; // 10 min
 type PendingTask = { submittedAt: number; task: string };
 export const _pendingTasks = new Map<string, PendingTask>(); // taskId → entry
 
 // Track which pending entries have already had their timeout badge fired so
 // we don't re-emit the same status event every 2s after the deadline passes.
 const _timeoutBadgeFired = new Set<string>();
-// Per-task nudge counter (0..MAX_NUDGES). Cleared when a result arrives so
-// the SAME task re-submitted later restarts the cycle.
-const _nudgeCount = new Map<string, number>();
-// Flag: did this task already get its post-MAX_NUDGES Discord escalation?
-const _escalated = new Set<string>();
-
-/** Default nudge-writer: drops a status-check task file in TASK_DIR. The
- * watcher will pick it up like any other task. Injected via a parameter on
- * `_checkPendingTimeouts` so tests can capture the call without writing
- * to disk. */
-function _defaultWriteNudge(nudgeId: string, content: string): void {
-	writeFileSync(join(TASK_DIR, `${nudgeId}.txt`), content);
-}
-
-/** Default escalator: writes a `results/proactive-stuck-{ts}.txt` file. The
- * Discord bridge watches that prefix and DMs the owner. Per CLAUDE.md
- * "Proactive messages: write to `results/proactive-{ts}.txt` to speak to
- * the user". Injected so tests can capture without DM-ing. */
-function _defaultEscalate(taskId: string, originalTask: string, ageMs: number, nudgeCount: number): void {
-	const ageMin = Math.floor(ageMs / 60000);
-	const truncated = originalTask.slice(0, 80);
-	const ts = Date.now();
-	const body = `[Sutando-stuck-alert] Core looks stuck on task ${taskId}: "${truncated}" (${ageMin} min old, ${nudgeCount} status-check nudges unanswered). You may want to check core's logs or run /pull-and-restart.`;
-	writeFileSync(join(RESULT_DIR, `proactive-stuck-${ts}.txt`), body);
-}
-
-function _buildNudgeContent(nudgeId: string, originalTaskId: string, originalTask: string, ageMs: number, attempt: number): string {
-	const ageMin = Math.floor(ageMs / 60000);
-	const ownerId = process.env.SUTANDO_DM_OWNER_ID || 'voice-local';
-	const truncated = originalTask.slice(0, 80);
-	return (
-		`id: ${nudgeId}\n` +
-		`timestamp: ${new Date().toISOString()}\n` +
-		`task: [Sutando-status-check #${attempt}] ${ageMin} min ago I queued: "${truncated}". Are you still working on it? If yes, post a brief status (what you've done so far). If you're stuck, name the blocker. If the task is no longer relevant, just say so. Don't restart the original task — only report status.\n` +
-		`source: voice\n` +
-		`channel_id: local-voice\n` +
-		`user_id: ${ownerId}\n` +
-		`access_tier: owner\n` +
-		`parent_task_id: ${originalTaskId}\n`
-	);
-}
 
 /**
  * Pure timeout check, extracted from startResultWatcher's setInterval so it
  * can be unit-tested without the 2s timer or the fs.readdir loop.
  *
- * Three escalating effects, each deduped per task:
- *
- * 1. UI-only / silent timeout badge once age > TASK_TIMEOUT_MS — marks the
- *    Tasks-tab row yellow. Does NOT fire `onResult`, so the voice agent
- *    stays silent. The pending entry is intentionally LEFT IN PLACE — if
- *    core eventually returns a result, `_processResult` will flip the row
- *    to `done` the normal way.
- *
- * 2. Status-check nudges starting at age > NUDGE_AT_MS, then every
- *    NUDGE_AT_MS thereafter, up to MAX_NUDGES total. Each nudge writes a
- *    new status-check task file (not a re-submit) so the in-flight task
- *    isn't duplicated. nudgeCount per task is cleared when the result
- *    arrives.
- *
- * 3. Discord DM escalation once nudgeCount reaches MAX_NUDGES — writes
- *    `results/proactive-stuck-{ts}.txt` which the Discord bridge picks up
- *    and DMs the owner. Fires exactly once per task per result-cycle.
+ * Silent UI-only badge once age > TASK_TIMEOUT_MS — marks the Tasks-tab
+ * row yellow. Does NOT fire `onResult`, so the voice agent stays silent.
+ * The pending entry is intentionally LEFT IN PLACE — if core eventually
+ * returns a result, `_processResult` will flip the row to `done` the
+ * normal way.
  */
 export function _checkPendingTimeouts(
 	now: number,
@@ -157,10 +93,6 @@ export function _checkPendingTimeouts(
 	sendStatus: ((taskId: string, status: string, text: string, result?: string) => void) | null,
 	_onResult: (result: string) => void,
 	firedSet: Set<string> = _timeoutBadgeFired,
-	nudgeCount: Map<string, number> = _nudgeCount,
-	writeNudge: (nudgeId: string, content: string) => void = _defaultWriteNudge,
-	escalated: Set<string> = _escalated,
-	escalate: (taskId: string, originalTask: string, ageMs: number, nudgeCount: number) => void = _defaultEscalate,
 ): void {
 	for (const [taskId, entry] of pending) {
 		const age = now - entry.submittedAt;
@@ -168,36 +100,6 @@ export function _checkPendingTimeouts(
 			firedSet.add(taskId);
 			console.error(`${ts()} [TaskBridge] Task ${taskId} timed out after ${TASK_TIMEOUT_MS / 1000}s (silent — UI badge only)`);
 			sendStatus?.(taskId, 'timeout', `Timed out: ${entry.task.slice(0, 60)}`);
-		}
-
-		// Periodic nudges: nudge #N fires at age >= N × NUDGE_AT_MS, capped at
-		// MAX_NUDGES total. Compute the highest nudge number this age qualifies
-		// for, then fire any not-yet-fired ones in order (in steady state we'll
-		// only fire one per tick, but this also handles long sleeps).
-		const fired = nudgeCount.get(taskId) ?? 0;
-		const target = Math.min(MAX_NUDGES, Math.floor(age / NUDGE_AT_MS));
-		if (target > fired) {
-			for (let attempt = fired + 1; attempt <= target; attempt++) {
-				const nudgeId = `task-${now}-nudge-${attempt}`;
-				try {
-					writeNudge(nudgeId, _buildNudgeContent(nudgeId, taskId, entry.task, age, attempt));
-					console.error(`${ts()} [TaskBridge] Status-check nudge #${attempt}/${MAX_NUDGES} ${nudgeId} sent for ${taskId} (${Math.floor(age / 60000)} min old)`);
-				} catch (e) {
-					console.error(`${ts()} [TaskBridge] Nudge write failed:`, e);
-				}
-			}
-			nudgeCount.set(taskId, target);
-		}
-
-		// Escalate via Discord DM after the MAX_NUDGES'th nudge has fired.
-		if ((nudgeCount.get(taskId) ?? 0) >= MAX_NUDGES && !escalated.has(taskId)) {
-			escalated.add(taskId);
-			try {
-				escalate(taskId, entry.task, age, MAX_NUDGES);
-				console.error(`${ts()} [TaskBridge] Escalated stuck-task ${taskId} to owner DM (${Math.floor(age / 60000)} min old, ${MAX_NUDGES} nudges unanswered)`);
-			} catch (e) {
-				console.error(`${ts()} [TaskBridge] Escalation failed:`, e);
-			}
 		}
 	}
 }
@@ -492,14 +394,7 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 		_checkPendingTimeouts(Date.now(), _pendingTasks, _sendTaskStatus, onResult);
 
 		try {
-			// Skip `proactive-*.txt` — those are outbound messages we WROTE
-			// (e.g. stuck-task escalations). The Discord bridge picks them up
-			// from results/, but the voice-agent's own result-watcher must NOT
-			// re-deliver them as task results: that would (a) inject the alert
-			// into the Gemini context (voice narrates it, breaking silent
-			// timeout) and (b) bodhi-push it as task.status='done' for a
-			// synthetic taskId, which spawns an extra row in the Tasks tab.
-			const files = readdirSync(RESULT_DIR).filter(f => f.endsWith('.txt') && !f.startsWith('proactive-')).sort();
+			const files = readdirSync(RESULT_DIR).filter(f => f.endsWith('.txt')).sort();
 			if (files.length === 0) return;
 
 			// Only deliver if a client is connected — otherwise keep files queued
@@ -518,8 +413,6 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					_deliveredResults.add(file);
 					_pendingTasks.delete(taskId);
 					_timeoutBadgeFired.delete(taskId);
-					_nudgeCount.delete(taskId);
-					_escalated.delete(taskId);
 					logConversation('core-agent', `[task:${taskId}] ${result.slice(0, 200)}`);
 					onResult(result);
 					// Notify agent-api directly, then delete file

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -169,6 +169,21 @@ export const workTool: ToolDefinition = {
 			console.log(`${ts()} [TaskBridge] WARNING: watcher offline — task will be queued for next cron pass`);
 		}
 
+		// Dedup: voice agent sometimes re-fires the same intent within minutes.
+		// Reuse an existing pending task if its content matches exactly and it is still in-flight.
+		const DEDUP_WINDOW_MS = 5 * 60 * 1000;
+		const dedupNow = Date.now();
+		for (const [existingId, entry] of _pendingTasks) {
+			if (entry.task === task && dedupNow - entry.submittedAt < DEDUP_WINDOW_MS) {
+				console.log(`${ts()} [TaskBridge] Dedup hit: reusing ${existingId} for "${task.slice(0, 60)}"`);
+				return {
+					status: 'pending',
+					taskId: existingId,
+					message: 'DEDUP: this exact task was already submitted moments ago. Stay silent — do NOT speak, do NOT narrate, do NOT acknowledge. The original is still in flight.',
+				};
+			}
+		}
+
 		const taskId = `task-${Date.now()}`;
 		const timestamp = new Date().toISOString();
 		const ownerId = process.env.SUTANDO_DM_OWNER_ID || 'voice-local';

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -310,6 +310,11 @@ const HTML = /* html */ `<!DOCTYPE html>
   .task-status.working { background: #1e3a5f; color: #60a5fa; animation: pulse 1.5s infinite; }
   .task-status.done { background: #1e4028; color: #4ecca3; }
   .task-status.timeout { background: #4a3a1e; color: #f59e0b; animation: pulse 1.5s infinite; }
+  .task-status-label.timeout {
+    flex-shrink: 0; padding: 2px 8px; border-radius: 10px;
+    background: #4a3a1e; color: #f59e0b; font-size: 11px; font-weight: 600;
+    letter-spacing: 0.05em; text-transform: uppercase; align-self: center;
+  }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
   .task-text { color: #d0d0d8; flex: 1; word-break: break-word; font-size: 16px; line-height: 1.6; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .task-text.expanded { white-space: normal; }
@@ -1053,6 +1058,7 @@ function renderTasks() {
     const expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide ▾' : 'Show details ▸') + '</span>' : '';
     return '<div class="task-item"' + clickAttr + '>' +
       '<div class="task-status ' + t.status + '">' + (icons[t.status] || '?') + '</div>' +
+      (t.status === 'timeout' ? '<span class="task-status-label timeout">timeout</span>' : '') +
       '<span class="' + textClass + '">' + displayText + '</span>' +
       '<span class="task-time">' + timeStr + '</span>' +
       expandChip +
@@ -2198,6 +2204,7 @@ function renderTabContent() {
         var expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide &#9662;' : 'Show details &#9656;') + '</span>' : '';
         return '<div class="task-item"' + clickAttr + '>' +
           '<div class="task-status ' + t.status + '">' + (icons[t.status] || '?') + '</div>' +
+      (t.status === 'timeout' ? '<span class="task-status-label timeout">timeout</span>' : '') +
           '<span class="' + textClass + '">' + displayText + '</span>' +
           '<span class="task-time">' + timeStr + '</span>' +
           expandChip +

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -315,6 +315,11 @@ const HTML = /* html */ `<!DOCTYPE html>
     background: #4a3a1e; color: #f59e0b; font-size: 11px; font-weight: 600;
     letter-spacing: 0.05em; text-transform: uppercase; align-self: center;
   }
+  .task-nudge-pill {
+    flex-shrink: 0; padding: 2px 8px; border-radius: 10px;
+    background: #1e3a5f; color: #60a5fa; font-size: 11px; font-weight: 500;
+    align-self: center; margin-left: 4px;
+  }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
   .task-text { color: #d0d0d8; flex: 1; word-break: break-word; font-size: 16px; line-height: 1.6; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .task-text.expanded { white-space: normal; }
@@ -1058,7 +1063,7 @@ function renderTasks() {
     const expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide ▾' : 'Show details ▸') + '</span>' : '';
     return '<div class="task-item"' + clickAttr + '>' +
       '<div class="task-status ' + t.status + '">' + (icons[t.status] || '?') + '</div>' +
-      (t.status === 'timeout' ? '<span class="task-status-label timeout">timeout</span>' : '') +
+      (t.status === 'timeout' ? '<span class="task-status-label timeout">timeout</span>' + (t.nudges > 0 ? '<span class="task-nudge-pill">' + t.nudges + '× sent to core</span>' : '') : '') +
       '<span class="' + textClass + '">' + displayText + '</span>' +
       '<span class="task-time">' + timeStr + '</span>' +
       expandChip +
@@ -2204,7 +2209,7 @@ function renderTabContent() {
         var expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide &#9662;' : 'Show details &#9656;') + '</span>' : '';
         return '<div class="task-item"' + clickAttr + '>' +
           '<div class="task-status ' + t.status + '">' + (icons[t.status] || '?') + '</div>' +
-      (t.status === 'timeout' ? '<span class="task-status-label timeout">timeout</span>' : '') +
+      (t.status === 'timeout' ? '<span class="task-status-label timeout">timeout</span>' + (t.nudges > 0 ? '<span class="task-nudge-pill">' + t.nudges + '× sent to core</span>' : '') : '') +
           '<span class="' + textClass + '">' + displayText + '</span>' +
           '<span class="task-time">' + timeStr + '</span>' +
           expandChip +

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -315,11 +315,6 @@ const HTML = /* html */ `<!DOCTYPE html>
     background: #4a3a1e; color: #f59e0b; font-size: 11px; font-weight: 600;
     letter-spacing: 0.05em; text-transform: uppercase; align-self: center;
   }
-  .task-nudge-pill {
-    flex-shrink: 0; padding: 2px 8px; border-radius: 10px;
-    background: #1e3a5f; color: #60a5fa; font-size: 11px; font-weight: 500;
-    align-self: center; margin-left: 4px;
-  }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
   .task-text { color: #d0d0d8; flex: 1; word-break: break-word; font-size: 16px; line-height: 1.6; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .task-text.expanded { white-space: normal; }
@@ -1063,7 +1058,7 @@ function renderTasks() {
     const expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide ▾' : 'Show details ▸') + '</span>' : '';
     return '<div class="task-item"' + clickAttr + '>' +
       '<div class="task-status ' + t.status + '">' + (icons[t.status] || '?') + '</div>' +
-      (t.status === 'timeout' ? '<span class="task-status-label timeout">timeout</span>' + (t.nudges > 0 ? '<span class="task-nudge-pill">' + t.nudges + '× sent to core</span>' : '') : '') +
+      (t.status === 'timeout' ? '<span class="task-status-label timeout">timeout</span>' : '') +
       '<span class="' + textClass + '">' + displayText + '</span>' +
       '<span class="task-time">' + timeStr + '</span>' +
       expandChip +
@@ -2209,7 +2204,7 @@ function renderTabContent() {
         var expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide &#9662;' : 'Show details &#9656;') + '</span>' : '';
         return '<div class="task-item"' + clickAttr + '>' +
           '<div class="task-status ' + t.status + '">' + (icons[t.status] || '?') + '</div>' +
-      (t.status === 'timeout' ? '<span class="task-status-label timeout">timeout</span>' + (t.nudges > 0 ? '<span class="task-nudge-pill">' + t.nudges + '× sent to core</span>' : '') : '') +
+      (t.status === 'timeout' ? '<span class="task-status-label timeout">timeout</span>' : '') +
           '<span class="' + textClass + '">' + displayText + '</span>' +
           '<span class="task-time">' + timeStr + '</span>' +
           expandChip +

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -309,6 +309,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   }
   .task-status.working { background: #1e3a5f; color: #60a5fa; animation: pulse 1.5s infinite; }
   .task-status.done { background: #1e4028; color: #4ecca3; }
+  .task-status.timeout { background: #4a3a1e; color: #f59e0b; animation: pulse 1.5s infinite; }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
   .task-text { color: #d0d0d8; flex: 1; word-break: break-word; font-size: 16px; line-height: 1.6; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .task-text.expanded { white-space: normal; }
@@ -1021,7 +1022,7 @@ function renderTasks() {
   }
   const sorted = entries.sort((a, b) => b[1].time - a[1].time).slice(0, 8);
   container.innerHTML = sorted.map(([id, t]) => {
-    const icons = { pending: '&#8987;', working: '&#9881;', done: '&#10003;', error: '&#10007;' };
+    const icons = { pending: '&#8987;', working: '&#9881;', done: '&#10003;', error: '&#10007;', timeout: '&#9201;' };
     const ago = Math.round((Date.now() - t.time) / 1000);
     const timeStr = ago < 60 ? ago + 's ago' : Math.round(ago / 60) + 'm ago';
     const hasResult = t.result && t.status === 'done';
@@ -2177,7 +2178,7 @@ function renderTabContent() {
       container.innerHTML = '<div style="color:#666;font-size:12px;text-align:center;padding:12px">No recent tasks</div>';
     } else {
       var sorted = entries.sort(function(a,b) { return b[1].time - a[1].time; }).slice(0, 10);
-      var icons = { pending: '&#8987;', working: '&#9881;', done: '&#10003;', error: '&#10007;' };
+      var icons = { pending: '&#8987;', working: '&#9881;', done: '&#10003;', error: '&#10007;', timeout: '&#9201;' };
       container.innerHTML = sorted.map(function(entry) {
         var id = entry[0], t = entry[1];
         var ago = Math.round((Date.now() - t.time) / 1000);

--- a/tests/task-bridge-dedup.test.ts
+++ b/tests/task-bridge-dedup.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, before, after, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readdirSync, unlinkSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { workTool, _pendingTasks } from '../src/task-bridge.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const TASK_DIR = join(REPO_ROOT, 'tasks');
+
+function listTaskFiles(): string[] {
+	if (!existsSync(TASK_DIR)) return [];
+	return readdirSync(TASK_DIR).filter(f => f.startsWith('task-') && f.endsWith('.txt'));
+}
+
+describe('task-bridge workTool — content dedup within window', () => {
+	let baseline: Set<string>;
+
+	before(() => {
+		mkdirSync(TASK_DIR, { recursive: true });
+		baseline = new Set(listTaskFiles());
+		_pendingTasks.clear();
+	});
+
+	afterEach(() => {
+		for (const fn of readdirSync(TASK_DIR)) {
+			if (fn.startsWith('task-') && fn.endsWith('.txt') && !baseline.has(fn)) {
+				try { unlinkSync(join(TASK_DIR, fn)); } catch { /* gone */ }
+			}
+		}
+		_pendingTasks.clear();
+	});
+
+	after(() => { _pendingTasks.clear(); });
+
+	it('reuses the same taskId for identical task strings within 5 minutes', async () => {
+		const task = 'Check the status of PR #15 in the Boldai/real-time-agent repo.';
+		const r1 = await workTool.execute({ task }, null) as { status: string; taskId: string };
+		const r2 = await workTool.execute({ task }, null) as { status: string; taskId: string };
+		assert.equal(r1.taskId, r2.taskId, 'duplicate same-content calls must collapse to one taskId');
+		assert.equal(_pendingTasks.size, 1, 'only one pending entry should exist');
+		// Filesystem should also have only one task file from this test
+		const created = readdirSync(TASK_DIR).filter(f =>
+			f.startsWith('task-') && f.endsWith('.txt') && !baseline.has(f)
+		);
+		assert.equal(created.length, 1, `exactly one task file expected, got ${created.length}`);
+	});
+
+	it('still creates a new task when content differs', async () => {
+		const r1 = await workTool.execute({ task: 'task A' }, null) as { status: string; taskId: string };
+		const r2 = await workTool.execute({ task: 'task B' }, null) as { status: string; taskId: string };
+		assert.notEqual(r1.taskId, r2.taskId, 'different content should produce different taskIds');
+		assert.equal(_pendingTasks.size, 2);
+	});
+});

--- a/tests/task-bridge-timeout.test.ts
+++ b/tests/task-bridge-timeout.test.ts
@@ -20,6 +20,7 @@ import { join } from 'node:path';
 import {
 	_checkPendingTimeouts,
 	_pendingTasks,
+	MAX_NUDGES,
 	NUDGE_AT_MS,
 	TASK_TIMEOUT_MS,
 	workTool,
@@ -106,33 +107,60 @@ test('integration: workTool submission stores task text so timeout title remains
 	assert.match(call!.text, /integration-canary task text/);
 });
 
-test('nudge fires once at NUDGE_AT_MS, sends a status-check (not a re-submit)', () => {
+test('nudges fire periodically up to MAX_NUDGES, then escalate via Discord DM', () => {
 	const pending = new Map<string, { submittedAt: number; task: string }>();
 	pending.set('task-x', { submittedAt: 0, task: 'long-running analysis of the open PRs' });
 	const { statusCalls, onResultCalls, sendStatus, onResult } = makeCaptures();
 	const fired = new Set<string>();
-	const nudge = new Set<string>();
+	const nudgeCount = new Map<string, number>();
 	const nudgeWrites: { id: string; content: string }[] = [];
 	const writeNudge = (id: string, content: string) => { nudgeWrites.push({ id, content }); };
+	const escalated = new Set<string>();
+	const escalateCalls: { taskId: string; task: string; ageMs: number; nudges: number }[] = [];
+	const escalate = (taskId: string, task: string, ageMs: number, n: number) => {
+		escalateCalls.push({ taskId, task, ageMs, nudges: n });
+	};
+	const callAt = (now: number) => _checkPendingTimeouts(now, pending, sendStatus, onResult, fired, nudgeCount, writeNudge, escalated, escalate);
 
-	// Below NUDGE_AT_MS — only the regular timeout badge, no nudge yet.
-	_checkPendingTimeouts(NUDGE_AT_MS - 1, pending, sendStatus, onResult, fired, nudge, writeNudge);
+	// Below NUDGE_AT_MS — timeout badge only, no nudge.
+	callAt(NUDGE_AT_MS - 1);
 	assert.equal(nudgeWrites.length, 0, 'no nudge before NUDGE_AT_MS');
 	assert.equal(statusCalls.length, 1, 'timeout badge fired (silent)');
+	assert.equal(escalateCalls.length, 0);
 
-	// Past NUDGE_AT_MS — nudge written exactly once.
-	_checkPendingTimeouts(NUDGE_AT_MS + 1, pending, sendStatus, onResult, fired, nudge, writeNudge);
-	assert.equal(nudgeWrites.length, 1, 'nudge fires once past NUDGE_AT_MS');
-	assert.match(nudgeWrites[0].content, /\[Sutando-status-check\]/, 'nudge is a status-check, not a re-submit');
-	assert.match(nudgeWrites[0].content, /long-running analysis of the open PRs/, 'nudge cites the original task text so core knows what to report on');
-	assert.match(nudgeWrites[0].content, /parent_task_id: task-x/, 'nudge carries parent_task_id for traceability');
+	// Past 1×NUDGE_AT_MS — nudge #1.
+	callAt(NUDGE_AT_MS + 1);
+	assert.equal(nudgeWrites.length, 1, 'nudge #1 fires past 1× threshold');
+	assert.match(nudgeWrites[0].content, /\[Sutando-status-check #1\]/);
+	assert.match(nudgeWrites[0].content, /long-running analysis of the open PRs/, 'nudge cites original task text');
+	assert.match(nudgeWrites[0].content, /parent_task_id: task-x/, 'nudge carries parent_task_id');
 	assert.match(nudgeWrites[0].content, /Don't restart the original task/, 'nudge explicitly tells core not to restart');
-	assert.equal(onResultCalls.length, 0, 'still silent — nudge does not narrate');
+	assert.equal(escalateCalls.length, 0, 'no escalation yet');
 
-	// Repeat ticks past the nudge threshold — must NOT fire a second nudge.
-	_checkPendingTimeouts(NUDGE_AT_MS + 60_000, pending, sendStatus, onResult, fired, nudge, writeNudge);
-	_checkPendingTimeouts(NUDGE_AT_MS + 120_000, pending, sendStatus, onResult, fired, nudge, writeNudge);
-	assert.equal(nudgeWrites.length, 1, 'nudge dedupes across ticks (only one per pending task)');
+	// Tick again before 2× threshold — no new nudge.
+	callAt(NUDGE_AT_MS + 60_000);
+	assert.equal(nudgeWrites.length, 1, 'no second nudge until 2×');
+
+	// Past 2×NUDGE_AT_MS — nudge #2.
+	callAt(2 * NUDGE_AT_MS + 1);
+	assert.equal(nudgeWrites.length, 2, 'nudge #2 fires past 2× threshold');
+	assert.match(nudgeWrites[1].content, /\[Sutando-status-check #2\]/);
+	assert.equal(escalateCalls.length, 0, 'no escalation yet');
+
+	// Past 3×NUDGE_AT_MS — nudge #3 + Discord escalation.
+	callAt(3 * NUDGE_AT_MS + 1);
+	assert.equal(nudgeWrites.length, 3, 'nudge #3 fires past 3× threshold');
+	assert.match(nudgeWrites[2].content, /\[Sutando-status-check #3\]/);
+	assert.equal(escalateCalls.length, 1, 'escalation fires after MAX_NUDGES');
+	assert.equal(escalateCalls[0].taskId, 'task-x');
+	assert.equal(escalateCalls[0].nudges, MAX_NUDGES);
+
+	// Past 4×NUDGE_AT_MS — capped at MAX_NUDGES, no nudge #4 and no second escalation.
+	callAt(4 * NUDGE_AT_MS + 1);
+	assert.equal(nudgeWrites.length, MAX_NUDGES, 'capped at MAX_NUDGES total');
+	assert.equal(escalateCalls.length, 1, 'escalation dedupes — only fires once');
+
+	assert.equal(onResultCalls.length, 0, 'still silent throughout — no voice narration');
 });
 
 test('timeout title carries original task text so distinct tasks render distinctly (THIS IS THE BUG)', () => {

--- a/tests/task-bridge-timeout.test.ts
+++ b/tests/task-bridge-timeout.test.ts
@@ -1,0 +1,104 @@
+// Unit tests for the task-bridge timeout path.
+//
+// Bug being covered: when a task hits TASK_TIMEOUT_MS, the status event
+// fired to the web UI used a generic title — "Task timed out — core agent
+// may be unresponsive" — which collapses N distinct timed-out tasks into
+// N visually-identical Tasks-tab rows (see screenshot 2026-05-02 8.54pm:
+// 16 indistinguishable rows). The desired behavior is that the timeout
+// status carries the original task text so each row remains identifiable.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+	_checkPendingTimeouts,
+	_pendingTasks,
+	TASK_TIMEOUT_MS,
+	workTool,
+} from '../src/task-bridge.ts';
+
+const REPO_DIR = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const TASK_DIR = join(REPO_DIR, 'tasks');
+
+type StatusCall = { taskId: string; status: string; text: string; result?: string };
+
+function makeCaptures() {
+	const statusCalls: StatusCall[] = [];
+	const onResultCalls: string[] = [];
+	const sendStatus = (taskId: string, status: string, text: string, result?: string) => {
+		statusCalls.push({ taskId, status, text, result });
+	};
+	const onResult = (s: string) => { onResultCalls.push(s); };
+	return { statusCalls, onResultCalls, sendStatus, onResult };
+}
+
+test('timeout fires for tasks older than TASK_TIMEOUT_MS', () => {
+	const pending = new Map<string, { submittedAt: number; task: string }>();
+	pending.set('task-1', { submittedAt: 0, task: 'summarize the 5 open PRs by sonichi' });
+	const { statusCalls, onResultCalls, sendStatus, onResult } = makeCaptures();
+
+	_checkPendingTimeouts(TASK_TIMEOUT_MS + 1, pending, sendStatus, onResult);
+
+	assert.equal(statusCalls.length, 1, 'one timeout status fired');
+	assert.equal(statusCalls[0].status, 'timeout');
+	assert.equal(onResultCalls.length, 1);
+	assert.equal(pending.size, 0, 'pending entry removed after timeout');
+});
+
+test('timeout does NOT fire for tasks within the deadline', () => {
+	const pending = new Map<string, { submittedAt: number; task: string }>();
+	pending.set('task-1', { submittedAt: 0, task: 'still working' });
+	const { statusCalls, onResultCalls, sendStatus, onResult } = makeCaptures();
+
+	_checkPendingTimeouts(TASK_TIMEOUT_MS - 1, pending, sendStatus, onResult);
+
+	assert.equal(statusCalls.length, 0);
+	assert.equal(onResultCalls.length, 0);
+	assert.equal(pending.size, 1, 'still pending');
+});
+
+test('integration: workTool submission stores task text so timeout title remains identifiable', async () => {
+	// Guards against a regression where the submit-site stops recording the
+	// task text into _pendingTasks (e.g. someone reverts the value shape from
+	// {submittedAt, task} to a bare timestamp). Without the task text in the
+	// map, the timeout title would collapse back to "Timed out: undefined"
+	// for every entry — same UI symptom as the original bug.
+	_pendingTasks.clear();
+	const taskText = 'integration-canary task text — should reach timeout title';
+	const result = await workTool.execute({ task: taskText }, null as any);
+	assert.equal((result as any).status, 'pending', 'workTool returns pending');
+	const taskId = (result as any).taskId as string;
+	// workTool writes tasks/<taskId>.txt on disk — remove it so the live
+	// watcher (if running) doesn't fire a TASK_FILE event for our fixture.
+	try { unlinkSync(join(TASK_DIR, `${taskId}.txt`)); } catch {}
+	const entry = _pendingTasks.get(taskId);
+	assert.ok(entry, 'task is registered in _pendingTasks');
+	assert.equal(entry!.task, taskText, 'submit-site preserves the original task text');
+	assert.equal(typeof entry!.submittedAt, 'number');
+
+	// Drive the timeout and confirm the title carries the text end-to-end.
+	const { statusCalls, sendStatus, onResult } = makeCaptures();
+	_checkPendingTimeouts(entry!.submittedAt + TASK_TIMEOUT_MS + 1, _pendingTasks, sendStatus, onResult);
+	const call = statusCalls.find(c => c.taskId === taskId);
+	assert.ok(call, 'timeout fired for the submitted task');
+	assert.equal(call!.status, 'timeout');
+	assert.match(call!.text, /integration-canary task text/);
+});
+
+test('timeout title carries original task text so distinct tasks render distinctly (THIS IS THE BUG)', () => {
+	const pending = new Map<string, { submittedAt: number; task: string }>();
+	pending.set('task-a', { submittedAt: 0, task: 'summarize the 5 open PRs by sonichi' });
+	pending.set('task-b', { submittedAt: 0, task: 'what is on my screen' });
+	const { statusCalls, sendStatus, onResult } = makeCaptures();
+
+	_checkPendingTimeouts(TASK_TIMEOUT_MS + 1, pending, sendStatus, onResult);
+
+	assert.equal(statusCalls.length, 2);
+	const titles = statusCalls.map(c => c.text);
+	const uniqueTitles = new Set(titles);
+	assert.equal(uniqueTitles.size, 2,
+		`expected 2 distinct timeout titles for 2 distinct tasks; got ${JSON.stringify(titles)}`);
+	assert.match(statusCalls.find(c => c.taskId === 'task-a')!.text, /5 open PRs/);
+	assert.match(statusCalls.find(c => c.taskId === 'task-b')!.text, /screen/);
+});

--- a/tests/task-bridge-timeout.test.ts
+++ b/tests/task-bridge-timeout.test.ts
@@ -1,11 +1,17 @@
 // Unit tests for the task-bridge timeout path.
 //
-// Bug being covered: when a task hits TASK_TIMEOUT_MS, the status event
-// fired to the web UI used a generic title — "Task timed out — core agent
-// may be unresponsive" — which collapses N distinct timed-out tasks into
-// N visually-identical Tasks-tab rows (see screenshot 2026-05-02 8.54pm:
-// 16 indistinguishable rows). The desired behavior is that the timeout
-// status carries the original task text so each row remains identifiable.
+// Two layered bugs covered:
+//
+// (1) Generic timeout title collapsed N distinct timed-out tasks into N
+//     visually-identical Tasks-tab rows (16-row screenshot 2026-05-02
+//     8.54pm). Fix: timeout status carries the original task text.
+//
+// (2) Timeout fired `onResult(...)` which was funneled into the voice
+//     agent's LLM context, causing it to narrate "the task timed out" out
+//     loud — annoying when a slow task often eventually completes anyway.
+//     Fix: timeout is UI-only (silent). The badge is set exactly once, the
+//     pending entry is left in place so an eventual real result still
+//     flips the row to `done` via the normal `_processResult` path.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -33,17 +39,17 @@ function makeCaptures() {
 	return { statusCalls, onResultCalls, sendStatus, onResult };
 }
 
-test('timeout fires for tasks older than TASK_TIMEOUT_MS', () => {
+test('timeout fires UI badge but stays silent (no onResult), pending entry survives', () => {
 	const pending = new Map<string, { submittedAt: number; task: string }>();
 	pending.set('task-1', { submittedAt: 0, task: 'summarize the 5 open PRs by sonichi' });
 	const { statusCalls, onResultCalls, sendStatus, onResult } = makeCaptures();
 
-	_checkPendingTimeouts(TASK_TIMEOUT_MS + 1, pending, sendStatus, onResult);
+	_checkPendingTimeouts(TASK_TIMEOUT_MS + 1, pending, sendStatus, onResult, new Set());
 
 	assert.equal(statusCalls.length, 1, 'one timeout status fired');
 	assert.equal(statusCalls[0].status, 'timeout');
-	assert.equal(onResultCalls.length, 1);
-	assert.equal(pending.size, 0, 'pending entry removed after timeout');
+	assert.equal(onResultCalls.length, 0, 'silent — no voice narration');
+	assert.equal(pending.size, 1, 'pending entry kept so an eventual result still flips to done');
 });
 
 test('timeout does NOT fire for tasks within the deadline', () => {
@@ -51,11 +57,24 @@ test('timeout does NOT fire for tasks within the deadline', () => {
 	pending.set('task-1', { submittedAt: 0, task: 'still working' });
 	const { statusCalls, onResultCalls, sendStatus, onResult } = makeCaptures();
 
-	_checkPendingTimeouts(TASK_TIMEOUT_MS - 1, pending, sendStatus, onResult);
+	_checkPendingTimeouts(TASK_TIMEOUT_MS - 1, pending, sendStatus, onResult, new Set());
 
 	assert.equal(statusCalls.length, 0);
 	assert.equal(onResultCalls.length, 0);
 	assert.equal(pending.size, 1, 'still pending');
+});
+
+test('timeout badge dedupes across ticks (does not re-fire every 2s)', () => {
+	const pending = new Map<string, { submittedAt: number; task: string }>();
+	pending.set('task-1', { submittedAt: 0, task: 'long-running task' });
+	const { statusCalls, sendStatus, onResult } = makeCaptures();
+	const fired = new Set<string>();
+
+	_checkPendingTimeouts(TASK_TIMEOUT_MS + 1, pending, sendStatus, onResult, fired);
+	_checkPendingTimeouts(TASK_TIMEOUT_MS + 2000, pending, sendStatus, onResult, fired);
+	_checkPendingTimeouts(TASK_TIMEOUT_MS + 4000, pending, sendStatus, onResult, fired);
+
+	assert.equal(statusCalls.length, 1, 'timeout badge fires exactly once even though the deadline keeps being exceeded');
 });
 
 test('integration: workTool submission stores task text so timeout title remains identifiable', async () => {
@@ -79,7 +98,7 @@ test('integration: workTool submission stores task text so timeout title remains
 
 	// Drive the timeout and confirm the title carries the text end-to-end.
 	const { statusCalls, sendStatus, onResult } = makeCaptures();
-	_checkPendingTimeouts(entry!.submittedAt + TASK_TIMEOUT_MS + 1, _pendingTasks, sendStatus, onResult);
+	_checkPendingTimeouts(entry!.submittedAt + TASK_TIMEOUT_MS + 1, _pendingTasks, sendStatus, onResult, new Set());
 	const call = statusCalls.find(c => c.taskId === taskId);
 	assert.ok(call, 'timeout fired for the submitted task');
 	assert.equal(call!.status, 'timeout');
@@ -92,7 +111,7 @@ test('timeout title carries original task text so distinct tasks render distinct
 	pending.set('task-b', { submittedAt: 0, task: 'what is on my screen' });
 	const { statusCalls, sendStatus, onResult } = makeCaptures();
 
-	_checkPendingTimeouts(TASK_TIMEOUT_MS + 1, pending, sendStatus, onResult);
+	_checkPendingTimeouts(TASK_TIMEOUT_MS + 1, pending, sendStatus, onResult, new Set());
 
 	assert.equal(statusCalls.length, 2);
 	const titles = statusCalls.map(c => c.text);

--- a/tests/task-bridge-timeout.test.ts
+++ b/tests/task-bridge-timeout.test.ts
@@ -20,6 +20,7 @@ import { join } from 'node:path';
 import {
 	_checkPendingTimeouts,
 	_pendingTasks,
+	NUDGE_AT_MS,
 	TASK_TIMEOUT_MS,
 	workTool,
 } from '../src/task-bridge.ts';
@@ -103,6 +104,35 @@ test('integration: workTool submission stores task text so timeout title remains
 	assert.ok(call, 'timeout fired for the submitted task');
 	assert.equal(call!.status, 'timeout');
 	assert.match(call!.text, /integration-canary task text/);
+});
+
+test('nudge fires once at NUDGE_AT_MS, sends a status-check (not a re-submit)', () => {
+	const pending = new Map<string, { submittedAt: number; task: string }>();
+	pending.set('task-x', { submittedAt: 0, task: 'long-running analysis of the open PRs' });
+	const { statusCalls, onResultCalls, sendStatus, onResult } = makeCaptures();
+	const fired = new Set<string>();
+	const nudge = new Set<string>();
+	const nudgeWrites: { id: string; content: string }[] = [];
+	const writeNudge = (id: string, content: string) => { nudgeWrites.push({ id, content }); };
+
+	// Below NUDGE_AT_MS — only the regular timeout badge, no nudge yet.
+	_checkPendingTimeouts(NUDGE_AT_MS - 1, pending, sendStatus, onResult, fired, nudge, writeNudge);
+	assert.equal(nudgeWrites.length, 0, 'no nudge before NUDGE_AT_MS');
+	assert.equal(statusCalls.length, 1, 'timeout badge fired (silent)');
+
+	// Past NUDGE_AT_MS — nudge written exactly once.
+	_checkPendingTimeouts(NUDGE_AT_MS + 1, pending, sendStatus, onResult, fired, nudge, writeNudge);
+	assert.equal(nudgeWrites.length, 1, 'nudge fires once past NUDGE_AT_MS');
+	assert.match(nudgeWrites[0].content, /\[Sutando-status-check\]/, 'nudge is a status-check, not a re-submit');
+	assert.match(nudgeWrites[0].content, /long-running analysis of the open PRs/, 'nudge cites the original task text so core knows what to report on');
+	assert.match(nudgeWrites[0].content, /parent_task_id: task-x/, 'nudge carries parent_task_id for traceability');
+	assert.match(nudgeWrites[0].content, /Don't restart the original task/, 'nudge explicitly tells core not to restart');
+	assert.equal(onResultCalls.length, 0, 'still silent — nudge does not narrate');
+
+	// Repeat ticks past the nudge threshold — must NOT fire a second nudge.
+	_checkPendingTimeouts(NUDGE_AT_MS + 60_000, pending, sendStatus, onResult, fired, nudge, writeNudge);
+	_checkPendingTimeouts(NUDGE_AT_MS + 120_000, pending, sendStatus, onResult, fired, nudge, writeNudge);
+	assert.equal(nudgeWrites.length, 1, 'nudge dedupes across ticks (only one per pending task)');
 });
 
 test('timeout title carries original task text so distinct tasks render distinctly (THIS IS THE BUG)', () => {

--- a/tests/task-bridge-timeout.test.ts
+++ b/tests/task-bridge-timeout.test.ts
@@ -20,8 +20,6 @@ import { join } from 'node:path';
 import {
 	_checkPendingTimeouts,
 	_pendingTasks,
-	MAX_NUDGES,
-	NUDGE_AT_MS,
 	TASK_TIMEOUT_MS,
 	workTool,
 } from '../src/task-bridge.ts';
@@ -105,62 +103,6 @@ test('integration: workTool submission stores task text so timeout title remains
 	assert.ok(call, 'timeout fired for the submitted task');
 	assert.equal(call!.status, 'timeout');
 	assert.match(call!.text, /integration-canary task text/);
-});
-
-test('nudges fire periodically up to MAX_NUDGES, then escalate via Discord DM', () => {
-	const pending = new Map<string, { submittedAt: number; task: string }>();
-	pending.set('task-x', { submittedAt: 0, task: 'long-running analysis of the open PRs' });
-	const { statusCalls, onResultCalls, sendStatus, onResult } = makeCaptures();
-	const fired = new Set<string>();
-	const nudgeCount = new Map<string, number>();
-	const nudgeWrites: { id: string; content: string }[] = [];
-	const writeNudge = (id: string, content: string) => { nudgeWrites.push({ id, content }); };
-	const escalated = new Set<string>();
-	const escalateCalls: { taskId: string; task: string; ageMs: number; nudges: number }[] = [];
-	const escalate = (taskId: string, task: string, ageMs: number, n: number) => {
-		escalateCalls.push({ taskId, task, ageMs, nudges: n });
-	};
-	const callAt = (now: number) => _checkPendingTimeouts(now, pending, sendStatus, onResult, fired, nudgeCount, writeNudge, escalated, escalate);
-
-	// Below NUDGE_AT_MS — timeout badge only, no nudge.
-	callAt(NUDGE_AT_MS - 1);
-	assert.equal(nudgeWrites.length, 0, 'no nudge before NUDGE_AT_MS');
-	assert.equal(statusCalls.length, 1, 'timeout badge fired (silent)');
-	assert.equal(escalateCalls.length, 0);
-
-	// Past 1×NUDGE_AT_MS — nudge #1.
-	callAt(NUDGE_AT_MS + 1);
-	assert.equal(nudgeWrites.length, 1, 'nudge #1 fires past 1× threshold');
-	assert.match(nudgeWrites[0].content, /\[Sutando-status-check #1\]/);
-	assert.match(nudgeWrites[0].content, /long-running analysis of the open PRs/, 'nudge cites original task text');
-	assert.match(nudgeWrites[0].content, /parent_task_id: task-x/, 'nudge carries parent_task_id');
-	assert.match(nudgeWrites[0].content, /Don't restart the original task/, 'nudge explicitly tells core not to restart');
-	assert.equal(escalateCalls.length, 0, 'no escalation yet');
-
-	// Tick again before 2× threshold — no new nudge.
-	callAt(NUDGE_AT_MS + 60_000);
-	assert.equal(nudgeWrites.length, 1, 'no second nudge until 2×');
-
-	// Past 2×NUDGE_AT_MS — nudge #2.
-	callAt(2 * NUDGE_AT_MS + 1);
-	assert.equal(nudgeWrites.length, 2, 'nudge #2 fires past 2× threshold');
-	assert.match(nudgeWrites[1].content, /\[Sutando-status-check #2\]/);
-	assert.equal(escalateCalls.length, 0, 'no escalation yet');
-
-	// Past 3×NUDGE_AT_MS — nudge #3 + Discord escalation.
-	callAt(3 * NUDGE_AT_MS + 1);
-	assert.equal(nudgeWrites.length, 3, 'nudge #3 fires past 3× threshold');
-	assert.match(nudgeWrites[2].content, /\[Sutando-status-check #3\]/);
-	assert.equal(escalateCalls.length, 1, 'escalation fires after MAX_NUDGES');
-	assert.equal(escalateCalls[0].taskId, 'task-x');
-	assert.equal(escalateCalls[0].nudges, MAX_NUDGES);
-
-	// Past 4×NUDGE_AT_MS — capped at MAX_NUDGES, no nudge #4 and no second escalation.
-	callAt(4 * NUDGE_AT_MS + 1);
-	assert.equal(nudgeWrites.length, MAX_NUDGES, 'capped at MAX_NUDGES total');
-	assert.equal(escalateCalls.length, 1, 'escalation dedupes — only fires once');
-
-	assert.equal(onResultCalls.length, 0, 'still silent throughout — no voice narration');
 });
 
 test('timeout title carries original task text so distinct tasks render distinctly (THIS IS THE BUG)', () => {


### PR DESCRIPTION
## Summary

When a task hits `TASK_TIMEOUT_MS`, every timeout event used the same generic title — *"Task timed out — core agent may be unresponsive"* — so N distinct timed-out tasks rendered as N visually-identical rows in the web client's Tasks tab. The screenshot below (taken 2026-05-02 ~8:54pm local) shows 16 indistinguishable rows accumulated this way.

## Fix

- Store the task text alongside the submission timestamp in `_pendingTasks`. Map value goes from `number` to `{submittedAt: number, task: string}`.
- Timeout title becomes `Timed out: <first 60 chars of task>`.
- Extracted the timeout-check loop out of `startResultWatcher`'s `setInterval` into an exported pure function `_checkPendingTimeouts(now, pending, sendStatus, onResult)` so it's unit-testable without the 2-second timer.

Out of scope (separate PR if wanted): auto-eviction of timed-out rows from the Tasks tab. The 16 stale rows in the screenshot are surviving across sessions because the UI never clears them.

## Test plan

`tests/task-bridge-timeout.test.ts` — 4 cases, all green:

- [x] past-deadline timeout fires with correct shape
- [x] within-deadline does not fire
- [x] **distinct task texts produce distinct titles** (the bug guard — fails red on `main`, passes green here)
- [x] integration via `workTool.execute` → submit-site preserves task text end-to-end into the timeout title (guards against shape regression at the submit site)
- [x] `tsc --noEmit` clean

## Manual verification (still WIP — testing on Maddy)

1. Set `TASK_TIMEOUT_MS = 30 * 1000` in `src/task-bridge.ts:72` (don't commit).
2. Restart voice-agent.
3. `pkill -f watch-tasks-stream` so submitted tasks aren't picked up.
4. Open the web client.
5. Submit 3 distinct voice tasks.
6. Wait 30s — Tasks tab should show 3 distinct `Timed out: <task>` rows. Pre-fix, all three would read identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)