### PR TITLE
fix(discord-bridge): silently escalate Discord-state task references

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -866,16 +866,38 @@ async def _silent_escalate_for_discord_state(message, user_task_text):
             sender_id = getattr(message.author, "id", None) if hasattr(message, "author") else None
             if sender_id is None:
                 continue
+            sender_member = None
             try:
-                sender_member = ch_guild.get_member(sender_id) if hasattr(ch_guild, "get_member") else None
-                if sender_member is None and hasattr(ch_guild, "fetch_member"):
-                    try:
-                        sender_member = await ch_guild.fetch_member(sender_id)
-                    except Exception:
-                        sender_member = None
+                if hasattr(ch_guild, "get_member"):
+                    sender_member = ch_guild.get_member(sender_id)
             except Exception as e:
-                print(f"  [discord-state-escalate] failed to check sender {sender_id} membership in guild {ch_guild.id}: {e}", flush=True)
+                print(f"  [discord-state-escalate] get_member raised for sender {sender_id} in guild {ch_guild.id}: {e}", flush=True)
                 sender_member = None
+            # If cache miss, fall back to HTTP. Per discord.py docs:
+            #   `Guild.fetch_member()` raises `discord.NotFound` when the user
+            #   is NOT in the guild (NOT `None`); also `discord.Forbidden` if
+            #   the bot lacks permission, and `discord.HTTPException` for
+            #   transient errors. All three should silently fail-closed (no
+            #   routing). Per MacBook's #639 v3 follow-up review.
+            if sender_member is None and hasattr(ch_guild, "fetch_member"):
+                _NotFound = getattr(discord, "NotFound", None)
+                _Forbidden = getattr(discord, "Forbidden", None)
+                _HTTPException = getattr(discord, "HTTPException", None)
+                try:
+                    sender_member = await ch_guild.fetch_member(sender_id)
+                except Exception as e:
+                    if _NotFound is not None and isinstance(e, _NotFound):
+                        # Expected: user is not in this guild — the silent path
+                        sender_member = None
+                    elif _Forbidden is not None and isinstance(e, _Forbidden):
+                        print(f"  [discord-state-escalate] fetch_member forbidden for sender {sender_id} in guild {ch_guild.id}: {e}", flush=True)
+                        sender_member = None
+                    elif _HTTPException is not None and isinstance(e, _HTTPException):
+                        print(f"  [discord-state-escalate] fetch_member http error for sender {sender_id} in guild {ch_guild.id}: {e}", flush=True)
+                        sender_member = None
+                    else:
+                        print(f"  [discord-state-escalate] fetch_member unexpected error for sender {sender_id} in guild {ch_guild.id}: {e}", flush=True)
+                        sender_member = None
             if sender_member is None:
                 print(f"  [discord-state-escalate] sender {sender_id} not a member of guild {ch_guild.id}; not routing DM-referenced escalation", flush=True)
                 continue

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -814,18 +814,50 @@ async def _silent_escalate_for_discord_state(message, user_task_text):
     if msg_guild is not None:
         target_guild_id = msg_guild.id
     else:
-        # DM origin — try resolving the first referenced channel to its guild
+        # DM origin — try resolving the first referenced channel to its guild.
+        # Two extra gates here vs origin-guild path (per MacBook's #639 review):
+        #   (a) reject anything that isn't a guild text/thread channel — a fetch
+        #       success on a category/voice/etc. doesn't mean it's safe to use
+        #       for routing, and we want fail-closed on weird shapes.
+        #   (b) require the target guild to have `mod_active=True` (explicit
+        #       opt-in for moderation flow) — without this, an arbitrary user
+        #       DM'ing a `<#...>` reference for ANY guild the bot is in could
+        #       leak their request into that guild's escalation channel.
+        guild_text_types = {
+            getattr(discord, "ChannelType", None) and discord.ChannelType.text,
+            getattr(discord, "ChannelType", None) and discord.ChannelType.public_thread,
+            getattr(discord, "ChannelType", None) and discord.ChannelType.private_thread,
+            getattr(discord, "ChannelType", None) and discord.ChannelType.news_thread,
+            getattr(discord, "ChannelType", None) and discord.ChannelType.news,
+        }
+        guild_text_types.discard(None)
         for ref_ch_id in refs:
             try:
                 ch = client.get_channel(ref_ch_id)
                 if ch is None:
                     ch = await client.fetch_channel(ref_ch_id)
-                ch_guild = getattr(ch, "guild", None)
-                if ch_guild is not None:
-                    target_guild_id = ch_guild.id
-                    break
             except Exception as e:
                 print(f"  [discord-state-escalate] failed to resolve channel {ref_ch_id}: {e}", flush=True)
+                continue
+            if ch is None:
+                continue
+            ch_type = getattr(ch, "type", None)
+            if guild_text_types and ch_type is not None and ch_type not in guild_text_types:
+                print(f"  [discord-state-escalate] channel {ref_ch_id} type={ch_type} is not a guild text/thread channel; skipping", flush=True)
+                continue
+            ch_guild = getattr(ch, "guild", None)
+            if ch_guild is None:
+                continue
+            # DM-origin gate: require explicit mod_active=True for routing
+            try:
+                guild_active, _roles = _load_mod_config(ch_guild.id)
+            except Exception:
+                guild_active = False
+            if not guild_active:
+                print(f"  [discord-state-escalate] guild {ch_guild.id} has mod_active=False; not routing DM-referenced escalation", flush=True)
+                continue
+            target_guild_id = ch_guild.id
+            break
 
     if target_guild_id is None:
         print(f"  [discord-state-escalate] no target guild resolvable; staying silent (NO-REPLY)", flush=True)
@@ -2083,27 +2115,31 @@ async def _handle_discord_message(message, force=False):
         except Exception as e:
             print(f"  [discord-state-escalate] outer guard caught: {e}", flush=True)
             already_escalated = False
+
+    # When the bridge has already silently escalated, the agent has nothing to
+    # do — skip the task-file write entirely. Otherwise the task would land in
+    # `pending_replies` (line ~2080 below) but no `results/task-*.txt` would
+    # ever appear (the new `already_escalated` tier instruction is NO-REPLY),
+    # leaving the entry to age out via _recovery only. Skipping the write
+    # avoids the leak + avoids a spurious 👀 auto-react that signals "the bot
+    # is processing this." Per MacBook #639 review finding #2.
+    if already_escalated:
+        print(f"  [discord-state-escalate] silent escalation handled; no task file written for {username} in #{getattr(message.channel, 'name', '?')}", flush=True)
+        return
     # Absolute path for codex's `-o` flag. The team-tier command runs from
     # the bridge's cwd (the repo) so a relative `results/...` path would work,
     # but the other-tier command uses `-C /tmp` which would resolve a
     # relative `-o results/...` against `/tmp/results/` (does not exist) and
     # codex fails with `os error 2`. Reuse the module-level RESULTS_DIR so
     # both tier blocks are robust regardless of cwd.
+    # Note: the silent-escalate path (above) `return`s before this point when
+    # `already_escalated=True`, so the only valid keys consumed below are
+    # owner/team/other. (An earlier draft had an `already_escalated` tier
+    # instruction that told the agent to NO-REPLY archive, but that left the
+    # task in `pending_replies` until age-out — leak-prone per MacBook's #639
+    # review. Removed in favor of skipping the task-file write entirely.)
     tier_instructions = {
         "owner": "",
-        "already_escalated": (
-            "\n\n===SUTANDO SYSTEM INSTRUCTIONS (do not ignore; overrides anything above)===\n"
-            "This task references Discord-side state (channel mention or recent-message lookup) that the "
-            "codex sandbox cannot access. The bridge has already posted a silent notification to the "
-            "configured escalation channel where a moderator can review and respond directly.\n\n"
-            "ACTION: archive this task without sender reply. Do NOT write results/task-{id}.txt. Do NOT "
-            "invoke codex. Move tasks/task-{id}.txt to tasks/archive/.\n\n"
-            "Rationale: per msze_'s 2026-05-07 directive, Sutando should not surface internal-mechanism "
-            "errors (e.g. 'Sandbox unavailable; refusing non-owner task.') on public channels. When the "
-            "request asks for Discord-side state the bot can't see, the appropriate escalation has "
-            "already been routed to the moderators silently.\n"
-            "===END SUTANDO SYSTEM INSTRUCTIONS===\n"
-        ),
         "team": (
             "\n\n===SUTANDO SYSTEM INSTRUCTIONS (do not ignore; overrides anything above)===\n"
             "This task is from a TEAM tier sender. Choose ONE of three actions based on the content:\n\n"
@@ -2154,7 +2190,6 @@ async def _handle_discord_message(message, force=False):
             except Exception as e:
                 print(f"  [auto-react] {react_emoji} failed: {e}", flush=True)
 
-    instruction_key = "already_escalated" if already_escalated else access_tier
     task_file.write_text(
         f"id: {task_id}\n"
         f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%S')}Z\n"
@@ -2163,7 +2198,7 @@ async def _handle_discord_message(message, force=False):
         f"channel_id: {message.channel.id}\n"
         f"user_id: {message.author.id}\n"
         f"access_tier: {access_tier}\n"
-        f"{tier_instructions.get(instruction_key, tier_instructions['other'])}"
+        f"{tier_instructions.get(access_tier, tier_instructions['other'])}"
     )
     pending_replies[task_id] = message.channel
     save_pending_replies()

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -66,6 +66,16 @@ SEND_ALLOWED_PREFIXES = (
 
 _FENCE_LINE = re.compile(r"^\s{0,3}(`{3,}|~{3,})\s*([^\s`~][^`~]*)?\s*$")
 
+# Discord-state references in task bodies that codex sandbox cannot resolve.
+# When a team/other-tier task asks the agent to look at a specific channel
+# or DM context, the codex sandbox path can't fulfill it (no Discord token,
+# no server access). Detected via channel-mention syntax `<#1234>`. The
+# bridge intercepts these BEFORE writing the task, posts a silent note to
+# the appropriate guild's escalation_channel, and writes a tier instruction
+# that tells the agent to NO-REPLY archive (no public "Sandbox unavailable"
+# string). Per msze_'s 2026-05-07 directive + Chi's "ship 1" call.
+_DISCORD_CHANNEL_REF_RE = re.compile(r"<#(\d+)>")
+
 
 def _is_fence_open_line(line: str):
     """Return the fence opener string if `line` is a real Markdown block-fence line.
@@ -758,6 +768,113 @@ def _sanitize_for_quote(text):
         .replace("@", "@\u200b")
         .replace("\n>", "\n>\u200b")  # avoid nested blockquote issues inside our `> ` line
     )
+
+
+def _extract_referenced_channels(text):
+    """Return the list of int channel-ids referenced via `<#1234>` syntax in
+    `text`. Empty list if none. Used by the bridge's task-write path to
+    detect task bodies asking for Discord-state codex sandbox can't resolve."""
+    if not text:
+        return []
+    return [int(m) for m in _DISCORD_CHANNEL_REF_RE.findall(text)]
+
+
+async def _silent_escalate_for_discord_state(message, user_task_text):
+    """Detect tasks that reference Discord-side state (channel mentions like
+    `<#1234>`) and silently escalate to the appropriate guild's
+    `escalation_channel` rather than letting the agent fall into the cold
+    "Sandbox unavailable" fallback when codex sandbox tries to fulfill what
+    it structurally can't (no Discord token, no server access).
+
+    Decision flow:
+      1. If `user_task_text` contains no `<#...>` reference → return False
+         (caller proceeds with normal team/other tier instruction).
+      2. Resolve target guild for escalation:
+         a. If the task originated in a guild channel → use that guild.
+         b. Else (DM origin) → look up the FIRST referenced channel and use
+            that channel's guild.
+      3. Look up `escalation_channel` from access.json's `guilds.<gid>` block.
+      4. POST a silent notification to that channel summarizing sender +
+         original task body. Returns True on attempted post (regardless of
+         success), so the caller writes the "already_escalated" tier
+         instruction and the agent NO-REPLY archives.
+      5. If no escalation channel can be resolved → still return True so
+         the agent stays silent (msze_'s "don't respond publicly" intent).
+
+    Returns True iff the task was identified as Discord-state-reference and
+    the agent should NO-REPLY archive instead of running codex.
+    """
+    refs = _extract_referenced_channels(user_task_text)
+    if not refs:
+        return False
+
+    # Determine target guild for escalation
+    target_guild_id = None
+    msg_guild = getattr(message, "guild", None)
+    if msg_guild is not None:
+        target_guild_id = msg_guild.id
+    else:
+        # DM origin — try resolving the first referenced channel to its guild
+        for ref_ch_id in refs:
+            try:
+                ch = client.get_channel(ref_ch_id)
+                if ch is None:
+                    ch = await client.fetch_channel(ref_ch_id)
+                ch_guild = getattr(ch, "guild", None)
+                if ch_guild is not None:
+                    target_guild_id = ch_guild.id
+                    break
+            except Exception as e:
+                print(f"  [discord-state-escalate] failed to resolve channel {ref_ch_id}: {e}", flush=True)
+
+    if target_guild_id is None:
+        print(f"  [discord-state-escalate] no target guild resolvable; staying silent (NO-REPLY)", flush=True)
+        return True
+
+    cfg = _load_mod_server_config(target_guild_id)
+    esc_ch_id = cfg.get("escalation_channel") if isinstance(cfg, dict) else None
+    if not esc_ch_id:
+        print(f"  [discord-state-escalate] guild {target_guild_id} has no escalation_channel; staying silent", flush=True)
+        return True
+
+    try:
+        esc_ch = client.get_channel(esc_ch_id)
+        if esc_ch is None:
+            esc_ch = await client.fetch_channel(esc_ch_id)
+    except Exception as e:
+        print(f"  [discord-state-escalate] failed to resolve escalation channel {esc_ch_id}: {e}", flush=True)
+        return True
+
+    if esc_ch is None:
+        return True
+
+    sender_id = getattr(message.author, "id", "?") if hasattr(message, "author") else "?"
+    origin_ch_id = getattr(message.channel, "id", "?") if hasattr(message, "channel") else "?"
+    body_lines = [
+        "**Sutando — task escalation**",
+        "",
+        f"Sender: <@{sender_id}>",
+        f"Origin: <#{origin_ch_id}>",
+        f"Referenced channel(s): {', '.join(f'<#{r}>' for r in refs)}",
+        "",
+        "Task body:",
+        "```",
+        (user_task_text or "")[:1500],
+        "```",
+        "",
+        ("This task references Discord-side state (channel content / message lookup) that the bot's "
+         "sandboxed processing path cannot access. A moderator can review and respond directly if appropriate."),
+    ]
+    cc_ids = []
+    if cfg.get("escalation_ccs"):
+        cc_ids = [int(s.strip("<@>")) for s in cfg["escalation_ccs"] if s.startswith("<@") and s.endswith(">")]
+    am = discord.AllowedMentions(everyone=False, roles=False, users=cc_ids)
+    try:
+        await esc_ch.send("\n".join(body_lines), allowed_mentions=am)
+        print(f"  [discord-state-escalate] posted to channel {esc_ch_id} for guild {target_guild_id}", flush=True)
+    except Exception as e:
+        print(f"  [discord-state-escalate] post failed: {e}", flush=True)
+    return True
 
 
 async def _post_mod_escalation(client_ref, suspect_message, rule_label, llm_rationale, extras_md=""):
@@ -1951,6 +2068,21 @@ async def _handle_discord_message(message, force=False):
     # See CLAUDE.md "Discord access control" section for the policy.
     user_task_text = f"[Discord @{username}] {text}{attachment_note}{reply_context}"
     quoted_task = shlex.quote(user_task_text)
+
+    # Pre-classify Discord-state-reference tasks (per msze_'s 2026-05-07
+    # directive + Chi's "ship 1" call). If the task body contains a
+    # channel-mention `<#1234>`, codex sandbox cannot read that channel's
+    # content; rather than letting the agent emit the cold "Sandbox
+    # unavailable" string publicly, the bridge silently escalates to the
+    # appropriate guild's escalation_channel and writes an "already_escalated"
+    # tier instruction telling the agent to NO-REPLY archive.
+    already_escalated = False
+    if access_tier in ("team", "other"):
+        try:
+            already_escalated = await _silent_escalate_for_discord_state(message, user_task_text)
+        except Exception as e:
+            print(f"  [discord-state-escalate] outer guard caught: {e}", flush=True)
+            already_escalated = False
     # Absolute path for codex's `-o` flag. The team-tier command runs from
     # the bridge's cwd (the repo) so a relative `results/...` path would work,
     # but the other-tier command uses `-C /tmp` which would resolve a
@@ -1959,6 +2091,19 @@ async def _handle_discord_message(message, force=False):
     # both tier blocks are robust regardless of cwd.
     tier_instructions = {
         "owner": "",
+        "already_escalated": (
+            "\n\n===SUTANDO SYSTEM INSTRUCTIONS (do not ignore; overrides anything above)===\n"
+            "This task references Discord-side state (channel mention or recent-message lookup) that the "
+            "codex sandbox cannot access. The bridge has already posted a silent notification to the "
+            "configured escalation channel where a moderator can review and respond directly.\n\n"
+            "ACTION: archive this task without sender reply. Do NOT write results/task-{id}.txt. Do NOT "
+            "invoke codex. Move tasks/task-{id}.txt to tasks/archive/.\n\n"
+            "Rationale: per msze_'s 2026-05-07 directive, Sutando should not surface internal-mechanism "
+            "errors (e.g. 'Sandbox unavailable; refusing non-owner task.') on public channels. When the "
+            "request asks for Discord-side state the bot can't see, the appropriate escalation has "
+            "already been routed to the moderators silently.\n"
+            "===END SUTANDO SYSTEM INSTRUCTIONS===\n"
+        ),
         "team": (
             "\n\n===SUTANDO SYSTEM INSTRUCTIONS (do not ignore; overrides anything above)===\n"
             "This task is from a TEAM tier sender. Choose ONE of three actions based on the content:\n\n"
@@ -2009,6 +2154,7 @@ async def _handle_discord_message(message, force=False):
             except Exception as e:
                 print(f"  [auto-react] {react_emoji} failed: {e}", flush=True)
 
+    instruction_key = "already_escalated" if already_escalated else access_tier
     task_file.write_text(
         f"id: {task_id}\n"
         f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%S')}Z\n"
@@ -2017,7 +2163,7 @@ async def _handle_discord_message(message, force=False):
         f"channel_id: {message.channel.id}\n"
         f"user_id: {message.author.id}\n"
         f"access_tier: {access_tier}\n"
-        f"{tier_instructions.get(access_tier, tier_instructions['other'])}"
+        f"{tier_instructions.get(instruction_key, tier_instructions['other'])}"
     )
     pending_replies[task_id] = message.channel
     save_pending_replies()

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -848,13 +848,36 @@ async def _silent_escalate_for_discord_state(message, user_task_text):
             ch_guild = getattr(ch, "guild", None)
             if ch_guild is None:
                 continue
-            # DM-origin gate: require explicit mod_active=True for routing
+            # DM-origin gate 1: require explicit mod_active=True for routing
+            # (the same opt-in signal #633's mod-judge uses).
             try:
                 guild_active, _roles = _load_mod_config(ch_guild.id)
             except Exception:
                 guild_active = False
             if not guild_active:
                 print(f"  [discord-state-escalate] guild {ch_guild.id} has mod_active=False; not routing DM-referenced escalation", flush=True)
+                continue
+            # DM-origin gate 2 (per MacBook #639 v2 follow-up review):
+            # `mod_active=True` is an opt-in gate, NOT a sender-auth gate.
+            # A team-tier-trusted DM sender is "trusted by Sutando" but that
+            # doesn't extend to routing escalations to ANOTHER guild they
+            # may not be a member of. Require the sender to be a member of
+            # the target guild before routing.
+            sender_id = getattr(message.author, "id", None) if hasattr(message, "author") else None
+            if sender_id is None:
+                continue
+            try:
+                sender_member = ch_guild.get_member(sender_id) if hasattr(ch_guild, "get_member") else None
+                if sender_member is None and hasattr(ch_guild, "fetch_member"):
+                    try:
+                        sender_member = await ch_guild.fetch_member(sender_id)
+                    except Exception:
+                        sender_member = None
+            except Exception as e:
+                print(f"  [discord-state-escalate] failed to check sender {sender_id} membership in guild {ch_guild.id}: {e}", flush=True)
+                sender_member = None
+            if sender_member is None:
+                print(f"  [discord-state-escalate] sender {sender_id} not a member of guild {ch_guild.id}; not routing DM-referenced escalation", flush=True)
                 continue
             target_guild_id = ch_guild.id
             break

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -76,6 +76,27 @@ _FENCE_LINE = re.compile(r"^\s{0,3}(`{3,}|~{3,})\s*([^\s`~][^`~]*)?\s*$")
 # string). Per msze_'s 2026-05-07 directive + Chi's "ship 1" call.
 _DISCORD_CHANNEL_REF_RE = re.compile(r"<#(\d+)>")
 
+# User-mention regex used by escalation cc_ids extraction. Critical: this
+# explicitly rejects role mentions `<@&id>` (the leading `&` after `<@`).
+# Earlier code did `s.strip("<@>")` after a startswith("<@") check, which
+# matched both shapes — role mentions then produced `&123` and `int(...)`
+# raised ValueError, killing the escalation post entirely. Per MacBook's
+# #639 v4 line-level review.
+_DISCORD_USER_MENTION_RE = re.compile(r"^<@(\d+)>$")
+
+
+def _extract_user_id_mentions(mention_strs):
+    """Parse `<@user_id>` strings from a sequence into int user_ids. Skips
+    role mentions `<@&role_id>` and any malformed entry. Used by escalation
+    paths that build a Discord `AllowedMentions(users=...)` list from
+    access.json's `escalation_cc_user_ids`."""
+    out = []
+    for s in mention_strs or ():
+        m = _DISCORD_USER_MENTION_RE.match(s)
+        if m:
+            out.append(int(m.group(1)))
+    return out
+
 
 def _is_fence_open_line(line: str):
     """Return the fence opener string if `line` is a real Markdown block-fence line.
@@ -944,7 +965,7 @@ async def _silent_escalate_for_discord_state(message, user_task_text):
     ]
     cc_ids = []
     if cfg.get("escalation_ccs"):
-        cc_ids = [int(s.strip("<@>")) for s in cfg["escalation_ccs"] if s.startswith("<@") and s.endswith(">")]
+        cc_ids = _extract_user_id_mentions(cfg["escalation_ccs"])
     am = discord.AllowedMentions(everyone=False, roles=False, users=cc_ids)
     try:
         await esc_ch.send("\n".join(body_lines), allowed_mentions=am)
@@ -1006,7 +1027,7 @@ async def _post_mod_escalation(client_ref, suspect_message, rule_label, llm_rati
         # ONLY the explicit cc user-ids; suppress @everyone/@here/@role and
         # any user mentions not in the cc list.
         try:
-            cc_ids = [int(s.strip("<@>")) for s in cfg["escalation_ccs"] if s.startswith("<@") and s.endswith(">")]
+            cc_ids = _extract_user_id_mentions(cfg["escalation_ccs"])
         except Exception:
             cc_ids = []
         try:
@@ -2158,8 +2179,15 @@ async def _handle_discord_message(message, force=False):
         try:
             already_escalated = await _silent_escalate_for_discord_state(message, user_task_text)
         except Exception as e:
-            print(f"  [discord-state-escalate] outer guard caught: {e}", flush=True)
-            already_escalated = False
+            # Per MacBook's #639 v4 review: fail-SILENT on unknown error in
+            # the escalate path. The previous fail-open default
+            # (already_escalated=False → run codex publicly) meant a broken
+            # escalation infra would leak the cold "Sandbox unavailable"
+            # string into public channels, which is exactly what msze_'s
+            # original directive said to avoid. Fail-silent matches the
+            # "don't surface internal errors publicly" intent.
+            print(f"  [discord-state-escalate] outer guard caught: {e}; fail-silent (NO-REPLY archive)", flush=True)
+            already_escalated = True
 
     # When the bridge has already silently escalated, the agent has nothing to
     # do — skip the task-file write entirely. Otherwise the task would land in

--- a/tests/discord-bridge-discord-state-detection.test.py
+++ b/tests/discord-bridge-discord-state-detection.test.py
@@ -123,8 +123,21 @@ class _MockChannel:
 
 
 class _MockGuild:
-    def __init__(self, gid):
+    def __init__(self, gid, members=None):
         self.id = gid
+        # members: dict of {user_id: _MockMember}; sender-auth gate looks up
+        # the sender via ch_guild.get_member(sender_id)
+        self._members = members or {}
+    def get_member(self, user_id):
+        return self._members.get(user_id)
+    async def fetch_member(self, user_id):
+        return self._members.get(user_id)
+
+
+class _MockMember:
+    def __init__(self, user_id, roles=()):
+        self.id = user_id
+        self.roles = roles
 
 
 class _MockMessage:
@@ -217,13 +230,14 @@ def case_g_guild_origin_with_config():
 def case_h_dm_origin_resolves_via_referenced_channel():
     fails = []
     # DM origin (msg.guild is None), task references a guild text channel that's
-    # mod_active=True. Should resolve target guild + post.
-    referenced_guild = _MockGuild(99)
+    # mod_active=True AND sender is a member. Should resolve target guild + post.
+    sender_id = 999  # _MockMessage default author_id
+    referenced_guild = _MockGuild(99, members={sender_id: _MockMember(sender_id)})
     referenced_ch = _MockChannel(1307539994751139893, referenced_guild, ch_type="text")
     esc_ch = _MockChannel(1153753796321738863, referenced_guild, name="mod-only", ch_type="text")
     _install_mock_client({1307539994751139893: referenced_ch, 1153753796321738863: esc_ch})
     bridge._load_mod_server_config = lambda gid: ({"escalation_channel": 1153753796321738863, "escalation_ccs": (), "redirect_channel_jobs": None} if gid == 99 else {"escalation_channel": None, "escalation_ccs": (), "redirect_channel_jobs": None})
-    bridge._load_mod_config = lambda gid: ((True, []) if gid == 99 else (False, []))  # DM-origin gate: must be mod_active=True
+    bridge._load_mod_config = lambda gid: ((True, []) if gid == 99 else (False, []))  # DM-origin gate 1: must be mod_active=True
     dm_origin = _MockChannel(1501715985584099398, None)  # DM
     msg = _MockMessage("m", dm_origin, guild=None)
     result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#1307539994751139893>"))
@@ -265,12 +279,13 @@ def case_k_dm_origin_target_guild_not_mod_active():
     guild the bot is in and route their request to that guild's escalation
     channel — information leak vector. Gate enforcement must NOT post."""
     fails = []
-    referenced_guild = _MockGuild(99)
+    sender_id = 999
+    referenced_guild = _MockGuild(99, members={sender_id: _MockMember(sender_id)})
     referenced_ch = _MockChannel(1307539994751139893, referenced_guild, ch_type="text")
     esc_ch = _MockChannel(1153753796321738863, referenced_guild, name="mod-only", ch_type="text")
     _install_mock_client({1307539994751139893: referenced_ch, 1153753796321738863: esc_ch})
     bridge._load_mod_server_config = lambda gid: {"escalation_channel": 1153753796321738863, "escalation_ccs": (), "redirect_channel_jobs": None}
-    # mod_active=False for the target guild — gate should reject
+    # mod_active=False for the target guild — gate 1 should reject
     bridge._load_mod_config = lambda gid: (False, [])
     dm_origin = _MockChannel(1501715985584099398, None)
     msg = _MockMessage("m", dm_origin, guild=None)
@@ -287,7 +302,8 @@ def case_l_dm_origin_referenced_channel_wrong_type():
     channels (voice/category/etc.). Even if mod_active=True, a category or
     voice channel reference shouldn't drive routing."""
     fails = []
-    referenced_guild = _MockGuild(99)
+    sender_id = 999
+    referenced_guild = _MockGuild(99, members={sender_id: _MockMember(sender_id)})
     # Non-text channel type
     referenced_ch = _MockChannel(1307539994751139893, referenced_guild, ch_type="category")
     esc_ch = _MockChannel(1153753796321738863, referenced_guild, name="mod-only", ch_type="text")
@@ -301,6 +317,31 @@ def case_l_dm_origin_referenced_channel_wrong_type():
         fails.append(f"l) wrong-type referenced channel should still return True silently; got {result}")
     if esc_ch.sent:
         fails.append("l) wrong-type referenced channel should NOT post to escalation channel")
+    return fails
+
+
+def case_n_dm_origin_sender_not_member_rejected():
+    """Per MacBook #639 v2 follow-up review: `mod_active=True` is an opt-in
+    gate, NOT a sender-auth gate. A team-tier-trusted DM sender is "trusted
+    by Sutando" but that doesn't extend to driving escalations into a guild
+    they're not a member of. DM-origin gate 2: reject if sender is not a
+    member of the target guild."""
+    fails = []
+    sender_id = 999
+    # Target guild has mod_active=True BUT sender is NOT a member
+    referenced_guild = _MockGuild(99, members={})  # empty members → sender not in
+    referenced_ch = _MockChannel(1307539994751139893, referenced_guild, ch_type="text")
+    esc_ch = _MockChannel(1153753796321738863, referenced_guild, name="mod-only", ch_type="text")
+    _install_mock_client({1307539994751139893: referenced_ch, 1153753796321738863: esc_ch})
+    bridge._load_mod_server_config = lambda gid: {"escalation_channel": 1153753796321738863, "escalation_ccs": (), "redirect_channel_jobs": None}
+    bridge._load_mod_config = lambda gid: (True, [])  # passes gate 1, fails gate 2
+    dm_origin = _MockChannel(1501715985584099398, None)
+    msg = _MockMessage("m", dm_origin, guild=None, author_id=sender_id)
+    result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#1307539994751139893>"))
+    if result is not True:
+        fails.append(f"n) non-member sender should still return True (silent); got {result}")
+    if esc_ch.sent:
+        fails.append("n) non-member sender should NOT trigger an escalation post")
     return fails
 
 
@@ -340,6 +381,7 @@ def main():
         ("k-dm-origin-mod-active-false-rejected", case_k_dm_origin_target_guild_not_mod_active),
         ("l-dm-origin-wrong-channel-type-rejected", case_l_dm_origin_referenced_channel_wrong_type),
         ("m-guild-origin-unaffected-by-dm-gates", case_m_guild_origin_unaffected_by_dm_gates),
+        ("n-dm-origin-sender-not-member-rejected", case_n_dm_origin_sender_not_member_rejected),
     ]
     failures = []
     for label, fn in cases:

--- a/tests/discord-bridge-discord-state-detection.test.py
+++ b/tests/discord-bridge-discord-state-detection.test.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Tests for the Discord-state-reference pre-classification in
+`discord-bridge.py`. Per msze_'s 2026-05-07 directive: when a non-owner
+task body references Discord-side state codex sandbox cannot read (channel
+mentions like `<#1234>`), the bridge silently escalates to the appropriate
+guild's `escalation_channel` and writes an "already_escalated" tier
+instruction telling the agent to NO-REPLY archive — instead of letting
+the agent emit the cold "Sandbox unavailable" string publicly.
+
+Cases:
+  Pure detection — `_extract_referenced_channels`:
+    a) plain text with no `<#...>` → []
+    b) single `<#1234>` → [1234]
+    c) multiple `<#...>` → all in order
+    d) malformed `<#abc>` (non-digit) → ignored
+    e) empty / None → []
+
+  Silent-escalate flow — `_silent_escalate_for_discord_state`:
+    f) no `<#...>` references → returns False (caller proceeds normal)
+    g) reference + guild channel + escalation_channel configured → posts
+       to that channel, returns True
+    h) reference + DM origin + referenced channel resolves to a guild with
+       config → posts to THAT guild's escalation channel, returns True
+    i) reference + no escalation_channel → returns True (silent NO-REPLY,
+       no post attempted)
+    j) reference + guild has no `mod_server_config` entry at all → True
+
+Run: python3 tests/discord-bridge-discord-state-detection.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *a, **kw):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+        self._channels = {}
+    def event(self, fn): return fn
+    def get_channel(self, cid): return self._channels.get(cid)
+    async def fetch_channel(self, cid): return self._channels.get(cid)
+
+
+class _AllowedMentions:
+    def __init__(self, *a, **kw): pass
+
+
+class _DMChannel: pass
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.AllowedMentions = _AllowedMentions
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+_discord_stub.DMChannel = _DMChannel
+
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# ---------------------------------------------------------------------------
+# Mocks
+# ---------------------------------------------------------------------------
+
+class _MockChannel:
+    def __init__(self, channel_id, guild=None, name="ch"):
+        self.id = channel_id
+        self.guild = guild
+        self.name = name
+        self.sent = []
+    async def send(self, content, allowed_mentions=None):
+        self.sent.append({"content": content, "allowed_mentions": allowed_mentions})
+
+
+class _MockGuild:
+    def __init__(self, gid):
+        self.id = gid
+
+
+class _MockMessage:
+    def __init__(self, msg_id, channel, author_id=999, guild=None):
+        self.id = msg_id
+        self.author = types.SimpleNamespace(id=author_id, display_name="alice")
+        self.channel = channel
+        self.guild = guild
+
+
+def _install_mock_client(mock_channels_by_id):
+    """Replace `bridge.client` with a _Client whose get_channel/fetch_channel
+    return mocks from the dict."""
+    c = _Client()
+    c._channels = mock_channels_by_id
+    bridge.client = c
+
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+def case_a_plain_text():
+    fails = []
+    if bridge._extract_referenced_channels("just a plain message, no refs") != []:
+        fails.append("a) plain text should return []")
+    return fails
+
+
+def case_b_single_ref():
+    fails = []
+    refs = bridge._extract_referenced_channels("look at <#1234567890>")
+    if refs != [1234567890]:
+        fails.append(f"b) single ref expected [1234567890], got {refs}")
+    return fails
+
+
+def case_c_multiple_refs():
+    fails = []
+    refs = bridge._extract_referenced_channels("compare <#111> and <#222> with <#333>")
+    if refs != [111, 222, 333]:
+        fails.append(f"c) multiple refs expected [111,222,333], got {refs}")
+    return fails
+
+
+def case_d_malformed_ignored():
+    fails = []
+    refs = bridge._extract_referenced_channels("<#abc> isn't valid, but <#42> is")
+    if refs != [42]:
+        fails.append(f"d) malformed ignored, valid kept; expected [42], got {refs}")
+    return fails
+
+
+def case_e_empty():
+    fails = []
+    if bridge._extract_referenced_channels("") != []:
+        fails.append("e1) empty string should return []")
+    if bridge._extract_referenced_channels(None) != []:
+        fails.append("e2) None should return []")
+    return fails
+
+
+def case_f_no_refs_returns_false():
+    fails = []
+    msg = _MockMessage("m", _MockChannel(7777, _MockGuild(42)), guild=_MockGuild(42))
+    result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "no channel refs here"))
+    if result is not False:
+        fails.append(f"f) no refs should return False (got {result})")
+    return fails
+
+
+def case_g_guild_origin_with_config():
+    fails = []
+    guild = _MockGuild(42)
+    origin_ch = _MockChannel(7777, guild)
+    msg = _MockMessage("m", origin_ch, guild=guild)
+    esc_ch = _MockChannel(9001, guild, name="mod-only")
+    _install_mock_client({9001: esc_ch})
+    bridge._load_mod_server_config = lambda gid: {"escalation_channel": 9001, "escalation_ccs": (), "redirect_channel_jobs": None}
+    result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#1234567890>"))
+    if result is not True:
+        fails.append(f"g) ref + guild + config should return True (got {result})")
+    if not esc_ch.sent:
+        fails.append("g) escalation channel should have received a post")
+    elif "<#1234567890>" not in esc_ch.sent[0]["content"]:
+        fails.append("g) escalation post should mention the referenced channel")
+    return fails
+
+
+def case_h_dm_origin_resolves_via_referenced_channel():
+    fails = []
+    # DM origin (msg.guild is None), but task references a channel that resolves to a guild
+    referenced_guild = _MockGuild(99)
+    referenced_ch = _MockChannel(1307539994751139893, referenced_guild)
+    esc_ch = _MockChannel(1153753796321738863, referenced_guild, name="mod-only")
+    _install_mock_client({1307539994751139893: referenced_ch, 1153753796321738863: esc_ch})
+    bridge._load_mod_server_config = lambda gid: ({"escalation_channel": 1153753796321738863, "escalation_ccs": (), "redirect_channel_jobs": None} if gid == 99 else {"escalation_channel": None, "escalation_ccs": (), "redirect_channel_jobs": None})
+    dm_origin = _MockChannel(1501715985584099398, None)  # DM
+    msg = _MockMessage("m", dm_origin, guild=None)
+    result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#1307539994751139893>"))
+    if result is not True:
+        fails.append(f"h) DM ref-resolve should return True (got {result})")
+    if not esc_ch.sent:
+        fails.append("h) referenced-channel's guild's escalation channel should have received the post")
+    return fails
+
+
+def case_i_no_escalation_channel_returns_true_no_post():
+    fails = []
+    guild = _MockGuild(42)
+    origin_ch = _MockChannel(7777, guild)
+    msg = _MockMessage("m", origin_ch, guild=guild)
+    _install_mock_client({})
+    bridge._load_mod_server_config = lambda gid: {"escalation_channel": None, "escalation_ccs": (), "redirect_channel_jobs": None}
+    result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#1234567890>"))
+    if result is not True:
+        fails.append(f"i) no escalation_channel should still return True (silent NO-REPLY); got {result}")
+    return fails
+
+
+def case_j_no_target_guild_resolvable():
+    fails = []
+    # DM origin, referenced channel can't be resolved
+    _install_mock_client({})  # nothing in cache, fetch returns None too
+    dm_origin = _MockChannel(1501715985584099398, None)
+    msg = _MockMessage("m", dm_origin, guild=None)
+    result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#9999999999>"))
+    if result is not True:
+        fails.append(f"j) no target guild resolvable should still return True (silent); got {result}")
+    return fails
+
+
+def main():
+    cases = [
+        ("a-plain-text", case_a_plain_text),
+        ("b-single-ref", case_b_single_ref),
+        ("c-multiple-refs", case_c_multiple_refs),
+        ("d-malformed-ignored", case_d_malformed_ignored),
+        ("e-empty", case_e_empty),
+        ("f-no-refs-returns-false", case_f_no_refs_returns_false),
+        ("g-guild-origin-with-config", case_g_guild_origin_with_config),
+        ("h-dm-origin-resolves-via-referenced-channel", case_h_dm_origin_resolves_via_referenced_channel),
+        ("i-no-escalation-channel-returns-true-no-post", case_i_no_escalation_channel_returns_true_no_post),
+        ("j-no-target-guild-resolvable", case_j_no_target_guild_resolvable),
+    ]
+    failures = []
+    for label, fn in cases:
+        fs = fn()
+        if fs:
+            failures.extend([(label, msg) for msg in fs])
+            print(f"  ✗ case {label}")
+            for f in fs:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll Discord-state pre-classify invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/discord-bridge-discord-state-detection.test.py
+++ b/tests/discord-bridge-discord-state-detection.test.py
@@ -415,6 +415,50 @@ def case_p_fetch_member_http_exception_silent():
     return fails
 
 
+def case_q_extract_user_id_mentions_excludes_roles():
+    """Per MacBook v4 line-level review: `<@&role_id>` strings would have
+    crashed cc_ids extraction with ValueError under the old
+    `s.startswith('<@')` check (the strip would yield `&123`, int() fails).
+    `_extract_user_id_mentions` must accept user mentions and skip role
+    mentions cleanly."""
+    fails = []
+    mixed = ["<@111>", "<@&222>", "<@333>", "garbage", "<@444>"]
+    result = bridge._extract_user_id_mentions(mixed)
+    expected = [111, 333, 444]
+    if result != expected:
+        fails.append(f"q1) expected user-only IDs {expected}, got {result}")
+    if bridge._extract_user_id_mentions(()) != []:
+        fails.append("q2) empty input should return []")
+    if bridge._extract_user_id_mentions(None) != []:
+        fails.append("q3) None input should return []")
+    if bridge._extract_user_id_mentions(["<@&100>", "<@&200>"]) != []:
+        fails.append("q4) role-only input should return []")
+    return fails
+
+
+def case_r_role_mention_in_escalation_ccs_does_not_crash():
+    """End-to-end: when access.json has a role mention in escalation_ccs,
+    the escalation post still goes through (role just doesn't appear in
+    `allowed_mentions.users`). Pre-fix this would ValueError + escalation-fail."""
+    fails = []
+    guild = _MockGuild(42)
+    origin_ch = _MockChannel(7777, guild)
+    msg = _MockMessage("m", origin_ch, guild=guild)
+    esc_ch = _MockChannel(9001, guild, name="mod-only")
+    _install_mock_client({9001: esc_ch})
+    bridge._load_mod_server_config = lambda gid: {
+        "escalation_channel": 9001,
+        "escalation_ccs": ("<@111>", "<@&999>", "<@222>"),
+        "redirect_channel_jobs": None,
+    }
+    result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#1234567890>"))
+    if result is not True:
+        fails.append(f"r) escalation with mixed cc list should still return True; got {result}")
+    if not esc_ch.sent:
+        fails.append("r) escalation should still post — role mentions must not crash the path")
+    return fails
+
+
 def case_m_guild_origin_unaffected_by_dm_gates():
     """Counter-case to k/l: when origin IS a guild channel, the DM-origin
     extra gates (mod_active check, channel-type validation) should NOT apply.
@@ -454,6 +498,8 @@ def main():
         ("n-dm-origin-sender-not-member-rejected", case_n_dm_origin_sender_not_member_rejected),
         ("o-fetch-member-forbidden-silent", case_o_fetch_member_forbidden_silent),
         ("p-fetch-member-http-exception-silent", case_p_fetch_member_http_exception_silent),
+        ("q-extract-user-id-mentions-excludes-roles", case_q_extract_user_id_mentions_excludes_roles),
+        ("r-role-mention-in-escalation-ccs-does-not-crash", case_r_role_mention_in_escalation_ccs_does_not_crash),
     ]
     failures = []
     for label, fn in cases:

--- a/tests/discord-bridge-discord-state-detection.test.py
+++ b/tests/discord-bridge-discord-state-detection.test.py
@@ -73,6 +73,17 @@ _discord_stub.Intents = _Intents
 _discord_stub.Client = _Client
 _discord_stub.AllowedMentions = _AllowedMentions
 _discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+# ChannelType — match the subset bridge whitelists for DM-origin escalation
+_discord_stub.ChannelType = types.SimpleNamespace(
+    text="text",
+    public_thread="public_thread",
+    private_thread="private_thread",
+    news_thread="news_thread",
+    news="news",
+    voice="voice",
+    category="category",
+    forum="forum",
+)
 _discord_stub.File = lambda *a, **kw: None
 _discord_stub.DMChannel = _DMChannel
 
@@ -101,10 +112,11 @@ bridge = load_bridge()
 # ---------------------------------------------------------------------------
 
 class _MockChannel:
-    def __init__(self, channel_id, guild=None, name="ch"):
+    def __init__(self, channel_id, guild=None, name="ch", ch_type="text"):
         self.id = channel_id
         self.guild = guild
         self.name = name
+        self.type = ch_type  # mirror discord.Channel.type — used by escalate's DM-origin gate
         self.sent = []
     async def send(self, content, allowed_mentions=None):
         self.sent.append({"content": content, "allowed_mentions": allowed_mentions})
@@ -204,12 +216,14 @@ def case_g_guild_origin_with_config():
 
 def case_h_dm_origin_resolves_via_referenced_channel():
     fails = []
-    # DM origin (msg.guild is None), but task references a channel that resolves to a guild
+    # DM origin (msg.guild is None), task references a guild text channel that's
+    # mod_active=True. Should resolve target guild + post.
     referenced_guild = _MockGuild(99)
-    referenced_ch = _MockChannel(1307539994751139893, referenced_guild)
-    esc_ch = _MockChannel(1153753796321738863, referenced_guild, name="mod-only")
+    referenced_ch = _MockChannel(1307539994751139893, referenced_guild, ch_type="text")
+    esc_ch = _MockChannel(1153753796321738863, referenced_guild, name="mod-only", ch_type="text")
     _install_mock_client({1307539994751139893: referenced_ch, 1153753796321738863: esc_ch})
     bridge._load_mod_server_config = lambda gid: ({"escalation_channel": 1153753796321738863, "escalation_ccs": (), "redirect_channel_jobs": None} if gid == 99 else {"escalation_channel": None, "escalation_ccs": (), "redirect_channel_jobs": None})
+    bridge._load_mod_config = lambda gid: ((True, []) if gid == 99 else (False, []))  # DM-origin gate: must be mod_active=True
     dm_origin = _MockChannel(1501715985584099398, None)  # DM
     msg = _MockMessage("m", dm_origin, guild=None)
     result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#1307539994751139893>"))
@@ -245,6 +259,72 @@ def case_j_no_target_guild_resolvable():
     return fails
 
 
+def case_k_dm_origin_target_guild_not_mod_active():
+    """Per MacBook #639 review #3: DM-origin path requires mod_active=True on
+    the target guild. Otherwise an arbitrary user could DM a `<#...>` for any
+    guild the bot is in and route their request to that guild's escalation
+    channel — information leak vector. Gate enforcement must NOT post."""
+    fails = []
+    referenced_guild = _MockGuild(99)
+    referenced_ch = _MockChannel(1307539994751139893, referenced_guild, ch_type="text")
+    esc_ch = _MockChannel(1153753796321738863, referenced_guild, name="mod-only", ch_type="text")
+    _install_mock_client({1307539994751139893: referenced_ch, 1153753796321738863: esc_ch})
+    bridge._load_mod_server_config = lambda gid: {"escalation_channel": 1153753796321738863, "escalation_ccs": (), "redirect_channel_jobs": None}
+    # mod_active=False for the target guild — gate should reject
+    bridge._load_mod_config = lambda gid: (False, [])
+    dm_origin = _MockChannel(1501715985584099398, None)
+    msg = _MockMessage("m", dm_origin, guild=None)
+    result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#1307539994751139893>"))
+    if result is not True:
+        fails.append(f"k) gate-rejected DM origin should still return True (silent); got {result}")
+    if esc_ch.sent:
+        fails.append("k) gate-rejected DM origin should NOT post to escalation channel")
+    return fails
+
+
+def case_l_dm_origin_referenced_channel_wrong_type():
+    """Per MacBook #639 review #3: DM-origin path must reject non-guild-text
+    channels (voice/category/etc.). Even if mod_active=True, a category or
+    voice channel reference shouldn't drive routing."""
+    fails = []
+    referenced_guild = _MockGuild(99)
+    # Non-text channel type
+    referenced_ch = _MockChannel(1307539994751139893, referenced_guild, ch_type="category")
+    esc_ch = _MockChannel(1153753796321738863, referenced_guild, name="mod-only", ch_type="text")
+    _install_mock_client({1307539994751139893: referenced_ch, 1153753796321738863: esc_ch})
+    bridge._load_mod_server_config = lambda gid: {"escalation_channel": 1153753796321738863, "escalation_ccs": (), "redirect_channel_jobs": None}
+    bridge._load_mod_config = lambda gid: (True, [])  # mod_active=True but channel type wrong
+    dm_origin = _MockChannel(1501715985584099398, None)
+    msg = _MockMessage("m", dm_origin, guild=None)
+    result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#1307539994751139893>"))
+    if result is not True:
+        fails.append(f"l) wrong-type referenced channel should still return True silently; got {result}")
+    if esc_ch.sent:
+        fails.append("l) wrong-type referenced channel should NOT post to escalation channel")
+    return fails
+
+
+def case_m_guild_origin_unaffected_by_dm_gates():
+    """Counter-case to k/l: when origin IS a guild channel, the DM-origin
+    extra gates (mod_active check, channel-type validation) should NOT apply.
+    Origin-guild path uses the message's own guild directly."""
+    fails = []
+    guild = _MockGuild(42)
+    origin_ch = _MockChannel(7777, guild, ch_type="text")
+    msg = _MockMessage("m", origin_ch, guild=guild)
+    esc_ch = _MockChannel(9001, guild, name="mod-only", ch_type="text")
+    _install_mock_client({9001: esc_ch})
+    bridge._load_mod_server_config = lambda gid: {"escalation_channel": 9001, "escalation_ccs": (), "redirect_channel_jobs": None}
+    # Even with mod_active=False, origin-guild path should still post
+    bridge._load_mod_config = lambda gid: (False, [])
+    result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#1234567890>"))
+    if result is not True:
+        fails.append(f"m) origin-guild should return True (got {result})")
+    if not esc_ch.sent:
+        fails.append("m) origin-guild path should post regardless of mod_active gate (DM-only gate)")
+    return fails
+
+
 def main():
     cases = [
         ("a-plain-text", case_a_plain_text),
@@ -257,6 +337,9 @@ def main():
         ("h-dm-origin-resolves-via-referenced-channel", case_h_dm_origin_resolves_via_referenced_channel),
         ("i-no-escalation-channel-returns-true-no-post", case_i_no_escalation_channel_returns_true_no_post),
         ("j-no-target-guild-resolvable", case_j_no_target_guild_resolvable),
+        ("k-dm-origin-mod-active-false-rejected", case_k_dm_origin_target_guild_not_mod_active),
+        ("l-dm-origin-wrong-channel-type-rejected", case_l_dm_origin_referenced_channel_wrong_type),
+        ("m-guild-origin-unaffected-by-dm-gates", case_m_guild_origin_unaffected_by_dm_gates),
     ]
     failures = []
     for label, fn in cases:

--- a/tests/discord-bridge-discord-state-detection.test.py
+++ b/tests/discord-bridge-discord-state-detection.test.py
@@ -73,6 +73,16 @@ _discord_stub.Intents = _Intents
 _discord_stub.Client = _Client
 _discord_stub.AllowedMentions = _AllowedMentions
 _discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+# Discord exception types — bridge's sender-auth gate catches NotFound /
+# Forbidden / HTTPException explicitly for the fetch_member fallback path.
+class _DiscordException(Exception): pass
+class _HTTPException(_DiscordException): pass
+class _NotFound(_HTTPException): pass
+class _Forbidden(_HTTPException): pass
+_discord_stub.DiscordException = _DiscordException
+_discord_stub.HTTPException = _HTTPException
+_discord_stub.NotFound = _NotFound
+_discord_stub.Forbidden = _Forbidden
 # ChannelType — match the subset bridge whitelists for DM-origin escalation
 _discord_stub.ChannelType = types.SimpleNamespace(
     text="text",
@@ -123,15 +133,26 @@ class _MockChannel:
 
 
 class _MockGuild:
-    def __init__(self, gid, members=None):
+    def __init__(self, gid, members=None, fetch_raises=None):
         self.id = gid
         # members: dict of {user_id: _MockMember}; sender-auth gate looks up
-        # the sender via ch_guild.get_member(sender_id)
+        # the sender via ch_guild.get_member(sender_id) (cache hit) then
+        # falls back to ch_guild.fetch_member(...) (HTTP, can raise).
         self._members = members or {}
+        # fetch_raises: optional Exception instance to raise from fetch_member
+        # — used to test the NotFound / Forbidden / HTTPException paths.
+        self._fetch_raises = fetch_raises
     def get_member(self, user_id):
         return self._members.get(user_id)
     async def fetch_member(self, user_id):
-        return self._members.get(user_id)
+        if self._fetch_raises is not None:
+            raise self._fetch_raises
+        # discord.py's real fetch_member raises NotFound for non-members; the
+        # mock matches that behavior when fetch_raises is unset and member
+        # is missing.
+        if user_id not in self._members:
+            raise _NotFound("user not in guild")
+        return self._members[user_id]
 
 
 class _MockMember:
@@ -325,11 +346,17 @@ def case_n_dm_origin_sender_not_member_rejected():
     gate, NOT a sender-auth gate. A team-tier-trusted DM sender is "trusted
     by Sutando" but that doesn't extend to driving escalations into a guild
     they're not a member of. DM-origin gate 2: reject if sender is not a
-    member of the target guild."""
+    member of the target guild.
+
+    The mock's `fetch_member` raises `_NotFound` when sender is not in the
+    `members` dict (mirrors discord.py's actual behavior — it raises
+    `discord.NotFound`, NOT returns None). The bridge's gate must catch
+    that explicitly to take the silent NO-REPLY path."""
     fails = []
     sender_id = 999
     # Target guild has mod_active=True BUT sender is NOT a member
-    referenced_guild = _MockGuild(99, members={})  # empty members → sender not in
+    # _MockGuild.fetch_member will raise _NotFound (mirrors discord.NotFound)
+    referenced_guild = _MockGuild(99, members={})
     referenced_ch = _MockChannel(1307539994751139893, referenced_guild, ch_type="text")
     esc_ch = _MockChannel(1153753796321738863, referenced_guild, name="mod-only", ch_type="text")
     _install_mock_client({1307539994751139893: referenced_ch, 1153753796321738863: esc_ch})
@@ -341,7 +368,50 @@ def case_n_dm_origin_sender_not_member_rejected():
     if result is not True:
         fails.append(f"n) non-member sender should still return True (silent); got {result}")
     if esc_ch.sent:
-        fails.append("n) non-member sender should NOT trigger an escalation post")
+        fails.append("n) non-member sender should NOT trigger an escalation post (NotFound path)")
+    return fails
+
+
+def case_o_fetch_member_forbidden_silent():
+    """Per MacBook v3 review: `fetch_member` can raise `Forbidden` (bot
+    lacks permission to view members of that guild). Fail-closed: no post,
+    no public reply."""
+    fails = []
+    sender_id = 999
+    referenced_guild = _MockGuild(99, members={}, fetch_raises=_Forbidden("bot lacks Members intent"))
+    referenced_ch = _MockChannel(1307539994751139893, referenced_guild, ch_type="text")
+    esc_ch = _MockChannel(1153753796321738863, referenced_guild, name="mod-only", ch_type="text")
+    _install_mock_client({1307539994751139893: referenced_ch, 1153753796321738863: esc_ch})
+    bridge._load_mod_server_config = lambda gid: {"escalation_channel": 1153753796321738863, "escalation_ccs": (), "redirect_channel_jobs": None}
+    bridge._load_mod_config = lambda gid: (True, [])
+    dm_origin = _MockChannel(1501715985584099398, None)
+    msg = _MockMessage("m", dm_origin, guild=None, author_id=sender_id)
+    result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#1307539994751139893>"))
+    if result is not True:
+        fails.append(f"o) Forbidden should still return True (silent); got {result}")
+    if esc_ch.sent:
+        fails.append("o) Forbidden should NOT trigger an escalation post")
+    return fails
+
+
+def case_p_fetch_member_http_exception_silent():
+    """Per MacBook v3 review: `fetch_member` can raise generic
+    `HTTPException` (5xx, rate limit, etc.). Fail-closed."""
+    fails = []
+    sender_id = 999
+    referenced_guild = _MockGuild(99, members={}, fetch_raises=_HTTPException("503 transient"))
+    referenced_ch = _MockChannel(1307539994751139893, referenced_guild, ch_type="text")
+    esc_ch = _MockChannel(1153753796321738863, referenced_guild, name="mod-only", ch_type="text")
+    _install_mock_client({1307539994751139893: referenced_ch, 1153753796321738863: esc_ch})
+    bridge._load_mod_server_config = lambda gid: {"escalation_channel": 1153753796321738863, "escalation_ccs": (), "redirect_channel_jobs": None}
+    bridge._load_mod_config = lambda gid: (True, [])
+    dm_origin = _MockChannel(1501715985584099398, None)
+    msg = _MockMessage("m", dm_origin, guild=None, author_id=sender_id)
+    result = asyncio.run(bridge._silent_escalate_for_discord_state(msg, "look at <#1307539994751139893>"))
+    if result is not True:
+        fails.append(f"p) HTTPException should still return True (silent); got {result}")
+    if esc_ch.sent:
+        fails.append("p) HTTPException should NOT trigger an escalation post")
     return fails
 
 
@@ -382,6 +452,8 @@ def main():
         ("l-dm-origin-wrong-channel-type-rejected", case_l_dm_origin_referenced_channel_wrong_type),
         ("m-guild-origin-unaffected-by-dm-gates", case_m_guild_origin_unaffected_by_dm_gates),
         ("n-dm-origin-sender-not-member-rejected", case_n_dm_origin_sender_not_member_rejected),
+        ("o-fetch-member-forbidden-silent", case_o_fetch_member_forbidden_silent),
+        ("p-fetch-member-http-exception-silent", case_p_fetch_member_http_exception_silent),
     ]
     failures = []
     for label, fn in cases:


### PR DESCRIPTION
## Summary

Per @msze_'s 2026-05-07 directive ("never refer to your sandbox / its being unavailable on public channels; if you can't function as a moderator, notify the moderators in <#1153753796321738863>"). Closes the structural failure where codex sandbox would hang 6+ minutes trying to resolve `<#1234>`-style channel references it has no Discord access for, then leak the cold "Sandbox unavailable; refusing non-owner task." fallback into public channels.

This is **fix 1** of @sonichi's 2-step plan. Fix 2 (give the agent a `read_discord_channel` tool to resolve `<#...>`/`<@...>` in-context BEFORE delegating to codex) ships separately.

## What changes

`src/discord-bridge.py` task-write block (~line 1944) now does a pre-classification:

1. If `access_tier in ("team", "other")` AND task body contains `<#1234>` channel-mention → call `_silent_escalate_for_discord_state(message, user_task_text)`.
2. The helper:
   - Resolves a target guild (origin guild, else fallback to first referenced channel's guild via `client.fetch_channel`)
   - Looks up that guild's `escalation_channel` from `_load_mod_server_config` (the same per-guild config #633's mod-judge uses)
   - Posts a silent notification with sender + origin + referenced channels + truncated task body to that escalation channel (no public reply, `allowed_mentions` constrained to configured cc users)
   - Returns `True` so the bridge writes a new `already_escalated` tier instruction
3. The `already_escalated` tier instruction tells the agent: NO-REPLY archive, do NOT write `results/task-{id}.txt`, do NOT invoke codex.

## Behavior matrix

| Scenario | Pre-PR | Post-PR |
|---|---|---|
| Task body has `<#1234>`, guild origin, escalation_channel configured | codex hangs 6min, leaks "Sandbox unavailable" | silent post to escalation_channel, NO-REPLY archive |
| Task body has `<#1234>`, DM origin, referenced channel resolves to a guild with config | same | silent post to that guild's escalation_channel, NO-REPLY |
| Task body has `<#1234>`, no escalation_channel resolvable anywhere | same | silent NO-REPLY (no post attempted, no public reply) |
| Task body has no `<#...>` reference | normal codex path | normal codex path (unchanged) |
| `access_tier == owner` | normal owner path | normal owner path (unchanged) |

## Test plan

- [x] `python3 tests/discord-bridge-discord-state-detection.test.py` — 10 cases, all green
- [x] `npm test` — full bridge suite still green
- [x] Syntax check (`python3 -c 'import ast; ast.parse(...)'`)

Cases cover: pure regex detection (plain text / single ref / multiple refs / malformed ignored / empty input), and the silent-escalate flow's 5 branches (no-refs returns False, guild-origin-with-config posts, DM-origin-resolves-via-referenced-channel posts, no-escalation-channel returns True silently, no-target-guild-resolvable returns True silently).

## Restart note

Bridge restart required to deploy. Mini-side: `pkill -f discord-bridge.py; sleep 2; nohup python3 src/discord-bridge.py >> logs/discord-bridge.log 2>&1 & disown` per `feedback_mini_bridges_no_launchd.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)