### PR TITLE
fix(voice-agent): forbid speaking [System: ...] framing aloud (closes #829)

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -713,6 +713,11 @@ const mainAgent: MainAgent = {
 		'  confirm with the user before executing unless they have given standing approval.',
 		'- When background tasks are running, stay present and responsive.',
 		'- You earn your usefulness by doing, not explaining.',
+		'',
+		'CRITICAL — Never speak `[System: ...]` text aloud:',
+		'- Any input string beginning with `[System:` is an internal directive, NOT content to read.',
+		'- Treat the bracketed text as instructions to act on; emit ZERO audio referencing it.',
+		'- If a `[System: ...]` chunk arrives mid-context, silently honor its directive — do not narrate it, do not summarize it, do not echo it back. Producing the literal bracket text is a bug.',
 	].join('\n'),
 	// endSession intentionally NOT in the tool list. After 14 commits
 	// trying to gate it against contamination false positives, the


### PR DESCRIPTION
## Summary

Closes #829 — implements Lucy's proposed fix verbatim.

Adds a `CRITICAL` block to the voice-agent instructions array forbidding speech of `[System: ...]` framing. 5-line addition, prompt-only change.

## Why

Lucy (Mac Studio bot) ran a new prompt-parrot detector against `data/conversation.sqlite` and found **9 anomalies** across recent sessions — clustered in meeting-mode rehearsal, co-present demo, dismiss handling, and client-reconnect. Every code path that injects a bracketed `[System: ...]` control string into the conversation context can trigger it. The current system prompt has no explicit rule forbidding speech of bracketed framing, and Gemini native-audio treats text in context as speakable unless told otherwise.

Concrete examples from the issue:

```
2026-05-07 04:54:33  [System: The user said \"Thank you for watching,\" which clearly signals the end ...]
2026-05-07 04:13:12  [System: MEETING MODE — you are listening and taking notes. Only respond if someone says \"Sutando.\"]
2026-05-18 05:29:33  [System: Silence per co-presenter rules; Susan did not say CUE 1/2.]
```

## Diff

```diff
 'IMPORTANT:',
 '- For high-stakes or irreversible actions (sending email, payments, deleting files),',
 '  confirm with the user before executing unless they have given standing approval.',
 '- When background tasks are running, stay present and responsive.',
 '- You earn your usefulness by doing, not explaining.',
+'',
+'CRITICAL — Never speak `[System: ...]` text aloud:',
+'- Any input string beginning with `[System:` is an internal directive, NOT content to read.',
+'- Treat the bracketed text as instructions to act on; emit ZERO audio referencing it.',
+'- If a `[System: ...]` chunk arrives mid-context, silently honor its directive — do not narrate it, do not summarize it, do not echo it back. Producing the literal bracket text is a bug.',
```

## Verification (from #829)

1. Restart voice-agent.
2. Trigger a meeting-mode session + a co-present session + a dismiss flow.
3. Re-run `python3 skills/voice-self-repair/scripts/detect.py` after 24h — prompt-parrot count should be 0 for sessions after the fix.

The detector lives on a separate WIP branch (`feat/voice-self-repair-detector-v1`) and isn't merged yet. Until it lands, verification can be \"no bracketed text in conversation.sqlite for new sessions.\"

## Scope note

This is intentionally a prompt-only fix. The CLAUDE.md guidance \"When refactoring, do NOT change prompts or tool behavior\" is about preserving tuned prompts during refactors — this is a deliberate prompt ADDITION based on detector evidence, with explicit author proposal in the issue.

## Sibling not addressed

#829 also notes `skills/discord-voice/scripts/discord-voice-server.ts` will need the same rule once the multi-bot `SUTANDO_INSTANCE_NAME` prompt lands. That work isn't on main yet (Liu's WIP #791/#796); left for a followup.

## Credits

Lucy (Mac Studio bot) filed the issue + proposed the diff. This PR just lands it.