### PR TITLE
fix(start-cli): enable tmux mouse-scroll by default

### DIFF
--- a/scripts/start-cli.sh
+++ b/scripts/start-cli.sh
@@ -78,6 +78,12 @@ fi
 # attaches. `mouse on` lets users two-finger scrollback in the Claude Code
 # pane (the default behavior, where Up-arrow goes to readline history and
 # you can't easily review prior agent output, is confusing for new installs).
+#
+# Tradeoff: `mouse on` intercepts native Cmd+drag text selection in the pane.
+# To copy text the macOS-native way, hold Option while dragging (Terminal.app,
+# iTerm2, Ghostty all honor Option-drag as a tmux-bypass). Documenting here
+# so future readers don't think this is a regression.
+#
 # Idempotent: re-running it on an already-configured server is a no-op.
 tmux -S "$TMUX_SOCKET" start-server 2>/dev/null || true
 tmux -S "$TMUX_SOCKET" set-option -g mouse on 2>/dev/null || true

--- a/scripts/start-cli.sh
+++ b/scripts/start-cli.sh
@@ -74,6 +74,14 @@ fi
 # TMPDIR due to macOS sandboxing when launched via `open`) can reach the
 # same tmux server as the user shell (per #PR_444 watcher-auto-restart).
 #
+# Sutando-friendly tmux defaults — applied to the server before the session
+# attaches. `mouse on` lets users two-finger scrollback in the Claude Code
+# pane (the default behavior, where Up-arrow goes to readline history and
+# you can't easily review prior agent output, is confusing for new installs).
+# Idempotent: re-running it on an already-configured server is a no-op.
+tmux -S "$TMUX_SOCKET" start-server 2>/dev/null || true
+tmux -S "$TMUX_SOCKET" set-option -g mouse on 2>/dev/null || true
+#
 # Branch on whether we have a TTY:
 #   - TTY (user running from terminal): exec attach so the user sees the
 #     Claude Code prompt and the script process IS the tmux client.


### PR DESCRIPTION
## Problem

New users open the Sutando core tmux pane and find Up-arrow goes to Claude Code's readline history, not to prior agent output. To review what just happened, they have to learn tmux copy-mode (`Ctrl-b [`, then arrows, then `q`) — enough friction that Qingyun (2026-05-13) flagged it as a real onboarding pain point.

## Fix

Set `-g mouse on` on the tmux server tied to Sutando's socket before the session attaches. Two-finger scrollback now works out of the box in any pane on that server.

## Scope

- One-line addition in `scripts/start-cli.sh` (plus a header comment explaining why)
- Affects only the Sutando-specific tmux server (`/tmp/sutando-tmux.sock`) — the user's other tmux configs / sessions are unchanged
- Idempotent — re-running on an already-configured server is a no-op
- Backward-compatible — users who already had a `.tmux.conf` with `mouse on` see no change; users with `mouse off` see only the Sutando socket flipped

## Test plan

- [ ] Fresh checkout: `bash scripts/start-cli.sh` → two-finger scroll-up in the Claude Code pane → see prior agent output
- [ ] Repeat in the same shell → no double-set warning, still works
- [ ] Run from Sutando.app's "Restart Core" menu (no-TTY branch) → same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)