### PR TITLE
fix(workspace): honor SUTANDO_WORKSPACE in 3 more scripts (round 2 audit, followup to #836)

### DIFF
--- a/skills/regression-search/scripts/diagnose-call.py
+++ b/skills/regression-search/scripts/diagnose-call.py
@@ -21,9 +21,16 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-REPO = Path(__file__).resolve().parent.parent.parent.parent
-CALLS_FILE = REPO / "results" / "calls" / "calls.jsonl"
-METRICS_FILE = REPO / "data" / "call-metrics.jsonl"
+# results/calls/ and data/call-metrics.jsonl are per-user runtime state —
+# live under $SUTANDO_WORKSPACE. Pre-fix this resolved to the repo checkout
+# which doesn't have either file post-#762, so `diagnose-call <sid>` always
+# printed "No call matches".
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "src"))
+from workspace_default import resolve_workspace  # noqa: E402
+
+WORKSPACE = resolve_workspace()
+CALLS_FILE = WORKSPACE / "results" / "calls" / "calls.jsonl"
+METRICS_FILE = WORKSPACE / "data" / "call-metrics.jsonl"
 
 REFUSAL_RE = re.compile(
     r"\b(i\s*can'?t|i'?m\s*not\s*able|i'?m\s*unable|unable\s*to|sorry,?\s*i\s*(can'?t|cannot))\b",

--- a/skills/regression-search/scripts/find-regression.py
+++ b/skills/regression-search/scripts/find-regression.py
@@ -18,7 +18,14 @@ import re
 import sys
 from pathlib import Path
 
-CALLS_FILE = Path(__file__).resolve().parent.parent.parent.parent / "results" / "calls" / "calls.jsonl"
+# results/calls/ is per-user runtime state — lives under $SUTANDO_WORKSPACE.
+# Pre-fix this resolved to <repo>/results/calls/calls.jsonl which doesn't
+# exist post-#762, so every `find-regression "..."` query silently returned
+# "calls file not found" instead of scanning real call history.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent.parent / "src"))
+from workspace_default import resolve_workspace  # noqa: E402
+
+CALLS_FILE = resolve_workspace() / "results" / "calls" / "calls.jsonl"
 
 # (label, regex) pairs — label is what shows up in the reasons column
 REFUSAL_PATTERNS = [

--- a/src/archive-stale-results.py
+++ b/src/archive-stale-results.py
@@ -31,8 +31,17 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
-RESULTS = REPO / "results"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_default import resolve_workspace  # noqa: E402
+
+# results/ is per-user runtime state — lives under $SUTANDO_WORKSPACE
+# (default ~/.sutando/workspace/), not the repo checkout. Pre-#762 this
+# resolved to <repo>/results/ which doesn't exist post-migration; the
+# archiver silently no-op'd because `if not RESULTS.is_dir()` short-circuits
+# the whole sweep. The DM-flood prevention this script was built for was
+# defeated until this fix.
+WORKSPACE = resolve_workspace()
+RESULTS = WORKSPACE / "results"
 
 RETENTION_HOURS = int(os.environ.get("RETENTION_HOURS", "24"))
 # Case-insensitive compare — without `.lower()`, `DRY_RUN=No` or `DRY_RUN=FALSE`


### PR DESCRIPTION
## Summary

PR #836 fixed 10 bug sites across 5 scripts hitting the workspace-vs-repo class. Owner asked the question \"PR #815 is just one example. There might be more of such issues.\" — the answer was yes, more sites existed, and #836 was \"all I could find from the first sweep.\" A widened grep across `src/`, `scripts/`, and `skills/` (the previous audit only covered `src/`) surfaces **3 more scripts × 4 more bug sites**, same bug class.

## Sites fixed

| Script | Sites | Pre-fix behavior |
| --- | --- | --- |
| `src/archive-stale-results.py` | 1 (`RESULTS`) | `RESULTS = REPO / \"results\"` resolved to `<repo>/results/` which doesn't exist post-#762. `if not RESULTS.is_dir()` short-circuited the entire sweep, so the **DM-flood prevention** this script exists for (2026-04-15 incident, 142-file flood) has been silently defeated on every startup since the workspace migration. **Active impact**: startup never archives. |
| `skills/regression-search/scripts/find-regression.py` | 1 (`CALLS_FILE`) | Resolved to `<repo>/results/calls/calls.jsonl` (doesn't exist). Every `find-regression \"...\"` query printed \"calls file not found\" instead of scanning real call history. |
| `skills/regression-search/scripts/diagnose-call.py` | 2 (`CALLS_FILE` + `METRICS_FILE`) | Same class — `diagnose-call <sid>` always printed \"No call matches\" regardless of input. |

## Why these escaped #836's audit

#836's grep was `WORKSPACE = Path(__file__)` and `Path(__file__).parent.parent` restricted to `src/`. These three scripts (a) use `REPO`/`REPO_DIR` as the variable name instead of `WORKSPACE`, and (b) one pair lives under `skills/`. Widening to `Path(__file__)\.(resolve()\.)?parent\.parent` across `src/`, `scripts/`, and `skills/` surfaced them.

The remaining sites flagged by the widened grep are **legitimate** — `REPO_DIR` in `agent-api.py`, `dashboard.py`, `github-webhook.py`, `util_paths.py`, and `health-check.py` (post-#836) is used for code-adjacent paths (`REPO_DIR/src/health-check.py`, git cwd, `.env` loading). Those are the correct semantics.

## Fix pattern

Each script now uses the canonical helper:

```python
sys.path.insert(0, str(Path(__file__).resolve().parent / ... / \"src\"))
from workspace_default import resolve_workspace

WORKSPACE = resolve_workspace()
RESULTS = WORKSPACE / \"results\"            # or CALLS_FILE / METRICS_FILE
```

## Verified locally

- `DRY_RUN=1 python3 src/archive-stale-results.py` — now reaches the sweep loop (previously short-circuited at \"results/ missing — nothing to do\").
- `python3 skills/regression-search/scripts/find-regression.py \"test\"` — now scans real `calls.jsonl` (2 entries) and returns \"No calls match 'test'\" instead of \"calls file not found: <repo>/results/calls/calls.jsonl\".
- All three scripts now resolve `WORKSPACE`/`CALLS_FILE`/`METRICS_FILE` against `\$SUTANDO_WORKSPACE` (or `~/.sutando/workspace/` default).

## Test plan

- [x] Smoke-test all three scripts locally — confirmed they now reach the workspace data (was previously short-circuited).
- [x] `python3 -c \"import importlib...\"` round-trip on each — `RESULTS` / `CALLS_FILE` / `METRICS_FILE` resolve to workspace paths that exist.
- [ ] CI tests on PR.

## Followup audit status

This brings the running total to **13 bug sites across 8 scripts** in the workspace-vs-repo class (#815 + #832 + #833 + #836 + this PR). One more sweep is worth doing for completeness — I'll check TS callers and any `new URL('..', import.meta.url)` patterns in a follow-up if anything turns up.