### PR TITLE
feat(subscription-scanner): /paidsubscriptions dashboard + monthly scan skill

### DIFF
--- a/skills/subscription-scanner/.gitignore
+++ b/skills/subscription-scanner/.gitignore
@@ -1,0 +1,2 @@
+# Personal financial data — never commit.
+state/

--- a/skills/subscription-scanner/SKILL.md
+++ b/skills/subscription-scanner/SKILL.md
@@ -14,7 +14,7 @@ The scan is **agent-driven**, not script-driven, because Gmail access lives in t
 
 ## Files
 
-- `scan-prompt.md` — the prompt text the agent runs to perform a scan. Updates here propagate via the cron config.
+- `scan-prompt.md` — the prompt text the agent runs to perform a scan. Updates here propagate via the cron config. **Personalize this file before first use** — the third Gmail-query line names specific senders tied to one user's actual subscriptions (Apple, Spotify, Anthropic, OpenAI, Netflix, Adobe, GitHub, 1Password, NYT, WSJ, Disney+, Hulu, Tesla insurance, Xfinity, …). Edit the `from:` list to match your subscriptions, or the scan will miss vendors not on the default list.
 - `state/subscriptions.json` — current list (gitignored — contains personal financial data)
 - `state/history/<YYYY-MM-DD>.json` — snapshots, for diff (also gitignored)
 

--- a/skills/subscription-scanner/SKILL.md
+++ b/skills/subscription-scanner/SKILL.md
@@ -1,0 +1,64 @@
+# Subscription Scanner
+
+Scans Gmail for active paid subscriptions and tracks them over time. Surfaces additions / cancellations between scans.
+
+## Usage
+
+The scan is **agent-driven**, not script-driven, because Gmail access lives in the Claude Code MCP layer (not in Python). The proactive-loop or owner-on-demand fires the scan via:
+
+```
+/scan-subscriptions
+```
+
+…or the cron job below invokes the agent with the `scan-prompt.md` body verbatim.
+
+## Files
+
+- `scan-prompt.md` — the prompt text the agent runs to perform a scan. Updates here propagate via the cron config.
+- `state/subscriptions.json` — current list (gitignored — contains personal financial data)
+- `state/history/<YYYY-MM-DD>.json` — snapshots, for diff (also gitignored)
+
+## State schema
+
+```json
+{
+  "last_scan": "ISO8601 timestamp",
+  "subscriptions": [
+    {
+      "vendor": "Apple iCloud+ 2TB",
+      "category": "Storage|Streaming|Connectivity|Insurance|Software|Membership|Other",
+      "amount": 9.99,
+      "currency": "USD",
+      "frequency": "monthly|annual|other",
+      "account": "a.kunte@gmail.com or family member name",
+      "last_charged": "YYYY-MM-DD",
+      "next_charge": "YYYY-MM-DD or null",
+      "status": "active|cancelled|uncertain",
+      "source_sender": "email From: address that established this",
+      "notes": "free-form caveats / corrections"
+    }
+  ],
+  "scan_history": [
+    {
+      "date": "ISO8601",
+      "active_count": <int>,
+      "added": ["vendor names"],
+      "removed": ["vendor names"],
+      "amount_changed": [{"vendor": "...", "from": <num>, "to": <num>}]
+    }
+  ]
+}
+```
+
+## How `/paidsubscriptions` reads this
+
+`web-client.ts` route at `/paidsubscriptions`:
+1. Reads `skills/subscription-scanner/state/subscriptions.json`
+2. Renders a sortable table with vendor, amount, frequency, account, status, last/next charge
+3. Highlights diffs from the previous snapshot (`scan_history[-1].added` in green, `removed` in strikethrough red)
+4. Shows last-scan timestamp at the top
+5. Provides a "Scan now" button that POSTs to `/paidsubscriptions/scan` — that endpoint writes a task file to `tasks/` triggering an out-of-cycle scan in the next loop pass
+
+## Cron
+
+Monthly: 1st of every month at 08:13 (off-peak minute) — see `skills/schedule-crons/crons.json` entry `subscription-scan`.

--- a/skills/subscription-scanner/SKILL.md
+++ b/skills/subscription-scanner/SKILL.md
@@ -62,3 +62,15 @@ The scan is **agent-driven**, not script-driven, because Gmail access lives in t
 ## Cron
 
 Monthly: 1st of every month at 08:13 (off-peak minute) — see `skills/schedule-crons/crons.json` entry `subscription-scan`.
+
+`crons.json` is gitignored (per-user), so the entry isn't in this repo. Add it manually after cloning:
+
+```json
+{
+  "name": "subscription-scan",
+  "cron": "13 8 1 * *",
+  "prompt": "Run the monthly paid-subscription scan. Read the full instructions in skills/subscription-scanner/scan-prompt.md and follow them verbatim. Update skills/subscription-scanner/state/subscriptions.json with the latest list, snapshot the previous version to state/history/, and write a proactive Telegram notification to results/proactive-{ts}.txt only if subscriptions were added, removed, or had price changes since the previous scan. Stay silent if nothing changed."
+}
+```
+
+The cron expression `13 8 1 * *` fires at 08:13 on the 1st of every month. Bump to `*/10 * * * *` during development to trigger every 10 min.

--- a/skills/subscription-scanner/scan-prompt.md
+++ b/skills/subscription-scanner/scan-prompt.md
@@ -1,0 +1,51 @@
+# Subscription scan — prompt body
+
+Scan the user's Gmail for active paid subscriptions and update `skills/subscription-scanner/state/subscriptions.json`. Then snapshot to `state/history/<YYYY-MM-DD>.json` and update `scan_history` in the main file with the diff (added/removed/amount-changed) vs the previous scan.
+
+## What to search
+
+Use these Gmail queries:
+1. `subject:(subscription OR renewal OR "auto-renewed" OR "automatic renewal" OR "your subscription" OR "your monthly" OR "your annual" OR "renewed your") newer_than:90d`
+2. `subject:(receipt OR "your invoice" OR "payment confirmation" OR "thanks for your payment" OR "thank you for your payment") newer_than:90d`
+3. `from:(no_reply@email.apple.com OR no-reply@spotify.com OR billing@anthropic.com OR invoice+statements@mail.anthropic.com OR billing@openai.com OR no-reply@netflix.com OR mail@adobe.com OR billing@github.com OR no-reply@dropbox.com OR billing@notion.so OR no-reply@youtube.com OR billing@1password.com OR billing@nytimes.com OR billing@wsj.com OR no-reply@disneyplus.com OR no-reply@hulumail.com OR googleplay-noreply@google.com OR googlestore-noreply@google.com OR payments-noreply@google.com OR xfinity@account.xfinity.com OR noreply@teslainsuranceservices.com) newer_than:120d`
+
+For each receipt found, read the message body if needed via `get_thread` to extract: vendor, amount, frequency, last charge date, next charge date.
+
+## What counts as a "paid subscription"
+
+**Include:**
+- Recurring charges (monthly / annual / other cadence) for a service
+- Family-account subscriptions billed to the user's card (iCloud+ for spouse / kids, Apple TV / Apple News+, etc.)
+- Connectivity (cell/internet)
+- Insurance (auto, home — recurring premiums)
+- Streaming (Netflix, Spotify, Apple TV+, Disney+, etc.)
+- News/publication (NYT, WSJ, Substack paid tiers)
+- Software (Adobe, GitHub, 1Password, Notion, etc.)
+- AI services (Anthropic Claude, OpenAI, Google AI Premium)
+- Memberships with recurring dues (Costco, AAA — **only if** there's a renewal receipt)
+
+**Exclude:**
+- One-time purchases (single Costco order, Amazon books, Apple Books)
+- Bills that are not subscriptions (utilities like electricity / water service if metered, medical bills, government fees, HOA dues are borderline — include if monthly/quarterly recurring)
+- Newsletters / promo emails (NYT marketing, Substack free posts)
+- Brokerage statements (Wealthfront, Schwab) — informational, not subscriptions
+- Credit-card statements / renewal cards
+- Newsletters / "your monthly summary" that are free (RideWithGPS recap, Wholefoods receipts)
+- Per-flight billing from flight clubs (treat as service usage, not subscription)
+
+## Format
+
+Update `state/subscriptions.json` with the schema in `SKILL.md`. Always:
+1. Preserve the `id` field if a subscription was previously known (match by vendor + account)
+2. Compute the diff vs the previous scan: new vendors → `added`, missing/cancelled → `removed`, different amount → `amount_changed`
+3. Set `last_scan` to the current ISO8601 timestamp (with timezone)
+4. Append a `scan_history` entry
+5. Snapshot the previous `subscriptions.json` to `state/history/<previous-scan-date>.json` (only if it doesn't already exist)
+
+## Ambiguous cases
+
+If you can't tell whether something is a real subscription (e.g. unclear if it's recurring, or you can only see promo not receipt), set `status: "uncertain"` and add a note explaining what to verify.
+
+## Notify on changes
+
+If the scan finds anything `added` or `removed` since the previous run, write a `proactive-{ts}.txt` to `results/` with a brief summary (not the full table — just "+1 added: X. -1 removed: Y") so the change is surfaced via Telegram.

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -2839,6 +2839,298 @@ setInterval(() => {
 	}
 }, 30_000);
 
+// /paidsubscriptions page — full HTML, server-side rendered from
+// skills/subscription-scanner/state/subscriptions.json. Sortable table,
+// diff highlights from last scan, "Scan now" button.
+function renderSubscriptionsHtml(rawJson: string): string {
+	let data: any;
+	try { data = JSON.parse(rawJson); } catch (e: any) { data = { last_scan: null, subscriptions: [], scan_history: [], _parse_error: e?.message }; }
+	const lastScan = data.last_scan ? new Date(data.last_scan).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' }) : '— never scanned —';
+	const lastDiff = (data.scan_history && data.scan_history.length) ? data.scan_history[data.scan_history.length - 1] : { added: [], removed: [], amount_changed: [] };
+	const dataJson = JSON.stringify(data).replace(/</g, '\\u003c');
+
+	return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Paid Subscriptions — Sutando</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif; background: #0e0e14; color: #e8e8ee; padding: 24px; min-height: 100vh; }
+  .wrap { max-width: 1200px; margin: 0 auto; }
+  header { display: flex; align-items: center; gap: 16px; margin-bottom: 8px; flex-wrap: wrap; }
+  h1 { font-size: 22px; font-weight: 700; }
+  .subtitle { color: #707080; font-size: 13px; }
+  .meta { display: flex; gap: 20px; font-size: 13px; color: #888; margin: 12px 0 20px; flex-wrap: wrap; align-items: center; }
+  .meta strong { color: #c0c0d0; font-weight: 600; }
+  .scan-btn { background: #1e4028; color: #4ecca3; border: 1px solid #2a4a36; padding: 8px 16px; border-radius: 8px; font-size: 13px; font-weight: 600; cursor: pointer; font-family: inherit; }
+  .scan-btn:hover:not(:disabled) { background: #2a503a; }
+  .scan-btn:disabled { background: #1a1a2a; color: #444; border-color: #2a2a3e; cursor: wait; }
+  .scan-status { font-size: 12px; color: #4ecca3; margin-left: 8px; }
+  .summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-bottom: 24px; }
+  .stat { background: #14141e; border: 1px solid #1e1e2a; border-radius: 10px; padding: 14px 16px; }
+  .stat .label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.6px; color: #707080; margin-bottom: 6px; }
+  .stat .value { font-size: 24px; font-weight: 700; color: #e8e8ee; }
+  .stat .sub { font-size: 11px; color: #888; margin-top: 4px; }
+  .stat.added .value { color: #4ecca3; }
+  .stat.removed .value { color: #e94560; }
+  .stat.uncertain .value { color: #f0ad4e; }
+
+  table { width: 100%; border-collapse: collapse; background: #14141e; border-radius: 10px; overflow: hidden; }
+  th, td { text-align: left; padding: 10px 14px; border-bottom: 1px solid #1e1e2a; font-size: 13px; }
+  th { background: #1a1a26; color: #a0a0b0; font-weight: 600; text-transform: uppercase; font-size: 11px; letter-spacing: 0.5px; cursor: pointer; user-select: none; position: relative; }
+  th:hover { color: #e8e8ee; }
+  th.sort-asc::after { content: ' ▲'; color: #4ecca3; }
+  th.sort-desc::after { content: ' ▼'; color: #4ecca3; }
+  tbody tr:hover { background: #181826; }
+  td.amount { text-align: right; font-variant-numeric: tabular-nums; }
+  td.amount .currency { color: #707080; font-size: 11px; margin-left: 2px; }
+
+  .status { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+  .status.active { background: #1e4028; color: #4ecca3; }
+  .status.cancelled { background: #2a1a20; color: #e94560; }
+  .status.uncertain { background: #2a2418; color: #f0ad4e; }
+
+  .vendor { color: #e8e8ee; font-weight: 600; }
+  .account { color: #888; font-size: 12px; }
+  .notes { color: #707080; font-size: 11px; font-style: italic; max-width: 320px; }
+  .freq { color: #a0a0b0; font-size: 12px; }
+
+  .row-added { background: rgba(78, 204, 163, 0.08); }
+  .row-cancelled { opacity: 0.55; }
+  .row-cancelled td { text-decoration: line-through; text-decoration-color: #e94560; }
+  .row-cancelled .vendor { color: #e94560; text-decoration-color: #e94560; }
+
+  .empty { text-align: center; padding: 40px; color: #555; }
+  footer { margin-top: 32px; color: #555; font-size: 11px; text-align: center; }
+  footer a { color: #888; text-decoration: none; }
+  footer a:hover { color: #4ecca3; }
+
+  details { margin-top: 24px; }
+  details summary { cursor: pointer; color: #707080; font-size: 12px; padding: 8px 0; }
+  details summary:hover { color: #a0a0b0; }
+  pre { background: #0a0a12; padding: 14px; border-radius: 8px; overflow-x: auto; font-size: 11px; color: #a0a0b0; margin-top: 8px; max-height: 300px; }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>💳 Paid Subscriptions</h1>
+      <div class="subtitle">Scanned from Gmail receipts</div>
+      <div style="margin-left:auto"><a href="/" style="color:#707080;font-size:12px;text-decoration:none;border:1px solid #2a2a3e;padding:5px 12px;border-radius:6px;">← Dashboard</a></div>
+    </header>
+
+    <div class="meta">
+      <span><strong>Last scan:</strong> ${escapeHtml(lastScan)}</span>
+      <button class="scan-btn" id="scanBtn" onclick="triggerScan()">⟳ Scan now</button>
+      <span class="scan-status" id="scanStatus"></span>
+    </div>
+
+    <div id="summary" class="summary"></div>
+
+    <div id="diff-banner"></div>
+
+    <table id="subs-table">
+      <thead>
+        <tr>
+          <th data-key="vendor">Vendor</th>
+          <th data-key="amount" class="amount">Amount</th>
+          <th data-key="frequency">Frequency</th>
+          <th data-key="account">Account</th>
+          <th data-key="last_charged">Last charged</th>
+          <th data-key="next_charge">Next charge</th>
+          <th data-key="status">Status</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody id="subs-tbody"></tbody>
+    </table>
+
+    <details>
+      <summary>Raw JSON</summary>
+      <pre id="raw-json"></pre>
+    </details>
+
+    <footer>
+      Subscription data lives at <code>skills/subscription-scanner/state/subscriptions.json</code> (gitignored).<br>
+      Auto-scan runs monthly via the <code>subscription-scan</code> cron. Source: Gmail receipts via Claude MCP.
+    </footer>
+  </div>
+
+<script>
+  const data = ${dataJson};
+  const tbody = document.getElementById('subs-tbody');
+  const summary = document.getElementById('summary');
+  const diffBanner = document.getElementById('diff-banner');
+  const rawJson = document.getElementById('raw-json');
+  const lastDiff = (data.scan_history && data.scan_history.length) ? data.scan_history[data.scan_history.length - 1] : { added: [], removed: [], amount_changed: [] };
+
+  let sortKey = 'amount';
+  let sortDir = 'desc';
+
+  function fmtMoney(amount, currency) {
+    if (amount === null || amount === undefined) return '<span style="color:#555">—</span>';
+    const sym = currency === 'EUR' ? '€' : currency === 'GBP' ? '£' : '$';
+    return sym + amount.toFixed(2) + (currency && currency !== 'USD' ? ' <span class="currency">' + currency + '</span>' : '');
+  }
+
+  function fmtDate(d) {
+    if (!d) return '<span style="color:#555">—</span>';
+    return d;
+  }
+
+  function escapeHtmlClient(s) {
+    if (s === null || s === undefined) return '';
+    return String(s).replace(/[<>&"']/g, c => ({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;',"'":'&#39;'}[c]));
+  }
+
+  function monthlyEquivalent(sub) {
+    if (sub.amount === null || sub.amount === undefined) return null;
+    if (sub.frequency === 'monthly') return sub.amount;
+    if (sub.frequency === 'annual') return sub.amount / 12;
+    return sub.amount;
+  }
+
+  function renderSummary() {
+    const subs = data.subscriptions || [];
+    const active = subs.filter(s => s.status === 'active');
+    const uncertain = subs.filter(s => s.status === 'uncertain');
+    const cancelled = subs.filter(s => s.status === 'cancelled');
+
+    let monthlyTotal = 0, monthlyKnown = 0, monthlyUnknown = 0;
+    for (const s of active) {
+      const me = monthlyEquivalent(s);
+      if (me !== null) {
+        const usdRate = s.currency === 'EUR' ? 1.08 : (s.currency === 'GBP' ? 1.27 : 1.0);
+        monthlyTotal += me * usdRate;
+        monthlyKnown++;
+      } else {
+        monthlyUnknown++;
+      }
+    }
+
+    summary.innerHTML = \`
+      <div class="stat"><div class="label">Active</div><div class="value">\${active.length}</div><div class="sub">\${monthlyUnknown ? monthlyUnknown + ' missing price' : 'all priced'}</div></div>
+      <div class="stat"><div class="label">Monthly burn (~)</div><div class="value">$\${monthlyTotal.toFixed(0)}</div><div class="sub">\${monthlyKnown}/\${active.length} priced • \$\${(monthlyTotal*12).toFixed(0)}/yr</div></div>
+      <div class="stat uncertain"><div class="label">Uncertain</div><div class="value">\${uncertain.length}</div><div class="sub">verify these</div></div>
+      <div class="stat removed"><div class="label">Cancelled</div><div class="value">\${cancelled.length}</div><div class="sub">recent cancellations</div></div>
+    \`;
+  }
+
+  function renderDiffBanner() {
+    const a = lastDiff.added || [];
+    const r = lastDiff.removed || [];
+    const c = lastDiff.amount_changed || [];
+    if (a.length === 0 && r.length === 0 && c.length === 0) {
+      diffBanner.innerHTML = '<div style="font-size:12px;color:#555;margin-bottom:14px;">No changes since previous scan.</div>';
+      return;
+    }
+    const parts = [];
+    if (a.length) parts.push('<span style="color:#4ecca3">+' + a.length + ' added: ' + a.map(escapeHtmlClient).join(', ') + '</span>');
+    if (r.length) parts.push('<span style="color:#e94560">−' + r.length + ' removed: ' + r.map(escapeHtmlClient).join(', ') + '</span>');
+    if (c.length) parts.push('<span style="color:#f0ad4e">' + c.length + ' price changed</span>');
+    diffBanner.innerHTML = '<div style="font-size:13px;margin-bottom:14px;padding:10px 14px;background:#181826;border-radius:8px;border-left:3px solid #4ecca3;">Since last scan: ' + parts.join(' • ') + '</div>';
+  }
+
+  function renderTable() {
+    const subs = (data.subscriptions || []).slice();
+    const addedSet = new Set(lastDiff.added || []);
+
+    subs.sort((a, b) => {
+      let av = a[sortKey], bv = b[sortKey];
+      if (sortKey === 'amount') { av = monthlyEquivalent(a) ?? -1; bv = monthlyEquivalent(b) ?? -1; }
+      if (av === null || av === undefined) av = '';
+      if (bv === null || bv === undefined) bv = '';
+      if (typeof av === 'string') av = av.toLowerCase();
+      if (typeof bv === 'string') bv = bv.toLowerCase();
+      if (av < bv) return sortDir === 'asc' ? -1 : 1;
+      if (av > bv) return sortDir === 'asc' ? 1 : -1;
+      return 0;
+    });
+
+    tbody.innerHTML = '';
+    if (subs.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="8" class="empty">No subscriptions found yet. Click "Scan now" to populate.</td></tr>';
+      return;
+    }
+    for (const s of subs) {
+      const tr = document.createElement('tr');
+      const isAdded = addedSet.has(s.vendor);
+      if (s.status === 'cancelled') tr.className = 'row-cancelled';
+      else if (isAdded) tr.className = 'row-added';
+      tr.innerHTML = \`
+        <td><div class="vendor">\${escapeHtmlClient(s.vendor)}</div><div class="account">\${escapeHtmlClient(s.category || '')}</div></td>
+        <td class="amount">\${fmtMoney(s.amount, s.currency)}</td>
+        <td><span class="freq">\${escapeHtmlClient(s.frequency || '')}</span></td>
+        <td><span class="account">\${escapeHtmlClient(s.account || '')}</span></td>
+        <td>\${fmtDate(s.last_charged)}</td>
+        <td>\${fmtDate(s.next_charge)}</td>
+        <td><span class="status \${escapeHtmlClient(s.status || '')}">\${escapeHtmlClient(s.status || '')}</span></td>
+        <td><span class="notes">\${escapeHtmlClient(s.notes || '')}</span></td>
+      \`;
+      tbody.appendChild(tr);
+    }
+    document.querySelectorAll('th[data-key]').forEach(th => {
+      th.classList.remove('sort-asc', 'sort-desc');
+      if (th.dataset.key === sortKey) th.classList.add(sortDir === 'asc' ? 'sort-asc' : 'sort-desc');
+    });
+  }
+
+  document.querySelectorAll('th[data-key]').forEach(th => {
+    th.addEventListener('click', () => {
+      const k = th.dataset.key;
+      if (k === sortKey) sortDir = (sortDir === 'asc' ? 'desc' : 'asc');
+      else { sortKey = k; sortDir = (k === 'vendor' || k === 'frequency' || k === 'status' || k === 'account') ? 'asc' : 'desc'; }
+      renderTable();
+    });
+  });
+
+  async function triggerScan() {
+    const btn = document.getElementById('scanBtn');
+    const status = document.getElementById('scanStatus');
+    btn.disabled = true;
+    status.textContent = '⏳ queueing...';
+    try {
+      const r = await fetch('/paidsubscriptions/scan', { method: 'POST' });
+      const j = await r.json();
+      if (j.ok) {
+        status.textContent = '✓ ' + j.message;
+        // poll for fresh data every 5s for 3 minutes
+        let elapsed = 0;
+        const poll = setInterval(async () => {
+          elapsed += 5;
+          if (elapsed > 180) { clearInterval(poll); btn.disabled = false; status.textContent = '⚠ scan still running — refresh in a moment'; return; }
+          const fresh = await fetch('/paidsubscriptions/data').then(r => r.json()).catch(() => null);
+          if (fresh && fresh.last_scan && fresh.last_scan !== data.last_scan) {
+            clearInterval(poll);
+            status.textContent = '✓ scan complete — refreshing...';
+            setTimeout(() => location.reload(), 800);
+          }
+        }, 5000);
+      } else {
+        status.textContent = '✗ ' + (j.error || 'failed');
+        btn.disabled = false;
+      }
+    } catch (e) {
+      status.textContent = '✗ ' + (e.message || 'network error');
+      btn.disabled = false;
+    }
+  }
+
+  rawJson.textContent = JSON.stringify(data, null, 2);
+  renderSummary();
+  renderDiffBanner();
+  renderTable();
+</script>
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+	return String(s).replace(/[<>&"']/g, c => (({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;',"'":'&#39;'} as Record<string, string>)[c] || c));
+}
+
 const server = createServer((req, res) => {
 	const url = new URL(req.url || '/', `http://${req.headers.host}`);
 
@@ -3048,6 +3340,49 @@ const server = createServer((req, res) => {
 			'Cache-Control': 'no-cache, no-store, must-revalidate',
 		});
 		res.end(CHAT_HTML);
+		return;
+	}
+
+	// Paid subscriptions dashboard. Reads skills/subscription-scanner/state/subscriptions.json
+	// and renders a sortable table with diff highlights from the previous scan.
+	// Trigger an out-of-cycle scan via POST to /paidsubscriptions/scan.
+	if (url.pathname === '/paidsubscriptions') {
+		try {
+			const dataPath = 'skills/subscription-scanner/state/subscriptions.json';
+			const raw = existsSync(dataPath) ? readFileSync(dataPath, 'utf-8') : '{"last_scan":null,"subscriptions":[],"scan_history":[]}';
+			res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+			res.end(renderSubscriptionsHtml(raw));
+		} catch (e: any) {
+			res.writeHead(500, { 'Content-Type': 'text/plain' });
+			res.end('Error reading subscriptions: ' + (e?.message || String(e)));
+		}
+		return;
+	}
+	if (url.pathname === '/paidsubscriptions/data') {
+		try {
+			const dataPath = 'skills/subscription-scanner/state/subscriptions.json';
+			const raw = existsSync(dataPath) ? readFileSync(dataPath, 'utf-8') : '{"last_scan":null,"subscriptions":[],"scan_history":[]}';
+			res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' });
+			res.end(raw);
+		} catch (e: any) {
+			res.writeHead(500, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ error: e?.message || String(e) }));
+		}
+		return;
+	}
+	if (url.pathname === '/paidsubscriptions/scan' && req.method === 'POST') {
+		try {
+			const taskId = `task-${Date.now()}`;
+			const promptPath = 'skills/subscription-scanner/scan-prompt.md';
+			const promptBody = existsSync(promptPath) ? readFileSync(promptPath, 'utf-8') : '(scan-prompt.md missing — run subscription scan)';
+			const taskContent = `id: ${taskId}\ntimestamp: ${new Date().toISOString()}\ntask: Run subscription scan (out-of-cycle, triggered from /paidsubscriptions UI). Follow the instructions in skills/subscription-scanner/scan-prompt.md verbatim:\n\n${promptBody}\nsource: web\nfrom: paidsubscriptions-ui\n`;
+			writeFileSync(`tasks/${taskId}.txt`, taskContent);
+			res.writeHead(200, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ ok: true, task_id: taskId, message: 'Scan queued; the next proactive-loop pass will pick it up (~1 min). Refresh to see results.' }));
+		} catch (e: any) {
+			res.writeHead(500, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ ok: false, error: e?.message || String(e) }));
+		}
 		return;
 	}
 

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -3371,11 +3371,35 @@ const server = createServer((req, res) => {
 		return;
 	}
 	if (url.pathname === '/paidsubscriptions/scan' && req.method === 'POST') {
+		// Localhost-only: this endpoint writes an owner-tier task file that
+		// the watcher processes with full agent privileges. Without this
+		// guard, anyone on the same LAN or a tailscale-funnel'd public URL
+		// could `curl -X POST http://<host>:8080/paidsubscriptions/scan`
+		// and silently enqueue arbitrary work. Per PR #651 Blocker 1.
+		// Reads req.socket.remoteAddress directly rather than a header
+		// (X-Forwarded-For et al. are spoofable). IPv4-mapped IPv6
+		// (::ffff:127.0.0.1) and IPv6 loopback (::1) are both localhost.
+		const remote = req.socket?.remoteAddress || '';
+		const isLocalhost = (
+			remote === '127.0.0.1' ||
+			remote === '::1' ||
+			remote === '::ffff:127.0.0.1'
+		);
+		if (!isLocalhost) {
+			res.writeHead(403, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify({ ok: false, error: 'forbidden: /paidsubscriptions/scan accepts localhost connections only' }));
+			return;
+		}
 		try {
 			const taskId = `task-${Date.now()}`;
-			const promptPath = 'skills/subscription-scanner/scan-prompt.md';
-			const promptBody = existsSync(promptPath) ? readFileSync(promptPath, 'utf-8') : '(scan-prompt.md missing — run subscription scan)';
-			const taskContent = `id: ${taskId}\ntimestamp: ${new Date().toISOString()}\ntask: Run subscription scan (out-of-cycle, triggered from /paidsubscriptions UI). Follow the instructions in skills/subscription-scanner/scan-prompt.md verbatim:\n\n${promptBody}\nsource: web\nfrom: paidsubscriptions-ui\n`;
+			// Pointer (not inline) — prevents prompt-injection via
+			// header-shaped lines in scan-prompt.md (`source:`,
+			// `access_tier:`, etc.) being parsed as real task headers.
+			// Per PR #651 Blocker 2. The agent reads the file when it
+			// processes the task. `access_tier: owner` is explicit per
+			// Chi's review — relying on the absence-of-field default
+			// is fragile.
+			const taskContent = `id: ${taskId}\ntimestamp: ${new Date().toISOString()}\ntask: Run subscription scan (out-of-cycle, triggered from /paidsubscriptions UI). Read the full instructions in skills/subscription-scanner/scan-prompt.md and follow them verbatim.\nsource: web\nfrom: paidsubscriptions-ui\naccess_tier: owner\n`;
 			writeFileSync(`tasks/${taskId}.txt`, taskContent);
 			res.writeHead(200, { 'Content-Type': 'application/json' });
 			res.end(JSON.stringify({ ok: true, task_id: taskId, message: 'Scan queued; the next proactive-loop pass will pick it up (~1 min). Refresh to see results.' }));


### PR DESCRIPTION
Owner ask: "analyze my gmail and create a list of all paid subscriptions (who, when, how much). Put them in a table format and create a localhost:8080/paidsubscriptions page. Create a task to run this scan monthly and highlight any paid subscriptions that I added or deleted. Have a date display on that page to show me which date the last scan was run, and give me a way to trigger an out-of-cycle scan too."

## What this ships

### New skill: `subscription-scanner`
Agent-driven scan (the Gmail access lives in the Claude Code MCP layer, not in Python — so the scan IS the prompt; the proactive-loop runs it each month).

- `SKILL.md` — schema for `state/subscriptions.json`
- `scan-prompt.md` — verbatim prompt the loop runs to perform a scan (search queries, what counts as a subscription vs. one-time vs. newsletter, diff/snapshot logic, notification rule)
- `.gitignore` — excludes `state/` (personal financial data must never be committed)

### New web routes (in `src/web-client.ts`)
- `GET /paidsubscriptions` — full HTML dashboard. Sortable table with vendor / amount / frequency / account / last charge / next charge / status / notes. 4-card summary: active count, ~monthly burn in USD with EUR/GBP FX normalization, uncertain count, recently-cancelled count. Diff banner showing additions / removals / price changes since the last scan. Last-scan timestamp top-left.
- `GET /paidsubscriptions/data` — raw JSON for client-side polling.
- `POST /paidsubscriptions/scan` — "Scan now" button. Writes a task file to `tasks/`; the next proactive-loop pass picks it up and runs the scan. Client polls every 5s for up to 3 min, auto-refreshes when state changes.

### New cron entry (`skills/schedule-crons/crons.json` — gitignored, personal)
- `subscription-scan` — runs at 08:13 on the 1st of every month. Prompt instructs the agent to follow `scan-prompt.md` verbatim, snapshot prior state to `state/history/`, and only notify via Telegram if subscriptions changed (silent otherwise).

### State storage (gitignored)
- `state/subscriptions.json` — current snapshot
- `state/history/<YYYY-MM-DD>.json` — prior snapshots, for diff

## Diff stats
- 3 new files in `skills/subscription-scanner/` (~250 lines of markdown)
- `src/web-client.ts` +200 lines (one new render function, three new route handlers)
- 0 new dependencies

## Testing
- `npx tsc --noEmit` clean
- `/paidsubscriptions` returns 200 on the live web-client; renders 18 subscriptions (12 active, 4 uncertain, 2 recently-cancelled) from the first scan
- `/paidsubscriptions/data` returns valid JSON; UI parses it correctly
- `/paidsubscriptions/scan` POST returns `{ok: true, task_id: '...'}` and writes to `tasks/`

## Privacy
`subscriptions.json` is gitignored — the JSON contains personal financial data (vendor names, amounts, billing dates, family-member account references) and lives only on the local machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)