### PR TITLE
fix(web-client): add gap to tasks-header flex spans (Tasks / show N done / expand all)

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -1162,6 +1162,7 @@ function renderTasks() {
   if (hdr) {
     const hasExpanded = expandedTasks.size > 0;
     hdr.style.display = 'flex';
+    hdr.style.gap = '12px';
     const doneToggle = doneCount > 0
       ? '<span onclick="toggleShowDone()" style="cursor:pointer">' +
         (showDone ? 'hide ' + doneCount + ' done' : 'show ' + doneCount + ' done') +


### PR DESCRIPTION
## Summary

`src/web-client.ts:1164` — the three `<span>` elements inside `#tasks-header` (Tasks label / show-done toggle / expand-all toggle) were rendered with `hdr.style.display = 'flex'` but no `gap`. Visually they smushed together as one mashed-up string ("Tasksshow 488 doneexpand all") instead of three distinct clickable affordances.

Adds `hdr.style.gap = '12px'` alongside the existing flex display.

## How spotted

Chi hotkey-dropped the Tasks-tab header into the chat this morning. The captured text came through as 3 newline-separated tokens:
```
Tasks
show 488 done
expand all
```

He then asked: "concatenated text is UI bug?" — yes, this fix.

## Test plan

- [ ] Restart web-client (`launchctl kickstart -k gui/$(id -u)/com.sutando.web-client`)
- [ ] Hard-refresh `http://localhost:8080/`
- [ ] Click "Tasks" section header — three affordances should now be visibly separated by ~12px

## Why now

Cosmetic but easy. Saves Chi the "what are those three things smushed together?" question every time he visits the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)