### PR TITLE
chore(health-check): retire AppleScript Mail.app email alert path

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -999,36 +999,6 @@ def main():
                                      stderr=subprocess.STDOUT, start_new_session=True)
                     print(f"  {c['name']}: {'restarted (stale code)' if c['status'] == 'stale' else 'restarted'}")
 
-    # Email alert if critical issues found and --fix didn't resolve them
-    if issues and do_fix:
-        # Re-check after fix attempts
-        import time
-        time.sleep(2)
-        rechecks = run_all_checks()
-        remaining = [c for c in rechecks if c["status"] not in ("ok",)]
-        if remaining:
-            alert_lines = ["Sutando health check found issues that auto-fix couldn't resolve:", ""]
-            for c in remaining:
-                alert_lines.append(f"  - {c['name']}: {c['status']} ({c['detail']})")
-            alert_lines.append("")
-            alert_lines.append("Check manually or run: python3 src/health-check.py")
-            alert_body = "\\n".join(alert_lines)
-            try:
-                subject = "Sutando: health check alert"
-                script = (
-                    'tell application "Mail"\n'
-                    f'    set m to make new outgoing message with properties {{subject:"{subject}", content:"{alert_body}", visible:false}}\n'
-                    '    tell m\n'
-                    f'        make new to recipient at end of to recipients with properties {{address:"{os.environ.get("NOTIFICATION_EMAIL", "")}"}}\n'
-                    '    end tell\n'
-                    '    send m\n'
-                    'end tell'
-                )
-                subprocess.run(["osascript", "-e", script], capture_output=True, timeout=15)
-                print("Alert email sent.")
-            except Exception:
-                pass
-
     sys.exit(1 if issues else 0)
 
 


### PR DESCRIPTION
## Summary

Deletes the Mail.app-via-osascript alert at the bottom of `health-check.py`. The path was broken in practice (NOTIFICATION_EMAIL never set, AppleScript escaping bugs) and is redundant with the trio's LEARN coverage check, which already routes health-check failures to Discord DM.

## Why

**Broken:**
- `NOTIFICATION_EMAIL` env never set on this fleet — empty-recipient AppleScript silently fails in `try ... except Exception: pass`
- `\\n` in `alert_body` becomes literal backslash-n, not newlines, in the AppleScript string
- Unescaped quotes in issue details could break the AppleScript string

**Redundant:**
- LEARN's `scan_health_anomalies` (in `~/.sutando-memory-sync/skills/personal-learn-loop/scripts/coverage-scanners.py`) already produces a `surface_owner` proposal on every health-check non-zero exit
- ACT routes that to Discord DM (canonical surface per `feedback_dm_pending_questions.md`)

**Single canonical surface:**
- Discord DM is the established notification path
- Removing the email path eliminates a "you got both an email and a DM" experience and a silent-failure mode

## Diff

30 lines deleted (`src/health-check.py:1002-1031`). No tests touched (the deleted block had no test coverage). The `print("Alert email sent.")` confirmation at line 1028 is gone — but it never actually ran because the email send always failed.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('src/health-check.py').read())"` — syntax check
- [x] `python3 src/health-check.py` — smoke run, exits 1 on real issues, no AppleScript invocation
- [x] No tests reference the deleted block (`grep -r 'NOTIFICATION_EMAIL\|Alert email sent' tests/` → empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)