### PR TITLE
fix(util_paths): default workspace fallback to resolveWorkspace() not cwd (issue #839)

### DIFF
--- a/src/util_paths.ts
+++ b/src/util_paths.ts
@@ -11,11 +11,16 @@
 //                                     (notes/, build_log.md).
 //
 // Both fall back to `<workspace>/<filename>` so existing installs keep working
-// until they migrate.
+// until they migrate. The `workspace` arg is optional; when omitted, the
+// helpers resolve to `$SUTANDO_WORKSPACE` (default `~/.sutando/workspace/`)
+// via resolveWorkspace() — NOT process.cwd(). Pre-#839 fixes the fallback was
+// cwd, which silently produced the wrong path on hosts where the caller's
+// cwd drifted from the workspace dir.
 
 import { existsSync } from 'node:fs';
 import { hostname } from 'node:os';
 import { join } from 'node:path';
+import { resolveWorkspace } from './workspace_default.js';
 
 function expandHome(p: string): string {
 	return p.replace(/^~/, process.env.HOME || '');
@@ -23,7 +28,7 @@ function expandHome(p: string): string {
 
 /** Per-machine resolver. */
 export function personalPath(filename: string, workspace?: string): string {
-	const ws = workspace ?? process.cwd();
+	const ws = workspace ?? resolveWorkspace();
 	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
 	if (privateRoot) {
 		const root = expandHome(privateRoot);
@@ -51,7 +56,7 @@ export function personalPath(filename: string, workspace?: string): string {
 
 /** Shared-across-fleet resolver (top-level private dir, not per-machine). */
 export function sharedPersonalPath(filename: string, workspace?: string): string {
-	const ws = workspace ?? process.cwd();
+	const ws = workspace ?? resolveWorkspace();
 	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
 	if (privateRoot) {
 		const root = expandHome(privateRoot);


### PR DESCRIPTION
## Summary

Third TS slice of the workspace audit. `src/util_paths.ts`'s `personalPath()` and `sharedPersonalPath()` both default the optional `workspace` parameter to `process.cwd()` when the caller doesn't pass one — same cwd-as-workspace antipattern the rest of the audit is fixing. Switches the default to `resolveWorkspace()`.

## Diff

```diff
-	const ws = workspace ?? process.cwd();
+	const ws = workspace ?? resolveWorkspace();
```

Two sites, plus an import + comment update. **1 file, 8+/-3.**

## Callers that benefit

After #842 + #843 land, most callers pass `WORKSPACE_DIR` explicitly. The ones that don't (and therefore depend on the default):

- `src/voice-agent.ts:556, 583` — `personalPath('stand-identity.json')` with no workspace arg. Stand-identity is per-machine state (different name per Mac), so this previously read from `\$cwd/stand-identity.json` and silently returned the wrong file if voice-agent's cwd drifted from the workspace.

Plus any future caller that forgets to pass workspace — the default is now correct.

## Audit family — TS side is essentially done

| PR | Scope | Status |
|---|---|---|
| #821 | Initial TS workspace_default + 4 callers | ✓ merged |
| #842 | round-3 TS slice 1: cartesia + inline-tools × 5 sites | queued |
| #843 | round-3 TS slice 2: voice-agent × ~15 call sites | queued |
| **this** | round-3 TS slice 3: util_paths fallback × 2 sites | this PR |

What's left in #839 after this lands: `src/inline-tools.ts:957, 1021` (`join(process.cwd(), 'skills')`) — but those are CODE-adjacent (skills ship with the code), so they need REPO_ROOT semantics, not WORKSPACE_DIR. Different fix shape, different PR.

## Test plan

- [x] `npx tsc --noEmit` ✓ clean.
- [ ] CI on PR.