### PR TITLE
fix(schedule-crons): point example sync-memory cron at workspace script

### DIFF
--- a/skills/schedule-crons/crons.example.json
+++ b/skills/schedule-crons/crons.example.json
@@ -22,7 +22,7 @@
   {
     "name": "sync-memory",
     "cron": "*/30 * * * *",
-    "prompt": "Run bash ~/.sutando-memory-sync/scripts/sync-memory.sh to sync memory and notes to the private memory repo (requires SUTANDO_MEMORY_REPO in .env)."
+    "prompt": "Run bash scripts/sync-memory.sh to sync memory and notes to the private memory repo (requires SUTANDO_MEMORY_REPO in .env)."
   },
   {
     "name": "cross-node-sync",


### PR DESCRIPTION
## Summary
\`crons.example.json\` ships a sync-memory cron prompt pointing at \`~/.sutando-memory-sync/scripts/sync-memory.sh\`. That path only exists **after** a successful first-time setup — \`scripts/sync-memory.sh\` clones the private memory repo to \`~/.sutando-memory-sync/\` on first run.

For any user who copies the example and registers the cron before running setup (or never sets \`SUTANDO_MEMORY_REPO\` at all), every 30-min firing is just \`bash: /Users/<user>/.sutando-memory-sync/scripts/sync-memory.sh: No such file or directory\`.

Hit this today on the primary node: my own \`crons.json\` had \`src/sync-memory.sh\` (also wrong — the file lives at \`scripts/sync-memory.sh\`), corrected locally + on the running cron, then noticed the checked-in template was equivalently broken.

## Why the workspace path is the right default
\`scripts/sync-memory.sh\` handles both the pre-setup and post-setup case gracefully:
- **Pre-setup**: prints \`sync-memory: SUTANDO_MEMORY_REPO not set in .env, skipping sync.\` and exits 0.
- **Post-setup**: auto-detects the clone via \`SUTANDO_MEMORY_SYNC_DIR\` / script-relative resolution (see comments in \`scripts/sync-memory.sh:1-30\`), then runs as before.

The clone-local path doesn't get that fallback — it's just a missing file when setup hasn't happened.

## Test plan
- [x] \`bash scripts/sync-memory.sh\` (no \`SUTANDO_MEMORY_REPO\` set) → \`skipping sync.\`, exit 0.
- [x] JSON validates.
- [ ] Owner: after setting \`SUTANDO_MEMORY_REPO\` + completing first-time setup, the cron continues to work because the script's self-detection takes over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)