### PR TITLE
feat(voice-agent): emit per-session usage into cost-accounting ledger

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -869,6 +869,33 @@ async function main() {
 		} catch (err) {
 			console.log(`${ts()} [Observability] Failed to write metrics: ${err}`);
 		}
+		// Also record per-session usage in the per-tenant cost-accounting
+		// ledger from PR #749. Token counts aren't yet exposed by the
+		// realtime transport, so this first cut records what we *do* have:
+		// session duration + per-tool invocation counts. When bodhi exposes
+		// in/out tokens (or we add a thin counter around the transport),
+		// the same hook lights up the token totals without changing shape.
+		//
+		// Dynamic import keeps cost-accounting an optional dependency — if
+		// the module is absent (older worktree, partial deploy), the catch
+		// below silently skips emit rather than crash session-end.
+		(async () => {
+			try {
+				const { record } = await import('./cost-accounting.js');
+				const deviceId = 'laptop'; // future per-device emission lives
+				                            // in the bridge that owns the
+				                            // DeviceSession (PR #740 / Mentra).
+				record({ source: 'voice-agent', device_id: deviceId, kind: 'api_call', amount: 1, unit: 'request', model: VOICE_MODEL });
+				if (voiceSessionStart) {
+					record({ source: 'voice-agent', device_id: deviceId, kind: 'api_call', amount: Date.now() - voiceSessionStart, unit: 'ms', model: VOICE_MODEL });
+				}
+				for (const tc of voiceToolCalls) {
+					record({ source: 'voice-agent', device_id: deviceId, kind: 'tool', amount: 1, unit: 'tool_call', tool: tc.name });
+				}
+			} catch (err) {
+				console.log(`${ts()} [CostAccounting] non-fatal emit error: ${(err as Error)?.message ?? err}`);
+			}
+		})();
 	}
 
 	const session = new VoiceSession({

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -879,6 +879,16 @@ async function main() {
 		// Dynamic import keeps cost-accounting an optional dependency — if
 		// the module is absent (older worktree, partial deploy), the catch
 		// below silently skips emit rather than crash session-end.
+		//
+		// Note on cost profile (per sonichi's #751 review of multi-record):
+		// `record()` does open+write+close per call — no explicit fsync,
+		// so the kernel batches writes via the page cache. Three syscalls
+		// per session-end (1 request + 1 ms + N tool_calls) is well below
+		// the threshold where batching to recordMany() would matter. The
+		// `_ensuredDirs` cache added in #749 fixup further amortizes the
+		// mkdir cost. If session-end ever needs to fire hundreds of events
+		// (e.g. per-utterance token counts once bodhi exposes them), revisit
+		// with a `recordMany([...])` API that keeps one fd open.
 		(async () => {
 			try {
 				const { record } = await import('./cost-accounting.js');


### PR DESCRIPTION
Activates #749's ledger from voice-agent's session-end path. Without this, the ledger stays empty and audit-summary (#750) reports 'No events recorded yet'.

**Base:** feat/cost-accounting-scaffold (#749). Depends on #749.

## What ships
- writeVoiceMetrics() also emits to cost-accounting after the existing voice-metrics.jsonl write:
  - 1 'request' event tagged with VOICE_MODEL
  - session duration in ms
  - 1 'tool_call' per voiceToolCalls entry, tagged with tool name
- Token in/out counts intentionally NOT emitted yet — realtime transport doesn't expose them. When bodhi adds them (or we wrap sendFile/sendContent in a counter), the same emit point lights up token totals.
- Dynamic import keeps cost-accounting an optional dep — older worktrees / partial deploys silently skip emit.

## Device-aware shape
'laptop' deviceId hardcoded because voice-agent IS the laptop. Per-device emission for Mentra glasses / phone calls lives in the bridge that owns the relevant DeviceSession (PR #740 / conversation-server) — those are the follow-ups.

## Test plan
- [x] npx tsc --noEmit clean.
- [ ] Manual: start voice-agent → complete a session → verify state/cost-accounting/usage-default.jsonl exists with api_call(request=1, ms=N) + per-tool entries.
- [ ] Manual: tsx src/audit-summary.ts --since 24h shows populated Cost ledger.

## Roadmap impact
§5 Next 'Cost accounting' first consumer (voice). Phone + skills + Mentra are follow-ups (one site per PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)