### PR TITLE
feat(voice-agent): VOICE_NAME env var for Gemini Live synthesis voice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,13 @@ PORT=9900
 # Native audio model (STT+LLM+TTS in one round trip for real-time voice)
 # VOICE_NATIVE_AUDIO_MODEL=gemini-3.1-flash-live-preview
 
+# Gemini Live prebuilt synthesis voice (default: Puck).
+# Male-perceived: Puck, Charon, Fenrir, Orus
+# Female-perceived: Aoede, Kore, Zephyr
+# Newer models also expose: Leda, Sulafat, Algenib, Despina
+# Unsupported names fail at Gemini setup-complete (WebSocket close 1007).
+# VOICE_NAME=Puck
+
 # Screen vision model (20-word screenshot descriptions — flash-lite is cheapest)
 # VISION_MODEL=gemini-3.1-flash-lite-preview
 

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -818,7 +818,7 @@ async function main() {
 		host: HOST,
 		model: google(VOICE_MODEL),
 		geminiModel: VOICE_NATIVE_AUDIO_MODEL,
-		speechConfig: { voiceName: 'Puck' },
+		speechConfig: { voiceName: process.env.VOICE_NAME || 'Puck' },
 		inputAudioTranscription: true,
 		hooks: {
 			onSessionStart: (e) => {


### PR DESCRIPTION
## Issue

Voice synthesis voice was hardcoded to `'Puck'` at [src/voice-agent.ts:821](https://github.com/sonichi/sutando/blob/main/src/voice-agent.ts#L821). Changing it required a code edit + restart. Users who want to try a different prebuilt Gemini Live voice (Aoede, Kore, Charon, etc.) shouldn't need to touch source.

## Fix

Read `VOICE_NAME` from `process.env`, fall back to `'Puck'` on unset. Matches the existing `VOICE_*` prefix used by `VOICE_MODEL` and `VOICE_NATIVE_AUDIO_MODEL`.

Documented in `.env.example` under MODEL CONFIGURATION with the list of prebuilt voice names and the close-code (1007) that fires on an unsupported name.

```diff
- speechConfig: { voiceName: 'Puck' },
+ speechConfig: { voiceName: process.env.VOICE_NAME || 'Puck' },
```

## Test

- `tsc --noEmit`: clean.
- `npm test`: 154/154 pass (no test changes — single-line env-var read).
- Live verification: `VOICE_NAME=Aoede` resolves to `"Aoede"`; unset resolves to default `"Puck"`.