### PR TITLE
feat(workspace): add TS workspace_default module, migrate 4 callers (closes #763)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -28,6 +28,7 @@
 import { config as _dotenvConfig } from 'dotenv';
 import { mkdirSync, writeFileSync, appendFileSync, existsSync, readFileSync, unlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { resolveWorkspace } from '../../../src/workspace_default.js';
 
 _dotenvConfig({ path: new URL('../../../.env', import.meta.url).pathname, override: true });
 _dotenvConfig({ path: join(process.env.HOME ?? '', '.claude/channels/discord/.env'), override: false });
@@ -64,9 +65,7 @@ import {
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY ?? '';
 const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN ?? '';
-const WORKSPACE_DIR =
-	process.env.SUTANDO_WORKSPACE ||
-	join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const WORKSPACE_DIR = resolveWorkspace();
 const DATA_DIR = join(WORKSPACE_DIR, 'data');
 const RESULTS_DIR = process.env.DISCORD_VOICE_RESULTS_DIR || join(WORKSPACE_DIR, 'results');
 const TASKS_DIR = join(WORKSPACE_DIR, 'tasks');

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -48,8 +48,9 @@ import { config as _dotenvConfig } from 'dotenv';
 _dotenvConfig({ path: new URL('../../../.env', import.meta.url).pathname, override: true });
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { mkdirSync, writeFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync, symlinkSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join } from 'node:path';
 import { hostname } from 'node:os';
+import { resolveWorkspace } from '../../../src/workspace_default.js';
 
 // Personal-asset path resolver — twin of util_paths.py / voice-agent.ts:personalPath.
 function personalPath(filename: string): string {
@@ -62,7 +63,6 @@ function personalPath(filename: string): string {
 	}
 	return filename;
 }
-import { fileURLToPath } from 'node:url';
 import { execSync, spawn, type ChildProcess } from 'node:child_process';
 import { VoiceSession, type ToolDefinition, type MainAgent } from 'bodhi-realtime-agent';
 import { WebSocketServer, WebSocket } from 'ws';
@@ -99,7 +99,7 @@ const TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN ?? '';
 const TWILIO_PHONE_NUMBER = process.env.TWILIO_PHONE_NUMBER ?? '';
 const NGROK_AUTHTOKEN = process.env.NGROK_AUTHTOKEN ?? '';
 const PORT = Number(process.env.PHONE_PORT) || 3100;
-const WORKSPACE_DIR = process.env.SUTANDO_WORKSPACE || join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const WORKSPACE_DIR = resolveWorkspace();
 const RESULTS_DIR = process.env.PHONE_RESULTS_DIR || join(WORKSPACE_DIR, 'results');
 const TASKS_DIR = join(WORKSPACE_DIR, 'tasks');
 const TASK_POLL_INTERVAL_MS = 500;
@@ -1355,9 +1355,8 @@ const server = createServer(async (req, res) => {
 			const preVerified = VERIFIED_MEETINGS.has(originalId) || VERIFIED_MEETINGS.has(digits);
 			if (!preVerified) {
 				const taskId = `task-approve-${Date.now()}`;
-				const REPO_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 				const taskContent = `id: ${taskId}\ntimestamp: ${new Date().toISOString()}\ntask: Sutando joined meeting ${originalId || digits} (${platform}) — call SID ${sid}. Ask the user on Telegram whether to enable task delegation for this meeting. If approved, POST to http://localhost:3100/meeting-approve with {"callSid":"${sid}"}. If denied or no response within 2 minutes, do nothing (notes-only mode).\n`;
-				writeFileSync(join(REPO_DIR, 'tasks', `${taskId}.txt`), taskContent);
+				writeFileSync(join(WORKSPACE_DIR, 'tasks', `${taskId}.txt`), taskContent);
 				console.log(`${ts()} [Meeting] Approval requested: ${taskId}`);
 			} else {
 				VERIFIED_MEETINGS.add(originalId).add(digits);

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -12,8 +12,9 @@ import { writeFileSync, readFileSync, existsSync, unlinkSync, mkdirSync, readdir
 import { join } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
+import { resolveWorkspace } from './workspace_default.js';
 
-const REPO_DIR = process.env.SUTANDO_WORKSPACE || new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const REPO_DIR = resolveWorkspace();
 const TASK_DIR = join(REPO_DIR, 'tasks');
 const RESULT_DIR = join(REPO_DIR, 'results');
 const STATE_DIR = join(REPO_DIR, 'state');

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -14,21 +14,20 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readTmuxStatus } from './tmux-status.js';
 import { CHAT_HTML } from './chat-ui.js';
+import { resolveWorkspace } from './workspace_default.js';
 
 const HTTP_PORT = Number(process.env.CLIENT_PORT) || 8080;
 const HTTP_HOST = process.env.CLIENT_HOST || '0.0.0.0'; // '0.0.0.0' binds to all interfaces for EC2
 const WS_PORT = Number(process.env.PORT) || 9900;
 const DEFAULT_WS_URL = `ws://localhost:${WS_PORT}`;
 
-// Workspace-relative paths must be resolved against an absolute REPO_DIR (not
-// process.cwd()) so the client works when launched from a bundle/launchd/symlink
-// install where CWD isn't the workspace root. Matches task-bridge.ts (issue #713).
-const REPO_DIR = (process.env.SUTANDO_WORKSPACE && existsSync(process.env.SUTANDO_WORKSPACE))
-    ? process.env.SUTANDO_WORKSPACE
-    : resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const TASK_DIR = join(REPO_DIR, 'tasks');
-const STATE_DIR = join(REPO_DIR, 'state');
-const SUBSCRIPTIONS_PATH = join(REPO_DIR, 'skills/subscription-scanner/state/subscriptions.json');
+// Workspace-relative paths use resolveWorkspace() (closes #763). Skills paths
+// (non-runtime, code-adjacent) remain anchored to the repo root.
+const WORKSPACE_DIR = resolveWorkspace();
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const TASK_DIR = join(WORKSPACE_DIR, 'tasks');
+const STATE_DIR = join(WORKSPACE_DIR, 'state');
+const SUBSCRIPTIONS_PATH = join(REPO_ROOT, 'skills/subscription-scanner/state/subscriptions.json');
 
 const HTML = /* html */ `<!DOCTYPE html>
 <html lang="en">

--- a/src/workspace_default.ts
+++ b/src/workspace_default.ts
@@ -1,0 +1,26 @@
+/**
+ * Canonical workspace-directory resolution for Sutando TS services.
+ *
+ * All runtime artifacts (tasks/, results/, state/, data/, notes/, ...) live
+ * under the workspace dir. Callers MUST use resolveWorkspace() rather than
+ * computing paths relative to import.meta.url or process.cwd() — the latter
+ * breaks when invoked from a bundle/launchd/symlink install where those
+ * anchors resolve into the app package rather than the user workspace.
+ *
+ * Twin of src/workspace_default.py — no migration logic here. The Python
+ * services run first (via startup.sh) and handle the one-time dir-move from
+ * any legacy repo-root install. TS callers rely on that having already run.
+ *
+ * Resolution order:
+ *   1. $SUTANDO_WORKSPACE env var (~ expanded).
+ *   2. ~/.sutando/workspace/
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export function resolveWorkspace(): string {
+	const env = process.env.SUTANDO_WORKSPACE?.trim();
+	if (env) return env.replace(/^~/, homedir());
+	return join(homedir(), '.sutando', 'workspace');
+}

--- a/tests/task-bridge-format.test.ts
+++ b/tests/task-bridge-format.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, before, after, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync, readFileSync, readdirSync, unlinkSync, mkdirSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { resolveWorkspace } from '../src/workspace_default.js';
 import { workTool } from '../src/task-bridge.js';
 
 // Integration test for PR #460's unified task-file schema. Every voice /
@@ -10,8 +10,9 @@ import { workTool } from '../src/task-bridge.js';
 // emits, so downstream consumers (Claude Code session, access-tier
 // sandboxing) can treat all tasks uniformly.
 
-const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const TASK_DIR = join(REPO_ROOT, 'tasks');
+// Task dir is wherever the bridge writes — `resolveWorkspace()/tasks/`. Was
+// `<REPO_ROOT>/tasks/` pre-#821, when the bridge fell back to repo root.
+const TASK_DIR = join(resolveWorkspace(), 'tasks');
 
 function listTaskFiles(): string[] {
 	if (!existsSync(TASK_DIR)) return [];

--- a/tests/task-bridge-isvoice.test.ts
+++ b/tests/task-bridge-isvoice.test.ts
@@ -2,7 +2,7 @@ import { describe, it, before, after, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { writeFileSync, existsSync, unlinkSync, mkdirSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolveWorkspace } from '../src/workspace_default.js';
 import { _isVoiceTask } from '../src/task-bridge.js';
 
 // Regression for the archive-path drift bug flagged by VasiliyRad 2026-05-06:
@@ -15,8 +15,9 @@ import { _isVoiceTask } from '../src/task-bridge.js';
 // archive lookup all surface a voice task; non-voice content stays false; missing
 // task files stay false.
 
-const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const TASK_DIR = join(REPO_ROOT, 'tasks');
+// Task dir is wherever the bridge looks — `resolveWorkspace()/tasks/`. Was
+// `<REPO_ROOT>/tasks/` pre-#821, when the bridge fell back to repo root.
+const TASK_DIR = join(resolveWorkspace(), 'tasks');
 const ARCHIVE_DIR = join(TASK_DIR, 'archive');
 
 const VOICE_BODY = `id: task-isvoice-test-aaa


### PR DESCRIPTION
## Summary

- Adds `src/workspace_default.ts` — the TypeScript twin of `src/workspace_default.py`
- `resolveWorkspace()` returns `$SUTANDO_WORKSPACE` (with `~` expansion) or `~/.sutando/workspace/` as the canonical default, matching the Python contract
- Migrates all 4 TS callsites that were still using `import.meta.url`-relative or `existsSync`-guarded fallbacks to the repo root instead of `~/.sutando/workspace/`
- Closes the path divergence where Python bridges wrote to `~/.sutando/workspace/tasks/` but the TS voice-agent task-bridge wrote to `<repo>/tasks/`, silently dropping voice tasks from the watcher

Closes #763.

## Callers migrated

| File | Before | After |
|---|---|---|
| `src/task-bridge.ts` | `new URL('..', import.meta.url).pathname` (repo root) | `resolveWorkspace()` |
| `src/web-client.ts` | `existsSync`-guarded env or `dirname` fallback | `resolveWorkspace()` for tasks/state; `REPO_ROOT` kept for skills paths |
| `skills/phone-conversation/scripts/conversation-server.ts` | Two sites: env or `dirname(fileURLToPath(...))` | `resolveWorkspace()` both sites; unused `dirname`/`fileURLToPath` imports removed |
| `skills/discord-voice/scripts/discord-voice-server.ts` | env or `dirname(fileURLToPath(...))` | `resolveWorkspace()`; `dirname`/`fileURLToPath` retained for `SHARE_SCRIPT` (skill-relative) |

## Design notes

No migration logic in the TS module — `workspace_default.py` handles the one-time dir-move from legacy repo-root installs on first Python-service start. TS services always start after Python services (via `startup.sh`), so the migration has already run by the time any TS callers resolve the workspace.

`web-client.ts` now cleanly separates `WORKSPACE_DIR` (runtime state: tasks/, state/) from `REPO_ROOT` (code-adjacent: skills/subscription-scanner/state/) — these were previously conflated under a single `REPO_DIR`.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] With `SUTANDO_WORKSPACE` unset: voice agent task-bridge resolves to `~/.sutando/workspace/`
- [ ] With `SUTANDO_WORKSPACE=/custom/path`: all four services use `/custom/path`
- [ ] With `SUTANDO_WORKSPACE=~/custom`: `~` is expanded correctly
- [ ] `web-client.ts`: subscription scanner path still resolves against REPO_ROOT (not workspace)
- [ ] `discord-voice-server.ts`: `SHARE_SCRIPT` still resolves against skill directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)