### PR TITLE
feat(phone-server): add /twilio/sms webhook for inbound SMS

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -1405,6 +1405,16 @@ const server = createServer(async (req, res) => {
   </Connect>
 </Response>`);
 
+		} else if (path === '/twilio/sms' && req.method === 'POST') {
+			const form = new URLSearchParams(await readBody(req));
+			const sender = form.get('From') ?? 'unknown';
+			const body = form.get('Body') ?? '';
+			console.log(`${ts()} [SMS] from=${sender} body=${body.slice(0, 80)}`);
+			const taskId = `task-${Date.now()}`;
+			const taskContent = `id: ${taskId}\ntimestamp: ${new Date().toISOString()}\ntask: SMS from ${sender}: ${body}\nsource: twilio_sms\nfrom: ${sender}\n`;
+			writeFileSync(join(WORKSPACE_DIR, 'tasks', `${taskId}.txt`), taskContent);
+			twimlResponse(res, `<?xml version="1.0" encoding="UTF-8"?>\n<Response><Message>Got it. Sutando is on it.</Message></Response>`);
+
 		} else if (path === '/twilio/status' && req.method === 'POST') {
 			const form = new URLSearchParams(await readBody(req));
 			const sid = form.get('CallSid') ?? '';


### PR DESCRIPTION
## What

Adds a `/twilio/sms` POST handler to `skills/phone-conversation/scripts/conversation-server.ts` that mirrors the existing handler in `src/agent-api.py`.

## Why

The Twilio free plan + ngrok free tier give us one publicly-reachable webhook. Voice already uses it (port 3100 → conversation-server). For SMS we'd otherwise need a second tunnel for `agent-api` (port 7843).

This change collapses voice + SMS onto the same tunnel — same Twilio number can receive calls and texts with one ngrok URL.

## Behavior

- Parses `From` and `Body` from the urlencoded Twilio POST
- Writes `tasks/task-{ts}.txt` with `source: twilio_sms`
- Replies with TwiML `<Message>Got it. Sutando is on it.</Message>`

Identical task shape to `/twilio/sms` in `agent-api.py`, so the proactive-loop's existing handling works unchanged.

## Test

```bash
curl -s -X POST http://localhost:3100/twilio/sms \
  -d "From=%2B16505551234&Body=hello"
# → <?xml…><Response><Message>Got it. Sutando is on it.</Message></Response>
# → tasks/task-{ts}.txt written
```

## Setup (after merge)

In Twilio Console → Phone Numbers → \`+1XXXXX\` → Messaging Configuration:
- "A message comes in" → Webhook → POST → \`https://<your-tunnel>/twilio/sms\`