### PR TITLE
feat(startup): derive git committer.name/email from stand-identity.json

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -14,6 +14,27 @@ cd "$REPO"
 # $SUTANDO_ROOT.
 export SUTANDO_ROOT="$REPO"
 
+# Git committer attribution from stand-identity.json (opt-in, no env var).
+# The repo-local `user.email` (set to the GitHub privacy noreply) is the
+# AUTHOR — CLA-Assistant resolves it to the owner's GitHub account, gating
+# the PR check. The COMMITTER is free to carry per-host attribution so that
+# `git log --format='%h %an / %cn %s'` distinguishes which Sutando host
+# crafted each commit (Mini, MacBook, …). Without this, all bot commits
+# share both fields and you lose track of which fleet host did the work.
+#
+# Silent fall-through on every "no identity" path: missing file, missing
+# jq, empty/malformed fields. OSS users see no change — they don't ship a
+# stand-identity.json. Fleet hosts opt in by virtue of having one.
+if [ -f "$REPO/stand-identity.json" ] && command -v jq > /dev/null 2>&1; then
+  _stand_name=$(jq -r '.name // empty' "$REPO/stand-identity.json" 2>/dev/null)
+  _stand_machine=$(jq -r '.machine // empty' "$REPO/stand-identity.json" 2>/dev/null)
+  if [ -n "$_stand_name" ] && [ -n "$_stand_machine" ]; then
+    git -C "$REPO" config committer.name "$_stand_name"
+    git -C "$REPO" config committer.email "${_stand_machine}@noreply.sutando.local"
+  fi
+  unset _stand_name _stand_machine
+fi
+
 # Auto-bootstrap: create-if-missing files and dirs that the agent + skills
 # expect to exist (logs, state, tasks, results, notes, contextual-chips.json,
 # pending-questions.md, build_log.md, crons.json, …). Idempotent — safe to


### PR DESCRIPTION
## Summary

Author stays the GitHub-noreply email (CLA-Assistant gate). Committer becomes per-host so `git log --format='%h %an / %cn %s'` distinguishes which Sutando fleet host crafted each commit.

After this lands:
- **Mini** → committer = `Echo Act IV (Mini) <mac-mini@noreply.sutando.local>`
- **MacBook** → committer = `<MacBook stand> <macbook@noreply.sutando.local>`
- **OSS user** → no change (no `stand-identity.json` → silent skip)

## Why

Today's CLA-Assistant incident (#779, #777) root-caused: Mini's commits were authored as `Chi <wangchi@Chis-Mac-mini.local>` (OS-default hostname email), which CLA can't resolve to any GitHub user → silent PENDING forever. MacBook's commits were authored as `4250911+sonichi@users.noreply.github.com` (GitHub privacy noreply) → resolved cleanly → ✅.

Fix in two parts:
1. Repo-local `user.email` set to the noreply on every host → unified author → CLA gate consistent. (Done manually on Mini today; this PR doesn't add it because per-host `git config --local` isn't bash-portable.)
2. **This PR**: lift the per-host signal that author used to badly carry into the COMMITTER field, where it belongs — author is _who wrote the change_ (Chi), committer is _who put it in this repo on this branch on this machine_ (Mini, MacBook).

## Test plan

- [x] `bash -n src/startup.sh` — syntax OK
- [x] Smoke-test with `stand-identity.json` present → committer fields set correctly
- [x] Smoke-test with file missing → silent skip
- [x] Smoke-test with empty `name` / `machine` → silent skip
- [ ] Run `bash src/startup.sh` on Mini (here) and verify `git config committer.email` resolves to `mac-mini@noreply.sutando.local`
- [ ] Same on MacBook — verify the MacBook's `stand-identity.json` populates the right machine slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)