### PR TITLE
fix(daily-insight): honor SUTANDO_WORKSPACE — write to workspace, not repo

### DIFF
--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -14,8 +14,9 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from util_paths import shared_personal_path  # noqa: E402
+from workspace_default import resolve_workspace  # noqa: E402
 
-WORKSPACE = Path(__file__).parent.parent
+WORKSPACE = resolve_workspace()
 CALLS_FILE = WORKSPACE / "results" / "calls" / "calls.jsonl"
 RESULTS_DIR = WORKSPACE / "results"
 STATE_DIR = WORKSPACE / "state"


### PR DESCRIPTION
## Symptom

The 06:50 daily-insight cron has been crashing silently for weeks:

\`\`\`
FileNotFoundError: [Errno 2] No such file or directory:
'/Users/qingyunwu/Documents/github/sutando/results/insight-2026-05-18.txt'
\`\`\`

## Root cause

\`src/daily-insight.py:18\` hardcodes:

\`\`\`python
WORKSPACE = Path(__file__).parent.parent
\`\`\`

That resolves to the repo root (\`/Users/.../github/sutando/\`) — but on this machine the canonical \`\$SUTANDO_WORKSPACE\` is \`/Users/.../sutando-workspace-001/\`. The script tried to write to \`<repo>/results/insight-{date}.txt\`, which doesn't exist.

Same workspace-path-violation pattern that the bridges had pre-PR #762.

## Fix

One-line change: use the canonical \`resolve_workspace()\` helper from \`workspace_default\` (the same helper telegram-bridge.py, discord-bridge.py, agent-api.py, dashboard.py, dm-result.py, health-check.py already use).

\`\`\`diff
 sys.path.insert(0, str(Path(__file__).parent))
 from util_paths import shared_personal_path  # noqa: E402
+from workspace_default import resolve_workspace  # noqa: E402

-WORKSPACE = Path(__file__).parent.parent
+WORKSPACE = resolve_workspace()
\`\`\`

## Verification

\`\`\`
$ python3 src/daily-insight.py
Daily insight → /Users/qingyunwu/Documents/github/sutando-workspace-001/results/insight-2026-05-18.txt
You've made 2 calls total. Peak hour: 1:00 (1 calls). Hours with zero calls: 8:00, 9:00, 10:00. Consider scheduling deep work during those quiet windows.
\`\`\`

Now writes to workspace and produces real insight content. The morning-briefing cron at 06:57 reads from \`results/insight-{date}.txt\`, so once this is merged the daily insights will actually surface in tomorrow's briefing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)