### PR TITLE
fix(task-num): embed index into displayText instead of flex-child span

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -310,7 +310,6 @@ const HTML = /* html */ `<!DOCTYPE html>
   .task-status.working { background: #1e3a5f; color: #60a5fa; animation: pulse 1.5s infinite; }
   .task-status.done { background: #1e4028; color: #4ecca3; }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
-  .task-num { color: #9aa8c0; font-size: 15px; font-weight: 600; min-width: 28px; flex-shrink: 0; user-select: none; display: inline-block; }
   .task-text { color: #d0d0d8; flex: 1; word-break: break-word; font-size: 16px; line-height: 1.6; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .task-text.expanded { white-space: normal; }
   .task-time { color: #777; font-size: 13px; flex-shrink: 0; }
@@ -1110,10 +1109,6 @@ function renderTasks() {
   // persistence above keeps results from being lost across refreshes.
   const sorted = visible.sort((a, b) => b[1].time - a[1].time).slice(0, 30);
   container.innerHTML = sorted.map(([id, t], i) => {
-    // Display index (1-based) so voice can say "expand task 3" knowing
-    // exactly which task it is. Matches the taskIndex param the toggle_tasks
-    // tool accepts.
-    const taskNum = '<span class="task-num">' + (i + 1) + '.</span>';
     const icons = { pending: '&#8987;', working: '&#9881;', done: '&#10003;', error: '&#10007;' };
     const ago = Math.round((Date.now() - t.time) / 1000);
     const timeStr = ago < 60 ? ago + 's ago' : Math.round(ago / 60) + 'm ago';
@@ -1145,12 +1140,16 @@ function renderTasks() {
     // Default-tag bare tasks (no [Channel] prefix) as [Voice] — the
     // overwhelming majority of un-prefixed tasks come from the voice agent.
     const taggedRaw = /^\\[/.test(rawText) ? rawText : '[Voice] ' + rawText;
-    const displayText = isExpanded ? taggedRaw : summarizeTaskText(taggedRaw);
+    // Prepend the 1-based index INTO the display text so it always renders
+    // — earlier attempt with a separate <span class="task-num"> got
+    // zero-width even with min-width set (flex layout/min-content issue).
+    // Embedding sidesteps the layout question entirely.
+    const numPrefix = (i + 1) + '. ';
+    const displayText = numPrefix + (isExpanded ? taggedRaw : summarizeTaskText(taggedRaw));
     const textClass = isExpanded ? 'task-text expanded' : 'task-text';
     const expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide ▾' : 'Show details ▸') + '</span>' : '';
     return '<div class="task-item"' + clickAttr + '>' +
       '<div class="task-status ' + t.status + '">' + (icons[t.status] || '?') + '</div>' +
-      taskNum +
       '<span class="' + textClass + '">' + displayText + '</span>' +
       '<span class="task-time">' + timeStr + '</span>' +
       expandChip +


### PR DESCRIPTION
## Summary
Sidesteps the flex-layout puzzle that left the `1.` / `2.` numbering invisible despite three rounds of CSS bumps. DevTools confirmed all 30 `.task-num` spans had `width=0` even with `min-width:28px`, `flex-shrink:0`, and `display:inline-block` (computed `'block'` from flex-item normalization).

Now: prepend `(i + 1) + '. '` directly into `.task-text`'s displayText. Same visual outcome (`1. [Voice] task...`), one less layout puzzle. Removes the standalone `<span class="task-num">` + its CSS rule.

## Why repeated fixes failed
- #679 added the span — element rendered but unstyled-looking.
- #680 bumped color/size/weight — element styled but `getBoundingClientRect()` reported `w=0,h=0`.
- Yellow-box `!important width:60px;height:30px` test STILL didn't paint — confirming the layout collapsed the span entirely. Likely interaction between `.task-text { flex:1; flex-basis:0 }` and min-content sizing on a parent.

## Test plan
- [x] tsc clean
- [ ] visual: numbers visible inline at the start of each task row after merge + web-client kickstart + hard-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)