### PR TITLE
fix(task-expand): preserve userCollapsed on expand:N (so collapse→expand-N actually isolates)

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -999,7 +999,14 @@ new MutationObserver(() => {
     .map(([id]) => id);
   if (Number.isInteger(idx) && idx >= 1 && idx <= ids.length) {
     const targetId = ids[idx - 1];
-    if (verb === 'expand') { expandedTasks.add(targetId); userExpanded.add(targetId); userCollapsed = false; }
+    if (verb === 'expand') {
+      // Add target. Do NOT reset userCollapsed — if the user just said
+      // "collapse all" → "expand task N", we want ONLY N visible.
+      // Resetting userCollapsed to false lets the API-poll auto-expand
+      // block re-add all working tasks on the next 3s tick, undoing the
+      // collapse and making per-task expand look like a no-op.
+      expandedTasks.add(targetId); userExpanded.add(targetId);
+    }
     else if (verb === 'collapse') { expandedTasks.delete(targetId); userExpanded.delete(targetId); }
     renderTasks();
   } else {


### PR DESCRIPTION
## Summary
After "collapse all → expand task N", the user expected ONLY task N to be visible. Actual behavior: all working tasks visible (collapse undone within 3s).

Root cause: my handler at `src/web-client.ts:1002` (introduced in #674) set `userCollapsed = false` after adding the target. The auto-expand block at line 1212 reads `userCollapsed` and re-adds all working tasks every 3s API poll. Setting false → auto-expand wins → other tasks come back.

## Fix
Don't touch `userCollapsed` in expand:N. Let collapse-all's sticky intent ride.

- If user just collapsed: stays `true` → auto-expand suppressed → only the target shows.
- If user hadn't collapsed: stays `false` → auto-expand keeps working as before.

## Test plan
- [x] tsc clean
- [ ] manual: "collapse tasks" then "expand task 3" → only task 3 visible
- [ ] manual: regular "expand task 3" without prior collapse → task 3 expanded + working tasks still auto-expand
- [ ] manual: "collapse all" alone → all collapsed, no auto-re-expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)