### PR TITLE
feat(telegram-bridge): trust-on-first-use auto-onboard for first DM after install

### DIFF
--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -159,11 +159,46 @@ def presenter_mode_active():
 # Load access config
 ACCESS_FILE = Path.home() / ".claude" / "channels" / "telegram" / "access.json"
 def load_allowed():
+    """Return the set of allowed sender IDs, OR None if access.json doesn't exist.
+
+    The None vs empty-set distinction matters for trust-on-first-use (TOFU)
+    auto-onboarding: "file missing" → the bridge has never been configured,
+    so the first DM should auto-onboard the sender as the owner. "File exists
+    but empty allowFrom" → the admin explicitly locked it down; never TOFU.
+    """
     try:
         data = json.loads(ACCESS_FILE.read_text())
         return set(data.get("allowFrom", []))
-    except:
+    except FileNotFoundError:
+        return None
+    except Exception:
         return set()
+
+
+def tofu_onboard(sender_id, username):
+    """First-time auto-onboard: write access.json with this sender as owner.
+
+    Triggered when access.json doesn't exist (i.e., the bridge has never been
+    configured for any user) AND a DM arrives. The expected flow is: user
+    rotates a token, starts the bridge, sends "hi" to their own bot, and
+    Sutando auto-trusts that first DM as coming from them. Subsequent senders
+    will be rejected as non-allowed and need explicit `/telegram:access allow`.
+
+    Logs the onboarding so the act is visible. Safe-by-default: if the file
+    already exists at write time (race with manual config), we don't clobber.
+    """
+    if ACCESS_FILE.exists():  # race-safety: someone else wrote it first
+        return load_allowed() or set()
+    ACCESS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "allowFrom": [sender_id],
+        "tofuOwner": sender_id,
+        "tofuOnboardedAt": int(time.time()),
+        "tofuOnboardedUsername": username or None,
+    }
+    ACCESS_FILE.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"  TOFU: auto-onboarded @{username} (id={sender_id}) as owner — wrote {ACCESS_FILE}")
+    return {sender_id}
 
 def api(method, **params):
     url = f"https://api.telegram.org/bot{TOKEN}/{method}"
@@ -310,6 +345,10 @@ def main():
 
                 # Reload access list periodically
                 allowed = load_allowed()
+                if allowed is None:
+                    # First-ever DM after install — access.json doesn't exist.
+                    # Auto-onboard this sender as the owner (TOFU).
+                    allowed = tofu_onboard(sender_id, username)
                 if sender_id not in allowed:
                     print(f"  Dropped message from non-allowed @{username}")
                     continue


### PR DESCRIPTION
## The bug

The Telegram bridge's allowlist (`~/.claude/channels/telegram/access.json`) is required for any inbound DM to be accepted. Before this PR, a fresh install left the file missing — `load_allowed()` returned an empty set, every DM was silently dropped, and the new user had no signal anything was wrong:

- Bridge log: just kept printing "Telegram bridge started. Polling for messages..."
- Telegram `getUpdates`: zero (bridge polled the messages and dropped them)
- User's bot: appears unresponsive

Hit this debugging with owner tonight after a token rotation. ~30 minutes of false leads (wrong bot username, token format, .env parsing) before realizing the silent allowlist drop was the actual issue.

## The fix

**Trust-on-first-use (TOFU):** if `access.json` doesn't exist at all (i.e., the bridge has never been configured for any user), auto-onboard the first DM sender as the owner. Subsequent DMs from other users still hit the standard "non-allowed" drop.

### Behavior matrix

| `access.json` state | First DM behavior |
|---|---|
| Doesn't exist | **TOFU**: write file, onboard sender as owner, message accepted |
| `{"allowFrom": [<your-id>]}` | Standard allow check (current behavior) |
| `{"allowFrom": []}` | Drop (lockdown mode — admin explicitly disabled the bot) |
| Malformed JSON | Drop (returns empty set, no TOFU — fails closed) |

The None-vs-empty distinction in `load_allowed()` is what enables this — `None` means "never configured" → TOFU eligible; empty set means "explicitly locked down" → never TOFU.

### Trust model

The bot token is the secret. After a token rotation, the first DM to your bot is by definition from someone who knows the bot's @username (which is public) AND has chosen this exact moment to message it. TOFU treats "first DM to a freshly-tokened bot" as a reasonable owner-identification heuristic — same trust shape as `git config user.email` accepting whatever the first commit author writes.

Audit fields (`tofuOwner`, `tofuOnboardedAt`, `tofuOnboardedUsername`) written into access.json so the onboarding moment is forensically recoverable.

## Diff summary

```
src/telegram-bridge.py | 41 ++++++++++++++++++++++++++++++++++++++++-
1 file changed, 40 insertions(+), 1 deletion(-)
```

- `load_allowed()` returns `None` when file missing, `set()` when malformed (fail closed), `set(data["allowFrom"])` otherwise
- New `tofu_onboard(sender_id, username)` writes the file
- Dispatch loop: `if allowed is None: allowed = tofu_onboard(sender_id, username)` before the membership check

## Smoke test

Local on this machine: deleted `~/.claude/channels/telegram/access.json`, restarted bridge, prepared to DM. Bridge running cleanly with the patch. Owner will exercise the TOFU path with the next DM.

## Caveats / follow-up

- TOFU writes a private file in `$HOME/.claude/channels/telegram/`. If multiple users share a Mac account (unusual but possible) and run separate Sutandos, the first one to DM wins. Probably need per-user paths in that scenario — separate concern.
- Currently the bridge has to be restarted between token rotations (it reads env at startup). Could add SIGHUP env-reload as a follow-up; not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)