### PR TITLE
fix(task-expand): match display order in expand:N handler (follow-up to #674)

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -991,7 +991,12 @@ new MutationObserver(() => {
   if (!a) return;
   const [verb, idxStr] = a.split(':');
   const idx = idxStr ? parseInt(idxStr, 10) : NaN;
-  const ids = Object.keys(taskMap);
+  // Match display order in renderTasks(): filter to visible (non-done unless
+  // showDone), then sort by time descending. "First task" = top of the list.
+  const ids = Object.entries(taskMap)
+    .filter(([, t]) => showDone || t.status !== 'done')
+    .sort((a, b) => b[1].time - a[1].time)
+    .map(([id]) => id);
   if (Number.isInteger(idx) && idx >= 1 && idx <= ids.length) {
     const targetId = ids[idx - 1];
     if (verb === 'expand') { expandedTasks.add(targetId); userExpanded.add(targetId); userCollapsed = false; }


### PR DESCRIPTION
## Summary
The expand:N MutationObserver from #674 used `Object.keys(taskMap)` to index tasks — that's **insertion order**, not display order. So voice "expand the first task" → taskIndex=1 expanded an old completed task buried at the bottom of the list (or filtered out entirely), while the visually-first task stayed collapsed.

## Repro
Voice cue at 23:59 PT after #674 merged: "expand the first task" → Gemini called toggle_tasks(action:'expand', taskIndex:1) → handler resolved that to `Object.keys(taskMap)[0]` which is whichever task happened to enter the map first this session. Visually-first task on screen stayed collapsed.

## Fix
Match `renderTasks()`'s sequence at line 1083-1105: filter visible (non-done unless `showDone`), sort by time descending, then index. Now `taskIndex=1` = top-of-list = what the user sees.

## Test plan
- [x] tsc clean
- [ ] manual: voice "expand the first task" → visually-first task expands (was: random old task)
- [ ] manual with `showDone` off: skipped-done filter applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)