### PR TITLE
fix(discord-bridge): proactive DM honors tierMap/list order, not set iteration (privacy)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2884,28 +2884,48 @@ async def poll_proactive():
                     if not text:
                         f.unlink(missing_ok=True)
                         continue
-                    # Send to first non-bot user in allowFrom.
-                    # `allowFrom` typically contains multiple bot IDs
-                    # (MacBook bot, Mac Mini bot) plus the human owner.
-                    # `next(iter(allowed))` picked bots ~50% of the time
-                    # based on set iteration, and Discord rejects bot→bot
-                    # DMs with HTTP 400 code 50007 ("Cannot send messages
-                    # to this user"). See `src/dm-result.py` which has
-                    # the matching `_resolve_owner_id()` for the CLI path.
-                    allowed = load_allowed()
-                    if not allowed:
-                        print(f"  [proactive] no owner in allowFrom, skipping {f.name}")
-                        f.unlink(missing_ok=True)
-                        continue
-                    owner_id = None
-                    for uid in allowed:
+                    # Resolve the DM recipient. Priority (mirrors
+                    # src/dm-result.py:_resolve_owner_id, modulo the
+                    # async/event-loop shape):
+                    #   1. $SUTANDO_DM_OWNER_ID env override.
+                    #   2. tierMap[uid] == "owner" — the unique tier-tagged
+                    #      owner from access.json.
+                    #   3. First non-bot user from allowFrom IN LIST ORDER.
+                    #
+                    # Pre-fix used `load_allowed()` which returns a SET, so
+                    # iteration was insertion/hash-ordered — on 2026-05-18
+                    # this picked a team-tier user (msze_) over the
+                    # owner-tier user (qingyunwu) because the set yielded
+                    # msze_ first. allowFrom is a *list* in access.json with
+                    # a meaningful first-entry-wins convention; preserving
+                    # that order fixes the routing.
+                    owner_id = os.environ.get("SUTANDO_DM_OWNER_ID", "").strip() or None
+                    if not owner_id:
                         try:
-                            u = await client.fetch_user(int(uid))
-                            if not u.bot:
-                                owner_id = str(uid)
-                                break
+                            access_data = json.loads(ACCESS_FILE.read_text())
                         except Exception:
+                            access_data = {}
+                        allow_list = access_data.get("allowFrom") or []
+                        tier_map = access_data.get("tierMap") or {}
+                        if not allow_list:
+                            print(f"  [proactive] no owner in allowFrom, skipping {f.name}")
+                            f.unlink(missing_ok=True)
                             continue
+                        # Preferred: the tier-tagged owner if one exists in allowFrom.
+                        owner_id = next(
+                            (uid for uid in allow_list if tier_map.get(uid) == "owner"),
+                            None,
+                        )
+                        # Fallback: first non-bot user, list order preserved.
+                        if owner_id is None:
+                            for uid in allow_list:
+                                try:
+                                    u = await client.fetch_user(int(uid))
+                                    if not u.bot:
+                                        owner_id = str(uid)
+                                        break
+                                except Exception:
+                                    continue
                     if owner_id is None:
                         print(f"  [proactive] no human user in allowFrom, skipping {f.name}")
                         f.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

**Bug class: privacy** — owner-private DMs delivered to wrong recipient due to non-deterministic set iteration.

The proactive DM path in `src/discord-bridge.py` was using `load_allowed()` which returns a Python `set`, then iterating to find the first non-bot user. Set iteration order is implementation-defined and depends on hash + insertion + Python version. On the bridge's prod runtime today, that order yielded **@msze_** (team-tier, in allowFrom for channel-level access) **before the owner-tier user** (qingyunwu). The 14:50 PDT pending-questions cron fire landed at msze_'s DM instead of the owner's.

## Symptom

```
[proactive] sent to 786410785197785088: ⚠️ 2 pending questions waiting:
• 2026-05-13 — auto-open web UI: bundle vs git ...
```

`786410785197785088` = @msze_, tier=team. Owner is `1025828152183885925`.

Delivered content was **titles only** (no question bodies) but still landed one level out from intended audience.

## Cause

```python
allowed = load_allowed()  # returns set
for uid in allowed:       # ← set iteration, non-deterministic
    u = await client.fetch_user(int(uid))
    if not u.bot:
        owner_id = str(uid); break
```

`allowFrom` in access.json is a **list** with a first-entry-wins convention, and `tierMap` separately tags each user's tier. Both were available but ignored.

## Fix

New resolution order (mirrors `src/dm-result.py:_resolve_owner_id` which was already correct on the CLI side):

1. `\$SUTANDO_DM_OWNER_ID` env override.
2. **`tierMap[uid] == \"owner\"`** — the unique tier-tagged owner.
3. First non-bot user in `allowFrom`, **list order preserved**.

Falls through to (3) on installs that haven't set `tierMap` yet — backwards compatible. On this install both (2) and (3) resolve to qingyunwu.

## Verified

- `python3 -c 'import ast; ast.parse(...)'` ✓
- Resolution test against current access.json:

  ```
  allowFrom: ['1025828152183885925', '1022910063620390932', '786410785197785088', '646244217877692416']
  tierMap:   {1025828152183885925: 'owner', 1022910063620390932: 'cofounder', 786410785197785088: 'team', 646244217877692416: 'team'}
  Resolved via tierMap → 1025828152183885925 (owner) ✓
  Set iteration would yield 1022910063620390932 (cofounder) on this Python build — confirming the non-determinism.
  ```

## Operational note

Takes effect on next discord-bridge restart. In-flight bridge processes keep using set iteration until restart.

## Related

- `src/dm-result.py:_resolve_owner_id` — already correct, the bridge now matches.
- access.json's `tierMap` was added but not yet consulted by the bridge's `load_allowed()` (only the top-level `allowFrom` list is read). This PR brings the proactive DM path into alignment; a broader audit of where else `load_allowed()` is used (and whether tierMap should gate other operations) is worth doing in a followup.

## Test plan

- [x] Syntax + resolution unit test ran locally.
- [ ] CI on PR.
- [ ] After merge + restart: trigger `python3 src/check-pending-questions.py` and confirm DM lands at owner, not at any team-tier user.