### PR TITLE
feat(vision-tools): wire access policy into /vision/register + /vision/frame

### DIFF
--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -149,6 +149,7 @@ let sessionRef: MinimalSession | null = null;
 // unchanged while opening a clean seam for Mentra glasses, phone agent,
 // and future devices to register their own sessions.
 import * as deviceSession from './device-session.js';
+import { attachPolicy, checkPolicy, logDenial } from './device-access-policy.js';
 export { deviceSession };
 
 export function setVisionSession(session: unknown): void {
@@ -535,6 +536,16 @@ export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): S
 			return respond(200, stopStreaming());
 		}
 		if (url.pathname === '/vision/frame' && req.method === 'POST') {
+			// Policy gate: if a DeviceSession is active, it must hold the
+			// `vision_frame_send` capability. The legacy browser path (no
+			// active DeviceSession, frames go through sessionRef) is
+			// unaffected — backward compatible. Only registered devices
+			// (Mentra, future bridges) hit the gate.
+			const active = deviceSession.activeForVision();
+			if (active && !checkPolicy(active, 'vision_frame_send')) {
+				logDenial(active, 'vision_frame_send', 'POST /vision/frame');
+				return respond(403, { status: 'failed', error: `device ${active.deviceId} lacks vision_frame_send capability` });
+			}
 			const chunks: Buffer[] = [];
 			req.on('data', (c: Buffer) => chunks.push(c));
 			req.on('end', () => {
@@ -601,9 +612,16 @@ export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): S
 			};
 			try {
 				deviceSession.register(session);
+				// Attach a default access policy from the profile's category.
+				// Recorder + 'other'-category devices get default-deny; the owner
+				// can override per-device via state/device-policy.json. Skipping
+				// this would make every newly-registered device implicitly
+				// trusted — exactly the §5 Next "default-deny for new device
+				// types" requirement.
+				const policy = attachPolicy(session);
 				deviceSession.activate(deviceId);
-				console.log(`${ts()} [Vision] device registered + activated: ${deviceId} (profile=${profileId})`);
-				return respond(200, { status: 'registered', deviceId });
+				console.log(`${ts()} [Vision] device registered + activated: ${deviceId} (profile=${profileId}, policy.allowed=${[...policy.allowed].join(',') || '(none)'}, owner_approved=${policy.owner_approved})`);
+				return respond(200, { status: 'registered', deviceId, policy: { allowed: [...policy.allowed], owner_approved: policy.owner_approved } });
 			} catch (err) {
 				return respond(409, { status: 'failed', error: (err as Error).message });
 			}

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -544,7 +544,18 @@ export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): S
 			const active = deviceSession.activeForVision();
 			if (active && !checkPolicy(active, 'vision_frame_send')) {
 				logDenial(active, 'vision_frame_send', 'POST /vision/frame');
-				return respond(403, { status: 'failed', error: `device ${active.deviceId} lacks vision_frame_send capability` });
+				// Surface the current policy so the caller can immediately see
+				// what's granted vs. requested. Most useful for owner-edited
+				// state/device-policy.json typos — without this the bridge
+				// author has to fish for the granted set via /vision/devices.
+				return respond(403, {
+					status: 'failed',
+					error: `device ${active.deviceId} lacks vision_frame_send capability`,
+					current_policy: {
+						allowed: active.policy ? [...active.policy.allowed] : [],
+						owner_approved: active.policy?.owner_approved ?? false,
+					},
+				});
 			}
 			const chunks: Buffer[] = [];
 			req.on('data', (c: Buffer) => chunks.push(c));


### PR DESCRIPTION
## Summary
Consumes #746's access-policy scaffold. Two thin hooks in the vision control server:

1. **`/vision/register`** — `attachPolicy(session)` immediately after `register()`. The defaulted policy comes from the profile's category. Logged in the response so bridges can verify what they were granted.
2. **`/vision/frame`** — checks `vision_frame_send` capability of the currently-active DeviceSession. Denial returns 403 + logs. The **legacy browser path** (no active DeviceSession; frames go through `sessionRef`) is unaffected.

**Base:** `feat/device-access-policy` (#746). Depends on #739 + #746.

## Backward-compatibility ledger
- **Browser/Watch** (today's path): no active DeviceSession → gate skipped → unchanged.
- **Mentra glasses** (PR #740): category=glasses → defaults include `vision_frame_send` → unchanged.
- **Recorders** (Plaud/Omi): `vision_frame_send` not in default → 403 if they ever push (they shouldn't — no cameras). Correct posture.
- **`other`-category devices**: empty default → 403. Owner explicit opt-in via `state/device-policy.json`.

## Test plan
- [x] `tsc --noEmit` clean.
- [ ] Manual: browser `/vision/frame` still works (regression check).
- [ ] Manual: Mentra register → frames flow.
- [ ] Manual: register `other`-category device → `/vision/frame` 403 + `[DeviceAccessPolicy] DENY ...` log.
- [ ] Manual: add `"mystery-device": ["vision_frame_send"]` to `state/device-policy.json` → frames flow.

## Roadmap impact
- **§5 Next ("Per-device access policy"):** policy is now live for frame ingress on registered devices. Other gates (output-router channels, task_write, audio_listen) are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)