### PR TITLE
fix(discord-bridge): honor SUTANDO_WORKSPACE for REPO resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,3 +142,8 @@ PORT=9900
 # Must match the secret configured in GitHub repo Settings → Webhooks → Secret.
 # If not set, all webhook payloads are rejected (fail-closed).
 # GITHUB_WEBHOOK_SECRET=your-webhook-secret-here
+
+# sutando workspace — set when src/ is a symlink into a packaged app bundle,
+# so the bridges write tasks/results into the user workspace rather than
+# the bundle's copy of src/. Leave unset for a normal git-clone install.
+# SUTANDO_WORKSPACE=/path/to/workspace

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -18,7 +18,16 @@ from pathlib import Path
 
 import discord
 
-REPO = Path(__file__).resolve().parent.parent
+# REPO resolution: prefer SUTANDO_WORKSPACE env var so the bridge writes to the
+# user's workspace tasks/results/state dirs, not the app-bundle's copy. When
+# this file lives under /Applications/Sutando.app/.../repo/src/, the workspace
+# `src/` is typically a symlink into the bundle, so `Path(__file__).resolve()`
+# walks INTO the bundle and `parent.parent` returns the bundle root rather
+# than the workspace. That divergence stranded owner DMs on 2026-05-14 — the
+# bridge wrote tasks to bundle-tasks/ while core agent watched workspace-tasks/.
+import os
+_workspace_env = os.environ.get("SUTANDO_WORKSPACE")
+REPO = Path(_workspace_env) if _workspace_env else Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from util_paths import shared_personal_path  # noqa: E402
 


### PR DESCRIPTION
## Summary
- `src/discord-bridge.py`: when `SUTANDO_WORKSPACE` is set, resolve `REPO` from that path instead of `Path(__file__).resolve().parent.parent`. Fixes the bundle/workspace divergence that stranded owner DMs on 2026-05-14 — bridge wrote tasks to bundle-tasks/ while core watched workspace-tasks/.
- `.env.example`: document when to set `SUTANDO_WORKSPACE` (app-bundle installs where src/ is symlinked; leave unset for normal git-clone).

## Test plan
- [ ] Set `SUTANDO_WORKSPACE` in `.env`, restart bridge, DM the bot → task lands in the workspace `tasks/`, not the bundle copy
- [ ] Unset `SUTANDO_WORKSPACE`, restart bridge → falls back to the previous `Path(__file__).resolve().parent.parent` behavior