### PR TITLE
refactor(tests): extract setupTempWorkspace helper (closes #862)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ tests/*
 !tests/*.test.ts
 !tests/*.test.py
 !tests/*.test.sh
+!tests/_helpers/
+!tests/_helpers/*.ts
 skills/personal-*/
 tests/security/*.md
 !tests/security/*.md.example

--- a/tests/_helpers/temp-workspace.ts
+++ b/tests/_helpers/temp-workspace.ts
@@ -1,0 +1,50 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Per-process temp workspace for tests that touch workspace state.
+ *
+ * Established by #849 as the durable fix for the cross-test-file race
+ * that produced flaky CI on #800 / #840 — concurrent test files writing
+ * to a shared `<REPO_ROOT>/core-status.json` (and similar). Each test
+ * process gets its own `$SUTANDO_WORKSPACE` so the `resolveWorkspace()`
+ * helper in production code resolves to an isolated dir.
+ *
+ * Usage (module-level — call before importing the code under test, so the
+ * code's module-init `WORKSPACE_DIR = resolveWorkspace()` captures the
+ * temp path):
+ *
+ *   import { setupTempWorkspace } from './_helpers/temp-workspace.js';
+ *   const { workspace, cleanup } = setupTempWorkspace('agent-state');
+ *
+ *   // ... write fixtures via `join(workspace, 'core-status.json')` etc.
+ *
+ *   after(cleanup);
+ *
+ * If you're spawning a subprocess that needs the same workspace, pass
+ * `SUTANDO_WORKSPACE: workspace` in the child's env so its
+ * `resolveWorkspace()` resolves to the same temp dir.
+ *
+ * The function also writes `process.env.SUTANDO_WORKSPACE = workspace`
+ * for the test process itself — useful when the code under test reads
+ * the env var directly OR when its module-init capture runs after this
+ * helper.
+ */
+export function setupTempWorkspace(name: string): {
+	workspace: string;
+	cleanup: () => void;
+} {
+	const workspace = mkdtempSync(join(tmpdir(), `sutando-test-${name}-`));
+	process.env.SUTANDO_WORKSPACE = workspace;
+	return {
+		workspace,
+		cleanup: () => {
+			try {
+				rmSync(workspace, { recursive: true, force: true });
+			} catch {
+				/* idempotent */
+			}
+		},
+	};
+}

--- a/tests/agent-state-endpoint.test.ts
+++ b/tests/agent-state-endpoint.test.ts
@@ -2,9 +2,9 @@ import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn, ChildProcess } from 'node:child_process';
 import { setTimeout as delay } from 'node:timers/promises';
-import { writeFileSync, unlinkSync, mkdtempSync, rmSync } from 'node:fs';
+import { writeFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { setupTempWorkspace } from './_helpers/temp-workspace.js';
 
 // Integration test for PR #418 / #419 agent-state plumbing.
 // Spawns web-client.ts on a random port, exercises /sse-status + /mute-state,
@@ -20,7 +20,8 @@ const PORT = 18081; // well above the 8080 dev server + 9900 voice-agent
 // reads. Before #840 fix: both tests shared <REPO_ROOT>/core-status.json
 // and node:test parallel file runs caused intermittent
 // `expected listening, got working` on the agent-state assertions.
-const TEMP_WORKSPACE = mkdtempSync(join(tmpdir(), 'sutando-test-agent-state-'));
+const { workspace: TEMP_WORKSPACE, cleanup: cleanupTempWorkspace } =
+	setupTempWorkspace('agent-state');
 const CORE_STATUS_PATH = join(TEMP_WORKSPACE, 'core-status.json');
 
 // voice-state.json is read by web-client's readVoiceState() as the authoritative
@@ -100,7 +101,7 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 		}
 		// Remove the per-test-process workspace temp dir wholesale.
 		// This now also covers voice-state.json (in the same temp dir).
-		try { rmSync(TEMP_WORKSPACE, { recursive: true, force: true }); } catch { /* idempotent */ }
+		cleanupTempWorkspace();
 	});
 
 	// Reset both tracks to idle before every subtest so order-dependence can't

--- a/tests/get-core-status-tool.test.ts
+++ b/tests/get-core-status-tool.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdtempSync, rmSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { setupTempWorkspace } from './_helpers/temp-workspace.js';
 
 // Unit tests for the get_core_status inline tool (PR #467).
 // The tool reads `<SUTANDO_WORKSPACE>/core-status.json` (post-#840 fix). Tests
@@ -11,8 +11,8 @@ import { tmpdir } from 'node:os';
 // web-client that ALSO reads core-status.json) can't race. Before #840: both
 // tests shared <REPO_ROOT>/core-status.json and node:test parallel-file mode
 // caused intermittent failures.
-const TEMP_WORKSPACE = mkdtempSync(join(tmpdir(), 'sutando-test-getcore-'));
-process.env.SUTANDO_WORKSPACE = TEMP_WORKSPACE;
+const { workspace: TEMP_WORKSPACE, cleanup: cleanupTempWorkspace } =
+	setupTempWorkspace('getcore');
 const CORE_STATUS_PATH = join(TEMP_WORKSPACE, 'core-status.json');
 
 // Import AFTER setting SUTANDO_WORKSPACE so the tool's module-load resolves
@@ -27,10 +27,7 @@ async function invoke(): Promise<any> {
 }
 
 describe('get_core_status inline tool', () => {
-	after(() => {
-		// Remove the per-test-process workspace temp dir wholesale.
-		try { rmSync(TEMP_WORKSPACE, { recursive: true, force: true }); } catch { /* idempotent */ }
-	});
+	after(cleanupTempWorkspace);
 
 	it('returns status:running with step + ageSec when fresh running file exists', async () => {
 		const nowSec = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
## Summary

Extract Mini's per-process `mkdtempSync` test isolation pattern (established by #849) into a shared helper, eliminating the boilerplate duplication flagged by sonichi-bot on #858 LGTM follow-up.

**Before** — each test file:
```ts
const TEMP_WORKSPACE = mkdtempSync(join(tmpdir(), 'sutando-test-foo-'));
process.env.SUTANDO_WORKSPACE = TEMP_WORKSPACE;
// ...
after(() => rmSync(TEMP_WORKSPACE, { recursive: true, force: true }));
```

**After**:
```ts
import { setupTempWorkspace } from './_helpers/temp-workspace.js';
const { workspace, cleanup } = setupTempWorkspace('foo');
// ...
after(cleanup);
```

## Changes

- `tests/_helpers/temp-workspace.ts` — new helper with `setupTempWorkspace(name)` returning `{ workspace, cleanup }`.
- `tests/agent-state-endpoint.test.ts` — uses helper, ditches inline `mkdtempSync`/`rmSync` boilerplate.
- `tests/get-core-status-tool.test.ts` — same.
- `.gitignore` — allowlist `tests/_helpers/` (the existing `tests/*` rule shadowed the new dir).

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx tsx --test tests/get-core-status-tool.test.ts` — all 6 cases pass.
- [ ] CI green on `tests/agent-state-endpoint.test.ts` (spawn-based, slow locally).

Closes #862.