### PR TITLE
fix(agent-api): /logs/voice serves logs/voice-agent.log (not src/)

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -490,8 +490,13 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(media_path.read_bytes())
         elif path == "/logs/voice":
-            # Return last 30 lines of voice-agent.log for debugging
-            log_file = REPO_DIR / "src" / "voice-agent.log"
+            # Return last 30 lines of voice-agent.log for debugging.
+            # Canonical path is logs/voice-agent.log (see startup.sh:153,
+            # health-check.py:288, check-pending-questions.py:24). The
+            # original src/ path here predated that migration and silently
+            # 404'd every /logs/voice request from web-client.ts:2183's
+            # "Copy logs" button.
+            log_file = REPO_DIR / "logs" / "voice-agent.log"
             if log_file.exists():
                 lines = log_file.read_text().splitlines()[-30:]
                 self.send_json(200, {"lines": lines})


### PR DESCRIPTION
## Summary
- The `/logs/voice` endpoint in `agent-api.py:494` hard-coded `REPO_DIR / "src" / "voice-agent.log"`, predating the canonical move to `logs/voice-agent.log`.
- All other call sites already use `logs/`: `startup.sh:153` (writer), `health-check.py:288, 365`, `check-pending-questions.py:24`, `scripts/stage-readiness.sh:49, 64`, `skills/self-diagnose/scripts/gather.sh:75`.
- Net effect: every "Copy logs" click from `web-client.ts:2183` silently 404'd, even when the log existed and contained the diagnostic lines the user was trying to share.

## Repro (before)
```
$ ls -la logs/voice-agent.log src/voice-agent.log 2>&1
ls: src/voice-agent.log: No such file or directory
-rw-r--r--  ... logs/voice-agent.log

$ curl -s localhost:7843/logs/voice
{"error": "voice-agent.log not found"}
```

## Fix
One-line path correction in `agent-api.py` — `src/` → `logs/`. Added a comment pointing to the canonical call sites so this doesn't re-drift.

## Test plan
- [ ] Start `python3 src/agent-api.py`, ensure `logs/voice-agent.log` exists with some content
- [ ] `curl -s localhost:7843/logs/voice | jq .lines | head` returns last 30 lines (was 404)
- [ ] Web UI "Copy logs" button (after 5 failed reconnects) copies log content to clipboard (was empty / error)
- [ ] If `logs/voice-agent.log` is absent, endpoint still returns the same 404 shape — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)