### PR TITLE
feat(workspace): notes/ honors SUTANDO_WORKSPACE + auto-migration for in-repo stragglers

### DIFF
--- a/skills/cross-node-sync/scripts/list-sync-files.sh
+++ b/skills/cross-node-sync/scripts/list-sync-files.sh
@@ -24,7 +24,13 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 
 MEM_DIR="$HOME/.claude/projects/-Users-xueqingliu-Documents-sutando-sutando/memory"
-NOTES_DIR="$REPO_ROOT/notes"
+# Notes lives under $SUTANDO_WORKSPACE per the workspace contract (CLAUDE.md
+# "Workspace contract"); fall back to $REPO_ROOT for pre-contract installs.
+if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+    NOTES_DIR="$SUTANDO_WORKSPACE/notes"
+else
+    NOTES_DIR="$REPO_ROOT/notes"
+fi
 ASSETS_DIR="$REPO_ROOT/assets"
 
 list_dir() {

--- a/skills/cross-node-sync/scripts/setup-rsync-sync.sh
+++ b/skills/cross-node-sync/scripts/setup-rsync-sync.sh
@@ -72,8 +72,15 @@ PEER="${SUTANDO_SYNC_PEER:-}"
 # /Users/xliu/Documents/xqq/.../sutando-agent-sonichi-test2/sutando).
 # Override with SUTANDO_MEM_LOCAL_DIR if the convention changes.
 MEM_LOCAL="${SUTANDO_MEM_LOCAL_DIR:-$HOME/.claude/projects/$(echo "$REPO_ROOT" | tr '/' '-')/memory/}"
-NOTES_LOCAL="$REPO_ROOT/notes/"
-DATA_LOCAL="$REPO_ROOT/data/"
+# Notes + data live under $SUTANDO_WORKSPACE per the workspace contract (CLAUDE.md
+# "Workspace contract"); fall back to $REPO_ROOT for pre-contract installs.
+if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+	NOTES_LOCAL="$SUTANDO_WORKSPACE/notes/"
+	DATA_LOCAL="$SUTANDO_WORKSPACE/data/"
+else
+	NOTES_LOCAL="$REPO_ROOT/notes/"
+	DATA_LOCAL="$REPO_ROOT/data/"
+fi
 ASSETS_LOCAL="$REPO_ROOT/assets/"
 
 # Peer-side paths — default to the same literal paths as local so users only

--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -41,6 +41,11 @@ mkdir -p "$OUT"
 # "Workspace contract" section). Falls back to $REPO/notes if env unset, matching
 # the historic pre-workspace-contract behavior. Same precedence as
 # `src/workspace_default.py:resolve_workspace()` for Python callers.
+# TODO(post-2026-08-15): drop the $REPO/notes fallback once all known
+# installs are confirmed on the workspace contract. Tracked via Lucy's
+# #769 review obs 4. Dual-path was added so pre-#762 installs don't
+# silently lose cold-review-log access; safe to remove after every node
+# has resolved its workspace at least once.
 if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
 	NOTES_DIR="$SUTANDO_WORKSPACE/notes"
 else

--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -37,6 +37,16 @@ TS="$(date +%s)"
 OUT="/tmp/sutando-diagnose-$TS"
 mkdir -p "$OUT"
 
+# Notes dir lives under $SUTANDO_WORKSPACE per the workspace contract (CLAUDE.md
+# "Workspace contract" section). Falls back to $REPO/notes if env unset, matching
+# the historic pre-workspace-contract behavior. Same precedence as
+# `src/workspace_default.py:resolve_workspace()` for Python callers.
+if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+	NOTES_DIR="$SUTANDO_WORKSPACE/notes"
+else
+	NOTES_DIR="$REPO/notes"
+fi
+
 # Convert window to seconds for log filtering
 case "$WINDOW" in
 	*h) SECONDS_AGO=$((${WINDOW%h} * 3600)) ;;
@@ -83,7 +93,7 @@ fi
 # 3) Build log tail + pending questions + cold-review log (small files, copy whole)
 tail -150 "$REPO/build_log.md" > "$OUT/build_log-tail.md" 2>/dev/null || true
 cp "$REPO/pending-questions.md" "$OUT/pending-questions.md" 2>/dev/null || true
-cp "$REPO/notes/cold-review-log.md" "$OUT/cold-review-log.md" 2>/dev/null || true
+cp "$NOTES_DIR/cold-review-log.md" "$OUT/cold-review-log.md" 2>/dev/null || true
 
 # 4) Voice-agent log — filter to window, grep for signal lines, keep it bounded.
 # Signals: transport closes (1006/1011/1007/1008), errors, GoAway, setup complete, 1006/1011 numeric.

--- a/src/workspace_default.py
+++ b/src/workspace_default.py
@@ -21,9 +21,15 @@ from pathlib import Path
 
 
 _DEFAULT_SUBPATH = (".sutando", "workspace")
-_LEGACY_DIRS = ("tasks", "results", "state")  # the runtime-state dirs that, if found
-                                              # in a legacy fallback location, signal an
-                                              # in-use older install we should migrate.
+_LEGACY_DIRS = ("tasks", "results", "state", "notes")  # the runtime-state dirs that, if
+                                                       # found in a legacy fallback location,
+                                                       # signal an in-use older install we
+                                                       # should migrate. `notes` joined the
+                                                       # list 2026-05-16; in-repo→workspace
+                                                       # migration for env-set installs is
+                                                       # handled by `_migrate_inrepo_notes`
+                                                       # below (different trigger condition
+                                                       # — see its docstring).
 
 
 def default_workspace_dir() -> Path:
@@ -92,6 +98,70 @@ def _migrate_from_legacy(target: Path) -> bool:
     return bool(moved)
 
 
+def _migrate_inrepo_notes(workspace: Path) -> bool:
+    """One-time migration of `<repo>/notes/*` -> `<workspace>/notes/` when env-set
+    workspaces have stragglers in the in-repo location.
+
+    Different trigger than `_migrate_from_legacy`: that one fires only when
+    `$SUTANDO_WORKSPACE` is UNSET (legacy install upgrading to the new default).
+    THIS one fires when the env IS set, BUT the in-repo `notes/` dir (which
+    code used to write to before the workspace contract) still contains files
+    that aren't under `<workspace>/notes/`. The trigger condition is
+    "workspace and in-repo location are different, AND in-repo has notes."
+
+    Symmetric to `_migrate_from_legacy`'s posture: non-destructive on collision
+    (skip the file if it already exists at the workspace location), logs each
+    moved file to stderr, idempotent (second run finds in-repo empty and
+    bails).
+
+    Per owner directive 2026-05-16: every design change must ship with an
+    automatic migration script so existing users don't have to migrate
+    manually. This is the migration for the notes-location change.
+
+    Returns True iff at least one file was migrated.
+    """
+    repo_root = _legacy_repo_root()
+    # If workspace IS the repo root, there's nothing to migrate (both names
+    # resolve to the same dir). Owner's case: workspace = <repo>/workspace/,
+    # different from repo root, migration applies.
+    try:
+        if repo_root.resolve() == workspace.resolve():
+            return False
+    except OSError:
+        return False
+    inrepo_notes = repo_root / "notes"
+    if not inrepo_notes.is_dir():
+        return False
+    # Only operate on regular md/txt files at the top level of in-repo notes/.
+    # Subdirectories (e.g. `notes/media/`) and the historic memory-sync symlink
+    # convention are left alone — they may have their own semantics this
+    # migration shouldn't touch.
+    candidates = [p for p in inrepo_notes.iterdir()
+                  if p.is_file() and p.suffix in (".md", ".txt")]
+    if not candidates:
+        return False
+    target_notes = workspace / "notes"
+    target_notes.mkdir(parents=True, exist_ok=True)
+    moved = []
+    for src in candidates:
+        dst = target_notes / src.name
+        if dst.exists():
+            continue  # don't clobber an existing file at the workspace location
+        try:
+            shutil.move(str(src), str(dst))
+            moved.append(src.name)
+        except Exception as e:  # pragma: no cover — best-effort
+            print(f"notes migration: failed to move {src} -> {dst}: {e}", file=sys.stderr)
+    if moved:
+        print(
+            f"notes migration: moved {len(moved)} file(s) from {inrepo_notes} "
+            f"to {target_notes} (one-time: {', '.join(moved[:5])}"
+            f"{', …' if len(moved) > 5 else ''})",
+            file=sys.stderr,
+        )
+    return bool(moved)
+
+
 def resolve_workspace(migrate: bool = True) -> Path:
     """Resolve the workspace directory per the canonical contract.
 
@@ -99,17 +169,28 @@ def resolve_workspace(migrate: bool = True) -> Path:
       1. `$SUTANDO_WORKSPACE` env var, expanded (`~` honored).
       2. `~/.sutando/workspace/`.
 
-    When `migrate=True` (default) AND the env is unset AND the new default
-    doesn't yet exist, also performs one-time auto-migration of runtime-state
-    dirs from the legacy repo-root fallback. See `_migrate_from_legacy` for
-    the exact conditions.
+    When `migrate=True` (default) the function ALSO runs two one-time
+    auto-migrations:
+      • `_migrate_from_legacy` — fires when env is unset and the new default
+        doesn't yet exist; pulls tasks/results/state/notes from the legacy
+        repo-root fallback.
+      • `_migrate_inrepo_notes` — fires when env IS set and workspace != repo
+        root; pulls top-level notes/*.md|*.txt from the in-repo `notes/` dir
+        into `<workspace>/notes/`. Covers users who set $SUTANDO_WORKSPACE
+        mid-stream while code was still writing to in-repo `notes/`.
 
     Returns a `Path` — does NOT create the directory; the caller decides.
     Pass `migrate=False` from tests that want pure resolution semantics.
     """
     env = os.environ.get("SUTANDO_WORKSPACE", "").strip()
     if env:
-        return Path(env).expanduser()
+        target = Path(env).expanduser()
+        if migrate:
+            try:
+                _migrate_inrepo_notes(target)
+            except Exception as e:  # pragma: no cover — must never break resolution
+                print(f"notes migration: skipped due to error: {e}", file=sys.stderr)
+        return target
     target = default_workspace_dir()
     if migrate:
         try:

--- a/src/workspace_default.py
+++ b/src/workspace_default.py
@@ -109,10 +109,20 @@ def _migrate_inrepo_notes(workspace: Path) -> bool:
     that aren't under `<workspace>/notes/`. The trigger condition is
     "workspace and in-repo location are different, AND in-repo has notes."
 
+    Scope: top-level `.md`/`.txt` files only. Subdirectories (e.g.
+    `notes/projects/`, `notes/media/`) are intentionally NOT migrated —
+    workspace notes are flat by current convention. If/when nested notes
+    become supported, this migrator grows a `recursive=True` flag rather
+    than silently changing posture. Owner's notes layout (2026-05-16) is
+    flat; this matches.
+
     Symmetric to `_migrate_from_legacy`'s posture: non-destructive on collision
     (skip the file if it already exists at the workspace location), logs each
     moved file to stderr, idempotent (second run finds in-repo empty and
-    bails).
+    bails). Also writes a sentinel (`<workspace>/.notes-migrated`) after a
+    successful run so subsequent `resolve_workspace()` calls short-circuit
+    on the cheap stat-check rather than re-running iterdir; per Lucy's #769
+    review obs 2.
 
     Per owner directive 2026-05-16: every design change must ship with an
     automatic migration script so existing users don't have to migrate
@@ -120,6 +130,12 @@ def _migrate_inrepo_notes(workspace: Path) -> bool:
 
     Returns True iff at least one file was migrated.
     """
+    # Sentinel-file short-circuit: after a previous successful migration we
+    # leave a marker so this function exits in O(1) instead of O(directory
+    # listing) on every bridge restart. Per Lucy's #769 review obs 2.
+    sentinel = workspace / ".notes-migrated"
+    if sentinel.exists():
+        return False
     repo_root = _legacy_repo_root()
     # If workspace IS the repo root, there's nothing to migrate (both names
     # resolve to the same dir). Owner's case: workspace = <repo>/workspace/,
@@ -133,12 +149,20 @@ def _migrate_inrepo_notes(workspace: Path) -> bool:
     if not inrepo_notes.is_dir():
         return False
     # Only operate on regular md/txt files at the top level of in-repo notes/.
-    # Subdirectories (e.g. `notes/media/`) and the historic memory-sync symlink
-    # convention are left alone — they may have their own semantics this
-    # migration shouldn't touch.
+    # Subdirectories (e.g. `notes/media/`, `notes/projects/`) and the historic
+    # memory-sync symlink convention are left alone — they may have their own
+    # semantics this migration shouldn't touch. See function docstring on
+    # the flat-notes convention.
     candidates = [p for p in inrepo_notes.iterdir()
                   if p.is_file() and p.suffix in (".md", ".txt")]
     if not candidates:
+        # No top-level notes to migrate — drop the sentinel anyway so we
+        # don't iterdir again on next call (Lucy obs 2). Cheap touch.
+        try:
+            workspace.mkdir(parents=True, exist_ok=True)
+            sentinel.touch()
+        except Exception:
+            pass  # sentinel is an optimization, never fatal
         return False
     target_notes = workspace / "notes"
     target_notes.mkdir(parents=True, exist_ok=True)
@@ -159,6 +183,13 @@ def _migrate_inrepo_notes(workspace: Path) -> bool:
             f"{', …' if len(moved) > 5 else ''})",
             file=sys.stderr,
         )
+    # Drop the sentinel so subsequent calls short-circuit on the cheap exists()
+    # check (Lucy's #769 obs 2). Best-effort; if the touch fails we'll just
+    # iterdir() again next call — correctness unaffected.
+    try:
+        sentinel.touch()
+    except Exception:
+        pass
     return bool(moved)
 
 

--- a/tests/workspace-default.test.py
+++ b/tests/workspace-default.test.py
@@ -156,16 +156,116 @@ class TestMigrationFromLegacy(unittest.TestCase):
         self.assertTrue(moved_1)
         self.assertFalse(moved_2)  # second run finds target populated, bails
 
-    def test_resolve_workspace_skips_migration_when_env_set(self):
-        """When SUTANDO_WORKSPACE is set, migrate=True still skips the legacy
-        path entirely (env-pinned users opt out of any auto-mv)."""
+    def test_resolve_workspace_skips_legacy_migration_when_env_set(self):
+        """When SUTANDO_WORKSPACE is set, the LEGACY migration (tasks/results/state)
+        is skipped. The notes in-repo migration runs independently — see the
+        separate test class for that."""
         self._seed_legacy_runtime()
         os.environ["SUTANDO_WORKSPACE"] = str(self.target)
         with patch.object(workspace_default, "_legacy_repo_root", return_value=self.legacy):
             ws = resolve_workspace(migrate=True)
         self.assertEqual(ws, self.target)
-        # Legacy state should be UNTOUCHED — env pin bypasses migration.
+        # Legacy state should be UNTOUCHED — env pin bypasses _migrate_from_legacy.
         self.assertTrue((self.legacy / "tasks" / "task-1.txt").exists())
+
+
+class TestInRepoNotesMigration(unittest.TestCase):
+    """Tests for `_migrate_inrepo_notes` — the env-set migration that catches
+    stragglers in `<repo>/notes/` after the workspace contract moved canonical
+    notes to `<workspace>/notes/`.
+
+    Different trigger than `_migrate_from_legacy`: that one is for env-UNSET
+    legacy installs. This one is for env-SET installs whose code was writing
+    to in-repo notes/ until the path-fix PR landed."""
+
+    def setUp(self):
+        self._saved_env = os.environ.get("SUTANDO_WORKSPACE")
+        self.repo_root = Path(tempfile.mkdtemp(prefix="ws-repo-"))
+        self.workspace = Path(tempfile.mkdtemp(prefix="ws-target-"))
+        # Provide env-set workspace pointing at our fixture.
+        os.environ["SUTANDO_WORKSPACE"] = str(self.workspace)
+
+    def tearDown(self):
+        if self._saved_env is not None:
+            os.environ["SUTANDO_WORKSPACE"] = self._saved_env
+        elif "SUTANDO_WORKSPACE" in os.environ:
+            del os.environ["SUTANDO_WORKSPACE"]
+        shutil.rmtree(self.repo_root, ignore_errors=True)
+        shutil.rmtree(self.workspace, ignore_errors=True)
+
+    def _seed_inrepo_notes(self, *names):
+        (self.repo_root / "notes").mkdir(parents=True, exist_ok=True)
+        for name in names:
+            (self.repo_root / "notes" / name).write_text(f"content of {name}")
+
+    def test_inrepo_notes_migrate_when_workspace_differs(self):
+        self._seed_inrepo_notes("a.md", "b.md")
+        with patch.object(workspace_default, "_legacy_repo_root", return_value=self.repo_root):
+            moved = workspace_default._migrate_inrepo_notes(self.workspace)
+        self.assertTrue(moved)
+        self.assertTrue((self.workspace / "notes" / "a.md").is_file())
+        self.assertTrue((self.workspace / "notes" / "b.md").is_file())
+        # Source side should be drained.
+        self.assertFalse((self.repo_root / "notes" / "a.md").exists())
+        self.assertFalse((self.repo_root / "notes" / "b.md").exists())
+
+    def test_inrepo_notes_skip_when_repo_equals_workspace(self):
+        # If workspace IS the repo root, the function bails (no infinite mv).
+        self._seed_inrepo_notes("x.md")
+        with patch.object(workspace_default, "_legacy_repo_root", return_value=self.repo_root):
+            moved = workspace_default._migrate_inrepo_notes(self.repo_root)
+        self.assertFalse(moved)
+        # File should still be where it was.
+        self.assertTrue((self.repo_root / "notes" / "x.md").exists())
+
+    def test_inrepo_notes_skip_when_inrepo_notes_missing(self):
+        # Fresh checkout — no in-repo notes/ dir.
+        with patch.object(workspace_default, "_legacy_repo_root", return_value=self.repo_root):
+            moved = workspace_default._migrate_inrepo_notes(self.workspace)
+        self.assertFalse(moved)
+
+    def test_inrepo_notes_no_clobber_on_collision(self):
+        self._seed_inrepo_notes("clash.md")
+        (self.workspace / "notes").mkdir(parents=True)
+        (self.workspace / "notes" / "clash.md").write_text("WORKSPACE WINS")
+        with patch.object(workspace_default, "_legacy_repo_root", return_value=self.repo_root):
+            workspace_default._migrate_inrepo_notes(self.workspace)
+        # Workspace file untouched, in-repo file still present (skipped, not moved).
+        self.assertEqual((self.workspace / "notes" / "clash.md").read_text(), "WORKSPACE WINS")
+        self.assertTrue((self.repo_root / "notes" / "clash.md").exists())
+
+    def test_inrepo_notes_ignores_subdirs_and_non_text(self):
+        # Subdir and unusual extension — both left alone.
+        (self.repo_root / "notes" / "media").mkdir(parents=True)
+        (self.repo_root / "notes" / "media" / "video.mp4").write_text("dummy")
+        (self.repo_root / "notes" / "scratch.bin").write_text("opaque")
+        self._seed_inrepo_notes("real-note.md")
+        with patch.object(workspace_default, "_legacy_repo_root", return_value=self.repo_root):
+            workspace_default._migrate_inrepo_notes(self.workspace)
+        # Only the .md was moved.
+        self.assertTrue((self.workspace / "notes" / "real-note.md").exists())
+        self.assertFalse((self.workspace / "notes" / "scratch.bin").exists())
+        self.assertFalse((self.workspace / "notes" / "video.mp4").exists())
+        self.assertTrue((self.repo_root / "notes" / "media" / "video.mp4").exists())
+        self.assertTrue((self.repo_root / "notes" / "scratch.bin").exists())
+
+    def test_inrepo_notes_idempotent(self):
+        self._seed_inrepo_notes("once.md")
+        with patch.object(workspace_default, "_legacy_repo_root", return_value=self.repo_root):
+            moved_1 = workspace_default._migrate_inrepo_notes(self.workspace)
+            moved_2 = workspace_default._migrate_inrepo_notes(self.workspace)
+        self.assertTrue(moved_1)
+        self.assertFalse(moved_2)  # second run finds in-repo notes/ empty (file moved)
+
+    def test_resolve_workspace_runs_inrepo_notes_migration_when_env_set(self):
+        # End-to-end: resolve_workspace called with env-set workspace, in-repo
+        # has notes, migration runs on the way through.
+        self._seed_inrepo_notes("e2e.md")
+        with patch.object(workspace_default, "_legacy_repo_root", return_value=self.repo_root):
+            ws = resolve_workspace(migrate=True)
+        self.assertEqual(ws, self.workspace)
+        self.assertTrue((self.workspace / "notes" / "e2e.md").exists())
+        self.assertFalse((self.repo_root / "notes" / "e2e.md").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Closes the workspace-vs-repo path drift for `notes/` that PR #762's first cut missed (it only covered `tasks/results/state`). Per @qingyun-wu's directive 2026-05-16 — every design change ships with an automatic migration script, no manual mv instructions.

**Stacks on #762.** Base branch is `feat/workspace-default-app-support-subdir`; merge after #762.

## Code-side path fix (3 shell scripts)
- `skills/self-diagnose/scripts/gather.sh` — `cold-review-log.md` read now resolves via `$SUTANDO_WORKSPACE/notes/`, falls back to `$REPO/notes/` for pre-contract installs.
- `skills/cross-node-sync/scripts/setup-rsync-sync.sh` — `NOTES_LOCAL` + `DATA_LOCAL` honor `$SUTANDO_WORKSPACE`.
- `skills/cross-node-sync/scripts/list-sync-files.sh` — same pattern.

All three preserve pre-contract behavior when env is unset.

## Auto-migration (two scenarios)

| Scenario | Trigger | Function |
|---|---|---|
| Env UNSET, legacy fallback has notes | `$SUTANDO_WORKSPACE` unset AND new default doesn't exist AND legacy repo-root has runtime evidence | `_migrate_from_legacy` (already in #762; `notes` joins `_LEGACY_DIRS`) |
| Env SET, in-repo stragglers | `$SUTANDO_WORKSPACE` set AND workspace ≠ repo-root AND `<repo>/notes/` has .md/.txt files | **NEW** `_migrate_inrepo_notes` |

The second scenario is @qingyun-wu's own case: env set mid-session, but code was still writing to `<repo>/notes/` until this PR landed. Next time anything calls `resolve_workspace()` (bridge restart, helper import), the migration fires automatically. No manual mv.

Non-destructive on collision (skip if `<workspace>/notes/<name>` already exists), idempotent (second run finds in-repo empty), ignores subdirs + non-text files (media/, scratch.bin, etc. left alone).

## Test plan
- [x] `python3 tests/workspace-default.test.py` — 19/19 green:
  - 7 new tests for `_migrate_inrepo_notes`:
    - migrates when workspace ≠ repo
    - bails when workspace == repo (avoid self-loop)
    - bails when in-repo notes/ missing
    - non-destructive on collision
    - ignores subdirs + non-md/txt files
    - idempotent on second run
    - end-to-end `resolve_workspace()` runs migration when env set
  - 12 existing tests still green
- [x] All 3 shell scripts pass `bash -n` syntax check
- [x] Python syntax check on `workspace_default.py`

## Out of scope (follow-ups)
- Other `notes/` references found in audit but lower-impact: `scripts/probe-team-sandbox.sh` (comment only), `scripts/poc-codeql-path-injection.sh` (URL paths not filesystem), `skills/macos-tools/scripts/calendar-reader.py` ("notes" field name unrelated to dir).
- TS twin of the migration (mentioned in #763 follow-up); this PR is Python-side only since the Python helper is what all bridges actually call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)