### PR TITLE
feat(core-heartbeat): per-host alive signal at state/cores/<hostname>.alive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,25 @@ EOF
 
 This ensures the dashboard, result-watcher, and timeout logic work the same regardless of entry path.
 
+## Core liveness signal
+
+Each running sutando-core writes `<workspace>/state/cores/<hostname>.alive`
+every 30 seconds (started by `src/startup.sh` as a background process; source
+at `src/core_heartbeat.py`). The file is per-host so multiple cores on
+different machines coexist; mtime is the cross-host "is this core alive?"
+signal (younger than ~90s → alive). On SIGTERM/SIGINT the .alive file is
+unlinked so peers see a graceful shutdown immediately.
+
+Payload schema:
+```json
+{"host": "...", "pid": ..., "started_at": ..., "last_beat_at": ..., "status": "...", "schema_version": 1}
+```
+
+This is foundation for the lease-based multi-core scheduler — workers consult
+the alive directory to know who's available before assigning a claim. For
+single-machine use today it also gives `health-check.py` and the dashboard a
+cleaner liveness probe than scanning `pgrep -f claude`.
+
 ## Memory
 
 Full memory index: $SUTANDO_MEMORY_DIR (default: ~/.claude/projects/.../memory)/MEMORY.md

--- a/src/core_heartbeat.py
+++ b/src/core_heartbeat.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Per-host heartbeat for sutando-core sessions.
+
+Writes a small JSON file at `<workspace>/state/cores/<hostname>.alive` every
+30 seconds while running. The file's content reports the core's pid, host,
+start time, last beat, and a free-form status string; the file's mtime is
+the cross-host "is this core still up?" signal.
+
+Why
+---
+Today's "is the core alive?" check reads `core-status.json` at the workspace
+root — a single file written by the proactive-loop each pass. That's fine
+for a single-machine install: one core, one status. The moment we want
+multi-core (multiple Claude Code sessions sharing a workspace, or sutando
+running on both Mac Studio + MacBook against a synced workspace), one file
+can no longer represent N processes.
+
+Per-host file at `state/cores/<hostname>.alive`:
+  • Each running core writes only its own file (no contention).
+  • Any process can read the directory to see who's alive across the fleet.
+  • mtime is the authoritative liveness signal (younger than ~90s = alive).
+  • Future lease-based scheduler consumes this to know who can pick up work.
+
+This script is intentionally tiny and standalone — startup.sh launches it as
+a background process. SIGTERM/SIGINT clean up the .alive file so a graceful
+shutdown is visible immediately (vs. waiting for mtime-staleness timeout).
+
+Usage:
+  python3 src/core_heartbeat.py                  # default 30s interval
+  python3 src/core_heartbeat.py --interval 10    # for tests
+  python3 src/core_heartbeat.py --status busy    # set the status string
+
+Runs forever until killed. Exit codes:
+  0 — clean shutdown (SIGTERM/SIGINT received)
+  Other — fatal write error (unrecoverable; supervisor should restart)
+"""
+from __future__ import annotations
+import argparse
+import json
+import os
+import signal
+import socket
+import sys
+import time
+from pathlib import Path
+
+# Resolve workspace path with the same precedence as the rest of Sutando.
+# Inlined (not imported) so this script can run before any other Sutando
+# module is loaded — keeps the heartbeat dep-free.
+_workspace_env = os.environ.get("SUTANDO_WORKSPACE", "").strip()
+if _workspace_env:
+    WORKSPACE = Path(_workspace_env).expanduser()
+else:
+    WORKSPACE = Path.home() / ".sutando" / "workspace"
+
+CORES_DIR = WORKSPACE / "state" / "cores"
+
+
+def _hostname() -> str:
+    """Short hostname without domain. Mirrors what sync-memory.sh uses for
+    machine-<host>/ dirs, so the .alive file is recognizable across the
+    fleet's other state files."""
+    return socket.gethostname().split(".")[0]
+
+
+def _alive_path() -> Path:
+    return CORES_DIR / f"{_hostname()}.alive"
+
+
+def write_beat(status: str = "running") -> None:
+    """Write one heartbeat record. Atomic-via-tmp-then-rename so a concurrent
+    reader never sees a partial file."""
+    CORES_DIR.mkdir(parents=True, exist_ok=True)
+    target = _alive_path()
+    payload = {
+        "host": _hostname(),
+        "pid": os.getpid(),
+        "started_at": _STARTED_AT,
+        "last_beat_at": time.time(),
+        "status": status,
+        "schema_version": 1,
+    }
+    tmp = target.with_suffix(".alive.tmp")
+    tmp.write_text(json.dumps(payload, indent=2))
+    tmp.replace(target)
+
+
+_STARTED_AT: float = time.time()
+_SHUTDOWN_REQUESTED = False
+
+
+def _handle_signal(signum: int, frame) -> None:
+    """Mark shutdown so the loop exits at the top of the next sleep; also
+    unlink the .alive file so peers see this core leave immediately rather
+    than wait for mtime staleness."""
+    global _SHUTDOWN_REQUESTED
+    _SHUTDOWN_REQUESTED = True
+    try:
+        _alive_path().unlink(missing_ok=True)
+    except Exception:  # pragma: no cover — best-effort cleanup
+        pass
+
+
+def run_forever(interval: float = 30.0, status: str = "running") -> int:
+    """Heartbeat loop. Returns the exit code (0 on graceful shutdown)."""
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+    while not _SHUTDOWN_REQUESTED:
+        try:
+            write_beat(status=status)
+        except Exception as e:
+            # Don't die on transient FS hiccups — log + retry next tick.
+            print(f"core_heartbeat: write failed: {e}", file=sys.stderr, flush=True)
+        # Sleep in small slices so SIGTERM is responsive (signal handler
+        # sets the flag; we check it between slices instead of blocking
+        # for the full `interval`).
+        slept = 0.0
+        slice_s = min(1.0, interval)
+        while slept < interval and not _SHUTDOWN_REQUESTED:
+            time.sleep(slice_s)
+            slept += slice_s
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--interval", type=float, default=30.0, help="seconds between beats (default: 30)")
+    p.add_argument("--status", type=str, default="running", help="status string written into the .alive file")
+    p.add_argument("--once", action="store_true", help="write a single beat and exit (for tests/debugging)")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.once:
+        write_beat(status=args.status)
+        return 0
+    return run_forever(interval=args.interval, status=args.status)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -131,6 +131,17 @@ mkdir -p tasks results data
 # notes/post-mortem-dm-flood-2026-04-15.md.
 python3 "$REPO/src/archive-stale-results.py" || true
 
+# Core heartbeat — per-host alive signal under state/cores/<hostname>.alive.
+# Foundation for multi-core / cross-machine "who's running?" checks. Single
+# instance per host; gracefully cleans up its .alive file on SIGTERM.
+if ! pgrep -f "src/core_heartbeat.py" > /dev/null 2>&1; then
+  echo "  Starting core heartbeat..."
+  python3 "$REPO/src/core_heartbeat.py" > /tmp/core-heartbeat.log 2>&1 &
+  echo "  ✓ core heartbeat"
+else
+  echo "  ✓ core heartbeat (already running)"
+fi
+
 # 0. Credential proxy for quota tracking (port 7846)
 if ! lsof -i :7846 > /dev/null 2>&1; then
   echo "  Starting credential proxy (port 7846)..."

--- a/tests/core-heartbeat.test.py
+++ b/tests/core-heartbeat.test.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests for src/core_heartbeat.py — per-host liveness signal.
+
+Run: python3 tests/core-heartbeat.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _short_host() -> str:
+    return socket.gethostname().split(".")[0]
+
+
+class TestHeartbeatWrite(unittest.TestCase):
+    def setUp(self):
+        self._saved_env = os.environ.get("SUTANDO_WORKSPACE")
+        self.tmp = Path(tempfile.mkdtemp(prefix="core-heartbeat-"))
+        os.environ["SUTANDO_WORKSPACE"] = str(self.tmp)
+        # Force re-import so module picks up the new env.
+        sys.modules.pop("core_heartbeat", None)
+
+    def tearDown(self):
+        if self._saved_env is not None:
+            os.environ["SUTANDO_WORKSPACE"] = self._saved_env
+        elif "SUTANDO_WORKSPACE" in os.environ:
+            del os.environ["SUTANDO_WORKSPACE"]
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        sys.modules.pop("core_heartbeat", None)
+
+    def test_write_beat_creates_per_host_file(self):
+        import core_heartbeat
+        core_heartbeat.write_beat()
+        alive_path = self.tmp / "state" / "cores" / f"{_short_host()}.alive"
+        self.assertTrue(alive_path.is_file(), f"expected {alive_path} to exist")
+
+    def test_write_beat_payload_schema(self):
+        import core_heartbeat
+        core_heartbeat.write_beat(status="custom-status")
+        data = json.loads((self.tmp / "state" / "cores" / f"{_short_host()}.alive").read_text())
+        # Required fields
+        self.assertEqual(data["host"], _short_host())
+        self.assertEqual(data["pid"], os.getpid())
+        self.assertEqual(data["status"], "custom-status")
+        self.assertEqual(data["schema_version"], 1)
+        self.assertIsInstance(data["started_at"], float)
+        self.assertIsInstance(data["last_beat_at"], float)
+        # last_beat_at advances after a sleep; just sanity-check it's recent.
+        self.assertLess(abs(time.time() - data["last_beat_at"]), 5)
+
+    def test_write_beat_is_atomic_via_tmp(self):
+        """The .alive write goes through .alive.tmp then renames into place —
+        a concurrent reader at the destination path never sees a half-file."""
+        import core_heartbeat
+        core_heartbeat.write_beat()
+        alive = self.tmp / "state" / "cores" / f"{_short_host()}.alive"
+        tmp = self.tmp / "state" / "cores" / f"{_short_host()}.alive.tmp"
+        self.assertTrue(alive.exists())
+        self.assertFalse(tmp.exists(), "tmp file should have been renamed away")
+
+    def test_write_beat_overwrites_on_second_call(self):
+        import core_heartbeat
+        core_heartbeat.write_beat(status="first")
+        path = self.tmp / "state" / "cores" / f"{_short_host()}.alive"
+        first_data = json.loads(path.read_text())
+        time.sleep(0.01)
+        core_heartbeat.write_beat(status="second")
+        second_data = json.loads(path.read_text())
+        self.assertEqual(second_data["status"], "second")
+        # started_at should NOT change — it's set at module import.
+        self.assertEqual(first_data["started_at"], second_data["started_at"])
+        # last_beat_at should advance.
+        self.assertGreater(second_data["last_beat_at"], first_data["last_beat_at"])
+
+    def test_write_beat_creates_cores_dir(self):
+        """The cores/ dir must be created if it doesn't yet exist — fresh
+        install case."""
+        import core_heartbeat
+        cores_dir = self.tmp / "state" / "cores"
+        self.assertFalse(cores_dir.exists())
+        core_heartbeat.write_beat()
+        self.assertTrue(cores_dir.is_dir())
+
+
+class TestHeartbeatCli(unittest.TestCase):
+    """End-to-end tests that exercise the script via subprocess so the CLI
+    parsing, signal handling, and cleanup paths are covered."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="core-heartbeat-cli-"))
+        self.env = {**os.environ, "SUTANDO_WORKSPACE": str(self.tmp)}
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_once_flag_writes_single_beat_and_exits(self):
+        script = ROOT / "src" / "core_heartbeat.py"
+        result = subprocess.run(
+            [sys.executable, str(script), "--once", "--status", "smoke"],
+            env=self.env, capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+        alive = self.tmp / "state" / "cores" / f"{_short_host()}.alive"
+        self.assertTrue(alive.is_file())
+        data = json.loads(alive.read_text())
+        self.assertEqual(data["status"], "smoke")
+
+    def test_sigterm_cleans_up_alive_file(self):
+        """Graceful shutdown removes the .alive file so peers see the core
+        leave immediately rather than wait for mtime staleness."""
+        import signal as _signal
+        script = ROOT / "src" / "core_heartbeat.py"
+        proc = subprocess.Popen(
+            [sys.executable, str(script), "--interval", "0.5"],
+            env=self.env,
+        )
+        # Wait for first beat to land.
+        alive = self.tmp / "state" / "cores" / f"{_short_host()}.alive"
+        for _ in range(40):
+            if alive.exists():
+                break
+            time.sleep(0.1)
+        self.assertTrue(alive.exists(), "first beat should have landed within 4s")
+        # Signal graceful shutdown.
+        proc.send_signal(_signal.SIGTERM)
+        proc.wait(timeout=5)
+        self.assertFalse(alive.exists(), ".alive should have been unlinked on SIGTERM")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- New `src/core_heartbeat.py` writes JSON to `<workspace>/state/cores/<hostname>.alive` every 30s.
- Launched by `src/startup.sh` as a background process; cleans up the .alive file on SIGTERM/SIGINT.
- Foundation for the lease-based multi-core scheduler — workers will consult the alive directory before claim_next().

## Why per-host (not the existing core-status.json)
`core-status.json` is one file at the workspace root, written by the proactive loop each pass. Fine for a single core; can't represent N processes when we run multi-core on the same Mac or sutando on both Mac Studio + MacBook against a synced workspace. Per-host file = each core writes only its own (no contention) + directory listing answers "who's alive across the fleet?" in one read.

## Payload
```json
{"host": "...", "pid": 1234, "started_at": 1778947000.0, "last_beat_at": 1778947030.0, "status": "running", "schema_version": 1}
```

- `last_beat_at` advances each beat; file mtime is the authoritative liveness signal (younger than ~90s → alive).
- Atomic-via-tmp-then-rename so concurrent readers never see a partial file.

## Consumer side
**Nothing reads it in this PR** — by design. Ship the signal first; follow-up PRs add consumers incrementally without coupling. Concrete next steps:
- `health-check.py` reads the cores/ dir to display fleet liveness
- Dashboard renders "active cores" panel
- Lease scheduler consults before claim_next()
- `sync-memory.sh` opts state/cores/ into cross-machine sync so the fleet is visible from any node

## Test plan
- [x] `python3 tests/core-heartbeat.test.py` — 7/7 green:
  - per-host file created (host = `socket.gethostname().split('.')[0]`)
  - payload schema present + types
  - atomic write (no .tmp left behind after rename)
  - repeat calls overwrite; started_at stable, last_beat_at advances
  - cores/ dir auto-created on first write
  - CLI `--once` writes and exits 0
  - SIGTERM unlinks the .alive file before exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)