### PR TITLE
fix(vision): prefer free-tier voice key for describe_screen (Option B)

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -241,8 +241,10 @@ export const openUrlTool: ToolDefinition = {
 // --- Describe screen (vision) ---
 
 async function describeScreenshot(imagePath: string, previousDescs: string[] = []): Promise<string> {
-	const apiKey = process.env.GEMINI_API_KEY;
-	if (!apiKey) return 'Vision description unavailable (no GEMINI_API_KEY)';
+	// Prefer free-tier voice key (gemini-3.1-flash-lite-preview is free-tier eligible on REST
+	// generateContent — verified 2026-05-14). Falls back to paid GEMINI_API_KEY if voice key absent.
+	const apiKey = process.env.GEMINI_VOICE_API_KEY || process.env.GEMINI_API_KEY;
+	if (!apiKey) return 'Vision description unavailable (no GEMINI_VOICE_API_KEY or GEMINI_API_KEY)';
 	try {
 		// Fixes CodeQL #27 (js/command-line-injection): use execFileSync argv array instead of shell string
 		const safePath = imagePath.replace(/[^a-zA-Z0-9_\-./]/g, '');

--- a/src/recording-tools.ts
+++ b/src/recording-tools.ts
@@ -273,8 +273,10 @@ function findRecording(version?: 'raw' | 'narrated' | 'subtitled'): string | nul
 // --- Vision helpers ---
 
 async function describeScreenshot(imagePath: string, previousDescs: string[] = []): Promise<string> {
-	const apiKey = process.env.GEMINI_API_KEY;
-	if (!apiKey) return 'Vision description unavailable (no GEMINI_API_KEY)';
+	// Prefer free-tier voice key (gemini-3.1-flash-lite-preview is free-tier eligible on REST
+	// generateContent — verified 2026-05-14). Falls back to paid GEMINI_API_KEY if voice key absent.
+	const apiKey = process.env.GEMINI_VOICE_API_KEY || process.env.GEMINI_API_KEY;
+	if (!apiKey) return 'Vision description unavailable (no GEMINI_VOICE_API_KEY or GEMINI_API_KEY)';
 	try {
 		// Fixes CodeQL #27 (js/command-line-injection): use execFileSync argv array instead of shell string
 		const safePath = imagePath.replace(/[^a-zA-Z0-9_\-./]/g, '');


### PR DESCRIPTION
## Summary
- `describeScreenshot()` in both `src/browser-tools.ts` and `src/recording-tools.ts` now reads `GEMINI_VOICE_API_KEY` first, falling back to `GEMINI_API_KEY`.
- Vision (REST `generateContent` on `gemini-3.1-flash-lite-preview`) is free-tier eligible — routes vision off the paid key by default.

## Why
Users following the PR #452 voice-key isolation pattern now get vision at \$0 instead of metering it on their main key.

## Empirical check
- `curl :generateContent?key=\$GEMINI_VOICE_API_KEY` with `gemini-3.1-flash-lite-preview` → HTTP 200, `serviceTier: standard` (2026-05-14).
- Live API + image input also works on the voice key via `send_client_content` + `Part(inline_data=Blob)` — separate finding, not part of this PR.

## Caveats not addressed in this PR
- `describeScreenshot()` is duplicated verbatim across the two files — DRY refactor deferred.
- Free-tier RPM caps under sustained describe_screen load (5s intervals during screen recording) untested. Current code returns an error string on 429 — no automatic fallback to paid key. If sustained recording sessions break, a follow-up should add a 429-retry-on-paid-key path.
- `src/voice-agent.ts` header comment (line 14) still calls `GEMINI_API_KEY` the "vision" key. `.env.example` (5-16) still implies vision = paid. Doc cleanup deferred to a separate PR.

## Test plan
- [ ] With `GEMINI_VOICE_API_KEY` set: voice-agent `describe_screen` returns a valid caption.
- [ ] With only `GEMINI_API_KEY` set: behavior unchanged (fallback).
- [ ] With neither set: error message names both keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)