### PR TITLE
fix(open_url): reuse active tab when target shares origin

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -214,7 +214,7 @@ export const closeTabTool: ToolDefinition = {
 export const openUrlTool: ToolDefinition = {
 	name: 'open_url',
 	description:
-		'Open a URL in a new Chrome tab. Use for: "open github.com", "go to that link".',
+		'Open a URL in Chrome. Reuses the active tab when the target shares origin (scheme + host + port) with what\'s already in the active tab; spawns a new tab only for cross-origin URLs. Use for: "open github.com", "go to that link".',
 	parameters: z.object({
 		url: z.string().describe('The URL to open'),
 	}),
@@ -223,10 +223,32 @@ export const openUrlTool: ToolDefinition = {
 		const { url } = args as { url: string };
 		// Escape backslashes first, then quotes — prevents shell injection via osascript
 		const safeUrl = url.replace(/\\/g, '\\\\').replace(/'/g, "'\\''").replace(/"/g, '\\"');
+		// Parse target origin (scheme + host + port). If unparseable, fall back to new-tab behavior.
+		let targetOrigin = '';
+		try { targetOrigin = new URL(url).origin; } catch { /* not a real URL, e.g. "about:blank" — let Chrome handle */ }
 		try {
-			execSync(`osascript -e 'tell application "Google Chrome" to tell front window to make new tab with properties {URL:"${safeUrl}"}'`, { timeout: 5_000 });
-			console.log(`${ts()} [OpenURL] opened: ${url}`);
-			return { status: 'opened', url };
+			// Query active-tab URL to decide reuse vs new-tab. If origin matches, set URL on active
+			// tab; otherwise open a new tab. Falls back to new-tab on any error so callers never
+			// silently fail to open the URL.
+			let reused = false;
+			if (targetOrigin) {
+				try {
+					const activeUrl = execSync(`osascript -e 'tell application "Google Chrome" to get URL of active tab of front window'`, { timeout: 3_000 }).toString().trim();
+					if (activeUrl) {
+						let activeOrigin = '';
+						try { activeOrigin = new URL(activeUrl).origin; } catch {}
+						if (activeOrigin && activeOrigin === targetOrigin) {
+							execSync(`osascript -e 'tell application "Google Chrome" to set URL of active tab of front window to "${safeUrl}"'`, { timeout: 5_000 });
+							reused = true;
+						}
+					}
+				} catch { /* fall through to new-tab */ }
+			}
+			if (!reused) {
+				execSync(`osascript -e 'tell application "Google Chrome" to tell front window to make new tab with properties {URL:"${safeUrl}"}'`, { timeout: 5_000 });
+			}
+			console.log(`${ts()} [OpenURL] ${reused ? 'reused active tab' : 'opened new tab'}: ${url}`);
+			return { status: reused ? 'reused' : 'opened', url };
 		} catch (err) {
 			return { error: `Failed to open ${url}: ${err instanceof Error ? err.message : err}` };
 		}


### PR DESCRIPTION
## Summary

Companion to PR #719 (merged as `429de3d`). #719 fixed the **core-agent / CLAUDE.md** path so `mcp__claude-in-chrome__navigate` reuses same-origin tabs. This PR fixes the **voice-agent** path: `open_url` (the inline tool Gemini Live calls for "open X" / "go to that link") previously always spawned a new Chrome tab.

## Change

`src/browser-tools.ts:openUrlTool`:

- Queries active tab URL via osascript before opening.
- Parses both URLs to origins (scheme + host + port, matching PR #719's terminology).
- Reuses active tab if origins match; spawns new tab if cross-origin.
- Any failure falls back to new-tab behavior — callers never silently lose the open.
- Tool description updated so Gemini's prompt sees the new behavior.

## Why now

Same root cause as the CLAUDE.md fix (PR #719) but on a different surface. Together they cover both navigation paths into Chrome:

| Path | Tool | Fix |
|---|---|---|
| Core agent (Claude Code) | `mcp__claude-in-chrome__navigate` | PR #719 (CLAUDE.md guidance) |
| Voice agent (Gemini Live) | `open_url` inline tool | This PR (in-tool behavior change) |

Per Chi: "for voice what's the solution" (2026-05-15 09:31 PT).

## Test plan

- [ ] Voice says "open github.com" → new tab.
- [ ] With github.com active, voice says "open github.com/sonichi/sutando" → **same tab reused**, tab count unchanged.
- [ ] Voice says "open example.com" with github active → new tab (cross-origin).
- [ ] CI: `tsc + tests (clean install)` — should pass; only browser-tools.ts changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)