### PR TITLE
fix(task-expand): support per-task expand/collapse via taskIndex (closes other half of #671)

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -540,15 +540,18 @@ export const cancelTaskTool: ToolDefinition = {
 export const toggleTasksTool: ToolDefinition = {
 	name: 'toggle_tasks',
 	description:
-		'Collapse or expand all tasks in the web UI. Use for: "collapse tasks", "expand tasks", "hide tasks", "show tasks". Instant.',
+		'Collapse or expand tasks in the web UI. Use for: "collapse tasks", "expand tasks", "hide tasks", "show tasks", "expand only the first task". Pass taskIndex=1 for "the first task", 2 for "the second", etc. (1-based, by display order); omit for all-tasks. Instant.',
 	parameters: z.object({
-		action: z.enum(['collapse', 'expand']).describe('"collapse" to hide all task results, "expand" to show them'),
+		action: z.enum(['collapse', 'expand']).describe('"collapse" to hide task results, "expand" to show them'),
+		taskIndex: z.number().int().min(1).optional().describe('1-based index of a single task to act on (by display order). Omit to act on all tasks.'),
 	}),
 	execution: 'inline',
 	async execute(args) {
-		const { action } = args as { action: 'collapse' | 'expand' };
-		// Set data attribute on body — MutationObserver in the page picks it up and updates state
-		const js = `document.body.dataset.taskAction = \\\"${action}\\\"; \\\"done\\\"`;
+		const { action, taskIndex } = args as { action: 'collapse' | 'expand'; taskIndex?: number };
+		// Set data attribute on body — MutationObserver in the page picks it up and updates state.
+		// When taskIndex is set, encode as "expand:N" / "collapse:N"; handler in web-client.ts parses the suffix.
+		const actionStr = taskIndex ? `${action}:${taskIndex}` : action;
+		const js = `document.body.dataset.taskAction = \\\"${actionStr}\\\"; \\\"done\\\"`;
 		try {
 			execSync(`osascript -e 'tell application "Google Chrome"
 				repeat with w in windows

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -984,10 +984,24 @@ function updateTask(taskId, status, text, result) {
 const expandedTasks = window.expandedTasks = loadPersistedExpanded();
 const userExpanded = window.userExpanded = new Set(); // user-initiated expands — never auto-collapse these
 let userCollapsed = false; // user manually collapsed — suppress auto-expand
-// Listen for external collapse/expand commands (from inline tools via AppleScript)
+// Listen for external collapse/expand commands (from inline tools via AppleScript).
+// Action is 'collapse' / 'expand' for all-tasks, or 'collapse:N' / 'expand:N' (1-based) for one.
 new MutationObserver(() => {
-  if (document.body.dataset.taskAction === 'collapse') { expandedTasks.clear(); userCollapsed = true; renderTasks(); document.body.dataset.taskAction = ''; }
-  if (document.body.dataset.taskAction === 'expand') { Object.keys(taskMap).forEach(id => { if (taskMap[id].result) expandedTasks.add(id); }); userCollapsed = false; renderTasks(); document.body.dataset.taskAction = ''; }
+  const a = document.body.dataset.taskAction || '';
+  if (!a) return;
+  const [verb, idxStr] = a.split(':');
+  const idx = idxStr ? parseInt(idxStr, 10) : NaN;
+  const ids = Object.keys(taskMap);
+  if (Number.isInteger(idx) && idx >= 1 && idx <= ids.length) {
+    const targetId = ids[idx - 1];
+    if (verb === 'expand') { expandedTasks.add(targetId); userExpanded.add(targetId); userCollapsed = false; }
+    else if (verb === 'collapse') { expandedTasks.delete(targetId); userExpanded.delete(targetId); }
+    renderTasks();
+  } else {
+    if (verb === 'collapse') { expandedTasks.clear(); userCollapsed = true; renderTasks(); }
+    else if (verb === 'expand') { ids.forEach(id => { if (taskMap[id].result) expandedTasks.add(id); }); userCollapsed = false; renderTasks(); }
+  }
+  document.body.dataset.taskAction = '';
 }).observe(document.body, { attributes: true, attributeFilter: ['data-task-action'] });
 function toggleResult(taskId) {
   if (expandedTasks.has(taskId)) { expandedTasks.delete(taskId); userExpanded.delete(taskId); } else { expandedTasks.add(taskId); userExpanded.add(taskId); userCollapsed = false; }


### PR DESCRIPTION
## Summary
Closes the second half of #671. `toggle_tasks` now accepts an optional `taskIndex` (1-based, by display order). When set, the web-client MutationObserver parses an `expand:N` / `collapse:N` suffix on `data-task-action` and acts on the Nth task only.

Backward-compatible: bare `expand` / `collapse` still toggle all tasks.

## Why
Phone call 2026-05-13 23:53 PT: caller asked "expand only the first one" four times. The agent had no tool to do that — only an all-or-nothing toggle. Filed in #671 alongside the scroll-precision bug (which #672 closed).

## Changes
- `src/inline-tools.ts`: add optional `taskIndex` param to `toggleTasksTool`; encode as `expand:N` / `collapse:N` in the dataset action when set.
- `src/web-client.ts`: parse the `:N` suffix; act on `Object.keys(taskMap)[N-1]` instead of all tasks.

Display order = `taskMap` key order, which matches the rendered list.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] manual: voice "expand the first task" → only task 1 expands; "expand the second" → only task 2; "expand all tasks" → all expand (bare path)
- [ ] manual: "collapse the first task" → toggle off

🤖 Generated with [Claude Code](https://claude.com/claude-code)