### PR TITLE
feat(skills): omnia-agent.yaml manifests — batch 2 (8 skills)

### DIFF
--- a/skills/deal-finder/omnia-agent.yaml
+++ b/skills/deal-finder/omnia-agent.yaml
@@ -1,0 +1,24 @@
+name: deal-finder
+description: Scan configured used-item listing sources (Craigslist, eBay, Facebook Marketplace) for matches against the owner's saved criteria. SMS + Telegram on hit.
+version: 0.1.0
+category: shopping
+
+agent:
+  tools: [deal_scan, deal_subscribe]
+
+capabilities:
+  intents:
+    - name: find
+      triggers: [find a deal, scan listings, check craigslist, look for, search for used]
+      description: One-shot scan against the configured criteria.
+    - name: subscribe
+      triggers: [watch for, notify me when, alert me on]
+      description: Add or update a saved search.
+
+io:
+  inputs: [voice, text, scheduled]
+  outputs: [voice, sms, telegram_dm]
+
+policy:
+  access_tier: owner
+  scheduled: hourly

--- a/skills/gemini-tts/omnia-agent.yaml
+++ b/skills/gemini-tts/omnia-agent.yaml
@@ -1,0 +1,20 @@
+name: gemini-tts
+description: Render text to mp3 via Google Gemini Flash TTS. Free-tier eligible (1500 req/day). Default TTS for make-viral-video.
+version: 0.1.0
+category: media
+
+agent:
+  tools: [gemini_tts_render]
+
+capabilities:
+  intents:
+    - name: synthesize
+      triggers: [synthesize voice, narrate, render audio, text to speech with gemini]
+      description: Generate mp3 from text using Gemini Flash TTS.
+
+io:
+  inputs: [text]
+  outputs: [media_file]
+
+policy:
+  access_tier: owner

--- a/skills/info-radar/omnia-agent.yaml
+++ b/skills/info-radar/omnia-agent.yaml
@@ -1,0 +1,24 @@
+name: info-radar
+description: Monitor arXiv, GitHub, Hacker News, and tech news for topics the owner cares about. Surface discoveries via morning briefing or voice.
+version: 0.1.0
+category: research
+
+agent:
+  tools: [radar_scan, radar_digest]
+
+capabilities:
+  intents:
+    - name: scan
+      triggers: [radar scan, info radar, scan sources, check arxiv, check hacker news, what's new in]
+      description: Run a discovery scan across configured sources for topics in the owner's interest list.
+    - name: digest
+      triggers: [radar digest, what's the latest, recent discoveries]
+      description: Surface the most recent digest of discoveries.
+
+io:
+  inputs: [voice, text, scheduled]
+  outputs: [voice, digest_file]
+
+policy:
+  access_tier: owner
+  scheduled: daily_with_morning_briefing

--- a/skills/macos-tools/omnia-agent.yaml
+++ b/skills/macos-tools/omnia-agent.yaml
@@ -1,0 +1,37 @@
+name: macos-tools
+description: macOS native integrations — screen capture, calendar, reminders, contacts, Mail.app, Spotlight. Use when the user asks about screen, schedule, to-do, contacts, or wants to send email on macOS.
+version: 0.1.0
+category: platform
+
+agent:
+  tools: [screen_capture, calendar_query, reminders_query, reminders_add, contacts_search, mail_send, spotlight_search]
+
+capabilities:
+  intents:
+    - name: screen_capture
+      triggers: [what's on my screen, capture screen, take screenshot, see my screen]
+      description: Grab a screenshot via the screen-capture-server.
+    - name: calendar
+      triggers: [what's my schedule, today's calendar, next meeting, do I have anything]
+      description: Query macOS Calendar via gws.
+    - name: reminders
+      triggers: [my todo list, what's on my reminders, add a reminder, remind me to]
+      description: Read/write macOS Reminders.
+    - name: contacts
+      triggers: [look up contact, find email for, phone number for]
+      description: Resolve a name to email/phone via macOS Contacts.
+    - name: mail_send
+      triggers: [send email via mail, send from mac mail]
+      description: Send email via Mail.app (no OAuth required). Confirmation required.
+    - name: spotlight
+      triggers: [find file, search for file, where is the file]
+      description: macOS Spotlight file search.
+
+io:
+  inputs: [voice, text]
+  outputs: [voice, file_path, attachments]
+
+policy:
+  access_tier: owner
+  platform: darwin
+  confirmation_required_for: [mail_send, reminders_add]

--- a/skills/openai-tts/omnia-agent.yaml
+++ b/skills/openai-tts/omnia-agent.yaml
@@ -1,0 +1,20 @@
+name: openai-tts
+description: Render text to mp3 via OpenAI tts-1-hd. Use for video narration, demo voiceovers, audio notes.
+version: 0.1.0
+category: media
+
+agent:
+  tools: [openai_tts_render]
+
+capabilities:
+  intents:
+    - name: synthesize
+      triggers: [synthesize voice, narrate, render audio, text to speech with openai]
+      description: Generate mp3 from text using OpenAI's tts-1-hd.
+
+io:
+  inputs: [text]
+  outputs: [media_file]
+
+policy:
+  access_tier: owner

--- a/skills/regression-search/omnia-agent.yaml
+++ b/skills/regression-search/omnia-agent.yaml
@@ -1,0 +1,23 @@
+name: regression-search
+description: Search phone-call history for when a feature regressed; drill into individual calls to see what went wrong. Skips manual transcript review.
+version: 0.1.0
+category: diagnostics
+
+agent:
+  tools: [find_regression, diagnose_call]
+
+capabilities:
+  intents:
+    - name: find_regression
+      triggers: [when did this break, when did the bug start, find regression, last working call]
+      description: Locate the call window where a feature transitioned from working to broken.
+    - name: diagnose_call
+      triggers: [what went wrong in, diagnose call, why did this fail]
+      description: Deep-dive into a single call's transcript + tool calls + error path.
+
+io:
+  inputs: [voice, text]
+  outputs: [voice, summary_file]
+
+policy:
+  access_tier: owner

--- a/skills/self-diagnose/omnia-agent.yaml
+++ b/skills/self-diagnose/omnia-agent.yaml
@@ -1,0 +1,20 @@
+name: self-diagnose
+description: Sutando introspection — read logs + git + memory + build log over a chosen time window. Produces a concise narrative of what the agent has been doing, what's broken, and what to prioritize next.
+version: 0.1.0
+category: diagnostics
+
+agent:
+  tools: [self_diagnose_gather, self_diagnose_narrate]
+
+capabilities:
+  intents:
+    - name: introspect
+      triggers: [self diagnose, what have you been doing, what's broken, status report, gather logs]
+      description: Read logs/git/memory and narrate the agent's recent activity, regressions, and priorities.
+
+io:
+  inputs: [voice, text]
+  outputs: [voice, report_file]
+
+policy:
+  access_tier: owner

--- a/skills/x-twitter/omnia-agent.yaml
+++ b/skills/x-twitter/omnia-agent.yaml
@@ -1,0 +1,33 @@
+name: x-twitter
+description: Post, search, read, and monitor on X (Twitter) via API v2. Owner confirmation required before posting.
+version: 0.1.0
+category: communications
+
+agent:
+  tools: [x_post, x_search, x_read, x_mentions, x_timeline, x_engagement]
+
+capabilities:
+  intents:
+    - name: post
+      triggers: [post a tweet, tweet, post to x, post to twitter]
+      description: Compose and post a tweet. Owner confirmation required.
+    - name: search
+      triggers: [search twitter, find tweets about, search x]
+      description: Recent tweet search.
+    - name: read_thread
+      triggers: [read tweet, open tweet, show tweet]
+      description: Read a tweet and its thread.
+    - name: mentions
+      triggers: [check mentions, who replied, did anyone tag me]
+      description: Recent @mentions.
+    - name: engagement
+      triggers: [engagement on tweet, how did the tweet do, tweet stats]
+      description: Likes / retweets / view counts for a posted tweet.
+
+io:
+  inputs: [voice, text]
+  outputs: [voice, post_id]
+
+policy:
+  access_tier: owner
+  confirmation_required_for: [post]


### PR DESCRIPTION
## Summary
Completes the §5 Next **Skill manifests** item for voice-invocable skills. Batch 1 (#742) covered the first 6; this batch adds the remaining 8.

## What ships
| Skill | Category | Intents |
|---|---|---|
| `info-radar` | research | scan, digest |
| `deal-finder` | shopping | find, subscribe |
| `regression-search` | diagnostics | find_regression, diagnose_call |
| `x-twitter` | communications | post, search, read_thread, mentions, engagement |
| `openai-tts` | media | synthesize |
| `gemini-tts` | media | synthesize |
| `macos-tools` | platform | screen_capture, calendar, reminders, contacts, mail_send, spotlight |
| `self-diagnose` | diagnostics | introspect |

## Validation
- [x] All 8 yamls parse cleanly via `yaml.safe_load`.

## Coverage after this batch
14 voice-invocable skills now have manifests (6 in #742 + 8 here). Internal-infra skills remain unmanifested by design — they aren't OC discovery candidates: `proactive-loop`, `schedule-crons`, `quota-tracker`, `bot2bot-post`, `cross-node-sync`, `claude-codex`, `claude-gemini`, `claude-router`.

## Roadmap impact
- **§5 Next ("Skill manifests"):** effectively complete for voice-invocable surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)