### PR TITLE
fix(workspace): honor SUTANDO_WORKSPACE in 5 scripts (audit followup to #815)

### DIFF
--- a/src/call-stats.py
+++ b/src/call-stats.py
@@ -22,7 +22,10 @@ from collections import Counter
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-CALLS_FILE = Path(__file__).parent.parent / "results" / "calls" / "calls.jsonl"
+sys.path.insert(0, str(Path(__file__).parent))
+from workspace_default import resolve_workspace  # noqa: E402
+
+CALLS_FILE = resolve_workspace() / "results" / "calls" / "calls.jsonl"
 
 
 def load_calls():

--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -16,8 +16,9 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 from util_paths import personal_path  # noqa: E402
+from workspace_default import resolve_workspace  # noqa: E402
 
-WORKSPACE = Path(__file__).parent.parent
+WORKSPACE = resolve_workspace()
 PQ_FILE = Path(personal_path("pending-questions.md", WORKSPACE))
 RESULTS_DIR = WORKSPACE / "results"
 LAST_NOTIFY_FILE = WORKSPACE / ".last-pq-notify"

--- a/src/event_log.py
+++ b/src/event_log.py
@@ -50,8 +50,11 @@ from typing import Any
 
 __all__ = ["log_event", "get_log_path", "LOGS_DIR"]
 
-REPO_DIR = Path(__file__).resolve().parent.parent
-LOGS_DIR = REPO_DIR / "logs"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_default import resolve_workspace  # noqa: E402
+
+WORKSPACE_DIR = resolve_workspace()
+LOGS_DIR = WORKSPACE_DIR / "logs"
 
 _CACHED_MACHINE: str | None = None
 
@@ -65,7 +68,7 @@ def _machine_id() -> str:
     try:
         sys.path.insert(0, str(Path(__file__).parent))
         from util_paths import personal_path
-        identity = personal_path("stand-identity.json", workspace=REPO_DIR)
+        identity = personal_path("stand-identity.json", workspace=WORKSPACE_DIR)
         if identity.exists():
             _CACHED_MACHINE = json.loads(identity.read_text()).get("machine", "") or "unknown"
         else:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -311,7 +311,7 @@ def _voice_log_path() -> Path:
     permanently warn "voice-agent.log not found" on Sutando.app installs.
     """
     launchd_log = Path.home() / "Library/Application Support/Sutando/logs/voice-agent.log"
-    workspace_log = REPO_DIR / "logs" / "voice-agent.log"
+    workspace_log = WORKSPACE_DIR / "logs" / "voice-agent.log"
     if launchd_log.exists() and launchd_log.stat().st_size > 0:
         return launchd_log
     return workspace_log
@@ -595,7 +595,7 @@ def check_core_proactive_loop(threshold_sec: int = 600) -> dict:
     Status is anything other than "running" → ok regardless of age.
     """
     name = "core-proactive-loop"
-    status_path = REPO_DIR / "core-status.json"
+    status_path = WORKSPACE_DIR / "core-status.json"
     if not status_path.exists():
         return {"name": name, "status": "ok", "detail": "core-status.json not yet written"}
     try:
@@ -678,7 +678,7 @@ def run_all_checks() -> list[dict]:
     # Critical files
     for name, path in [
         ("CLAUDE.md", REPO_DIR / "CLAUDE.md"),
-        ("build_log.md", REPO_DIR / "build_log.md"),
+        ("build_log.md", WORKSPACE_DIR / "build_log.md"),
         (".env", REPO_DIR / ".env"),
     ]:
         checks.append(check_file(path, name))
@@ -792,7 +792,7 @@ def run_all_checks() -> list[dict]:
         # so log-stale warnings never fired (caught 2026-05-05 when Mini's
         # logs/discord-bridge.log was 36h stale but health-check stayed "ok").
         import time
-        log_file = REPO_DIR / "logs" / f"{name}.log"
+        log_file = WORKSPACE_DIR / "logs" / f"{name}.log"
         if not log_file.exists():
             log_file = REPO_DIR / "src" / f"{name}.log"
         detail = "running"
@@ -804,7 +804,7 @@ def run_all_checks() -> list[dict]:
                 detail = f"running but log stale ({int(age_sec)}s old)"
 
         # Check 3: Heartbeat file freshness (overrides log staleness if fresh)
-        heartbeat_file = REPO_DIR / "state" / f"{name}.heartbeat"
+        heartbeat_file = WORKSPACE_DIR / "state" / f"{name}.heartbeat"
         if heartbeat_file.exists():
             hb_age = time.time() - heartbeat_file.stat().st_mtime
             if hb_age <= 120:  # heartbeat is fresh — bridge is alive
@@ -1168,7 +1168,7 @@ def main():
                     # dotenv, etc.) — restart would crash on import.
                     # Log path uses logs/ (post-PR #251 refactor).
                     subprocess.Popen([sys.executable, str(REPO_DIR / "src" / f"{c['name']}.py")],
-                                     stdout=open(str(REPO_DIR / "logs" / f"{c['name']}.log"), "a"),
+                                     stdout=open(str(WORKSPACE_DIR / "logs" / f"{c['name']}.log"), "a"),
                                      stderr=subprocess.STDOUT, start_new_session=True)
                     print(f"  {c['name']}: {'restarted (stale code)' if c['status'] == 'stale' else 'restarted'}")
                 elif c["name"] == "sutando-app":

--- a/src/scan-call-logs.py
+++ b/src/scan-call-logs.py
@@ -12,8 +12,12 @@ import json, re, sys, os
 from pathlib import Path
 from datetime import datetime
 
-CALLS_FILE = Path(__file__).parent.parent / "results" / "calls" / "calls.jsonl"
-STATE_FILE = Path(__file__).parent.parent / "results" / "calls" / ".scan-state.json"
+sys.path.insert(0, str(Path(__file__).parent))
+from workspace_default import resolve_workspace  # noqa: E402
+
+_WORKSPACE = resolve_workspace()
+CALLS_FILE = _WORKSPACE / "results" / "calls" / "calls.jsonl"
+STATE_FILE = _WORKSPACE / "results" / "calls" / ".scan-state.json"
 
 # --- Detection patterns ---
 

--- a/tests/health-check-stuck-loop.test.py
+++ b/tests/health-check-stuck-loop.test.py
@@ -59,11 +59,13 @@ def make_checks(*statuses_and_names):
     return [{"name": n, "status": s, "detail": "test"} for (s, n) in statuses_and_names]
 
 
-def write_status(repo_dir: Path, payload: dict | None) -> None:
-    """Write core-status.json into a temp REPO_DIR override; pass None to
-    skip writing the file at all."""
+def write_status(workspace_dir: Path, payload: dict | None) -> None:
+    """Write core-status.json into a temp WORKSPACE_DIR override; pass None
+    to skip writing the file at all. (Was REPO_DIR pre-PR #836;
+    check_core_proactive_loop now reads from WORKSPACE_DIR — core-status.json
+    is per-user runtime state, not code.)"""
     if payload is not None:
-        (repo_dir / "core-status.json").write_text(json.dumps(payload))
+        (workspace_dir / "core-status.json").write_text(json.dumps(payload))
 
 
 def write_task(tasks_dir: Path, name: str, age_sec: int) -> Path:
@@ -79,17 +81,19 @@ def write_task(tasks_dir: Path, name: str, age_sec: int) -> Path:
 # ---------------------------------------------------------------------------
 
 def with_repo_override(payload):
-    """Run check_core_proactive_loop against a temp REPO_DIR. Returns the
-    check dict. `payload=None` means don't write the status file."""
+    """Run check_core_proactive_loop against a temp WORKSPACE_DIR. Returns
+    the check dict. `payload=None` means don't write the status file.
+    Renamed semantics: pre-PR #836 this mocked REPO_DIR; core-status.json
+    now lives in WORKSPACE_DIR (per-user runtime state)."""
     with tempfile.TemporaryDirectory() as td:
         td = Path(td)
         write_status(td, payload)
-        orig_repo = hc.REPO_DIR
+        orig_ws = hc.WORKSPACE_DIR
         try:
-            hc.REPO_DIR = td
+            hc.WORKSPACE_DIR = td
             return hc.check_core_proactive_loop(threshold_sec=600)
         finally:
-            hc.REPO_DIR = orig_repo
+            hc.WORKSPACE_DIR = orig_ws
 
 
 def case_a_status_missing() -> list[str]:
@@ -105,12 +109,12 @@ def case_b_status_malformed() -> list[str]:
     with tempfile.TemporaryDirectory() as td:
         td = Path(td)
         (td / "core-status.json").write_text("{ this is not json")
-        orig = hc.REPO_DIR
+        orig = hc.WORKSPACE_DIR
         try:
-            hc.REPO_DIR = td
+            hc.WORKSPACE_DIR = td
             r = hc.check_core_proactive_loop(threshold_sec=600)
         finally:
-            hc.REPO_DIR = orig
+            hc.WORKSPACE_DIR = orig
     if r["status"] != "ok":
         fails.append(f"b) malformed JSON should be ok (don't false-alarm), got {r['status']}")
     return fails


### PR DESCRIPTION
## Summary

Owner asked: \"PR #815 is just one example. There might be more of such issues.\" Audit confirmed **10 bugs across 5 scripts** all hitting the same workspace-vs-repo distinction the bridges fixed pre-#762.

Each script was resolving per-user-state paths (\`logs/\`, \`results/\`, \`state/\`, \`build_log.md\`, \`core-status.json\`, \`pending-questions.md\`) to the repo root instead of \`\$SUTANDO_WORKSPACE\`. On any workspace-only install (i.e. canonical setup post-#762), the scripts were reading/writing the wrong place — silently for some, with FileNotFoundError for others.

## Files

| File | Sites fixed | Behavior delta |
|---|---|---|
| \`src/health-check.py\` | 6 (lines 314, 598, 681, 795, 807, 1171) | False-positive cascade GONE (log stale / heartbeat missing / build_log missing / sutando-app not running). Real issues (voice-agent code stale, discord-bridge code stale) now surface cleanly. |
| \`src/event_log.py\` | 2 (LOGS_DIR + personal_path workspace arg) | LOGS_DIR now resolves to workspace |
| \`src/check-pending-questions.py\` | 1 (module-level WORKSPACE) | The cron has been silently doing nothing for weeks. Now surfaces the 2 long-pending questions. |
| \`src/call-stats.py\` | 1 (CALLS_FILE) | Was reading 0 calls on workspace-only installs. Now reads real data. |
| \`src/scan-call-logs.py\` | 2 (CALLS_FILE, STATE_FILE) | Same as call-stats. |

Each follows the same canonical pattern as PR #832 (daily-insight) and #833 (friction-detector): \`from workspace_default import resolve_workspace; WORKSPACE = resolve_workspace()\`.

## What's NOT in this PR

- \`src/health-check.py\` line 693 (notes-dir) — leaving to **PR #815** (James) to avoid conflict. Same bug, same fix shape.
- Code paths in health-check.py that legitimately use REPO_DIR (\`src/*.py\` for restart-spawn, \`src/*.ts\` for staleness checks, \`node_modules/bodhi-realtime-agent\`, \`Sutando.app\` binary, \`subprocess cwd=\`, \`.env\`, \`CLAUDE.md\`) — kept as-is.

## Verification

\`\`\`
$ python3 src/health-check.py
  ✓ core-proactive-loop            ok           running (186s ago)
  ✓ sutando-app                    ok           running (⌃C/⌃V/⌃M)
  ✓ task-queue                     ok           3 task(s), oldest 309s
  ⚠ voice-agent: stale (running but code is 998 min newer than process — restart needed)   # REAL
  ⚠ discord-bridge: stale (running but code is 1117 min newer than process — restart needed) # REAL

$ python3 src/check-pending-questions.py
Notified: 2 pending questions   # the May 9 + May 13 questions; cron was silently broken

$ python3 src/call-stats.py
☎️  Top callers:
   +1-434-XXX-XXXX: 2

$ python3 src/scan-call-logs.py
No new calls to scan (total: 2, already scanned: 2).
\`\`\`

The false-positive noise I've been logging on every health-check task for 18+ hours (\"telegram-bridge log stale, discord-bridge log stale, sutando-app not running\") is gone with this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)