### PR TITLE
fix(core-status): TS readers honor SUTANDO_WORKSPACE + isolate tests (closes #840 properly)

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -620,8 +620,12 @@ export const getCoreStatusTool: ToolDefinition = {
 	execution: 'inline',
 	async execute() {
 		try {
-			const repoDir = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
-			const statusPath = join(repoDir, 'core-status.json');
+			// core-status.json is per-user runtime state at $SUTANDO_WORKSPACE
+			// (default ~/.sutando/workspace/). Pre-fix this read from REPO_ROOT
+			// via import.meta.url-relative path — but Python writers migrated
+			// to WORKSPACE_DIR in #836, so the TS reader silently saw stale or
+			// missing data. Same workspace-contract fix as #821/#842/#843.
+			const statusPath = join(WORKSPACE_DIR, 'core-status.json');
 			if (!existsSync(statusPath)) {
 				return { status: 'idle', description: 'Core agent is not currently running.' };
 			}

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -3104,13 +3104,18 @@ let _seeingUntil = 0;
 const CORE_STATUS_STALE_SECONDS = 60;
 function readCoreStatus(): { running: boolean; step: string; stale: boolean } {
 	try {
-		const url = new URL('../core-status.json', import.meta.url);
-		const raw = readFileSync(url, 'utf-8');
+		// core-status.json is per-user runtime state at $SUTANDO_WORKSPACE
+		// (default ~/.sutando/workspace/). Pre-fix this read from REPO_ROOT via
+		// import.meta.url-relative `../core-status.json` — but Python writers
+		// migrated to WORKSPACE_DIR in #836, so the TS reader silently saw stale
+		// or missing data. Same workspace-contract fix as #821/#842/#843.
+		const statusPath = join(WORKSPACE_DIR, 'core-status.json');
+		const raw = readFileSync(statusPath, 'utf-8');
 		const s = JSON.parse(raw) as { status?: string; ts?: number; step?: string };
 		const nowSec = Date.now() / 1000;
 		let stale = false;
 		try {
-			const mtimeSec = statSync(url).mtimeMs / 1000;
+			const mtimeSec = statSync(statusPath).mtimeMs / 1000;
 			if (nowSec - mtimeSec > CORE_STATUS_STALE_SECONDS) stale = true;
 		} catch { stale = true; }
 		// "Running with old ts" → loop likely crashed mid-pass, treat as stale.

--- a/tests/agent-state-endpoint.test.ts
+++ b/tests/agent-state-endpoint.test.ts
@@ -2,8 +2,9 @@ import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn, ChildProcess } from 'node:child_process';
 import { setTimeout as delay } from 'node:timers/promises';
-import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdtempSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 // Integration test for PR #418 / #419 agent-state plumbing.
@@ -14,20 +15,21 @@ import { fileURLToPath } from 'node:url';
 
 const PORT = 18081; // well above the 8080 dev server + 9900 voice-agent
 
-// Test spawns the same web-client.ts the prod server uses. web-client reads
-// `../core-status.json` via the #443 coreIsRunning fallback, so a mid-pass
-// `{"status":"running"}` write by the proactive loop leaks into the isolated
-// test server and turns "idle" assertions into "working". Neutralize by
-// writing an idle sentinel before the test + restoring the original bytes on
-// teardown. Without this, 2 tests fail whenever `npm test` coincides with a
-// /proactive-loop step-0 write (or any other running-state write).
-const CORE_STATUS_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'core-status.json');
-let savedCoreStatus: string | null = null;
+// Each test process gets its own SUTANDO_WORKSPACE temp dir so concurrent
+// test files (notably tests/get-core-status-tool.test.ts, which writes
+// core-status.json with status:'running' as a fixture) can't race with our
+// reads. Before #840 fix: both tests shared <REPO_ROOT>/core-status.json
+// and node:test parallel file runs caused intermittent
+// `expected listening, got working` on the agent-state assertions.
+const TEMP_WORKSPACE = mkdtempSync(join(tmpdir(), 'sutando-test-agent-state-'));
+const CORE_STATUS_PATH = join(TEMP_WORKSPACE, 'core-status.json');
 
 // voice-state.json is read by web-client's readVoiceState() as the authoritative
 // voiceConnected source (browser POST cache is the fallback). Tests in the
 // voice-state describe block below write/remove this file to exercise both
-// branches. Stash + restore any real prod value on setup/teardown.
+// branches. Stash + restore any real prod value on setup/teardown. This file
+// still lives at REPO_ROOT (readVoiceState not yet migrated — separate PR);
+// stash/restore retained until that's fixed.
 const VOICE_STATE_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'voice-state.json');
 let savedVoiceState: string | null = null;
 
@@ -40,16 +42,14 @@ async function fetchJson(path: string): Promise<any> {
 
 describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 	before(async () => {
-		// Stash + neutralize core-status.json so a mid-pass "running" write
-		// by a live proactive loop can't leak "working" state into the test.
-		if (existsSync(CORE_STATUS_PATH)) {
-			savedCoreStatus = readFileSync(CORE_STATUS_PATH, 'utf-8');
-		}
+		// Write idle core-status into the per-test-process workspace temp dir.
+		// No stash/restore needed — the temp dir didn't exist before this test
+		// and gets rm'd on teardown.
 		writeFileSync(CORE_STATUS_PATH, JSON.stringify({ status: 'idle', ts: Math.floor(Date.now() / 1000) }) + '\n');
 
-		// Same rationale as core-status.json: stash + neutralize so a prod
-		// voice-state.json at repo root doesn't leak voiceConnected=true into
-		// the idle baseline assertion below.
+		// Stash + neutralize voice-state.json (still lives at REPO_ROOT until
+		// readVoiceState migrates) so a prod voice-state.json doesn't leak
+		// voiceConnected=true into the idle baseline assertion below.
 		if (existsSync(VOICE_STATE_PATH)) {
 			savedVoiceState = readFileSync(VOICE_STATE_PATH, 'utf-8');
 		}
@@ -59,7 +59,16 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 			'npx',
 			['tsx', 'src/web-client.ts'],
 			{
-				env: { ...process.env, CLIENT_PORT: String(PORT), PORT: '19900', CLIENT_HOST: '127.0.0.1' },
+				env: {
+					...process.env,
+					CLIENT_PORT: String(PORT),
+					PORT: '19900',
+					CLIENT_HOST: '127.0.0.1',
+					// Spawned web-client uses TEMP_WORKSPACE for core-status.json,
+					// so concurrent test processes can't race on the file. Same
+					// SUTANDO_WORKSPACE env override the rest of the test suite uses.
+					SUTANDO_WORKSPACE: TEMP_WORKSPACE,
+				},
 				// 'ignore' prevents the pipe buffer from filling in CI (stdout isn't drained),
 				// which would block the child and cause the /sse-status poll to time out.
 				stdio: 'ignore',
@@ -92,13 +101,9 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 				child.kill('SIGTERM');
 			});
 		}
-		// Restore original core-status.json bytes (or delete the sentinel we
-		// wrote if no original existed). Keeps the live proactive loop's
-		// post-test reads consistent with what it wrote last.
-		if (savedCoreStatus !== null) {
-			writeFileSync(CORE_STATUS_PATH, savedCoreStatus);
-		}
-		// Restore voice-state.json (or clean up our test write)
+		// Remove the per-test-process workspace temp dir wholesale.
+		try { rmSync(TEMP_WORKSPACE, { recursive: true, force: true }); } catch { /* idempotent */ }
+		// Restore voice-state.json (still at REPO_ROOT — separate migration).
 		if (savedVoiceState !== null) {
 			writeFileSync(VOICE_STATE_PATH, savedVoiceState);
 		} else {

--- a/tests/get-core-status-tool.test.ts
+++ b/tests/get-core-status-tool.test.ts
@@ -1,17 +1,23 @@
 import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { getCoreStatusTool } from '../src/inline-tools.js';
+import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 // Unit tests for the get_core_status inline tool (PR #467).
-// The tool is an async fn that reads core-status.json via a hardcoded
-// relative path (repo-root). Tests stash + restore any live value on the
-// disk so a concurrent /proactive-loop pass doesn't corrupt the fixtures.
+// The tool reads `<SUTANDO_WORKSPACE>/core-status.json` (post-#840 fix). Tests
+// run with SUTANDO_WORKSPACE pointing at a per-process temp dir so concurrent
+// test files (notably tests/agent-state-endpoint.test.ts, which spawns a
+// web-client that ALSO reads core-status.json) can't race. Before #840: both
+// tests shared <REPO_ROOT>/core-status.json and node:test parallel-file mode
+// caused intermittent failures.
+const TEMP_WORKSPACE = mkdtempSync(join(tmpdir(), 'sutando-test-getcore-'));
+process.env.SUTANDO_WORKSPACE = TEMP_WORKSPACE;
+const CORE_STATUS_PATH = join(TEMP_WORKSPACE, 'core-status.json');
 
-const CORE_STATUS_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'core-status.json');
-let saved: string | null = null;
+// Import AFTER setting SUTANDO_WORKSPACE so the tool's module-load resolves
+// to the temp dir, not whatever the test process's env was before.
+const { getCoreStatusTool } = await import('../src/inline-tools.js');
 
 // Tool execute returns a plain object. Use any here because ToolDefinition
 // typing makes the return a generic JsonValue.
@@ -21,18 +27,9 @@ async function invoke(): Promise<any> {
 }
 
 describe('get_core_status inline tool', () => {
-	before(() => {
-		if (existsSync(CORE_STATUS_PATH)) {
-			saved = readFileSync(CORE_STATUS_PATH, 'utf-8');
-		}
-	});
-
 	after(() => {
-		if (saved !== null) {
-			writeFileSync(CORE_STATUS_PATH, saved);
-		} else {
-			try { unlinkSync(CORE_STATUS_PATH); } catch { /* idempotent */ }
-		}
+		// Remove the per-test-process workspace temp dir wholesale.
+		try { rmSync(TEMP_WORKSPACE, { recursive: true, force: true }); } catch { /* idempotent */ }
 	});
 
 	it('returns status:running with step + ageSec when fresh running file exists', async () => {


### PR DESCRIPTION
## Summary

Two stacked issues fixed in one shot. Closes #840 properly (PR #841's beforeEach was a partial fix).

### 1. Production bug — silent path divergence

Python writers migrated `core-status.json` to `$SUTANDO_WORKSPACE` in #836 per the CLAUDE.md workspace contract. TS readers in `src/web-client.ts:readCoreStatus` and `src/inline-tools.ts:getCoreStatusTool` still read it from `REPO_ROOT` via `import.meta.url`-relative paths. Same silent-divergence shape as #821/#842/#843 fixed for other paths — voice-agent reading "core idle" while Python actually wrote "core working" elsewhere.

**Fix:** both TS readers now `join(WORKSPACE_DIR, 'core-status.json')`. WORKSPACE_DIR comes from `resolveWorkspace()`.

### 2. Test flake (#840)

`tests/agent-state-endpoint.test.ts` and `tests/get-core-status-tool.test.ts` both wrote to `<REPO_ROOT>/core-status.json`. node:test runs files in parallel by default. The get-core-status-tool test writes `status:'running'` as one of its cases right when agent-state-endpoint asserts `state:'listening'`. Race manifested as `expected listening, got working` on whichever subtest called `effectiveAgentState()` during the foreign 'running' write.

Two PRs (#836, #832) already flaked on this today; PR #843's CI also failed but merged via non-required-check semantics. PR #841 added per-subtest `beforeEach` reset which helped within-suite ordering but didn't address the cross-file race.

**Fix:** each test process now creates its own `mkdtempSync` workspace dir and exports `SUTANDO_WORKSPACE=$TEMP_DIR`. The spawned web-client inherits the env; the in-process tool import reads the same temp dir. No more shared state, no more race.

### Test plan

- [x] `tests/agent-state-endpoint.test.ts` — 9/9 pass
- [x] `tests/get-core-status-tool.test.ts` — 6/6 pass
- [x] Running both together (the failure mode pre-fix): 15/15 pass
- [x] Full TS suite: 173/173 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)