### PR TITLE
fix(menu-bar): initial active-mode bullet + ⌃S hotkey doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,10 +251,8 @@ open -a "Slack"
 open "https://github.com"           # open URL in default browser
 ```
 
-**Context drop + shortcuts** — the Sutando menu bar app (`src/Sutando/`) provides global hotkeys:
-- ⌃C — drop selected text, clipboard image, or Finder file to `tasks/`
-- ⌃V — toggle voice connection in the browser
-- ⌃M — toggle mute during voice
+**Context drop + shortcuts** — the Sutando menu bar app (`src/Sutando/`) provides global hotkeys. **Live config**: `~/.config/sutando/hotkeys.json` (per-user override) with defaults registered in `src/Sutando/main.swift:944` (`registerHotKey()` action list). When the user asks "what hotkeys do I have", read those sources — don't quote a static list from this file (it would drift behind the actual registration).
+
 Launches automatically via `startup.sh`. Check `tasks/` for dropped context.
 
 **Learn from demonstration** — when the user says "learn this", "remember my preference", "I always do it this way", or demonstrates a pattern:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ cp .env.example .env
 bash src/startup.sh
 ```
 
-This starts all services (voice agent, phone conversation server, web client, dashboard, API, Sutando menu bar app) and opens http://localhost:8080 in your browser. The autonomous loop starts automatically — click **Connect** and start talking. Look for **S** in your menu bar — it provides shortcuts (⌃C context drop, ⌃V voice toggle, ⌃M mute) plus **Open Core** (Claude Code terminal) and **Open Dashboard** (status page).
+This starts all services (voice agent, phone conversation server, web client, dashboard, API, Sutando menu bar app) and opens http://localhost:8080 in your browser. The autonomous loop starts automatically — click **Connect** and start talking. Look for **S** in your menu bar — it provides global hotkeys (see [Keyboard shortcuts](#keyboard-shortcuts)) plus **Open Core** (Claude Code terminal) and **Open Dashboard** (status page).
 
 > **Why Sutando runs with elevated permissions.** Autonomous voice-driven work means `startup.sh` launches Claude Code with `--dangerously-skip-permissions` — the prompts that would otherwise fire on every tool call would break the voice-in / answer-out flow. In exchange:
 >
@@ -190,7 +190,7 @@ These unlock more capabilities. Add to `.env` when ready:
 | Telegram | Message Sutando from your phone | [Create bot via @BotFather](https://t.me/BotFather), then `/telegram:configure <token>` |
 | Discord | Message Sutando from Discord (DM + channel @mentions) | [Developer portal](https://discord.com/developers), then `/discord:configure <token>` |
 | Claude for Chrome | Browser automation — navigate, read pages, fill forms, interact with web apps | [Install extension](https://claude.ai/chrome), log in with the same account as Claude Code |
-| Sutando app (menu bar) | Global shortcuts: ⌃C context drop, ⌃V voice toggle, ⌃M mute | Auto-launches via `startup.sh` |
+| Sutando app (menu bar) | Global hotkeys (see [Keyboard shortcuts](#keyboard-shortcuts)) | Auto-launches via `startup.sh` |
 
 ---
 
@@ -266,6 +266,7 @@ The Sutando menu bar app (`src/Sutando/`) provides global keyboard shortcuts. It
 | Shortcut | Action |
 |----------|--------|
 | ⌃C | **Context drop** — sends selected text, clipboard image, or Finder file to Sutando |
+| ⌃S | **Screenshot drop** — sends a screenshot of the active window/screen to Sutando |
 | ⌃V | **Voice toggle** — connects/disconnects voice in the browser |
 | ⌃M | **Mute toggle** — mutes/unmutes microphone during voice |
 
@@ -307,7 +308,7 @@ It consumes API quota proportional to how much work it finds to do.
 
 **macOS permissions Sutando needs** (System Settings → Privacy & Security):
 - **Screen Recording** → add `claude` and `node`. Required for `describe_screen`, `capture_screen`, and the screen-capture server (port 7845) — lets Sutando see what you're looking at when you ask "what's on my screen?". Also used by the screen-record skill for subtitled recordings.
-- **Accessibility** → add the Sutando menu-bar app. Required for the global hotkeys (⌃C context drop, ⌃V voice toggle, ⌃M mute) and for the `macos-use` skill to click/type into native apps on your behalf.
+- **Accessibility** → add the Sutando menu-bar app. Required for the global hotkeys (see [Keyboard shortcuts](#keyboard-shortcuts)) and for the `macos-use` skill to click/type into native apps on your behalf.
 - **Microphone** → Chrome (and Terminal, for the screen-record skill). Chrome asks on first voice connect — click Allow.
 - **Contacts / Calendar / Reminders** → asked on demand by the features that use them (contact lookup before a call, `gws calendar +agenda`, `reminders.py add/list/complete`). You can grant these when first prompted rather than up front.
 

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -256,6 +256,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.pollPresenterMode()
             self?.pollVoiceMode()
         }
+        // Render the initial mode bullet on the dropdown. Without this, the
+        // first pollVoiceMode() tick bails early when sentinel matches the
+        // default `voiceMode = "active"`, leaving the menu items at their
+        // creation-time titles ("  Mode: Active") with no `●` marker. Caught
+        // 2026-05-05 — Chi reported the dot-next-to-Active was gone after a
+        // restart that landed in active mode (the common case). Calling
+        // updateModeMenuItem() once at end-of-launch makes the bullet appear
+        // immediately regardless of whether mode ever changes.
+        updateModeMenuItem()
     }
 
     // Write state/voice-mode.request for voice-agent to pick up on its 1s

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -313,6 +313,7 @@ def render_dashboard() -> str:
 <div class="check">{shortcut_status}</div>
 <div style="margin-top:8px;font-size:12px;color:#555">
 <div style="margin:4px 0"><kbd style="background:#222;color:#aaa;padding:2px 6px;border-radius:3px;font-family:monospace">⌃C</kbd> Context drop (text/image/file)</div>
+<div style="margin:4px 0"><kbd style="background:#222;color:#aaa;padding:2px 6px;border-radius:3px;font-family:monospace">⌃S</kbd> Drop screenshot</div>
 <div style="margin:4px 0"><kbd style="background:#222;color:#aaa;padding:2px 6px;border-radius:3px;font-family:monospace">⌃V</kbd> Toggle voice</div>
 <div style="margin:4px 0"><kbd style="background:#222;color:#aaa;padding:2px 6px;border-radius:3px;font-family:monospace">⌃M</kbd> Toggle mute</div>
 </div></div>""")

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -645,6 +645,8 @@ fetch('http://localhost:7844/stand-identity').then(r=>r.json()).then(s=>{
 <div id="status-bar" style="text-align:center;font-size:16px;color:#888;letter-spacing:0.3px;padding:12px 16px">
   <kbd style="background:#1a1a2e;padding:3px 8px;border-radius:4px;border:1px solid #333;font-family:monospace;color:#8af;font-size:14px">⌃C</kbd> drop context
   <span style="margin:0 8px;color:#444">|</span>
+  <kbd style="background:#1a1a2e;padding:3px 8px;border-radius:4px;border:1px solid #333;font-family:monospace;color:#8af;font-size:14px">⌃S</kbd> drop screenshot
+  <span style="margin:0 8px;color:#444">|</span>
   <kbd style="background:#1a1a2e;padding:3px 8px;border-radius:4px;border:1px solid #333;font-family:monospace;color:#8af;font-size:14px">⌃V</kbd> voice
   <span style="margin:0 8px;color:#444">|</span>
   <kbd style="background:#1a1a2e;padding:3px 8px;border-radius:4px;border:1px solid #333;font-family:monospace;color:#8af;font-size:14px">⌃M</kbd> mute


### PR DESCRIPTION
## Summary

Two small UX bugs caught while testing PR #600.

### 1. Mode dropdown bullet missing on `Mode: Active` after most restarts

`pollVoiceMode()` short-circuits via `voiceMode != newMode` to skip redundant updates. But the FIRST tick after launch matches the default `voiceMode = \"active\"` against the file sentinel's \"active\" and bails — so `updateModeMenuItem()` never runs, and the menu items stay at creation-time titles (`\"  Mode: Active\"`, two spaces, no `●`).

Common case = every restart that lands in active mode = the majority.

**Fix**: call `updateModeMenuItem()` once at the end of `applicationDidFinishLaunching`. Idempotent. Bullet renders immediately whether or not the subsequent poll fires an update.

### 2. `⌃S` (drop_screenshot) hotkey undocumented

`registerHotKey()` registers `⌃S` for screenshot drop (`src/Sutando/main.swift:944`), but the web UI status bar (`src/web-client.ts:646`) and dashboard shortcut block (`src/dashboard.py:315`) both list `⌃C / ⌃V / ⌃M` only. Added the `⌃S` `<kbd>` entry to both surfaces.

## Verification

- Sutando.app rebuilt + relaunched: bullet now appears next to \"Mode: Active\" on first launch with no mode change required.
- web-client + dashboard kickstarted: `⌃S` kbd label renders in both.

## Test plan

- [x] swiftc -O clean
- [x] manual menu inspection: bullet present immediately on launch
- [x] dashboard.py manual reload: `⌃S Drop screenshot` row visible
- [x] web-client.ts compile + reload: `⌃S drop screenshot` chip visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)