### PR TITLE
docs(workspace-contract): migration-first for existing-repo installs (#762 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,23 +52,25 @@ The default deliberately avoids `~/Library/Application Support/sutando/` — tha
 - Python: `from workspace_default import resolve_workspace` → returns a `Path`.
 - TypeScript: `process.env.SUTANDO_WORKSPACE || join(homedir(), '.sutando', 'workspace')`.
 
-### Existing-repo installs MUST pin `SUTANDO_WORKSPACE`
+### Existing-repo installs: trigger the migration (or pin `SUTANDO_WORKSPACE` as stop-gap)
 
-If your loop / cron / scripts run from `<repo>/` itself (the historic default before #762) and you do NOT explicitly set `SUTANDO_WORKSPACE`, you will hit a silent **path divergence**:
+If your loop / cron / scripts polled `<repo>/tasks/` directly before #762 (and any component — Python or TS — that hardcoded the repo path via `Path(__file__).parent.parent` or `new URL('..', import.meta.url)` is still doing so), you'll see a silent **path divergence**:
 
 - The bridge (and any caller of `resolve_workspace()`) writes new tasks to the canonical default `~/.sutando/workspace/tasks/`.
-- The proactive-loop session and any non-Python component polling `tasks/` via a relative path keep reading `<repo>/tasks/`.
+- Any component still reading from `<repo>/tasks/` via a relative path won't see them.
 - Result: new tasks never reach the loop. Observed 2026-05-16 — 7 owner DMs orphaned over 19 minutes before the divergence was caught.
 
-**Fix for existing installs:** put one line in `.env` at the repo root:
+**Preferred fix:** restart the bridge and sutando-app. The migration code from #762 (`_migrate_from_legacy`) auto-moves `<repo>/{tasks,results,state}` → `~/.sutando/workspace/{tasks,results,state}` on first new-default run. After migration, both sides agree on the canonical default and no env var is needed.
+
+**Stop-gap (if migration won't run):** pin `SUTANDO_WORKSPACE` in `.env` at the repo root and restart the bridges:
 
 ```bash
 SUTANDO_WORKSPACE=/full/path/to/your/repo
 ```
 
-After setting, restart the discord/telegram bridges so they re-read the env. Everything then writes and reads from the same `<repo>/tasks/` and `<repo>/results/` — no symlinks needed.
+**Caveat:** this revives the git-status-pollution antipattern that #762 was designed to escape (every `tasks/`, `results/`, `state/` write shows up in `git status`). Use sparingly; prefer the migration when possible.
 
-**Fresh installs** can skip this — the `~/.sutando/workspace/` default works because nothing else polls the repo path.
+**Fresh installs** can skip this entirely — the `~/.sutando/workspace/` default works because nothing else polls the repo path.
 
 ## Personal overrides
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,24 @@ The default deliberately avoids `~/Library/Application Support/sutando/` — tha
 - Python: `from workspace_default import resolve_workspace` → returns a `Path`.
 - TypeScript: `process.env.SUTANDO_WORKSPACE || join(homedir(), '.sutando', 'workspace')`.
 
+### Existing-repo installs MUST pin `SUTANDO_WORKSPACE`
+
+If your loop / cron / scripts run from `<repo>/` itself (the historic default before #762) and you do NOT explicitly set `SUTANDO_WORKSPACE`, you will hit a silent **path divergence**:
+
+- The bridge (and any caller of `resolve_workspace()`) writes new tasks to the canonical default `~/.sutando/workspace/tasks/`.
+- The proactive-loop session and any non-Python component polling `tasks/` via a relative path keep reading `<repo>/tasks/`.
+- Result: new tasks never reach the loop. Observed 2026-05-16 — 7 owner DMs orphaned over 19 minutes before the divergence was caught.
+
+**Fix for existing installs:** put one line in `.env` at the repo root:
+
+```bash
+SUTANDO_WORKSPACE=/full/path/to/your/repo
+```
+
+After setting, restart the discord/telegram bridges so they re-read the env. Everything then writes and reads from the same `<repo>/tasks/` and `<repo>/results/` — no symlinks needed.
+
+**Fresh installs** can skip this — the `~/.sutando/workspace/` default works because nothing else polls the repo path.
+
 ## Personal overrides
 
 If `PERSONAL_CLAUDE.md` exists in the workspace root, read and follow it. It contains user-specific rules, preferences, and configuration that override or extend these shared instructions.


### PR DESCRIPTION
## Summary

Documents a silent path-divergence trap downstream of #762 that bit my proactive-loop node today (2026-05-16) and orphaned 7 owner DMs across 19 minutes.

**Symptom:** Discord bridge writes new task files to `~/.sutando/workspace/tasks/` (post-#762 canonical), but the proactive-loop session — which polls `tasks/*.txt` via a cwd-relative glob in shell — keeps reading `<repo>/tasks/`. Both components are "right" against their own contract, but they read/write different dirs. Silent divergence.

**Root cause is NOT a `workspace_default.py` bug.** The contract is correct and every Python caller of `resolve_workspace()` agrees on one path. The gap is contract-adoption for non-Python callers (shell loops, relative-path globs, `ls tasks/*.txt`-style polling) that historically operated relative to `<repo>/` and were not updated when the canonical default moved.

## What this PR adds

One section in CLAUDE.md's `## Workspace contract`, immediately after the resolution rules:

```
### Existing-repo installs: trigger the migration (or pin `SUTANDO_WORKSPACE` as stop-gap)
```

States the divergence symptom, points existing-repo installs at #762's `_migrate_from_legacy` (preferred — restart the bridge + sutando-app, auto-moves `tasks/`, `results/`, `state/` to the new canonical default), and gives env-pin (`SUTANDO_WORKSPACE=<repo>` in `.env`) as a stop-gap with the antipattern caveat (revives git-status pollution). Fresh installs unaffected.

## Why docs-only

Smallest fix that closes the gap for the affected user class today, without code-side reverts or risky migration changes. The follow-ups (PR description's footer) are real but bigger commits:

- `skills/proactive-loop/SKILL.md` still uses relative `tasks/` phrasing; could be tightened to `$SUTANDO_WORKSPACE/tasks/`.
- `workspace_default.py` could emit a warning when it detects `<repo>/tasks/` has runtime evidence AND `$SUTANDO_WORKSPACE` is unset AND the new canonical default exists (would have surfaced today's case loudly instead of silently).

Repro of the bug (single shell script):

```bash
mkdir -p $HOME/.sutando/workspace/tasks
echo 'task: hi' > $HOME/.sutando/workspace/tasks/task-001.txt  # bridge writes here post-#762
cd /tmp/repo && mkdir -p tasks                                  # loop's cwd
ls tasks/*.txt                                                   # → no match (orphan)
export SUTANDO_WORKSPACE=$HOME/.sutando/workspace
ls \$SUTANDO_WORKSPACE/tasks/*.txt                                # → found ✓
```

## Test plan

- [x] CLAUDE.md renders cleanly (markdown).
- [x] Verified locally: adding `SUTANDO_WORKSPACE=<repo>` to `.env` + restarting bridge eliminates the divergence (no symlinks needed).
- [x] Verified workaround for installs not yet updating `.env`: symlink `~/.sutando/workspace/{tasks,results} → <repo>/{tasks,results}` also works as a stop-gap.

— Lucy (Mac Studio bot, on Susan's ask)
