### PR TITLE
fix(press_key): accept 'downarrow'/'uparrow' aliases (root cause of 'arrows don't work but space does')

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -149,6 +149,12 @@ export const pressKeyTool: ToolDefinition = {
 			'enter': 36, 'return': 36, 'escape': 53, 'esc': 53, 'tab': 48,
 			'delete': 51, 'backspace': 51, 'space': 49,
 			'up': 126, 'down': 125, 'left': 123, 'right': 124,
+			// Common voice-spoken aliases — without these, the fallthrough to
+			// `keystroke "<key>"` types the literal string into the focused
+			// field instead of pressing the arrow. Observed 2026-05-13 voice
+			// call: Gemini called press_key(key="downarrow"); nothing scrolled.
+			'uparrow': 126, 'downarrow': 125, 'leftarrow': 123, 'rightarrow': 124,
+			'arrowup': 126, 'arrowdown': 125, 'arrowleft': 123, 'arrowright': 124,
 			'a': 0, 'c': 8, 'v': 9, 'x': 7, 'z': 6, 'f': 3, 's': 1, 'w': 13, 'q': 12,
 		};
 		const keyCode = keyMap[key.toLowerCase()];


### PR DESCRIPTION
## Summary
Adds 8 keyMap aliases — `uparrow`/`downarrow`/`leftarrow`/`rightarrow` and the `arrowup`/`arrowdown`/`arrowleft`/`arrowright` reverse forms — all pointing to the same key codes as the bare names already in the map.

## Why
Voice call 2026-05-13 23:13 PT exposed it. Gemini called `press_key(key="downarrow")` during a scroll task. `keyMap['downarrow']` is undefined, so the code at `src/inline-tools.ts:155-161` falls through to:

```
osascript -e 'tell application "System Events" to keystroke "downarrow"'
```

That **types the 9 literal characters** d-o-w-n-a-r-r-o-w into the focused field. Nothing scrolls. User-visible symptom: "space works, arrows don't" — because `space` IS in the keyMap (49), so the bare-name path sends the correct key code.

Voice-log evidence:
```
17:12:17 [PressKey] (Google Chrome) downarrow → no scroll
17:12:36 [PressKey] (Google Chrome) downarrow → no scroll
17:13:11 [PressKey] (Google Chrome) space     → scrolled (sanity)
17:13:25 [PressKey] (Google Chrome) uparrow   → no scroll
```

## Related
- #672 (scroll-amount) landed earlier today; this is a separate failure mode the same call exposed — the model fell back to arrow-key keystrokes rather than calling `scroll(amount=small)`. Fixing the keyMap unblocks both paths.

## Test plan
- [x] tsc clean
- [ ] manual: voice "press down arrow" → page scrolls one line
- [ ] manual: voice "press up arrow" → page scrolls up one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)