### PR TITLE
feat(discord-bridge): AG2 auto-mod LLM-judge (full feature, dehardcoded)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -381,6 +381,835 @@ def load_channel_allowed(channel_id):
         return None
     return cfg[1]
 
+
+# ---------------------------------------------------------------------------
+# AG2 auto-mod LLM-judge helpers (per `notes/ag2-moderator-policy.md` §6.1).
+# Locked-in 2026-05-06 with msze + Chi: codex CLI + gpt-4o-mini, batched
+# 5s/20msgs, 7 rules + 2 global guardrails (G1 mod immunity / G2 escalate-on-
+# uncertainty). This PR ships the pure helpers + tests; the on_message hook +
+# action dispatchers ship in a follow-up so each PR stays focused.
+#
+# Per-guild config in access.json:
+#   {"guilds": {"<guild_id>": {
+#     "mod_active": true,
+#     "moderator_roles": ["<role_id_1>", "<role_id_2>"],
+#     ...
+#   }}}
+# `mod_active` defaults to false; the bridge does no auto-mod on a guild
+# without an explicit opt-in. AG2 starts in observer-mode until msze + Chi
+# flip the flag.
+
+# Per-rule confidence thresholds for G2 (escalate if confidence < threshold).
+MOD_RULE_CONFIDENCE = {
+    "rule_1": 0.85,  # crypto-job spam → auto-delete
+    "rule_2": 0.85,  # CSAM-bait → auto-delete + T&S rec
+    "rule_3": 0.85,  # cross-channel duplicate → server-rules-check
+    "rule_4": 0.85,  # job-availability → delete + redirect
+    "rule_5": 0.90,  # personal attack → escalate-only (highest FP risk)
+    "rule_6": 0.85,  # bare invite link → conditional delete
+    "rule_7": 0.85,  # off-topic streak → polite reminder
+}
+
+
+def _load_mod_config(guild_id):
+    """Return (mod_active: bool, moderator_role_ids: list[str]) for `guild_id`
+    from access.json. Defaults: (False, []) if guild not configured or
+    access.json missing/malformed. Defensive parsing — caller treats
+    mod_active=False as "do nothing" (the safe default)."""
+    try:
+        data = json.loads(ACCESS_FILE.read_text())
+    except Exception:
+        return False, []
+    g = data.get("guilds", {}).get(str(guild_id))
+    if not isinstance(g, dict):
+        return False, []
+    active = bool(g.get("mod_active", False))
+    roles_raw = g.get("moderator_roles", [])
+    roles = [str(r) for r in roles_raw] if isinstance(roles_raw, list) else []
+    return active, roles
+
+
+def _is_moderator(member, mod_role_ids):
+    """G1 — moderator immunity gate. Return True if `member` has any role in
+    `mod_role_ids` (or owns the guild). Pure function for testability —
+    caller passes the resolved role list."""
+    if member is None:
+        return False
+    # Server owner is always a mod
+    guild = getattr(member, "guild", None)
+    if guild is not None and getattr(guild, "owner_id", None) == getattr(member, "id", None):
+        return True
+    member_roles = getattr(member, "roles", []) or []
+    member_role_ids = {str(getattr(r, "id", r)) for r in member_roles}
+    return bool(member_role_ids.intersection(set(mod_role_ids)))
+
+
+def _should_auto_action(verdict, rule_threshold=None):
+    """G2 — confidence gate. Return True if the LLM verdict is confident
+    enough to act on. `verdict` is a dict with at least `confidence` (float)
+    and `rule_match` (str like "rule_1"). Below-threshold verdicts go to
+    escalate-only path even if rule_match is set."""
+    if not isinstance(verdict, dict):
+        return False
+    if not verdict.get("rule_match"):
+        return False
+    rm = verdict.get("rule_match")
+    threshold = rule_threshold if rule_threshold is not None else MOD_RULE_CONFIDENCE.get(rm, 0.85)
+    try:
+        conf = float(verdict.get("confidence", 0))
+    except (TypeError, ValueError):
+        return False
+    return conf >= threshold
+
+
+def _parse_judge_output(json_str):
+    """Parse codex's batched-judge output into a list of verdict dicts.
+
+    Expected schema (per message):
+        {
+          "msg_id": "<discord_msg_id>",
+          "rule_match": "rule_1" | "rule_2" | ... | null,
+          "confidence": 0.0–1.0,
+          "rationale": "<short explanation>"
+        }
+
+    Returns [] on any parse / schema failure (caller treats empty as
+    "no verdicts; don't act"). Lenient on extra keys; strict on required
+    keys (msg_id, confidence). `rule_match` may be null for clean messages.
+    """
+    if not isinstance(json_str, str) or not json_str.strip():
+        return []
+    try:
+        data = json.loads(json_str)
+    except Exception:
+        return []
+    # Accept either a list of verdicts or {"verdicts": [...]} wrapper
+    if isinstance(data, dict):
+        data = data.get("verdicts", [])
+    if not isinstance(data, list):
+        return []
+    out = []
+    for v in data:
+        if not isinstance(v, dict):
+            continue
+        msg_id = v.get("msg_id")
+        conf = v.get("confidence")
+        if not msg_id or conf is None:
+            continue
+        try:
+            conf_f = float(conf)
+        except (TypeError, ValueError):
+            continue
+        rule_match = v.get("rule_match")
+        if rule_match is not None and not isinstance(rule_match, str):
+            continue
+        rationale = v.get("rationale") if isinstance(v.get("rationale"), str) else ""
+        out.append({
+            "msg_id": str(msg_id),
+            "rule_match": rule_match,
+            "confidence": max(0.0, min(1.0, conf_f)),
+            "rationale": rationale,
+        })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# AG2 auto-mod LLM-judge — codex subprocess wrapper + prompt builder.
+# Per `notes/ag2-moderator-policy.md` §6.1: codex CLI + gpt-4o-mini, batched
+# 5s/20msgs. PR2 of 3 — pure prompt builder + the codex invocation. Action
+# dispatchers + on_message buffer/flush wiring come in PR3.
+
+# Prefix that the LLM judge prompt includes for every batch — names the rules
+# and global guardrails. Source of truth for rule definitions stays in
+# `notes/ag2-moderator-policy.md`; this is the LLM-readable distillation.
+MOD_JUDGE_SYSTEM_PROMPT = """You are a Discord moderation judge. For each user message in the batch below, decide whether it matches one of these rules. Return STRICT JSON.
+
+Rules (return rule_match = "rule_N" if the message matches; null if clean):
+
+rule_1 — Crypto-job-listing spam: message advertises crypto-related employment with payment offers (e.g. "Beta tester $X/hour", "Moderator $Y/week") + @everyone/@here/DM-bait. Excludes legit hiring posts in #jobs that mention crypto as a topic but lack scam markers.
+
+rule_2 — CSAM-bait invite spam: explicit-content language (teen, underage, leaks) AND mass-broadcast pattern (@everyone/@here OR Discord invite tied to such content). Must combine both signals.
+
+rule_3 — Cross-channel duplicate: this is detected upstream by the bridge (caller sets rule_match=rule_3 in the prompt context if applicable). When triggered, your job is to also judge whether the duplicates VIOLATE any general server rule (separate from duplication itself).
+
+rule_4 — Job-availability post outside #jobs: user offering their own services for hire ("I'm a full-stack dev looking for work", "iOS dev DM me", "Looking for teammate to build X"). Excludes hiring-FROM-a-company posts and on-topic mentions where someone happens to mention they're available.
+
+rule_5 — Personal attack / derogatory toward community: personal attack, harassment, slurs, name-calling, content asserting community members are worthless / bad / criminal. Excludes vigorous technical disagreement, self-deprecation, non-targeted humor.
+
+rule_6 — Bare invite-link from non-mod: message contains a Discord invite (`discord.gg/...`) or external server invite link, with no surrounding conversational context, in a non-#geo / non-#announcements channel. Exception: if the message is a reply to a parent that's asking for that invite, return rule_match=null.
+
+rule_7 — Off-topic in focused channel: this is detected upstream as a streak of 5+ off-topic messages. When triggered, your job is to verify each message is indeed off-topic for the channel's stated topic.
+
+Global guardrails (apply to every rule):
+- G1: Moderator messages are always rule_match=null regardless of content. Bridge enforces this upstream; you can rely on the moderator filter happening before this prompt.
+- G2: When uncertain, lower the confidence (don't force a match). Bridge gates auto-action on confidence ≥ per-rule threshold.
+
+Output schema — STRICT JSON, no prose, no code fences:
+{"verdicts": [
+  {"msg_id": "<discord_msg_id>", "rule_match": "rule_N" | null, "confidence": 0.0–1.0, "rationale": "<one sentence>"}
+]}
+
+One entry per input message. Preserve msg_id strings exactly as given.
+"""
+
+
+def _format_judge_prompt(messages, rules_context=""):
+    """Build the codex judge prompt for a batch of messages.
+
+    `messages`: list of dicts with at least {msg_id, channel_name, author_name, content, is_reply, parent_content}.
+    `rules_context`: optional extra context (e.g. for Rule 3 the cross-channel-
+    duplicate evidence; for Rule 7 the channel topic + recent context).
+    Returns the full prompt string ready to feed `codex exec ... -- <prompt>`.
+    """
+    lines = [MOD_JUDGE_SYSTEM_PROMPT.strip(), ""]
+    if rules_context:
+        lines.append("Additional context for this batch:")
+        lines.append(rules_context.strip())
+        lines.append("")
+    lines.append("Messages to judge:")
+    for m in messages:
+        msg_id = m.get("msg_id", "?")
+        ch = m.get("channel_name", "?")
+        author = m.get("author_name", "?")
+        content = (m.get("content") or "").replace("\n", " ").strip()[:500]
+        is_reply = bool(m.get("is_reply"))
+        parent = m.get("parent_content", "") if is_reply else ""
+        prefix = f"  msg_id={msg_id} #{ch} @{author}"
+        if is_reply and parent:
+            parent_short = parent.replace("\n", " ").strip()[:120]
+            prefix += f' [reply to: "{parent_short}"]'
+        lines.append(f"{prefix}:")
+        lines.append(f"    {content!r}")
+    lines.append("")
+    lines.append("Respond with STRICT JSON only.")
+    return "\n".join(lines)
+
+
+async def _codex_judge_batch(messages, rules_context="", model=None, timeout_s=30):
+    """Async wrapper that invokes codex CLI to judge a batch of messages.
+
+    Spawns `codex exec --sandbox read-only -o <tmpfile> -- <prompt>` via
+    asyncio subprocess. The `-o` flag writes only the agent's final
+    message to the file (no agent-headers / token counts / shell
+    execution traces) — that's the clean read path for codex-as-judge.
+    `model` is optional; None uses codex's configured default
+    (gpt-5.5 currently). Returns list of verdict dicts; [] on any
+    failure (timeout, non-zero exit, malformed JSON, missing output).
+
+    Caller is responsible for the buffer/flush logic that decides WHEN to
+    invoke this. This function is stateless.
+
+    Tests should patch `_run_codex_subprocess` to avoid real LLM calls.
+    """
+    if not messages:
+        return []
+    prompt = _format_judge_prompt(messages, rules_context)
+    raw = await _run_codex_subprocess(prompt, model, timeout_s)
+    return _parse_judge_output(raw)
+
+
+async def _run_codex_subprocess(prompt, model, timeout_s):
+    """Default codex subprocess invocation. Patched in tests.
+
+    Uses the `-o <tmpfile>` flag so codex writes ONLY the agent's final
+    message (the JSON we care about) to a tempfile — bypasses the agent-
+    header wrapping that pollutes stdout. Returns the file contents on
+    success, "" on any failure (timeout / non-zero exit / file missing).
+    Stays read-only sandbox (codex won't shell out for any tool).
+
+    `model` is None to use codex's configured default (avoids the
+    "model not supported under ChatGPT account" 400 we'd get with
+    `-m gpt-4o-mini` under that auth path).
+    """
+    import tempfile, os
+    try:
+        out_fd, out_path = tempfile.mkstemp(prefix="sutando-mod-judge-", suffix=".json")
+        os.close(out_fd)
+    except Exception:
+        return ""
+    try:
+        argv = ["codex", "exec", "--sandbox", "read-only", "-o", out_path]
+        if model:
+            argv.extend(["-m", model])
+        argv.extend(["--", prompt])
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except Exception:
+            return ""
+        try:
+            await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            return ""
+        if proc.returncode != 0:
+            return ""
+        try:
+            with open(out_path, "r", encoding="utf-8", errors="replace") as fp:
+                return fp.read()
+        except Exception:
+            return ""
+    finally:
+        try:
+            os.unlink(out_path)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# AG2 auto-mod LLM-judge — per-rule action dispatchers (PR3 of 4).
+# Per `notes/ag2-moderator-policy.md` §6.1. These are the async functions
+# that execute Discord operations (delete / post) when a verdict matches a
+# rule. They're parameterized so they can be unit-tested with mocked
+# discord.py message + channel objects (no real Discord API hits in tests).
+# Buffer + flush + on_message wiring + Rule 3/7 stateful detectors come in
+# the final PR4.
+
+# Per-guild moderation channels and CC roster live in access.json under
+# `guilds.<guild_id>` keys: `escalation_channel` (int channel id),
+# `escalation_cc_user_ids` (list of user-id strings or ints),
+# `redirect_channel_jobs` (int channel id for Rule 4). No bridge-side
+# default — operator must configure per-guild.
+
+
+def _load_mod_server_config(guild_id):
+    """Return dict of per-guild moderation config:
+        {
+          "escalation_channel": int | None,
+          "escalation_ccs": tuple[str, ...],   # `<@id>` mention strings
+          "redirect_channel_jobs": int | None,
+        }
+    Defaults to empty/None on any missing/malformed access.json entry.
+    Caller must handle None channels (skip the action with a log line)."""
+    try:
+        data = json.loads(ACCESS_FILE.read_text())
+    except Exception:
+        return {"escalation_channel": None, "escalation_ccs": (), "redirect_channel_jobs": None}
+    g = data.get("guilds", {}).get(str(guild_id))
+    if not isinstance(g, dict):
+        return {"escalation_channel": None, "escalation_ccs": (), "redirect_channel_jobs": None}
+    def _to_int(v):
+        try:
+            return int(v) if v is not None else None
+        except (TypeError, ValueError):
+            return None
+    raw_ccs = g.get("escalation_cc_user_ids", [])
+    ccs = tuple(f"<@{u}>" for u in raw_ccs) if isinstance(raw_ccs, list) else ()
+    return {
+        "escalation_channel": _to_int(g.get("escalation_channel")),
+        "escalation_ccs": ccs,
+        "redirect_channel_jobs": _to_int(g.get("redirect_channel_jobs")),
+    }
+
+
+def _guild_id_of(message):
+    """Best-effort extract guild_id from a discord.Message-like object.
+    Returns None for DMs or when guild attribute is missing."""
+    try:
+        g = getattr(message, "guild", None)
+        return getattr(g, "id", None) if g is not None else None
+    except Exception:
+        return None
+
+
+async def _post_mod_escalation(client_ref, suspect_message, rule_label, llm_rationale, extras_md=""):
+    """Shared escalation post template. Used by Rules 1/2/3-violates/5/6.
+
+    `client_ref` is the discord.Client (so we can resolve the mod channel
+    by id). `suspect_message` is the discord.Message that triggered. Posts
+    a structured msg to #moderator-only with cc-mentions of the 3 mods.
+    Returns the posted message object on success, None on failure.
+    """
+    try:
+        guild_id = _guild_id_of(suspect_message)
+        cfg = _load_mod_server_config(guild_id)
+        ch_id = cfg["escalation_channel"]
+        if ch_id is None:
+            print(f"  [mod-escalate] no escalation_channel configured for guild {guild_id}; skipping", flush=True)
+            return None
+        mod_ch = client_ref.get_channel(ch_id)
+        if mod_ch is None:
+            print(f"  [mod-escalate] {ch_id} not in client cache; skipping", flush=True)
+            return None
+        suspect_link = ""
+        try:
+            suspect_link = f" — [jump]({suspect_message.jump_url})" if hasattr(suspect_message, "jump_url") else ""
+        except Exception:
+            pass
+        author = getattr(suspect_message.author, "display_name", None) or str(suspect_message.author)
+        ch_name = getattr(suspect_message.channel, "name", "?")
+        body_preview = (getattr(suspect_message, "content", None) or "")[:300]
+        body_lines = [
+            f"**Mod escalation — {rule_label}** (auto-judge)",
+            "",
+            f"From: **{author}** in `#{ch_name}`{suspect_link}",
+            "Suspect message preview:",
+            f"> {body_preview}" if body_preview else "> (no text content)",
+            "",
+            f"LLM rationale: {llm_rationale}",
+        ]
+        if extras_md:
+            body_lines.append("")
+            body_lines.append(extras_md.strip())
+        if cfg["escalation_ccs"]:
+            body_lines.append("")
+            body_lines.append(f"cc {' '.join(cfg['escalation_ccs'])}")
+        return await mod_ch.send("\n".join(body_lines))
+    except Exception as e:
+        print(f"  [mod-escalate] post failed: {e}", flush=True)
+        return None
+
+
+async def _action_delete_and_escalate(client_ref, suspect_message, verdict, extras_md=""):
+    """Rules 1, 2, 6 (and Rule 3 when duplicates violate server rules):
+    delete the offending message + post mod escalation. Returns
+    (deleted_ok: bool, escalation_msg or None)."""
+    deleted_ok = False
+    try:
+        await suspect_message.delete()
+        deleted_ok = True
+    except Exception as e:
+        print(f"  [mod-action] delete failed for {getattr(suspect_message,'id','?')}: {e}", flush=True)
+    rule_label = verdict.get("rule_match", "rule_?")
+    rationale = verdict.get("rationale", "")
+    esc = await _post_mod_escalation(client_ref, suspect_message, rule_label, rationale, extras_md)
+    return deleted_ok, esc
+
+
+async def _action_redirect_to_jobs(client_ref, suspect_message, verdict):
+    """Rule 4: delete the misplaced message + post a redirect with
+    @-mention in the same channel pointing to #jobs. No mod escalation
+    (legit user, just wrong channel). Returns (deleted_ok, redirect_msg)."""
+    deleted_ok = False
+    try:
+        await suspect_message.delete()
+        deleted_ok = True
+    except Exception as e:
+        print(f"  [mod-action] redirect-delete failed: {e}", flush=True)
+    redirect_msg = None
+    try:
+        author_id = getattr(suspect_message.author, "id", None)
+        if author_id is None:
+            return deleted_ok, None
+        guild_id = _guild_id_of(suspect_message)
+        jobs_ch = _load_mod_server_config(guild_id)["redirect_channel_jobs"]
+        if jobs_ch is None:
+            print(f"  [mod-action] no redirect_channel_jobs configured for guild {guild_id}; skipping redirect post", flush=True)
+            return deleted_ok, None
+        body = (
+            f"<@{author_id}> Looking-for-work posts belong in <#{jobs_ch}> — "
+            f"please re-post there. (Automated reminder.)"
+        )
+        redirect_msg = await suspect_message.channel.send(body)
+    except Exception as e:
+        print(f"  [mod-action] redirect post failed: {e}", flush=True)
+    return deleted_ok, redirect_msg
+
+
+async def _action_escalate_only(client_ref, suspect_message, verdict, extras_md=""):
+    """Rule 5 (personal attack), Rule 3 non-violating duplicates, and any
+    G2-uncertain verdict: post to #moderator-only WITHOUT deleting the
+    suspect message. Mods decide. Returns the escalation message or None."""
+    rule_label = verdict.get("rule_match", "rule_?")
+    rationale = verdict.get("rationale", "")
+    return await _post_mod_escalation(client_ref, suspect_message, rule_label, rationale, extras_md)
+
+
+async def _action_polite_reminder(channel, channel_topic_hint=None):
+    """Rule 7: post one polite reminder when a 5-msg off-topic streak hits.
+    No @-mention (don't single anyone out). Returns the reminder message
+    or None on failure. Caller is responsible for cooldown bookkeeping
+    (only fire once per channel per cooldown window) — this function just
+    posts."""
+    try:
+        topic = channel_topic_hint or "#" + getattr(channel, "name", "this channel")
+        body = (
+            f"Hey folks 👋 — looks like the chat's drifting from the {topic} focus. "
+            f"No worries, but if you want to keep going, a more general channel might be a great spot. "
+            f"Carry on if it's still relevant!"
+        )
+        return await channel.send(body)
+    except Exception as e:
+        print(f"  [mod-action] polite reminder post failed: {e}", flush=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# AG2 auto-mod LLM-judge — stateful detectors (PR4 of 5).
+# Two pure state-machine classes that the buffer/flush logic in PR5 will
+# call. Each class is parameterized for testability — caller passes in
+# `now_s` rather than the trackers reading `time.time()` themselves.
+#
+# `_DupeTracker` — Rule 3 cross-channel-duplicate detection. Tracks
+# (user_id, normalized_text) → set of (channel_id, ts_s). Rolling 5-min
+# window. Fires when same (user, text) spans ≥3 distinct channels in
+# the window.
+#
+# `_OffTopicStreakTracker` — Rule 7 streak detection. Per-channel
+# rolling list of off-topic verdicts. Mod messages reset the streak.
+# Fires when 5 consecutive off-topic non-mod messages accumulate (per
+# channel, per cooldown).
+
+DUPE_WINDOW_S = 5 * 60      # Rule 3 rolling window: 5 minutes
+DUPE_CHANNEL_THRESHOLD = 3  # Rule 3: fire on 3+ distinct channels in window
+OFFTOPIC_STREAK_LEN = 5     # Rule 7: 5 consecutive off-topic msgs trigger
+OFFTOPIC_REMINDER_COOLDOWN_S = 30 * 60  # Rule 7: 30 min between reminders per channel
+
+
+def _normalize_msg_text(text):
+    """Same normalization as Rule 3 / dedup — lowercase, collapse runs of
+    whitespace, trim, cap at 200 chars. Differs slightly from work-tool
+    dedup (150 chars) — moderation can afford a bit more context for
+    matching cross-channel raid spam."""
+    if not text:
+        return ""
+    return re.sub(r"\s+", " ", text).strip().lower()[:200]
+
+
+class _DupeTracker:
+    """Rule 3 detector. Tracks (user_id, normalized_text) → set of
+    (channel_id, msg_id, ts_s). Rolling 5-min window. Caller passes
+    `now_s` for testability."""
+
+    def __init__(self, window_s=DUPE_WINDOW_S, channel_threshold=DUPE_CHANNEL_THRESHOLD):
+        self._window_s = window_s
+        self._channel_threshold = channel_threshold
+        # key: (user_id_str, normalized_text) → list[(channel_id, msg_id, ts_s)]
+        self._store = {}
+
+    def add(self, user_id, channel_id, msg_id, text, now_s):
+        """Record a message. Returns the dupe-set if this addition triggers
+        Rule 3 (>= channel_threshold distinct channels), else None.
+
+        On trigger, returns list[(channel_id, msg_id)] of all duplicate
+        copies in the window — caller deletes them all + escalates."""
+        key = (str(user_id), _normalize_msg_text(text))
+        if not key[1]:
+            return None  # empty/normalized-to-blank text → ignore
+        bucket = self._store.setdefault(key, [])
+        # Drop entries outside window
+        bucket[:] = [(c, m, t) for (c, m, t) in bucket if (now_s - t) <= self._window_s]
+        bucket.append((str(channel_id), str(msg_id), now_s))
+        distinct_channels = {c for (c, _m, _t) in bucket}
+        if len(distinct_channels) >= self._channel_threshold:
+            # Trigger! Return all duplicate (channel, msg) pairs in window.
+            return [(c, m) for (c, m, _t) in bucket]
+        return None
+
+    def clear(self, user_id, text):
+        """Manual reset for a (user, text) key — used after Rule 3 fires
+        and the duplicates are deleted, so the same evidence doesn't
+        re-trigger on subsequent messages."""
+        key = (str(user_id), _normalize_msg_text(text))
+        self._store.pop(key, None)
+
+    def gc(self, now_s):
+        """Drop empty + expired entries to keep memory bounded. Caller
+        should run this periodically (e.g. on every flush)."""
+        for k in list(self._store.keys()):
+            self._store[k] = [(c, m, t) for (c, m, t) in self._store[k] if (now_s - t) <= self._window_s]
+            if not self._store[k]:
+                del self._store[k]
+
+
+class _OffTopicStreakTracker:
+    """Rule 7 detector. Per-channel rolling list of recent verdicts.
+    Mod messages reset the streak (we don't count them). Fires when
+    OFFTOPIC_STREAK_LEN consecutive non-mod off-topic verdicts accumulate.
+    Per-channel cooldown after each fire so we don't spam reminders."""
+
+    def __init__(self, streak_len=OFFTOPIC_STREAK_LEN, cooldown_s=OFFTOPIC_REMINDER_COOLDOWN_S):
+        self._streak_len = streak_len
+        self._cooldown_s = cooldown_s
+        # channel_id_str → deque-like list of dicts {user_id, ts, off_topic, is_mod}
+        self._streaks = {}
+        # channel_id_str → ts_s of last reminder fire
+        self._last_reminder = {}
+
+    def record(self, channel_id, user_id, off_topic, is_mod, now_s):
+        """Record a message verdict for this channel. Returns True if
+        this addition triggers a reminder (passes cooldown + streak). On
+        trigger, the streak buffer is cleared so the next reminder needs
+        a fresh streak."""
+        ch = str(channel_id)
+        # Mod messages: reset streak (we don't count them at all)
+        if is_mod:
+            self._streaks[ch] = []
+            return False
+        # Cooldown gate: only suppresses if a reminder has already fired
+        # (last_reminder set). Initial state has no entry, so the first
+        # fire is unrestricted.
+        last_fire = self._last_reminder.get(ch)
+        in_cooldown = last_fire is not None and (now_s - last_fire) < self._cooldown_s
+        buf = self._streaks.setdefault(ch, [])
+        buf.append({"user": str(user_id), "ts": now_s, "off_topic": bool(off_topic)})
+        # Cap buffer to streak_len so we don't grow unbounded
+        if len(buf) > self._streak_len:
+            buf[:] = buf[-self._streak_len:]
+        if in_cooldown:
+            return False
+        # Streak fires only if there are streak_len consecutive off-topic
+        # entries from AFTER the cooldown window expired. Entries during
+        # cooldown are stale and don't count toward the next fire.
+        if last_fire is None:
+            cutoff = 0  # no prior fire — all entries valid
+        else:
+            cutoff = last_fire + self._cooldown_s
+        relevant = [e for e in buf if e["ts"] > cutoff]
+        if len(relevant) >= self._streak_len and all(e["off_topic"] for e in relevant[-self._streak_len:]):
+            self._last_reminder[ch] = now_s
+            self._streaks[ch] = []  # clear so next reminder needs fresh streak
+            return True
+        return False
+
+    def reset_channel(self, channel_id):
+        """Manual reset (e.g. after a mod posts in the channel out-of-band)."""
+        self._streaks[str(channel_id)] = []
+
+
+# ---------------------------------------------------------------------------
+# AG2 auto-mod LLM-judge — verdict dispatcher (PR5 of 6).
+# Takes a batch of LLM verdicts + the source messages, routes each to the
+# right action (delete/escalate/redirect/polite-reminder) per the rule
+# match. Buffer + on_message integration ship in PR6.
+
+# Per-rule action routing. Rule 3 is special-cased (handled at on_message
+# time by _DupeTracker before the judge runs); the dispatcher handles
+# verdicts on Rule 3-flagged messages by either delete-and-escalate (if
+# the LLM judges them as also violating server rules) or escalate-only.
+RULE_TO_ACTION = {
+    "rule_1": "delete_and_escalate",  # crypto-job spam
+    "rule_2": "delete_and_escalate",  # CSAM-bait spam
+    "rule_3": "rule_3_conditional",   # routed via verdict.violates_server_rules
+    "rule_4": "redirect_to_jobs",     # job-availability misplaced
+    "rule_5": "escalate_only",        # personal attack
+    "rule_6": "delete_and_escalate",  # bare invite link
+    "rule_7": "rule_7_streak",        # off-topic streak (handled separately)
+}
+
+
+async def _dispatch_verdicts(verdicts, messages_by_id, client_ref, off_topic_tracker=None):
+    """Process a batch of verdicts. For each verdict:
+      - Look up the corresponding source message by msg_id.
+      - Apply G2: if confidence below per-rule threshold, escalate-only.
+      - Otherwise route to the action keyed in RULE_TO_ACTION.
+      - For rule_7, feed the off_topic signal into the streak tracker;
+        fire a polite reminder if the streak triggers.
+
+    `messages_by_id`: dict of {msg_id_str: discord.Message}. Caller assembles
+    this from the buffer at flush time.
+    `off_topic_tracker`: optional `_OffTopicStreakTracker`. If provided,
+    Rule 7 verdicts feed into it.
+
+    Returns a summary dict for logging:
+      {"acted": <count>, "escalated_only": <count>, "skipped": <count>}.
+    """
+    summary = {"acted": 0, "escalated_only": 0, "skipped": 0}
+    for v in verdicts:
+        msg_id = str(v.get("msg_id", ""))
+        msg = messages_by_id.get(msg_id)
+        if msg is None:
+            summary["skipped"] += 1
+            continue
+        rule_match = v.get("rule_match")
+        if not rule_match:
+            # Clean message — no action. But for Rule 7, we still record
+            # the on-topic verdict (off_topic=False) into the streak tracker.
+            if off_topic_tracker is not None:
+                channel_id = getattr(msg.channel, "id", None)
+                user_id = getattr(msg.author, "id", None)
+                is_mod = bool(getattr(v, "_is_mod", False))  # caller can flag
+                if channel_id is not None and user_id is not None:
+                    import time as _t
+                    off_topic_tracker.record(channel_id, user_id, off_topic=False, is_mod=is_mod, now_s=_t.time())
+            summary["skipped"] += 1
+            continue
+        # Rule 7 path: judge says message is off-topic; feed into streak
+        # tracker. Action only if the streak fires (handled separately —
+        # caller pulls trigger from the tracker's record() return value
+        # during on_message dispatch). Here we just no-op (action ran or
+        # didn't already).
+        if rule_match == "rule_7":
+            summary["skipped"] += 1
+            continue
+        # G2 confidence gate. Below threshold → escalate-only fallback.
+        if not _should_auto_action(v):
+            await _action_escalate_only(client_ref, msg, v,
+                                          extras_md="(G2: LLM confidence below threshold)")
+            summary["escalated_only"] += 1
+            continue
+        # Above-threshold action routing
+        action = RULE_TO_ACTION.get(rule_match, "escalate_only")
+        if action == "delete_and_escalate":
+            await _action_delete_and_escalate(client_ref, msg, v)
+            summary["acted"] += 1
+        elif action == "redirect_to_jobs":
+            await _action_redirect_to_jobs(client_ref, msg, v)
+            summary["acted"] += 1
+        elif action == "escalate_only":
+            await _action_escalate_only(client_ref, msg, v)
+            summary["escalated_only"] += 1
+        elif action == "rule_3_conditional":
+            # Rule 3: LLM also judged whether duplicates violate server
+            # rules. The verdict's `violates_server_rules` field (if set)
+            # disambiguates. If True or unset (default to caution), delete.
+            # Otherwise escalate-only (legit cross-post).
+            if v.get("violates_server_rules", True):
+                await _action_delete_and_escalate(client_ref, msg, v,
+                                                    extras_md="(Rule 3: cross-channel duplicate violates server rules)")
+                summary["acted"] += 1
+            else:
+                await _action_escalate_only(client_ref, msg, v,
+                                              extras_md="(Rule 3: cross-channel duplicate, NOT violating server rules — for human review)")
+                summary["escalated_only"] += 1
+        else:
+            # Unknown rule label → escalate-only as safe default.
+            await _action_escalate_only(client_ref, msg, v,
+                                          extras_md=f"(unknown rule_match={rule_match!r})")
+            summary["escalated_only"] += 1
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# AG2 auto-mod LLM-judge — buffer + flush + on_message hook (PR6 of 6).
+# Final integration. The buffer-collection observe runs at the TOP of
+# `_handle_discord_message` and only OBSERVES (no immediate action), so
+# the existing task pipeline (mentions, allowFrom, requireMention, etc.)
+# remains untouched. Auto-mod actions run from the periodic flush.
+
+MOD_BUFFER_FLUSH_INTERVAL_S = 5      # flush every N seconds when buffer non-empty
+MOD_BUFFER_SIZE_THRESHOLD = 20       # also flush when buffer hits this size
+_mod_buffer = []                     # type: list  (each entry is a dict + the discord.Message)
+_mod_buffer_lock = None              # asyncio.Lock created in on_ready
+_mod_dupe_tracker = _DupeTracker()
+_mod_streak_tracker = _OffTopicStreakTracker()
+
+
+def _ensure_mod_lock():
+    """Lazy-init asyncio.Lock — must run inside an event loop."""
+    global _mod_buffer_lock
+    if _mod_buffer_lock is None:
+        _mod_buffer_lock = asyncio.Lock()
+    return _mod_buffer_lock
+
+
+async def _observe_for_mod(message):
+    """Push a message into the auto-mod buffer if its guild has mod_active=True
+    and the author is not a mod (G1). Called from the top of
+    `_handle_discord_message`. Returns silently — never blocks the existing
+    task pipeline."""
+    try:
+        guild = getattr(message, "guild", None)
+        if guild is None:
+            return  # DMs / private contexts not auto-modded
+        active, mod_role_ids = _load_mod_config(guild.id)
+        if not active:
+            return  # this guild hasn't opted in
+        if _is_moderator(message.author, mod_role_ids):
+            return  # G1 — mod immunity at observation time
+        # Build a queued-message record and append to buffer.
+        rec = {
+            "msg_id": str(getattr(message, "id", "")),
+            "channel_name": getattr(message.channel, "name", "?"),
+            "channel_id": getattr(message.channel, "id", None),
+            "author_name": str(getattr(message.author, "display_name", message.author)),
+            "author_id": getattr(message.author, "id", None),
+            "content": getattr(message, "content", "") or "",
+            "is_reply": bool(getattr(message, "reference", None)),
+            "parent_content": _resolve_reply_parent_content(message),
+            "_msg": message,  # discord.Message ref, used at dispatch time
+        }
+        lock = _ensure_mod_lock()
+        async with lock:
+            _mod_buffer.append(rec)
+            buffer_full = len(_mod_buffer) >= MOD_BUFFER_SIZE_THRESHOLD
+        if buffer_full:
+            # Eager flush — don't wait for the 5s timer if we hit threshold.
+            asyncio.create_task(_flush_mod_buffer())
+    except Exception as e:
+        print(f"  [mod-observe] failed: {e}", flush=True)
+
+
+def _resolve_reply_parent_content(message):
+    """Best-effort: pull parent message content for reply-context. Returns
+    "" if not a reply or parent not resolvable."""
+    try:
+        ref = getattr(message, "reference", None)
+        if ref is None:
+            return ""
+        resolved = getattr(ref, "resolved", None)
+        if resolved is None:
+            return ""
+        return getattr(resolved, "content", "") or ""
+    except Exception:
+        return ""
+
+
+async def _flush_mod_buffer():
+    """Drain the buffer, run codex batch judge, dispatch actions. Idempotent
+    when buffer is empty. Caller (timer / threshold trigger) doesn't need
+    to coordinate — internal lock makes this safe to invoke concurrently."""
+    lock = _ensure_mod_lock()
+    async with lock:
+        if not _mod_buffer:
+            return
+        batch = _mod_buffer[:]
+        _mod_buffer.clear()
+    # Build the message list for codex judge prompt
+    messages_for_judge = [
+        {
+            "msg_id": r["msg_id"],
+            "channel_name": r["channel_name"],
+            "author_name": r["author_name"],
+            "content": r["content"],
+            "is_reply": r["is_reply"],
+            "parent_content": r["parent_content"],
+        }
+        for r in batch
+    ]
+    messages_by_id = {r["msg_id"]: r["_msg"] for r in batch}
+    try:
+        verdicts = await _codex_judge_batch(messages_for_judge)
+    except Exception as e:
+        print(f"  [mod-flush] codex judge failed: {e}", flush=True)
+        return
+    if not verdicts:
+        return
+    try:
+        summary = await _dispatch_verdicts(verdicts, messages_by_id, client_ref=client,
+                                             off_topic_tracker=_mod_streak_tracker)
+        print(f"  [mod-flush] batch={len(batch)} verdicts={len(verdicts)} {summary}", flush=True)
+    except Exception as e:
+        print(f"  [mod-flush] dispatch failed: {e}", flush=True)
+    # GC the dupe tracker periodically so it doesn't grow unbounded
+    try:
+        import time as _t
+        _mod_dupe_tracker.gc(now_s=_t.time())
+    except Exception:
+        pass
+
+
+async def _mod_flush_timer_loop():
+    """Background task: flush every N seconds when buffer non-empty.
+    Started in on_ready alongside the existing poll_results / poll_proactive
+    tasks."""
+    while True:
+        try:
+            await asyncio.sleep(MOD_BUFFER_FLUSH_INTERVAL_S)
+            if _mod_buffer:
+                await _flush_mod_buffer()
+        except asyncio.CancelledError:
+            return
+        except Exception as e:
+            print(f"  [mod-flush-timer] error: {e}", flush=True)
+
+
 # Track pending replies: task_id -> channel
 pending_replies = {}
 
@@ -397,6 +1226,8 @@ async def on_ready():
     client.loop.create_task(poll_approved())
     client.loop.create_task(poll_proactive())
     client.loop.create_task(poll_dm_fallback())
+    # Auto-mod LLM-judge flush timer (per-guild gate enforced inside flush)
+    client.loop.create_task(_mod_flush_timer_loop())
 
 
 def _message_mentions_bot(message):
@@ -439,6 +1270,10 @@ async def on_message_edit(before, after):
 async def _handle_discord_message(message, force=False):
     if message.author == client.user:
         return
+    # Auto-mod LLM-judge observation hook (per-guild opt-in via access.json
+    # `mod_active`). Pure observe — never blocks the rest of the function.
+    # Action only fires from the periodic flush task, not at receive time.
+    await _observe_for_mod(message)
     # NOTE: the bot-author filter ("drop bot messages without @-mention") used
     # to fire here unconditionally. It now lives in the `if not is_dm:` branch
     # below, gated on the channel's `requireMention` setting, so channels

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -504,12 +504,22 @@ def _parse_judge_output(json_str):
         if rule_match is not None and not isinstance(rule_match, str):
             continue
         rationale = v.get("rationale") if isinstance(v.get("rationale"), str) else ""
-        out.append({
+        verdict = {
             "msg_id": str(msg_id),
             "rule_match": rule_match,
             "confidence": max(0.0, min(1.0, conf_f)),
             "rationale": rationale,
-        })
+        }
+        # Rule 3 carries an extra boolean: violates_server_rules. If the LLM
+        # returned it, preserve it so the dispatcher can branch on legit
+        # cross-post (false) vs spam (true). Default missing → True (act
+        # conservatively: treat as violation when LLM didn't say otherwise).
+        if "violates_server_rules" in v:
+            try:
+                verdict["violates_server_rules"] = bool(v.get("violates_server_rules"))
+            except Exception:
+                pass
+        out.append(verdict)
     return out
 
 
@@ -718,6 +728,22 @@ def _guild_id_of(message):
         return None
 
 
+def _sanitize_for_quote(text):
+    """Neutralize mention-shaped substrings so quoting them in the mod
+    channel doesn't ping anyone. Inserts a zero-width space after each `@`
+    so Discord's parser no longer matches `@everyone`, `<@id>`, `<@&id>`,
+    etc. Also collapses `>` so the embedded line doesn't break the outer
+    blockquote. Reads visually identical to the original."""
+    if not isinstance(text, str):
+        return ""
+    # ZWSP = U+200B; invisible but breaks mention/everyone parsing
+    return (
+        text
+        .replace("@", "@\u200b")
+        .replace("\n>", "\n>\u200b")  # avoid nested blockquote issues inside our `> ` line
+    )
+
+
 async def _post_mod_escalation(client_ref, suspect_message, rule_label, llm_rationale, extras_md=""):
     """Shared escalation post template. Used by Rules 1/2/3-violates/5/6.
 
@@ -744,7 +770,13 @@ async def _post_mod_escalation(client_ref, suspect_message, rule_label, llm_rati
             pass
         author = getattr(suspect_message.author, "display_name", None) or str(suspect_message.author)
         ch_name = getattr(suspect_message.channel, "name", "?")
-        body_preview = (getattr(suspect_message, "content", None) or "")[:300]
+        # Sanitize the suspect message preview to prevent mention-injection:
+        # a malicious message containing @everyone / <@user> / <@&role> would
+        # otherwise emit real pings when we replay it in the mod channel. We
+        # neutralize by inserting a zero-width space after the @ — the mention
+        # is no longer parsed by Discord, but reads identically.
+        raw_content = (getattr(suspect_message, "content", None) or "")[:300]
+        body_preview = _sanitize_for_quote(raw_content)
         body_lines = [
             f"**Mod escalation — {rule_label}** (auto-judge)",
             "",
@@ -760,7 +792,19 @@ async def _post_mod_escalation(client_ref, suspect_message, rule_label, llm_rati
         if cfg["escalation_ccs"]:
             body_lines.append("")
             body_lines.append(f"cc {' '.join(cfg['escalation_ccs'])}")
-        return await mod_ch.send("\n".join(body_lines))
+        # Belt + suspenders: also use Discord's allowed_mentions to whitelist
+        # ONLY the explicit cc user-ids; suppress @everyone/@here/@role and
+        # any user mentions not in the cc list.
+        try:
+            cc_ids = [int(s.strip("<@>")) for s in cfg["escalation_ccs"] if s.startswith("<@") and s.endswith(">")]
+        except Exception:
+            cc_ids = []
+        try:
+            am = discord.AllowedMentions(everyone=False, roles=False, users=cc_ids)
+            return await mod_ch.send("\n".join(body_lines), allowed_mentions=am)
+        except Exception:
+            # Fallback if discord.AllowedMentions is unavailable in stub/test env
+            return await mod_ch.send("\n".join(body_lines))
     except Exception as e:
         print(f"  [mod-escalate] post failed: {e}", flush=True)
         return None
@@ -1030,13 +1074,31 @@ async def _dispatch_verdicts(verdicts, messages_by_id, client_ref, off_topic_tra
                     off_topic_tracker.record(channel_id, user_id, off_topic=False, is_mod=is_mod, now_s=_t.time())
             summary["skipped"] += 1
             continue
-        # Rule 7 path: judge says message is off-topic; feed into streak
-        # tracker. Action only if the streak fires (handled separately —
-        # caller pulls trigger from the tracker's record() return value
-        # during on_message dispatch). Here we just no-op (action ran or
-        # didn't already).
+        # Rule 7 path: judge says message is off-topic. Feed off_topic=True
+        # into the streak tracker; if the streak fires (5+ off-topic in
+        # cooldown window), post a polite reminder in the channel.
         if rule_match == "rule_7":
-            summary["skipped"] += 1
+            if off_topic_tracker is not None:
+                channel_id = getattr(msg.channel, "id", None)
+                user_id = getattr(msg.author, "id", None)
+                if channel_id is not None and user_id is not None:
+                    import time as _t
+                    fired = off_topic_tracker.record(
+                        channel_id, user_id, off_topic=True, is_mod=False, now_s=_t.time()
+                    )
+                    if fired:
+                        try:
+                            await _action_polite_reminder(msg.channel)
+                            summary["acted"] += 1
+                        except Exception as e:
+                            print(f"  [mod-action] rule_7 reminder failed: {e}", flush=True)
+                            summary["skipped"] += 1
+                    else:
+                        summary["skipped"] += 1
+                else:
+                    summary["skipped"] += 1
+            else:
+                summary["skipped"] += 1
             continue
         # G2 confidence gate. Below threshold → escalate-only fallback.
         if not _should_auto_action(v):
@@ -1154,14 +1216,41 @@ def _resolve_reply_parent_content(message):
 async def _flush_mod_buffer():
     """Drain the buffer, run codex batch judge, dispatch actions. Idempotent
     when buffer is empty. Caller (timer / threshold trigger) doesn't need
-    to coordinate — internal lock makes this safe to invoke concurrently."""
+    to coordinate — internal lock makes this safe to invoke concurrently.
+
+    Failure semantics: snapshot buffer WITHOUT clearing. Clear only after
+    successful dispatch. On codex/judge failure or empty-verdicts the
+    messages remain in the buffer for the next flush. Prevents silent
+    data loss when codex times out or returns malformed output."""
     lock = _ensure_mod_lock()
     async with lock:
         if not _mod_buffer:
             return
+        # Snapshot — do NOT clear yet. Clear only after successful dispatch.
         batch = _mod_buffer[:]
-        _mod_buffer.clear()
-    # Build the message list for codex judge prompt
+        batch_ids = {r["msg_id"] for r in batch}
+    # Feed bridge-side dupe-tracker; identify Rule 3 candidates to pass into prompt.
+    # `_DupeTracker.add()` returns a trigger list (channel_id, msg_id) when
+    # >= DUPE_CHANNEL_THRESHOLD distinct channels see the same content from
+    # the same user within DUPE_WINDOW_S. Collect those msg_ids.
+    rule3_ids = set()
+    try:
+        import time as _t
+        now_s = _t.time()
+        for r in batch:
+            ch_id = r.get("channel_id")
+            user_id = r.get("author_id")
+            if ch_id is None or user_id is None:
+                continue
+            trigger = _mod_dupe_tracker.add(
+                user_id=user_id, channel_id=ch_id, msg_id=r["msg_id"],
+                text=r["content"], now_s=now_s,
+            )
+            if trigger:
+                # All msg_ids in the trigger list are Rule 3 candidates
+                rule3_ids.update(m for (_c, m) in trigger)
+    except Exception as e:
+        print(f"  [mod-flush] dupe-tracker error (continuing without rule_3 context): {e}", flush=True)
     messages_for_judge = [
         {
             "msg_id": r["msg_id"],
@@ -1170,23 +1259,36 @@ async def _flush_mod_buffer():
             "content": r["content"],
             "is_reply": r["is_reply"],
             "parent_content": r["parent_content"],
+            "_rule3_candidate": r["msg_id"] in rule3_ids,
         }
         for r in batch
     ]
     messages_by_id = {r["msg_id"]: r["_msg"] for r in batch}
+    rules_context = ""
+    if rule3_ids:
+        rules_context = (
+            f"Rule 3 candidates (cross-channel duplicates detected by bridge in last 5min): "
+            f"{sorted(rule3_ids)}. For these set rule_match=rule_3 AND additionally include "
+            f"a boolean violates_server_rules: true|false in the verdict (true if the duplicates "
+            f"violate a general server rule, false if benign legit cross-post)."
+        )
     try:
-        verdicts = await _codex_judge_batch(messages_for_judge)
+        verdicts = await _codex_judge_batch(messages_for_judge, rules_context=rules_context)
     except Exception as e:
-        print(f"  [mod-flush] codex judge failed: {e}", flush=True)
+        print(f"  [mod-flush] codex judge failed: {e} — batch retained in buffer for retry", flush=True)
         return
     if not verdicts:
+        print(f"  [mod-flush] codex returned no verdicts — batch retained in buffer for retry", flush=True)
         return
+    # Dispatch — clear the judged messages from the buffer ONLY on dispatch success.
     try:
         summary = await _dispatch_verdicts(verdicts, messages_by_id, client_ref=client,
                                              off_topic_tracker=_mod_streak_tracker)
+        async with lock:
+            _mod_buffer[:] = [r for r in _mod_buffer if r["msg_id"] not in batch_ids]
         print(f"  [mod-flush] batch={len(batch)} verdicts={len(verdicts)} {summary}", flush=True)
     except Exception as e:
-        print(f"  [mod-flush] dispatch failed: {e}", flush=True)
+        print(f"  [mod-flush] dispatch failed: {e} — batch retained in buffer for retry", flush=True)
     # GC the dupe tracker periodically so it doesn't grow unbounded
     try:
         import time as _t

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -1065,13 +1065,15 @@ async def _dispatch_verdicts(verdicts, messages_by_id, client_ref, off_topic_tra
         if not rule_match:
             # Clean message — no action. But for Rule 7, we still record
             # the on-topic verdict (off_topic=False) into the streak tracker.
+            # Mod messages never reach this path: `_observe_for_mod()` filters
+            # them at observation time and feeds the streak tracker directly
+            # with is_mod=True. So is_mod is always False here.
             if off_topic_tracker is not None:
                 channel_id = getattr(msg.channel, "id", None)
                 user_id = getattr(msg.author, "id", None)
-                is_mod = bool(getattr(v, "_is_mod", False))  # caller can flag
                 if channel_id is not None and user_id is not None:
                     import time as _t
-                    off_topic_tracker.record(channel_id, user_id, off_topic=False, is_mod=is_mod, now_s=_t.time())
+                    off_topic_tracker.record(channel_id, user_id, off_topic=False, is_mod=False, now_s=_t.time())
             summary["skipped"] += 1
             continue
         # Rule 7 path: judge says message is off-topic. Feed off_topic=True
@@ -1148,7 +1150,8 @@ async def _dispatch_verdicts(verdicts, messages_by_id, client_ref, off_topic_tra
 MOD_BUFFER_FLUSH_INTERVAL_S = 5      # flush every N seconds when buffer non-empty
 MOD_BUFFER_SIZE_THRESHOLD = 20       # also flush when buffer hits this size
 _mod_buffer = []                     # type: list  (each entry is a dict + the discord.Message)
-_mod_buffer_lock = None              # asyncio.Lock created in on_ready
+_mod_buffer_lock = None              # asyncio.Lock guarding _mod_buffer mutation
+_mod_flush_lock = None               # asyncio.Lock serializing whole-flush executions
 _mod_dupe_tracker = _DupeTracker()
 _mod_streak_tracker = _OffTopicStreakTracker()
 
@@ -1161,11 +1164,29 @@ def _ensure_mod_lock():
     return _mod_buffer_lock
 
 
+def _ensure_mod_flush_lock():
+    """Lazy-init asyncio.Lock that serializes flushes. Single-flight guard:
+    only one `_flush_mod_buffer` call runs at a time. Subsequent invocations
+    await this lock, then re-snapshot the buffer (which by then has been
+    cleared of the prior batch on success, or still contains it on failure
+    so the retry processes it). Without this, a threshold-eager flush + the
+    timer flush can race and double-judge / double-action the same batch."""
+    global _mod_flush_lock
+    if _mod_flush_lock is None:
+        _mod_flush_lock = asyncio.Lock()
+    return _mod_flush_lock
+
+
 async def _observe_for_mod(message):
     """Push a message into the auto-mod buffer if its guild has mod_active=True
     and the author is not a mod (G1). Called from the top of
     `_handle_discord_message`. Returns silently — never blocks the existing
-    task pipeline."""
+    task pipeline.
+
+    Mod messages are NOT buffered (G1 immunity) but they DO feed the
+    Rule 7 streak tracker as `is_mod=True` so an in-channel mod intervention
+    resets any pending off-topic streak — which is the whole point of the
+    streak-tracker's mod-reset rule."""
     try:
         guild = getattr(message, "guild", None)
         if guild is None:
@@ -1174,7 +1195,19 @@ async def _observe_for_mod(message):
         if not active:
             return  # this guild hasn't opted in
         if _is_moderator(message.author, mod_role_ids):
-            return  # G1 — mod immunity at observation time
+            # G1 — mods aren't judged. But Rule 7 wants mod intervention to
+            # reset the channel streak; feed the tracker directly.
+            channel_id = getattr(message.channel, "id", None)
+            user_id = getattr(message.author, "id", None)
+            if channel_id is not None and user_id is not None:
+                try:
+                    import time as _t
+                    _mod_streak_tracker.record(
+                        channel_id, user_id, off_topic=False, is_mod=True, now_s=_t.time()
+                    )
+                except Exception as e:
+                    print(f"  [mod-observe] mod-reset streak failed: {e}", flush=True)
+            return
         # Build a queued-message record and append to buffer.
         rec = {
             "msg_id": str(getattr(message, "id", "")),
@@ -1215,13 +1248,23 @@ def _resolve_reply_parent_content(message):
 
 async def _flush_mod_buffer():
     """Drain the buffer, run codex batch judge, dispatch actions. Idempotent
-    when buffer is empty. Caller (timer / threshold trigger) doesn't need
-    to coordinate — internal lock makes this safe to invoke concurrently.
+    when buffer is empty. Concurrent calls are serialized by `_mod_flush_lock`
+    — single-flight, so the same messages cannot be judged twice.
 
     Failure semantics: snapshot buffer WITHOUT clearing. Clear only after
     successful dispatch. On codex/judge failure or empty-verdicts the
     messages remain in the buffer for the next flush. Prevents silent
     data loss when codex times out or returns malformed output."""
+    flush_lock = _ensure_mod_flush_lock()
+    async with flush_lock:
+        await _flush_mod_buffer_inner()
+
+
+async def _flush_mod_buffer_inner():
+    """Body of `_flush_mod_buffer`. Caller MUST hold `_mod_flush_lock`.
+    Split out so tests can drive the body directly without the outer lock
+    (e.g. the concurrency test asserts that two parallel _flush_mod_buffer
+    calls serialize and don't double-process)."""
     lock = _ensure_mod_lock()
     async with lock:
         if not _mod_buffer:
@@ -1234,6 +1277,10 @@ async def _flush_mod_buffer():
     # >= DUPE_CHANNEL_THRESHOLD distinct channels see the same content from
     # the same user within DUPE_WINDOW_S. Collect those msg_ids.
     rule3_ids = set()
+    # (user_id, text) keys whose buckets fired Rule 3 in this batch — clear
+    # them after dispatch success so a follow-up repost in the 5min window
+    # doesn't inherit the stale 3-channel evidence.
+    triggered_keys = []
     try:
         import time as _t
         now_s = _t.time()
@@ -1249,6 +1296,7 @@ async def _flush_mod_buffer():
             if trigger:
                 # All msg_ids in the trigger list are Rule 3 candidates
                 rule3_ids.update(m for (_c, m) in trigger)
+                triggered_keys.append((user_id, r["content"]))
     except Exception as e:
         print(f"  [mod-flush] dupe-tracker error (continuing without rule_3 context): {e}", flush=True)
     messages_for_judge = [
@@ -1286,6 +1334,13 @@ async def _flush_mod_buffer():
                                              off_topic_tracker=_mod_streak_tracker)
         async with lock:
             _mod_buffer[:] = [r for r in _mod_buffer if r["msg_id"] not in batch_ids]
+        # Clear Rule 3 evidence for keys that fired in this batch — only
+        # after dispatch success so a retry can still re-trigger if needed.
+        for (uid, text) in triggered_keys:
+            try:
+                _mod_dupe_tracker.clear(uid, text)
+            except Exception as e:
+                print(f"  [mod-flush] dupe-tracker clear failed for ({uid}): {e}", flush=True)
         print(f"  [mod-flush] batch={len(batch)} verdicts={len(verdicts)} {summary}", flush=True)
     except Exception as e:
         print(f"  [mod-flush] dispatch failed: {e} — batch retained in buffer for retry", flush=True)

--- a/tests/discord-bridge-mod-judge-actions.test.py
+++ b/tests/discord-bridge-mod-judge-actions.test.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+Tests for the per-rule action dispatchers in discord-bridge.py.
+
+PR3 of 4 — covers `_post_mod_escalation`, `_action_delete_and_escalate`,
+`_action_redirect_to_jobs`, `_action_escalate_only`, `_action_polite_reminder`.
+The buffer + on_message wiring + Rule-3/Rule-7 stateful detectors land in PR4.
+
+Tests use mocked discord.py message + channel objects so no real Discord
+API hits.
+
+Run: python3 tests/discord-bridge-mod-judge-actions.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *args, **kwargs):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+    def get_channel(self, _id): return None
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# Per-guild mod config fixture: provide channels + cc list that the action
+# functions look up via `_load_mod_server_config(guild_id)`. Replaces real
+# access.json read so tests don't need a populated file.
+_TEST_ESCALATION_CHANNEL_ID = 1153753796321738863
+_TEST_JOBS_CHANNEL_ID = 1168719200605437952
+_TEST_ESCALATION_CCS = ("<@1022910063620390932>", "<@1025828152183885925>", "<@786410785197785088>")
+
+
+def _fake_server_config(guild_id):
+    return {
+        "escalation_channel": _TEST_ESCALATION_CHANNEL_ID,
+        "escalation_ccs": _TEST_ESCALATION_CCS,
+        "redirect_channel_jobs": _TEST_JOBS_CHANNEL_ID,
+    }
+
+
+bridge._load_mod_server_config = _fake_server_config
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+class _MockChannel:
+    """Captures every .send() call. Returns a sentinel message object."""
+    def __init__(self, name="general", channel_id=999):
+        self.name = name
+        self.id = channel_id
+        self.sent = []  # list of strings sent
+        self.send_should_raise = None
+    async def send(self, content):
+        if self.send_should_raise:
+            raise self.send_should_raise
+        self.sent.append(content)
+        return types.SimpleNamespace(id=12345, content=content)
+
+
+class _MockMessage:
+    """Captures .delete() calls."""
+    def __init__(self, msg_id="111", author_id=999, author_name="alice",
+                 channel=None, content="hi", jump_url="https://discord/jump"):
+        self.id = msg_id
+        self.author = types.SimpleNamespace(id=author_id, display_name=author_name)
+        self.channel = channel or _MockChannel()
+        self.content = content
+        self.jump_url = jump_url
+        self.deleted = False
+        self.delete_should_raise = None
+    async def delete(self):
+        if self.delete_should_raise:
+            raise self.delete_should_raise
+        self.deleted = True
+
+
+def _client_with_mod_channel(mock_mod_ch):
+    """Return a client mock where get_channel(_TEST_ESCALATION_CHANNEL_ID) returns mock_mod_ch."""
+    def get_channel(cid):
+        if cid == _TEST_ESCALATION_CHANNEL_ID:
+            return mock_mod_ch
+        return None
+    return types.SimpleNamespace(get_channel=get_channel)
+
+
+# ---------------------------------------------------------------------------
+# _post_mod_escalation
+# ---------------------------------------------------------------------------
+
+def case_post_mod_escalation_basic() -> list[str]:
+    fails = []
+    mod_ch = _MockChannel(name="moderator-only")
+    client = _client_with_mod_channel(mod_ch)
+    msg = _MockMessage(content="some bad message")
+    asyncio.run(bridge._post_mod_escalation(client, msg, "rule_1", "crypto-spam pattern"))
+    if not mod_ch.sent:
+        fails.append("a) escalation should post to mod channel")
+        return fails
+    posted = mod_ch.sent[0]
+    if "rule_1" not in posted:
+        fails.append("a) post should include rule label")
+    if "crypto-spam pattern" not in posted:
+        fails.append("a) post should include rationale")
+    if "<@1022910063620390932>" not in posted:
+        fails.append("a) post should cc Chi snowflake")
+    if "<@786410785197785088>" not in posted:
+        fails.append("a) post should cc msze snowflake")
+    if "<@1025828152183885925>" not in posted:
+        fails.append("a) post should cc Qingyun snowflake")
+    return fails
+
+
+def case_post_mod_escalation_no_channel_in_cache() -> list[str]:
+    """If client.get_channel returns None (channel not in cache), don't crash."""
+    fails = []
+    client = types.SimpleNamespace(get_channel=lambda _id: None)
+    msg = _MockMessage()
+    result = asyncio.run(bridge._post_mod_escalation(client, msg, "rule_1", ""))
+    if result is not None:
+        fails.append("b) should return None when mod channel not cached")
+    return fails
+
+
+def case_post_mod_escalation_includes_extras() -> list[str]:
+    fails = []
+    mod_ch = _MockChannel()
+    client = _client_with_mod_channel(mod_ch)
+    msg = _MockMessage()
+    asyncio.run(bridge._post_mod_escalation(client, msg, "rule_3", "raid pattern",
+                                             extras_md="Cross-channel duplicates: #a, #b, #c"))
+    posted = mod_ch.sent[0]
+    if "Cross-channel duplicates" not in posted:
+        fails.append("c) extras_md should appear in post")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _action_delete_and_escalate
+# ---------------------------------------------------------------------------
+
+def case_action_delete_and_escalate_happy() -> list[str]:
+    fails = []
+    mod_ch = _MockChannel()
+    client = _client_with_mod_channel(mod_ch)
+    msg = _MockMessage(content="crypto job spam $X/hour DM @everyone")
+    verdict = {"msg_id": "111", "rule_match": "rule_1", "confidence": 0.92,
+               "rationale": "crypto-job-listing"}
+    deleted, esc = asyncio.run(bridge._action_delete_and_escalate(client, msg, verdict))
+    if not deleted:
+        fails.append("d) message should be deleted")
+    if not msg.deleted:
+        fails.append("d) message.delete() should have been called")
+    if not mod_ch.sent:
+        fails.append("d) escalation post should have been made")
+    return fails
+
+
+def case_action_delete_and_escalate_delete_fails() -> list[str]:
+    """If delete fails (e.g. msg already gone), still post the escalation."""
+    fails = []
+    mod_ch = _MockChannel()
+    client = _client_with_mod_channel(mod_ch)
+    msg = _MockMessage()
+    msg.delete_should_raise = Exception("404 Not Found")
+    verdict = {"rule_match": "rule_2", "confidence": 0.91, "rationale": "csam-bait"}
+    deleted, esc = asyncio.run(bridge._action_delete_and_escalate(client, msg, verdict))
+    if deleted:
+        fails.append("e) deleted should be False when delete raises")
+    if not mod_ch.sent:
+        fails.append("e) escalation should still post even if delete failed")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _action_redirect_to_jobs
+# ---------------------------------------------------------------------------
+
+def case_action_redirect_to_jobs_happy() -> list[str]:
+    fails = []
+    src_ch = _MockChannel(name="ag-for-mobile", channel_id=500)
+    client = types.SimpleNamespace(get_channel=lambda _id: None)
+    msg = _MockMessage(channel=src_ch, content="iOS dev DM me")
+    verdict = {"rule_match": "rule_4", "confidence": 0.88, "rationale": "job-availability"}
+    deleted, redirect = asyncio.run(bridge._action_redirect_to_jobs(client, msg, verdict))
+    if not deleted:
+        fails.append("f) message should be deleted")
+    if not src_ch.sent:
+        fails.append("f) redirect should be posted in same channel")
+        return fails
+    redirect_text = src_ch.sent[0]
+    if f"<#{_TEST_JOBS_CHANNEL_ID}>" not in redirect_text:
+        fails.append("f) redirect should mention #jobs channel by id")
+    if f"<@{msg.author.id}>" not in redirect_text:
+        fails.append("f) redirect should @-mention the original author")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _action_escalate_only
+# ---------------------------------------------------------------------------
+
+def case_action_escalate_only_no_delete() -> list[str]:
+    fails = []
+    mod_ch = _MockChannel()
+    client = _client_with_mod_channel(mod_ch)
+    msg = _MockMessage(content="possibly harassing message")
+    verdict = {"rule_match": "rule_5", "confidence": 0.93, "rationale": "personal attack"}
+    asyncio.run(bridge._action_escalate_only(client, msg, verdict))
+    if msg.deleted:
+        fails.append("g) escalate-only should NOT delete the suspect message")
+    if not mod_ch.sent:
+        fails.append("g) escalate-only should post to #moderator-only")
+        return fails
+    posted = mod_ch.sent[0]
+    if "rule_5" not in posted:
+        fails.append("g) post should include rule label")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _action_polite_reminder
+# ---------------------------------------------------------------------------
+
+def case_action_polite_reminder() -> list[str]:
+    fails = []
+    ch = _MockChannel(name="ag-for-finance")
+    asyncio.run(bridge._action_polite_reminder(ch))
+    if not ch.sent:
+        fails.append("h) polite reminder should post in the same channel")
+        return fails
+    body = ch.sent[0]
+    if "drifting" not in body and "drift" not in body:
+        fails.append("h) reminder should mention drift / off-topic")
+    if "<@" in body:
+        fails.append("h) reminder should NOT @-mention anyone (don't single out)")
+    return fails
+
+
+def case_action_polite_reminder_send_fails() -> list[str]:
+    """Polite reminder send failure should not raise — return None."""
+    fails = []
+    ch = _MockChannel()
+    ch.send_should_raise = Exception("permission denied")
+    out = asyncio.run(bridge._action_polite_reminder(ch))
+    if out is not None:
+        fails.append("i) failed reminder should return None")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a-escalate-basic", case_post_mod_escalation_basic),
+        ("b-no-cache", case_post_mod_escalation_no_channel_in_cache),
+        ("c-extras", case_post_mod_escalation_includes_extras),
+        ("d-del+esc-happy", case_action_delete_and_escalate_happy),
+        ("e-del-fails", case_action_delete_and_escalate_delete_fails),
+        ("f-redirect", case_action_redirect_to_jobs_happy),
+        ("g-escalate-only", case_action_escalate_only_no_delete),
+        ("h-reminder", case_action_polite_reminder),
+        ("i-reminder-fails", case_action_polite_reminder_send_fails),
+    ]
+    failures: list[str] = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll mod-judge action-dispatcher invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/discord-bridge-mod-judge-buffer.test.py
+++ b/tests/discord-bridge-mod-judge-buffer.test.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""
+Tests for the auto-mod buffer + flush + on_message observation hook
+in discord-bridge.py.
+
+PR6 of 6 (final). Covers `_observe_for_mod` (the on_message hook) and
+`_flush_mod_buffer` (the periodic drain). Patches `_codex_judge_batch`
+and the action helpers to keep tests deterministic.
+
+Run: python3 tests/discord-bridge-mod-judge-buffer.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import asyncio
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *args, **kwargs):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+    def get_channel(self, _id): return None
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# ---------------------------------------------------------------------------
+# Helpers / mocks
+# ---------------------------------------------------------------------------
+
+def _make_message(msg_id, guild_id, author_id, channel_id=42, content="hi",
+                  is_bot=False, role_ids=None):
+    roles = [types.SimpleNamespace(id=r) for r in (role_ids or [])]
+    author = types.SimpleNamespace(
+        id=author_id, display_name=f"u{author_id}", bot=is_bot, roles=roles
+    )
+    guild = types.SimpleNamespace(id=guild_id, owner_id=None)
+    channel = types.SimpleNamespace(id=channel_id, name="general")
+    return types.SimpleNamespace(
+        id=msg_id, author=author, guild=guild, channel=channel,
+        content=content, reference=None,
+    )
+
+
+def _write_access(active=True, mod_roles=None, guild_id=42):
+    """Write a temp access.json; return path."""
+    f = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    json.dump({"guilds": {str(guild_id): {
+        "mod_active": active,
+        "moderator_roles": mod_roles or [],
+    }}}, f)
+    f.close()
+    return Path(f.name)
+
+
+def _reset_buffer():
+    """Tests share module-level _mod_buffer; clear between cases."""
+    bridge._mod_buffer.clear()
+    bridge._mod_buffer_lock = None
+
+
+# ---------------------------------------------------------------------------
+# _observe_for_mod
+# ---------------------------------------------------------------------------
+
+def case_observe_buffers_normal_message() -> list[str]:
+    fails = []
+    _reset_buffer()
+    path = _write_access(active=True, mod_roles=["111"], guild_id=42)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        msg = _make_message("m1", 42, 999, content="hello")
+        asyncio.run(bridge._observe_for_mod(msg))
+        if len(bridge._mod_buffer) != 1:
+            fails.append(f"a) buffer should hold 1 record, got {len(bridge._mod_buffer)}")
+        if bridge._mod_buffer and bridge._mod_buffer[0]["msg_id"] != "m1":
+            fails.append("a) record msg_id should be preserved")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+        _reset_buffer()
+    return fails
+
+
+def case_observe_skips_inactive_guild() -> list[str]:
+    fails = []
+    _reset_buffer()
+    path = _write_access(active=False, mod_roles=[], guild_id=42)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        msg = _make_message("m1", 42, 999)
+        asyncio.run(bridge._observe_for_mod(msg))
+        if bridge._mod_buffer:
+            fails.append("b) inactive guild should not buffer")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+        _reset_buffer()
+    return fails
+
+
+def case_observe_skips_unconfigured_guild() -> list[str]:
+    fails = []
+    _reset_buffer()
+    path = _write_access(active=True, mod_roles=[], guild_id=42)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        # message from a DIFFERENT guild — not in access.json
+        msg = _make_message("m1", 99999, 999)
+        asyncio.run(bridge._observe_for_mod(msg))
+        if bridge._mod_buffer:
+            fails.append("c) unconfigured guild should not buffer")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+        _reset_buffer()
+    return fails
+
+
+def case_observe_skips_mod_message() -> list[str]:
+    """G1 mod-immunity at observation time — mod messages never enter the
+    buffer (saves codex tokens)."""
+    fails = []
+    _reset_buffer()
+    path = _write_access(active=True, mod_roles=["111"], guild_id=42)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        # Author has role 111 → mod
+        msg = _make_message("m1", 42, 999, role_ids=["111"])
+        asyncio.run(bridge._observe_for_mod(msg))
+        if bridge._mod_buffer:
+            fails.append("d) mod author should not buffer")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+        _reset_buffer()
+    return fails
+
+
+def case_observe_skips_dm() -> list[str]:
+    """Messages without a guild (DMs) shouldn't buffer."""
+    fails = []
+    _reset_buffer()
+    msg = types.SimpleNamespace(
+        id="m1", author=types.SimpleNamespace(id=999, display_name="u", bot=False, roles=[]),
+        guild=None, channel=types.SimpleNamespace(id=1, name="dm"),
+        content="hi", reference=None,
+    )
+    asyncio.run(bridge._observe_for_mod(msg))
+    if bridge._mod_buffer:
+        fails.append("e) DM should not buffer (no guild)")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _flush_mod_buffer
+# ---------------------------------------------------------------------------
+
+def case_flush_empty_buffer_no_op() -> list[str]:
+    fails = []
+    _reset_buffer()
+    judge_calls = {"n": 0}
+    async def _stub_judge(messages, rules_context="", model="gpt-4o-mini", timeout_s=30):
+        judge_calls["n"] += 1
+        return []
+    bridge._codex_judge_batch = _stub_judge
+    asyncio.run(bridge._flush_mod_buffer())
+    if judge_calls["n"] != 0:
+        fails.append("f) empty buffer flush should not invoke codex")
+    return fails
+
+
+def case_flush_drains_and_dispatches() -> list[str]:
+    fails = []
+    _reset_buffer()
+    # Set up access.json so _observe queues the messages.
+    path = _write_access(active=True, mod_roles=[], guild_id=42)
+    orig_access = bridge.ACCESS_FILE
+    bridge.ACCESS_FILE = path
+    # Patch codex + dispatcher
+    judge_calls = {"n": 0, "msgs": None}
+    async def _stub_judge(messages, rules_context="", model="gpt-4o-mini", timeout_s=30):
+        judge_calls["n"] += 1
+        judge_calls["msgs"] = messages
+        return [{"msg_id": m["msg_id"], "rule_match": None, "confidence": 0.99, "rationale": ""}
+                for m in messages]
+    bridge._codex_judge_batch = _stub_judge
+    dispatch_calls = {"n": 0, "verdict_count": 0}
+    async def _stub_dispatch(verdicts, msgs_by_id, client_ref, off_topic_tracker=None):
+        dispatch_calls["n"] += 1
+        dispatch_calls["verdict_count"] = len(verdicts)
+        return {"acted": 0, "escalated_only": 0, "skipped": len(verdicts)}
+    bridge._dispatch_verdicts = _stub_dispatch
+    try:
+        # Push 3 messages
+        for i in range(3):
+            msg = _make_message(f"m{i}", 42, 1000 + i, content=f"hi {i}")
+            asyncio.run(bridge._observe_for_mod(msg))
+        if len(bridge._mod_buffer) != 3:
+            fails.append(f"g) buffer should have 3 entries pre-flush, got {len(bridge._mod_buffer)}")
+        # Flush
+        asyncio.run(bridge._flush_mod_buffer())
+        if judge_calls["n"] != 1:
+            fails.append("g) flush should invoke codex once")
+        if dispatch_calls["n"] != 1:
+            fails.append("g) flush should invoke dispatcher once")
+        if dispatch_calls["verdict_count"] != 3:
+            fails.append(f"g) dispatcher should get 3 verdicts, got {dispatch_calls['verdict_count']}")
+        if bridge._mod_buffer:
+            fails.append("g) buffer should be drained after flush")
+    finally:
+        bridge.ACCESS_FILE = orig_access
+        path.unlink(missing_ok=True)
+        _reset_buffer()
+    return fails
+
+
+def case_flush_codex_failure_doesnt_drop_state() -> list[str]:
+    """If codex throws, the flush should log + return without crashing
+    or losing buffer state silently. (Buffer IS drained at lock-release;
+    this is acceptable since we'd rather drop a batch than re-judge
+    the same messages forever.)"""
+    fails = []
+    _reset_buffer()
+    path = _write_access(active=True, mod_roles=[], guild_id=42)
+    orig_access = bridge.ACCESS_FILE
+    bridge.ACCESS_FILE = path
+    async def _stub_judge_raises(messages, rules_context="", model="gpt-4o-mini", timeout_s=30):
+        raise RuntimeError("codex went down")
+    bridge._codex_judge_batch = _stub_judge_raises
+    try:
+        msg = _make_message("m1", 42, 999)
+        asyncio.run(bridge._observe_for_mod(msg))
+        # Should not raise
+        try:
+            asyncio.run(bridge._flush_mod_buffer())
+        except Exception as e:
+            fails.append(f"h) flush should swallow codex errors, raised {e}")
+    finally:
+        bridge.ACCESS_FILE = orig_access
+        path.unlink(missing_ok=True)
+        _reset_buffer()
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a-buffer-normal", case_observe_buffers_normal_message),
+        ("b-skip-inactive", case_observe_skips_inactive_guild),
+        ("c-skip-unconfigured", case_observe_skips_unconfigured_guild),
+        ("d-skip-mod", case_observe_skips_mod_message),
+        ("e-skip-dm", case_observe_skips_dm),
+        ("f-flush-empty", case_flush_empty_buffer_no_op),
+        ("g-flush-drains", case_flush_drains_and_dispatches),
+        ("h-codex-fails", case_flush_codex_failure_doesnt_drop_state),
+    ]
+    failures: list[str] = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll mod-judge buffer/flush invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/discord-bridge-mod-judge-codex.test.py
+++ b/tests/discord-bridge-mod-judge-codex.test.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+Tests for the codex judge wrapper + prompt builder in discord-bridge.py.
+
+PR2 of 3 — covers `_format_judge_prompt` (pure) and `_codex_judge_batch`
+(async, subprocess invocation patched in tests). The buffer/flush state
+machine + on_message hook + per-rule action dispatchers come in PR3.
+
+Run: python3 tests/discord-bridge-mod-judge-codex.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *args, **kwargs):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+    def get_channel(self, _id): return None
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# ---------------------------------------------------------------------------
+# _format_judge_prompt
+# ---------------------------------------------------------------------------
+
+def case_format_prompt_basic() -> list[str]:
+    fails = []
+    msgs = [
+        {"msg_id": "111", "channel_name": "general", "author_name": "alice",
+         "content": "hello world", "is_reply": False, "parent_content": ""},
+    ]
+    out = bridge._format_judge_prompt(msgs)
+    if "msg_id=111" not in out:
+        fails.append("a) prompt should include msg_id")
+    if "@alice" not in out or "#general" not in out:
+        fails.append("a) prompt should include channel + author")
+    if "hello world" not in out:
+        fails.append("a) prompt should include content (repr ok)")
+    if "STRICT JSON" not in out:
+        fails.append("a) prompt should mandate strict JSON")
+    if "rule_1" not in out or "rule_7" not in out:
+        fails.append("a) prompt should enumerate rules 1-7")
+    return fails
+
+
+def case_format_prompt_reply_includes_parent() -> list[str]:
+    fails = []
+    msgs = [
+        {"msg_id": "222", "channel_name": "geo-sf", "author_name": "bob",
+         "content": "discord.gg/abc123", "is_reply": True,
+         "parent_content": "what's your discord for the bay area meetup?"},
+    ]
+    out = bridge._format_judge_prompt(msgs)
+    if "reply to:" not in out:
+        fails.append("b) reply context should appear")
+    if "bay area meetup" not in out:
+        fails.append("b) parent content should be included")
+    return fails
+
+
+def case_format_prompt_truncates_long_content() -> list[str]:
+    fails = []
+    long = "x" * 5000
+    msgs = [
+        {"msg_id": "333", "channel_name": "x", "author_name": "y",
+         "content": long, "is_reply": False, "parent_content": ""},
+    ]
+    out = bridge._format_judge_prompt(msgs)
+    # 500-char cap for content; the prompt should not contain the full 5000
+    if long in out:
+        fails.append("c) content should be truncated to 500 chars")
+    return fails
+
+
+def case_format_prompt_with_rules_context() -> list[str]:
+    fails = []
+    msgs = [{"msg_id": "111", "channel_name": "x", "author_name": "y",
+             "content": "z", "is_reply": False, "parent_content": ""}]
+    out = bridge._format_judge_prompt(msgs, rules_context="user posted in 4 channels")
+    if "user posted in 4 channels" not in out:
+        fails.append("d) rules_context should appear in prompt")
+    if "Additional context" not in out:
+        fails.append("d) rules_context section header should appear")
+    return fails
+
+
+def case_format_prompt_empty_messages() -> list[str]:
+    """Empty message list should still produce a well-formed prompt
+    (even though caller shouldn't invoke judge with no messages)."""
+    fails = []
+    out = bridge._format_judge_prompt([])
+    if "STRICT JSON" not in out:
+        fails.append("e) empty-msgs prompt should still have schema directive")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _codex_judge_batch (subprocess patched)
+# ---------------------------------------------------------------------------
+
+def _patch_codex(bridge_mod, fake_stdout):
+    """Replace `_run_codex_subprocess` with one that returns `fake_stdout`."""
+    async def _stub(prompt, model, timeout_s):
+        return fake_stdout
+    bridge_mod._run_codex_subprocess = _stub
+
+
+def case_judge_batch_happy_path() -> list[str]:
+    fails = []
+    fake = json.dumps({"verdicts": [
+        {"msg_id": "111", "rule_match": "rule_1", "confidence": 0.92, "rationale": "crypto-job spam"},
+        {"msg_id": "222", "rule_match": None, "confidence": 0.99, "rationale": "clean"},
+    ]})
+    _patch_codex(bridge, fake)
+    msgs = [
+        {"msg_id": "111", "channel_name": "x", "author_name": "y", "content": "z", "is_reply": False, "parent_content": ""},
+        {"msg_id": "222", "channel_name": "x", "author_name": "y", "content": "z", "is_reply": False, "parent_content": ""},
+    ]
+    verdicts = asyncio.run(bridge._codex_judge_batch(msgs))
+    if len(verdicts) != 2:
+        fails.append(f"f) should return 2 verdicts, got {len(verdicts)}")
+    if verdicts and verdicts[0]["rule_match"] != "rule_1":
+        fails.append("f) verdict ordering should be preserved")
+    return fails
+
+
+def case_judge_batch_empty_messages() -> list[str]:
+    """Empty msg list should short-circuit without invoking codex."""
+    fails = []
+    called = {"n": 0}
+    async def _stub(prompt, model, timeout_s):
+        called["n"] += 1
+        return "[]"
+    bridge._run_codex_subprocess = _stub
+    verdicts = asyncio.run(bridge._codex_judge_batch([]))
+    if verdicts != []:
+        fails.append("g) empty-msgs should return []")
+    if called["n"] != 0:
+        fails.append("g) empty-msgs should NOT spawn codex subprocess")
+    return fails
+
+
+def case_judge_batch_malformed_codex_output() -> list[str]:
+    fails = []
+    _patch_codex(bridge, "not json garbage")
+    msgs = [{"msg_id": "111", "channel_name": "x", "author_name": "y",
+             "content": "z", "is_reply": False, "parent_content": ""}]
+    verdicts = asyncio.run(bridge._codex_judge_batch(msgs))
+    if verdicts != []:
+        fails.append("h) malformed codex output should return []")
+    return fails
+
+
+def case_judge_batch_codex_empty_string() -> list[str]:
+    """codex subprocess failure (timeout, non-zero exit) returns empty
+    stdout; downstream should parse to []."""
+    fails = []
+    _patch_codex(bridge, "")
+    msgs = [{"msg_id": "111", "channel_name": "x", "author_name": "y",
+             "content": "z", "is_reply": False, "parent_content": ""}]
+    verdicts = asyncio.run(bridge._codex_judge_batch(msgs))
+    if verdicts != []:
+        fails.append("i) empty codex output should return []")
+    return fails
+
+
+def case_judge_batch_passes_model_arg() -> list[str]:
+    fails = []
+    captured = {"model": None, "prompt": None}
+    async def _capture(prompt, model, timeout_s):
+        captured["model"] = model
+        captured["prompt"] = prompt
+        return "[]"
+    bridge._run_codex_subprocess = _capture
+    msgs = [{"msg_id": "111", "channel_name": "x", "author_name": "y",
+             "content": "z", "is_reply": False, "parent_content": ""}]
+    asyncio.run(bridge._codex_judge_batch(msgs, model="gpt-4o-mini"))
+    if captured["model"] != "gpt-4o-mini":
+        fails.append(f"j) model arg should pass through, got {captured['model']}")
+    if "msg_id=111" not in (captured["prompt"] or ""):
+        fails.append("j) prompt should be the formatted judge prompt")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a-format-basic", case_format_prompt_basic),
+        ("b-format-reply", case_format_prompt_reply_includes_parent),
+        ("c-format-trunc", case_format_prompt_truncates_long_content),
+        ("d-format-ctx", case_format_prompt_with_rules_context),
+        ("e-format-empty", case_format_prompt_empty_messages),
+        ("f-batch-happy", case_judge_batch_happy_path),
+        ("g-batch-empty", case_judge_batch_empty_messages),
+        ("h-batch-malformed", case_judge_batch_malformed_codex_output),
+        ("i-batch-empty-out", case_judge_batch_codex_empty_string),
+        ("j-batch-model-arg", case_judge_batch_passes_model_arg),
+    ]
+    failures: list[str] = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll codex-judge wrapper invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/discord-bridge-mod-judge-dispatcher.test.py
+++ b/tests/discord-bridge-mod-judge-dispatcher.test.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+Tests for the verdict dispatcher in discord-bridge.py.
+
+PR5 of 6 — covers `_dispatch_verdicts`. PR6 wires the on_message hook +
+buffer + flush timer.
+
+Run: python3 tests/discord-bridge-mod-judge-dispatcher.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *args, **kwargs):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+    def get_channel(self, _id): return None
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# ---------------------------------------------------------------------------
+# Mocks — the dispatcher calls action helpers; capture action types.
+# ---------------------------------------------------------------------------
+
+class _MockChannel:
+    def __init__(self, name="g", channel_id=42):
+        self.name = name
+        self.id = channel_id
+        self.sent = []
+    async def send(self, content):
+        self.sent.append(content)
+        return types.SimpleNamespace(id=12345)
+
+
+class _MockMessage:
+    def __init__(self, msg_id, content="x", channel=None, author_id=999):
+        self.id = msg_id
+        self.author = types.SimpleNamespace(id=author_id, display_name="u")
+        self.channel = channel or _MockChannel()
+        self.content = content
+        self.jump_url = "https://discord/jump"
+        self.deleted = False
+    async def delete(self):
+        self.deleted = True
+
+
+def _patch_actions(bridge_mod):
+    """Replace each action with a counter so we can assert which ran."""
+    counters = {"delete_and_escalate": 0, "redirect_to_jobs": 0,
+                "escalate_only": 0, "polite_reminder": 0}
+
+    async def _del(client, msg, verdict, extras_md=""):
+        counters["delete_and_escalate"] += 1
+        return True, types.SimpleNamespace()
+    async def _red(client, msg, verdict):
+        counters["redirect_to_jobs"] += 1
+        return True, types.SimpleNamespace()
+    async def _esc(client, msg, verdict, extras_md=""):
+        counters["escalate_only"] += 1
+        return types.SimpleNamespace()
+    async def _rem(channel, channel_topic_hint=None):
+        counters["polite_reminder"] += 1
+
+    bridge_mod._action_delete_and_escalate = _del
+    bridge_mod._action_redirect_to_jobs = _red
+    bridge_mod._action_escalate_only = _esc
+    bridge_mod._action_polite_reminder = _rem
+    return counters
+
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+def case_dispatch_rule_1_delete() -> list[str]:
+    fails = []
+    counters = _patch_actions(bridge)
+    msg = _MockMessage("111")
+    msgs = {"111": msg}
+    verdicts = [{"msg_id": "111", "rule_match": "rule_1", "confidence": 0.92, "rationale": ""}]
+    summary = asyncio.run(bridge._dispatch_verdicts(verdicts, msgs, client_ref=None))
+    if counters["delete_and_escalate"] != 1:
+        fails.append(f"a) rule_1 should trigger delete_and_escalate, got {counters}")
+    if summary["acted"] != 1:
+        fails.append(f"a) summary acted=1 expected, got {summary}")
+    return fails
+
+
+def case_dispatch_rule_4_redirect() -> list[str]:
+    fails = []
+    counters = _patch_actions(bridge)
+    msg = _MockMessage("222")
+    verdicts = [{"msg_id": "222", "rule_match": "rule_4", "confidence": 0.90, "rationale": ""}]
+    asyncio.run(bridge._dispatch_verdicts(verdicts, {"222": msg}, client_ref=None))
+    if counters["redirect_to_jobs"] != 1:
+        fails.append("b) rule_4 should trigger redirect_to_jobs")
+    return fails
+
+
+def case_dispatch_rule_5_escalate_only() -> list[str]:
+    fails = []
+    counters = _patch_actions(bridge)
+    msg = _MockMessage("333")
+    verdicts = [{"msg_id": "333", "rule_match": "rule_5", "confidence": 0.95, "rationale": ""}]
+    asyncio.run(bridge._dispatch_verdicts(verdicts, {"333": msg}, client_ref=None))
+    if counters["escalate_only"] != 1:
+        fails.append("c) rule_5 should trigger escalate_only")
+    if counters["delete_and_escalate"] != 0:
+        fails.append("c) rule_5 should NOT trigger delete")
+    return fails
+
+
+def case_dispatch_below_threshold_falls_to_escalate() -> list[str]:
+    """G2: low-confidence verdict for a delete-rule still gets escalate-only,
+    not delete."""
+    fails = []
+    counters = _patch_actions(bridge)
+    msg = _MockMessage("444")
+    verdicts = [{"msg_id": "444", "rule_match": "rule_1", "confidence": 0.40, "rationale": ""}]
+    asyncio.run(bridge._dispatch_verdicts(verdicts, {"444": msg}, client_ref=None))
+    if counters["escalate_only"] != 1:
+        fails.append("d) below-threshold rule_1 should fall to escalate_only")
+    if counters["delete_and_escalate"] != 0:
+        fails.append("d) below-threshold should NOT delete")
+    return fails
+
+
+def case_dispatch_rule_3_violates() -> list[str]:
+    """Rule 3 with violates_server_rules=True → delete + escalate."""
+    fails = []
+    counters = _patch_actions(bridge)
+    msg = _MockMessage("555")
+    verdicts = [{"msg_id": "555", "rule_match": "rule_3", "confidence": 0.90,
+                 "rationale": "", "violates_server_rules": True}]
+    asyncio.run(bridge._dispatch_verdicts(verdicts, {"555": msg}, client_ref=None))
+    if counters["delete_and_escalate"] != 1:
+        fails.append("e) rule_3 + violates_server_rules → delete")
+    return fails
+
+
+def case_dispatch_rule_3_legit_crosspost() -> list[str]:
+    """Rule 3 with violates_server_rules=False → escalate-only."""
+    fails = []
+    counters = _patch_actions(bridge)
+    msg = _MockMessage("666")
+    verdicts = [{"msg_id": "666", "rule_match": "rule_3", "confidence": 0.92,
+                 "rationale": "", "violates_server_rules": False}]
+    asyncio.run(bridge._dispatch_verdicts(verdicts, {"666": msg}, client_ref=None))
+    if counters["escalate_only"] != 1:
+        fails.append("f) rule_3 + NOT violates → escalate-only, not delete")
+    if counters["delete_and_escalate"] != 0:
+        fails.append("f) rule_3 + NOT violates should not delete")
+    return fails
+
+
+def case_dispatch_rule_7_no_action_here() -> list[str]:
+    """Rule 7 dispatch is a no-op in _dispatch_verdicts — the streak tracker
+    + action fire happens upstream at on_message time."""
+    fails = []
+    counters = _patch_actions(bridge)
+    msg = _MockMessage("777")
+    verdicts = [{"msg_id": "777", "rule_match": "rule_7", "confidence": 0.92, "rationale": ""}]
+    summary = asyncio.run(bridge._dispatch_verdicts(verdicts, {"777": msg}, client_ref=None))
+    if any(counters[k] for k in counters):
+        fails.append(f"g) rule_7 should not trigger any action in dispatcher, got {counters}")
+    if summary["skipped"] != 1:
+        fails.append(f"g) rule_7 should be skipped, got {summary}")
+    return fails
+
+
+def case_dispatch_clean_message() -> list[str]:
+    fails = []
+    counters = _patch_actions(bridge)
+    msg = _MockMessage("888")
+    verdicts = [{"msg_id": "888", "rule_match": None, "confidence": 0.99, "rationale": "ok"}]
+    summary = asyncio.run(bridge._dispatch_verdicts(verdicts, {"888": msg}, client_ref=None))
+    if any(counters[k] for k in counters):
+        fails.append("h) clean verdict should not trigger any action")
+    if summary["skipped"] != 1:
+        fails.append("h) clean verdict should count as skipped")
+    return fails
+
+
+def case_dispatch_unknown_msg_id_skipped() -> list[str]:
+    fails = []
+    counters = _patch_actions(bridge)
+    verdicts = [{"msg_id": "999", "rule_match": "rule_1", "confidence": 0.95, "rationale": ""}]
+    summary = asyncio.run(bridge._dispatch_verdicts(verdicts, {}, client_ref=None))
+    if any(counters[k] for k in counters):
+        fails.append("i) verdict with unknown msg_id should not trigger action")
+    if summary["skipped"] != 1:
+        fails.append("i) unknown msg_id should be counted as skipped")
+    return fails
+
+
+def case_dispatch_unknown_rule_falls_to_escalate() -> list[str]:
+    fails = []
+    counters = _patch_actions(bridge)
+    msg = _MockMessage("aaa")
+    verdicts = [{"msg_id": "aaa", "rule_match": "rule_99", "confidence": 0.95, "rationale": ""}]
+    asyncio.run(bridge._dispatch_verdicts(verdicts, {"aaa": msg}, client_ref=None))
+    if counters["escalate_only"] != 1:
+        fails.append("j) unknown rule_match should fall to escalate_only as safe default")
+    return fails
+
+
+def case_dispatch_batch_summary() -> list[str]:
+    """Mixed batch: 1 delete, 1 escalate-only, 1 clean, 1 unknown-id."""
+    fails = []
+    counters = _patch_actions(bridge)
+    msg1 = _MockMessage("1")
+    msg2 = _MockMessage("2")
+    msg3 = _MockMessage("3")
+    msgs = {"1": msg1, "2": msg2, "3": msg3}
+    verdicts = [
+        {"msg_id": "1", "rule_match": "rule_1", "confidence": 0.95, "rationale": ""},
+        {"msg_id": "2", "rule_match": "rule_5", "confidence": 0.95, "rationale": ""},
+        {"msg_id": "3", "rule_match": None, "confidence": 0.99, "rationale": ""},
+        {"msg_id": "404", "rule_match": "rule_1", "confidence": 0.95, "rationale": ""},
+    ]
+    summary = asyncio.run(bridge._dispatch_verdicts(verdicts, msgs, client_ref=None))
+    if summary != {"acted": 1, "escalated_only": 1, "skipped": 2}:
+        fails.append(f"k) summary should reflect mixed outcomes, got {summary}")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a-rule-1", case_dispatch_rule_1_delete),
+        ("b-rule-4", case_dispatch_rule_4_redirect),
+        ("c-rule-5", case_dispatch_rule_5_escalate_only),
+        ("d-g2-fall", case_dispatch_below_threshold_falls_to_escalate),
+        ("e-r3-violates", case_dispatch_rule_3_violates),
+        ("f-r3-legit", case_dispatch_rule_3_legit_crosspost),
+        ("g-r7-noop", case_dispatch_rule_7_no_action_here),
+        ("h-clean", case_dispatch_clean_message),
+        ("i-unknown-msg", case_dispatch_unknown_msg_id_skipped),
+        ("j-unknown-rule", case_dispatch_unknown_rule_falls_to_escalate),
+        ("k-batch-summary", case_dispatch_batch_summary),
+    ]
+    failures: list[str] = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll mod-judge dispatcher invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/discord-bridge-mod-judge-integration.test.py
+++ b/tests/discord-bridge-mod-judge-integration.test.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""
+Integration tests for the AG2 auto-mod LLM-judge end-to-end pipeline:
+observe → buffer → flush → parse → dispatch. Specifically exercises the
+wiring that earlier unit tests didn't cover (Rule 3 dupe context, Rule 7
+streak feed, batch retention on judge failure, mention sanitization).
+
+These cases caught bugs in the original PR #633 (per MacBook cold-review):
+- batch silently dropped on codex failure
+- Rule 3 wiring dead (DupeTracker.add never called)
+- Rule 7 dispatcher path skipped instead of feeding tracker
+- violates_server_rules field stripped at parse time
+- mention-injection in escalation post
+
+Run: python3 tests/discord-bridge-mod-judge-integration.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *a, **kw):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+    def get_channel(self, _id): return None
+
+
+class _AllowedMentions:
+    def __init__(self, *a, **kw): pass
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.AllowedMentions = _AllowedMentions
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+# Per-guild fixture so escalation/redirect resolve cleanly
+def _fake_server_config(guild_id):
+    return {
+        "escalation_channel": 9001,
+        "escalation_ccs": ("<@111>", "<@222>"),
+        "redirect_channel_jobs": 8002,
+    }
+
+
+bridge._load_mod_server_config = _fake_server_config
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+class _MockChannel:
+    def __init__(self, name="general", channel_id=999):
+        self.name = name
+        self.id = channel_id
+        self.sent = []
+    async def send(self, content, allowed_mentions=None):
+        self.sent.append({"content": content, "allowed_mentions": allowed_mentions})
+        return types.SimpleNamespace(id=12345)
+
+
+class _MockMessage:
+    def __init__(self, msg_id, channel, author_id=999, author_name="alice", content="", guild_id=42):
+        self.id = msg_id
+        self.author = types.SimpleNamespace(id=author_id, display_name=author_name)
+        self.channel = channel
+        self.content = content
+        self.guild = types.SimpleNamespace(id=guild_id)
+        self.jump_url = f"https://discord/jump/{msg_id}"
+        self.deleted = False
+    async def delete(self):
+        self.deleted = True
+
+
+def _client_with_channel(mock_ch, ch_id):
+    def get_channel(cid):
+        return mock_ch if cid == ch_id else None
+    return types.SimpleNamespace(get_channel=get_channel)
+
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+def case_a_batch_retained_on_codex_failure():
+    """Buffer must be preserved when codex raises. Original bug: buffer
+    cleared before codex call, so failure = silent loss of 20 messages."""
+    fails = []
+    bridge._mod_buffer.clear()
+    ch = _MockChannel("general", 9999)
+    msg = _MockMessage("m1", ch, content="hello")
+
+    # Inject a synthetic record into the buffer (skip async observe)
+    bridge._mod_buffer.append({
+        "msg_id": "m1", "channel_name": "general", "channel_id": 9999,
+        "author_name": "alice", "author_id": 999, "content": "hello",
+        "is_reply": False, "parent_content": "", "_msg": msg,
+    })
+    # Force codex to fail
+    async def boom(*a, **kw):
+        raise RuntimeError("codex timeout")
+    orig = bridge._codex_judge_batch
+    bridge._codex_judge_batch = boom
+    try:
+        asyncio.run(bridge._flush_mod_buffer())
+        if len(bridge._mod_buffer) != 1:
+            fails.append(f"a) batch should remain in buffer on codex failure (got {len(bridge._mod_buffer)} items)")
+    finally:
+        bridge._codex_judge_batch = orig
+        bridge._mod_buffer.clear()
+    return fails
+
+
+def case_b_batch_retained_on_empty_verdicts():
+    """Buffer must be preserved when codex returns no verdicts (malformed
+    output). Original bug: empty list → silent buffer clear."""
+    fails = []
+    bridge._mod_buffer.clear()
+    ch = _MockChannel("general", 9999)
+    msg = _MockMessage("m1", ch, content="hello")
+    bridge._mod_buffer.append({
+        "msg_id": "m1", "channel_name": "general", "channel_id": 9999,
+        "author_name": "alice", "author_id": 999, "content": "hello",
+        "is_reply": False, "parent_content": "", "_msg": msg,
+    })
+    async def empty(*a, **kw):
+        return []
+    orig = bridge._codex_judge_batch
+    bridge._codex_judge_batch = empty
+    try:
+        asyncio.run(bridge._flush_mod_buffer())
+        if len(bridge._mod_buffer) != 1:
+            fails.append(f"b) batch should remain in buffer when codex returns []")
+    finally:
+        bridge._codex_judge_batch = orig
+        bridge._mod_buffer.clear()
+    return fails
+
+
+def case_c_batch_cleared_on_dispatch_success():
+    """When dispatch completes, the judged messages should be removed from buffer."""
+    fails = []
+    bridge._mod_buffer.clear()
+    ch = _MockChannel("general", 9999)
+    msg = _MockMessage("m1", ch, content="just chatting")
+    bridge._mod_buffer.append({
+        "msg_id": "m1", "channel_name": "general", "channel_id": 9999,
+        "author_name": "alice", "author_id": 999, "content": "just chatting",
+        "is_reply": False, "parent_content": "", "_msg": msg,
+    })
+    async def clean_verdict(*a, **kw):
+        return [{"msg_id": "m1", "rule_match": None, "confidence": 0.95, "rationale": "clean"}]
+    orig_codex = bridge._codex_judge_batch
+    bridge._codex_judge_batch = clean_verdict
+    try:
+        asyncio.run(bridge._flush_mod_buffer())
+        if len(bridge._mod_buffer) != 0:
+            fails.append(f"c) batch should clear after successful dispatch (got {len(bridge._mod_buffer)})")
+    finally:
+        bridge._codex_judge_batch = orig_codex
+        bridge._mod_buffer.clear()
+    return fails
+
+
+def case_d_rule3_dupe_tracker_wired():
+    """When 3 messages with same content land in 3 different channels in
+    the same flush window, dupe-tracker should mark them as Rule 3 candidates
+    and the prompt should carry rule_3 context."""
+    fails = []
+    bridge._mod_buffer.clear()
+    bridge._mod_dupe_tracker = bridge._DupeTracker()
+    captured = {"rules_context": None}
+    async def capture(messages_for_judge, rules_context="", **kw):
+        captured["rules_context"] = rules_context
+        # All Rule 3 candidates should also be in the messages list
+        return [{"msg_id": m["msg_id"], "rule_match": None, "confidence": 0.9, "rationale": "ok"}
+                for m in messages_for_judge]
+    orig = bridge._codex_judge_batch
+    bridge._codex_judge_batch = capture
+    try:
+        for i, ch_id in enumerate([100, 200, 300]):
+            ch = _MockChannel(f"ch{i}", ch_id)
+            msg = _MockMessage(f"m{i}", ch, content="join my crypto server discord.gg/xyz")
+            bridge._mod_buffer.append({
+                "msg_id": f"m{i}", "channel_name": f"ch{i}", "channel_id": ch_id,
+                "author_name": "spammer", "author_id": 999, "content": "join my crypto server discord.gg/xyz",
+                "is_reply": False, "parent_content": "", "_msg": msg,
+            })
+        asyncio.run(bridge._flush_mod_buffer())
+        if not captured["rules_context"]:
+            fails.append("d) dupe-tracker should add+detect duplicates and inject rule_3 context into prompt")
+        elif "rule_3" not in captured["rules_context"]:
+            fails.append(f"d) rules_context should mention rule_3 (got: {captured['rules_context'][:80]})")
+    finally:
+        bridge._codex_judge_batch = orig
+        bridge._mod_buffer.clear()
+    return fails
+
+
+def case_e_rule7_feeds_streak_tracker():
+    """When dispatcher receives a rule_7 verdict, it should feed off_topic=True
+    into the streak tracker (originally the path skipped without feeding)."""
+    fails = []
+    bridge._mod_streak_tracker = bridge._OffTopicStreakTracker()
+    ch = _MockChannel("focused-channel", 4242)
+    msg = _MockMessage("m1", ch, content="random off-topic chat", author_id=777)
+    verdicts = [{"msg_id": "m1", "rule_match": "rule_7", "confidence": 0.95, "rationale": "off-topic"}]
+    asyncio.run(bridge._dispatch_verdicts(
+        verdicts, {"m1": msg}, client_ref=None,
+        off_topic_tracker=bridge._mod_streak_tracker,
+    ))
+    # After 1 rule_7 verdict, the tracker should have 1 off-topic entry for this channel.
+    snapshot = bridge._mod_streak_tracker._streaks.get("4242", [])
+    if not snapshot:
+        fails.append("e) rule_7 verdict should feed an entry into _OffTopicStreakTracker")
+    elif not any(e.get("off_topic") for e in snapshot):
+        fails.append("e) rule_7 verdict should feed off_topic=True into tracker")
+    return fails
+
+
+def case_f_violates_server_rules_preserved():
+    """_parse_judge_output must preserve `violates_server_rules` so the
+    dispatcher's rule_3 escape hatch is reachable."""
+    fails = []
+    raw = (
+        '{"verdicts":[{"msg_id":"m1","rule_match":"rule_3",'
+        '"confidence":0.9,"rationale":"legit cross-post",'
+        '"violates_server_rules":false}]}'
+    )
+    parsed = bridge._parse_judge_output(raw)
+    if not parsed:
+        fails.append("f) parser should return verdict for valid rule_3 output")
+        return fails
+    if "violates_server_rules" not in parsed[0]:
+        fails.append("f) violates_server_rules field should be preserved by parser")
+    elif parsed[0]["violates_server_rules"] is not False:
+        fails.append(f"f) violates_server_rules=false should preserve as False (got {parsed[0]['violates_server_rules']})")
+    return fails
+
+
+def case_g_rule3_legit_crosspost_escalates_only():
+    """When rule_3 verdict has violates_server_rules=False, dispatcher
+    should escalate-only (NOT delete). Originally the escape hatch was
+    unreachable because parser stripped the field."""
+    fails = []
+    mod_ch = _MockChannel("mod-only", 9001)
+    client = _client_with_channel(mod_ch, 9001)
+    ch = _MockChannel("ann-1", 4321)
+    msg = _MockMessage("m1", ch, content="Event Friday at 3pm!")
+    verdicts = [{
+        "msg_id": "m1", "rule_match": "rule_3", "confidence": 0.95,
+        "rationale": "legit cross-post", "violates_server_rules": False,
+    }]
+    asyncio.run(bridge._dispatch_verdicts(verdicts, {"m1": msg}, client_ref=client))
+    if msg.deleted:
+        fails.append("g) Rule 3 with violates_server_rules=False should NOT delete the message")
+    if not mod_ch.sent:
+        fails.append("g) Rule 3 with violates_server_rules=False should escalate-only (post to mod channel)")
+    return fails
+
+
+def case_h_mention_injection_sanitized():
+    """Suspect message containing @everyone should not produce a real ping
+    in the escalation post. Body should also use allowed_mentions to limit
+    to cc users only."""
+    fails = []
+    mod_ch = _MockChannel("mod-only", 9001)
+    client = _client_with_channel(mod_ch, 9001)
+    ch = _MockChannel("general", 7777)
+    msg = _MockMessage("m1", ch, content="@everyone free crypto here", author_id=999)
+    asyncio.run(bridge._post_mod_escalation(client, msg, "rule_1", "spam pattern"))
+    if not mod_ch.sent:
+        fails.append("h) escalation should still post even with hostile content")
+        return fails
+    posted = mod_ch.sent[0]["content"]
+    if "@everyone" in posted and "@\u200beveryone" not in posted:
+        fails.append("h) @everyone should be sanitized (zero-width space inserted after @)")
+    am = mod_ch.sent[0]["allowed_mentions"]
+    if am is None:
+        fails.append("h) allowed_mentions should be set on the escalation send")
+    return fails
+
+
+def main():
+    cases = [
+        ("a-batch-retained-on-codex-failure", case_a_batch_retained_on_codex_failure),
+        ("b-batch-retained-on-empty-verdicts", case_b_batch_retained_on_empty_verdicts),
+        ("c-batch-cleared-on-dispatch-success", case_c_batch_cleared_on_dispatch_success),
+        ("d-rule3-dupe-tracker-wired", case_d_rule3_dupe_tracker_wired),
+        ("e-rule7-feeds-streak-tracker", case_e_rule7_feeds_streak_tracker),
+        ("f-violates-server-rules-preserved", case_f_violates_server_rules_preserved),
+        ("g-rule3-legit-crosspost-escalates-only", case_g_rule3_legit_crosspost_escalates_only),
+        ("h-mention-injection-sanitized", case_h_mention_injection_sanitized),
+    ]
+    failures = []
+    for label, fn in cases:
+        fs = fn()
+        if fs:
+            failures.extend([(label, msg) for msg in fs])
+            print(f"  ✗ case {label}")
+            for f in fs:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll mod-judge integration invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/discord-bridge-mod-judge-integration.test.py
+++ b/tests/discord-bridge-mod-judge-integration.test.py
@@ -328,6 +328,174 @@ def case_h_mention_injection_sanitized():
     return fails
 
 
+def case_i_concurrent_flush_single_flight():
+    """v2 HIGH: Two parallel `_flush_mod_buffer()` calls must not double-judge
+    the same batch. Original bug (pre-fix): snapshot under buffer-lock, release
+    for codex, only clear after dispatch — so a second flush snapshots the same
+    still-populated buffer and the same messages get judged twice. Fix uses a
+    flush-level lock for single-flight execution.
+
+    Test: launch 2 flushes concurrently with a slow codex stub; assert codex
+    is invoked exactly once with all messages, and the buffer ends empty."""
+    fails = []
+    bridge._mod_buffer.clear()
+    # Reset locks so a fresh asyncio event loop can recreate them
+    bridge._mod_buffer_lock = None
+    bridge._mod_flush_lock = None
+    ch = _MockChannel("general", 9999)
+    msgs = []
+    for i in range(3):
+        m = _MockMessage(f"m{i}", ch, content=f"hello {i}", author_id=900 + i)
+        msgs.append(m)
+        bridge._mod_buffer.append({
+            "msg_id": f"m{i}", "channel_name": "general", "channel_id": 9999,
+            "author_name": f"user{i}", "author_id": 900 + i, "content": f"hello {i}",
+            "is_reply": False, "parent_content": "", "_msg": m,
+        })
+    invocations = {"count": 0, "msg_ids_seen": []}
+
+    async def slow_codex(messages_for_judge, rules_context="", **kw):
+        invocations["count"] += 1
+        invocations["msg_ids_seen"].append([m["msg_id"] for m in messages_for_judge])
+        # Simulate codex latency so the concurrent flush has time to enter
+        # and try to snapshot the same buffer.
+        await asyncio.sleep(0.05)
+        return [{"msg_id": m["msg_id"], "rule_match": None, "confidence": 0.9, "rationale": "ok"}
+                for m in messages_for_judge]
+    orig = bridge._codex_judge_batch
+    bridge._codex_judge_batch = slow_codex
+    try:
+        async def run_two():
+            await asyncio.gather(
+                bridge._flush_mod_buffer(),
+                bridge._flush_mod_buffer(),
+            )
+        asyncio.run(run_two())
+        if invocations["count"] != 1:
+            fails.append(f"i) codex should be invoked exactly once for one batch (got {invocations['count']})")
+        if invocations["msg_ids_seen"] and len(invocations["msg_ids_seen"][0]) != 3:
+            fails.append(f"i) first invocation should see all 3 messages (got {invocations['msg_ids_seen']})")
+        if len(bridge._mod_buffer) != 0:
+            fails.append(f"i) buffer should be cleared after successful dispatch (got {len(bridge._mod_buffer)})")
+    finally:
+        bridge._codex_judge_batch = orig
+        bridge._mod_buffer.clear()
+    return fails
+
+
+def case_j_rule3_clears_after_trigger():
+    """v2 MEDIUM: After a Rule 3 trigger fires and dispatch succeeds, the
+    DupeTracker bucket for that (user_id, text) key must be cleared. Otherwise
+    a follow-up post in the 5-min window inherits the old 3-channel evidence
+    and re-triggers Rule 3 with weak evidence (1 new + 3 stale msgs).
+
+    Test: trigger Rule 3, run flush, then assert the bucket is empty so a
+    new post in a 4th channel does NOT immediately trigger again."""
+    fails = []
+    bridge._mod_buffer.clear()
+    bridge._mod_dupe_tracker = bridge._DupeTracker()
+    # Reset flush lock so this test's event loop creates a fresh one
+    bridge._mod_buffer_lock = None
+    bridge._mod_flush_lock = None
+    spam_text = "JOIN MY CRYPTO discord.gg/zzz"
+    user_id = 13579
+
+    async def clean_codex(messages_for_judge, rules_context="", **kw):
+        return [{"msg_id": m["msg_id"], "rule_match": "rule_3", "confidence": 0.95,
+                 "rationale": "dupe", "violates_server_rules": True}
+                for m in messages_for_judge]
+    orig = bridge._codex_judge_batch
+    bridge._codex_judge_batch = clean_codex
+    try:
+        # First batch: same user, same text, 3 distinct channels → fires Rule 3
+        for i, ch_id in enumerate([100, 200, 300]):
+            ch = _MockChannel(f"ch{i}", ch_id)
+            m = _MockMessage(f"m{i}", ch, content=spam_text, author_id=user_id)
+            bridge._mod_buffer.append({
+                "msg_id": f"m{i}", "channel_name": f"ch{i}", "channel_id": ch_id,
+                "author_name": "spammer", "author_id": user_id, "content": spam_text,
+                "is_reply": False, "parent_content": "", "_msg": m,
+            })
+        asyncio.run(bridge._flush_mod_buffer())
+        # Assert dupe-tracker bucket cleared for this (user, text)
+        norm_key = (str(user_id), bridge._normalize_msg_text(spam_text))
+        bucket = bridge._mod_dupe_tracker._store.get(norm_key)
+        if bucket and len(bucket) > 0:
+            fails.append(f"j) DupeTracker bucket for triggered (user,text) should be cleared "
+                         f"after dispatch success (got {len(bucket)} entries: {bucket})")
+        # And: a follow-up post in a 4th channel should NOT immediately re-fire,
+        # because the bucket is fresh — only 1 entry, well under threshold of 3.
+        import time as _t
+        trigger = bridge._mod_dupe_tracker.add(
+            user_id=user_id, channel_id=400, msg_id="m_follow",
+            text=spam_text, now_s=_t.time(),
+        )
+        if trigger:
+            fails.append(f"j) a single follow-up post should NOT re-trigger Rule 3 "
+                         f"after the bucket was cleared (got trigger={trigger})")
+    finally:
+        bridge._codex_judge_batch = orig
+        bridge._mod_buffer.clear()
+    return fails
+
+
+def case_k_mod_message_resets_offtopic_streak():
+    """v2 MEDIUM: A moderator posting in an mod-active channel must reset the
+    Rule 7 off-topic streak. Original bugs: (1) `_observe_for_mod` returns
+    silently for mods so they never reach the streak tracker; (2) the dispatcher
+    clean-verdict path read `getattr(v, "_is_mod", False)` on a dict (always
+    False). Fix: `_observe_for_mod` feeds the streak tracker directly with
+    is_mod=True for mod authors.
+
+    Test: pre-load a streak with off-topic entries, then call _observe_for_mod
+    with a mod author; assert the channel's streak buffer is empty afterwards.
+    """
+    fails = []
+    bridge._mod_streak_tracker = bridge._OffTopicStreakTracker()
+    # Reset buffer lock so the observe call's event loop creates a fresh one
+    bridge._mod_buffer_lock = None
+    bridge._mod_flush_lock = None
+    bridge._mod_buffer.clear()
+    channel_id = 5555
+    # Pre-load streak with 3 off-topic entries from a regular user
+    import time as _t
+    now = _t.time()
+    for i in range(3):
+        bridge._mod_streak_tracker.record(
+            channel_id, user_id=999 + i, off_topic=True, is_mod=False, now_s=now,
+        )
+    pre = bridge._mod_streak_tracker._streaks.get(str(channel_id), [])
+    if len(pre) != 3:
+        fails.append(f"k) test setup: expected 3 pre-loaded streak entries, got {len(pre)}")
+        return fails
+    # Stub _load_mod_config + _is_moderator so the observe path classifies
+    # the author as a mod and the guild as mod_active=True.
+    orig_load = bridge._load_mod_config
+    orig_is_mod = bridge._is_moderator
+    bridge._load_mod_config = lambda gid: (True, ["mod-role-1"])
+    bridge._is_moderator = lambda member, mod_role_ids: True
+    try:
+        ch = _MockChannel("general", channel_id)
+        mod_msg = _MockMessage("m_mod", ch, content="please stay on-topic everyone",
+                                author_id=42, author_name="modA")
+        # Author needs roles attribute for _is_moderator path (but our stub
+        # bypasses that — the real path is exercised in unit tests).
+        mod_msg.author.roles = []
+        asyncio.run(bridge._observe_for_mod(mod_msg))
+        post = bridge._mod_streak_tracker._streaks.get(str(channel_id), [])
+        if post and len(post) > 0:
+            fails.append(f"k) mod message should reset channel streak to empty "
+                         f"(got {len(post)} entries remaining)")
+        # Mod messages also must NOT be added to the buffer (G1 immunity)
+        if any(r.get("msg_id") == "m_mod" for r in bridge._mod_buffer):
+            fails.append("k) mod message should NOT be added to mod buffer (G1)")
+    finally:
+        bridge._load_mod_config = orig_load
+        bridge._is_moderator = orig_is_mod
+        bridge._mod_buffer.clear()
+    return fails
+
+
 def main():
     cases = [
         ("a-batch-retained-on-codex-failure", case_a_batch_retained_on_codex_failure),
@@ -338,6 +506,9 @@ def main():
         ("f-violates-server-rules-preserved", case_f_violates_server_rules_preserved),
         ("g-rule3-legit-crosspost-escalates-only", case_g_rule3_legit_crosspost_escalates_only),
         ("h-mention-injection-sanitized", case_h_mention_injection_sanitized),
+        ("i-concurrent-flush-single-flight", case_i_concurrent_flush_single_flight),
+        ("j-rule3-clears-after-trigger", case_j_rule3_clears_after_trigger),
+        ("k-mod-message-resets-offtopic-streak", case_k_mod_message_resets_offtopic_streak),
     ]
     failures = []
     for label, fn in cases:

--- a/tests/discord-bridge-mod-judge-trackers.test.py
+++ b/tests/discord-bridge-mod-judge-trackers.test.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""
+Tests for the stateful detectors in discord-bridge.py.
+
+PR4 of 5 — covers `_DupeTracker` (Rule 3 cross-channel-duplicate) and
+`_OffTopicStreakTracker` (Rule 7). PR5 wires the buffer + on_message hook
++ verdict dispatcher.
+
+Run: python3 tests/discord-bridge-mod-judge-trackers.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *args, **kwargs):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+    def get_channel(self, _id): return None
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# ---------------------------------------------------------------------------
+# _normalize_msg_text
+# ---------------------------------------------------------------------------
+
+def case_normalize_basic() -> list[str]:
+    fails = []
+    if bridge._normalize_msg_text("  Hello   World\t!  ") != "hello world !":
+        fails.append("a) lowercase + whitespace-collapse + trim expected")
+    if bridge._normalize_msg_text("") != "":
+        fails.append("a) empty input → empty")
+    if bridge._normalize_msg_text(None) != "":
+        fails.append("a) None input → empty (defensive)")
+    if len(bridge._normalize_msg_text("x" * 1000)) != 200:
+        fails.append("a) 200-char cap")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _DupeTracker (Rule 3)
+# ---------------------------------------------------------------------------
+
+def case_dupe_below_threshold_no_trigger() -> list[str]:
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    # Same user posts same text in 2 channels — under threshold (3)
+    r = t.add("u1", "ch_a", "m1", "join us!", now_s=100)
+    if r is not None:
+        fails.append("b) 1 channel should not trigger")
+    r = t.add("u1", "ch_b", "m2", "join us!", now_s=110)
+    if r is not None:
+        fails.append("b) 2 channels should not trigger (threshold=3)")
+    return fails
+
+
+def case_dupe_at_threshold_triggers() -> list[str]:
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    t.add("u1", "ch_a", "m1", "join discord.gg/spam", now_s=100)
+    t.add("u1", "ch_b", "m2", "join discord.gg/spam", now_s=110)
+    r = t.add("u1", "ch_c", "m3", "join discord.gg/spam", now_s=120)
+    if r is None:
+        fails.append("c) 3 distinct channels should trigger")
+        return fails
+    triggered_msgs = {m for (_c, m) in r}
+    if triggered_msgs != {"m1", "m2", "m3"}:
+        fails.append(f"c) trigger should return all 3 msg_ids, got {triggered_msgs}")
+    return fails
+
+
+def case_dupe_window_expiry() -> list[str]:
+    """Old entries outside window don't count toward channel threshold."""
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    t.add("u1", "ch_a", "m1", "spam text", now_s=0)
+    t.add("u1", "ch_b", "m2", "spam text", now_s=10)
+    # Third post 400s later — first two are outside window
+    r = t.add("u1", "ch_c", "m3", "spam text", now_s=400)
+    if r is not None:
+        fails.append("d) old entries outside window should not count toward threshold")
+    return fails
+
+
+def case_dupe_different_text_separate_keys() -> list[str]:
+    """Different normalized texts → separate keys → don't combine into a trigger."""
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    t.add("u1", "ch_a", "m1", "buy crypto here", now_s=100)
+    t.add("u1", "ch_b", "m2", "free vbucks here", now_s=110)
+    r = t.add("u1", "ch_c", "m3", "click for prize", now_s=120)
+    if r is not None:
+        fails.append("e) 3 different texts should NOT trigger (different keys)")
+    return fails
+
+
+def case_dupe_same_channel_doesnt_double_count() -> list[str]:
+    """User posting the same text 3 times in the SAME channel doesn't trigger
+    Rule 3 — Rule 3 is about cross-channel."""
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    t.add("u1", "ch_a", "m1", "spam", now_s=100)
+    t.add("u1", "ch_a", "m2", "spam", now_s=110)
+    r = t.add("u1", "ch_a", "m3", "spam", now_s=120)
+    if r is not None:
+        fails.append("f) same-channel duplicates shouldn't trigger Rule 3 (need cross-channel)")
+    return fails
+
+
+def case_dupe_clear_after_trigger() -> list[str]:
+    """After a trigger, caller calls clear() — subsequent posts of the same
+    text in a 4th channel shouldn't re-trigger (it's a deduped pattern)."""
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    t.add("u1", "ch_a", "m1", "spam", now_s=100)
+    t.add("u1", "ch_b", "m2", "spam", now_s=110)
+    r1 = t.add("u1", "ch_c", "m3", "spam", now_s=120)
+    if r1 is None:
+        fails.append("g) trigger expected on 3rd channel")
+    t.clear("u1", "spam")
+    r2 = t.add("u1", "ch_d", "m4", "spam", now_s=130)
+    if r2 is not None:
+        fails.append("g) after clear, 1 channel post should not trigger")
+    return fails
+
+
+def case_dupe_gc_drops_expired() -> list[str]:
+    fails = []
+    t = bridge._DupeTracker(window_s=300, channel_threshold=3)
+    t.add("u1", "ch_a", "m1", "spam", now_s=0)
+    t.gc(now_s=400)
+    if t._store:
+        fails.append("h) gc should drop expired entries")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _OffTopicStreakTracker (Rule 7)
+# ---------------------------------------------------------------------------
+
+def case_offtopic_streak_below_threshold() -> list[str]:
+    fails = []
+    t = bridge._OffTopicStreakTracker(streak_len=5, cooldown_s=600)
+    # 4 off-topic msgs — under threshold
+    fired = [t.record("ch1", f"u{i}", off_topic=True, is_mod=False, now_s=100 + i)
+             for i in range(4)]
+    if any(fired):
+        fails.append("i) 4 off-topic should not fire (need 5)")
+    return fails
+
+
+def case_offtopic_streak_fires_at_5() -> list[str]:
+    fails = []
+    t = bridge._OffTopicStreakTracker(streak_len=5, cooldown_s=600)
+    fired_log = [t.record("ch1", f"u{i}", off_topic=True, is_mod=False, now_s=100 + i)
+                 for i in range(5)]
+    if not fired_log[-1]:
+        fails.append("j) 5th off-topic should fire")
+    return fails
+
+
+def case_offtopic_on_topic_resets_streak() -> list[str]:
+    fails = []
+    t = bridge._OffTopicStreakTracker(streak_len=5, cooldown_s=600)
+    t.record("ch1", "u1", off_topic=True, is_mod=False, now_s=100)
+    t.record("ch1", "u2", off_topic=True, is_mod=False, now_s=101)
+    # On-topic interrupts streak — buffer keeps growing but the 5th won't
+    # be all-off-topic, so no fire.
+    t.record("ch1", "u3", off_topic=False, is_mod=False, now_s=102)
+    t.record("ch1", "u4", off_topic=True, is_mod=False, now_s=103)
+    t.record("ch1", "u5", off_topic=True, is_mod=False, now_s=104)
+    fired = t.record("ch1", "u6", off_topic=True, is_mod=False, now_s=105)
+    if fired:
+        fails.append("k) on-topic msg in middle should prevent streak from firing")
+    return fails
+
+
+def case_offtopic_mod_resets_streak() -> list[str]:
+    fails = []
+    t = bridge._OffTopicStreakTracker(streak_len=5, cooldown_s=600)
+    for i in range(4):
+        t.record("ch1", f"u{i}", off_topic=True, is_mod=False, now_s=100 + i)
+    # Mod posts — clears the streak
+    t.record("ch1", "mod1", off_topic=True, is_mod=True, now_s=104)
+    # Now 4 more off-topic — needs 5 fresh, not 1 more
+    fireds = [t.record("ch1", f"u{i+10}", off_topic=True, is_mod=False, now_s=200 + i)
+              for i in range(4)]
+    if any(fireds):
+        fails.append("l) mod-reset should clear streak; next 4 shouldn't fire")
+    fired_5 = t.record("ch1", "uX", off_topic=True, is_mod=False, now_s=210)
+    if not fired_5:
+        fails.append("l) 5 fresh post-mod-reset should fire")
+    return fails
+
+
+def case_offtopic_cooldown_suppresses() -> list[str]:
+    fails = []
+    t = bridge._OffTopicStreakTracker(streak_len=5, cooldown_s=600)
+    # First fire
+    for i in range(5):
+        t.record("ch1", f"u{i}", off_topic=True, is_mod=False, now_s=100 + i)
+    # Try another 5 within cooldown — should NOT fire
+    fireds = [t.record("ch1", f"u{i+10}", off_topic=True, is_mod=False, now_s=200 + i)
+              for i in range(5)]
+    if any(fireds):
+        fails.append("m) within cooldown, second streak should not fire")
+    # After cooldown
+    fired_after = t.record("ch1", "uY", off_topic=True, is_mod=False, now_s=900)
+    # Need to refill buffer; cooldown logic still keeps buffer trimmed during cooldown
+    # so a single post post-cooldown isn't enough. Add 4 more.
+    for i in range(4):
+        fired_after = t.record("ch1", f"uZ{i}", off_topic=True, is_mod=False, now_s=901 + i)
+    if not fired_after:
+        fails.append("m) post-cooldown 5-streak should fire")
+    return fails
+
+
+def case_offtopic_per_channel_isolation() -> list[str]:
+    """Streaks are per-channel — drift in #a doesn't trigger reminder in #b."""
+    fails = []
+    t = bridge._OffTopicStreakTracker(streak_len=5, cooldown_s=600)
+    # Fill #a streak
+    for i in range(5):
+        t.record("ch_a", f"u{i}", off_topic=True, is_mod=False, now_s=100 + i)
+    # #b should be unaffected
+    fired_b = t.record("ch_b", "u_x", off_topic=True, is_mod=False, now_s=200)
+    if fired_b:
+        fails.append("n) per-channel isolation: ch_b shouldn't fire from ch_a streak")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a-norm", case_normalize_basic),
+        ("b-dupe-below", case_dupe_below_threshold_no_trigger),
+        ("c-dupe-trig", case_dupe_at_threshold_triggers),
+        ("d-dupe-window", case_dupe_window_expiry),
+        ("e-dupe-diff-text", case_dupe_different_text_separate_keys),
+        ("f-dupe-same-ch", case_dupe_same_channel_doesnt_double_count),
+        ("g-dupe-clear", case_dupe_clear_after_trigger),
+        ("h-dupe-gc", case_dupe_gc_drops_expired),
+        ("i-offtopic-below", case_offtopic_streak_below_threshold),
+        ("j-offtopic-fires", case_offtopic_streak_fires_at_5),
+        ("k-ontopic-reset", case_offtopic_on_topic_resets_streak),
+        ("l-mod-reset", case_offtopic_mod_resets_streak),
+        ("m-cooldown", case_offtopic_cooldown_suppresses),
+        ("n-per-channel", case_offtopic_per_channel_isolation),
+    ]
+    failures: list[str] = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll mod-judge stateful-detector invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/discord-bridge-mod-judge.test.py
+++ b/tests/discord-bridge-mod-judge.test.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""
+Tests for the AG2 auto-mod LLM-judge helpers in discord-bridge.py.
+
+Per `notes/ag2-moderator-policy.md` §6.1: codex+gpt-4o-mini batched judge
+with 7 rules + G1 (mod immunity) + G2 (confidence gate). This PR ships the
+helpers; this file locks in their invariants. The on_message hook + action
+dispatchers (and the codex subprocess invocation itself) come in a follow-up.
+
+Helpers under test:
+- _load_mod_config(guild_id) — per-guild active/roles from access.json
+- _is_moderator(member, role_ids) — G1 mod-immunity check
+- _should_auto_action(verdict, threshold) — G2 confidence gate
+- _parse_judge_output(json_str) — codex JSON output → verdicts
+
+Run: python3 tests/discord-bridge-mod-judge.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module so the bridge imports cleanly without the lib.
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *args, **kwargs):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+    def get_channel(self, _id): return None
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# ---------------------------------------------------------------------------
+# _load_mod_config
+# ---------------------------------------------------------------------------
+
+def case_load_mod_config_active() -> list[str]:
+    fails = []
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump({
+            "guilds": {
+                "1153072414184452236": {
+                    "mod_active": True,
+                    "moderator_roles": ["111", "222"],
+                }
+            }
+        }, f)
+        path = Path(f.name)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        active, roles = bridge._load_mod_config(1153072414184452236)
+        if active is not True:
+            fails.append(f"a) mod_active should be True, got {active}")
+        if set(roles) != {"111", "222"}:
+            fails.append(f"a) moderator_roles should be {{'111','222'}}, got {set(roles)}")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+    return fails
+
+
+def case_load_mod_config_default_inactive() -> list[str]:
+    """Guild not configured at all → (False, []). Safe default — bridge
+    does NOTHING for guilds without explicit opt-in."""
+    fails = []
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump({"guilds": {}}, f)
+        path = Path(f.name)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        active, roles = bridge._load_mod_config(99999)
+        if active is not False:
+            fails.append("b) unconfigured guild should default to mod_active=False")
+        if roles != []:
+            fails.append(f"b) unconfigured guild should default to roles=[], got {roles}")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+    return fails
+
+
+def case_load_mod_config_missing_file() -> list[str]:
+    fails = []
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = Path("/nonexistent/path/access.json")
+        active, roles = bridge._load_mod_config(123)
+        if active is not False or roles != []:
+            fails.append("c) missing access.json should give (False, [])")
+    finally:
+        bridge.ACCESS_FILE = orig
+    return fails
+
+
+def case_load_mod_config_malformed_json() -> list[str]:
+    fails = []
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        f.write("{ this is not json")
+        path = Path(f.name)
+    orig = bridge.ACCESS_FILE
+    try:
+        bridge.ACCESS_FILE = path
+        active, roles = bridge._load_mod_config(123)
+        if active is not False or roles != []:
+            fails.append("d) malformed access.json should give (False, [])")
+    finally:
+        bridge.ACCESS_FILE = orig
+        path.unlink(missing_ok=True)
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _is_moderator (G1 mod-immunity gate)
+# ---------------------------------------------------------------------------
+
+def _make_member(member_id, role_ids, guild_owner_id=None):
+    roles = [types.SimpleNamespace(id=r) for r in role_ids]
+    guild = types.SimpleNamespace(owner_id=guild_owner_id) if guild_owner_id else None
+    return types.SimpleNamespace(id=member_id, roles=roles, guild=guild)
+
+
+def case_is_moderator_via_role() -> list[str]:
+    fails = []
+    member = _make_member(999, ["111", "222"])
+    if not bridge._is_moderator(member, ["111"]):
+        fails.append("e) member with role 111 should be mod when 111 is in mod_role_ids")
+    if bridge._is_moderator(member, ["333"]):
+        fails.append("e) member without any matching role should NOT be mod")
+    return fails
+
+
+def case_is_moderator_owner_immune() -> list[str]:
+    """Guild owner is always treated as mod, even if they don't have the
+    mod role explicitly."""
+    fails = []
+    member = _make_member(999, [], guild_owner_id=999)
+    if not bridge._is_moderator(member, []):
+        fails.append("f) guild owner should always be considered mod")
+    return fails
+
+
+def case_is_moderator_none_safe() -> list[str]:
+    fails = []
+    if bridge._is_moderator(None, ["111"]):
+        fails.append("g) None member should not be mod (defensive)")
+    return fails
+
+
+def case_is_moderator_handles_string_role_ids() -> list[str]:
+    """member.roles[i].id may be int (real Discord) or string (test mocks);
+    mod_role_ids may be either too. The check should normalize."""
+    fails = []
+    member_int_roles = _make_member(999, [111, 222])
+    if not bridge._is_moderator(member_int_roles, ["111"]):
+        fails.append("h) int role IDs should match string mod_role_ids")
+    member_str_roles = _make_member(999, ["111", "222"])
+    if not bridge._is_moderator(member_str_roles, ["111"]):
+        fails.append("h) string role IDs should match string mod_role_ids")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _should_auto_action (G2 confidence gate)
+# ---------------------------------------------------------------------------
+
+def case_should_auto_action_above_threshold() -> list[str]:
+    fails = []
+    # rule_1 default threshold = 0.85
+    v = {"msg_id": "x", "rule_match": "rule_1", "confidence": 0.92, "rationale": "..."}
+    if not bridge._should_auto_action(v):
+        fails.append("i) high-confidence rule_1 verdict should auto-action")
+    return fails
+
+
+def case_should_auto_action_below_threshold() -> list[str]:
+    fails = []
+    v = {"msg_id": "x", "rule_match": "rule_1", "confidence": 0.50, "rationale": "..."}
+    if bridge._should_auto_action(v):
+        fails.append("j) below-threshold verdict should NOT auto-action (G2 → escalate-only)")
+    return fails
+
+
+def case_should_auto_action_rule_specific_threshold() -> list[str]:
+    """rule_5 has threshold 0.90; 0.87 should be below."""
+    fails = []
+    v = {"msg_id": "x", "rule_match": "rule_5", "confidence": 0.87, "rationale": "..."}
+    if bridge._should_auto_action(v):
+        fails.append("k) rule_5 needs ≥0.90; 0.87 should not auto-action")
+    v = {"msg_id": "x", "rule_match": "rule_5", "confidence": 0.95, "rationale": "..."}
+    if not bridge._should_auto_action(v):
+        fails.append("k) rule_5 at 0.95 should auto-action")
+    return fails
+
+
+def case_should_auto_action_no_match() -> list[str]:
+    fails = []
+    v = {"msg_id": "x", "rule_match": None, "confidence": 0.99, "rationale": "ok"}
+    if bridge._should_auto_action(v):
+        fails.append("l) no rule_match should never auto-action regardless of confidence")
+    return fails
+
+
+def case_should_auto_action_malformed() -> list[str]:
+    fails = []
+    if bridge._should_auto_action(None):
+        fails.append("m) None verdict should not auto-action")
+    if bridge._should_auto_action({"rule_match": "rule_1", "confidence": "not-a-float"}):
+        fails.append("m) malformed confidence should not auto-action")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _parse_judge_output
+# ---------------------------------------------------------------------------
+
+def case_parse_judge_output_list_form() -> list[str]:
+    fails = []
+    j = json.dumps([
+        {"msg_id": "111", "rule_match": "rule_1", "confidence": 0.92, "rationale": "spam"},
+        {"msg_id": "222", "rule_match": None, "confidence": 0.98, "rationale": "ok"},
+    ])
+    out = bridge._parse_judge_output(j)
+    if len(out) != 2:
+        fails.append(f"n) should parse 2 verdicts, got {len(out)}")
+    if out and out[0]["msg_id"] != "111":
+        fails.append("n) msg_id ordering preserved")
+    return fails
+
+
+def case_parse_judge_output_wrapped_form() -> list[str]:
+    """Codex sometimes wraps output as {"verdicts": [...]} — accept both."""
+    fails = []
+    j = json.dumps({"verdicts": [
+        {"msg_id": "111", "rule_match": "rule_2", "confidence": 0.91, "rationale": ""},
+    ]})
+    out = bridge._parse_judge_output(j)
+    if len(out) != 1:
+        fails.append("o) wrapped form should parse")
+    return fails
+
+
+def case_parse_judge_output_malformed() -> list[str]:
+    fails = []
+    if bridge._parse_judge_output("not json") != []:
+        fails.append("p) non-JSON should parse to []")
+    if bridge._parse_judge_output("") != []:
+        fails.append("p) empty string should parse to []")
+    if bridge._parse_judge_output(None) != []:
+        fails.append("p) None should parse to []")
+    return fails
+
+
+def case_parse_judge_output_drops_invalid_entries() -> list[str]:
+    """Mixed valid/invalid entries: keep the valid ones, drop the bad."""
+    fails = []
+    j = json.dumps([
+        {"msg_id": "111", "rule_match": "rule_1", "confidence": 0.9, "rationale": ""},
+        {"rule_match": "rule_1", "confidence": 0.9},  # missing msg_id
+        {"msg_id": "333", "confidence": "bad"},  # bad confidence
+        {"msg_id": "444", "rule_match": 42, "confidence": 0.8},  # bad rule_match type
+        {"msg_id": "555", "rule_match": None, "confidence": 0.99, "rationale": "clean"},
+    ])
+    out = bridge._parse_judge_output(j)
+    msg_ids = [v["msg_id"] for v in out]
+    if msg_ids != ["111", "555"]:
+        fails.append(f"q) should keep only valid entries 111 + 555, got {msg_ids}")
+    return fails
+
+
+def case_parse_judge_output_clamps_confidence() -> list[str]:
+    """Confidence outside [0,1] is clamped, not rejected."""
+    fails = []
+    j = json.dumps([
+        {"msg_id": "111", "rule_match": "rule_1", "confidence": 1.5, "rationale": ""},
+        {"msg_id": "222", "rule_match": "rule_1", "confidence": -0.3, "rationale": ""},
+    ])
+    out = bridge._parse_judge_output(j)
+    if len(out) != 2 or out[0]["confidence"] != 1.0 or out[1]["confidence"] != 0.0:
+        fails.append(f"r) confidence should clamp to [0,1], got {[v['confidence'] for v in out]}")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a-active", case_load_mod_config_active),
+        ("b-default", case_load_mod_config_default_inactive),
+        ("c-no-file", case_load_mod_config_missing_file),
+        ("d-malformed", case_load_mod_config_malformed_json),
+        ("e-via-role", case_is_moderator_via_role),
+        ("f-owner", case_is_moderator_owner_immune),
+        ("g-none", case_is_moderator_none_safe),
+        ("h-id-coerce", case_is_moderator_handles_string_role_ids),
+        ("i-above", case_should_auto_action_above_threshold),
+        ("j-below", case_should_auto_action_below_threshold),
+        ("k-rule-spec", case_should_auto_action_rule_specific_threshold),
+        ("l-no-match", case_should_auto_action_no_match),
+        ("m-malformed", case_should_auto_action_malformed),
+        ("n-list", case_parse_judge_output_list_form),
+        ("o-wrapped", case_parse_judge_output_wrapped_form),
+        ("p-malformed", case_parse_judge_output_malformed),
+        ("q-drops", case_parse_judge_output_drops_invalid_entries),
+        ("r-clamp", case_parse_judge_output_clamps_confidence),
+    ]
+    failures: list[str] = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll mod-judge helper invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/discord-bridge-mod-server-config.test.py
+++ b/tests/discord-bridge-mod-server-config.test.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+Tests for `_load_mod_server_config(guild_id)` in discord-bridge.py — the
+per-guild config reader that replaces the old AG2-hardcoded MOD_ESCALATION_*
+constants.
+
+Run: python3 tests/discord-bridge-mod-server-config.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *a, **kw):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn): return fn
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+
+
+class _DMChannel: pass
+
+
+_discord_stub.DMChannel = _DMChannel
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge_with_access_json(content: dict | None):
+    """Load discord-bridge with ACCESS_FILE pointed at a temp file."""
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    if content is None:
+        bridge.ACCESS_FILE = Path("/tmp/_definitely-does-not-exist-99999")
+    else:
+        tf = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+        json.dump(content, tf)
+        tf.close()
+        bridge.ACCESS_FILE = Path(tf.name)
+    return bridge
+
+
+def case_a_no_access_file():
+    """When access.json doesn't exist, all fields default safely."""
+    fails = []
+    bridge = load_bridge_with_access_json(None)
+    cfg = bridge._load_mod_server_config(123)
+    if cfg["escalation_channel"] is not None:
+        fails.append("a) missing access.json should default escalation_channel to None")
+    if cfg["escalation_ccs"] != ():
+        fails.append("a) missing access.json should default escalation_ccs to ()")
+    if cfg["redirect_channel_jobs"] is not None:
+        fails.append("a) missing access.json should default redirect_channel_jobs to None")
+    return fails
+
+
+def case_b_no_guilds_key():
+    fails = []
+    bridge = load_bridge_with_access_json({"groups": {}})
+    cfg = bridge._load_mod_server_config(123)
+    if cfg["escalation_channel"] is not None:
+        fails.append("b) missing guilds key should default escalation_channel to None")
+    if cfg["escalation_ccs"] != ():
+        fails.append("b) missing guilds key should default escalation_ccs to ()")
+    return fails
+
+
+def case_c_guild_not_listed():
+    fails = []
+    bridge = load_bridge_with_access_json({"guilds": {"999": {"escalation_channel": 555}}})
+    cfg = bridge._load_mod_server_config(123)
+    if cfg["escalation_channel"] is not None:
+        fails.append("c) unlisted guild should not inherit other guild's config")
+    return fails
+
+
+def case_d_full_config_lookup():
+    """Happy path — escalation_channel, escalation_cc_user_ids, redirect_channel_jobs all present."""
+    fails = []
+    bridge = load_bridge_with_access_json({
+        "guilds": {
+            "1153072414184452236": {
+                "mod_active": True,
+                "moderator_roles": ["1234"],
+                "escalation_channel": 1153753796321738863,
+                "escalation_cc_user_ids": ["1022910063620390932", "1025828152183885925"],
+                "redirect_channel_jobs": 1168719200605437952,
+            }
+        }
+    })
+    cfg = bridge._load_mod_server_config(1153072414184452236)
+    if cfg["escalation_channel"] != 1153753796321738863:
+        fails.append(f"d) escalation_channel mismatch: got {cfg['escalation_channel']}")
+    if cfg["escalation_ccs"] != ("<@1022910063620390932>", "<@1025828152183885925>"):
+        fails.append(f"d) escalation_ccs mismatch: got {cfg['escalation_ccs']}")
+    if cfg["redirect_channel_jobs"] != 1168719200605437952:
+        fails.append(f"d) redirect_channel_jobs mismatch: got {cfg['redirect_channel_jobs']}")
+    return fails
+
+
+def case_e_string_guild_id():
+    """guild_id passed as int should still match string-keyed access.json."""
+    fails = []
+    bridge = load_bridge_with_access_json({"guilds": {"42": {"escalation_channel": 99}}})
+    cfg = bridge._load_mod_server_config(42)  # int
+    if cfg["escalation_channel"] != 99:
+        fails.append(f"e) int guild_id should match string key: got {cfg['escalation_channel']}")
+    return fails
+
+
+def case_f_malformed_cc_list():
+    """When escalation_cc_user_ids is malformed (not a list), default to ()."""
+    fails = []
+    bridge = load_bridge_with_access_json({"guilds": {"42": {"escalation_cc_user_ids": "not-a-list"}}})
+    cfg = bridge._load_mod_server_config(42)
+    if cfg["escalation_ccs"] != ():
+        fails.append(f"f) malformed cc list should default to (): got {cfg['escalation_ccs']}")
+    return fails
+
+
+def case_g_int_user_ids_in_cc():
+    """If user_ids are stored as int (not str), still work."""
+    fails = []
+    bridge = load_bridge_with_access_json({
+        "guilds": {"42": {"escalation_cc_user_ids": [123, 456]}}
+    })
+    cfg = bridge._load_mod_server_config(42)
+    if cfg["escalation_ccs"] != ("<@123>", "<@456>"):
+        fails.append(f"g) int user_ids should still produce mention strings: got {cfg['escalation_ccs']}")
+    return fails
+
+
+def case_h_partial_config():
+    """When only some fields are configured, others default to None/()."""
+    fails = []
+    bridge = load_bridge_with_access_json({
+        "guilds": {"42": {"escalation_channel": 555}}  # only escalation_channel
+    })
+    cfg = bridge._load_mod_server_config(42)
+    if cfg["escalation_channel"] != 555:
+        fails.append(f"h) partial config: escalation_channel should be 555, got {cfg['escalation_channel']}")
+    if cfg["escalation_ccs"] != ():
+        fails.append(f"h) partial config: missing ccs should default to ()")
+    if cfg["redirect_channel_jobs"] is not None:
+        fails.append(f"h) partial config: missing redirect should default to None")
+    return fails
+
+
+def case_i_guild_id_of_message():
+    """_guild_id_of: extracts message.guild.id when present, else None."""
+    fails = []
+    bridge = load_bridge_with_access_json({})
+    msg_with_guild = types.SimpleNamespace(guild=types.SimpleNamespace(id=42))
+    if bridge._guild_id_of(msg_with_guild) != 42:
+        fails.append("i) should extract guild.id from message")
+    msg_no_guild = types.SimpleNamespace(guild=None)
+    if bridge._guild_id_of(msg_no_guild) is not None:
+        fails.append("i) message.guild=None should return None")
+    msg_no_attr = types.SimpleNamespace()
+    if bridge._guild_id_of(msg_no_attr) is not None:
+        fails.append("i) message without guild attr should return None")
+    return fails
+
+
+def main():
+    cases = [
+        ("a-no-access-file", case_a_no_access_file),
+        ("b-no-guilds-key", case_b_no_guilds_key),
+        ("c-guild-not-listed", case_c_guild_not_listed),
+        ("d-full-config-lookup", case_d_full_config_lookup),
+        ("e-string-guild-id", case_e_string_guild_id),
+        ("f-malformed-cc-list", case_f_malformed_cc_list),
+        ("g-int-user-ids-in-cc", case_g_int_user_ids_in_cc),
+        ("h-partial-config", case_h_partial_config),
+        ("i-guild-id-of-message", case_i_guild_id_of_message),
+    ]
+    failures = []
+    for label, fn in cases:
+        fs = fn()
+        if fs:
+            failures.extend([(label, msg) for msg in fs])
+            print(f"  ✗ case {label}")
+            for f in fs:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll mod-judge server-config invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Single clean PR replacing the 8-PR stack #625-#632. Same feature, no AG2-specific hardcoding from the start.

Implements the full AG2 auto-mod LLM-judge per \`notes/ag2-moderator-policy.md\` §6.1 — codex-CLI based judge, batched 5s/20msgs, all 7 rules + G1+G2 guardrails. All operator-specific values (mod role-IDs, escalation channel, cc list, jobs redirect channel) live in per-guild \`access.json\` config.

## Why this PR replaces the stack

The original stack #625-#632 was structured for incremental review. But the early PRs in the stack carried hardcoded AG2-specific constants:
- \`MOD_ESCALATION_CHANNEL_ID = 1153753796321738863\`
- \`MOD_ESCALATION_CCS = (<3 user-id mentions>)\`
- \`MOD_JOBS_CHANNEL_ID = 1168719200605437952\`
- Prompt: \"for the AG2 server\" / \"general AG2 server rule\"

PR #632 then de-hardcoded these. But that left main transiently hardcoded between #625 merge and #632 merge. Per Chi: \"don't merge hardcoded PR.\"

This PR squashes the entire feature into one diff with the dehardcoded version from the start.

## What was hardcoded → now per-guild config

All operator data lives under \`access.json: guilds.<guild_id>.*\`:

\`\`\`json
{
  \"guilds\": {
    \"<guild_id>\": {
      \"mod_active\": true,
      \"moderator_roles\": [\"<role-id>\", ...],
      \"escalation_channel\": <channel_id>,
      \"escalation_cc_user_ids\": [\"<user-id>\", ...],
      \"redirect_channel_jobs\": <channel_id>
    }
  }
}
\`\`\`

When config is absent → action functions log + no-op; \`mod_active: false\` (default) → fully observe-only.

## Tests

79 unit tests across 7 files, all green:
- \`discord-bridge-mod-judge.test.py\` (18) — helpers + G1/G2
- \`discord-bridge-mod-judge-codex.test.py\` (10) — codex wrapper
- \`discord-bridge-mod-judge-actions.test.py\` (9) — action dispatchers
- \`discord-bridge-mod-judge-trackers.test.py\` (14) — Rule 3 + 7 stateful detectors
- \`discord-bridge-mod-judge-dispatcher.test.py\` (11) — verdict routing
- \`discord-bridge-mod-judge-buffer.test.py\` (8) — buffer + flush timer
- \`discord-bridge-mod-server-config.test.py\` (9) — per-guild config reader

## Activation

See \`notes/ag2-mod-merge-runbook.md\` for the full path:
- §0: pre-flight \`codex exec\` smoke test
- §1: edit access.json with the 5-field guild block above
- §2: bridge restart (race-safe pkill + sleep + nohup pattern)
- Post-restart diagnostic (greps for \`[mod-flush]\` log lines)

## Default behavior unchanged

This PR is observe-only at runtime until an operator sets \`mod_active: true\` for a specific guild_id in access.json AND restarts the bridge.

## Test plan

- [x] 79 unit tests pass locally (\`for f in tests/discord-bridge-mod-judge*.test.py tests/discord-bridge-mod-server-config.test.py; do python3 \$f; done\`)
- [ ] CI runs on this PR (workflow gates on base=main — should fire)
- [ ] Pre-flight smoke test post-merge
- [ ] Activation per runbook

## Closes (replaces)

Closes #625, #626, #627, #628, #629, #630, #631, #632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)