### PR TITLE
docs(readme): swap stale Python badge for verified all-langs Developer badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sutando
 
-[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ai-blue)](https://sutando.ai) [![GitHub Trending](https://img.shields.io/badge/GitHub_Trending-%231_Python_(May_16)-FFD700?logo=github&logoColor=white)](https://github.com/trending/developers/python?since=daily)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ai-blue)](https://sutando.ai) [![GitHub Trending](https://img.shields.io/badge/GitHub_Trending-%231_Developer_(May_17)-FFD700?logo=github&logoColor=white)](https://github.com/trending/developers?since=daily)
 
 **My AI Stand — Realtime by Day, Rewriting Itself by Night.**
 **Summon my AI superpower.**


### PR DESCRIPTION
## Summary

Swap the README hero-row trending badge:
- **Old (from #777):** `GitHub Trending — #1 Python (May 16)` — claim conflated Python developers leaderboard with Python projects leaderboard, and Sutando was never on the latter. Link pointed at the Python developers filter which was the verifiable axis but the label said "Python" without "Developer" → reads as project rank.
- **New (this PR):** `GitHub Trending — #1 Developer (May 17)` — verified against `github.com/trending/developers?since=daily` (all languages). Date-anchored so the brittleness has a known boundary.

## Why the rewrite (was originally "drop entirely")

This PR's first push was per Chi pick **B (drop the badge)** after the earlier conflation got caught. Qingyun pushed back in PR comment: "Should not drop the badge. But update it to be all language not just python." Chi reconsidered, picked path **2** (interim static all-langs → swap to dynamic Trendshift badge in follow-up PR once `trendshift.io/developers/sonichi` indexes — currently 404).

So this PR's net delta vs main is now a one-character-class change: Python → Developer, with the matching link/label scope update.

## Follow-up

A second PR will swap this static badge for the [Trendshift](https://trendshift.io/) dynamic dev-of-day embed once Trendshift indexes Chi's profile (typically ~24h after first GitHub-trending hit; currently 404'ing on `trendshift.io/developers/sonichi`). The dynamic variant auto-updates so the "rank-claims age into lies" failure mode is eliminated.

## Diff

```diff
- [![Website](...)](sutando.ai) [![GitHub Trending](...#1_Python...)](https://github.com/trending/developers/python?since=daily)
+ [![Website](...)](sutando.ai) [![GitHub Trending](...#1_Developer_(May_17)...)](https://github.com/trending/developers?since=daily)
```

## Test plan

- [x] `gh pr diff` shows single-line change, swap-not-add
- [x] Badge label, link, and color match expectations
- [ ] Eyeball the rendered badge on the PR "Files changed" tab — confirm the parens render in the badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @qingyun-ag2 — addressed your "all language not just python" comment in-place rather than dropping then re-adding.