### PR TITLE
fix(web-client): hide done tasks by default with show/hide toggle

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -929,6 +929,18 @@ function setStatus(text, state) {
 // here, refreshing the page wipes the results from the UI.
 const PERSIST_KEY_TASKS = 'sutando-taskmap-v1';
 const PERSIST_KEY_EXPAND = 'sutando-expanded-v1';
+const PERSIST_KEY_SHOW_DONE = 'sutando-show-done-v1';
+// Default-hide done tasks. With Tasks growing to top-30, completed work was
+// crowding out active items and the watcher-glance use case ("what's still
+// running?") got lost. Toggle persists across reloads.
+let showDone = (() => {
+  try { return localStorage.getItem(PERSIST_KEY_SHOW_DONE) === '1'; } catch { return false; }
+})();
+window.toggleShowDone = function() {
+  showDone = !showDone;
+  try { localStorage.setItem(PERSIST_KEY_SHOW_DONE, showDone ? '1' : '0'); } catch {}
+  renderTasks();
+};
 function loadPersistedTaskMap() {
   try {
     const raw = localStorage.getItem(PERSIST_KEY_TASKS);
@@ -1051,18 +1063,32 @@ function renderTasks() {
   window._drTaskCount = entries.length;
   const hdr = $('tasks-header');
   if (entries.length === 0) { container.innerHTML = ''; if (hdr) hdr.style.display = 'none'; return; }
+  // Default-filter done tasks. error/pending/working always render so the
+  // user never loses sight of active work. Toggle in header reveals done.
+  const doneCount = entries.filter(([, t]) => t.status === 'done').length;
+  const visible = showDone ? entries : entries.filter(([, t]) => t.status !== 'done');
   if (hdr) {
     const hasExpanded = expandedTasks.size > 0;
     hdr.style.display = 'flex';
-    hdr.innerHTML = '<span>Tasks</span><span onclick="toggleAllTasks()" style="cursor:pointer">' +
+    const doneToggle = doneCount > 0
+      ? '<span onclick="toggleShowDone()" style="cursor:pointer">' +
+        (showDone ? 'hide ' + doneCount + ' done' : 'show ' + doneCount + ' done') +
+        '</span>'
+      : '';
+    hdr.innerHTML = '<span>Tasks</span>' +
+      doneToggle +
+      '<span onclick="toggleAllTasks()" style="cursor:pointer">' +
       (hasExpanded ? 'collapse all' : 'expand all') +
       '</span>';
   }
+  // Empty visible list with non-empty entries means everything is done and
+  // hidden. Show the header toggle so the user can reveal — clear the list.
+  if (visible.length === 0) { container.innerHTML = ''; return; }
   // Render top-30 most recent. Was 8, but in active sessions (e.g. a kid
   // iterating on a party plan) new tasks pushed earlier valuable results out
   // of view within seconds. 30 keeps a longer history visible; localStorage
   // persistence above keeps results from being lost across refreshes.
-  const sorted = entries.sort((a, b) => b[1].time - a[1].time).slice(0, 30);
+  const sorted = visible.sort((a, b) => b[1].time - a[1].time).slice(0, 30);
   container.innerHTML = sorted.map(([id, t]) => {
     const icons = { pending: '&#8987;', working: '&#9881;', done: '&#10003;', error: '&#10007;' };
     const ago = Math.round((Date.now() - t.time) / 1000);


### PR DESCRIPTION
## Summary

You said the Tasks panel showing completed alongside active tasks was confusing. With top-30 rendering (introduced for the party-plan iteration use case), done items crowd out active work and the "what's still running?" glance gets lost.

This PR default-hides \`done\` tasks. Header gets a \`show N done\` / \`hide N done\` chip whenever there are any. Other statuses (\`pending\`/\`working\`/\`error\`) always render.

## Behavior
- First load: done tasks hidden; pending/working/error visible
- Toggle persists in localStorage (\`sutando-show-done-v1\`) across reloads
- When all tasks are done and toggle is off: list renders empty, header still shows the toggle so the user can reveal them
- 30-task cap still applies — it just applies to the visible (filtered) list now

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` 154/154 pass (no behavioral test for renderTasks; logic verified by reading)
- [ ] After merge: refresh web client; submit a voice task; confirm it appears in pending → working → done; on done it disappears and \`show 1 done\` chip appears in header
- [ ] Click chip → done task reappears, chip flips to \`hide 1 done\`
- [ ] Refresh page; toggle state persists

## Notes
- 30-line change to \`src/web-client.ts\` only
- Filed to track the related observation that the renderTasks gating decision (status-aware vs result-aware) is already complex; happy to bundle a "history view tab" instead of inline filter if you'd rather

🤖 Generated with [Claude Code](https://claude.com/claude-code)