### PR TITLE
docs(cla): add CLA.md + CONTRIBUTING note for CLA Assistant bot

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,34 @@
+# Sutando Contributor License Agreement
+
+Thank you for your interest in contributing to Sutando ("the Project"),
+maintained by Chi Wang ("the Maintainer"). This Contributor License Agreement
+("CLA") clarifies the terms under which You ("the Contributor") make
+intellectual property contributions to the Project.
+
+By signing this CLA, You agree:
+
+1. **License grant.** You grant the Maintainer and to recipients of software
+   distributed by the Maintainer a perpetual, worldwide, non-exclusive,
+   no-charge, royalty-free, irrevocable copyright license to reproduce,
+   prepare derivative works of, publicly display, publicly perform,
+   sublicense, and distribute Your Contributions and such derivative works.
+
+2. **Patent license.** You grant the Maintainer and to recipients of software
+   distributed by the Maintainer a perpetual, worldwide, non-exclusive,
+   no-charge, royalty-free, irrevocable (except as stated in this section)
+   patent license to make, have made, use, offer to sell, sell, import, and
+   otherwise transfer Your Contributions.
+
+3. **You are entitled to make the Contribution.** You represent that Your
+   Contributions are Your original creations or that You have sufficient
+   rights to grant the licenses above. If Your employer has rights to
+   intellectual property You create, You represent that You have received
+   permission to make Contributions on behalf of that employer, or that Your
+   employer has waived such rights for Your Contributions to the Project.
+
+4. **No warranties.** Your Contributions are provided "as is", without any
+   warranties or conditions, express or implied.
+
+By signing electronically through the CLA Assistant bot, you indicate
+acceptance of the terms above for all Your past, present, and future
+Contributions to sonichi/sutando.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 Thanks for your interest! Sutando is alpha software — the biggest need is **testing and hardening**.
 
+## Contributor License Agreement (CLA)
+
+Before your first contribution can be merged, you'll be asked to sign the project's CLA — a one-time, web-based "I agree" via the [CLA Assistant](https://cla-assistant.io) bot. The bot will comment on your PR with a link; just click through and sign. The CLA text is in [`CLA.md`](CLA.md). Subsequent PRs are auto-recognized.
+
 ## Quick ways to contribute
 
 ### Test a capability


### PR DESCRIPTION
## Summary
- Adds `CLA.md` (simplified Apache-2.0-ICLA-style: copyright + patent license + entitlement rep + no-warranty)
- Adds a short "Contributor License Agreement" section near the top of `CONTRIBUTING.md` explaining the upcoming sign flow

## Why
Repo has community contributors shipping PRs against an MIT codebase with no contributor-IP framework. Chi picked Option A (CLA Assistant) over Option B (DCO) given product trajectory — explicit IP grant matters if the project ever relicenses, repackages, or commercializes.

## Out of scope (owner-only setup)
Installing/configuring the CLA Assistant GitHub App at https://cla-assistant.io — OAuth flow has to happen in Chi's browser. Once installed and pointed at `CLA.md`, the bot will start commenting on new PRs requesting first-time-contributor signatures.

## Test plan
- [ ] Lawyer review of `CLA.md` if this becomes load-bearing for IP defense
- [ ] After Chi installs the App: open a throwaway PR from a non-allowlisted account and verify bot comment lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)