### PR TITLE
feat(sutando-app+discord-bridge): emit-task flag + dm-fallback notify/archive

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -1541,9 +1541,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let homebrewPython = "/opt/homebrew/opt/python@3.11/libexec/bin/python3"
         let pythonPath = FileManager.default.fileExists(atPath: homebrewPython)
             ? homebrewPython : "/usr/bin/env"
+        // `--emit-task` writes tasks/task-health-{ts}.txt on failure (with
+        // built-in dedup: 1h cooldown per failure-set hash). The agent picks
+        // it up via the bridge as a regular owner task — gives the trio's
+        // surface_owner path a redundant peer in the file-bridge layer, so
+        // health failures the trio's coverage scanner suppresses by cooldown
+        // (or the LLM step archives by judgment) still reach the agent. Per
+        // Chi 2026-05-07 PT.
         let arguments: [String] = (pythonPath == "/usr/bin/env")
-            ? ["python3", scriptPath, "--fix"]
-            : [scriptPath, "--fix"]
+            ? ["python3", scriptPath, "--fix", "--emit-task"]
+            : [scriptPath, "--fix", "--emit-task"]
 
         DispatchQueue.global(qos: .background).async { [weak self] in
             guard let self = self else { return }

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -267,6 +267,34 @@ def archive_file(src: "Path", kind: str, task_id: str) -> None:
             src.unlink(missing_ok=True)
         except Exception:
             pass
+
+
+def notify_agent_api_task_done(task_id: str, result: str) -> None:
+    """POST to agent-api /task-done so web UI flips status without waiting
+    for its next /tasks/active poll. Best-effort; silent on failure (web UI
+    will catch up on next poll regardless).
+
+    Mirrors voice-agent's task-bridge.ts:533 path. Used after bridge
+    dm-fallback successfully delivers a result that voice-agent never saw
+    (i.e., voice was down). Without this, web UI has a ~5s lag flipping
+    the task to done.
+    """
+    try:
+        import urllib.request
+        token = os.environ.get("SUTANDO_API_TOKEN", "")
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        body = json.dumps({"taskId": task_id, "result": result}).encode("utf-8")
+        req = urllib.request.Request(
+            "http://localhost:7843/task-done",
+            data=body,
+            headers=headers,
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=2).read()
+    except Exception:
+        pass  # best-effort; agent-api will catch up via polling
 INBOX_DIR = Path("/tmp/discord-inbox")
 TASKS_DIR.mkdir(exist_ok=True)
 RESULTS_DIR.mkdir(exist_ok=True)
@@ -2365,6 +2393,12 @@ async def poll_dm_fallback():
                 if st.st_size == 0:
                     print(f"  [dm-fallback] dropping empty {f.name}", flush=True)
                     f.unlink(missing_ok=True)
+                    # Archive matching task file so audit_orphan_tasks sees
+                    # the task as processed (even if drop-without-reply).
+                    _task_id = f.stem
+                    _task_file = TASKS_DIR / f"{_task_id}.txt"
+                    if _task_file.exists():
+                        archive_file(_task_file, "tasks", _task_id)
                     continue
                 # Stop retrying after 24h. Without this cap, a permanent
                 # failure (bad channel ID, bot removed from DM, etc.)
@@ -2374,6 +2408,10 @@ async def poll_dm_fallback():
                 if age > MAX_RETRY_AGE_SECONDS:
                     print(f"  [dm-fallback] dropping stale {f.name} (age={int(age)}s)", flush=True)
                     f.unlink(missing_ok=True)
+                    _task_id = f.stem
+                    _task_file = TASKS_DIR / f"{_task_id}.txt"
+                    if _task_file.exists():
+                        archive_file(_task_file, "tasks", _task_id)
                     continue
                 # Subprocess out to the shared CLI tool so there's only one
                 # code path for the voiceConnected check + DM send.
@@ -2381,9 +2419,13 @@ async def poll_dm_fallback():
                 # bare `python3` may resolve to a different interpreter than the one
                 # running the bridge, or fail with "command not found" on minimal PATH.
                 try:
+                    # stdin=DEVNULL: under launchd, parent's fd 0 may be invalid,
+                    # causing the child Python's `init_sys_streams` to fail with
+                    # `OSError: [Errno 9] Bad file descriptor`. Force clean stdin.
                     result = subprocess.run(
                         [sys.executable, str(REPO / "src" / "dm-result.py"), "--file", str(f)],
                         capture_output=True, text=True, timeout=15,
+                        stdin=subprocess.DEVNULL,
                     )
                 except Exception as e:
                     print(f"  [dm-fallback] subprocess failed on {f.name}: {e}", flush=True)
@@ -2395,7 +2437,25 @@ async def poll_dm_fallback():
                     if "skipping DM" in stdout:
                         continue
                     print(f"  [dm-fallback] sent {f.name} via dm-result.py", flush=True)
-                    f.unlink(missing_ok=True)
+                    # Archive both result and matching task file (parity with
+                    # the main reply path at line ~2219). Without this, tasks
+                    # accumulate in tasks/ forever and audit_orphan_tasks
+                    # reports false-positive orphans.
+                    _task_id = f.stem
+                    # Read result content BEFORE archive so we can POST to
+                    # /task-done. Voice-agent's task-bridge does the same
+                    # via fetch(); this keeps web UI status in sync without
+                    # waiting for agent-api's next /tasks/active poll.
+                    try:
+                        _result_text = f.read_text(encoding="utf-8", errors="replace")
+                    except OSError:
+                        _result_text = ""
+                    archive_file(f, "results", _task_id)
+                    _task_file = TASKS_DIR / f"{_task_id}.txt"
+                    if _task_file.exists():
+                        archive_file(_task_file, "tasks", _task_id)
+                    if _result_text and _task_id.startswith("task-"):
+                        notify_agent_api_task_done(_task_id, _result_text)
                 else:
                     stderr = (result.stderr or "").strip()[:200]
                     print(f"  [dm-fallback] dm-result.py failed on {f.name}: {stderr}", flush=True)

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1034,9 +1034,15 @@ def main():
     if do_notify:
         notify_for_failures(checks)
 
-    # Note: emit-task is moved to AFTER the fix loop below, so it surfaces
-    # the RESIDUAL failure set (per PR #640 v2 review). Pre-fix surfacing
-    # creates owner tasks for failures fixed in the same invocation.
+    # Emit-task: when NOT running --fix, the initial check IS the residual,
+    # so emit here BEFORE the early-exit paths (--json return, --quiet
+    # sys.exit). Per Mini's PR #640 v2-regression catch: my prior change
+    # moved emit-task to end-of-main, which the launchd fallback's
+    # `--quiet --emit-task --notify-on-fail` invocation bypassed via the
+    # quiet-path sys.exit(1). Splitting the emit logic by --fix state
+    # restores coverage for the no-fix path.
+    if do_emit and not do_fix:
+        emit_task_for_failures(checks)
 
     if as_json:
         print(json.dumps({"checks": checks, "issues": len(issues), "total": len(checks)}, indent=2))
@@ -1169,18 +1175,15 @@ def main():
                                      stderr=subprocess.STDOUT, start_new_session=True)
                     print(f"  {c['name']}: {'restarted (stale code)' if c['status'] == 'stale' else 'restarted'}")
 
-    # Emit task on the RESIDUAL failure set (per PR #640 v2 review).
-    # When --fix ran, re-run checks to capture post-fix state — restarts
-    # may have resolved some staleness in-place. When --fix did NOT run,
-    # the initial `checks` IS the residual.
-    if do_emit:
-        if do_fix and issues:
-            # Brief delay so restarts have a chance to register before re-check.
-            # 2s matches the fix-loop's per-service `time.sleep(1)` budget.
-            import time as _t; _t.sleep(2)
-            residual_checks = run_all_checks()
-        else:
-            residual_checks = checks
+    # Emit task on the RESIDUAL failure set when --fix ran (per PR #640 v2
+    # review). The no-fix path emits earlier, before --quiet / --json early
+    # exits (per #640 v2-regression: launchd's `--quiet --emit-task` was
+    # bypassing the end-of-main emit via sys.exit(1)).
+    if do_emit and do_fix and issues:
+        # Brief delay so restarts have a chance to register before re-check.
+        # 2s matches the fix-loop's per-service `time.sleep(1)` budget.
+        import time as _t; _t.sleep(2)
+        residual_checks = run_all_checks()
         emit_task_for_failures(residual_checks)
 
     sys.exit(1 if issues else 0)

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1025,16 +1025,18 @@ def main():
     checks = run_all_checks()
     issues = [c for c in checks if c["status"] not in ("ok", "warn")]
 
-    # Optional: emit a task for the CLI to act on. Runs before --json early-
-    # return so cron-driven --json --emit-task callers get both behaviors.
-    if do_emit:
-        emit_task_for_failures(checks)
     # Optional: macOS notification surface for the launchd-supervised path
-    # (com.sutando.health-check-fallback). Independent dedup state from
+    # (com.sutando.health-check-fallback). Notifies on the INITIAL check set
+    # — the launchd fallback wants the user-visible alert immediately, even
+    # if --fix would resolve some issues. Independent dedup state from
     # emit-task — the two surfaces are deliberately decoupled so neither
     # can suppress the other.
     if do_notify:
         notify_for_failures(checks)
+
+    # Note: emit-task is moved to AFTER the fix loop below, so it surfaces
+    # the RESIDUAL failure set (per PR #640 v2 review). Pre-fix surfacing
+    # creates owner tasks for failures fixed in the same invocation.
 
     if as_json:
         print(json.dumps({"checks": checks, "issues": len(issues), "total": len(checks)}, indent=2))
@@ -1166,6 +1168,20 @@ def main():
                                      stdout=open("/tmp/conversation-server.log", "a"),
                                      stderr=subprocess.STDOUT, start_new_session=True)
                     print(f"  {c['name']}: {'restarted (stale code)' if c['status'] == 'stale' else 'restarted'}")
+
+    # Emit task on the RESIDUAL failure set (per PR #640 v2 review).
+    # When --fix ran, re-run checks to capture post-fix state — restarts
+    # may have resolved some staleness in-place. When --fix did NOT run,
+    # the initial `checks` IS the residual.
+    if do_emit:
+        if do_fix and issues:
+            # Brief delay so restarts have a chance to register before re-check.
+            # 2s matches the fix-loop's per-service `time.sleep(1)` budget.
+            import time as _t; _t.sleep(2)
+            residual_checks = run_all_checks()
+        else:
+            residual_checks = checks
+        emit_task_for_failures(residual_checks)
 
     sys.exit(1 if issues else 0)
 


### PR DESCRIPTION
## Summary

Two related improvements to keep web UI status in sync with actual task lifecycle.

**1. Sutando.app: `--emit-task` flag for `runHealthCheck`** (commits eabedd5, f9a88e4, d1556a0)
- Adds opt-in flag so Sutando.app's Timer-driven health checks can surface residual failures via the task bridge instead of silent log spam.
- Splits emit-task logic by `--fix` state so `--quiet` coverage is restored.
- Source: `src/Sutando/main.swift`, `src/health-check.py`.

**2. Discord-bridge: notify agent-api + archive task/result on dm-fallback** (commit 44a2631)
- New helper `notify_agent_api_task_done()` POSTs to `localhost:7843/task-done` after `dm-result.py` succeeds, mirroring voice-agent's `task-bridge.ts:533` path. Eliminates ~5s web-UI status lag waiting for agent-api's next `/tasks/active` poll.
- Archives task + result files in all three dm-fallback exit paths (`drop-empty` / `drop-stale` / `sent-via-dm`). Previously only the result file was unlinked, leaving orphan task files in `tasks/` that never got archived.
- Addresses the systemic missed-replies pattern surfaced by today's user-behavior probe (187 historical owner-tier orphans in 7d archive without matching results).

## Test plan
- [ ] Run Sutando.app menu-bar health timer; verify `--emit-task` writes to `tasks/` only when residual failures exist post-`--fix`
- [ ] Disconnect voice-agent; trigger a Discord task that hits dm-fallback; verify result file written + task file archived + web UI flips status without poll lag
- [ ] Verify `/task-done` POST silently no-ops when `agent-api` is down (best-effort path)
- [ ] Confirm no double-archives if both main reply path + dm-fallback fire

## Risks
- `notify_agent_api_task_done` uses 2s timeout — if agent-api is overloaded, that's 2s blocked per dm-fallback call. Acceptable given dm-fallback frequency is low.
- Token env var `SUTANDO_API_TOKEN` must match agent-api's expectation; missing token = unauthenticated POST (agent-api decides).

## Roll-back
Both threads are additive. Revert single commits if either misbehaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)