### PR TITLE
fix(bridges): honor SUTANDO_WORKSPACE in telegram-bridge + dm-result (#720)

### DIFF
--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -37,8 +37,8 @@ from pathlib import Path
 # discord-bridge.py (PR #708) — when src/ is a symlink into a packaged
 # Sutando.app bundle, Path(__file__).resolve().parent.parent returns the bundle
 # root rather than the workspace.
-_workspace_env = os.environ.get("SUTANDO_WORKSPACE")
-REPO = Path(_workspace_env) if _workspace_env else Path(__file__).resolve().parent.parent
+_workspace_env = os.environ.get("SUTANDO_WORKSPACE", "").strip()
+REPO = Path(_workspace_env).expanduser() if _workspace_env else Path(__file__).resolve().parent.parent
 ACCESS_JSON = Path.home() / ".claude" / "channels" / "discord" / "access.json"
 SSE_STATUS_URL = "http://localhost:8080/sse-status"
 

--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -32,7 +32,13 @@ import sys
 import urllib.request
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
+# REPO resolution: prefer SUTANDO_WORKSPACE env var so the script reads from the
+# user's workspace results/ dir, not the app-bundle's copy. Same rationale as
+# discord-bridge.py (PR #708) — when src/ is a symlink into a packaged
+# Sutando.app bundle, Path(__file__).resolve().parent.parent returns the bundle
+# root rather than the workspace.
+_workspace_env = os.environ.get("SUTANDO_WORKSPACE")
+REPO = Path(_workspace_env) if _workspace_env else Path(__file__).resolve().parent.parent
 ACCESS_JSON = Path.home() / ".claude" / "channels" / "discord" / "access.json"
 SSE_STATUS_URL = "http://localhost:8080/sse-status"
 

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -18,8 +18,8 @@ from pathlib import Path
 # rationale as discord-bridge.py (PR #708) — when src/ is a symlink into a
 # packaged Sutando.app bundle, Path(__file__).resolve().parent.parent returns
 # the bundle root rather than the workspace.
-_workspace_env = os.environ.get("SUTANDO_WORKSPACE")
-REPO = Path(_workspace_env) if _workspace_env else Path(__file__).resolve().parent.parent
+_workspace_env = os.environ.get("SUTANDO_WORKSPACE", "").strip()
+REPO = Path(_workspace_env).expanduser() if _workspace_env else Path(__file__).resolve().parent.parent
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
 

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -13,7 +13,13 @@ import urllib.request
 import urllib.error
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
+# REPO resolution: prefer SUTANDO_WORKSPACE env var so the bridge writes to the
+# user's workspace tasks/results/state dirs, not the app-bundle's copy. Same
+# rationale as discord-bridge.py (PR #708) — when src/ is a symlink into a
+# packaged Sutando.app bundle, Path(__file__).resolve().parent.parent returns
+# the bundle root rather than the workspace.
+_workspace_env = os.environ.get("SUTANDO_WORKSPACE")
+REPO = Path(_workspace_env) if _workspace_env else Path(__file__).resolve().parent.parent
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
 


### PR DESCRIPTION
## Summary

- Closes #720 — extends PR #708's fix to the two remaining bridge files
- One-liner per file mirroring the merged discord-bridge pattern

## Changes

```python
_workspace_env = os.environ.get("SUTANDO_WORKSPACE")
REPO = Path(_workspace_env) if _workspace_env else Path(__file__).resolve().parent.parent
```

Applied to:
- `src/telegram-bridge.py:16` (closes the Telegram analogue of the 2026-05-14 owner-DM strand)
- `src/dm-result.py:35` (result-mailer also reads workspace results/)

## Test plan
- [x] `SUTANDO_WORKSPACE=/tmp/x python3 -c '...load module...' ` → REPO=/tmp/x for both files
- [x] Unset → REPO falls back to `Path(__file__).resolve().parent.parent` unchanged
- [ ] (not run) Live Telegram smoke — would require user-side .env edit + restart

No new env var docs; `.env.example` entry from PR #708 already covers all three files transitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)