### PR TITLE
feat(voice-session-context): recent_context tool + writer convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,17 @@ Tasks arrive from multiple channels via the same file bridge:
 
 **Cancel handling.** When you read a task whose `task:` body starts with `CANCEL_INSTRUCTION:` — written by the `cancel_task` voice tool — stop any in-flight work on the referenced task ID, write a brief confirm result for the CANCEL_INSTRUCTION task itself (e.g. `"Cancelled task-X (was in progress)"` or `"task-X already completed, nothing to cancel"`), and do NOT process the original referenced task. The CANCEL_INSTRUCTION task uses the regular task pipeline as its signal channel — picking it up means you've reached the user's cancel intent.
 
+**Voice session context.** Voice-agent's Gemini context window rolls off after ~10 minutes of turns; voice forgets specifics like "the post" or "Mini Draft A" that landed earlier in your session. Whenever you make a durable decision the voice agent may need to reference later — picking a draft, writing text to clipboard for a pending paste, committing to an active task — update `state/voice-session-context.json`. Schema:
+```json
+{
+  "updated_at": "<ISO ts>",
+  "active_drafts": [{"name": "...", "summary": "...", "path": "..."}],
+  "pending_action": {"kind": "paste|review|other", "what": "...", "where": "..."} | null,
+  "last_results": [{"task_id": "...", "subject": "...", "ts": "..."}]
+}
+```
+Keep `active_drafts` and `last_results` to ~3 entries each (drop oldest). Voice can call the `recent_context` tool to read this file when it senses confusion ("what was the post?" / "what's pending?"). Per Chi 2026-05-13.
+
 ## Tutorial
 
 When the user says "tutorial", "walk me through", or "show me what you can do" (via voice or text):

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -802,6 +802,59 @@ export const deleteNoteTool: ToolDefinition = {
 	},
 };
 
+// --- Voice session context (Chi 2026-05-13: voice agent loses context across turns) ---
+//
+// Background: voice-agent's Gemini context window is independent from core's. After
+// ~10 minutes of turns earlier transcript rolls off and voice "forgets" specifics
+// like "the post" or "Mini Draft A". The fix is a small JSON file at
+// `state/voice-session-context.json` that core writes whenever a durable decision
+// lands (active draft, pending paste, today's selected option). Voice can ask for
+// the file's contents at any time via `recent_context`.
+//
+// Schema (informal):
+//   {
+//     "updated_at": "<ISO ts>",
+//     "active_drafts": [
+//       { "name": "Mini Draft A", "summary": "...", "path": "/tmp/sutando-draft.txt" }
+//     ],
+//     "pending_action": { "kind": "paste", "what": "Mini Draft A", "where": "Cursor / X compose" } | null,
+//     "last_results": [
+//       { "task_id": "task-...", "subject": "DeepMind post drafted", "ts": "<ISO>" }
+//     ]
+//   }
+//
+// Core writes the file by direct fs operations — no inline tool needed for the writer
+// path (core is this Claude Code session and already has fs access). The tool here
+// is the READ path that voice-agent's Gemini can call when it senses confusion
+// ("what was the post we picked?" / "what's pending?").
+
+const VOICE_SESSION_CONTEXT_PATH = join(process.cwd(), 'state', 'voice-session-context.json');
+
+export const recentContextTool: ToolDefinition = {
+	name: 'recent_context',
+	description:
+		'Return the current voice-session context — active drafts, pending actions, recent task results — so you can pick up a thread even if it predates your Gemini context window. ' +
+		'Call this when the user references something with a deictic pronoun ("the post", "the draft", "the one I just typed") that you can\'t place from your own recent transcript. ' +
+		'Also fine to call proactively at the start of an active session to ground yourself. ' +
+		'Returns JSON with keys: active_drafts (array), pending_action (object|null), last_results (array of {task_id, subject, ts}). ' +
+		'If the file is missing or empty, returns {note: "no context recorded yet"}.',
+	parameters: z.object({}),
+	execution: 'inline',
+	async execute() {
+		try {
+			if (!existsSync(VOICE_SESSION_CONTEXT_PATH)) {
+				return { note: 'no context recorded yet — core hasn\'t written voice-session-context.json' };
+			}
+			const raw = readFileSync(VOICE_SESSION_CONTEXT_PATH, 'utf-8');
+			const parsed = JSON.parse(raw);
+			console.log(`${ts()} [RecentContext] returned (updated_at=${parsed.updated_at || 'unknown'}, ${(parsed.active_drafts || []).length} drafts, ${(parsed.last_results || []).length} results)`);
+			return parsed;
+		} catch (err) {
+			return { error: `recent_context read failed: ${err instanceof Error ? err.message : err}` };
+		}
+	},
+};
+
 // IMPORTANT: Every tool defined in browser-tools.ts MUST be added to BOTH arrays below.
 // Tools not registered here are invisible to Gemini — it will hallucinate actions instead
 // of calling them (e.g. "I've closed the video" without actually closing it).
@@ -955,6 +1008,7 @@ export const inlineTools = assertUniqueToolNames([
 	joinZoomTool, joinGmeetTool, lookupMeetingIdTool, callContactTool,
 	describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, slideControlTool, fullscreenTool,
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
+	recentContextTool,
 	...personalTools ]);
 
 /** Tools available to any caller (including unverified) */
@@ -971,6 +1025,7 @@ export const ownerOnlyTools = [
 	clipboardTool, cancelTaskTool, toggleTasksTool, summonTool, dismissTool,
 	joinZoomTool, joinGmeetTool, callContactTool, slideControlTool, fullscreenTool,
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
+	recentContextTool,
 	describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool,
 ];
 


### PR DESCRIPTION
## Summary

Chi 2026-05-13: voice-agent's Gemini context window rolls off after ~10 min, voice forgets "the post" / "Mini Draft A" / "the draft we picked" — caught it ~5 times during this morning's debug session. Fix per Chi's "hybrid" pick: a small JSON file core writes when durable decisions land, plus a voice-callable tool to read it.

## What this PR ships

**Read path** (Gemini-callable):
- New `recentContextTool` in `src/inline-tools.ts`. Returns parsed `state/voice-session-context.json` or `{note: 'no context recorded yet'}` placeholder. Registered in both `inlineTools` and `ownerOnlyTools`.

**Writer convention** (CLAUDE.md):
- New "Voice session context" paragraph in the task-bridge section.
- Schema: `{updated_at, active_drafts[], pending_action|null, last_results[]}`.
- Prune rule: ~3 entries each (drop oldest).
- When to write: durable decisions voice may need later — picking a draft, clipboard-paste pending, active task commit.

State file at `state/voice-session-context.json` is gitignored via existing `state/*`.

## What this PR defers

The per-turn auto-injection into Gemini's system message (proposed flavor #1). That's a deeper voice-agent change touching the bodhi `VoiceSession` lifecycle and gets a follow-up PR after we see the `recent_context` tool perform in real sessions.

For the immediate "voice forgets specifics" gap, the tool is enough: Gemini will call `recent_context()` when it sees a deictic pronoun ("the post", "the draft") it can't resolve from its own transcript window.

## Active-mode gate

Chi asked for refresh-only-when-active. The `recent_context` tool is model-triggered, which by definition only fires during live VoiceSession turns. Zero token cost when voice is idle. If the per-turn injection follow-up lands, the active-mode gate goes there.

## Test plan

- [ ] Restart voice-agent after merge
- [ ] Say something deictic that predates voice's context: "what was the post we picked?" → voice should call `recent_context` and return Mini Draft A details
- [ ] Confirm log line `[RecentContext] returned (updated_at=..., N drafts, N results)`
- [ ] Verify `state/voice-session-context.json` stays gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)