### PR TITLE
chore(deps): bump bodhi-realtime-agent to ffec0cd (reconnect fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@google/genai": "^1.49.0",
         "@types/ws": "^8.18.1",
         "ai": "^6.0.149",
-        "bodhi-realtime-agent": "github:sonichi/bodhi_realtime_agent#ee58489a",
+        "bodhi-realtime-agent": "github:sonichi/bodhi_realtime_agent#ffec0cd",
         "dotenv": "^17.4.1",
         "playwright": "^1.58.2",
         "ws": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@google/genai": "^1.49.0",
     "@types/ws": "^8.18.1",
     "ai": "^6.0.149",
-    "bodhi-realtime-agent": "github:sonichi/bodhi_realtime_agent#ee58489a",
+    "bodhi-realtime-agent": "github:sonichi/bodhi_realtime_agent#ffec0cd",
     "dotenv": "^17.4.1",
     "playwright": "^1.58.2",
     "ws": "^8.20.0",


### PR DESCRIPTION
## Summary
- Picks up bodhi #16 (replay-text wait-silently in BOTH reconnect paths) and #17 (reconnect promise deadline)
- Together these eliminate stuck RECONNECTING after ECONNRESET-during-reconnect (previously required `launchctl kickstart` recovery; observed live 5+ min stuck on 2026-05-01)

## Test plan
- [ ] CI passes
- [ ] After merge: `launchctl kickstart -k gui/$(id -u)/com.sutando.voice-agent` and confirm voice-agent connects with new bodhi version
- [ ] Watch one full Gemini Live session for clean reconnect behavior over the next ~30 min