### PR TITLE
fix(workspace): writer-side workspace-aware patch for task-bridge.ts + agent-api.py + github-webhook.py (#774 sibling)

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -82,14 +82,19 @@ def validate_twilio_signature(handler, body: str) -> bool:
     return hmac.compare_digest(expected, signature)
 
 
-REPO_DIR = Path(__file__).parent.parent
+# Workspace resolver — see src/workspace_default.py. SUTANDO_WORKSPACE env
+# (if set) wins; otherwise falls back to ~/.sutando/workspace/. Keeps task/
+# result writes aligned with the watcher and other workspace-aware bridges.
+sys.path.insert(0, str(Path(__file__).parent))
+from workspace_default import resolve_workspace  # noqa: E402
+
+REPO_DIR = resolve_workspace()
 TASK_DIR = REPO_DIR / "tasks"
 PORT = 7843
 
 # Personal-asset path resolver — see src/util_paths.py. Imported here so the
 # /avatar and /stand-identity endpoints prefer the per-machine private dir
 # over the public workspace.
-sys.path.insert(0, str(Path(__file__).parent))
 from util_paths import personal_path  # noqa: E402
 
 # Simple token auth — set SUTANDO_API_TOKEN in .env for remote access security

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -82,14 +82,20 @@ def validate_twilio_signature(handler, body: str) -> bool:
     return hmac.compare_digest(expected, signature)
 
 
-# Workspace resolver — see src/workspace_default.py. SUTANDO_WORKSPACE env
-# (if set) wins; otherwise falls back to ~/.sutando/workspace/. Keeps task/
-# result writes aligned with the watcher and other workspace-aware bridges.
+# Two separate concerns (per qingyun review on PR #775):
+# - REPO_DIR  = source tree (this file's parent.parent) — for reading source
+#               files like src/health-check.py, running `git -C` against the
+#               checkout, loading .env, etc. Stays anchored to the checkout.
+# - WORKSPACE_DIR = runtime state (resolve_workspace()) — for tasks/, results/,
+#               core-status.json, pending-questions.md, contextual-chips.json,
+#               etc. Honors SUTANDO_WORKSPACE when set so watcher + bridges
+#               stay aligned with these writes.
+REPO_DIR = Path(__file__).parent.parent
 sys.path.insert(0, str(Path(__file__).parent))
 from workspace_default import resolve_workspace  # noqa: E402
 
-REPO_DIR = resolve_workspace()
-TASK_DIR = REPO_DIR / "tasks"
+WORKSPACE_DIR = resolve_workspace()
+TASK_DIR = WORKSPACE_DIR / "tasks"
 PORT = 7843
 
 # Personal-asset path resolver — see src/util_paths.py. Imported here so the
@@ -100,7 +106,7 @@ from util_paths import personal_path  # noqa: E402
 # Simple token auth — set SUTANDO_API_TOKEN in .env for remote access security
 API_TOKEN = os.environ.get("SUTANDO_API_TOKEN", "")
 
-RESULT_DIR = REPO_DIR / "results"
+RESULT_DIR = WORKSPACE_DIR / "results"
 TASK_DIR.mkdir(exist_ok=True)
 RESULT_DIR.mkdir(exist_ok=True)
 
@@ -277,7 +283,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.send_json(200, {"pong": True})
         elif path == "/core-status":
             # Read loop status file for web UI
-            status_file = REPO_DIR / "core-status.json"
+            status_file = WORKSPACE_DIR / "core-status.json"
             if status_file.exists():
                 import json as _json
                 try:
@@ -361,7 +367,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             tasks = [{"id": tid, **tdata} for tid, tdata in sorted_tasks]
             # Parse pending questions
             questions = []
-            pq_file = Path(personal_path("pending-questions.md", REPO_DIR))
+            pq_file = Path(personal_path("pending-questions.md", WORKSPACE_DIR))
             if pq_file.exists():
                 import re
                 content = pq_file.read_text()
@@ -397,7 +403,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             else:
                 self.send_json(404, {"error": "task not found"})
         elif path == "/avatar":
-            avatar_file = personal_path("stand-avatar.png", workspace=REPO_DIR)
+            avatar_file = personal_path("stand-avatar.png", workspace=WORKSPACE_DIR)
             if avatar_file.exists():
                 self.send_response(200)
                 self.send_header("Content-Type", "image/png")
@@ -408,7 +414,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             else:
                 self.send_json(404, {"error": "no avatar"})
         elif path == "/stand-identity":
-            si_file = personal_path("stand-identity.json", workspace=REPO_DIR)
+            si_file = personal_path("stand-identity.json", workspace=WORKSPACE_DIR)
             data = json.loads(si_file.read_text()) if si_file.exists() else {}
             self.send_json(200, data)
         elif path == "/activity":
@@ -427,7 +433,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 pass
             # Recent results
             try:
-                results_dir = REPO_DIR / "results"
+                results_dir = WORKSPACE_DIR / "results"
                 result_files = sorted(results_dir.glob("task-*.txt"), key=lambda p: p.stat().st_mtime, reverse=True)[:5]
                 for f in result_files:
                     content = f.read_text()[:200]
@@ -436,7 +442,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 pass
             self.send_json(200, {"activity": activity})
         elif path == "/contextual-chips":
-            chips_file = REPO_DIR / "contextual-chips.json"
+            chips_file = WORKSPACE_DIR / "contextual-chips.json"
             if chips_file.exists():
                 try:
                     data = json.loads(chips_file.read_text())
@@ -446,7 +452,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             else:
                 self.send_json(200, {"chips": []})
         elif path == "/dynamic-content":
-            dc_file = REPO_DIR / "dynamic-content.json"
+            dc_file = WORKSPACE_DIR / "dynamic-content.json"
             if dc_file.exists():
                 try:
                     data = json.loads(dc_file.read_text())
@@ -472,7 +478,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             if not safe_parts:
                 self.send_json(400, {"error": "invalid path"})
                 return
-            repo_resolved = REPO_DIR.resolve()
+            repo_resolved = WORKSPACE_DIR.resolve()  # /media/ serves from workspace (results/, data/, notes/)
             media_path = repo_resolved.joinpath(*safe_parts).resolve()
             if not media_path.is_relative_to(repo_resolved) or not media_path.is_file():
                 self.send_json(404, {"error": "not found"})
@@ -501,7 +507,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             # original src/ path here predated that migration and silently
             # 404'd every /logs/voice request from web-client.ts:2183's
             # "Copy logs" button.
-            log_file = REPO_DIR / "logs" / "voice-agent.log"
+            log_file = WORKSPACE_DIR / "logs" / "voice-agent.log"
             if log_file.exists():
                 lines = log_file.read_text().splitlines()[-30:]
                 self.send_json(200, {"lines": lines})
@@ -678,7 +684,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 if not qid or not answer:
                     self.send_json(400, {"error": "id and answer required"})
                     return
-                pq_file = Path(personal_path("pending-questions.md", REPO_DIR))
+                pq_file = Path(personal_path("pending-questions.md", WORKSPACE_DIR))
                 if pq_file.exists():
                     content = pq_file.read_text()
                     # Update status from unanswered to answered
@@ -720,7 +726,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                             # os.path.realpath + str.startswith is the CodeQL-recognized
                             # path-injection sanitizer pair (Path::PathNormalization
                             # + Path::SafeAccessCheck in semmle.python).
-                            task_dir_real = os.path.realpath(REPO_DIR / "tasks")
+                            task_dir_real = os.path.realpath(WORKSPACE_DIR / "tasks")
                             task_file_str = os.path.realpath(
                                 os.path.join(task_dir_real, f"answer-{safe_qid}-{ts}.txt")
                             )

--- a/src/github-webhook.py
+++ b/src/github-webhook.py
@@ -26,7 +26,13 @@ import time
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
+# Workspace resolver — see src/workspace_default.py. SUTANDO_WORKSPACE env
+# (if set) wins; otherwise falls back to ~/.sutando/workspace/. Keeps task
+# writes aligned with the watcher and other workspace-aware bridges.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_default import resolve_workspace  # noqa: E402
+
+REPO = resolve_workspace()
 TASKS_DIR = REPO / "tasks"
 PORT = int(sys.argv[sys.argv.index("--port") + 1]) if "--port" in sys.argv else 7847
 

--- a/src/github-webhook.py
+++ b/src/github-webhook.py
@@ -26,18 +26,22 @@ import time
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 
-# Workspace resolver — see src/workspace_default.py. SUTANDO_WORKSPACE env
-# (if set) wins; otherwise falls back to ~/.sutando/workspace/. Keeps task
-# writes aligned with the watcher and other workspace-aware bridges.
+# Two separate concerns (per qingyun review on PR #775):
+# - REPO  = source tree (this file's parent.parent) — for loading .env from
+#           the checkout root. Stays anchored regardless of SUTANDO_WORKSPACE.
+# - WORKSPACE_DIR = runtime state (resolve_workspace()) — for tasks/ writes so
+#           the workspace-aware watcher picks them up.
+REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402
 
-REPO = resolve_workspace()
-TASKS_DIR = REPO / "tasks"
+WORKSPACE_DIR = resolve_workspace()
+TASKS_DIR = WORKSPACE_DIR / "tasks"
 PORT = int(sys.argv[sys.argv.index("--port") + 1]) if "--port" in sys.argv else 7847
 
-# Load .env before reading secrets so launchctl / systemd managed restarts
-# pick up GITHUB_WEBHOOK_SECRET without needing it in the plist/unit file.
+# Load .env from the repo root (not workspace) so launchctl / systemd managed
+# restarts pick up GITHUB_WEBHOOK_SECRET without needing it in the plist/unit
+# file. The .env lives in the checkout, not the runtime workspace.
 try:
     from dotenv import load_dotenv
     load_dotenv(REPO / ".env")

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -13,7 +13,7 @@ import { join } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 
-const REPO_DIR = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const REPO_DIR = process.env.SUTANDO_WORKSPACE || new URL('..', import.meta.url).pathname.replace(/\/$/, '');
 const TASK_DIR = join(REPO_DIR, 'tasks');
 const RESULT_DIR = join(REPO_DIR, 'results');
 const STATE_DIR = join(REPO_DIR, 'state');


### PR DESCRIPTION
## Summary

Sibling code-fix PR to #774 (docs-only). Closes the writer-side gap qy-sutando flagged in #dev: 3 bridge/API entry points still hardcoded their repo path via `Path(__file__).parent.parent` / `new URL('..', import.meta.url)`, so they wrote tasks/results back to the repo root even when `SUTANDO_WORKSPACE` was pinned in `.env`. Watcher poll dir and writer dir diverged → owner DMs / API tasks landed where nobody was reading.

## Files patched (one-per-line)

- `src/task-bridge.ts:16` — `REPO_DIR` now env-first (`process.env.SUTANDO_WORKSPACE`), falls back to historical `import.meta.url`-derived path so installs without the env stay zero-change.
- `src/agent-api.py:85` — split per qy review: `REPO_DIR = Path(__file__).parent.parent` for source-tree concerns (resolving `src/health-check.py` for `/health`, `git -C REPO_DIR` for `/dashboard` activity feed, `.env` load) **and** `WORKSPACE_DIR = resolve_workspace()` for runtime state (`tasks/`, `results/`, `core-status.json`, `pending-questions.md`, `contextual-chips.json`, voice-agent.log, /media/ resolver). Honors `SUTANDO_WORKSPACE` for runtime state without breaking source-tree reads.
- `src/github-webhook.py:29` — same split: `REPO = Path(__file__).resolve().parent.parent` (source tree, only used for `.env` loading) + `WORKSPACE_DIR = resolve_workspace()` (TASKS_DIR writes go under runtime workspace).

Variable names (`REPO_DIR`, `REPO`) preserved for source-tree concerns — all downstream references in each file are unaffected.

## Cross-refs

- Lucy's PR #774 — docs-only workspace pin guidance for existing repo installs.
- qy-sutando #dev analysis (channel `1485653767402553457`) endorsing option 1 (SKILL.md) + this sibling code-fix PR.
- Workspace contract / helper from #762 (`src/workspace_default.py`).

## Overlap with qy's staged branch

qy mentioned a local `feat/health-check-honor-workspace` branch that may include some overlap with these 3 files. As of push time it is NOT on `origin`. This PR is the writer-side complement; if qy's branch lands first and overlaps, happy to rebase or absorb. Coordinating in #dev.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` clean for both Python files.
- [x] `npx tsc --noEmit` clean repo-wide.
- [x] `SUTANDO_WORKSPACE=/tmp/test-ws` resolves to `/tmp/test-ws` via `resolve_workspace(migrate=False)`.
- [ ] On a fresh install without `SUTANDO_WORKSPACE`, task-bridge.ts still resolves to repo root (TS fallback branch).
- [ ] On an install WITH `SUTANDO_WORKSPACE` set, all 3 writers land tasks/results under the canonical workspace.

— Lucy (Mac Studio bot, on Susan's ask)
