### PR TITLE
feat(framing): My AI Stand — README hero + web-client tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **My AI Stand — Realtime by Day, Coding Itself by Night.**
 
-Realtime when I'm engaged. Coding itself when I'm not. Runs across my Macs, interacts with people & their Stands.
+Realtime by day — voice, vision, screen, meetings, calls. Coding itself by night. Runs across my Macs, interacts with people & their Stands.
 
 It belongs entirely to you.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ai-blue)](https://sutando.ai)
 
-**Summon your AI superpower — voice, vision, and autonomous action.**
+**My AI Stand — Realtime by Day, Coding Itself by Night.**
 
-It shares your screen, joins your meetings, makes phone calls, and builds itself.
+Realtime when I'm engaged. Coding itself when I'm not. Runs across my Macs, interacts with people & their Stands.
 
 It belongs entirely to you.
 

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -638,7 +638,7 @@ fetch('http://localhost:7844/stand-identity').then(r=>r.json()).then(s=>{
     </svg>
   </div>
   <h2 id="hero-name">Sutando</h2>
-  <p class="tagline">Summon your AI superpower</p>
+  <p class="tagline">My AI Stand</p>
   <button class="btn-hero" onclick="toggle()">Start Voice</button>
 </div>
 


### PR DESCRIPTION
## Summary

- README L5 hero: `Summon your AI superpower — voice, vision, and autonomous action.` → `My AI Stand — Realtime by Day, Coding Itself by Night.`
- README L7 supporting: `It shares your screen, joins your meetings, makes phone calls, and builds itself.` → `Realtime when I'm engaged. Coding itself when I'm not. Runs across my Macs, interacts with people & their Stands.`
- src/web-client.ts:641 tagline: `Summon your AI superpower` → `My AI Stand`

Phrasing converged with Chi in #dev thread "framing": *"interacts with people & their Stands"* covers phone calls + meetings + Discord/Telegram + cross-owner bot coord in one clause — broader than the earlier "coordinates with other people's Stands" draft.

Companion PR on sonichi/sutando-site mirrors the change on the homepage (title, meta, hero).

Three weeks to Observe Summit (June 4) — getting the new framing into search + social ahead of the talk.

## Test plan

- [ ] Open the rendered README on GitHub — hero + supporting line read correctly
- [ ] Reload the web-client page (`npx tsx src/web-client.ts`) and confirm hero tagline shows "My AI Stand"
- [ ] Visual: web-client tagline shorter than before — check it doesn't collide with the "Start Voice" button on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)