### PR TITLE
fix(vision): migrate gemini-3.1-flash-lite preview→GA before May 25 deprecation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,7 +127,7 @@ PORT=9900
 # VOICE_NAME=Puck
 
 # Screen vision model (20-word screenshot descriptions — flash-lite is cheapest)
-# VISION_MODEL=gemini-3.1-flash-lite-preview
+# VISION_MODEL=gemini-3.1-flash-lite
 
 # Image generation model
 # IMAGE_MODEL=gemini-3.1-flash-image-preview

--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -28,7 +28,7 @@ export function injectText(session: any, text: string) {
 }
 
 // Vision model — override via .env (default: flash-lite for this trivial 20-word task)
-const VISION_MODEL = process.env.VISION_MODEL || 'gemini-3.1-flash-lite-preview';
+const VISION_MODEL = process.env.VISION_MODEL || 'gemini-3.1-flash-lite';
 
 // --- Scroll ---
 

--- a/src/recording-tools.ts
+++ b/src/recording-tools.ts
@@ -53,7 +53,7 @@ function injectText(session: any, text: string) {
 }
 
 // Vision model — override via .env (default: flash-lite for this trivial 20-word task)
-const VISION_MODEL = process.env.VISION_MODEL || 'gemini-3.1-flash-lite-preview';
+const VISION_MODEL = process.env.VISION_MODEL || 'gemini-3.1-flash-lite';
 
 // --- Shared recording state ---
 


### PR DESCRIPTION
## Summary

- `src/browser-tools.ts:31` + `src/recording-tools.ts:56` + `.env.example:130`: drop `-preview` suffix to migrate the vision model identifier from `gemini-3.1-flash-lite-preview` → `gemini-3.1-flash-lite`.
- Triggered by Google AI Studio email 2026-05-14: the Preview variant is deprecated **May 25, 2026** (10 days). Email explicitly states "no modifications to user-defined prompts or application logic are required; only the model identifier string."

## Affected surfaces

| File | Line | What |
|---|---|---|
| `src/browser-tools.ts` | 31 | `VISION_MODEL` default for `describeScreenshot()` |
| `src/recording-tools.ts` | 56 | `VISION_MODEL` default in recording surface |
| `.env.example` | 130 | Commented-out user override example |

The free-tier-eligibility comments at `browser-tools.ts:244` + `recording-tools.ts:276` are left untouched; they reference the preview model's empirically-verified free-tier status. **If the GA model's free-tier status differs, that's a follow-up PR** (see test plan below).

## ⚠️  Pre-merge test plan

Free-tier eligibility on `gemini-3.1-flash-lite` was NOT confirmed in the deprecation email. Recommend a 1-line REST sanity check before merging:

```bash
curl -s -X POST \
  "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent?key=$GEMINI_VOICE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"contents":[{"parts":[{"text":"hi"}]}]}' | jq '.candidates[0].content.parts[0].text, .error'
```

- 200 + text → GA model accepts the voice (free-tier) key, ship as-is.
- 403/429 → GA dropped free-tier; either update the comments at lines 244/276 + budget for paid usage, OR find a different default.

## Why now

Deprecation deadline is **May 25, 2026** (10 days). After that date any request to `gemini-3.1-flash-lite-preview` returns an error and `describe_screen` / vision-driven recording tools stop working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)