### PR TITLE
feat(discord-bridge): mod-judge stateful detectors (PR4 of 5)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -767,6 +767,139 @@ async def _action_polite_reminder(channel, channel_topic_hint=None):
         return None
 
 
+# ---------------------------------------------------------------------------
+# AG2 auto-mod LLM-judge — stateful detectors (PR4 of 5).
+# Two pure state-machine classes that the buffer/flush logic in PR5 will
+# call. Each class is parameterized for testability — caller passes in
+# `now_s` rather than the trackers reading `time.time()` themselves.
+#
+# `_DupeTracker` — Rule 3 cross-channel-duplicate detection. Tracks
+# (user_id, normalized_text) → set of (channel_id, ts_s). Rolling 5-min
+# window. Fires when same (user, text) spans ≥3 distinct channels in
+# the window.
+#
+# `_OffTopicStreakTracker` — Rule 7 streak detection. Per-channel
+# rolling list of off-topic verdicts. Mod messages reset the streak.
+# Fires when 5 consecutive off-topic non-mod messages accumulate (per
+# channel, per cooldown).
+
+DUPE_WINDOW_S = 5 * 60      # Rule 3 rolling window: 5 minutes
+DUPE_CHANNEL_THRESHOLD = 3  # Rule 3: fire on 3+ distinct channels in window
+OFFTOPIC_STREAK_LEN = 5     # Rule 7: 5 consecutive off-topic msgs trigger
+OFFTOPIC_REMINDER_COOLDOWN_S = 30 * 60  # Rule 7: 30 min between reminders per channel
+
+
+def _normalize_msg_text(text):
+    """Same normalization as Rule 3 / dedup — lowercase, collapse runs of
+    whitespace, trim, cap at 200 chars. Differs slightly from work-tool
+    dedup (150 chars) — moderation can afford a bit more context for
+    matching cross-channel raid spam."""
+    if not text:
+        return ""
+    return re.sub(r"\s+", " ", text).strip().lower()[:200]
+
+
+class _DupeTracker:
+    """Rule 3 detector. Tracks (user_id, normalized_text) → set of
+    (channel_id, msg_id, ts_s). Rolling 5-min window. Caller passes
+    `now_s` for testability."""
+
+    def __init__(self, window_s=DUPE_WINDOW_S, channel_threshold=DUPE_CHANNEL_THRESHOLD):
+        self._window_s = window_s
+        self._channel_threshold = channel_threshold
+        # key: (user_id_str, normalized_text) → list[(channel_id, msg_id, ts_s)]
+        self._store = {}
+
+    def add(self, user_id, channel_id, msg_id, text, now_s):
+        """Record a message. Returns the dupe-set if this addition triggers
+        Rule 3 (>= channel_threshold distinct channels), else None.
+
+        On trigger, returns list[(channel_id, msg_id)] of all duplicate
+        copies in the window — caller deletes them all + escalates."""
+        key = (str(user_id), _normalize_msg_text(text))
+        if not key[1]:
+            return None  # empty/normalized-to-blank text → ignore
+        bucket = self._store.setdefault(key, [])
+        # Drop entries outside window
+        bucket[:] = [(c, m, t) for (c, m, t) in bucket if (now_s - t) <= self._window_s]
+        bucket.append((str(channel_id), str(msg_id), now_s))
+        distinct_channels = {c for (c, _m, _t) in bucket}
+        if len(distinct_channels) >= self._channel_threshold:
+            # Trigger! Return all duplicate (channel, msg) pairs in window.
+            return [(c, m) for (c, m, _t) in bucket]
+        return None
+
+    def clear(self, user_id, text):
+        """Manual reset for a (user, text) key — used after Rule 3 fires
+        and the duplicates are deleted, so the same evidence doesn't
+        re-trigger on subsequent messages."""
+        key = (str(user_id), _normalize_msg_text(text))
+        self._store.pop(key, None)
+
+    def gc(self, now_s):
+        """Drop empty + expired entries to keep memory bounded. Caller
+        should run this periodically (e.g. on every flush)."""
+        for k in list(self._store.keys()):
+            self._store[k] = [(c, m, t) for (c, m, t) in self._store[k] if (now_s - t) <= self._window_s]
+            if not self._store[k]:
+                del self._store[k]
+
+
+class _OffTopicStreakTracker:
+    """Rule 7 detector. Per-channel rolling list of recent verdicts.
+    Mod messages reset the streak (we don't count them). Fires when
+    OFFTOPIC_STREAK_LEN consecutive non-mod off-topic verdicts accumulate.
+    Per-channel cooldown after each fire so we don't spam reminders."""
+
+    def __init__(self, streak_len=OFFTOPIC_STREAK_LEN, cooldown_s=OFFTOPIC_REMINDER_COOLDOWN_S):
+        self._streak_len = streak_len
+        self._cooldown_s = cooldown_s
+        # channel_id_str → deque-like list of dicts {user_id, ts, off_topic, is_mod}
+        self._streaks = {}
+        # channel_id_str → ts_s of last reminder fire
+        self._last_reminder = {}
+
+    def record(self, channel_id, user_id, off_topic, is_mod, now_s):
+        """Record a message verdict for this channel. Returns True if
+        this addition triggers a reminder (passes cooldown + streak). On
+        trigger, the streak buffer is cleared so the next reminder needs
+        a fresh streak."""
+        ch = str(channel_id)
+        # Mod messages: reset streak (we don't count them at all)
+        if is_mod:
+            self._streaks[ch] = []
+            return False
+        # Cooldown gate: only suppresses if a reminder has already fired
+        # (last_reminder set). Initial state has no entry, so the first
+        # fire is unrestricted.
+        last_fire = self._last_reminder.get(ch)
+        in_cooldown = last_fire is not None and (now_s - last_fire) < self._cooldown_s
+        buf = self._streaks.setdefault(ch, [])
+        buf.append({"user": str(user_id), "ts": now_s, "off_topic": bool(off_topic)})
+        # Cap buffer to streak_len so we don't grow unbounded
+        if len(buf) > self._streak_len:
+            buf[:] = buf[-self._streak_len:]
+        if in_cooldown:
+            return False
+        # Streak fires only if there are streak_len consecutive off-topic
+        # entries from AFTER the cooldown window expired. Entries during
+        # cooldown are stale and don't count toward the next fire.
+        if last_fire is None:
+            cutoff = 0  # no prior fire — all entries valid
+        else:
+            cutoff = last_fire + self._cooldown_s
+        relevant = [e for e in buf if e["ts"] > cutoff]
+        if len(relevant) >= self._streak_len and all(e["off_topic"] for e in relevant[-self._streak_len:]):
+            self._last_reminder[ch] = now_s
+            self._streaks[ch] = []  # clear so next reminder needs fresh streak
+            return True
+        return False
+
+    def reset_channel(self, channel_id):
+        """Manual reset (e.g. after a mod posts in the channel out-of-band)."""
+        self._streaks[str(channel_id)] = []
+
+
 # Track pending replies: task_id -> channel
 pending_replies = {}
 

--- a/tests/discord-bridge-mod-judge-trackers.test.py
+++ b/tests/discord-bridge-mod-judge-trackers.test.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""
+Tests for the stateful detectors in discord-bridge.py.
+
+PR4 of 5 — covers `_DupeTracker` (Rule 3 cross-channel-duplicate) and
+`_OffTopicStreakTracker` (Rule 7). PR5 wires the buffer + on_message hook
++ verdict dispatcher.
+
+Run: python3 tests/discord-bridge-mod-judge-trackers.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *args, **kwargs):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+    def get_channel(self, _id): return None
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# ---------------------------------------------------------------------------
+# _normalize_msg_text
+# ---------------------------------------------------------------------------
+
+def case_normalize_basic() -> list[str]:
+    fails = []
+    if bridge._normalize_msg_text("  Hello   World\t!  ") != "hello world !":
+        fails.append("a) lowercase + whitespace-collapse + trim expected")
+    if bridge._normalize_msg_text("") != "":
+        fails.append("a) empty input → empty")
+    if bridge._normalize_msg_text(None) != "":
+        fails.append("a) None input → empty (defensive)")
+    if len(bridge._normalize_msg_text("x" * 1000)) != 200:
+        fails.append("a) 200-char cap")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _DupeTracker (Rule 3)
+# ---------------------------------------------------------------------------
+
+def case_dupe_below_threshold_no_trigger() -> list[str]:
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    # Same user posts same text in 2 channels — under threshold (3)
+    r = t.add("u1", "ch_a", "m1", "join us!", now_s=100)
+    if r is not None:
+        fails.append("b) 1 channel should not trigger")
+    r = t.add("u1", "ch_b", "m2", "join us!", now_s=110)
+    if r is not None:
+        fails.append("b) 2 channels should not trigger (threshold=3)")
+    return fails
+
+
+def case_dupe_at_threshold_triggers() -> list[str]:
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    t.add("u1", "ch_a", "m1", "join discord.gg/spam", now_s=100)
+    t.add("u1", "ch_b", "m2", "join discord.gg/spam", now_s=110)
+    r = t.add("u1", "ch_c", "m3", "join discord.gg/spam", now_s=120)
+    if r is None:
+        fails.append("c) 3 distinct channels should trigger")
+        return fails
+    triggered_msgs = {m for (_c, m) in r}
+    if triggered_msgs != {"m1", "m2", "m3"}:
+        fails.append(f"c) trigger should return all 3 msg_ids, got {triggered_msgs}")
+    return fails
+
+
+def case_dupe_window_expiry() -> list[str]:
+    """Old entries outside window don't count toward channel threshold."""
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    t.add("u1", "ch_a", "m1", "spam text", now_s=0)
+    t.add("u1", "ch_b", "m2", "spam text", now_s=10)
+    # Third post 400s later — first two are outside window
+    r = t.add("u1", "ch_c", "m3", "spam text", now_s=400)
+    if r is not None:
+        fails.append("d) old entries outside window should not count toward threshold")
+    return fails
+
+
+def case_dupe_different_text_separate_keys() -> list[str]:
+    """Different normalized texts → separate keys → don't combine into a trigger."""
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    t.add("u1", "ch_a", "m1", "buy crypto here", now_s=100)
+    t.add("u1", "ch_b", "m2", "free vbucks here", now_s=110)
+    r = t.add("u1", "ch_c", "m3", "click for prize", now_s=120)
+    if r is not None:
+        fails.append("e) 3 different texts should NOT trigger (different keys)")
+    return fails
+
+
+def case_dupe_same_channel_doesnt_double_count() -> list[str]:
+    """User posting the same text 3 times in the SAME channel doesn't trigger
+    Rule 3 — Rule 3 is about cross-channel."""
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    t.add("u1", "ch_a", "m1", "spam", now_s=100)
+    t.add("u1", "ch_a", "m2", "spam", now_s=110)
+    r = t.add("u1", "ch_a", "m3", "spam", now_s=120)
+    if r is not None:
+        fails.append("f) same-channel duplicates shouldn't trigger Rule 3 (need cross-channel)")
+    return fails
+
+
+def case_dupe_clear_after_trigger() -> list[str]:
+    """After a trigger, caller calls clear() — subsequent posts of the same
+    text in a 4th channel shouldn't re-trigger (it's a deduped pattern)."""
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    t.add("u1", "ch_a", "m1", "spam", now_s=100)
+    t.add("u1", "ch_b", "m2", "spam", now_s=110)
+    r1 = t.add("u1", "ch_c", "m3", "spam", now_s=120)
+    if r1 is None:
+        fails.append("g) trigger expected on 3rd channel")
+    t.clear("u1", "spam")
+    r2 = t.add("u1", "ch_d", "m4", "spam", now_s=130)
+    if r2 is not None:
+        fails.append("g) after clear, 1 channel post should not trigger")
+    return fails
+
+
+def case_dupe_gc_drops_expired() -> list[str]:
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    t.add("u1", "ch_a", "m1", "spam", now_s=0)
+    t.gc(now_s=400)
+    if t._store:
+        fails.append("h) gc should drop expired entries")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _OffTopicStreakTracker (Rule 7)
+# ---------------------------------------------------------------------------
+
+def case_offtopic_streak_below_threshold() -> list[str]:
+    fails = []
+    t = bridge._OffTopicStreakTracker(streak_len=5, cooldown_s=600)
+    # 4 off-topic msgs — under threshold
+    fired = [t.record("ch1", f"u{i}", off_topic=True, is_mod=False, now_s=100 + i)
+             for i in range(4)]
+    if any(fired):
+        fails.append("i) 4 off-topic should not fire (need 5)")
+    return fails
+
+
+def case_offtopic_streak_fires_at_5() -> list[str]:
+    fails = []
+    t = bridge._OffTopicStreakTracker(streak_len=5, cooldown_s=600)
+    fired_log = [t.record("ch1", f"u{i}", off_topic=True, is_mod=False, now_s=100 + i)
+                 for i in range(5)]
+    if not fired_log[-1]:
+        fails.append("j) 5th off-topic should fire")
+    return fails
+
+
+def case_offtopic_on_topic_resets_streak() -> list[str]:
+    fails = []
+    t = bridge._OffTopicStreakTracker(streak_len=5, cooldown_s=600)
+    t.record("ch1", "u1", off_topic=True, is_mod=False, now_s=100)
+    t.record("ch1", "u2", off_topic=True, is_mod=False, now_s=101)
+    # On-topic interrupts streak — buffer keeps growing but the 5th won't
+    # be all-off-topic, so no fire.
+    t.record("ch1", "u3", off_topic=False, is_mod=False, now_s=102)
+    t.record("ch1", "u4", off_topic=True, is_mod=False, now_s=103)
+    t.record("ch1", "u5", off_topic=True, is_mod=False, now_s=104)
+    fired = t.record("ch1", "u6", off_topic=True, is_mod=False, now_s=105)
+    if fired:
+        fails.append("k) on-topic msg in middle should prevent streak from firing")
+    return fails
+
+
+def case_offtopic_mod_resets_streak() -> list[str]:
+    fails = []
+    t = bridge._OffTopicStreakTracker(streak_len=5, cooldown_s=600)
+    for i in range(4):
+        t.record("ch1", f"u{i}", off_topic=True, is_mod=False, now_s=100 + i)
+    # Mod posts — clears the streak
+    t.record("ch1", "mod1", off_topic=True, is_mod=True, now_s=104)
+    # Now 4 more off-topic — needs 5 fresh, not 1 more
+    fireds = [t.record("ch1", f"u{i+10}", off_topic=True, is_mod=False, now_s=200 + i)
+              for i in range(4)]
+    if any(fireds):
+        fails.append("l) mod-reset should clear streak; next 4 shouldn't fire")
+    fired_5 = t.record("ch1", "uX", off_topic=True, is_mod=False, now_s=210)
+    if not fired_5:
+        fails.append("l) 5 fresh post-mod-reset should fire")
+    return fails
+
+
+def case_offtopic_cooldown_suppresses() -> list[str]:
+    fails = []
+    t = bridge._OffTopicStreakTracker(streak_len=5, cooldown_s=600)
+    # First fire
+    for i in range(5):
+        t.record("ch1", f"u{i}", off_topic=True, is_mod=False, now_s=100 + i)
+    # Try another 5 within cooldown — should NOT fire
+    fireds = [t.record("ch1", f"u{i+10}", off_topic=True, is_mod=False, now_s=200 + i)
+              for i in range(5)]
+    if any(fireds):
+        fails.append("m) within cooldown, second streak should not fire")
+    # After cooldown
+    fired_after = t.record("ch1", "uY", off_topic=True, is_mod=False, now_s=900)
+    # Need to refill buffer; cooldown logic still keeps buffer trimmed during cooldown
+    # so a single post post-cooldown isn't enough. Add 4 more.
+    for i in range(4):
+        fired_after = t.record("ch1", f"uZ{i}", off_topic=True, is_mod=False, now_s=901 + i)
+    if not fired_after:
+        fails.append("m) post-cooldown 5-streak should fire")
+    return fails
+
+
+def case_offtopic_per_channel_isolation() -> list[str]:
+    """Streaks are per-channel — drift in #a doesn't trigger reminder in #b."""
+    fails = []
+    t = bridge._OffTopicStreakTracker(streak_len=5, cooldown_s=600)
+    # Fill #a streak
+    for i in range(5):
+        t.record("ch_a", f"u{i}", off_topic=True, is_mod=False, now_s=100 + i)
+    # #b should be unaffected
+    fired_b = t.record("ch_b", "u_x", off_topic=True, is_mod=False, now_s=200)
+    if fired_b:
+        fails.append("n) per-channel isolation: ch_b shouldn't fire from ch_a streak")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a-norm", case_normalize_basic),
+        ("b-dupe-below", case_dupe_below_threshold_no_trigger),
+        ("c-dupe-trig", case_dupe_at_threshold_triggers),
+        ("d-dupe-window", case_dupe_window_expiry),
+        ("e-dupe-diff-text", case_dupe_different_text_separate_keys),
+        ("f-dupe-same-ch", case_dupe_same_channel_doesnt_double_count),
+        ("g-dupe-clear", case_dupe_clear_after_trigger),
+        ("h-dupe-gc", case_dupe_gc_drops_expired),
+        ("i-offtopic-below", case_offtopic_streak_below_threshold),
+        ("j-offtopic-fires", case_offtopic_streak_fires_at_5),
+        ("k-ontopic-reset", case_offtopic_on_topic_resets_streak),
+        ("l-mod-reset", case_offtopic_mod_resets_streak),
+        ("m-cooldown", case_offtopic_cooldown_suppresses),
+        ("n-per-channel", case_offtopic_per_channel_isolation),
+    ]
+    failures: list[str] = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll mod-judge stateful-detector invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Stacks on **PR #627**. Adds the two stateful detector classes for Rules 3 (cross-channel duplicate) and 7 (off-topic streak). Buffer + on_message wiring + verdict dispatcher land in the final PR5.

**Base branch:** `feat/discord-mod-llm-judge-3` (PR #627). Once #627 merges, rebases.

## Scope

3 module additions to `src/discord-bridge.py`:

| Symbol | Purpose |
|---|---|
| `_normalize_msg_text(text)` | Lowercase + whitespace-collapse + 200-char cap. Used as dedup key for Rule 3. |
| `_DupeTracker` | Rule 3: tracks `(user_id, normalized_text) → list[(channel, msg_id, ts)]` over rolling 5-min window. `add()` returns dupe-set when ≥3 distinct channels accumulate. `clear()` after acting; `gc()` for memory bound. Same-channel dupes don't count. |
| `_OffTopicStreakTracker` | Rule 7: per-channel rolling list. `record()` returns True when 5 consecutive off-topic non-mod messages accumulate. Mod messages reset streak. Cooldown (30 min) gates fires; post-cooldown needs FRESH streak (stale cooldown-era entries excluded via `cutoff = last_fire + cooldown_s`). |

Constants: `DUPE_WINDOW_S=300`, `DUPE_CHANNEL_THRESHOLD=3`, `OFFTOPIC_STREAK_LEN=5`, `OFFTOPIC_REMINDER_COOLDOWN_S=1800`.

## Default behavior unchanged

Helpers added but nothing calls them yet. `on_message`, `poll_results`, `poll_proactive` all unchanged. **No guild gets auto-modded after merge** — PR5 wires the buffer + verdict dispatcher.

## Tests

`tests/discord-bridge-mod-judge-trackers.test.py` — 14 cases. All pass.

- a: `_normalize_msg_text` (basic + 200-char cap + None-safe)
- b-h: `_DupeTracker` (below threshold, at threshold, window expiry, different texts separate, same-channel-doesn't-count, clear-after-trigger, gc)
- i-n: `_OffTopicStreakTracker` (below, fires-at-5, on-topic-resets, mod-resets, cooldown-suppresses + post-cooldown-needs-fresh-streak, per-channel-isolation)

Full `npm test` still 162/162.

## What's still missing (PR5)

- Module-level `_msg_buffer: list[QueuedMessage]`
- 5s/20-msg flush timer (asyncio task + flush trigger from `on_message`)
- on_message hook integration (G1 mod-immunity check happens here; push to buffer instead of immediate-process)
- `_dispatch_verdicts(verdicts, messages_by_id)` — looks up rule_match per verdict, calls right action dispatcher (Rules 1/2/4/5/6/7) or no-op for clean messages
- Rule 3 wiring (post-judge: feed verdicts back to dupe tracker; on trigger, mass-delete + escalate)
- Server-rules cache for Rule 3 server-rules-check (refresh from `<#1153753796321738862>` periodically)
- Per-guild `mod_active` opt-in gate at top of `on_message`

## Activation requirements (post-PR5)

- Codex CLI installed + auth'd
- access.json `guilds.<id>.mod_active: true` + `moderator_roles: [...]` per opt-in guild

🤖 Generated with [Claude Code](https://claude.com/claude-code)