### PR TITLE
fix(voice-agent): honor SUTANDO_WORKSPACE for runtime data (issue #839)

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -16,7 +16,9 @@
  *                          Falls back to GEMINI_API_KEY. Useful for isolating voice
  *                          (free-tier eligible) from paid-tier spend on a single key.
  *   ANTHROPIC_API_KEY   — Optional: only needed if not using claude CLI subscription auth
- *   WORKSPACE_DIR       — Claude's working directory (default: sutando/)
+ *   SUTANDO_WORKSPACE   — Per-user workspace dir (default: ~/.sutando/workspace/).
+ *                          Stores tasks/, results/, state/, logs/, conversation.log.
+ *                          See workspace_default.ts (#821) for the canonical resolver.
  *   PORT                — WebSocket port (default: 9900)
  *   HOST                — Bind address (default: 0.0.0.0)
  */
@@ -93,14 +95,23 @@ if (process.env.GEMINI_VOICE_API_KEY) {
 
 const PORT = Number(process.env.PORT) || 9900;
 const HOST = process.env.HOST || '0.0.0.0';
-// Default to sutando/ so Claude Code subprocess picks up CLAUDE.md automatically
-const WORKSPACE_DIR = process.env.WORKSPACE_DIR || new URL('..', import.meta.url).pathname;
+// Per-user runtime state lives under $SUTANDO_WORKSPACE (default
+// ~/.sutando/workspace/), not the repo checkout. Pre-#762 voice-agent
+// resolved its tasks/results/state against the repo path via the legacy
+// `WORKSPACE_DIR` env name + `import.meta.url`-relative fallback; post-#762
+// the canonical workspace lives elsewhere. resolveWorkspace() is the TS
+// twin of resolve_workspace() introduced in #821. Also remove the prior
+// "default to sutando/ so Claude Code subprocess picks up CLAUDE.md" comment
+// — voice-agent no longer spawns Claude Code (task-bridge handles that via
+// the file pipeline); the dual-use rationale is obsolete.
+import { resolveWorkspace } from './workspace_default.js';
+const WORKSPACE_DIR = resolveWorkspace();
 const PIDFILE = join(WORKSPACE_DIR, '.voice-agent.pid');
 const DEFAULT_THREAD_KEY = 'sutando_main';
 const SESSION_ID = `session_${Date.now()}`;
 const PHONE_PORT = Number(process.env.PHONE_PORT) || 3100;
 const PHONE_SERVER_URL = `http://localhost:${PHONE_PORT}`;
-const CALL_RESULTS_DIR = join(new URL('.', import.meta.url).pathname, '..', 'results', 'calls');
+const CALL_RESULTS_DIR = join(WORKSPACE_DIR, 'results', 'calls');
 
 /** Single-instance lock for this workspace.
  *


### PR DESCRIPTION
## Summary

Round-3 audit followup — migrates `src/voice-agent.ts`'s `WORKSPACE_DIR` + `CALL_RESULTS_DIR` constants to `resolveWorkspace()` (the canonical TS helper from #821). **2 const definitions, 1 file, 15+/-4** — but those constants cover ~15 call sites covering tasks/, results/, state/, conversation.log, briefings, audio, dynamic-content, PIDFILE, and CALL_RESULTS_DIR. All workspace data.

## Why this matters — split-brain on SUTANDO_WORKSPACE-enabled hosts

Pre-fix behavior on my machine (`\$SUTANDO_WORKSPACE` set):

| Component | Wrote to |
|---|---|
| Sutando.app (post-#837 Swift) | workspace ✓ |
| Python bridges (post-#762) | workspace ✓ |
| inline-tools.ts (post-#842) | workspace ✓ |
| **voice-agent.ts (this PR)** | **repo ✗** |

Result: phone-call `latest-result.json`, voice-agent briefings, conversation.log, the PIDFILE, etc. landed under the repo, while bridges + the menu-bar app + inline-tools wrote/read from the workspace. The two halves of the same conversation system disagreed on where state lives.

## Pre-fix code (lines 97 + 103)

```ts
// Default to sutando/ so Claude Code subprocess picks up CLAUDE.md automatically
const WORKSPACE_DIR = process.env.WORKSPACE_DIR || new URL('..', import.meta.url).pathname;
...
const CALL_RESULTS_DIR = join(new URL('.', import.meta.url).pathname, '..', 'results', 'calls');
```

Two problems:
- `WORKSPACE_DIR` was the *legacy* env var name. Post-#762 the canonical name is `SUTANDO_WORKSPACE`. On every machine where the env var name was modernized, the override silently stopped working.
- Fallback resolved to the repo via `new URL('..', import.meta.url).pathname`. Post-#762, the repo no longer has `tasks/`, `results/`, `state/` — they were moved to the workspace. So `<repo>/tasks/` etc. silently didn't exist; writes succeeded only because `mkdirSync(..., recursive: true)` created the missing trees inside the repo checkout.

## Fix

```ts
import { resolveWorkspace } from './workspace_default.js';
const WORKSPACE_DIR = resolveWorkspace();
...
const CALL_RESULTS_DIR = join(WORKSPACE_DIR, 'results', 'calls');
```

All 15 existing call sites keep their `WORKSPACE_DIR` reference — they automatically pick up the new resolution. No site-by-site edits required.

## Doc-comment cleanup

- Renamed env doc at line 19 from `WORKSPACE_DIR` (legacy) to `SUTANDO_WORKSPACE` (canonical) with a pointer to `workspace_default.ts`.
- Removed the stale comment at line 96: \"Default to sutando/ so Claude Code subprocess picks up CLAUDE.md automatically.\" Voice-agent doesn't spawn Claude Code anymore (`grep -n claude src/voice-agent.ts` is empty) — task-bridge handles that via the file pipeline. The dual-use rationale that conflated repo + workspace into one var is obsolete.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] Diff is targeted: 1 file, 15+/-4.
- [ ] CI on PR.

## Operational note

Takes effect on next voice-agent restart. Currently-running voice-agent processes keep their old paths until restart. No mid-flight disruption.

## Audit family status

| PR | Scope | Status |
|---|---|---|
| #815 | health-check notes-dir | ✓ merged earlier |
| #836 | 5 Python scripts × 10 sites | ✓ merged today |
| #833 | friction-detector | ✓ merged today |
| #838 | round-2: 3 Python scripts × 4 sites | ✓ merged today |
| #832 | daily-insight | queued |
| #842 | round-3 TS: cartesia + inline-tools × 5 sites | queued |
| **this** | **round-3 TS: voice-agent × ~15 sites** | **this PR** |
| #839 | TS audit followup (filed; remaining: util_paths fallback, skills-path REPO_ROOT semantics) | open |

Running total: **23 bug sites across 11 files**, in the workspace-vs-repo class.