### PR TITLE
feat(cancel-task): use task pipeline as cancel signal channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,8 @@ Tasks arrive from multiple channels via the same file bridge:
 
 **IMPORTANT:** On session start, check if the task watcher is running (`pgrep -f "watch-tasks"`). If not, start it with `bash src/watch-tasks.sh` using `run_in_background: true`. When notified, read the output — it lists ALL pending task files. Process every one, write results to `results/`, then restart the watcher. This is how voice commands reach you.
 
+**Cancel handling.** When you read a task whose `task:` body starts with `CANCEL_INSTRUCTION:` — written by the `cancel_task` voice tool — stop any in-flight work on the referenced task ID, write a brief confirm result for the CANCEL_INSTRUCTION task itself (e.g. `"Cancelled task-X (was in progress)"` or `"task-X already completed, nothing to cancel"`), and do NOT process the original referenced task. The CANCEL_INSTRUCTION task uses the regular task pipeline as its signal channel — picking it up means you've reached the user's cancel intent.
+
 ## Tutorial
 
 When the user says "tutorial", "walk me through", or "show me what you can do" (via voice or text):

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -421,11 +421,14 @@ export const clipboardTool: ToolDefinition = {
 export const cancelTaskTool: ToolDefinition = {
 	name: 'cancel_task',
 	description:
-		'Cancel a pending task. Default (no args) cancels the most recent. ' +
+		'Cancel a pending or in-flight task by writing a CANCEL_INSTRUCTION task that core will see next. ' +
+		'Default (no args) cancels the most recent. ' +
 		'Pass `taskId` to cancel a specific task by id (e.g. "task-1777686932069"). ' +
 		'Pass `query` to cancel the first task whose content contains the substring (case-insensitive). ' +
 		'Pass `list: true` to list pending tasks (id + first 60 chars of content) without cancelling. ' +
-		'Use when user says "cancel", "nevermind", "stop that", "what\'s queued", "cancel the one about X".',
+		'Use when user says "cancel", "nevermind", "stop that", "what\'s queued", "cancel the one about X". ' +
+		'Note: in-flight processing only halts when core reaches the CANCEL_INSTRUCTION task in its queue — ' +
+		'this prevents future pickup + tells core to abort if mid-task, but doesn\'t interrupt a single LLM turn.',
 	parameters: z.object({
 		taskId: z.string().optional().describe('Specific task id to cancel (matches the filename without .txt).'),
 		query: z.string().optional().describe('Case-insensitive substring to match against task content. Cancels first match.'),
@@ -438,10 +441,10 @@ export const cancelTaskTool: ToolDefinition = {
 			const tasksDir = join(process.cwd(), 'tasks');
 			const resultsDir = join(process.cwd(), 'results');
 			const files = readdirSync(tasksDir).filter(f => f.endsWith('.txt')).sort();
-			if (files.length === 0) return { status: 'nothing_to_cancel' };
 
 			// list mode: return id + preview, no cancel
 			if (list) {
+				if (files.length === 0) return { status: 'nothing_pending', count: 0, tasks: [] };
 				const items = files.map(f => {
 					const id = f.replace('.txt', '');
 					let preview = '';
@@ -456,33 +459,62 @@ export const cancelTaskTool: ToolDefinition = {
 				return { status: 'pending_tasks', count: items.length, tasks: items };
 			}
 
-			// targeted cancel: by exact id
-			let target: string | undefined;
+			// Targeting: by exact id, by query, or default-to-most-recent.
+			// IMPORTANT: target can be a file in `tasks/` OR a recently-archived task whose
+			// processing is in-flight (file already moved). For id-based cancels we accept
+			// either case; for query-based we need the file present to grep its content.
+			let targetId: string | undefined;
+			let targetFile: string | undefined;
 			if (taskId) {
 				const wantFile = taskId.endsWith('.txt') ? taskId : `${taskId}.txt`;
-				if (files.includes(wantFile)) target = wantFile;
-				else return { status: 'not_found', taskId };
+				targetId = wantFile.replace('.txt', '');
+				if (files.includes(wantFile)) targetFile = wantFile;
+				// else: accept the cancel even if file is gone (in-flight); core sees CANCEL and decides
 			} else if (query) {
-				// targeted cancel: by content query (case-insensitive substring)
+				if (files.length === 0) return { status: 'nothing_pending' };
 				const needle = query.toLowerCase();
 				for (const f of files) {
 					try {
 						const body = readFileSync(join(tasksDir, f), 'utf-8').toLowerCase();
-						if (body.includes(needle)) { target = f; break; }
+						if (body.includes(needle)) { targetFile = f; targetId = f.replace('.txt', ''); break; }
 					} catch { /* ignore */ }
 				}
-				if (!target) return { status: 'not_found', query };
+				if (!targetId) return { status: 'not_found', query };
 			} else {
-				// default: most recent
-				target = files[files.length - 1];
+				// default: most recent pending file
+				if (files.length === 0) return { status: 'nothing_pending' };
+				targetFile = files[files.length - 1];
+				targetId = targetFile.replace('.txt', '');
 			}
 
-			const targetId = target.replace('.txt', '');
-			// Write a cancelled result so the web UI shows it with the cancelled icon
-			writeFileSync(join(resultsDir, target), 'Cancelled.');
-			unlinkSync(join(tasksDir, target));
-			console.log(`${ts()} [CancelTask] cancelled: ${targetId}${taskId ? ' (by id)' : query ? ` (by query: ${query})` : ''}`);
-			return { status: 'cancelled', taskId: targetId };
+			// Write a CANCEL_INSTRUCTION task — core picks it up next and aborts/skips
+			// the named target. Design (Chi 2026-05-13): reuse the task pipeline as the
+			// cancel signal channel instead of building a parallel one.
+			const cancelTs = Date.now();
+			const cancelFilename = `task-${cancelTs}.txt`;
+			const cancelBody = [
+				`id: task-${cancelTs}`,
+				`timestamp: ${new Date().toISOString()}`,
+				`task: CANCEL_INSTRUCTION: stop processing ${targetId} if still in flight. If already completed, no-op. Reply briefly confirming.`,
+				`source: voice`,
+				`channel_id: local-voice`,
+				`user_id: voice-local`,
+				`access_tier: owner`,
+				``,
+			].join('\n');
+			writeFileSync(join(tasksDir, cancelFilename), cancelBody);
+
+			// Also unlink the original task file if it's still present — prevents
+			// double-pickup if core hadn't started yet. Best-effort.
+			if (targetFile) {
+				try { unlinkSync(join(tasksDir, targetFile)); } catch { /* already gone is fine */ }
+			}
+
+			// Touch a cancelled result for the web UI's cancel icon (best-effort).
+			try { writeFileSync(join(resultsDir, `${targetId}.txt`), 'Cancelled.'); } catch { /* ignore */ }
+
+			console.log(`${ts()} [CancelTask] cancel-instruction written for ${targetId}${taskId ? ' (by id)' : query ? ` (by query: ${query})` : ''} → ${cancelFilename}`);
+			return { status: 'cancel_instruction_queued', taskId: targetId, instruction: `task-${cancelTs}` };
 		} catch (err) {
 			return { error: `Cancel failed: ${err instanceof Error ? err.message : err}` };
 		}


### PR DESCRIPTION
## Summary

Chi 2026-05-13 (Discord): "1 No. I think the right way is to write another task to give cancel instruction"

The old `cancel_task` voice tool just `unlink`ed the task file. That doesn't actually stop in-flight processing — once core has the task content in its context, deleting the file is a no-op. Chi's design: write a NEW task with a `CANCEL_INSTRUCTION:` header. Core picks it up through the normal task pipeline and either aborts in-flight work on the named target, or no-ops if the target was already completed.

Trade-off Chi accepted: the cancel takes effect when core reaches the cancel-instruction task in its queue, not mid-turn. That's enough for the common "nevermind"-style intents that fire before core gets very far.

## Changes

- **`cancelTaskTool.execute` rewritten** to write a `tasks/task-{cancelTs}.txt` with a `CANCEL_INSTRUCTION:` body that names the target task ID.
- **Best-effort unlink** of the original task file (prevents double-pickup if core hadn't started yet).
- **Still writes `results/{targetId}.txt = "Cancelled."`** so the web UI shows the cancelled icon for the original task.
- **Tool description updated** to clarify the new semantics and the in-turn vs in-queue caveat.
- **New return shape**: `{ status: 'cancel_instruction_queued', taskId, instruction: 'task-{cancelTs}' }`.
- **CLAUDE.md task-bridge section** gets a "Cancel handling" paragraph so core (this session) recognizes the convention and reacts correctly (abort in-flight + brief confirm result).

## Test plan

- [ ] Restart voice-agent after merge
- [ ] Voice command: "cancel" while a task is in flight → confirm a CANCEL_INSTRUCTION task lands in `tasks/`, original task file is gone, core sees the instruction and replies briefly
- [ ] Voice command: "cancel" with no pending tasks → returns `nothing_pending`, no garbage in `tasks/`
- [ ] Voice command: "cancel the one about X" → CANCEL_INSTRUCTION naming task-X gets written
- [ ] Voice command: "what's queued" (`list: true`) → still returns the list, no cancel-instruction written

🤖 Generated with [Claude Code](https://claude.com/claude-code)