### PR TITLE
fix(sutando-app): seed Info.plist NSAppleEventsUsageDescription on rebuild

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -241,6 +241,22 @@ if [ -f "$SUT_SRC" ] && { [ ! -f "$SUT_BIN" ] || [ "$SUT_SRC" -nt "$SUT_BIN" ]; 
   echo "  Compiling Sutando (source newer than binary)..."
   if (cd "$REPO/src/Sutando" && swiftc -O -o Sutando main.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation 2>/dev/null); then
     echo "  ✓ Sutando compiled"
+
+    # Sync the fresh binary into the .app bundle if one exists, ensure the
+    # AppleEvents usage-description key is present, and re-sign so the
+    # cdhash matches. Without NSAppleEventsUsageDescription macOS silently
+    # denies AppleEvents — getFinderSelection() returns [] and the ⌃C
+    # drop handler logs "Nothing selected" with no permission prompt.
+    SUT_APP="$REPO/src/Sutando/Sutando.app"
+    if [ -d "$SUT_APP" ]; then
+      cp "$SUT_BIN" "$SUT_APP/Contents/MacOS/Sutando"
+      /usr/libexec/PlistBuddy \
+        -c "Add :NSAppleEventsUsageDescription string 'Sutando reads your Finder selection to drop files into the agent task queue.'" \
+        "$SUT_APP/Contents/Info.plist" 2>/dev/null || true
+      codesign --force --sign - "$SUT_APP" 2>/dev/null || true
+      echo "  ✓ Sutando.app synced + signed"
+    fi
+
     if pgrep -f "src/Sutando/Sutando" > /dev/null 2>&1; then
       pkill -f "src/Sutando/Sutando" 2>/dev/null || true
       # Wait for kernel cleanup to drain before relaunch — fixed sleep 1


### PR DESCRIPTION
## Summary
- After `swiftc` produces a fresh `Sutando` binary, sync it into `Sutando.app/Contents/MacOS/Sutando`, ensure the `NSAppleEventsUsageDescription` key exists in `Info.plist`, and re-sign the .app ad-hoc.
- Without that Info.plist key, macOS 10.14+ silently denies AppleEvents requests with no permission prompt → `getFinderSelection()` returns `[]` → ⌃C file-drop logs `"Nothing selected"` even though Finder is frontmost with a file selected.

## Why
Diagnosed live with Chi tonight: he hit ⌃C in Finder repeatedly, every attempt landed in `logs/context-drop.log` as `"Nothing selected"`. Bundle was unsigned-bound and Info.plist was missing the AppleEvents usage description, so macOS never asked for permission and the AppleScript silently returned empty. Patched the running .app manually (`PlistBuddy Add` + `codesign --force --sign -` + `tccutil reset AppleEvents com.sutando.menubar`) and the next ⌃C drop succeeded immediately.

This PR keeps the fix in place across future `bash src/startup.sh` rebuilds.

## Implementation
- `PlistBuddy -c "Add ..."` is idempotent (exits 1 if key already exists, wrapped with `|| true`).
- `codesign --force --sign -` re-binds the cdhash; TCC permissions are tied to the cdhash so a re-sign forces a fresh permission prompt on next AppleEvents request.

## Test plan
- [ ] `touch src/Sutando/main.swift && bash src/startup.sh` — confirm `Sutando.app synced + signed` line prints, Info.plist has the key, codesign verifies.
- [ ] Hit ⌃C in Finder with a file selected — drop lands as `Dropped: file (<path>)` in `logs/context-drop.log`.
- [ ] On a fresh machine where Sutando has never been granted Finder access, first ⌃C should pop the macOS permission dialog (it wouldn't before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)