### PR TITLE
feat(cost-accounting): per-tenant + per-device usage ledger (§5 Next)

### DIFF
--- a/src/audit-summary.ts
+++ b/src/audit-summary.ts
@@ -1,0 +1,336 @@
+/**
+ * Sutando — Audit Summary CLI
+ *
+ * Implements §5 Next: "Audit UI built on existing audit.jsonl files. 'What
+ * did the agent do, on which device, with which methodology, why?' A trust
+ * feature for productization, not just a debugging artifact."
+ *
+ * First-cut shape: a CLI that aggregates the existing JSONL audit sources
+ * into a markdown summary. Web UI is a future iteration; CLI lands first
+ * because (a) it's the canonical interface for owner introspection,
+ * (b) every other diagnostic in the repo (self-diagnose, regression-search)
+ * is a CLI too, and (c) the output composes — `audit-summary | gh issue
+ * create --body-file -` is one line of plumbing.
+ *
+ * Sources consumed (any subset; missing files are skipped):
+ *   - data/voice-metrics.jsonl       (voice-agent session metrics)
+ *   - data/call-metrics.jsonl        (phone-conversation metrics) — also
+ *     looks under workspace/tasks/data/ and tasks/archive/data/ for moved
+ *     fleet copies.
+ *   - state/cost-accounting/usage-<tenant>.jsonl  (from PR #749)
+ *   - tasks/archive/<YYYY-MM>/                    (task lifecycle counts)
+ *   - results/archive/<YYYY-MM>/                  (result lifecycle counts)
+ *
+ * Output: markdown to stdout. Use `--json` for machine-readable shape.
+ *
+ * Usage:
+ *   tsx src/audit-summary.ts                  # today
+ *   tsx src/audit-summary.ts --since 7d       # last 7 days
+ *   tsx src/audit-summary.ts --since 2026-05-01 --until 2026-05-15
+ *   tsx src/audit-summary.ts --tenant acme    # cost rollup scoped
+ *   tsx src/audit-summary.ts --json           # machine-readable
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { rollup as costRollup, type UsageRollup } from './cost-accounting.js';
+import { tenantId } from './tenant.js';
+
+interface VoiceMetric {
+	timestamp: string;
+	sessionId: string;
+	source: string;
+	durationMs: number;
+	transcriptLines: number;
+	toolCalls: Array<{ name: string; durationMs: number }>;
+	toolCount: number;
+	events: Array<{ event: string; timestamp: string }>;
+}
+
+interface CallMetric {
+	timestamp: string;
+	callSid: string;
+	caller: string;
+	isOwner: boolean;
+	isMeeting: boolean;
+	durationMs: number;
+	transcriptLines: number;
+	toolCalls: Array<{ name: string; durationMs: number }>;
+	toolCount: number;
+	events: Array<{ event: string; timestamp: string }>;
+}
+
+export interface AuditSummary {
+	from: string;
+	to: string;
+	voice: {
+		sessions: number;
+		total_duration_ms: number;
+		total_transcript_lines: number;
+		total_tool_calls: number;
+		tools_by_count: Record<string, number>;
+		errors: string[];
+	};
+	calls: {
+		count: number;
+		total_duration_ms: number;
+		owner_calls: number;
+		meeting_calls: number;
+		tools_by_count: Record<string, number>;
+	};
+	tasks: {
+		archived_count: number;
+		by_source: Record<string, number>;
+	};
+	results: {
+		archived_count: number;
+	};
+	cost: UsageRollup | null;
+}
+
+function workspaceDir(): string {
+	return process.env.SUTANDO_WORKSPACE || process.cwd();
+}
+
+function findFirst(...paths: string[]): string | null {
+	for (const p of paths) if (existsSync(p)) return p;
+	return null;
+}
+
+function readJsonl<T>(path: string | null): T[] {
+	if (!path) return [];
+	try {
+		const raw = readFileSync(path, 'utf-8');
+		return raw.split('\n').filter((l) => l.length > 0).flatMap((l) => {
+			try { return [JSON.parse(l) as T]; }
+			catch { return []; }
+		});
+	} catch { return []; }
+}
+
+function listArchive(dir: string, since: Date, until: Date): { count: number; bySource: Record<string, number> } {
+	const result = { count: 0, bySource: {} as Record<string, number> };
+	if (!existsSync(dir)) return result;
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		try {
+			const st = statSync(full);
+			if (st.isDirectory()) {
+				// recurse — archive layout is <YYYY-MM>/<file>.txt
+				const sub = listArchive(full, since, until);
+				result.count += sub.count;
+				for (const [k, v] of Object.entries(sub.bySource)) {
+					result.bySource[k] = (result.bySource[k] ?? 0) + v;
+				}
+				continue;
+			}
+			if (st.mtime < since || st.mtime > until) continue;
+			result.count++;
+			// Best-effort source classification from filename: task-<source>-<ts>.txt.
+			// task-<source>-<ts>.txt — source is one segment of lowercase letters
+			// between two hyphens. Stop at the first hyphen so we don't accidentally
+			// pick up the trailing timestamp.
+			const m = entry.match(/^(task|result|proactive|question|briefing|insight|friction)(?:-([a-z]+))?-?\d*/i);
+			const source = m ? (m[2] || m[1] || 'unknown').toLowerCase() : 'unknown';
+			result.bySource[source] = (result.bySource[source] ?? 0) + 1;
+		} catch { /* unreadable entry */ }
+	}
+	return result;
+}
+
+function parseDuration(spec: string, now: Date): Date {
+	// Accept "7d", "24h", "30m" or an ISO date.
+	const m = spec.match(/^(\d+)([dhm])$/);
+	if (m) {
+		const n = Number(m[1]);
+		const unit = m[2];
+		const ms = unit === 'd' ? n * 86_400_000 : unit === 'h' ? n * 3_600_000 : n * 60_000;
+		return new Date(now.getTime() - ms);
+	}
+	const d = new Date(spec);
+	if (Number.isNaN(d.getTime())) throw new Error(`unparseable date: ${spec}`);
+	return d;
+}
+
+export function summarize(opts: { since?: Date; until?: Date; tenant?: string; ws?: string } = {}): AuditSummary {
+	const now = new Date();
+	const until = opts.until ?? now;
+	const since = opts.since ?? new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 0, 0, 0));
+	const ws = opts.ws ?? workspaceDir();
+	const fromIso = since.toISOString();
+	const toIso = until.toISOString();
+
+	// --- voice metrics ---
+	const voicePath = findFirst(
+		join(ws, 'data', 'voice-metrics.jsonl'),
+		join(ws, 'workspace', 'data', 'voice-metrics.jsonl'),
+	);
+	const voice = readJsonl<VoiceMetric>(voicePath).filter((m) => m.timestamp >= fromIso && m.timestamp <= toIso);
+	const voiceTools: Record<string, number> = {};
+	const voiceErrors: string[] = [];
+	let voiceDuration = 0;
+	let voiceLines = 0;
+	let voiceToolCount = 0;
+	for (const m of voice) {
+		voiceDuration += m.durationMs;
+		voiceLines += m.transcriptLines;
+		voiceToolCount += m.toolCount;
+		for (const tc of m.toolCalls || []) {
+			voiceTools[tc.name] = (voiceTools[tc.name] ?? 0) + 1;
+		}
+		for (const ev of m.events || []) {
+			if (ev.event.startsWith('error:')) voiceErrors.push(ev.event);
+		}
+	}
+
+	// --- call metrics ---
+	const callPath = findFirst(
+		join(ws, 'data', 'call-metrics.jsonl'),
+		join(ws, 'workspace', 'data', 'call-metrics.jsonl'),
+		join(ws, 'tasks', 'archive', 'data', 'call-metrics.jsonl'),
+	);
+	const calls = readJsonl<CallMetric>(callPath).filter((m) => m.timestamp >= fromIso && m.timestamp <= toIso);
+	const callTools: Record<string, number> = {};
+	let callDuration = 0;
+	let ownerCalls = 0;
+	let meetingCalls = 0;
+	for (const m of calls) {
+		callDuration += m.durationMs;
+		if (m.isOwner) ownerCalls++;
+		if (m.isMeeting) meetingCalls++;
+		for (const tc of m.toolCalls || []) {
+			callTools[tc.name] = (callTools[tc.name] ?? 0) + 1;
+		}
+	}
+
+	// --- task / result archive counts ---
+	const tasksArch = listArchive(join(ws, 'tasks', 'archive'), since, until);
+	const resultsArch = listArchive(join(ws, 'results', 'archive'), since, until);
+
+	// --- cost rollup (per tenant, from #749) ---
+	let cost: UsageRollup | null = null;
+	try {
+		cost = costRollup({ tenant_id: opts.tenant ?? tenantId(ws), from: fromIso, to: toIso });
+		if (cost.event_count === 0) cost = null;
+	} catch { cost = null; }
+
+	return {
+		from: fromIso,
+		to: toIso,
+		voice: {
+			sessions: voice.length,
+			total_duration_ms: voiceDuration,
+			total_transcript_lines: voiceLines,
+			total_tool_calls: voiceToolCount,
+			tools_by_count: voiceTools,
+			errors: voiceErrors.slice(0, 10),  // cap
+		},
+		calls: {
+			count: calls.length,
+			total_duration_ms: callDuration,
+			owner_calls: ownerCalls,
+			meeting_calls: meetingCalls,
+			tools_by_count: callTools,
+		},
+		tasks: {
+			archived_count: tasksArch.count,
+			by_source: tasksArch.bySource,
+		},
+		results: {
+			archived_count: resultsArch.count,
+		},
+		cost,
+	};
+}
+
+export function renderMarkdown(s: AuditSummary): string {
+	const mins = (ms: number) => (ms / 60_000).toFixed(1);
+	const topN = (o: Record<string, number>, n = 5): string =>
+		Object.entries(o).sort((a, b) => b[1] - a[1]).slice(0, n)
+			.map(([k, v]) => `${k} (${v})`).join(', ') || '(none)';
+
+	const lines: string[] = [];
+	lines.push(`# Sutando audit summary — ${s.from} → ${s.to}`);
+	lines.push('');
+	lines.push('## Voice sessions');
+	lines.push(`- Sessions: **${s.voice.sessions}**`);
+	lines.push(`- Total duration: ${mins(s.voice.total_duration_ms)} min`);
+	lines.push(`- Transcript lines: ${s.voice.total_transcript_lines}`);
+	lines.push(`- Tool calls: ${s.voice.total_tool_calls} — top: ${topN(s.voice.tools_by_count)}`);
+	if (s.voice.errors.length > 0) {
+		lines.push(`- Errors: ${s.voice.errors.length}`);
+		for (const e of s.voice.errors) lines.push(`  - ${e}`);
+	}
+	lines.push('');
+	lines.push('## Phone calls');
+	lines.push(`- Calls: **${s.calls.count}** (${s.calls.owner_calls} owner, ${s.calls.meeting_calls} meetings)`);
+	lines.push(`- Total duration: ${mins(s.calls.total_duration_ms)} min`);
+	lines.push(`- Tool calls top: ${topN(s.calls.tools_by_count)}`);
+	lines.push('');
+	lines.push('## Tasks / Results');
+	lines.push(`- Archived tasks: **${s.tasks.archived_count}** — top sources: ${topN(s.tasks.by_source)}`);
+	lines.push(`- Archived results: **${s.results.archived_count}**`);
+	lines.push('');
+	if (s.cost) {
+		lines.push(`## Cost ledger (tenant=${s.cost.tenant_id})`);
+		lines.push(`- Events: ${s.cost.event_count}`);
+		lines.push(`- Tokens in/out: ${s.cost.totals.in_tokens.toLocaleString()} / ${s.cost.totals.out_tokens.toLocaleString()}`);
+		lines.push(`- Tool calls: ${s.cost.totals.tool_calls}, requests: ${s.cost.totals.requests}`);
+		const models = Object.keys(s.cost.by_model);
+		if (models.length > 0) {
+			lines.push(`- By model: ${models.map((m) => `${m} (in=${s.cost!.by_model[m].in_tokens}, out=${s.cost!.by_model[m].out_tokens})`).join('; ')}`);
+		}
+		const tools = Object.entries(s.cost.by_tool);
+		if (tools.length > 0) {
+			lines.push(`- By tool: ${tools.sort((a, b) => b[1] - a[1]).slice(0, 5).map(([k, v]) => `${k} (${v})`).join(', ')}`);
+		}
+		const devices = Object.entries(s.cost.by_device);
+		if (devices.length > 0) {
+			lines.push(`- By device: ${devices.sort((a, b) => b[1] - a[1]).slice(0, 5).map(([k, v]) => `${k} (${v})`).join(', ')}`);
+		}
+	} else {
+		lines.push('## Cost ledger');
+		lines.push('- No events recorded yet (cost-accounting emitters not wired).');
+	}
+	return lines.join('\n') + '\n';
+}
+
+// --- CLI entry point ---
+
+function parseArgs(argv: string[]): { since?: string; until?: string; tenant?: string; json: boolean } {
+	const out: { since?: string; until?: string; tenant?: string; json: boolean } = { json: false };
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === '--since') out.since = argv[++i];
+		else if (a === '--until') out.until = argv[++i];
+		else if (a === '--tenant') out.tenant = argv[++i];
+		else if (a === '--json') out.json = true;
+		else if (a === '--help' || a === '-h') {
+			console.log('Usage: tsx src/audit-summary.ts [--since 7d|YYYY-MM-DD] [--until YYYY-MM-DD] [--tenant ID] [--json]');
+			process.exit(0);
+		}
+	}
+	return out;
+}
+
+// Only run main() when invoked directly, not when imported by tests.
+// Use `realpath` on both sides so macOS's `/tmp` → `/private/tmp` symlink
+// doesn't cause a false "imported" classification when invoked from a
+// tmp path. import.meta.url includes the resolved /private/tmp form;
+// process.argv[1] is the user-supplied path which may not.
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+const isMain = (() => {
+	try {
+		return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+	} catch { return false; }
+})();
+if (isMain) {
+	const args = parseArgs(process.argv.slice(2));
+	const now = new Date();
+	const since = args.since ? parseDuration(args.since, now) : undefined;
+	const until = args.until ? parseDuration(args.until, now) : undefined;
+	const summary = summarize({ since, until, tenant: args.tenant });
+	if (args.json) console.log(JSON.stringify(summary, null, 2));
+	else process.stdout.write(renderMarkdown(summary));
+}

--- a/src/cost-accounting.ts
+++ b/src/cost-accounting.ts
@@ -1,0 +1,194 @@
+/**
+ * Sutando — Cost Accounting
+ *
+ * Implements §5 Next: "Cost accounting. Per-tenant + per-device token +
+ * tool usage metering. Required to price anything; useful even single-
+ * tenant."
+ *
+ * Design shape: append-only JSONL ledger per tenant. Same pattern as
+ * `src/learn-collector.py`'s `state/learning-<instance>.jsonl` — atomic
+ * writes via `os.O_APPEND`, single-line events under PIPE_BUF (~512 on
+ * macOS / 4096 on Linux), no in-process aggregation that could be lost
+ * to a crash. Downstream summarizers roll up usage when the owner needs
+ * a report.
+ *
+ * Event shape (JSON line):
+ *   { ts, tenant_id, device_id?, source, kind, amount, unit, model?,
+ *     tool?, request_id? }
+ *
+ *   ts:          ISO-8601 UTC timestamp.
+ *   tenant_id:   from tenant.ts. Routes the event to its tenant ledger.
+ *   device_id:   optional — the DeviceSession that originated the call.
+ *   source:      free-form ("voice-agent", "mentra-bridge", "skill:gws-gmail").
+ *   kind:        "token" | "tool" | "api_call".
+ *   amount:      numeric (tokens, ms, calls).
+ *   unit:        "in_tokens" | "out_tokens" | "tool_call" | "ms" | "request".
+ *   model:       optional model name when relevant (gemini-2.5-flash, etc.).
+ *   tool:        optional tool name for kind="tool".
+ *   request_id:  optional client-side correlator.
+ *
+ * The ledger is owner-readable (the only data is the owner's own usage),
+ * gitignored, and survives across processes via append-only writes.
+ * Aggregation lives in a separate summarizer (this PR does not ship one).
+ *
+ * Not in scope:
+ *   - Aggregation / reporting UI — that's the §5 Next "Audit UI" item.
+ *   - Quota-tracker integration — quota-tracker measures the Anthropic
+ *     window separately; this is for Sutando's own per-tenant usage
+ *     view. Both can coexist.
+ *   - Cross-tenant rollup — single-tenant today; cross-tenant aggregation
+ *     waits until a second tenant exists.
+ */
+
+import { openSync, writeSync, closeSync, existsSync, readFileSync, mkdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tenantId, tenantPath } from './tenant.js';
+
+export type UsageKind = 'token' | 'tool' | 'api_call';
+
+export interface UsageEvent {
+	tenant_id: string;
+	device_id?: string;
+	source: string;
+	kind: UsageKind;
+	amount: number;
+	unit: 'in_tokens' | 'out_tokens' | 'tool_call' | 'ms' | 'request';
+	model?: string;
+	tool?: string;
+	request_id?: string;
+}
+
+function nowIso(): string {
+	// Keep millisecond precision — downstream rollup queries filter by
+	// timestamp range, and second-precision ties would collapse multiple
+	// events at the same second into an ambiguous boundary.
+	return new Date().toISOString();
+}
+
+function ledgerPath(forTenant: string): string {
+	// Pass `forTenant` explicitly so cross-tenant rollup queries route to
+	// the right tenant directory regardless of the current cached id. The
+	// 'shared' scope keeps the ledger fleet-wide within a tenant — usage
+	// from any machine in the tenant rolls up into the same JSONL.
+	return tenantPath(`cost-accounting/usage-${forTenant}.jsonl`, 'shared', undefined, forTenant);
+}
+
+function ensureDir(path: string): void {
+	try { mkdirSync(dirname(path), { recursive: true }); } catch {}
+}
+
+/** Emit one usage event. Atomic single write — `O_APPEND` guarantees
+ *  the kernel orders the bytes correctly even under concurrent writers
+ *  (mirrors `learn-collector.py`'s ledger discipline). */
+export function record(event: Omit<UsageEvent, 'tenant_id'> & { tenant_id?: string }): void {
+	const tid = event.tenant_id ?? tenantId();
+	const full: UsageEvent = { ...event, tenant_id: tid };
+	const line = JSON.stringify({ ts: nowIso(), ...full }) + '\n';
+	const path = ledgerPath(tid);
+	ensureDir(path);
+	const fd = openSync(path, 'a', 0o644);
+	try { writeSync(fd, line); }
+	finally { closeSync(fd); }
+}
+
+export interface UsageRollup {
+	tenant_id: string;
+	from?: string;
+	to?: string;
+	totals: {
+		in_tokens: number;
+		out_tokens: number;
+		tool_calls: number;
+		requests: number;
+		ms: number;
+	};
+	by_model: Record<string, { in_tokens: number; out_tokens: number; requests: number }>;
+	by_tool: Record<string, number>;
+	by_device: Record<string, number>;
+	event_count: number;
+}
+
+/** Read + aggregate the ledger for a tenant over an optional date range.
+ *  This is the read path; for owner reports, daily summaries, etc.
+ *
+ *  `from` / `to` are ISO timestamps (inclusive). Omit to roll up all.
+ *  Returns zeros + empty maps when no ledger exists yet.
+ */
+export function rollup(opts: { tenant_id?: string; from?: string; to?: string } = {}): UsageRollup {
+	const tid = opts.tenant_id ?? tenantId();
+	const path = ledgerPath(tid);
+	const empty: UsageRollup = {
+		tenant_id: tid,
+		from: opts.from,
+		to: opts.to,
+		totals: { in_tokens: 0, out_tokens: 0, tool_calls: 0, requests: 0, ms: 0 },
+		by_model: {},
+		by_tool: {},
+		by_device: {},
+		event_count: 0,
+	};
+	if (!existsSync(path)) return empty;
+	let raw: string;
+	try { raw = readFileSync(path, 'utf-8'); }
+	catch { return empty; }
+	const lines = raw.split('\n').filter((l) => l.length > 0);
+	for (const line of lines) {
+		let event: UsageEvent & { ts: string };
+		try { event = JSON.parse(line); }
+		catch { continue; }
+		if (event.tenant_id !== tid) continue;
+		if (opts.from && event.ts < opts.from) continue;
+		if (opts.to && event.ts > opts.to) continue;
+		empty.event_count++;
+		if (event.unit === 'in_tokens') empty.totals.in_tokens += event.amount;
+		if (event.unit === 'out_tokens') empty.totals.out_tokens += event.amount;
+		if (event.unit === 'tool_call') empty.totals.tool_calls += event.amount;
+		if (event.unit === 'request') empty.totals.requests += event.amount;
+		if (event.unit === 'ms') empty.totals.ms += event.amount;
+		if (event.model) {
+			const m = (empty.by_model[event.model] ??= { in_tokens: 0, out_tokens: 0, requests: 0 });
+			if (event.unit === 'in_tokens') m.in_tokens += event.amount;
+			if (event.unit === 'out_tokens') m.out_tokens += event.amount;
+			if (event.unit === 'request') m.requests += event.amount;
+		}
+		if (event.tool) {
+			empty.by_tool[event.tool] = (empty.by_tool[event.tool] ?? 0) + event.amount;
+		}
+		if (event.device_id) {
+			empty.by_device[event.device_id] = (empty.by_device[event.device_id] ?? 0) + event.amount;
+		}
+	}
+	return empty;
+}
+
+/** @internal — test-only helper to inspect the ledger path. */
+export function __ledgerPathForTests(forTenant?: string): string {
+	return ledgerPath(forTenant ?? tenantId());
+}
+
+/** @internal — test-only helper to drop the ledger between tests. */
+export function __resetLedgerForTests(forTenant?: string): void {
+	const path = ledgerPath(forTenant ?? tenantId());
+	try {
+		if (existsSync(path)) {
+			// Truncate by re-opening for write. Avoids fs.rmSync because the
+			// ledger path may be under a private dir we don't own outright in
+			// tests; truncation is enough to reset state.
+			closeSync(openSync(path, 'w'));
+		}
+	} catch {}
+}
+
+/** Check whether the ledger file exists yet (mostly for diagnostics). */
+export function ledgerExists(forTenant?: string): boolean {
+	const path = ledgerPath(forTenant ?? tenantId());
+	return existsSync(path);
+}
+
+/** Approximate ledger size in bytes (for owner diagnostics). */
+export function ledgerSizeBytes(forTenant?: string): number {
+	const path = ledgerPath(forTenant ?? tenantId());
+	if (!existsSync(path)) return 0;
+	try { return statSync(path).size; }
+	catch { return 0; }
+}

--- a/src/cost-accounting.ts
+++ b/src/cost-accounting.ts
@@ -73,8 +73,15 @@ function ledgerPath(forTenant: string): string {
 	return tenantPath(`cost-accounting/usage-${forTenant}.jsonl`, 'shared', undefined, forTenant);
 }
 
+// Memoize mkdir targets so the per-record `mkdirSync` doesn't fire a
+// redundant syscall on every emit. Recursive mkdir is cheap but
+// non-zero; record() is called per tool/session-end, so the cache
+// saves N-1 syscalls per ledger across the lifetime of the process.
+const _ensuredDirs = new Set<string>();
 function ensureDir(path: string): void {
-	try { mkdirSync(dirname(path), { recursive: true }); } catch {}
+	const dir = dirname(path);
+	if (_ensuredDirs.has(dir)) return;
+	try { mkdirSync(dir, { recursive: true }); _ensuredDirs.add(dir); } catch {}
 }
 
 /** Emit one usage event. Atomic single write — `O_APPEND` guarantees
@@ -102,7 +109,7 @@ export interface UsageRollup {
 		requests: number;
 		ms: number;
 	};
-	by_model: Record<string, { in_tokens: number; out_tokens: number; requests: number }>;
+	by_model: Record<string, { in_tokens: number; out_tokens: number; requests: number; ms: number }>;
 	by_tool: Record<string, number>;
 	by_device: Record<string, number>;
 	event_count: number;
@@ -113,6 +120,12 @@ export interface UsageRollup {
  *
  *  `from` / `to` are ISO timestamps (inclusive). Omit to roll up all.
  *  Returns zeros + empty maps when no ledger exists yet.
+ *
+ *  TODO(scale): currently reads the whole ledger into memory. Fine for
+ *  near-term (weeks of events per tenant). When a long-running tenant
+ *  accumulates months of events and rollup() crosses ~50MB+, switch to
+ *  `createReadStream` + `readline` for streaming aggregation. Trigger:
+ *  audit-summary on multi-month windows starts feeling slow.
  */
 export function rollup(opts: { tenant_id?: string; from?: string; to?: string } = {}): UsageRollup {
 	const tid = opts.tenant_id ?? tenantId();
@@ -146,10 +159,11 @@ export function rollup(opts: { tenant_id?: string; from?: string; to?: string } 
 		if (event.unit === 'request') empty.totals.requests += event.amount;
 		if (event.unit === 'ms') empty.totals.ms += event.amount;
 		if (event.model) {
-			const m = (empty.by_model[event.model] ??= { in_tokens: 0, out_tokens: 0, requests: 0 });
+			const m = (empty.by_model[event.model] ??= { in_tokens: 0, out_tokens: 0, requests: 0, ms: 0 });
 			if (event.unit === 'in_tokens') m.in_tokens += event.amount;
 			if (event.unit === 'out_tokens') m.out_tokens += event.amount;
 			if (event.unit === 'request') m.requests += event.amount;
+			if (event.unit === 'ms') m.ms += event.amount;
 		}
 		if (event.tool) {
 			empty.by_tool[event.tool] = (empty.by_tool[event.tool] ?? 0) + event.amount;

--- a/src/tenant.ts
+++ b/src/tenant.ts
@@ -127,9 +127,12 @@ export type PathScope = 'device' | 'shared';
  *  exists, returns the *preferred* private-dir path so an existsSync
  *  check fails gracefully and a subsequent write lands in the right place.
  */
-export function tenantPath(filename: string, scope: PathScope = 'shared', workspace?: string): string {
+export function tenantPath(filename: string, scope: PathScope = 'shared', workspace?: string, forTenant?: string): string {
 	const ws = workspace ?? workspaceDir();
-	const id = tenantId(ws);
+	// Cross-tenant queries pass `forTenant` explicitly; default uses the
+	// current cached tenant id. Keeping both shapes lets a caller read
+	// another tenant's data without invalidating their own cache.
+	const id = forTenant ?? tenantId(ws);
 	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
 
 	if (privateRoot) {

--- a/tests/audit-summary.test.ts
+++ b/tests/audit-summary.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { summarize, renderMarkdown } from '../src/audit-summary.ts';
+import { record, __resetLedgerForTests } from '../src/cost-accounting.ts';
+import { __resetForTests as resetTenant } from '../src/tenant.ts';
+
+let savedEnv: Record<string, string | undefined>;
+
+function snap(): Record<string, string | undefined> {
+	return {
+		SUTANDO_TENANT_ID: process.env.SUTANDO_TENANT_ID,
+		SUTANDO_PRIVATE_DIR: process.env.SUTANDO_PRIVATE_DIR,
+		SUTANDO_WORKSPACE: process.env.SUTANDO_WORKSPACE,
+	};
+}
+
+function restore(s: Record<string, string | undefined>): void {
+	for (const k of Object.keys(s)) {
+		if (s[k] === undefined) delete process.env[k];
+		else process.env[k] = s[k];
+	}
+}
+
+function writeJsonl(path: string, items: unknown[]): void {
+	writeFileSync(path, items.map((i) => JSON.stringify(i)).join('\n') + '\n');
+}
+
+describe('audit-summary', () => {
+	let ws: string;
+	let priv: string;
+
+	beforeEach(() => {
+		savedEnv = snap();
+		resetTenant();
+		__resetLedgerForTests();
+		ws = mkdtempSync(join(tmpdir(), 'sutando-audit-ws-'));
+		priv = mkdtempSync(join(tmpdir(), 'sutando-audit-priv-'));
+		process.env.SUTANDO_WORKSPACE = ws;
+		process.env.SUTANDO_PRIVATE_DIR = priv;
+		delete process.env.SUTANDO_TENANT_ID;
+		mkdirSync(join(ws, 'data'), { recursive: true });
+		mkdirSync(join(ws, 'tasks', 'archive', '2026-05'), { recursive: true });
+		mkdirSync(join(ws, 'results', 'archive', '2026-05'), { recursive: true });
+	});
+
+	afterEach(() => {
+		restore(savedEnv);
+		resetTenant();
+		__resetLedgerForTests();
+		try { rmSync(ws, { recursive: true, force: true }); } catch {}
+		try { rmSync(priv, { recursive: true, force: true }); } catch {}
+	});
+
+	it('empty workspace → empty counts, no cost section', () => {
+		const s = summarize();
+		assert.equal(s.voice.sessions, 0);
+		assert.equal(s.calls.count, 0);
+		assert.equal(s.tasks.archived_count, 0);
+		assert.equal(s.results.archived_count, 0);
+		assert.equal(s.cost, null);
+		// renderMarkdown still produces output without throwing.
+		assert.ok(renderMarkdown(s).includes('Voice sessions'));
+	});
+
+	it('voice metrics: filtered by date range, aggregated', () => {
+		const today = new Date().toISOString();
+		const lastWeek = new Date(Date.now() - 8 * 86_400_000).toISOString();
+		writeJsonl(join(ws, 'data', 'voice-metrics.jsonl'), [
+			{
+				timestamp: today, sessionId: 's1', source: 'voice', durationMs: 60_000,
+				transcriptLines: 5, toolCount: 2,
+				toolCalls: [
+					{ name: 'triage_email', durationMs: 1000 },
+					{ name: 'work', durationMs: 2000 },
+				],
+				events: [{ event: 'session_started', timestamp: today }],
+			},
+			{
+				timestamp: today, sessionId: 's2', source: 'voice', durationMs: 30_000,
+				transcriptLines: 2, toolCount: 1,
+				toolCalls: [{ name: 'triage_email', durationMs: 800 }],
+				events: [{ event: 'error:reconnect:timeout', timestamp: today }],
+			},
+			{
+				timestamp: lastWeek, sessionId: 's-old', source: 'voice', durationMs: 99_999,
+				transcriptLines: 1, toolCount: 0, toolCalls: [], events: [],
+			},
+		]);
+		const s = summarize();
+		// Today's window — only s1+s2 (not s-old).
+		assert.equal(s.voice.sessions, 2);
+		assert.equal(s.voice.total_duration_ms, 90_000);
+		assert.equal(s.voice.total_transcript_lines, 7);
+		assert.equal(s.voice.total_tool_calls, 3);
+		assert.equal(s.voice.tools_by_count['triage_email'], 2);
+		assert.equal(s.voice.tools_by_count['work'], 1);
+		assert.equal(s.voice.errors.length, 1);
+	});
+
+	it('call metrics: owner + meeting flags counted', () => {
+		const today = new Date().toISOString();
+		writeJsonl(join(ws, 'data', 'call-metrics.jsonl'), [
+			{ timestamp: today, callSid: 'c1', caller: '+1', isOwner: true, isMeeting: false, durationMs: 60_000, transcriptLines: 5, toolCount: 1, toolCalls: [{ name: 'hang_up', durationMs: 200 }], events: [] },
+			{ timestamp: today, callSid: 'c2', caller: '+2', isOwner: false, isMeeting: true, durationMs: 120_000, transcriptLines: 20, toolCount: 0, toolCalls: [], events: [] },
+		]);
+		const s = summarize();
+		assert.equal(s.calls.count, 2);
+		assert.equal(s.calls.owner_calls, 1);
+		assert.equal(s.calls.meeting_calls, 1);
+		assert.equal(s.calls.total_duration_ms, 180_000);
+		assert.equal(s.calls.tools_by_count['hang_up'], 1);
+	});
+
+	it('archive counts: tasks + results by mtime within range', () => {
+		const today = new Date();
+		const taskFile = join(ws, 'tasks', 'archive', '2026-05', 'task-health-1.txt');
+		const resultFile = join(ws, 'results', 'archive', '2026-05', 'task-discord-2.txt');
+		writeFileSync(taskFile, 'x');
+		writeFileSync(resultFile, 'y');
+		// Touch mtimes to today.
+		utimesSync(taskFile, today, today);
+		utimesSync(resultFile, today, today);
+		const s = summarize();
+		assert.equal(s.tasks.archived_count, 1);
+		assert.equal(s.results.archived_count, 1);
+		assert.ok(s.tasks.by_source['health'] === 1 || s.tasks.by_source['task'] === 1);
+	});
+
+	it('cost ledger surfaces when events are present', () => {
+		record({ source: 'voice', kind: 'token', amount: 1000, unit: 'in_tokens', model: 'gemini-2.5-flash' });
+		record({ source: 'voice', kind: 'token', amount: 200, unit: 'out_tokens', model: 'gemini-2.5-flash' });
+		record({ source: 'voice', kind: 'tool', amount: 1, unit: 'tool_call', tool: 'triage_email' });
+		const s = summarize();
+		assert.ok(s.cost);
+		assert.equal(s.cost!.totals.in_tokens, 1000);
+		assert.equal(s.cost!.totals.out_tokens, 200);
+		assert.equal(s.cost!.totals.tool_calls, 1);
+		const md = renderMarkdown(s);
+		assert.ok(md.includes('Cost ledger'));
+		assert.ok(md.includes('1,000'));
+	});
+
+	it('renderMarkdown produces a structured report with key sections', () => {
+		const today = new Date().toISOString();
+		writeJsonl(join(ws, 'data', 'voice-metrics.jsonl'), [
+			{ timestamp: today, sessionId: 's', source: 'voice', durationMs: 12_345, transcriptLines: 1, toolCount: 0, toolCalls: [], events: [] },
+		]);
+		const md = renderMarkdown(summarize());
+		assert.ok(md.includes('# Sutando audit summary'));
+		assert.ok(md.includes('## Voice sessions'));
+		assert.ok(md.includes('## Phone calls'));
+		assert.ok(md.includes('## Tasks / Results'));
+		assert.ok(md.includes('## Cost ledger'));
+	});
+});

--- a/tests/cost-accounting.test.ts
+++ b/tests/cost-accounting.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	record,
+	rollup,
+	ledgerExists,
+	__ledgerPathForTests,
+	__resetLedgerForTests,
+} from '../src/cost-accounting.ts';
+import { __resetForTests as resetTenant } from '../src/tenant.ts';
+
+let savedEnv: Record<string, string | undefined>;
+
+function snapshotEnv(): Record<string, string | undefined> {
+	return {
+		SUTANDO_TENANT_ID: process.env.SUTANDO_TENANT_ID,
+		SUTANDO_PRIVATE_DIR: process.env.SUTANDO_PRIVATE_DIR,
+		SUTANDO_WORKSPACE: process.env.SUTANDO_WORKSPACE,
+	};
+}
+
+function restoreEnv(snap: Record<string, string | undefined>): void {
+	for (const k of Object.keys(snap)) {
+		if (snap[k] === undefined) delete process.env[k];
+		else process.env[k] = snap[k];
+	}
+}
+
+describe('cost-accounting ledger', () => {
+	let tempPrivate: string;
+	let tempWs: string;
+
+	beforeEach(() => {
+		savedEnv = snapshotEnv();
+		resetTenant();
+		tempPrivate = mkdtempSync(join(tmpdir(), 'sutando-cost-priv-'));
+		tempWs = mkdtempSync(join(tmpdir(), 'sutando-cost-ws-'));
+		process.env.SUTANDO_PRIVATE_DIR = tempPrivate;
+		process.env.SUTANDO_WORKSPACE = tempWs;
+		delete process.env.SUTANDO_TENANT_ID;
+		__resetLedgerForTests();
+	});
+
+	afterEach(() => {
+		__resetLedgerForTests();
+		restoreEnv(savedEnv);
+		resetTenant();
+		try { rmSync(tempPrivate, { recursive: true, force: true }); } catch {}
+		try { rmSync(tempWs, { recursive: true, force: true }); } catch {}
+	});
+
+	it('records a single token event + ledger appears', () => {
+		assert.equal(ledgerExists(), false);
+		record({
+			source: 'voice-agent',
+			kind: 'token',
+			amount: 100,
+			unit: 'in_tokens',
+			model: 'gemini-2.5-flash',
+		});
+		assert.equal(ledgerExists(), true);
+		const r = rollup();
+		assert.equal(r.event_count, 1);
+		assert.equal(r.totals.in_tokens, 100);
+		assert.equal(r.by_model['gemini-2.5-flash'].in_tokens, 100);
+	});
+
+	it('aggregates in + out tokens + tool_calls + requests separately', () => {
+		record({ source: 'voice', kind: 'token', amount: 500, unit: 'in_tokens', model: 'a' });
+		record({ source: 'voice', kind: 'token', amount: 50, unit: 'out_tokens', model: 'a' });
+		record({ source: 'voice', kind: 'tool', amount: 1, unit: 'tool_call', tool: 'triage_email' });
+		record({ source: 'voice', kind: 'tool', amount: 1, unit: 'tool_call', tool: 'triage_email' });
+		record({ source: 'voice', kind: 'api_call', amount: 1, unit: 'request', model: 'a' });
+		const r = rollup();
+		assert.equal(r.event_count, 5);
+		assert.equal(r.totals.in_tokens, 500);
+		assert.equal(r.totals.out_tokens, 50);
+		assert.equal(r.totals.tool_calls, 2);
+		assert.equal(r.totals.requests, 1);
+		assert.equal(r.by_tool['triage_email'], 2);
+		assert.equal(r.by_model['a'].in_tokens, 500);
+		assert.equal(r.by_model['a'].out_tokens, 50);
+		assert.equal(r.by_model['a'].requests, 1);
+	});
+
+	it('rollup is per-tenant — events for one tenant don\'t leak into another', () => {
+		process.env.SUTANDO_TENANT_ID = 'acme';
+		resetTenant();
+		record({ source: 's', kind: 'token', amount: 100, unit: 'in_tokens', model: 'm' });
+		// Switch tenants.
+		process.env.SUTANDO_TENANT_ID = 'beta';
+		resetTenant();
+		record({ source: 's', kind: 'token', amount: 200, unit: 'in_tokens', model: 'm' });
+		assert.equal(rollup({ tenant_id: 'acme' }).totals.in_tokens, 100);
+		assert.equal(rollup({ tenant_id: 'beta' }).totals.in_tokens, 200);
+	});
+
+	it('time-range filter respects from/to', () => {
+		// Three events with synthetic but real timestamps.
+		const path = __ledgerPathForTests();
+		// We can't easily inject fake timestamps via `record()` because it
+		// stamps with `new Date()`; instead write three events with real
+		// timestamps spaced over the test.
+		record({ source: 's', kind: 'token', amount: 1, unit: 'in_tokens', model: 'm' });
+		const t1 = new Date().toISOString();
+		record({ source: 's', kind: 'token', amount: 1, unit: 'in_tokens', model: 'm' });
+		const t2 = new Date().toISOString();
+		record({ source: 's', kind: 'token', amount: 1, unit: 'in_tokens', model: 'm' });
+		const all = rollup();
+		assert.equal(all.event_count, 3);
+		// From t2: should include only events at or after t2 — at minimum the
+		// third event.
+		const fromT2 = rollup({ from: t2 });
+		assert.ok(fromT2.event_count >= 1 && fromT2.event_count <= 2);
+		// Sanity: file path exists.
+		assert.ok(path.endsWith('.jsonl'));
+	});
+
+	it('by_device fanout', () => {
+		record({ source: 's', device_id: 'mac', kind: 'token', amount: 100, unit: 'in_tokens' });
+		record({ source: 's', device_id: 'mac', kind: 'token', amount: 50, unit: 'out_tokens' });
+		record({ source: 's', device_id: 'glasses', kind: 'tool', amount: 1, unit: 'tool_call', tool: 't' });
+		const r = rollup();
+		assert.equal(r.by_device['mac'], 150);
+		assert.equal(r.by_device['glasses'], 1);
+	});
+
+	it('rollup with no ledger returns zeros', () => {
+		const r = rollup();
+		assert.equal(r.event_count, 0);
+		assert.equal(r.totals.in_tokens, 0);
+		assert.deepEqual(r.by_model, {});
+		assert.deepEqual(r.by_tool, {});
+		assert.deepEqual(r.by_device, {});
+	});
+
+	it('explicit tenant_id on record routes to that tenant', () => {
+		record({ source: 's', tenant_id: 'override', kind: 'token', amount: 999, unit: 'in_tokens' });
+		assert.equal(rollup({ tenant_id: 'override' }).totals.in_tokens, 999);
+		assert.equal(rollup({ tenant_id: 'default' }).totals.in_tokens, 0);
+	});
+
+	it('corrupt jsonl line is skipped (doesn\'t throw)', () => {
+		const path = __ledgerPathForTests();
+		// Write one valid + one corrupt line via record() then append corrupt.
+		record({ source: 's', kind: 'token', amount: 10, unit: 'in_tokens' });
+		// Append a corrupt line directly.
+		appendFileSync(path, 'this is not json\n');
+		record({ source: 's', kind: 'token', amount: 20, unit: 'in_tokens' });
+		const r = rollup();
+		assert.equal(r.event_count, 2);
+		assert.equal(r.totals.in_tokens, 30);
+	});
+});

--- a/tests/cost-accounting.test.ts
+++ b/tests/cost-accounting.test.ts
@@ -98,25 +98,36 @@ describe('cost-accounting ledger', () => {
 		assert.equal(rollup({ tenant_id: 'beta' }).totals.in_tokens, 200);
 	});
 
-	it('time-range filter respects from/to', () => {
-		// Three events with synthetic but real timestamps.
+	it('time-range filter respects from/to', async () => {
+		// Three events spaced ≥2ms apart. ts is ms-precision, so adjacent
+		// record() calls can collide on the same ms; setTimeout(2) guarantees
+		// separation so the from/to filter has a stable cut point.
 		const path = __ledgerPathForTests();
-		// We can't easily inject fake timestamps via `record()` because it
-		// stamps with `new Date()`; instead write three events with real
-		// timestamps spaced over the test.
 		record({ source: 's', kind: 'token', amount: 1, unit: 'in_tokens', model: 'm' });
-		const t1 = new Date().toISOString();
-		record({ source: 's', kind: 'token', amount: 1, unit: 'in_tokens', model: 'm' });
+		await new Promise((r) => setTimeout(r, 2));
 		const t2 = new Date().toISOString();
+		await new Promise((r) => setTimeout(r, 2));
+		record({ source: 's', kind: 'token', amount: 1, unit: 'in_tokens', model: 'm' });
+		await new Promise((r) => setTimeout(r, 2));
 		record({ source: 's', kind: 'token', amount: 1, unit: 'in_tokens', model: 'm' });
 		const all = rollup();
 		assert.equal(all.event_count, 3);
-		// From t2: should include only events at or after t2 — at minimum the
-		// third event.
 		const fromT2 = rollup({ from: t2 });
-		assert.ok(fromT2.event_count >= 1 && fromT2.event_count <= 2);
-		// Sanity: file path exists.
+		assert.equal(fromT2.event_count, 2);
 		assert.ok(path.endsWith('.jsonl'));
+	});
+
+	it('by_model now breaks out ms (for future audit-UI latency view)', () => {
+		record({ source: 's', kind: 'api_call', amount: 1, unit: 'request', model: 'gemini-2.5-flash' });
+		record({ source: 's', kind: 'api_call', amount: 2500, unit: 'ms', model: 'gemini-2.5-flash' });
+		record({ source: 's', kind: 'api_call', amount: 1, unit: 'request', model: 'gemini-2.5-pro' });
+		record({ source: 's', kind: 'api_call', amount: 800, unit: 'ms', model: 'gemini-2.5-pro' });
+		const r = rollup();
+		assert.equal(r.by_model['gemini-2.5-flash'].requests, 1);
+		assert.equal(r.by_model['gemini-2.5-flash'].ms, 2500);
+		assert.equal(r.by_model['gemini-2.5-pro'].requests, 1);
+		assert.equal(r.by_model['gemini-2.5-pro'].ms, 800);
+		assert.equal(r.totals.ms, 3300);
 	});
 
 	it('by_device fanout', () => {


### PR DESCRIPTION
Implements §5 Next "Cost accounting" — append-only JSONL ledger per tenant. Mirrors src/learn-collector.py discipline (atomic O_APPEND write under PIPE_BUF, no in-process buffer, separate emit/read paths).

**Base:** feat/tenant-identity-scaffold (#748). Depends on #748 for tenantPath (extended in this PR with a forTenant override for cross-tenant reads).

## What ships
- src/cost-accounting.ts (~150 LOC): UsageEvent shape, record(), rollup({tenant_id, from, to}), ledgerExists/ledgerSizeBytes helpers.
- src/tenant.ts: tenantPath extended with optional 4th param forTenant. Backward-compatible.
- tests/cost-accounting.test.ts — 8 tests, all pass. Existing 14 tenant tests stay green.

## Out of scope
- No callers emit usage events yet — voice-agent / bodhi / skills have the data; wiring is the follow-up.
- No UI. rollup() is the contract the future §5 Next Audit UI consumes.

## Test plan
- [x] npx tsx --test tests/cost-accounting.test.ts — 8/8.
- [x] npx tsx --test tests/tenant.test.ts — 14/14 (regression check).
- [x] npx tsc --noEmit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)