### PR TITLE
refactor(discord-bridge): de-hardcode mod-judge to per-guild access.json config

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -522,7 +522,7 @@ def _parse_judge_output(json_str):
 # Prefix that the LLM judge prompt includes for every batch — names the rules
 # and global guardrails. Source of truth for rule definitions stays in
 # `notes/ag2-moderator-policy.md`; this is the LLM-readable distillation.
-MOD_JUDGE_SYSTEM_PROMPT = """You are a Discord moderation judge for the AG2 server. For each user message in the batch below, decide whether it matches one of these rules. Return STRICT JSON.
+MOD_JUDGE_SYSTEM_PROMPT = """You are a Discord moderation judge. For each user message in the batch below, decide whether it matches one of these rules. Return STRICT JSON.
 
 Rules (return rule_match = "rule_N" if the message matches; null if clean):
 
@@ -530,7 +530,7 @@ rule_1 — Crypto-job-listing spam: message advertises crypto-related employment
 
 rule_2 — CSAM-bait invite spam: explicit-content language (teen, underage, leaks) AND mass-broadcast pattern (@everyone/@here OR Discord invite tied to such content). Must combine both signals.
 
-rule_3 — Cross-channel duplicate: this is detected upstream by the bridge (caller sets rule_match=rule_3 in the prompt context if applicable). When triggered, your job is to also judge whether the duplicates VIOLATE any general AG2 server rule (separate from duplication itself).
+rule_3 — Cross-channel duplicate: this is detected upstream by the bridge (caller sets rule_match=rule_3 in the prompt context if applicable). When triggered, your job is to also judge whether the duplicates VIOLATE any general server rule (separate from duplication itself).
 
 rule_4 — Job-availability post outside #jobs: user offering their own services for hire ("I'm a full-stack dev looking for work", "iOS dev DM me", "Looking for teammate to build X"). Excludes hiring-FROM-a-company posts and on-topic mentions where someone happens to mention they're available.
 
@@ -671,18 +671,51 @@ async def _run_codex_subprocess(prompt, model, timeout_s):
 # Buffer + flush + on_message wiring + Rule 3/7 stateful detectors come in
 # the final PR4.
 
-# Snowflakes for the 3 mods to cc on every escalation post (per the locked
-# ruleset). For now hardcoded to AG2's mod set; per-guild override could
-# come later if Sutando ever runs in a second moderated server.
-MOD_ESCALATION_CCS = (
-    "<@1022910063620390932>",  # Chi (sonichi)
-    "<@1025828152183885925>",  # Qingyun Wu
-    "<@786410785197785088>",   # msze_
-)
-# Discord channel id for AG2's #moderator-only — escalation destination.
-MOD_ESCALATION_CHANNEL_ID = 1153753796321738863
-# Discord channel id for AG2's #jobs — Rule 4 redirect destination.
-MOD_JOBS_CHANNEL_ID = 1168719200605437952
+# Per-guild moderation channels and CC roster live in access.json under
+# `guilds.<guild_id>` keys: `escalation_channel` (int channel id),
+# `escalation_cc_user_ids` (list of user-id strings or ints),
+# `redirect_channel_jobs` (int channel id for Rule 4). No bridge-side
+# default — operator must configure per-guild.
+
+
+def _load_mod_server_config(guild_id):
+    """Return dict of per-guild moderation config:
+        {
+          "escalation_channel": int | None,
+          "escalation_ccs": tuple[str, ...],   # `<@id>` mention strings
+          "redirect_channel_jobs": int | None,
+        }
+    Defaults to empty/None on any missing/malformed access.json entry.
+    Caller must handle None channels (skip the action with a log line)."""
+    try:
+        data = json.loads(ACCESS_FILE.read_text())
+    except Exception:
+        return {"escalation_channel": None, "escalation_ccs": (), "redirect_channel_jobs": None}
+    g = data.get("guilds", {}).get(str(guild_id))
+    if not isinstance(g, dict):
+        return {"escalation_channel": None, "escalation_ccs": (), "redirect_channel_jobs": None}
+    def _to_int(v):
+        try:
+            return int(v) if v is not None else None
+        except (TypeError, ValueError):
+            return None
+    raw_ccs = g.get("escalation_cc_user_ids", [])
+    ccs = tuple(f"<@{u}>" for u in raw_ccs) if isinstance(raw_ccs, list) else ()
+    return {
+        "escalation_channel": _to_int(g.get("escalation_channel")),
+        "escalation_ccs": ccs,
+        "redirect_channel_jobs": _to_int(g.get("redirect_channel_jobs")),
+    }
+
+
+def _guild_id_of(message):
+    """Best-effort extract guild_id from a discord.Message-like object.
+    Returns None for DMs or when guild attribute is missing."""
+    try:
+        g = getattr(message, "guild", None)
+        return getattr(g, "id", None) if g is not None else None
+    except Exception:
+        return None
 
 
 async def _post_mod_escalation(client_ref, suspect_message, rule_label, llm_rationale, extras_md=""):
@@ -694,9 +727,15 @@ async def _post_mod_escalation(client_ref, suspect_message, rule_label, llm_rati
     Returns the posted message object on success, None on failure.
     """
     try:
-        mod_ch = client_ref.get_channel(MOD_ESCALATION_CHANNEL_ID)
+        guild_id = _guild_id_of(suspect_message)
+        cfg = _load_mod_server_config(guild_id)
+        ch_id = cfg["escalation_channel"]
+        if ch_id is None:
+            print(f"  [mod-escalate] no escalation_channel configured for guild {guild_id}; skipping", flush=True)
+            return None
+        mod_ch = client_ref.get_channel(ch_id)
         if mod_ch is None:
-            print(f"  [mod-escalate] {MOD_ESCALATION_CHANNEL_ID} not in client cache; skipping", flush=True)
+            print(f"  [mod-escalate] {ch_id} not in client cache; skipping", flush=True)
             return None
         suspect_link = ""
         try:
@@ -718,8 +757,9 @@ async def _post_mod_escalation(client_ref, suspect_message, rule_label, llm_rati
         if extras_md:
             body_lines.append("")
             body_lines.append(extras_md.strip())
-        body_lines.append("")
-        body_lines.append(f"cc {' '.join(MOD_ESCALATION_CCS)}")
+        if cfg["escalation_ccs"]:
+            body_lines.append("")
+            body_lines.append(f"cc {' '.join(cfg['escalation_ccs'])}")
         return await mod_ch.send("\n".join(body_lines))
     except Exception as e:
         print(f"  [mod-escalate] post failed: {e}", flush=True)
@@ -757,8 +797,13 @@ async def _action_redirect_to_jobs(client_ref, suspect_message, verdict):
         author_id = getattr(suspect_message.author, "id", None)
         if author_id is None:
             return deleted_ok, None
+        guild_id = _guild_id_of(suspect_message)
+        jobs_ch = _load_mod_server_config(guild_id)["redirect_channel_jobs"]
+        if jobs_ch is None:
+            print(f"  [mod-action] no redirect_channel_jobs configured for guild {guild_id}; skipping redirect post", flush=True)
+            return deleted_ok, None
         body = (
-            f"<@{author_id}> Looking-for-work posts belong in <#{MOD_JOBS_CHANNEL_ID}> — "
+            f"<@{author_id}> Looking-for-work posts belong in <#{jobs_ch}> — "
             f"please re-post there. (Automated reminder.)"
         )
         redirect_msg = await suspect_message.channel.send(body)

--- a/tests/discord-bridge-mod-judge-actions.test.py
+++ b/tests/discord-bridge-mod-judge-actions.test.py
@@ -73,6 +73,25 @@ def load_bridge():
 bridge = load_bridge()
 
 
+# Per-guild mod config fixture: provide channels + cc list that the action
+# functions look up via `_load_mod_server_config(guild_id)`. Replaces real
+# access.json read so tests don't need a populated file.
+_TEST_ESCALATION_CHANNEL_ID = 1153753796321738863
+_TEST_JOBS_CHANNEL_ID = 1168719200605437952
+_TEST_ESCALATION_CCS = ("<@1022910063620390932>", "<@1025828152183885925>", "<@786410785197785088>")
+
+
+def _fake_server_config(guild_id):
+    return {
+        "escalation_channel": _TEST_ESCALATION_CHANNEL_ID,
+        "escalation_ccs": _TEST_ESCALATION_CCS,
+        "redirect_channel_jobs": _TEST_JOBS_CHANNEL_ID,
+    }
+
+
+bridge._load_mod_server_config = _fake_server_config
+
+
 # ---------------------------------------------------------------------------
 # Mock helpers
 # ---------------------------------------------------------------------------
@@ -109,9 +128,9 @@ class _MockMessage:
 
 
 def _client_with_mod_channel(mock_mod_ch):
-    """Return a client mock where get_channel(MOD_ESCALATION_CHANNEL_ID) returns mock_mod_ch."""
+    """Return a client mock where get_channel(_TEST_ESCALATION_CHANNEL_ID) returns mock_mod_ch."""
     def get_channel(cid):
-        if cid == bridge.MOD_ESCALATION_CHANNEL_ID:
+        if cid == _TEST_ESCALATION_CHANNEL_ID:
             return mock_mod_ch
         return None
     return types.SimpleNamespace(get_channel=get_channel)
@@ -222,7 +241,7 @@ def case_action_redirect_to_jobs_happy() -> list[str]:
         fails.append("f) redirect should be posted in same channel")
         return fails
     redirect_text = src_ch.sent[0]
-    if f"<#{bridge.MOD_JOBS_CHANNEL_ID}>" not in redirect_text:
+    if f"<#{_TEST_JOBS_CHANNEL_ID}>" not in redirect_text:
         fails.append("f) redirect should mention #jobs channel by id")
     if f"<@{msg.author.id}>" not in redirect_text:
         fails.append("f) redirect should @-mention the original author")

--- a/tests/discord-bridge-mod-server-config.test.py
+++ b/tests/discord-bridge-mod-server-config.test.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+Tests for `_load_mod_server_config(guild_id)` in discord-bridge.py — the
+per-guild config reader that replaces the old AG2-hardcoded MOD_ESCALATION_*
+constants.
+
+Run: python3 tests/discord-bridge-mod-server-config.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *a, **kw):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge_with_access_json(content: dict | None):
+    """Load discord-bridge with ACCESS_FILE pointed at a temp file."""
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    if content is None:
+        bridge.ACCESS_FILE = Path("/tmp/_definitely-does-not-exist-99999")
+    else:
+        tf = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+        json.dump(content, tf)
+        tf.close()
+        bridge.ACCESS_FILE = Path(tf.name)
+    return bridge
+
+
+def case_a_no_access_file():
+    """When access.json doesn't exist, all fields default safely."""
+    fails = []
+    bridge = load_bridge_with_access_json(None)
+    cfg = bridge._load_mod_server_config(123)
+    if cfg["escalation_channel"] is not None:
+        fails.append("a) missing access.json should default escalation_channel to None")
+    if cfg["escalation_ccs"] != ():
+        fails.append("a) missing access.json should default escalation_ccs to ()")
+    if cfg["redirect_channel_jobs"] is not None:
+        fails.append("a) missing access.json should default redirect_channel_jobs to None")
+    return fails
+
+
+def case_b_no_guilds_key():
+    fails = []
+    bridge = load_bridge_with_access_json({"groups": {}})
+    cfg = bridge._load_mod_server_config(123)
+    if cfg["escalation_channel"] is not None:
+        fails.append("b) missing guilds key should default escalation_channel to None")
+    if cfg["escalation_ccs"] != ():
+        fails.append("b) missing guilds key should default escalation_ccs to ()")
+    return fails
+
+
+def case_c_guild_not_listed():
+    fails = []
+    bridge = load_bridge_with_access_json({"guilds": {"999": {"escalation_channel": 555}}})
+    cfg = bridge._load_mod_server_config(123)
+    if cfg["escalation_channel"] is not None:
+        fails.append("c) unlisted guild should not inherit other guild's config")
+    return fails
+
+
+def case_d_full_config_lookup():
+    """Happy path — escalation_channel, escalation_cc_user_ids, redirect_channel_jobs all present."""
+    fails = []
+    bridge = load_bridge_with_access_json({
+        "guilds": {
+            "1153072414184452236": {
+                "mod_active": True,
+                "moderator_roles": ["1234"],
+                "escalation_channel": 1153753796321738863,
+                "escalation_cc_user_ids": ["1022910063620390932", "1025828152183885925"],
+                "redirect_channel_jobs": 1168719200605437952,
+            }
+        }
+    })
+    cfg = bridge._load_mod_server_config(1153072414184452236)
+    if cfg["escalation_channel"] != 1153753796321738863:
+        fails.append(f"d) escalation_channel mismatch: got {cfg['escalation_channel']}")
+    if cfg["escalation_ccs"] != ("<@1022910063620390932>", "<@1025828152183885925>"):
+        fails.append(f"d) escalation_ccs mismatch: got {cfg['escalation_ccs']}")
+    if cfg["redirect_channel_jobs"] != 1168719200605437952:
+        fails.append(f"d) redirect_channel_jobs mismatch: got {cfg['redirect_channel_jobs']}")
+    return fails
+
+
+def case_e_string_guild_id():
+    """guild_id passed as int should still match string-keyed access.json."""
+    fails = []
+    bridge = load_bridge_with_access_json({"guilds": {"42": {"escalation_channel": 99}}})
+    cfg = bridge._load_mod_server_config(42)  # int
+    if cfg["escalation_channel"] != 99:
+        fails.append(f"e) int guild_id should match string key: got {cfg['escalation_channel']}")
+    return fails
+
+
+def case_f_malformed_cc_list():
+    """When escalation_cc_user_ids is malformed (not a list), default to ()."""
+    fails = []
+    bridge = load_bridge_with_access_json({"guilds": {"42": {"escalation_cc_user_ids": "not-a-list"}}})
+    cfg = bridge._load_mod_server_config(42)
+    if cfg["escalation_ccs"] != ():
+        fails.append(f"f) malformed cc list should default to (): got {cfg['escalation_ccs']}")
+    return fails
+
+
+def case_g_int_user_ids_in_cc():
+    """If user_ids are stored as int (not str), still work."""
+    fails = []
+    bridge = load_bridge_with_access_json({
+        "guilds": {"42": {"escalation_cc_user_ids": [123, 456]}}
+    })
+    cfg = bridge._load_mod_server_config(42)
+    if cfg["escalation_ccs"] != ("<@123>", "<@456>"):
+        fails.append(f"g) int user_ids should still produce mention strings: got {cfg['escalation_ccs']}")
+    return fails
+
+
+def case_h_partial_config():
+    """When only some fields are configured, others default to None/()."""
+    fails = []
+    bridge = load_bridge_with_access_json({
+        "guilds": {"42": {"escalation_channel": 555}}  # only escalation_channel
+    })
+    cfg = bridge._load_mod_server_config(42)
+    if cfg["escalation_channel"] != 555:
+        fails.append(f"h) partial config: escalation_channel should be 555, got {cfg['escalation_channel']}")
+    if cfg["escalation_ccs"] != ():
+        fails.append(f"h) partial config: missing ccs should default to ()")
+    if cfg["redirect_channel_jobs"] is not None:
+        fails.append(f"h) partial config: missing redirect should default to None")
+    return fails
+
+
+def case_i_guild_id_of_message():
+    """_guild_id_of: extracts message.guild.id when present, else None."""
+    fails = []
+    bridge = load_bridge_with_access_json({})
+    msg_with_guild = types.SimpleNamespace(guild=types.SimpleNamespace(id=42))
+    if bridge._guild_id_of(msg_with_guild) != 42:
+        fails.append("i) should extract guild.id from message")
+    msg_no_guild = types.SimpleNamespace(guild=None)
+    if bridge._guild_id_of(msg_no_guild) is not None:
+        fails.append("i) message.guild=None should return None")
+    msg_no_attr = types.SimpleNamespace()
+    if bridge._guild_id_of(msg_no_attr) is not None:
+        fails.append("i) message without guild attr should return None")
+    return fails
+
+
+def main():
+    cases = [
+        ("a-no-access-file", case_a_no_access_file),
+        ("b-no-guilds-key", case_b_no_guilds_key),
+        ("c-guild-not-listed", case_c_guild_not_listed),
+        ("d-full-config-lookup", case_d_full_config_lookup),
+        ("e-string-guild-id", case_e_string_guild_id),
+        ("f-malformed-cc-list", case_f_malformed_cc_list),
+        ("g-int-user-ids-in-cc", case_g_int_user_ids_in_cc),
+        ("h-partial-config", case_h_partial_config),
+        ("i-guild-id-of-message", case_i_guild_id_of_message),
+    ]
+    failures = []
+    for label, fn in cases:
+        fs = fn()
+        if fs:
+            failures.extend([(label, msg) for msg in fs])
+            print(f"  ✗ case {label}")
+            for f in fs:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll mod-judge server-config invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Removes AG2-specific hardcoding from the PR #625-#631 mod-judge stack. Per Chi's review (\"hardcoding checked? — present, not removed\"). Stacked on PR #631.

## What was hardcoded → now per-guild config

| Was | Now |
|---|---|
| \`MOD_ESCALATION_CHANNEL_ID = 1153753796321738863\` | \`access.json: guilds.<id>.escalation_channel\` |
| \`MOD_ESCALATION_CCS = (<3 user-id mentions>)\` | \`access.json: guilds.<id>.escalation_cc_user_ids\` (list) |
| \`MOD_JOBS_CHANNEL_ID = 1168719200605437952\` | \`access.json: guilds.<id>.redirect_channel_jobs\` |
| \`\"for the AG2 server\"\` (prompt) | \`\"for a Discord server\"\` (generic) |
| \`\"general AG2 server rule\"\` (prompt) | \`\"general server rule\"\` (generic) |

## New helpers

- \`_load_mod_server_config(guild_id)\` returns \`{escalation_channel, escalation_ccs, redirect_channel_jobs}\` — defaults safely on missing/malformed data, no bridge-side AG2 default.
- \`_guild_id_of(message)\` best-effort extracts \`message.guild.id\`.

Action functions (\`_post_mod_escalation\`, \`_action_redirect_to_jobs\`) call \`_guild_id_of(suspect_message)\` then look up config. When config is absent → log + skip (no crash).

## Tests

- **NEW** \`tests/discord-bridge-mod-server-config.test.py\` — 9 cases covering: missing access.json, missing \`guilds\` key, unlisted guild, full happy-path, int vs string guild_id, malformed cc list, int user_ids in cc, partial config, \`_guild_id_of\` extraction.
- **UPDATED** \`tests/discord-bridge-mod-judge-actions.test.py\` — monkey-patches \`_load_mod_server_config\` with a fixture. Original assertions on user-ids preserved by feeding fixture-config that matches the AG2 mod set.
- Other 5 mod-judge test files unchanged.

**Total: 70 → 79 unit tests, all green.**

## Activation config example

After this PR + the 7-PR stack merges, the only place AG2-specific data lives is operator config in \`~/.claude/channels/discord/access.json\`:

\`\`\`json
{
  \"guilds\": {
    \"1153072414184452236\": {
      \"mod_active\": true,
      \"moderator_roles\": [\"<role-id>\"],
      \"escalation_channel\": 1153753796321738863,
      \"escalation_cc_user_ids\": [\"1022910063620390932\", \"1025828152183885925\", \"786410785197785088\"],
      \"redirect_channel_jobs\": 1168719200605437952
    }
  }
}
\`\`\`

Different operator can run the bridge in their own moderated server with their own \`guilds.<id>.*\` config — no code change needed.

## Default behavior unchanged

If no \`guilds.<id>\` config is present, \`_load_mod_server_config\` returns all-None/empty values → actions log a \"no … configured for guild N; skipping\" line and no-op. Combined with \`mod_active: false\` default, this PR is fully observe-only by default.

## Test plan

- [x] All 79 unit tests pass locally
- [ ] CI runs after rebase onto main (workflow gates on base=main)
- [ ] Pre-flight smoke test (\`notes/ag2-mod-merge-runbook.md\` §0) post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)