### PR TITLE
fix(task-bridge): containment try/catch around result-watcher loop body

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -445,6 +445,18 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 
 	// Check every 2 seconds for new result files
 	setInterval(() => {
+		// Defensive try/catch around the timeout-check loop. Without this,
+		// a single throw during _pendingTasks iteration (corrupt entry,
+		// race with concurrent delete/set, unhandled rejection in a
+		// destructure of `pending`) takes down the visible behavior of
+		// this tick — the readdir block below has its own try/catch, but
+		// the loop above did not. Observed live 2026-05-16: post-restart
+		// voice-agent's result-watcher fell silent (no TaskBridge log
+		// lines across 30+ minutes) while the 30s health monitor's
+		// setInterval kept firing normally — same Node process, same
+		// event loop, so the only differential was an early throw in
+		// this body that propagated past the setInterval callback.
+		try {
 		// Check for timed-out tasks — runs every interval regardless of result files
 		for (const [taskId, pending] of _pendingTasks) {
 			const { submittedAt, timeoutMs, dmOnTimeout } = pending;
@@ -505,6 +517,9 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					}
 				}
 			}
+		}
+		} catch (err) {
+			console.error(`${ts()} [TaskBridge] timeout-check loop threw (non-fatal, continuing watch):`, err);
 		}
 
 		try {
@@ -597,8 +612,14 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					}, 10_000);
 				}
 			}
-		} catch {
-			// Directory might not exist yet or file in transit
+		} catch (err) {
+			// Directory might not exist yet or file in transit. Log on
+			// unusual exceptions (not ENOENT) so a real file-system
+			// problem is observable, while still containing the throw.
+			const code = (err as NodeJS.ErrnoException)?.code;
+			if (code && code !== 'ENOENT') {
+				console.error(`${ts()} [TaskBridge] result-scan threw (non-fatal):`, err);
+			}
 		}
 	}, 2000);
 }


### PR DESCRIPTION
Real bug observed 2026-05-16 in pass 89-90: post-restart voice-agent's 2s result-watcher fell silent across 30+ minutes — no `[TaskBridge]` log entries at all, while the 30s health monitor's setInterval kept firing normally in the same Node process. Health-check tasks + `[no-send]`/`[deduped:]` result files sat unarchived.

## Differential
Only the 2s setInterval body had an unprotected loop (`_pendingTasks` iteration at lines 449-508). The readdir block below was already inside `try { } catch { }`. The 30s health-monitor body is just state-check logging — no unprotected paths.

If anything in the timeout-check loop throws (corrupt `_pendingTasks` entry, race with concurrent `delete()`/`set()`, destructure on an undefined `pending`), the throw propagates past the setInterval callback. Node's behavior on setInterval callback exceptions is implementation-specific; tsx ESM may differ from CJS in handler attachment.

## Fix
1. Wrap the `_pendingTasks` timeout-check loop in try/catch with a non-fatal error log. Same pattern the readdir block uses.
2. Replace the readdir block's bare catch with one that logs on non-ENOENT errors — real fs problems become observable; ENOENT stays silent (RESULT_DIR not yet created on first run is normal).

No behavior change in the happy path. Defensive: if the silent-death hypothesis is right, this is the structural fix. If wrong, the change is harmless.

## Impact
- **User-visible impact of the bug**: bounded. Voice-task delivery to connected web clients uses a different path (session.eventBus injection). Only health-check / cron-originated tasks were affected — they accumulated in `tasks/` until manual archive.
- **Fix impact**: voice-agent restart picks up the fix; the watcher should keep ticking through transient errors rather than going silent.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [ ] After merge + voice-agent restart: `grep TaskBridge ~/Library/Application Support/Sutando/logs/voice-agent.log` shows ongoing 'Result X:' lines as health-check tasks are processed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)