### PR TITLE
fix(health-check): absolute paths for all detection bare-name cmds (follow-up to #724)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -58,7 +58,7 @@ def check_launchd(label: str) -> dict:
     """Check if a launchd job is loaded and running."""
     try:
         result = subprocess.run(
-            ["launchctl", "list"],
+            ["/bin/launchctl", "list"],
             capture_output=True, text=True, timeout=5,
         )
         for line in result.stdout.split("\n"):
@@ -130,17 +130,17 @@ def fix_launchd(label: str) -> str:
     if not plist or not plist.exists():
         return f"no plist found for {label}"
 
-    uid = subprocess.run(["id", "-u"], capture_output=True, text=True).stdout.strip()
+    uid = subprocess.run(["/usr/bin/id", "-u"], capture_output=True, text=True).stdout.strip()
     # Try kickstart
     result = subprocess.run(
-        ["launchctl", "kickstart", "-k", f"gui/{uid}/{label}"],
+        ["/bin/launchctl", "kickstart", "-k", f"gui/{uid}/{label}"],
         capture_output=True, text=True, timeout=10,
     )
     if result.returncode == 0:
         return f"restarted {label}"
     # Try bootstrap
     result = subprocess.run(
-        ["launchctl", "bootstrap", f"gui/{uid}", str(plist)],
+        ["/bin/launchctl", "bootstrap", f"gui/{uid}", str(plist)],
         capture_output=True, text=True, timeout=10,
     )
     if result.returncode == 0:
@@ -194,7 +194,7 @@ def mark_stale_if_outdated(check: dict, src_file: Path, pgrep_pattern: str, thre
         if not pids:
             return
         ps_out = subprocess.run(
-            ["ps", "-o", "lstart=", "-p", ",".join(pids)],
+            ["/bin/ps", "-o", "lstart=", "-p", ",".join(pids)],
             capture_output=True, text=True, timeout=5
         ).stdout.strip().split("\n")
         from datetime import datetime as _dt
@@ -238,7 +238,7 @@ def _file_unchanged_since(src_file: Path, proc_start: float) -> bool:
     """
     try:
         log = subprocess.run(
-            ["git", "log", "-1", "--format=%ct", "HEAD", "--", str(src_file)],
+            ["/usr/bin/git", "log", "-1", "--format=%ct", "HEAD", "--", str(src_file)],
             cwd=REPO_DIR, capture_output=True, text=True, timeout=5
         )
         if log.returncode != 0 or not log.stdout.strip():
@@ -249,7 +249,7 @@ def _file_unchanged_since(src_file: Path, proc_start: float) -> bool:
             return False
         # No commits since proc_start; check for uncommitted edits
         diff = subprocess.run(
-            ["git", "diff", "--quiet", "HEAD", "--", str(src_file)],
+            ["/usr/bin/git", "diff", "--quiet", "HEAD", "--", str(src_file)],
             cwd=REPO_DIR, capture_output=True, timeout=5
         )
         return diff.returncode == 0  # 0 = no diff
@@ -772,7 +772,7 @@ def run_all_checks() -> list[dict]:
                 src_mtime = src_file.stat().st_mtime
                 # Use ps to get process start time as Unix epoch
                 ps_out = subprocess.run(
-                    ["ps", "-o", "lstart=", "-p", pids[0]],
+                    ["/bin/ps", "-o", "lstart=", "-p", pids[0]],
                     capture_output=True, text=True, timeout=5
                 ).stdout.strip()
                 if ps_out:
@@ -803,7 +803,7 @@ def run_all_checks() -> list[dict]:
         # state/<name>.heartbeat.
         try:
             lsof_out = subprocess.run(
-                ["lsof", "-p", pids[0]], capture_output=True, text=True, timeout=5
+                ["/usr/sbin/lsof", "-p", pids[0]], capture_output=True, text=True, timeout=5
             ).stdout
             for line in lsof_out.splitlines():
                 parts = line.split()
@@ -1106,7 +1106,7 @@ def main():
                             ).stdout.strip().split("\n")
                             for pid in old_pids:
                                 if pid:
-                                    subprocess.run(["kill", pid], check=False)
+                                    subprocess.run(["/bin/kill", pid], check=False)
                             import time as _t; _t.sleep(1)
                         except Exception:
                             pass
@@ -1165,7 +1165,7 @@ def main():
                             ).stdout.strip().split("\n")
                             for pid in old_pids:
                                 if pid:
-                                    subprocess.run(["kill", pid], check=False)
+                                    subprocess.run(["/bin/kill", pid], check=False)
                             import time as _t; _t.sleep(1)
                         except Exception:
                             pass


### PR DESCRIPTION
## Summary

Follow-up to PR #724 per Chi's "can you check others" + Mini's review note.

Audit found 18 bare-name subprocess calls in `src/health-check.py`. Empirically tested all 9 distinct commands under empty PATH (simulating Sutando.app Timer's invocation env):

```
$ PATH= python3 -c "subprocess.run(['<cmd>', '--help'])"
launchctl  → FileNotFoundError
id         → FileNotFoundError
ps         → FileNotFoundError
git        → FileNotFoundError
lsof       → FileNotFoundError
kill       → FileNotFoundError
ngrok      → FileNotFoundError
npx        → FileNotFoundError
pgrep      → FileNotFoundError  (fixed in #724)
```

All fail. Same bug class as `pgrep` in #724: bare `subprocess.run([...])` raises FileNotFoundError under constrained PATH → swallowed by surrounding try/except → silent wrong behavior.

## Changes

All detection bare-names → absolute macOS-system paths:

| Command | New path | Count | Notes |
|---|---|---:|---|
| `launchctl` | `/bin/launchctl` | 3 | Always at /bin on macOS |
| `id` | `/usr/bin/id` | 1 | BSD `id -u` works fine |
| `ps` | `/bin/ps` | 2 | Always at /bin |
| `git` | `/usr/bin/git` | 2 | Apple-shipped git; no Homebrew dep |
| `lsof` | `/usr/sbin/lsof` | 1 | Always at /usr/sbin |
| `kill` | `/bin/kill` | 2 | Bonus: action paths included |

Total: 11 lines changed (–11 / +11).

## Deferred (recovery code paths, user-specific install paths)

- `ngrok` (Popen, line 1147): `/opt/homebrew/bin/ngrok` on Apple-Silicon Homebrew, `/usr/local/bin/ngrok` on Intel Homebrew. Could be other paths.
- `npx` (Popen, line 1172): `~/.nvm/versions/node/vX.Y.Z/bin/npx` on nvm installs (varies per user).

Both are auto-restart recovery code. If they fail, the next health-check pass retries — failure mode is "loud retry" not "silent false-positive." Lower priority. Cleanly fixable later with a `shutil.which()` + fallback-list helper.

## Test plan
- [x] Empirical: all 9 bare commands fail under empty PATH (above)
- [x] Manual health-check run from normal shell still works (no regression on the absolute-paths)
- [ ] Sutando.app Timer-triggered health-check should now report all states correctly (was previously masking failures behind bare-except)

## Related

- #724 — pgrep fix (companion; this is the broader audit follow-up)
- `feedback_subprocess_sys_executable.md` memory — same family of bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)