### PR TITLE
feat(util_paths): claudeHomePath() helper — centralize ~/.claude/ resolution (closes impl-gap #5 from #857)

### DIFF
--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -119,3 +119,37 @@ def shared_personal_path(filename: str, workspace: Path | None = None) -> Path:
 
     p = ws / filename
     return p
+
+
+# ---------------------------------------------------------------------------
+# Claude Code home directory — the host CLI's per-user state lives at
+# `~/.claude/`. Sutando consumes several subpaths (channels/, projects/,
+# skills/, settings.json, etc.); centralizing the resolution here keeps the
+# host-CLI dependency surface a single grep.
+#
+# Why this helper: per the 2026-05-18 workspace-design RFC discussion, the
+# dependency on `~/.claude/` is real (memory storage, channel tokens, skill
+# discovery, slash-command write convention) and we accept it operationally —
+# but we want the surface countable so a future swap is a 1-day grep+replace
+# rather than a re-architecture. ANY new read/write into the Claude Code home
+# directory should go through this helper.
+#
+# Resolution: prefer $CLAUDE_HOME if set (override / testing), else
+# `~/.claude/`. Does NOT create the dir.
+# ---------------------------------------------------------------------------
+
+def claude_home_path(*subpath: str) -> Path:
+    """Resolve a path under Claude Code's per-user home (`~/.claude/`).
+
+    Pass subpath components positionally, e.g.:
+        claude_home_path("channels", "discord", "access.json")
+        claude_home_path("projects", project_slug, "memory", "MEMORY.md")
+        claude_home_path("skills", skill_name)
+
+    Override the base with `$CLAUDE_HOME` for tests + alt-host installs.
+    """
+    base_env = os.environ.get("CLAUDE_HOME")
+    base = Path(os.path.expanduser(base_env)) if base_env else (Path.home() / ".claude")
+    if not subpath:
+        return base
+    return base.joinpath(*subpath)

--- a/src/util_paths.ts
+++ b/src/util_paths.ts
@@ -68,3 +68,40 @@ export function sharedPersonalPath(filename: string, workspace?: string): string
 	}
 	return join(ws, filename);
 }
+
+
+// ---------------------------------------------------------------------------
+// Claude Code home directory — the host CLI's per-user state lives at
+// `~/.claude/`. Sutando consumes several subpaths (channels/, projects/,
+// skills/, settings.json, etc.); centralizing the resolution here keeps the
+// host-CLI dependency surface a single grep.
+//
+// Why this helper: per the 2026-05-18 workspace-design RFC discussion, the
+// dependency on `~/.claude/` is real (memory storage, channel tokens, skill
+// discovery, slash-command write convention) and we accept it operationally —
+// but we want the surface countable so a future swap is a 1-day grep+replace
+// rather than a re-architecture. ANY new read/write into the Claude Code home
+// directory should go through this helper.
+//
+// Resolution: prefer $CLAUDE_HOME if set (override / testing), else
+// `~/.claude/`. Does NOT create the dir.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a path under Claude Code's per-user home (`~/.claude/`).
+ *
+ * Pass subpath components as separate args:
+ *   claudeHomePath('channels', 'discord', 'access.json')
+ *   claudeHomePath('projects', projectSlug, 'memory', 'MEMORY.md')
+ *   claudeHomePath('skills', skillName)
+ *
+ * Override the base with `$CLAUDE_HOME` for tests + alt-host installs.
+ */
+export function claudeHomePath(...subpath: string[]): string {
+	const baseEnv = process.env.CLAUDE_HOME;
+	const base = baseEnv
+		? expandHome(baseEnv)
+		: join(process.env.HOME || '', '.claude');
+	if (subpath.length === 0) return base;
+	return join(base, ...subpath);
+}


### PR DESCRIPTION
## Summary

Adds `claude_home_path(*subpath)` (Python) and `claudeHomePath(...subpath)` (TS) to `src/util_paths.{py,ts}`. Both resolve a path under Claude Code's per-user home directory (`~/.claude/` by default; `$CLAUDE_HOME` for override / testing).

Closes implementation-gap #5 from issue #857 (workspace-design RFC tracking issue).

## Motivation

Per the 2026-05-18 workspace-design RFC discussion in PR #858 + issue #857: Sutando's dependency on `~/.claude/` is real and accepted operationally. Channel tokens, agent memory, skill discovery, settings — all live there. We commit to Claude Code as the host CLI **today**, but want the dependency surface countable so a future swap is a 1-day grep+replace rather than a re-architecture.

**This helper IS the "stop hedging on swap" discipline.** ~20 LoC now, single grep surface for any future audit.

## Usage

```python
from util_paths import claude_home_path
claude_home_path('channels', 'discord', 'access.json')   # /Users/wangchi/.claude/channels/discord/access.json
claude_home_path('projects', project_slug, 'memory', 'MEMORY.md')
claude_home_path('skills', skill_name)
```

```typescript
import { claudeHomePath } from './util_paths.js';
claudeHomePath('channels', 'discord', 'access.json');
claudeHomePath('projects', projectSlug, 'memory', 'MEMORY.md');
```

`$CLAUDE_HOME` env var overrides the base for tests + alt-host installs.

## Migration plan

**Not flag-day.** Existing callers (discord-bridge.py, inline-tools.ts skill-loader, health-check.py memory checks, etc.) can migrate opportunistically. New code that reads/writes under `~/.claude/` should go through this helper.

## Test plan

- [x] Python smoke: `claude_home_path('channels', 'discord', 'access.json')` → expected path
- [x] TS smoke: same shape, same result
- [x] `$CLAUDE_HOME` override honored on both
- [x] `npx tsc --noEmit` passes
- [x] Full TS suite: 173/173 pass
- [ ] CI run — should pass (helper-only, no callers migrated yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)