### PR TITLE
fix(task-bridge): unify timeout archive path → tasks/archive/<YYYY-MM>/

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -456,14 +456,12 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 				// Move the task file out of tasks/ so /tasks/active stops listing it
 				// as 'working' forever. (Without this, dedup-orphan tasks left behind
 				// after a consolidated reply pile up in the UI as stuck spinners.)
+				// Use archiveFile() — same destination (tasks/archive/<YYYY-MM>/) as
+				// the result-delivery archival paths so all timeout/done/dedupe lands
+				// in one place. (Mini's #589 review flagged the previous
+				// tasks/processed/ split as a learn-collector scan footprint.)
 				if (existsSync(taskFile)) {
-					try {
-						const processedDir = join(TASK_DIR, 'processed');
-						mkdirSync(processedDir, { recursive: true });
-						renameSync(taskFile, join(processedDir, `${taskId}.txt`));
-					} catch (e) {
-						console.error(`${ts()} [TaskBridge] Failed to archive timed-out task ${taskId}:`, e);
-					}
+					archiveFile(taskFile, 'tasks', taskId);
 				}
 				// Discord DM fallback (opt-in via dm_on_timeout). Default off per
 				// Susan's PR #578 contract — silent timeout. We emit by writing


### PR DESCRIPTION
## Summary

Mini flagged on the #589 cold review: the timeout path moved task files to `tasks/processed/` while every other "task is done" path uses `archiveFile()` → `tasks/archive/<YYYY-MM>/`. Two destinations means the learn-collector / summarizer would have to scan both.

Replaced the inline `mkdir + renameSync` with a single `archiveFile()` call. Same shape as the result-delivery + deduped + voice-offline paths.

`_isVoiceTask()` already checks both `processed/` AND `archive/` when looking up source channel, so no breakage for tasks already in `processed/` from before this PR.

## Test plan

- [ ] Submit a task without writing a result; wait `timeout_minutes` (default 10m); confirm task file lands in `tasks/archive/<YYYY-MM>/<id>.txt` instead of `tasks/processed/<id>.txt`.
- [ ] Confirm UI clears the task at timeout (no stuck spinner).
- [ ] Existing tasks in `tasks/processed/` (legacy) — `_isVoiceTask` still resolves them; no functional regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)