### PR TITLE
test(agent-state-endpoint): pre-clear tool track in browser-track loop (closes #800)

### DIFF
--- a/tests/agent-state-endpoint.test.ts
+++ b/tests/agent-state-endpoint.test.ts
@@ -115,6 +115,13 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 	});
 
 	it('accepts all 5 valid agent states via the correct track', async () => {
+		// Pre-clear tool track. Without this, a prior test (or prior
+		// process state) that left the tool track at `working`/`seeing`
+		// makes /sse-status return that tool-track value instead of the
+		// browser-track value being set below — the tool track has
+		// precedence by design. The "tool track takes precedence" test
+		// at line 149 already follows this convention; closing #800.
+		await fetchJson('/mute-state?state=idle&source=tool');
 		// Browser track (no source=tool): idle / listening / speaking only.
 		for (const state of ['idle', 'listening', 'speaking']) {
 			const body = await fetchJson(`/mute-state?state=${state}`);
@@ -158,6 +165,13 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 	});
 
 	it('rejects invalid agent state (keeps previous value)', async () => {
+		// Pre-clear tool track for the same reason as the line-117 test:
+		// if a prior test left the tool track at `working`/`seeing`, the
+		// baseline assertion below ("invalid value should not overwrite —
+		// expected 'listening'") fails because /sse-status surfaces the
+		// tool-track value instead of the browser-track value we just set.
+		// Same root cause as #800; observed flaking on #739's rebase CI.
+		await fetchJson('/mute-state?state=idle&source=tool');
 		// Set a known baseline
 		await fetchJson('/mute-state?state=listening');
 		// Try invalid


### PR DESCRIPTION
Closes #800.

The "accepts all 5 valid agent states via the correct track" test (`tests/agent-state-endpoint.test.ts:117`) has been alternating pass/fail in CI. Observed during PR #794 — same test failed/passed on commits that touched only `skills/screen-companion/*` files, never `src/sse-server.ts` or anything in agent-state plumbing.

**Root cause** — the test's browser-track loop doesn't pre-clear the tool track. If prior process state (or another test order) left the tool track at `working` or `seeing`, `/sse-status` returns that tool-track value because tool track has precedence by design (per `tests/agent-state-endpoint.test.ts:149`). The assertion fails with `expected 'listening' got 'working'`.

The sibling test at line 149 (`tool track takes precedence over browser track`) already follows the pre-clear convention. Just adding the matching one-liner at the top of the line-117 test.

## Smoke test

```bash
node --test --test-name-pattern='accepts all 5 valid agent states' tests/agent-state-endpoint.test.ts
```

3 consecutive runs locally: 3/3 pass. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)