### PR TITLE
fix(proactive-loop): skip /loop arming if main-loop cron is already active

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -23,7 +23,9 @@ If an interval is provided in ARGUMENTS (e.g. "5m", "10m", "30m"), use it. Other
 
 ## Start the loop
 
-Use `/loop <interval>` with this prompt:
+If `CronList` already shows a recurring job that drives this loop — either a `main-loop` entry from `/schedule-crons` (typically `*/5 * * * *` → `/proactive-loop`) or a prior `/loop` invocation with the body below — **skip this section and run the per-pass body directly**. That cron is the canonical driver; adding another would compound on every fire — each `/proactive-loop` invocation would re-run `/loop`, scheduling another recurring job and growing the cron list unboundedly.
+
+Otherwise, use `/loop <interval>` with this prompt:
 
 ---
 


### PR DESCRIPTION
## Issue

Every cron-fired `/proactive-loop` re-runs the activation skill, which unconditionally calls `/loop` with the per-pass body as its prompt. `/loop` always issues a fresh `CronCreate` — there's no dedup. With `crons.json` shipping `main-loop` (`*/5 * * * *` → `/proactive-loop`) as the canonical driver, **every */5 fire spawns a fresh */10 cron whose prompt is the full loop body**. The cron list grows unboundedly; per-pass cost compounds.

I caught it in this session:

```
Pass 1 (manual /proactive-loop): created cron 38365d23 (*/10) for the loop body
Pass 2 (this one, fired by */5 main-loop):
  CronList shows 38365d23 still present
  if I had not skipped /loop, a second */10 cron would have been created
  another 5min from now, a third would arrive, etc.
```

After 1 hour of unattended running the schedule would already have ~12 redundant `*/10` jobs all firing the body. After a day, ~288.

## Fix

1-line guard added to the top of `## Start the loop`. If `CronList` already drives the loop — either `main-loop` from `/schedule-crons` or a prior `/loop` invocation — the section is skipped and the activation skill executes the per-pass body directly. Otherwise behavior is unchanged: `/loop <interval>` self-arms as before, preserving the path for users without `main-loop` in their `crons.json`.

## Why a guard rather than dropping the section entirely

Users without `main-loop` (haven't copied `crons.example.json`, or running `/proactive-loop` ad-hoc in a session that hasn't run `/schedule-crons` yet) still need the self-arming path. Conditional skip handles both setups without forcing one configuration.

## Why a separate small PR vs folding into #534 / #565

Both #534 (5-state machine) and #565 (state-machine rewrite) restructure `## Start the loop`'s parent section, but neither addresses the duplicate-driver issue — the `## Start the loop` block remains present and unconditional in both. Whichever lands first, the merge of this 1-line guard is mechanical (3-line addition, no semantic conflict with structural changes). Holding this fix in those PRs would couple it to design decisions still under discussion.

## Test plan

- [x] `git diff` clean — single-section docs change
- [x] Behavior verified live: with this guard in place, the next */5 `main-loop` fire entered the per-pass body directly without re-arming `/loop`. CronList stays at the original 7 entries instead of growing.
- [ ] No CI for `skills/**/*.md` paths — markdown-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)