### PR TITLE
feat(skills): manifest-driven discovery of core-documented skills

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -816,6 +816,48 @@ async function loadSkillManifestTools(): Promise<ToolDefinition[]> {
 }
 const personalTools = await loadSkillManifestTools();
 
+// Manifest-driven discovery of skills that core (not voice-inline) runs.
+// When a manifest has `documented_for_core: true` and a `core_description`,
+// the description is exposed to voice-agent's system-prompt assembly so
+// Gemini knows the capability exists and to delegate via `work` instead
+// of saying "I can't do that". The skill itself is NOT loaded inline — it
+// stays as docs+scripts and the core agent runs it when the work-task
+// arrives. Same scan-paths as loadSkillManifestTools.
+function loadCoreDocumentedSkills(): { name: string; description: string }[] {
+	const dirsToScan: string[] = [join(process.cwd(), 'skills')];
+	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+	if (privateRoot) {
+		const expanded = privateRoot.replace(/^~/, process.env.HOME || '');
+		dirsToScan.push(join(expanded, 'skills'));
+	}
+	const out: { name: string; description: string }[] = [];
+	const seen = new Set<string>();
+	for (const skillsDir of dirsToScan) {
+		if (!existsSync(skillsDir)) continue;
+		let dirs: string[];
+		try {
+			dirs = readdirSync(skillsDir).filter(n => {
+				try { return statSync(join(skillsDir, n)).isDirectory(); } catch { return false; }
+			});
+		} catch { continue; }
+		for (const dirName of dirs) {
+			const manifestPath = join(skillsDir, dirName, 'manifest.json');
+			if (!existsSync(manifestPath)) continue;
+			let manifest: { documented_for_core?: boolean; core_description?: string; name?: string };
+			try {
+				manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+			} catch { continue; }
+			if (!manifest.documented_for_core || !manifest.core_description) continue;
+			const name = manifest.name || dirName;
+			if (seen.has(name)) continue;
+			seen.add(name);
+			out.push({ name, description: manifest.core_description });
+		}
+	}
+	return out;
+}
+export const coreDocumentedSkills = loadCoreDocumentedSkills();
+
 export const inlineTools = assertUniqueToolNames([
 	pressKeyTool, scrollTool, switchTabTool, closeTabTool, openUrlTool,
 	switchAppTool, captureScreenTool, typeTextTool,

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -823,6 +823,12 @@ const personalTools = await loadSkillManifestTools();
 // of saying "I can't do that". The skill itself is NOT loaded inline — it
 // stays as docs+scripts and the core agent runs it when the work-task
 // arrives. Same scan-paths as loadSkillManifestTools.
+//
+// SYNC vs ASYNC NOTE (Mini's #592 review): this helper is sync because
+// we never need to import any module — we just read manifest.json files.
+// loadSkillManifestTools is async because it dynamically `await import()`s
+// a tools.ts. Don't try to align them — they're correctly sync/async for
+// what each one does.
 function loadCoreDocumentedSkills(): { name: string; description: string }[] {
 	const dirsToScan: string[] = [join(process.cwd(), 'skills')];
 	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
@@ -830,8 +836,9 @@ function loadCoreDocumentedSkills(): { name: string; description: string }[] {
 		const expanded = privateRoot.replace(/^~/, process.env.HOME || '');
 		dirsToScan.push(join(expanded, 'skills'));
 	}
-	const out: { name: string; description: string }[] = [];
-	const seen = new Set<string>();
+	// Last-write-wins map so private (later in dirsToScan) overrides public —
+	// same precedence convention as loadSkillManifestTools above.
+	const byName = new Map<string, { name: string; description: string }>();
 	for (const skillsDir of dirsToScan) {
 		if (!existsSync(skillsDir)) continue;
 		let dirs: string[];
@@ -843,18 +850,21 @@ function loadCoreDocumentedSkills(): { name: string; description: string }[] {
 		for (const dirName of dirs) {
 			const manifestPath = join(skillsDir, dirName, 'manifest.json');
 			if (!existsSync(manifestPath)) continue;
-			let manifest: { documented_for_core?: boolean; core_description?: string; name?: string };
+			let manifest: { documented_for_core?: boolean; core_description?: string; name?: string; tools?: string };
 			try {
 				manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
 			} catch { continue; }
 			if (!manifest.documented_for_core || !manifest.core_description) continue;
+			// Dedup against inline-loaded skills: if the manifest also exposes
+			// a `tools:` entry, the skill is already inline-listed and
+			// double-listing here would teach Gemini both "call this inline"
+			// AND "delegate via work" simultaneously. Pick the inline path.
+			if (manifest.tools) continue;
 			const name = manifest.name || dirName;
-			if (seen.has(name)) continue;
-			seen.add(name);
-			out.push({ name, description: manifest.core_description });
+			byName.set(name, { name, description: manifest.core_description });
 		}
 	}
-	return out;
+	return Array.from(byName.values());
 }
 export const coreDocumentedSkills = loadCoreDocumentedSkills();
 

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -26,7 +26,7 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { z } from 'zod';
 import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, mkdirSync, appendFileSync, writeFileSync } from 'node:fs';
 import { execSync as execSyncTop } from 'node:child_process';
-import { inlineTools } from './inline-tools.js';
+import { inlineTools, coreDocumentedSkills } from './inline-tools.js';
 import { injectText } from './browser-tools.js';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
@@ -595,6 +595,11 @@ const mainAgent: MainAgent = {
 		'- save_meeting_note: Save meeting observations to notes/meeting-{date}.md. Call every 5-10 min in meeting mode. Use type "summary" when exiting meeting mode.',
 		'- For phone calls, meeting dial-in, or anything needing contacts/calendar context → use work (core handles it).',
 		...inlineTools.map(t => `- ${t.name}: ${(t.description as string).split('.')[0]}. Instant.`),
+		...(coreDocumentedSkills.length > 0 ? [
+			'',
+			'DELEGATABLE SKILLS (call via work — core runs these, not voice-inline):',
+			...coreDocumentedSkills.map(s => `- ${s.name}: ${s.description}`),
+		] : []),
 		'',
 		'CRITICAL RULES:',
 		(() => meetingActive

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -599,6 +599,7 @@ const mainAgent: MainAgent = {
 			'',
 			'DELEGATABLE SKILLS (call via work — core runs these, not voice-inline):',
 			...coreDocumentedSkills.map(s => `- ${s.name}: ${s.description}`),
+			'IMPORTANT: these are NOT inline tools you can call directly. When the user requests one, call work({task: "<verbatim user request>"}) — core picks up the skill and runs it. Do NOT attempt to call <skill-name> as if it were an inline tool; that will fail.',
 		] : []),
 		'',
 		'CRITICAL RULES:',


### PR DESCRIPTION
## Summary

Voice agent didn't know about skills that core runs (not inline), so it rejected requests like 'preview my post' as unsupported. This adds two manifest fields:

- `documented_for_core: true` — flag a skill as 'advertise to voice-agent'
- `core_description: string` — one-line capability blurb shown to Gemini

When set, the skill's description appears in voice-agent's system prompt under a new 'DELEGATABLE SKILLS (call via work — core runs these, not voice-inline)' section. Voice learns the capability exists; calls go through `work` as normal — no inline-blocking.

## Test plan

- [ ] After merge + voice-agent kickstart, voice says 'preview my post' → calls `work` (not 'I can't do that')
- [ ] Adding `documented_for_core: true` + `core_description` to any new skill makes it visible to voice on next restart
- [ ] No regression on existing inline-tool loading (manifests with `enabled: true` + `tools: ./tools.ts` still load tools as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)