### PR TITLE
feat(skill): html-animation-render — HTML/SVG → MP4 pipeline

### DIFF
--- a/skills/html-animation-render/SKILL.md
+++ b/skills/html-animation-render/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: html-animation-render
+description: Render an HTML/SVG animation page to an MP4 video, optionally muxing in a soundtrack. For investor demos, social posts, talk videos — anything you've designed in the browser and need as a shareable file.
+---
+
+# HTML Animation Render
+
+Take any self-driving HTML/SVG animation (CSS animations + optional rAF JS) and convert it to an MP4. Playwright records the page in headless Chrome, then ffmpeg muxes in your audio track.
+
+## When to use
+
+- You've built an animation in HTML/SVG (because iterating in the browser is fast) and need an MP4 to attach to email, post on social, drop into a slide deck, or share on Discord.
+- The animation is self-driving — runs from page load with no user interaction needed.
+- You want exact framing — viewBox-based SVG renders pixel-perfect at any output resolution.
+
+## When NOT to use
+
+- Programmatic / pixel-perfect math-driven animation → use `~/.sutando-memory-sync/machine-Chis-Mac-mini/skills/personal-diagram-animation/` (Manim).
+- Photorealistic / generative video → use Veo via `skills/image-generation`.
+- Live screen recording of an interactive session → use `skills/screen-record`.
+
+## Usage
+
+```bash
+node skills/html-animation-render/scripts/render.mjs \
+  --html ~/.sutando-memory-sync/notes/sutando-fleet-growth.html \
+  --out  ~/.sutando-memory-sync/notes/media/sutando-fleet-growth.mp4 \
+  --audio ~/.sutando-memory-sync/notes/media/happy-light-30s.mp3 \
+  --duration 33
+```
+
+Flags:
+- `--html` (required) absolute or relative path to the HTML file.
+- `--out` (required) output `.mp4` path.
+- `--audio` optional MP3 to mux in.
+- `--duration` seconds to record. Set to your animation length + ~1s buffer (default 33).
+- `--width` output width in pixels (default 1920).
+- `--height` output height (default `width / 2.25` to match a 22.5x10 viewBox).
+
+Output goes to stdout (the OUT path). Status messages to stderr.
+
+## Authoring tips for the source HTML
+
+- Drive everything from page load — no user gesture needed for the recording (audio CAN stay autoplay-blocked in headless; ffmpeg supplies the audio track separately).
+- Match the page's aspect to your output resolution. `viewBox="-11.25 -4.5 22.5 10"` (2.25:1) matches the default 1920x853.
+- Verify the layout BEFORE you render — see `feedback_self_render_layout_fixes.md` (in memory). Run `node src/browser.mjs <url> "wait:<ms>" screenshot` first to confirm no overlaps at peak event windows.
+
+## Dependencies
+
+- `playwright` (project node_modules — Sutando has it).
+- System Chrome (Playwright `channel: 'chrome'`).
+- Playwright's bundled ffmpeg: `npx playwright install ffmpeg` (one-time, ~1MB).
+- `ffmpeg` in PATH (Homebrew: `brew install ffmpeg`).
+
+## Worked example: Sutando fleet growth animation
+
+`scripts/sample-sutando-fleet.sh` runs the renderer with the live fleet-growth page and the canonical happy-light-30s soundtrack. Output: 1920x852, 33s, ~2.1MB MP4. Re-run after every HTML edit.

--- a/skills/html-animation-render/scripts/render.mjs
+++ b/skills/html-animation-render/scripts/render.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Render an HTML/SVG animation page to an MP4 video, optionally muxing in audio.
+//
+// Usage:
+//   node render.mjs --html path/to/page.html --out path/to/out.mp4 \
+//                   [--audio path/to/track.mp3] [--duration 33] \
+//                   [--width 1920] [--height 853]
+//
+// Pipeline:
+//   1. Playwright headless Chrome records the page (silent webm).
+//   2. ffmpeg muxes the audio in (or copies the silent video) → mp4.
+//
+// The page must drive its own animation on load (CSS animations or rAF).
+// The duration you pass is just how long Playwright records — set it to
+// the page's full animation length plus a small buffer.
+//
+// Requires: playwright (project dep), system Chrome, ffmpeg in PATH,
+// playwright's bundled ffmpeg (run `npx playwright install ffmpeg` once).
+
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+import { spawnSync, execSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+  options: {
+    html: { type: 'string' },
+    out: { type: 'string' },
+    audio: { type: 'string' },
+    duration: { type: 'string', default: '33' },
+    width: { type: 'string', default: '1920' },
+    height: { type: 'string' },
+  },
+});
+
+if (!values.html || !values.out) {
+  console.error('Usage: render.mjs --html <input.html> --out <output.mp4> [--audio <track.mp3>] [--duration 33] [--width 1920] [--height ...]');
+  process.exit(1);
+}
+
+const HTML = values.html.startsWith('file://') ? values.html : `file://${resolve(values.html)}`;
+const OUT = resolve(values.out);
+const AUDIO = values.audio ? resolve(values.audio) : null;
+const DURATION_S = Number(values.duration);
+const WIDTH = Number(values.width);
+const HEIGHT = values.height ? Number(values.height) : Math.round(WIDTH / 2.25);
+const TMP_DIR = `/tmp/html-animation-render-${Date.now()}`;
+
+mkdirSync(TMP_DIR, { recursive: true });
+
+console.error(`Recording ${WIDTH}x${HEIGHT} for ${DURATION_S}s ...`);
+
+const browser = await chromium.launch({ channel: 'chrome', headless: true });
+const context = await browser.newContext({
+  viewport: { width: WIDTH, height: HEIGHT },
+  recordVideo: { dir: TMP_DIR, size: { width: WIDTH, height: HEIGHT } },
+});
+const page = await context.newPage();
+await page.goto(HTML, { waitUntil: 'domcontentloaded' });
+await page.waitForTimeout(DURATION_S * 1000);
+await page.close();
+await context.close();
+await browser.close();
+
+const webm = execSync(`ls -t ${TMP_DIR}/*.webm | head -1`).toString().trim();
+if (!webm) { console.error('No webm produced'); process.exit(1); }
+console.error(`Recorded: ${webm}`);
+
+const ffmpegArgs = ['-y', '-loglevel', 'error', '-i', webm];
+if (AUDIO) ffmpegArgs.push('-i', AUDIO, '-map', '0:v', '-map', '1:a');
+ffmpegArgs.push(
+  '-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-crf', '20',
+);
+if (AUDIO) ffmpegArgs.push('-c:a', 'aac', '-b:a', '192k');
+ffmpegArgs.push('-t', String(DURATION_S), OUT);
+
+const ff = spawnSync('ffmpeg', ffmpegArgs, { stdio: 'inherit' });
+if (ff.status !== 0) { console.error('ffmpeg failed'); process.exit(ff.status); }
+console.log(OUT);

--- a/skills/html-animation-render/scripts/sample-sutando-fleet.sh
+++ b/skills/html-animation-render/scripts/sample-sutando-fleet.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Render the Sutando fleet-growth animation. Convenience wrapper around render.mjs.
+# Run from anywhere — paths are absolute.
+set -euo pipefail
+
+cd "$HOME/Desktop/sutando"
+node skills/html-animation-render/scripts/render.mjs \
+  --html "$HOME/.sutando-memory-sync/notes/sutando-fleet-growth.html" \
+  --out  "$HOME/.sutando-memory-sync/notes/media/sutando-fleet-growth.mp4" \
+  --audio "$HOME/.sutando-memory-sync/notes/media/happy-light-30s.mp3" \
+  --duration 33


### PR DESCRIPTION
## Summary
- New skill at `skills/html-animation-render/` extracts the ad-hoc fleet-growth render code into a reusable CLI.
- Pipeline: Playwright headless Chrome records the page → ffmpeg muxes optional audio → MP4.
- Replaces ad-hoc src/render-fleet-growth.mjs (removed in a separate change); canonical fleet-growth render now runs via skills/html-animation-render/scripts/sample-sutando-fleet.sh.

## Scope
- Generic — html, out, audio, duration, width, height flags, no Sutando-specific logic.
- Distinct from personal-diagram-animation/ (Manim, Mini-side, math-driven). This one is for HTML/SVG/CSS animations where iteration happens in the browser.

## Test plan
- [x] Smoke test: sample-sutando-fleet.sh produces the expected mp4 (1920x852, 33s, ~2.1MB) — verified end-to-end before raising this PR.
- [ ] Re-run after a HTML edit to confirm idempotent output.
- [ ] Try with a different HTML page to verify the CLI generalizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)