### PR TITLE
fix(task-expand): make expand:N exclusive (clear before add)

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -999,7 +999,14 @@ new MutationObserver(() => {
     .map(([id]) => id);
   if (Number.isInteger(idx) && idx >= 1 && idx <= ids.length) {
     const targetId = ids[idx - 1];
-    if (verb === 'expand') { expandedTasks.add(targetId); userExpanded.add(targetId); userCollapsed = false; }
+    if (verb === 'expand') {
+      // Exclusive expand: clear other expansions so only the target shows.
+      // Without this, the per-task expand is a visible no-op because
+      // working/done tasks are already in expandedTasks via auto-expand
+      // (see updateTask + the API poll auto-expand block).
+      expandedTasks.clear(); userExpanded.clear();
+      expandedTasks.add(targetId); userExpanded.add(targetId); userCollapsed = false;
+    }
     else if (verb === 'collapse') { expandedTasks.delete(targetId); userExpanded.delete(targetId); }
     renderTasks();
   } else {


### PR DESCRIPTION
## Summary
`expand:N` from #674 was technically working — target task landed in `expandedTasks` — but visually a no-op because working/done tasks **auto-expand** via `updateTask` (web-client.ts:977) and the API-poll auto-expand block (~line 1212). The target was already in the set, so adding again produced no visible change.

Now `expand:N` clears `expandedTasks` first then adds the target. Matches the voice agent's own narration ("I've expanded the first and **collapsed all others**").

## Repro
2026-05-14 01:22 PT: Chi voiced "expand the first task" multiple times. DevTools console showed `expandedTasks` already had 6 entries (3 working tasks auto-expanded), per-task expand kept adding to the set with no visible UI delta.

## Diff
8 lines in `src/web-client.ts:1000-1010`. Bare `expand` / `collapse` paths untouched.

## Test plan
- [x] tsc clean
- [ ] manual: voice "expand the first task" → only task 1 visible-expanded, others collapsed
- [ ] manual: voice "expand the second task" → only task 2 expanded
- [ ] manual: bare voice "collapse tasks" / "expand tasks" still behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)