### PR TITLE
fix(watch-tasks): honor SUTANDO_WORKSPACE for default TASKS_DIR

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -20,7 +20,20 @@
 
 set -u
 
-TASKS_DIR="${1:-$(dirname "$0")/../tasks}"
+# Resolve TASKS_DIR. Priority: explicit positional arg → $SUTANDO_WORKSPACE/tasks
+# → repo-relative fallback. The SUTANDO_WORKSPACE branch matches what every
+# bridge does (discord-bridge.py, telegram-bridge.py, dm-result.py — see
+# PRs #708/#720/#722/#723) — without it, the bridges write tasks to the
+# workspace but the watcher polls the repo's tasks/, so owner DMs land but
+# the agent never sees them. Diagnosed 2026-05-15 (~3 dropped DMs over
+# 17 min before the workaround restart).
+if [ -n "${1:-}" ]; then
+  TASKS_DIR="$1"
+elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+  TASKS_DIR="$SUTANDO_WORKSPACE/tasks"
+else
+  TASKS_DIR="$(dirname "$0")/../tasks"
+fi
 mkdir -p "$TASKS_DIR"
 # Canonicalize watched dir for the parent-dir filter below. fswatch always
 # emits PHYSICAL paths (e.g. /private/tmp/... not /tmp/...), so we resolve


### PR DESCRIPTION
## Summary
Aligns `src/watch-tasks-stream.sh` with the rest of the bridges (discord, telegram, dm-result), which all honor `\$SUTANDO_WORKSPACE` per PRs #708/#720/#722/#723. Without this, when Sutando.app sets `SUTANDO_WORKSPACE` (which it always does), the bridges write tasks to the workspace but the watcher polls the repo — owner DMs land but the agent never sees them.

## Diagnosed live
2026-05-15 — three Discord DMs were stranded in \`\$SUTANDO_WORKSPACE/tasks/\` for ~17 min before the manual workaround (restart the Monitor with an explicit positional arg). Detailed in build_log.

## Resolution priority
1. explicit positional arg → back-compat for callers that pass an explicit dir
2. \`\$SUTANDO_WORKSPACE/tasks\` → matches the bridges
3. repo-relative fallback → matches old default for non-workspace setups

## Test plan
- [ ] \`bash src/watch-tasks-stream.sh\` (no env, no arg) → watches repo's \`tasks/\` (unchanged behavior).
- [ ] \`SUTANDO_WORKSPACE=/tmp/wsp bash src/watch-tasks-stream.sh\` → watches \`/tmp/wsp/tasks\` (new behavior).
- [ ] \`bash src/watch-tasks-stream.sh /custom/dir\` → watches \`/custom/dir\` (explicit-arg back-compat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)