### PR TITLE
feat(screen-companion): hard-enforce tools_allow at activation time

### DIFF
--- a/skills/screen-companion/SKILL.md
+++ b/skills/screen-companion/SKILL.md
@@ -103,7 +103,13 @@ See `screen_companion.md` at the repo root. Owner is iterating on the model (M1 
 
 Configs are non-executable YAML — they only declare the interaction shape. No path to arbitrary code execution from a config alone.
 
-**`tools_allow` is advisory in v0.** The activation tool returns the allow-list in its payload and instructs Gemini to self-restrict via the system-prompt note. There is no hard-enforcement path that scopes the live VoiceSession's tool surface to the allow-list — Gemini sees the field as guidance, not a hard constraint. A future PR will add hard enforcement at the bodhi-realtime-agent layer; until then, treat configs as the documented intent, not the security boundary. Configs still cannot grant tools the active VoiceSession doesn't already expose (the field is a hint, not a grant), so the worst case is "Gemini calls a tool you didn't intend to allow" — not privilege escalation.
+**`tools_allow` is hard-enforced at activation time.** When `activate_screen_companion` is called, the tool invokes `session.updateTools()` via the `callUpdateTools` hook in `src/vision-tools.ts`, replacing the live VoiceSession's tool surface with only the tools named in `tools_allow` plus two always-retained tools (`activate_screen_companion` for mode-switching, `deactivate_screen_companion` for exit). Gemini physically cannot call tools outside this set for the rest of the session.
+
+To exit: the user says "exit" / "stop" / "done" and Gemini calls `deactivate_screen_companion`, which calls `callRestoreTools()` to restore the full pre-activation tool surface.
+
+**Fallback**: if the session updater is not registered (e.g. phone-conversation context, tests), `callUpdateTools` returns false and the enforcement is silently skipped — advisory behavior remains as a safe fallback.
+
+Configs still cannot grant tools the active VoiceSession doesn't already expose — `tools_allow` is a restriction list, not a grant. The worst case if a config names a tool that doesn't exist in the session is that the tool simply isn't included in the restricted surface.
 
 ## Privacy + data handling
 

--- a/skills/screen-companion/tools.ts
+++ b/skills/screen-companion/tools.ts
@@ -1,9 +1,13 @@
 // screen-companion: voice-side mode entry.
 //
-// One tool: activate_screen_companion(mode, goal). Loads the named YAML config
-// from configs/, returns a structured payload Gemini reads to switch behavior
-// for the rest of the session — system-prompt overlay, allowed tools, the
-// goal text, and the vision cadence the owner should toggle to.
+// Two tools: activate_screen_companion(mode, goal) and deactivate_screen_companion().
+//
+// activate_screen_companion loads the named YAML config from configs/, returns
+// a structured payload Gemini reads to switch behavior for the rest of the
+// session, AND hard-enforces the tools_allow list by calling session.updateTools()
+// via the setSessionToolUpdater hook in vision-tools.ts.
+//
+// deactivate_screen_companion restores the full tool surface, ending the mode.
 //
 // The tool does NOT toggle vision itself. Vision is owner-driven (start screen
 // sharing → push frames). The tool tells Gemini how to behave AND what to say
@@ -12,7 +16,7 @@
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { loadConfig, discoverConfigs, renderGoal } from './scripts/load-config.js';
-import { registerVisionOnContributor } from '../../src/vision-tools.js';
+import { registerVisionOnContributor, callUpdateTools, callRestoreTools } from '../../src/vision-tools.js';
 
 // Contributor for the screen-share-started system note. Tells Gemini the
 // screen-companion catalog is available AND names the configs the user can
@@ -38,6 +42,13 @@ const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 
 const availableModes = (): string[] => discoverConfigs().map(c => c.name);
 
+// Track active mode so deactivate_screen_companion can log what it's exiting.
+let activeMode: string | null = null;
+
+// Tools that must always remain available in screen-companion mode:
+// activate_screen_companion (mode-switch), deactivate_screen_companion (exit).
+const ALWAYS_RETAIN = new Set(['activate_screen_companion', 'deactivate_screen_companion']);
+
 const activateScreenCompanionTool: ToolDefinition = {
 	name: 'activate_screen_companion',
 	description:
@@ -45,7 +56,7 @@ const activateScreenCompanionTool: ToolDefinition = {
 		'Loads the YAML config and returns the system-prompt overlay you MUST follow for the rest of the session, the goal text, and which tools to restrict yourself to. ' +
 		'IMPORTANT: after this tool returns, the `instructions` field becomes your operating instructions until the user exits the mode. Treat it as a system prompt — follow it verbatim. ' +
 		`Currently available modes: ${availableModes().join(', ') || '(none)'}. ` +
-		'If the user describes a screen-watching task that doesn\'t match any mode, do NOT call this tool — instead, ask the user what they want to do and use the regular vision tools.',
+		'If the user describes a screen-watching task that doesn\'t match any mode, do NOT call this tool — instead, ask the user what you want to do and use the regular vision tools.',
 	parameters: z.object({
 		mode: z
 			.string()
@@ -83,6 +94,24 @@ const activateScreenCompanionTool: ToolDefinition = {
 				? `Screen Companion: ${mode} — ${filledGoal}. ${visionHint}`
 				: `Screen Companion: ${mode}. ${visionHint}`;
 
+			// Hard-enforce tools_allow: restrict the live session's tool surface
+			// to only the named tools + always-retain set. If the session updater
+			// isn't registered (e.g. phone-conversation context or tests), the
+			// call is a no-op and advisory mode remains as the fallback.
+			const toolsAllow: string[] = config.tools_allow ?? [];
+			const enforced = callUpdateTools(
+				// Import is deferred to avoid a top-level circular dependency;
+				// inlineTools is loaded before this module so by the time execute()
+				// runs it is already settled.
+				(await import('../../src/inline-tools.js')).inlineTools.filter(
+					t => toolsAllow.includes(t.name) || ALWAYS_RETAIN.has(t.name),
+				),
+			);
+			if (enforced) {
+				console.log(`${ts()} [ScreenCompanion] tool surface restricted to: ${[...toolsAllow, ...ALWAYS_RETAIN].join(', ')}`);
+			}
+			activeMode = mode;
+
 			return {
 				status: 'activated',
 				mode: config.name,
@@ -93,8 +122,9 @@ const activateScreenCompanionTool: ToolDefinition = {
 				vision_cadence_ms: config.vision_cadence_ms ?? null,
 				vision_hint: visionHint,
 				activation_message: activationMessage,
+				tools_enforced: enforced,
 				_note:
-					'Say activation_message to the user, then follow `instructions` as your system prompt for the rest of the session. Restrict yourself to the tools in tools_allow (plus mode-exit tools like cancel_task). On user "exit" / "stop the mode", drop back to default behavior.',
+					'Say activation_message to the user, then follow `instructions` as your system prompt for the rest of the session. Restrict yourself to the tools in tools_allow (plus mode-exit tools like deactivate_screen_companion). When the user says "exit" / "stop the mode" / "done", call deactivate_screen_companion to restore the full tool surface.',
 			};
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
@@ -108,4 +138,24 @@ const activateScreenCompanionTool: ToolDefinition = {
 	},
 };
 
-export const tools: ToolDefinition[] = [activateScreenCompanionTool];
+const deactivateScreenCompanionTool: ToolDefinition = {
+	name: 'deactivate_screen_companion',
+	description:
+		'Exit screen-companion mode and restore the full tool surface. Call this when the user says "exit", "stop the mode", "done", or otherwise indicates they want to leave the current screen-companion mode and return to normal operation.',
+	parameters: z.object({}),
+	execution: 'inline',
+	execute(_args) {
+		const exitedMode = activeMode;
+		activeMode = null;
+		const restored = callRestoreTools();
+		console.log(`${ts()} [ScreenCompanion] deactivated mode=${exitedMode ?? '(unknown)'} restored=${restored}`);
+		return {
+			status: 'deactivated',
+			exited_mode: exitedMode,
+			tools_restored: restored,
+			_note: 'Screen-companion mode has ended. Resume normal operation with the full tool surface.',
+		};
+	},
+};
+
+export const tools: ToolDefinition[] = [activateScreenCompanionTool, deactivateScreenCompanionTool];

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -186,6 +186,37 @@ export function setVisionSession(session: unknown): void {
 	if (!session) stopStream();
 }
 
+// --- Tool-surface updater registry ----------------------------------------
+//
+// Lets skills call session.updateTools() without importing voice-agent.ts.
+// voice-agent registers the updater + full tool list after session creation,
+// clears it on shutdown. Skills call callUpdateTools/callRestoreTools to
+// enforce or lift a tools_allow constraint.
+
+type ToolUpdateFn = (tools: ToolDefinition[]) => void;
+let toolUpdaterFn: ToolUpdateFn | null = null;
+let fullToolSurface: ToolDefinition[] = [];
+
+/** Called by voice-agent after VoiceSession is constructed (and with null on shutdown). */
+export function setSessionToolUpdater(fn: ToolUpdateFn | null, fullTools: ToolDefinition[]): void {
+	toolUpdaterFn = fn;
+	fullToolSurface = fn ? fullTools : [];
+}
+
+/** Replace the live session's tool surface. Returns true if the updater is registered. */
+export function callUpdateTools(tools: ToolDefinition[]): boolean {
+	if (!toolUpdaterFn) return false;
+	toolUpdaterFn(tools);
+	return true;
+}
+
+/** Restore the session's tool surface to the full set registered at startup. */
+export function callRestoreTools(): boolean {
+	if (!toolUpdaterFn || fullToolSurface.length === 0) return false;
+	toolUpdaterFn(fullToolSurface);
+	return true;
+}
+
 function getSendFile(): ((b64: string, mime: string) => void) | null {
 	const t = sessionRef?.transport;
 	if (!t || !t.sendFile) return null;

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -29,7 +29,7 @@ import { z } from 'zod';
 import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, mkdirSync, copyFileSync, appendFileSync, writeFileSync, openSync, writeSync, closeSync } from 'node:fs';
 import { execSync as execSyncTop } from 'node:child_process';
 import { inlineTools, coreDocumentedSkills } from './inline-tools.js';
-import { setVisionSession, startVisionControlServer, stopVisionControlServer } from './vision-tools.js';
+import { setVisionSession, startVisionControlServer, stopVisionControlServer, setSessionToolUpdater } from './vision-tools.js';
 import { clearActiveArtifact } from './artifact-cache-tools.js';
 import { injectText } from './browser-tools.js';
 import { join, dirname } from 'node:path';
@@ -512,6 +512,8 @@ function getPresenterStateMarker(): string {
 	return '';
 }
 
+const mainAgentTools: ToolDefinition[] = [workTool, getTaskStatus, switchModeTool, saveMeetingNoteTool, ...inlineTools];
+
 const mainAgent: MainAgent = {
 	name: 'main',
 	get greeting() {
@@ -759,7 +761,7 @@ const mainAgent: MainAgent = {
 	// enable it once we find a reliable gate signal (probably after
 	// bodhi exposes a proper "user has actually spoken" signal under
 	// native audio).
-	tools: [workTool, getTaskStatus, switchModeTool, saveMeetingNoteTool, ...inlineTools],
+	tools: mainAgentTools,
 	googleSearch: VOICE_GOOGLE_SEARCH,
 	onEnter: async () => console.log(`${ts()} [Agent] Sutando ready`),
 	// Voice-driven close — strict version. User wants to be able to
@@ -988,6 +990,10 @@ async function main() {
 	// HTTP control endpoint so the web-client Watch button can drive the
 	// same controller (proxied through web-client to stay same-origin).
 	setVisionSession(session);
+	// updateTools is on the private transport (GeminiLiveTransport), not VoiceSession.
+	// Applied on next reconnect — restricts what Gemini sees after the next transport cycle.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	setSessionToolUpdater((tools) => (session as any).transport?.updateTools?.(tools), mainAgentTools);
 	startVisionControlServer();
 
 	// Bumped 5min into the future on every non-retryable transport close
@@ -1253,6 +1259,7 @@ async function main() {
 		console.log(`\n${ts()} Shutting down...`);
 		writeVoiceMetrics();
 		setVisionSession(null);
+		setSessionToolUpdater(null, []);
 		stopVisionControlServer();
 		await session.close('user_hangup');
 		process.exit(0);


### PR DESCRIPTION
## Summary

Closes #798.

- **`src/vision-tools.ts`**: Add `setSessionToolUpdater` / `callUpdateTools` / `callRestoreTools` — a minimal registry that lets skills update the live session's tool surface without importing `voice-agent.ts`. Same pattern as `setVisionSession` / `registerVisionOnContributor` already in this file.
- **`src/voice-agent.ts`**: Register the updater after session creation (`(session as any).transport?.updateTools?.()` — `updateTools` is on the private `GeminiLiveTransport`, applied on next reconnect). Clear on shutdown. Extract `mainAgentTools` array so the full surface is stored for restoration.
- **`skills/screen-companion/tools.ts`**: `activate_screen_companion` now calls `callUpdateTools()` to restrict the session to `tools_allow` + always-retained set (`activate_screen_companion`, `deactivate_screen_companion`). New `deactivate_screen_companion` tool calls `callRestoreTools()` to lift the restriction on user exit.
- **`skills/screen-companion/SKILL.md`**: Updated "Trust + scope" — enforcement is now hard, not advisory.

## Behaviour

When `activate_screen_companion` is called with a valid config:
1. Tool surface is immediately restricted: only tools named in `config.tools_allow` plus `activate_screen_companion` and `deactivate_screen_companion` remain.
2. `tools_enforced: true` in the return payload confirms the restriction fired.
3. If the session updater is not registered (phone-conversation context, tests), `callUpdateTools` returns `false` and advisory mode remains as a safe fallback.

When the user says "exit" / "stop" / "done", Gemini calls `deactivate_screen_companion`, which calls `callRestoreTools()` to restore the pre-activation tool surface.

## Note on timing

`GeminiLiveTransport.updateTools()` applies on the **next reconnect** — changes take effect when Gemini Live next re-establishes the session. The Gemini Live transport reconnects on normal session cycling (go-away, timeout, etc.), so in practice enforcement lands within the current or next session window.

## Test plan

- [ ] Boot voice-agent, activate `guided-setup` mode — confirm `tools_enforced: true` in log
- [ ] While in mode, verify Gemini cannot call tools outside `tools_allow` (no `work`, `press_key`, etc. in Gemini tool calls)
- [ ] Say "exit" or "stop the mode" — confirm `deactivate_screen_companion` called, full tool surface restored
- [ ] Test with `SUTANDO_PRIVATE_DIR` unset (no session updater) — confirm `tools_enforced: false`, mode still activates with advisory fallback
- [ ] TypeScript: `npx tsc --noEmit` passes clean