### PR TITLE
fix(inline-tools): skill-loader scans REPO_ROOT/skills, not cwd/skills — closes #839 TS audit

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -7,7 +7,8 @@
 
 import { execSync, execFileSync } from 'node:child_process';
 import { writeFileSync, unlinkSync, readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
-import { join, extname } from 'node:path';
+import { join, extname, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { resolveWorkspace } from './workspace_default.js';
@@ -18,6 +19,11 @@ import { resolveWorkspace } from './workspace_default.js';
 // voice-agent was launched from the repo with SUTANDO_WORKSPACE unset.
 // resolveWorkspace() is the canonical TS helper introduced in #821.
 const WORKSPACE_DIR = resolveWorkspace();
+
+// Code-adjacent paths (skills/, etc.) ship with the repo checkout, NOT the
+// workspace. Compute REPO_ROOT from this file's URL so the resolution
+// survives any cwd drift at startup. Used by the skill-loader below.
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 
@@ -957,7 +963,7 @@ async function loadSkillManifestTools(): Promise<{ owner: ToolDefinition[]; anyC
 	// Order: public first, then private — same-name skills loaded from
 	// private take precedence (last one wins via the dup-name guard below if
 	// any; in practice they should be uniquely named).
-	const dirsToScan: string[] = [join(process.cwd(), 'skills')];
+	const dirsToScan: string[] = [join(REPO_ROOT, 'skills')];
 	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
 	if (privateRoot) {
 		const expanded = privateRoot.replace(/^~/, process.env.HOME || '');
@@ -1021,7 +1027,7 @@ const personalAllTools = [...personalTools.owner, ...personalTools.anyCaller];
 // a tools.ts. Don't try to align them — they're correctly sync/async for
 // what each one does.
 function loadCoreDocumentedSkills(): { name: string; description: string }[] {
-	const dirsToScan: string[] = [join(process.cwd(), 'skills')];
+	const dirsToScan: string[] = [join(REPO_ROOT, 'skills')];
 	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
 	if (privateRoot) {
 		const expanded = privateRoot.replace(/^~/, process.env.HOME || '');


### PR DESCRIPTION
## Summary

Last TS slice of the workspace audit (#839). The skill-loader at `src/inline-tools.ts:960` + `:1024` resolved its public-skills scan dir against `process.cwd()`. That only produces the right path when the launcher started from the repo root — if voice-agent or phone-conversation is invoked from a different cwd (direct `npx tsx` from elsewhere, IDE-launched, ad-hoc test runs), no skills load and the agent boots with an unexpectedly thin tool surface.

`skills/` ships with the code, so it's a CODE-adjacent path (REPO_ROOT semantics) — not workspace data. Different fix shape than the other audit PRs.

## Diff

```diff
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 ...
-const dirsToScan: string[] = [join(process.cwd(), 'skills')];
+const dirsToScan: string[] = [join(REPO_ROOT, 'skills')];
```

Two replacements, one new const at module-init. Same pattern as `src/web-client.ts:27` (which uses `resolve(dirname(fileURLToPath(import.meta.url)), '..')` — identical effect).

The private `\$SUTANDO_PRIVATE_DIR/skills` branch is correct as-is — it uses an env var with explicit user intent, not cwd.

## Test plan

- [x] `npx tsc --noEmit` ✓
- [x] Spot-check: REPO_ROOT computation against an isolated `test.mjs` in `/tmp/test-src/` correctly resolves to `/private/tmp` (the parent).
- [ ] CI on PR.

## Audit family — this closes the #839 TS backlog

Running totals after this lands:

| PR | Slice | Status |
|---|---|---|
| #815 | health-check notes-dir | ✓ |
| #821 | Initial TS workspace_default + 4 callers | ✓ |
| #832 | daily-insight | ✓ |
| #833 | friction-detector | ✓ |
| #836 | round-1: 5 Python scripts × 10 sites | ✓ |
| #837 | Sutando.app Swift split | ✓ |
| #838 | round-2: 3 Python scripts × 4 sites | ✓ |
| #842 | round-3 TS: cartesia + inline-tools × 5 sites | ✓ |
| #843 | round-3 TS: voice-agent × ~15 call sites | ✓ |
| #844 | round-3 TS: util_paths fallback | ✓ |
| **this** | **round-3 TS: skills-path REPO_ROOT** | **this PR** |

Total: ~27 sites across 12 files, all in the workspace-vs-repo class. Issue #839 can close once this lands.