### PR TITLE
chore(screen-companion): post-LGTM cleanup from PR #794 (sonichi #4 + 2 leaks)

### DIFF
--- a/skills/screen-companion/SKILL.md
+++ b/skills/screen-companion/SKILL.md
@@ -111,7 +111,7 @@ Configs are non-executable YAML — they only declare the interaction shape. No 
 
 What IS persisted by default:
 - **Text transcript** of the spoken conversation, in `<workspace>/data/screen-companion-<sessionId>.jsonl`. Same convention as `phone-conversation/conversation-server.ts` + `discord-voice/discord-voice-server.ts`.
-- **Notes the user explicitly asks Sutando to take** via the `take_note` tool, in `<workspace>/notes/`.
+- **Notes the user explicitly asks Sutando to take** — saved to `<workspace>/notes/` once a `take_note` tool lands (planned; see issue #797). Today, "remember this" requests are persisted only as part of the conversation transcript above.
 
 What is NOT persisted by default:
 - Vision frames (the screenshots themselves) — sent to Gemini Live and discarded.

--- a/skills/screen-companion/tools.ts
+++ b/skills/screen-companion/tools.ts
@@ -65,12 +65,15 @@ const activateScreenCompanionTool: ToolDefinition = {
 		console.log(`${ts()} [ScreenCompanion] activate mode=${mode} goal=${goal ? `"${goal}"` : '(none)'}`);
 		try {
 			const config = loadConfig(mode);
-			const filledGoal = renderGoal(config, goal);
+			// Run the goal-required guard BEFORE renderGoal so we never
+			// produce a string with an un-substituted `{goal}` placeholder.
+			// Per sonichi review #4 on PR #794.
 			if (config.goal_template && !goal) {
 				return {
 					error: `Mode "${mode}" requires a goal. Ask the user: "What are you trying to set up?" then call activate_screen_companion again with goal=...`,
 				};
 			}
+			const filledGoal = renderGoal(config, goal);
 			const visionHint =
 				config.vision_mode === 'push'
 					? `Vision mode is PUSH (frames stream at ${config.vision_cadence_ms ?? 1000}ms cadence). If the user is not already screen-sharing, ask them to start it now so you can see what they're doing.`
@@ -99,7 +102,7 @@ const activateScreenCompanionTool: ToolDefinition = {
 			return {
 				error: msg,
 				available_modes: availableModes(),
-				hint: 'If the user\'s request doesn\'t match any available mode, do NOT call this tool — fall back to regular vision_query / take_note / look_up_reference behavior.',
+				hint: 'If the user\'s request doesn\'t match any available mode, do NOT call this tool — operate normally with whatever tools the session already has registered.',
 			};
 		}
 	},


### PR DESCRIPTION
Follow-up to **#794** (merged at `e588d3f`). Lands the three cleanup items Chi flagged as "non-blockers, ship in a follow-up" in his second review (https://github.com/sonichi/sutando/pull/794#pullrequestreview, 2026-05-18T01:45:10Z):

## Changes

- **`tools.ts` — renderGoal reorder (sonichi #4)**: goal-required guard now runs BEFORE `renderGoal()`, so we never produce a string with an un-substituted `{goal}` placeholder. Today's effect is harmless (the unfilled string was unused), but the wasted call is the kind of bug that lands a stray prompt-injected `{goal}` in a future code path.

- **`tools.ts:102` — false-tool-name leak in error hint**: the activation-failure response no longer says "fall back to regular `vision_query` / `take_note` / `look_up_reference` behavior" — those tools don't exist yet (tracked in #797). Replaced with neutral "operate normally with whatever tools the session already has registered."

- **`SKILL.md` — Privacy section take_note reference**: removed the implication that `take_note` exists today. Updated to acknowledge it's planned (#797) and that today "remember this" requests are persisted as part of the conversation transcript.

## Smoke test

`npx tsx skills/screen-companion/scripts/activate.ts --list` → ✓ `guided-setup`. tsc clean. No behavior change beyond the renderGoal call-order fix (which is a no-op today since the unfilled string was unused).

## Context

PR #794 merged before these cleanups landed (timing: merge at 01:47:42Z; my cleanup commit at 01:51:03Z — 3 min late). Per Chi's framing in the re-review, the substantive must-fixes were all addressed before merge; this PR catches the trailing nits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)