### PR TITLE
chore(voice-agent): VOICE_NAME consistency nits from #618 review

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -102,6 +102,7 @@ const CALL_RESULTS_DIR = join(new URL('.', import.meta.url).pathname, '..', 'res
 // Model configuration — override via .env for cost/quality tuning
 const VOICE_MODEL = process.env.VOICE_MODEL || 'gemini-2.5-flash';
 const VOICE_NATIVE_AUDIO_MODEL = process.env.VOICE_NATIVE_AUDIO_MODEL || 'gemini-3.1-flash-live-preview';
+const VOICE_NAME = process.env.VOICE_NAME || 'Puck';
 // Google Search grounding — MUST be false under gemini-3.1-flash-live-preview
 // native audio. Combining googleSearch: true + 3.1 native audio causes the
 // transport to reject setup with close code 1011 "exceeded your current
@@ -818,7 +819,7 @@ async function main() {
 		host: HOST,
 		model: google(VOICE_MODEL),
 		geminiModel: VOICE_NATIVE_AUDIO_MODEL,
-		speechConfig: { voiceName: process.env.VOICE_NAME || 'Puck' },
+		speechConfig: { voiceName: VOICE_NAME },
 		inputAudioTranscription: true,
 		hooks: {
 			onSessionStart: (e) => {
@@ -1303,6 +1304,7 @@ async function main() {
 	console.log(`  Models:`);
 	console.log(`    Voice LLM:       ${VOICE_MODEL}`);
 	console.log(`    Native audio:    ${VOICE_NATIVE_AUDIO_MODEL}`);
+	console.log(`    Voice name:      ${VOICE_NAME}`);
 	console.log(`    STT:             native Gemini Live inputAudioTranscription`);
 	console.log(`    Cartesia TTS:    ${CARTESIA_API_KEY ? 'sonic-3' : 'disabled'}`);
 	console.log();


### PR DESCRIPTION
## Summary

Two non-blocking follow-ups noted during #618 cold-review (3 prior Mini reviews on the PR, all marked LGTM-with-nits).

### Nits addressed

1. **Module-level constant** — matches `VOICE_MODEL` / `VOICE_NATIVE_AUDIO_MODEL` pattern at `src/voice-agent.ts:103-104`:
   ```ts
   const VOICE_NAME = process.env.VOICE_NAME || 'Puck';
   ```
   Then `voiceName: VOICE_NAME` in the speechConfig (was the only inline `process.env.*` env access in that section, slightly disrupted the pattern).

2. **Startup banner** — `VOICE_MODEL` + `VOICE_NATIVE_AUDIO_MODEL` are logged at startup (`src/voice-agent.ts:1304-1305`). `VOICE_NAME` now logs alongside, so users see which voice they're getting before first synthesis — particularly useful since invalid names fail silently at Gemini's WebSocket layer (close code 1007), not at config parse.

### What didn't change

- Default behavior preserved: `process.env.VOICE_NAME || 'Puck'` → `'Puck'` when env unset
- Empty-string handling preserved: `'' || 'Puck'` → `'Puck'` (JS truthy fallback unchanged)
- `.env.example` doc untouched (#618 already added voice list + 1007-failure callout)

### Diff size

3 insertions, 1 deletion. `tsc --noEmit -p .` clean. No new tests — the nits are pure structural / log-output, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)