### PR TITLE
fix(discord-bridge): dm-fallback honors [no-send]/[REPLIED]/[deduped:] markers

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2880,6 +2880,23 @@ async def poll_dm_fallback():
                     if _task_file.exists():
                         archive_file(_task_file, "tasks", _task_id)
                     continue
+                # Honor result-body suppression markers (parity with the
+                # main reply path at line ~2660). Without this, results
+                # written specifically to suppress delivery (deduped /
+                # internally-handled / already-replied-elsewhere) get DM'd
+                # to the owner via this fallback when voice is offline.
+                try:
+                    _peek = f.read_text(encoding="utf-8", errors="replace").lstrip()
+                except OSError:
+                    _peek = ""
+                if _peek.startswith('[no-send]') or _peek.startswith('[REPLIED]') or _peek.startswith('[deduped:'):
+                    print(f"  [dm-fallback] skipped (suppression marker): {f.name}", flush=True)
+                    _task_id = f.stem
+                    _task_file = TASKS_DIR / f"{_task_id}.txt"
+                    if _task_file.exists():
+                        archive_file(_task_file, "tasks", _task_id)
+                    archive_file(f, "results", _task_id)
+                    continue
                 # Subprocess out to the shared CLI tool so there's only one
                 # code path for the voiceConnected check + DM send.
                 # Use sys.executable: under launchd (discord-bridge is launchd-managed),


### PR DESCRIPTION
## Summary
- The main reply path in `discord-bridge.py:2660` skips Discord delivery when a result body starts with `[no-send]`, `[REPLIED]`, or `[deduped:`. The `poll_dm_fallback` loop did not have the same check — so results written specifically to suppress delivery still got DM'd to the owner when voice-agent was offline.
- Add the same marker check to the dm-fallback loop; on match, archive both result + task (parity with main path) and continue.

## Repro
Today: I wrote `[no-send]` markers on `results/task-phone-1778876451343.txt` and `results/task-phone-1778876570451.txt` (voice agent had already delivered the inbox-query answer live during the call — re-DM would be duplicate). Bridge log:
```
[dm-fallback] sent task-phone-1778876451343.txt via dm-result.py
[dm-fallback] sent task-phone-1778876570451.txt via dm-result.py
```
Both got DM'd to Chi despite the marker.

## Test plan
- [ ] Write a result with `[no-send]` while voice-agent is offline; verify `[dm-fallback] skipped (suppression marker)` log line + no DM
- [ ] Repeat for `[REPLIED]` and `[deduped: task-XYZ]`
- [ ] Sanity: result without marker still delivers via dm-fallback as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)