### PR TITLE
fix(health-check): use absolute /usr/bin/pgrep (PATH-resilient)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -187,7 +187,7 @@ def mark_stale_if_outdated(check: dict, src_file: Path, pgrep_pattern: str, thre
             pass
     try:
         pids = subprocess.run(
-            ["pgrep", "-f", pgrep_pattern],
+            ["/usr/bin/pgrep", "-f", pgrep_pattern],
             capture_output=True, text=True, timeout=5
         ).stdout.strip().split("\n")
         pids = [p for p in pids if p]
@@ -719,7 +719,7 @@ def run_all_checks() -> list[dict]:
             # invocations, ps/grep pipelines, etc). Otherwise pgrep -f bare
             # name produces false-positive "multiple processes" warnings
             # that scared us into thinking the bridges were zombied today.
-            result = subprocess.run(["pgrep", "-f", f"{proc_name}\\.py$"], capture_output=True, text=True)
+            result = subprocess.run(["/usr/bin/pgrep", "-f", f"{proc_name}\\.py$"], capture_output=True, text=True)
             pids = result.stdout.strip().split("\n") if result.returncode == 0 else []
             pids = [p for p in pids if p]
         except:
@@ -832,7 +832,7 @@ def run_all_checks() -> list[dict]:
     sutando_bin = REPO_DIR / "src" / "Sutando" / "Sutando"
     if sutando_bin.exists():
         try:
-            result = subprocess.run(["pgrep", "-f", "Sutando/Sutando"], capture_output=True, text=True)
+            result = subprocess.run(["/usr/bin/pgrep", "-f", "Sutando/Sutando"], capture_output=True, text=True)
             pids = [p for p in result.stdout.strip().split("\n") if p]
         except:
             pids = []
@@ -1102,7 +1102,7 @@ def main():
                             # bridge process. PR #243 fixed the detect
                             # side; this keeps the kill side consistent.
                             old_pids = subprocess.run(
-                                ["pgrep", "-f", f"{c['name']}\\.py$"], capture_output=True, text=True
+                                ["/usr/bin/pgrep", "-f", f"{c['name']}\\.py$"], capture_output=True, text=True
                             ).stdout.strip().split("\n")
                             for pid in old_pids:
                                 if pid:
@@ -1160,7 +1160,7 @@ def main():
                     if c["status"] == "stale":
                         try:
                             old_pids = subprocess.run(
-                                ["pgrep", "-f", "conversation-server.ts"],
+                                ["/usr/bin/pgrep", "-f", "conversation-server.ts"],
                                 capture_output=True, text=True
                             ).stdout.strip().split("\n")
                             for pid in old_pids:


### PR DESCRIPTION
## Summary

Today's 17:55 health-check task from Sutando.app's Timer falsely reported `sutando-app: warn (not running — hotkeys disabled)` while the app had 27h+ uptime (PID 1352, lstart Thu 08:09:21).

**Root cause** (empirically confirmed): bare `subprocess.run(["pgrep", ...])` raises `FileNotFoundError` when invoked under a constrained PATH lacking `/usr/bin`. The surrounding `try/except: pids = []` swallows the exception → process reported as not running.

## Empirical test

```
$ PATH= /usr/bin/python3 -c "import subprocess; subprocess.run(['pgrep','-f','Sutando/Sutando'])"
FileNotFoundError: [Errno 2] No such file or directory: 'pgrep'

$ PATH= /usr/bin/python3 -c "import subprocess; r = subprocess.run(['/usr/bin/pgrep','-f','Sutando/Sutando'], capture_output=True, text=True); print(r.returncode, r.stdout.strip())"
0 1352
```

## Changes

5 occurrences of `["pgrep", "-f", ...]` → `["/usr/bin/pgrep", "-f", ...]`:
- `mark_stale_if_outdated` (l.190)
- `proc_name`-by-py check (l.722)
- Sutando.app detection (l.835)
- Auto-restart pid-discovery for bridges (l.1105)
- Auto-restart pid-discovery for conversation-server (l.1163)

## Why absolute path (not env={"PATH":...} or psutil)

- `/usr/bin/pgrep` is guaranteed by macOS — no install/env coupling.
- One-line shape change per occurrence; tiny patch surface.
- No new deps (psutil would also work + give richer process info, but adds an install requirement).

## Out of scope

Other bare-name `subprocess.run` calls in this file (`id`, `kill`, `ngrok`, `npx`, etc.) have the same theoretical vulnerability but are either early-exit (`id` → script bails on failure) or recovery code paths. Can file follow-up if any of them bite in practice.

## Test plan
- [x] Empirical test: bare pgrep fails with empty PATH; `/usr/bin/pgrep` succeeds
- [x] Full health-check run from normal shell: sutando-app correctly reported as `stale (running, but binary is 620 min older than source)`
- [ ] Next Sutando.app Timer-triggered health-check should now correctly detect the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)