### PR TITLE
feat(discord-bridge): per-channel auto_react for instant pickup ack

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -381,6 +381,22 @@ def load_channel_allowed(channel_id):
         return None
     return cfg[1]
 
+def load_channel_auto_react(channel_id):
+    """Return list of emoji strings to auto-react with on each new message in this
+    channel, or empty list if not configured. Reactions land at gateway-event
+    speed (~hundreds of ms) while task-file processing happens downstream —
+    gives users an immediate visual ack that the bot saw their message.
+    The task handler removes the reaction when it posts a response."""
+    try:
+        data = json.loads(ACCESS_FILE.read_text())
+        cfg = data.get("groups", {}).get(str(channel_id))
+        if isinstance(cfg, dict):
+            val = cfg.get("auto_react", [])
+            return val if isinstance(val, list) else []
+        return []
+    except Exception:
+        return []
+
 # Track pending replies: task_id -> channel
 pending_replies = {}
 
@@ -811,6 +827,19 @@ async def _handle_discord_message(message, force=False):
             "===END SUTANDO SYSTEM INSTRUCTIONS===\n"
         ),
     }
+
+    # Auto-react BEFORE writing the task — gives the user an instant visual ack
+    # at gateway-event speed, while the rest of task processing (file write,
+    # watcher pickup, agent response craft) happens downstream. The task
+    # handler is expected to remove the reaction when it posts its reply.
+    # Configured per-channel via `auto_react: ["👀", ...]` in access.json.
+    # No-op if the channel has no `auto_react` config.
+    if not is_dm:
+        for react_emoji in load_channel_auto_react(message.channel.id):
+            try:
+                await message.add_reaction(react_emoji)
+            except Exception as e:
+                print(f"  [auto-react] {react_emoji} failed: {e}", flush=True)
 
     task_file.write_text(
         f"id: {task_id}\n"


### PR DESCRIPTION
## Summary
- New optional `auto_react: ["👀", ...]` field per channel in `access.json`. When set, the bridge calls `message.add_reaction()` immediately on gateway-event arrival, before writing the task file.
- Bridge does NOT auto-remove the reaction — that's the agent's responsibility per `feedback_msze_always_remove_eyes.md` (agent calls `DELETE /reactions/<emoji>/@me` when responding). Bridge-side auto-remove on result-file dispatch is a candidate follow-up (see `notes/ag2-moderator-policy.md` §9).
- Default behavior unchanged for any channel without the config (empty list = no-op).

## Why
AG2-mod test feedback from msze: visual "I saw your message" signal needs to land at gateway-event speed (~100ms), not at agent-response speed (~30-60s including bridge poll + watcher + Python startup). The bridge already sees the message before any of that downstream pipeline runs.

## Test plan
- [x] Configured `#sutando-test` with `auto_react: ["👀"]`
- [x] Mini bridge restarted (nohup pattern per `feedback_mini_bridges_no_launchd.md`)
- [x] Verified syntax via `python3 -c 'import ast; ast.parse(...)'`
- [x] Live latency verification with msze in #sutando-test — confirmed during 2026-05-06 accounthack mod work; 👀 lands at gateway-event speed across ~10 msze messages
- [ ] MacBook bridge restart if PR merges (separate but coordinated)

## Notes for reviewer
- Handles missing/malformed `auto_react` config gracefully (returns empty list).
- Skipped for DMs (`is_dm` guard) — auto-react in DMs is unusual UX.
- `await message.add_reaction()` failures are caught + logged but don't block task processing. Per #614 review nit, future log lines on this path should include `[auto-react]` prefix + channel_id for triangulation.
- Hook placement is downstream of the bot-author + mention filters in `_handle_discord_message`, so auto-react fires only on real user messages that pass the existing filters.
- **Removal limitation**: bridge auto-adds the reaction but does NOT auto-remove it. Removal stays the agent's responsibility (manual `DELETE /reactions/{emoji}/@me` for NO-REPLY tasks). A follow-up PR could add bridge-side auto-removal when the bridge dispatches a result file, but that would only cover the "agent posts a result" case — NO-REPLY archive paths still need manual cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)