### PR TITLE
fix(task-bridge): dedup duplicate work() submissions while same-text task is pending

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -77,6 +77,51 @@ const DEFAULT_TASK_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes default
 type PendingTask = { submittedAt: number; timeoutMs: number; dmOnTimeout: boolean };
 const _pendingTasks = new Map<string, PendingTask>();
 
+// Submit-side dedup map — issue #561. Keyed by taskId, value is the
+// normalized task text. Used by workTool to detect "same task already in
+// flight" and return the existing taskId rather than spawning a parallel
+// duplicate. Cleared on every _pendingTasks.delete site below so a task
+// text legitimately re-submitted after its first attempt finishes (or
+// times out) is treated as fresh work.
+const _pendingTaskTexts = new Map<string, string>();
+
+/** Normalize task text for dedup comparison: lowercase, collapse runs of
+ *  whitespace to single space, trim, and cap at the first 150 chars.
+ *  Cap is intentional — voice users phrasing the same intent two slightly-
+ *  different ways ("summarize the call" vs "summarize that call I just
+ *  had") tend to differ in suffix, not prefix; a normalized prefix match
+ *  catches the common dedup case while staying conservative on near-
+ *  duplicates that are actually different work. */
+export function _normalizeTaskTextForDedup(s: string): string {
+	return s.toLowerCase().replace(/\s+/g, ' ').trim().slice(0, 150);
+}
+
+/** Check whether a normalized text matches any currently-pending task that
+ *  has not yet timed out. Returns the matching taskId or null. Exported for
+ *  testability — the dedup decision in workTool is a one-liner that calls
+ *  this. */
+export function _findActivePendingByText(normalized: string, now: number = Date.now()): string | null {
+	for (const [existingTaskId, existingNormalized] of _pendingTaskTexts) {
+		if (existingNormalized !== normalized) continue;
+		const pending = _pendingTasks.get(existingTaskId);
+		if (!pending) continue;
+		// timeoutMs === 0 means "no timeout" — always considered active until
+		// the result watcher cleans it up. Otherwise, only dedup against
+		// non-timed-out submissions.
+		if (pending.timeoutMs !== 0 && now - pending.submittedAt > pending.timeoutMs) continue;
+		return existingTaskId;
+	}
+	return null;
+}
+
+/** Test-only: clear both pending maps. Module state survives across tests
+ *  in the same process, so each describe block calls this in `before` /
+ *  `afterEach`. */
+export function _resetPendingForTests(): void {
+	_pendingTasks.clear();
+	_pendingTaskTexts.clear();
+}
+
 /** True if the task file (in tasks/, tasks/processed/, or tasks/archive/)
  * is voice-originated (channel_id: local-voice). Used by the result watcher
  * to decide whether to forward an unsent result to Discord DM when voice is
@@ -187,6 +232,22 @@ export const workTool: ToolDefinition = {
 			console.log(`${ts()} [TaskBridge] WARNING: watcher offline — task will be queued for next cron pass`);
 		}
 
+		// Submit-side dedup (issue #561). Voice users repeating "the same
+		// thing" — usually because the previous submission is taking too
+		// long — used to spawn a parallel duplicate that doubled work and
+		// produced two spoken results. Now: if a same-text task is already
+		// pending and not timed out, return the existing taskId.
+		const normalizedText = _normalizeTaskTextForDedup(task);
+		const existingTaskId = _findActivePendingByText(normalizedText);
+		if (existingTaskId !== null) {
+			console.log(`${ts()} [TaskBridge] Dedup: same-text task already pending as ${existingTaskId}; not spawning duplicate`);
+			return {
+				status: 'pending',
+				taskId: existingTaskId,
+				message: `Already working on this — task ${existingTaskId} is still in flight. The result will be spoken when ready. Tell the user you're already on it; do not re-confirm or re-acknowledge.`,
+			};
+		}
+
 		const taskId = `task-${Date.now()}`;
 		const timestamp = new Date().toISOString();
 		const ownerId = process.env.SUTANDO_DM_OWNER_ID || 'voice-local';
@@ -212,6 +273,7 @@ export const workTool: ToolDefinition = {
 		// default was producing unwanted DMs). Caller must explicitly pass
 		// dm_on_timeout: true on critical tasks where they want the fallback.
 		_pendingTasks.set(taskId, { submittedAt: Date.now(), timeoutMs, dmOnTimeout: dm_on_timeout === true });
+		_pendingTaskTexts.set(taskId, normalizedText);
 		// Record owner activity for status-aware-pivot in proactive loop
 		writeOwnerActivity('voice', task);
 		console.log(`${ts()} [TaskBridge] Task ${taskId}: ${task.slice(0, 100)}`);
@@ -435,6 +497,7 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 			if (timeoutMs === 0) continue;
 			if (Date.now() - submittedAt > timeoutMs) {
 				_pendingTasks.delete(taskId);
+				_pendingTaskTexts.delete(taskId);
 				// Read the task body (or a snippet of it) so the timeout message
 				// can identify which task timed out — the prior generic "[Task
 				// timed out]" string left no clue when multiple tasks were in
@@ -512,6 +575,7 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					_sendTaskStatus?.(taskId, 'done', result.slice(0, 60), result);
 					_deliveredResults.add(file);
 					_pendingTasks.delete(taskId);
+					_pendingTaskTexts.delete(taskId);
 					try {
 						fetch('http://localhost:7843/task-done', {
 							method: 'POST',
@@ -540,6 +604,7 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 							console.log(`${ts()} [TaskBridge] Voice offline; forwarded ${taskId} result to Discord DM via ${proactivePath}`);
 							_deliveredResults.add(file);
 							_pendingTasks.delete(taskId);
+							_pendingTaskTexts.delete(taskId);
 							setTimeout(() => {
 								archiveFile(path, 'results', taskId);
 								const taskFile = join(TASK_DIR, `${taskId}.txt`);
@@ -557,6 +622,7 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					_sendTaskStatus?.(taskId, 'done', result.slice(0, 60), result);
 					_deliveredResults.add(file);
 					_pendingTasks.delete(taskId);
+					_pendingTaskTexts.delete(taskId);
 					logConversation('core-agent', `[task:${taskId}] ${result.slice(0, LOG_LINE_MAX_CHARS)}`);
 					onResult(result);
 					// Notify agent-api directly, then delete file

--- a/tests/task-bridge-dedup.test.ts
+++ b/tests/task-bridge-dedup.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, before, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, unlinkSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+	workTool,
+	_normalizeTaskTextForDedup,
+	_findActivePendingByText,
+	_resetPendingForTests,
+} from '../src/task-bridge.js';
+
+// Submit-side dedup invariants for issue #561. The voice `work` tool used
+// to spawn parallel duplicate task files when the user repeated the same
+// intent (because the previous submission was taking too long). After this
+// fix, a same-text submission while the previous one is still pending
+// returns the existing taskId and writes no new file.
+//
+// Test isolation: tests run in parallel by default, and task-bridge-format
+// test's leak check would false-fire on any extra files we leave behind
+// during interleaved execution. So we only call the file-writing path
+// (`workTool.execute`) inside ONE focused test, with synchronous cleanup,
+// and otherwise drive the dedup logic through the pure helpers
+// (`_normalizeTaskTextForDedup`, `_findActivePendingByText`,
+// `_resetPendingForTests`).
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const TASK_DIR = join(REPO_ROOT, 'tasks');
+
+describe('_normalizeTaskTextForDedup', () => {
+	it('lowercases and collapses whitespace', () => {
+		assert.equal(_normalizeTaskTextForDedup('  Foo   BAR\tbaz  '), 'foo bar baz');
+	});
+	it('caps at 150 chars (defensive against giant inputs)', () => {
+		const long = 'a'.repeat(200);
+		assert.equal(_normalizeTaskTextForDedup(long).length, 150);
+	});
+	it('handles empty input', () => {
+		assert.equal(_normalizeTaskTextForDedup(''), '');
+	});
+	it('treats case + whitespace variants as equal', () => {
+		const a = _normalizeTaskTextForDedup('Summarize THE meeting notes');
+		const b = _normalizeTaskTextForDedup('  summarize   the  MEETING\tnotes  ');
+		assert.equal(a, b);
+	});
+});
+
+describe('_findActivePendingByText (dedup decision)', () => {
+	beforeEach(() => _resetPendingForTests());
+
+	it('returns null when nothing pending', () => {
+		assert.equal(_findActivePendingByText('foo'), null);
+	});
+
+	it('returns the matching taskId after a workTool submission', async () => {
+		// One controlled file write — clean up immediately so format.test's
+		// leak check never sees this file.
+		const r = await workTool.execute({ task: 'dedup-helper-test-AAA' } as any, null as any) as any;
+		try {
+			assert.ok(r.taskId);
+			assert.equal(_findActivePendingByText('dedup-helper-test-aaa'), r.taskId);
+			assert.equal(_findActivePendingByText('something different'), null);
+		} finally {
+			try { unlinkSync(join(TASK_DIR, `${r.taskId}.txt`)); } catch {}
+			_resetPendingForTests();
+		}
+	});
+
+	it('case + whitespace variant of submitted text matches the pending taskId', async () => {
+		const r = await workTool.execute({ task: 'Summarize THE meeting notes' } as any, null as any) as any;
+		try {
+			// _findActivePendingByText takes a *normalized* string — caller
+			// (workTool.execute) does the normalization before lookup.
+			const variantNormalized = _normalizeTaskTextForDedup('  summarize   the  MEETING\tnotes  ');
+			assert.equal(_findActivePendingByText(variantNormalized), r.taskId);
+		} finally {
+			try { unlinkSync(join(TASK_DIR, `${r.taskId}.txt`)); } catch {}
+			_resetPendingForTests();
+		}
+	});
+});
+
+describe('workTool dedup behavior (issue #561) — single-write scenario', () => {
+	let createdTaskIds: string[] = [];
+
+	before(() => {
+		mkdirSync(TASK_DIR, { recursive: true });
+	});
+
+	beforeEach(() => {
+		_resetPendingForTests();
+		createdTaskIds = [];
+	});
+
+	afterEach(() => {
+		for (const id of createdTaskIds) {
+			try { unlinkSync(join(TASK_DIR, `${id}.txt`)); } catch {}
+		}
+		createdTaskIds = [];
+	});
+
+	async function submit(task: string): Promise<{ taskId: string; status: string; message?: string }> {
+		const r = await workTool.execute({ task } as any, null as any) as any;
+		assert.ok(r.taskId);
+		if (!createdTaskIds.includes(r.taskId)) createdTaskIds.push(r.taskId);
+		return r;
+	}
+
+	it('duplicate submission returns the same taskId; original file still on disk', async () => {
+		const r1 = await submit('dedup-flow-BBB');
+		const r2 = await submit('dedup-flow-BBB');
+
+		assert.equal(r2.taskId, r1.taskId, 'second submission returns first taskId');
+		assert.equal(r2.status, 'pending');
+		assert.match(r2.message ?? '', /already working|in flight/i);
+		// The single shared file (from r1) exists.
+		assert.ok(existsSync(join(TASK_DIR, `${r1.taskId}.txt`)));
+	});
+
+	it('after pending is cleared (task completed), same text spawns fresh task', async () => {
+		const r1 = await submit('dedup-flow-EEE');
+		_resetPendingForTests(); // simulates result-watcher cleanup
+		const r2 = await submit('dedup-flow-EEE');
+
+		assert.notEqual(r2.taskId, r1.taskId, 'fresh taskId after pending was cleared');
+	});
+});


### PR DESCRIPTION
Closes #561.

## Problem

`workTool` (`src/task-bridge.ts:90-165`) creates a fresh `task-${Date.now()}.txt` on every call. There was no submit-side content check. When a voice user repeated the same intent — usually because the previous one was taking too long — two identical task files landed in the queue, both flushed through, and both produced duplicate spoken results. Susan reproduced 2026-04-30 with three near-identical tasks within ~30s ([issue #561](https://github.com/sonichi/sutando/issues/561)).

## Fix

Matches Susan's proposed sketch in the issue with one efficiency tweak (in-memory parallel map instead of per-submit file I/O):

- New `_pendingTaskTexts: Map<taskId, normalizedText>` alongside the existing `_pendingTasks`.
- New pure helpers `_normalizeTaskTextForDedup(s)` (lowercase + collapse whitespace + 150-char cap) and `_findActivePendingByText(normalized)` (returns matching active taskId or null, skipping timed-out entries).
- `workTool.execute()` calls the helper before writing; on match, returns the existing taskId with `status: 'pending'` and a "Already working on this" message. **Skips the file write.**
- Cleanup wired into all 4 existing `_pendingTasks.delete(taskId)` sites in the result watcher (timeout, deduped-marker, voice-offline-forward, normal-done) so the dedup window closes when the original task completes.

## Edge cases (covered)

| Scenario | Behavior |
|---|---|
| Same task across different sessions | Maps clear on process exit → no false dedup |
| Task re-submitted after previous one finished | Cleanup path clears the entry → fresh task spawns |
| Near-duplicates ("the call" vs "that call") | 150-char prefix exact match — intentionally conservative |
| Timed-out pending entries | `_findActivePendingByText` skips them — stale entries don't suppress |

## Out of scope (per issue)

- Cross-process dedup across phone / Discord / Telegram entry paths. Voice is the dominant duplicate source today; other paths can layer this in if observed.
- Fuzzy / embedding similarity. Prefix-exact is sufficient for the observed failure mode.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` 163/163 ts + all py tests green (was 154 baseline; +9 new in `tests/task-bridge-dedup.test.ts`)
- [x] No file leakage in `tasks/` after full suite
- [ ] **Manual voice verification (gated on Gemini credit top-up)**: ask voice agent "summarize my last meeting"; while it's working, ask the same question — expect "already working on this" instead of a parallel duplicate task.

## Test isolation note

Node's test runner runs files in parallel by default. Since `task-bridge-format.test.ts` has its own leak check on `TASK_DIR`, this PR's tests use specific taskIds for cleanup (no directory scanning) and call `workTool.execute` only inside controlled `try/finally` blocks. Verified clean co-execution.

## Why in-memory map vs Susan's sketch

Susan's sketch suggested walking `_pendingTasks` keys and reading the task file for each on every submit. Equivalent semantics, but O(N) file I/O on every voice submission. The parallel `_pendingTaskTexts` map gives O(1) lookup with no syscalls. Same dedup decision, less work on the hot path.

cc: @sonichi @liususan091219 — Susan's sketch landed almost verbatim; only the lookup mechanism differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)