### PR TITLE
feat(sutando-app): add Pause/Resume Loop menu commands

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -209,6 +209,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // by updateModeMenuItem() now.
         presenterMenuItem = presenterItem
         menu.addItem(NSMenuItem.separator())
+        // Loop pause/resume — proactive-loop's skip-conditions check
+        // `state/loop-paused-until.sentinel` (per skills/proactive-loop/SKILL.md
+        // Skip Conditions §(d)). Pause writes a future-dated sentinel; Resume
+        // deletes it. Sentinel format: ISO-8601 expiry timestamp (UTC).
+        // Auto-expires so a forgotten pause re-enables itself.
+        menu.addItem(NSMenuItem(title: "Pause Loop (30 min)", action: #selector(pauseLoop30), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: "Resume Loop", action: #selector(resumeLoop), keyEquivalent: ""))
+        menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Restart All Services", action: #selector(restartServices), keyEquivalent: "r"))
         menu.addItem(NSMenuItem(title: "Stop All Services", action: #selector(stopServices), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Restart Sutando App", action: #selector(restartSelf), keyEquivalent: ""))
@@ -1614,6 +1622,40 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func quit() {
         NSApplication.shared.terminate(nil)
+    }
+
+    /// Pause the proactive loop for 30 minutes by writing the sentinel
+    /// the loop's skip-conditions check (per
+    /// `~/.claude/skills/proactive-loop/SKILL.md` Skip Conditions §(d)).
+    /// Format: ISO-8601 expiry timestamp (UTC). Auto-expires — forgetting
+    /// to resume just means the loop self-re-enables in 30 min.
+    @objc func pauseLoop30() {
+        let expiry = Date().addingTimeInterval(30 * 60)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let iso = formatter.string(from: expiry)
+        let path = workspace + "/state/loop-paused-until.sentinel"
+        let dir = workspace + "/state"
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        do {
+            try iso.write(toFile: path, atomically: true, encoding: .utf8)
+            let humanTime = DateFormatter.localizedString(from: expiry, dateStyle: .none, timeStyle: .short)
+            notify("Sutando", "Loop paused until \(humanTime). Click Resume Loop to re-enable sooner.")
+        } catch {
+            notify("Sutando", "Loop pause failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Resume the proactive loop by deleting the pause sentinel. No-op
+    /// if the sentinel doesn't exist (loop wasn't paused).
+    @objc func resumeLoop() {
+        let path = workspace + "/state/loop-paused-until.sentinel"
+        if FileManager.default.fileExists(atPath: path) {
+            try? FileManager.default.removeItem(atPath: path)
+            notify("Sutando", "Loop resumed.")
+        } else {
+            notify("Sutando", "Loop wasn't paused.")
+        }
     }
 
     /// Restart the Sutando.app menu bar app — useful after editing


### PR DESCRIPTION
## Summary

Per Chi's prompt 2026-05-05 (\"shall we add core CLI-related commands in sutando app\"): anything mechanical the user currently does in the terminal but doesn't need LLM judgment is a candidate for a menu item. Same logic that folded chip refresh into Sutando.app in PR #600.

This PR adds two: **Pause Loop (30 min)** and **Resume Loop**. Backed by `state/loop-paused-until.sentinel` which the proactive-loop's skip-conditions §(d) already checks (per `~/.claude/skills/proactive-loop/SKILL.md`).

## What lands

- `pauseLoop30()` writes ISO-8601 UTC expiry timestamp (now + 30 min) to `state/loop-paused-until.sentinel`. Notifies user with localized expiry time.
- `resumeLoop()` deletes the sentinel. No-op + friendly notify if not paused.
- Two menu items in a new section between Mode toggles and the Restart/Stop block.

## Why no code change to the loop

The sentinel mechanism already exists in `proactive-loop/SKILL.md` §(d): \"Explicit pause: `state/loop-paused-until.sentinel` is active (future-dated).\" Loop already skips step-6 work while now < expiry. This PR just gives it UI.

## Verified end-to-end

- swiftc -O clean
- App rebuilt + relaunched (PID 78953)
- Menu items present in dropdown
- Pause writes ISO-8601 sentinel correctly
- Resume removes it
- Notifications fire for both

## Deferred (not in this PR)

- **Restart Core** — needs `scripts/start-cli.sh` extracted from `src/startup.sh` first so the menu item has something to invoke. Currently the launch command is inlined in startup.sh.
- **Voice agent restart** — Chi explicitly excluded.
- **Force loop tick / Quota status / Health summary** — defer to follow-up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)