### PR TITLE
fix(self-diagnose): resolve real gh when miniconda shadows it on PATH

### DIFF
--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -55,11 +55,26 @@ git -C "$REPO" log --since="$SINCE_ISO" --pretty=format:'%h %ad %s' --date=short
 git -C "$REPO" status --short > "$OUT/git-status.txt" 2>/dev/null || true
 
 # 2) Open PRs + recently merged (last 14d) — cheap, already cached by gh
-if command -v gh >/dev/null; then
-	gh pr list --state open --limit 20 --json number,title,mergeable,headRefName,author,updatedAt \
+# Resolve the real GitHub CLI. On systems where another tool named `gh` (e.g.
+# miniconda's `gh v0.0.4`) precedes /opt/homebrew/bin/gh on PATH, plain
+# `command -v gh` returns the wrong binary and every invocation below would
+# silently fail through `|| true`, producing empty PR data with no error.
+GH=""
+for _gh_cand in $(/usr/bin/which -a gh 2>/dev/null); do
+	# Discriminator: real GitHub CLI prints "gh version 2.x.x (...)" with NO
+	# colon — distinct from miniconda's `gh v0.0.4` which prints "gh version:
+	# v0.0.4" (note colon). Require the literal " version N." form.
+	if "$_gh_cand" --version 2>/dev/null | grep -Eq '^gh version [0-9]+\.'; then
+		GH="$_gh_cand"
+		break
+	fi
+done
+[ -z "$GH" ] && [ -x /opt/homebrew/bin/gh ] && GH=/opt/homebrew/bin/gh
+if [ -n "$GH" ]; then
+	"$GH" pr list --state open --limit 20 --json number,title,mergeable,headRefName,author,updatedAt \
 		--jq '.[] | "#\(.number) \(.headRefName) [@\(.author.login)] \(.title) — \(.mergeable)"' \
 		> "$OUT/prs-open.txt" 2>/dev/null || true
-	gh pr list --state merged --search "merged:>$(date -v -14d +%Y-%m-%d 2>/dev/null || date -d '14 days ago' +%Y-%m-%d)" \
+	"$GH" pr list --state merged --search "merged:>$(date -v -14d +%Y-%m-%d 2>/dev/null || date -d '14 days ago' +%Y-%m-%d)" \
 		--limit 30 --json number,title,mergedAt,author \
 		--jq '.[] | "#\(.number) \(.mergedAt[:10]) [@\(.author.login)] \(.title)"' \
 		> "$OUT/prs-recent-merged.txt" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- `gather.sh` guarded its gh block with `command -v gh >/dev/null` and then invoked `gh pr list ...`. When another binary named `gh` precedes /opt/homebrew/bin/gh on PATH (on this machine: `/Users/qingyunwu/miniconda3/bin/gh`, a tool labelled `gh v0.0.4`), `command -v` returns the wrong binary, both `gh pr list` calls error out, and the `2>/dev/null || true` swallows the failure — producing empty `prs-open.txt` and `prs-recent-merged.txt` with no signal that anything broke. `/self-diagnose` then runs blind to PRs.
- Walk `which -a gh`, pick the candidate whose `--version` matches the literal `gh version N.` form. The digit-dot discriminator is required because the shadowing tool prints `gh version: v0.0.4` (note colon) which also matches a naive `^gh version`.
- Fall back to `/opt/homebrew/bin/gh` if no candidate qualifies but the file exists.

Same class of PATH-shadow fix as #724/#725 for `health-check.py`.

## Test plan
- [x] Reproduced on owner machine — before fix: empty `prs-open.txt`. After fix: 9 lines, real PR data.
- [x] `bash -n` syntax check passes.
- [x] Smoke-tested `bash skills/self-diagnose/scripts/gather.sh 1h` end-to-end — both PR files populated correctly.
- [ ] Verify on a machine where only the real `gh` is on PATH (no shadow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)