### PR TITLE
docs(CLAUDE.md): drop dead memory-file refs, point at MEMORY.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,9 @@ Full memory index: $SUTANDO_MEMORY_DIR (default: ~/.claude/projects/.../memory)/
 
 Key files:
 - User profile: $SUTANDO_MEMORY_DIR (default: ~/.claude/projects/.../memory)/user_profile.md
-- Feedback (response style): $SUTANDO_MEMORY_DIR (default: ~/.claude/projects/.../memory)/feedback_response_style.md
-- Feedback (operating principle): $SUTANDO_MEMORY_DIR (default: ~/.claude/projects/.../memory)/feedback_minimal_cost_max_value.md
 - Build log (what's built, what's next): build_log.md
+
+`MEMORY.md` is the source of truth for available memory files — read it first to discover the current set (feedback, project, reference entries). Hardcoded paths here drift; MEMORY.md doesn't.
 
 Read relevant memory files when user preferences or history would improve task quality. Write new memory when you learn something durable about the user or the project.
 


### PR DESCRIPTION
## Summary
- `feedback_response_style.md` and `feedback_minimal_cost_max_value.md` were listed under \`## Memory\` > \`Key files\` but neither file exists in \`~/.claude/projects/.../memory/\`. Actual files: \`user_profile.md\`, \`feedback_task_logging.md\`, \`feedback_design_quality.md\`, \`feedback_note_timestamps.md\`, \`project_open_closed_commercialization_line.md\`, \`reference_discord_channels.md\` (all indexed in \`MEMORY.md\`).
- Replaced the two stale lines with a one-sentence pointer at \`MEMORY.md\` as the canonical source of truth. Hardcoded path lists drift as memory files come and go; MEMORY.md is auto-loaded into every conversation and doesn't.
- 2 lines net, no behavior change.

## Test plan
- [ ] \`grep feedback_response_style CLAUDE.md\` → no matches
- [ ] \`grep feedback_minimal_cost CLAUDE.md\` → no matches
- [ ] \`## Memory\` section still surfaces user_profile + build_log as the two persistent anchors

(Drift was first noticed in build_log 2026-05-15 17:46 — deferred then, fixed now.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)