### PR TITLE
feat(learn-mining): CURATE primitives + 19 unit tests

### DIFF
--- a/src/learn-mining.py
+++ b/src/learn-mining.py
@@ -1,0 +1,444 @@
+"""learn-mining — pull-at-consumer primitives for the CURATE loop.
+
+The CURATE loop reads local sources growing on their own (logs, tasks/,
+results/, CLI conversation JSONL, notes/, memory dir) and emits structured
+signals for the LEARN loop to consume. Per the design discussion captured
+in `notes/curate-learn-act-self-review-2026-05-05.md`, this module
+provides the deterministic primitives the SKILL.md orchestrates.
+
+What lives here (mechanical, testable):
+- Cursor management (load / save with atomic write)
+- mine_dir: stat-poll a directory, emit events for files newer than cursor
+- mine_log: byte-poll a log file, regex-pre-filter, emit events for matches
+- mine_jsonl: tail a JSONL file from byte-offset cursor, emit each new line
+- audit_memory_pointers: validate MEMORY.md references against actual files
+- audit_notes_staleness: list notes with mtime older than threshold
+- dedup_against_cooldown: hash-based dedup with TTL window
+- DEFAULT_FILTERS: builtin regex set (gap #2 resolution — bootstrap-safe)
+
+What does NOT live here (LLM judgment):
+- Pattern recognition over filtered evidence (CURATE's LLM step)
+- Action proposing (LEARN)
+- Action executing (ACT)
+
+Per `feedback_unit_test_copied_helpers.md`: every primitive has unit tests
+in `tests/curate-mining.test.py`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Iterable
+
+# ---------------------------------------------------------------------------
+# DEFAULT_FILTERS — builtin regex set CURATE falls back to when
+# `state/learn-filters.json` is missing on first run (gap #2 resolution,
+# Chi 2026-05-06). LEARN's `filter_tune` action is the only override path.
+#
+# Format: list of (log_filename_suffix, kind_label, regex). The `replied`
+# pattern is `\bReplied:` not `^Replied:` so a future log-format change
+# that prefixes timestamps still matches without a regex update. Per cold
+# review on PR #590.
+#
+# `[skip]` was dropped from the discord-bridge filter set per the
+# 2026-05-05 dogfood finding (`notes/curate-dogfood-2026-05-05.md`):
+# 365 skip events per 200KB log = 95% noise.
+DEFAULT_FILTERS: list[tuple[str, str, str]] = [
+    # discord-bridge: routing + outgoing reply confirmations
+    ("discord-bridge.log", "replied", r"\bReplied:"),
+    ("discord-bridge.log", "error",   r"\b(ERROR|Exception|Traceback|TypeError)\b"),
+    # voice-agent: transport health + tool errors
+    ("voice-agent.log", "transport", r"transport (1006|1011|1007|connected|closed)"),
+    ("voice-agent.log", "error",     r"\b(ERROR|Exception|Traceback)\b"),
+    ("voice-agent.log", "delegated", r"\bdelegated\b"),
+    # conversation-server: phone call lifecycle
+    ("conversation-server.log", "call_event", r"\b(call_started|call_ended|hangup|summary)"),
+    ("conversation-server.log", "error",      r"\b(ERROR|Exception|Traceback)\b"),
+    # telegram-bridge: same shape as discord
+    ("telegram-bridge.log", "replied", r"\bReplied:"),
+    ("telegram-bridge.log", "error",   r"\b(ERROR|Exception|Traceback)\b"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Cursor management
+
+
+def load_cursor(state_file: Path) -> dict:
+    """Load cursor map from JSON, returning empty dict if missing or
+    corrupt. The CURATE pass tolerates a missing cursor (first run) by
+    starting fresh. Corrupt JSON is also treated as missing rather than
+    crashing the pass — the cost of re-emitting some old events is lower
+    than blocking forever on a one-off file corruption."""
+    if not state_file.exists():
+        return {}
+    try:
+        return json.loads(state_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def save_cursor(state_file: Path, cursor: dict) -> None:
+    """Atomic write of cursor map. tmp + rename so a concurrent reader
+    never sees a partial file. Required because CURATE and LEARN may both
+    read the cursor map between passes."""
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp = state_file.with_suffix(state_file.suffix + ".tmp")
+    tmp.write_text(json.dumps(cursor, indent=2, sort_keys=True))
+    tmp.replace(state_file)
+
+
+# ---------------------------------------------------------------------------
+# Directory mining (tasks/, results/)
+
+
+def mine_dir(
+    directory: Path,
+    cursor_key: str,
+    cursor: dict,
+    pattern: str = "*.txt",
+    recursive: bool = False,
+) -> list[dict]:
+    """Stat-poll `directory` for files newer than the cursor's recorded
+    freshness. Returns a list of event dicts; mutates `cursor[cursor_key]`
+    to the max freshness seen.
+
+    "Freshness" is `max(st_mtime, st_ctime)` — ctime updates on rename, so
+    files moved into archive/ via `mv` are detected (mtime alone misses
+    these). Same trick PR #586 uses.
+
+    Each event has shape:
+        {"source": str, "kind": "file-event", "data": {"path": str,
+         "freshness": float}}
+
+    `kind` is mechanical regex-grade; the LLM-driven classification
+    (correction / preference / etc.) happens in LEARN, not here.
+    """
+    events: list[dict] = []
+    if not directory.exists():
+        return events
+
+    last_seen = float(cursor.get(cursor_key, 0.0))
+    new_max = last_seen
+    iterator = directory.rglob(pattern) if recursive else directory.glob(pattern)
+
+    for p in iterator:
+        if not p.is_file():
+            continue
+        try:
+            st = p.stat()
+        except OSError:
+            continue
+        freshness = max(st.st_mtime, st.st_ctime)
+        if freshness <= last_seen:
+            continue
+        events.append({
+            "source": str(directory.name),
+            "kind": "file-event",
+            "data": {"path": str(p), "freshness": freshness},
+        })
+        if freshness > new_max:
+            new_max = freshness
+
+    if new_max > last_seen:
+        cursor[cursor_key] = new_max
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Log mining (byte-offset cursor + regex pre-filter)
+
+
+def mine_log(
+    log_path: Path,
+    cursor: dict,
+    filters: list[tuple[str, str, str]] | None = None,
+) -> list[dict]:
+    """Byte-poll `log_path` from the cursor's recorded offset to EOF.
+    Each new line is regex-tested against `filters`; matched lines emit
+    an event tagged with the first matching kind label.
+
+    Filter format: list of (log_filename_suffix, kind, regex). Only
+    filters whose suffix matches `log_path.name` are applied.
+
+    Returns events of shape:
+        {"source": str, "kind": str, "data": {"byte_offset": int,
+         "excerpt": str}}
+
+    Cursor key is the absolute log path string. Updates
+    `cursor[<path>]` to new EOF offset. On rotation (file size shrinks
+    below recorded cursor), emits a `kind="rotated"` event and resets
+    cursor to 0 before reading.
+
+    `excerpt` is capped at 250 chars — pointer-style; full context
+    recoverable via `{path, byte_offset}`.
+    """
+    events: list[dict] = []
+    if not log_path.exists():
+        return events
+
+    if filters is None:
+        filters = DEFAULT_FILTERS
+
+    # Compile only the filters whose suffix matches this log file.
+    suffix = log_path.name
+    applicable = [
+        (kind, re.compile(pat))
+        for f_suffix, kind, pat in filters
+        if suffix == f_suffix or suffix.endswith(f_suffix)
+    ]
+    if not applicable:
+        return events
+
+    cursor_key = str(log_path.resolve())
+    offset = int(cursor.get(cursor_key, 0))
+
+    try:
+        size = log_path.stat().st_size
+    except OSError:
+        return events
+
+    # Rotation detection: file shrunk below cursor.
+    if size < offset:
+        events.append({
+            "source": str(log_path.name),
+            "kind": "rotated",
+            "data": {"byte_offset": offset, "excerpt": f"size {size} < cursor {offset}"},
+        })
+        offset = 0
+
+    if size <= offset:
+        return events
+
+    try:
+        with log_path.open("rb") as f:
+            f.seek(offset)
+            chunk = f.read(size - offset)
+    except OSError:
+        return events
+
+    text = chunk.decode("utf-8", errors="replace")
+    line_offset = offset
+    for line in text.splitlines(keepends=True):
+        line_len = len(line.encode("utf-8"))
+        stripped = line.rstrip("\n\r")
+        for kind, pat in applicable:
+            if pat.search(stripped):
+                events.append({
+                    "source": str(log_path.name),
+                    "kind": kind,
+                    "data": {
+                        "byte_offset": line_offset,
+                        "excerpt": stripped[:250],
+                    },
+                })
+                break
+        line_offset += line_len
+
+    cursor[cursor_key] = size
+    return events
+
+
+# ---------------------------------------------------------------------------
+# JSONL mining (Claude Code session transcripts)
+
+
+def mine_jsonl(
+    jsonl_path: Path,
+    cursor: dict,
+    cursor_subkey: str | None = None,
+) -> list[dict]:
+    """Tail a JSONL file from a byte-offset cursor. Each new line emits a
+    raw event; LEARN classifies content downstream.
+
+    `cursor_subkey` — if provided, the cursor map is treated as nested:
+    `cursor[<jsonl_top_key>][cursor_subkey]`. Used for the CLI session
+    case where multiple per-UUID cursors live under one top-level key
+    (gap #3 resolution: cursor map per UUID).
+
+    Returns events of shape:
+        {"source": str, "kind": "jsonl-line",
+         "data": {"byte_offset": int, "line_excerpt": str}}
+    """
+    events: list[dict] = []
+    if not jsonl_path.exists():
+        return events
+
+    abs_key = str(jsonl_path.resolve())
+    if cursor_subkey is None:
+        offset = int(cursor.get(abs_key, 0))
+    else:
+        sub = cursor.get(abs_key, {})
+        if not isinstance(sub, dict):
+            sub = {}
+        offset = int(sub.get(cursor_subkey, 0))
+
+    try:
+        size = jsonl_path.stat().st_size
+    except OSError:
+        return events
+
+    if size < offset:
+        # Rotation / truncation — reset.
+        offset = 0
+        events.append({
+            "source": str(jsonl_path.name),
+            "kind": "rotated",
+            "data": {"byte_offset": offset, "excerpt": "shrunk below cursor"},
+        })
+
+    if size <= offset:
+        return events
+
+    try:
+        with jsonl_path.open("rb") as f:
+            f.seek(offset)
+            chunk = f.read(size - offset)
+    except OSError:
+        return events
+
+    text = chunk.decode("utf-8", errors="replace")
+    line_offset = offset
+    for line in text.splitlines(keepends=True):
+        line_len = len(line.encode("utf-8"))
+        stripped = line.rstrip("\n\r")
+        if stripped:
+            events.append({
+                "source": str(jsonl_path.name),
+                "kind": "jsonl-line",
+                "data": {
+                    "byte_offset": line_offset,
+                    "line_excerpt": stripped[:500],
+                },
+            })
+        line_offset += line_len
+
+    if cursor_subkey is None:
+        cursor[abs_key] = size
+    else:
+        sub = cursor.setdefault(abs_key, {})
+        sub[cursor_subkey] = size
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Memory + notes audits
+
+
+def audit_memory_pointers(memory_dir: Path) -> list[dict]:
+    """Validate `MEMORY.md` references against actual files in `memory_dir`.
+
+    Returns findings of shape:
+        {"kind": "broken-pointer" | "orphan-file", "data": {"file": str}}
+
+    - `broken-pointer`: MEMORY.md references a file that doesn't exist.
+    - `orphan-file`: a `.md` file in the dir is not referenced in
+      MEMORY.md (excluding `MEMORY.md` itself).
+
+    No mutations — read-only audit. LEARN proposes any cleanup actions;
+    ACT executes after owner approval.
+    """
+    findings: list[dict] = []
+    index = memory_dir / "MEMORY.md"
+    if not index.exists() or not memory_dir.is_dir():
+        return findings
+
+    try:
+        content = index.read_text()
+    except OSError:
+        return findings
+
+    # Match `[Title](file.md)` markdown link references.
+    referenced = set(
+        m.group(1) for m in re.finditer(r"\[[^\]]+\]\(([^)]+\.md)\)", content)
+    )
+
+    on_disk = {p.name for p in memory_dir.glob("*.md") if p.name != "MEMORY.md"}
+
+    for ref in sorted(referenced - on_disk):
+        findings.append({"kind": "broken-pointer", "data": {"file": ref}})
+    for orphan in sorted(on_disk - referenced):
+        findings.append({"kind": "orphan-file", "data": {"file": orphan}})
+    return findings
+
+
+def audit_notes_staleness(notes_dir: Path, threshold_days: int = 30) -> list[dict]:
+    """List notes with mtime older than `threshold_days`. No mutations.
+
+    Returns findings of shape:
+        {"kind": "stale-note", "data": {"path": str, "age_days": float}}
+    """
+    findings: list[dict] = []
+    if not notes_dir.is_dir():
+        return findings
+
+    cutoff_s = time.time() - (threshold_days * 86400)
+    for p in notes_dir.glob("*.md"):
+        try:
+            mtime = p.stat().st_mtime
+        except OSError:
+            continue
+        if mtime < cutoff_s:
+            age_days = (time.time() - mtime) / 86400
+            findings.append({
+                "kind": "stale-note",
+                "data": {"path": str(p), "age_days": round(age_days, 1)},
+            })
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Cooldown dedup
+
+
+def hash_finding(parts: Iterable[str]) -> str:
+    """Stable 16-char sha256 hash of joined parts. Used as the cooldown
+    key for findings — same content → same hash → suppressed within TTL."""
+    h = hashlib.sha256()
+    for part in parts:
+        h.update(part.encode("utf-8"))
+        h.update(b"\0")
+    return h.hexdigest()[:16]
+
+
+def dedup_against_cooldown(
+    finding_hash: str,
+    cooldown_state: dict,
+    ttl_h: float,
+    now_s: float | None = None,
+) -> bool:
+    """Return True if `finding_hash` is within the TTL cooldown window
+    (suppressed). Side-effect: if NOT suppressed, records the hash with
+    the current timestamp into `cooldown_state` for the next pass.
+
+    Per `notes/curate-learn-act-self-review-2026-05-05.md`:
+    - 6h TTL for behavioral signals (correction / preference / etc.)
+    - 24h TTL for audit findings (drift / staleness)
+    - LEARN owns its own 12h cooldown for proposals
+
+    `now_s` parameter exists for testability (inject deterministic time).
+    """
+    now = now_s if now_s is not None else time.time()
+    ttl_s = ttl_h * 3600
+    last_seen = cooldown_state.get(finding_hash)
+    if last_seen is not None and (now - last_seen) < ttl_s:
+        return True
+    cooldown_state[finding_hash] = now
+    return False
+
+
+def prune_cooldown(cooldown_state: dict, max_age_h: float = 24.0, now_s: float | None = None) -> int:
+    """Drop entries older than `max_age_h` hours. Returns count pruned.
+    Keeps the cooldown state file from growing unboundedly across passes.
+    """
+    now = now_s if now_s is not None else time.time()
+    max_age_s = max_age_h * 3600
+    stale = [k for k, ts in cooldown_state.items() if (now - ts) > max_age_s]
+    for k in stale:
+        del cooldown_state[k]
+    return len(stale)

--- a/tests/curate-mining.test.py
+++ b/tests/curate-mining.test.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Unit tests for src/learn-mining.py — the deterministic primitives the
+CURATE skill orchestrates. Each primitive is tested in isolation per
+`feedback_unit_test_copied_helpers.md`.
+
+Same shape as `tests/health-check-emit-task.test.py` (PR #610): standalone
+script, exits 0 on pass, no test runner dependency. Run via:
+
+    python3 tests/curate-mining.test.py
+
+CI picks it up via `npm test` (PR #611 wires `tests/*.test.py`).
+"""
+
+from __future__ import annotations
+import importlib.util
+import json
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Load src/learn-mining.py as `lm` (filename has a hyphen, can't import directly).
+spec = importlib.util.spec_from_file_location("learn_mining", REPO / "src" / "learn-mining.py")
+lm = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(lm)
+
+
+# ---------------------------------------------------------------------------
+# Cursor management
+
+
+def case_a_cursor_missing_returns_empty() -> list[str]:
+    """load_cursor on missing file returns {}, not error."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "nope.json"
+        result = lm.load_cursor(p)
+        if result != {}:
+            fails.append(f"a) missing file should return empty dict, got {result!r}")
+    return fails
+
+
+def case_a_cursor_corrupt_returns_empty() -> list[str]:
+    """load_cursor on corrupt JSON returns {}, doesn't crash."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "corrupt.json"
+        p.write_text("not valid json {{{")
+        result = lm.load_cursor(p)
+        if result != {}:
+            fails.append(f"a-corrupt) corrupt JSON should return empty dict, got {result!r}")
+    return fails
+
+
+def case_a_cursor_save_atomic() -> list[str]:
+    """save_cursor + load_cursor round-trips. tmp file is cleaned up."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "sub" / "cursor.json"  # nested dir to test mkdir
+        lm.save_cursor(p, {"foo": 42, "bar": "baz"})
+        result = lm.load_cursor(p)
+        if result != {"foo": 42, "bar": "baz"}:
+            fails.append(f"a-save) round-trip mismatch: {result!r}")
+        # tmp file should be cleaned up after replace()
+        if (Path(td) / "sub" / "cursor.json.tmp").exists():
+            fails.append("a-save) tmp file not cleaned up after replace")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# mine_dir
+
+
+def case_b_mine_dir_empty_no_events() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        cursor = {}
+        events = lm.mine_dir(Path(td), "tasks", cursor)
+        if events:
+            fails.append(f"b-empty) empty dir produced {len(events)} events, expected 0")
+        if "tasks" in cursor:
+            fails.append("b-empty) empty dir advanced cursor")
+    return fails
+
+
+def case_b_mine_dir_one_new_file_one_event() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td_p = Path(td)
+        (td_p / "task-1.txt").write_text("hello")
+        cursor = {}
+        events = lm.mine_dir(td_p, "tasks", cursor)
+        if len(events) != 1:
+            fails.append(f"b-one) expected 1 event, got {len(events)}")
+        if "tasks" not in cursor:
+            fails.append("b-one) cursor not advanced")
+    return fails
+
+
+def case_b_mine_dir_cursor_advances_no_replay() -> list[str]:
+    """Files seen in pass 1 don't re-emit in pass 2."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td_p = Path(td)
+        (td_p / "task-1.txt").write_text("a")
+        cursor = {}
+        first = lm.mine_dir(td_p, "tasks", cursor)
+        # Second pass — no new files, cursor advanced to first pass max.
+        second = lm.mine_dir(td_p, "tasks", cursor)
+        if len(first) != 1 or len(second) != 0:
+            fails.append(f"b-noreplay) first={len(first)} second={len(second)}, expected 1/0")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# mine_log
+
+
+def case_c_mine_log_empty_no_events() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        log = Path(td) / "voice-agent.log"
+        log.write_text("")
+        events = lm.mine_log(log, {})
+        if events:
+            fails.append(f"c-empty) empty log produced {len(events)} events")
+    return fails
+
+
+def case_c_mine_log_match_emits_event() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        log = Path(td) / "voice-agent.log"
+        log.write_text(
+            "ok normal line\n"
+            "[VoiceSession] transport connected and setup complete\n"
+            "more normal\n"
+            "ERROR: something broke\n"
+        )
+        events = lm.mine_log(log, {})
+        # Should emit 1 transport + 1 error = 2 events
+        kinds = sorted(e["kind"] for e in events)
+        if kinds != ["error", "transport"]:
+            fails.append(f"c-match) expected ['error','transport'], got {kinds}")
+    return fails
+
+
+def case_c_mine_log_cursor_no_replay() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        log = Path(td) / "voice-agent.log"
+        log.write_text("ERROR x\n")
+        cursor = {}
+        first = lm.mine_log(log, cursor)
+        second = lm.mine_log(log, cursor)
+        if len(first) != 1 or len(second) != 0:
+            fails.append(f"c-cursor) first={len(first)} second={len(second)}, expected 1/0")
+    return fails
+
+
+def case_c_mine_log_rotation_detected() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        log = Path(td) / "voice-agent.log"
+        log.write_text("ERROR x\nERROR y\n")
+        cursor = {}
+        lm.mine_log(log, cursor)  # advance cursor to EOF
+        # Now truncate the log (rotation)
+        log.write_text("ERROR z\n")
+        events = lm.mine_log(log, cursor)
+        kinds = [e["kind"] for e in events]
+        if "rotated" not in kinds:
+            fails.append(f"c-rotated) no rotated event after truncation; got {kinds}")
+        if "error" not in kinds:
+            fails.append(f"c-rotated) no error event for new content; got {kinds}")
+    return fails
+
+
+def case_c_mine_log_no_filters_match_no_events() -> list[str]:
+    """Log file whose name doesn't match any filter suffix → no events."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        log = Path(td) / "unrelated.log"
+        log.write_text("ERROR something\n")
+        events = lm.mine_log(log, {})
+        if events:
+            fails.append(f"c-nofilter) unmatched log filename emitted {len(events)} events")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# mine_jsonl
+
+
+def case_d_mine_jsonl_emits_per_line() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        jsonl = Path(td) / "session.jsonl"
+        jsonl.write_text('{"a":1}\n{"b":2}\n{"c":3}\n')
+        events = lm.mine_jsonl(jsonl, {})
+        if len(events) != 3:
+            fails.append(f"d) expected 3 events, got {len(events)}")
+    return fails
+
+
+def case_d_mine_jsonl_cursor_subkey_per_uuid() -> list[str]:
+    """Per-UUID cursor (gap #3 resolution)."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        jsonl = Path(td) / "uuid1.jsonl"
+        jsonl.write_text('{"a":1}\n{"b":2}\n')
+        cursor = {}
+        first = lm.mine_jsonl(jsonl, cursor, cursor_subkey="uuid1")
+        # cursor should be nested
+        abs_key = str(jsonl.resolve())
+        if not isinstance(cursor.get(abs_key), dict):
+            fails.append(f"d-sub) cursor not nested: {cursor!r}")
+        elif "uuid1" not in cursor[abs_key]:
+            fails.append(f"d-sub) subkey missing: {cursor!r}")
+        # Second pass should be empty
+        second = lm.mine_jsonl(jsonl, cursor, cursor_subkey="uuid1")
+        if len(second) != 0:
+            fails.append(f"d-sub) replay on cursored read: {len(second)}")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# audit_memory_pointers
+
+
+def case_e_audit_pointers_clean() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td_p = Path(td)
+        (td_p / "feedback_x.md").write_text("body")
+        (td_p / "MEMORY.md").write_text("- [feedback_x](feedback_x.md) — desc\n")
+        findings = lm.audit_memory_pointers(td_p)
+        if findings:
+            fails.append(f"e-clean) clean dir produced {len(findings)} findings: {findings}")
+    return fails
+
+
+def case_e_audit_pointers_broken() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td_p = Path(td)
+        (td_p / "MEMORY.md").write_text("- [missing](missing.md) — desc\n")
+        findings = lm.audit_memory_pointers(td_p)
+        kinds = [f["kind"] for f in findings]
+        if "broken-pointer" not in kinds:
+            fails.append(f"e-broken) expected broken-pointer, got {kinds}")
+    return fails
+
+
+def case_e_audit_pointers_orphan() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td_p = Path(td)
+        (td_p / "feedback_orphan.md").write_text("body")
+        (td_p / "MEMORY.md").write_text("# index\n")  # nothing referenced
+        findings = lm.audit_memory_pointers(td_p)
+        kinds = [f["kind"] for f in findings]
+        if "orphan-file" not in kinds:
+            fails.append(f"e-orphan) expected orphan-file, got {kinds}")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# audit_notes_staleness
+
+
+def case_f_audit_notes_threshold() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td_p = Path(td)
+        fresh = td_p / "fresh.md"
+        stale = td_p / "stale.md"
+        fresh.write_text("a")
+        stale.write_text("b")
+        # Backdate stale's mtime to 60 days ago.
+        old = time.time() - (60 * 86400)
+        import os as _os
+        _os.utime(stale, (old, old))
+        findings = lm.audit_notes_staleness(td_p, threshold_days=30)
+        names = [Path(f["data"]["path"]).name for f in findings]
+        if "stale.md" not in names:
+            fails.append(f"f) expected stale.md flagged, got {names}")
+        if "fresh.md" in names:
+            fails.append(f"f) fresh.md should not be flagged, got {names}")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# Cooldown
+
+
+def case_g_cooldown_within_window_suppresses() -> list[str]:
+    fails = []
+    state = {}
+    h = lm.hash_finding(["correction", "voice-agent.log", "user said no"])
+    # First call — not in cooldown, registers.
+    if lm.dedup_against_cooldown(h, state, ttl_h=6.0, now_s=1000.0):
+        fails.append("g-first) first call should NOT be deduped")
+    # Second call within window.
+    if not lm.dedup_against_cooldown(h, state, ttl_h=6.0, now_s=1000.0 + 100):
+        fails.append("g-second) second call within TTL should be deduped")
+    # Third call past TTL.
+    if lm.dedup_against_cooldown(h, state, ttl_h=6.0, now_s=1000.0 + 7 * 3600):
+        fails.append("g-past) call past TTL should NOT be deduped")
+    return fails
+
+
+def case_g_prune_cooldown() -> list[str]:
+    fails = []
+    state = {
+        "fresh": time.time() - 3600,       # 1h old, kept
+        "stale": time.time() - 100 * 3600, # 100h old, dropped
+    }
+    pruned = lm.prune_cooldown(state, max_age_h=24.0)
+    if pruned != 1:
+        fails.append(f"g-prune) expected 1 pruned, got {pruned}")
+    if "stale" in state:
+        fails.append("g-prune) stale entry not removed")
+    if "fresh" not in state:
+        fails.append("g-prune) fresh entry wrongly removed")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# Driver
+
+
+def main() -> int:
+    cases = [
+        ("a-missing", case_a_cursor_missing_returns_empty),
+        ("a-corrupt", case_a_cursor_corrupt_returns_empty),
+        ("a-save",    case_a_cursor_save_atomic),
+        ("b-empty",   case_b_mine_dir_empty_no_events),
+        ("b-one",     case_b_mine_dir_one_new_file_one_event),
+        ("b-noreplay", case_b_mine_dir_cursor_advances_no_replay),
+        ("c-empty",   case_c_mine_log_empty_no_events),
+        ("c-match",   case_c_mine_log_match_emits_event),
+        ("c-cursor",  case_c_mine_log_cursor_no_replay),
+        ("c-rotated", case_c_mine_log_rotation_detected),
+        ("c-nofilter", case_c_mine_log_no_filters_match_no_events),
+        ("d-emit",    case_d_mine_jsonl_emits_per_line),
+        ("d-sub",     case_d_mine_jsonl_cursor_subkey_per_uuid),
+        ("e-clean",   case_e_audit_pointers_clean),
+        ("e-broken",  case_e_audit_pointers_broken),
+        ("e-orphan",  case_e_audit_pointers_orphan),
+        ("f",         case_f_audit_notes_threshold),
+        ("g-cooldown", case_g_cooldown_within_window_suppresses),
+        ("g-prune",   case_g_prune_cooldown),
+    ]
+    all_failures = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            all_failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if all_failures:
+        print(f"\n{len(all_failures)} failure(s)")
+        return 1
+    print(f"\nAll {len(cases)} curate-mining primitives pass.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Deterministic primitives the CURATE skill orchestrates per the trio design (CURATE → LEARN → ACT) ratified 2026-05-06 in `notes/curate-learn-act-self-review-2026-05-05.md`.

Owner-greenlit pick A: extract \`learn-mining.py\` first, CURATE-side primitives.

## What lives here

- \`DEFAULT_FILTERS\` — builtin regex set CURATE falls back to when \`state/learn-filters.json\` is missing on first run. **Gap #2 resolution** (Chi 2026-05-06).
- \`load_cursor\` / \`save_cursor\` — atomic tmp+rename; tolerant of missing/corrupt JSON.
- \`mine_dir\` — stat-poll directory; emits events for files newer than cursor. Uses \`max(st_mtime, st_ctime)\` so \`mv\`-into-archive is detected.
- \`mine_log\` — byte-poll log file, regex-pre-filter, emit matched lines. Rotation detection on shrink-below-cursor.
- \`mine_jsonl\` — tail JSONL from byte-offset cursor. \`cursor_subkey\` param supports per-UUID nested cursor (CLI conversation transcripts). **Gap #3 resolution**.
- \`audit_memory_pointers\` — validate MEMORY.md refs against on-disk files; emits broken-pointer / orphan-file findings. Read-only.
- \`audit_notes_staleness\` — list notes older than threshold.
- \`hash_finding\` + \`dedup_against_cooldown\` + \`prune_cooldown\` — TTL-based finding dedup.

## What does NOT live here

- Pattern recognition over filtered evidence (CURATE's LLM step)
- Action proposing (LEARN)
- Action executing (ACT)

These remain in the SKILL.md prompts in the private memory-sync repo.

## Test plan

- [x] \`python3 tests/curate-mining.test.py\` — all 19 cases pass green
- [x] One bug caught + fixed during test-write: \`dedup_against_cooldown\` was treating \`last_seen=0\` (never-seen) as "within TTL" → suppressing first emit. Fixed to check \`is not None\` explicitly. Test \`g-cooldown\` covers.
- [x] Same shape as \`tests/health-check-emit-task.test.py\` (PR #610) — standalone script, no test runner; picked up by \`npm test\` via PR #611's wiring.
- [x] No collision with Mini's open work (no recent learn-mining branches; \`gh pr list --search learn-mining\` returns []).

## Cross-ref

- Trio specs: \`~/.sutando-memory-sync/skills/personal-{curate,learn,act}-loop/\`
- Self-review (gaps resolved 2026-05-06): \`notes/curate-learn-act-self-review-2026-05-05.md\`
- Dogfood empirical data behind dropping \`[skip]\` from defaults: \`notes/curate-dogfood-2026-05-05.md\`
- Trio test plan: \`notes/curate-learn-act-test-plan-2026-05-05.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)