### PR TITLE
fix(voice-agent): write voice-state.json at startup (friction 9h-delay root-cause)

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -776,6 +776,17 @@ async function main() {
 		}
 	}
 
+	// Initialize voice-state.json at startup so dm-fallback's voiceConnected
+	// query has a fresh, authoritative file to read even before any client
+	// has ever connected. Without this, the file doesn't exist on instances
+	// that have never seen a client (e.g. Mac Mini, where voice routes to
+	// MacBook), and dm-result.py falls back to web-client.ts's `_voiceState`
+	// module variable — a sticky value set by browser SSE reports with no
+	// TTL. That caused the 2026-05-05 9h friction-delivery delay (see
+	// notes/friction-9h-delay-investigation-2026-05-05.md). With this write,
+	// the file is always present + always reflects the latest known state.
+	writeVoiceState(false);
+
 	function writeVoiceMetrics() {
 		if (metricsWritten) return;
 		metricsWritten = true;


### PR DESCRIPTION
## Summary
Root-cause fix for the 2026-05-05 friction 9h-delay. Full trace: \`notes/friction-9h-delay-investigation-2026-05-05.md\`.

\`dm-fallback\` shells to \`dm-result.py\` → queries \`/sse-status\` for \`voiceConnected\`. \`web-client.ts\` tries \`voice-state.json\` first (authoritative), falls back to \`_voiceState\` (browser-SSE module var). On instances that have never had a client connect (e.g. Mini, where voice routes to MacBook), the file doesn't exist → fallback to sticky \`_voiceState\` with no TTL. A morning sticky-true value parked the friction file for 9h until the var transitioned.

**Change** (~5 LOC): call \`writeVoiceState(false)\` once at startup, right after the function is defined. File is now always present + always reflects the latest known state.

## Design discussion
MacBook reviewed in private #bot2bot:
- A (this fix) is must-have — eliminates the file-missing fallback path entirely.
- B (TTL on \`_voiceState\`) is soft nice-to-have, has a subtle edge case (frozen browser tab → spurious DM-fallbacks). Defer to evaluate after observing A in production for a week.
- Shipping A only.

## Test plan
- [x] Syntax check (\`npx tsc --noEmit\` clean)
- [ ] Restart voice-agent on Mini. Verify \`voice-state.json\` appears in cwd with \`{connected: false, ts: ...}\`.
- [ ] Drop a marker \`friction-*.txt\` in \`results/\`. Verify \`dm-fallback\` delivers within ~30-90s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)