### PR TITLE
feat(discord-bridge): codex judge wrapper + prompt builder (PR2 of 3)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -513,6 +513,127 @@ def _parse_judge_output(json_str):
     return out
 
 
+# ---------------------------------------------------------------------------
+# AG2 auto-mod LLM-judge — codex subprocess wrapper + prompt builder.
+# Per `notes/ag2-moderator-policy.md` §6.1: codex CLI + gpt-4o-mini, batched
+# 5s/20msgs. PR2 of 3 — pure prompt builder + the codex invocation. Action
+# dispatchers + on_message buffer/flush wiring come in PR3.
+
+# Prefix that the LLM judge prompt includes for every batch — names the rules
+# and global guardrails. Source of truth for rule definitions stays in
+# `notes/ag2-moderator-policy.md`; this is the LLM-readable distillation.
+MOD_JUDGE_SYSTEM_PROMPT = """You are a Discord moderation judge for the AG2 server. For each user message in the batch below, decide whether it matches one of these rules. Return STRICT JSON.
+
+Rules (return rule_match = "rule_N" if the message matches; null if clean):
+
+rule_1 — Crypto-job-listing spam: message advertises crypto-related employment with payment offers (e.g. "Beta tester $X/hour", "Moderator $Y/week") + @everyone/@here/DM-bait. Excludes legit hiring posts in #jobs that mention crypto as a topic but lack scam markers.
+
+rule_2 — CSAM-bait invite spam: explicit-content language (teen, underage, leaks) AND mass-broadcast pattern (@everyone/@here OR Discord invite tied to such content). Must combine both signals.
+
+rule_3 — Cross-channel duplicate: this is detected upstream by the bridge (caller sets rule_match=rule_3 in the prompt context if applicable). When triggered, your job is to also judge whether the duplicates VIOLATE any general AG2 server rule (separate from duplication itself).
+
+rule_4 — Job-availability post outside #jobs: user offering their own services for hire ("I'm a full-stack dev looking for work", "iOS dev DM me", "Looking for teammate to build X"). Excludes hiring-FROM-a-company posts and on-topic mentions where someone happens to mention they're available.
+
+rule_5 — Personal attack / derogatory toward community: personal attack, harassment, slurs, name-calling, content asserting community members are worthless / bad / criminal. Excludes vigorous technical disagreement, self-deprecation, non-targeted humor.
+
+rule_6 — Bare invite-link from non-mod: message contains a Discord invite (`discord.gg/...`) or external server invite link, with no surrounding conversational context, in a non-#geo / non-#announcements channel. Exception: if the message is a reply to a parent that's asking for that invite, return rule_match=null.
+
+rule_7 — Off-topic in focused channel: this is detected upstream as a streak of 5+ off-topic messages. When triggered, your job is to verify each message is indeed off-topic for the channel's stated topic.
+
+Global guardrails (apply to every rule):
+- G1: Moderator messages are always rule_match=null regardless of content. Bridge enforces this upstream; you can rely on the moderator filter happening before this prompt.
+- G2: When uncertain, lower the confidence (don't force a match). Bridge gates auto-action on confidence ≥ per-rule threshold.
+
+Output schema — STRICT JSON, no prose, no code fences:
+{"verdicts": [
+  {"msg_id": "<discord_msg_id>", "rule_match": "rule_N" | null, "confidence": 0.0–1.0, "rationale": "<one sentence>"}
+]}
+
+One entry per input message. Preserve msg_id strings exactly as given.
+"""
+
+
+def _format_judge_prompt(messages, rules_context=""):
+    """Build the codex judge prompt for a batch of messages.
+
+    `messages`: list of dicts with at least {msg_id, channel_name, author_name, content, is_reply, parent_content}.
+    `rules_context`: optional extra context (e.g. for Rule 3 the cross-channel-
+    duplicate evidence; for Rule 7 the channel topic + recent context).
+    Returns the full prompt string ready to feed `codex exec ... -- <prompt>`.
+    """
+    lines = [MOD_JUDGE_SYSTEM_PROMPT.strip(), ""]
+    if rules_context:
+        lines.append("Additional context for this batch:")
+        lines.append(rules_context.strip())
+        lines.append("")
+    lines.append("Messages to judge:")
+    for m in messages:
+        msg_id = m.get("msg_id", "?")
+        ch = m.get("channel_name", "?")
+        author = m.get("author_name", "?")
+        content = (m.get("content") or "").replace("\n", " ").strip()[:500]
+        is_reply = bool(m.get("is_reply"))
+        parent = m.get("parent_content", "") if is_reply else ""
+        prefix = f"  msg_id={msg_id} #{ch} @{author}"
+        if is_reply and parent:
+            parent_short = parent.replace("\n", " ").strip()[:120]
+            prefix += f' [reply to: "{parent_short}"]'
+        lines.append(f"{prefix}:")
+        lines.append(f"    {content!r}")
+    lines.append("")
+    lines.append("Respond with STRICT JSON only.")
+    return "\n".join(lines)
+
+
+async def _codex_judge_batch(messages, rules_context="", model="gpt-4o-mini", timeout_s=30):
+    """Async wrapper that invokes codex CLI to judge a batch of messages.
+
+    Spawns `codex exec --sandbox read-only -m <model> -- <prompt>` via
+    asyncio subprocess. Captures stdout (the judge's JSON output) and parses
+    via `_parse_judge_output`. Returns list of verdict dicts; [] on any
+    failure (timeout, non-zero exit, malformed JSON).
+
+    Caller is responsible for the buffer/flush logic that decides WHEN to
+    invoke this. This function is stateless.
+
+    Tests should patch `_run_codex_subprocess` to avoid real LLM calls.
+    """
+    if not messages:
+        return []
+    prompt = _format_judge_prompt(messages, rules_context)
+    raw = await _run_codex_subprocess(prompt, model, timeout_s)
+    return _parse_judge_output(raw)
+
+
+async def _run_codex_subprocess(prompt, model, timeout_s):
+    """Default codex subprocess invocation. Patched in tests.
+
+    Returns the captured stdout (judge's JSON string) or "" on any failure.
+    Stays read-only (codex won't act, just judges). Doesn't escape — the
+    prompt is passed as a single argv argument so shell-quoting isn't a
+    concern.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "codex", "exec", "--sandbox", "read-only", "-m", model, "--", prompt,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, _stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            return ""
+        if proc.returncode != 0:
+            return ""
+        return stdout.decode("utf-8", errors="replace") if stdout else ""
+    except Exception:
+        return ""
+
+
 # Track pending replies: task_id -> channel
 pending_replies = {}
 

--- a/tests/discord-bridge-mod-judge-codex.test.py
+++ b/tests/discord-bridge-mod-judge-codex.test.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+Tests for the codex judge wrapper + prompt builder in discord-bridge.py.
+
+PR2 of 3 — covers `_format_judge_prompt` (pure) and `_codex_judge_batch`
+(async, subprocess invocation patched in tests). The buffer/flush state
+machine + on_message hook + per-rule action dispatchers come in PR3.
+
+Run: python3 tests/discord-bridge-mod-judge-codex.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *args, **kwargs):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+    def get_channel(self, _id): return None
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# ---------------------------------------------------------------------------
+# _format_judge_prompt
+# ---------------------------------------------------------------------------
+
+def case_format_prompt_basic() -> list[str]:
+    fails = []
+    msgs = [
+        {"msg_id": "111", "channel_name": "general", "author_name": "alice",
+         "content": "hello world", "is_reply": False, "parent_content": ""},
+    ]
+    out = bridge._format_judge_prompt(msgs)
+    if "msg_id=111" not in out:
+        fails.append("a) prompt should include msg_id")
+    if "@alice" not in out or "#general" not in out:
+        fails.append("a) prompt should include channel + author")
+    if "hello world" not in out:
+        fails.append("a) prompt should include content (repr ok)")
+    if "STRICT JSON" not in out:
+        fails.append("a) prompt should mandate strict JSON")
+    if "rule_1" not in out or "rule_7" not in out:
+        fails.append("a) prompt should enumerate rules 1-7")
+    return fails
+
+
+def case_format_prompt_reply_includes_parent() -> list[str]:
+    fails = []
+    msgs = [
+        {"msg_id": "222", "channel_name": "geo-sf", "author_name": "bob",
+         "content": "discord.gg/abc123", "is_reply": True,
+         "parent_content": "what's your discord for the bay area meetup?"},
+    ]
+    out = bridge._format_judge_prompt(msgs)
+    if "reply to:" not in out:
+        fails.append("b) reply context should appear")
+    if "bay area meetup" not in out:
+        fails.append("b) parent content should be included")
+    return fails
+
+
+def case_format_prompt_truncates_long_content() -> list[str]:
+    fails = []
+    long = "x" * 5000
+    msgs = [
+        {"msg_id": "333", "channel_name": "x", "author_name": "y",
+         "content": long, "is_reply": False, "parent_content": ""},
+    ]
+    out = bridge._format_judge_prompt(msgs)
+    # 500-char cap for content; the prompt should not contain the full 5000
+    if long in out:
+        fails.append("c) content should be truncated to 500 chars")
+    return fails
+
+
+def case_format_prompt_with_rules_context() -> list[str]:
+    fails = []
+    msgs = [{"msg_id": "111", "channel_name": "x", "author_name": "y",
+             "content": "z", "is_reply": False, "parent_content": ""}]
+    out = bridge._format_judge_prompt(msgs, rules_context="user posted in 4 channels")
+    if "user posted in 4 channels" not in out:
+        fails.append("d) rules_context should appear in prompt")
+    if "Additional context" not in out:
+        fails.append("d) rules_context section header should appear")
+    return fails
+
+
+def case_format_prompt_empty_messages() -> list[str]:
+    """Empty message list should still produce a well-formed prompt
+    (even though caller shouldn't invoke judge with no messages)."""
+    fails = []
+    out = bridge._format_judge_prompt([])
+    if "STRICT JSON" not in out:
+        fails.append("e) empty-msgs prompt should still have schema directive")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _codex_judge_batch (subprocess patched)
+# ---------------------------------------------------------------------------
+
+def _patch_codex(bridge_mod, fake_stdout):
+    """Replace `_run_codex_subprocess` with one that returns `fake_stdout`."""
+    async def _stub(prompt, model, timeout_s):
+        return fake_stdout
+    bridge_mod._run_codex_subprocess = _stub
+
+
+def case_judge_batch_happy_path() -> list[str]:
+    fails = []
+    fake = json.dumps({"verdicts": [
+        {"msg_id": "111", "rule_match": "rule_1", "confidence": 0.92, "rationale": "crypto-job spam"},
+        {"msg_id": "222", "rule_match": None, "confidence": 0.99, "rationale": "clean"},
+    ]})
+    _patch_codex(bridge, fake)
+    msgs = [
+        {"msg_id": "111", "channel_name": "x", "author_name": "y", "content": "z", "is_reply": False, "parent_content": ""},
+        {"msg_id": "222", "channel_name": "x", "author_name": "y", "content": "z", "is_reply": False, "parent_content": ""},
+    ]
+    verdicts = asyncio.run(bridge._codex_judge_batch(msgs))
+    if len(verdicts) != 2:
+        fails.append(f"f) should return 2 verdicts, got {len(verdicts)}")
+    if verdicts and verdicts[0]["rule_match"] != "rule_1":
+        fails.append("f) verdict ordering should be preserved")
+    return fails
+
+
+def case_judge_batch_empty_messages() -> list[str]:
+    """Empty msg list should short-circuit without invoking codex."""
+    fails = []
+    called = {"n": 0}
+    async def _stub(prompt, model, timeout_s):
+        called["n"] += 1
+        return "[]"
+    bridge._run_codex_subprocess = _stub
+    verdicts = asyncio.run(bridge._codex_judge_batch([]))
+    if verdicts != []:
+        fails.append("g) empty-msgs should return []")
+    if called["n"] != 0:
+        fails.append("g) empty-msgs should NOT spawn codex subprocess")
+    return fails
+
+
+def case_judge_batch_malformed_codex_output() -> list[str]:
+    fails = []
+    _patch_codex(bridge, "not json garbage")
+    msgs = [{"msg_id": "111", "channel_name": "x", "author_name": "y",
+             "content": "z", "is_reply": False, "parent_content": ""}]
+    verdicts = asyncio.run(bridge._codex_judge_batch(msgs))
+    if verdicts != []:
+        fails.append("h) malformed codex output should return []")
+    return fails
+
+
+def case_judge_batch_codex_empty_string() -> list[str]:
+    """codex subprocess failure (timeout, non-zero exit) returns empty
+    stdout; downstream should parse to []."""
+    fails = []
+    _patch_codex(bridge, "")
+    msgs = [{"msg_id": "111", "channel_name": "x", "author_name": "y",
+             "content": "z", "is_reply": False, "parent_content": ""}]
+    verdicts = asyncio.run(bridge._codex_judge_batch(msgs))
+    if verdicts != []:
+        fails.append("i) empty codex output should return []")
+    return fails
+
+
+def case_judge_batch_passes_model_arg() -> list[str]:
+    fails = []
+    captured = {"model": None, "prompt": None}
+    async def _capture(prompt, model, timeout_s):
+        captured["model"] = model
+        captured["prompt"] = prompt
+        return "[]"
+    bridge._run_codex_subprocess = _capture
+    msgs = [{"msg_id": "111", "channel_name": "x", "author_name": "y",
+             "content": "z", "is_reply": False, "parent_content": ""}]
+    asyncio.run(bridge._codex_judge_batch(msgs, model="gpt-4o-mini"))
+    if captured["model"] != "gpt-4o-mini":
+        fails.append(f"j) model arg should pass through, got {captured['model']}")
+    if "msg_id=111" not in (captured["prompt"] or ""):
+        fails.append("j) prompt should be the formatted judge prompt")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a-format-basic", case_format_prompt_basic),
+        ("b-format-reply", case_format_prompt_reply_includes_parent),
+        ("c-format-trunc", case_format_prompt_truncates_long_content),
+        ("d-format-ctx", case_format_prompt_with_rules_context),
+        ("e-format-empty", case_format_prompt_empty_messages),
+        ("f-batch-happy", case_judge_batch_happy_path),
+        ("g-batch-empty", case_judge_batch_empty_messages),
+        ("h-batch-malformed", case_judge_batch_malformed_codex_output),
+        ("i-batch-empty-out", case_judge_batch_codex_empty_string),
+        ("j-batch-model-arg", case_judge_batch_passes_model_arg),
+    ]
+    failures: list[str] = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll codex-judge wrapper invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Stacks on **PR #625** (the helper foundation). Adds the codex subprocess invocation + LLM judge prompt builder. Still no `on_message` wiring; the buffer/flush state machine + per-rule action dispatchers come in PR3.

**Base branch:** `feat/discord-mod-llm-judge` (PR #625). Once #625 merges, this rebases to `main`.

## Scope

3 module additions to `src/discord-bridge.py`:

| Function | Purpose |
|---|---|
| `MOD_JUDGE_SYSTEM_PROMPT` | Rules 1-7 + G1+G2 distilled for the LLM. Tells codex to return STRICT JSON `{"verdicts": [{msg_id, rule_match, confidence, rationale}, ...]}`. |
| `_format_judge_prompt(messages, rules_context)` | Pure function building per-batch prompt. Includes msg_id, channel, author, content (500-char cap), and reply-context where applicable. |
| `_codex_judge_batch(messages, rules_context, model, timeout_s)` | Async — invokes codex CLI, parses output via `_parse_judge_output` from PR #625, returns verdicts. Empty-msgs short-circuits. |
| `_run_codex_subprocess(prompt, model, timeout_s)` | Async — `codex exec --sandbox read-only -m gpt-4o-mini -- <prompt>`. Patched in tests so we don't burn real LLM quota. |

## Default behavior unchanged

Helpers are added but nothing calls them yet. `on_message`, `poll_results`, `poll_proactive` all unchanged. No guild gets auto-modded after merge.

## Tests

`tests/discord-bridge-mod-judge-codex.test.py` — 10 cases. All pass.

- a-e: `_format_judge_prompt` (basic, reply context, 500-char content truncation, rules_context, empty-msgs)
- f-j: `_codex_judge_batch` with patched subprocess (happy path, empty short-circuit, malformed output → [], empty stdout → [], model arg passthrough)

Patched-subprocess pattern keeps tests deterministic + fast — no real codex calls.

## What's still missing (PR3)

- Message buffer + 5s/20-msg flush timer
- on_message hook (push messages into buffer instead of immediate-process)
- 7 per-rule action dispatchers (delete + escalate / delete + redirect / escalate-only / polite reminder)
- Cross-channel duplicate detection state for Rule 3
- Off-topic streak counter for Rule 7
- Server-rules cache for Rule 3's "violates rules?" sub-judgment

## Activation requirements (post-PR3)

- Codex CLI installed + auth'd via existing subscription
- access.json `guilds.<id>.mod_active: true` + `moderator_roles: [...]` per opt-in guild
- AG2 starts in observer-mode until msze + Chi flip the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)