### PR TITLE
fix(discord-bridge): strip + expanduser SUTANDO_WORKSPACE

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -26,8 +26,8 @@ import discord
 # than the workspace. That divergence stranded owner DMs on 2026-05-14 — the
 # bridge wrote tasks to bundle-tasks/ while core agent watched workspace-tasks/.
 import os
-_workspace_env = os.environ.get("SUTANDO_WORKSPACE")
-REPO = Path(_workspace_env) if _workspace_env else Path(__file__).resolve().parent.parent
+_workspace_env = os.environ.get("SUTANDO_WORKSPACE", "").strip()
+REPO = Path(_workspace_env).expanduser() if _workspace_env else Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from util_paths import shared_personal_path  # noqa: E402
 


### PR DESCRIPTION
## Summary

Mirror Mini's PR #722 review fix into `discord-bridge.py`. PR #708 originally introduced the `SUTANDO_WORKSPACE` env override but left two robustness gaps Mini caught when reviewing the follow-up PR for the same pattern in telegram-bridge + dm-result.

## Changes

```python
-_workspace_env = os.environ.get("SUTANDO_WORKSPACE")
-REPO = Path(_workspace_env) if _workspace_env else Path(__file__).resolve().parent.parent
+_workspace_env = os.environ.get("SUTANDO_WORKSPACE", "").strip()
+REPO = Path(_workspace_env).expanduser() if _workspace_env else Path(__file__).resolve().parent.parent
```

Two guards:
1. Empty/whitespace `SUTANDO_WORKSPACE=` no longer becomes `Path("")` = `Path(".")` (cwd misroute). Now short-circuits to the workspace fallback.
2. `SUTANDO_WORKSPACE=~/work` now expands to home. Was a literal `~/work` directory.

## Test plan

Same 5-case smoke test as #722:

| Input | REPO |
|---|---|
| (unset) | `/Users/wangchi/Desktop/sutando` (workspace fallback) ✓ |
| `""` | `/Users/wangchi/Desktop/sutando` (fallback) ✓ |
| `"   "` | `/Users/wangchi/Desktop/sutando` (fallback) ✓ |
| `"~/work"` | `/Users/wangchi/work` (expanded) ✓ |
| `"/tmp/test"` | `/tmp/test` (absolute) ✓ |

Default behavior for git-clone installs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)