### PR TITLE
Revert "docs(CLAUDE.md): drop dead memory-file refs" (#773)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,9 @@ Full memory index: $SUTANDO_MEMORY_DIR (default: ~/.claude/projects/.../memory)/
 
 Key files:
 - User profile: $SUTANDO_MEMORY_DIR (default: ~/.claude/projects/.../memory)/user_profile.md
+- Feedback (response style): $SUTANDO_MEMORY_DIR (default: ~/.claude/projects/.../memory)/feedback_response_style.md
+- Feedback (operating principle): $SUTANDO_MEMORY_DIR (default: ~/.claude/projects/.../memory)/feedback_minimal_cost_max_value.md
 - Build log (what's built, what's next): build_log.md
-
-`MEMORY.md` is the source of truth for available memory files — read it first to discover the current set (feedback, project, reference entries). Hardcoded paths here drift; MEMORY.md doesn't.
 
 Read relevant memory files when user preferences or history would improve task quality. Write new memory when you learn something durable about the user or the project.
 


### PR DESCRIPTION
Reverts #773 per owner ask in chat at 2026-05-16 22:05 PT.

Restores the two memory-file references that #773 removed:
- `feedback_response_style.md`
- `feedback_minimal_cost_max_value.md`

#773 removed these references because the named files don't currently exist in this node's memory dir. Reverting on the assumption owner intends to (re)create them rather than have CLAUDE.md silently drop the pointers.

## Test plan
- [x] `git revert` clean (1 file, +2/-2 — exact inverse of #773).
- [ ] After merge, CLAUDE.md `## Memory` > `Key files` should list user_profile + 2× feedback refs + build_log (4 entries, original layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)