### PR TITLE
feat(discord-bridge): pre-fetch referenced Discord-state for non-owner tasks

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -804,16 +804,19 @@ _PREFETCH_MAX_MESSAGES_PER_REF = 5
 _PREFETCH_EXCERPT_MAX = 280
 _PREFETCH_CACHE = {}  # (channel_id, bucket_60s) -> formatted block; in-process only
 _PREFETCH_CACHE_TTL_S = 60
+_PREFETCH_PER_REF_TIMEOUT_S = 8.0  # bounded wait per fetch_channel + history call
 
 
 async def _fetch_discord_channel_messages(channel_id, n=_PREFETCH_MAX_MESSAGES_PER_REF):
     """Fetch the last `n` messages from a Discord channel via the bot's REST
-    client. Returns a formatted text block (newest-first, with author + relative
-    timestamp + truncated content) or None on any failure (channel not found,
-    bot lacks permission, channel not text/thread, transient API error).
+    client. Returns one of three sentinel values:
+      - a non-empty formatted string  → channel has messages
+      - the empty string `""`         → channel exists + readable but is empty
+      - the literal `None`            → fetch FAILED (perms / NotFound / timeout / wrong type)
 
-    Returning None — not raising — is deliberate: the caller falls through to
-    silent-escalate if pre-fetch yields nothing usable.
+    The empty-string-vs-None distinction lets the caller treat empty channels
+    as a real answer ("no recent messages") rather than escalating as if the
+    fetch had failed.
     """
     cache_bucket = int(time.time() // _PREFETCH_CACHE_TTL_S)
     cache_key = (int(channel_id), cache_bucket)
@@ -822,7 +825,13 @@ async def _fetch_discord_channel_messages(channel_id, n=_PREFETCH_MAX_MESSAGES_P
     try:
         ch = client.get_channel(int(channel_id))
         if ch is None:
-            ch = await client.fetch_channel(int(channel_id))
+            ch = await asyncio.wait_for(
+                client.fetch_channel(int(channel_id)),
+                timeout=_PREFETCH_PER_REF_TIMEOUT_S,
+            )
+    except asyncio.TimeoutError:
+        print(f"  [discord-state-prefetch] resolve channel {channel_id} timed out after {_PREFETCH_PER_REF_TIMEOUT_S}s", flush=True)
+        return None
     except Exception as e:
         print(f"  [discord-state-prefetch] resolve channel {channel_id} failed: {e}", flush=True)
         return None
@@ -843,9 +852,16 @@ async def _fetch_discord_channel_messages(channel_id, n=_PREFETCH_MAX_MESSAGES_P
         print(f"  [discord-state-prefetch] channel {channel_id} type={ch_type} not text/thread; skipping", flush=True)
         return None
     try:
-        msgs = []
-        async for m in ch.history(limit=n):
-            msgs.append(m)
+        async def _drain_history():
+            collected = []
+            async for m in ch.history(limit=n):
+                collected.append(m)
+            return collected
+
+        msgs = await asyncio.wait_for(_drain_history(), timeout=_PREFETCH_PER_REF_TIMEOUT_S)
+    except asyncio.TimeoutError:
+        print(f"  [discord-state-prefetch] history({n}) on channel {channel_id} timed out after {_PREFETCH_PER_REF_TIMEOUT_S}s", flush=True)
+        return None
     except Exception as e:
         # Forbidden / NotFound / HTTPException / unexpected — all silent-fail.
         # The `_silent_escalate_for_discord_state` path is the safety net.
@@ -853,8 +869,8 @@ async def _fetch_discord_channel_messages(channel_id, n=_PREFETCH_MAX_MESSAGES_P
         return None
     if not msgs:
         # Channel exists + readable but empty — return empty marker so we don't
-        # re-fetch on every retry within the cache window. Caller treats as no
-        # useful prefetched content.
+        # re-fetch on every retry within the cache window. Caller treats as a
+        # successful "no recent messages" answer (distinct from a failed fetch).
         formatted = ""
         _PREFETCH_CACHE[cache_key] = formatted
         return formatted
@@ -880,14 +896,22 @@ async def _prefetch_discord_state_refs(user_task_text):
     """For every `<#channel_id>` reference in `user_task_text`, attempt to fetch
     the channel's recent messages via the bot's REST client and produce a
     prepended context block. Returns the enriched task body (context block +
-    `[Original task body:]` separator + original text) when at least one ref
-    fetched usefully. Returns None when there are no refs OR all fetches
-    failed (caller falls through to `_silent_escalate_for_discord_state`).
+    `[Original task body:]` separator + original text) when ALL refs fetched
+    usefully (including empty channels — those render as "[no recent messages]"
+    so the agent gets a real answer). Returns None when there are no refs OR
+    ANY ref fetch failed — falling through to silent-escalate avoids handing
+    the agent partial context that could lead to wrong answers.
 
     This is the proactive path (option 3 from Chi's 2026-05-08 strategy chat)
     that lets the agent layer answer Discord-state questions WITHOUT codex
     sandbox needing API access. Replaces the old "always silent-escalate on a
     `<#...>` ref" behavior with a try-then-fall-through shape.
+
+    All-or-nothing semantics on multi-ref tasks (per PR #644 cold review):
+    if a user asks "compare <#A> with <#B>" and <#B> is Forbidden, the bridge
+    should NOT proceed with only <#A> — that would let the agent confidently
+    answer half the question. Instead, return None and let silent-escalate
+    handle the whole task with the in-band rule.
     """
     if not user_task_text:
         return None
@@ -906,10 +930,18 @@ async def _prefetch_discord_state_refs(user_task_text):
     blocks = []
     for ref in ordered_refs:
         formatted = await _fetch_discord_channel_messages(ref)
-        if not formatted:  # None (failed) or empty string (channel empty)
-            continue
-        blocks.append(f"[Channel <#{ref}> recent messages:\n{formatted}\n]")
+        if formatted is None:
+            # Failure (perms / NotFound / timeout / wrong type). Fail-closed:
+            # one bad ref invalidates the whole prefetch. Caller silent-escalates.
+            print(f"  [discord-state-prefetch] one ref failed (<#{ref}>); failing whole prefetch to avoid partial context", flush=True)
+            return None
+        if formatted == "":
+            # Channel exists + readable + empty. That IS a real answer.
+            blocks.append(f"[Channel <#{ref}> recent messages:\n  [no recent messages]\n]")
+        else:
+            blocks.append(f"[Channel <#{ref}> recent messages:\n{formatted}\n]")
     if not blocks:
+        # No refs survived (e.g. all dedup'd to empty after filter). Fall through.
         return None
     enriched = "\n\n".join(blocks) + "\n\n[Original task body:]\n" + user_task_text
     return enriched

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2351,7 +2351,12 @@ async def _handle_discord_message(message, force=False):
         if enriched:
             print(f"  [discord-state-prefetch] enriched task body for {username} in #{getattr(message.channel, 'name', '?')}", flush=True)
             user_task_text = enriched
-            quoted_task = shlex.quote(user_task_text)
+            # Rewrite the prompt file with the enriched body. quoted_task
+            # already points to `"$(cat {prompt_path})"` — keep the heredoc
+            # form (per PR #652's codex-stdin-hang fix). Using shlex.quote
+            # here would reintroduce the nested-escape pathology codex's
+            # stdin parser hangs on. Per MacBook's #644 v2 review 2026-05-10.
+            Path(prompt_path).write_text(user_task_text)
         else:
             try:
                 already_escalated = await _silent_escalate_for_discord_state(message, user_task_text)

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -800,6 +800,121 @@ def _extract_referenced_channels(text):
     return [int(m) for m in _DISCORD_CHANNEL_REF_RE.findall(text)]
 
 
+_PREFETCH_MAX_MESSAGES_PER_REF = 5
+_PREFETCH_EXCERPT_MAX = 280
+_PREFETCH_CACHE = {}  # (channel_id, bucket_60s) -> formatted block; in-process only
+_PREFETCH_CACHE_TTL_S = 60
+
+
+async def _fetch_discord_channel_messages(channel_id, n=_PREFETCH_MAX_MESSAGES_PER_REF):
+    """Fetch the last `n` messages from a Discord channel via the bot's REST
+    client. Returns a formatted text block (newest-first, with author + relative
+    timestamp + truncated content) or None on any failure (channel not found,
+    bot lacks permission, channel not text/thread, transient API error).
+
+    Returning None — not raising — is deliberate: the caller falls through to
+    silent-escalate if pre-fetch yields nothing usable.
+    """
+    cache_bucket = int(time.time() // _PREFETCH_CACHE_TTL_S)
+    cache_key = (int(channel_id), cache_bucket)
+    if cache_key in _PREFETCH_CACHE:
+        return _PREFETCH_CACHE[cache_key]
+    try:
+        ch = client.get_channel(int(channel_id))
+        if ch is None:
+            ch = await client.fetch_channel(int(channel_id))
+    except Exception as e:
+        print(f"  [discord-state-prefetch] resolve channel {channel_id} failed: {e}", flush=True)
+        return None
+    if ch is None:
+        return None
+    # Only fetch from text/thread channels — voice/category/etc. would either
+    # 404 on history() or yield nothing useful for the agent.
+    guild_text_types = {
+        getattr(discord, "ChannelType", None) and discord.ChannelType.text,
+        getattr(discord, "ChannelType", None) and discord.ChannelType.public_thread,
+        getattr(discord, "ChannelType", None) and discord.ChannelType.private_thread,
+        getattr(discord, "ChannelType", None) and discord.ChannelType.news_thread,
+        getattr(discord, "ChannelType", None) and discord.ChannelType.news,
+    }
+    guild_text_types.discard(None)
+    ch_type = getattr(ch, "type", None)
+    if guild_text_types and ch_type is not None and ch_type not in guild_text_types:
+        print(f"  [discord-state-prefetch] channel {channel_id} type={ch_type} not text/thread; skipping", flush=True)
+        return None
+    try:
+        msgs = []
+        async for m in ch.history(limit=n):
+            msgs.append(m)
+    except Exception as e:
+        # Forbidden / NotFound / HTTPException / unexpected — all silent-fail.
+        # The `_silent_escalate_for_discord_state` path is the safety net.
+        print(f"  [discord-state-prefetch] history({n}) on channel {channel_id} failed: {type(e).__name__}: {e}", flush=True)
+        return None
+    if not msgs:
+        # Channel exists + readable but empty — return empty marker so we don't
+        # re-fetch on every retry within the cache window. Caller treats as no
+        # useful prefetched content.
+        formatted = ""
+        _PREFETCH_CACHE[cache_key] = formatted
+        return formatted
+    lines = []
+    for m in msgs:  # history(limit=n) yields newest-first; preserve that order
+        author = getattr(getattr(m, "author", None), "name", "?")
+        ts = getattr(m, "created_at", None)
+        ts_str = ts.strftime("%Y-%m-%dT%H:%MZ") if ts is not None else "?"
+        content = (getattr(m, "content", "") or "")[:_PREFETCH_EXCERPT_MAX]
+        lines.append(f"  [{ts_str}] {author}: {content}")
+    formatted = "\n".join(lines)
+    _PREFETCH_CACHE[cache_key] = formatted
+    # Light-touch GC: if the cache grew past 200 entries, drop oldest buckets.
+    # Bridge restarts wipe state anyway; this just guards a long-running process.
+    if len(_PREFETCH_CACHE) > 200:
+        cutoff = cache_bucket - 5
+        for k in [kk for kk in _PREFETCH_CACHE if kk[1] < cutoff]:
+            del _PREFETCH_CACHE[k]
+    return formatted
+
+
+async def _prefetch_discord_state_refs(user_task_text):
+    """For every `<#channel_id>` reference in `user_task_text`, attempt to fetch
+    the channel's recent messages via the bot's REST client and produce a
+    prepended context block. Returns the enriched task body (context block +
+    `[Original task body:]` separator + original text) when at least one ref
+    fetched usefully. Returns None when there are no refs OR all fetches
+    failed (caller falls through to `_silent_escalate_for_discord_state`).
+
+    This is the proactive path (option 3 from Chi's 2026-05-08 strategy chat)
+    that lets the agent layer answer Discord-state questions WITHOUT codex
+    sandbox needing API access. Replaces the old "always silent-escalate on a
+    `<#...>` ref" behavior with a try-then-fall-through shape.
+    """
+    if not user_task_text:
+        return None
+    refs = _extract_referenced_channels(user_task_text)
+    if not refs:
+        return None
+    # Deduplicate while preserving order — sometimes the same ref appears
+    # twice in a task body (e.g. quoted reply + body).
+    seen = set()
+    ordered_refs = []
+    for r in refs:
+        if r in seen:
+            continue
+        seen.add(r)
+        ordered_refs.append(r)
+    blocks = []
+    for ref in ordered_refs:
+        formatted = await _fetch_discord_channel_messages(ref)
+        if not formatted:  # None (failed) or empty string (channel empty)
+            continue
+        blocks.append(f"[Channel <#{ref}> recent messages:\n{formatted}\n]")
+    if not blocks:
+        return None
+    enriched = "\n\n".join(blocks) + "\n\n[Original task body:]\n" + user_task_text
+    return enriched
+
+
 async def _silent_escalate_for_discord_state(message, user_task_text):
     """Detect tasks that reference Discord-side state (channel mentions like
     `<#1234>`) and silently escalate to the appropriate guild's
@@ -2177,27 +2292,47 @@ async def _handle_discord_message(message, force=False):
     Path(prompt_path).write_text(user_task_text)
     quoted_task = f'"$(cat {prompt_path})"'
 
-    # Pre-classify Discord-state-reference tasks (per msze_'s 2026-05-07
-    # directive + Chi's "ship 1" call). If the task body contains a
-    # channel-mention `<#1234>`, codex sandbox cannot read that channel's
-    # content; rather than letting the agent emit the cold "Sandbox
-    # unavailable" string publicly, the bridge silently escalates to the
-    # appropriate guild's escalation_channel and writes an "already_escalated"
-    # tier instruction telling the agent to NO-REPLY archive.
+    # Pre-classify Discord-state-reference tasks. Two-tier flow (per Chi's
+    # 2026-05-08 strategy chat — option 3 systemic fix):
+    #
+    # Tier 1 — pre-fetch (proactive). For team/other-tier tasks containing
+    # `<#channel_id>` references, attempt to fetch each referenced channel's
+    # recent messages via the bot's REST client and PREPEND them to the task
+    # body. The agent (codex sandbox or core) then has the data inline and
+    # can answer normally without needing API access mid-task.
+    #
+    # Tier 2 — silent-escalate (fallback). If pre-fetch yields nothing useful
+    # (channel not found, bot lacks permission, all fetches errored), fall
+    # through to `_silent_escalate_for_discord_state` — the existing PR #639
+    # path that silently routes to the guild's escalation_channel + writes
+    # an `already_escalated` NO-REPLY instruction.
+    #
+    # Order matters: the proactive path can ANSWER the user's question; the
+    # fallback path just declines silently. Try answering first.
     already_escalated = False
     if access_tier in ("team", "other"):
         try:
-            already_escalated = await _silent_escalate_for_discord_state(message, user_task_text)
+            enriched = await _prefetch_discord_state_refs(user_task_text)
         except Exception as e:
-            # Per MacBook's #639 v4 review: fail-SILENT on unknown error in
-            # the escalate path. The previous fail-open default
-            # (already_escalated=False → run codex publicly) meant a broken
-            # escalation infra would leak the cold "Sandbox unavailable"
-            # string into public channels, which is exactly what msze_'s
-            # original directive said to avoid. Fail-silent matches the
-            # "don't surface internal errors publicly" intent.
-            print(f"  [discord-state-escalate] outer guard caught: {e}; fail-silent (NO-REPLY archive)", flush=True)
-            already_escalated = True
+            print(f"  [discord-state-prefetch] outer guard caught: {e}; falling through to silent-escalate", flush=True)
+            enriched = None
+        if enriched:
+            print(f"  [discord-state-prefetch] enriched task body for {username} in #{getattr(message.channel, 'name', '?')}", flush=True)
+            user_task_text = enriched
+            quoted_task = shlex.quote(user_task_text)
+        else:
+            try:
+                already_escalated = await _silent_escalate_for_discord_state(message, user_task_text)
+            except Exception as e:
+                # Per MacBook's #639 v4 review: fail-SILENT on unknown error in
+                # the escalate path. The previous fail-open default
+                # (already_escalated=False → run codex publicly) meant a broken
+                # escalation infra would leak the cold "Sandbox unavailable"
+                # string into public channels, which is exactly what msze_'s
+                # original directive said to avoid. Fail-silent matches the
+                # "don't surface internal errors publicly" intent.
+                print(f"  [discord-state-escalate] outer guard caught: {e}; fail-silent (NO-REPLY archive)", flush=True)
+                already_escalated = True
 
     # When the bridge has already silently escalated, the agent has nothing to
     # do — skip the task-file write entirely. Otherwise the task would land in

--- a/tests/discord-bridge-state-prefetch.test.py
+++ b/tests/discord-bridge-state-prefetch.test.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""
+Tests for the Discord-state-reference pre-fetch path in `discord-bridge.py`.
+
+Per Chi's 2026-05-08 strategy chat (option 3 systemic fix): when a non-owner
+task body references Discord-side state via `<#channel_id>`, the bridge
+attempts to fetch the referenced channel's recent messages via the bot's REST
+client and PREPEND them to the task body BEFORE falling through to the
+PR #639 silent-escalate path. The agent then has the data inline and can
+answer normally without codex sandbox needing API access.
+
+Cases:
+  Pure pre-fetch — `_prefetch_discord_state_refs`:
+    a) ref + readable channel with messages → prepend formatted block
+    b) ref + history() raises Forbidden → returns None (caller falls through)
+    c) ref + channel not found (None from get_channel + fetch_channel) → None
+    d) ref + wrong channel type (voice/category) → None
+    e) multiple refs → all prepended in source-order
+    f) duplicate refs in same body → fetched once, prepended once
+    g) empty channel (history() yields nothing) → empty marker; not added
+    h) cache hit within TTL → second call doesn't re-fetch
+    i) no refs → returns None (caller proceeds normally without prepend)
+    j) unexpected exception inside fetch → silent fail, returns None
+
+Run: python3 tests/discord-bridge-state-prefetch.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import asyncio
+import importlib.util
+import sys
+import time
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module — same pattern as discord-state-detection test.
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *a, **kw):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+        self._channels = {}
+    def event(self, fn): return fn
+    def get_channel(self, cid): return self._channels.get(cid)
+    async def fetch_channel(self, cid):
+        ch = self._channels.get(cid)
+        if ch is None:
+            raise _NotFound("channel not found")
+        return ch
+
+
+class _AllowedMentions:
+    def __init__(self, *a, **kw): pass
+
+
+class _DMChannel: pass
+
+
+class _DiscordException(Exception): pass
+class _HTTPException(_DiscordException): pass
+class _NotFound(_HTTPException): pass
+class _Forbidden(_HTTPException): pass
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.AllowedMentions = _AllowedMentions
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.DiscordException = _DiscordException
+_discord_stub.HTTPException = _HTTPException
+_discord_stub.NotFound = _NotFound
+_discord_stub.Forbidden = _Forbidden
+_discord_stub.ChannelType = types.SimpleNamespace(
+    text="text",
+    public_thread="public_thread",
+    private_thread="private_thread",
+    news_thread="news_thread",
+    news="news",
+    voice="voice",
+    category="category",
+    forum="forum",
+)
+_discord_stub.File = lambda *a, **kw: None
+_discord_stub.DMChannel = _DMChannel
+
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# ---------------------------------------------------------------------------
+# Mocks
+# ---------------------------------------------------------------------------
+
+class _MockMessage:
+    """Minimal Discord Message mock for history() iteration."""
+    def __init__(self, mid, author_name, content, created_at):
+        self.id = mid
+        self.author = types.SimpleNamespace(name=author_name)
+        self.content = content
+        self.created_at = created_at
+
+
+class _MockHistoryIterator:
+    """Async iterator mimicking discord.py's HistoryIterator."""
+    def __init__(self, messages, raise_exc=None):
+        self._messages = list(messages)
+        self._raise = raise_exc
+        self._idx = 0
+    def __aiter__(self): return self
+    async def __anext__(self):
+        if self._raise is not None:
+            raise self._raise
+        if self._idx >= len(self._messages):
+            raise StopAsyncIteration
+        m = self._messages[self._idx]
+        self._idx += 1
+        return m
+
+
+class _MockChannel:
+    def __init__(self, channel_id, name="ch", ch_type="text", messages=None, history_raises=None):
+        self.id = channel_id
+        self.name = name
+        self.type = ch_type
+        self._messages = messages or []
+        self._history_raises = history_raises
+        self.history_call_count = 0
+    def history(self, limit=5):
+        self.history_call_count += 1
+        return _MockHistoryIterator(self._messages[:limit], raise_exc=self._history_raises)
+
+
+def _install_mock_client(mock_channels_by_id):
+    c = _Client()
+    c._channels = mock_channels_by_id
+    bridge.client = c
+
+
+def _clear_cache():
+    if hasattr(bridge, "_PREFETCH_CACHE"):
+        bridge._PREFETCH_CACHE.clear()
+
+
+def _now_dt():
+    """Return a datetime for mock-message timestamps."""
+    import datetime
+    return datetime.datetime(2026, 5, 9, 8, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+def case_a_ref_with_perms_prepends():
+    """Channel readable + messages → enriched body has channel block + original."""
+    fails = []
+    _clear_cache()
+    msgs = [
+        _MockMessage("1", "snoopz_loc", "self-promo content", _now_dt()),
+        _MockMessage("2", "elcapitan__", "hackathon post", _now_dt()),
+    ]
+    ch = _MockChannel(1153072414184452241, "general", "text", msgs)
+    _install_mock_client({1153072414184452241: ch})
+    body = "classify the latest message in <#1153072414184452241>"
+    enriched = asyncio.run(bridge._prefetch_discord_state_refs(body))
+    if enriched is None:
+        fails.append("a) expected enriched body, got None")
+        return fails
+    if "Channel <#1153072414184452241> recent messages" not in enriched:
+        fails.append("a) enriched should contain channel block header")
+    if "snoopz_loc" not in enriched or "self-promo content" not in enriched:
+        fails.append("a) enriched should include fetched message content + author")
+    if "[Original task body:]" not in enriched:
+        fails.append("a) enriched should include separator before original")
+    if body not in enriched:
+        fails.append("a) enriched should preserve original body")
+    return fails
+
+
+def case_b_history_forbidden_falls_through():
+    """history() raises Forbidden → returns None (caller silent-escalates)."""
+    fails = []
+    _clear_cache()
+    ch = _MockChannel(1153072414184452241, "general", "text", history_raises=_Forbidden("no access"))
+    _install_mock_client({1153072414184452241: ch})
+    enriched = asyncio.run(bridge._prefetch_discord_state_refs("classify <#1153072414184452241>"))
+    if enriched is not None:
+        fails.append(f"b) Forbidden should return None, got {type(enriched).__name__}")
+    return fails
+
+
+def case_c_channel_not_found_falls_through():
+    """get_channel + fetch_channel both fail → returns None."""
+    fails = []
+    _clear_cache()
+    _install_mock_client({})  # empty: get_channel returns None, fetch_channel raises NotFound
+    enriched = asyncio.run(bridge._prefetch_discord_state_refs("classify <#9999999999>"))
+    if enriched is not None:
+        fails.append(f"c) channel-not-found should return None, got {type(enriched).__name__}")
+    return fails
+
+
+def case_d_wrong_channel_type_falls_through():
+    """Voice/category channel type → returns None."""
+    fails = []
+    _clear_cache()
+    ch = _MockChannel(1234, "voice-room", "voice", [])
+    _install_mock_client({1234: ch})
+    enriched = asyncio.run(bridge._prefetch_discord_state_refs("classify <#1234>"))
+    if enriched is not None:
+        fails.append(f"d) voice channel should return None, got {type(enriched).__name__}")
+    return fails
+
+
+def case_e_multiple_refs_all_prepended_in_order():
+    """Two refs in body → both fetched, both prepended in source-order."""
+    fails = []
+    _clear_cache()
+    ch1 = _MockChannel(111, "ch-one", "text", [_MockMessage("a", "u1", "msg from ch1", _now_dt())])
+    ch2 = _MockChannel(222, "ch-two", "text", [_MockMessage("b", "u2", "msg from ch2", _now_dt())])
+    _install_mock_client({111: ch1, 222: ch2})
+    body = "compare <#111> with <#222>"
+    enriched = asyncio.run(bridge._prefetch_discord_state_refs(body))
+    if enriched is None:
+        fails.append("e) expected enriched body, got None")
+        return fails
+    pos1 = enriched.find("Channel <#111>")
+    pos2 = enriched.find("Channel <#222>")
+    if pos1 == -1 or pos2 == -1:
+        fails.append(f"e) both channel blocks expected; pos1={pos1} pos2={pos2}")
+    elif pos1 >= pos2:
+        fails.append(f"e) source-order expected: <#111> before <#222>; pos1={pos1} pos2={pos2}")
+    return fails
+
+
+def case_f_duplicate_refs_dedup():
+    """Same ref twice in body → channel fetched once, block appears once."""
+    fails = []
+    _clear_cache()
+    ch = _MockChannel(555, "ch", "text", [_MockMessage("a", "u1", "msg", _now_dt())])
+    _install_mock_client({555: ch})
+    body = "first look at <#555>, then re-check <#555>"
+    enriched = asyncio.run(bridge._prefetch_discord_state_refs(body))
+    if enriched is None:
+        fails.append("f) expected enriched body, got None")
+        return fails
+    occurrences = enriched.count("Channel <#555> recent messages")
+    if occurrences != 1:
+        fails.append(f"f) expected 1 channel block, got {occurrences}")
+    if ch.history_call_count > 1:
+        fails.append(f"f) duplicate refs should fetch once; got {ch.history_call_count} calls")
+    return fails
+
+
+def case_g_empty_channel_no_block():
+    """Channel readable but no messages → empty-string marker; no block emitted."""
+    fails = []
+    _clear_cache()
+    ch = _MockChannel(666, "empty", "text", messages=[])
+    _install_mock_client({666: ch})
+    enriched = asyncio.run(bridge._prefetch_discord_state_refs("look at <#666>"))
+    # Empty channel returns "" from _fetch_..., which is falsy in
+    # _prefetch loop's `if not formatted` test → block not added → no usable
+    # blocks → overall returns None.
+    if enriched is not None:
+        fails.append(f"g) empty channel should yield None overall (no usable blocks); got enriched")
+    return fails
+
+
+def case_h_cache_hit_skips_refetch():
+    """Same ref fetched twice within TTL → second call is cache hit."""
+    fails = []
+    _clear_cache()
+    ch = _MockChannel(777, "ch", "text", [_MockMessage("a", "u1", "msg", _now_dt())])
+    _install_mock_client({777: ch})
+    asyncio.run(bridge._prefetch_discord_state_refs("read <#777>"))
+    first_count = ch.history_call_count
+    if first_count != 1:
+        fails.append(f"h) expected 1 fetch on first call, got {first_count}")
+    asyncio.run(bridge._prefetch_discord_state_refs("re-read <#777>"))
+    if ch.history_call_count != first_count:
+        fails.append(f"h) cache hit expected; got {ch.history_call_count} fetches (first was {first_count})")
+    return fails
+
+
+def case_i_no_refs_returns_none():
+    """Body with no `<#...>` → returns None (caller proceeds without enrichment)."""
+    fails = []
+    _clear_cache()
+    _install_mock_client({})
+    enriched = asyncio.run(bridge._prefetch_discord_state_refs("just a plain question, no refs"))
+    if enriched is not None:
+        fails.append(f"i) no-refs body should return None, got {type(enriched).__name__}")
+    enriched_empty = asyncio.run(bridge._prefetch_discord_state_refs(""))
+    if enriched_empty is not None:
+        fails.append(f"i2) empty body should return None")
+    enriched_none = asyncio.run(bridge._prefetch_discord_state_refs(None))
+    if enriched_none is not None:
+        fails.append(f"i3) None body should return None")
+    return fails
+
+
+def case_j_unexpected_exception_silent_fail():
+    """Any unexpected exception in the fetch path → silent fail, returns None."""
+    fails = []
+    _clear_cache()
+    ch = _MockChannel(888, "ch", "text", history_raises=RuntimeError("internal error"))
+    _install_mock_client({888: ch})
+    # Should not raise — should fail silently and return None
+    try:
+        enriched = asyncio.run(bridge._prefetch_discord_state_refs("read <#888>"))
+    except Exception as e:
+        fails.append(f"j) unexpected exception leaked out of prefetch: {type(e).__name__}: {e}")
+        return fails
+    if enriched is not None:
+        fails.append(f"j) unexpected exception should return None, got enriched body")
+    return fails
+
+
+def main():
+    cases = [
+        ("a-ref-with-perms-prepends", case_a_ref_with_perms_prepends),
+        ("b-history-forbidden-falls-through", case_b_history_forbidden_falls_through),
+        ("c-channel-not-found-falls-through", case_c_channel_not_found_falls_through),
+        ("d-wrong-channel-type-falls-through", case_d_wrong_channel_type_falls_through),
+        ("e-multiple-refs-source-order", case_e_multiple_refs_all_prepended_in_order),
+        ("f-duplicate-refs-dedup", case_f_duplicate_refs_dedup),
+        ("g-empty-channel-no-block", case_g_empty_channel_no_block),
+        ("h-cache-hit-skips-refetch", case_h_cache_hit_skips_refetch),
+        ("i-no-refs-returns-none", case_i_no_refs_returns_none),
+        ("j-unexpected-exception-silent-fail", case_j_unexpected_exception_silent_fail),
+    ]
+    failures = []
+    for label, fn in cases:
+        fs = fn()
+        if fs:
+            failures.extend([(label, m) for m in fs])
+            print(f"  ✗ case {label}")
+            for f in fs:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll Discord-state pre-fetch invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/discord-bridge-state-prefetch.test.py
+++ b/tests/discord-bridge-state-prefetch.test.py
@@ -282,18 +282,22 @@ def case_f_duplicate_refs_dedup():
     return fails
 
 
-def case_g_empty_channel_no_block():
-    """Channel readable but no messages → empty-string marker; no block emitted."""
+def case_g_empty_channel_renders_marker():
+    """Channel readable but no messages → empty-string from fetch; rendered as
+    `[no recent messages]` block in enriched body. Empty IS a real answer
+    (per PR #644 v2 review fix #2 — distinguish empty from failed fetch)."""
     fails = []
     _clear_cache()
     ch = _MockChannel(666, "empty", "text", messages=[])
     _install_mock_client({666: ch})
     enriched = asyncio.run(bridge._prefetch_discord_state_refs("look at <#666>"))
-    # Empty channel returns "" from _fetch_..., which is falsy in
-    # _prefetch loop's `if not formatted` test → block not added → no usable
-    # blocks → overall returns None.
-    if enriched is not None:
-        fails.append(f"g) empty channel should yield None overall (no usable blocks); got enriched")
+    if enriched is None:
+        fails.append("g) empty channel should yield enriched body with 'no recent messages' marker; got None")
+        return fails
+    if "no recent messages" not in enriched:
+        fails.append(f"g) enriched body should contain 'no recent messages' marker; got: {enriched[:200]!r}")
+    if "Channel <#666>" not in enriched:
+        fails.append(f"g) enriched body should reference <#666>; got: {enriched[:200]!r}")
     return fails
 
 
@@ -347,6 +351,67 @@ def case_j_unexpected_exception_silent_fail():
     return fails
 
 
+def case_k_partial_failure_fails_whole_prefetch():
+    """v2 fix #1: multi-ref task where one ref succeeds and one fails should
+    fail the whole prefetch (return None), not return partial context. Lets
+    silent-escalate handle the whole task instead of letting the agent see
+    only half the references and answer confidently-wrong."""
+    fails = []
+    _clear_cache()
+    good = _MockChannel(111, "good", "text", [_MockMessage("a", "u1", "msg from good", _now_dt())])
+    bad = _MockChannel(222, "bad", "text", history_raises=_Forbidden("no access"))
+    _install_mock_client({111: good, 222: bad})
+    body = "compare <#111> with <#222>"
+    enriched = asyncio.run(bridge._prefetch_discord_state_refs(body))
+    if enriched is not None:
+        fails.append("k) one-ref-fails should fail whole prefetch (return None); got partial enriched body")
+        if "Channel <#111>" in (enriched or "") and "Channel <#222>" not in (enriched or ""):
+            fails.append("k)   ...and partial body contains good ref but not bad — exactly the wrong-answer pattern PR #644 v2 prevents")
+    return fails
+
+
+def case_l_history_timeout_returns_none():
+    """v2 fix #3: a history() call that hangs longer than the per-ref timeout
+    should be treated as a failed fetch. Simulated by patching
+    _PREFETCH_PER_REF_TIMEOUT_S to a small value and an async history that
+    sleeps longer."""
+    fails = []
+    _clear_cache()
+    import asyncio as _asyncio
+
+    class _SlowHistory:
+        def __init__(self, delay_s):
+            self._delay = delay_s
+        def __aiter__(self): return self
+        async def __anext__(self):
+            await _asyncio.sleep(self._delay)
+            raise StopAsyncIteration
+
+    class _SlowChannel:
+        def __init__(self, channel_id, delay_s):
+            self.id = channel_id
+            self.type = "text"
+            self.name = "slow"
+            self._delay = delay_s
+            self.history_call_count = 0
+        def history(self, limit=5):
+            self.history_call_count += 1
+            return _SlowHistory(self._delay)
+
+    # Bridge will use whatever _PREFETCH_PER_REF_TIMEOUT_S is at call time.
+    original_timeout = bridge._PREFETCH_PER_REF_TIMEOUT_S
+    try:
+        bridge._PREFETCH_PER_REF_TIMEOUT_S = 0.05  # 50ms
+        slow = _SlowChannel(999, delay_s=0.5)  # 500ms — well over the timeout
+        _install_mock_client({999: slow})
+        enriched = asyncio.run(bridge._prefetch_discord_state_refs("read <#999>"))
+        if enriched is not None:
+            fails.append("l) history timeout should fail prefetch (return None); got enriched body")
+    finally:
+        bridge._PREFETCH_PER_REF_TIMEOUT_S = original_timeout
+    return fails
+
+
 def main():
     cases = [
         ("a-ref-with-perms-prepends", case_a_ref_with_perms_prepends),
@@ -355,10 +420,12 @@ def main():
         ("d-wrong-channel-type-falls-through", case_d_wrong_channel_type_falls_through),
         ("e-multiple-refs-source-order", case_e_multiple_refs_all_prepended_in_order),
         ("f-duplicate-refs-dedup", case_f_duplicate_refs_dedup),
-        ("g-empty-channel-no-block", case_g_empty_channel_no_block),
+        ("g-empty-channel-renders-marker", case_g_empty_channel_renders_marker),
         ("h-cache-hit-skips-refetch", case_h_cache_hit_skips_refetch),
         ("i-no-refs-returns-none", case_i_no_refs_returns_none),
         ("j-unexpected-exception-silent-fail", case_j_unexpected_exception_silent_fail),
+        ("k-partial-failure-fails-whole-prefetch", case_k_partial_failure_fails_whole_prefetch),
+        ("l-history-timeout-returns-none", case_l_history_timeout_returns_none),
     ]
     failures = []
     for label, fn in cases:


### PR DESCRIPTION
## Summary

- For non-owner tasks (`team` / `other` tier) whose body contains `<#channel-id>` references, the bridge now fetches the last 5 messages from each channel and prepends formatted excerpts to the task body **before** writing to disk.
- This is the systemic fix for the codex-sandbox-can't-read-Discord pathology: cross-channel questions like *"can you summarize what's been said in <#1153072414184452241>"* used to silent-escalate (Tier 2) because codex has no Discord token. Now the bot account (which IS in the referenced server) fetches them once at task-write time, and codex sees them inline.
- PR #639's silent-escalate stays as Tier 2 fallback for `Forbidden` / `NotFound` / unexpected exceptions.

## Implementation

Two new helpers in `src/discord-bridge.py`:

- `_fetch_discord_channel_messages(channel_id, n=5)` — async, returns formatted excerpt block or `None` on failure. Filters non-text channel types (voice/category) up front. In-process cache keyed by `(channel_id, time.time() // 60)` with 60s TTL and light-touch GC at 200 entries.
- `_prefetch_discord_state_refs(user_task_text)` — extracts refs via existing `_extract_referenced_channels`, dedups while preserving source order, fetches each, and returns enriched body or `None` if nothing usable.

Wired into the task-write block: runs **first** for non-owner tier; if it returns `None` we fall through to the existing silent-escalate path.

Limits: 5 messages per ref, 280-char excerpt each, ~5 refs ≈ ≤7KB worst-case enrichment. Cache hits avoid refetching during burst traffic (e.g. parallel Sutando instances replying to the same `<#x>` reference).

## Test plan

- [x] `python3 tests/discord-bridge-state-prefetch.test.py` — 10 cases (a-j): success, `Forbidden`, `NotFound`, wrong channel type, multi-ref, dedup, empty channel, cache hit, no refs, unexpected exception
- [x] Full bridge test suite: all 14 `tests/discord-bridge-*.test.py` files green, no regressions
- [ ] Post-merge: verify enrichment in production by sending a non-owner test task referencing a channel the bot is in; confirm task body contains the prepended `[Channel <#x> recent messages: ... ]` block before the codex invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)