### PR TITLE
fix(discord-bridge): use /tmp+cat-substitution to avoid codex stdin hang on nested quotes

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2165,7 +2165,17 @@ async def _handle_discord_message(message, force=False):
     # accidentally process a non-owner task with full capabilities.
     # See CLAUDE.md "Discord access control" section for the policy.
     user_task_text = f"[Discord @{username}] {text}{attachment_note}{reply_context}"
-    quoted_task = shlex.quote(user_task_text)
+    # Write task text to a /tmp file and reference via `"$(cat ...)"` heredoc
+    # form instead of shlex.quote'ing it inline. Reason: codex's stdin parser
+    # hangs 7-20min on nested-quote escapes (`'"'"'` style) that arise when
+    # the agent's Bash tool eval-wraps the bridge-injected codex command. The
+    # heredoc form has no nesting depth at any layer; codex receives the file
+    # contents directly via shell command substitution. Per memory
+    # `feedback_codex_nested_quotes_hang_stdin` (Lucy 2026-05-08) + reproduced
+    # live 2026-05-09 PT on Mini coord ping (task-1778363006905, hung 7+min).
+    prompt_path = f"/tmp/sutando-{task_id}.txt"
+    Path(prompt_path).write_text(user_task_text)
+    quoted_task = f'"$(cat {prompt_path})"'
 
     # Pre-classify Discord-state-reference tasks (per msze_'s 2026-05-07
     # directive + Chi's "ship 1" call). If the task body contains a


### PR DESCRIPTION
## Summary
- Bridge-injected codex command was inlining task text via `shlex.quote`. When the agent's Bash tool `eval`-wraps it, the resulting nested-quote escapes (`'"'"'` style) hang codex's stdin parser 7-20 min.
- Switch to writing task text to `/tmp/sutando-{task_id}.txt` and referencing via `"$(cat ...)"` command substitution. No nesting depth at any shell layer.
- Per `feedback_codex_nested_quotes_hang_stdin` memory (Lucy 2026-05-08); reproduced live 2026-05-09 PT on Mini coord ping (task-1778363006905, hung 7+ min until killed; fallback sentinel applied).

## Repro before fix
1. Mini emits `<@1485364006297534584> ping: checking in — what are you working on?` to bot2bot.
2. Bridge writes task with `quoted_task = shlex.quote(...)`; eval-wrap by agent's Bash tool produces `'"'"'[Discord ...]'"'"'`.
3. Codex hangs ≥7 min on stdin parse; agent kills + applies "Sandbox unavailable" fallback.
4. Mini sees fallback, retries → loop. 12+ pings observed in last 30 archived tasks.

## Diff
3-line change at `src/discord-bridge.py:2168` (now expanded to 11 lines with the comment block citing the memory + repro).

## Test plan
- [ ] Restart bridge: `launchctl kickstart -k gui/$(id -u)/com.sutando.discord-bridge`
- [ ] Send a non-owner Discord task containing apostrophes / unicode quotes / ampersands
- [ ] Verify codex returns within normal latency (no 7+ min hang)
- [ ] Verify reply appears in `results/task-{id}.txt`
- [ ] Send a follow-up task to verify per-task-id `/tmp` path is unique (no clobber on concurrent tasks)
- [ ] Confirm Mini ping-bombs stop hanging

## Risks
- If `task_id` ever contains `/` or shell-special chars: file path unsafe. Currently task-IDs are stable timestamps (e.g. `task-1778363006905`) — no risk.
- If bridge runs as a different user than the agent: `/tmp` permissions could block read. Same user in this fleet — no risk.

## Roll-back
`git revert <commit>` — single-commit, single-file. Trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)