### PR TITLE
fix(web-client): remove TypeScript cast leak that broke UI runtime

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -1027,7 +1027,7 @@ new MutationObserver(() => {
       document.querySelectorAll('[data-taskid="' + targetId + '"]').forEach(function(el) {
         el.classList.remove('task-flash');
         // Force reflow so the animation re-triggers on repeat expand:N.
-        void (el as HTMLElement).offsetWidth;
+        void el.offsetWidth;
         el.classList.add('task-flash');
         setTimeout(function() { el.classList.remove('task-flash'); }, 1100);
       });


### PR DESCRIPTION
## Summary
- `void (el as HTMLElement).offsetWidth` from PR #684 sat inside an inline-JS template-string. The `as HTMLElement` cast leaked unchanged to the browser, causing `Uncaught SyntaxError: Unexpected identifier 'as'` and breaking the whole web UI.
- Drop the cast — querySelectorAll's HTMLElement typing at runtime makes it redundant anyway.

## Self-verification
- Edited file → `launchctl kickstart -k gui/$(id -u)/com.sutando.web-client` (PID 73145)
- Chrome MCP: navigated to http://localhost:8080/, `document.querySelectorAll('.task-item').length === 30`, `typeof renderTasks === 'function'`, console clean.

## Test plan
- [ ] Hard-refresh web UI; check Console for `Unexpected identifier 'as'` — should be gone
- [ ] Tasks list renders (was failing because the parse error halted script execution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)