### PR TITLE
chore(readme): tagline 'Coding Itself' → 'Rewriting Itself'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Sutando
 
-[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ai-blue)](https://sutando.ai)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ag2.ai-blue)](https://sutando.ag2.ai)
 
-**My AI Stand — Realtime by Day, Coding Itself by Night.**
+**My AI Stand — Realtime by Day, Self Improve by Night.**
 
 Voice, vision, screen, meetings, calls when I'm engaged. Learns my patterns, ships its own code when I'm not. Runs across my Macs, interacts with people & their Stands.
 
 It belongs entirely to you.
 
 > 🛠 **Open source:** this repo — clone, build, run locally on your own Mac.
-> 🍎 **Native app preview:** [sutando.ai](https://sutando.ai) — packaged Mac app, request access.
+> 🍎 **Native app preview:** [sutando.ag2.ai](https://sutando.ag2.ai) — packaged Mac app, request access.
 
 > **No *Claude Extra usage* required.** Sutando runs on your existing Claude Code subscription ($20, $100, or $200/month) with minimal extra costs — no separate Anthropic API key to top up — unlike agents that route every action through pay-per-token APIs and hosted services.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Sutando
 
-[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ag2.ai-blue)](https://sutando.ag2.ai)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ai-blue)](https://sutando.ai)
 
-**My AI Stand — Realtime by Day, Self Improve by Night.**
+**My AI Stand — Realtime by Day, Rewriting Itself by Night.**
 
 Voice, vision, screen, meetings, calls when I'm engaged. Learns my patterns, ships its own code when I'm not. Runs across my Macs, interacts with people & their Stands.
 
 It belongs entirely to you.
 
 > 🛠 **Open source:** this repo — clone, build, run locally on your own Mac.
-> 🍎 **Native app preview:** [sutando.ag2.ai](https://sutando.ag2.ai) — packaged Mac app, request access.
+> 🍎 **Native app preview:** [sutando.ai](https://sutando.ai) — packaged Mac app, request access.
 
 > **No *Claude Extra usage* required.** Sutando runs on your existing Claude Code subscription ($20, $100, or $200/month) with minimal extra costs — no separate Anthropic API key to top up — unlike agents that route every action through pay-per-token APIs and hosted services.
 

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -328,7 +328,7 @@ def render_dashboard() -> str:
 <a href="http://localhost:7845" style="color:#4a8aaa;text-decoration:none">Screen Capture :7845</a>
 <a href="/notes-ui" style="color:#4a8aaa;text-decoration:none">Notes Browser</a>
 <a href="https://github.com/sonichi/sutando" style="color:#4a8aaa;text-decoration:none">GitHub</a>
-<a href="https://sutando.ag2.ai" style="color:#4a8aaa;text-decoration:none">Website</a>
+<a href="https://sutando.ai" style="color:#4a8aaa;text-decoration:none">Website</a>
 <a href="https://discord.gg/uZHWXXmrCS" style="color:#4a8aaa;text-decoration:none">Discord</a>
 </div></div>""")
 

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -328,7 +328,7 @@ def render_dashboard() -> str:
 <a href="http://localhost:7845" style="color:#4a8aaa;text-decoration:none">Screen Capture :7845</a>
 <a href="/notes-ui" style="color:#4a8aaa;text-decoration:none">Notes Browser</a>
 <a href="https://github.com/sonichi/sutando" style="color:#4a8aaa;text-decoration:none">GitHub</a>
-<a href="https://sutando.ai" style="color:#4a8aaa;text-decoration:none">Website</a>
+<a href="https://sutando.ag2.ai" style="color:#4a8aaa;text-decoration:none">Website</a>
 <a href="https://discord.gg/uZHWXXmrCS" style="color:#4a8aaa;text-decoration:none">Discord</a>
 </div></div>""")
 


### PR DESCRIPTION
## Summary

- Tagline: `Coding Itself by Night` → `Self Improve by Night`
- Domain rename across README + dashboard footer: `sutando.ai` → `sutando.ag2.ai`

## Files

- `README.md` — tagline + 2 link references
- `src/dashboard.py` — footer Website link

## Test plan

- [ ] Visual check on the rendered README on GitHub
- [ ] Dashboard footer link at http://localhost:7844/ resolves to the new domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)