### PR TITLE
fix(sync-memory,cross-node-sync): source .env from workspace root (closes #714)

### DIFF
--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -29,6 +29,18 @@
 # the private sync clone.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT_PARENT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load .env from the sutando workspace early — non-interactive shells (cron,
+# launchd) don't run user shell startup, so SUTANDO_WORKSPACE / SUTANDO_MEMORY_REPO
+# wouldn't otherwise be visible even when set in .env. Without this the script
+# exits 0 silently with "workspace not found" or "MEMORY_REPO not set" (issue #714).
+if [ -f "$SCRIPT_PARENT/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$SCRIPT_PARENT/.env"
+    set +a
+fi
+
 if [ -n "$SUTANDO_MEMORY_SYNC_DIR" ]; then
     SYNC_DIR="$SUTANDO_MEMORY_SYNC_DIR"
 elif [ "$(basename "$SCRIPT_PARENT")" = ".sutando-memory-sync" ]; then

--- a/skills/cross-node-sync/scripts/setup-rsync-sync.sh
+++ b/skills/cross-node-sync/scripts/setup-rsync-sync.sh
@@ -49,6 +49,16 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 cd "$REPO_ROOT"
 
+# Load .env from the sutando workspace early — non-interactive shells (cron,
+# launchd) don't run user shell startup, so SUTANDO_SYNC_PEER / SUTANDO_PEER_*
+# wouldn't otherwise be visible even when set in .env (same root cause as #714).
+if [ -f "$REPO_ROOT/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$REPO_ROOT/.env"
+    set +a
+fi
+
 # --- Config ------------------------------------------------------------------
 # Peer host: set via SUTANDO_SYNC_PEER env var (e.g. "susan@macbook.local")
 # so the script is portable between Studio and Mini without code changes.


### PR DESCRIPTION
## Summary

Both `scripts/sync-memory.sh` and `skills/cross-node-sync/scripts/setup-rsync-sync.sh` read `SUTANDO_*` env vars from the process environment only. When fired from cron / launchd (no user shell startup), `.env` never gets loaded, so the scripts either exit 0 silently ("workspace not found at ~/Desktop/sutando") or error loudly on a misleading path. This hides regressions for days in cron output.

Fix: source `.env` from the workspace root early, before any `SUTANDO_*` read. Matches the pattern already used in `src/startup.sh` and the bridges.

Closes #714.

## Test plan

- [x] Repro before patch: `env -i bash scripts/sync-memory.sh` → silent exit 0 with \"workspace not found\"
- [x] Repro after patch (with `.env` present): script now loads `SUTANDO_MEMORY_REPO` and proceeds to clone/sync
- [x] Repro before patch: `env -i bash skills/cross-node-sync/scripts/setup-rsync-sync.sh` → \"SUTANDO_SYNC_PEER not set\" exit 1
- [x] Repro after patch (with `.env` setting SUTANDO_SYNC_PEER): script reaches \"Testing SSH to peer...\"
- [ ] @chetanunadkat to verify in his cron environment

The existing line-67 grep fallback for `SUTANDO_MEMORY_REPO` in `sync-memory.sh` is left in place as defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)