### PR TITLE
feat(discord-bridge): mod-judge action dispatchers (PR3 of 4)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -634,6 +634,139 @@ async def _run_codex_subprocess(prompt, model, timeout_s):
         return ""
 
 
+# ---------------------------------------------------------------------------
+# AG2 auto-mod LLM-judge — per-rule action dispatchers (PR3 of 4).
+# Per `notes/ag2-moderator-policy.md` §6.1. These are the async functions
+# that execute Discord operations (delete / post) when a verdict matches a
+# rule. They're parameterized so they can be unit-tested with mocked
+# discord.py message + channel objects (no real Discord API hits in tests).
+# Buffer + flush + on_message wiring + Rule 3/7 stateful detectors come in
+# the final PR4.
+
+# Snowflakes for the 3 mods to cc on every escalation post (per the locked
+# ruleset). For now hardcoded to AG2's mod set; per-guild override could
+# come later if Sutando ever runs in a second moderated server.
+MOD_ESCALATION_CCS = (
+    "<@1022910063620390932>",  # Chi (sonichi)
+    "<@1025828152183885925>",  # Qingyun Wu
+    "<@786410785197785088>",   # msze_
+)
+# Discord channel id for AG2's #moderator-only — escalation destination.
+MOD_ESCALATION_CHANNEL_ID = 1153753796321738863
+# Discord channel id for AG2's #jobs — Rule 4 redirect destination.
+MOD_JOBS_CHANNEL_ID = 1168719200605437952
+
+
+async def _post_mod_escalation(client_ref, suspect_message, rule_label, llm_rationale, extras_md=""):
+    """Shared escalation post template. Used by Rules 1/2/3-violates/5/6.
+
+    `client_ref` is the discord.Client (so we can resolve the mod channel
+    by id). `suspect_message` is the discord.Message that triggered. Posts
+    a structured msg to #moderator-only with cc-mentions of the 3 mods.
+    Returns the posted message object on success, None on failure.
+    """
+    try:
+        mod_ch = client_ref.get_channel(MOD_ESCALATION_CHANNEL_ID)
+        if mod_ch is None:
+            print(f"  [mod-escalate] {MOD_ESCALATION_CHANNEL_ID} not in client cache; skipping", flush=True)
+            return None
+        suspect_link = ""
+        try:
+            suspect_link = f" — [jump]({suspect_message.jump_url})" if hasattr(suspect_message, "jump_url") else ""
+        except Exception:
+            pass
+        author = getattr(suspect_message.author, "display_name", None) or str(suspect_message.author)
+        ch_name = getattr(suspect_message.channel, "name", "?")
+        body_preview = (getattr(suspect_message, "content", None) or "")[:300]
+        body_lines = [
+            f"**Mod escalation — {rule_label}** (auto-judge)",
+            "",
+            f"From: **{author}** in `#{ch_name}`{suspect_link}",
+            "Suspect message preview:",
+            f"> {body_preview}" if body_preview else "> (no text content)",
+            "",
+            f"LLM rationale: {llm_rationale}",
+        ]
+        if extras_md:
+            body_lines.append("")
+            body_lines.append(extras_md.strip())
+        body_lines.append("")
+        body_lines.append(f"cc {' '.join(MOD_ESCALATION_CCS)}")
+        return await mod_ch.send("\n".join(body_lines))
+    except Exception as e:
+        print(f"  [mod-escalate] post failed: {e}", flush=True)
+        return None
+
+
+async def _action_delete_and_escalate(client_ref, suspect_message, verdict, extras_md=""):
+    """Rules 1, 2, 6 (and Rule 3 when duplicates violate server rules):
+    delete the offending message + post mod escalation. Returns
+    (deleted_ok: bool, escalation_msg or None)."""
+    deleted_ok = False
+    try:
+        await suspect_message.delete()
+        deleted_ok = True
+    except Exception as e:
+        print(f"  [mod-action] delete failed for {getattr(suspect_message,'id','?')}: {e}", flush=True)
+    rule_label = verdict.get("rule_match", "rule_?")
+    rationale = verdict.get("rationale", "")
+    esc = await _post_mod_escalation(client_ref, suspect_message, rule_label, rationale, extras_md)
+    return deleted_ok, esc
+
+
+async def _action_redirect_to_jobs(client_ref, suspect_message, verdict):
+    """Rule 4: delete the misplaced message + post a redirect with
+    @-mention in the same channel pointing to #jobs. No mod escalation
+    (legit user, just wrong channel). Returns (deleted_ok, redirect_msg)."""
+    deleted_ok = False
+    try:
+        await suspect_message.delete()
+        deleted_ok = True
+    except Exception as e:
+        print(f"  [mod-action] redirect-delete failed: {e}", flush=True)
+    redirect_msg = None
+    try:
+        author_id = getattr(suspect_message.author, "id", None)
+        if author_id is None:
+            return deleted_ok, None
+        body = (
+            f"<@{author_id}> Looking-for-work posts belong in <#{MOD_JOBS_CHANNEL_ID}> — "
+            f"please re-post there. (Automated reminder.)"
+        )
+        redirect_msg = await suspect_message.channel.send(body)
+    except Exception as e:
+        print(f"  [mod-action] redirect post failed: {e}", flush=True)
+    return deleted_ok, redirect_msg
+
+
+async def _action_escalate_only(client_ref, suspect_message, verdict, extras_md=""):
+    """Rule 5 (personal attack), Rule 3 non-violating duplicates, and any
+    G2-uncertain verdict: post to #moderator-only WITHOUT deleting the
+    suspect message. Mods decide. Returns the escalation message or None."""
+    rule_label = verdict.get("rule_match", "rule_?")
+    rationale = verdict.get("rationale", "")
+    return await _post_mod_escalation(client_ref, suspect_message, rule_label, rationale, extras_md)
+
+
+async def _action_polite_reminder(channel, channel_topic_hint=None):
+    """Rule 7: post one polite reminder when a 5-msg off-topic streak hits.
+    No @-mention (don't single anyone out). Returns the reminder message
+    or None on failure. Caller is responsible for cooldown bookkeeping
+    (only fire once per channel per cooldown window) — this function just
+    posts."""
+    try:
+        topic = channel_topic_hint or "#" + getattr(channel, "name", "this channel")
+        body = (
+            f"Hey folks 👋 — looks like the chat's drifting from the {topic} focus. "
+            f"No worries, but if you want to keep going, a more general channel might be a great spot. "
+            f"Carry on if it's still relevant!"
+        )
+        return await channel.send(body)
+    except Exception as e:
+        print(f"  [mod-action] polite reminder post failed: {e}", flush=True)
+        return None
+
+
 # Track pending replies: task_id -> channel
 pending_replies = {}
 

--- a/tests/discord-bridge-mod-judge-actions.test.py
+++ b/tests/discord-bridge-mod-judge-actions.test.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""
+Tests for the per-rule action dispatchers in discord-bridge.py.
+
+PR3 of 4 — covers `_post_mod_escalation`, `_action_delete_and_escalate`,
+`_action_redirect_to_jobs`, `_action_escalate_only`, `_action_polite_reminder`.
+The buffer + on_message wiring + Rule-3/Rule-7 stateful detectors land in PR4.
+
+Tests use mocked discord.py message + channel objects so no real Discord
+API hits.
+
+Run: python3 tests/discord-bridge-mod-judge-actions.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *args, **kwargs):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+    def get_channel(self, _id): return None
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+class _MockChannel:
+    """Captures every .send() call. Returns a sentinel message object."""
+    def __init__(self, name="general", channel_id=999):
+        self.name = name
+        self.id = channel_id
+        self.sent = []  # list of strings sent
+        self.send_should_raise = None
+    async def send(self, content):
+        if self.send_should_raise:
+            raise self.send_should_raise
+        self.sent.append(content)
+        return types.SimpleNamespace(id=12345, content=content)
+
+
+class _MockMessage:
+    """Captures .delete() calls."""
+    def __init__(self, msg_id="111", author_id=999, author_name="alice",
+                 channel=None, content="hi", jump_url="https://discord/jump"):
+        self.id = msg_id
+        self.author = types.SimpleNamespace(id=author_id, display_name=author_name)
+        self.channel = channel or _MockChannel()
+        self.content = content
+        self.jump_url = jump_url
+        self.deleted = False
+        self.delete_should_raise = None
+    async def delete(self):
+        if self.delete_should_raise:
+            raise self.delete_should_raise
+        self.deleted = True
+
+
+def _client_with_mod_channel(mock_mod_ch):
+    """Return a client mock where get_channel(MOD_ESCALATION_CHANNEL_ID) returns mock_mod_ch."""
+    def get_channel(cid):
+        if cid == bridge.MOD_ESCALATION_CHANNEL_ID:
+            return mock_mod_ch
+        return None
+    return types.SimpleNamespace(get_channel=get_channel)
+
+
+# ---------------------------------------------------------------------------
+# _post_mod_escalation
+# ---------------------------------------------------------------------------
+
+def case_post_mod_escalation_basic() -> list[str]:
+    fails = []
+    mod_ch = _MockChannel(name="moderator-only")
+    client = _client_with_mod_channel(mod_ch)
+    msg = _MockMessage(content="some bad message")
+    asyncio.run(bridge._post_mod_escalation(client, msg, "rule_1", "crypto-spam pattern"))
+    if not mod_ch.sent:
+        fails.append("a) escalation should post to mod channel")
+        return fails
+    posted = mod_ch.sent[0]
+    if "rule_1" not in posted:
+        fails.append("a) post should include rule label")
+    if "crypto-spam pattern" not in posted:
+        fails.append("a) post should include rationale")
+    if "<@1022910063620390932>" not in posted:
+        fails.append("a) post should cc Chi snowflake")
+    if "<@786410785197785088>" not in posted:
+        fails.append("a) post should cc msze snowflake")
+    if "<@1025828152183885925>" not in posted:
+        fails.append("a) post should cc Qingyun snowflake")
+    return fails
+
+
+def case_post_mod_escalation_no_channel_in_cache() -> list[str]:
+    """If client.get_channel returns None (channel not in cache), don't crash."""
+    fails = []
+    client = types.SimpleNamespace(get_channel=lambda _id: None)
+    msg = _MockMessage()
+    result = asyncio.run(bridge._post_mod_escalation(client, msg, "rule_1", ""))
+    if result is not None:
+        fails.append("b) should return None when mod channel not cached")
+    return fails
+
+
+def case_post_mod_escalation_includes_extras() -> list[str]:
+    fails = []
+    mod_ch = _MockChannel()
+    client = _client_with_mod_channel(mod_ch)
+    msg = _MockMessage()
+    asyncio.run(bridge._post_mod_escalation(client, msg, "rule_3", "raid pattern",
+                                             extras_md="Cross-channel duplicates: #a, #b, #c"))
+    posted = mod_ch.sent[0]
+    if "Cross-channel duplicates" not in posted:
+        fails.append("c) extras_md should appear in post")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _action_delete_and_escalate
+# ---------------------------------------------------------------------------
+
+def case_action_delete_and_escalate_happy() -> list[str]:
+    fails = []
+    mod_ch = _MockChannel()
+    client = _client_with_mod_channel(mod_ch)
+    msg = _MockMessage(content="crypto job spam $X/hour DM @everyone")
+    verdict = {"msg_id": "111", "rule_match": "rule_1", "confidence": 0.92,
+               "rationale": "crypto-job-listing"}
+    deleted, esc = asyncio.run(bridge._action_delete_and_escalate(client, msg, verdict))
+    if not deleted:
+        fails.append("d) message should be deleted")
+    if not msg.deleted:
+        fails.append("d) message.delete() should have been called")
+    if not mod_ch.sent:
+        fails.append("d) escalation post should have been made")
+    return fails
+
+
+def case_action_delete_and_escalate_delete_fails() -> list[str]:
+    """If delete fails (e.g. msg already gone), still post the escalation."""
+    fails = []
+    mod_ch = _MockChannel()
+    client = _client_with_mod_channel(mod_ch)
+    msg = _MockMessage()
+    msg.delete_should_raise = Exception("404 Not Found")
+    verdict = {"rule_match": "rule_2", "confidence": 0.91, "rationale": "csam-bait"}
+    deleted, esc = asyncio.run(bridge._action_delete_and_escalate(client, msg, verdict))
+    if deleted:
+        fails.append("e) deleted should be False when delete raises")
+    if not mod_ch.sent:
+        fails.append("e) escalation should still post even if delete failed")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _action_redirect_to_jobs
+# ---------------------------------------------------------------------------
+
+def case_action_redirect_to_jobs_happy() -> list[str]:
+    fails = []
+    src_ch = _MockChannel(name="ag-for-mobile", channel_id=500)
+    client = types.SimpleNamespace(get_channel=lambda _id: None)
+    msg = _MockMessage(channel=src_ch, content="iOS dev DM me")
+    verdict = {"rule_match": "rule_4", "confidence": 0.88, "rationale": "job-availability"}
+    deleted, redirect = asyncio.run(bridge._action_redirect_to_jobs(client, msg, verdict))
+    if not deleted:
+        fails.append("f) message should be deleted")
+    if not src_ch.sent:
+        fails.append("f) redirect should be posted in same channel")
+        return fails
+    redirect_text = src_ch.sent[0]
+    if f"<#{bridge.MOD_JOBS_CHANNEL_ID}>" not in redirect_text:
+        fails.append("f) redirect should mention #jobs channel by id")
+    if f"<@{msg.author.id}>" not in redirect_text:
+        fails.append("f) redirect should @-mention the original author")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _action_escalate_only
+# ---------------------------------------------------------------------------
+
+def case_action_escalate_only_no_delete() -> list[str]:
+    fails = []
+    mod_ch = _MockChannel()
+    client = _client_with_mod_channel(mod_ch)
+    msg = _MockMessage(content="possibly harassing message")
+    verdict = {"rule_match": "rule_5", "confidence": 0.93, "rationale": "personal attack"}
+    asyncio.run(bridge._action_escalate_only(client, msg, verdict))
+    if msg.deleted:
+        fails.append("g) escalate-only should NOT delete the suspect message")
+    if not mod_ch.sent:
+        fails.append("g) escalate-only should post to #moderator-only")
+        return fails
+    posted = mod_ch.sent[0]
+    if "rule_5" not in posted:
+        fails.append("g) post should include rule label")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _action_polite_reminder
+# ---------------------------------------------------------------------------
+
+def case_action_polite_reminder() -> list[str]:
+    fails = []
+    ch = _MockChannel(name="ag-for-finance")
+    asyncio.run(bridge._action_polite_reminder(ch))
+    if not ch.sent:
+        fails.append("h) polite reminder should post in the same channel")
+        return fails
+    body = ch.sent[0]
+    if "drifting" not in body and "drift" not in body:
+        fails.append("h) reminder should mention drift / off-topic")
+    if "<@" in body:
+        fails.append("h) reminder should NOT @-mention anyone (don't single out)")
+    return fails
+
+
+def case_action_polite_reminder_send_fails() -> list[str]:
+    """Polite reminder send failure should not raise — return None."""
+    fails = []
+    ch = _MockChannel()
+    ch.send_should_raise = Exception("permission denied")
+    out = asyncio.run(bridge._action_polite_reminder(ch))
+    if out is not None:
+        fails.append("i) failed reminder should return None")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a-escalate-basic", case_post_mod_escalation_basic),
+        ("b-no-cache", case_post_mod_escalation_no_channel_in_cache),
+        ("c-extras", case_post_mod_escalation_includes_extras),
+        ("d-del+esc-happy", case_action_delete_and_escalate_happy),
+        ("e-del-fails", case_action_delete_and_escalate_delete_fails),
+        ("f-redirect", case_action_redirect_to_jobs_happy),
+        ("g-escalate-only", case_action_escalate_only_no_delete),
+        ("h-reminder", case_action_polite_reminder),
+        ("i-reminder-fails", case_action_polite_reminder_send_fails),
+    ]
+    failures: list[str] = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll mod-judge action-dispatcher invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Stacks on **PR #626**. Adds the 4 per-rule action dispatchers + shared escalation post helper. The buffer + on_message wiring + Rule-3/Rule-7 stateful detectors land in PR4.

**Base branch:** `feat/discord-mod-llm-judge-2` (PR #626). Once #626 merges, this rebases.

## Scope

8 module additions to `src/discord-bridge.py`:

| Symbol | Purpose |
|---|---|
| `MOD_ESCALATION_CCS` | 3-mod snowflake tuple (Chi, Qingyun, msze). |
| `MOD_ESCALATION_CHANNEL_ID` | `1153753796321738863` — AG2 #moderator-only. |
| `MOD_JOBS_CHANNEL_ID` | `1168719200605437952` — AG2 #jobs (Rule 4 redirect dest). |
| `_post_mod_escalation(client, msg, rule_label, rationale, extras_md)` | Shared escalation post template; cc'd to 3 mods. Returns None when channel not in cache. |
| `_action_delete_and_escalate(client, msg, verdict, extras_md)` | Rules 1/2/6 (and Rule 3-violates). Delete failure is non-fatal; escalation still posts. |
| `_action_redirect_to_jobs(client, msg, verdict)` | Rule 4: delete + post @-mention redirect to #jobs in same channel. No mod escalation. |
| `_action_escalate_only(client, msg, verdict, extras_md)` | Rule 5 + Rule 3-non-violating + G2-uncertain. Posts to #moderator-only WITHOUT deleting. |
| `_action_polite_reminder(channel, channel_topic_hint)` | Rule 7: ONE upbeat reminder, no @-mentions. |

## Default behavior unchanged

Helpers added but nothing calls them yet. `on_message`, `poll_results`, `poll_proactive` all unchanged. **No guild gets auto-modded after merge** until PR4 wires the buffer + on_message hook AND the per-guild access.json `mod_active` flag is flipped.

## Tests

`tests/discord-bridge-mod-judge-actions.test.py` — 9 cases. All pass.

- a-c: `_post_mod_escalation` (basic with cc-mentions, no-cache returns None, extras_md included)
- d-e: `_action_delete_and_escalate` (happy path, delete-fails-still-escalates)
- f: `_action_redirect_to_jobs` (delete + redirect post with @-mention + `<#jobs>` id)
- g: `_action_escalate_only` (no-delete, post-only)
- h-i: `_action_polite_reminder` (no-mention upbeat reminder, send-fails returns None)

Mocked discord.py message + channel objects via `_MockChannel.send()` / `_MockMessage.delete()`. No real Discord API hits.

## What's still missing (PR4)

- Message buffer (in-memory, deque)
- 5s/20-msg flush timer (asyncio task)
- on_message hook integration (push to buffer instead of immediate processing)
- Cross-channel duplicate detection state for Rule 3 (rolling 5-min window of `(user_id, normalized_text) → channel_set`)
- Off-topic streak counter for Rule 7 (per-channel rolling list of `(user_id, ts, off_topic_score)`)
- Rule-3 server-rules cache (refresh from `<#1153753796321738862>` periodically)
- Per-guild `mod_active` opt-in gate before any auto-action

## Activation requirements (post-PR4)

- Codex CLI installed + auth'd
- access.json `guilds.<id>.mod_active: true` + `moderator_roles: [...]` per opt-in guild

🤖 Generated with [Claude Code](https://claude.com/claude-code)