### PR TITLE
test(agent-state-endpoint): reset tracks beforeEach to deflake CI (closes #840)

### DIFF
--- a/tests/agent-state-endpoint.test.ts
+++ b/tests/agent-state-endpoint.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from 'node:test';
+import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn, ChildProcess } from 'node:child_process';
 import { setTimeout as delay } from 'node:timers/promises';
@@ -104,6 +104,17 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 		} else {
 			try { unlinkSync(VOICE_STATE_PATH); } catch { /* idempotent */ }
 		}
+	});
+
+	// Reset both tracks to idle before every subtest so order-dependence can't
+	// flake on CI. The describe block shares one spawned web-client child for
+	// all subtests, so the tool-track 'working' from one test would otherwise
+	// linger into the next if the prior teardown raced with CI scheduling.
+	// Issue #840: 2 unrelated PRs flaked on this same suite same day.
+	beforeEach(async () => {
+		await fetchJson('/mute-state?state=idle&source=tool');  // clear tool track
+		await fetchJson('/mute-state?state=idle');               // clear browser track
+		await delay(20);                                          // small flush window
 	});
 
 	it('default /sse-status returns state:"idle"', async () => {


### PR DESCRIPTION
## Summary

- Adds `beforeEach` to `tests/agent-state-endpoint.test.ts` that resets both tool and browser tracks to idle + a 20ms flush window
- Closes #840 (flaky-test pattern documented after 2 unrelated PRs hit different subtests of this suite today)

## Problem

The describe block shares one spawned `web-client.ts` child for all 9 subtests. Tool-track `working` set in subtest 4 (`tool track takes precedence`) is cleared at the end with `state=idle&source=tool`. Subtest 5 (`rejects invalid agent state`) then expects the effective state to fall back to browser-track `listening`.

On CI runners, the async `clear-tool` POST may not have flushed by the time subtest 5's baseline read runs — `listening` (expected) becomes `working` (actual). Same race hits a different subtest on subtest 2 (`accepts all 5 valid agent states`).

Both PR #836 and PR #832 flaked on this today. Both pass `npx tsx --test tests/agent-state-endpoint.test.ts` locally 9/9. Both passed on `gh run rerun --failed`.

## Fix

Per-subtest baseline via `beforeEach`:

```ts
beforeEach(async () => {
  await fetchJson('/mute-state?state=idle&source=tool');  // clear tool track
  await fetchJson('/mute-state?state=idle');               // clear browser track
  await delay(20);                                          // small flush window
});
```

Removes order-dependency between subtests. The 20ms flush window is empirical — small enough to keep the suite under 1s, large enough to absorb CI scheduler jitter.

## Test plan

- [x] `npx tsx --test tests/agent-state-endpoint.test.ts` — 9/9 pass
- [x] `npx tsx --test tests/*.test.ts` — 162/162 pass (full TS suite)
- [ ] CI run on this PR — should be CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)