### PR TITLE
fix(session-handoff): honor SUTANDO_WORKSPACE (extends #708/#722/#723)

### DIFF
--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -5,7 +5,7 @@
 # Reads the transcript, extracts key signals, and writes to session-state.md.
 # The incoming session reads this in CLAUDE.md or as part of the proactive loop.
 
-REPO="$HOME/Desktop/sutando"
+REPO="${SUTANDO_WORKSPACE:-$HOME/Desktop/sutando}"
 export PATH="/opt/homebrew/bin:$HOME/.nvm/versions/node/v24.14.1/bin:$PATH"
 STATE_FILE="$REPO/session-state.md"
 TRANSCRIPT="$1"  # Passed by PreCompact hook as $TRANSCRIPT_PATH


### PR DESCRIPTION
## Summary
- `src/session-handoff.sh:8` hard-coded \`REPO=\"\$HOME/Desktop/sutando\"\`.
- On hosts where the workspace lives elsewhere (e.g. \`~/Documents/github/sutando\`, the layout on my primary node), the PreCompact hook silently no-ops: the redirect on line 78 (\`> \"\$STATE_FILE\" 2>/dev/null\`) eats the resulting \"no such file or directory\" error.
- CLAUDE.md \"Session Continuity\" explicitly relies on this file (*\"Read this file at session start to understand what the previous session was doing\"*), so on any non-\`~/Desktop/sutando\` host the handoff has been silently broken since the script was added.
- Same env-resolution pattern that #708, #720/#722, and #723 already established for the Discord and Telegram bridges.

## Repro (before)
\`\`\`
$ ls -d ~/Desktop/sutando
ls: /Users/qingyunwu/Desktop/sutando: No such file or directory

$ bash src/session-handoff.sh /dev/null
Session state saved to /Users/qingyunwu/Desktop/sutando/session-state.md
# (note: file isn't actually written — \$STATE_FILE redirect failed
#  silently, but the trailing echo prints regardless)
\`\`\`

## Fix
One-line change: \`REPO=\"\${SUTANDO_WORKSPACE:-\$HOME/Desktop/sutando}\"\`. Preserves the legacy default for users who never set the env.

## Test plan
- [x] \`SUTANDO_WORKSPACE=\$PWD bash src/session-handoff.sh /dev/null\` writes session-state.md to \`\$PWD\` with populated System Status / Recent Work / Open PRs / Pending Questions / Tasks / Quota / Repo Stats sections.
- [x] Unset SUTANDO_WORKSPACE: script still targets \`~/Desktop/sutando\` (legacy behavior preserved).
- [x] \`bash -n\` syntax check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)