### PR TITLE
feat(device-session): minimum-viable scaffold for §5 Now item 3

### DIFF
--- a/src/device-session.ts
+++ b/src/device-session.ts
@@ -1,0 +1,196 @@
+/**
+ * Sutando — DeviceSession
+ *
+ * Single source of truth for "which device is connected and what can it do?"
+ * Replaces the four module-level globals in `vision-tools.ts` (sessionRef,
+ * ticker, activeSource, pushMode) which today encode "the one device sending
+ * us frames" and force every push-mode sender — browser tab, Mentra glasses,
+ * Discord/Telegram photo helper, phone agent — to race for one slot.
+ *
+ * Roadmap anchor:
+ * - §5 Now item 3 ("Define DeviceSession in src/voice-agent.ts"), explicit
+ *   TODO at `vision-tools.ts:144-150`.
+ * - §5 Now item 2 (Mentra wire-up): `mentra-bridge.ts` registers via the
+ *   `/vision/register` endpoint added in this PR.
+ * - §5 Next ("Device-aware output routing"): output channels declared per
+ *   session; `routeReply` (separate PR) consumes them.
+ * - §7 device fleet matrix: each row corresponds to a `DeviceProfile` shape.
+ *
+ * Design doc: `notes/devicesession-design-2026-05-16.md`.
+ *
+ * Scope of this file:
+ * - Defines the data types (`DeviceProfile`, `OutputChannel`, `DeviceSession`).
+ * - In-process registry keyed by `deviceId`.
+ * - `activeForVision()` resolver — the one device that owns the vision slot
+ *   right now. Last-activated wins.
+ *
+ * Out of scope (follow-up PRs):
+ * - Output routing (`routeReply`) — declared shape only; no caller wired yet.
+ * - OC `device_register` envelope consumption — Mentra bridge calls the
+ *   in-repo HTTP register endpoint instead, mirrors the same payload.
+ * - Multi-tenant — `deviceId` is process-local; tenant boundary wraps later.
+ */
+
+// --- Types --------------------------------------------------------------
+
+/** A voice-agent transport that can ferry frames + hidden context turns
+ *  into the upstream realtime model. Subset of bodhi's VoiceSession
+ *  transport; redeclared here to avoid a circular import with vision-tools. */
+export interface VoiceTransport {
+	sendFile?: (base64: string, mimeType: string) => void;
+	sendContent?: (
+		turns: Array<{ role: 'user' | 'assistant'; text: string }>,
+		turnComplete?: boolean,
+	) => void;
+	isConnected?: boolean;
+}
+
+/** Declared capabilities of the device, sourced from OpenCompanion's
+ *  `device-profiles/<category>/<id>.yaml`. Mic/camera/HUD presence dictates
+ *  what tools are valid for this session. Mirrors the fields of OC's yaml
+ *  with the bits we actually consume today. */
+export interface DeviceProfile {
+	id: string;
+	name: string;
+	category: 'glasses' | 'audio_wearable' | 'recorder' | 'phone' | 'laptop' | 'other';
+	mic: boolean;
+	camera: { enabled: boolean; mode?: 'stream' | 'capture'; resolution?: string };
+	hud: { enabled: boolean; resolution?: string; color?: string; position?: string };
+	gestures?: string[];
+	/** Free-text from §7 — what Sutando does with this device. */
+	role?: string;
+}
+
+/** Per-output declarations. A session can carry any subset of these; the
+ *  output router (separate PR) picks the right one per reply shape. */
+export type OutputChannel =
+	| { kind: 'voice'; transport: VoiceTransport }
+	| { kind: 'hud'; render: (text: string, zone?: HudZone) => Promise<void> }
+	| { kind: 'file_push'; push: (path: string) => Promise<void> }
+	| { kind: 'task'; writeTask: (text: string) => string };
+
+export type HudZone = 'center' | 'top' | 'bottom' | 'left' | 'right';
+
+/** One connected device. Owns the slice of state today's vision-tools
+ *  globals encode (push mode, source label, frame counts). */
+export interface DeviceSession {
+	deviceId: string;
+	profile: DeviceProfile;
+	createdAt: number;
+	lastFrameAt: number | null;
+	pushMode: boolean;
+	pushSourceLabel: string | null;
+	frameCount: number;
+	output: OutputChannel[];
+	/** Idempotent teardown. Called by `unregister()`. */
+	close: () => Promise<void>;
+}
+
+// --- Registry -----------------------------------------------------------
+
+const sessions = new Map<string, DeviceSession>();
+let activeForVisionId: string | null = null;
+const listeners = new Set<(event: SessionEvent) => void>();
+
+export type SessionEvent =
+	| { kind: 'registered'; deviceId: string; profile: DeviceProfile }
+	| { kind: 'unregistered'; deviceId: string }
+	| { kind: 'activated'; deviceId: string };
+
+/** Register a new device session. Throws on duplicate `deviceId`; callers
+ *  are responsible for unique IDs (typically `${profile.id}-${sessionId}`). */
+export function register(session: DeviceSession): void {
+	if (sessions.has(session.deviceId)) {
+		throw new Error(`DeviceSession ${session.deviceId} already registered`);
+	}
+	sessions.set(session.deviceId, session);
+	emit({ kind: 'registered', deviceId: session.deviceId, profile: session.profile });
+}
+
+/** Remove a device session. Calls its `close()` first. Safe to call with
+ *  unknown deviceIds (no-op). */
+export function unregister(deviceId: string): void {
+	const s = sessions.get(deviceId);
+	if (!s) return;
+	sessions.delete(deviceId);
+	if (activeForVisionId === deviceId) activeForVisionId = null;
+	void s.close().catch(() => {});
+	emit({ kind: 'unregistered', deviceId });
+}
+
+export function get(deviceId: string): DeviceSession | undefined {
+	return sessions.get(deviceId);
+}
+
+export function list(): DeviceSession[] {
+	return Array.from(sessions.values());
+}
+
+/** Mark a session as the current vision target. Frames POSTed to the
+ *  vision control server route here. Last call wins. */
+export function activate(deviceId: string): void {
+	if (!sessions.has(deviceId)) {
+		throw new Error(`cannot activate unknown device ${deviceId}`);
+	}
+	activeForVisionId = deviceId;
+	emit({ kind: 'activated', deviceId });
+}
+
+/** Which session owns the vision slot? Returns null when no session has
+ *  been activated yet (or after the active one was unregistered). */
+export function activeForVision(): DeviceSession | null {
+	if (!activeForVisionId) return null;
+	return sessions.get(activeForVisionId) ?? null;
+}
+
+/** Subscribe to lifecycle events. Returns an unsubscribe handle.
+ *  Useful for the vision control server to react to register/activate
+ *  without polling. */
+export function onEvent(fn: (event: SessionEvent) => void): () => void {
+	listeners.add(fn);
+	return () => listeners.delete(fn);
+}
+
+function emit(event: SessionEvent): void {
+	for (const fn of listeners) {
+		try { fn(event); }
+		catch (err) { console.error('[DeviceSession] listener threw:', err); }
+	}
+}
+
+// --- Convenience constructors ------------------------------------------
+
+/** Build a DeviceSession for the local laptop — voice-agent boots this
+ *  by default so today's call sites (which assume "there is one device")
+ *  still see a session to route through. */
+export function newLaptopSession(transport: VoiceTransport, deviceId = 'laptop'): DeviceSession {
+	const profile: DeviceProfile = {
+		id: 'laptop',
+		name: 'Mac (laptop / Studio)',
+		category: 'laptop',
+		mic: true,
+		camera: { enabled: true, mode: 'capture', resolution: 'screen' },
+		hud: { enabled: true, resolution: 'full', position: 'center' },
+		role: 'Full engine, full output. The cockpit.',
+	};
+	return {
+		deviceId,
+		profile,
+		createdAt: Date.now(),
+		lastFrameAt: null,
+		pushMode: false,
+		pushSourceLabel: null,
+		frameCount: 0,
+		output: [{ kind: 'voice', transport }],
+		close: async () => {},
+	};
+}
+
+// --- Test hooks (intentionally not exported via package) ---------------
+
+/** @internal — test-only reset. Do not call from production paths. */
+export function __resetForTests(): void {
+	sessions.clear();
+	activeForVisionId = null;
+	listeners.clear();
+}

--- a/src/device-session.ts
+++ b/src/device-session.ts
@@ -71,6 +71,17 @@ export type OutputChannel =
 
 export type HudZone = 'center' | 'top' | 'bottom' | 'left' | 'right';
 
+/** Per-device access policy declared by `src/device-access-policy.ts`.
+ *  Defined here so DeviceSession can carry the field without a circular
+ *  import from device-access-policy.ts (which uses DeviceProfile). */
+export interface DeviceAccessPolicyRef {
+	/** Capabilities this device is granted. Set of capability strings —
+	 *  see `device-access-policy.ts` for the canonical Capability union. */
+	allowed: Set<string>;
+	label?: string;
+	owner_approved: boolean;
+}
+
 /** One connected device. Owns the slice of state today's vision-tools
  *  globals encode (push mode, source label, frame counts). */
 export interface DeviceSession {
@@ -82,6 +93,9 @@ export interface DeviceSession {
 	pushSourceLabel: string | null;
 	frameCount: number;
 	output: OutputChannel[];
+	/** Optional — populated by `attachPolicy()` from device-access-policy.ts.
+	 *  When absent, `checkPolicy()` denies everything (safe default). */
+	policy?: DeviceAccessPolicyRef;
 	/** Idempotent teardown. Called by `unregister()`. */
 	close: () => Promise<void>;
 }

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -174,22 +174,42 @@ export function _getVisionOnContributorCount(): number {
 	return visionOnContributors.length;
 }
 
-// TODO(roadmap §5 Now: "Define DeviceSession"): Replace this single-session
-// global with a DeviceSession map keyed by device ID. Today push-mode senders
-// (browser, Mentra glasses, Discord/Telegram photo helper, phone agent) all
-// race for one slot — last-set wins, and the phone-agent fix in
-// skills/phone-conversation/scripts/conversation-server.ts uses a fragile
-// swap-and-restore. Once DeviceSession exists, frames should carry a target
-// device ID and fan out only to that session.
+// DeviceSession registry (PR scaffold for roadmap §5 Now item 3, design at
+// `notes/devicesession-design-2026-05-16.md`). When a `DeviceSession` is
+// activated via `/vision/register`+`activate()`, frames route to that
+// session's voice transport. Otherwise the legacy `sessionRef` (set by
+// `setVisionSession`) is used — preserves today's browser/web-client path
+// unchanged while opening a clean seam for Mentra glasses, phone agent,
+// and future devices to register their own sessions.
+//
+// This replaces the prior TODO at this site: push-mode senders (browser,
+// Mentra glasses, Discord/Telegram photo helper, phone agent) used to race
+// for one slot (last-set wins, with the phone-agent fix in
+// skills/phone-conversation/scripts/conversation-server.ts relying on a
+// fragile swap-and-restore). The registry below is the durable fix.
+import * as deviceSession from './device-session.js';
+export { deviceSession };
+
 export function setVisionSession(session: unknown): void {
 	sessionRef = session as MinimalSession | null;
 	if (!session) stopStream();
 }
 
 function getSendFile(): ((b64: string, mime: string) => void) | null {
+	// Prefer the active DeviceSession when one is registered — that's the
+	// per-device routing the §5 Now item asks for. Falls back to the legacy
+	// `sessionRef` (today's laptop/browser path) when no DeviceSession is
+	// active. This dual-path will collapse to DeviceSession-only once
+	// voice-agent registers its own laptop session unconditionally (separate
+	// follow-up).
+	const active = deviceSession.activeForVision();
+	const voice = active?.output.find((o) => o.kind === 'voice');
+	if (voice && voice.kind === 'voice') {
+		const t = voice.transport;
+		if (t.sendFile && t.isConnected !== false) return t.sendFile.bind(t);
+	}
 	const t = sessionRef?.transport;
 	if (!t || !t.sendFile) return null;
-	// isConnected is optional — if exposed and false, skip; otherwise trust the call.
 	if (t.isConnected === false) return null;
 	return t.sendFile.bind(t);
 }
@@ -576,6 +596,82 @@ export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): S
 			});
 			req.on('error', () => respond(500, { status: 'failed', error: 'request error' }));
 			return;
+		}
+		// DeviceSession registry endpoints (PR scaffold for roadmap §5 Now
+		// item 3). Bridges like Mentra POST to /vision/register on session
+		// connect; the registered session becomes the vision target so
+		// frames from that device land in the local voice transport. See
+		// `notes/devicesession-design-2026-05-16.md`.
+		if (url.pathname === '/vision/register' && req.method === 'POST') {
+			const body = await readJsonBody(req);
+			const deviceId = typeof body.deviceId === 'string' ? body.deviceId : undefined;
+			const profileId = typeof body.profileId === 'string' ? body.profileId : undefined;
+			const pushSourceLabel = typeof body.pushSourceLabel === 'string' ? body.pushSourceLabel : null;
+			if (!deviceId || !profileId) {
+				return respond(400, { status: 'failed', error: 'deviceId and profileId required' });
+			}
+			// Minimum-viable profile inference — full OC YAML loader is its own
+			// follow-up. For now we accept any profileId and synthesize a
+			// best-guess shape so the registry has a complete object. Bridges
+			// can override fields via the body if needed.
+			const camera = (body.camera as deviceSession.DeviceProfile['camera']) ?? { enabled: true };
+			const hud = (body.hud as deviceSession.DeviceProfile['hud']) ?? { enabled: false };
+			const profile: deviceSession.DeviceProfile = {
+				id: profileId,
+				name: typeof body.name === 'string' ? body.name : profileId,
+				category: (body.category as deviceSession.DeviceProfile['category']) ?? 'other',
+				mic: body.mic !== false,
+				camera,
+				hud,
+				gestures: Array.isArray(body.gestures) ? (body.gestures as string[]) : undefined,
+				role: typeof body.role === 'string' ? body.role : undefined,
+			};
+			// Reuse the voice-agent's transport — same one today's `sessionRef`
+			// points at — so registered devices get framed into the same Gemini
+			// Live session. Per-device transports are a §5 Next concern.
+			const transport = sessionRef?.transport ?? {};
+			const session: deviceSession.DeviceSession = {
+				deviceId,
+				profile,
+				createdAt: Date.now(),
+				lastFrameAt: null,
+				pushMode: false,
+				pushSourceLabel,
+				frameCount: 0,
+				output: [{ kind: 'voice', transport }],
+				close: async () => {},
+			};
+			try {
+				deviceSession.register(session);
+				deviceSession.activate(deviceId);
+				console.log(`${ts()} [Vision] device registered + activated: ${deviceId} (profile=${profileId})`);
+				return respond(200, { status: 'registered', deviceId });
+			} catch (err) {
+				return respond(409, { status: 'failed', error: (err as Error).message });
+			}
+		}
+		if (url.pathname === '/vision/unregister' && req.method === 'POST') {
+			const body = await readJsonBody(req);
+			const deviceId = typeof body.deviceId === 'string' ? body.deviceId : undefined;
+			if (!deviceId) {
+				return respond(400, { status: 'failed', error: 'deviceId required' });
+			}
+			deviceSession.unregister(deviceId);
+			console.log(`${ts()} [Vision] device unregistered: ${deviceId}`);
+			return respond(200, { status: 'unregistered', deviceId });
+		}
+		if (url.pathname === '/vision/devices' && req.method === 'GET') {
+			return respond(200, {
+				active: deviceSession.activeForVision()?.deviceId ?? null,
+				devices: deviceSession.list().map((s) => ({
+					deviceId: s.deviceId,
+					profile: s.profile,
+					createdAt: s.createdAt,
+					pushMode: s.pushMode,
+					pushSourceLabel: s.pushSourceLabel,
+					frameCount: s.frameCount,
+				})),
+			});
 		}
 		respond(404, { error: 'not found' });
 	});

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -614,12 +614,21 @@ export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): S
 			// follow-up. For now we accept any profileId and synthesize a
 			// best-guess shape so the registry has a complete object. Bridges
 			// can override fields via the body if needed.
+			// Validate category against the known union so a lying caller
+			// (or a typo) can't pollute the registry with `category:'spaceship'`
+			// — downstream consumers do `switch(profile.category)` and would
+			// silently fall through.
+			const VALID_CATEGORIES = new Set(['glasses', 'audio_wearable', 'recorder', 'phone', 'laptop', 'other']);
+			const rawCategory = typeof body.category === 'string' ? body.category : 'other';
+			if (!VALID_CATEGORIES.has(rawCategory)) {
+				return respond(400, { status: 'failed', error: `invalid category "${rawCategory}"; must be one of ${[...VALID_CATEGORIES].join(',')}` });
+			}
 			const camera = (body.camera as deviceSession.DeviceProfile['camera']) ?? { enabled: true };
 			const hud = (body.hud as deviceSession.DeviceProfile['hud']) ?? { enabled: false };
 			const profile: deviceSession.DeviceProfile = {
 				id: profileId,
 				name: typeof body.name === 'string' ? body.name : profileId,
-				category: (body.category as deviceSession.DeviceProfile['category']) ?? 'other',
+				category: rawCategory as deviceSession.DeviceProfile['category'],
 				mic: body.mic !== false,
 				camera,
 				hud,
@@ -661,16 +670,27 @@ export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): S
 			return respond(200, { status: 'unregistered', deviceId });
 		}
 		if (url.pathname === '/vision/devices' && req.method === 'GET') {
+			// `transportReady` lets a bridge polling /vision/devices distinguish
+			// "registered AND deliverable" from "registered but the underlying
+			// transport isn't connected yet" (e.g. /vision/register raced ahead
+			// of setVisionSession() on cold start). Tracks the same predicate
+			// getSendFile() uses: voice transport present + isConnected !== false.
 			return respond(200, {
 				active: deviceSession.activeForVision()?.deviceId ?? null,
-				devices: deviceSession.list().map((s) => ({
-					deviceId: s.deviceId,
-					profile: s.profile,
-					createdAt: s.createdAt,
-					pushMode: s.pushMode,
-					pushSourceLabel: s.pushSourceLabel,
-					frameCount: s.frameCount,
-				})),
+				devices: deviceSession.list().map((s) => {
+					const voice = s.output.find((o) => o.kind === 'voice');
+					const t = voice && voice.kind === 'voice' ? voice.transport : null;
+					const transportReady = !!(t && t.sendFile && t.isConnected !== false);
+					return {
+						deviceId: s.deviceId,
+						profile: s.profile,
+						createdAt: s.createdAt,
+						pushMode: s.pushMode,
+						pushSourceLabel: s.pushSourceLabel,
+						frameCount: s.frameCount,
+						transportReady,
+					};
+				}),
 			});
 		}
 		respond(404, { error: 'not found' });

--- a/tests/device-session.test.ts
+++ b/tests/device-session.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	register,
+	unregister,
+	get,
+	list,
+	activate,
+	activeForVision,
+	onEvent,
+	newLaptopSession,
+	__resetForTests,
+	type DeviceSession,
+	type DeviceProfile,
+	type SessionEvent,
+} from '../src/device-session.ts';
+
+// Unit tests for the DeviceSession registry. Covers the contract the
+// `/vision/register` endpoint and downstream callers (mentra-bridge,
+// phone-conversation, voice-agent) depend on.
+
+function makeSession(deviceId: string, profileId = 'test-device'): DeviceSession {
+	const profile: DeviceProfile = {
+		id: profileId,
+		name: 'Test',
+		category: 'other',
+		mic: true,
+		camera: { enabled: true },
+		hud: { enabled: false },
+	};
+	return {
+		deviceId,
+		profile,
+		createdAt: Date.now(),
+		lastFrameAt: null,
+		pushMode: false,
+		pushSourceLabel: null,
+		frameCount: 0,
+		output: [{ kind: 'voice', transport: {} }],
+		close: async () => {},
+	};
+}
+
+describe('DeviceSession registry', () => {
+	beforeEach(() => __resetForTests());
+
+	it('register stores and get retrieves', () => {
+		const s = makeSession('alpha');
+		register(s);
+		assert.equal(get('alpha')?.deviceId, 'alpha');
+		assert.equal(list().length, 1);
+	});
+
+	it('register throws on duplicate deviceId', () => {
+		register(makeSession('alpha'));
+		assert.throws(() => register(makeSession('alpha')), /already registered/);
+	});
+
+	it('unregister removes and is idempotent on unknown id', () => {
+		register(makeSession('alpha'));
+		unregister('alpha');
+		assert.equal(get('alpha'), undefined);
+		assert.equal(list().length, 0);
+		// Idempotent — unknown ID is a no-op.
+		unregister('alpha');
+		unregister('never-existed');
+		assert.equal(list().length, 0);
+	});
+
+	it('unregister calls close() on the session', async () => {
+		let closed = false;
+		const s = makeSession('alpha');
+		s.close = async () => { closed = true; };
+		register(s);
+		unregister('alpha');
+		// close() is fire-and-forget — give the microtask a tick to run.
+		await new Promise((r) => setImmediate(r));
+		assert.equal(closed, true);
+	});
+
+	it('activate marks the device as the vision target', () => {
+		register(makeSession('alpha'));
+		register(makeSession('beta'));
+		assert.equal(activeForVision(), null);
+		activate('beta');
+		assert.equal(activeForVision()?.deviceId, 'beta');
+		activate('alpha');
+		assert.equal(activeForVision()?.deviceId, 'alpha');
+	});
+
+	it('activate throws on unknown deviceId', () => {
+		assert.throws(() => activate('nope'), /unknown device/);
+	});
+
+	it('unregistering the active device clears activeForVision', () => {
+		register(makeSession('alpha'));
+		activate('alpha');
+		assert.equal(activeForVision()?.deviceId, 'alpha');
+		unregister('alpha');
+		assert.equal(activeForVision(), null);
+	});
+
+	it('emits register/activate/unregister events to subscribers', () => {
+		const events: SessionEvent[] = [];
+		const off = onEvent((e) => events.push(e));
+		register(makeSession('alpha'));
+		activate('alpha');
+		unregister('alpha');
+		off();
+		// Verify another emit after unsubscribe does not reach us.
+		register(makeSession('beta'));
+		assert.deepEqual(
+			events.map((e) => e.kind),
+			['registered', 'activated', 'unregistered'],
+		);
+		assert.equal(events[0].kind, 'registered');
+		if (events[0].kind === 'registered') {
+			assert.equal(events[0].deviceId, 'alpha');
+			assert.equal(events[0].profile.id, 'test-device');
+		}
+	});
+
+	it('listener exceptions do not break emit (other listeners still fire)', () => {
+		const seen: string[] = [];
+		onEvent(() => { throw new Error('boom'); });
+		onEvent((e) => seen.push(e.kind));
+		register(makeSession('alpha'));
+		assert.deepEqual(seen, ['registered']);
+	});
+
+	it('newLaptopSession constructs a laptop-profile session with voice output', () => {
+		const transport = { sendFile: () => {}, isConnected: true };
+		const s = newLaptopSession(transport, 'laptop-test');
+		assert.equal(s.deviceId, 'laptop-test');
+		assert.equal(s.profile.category, 'laptop');
+		assert.equal(s.profile.hud.enabled, true);
+		assert.equal(s.profile.camera.enabled, true);
+		const voice = s.output.find((o) => o.kind === 'voice');
+		assert.ok(voice && voice.kind === 'voice');
+		assert.equal(voice.transport, transport);
+	});
+});


### PR DESCRIPTION
## Summary
Ships the **DeviceSession** primitive the roadmap (§5 Now item 3) calls for and that `vision-tools.ts:144-150` explicitly TODOs. Today's single-session globals force browser / Mentra / Discord-photo / phone agent to race for one vision slot; this PR adds the per-device state slot they should each register against.

Design doc: `notes/devicesession-design-2026-05-16.md` (in this PR's branch via the follow-up commit, or read [here](https://github.com/sonichi/sutando/blob/feat/device-session-scaffold/notes/devicesession-design-2026-05-16.md)).

## What ships

- **`src/device-session.ts`** (~170 LOC, new):
  - `DeviceProfile` mirrors OpenCompanion's `device-profiles/*.yaml` shape.
  - `OutputChannel` union (voice / hud / file_push / task) — declarations the §5 Next output router will consume.
  - `DeviceSession` instance — owns the per-device state the globals encoded.
  - Registry: `register / unregister / get / list / activate / activeForVision`, plus `onEvent` for subscribers.
  - `newLaptopSession()` constructor.
- **`src/vision-tools.ts`** (+98/-8):
  - `getSendFile()` prefers the active DeviceSession's voice transport, falls back to legacy `sessionRef` (today's browser path) — zero behavior change for the current Watch button.
  - Three new endpoints on the vision control server (`:7847`): `POST /vision/register`, `POST /vision/unregister`, `GET /vision/devices`.
- **`tests/device-session.test.ts`** — 10 unit tests, all pass.

## What this PR does NOT change

- The browser/Watch path: `setVisionSession()` + `submitFrame()` behave identically. `getSendFile()`'s new branch falls back to the legacy global when no DeviceSession is active.
- Output routing: `OutputChannel[]` is declared but no caller consumes it yet. `routeReply()` is the next PR.
- OC's `device_register` envelope: bridges call the in-repo HTTP endpoint mirroring the same payload. The OC-protocol branch lands when OC's protocol package is consumed.
- Phone-agent's swap-and-restore + the Mentra-bridge `/vision/register` call site: separate follow-ups. This PR provides the seam.

## Test plan

- [x] `npx tsx --test tests/device-session.test.ts` — 10/10 pass.
- [x] `npx tsc --noEmit` clean.
- [ ] Manual: fresh voice-agent boot → `curl :7847/vision/devices` returns `{active: null, devices: []}`.
- [ ] Manual: `curl -X POST :7847/vision/register -d '{"deviceId":"test","profileId":"glasses-test"}'` returns `{status:"registered",deviceId:"test"}` and `/vision/devices` shows it active.
- [ ] Manual: browser Watch button still works (regression check for the fallback path).

## Roadmap impact

- **§5 Now item 3 (DeviceSession):** primitive landed.
- **§5 Now item 2 (Mentra):** unblocks `src/mentra-bridge.ts` — the three TODOs in that file (DeviceSession, output routing, manifests) now have an anchor.
- **§5 Next ("Device-aware output routing"):** `OutputChannel[]` declared, ready for the router PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)