### PR TITLE
fix(self-diagnose): export SUTANDO_ROOT + smarter REPO walk

### DIFF
--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -7,7 +7,20 @@
 set -euo pipefail
 
 WINDOW="${1:-24h}"
-REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+# REPO resolution: prefer SUTANDO_ROOT env, then $PWD if it looks like a
+# Sutando workspace (has build_log.md), else fall back to script-relative
+# dirname-walk. The dirname-walk fails when the skill is invoked via its
+# userSettings hardlink at ~/.claude/skills/... — $0 resolves there and
+# walking up 3 lands at ~/.claude/ instead of the workspace root. Caught
+# 2026-05-05 when /self-diagnose silently ran against ~/.claude/ on Mini,
+# producing empty git-log/build_log/health.txt.
+if [ -n "${SUTANDO_ROOT:-}" ] && [ -f "${SUTANDO_ROOT}/build_log.md" ]; then
+	REPO="$SUTANDO_ROOT"
+elif [ -f "$PWD/build_log.md" ]; then
+	REPO="$PWD"
+else
+	REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+fi
 TS="$(date +%s)"
 OUT="/tmp/sutando-diagnose-$TS"
 mkdir -p "$OUT"

--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -8,18 +8,30 @@ set -euo pipefail
 
 WINDOW="${1:-24h}"
 # REPO resolution: prefer SUTANDO_ROOT env, then $PWD if it looks like a
-# Sutando workspace (has build_log.md), else fall back to script-relative
-# dirname-walk. The dirname-walk fails when the skill is invoked via its
-# userSettings hardlink at ~/.claude/skills/... — $0 resolves there and
-# walking up 3 lands at ~/.claude/ instead of the workspace root. Caught
-# 2026-05-05 when /self-diagnose silently ran against ~/.claude/ on Mini,
-# producing empty git-log/build_log/health.txt.
+# Sutando workspace (has build_log.md), else walk up from $0 looking for
+# build_log.md (handles invocation via the userSettings hardlink at
+# ~/.claude/skills/... where the original 3-level dirname-walk landed at
+# ~/.claude/ instead of the workspace). Caught 2026-05-05 when /self-diagnose
+# silently ran against ~/.claude/ on Mini, producing empty
+# git-log/build_log/health.txt.
+REPO=""
 if [ -n "${SUTANDO_ROOT:-}" ] && [ -f "${SUTANDO_ROOT}/build_log.md" ]; then
 	REPO="$SUTANDO_ROOT"
 elif [ -f "$PWD/build_log.md" ]; then
 	REPO="$PWD"
 else
-	REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+	# Walk up from $0 looking for build_log.md (max 5 levels)
+	DIR="$(cd "$(dirname "$0")" && pwd)"
+	for _ in 1 2 3 4 5; do
+		if [ -f "$DIR/build_log.md" ]; then
+			REPO="$DIR"
+			break
+		fi
+		DIR="$(dirname "$DIR")"
+		[ "$DIR" = "/" ] && break
+	done
+	# Last-resort fallback: original 3-level dirname-walk
+	[ -z "$REPO" ] && REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
 fi
 TS="$(date +%s)"
 OUT="/tmp/sutando-diagnose-$TS"

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -7,6 +7,13 @@ set -e
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO"
 
+# Export workspace root so child processes (skills, gather scripts, etc.) can
+# resolve "the Sutando workspace" without walking dirname-relative paths that
+# break when the script is invoked via a userSettings hardlink. Picked up by
+# skills/self-diagnose/scripts/gather.sh and any other script that honors
+# $SUTANDO_ROOT.
+export SUTANDO_ROOT="$REPO"
+
 # Auto-bootstrap: create-if-missing files and dirs that the agent + skills
 # expect to exist (logs, state, tasks, results, notes, contextual-chips.json,
 # pending-questions.md, build_log.md, crons.json, …). Idempotent — safe to


### PR DESCRIPTION
## Summary
\`/self-diagnose\` was silently broken on Mini — \`gather.sh\`'s REPO resolution walked 3 levels up from \$0, which lands at \`~/.claude/\` when invoked via the userSettings hardlink. Result: empty git-log/build_log/health.txt files.

Two changes (A+B from the design discussion in #priv-bot2bot):

**A) src/startup.sh**: \`export SUTANDO_ROOT=\"\$REPO\"\` after the existing dynamic \$REPO derivation (line 7). No hardcode — \$REPO is computed from script location. Child processes (Claude session, skills, gather scripts) inherit.

**B) skills/self-diagnose/scripts/gather.sh**: replace the 3-level dirname-walk with a 5-level walk that stops at the first dir containing \`build_log.md\`. Catches workspace-path invocation even when no env var is set. Last-resort dirname-walk preserved.

## Verified all 4 invocation cases
- cwd=workspace, no env       → PWD branch, REPO correct ✓
- cwd=/tmp, workspace-path    → walk-up branch, REPO correct ✓
- cwd=/tmp, userSettings link, no env → still broken (no signal at all)
- cwd=/tmp, userSettings link, env set → env branch, REPO correct ✓

Last broken case requires an actual config file or hardcoded search paths to fix; A+B closes the realistic invocation scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)