### PR TITLE
feat(cross-node-sync): package MEMORY.md regenerator + auto-call after sync (closes #712)

### DIFF
--- a/skills/cross-node-sync/scripts/regenerate-memory-index.py
+++ b/skills/cross-node-sync/scripts/regenerate-memory-index.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Regenerate MEMORY.md from per-file YAML frontmatter in the memory dir.
+
+Index manifests like MEMORY.md cannot use rsync mtime-wins — one side's
+newer-but-shorter listing clobbers the other's longer one (Studio + MBP both
+hit this on 2026-04-17: 74 files on disk, only 19 linked). The fix is to
+exclude MEMORY.md from rsync and regenerate it locally from each entry's
+YAML frontmatter after every sync.
+
+Usage:
+    python3 regenerate-memory-index.py [--memory-dir PATH] [--dry-run]
+
+Memory dir resolution order:
+    1. --memory-dir CLI flag
+    2. $SUTANDO_MEMORY_DIR env var
+    3. ~/.claude/projects/<repo-slug>/memory/  (slug = repo-root absolute
+       path with '/' → '-', matching Claude Code's convention)
+
+Closes #712.
+"""
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+EXCLUDE_FILES = {"MEMORY.md", "INDEX.md", "self_identity.md"}
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+MAX_LINE = 200  # per CLAUDE.md: "Keep index entries to one line under ~200 chars"
+
+
+def default_memory_dir() -> Path:
+    env = os.environ.get("SUTANDO_MEMORY_DIR")
+    if env:
+        return Path(env).expanduser()
+    # Derive from this script's location: <repo>/skills/cross-node-sync/scripts/<this>
+    repo_root = Path(__file__).resolve().parent.parent.parent.parent
+    slug = str(repo_root.resolve()).replace("/", "-")
+    return Path.home() / ".claude" / "projects" / slug / "memory"
+
+
+def parse_frontmatter(text: str) -> dict:
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+    out: dict = {}
+    for line in m.group(1).splitlines():
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+def collect_entries(memdir: Path) -> list:
+    entries = []
+    for p in sorted(memdir.glob("*.md")):
+        if p.name in EXCLUDE_FILES:
+            continue
+        try:
+            text = p.read_text()
+        except Exception as e:
+            print(f"warn: {p.name}: {e}", file=sys.stderr)
+            continue
+        fm = parse_frontmatter(text)
+        name = fm.get("name", p.stem)
+        desc = fm.get("description", "")
+        entries.append((name, p.name, desc))
+    return entries
+
+
+def render(entries: list) -> str:
+    lines = []
+    for name, fname, desc in sorted(entries, key=lambda x: x[0].lower()):
+        prefix = f"- [{name}]({fname}) — "
+        budget = MAX_LINE - len(prefix)
+        if budget < 20:
+            line = prefix + desc[: max(0, budget)]
+        elif len(desc) <= budget:
+            line = prefix + desc
+        else:
+            line = prefix + desc[: budget - 3] + "..."
+        lines.append(line)
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--memory-dir", type=Path, default=default_memory_dir())
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    memdir = args.memory_dir
+    if not memdir.is_dir():
+        # Not an error — first-run / fresh install may not have memory yet.
+        print(f"memory dir not found: {memdir} (skipping regen)", file=sys.stderr)
+        return 0
+
+    entries = collect_entries(memdir)
+    body = render(entries)
+    target = memdir / "MEMORY.md"
+
+    if args.dry_run:
+        print(f"would write {len(entries)} entries to {target}")
+        print(body[:400])
+        return 0
+
+    target.write_text(body)
+    print(f"wrote {len(entries)} entries to {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/cross-node-sync/scripts/setup-rsync-sync.sh
+++ b/skills/cross-node-sync/scripts/setup-rsync-sync.sh
@@ -258,6 +258,21 @@ else
 fi
 
 say ""
+
+# Rebuild MEMORY.md from per-file YAML frontmatter. We exclude MEMORY.md from
+# the rsync pass (mtime-wins truncates the index — see comment near MEM rsync
+# above and issue #712), so each node regenerates its own index after every
+# sync. Falls back to a friendly skip if the memory dir doesn't exist.
+if [ "$DRY_RUN" != "1" ]; then
+    if command -v python3 >/dev/null 2>&1; then
+        say "Regenerating MEMORY.md from frontmatter..."
+        python3 "$REPO_ROOT/skills/cross-node-sync/scripts/regenerate-memory-index.py" \
+            2>&1 | sed 's/^/  /' || say "  (regen failed; MEMORY.md may be stale until next pass)"
+    else
+        say "python3 not on PATH — skipping MEMORY.md regen"
+    fi
+fi
+
 if [ "$DRY_RUN" = "1" ]; then
     say "━━━ DRY-RUN complete ━━━"
 else


### PR DESCRIPTION
## Summary

The skill's `setup-rsync-sync.sh` has excluded `MEMORY.md` from the rsync pass since 2026-04-17 (both Studio and MBP hit the truncate-on-mtime-wins regression: 74 files on disk, only 19 linked in `MEMORY.md` after sync). The comment near the rsync call promised \"regenerate locally from file frontmatter after each sync\", and the cron-prompt in `crons.example.json` told operators to \"Then regenerate MEMORY.md from frontmatter\" — but the regen script lived only in operators' local checkouts (private), never committed.

This PR:

- Adds `skills/cross-node-sync/scripts/regenerate-memory-index.py` — walks `\$SUTANDO_MEMORY_DIR` (or auto-derives from `~/.claude/projects/<slug>/`), parses each `*.md`'s YAML frontmatter, emits `- [name](file) — description` lines sorted alphabetically, truncates each line to ~200 chars per CLAUDE.md. Skips `MEMORY.md` / `INDEX.md` / `self_identity.md` from the index.
- Hooks the regen into `setup-rsync-sync.sh` at the tail, after all rsync legs finish but before the \"Sync complete\" banner. Skipped on `--dry-run`. If `python3` isn't on PATH, prints a friendly note and continues. If the memory dir doesn't exist (first-run / fresh install), the regen exits 0 with a skip message rather than failing the whole sync.

After this lands, operators no longer need to wire a separate cron entry for regen — `setup-rsync-sync.sh` handles the full sync+regen cycle in one call.

Closes #712.

## Test plan

- [x] `regenerate-memory-index.py --dry-run` exits 0 with a skip message when the memory dir doesn't exist
- [x] Default `default_memory_dir()` correctly derives slug from script's repo root (portable across operators)
- [x] CLI flags `--memory-dir PATH` and `--dry-run` work
- [x] `setup-rsync-sync.sh` regen hook only runs in non-dry-run mode
- [x] `setup-rsync-sync.sh` regen hook tolerates missing python3 / missing memory dir gracefully
- [ ] @chetanunadkat to verify after his next sync — should see MEMORY.md auto-regen without the separate cron entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)