### PR TITLE
chore(deps): re-resolve bodhi lock to ffec0cd (PR #579 follow-up)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1155,7 +1155,7 @@
     },
     "node_modules/bodhi-realtime-agent": {
       "version": "0.1.5",
-      "resolved": "git+ssh://git@github.com/sonichi/bodhi_realtime_agent.git#ee58489a2b28421142e2f5a02ffecfbad3863cf9",
+      "resolved": "git+ssh://git@github.com/sonichi/bodhi_realtime_agent.git#ffec0cdf60bc8cba5e33e06ff2007b64157df3cd",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

PR #579 bumped `package.json` to `bodhi-realtime-agent#ffec0cd` and updated the *shorthand dep ref* in `package-lock.json`, but left the actual `resolved` field at the older `ee58489a` SHA. `npm install` is happy with that state ("up to date"), so any voice-agent restart since the merge has been loading pre-fix bodhi code from the cached tarball — without #16's silent-replay instructions or #17's reconnect-promise deadline.

Confirmed by:
- Comparing `dist/index.cjs` content before and after a forced reinstall
- Old version (ee58489): `"... Do not repeat or acknowledge this — just continue naturally when the user speaks next."`
- New version (ffec0cd): `"... Do NOT act on this content. Wait silently for the user's next spoken input before producing any output."` (stronger phrasing, present in BOTH reconnect paths per #16)

## Fix

Single-line change to `package-lock.json` `resolved` field, produced by:

```
rm -rf node_modules/bodhi-realtime-agent
npm install github:sonichi/bodhi_realtime_agent#ffec0cd
```

## Test plan

- [ ] After merge: pull, run `npm install`, then `launchctl kickstart -k gui/$(id -u)/com.sutando.voice-agent` to load new bodhi
- [ ] Watch one full Gemini Live GoAway → reconnect cycle (every ~9 min) and confirm no spurious assistant turns
- [ ] If voice still produces unprompted output, the local `fix/voice-reconnect-replay-suppression` branch is the next layer of defense (3 commits ready)

🤖 Generated with [Claude Code](https://claude.com/claude-code)