### PR TITLE
docs(claude-md): default browser automation to reuse the active tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,8 @@ Prefer this for any "open X and do Y" task in a native app (Zoom join, Mail comp
 
 Preferred (interactive): Use **Playwright MCP tools** (`mcp__playwright__*`) or **Chrome plugin** (`mcp__claude-in-chrome__*`). These provide real browser control with live DOM access, screenshots, and form interaction.
 
+**Default: navigate within the active tab when the next URL has the same host as the current tab.** Only spawn a new tab for cross-origin navigation, when an existing tab is the only context that holds the relevant state (a logged-in session, a long-running app), or when the user explicitly asks for a new tab. This keeps the browser tab count bounded during multi-step flows — without it, every `mcp__claude-in-chrome__navigate` opens a fresh tab and the user ends up with dozens of half-used tabs after a research session.
+
 Fallback (non-interactive / headless): `src/browser.mjs` for scripted or background use:
 ```bash
 node src/browser.mjs "https://example.com"                    # get page text

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,7 @@ Prefer this for any "open X and do Y" task in a native app (Zoom join, Mail comp
 
 Preferred (interactive): Use **Playwright MCP tools** (`mcp__playwright__*`) or **Chrome plugin** (`mcp__claude-in-chrome__*`). These provide real browser control with live DOM access, screenshots, and form interaction.
 
-**Default: navigate within the active tab when the next URL has the same host as the current tab.** Only spawn a new tab for cross-origin navigation, when an existing tab is the only context that holds the relevant state (a logged-in session, a long-running app), or when the user explicitly asks for a new tab. This keeps the browser tab count bounded during multi-step flows — without it, every `mcp__claude-in-chrome__navigate` opens a fresh tab and the user ends up with dozens of half-used tabs after a research session.
+**Default: navigate within the active tab when the next URL has the same origin (scheme + host + port) as the current tab.** Only spawn a new tab for cross-origin navigation, when an existing tab is the only context that holds the relevant state (a logged-in session, a long-running app), or when the user explicitly asks for a new tab. `localhost:7844` and `localhost:8080` are DIFFERENT origins — same hostname, but different ports → different services → don't share a tab. This keeps the browser tab count bounded during multi-step flows — without it, every `mcp__claude-in-chrome__navigate` opens a fresh tab and the user ends up with dozens of half-used tabs after a research session.
 
 Fallback (non-interactive / headless): `src/browser.mjs` for scripted or background use:
 ```bash


### PR DESCRIPTION
## Summary

Adds a one-paragraph default to `CLAUDE.md` "Browser automation" section (right after the tool-selection sentence, line 233 area):

> **Default: navigate within the active tab when the next URL has the same host as the current tab.** Only spawn a new tab for cross-origin navigation, when an existing tab is the only context that holds the relevant state (a logged-in session, a long-running app), or when the user explicitly asks for a new tab. This keeps the browser tab count bounded during multi-step flows — without it, every `mcp__claude-in-chrome__navigate` opens a fresh tab and the user ends up with dozens of half-used tabs after a research session.

## Why

Per Chi 2026-05-14 discussion. The current behavior — every navigate-call spawns a fresh tab — isn't a bug in the underlying tool; it's the absence of guidance in `CLAUDE.md` telling the agent to prefer same-host navigation in the active tab. Result: after a 5-step research flow you have 5 tabs all on (say) github.com when 1 would have done.

CLAUDE.md is the prompt every agent session reads at boot, so doc-only changes here do propagate to behavior.

## Test plan

- [x] CI passes on the doc-only change.
- [ ] In a follow-up session, observe `mcp__claude-in-chrome__navigate` calls — same-host navigations should reuse the tab; cross-origin should spawn new. Behavior change is in the LLM's tool-selection, not in tool code, so verification is observational.

## Scope

- `CLAUDE.md` only (+2/-0). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)