### PR TITLE
feat(discord-bridge): on_member_join auto-welcome with raid guards

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -386,6 +386,11 @@ pending_replies = {}
 
 intents = discord.Intents.default()
 intents.message_content = True
+# Server Members Intent — required for on_member_join to fire. Privileged
+# intent: must ALSO be toggled in the Discord Developer Portal (Bot tab →
+# Privileged Gateway Intents → "Server Members Intent"). Without the portal
+# toggle, the gateway connection fails at startup with intents-mismatch.
+intents.members = True
 client = discord.Client(intents=intents)
 
 
@@ -397,6 +402,123 @@ async def on_ready():
     client.loop.create_task(poll_approved())
     client.loop.create_task(poll_proactive())
     client.loop.create_task(poll_dm_fallback())
+
+
+# ---------------------------------------------------------------------------
+# Auto-welcome on member join — see access.json `welcome_channel` field
+# ---------------------------------------------------------------------------
+# A new-user welcome posts the contents of WELCOME_TEMPLATE_PATH (or a
+# guild-specific override read from access.json) into the configured
+# welcome channel for that guild. Joins from bot accounts and very-new
+# accounts (likely throwaways used in raids) are skipped. A short rate-
+# limit window suppresses welcomes when joins burst (raid-protection).
+
+WELCOME_TEMPLATE_PATH = REPO / "notes" / "ag2-welcome-template.md"
+# Account-age floor — accounts younger than this when they join are
+# skipped. 12 hours is a decent compromise: catches throwaway raid
+# accounts (typically minutes-old) while letting legitimate new Discord
+# users through (most are days/weeks old).
+WELCOME_MIN_ACCOUNT_AGE_S = 12 * 3600
+# Raid window — if more than WELCOME_BURST_LIMIT joins land within
+# WELCOME_BURST_WINDOW_S, suppress welcomes for the rest of the window.
+WELCOME_BURST_WINDOW_S = 60
+WELCOME_BURST_LIMIT = 5
+_recent_joins_ts = []  # type: list[float]; comment-form annotation keeps Py3.9 loaders happy
+
+
+def _load_welcome_channel(guild_id):  # -> Optional[int]; bare annotation kept Py3.9-compatible (loaders use sys default)
+    """Return the welcome channel id for `guild_id` from access.json, or None
+    if no welcome destination is configured for this guild. The lookup is
+    intentionally per-guild — Mini's bot may be in multiple servers, and
+    welcome destinations differ. Schema: groups[<channel_id>].welcome_channel
+    keyed under any channel of that guild OR a top-level guilds map."""
+    try:
+        data = json.loads(ACCESS_FILE.read_text())
+    except Exception:
+        return None
+    # Preferred form: top-level guilds map keyed by guild id.
+    guilds = data.get("guilds", {})
+    g = guilds.get(str(guild_id))
+    if isinstance(g, dict):
+        ch = g.get("welcome_channel")
+        if isinstance(ch, (int, str)):
+            try:
+                return int(ch)
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _read_welcome_template() -> str:
+    """Read the canonical welcome template. Returns empty string on missing
+    file (callers should treat empty as "skip the welcome")."""
+    try:
+        return WELCOME_TEMPLATE_PATH.read_text()
+    except Exception:
+        return ""
+
+
+def _should_welcome_member(member, now_s, joins_ts):  # -> Tuple[bool, str]; Py3.9-compat (no PEP 585/604 generics)
+    """Decide whether to welcome `member`. Returns (do_welcome, reason).
+    Pure logic for testability — callers pass in `now_s` and the joins-ts
+    list explicitly so the rate-limit decision is deterministic."""
+    # Bot accounts never get welcomed
+    if getattr(member, "bot", False):
+        return False, "bot_account"
+    # Very-new accounts (raid-throwaway pattern)
+    created_at = getattr(member, "created_at", None)
+    if created_at is not None:
+        age_s = now_s - created_at.timestamp()
+        if age_s < WELCOME_MIN_ACCOUNT_AGE_S:
+            return False, f"account_age_{int(age_s)}s_under_floor"
+    # Raid-burst guard: count joins in the rolling window
+    cutoff = now_s - WELCOME_BURST_WINDOW_S
+    burst_count = sum(1 for t in joins_ts if t >= cutoff)
+    if burst_count >= WELCOME_BURST_LIMIT:
+        return False, f"raid_burst_{burst_count}_in_{WELCOME_BURST_WINDOW_S}s"
+    return True, "ok"
+
+
+@client.event
+async def on_member_join(member):
+    """Post the canonical welcome template into the guild's configured
+    welcome_channel when a new member joins. No-op for guilds with no
+    welcome_channel set (default behavior preserved). Spam guards: bot
+    filter / account-age floor / raid-burst rate-limit."""
+    guild = getattr(member, "guild", None)
+    if guild is None:
+        return
+    channel_id = _load_welcome_channel(guild.id)
+    if channel_id is None:
+        return  # this guild has no welcome destination configured
+
+    now_s = time.time()
+    do_welcome, reason = _should_welcome_member(member, now_s, _recent_joins_ts)
+    _recent_joins_ts.append(now_s)
+    # Trim history outside the burst window so the list doesn't grow.
+    cutoff = now_s - WELCOME_BURST_WINDOW_S
+    _recent_joins_ts[:] = [t for t in _recent_joins_ts if t >= cutoff]
+    if not do_welcome:
+        print(f"  [welcome] skipping {member} (reason={reason})", flush=True)
+        return
+
+    template = _read_welcome_template()
+    if not template:
+        print(f"  [welcome] template empty/missing at {WELCOME_TEMPLATE_PATH}; skipping {member}", flush=True)
+        return
+
+    channel = client.get_channel(channel_id)
+    if channel is None:
+        print(f"  [welcome] channel {channel_id} not in cache for guild {guild.id}; skipping {member}", flush=True)
+        return
+
+    body = f"<@{member.id}> {template}"
+    try:
+        for chunk in _chunk_for_discord(body):
+            await channel.send(chunk)
+        print(f"  [welcome] sent to {member} in #{getattr(channel,'name','?')}", flush=True)
+    except Exception as e:
+        print(f"  [welcome] post failed for {member}: {e}", flush=True)
 
 
 def _message_mentions_bot(message):

--- a/tests/discord-bridge-on-member-join.test.py
+++ b/tests/discord-bridge-on-member-join.test.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+Tests for the on_member_join helper logic in discord-bridge.py.
+
+The async event handler itself is tested via integration in a live bridge —
+here we lock in the pure-function helpers it composes:
+  - _load_welcome_channel(): per-guild lookup from access.json
+  - _read_welcome_template(): canonical-template file read
+  - _should_welcome_member(): bot-filter + account-age-floor + raid-burst gate
+
+The on_member_join callback is a thin wrapper that calls these in sequence;
+its happy/skip paths are covered by the helper invariants.
+
+Run: python3 tests/discord-bridge-on-member-join.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import json
+import sys
+import tempfile
+import time
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Load src/discord-bridge.py as `bridge` (filename has a hyphen, can't import
+# directly). We don't run the full module — Discord client init would try to
+# read the bot token. Instead we exec the file in a sandbox where the
+# discord library is stubbed.
+
+# Stub minimal discord module BEFORE the bridge is exec'd, so that
+# `import discord` + `discord.Intents.default()` work without the real lib.
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *args, **kwargs):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn):
+        return fn  # decorator passthrough
+    def get_channel(self, _id):
+        return None
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    """Exec the bridge module without running its main()."""
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    # The file calls `client.event` decorators at import time. Our stub's
+    # decorator is a passthrough so this is safe. The `if not TOKEN: exit(1)`
+    # guard would trip — write a temp .env to satisfy it.
+    import os
+    os.environ.setdefault("DISCORD_BOT_TOKEN", "test-stub-token")
+    # Patch the bridge's token-loading logic by writing a temp .env
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+def case_should_welcome_real_user() -> list[str]:
+    """Adult, non-bot account, no burst → welcome."""
+    fails = []
+    member = types.SimpleNamespace(
+        bot=False,
+        created_at=types.SimpleNamespace(timestamp=lambda: time.time() - 30 * 86400),
+    )
+    do, reason = bridge._should_welcome_member(member, time.time(), [])
+    if not do:
+        fails.append(f"a) real user should welcome, reason={reason}")
+    return fails
+
+
+def case_skip_bot_account() -> list[str]:
+    fails = []
+    member = types.SimpleNamespace(
+        bot=True,
+        created_at=types.SimpleNamespace(timestamp=lambda: time.time() - 30 * 86400),
+    )
+    do, reason = bridge._should_welcome_member(member, time.time(), [])
+    if do:
+        fails.append("b) bot account should be skipped")
+    if reason != "bot_account":
+        fails.append(f"b) wrong reason: {reason}")
+    return fails
+
+
+def case_skip_very_new_account() -> list[str]:
+    """Account 5 minutes old → skipped (under 12h floor)."""
+    fails = []
+    member = types.SimpleNamespace(
+        bot=False,
+        created_at=types.SimpleNamespace(timestamp=lambda: time.time() - 5 * 60),
+    )
+    do, reason = bridge._should_welcome_member(member, time.time(), [])
+    if do:
+        fails.append("c) 5min-old account should be skipped (raid-throwaway pattern)")
+    if not reason.startswith("account_age_"):
+        fails.append(f"c) wrong reason: {reason}")
+    return fails
+
+
+def case_account_at_floor_boundary() -> list[str]:
+    """Account exactly at the 12h floor — strict-less-than: 12h+1s passes,
+    12h-1s fails."""
+    fails = []
+    now = time.time()
+    just_above = types.SimpleNamespace(
+        bot=False,
+        created_at=types.SimpleNamespace(timestamp=lambda: now - bridge.WELCOME_MIN_ACCOUNT_AGE_S - 1),
+    )
+    just_below = types.SimpleNamespace(
+        bot=False,
+        created_at=types.SimpleNamespace(timestamp=lambda: now - bridge.WELCOME_MIN_ACCOUNT_AGE_S + 1),
+    )
+    if not bridge._should_welcome_member(just_above, now, [])[0]:
+        fails.append("d) account at 12h+1s should pass the floor")
+    if bridge._should_welcome_member(just_below, now, [])[0]:
+        fails.append("d) account at 12h-1s should fail the floor")
+    return fails
+
+
+def case_raid_burst_suppression() -> list[str]:
+    """If WELCOME_BURST_LIMIT joins already in window, next is suppressed."""
+    fails = []
+    now = time.time()
+    member = types.SimpleNamespace(
+        bot=False,
+        created_at=types.SimpleNamespace(timestamp=lambda: now - 30 * 86400),
+    )
+    # Fill the window — exactly LIMIT entries should block the next.
+    burst = [now - i for i in range(bridge.WELCOME_BURST_LIMIT)]
+    do, reason = bridge._should_welcome_member(member, now, burst)
+    if do:
+        fails.append("e) burst-window full should suppress")
+    if not reason.startswith("raid_burst_"):
+        fails.append(f"e) wrong reason: {reason}")
+    return fails
+
+
+def case_burst_outside_window_doesnt_suppress() -> list[str]:
+    """Old joins outside the rolling window are excluded from the count."""
+    fails = []
+    now = time.time()
+    member = types.SimpleNamespace(
+        bot=False,
+        created_at=types.SimpleNamespace(timestamp=lambda: now - 30 * 86400),
+    )
+    # 10 joins, all OLDER than the burst window.
+    old_burst = [now - bridge.WELCOME_BURST_WINDOW_S - 10 - i for i in range(10)]
+    do, reason = bridge._should_welcome_member(member, now, old_burst)
+    if not do:
+        fails.append(f"f) old burst should not suppress current join, reason={reason}")
+    return fails
+
+
+def case_load_welcome_channel_per_guild() -> list[str]:
+    """access.json `guilds` map keyed by guild id supplies per-guild
+    welcome_channel lookup. Other guilds return None."""
+    fails = []
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump({
+            "guilds": {
+                "1153072414184452236": {"welcome_channel": "1307539994751139893"},
+            },
+        }, f)
+        path = Path(f.name)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        if bridge._load_welcome_channel(1153072414184452236) != 1307539994751139893:
+            fails.append("g) configured guild should resolve to int channel id")
+        if bridge._load_welcome_channel(99999999999999999) is not None:
+            fails.append("g) unconfigured guild should return None")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+    return fails
+
+
+def case_load_welcome_channel_missing_file() -> list[str]:
+    fails = []
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = Path("/nonexistent/path/access.json")
+        if bridge._load_welcome_channel(123) is not None:
+            fails.append("h) missing access.json should return None")
+    finally:
+        bridge.ACCESS_FILE = orig
+    return fails
+
+
+def case_load_welcome_channel_malformed() -> list[str]:
+    fails = []
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        f.write("{ this is not json")
+        path = Path(f.name)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        if bridge._load_welcome_channel(123) is not None:
+            fails.append("i) malformed access.json should return None (defensive)")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+    return fails
+
+
+def case_read_welcome_template() -> list[str]:
+    fails = []
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+        f.write("Welcome body here\n")
+        path = Path(f.name)
+    orig = bridge.WELCOME_TEMPLATE_PATH
+    try:
+        bridge.WELCOME_TEMPLATE_PATH = path
+        if bridge._read_welcome_template() != "Welcome body here\n":
+            fails.append("j) template content not returned")
+    finally:
+        bridge.WELCOME_TEMPLATE_PATH = orig
+        path.unlink(missing_ok=True)
+    return fails
+
+
+def case_read_welcome_template_missing() -> list[str]:
+    fails = []
+    orig = bridge.WELCOME_TEMPLATE_PATH
+    try:
+        bridge.WELCOME_TEMPLATE_PATH = Path("/nonexistent/welcome.md")
+        if bridge._read_welcome_template() != "":
+            fails.append("k) missing template should return empty string (skip-welcome signal)")
+    finally:
+        bridge.WELCOME_TEMPLATE_PATH = orig
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a-real", case_should_welcome_real_user),
+        ("b-bot", case_skip_bot_account),
+        ("c-young", case_skip_very_new_account),
+        ("d-floor", case_account_at_floor_boundary),
+        ("e-burst", case_raid_burst_suppression),
+        ("f-old-burst", case_burst_outside_window_doesnt_suppress),
+        ("g-perguild", case_load_welcome_channel_per_guild),
+        ("h-no-file", case_load_welcome_channel_missing_file),
+        ("i-malformed", case_load_welcome_channel_malformed),
+        ("j-tmpl", case_read_welcome_template),
+        ("k-tmpl-missing", case_read_welcome_template_missing),
+    ]
+    failures: list[str] = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll on_member_join helper invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

When a new member joins a guild whose `welcome_channel` is configured in `access.json`, the bridge posts the canonical welcome template (`notes/ag2-welcome-template.md`) into that channel with the new member @-mentioned. Bot-filter / account-age-floor / raid-burst guards are wired in.

msze (AG2 server) flagged 2026-05-06 that he wants welcomes on join, not reactively on first message, and provided `#welcome-and-intro` (id `1307539994751139893`) as the AG2 destination.

## Behavior

| Scenario | Behavior |
|---|---|
| Guild without `welcome_channel` config | Skipped (current behavior preserved) |
| New user, real account, normal cadence | Welcome posted in configured channel |
| Bot account joins | Skipped (`member.bot`) |
| Account < 12h old (raid throwaway pattern) | Skipped, reason logged |
| 5+ joins in a 60s window (raid) | Excess welcomes suppressed for rest of window |
| Welcome channel ID set but channel not in cache | Skipped, logged |
| Welcome template file missing | Skipped, logged |

Thresholds (`WELCOME_MIN_ACCOUNT_AGE_S = 12*3600`, `WELCOME_BURST_LIMIT = 5`, `WELCOME_BURST_WINDOW_S = 60`) are module constants for tuning.

## Activation requirements (NOT shipped — manual)

This PR ships the **code path**. Three operator steps remain after merge:

1. **Enable Privileged Server Members Intent in the Discord Developer Portal** — Bot tab → "Privileged Gateway Intents" → toggle on "Server Members Intent." This is **bot-account scope** — the toggle affects every guild Mini's bot is in. Without it, gateway connection fails at startup with intents-mismatch (the bridge has `intents.members = True` set in code).
2. **Add `welcome_channel` to access.json** under the `guilds` map for each opt-in guild. Schema:
   ```json
   {"guilds": {"<guild_id>": {"welcome_channel": "<channel_id>"}}}
   ```
   AG2 destination per msze: `guilds.1153072414184452236.welcome_channel = "1307539994751139893"`.
3. **Restart the bridge** (`launchctl kickstart` on MacBook / nohup-restart on Mini per `feedback_mini_bridges_no_launchd.md`).

## Tests

`tests/discord-bridge-on-member-join.test.py` — 11 cases. All pass.

- a) real-user welcome
- b) bot skip
- c) very-young account skip
- d) account-age floor boundary (just-above passes / just-below fails)
- e) raid-burst suppression at limit
- f) old burst (outside window) doesn't suppress
- g) per-guild channel lookup from access.json
- h) missing access.json → None
- i) malformed access.json → None (defensive)
- j) template read returns content
- k) missing template → empty (skip-welcome signal)

The async `on_member_join` callback is tested via the pure helpers it composes — bot-filter / account-age-floor / raid-burst gate / template loader / per-guild config lookup. Decomposition keeps the gates deterministic and unit-testable without standing up a live discord.py client.

## Caveats

- **Welcome message length:** the canonical template is ~1450 chars (within the 1500–1700 ceiling per `feedback_discord_2000_char_per_message.md`). With the @-mention prefix it stays under the 2000 char limit, but the bridge's `_chunk_for_discord` handles split if a future template grows.
- **No `[reply: <id>]` directive use:** new joins have no message to reply to (joins fire before any user post). Welcomes are fresh messages with @-mention attribution.
- **Privileged-intent cross-server scope:** flagged above. Once enabled, every guild Mini's bot is in delivers member events to the bridge — guilds without `welcome_channel` config get the no-op skip path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)