### PR TITLE
feat(tenant): Python twin — src/tenant.py + util_paths.py delegation

### DIFF
--- a/src/tenant.py
+++ b/src/tenant.py
@@ -1,8 +1,9 @@
 """Sutando — Per-Tenant Identity (Python twin of src/tenant.ts).
 
-Mirrors the TypeScript module shipped in PR #748. See `src/tenant.ts` for the
-authoritative design doc — the layout, fallback ordering, and validation
-rules are identical.
+Mirrors the TypeScript module shipped in PR #748. Both languages implement
+the same design — the layout, fallback ordering, and validation rules are
+identical, and changes must land in both to stay aligned. See `src/tenant.ts`
+for the parallel implementation.
 
 Three-level path model:
 
@@ -28,6 +29,7 @@ import json
 import os
 import re
 import socket
+import sys
 from pathlib import Path
 from typing import Literal, Optional
 
@@ -54,9 +56,9 @@ def _read_from_state_file(workspace: Path) -> Optional[str]:
         if isinstance(tid, str) and TENANT_ID_PATTERN.match(tid):
             return tid
         if tid is not None:
-            print(f"[Tenant] state/tenant.json id {tid!r} failed validation; using default")
+            print(f"[Tenant] state/tenant.json id {tid!r} failed validation; using default", file=sys.stderr)
     except Exception as e:
-        print(f"[Tenant] failed to read state/tenant.json: {e}")
+        print(f"[Tenant] failed to read state/tenant.json: {e}", file=sys.stderr)
     return None
 
 
@@ -74,7 +76,7 @@ def tenant_id(workspace: Optional[Path] = None) -> str:
         _cached_tenant_id = env_id
         return env_id
     if env_id:
-        print(f"[Tenant] SUTANDO_TENANT_ID {env_id!r} failed validation; using default")
+        print(f"[Tenant] SUTANDO_TENANT_ID {env_id!r} failed validation; using default", file=sys.stderr)
     from_state = _read_from_state_file(ws)
     if from_state:
         _cached_tenant_id = from_state

--- a/src/tenant.py
+++ b/src/tenant.py
@@ -1,0 +1,155 @@
+"""Sutando — Per-Tenant Identity (Python twin of src/tenant.ts).
+
+Mirrors the TypeScript module shipped in PR #748. See `src/tenant.ts` for the
+authoritative design doc — the layout, fallback ordering, and validation
+rules are identical.
+
+Three-level path model:
+
+    $SUTANDO_PRIVATE_DIR/
+      ├── tenant-default/                ← today (single-tenant)
+      │   ├── machine-<host>/            ← per-device (scope='device')
+      │   └── ...                        ← fleet-shared (scope='shared')
+      └── tenant-acme/                   ← future second tenant
+          └── ...
+
+Tenant id resolution (high → low):
+    1. SUTANDO_TENANT_ID env var.
+    2. <workspace>/state/tenant.json   {"id": "...", "name": "..."}
+    3. 'default'.
+
+`tenant_path(filename, scope, workspace=None, for_tenant=None)` builds the
+three-level path with legacy-pre-migration fallback when the tenant
+directory doesn't exist yet.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+from pathlib import Path
+from typing import Literal, Optional
+
+TENANT_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+_cached_tenant_id: Optional[str] = None
+
+
+def _workspace_dir() -> Path:
+    """Mirrors src/util_paths.py:REPO_DIR + SUTANDO_WORKSPACE env override."""
+    ws = os.environ.get("SUTANDO_WORKSPACE")
+    if ws:
+        return Path(os.path.expanduser(ws))
+    return Path(__file__).resolve().parent.parent
+
+
+def _read_from_state_file(workspace: Path) -> Optional[str]:
+    path = workspace / "state" / "tenant.json"
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        tid = data.get("id") if isinstance(data, dict) else None
+        if isinstance(tid, str) and TENANT_ID_PATTERN.match(tid):
+            return tid
+        if tid is not None:
+            print(f"[Tenant] state/tenant.json id {tid!r} failed validation; using default")
+    except Exception as e:
+        print(f"[Tenant] failed to read state/tenant.json: {e}")
+    return None
+
+
+def tenant_id(workspace: Optional[Path] = None) -> str:
+    """Resolve the current tenant id. Cached after first call.
+
+    Call `_reset_for_tests()` in tests that switch IDs.
+    """
+    global _cached_tenant_id
+    if _cached_tenant_id is not None:
+        return _cached_tenant_id
+    ws = workspace if workspace is not None else _workspace_dir()
+    env_id = os.environ.get("SUTANDO_TENANT_ID")
+    if env_id and TENANT_ID_PATTERN.match(env_id):
+        _cached_tenant_id = env_id
+        return env_id
+    if env_id:
+        print(f"[Tenant] SUTANDO_TENANT_ID {env_id!r} failed validation; using default")
+    from_state = _read_from_state_file(ws)
+    if from_state:
+        _cached_tenant_id = from_state
+        return from_state
+    _cached_tenant_id = "default"
+    return "default"
+
+
+PathScope = Literal["device", "shared"]
+
+
+def tenant_path(
+    filename: str,
+    scope: PathScope = "shared",
+    workspace: Optional[Path] = None,
+    for_tenant: Optional[str] = None,
+) -> Path:
+    """Per-tenant path resolver. See module docstring for the layout.
+
+    Workspace fallback (mirrors existing personal_path semantics): if
+    SUTANDO_PRIVATE_DIR is unset OR the resolved path doesn't exist,
+    returns `<workspace>/<file>` for single-tenant installs that haven't
+    migrated yet. Callers do `.exists()` checks against the return.
+
+    Returns the FIRST existing path along the priority chain. When nothing
+    exists, returns the *preferred* private-dir path so the caller's
+    `.exists()` check fails gracefully and a subsequent write lands there.
+
+    `for_tenant`: cross-tenant queries pass it explicitly; default uses the
+    current cached tenant id. Keeping both shapes lets a caller read
+    another tenant's data without invalidating their own cache.
+    """
+    ws = workspace if workspace is not None else _workspace_dir()
+    tid = for_tenant if for_tenant is not None else tenant_id(ws)
+    private_root_env = os.environ.get("SUTANDO_PRIVATE_DIR")
+    host = socket.gethostname().split(".")[0]
+
+    if private_root_env:
+        root = Path(os.path.expanduser(private_root_env))
+        tenant_root = root / f"tenant-{tid}"
+        candidate = (
+            tenant_root / f"machine-{host}" / filename
+            if scope == "device"
+            else tenant_root / filename
+        )
+        if candidate.exists():
+            return candidate
+        # Single-tenant pre-migration fallback: an existing install may
+        # still have files at $SUTANDO_PRIVATE_DIR/machine-<host>/<file>
+        # (no tenant-default prefix). Try that path before workspace.
+        if tid == "default":
+            legacy = (
+                root / f"machine-{host}" / filename
+                if scope == "device"
+                else root / filename
+            )
+            if legacy.exists():
+                return legacy
+
+    ws_path = ws / filename
+    if ws_path.exists():
+        return ws_path
+
+    if private_root_env:
+        root = Path(os.path.expanduser(private_root_env))
+        tenant_root = root / f"tenant-{tid}"
+        return (
+            tenant_root / f"machine-{host}" / filename
+            if scope == "device"
+            else tenant_root / filename
+        )
+    return ws_path
+
+
+def _reset_for_tests() -> None:
+    """Test-only: clear the tenant-id cache between tests."""
+    global _cached_tenant_id
+    _cached_tenant_id = None

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -1,96 +1,54 @@
 """Resolve personal-asset paths with private-dir-first lookup.
 
-Each Stand has its own identity + avatar. These files are gitignored and
-machine-local. Canonical home is `$SUTANDO_PRIVATE_DIR/machine-<hostname>/`
-so they live with the rest of the per-machine memory under the private
-sync repo. Public-workspace fallback is preserved so existing installs
-keep working until they migrate.
+As of PR #748+#753 (TypeScript) / this PR (Python), these helpers delegate
+to `tenant_path` (src/tenant.py) which handles the three-level resolution
+(per-tenant / per-device / fleet-shared) plus the single-tenant legacy
+fallback. Single-tenant installs (no SUTANDO_TENANT_ID, no state/tenant.json)
+see no behavior change.
 
-Usage:
-    from util_paths import personal_path
-    si = personal_path("stand-identity.json")
-    avatar = personal_path("stand-avatar.png")  # also tries assets/ in public
+Two public helpers preserved:
+
+    personal_path(filename)        — per-machine state (stand-identity.json,
+                                     pending-questions.md). Maps to
+                                     tenant_path(..., 'device').
+    shared_personal_path(filename) — fleet-shared state (notes, build_log).
+                                     Maps to tenant_path(..., 'shared').
+
+Special case: stand-avatar.png also lives under <workspace>/assets/ in the
+public repo. The avatar fallback is preserved here.
 """
 from __future__ import annotations
-import os
-import socket
 from pathlib import Path
+from typing import Optional
+
+# Local import so the file is usable both as `from util_paths import ...`
+# (the existing convention in src/ scripts) and as `from src.util_paths
+# import ...` from the repo root.
+try:
+    from tenant import tenant_path
+except ImportError:
+    from .tenant import tenant_path  # type: ignore[no-redef]
 
 REPO_DIR = Path(__file__).resolve().parent.parent
 
 
-def _private_machine_dir() -> Path | None:
-    root = os.environ.get("SUTANDO_PRIVATE_DIR")
-    if not root:
-        return None
-    expanded = os.path.expanduser(root)
-    host = socket.gethostname().split(".")[0]
-    return Path(expanded) / f"machine-{host}"
+def personal_path(filename: str, workspace: Optional[Path] = None) -> Path:
+    """Resolve a personal-asset path. Delegates to tenant_path(..., 'device').
 
-
-def personal_path(filename: str, workspace: Path | None = None) -> Path:
-    """Resolve a personal-asset path.
-
-    Order: `$SUTANDO_PRIVATE_DIR/machine-<host>/<filename>` → `<workspace>/<filename>`.
-    For files known to live under `assets/` in the public workspace
-    (currently `stand-avatar.png`), also tries `<workspace>/assets/<filename>`
-    before falling back to `<workspace>/<filename>`.
-
-    Returns the FIRST existing path. If none exist, returns the preferred
-    private-dir path so the caller's `.exists()` check fails gracefully.
+    Avatar fallback: stand-avatar.png ships under assets/ in the public
+    repo. Preserve the special case so a fresh install with no private
+    dir still resolves the asset.
     """
     ws = workspace if workspace is not None else REPO_DIR
 
-    private = _private_machine_dir()
-    if private is not None:
-        p = private / filename
-        if p.exists():
-            return p
+    if filename == "stand-avatar.png":
+        in_assets = ws / "assets" / filename
+        if in_assets.exists():
+            return in_assets
 
-    # Public workspace — assets/ first for avatar-style files, then root
-    if filename in {"stand-avatar.png"}:
-        p = ws / "assets" / filename
-        if p.exists():
-            return p
-
-    p = ws / filename
-    if p.exists():
-        return p
-
-    # Nothing exists; return preferred (private if configured, else workspace)
-    if private is not None:
-        return private / filename
-    if filename in {"stand-avatar.png"}:
-        return ws / "assets" / filename
-    return ws / filename
+    return tenant_path(filename, "device", workspace=ws)
 
 
-def shared_personal_path(filename: str, workspace: Path | None = None) -> Path:
-    """Resolve a shared-private path (notes, build_log, etc.) — files that
-    sync across all of an owner's machines, not per-machine state.
-
-    Order: `$SUTANDO_PRIVATE_DIR/<filename>` (top-level, shared) → `<workspace>/<filename>`.
-
-    Difference vs `personal_path`: this resolves to the top-level private dir,
-    NOT `machine-<host>/`. Use for files like notes/, where every Mac in
-    Chi's fleet should see the same content.
-
-    Returns the FIRST existing path. If none exist, returns the preferred
-    private path so the caller's `.exists()` check fails gracefully.
-    """
-    ws = workspace if workspace is not None else REPO_DIR
-
-    root = os.environ.get("SUTANDO_PRIVATE_DIR")
-    if root:
-        private = Path(os.path.expanduser(root)) / filename
-        if private.exists():
-            return private
-        # Fall back to workspace if private doesn't have it, but remember
-        # the preferred private path for the "nothing exists" branch.
-        p = ws / filename
-        if p.exists():
-            return p
-        return private
-
-    p = ws / filename
-    return p
+def shared_personal_path(filename: str, workspace: Optional[Path] = None) -> Path:
+    """Resolve a shared-private path. Delegates to tenant_path(..., 'shared')."""
+    return tenant_path(filename, "shared", workspace=workspace)

--- a/tests/tenant.test.py
+++ b/tests/tenant.test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Unit tests for src/tenant.py — mirrors tests/tenant.test.ts shape.
+
+Run: python3 tests/tenant.test.py
+"""
+import os
+import sys
+import socket
+import tempfile
+import shutil
+import unittest
+from pathlib import Path
+
+# Make `src/` importable as a flat package (mirrors how scripts under src/
+# already do `from util_paths import ...`).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from tenant import tenant_id, tenant_path, _reset_for_tests  # type: ignore  # noqa: E402
+
+HOST = socket.gethostname().split(".")[0]
+
+
+class TenantIdResolution(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved = {k: os.environ.get(k) for k in ("SUTANDO_TENANT_ID", "SUTANDO_PRIVATE_DIR", "SUTANDO_WORKSPACE")}
+        _reset_for_tests()
+        self.tmp = tempfile.mkdtemp(prefix="sutando-tenant-py-")
+        os.environ.pop("SUTANDO_TENANT_ID", None)
+        os.environ.pop("SUTANDO_PRIVATE_DIR", None)
+        os.environ["SUTANDO_WORKSPACE"] = self.tmp
+
+    def tearDown(self) -> None:
+        for k, v in self.saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        _reset_for_tests()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_default_when_no_env_no_state(self) -> None:
+        self.assertEqual(tenant_id(), "default")
+
+    def test_env_var_when_valid(self) -> None:
+        os.environ["SUTANDO_TENANT_ID"] = "acme"
+        self.assertEqual(tenant_id(), "acme")
+
+    def test_invalid_env_falls_back(self) -> None:
+        os.environ["SUTANDO_TENANT_ID"] = "BAD ID!"
+        self.assertEqual(tenant_id(), "default")
+
+    def test_reads_state_file(self) -> None:
+        state_dir = Path(self.tmp) / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / "tenant.json").write_text('{"id":"beta-tenant"}')
+        self.assertEqual(tenant_id(), "beta-tenant")
+
+    def test_env_wins_over_state(self) -> None:
+        state_dir = Path(self.tmp) / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / "tenant.json").write_text('{"id":"from-file"}')
+        os.environ["SUTANDO_TENANT_ID"] = "from-env"
+        self.assertEqual(tenant_id(), "from-env")
+
+    def test_corrupt_state_falls_back(self) -> None:
+        state_dir = Path(self.tmp) / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / "tenant.json").write_text("not json {{")
+        self.assertEqual(tenant_id(), "default")
+
+    def test_cached_after_first_call(self) -> None:
+        os.environ["SUTANDO_TENANT_ID"] = "first"
+        self.assertEqual(tenant_id(), "first")
+        os.environ["SUTANDO_TENANT_ID"] = "second"
+        self.assertEqual(tenant_id(), "first")
+        _reset_for_tests()
+        self.assertEqual(tenant_id(), "second")
+
+
+class TenantPathResolution(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved = {k: os.environ.get(k) for k in ("SUTANDO_TENANT_ID", "SUTANDO_PRIVATE_DIR", "SUTANDO_WORKSPACE")}
+        _reset_for_tests()
+        self.priv = tempfile.mkdtemp(prefix="sutando-priv-py-")
+        self.ws = tempfile.mkdtemp(prefix="sutando-ws-py-")
+        os.environ["SUTANDO_PRIVATE_DIR"] = self.priv
+        os.environ["SUTANDO_WORKSPACE"] = self.ws
+        os.environ.pop("SUTANDO_TENANT_ID", None)
+
+    def tearDown(self) -> None:
+        for k, v in self.saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        _reset_for_tests()
+        shutil.rmtree(self.priv, ignore_errors=True)
+        shutil.rmtree(self.ws, ignore_errors=True)
+
+    def test_shared_under_tenant_when_present(self) -> None:
+        os.environ["SUTANDO_TENANT_ID"] = "acme"
+        _reset_for_tests()
+        tenant_dir = Path(self.priv) / "tenant-acme"
+        tenant_dir.mkdir(parents=True)
+        (tenant_dir / "build_log.md").write_text("acme log")
+        p = tenant_path("build_log.md", "shared")
+        self.assertEqual(p, tenant_dir / "build_log.md")
+
+    def test_device_under_tenant_machine_when_present(self) -> None:
+        os.environ["SUTANDO_TENANT_ID"] = "acme"
+        _reset_for_tests()
+        machine_dir = Path(self.priv) / "tenant-acme" / f"machine-{HOST}"
+        machine_dir.mkdir(parents=True)
+        (machine_dir / "pending-questions.md").write_text("q")
+        p = tenant_path("pending-questions.md", "device")
+        self.assertEqual(p, machine_dir / "pending-questions.md")
+
+    def test_legacy_fallback_shared(self) -> None:
+        (Path(self.priv) / "notes.md").write_text("legacy notes")
+        p = tenant_path("notes.md", "shared")
+        self.assertEqual(p, Path(self.priv) / "notes.md")
+
+    def test_legacy_fallback_device(self) -> None:
+        legacy = Path(self.priv) / f"machine-{HOST}"
+        legacy.mkdir()
+        (legacy / "stand-identity.json").write_text("{}")
+        p = tenant_path("stand-identity.json", "device")
+        self.assertEqual(p, legacy / "stand-identity.json")
+
+    def test_workspace_fallback(self) -> None:
+        (Path(self.ws) / "README.md").write_text("in workspace")
+        p = tenant_path("README.md", "shared")
+        self.assertEqual(p, Path(self.ws) / "README.md")
+
+    def test_preferred_private_path_on_miss(self) -> None:
+        os.environ["SUTANDO_TENANT_ID"] = "acme"
+        _reset_for_tests()
+        p = tenant_path("does-not-exist.md", "shared")
+        self.assertEqual(p, Path(self.priv) / "tenant-acme" / "does-not-exist.md")
+
+    def test_no_private_dir_returns_workspace(self) -> None:
+        os.environ.pop("SUTANDO_PRIVATE_DIR", None)
+        (Path(self.ws) / "x.md").write_text("x")
+        self.assertEqual(tenant_path("x.md", "shared"), Path(self.ws) / "x.md")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/util_paths.test.py
+++ b/tests/util_paths.test.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Unit tests for src/util_paths.py — mirrors tests/util_paths.test.ts.
+
+Run: python3 tests/util_paths.test.py
+"""
+import os
+import sys
+import socket
+import tempfile
+import shutil
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from util_paths import personal_path, shared_personal_path  # type: ignore  # noqa: E402
+from tenant import _reset_for_tests  # type: ignore  # noqa: E402
+
+HOST = socket.gethostname().split(".")[0]
+
+
+class UtilPathsDelegation(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved = {k: os.environ.get(k) for k in ("SUTANDO_TENANT_ID", "SUTANDO_PRIVATE_DIR", "SUTANDO_WORKSPACE")}
+        _reset_for_tests()
+        self.priv = tempfile.mkdtemp(prefix="sutando-paths-priv-py-")
+        self.ws = tempfile.mkdtemp(prefix="sutando-paths-ws-py-")
+        os.environ["SUTANDO_PRIVATE_DIR"] = self.priv
+        os.environ["SUTANDO_WORKSPACE"] = self.ws
+        os.environ.pop("SUTANDO_TENANT_ID", None)
+
+    def tearDown(self) -> None:
+        for k, v in self.saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        _reset_for_tests()
+        shutil.rmtree(self.priv, ignore_errors=True)
+        shutil.rmtree(self.ws, ignore_errors=True)
+
+    def test_legacy_personal_path(self) -> None:
+        legacy = Path(self.priv) / f"machine-{HOST}"
+        legacy.mkdir()
+        (legacy / "stand-identity.json").write_text("{}")
+        self.assertEqual(
+            personal_path("stand-identity.json"),
+            legacy / "stand-identity.json",
+        )
+
+    def test_legacy_shared_path(self) -> None:
+        (Path(self.priv) / "build_log.md").write_text("log")
+        self.assertEqual(
+            shared_personal_path("build_log.md"),
+            Path(self.priv) / "build_log.md",
+        )
+
+    def test_migrated_personal_path(self) -> None:
+        tenant_machine = Path(self.priv) / "tenant-default" / f"machine-{HOST}"
+        tenant_machine.mkdir(parents=True)
+        (tenant_machine / "stand-identity.json").write_text("{}")
+        self.assertEqual(
+            personal_path("stand-identity.json"),
+            tenant_machine / "stand-identity.json",
+        )
+
+    def test_migrated_shared_path(self) -> None:
+        tenant_dir = Path(self.priv) / "tenant-default"
+        tenant_dir.mkdir()
+        (tenant_dir / "build_log.md").write_text("log")
+        self.assertEqual(
+            shared_personal_path("build_log.md"),
+            tenant_dir / "build_log.md",
+        )
+
+    def test_stand_avatar_assets_fallback(self) -> None:
+        assets = Path(self.ws) / "assets"
+        assets.mkdir()
+        (assets / "stand-avatar.png").write_text("png")
+        self.assertEqual(
+            personal_path("stand-avatar.png", workspace=Path(self.ws)),
+            assets / "stand-avatar.png",
+        )
+
+    def test_workspace_fallback_no_private(self) -> None:
+        os.environ.pop("SUTANDO_PRIVATE_DIR", None)
+        (Path(self.ws) / "config.json").write_text("{}")
+        self.assertEqual(
+            shared_personal_path("config.json", workspace=Path(self.ws)),
+            Path(self.ws) / "config.json",
+        )
+
+    def test_non_default_tenant(self) -> None:
+        os.environ["SUTANDO_TENANT_ID"] = "acme"
+        _reset_for_tests()
+        tenant_machine = Path(self.priv) / "tenant-acme" / f"machine-{HOST}"
+        tenant_machine.mkdir(parents=True)
+        (tenant_machine / "pending-questions.md").write_text("q")
+        self.assertEqual(
+            personal_path("pending-questions.md"),
+            tenant_machine / "pending-questions.md",
+        )
+
+    def test_preferred_write_target_on_miss(self) -> None:
+        p = shared_personal_path("new-file.md")
+        self.assertEqual(p, Path(self.priv) / "tenant-default" / "new-file.md")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Completes the per-tenant identity story on the Python side (deferred from #748 + #753).

**Base:** feat/personal-path-delegate-to-tenant (#753). Depends on #748 + #753 for the TypeScript half.

## What ships
- **src/tenant.py** (~150 LOC) — mirror of src/tenant.ts. Same resolution order, same TENANT_ID_PATTERN, same legacy-pre-migration fallback, same forTenant/for_tenant override for cross-tenant queries.
- **src/util_paths.py** migrated to delegate. personal_path() / shared_personal_path() now thin-wrap tenant_path(filename, scope). Single-tenant installs with no tenant-default/ see zero change.
- **tests/tenant.test.py** — 14 unit tests (7 id-resolution + 7 path-resolution). Mirrors tenant.test.ts shape via Python unittest.
- **tests/util_paths.test.py** — 8 unit tests covering legacy, migrated, multi-tenant, avatar fallback, workspace fallback, preferred-write-target.

## Mirror parity check
| Aspect | TS (#748+#753) | Python (this PR) |
|---|---|---|
| Three-level path model | ✓ | ✓ |
| env > state-file > 'default' precedence | ✓ | ✓ |
| TENANT_ID_PATTERN = ^[a-z0-9][a-z0-9_-]{0,63}$ | ✓ | ✓ |
| Legacy single-tenant fallback | ✓ | ✓ |
| Cross-tenant override (forTenant) | ✓ | ✓ |
| Reset-for-tests cache invalidator | ✓ | ✓ |

## Test plan
- [x] python3 tests/tenant.test.py — 14/14 pass.
- [x] python3 tests/util_paths.test.py — 8/8 pass.
- [x] No TS changes; the stack underneath (tsc + tsx tests from #748+#753) is unaffected.

## Roadmap impact
§5 Next 'Per-tenant identity scaffold': Python side complete. TypeScript and Python now have parity for the tenant-aware path resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)