### PR TITLE
fix(discord-bridge): keep all user @-mentions in task body

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -506,8 +506,12 @@ async def _handle_discord_message(message, force=False):
                 print(f"  [skip] message addressed to other bot(s): {[str(m) for m in explicit_mentions]}", flush=True)
                 return
 
-        # Strip mentions from the text
-        text = text.replace(f"<@{client.user.id}>", "")
+        # Strip role mentions only. User mentions (this bot's and other
+        # bots') are kept verbatim so consumers can see the full addressee
+        # list — stripping own-id used to mislead each bot in a multi-bot
+        # mention into "addressed to the other, not me" deferrals
+        # (incident 2026-05-03: Lucy + Maddy both deferred a `<@Maddy>
+        # <@Lucy>` ping in #dev for 40 min).
         for role in message.role_mentions:
             text = text.replace(f"<@&{role.id}>", "")
         text = text.strip()


### PR DESCRIPTION
## Summary

The bridge was stripping THIS bot's own `<@id>` from the rendered task body before writing to disk. Other bots' `<@id>`s stayed. In a multi-bot ping like `<@Maddy> <@Lucy> can you share X` each bot saw only the *other's* mention in its body and concluded "addressed to them, not me" — so both deferred.

## Caught how

2026-05-03 ~16:19 UTC: Susan posted in #dev:

> `<@1485656249705169031> <@1494435872949665953> can you share your birthday and milestones by searching the log? Don't hallucinate`

(both Maddy and Lucy explicitly mentioned). Each bot received a task file with its own `<@id>` stripped:

```
Lucy's queue: <@1485656249705169031>  can you share...   ← Maddy preserved, Lucy stripped
Maddy's queue: <@1494435872949665953>  can you share...   ← Lucy preserved, Maddy stripped
```

Both bots independently read the surviving foreign `<@id>` as "addressed to the other, not me" and deferred. Susan re-pinged ~17 min later in DM and got responses (DM path bypasses the strip). Total wait: ~40 min before either bot answered.

## Fix

`src/discord-bridge.py:509-510` — drop the `text.replace(f"<@{client.user.id}>", "")` line. Role-mention stripping (`<@&{role.id}>`) preserved. Both bots will now see the full `<@Maddy> <@Lucy>` addressee list in the body.

```diff
-        # Strip mentions from the text
-        text = text.replace(f"<@{client.user.id}>", "")
+        # Strip role mentions only. User mentions (this bot's and other
+        # bots') are kept verbatim so consumers can see the full addressee
+        # list — stripping own-id used to mislead each bot in a multi-bot
+        # mention into "addressed to the other, not me" deferrals
+        # (incident 2026-05-03: Lucy + Maddy both deferred a \`<@Maddy>
+        # <@Lucy>\` ping in #dev for 40 min).
         for role in message.role_mentions:
             text = text.replace(f"<@&{role.id}>", "")
         text = text.strip()
```

## Routing semantics unchanged

Delivery is gated by `message.mentions` membership at the channel level (`requireMention=true`) — see `src/discord-bridge.py:484-495`. The strip happened *after* the routing decision, so removing it doesn't change which bot gets the task. DM path also unchanged (strip ran only in the `not is_dm` branch).

## Test plan

- [x] `python3 -c 'import ast; ast.parse(open("src/discord-bridge.py").read())'` — clean
- [x] Manual diff review (8 lines: -2 +6, the +6 is just the rationale comment)
- [ ] Live verify: next multi-bot #dev ping lands with both `<@id>`s in the body on both consumer sides

## Related memory

I also added `feedback_trust_queue_not_body_for_mention.md` on the consumer side as belt-and-suspenders — even with this PR, future bots should treat "task arrived in my queue from `requireMention=true` channel" as the authoritative "I was mentioned" signal, not body parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)