### PR TITLE
feat(sutando-app + scripts): Restart Core CLI menu + extracted start-cli.sh

### DIFF
--- a/scripts/start-cli.sh
+++ b/scripts/start-cli.sh
@@ -24,12 +24,22 @@ SESSION="sutando-core"
 # --restart: kill any existing session before starting fresh. Without this,
 # the script's "already running → attach" path returns and the old session
 # keeps running.
+#
+# HAZARD: --restart MUST NOT be invoked from inside the sutando-core
+# session itself — kill-session terminates the running agent mid-task.
+# Safe callers: Sutando.app menu, terminal one-off, future health-check
+# emit-task. Unsafe: a future agent processing a "restart core" task by
+# exec'ing this script from within sutando-core. Per Mini's #608 review.
 if [ "$1" = "--restart" ]; then
   if pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1; then
     echo "Killing existing $SESSION session..."
     tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION" 2>/dev/null || true
-    # Give tmux + claude a beat to release the socket + shut down cleanly.
-    sleep 1
+    # Poll for actual shutdown — robust on slow machines, faster on fast
+    # ones (~1s ceiling) than a fixed sleep.
+    for _ in 1 2 3 4 5; do
+      pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1 || break
+      sleep 0.2
+    done
   fi
 fi
 

--- a/scripts/start-cli.sh
+++ b/scripts/start-cli.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# scripts/start-cli.sh — canonical launch script for the sutando-core tmux
+# session. Single source of truth for the "how to start Claude Code" command,
+# so startup.sh + Sutando.app's Restart Core menu can both invoke it without
+# duplicating the launch arguments.
+#
+# Usage:
+#   bash scripts/start-cli.sh           # start (or attach if running)
+#   bash scripts/start-cli.sh --restart # kill existing session then start fresh
+#
+# Per Chi's prompt 2026-05-05 ("shall we add core CLI-related commands in
+# sutando app"): extracting the launch command from startup.sh's inline tmux
+# block lets the menu-bar app's Restart Core action invoke the same canonical
+# entry without re-implementing the tmux flags.
+
+set -e
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+TMUX_SOCKET="/tmp/sutando-tmux.sock"
+SESSION="sutando-core"
+
+# --restart: kill any existing session before starting fresh. Without this,
+# the script's "already running → attach" path returns and the old session
+# keeps running.
+if [ "$1" = "--restart" ]; then
+  if pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1; then
+    echo "Killing existing $SESSION session..."
+    tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION" 2>/dev/null || true
+    # Give tmux + claude a beat to release the socket + shut down cleanly.
+    sleep 1
+  fi
+fi
+
+# Already running — attach if interactive, else exit cleanly. This branch
+# also catches the !--restart path so re-running the script is idempotent.
+if pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1; then
+  if [ -t 1 ] && command -v tmux > /dev/null 2>&1; then
+    echo "Attaching to existing $SESSION (Ctrl-b d to detach)..."
+    exec tmux -S "$TMUX_SOCKET" attach -t "$SESSION"
+  fi
+  echo "$SESSION already running."
+  echo "To attach: tmux -S $TMUX_SOCKET attach -t $SESSION"
+  exit 0
+fi
+
+# Auto-install tmux via Homebrew if missing. Sutando.app's
+# watcher-auto-restart depends on a tmux-wrapped CLI pane.
+if ! command -v tmux > /dev/null 2>&1 && command -v brew > /dev/null 2>&1; then
+  echo "tmux not found — installing via Homebrew (~30s, required for Sutando.app watcher-auto-restart)..."
+  brew install tmux 2>&1 | tail -3
+fi
+
+# Fall back to a bare `exec claude` if tmux is still missing.
+if ! command -v tmux > /dev/null 2>&1; then
+  echo "  ⚠ tmux not found — running without tmux wrapper"
+  echo "    (Sutando.app's watcher-auto-restart won't work; brew install tmux to enable)"
+  exec claude --name "$SESSION" --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
+    -- "/proactive-loop"
+fi
+
+# Explicit -S socket path so Sutando.app (which runs under a different
+# TMPDIR due to macOS sandboxing when launched via `open`) can reach the
+# same tmux server as the user shell (per #PR_444 watcher-auto-restart).
+#
+# Branch on whether we have a TTY:
+#   - TTY (user running from terminal): exec attach so the user sees the
+#     Claude Code prompt and the script process IS the tmux client.
+#   - No TTY (Sutando.app's Restart Core or any background invocation):
+#     start detached so we don't hang, server keeps running.
+if [ -t 1 ]; then
+  exec tmux -S "$TMUX_SOCKET" new-session -A -s "$SESSION" \
+    claude --name "$SESSION" --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
+    -- "/proactive-loop"
+else
+  tmux -S "$TMUX_SOCKET" new-session -d -s "$SESSION" \
+    claude --name "$SESSION" --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
+    -- "/proactive-loop"
+  echo "Started $SESSION detached. Attach via Open Core CLI in menu bar, or:"
+  echo "  tmux -S $TMUX_SOCKET attach -t $SESSION"
+fi

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -1665,6 +1665,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// "Open Core CLI" in the menu (or `tmux -S /tmp/sutando-tmux.sock
     /// attach -t sutando-core` from a terminal).
     ///
+    /// **Hazard** (per Mini's #608 review): this MUST be invoked from
+    /// outside the sutando-core CLI session — Sutando.app menu, terminal,
+    /// future health-check emit-task, etc. If a future agent runs this
+    /// from WITHIN the sutando-core session (e.g., processing a "restart
+    /// core" task), --restart will kill its own parent session and
+    /// terminate the agent mid-task. The menu-bar app is safe; agent
+    /// self-invocation is not.
+    ///
     /// Per Chi 2026-05-05: voice-agent restart explicitly excluded —
     /// this only restarts the Claude Code CLI session.
     @objc func restartCore() {
@@ -1673,11 +1681,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/bash")
         proc.arguments = [script, "--restart"]
+        // Capture stderr so we can surface failures via notify rather than
+        // silently swallowing (per Mini's #608 review nit #1). stdout still
+        // discarded — script's success messages aren't useful to the user.
+        let errPipe = Pipe()
         proc.standardOutput = FileHandle.nullDevice
-        proc.standardError = FileHandle.nullDevice
-        DispatchQueue.global(qos: .utility).async {
-            try? proc.run()
+        proc.standardError = errPipe
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            do {
+                try proc.run()
+            } catch {
+                self?.notify("Sutando", "Core restart failed to start: \(error.localizedDescription)")
+                return
+            }
             proc.waitUntilExit()
+            if proc.terminationStatus == 0 {
+                self?.notify("Sutando", "Core restarted. Attach via Open Core CLI in menu.")
+            } else {
+                let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+                let errStr = String(data: errData, encoding: .utf8) ?? ""
+                let preview = String(errStr.prefix(200))
+                self?.notify("Sutando", "Core restart failed (exit \(proc.terminationStatus)): \(preview)")
+            }
         }
     }
 

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -217,6 +217,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem(title: "Pause Loop (30 min)", action: #selector(pauseLoop30), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Resume Loop", action: #selector(resumeLoop), keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
+        menu.addItem(NSMenuItem(title: "Restart Core CLI", action: #selector(restartCore), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Restart All Services", action: #selector(restartServices), keyEquivalent: "r"))
         menu.addItem(NSMenuItem(title: "Stop All Services", action: #selector(stopServices), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Restart Sutando App", action: #selector(restartSelf), keyEquivalent: ""))
@@ -1655,6 +1656,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             notify("Sutando", "Loop resumed.")
         } else {
             notify("Sutando", "Loop wasn't paused.")
+        }
+    }
+
+    /// Restart the Claude Code core session (sutando-core tmux session).
+    /// Invokes scripts/start-cli.sh --restart which kills any existing
+    /// session and starts fresh detached. User can re-attach via
+    /// "Open Core CLI" in the menu (or `tmux -S /tmp/sutando-tmux.sock
+    /// attach -t sutando-core` from a terminal).
+    ///
+    /// Per Chi 2026-05-05: voice-agent restart explicitly excluded —
+    /// this only restarts the Claude Code CLI session.
+    @objc func restartCore() {
+        notify("Sutando", "Restarting Core CLI…")
+        let script = workspace + "/scripts/start-cli.sh"
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/bash")
+        proc.arguments = [script, "--restart"]
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        DispatchQueue.global(qos: .utility).async {
+            try? proc.run()
+            proc.waitUntilExit()
         }
     }
 

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -316,51 +316,7 @@ done
 echo ""
 open "http://localhost:8080"
 
-# Check if a sutando-core session is already running
-if pgrep -f "claude.*--name.*sutando-core" > /dev/null 2>&1; then
-  echo "Claude Code (sutando-core) is already running."
-  # Auto-attach when invoked from an interactive terminal — saves the user
-  # the copy-paste of the long `tmux -S /tmp/sutando-tmux.sock attach -t
-  # sutando-core` command. Falls back to printing the instruction in
-  # non-interactive contexts (launchd, cron, CI) where exec'ing into an
-  # attach would hang without a tty.
-  if [ -t 1 ] && command -v tmux > /dev/null 2>&1; then
-    echo "Attaching... (Ctrl-b d to detach)"
-    exec tmux -S /tmp/sutando-tmux.sock attach -t sutando-core
-  fi
-  echo "To restart: kill it first, then re-run this script."
-  echo "To attach to the running session: tmux -S /tmp/sutando-tmux.sock attach -t sutando-core"
-  echo ""
-else
-  echo "Starting Claude Code (sutando-core) inside tmux..."
-  echo ""
-  # Wrap in a tmux session named `sutando-core` so Sutando.app can send
-  # keystrokes into the pane when the task watcher dies (see
-  # AppDelegate.checkWatcher). `tmux new-session -A -s sutando-core …`
-  # creates the session if it doesn't exist and attaches if it does,
-  # so the user sees the Claude Code prompt exactly as before.
-  # Auto-install tmux via Homebrew if missing. Sutando.app's
-  # watcher-auto-restart (PR #444) depends on a tmux-wrapped CLI pane,
-  # so a first-run user without tmux silently loses that feature.
-  if ! command -v tmux > /dev/null 2>&1 && command -v brew > /dev/null 2>&1; then
-    echo "tmux not found — installing via Homebrew (~30s, required for Sutando.app watcher-auto-restart)..."
-    brew install tmux 2>&1 | tail -3
-  fi
-  # Fall back to a bare `exec claude` if tmux is still missing.
-  if command -v tmux > /dev/null 2>&1; then
-    # Explicit socket path so Sutando.app (which runs under a different
-    # TMPDIR due to macOS sandboxing when launched via `open`) can reach
-    # the same tmux server. Without -S, tmux defaults to
-    # $TMPDIR/tmux-$(id -u)/default — different path app-side vs
-    # shell-side → tmux has-session fails → watcher-auto-restart falls
-    # back to macOS notification instead of sending `watcher`.
-    exec tmux -S /tmp/sutando-tmux.sock new-session -A -s sutando-core \
-      claude --name sutando-core --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
-      -- "/proactive-loop"
-  else
-    echo "  ⚠ tmux not found — running without tmux wrapper"
-    echo "    (Sutando.app's watcher-auto-restart won't work; brew install tmux to enable)"
-    exec claude --name sutando-core --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
-      -- "/proactive-loop"
-  fi
-fi
+# Delegate to scripts/start-cli.sh — canonical sutando-core launch command.
+# Single source of truth so Sutando.app's Restart Core menu can invoke the
+# same launch path without duplicating the tmux + claude flags.
+exec bash "$REPO/scripts/start-cli.sh"


### PR DESCRIPTION
## Summary

Adds **Restart Core CLI** menu item to Sutando.app, plus extracts the canonical sutando-core launch command into `scripts/start-cli.sh`. Same logic that folded chip refresh + Pause/Resume into the menu bar (PR #600 / #606): mechanical, no-LLM operations belong in Swift, not the terminal.

Per Chi 2026-05-05: voice-agent restart explicitly excluded.

## What lands

### 1. `scripts/start-cli.sh` (new)
Single source of truth for the tmux + claude launch flags. Two modes:
- `bash scripts/start-cli.sh` — idempotent. Attach if running (interactive), exit cleanly otherwise. Start fresh if not running.
- `bash scripts/start-cli.sh --restart` — kill existing session first, then start fresh.

Handles: tmux auto-install via Homebrew, detached vs interactive (TTY) launch, no-tmux fallback to bare `claude`.

### 2. `src/startup.sh`
Replaces the ~50-line inline tmux block at the end with `exec bash "$REPO/scripts/start-cli.sh"`. No user-visible behavior change — startup.sh still ends by attaching to (or starting) sutando-core. Just delegating to the canonical script.

### 3. `src/Sutando/main.swift`
Adds `Restart Core CLI` menu item in the Restart/Stop block. Action spawns `bash scripts/start-cli.sh --restart` detached on a background queue.

## Verified

- `bash -n scripts/start-cli.sh` — syntax clean
- `swiftc -O` — clean compile
- Did NOT relaunch Sutando.app or test `--restart` (running session would self-terminate mid-conversation; will verify after merge during a quiet window)

## Test plan post-merge

- [ ] User clicks Sutando menu → Restart Core CLI → notification fires → tmux session is killed + restarted detached
- [ ] User can re-attach via "Open Core CLI" menu item or `tmux -S /tmp/sutando-tmux.sock attach -t sutando-core`
- [ ] First-run `bash src/startup.sh` still launches sutando-core (delegated path)
- [ ] No-tmux machine (rare): falls back to bare `claude`

## Why one PR for two changes

The script extraction is the prerequisite for the menu item. Bundling means: one merge, both work. Splitting would land scripts/start-cli.sh first (no consumer change), then the menu item — extra round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)