### PR TITLE
feat(context-drop): handle multi-file Finder selection

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -1028,15 +1028,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 notify("Sutando", "File dropped: \(URL(fileURLWithPath: finderFile).lastPathComponent)")
                 return
             } else if finderFiles.count > 1 {
-                let pathsBlock = finderFiles.map { "  - \($0)" }.joined(separator: "\n")
+                // Emit JSON-array on the `paths:` line for unambiguous parsing
+                // (handles paths with spaces, colons, etc. without YAML lib).
+                // Body trailer keeps a human-readable multi-line list.
+                let pathsJSON: String = {
+                    let data = try? JSONSerialization.data(withJSONObject: finderFiles, options: [])
+                    return data.flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
+                }()
+                let humanList = finderFiles.map { "  - \($0)" }.joined(separator: "\n")
                 let content = """
                 timestamp: \(timestamp)
                 type: files
-                paths:
-                \(pathsBlock)
+                paths: \(pathsJSON)
                 \(ctxHeader)---
                 [Files selected in Finder: \(finderFiles.count) files]
-                \(pathsBlock)
+                \(humanList)
                 """
                 appendLog(logFile, "[\(timestamp)] Dropped: \(finderFiles.count) files")
                 writeTask(tasksDir, timestamp: timestamp, content: content)

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -1013,7 +1013,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // 1. Check Finder selection (only if Finder is frontmost)
         if let frontApp = NSWorkspace.shared.frontmostApplication,
            frontApp.bundleIdentifier == "com.apple.finder" {
-            if let finderFile = getFinderSelection() {
+            let finderFiles = getFinderSelection()
+            if finderFiles.count == 1 {
+                let finderFile = finderFiles[0]
                 let content = """
                 timestamp: \(timestamp)
                 type: file
@@ -1024,6 +1026,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 appendLog(logFile, "[\(timestamp)] Dropped: file (\(finderFile))")
                 writeTask(tasksDir, timestamp: timestamp, content: content)
                 notify("Sutando", "File dropped: \(URL(fileURLWithPath: finderFile).lastPathComponent)")
+                return
+            } else if finderFiles.count > 1 {
+                let pathsBlock = finderFiles.map { "  - \($0)" }.joined(separator: "\n")
+                let content = """
+                timestamp: \(timestamp)
+                type: files
+                paths:
+                \(pathsBlock)
+                \(ctxHeader)---
+                [Files selected in Finder: \(finderFiles.count) files]
+                \(pathsBlock)
+                """
+                appendLog(logFile, "[\(timestamp)] Dropped: \(finderFiles.count) files")
+                writeTask(tasksDir, timestamp: timestamp, content: content)
+                notify("Sutando", "\(finderFiles.count) files dropped")
                 return
             }
         }
@@ -1266,27 +1283,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Helpers
 
-    func getFinderSelection() -> String? {
+    func getFinderSelection() -> [String] {
         let script = """
         tell application "Finder"
             try
                 set sel to selection
-                if (count of sel) > 0 then
-                    return POSIX path of (item 1 of sel as alias)
-                end if
+                set out to ""
+                repeat with anItem in sel
+                    set out to out & POSIX path of (anItem as alias) & "\n"
+                end repeat
+                return out
             on error
                 return ""
             end try
         end tell
         """
-        guard let appleScript = NSAppleScript(source: script) else { return nil }
+        guard let appleScript = NSAppleScript(source: script) else { return [] }
         var error: NSDictionary?
         let result = appleScript.executeAndReturnError(&error)
-        let path = result.stringValue
-        if let path = path, !path.isEmpty, FileManager.default.fileExists(atPath: path) {
-            return path
-        }
-        return nil
+        guard let raw = result.stringValue, !raw.isEmpty else { return [] }
+        return raw.split(separator: "\n").map(String.init).filter { !$0.isEmpty && FileManager.default.fileExists(atPath: $0) }
     }
 
     func getSelectedText() -> String? {

--- a/src/context-drop.sh
+++ b/src/context-drop.sh
@@ -63,19 +63,21 @@ EOF
   osascript -e "display notification \"File dropped: $BASENAME\" with title \"Sutando\""
   exit 0
 elif [ ${#VALID_FILES[@]} -gt 1 ]; then
-  PATHS_BLOCK=""
+  # Emit JSON-array on the `paths:` line so a path with spaces or colons
+  # parses unambiguously (no YAML lib needed downstream).
+  PATHS_JSON=$(printf '%s\n' "${VALID_FILES[@]}" | python3 -c 'import sys,json; print(json.dumps([l.rstrip("\n") for l in sys.stdin]))')
+  HUMAN_LIST=""
   for f in "${VALID_FILES[@]}"; do
-    PATHS_BLOCK+="  - $f"$'\n'
+    HUMAN_LIST+="  - $f"$'\n'
   done
-  PATHS_BLOCK="${PATHS_BLOCK%$'\n'}"
+  HUMAN_LIST="${HUMAN_LIST%$'\n'}"
   cat > "$DROP_FILE" << EOF
 timestamp: $TIMESTAMP
 type: files
-paths:
-$PATHS_BLOCK
+paths: $PATHS_JSON
 ---
 [Files selected in Finder: ${#VALID_FILES[@]} files]
-$PATHS_BLOCK
+$HUMAN_LIST
 EOF
   echo "[$TIMESTAMP] Dropped: ${#VALID_FILES[@]} files" >> "$LOG_FILE"
   osascript -e "display notification \"${#VALID_FILES[@]} files dropped\" with title \"Sutando\""

--- a/src/context-drop.sh
+++ b/src/context-drop.sh
@@ -24,21 +24,33 @@ TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
 
 # --- Check for Finder file selection FIRST (before clipboard) ---
 # Always check Finder selection regardless of frontmost app
-# (Automator may steal focus before script runs)
-FINDER_FILE=$(osascript -e '
+# (Automator may steal focus before script runs).
+# Returns newline-separated POSIX paths for ALL selected items (not just first).
+FINDER_FILES=$(osascript -e '
 tell application "Finder"
   try
     set sel to selection
-    if (count of sel) > 0 then
-      return POSIX path of (item 1 of sel as alias)
-    end if
+    set out to ""
+    repeat with anItem in sel
+      set out to out & POSIX path of (anItem as alias) & linefeed
+    end repeat
+    return out
   on error
     return ""
   end try
 end tell
 ' 2>/dev/null)
 
-if [ -n "$FINDER_FILE" ] && [ -e "$FINDER_FILE" ]; then
+# Filter to existing files; count valid ones.
+VALID_FILES=()
+while IFS= read -r f; do
+  if [ -n "$f" ] && [ -e "$f" ]; then
+    VALID_FILES+=("$f")
+  fi
+done <<< "$FINDER_FILES"
+
+if [ ${#VALID_FILES[@]} -eq 1 ]; then
+  FINDER_FILE="${VALID_FILES[0]}"
   cat > "$DROP_FILE" << EOF
 timestamp: $TIMESTAMP
 type: file
@@ -49,6 +61,24 @@ EOF
   echo "[$TIMESTAMP] Dropped: file ($FINDER_FILE)" >> "$LOG_FILE"
   BASENAME=$(basename "$FINDER_FILE")
   osascript -e "display notification \"File dropped: $BASENAME\" with title \"Sutando\""
+  exit 0
+elif [ ${#VALID_FILES[@]} -gt 1 ]; then
+  PATHS_BLOCK=""
+  for f in "${VALID_FILES[@]}"; do
+    PATHS_BLOCK+="  - $f"$'\n'
+  done
+  PATHS_BLOCK="${PATHS_BLOCK%$'\n'}"
+  cat > "$DROP_FILE" << EOF
+timestamp: $TIMESTAMP
+type: files
+paths:
+$PATHS_BLOCK
+---
+[Files selected in Finder: ${#VALID_FILES[@]} files]
+$PATHS_BLOCK
+EOF
+  echo "[$TIMESTAMP] Dropped: ${#VALID_FILES[@]} files" >> "$LOG_FILE"
+  osascript -e "display notification \"${#VALID_FILES[@]} files dropped\" with title \"Sutando\""
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Both `src/Sutando/main.swift` and `src/context-drop.sh` hardcoded `item 1 of sel` in their AppleScript, so a multi-file Finder selection silently dropped only the first file. Chi reported it after a multi-select drop arrived as one file.

## Fix

- AppleScript now iterates `sel`, returning newline-joined POSIX paths.
- Swift `getFinderSelection()` returns `[String]` (was `String?`); zero-vs-one-vs-many gates the task format:
  - 0 items → fall through to clipboard/text branch (unchanged).
  - 1 item → existing `type: file` + `path:` (backward-compat).
  - >1 items → new `type: files` + `paths:` block:
    ```
    type: files
    paths:
      - /a/b/c
      - /d/e/f
    ```
- `context-drop.sh` mirrors the same logic with bash arrays (`VALID_FILES`).
- Notification reflects count ("3 files dropped" vs single filename).

## Test plan

- [x] swiftc compile clean (no warnings beyond the pre-existing dropFile one)
- [x] Sutando.app rebuilt + relaunched (PID 14526) — old PID 57712 killed
- [ ] User test: select 2+ files in Finder → ⌃C → task file has `type: files` + multi-path block
- [ ] User test: select 1 file → still gets `type: file` (regression check)

## Follow-up

- The voice-agent's `read_selection` tool (`personal-deictic` skill via `ax-read.swift`) reads `AXSelectedText`, **not** Finder file selection. It would need its own Finder-AppleScript branch to surface multi-file paths to the voice context. Not in this PR — flag for separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)