### PR TITLE
fix(toggle-tasks): log actionStr so taskIndex visible in voice-agent.log

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -570,7 +570,7 @@ export const toggleTasksTool: ToolDefinition = {
 				end repeat
 				return "not found"
 			end tell'`, { timeout: 5_000 });
-			console.log(`${ts()} [ToggleTasks] ${action}`);
+			console.log(`${ts()} [ToggleTasks] ${actionStr}`);
 			return { status: action === 'collapse' ? 'collapsed' : 'expanded' };
 		} catch (err) {
 			return { error: `Toggle tasks failed: ${err instanceof Error ? err.message : err}` };


### PR DESCRIPTION
## Summary
1-line diagnostic fix. `console.log` in `toggleTasksTool` (`src/inline-tools.ts:573`) now prints `actionStr` (e.g. `expand:1`) instead of `action` (e.g. `expand`). Makes voice-agent.log entries diagnostic after #674's taskIndex addition.

## Why
2026-05-13 23:59 PT: voice "expand the first task" appeared broken in UI. Couldn't tell from log whether Gemini omitted `taskIndex` or my parsing failed. Both possibilities looked identical in `[ToggleTasks] expand`.

## Test plan
- [x] tsc clean
- [ ] manual: voice "expand the first task" → log line should now read `[ToggleTasks] expand:1`. If it still reads `[ToggleTasks] expand`, Gemini didn't pass the param (model-side bug, not parsing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)