### PR TITLE
feat(discord-bridge): mod-judge buffer + on_message wiring (PR6 of 6, FINAL)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -1003,6 +1003,140 @@ async def _dispatch_verdicts(verdicts, messages_by_id, client_ref, off_topic_tra
     return summary
 
 
+# ---------------------------------------------------------------------------
+# AG2 auto-mod LLM-judge — buffer + flush + on_message hook (PR6 of 6).
+# Final integration. The buffer-collection observe runs at the TOP of
+# `_handle_discord_message` and only OBSERVES (no immediate action), so
+# the existing task pipeline (mentions, allowFrom, requireMention, etc.)
+# remains untouched. Auto-mod actions run from the periodic flush.
+
+MOD_BUFFER_FLUSH_INTERVAL_S = 5      # flush every N seconds when buffer non-empty
+MOD_BUFFER_SIZE_THRESHOLD = 20       # also flush when buffer hits this size
+_mod_buffer = []                     # type: list  (each entry is a dict + the discord.Message)
+_mod_buffer_lock = None              # asyncio.Lock created in on_ready
+_mod_dupe_tracker = _DupeTracker()
+_mod_streak_tracker = _OffTopicStreakTracker()
+
+
+def _ensure_mod_lock():
+    """Lazy-init asyncio.Lock — must run inside an event loop."""
+    global _mod_buffer_lock
+    if _mod_buffer_lock is None:
+        _mod_buffer_lock = asyncio.Lock()
+    return _mod_buffer_lock
+
+
+async def _observe_for_mod(message):
+    """Push a message into the auto-mod buffer if its guild has mod_active=True
+    and the author is not a mod (G1). Called from the top of
+    `_handle_discord_message`. Returns silently — never blocks the existing
+    task pipeline."""
+    try:
+        guild = getattr(message, "guild", None)
+        if guild is None:
+            return  # DMs / private contexts not auto-modded
+        active, mod_role_ids = _load_mod_config(guild.id)
+        if not active:
+            return  # this guild hasn't opted in
+        if _is_moderator(message.author, mod_role_ids):
+            return  # G1 — mod immunity at observation time
+        # Build a queued-message record and append to buffer.
+        rec = {
+            "msg_id": str(getattr(message, "id", "")),
+            "channel_name": getattr(message.channel, "name", "?"),
+            "channel_id": getattr(message.channel, "id", None),
+            "author_name": str(getattr(message.author, "display_name", message.author)),
+            "author_id": getattr(message.author, "id", None),
+            "content": getattr(message, "content", "") or "",
+            "is_reply": bool(getattr(message, "reference", None)),
+            "parent_content": _resolve_reply_parent_content(message),
+            "_msg": message,  # discord.Message ref, used at dispatch time
+        }
+        lock = _ensure_mod_lock()
+        async with lock:
+            _mod_buffer.append(rec)
+            buffer_full = len(_mod_buffer) >= MOD_BUFFER_SIZE_THRESHOLD
+        if buffer_full:
+            # Eager flush — don't wait for the 5s timer if we hit threshold.
+            asyncio.create_task(_flush_mod_buffer())
+    except Exception as e:
+        print(f"  [mod-observe] failed: {e}", flush=True)
+
+
+def _resolve_reply_parent_content(message):
+    """Best-effort: pull parent message content for reply-context. Returns
+    "" if not a reply or parent not resolvable."""
+    try:
+        ref = getattr(message, "reference", None)
+        if ref is None:
+            return ""
+        resolved = getattr(ref, "resolved", None)
+        if resolved is None:
+            return ""
+        return getattr(resolved, "content", "") or ""
+    except Exception:
+        return ""
+
+
+async def _flush_mod_buffer():
+    """Drain the buffer, run codex batch judge, dispatch actions. Idempotent
+    when buffer is empty. Caller (timer / threshold trigger) doesn't need
+    to coordinate — internal lock makes this safe to invoke concurrently."""
+    lock = _ensure_mod_lock()
+    async with lock:
+        if not _mod_buffer:
+            return
+        batch = _mod_buffer[:]
+        _mod_buffer.clear()
+    # Build the message list for codex judge prompt
+    messages_for_judge = [
+        {
+            "msg_id": r["msg_id"],
+            "channel_name": r["channel_name"],
+            "author_name": r["author_name"],
+            "content": r["content"],
+            "is_reply": r["is_reply"],
+            "parent_content": r["parent_content"],
+        }
+        for r in batch
+    ]
+    messages_by_id = {r["msg_id"]: r["_msg"] for r in batch}
+    try:
+        verdicts = await _codex_judge_batch(messages_for_judge)
+    except Exception as e:
+        print(f"  [mod-flush] codex judge failed: {e}", flush=True)
+        return
+    if not verdicts:
+        return
+    try:
+        summary = await _dispatch_verdicts(verdicts, messages_by_id, client_ref=client,
+                                             off_topic_tracker=_mod_streak_tracker)
+        print(f"  [mod-flush] batch={len(batch)} verdicts={len(verdicts)} {summary}", flush=True)
+    except Exception as e:
+        print(f"  [mod-flush] dispatch failed: {e}", flush=True)
+    # GC the dupe tracker periodically so it doesn't grow unbounded
+    try:
+        import time as _t
+        _mod_dupe_tracker.gc(now_s=_t.time())
+    except Exception:
+        pass
+
+
+async def _mod_flush_timer_loop():
+    """Background task: flush every N seconds when buffer non-empty.
+    Started in on_ready alongside the existing poll_results / poll_proactive
+    tasks."""
+    while True:
+        try:
+            await asyncio.sleep(MOD_BUFFER_FLUSH_INTERVAL_S)
+            if _mod_buffer:
+                await _flush_mod_buffer()
+        except asyncio.CancelledError:
+            return
+        except Exception as e:
+            print(f"  [mod-flush-timer] error: {e}", flush=True)
+
+
 # Track pending replies: task_id -> channel
 pending_replies = {}
 
@@ -1019,6 +1153,8 @@ async def on_ready():
     client.loop.create_task(poll_approved())
     client.loop.create_task(poll_proactive())
     client.loop.create_task(poll_dm_fallback())
+    # Auto-mod LLM-judge flush timer (per-guild gate enforced inside flush)
+    client.loop.create_task(_mod_flush_timer_loop())
 
 
 def _message_mentions_bot(message):
@@ -1061,6 +1197,10 @@ async def on_message_edit(before, after):
 async def _handle_discord_message(message, force=False):
     if message.author == client.user:
         return
+    # Auto-mod LLM-judge observation hook (per-guild opt-in via access.json
+    # `mod_active`). Pure observe — never blocks the rest of the function.
+    # Action only fires from the periodic flush task, not at receive time.
+    await _observe_for_mod(message)
     # NOTE: the bot-author filter ("drop bot messages without @-mention") used
     # to fire here unconditionally. It now lives in the `if not is_dm:` branch
     # below, gated on the channel's `requireMention` setting, so channels

--- a/tests/discord-bridge-mod-judge-buffer.test.py
+++ b/tests/discord-bridge-mod-judge-buffer.test.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""
+Tests for the auto-mod buffer + flush + on_message observation hook
+in discord-bridge.py.
+
+PR6 of 6 (final). Covers `_observe_for_mod` (the on_message hook) and
+`_flush_mod_buffer` (the periodic drain). Patches `_codex_judge_batch`
+and the action helpers to keep tests deterministic.
+
+Run: python3 tests/discord-bridge-mod-judge-buffer.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import asyncio
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *args, **kwargs):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+    def get_channel(self, _id): return None
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# ---------------------------------------------------------------------------
+# Helpers / mocks
+# ---------------------------------------------------------------------------
+
+def _make_message(msg_id, guild_id, author_id, channel_id=42, content="hi",
+                  is_bot=False, role_ids=None):
+    roles = [types.SimpleNamespace(id=r) for r in (role_ids or [])]
+    author = types.SimpleNamespace(
+        id=author_id, display_name=f"u{author_id}", bot=is_bot, roles=roles
+    )
+    guild = types.SimpleNamespace(id=guild_id, owner_id=None)
+    channel = types.SimpleNamespace(id=channel_id, name="general")
+    return types.SimpleNamespace(
+        id=msg_id, author=author, guild=guild, channel=channel,
+        content=content, reference=None,
+    )
+
+
+def _write_access(active=True, mod_roles=None, guild_id=42):
+    """Write a temp access.json; return path."""
+    f = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    json.dump({"guilds": {str(guild_id): {
+        "mod_active": active,
+        "moderator_roles": mod_roles or [],
+    }}}, f)
+    f.close()
+    return Path(f.name)
+
+
+def _reset_buffer():
+    """Tests share module-level _mod_buffer; clear between cases."""
+    bridge._mod_buffer.clear()
+    bridge._mod_buffer_lock = None
+
+
+# ---------------------------------------------------------------------------
+# _observe_for_mod
+# ---------------------------------------------------------------------------
+
+def case_observe_buffers_normal_message() -> list[str]:
+    fails = []
+    _reset_buffer()
+    path = _write_access(active=True, mod_roles=["111"], guild_id=42)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        msg = _make_message("m1", 42, 999, content="hello")
+        asyncio.run(bridge._observe_for_mod(msg))
+        if len(bridge._mod_buffer) != 1:
+            fails.append(f"a) buffer should hold 1 record, got {len(bridge._mod_buffer)}")
+        if bridge._mod_buffer and bridge._mod_buffer[0]["msg_id"] != "m1":
+            fails.append("a) record msg_id should be preserved")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+        _reset_buffer()
+    return fails
+
+
+def case_observe_skips_inactive_guild() -> list[str]:
+    fails = []
+    _reset_buffer()
+    path = _write_access(active=False, mod_roles=[], guild_id=42)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        msg = _make_message("m1", 42, 999)
+        asyncio.run(bridge._observe_for_mod(msg))
+        if bridge._mod_buffer:
+            fails.append("b) inactive guild should not buffer")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+        _reset_buffer()
+    return fails
+
+
+def case_observe_skips_unconfigured_guild() -> list[str]:
+    fails = []
+    _reset_buffer()
+    path = _write_access(active=True, mod_roles=[], guild_id=42)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        # message from a DIFFERENT guild — not in access.json
+        msg = _make_message("m1", 99999, 999)
+        asyncio.run(bridge._observe_for_mod(msg))
+        if bridge._mod_buffer:
+            fails.append("c) unconfigured guild should not buffer")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+        _reset_buffer()
+    return fails
+
+
+def case_observe_skips_mod_message() -> list[str]:
+    """G1 mod-immunity at observation time — mod messages never enter the
+    buffer (saves codex tokens)."""
+    fails = []
+    _reset_buffer()
+    path = _write_access(active=True, mod_roles=["111"], guild_id=42)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        # Author has role 111 → mod
+        msg = _make_message("m1", 42, 999, role_ids=["111"])
+        asyncio.run(bridge._observe_for_mod(msg))
+        if bridge._mod_buffer:
+            fails.append("d) mod author should not buffer")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+        _reset_buffer()
+    return fails
+
+
+def case_observe_skips_dm() -> list[str]:
+    """Messages without a guild (DMs) shouldn't buffer."""
+    fails = []
+    _reset_buffer()
+    msg = types.SimpleNamespace(
+        id="m1", author=types.SimpleNamespace(id=999, display_name="u", bot=False, roles=[]),
+        guild=None, channel=types.SimpleNamespace(id=1, name="dm"),
+        content="hi", reference=None,
+    )
+    asyncio.run(bridge._observe_for_mod(msg))
+    if bridge._mod_buffer:
+        fails.append("e) DM should not buffer (no guild)")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _flush_mod_buffer
+# ---------------------------------------------------------------------------
+
+def case_flush_empty_buffer_no_op() -> list[str]:
+    fails = []
+    _reset_buffer()
+    judge_calls = {"n": 0}
+    async def _stub_judge(messages, rules_context="", model="gpt-4o-mini", timeout_s=30):
+        judge_calls["n"] += 1
+        return []
+    bridge._codex_judge_batch = _stub_judge
+    asyncio.run(bridge._flush_mod_buffer())
+    if judge_calls["n"] != 0:
+        fails.append("f) empty buffer flush should not invoke codex")
+    return fails
+
+
+def case_flush_drains_and_dispatches() -> list[str]:
+    fails = []
+    _reset_buffer()
+    # Set up access.json so _observe queues the messages.
+    path = _write_access(active=True, mod_roles=[], guild_id=42)
+    orig_access = bridge.ACCESS_FILE
+    bridge.ACCESS_FILE = path
+    # Patch codex + dispatcher
+    judge_calls = {"n": 0, "msgs": None}
+    async def _stub_judge(messages, rules_context="", model="gpt-4o-mini", timeout_s=30):
+        judge_calls["n"] += 1
+        judge_calls["msgs"] = messages
+        return [{"msg_id": m["msg_id"], "rule_match": None, "confidence": 0.99, "rationale": ""}
+                for m in messages]
+    bridge._codex_judge_batch = _stub_judge
+    dispatch_calls = {"n": 0, "verdict_count": 0}
+    async def _stub_dispatch(verdicts, msgs_by_id, client_ref, off_topic_tracker=None):
+        dispatch_calls["n"] += 1
+        dispatch_calls["verdict_count"] = len(verdicts)
+        return {"acted": 0, "escalated_only": 0, "skipped": len(verdicts)}
+    bridge._dispatch_verdicts = _stub_dispatch
+    try:
+        # Push 3 messages
+        for i in range(3):
+            msg = _make_message(f"m{i}", 42, 1000 + i, content=f"hi {i}")
+            asyncio.run(bridge._observe_for_mod(msg))
+        if len(bridge._mod_buffer) != 3:
+            fails.append(f"g) buffer should have 3 entries pre-flush, got {len(bridge._mod_buffer)}")
+        # Flush
+        asyncio.run(bridge._flush_mod_buffer())
+        if judge_calls["n"] != 1:
+            fails.append("g) flush should invoke codex once")
+        if dispatch_calls["n"] != 1:
+            fails.append("g) flush should invoke dispatcher once")
+        if dispatch_calls["verdict_count"] != 3:
+            fails.append(f"g) dispatcher should get 3 verdicts, got {dispatch_calls['verdict_count']}")
+        if bridge._mod_buffer:
+            fails.append("g) buffer should be drained after flush")
+    finally:
+        bridge.ACCESS_FILE = orig_access
+        path.unlink(missing_ok=True)
+        _reset_buffer()
+    return fails
+
+
+def case_flush_codex_failure_doesnt_drop_state() -> list[str]:
+    """If codex throws, the flush should log + return without crashing
+    or losing buffer state silently. (Buffer IS drained at lock-release;
+    this is acceptable since we'd rather drop a batch than re-judge
+    the same messages forever.)"""
+    fails = []
+    _reset_buffer()
+    path = _write_access(active=True, mod_roles=[], guild_id=42)
+    orig_access = bridge.ACCESS_FILE
+    bridge.ACCESS_FILE = path
+    async def _stub_judge_raises(messages, rules_context="", model="gpt-4o-mini", timeout_s=30):
+        raise RuntimeError("codex went down")
+    bridge._codex_judge_batch = _stub_judge_raises
+    try:
+        msg = _make_message("m1", 42, 999)
+        asyncio.run(bridge._observe_for_mod(msg))
+        # Should not raise
+        try:
+            asyncio.run(bridge._flush_mod_buffer())
+        except Exception as e:
+            fails.append(f"h) flush should swallow codex errors, raised {e}")
+    finally:
+        bridge.ACCESS_FILE = orig_access
+        path.unlink(missing_ok=True)
+        _reset_buffer()
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a-buffer-normal", case_observe_buffers_normal_message),
+        ("b-skip-inactive", case_observe_skips_inactive_guild),
+        ("c-skip-unconfigured", case_observe_skips_unconfigured_guild),
+        ("d-skip-mod", case_observe_skips_mod_message),
+        ("e-skip-dm", case_observe_skips_dm),
+        ("f-flush-empty", case_flush_empty_buffer_no_op),
+        ("g-flush-drains", case_flush_drains_and_dispatches),
+        ("h-codex-fails", case_flush_codex_failure_doesnt_drop_state),
+    ]
+    failures: list[str] = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll mod-judge buffer/flush invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Stacks on **PR #629**. Final integration of the AG2 auto-mod LLM-judge ruleset (msze + Chi locked 2026-05-06). After this lands, the feature is implementation-complete; only the per-guild access.json flip + bridge restart are needed to activate.

**Base branch:** `feat/discord-mod-llm-judge-5` (PR #629). Once #629 merges, rebases.

**Total of the 6-PR stack:** ~2200 lines code + tests, 74 unit tests across 6 test files. Default behavior unchanged on every PR including this one.

## Scope

8 module additions + 2 wire-up edits to `src/discord-bridge.py`:

| Symbol | Purpose |
|---|---|
| `MOD_BUFFER_FLUSH_INTERVAL_S = 5` | Flush every 5s when non-empty. |
| `MOD_BUFFER_SIZE_THRESHOLD = 20` | Eager-flush threshold. |
| `_mod_buffer`, `_mod_buffer_lock` | Module-level state, asyncio.Lock for concurrent access. |
| `_mod_dupe_tracker`, `_mod_streak_tracker` | Instances of PR4's `_DupeTracker` + `_OffTopicStreakTracker`. |
| `_observe_for_mod(message)` | The on_message hook. Per-guild `mod_active` gate + G1 mod-immunity. Pure observation. |
| `_resolve_reply_parent_content(message)` | Best-effort pull of `message.reference.resolved.content` for reply-context. |
| `_flush_mod_buffer()` | Drains buffer, calls `_codex_judge_batch`, routes via `_dispatch_verdicts`, GCs dupe tracker. Swallows failures. |
| `_mod_flush_timer_loop()` | Background asyncio task that wakes every N seconds. |

Wire-up:
- `on_ready` starts `_mod_flush_timer_loop()` alongside existing pollers.
- Top of `_handle_discord_message` (after bot-self filter) calls `await _observe_for_mod(message)`. Early-returns at the first gate when guild not opted-in or author is mod.

## Default behavior unchanged

Guilds without `mod_active: true` in access.json are silently ignored. The flush timer is harmless when the buffer stays empty.

## Activation (post-merge)

Two ops steps:

```json
// In ~/.claude/channels/discord/access.json:
{"guilds": {"1153072414184452236": {
  "mod_active": true,
  "moderator_roles": ["<role_id_1>", "<role_id_2>"]
}}}
```

Then restart the bridge. Codex CLI must be installed + auth'd (it already is per earlier verification).

**AG2 stays in observer-mode** until you decide to flip `mod_active`. msze + I locked the ruleset; you have final say on activation timing.

## Tests

`tests/discord-bridge-mod-judge-buffer.test.py` — 8 cases. All pass.

- a-e: `_observe_for_mod` (normal-buffers, inactive-skips, unconfigured-skips, mod-skips, DM-skips)
- f: `_flush_mod_buffer` empty → no codex
- g: drain → codex called once with N msgs → dispatcher called with N verdicts → buffer empty after
- h: codex raises → flush swallows, no propagation

## Whole-stack rollup (PRs #625 → #630)

| PR | Adds | Tests |
|---|---|---|
| #625 | 5 helpers (G1, G2, parsers, config) | 18 |
| #626 | codex wrapper + prompt builder | 10 |
| #627 | 4 action dispatchers + escalation post | 9 |
| #628 | `_DupeTracker` + `_OffTopicStreakTracker` | 14 |
| #629 | `_dispatch_verdicts` routing | 11 |
| #630 (this) | buffer + on_message + flush timer | 8 |
| **total** | | **70 unit tests** |

Source-of-truth ruleset: `notes/ag2-moderator-policy.md` §6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)