### PR TITLE
fix(health-check): catch dead bridge log paths + dead inodes

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -652,9 +652,15 @@ def run_all_checks() -> list[dict]:
             checks.append({"name": name, "status": "warn", "detail": f"multiple processes ({len(pids)} PIDs: {','.join(pids)})"})
             continue
 
-        # Check 2: Log file freshness
+        # Check 2: Log file freshness — prefer logs/ (where startup.sh writes)
+        # and fall back to src/ for legacy. The src/ default was silently a
+        # no-op since 2026-04 when startup.sh was changed to write logs/<name>.log,
+        # so log-stale warnings never fired (caught 2026-05-05 when Mini's
+        # logs/discord-bridge.log was 36h stale but health-check stayed "ok").
         import time
-        log_file = REPO_DIR / "src" / f"{name}.log"
+        log_file = REPO_DIR / "logs" / f"{name}.log"
+        if not log_file.exists():
+            log_file = REPO_DIR / "src" / f"{name}.log"
         detail = "running"
         status = "ok"
         if log_file.exists():
@@ -704,6 +710,32 @@ def run_all_checks() -> list[dict]:
                             status = "stale"
                             detail = f"running but code is {int((src_mtime - proc_start) / 60)} min newer than process — restart needed"
         except (subprocess.TimeoutExpired, ValueError, OSError):
+            pass
+
+        # Check 5: Dead-log-inode detection — last so heartbeat doesn't override.
+        # Bridge process FDs point to a path that's been renamed/deleted (the
+        # 2026-05-05 case where discord-bridge stdout was going to
+        # /discord-bridge.log.bak after the file was unlinked, so logging
+        # silently went to /dev/null while bridge appeared healthy). Heartbeats
+        # don't catch this because they're written to a separate file via
+        # state/<name>.heartbeat.
+        try:
+            lsof_out = subprocess.run(
+                ["lsof", "-p", pids[0]], capture_output=True, text=True, timeout=5
+            ).stdout
+            for line in lsof_out.splitlines():
+                parts = line.split()
+                # Columns: COMMAND PID USER FD TYPE DEVICE SIZE NODE NAME
+                # FD column is index 3 — "1w" or "2w" carry log writes
+                if len(parts) < 9 or parts[3] not in ("1w", "2w"):
+                    continue
+                log_path = parts[-1]
+                if log_path.endswith(".log") or log_path.endswith(".log.bak"):
+                    if not Path(log_path).exists():
+                        status = "warn"
+                        detail = f"running but log inode dead ({log_path} unlinked) — restart for clean logging"
+                        break
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             pass
 
         checks.append({"name": name, "status": status, "detail": detail})

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -729,11 +729,17 @@ def run_all_checks() -> list[dict]:
                 # FD column is index 3 — "1w" or "2w" carry log writes
                 if len(parts) < 9 or parts[3] not in ("1w", "2w"):
                     continue
-                log_path = parts[-1]
+                # NAME starts at col 8 — join remaining tokens to handle paths
+                # with spaces (per MacBook's PR #596 review nit).
+                log_path = " ".join(parts[8:])
                 if log_path.endswith(".log") or log_path.endswith(".log.bak"):
                     if not Path(log_path).exists():
                         status = "warn"
-                        detail = f"running but log inode dead ({log_path} unlinked) — restart for clean logging"
+                        detail = (
+                            f"running but log inode dead ({log_path} unlinked) — "
+                            f"restart with: launchctl kickstart -k gui/$(id -u)/com.sutando.{name} "
+                            "(or nohup+disown on Mini)"
+                        )
                         break
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             pass


### PR DESCRIPTION
## Summary
- **Log path bug**: staleness check used `src/<name>.log` but startup.sh writes to `logs/<name>.log` (changed ~2026-04). The check has been a silent no-op for ~6 weeks — caught 2026-05-05 when Mini's `logs/discord-bridge.log` was 36h stale but health-check stayed \`ok\`.
- **Dead-inode detection (new Check 5)**: bridge process FDs can outlive the file they were originally pointed at. On Mini today, discord-bridge's stdout/stderr were targeting `/discord-bridge.log.bak` — a file that had been unlinked, so all logging silently went to /dev/null while heartbeat + log mtime stayed fresh. Now health-check uses `lsof` to see where FDs 1+2 actually point, and if the path doesn't exist on disk, flags warn with restart guidance.

## Verification

Before:
\`\`\`
✓ discord-bridge  ok  running
\`\`\`

After:
\`\`\`
⚠ discord-bridge  warn  running but log inode dead (/discord-bridge.log.bak unlinked) — restart for clean logging
\`\`\`

## Why placement matters

Check 5 runs AFTER the heartbeat check so a fresh heartbeat (which is written to `state/<name>.heartbeat`, not the bridge's stdout) doesn't silently override the dead-inode condition.

## Test plan
- [x] Manual smoke-test on Mini — flagged the live dead-inode case
- [ ] Verify on MacBook bridge (logs intact) shows no false positive
- [ ] Optional: induce dead inode on a test process and confirm flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)