### PR TITLE
feat(task-priority): three-tier priority header (urgent/normal/low) + per-source defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,11 @@ source: chat
 channel_id: local-chat
 user_id: ${SUTANDO_DM_OWNER_ID:-chat-local}
 access_tier: owner
+priority: normal
 EOF
 ```
+
+**Priority field**: `urgent` (voice/phone, sub-second latency target) | `normal` (chat/owner DM, default) | `low` (cron, health-check, non-owner DMs). When more than one task is pending, the consumer processes highest-priority first; tie-breaker is mtime FIFO. Defaults per source are encoded in `src/task_priority.py:default_priority_for_source`.
 
 **When done:**
 Write a result file using the same task ID:

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -54,6 +54,7 @@ except ModuleNotFoundError:
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402
 from util_paths import shared_personal_path  # noqa: E402
+from task_priority import default_priority_for_source  # noqa: E402
 REPO = resolve_workspace()
 
 # Vision-frame helper — pushes image attachments into the active voice session
@@ -2549,6 +2550,7 @@ async def _handle_discord_message(message, force=False):
             except Exception as e:
                 print(f"  [auto-react] {react_emoji} failed: {e}", flush=True)
 
+    priority = default_priority_for_source("discord", access_tier)
     task_file.write_text(
         f"id: {task_id}\n"
         f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%S')}Z\n"
@@ -2557,6 +2559,7 @@ async def _handle_discord_message(message, force=False):
         f"channel_id: {message.channel.id}\n"
         f"user_id: {message.author.id}\n"
         f"access_tier: {access_tier}\n"
+        f"priority: {priority}\n"
         f"{tier_instructions.get(access_tier, tier_instructions['other'])}"
     )
     pending_replies[task_id] = message.channel

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -962,6 +962,7 @@ def emit_task_for_failures(checks: list[dict], state_file: Optional[Path] = None
         f"source: health-check\n"
         f"user_id: health-check\n"
         f"access_tier: owner\n"
+        f"priority: low\n"
     )
     task_path = tasks_dir / f"task-health-{int(time.time())}.txt"
     task_path.write_text(body)

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -81,6 +81,7 @@ export function writeChatTask(taskDescription: string): string {
 		`channel_id: local-chat`,
 		`user_id: ${process.env.SUTANDO_DM_OWNER_ID || 'chat-local'}`,
 		`access_tier: owner`,
+		`priority: normal`,
 		'',
 	].join('\n');
 	writeFileSync(join(TASK_DIR, `${taskId}.txt`), content);
@@ -240,7 +241,8 @@ export const workTool: ToolDefinition = {
 			`source: voice\n` +
 			`channel_id: local-voice\n` +
 			`user_id: ${ownerId}\n` +
-			`access_tier: owner\n`;
+			`access_tier: owner\n` +
+			`priority: urgent\n`;
 		writeFileSync(join(TASK_DIR, `${taskId}.txt`), content);
 		// Resolve per-task timeout. 0 → no timeout. Negative or NaN → default.
 		// Cap at 6 hours to prevent runaway pending-state if the voice agent
@@ -384,7 +386,8 @@ export function startContextDropWatcher(onContextDrop: (content: string) => void
 						`source: context-drop\n` +
 						`channel_id: local-hotkey\n` +
 						`user_id: ${ownerId}\n` +
-						`access_tier: owner\n`,
+						`access_tier: owner\n` +
+						`priority: normal\n`,
 					);
 					unlinkSync(CONTEXT_DROP_FILE);
 					// Also inject into Gemini if available

--- a/src/task_priority.py
+++ b/src/task_priority.py
@@ -1,0 +1,86 @@
+"""Task priority taxonomy + readers.
+
+Three-tier enum so writers attach an explicit `priority:` header and consumers
+can decide what to process first when more than one task is pending. Keeps the
+semantics intentionally coarse — finer-grained scheduling lives in a future
+lease-based scheduler; today this is just machine-readable metadata.
+
+Defaults by source (writers emit these; consumers can override per call):
+  voice, phone            -> "urgent"   (sub-second response expected)
+  chat, context-drop      -> "normal"   (owner foreground)
+  discord, telegram (owner-tier)        -> "normal"
+  discord, telegram (team/other-tier)   -> "low"
+  health-check, sync-memory, cron       -> "low"
+
+Anything not recognized parses as "normal" (fail-open). Order on disk:
+"urgent" -> "normal" -> "low" -> unknown -> oldest mtime tiebreak.
+"""
+from __future__ import annotations
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+_ORDER = {"urgent": 0, "normal": 1, "low": 2}
+_VALID = frozenset(_ORDER.keys())
+_DEFAULT = "normal"
+
+
+def is_valid_priority(value: str) -> bool:
+    """True iff `value` is a recognized priority enum string."""
+    return value in _VALID
+
+
+def default_priority_for_source(source: str, access_tier: str | None = None) -> str:
+    """Recommended priority for a given source. Writers should pass the
+    `access_tier` (when known) so non-owner channel tasks demote correctly."""
+    s = (source or "").lower().strip()
+    if s in ("voice", "phone"):
+        return "urgent"
+    if s in ("chat", "context-drop"):
+        return "normal"
+    if s in ("discord", "telegram"):
+        # Owner-tier traffic stays at normal; team/other gets demoted so a
+        # public-channel ping never preempts an owner-DM follow-up.
+        return "normal" if (access_tier or "owner").lower() == "owner" else "low"
+    if s in ("health-check", "sync-memory", "cron"):
+        return "low"
+    return _DEFAULT
+
+
+def parse_priority_from_text(content: str) -> str:
+    """Read the `priority:` header from a task-file body. Returns the
+    recognized enum string, or "normal" if the header is missing/malformed."""
+    for line in content.splitlines():
+        line = line.strip()
+        if line.lower().startswith("priority:"):
+            value = line.split(":", 1)[1].strip().lower()
+            if value in _VALID:
+                return value
+            return _DEFAULT  # malformed -> fail-open to normal
+        if line.startswith("---") or line == "":
+            # End of header block (heuristic) — stop scanning so we don't
+            # match the word "priority" appearing in the task body.
+            break
+    return _DEFAULT
+
+
+def parse_priority_from_file(path: Path) -> str:
+    """Read priority from a task file. Missing file -> "normal" (fail-open)."""
+    try:
+        return parse_priority_from_text(path.read_text(errors="replace"))
+    except (OSError, UnicodeDecodeError):
+        return _DEFAULT
+
+
+def sort_tasks_by_priority(paths: Iterable[Path]) -> List[Path]:
+    """Sort an iterable of task file paths so the highest-priority comes first.
+    Tiebreaker: file mtime ascending (oldest first, FIFO within tier)."""
+    enriched: List[Tuple[int, float, Path]] = []
+    for p in paths:
+        try:
+            mtime = p.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        prio = parse_priority_from_file(p)
+        enriched.append((_ORDER.get(prio, _ORDER[_DEFAULT]), mtime, p))
+    enriched.sort(key=lambda t: (t[0], t[1]))
+    return [p for _, _, p in enriched]

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -23,6 +23,7 @@ try:
 except Exception:  # pragma: no cover — bridge must keep running
     def _push_vision_image(path: str, source: str = "telegram") -> bool:  # type: ignore
         return False
+from task_priority import default_priority_for_source  # noqa: E402
 
 from workspace_default import resolve_workspace  # noqa: E402
 REPO = resolve_workspace()
@@ -351,12 +352,14 @@ def main():
                 ts = int(time.time() * 1000)
                 task_id = f"task-{ts}"
                 task_file = TASKS_DIR / f"{task_id}.txt"
+                priority = default_priority_for_source("telegram", "owner")
                 task_file.write_text(
                     f"id: {task_id}\n"
                     f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%S')}Z\n"
                     f"task: [Telegram @{username}] {text}{attachment_note}\n"
                     f"source: telegram\n"
                     f"chat_id: {chat_id}\n"
+                    f"priority: {priority}\n"
                 )
                 pending_replies[task_id] = chat_id
 

--- a/tests/task-priority.test.py
+++ b/tests/task-priority.test.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests for src/task_priority.py — task priority taxonomy + readers.
+
+Run: python3 tests/task-priority.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from task_priority import (  # noqa: E402
+    default_priority_for_source,
+    is_valid_priority,
+    parse_priority_from_file,
+    parse_priority_from_text,
+    sort_tasks_by_priority,
+)
+
+
+class TestEnumAndDefaults(unittest.TestCase):
+    def test_valid_priority_enum(self):
+        for v in ("urgent", "normal", "low"):
+            self.assertTrue(is_valid_priority(v))
+        for v in ("Urgent", "URGENT", "high", "", "lowest", "1"):
+            self.assertFalse(is_valid_priority(v))
+
+    def test_voice_phone_default_urgent(self):
+        self.assertEqual(default_priority_for_source("voice"), "urgent")
+        self.assertEqual(default_priority_for_source("phone"), "urgent")
+        # Mixed case + whitespace tolerated.
+        self.assertEqual(default_priority_for_source(" Voice "), "urgent")
+
+    def test_chat_context_drop_default_normal(self):
+        self.assertEqual(default_priority_for_source("chat"), "normal")
+        self.assertEqual(default_priority_for_source("context-drop"), "normal")
+
+    def test_discord_owner_tier_normal_other_tier_low(self):
+        self.assertEqual(default_priority_for_source("discord", "owner"), "normal")
+        self.assertEqual(default_priority_for_source("discord", "team"), "low")
+        self.assertEqual(default_priority_for_source("discord", "other"), "low")
+        # Missing access_tier defaults to owner per the helper.
+        self.assertEqual(default_priority_for_source("discord", None), "normal")
+
+    def test_telegram_owner_tier_normal_other_tier_low(self):
+        self.assertEqual(default_priority_for_source("telegram", "owner"), "normal")
+        self.assertEqual(default_priority_for_source("telegram", "team"), "low")
+
+    def test_health_check_and_cron_default_low(self):
+        self.assertEqual(default_priority_for_source("health-check"), "low")
+        self.assertEqual(default_priority_for_source("sync-memory"), "low")
+        self.assertEqual(default_priority_for_source("cron"), "low")
+
+    def test_unknown_source_falls_back_to_normal(self):
+        self.assertEqual(default_priority_for_source("future-channel-x"), "normal")
+        self.assertEqual(default_priority_for_source(""), "normal")
+        self.assertEqual(default_priority_for_source(None), "normal")
+
+
+class TestParsing(unittest.TestCase):
+    def test_parse_priority_from_text_finds_header(self):
+        body = (
+            "id: task-1\n"
+            "timestamp: 2026-05-16T00:00:00Z\n"
+            "task: do something\n"
+            "source: voice\n"
+            "priority: urgent\n"
+        )
+        self.assertEqual(parse_priority_from_text(body), "urgent")
+
+    def test_parse_priority_missing_returns_normal(self):
+        body = "id: task-1\nsource: chat\n"
+        self.assertEqual(parse_priority_from_text(body), "normal")
+
+    def test_parse_priority_malformed_value_returns_normal(self):
+        body = "id: task-1\npriority: super-urgent\n"
+        self.assertEqual(parse_priority_from_text(body), "normal")
+
+    def test_parse_priority_case_insensitive_value(self):
+        body = "id: task-1\npriority: URGENT\n"
+        self.assertEqual(parse_priority_from_text(body), "urgent")
+
+    def test_parse_priority_stops_at_blank_line(self):
+        # Body text containing "priority:" after a blank line MUST be ignored.
+        body = (
+            "id: task-1\n"
+            "task: short\n"
+            "\n"
+            "...somewhere in the body it mentions priority: urgent...\n"
+        )
+        # No priority header in the header block — falls back to normal.
+        self.assertEqual(parse_priority_from_text(body), "normal")
+
+
+class TestSorting(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="task-pri-"))
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, name: str, priority: str | None, mtime_offset: float = 0):
+        p = self.tmp / name
+        if priority is None:
+            p.write_text("id: x\ntask: y\n")
+        else:
+            p.write_text(f"id: x\npriority: {priority}\ntask: y\n")
+        if mtime_offset:
+            now = time.time() + mtime_offset
+            os.utime(p, (now, now))
+        return p
+
+    def test_urgent_before_normal_before_low(self):
+        low = self._write("a-low.txt", "low")
+        urgent = self._write("b-urgent.txt", "urgent")
+        normal = self._write("c-normal.txt", "normal")
+        out = sort_tasks_by_priority([low, urgent, normal])
+        self.assertEqual([p.name for p in out], ["b-urgent.txt", "c-normal.txt", "a-low.txt"])
+
+    def test_missing_priority_treated_as_normal(self):
+        no_pri = self._write("a-no-prio.txt", None)
+        urgent = self._write("b-urgent.txt", "urgent")
+        low = self._write("c-low.txt", "low")
+        out = sort_tasks_by_priority([no_pri, urgent, low])
+        # urgent first, then no-prio (== normal), then low
+        self.assertEqual([p.name for p in out], ["b-urgent.txt", "a-no-prio.txt", "c-low.txt"])
+
+    def test_tiebreak_by_mtime_within_same_priority(self):
+        # Both urgent — older mtime should come first (FIFO within tier).
+        new_one = self._write("newer.txt", "urgent", mtime_offset=+10)
+        old_one = self._write("older.txt", "urgent", mtime_offset=-10)
+        out = sort_tasks_by_priority([new_one, old_one])
+        self.assertEqual([p.name for p in out], ["older.txt", "newer.txt"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Adds a `priority:` header (`urgent` | `normal` | `low`) to every task file written by Sutando bridges + health-check.
- New shared module `src/task_priority.py`: enum, per-source defaults, parser, sort helper.
- All 4 current writers emit the field with the right default — voice/phone → urgent, chat/owner DM → normal, non-owner DM and cron/health → low.

## Motivation
Today's single-consumer file bridge processes tasks in fswatch arrival order (≈ FIFO by mtime). A 5-min research task blocks an urgent "what's on my calendar?" voice question behind it whenever the queue has more than one entry. Priority gives the consumer a cheap, unambiguous way to pick the right one first — and it's the foundation the upcoming lease-based multi-core scheduler will consume without another schema change.

The taxonomy is intentionally coarse (3 tiers, not 5+): coarse is enough to separate urgent foreground from deferrable background, and avoids debates about whether a Discord owner DM should be tier 3 or tier 4.

## Behavior changes
- Every new task file now carries `priority: <enum>`.
- Consumers that don't read the header are unaffected (FIFO still works as before).
- Consumers that DO read the header (via `parse_priority_from_file()` / `sort_tasks_by_priority()`) get a deterministic order: urgent → normal → low → mtime tiebreak.
- Current Claude Code session-as-consumer continues to process one task at a time via Monitor notifications — full benefit lands when multi-task pickup logic ships or the lease scheduler arrives.

## Test plan
- [x] `python3 tests/task-priority.test.py` — 15 cases, all green:
  - Enum validation (valid + invalid forms)
  - Per-source defaults for voice/phone/chat/context-drop/discord/telegram/health-check/sync-memory/cron/unknown
  - Owner vs team tier demotion for discord/telegram
  - Parser: case-insensitive value, malformed falls back to normal, header parser stops at blank line (body text can't smuggle "priority: urgent" through)
  - Sort: urgent < normal < low, missing priority = normal, mtime tiebreak within same tier
- [x] Existing discord-bridge / telegram-bridge tests still pass
- [x] `tsc --noEmit` clean

## Out of scope (follow-up issues to file)
- **Priority interviewer skill** (per @qingyun-wu ask 2026-05-16): proactively ask the user which task to prioritize when several are competing; fall back to these defaults if the user doesn't respond. Owns the user-in-the-loop layer on top of this static taxonomy.
- **Lease-based multi-core scheduler**: consumes the priority header during `claim_next()`. Design doc first.
- **Consumer-side sort enforcement**: the proactive-loop skill (in `~/.claude/skills/proactive-loop/`) could explicitly sort by priority in step 1 ("Check for tasks") — small docs change, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)