### PR TITLE
fix(friction-detector): honor SUTANDO_WORKSPACE — write to workspace, not repo

### DIFF
--- a/src/friction-detector.py
+++ b/src/friction-detector.py
@@ -20,8 +20,9 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from util_paths import personal_path, shared_personal_path  # noqa: E402
+from workspace_default import resolve_workspace  # noqa: E402
 
-WORKSPACE = Path(__file__).parent.parent
+WORKSPACE = resolve_workspace()
 RESULTS_DIR = WORKSPACE / "results"
 
 


### PR DESCRIPTION
## Symptom

Sibling bug to PR #832. \`/morning-briefing\` calls \`friction-detector.py\` and it has been crashing silently for weeks:

\`\`\`
FileNotFoundError: [Errno 2] No such file or directory:
'/Users/qingyunwu/Documents/github/sutando/results/friction-2026-05-18.txt'
\`\`\`

## Root cause

Same one-line bug as \`daily-insight.py\` (fixed in #832). Line 24:

\`\`\`python
WORKSPACE = Path(__file__).parent.parent
\`\`\`

Resolves to the repo root, not \`\$SUTANDO_WORKSPACE\`.

## Fix

Match the canonical pattern from telegram-bridge / discord-bridge / agent-api / dashboard / health-check / dm-result:

\`\`\`diff
 sys.path.insert(0, str(Path(__file__).parent))
 from util_paths import personal_path, shared_personal_path  # noqa: E402
+from workspace_default import resolve_workspace  # noqa: E402

-WORKSPACE = Path(__file__).parent.parent
+WORKSPACE = resolve_workspace()
\`\`\`

## Verification

\`\`\`
$ python3 src/friction-detector.py
Friction check → /Users/qingyunwu/Documents/github/sutando-workspace-001/results/friction-2026-05-18.txt
Found 3 item(s) that may need attention:
  1. Pending question unanswered: 2026-05-13 — auto-open web UI: bundle vs git fork
  2. Pending question unanswered: 2026-05-09 — email organize task (voice, 21:01 PDT)
  3. Stale task unprocessed for 9h: task-1779092831899.txt
\`\`\`

Surfaces the two long-open pending questions + an orphaned stale task — exactly what a friction detector should be doing. Once merged the morning-briefing will get the ⚠️ Friction section back tomorrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)