### PR TITLE
feat(sync-memory): default = ~/.sutando/memory-sync/ (+ auto-migration from legacy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ dynamic-content.json
 tests/*
 !tests/*.test.ts
 !tests/*.test.py
+!tests/*.test.sh
 skills/personal-*/
 tests/security/*.md
 !tests/security/*.md.example

--- a/docs/memory-sync.md
+++ b/docs/memory-sync.md
@@ -25,7 +25,7 @@ If you only run Sutando on one machine, you don't need this.
    ```bash
    bash scripts/sync-memory.sh
    ```
-   First run auto-clones to `~/.sutando-memory-sync/` and pushes whatever's locally in `memory/` + `notes/` as the initial commit.
+   First run auto-clones to `~/.sutando/memory-sync/` and pushes whatever's locally in `memory/` + `notes/` as the initial commit.
 
 4. **Add a cron entry** to run every 10–30 minutes:
    ```cron
@@ -38,8 +38,8 @@ Repeat the same steps on every machine in the fleet. All clone the same `SUTANDO
 
 | Source | Synced to | Notes |
 |---|---|---|
-| `~/.claude/projects/<workspace-hash>/memory/*.md` | `~/.sutando-memory-sync/memory/` | Claude Code auto-memory files. Append-only is safest. |
-| `<sutando workspace>/notes/` | `~/.sutando-memory-sync/notes/` | Long-form notes. Symlink pattern recommended (see below). |
+| `~/.claude/projects/<workspace-hash>/memory/*.md` | `~/.sutando/memory-sync/memory/` | Claude Code auto-memory files. Append-only is safest. |
+| `<sutando workspace>/notes/` | `~/.sutando/memory-sync/notes/` | Long-form notes. Symlink pattern recommended (see below). |
 
 ## What does NOT get synced
 
@@ -53,7 +53,7 @@ Concurrent edits from two machines land via `rsync --update --checksum` (mtime-w
 
 - **Prefer append-only files** for shared state (`build_log.md`, `MEMORY.md` index entries).
 - **Avoid simultaneous edits** to the same memory file from two machines.
-- If you hit a conflict, the loser's edit is in the previous commit on `~/.sutando-memory-sync/` — recover via `git log -p memory/the-file.md`.
+- If you hit a conflict, the loser's edit is in the previous commit on `~/.sutando/memory-sync/` — recover via `git log -p memory/the-file.md`.
 
 The script self-heals if the local sync clone gets stuck on a non-`main` branch.
 
@@ -63,15 +63,15 @@ The script self-heals if the local sync clone gets stuck on a non-`main` branch.
 |---|---|---|
 | `SUTANDO_MEMORY_REPO` | (required) | git URL of your private memory repo |
 | `SUTANDO_WORKSPACE` | `~/Desktop/sutando` | path to your sutando working tree |
-| `SUTANDO_MEMORY_SYNC_DIR` | `~/.sutando-memory-sync` | local clone path |
+| `SUTANDO_MEMORY_SYNC_DIR` | `~/.sutando/memory-sync` | local clone path |
 
 ## Optional: notes/ as a symlink
 
-If you want `<workspace>/notes/` and `~/.sutando-memory-sync/notes/` to be the same directory (so editing a note instantly syncs without a round-trip through `cp`), symlink one to the other on every machine:
+If you want `<workspace>/notes/` and `~/.sutando/memory-sync/notes/` to be the same directory (so editing a note instantly syncs without a round-trip through `cp`), symlink one to the other on every machine:
 
 ```bash
 mv ~/Desktop/sutando/notes ~/Desktop/sutando/notes.legacy-backup
-ln -s ~/.sutando-memory-sync/notes ~/Desktop/sutando/notes
+ln -s ~/.sutando/memory-sync/notes ~/Desktop/sutando/notes
 ```
 
 Memory files (`~/.claude/projects/.../memory/`) can't be symlinked the same way because Claude Code creates new files in that directory at runtime; let the script's `cp_if_newer` handle them.
@@ -80,5 +80,5 @@ Memory files (`~/.claude/projects/.../memory/`) can't be symlinked the same way 
 
 - **`sync-memory: SUTANDO_MEMORY_REPO not set in .env, skipping sync.`** — Add the variable to your `.env` per step 2 above.
 - **`Another sync already in progress, exiting.`** — A previous cron tick is still running. The script self-clears stale locks after 10 minutes; if you see this repeatedly, check `/tmp/sync-memory.log` for the previous tick's error.
-- **`sync repo on non-main branch '...'`** — Someone manually `git checkout`-ed a feature branch in `~/.sutando-memory-sync/`. The script auto-recovers by switching back to `main`.
+- **`sync repo on non-main branch '...'`** — Someone manually `git checkout`-ed a feature branch in `~/.sutando/memory-sync/`. The script auto-recovers by switching back to `main`.
 - **Push fails** — Check that your machine has push access to the memory repo (`gh auth status` if you use the GitHub CLI). Read-only clones won't push.

--- a/scripts/stage-readiness.sh
+++ b/scripts/stage-readiness.sh
@@ -175,7 +175,14 @@ if [ -f "$SYNC_HEAD" ]; then
     if [ "$age_h" -lt 6 ]; then
         pass "memory-sync" "last sync ${age_h}h ago"
     elif [ "$age_h" -lt 48 ]; then
-        warn "memory-sync" "last sync ${age_h}h ago — run 'bash ~/.sutando-memory-sync/scripts/sync-memory.sh'"
+        # Show whichever sync-script path exists locally (new default is
+        # ~/.sutando/memory-sync/; legacy ~/.sutando-memory-sync/ still
+        # works until the next sync-memory.sh run auto-migrates).
+        if [ -d "$HOME/.sutando/memory-sync" ]; then
+            warn "memory-sync" "last sync ${age_h}h ago — run 'bash ~/.sutando/memory-sync/scripts/sync-memory.sh'"
+        else
+            warn "memory-sync" "last sync ${age_h}h ago — run 'bash ~/.sutando-memory-sync/scripts/sync-memory.sh'"
+        fi
     else
         fail "memory-sync" "last sync ${age_h}h ago — stale, sync before talk"
     fi

--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -18,15 +18,17 @@
 # Env vars (all optional except SUTANDO_MEMORY_REPO):
 #   SUTANDO_MEMORY_REPO     — git URL of your private memory repo (REQUIRED)
 #   SUTANDO_WORKSPACE       — public sutando checkout. Default: ~/Desktop/sutando
-#   SUTANDO_MEMORY_SYNC_DIR — local clone path. Default: ~/.sutando-memory-sync
+#   SUTANDO_MEMORY_SYNC_DIR — local clone path. Default: ~/.sutando/memory-sync
+#                             (was ~/.sutando-memory-sync before #762's
+#                             companion PR; one-time auto-migration below)
 #
 # Run: bash scripts/sync-memory.sh
 
 # If SUTANDO_MEMORY_SYNC_DIR is not set, try to auto-detect: if the script
-# lives inside an existing ~/.sutando-memory-sync/scripts/ checkout, use
-# that. Otherwise default to ~/.sutando-memory-sync/. This lets the script
-# work both when bundled in the public sutando repo AND when copied into
-# the private sync clone.
+# lives inside an existing memory-sync clone, use that. Otherwise default
+# to ~/.sutando/memory-sync/. The auto-detect handles both the new convention
+# (~/.sutando/memory-sync/) and the legacy convention (~/.sutando-memory-sync/)
+# so a sync clone with this script copied in keeps working through the move.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT_PARENT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -41,12 +43,37 @@ if [ -f "$SCRIPT_PARENT/.env" ]; then
     set +a
 fi
 
+# One-time migration from legacy default (~/.sutando-memory-sync/) to the
+# new convention (~/.sutando/memory-sync/). Triggers only when the env var
+# is unset (user hasn't pinned a path), the legacy dir exists, AND the new
+# default doesn't yet exist — so env-pinned installs and fresh installs
+# both skip this. Idempotent: second run finds the new path populated and
+# the migration becomes a no-op. Per owner directive (2026-05-16): default
+# changes should ship with automatic migration, not just docs telling users
+# to mv manually.
+__OLD_DEFAULT="$HOME/.sutando-memory-sync"
+__NEW_DEFAULT="$HOME/.sutando/memory-sync"
+if [ -z "${SUTANDO_MEMORY_SYNC_DIR:-}" ] && [ -d "$__OLD_DEFAULT" ] && [ ! -e "$__NEW_DEFAULT" ]; then
+    mkdir -p "$(dirname "$__NEW_DEFAULT")"
+    if mv "$__OLD_DEFAULT" "$__NEW_DEFAULT" 2>/dev/null; then
+        echo "sync-memory: migrated $__OLD_DEFAULT -> $__NEW_DEFAULT (one-time)" >&2
+    fi
+fi
+
 if [ -n "$SUTANDO_MEMORY_SYNC_DIR" ]; then
     SYNC_DIR="$SUTANDO_MEMORY_SYNC_DIR"
+elif [ "$(basename "$SCRIPT_PARENT")" = "memory-sync" ] \
+     && [ "$(basename "$(dirname "$SCRIPT_PARENT")")" = ".sutando" ]; then
+    # New convention: script is inside ~/.sutando/memory-sync/scripts/
+    SYNC_DIR="$SCRIPT_PARENT"
 elif [ "$(basename "$SCRIPT_PARENT")" = ".sutando-memory-sync" ]; then
+    # Legacy convention kept for backward compat — auto-migration above
+    # should have moved this case to the new path, but if a user has
+    # SUTANDO_MEMORY_SYNC_DIR pointing somewhere else and the script lives
+    # inside the old layout, still honor it.
     SYNC_DIR="$SCRIPT_PARENT"
 else
-    SYNC_DIR="$HOME/.sutando-memory-sync"
+    SYNC_DIR="$__NEW_DEFAULT"
 fi
 REPO_DIR="${SUTANDO_WORKSPACE:-$HOME/Desktop/sutando}"
 if [ ! -d "$REPO_DIR" ]; then

--- a/tests/sync-memory-migration.test.sh
+++ b/tests/sync-memory-migration.test.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Tests for scripts/sync-memory.sh one-time migration from
+# ~/.sutando-memory-sync to ~/.sutando/memory-sync.
+#
+# Run: bash tests/sync-memory-migration.test.sh
+# Exit: 0 on pass, 1 on fail.
+#
+# Approach: extract the migration block from sync-memory.sh, run it inside a
+# tempdir-rooted fake HOME under three scenarios — legacy present, target
+# already present (collision), env pinned — and assert the resulting tree.
+# Keeps the migration testable without invoking the rest of the script (git
+# clone, push, etc., which require a real remote).
+
+set -u
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/scripts/sync-memory.sh"
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "FAIL: $SCRIPT not found"
+    exit 1
+fi
+
+# Extract just the migration block from sync-memory.sh into a sourceable
+# snippet. We grep between the start sentinel comment and the next blank
+# line after the closing `fi`. Tightly coupled to the block's text but
+# that's the point — a refactor that drops or renames the block trips this
+# extraction and the test fails loudly.
+MIGRATION_BLOCK="$(awk '
+    /^__OLD_DEFAULT="/                  { capture = 1 }
+    capture                              { print }
+    capture && /^fi$/                    { capture = 0; exit }
+' "$SCRIPT")"
+
+if [ -z "$MIGRATION_BLOCK" ]; then
+    echo "FAIL: could not extract migration block from $SCRIPT"
+    echo "      (anchor likely changed — update the awk pattern above)"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+
+run_case() {
+    local name="$1"
+    shift
+    if ( "$@" ); then
+        echo "PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+case_legacy_migrates() {
+    local tmp; tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' RETURN
+    mkdir -p "$tmp/.sutando-memory-sync/memory"
+    echo "preserved content" > "$tmp/.sutando-memory-sync/memory/test.md"
+    HOME="$tmp" unset SUTANDO_MEMORY_SYNC_DIR
+    # Run the extracted block in a subshell with HOME overridden.
+    HOME="$tmp" bash -c "$MIGRATION_BLOCK" >/dev/null 2>&1
+    [ -d "$tmp/.sutando/memory-sync" ] || { echo "  new dir missing"; return 1; }
+    [ ! -d "$tmp/.sutando-memory-sync" ] || { echo "  old dir still present (should have been mv'd)"; return 1; }
+    grep -q "preserved content" "$tmp/.sutando/memory-sync/memory/test.md" || { echo "  content not preserved"; return 1; }
+    return 0
+}
+
+case_env_pin_skips_migration() {
+    local tmp; tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' RETURN
+    mkdir -p "$tmp/.sutando-memory-sync/memory"
+    echo "keep me" > "$tmp/.sutando-memory-sync/memory/test.md"
+    HOME="$tmp" SUTANDO_MEMORY_SYNC_DIR="$tmp/elsewhere" \
+        bash -c "$MIGRATION_BLOCK" >/dev/null 2>&1
+    # Env pin → migration should NOT fire → legacy untouched.
+    [ -d "$tmp/.sutando-memory-sync" ] || { echo "  legacy dir was moved despite env pin"; return 1; }
+    [ ! -d "$tmp/.sutando/memory-sync" ] || { echo "  new dir created despite env pin"; return 1; }
+    grep -q "keep me" "$tmp/.sutando-memory-sync/memory/test.md" || { echo "  legacy content lost"; return 1; }
+    return 0
+}
+
+case_target_exists_skips_migration() {
+    local tmp; tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' RETURN
+    mkdir -p "$tmp/.sutando-memory-sync/memory"
+    echo "legacy" > "$tmp/.sutando-memory-sync/memory/test.md"
+    mkdir -p "$tmp/.sutando/memory-sync"
+    echo "EXISTING" > "$tmp/.sutando/memory-sync/marker.txt"
+    HOME="$tmp" unset SUTANDO_MEMORY_SYNC_DIR
+    HOME="$tmp" bash -c "$MIGRATION_BLOCK" >/dev/null 2>&1
+    # Target already exists → don't clobber → legacy stays put.
+    [ -f "$tmp/.sutando/memory-sync/marker.txt" ] || { echo "  target marker lost"; return 1; }
+    [ -d "$tmp/.sutando-memory-sync" ] || { echo "  legacy moved despite target existing"; return 1; }
+    return 0
+}
+
+case_idempotent_second_run() {
+    local tmp; tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' RETURN
+    mkdir -p "$tmp/.sutando-memory-sync/memory"
+    echo "v1" > "$tmp/.sutando-memory-sync/memory/test.md"
+    HOME="$tmp" unset SUTANDO_MEMORY_SYNC_DIR
+    HOME="$tmp" bash -c "$MIGRATION_BLOCK" >/dev/null 2>&1
+    # Second run — should be a no-op.
+    local out
+    out="$(HOME="$tmp" bash -c "$MIGRATION_BLOCK" 2>&1)"
+    [ -z "$out" ] || { echo "  second run emitted output: $out"; return 1; }
+    [ -d "$tmp/.sutando/memory-sync" ] || { echo "  new dir lost on second run"; return 1; }
+    return 0
+}
+
+case_no_legacy_no_op() {
+    local tmp; tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' RETURN
+    # Fresh install: neither old nor new exists.
+    HOME="$tmp" unset SUTANDO_MEMORY_SYNC_DIR
+    HOME="$tmp" bash -c "$MIGRATION_BLOCK" >/dev/null 2>&1
+    [ ! -d "$tmp/.sutando-memory-sync" ] || { echo "  legacy created from thin air"; return 1; }
+    [ ! -d "$tmp/.sutando/memory-sync" ] || { echo "  new dir created without trigger"; return 1; }
+    return 0
+}
+
+run_case "legacy ~/.sutando-memory-sync migrates to ~/.sutando/memory-sync" case_legacy_migrates
+run_case "SUTANDO_MEMORY_SYNC_DIR env pin skips migration"               case_env_pin_skips_migration
+run_case "target already exists -> no clobber, no migration"             case_target_exists_skips_migration
+run_case "idempotent: second run is silent no-op"                        case_idempotent_second_run
+run_case "fresh install (no legacy) is silent no-op"                     case_no_legacy_no_op
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- Default `SUTANDO_MEMORY_SYNC_DIR` changes from `~/.sutando-memory-sync` → `~/.sutando/memory-sync`. Companion to PR #762 — consolidates all of Sutando's hidden per-user state under one `~/.sutando/` umbrella (one place to find, back up, or nuke).
- **Auto-migration on first run.** Per owner directive: a default change must ship with the migration script, not docs telling users to `mv` manually. Block at the top of `scripts/sync-memory.sh` moves the legacy dir to the new location when (a) `$SUTANDO_MEMORY_SYNC_DIR` is unset, (b) `~/.sutando-memory-sync/` exists, AND (c) `~/.sutando/memory-sync/` doesn't yet. Idempotent + non-destructive on collision + one stderr line per migration.
- Auto-detect for sync-clone copies updated to recognize both layouts (legacy + new) for backward compat.
- Other readers updated: `scripts/stage-readiness.sh` warn hint (now path-aware), `docs/memory-sync.md` (all path references swept).

## Motivation
After PR #762 the workspace lives at `~/.sutando/workspace/`; the memory-sync clone living next door at `~/.sutando-memory-sync/` is a naming inconsistency. Combining them under `~/.sutando/` matches the convention. The migration block makes the change invisible to existing users on the legacy default — first cron-fire after the upgrade silently `mv`s the dir + logs one line.

## Test plan
- [x] `bash tests/sync-memory-migration.test.sh` — 5/5 green:
  - legacy `~/.sutando-memory-sync` migrates to `~/.sutando/memory-sync`
  - env pin (`SUTANDO_MEMORY_SYNC_DIR`) skips migration entirely (legacy untouched)
  - target already exists → no clobber, legacy untouched
  - idempotent: second run is a silent no-op
  - fresh install (no legacy) is a silent no-op

## Out of scope (separate PRs if needed)
- `sutando-resources/skills/ag2qw-executive-coach/scripts/data_dir.py` still references `~/.sutando-memory-sync/state/coach/`. That file lives in the private `sutando-resources/` tree (untracked here) — should track in its own PR by the resources-repo owner.
- `skills/cross-node-sync/scripts/setup-rsync-sync.sh` — review for any path-default drift in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)