### PR TITLE
docs(README): add Recent autonomous output section — Sutando WIRE + capability proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ https://github.com/user-attachments/assets/a86ec34e-3b26-4011-824c-d2d124753c25
 
 ---
 
+## 🎬 Recent autonomous output
+
+**Sutando WIRE** — Sutando reads the news, drafts the script, generates narration, renders the video. No editor, no animator, no narration session.
+- [Declassified, Debunked, Unexplained: 3 Pentagon UAP Files in 40 Seconds](https://youtu.be/eBvHemYhc2o) — ep002
+- [162 UAP Files Just Declassified. The Pentagon's Apollo 17 Photo](https://youtu.be/JoltTj3x410) — ep001
+
+[@sutando-ai channel](https://www.youtube.com/@sutando-ai) · [Sutando WIRE playlist](https://www.youtube.com/playlist?list=PLoEaHbP1bU5FDWAyeLDL9J9i7Iblp3_m_)
+
+**Recent capability proofs:**
+- [An AI agent caught a bug humans missed — phantom voice sessions, found via anomaly detection](https://youtu.be/FeLfufsMJpY)
+- [42 Days of Sutando — a fleet-growth visualization](https://youtu.be/t2SQqR07T3c)
+- [The AI agent that presented live](https://youtu.be/tisE8YjmLdU)
+- [9-year-old planned her birthday party with AI agent — by voice](https://youtu.be/YuhWklKBP2Q)
+- [When one AI agent can't fix itself, it asks another — same owner or different](https://youtu.be/k_aNNEN_GAc)
+
+---
+
 ## What can you do with it?
 
 **Talk while you work.** You're looking at a doc. You say "make this paragraph shorter." Sutando sees your screen, rewrites the paragraph, and replaces the original text directly.

--- a/skills/gemini-tts/SKILL.md
+++ b/skills/gemini-tts/SKILL.md
@@ -6,7 +6,7 @@ user-invocable: true
 
 # Gemini TTS
 
-Synthesize speech via Google's `gemini-2.5-flash-tts` (or `-pro-tts` / `-lite-preview-tts` per env override). Reads `GEMINI_API_KEY` from `.env`.
+Synthesize speech via Google's `gemini-2.5-flash-preview-tts` (or `-pro-tts` / `-lite-preview-tts` per env override). Reads `GEMINI_API_KEY` from `.env`.
 
 This is offline synthesis — distinct from voice-agent's bidirectional Gemini Live audio. Same model family, different surface (POST text → get audio bytes back, no streaming).
 
@@ -20,7 +20,7 @@ ARGUMENTS: $ARGUMENTS
 
 ## Model selection
 
-Default: `gemini-2.5-flash-tts` (free tier, 1500 req/day, $0 within quota).
+Default: `gemini-2.5-flash-preview-tts` (free tier, 1500 req/day, $0 within quota).
 
 Override via `GEMINI_TTS_MODEL` env var:
 - `gemini-2.5-pro-tts` — paid, higher fidelity

--- a/skills/gemini-tts/SKILL.md
+++ b/skills/gemini-tts/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: gemini-tts
+description: "Render text to mp3 via Google Gemini Flash TTS. Free-tier eligible (1500 req/day). Use for video narration, demo voiceovers, audio notes. Parallels openai-tts; default for make-viral-video."
+user-invocable: true
+---
+
+# Gemini TTS
+
+Synthesize speech via Google's `gemini-2.5-flash-tts` (or `-pro-tts` / `-lite-preview-tts` per env override). Reads `GEMINI_API_KEY` from `.env`.
+
+This is offline synthesis — distinct from voice-agent's bidirectional Gemini Live audio. Same model family, different surface (POST text → get audio bytes back, no streaming).
+
+**Usage**: `/gemini-tts [text]`
+
+ARGUMENTS: $ARGUMENTS
+
+## Voices
+
+`Aoede` (default — alto, neutral), `Charon` (baritone, news-anchor), `Kore` (mid, expressive), `Puck` (high, conversational). Per Lucy's 2026-05-09 testing: Aoede is the closest match to OpenAI's `sage`.
+
+## Model selection
+
+Default: `gemini-2.5-flash-tts` (free tier, 1500 req/day, $0 within quota).
+
+Override via `GEMINI_TTS_MODEL` env var:
+- `gemini-2.5-pro-tts` — paid, higher fidelity
+- `gemini-2.5-flash-lite-preview-tts` — preview, faster
+- `gemini-3.1-flash-tts-preview` — preview
+
+## Examples
+
+```bash
+bash "$SKILL_DIR/scripts/synthesize.sh" -- "Hello, this is Sutando."
+bash "$SKILL_DIR/scripts/synthesize.sh" --voice Charon --out /tmp/intro.mp3 -- "Hi."
+GEMINI_TTS_MODEL=gemini-2.5-pro-tts bash "$SKILL_DIR/scripts/synthesize.sh" -- "High-fidelity narration."
+```
+
+Default output path: `results/gemini-tts-{epoch}.mp3`.
+
+## Cost
+
+Free tier: $0 within 1500 req/day quota. For our cadence (a few demos a day), stays free indefinitely.
+Paid (Flash): $0.50 / 1M input tokens + $10.00 / 1M output tokens.
+
+Compared to OpenAI TTS (`gpt-4o-mini-tts`) at ~$0.02 per 60s: Gemini Flash is free-equivalent for typical demo workloads.
+
+## When to fall back to openai-tts
+
+The `make-viral-video` skill auto-falls-back to OpenAI TTS when:
+- Gemini API returns 4xx/5xx
+- Gemini quota hit (429)
+- `GEMINI_API_KEY` missing
+- `TTS_PROVIDER=OPENAI` env override set
+
+## If Invoked As A Slash Command
+
+If ARGUMENTS is empty, ask the user for the text. Otherwise:
+
+```bash
+bash "$SKILL_DIR/scripts/synthesize.sh" -- "$ARGUMENTS"
+```

--- a/skills/gemini-tts/scripts/synthesize.sh
+++ b/skills/gemini-tts/scripts/synthesize.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 VOICE="Aoede"
 OUT=""
-MODEL="${GEMINI_TTS_MODEL:-gemini-2.5-flash-tts}"
+MODEL="${GEMINI_TTS_MODEL:-gemini-2.5-flash-preview-tts}"
 ARGS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/skills/gemini-tts/scripts/synthesize.sh
+++ b/skills/gemini-tts/scripts/synthesize.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Render text to speech via Google Gemini Flash TTS. Reads GEMINI_API_KEY from .env.
+# Usage: synthesize.sh [--voice <name>] [--out <path>] [--model <id>] -- "text"
+#
+# Free-tier eligible: gemini-2.5-flash-tts within 1500 req/day. Parallels
+# skills/openai-tts/scripts/synthesize.sh (same flag shape, different backend).
+set -euo pipefail
+
+VOICE="Aoede"
+OUT=""
+MODEL="${GEMINI_TTS_MODEL:-gemini-2.5-flash-tts}"
+ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --voice) VOICE="$2"; shift 2 ;;
+    --out)   OUT="$2"; shift 2 ;;
+    --model) MODEL="$2"; shift 2 ;;
+    --) shift; ARGS+=("$@"); break ;;
+    *) ARGS+=("$1"); shift ;;
+  esac
+done
+
+TEXT="${ARGS[*]-}"
+[[ -n "$TEXT" ]] || { echo "Usage: synthesize.sh [--voice <name>] [--out <path>] [--model <id>] -- \"text\"" >&2; exit 2; }
+
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+KEY="${GEMINI_API_KEY:-$(grep -E '^GEMINI_API_KEY=' "$REPO/.env" 2>/dev/null | cut -d= -f2-)}"
+[[ -n "$KEY" ]] || { echo "GEMINI_API_KEY missing (set env or add to .env)" >&2; exit 1; }
+
+[[ -n "$OUT" ]] || OUT="$REPO/results/gemini-tts-$(date +%s).mp3"
+mkdir -p "$(dirname "$OUT")"
+
+# Gemini TTS API: generateContent with audio modality + voice config
+# Endpoint: https://generativelanguage.googleapis.com/v1beta/models/{MODEL}:generateContent
+PAYLOAD=$(python3 -c '
+import json, sys
+text, voice = sys.argv[1], sys.argv[2]
+print(json.dumps({
+  "contents": [{"parts": [{"text": text}]}],
+  "generationConfig": {
+    "responseModalities": ["AUDIO"],
+    "speechConfig": {
+      "voiceConfig": {
+        "prebuiltVoiceConfig": {"voiceName": voice}
+      }
+    }
+  }
+}))
+' "$TEXT" "$VOICE")
+
+URL="https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${KEY}"
+
+RESPONSE=$(curl -sSf "$URL" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" 2>&1) || {
+    echo "Gemini TTS request failed:" >&2
+    echo "$RESPONSE" >&2
+    exit 1
+  }
+
+# Extract base64 audio data from response.candidates[0].content.parts[0].inlineData.data
+B64=$(echo "$RESPONSE" | python3 -c '
+import json, sys
+try:
+  d = json.load(sys.stdin)
+  parts = d["candidates"][0]["content"]["parts"]
+  for p in parts:
+    inline = p.get("inlineData") or p.get("inline_data")
+    if inline and "data" in inline:
+      print(inline["data"])
+      sys.exit(0)
+  print("ERR: no inlineData in response", file=sys.stderr)
+  sys.exit(2)
+except (KeyError, IndexError, json.JSONDecodeError) as e:
+  print(f"ERR: parse failed: {e}", file=sys.stderr)
+  sys.exit(2)
+')
+
+[[ -n "$B64" ]] || { echo "Empty audio response from Gemini" >&2; exit 1; }
+
+# Decode base64 → raw audio. Gemini returns 24kHz PCM by default; we wrap as MP3
+# via ffmpeg pipe. If ffmpeg missing, fall back to writing raw PCM with .pcm
+# suffix so the user knows.
+if command -v ffmpeg >/dev/null 2>&1; then
+  echo "$B64" | base64 -d | ffmpeg -hide_banner -loglevel error -y \
+    -f s16le -ar 24000 -ac 1 -i - "$OUT"
+else
+  # Fall back: write raw PCM
+  PCM_OUT="${OUT%.mp3}.pcm"
+  echo "$B64" | base64 -d > "$PCM_OUT"
+  echo "WARN: ffmpeg missing; wrote raw 24kHz PCM to $PCM_OUT instead of mp3" >&2
+  OUT="$PCM_OUT"
+fi
+
+echo "$OUT"

--- a/skills/make-viral-video/SKILL.md
+++ b/skills/make-viral-video/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: make-viral-video
+description: "Build a short news-explainer video tuned for shareability. One striking moment per video; real fetched assets; self-heal validation; pluggable TTS (Gemini-free default, OpenAI fallback)."
+user-invocable: true
+---
+
+# make-viral-video
+
+Build a short (~30-60s, 1280×720 landscape, h264+aac) news-explainer video around a single source URL or news event. Designed for shareability via the **specificity-shape** framing (Chi's pick 2026-05-09): one striking number, image, or quote — not a comprehensive overview.
+
+Distinct from Lucy's `recursive-meta-explorer` v8-v12 lineage (which optimized for completeness). This skill optimizes for *the one moment that makes someone share*.
+
+## Usage
+
+```bash
+bash "$SKILL_DIR/scripts/build.sh" --topic "DoW UAP file release" --source "https://war.gov/UFO" --out results/
+```
+
+Produces:
+- `results/viral-{ts}/video.mp4` — the rendered video
+- `results/viral-{ts}/script.md` — the narration script
+- `results/viral-{ts}/assets/` — fetched images with hash + validation log
+- `results/viral-{ts}/build.log` — full build trace (codex iterations + validation results)
+- `results/viral-{ts}/verify.sh` — script to independently re-validate the build
+
+## Required tools
+
+- `python3 ≥ 3.10` (PIL for frame composition)
+- `ffmpeg` (encode + ffprobe gate)
+- `gemini` API key (free tier, default) **OR** `openai` API key (fallback)
+- Codex CLI (for script generation per pass)
+
+## Architecture
+
+### Three-phase build with self-heal
+
+**Phase 1 — Source ingestion + script generation**
+- Fetch the source URL (curl + Playwright fallback for JS-rendered pages)
+- Codex generates a narration script + asset manifest with the **specificity-shape framing**:
+  - One striking opening fact (the hook)
+  - 3-5 supporting details (context)
+  - One closing twist or open question (the share moment)
+- Asset manifest is JSON: `[{"url": "...", "alt": "...", "purpose": "hook|support|closer"}]`
+
+**Phase 2 — Asset validation (the self-heal loop)**
+
+For each asset URL:
+1. Fetch
+2. Hash check: refuse duplicates (catches the v12 PR46-404-dupe pattern)
+3. Content-type check: must be image/* or fall back
+4. 404 detector: known-404-page hash list + OCR keywords ("404", "page not found", "Not Found")
+5. Resolution check: ≥600×400 (sub-thumb assets are not viral-grade)
+6. Re-fetch on failure with up to 2 retries
+7. **If validation still fails** → script regen with that asset removed, NOT a silent skip
+
+If 3+ assets fail validation, escalate to user (don't ship a video with placeholder content).
+
+**Phase 3 — Render + pre-publish gate**
+
+1. Compose frames via PIL (templates: hook-card / asset-with-caption / closer-card)
+2. TTS narration via Gemini Flash (free) → fall back to OpenAI on rate-limit / error
+3. ffmpeg encode
+4. **ffprobe gate**: confirm h264 video stream + aac audio stream + 1280×720 dimensions + duration within ±5s of script estimate
+5. If gate fails → report what's missing + don't post
+
+## Visual constraints (specificity-shape)
+
+Per Chi's "visual needs improvement too":
+
+- **Hook card** (0-3s): single bold claim in large type (≥120pt), brand color background, no other text
+- **Support cards** (3-X seconds before closer): real fetched image fills frame; caption overlay (semi-transparent strip, 36pt) with the *one* attributable fact about that image
+- **Closer card** (last 3-5s): the share-moment text — not a recap. A pointed question, surprising number, or open-ended provocation.
+- Aspect: 1280×720 (16:9). NOT vertical 9:16 (Lucy's v10/v11 cropped pictures because of this; landscape preserves news-photo composition).
+- Typography: max 2 fonts (one display, one body). Body font must read at 36pt against any image (test: bottom-third of the frame must contain text or be black-strip overlay).
+
+## TTS provider selection
+
+Default: `GEMINI` (free tier, Aoede voice, 1500 req/day quota). Fallback: `OPENAI` (sage voice, paid, ~$0.02/min).
+
+Override: `TTS_PROVIDER=OPENAI` env var.
+
+## Smoke test
+
+```bash
+# Reproduce the UAP topic with this skill, compare against Lucy's v12 visually:
+bash scripts/build.sh --topic "DoW UAP file release" --source "https://war.gov/UFO"
+```
+
+Validate the output passes:
+- ffprobe shows h264 + aac, 1280×720, ~45s
+- 0 duplicate-hash assets
+- 0 404 page screenshots in assets/
+- Hook card has one bold claim (not 3 bullet points)
+
+## Why this isn't `recursive-meta-explorer-prompt` v13
+
+Lucy's lineage optimized for *informational completeness* + per-pass codex /goal iteration. This skill optimizes for *one shareable moment* + a deterministic validation gate. They serve different goals; both can coexist. Not deleting Lucy's work.

--- a/skills/make-viral-video/SKILL.md
+++ b/skills/make-viral-video/SKILL.md
@@ -73,11 +73,65 @@ Per Chi's "visual needs improvement too":
 - Aspect: 1280×720 (16:9). NOT vertical 9:16 (Lucy's v10/v11 cropped pictures because of this; landscape preserves news-photo composition).
 - Typography: max 2 fonts (one display, one body). Body font must read at 36pt against any image (test: bottom-third of the frame must contain text or be black-strip overlay).
 
-## TTS provider selection
+## TTS provider + voice selection
 
-Default: `GEMINI` (free tier, Aoede voice, 1500 req/day quota). Fallback: `OPENAI` (sage voice, paid, ~$0.02/min).
+Default: `GEMINI` (free tier, 1500 req/day quota) → `OPENAI` (sage voice, ~$0.02/min) fallback.
 
-Override: `TTS_PROVIDER=OPENAI` env var.
+Voice flags (per `render.py --help`):
+- `--gemini-voice {Aoede,Charon,Kore,Puck}` (default `Aoede`)
+  - **Aoede** — alto/neutral, default, fits documentary tone
+  - **Charon** — baritone news-anchor; per Susan/Lucy 2026-05-10: matches news-explainer shape
+  - Kore (mid expressive), Puck (high conversational)
+- `--openai-voice` — free-text (used only on OpenAI fallback path)
+
+## Series branding (Mini Wire)
+
+The skill ships an end-card slate (last 2s) for series identity. Per Chi 2026-05-10:
+
+```
+MINI WIRE
+by Echo Act IV · Sutando   (optional byline)
+ep. 001 · 2026.05.10
+```
+
+Slate flags:
+- `--series-title "Mini Wire"` — wordmark in brand red. Empty string skips the slate entirely.
+- `--episode 001`
+- `--date 2026.05.10` (defaults to today)
+- `--byline "by Echo Act IV · Sutando"` — free-text, between title and episode line. Empty omits byline. **Caller controls every word — no hardcoded identity in render.py.**
+- `--slate-duration 2.0` — seconds
+
+The slate is **silent** — narration runs over the prior frames; slate gets a `apad=pad_dur=2` audio tail so AV streams stay synced through the silent end-card.
+
+## Multi-image visual support
+
+`render.py` reads `asset_manifest.json` and maps each entry's `purpose` to its frame:
+- `purpose=hook` → HOOK frame bg
+- `purpose=support` (idx N) → SUPPORT[N] frame bg
+- `purpose=closer` → CLOSER frame bg
+- Falls back to first non-`data-card-*` real image if no explicit asset
+
+Manifest entries have shape:
+```json
+{
+  "url": "https://example.com/photo.jpg",
+  "local_file": "photo.jpg",
+  "alt": "...",
+  "purpose": "hook|support|closer",
+  "provenance": "..."
+}
+```
+
+Per-frame durations are allocated **proportional to that frame's narration word count** (not fixed allocations). 18-word HOOK gets ~3× the screen time of a 6-word SUPPORT sliver — fixes the "scene changed before narration finished" failure mode.
+
+## Asset cache (cross-run reuse)
+
+Shared cache at `state/viral-cache/fetched_assets/` keyed by URL → local-file mapping. `build.sh` automatically:
+- Phase 0.5: preload cache hits (if manifest exists) before fetch attempts
+- Phase 1.5: preload again after codex writes manifest (catches DNS/403 failures the cache can fix)
+- Phase 2.5: promote validated assets to cache for future runs
+
+Manual control via `python3 skills/make-viral-video/scripts/asset_cache.py {preload|promote|list} <run_dir>`. Cache index at `state/viral-cache/index.json`.
 
 ## Smoke test
 

--- a/skills/make-viral-video/SKILL.md
+++ b/skills/make-viral-video/SKILL.md
@@ -118,9 +118,27 @@ Manifest entries have shape:
   "local_file": "photo.jpg",
   "alt": "...",
   "purpose": "hook|support|closer",
-  "provenance": "..."
+  "badge": "Optional upper-strip badge text",
+  "is_video": false,
+  "source_tag": {
+    "event_id": "pursue-release-01-2026-05-08",
+    "case_id": "apollo-17-vm6-1972",
+    "source_agency": "NASA",
+    "source_url": "https://www.war.gov/UFO/",
+    "source_type": "primary",
+    "attribution": "war.gov/UFO/ · NASA",
+    "license": "public-domain",
+    "footer_short": "Apollo 17 / 1972"
+  },
+  "provenance": "Free-text operator note."
 }
 ```
+
+**`source_tag` is optional** (v1.0, Mini↔Lucy 2026-05-10). When present, renderer:
+- Auto-derives `--footer` from distinct `event_id + footer_short` values across manifest entries (operator-supplied `--footer` overrides).
+- Warns on stderr for any entry with `license: needs-license` and empty `attribution`.
+
+Full schema reference: `notes/sutando-wire/source-tag-schema-v1.md`. v1.1 candidate adds optional `primary: bool` for multi-event Deep-slot pieces (gates which event_ids enter the auto-footer chain).
 
 Per-frame durations are allocated **proportional to that frame's narration word count** (not fixed allocations). 18-word HOOK gets ~3× the screen time of a 6-word SUPPORT sliver — fixes the "scene changed before narration finished" failure mode.
 

--- a/skills/make-viral-video/scripts/asset_cache.py
+++ b/skills/make-viral-video/scripts/asset_cache.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Shared asset cache for make-viral-video skill.
+
+Chi 2026-05-10: "Make existing assets available." Currently each re-run
+gets its own state/viral-{ts}/fetched_assets/ — Apollo image + NASA
+portraits get re-fetched every time. This module backs a shared
+state/viral-cache/fetched_assets/ that any run can preload from + promote
+new fetches into.
+
+Schema:
+- Cache dir: $REPO/state/viral-cache/fetched_assets/<basename>
+- Key: URL basename (post-querystring stripping). Collision-resistant
+  enough for our scale (<1000 unique URLs); no SHA needed yet.
+- Manifest sidecar: $REPO/state/viral-cache/index.json
+  Maps URL → {"local_file": str, "fetched_ts": int, "size_bytes": int}
+
+CLI:
+  python3 asset_cache.py preload <run_dir> [--manifest <path>]
+    Reads run_dir/artifacts/asset_manifest.json (or --manifest) and copies
+    cache hits into run_dir/fetched_assets/. Returns count of hits.
+
+  python3 asset_cache.py promote <run_dir>
+    Copies all files in run_dir/fetched_assets/ to the cache (URL inferred
+    from manifest entries; un-manifested files keyed by basename only).
+
+  python3 asset_cache.py list
+    Prints URL → local_file mapping from the cache index.
+
+API (when imported):
+  cache_get(url) -> Optional[Path]   # cached path or None
+  cache_put(url, local_path)          # copy local_path to cache
+"""
+import argparse
+import json
+import re
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+
+REPO = Path(__file__).resolve().parents[3]
+CACHE_DIR = REPO / "state" / "viral-cache" / "fetched_assets"
+INDEX_FILE = REPO / "state" / "viral-cache" / "index.json"
+
+
+def _ensure_cache_dir():
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _load_index() -> dict:
+    if INDEX_FILE.exists():
+        try:
+            return json.loads(INDEX_FILE.read_text())
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _save_index(index: dict):
+    _ensure_cache_dir()
+    tmp = INDEX_FILE.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(index, indent=2, sort_keys=True))
+    tmp.rename(INDEX_FILE)
+
+
+def _basename_from_url(url: str) -> str:
+    """Strip query string, return path basename."""
+    path = url.split("?", 1)[0].split("#", 1)[0]
+    name = path.rstrip("/").split("/")[-1]
+    if not name:
+        return "asset"
+    return re.sub(r"[^A-Za-z0-9._-]", "_", name)
+
+
+def cache_get(url: str) -> Optional[Path]:
+    """Return cached file path for URL, or None if not cached."""
+    index = _load_index()
+    entry = index.get(url)
+    if not entry:
+        return None
+    p = CACHE_DIR / entry["local_file"]
+    return p if p.is_file() else None
+
+
+def cache_put(url: str, local_path: Path):
+    """Copy local_path into cache by URL basename. Updates index."""
+    if not local_path.is_file():
+        return
+    _ensure_cache_dir()
+    target_name = _basename_from_url(url)
+    target = CACHE_DIR / target_name
+    if target.resolve() == local_path.resolve():
+        return  # already in cache
+    shutil.copy2(local_path, target)
+    index = _load_index()
+    index[url] = {
+        "local_file": target_name,
+        "fetched_ts": int(time.time()),
+        "size_bytes": target.stat().st_size,
+    }
+    _save_index(index)
+
+
+def preload_run_from_cache(run_dir: Path, manifest_path: Optional[Path] = None) -> int:
+    """For each manifest entry with a cache hit, copy from cache into
+    run_dir/fetched_assets/. Returns count of hits."""
+    manifest_path = manifest_path or (run_dir / "artifacts" / "asset_manifest.json")
+    if not manifest_path.is_file():
+        return 0
+    manifest = json.loads(manifest_path.read_text())
+    fetched = run_dir / "fetched_assets"
+    fetched.mkdir(parents=True, exist_ok=True)
+
+    hits = 0
+    for entry in manifest:
+        url = entry.get("url")
+        if not url:
+            continue
+        cached = cache_get(url)
+        if not cached:
+            continue
+        # Use manifest-declared local_file if set, else cache basename
+        target_name = entry.get("local_file") or cached.name
+        target = fetched / target_name
+        if target.exists() and target.stat().st_size == cached.stat().st_size:
+            hits += 1
+            continue
+        shutil.copy2(cached, target)
+        hits += 1
+    return hits
+
+
+def promote_run_to_cache(run_dir: Path) -> int:
+    """For each fetched asset in run_dir/fetched_assets/, promote to cache.
+    URL is read from the manifest if available. Returns count promoted."""
+    fetched = run_dir / "fetched_assets"
+    manifest_path = run_dir / "artifacts" / "asset_manifest.json"
+    manifest = json.loads(manifest_path.read_text()) if manifest_path.is_file() else []
+    by_filename = {}
+    for entry in manifest:
+        local = entry.get("local_file")
+        url = entry.get("url")
+        if local and url and url.startswith("http"):
+            by_filename[local] = url
+
+    promoted = 0
+    for asset in fetched.glob("*"):
+        if not asset.is_file():
+            continue
+        # Skip PIL-generated data-cards (locally rendered, not real fetches)
+        if asset.name.startswith("data-card-"):
+            continue
+        url = by_filename.get(asset.name)
+        if not url:
+            # No URL known — promote under a synthetic key for content-addressed reuse
+            url = f"local://{asset.name}"
+        cache_put(url, asset)
+        promoted += 1
+    return promoted
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Shared asset cache for make-viral-video")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    p_pre = sub.add_parser("preload", help="Pre-stage cache hits into a run dir")
+    p_pre.add_argument("run_dir")
+    p_pre.add_argument("--manifest")
+    p_prom = sub.add_parser("promote", help="Promote a run's fetched_assets/ to cache")
+    p_prom.add_argument("run_dir")
+    sub.add_parser("list", help="Print cache index")
+    args = ap.parse_args()
+
+    if args.cmd == "preload":
+        n = preload_run_from_cache(Path(args.run_dir),
+                                   Path(args.manifest) if args.manifest else None)
+        print(f"preload: {n} cache hits → {args.run_dir}/fetched_assets/")
+    elif args.cmd == "promote":
+        n = promote_run_to_cache(Path(args.run_dir))
+        print(f"promote: {n} files copied to {CACHE_DIR}")
+    elif args.cmd == "list":
+        index = _load_index()
+        for url, entry in sorted(index.items()):
+            print(f"{entry['local_file']:40s}  {entry['size_bytes']:>9d}  {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/make-viral-video/scripts/build.sh
+++ b/skills/make-viral-video/scripts/build.sh
@@ -55,6 +55,20 @@ echo "tts_provider: $TTS_PROVIDER"
 echo "out_dir: $OUT_DIR"
 
 # ----------------------------------------------------------------
+# Phase 0.5: Asset-cache preload (best-effort)
+# ----------------------------------------------------------------
+# If the run dir already has a manifest (e.g. from a prior partial run, or
+# core-agent Phase 1 that pre-staged it), preload any cache hits before
+# codex/Phase 1 starts so we don't re-fetch identical URLs across runs.
+# Per Chi 2026-05-10: "Make existing assets available."
+if [[ -f "$OUT_DIR/artifacts/asset_manifest.json" ]]; then
+  hits=$(python3 "$SKILL_DIR/scripts/asset_cache.py" preload "$OUT_DIR" 2>&1)
+  echo "[Phase 0.5] $hits"
+else
+  echo "[Phase 0.5] no manifest yet; cache preload deferred to Phase 1.5"
+fi
+
+# ----------------------------------------------------------------
 # Phase 1: Codex script + asset manifest generation
 # ----------------------------------------------------------------
 echo ""
@@ -76,6 +90,17 @@ sed -e "s|{{TOPIC}}|$TOPIC|g" \
 # Per `feedback_codex_nested_quotes_hang_stdin.md`: pass via "$(cat /tmp/file)" not raw -- arg
 codex exec --sandbox workspace-write -o "$OUT_DIR/artifacts/codex-output.txt" -- "$(cat "$PROMPT_FILE")"
 echo "[Phase 1] codex done; output at $OUT_DIR/artifacts/codex-output.txt"
+
+# ----------------------------------------------------------------
+# Phase 1.5: Cache preload after codex writes manifest
+# ----------------------------------------------------------------
+# Codex may have failed to fetch some URLs (DNS, 403, etc.). If the cache has
+# them from a prior run, copy them in before validation. Idempotent — skipping
+# any file that already exists with matching size.
+if [[ -f "$OUT_DIR/artifacts/asset_manifest.json" ]]; then
+  hits=$(python3 "$SKILL_DIR/scripts/asset_cache.py" preload "$OUT_DIR" 2>&1)
+  echo "[Phase 1.5] $hits"
+fi
 
 # ----------------------------------------------------------------
 # Phase 2: Asset validation
@@ -109,6 +134,15 @@ if [[ $fail_count -ge 3 ]]; then
   echo "ERROR: $fail_count/$total_count assets failed validation. Aborting before render." >&2
   exit 1
 fi
+
+# ----------------------------------------------------------------
+# Phase 2.5: Promote validated assets to shared cache
+# ----------------------------------------------------------------
+# Only files that passed validation reach the cache. URL keys come from the
+# manifest. Per Chi 2026-05-10: "Make existing assets available." Future runs
+# of any topic that share asset URLs will see cache hits at Phase 0.5/1.5.
+promoted=$(python3 "$SKILL_DIR/scripts/asset_cache.py" promote "$OUT_DIR" 2>&1)
+echo "[Phase 2.5] $promoted"
 
 # ----------------------------------------------------------------
 # Phase 3+5: Frame composition + TTS + ffmpeg encode

--- a/skills/make-viral-video/scripts/build.sh
+++ b/skills/make-viral-video/scripts/build.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Top-level orchestrator for make-viral-video skill.
+# Phases 1-6 of issue #645 (specificity-shape framing per Chi 2026-05-09).
+#
+# Usage:
+#   bash skills/make-viral-video/scripts/build.sh \
+#     --topic "DoW UAP file release" \
+#     --source "https://war.gov/UFO" \
+#     [--target-duration 45] \
+#     [--tts-provider GEMINI|OPENAI] \
+#     [--out-dir state/viral-{ts}]
+#
+# Output: state/viral-{ts}/video.mp4 (validated by ffprobe gate before declared)
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+SKILL_DIR="$REPO/skills/make-viral-video"
+
+TOPIC=""
+SOURCE_URL=""
+TARGET_DURATION=45
+TTS_PROVIDER="GEMINI"
+OUT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --topic) TOPIC="$2"; shift 2 ;;
+    --source) SOURCE_URL="$2"; shift 2 ;;
+    --target-duration) TARGET_DURATION="$2"; shift 2 ;;
+    --tts-provider) TTS_PROVIDER="$2"; shift 2 ;;
+    --out-dir) OUT_DIR="$2"; shift 2 ;;
+    -h|--help)
+      cat <<EOF
+Usage: $0 --topic "X" --source "URL" [--target-duration 45] [--tts-provider GEMINI|OPENAI] [--out-dir state/viral-{ts}]
+EOF
+      exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$TOPIC" ]] || { echo "ERROR: --topic required" >&2; exit 2; }
+[[ -n "$SOURCE_URL" ]] || { echo "ERROR: --source required" >&2; exit 2; }
+
+[[ -n "$OUT_DIR" ]] || OUT_DIR="$REPO/state/viral-$(date +%s)"
+mkdir -p "$OUT_DIR/artifacts" "$OUT_DIR/fetched_assets" "$OUT_DIR/frames"
+LOG="$OUT_DIR/build.log"
+
+# tee everything to build.log
+exec > >(tee -a "$LOG") 2>&1
+echo "=== make-viral-video build $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "topic: $TOPIC"
+echo "source: $SOURCE_URL"
+echo "target_duration: ${TARGET_DURATION}s"
+echo "tts_provider: $TTS_PROVIDER"
+echo "out_dir: $OUT_DIR"
+
+# ----------------------------------------------------------------
+# Phase 1: Codex script + asset manifest generation
+# ----------------------------------------------------------------
+echo ""
+echo "--- Phase 1: codex script generation ---"
+
+PROMPT_TEMPLATE="$SKILL_DIR/scripts/codex-prompt.md"
+[[ -f "$PROMPT_TEMPLATE" ]] || { echo "ERROR: prompt template missing at $PROMPT_TEMPLATE" >&2; exit 1; }
+
+# Substitute variables into the template, write to tmp file
+PROMPT_FILE="$OUT_DIR/codex-prompt.txt"
+sed -e "s|{{TOPIC}}|$TOPIC|g" \
+    -e "s|{{SOURCE_URL}}|$SOURCE_URL|g" \
+    -e "s|{{TARGET_DURATION_S}}|$TARGET_DURATION|g" \
+    -e "s|{{ASSET_DIR}}|$OUT_DIR/fetched_assets/|g" \
+    -e "s|{{OUTPUT_DIR}}|$OUT_DIR/artifacts/|g" \
+    "$PROMPT_TEMPLATE" > "$PROMPT_FILE"
+
+# Run codex /goal exec (codex sandbox can fetch URLs + write files; needs network access)
+# Per `feedback_codex_nested_quotes_hang_stdin.md`: pass via "$(cat /tmp/file)" not raw -- arg
+codex exec --sandbox workspace-write -o "$OUT_DIR/artifacts/codex-output.txt" -- "$(cat "$PROMPT_FILE")"
+echo "[Phase 1] codex done; output at $OUT_DIR/artifacts/codex-output.txt"
+
+# ----------------------------------------------------------------
+# Phase 2: Asset validation
+# ----------------------------------------------------------------
+echo ""
+echo "--- Phase 2: asset validation ---"
+
+VALIDATION_LOG="$OUT_DIR/validation.jsonl"
+> "$VALIDATION_LOG"
+fail_count=0
+total_count=0
+for asset in "$OUT_DIR/fetched_assets"/*; do
+  [[ -f "$asset" ]] || continue
+  total_count=$((total_count + 1))
+  result=$(python3 "$SKILL_DIR/scripts/validate_asset.py" "$asset" 2>&1) || true
+  echo "$result" >> "$VALIDATION_LOG"
+  valid=$(echo "$result" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("valid", False))' 2>/dev/null || echo False)
+  if [[ "$valid" != "True" ]]; then
+    fail_count=$((fail_count + 1))
+    echo "  ✗ $(basename "$asset") — $(echo "$result" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("reason","unknown"))')"
+  else
+    echo "  ✓ $(basename "$asset")"
+  fi
+done
+echo "[Phase 2] $((total_count - fail_count))/$total_count assets valid"
+if [[ $total_count -lt 1 ]]; then
+  echo "ERROR: no assets fetched. Codex may have failed silently. See $OUT_DIR/artifacts/codex-output.txt" >&2
+  exit 1
+fi
+if [[ $fail_count -ge 3 ]]; then
+  echo "ERROR: $fail_count/$total_count assets failed validation. Aborting before render." >&2
+  exit 1
+fi
+
+# ----------------------------------------------------------------
+# Phase 3+5: Frame composition + TTS + ffmpeg encode
+# (TTS is invoked from inside render.py)
+# ----------------------------------------------------------------
+echo ""
+echo "--- Phase 5: render (frames + TTS + encode) ---"
+
+python3 "$SKILL_DIR/scripts/render.py" --workdir "$OUT_DIR" --tts-provider "$TTS_PROVIDER"
+
+# ----------------------------------------------------------------
+# Phase 6: Pre-publish ffprobe gate
+# ----------------------------------------------------------------
+echo ""
+echo "--- Phase 6: ffprobe gate ---"
+
+if ! python3 "$SKILL_DIR/scripts/verify_video.py" "$OUT_DIR/video.mp4" --expected-duration "$TARGET_DURATION"; then
+  echo "ERROR: video failed ffprobe gate. NOT publishing." >&2
+  exit 1
+fi
+
+# ----------------------------------------------------------------
+# Done
+# ----------------------------------------------------------------
+echo ""
+echo "=== BUILD OK ==="
+echo "video: $OUT_DIR/video.mp4"
+echo "log: $LOG"
+echo "validation: $VALIDATION_LOG"
+
+# Emit a verify.sh for independent re-validation
+cat > "$OUT_DIR/verify.sh" <<EOFV
+#!/bin/bash
+# Independent re-validation of this build. Run from the build dir.
+set -euo pipefail
+cd "\$(dirname "\$0")"
+echo "=== Re-validating make-viral-video output ==="
+echo "Video:"
+python3 "$SKILL_DIR/scripts/verify_video.py" video.mp4 --expected-duration $TARGET_DURATION
+echo ""
+echo "Assets:"
+for a in fetched_assets/*; do
+  python3 "$SKILL_DIR/scripts/validate_asset.py" "\$a" >/dev/null && echo "  ✓ \$(basename "\$a")" || echo "  ✗ \$(basename "\$a")"
+done
+EOFV
+chmod +x "$OUT_DIR/verify.sh"
+echo "verify: $OUT_DIR/verify.sh"

--- a/skills/make-viral-video/scripts/build.sh
+++ b/skills/make-viral-video/scripts/build.sh
@@ -125,9 +125,22 @@ python3 "$SKILL_DIR/scripts/render.py" --workdir "$OUT_DIR" --tts-provider "$TTS
 echo ""
 echo "--- Phase 6: ffprobe gate ---"
 
-if ! python3 "$SKILL_DIR/scripts/verify_video.py" "$OUT_DIR/video.mp4" --expected-duration "$TARGET_DURATION"; then
+# Gate validates structure (h264 + aac + dims + AV sync), not absolute duration.
+# Per 2026-05-10 Lucy-Mini iteration: TTS rate varies 117-138 wpm with Aoede;
+# the user-supplied --target-duration is a planning hint, not a hard constraint.
+# Structural gate stays hard; absolute-duration drift is a soft warning.
+if ! python3 "$SKILL_DIR/scripts/verify_video.py" "$OUT_DIR/video.mp4"; then
   echo "ERROR: video failed ffprobe gate. NOT publishing." >&2
   exit 1
+fi
+
+# Soft warning if narration drifted ±10s from target
+ACTUAL_DUR=$(ffprobe -v quiet -print_format json -show_format "$OUT_DIR/video.mp4" | python3 -c 'import json,sys;print(int(float(json.load(sys.stdin)["format"]["duration"])))')
+if [[ -n "$ACTUAL_DUR" ]] && [[ -n "$TARGET_DURATION" ]]; then
+  DIFF=$((ACTUAL_DUR - TARGET_DURATION))
+  if [[ $DIFF -gt 10 ]] || [[ $DIFF -lt -10 ]]; then
+    echo "  [warn] narration drifted ${DIFF}s from target ${TARGET_DURATION}s (actual: ${ACTUAL_DUR}s) — gate passed on AV-sync, but consider tighter prompt"
+  fi
 fi
 
 # ----------------------------------------------------------------

--- a/skills/make-viral-video/scripts/codex-prompt.md
+++ b/skills/make-viral-video/scripts/codex-prompt.md
@@ -58,6 +58,14 @@ Drift past that is a planning bug — count words before you finalize the script
 ## Part 2: SUPPORT (3-5 specific facts, ~5-8s each, total 25-35s, ≤90 words for a 45s target)
 - 3-5 supporting facts that build on the hook
 - Each fact MUST be attributed: "war.gov says...", "AP reports..."
+- **Corroboration rule**: across the 3-5 SUPPORT facts, you MUST cite at least
+  2 distinct sources (e.g., war.gov + AP, or war.gov + Reuters + AeroTime).
+  A 4-fact script that's "war.gov says... war.gov says... war.gov says...
+  war.gov says..." reads as single-sourced and lacks credibility.
+  - HOOK can stay single-sourced (the strongest anchor for the one striking
+    element).
+  - SUPPORT must spread across multiple authoritative sources for
+    corroboration. (Susan's 2026-05-10 review: "better to have more than 1 source.")
 - Each fact MUST be PAIRED with a real fetched image OR a clear PIL-rendered
   data card. Do NOT pad with stock footage, generic ufo art, or symbolic imagery.
 - The image manifest you produce drives Phase 2 asset validation — see "Asset rules" below.

--- a/skills/make-viral-video/scripts/codex-prompt.md
+++ b/skills/make-viral-video/scripts/codex-prompt.md
@@ -38,9 +38,11 @@ an image, a quote, an event, or a juxtaposition — that lands as a share-moment
 # Output structure (3 parts) — STRICT length budget
 
 **Total narration budget: ≤ {{TARGET_DURATION_S}} seconds at TTS pace.**
-At ~155 words/minute (typical TTS rate for Aoede / sage), this means
-≤ ⌊{{TARGET_DURATION_S}} × 2.6⌋ words across HOOK + SUPPORT + CLOSER combined.
-For a 45s target, that's ~117 words. For a 30s target, ~78 words.
+At ~120 words/minute (typical TTS rate for Aoede / sage), this means
+≤ ⌊{{TARGET_DURATION_S}} × 2.0⌋ words across HOOK + SUPPORT + CLOSER combined.
+For a 45s target, that's ~90 words. For a 30s target, ~60 words.
+
+(Empirically: Aoede TTS = ~117 wpm on 2026-05-10 UAP re-run. Conservative budget at 120 wpm leaves 3-5s headroom for inter-sentence silence.)
 
 The ffprobe pre-publish gate enforces narration duration ≤ {{TARGET_DURATION_S}}+5s.
 Drift past that is a planning bug — count words before you finalize the script.

--- a/skills/make-viral-video/scripts/codex-prompt.md
+++ b/skills/make-viral-video/scripts/codex-prompt.md
@@ -35,9 +35,17 @@ You will fetch this URL (use curl + Playwright fallback for JS-rendered pages),
 read its content, and identify the ONE most striking specific element — a number,
 an image, a quote, an event, or a juxtaposition — that lands as a share-moment.
 
-# Output structure (3 parts)
+# Output structure (3 parts) — STRICT length budget
 
-## Part 1: HOOK (3-5s narration, single striking claim)
+**Total narration budget: ≤ {{TARGET_DURATION_S}} seconds at TTS pace.**
+At ~155 words/minute (typical TTS rate for Aoede / sage), this means
+≤ ⌊{{TARGET_DURATION_S}} × 2.6⌋ words across HOOK + SUPPORT + CLOSER combined.
+For a 45s target, that's ~117 words. For a 30s target, ~78 words.
+
+The ffprobe pre-publish gate enforces narration duration ≤ {{TARGET_DURATION_S}}+5s.
+Drift past that is a planning bug — count words before you finalize the script.
+
+## Part 1: HOOK (3-5s narration, ~10-13 words, single striking claim)
 - One sentence
 - The MOST specific thing in the source — NOT "162 files released" but
   "an FBI report from 1947 about an unidentified object the public has never
@@ -45,14 +53,17 @@ an image, a quote, an event, or a juxtaposition — that lands as a share-moment
 - No hedging modifiers ("reportedly", "may have", etc.) unless the source itself hedges
 - Must be defensible from the source — no embellishment
 
-## Part 2: SUPPORT (3-5 specific facts, ~5-8s each, 25-35s total)
+## Part 2: SUPPORT (3-5 specific facts, ~5-8s each, total 25-35s, ≤90 words for a 45s target)
 - 3-5 supporting facts that build on the hook
 - Each fact MUST be attributed: "war.gov says...", "AP reports..."
 - Each fact MUST be PAIRED with a real fetched image OR a clear PIL-rendered
   data card. Do NOT pad with stock footage, generic ufo art, or symbolic imagery.
 - The image manifest you produce drives Phase 2 asset validation — see "Asset rules" below.
+- If you find yourself needing more than 90 words to support the hook,
+  CUT support facts down to 3 strongest. Coverage is the failure mode the
+  specificity-shape framing is designed to prevent.
 
-## Part 3: CLOSER (3-5s, the share-moment)
+## Part 3: CLOSER (3-5s, ~10-13 words, the share-moment)
 - NOT a recap
 - NOT "the useful question is ..." (too academic)
 - A pointed observation, surprising number, or open-ended provocation that
@@ -61,6 +72,13 @@ an image, a quote, an event, or a juxtaposition — that lands as a share-moment
   - "{specific surprising fact} — and we are still finding more."
   - "{specific number} cases. Government says it cannot resolve them."
   - "{striking quote from a participant}."
+
+## Length self-check before exit
+
+Count words in your final HOOK + SUPPORT + CLOSER. Multiply by 60 / 155 to
+estimate seconds. If estimate exceeds {{TARGET_DURATION_S}}+3s, trim the
+weakest support fact and recount. Do this BEFORE writing files. The gate
+is a hard contract — drift past it means you ship nothing.
 
 # Asset rules (Phase 2 validation will enforce)
 

--- a/skills/make-viral-video/scripts/codex-prompt.md
+++ b/skills/make-viral-video/scripts/codex-prompt.md
@@ -1,0 +1,140 @@
+# Codex prompt template — make-viral-video script generation
+
+This is the prompt template fed to `codex exec` (or `codex /goal exec`) during
+Phase 1 of the build. Produces a `final_script.md` + `source_table.json` +
+asset manifest that downstream phases consume.
+
+The template optimizes for **specificity-shape** output (Chi's 2026-05-09 pick):
+one striking moment per video — not comprehensive coverage. This is the explicit
+counterpoint to Lucy's v8-v12 lineage, which produced informationally-dense
+news-summary-shape output that Chi judged "far from viral."
+
+## Variables
+
+When invoking, substitute:
+- `{{TOPIC}}` — short topic name, e.g. "DoW UAP file release"
+- `{{SOURCE_URL}}` — primary source URL, e.g. "https://war.gov/UFO"
+- `{{TARGET_DURATION_S}}` — target wall-clock seconds, default 45
+- `{{ASSET_DIR}}` — where to drop fetched assets, e.g. `state/viral-{ts}/fetched_assets/`
+- `{{OUTPUT_DIR}}` — where to write script + tables, e.g. `state/viral-{ts}/artifacts/`
+
+## Prompt body
+
+```
+You are generating a script for a short news-explainer video, ~{{TARGET_DURATION_S}}s,
+1280×720 landscape, on the topic: {{TOPIC}}.
+
+The video must achieve **specificity-shape virality**: one striking moment that
+makes someone share. NOT a comprehensive overview. NOT a news-summary.
+
+# Inputs
+
+Primary source URL: {{SOURCE_URL}}
+
+You will fetch this URL (use curl + Playwright fallback for JS-rendered pages),
+read its content, and identify the ONE most striking specific element — a number,
+an image, a quote, an event, or a juxtaposition — that lands as a share-moment.
+
+# Output structure (3 parts)
+
+## Part 1: HOOK (3-5s narration, single striking claim)
+- One sentence
+- The MOST specific thing in the source — NOT "162 files released" but
+  "an FBI report from 1947 about an unidentified object the public has never
+  seen" or whatever the most specific anchor in the source actually is
+- No hedging modifiers ("reportedly", "may have", etc.) unless the source itself hedges
+- Must be defensible from the source — no embellishment
+
+## Part 2: SUPPORT (3-5 specific facts, ~5-8s each, 25-35s total)
+- 3-5 supporting facts that build on the hook
+- Each fact MUST be attributed: "war.gov says...", "AP reports..."
+- Each fact MUST be PAIRED with a real fetched image OR a clear PIL-rendered
+  data card. Do NOT pad with stock footage, generic ufo art, or symbolic imagery.
+- The image manifest you produce drives Phase 2 asset validation — see "Asset rules" below.
+
+## Part 3: CLOSER (3-5s, the share-moment)
+- NOT a recap
+- NOT "the useful question is ..." (too academic)
+- A pointed observation, surprising number, or open-ended provocation that
+  rewards the viewer for finishing — gives them something to share/think about
+- Examples of closer-shape (paraphrase, not literal):
+  - "{specific surprising fact} — and we are still finding more."
+  - "{specific number} cases. Government says it cannot resolve them."
+  - "{striking quote from a participant}."
+
+# Asset rules (Phase 2 validation will enforce)
+
+Produce `source_table.json` with one entry per source. Each entry MUST have:
+```
+{
+  "source_title": "...",
+  "url_or_path": "<verbatim URL — must literally appear in the source page or be directly fetched>",
+  "source_type": "official|wire|secondary",
+  "date": "YYYY-MM-DD",
+  "key_fact": "<one sentence>",
+  "strongest_quote_or_claim": "<verbatim from source>",
+  "available_visual_material": "<URL of a real image hosted by source — NOT a guessed pattern>",
+  "reliability_level": "high|medium|low"
+}
+```
+
+**The `url_or_path` and `available_visual_material` fields MUST be URLs you have
+actually loaded** — either via your fetch in this run, or that appear verbatim
+in HTML you fetched. **Do NOT extrapolate URL patterns.** (Lucy's v12 hallucinated
+PR46 URLs that 404'd; Mini's gate will reject any URL not provenance-trailed.)
+
+If the source has fewer than 3 verifiable visual assets, say so in the script
+and use PIL-rendered data cards for the gap — do NOT fabricate URLs.
+
+# Output files
+
+Write to {{OUTPUT_DIR}}:
+- `final_script.md` — the narration text, sectioned HOOK / SUPPORT / CLOSER
+- `source_table.json` — JSON array per the schema above
+- `asset_manifest.json` — `[{"url": "...", "alt": "...", "purpose": "hook|support|closer", "provenance": "<which fetched-page or source_table.url_or_path it came from>"}]`
+
+Fetch all assets to {{ASSET_DIR}}. Mini's validator will run on each before
+proceeding to render.
+
+# Forbidden patterns (will fail Phase 2 gate)
+
+1. URLs you did not actually load (no PR46-pattern hallucinations)
+2. Generic UFO art / stock symbolic imagery as primary visuals
+3. Comprehensive coverage shape ("AP says... Reuters says... AeroTime says...
+   Live Science says...") — pick the strongest 2-3, not all
+4. Closer that summarizes ("So in summary, ..."); closer must be share-shape
+5. Hook that starts with the headline number ("162 files released") instead
+   of the most specific element
+
+# Self-validation before exit
+
+Before returning, run:
+1. `python3 skills/make-viral-video/scripts/validate_asset.py <each fetched asset>`
+   — all must return `valid:true`
+2. Verify each `url_or_path` and `available_visual_material` either appears in
+   `<raw_html_you_fetched>` OR was directly fetched by you (provenance trail)
+
+If any validation fails, drop that asset from the manifest and re-fetch a
+substitute or substitute a PIL data card. Do NOT proceed with broken assets.
+
+Return when self-validation passes. Phase 2 of the build will re-run validation
+as a gate; your output should match.
+```
+
+## Notes on the prompt design
+
+- **Why the hook example "FBI report from 1947"** is specificity-shape: it
+  picks ONE thing from the 162 files, makes a viewer think "wait, what?" —
+  not "162 files = a lot." The 162-headline lands as the second beat, not
+  the first.
+- **Why "no comprehensive AP/Reuters/Axios listing"**: Lucy's v12 narrated
+  "AP says... AeroTime says... Axios reports... Live Science says..." in
+  one breath. It reads as wire-summary-shape; specificity-shape picks 2-3
+  strongest sources and quotes them by name, not by enumeration.
+- **Why provenance trail required on URLs**: Lucy's PR46 URLs were extrapolated
+  from a real pattern (codex saw `PR19` and guessed `PR20-PR99`). The provenance
+  rule (URL must literally appear in fetched HTML or be directly loaded by
+  codex in this session) catches that pattern without requiring a static
+  domain whitelist.
+- **Why self-validate before exit**: forces codex to encounter its own broken
+  asset URLs before Mini's external gate does. Cuts iteration count.

--- a/skills/make-viral-video/scripts/codex-prompt.md
+++ b/skills/make-viral-video/scripts/codex-prompt.md
@@ -54,10 +54,20 @@ Drift past that is a planning bug — count words before you finalize the script
   seen" or whatever the most specific anchor in the source actually is
 - No hedging modifiers ("reportedly", "may have", etc.) unless the source itself hedges
 - Must be defensible from the source — no embellishment
+- **Forbidden hook shapes** (Chi 2026-05-10 feedback: "too dry, hook weak"):
+  - "X shows Y": "War.gov shows Apollo 17's photo..." — reportorial, not visceral
+  - "X says Y": "AP says..." — wire-service lede, doesn't pull viewer in
+  - Any sentence that opens with the source name as subject
+- **Required hook shape**: open with the surprising element itself, not its provenance.
+  Examples (paraphrase only):
+  - "Three lights hover above the moon in this 1972 photo." (subject = the thing)
+  - "A 1972 Apollo photo just got declassified — and there are three lights." (the reveal IS the hook)
+  - "NASA said the dots were nothing. The Pentagon now says: physical object, possibly."
+  Attribution belongs in SUPPORT, not HOOK.
 
 ## Part 2: SUPPORT (3-5 specific facts, ~5-8s each, total 25-35s, ≤90 words for a 45s target)
 - 3-5 supporting facts that build on the hook
-- Each fact MUST be attributed: "war.gov says...", "AP reports..."
+- Each fact MUST be attributed (somewhere — not necessarily as the sentence's opening clause).
 - **Corroboration rule**: across the 3-5 SUPPORT facts, you MUST cite at least
   2 distinct sources (e.g., war.gov + AP, or war.gov + Reuters + AeroTime).
   A 4-fact script that's "war.gov says... war.gov says... war.gov says...
@@ -66,6 +76,24 @@ Drift past that is a planning bug — count words before you finalize the script
     element).
   - SUPPORT must spread across multiple authoritative sources for
     corroboration. (Susan's 2026-05-10 review: "better to have more than 1 source.")
+- **Anti-enumeration rule** (Susan's 2026-05-10 second review: "you just ended up
+  enumerating all sources"): SUPPORT must NOT read as a list where every fact
+  opens with attribution. Forbidden:
+    "war.gov says X. CBS News says Y. war.gov says Z. CBS News says W."
+  Required: vary the opening structure across the 3-5 facts. At most ONE fact
+  may open with a "<source> says..." clause; the rest must lead with the fact
+  itself and cite the source mid-sentence or at the end:
+    "Three dots sit in a triangular formation, per the Pentagon caption."
+    "Preliminary analysis called a physical object possible — though no consensus, CBS reported."
+    "Pilot Ronald Evans logged 'bright fragments drifting' during the maneuver."
+- **Storytelling rule** (Susan's 2026-05-10 review: "could use more asks of the
+  WHY questions between different [facts]"): at least ONE transition between
+  SUPPORT facts should bridge with a curiosity beat — a question, a contrast,
+  or an unexpected pivot — not just a flat sequence of independent facts.
+  Examples of bridge shapes:
+    "...visible only after magnification. Why didn't anyone catch this in 1972?"
+    "...called a physical object possible. But the Pentagon stopped short of saying what."
+  Bridges count toward the 90-word budget. Use them only if they earn their cost.
 - Each fact MUST be PAIRED with a real fetched image OR a clear PIL-rendered
   data card. Do NOT pad with stock footage, generic ufo art, or symbolic imagery.
 - The image manifest you produce drives Phase 2 asset validation — see "Asset rules" below.
@@ -76,12 +104,17 @@ Drift past that is a planning bug — count words before you finalize the script
 ## Part 3: CLOSER (3-5s, ~10-13 words, the share-moment)
 - NOT a recap
 - NOT "the useful question is ..." (too academic)
-- A pointed observation, surprising number, or open-ended provocation that
-  rewards the viewer for finishing — gives them something to share/think about
-- Examples of closer-shape (paraphrase, not literal):
-  - "{specific surprising fact} — and we are still finding more."
-  - "{specific number} cases. Government says it cannot resolve them."
-  - "{striking quote from a participant}."
+- NOT a colon-list-of-attributions ("Three dots, one caption: no consensus, maybe physical object" — Chi 2026-05-10 flagged this as recap-shape disguised as commentary)
+- A pointed observation, surprising number, open-ended provocation, or a direct
+  participant quote that rewards the viewer for finishing — gives them something
+  to share/think about
+- **Required closer shape** — pick ONE of:
+  1. **Direct quote** from a named participant: "Evans called them 'bright particles drifting.'"
+  2. **Anchor stat with implication**: "162 cases. Zero closed."
+  3. **Provocation question**: "What did the camera catch that the astronauts couldn't?"
+  4. **Stakes-flip**: "The Pentagon won't rule it out. Will you?"
+- The closer must end the video with energy that makes someone tap share or
+  comment — not with a tidy summary that says "video over, you can move on."
 
 ## Length self-check before exit
 

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -239,6 +239,71 @@ def render_support_frame(hero_path: Path, caption: str, out_path: Path,
     out.save(out_path, "PNG")
 
 
+def render_video_overlay(caption: str, out_path: Path, badge: str = ""):
+    """Transparent-bg PNG used as overlay on a video clip. Contains the bottom
+    caption strip + optional top-left name-chip — same layout as the still
+    support frame, but background pixels are 0-alpha so the source video shows
+    through everywhere else.
+
+    Used when a manifest support entry has `is_video: true` (Lucy v1.7
+    integration: Pentagon UAP sensor clip plays as full-frame video instead of
+    a Ken-Burns still).
+    """
+    from PIL import Image, ImageDraw
+    overlay = Image.new("RGBA", (CANVAS_W, CANVAS_H), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(overlay)
+
+    strip_h = 180
+    draw.rectangle([(0, CANVAS_H - strip_h), (CANVAS_W, CANVAS_H)], fill=CAPTION_BG)
+
+    cap_font = get_font(34)
+    lines = wrap_text(caption.strip(), 60)[:3]
+    y = CANVAS_H - strip_h + 22
+    for line in lines:
+        draw.text((40, y), line, fill=TEXT, font=cap_font)
+        y += 48
+
+    if badge:
+        badge_text = badge.upper()
+        badge_font = get_font(28)
+        bbb = draw.textbbox((0, 0), badge_text, font=badge_font)
+        bw, bh = bbb[2] - bbb[0], bbb[3] - bbb[1]
+        pad_x, pad_y = 18, 12
+        chip_w = bw + pad_x * 2
+        chip_h = bh + pad_y * 2 + 6
+        draw.rectangle([(40, 40), (40 + chip_w, 40 + chip_h)], fill=ACCENT)
+        draw.text((40 + pad_x, 40 + pad_y), badge_text, fill=TEXT, font=badge_font)
+
+    overlay.save(out_path, "PNG")
+
+
+def video_clip(video_source: Path, overlay_png: Path, duration_s: float,
+               clip_idx: int, out_path: Path):
+    """Clip a source video to `duration_s` and composite the caption/badge
+    overlay PNG over it. Output is silent h264 (audio overlaid on final concat).
+
+    Source video is scaled to 1280×720 cover-style; overlay PNG is full canvas
+    transparent except for caption strip + badge regions.
+    """
+    vf = (
+        "[0:v]scale=1280:720:force_original_aspect_ratio=increase,"
+        "crop=1280:720,setsar=1[v];"
+        "[v][1:v]overlay=0:0[out]"
+    )
+    cmd = [
+        "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+        "-i", str(video_source),
+        "-i", str(overlay_png),
+        "-filter_complex", vf,
+        "-map", "[out]",
+        "-c:v", "libx264", "-pix_fmt", "yuv420p", "-r", str(FPS),
+        "-t", f"{duration_s:.3f}",
+        "-an",
+        str(out_path),
+    ]
+    subprocess.run(cmd, check=True)
+
+
 def render_closer_frame(text: str, hero_path: Optional[Path], out_path: Path):
     """Hero image (lightly dimmed) + share-shape closing line, centered, large."""
     from PIL import Image, ImageDraw
@@ -512,6 +577,7 @@ def main():
     # which under-allocates frames whose text is longer than average).
     durations = []  # placeholders, filled after TTS via word-share
     frame_words = []  # parallel: word count of each frame's narration
+    video_source = []  # parallel: Path(mp4) if frame is video-sourced, else None
     frame_idx = 0
 
     if sections.get("HOOK"):
@@ -519,6 +585,7 @@ def main():
         render_hook_frame(sections["HOOK"], hook_path, frames_dir / f"frame_{frame_idx:03d}.png")
         durations.append(0.0)
         frame_words.append(len(sections["HOOK"].split()))
+        video_source.append(None)
         frame_idx += 1
 
     support_text = sections.get("SUPPORT", "")
@@ -527,12 +594,21 @@ def main():
 
     for i, fact in enumerate(support_facts):
         sup_asset, sup_entry = asset_for("support", i)
-        if sup_asset:
+        is_video = bool(sup_entry and sup_entry.get("is_video"))
+        if is_video and sup_asset:
+            # Video-sourced support: render only the transparent caption/badge
+            # overlay PNG; full clip is built from the source video at clip-gen time.
+            badge = sup_entry.get("badge", "")
+            render_video_overlay(fact, frames_dir / f"frame_{frame_idx:03d}.png", badge=badge)
+            video_source.append(sup_asset)
+        elif sup_asset:
             badge = (sup_entry.get("badge", "") if sup_entry else "")
             render_support_frame(sup_asset, fact, frames_dir / f"frame_{frame_idx:03d}.png",
                                   crop_seed=i, badge=badge)
+            video_source.append(None)
         else:
             render_closer_frame(fact, None, frames_dir / f"frame_{frame_idx:03d}.png")
+            video_source.append(None)
         durations.append(0.0)
         frame_words.append(len(fact.split()))
         frame_idx += 1
@@ -542,6 +618,7 @@ def main():
         render_closer_frame(sections["CLOSER"], closer_path, frames_dir / f"frame_{frame_idx:03d}.png")
         durations.append(0.0)
         frame_words.append(len(sections["CLOSER"].split()))
+        video_source.append(None)
         frame_idx += 1
 
     # Track narration-mapped frame count BEFORE adding the slate. The slate
@@ -597,13 +674,19 @@ def main():
 
     print(f"[render] total: {sum(durations):.1f}s ({narration_dur:.1f}s narration + {sum(durations[narration_frame_count:]):.1f}s slate)", file=sys.stderr)
 
-    # Pre-render each frame as a Ken-Burns clip
+    # Per-frame clip generation. Stills get Ken-Burns (zoompan); video-sourced
+    # frames get the source video clipped + overlay PNG composited.
     clip_paths = []
-    for i, (frame, dur) in enumerate(zip(sorted(frames_dir.glob("frame_*.png")), durations)):
+    sorted_frames = sorted(frames_dir.glob("frame_*.png"))
+    for i, (frame, dur) in enumerate(zip(sorted_frames, durations)):
         clip = clips_dir / f"clip_{i:03d}.mp4"
-        kenburns_clip(frame, dur, i, clip)
+        if i < len(video_source) and video_source[i] is not None:
+            video_clip(video_source[i], frame, dur, i, clip)
+            print(f"[render] clip {i}: video-sourced ({video_source[i].name})", file=sys.stderr)
+        else:
+            kenburns_clip(frame, dur, i, clip)
         clip_paths.append(clip)
-    print(f"[render] {len(clip_paths)} Ken-Burns clips", file=sys.stderr)
+    print(f"[render] {len(clip_paths)} clips ({sum(1 for v in video_source if v)} video-sourced)", file=sys.stderr)
 
     out = workdir / "video.mp4"
     # Slate (if present) extends video duration past narration by slate_duration.

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -259,13 +259,15 @@ def render_closer_frame(text: str, hero_path: Optional[Path], out_path: Path):
     base.save(out_path, "PNG")
 
 
-def render_slate_frame(series_title: str, episode: str, date: str, out_path: Path):
+def render_slate_frame(series_title: str, episode: str, date: str, out_path: Path,
+                        byline: str = ""):
     """Series signature slate — 2s end card. Black bg, large brand-red wordmark,
-    small episode + date subtitle. Mini Wire branding per Chi 2026-05-10.
+    small episode + date subtitle, optional byline. Branding per Chi 2026-05-10.
 
-    Layout:
+    Layout (byline optional):
         [vertical center]
         SERIES TITLE         ← large, brand red, bold
+        byline               ← smaller, white, optional (e.g. "by Echo Act IV · Sutando")
         ep. NNN · YYYY.MM.DD ← smaller, white
     """
     from PIL import Image, ImageDraw
@@ -273,32 +275,41 @@ def render_slate_frame(series_title: str, episode: str, date: str, out_path: Pat
     draw = ImageDraw.Draw(base)
 
     title_font = get_font(120)
+    byline_font = get_font(34)
     sub_font = get_font(36)
 
     title_text = series_title.upper()
     sub_text = f"ep. {episode} · {date}"
 
-    # Title bbox
     tbb = draw.textbbox((0, 0), title_text, font=title_font)
-    tw = tbb[2] - tbb[0]
-    th = tbb[3] - tbb[1]
-    # Subtitle bbox
+    tw, th = tbb[2] - tbb[0], tbb[3] - tbb[1]
     sbb = draw.textbbox((0, 0), sub_text, font=sub_font)
-    sw = sbb[2] - sbb[0]
-    sh = sbb[3] - sbb[1]
+    sw, sh = sbb[2] - sbb[0], sbb[3] - sbb[1]
+    if byline:
+        bbb = draw.textbbox((0, 0), byline, font=byline_font)
+        bw, bh = bbb[2] - bbb[0], bbb[3] - bbb[1]
+    else:
+        bw = bh = 0
 
-    gap = 30
-    total_h = th + gap + sh
+    gap_above_byline = 24
+    gap_above_sub = 22 if byline else 30
+    total_h = th + (gap_above_byline + bh if byline else 0) + gap_above_sub + sh
     y_title = (CANVAS_H - total_h) // 2
 
     # Title in brand red
     x_title = (CANVAS_W - tw) // 2
     draw.text((x_title, y_title), title_text, fill=ACCENT, font=title_font)
 
-    # Subtitle in white
-    y_sub = y_title + th + gap
+    y = y_title + th
+    if byline:
+        y += gap_above_byline
+        x_byline = (CANVAS_W - bw) // 2
+        draw.text((x_byline, y), byline, fill=TEXT, font=byline_font)
+        y += bh
+
+    y += gap_above_sub
     x_sub = (CANVAS_W - sw) // 2
-    draw.text((x_sub, y_sub), sub_text, fill=TEXT, font=sub_font)
+    draw.text((x_sub, y), sub_text, fill=TEXT, font=sub_font)
 
     base.save(out_path, "PNG")
 
@@ -430,6 +441,9 @@ def main():
                    help="Branded series name shown on the end-card slate (set empty to skip slate).")
     p.add_argument("--episode", default="001", help="Episode number for slate (e.g. '001')")
     p.add_argument("--date", default=None, help="Date for slate (YYYY.MM.DD); defaults to today")
+    p.add_argument("--byline", default="",
+                   help="Optional byline shown between title and ep/date (e.g. 'by Echo Act IV · Sutando'). "
+                        "Empty string omits the byline. Free-text — caller controls identity wording.")
     p.add_argument("--slate-duration", type=float, default=2.0, help="End-card slate duration (s)")
     args = p.parse_args()
 
@@ -514,7 +528,8 @@ def main():
         from datetime import datetime
         slate_date = args.date or datetime.now().strftime("%Y.%m.%d")
         render_slate_frame(args.series_title, args.episode, slate_date,
-                           frames_dir / f"frame_{frame_idx:03d}.png")
+                           frames_dir / f"frame_{frame_idx:03d}.png",
+                           byline=args.byline)
         durations.append(args.slate_duration)  # slate gets fixed duration, not narration-proportional
         frame_words.append(0)  # no narration on slate
         frame_idx += 1

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -225,7 +225,20 @@ def synthesize_tts(text: str, out_path: Path, provider: str = "GEMINI"):
 
 
 def encode_video(frames_dir: Path, narration_path: Path, durations_s: list, out_path: Path):
-    """Concat frames at fixed durations, overlay narration audio. Uses ffmpeg concat demuxer."""
+    """Concat frames at fixed durations, overlay narration audio. Uses ffmpeg concat demuxer.
+
+    Audio duration is the source of truth for output length. We set output `-t`
+    to the narration duration so video always matches audio (no AV-sync drift
+    from concat-demuxer's last-frame-repeat behavior, caught in smoke test
+    2026-05-10).
+    """
+    # Get exact narration duration
+    probe = subprocess.run(
+        ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", str(narration_path)],
+        capture_output=True, text=True, check=True,
+    )
+    narration_dur = float(json.loads(probe.stdout).get("format", {}).get("duration", sum(durations_s)))
+
     # Build concat list file
     concat_list = frames_dir / "concat.txt"
     with open(concat_list, "w") as f:
@@ -243,7 +256,7 @@ def encode_video(frames_dir: Path, narration_path: Path, durations_s: list, out_
         "-c:v", "libx264", "-pix_fmt", "yuv420p",
         "-c:a", "aac", "-b:a", "128k",
         "-r", str(FPS),
-        "-shortest",
+        "-t", f"{narration_dur:.3f}",  # clip output to exact narration length
         str(out_path),
     ]
     subprocess.run(cmd, check=True)
@@ -316,6 +329,25 @@ def main():
     narration_path = workdir / "narration.mp3"
     provider_used = synthesize_tts(full_narration, narration_path, provider=args.tts_provider)
     print(f"[render] narration via {provider_used}", file=sys.stderr)
+
+    # Scale frame durations to match narration length so the video doesn't
+    # cut off mid-sentence (caught by smoke test 2026-05-10: 25s frames vs
+    # 57s narration → ffmpeg --shortest truncated audio). Scale proportionally,
+    # keeping the relative weights of HOOK / SUPPORT / CLOSER frames intact.
+    try:
+        probe = subprocess.run(
+            ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", str(narration_path)],
+            capture_output=True, text=True, check=True,
+        )
+        narration_dur = float(json.loads(probe.stdout).get("format", {}).get("duration", 0))
+    except Exception as e:
+        print(f"[render] ffprobe on narration failed ({e}); using planned durations", file=sys.stderr)
+        narration_dur = sum(durations)
+
+    if narration_dur > 0 and abs(narration_dur - sum(durations)) > 1.0:
+        scale = narration_dur / sum(durations)
+        durations = [d * scale for d in durations]
+        print(f"[render] scaled frame durations by {scale:.2f}x to match narration {narration_dur:.1f}s", file=sys.stderr)
 
     # Encode
     out = workdir / "video.mp4"

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -368,10 +368,29 @@ def main():
     sections = parse_script(script_md)
     print(f"[render] sections: {list(sections.keys())}", file=sys.stderr)
 
+    # Per-frame asset selection from manifest (Mini Phase 3, 2026-05-10).
+    # Manifest entries with purpose in {hook, support, closer} map to frames.
+    # Multi-image support — fixes Lucy's "only one image across the whole video"
+    # critique on re-run 5b. Fallback: hero (first real image) if no explicit
+    # asset for a frame.
+    manifest_path = artifacts / "asset_manifest.json"
+    manifest = json.loads(manifest_path.read_text()) if manifest_path.exists() else []
     hero = find_hero_image(fetched)
-    print(f"[render] hero image: {hero}", file=sys.stderr)
-    if not hero:
-        print("[render] WARNING: no real fetched image — falling back to text-on-black", file=sys.stderr)
+    print(f"[render] hero (fallback): {hero}", file=sys.stderr)
+
+    def asset_for(purpose: str, idx: int = 0):
+        matches = [m for m in manifest if m.get("purpose") == purpose]
+        if purpose == "support" and idx < len(matches):
+            target = matches[idx].get("local_file") or matches[idx].get("url", "").split("/")[-1]
+            p = fetched / target
+            if p.is_file():
+                return p
+        elif purpose != "support" and matches:
+            target = matches[0].get("local_file") or matches[0].get("url", "").split("/")[-1]
+            p = fetched / target
+            if p.is_file():
+                return p
+        return hero
 
     # Default per-section durations (will be scaled to narration length below)
     HOOK_DUR = 4.0
@@ -382,7 +401,7 @@ def main():
     frame_idx = 0
 
     if sections.get("HOOK"):
-        render_hook_frame(sections["HOOK"], hero, frames_dir / f"frame_{frame_idx:03d}.png")
+        render_hook_frame(sections["HOOK"], asset_for("hook"), frames_dir / f"frame_{frame_idx:03d}.png")
         durations.append(HOOK_DUR)
         frame_idx += 1
 
@@ -391,16 +410,17 @@ def main():
     support_facts = [f for f in support_facts if f.strip()]
 
     for i, fact in enumerate(support_facts):
-        if hero:
-            render_support_frame(hero, fact, frames_dir / f"frame_{frame_idx:03d}.png", crop_seed=i)
+        sup_asset = asset_for("support", i)
+        if sup_asset:
+            render_support_frame(sup_asset, fact, frames_dir / f"frame_{frame_idx:03d}.png", crop_seed=i)
         else:
-            # No hero: render as text-on-black via closer renderer (looks like a quote card)
+            # No asset: render as text-on-black via closer renderer (quote-card shape)
             render_closer_frame(fact, None, frames_dir / f"frame_{frame_idx:03d}.png")
         durations.append(SUPPORT_DUR)
         frame_idx += 1
 
     if sections.get("CLOSER"):
-        render_closer_frame(sections["CLOSER"], hero, frames_dir / f"frame_{frame_idx:03d}.png")
+        render_closer_frame(sections["CLOSER"], asset_for("closer"), frames_dir / f"frame_{frame_idx:03d}.png")
         durations.append(CLOSER_DUR)
         frame_idx += 1
 

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -662,9 +662,42 @@ def main():
     # Apply persistent footer to all narrated frames (skipped on slate).
     # Per Lucy v1.7 pattern: small lower-strip with event-ID anchor on every
     # narrated frame. Skipped silently if --footer is empty.
-    if args.footer:
+    #
+    # source_tag schema v1 (Mini ↔ Lucy 2026-05-10): if --footer is empty but
+    # manifest entries carry `source_tag.footer_short` + `source_tag.event_id`,
+    # auto-build the footer from those fields. Preserves wedge-1 (primary-source
+    # citation density) without operator having to hand-craft the --footer string.
+    footer_text = args.footer
+    if not footer_text and manifest:
+        event_ids = []
+        shorts = []
+        for entry in manifest:
+            st = entry.get("source_tag") or {}
+            if isinstance(st, dict):
+                ev = st.get("event_id")
+                fs = st.get("footer_short")
+                if ev and ev not in event_ids:
+                    event_ids.append(ev)
+                if fs and fs not in shorts:
+                    shorts.append(fs)
+        if event_ids and shorts:
+            footer_text = " · ".join(event_ids + shorts)
+            print(f"[render] auto-footer from source_tag: {footer_text}", file=sys.stderr)
+
+    # License gate (source_tag v1): warn on any manifest entry that claims
+    # needs-license without supplying attribution. Non-fatal in v1 — operator
+    # gets a stderr line, render continues. Can be made fatal in a later pass.
+    if manifest:
+        for entry in manifest:
+            st = entry.get("source_tag") or {}
+            if isinstance(st, dict) and st.get("license") == "needs-license" and not st.get("attribution"):
+                print(f"[render] WARN license-gate: {entry.get('local_file', '?')} "
+                      f"is `needs-license` with no attribution — fix before publishing",
+                      file=sys.stderr)
+
+    if footer_text:
         for i in range(narration_frame_count):
-            draw_footer_strip(frames_dir / f"frame_{i:03d}.png", args.footer)
+            draw_footer_strip(frames_dir / f"frame_{i:03d}.png", footer_text)
         print(f"[render] footer applied to {narration_frame_count} narrated frames", file=sys.stderr)
 
     # Series signature slate (Mini Wire branding per Chi 2026-05-10).

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -303,21 +303,31 @@ def render_slate_frame(series_title: str, episode: str, date: str, out_path: Pat
     base.save(out_path, "PNG")
 
 
-def synthesize_tts(text: str, out_path: Path, provider: str = "GEMINI"):
-    """Render full narration to mp3. gemini-tts (free) → openai-tts fallback."""
+def synthesize_tts(text: str, out_path: Path, provider: str = "GEMINI",
+                    gemini_voice: str = "Aoede", openai_voice: str = "sage"):
+    """Render full narration to mp3. gemini-tts (free) → openai-tts fallback.
+
+    Voice options:
+      gemini_voice: Aoede (alto/neutral, default), Charon (baritone news-anchor —
+        Susan/Lucy 2026-05-10 finding: matches Mini Wire's news-explainer shape
+        better than Aoede), Kore (mid expressive), Puck (high conversational)
+      openai_voice: sage (default), nova, alloy, etc.
+    """
     repo_root = Path(__file__).resolve().parents[3]
     if provider == "GEMINI":
         gemini_script = repo_root / "skills" / "gemini-tts" / "scripts" / "synthesize.sh"
         if gemini_script.exists():
             try:
-                subprocess.run(["bash", str(gemini_script), "--out", str(out_path), "--", text], check=True)
-                return "GEMINI"
+                subprocess.run(["bash", str(gemini_script), "--voice", gemini_voice,
+                                 "--out", str(out_path), "--", text], check=True)
+                return f"GEMINI:{gemini_voice}"
             except subprocess.CalledProcessError as e:
                 print(f"  [render] gemini-tts failed (exit {e.returncode}); falling back to openai", file=sys.stderr)
     openai_script = repo_root / "skills" / "openai-tts" / "scripts" / "synthesize.sh"
     if openai_script.exists():
-        subprocess.run(["bash", str(openai_script), "--voice", "sage", "--out", str(out_path), "--", text], check=True)
-        return "OPENAI"
+        subprocess.run(["bash", str(openai_script), "--voice", openai_voice,
+                         "--out", str(out_path), "--", text], check=True)
+        return f"OPENAI:{openai_voice}"
     raise RuntimeError("No TTS skill available")
 
 
@@ -411,6 +421,11 @@ def main():
     p = argparse.ArgumentParser(description="Render make-viral-video output")
     p.add_argument("--workdir", required=True, help="state/viral-{ts}/ directory")
     p.add_argument("--tts-provider", default="GEMINI", choices=["GEMINI", "OPENAI"])
+    p.add_argument("--gemini-voice", default="Aoede",
+                   choices=["Aoede", "Charon", "Kore", "Puck"],
+                   help="Gemini TTS voice (Charon is news-anchor baritone).")
+    p.add_argument("--openai-voice", default="sage",
+                   help="OpenAI TTS voice (used only if Gemini fallback path).")
     p.add_argument("--series-title", default="Mini Wire",
                    help="Branded series name shown on the end-card slate (set empty to skip slate).")
     p.add_argument("--episode", default="001", help="Episode number for slate (e.g. '001')")
@@ -507,7 +522,10 @@ def main():
 
     full_narration = " ".join(filter(None, [sections.get("HOOK"), sections.get("SUPPORT"), sections.get("CLOSER")]))
     narration_path = workdir / "narration.mp3"
-    provider_used = synthesize_tts(full_narration, narration_path, provider=args.tts_provider)
+    provider_used = synthesize_tts(full_narration, narration_path,
+                                   provider=args.tts_provider,
+                                   gemini_voice=args.gemini_voice,
+                                   openai_voice=args.openai_voice)
     print(f"[render] narration via {provider_used}", file=sys.stderr)
 
     try:

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -454,17 +454,19 @@ def main():
                 return p
         return hero
 
-    # Default per-section durations (will be scaled to narration length below)
-    HOOK_DUR = 4.0
-    SUPPORT_DUR = 7.0
-    CLOSER_DUR = 4.0
-
-    durations = []
+    # Per-frame durations are allocated PROPORTIONAL to that frame's narration
+    # word count (Mini fix 2026-05-10 after Chi: "initial scene changed
+    # prematurely before narration finished" — earlier code used fixed
+    # HOOK=4 / SUPPORT=7 / CLOSER=4 then uniformly scaled to TTS length,
+    # which under-allocates frames whose text is longer than average).
+    durations = []  # placeholders, filled after TTS via word-share
+    frame_words = []  # parallel: word count of each frame's narration
     frame_idx = 0
 
     if sections.get("HOOK"):
         render_hook_frame(sections["HOOK"], asset_for("hook"), frames_dir / f"frame_{frame_idx:03d}.png")
-        durations.append(HOOK_DUR)
+        durations.append(0.0)
+        frame_words.append(len(sections["HOOK"].split()))
         frame_idx += 1
 
     support_text = sections.get("SUPPORT", "")
@@ -476,14 +478,15 @@ def main():
         if sup_asset:
             render_support_frame(sup_asset, fact, frames_dir / f"frame_{frame_idx:03d}.png", crop_seed=i)
         else:
-            # No asset: render as text-on-black via closer renderer (quote-card shape)
             render_closer_frame(fact, None, frames_dir / f"frame_{frame_idx:03d}.png")
-        durations.append(SUPPORT_DUR)
+        durations.append(0.0)
+        frame_words.append(len(fact.split()))
         frame_idx += 1
 
     if sections.get("CLOSER"):
         render_closer_frame(sections["CLOSER"], asset_for("closer"), frames_dir / f"frame_{frame_idx:03d}.png")
-        durations.append(CLOSER_DUR)
+        durations.append(0.0)
+        frame_words.append(len(sections["CLOSER"].split()))
         frame_idx += 1
 
     # Track narration-mapped frame count BEFORE adding the slate. The slate
@@ -497,18 +500,16 @@ def main():
         slate_date = args.date or datetime.now().strftime("%Y.%m.%d")
         render_slate_frame(args.series_title, args.episode, slate_date,
                            frames_dir / f"frame_{frame_idx:03d}.png")
-        durations.append(args.slate_duration)
+        durations.append(args.slate_duration)  # slate gets fixed duration, not narration-proportional
+        frame_words.append(0)  # no narration on slate
         frame_idx += 1
         print(f"[render] added slate: {args.series_title} ep.{args.episode} {slate_date}", file=sys.stderr)
-
-    print(f"[render] {frame_idx} frames, planned duration {sum(durations):.1f}s", file=sys.stderr)
 
     full_narration = " ".join(filter(None, [sections.get("HOOK"), sections.get("SUPPORT"), sections.get("CLOSER")]))
     narration_path = workdir / "narration.mp3"
     provider_used = synthesize_tts(full_narration, narration_path, provider=args.tts_provider)
     print(f"[render] narration via {provider_used}", file=sys.stderr)
 
-    # Scale frame durations to match actual narration length
     try:
         probe = subprocess.run(
             ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", str(narration_path)],
@@ -516,14 +517,26 @@ def main():
         )
         narration_dur = float(json.loads(probe.stdout).get("format", {}).get("duration", 0))
     except Exception as e:
-        print(f"[render] ffprobe on narration failed ({e}); using planned durations", file=sys.stderr)
-        narration_dur = sum(durations[:narration_frame_count])
+        print(f"[render] ffprobe on narration failed ({e}); fallback to 36s", file=sys.stderr)
+        narration_dur = 36.0
 
-    narrated_planned = sum(durations[:narration_frame_count])
-    if narration_dur > 0 and abs(narration_dur - narrated_planned) > 1.0:
-        scale = narration_dur / narrated_planned
-        durations = [d * scale for d in durations[:narration_frame_count]] + durations[narration_frame_count:]
-        print(f"[render] scaled narrated durations by {scale:.2f}x (slate kept at {durations[narration_frame_count] if narration_frame_count < len(durations) else 0:.1f}s)", file=sys.stderr)
+    # Allocate narration_dur across narrated frames PROPORTIONAL TO WORD COUNT.
+    # Each frame is on-screen for the time its text is being narrated. A frame
+    # with 22 words gets ~22/total_words × narration_dur. Slate (0 words, set
+    # earlier to args.slate_duration) is left unchanged.
+    narrated_words_total = sum(frame_words[:narration_frame_count])
+    if narrated_words_total > 0 and narration_dur > 0:
+        for i in range(narration_frame_count):
+            durations[i] = narration_dur * (frame_words[i] / narrated_words_total)
+        print(f"[render] word-share durations: " +
+              " ".join(f"{frame_words[i]}w→{durations[i]:.1f}s" for i in range(narration_frame_count)),
+              file=sys.stderr)
+    else:
+        # Fallback if no narration: keep stub durations
+        for i in range(narration_frame_count):
+            durations[i] = narration_dur / max(narration_frame_count, 1)
+
+    print(f"[render] total: {sum(durations):.1f}s ({narration_dur:.1f}s narration + {sum(durations[narration_frame_count:]):.1f}s slate)", file=sys.stderr)
 
     # Pre-render each frame as a Ken-Burns clip
     clip_paths = []

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -197,8 +197,15 @@ def render_hook_frame(text: str, hero_path: Optional[Path], out_path: Path):
     base.save(out_path, "PNG")
 
 
-def render_support_frame(hero_path: Path, caption: str, out_path: Path, crop_seed: int = 0):
-    """Hero image with crop variation + semi-transparent caption strip overlay."""
+def render_support_frame(hero_path: Path, caption: str, out_path: Path,
+                          crop_seed: int = 0, badge: str = ""):
+    """Hero image with crop variation + caption strip + optional name badge.
+
+    If `badge` is non-empty, draws a styled name-chip in the top-left of the
+    frame (e.g. "HARRISON SCHMITT"). Per Lucy's v1.7 design: when the bg image
+    is a person's portrait, the badge anchors who's on screen for viewers
+    who joined mid-scroll. Free-text — caller controls the wording.
+    """
     from PIL import Image, ImageDraw
     bg = hero_bg(hero_path, dim_alpha=70).convert("RGB")
     overlay = Image.new("RGBA", (CANVAS_W, CANVAS_H), (0, 0, 0, 0))
@@ -214,6 +221,19 @@ def render_support_frame(hero_path: Path, caption: str, out_path: Path, crop_see
     for line in lines:
         draw.text((40, y), line, fill=TEXT, font=cap_font)
         y += 48
+
+    # Top-left name badge (e.g. "HARRISON SCHMITT") in brand-red chip
+    if badge:
+        badge_text = badge.upper()
+        badge_font = get_font(28)
+        bbb = draw.textbbox((0, 0), badge_text, font=badge_font)
+        bw = bbb[2] - bbb[0]
+        bh = bbb[3] - bbb[1]
+        pad_x, pad_y = 18, 12
+        chip_w = bw + pad_x * 2
+        chip_h = bh + pad_y * 2 + 6
+        draw.rectangle([(40, 40), (40 + chip_w, 40 + chip_h)], fill=ACCENT)
+        draw.text((40 + pad_x, 40 + pad_y), badge_text, fill=TEXT, font=badge_font)
 
     out = Image.alpha_composite(bg.convert("RGBA"), overlay).convert("RGB")
     out.save(out_path, "PNG")
@@ -470,18 +490,20 @@ def main():
     print(f"[render] hero (fallback): {hero}", file=sys.stderr)
 
     def asset_for(purpose: str, idx: int = 0):
+        """Return (Path, manifest_entry) for the requested purpose+idx, or
+        (hero, None) on fallback. Manifest entry exposes badge / alt / etc."""
         matches = [m for m in manifest if m.get("purpose") == purpose]
+        entry = None
         if purpose == "support" and idx < len(matches):
-            target = matches[idx].get("local_file") or matches[idx].get("url", "").split("/")[-1]
-            p = fetched / target
-            if p.is_file():
-                return p
+            entry = matches[idx]
         elif purpose != "support" and matches:
-            target = matches[0].get("local_file") or matches[0].get("url", "").split("/")[-1]
+            entry = matches[0]
+        if entry:
+            target = entry.get("local_file") or entry.get("url", "").split("/")[-1]
             p = fetched / target
             if p.is_file():
-                return p
-        return hero
+                return p, entry
+        return hero, None
 
     # Per-frame durations are allocated PROPORTIONAL to that frame's narration
     # word count (Mini fix 2026-05-10 after Chi: "initial scene changed
@@ -493,7 +515,8 @@ def main():
     frame_idx = 0
 
     if sections.get("HOOK"):
-        render_hook_frame(sections["HOOK"], asset_for("hook"), frames_dir / f"frame_{frame_idx:03d}.png")
+        hook_path, _ = asset_for("hook")
+        render_hook_frame(sections["HOOK"], hook_path, frames_dir / f"frame_{frame_idx:03d}.png")
         durations.append(0.0)
         frame_words.append(len(sections["HOOK"].split()))
         frame_idx += 1
@@ -503,9 +526,11 @@ def main():
     support_facts = [f for f in support_facts if f.strip()]
 
     for i, fact in enumerate(support_facts):
-        sup_asset = asset_for("support", i)
+        sup_asset, sup_entry = asset_for("support", i)
         if sup_asset:
-            render_support_frame(sup_asset, fact, frames_dir / f"frame_{frame_idx:03d}.png", crop_seed=i)
+            badge = (sup_entry.get("badge", "") if sup_entry else "")
+            render_support_frame(sup_asset, fact, frames_dir / f"frame_{frame_idx:03d}.png",
+                                  crop_seed=i, badge=badge)
         else:
             render_closer_frame(fact, None, frames_dir / f"frame_{frame_idx:03d}.png")
         durations.append(0.0)
@@ -513,7 +538,8 @@ def main():
         frame_idx += 1
 
     if sections.get("CLOSER"):
-        render_closer_frame(sections["CLOSER"], asset_for("closer"), frames_dir / f"frame_{frame_idx:03d}.png")
+        closer_path, _ = asset_for("closer")
+        render_closer_frame(sections["CLOSER"], closer_path, frames_dir / f"frame_{frame_idx:03d}.png")
         durations.append(0.0)
         frame_words.append(len(sections["CLOSER"].split()))
         frame_idx += 1

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Frame composition + ffmpeg encode for make-viral-video skill — phase 5.
+
+Reads:
+  - {workdir}/artifacts/final_script.md   (HOOK / SUPPORT / CLOSER sections)
+  - {workdir}/artifacts/asset_manifest.json
+  - {workdir}/fetched_assets/*.png
+
+Produces:
+  - {workdir}/frames/                     (PIL-rendered frames)
+  - {workdir}/narration.mp3               (TTS, gemini default → openai fallback)
+  - {workdir}/video.mp4                   (h264 + aac, 1280×720)
+
+Visual rules per SKILL.md:
+  - HOOK card (3s): single bold claim, ≥120pt, brand-color background
+  - SUPPORT cards (per-fact, ~5-8s each): real fetched image fills frame +
+    semi-transparent caption strip with one attributable fact
+  - CLOSER card (3-5s): share-moment text on solid background
+
+ffmpeg encoder concatenates frames at fixed FPS, overlays narration audio.
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CANVAS_W, CANVAS_H = 1280, 720
+FPS = 30
+HOOK_DURATION_S = 3.0
+SUPPORT_DURATION_S = 6.0
+CLOSER_DURATION_S = 4.0
+
+# Brand colors (kept simple — black + accent)
+BG = (10, 10, 14)        # near-black
+ACCENT = (220, 56, 76)   # red-ish for hook badge
+TEXT = (240, 240, 240)
+CAPTION_BG = (0, 0, 0, 180)  # semi-transparent black for caption strips
+
+
+def parse_script(script_md: str):
+    """Parse final_script.md into HOOK/SUPPORT/CLOSER sections.
+
+    Accepts two shapes:
+      a) Section headers like "## HOOK" or "**Hook:**"
+      b) Single paragraph (Lucy's v12 shape) — fall back to splitting on sentences
+    """
+    sections = {"HOOK": [], "SUPPORT": [], "CLOSER": []}
+
+    # Shape (a): explicit section headers
+    current = None
+    section_re = re.compile(r"^\s*(?:##|##|\*\*|\#)\s*(HOOK|SUPPORT|CLOSER)\b", re.IGNORECASE)
+    for line in script_md.splitlines():
+        m = section_re.match(line)
+        if m:
+            current = m.group(1).upper()
+            continue
+        if current and line.strip():
+            sections[current].append(line.strip())
+
+    if any(sections.values()):
+        return {k: " ".join(v).strip() for k, v in sections.items() if v}
+
+    # Shape (b) fallback: split paragraph into hook=first-sentence, closer=last,
+    # support=middle. Best-effort for back-compat with Lucy's v12 output.
+    text = script_md.strip()
+    sentences = re.split(r"(?<=[.!?])\s+", text)
+    if len(sentences) >= 3:
+        return {
+            "HOOK": sentences[0],
+            "SUPPORT": " ".join(sentences[1:-1]),
+            "CLOSER": sentences[-1],
+        }
+    return {"HOOK": text, "SUPPORT": "", "CLOSER": ""}
+
+
+def render_hook_frame(text: str, out_path: Path):
+    """One frame: bold claim centered on dark bg with accent corner badge."""
+    from PIL import Image, ImageDraw, ImageFont
+    img = Image.new("RGB", (CANVAS_W, CANVAS_H), BG)
+    draw = ImageDraw.Draw(img)
+
+    # Try to find a system font; fall back gracefully
+    font_paths = [
+        "/System/Library/Fonts/Helvetica.ttc",
+        "/System/Library/Fonts/HelveticaNeue.ttc",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    ]
+    font = None
+    size = 64
+    for fp in font_paths:
+        if Path(fp).exists():
+            try:
+                font = ImageFont.truetype(fp, size)
+                break
+            except Exception:
+                pass
+    if font is None:
+        font = ImageFont.load_default()
+
+    # Word-wrap the hook text
+    words = text.split()
+    lines, current = [], ""
+    max_chars_per_line = 30
+    for w in words:
+        if len(current) + len(w) + 1 <= max_chars_per_line:
+            current = (current + " " + w).strip()
+        else:
+            lines.append(current)
+            current = w
+    if current:
+        lines.append(current)
+
+    line_h = size + 10
+    total_h = len(lines) * line_h
+    y = (CANVAS_H - total_h) // 2
+    for line in lines:
+        bbox = draw.textbbox((0, 0), line, font=font)
+        line_w = bbox[2] - bbox[0]
+        x = (CANVAS_W - line_w) // 2
+        draw.text((x, y), line, fill=TEXT, font=font)
+        y += line_h
+
+    # Accent badge top-left
+    draw.rectangle([(40, 40), (160, 90)], fill=ACCENT)
+    badge_font = ImageFont.truetype(font_paths[0], 24) if font_paths and Path(font_paths[0]).exists() else font
+    draw.text((58, 52), "BREAKING", fill=TEXT, font=badge_font)
+
+    img.save(out_path, "PNG")
+
+
+def render_support_frame(image_path: Path, caption: str, out_path: Path):
+    """Real fetched image fills frame; semi-transparent caption strip overlays bottom."""
+    from PIL import Image, ImageDraw, ImageFont
+    bg = Image.open(image_path).convert("RGB")
+    bg = bg.resize((CANVAS_W, CANVAS_H), Image.LANCZOS)
+
+    # Caption strip
+    overlay = Image.new("RGBA", (CANVAS_W, CANVAS_H), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(overlay)
+    strip_h = 140
+    draw.rectangle([(0, CANVAS_H - strip_h), (CANVAS_W, CANVAS_H)], fill=CAPTION_BG)
+
+    font_path = "/System/Library/Fonts/Helvetica.ttc"
+    try:
+        cap_font = ImageFont.truetype(font_path, 36)
+    except Exception:
+        cap_font = ImageFont.load_default()
+
+    # Wrap caption to ≤80 chars/line, ≤2 lines
+    words = caption.split()
+    lines, current = [], ""
+    for w in words:
+        if len(current) + len(w) + 1 <= 80:
+            current = (current + " " + w).strip()
+        else:
+            lines.append(current)
+            current = w
+    if current:
+        lines.append(current)
+    lines = lines[:2]
+
+    y = CANVAS_H - strip_h + 20
+    for line in lines:
+        draw.text((40, y), line, fill=TEXT, font=cap_font)
+        y += 50
+
+    out = Image.alpha_composite(bg.convert("RGBA"), overlay).convert("RGB")
+    out.save(out_path, "PNG")
+
+
+def render_closer_frame(text: str, out_path: Path):
+    """Closer = share-moment text on solid bg, slightly larger than support captions."""
+    from PIL import Image, ImageDraw, ImageFont
+    img = Image.new("RGB", (CANVAS_W, CANVAS_H), BG)
+    draw = ImageDraw.Draw(img)
+    font_path = "/System/Library/Fonts/Helvetica.ttc"
+    try:
+        font = ImageFont.truetype(font_path, 56)
+    except Exception:
+        font = ImageFont.load_default()
+
+    words = text.split()
+    lines, current = [], ""
+    for w in words:
+        if len(current) + len(w) + 1 <= 35:
+            current = (current + " " + w).strip()
+        else:
+            lines.append(current)
+            current = w
+    if current:
+        lines.append(current)
+
+    line_h = 70
+    total_h = len(lines) * line_h
+    y = (CANVAS_H - total_h) // 2
+    for line in lines:
+        bbox = draw.textbbox((0, 0), line, font=font)
+        line_w = bbox[2] - bbox[0]
+        x = (CANVAS_W - line_w) // 2
+        draw.text((x, y), line, fill=TEXT, font=font)
+        y += line_h
+
+    img.save(out_path, "PNG")
+
+
+def synthesize_tts(text: str, out_path: Path, provider: str = "GEMINI"):
+    """Render full narration to mp3. Tries gemini-tts (free) → openai-tts (paid)."""
+    repo_root = Path(__file__).resolve().parents[3]
+    if provider == "GEMINI":
+        gemini_script = repo_root / "skills" / "gemini-tts" / "scripts" / "synthesize.sh"
+        if gemini_script.exists():
+            try:
+                subprocess.run(["bash", str(gemini_script), "--out", str(out_path), "--", text], check=True)
+                return "GEMINI"
+            except subprocess.CalledProcessError as e:
+                print(f"  [render] gemini-tts failed (exit {e.returncode}); falling back to openai", file=sys.stderr)
+    # OpenAI fallback
+    openai_script = repo_root / "skills" / "openai-tts" / "scripts" / "synthesize.sh"
+    if openai_script.exists():
+        subprocess.run(["bash", str(openai_script), "--voice", "sage", "--out", str(out_path), "--", text], check=True)
+        return "OPENAI"
+    raise RuntimeError("No TTS skill available")
+
+
+def encode_video(frames_dir: Path, narration_path: Path, durations_s: list, out_path: Path):
+    """Concat frames at fixed durations, overlay narration audio. Uses ffmpeg concat demuxer."""
+    # Build concat list file
+    concat_list = frames_dir / "concat.txt"
+    with open(concat_list, "w") as f:
+        for frame, dur in zip(sorted(frames_dir.glob("frame_*.png")), durations_s):
+            f.write(f"file '{frame.resolve()}'\n")
+            f.write(f"duration {dur}\n")
+        # ffmpeg concat demuxer requires the last file repeated without duration
+        last = sorted(frames_dir.glob("frame_*.png"))[-1]
+        f.write(f"file '{last.resolve()}'\n")
+
+    cmd = [
+        "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+        "-f", "concat", "-safe", "0", "-i", str(concat_list),
+        "-i", str(narration_path),
+        "-c:v", "libx264", "-pix_fmt", "yuv420p",
+        "-c:a", "aac", "-b:a", "128k",
+        "-r", str(FPS),
+        "-shortest",
+        str(out_path),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def main():
+    p = argparse.ArgumentParser(description="Render make-viral-video output")
+    p.add_argument("--workdir", required=True, help="state/viral-{ts}/ directory")
+    p.add_argument("--tts-provider", default="GEMINI", choices=["GEMINI", "OPENAI"])
+    args = p.parse_args()
+
+    workdir = Path(args.workdir)
+    artifacts = workdir / "artifacts"
+    fetched = workdir / "fetched_assets"
+    frames_dir = workdir / "frames"
+    frames_dir.mkdir(parents=True, exist_ok=True)
+
+    script_md = (artifacts / "final_script.md").read_text()
+    sections = parse_script(script_md)
+    print(f"[render] sections: {list(sections.keys())}", file=sys.stderr)
+
+    manifest_path = artifacts / "asset_manifest.json"
+    manifest = json.loads(manifest_path.read_text()) if manifest_path.exists() else []
+
+    # Frame plan
+    durations = []
+    frame_idx = 0
+
+    # HOOK
+    if sections.get("HOOK"):
+        render_hook_frame(sections["HOOK"], frames_dir / f"frame_{frame_idx:03d}.png")
+        durations.append(HOOK_DURATION_S)
+        frame_idx += 1
+
+    # SUPPORT — one frame per asset in manifest, captioned with the support text
+    support_text = sections.get("SUPPORT", "")
+    support_facts = re.split(r"(?<=[.!?])\s+", support_text) if support_text else []
+    support_assets = [m for m in manifest if m.get("purpose") == "support"]
+    if not support_assets:
+        # Fallback: use any non-hook/closer assets
+        support_assets = [m for m in manifest if m.get("purpose") not in ("hook", "closer")]
+
+    for i, fact in enumerate(support_facts[:len(support_assets) or 1]):
+        if i < len(support_assets):
+            asset_url = support_assets[i].get("url", "")
+            # Map URL to local file by basename matching fetched_assets/
+            local_assets = list(fetched.glob("*"))
+            best = None
+            for la in local_assets:
+                if la.name in asset_url or asset_url.endswith(la.name):
+                    best = la
+                    break
+            if best is None and local_assets:
+                best = local_assets[i % len(local_assets)]
+            if best:
+                render_support_frame(best, fact, frames_dir / f"frame_{frame_idx:03d}.png")
+                durations.append(SUPPORT_DURATION_S)
+                frame_idx += 1
+
+    # CLOSER
+    if sections.get("CLOSER"):
+        render_closer_frame(sections["CLOSER"], frames_dir / f"frame_{frame_idx:03d}.png")
+        durations.append(CLOSER_DURATION_S)
+        frame_idx += 1
+
+    print(f"[render] {frame_idx} frames, total duration {sum(durations):.1f}s", file=sys.stderr)
+
+    # TTS the full script (HOOK + SUPPORT + CLOSER concatenated)
+    full_narration = " ".join(filter(None, [sections.get("HOOK"), sections.get("SUPPORT"), sections.get("CLOSER")]))
+    narration_path = workdir / "narration.mp3"
+    provider_used = synthesize_tts(full_narration, narration_path, provider=args.tts_provider)
+    print(f"[render] narration via {provider_used}", file=sys.stderr)
+
+    # Encode
+    out = workdir / "video.mp4"
+    encode_video(frames_dir, narration_path, durations, out)
+    print(f"[render] {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -239,6 +239,35 @@ def render_support_frame(hero_path: Path, caption: str, out_path: Path,
     out.save(out_path, "PNG")
 
 
+def draw_footer_strip(frame_path: Path, footer_text: str):
+    """Open a rendered frame PNG, draw a thin lower-strip with footer_text,
+    re-save in place. Persistent footer for event-ID anchoring per Lucy v1.7
+    pattern. Skipped silently if footer_text is empty.
+
+    Preserves the input mode (RGB for still frames; RGBA for video-overlay
+    frames — so the overlay's transparent regions stay transparent and only
+    the footer strip becomes opaque).
+    """
+    if not footer_text:
+        return
+    from PIL import Image, ImageDraw
+    img = Image.open(frame_path)
+    src_mode = img.mode
+    img = img.convert("RGBA")
+    overlay = Image.new("RGBA", img.size, (0, 0, 0, 0))
+    draw = ImageDraw.Draw(overlay)
+    strip_h = 32
+    draw.rectangle([(0, img.size[1] - strip_h), (img.size[0], img.size[1])],
+                   fill=(0, 0, 0, 200))
+    fnt = get_font(20)
+    draw.text((20, img.size[1] - strip_h + 6), footer_text, fill=(220, 220, 220), font=fnt)
+    out = Image.alpha_composite(img, overlay)
+    # Preserve original mode — RGB for stills, RGBA for video-overlays
+    if src_mode != "RGBA":
+        out = out.convert(src_mode)
+    out.save(frame_path, "PNG")
+
+
 def render_video_overlay(caption: str, out_path: Path, badge: str = ""):
     """Transparent-bg PNG used as overlay on a video clip. Contains the bottom
     caption strip + optional top-left name-chip — same layout as the still
@@ -530,6 +559,10 @@ def main():
                    help="Optional byline shown between title and ep/date (e.g. 'by Echo Act IV · Sutando'). "
                         "Empty string omits the byline. Free-text — caller controls identity wording.")
     p.add_argument("--slate-duration", type=float, default=2.0, help="End-card slate duration (s)")
+    p.add_argument("--footer", default="",
+                   help="Optional persistent footer text drawn on every narrated frame (small lower-strip). "
+                        "Free-text — e.g. 'pursue-release-01 · Apollo 17 / 1972 · wind farm / 2024'. "
+                        "Anchors viewers in the event-ID across the whole video. Per Lucy v1.7 pattern. Empty = no footer.")
     args = p.parse_args()
 
     workdir = Path(args.workdir)
@@ -625,6 +658,14 @@ def main():
     # is silent (extends video beyond TTS) and must NOT be scaled to fit
     # narration duration. Only durations[:narration_frame_count] get scaled.
     narration_frame_count = frame_idx
+
+    # Apply persistent footer to all narrated frames (skipped on slate).
+    # Per Lucy v1.7 pattern: small lower-strip with event-ID anchor on every
+    # narrated frame. Skipped silently if --footer is empty.
+    if args.footer:
+        for i in range(narration_frame_count):
+            draw_footer_strip(frames_dir / f"frame_{i:03d}.png", args.footer)
+        print(f"[render] footer applied to {narration_frame_count} narrated frames", file=sys.stderr)
 
     # Series signature slate (Mini Wire branding per Chi 2026-05-10).
     if args.series_title:

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -305,11 +305,18 @@ def kenburns_clip(frame_path: Path, duration_s: float, clip_idx: int, clip_path:
         f"d={total_frames}:s={CANVAS_W}x{CANVAS_H}:fps={FPS}"
     )
 
+    # CRITICAL: -t goes at the OUTPUT, not the input. Input -t with -loop 1 + zoompan
+    # causes zoompan to fire per-input-frame, producing duration*fps output frames
+    # PER input frame (so a 4s clip ended up 400s). With -t at output, zoompan
+    # uses the d=total_frames as the motion span, and -t clips the encode to
+    # exactly duration_s. Bug caught 2026-05-10 after re-run 5 sampled frames
+    # showed only the HOOK across the whole 36s video.
     cmd = [
         "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
-        "-loop", "1", "-t", f"{duration_s:.3f}", "-i", str(frame_path),
+        "-loop", "1", "-i", str(frame_path),
         "-vf", vf,
         "-c:v", "libx264", "-pix_fmt", "yuv420p", "-r", str(FPS),
+        "-t", f"{duration_s:.3f}",
         "-an",
         str(clip_path),
     ]

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -259,6 +259,50 @@ def render_closer_frame(text: str, hero_path: Optional[Path], out_path: Path):
     base.save(out_path, "PNG")
 
 
+def render_slate_frame(series_title: str, episode: str, date: str, out_path: Path):
+    """Series signature slate — 2s end card. Black bg, large brand-red wordmark,
+    small episode + date subtitle. Mini Wire branding per Chi 2026-05-10.
+
+    Layout:
+        [vertical center]
+        SERIES TITLE         ← large, brand red, bold
+        ep. NNN · YYYY.MM.DD ← smaller, white
+    """
+    from PIL import Image, ImageDraw
+    base = Image.new("RGB", (CANVAS_W, CANVAS_H), BG)
+    draw = ImageDraw.Draw(base)
+
+    title_font = get_font(120)
+    sub_font = get_font(36)
+
+    title_text = series_title.upper()
+    sub_text = f"ep. {episode} · {date}"
+
+    # Title bbox
+    tbb = draw.textbbox((0, 0), title_text, font=title_font)
+    tw = tbb[2] - tbb[0]
+    th = tbb[3] - tbb[1]
+    # Subtitle bbox
+    sbb = draw.textbbox((0, 0), sub_text, font=sub_font)
+    sw = sbb[2] - sbb[0]
+    sh = sbb[3] - sbb[1]
+
+    gap = 30
+    total_h = th + gap + sh
+    y_title = (CANVAS_H - total_h) // 2
+
+    # Title in brand red
+    x_title = (CANVAS_W - tw) // 2
+    draw.text((x_title, y_title), title_text, fill=ACCENT, font=title_font)
+
+    # Subtitle in white
+    y_sub = y_title + th + gap
+    x_sub = (CANVAS_W - sw) // 2
+    draw.text((x_sub, y_sub), sub_text, fill=TEXT, font=sub_font)
+
+    base.save(out_path, "PNG")
+
+
 def synthesize_tts(text: str, out_path: Path, provider: str = "GEMINI"):
     """Render full narration to mp3. gemini-tts (free) → openai-tts fallback."""
     repo_root = Path(__file__).resolve().parents[3]
@@ -323,28 +367,41 @@ def kenburns_clip(frame_path: Path, duration_s: float, clip_idx: int, clip_path:
     subprocess.run(cmd, check=True)
 
 
-def concat_clips_with_audio(clip_paths: list, narration_path: Path, out_path: Path):
-    """Concat per-frame clips and overlay narration audio. Output -t = narration_dur."""
+def concat_clips_with_audio(clip_paths: list, narration_path: Path, out_path: Path,
+                             extra_silent_tail_s: float = 0.0):
+    """Concat per-frame clips, overlay narration audio. Output duration =
+    narration_dur + extra_silent_tail_s (slate gets a silent tail).
+
+    Without extra_silent_tail_s the video clips at narration end (TTS finishes,
+    clips truncate at -t). With extra_silent_tail_s we extend video by exactly
+    that much past the narration, leaving the final frame (slate) visible
+    in silence.
+    """
     probe = subprocess.run(
         ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", str(narration_path)],
         capture_output=True, text=True, check=True,
     )
     narration_dur = float(json.loads(probe.stdout).get("format", {}).get("duration", 0) or 0)
+    total_dur = narration_dur + extra_silent_tail_s
 
     concat_list = clip_paths[0].parent / "concat.txt"
     with open(concat_list, "w") as f:
         for cp in clip_paths:
             f.write(f"file '{cp.resolve()}'\n")
 
+    # Pad audio with silence so AV streams stay synced through the slate.
+    # apad=pad_dur=<extra> appends silence; -t clips total to total_dur.
+    audio_filter = ["-af", f"apad=pad_dur={extra_silent_tail_s:.3f}"] if extra_silent_tail_s > 0 else []
+
     cmd = [
         "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
         "-f", "concat", "-safe", "0", "-i", str(concat_list),
         "-i", str(narration_path),
+        *audio_filter,
         "-c:v", "libx264", "-pix_fmt", "yuv420p",
         "-c:a", "aac", "-b:a", "128k",
         "-r", str(FPS),
-        "-t", f"{narration_dur:.3f}",
-        "-shortest",
+        "-t", f"{total_dur:.3f}",
         str(out_path),
     ]
     subprocess.run(cmd, check=True)
@@ -354,6 +411,11 @@ def main():
     p = argparse.ArgumentParser(description="Render make-viral-video output")
     p.add_argument("--workdir", required=True, help="state/viral-{ts}/ directory")
     p.add_argument("--tts-provider", default="GEMINI", choices=["GEMINI", "OPENAI"])
+    p.add_argument("--series-title", default="Mini Wire",
+                   help="Branded series name shown on the end-card slate (set empty to skip slate).")
+    p.add_argument("--episode", default="001", help="Episode number for slate (e.g. '001')")
+    p.add_argument("--date", default=None, help="Date for slate (YYYY.MM.DD); defaults to today")
+    p.add_argument("--slate-duration", type=float, default=2.0, help="End-card slate duration (s)")
     args = p.parse_args()
 
     workdir = Path(args.workdir)
@@ -424,6 +486,21 @@ def main():
         durations.append(CLOSER_DUR)
         frame_idx += 1
 
+    # Track narration-mapped frame count BEFORE adding the slate. The slate
+    # is silent (extends video beyond TTS) and must NOT be scaled to fit
+    # narration duration. Only durations[:narration_frame_count] get scaled.
+    narration_frame_count = frame_idx
+
+    # Series signature slate (Mini Wire branding per Chi 2026-05-10).
+    if args.series_title:
+        from datetime import datetime
+        slate_date = args.date or datetime.now().strftime("%Y.%m.%d")
+        render_slate_frame(args.series_title, args.episode, slate_date,
+                           frames_dir / f"frame_{frame_idx:03d}.png")
+        durations.append(args.slate_duration)
+        frame_idx += 1
+        print(f"[render] added slate: {args.series_title} ep.{args.episode} {slate_date}", file=sys.stderr)
+
     print(f"[render] {frame_idx} frames, planned duration {sum(durations):.1f}s", file=sys.stderr)
 
     full_narration = " ".join(filter(None, [sections.get("HOOK"), sections.get("SUPPORT"), sections.get("CLOSER")]))
@@ -440,12 +517,13 @@ def main():
         narration_dur = float(json.loads(probe.stdout).get("format", {}).get("duration", 0))
     except Exception as e:
         print(f"[render] ffprobe on narration failed ({e}); using planned durations", file=sys.stderr)
-        narration_dur = sum(durations)
+        narration_dur = sum(durations[:narration_frame_count])
 
-    if narration_dur > 0 and abs(narration_dur - sum(durations)) > 1.0:
-        scale = narration_dur / sum(durations)
-        durations = [d * scale for d in durations]
-        print(f"[render] scaled durations by {scale:.2f}x to match narration {narration_dur:.1f}s", file=sys.stderr)
+    narrated_planned = sum(durations[:narration_frame_count])
+    if narration_dur > 0 and abs(narration_dur - narrated_planned) > 1.0:
+        scale = narration_dur / narrated_planned
+        durations = [d * scale for d in durations[:narration_frame_count]] + durations[narration_frame_count:]
+        print(f"[render] scaled narrated durations by {scale:.2f}x (slate kept at {durations[narration_frame_count] if narration_frame_count < len(durations) else 0:.1f}s)", file=sys.stderr)
 
     # Pre-render each frame as a Ken-Burns clip
     clip_paths = []
@@ -456,7 +534,9 @@ def main():
     print(f"[render] {len(clip_paths)} Ken-Burns clips", file=sys.stderr)
 
     out = workdir / "video.mp4"
-    concat_clips_with_audio(clip_paths, narration_path, out)
+    # Slate (if present) extends video duration past narration by slate_duration.
+    extra_tail = args.slate_duration if args.series_title else 0.0
+    concat_clips_with_audio(clip_paths, narration_path, out, extra_silent_tail_s=extra_tail)
     print(f"[render] {out}")
     return 0
 

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -8,16 +8,20 @@ Reads:
 
 Produces:
   - {workdir}/frames/                     (PIL-rendered frames)
+  - {workdir}/clips/                      (per-frame mp4s with Ken-Burns motion)
   - {workdir}/narration.mp3               (TTS, gemini default → openai fallback)
   - {workdir}/video.mp4                   (h264 + aac, 1280×720)
 
 Visual rules per SKILL.md:
-  - HOOK card (3s): single bold claim, ≥120pt, brand-color background
-  - SUPPORT cards (per-fact, ~5-8s each): real fetched image fills frame +
-    semi-transparent caption strip with one attributable fact
-  - CLOSER card (3-5s): share-moment text on solid background
+  - HOOK card: hero image as bg, dimmed; bold claim overlay; BREAKING badge
+  - SUPPORT cards: hero image (cropped/zoomed differently per fact) + caption strip
+  - CLOSER card: hero image dimmed + share-shape line overlay
 
-ffmpeg encoder concatenates frames at fixed FPS, overlays narration audio.
+Phase 1 v2 (2026-05-10, Chi A+C feedback): hero image is now used as visual
+spine — previously, real images were tagged purpose=hook in the manifest but
+the renderer ignored them and produced text-on-black for hook+closer, while
+support frames rendered PIL data-cards instead of the real photo. Per Chi:
+"bare PIL cards, no motion, no real imagery."
 """
 import argparse
 import json
@@ -25,30 +29,40 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import Optional
 
 CANVAS_W, CANVAS_H = 1280, 720
 FPS = 30
-HOOK_DURATION_S = 3.0
-SUPPORT_DURATION_S = 6.0
-CLOSER_DURATION_S = 4.0
 
-# Brand colors (kept simple — black + accent)
-BG = (10, 10, 14)        # near-black
+# Brand colors
+BG = (10, 10, 14)        # near-black fallback
 ACCENT = (220, 56, 76)   # red-ish for hook badge
 TEXT = (240, 240, 240)
-CAPTION_BG = (0, 0, 0, 180)  # semi-transparent black for caption strips
+CAPTION_BG = (0, 0, 0, 180)
+DARKEN_OVERLAY = (0, 0, 0, 110)  # for text-on-image readability
+
+FONT_PATHS = [
+    "/System/Library/Fonts/Helvetica.ttc",
+    "/System/Library/Fonts/HelveticaNeue.ttc",
+    "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+]
+
+
+def get_font(size: int):
+    from PIL import ImageFont
+    for fp in FONT_PATHS:
+        if Path(fp).exists():
+            try:
+                return ImageFont.truetype(fp, size)
+            except Exception:
+                pass
+    return ImageFont.load_default()
 
 
 def parse_script(script_md: str):
-    """Parse final_script.md into HOOK/SUPPORT/CLOSER sections.
-
-    Accepts two shapes:
-      a) Section headers like "## HOOK" or "**Hook:**"
-      b) Single paragraph (Lucy's v12 shape) — fall back to splitting on sentences
-    """
+    """Parse final_script.md into HOOK/SUPPORT/CLOSER sections."""
     sections = {"HOOK": [], "SUPPORT": [], "CLOSER": []}
-
-    # Shape (a): explicit section headers
     current = None
     section_re = re.compile(r"^\s*(?:##|##|\*\*|\#)\s*(HOOK|SUPPORT|CLOSER)\b", re.IGNORECASE)
     for line in script_md.splitlines():
@@ -58,12 +72,8 @@ def parse_script(script_md: str):
             continue
         if current and line.strip():
             sections[current].append(line.strip())
-
     if any(sections.values()):
         return {k: " ".join(v).strip() for k, v in sections.items() if v}
-
-    # Shape (b) fallback: split paragraph into hook=first-sentence, closer=last,
-    # support=middle. Best-effort for back-compat with Lucy's v12 output.
     text = script_md.strip()
     sentences = re.split(r"(?<=[.!?])\s+", text)
     if len(sentences) >= 3:
@@ -75,34 +85,20 @@ def parse_script(script_md: str):
     return {"HOOK": text, "SUPPORT": "", "CLOSER": ""}
 
 
-def render_hook_frame(text: str, out_path: Path):
-    """One frame: bold claim centered on dark bg with accent corner badge."""
-    from PIL import Image, ImageDraw, ImageFont
-    img = Image.new("RGB", (CANVAS_W, CANVAS_H), BG)
-    draw = ImageDraw.Draw(img)
-
-    # Try to find a system font; fall back gracefully
-    font_paths = [
-        "/System/Library/Fonts/Helvetica.ttc",
-        "/System/Library/Fonts/HelveticaNeue.ttc",
-        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+def find_hero_image(fetched: Path):
+    """Return the real-photo hero image. Filters out data-card-*.jpg/png
+    (PIL-generated text panels — not real imagery)."""
+    candidates = [
+        p for p in fetched.glob("*")
+        if p.is_file() and not p.name.startswith("data-card-")
+        and p.suffix.lower() in (".jpg", ".jpeg", ".png", ".webp")
     ]
-    font = None
-    size = 64
-    for fp in font_paths:
-        if Path(fp).exists():
-            try:
-                font = ImageFont.truetype(fp, size)
-                break
-            except Exception:
-                pass
-    if font is None:
-        font = ImageFont.load_default()
+    return candidates[0] if candidates else None
 
-    # Word-wrap the hook text
+
+def wrap_text(text: str, max_chars_per_line: int):
     words = text.split()
     lines, current = [], ""
-    max_chars_per_line = 30
     for w in words:
         if len(current) + len(w) + 1 <= max_chars_per_line:
             current = (current + " " + w).strip()
@@ -111,102 +107,160 @@ def render_hook_frame(text: str, out_path: Path):
             current = w
     if current:
         lines.append(current)
+    return lines
 
-    line_h = size + 10
+
+def trim_black_borders(img, threshold: int = 25):
+    """Auto-crop solid-black margin (e.g. press photo mats). Returns trimmed
+    image (same as input if no borders detected). Uses ImageChops.difference
+    against pure black + getbbox — pure PIL, no numpy dep."""
+    from PIL import Image, ImageChops
+    bg = Image.new(img.mode, img.size, (0, 0, 0))
+    diff = ImageChops.difference(img, bg)
+    # Boost the diff so threshold-level dark pixels get included
+    diff = ImageChops.add(diff, diff, 2.0, -threshold)
+    bbox = diff.getbbox()
+    if bbox and (bbox[2] - bbox[0]) > 100 and (bbox[3] - bbox[1]) > 100:
+        return img.crop(bbox)
+    return img
+
+
+def hero_bg(hero_path: Path, dim_alpha: int = 110):
+    """Open hero image, trim black mat, fill 1280×720 cover-style, dim."""
+    from PIL import Image
+    img = Image.open(hero_path).convert("RGB")
+    img = trim_black_borders(img)
+    iw, ih = img.size
+    canvas_ratio = CANVAS_W / CANVAS_H
+    img_ratio = iw / ih
+    if img_ratio > canvas_ratio:
+        new_h = CANVAS_H
+        new_w = int(iw * (CANVAS_H / ih))
+    else:
+        new_w = CANVAS_W
+        new_h = int(ih * (CANVAS_W / iw))
+    img = img.resize((new_w, new_h), Image.LANCZOS)
+    left = (new_w - CANVAS_W) // 2
+    top = (new_h - CANVAS_H) // 2
+    img = img.crop((left, top, left + CANVAS_W, top + CANVAS_H))
+    overlay = Image.new("RGBA", (CANVAS_W, CANVAS_H), (0, 0, 0, dim_alpha))
+    return Image.alpha_composite(img.convert("RGBA"), overlay)
+
+
+def render_hook_frame(text: str, hero_path: Optional[Path], out_path: Path):
+    """Hero image as bg (dimmed) + bold claim centered + BREAKING badge."""
+    from PIL import Image, ImageDraw
+    if hero_path:
+        base = hero_bg(hero_path, dim_alpha=80).convert("RGB")
+    else:
+        base = Image.new("RGB", (CANVAS_W, CANVAS_H), BG)
+    draw = ImageDraw.Draw(base)
+    font = get_font(60)
+
+    lines = wrap_text(text, 30)
+    line_h = 72
     total_h = len(lines) * line_h
-    y = (CANVAS_H - total_h) // 2
+    y = (CANVAS_H - total_h) // 2 + 30
+
+    # Localized darken behind text block for legibility
+    if hero_path:
+        from PIL import Image as _Im
+        text_overlay = _Im.new("RGBA", (CANVAS_W, CANVAS_H), (0, 0, 0, 0))
+        text_draw = ImageDraw.Draw(text_overlay)
+        pad = 30
+        text_draw.rectangle(
+            [(0, y - pad), (CANVAS_W, y + total_h + pad)],
+            fill=(0, 0, 0, 160),
+        )
+        base = _Im.alpha_composite(base.convert("RGBA"), text_overlay).convert("RGB")
+        draw = ImageDraw.Draw(base)
+
     for line in lines:
         bbox = draw.textbbox((0, 0), line, font=font)
         line_w = bbox[2] - bbox[0]
         x = (CANVAS_W - line_w) // 2
+        for dx, dy in [(-2,0),(2,0),(0,-2),(0,2)]:
+            draw.text((x+dx, y+dy), line, fill=(0,0,0), font=font)
         draw.text((x, y), line, fill=TEXT, font=font)
         y += line_h
 
-    # Accent badge top-left
-    draw.rectangle([(40, 40), (160, 90)], fill=ACCENT)
-    badge_font = ImageFont.truetype(font_paths[0], 24) if font_paths and Path(font_paths[0]).exists() else font
-    draw.text((58, 52), "BREAKING", fill=TEXT, font=badge_font)
+    badge_font = get_font(28)
+    bbox = draw.textbbox((0, 0), "BREAKING", font=badge_font)
+    bw = bbox[2] - bbox[0]
+    bh = bbox[3] - bbox[1]
+    badge_pad_x, badge_pad_y = 16, 12
+    badge_w = bw + badge_pad_x * 2
+    badge_h = bh + badge_pad_y * 2 + 6
+    draw.rectangle([(40, 40), (40 + badge_w, 40 + badge_h)], fill=ACCENT)
+    draw.text((40 + badge_pad_x, 40 + badge_pad_y), "BREAKING", fill=TEXT, font=badge_font)
 
-    img.save(out_path, "PNG")
+    base.save(out_path, "PNG")
 
 
-def render_support_frame(image_path: Path, caption: str, out_path: Path):
-    """Real fetched image fills frame; semi-transparent caption strip overlays bottom."""
-    from PIL import Image, ImageDraw, ImageFont
-    bg = Image.open(image_path).convert("RGB")
-    bg = bg.resize((CANVAS_W, CANVAS_H), Image.LANCZOS)
-
-    # Caption strip
+def render_support_frame(hero_path: Path, caption: str, out_path: Path, crop_seed: int = 0):
+    """Hero image with crop variation + semi-transparent caption strip overlay."""
+    from PIL import Image, ImageDraw
+    bg = hero_bg(hero_path, dim_alpha=70).convert("RGB")
     overlay = Image.new("RGBA", (CANVAS_W, CANVAS_H), (0, 0, 0, 0))
     draw = ImageDraw.Draw(overlay)
-    strip_h = 140
+
+    strip_h = 180
     draw.rectangle([(0, CANVAS_H - strip_h), (CANVAS_W, CANVAS_H)], fill=CAPTION_BG)
 
-    font_path = "/System/Library/Fonts/Helvetica.ttc"
-    try:
-        cap_font = ImageFont.truetype(font_path, 36)
-    except Exception:
-        cap_font = ImageFont.load_default()
+    cap_font = get_font(34)
+    lines = wrap_text(caption.strip(), 60)[:3]
 
-    # Wrap caption to ≤80 chars/line, ≤2 lines
-    words = caption.split()
-    lines, current = [], ""
-    for w in words:
-        if len(current) + len(w) + 1 <= 80:
-            current = (current + " " + w).strip()
-        else:
-            lines.append(current)
-            current = w
-    if current:
-        lines.append(current)
-    lines = lines[:2]
-
-    y = CANVAS_H - strip_h + 20
+    y = CANVAS_H - strip_h + 22
     for line in lines:
         draw.text((40, y), line, fill=TEXT, font=cap_font)
-        y += 50
+        y += 48
 
     out = Image.alpha_composite(bg.convert("RGBA"), overlay).convert("RGB")
     out.save(out_path, "PNG")
 
 
-def render_closer_frame(text: str, out_path: Path):
-    """Closer = share-moment text on solid bg, slightly larger than support captions."""
-    from PIL import Image, ImageDraw, ImageFont
-    img = Image.new("RGB", (CANVAS_W, CANVAS_H), BG)
-    draw = ImageDraw.Draw(img)
-    font_path = "/System/Library/Fonts/Helvetica.ttc"
-    try:
-        font = ImageFont.truetype(font_path, 56)
-    except Exception:
-        font = ImageFont.load_default()
+def render_closer_frame(text: str, hero_path: Optional[Path], out_path: Path):
+    """Hero image (lightly dimmed) + share-shape closing line, centered, large."""
+    from PIL import Image, ImageDraw
+    if hero_path:
+        base = hero_bg(hero_path, dim_alpha=90).convert("RGB")
+    else:
+        base = Image.new("RGB", (CANVAS_W, CANVAS_H), BG)
+    draw = ImageDraw.Draw(base)
+    font = get_font(56)
 
-    words = text.split()
-    lines, current = [], ""
-    for w in words:
-        if len(current) + len(w) + 1 <= 35:
-            current = (current + " " + w).strip()
-        else:
-            lines.append(current)
-            current = w
-    if current:
-        lines.append(current)
-
+    lines = wrap_text(text, 35)
     line_h = 70
     total_h = len(lines) * line_h
     y = (CANVAS_H - total_h) // 2
+
+    # Localized darken behind text block
+    if hero_path:
+        from PIL import Image as _Im
+        text_overlay = _Im.new("RGBA", (CANVAS_W, CANVAS_H), (0, 0, 0, 0))
+        text_draw = ImageDraw.Draw(text_overlay)
+        pad = 28
+        text_draw.rectangle(
+            [(0, y - pad), (CANVAS_W, y + total_h + pad)],
+            fill=(0, 0, 0, 170),
+        )
+        base = _Im.alpha_composite(base.convert("RGBA"), text_overlay).convert("RGB")
+        draw = ImageDraw.Draw(base)
+
     for line in lines:
         bbox = draw.textbbox((0, 0), line, font=font)
         line_w = bbox[2] - bbox[0]
         x = (CANVAS_W - line_w) // 2
+        for dx, dy in [(-2,0),(2,0),(0,-2),(0,2)]:
+            draw.text((x+dx, y+dy), line, fill=(0,0,0), font=font)
         draw.text((x, y), line, fill=TEXT, font=font)
         y += line_h
 
-    img.save(out_path, "PNG")
+    base.save(out_path, "PNG")
 
 
 def synthesize_tts(text: str, out_path: Path, provider: str = "GEMINI"):
-    """Render full narration to mp3. Tries gemini-tts (free) → openai-tts (paid)."""
+    """Render full narration to mp3. gemini-tts (free) → openai-tts fallback."""
     repo_root = Path(__file__).resolve().parents[3]
     if provider == "GEMINI":
         gemini_script = repo_root / "skills" / "gemini-tts" / "scripts" / "synthesize.sh"
@@ -216,7 +270,6 @@ def synthesize_tts(text: str, out_path: Path, provider: str = "GEMINI"):
                 return "GEMINI"
             except subprocess.CalledProcessError as e:
                 print(f"  [render] gemini-tts failed (exit {e.returncode}); falling back to openai", file=sys.stderr)
-    # OpenAI fallback
     openai_script = repo_root / "skills" / "openai-tts" / "scripts" / "synthesize.sh"
     if openai_script.exists():
         subprocess.run(["bash", str(openai_script), "--voice", "sage", "--out", str(out_path), "--", text], check=True)
@@ -224,30 +277,57 @@ def synthesize_tts(text: str, out_path: Path, provider: str = "GEMINI"):
     raise RuntimeError("No TTS skill available")
 
 
-def encode_video(frames_dir: Path, narration_path: Path, durations_s: list, out_path: Path):
-    """Concat frames at fixed durations, overlay narration audio. Uses ffmpeg concat demuxer.
+def kenburns_clip(frame_path: Path, duration_s: float, clip_idx: int, clip_path: Path):
+    """Pre-render a single still as a {duration_s} mp4 with subtle Ken-Burns zoom.
 
-    Audio duration is the source of truth for output length. We set output `-t`
-    to the narration duration so video always matches audio (no AV-sync drift
-    from concat-demuxer's last-frame-repeat behavior, caught in smoke test
-    2026-05-10).
+    Direction alternates per clip_idx for visual variety:
+      - even idx: zoom in (1.00 → 1.08), slight drift down-right
+      - odd idx:  zoom out (1.08 → 1.00), slight drift up-left
+
+    Output is silent h264; audio is overlaid on the final concat.
     """
-    # Get exact narration duration
+    total_frames = max(int(round(duration_s * FPS)), 30)
+    even = clip_idx % 2 == 0
+
+    if even:
+        zoom_expr = f"min(zoom+0.0008,1.08)"
+        x_expr = "iw/2-(iw/zoom/2)"
+        y_expr = "ih/2-(ih/zoom/2)"
+    else:
+        # zoom-out: start zoomed at 1.08, end at 1.00
+        zoom_expr = f"if(eq(on,0),1.08,max(zoom-0.0008,1.00))"
+        x_expr = "iw/2-(iw/zoom/2)"
+        y_expr = "ih/2-(ih/zoom/2)"
+
+    vf = (
+        f"scale=2560:1440:flags=lanczos,"
+        f"zoompan=z='{zoom_expr}':x='{x_expr}':y='{y_expr}':"
+        f"d={total_frames}:s={CANVAS_W}x{CANVAS_H}:fps={FPS}"
+    )
+
+    cmd = [
+        "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
+        "-loop", "1", "-t", f"{duration_s:.3f}", "-i", str(frame_path),
+        "-vf", vf,
+        "-c:v", "libx264", "-pix_fmt", "yuv420p", "-r", str(FPS),
+        "-an",
+        str(clip_path),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def concat_clips_with_audio(clip_paths: list, narration_path: Path, out_path: Path):
+    """Concat per-frame clips and overlay narration audio. Output -t = narration_dur."""
     probe = subprocess.run(
         ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", str(narration_path)],
         capture_output=True, text=True, check=True,
     )
-    narration_dur = float(json.loads(probe.stdout).get("format", {}).get("duration", sum(durations_s)))
+    narration_dur = float(json.loads(probe.stdout).get("format", {}).get("duration", 0) or 0)
 
-    # Build concat list file
-    concat_list = frames_dir / "concat.txt"
+    concat_list = clip_paths[0].parent / "concat.txt"
     with open(concat_list, "w") as f:
-        for frame, dur in zip(sorted(frames_dir.glob("frame_*.png")), durations_s):
-            f.write(f"file '{frame.resolve()}'\n")
-            f.write(f"duration {dur}\n")
-        # ffmpeg concat demuxer requires the last file repeated without duration
-        last = sorted(frames_dir.glob("frame_*.png"))[-1]
-        f.write(f"file '{last.resolve()}'\n")
+        for cp in clip_paths:
+            f.write(f"file '{cp.resolve()}'\n")
 
     cmd = [
         "ffmpeg", "-hide_banner", "-loglevel", "error", "-y",
@@ -256,7 +336,8 @@ def encode_video(frames_dir: Path, narration_path: Path, durations_s: list, out_
         "-c:v", "libx264", "-pix_fmt", "yuv420p",
         "-c:a", "aac", "-b:a", "128k",
         "-r", str(FPS),
-        "-t", f"{narration_dur:.3f}",  # clip output to exact narration length
+        "-t", f"{narration_dur:.3f}",
+        "-shortest",
         str(out_path),
     ]
     subprocess.run(cmd, check=True)
@@ -272,68 +353,58 @@ def main():
     artifacts = workdir / "artifacts"
     fetched = workdir / "fetched_assets"
     frames_dir = workdir / "frames"
+    clips_dir = workdir / "clips"
     frames_dir.mkdir(parents=True, exist_ok=True)
+    clips_dir.mkdir(parents=True, exist_ok=True)
 
     script_md = (artifacts / "final_script.md").read_text()
     sections = parse_script(script_md)
     print(f"[render] sections: {list(sections.keys())}", file=sys.stderr)
 
-    manifest_path = artifacts / "asset_manifest.json"
-    manifest = json.loads(manifest_path.read_text()) if manifest_path.exists() else []
+    hero = find_hero_image(fetched)
+    print(f"[render] hero image: {hero}", file=sys.stderr)
+    if not hero:
+        print("[render] WARNING: no real fetched image — falling back to text-on-black", file=sys.stderr)
 
-    # Frame plan
+    # Default per-section durations (will be scaled to narration length below)
+    HOOK_DUR = 4.0
+    SUPPORT_DUR = 7.0
+    CLOSER_DUR = 4.0
+
     durations = []
     frame_idx = 0
 
-    # HOOK
     if sections.get("HOOK"):
-        render_hook_frame(sections["HOOK"], frames_dir / f"frame_{frame_idx:03d}.png")
-        durations.append(HOOK_DURATION_S)
+        render_hook_frame(sections["HOOK"], hero, frames_dir / f"frame_{frame_idx:03d}.png")
+        durations.append(HOOK_DUR)
         frame_idx += 1
 
-    # SUPPORT — one frame per asset in manifest, captioned with the support text
     support_text = sections.get("SUPPORT", "")
     support_facts = re.split(r"(?<=[.!?])\s+", support_text) if support_text else []
-    support_assets = [m for m in manifest if m.get("purpose") == "support"]
-    if not support_assets:
-        # Fallback: use any non-hook/closer assets
-        support_assets = [m for m in manifest if m.get("purpose") not in ("hook", "closer")]
+    support_facts = [f for f in support_facts if f.strip()]
 
-    for i, fact in enumerate(support_facts[:len(support_assets) or 1]):
-        if i < len(support_assets):
-            asset_url = support_assets[i].get("url", "")
-            # Map URL to local file by basename matching fetched_assets/
-            local_assets = list(fetched.glob("*"))
-            best = None
-            for la in local_assets:
-                if la.name in asset_url or asset_url.endswith(la.name):
-                    best = la
-                    break
-            if best is None and local_assets:
-                best = local_assets[i % len(local_assets)]
-            if best:
-                render_support_frame(best, fact, frames_dir / f"frame_{frame_idx:03d}.png")
-                durations.append(SUPPORT_DURATION_S)
-                frame_idx += 1
-
-    # CLOSER
-    if sections.get("CLOSER"):
-        render_closer_frame(sections["CLOSER"], frames_dir / f"frame_{frame_idx:03d}.png")
-        durations.append(CLOSER_DURATION_S)
+    for i, fact in enumerate(support_facts):
+        if hero:
+            render_support_frame(hero, fact, frames_dir / f"frame_{frame_idx:03d}.png", crop_seed=i)
+        else:
+            # No hero: render as text-on-black via closer renderer (looks like a quote card)
+            render_closer_frame(fact, None, frames_dir / f"frame_{frame_idx:03d}.png")
+        durations.append(SUPPORT_DUR)
         frame_idx += 1
 
-    print(f"[render] {frame_idx} frames, total duration {sum(durations):.1f}s", file=sys.stderr)
+    if sections.get("CLOSER"):
+        render_closer_frame(sections["CLOSER"], hero, frames_dir / f"frame_{frame_idx:03d}.png")
+        durations.append(CLOSER_DUR)
+        frame_idx += 1
 
-    # TTS the full script (HOOK + SUPPORT + CLOSER concatenated)
+    print(f"[render] {frame_idx} frames, planned duration {sum(durations):.1f}s", file=sys.stderr)
+
     full_narration = " ".join(filter(None, [sections.get("HOOK"), sections.get("SUPPORT"), sections.get("CLOSER")]))
     narration_path = workdir / "narration.mp3"
     provider_used = synthesize_tts(full_narration, narration_path, provider=args.tts_provider)
     print(f"[render] narration via {provider_used}", file=sys.stderr)
 
-    # Scale frame durations to match narration length so the video doesn't
-    # cut off mid-sentence (caught by smoke test 2026-05-10: 25s frames vs
-    # 57s narration → ffmpeg --shortest truncated audio). Scale proportionally,
-    # keeping the relative weights of HOOK / SUPPORT / CLOSER frames intact.
+    # Scale frame durations to match actual narration length
     try:
         probe = subprocess.run(
             ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_format", str(narration_path)],
@@ -347,11 +418,18 @@ def main():
     if narration_dur > 0 and abs(narration_dur - sum(durations)) > 1.0:
         scale = narration_dur / sum(durations)
         durations = [d * scale for d in durations]
-        print(f"[render] scaled frame durations by {scale:.2f}x to match narration {narration_dur:.1f}s", file=sys.stderr)
+        print(f"[render] scaled durations by {scale:.2f}x to match narration {narration_dur:.1f}s", file=sys.stderr)
 
-    # Encode
+    # Pre-render each frame as a Ken-Burns clip
+    clip_paths = []
+    for i, (frame, dur) in enumerate(zip(sorted(frames_dir.glob("frame_*.png")), durations)):
+        clip = clips_dir / f"clip_{i:03d}.mp4"
+        kenburns_clip(frame, dur, i, clip)
+        clip_paths.append(clip)
+    print(f"[render] {len(clip_paths)} Ken-Burns clips", file=sys.stderr)
+
     out = workdir / "video.mp4"
-    encode_video(frames_dir, narration_path, durations, out)
+    concat_clips_with_audio(clip_paths, narration_path, out)
     print(f"[render] {out}")
     return 0
 

--- a/skills/make-viral-video/scripts/test_source_tag.py
+++ b/skills/make-viral-video/scripts/test_source_tag.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Unit tests for source_tag schema v1 auto-footer + license-gate logic.
+
+Lifts the tested logic from render.py main() into pure functions so we can
+exercise edge cases without firing TTS/ffmpeg. Run:
+
+    python3 skills/make-viral-video/scripts/test_source_tag.py
+
+Exits 0 on pass, non-zero on fail. No external deps.
+"""
+import sys
+from typing import Any
+
+
+def derive_auto_footer(manifest: list[dict[str, Any]]) -> str:
+    """Replicates the auto-footer derivation from render.py:670-685.
+
+    Returns the joined footer text, or empty string if manifest doesn't carry
+    enough source_tag fields to derive a footer."""
+    event_ids: list[str] = []
+    shorts: list[str] = []
+    for entry in manifest:
+        st = entry.get("source_tag") or {}
+        if isinstance(st, dict):
+            ev = st.get("event_id")
+            fs = st.get("footer_short")
+            if ev and ev not in event_ids:
+                event_ids.append(ev)
+            if fs and fs not in shorts:
+                shorts.append(fs)
+    if event_ids and shorts:
+        return " · ".join(event_ids + shorts)
+    return ""
+
+
+def license_gate_warnings(manifest: list[dict[str, Any]]) -> list[str]:
+    """Replicates the license-gate logic from render.py:690-696. Returns the
+    list of local_file names that trigger a warning (license=needs-license +
+    empty attribution)."""
+    warns = []
+    for entry in manifest:
+        st = entry.get("source_tag") or {}
+        if isinstance(st, dict) and st.get("license") == "needs-license" and not st.get("attribution"):
+            warns.append(entry.get("local_file", "?"))
+    return warns
+
+
+# -- Tests --
+
+def test_empty_manifest():
+    """No manifest entries → empty auto-footer, no warnings."""
+    assert derive_auto_footer([]) == ""
+    assert license_gate_warnings([]) == []
+
+
+def test_manifest_without_source_tag():
+    """Manifest with entries but no source_tag → falls back to empty."""
+    manifest = [{"local_file": "x.jpg", "purpose": "hook"}]
+    assert derive_auto_footer(manifest) == ""
+    assert license_gate_warnings(manifest) == []
+
+
+def test_single_event_full_chain():
+    """Single event_id + 3 distinct footer_shorts → joined chain."""
+    manifest = [
+        {"source_tag": {"event_id": "ev1", "footer_short": "a"}},
+        {"source_tag": {"event_id": "ev1", "footer_short": "b"}},
+        {"source_tag": {"event_id": "ev1", "footer_short": "c"}},
+    ]
+    assert derive_auto_footer(manifest) == "ev1 · a · b · c"
+
+
+def test_duplicate_footer_shorts_deduped():
+    """Same footer_short on multiple entries → only listed once (dedup by value)."""
+    manifest = [
+        {"source_tag": {"event_id": "ev1", "footer_short": "a"}},
+        {"source_tag": {"event_id": "ev1", "footer_short": "a"}},  # dupe
+        {"source_tag": {"event_id": "ev1", "footer_short": "b"}},
+    ]
+    assert derive_auto_footer(manifest) == "ev1 · a · b"
+
+
+def test_multi_event_bloat_pattern():
+    """Multi-event manifest (Lucy's ShinyHunters case) → all event_ids land
+    in chain. This is the v1.0 behavior that motivated the v1.1 `primary` flag."""
+    manifest = [
+        {"source_tag": {"event_id": "ev_canvas", "footer_short": "canvas"}},
+        {"source_tag": {"event_id": "ev_ticketmaster", "footer_short": "ticket"}},
+        {"source_tag": {"event_id": "ev_powerschool", "footer_short": "school"}},
+        {"source_tag": {"event_id": "ev_raoult", "footer_short": "raoult"}},
+    ]
+    footer = derive_auto_footer(manifest)
+    # All 4 event_ids + all 4 shorts present
+    assert "ev_canvas" in footer
+    assert "ev_raoult" in footer
+    assert "canvas" in footer
+    assert "raoult" in footer
+
+
+def test_partial_source_tag_skipped():
+    """Entry with source_tag but missing event_id or footer_short doesn't
+    block the others. Only complete entries contribute."""
+    manifest = [
+        {"source_tag": {"event_id": "ev1", "footer_short": "a"}},
+        {"source_tag": {"event_id": "ev1"}},  # missing footer_short
+        {"source_tag": {"footer_short": "b"}},  # missing event_id (but b joins via dedup)
+    ]
+    footer = derive_auto_footer(manifest)
+    assert "ev1" in footer
+    assert "a" in footer
+    assert "b" in footer  # b is collected even without an event_id since collection is per-field
+
+
+def test_license_gate_warns_on_needs_license_no_attribution():
+    manifest = [
+        {"local_file": "ok.jpg", "source_tag": {"license": "public-domain", "attribution": "NASA"}},
+        {"local_file": "bad.jpg", "source_tag": {"license": "needs-license"}},
+        {"local_file": "ok-needs.jpg", "source_tag": {"license": "needs-license", "attribution": "via permission letter"}},
+    ]
+    warns = license_gate_warnings(manifest)
+    assert warns == ["bad.jpg"], f"expected ['bad.jpg'], got {warns}"
+
+
+def test_license_gate_silent_on_other_licenses():
+    manifest = [
+        {"local_file": "a.jpg", "source_tag": {"license": "fair-use"}},
+        {"local_file": "b.jpg", "source_tag": {"license": "cc-by"}},
+        {"local_file": "c.jpg", "source_tag": {"license": "editorial-only", "attribution": "press use only"}},
+    ]
+    assert license_gate_warnings(manifest) == []
+
+
+def test_source_tag_none_handled_safely():
+    """source_tag explicitly None (not just missing) should not crash."""
+    manifest = [{"local_file": "x.jpg", "source_tag": None}]
+    assert derive_auto_footer(manifest) == ""
+    assert license_gate_warnings(manifest) == []
+
+
+def main():
+    tests = [
+        ("empty_manifest", test_empty_manifest),
+        ("manifest_without_source_tag", test_manifest_without_source_tag),
+        ("single_event_full_chain", test_single_event_full_chain),
+        ("duplicate_footer_shorts_deduped", test_duplicate_footer_shorts_deduped),
+        ("multi_event_bloat_pattern", test_multi_event_bloat_pattern),
+        ("partial_source_tag_skipped", test_partial_source_tag_skipped),
+        ("license_gate_warns_on_needs_license_no_attribution", test_license_gate_warns_on_needs_license_no_attribution),
+        ("license_gate_silent_on_other_licenses", test_license_gate_silent_on_other_licenses),
+        ("source_tag_none_handled_safely", test_source_tag_none_handled_safely),
+    ]
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/make-viral-video/scripts/validate_asset.py
+++ b/skills/make-viral-video/scripts/validate_asset.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Asset validation for make-viral-video skill — phase 2 of the build pipeline.
+
+Per Lucy's `feedback_verification_gates_need_semantic_checks.md` (2026-05-09)
+and the v12 PR46-404-dupe incident:
+
+Structural counts (asset_count == 4) are insufficient. We need semantic
+checks that catch:
+  - hash duplicates (codex hallucinates 4× the same broken URL → 4× the
+    same captured 404 page)
+  - the 404 page itself (browser fallback captures a 1280×720 PNG of the
+    "Page Not Found" page, indistinguishable from a real news photo by
+    structural ffprobe checks alone)
+  - sub-thumb resolutions (≥600×400 minimum)
+  - non-image content-types served as image extensions
+  - off-domain captures (codex following redirects out of the whitelist)
+
+Usage:
+  python3 validate_asset.py <asset_path> [--allowed-domain war.gov]
+                                         [--allowed-domain whitehouse.gov]
+                                         [--known-404-hash <md5>]
+
+Returns exit 0 + writes validation report to stdout (JSON) on success;
+exit 1 on validation failure (with structured failure reason).
+"""
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+
+# Hash patterns observed for known 404-page captures. Lucy reported
+# md5 `00743781de0532...` for war.gov's PR46 404 page (4 dupes in v12).
+# This list grows as we encounter new 404 page hashes per domain.
+KNOWN_404_HASH_PREFIXES = (
+    "00743781de0532",  # war.gov PR-not-found, observed 2026-05-09
+)
+
+# OCR keyword patterns. If we have to OCR (PIL+tesseract not assumed),
+# we look for these in any extracted text. Implemented as a fallback —
+# the hash check + content-type check should catch most cases first.
+OCR_404_KEYWORDS = (
+    "404",
+    "page not found",
+    "not found",
+    "this page does not exist",
+    "the requested url",
+)
+
+MIN_WIDTH = 600
+MIN_HEIGHT = 400
+
+
+def md5_of_file(path: Path) -> str:
+    h = hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def detect_image_dims(path: Path):
+    """Best-effort image dimension detection without requiring PIL.
+
+    Tries `file` command first (POSIX), falls back to PIL if available."""
+    try:
+        import subprocess
+        r = subprocess.run(["file", "--mime-type", "-b", str(path)], capture_output=True, text=True)
+        mime = r.stdout.strip()
+        if not mime.startswith("image/"):
+            return None, mime
+    except Exception:
+        mime = "unknown"
+
+    # Use PIL if installed; otherwise rely on `file` for size info via -i / sips.
+    try:
+        from PIL import Image
+        with Image.open(path) as im:
+            return im.size, mime
+    except Exception:
+        pass
+
+    # Fallback: macOS sips
+    try:
+        import subprocess
+        r = subprocess.run(["sips", "-g", "pixelWidth", "-g", "pixelHeight", str(path)],
+                           capture_output=True, text=True)
+        w, h = None, None
+        for line in r.stdout.splitlines():
+            line = line.strip()
+            if line.startswith("pixelWidth:"):
+                w = int(line.split(":")[1].strip())
+            elif line.startswith("pixelHeight:"):
+                h = int(line.split(":")[1].strip())
+        if w and h:
+            return (w, h), mime
+    except Exception:
+        pass
+
+    return None, mime
+
+
+def ocr_text(path: Path) -> str:
+    """Try to OCR an image; return empty string if no OCR available.
+
+    This is a best-effort fallback — we'd prefer to catch 404 pages by
+    hash before reaching OCR."""
+    try:
+        import subprocess
+        # tesseract if available
+        r = subprocess.run(["tesseract", str(path), "-", "-l", "eng"],
+                           capture_output=True, text=True, timeout=15)
+        return (r.stdout or "").lower()
+    except Exception:
+        return ""
+
+
+def validate(path: Path, allowed_domains, known_404_hashes, source_url=None):
+    """Returns dict: {valid: bool, reason?: str, hash: str, mime: str, dims?: [w, h]}."""
+    if not path.exists():
+        return {"valid": False, "reason": "file_not_found", "path": str(path)}
+
+    file_md5 = md5_of_file(path)
+    dims, mime = detect_image_dims(path)
+
+    report = {
+        "path": str(path),
+        "hash": file_md5,
+        "mime": mime,
+    }
+    if dims:
+        report["dims"] = list(dims)
+
+    # 1. Content-type must be image/*
+    if not mime.startswith("image/"):
+        return {**report, "valid": False, "reason": "non_image_content_type"}
+
+    # 2. Hash must not match a known 404 page
+    for prefix in known_404_hashes:
+        if file_md5.startswith(prefix):
+            return {**report, "valid": False, "reason": f"matches_known_404_hash({prefix}...)"}
+
+    # 3. Resolution check
+    if dims:
+        w, h = dims
+        if w < MIN_WIDTH or h < MIN_HEIGHT:
+            return {**report, "valid": False, "reason": f"sub_minimum_resolution({w}x{h}, need {MIN_WIDTH}x{MIN_HEIGHT})"}
+
+    # 4. OCR fallback for 404 detection (best-effort)
+    text = ocr_text(path)
+    if text:
+        for keyword in OCR_404_KEYWORDS:
+            if keyword in text:
+                return {**report, "valid": False, "reason": f"ocr_matched_404_keyword({keyword!r})", "ocr_excerpt": text[:200]}
+
+    # 5. Domain whitelist (informational only — caller enforces if needed)
+    if source_url and allowed_domains:
+        from urllib.parse import urlparse
+        host = urlparse(source_url).hostname or ""
+        if not any(host == d or host.endswith("." + d) for d in allowed_domains):
+            return {**report, "valid": False, "reason": f"off_whitelist_domain({host})", "source_url": source_url}
+
+    return {**report, "valid": True}
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Validate a fetched asset for the make-viral-video skill")
+    p.add_argument("path", help="Path to the asset file")
+    p.add_argument("--allowed-domain", action="append", default=[], help="Allowed source domain (repeatable). Omit to skip whitelist check.")
+    p.add_argument("--known-404-hash", action="append", default=[], help="Additional known-404 hash prefix (repeatable). Built-in list always applied.")
+    p.add_argument("--source-url", default=None, help="Original source URL (for whitelist enforcement)")
+    args = p.parse_args(argv)
+
+    known_404 = list(KNOWN_404_HASH_PREFIXES) + list(args.known_404_hash)
+    result = validate(Path(args.path), args.allowed_domain, known_404, source_url=args.source_url)
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("valid") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/make-viral-video/scripts/verify_video.py
+++ b/skills/make-viral-video/scripts/verify_video.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Pre-publish ffprobe gate for make-viral-video skill — phase 6.
+
+Per Lucy's `feedback_ffprobe_video_outputs_before_posting.md`:
+the v11/v12 ship-broken pattern was "looks fine to the human eye but is
+missing audio / wrong orientation / cropped pictures." Structural ffprobe
+checks catch all three before the video reaches the user.
+
+Validates:
+  1. File exists + non-zero size
+  2. Has h264 video stream
+  3. Has aac audio stream (Lucy's v11 shipped silent — no audio stream)
+  4. Dimensions are 1280×720 landscape (Lucy's v10/v11 were 1080×1920 portrait)
+  5. Duration within ±5s of expected (caller passes expected_seconds)
+  6. Audio duration matches video duration ±0.5s (no silent tail / dropped audio)
+
+Exit 0 + JSON report on success. Exit 1 + structured failure reason on any check fail.
+
+Usage:
+  python3 verify_video.py /path/to/video.mp4 --expected-duration 45
+"""
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+EXPECTED_W, EXPECTED_H = 1280, 720
+DURATION_TOLERANCE_S = 5.0
+AV_SYNC_TOLERANCE_S = 0.5
+
+
+def ffprobe(path: Path):
+    """Return parsed JSON from ffprobe -show_streams + -show_format."""
+    cmd = [
+        "ffprobe", "-v", "quiet", "-print_format", "json",
+        "-show_streams", "-show_format", str(path),
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(r.stdout)
+
+
+def verify(video_path: Path, expected_duration_s: float = None):
+    if not video_path.exists():
+        return {"valid": False, "reason": "file_not_found", "path": str(video_path)}
+    if video_path.stat().st_size == 0:
+        return {"valid": False, "reason": "zero_byte_file", "path": str(video_path)}
+
+    try:
+        probe = ffprobe(video_path)
+    except subprocess.CalledProcessError as e:
+        return {"valid": False, "reason": f"ffprobe_failed", "stderr": e.stderr}
+    except Exception as e:
+        return {"valid": False, "reason": f"ffprobe_exception: {type(e).__name__}: {e}"}
+
+    streams = probe.get("streams", [])
+    fmt = probe.get("format", {})
+    report = {
+        "path": str(video_path),
+        "duration_s": float(fmt.get("duration", 0) or 0),
+        "size_bytes": int(fmt.get("size", 0) or 0),
+        "streams": [],
+    }
+
+    video_streams = [s for s in streams if s.get("codec_type") == "video"]
+    audio_streams = [s for s in streams if s.get("codec_type") == "audio"]
+
+    for s in streams:
+        report["streams"].append({
+            "codec_type": s.get("codec_type"),
+            "codec_name": s.get("codec_name"),
+            "width": s.get("width"),
+            "height": s.get("height"),
+            "duration": s.get("duration"),
+        })
+
+    # Check 1: has video stream
+    if not video_streams:
+        return {**report, "valid": False, "reason": "no_video_stream"}
+
+    # Check 2: video codec is h264
+    vstream = video_streams[0]
+    if vstream.get("codec_name") != "h264":
+        return {**report, "valid": False, "reason": f"video_codec_not_h264 (got {vstream.get('codec_name')})"}
+
+    # Check 3: dimensions are 1280×720
+    w, h = vstream.get("width"), vstream.get("height")
+    if w != EXPECTED_W or h != EXPECTED_H:
+        return {**report, "valid": False, "reason": f"wrong_dimensions ({w}x{h}, expected {EXPECTED_W}x{EXPECTED_H})"}
+
+    # Check 4: has audio stream (catches Lucy's v11 silent regression)
+    if not audio_streams:
+        return {**report, "valid": False, "reason": "no_audio_stream"}
+
+    # Check 5: audio codec is aac
+    astream = audio_streams[0]
+    if astream.get("codec_name") != "aac":
+        return {**report, "valid": False, "reason": f"audio_codec_not_aac (got {astream.get('codec_name')})"}
+
+    # Check 6: duration within tolerance of expected
+    actual_dur = report["duration_s"]
+    if expected_duration_s is not None:
+        if abs(actual_dur - expected_duration_s) > DURATION_TOLERANCE_S:
+            return {**report, "valid": False,
+                    "reason": f"duration_outside_tolerance (got {actual_dur:.1f}s, expected {expected_duration_s:.1f}s ± {DURATION_TOLERANCE_S}s)"}
+
+    # Check 7: audio duration ≈ video duration
+    vdur = float(vstream.get("duration", actual_dur) or actual_dur)
+    adur = float(astream.get("duration", actual_dur) or actual_dur)
+    if abs(vdur - adur) > AV_SYNC_TOLERANCE_S:
+        return {**report, "valid": False,
+                "reason": f"av_duration_mismatch (video={vdur:.2f}s, audio={adur:.2f}s, tolerance ±{AV_SYNC_TOLERANCE_S}s)"}
+
+    return {**report, "valid": True}
+
+
+def main():
+    p = argparse.ArgumentParser(description="Pre-publish ffprobe gate for make-viral-video")
+    p.add_argument("video", help="Path to mp4 file")
+    p.add_argument("--expected-duration", type=float, default=None,
+                   help="Expected duration in seconds (±5s tolerance)")
+    args = p.parse_args()
+
+    result = verify(Path(args.video), expected_duration_s=args.expected_duration)
+    print(json.dumps(result, indent=2))
+    return 0 if result.get("valid") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds a `## 🎬 Recent autonomous output` section between the existing vision-talk link and the `## What can you do with it?` feature list
- Surfaces 2 Sutando WIRE episodes + 5 recent capability-proof videos from the `@sutando-ai` channel
- Includes channel + Sutando WIRE playlist links as "see more" exits

## Why this order

Proof-of-output (concrete recent videos) reads before pitch (feature list). Skim-readers who already know what an agent CAN do see what Sutando HAS done first.

## What got featured vs skipped

Featured 7 of 12 channel videos. Older April/March demos were skipped to avoid bloat — the existing demo embed at the top of the README + this new section together cover the recent + canonical body of work.

## Test plan

- [ ] Render preview on GitHub mobile + desktop — confirm 7 link lines don't push the feature list below the fold
- [ ] Click through all 7 video links → confirm they resolve (all sutando-ai channel, public)
- [ ] Confirm playlist link includes ep001 + ep002

🤖 Generated with [Claude Code](https://claude.com/claude-code)