### PR TITLE
fix(oss): remove Chi-specific paths/IDs from tool descriptions

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -968,7 +968,7 @@ function cleanupCall(callSid: string): void {
 			`instructions:`,
 			`  1. Write a structured summary: ## Key Topics, ## Decisions, ## Action Items, ## Notable Quotes`,
 			`  2. Save to notes/meetings/${summaryTaskId}.md with YAML frontmatter (title, date, tags: [meeting])`,
-			`  3. Send a concise version (3-5 bullet points) to Discord DM (channel 1485370959870431433)`,
+			`  3. Send a concise version (3-5 bullet points) to Discord DM (bridge resolves owner DM channel from $SUTANDO_DM_OWNER_ID / access.json allowFrom)`,
 			`  4. Write result to results/${summaryTaskId}.txt so voice agent can speak it`,
 			`transcript:`,
 			formatted,

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -968,7 +968,7 @@ function cleanupCall(callSid: string): void {
 			`instructions:`,
 			`  1. Write a structured summary: ## Key Topics, ## Decisions, ## Action Items, ## Notable Quotes`,
 			`  2. Save to notes/meetings/${summaryTaskId}.md with YAML frontmatter (title, date, tags: [meeting])`,
-			`  3. Send a concise version (3-5 bullet points) to Discord DM (bridge resolves owner DM channel from $SUTANDO_DM_OWNER_ID / access.json allowFrom)`,
+			`  3. Send a concise version (3-5 bullet points) to the owner via Discord DM.`,
 			`  4. Write result to results/${summaryTaskId}.txt so voice agent can speak it`,
 			`transcript:`,
 			formatted,

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -27,7 +27,7 @@ export const openFileTool: ToolDefinition = {
 		'If the user says "open the log" or similar, ASK which log they mean (voice-agent, discord-bridge, etc.) — do NOT guess. ' +
 		'Known files: "diagnostic tracker" or "diagnostics" = /tmp/phone-diagnostics-tracker.html, ' +
 		'"voice diagnostics" = /tmp/voice-diagnostics-tracker.html, ' +
-		'"voice context" / "the voice context file" / "the active context" = $SUTANDO_PRIVATE_DIR/voice-contexts/<active>.txt where <active> is the trimmed contents of $SUTANDO_PRIVATE_DIR/voice-contexts/active. Pass it with the env-var expanded by you (e.g. /Users/wangchi/.sutando-memory-sync/voice-contexts/ag2ai-investor.txt) or as $SUTANDO_PRIVATE_DIR/voice-contexts/ag2ai-investor.txt — both work. ' +
+		'"voice context" / "the voice context file" / "the active context" = $SUTANDO_PRIVATE_DIR/voice-contexts/<active>.txt where <active> is the trimmed contents of $SUTANDO_PRIVATE_DIR/voice-contexts/active. Pass it with the env-var expanded by you, or as $SUTANDO_PRIVATE_DIR/voice-contexts/<active>.txt — both work. ' +
 		'Pass `app` when the user names a specific app ("open with Sublime Text", "open the SQLite db in TablePlus") OR when recent conversation makes the intended app clear (e.g. user just said "I\'ll review this in VS Code"). Without `app`, macOS uses its default handler for that file type — leave unset when the default is fine. ' +
 		'Pass `fullscreen=true` if the user wants the file opened in fullscreen — works generically for any file type via Cmd+Ctrl+F to whichever app the OS routed the file to (QuickTime → Present mode, Preview → fullscreen PDF, Chrome → fullscreen page, etc.).',
 	parameters: z.object({


### PR DESCRIPTION
## Summary
Two hardcoded literals that bake an OSS-user-failing assumption into the shipped code, caught after an OSS user's Discord drop:

1. **`src/inline-tools.ts:30`** — `openFileTool` description had `/Users/wangchi/.sutando-memory-sync/voice-contexts/ag2ai-investor.txt` as a literal example. Replaced with `<active>` placeholder.
2. **`skills/phone-conversation/scripts/conversation-server.ts:971`** — phone-summary task instructed delivery to hardcoded channel `1485370959870431433` (Chi's DM). Rewrote to reference the bridge's runtime resolution (`$SUTANDO_DM_OWNER_ID` / `access.json` allowFrom), which `src/dm-result.py` already implements correctly.

## Behavior

- **Owner instance** (Chi's macs): no change — env vars + access.json resolve to the same channel/path.
- **OSS user**: phone-call summaries now route to *their* owner DM channel via bridge resolution; voice-context example doesn't point Gemini at a path that doesn't exist on their machine.

## Diff size
2 files, +2/-2. Typecheck clean (`npx tsc --noEmit`).

## Not addressed in this PR
- `sonichi/sutando` GitHub URLs in `src/health-check.py`, `src/session-handoff.sh`, `src/web-client.ts`, etc. — these are *correct* repo references for OSS users to find the canonical repo. Not bugs.
- Other Chi-specific configurations (e.g. `VERIFIED_CALLERS`, voice context names) are correctly env-gated or `.env`-driven; no action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)