### PR TITLE
fix(inline-tools): close shell injection in type_text, press_key, and clipboard

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -145,8 +145,10 @@ export const pressKeyTool: ToolDefinition = {
 		if (keyCode === undefined) {
 			// Use keystroke for unknown keys
 			const modStr = modifiers.length ? ` using {${modifiers.map(m => m + ' down').join(', ')}}` : '';
+			// Escape single quotes for shell context (same pattern as switchAppTool).
+			const safeKey = key.replace(/\\/g, '\\\\').replace(/'/g, "'\\''").replace(/"/g, '\\"');
 			try {
-				execSync(`osascript -e 'tell application "System Events" to keystroke "${key}"${modStr}'`, { timeout: 3_000 });
+				execSync(`osascript -e 'tell application "System Events" to keystroke "${safeKey}"${modStr}'`, { timeout: 3_000 });
 			} catch (err) {
 				return { error: `press_key failed: ${err instanceof Error ? err.message : err}` };
 			}
@@ -279,7 +281,10 @@ export const typeTextTool: ToolDefinition = {
 			}
 		}
 		// Single-line short text: use keystroke
-		const safeText = text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+		// Escape backslash for AppleScript, single-quote for shell, double-quote for AppleScript.
+		// Same three-step chain as switchAppTool — missing single-quote escape allowed
+		// shell breakout via text containing apostrophes.
+		const safeText = text.replace(/\\/g, '\\\\').replace(/'/g, "'\\''").replace(/"/g, '\\"');
 		try {
 			execSync(`osascript -e 'tell application "System Events" to keystroke "${safeText}"'`, { timeout: 5_000 });
 			console.log(`${ts()} [TypeText] typed: ${text.slice(0, 40)}`);
@@ -377,7 +382,13 @@ export const clipboardTool: ToolDefinition = {
 				return { status: 'read', content };
 			} else {
 				if (!text) return { error: 'No text provided to write' };
-				execSync(`echo ${JSON.stringify(text)} | pbcopy`, { timeout: 5_000 });
+				// Write to temp file then pipe to pbcopy — avoids shell injection via
+				// echo "$(cmd)" since JSON.stringify wraps in double-quotes which don't
+				// prevent $() substitution in bash.
+				const tmpPb = `/tmp/sutando-clipboard-${Date.now()}.txt`;
+				writeFileSync(tmpPb, text);
+				execSync(`pbcopy < "${tmpPb}"`, { timeout: 5_000 });
+				try { unlinkSync(tmpPb); } catch {}
 				console.log(`${ts()} [Clipboard] wrote: ${text.slice(0, 40)}`);
 				return { status: 'written', text };
 			}


### PR DESCRIPTION
Three shell injection vectors in `osascript`/`execSync` calls, all in `src/inline-tools.ts`.

## 1. `type_text` — single-quote breakout

`safeText` escapes `\` and `"` but not `'`. The shell command is:

```bash
osascript -e 'tell application "System Events" to keystroke "TEXT"'
```

Text containing a single quote closes the shell's single-quoted argument, allowing arbitrary command execution. The `switchAppTool` on line 200 already does the correct three-step escaping (backslash, single-quote, double-quote) — `type_text` and `press_key` were missing the single-quote step.

**Fix:** Add `.replace(/'/g, "'\\''")` to match `switchAppTool`'s escaping chain.

## 2. `press_key` — same single-quote breakout

Unknown keys (those not in `keyMap`) fall through to a `keystroke "${key}"` branch with no single-quote escaping.

**Fix:** Same three-step chain as `switchAppTool`.

## 3. `clipboard` write — `$()` substitution in double quotes

```js
execSync(`echo ${JSON.stringify(text)} | pbcopy`)
```

`JSON.stringify` wraps text in double-quotes, but bash executes `$(cmd)` inside double-quotes. Text like `$(whoami)` gets command-substituted before `pbcopy` receives it.

**Fix:** Write to a temp file and pipe to `pbcopy` via `< file`, eliminating shell interpolation.

---

All three fixes follow existing patterns in the codebase (`switchAppTool`'s escaping chain, `type_text`'s own clipboard-paste path). ~14 lines changed.