### PR TITLE
fix(task-bridge): _isVoiceTask scans month-partitioned archive subdirs

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -77,18 +77,35 @@ const DEFAULT_TASK_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes default
 type PendingTask = { submittedAt: number; timeoutMs: number; dmOnTimeout: boolean };
 const _pendingTasks = new Map<string, PendingTask>();
 
-/** True if the task file (in tasks/, tasks/processed/, or tasks/archive/)
- * is voice-originated (channel_id: local-voice). Used by the result watcher
+/** True if the task file (in tasks/, tasks/processed/, or tasks/archive/
+ * — including month-partitioned subdirs `tasks/archive/YYYY-MM/`) is
+ * voice-originated (channel_id: local-voice). Used by the result watcher
  * to decide whether to forward an unsent result to Discord DM when voice is
  * offline. Returns false on missing file or parse error — bias toward not
  * forwarding to keep Susan-rejected always-DM behavior off by default for
  * non-voice tasks. */
-function _isVoiceTask(taskId: string): boolean {
-	const candidates = [
+export function _isVoiceTask(taskId: string): boolean {
+	const candidates: string[] = [
 		join(TASK_DIR, `${taskId}.txt`),
 		join(TASK_DIR, 'processed', `${taskId}.txt`),
+		// Legacy flat-archive location — kept for any task archived before
+		// the YYYY-MM partitioning (PR #591) was introduced.
 		join(TASK_DIR, 'archive', `${taskId}.txt`),
 	];
+	// Active archive layout: tasks/archive/YYYY-MM/<taskId>.txt. Glob the
+	// month subdirs rather than rebuild the YYYY-MM from the task's mtime —
+	// the writer's archive month and current month can differ around month
+	// boundaries.
+	const archiveRoot = join(TASK_DIR, 'archive');
+	if (existsSync(archiveRoot)) {
+		try {
+			for (const entry of readdirSync(archiveRoot)) {
+				// Only month-shaped names (YYYY-MM); skip stray files.
+				if (!/^\d{4}-\d{2}$/.test(entry)) continue;
+				candidates.push(join(archiveRoot, entry, `${taskId}.txt`));
+			}
+		} catch {}
+	}
 	for (const p of candidates) {
 		if (!existsSync(p)) continue;
 		try {

--- a/tests/task-bridge-isvoice.test.ts
+++ b/tests/task-bridge-isvoice.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, before, after, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, existsSync, unlinkSync, mkdirSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { _isVoiceTask } from '../src/task-bridge.js';
+
+// Regression for the archive-path drift bug flagged by VasiliyRad 2026-05-06:
+// `archiveFile()` writes to `tasks/archive/YYYY-MM/<taskId>.txt`, but
+// `_isVoiceTask()` only checked the legacy flat path `tasks/archive/<taskId>.txt`.
+// That meant the offline-forwarding gate in the result watcher misclassified
+// every archived voice task as non-voice, suppressing DM-fallback delivery.
+//
+// These tests lock in: live + processed + legacy-flat-archive + month-partitioned-
+// archive lookup all surface a voice task; non-voice content stays false; missing
+// task files stay false.
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const TASK_DIR = join(REPO_ROOT, 'tasks');
+const ARCHIVE_DIR = join(TASK_DIR, 'archive');
+
+const VOICE_BODY = `id: task-isvoice-test-aaa
+timestamp: 2026-05-06T00:00:00Z
+task: hello world
+source: voice
+channel_id: local-voice
+`;
+const NON_VOICE_BODY = `id: task-isvoice-test-bbb
+timestamp: 2026-05-06T00:00:00Z
+task: hello world
+source: discord
+channel_id: 1490906927675474030
+`;
+
+const created: string[] = [];
+function writeTask(path: string, body: string) {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, body);
+	created.push(path);
+}
+
+describe('_isVoiceTask — archive-path coverage', () => {
+	afterEach(() => {
+		for (const p of created.splice(0)) {
+			try { unlinkSync(p); } catch {}
+		}
+	});
+
+	it('returns true for a voice task in the live tasks/ dir', () => {
+		const id = 'task-isvoice-test-live-aaa';
+		writeTask(join(TASK_DIR, `${id}.txt`), VOICE_BODY);
+		assert.equal(_isVoiceTask(id), true);
+	});
+
+	it('returns true for a voice task in tasks/processed/', () => {
+		const id = 'task-isvoice-test-proc-aaa';
+		writeTask(join(TASK_DIR, 'processed', `${id}.txt`), VOICE_BODY);
+		assert.equal(_isVoiceTask(id), true);
+	});
+
+	it('returns true for a voice task in legacy flat tasks/archive/', () => {
+		const id = 'task-isvoice-test-flat-aaa';
+		writeTask(join(ARCHIVE_DIR, `${id}.txt`), VOICE_BODY);
+		assert.equal(_isVoiceTask(id), true);
+	});
+
+	it('returns true for a voice task in month-partitioned tasks/archive/YYYY-MM/ — the bug fix', () => {
+		const id = 'task-isvoice-test-month-aaa';
+		writeTask(join(ARCHIVE_DIR, '2026-05', `${id}.txt`), VOICE_BODY);
+		assert.equal(_isVoiceTask(id), true);
+	});
+
+	it('finds a voice task across multiple month subdirs', () => {
+		// The taskId may live in any historical month; the function must scan
+		// all month-shaped subdirs, not just the current month.
+		const id = 'task-isvoice-test-old-month-aaa';
+		writeTask(join(ARCHIVE_DIR, '2026-01', `${id}.txt`), VOICE_BODY);
+		assert.equal(_isVoiceTask(id), true);
+	});
+
+	it('returns false for a non-voice task in month-partitioned archive', () => {
+		const id = 'task-isvoice-test-nonvoice-aaa';
+		writeTask(join(ARCHIVE_DIR, '2026-05', `${id}.txt`), NON_VOICE_BODY);
+		assert.equal(_isVoiceTask(id), false);
+	});
+
+	it('ignores non-month-shaped subdirs (e.g. "done", "tmp")', () => {
+		// Stray subdirs under tasks/archive/ shouldn't trip the regex; they
+		// won't be scanned. Negative-control: a voice task placed under a
+		// non-month-shaped subdir is NOT found, confirming the regex gate.
+		const id = 'task-isvoice-test-stray-subdir-aaa';
+		writeTask(join(ARCHIVE_DIR, 'done', `${id}.txt`), VOICE_BODY);
+		assert.equal(_isVoiceTask(id), false);
+	});
+
+	it('returns false when the task file is missing entirely', () => {
+		assert.equal(_isVoiceTask('task-isvoice-test-no-such-file'), false);
+	});
+});


### PR DESCRIPTION
## Summary

Concrete path-drift bug found by @VasiliyRad during 2026-05-06 task-bridge review. `archiveFile()` (line 47) writes archived task files into `tasks/archive/YYYY-MM/<taskId>.txt` (PR #591's month-partitioning layout), but `_isVoiceTask()` (line 86) only checked the legacy flat path `tasks/archive/<taskId>.txt`. After archive, voice classification silently fell back to false — the offline-forwarding gate at `task-bridge.ts:535` then misclassified archived voice tasks as non-voice and suppressed DM-fallback delivery for them.

## Fix

Walk month subdirs under `tasks/archive/`, regex-gated to `YYYY-MM` names (skips stray subdirs like `done/`, `tmp/`). Legacy flat-archive path retained as a fallback for any task archived pre-#591.

```diff
+	// Active archive layout: tasks/archive/YYYY-MM/<taskId>.txt. Glob the
+	// month subdirs rather than rebuild the YYYY-MM from the task's mtime —
+	// the writer's archive month and current month can differ around month
+	// boundaries.
+	const archiveRoot = join(TASK_DIR, 'archive');
+	if (existsSync(archiveRoot)) {
+		try {
+			for (const entry of readdirSync(archiveRoot)) {
+				if (!/^\d{4}-\d{2}$/.test(entry)) continue;
+				candidates.push(join(archiveRoot, entry, `${taskId}.txt`));
+			}
+		} catch {}
+	}
```

## Tests

New file `tests/task-bridge-isvoice.test.ts` — 8 cases:
- Voice task in live `tasks/` → true
- Voice task in `tasks/processed/` → true
- Voice task in legacy flat `tasks/archive/` → true
- **Voice task in month-partitioned `tasks/archive/YYYY-MM/` → true (the fix)**
- Voice task in older month subdir (e.g. `2026-01/`) → true
- Non-voice task in month-partitioned archive → false
- Stray non-month-shaped subdir (`done/`) ignored → false
- Missing file → false

All pass.

`_isVoiceTask` now exported (with `_`-prefix signaling test-only) so the unit test can drive it directly — same convention as PR #619's `_normalizeTaskTextForDedup` / `_findActivePendingByText`.

## Out of scope

The broader task-classification decision-boundary refactor stays in Path D Stage 2 per @VasiliyRad's read. This PR is just the path-drift fix — small, focused, test-locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)