### PR TITLE
docs(task-bridge): document [deduped]/[no-send]/[REPLIED] result-body markers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,12 @@ Tasks arrive from multiple channels via the same file bridge:
 - Proactive messages: write to `results/proactive-{ts}.txt` to speak to the user
 - To send files in replies, include `[file: /path/to/file]` in the result text
 
+**Result-body protocol markers** — when the result body STARTS with one of these, the bridge handles delivery specially. Use them when multiple related tasks should produce ONE user-facing reply instead of N separate ones:
+- `[deduped: task-<other-id>]` — both voice (task-bridge) and Discord (discord-bridge) silently archive this task as done, no narration, no DM. Put the full reply in the other task's result file and put this marker in each superseded task's result. The canonical way to handle thread-consolidated replies (e.g. when voice over-delegates 3 tasks for the same continuation utterance — see `src/task-bridge.ts:527`).
+- `[no-send]` — Discord bridge skips delivery for this task (still archives). Use when the task is internally handled but produces no user-visible reply.
+- `[REPLIED]` — Discord bridge skips delivery (already sent through another path).
+- `[file: /path]` / `[send: /path]` / `[attach: /path]` — Discord bridge extracts and attaches the file alongside the text body.
+
 **IMPORTANT:** On session start, check if the task watcher is running (`pgrep -f "watch-tasks"`). If not, start it with `bash src/watch-tasks.sh` using `run_in_background: true`. When notified, read the output — it lists ALL pending task files. Process every one, write results to `results/`, then restart the watcher. This is how voice commands reach you.
 
 ## Tutorial

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -63,6 +63,7 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 1. **Check for tasks.** Look in `tasks/` for voice / Discord / Telegram / phone tasks. Look at `context-drop.txt` for context drops. Process anything found — execute the task, write results to `results/`.
    - **Access control:** If the task has `access_tier: other` or `access_tier: team`, delegate to a sandboxed agent. Do NOT process non-owner tasks with your full capabilities. Write the sandboxed output to results.
    - Only `access_tier: owner` (or tasks without an access_tier field) get full processing.
+   - **Thread consolidation:** when several tasks in a short window are the same continuation thought (e.g. voice over-delegating "yes, right, this is useful…" as 3 separate tasks), put the FULL reply in the latest task's result and put `[deduped: task-<latest-id>]` in each earlier task's result. The bridge silently archives the deduped ones — no voice cascade, no DM duplicates. See CLAUDE.md "Result-body protocol markers" for the full marker list.
 
 2. **Check pending questions.** Read `pending-questions.md`. If any unanswered items and voice client is connected, surface them via `results/question-{ts}.txt`. Also send a macOS notification.
 


### PR DESCRIPTION
## What this is

The task-bridge already supports a `[deduped: task-<other-id>]` result-body marker (`src/task-bridge.ts:527`) that silently archives a task — no voice narration, no Discord DM. Discord-bridge also recognises `[no-send]` and `[REPLIED]` (`src/discord-bridge.py:2601`). None are documented in `CLAUDE.md` or any skill prompt today; the only marker the docs mentioned was `[file: ...]` for attachments.

## Why now

In a 2026-05-14 voice session, this very proactive-loop processed 13 voice tasks across 3 continuation threads (over-delegation from the voice agent). I wrote stub "(see other reply)" results for the superseded tasks instead of using the dedup marker — because I didn't know it existed. The bridge played all 13 replies in sequence (turns 18–28 in `logs/voice-agent.log`), producing an interrupt cascade and the owner ended the session.

The `[deduped: ...]` path would have silenced 10 of those replies. Documenting it surfaces an existing-but-hidden protocol so the next pass doesn't repeat the mistake.

## Changes

- `CLAUDE.md` "## Task bridge" — new **Result-body protocol markers** block listing `[deduped]`, `[no-send]`, `[REPLIED]`, and the file-attach trio (`[file:` / `[send:` / `[attach:`).
- `skills/proactive-loop/SKILL.md` step 1 — thread-consolidation guidance pointing at the dedup marker, cross-linked to the full list in `CLAUDE.md`.

7 lines added, 0 changed. Pure docs.

## What this is *not*

- Not a code change to the bridges. The behaviour was already there.
- Not a prompt change to the voice agent. Per CLAUDE.md ("do not change prompts"), I left voice-agent.ts alone. The over-delegation pattern that motivated this is a separate problem; documenting the dedup marker is the cheapest mitigation pending a real fix.
- Not in conflict with #565 / #534 / #619. Different file, different topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)