### PR TITLE
fix(voice-agent): back off health-monitor reconnect on non-retryable closes

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -870,6 +870,17 @@ async function main() {
 
 	sessionRef = session;
 
+	// Bumped 5min into the future on every non-retryable transport close
+	// (set inside the classifier IIFE below). Read by the 30s health
+	// monitor — when the deadline is in the future, the monitor skips its
+	// reconnect-trigger so a permanent upstream failure (credits depleted,
+	// key invalid, quota exceeded) doesn't produce a tight 60s retry loop
+	// that spams logs + Gemini API requests until the user fixes things.
+	// Auto-recovery resumes ~5min after the last fatal close. Reset to 0
+	// when the session reaches ACTIVE so a transient close after recovery
+	// doesn't inherit a stale backoff window.
+	let voiceFatalBackoffUntil = 0;
+
 	// Wire voice-failure classifier: when the Gemini Live transport closes
 	// with a non-retryable reason (credits depleted, quota exceeded, key
 	// invalid, model not found), surface an actionable message via the
@@ -887,6 +898,12 @@ async function main() {
 		const notifiedCategories = new Set<string>();
 		const handleClose = (c: ClassifiedClose): void => {
 			if (c.retryable) return;
+			// Push the health-monitor reconnect window out by 5min on every
+			// non-retryable close — including repeats of an already-notified
+			// category — so the 60s retry loop doesn't keep firing while the
+			// upstream issue persists. Without this, a 1011 credit-depleted
+			// loop produces ~6 log lines / 60s indefinitely.
+			voiceFatalBackoffUntil = Date.now() + 5 * 60 * 1000;
 			if (notifiedCategories.has(c.category)) return;
 			notifiedCategories.add(c.category);
 			console.error(`${ts()} [VoiceFailure] ${c.category}: ${c.userMessage} (raw="${c.rawReason}")`);
@@ -1210,11 +1227,18 @@ async function main() {
 			console.log(`${ts()} [Health] ${status}`);
 			lastLoggedStatus = status;
 		}
+		// Clear any stale fatal-backoff once we observe a healthy session —
+		// otherwise a brief outage that triggered a backoff would suppress
+		// recovery from a later transient close even after the upstream
+		// issue was fixed.
+		if (state === 'ACTIVE' && voiceFatalBackoffUntil > 0) {
+			voiceFatalBackoffUntil = 0;
+		}
 		// Recover when session is CLOSED and a client is waiting. handleClientConnected
 		// is bodhi's internal entry point for this exact scenario (CLOSED + client
 		// present → transition to CONNECTING, reconnect fire-and-forget).
 		// TODO: drop the (session as any) cast once bodhi exposes a public API.
-		if (state === 'CLOSED' && clientConnected && Date.now() - lastReconnectAt > 60_000) {
+		if (state === 'CLOSED' && clientConnected && Date.now() - lastReconnectAt > 60_000 && Date.now() > voiceFatalBackoffUntil) {
 			lastReconnectAt = Date.now();
 			console.log(`${ts()} [Health] Dead session — triggering reconnect`);
 			try {


### PR DESCRIPTION
## Summary

When the Gemini Live transport closes for a **non-retryable** reason (1011 credits depleted, 1011 quota exceeded, 401/403 auth, model not found), voice-agent's health monitor keeps triggering reconnect every 60s. Each attempt fails after a 30s timeout, producing ~6 log lines/min indefinitely.

Reproduced live this session (Studio): 17 instances of `code=1011 reason="prepayment credits depleted"` in a 5-min window while `clientConnected=true`. Snippet from `logs/voice-agent.log`:

```
01:34:53.575 [Health] Dead session — triggering reconnect
01:34:53.992 [VoiceSession] Transport closed (state=CONNECTING code=1011 reason="prepayment credits depleted...")
01:35:23.572 [Health] state=CONNECTING client=true
01:35:23.735 [VoiceSession] Gemini reconnect failed: Gemini connect timed out after 30000ms
01:35:53.575 [Health] Dead session — triggering reconnect
... (repeats ad infinitum)
```

The voice-failure classifier already does the right thing on the *first* fatal close — fires the OS notification + writes the actionable proactive-result file once per category. This PR just stops the retry loop after the user has been told.

PR #602 (idle teardown, already approved) handles the *no-client* case. This is the *active-client + permanent-upstream-failure* case — disjoint, no merge-order dependency.

## Fix

New `voiceFatalBackoffUntil` deadline (one closure-scoped `let`, same scope as the existing `lastReconnectAt`):

- **Bumped** to `Date.now() + 5min` on every non-retryable close — including repeats of an already-notified category. Lives next to the dedup so the bump fires even when the per-category notification is suppressed.
- **Read** by the 30s health monitor's reconnect-trigger condition. Monitor skips `handleClientConnected()` when the deadline is in the future. Reconnect cycle drops 60s → ~5min during a persistent outage.
- **Reset to 0** when the monitor observes `state=ACTIVE` — recovery from a transient close after the user fixed the upstream issue is not suppressed by a stale fatal window.

No new env vars, no new exposed constants. ~25 lines including comments.

## Why not unconditional 5-min throttle

Today's 60s throttle handles transient network blips well. Slowing every reconnect would degrade UX during normal flaps. Better to slow only the cases the classifier already knows are fatal.

## Why not stop reconnecting entirely on fatal

Top-ups and key rotations often resolve without restarting voice-agent. A 5min auto-recovery window keeps the agent self-healing. Stopping permanently would require manual restart.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 154/154 ts + all py green
- [x] Trace-through verified for the 1011 + recovery + transient-after-recovery scenarios (see commit message).
- [ ] (manual, gated on credit top-up) Restart voice-agent on this branch, observe a single classifier line + ~5min silence + auto-reconnect when credits return — vs the current 1011-spam baseline.

## Notes

- Disjoint from PR #602 (idle teardown) — different region of `voice-agent.ts`. Either order merges cleanly.
- The classifier-aware backoff approach was chosen over a flat 5min throttle (would slow normal flaps) and over a "stop permanently on fatal" approach (would lose auto-recovery on top-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)