### PR TITLE
fix(agent-api,dashboard): use absolute paths for bare subprocess.run cmds (pgrep, pmset, git)

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -288,8 +288,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.send_json(200, get_status())
         elif path == "/tasks/active":
             # List active tasks + system status for the web client
-            watcher_ok = subprocess.run(["pgrep", "-f", "watch-tasks"], capture_output=True).returncode == 0
-            claude_ok = subprocess.run(["pgrep", "-f", "claude.*sutando-core"], capture_output=True).returncode == 0
+            watcher_ok = subprocess.run(["/usr/bin/pgrep", "-f", "watch-tasks"], capture_output=True).returncode == 0
+            claude_ok = subprocess.run(["/usr/bin/pgrep", "-f", "claude.*sutando-core"], capture_output=True).returncode == 0
             # Scan disk for active tasks, update history (preserve existing text)
             for f in sorted(TASK_DIR.glob("*.txt"), key=lambda p: p.stat().st_mtime, reverse=True)[:10]:
                 task_id = f.stem

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -411,7 +411,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             activity = []
             try:
                 git_log = subprocess.run(
-                    ["git", "-C", str(REPO_DIR), "log", "--oneline", "--since=24 hours ago", "-10"],
+                    ["/usr/bin/git", "-C", str(REPO_DIR), "log", "--oneline", "--since=24 hours ago", "-10"],
                     capture_output=True, text=True, timeout=5
                 ).stdout.strip()
                 for line in git_log.split("\n"):

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -142,7 +142,7 @@ def get_system_stats() -> dict:
     st = os.statvfs("/")
     free_gb = (st.f_bavail * st.f_frsize) / (1024 ** 3)
 
-    result = subprocess.run(["pmset", "-g", "batt"], capture_output=True, text=True, timeout=5)
+    result = subprocess.run(["/usr/bin/pmset", "-g", "batt"], capture_output=True, text=True, timeout=5)
     battery_m = re.search(r'(\d+)%', result.stdout)
     battery = f"{battery_m.group(1)}%" if battery_m else "?"
     charging = "charging" in result.stdout.lower() or "ac power" in result.stdout.lower()

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -306,7 +306,7 @@ def render_dashboard() -> str:
         cards.append(f'<div class="card full"><h2>Capabilities Matrix</h2>{matrix_html}</div>')
 
     # Keyboard shortcuts
-    sutando_running = subprocess.run(["pgrep", "-f", "src/Sutando/Sutando"], capture_output=True).returncode == 0
+    sutando_running = subprocess.run(["/usr/bin/pgrep", "-f", "src/Sutando/Sutando"], capture_output=True).returncode == 0
     shortcut_status = '<span class="ok">✓</span> Sutando app running' if sutando_running else '<span class="bad">✗</span> Sutando app not running'
     cards.append(f"""<div class="card">
 <h2>Keyboard Shortcuts</h2>


### PR DESCRIPTION
## Summary
- #724 and #725 made `health-check.py` PATH-resilient by switching `["pgrep", ...]` → `["/usr/bin/pgrep", ...]`. The same pattern still lives unfixed in two other files; this PR finishes the sweep.
- `src/agent-api.py:291,292` — `watcher_ok` / `claude_ok` in the `/tasks/active` endpoint. **No try/except wraps this one** — under constrained PATH it would raise FileNotFoundError into the HTTP handler.
- `src/dashboard.py:309` — `sutando_running` in the Keyboard Shortcuts card. Falsely reports "Sutando app not running" under constrained PATH.

Mechanical, scoped, no behavior change when PATH is well-formed.

## Test plan
- [x] `python3 -m py_compile` on both files (passes).
- [x] Grep confirmed no remaining bare `["pgrep"...]` in `src/` after this change.
- [ ] Hit `/tasks/active` and check dashboard cards on a machine with constrained PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)