### PR TITLE
fix(sutando-app): split workspace (runtime) from repoRoot (skills-adjacent)

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -13,19 +13,35 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var hotKeyRefs: [EventHotKeyRef?] = []  // one entry per registered hotkey
     var hotKeyActions: [UInt32: String] = [:]  // hotkey id → action name
     var lastDropTime: Date = .distantPast
+    // Runtime state lives under the per-user workspace dir, not the repo
+    // checkout. Mirrors src/workspace_default.py + src/workspace_default.ts
+    // (PR #762 / #821). Resolution:
+    //   1. $SUTANDO_WORKSPACE (override; ~ expansion supported)
+    //   2. ~/.sutando/workspace/ (canonical default)
+    //
+    // Pre-#762 main.swift wrote tasks/logs/state under the repo checkout via
+    // CLAUDE.md walk-up. Post-#762 that dir no longer exists, so writeTask
+    // silently failed (try? write returns nil if parent dir missing) — the
+    // bug Chi hit 2026-05-18 where context-drop notified + logged but the
+    // bridge never saw the task.
     let workspace: String = {
-        // Derive from binary location → repo root
-        // Raw binary: src/Sutando/Sutando (3 levels up)
-        // .app bundle: src/Sutando/Sutando.app/Contents/MacOS/Sutando (5 levels up)
+        let env = ProcessInfo.processInfo.environment["SUTANDO_WORKSPACE"]?.trimmingCharacters(in: .whitespaces)
+        if let env = env, !env.isEmpty {
+            return (env as NSString).expandingTildeInPath
+        }
+        return NSHomeDirectory() + "/.sutando/workspace"
+    }()
+
+    // Repo checkout for skills-adjacent paths (assets, src/*.py, scripts/*.sh)
+    // that ship alongside the code. Same CLAUDE.md walk-up used before #762.
+    let repoRoot: String = {
         var url = URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0]).resolvingSymlinksInPath()
-        // Walk up until we find CLAUDE.md (repo root marker)
         for _ in 0..<8 {
             url = url.deletingLastPathComponent()
             if FileManager.default.fileExists(atPath: url.appendingPathComponent("CLAUDE.md").path) {
                 return url.path
             }
         }
-        // Fallback: 3 levels up from binary
         let fallback = URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0]).resolvingSymlinksInPath()
         return fallback.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().path
     }()
@@ -154,7 +170,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func setupMenuBar() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         if let button = statusItem.button {
-            let avatarPath = workspace + "/assets/stand-avatar.png"
+            let avatarPath = repoRoot + "/assets/stand-avatar.png"
             if let image = NSImage(contentsOfFile: avatarPath) {
                 image.size = NSSize(width: 18, height: 18)
                 image.isTemplate = false
@@ -793,7 +809,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// Composited onto the top-right corner of the 18×18 avatar so the
     /// menu bar continuously signals mode without taking an extra slot.
     func avatarImage(presenterActive: Bool, meetingActive: Bool = false) -> NSImage? {
-        let avatarPath = workspace + "/assets/stand-avatar.png"
+        let avatarPath = repoRoot + "/assets/stand-avatar.png"
         guard let base = NSImage(contentsOfFile: avatarPath) else { return nil }
         base.size = NSSize(width: 18, height: 18)
         base.isTemplate = false
@@ -1541,6 +1557,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         \(content)
         """
         let taskPath = tasksDir + "/task-\(ts).txt"
+        // mkdir -p the parent dir to prevent the silent-failure class where
+        // try?-write returns nil and the dropped context vanishes. This was
+        // the bug Chi hit 2026-05-18: workspace var pointed at repo, but
+        // tasks/ had been moved to the workspace dir by PR #762, so
+        // try? write to <repo>/tasks/task-X.txt silently dropped the data.
+        try? FileManager.default.createDirectory(atPath: tasksDir, withIntermediateDirectories: true)
         try? taskContent.write(toFile: taskPath, atomically: true, encoding: .utf8)
     }
 
@@ -1557,7 +1579,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         lastHealthCheckStart = now
 
         let logPath = workspace + "/logs/health-check.log"
-        let scriptPath = workspace + "/src/health-check.py"
+        let scriptPath = repoRoot + "/src/health-check.py"
         // Match the (retired) launchd plist's interpreter so behavior is
         // identical. Falls back to /usr/bin/env python3 if homebrew python
         // is missing on this host.
@@ -1692,7 +1714,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         notify("Sutando", "Restarting all services...")
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/bash")
-        proc.arguments = [workspace + "/src/restart.sh"]
+        proc.arguments = [repoRoot + "/src/restart.sh"]
         proc.standardOutput = FileHandle.nullDevice
         proc.standardError = FileHandle.nullDevice
         DispatchQueue.global(qos: .utility).async {
@@ -1705,7 +1727,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         notify("Sutando", "Stopping all services...")
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/bash")
-        proc.arguments = [workspace + "/src/stop.sh"]
+        proc.arguments = [repoRoot + "/src/stop.sh"]
         proc.standardOutput = FileHandle.nullDevice
         proc.standardError = FileHandle.nullDevice
         DispatchQueue.global(qos: .utility).async {
@@ -1807,7 +1829,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// this only restarts the Claude Code CLI session.
     @objc func restartCore() {
         notify("Sutando", "Restarting Core CLI…")
-        let script = workspace + "/scripts/start-cli.sh"
+        let script = repoRoot + "/scripts/start-cli.sh"
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/bash")
         proc.arguments = [script, "--restart"]

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -112,6 +112,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             registerHotKey()
             watchResults()
             logToFile("App started, workspace=\(workspace)")
+            // Startup smoke: ensure the runtime dirs exist so the silent-
+            // write class can't recur (Mini nit #3). mkdir is idempotent;
+            // missing-dir is logged so an unexpected absence is visible.
+            for sub in ["tasks", "logs", "state", "results"] {
+                let dir = workspace + "/" + sub
+                if !FileManager.default.fileExists(atPath: dir) {
+                    logToFile("startup-smoke: \(sub)/ missing under \(workspace) — creating")
+                }
+                try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            }
         }
     }
 
@@ -1539,12 +1549,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func appendLog(_ path: String, _ line: String) {
+        // mkdir -p parent so the write doesn't silently drop when the log
+        // dir is missing — same defensive pattern as writeTask (Mini nit #2).
+        let parent = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: parent, withIntermediateDirectories: true)
         if let handle = FileHandle(forWritingAtPath: path) {
             handle.seekToEndOfFile()
             handle.write((line + "\n").data(using: .utf8)!)
             handle.closeFile()
         } else {
-            try? (line + "\n").write(toFile: path, atomically: true, encoding: .utf8)
+            do {
+                try (line + "\n").write(toFile: path, atomically: true, encoding: .utf8)
+            } catch {
+                // Last-resort log so disk-full / permission failures aren't
+                // silent (Mini nit #1). logToFile writes to a different dir
+                // so a single-dir failure doesn't cascade.
+                logToFile("appendLog: write failed for \(path) — \(error.localizedDescription)")
+            }
         }
     }
 
@@ -1563,7 +1584,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // tasks/ had been moved to the workspace dir by PR #762, so
         // try? write to <repo>/tasks/task-X.txt silently dropped the data.
         try? FileManager.default.createDirectory(atPath: tasksDir, withIntermediateDirectories: true)
-        try? taskContent.write(toFile: taskPath, atomically: true, encoding: .utf8)
+        do {
+            try taskContent.write(toFile: taskPath, atomically: true, encoding: .utf8)
+        } catch {
+            // disk-full / permission fail (Mini nit #1) — don't lose the
+            // signal silently. Surface to debug log.
+            logToFile("writeTask: write failed for \(taskPath) — \(error.localizedDescription)")
+        }
     }
 
     var lastHealthCheckStart: Date = .distantPast


### PR DESCRIPTION
## Summary

Mirrors `src/workspace_default.py` (PR #762) + `src/workspace_default.ts` (PR #821, in-flight) in Swift. Splits the single `workspace` var in `main.swift` into two:

- **`workspace`** → `$SUTANDO_WORKSPACE` env or `~/.sutando/workspace/` — for runtime state (logs/, tasks/, state/, results/, pending-questions.md, contextual-chips.json). 19 call sites.
- **`repoRoot`** → CLAUDE.md walk-up (the old `workspace` logic) — for skills-adjacent paths that ship with the code (assets/stand-avatar.png × 2, src/health-check.py, src/restart.sh, src/stop.sh, scripts/start-cli.sh). 5 call sites.

Also defensive-mkdir's `writeTask` to prevent silent-failure recurrence.

## Why

Chi hit a silent data-loss bug today (2026-05-18): context-drop hotkey fired, Sutando.app notified + appended its log line ("Dropped: 236 chars"), but the dropped text vanished. Bridge never saw the task. Recovered only via clipboard.

Root cause: `main.swift`'s `workspace` resolved to the repo checkout via CLAUDE.md walk-up, but `<repo>/tasks/` was removed in PR #762's workspace migration (`tasks/` moved to `~/.sutando/workspace/tasks/`). `writeTask`'s `try? content.write(toFile: taskPath, atomically: true, ...)` silently returns nil when the parent dir is missing, so the bridge never saw the task. Same class as the Python+TS callers PR #762 / #821 fix — just unfixed on the Swift side until now.

## Test plan

- [x] `swiftc -parse src/Sutando/main.swift` — no syntax errors
- [ ] Rebuild Sutando.app; verify debug log shows fresh writes to `~/.sutando/workspace/logs/sutando-app-debug.log` (not `<repo>/logs/`)
- [ ] Drop context via hotkey; verify task lands in `~/.sutando/workspace/tasks/task-*.txt`
- [ ] Health-check menu still resolves to `<repo>/src/health-check.py` (via `repoRoot`)
- [ ] Avatar still loads (via `repoRoot + "/assets/stand-avatar.png"`)
- [ ] `SUTANDO_WORKSPACE=/tmp/wstest open Sutando.app` — drop lands in `/tmp/wstest/tasks/`

## Co-authoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)