### PR TITLE
fix(discord-bridge): atomic write for pending_replies (#597 follow-up)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -866,11 +866,22 @@ async def poll_approved():
 
 PENDING_REPLIES_FILE = REPO / "state" / "discord-pending-replies.json"
 
+def _atomic_write_pending_replies(data: dict) -> None:
+    """Write JSON atomically: tmp + rename. Avoids truncation on mid-write
+    crash (rare but real for unattended bridge restarts). Per MacBook's
+    review on PR #597."""
+    try:
+        tmp = PENDING_REPLIES_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(data))
+        tmp.replace(PENDING_REPLIES_FILE)
+    except Exception:
+        pass
+
 def save_pending_replies():
     """Persist pending_replies channel IDs to disk for crash recovery."""
     try:
         data = {k: str(v.id) for k, v in pending_replies.items()}
-        PENDING_REPLIES_FILE.write_text(json.dumps(data))
+        _atomic_write_pending_replies(data)
     except Exception:
         pass
 
@@ -901,10 +912,7 @@ def load_pending_replies_from_disk():
                 pass
         if aged_out:
             print(f"  [recovery] aged out {len(aged_out)} pending_replies > 7d", flush=True)
-            try:
-                PENDING_REPLIES_FILE.write_text(json.dumps(data))
-            except Exception:
-                pass
+            _atomic_write_pending_replies(data)
         return data
     except Exception:
         pass


### PR DESCRIPTION
## Summary
Follow-up to merged #597. The atomic-write nit MacBook flagged on his review was committed AFTER #597 merged — orphaned on the merged branch, not in main. This PR cherry-picks that commit onto a fresh branch.

**Change**: extracted \`_atomic_write_pending_replies(data)\` helper (tmp file + rename). Both \`save_pending_replies()\` and the recovery rewrite at \`load_pending_replies_from_disk()\` now use it. Avoids truncation on mid-write crash, especially at startup which is exactly when the recovery rewrite runs.

## Test plan
- [x] syntax check (no behavior change beyond write atomicity)
- [ ] restart bridge after merge, verify no truncation regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)