### PR TITLE
feat(phone-conversation): emit per-call usage into cost-accounting ledger

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -984,7 +984,11 @@ function cleanupCall(callSid: string): void {
 	// is preserved without leaking the caller number into device_id keys.
 	(async () => {
 		try {
-			const { record } = await import(join(WORKSPACE_DIR, 'src', 'cost-accounting.js'));
+			// Static relative import resolves via Node ESM + TypeScript's
+			// module resolver (better than the previous computed
+			// `import(join(WORKSPACE_DIR, ...))` which confused static
+			// analyzers, bundlers, and tsc's path tracking).
+			const { record } = await import('../../../src/cost-accounting.js');
 			const deviceId = `phone-call:${callSid}`;
 			const source = session.isOwner ? 'phone-conversation' : 'phone-conversation:non-owner';
 			record({ source, device_id: deviceId, kind: 'api_call', amount: 1, unit: 'request', model: VOICE_MODEL });
@@ -993,7 +997,9 @@ function cleanupCall(callSid: string): void {
 				record({ source, device_id: deviceId, kind: 'tool', amount: 1, unit: 'tool_call', tool: tc.name });
 			}
 		} catch (err) {
-			console.log(`${ts()} [CostAccounting] phone emit error (non-fatal): ${(err as Error)?.message ?? err}`);
+			// Include callSid so concurrent-call failures can be correlated
+			// when multiple emits race close together.
+			console.log(`${ts()} [CostAccounting] ${callSid} phone emit error (non-fatal): ${(err as Error)?.message ?? err}`);
 		}
 	})();
 

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -972,6 +972,31 @@ function cleanupCall(callSid: string): void {
 		appendFileSync(join(WORKSPACE_DIR, 'data', 'call-metrics.jsonl'), JSON.stringify(metrics) + '\n');
 	} catch { /* best effort */ }
 
+	// Also emit per-call usage into the per-tenant cost-accounting ledger
+	// (PR #749). Mirrors voice-agent.writeVoiceMetrics() emit (PR #751):
+	// 1 request, total duration in ms, 1 tool_call per session.toolCalls
+	// entry. Token in/out counts deferred — same shape will light up when
+	// bodhi exposes them.
+	//
+	// device_id='phone-call:<callSid>' distinguishes phone-originated
+	// usage from laptop/glasses in audit-summary's by_device breakdown.
+	// For non-owner calls, the source string tags them so spam attribution
+	// is preserved without leaking the caller number into device_id keys.
+	(async () => {
+		try {
+			const { record } = await import(join(WORKSPACE_DIR, 'src', 'cost-accounting.js'));
+			const deviceId = `phone-call:${callSid}`;
+			const source = session.isOwner ? 'phone-conversation' : 'phone-conversation:non-owner';
+			record({ source, device_id: deviceId, kind: 'api_call', amount: 1, unit: 'request', model: VOICE_MODEL });
+			record({ source, device_id: deviceId, kind: 'api_call', amount: durationMs, unit: 'ms', model: VOICE_MODEL });
+			for (const tc of session.toolCalls || []) {
+				record({ source, device_id: deviceId, kind: 'tool', amount: 1, unit: 'tool_call', tool: tc.name });
+			}
+		} catch (err) {
+			console.log(`${ts()} [CostAccounting] phone emit error (non-fatal): ${(err as Error)?.message ?? err}`);
+		}
+	})();
+
 	// Auto-scan the latest call for issues (async, best effort)
 	try {
 		const scanScript = join(WORKSPACE_DIR, 'src', 'scan-call-logs.py');


### PR DESCRIPTION
Second consumer of #749's per-tenant cost ledger. Mirrors voice-agent's emit shape from #751: 1 request + total duration in ms + 1 tool_call per session.toolCalls entry. Token counts deferred (bodhi doesn't expose them yet).

**Base:** feat/cost-accounting-scaffold (#749). Depends on #749. Independent of #751 — both emit at separate call sites.

## What ships
- 25 lines added to conversation-server.ts's call-end finalization, right after the existing call-metrics.jsonl write.
- device_id='phone-call:<callSid>' distinguishes phone usage from laptop/glasses in audit-summary's by_device breakdown.
- Non-owner calls tagged with source='phone-conversation:non-owner' — spam attribution without leaking caller numbers into device_id keys.
- Dynamic import + try/catch keeps cost-accounting an optional dep (mirrors #751's defensive shape).

## Test plan
- [x] tsc --noEmit clean.
- [ ] Manual: complete a call → state/cost-accounting/usage-default.jsonl gains api_call(request=1) + api_call(ms=N) + per-tool entries with device_id='phone-call:<callSid>'.
- [ ] Manual: audit-summary --since 24h shows by_device populated.

## Roadmap impact
§5 Next 'Cost accounting' second consumer (phone). Remaining emit sites: skills + Mentra bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)