### PR TITLE
feat(discord-bridge): treat owner DM edits within 5min as new tasks

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -1990,18 +1990,32 @@ async def on_message(message):
 
 @client.event
 async def on_message_edit(before, after):
-    """Handle edited messages that add a mention the bot didn't have before.
-    Scenario: user sends a message, then edits to add @Sutando mention later.
-    Without this handler, Discord fires on_message once on CREATE and the edit
-    is invisible to the bridge."""
+    """Handle edited messages in two cases:
+    Case 1: edit introduced a @Sutando mention that wasn't there before.
+    Case 2 (issue #795): owner edited their own DM within 5 minutes — treat as
+    a replacement task so corrections ("actually do X instead") are picked up."""
     if after.author == client.user:
         return
     if after.author.bot and client.user not in after.mentions:
         return
-    # Only reprocess if the edit introduced a mention that wasn't there before
+    # Case 1: edit introduced a bot mention
     if _message_mentions_bot(after) and not _message_mentions_bot(before):
         print(f"  [edit] mention added to msg {after.id} — reprocessing", flush=True)
         await _handle_discord_message(after, force=True)
+        return
+    # Case 2: owner edited their own DM within 5 minutes
+    if not isinstance(after.channel, discord.DMChannel):
+        return  # channel edits fire on embed unfurls/link previews — too noisy
+    if not after.content or after.content == before.content:
+        return  # attachment update or embed unfurl with no text change
+    sender_id = str(after.author.id)
+    if sender_id not in load_allowed():
+        return
+    age_sec = time.time() - after.created_at.timestamp()
+    if age_sec > 300:
+        return
+    print(f"  [edit] owner edited DM {after.id} within {age_sec:.0f}s — reprocessing as new task", flush=True)
+    await _handle_discord_message(after, force=True)
 
 
 async def _handle_discord_message(message, force=False):


### PR DESCRIPTION
## Summary

- Extends `on_message_edit` with Case 2 (issue #795): when the **owner** edits their own DM within 5 minutes, the edited message is reprocessed via `_handle_discord_message(after, force=True)` so corrections ("actually do X instead") reach the bridge as a replacement task.
- Restricted to DMs only — channel edits fire on embed unfurls / link previews and don't represent user intent.
- Skips events where `after.content == before.content` (attachment updates, embed unfurls with no text delta).
- Owner verified via existing `load_allowed()` before reprocessing.
- Case 1 (edit adds a bot @-mention) is preserved unchanged; now has an explicit `return` so it doesn't fall through into Case 2 guards.

Closes #795.

## Test plan
- [ ] Owner edits a DM within 5 min → bridge logs `[edit] owner edited DM … — reprocessing as new task` and a new task file is written
- [ ] Owner edits a DM after >5 min → no reprocessing (age_sec > 300 guard)
- [ ] Non-owner edits a DM → no reprocessing (`load_allowed()` guard)
- [ ] Owner edits a channel message → no reprocessing (`isinstance(DMChannel)` guard)
- [ ] Owner edits DM with no text change (e.g. embed unfurl) → no reprocessing (`content == before.content` guard)
- [ ] Edit that adds a bot @-mention → Case 1 still fires correctly; no double-processing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)