### PR TITLE
fix(discord-bridge): unblock asyncio loop in poll_dm_fallback (rudyalways PR #653 follow-up)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2913,7 +2913,10 @@ async def poll_dm_fallback():
                     if _task_file.exists():
                         archive_file(_task_file, "tasks", _task_id)
                     if _result_text and _task_id.startswith("task-"):
-                        notify_agent_api_task_done(_task_id, _result_text)
+                        # urlopen is blocking — run in thread so we don't stall
+                        # the asyncio event loop for up to 2s per dm-fallback.
+                        # Per rudyalways PR #653 post-merge review.
+                        await asyncio.to_thread(notify_agent_api_task_done, _task_id, _result_text)
                 else:
                     stderr = (result.stderr or "").strip()[:200]
                     print(f"  [dm-fallback] dm-result.py failed on {f.name}: {stderr}", flush=True)


### PR DESCRIPTION
## Summary

Post-merge fix for the bug rudyalways flagged on PR #653 (merged earlier today):

> **Blocking call inside async event loop — medium**
> `notify_agent_api_task_done` uses `urllib.request.urlopen(req, timeout=2)` synchronously, but it's called from `async def poll_dm_fallback()` at `src/discord-bridge.py:2761`. `urlopen` is a synchronous, blocking IO call — for up to **2 seconds per dm-fallback delivery, the entire asyncio event loop is stalled**. No incoming DMs are processed, no other coroutines run, `tasks/active` polls back up.

## Fix

Wrap the call site in `asyncio.to_thread(...)` so the blocking `urlopen` runs in a worker thread and the event loop stays responsive. Only one caller of `notify_agent_api_task_done` — local fix, no signature change.

```diff
-                        notify_agent_api_task_done(_task_id, _result_text)
+                        await asyncio.to_thread(notify_agent_api_task_done, _task_id, _result_text)
```

`asyncio` is already imported at `src/discord-bridge.py:9`.

## Test plan

- [ ] tsc + tests CI green
- [ ] Manual: trigger a dm-fallback (kill voice-agent → owner ping route falls through to DM) and verify discord-bridge keeps polling other DMs in parallel
- [ ] Verify no functional regression — payload, archiving, headers all unchanged

cc: @rudyalways — thanks for catching this. Inviting you to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)