### PR TITLE
fix(voice-agent): close idle Gemini transport to stop phantom turns

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -1086,14 +1086,51 @@ async function main() {
 
 	voiceSessionRef = session;
 
+	// Idle teardown — close the upstream Gemini transport when no client has
+	// been connected for IDLE_TEARDOWN_MS. Without this, voice-agent keeps the
+	// Gemini Live session alive 24/7; every ~9-min Gemini reconnect ("GoAway")
+	// produces a phantom assistant turn (sometimes a tool call) with no user
+	// input. Symptoms observed: phantom save_meeting_note polluting markdown
+	// notes, phantom open_url opening browser tabs, phantom work tool calls
+	// writing fake task files. CLOSED state is a fixed point when
+	// clientConnected=false (the existing health monitor only reconnects
+	// CLOSED→CONNECTING when a client is present), so once we transition there
+	// no phantoms can fire until the next legitimate client reconnect.
+	const IDLE_TEARDOWN_MS = 60_000;
+	let idleTeardownTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const cancelIdleTeardown = () => {
+		if (idleTeardownTimer) {
+			clearTimeout(idleTeardownTimer);
+			idleTeardownTimer = null;
+		}
+	};
+	const scheduleIdleTeardown = () => {
+		cancelIdleTeardown();
+		idleTeardownTimer = setTimeout(async () => {
+			idleTeardownTimer = null;
+			if ((session as any).clientConnected) return;
+			const transport = (session as any).transport;
+			if (!transport?.disconnect) return;
+			console.log(`${ts()} [VoiceSession] Idle ${IDLE_TEARDOWN_MS / 1000}s — closing Gemini transport (no phantoms while CLOSED)`);
+			try {
+				await transport.disconnect();
+			} catch (err) {
+				console.error(`${ts()} [VoiceSession] Idle teardown failed: ${(err as Error)?.message ?? err}`);
+			}
+		}, IDLE_TEARDOWN_MS);
+	};
+
 	// Flush metrics on client disconnect — bodhi's handleClientDisconnected()
-	// doesn't trigger onSessionEnd, so metrics would never be written.
+	// doesn't trigger onSessionEnd, so metrics would never be written. Also
+	// arms the idle-teardown timer (see above).
 	const origDisconnect = (session as any).handleClientDisconnected?.bind(session);
 	if (origDisconnect) {
 		(session as any).handleClientDisconnected = () => {
 			origDisconnect();
 			writeVoiceMetrics();
 			writeVoiceState(false);
+			scheduleIdleTeardown();
 		};
 	}
 
@@ -1108,11 +1145,12 @@ async function main() {
 	// jsonl because MBP kept one voice-agent process alive across many
 	// client reconnects. First connect still goes through bodhi's
 	// onSessionStart (our callback resets state there); this wrap only
-	// kicks in on the 2nd+ connect.
+	// kicks in on the 2nd+ connect. Also cancels any pending idle teardown.
 	let clientHasConnectedOnce = false;
 	const origConnect = (session as any).handleClientConnected?.bind(session);
 	if (origConnect) {
 		(session as any).handleClientConnected = () => {
+			cancelIdleTeardown();
 			if (clientHasConnectedOnce) {
 				userTurnCount = 0; userHasInterrupted = false; sessionEnding = false;
 				voiceSessionStart = Date.now(); metricsWritten = false;
@@ -1125,6 +1163,10 @@ async function main() {
 			origConnect();
 		};
 	}
+
+	// Arm the initial teardown — voice-agent boots with no client; if none
+	// connects within IDLE_TEARDOWN_MS, close the upstream transport.
+	scheduleIdleTeardown();
 
 	// Wire task status → web client
 	setTaskStatusCallback((taskId, status, text, result) => {

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -1096,7 +1096,10 @@ async function main() {
 	// clientConnected=false (the existing health monitor only reconnects
 	// CLOSED→CONNECTING when a client is present), so once we transition there
 	// no phantoms can fire until the next legitimate client reconnect.
-	const IDLE_TEARDOWN_MS = 60_000;
+	// Tunable via env var per Mini's #602 review note. Defaults to 60s — sane
+	// for the voice / phone reconnect cadence we've observed; raise if a host
+	// has frequent ~70s connect/disconnect churn that re-opens too aggressively.
+	const IDLE_TEARDOWN_MS = Number(process.env.SUTANDO_VOICE_IDLE_TEARDOWN_MS) || 60_000;
 	let idleTeardownTimer: ReturnType<typeof setTimeout> | null = null;
 
 	const cancelIdleTeardown = () => {


### PR DESCRIPTION
## Summary

Voice-agent kept the Gemini Live session alive even with `clientConnected=false`. Every ~9-min Gemini reconnect (`GoAway`) produced a phantom assistant turn 2-3s later — sometimes a tool call (`save_meeting_note`, `open_url`, `work`) that polluted notes files, opened browser tabs, or wrote phantom task files. Reproduced 100% on Studio + verified on Maddy (latest `1c350fa` / bodhi `ffec0cd`).

Adds a 60s idle teardown:
- on `handleClientDisconnected`, schedule a timer
- timer calls `transport.disconnect()` if no client returned in time
- on `handleClientConnected`, cancel any pending timer
- also armed at boot so a freshly-started voice-agent with no client doesn't keep an idle session open

`CLOSED` is a fixed point when `clientConnected=false` (existing health monitor only resumes `CLOSED → CONNECTING` when a client is present), so no phantoms can fire until a real client reconnects.

## Pre-patch evidence

```
12:23 turn_1 [user] hello (injected via WS)
12:23 client disconnected
12:29 GoAway → 12:29:51 turn_2 [assistant] "ack"   ← PHANTOM
12:38 GoAway → 12:38:50 turn_3 [assistant] "ack"   ← PHANTOM
... (10 phantoms / 10 reconnect cycles in 90 min)
```

Cross-host (Maddy): same pattern, silent-failure surface — phantom `[Tool] save_meeting_note` polluting `notes/meeting-2026-05-04.md` (17 lines, all phantom — confirmed by Susan she didn't dictate any).

## Post-patch verification (Studio, latest main + this patch)

```
15:09:54 voice-agent restart on patched code
15:10:50 [VoiceSession] Idle 60s — closing Gemini transport (no phantoms while CLOSED)   ← BOOT teardown
15:10:50 Transport closed (state=ACTIVE code=1000), Session Ended
15:11:20 → 15:13:51 [Health] state=CLOSED client=false   ← stayed CLOSED through 4 would-be reconnect windows, zero phantoms
15:13:54 Client connected → Gemini reopens automatically (existing health-monitor recovery)
15:13:59 Client disconnected
15:14:59 [VoiceSession] Idle 60s — closing Gemini transport   ← DISCONNECT teardown fired exactly 60s after client gone
```

**Pre-patch baseline:** 90 min idle = 10 phantoms.
**Post-patch:** 6 min spanning boot + connect + disconnect cycle = **0 phantoms** + 2 confirmed teardown events.

## Test plan

- [x] Boot voice-agent fresh, wait 60s, verify idle teardown log appears + state goes CLOSED
- [x] Connect a client (WS text-input), verify Gemini reopens (`Client connected → Gemini inactive — resetting session and reconnecting`)
- [x] Disconnect client, wait 60s, verify teardown fires again
- [x] Verify zero \`[Tool]\` calls or \`Turn complete\` events fire while state=CLOSED
- [ ] (manual) Verify normal voice flow on a real client connection still works — voice metrics, transcripts, tool calls all behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)