### PR TITLE
fix(health-check): distinguish pgrep error from no-match in sutando-app detection

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -883,12 +883,35 @@ def run_all_checks() -> list[dict]:
     # Sutando menu bar app (optional — only check if binary exists)
     sutando_bin = REPO_DIR / "src" / "Sutando" / "Sutando"
     if sutando_bin.exists():
+        # Distinguish pgrep failures (exit code != 0 and != 1) from a real
+        # no-match (exit code 1). Pre-fix the bare try/except swallowed
+        # subprocess errors AND empty results into a single "no pids" path,
+        # which surfaced as a false "not running" warn when pgrep itself
+        # hiccupped (CPU contention, fd exhaustion, etc.). Chi hit this
+        # 2026-05-18 — app was alive (PID 34586 since May 17) but a
+        # health-check tick reported "not running."
+        pgrep_status = None  # "ok-running" | "ok-stopped" | "error"
+        pgrep_err = ""
+        pids: list[str] = []
         try:
-            result = subprocess.run(["/usr/bin/pgrep", "-f", "Sutando/Sutando"], capture_output=True, text=True)
-            pids = [p for p in result.stdout.strip().split("\n") if p]
-        except:
-            pids = []
-        if pids:
+            result = subprocess.run(
+                ["/usr/bin/pgrep", "-f", "Sutando/Sutando"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                pids = [p for p in result.stdout.strip().split("\n") if p]
+                pgrep_status = "ok-running"
+            elif result.returncode == 1:
+                # pgrep convention: 1 = no match
+                pgrep_status = "ok-stopped"
+            else:
+                pgrep_status = "error"
+                pgrep_err = (result.stderr or f"pgrep exit={result.returncode}").strip()[:120]
+        except Exception as e:
+            pgrep_status = "error"
+            pgrep_err = f"{type(e).__name__}: {e}"[:120]
+
+        if pgrep_status == "ok-running" and pids:
             check = {"name": "sutando-app", "status": "ok", "detail": f"running (⌃C/⌃V/⌃M)"}
             mark_stale_if_outdated(
                 check,
@@ -897,8 +920,13 @@ def run_all_checks() -> list[dict]:
                 binary_path=REPO_DIR / "src" / "Sutando" / "Sutando",
             )
             checks.append(check)
-        else:
+        elif pgrep_status == "ok-stopped":
             checks.append({"name": "sutando-app", "status": "warn", "detail": "not running — hotkeys disabled"})
+        else:
+            # pgrep itself errored — don't false-alarm "not running" when we
+            # actually couldn't determine state. Surface as a transient warn
+            # with the cause so it's debuggable, not a routine "app is down."
+            checks.append({"name": "sutando-app", "status": "warn", "detail": f"detection failed (pgrep: {pgrep_err or 'unknown error'}) — actual app state unknown"})
 
     # Stuck-loop / queue-pileup detection — consequence-level signals that
     # fire whether the watcher died, the proactive loop crashed mid-pass, or


### PR DESCRIPTION
## Problem

Pre-fix the `sutando-app` check wraps `subprocess.run` in a bare `try/except` that swallows BOTH subprocess errors AND empty-match cases into a single `pids = []` path → false "not running — hotkeys disabled" warn whenever pgrep itself hiccups (CPU contention, fd exhaustion, transient subprocess failure).

**Chi hit this 2026-05-18:** sutando-app was alive on Mini (PID 34586 running since May 17 07:13, ~30h continuous) but a health-check tick reported "not running." When Chi ran pgrep manually a moment later it returned the PID correctly.

## Fix

Inspect subprocess return code (pgrep convention: `0 = match`, `1 = no-match`, `2+ = error`) + a 5s timeout. Three branches:

- **`ok-running + pids`** → ok status (unchanged behavior)
- **`ok-stopped`** → warn "not running" (unchanged behavior)
- **`error`** → warn with the pgrep error message, "actual app state unknown" (NEW: doesn't false-alarm "not running" when detection itself failed)

## Test plan

- [x] `python3 src/health-check.py` → correctly reports `sutando-app: stale (running, but binary is 1786 min older than source)` for the live PID 34586
- [x] `tests/health-check-stuck-loop.test.py` — all stuck-loop / queue-pileup invariants pass
- [x] `tests/health-check-emit-task.test.py` — all emit-task dedup invariants pass
- [ ] CI run — should pass (1-file Python diff, no TS changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)