### PR TITLE
feat(community): use-case submission channel — issue template + community-use-cases/ dir

### DIFF
--- a/.github/ISSUE_TEMPLATE/use-case-submission.md
+++ b/.github/ISSUE_TEMPLATE/use-case-submission.md
@@ -1,0 +1,42 @@
+---
+name: Use-case submission
+about: Share what your Sutando did. We'll review for the public showcase at https://sutando.ai/.
+labels: use-case-submission
+---
+
+**Title (outcome-first, not capability-first):**
+<!-- ✅ "Your AI books your dinner — and talks to their AI"
+     ❌ "Ask your AI to make a phone call"
+     If your title starts with "Ask your AI to ...", "Sutando can ...",
+     or names a button/capability, please reframe as a user outcome. -->
+
+
+
+**One-line summary:**
+<!-- Reads on the tile + detail page. ~25 words. Tell the story, not the
+     stack. Example: "Sutando called Haidilao for a dinner reservation.
+     Their phone was answered by an AI too — two AIs negotiated a table
+     for 3." -->
+
+
+
+**Link to the demo:**
+<!-- One or more: video file, YouTube URL, X/Twitter post, LinkedIn post,
+     blog post. Anything that shows the moment in action. -->
+
+
+
+**Long description (optional):**
+<!-- 2–4 sentences. What happened, why it matters, who else this is
+     useful for. -->
+
+
+
+**Contact (optional):**
+<!-- How we credit you on the page — GitHub handle, X/Twitter handle,
+     email. Leave blank for "anonymous community submission". -->
+
+
+
+**Anything else?**
+<!-- Caveats, props to collaborators, notes for the review. -->

--- a/community-use-cases/README.md
+++ b/community-use-cases/README.md
@@ -1,0 +1,72 @@
+# Community use cases
+
+Got a moment where your Sutando did something you'd want to show off?
+Share it here. We promote the best entries to the public showcase at
+**https://sutando.ai/** under "Use cases".
+
+## Two ways to submit
+
+### 1. GitHub issue (lowest friction)
+
+Open a [use-case submission issue](https://github.com/sonichi/sutando/issues/new?template=use-case-submission.md).
+Walk through the template fields. A maintainer triages and either
+promotes it directly or asks for a small reframe.
+
+### 2. Pull request (structured, gets you credit on merge)
+
+Add a file to `community-use-cases/<slug>.md` matching the schema
+below. CLA-Assistant gates the PR (one-time signature). On merge, a
+sync job picks up the entry and stages a PR against the showcase site.
+
+#### File schema
+
+```markdown
+---
+slug: your-ai-does-laundry          # lowercased, dashed
+title: "Your AI does your laundry while you're at work"
+summary: "One sentence that reads on the tile + detail page."
+videoUrl: /community-use-cases/videos/your-ai-does-laundry.mp4  # optional
+youtubeId: ABCDEFG1234               # optional
+xUrl: https://x.com/you/status/...   # optional
+linkedinUrl: https://www.linkedin.com/...  # optional
+thumbnail: /community-use-cases/thumbnails/your-ai-does-laundry.jpg
+contact: "@yourhandle (or email)"    # optional; we credit you on the page
+submitted_at: 2026-05-17T07:50:00Z
+---
+
+Long description (2–4 sentences). What happened, why it matters, who
+else this is useful for. Outcome-first language ("books the table",
+"fixes the bug") — not capability-list ("can make calls", "supports
+voice").
+```
+
+Drop the thumbnail at `community-use-cases/thumbnails/<slug>.jpg`
+(any image format works; we'll re-encode if needed). Drop a self-hosted
+video (if you have one) at `community-use-cases/videos/<slug>.mp4`.
+Skip the video and just link YouTube/X if you'd rather.
+
+## Framing — what we look for
+
+The showcase tells *user-outcome stories*, not *capability lists*.
+Compare:
+
+- ✅ "Your AI books your dinner — and talks to their AI"
+- ❌ "Ask your AI to make a phone call"
+- ✅ "Catch and fix your own bugs"
+- ❌ "Sutando supports anomaly detection"
+
+If the title starts with "Ask your AI to …", "Sutando can …", or
+names a button or feature — please reframe as a user outcome. The
+review will ask for that change anyway.
+
+## Easiest path: use the skill
+
+Sutando ships a `/submit-use-case` skill that does the issue + PR
+in one shot, including the framing-check. If you've got Sutando
+installed:
+
+```bash
+/submit-use-case --title "..." --summary "..." --image-url "..."
+```
+
+It validates, stages, and opens both an issue and a PR for you.

--- a/community-use-cases/thumbnails/.gitkeep
+++ b/community-use-cases/thumbnails/.gitkeep
@@ -1,0 +1,2 @@
+# Thumbnails for community-use-case submissions land here.
+# Filename matches the slug in the parent dir's .md file.

--- a/community-use-cases/videos/.gitkeep
+++ b/community-use-cases/videos/.gitkeep
@@ -1,0 +1,2 @@
+# Self-hosted videos for community-use-case submissions land here.
+# Filename matches the slug in the parent dir's .md file.


### PR DESCRIPTION
## Summary

Sets up the OSS-facing channel for community use-case submissions:

1. **Issue template** at `.github/ISSUE_TEMPLATE/use-case-submission.md` — lowest-friction path. Anyone with a GitHub account walks through structured prompts (title, summary, demo link, contact, framing hints).
2. **PR path** via `community-use-cases/<slug>.md` — structured submission with YAML frontmatter mirroring the `UseCase` type from `AG2Platform/agent-universe`. CLA-gated, submitter gets credit on merge.
3. **`community-use-cases/README.md`** — schema doc + framing guidance ("outcome-first, not capability-list") + pointer at the forthcoming `/submit-use-case` skill that automates both paths.

Subdirs `videos/` and `thumbnails/` are seeded for self-hosted media.

## Why now

Per Chi 2026-05-17, the existing internal `add-use-case` skill targets the private `AG2Platform/agent-universe` — OSS contributors can't run it end-to-end. This PR opens the public channel they CAN use.

## What still needs to land

- [ ] `/submit-use-case` skill in `sonichi/sutando-skills` (subagent building it now) — the OSS-side automation
- [ ] Sync script in `sonichi/sutando-skills` that watches merged `community-use-cases/` entries and stages PRs against `AG2Platform/agent-universe` (follow-up — defer until volume justifies)

## Test plan

- [ ] Eyeball the rendered issue template at https://github.com/sonichi/sutando/issues/new?template=use-case-submission.md after merge
- [ ] Confirm `labels: use-case-submission` is applied automatically
- [ ] Confirm `community-use-cases/README.md` renders cleanly with the YAML frontmatter example

🤖 Generated with [Claude Code](https://claude.com/claude-code)