### PR TITLE
feat(framing): layer "Summon my AI superpower" CTA into README + web tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ai-blue)](https://sutando.ai)
 
 **My AI Stand — Realtime by Day, Coding Itself by Night.**
-**Summon your AI superpower.**
+**Summon my AI superpower.**
 
 Voice, vision, screen, meetings, calls when I'm engaged. Learns my patterns, ships its own code when I'm not. Runs across my Macs, interacts with people & their Stands.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ai-blue)](https://sutando.ai)
 
 **My AI Stand — Realtime by Day, Coding Itself by Night.**
+**Summon your AI superpower.**
 
 Voice, vision, screen, meetings, calls when I'm engaged. Learns my patterns, ships its own code when I'm not. Runs across my Macs, interacts with people & their Stands.
 

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -674,7 +674,7 @@ fetch('http://localhost:7844/stand-identity').then(r=>r.json()).then(s=>{
     </svg>
   </div>
   <h2 id="hero-name">Sutando</h2>
-  <p class="tagline">My AI Stand · Summon your AI superpower</p>
+  <p class="tagline">My AI Stand · Summon my AI superpower</p>
   <button class="btn-hero" onclick="toggle()">Start Voice</button>
 </div>
 

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -674,7 +674,7 @@ fetch('http://localhost:7844/stand-identity').then(r=>r.json()).then(s=>{
     </svg>
   </div>
   <h2 id="hero-name">Sutando</h2>
-  <p class="tagline">My AI Stand</p>
+  <p class="tagline">My AI Stand · Summon your AI superpower</p>
   <button class="btn-hero" onclick="toggle()">Start Voice</button>
 </div>
 


### PR DESCRIPTION
## Summary

Adds the original [PR #44](https://github.com/sonichi/sutando/pull/44) CTA verb back into the README hero and web-client tagline as a *second* line, without removing the PR #666 "My AI Stand" brand line. The two reinforce each other — Stand is the *what*, "Summon your AI superpower" is the *what-you-feel*.

**Why now:** Robin Li keynoted Baidu Create 2026 on 2026-05-14 framing the personal-AI category as *"the rise of super individuals."* "Superpower" reads differently in that discourse window than it did when PR #44 originally shipped it. Restoring the verb-pair now positions the docs ahead of the Observe Summit talk on June 4.

## Diff (surgical)

- `README.md` hero (line 5+6): adds one bolded CTA line under the brand line
- `src/web-client.ts:649` tagline: `My AI Stand` → `My AI Stand · Summon your AI superpower`
  - The dynamic stand-identity branch at `src/web-client.ts:590-591` still overrides this with the user's named-Stand origin once they earn one — unchanged behavior post-naming
- `summonTool` in `src/inline-tools.ts` already carries the verb in code (Zoom + screen-share + computer-audio); this brings docs back in sync with runtime

## Owner sign-off

Per Chi pick **A (layer, not replace)** from 2026-05-15 16:06 in the ep006-decision thread.

## Test plan

- [ ] Visually confirm README renders the bolded CTA line on GitHub
- [ ] Reload web-client locally and confirm the tagline displays `My AI Stand · Summon your AI superpower` on unnamed-Sutando state
- [ ] Confirm the named-Stand identity branch still overrides the tagline once a Stand is named (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)