### PR TITLE
feat(health-check): detect stuck proactive loop + queue pileup; OS-supervised invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Exiting `startup.sh` alone does NOT stop background services. Always use `restar
 3. Remove config: `rm -rf ~/.claude/projects/*sutando*`
 4. Remove npm packages (optional): the repo uses local `node_modules/` — deleted with the repo
 5. Remove any tools you installed during setup (e.g. `imsg`, `wacli`) via the package manager you used to install them.
+6. If you installed the OS-supervised health checks: `bash src/install-health-check-launchd.sh --uninstall` (idempotent — no-op if not installed).
 
 ---
 
@@ -191,6 +192,7 @@ These unlock more capabilities. Add to `.env` when ready:
 | Discord | Message Sutando from Discord (DM + channel @mentions) | [Developer portal](https://discord.com/developers), then `/discord:configure <token>` |
 | Claude for Chrome | Browser automation — navigate, read pages, fill forms, interact with web apps | [Install extension](https://claude.ai/chrome), log in with the same account as Claude Code |
 | Sutando app (menu bar) | Global hotkeys (see [Keyboard shortcuts](#keyboard-shortcuts)) | Auto-launches via `startup.sh` |
+| OS-supervised health checks | Detect stuck loops, dead watchers, and queue pileups even when core is unresponsive — macOS notifies you when Sutando is broken | `bash src/install-health-check-launchd.sh` (idempotent; uninstall with `--uninstall`) |
 
 ---
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -955,9 +955,9 @@ def notify_for_failures(
     set hash, 1h cooldown, separate state file). Two surfaces are needed for
     robustness: emit-task only delivers if the agent is alive to read tasks/,
     osascript runs at OS level and surfaces even when every Sutando service
-    is dead. The launchd-supervised health-check (com.sutando.health-check)
-    relies on this property — it's the alert path that survives "all of
-    Sutando is down."
+    is dead. The launchd-supervised fallback health-check
+    (com.sutando.health-check-fallback) relies on this property — it's the
+    alert path that survives "all of Sutando is down."
 
     `notify_cmd` is the executable + args used to fire the notification;
     defaults to `osascript` driving `display notification`. Tests inject a
@@ -1030,9 +1030,9 @@ def main():
     if do_emit:
         emit_task_for_failures(checks)
     # Optional: macOS notification surface for the launchd-supervised path
-    # (com.sutando.health-check). Independent dedup state from emit-task —
-    # the two surfaces are deliberately decoupled so neither can suppress
-    # the other.
+    # (com.sutando.health-check-fallback). Independent dedup state from
+    # emit-task — the two surfaces are deliberately decoupled so neither
+    # can suppress the other.
     if do_notify:
         notify_for_failures(checks)
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3,9 +3,11 @@
 Sutando health check — verifies all components are running correctly.
 
 Usage:
-  python3 src/health-check.py            # full check, human-readable
-  python3 src/health-check.py --json     # machine-readable output
-  python3 src/health-check.py --fix      # attempt to fix issues
+  python3 src/health-check.py                  # full check, human-readable
+  python3 src/health-check.py --json           # machine-readable output
+  python3 src/health-check.py --fix            # attempt to fix issues
+  python3 src/health-check.py --emit-task      # write tasks/task-health-*.txt on failure
+  python3 src/health-check.py --notify-on-fail # macOS notification on failure
 
 Checks:
   - Voice agent (port 9900), web client, agent API, dashboard
@@ -523,6 +525,85 @@ def _extract_body(text: str, start: int) -> str:
     return text[brace : brace + 2000]
 
 
+# ---------------------------------------------------------------------------
+# Stuck-loop / dead-watcher detection
+# ---------------------------------------------------------------------------
+# These two checks together catch the failure mode observed 2026-05-06 where
+# voice-queued tasks piled up in tasks/ for 5+ minutes with no processing,
+# because (a) the watch-tasks.sh fswatch shim wasn't running and (b) the
+# core proactive loop's last status update was 5 days old (status="running"
+# with a stale ts means a pass crashed mid-execution and the loop never
+# re-armed). Each check is a *consequence* signal that fires regardless of
+# which underlying mechanism died.
+
+def check_core_proactive_loop(threshold_sec: int = 600) -> dict:
+    """Detect a stuck core proactive loop via stale core-status.json.
+
+    The proactive loop writes core-status.json at every state transition
+    (see CLAUDE.md "Work Status"). If status reads "running" but the
+    timestamp hasn't advanced in `threshold_sec`, a pass crashed mid-
+    execution and the loop never re-armed — emitted tasks won't be
+    processed. Returns "warn" so emit_task_for_failures surfaces it.
+
+    File missing or malformed → ok (new install, or core has never run).
+    Status is anything other than "running" → ok regardless of age.
+    """
+    name = "core-proactive-loop"
+    status_path = REPO_DIR / "core-status.json"
+    if not status_path.exists():
+        return {"name": name, "status": "ok", "detail": "core-status.json not yet written"}
+    try:
+        data = json.loads(status_path.read_text())
+    except Exception as e:
+        # Malformed JSON shouldn't be treated as a stuck loop — could be a
+        # half-written file caught between os.write() syscalls. Fall through
+        # to ok so the next tick sees a (re-)written status.
+        return {"name": name, "status": "ok", "detail": f"core-status.json unreadable: {str(e)[:60]}"}
+    state = data.get("status")
+    ts = data.get("ts")
+    if state != "running":
+        return {"name": name, "status": "ok", "detail": f"status={state}"}
+    if not isinstance(ts, (int, float)):
+        return {"name": name, "status": "ok", "detail": "running, no ts"}
+    age = int(time.time() - ts)
+    if age > threshold_sec:
+        step = data.get("step", "?")
+        return {
+            "name": name,
+            "status": "warn",
+            "detail": f"running for {age}s on '{step}' — last heartbeat > {threshold_sec}s ago",
+        }
+    return {"name": name, "status": "ok", "detail": f"running ({age}s ago)"}
+
+
+def check_task_queue(threshold_count: int = 3, threshold_age_sec: int = 300) -> dict:
+    """Detect a task-queue pileup — tasks/ directory growing without
+    being drained. Independent of which watcher / loop is dying: the queue
+    backs up either way. Fires when BOTH count and age cross thresholds so
+    a transient spike of fresh tasks (normal during heavy use) doesn't
+    alert.
+    """
+    name = "task-queue"
+    tasks_dir = REPO_DIR / "tasks"
+    if not tasks_dir.exists():
+        return {"name": name, "status": "ok", "detail": "tasks/ not yet created"}
+    # *.txt at the top level only — archive lives in tasks/archive/<YYYY-MM>/
+    # (PR #591) and shouldn't count toward the queue.
+    files = [p for p in tasks_dir.glob("*.txt") if p.is_file()]
+    if not files:
+        return {"name": name, "status": "ok", "detail": "queue empty"}
+    now = time.time()
+    oldest = min(files, key=lambda p: p.stat().st_mtime)
+    oldest_age = int(now - oldest.stat().st_mtime)
+    if len(files) > threshold_count and oldest_age > threshold_age_sec:
+        return {
+            "name": name,
+            "status": "warn",
+            "detail": f"{len(files)} tasks queued, oldest {oldest_age}s — watcher or core may be stuck",
+        }
+    return {"name": name, "status": "ok", "detail": f"{len(files)} task(s), oldest {oldest_age}s"}
+
+
 def run_all_checks() -> list[dict]:
     checks = []
 
@@ -767,6 +848,15 @@ def run_all_checks() -> list[dict]:
         else:
             checks.append({"name": "sutando-app", "status": "warn", "detail": "not running — hotkeys disabled"})
 
+    # Stuck-loop / queue-pileup detection — consequence-level signals that
+    # fire whether the watcher died, the proactive loop crashed mid-pass, or
+    # both. Independent of which mechanism died.
+    loop_stale_sec = int(os.environ.get("SUTANDO_HEALTH_LOOP_STALE_SEC", "600"))
+    queue_age_sec = int(os.environ.get("SUTANDO_HEALTH_QUEUE_AGE_SEC", "300"))
+    queue_count = int(os.environ.get("SUTANDO_HEALTH_QUEUE_COUNT", "3"))
+    checks.append(check_core_proactive_loop(threshold_sec=loop_stale_sec))
+    checks.append(check_task_queue(threshold_count=queue_count, threshold_age_sec=queue_age_sec))
+
     return checks
 
 
@@ -854,10 +944,82 @@ def emit_task_for_failures(checks: list[dict], state_file: Optional[Path] = None
         pass
 
 
+def notify_for_failures(
+    checks: list[dict],
+    state_file: Optional[Path] = None,
+    notify_cmd: Optional[list[str]] = None,
+) -> None:
+    """Surface health-check failures via macOS notification.
+
+    Companion to `emit_task_for_failures` — same dedup contract (per-failure-
+    set hash, 1h cooldown, separate state file). Two surfaces are needed for
+    robustness: emit-task only delivers if the agent is alive to read tasks/,
+    osascript runs at OS level and surfaces even when every Sutando service
+    is dead. The launchd-supervised health-check (com.sutando.health-check)
+    relies on this property — it's the alert path that survives "all of
+    Sutando is down."
+
+    `notify_cmd` is the executable + args used to fire the notification;
+    defaults to `osascript` driving `display notification`. Tests inject a
+    fake to avoid spamming the developer's own notification center.
+    """
+    failures = [c for c in checks if c["status"] in ("down", "missing", "not_loaded", "fail", "stale", "warn")]
+    if not failures:
+        return
+
+    if state_file is None:
+        state_file = REPO_DIR / "state" / "health-last-notified.json"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+
+    set_key = "|".join(sorted(c["name"] for c in failures))
+    hash_key = hashlib.sha256(set_key.encode()).hexdigest()[:16]
+    now_ms = int(time.time() * 1000)
+    cooldown_ms = 3600 * 1000  # 1h — matches emit_task
+
+    history: dict = {}
+    try:
+        if state_file.exists():
+            history = json.loads(state_file.read_text())
+    except Exception:
+        history = {}
+
+    last_notified = history.get(hash_key, 0)
+    if now_ms - last_notified < cooldown_ms:
+        return
+
+    # Build a short notification body — macOS truncates aggressively. Lead
+    # with count, then top failure names. Full detail is in emit-task.
+    names = [c["name"] for c in failures[:3]]
+    extra = f" (+{len(failures) - 3} more)" if len(failures) > 3 else ""
+    body = f"{len(failures)} health check failure(s): {', '.join(names)}{extra}"
+
+    # AppleScript single-quote escaping: drop double-quotes and backslashes
+    # so the shell command literal can't be broken by check details.
+    safe = body.replace('"', '').replace('\\', '')
+    cmd = notify_cmd or [
+        "osascript", "-e",
+        f'display notification "{safe}" with title "Sutando — health check"',
+    ]
+    try:
+        subprocess.run(cmd, check=False, timeout=10)
+    except Exception:
+        # Notification failure is non-fatal — we still want emit-task to fire.
+        pass
+
+    history[hash_key] = now_ms
+    cutoff = now_ms - (24 * 3600 * 1000)
+    history = {k: v for k, v in history.items() if v >= cutoff}
+    try:
+        state_file.write_text(json.dumps(history))
+    except Exception:
+        pass
+
+
 def main():
     as_json = "--json" in sys.argv
     do_fix = "--fix" in sys.argv
     do_emit = "--emit-task" in sys.argv
+    do_notify = "--notify-on-fail" in sys.argv
     quiet = "--quiet" in sys.argv or "-q" in sys.argv
 
     checks = run_all_checks()
@@ -867,6 +1029,12 @@ def main():
     # return so cron-driven --json --emit-task callers get both behaviors.
     if do_emit:
         emit_task_for_failures(checks)
+    # Optional: macOS notification surface for the launchd-supervised path
+    # (com.sutando.health-check). Independent dedup state from emit-task —
+    # the two surfaces are deliberately decoupled so neither can suppress
+    # the other.
+    if do_notify:
+        notify_for_failures(checks)
 
     if as_json:
         print(json.dumps({"checks": checks, "issues": len(issues), "total": len(checks)}, indent=2))

--- a/src/install-health-check-launchd.sh
+++ b/src/install-health-check-launchd.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Install / uninstall the launchd-supervised health-check job.
+#
+# What this does:
+#   - Renders src/launchd/com.sutando.health-check.plist with absolute paths
+#     and writes it to ~/Library/LaunchAgents/com.sutando.health-check.plist
+#   - Loads it via `launchctl bootstrap gui/$UID` (the modern Sequoia idiom).
+#   - Result: macOS runs `python3 src/health-check.py --emit-task
+#     --notify-on-fail --quiet` every 60s, independent of any other Sutando
+#     process. Failures surface as tasks (for the agent to act on) AND as
+#     macOS notifications (so the human sees them even if all of Sutando is
+#     dead).
+#
+# What the user sees first time they install:
+#   - One macOS "Background Item Added" notification banner (Apple's own UX,
+#     not Sutando's). Dismissable.
+#   - A new "Sutando — Health Check" entry in System Settings → General →
+#     Login Items → "Allow in the Background" with a toggle. Disable any
+#     time without breaking Sutando.
+#
+# Strictly opt-in: not called by startup.sh. Run this script when you want
+# OS-supervised health detection.
+#
+# Usage:
+#   bash src/install-health-check-launchd.sh             # install (idempotent)
+#   bash src/install-health-check-launchd.sh --uninstall # remove (idempotent)
+#   bash src/install-health-check-launchd.sh --status    # print job state
+#
+# Idempotent: re-running install bootouts the existing job before
+# bootstrapping the new one, so a `git pull` that updates the template is
+# picked up by re-running this script.
+
+set -e
+
+LABEL="com.sutando.health-check"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE="$REPO/src/launchd/$LABEL.plist"
+DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+DOMAIN="gui/$(id -u)"
+SERVICE="$DOMAIN/$LABEL"
+
+cmd="${1:-install}"
+
+bootout_if_loaded() {
+    if launchctl print "$SERVICE" >/dev/null 2>&1; then
+        echo "  Existing job found, removing first..."
+        launchctl bootout "$SERVICE" 2>/dev/null || true
+        # bootout is async — wait for the service to actually disappear so
+        # the subsequent bootstrap doesn't race.
+        for _ in $(seq 1 10); do
+            launchctl print "$SERVICE" >/dev/null 2>&1 || break
+            sleep 0.3
+        done
+    fi
+}
+
+resolve_python() {
+    # Prefer Homebrew python3 — system /usr/bin/python3 is 3.9 on older
+    # Macs and health-check.py uses 3.10+ syntax (per agent-api.py:115
+    # comment).
+    if [ -x /opt/homebrew/bin/python3 ]; then
+        echo /opt/homebrew/bin/python3
+    elif [ -x /usr/local/bin/python3 ]; then
+        echo /usr/local/bin/python3
+    elif command -v python3 >/dev/null 2>&1; then
+        command -v python3
+    else
+        echo "ERROR: no python3 found" >&2
+        exit 1
+    fi
+}
+
+resolve_homebrew_bin() {
+    # Apple Silicon vs Intel — both prefixes work; pick whichever exists.
+    if [ -d /opt/homebrew/bin ]; then
+        echo /opt/homebrew/bin
+    elif [ -d /usr/local/bin ]; then
+        echo /usr/local/bin
+    else
+        echo /usr/bin
+    fi
+}
+
+case "$cmd" in
+    install)
+        if [ ! -f "$TEMPLATE" ]; then
+            echo "ERROR: template not found: $TEMPLATE" >&2
+            exit 1
+        fi
+        PYTHON_BIN="$(resolve_python)"
+        BREW_BIN="$(resolve_homebrew_bin)"
+        echo "Installing $LABEL"
+        echo "  repo:    $REPO"
+        echo "  python:  $PYTHON_BIN"
+        echo "  brew:    $BREW_BIN"
+        mkdir -p "$HOME/Library/LaunchAgents"
+        mkdir -p "$REPO/logs"
+        # Render the template. Use a delimiter unlikely to appear in paths.
+        sed \
+            -e "s|__REPO__|$REPO|g" \
+            -e "s|__PYTHON__|$PYTHON_BIN|g" \
+            -e "s|__HOMEBREW_BIN__|$BREW_BIN|g" \
+            "$TEMPLATE" > "$DEST"
+        bootout_if_loaded
+        launchctl bootstrap "$DOMAIN" "$DEST"
+        echo "  Loaded via $SERVICE"
+        echo
+        echo "Sutando — Health Check is now running every 60s."
+        echo "  • Failures fire macOS notifications + write tasks/task-health-*.txt"
+        echo "  • View status:  bash $0 --status"
+        echo "  • Uninstall:    bash $0 --uninstall"
+        echo "  • Disable temporarily: System Settings → General → Login Items"
+        echo "    → 'Allow in the Background' → toggle off Sutando — Health Check"
+        ;;
+    --uninstall|uninstall)
+        echo "Uninstalling $LABEL"
+        bootout_if_loaded
+        if [ -f "$DEST" ]; then
+            rm "$DEST"
+            echo "  Removed $DEST"
+        else
+            echo "  (no plist on disk; nothing to remove)"
+        fi
+        echo "Done."
+        ;;
+    --status|status)
+        echo "Service: $SERVICE"
+        if launchctl print "$SERVICE" >/dev/null 2>&1; then
+            launchctl print "$SERVICE" | grep -E '^\s+(state|pid|last exit code|runs|path)' || true
+        else
+            echo "  (not loaded)"
+        fi
+        ;;
+    *)
+        echo "Usage: $0 [install|--uninstall|--status]" >&2
+        exit 2
+        ;;
+esac

--- a/src/install-health-check-launchd.sh
+++ b/src/install-health-check-launchd.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
-# Install / uninstall the launchd-supervised health-check job.
+# Install / uninstall the launchd-supervised health-check FALLBACK job.
+#
+# Role: OS-level safety net for "all of Sutando is dead." Sutando.app's
+# in-process Timer (PR #613) is the primary 30min health-check while the
+# menu-bar app is alive. This job is the redundant supervisor that keeps
+# running even when Sutando.app exits / crashes / signs out — closing the
+# circular-dependency gap that motivated PR #616.
 #
 # What this does:
-#   - Renders src/launchd/com.sutando.health-check.plist with absolute paths
-#     and writes it to ~/Library/LaunchAgents/com.sutando.health-check.plist
+#   - Renders src/launchd/com.sutando.health-check-fallback.plist with
+#     absolute paths and writes it to
+#     ~/Library/LaunchAgents/com.sutando.health-check-fallback.plist
 #   - Loads it via `launchctl bootstrap gui/$UID` (the modern Sequoia idiom).
 #   - Result: macOS runs `python3 src/health-check.py --emit-task
-#     --notify-on-fail --quiet` every 60s, independent of any other Sutando
+#     --notify-on-fail --quiet` every 5min, independent of any other Sutando
 #     process. Failures surface as tasks (for the agent to act on) AND as
 #     macOS notifications (so the human sees them even if all of Sutando is
 #     dead).
@@ -32,7 +39,7 @@
 
 set -e
 
-LABEL="com.sutando.health-check"
+LABEL="com.sutando.health-check-fallback"
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 TEMPLATE="$REPO/src/launchd/$LABEL.plist"
 DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
@@ -105,7 +112,7 @@ case "$cmd" in
         launchctl bootstrap "$DOMAIN" "$DEST"
         echo "  Loaded via $SERVICE"
         echo
-        echo "Sutando — Health Check is now running every 60s."
+        echo "Sutando — Health Check (fallback) is now running every 5min."
         echo "  • Failures fire macOS notifications + write tasks/task-health-*.txt"
         echo "  • View status:  bash $0 --status"
         echo "  • Uninstall:    bash $0 --uninstall"

--- a/src/launchd/com.sutando.health-check-fallback.plist
+++ b/src/launchd/com.sutando.health-check-fallback.plist
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Sutando — health-check launchd job (template).
+  Sutando — health-check FALLBACK launchd job (template).
+
+  Role: OS-level safety net for "all of Sutando is dead." Sutando.app's
+  in-process Timer (PR #613) is the primary 30min health-check while the
+  menu-bar app is alive. This launchd job is the redundant supervisor
+  that keeps running even when Sutando.app exits / crashes / is signed
+  out, closing the circular-dependency gap (a stuck proactive loop also
+  stops Sutando.app's Timer from being the only check).
+
+  Cadence: every 5min. Higher than #613's 30min so the stuck-loop and
+  task-queue checks (which require 5–10min thresholds before warning)
+  fire promptly. Lower than the original 60s — those underlying
+  thresholds make sub-5min polling redundant.
 
   Installed by `bash src/install-health-check-launchd.sh` after the install
   script substitutes __REPO__, __PYTHON__, and __HOMEBREW_BIN__ with the
@@ -8,10 +20,10 @@
   expanded first.
 
   Behavior:
-    - Fires every 60s (StartInterval).
+    - Fires every 300s (StartInterval).
     - Runs `python3 src/health-check.py --emit-task --notify-on-fail --quiet`.
     - Surfaces failures as tasks/task-health-*.txt AND macOS notifications.
-    - ThrottleInterval=30 prevents crash-loop thrash.
+    - ThrottleInterval=60 prevents crash-loop thrash.
     - Exit-only job (KeepAlive omitted) — launchd waits StartInterval, fires
       again, no zombie process between runs.
     - All output goes to logs/health-check-launchd.log for postmortem.
@@ -19,7 +31,7 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.sutando.health-check</string>
+    <string>com.sutando.health-check-fallback</string>
 
     <key>ProgramArguments</key>
     <array>
@@ -34,13 +46,13 @@
     <string>__REPO__</string>
 
     <key>StartInterval</key>
-    <integer>60</integer>
+    <integer>300</integer>
 
     <key>RunAtLoad</key>
     <true/>
 
     <key>ThrottleInterval</key>
-    <integer>30</integer>
+    <integer>60</integer>
 
     <key>EnvironmentVariables</key>
     <dict>

--- a/src/launchd/com.sutando.health-check.plist
+++ b/src/launchd/com.sutando.health-check.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Sutando — health-check launchd job (template).
+
+  Installed by `bash src/install-health-check-launchd.sh` after the install
+  script substitutes __REPO__, __PYTHON__, and __HOMEBREW_BIN__ with the
+  user's actual paths. Do NOT load this template directly — paths must be
+  expanded first.
+
+  Behavior:
+    - Fires every 60s (StartInterval).
+    - Runs `python3 src/health-check.py --emit-task --notify-on-fail --quiet`.
+    - Surfaces failures as tasks/task-health-*.txt AND macOS notifications.
+    - ThrottleInterval=30 prevents crash-loop thrash.
+    - Exit-only job (KeepAlive omitted) — launchd waits StartInterval, fires
+      again, no zombie process between runs.
+    - All output goes to logs/health-check-launchd.log for postmortem.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.sutando.health-check</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__PYTHON__</string>
+        <string>__REPO__/src/health-check.py</string>
+        <string>--emit-task</string>
+        <string>--notify-on-fail</string>
+        <string>--quiet</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <key>StartInterval</key>
+    <integer>60</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__HOMEBREW_BIN__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__REPO__/logs/health-check-launchd.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__REPO__/logs/health-check-launchd.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/tests/health-check-stuck-loop.test.py
+++ b/tests/health-check-stuck-loop.test.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""
+Tests for the stuck-loop / queue-pileup detection added to health-check.py.
+
+Motivated by the 2026-05-06 incident: 5 voice-queued tasks sat in tasks/ for
+20+ minutes with no processing while core-status.json showed status="running"
+with a 5-day-old timestamp. The detection layer that would have caught this
+didn't exist; it does now.
+
+Covers:
+  Core proactive loop staleness — `check_core_proactive_loop`
+    a) missing core-status.json → ok
+    b) malformed JSON → ok (don't false-alarm on half-written files)
+    c) status != "running" → ok regardless of age
+    d) status="running" with fresh ts → ok
+    e) status="running" with stale ts → warn
+    f) status="running" with no ts → ok (defensive)
+
+  Task-queue pileup — `check_task_queue`
+    g) no tasks dir → ok
+    h) empty queue → ok
+    i) small queue, all fresh → ok
+    j) large queue, all fresh → ok (count alone shouldn't alarm)
+    k) small queue, all old → ok (age alone shouldn't alarm)
+    l) large queue with old oldest → warn
+    m) archive subdir is excluded from the count
+
+  Notification dedup — `notify_for_failures`
+    n) empty failures → no notification
+    o) same set within 1h → only one notification
+    p) different sets → both fire
+    q) all-ok input → no state file touched
+
+Run: python3 tests/health-check-stuck-loop.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Load src/health-check.py as `health_check` (filename has a hyphen, can't
+# import directly).
+spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+
+def make_checks(*statuses_and_names):
+    """[(status, name), ...] → list of check dicts. Mirrors the pattern in
+    health-check-emit-task.test.py."""
+    return [{"name": n, "status": s, "detail": "test"} for (s, n) in statuses_and_names]
+
+
+def write_status(repo_dir: Path, payload: dict | None) -> None:
+    """Write core-status.json into a temp REPO_DIR override; pass None to
+    skip writing the file at all."""
+    if payload is not None:
+        (repo_dir / "core-status.json").write_text(json.dumps(payload))
+
+
+def write_task(tasks_dir: Path, name: str, age_sec: int) -> Path:
+    p = tasks_dir / name
+    p.write_text("test task body")
+    mtime = time.time() - age_sec
+    os.utime(p, (mtime, mtime))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# core-status.json staleness — check_core_proactive_loop
+# ---------------------------------------------------------------------------
+
+def with_repo_override(payload):
+    """Run check_core_proactive_loop against a temp REPO_DIR. Returns the
+    check dict. `payload=None` means don't write the status file."""
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        write_status(td, payload)
+        orig_repo = hc.REPO_DIR
+        try:
+            hc.REPO_DIR = td
+            return hc.check_core_proactive_loop(threshold_sec=600)
+        finally:
+            hc.REPO_DIR = orig_repo
+
+
+def case_a_status_missing() -> list[str]:
+    fails = []
+    r = with_repo_override(None)
+    if r["status"] != "ok":
+        fails.append(f"a) missing core-status.json should be ok, got {r['status']}")
+    return fails
+
+
+def case_b_status_malformed() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        (td / "core-status.json").write_text("{ this is not json")
+        orig = hc.REPO_DIR
+        try:
+            hc.REPO_DIR = td
+            r = hc.check_core_proactive_loop(threshold_sec=600)
+        finally:
+            hc.REPO_DIR = orig
+    if r["status"] != "ok":
+        fails.append(f"b) malformed JSON should be ok (don't false-alarm), got {r['status']}")
+    return fails
+
+
+def case_c_status_not_running() -> list[str]:
+    fails = []
+    # Idle status — even with a very old ts, should be ok.
+    r = with_repo_override({"status": "idle", "ts": int(time.time()) - 86400})
+    if r["status"] != "ok":
+        fails.append(f"c) status=idle should be ok regardless of ts, got {r['status']}")
+    return fails
+
+
+def case_d_running_fresh() -> list[str]:
+    fails = []
+    r = with_repo_override({"status": "running", "step": "doing X", "ts": int(time.time()) - 30})
+    if r["status"] != "ok":
+        fails.append(f"d) running with fresh ts should be ok, got {r['status']} ({r['detail']})")
+    return fails
+
+
+def case_e_running_stale() -> list[str]:
+    fails = []
+    # 5 days old — exactly the failure mode observed.
+    r = with_repo_override({"status": "running", "step": "Pass 361: starting", "ts": int(time.time()) - 5 * 86400})
+    if r["status"] != "warn":
+        fails.append(f"e) running with 5-day-old ts should be warn, got {r['status']} ({r['detail']})")
+    if r["status"] == "warn" and "Pass 361" not in r["detail"]:
+        fails.append(f"e) detail should mention the stuck step, got: {r['detail']}")
+    return fails
+
+
+def case_f_running_no_ts() -> list[str]:
+    fails = []
+    # No ts at all — can't determine staleness, must not false-alarm.
+    r = with_repo_override({"status": "running", "step": "doing X"})
+    if r["status"] != "ok":
+        fails.append(f"f) running with no ts should be ok (defensive), got {r['status']}")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# Task queue pileup — check_task_queue
+# ---------------------------------------------------------------------------
+
+def with_tasks_override(setup_fn):
+    """Run check_task_queue against a temp REPO_DIR/tasks. setup_fn(tasks_dir)
+    populates the queue."""
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        tasks_dir = td / "tasks"
+        if setup_fn is not None:
+            tasks_dir.mkdir(parents=True, exist_ok=True)
+            setup_fn(tasks_dir)
+        orig = hc.REPO_DIR
+        try:
+            hc.REPO_DIR = td
+            return hc.check_task_queue(threshold_count=3, threshold_age_sec=300)
+        finally:
+            hc.REPO_DIR = orig
+
+
+def case_g_no_tasks_dir() -> list[str]:
+    fails = []
+    r = with_tasks_override(None)
+    if r["status"] != "ok":
+        fails.append(f"g) missing tasks dir should be ok, got {r['status']}")
+    return fails
+
+
+def case_h_empty_queue() -> list[str]:
+    fails = []
+    r = with_tasks_override(lambda d: None)
+    if r["status"] != "ok":
+        fails.append(f"h) empty queue should be ok, got {r['status']}")
+    return fails
+
+
+def case_i_small_fresh_queue() -> list[str]:
+    fails = []
+    def setup(d):
+        for i in range(2):
+            write_task(d, f"task-{i}.txt", age_sec=10)
+    r = with_tasks_override(setup)
+    if r["status"] != "ok":
+        fails.append(f"i) 2 fresh tasks should be ok, got {r['status']}")
+    return fails
+
+
+def case_j_large_fresh_queue() -> list[str]:
+    fails = []
+    # Many tasks but all fresh — count alone shouldn't alarm.
+    def setup(d):
+        for i in range(10):
+            write_task(d, f"task-{i}.txt", age_sec=30)
+    r = with_tasks_override(setup)
+    if r["status"] != "ok":
+        fails.append(f"j) 10 fresh tasks should be ok (heavy use is normal), got {r['status']}")
+    return fails
+
+
+def case_k_small_old_queue() -> list[str]:
+    fails = []
+    # Small queue but old — age alone shouldn't alarm. The user might have
+    # 1-2 long-tail tasks that take a while; not stuck.
+    def setup(d):
+        for i in range(2):
+            write_task(d, f"task-{i}.txt", age_sec=600)
+    r = with_tasks_override(setup)
+    if r["status"] != "ok":
+        fails.append(f"k) 2 old tasks should be ok (age alone), got {r['status']}")
+    return fails
+
+
+def case_l_pileup() -> list[str]:
+    fails = []
+    # The actual failure mode: many tasks, oldest is old. Both signals
+    # together → warn.
+    def setup(d):
+        for i in range(5):
+            write_task(d, f"task-{i}.txt", age_sec=600)
+    r = with_tasks_override(setup)
+    if r["status"] != "warn":
+        fails.append(f"l) 5 old tasks should be warn (the actual incident), got {r['status']} ({r['detail']})")
+    return fails
+
+
+def case_m_archive_excluded() -> list[str]:
+    fails = []
+    # Archive subdir at tasks/archive/2026-05/ shouldn't count toward queue
+    # (tasks/*.txt is non-recursive). Many archived tasks + small fresh queue
+    # = ok.
+    def setup(d):
+        archive = d / "archive" / "2026-05"
+        archive.mkdir(parents=True, exist_ok=True)
+        for i in range(20):
+            (archive / f"task-{i}.txt").write_text("archived")
+        # And one fresh queue file.
+        write_task(d, "task-current.txt", age_sec=10)
+    r = with_tasks_override(setup)
+    if r["status"] != "ok":
+        fails.append(f"m) archived files leaked into count: {r['detail']}")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# Notify-on-fail dedup — notify_for_failures
+# ---------------------------------------------------------------------------
+
+def case_n_notify_empty_no_call() -> list[str]:
+    fails = []
+    calls = []
+    with tempfile.TemporaryDirectory() as td:
+        state_file = Path(td) / "state" / "health-last-notified.json"
+        hc.notify_for_failures(
+            make_checks(("ok", "svcA"), ("ok", "svcB")),
+            state_file=state_file,
+            notify_cmd=["true"],  # would always succeed if called, but spy below
+        )
+        # No-failure path returns before invoking notify_cmd. Easier to spy
+        # via state file existence — empty failures must not write state.
+        if state_file.exists():
+            fails.append("n) all-ok input wrote state file (should not)")
+    return fails
+
+
+def case_o_dedup_within_cooldown() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        state_file = Path(td) / "state" / "health-last-notified.json"
+        checks = make_checks(("down", "voice-agent"))
+        # Use `true` as a no-op stand-in so we don't fire real macOS notifs.
+        hc.notify_for_failures(checks, state_file=state_file, notify_cmd=["true"])
+        first = json.loads(state_file.read_text())
+        # Second call with the same set, no time advance — must be deduped.
+        hc.notify_for_failures(checks, state_file=state_file, notify_cmd=["true"])
+        second = json.loads(state_file.read_text())
+        if first != second:
+            fails.append("o) within-cooldown second call updated state (should be no-op)")
+        if len(first) != 1:
+            fails.append(f"o) first call should write 1 history entry, got {len(first)}")
+    return fails
+
+
+def case_p_different_sets_both_fire() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        state_file = Path(td) / "state" / "health-last-notified.json"
+        hc.notify_for_failures(
+            make_checks(("down", "voice-agent")),
+            state_file=state_file, notify_cmd=["true"],
+        )
+        hc.notify_for_failures(
+            make_checks(("down", "discord-bridge")),
+            state_file=state_file, notify_cmd=["true"],
+        )
+        history = json.loads(state_file.read_text())
+        if len(history) != 2:
+            fails.append(f"p) two different sets should produce 2 history entries, got {len(history)}")
+    return fails
+
+
+def case_q_separate_state_from_emit() -> list[str]:
+    """notify and emit_task must use DIFFERENT default state files so they
+    can't mutually suppress each other. Verifies that notify_for_failures
+    writes its own state file under state/health-last-notified.json and not
+    the emit-task path state/health-last-alerted.json."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        orig = hc.REPO_DIR
+        try:
+            hc.REPO_DIR = td
+            hc.notify_for_failures(make_checks(("down", "svc")), notify_cmd=["true"])
+        finally:
+            hc.REPO_DIR = orig
+        notified = td / "state" / "health-last-notified.json"
+        alerted = td / "state" / "health-last-alerted.json"
+        if not notified.exists():
+            fails.append("q) notify_for_failures default state file not at state/health-last-notified.json")
+        if alerted.exists():
+            fails.append("q) notify_for_failures wrote to emit-task's state file (must be separate)")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    cases = [
+        ("a", case_a_status_missing),
+        ("b", case_b_status_malformed),
+        ("c", case_c_status_not_running),
+        ("d", case_d_running_fresh),
+        ("e", case_e_running_stale),
+        ("f", case_f_running_no_ts),
+        ("g", case_g_no_tasks_dir),
+        ("h", case_h_empty_queue),
+        ("i", case_i_small_fresh_queue),
+        ("j", case_j_large_fresh_queue),
+        ("k", case_k_small_old_queue),
+        ("l", case_l_pileup),
+        ("m", case_m_archive_excluded),
+        ("n", case_n_notify_empty_no_call),
+        ("o", case_o_dedup_within_cooldown),
+        ("p", case_p_different_sets_both_fire),
+        ("q", case_q_separate_state_from_emit),
+    ]
+    all_failures = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            all_failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if all_failures:
+        print(f"\n{len(all_failures)} failure(s)")
+        return 1
+    print("\nAll stuck-loop / queue-pileup invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
@sonichi — eval/quality follow-up to #569.

## Issue

On 2026-05-06 I voice-queued 4 tasks. None were processed. `tasks/` held them for 20+ minutes; no result was ever delivered. The voice agent kept conversing fluently and confabulated plausible status (*"the task timed out"*) because nothing in the pipeline could tell it the work hadn't run.

## Root cause

Two failures stacked:

1. `watch-tasks.sh` exits on first event by design; its caller (the proactive loop) is supposed to restart it. The caller was stuck.
2. `core-status.json` showed `status="running"` with a `ts` 5 days old — a `/proactive-loop` pass crashed mid-execution and the loop never re-armed.

Neither layer has a supervisor. `emit_task_for_failures` (PR #607) would surface failures, but `health-check.py` is invoked *from* the proactive loop — when the loop is stuck, health-check doesn't run either. Circular dependency.

## Fix — one mechanism, three parts

**1. Two new checks** in `health-check.py`:

- `check_core_proactive_loop()` — warns when `core-status.json` shows `running` with `ts > threshold_sec` (default 600s). Defensive on missing/malformed.
- `check_task_queue()` — warns when `tasks/*.txt` count > 3 **AND** oldest > 300s. Both signals together filter transient spikes from legitimate heavy use. Excludes `tasks/archive/`.
- Thresholds overridable via `SUTANDO_HEALTH_LOOP_STALE_SEC`, `SUTANDO_HEALTH_QUEUE_AGE_SEC`, `SUTANDO_HEALTH_QUEUE_COUNT`.

**2. Independent invocation** — launchd LaunchAgent:

- `src/launchd/com.sutando.health-check.plist` (template, paths substituted at install).
- `src/install-health-check-launchd.sh` — `launchctl bootstrap gui/$UID`. Idempotent. `--uninstall` and `--status` modes.
- Runs `python3 src/health-check.py --emit-task --notify-on-fail --quiet` every 60s. Independent of any Sutando process — closes the circular dependency.

**3. New surface** — `--notify-on-fail` flag:

- Companion to `--emit-task`. Same dedup contract (per-failure-set hash, 1h cooldown), **separate state file** (`state/health-last-notified.json`) so the surfaces can't suppress each other.
- Why two: emit-task only delivers if the agent is alive to read `tasks/`. `osascript` runs at OS level — surfaces even when every Sutando service is dead. Robustness comes from disjoint failure modes.

## Onboarding impact

**Strictly opt-in.** `startup.sh` is not touched. Default `git clone` → first voice reply path is unchanged. No new TCC permissions.

A user who runs the install script sees, once: a macOS "Background Item Added" banner, and a "Sutando — Health Check" entry in System Settings → Login Items they can disable any time without breaking the rest of Sutando. README updated with one row in Optional integrations + one line in Uninstalling.

## Considered alternatives

- *"Why not extend Sutando.app to run health-check on a timer?"* — the menu-bar app is itself a Sutando-managed Login Item; if it crashes, no detection. launchd is the OS supervisor. More robust.
- *"Why not bundle auto-fix?"* — restarting a stuck `claude` proactive loop kills in-flight work. Detection-first is safer to land. Recovery can build on this once we see real data.
- *"Why not refactor the dedup helper between emit-task and notify?"* — duplication is small (~25 lines), and CLAUDE.md prefers no premature abstractions. Easy follow-up if the helper grows a third user.

## Test

- `tests/health-check-stuck-loop.test.py` — 17 cases (modeled on PR #610 conventions): missing/malformed/idle/fresh/stale `core-status.json`; empty/small/large/old/archive-excluded queue states; notify dedup (empty/within-cooldown/different-sets/separate-state-from-emit).
- `npm test`: passes (existing emit-task tests + 17 new stuck-loop tests).
- `tsc --noEmit`: clean.
- `plutil -lint` on rendered plist: OK.
- Live verification: ran `health-check` on the stuck system that motivated this PR; the new checks reported `ok` on healthy state (no false-alarm) and would have reported `warn` at the moment of the original incident.