### PR TITLE
feat(vision): screen sharing + push-mode vision pipeline

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -69,6 +69,27 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { z } from 'zod';
 import { inlineTools, anyCallerTools, ownerOnlyTools, configurableTools } from '../../../src/inline-tools.js';
+// Lazy vision-session handle. Only loaded if a call ever needs it — keeps the
+// phone-agent boot path free of the vision-tools.ts side-effects on cold start.
+let _setVisionSession: ((s: unknown) => void) | null = null;
+let _priorVisionSession: unknown = undefined; // snapshot to restore on hang-up
+async function attachVisionToCall(session: unknown): Promise<void> {
+	try {
+		if (!_setVisionSession) {
+			const m = await import('../../../src/vision-tools.js');
+			_setVisionSession = m.setVisionSession;
+			// First time only: there's no public getter, so we just mark the
+			// snapshot as null (web session, if any, will re-set itself when
+			// vision is needed there again — voice tools call setVisionSession
+			// on every connect).
+			_priorVisionSession = null;
+		}
+		_setVisionSession(session);
+	} catch {}
+}
+function detachVisionFromCall(): void {
+	try { _setVisionSession?.(_priorVisionSession ?? null); } catch {}
+}
 
 // --- Config ---
 
@@ -722,6 +743,12 @@ async function createCallSession(params: {
 
 	callSession.voiceSession = session;
 
+	// Route vision frames to this call's session for its duration. Push-mode
+	// senders (Mentra glasses, Discord/Telegram photo helper, the web Watch
+	// button) now reach the phone caller's session instead of the web
+	// session. Restored on hang-up (see endCall).
+	await attachVisionToCall(session);
+
 	// Start VoiceSession (creates ClientTransport WebSocket server on bodhiPort)
 	await session.start();
 	console.log(`${ts()} [Bodhi] VoiceSession started on port ${bodhiPort} for ${params.callSid}`);
@@ -880,6 +907,11 @@ function cleanupCall(callSid: string): void {
 	session.cleanupNarration?.();
 	try { unlinkSync('/tmp/sutando-playback-pause'); } catch {}
 	try { unlinkSync('/tmp/sutando-playback-path'); } catch {}
+
+	// Restore vision session to the prior (likely web) session before tearing
+	// down the call's VoiceSession so push-mode frames don't get sent to a
+	// closed transport.
+	detachVisionFromCall();
 
 	// Close VoiceSession
 	session.voiceSession.close('call_ended').catch(e =>

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -31,6 +31,15 @@ REPO = Path(_workspace_env) if _workspace_env else Path(__file__).resolve().pare
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from util_paths import shared_personal_path  # noqa: E402
 
+# Vision-frame helper — pushes image attachments into the active voice session
+# so Gemini reacts in-stream. Best-effort: import failure or unreachable
+# voice-agent leaves the regular task pipeline unchanged.
+try:
+    from vision_push import push_image as _push_vision_image  # noqa: E402
+except Exception:  # pragma: no cover
+    def _push_vision_image(path: str, source: str = "discord") -> bool:  # type: ignore
+        return False
+
 # Load token from channels config
 TOKEN = ""
 channels_env = Path.home() / ".claude" / "channels" / "discord" / ".env"
@@ -2231,6 +2240,17 @@ async def _handle_discord_message(message, force=False):
         try:
             await att.save(local_path)
             attachment_note += f"\n[File attached: {local_path}]"
+            # If voice is connected and the attachment is an image, also push
+            # it as a vision frame so Gemini sees it in-stream (in addition
+            # to the file-attached task pipeline).
+            try:
+                ct = (getattr(att, "content_type", "") or "").lower()
+                if ct.startswith("image/") or str(local_path).lower().endswith(
+                    (".jpg", ".jpeg", ".png", ".webp", ".gif")
+                ):
+                    _push_vision_image(str(local_path), source="discord")
+            except Exception:
+                pass
         except Exception as e:
             print(f"  Download failed: {e}")
 

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -17,6 +17,10 @@ const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 export { describeScreenTool, clickTool, scrollAndDescribeTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool, openUrlTool } from './browser-tools.js';
 import { describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, switchTabTool, closeTabTool, scrollTool, openUrlTool } from './browser-tools.js';
 
+// Vision: one-shot frame + start/stop live screen-to-Gemini video.
+export { sendVisionFrameTool, startVisionTool, stopVisionTool } from './vision-tools.js';
+import { sendVisionFrameTool, startVisionTool, stopVisionTool } from './vision-tools.js';
+
 // --- File-open tool (moved out of recording-tools — generic file open, optionally fullscreen) ---
 
 export const openFileTool: ToolDefinition = {
@@ -1024,6 +1028,7 @@ export const inlineTools = assertUniqueToolNames([
 	describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, slideControlTool, fullscreenTool,
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
 	recentContextTool,
+	sendVisionFrameTool, startVisionTool, stopVisionTool,
 	...personalAllTools ]);
 
 /** Tools available to any caller (including unverified) */
@@ -1043,6 +1048,7 @@ export const ownerOnlyTools = [
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
 	recentContextTool,
 	describeScreenTool, clickTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool,
+	sendVisionFrameTool, startVisionTool, stopVisionTool,
 	...personalTools.owner,
 ];
 

--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -84,43 +84,54 @@ class Handler(http.server.BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path.startswith("/capture"):
-            # Flash agent-state=seeing on the menu-bar avatar for ~1.5s.
-            # Non-blocking fire-and-forget; capture succeeds regardless.
-            _signal_seeing()
-            # macOS notification "Sutando captured screen" — opt-out via
-            # SUTANDO_CAPTURE_NOTIFY=0. Debounced at 5s to avoid spam
-            # during burst captures.
-            _notify_capture()
-            os.makedirs(DIR, exist_ok=True)
-            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
             # Parse display number from query: /capture?display=2 or /capture?all=true
             from urllib.parse import urlparse, parse_qs
             query = parse_qs(urlparse(self.path).query)
+            # silent=true suppresses the menu-bar flash + notification. Used by
+            # the vision streaming ticker, which fires once per second and would
+            # otherwise spam the indicator and notification center.
+            silent = query.get("silent", ["false"])[0] == "true"
+            if not silent:
+                # Flash agent-state=seeing on the menu-bar avatar for ~1.5s.
+                # Non-blocking fire-and-forget; capture succeeds regardless.
+                _signal_seeing()
+                # macOS notification "Sutando captured screen" — opt-out via
+                # SUTANDO_CAPTURE_NOTIFY=0. Debounced at 5s to avoid spam
+                # during burst captures.
+                _notify_capture()
+            os.makedirs(DIR, exist_ok=True)
+            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
             display_raw = query.get("display", [None])[0]
             # Coerce to int to short-circuit taint flow into the subprocess
             # argument list. Display index constrained to 1..9 (macOS never has
             # more than a handful of displays).
             display = int(display_raw) if display_raw and display_raw.isdigit() and 1 <= int(display_raw) <= 9 else None
             capture_all = query.get("all", ["false"])[0] == "true"
+            # format=jpeg → screencapture -t jpg, smaller files for streaming.
+            fmt = query.get("format", ["png"])[0]
+            if fmt not in ("png", "jpg", "jpeg"):
+                fmt = "png"
+            ext = "jpg" if fmt in ("jpg", "jpeg") else "png"
+            type_flag = "jpg" if ext == "jpg" else "png"
             try:
                 if capture_all:
                     # Capture all displays separately
                     paths = []
                     for d in range(1, 5):  # up to 4 displays
-                        p = f"{DIR}/screen-{ts}-d{d}.png"
-                        result = subprocess.run(["screencapture", "-x", f"-D{d}", p], timeout=5, capture_output=True)
+                        p = f"{DIR}/screen-{ts}-d{d}.{ext}"
+                        result = subprocess.run(["screencapture", "-x", "-t", type_flag, f"-D{d}", p], timeout=5, capture_output=True)
                         if result.returncode == 0 and os.path.exists(p) and os.path.getsize(p) > 0:
                             paths.append(p)
                         else:
                             try: os.unlink(p)
                             except: pass
                             break  # no more displays
-                    path = paths[0] if paths else f"{DIR}/screen-{ts}.png"
+                    path = paths[0] if paths else f"{DIR}/screen-{ts}.{ext}"
                 else:
                     suffix = f"-d{display}" if display else ""
-                    path = f"{DIR}/screen-{ts}{suffix}.png"
+                    path = f"{DIR}/screen-{ts}{suffix}.{ext}"
                     paths = [path]
-                    cmd = ["screencapture", "-x"]
+                    cmd = ["screencapture", "-x", "-t", type_flag]
                     if display:
                         cmd.append(f"-D{display}")
                     cmd.append(path)

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -8,10 +8,21 @@ Usage: python3 src/telegram-bridge.py
 
 import json
 import os
+import sys
 import time
 import urllib.request
 import urllib.error
 from pathlib import Path
+
+# Vision-frame helper — pushes the latest photo into the active voice session
+# so Gemini can react in-stream. No-op when voice isn't connected. Import is
+# best-effort so the bridge keeps booting if vision_push.py is missing.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from vision_push import push_image as _push_vision_image  # type: ignore
+except Exception:  # pragma: no cover — bridge must keep running
+    def _push_vision_image(path: str, source: str = "telegram") -> bool:  # type: ignore
+        return False
 
 REPO = Path(__file__).resolve().parent.parent
 TASKS_DIR = REPO / "tasks"
@@ -311,6 +322,13 @@ def main():
                     local_path = download_file(file_id, "photo")
                     if local_path:
                         attachment_note = f"\n[Photo attached: {local_path}]"
+                        # If voice is connected, also push the photo as a
+                        # vision frame so Gemini sees it in-stream (in
+                        # addition to the file-attached task pipeline).
+                        try:
+                            _push_vision_image(local_path, source="telegram")
+                        except Exception:
+                            pass
                 if "document" in msg:
                     file_id = msg["document"]["file_id"]
                     fname = msg["document"].get("file_name", "file")

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -63,7 +63,11 @@ const screenSource: VisionSource = {
 		}
 		const buf = readFileSync(data.path);
 		// Drop the on-disk copy — we've already uploaded the bytes.
-		try { unlinkSync(data.path); } catch {}
+		try {
+			unlinkSync(data.path);
+		} catch (err) {
+			console.warn(`${ts()} [Vision] failed to unlink ${data.path}: ${(err as Error)?.message ?? err}`);
+		}
 		return { data: buf, mimeType: 'image/jpeg' };
 	},
 };
@@ -535,6 +539,9 @@ export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): S
 		// the existing instance owns the control endpoint.
 		if (err.code === 'EADDRINUSE') {
 			console.warn(`${ts()} [Vision] control port ${port} in use; skipping (another voice-agent?)`);
+			// Intentionally null — another process owns the listener, so our
+			// stopVisionControlServer() should be a no-op (don't close
+			// someone else's server on shutdown).
 			controlServer = null;
 			return;
 		}

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -1,0 +1,554 @@
+/**
+ * Vision pipeline — pipe JPEG frames from a source (screen, webcam) into the
+ * Gemini Live voice session.
+ *
+ * Sources are pluggable via the VisionSource interface; tools accept a
+ * `source` argument. Modes: one-shot (send_vision_frame) and continuous
+ * streaming (start_vision / stop_vision).
+ *
+ * Wire-up: voice-agent calls setVisionSession(session) once the VoiceSession
+ * is constructed (and setVisionSession(null) on close). Tool definitions are
+ * exported and registered via inline-tools.ts so they appear in both the
+ * voice and phone agents.
+ *
+ * Frame path: source.capture() → JPEG bytes → base64 →
+ * (session as any).transport.sendFile(b64, 'image/jpeg'). Gemini Live's
+ * realtime_input.video slot accepts single-frame images.
+ */
+
+import { readFileSync, unlinkSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createServer, type Server } from 'node:http';
+import { z } from 'zod';
+import type { ToolDefinition } from 'bodhi-realtime-agent';
+
+const execFileAsync = promisify(execFile);
+const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
+
+const DEFAULT_FPS = 1;
+const MAX_FPS = 2;
+const MIN_INTERVAL_MS = 250;
+// TODO(roadmap §5 Now: cost posture): A 720p JPEG q=0.6 ≈ 80–150KB. At 1 fps
+// continuous that's ~6–9MB/min into Gemini Live's video slot, plus context-
+// window growth from frame turns. Default off and tools never auto-start are
+// the cheap guard — the open work is a quota-aware throttle (drop fps on
+// rate-limit hints) and a brief doc explaining the per-minute cost
+// envelope. See vision and roadmap.md §5 Now.
+
+// --- Source abstraction ---------------------------------------------------
+
+export interface VisionFrame {
+	data: Buffer;
+	mimeType: string;
+}
+
+export interface VisionSource {
+	readonly name: string;
+	capture(): Promise<VisionFrame>;
+}
+
+const screenSource: VisionSource = {
+	name: 'screen',
+	async capture() {
+		// silent=true skips the menu-bar flash + macOS notification, which would
+		// otherwise fire on every frame during a stream. format=jpeg keeps
+		// frames small (~50–150KB).
+		const res = await fetch('http://localhost:7845/capture?format=jpeg&silent=true');
+		const data = (await res.json()) as { status: string; path?: string; error?: string };
+		if (data.status !== 'ok' || !data.path) {
+			throw new Error(`screen-capture-server: ${data.error || 'no path'}`);
+		}
+		const buf = readFileSync(data.path);
+		// Drop the on-disk copy — we've already uploaded the bytes.
+		try { unlinkSync(data.path); } catch {}
+		return { data: buf, mimeType: 'image/jpeg' };
+	},
+};
+
+const webcamSource: VisionSource = (() => {
+	// One scratch dir for the whole process — imagesnap is happiest writing to
+	// a real path it can stat, and reusing the path keeps tmpdir clean.
+	const dir = mkdtempSync(join(tmpdir(), 'sutando-webcam-'));
+	const path = join(dir, 'frame.jpg');
+	return {
+		name: 'webcam',
+		async capture() {
+			// `-w 0` skips the default 0.5s warmup. The first frame after a
+			// long pause may still look dim while the auto-exposure settles —
+			// callers driving a stream should expect frame #1 to be lower
+			// quality than steady-state. JPEG, default resolution.
+			await execFileAsync('imagesnap', ['-q', '-w', '0', path], { timeout: 8_000 });
+			const buf = readFileSync(path);
+			return { data: buf, mimeType: 'image/jpeg' };
+		},
+	};
+})();
+
+const sources: Record<string, VisionSource> = {
+	screen: screenSource,
+	webcam: webcamSource,
+};
+
+/** Register an additional vision source at runtime.
+ *
+ * Lets external integrations (AI glasses webhooks, Telegram photo bridges,
+ * external camera daemons, etc.) plug into the same start_vision /
+ * send_vision_frame pipeline without modifying this file. Example:
+ *
+ *   import { registerSource } from './vision-tools.js';
+ *   registerSource({
+ *     name: 'glasses',
+ *     async capture() { return { data: await fetchLatestGlassesFrame(), mimeType: 'image/jpeg' }; },
+ *   });
+ *
+ * Names are case-insensitive. Re-registering a name overwrites the prior source. */
+export function registerSource(source: VisionSource): void {
+	sources[source.name.toLowerCase()] = source;
+}
+
+/** Names of all currently registered sources, for tool descriptions / diagnostics. */
+export function listSources(): string[] {
+	return Object.keys(sources);
+}
+
+function resolveSource(name?: string): VisionSource {
+	const key = (name ?? 'screen').toLowerCase();
+	const src = sources[key];
+	if (!src) throw new Error(`Unknown vision source "${name}". Known: ${Object.keys(sources).join(', ')}.`);
+	return src;
+}
+
+// --- Session wiring -------------------------------------------------------
+
+interface MinimalSession {
+	transport?: {
+		sendFile?: (base64: string, mimeType: string) => void;
+		// Inject a hidden conversation turn (no generation trigger when
+		// turnComplete=false) so the model sees a context update without
+		// the user hearing audio. Used to evict stale push frames from
+		// Gemini Live's context when screen sharing ends.
+		sendContent?: (turns: Array<{ role: 'user' | 'assistant'; text: string }>, turnComplete?: boolean) => void;
+		isConnected?: boolean;
+	};
+}
+
+let sessionRef: MinimalSession | null = null;
+
+// TODO(roadmap §5 Now: "Define DeviceSession"): Replace this single-session
+// global with a DeviceSession map keyed by device ID. Today push-mode senders
+// (browser, Mentra glasses, Discord/Telegram photo helper, phone agent) all
+// race for one slot — last-set wins, and the phone-agent fix in
+// skills/phone-conversation/scripts/conversation-server.ts uses a fragile
+// swap-and-restore. Once DeviceSession exists, frames should carry a target
+// device ID and fan out only to that session.
+export function setVisionSession(session: unknown): void {
+	sessionRef = session as MinimalSession | null;
+	if (!session) stopStream();
+}
+
+function getSendFile(): ((b64: string, mime: string) => void) | null {
+	const t = sessionRef?.transport;
+	if (!t || !t.sendFile) return null;
+	// isConnected is optional — if exposed and false, skip; otherwise trust the call.
+	if (t.isConnected === false) return null;
+	return t.sendFile.bind(t);
+}
+
+// --- Streaming controller -------------------------------------------------
+
+let ticker: NodeJS.Timeout | null = null;
+let activeSource: VisionSource | null = null;
+let inFlight = false;
+let frameCount = 0;
+let startedAt = 0;
+// Push mode: the web-client owns capture (via getDisplayMedia, so the user
+// gets the native "Chrome Tab / Window / Entire Screen" picker) and POSTs
+// each JPEG frame to /vision/frame. The controller doesn't tick — it just
+// forwards frames to the live session.
+let pushMode = false;
+let pushSourceName: string | null = null;
+
+export function isStreaming(): boolean {
+	return ticker !== null || pushMode;
+}
+
+export interface VisionState {
+	streaming: boolean;
+	source: string | null;
+	fps: number;
+	frames: number;
+	durationMs: number;
+	sessionReady: boolean;
+}
+
+/** Public read-only view of vision streaming state.
+ *
+ * Used by the web-client toggle button to reflect "currently streaming /
+ * idle" regardless of whether the stream was started by voice or button. */
+export function getVisionState(): VisionState {
+	const streaming = ticker !== null || pushMode;
+	return {
+		streaming,
+		source: pushMode ? pushSourceName : (activeSource?.name ?? null),
+		fps: streaming ? Math.round((frameCount * 1000) / Math.max(1, Date.now() - startedAt)) : 0,
+		frames: frameCount,
+		durationMs: streaming && startedAt ? Date.now() - startedAt : 0,
+		sessionReady: getSendFile() !== null,
+	};
+}
+
+/** Programmatic start (used by the HTTP control server / button).
+ *
+ *  Two modes:
+ *    - **pull** (default): the controller ticks at `fps` Hz and calls the
+ *      registered source's `capture()`. Source must exist in the sources map
+ *      (built-in `screen`/`webcam`, or registered via `registerSource`).
+ *    - **push**: the caller owns capture and POSTs frames to /vision/frame.
+ *      Source is a free-form label ('browser', 'glasses', 'mentra-camera').
+ *      Use this for browser getDisplayMedia, Mentra glasses, AI-glasses
+ *      webhooks, or anything that produces frames out-of-band.
+ *  `browser` is an alias for `mode: 'push'` (back-compat).
+ *
+ *  Returns the same shape as the start_vision tool. */
+export function startStreaming(
+	sourceName: string | undefined,
+	fps: number | undefined,
+	mode?: 'pull' | 'push',
+):
+	| { status: 'streaming'; source: string; fps: number; intervalMs: number; mode: 'pull' | 'push' }
+	| { status: 'failed'; error: string } {
+	if (!getSendFile()) {
+		return { status: 'failed', error: 'No active voice session — vision streaming requires a connected session.' };
+	}
+	try {
+		const lower = (sourceName ?? 'screen').toLowerCase();
+		const effectiveMode: 'pull' | 'push' = mode ?? (lower === 'browser' ? 'push' : 'pull');
+		if (effectiveMode === 'push') {
+			// Push mode — caller (web-client, Mentra bridge, glasses webhook,
+			// etc.) captures frames and POSTs them to /vision/frame. No ticker.
+			stopStream();
+			pushMode = true;
+			pushSourceName = lower;
+			frameCount = 0;
+			startedAt = Date.now();
+			console.log(`${ts()} [Vision] started ${lower} (push mode)`);
+			// Tell the model push just started so it can briefly acknowledge
+			// on its next turn ("I can see your screen now"). Without this
+			// the user clicks Watch and gets no audible confirmation — silent
+			// activation feels broken even when frames are flowing. Symmetric
+			// to the stop-side cache-clear injection in stopStream().
+			const transport = sessionRef?.transport;
+			if (transport && typeof transport.sendContent === 'function') {
+				try {
+					transport.sendContent([{
+						role: 'user',
+						text: `[system note] User just started sharing their screen via the Watch button (source='${lower}'). Frames are now flowing live. On your next turn, briefly acknowledge that you can see their shared screen — e.g. "I can see your screen now." Do not describe it in detail unless the user asks.`,
+					}], false);
+					console.log(`${ts()} [Vision] injected screen-share-started context hint`);
+				} catch (err) {
+					console.warn(`${ts()} [Vision] failed to inject screen-share-started hint: ${(err as Error).message}`);
+				}
+			}
+			return { status: 'streaming', source: lower, fps: 0, intervalMs: 0, mode: 'push' };
+		}
+		const source = resolveSource(sourceName);
+		const info = startStream(source, fps ?? DEFAULT_FPS);
+		return { status: 'streaming', source: source.name, fps: info.fps, intervalMs: info.intervalMs, mode: 'pull' };
+	} catch (err) {
+		return { status: 'failed', error: (err as Error)?.message ?? String(err) };
+	}
+}
+
+/** Programmatic stop (used by the HTTP control server / button). */
+export function stopStreaming(): { status: 'stopped' | 'idle'; source: string | null; frames: number; durationMs: number } {
+	const r = stopStream();
+	return { status: r.wasRunning ? 'stopped' : 'idle', source: r.source, frames: r.frames, durationMs: r.durationMs };
+}
+
+function stopStream(): { wasRunning: boolean; frames: number; durationMs: number; source: string | null } {
+	const wasRunning = ticker !== null || pushMode;
+	const sourceName = pushMode ? pushSourceName : (activeSource?.name ?? null);
+	const wasPush = pushMode;
+	if (ticker) {
+		clearInterval(ticker);
+		ticker = null;
+	}
+	pushMode = false;
+	pushSourceName = null;
+	const frames = frameCount;
+	const durationMs = startedAt ? Date.now() - startedAt : 0;
+	if (wasRunning) {
+		console.log(`${ts()} [Vision] stopped ${sourceName}${wasPush ? ' (push)' : ''} — ${frames} frame(s) in ${(durationMs / 1000).toFixed(1)}s`);
+	}
+	activeSource = null;
+	frameCount = 0;
+	startedAt = 0;
+	// Push-mode frames accumulate in Gemini Live's conversation context.
+	// Without this hint, "what do you see?" after the user stops sharing
+	// gets answered from the last frame still in context (model recalls
+	// from memory instead of calling send_vision_frame to grab a fresh
+	// view). Inject a silent user-role turn (turnComplete=false → no
+	// generation triggered) so the next user turn carries the context
+	// shift: visual frames are stale.
+	if (wasPush) {
+		const transport = sessionRef?.transport;
+		// Call as a method (not via an extracted reference) so `this` binds
+		// to the transport — GeminiLiveTransport.sendContent uses `this.session`
+		// internally and throws otherwise.
+		if (transport && typeof transport.sendContent === 'function') {
+			try {
+				transport.sendContent([{
+					role: 'user',
+					text: '[system note] User has stopped sharing their screen. Previously-streamed video frames are stale — do not describe them as the current view. If the user now asks "what do you see", call send_vision_frame to capture a fresh image.',
+				}], false);
+				console.log(`${ts()} [Vision] injected screen-share-ended context hint`);
+			} catch (err) {
+				console.warn(`${ts()} [Vision] failed to inject screen-share-ended hint: ${(err as Error).message}`);
+			}
+		}
+	}
+	return { wasRunning, frames, durationMs, source: sourceName };
+}
+
+/** Inject a frame from an external pusher (the web-client's
+ *  getDisplayMedia loop). Push-mode must be active — caller should have
+ *  hit /vision/start with source='browser' first. */
+export function submitFrame(data: Buffer, mimeType: string = 'image/jpeg'): { ok: boolean; error?: string } {
+	const sendFile = getSendFile();
+	if (!sendFile) {
+		console.warn(`${ts()} [Vision] frame dropped: no active voice session (sessionRef=${!!sessionRef}, transport=${!!sessionRef?.transport})`);
+		return { ok: false, error: 'no active voice session' };
+	}
+	if (!pushMode) {
+		console.warn(`${ts()} [Vision] frame dropped: push mode inactive — call /vision/start with source=browser first`);
+		return { ok: false, error: 'not in push mode — call /vision/start with source=browser first' };
+	}
+	try {
+		sendFile(data.toString('base64'), mimeType);
+		frameCount++;
+		// Log first frame so the user can confirm vision is wired end-to-end,
+		// and every 10th to keep tail noise low.
+		if (frameCount === 1 || frameCount % 10 === 0) {
+			console.log(`${ts()} [Vision] sent frame #${frameCount} (${Math.round(data.byteLength / 1024)}KB ${mimeType})`);
+		}
+		return { ok: true };
+	} catch (err) {
+		console.error(`${ts()} [Vision] sendFile threw: ${(err as Error)?.message ?? err}`);
+		return { ok: false, error: (err as Error)?.message ?? String(err) };
+	}
+}
+
+async function captureAndSend(source: VisionSource): Promise<{ ok: boolean; error?: string }> {
+	const sendFile = getSendFile();
+	if (!sendFile) return { ok: false, error: 'no active voice session' };
+	const frame = await source.capture();
+	sendFile(frame.data.toString('base64'), frame.mimeType);
+	return { ok: true };
+}
+
+async function tick(): Promise<void> {
+	if (inFlight || !activeSource) return; // skip overlap — slow camera or slow disk
+	inFlight = true;
+	try {
+		const r = await captureAndSend(activeSource);
+		if (r.ok) frameCount++;
+		else console.error(`${ts()} [Vision] tick skipped: ${r.error}`);
+	} catch (err) {
+		console.error(`${ts()} [Vision] frame error: ${(err as Error)?.message ?? err}`);
+	} finally {
+		inFlight = false;
+	}
+}
+
+function startStream(source: VisionSource, fps: number): { fps: number; intervalMs: number } {
+	const clamped = Math.max(0.5, Math.min(MAX_FPS, fps));
+	const intervalMs = Math.max(MIN_INTERVAL_MS, Math.round(1000 / clamped));
+	if (ticker) clearInterval(ticker);
+	activeSource = source;
+	frameCount = 0;
+	startedAt = Date.now();
+	console.log(`${ts()} [Vision] started ${source.name} — ${clamped} fps (${intervalMs}ms)`);
+	// Send one frame immediately so the model has context before the first interval.
+	void tick();
+	ticker = setInterval(() => { void tick(); }, intervalMs);
+	return { fps: clamped, intervalMs };
+}
+
+// --- Tools ----------------------------------------------------------------
+
+export const sendVisionFrameTool: ToolDefinition = {
+	name: 'send_vision_frame',
+	description:
+		"Capture and send a single image to you (Gemini) as vision input. Use for one-off " +
+		"\"what am I looking at\", \"can you see this\", \"check what's on my screen now\". " +
+		"Source defaults to the user's screen; pass source='webcam' for the front camera, or any other registered source (e.g. 'glasses'). " +
+		'For ongoing observation, use start_vision instead. Instant.',
+	parameters: z.object({
+		source: z.string().optional().describe("Frame source. Default 'screen'. Built-in: 'screen', 'webcam'. External integrations may register more (e.g. 'glasses')."),
+	}),
+	execution: 'inline',
+	async execute(args) {
+		const { source: sourceName } = (args ?? {}) as { source?: string };
+		// Push mode: frames are already streaming; the latest one is in your
+		// context. Don't fight the active stream by shelling out to a
+		// (possibly permission-denied) screencapture.
+		if (pushMode) {
+			return {
+				status: 'sent',
+				source: `push:${pushSourceName || 'unknown'}`,
+				framesSinceStart: frameCount,
+				note: 'Push mode active — latest frame is already in your context.',
+			};
+		}
+		try {
+			const source = resolveSource(sourceName);
+			const r = await captureAndSend(source);
+			if (!r.ok) return { status: 'failed', error: r.error };
+			return { status: 'sent', source: source.name };
+		} catch (err) {
+			return { status: 'failed', error: (err as Error)?.message ?? String(err) };
+		}
+	},
+};
+
+export const startVisionTool: ToolDefinition = {
+	name: 'start_vision',
+	description:
+		"Start streaming live vision frames to you (Gemini) so you can see what the user is doing in real time. " +
+		"Use for: \"watch my screen\", \"look at what I'm doing\", \"follow along\", \"see me as I talk\". " +
+		'Frames flow at ~1 fps until stop_vision is called or the session ends. ' +
+		"Source defaults to the user's screen; pass source='webcam' for the front camera, or any other registered source (e.g. 'glasses'). " +
+		'Prefer send_vision_frame for one-off "look at this" questions. Instant.',
+	parameters: z.object({
+		source: z.string().optional().describe("Frame source. Default 'screen'. Built-in: 'screen', 'webcam'. External integrations may register more (e.g. 'glasses')."),
+		fps: z.number().optional().describe('Frames per second, 0.5–2. Default 1. Webcam may not keep up above 0.5.'),
+	}),
+	execution: 'inline',
+	async execute(args) {
+		const { source: sourceName, fps } = (args ?? {}) as { source?: string; fps?: number };
+		if (!getSendFile()) {
+			return { status: 'failed', error: 'No active voice session — vision streaming requires a connected session.' };
+		}
+		// Push mode: the user has already chosen a surface (tab/window/screen)
+		// via the browser's getDisplayMedia picker (or another pusher), and
+		// frames are flowing. Don't switch to pull-mode screencapture — that
+		// would replace the user's deliberately-chosen surface with the whole
+		// desktop. Just acknowledge that we're already watching.
+		if (pushMode) {
+			return {
+				status: 'streaming',
+				source: `push:${pushSourceName || 'unknown'}`,
+				fps: 0,
+				intervalMs: 0,
+				mode: 'push',
+				note: 'Push mode already active — frames are flowing from the externally-chosen surface. Latest frame is in your context.',
+			};
+		}
+		try {
+			const source = resolveSource(sourceName);
+			const info = startStream(source, fps ?? DEFAULT_FPS);
+			return { status: 'streaming', source: source.name, fps: info.fps, intervalMs: info.intervalMs };
+		} catch (err) {
+			return { status: 'failed', error: (err as Error)?.message ?? String(err) };
+		}
+	},
+};
+
+export const stopVisionTool: ToolDefinition = {
+	name: 'stop_vision',
+	description:
+		'Stop the live vision stream started by start_vision. ' +
+		'Use for: "stop watching", "you can stop looking now", "stop the screen share", "stop the camera". Instant.',
+	parameters: z.object({}),
+	execution: 'inline',
+	async execute() {
+		const r = stopStream();
+		if (!r.wasRunning) return { status: 'idle', note: 'Vision was not streaming.' };
+		return { status: 'stopped', source: r.source, frames: r.frames, durationMs: r.durationMs };
+	},
+};
+
+// --- HTTP control server --------------------------------------------------
+// Tiny localhost-only server so the web-client's Watch button (and any other
+// out-of-process caller) can drive the same controller the voice tools use.
+// web-client.ts proxies /vision/* to this port to keep the browser
+// same-origin — don't expose this port externally.
+
+// 7846 is taken by credential-proxy (ANTHROPIC_BASE_URL); 7847 is free.
+const DEFAULT_CONTROL_PORT = Number(process.env.VISION_CONTROL_PORT) || 7847;
+let controlServer: Server | null = null;
+
+function readJsonBody(req: import('node:http').IncomingMessage): Promise<Record<string, unknown>> {
+	return new Promise((resolve) => {
+		const chunks: Buffer[] = [];
+		req.on('data', (c: Buffer) => chunks.push(c));
+		req.on('end', () => {
+			if (chunks.length === 0) return resolve({});
+			try { resolve(JSON.parse(Buffer.concat(chunks).toString('utf-8')) as Record<string, unknown>); }
+			catch { resolve({}); }
+		});
+		req.on('error', () => resolve({}));
+	});
+}
+
+export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): Server {
+	if (controlServer) return controlServer;
+	const srv = createServer(async (req, res) => {
+		const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+		const respond = (status: number, body: unknown) => {
+			res.writeHead(status, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify(body));
+		};
+		if (url.pathname === '/vision/state' && req.method === 'GET') {
+			return respond(200, getVisionState());
+		}
+		if (url.pathname === '/vision/start' && req.method === 'POST') {
+			const body = await readJsonBody(req);
+			const source = typeof body.source === 'string' ? body.source : undefined;
+			const fps = typeof body.fps === 'number' ? body.fps : undefined;
+			const mode = body.mode === 'push' || body.mode === 'pull' ? body.mode : undefined;
+			const r = startStreaming(source, fps, mode);
+			return respond(r.status === 'failed' ? 409 : 200, r);
+		}
+		if (url.pathname === '/vision/stop' && req.method === 'POST') {
+			return respond(200, stopStreaming());
+		}
+		if (url.pathname === '/vision/frame' && req.method === 'POST') {
+			const chunks: Buffer[] = [];
+			req.on('data', (c: Buffer) => chunks.push(c));
+			req.on('end', () => {
+				const buf = Buffer.concat(chunks);
+				const mime = (req.headers['content-type'] as string | undefined) || 'image/jpeg';
+				const r = submitFrame(buf, mime);
+				respond(r.ok ? 200 : 409, r.ok ? { status: 'sent' } : { status: 'failed', error: r.error });
+			});
+			req.on('error', () => respond(500, { status: 'failed', error: 'request error' }));
+			return;
+		}
+		respond(404, { error: 'not found' });
+	});
+	srv.on('error', (err: NodeJS.ErrnoException) => {
+		// EADDRINUSE means another voice-agent is already running. Don't crash —
+		// the existing instance owns the control endpoint.
+		if (err.code === 'EADDRINUSE') {
+			console.warn(`${ts()} [Vision] control port ${port} in use; skipping (another voice-agent?)`);
+			controlServer = null;
+			return;
+		}
+		console.error(`${ts()} [Vision] control server error: ${err.message}`);
+	});
+	srv.listen(port, '127.0.0.1', () => {
+		console.log(`${ts()} [Vision] control server listening on 127.0.0.1:${port}`);
+	});
+	controlServer = srv;
+	return srv;
+}
+
+export function stopVisionControlServer(): void {
+	if (!controlServer) return;
+	try { controlServer.close(); } catch {}
+	controlServer = null;
+}

--- a/src/vision_push.py
+++ b/src/vision_push.py
@@ -24,6 +24,11 @@ import urllib.error
 VISION_PORT = int(os.environ.get("VISION_CONTROL_PORT", "7847"))
 VISION_BASE = f"http://127.0.0.1:{VISION_PORT}"
 
+# Skip bytes below typical JPEG minimum to avoid forwarding corrupted or
+# in-flight downloads — a partial fetch returning under 2 KB is almost
+# certainly not a real frame (header + tiny payload at best).
+MIN_FRAME_BYTES = 2048
+
 
 def _post(path: str, body: bytes, content_type: str, timeout: float = 3.0) -> tuple[int, bytes]:
     req = urllib.request.Request(
@@ -70,8 +75,8 @@ def push_image(path: str, source: str = "bridge") -> bool:
             data = fh.read()
     except OSError:
         return False
-    if len(data) < 2048:
-        return False  # blank/tiny
+    if len(data) < MIN_FRAME_BYTES:
+        return False  # blank/tiny/partial
 
     if not is_voice_ready():
         return False

--- a/src/vision_push.py
+++ b/src/vision_push.py
@@ -1,0 +1,87 @@
+"""Small helper for posting one-shot vision frames to the active voice session.
+
+Used by the Discord and Telegram bridges (and any other Python integration)
+to push an image into Gemini Live's vision context when a photo arrives and
+voice is connected. No-op when voice-agent isn't reachable — the photo will
+still flow through the regular task pipeline as a file attachment.
+
+Contract mirrors the JS-side controller in src/vision-tools.ts:
+  - POST /vision/start  {source, mode:'push'}   enter push mode
+  - POST /vision/frame  <binary JPEG/PNG>       inject one frame
+  - POST /vision/stop                            leave push mode
+
+Single-shot helper: starts push mode, sends the frame, leaves push mode on.
+Calling it again while push mode is already on just sends another frame
+(the start call is idempotent).
+"""
+
+import mimetypes
+import os
+import urllib.request
+import urllib.error
+
+
+VISION_PORT = int(os.environ.get("VISION_CONTROL_PORT", "7847"))
+VISION_BASE = f"http://127.0.0.1:{VISION_PORT}"
+
+
+def _post(path: str, body: bytes, content_type: str, timeout: float = 3.0) -> tuple[int, bytes]:
+    req = urllib.request.Request(
+        f"{VISION_BASE}{path}",
+        data=body,
+        headers={"Content-Type": content_type},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read() if e.fp else b""
+    except (urllib.error.URLError, ConnectionRefusedError, TimeoutError, OSError):
+        return 0, b""
+
+
+def is_voice_ready(timeout: float = 1.0) -> bool:
+    """Return True if a voice session is up and can accept frames."""
+    try:
+        with urllib.request.urlopen(f"{VISION_BASE}/vision/state", timeout=timeout) as resp:
+            import json
+            data = json.loads(resp.read())
+            return bool(data.get("sessionReady"))
+    except Exception:
+        return False
+
+
+def push_image(path: str, source: str = "bridge") -> bool:
+    """Inject the JPEG/PNG at *path* into the active voice session's vision stream.
+
+    Returns True if the frame was accepted. Silently returns False if voice
+    isn't ready or the file can't be read — callers shouldn't break on this
+    because the photo still flows through the normal task path.
+    """
+    if not os.path.isfile(path):
+        return False
+    mime, _ = mimetypes.guess_type(path)
+    if not mime or not mime.startswith("image/"):
+        # Unknown extension — assume JPEG. Gemini will reject if it's wrong.
+        mime = "image/jpeg"
+    try:
+        with open(path, "rb") as fh:
+            data = fh.read()
+    except OSError:
+        return False
+    if len(data) < 2048:
+        return False  # blank/tiny
+
+    if not is_voice_ready():
+        return False
+
+    # Idempotent: starting push mode while already in push mode is fine; the
+    # controller resets counters and continues to accept frames.
+    _post(
+        "/vision/start",
+        b'{"source":"' + source.encode() + b'","mode":"push"}',
+        "application/json",
+    )
+    status, _ = _post("/vision/frame", data, mime)
+    return 200 <= status < 300

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -27,6 +27,7 @@ import { z } from 'zod';
 import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, mkdirSync, appendFileSync, writeFileSync } from 'node:fs';
 import { execSync as execSyncTop } from 'node:child_process';
 import { inlineTools, coreDocumentedSkills } from './inline-tools.js';
+import { setVisionSession, startVisionControlServer, stopVisionControlServer } from './vision-tools.js';
 import { injectText } from './browser-tools.js';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
@@ -871,6 +872,12 @@ async function main() {
 	});
 
 	sessionRef = session;
+	// Wire vision streaming — the start_vision tool needs the live session
+	// to call session.transport.sendFile for each frame. Also boot the local
+	// HTTP control endpoint so the web-client Watch button can drive the
+	// same controller (proxied through web-client to stay same-origin).
+	setVisionSession(session);
+	startVisionControlServer();
 
 	// Bumped 5min into the future on every non-retryable transport close
 	// (set inside the classifier IIFE below). Read by the 30s health
@@ -1102,6 +1109,8 @@ async function main() {
 	const shutdown = async () => {
 		console.log(`\n${ts()} Shutting down...`);
 		writeVoiceMetrics();
+		setVisionSession(null);
+		stopVisionControlServer();
 		await session.close('user_hangup');
 		process.exit(0);
 	};

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -240,6 +240,19 @@ const HTML = /* html */ `<!DOCTYPE html>
   .btn-mute { background: #2a2a3e; color: #888; }
   .btn-mute:hover { background: #3a3a4e; color: #fff; }
   .btn-mute.muted { background: #4a1a1a; color: #e94560; }
+  /* Watch (vision streaming) — matches the avatar 'seeing' palette (#fbbf24). */
+  .btn-watch { background: #2a2a3e; color: #888; }
+  .btn-watch:hover { background: #3a3a4e; color: #fff; }
+  .btn-watch.watching {
+    background: #3a2e10; color: #fbbf24; border: 1px solid #7a5a14;
+    box-shadow: 0 0 10px rgba(251, 191, 36, 0.35);
+    animation: btn-watch-pulse 1.6s ease-in-out infinite;
+  }
+  .btn-watch.watching:hover { background: #4a3a14; color: #ffd966; }
+  @keyframes btn-watch-pulse {
+    0%, 100% { box-shadow: 0 0 8px rgba(251, 191, 36, 0.3); }
+    50%      { box-shadow: 0 0 16px rgba(251, 191, 36, 0.55); }
+  }
   .btn-subtle { background: transparent; color: #444; font-size: 11px; padding: 5px 8px; }
   .btn-subtle:hover { color: #888; }
 
@@ -605,7 +618,18 @@ const HTML = /* html */ `<!DOCTYPE html>
   <div class="controls">
     <button id="btn" class="btn-voice" onclick="toggle()" style="display:none">End Voice</button>
     <button id="btn-mute" class="btn-mute" onclick="toggleMute()" style="display:none">Mute</button>
+    <button id="btn-watch" class="btn-watch" onclick="toggleWatch()" title="Let Sutando watch your screen" style="display:none">👁️ Watch</button>
   </div>
+</div>
+<!-- Vision preview — shows what Sutando is seeing. Mirrors the MediaStream
+     captured by getDisplayMedia so the user can verify the picked surface
+     and see the same view the model gets. -->
+<div id="vision-preview-wrap" style="display:none; position: fixed; bottom: 16px; right: 16px; z-index: 200; background: rgba(0,0,0,0.6); border: 2px solid #fbbf24; border-radius: 10px; padding: 6px 6px 4px; box-shadow: 0 4px 18px rgba(0,0,0,0.35), 0 0 14px rgba(251,191,36,0.45); max-width: 280px;">
+  <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:4px; font: 11px/1.2 -apple-system, system-ui, sans-serif; color:#fbbf24;">
+    <span style="display:inline-flex; align-items:center; gap:6px;">👁️ Sutando is seeing</span>
+    <span id="vision-preview-stats" style="color:#bbb; font-size:10px;"></span>
+  </div>
+  <video id="vision-preview" autoplay muted playsinline style="display:block; width: 100%; max-height: 180px; background:#000; border-radius:6px;"></video>
 </div>
 <input type="text" id="wsUrl" value="${DEFAULT_WS_URL}" />
 <script>
@@ -1859,11 +1883,288 @@ function doCleanup() {
   $('hero').style.display = '';
   $('btn').style.display = 'none';
   $('btn-mute').style.display = 'none';
+  $('btn-watch').style.display = 'none';
+  teardownPushSession();
+  stopVisionPoll();
   $('voice-status').className = 'status-pill voice-off';
   try { sessionStorage.removeItem('sutando-voice'); } catch {}
   if (statsTimer) { clearInterval(statsTimer); statsTimer = null; }
   updateStats();
 }
+
+// ─── Vision toggle (let Sutando see your screen) ──────────
+// The browser owns capture (so the user gets the native Chrome Tab / Window /
+// Entire Screen picker), and we POST each frame to /vision/frame. The same
+// MediaStream renders into the on-screen preview so the user sees exactly
+// what Sutando sees. Voice tools (start_vision/stop_vision) still flip the
+// button via the 2s poll for the server-side screencapture path.
+var VISION_FRAME_INTERVAL_MS = 1500; // 1280x720 JPEG q=0.6 → ~80–150KB/frame; ~0.7 fps
+var VISION_FRAME_WIDTH = 1280;
+var VISION_FRAME_HEIGHT = 720;
+var VISION_FRAME_QUALITY = 0.6;
+var _visionStreaming = false;        // last-known server state (push or pull)
+var _visionPushActive = false;       // this browser is the push-mode driver
+var _visionPollTimer = null;
+var _visionStream = null;            // MediaStream from getDisplayMedia
+var _visionFrameTimer = null;
+var _visionFrameCount = 0;
+var _visionCanvas = null;            // hidden canvas reused for toBlob
+// Auto-recover state: when voice-agent restarts, the browser still holds
+// a live MediaStream but the server has pushMode=false. We re-issue
+// /vision/start (without re-prompting for getDisplayMedia) to recover.
+// Capped to prevent thrashing if recovery genuinely fails.
+var _visionRearmInFlight = false;
+var _visionRearmCount = 0;
+var _VISION_REARM_LIMIT = 3;
+
+function applyVisionState(state) {
+  if (!state) return;
+  var streaming = !!state.streaming;
+  _visionStreaming = streaming;
+  var btn = document.getElementById('btn-watch');
+  if (!btn) return;
+  btn.className = streaming ? 'btn-watch watching' : 'btn-watch';
+  if (streaming) {
+    var src = state.source || 'screen';
+    var label = src === 'browser' ? 'screen' : src;
+    btn.textContent = '👁️ Watching (' + label + ')';
+    btn.title = 'Sutando is watching your ' + label + ' — click to stop';
+  } else {
+    btn.textContent = '👁️ Watch';
+    btn.title = 'Let Sutando watch your screen';
+  }
+  // Auto-recover: the server has fallen out of push mode (voice-agent
+  // restart, race, etc.) but we still hold a live MediaStream. Re-arm
+  // push mode without re-prompting for getDisplayMedia. If the stream
+  // is gone, just tear down our side.
+  var ourSideStale = _visionPushActive && (!streaming || state.source !== 'browser');
+  if (ourSideStale) {
+    if (_visionStream && _visionStream.active) {
+      rearmPushMode();
+    } else {
+      teardownPushSession();
+    }
+  } else if (streaming && state.source === 'browser') {
+    // Healthy push session — clear any prior recovery attempts.
+    _visionRearmCount = 0;
+  }
+}
+
+// Re-issue /vision/start so the server re-enters push mode, without
+// re-prompting the user for getDisplayMedia. The browser's MediaStream
+// is still live; only the server-side flag was lost. Capped at
+// _VISION_REARM_LIMIT consecutive attempts to prevent thrashing if
+// recovery genuinely fails (e.g., voice session is gone).
+function rearmPushMode() {
+  if (_visionRearmInFlight || _visionRearmCount >= _VISION_REARM_LIMIT) return;
+  if (!_visionStream || !_visionStream.active) return;
+  _visionRearmInFlight = true;
+  _visionRearmCount++;
+  fetch('/vision/start', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ source: 'browser' }),
+  }).then(function(r) {
+    return r.json().catch(function() { return {}; });
+  }).then(function(d) {
+    if (d && d.status === 'streaming') {
+      _visionRearmCount = 0;
+      addSystem('Vision: push mode re-armed (server restart detected).');
+    } else if (_visionRearmCount >= _VISION_REARM_LIMIT) {
+      addSystem('Vision: re-arm failed — click Watch to share again.');
+      teardownPushSession();
+    }
+  }).catch(function() {
+    if (_visionRearmCount >= _VISION_REARM_LIMIT) {
+      teardownPushSession();
+    }
+  }).finally(function() {
+    _visionRearmInFlight = false;
+  });
+}
+function pollVisionState() {
+  fetch('/vision/state').then(function(r) {
+    if (!r.ok) return null;
+    return r.json();
+  }).then(function(s) { if (s) applyVisionState(s); }).catch(function() {});
+}
+function startVisionPoll() {
+  pollVisionState();
+  if (_visionPollTimer) clearInterval(_visionPollTimer);
+  _visionPollTimer = setInterval(pollVisionState, 2000);
+}
+function stopVisionPoll() {
+  if (_visionPollTimer) { clearInterval(_visionPollTimer); _visionPollTimer = null; }
+  _visionStreaming = false;
+}
+
+function updateVisionPreviewStats() {
+  var stats = document.getElementById('vision-preview-stats');
+  if (stats) stats.textContent = _visionFrameCount + ' frame' + (_visionFrameCount === 1 ? '' : 's');
+}
+
+function captureAndSendFrame() {
+  var preview = document.getElementById('vision-preview');
+  if (!preview || !_visionStream) return;
+  // Wait for the video to actually have pixels — readyState >= HAVE_CURRENT_DATA (2)
+  if (preview.readyState < 2 || !preview.videoWidth || !preview.videoHeight) return;
+  if (!_visionCanvas) _visionCanvas = document.createElement('canvas');
+  _visionCanvas.width = VISION_FRAME_WIDTH;
+  _visionCanvas.height = VISION_FRAME_HEIGHT;
+  var ctx = _visionCanvas.getContext('2d');
+  ctx.drawImage(preview, 0, 0, VISION_FRAME_WIDTH, VISION_FRAME_HEIGHT);
+  _visionCanvas.toBlob(function(blob) {
+    if (!blob) return;
+    // Skip blank frames — getDisplayMedia sometimes paints a black frame
+    // for the first tick when the user switches surfaces; uploading a
+    // black JPEG just wastes context.
+    if (blob.size < 2048) return;
+    fetch('/vision/frame', {
+      method: 'POST',
+      headers: { 'Content-Type': 'image/jpeg' },
+      body: blob,
+    }).then(function(r) {
+      if (r.ok) {
+        _visionFrameCount++;
+        // Successful POST → server is in push mode again. Reset the
+        // recovery counter so future restarts get a fresh budget.
+        _visionRearmCount = 0;
+        updateVisionPreviewStats();
+      } else {
+        // 409 means the server's pushMode flag is false (voice-agent
+        // restart) — try to re-arm without waiting for the 2s state poll.
+        if (r.status === 409 && _visionPushActive) {
+          rearmPushMode();
+        }
+        // Surface the first rejection so the user sees why Sutando doesn't
+        // see frames (e.g. push mode not active because voice isn't ready).
+        if (_visionFrameCount === 0) {
+          r.text().then(function(t) { addSystem('Vision frame rejected (' + r.status + '): ' + t); }).catch(function() {});
+        }
+      }
+    }).catch(function() { /* network blip — next tick will retry */ });
+  }, 'image/jpeg', VISION_FRAME_QUALITY);
+}
+
+function teardownPushSession() {
+  _visionPushActive = false;
+  if (_visionFrameTimer) { clearInterval(_visionFrameTimer); _visionFrameTimer = null; }
+  if (_visionStream) {
+    try { _visionStream.getTracks().forEach(function(t) { t.stop(); }); } catch (e) {}
+    _visionStream = null;
+  }
+  var preview = document.getElementById('vision-preview');
+  if (preview) preview.srcObject = null;
+  var wrap = document.getElementById('vision-preview-wrap');
+  if (wrap) wrap.style.display = 'none';
+  _visionFrameCount = 0;
+  _visionRearmCount = 0;
+}
+
+async function startWatch() {
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getDisplayMedia) {
+    addSystem('Vision: this browser does not support screen sharing.');
+    return;
+  }
+  var stream;
+  try {
+    // User picks Chrome Tab / Window / Entire Screen here.
+    stream = await navigator.mediaDevices.getDisplayMedia({
+      video: { width: VISION_FRAME_WIDTH, height: VISION_FRAME_HEIGHT, frameRate: 2 },
+      audio: false,
+    });
+  } catch (err) {
+    // NotAllowedError when the user cancels the picker — silent.
+    if (err && err.name !== 'NotAllowedError') {
+      addSystem('Vision: ' + (err.message || 'screen share failed'));
+    }
+    return;
+  }
+  _visionStream = stream;
+  var preview = document.getElementById('vision-preview');
+  var wrap = document.getElementById('vision-preview-wrap');
+  if (preview) preview.srcObject = stream;
+  if (wrap) wrap.style.display = '';
+
+  // User can end sharing from the browser's native UI ("Stop sharing"
+  // toolbar) — clean up our side and tell the server.
+  var track = stream.getVideoTracks()[0];
+  if (track) track.addEventListener('ended', function() {
+    console.log('[Vision] track.ended fired — user stopped share via Chrome native UI (or track died)');
+    stopWatch();
+  });
+
+  // Tell the server we're entering push mode.
+  var startResp;
+  try {
+    var r = await fetch('/vision/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source: 'browser' }),
+    });
+    startResp = await r.json().catch(function() { return { status: 'failed', error: 'bad json' }; });
+  } catch (e) {
+    startResp = { status: 'failed', error: 'voice-agent not reachable' };
+  }
+  if (startResp.status === 'failed') {
+    addSystem('Vision: ' + (startResp.error || 'failed to start'));
+    teardownPushSession();
+    pollVisionState();
+    return;
+  }
+  _visionPushActive = true;
+  _visionFrameCount = 0;
+  updateVisionPreviewStats();
+
+  // Wait for the first painted frame, then start the ticker. Without this
+  // the first capture often paints a black canvas because the video
+  // element hasn't rendered any data yet.
+  var startTicker = function() {
+    if (_visionFrameTimer) clearInterval(_visionFrameTimer);
+    setTimeout(captureAndSendFrame, 250);
+    _visionFrameTimer = setInterval(captureAndSendFrame, VISION_FRAME_INTERVAL_MS);
+  };
+  if (preview && preview.readyState >= 2 && preview.videoWidth) {
+    startTicker();
+  } else if (preview) {
+    preview.addEventListener('playing', startTicker, { once: true });
+  }
+  pollVisionState();
+}
+
+async function stopWatch() {
+  console.log('[Vision] stopWatch called — tearing down push session and POSTing /vision/stop');
+  console.trace('[Vision] stopWatch caller');
+  teardownPushSession();
+  try {
+    await fetch('/vision/stop', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+  } catch (e) {}
+  pollVisionState();
+}
+
+function toggleWatch() {
+  // Debug: log entry state so we can see why a click went to stop vs start.
+  // Common gotcha: a stale _visionPushActive=true from a prior dead
+  // session sends the click to stopWatch silently, and the user is stuck.
+  var streamAlive = !!(_visionStream && _visionStream.active);
+  console.log('[Vision] toggleWatch:',
+    'pushActive=' + _visionPushActive,
+    'streaming=' + _visionStreaming,
+    'streamAlive=' + streamAlive);
+  // Defensive: if we *think* we're pushing but the MediaStream is gone
+  // or its tracks have ended, drop the stale flag so the click resolves
+  // to startWatch instead of a no-op stopWatch.
+  if (_visionPushActive && !streamAlive) {
+    console.log('[Vision] toggleWatch: clearing stale _visionPushActive — stream is dead');
+    teardownPushSession();
+  }
+  if (_visionPushActive || _visionStreaming) {
+    stopWatch();
+  } else {
+    startWatch();
+  }
+}
+window.toggleWatch = toggleWatch;
 
 // ─── Mute toggle ──────────────────────────────────────────
 function toggleMute() {
@@ -1952,6 +2253,10 @@ function toggle() {
     $('btn-mute').style.display = '';
     $('btn-mute').textContent = 'Mute';
     $('btn-mute').className = 'btn-mute';
+    $('btn-watch').style.display = '';
+    $('btn-watch').textContent = '👁️ Watch';
+    $('btn-watch').className = 'btn-watch';
+    startVisionPoll();
     $('voice-status').className = 'status-pill voice-on';
     $('status').textContent = 'Voice active';
     try { sessionStorage.setItem('sutando-voice', '1'); } catch {}
@@ -3301,6 +3606,46 @@ const server = createServer((req, res) => {
 		}
 		res.writeHead(200, { 'Content-Type': 'application/json' });
 		res.end(JSON.stringify({ ok: true, event, clients: sseClients.length }));
+		return;
+	}
+
+	// Vision control proxy. The voice-agent process exposes /vision/{state,
+	// start, stop, frame} on 127.0.0.1:VISION_CONTROL_PORT (default 7847); the
+	// browser hits us same-origin to avoid CORS and to keep one public surface.
+	// /vision/frame carries a binary JPEG body — preserve content-type and
+	// pass the buffer through. If voice-agent isn't up, the fetch fails and
+	// we surface a synthetic "session not ready" state so the Watch button
+	// can't get stuck mid-toggle.
+	if (
+		url.pathname === '/vision/state' ||
+		url.pathname === '/vision/start' ||
+		url.pathname === '/vision/stop' ||
+		url.pathname === '/vision/frame'
+	) {
+		const port = Number(process.env.VISION_CONTROL_PORT) || 7847;
+		const method = req.method === 'POST' ? 'POST' : 'GET';
+		const isFrame = url.pathname === '/vision/frame';
+		const chunks: Buffer[] = [];
+		req.on('data', (c: Buffer) => chunks.push(c));
+		req.on('end', async () => {
+			try {
+				const incomingType = (req.headers['content-type'] as string | undefined) || (isFrame ? 'image/jpeg' : 'application/json');
+				const r = await fetch(`http://127.0.0.1:${port}${url.pathname}`, {
+					method,
+					headers: method === 'POST' ? { 'Content-Type': incomingType } : undefined,
+					body: method === 'POST' ? (chunks.length ? Buffer.concat(chunks) : (isFrame ? Buffer.alloc(0) : '{}')) : undefined,
+				});
+				const text = await r.text();
+				res.writeHead(r.status, { 'Content-Type': 'application/json' });
+				res.end(text);
+			} catch (err) {
+				const fallback = url.pathname === '/vision/state'
+					? { streaming: false, source: null, fps: 0, frames: 0, durationMs: 0, sessionReady: false }
+					: { status: 'failed', error: 'voice-agent not reachable' };
+				res.writeHead(url.pathname === '/vision/state' ? 200 : 503, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify(fallback));
+			}
+		});
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- Adds a clean tool surface (\`start_vision\` / \`stop_vision\` / \`send_vision_frame\`) for streaming visual context into Gemini Live.
- Web UI: 👁️ Watch button → native browser screen picker (\`getDisplayMedia\`) → on-screen preview of exactly what Sutando sees → JPEG frames POSTed to a local /vision/frame endpoint.
- Bridges: image attachments arriving via Discord/Telegram during an active voice session also flow into the vision stream (one-shot push via \`vision_push.py\`).
- Phone calls: vision routes to the phone's VoiceSession for the call's duration, then restores on hang-up.
- Default OFF. No ambient watching unless the user clicks Watch or voice explicitly starts it.

## Architecture
Two modes share one controller:
- **pull**: server ticks at fps, calls a registered \`VisionSource.capture()\` (built-ins: \`screen\` via screen-capture-server, \`webcam\` via imagesnap). Pluggable through \`registerSource\`.
- **push**: external caller POSTs JPEG frames to \`/vision/frame\`. Used by the web Watch button and the photo bridges.

HTTP control surface on \`127.0.0.1:7847\` (proxied same-origin through web-client):
- \`GET  /vision/state\`
- \`POST /vision/start  {source, mode?: 'push'|'pull', fps?}\`
- \`POST /vision/stop\`
- \`POST /vision/frame\` (binary JPEG/PNG)

## Files
- \`src/vision-tools.ts\` (new) — pipeline + tools + HTTP control server
- \`src/vision_push.py\` (new) — Python helper for bridges
- \`src/web-client.ts\` — Watch button, preview UI, capture loop, /vision/* proxy
- \`src/screen-capture-server.py\` — \`silent=true\` + \`format=jpeg\` for streaming
- \`src/inline-tools.ts\` — register vision tools (inline + owner-only)
- \`src/voice-agent.ts\` — \`setVisionSession(session)\` + \`startVisionControlServer()\`
- \`src/{discord,telegram}-bridge.py\` — image attachments push to vision when voice is up
- \`skills/phone-conversation/scripts/conversation-server.ts\` — phone session takes over vision during a call

## Roadmap alignment (\`vision and roadmap.md\`)
Lands the §5 \"Now: continuous vision\" milestone. Items deferred and tagged with TODOs in code:
- §5 Now: \`DeviceSession\` to replace the single \`sessionRef\` (phone/web race is currently handled by a swap-and-restore).
- §5 Now: cost-posture doc + quota-aware throttle.
- §4 bet: route through OC's multi-device protocol rather than direct bridges.
- §4 bet: 3-tier access control on future glasses bridges.
- §5 Next: device-aware HUD routing, \`omnia-agent.yaml\` manifests.

## Test plan
- [ ] Start voice (\`bash src/startup.sh\`), click 👁️ Watch — native Chrome Tab / Window / Entire Screen picker appears.
- [ ] After picking, on-screen preview shows the same view Sutando sees; \"X frames\" counter increments.
- [ ] Voice-agent console logs \`[Vision] started browser (push mode)\` and \`[Vision] sent frame #1 …\`.
- [ ] Ask \"what's on my screen\" — Gemini reacts to current screen contents.
- [ ] Stop via the Watch button OR Chrome's native \"Stop sharing\" toolbar — preview hides, tracker stops.
- [ ] Send a photo from Telegram or Discord while voice is connected — voice references the photo in its next turn.
- [ ] Voice tool \`send_vision_frame\` (one-shot) still works for non-browser contexts (screencapture path).
- [ ] Phone call with \`/vision/frame\` push active — frames go to the phone's session during the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)