### PR TITLE
docs(README): point Web badge to sutando.ag2.ai + add OSS-vs-native-app split

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sutando
 
-[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ag2.ai-blue)](https://sutando.ag2.ai)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ai-blue)](https://sutando.ai)
 
 **My AI Stand — Realtime by Day, Coding Itself by Night.**
 
@@ -9,7 +9,7 @@ Voice, vision, screen, meetings, calls when I'm engaged. Learns my patterns, shi
 It belongs entirely to you.
 
 > 🛠 **Open source:** this repo — clone, build, run locally on your own Mac.
-> 🍎 **Native app preview:** [sutando.ag2.ai](https://sutando.ag2.ai) — packaged Mac app, request access.
+> 🍎 **Native app preview:** [sutando.ai](https://sutando.ai) — packaged Mac app, request access.
 
 > **No *Claude Extra usage* required.** Sutando runs on your existing Claude Code subscription ($20, $100, or $200/month) with minimal extra costs — no separate Anthropic API key to top up — unlike agents that route every action through pay-per-token APIs and hosted services.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Sutando
 
-[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ai-blue)](https://sutando.ai)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ag2.ai-blue)](https://sutando.ag2.ai)
 
 **My AI Stand — Realtime by Day, Coding Itself by Night.**
 
 Voice, vision, screen, meetings, calls when I'm engaged. Learns my patterns, ships its own code when I'm not. Runs across my Macs, interacts with people & their Stands.
 
 It belongs entirely to you.
+
+> 🛠 **Open source:** this repo — clone, build, run locally on your own Mac.
+> 🍎 **Native app preview:** [sutando.ag2.ai](https://sutando.ag2.ai) — packaged Mac app, request access.
 
 > **No *Claude Extra usage* required.** Sutando runs on your existing Claude Code subscription ($20, $100, or $200/month) with minimal extra costs — no separate Anthropic API key to top up — unlike agents that route every action through pay-per-token APIs and hosted services.
 


### PR DESCRIPTION
## Summary
- Two-line "Open source / Native app preview" split near the top of the README, so viewers landing from Sutando WIRE ep005 (which references both `github.com/sonichi/sutando` and `sutando.ag2.ai`) immediately understand the relationship without conflating the two URLs.
- Stale Web badge `sutando.ai` → `sutando.ag2.ai`.

## Why now
ep005 ("Three labs, three directions") is shipping today with both URLs in the caption + YouTube description. Without README context, first-time visitors clicking either URL won't know which is which.

## Test plan
- [x] Rendered README locally — badge URL updated, blockquote renders cleanly above the existing "No Claude Extra usage required" callout
- [ ] Reviewer to confirm phrasing ("Native app preview") matches what we want long-term

🤖 Generated with [Claude Code](https://claude.com/claude-code)