### PR TITLE
fix(type-text): force clipboard-paste for non-ASCII text

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -263,10 +263,17 @@ export const typeTextTool: ToolDefinition = {
 	execution: 'inline',
 	async execute(args) {
 		const { text } = args as { text: string };
-		// Multi-line or long text: use clipboard paste (keystroke can't handle newlines)
-		// Gemini sends literal \n (two chars backslash+n), not actual newlines
-		const hasNewline = text.includes('\n') || text.includes('\r') || /\\n/.test(text) || text.length > 80;
-		if (hasNewline) {
+		// Multi-line, long, or non-ASCII text: use clipboard paste.
+		// AppleScript's `keystroke "..."` routes through virtual-key codes that
+		// can't represent characters outside the basic ASCII typing range —
+		// em-dashes (U+2014), curly quotes (U+2018-U+201D), and emoji all get
+		// corrupted (UTF-8 bytes reinterpreted as Mac Roman → e.g. 🤖 mojibake,
+		// — → "‚Äî"). The paste branch round-trips through the system pasteboard
+		// which preserves bytes. Per Chi 2026-05-13 frustration with emoji corruption.
+		// Gemini sends literal \n (two chars backslash+n), not actual newlines.
+		const hasNonAscii = /[^\x00-\x7f]/.test(text);
+		const needsPaste = text.includes('\n') || text.includes('\r') || /\\n/.test(text) || text.length > 80 || hasNonAscii;
+		if (needsPaste) {
 			try {
 				let savedClipboard = '';
 				try { savedClipboard = execSync('pbpaste', { encoding: 'utf-8', timeout: 2_000 }); } catch {}


### PR DESCRIPTION
## Summary

- `type_text` was corrupting any non-ASCII char (emoji, em-dashes, curly quotes) because AppleScript's `keystroke "..."` routes through virtual-key codes that can't represent characters outside basic ASCII typing range
- Fix: add `hasNonAscii = /[^\x00-\x7f]/.test(text)` to the existing conditional that already routes multi-line / long text through the clipboard-paste branch (which preserves bytes)

## Root cause (from `src/inline-tools.ts:268`)

Before this PR, `type_text` only used the clipboard-paste branch when text had newlines or `length > 80`. Single-line short text fell to:

```ts
osascript -e 'tell application "System Events" to keystroke "${safeText}"'
```

This works for ASCII but butchers multi-byte UTF-8. Real failures Chi hit today:

- `—` (em-dash, U+2014, UTF-8 `E2 80 94`) → reinterpreted as Mac Roman `‚Äî`
- `🤖` (robot emoji, UTF-8 `F0 9F A4 96`) → garbled output
- `'` → also got escape-leaked through Cursor's auto-pair, but that's a Cursor-side artifact (not in this PR's scope)

## Test plan

- [ ] Restart voice-agent after merge
- [ ] Say "type robot emoji" or similar prompt → confirm 🤖 lands clean in the focused field
- [ ] Try em-dash, curly quotes, accented chars (é, ñ, ü) — should all round-trip clean
- [ ] Verify ASCII typing path still works for short strings ("hello", "yes") — keystroke fast path retained

## Why the fix is minimal

The clipboard-paste branch already exists (lines 270-291 of inline-tools.ts) and is well-tested. This PR only widens the entry condition. Zero new code paths; zero behavior change for ASCII inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)