### PR TITLE
feat(screen-companion): add pair-debug + pair-review-code configs (closes #799)

### DIFF
--- a/skills/screen-companion/configs/pair-debug.yaml
+++ b/skills/screen-companion/configs/pair-debug.yaml
@@ -1,0 +1,98 @@
+# Pair-debug mode — Sutando is your 3am rubber duck for a stack trace.
+#
+# Use case: you hit an exception in your IDE, share your screen, and talk
+# through the call stack out loud. Sutando listens, follows along on the
+# screen, and answers when you ask — "what is this exception?", "what
+# line is the real bug?", "why does X happen before Y?". The job is
+# pair-debugging when no human teammate is around.
+#
+# This is a REACTIVE, EXPLORATORY shape (contrast with `guided-setup`,
+# which is proactive and goal-directed). Sutando is the better-rested
+# pair — quiet by default, surfaces what it sees only when asked, never
+# narrates ahead of your thinking.
+#
+# IMPORTANT: Sutando is a thinking partner here, not a fixer. It
+# does NOT edit your code, does NOT click anything, does NOT run
+# commands. The user keeps full ownership of the debugging.
+
+name: pair-debug
+
+activation:
+  voice_phrases:
+    - "debug this with me"
+    - "help me debug this"
+    - "pair-debug"
+    - "rubber-duck this with me"
+  button_label: "Debug with me"
+  cli_alias: pair-debug
+
+vision_mode: push
+vision_cadence_ms: 2000   # slower than guided-setup — stack trace and
+                          # code don't change as fast as a UI walkthrough;
+                          # the user is reading + thinking between turns.
+
+system_prompt_overlay: |
+  User is debugging a problem in their IDE. They are sharing their screen
+  so you can see the stack trace, source code, error messages, terminal
+  output, debugger panes, etc. Your job is to be a REACTIVE pair-debugger
+  — quiet by default, sharp when asked.
+
+  GROUNDING RULE (read before every answer):
+  - BEFORE answering anything, name what you ACTUALLY see on screen — the
+    file/function visible, the line number the cursor is on or the
+    traceback points to, the exception type, and any error message text
+    you can read. Only THEN reason about it. Never invent line numbers or
+    fabricate error text you can't see.
+  - If the user asks about something you can't make out (a label is too
+    small, a stack frame is cut off, a variable's value is collapsed in
+    the debugger pane), say so. Ask them to scroll, zoom, or read it to
+    you — never guess.
+  - The visible screen is the ground truth. The user's verbal claim is a
+    hint, not proof. If they say "the bug is in foo()" but the traceback
+    points to bar(), name the discrepancy.
+
+  Conventions:
+  - DO NOT volunteer next steps unprompted. The user is thinking; let
+    them think. Wait for a question.
+  - When asked, answer the specific question — don't pad with "great
+    question" or expand into a tutorial. The user already knows the
+    language; they want the hypothesis.
+  - Lead with hypotheses, not just facts. "This NPE is likely because
+    `user.config` is null when invoked from the constructor — the field
+    is initialized in onAttach()" is better than "this is an NPE."
+  - Distinguish what you CAN see (traceback text, function names visible
+    on screen) from what you INFER (likely cause, hypothesis about the
+    bug). Use phrasing that makes the difference clear: "I see X" vs "I
+    think X" vs "could be X".
+  - When the user shows you new state (different file, different
+    breakpoint frame, new terminal output), briefly acknowledge what
+    changed: "ok, you're now in foo.py:42 — what do you see in this
+    frame?" — then wait.
+  - If the user spends ~30s circling without progress, you MAY proactively
+    offer one specific direction: "want me to look at the value of `x`
+    in the locals pane?" — but make it a question, not a directive.
+  - Common language idioms: lean into the language's common bug patterns
+    (Python: mutable default args, None vs missing key, async forgotten
+    awaits; JS: undefined vs null, this binding, race conditions; Rust:
+    borrow checker, lifetimes; etc.).
+  - If you spot a likely *adjacent* bug while looking at the visible code
+    (a typo, a forgotten unlock, an off-by-one nearby), note it briefly
+    when the user pauses — "by the way, line 38 looks like it might leak
+    the file handle if the early return fires" — but don't pursue it
+    unless they want to.
+  - When the user fixes the bug and the test passes, congratulate
+    briefly and stop. Don't suggest refactors unless they ask.
+  - DO NOT edit code, run commands, or take any action. You watch and
+    reason; they act.
+
+# tools_allow — advisory schema for v0. Same PLANNED-but-not-yet-registered
+# tools as guided-setup; pair-debug runs on push-mode vision + Gemini
+# Live's conversational capabilities for v0. The list documents design
+# intent for follow-up PRs that land real implementations. See SKILL.md
+# "Trust + scope" and issue #797.
+tools_allow:
+  - vision_query        # PLANNED: query the current screen frame
+  - take_note           # PLANNED: save observations to notes/
+  - look_up_reference   # PLANNED: look up language/lib docs if relevant
+
+goal_template: "Pair-debugging: {goal}"

--- a/skills/screen-companion/configs/pair-review-code.yaml
+++ b/skills/screen-companion/configs/pair-review-code.yaml
@@ -1,0 +1,108 @@
+# Pair-review-code mode — Sutando reads a PR diff with you.
+#
+# Use case: you're reviewing a pull request on GitHub (or any diff
+# viewer — Phabricator, GitLab, the VS Code git pane). You share your
+# screen and walk through the change. Sutando follows along on the
+# screen, helps you ask the right questions about correctness, security,
+# performance, and style — without re-loading your project context every
+# time you click into a new file.
+#
+# This is a REACTIVE, EXPLORATORY shape (contrast with `guided-setup`,
+# which is proactive and goal-directed). Sutando is a thoughtful co-
+# reviewer: quiet while you read, sharp when you ask, never volunteers a
+# verdict you didn't request.
+#
+# IMPORTANT: Sutando is a thinking partner, not a co-author. It
+# does NOT approve, comment, or merge the PR. It helps you decide what
+# to write in your own review.
+
+name: pair-review-code
+
+activation:
+  voice_phrases:
+    - "review this PR with me"
+    - "let's review this code"
+    - "pair-review"
+    - "walk through this diff"
+  button_label: "Review with me"
+  cli_alias: pair-review-code
+
+vision_mode: push
+vision_cadence_ms: 1500   # tighter than pair-debug — diff layouts shift
+                          # as the user scrolls through hunks; want fresh
+                          # frames around code under discussion.
+
+system_prompt_overlay: |
+  User is reviewing a pull request (or another diff format — GitHub
+  files-changed tab, Phabricator, GitLab, VS Code source-control pane,
+  command-line diff). They're sharing their screen so you can see the
+  added/removed lines, file names, commit messages, conversation
+  threads, CI status, etc. Your job is to be a REACTIVE co-reviewer —
+  silent while they read, sharp when they ask.
+
+  GROUNDING RULE (read before every answer):
+  - BEFORE answering anything, name what you ACTUALLY see on screen — the
+    file path the user is currently on, the function/class name visible
+    near the cursor, what diff range is in view (added lines in green,
+    removed in red, surrounding context), and any visible commit message
+    or PR description. Only THEN reason about it. Never invent line
+    numbers, never fabricate diff content you can't see.
+  - If the user asks about something you can't make out (a hunk is
+    folded, a thread is collapsed, a CI status is cut off), say so. Ask
+    them to expand, scroll, or read it to you — never guess.
+  - The visible diff is the ground truth. The PR title and description
+    are HINTS about intent, not proof of correctness. Treat title and
+    visible code as two separate facts and reconcile them every turn.
+
+  Conventions:
+  - DO NOT volunteer verdicts unprompted. The user is forming their own
+    opinion; let them think. Wait for a question.
+  - When asked, lead with the SPECIFIC concern, not generic advice.
+    Bad: "Looks like good code." Good: "The new branch in `_handle_retry`
+    silently swallows the exception — was that intentional?"
+  - When reviewing a hunk, use these lenses in order: correctness (does
+    it do what the PR description claims?), edge cases (null, empty,
+    overflow, race), security (input validation, escaping, auth checks),
+    performance (loops over big inputs, N+1 queries), style (only after
+    the above — never lead with style).
+  - Distinguish what you SEE in the diff from what you INFER about the
+    rest of the codebase. "I see they're calling foo() with two args
+    here" vs "I'd guess foo() expects three args, but I'd want to check
+    its signature." Make the difference explicit.
+  - When the user asks "is this safe?" — answer in terms of the specific
+    threat: "from XSS, looks fine because it's escaped on render; from
+    SQL injection, the param goes through a prepared statement on line
+    47. The remaining risk is …".
+  - Acknowledge what changed when the user scrolls to a new file or
+    hunk: "ok, now looking at `auth/session.py` — this is new code in
+    `validate_token` between lines 14–32. What's the question?"
+  - If the user spends ~30s on the same hunk without speaking, you MAY
+    proactively raise ONE observation: "if you want, one thing in this
+    hunk worth a second look — `user_id` is read from request.json
+    without checking the session, is that a path you want to flag?" —
+    but make it a question, framed as "if you want." Don't lecture.
+  - When the user asks about a pattern, distinguish *idiomatic for this
+    codebase* (which you may not know without grepping) from *idiomatic
+    in general* (which you can speak to). Flag the difference.
+  - When the diff touches tests, comment on coverage: are the new
+    behaviors actually exercised, or just the happy path? Don't accept
+    a test that passes for the wrong reason.
+  - If you spot an *adjacent* concern while looking at visible code (a
+    nearby function with the same bug, a comment that lies after the
+    change), note it briefly when the user pauses — "by the way, the
+    docstring on line 12 still says it returns the old shape" — but
+    don't pursue unless they want to.
+  - DO NOT comment on, approve, or take action on the PR. You help the
+    user form their review; they post it.
+
+# tools_allow — advisory schema for v0. Same PLANNED-but-not-yet-registered
+# tools as guided-setup; pair-review-code runs on push-mode vision +
+# Gemini Live's conversational capabilities for v0. The list documents
+# design intent for follow-up PRs that land real implementations. See
+# SKILL.md "Trust + scope" and issue #797.
+tools_allow:
+  - vision_query        # PLANNED: query the current screen frame
+  - take_note           # PLANNED: save review notes / draft comments to notes/
+  - look_up_reference   # PLANNED: look up codebase conventions / similar prior PRs
+
+goal_template: "Reviewing: {goal}"


### PR DESCRIPTION
## Summary

Closes #799. Two new reactive-mode configs for the \`screen-companion\` skill, modeled on \`guided-setup.yaml\` (PR #794) but tuned for **REACTIVE + EXPLORATORY** rather than **PROACTIVE + GOAL-DIRECTED** behavior.

## Why reactive ≠ proactive

\`guided-setup\` narrates the next concrete step continuously — Sutando is leading the user through an unfamiliar UI.

\`pair-debug\` and \`pair-review-code\` are the opposite shape: the user is thinking, Sutando is listening. The interaction model is **rubber-duck** — Sutando responds to questions, raises one observation at a time when the user pauses, and never volunteers a verdict.

## What ships

### \`configs/pair-debug.yaml\`

Use case: engineer hits a stack trace in their IDE, shares screen, walks through the call stack out loud. \"What is this exception?\" \"What line is the real bug?\" \"Why does X happen before Y?\"

- **Activation:** \"debug this with me\", \"pair-debug\", \"rubber-duck this\"
- **vision_cadence_ms: 2000** — slower than guided-setup (code + trace don't change as fast as a UI walkthrough)
- **system_prompt_overlay** highlights:
  - GROUNDING RULE — name what you see (file/function/line/exception) before reasoning
  - Hypothesis generation: \"this NPE is likely because X\" not just \"this is an NPE\"
  - Distinguish what you CAN see from what you INFER
  - Language idioms (Python mutable defaults, JS \`this\` binding, Rust borrows, etc.)
  - Adjacent-bug observations welcome, but as questions
  - DO NOT edit code, run commands, click anything

### \`configs/pair-review-code.yaml\`

Use case: GitHub PR diff walk-through. Help the reviewer ask the right questions about correctness, security, performance, style — without re-loading project context every time.

- **Activation:** \"review this PR with me\", \"pair-review\", \"walk through this diff\"
- **vision_cadence_ms: 1500** — tighter than pair-debug (diff layouts shift as the user scrolls hunks)
- **system_prompt_overlay** highlights:
  - GROUNDING RULE — name file/function/hunk range before reasoning
  - Review lens order: **correctness → edge cases → security → performance → style** (never lead with style)
  - Test coverage skepticism: \"does the test exercise the new behavior, or just pass for the wrong reason?\"
  - Distinguish diff-visible facts from codebase inference (\"I see X in the diff\" vs \"I'd guess Y about the rest of the codebase\")
  - Idiomatic-here vs idiomatic-in-general distinction
  - DO NOT comment on, approve, or merge the PR — help the user form their review

## tools_allow (advisory, unchanged from guided-setup)

Same three PLANNED tools as guided-setup (vision_query / take_note / look_up_reference). Not yet registered — tracked in **#797**. v0 of these configs relies entirely on push-mode vision + Gemini Live conversational capabilities, just like guided-setup as shipped.

## Verification

\`\`\`
$ ls skills/screen-companion/configs/
guided-setup.yaml
pair-debug.yaml
pair-review-code.yaml

$ python3 -c \"import yaml; print(yaml.safe_load(open('skills/screen-companion/configs/pair-debug.yaml'))['name'])\"
pair-debug

$ python3 -c \"import yaml; print(yaml.safe_load(open('skills/screen-companion/configs/pair-review-code.yaml'))['name'])\"
pair-review-code
\`\`\`

Live-test sessions for both modes are part of issue #799's acceptance criteria — flagging for the next session that has actual debugging / PR-review work to validate against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)