### PR TITLE
fix(tts): strip quotes from .env-parsed API key (gemini-tts + openai-tts)

### DIFF
--- a/skills/gemini-tts/scripts/synthesize.sh
+++ b/skills/gemini-tts/scripts/synthesize.sh
@@ -25,6 +25,7 @@ TEXT="${ARGS[*]-}"
 
 REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
 KEY="${GEMINI_API_KEY:-$(grep -E '^GEMINI_API_KEY=' "$REPO/.env" 2>/dev/null | cut -d= -f2-)}"
+KEY="${KEY%\"}"; KEY="${KEY#\"}"; KEY="${KEY%\'}"; KEY="${KEY#\'}"
 [[ -n "$KEY" ]] || { echo "GEMINI_API_KEY missing (set env or add to .env)" >&2; exit 1; }
 
 [[ -n "$OUT" ]] || OUT="$REPO/results/gemini-tts-$(date +%s).mp3"

--- a/skills/openai-tts/scripts/synthesize.sh
+++ b/skills/openai-tts/scripts/synthesize.sh
@@ -20,6 +20,7 @@ TEXT="${ARGS[*]-}"
 
 REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
 KEY="${OPENAI_API_KEY:-$(grep -E '^OPENAI_API_KEY=' "$REPO/.env" 2>/dev/null | cut -d= -f2-)}"
+KEY="${KEY%\"}"; KEY="${KEY#\"}"; KEY="${KEY%\'}"; KEY="${KEY#\'}"
 [[ -n "$KEY" ]] || { echo "OPENAI_API_KEY missing" >&2; exit 1; }
 
 [[ -n "$OUT" ]] || OUT="$REPO/results/openai-tts-$(date +%s).mp3"


### PR DESCRIPTION
## Summary

`KEY=\$(grep -E '^KEY=' .env | cut -d= -f2-)` keeps the literal quotes when the .env line is `KEY=\"abc\"` or `KEY='abc'`. The Authorization header ends up as `Bearer \"abc123\"` and the request 401s with no useful error (curl -sSf just exits 22).

1-line shell-parameter-expansion strip mirrored in both `skills/gemini-tts/scripts/synthesize.sh` and `skills/openai-tts/scripts/synthesize.sh` — they shipped identical env-parse patterns.

## Why

- `telegram-bridge.py`'s `load_env` already strips quotes — codebase convention.
- This Mac's .env happens to use unquoted values so the bug doesn't fire locally — but quoted .env values are normal practice and break silently.
- Originated from the non-blocking note on PR #646 review (2026-05-11). #646 itself is superseded by main, but the env-quote note still applies on main. Closing #646 doesn't address the bug.

## Test plan

Verified all 4 cases:

```
DQUOTED_KEY -> [abc123]   # double-quoted in .env -> stripped
SQUOTED_KEY -> [def456]   # single-quoted in .env -> stripped
UNQUOTED_KEY -> [ghi789]  # unquoted -> unchanged
MIXED -> [hard'value]     # interior single-quote in double-quoted -> preserved
```

Both scripts still exit cleanly with the Usage message when run with no args (no regression in pre-API flow). `bash -n` clean.

## Risk

Trivial. If a user has a literal leading/trailing `\"` or `'` as a real character in their key, this strips it — but no real API key has that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)