### PR TITLE
feat(sutando-app): add --emit-task to health-check invocation

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -1541,9 +1541,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let homebrewPython = "/opt/homebrew/opt/python@3.11/libexec/bin/python3"
         let pythonPath = FileManager.default.fileExists(atPath: homebrewPython)
             ? homebrewPython : "/usr/bin/env"
+        // `--emit-task` writes tasks/task-health-{ts}.txt on failure (with
+        // built-in dedup: 1h cooldown per failure-set hash). The agent picks
+        // it up via the bridge as a regular owner task — gives the trio's
+        // surface_owner path a redundant peer in the file-bridge layer, so
+        // health failures the trio's coverage scanner suppresses by cooldown
+        // (or the LLM step archives by judgment) still reach the agent. Per
+        // Chi 2026-05-07 PT.
         let arguments: [String] = (pythonPath == "/usr/bin/env")
-            ? ["python3", scriptPath, "--fix"]
-            : [scriptPath, "--fix"]
+            ? ["python3", scriptPath, "--fix", "--emit-task"]
+            : [scriptPath, "--fix", "--emit-task"]
 
         DispatchQueue.global(qos: .background).async { [weak self] in
             guard let self = self else { return }

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1034,9 +1034,15 @@ def main():
     if do_notify:
         notify_for_failures(checks)
 
-    # Note: emit-task is moved to AFTER the fix loop below, so it surfaces
-    # the RESIDUAL failure set (per PR #640 v2 review). Pre-fix surfacing
-    # creates owner tasks for failures fixed in the same invocation.
+    # Emit-task: when NOT running --fix, the initial check IS the residual,
+    # so emit here BEFORE the early-exit paths (--json return, --quiet
+    # sys.exit). Per Mini's PR #640 v2-regression catch: my prior change
+    # moved emit-task to end-of-main, which the launchd fallback's
+    # `--quiet --emit-task --notify-on-fail` invocation bypassed via the
+    # quiet-path sys.exit(1). Splitting the emit logic by --fix state
+    # restores coverage for the no-fix path.
+    if do_emit and not do_fix:
+        emit_task_for_failures(checks)
 
     if as_json:
         print(json.dumps({"checks": checks, "issues": len(issues), "total": len(checks)}, indent=2))
@@ -1169,18 +1175,15 @@ def main():
                                      stderr=subprocess.STDOUT, start_new_session=True)
                     print(f"  {c['name']}: {'restarted (stale code)' if c['status'] == 'stale' else 'restarted'}")
 
-    # Emit task on the RESIDUAL failure set (per PR #640 v2 review).
-    # When --fix ran, re-run checks to capture post-fix state — restarts
-    # may have resolved some staleness in-place. When --fix did NOT run,
-    # the initial `checks` IS the residual.
-    if do_emit:
-        if do_fix and issues:
-            # Brief delay so restarts have a chance to register before re-check.
-            # 2s matches the fix-loop's per-service `time.sleep(1)` budget.
-            import time as _t; _t.sleep(2)
-            residual_checks = run_all_checks()
-        else:
-            residual_checks = checks
+    # Emit task on the RESIDUAL failure set when --fix ran (per PR #640 v2
+    # review). The no-fix path emits earlier, before --quiet / --json early
+    # exits (per #640 v2-regression: launchd's `--quiet --emit-task` was
+    # bypassing the end-of-main emit via sys.exit(1)).
+    if do_emit and do_fix and issues:
+        # Brief delay so restarts have a chance to register before re-check.
+        # 2s matches the fix-loop's per-service `time.sleep(1)` budget.
+        import time as _t; _t.sleep(2)
+        residual_checks = run_all_checks()
         emit_task_for_failures(residual_checks)
 
     sys.exit(1 if issues else 0)

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1025,16 +1025,18 @@ def main():
     checks = run_all_checks()
     issues = [c for c in checks if c["status"] not in ("ok", "warn")]
 
-    # Optional: emit a task for the CLI to act on. Runs before --json early-
-    # return so cron-driven --json --emit-task callers get both behaviors.
-    if do_emit:
-        emit_task_for_failures(checks)
     # Optional: macOS notification surface for the launchd-supervised path
-    # (com.sutando.health-check-fallback). Independent dedup state from
+    # (com.sutando.health-check-fallback). Notifies on the INITIAL check set
+    # — the launchd fallback wants the user-visible alert immediately, even
+    # if --fix would resolve some issues. Independent dedup state from
     # emit-task — the two surfaces are deliberately decoupled so neither
     # can suppress the other.
     if do_notify:
         notify_for_failures(checks)
+
+    # Note: emit-task is moved to AFTER the fix loop below, so it surfaces
+    # the RESIDUAL failure set (per PR #640 v2 review). Pre-fix surfacing
+    # creates owner tasks for failures fixed in the same invocation.
 
     if as_json:
         print(json.dumps({"checks": checks, "issues": len(issues), "total": len(checks)}, indent=2))
@@ -1166,6 +1168,20 @@ def main():
                                      stdout=open("/tmp/conversation-server.log", "a"),
                                      stderr=subprocess.STDOUT, start_new_session=True)
                     print(f"  {c['name']}: {'restarted (stale code)' if c['status'] == 'stale' else 'restarted'}")
+
+    # Emit task on the RESIDUAL failure set (per PR #640 v2 review).
+    # When --fix ran, re-run checks to capture post-fix state — restarts
+    # may have resolved some staleness in-place. When --fix did NOT run,
+    # the initial `checks` IS the residual.
+    if do_emit:
+        if do_fix and issues:
+            # Brief delay so restarts have a chance to register before re-check.
+            # 2s matches the fix-loop's per-service `time.sleep(1)` budget.
+            import time as _t; _t.sleep(2)
+            residual_checks = run_all_checks()
+        else:
+            residual_checks = checks
+        emit_task_for_failures(residual_checks)
 
     sys.exit(1 if issues else 0)
 


### PR DESCRIPTION
## Summary
- Sutando.app menu-bar Timer was firing `health-check.py` with `--fix` only.
- Failures health-check can't auto-fix (e.g. stale-service detection where binary is older than source) went silent — no DM, no task file, no surface.
- Adds `--emit-task` to args so failures write `tasks/task-health-{ts}.txt` (with `access_tier: owner`, 1h cooldown per failure-set hash, dedup history).

## Why
3 stale services (voice-agent, web-client, sutando-app) suppressed in trio cooldown all day 2026-05-07 PT. The trio's `scan_health_anomalies` was firing but its `surface_owner` proposals kept hitting cooldown / ACT's "owner-aware" archival. The `--emit-task` path is independent of the trio queue — gives a redundant peer in the file-bridge layer.

## Test plan
- [ ] Wait for next 30min Timer fire OR `open src/Sutando/Sutando` to trigger a fresh check
- [ ] Verify a `tasks/task-health-{ts}.txt` lands when health-check exits non-zero
- [ ] Verify the dedup state file (`state/health-emit-dedup.json` or similar — check health-check.py source) prevents flooding within 1h

🤖 Generated with [Claude Code](https://claude.com/claude-code)