### PR TITLE
fix(voice-state): TS reader+writer honor SUTANDO_WORKSPACE (closes #853)

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -850,7 +850,14 @@ async function main() {
 	// this after ~5 PR-restart cycles desyncing voiceConnected.
 	function writeVoiceState(connected: boolean) {
 		try {
-			writeFileSync('voice-state.json', JSON.stringify({ connected, ts: Math.floor(Date.now() / 1000) }));
+			// voice-state.json is per-user runtime state — lives under
+			// $SUTANDO_WORKSPACE. Pre-fix this was a cwd-relative write
+			// (effectively REPO_ROOT when launched from there), so the
+			// web-client's REPO_ROOT-relative reader happened to find it —
+			// but on hosts where SUTANDO_WORKSPACE is set or cwd drifts,
+			// voice-agent wrote one place and the consumer read another.
+			// Same workspace-contract fix as #849 for core-status.json.
+			writeFileSync(join(WORKSPACE_DIR, 'voice-state.json'), JSON.stringify({ connected, ts: Math.floor(Date.now() / 1000) }));
 		} catch (err) {
 			console.error(`${ts()} [VoiceState] write failed:`, err);
 		}

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -3134,8 +3134,15 @@ function coreIsRunning(): boolean { return readCoreStatus().running; }
 const VOICE_STATE_STALE_SECONDS = 120;
 function readVoiceState(): boolean | null {
 	try {
-		const url = new URL('../voice-state.json', import.meta.url);
-		const raw = readFileSync(url, 'utf-8');
+		// voice-state.json is per-user runtime state — lives under
+		// $SUTANDO_WORKSPACE. Pre-fix this read from REPO_ROOT via the
+		// import.meta.url-relative path — but voice-agent's writer also
+		// resolved relative to its cwd (= REPO_ROOT when launched from
+		// there), so both sides happened to align on the same install.
+		// On SUTANDO_WORKSPACE-set hosts (or cwd-drift), the two split.
+		// Same workspace-contract fix as #849 for core-status.json.
+		const statusPath = join(WORKSPACE_DIR, 'voice-state.json');
+		const raw = readFileSync(statusPath, 'utf-8');
 		const s = JSON.parse(raw) as { connected?: boolean; ts?: number };
 		const nowSec = Date.now() / 1000;
 		if (typeof s.ts === 'number' && nowSec - s.ts > VOICE_STATE_STALE_SECONDS && s.connected) {

--- a/tests/agent-state-endpoint.test.ts
+++ b/tests/agent-state-endpoint.test.ts
@@ -2,10 +2,9 @@ import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn, ChildProcess } from 'node:child_process';
 import { setTimeout as delay } from 'node:timers/promises';
-import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdtempSync, rmSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { writeFileSync, unlinkSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { fileURLToPath } from 'node:url';
 
 // Integration test for PR #418 / #419 agent-state plumbing.
 // Spawns web-client.ts on a random port, exercises /sse-status + /mute-state,
@@ -27,11 +26,11 @@ const CORE_STATUS_PATH = join(TEMP_WORKSPACE, 'core-status.json');
 // voice-state.json is read by web-client's readVoiceState() as the authoritative
 // voiceConnected source (browser POST cache is the fallback). Tests in the
 // voice-state describe block below write/remove this file to exercise both
-// branches. Stash + restore any real prod value on setup/teardown. This file
-// still lives at REPO_ROOT (readVoiceState not yet migrated — separate PR);
-// stash/restore retained until that's fixed.
-const VOICE_STATE_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'voice-state.json');
-let savedVoiceState: string | null = null;
+// branches. Lives in the same per-test-process TEMP_WORKSPACE as core-status.json
+// — no stash/restore needed, the temp dir didn't exist before this test and
+// gets rm'd on teardown. (Was REPO_ROOT pre-#853 fix; migrated to match the
+// post-#849 web-client reader semantics.)
+const VOICE_STATE_PATH = join(TEMP_WORKSPACE, 'voice-state.json');
 
 let child: ChildProcess;
 
@@ -47,12 +46,10 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 		// and gets rm'd on teardown.
 		writeFileSync(CORE_STATUS_PATH, JSON.stringify({ status: 'idle', ts: Math.floor(Date.now() / 1000) }) + '\n');
 
-		// Stash + neutralize voice-state.json (still lives at REPO_ROOT until
-		// readVoiceState migrates) so a prod voice-state.json doesn't leak
-		// voiceConnected=true into the idle baseline assertion below.
-		if (existsSync(VOICE_STATE_PATH)) {
-			savedVoiceState = readFileSync(VOICE_STATE_PATH, 'utf-8');
-		}
+		// voice-state.json lives in TEMP_WORKSPACE post-#853 migration, so no
+		// prod-state leak is possible (the temp dir is fresh). Just ensure the
+		// file is absent before the spawned web-client reads it for the
+		// "missing voice-state.json falls back to cache" subtest baseline.
 		try { unlinkSync(VOICE_STATE_PATH); } catch { /* already gone */ }
 
 		child = spawn(
@@ -102,13 +99,8 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 			});
 		}
 		// Remove the per-test-process workspace temp dir wholesale.
+		// This now also covers voice-state.json (in the same temp dir).
 		try { rmSync(TEMP_WORKSPACE, { recursive: true, force: true }); } catch { /* idempotent */ }
-		// Restore voice-state.json (still at REPO_ROOT — separate migration).
-		if (savedVoiceState !== null) {
-			writeFileSync(VOICE_STATE_PATH, savedVoiceState);
-		} else {
-			try { unlinkSync(VOICE_STATE_PATH); } catch { /* idempotent */ }
-		}
 	});
 
 	// Reset both tracks to idle before every subtest so order-dependence can't


### PR DESCRIPTION
## Summary

Closes #853. Followup to #849 — same workspace-contract fix for `voice-state.json` that #849 landed for `core-status.json`.

**3 sites, 29+/23-, 1 issue.**

## Sites migrated

| File | Line | Pre-fix | Post-fix |
|---|---|---|---|
| `src/voice-agent.ts` | 853 | `writeFileSync('voice-state.json', ...)` (cwd-relative) | `writeFileSync(join(WORKSPACE_DIR, 'voice-state.json'), ...)` |
| `src/web-client.ts` | 3137 | `new URL('../voice-state.json', import.meta.url)` (REPO_ROOT) | `join(WORKSPACE_DIR, 'voice-state.json')` |
| `tests/agent-state-endpoint.test.ts` | 33 | REPO_ROOT-relative VOICE_STATE_PATH + stash/restore | `join(TEMP_WORKSPACE, 'voice-state.json')` — same temp dir as core-status.json (introduced in #849) |

Test-side: dropped `savedVoiceState` stash/restore — TEMP_WORKSPACE is fresh per process + `rmSync`'d on teardown, no prod-file leak possible. Also removed now-unused imports (`readFileSync`, `existsSync`, `dirname`, `fileURLToPath`).

## Why this matters

Pre-fix, voice-agent's writer used `writeFileSync('voice-state.json', ...)` — cwd-relative. On hosts launched from the repo, cwd ≈ REPO_ROOT and both writer + reader aligned by accident. But:

- On `\$SUTANDO_WORKSPACE`-set hosts: writer kept writing to repo; reader (post-#849 — already migrated for core-status.json) had no symmetric migration, so voice-state.json was still REPO_ROOT-relative. After #849 landed, web-client's `readVoiceState()` was a known leak — explicitly documented in #849's test file: `"This file still lives at REPO_ROOT (readVoiceState not yet migrated — separate PR)"`.
- On hosts where cwd drifts from REPO_ROOT (IDE spawn, `npx tsx` from elsewhere): writer landed in an unexpected dir.

`dm-result.py`'s voiceConnected query goes through web-client's `/sse-status` → `readVoiceState()` → now uniformly resolves through WORKSPACE_DIR. Same path for the writer. Split-brain closed.

## Test plan

- [x] `npx tsc --noEmit` ✓ clean
- [x] Diff scoped: 3 files
- [ ] CI on PR

## Audit family — TS side complete

This is the last known core-state file at REPO_ROOT. After this lands, all workspace runtime data flows through `\$SUTANDO_WORKSPACE` consistently across Python + TS + Swift writers and readers:

- ~28 sites in 13 files (#815, #821, #832, #833, #836, #837, #838, #842, #843, #844, #846, #849, this).
- Plus a few skills-side migrations from earlier PRs.

The `## Built-in tools` stub tightening (#854) and the `inline-tools.ts:957/1021` skills-path REPO_ROOT semantics (#848, still queued) remain — both are different shapes from the runtime-data audit and don't block this closure.