### PR TITLE
docs(gemini-tts): note that bracket audio tags are stylistic, not spoken literally

### DIFF
--- a/skills/gemini-tts/SKILL.md
+++ b/skills/gemini-tts/SKILL.md
@@ -18,6 +18,14 @@ ARGUMENTS: $ARGUMENTS
 
 `Aoede` (default — alto, neutral), `Charon` (baritone, news-anchor), `Kore` (mid, expressive), `Puck` (high, conversational). Per Lucy's 2026-05-09 testing: Aoede is the closest match to OpenAI's `sage`.
 
+## Audio tags for expression
+
+Inline bracket tags like `[whispers]`, `[excitedly]`, `[slowly]` are interpreted as stylistic direction, not spoken literally. Empirically verified against `gemini-2.5-flash-preview-tts` (per PR #646 comment): `[whispers] hello` → 1.05s audio; `hello` alone → 1.01s. If the tag were spoken literally as 8 words, the clip would be ~5× longer.
+
+```bash
+bash "$SKILL_DIR/scripts/synthesize.sh" -- "[whispers] Pull request 691 has landed."
+```
+
 ## Model selection
 
 Default: `gemini-2.5-flash-preview-tts` (free tier, 1500 req/day, $0 within quota).


### PR DESCRIPTION
## Summary

8-line addition to `skills/gemini-tts/SKILL.md` documenting that inline bracket tags (`[whispers]`, `[excitedly]`, `[slowly]`) are interpreted as stylistic direction by Gemini TTS, not spoken as literal words.

## Why

The question is non-obvious — a reader seeing `[whispers]` in a TTS doc could reasonably wonder whether Gemini parses or speaks it. Currently main says nothing on this.

PR #646 had the same audio-tag note plus empirical verification from amkunte (2026-05-13 comment):

| input | output bytes | duration (24kHz, 16-bit) |
|---|---|---|
| `[whispers] hello` | 50446 | 1.05s |
| `hello` | 48526 | 1.01s |

If `[whispers]` were spoken literally (8 words), the audio would be ~5× longer. It isn't.

#646 is superseded by main, so its audio-tag note is the one piece worth carrying forward — this PR does that.

## Risk

Docs-only. Trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)