### PR TITLE
fix(task-num): apply numPrefix to the dynamic-region task list (2nd render path)

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -2277,7 +2277,7 @@ function renderTabContent() {
     } else {
       var sorted = entries.sort(function(a,b) { return b[1].time - a[1].time; }).slice(0, 10);
       var icons = { pending: '&#8987;', working: '&#9881;', done: '&#10003;', error: '&#10007;' };
-      container.innerHTML = sorted.map(function(entry) {
+      container.innerHTML = sorted.map(function(entry, i) {
         var id = entry[0], t = entry[1];
         var ago = Math.round((Date.now() - t.time) / 1000);
         var timeStr = ago < 60 ? ago + 's ago' : Math.round(ago / 60) + 'm ago';
@@ -2294,7 +2294,10 @@ function renderTabContent() {
         // overwhelming majority of un-prefixed tasks come from the voice agent.
         // (Was [Sutando-core]; renamed 2026-05-03 per Chi's "rename to Voice".)
         var taggedRaw = /^\\[/.test(rawText) ? rawText : '[Voice] ' + rawText;
-        var displayText = isExpanded ? taggedRaw : summarizeTaskText(taggedRaw);
+        // Prepend 1-based index — same as the primary renderTasks path,
+        // so voice can target tasks by number on this dynamic-region list too.
+        var numPrefix = (i + 1) + '. ';
+        var displayText = numPrefix + (isExpanded ? taggedRaw : summarizeTaskText(taggedRaw));
         var textClass = isExpanded ? 'task-text expanded' : 'task-text';
         var expandChip = hasResult ? '<span class="task-expand">' + (isExpanded ? 'Hide &#9662;' : 'Show details &#9656;') + '</span>' : '';
         return '<div class="task-item"' + clickAttr + '>' +


### PR DESCRIPTION
## Summary
PR #681 only patched the primary `renderTasks` at line 1148. The dashboard has a **second** task-list renderer at line 2280 (the dynamic-region contextual list) — that's the surface Chi was actually viewing. Hence "DevTools finds .task-text but text starts with '[Discord] '" — the 2nd renderer ran, no numPrefix.

This PR adds the same numPrefix logic to the 2nd renderer. `.map()` now passes `(entry, i)`.

## Why I missed it first time
Greped for `task-num` and `task-text` and patched the first match. Should have searched the full bundle for ALL `displayText` assignments before assuming one renderer.

## Test plan
- [x] tsc clean
- [ ] After merge + web-client kickstart + tab reopen: numbering appears on EVERY task in the dynamic-region list

🤖 Generated with [Claude Code](https://claude.com/claude-code)