### PR TITLE
feat(#560): open_file optional `app` parameter for explicit + contextual app routing

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -22,21 +22,23 @@ import { describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool,
 export const openFileTool: ToolDefinition = {
 	name: 'open_file',
 	description:
-		'Open a file with the default macOS app. ALWAYS pass an absolute `path` (or one starting with $VAR / ~). ' +
+		'Open a file with macOS. ALWAYS pass an absolute `path` (or one starting with $VAR / ~). ' +
 		'Use for: "open the file", "open that", "can you open it". ' +
 		'If the user says "open the log" or similar, ASK which log they mean (voice-agent, discord-bridge, etc.) — do NOT guess. ' +
 		'Known files: "diagnostic tracker" or "diagnostics" = /tmp/phone-diagnostics-tracker.html, ' +
 		'"voice diagnostics" = /tmp/voice-diagnostics-tracker.html, ' +
 		'"voice context" / "the voice context file" / "the active context" = $SUTANDO_PRIVATE_DIR/voice-contexts/<active>.txt where <active> is the trimmed contents of $SUTANDO_PRIVATE_DIR/voice-contexts/active. Pass it with the env-var expanded by you (e.g. /Users/wangchi/.sutando-memory-sync/voice-contexts/ag2ai-investor.txt) or as $SUTANDO_PRIVATE_DIR/voice-contexts/ag2ai-investor.txt — both work. ' +
+		'Pass `app` when the user names a specific app ("open with Sublime Text", "open the SQLite db in TablePlus") OR when recent conversation makes the intended app clear (e.g. user just said "I\'ll review this in VS Code"). Without `app`, macOS uses its default handler for that file type — leave unset when the default is fine. ' +
 		'Pass `fullscreen=true` if the user wants the file opened in fullscreen — works generically for any file type via Cmd+Ctrl+F to whichever app the OS routed the file to (QuickTime → Present mode, Preview → fullscreen PDF, Chrome → fullscreen page, etc.).',
 	parameters: z.object({
 		path: z.string().describe('Absolute file path to open.'),
+		app: z.string().optional().describe('Optional app name (e.g. "Sublime Text", "VS Code", "TablePlus") to open the file with. If omitted, macOS uses its default handler for the file type. Set this when the user names an app explicitly OR recent conversation makes the intended app clear; otherwise leave unset.'),
 		fullscreen: z.boolean().optional().describe('If true, send Cmd+Ctrl+F to the default app right after opening — generic native-fullscreen toggle, works for any file type (video, PDF, image, web page).'),
 	}),
 	execution: 'inline',
 	async execute(args) {
-		const { path, fullscreen } = args as { path: string; fullscreen?: boolean };
-		console.log(`${ts()} [OpenFile] called (path=${path || 'none'}, fullscreen=${fullscreen || false})`);
+		const { path, app, fullscreen } = args as { path: string; app?: string; fullscreen?: boolean };
+		console.log(`${ts()} [OpenFile] called (path=${path || 'none'}, app=${app || 'default'}, fullscreen=${fullscreen || false})`);
 		try {
 			if (!path) return { error: 'No path provided. Pass an absolute file path. (For the most recent recording, call play_video — it auto-finds the file.)' };
 			// Expand $VAR / ${VAR} env-var references and ~ in the path so Sutando
@@ -63,10 +65,18 @@ export const openFileTool: ToolDefinition = {
 				return { error: `File not found: ${filePath}. Do not invent paths — use the exact path returned by the tool that produced the file (e.g. record_screen_with_narration returns subtitled_path/narrated_path/recording_path). For the most recent recording without a known path, call play_video instead.` };
 			}
 			// execFileSync — no shell interpolation of caller-controlled filePath
-			// (same CodeQL js/command-line-injection class as #27).
-			// `open <path>` lets macOS's LaunchServices route to the user's default
-			// app for that file type. open_file stays generic — no app forcing.
-			execFileSync('open', [filePath], { timeout: 5_000 });
+			// or caller-controlled app name (same CodeQL js/command-line-injection
+			// class as #27). Both are passed as separate argv entries, never spliced
+			// into a shell string.
+			//
+			// Resolution per issue #560:
+			//   1. Explicit `app` arg → `open -a <app> <path>`
+			//   2. No `app` → `open <path>` (macOS LaunchServices picks default)
+			// Contextual inference (rule 2 from issue) is the model's job — Gemini
+			// reads the conversation and decides whether to pass `app`. The tool
+			// only honors what it's told.
+			const openArgs = app ? ['-a', app, filePath] : [filePath];
+			execFileSync('open', openArgs, { timeout: 5_000 });
 			if (fullscreen) {
 				// Brief delay so the just-opened app becomes frontmost before
 				// the keystroke lands. Cmd+Ctrl+F is the macOS native-fullscreen

--- a/tests/open-file-app-param.test.ts
+++ b/tests/open-file-app-param.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { openFileTool } from '../src/inline-tools.js';
+
+// Issue #560: open_file gains an optional `app` parameter so callers can
+// direct macOS to use a specific app (e.g. "Sublime Text", "TablePlus")
+// instead of the default file-type handler. We verify the schema and
+// description rather than actually opening files (would mutate the test
+// machine's app state).
+
+describe('open_file — issue #560 app parameter', () => {
+	it('declares an optional `app` string parameter in the zod schema', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const shape = (openFileTool.parameters as any).shape;
+		assert.ok('app' in shape, 'schema must include `app` field');
+		// optional: parsing without `app` must succeed
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const parsed = (openFileTool.parameters as any).safeParse({ path: '/tmp/nonexistent.txt' });
+		assert.equal(parsed.success, true, 'omitting `app` must remain valid');
+		// providing `app` as string must also succeed
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const parsedWithApp = (openFileTool.parameters as any).safeParse({ path: '/tmp/x.py', app: 'Sublime Text' });
+		assert.equal(parsedWithApp.success, true, 'passing `app` as string must be valid');
+	});
+
+	it('description explains when to set `app`', () => {
+		const desc = openFileTool.description ?? '';
+		assert.match(desc, /\bapp\b/i, 'description must mention `app` parameter');
+		// per issue: explicit-app phrasing AND contextual-inference phrasing
+		assert.match(desc, /open with|open .* in /i, 'description should describe explicit-app trigger phrases');
+	});
+
+	it('still surfaces a File-not-found error when path does not exist (no app)', async () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const result = await (openFileTool.execute as any)({ path: '/tmp/__nonexistent_for_test_560__' }, null) as { error?: string };
+		assert.ok(result.error, 'should return error for missing path');
+		assert.match(result.error!, /File not found/, 'error mentions File not found');
+	});
+
+	it('still surfaces a File-not-found error when path does not exist (with app)', async () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const result = await (openFileTool.execute as any)({ path: '/tmp/__nonexistent_for_test_560__', app: 'Sublime Text' }, null) as { error?: string };
+		assert.ok(result.error, 'should return error for missing path');
+		assert.match(result.error!, /File not found/, 'error mentions File not found even with app');
+	});
+});


### PR DESCRIPTION
Closes #560.

## Summary

Voice / text users can now direct `open_file` to a specific macOS app instead of always going through the file-type default. Resolves the "open this in Sublime Text", "open the SQLite db in TablePlus" flow.

## Resolution per issue

1. **Explicit `app` arg** → `open -a <app> <path>`
2. **No `app`** → `open <path>` (macOS LaunchServices picks default)

Contextual inference (rule 2 from the issue body — model passes `app` based on prior conversation, even without a literal "with" phrase) is the model's job. The tool description spells out when Gemini should populate `app`; the tool itself only honors what it's told.

## Security note

Argv-form preserved: `open -a "<app>" "<path>"` is invoked via `execFileSync` with both as separate argv entries — no shell interpolation, no command-line-injection risk (same CodeQL `js/command-line-injection` class as #27).

## Test plan

- [x] 4 unit tests cover the new schema (optional string, parses with and without `app`), the description trigger phrasing, and the File-not-found error path with + without `app`. Did NOT add tests that actually open files (would mutate the test machine's app state).
- [x] `npx tsc --noEmit` clean
- [ ] (manual sanity) call `open_file` with `{path: "/path/to/some.py", app: "Sublime Text"}` end-to-end via voice — verify Sublime Text opens it, not the default handler

## Diff

`src/inline-tools.ts` (schema + description + execFile branch) + `tests/open-file-app-param.test.ts` (4 cases). 2 files / +63 / -7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)