### PR TITLE
fix(watch-tasks-stream): default fallback to ~/.sutando/workspace/tasks (matches bridge contract)

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -21,18 +21,23 @@
 set -u
 
 # Resolve TASKS_DIR. Priority: explicit positional arg → $SUTANDO_WORKSPACE/tasks
-# → repo-relative fallback. The SUTANDO_WORKSPACE branch matches what every
-# bridge does (discord-bridge.py, telegram-bridge.py, dm-result.py — see
-# PRs #708/#720/#722/#723) — without it, the bridges write tasks to the
-# workspace but the watcher polls the repo's tasks/, so owner DMs land but
-# the agent never sees them. Diagnosed 2026-05-15 (~3 dropped DMs over
-# 17 min before the workaround restart).
+# → canonical default `~/.sutando/workspace/tasks` (matching
+# `workspace_default.resolve_workspace()` — the shared contract every bridge
+# already follows). The bridges (discord-bridge.py, telegram-bridge.py,
+# dm-result.py — see PRs #708/#720/#722/#723) write to that default when env
+# is unset; if this watcher fell back to `<repo>/tasks/` instead, the bridges
+# would write to one dir and the watcher would poll another, so owner DMs land
+# silently. Diagnosed 2026-05-15 (~3 dropped DMs over 17 min) and again
+# 2026-05-16 (~45 min silent gap when the Monitor was started without
+# SUTANDO_WORKSPACE exported into its env) — second incident motivated
+# replacing the legacy `<repo>/tasks` fallback with the workspace default so
+# the divergence can't happen even when callers forget to export.
 if [ -n "${1:-}" ]; then
   TASKS_DIR="$1"
 elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   TASKS_DIR="$SUTANDO_WORKSPACE/tasks"
 else
-  TASKS_DIR="$(dirname "$0")/../tasks"
+  TASKS_DIR="$HOME/.sutando/workspace/tasks"
 fi
 mkdir -p "$TASKS_DIR"
 # Canonicalize watched dir for the parent-dir filter below. fswatch always


### PR DESCRIPTION
## Summary

When `$SUTANDO_WORKSPACE` is unset AND no positional arg is given, `watch-tasks-stream.sh` was falling back to `<repo>/tasks/` while every bridge (`discord-bridge.py`, `telegram-bridge.py`, `dm-result.py`) falls back to `~/.sutando/workspace/tasks/` via `workspace_default.resolve_workspace()`. Bridges and watcher diverge, owner DMs land but never reach the agent.

Switch the fallback to match the bridge contract.

## Why now

- 2026-05-15: ~3 dropped DMs over 17 min — workaround was a manual restart with the env exported.
- 2026-05-16 (today): ~45 min silent gap on Chi's MacBook. The Monitor was started without `SUTANDO_WORKSPACE` in its env, watcher polled the legacy `<repo>/tasks/`, bridge wrote to `~/.sutando/workspace/tasks/`. Chi: _"this will be an issue for other sutandos too."_ Confirmed — same bug surfaces on any fresh install whose watcher launcher doesn't pin the env.

Related: #774 (docs warning for existing-repo installs to pin the env). This is the codepath fix that complements that doc change — fresh installs and any caller that forgot to export now still land on the bridge-canonical default.

## Diff

```diff
-  TASKS_DIR="$(dirname "$0")/../tasks"
+  TASKS_DIR="$HOME/.sutando/workspace/tasks"
```

Plus comment update explaining the divergence and the two incidents.

## Post-merge restart caveat

Per MacBook bot's review observation: any host that pulls this commit but doesn't restart its Monitor / `watch-tasks-stream.sh` process is briefly divergent in the **opposite** direction — new code on disk (env-unset → `~/.sutando/workspace/tasks/`) but the still-running watcher loaded from the old code (env-unset → `<repo>/tasks/`). Smaller window than the bug being fixed, but same failure mode.

**Merge / rollout note:** after `git pull`, restart the watcher:
- Via Monitor tool: `TaskStop` the old watcher task, then re-arm with the same command (now loads new fallback).
- Via shell: `pkill -f watch-tasks-stream.sh` — the per-session caller (proactive-loop / startup.sh) will respawn it.

This should also be announced on `#bot2bot` at merge time so cross-fleet hosts re-sync without dropping DMs in the gap.

## Test plan

- [x] Smoke test: all 3 resolution branches return the expected path
  - no env + no arg → `~/.sutando/workspace/tasks` (was `<repo>/tasks`)
  - `SUTANDO_WORKSPACE=/x/ws` → `/x/ws/tasks`
  - positional arg → arg value
- [ ] Stop current Monitor, restart with no env exported, confirm it points at the bridge's actual tasks dir
- [ ] No regression for installs that DO set `SUTANDO_WORKSPACE` (env branch unchanged)
- [ ] After merge: announce restart-watcher on `#bot2bot` for cross-fleet alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
