### PR TITLE
feat: Slack bridge (DMs + @mentions + file attachments via Socket Mode)

### DIFF
--- a/docs/slack-bridge.md
+++ b/docs/slack-bridge.md
@@ -19,10 +19,20 @@ pipeline as voice / Discord / Telegram.
    `im:write`, `app_mentions:read`, `channels:history`,
    `groups:history`, `files:read`, `files:write`, `users:read`.
 
-4. **Event Subscriptions**: enable. Subscribe to bot events `app_mention` and
-   `message.im` (DMs).
+4. **Event Subscriptions**: turn the **Enable Events** toggle ON at the
+   top of the page. Leave the Request URL field blank — Socket Mode
+   delivers events over the WebSocket, no public webhook needed. Under
+   **Subscribe to bot events**, add `message.im` and `app_mention`.
+   Click **Save Changes**.
 
-5. **Install to workspace**. Copy the Bot User OAuth Token (`xoxb-...`).
+5. **App Home → Messages Tab**: in the left sidebar pick **App Home**,
+   scroll to **Show Tabs** → **Messages Tab**, and check
+   **"Allow users to send Slash commands and messages from the messages
+   tab"**. Without this, the bot's DM screen shows
+   *"Sending messages to this app has been turned off"* and your DMs
+   silently fail.
+
+6. **Install to workspace**. Copy the Bot User OAuth Token (`xoxb-...`).
 
 ## Local config
 
@@ -97,3 +107,39 @@ bash src/startup.sh     # restart (and all other bridges)
 ```
 
 Logs land in `logs/slack-bridge.log`.
+
+## Install gotchas hit during real installs
+
+The Slack API config UI has a few places where a sensible default
+silently blocks the bridge. If your DMs aren't reaching the bridge,
+check these in order:
+
+1. **App-Level Token scope** — must be `connections:write`, NOT
+   `app_configurations:write`. The token-create dialog defaults to the
+   wrong one. The daemon crashes on boot with
+   `slack_sdk.errors.SlackApiError: missing_scope` if you picked the
+   other.
+
+2. **Bot Token Scopes vs User Token Scopes** — OAuth & Permissions has
+   two scope lists. Sutando runs entirely as a bot, so User Token
+   Scopes stays empty.
+
+3. **Event Subscriptions disabled** — the `Enable Events` toggle defaults
+   to OFF. Even with Socket Mode running, no events flow until this is
+   on. Bridge log will show only "Socket Mode connecting…" with no
+   subsequent activity, and `~/.claude/channels/slack/access.json` will
+   never be created.
+
+4. **Save Changes button greyed out** — when Event Subscriptions has
+   pending changes but Save is greyed, the form's Socket Mode state is
+   stale. Hard-refresh the page (cmd-shift-R) and try again. If still
+   greyed, type any placeholder URL into Request URL (e.g.
+   `https://example.com/x`); Socket Mode overrides it after save.
+
+5. **Messages Tab disabled in App Home** — see step 5 of setup above. If
+   you forget this, DMs to the bot show "Sending messages to this app
+   has been turned off" before the message even leaves Slack.
+
+6. **Forgot to reinstall after scope changes** — Slack shows a yellow
+   banner "Workspace needs to reinstall app" any time you add scopes.
+   Click it and re-authorize, otherwise the new scopes don't take effect.

--- a/docs/slack-bridge.md
+++ b/docs/slack-bridge.md
@@ -1,0 +1,78 @@
+# Slack bridge
+
+Receive DMs + channel @mentions in Slack, processed through the same task
+pipeline as voice / Discord / Telegram.
+
+## One-time Slack app setup
+
+1. **Create the app**: https://api.slack.com/apps → "Create New App" → "From scratch".
+   Pick a name + a workspace.
+
+2. **Socket Mode**: enable on the "Socket Mode" page. Generate an App-level
+   token with scope `connections:write`. Copy it (`xapp-...`).
+
+3. **OAuth & Permissions**: under "Bot Token Scopes", add
+   `chat:write`, `im:history`, `im:write`, `app_mentions:read`,
+   `channels:history`, `groups:history`.
+
+4. **Event Subscriptions**: enable. Subscribe to bot events `app_mention` and
+   `message.im` (DMs).
+
+5. **Install to workspace**. Copy the Bot User OAuth Token (`xoxb-...`).
+
+## Local config
+
+Create `~/.claude/channels/slack/.env`:
+
+```sh
+SLACK_BOT_TOKEN=xoxb-...
+SLACK_APP_TOKEN=xapp-...
+```
+
+Install the Python dep (only once):
+
+```sh
+pip3 install slack_bolt
+```
+
+## First run + TOFU onboarding
+
+`src/startup.sh` picks up the env file and starts `src/slack-bridge.py`
+automatically. On first DM after the bridge starts, the sender is
+auto-enrolled as owner — same trust-on-first-use flow Telegram uses (see
+`CLAUDE.md` → "Telegram access control"). The access list lives at
+`~/.claude/channels/slack/access.json`.
+
+To allow additional senders later, add their Slack user IDs to `allowFrom`
+in that file.
+
+## How messages flow
+
+| Slack event                | Goes to                                          |
+|----------------------------|--------------------------------------------------|
+| DM to the bot              | `tasks/task-{ts}.txt` with `source: slack`       |
+| @mention in a channel      | `tasks/task-{ts}.txt`, replied in-thread         |
+
+Results from `results/task-{ts}.txt` are posted back to the originating
+channel. DMs get a top-level reply; @mentions get a threaded reply.
+
+Protocol markers (`[no-send]`, `[REPLIED]`, `[deduped: ...]`) are honored
+identically to the Telegram bridge — see `CLAUDE.md` → "Result-body protocol
+markers".
+
+## What's NOT supported in v0
+
+- File attachments (image / file uploads, in either direction).
+- Slash commands.
+- Voice notes (no public Huddle audio API).
+
+See issue #866 for the full v0 scope + planned follow-ups.
+
+## Stop / restart
+
+```sh
+pkill -f slack-bridge   # stop
+bash src/startup.sh     # restart (and all other bridges)
+```
+
+Logs land in `logs/slack-bridge.log`.

--- a/docs/slack-bridge.md
+++ b/docs/slack-bridge.md
@@ -8,12 +8,16 @@ pipeline as voice / Discord / Telegram.
 1. **Create the app**: https://api.slack.com/apps → "Create New App" → "From scratch".
    Pick a name + a workspace.
 
-2. **Socket Mode**: enable on the "Socket Mode" page. Generate an App-level
-   token with scope `connections:write`. Copy it (`xapp-...`).
+2. **Socket Mode**: enable on the "Socket Mode" page. Generate an
+   **App-Level Token** with scope **`connections:write`** (NOT
+   `app_configurations:write` — that's a different scope and the daemon
+   will crash on boot with `missing_scope` if you pick the wrong one).
+   Copy the token (`xapp-...`).
 
-3. **OAuth & Permissions**: under "Bot Token Scopes", add
-   `chat:write`, `im:history`, `im:write`, `app_mentions:read`,
-   `channels:history`, `groups:history`.
+3. **OAuth & Permissions**: under "Bot Token Scopes" (NOT "User Token
+   Scopes" — leave that one empty), add `chat:write`, `im:history`,
+   `im:write`, `app_mentions:read`, `channels:history`,
+   `groups:history`, `files:read`, `files:write`, `users:read`.
 
 4. **Event Subscriptions**: enable. Subscribe to bot events `app_mention` and
    `message.im` (DMs).

--- a/docs/slack-bridge.md
+++ b/docs/slack-bridge.md
@@ -60,13 +60,30 @@ Protocol markers (`[no-send]`, `[REPLIED]`, `[deduped: ...]`) are honored
 identically to the Telegram bridge — see `CLAUDE.md` → "Result-body protocol
 markers".
 
-## What's NOT supported in v0
+## File attachments
 
-- File attachments (image / file uploads, in either direction).
-- Slash commands.
+Both directions work:
+
+- **Inbound** — any files attached to a DM or @mention are downloaded into
+  `$SUTANDO_WORKSPACE/slack-inbox/` and the local path is surfaced in the
+  task body as `[File attached: /path]`. Slack file URLs require the bot
+  token in an Authorization header (they're not public), so the bridge
+  handles that internally.
+- **Outbound** — result bodies may include `[file: /path]`, `[send: /path]`,
+  or `[attach: /path]` markers. Paths are allowlist-gated via
+  `_is_path_sendable()` (same `os.path.realpath` + `startswith` sanitizer
+  the telegram / discord bridges use — fail-closed by default; allowed
+  roots are `$SUTANDO_WORKSPACE/{results,notes,docs}`,
+  `$SUTANDO_WORKSPACE/slack-inbox/`, and `/tmp/sutando-*`). Uploads go
+  through `files_upload_v2` (the modern endpoint; `files.upload` is
+  deprecated as of 2025).
+
+## What's NOT supported
+
+- Slash commands (`/sutando ...`).
 - Voice notes (no public Huddle audio API).
 
-See issue #866 for the full v0 scope + planned follow-ups.
+See issue #866 for the v0 scope tracker.
 
 ## Stop / restart
 

--- a/src/migrate.sh
+++ b/src/migrate.sh
@@ -295,7 +295,7 @@ swiftc -O -o Sutando main.swift -framework Cocoa -framework Carbon -framework Ap
 cd "$REPO"
 
 # Python deps
-pip3 install google-genai discord.py python-telegram-bot Pillow 2>/dev/null || true
+pip3 install google-genai discord.py python-telegram-bot slack_bolt Pillow 2>/dev/null || true
 
 # Install shared skills (external, not in repo)
 echo "Installing shared skills..."

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""
+Slack bridge for Sutando — receives DMs + @mentions via Socket Mode, writes to
+tasks/, sends replies from results/. Works alongside the voice / discord /
+telegram bridges. Runs as a background daemon.
+
+Usage: python3 src/slack-bridge.py
+
+Env vars:
+    SLACK_BOT_TOKEN  — xoxb-... from app's OAuth & Permissions page
+    SLACK_APP_TOKEN  — xapp-... from app's Basic Information page
+                       (Socket Mode enabled, scope `connections:write`)
+
+Bot scopes (OAuth & Permissions):
+    chat:write, im:history, im:write, app_mentions:read,
+    channels:history, groups:history
+
+Access list (TOFU onboarding, same schema as telegram):
+    ~/.claude/channels/slack/access.json
+        {"allowFrom": ["U0123..."], "tofuOwner": "U0123...", ...}
+
+File attachments are NOT supported in v0 — see issue #866 for the full scope.
+"""
+
+import json
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from task_priority import default_priority_for_source  # noqa: E402
+from workspace_default import resolve_workspace  # noqa: E402
+
+try:
+    from slack_bolt import App
+    from slack_bolt.adapter.socket_mode import SocketModeHandler
+except ImportError:
+    print("slack_bolt not installed. Run: pip install slack_bolt", file=sys.stderr)
+    sys.exit(1)
+
+REPO = resolve_workspace()
+TASKS_DIR = REPO / "tasks"
+RESULTS_DIR = REPO / "results"
+STATE_DIR = REPO / "state"
+ARCHIVE_TASKS_DIR = REPO / "tasks" / "archive"
+ARCHIVE_RESULTS_DIR = REPO / "results" / "archive"
+OWNER_ACTIVITY_FILE = STATE_DIR / "last-owner-activity.json"
+TASKS_DIR.mkdir(parents=True, exist_ok=True)
+RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
+APP_TOKEN = os.environ.get("SLACK_APP_TOKEN", "")
+if not BOT_TOKEN or not APP_TOKEN:
+    print("SLACK_BOT_TOKEN and/or SLACK_APP_TOKEN not set", file=sys.stderr)
+    sys.exit(1)
+
+
+def write_owner_activity(channel: str, summary: str) -> None:
+    """Record owner activity — same schema as src/discord-bridge.py."""
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "ts": int(time.time()),
+            "channel": channel,
+            "summary": summary[:80],
+        }
+        tmp = OWNER_ACTIVITY_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload))
+        tmp.rename(OWNER_ACTIVITY_FILE)
+    except Exception as e:
+        print(f"  [owner-activity] write failed: {e}", flush=True)
+
+
+def archive_file(src: Path, kind: str, task_id: str) -> None:
+    """Move src into archive/<tasks|results>/YYYY-MM/ instead of deleting.
+    Matches the behavior of telegram-bridge.py / discord-bridge.py."""
+    try:
+        if not src.exists():
+            return
+        from datetime import datetime
+        import shutil
+        ym = datetime.now().strftime("%Y-%m")
+        base = ARCHIVE_TASKS_DIR if kind == "tasks" else ARCHIVE_RESULTS_DIR
+        dest_dir = base / ym
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
+    except Exception as e:
+        print(f"[Slack] archive_file({kind}, {task_id}) failed: {e}", flush=True)
+        try:
+            src.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+
+PRESENTER_SENTINEL = REPO / "state" / "presenter-mode.sentinel"
+
+
+def presenter_mode_active() -> bool:
+    if not PRESENTER_SENTINEL.exists():
+        return False
+    try:
+        expire_iso = PRESENTER_SENTINEL.read_text().strip()
+        if not expire_iso or not expire_iso[0].isdigit():
+            return False
+        now_iso = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
+        return now_iso < expire_iso
+    except Exception:
+        return False
+
+
+ACCESS_FILE = Path.home() / ".claude" / "channels" / "slack" / "access.json"
+
+
+def load_allowed():
+    """Return set of allowed Slack user IDs, or None if access.json missing.
+
+    None vs empty-set: file-missing means never-configured (TOFU-eligible);
+    empty allowFrom means admin explicitly locked it down (no TOFU)."""
+    try:
+        data = json.loads(ACCESS_FILE.read_text())
+        return set(data.get("allowFrom", []))
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return set()
+
+
+def tofu_onboard(user_id: str, username: str | None) -> set:
+    """First-time auto-onboard — same contract as telegram-bridge.py."""
+    if ACCESS_FILE.exists():
+        return load_allowed() or set()
+    ACCESS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "allowFrom": [user_id],
+        "tofuOwner": user_id,
+        "tofuOnboardedAt": int(time.time()),
+        "tofuOnboardedUsername": username or None,
+    }
+    ACCESS_FILE.write_text(json.dumps(payload, indent=2) + "\n")
+    os.chmod(ACCESS_FILE, 0o600)
+    print(
+        f"  TOFU: auto-onboarded @{username} (id={user_id}) as owner — wrote {ACCESS_FILE}",
+        flush=True,
+    )
+    return {user_id}
+
+
+# Track which Slack channel/thread to reply into for each task we wrote.
+# Keyed by task_id; value is {channel, thread_ts} so we can reply in-thread
+# for @mentions and at top-level for DMs.
+pending_replies: dict[str, dict] = {}
+pending_replies_lock = threading.Lock()
+
+# Bolt App. Socket Mode handler attaches via SocketModeHandler below.
+app = App(token=BOT_TOKEN)
+
+
+def _write_task(event: dict, prefix: str, text: str, username: str | None) -> str | None:
+    """Write a task file from a Slack event. Returns task_id or None if skipped."""
+    user_id = event.get("user")
+    if not user_id:
+        return None
+
+    # Access control via TOFU
+    allowed = load_allowed()
+    if allowed is None:
+        allowed = tofu_onboard(user_id, username)
+    if user_id not in allowed:
+        print(f"  Dropped message from non-allowed user {user_id}", flush=True)
+        return None
+
+    write_owner_activity("slack", text)
+
+    channel = event.get("channel", "")
+    # Reply in-thread for channel @mentions, top-level for DMs.
+    thread_ts = event.get("thread_ts") or event.get("ts") if event.get("channel_type") != "im" else None
+
+    ts = int(time.time() * 1000)
+    task_id = f"task-{ts}"
+    task_file = TASKS_DIR / f"{task_id}.txt"
+    priority = default_priority_for_source("slack", "owner")
+    task_file.write_text(
+        f"id: {task_id}\n"
+        f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%S')}Z\n"
+        f"task: [{prefix} @{username or user_id}] {text}\n"
+        f"source: slack\n"
+        f"channel_id: {channel}\n"
+        f"user_id: {user_id}\n"
+        f"access_tier: owner\n"
+        f"priority: {priority}\n"
+    )
+    with pending_replies_lock:
+        pending_replies[task_id] = {"channel": channel, "thread_ts": thread_ts}
+
+    print(f"  Wrote {task_id} from {prefix} @{username}", flush=True)
+    return task_id
+
+
+def _resolve_username(user_id: str) -> str | None:
+    try:
+        resp = app.client.users_info(user=user_id)
+        return resp["user"]["profile"].get("display_name") or resp["user"].get("name")
+    except Exception:
+        return None
+
+
+@app.event("app_mention")
+def handle_mention(event, say):
+    """Channel @mention → task file."""
+    user_id = event.get("user")
+    username = _resolve_username(user_id) if user_id else None
+    # Strip the leading <@BOTID> mention from the text body for cleanliness.
+    raw = event.get("text", "")
+    import re
+    text = re.sub(r"^<@[A-Z0-9]+>\s*", "", raw).strip()
+    if not text:
+        return
+    _write_task(event, "Slack mention", text, username)
+
+
+@app.event("message")
+def handle_message(event, say):
+    """DM → task file. Channel messages are handled via app_mention only."""
+    # Ignore bot messages, edited messages, and channel-history backfills.
+    if event.get("subtype") in ("bot_message", "message_changed", "message_deleted"):
+        return
+    # Only handle direct messages (channel_type=im). Channel @mentions arrive
+    # via the separate app_mention event above, so handling them here would
+    # double-fire.
+    if event.get("channel_type") != "im":
+        return
+    user_id = event.get("user")
+    if not user_id:
+        return
+    username = _resolve_username(user_id)
+    text = event.get("text", "").strip()
+    if not text:
+        return
+    _write_task(event, "Slack DM", text, username)
+
+
+def _send_reply(channel: str, thread_ts: str | None, text: str) -> None:
+    """Post a reply via chat.postMessage. Slack truncates messages at ~40KB
+    but Discord-style 2000-char chunking keeps things readable in the UI."""
+    if not text:
+        return
+    for i in range(0, len(text), 4000):
+        kwargs = {"channel": channel, "text": text[i:i + 4000]}
+        if thread_ts:
+            kwargs["thread_ts"] = thread_ts
+        try:
+            app.client.chat_postMessage(**kwargs)
+        except Exception as e:
+            print(f"[Slack] chat_postMessage failed: {e}", flush=True)
+            break
+
+
+def result_watcher():
+    """Background thread: polls results/ for replies + proactive messages."""
+    heartbeat_file = REPO / "state" / "slack-bridge.heartbeat"
+    last_heartbeat = 0.0
+    while True:
+        try:
+            # Replies to pending tasks
+            with pending_replies_lock:
+                pending_ids = list(pending_replies.keys())
+            for task_id in pending_ids:
+                result_file = RESULTS_DIR / f"{task_id}.txt"
+                if not result_file.exists():
+                    continue
+                reply_text = result_file.read_text().strip()
+                with pending_replies_lock:
+                    target = pending_replies.pop(task_id, None)
+                if not target:
+                    continue
+
+                if (reply_text.startswith("[no-send]")
+                        or reply_text.startswith("[REPLIED]")
+                        or reply_text.startswith("[deduped:")):
+                    print(f"  Skipped (marker): {task_id}", flush=True)
+                else:
+                    try:
+                        _send_reply(target["channel"], target.get("thread_ts"), reply_text)
+                        print(f"  Replied to {target['channel']}: {reply_text[:80]}...", flush=True)
+                    except Exception as e:
+                        print(f"[Slack] reply error: {e}", flush=True)
+
+                archive_file(result_file, "results", task_id)
+                archive_file(TASKS_DIR / f"{task_id}.txt", "tasks", task_id)
+
+            # Proactive messages (sent to owner DM)
+            if not presenter_mode_active():
+                for f in list(RESULTS_DIR.iterdir()):
+                    if not (f.name.startswith("proactive-") and f.suffix == ".txt"):
+                        continue
+                    claim = f.with_suffix(".sending")
+                    try:
+                        f.rename(claim)
+                    except FileNotFoundError:
+                        continue
+                    text = claim.read_text().strip()
+                    if not text:
+                        claim.unlink(missing_ok=True)
+                        continue
+                    owner_ids = load_allowed()
+                    if owner_ids:
+                        owner_id = next(iter(owner_ids))
+                        # Open a DM channel to the owner (idempotent).
+                        try:
+                            resp = app.client.conversations_open(users=owner_id)
+                            dm_channel = resp["channel"]["id"]
+                            _send_reply(dm_channel, None, text)
+                            print(f"  [proactive] sent to {owner_id}: {text[:80]}", flush=True)
+                        except Exception as e:
+                            print(f"  [proactive] failed: {e}", flush=True)
+                    claim.unlink(missing_ok=True)
+
+            # Heartbeat (used by health-check.py)
+            now = time.time()
+            if now - last_heartbeat >= 60:
+                try:
+                    heartbeat_file.write_text(str(int(now)))
+                    last_heartbeat = now
+                except Exception:
+                    pass
+
+            time.sleep(1)
+        except Exception as e:
+            print(f"[Slack] result_watcher error: {e}", flush=True)
+            time.sleep(5)
+
+
+def main():
+    print("Slack bridge started. Socket Mode connecting...", flush=True)
+    threading.Thread(target=result_watcher, name="slack-result-watcher", daemon=True).start()
+    handler = SocketModeHandler(app, APP_TOKEN)
+    handler.start()  # blocks
+
+
+if __name__ == "__main__":
+    main()

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -214,6 +214,13 @@ pending_replies_lock = threading.Lock()
 _username_cache: dict[str, str | None] = {}
 _username_cache_lock = threading.Lock()
 
+# Event counter — used by the no-events-after-60s hint thread to detect
+# the "Socket Mode connected but Event Subscriptions disabled" install
+# trap. Cost of the most common install hang-up is ~1h of owner time
+# (verified 2026-05-18). The hint is cheap insurance.
+_event_count = 0
+_event_count_lock = threading.Lock()
+
 # Bolt App. Socket Mode handler attaches via SocketModeHandler below.
 app = App(token=BOT_TOKEN)
 
@@ -299,6 +306,10 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
     )
     with pending_replies_lock:
         pending_replies[task_id] = {"channel": channel, "thread_ts": thread_ts}
+
+    global _event_count
+    with _event_count_lock:
+        _event_count += 1
 
     print(f"  Wrote {task_id} from {prefix} @{username}", flush=True)
     return task_id
@@ -513,9 +524,39 @@ def result_watcher():
             time.sleep(5)
 
 
+def _no_events_hint_thread():
+    """One-shot watchdog: 60s after start, if no events have arrived,
+    log a hint pointing at the most common install trap (Event
+    Subscriptions disabled). Suppresses itself once any event is seen.
+
+    Owner spent ~1h on 2026-05-18 hitting exactly this state: bridge
+    alive, Socket Mode WS connected to Slack, but Event Subscriptions
+    was off so no events ever flowed. The bridge log was silent past
+    "Socket Mode connecting…" — no signal to act on. This hint surfaces
+    the diagnostic the next install will need.
+    """
+    time.sleep(60)
+    with _event_count_lock:
+        n = _event_count
+    if n == 0:
+        print(
+            "[Slack] HINT: 60s elapsed with zero events received.\n"
+            "  Bridge is connected to Slack's edge, but events are not arriving.\n"
+            "  Most common cause: Event Subscriptions is disabled in your app config.\n"
+            "  Fix: https://api.slack.com/apps → your app → Event Subscriptions →\n"
+            "    1. Toggle 'Enable Events' to ON\n"
+            "    2. Under 'Subscribe to bot events' add: message.im, app_mention\n"
+            "    3. Save Changes (if greyed, see docs/slack-bridge.md install gotchas)\n"
+            "    4. Reinstall app if Slack prompts a yellow banner\n"
+            "  Then send a DM to your bot — TOFU will auto-onboard you as owner.",
+            flush=True,
+        )
+
+
 def main():
     print("Slack bridge started. Socket Mode connecting...", flush=True)
     threading.Thread(target=result_watcher, name="slack-result-watcher", daemon=True).start()
+    threading.Thread(target=_no_events_hint_thread, name="slack-no-events-hint", daemon=True).start()
     handler = SocketModeHandler(app, APP_TOKEN)
     handler.start()  # blocks
 

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -13,20 +13,32 @@ Env vars:
 
 Bot scopes (OAuth & Permissions):
     chat:write, im:history, im:write, app_mentions:read,
-    channels:history, groups:history
+    channels:history, groups:history, files:read, files:write,
+    users:read
 
 Access list (TOFU onboarding, same schema as telegram):
     ~/.claude/channels/slack/access.json
         {"allowFrom": ["U0123..."], "tofuOwner": "U0123...", ...}
 
-File attachments are NOT supported in v0 — see issue #866 for the full scope.
+File round-trip:
+    Inbound  — files attached to DMs/mentions are downloaded into
+               $SUTANDO_WORKSPACE/slack-inbox/ and the path is surfaced
+               in the task body as "[File attached: /path]".
+    Outbound — result bodies may include [file: /path], [send: /path],
+               or [attach: /path] markers. Paths are allowlisted via
+               _is_path_sendable() (same realpath+startswith sanitizer
+               the telegram/discord bridges use) and uploaded via
+               files_upload_v2.
 """
 
 import json
+import mimetypes
 import os
+import re
 import sys
 import threading
 import time
+import urllib.request
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -44,17 +56,58 @@ REPO = resolve_workspace()
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
 STATE_DIR = REPO / "state"
+INBOX_DIR = REPO / "slack-inbox"
 ARCHIVE_TASKS_DIR = REPO / "tasks" / "archive"
 ARCHIVE_RESULTS_DIR = REPO / "results" / "archive"
 OWNER_ACTIVITY_FILE = STATE_DIR / "last-owner-activity.json"
 TASKS_DIR.mkdir(parents=True, exist_ok=True)
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+INBOX_DIR.mkdir(parents=True, exist_ok=True)
 
 BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
 APP_TOKEN = os.environ.get("SLACK_APP_TOKEN", "")
 if not BOT_TOKEN or not APP_TOKEN:
     print("SLACK_BOT_TOKEN and/or SLACK_APP_TOKEN not set", file=sys.stderr)
     sys.exit(1)
+
+
+# Outbound file-send allowlist — mirrors _is_path_sendable() in
+# discord-bridge.py + telegram-bridge.py. Fail-closed by default.
+SEND_ALLOWED_ROOTS = (
+    str(REPO / "results"),
+    str(REPO / "notes"),
+    str(REPO / "docs"),
+    str(INBOX_DIR),
+)
+SEND_ALLOWED_PREFIXES = (
+    "/tmp/sutando-",
+    "/private/tmp/sutando-",
+    "/tmp/echo-",
+    "/private/tmp/echo-",
+)
+
+
+def _is_path_sendable(fpath: str) -> bool:
+    """True iff `fpath` is a real file AND resolves under an allowed root.
+
+    Uses os.path.realpath + startswith — CodeQL recognizes this pattern as
+    a path-injection sanitizer. Do NOT swap for Path.resolve() without
+    re-proving to CodeQL. Same shape as the discord/telegram allowlist.
+    """
+    if not os.path.isfile(fpath):
+        return False
+    try:
+        real = os.path.realpath(fpath)
+    except OSError:
+        return False
+    for root in SEND_ALLOWED_ROOTS:
+        root_real = os.path.realpath(root)
+        if real == root_real or real.startswith(root_real + os.sep):
+            return True
+    for prefix in SEND_ALLOWED_PREFIXES:
+        if real.startswith(prefix):
+            return True
+    return False
 
 
 def write_owner_activity(channel: str, summary: str) -> None:
@@ -153,8 +206,43 @@ def tofu_onboard(user_id: str, username: str | None) -> set:
 pending_replies: dict[str, dict] = {}
 pending_replies_lock = threading.Lock()
 
+# Username cache — users.info is rate-limited (Tier 4 = 100/min). One
+# cache lookup per known user saves a network hop on every DM. Cache
+# never invalidates because display names rarely change and a stale
+# username is only a cosmetic issue in the task body. Cleared on
+# process restart.
+_username_cache: dict[str, str | None] = {}
+_username_cache_lock = threading.Lock()
+
 # Bolt App. Socket Mode handler attaches via SocketModeHandler below.
 app = App(token=BOT_TOKEN)
+
+
+def _download_slack_file(file_dict: dict) -> str | None:
+    """Download a Slack file to INBOX_DIR. Returns the local path or None.
+
+    Slack file URLs require the bot token in an Authorization header — they
+    are NOT public. We GET url_private and write to a name-mangled local
+    file using the original filename suffix where possible.
+    """
+    url = file_dict.get("url_private_download") or file_dict.get("url_private")
+    if not url:
+        return None
+    name_hint = file_dict.get("name") or file_dict.get("id") or "file"
+    # Slack returns filenames that may contain path separators or weird
+    # chars. Strip to basename and replace anything sketchy with _.
+    safe_name = os.path.basename(name_hint).replace(os.sep, "_") or "file"
+    local_path = INBOX_DIR / f"{int(time.time() * 1000)}-{safe_name}"
+    try:
+        req = urllib.request.Request(
+            url, headers={"Authorization": f"Bearer {BOT_TOKEN}"}
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp, open(local_path, "wb") as f:
+            f.write(resp.read())
+        return str(local_path)
+    except Exception as e:
+        print(f"  [file] download failed for {name_hint}: {e}", flush=True)
+        return None
 
 
 def _write_task(event: dict, prefix: str, text: str, username: str | None) -> str | None:
@@ -171,11 +259,29 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
         print(f"  Dropped message from non-allowed user {user_id}", flush=True)
         return None
 
-    write_owner_activity("slack", text)
+    # Download any attached files BEFORE writing the task, so the task body
+    # carries the local paths. Skips silently on failure — task still goes
+    # through with whatever files did download.
+    attachment_lines = []
+    for file_dict in event.get("files") or []:
+        local_path = _download_slack_file(file_dict)
+        if local_path:
+            attachment_lines.append(f"[File attached: {local_path}]")
+    attachment_note = ("\n" + "\n".join(attachment_lines)) if attachment_lines else ""
+
+    if not text and not attachment_note:
+        return None
+
+    write_owner_activity("slack", text or attachment_note)
 
     channel = event.get("channel", "")
-    # Reply in-thread for channel @mentions, top-level for DMs.
-    thread_ts = event.get("thread_ts") or event.get("ts") if event.get("channel_type") != "im" else None
+    # Reply in-thread for channel @mentions, top-level for DMs. parens for
+    # readability; Python's `or` + ternary precedence is correct here but
+    # the explicit grouping makes the intent obvious to humans.
+    if event.get("channel_type") != "im":
+        thread_ts = event.get("thread_ts") or event.get("ts")
+    else:
+        thread_ts = None
 
     ts = int(time.time() * 1000)
     task_id = f"task-{ts}"
@@ -184,7 +290,7 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
     task_file.write_text(
         f"id: {task_id}\n"
         f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%S')}Z\n"
-        f"task: [{prefix} @{username or user_id}] {text}\n"
+        f"task: [{prefix} @{username or user_id}] {text}{attachment_note}\n"
         f"source: slack\n"
         f"channel_id: {channel}\n"
         f"user_id: {user_id}\n"
@@ -199,11 +305,24 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
 
 
 def _resolve_username(user_id: str) -> str | None:
+    """Resolve Slack user_id → display_name, cached.
+
+    The cache is unbounded but keyed by user_id, so practical size is
+    O(distinct senders) per process lifetime — fine for a personal agent.
+    Never invalidates: a stale display name is only cosmetic.
+    """
+    with _username_cache_lock:
+        if user_id in _username_cache:
+            return _username_cache[user_id]
+    name: str | None = None
     try:
         resp = app.client.users_info(user=user_id)
-        return resp["user"]["profile"].get("display_name") or resp["user"].get("name")
+        name = resp["user"]["profile"].get("display_name") or resp["user"].get("name")
     except Exception:
-        return None
+        pass
+    with _username_cache_lock:
+        _username_cache[user_id] = name
+    return name
 
 
 @app.event("app_mention")
@@ -211,12 +330,9 @@ def handle_mention(event, say):
     """Channel @mention → task file."""
     user_id = event.get("user")
     username = _resolve_username(user_id) if user_id else None
-    # Strip the leading <@BOTID> mention from the text body for cleanliness.
     raw = event.get("text", "")
-    import re
+    # Strip the leading <@BOTID> mention from the text body for cleanliness.
     text = re.sub(r"^<@[A-Z0-9]+>\s*", "", raw).strip()
-    if not text:
-        return
     _write_task(event, "Slack mention", text, username)
 
 
@@ -235,26 +351,91 @@ def handle_message(event, say):
     if not user_id:
         return
     username = _resolve_username(user_id)
-    text = event.get("text", "").strip()
-    if not text:
-        return
+    text = (event.get("text") or "").strip()
     _write_task(event, "Slack DM", text, username)
 
 
-def _send_reply(channel: str, thread_ts: str | None, text: str) -> None:
-    """Post a reply via chat.postMessage. Slack truncates messages at ~40KB
-    but Discord-style 2000-char chunking keeps things readable in the UI."""
-    if not text:
-        return
-    for i in range(0, len(text), 4000):
-        kwargs = {"channel": channel, "text": text[i:i + 4000]}
+# Markers that the bridge handles specially in result bodies. Same set as
+# discord-bridge.py + telegram-bridge.py — see CLAUDE.md "Result-body
+# protocol markers".
+FILE_MARKER_RE = re.compile(r'\[(?:file|send|attach):\s*([^\]]+)\]')
+
+
+def _send_file(channel: str, thread_ts: str | None, fpath: str) -> bool:
+    """Upload a file to a Slack channel/DM via files_upload_v2.
+
+    Returns True on success. Caller is responsible for allowlist-gating
+    the path before invocation — this function does not re-check.
+    """
+    try:
+        kwargs: dict = {
+            "channel": channel,
+            "file": fpath,
+            "filename": os.path.basename(fpath),
+        }
         if thread_ts:
             kwargs["thread_ts"] = thread_ts
-        try:
-            app.client.chat_postMessage(**kwargs)
-        except Exception as e:
-            print(f"[Slack] chat_postMessage failed: {e}", flush=True)
-            break
+        # files_upload_v2 is the recommended modern endpoint; the older
+        # files.upload is deprecated as of March 2025.
+        app.client.files_upload_v2(**kwargs)
+        return True
+    except Exception as e:
+        print(f"[Slack] files_upload_v2 failed for {fpath}: {e}", flush=True)
+        return False
+
+
+def _send_reply(channel: str, thread_ts: str | None, text: str) -> None:
+    """Post a reply via chat.postMessage with file-marker extraction.
+
+    Extracts [file:]/[send:]/[attach:] markers, uploads each allowlisted
+    file via files_upload_v2, and posts whatever text remains via
+    chat.postMessage. Chunks long text into 4000-char Slack messages.
+    """
+    if not text:
+        return
+
+    # Extract file paths first so the text body doesn't carry them.
+    file_paths = [m.strip() for m in FILE_MARKER_RE.findall(text)]
+    clean_text = FILE_MARKER_RE.sub('', text).strip()
+
+    # Post the text body in 4000-char chunks (Slack's per-message limit is
+    # 40k chars but readability suffers above ~4k).
+    if clean_text:
+        for i in range(0, len(clean_text), 4000):
+            kwargs = {"channel": channel, "text": clean_text[i:i + 4000]}
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+            try:
+                app.client.chat_postMessage(**kwargs)
+            except Exception as e:
+                print(f"[Slack] chat_postMessage failed: {e}", flush=True)
+                break
+
+    # Then upload each file. Fail-closed via _is_path_sendable.
+    for fpath in file_paths:
+        if _is_path_sendable(fpath):
+            if _send_file(channel, thread_ts, fpath):
+                print(f"  Sent file: {fpath}", flush=True)
+        elif os.path.isfile(fpath):
+            # Path exists but isn't allowlisted — surface a visible deny.
+            try:
+                app.client.chat_postMessage(
+                    channel=channel,
+                    text=f"(file access denied: {fpath})",
+                    **({"thread_ts": thread_ts} if thread_ts else {}),
+                )
+            except Exception:
+                pass
+            print(f"  BLOCKED file: {fpath}", flush=True)
+        else:
+            try:
+                app.client.chat_postMessage(
+                    channel=channel,
+                    text=f"(file not found: {fpath})",
+                    **({"thread_ts": thread_ts} if thread_ts else {}),
+                )
+            except Exception:
+                pass
 
 
 def result_watcher():

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -330,6 +330,32 @@ else
   echo "  ~ discord bridge (no token — optional)"
 fi
 
+# 7b. Slack bridge (optional — needs SLACK_BOT_TOKEN + SLACK_APP_TOKEN + slack_bolt)
+# Probes the same Python-interpreter candidates as the discord bridge so a
+# fresh-install miniconda env doesn't silently miss slack_bolt.
+if [ -f "$HOME/.claude/channels/slack/.env" ] && grep -q "SLACK_BOT_TOKEN=" "$HOME/.claude/channels/slack/.env" 2>/dev/null; then
+  PYTHON_WITH_SLACK=""
+  for _p in /opt/homebrew/bin/python3 /usr/local/bin/python3 python3; do
+    if command -v "$_p" >/dev/null 2>&1 && "$_p" -c "import slack_bolt" 2>/dev/null; then
+      PYTHON_WITH_SLACK="$_p"
+      break
+    fi
+  done
+  if [ -z "$PYTHON_WITH_SLACK" ]; then
+    echo "  ~ slack bridge (no python with slack_bolt — run: /opt/homebrew/bin/pip3 install slack_bolt)"
+  elif ! pgrep -f "slack-bridge" > /dev/null 2>&1; then
+    echo "  Starting Slack bridge with $PYTHON_WITH_SLACK..."
+    # Source the env file so SLACK_BOT_TOKEN / SLACK_APP_TOKEN reach the child.
+    set -a; . "$HOME/.claude/channels/slack/.env"; set +a
+    "$PYTHON_WITH_SLACK" src/slack-bridge.py > logs/slack-bridge.log 2>&1 &
+    echo "  ✓ slack bridge"
+  else
+    echo "  ✓ slack bridge (already running)"
+  fi
+else
+  echo "  ~ slack bridge (no token — optional)"
+fi
+
 # 8. Phone conversation server + ngrok (optional — needs Twilio creds, skip with SKIP_PHONE=1)
 if [ "${SKIP_PHONE:-}" = "1" ]; then
   echo "  ~ conversation server (skipped via SKIP_PHONE)"

--- a/src/verify-setup.sh
+++ b/src/verify-setup.sh
@@ -81,6 +81,15 @@ if [ -f .env ]; then
   else
     warn "Discord not configured (optional — run /discord:configure)"
   fi
+  if [ -f "$HOME/.claude/channels/slack/.env" ]; then
+    if python3 -c "import slack_bolt" 2>/dev/null; then
+      pass "Slack bot configured"
+    else
+      warn "Slack configured but slack_bolt missing (pip3 install slack_bolt)"
+    fi
+  else
+    warn "Slack not configured (optional — run /slack:configure)"
+  fi
 else
   fail ".env file missing (cp .env.example .env and edit)"
 fi

--- a/tests/slack-bridge-access.test.py
+++ b/tests/slack-bridge-access.test.py
@@ -73,9 +73,11 @@ def main() -> int:
                     "owner's Slack user ID, must not inherit umask 644",
                     tofu_block)
 
-    # 3. _write_task fails closed on unknown sender
+    # 3. _write_task fails closed on unknown sender. Budget bumped from
+    # 2000 to 4000 in commit 98e188b — function body grew once file-
+    # attachment download + thread_ts disambiguation moved in.
     write_match = re.search(
-        r"def _write_task\([^)]*\)[^:]*:\s*\n([\s\S]{0,2000}?)(?=\n\ndef |\Z)",
+        r"def _write_task\([^)]*\)[^:]*:\s*\n([\s\S]{0,4000}?)(?=\n\ndef |\Z)",
         src,
     )
     if not write_match:

--- a/tests/slack-bridge-access.test.py
+++ b/tests/slack-bridge-access.test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Structural regression test for the Slack bridge access control (PR #867 / #866).
+
+Guards that refactors of src/slack-bridge.py don't accidentally drop the
+TOFU + allowlist gate, which is the only thing keeping a Slack bot from
+processing tasks for arbitrary senders once it's installed.
+
+Same scope as tests/discord-bridge-access-tier.test.py: STRUCTURAL —
+regex-matches the source. Does NOT import the bridge (slack_bolt dep is
+optional + heavy). Run manually:
+
+    python3 tests/slack-bridge-access.test.py
+
+Guards:
+  1. `load_allowed()` returns None when ACCESS_FILE is missing (the
+     None-vs-empty-set distinction TOFU relies on).
+  2. `tofu_onboard()` exists, is gated on `ACCESS_FILE.exists()`, and
+     writes the file at 0o600 perms (don't leak the owner's Slack user ID
+     world-readable via umask 644).
+  3. `_write_task()` checks `user_id not in allowed` and drops with a log
+     line — fail-closed for unknown senders.
+  4. ACCESS_FILE lives under ~/.claude/channels/slack/ — consistent with
+     telegram + discord (so /sutando uninstall scripts find it).
+"""
+
+from pathlib import Path
+import re
+import sys
+
+REPO = Path(__file__).resolve().parent.parent
+BRIDGE = REPO / "src" / "slack-bridge.py"
+
+
+def fail(msg: str, context: str = "") -> int:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    if context:
+        print("---context---", file=sys.stderr)
+        print(context[:1500], file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if not BRIDGE.exists():
+        return fail(f"{BRIDGE} not found")
+
+    src = BRIDGE.read_text()
+
+    # 1. load_allowed returns None on FileNotFoundError
+    load_match = re.search(
+        r"def load_allowed\(\):\s*\n([\s\S]{0,1500}?)(?=\n\ndef |\Z)",
+        src,
+    )
+    if not load_match:
+        return fail("`load_allowed` function not found")
+    block = load_match.group(1)
+    if not re.search(r"except\s+FileNotFoundError:\s*\n\s+return\s+None", block):
+        return fail("load_allowed must `return None` on FileNotFoundError "
+                    "(TOFU relies on None vs empty-set distinction)", block)
+
+    # 2. tofu_onboard exists with race-guard + 0o600 chmod
+    tofu_match = re.search(
+        r"def tofu_onboard\([^)]*\)[^:]*:\s*\n([\s\S]{0,2000}?)(?=\n\ndef |\Z)",
+        src,
+    )
+    if not tofu_match:
+        return fail("`tofu_onboard` function not found")
+    tofu_block = tofu_match.group(1)
+    if not re.search(r"if\s+ACCESS_FILE\.exists\(\)", tofu_block):
+        return fail("tofu_onboard must race-guard with ACCESS_FILE.exists()", tofu_block)
+    if not re.search(r"os\.chmod\s*\(\s*ACCESS_FILE\s*,\s*0o600\s*\)", tofu_block):
+        return fail("tofu_onboard must chmod ACCESS_FILE to 0o600 — file holds "
+                    "owner's Slack user ID, must not inherit umask 644",
+                    tofu_block)
+
+    # 3. _write_task fails closed on unknown sender
+    write_match = re.search(
+        r"def _write_task\([^)]*\)[^:]*:\s*\n([\s\S]{0,2000}?)(?=\n\ndef |\Z)",
+        src,
+    )
+    if not write_match:
+        return fail("`_write_task` function not found")
+    write_block = write_match.group(1)
+    # Must check `user_id not in allowed` (or equivalent) and return None
+    if not re.search(
+        r"if\s+user_id\s+not\s+in\s+allowed\s*:\s*\n[\s\S]{0,200}?return\s+None",
+        write_block,
+    ):
+        return fail("_write_task must drop messages from senders not in allowed "
+                    "(fail-closed access gate)", write_block)
+
+    # 4. ACCESS_FILE path is ~/.claude/channels/slack/
+    if not re.search(
+        r"ACCESS_FILE\s*=\s*Path\.home\(\)\s*/\s*['\"]\.claude['\"]\s*/\s*['\"]channels['\"]\s*/\s*['\"]slack['\"]\s*/\s*['\"]access\.json['\"]",
+        src,
+    ):
+        return fail("ACCESS_FILE must be ~/.claude/channels/slack/access.json "
+                    "for parity with telegram + discord bridges")
+
+    print("PASS: slack-bridge.py access control looks correct.")
+    print("  - load_allowed returns None when ACCESS_FILE missing (TOFU-eligible)")
+    print("  - tofu_onboard race-guards and chmods to 0o600")
+    print("  - _write_task fails closed on unknown senders")
+    print("  - ACCESS_FILE path consistent with telegram/discord bridges")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/slack-bridge-allowlist.test.py
+++ b/tests/slack-bridge-allowlist.test.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Behavioral test for src/slack-bridge.py's _is_path_sendable() — the
+allowlist gate the bridge uses before uploading a file to Slack via
+files_upload_v2.
+
+Same security contract as the discord-bridge / telegram-bridge versions:
+    1. File must exist.
+    2. Real path (os.path.realpath) must equal-or-start-with an entry in
+       SEND_ALLOWED_ROOTS, OR start with one of SEND_ALLOWED_PREFIXES.
+    3. Fail-closed default — anything else returns False.
+
+Why behavioral, not just structural: the structural test
+(slack-bridge-access.test.py) guards "the function exists with the right
+shape", but a future refactor could keep the regex-visible shape while
+breaking the fail-closed default (e.g. changing `for root in
+SEND_ALLOWED_ROOTS: if real.startswith(root)` into something that returns
+True before the prefix check completes). Behavioral coverage shows the
+function actually rejects unauthorized paths.
+
+The bridge imports `slack_bolt.App` at module load and the real App
+constructor hits `auth.test` against Slack with the token — which fails
+on a fake token. This test monkey-patches `slack_bolt.App` with a stub
+before importing, so we can exercise the bridge's pure-Python helpers
+without network access. If `slack_bolt` is not installed, the test
+skips silently (the structural test in slack-bridge-access.test.py is
+still useful in that environment).
+
+Run: python3 tests/slack-bridge-allowlist.test.py
+Exit code: 0 on pass / skip, 1 on fail.
+"""
+
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+
+class _StubApp:
+    """Stub for slack_bolt.App — accepts any constructor kwargs, provides
+    .event() decorator, .client placeholder. Skips the auth.test that
+    the real App fires on init."""
+
+    def __init__(self, *a, **kw):
+        self.client = types.SimpleNamespace()
+
+    def event(self, _name):
+        def decorator(fn):
+            return fn
+        return decorator
+
+
+def _load_module():
+    """Import slack-bridge.py with stubbed slack_bolt + env vars, so we
+    can exercise pure-Python helpers without network access. Returns the
+    module or None if even the stub setup fails."""
+    os.environ.setdefault("SLACK_BOT_TOKEN", "xoxb-test-token-for-helper-only")
+    os.environ.setdefault("SLACK_APP_TOKEN", "xapp-test-token-for-helper-only")
+    os.environ.setdefault("SUTANDO_WORKSPACE", tempfile.mkdtemp(prefix="sutando-test-slack-allowlist-"))
+
+    # Monkey-patch slack_bolt BEFORE importing the bridge. If slack_bolt
+    # isn't installed at all, fabricate the whole module tree so the
+    # bridge's `from slack_bolt import App` succeeds.
+    try:
+        import slack_bolt as _real_bolt
+        # Real lib installed — only patch App.
+        _real_bolt.App = _StubApp
+    except ImportError:
+        # Not installed — fabricate the bare minimum so the bridge imports.
+        stub_bolt = types.ModuleType("slack_bolt")
+        stub_bolt.App = _StubApp
+        sys.modules["slack_bolt"] = stub_bolt
+        adapter_pkg = types.ModuleType("slack_bolt.adapter")
+        sys.modules["slack_bolt.adapter"] = adapter_pkg
+        sm_mod = types.ModuleType("slack_bolt.adapter.socket_mode")
+        sm_mod.SocketModeHandler = object
+        sys.modules["slack_bolt.adapter.socket_mode"] = sm_mod
+
+    # Also stub the submodule that the bridge imports directly.
+    if "slack_bolt.adapter.socket_mode" not in sys.modules:
+        adapter_pkg = types.ModuleType("slack_bolt.adapter")
+        sys.modules["slack_bolt.adapter"] = adapter_pkg
+        sm_mod = types.ModuleType("slack_bolt.adapter.socket_mode")
+        sm_mod.SocketModeHandler = object
+        sys.modules["slack_bolt.adapter.socket_mode"] = sm_mod
+
+    import importlib.util
+    repo = Path(__file__).resolve().parent.parent
+    bridge_path = repo / "src" / "slack-bridge.py"
+    if not bridge_path.exists():
+        print(f"FAIL: {bridge_path} not found", file=sys.stderr)
+        sys.exit(1)
+    spec = importlib.util.spec_from_file_location("slack_bridge_under_test", bridge_path)
+    sys.path.insert(0, str(repo / "src"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main() -> int:
+    try:
+        mod = _load_module()
+    except Exception as e:
+        print(f"FAIL: could not load slack-bridge.py for testing: {e}", file=sys.stderr)
+        return 1
+
+    is_path_sendable = mod._is_path_sendable
+    workspace = Path(mod.REPO)
+
+    # Set up test fixtures inside the temp workspace
+    notes_dir = workspace / "notes"
+    notes_dir.mkdir(parents=True, exist_ok=True)
+    docs_dir = workspace / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    results_dir = workspace / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    inbox_dir = workspace / "slack-inbox"
+    inbox_dir.mkdir(parents=True, exist_ok=True)
+    allowed_file = notes_dir / "ok.md"
+    allowed_file.write_text("ok")
+    inbox_file = inbox_dir / "downloaded.png"
+    inbox_file.write_text("binary")
+
+    # /tmp/sutando-* allowed-prefix fixture. dir="/tmp" forces real /tmp
+    # — without it macOS tempfile uses $TMPDIR (/var/folders/...), which
+    # is NOT in the allowlist's prefix list.
+    tmp_sutando = Path(tempfile.mkdtemp(prefix="sutando-test-allowed-", dir="/tmp"))
+    tmp_sutando_file = tmp_sutando / "ok.txt"
+    tmp_sutando_file.write_text("ok")
+
+    # Disallowed: a file outside any allowed root or prefix
+    not_allowed_dir = Path(tempfile.mkdtemp(prefix="other-not-sutando-"))
+    not_allowed_file = not_allowed_dir / "secret.txt"
+    not_allowed_file.write_text("secret")
+
+    cases = [
+        # (path, expected, label)
+        (str(allowed_file), True, "allowed file in $WORKSPACE/notes/"),
+        (str(inbox_file), True, "allowed file in $WORKSPACE/slack-inbox/"),
+        (str(tmp_sutando_file), True, "allowed file at /tmp/sutando-* prefix"),
+        (str(not_allowed_file), False, "disallowed file outside any allowed root"),
+        (str(workspace / "notes" / "does-not-exist"), False, "missing file in allowed root"),
+        ("/etc/passwd", False, "fail-closed for sensitive system file"),
+        ("relative/path.txt", False, "fail-closed for relative path"),
+        ("", False, "fail-closed for empty string"),
+    ]
+
+    failed = 0
+    for path, expected, label in cases:
+        actual = is_path_sendable(path)
+        if actual != expected:
+            print(f"FAIL: {label} → expected {expected}, got {actual} (path={path!r})", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"  OK: {label}")
+
+    # Symlink traversal — the CodeQL-recognized sanitizer is realpath.
+    # A symlink in an allowed dir pointing OUT must return False.
+    if hasattr(os, "symlink"):
+        symlink_path = notes_dir / "evil-link"
+        try:
+            symlink_path.symlink_to(not_allowed_file)
+            actual = is_path_sendable(str(symlink_path))
+            label = "symlink in allowed root targeting non-allowed file"
+            if actual is not False:
+                print(f"FAIL: {label} → expected False, got {actual}", file=sys.stderr)
+                failed += 1
+            else:
+                print(f"  OK: {label}")
+        finally:
+            try:
+                symlink_path.unlink()
+            except FileNotFoundError:
+                pass
+
+    if failed:
+        print(f"\nFAIL: {failed} case(s) failed", file=sys.stderr)
+        return 1
+
+    print("\nPASS: _is_path_sendable() enforces the allowlist correctly.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a Slack bridge to the existing voice / Discord / Telegram / phone task pipeline. Transport is Slack Socket Mode (no public webhook needed). Modeled on the leaner telegram-bridge.py (~470 LoC). Closes #866.

Per owner's "finish everything about slack in this PR" directive, this is the full v0 — file attachments in both directions are in scope at first ship.

**Live E2E verified 2026-05-18 20:21 PT** — first DM round-tripped through TOFU onboarding, task file write, reply delivery. See PR comments for the live install log including the 6 Slack-UI traps that surfaced during onboarding (all now codified in `docs/slack-bridge.md`).

## What's in

- `src/slack-bridge.py` (new, ~520 LoC) — daemon: DMs + channel @mentions → `tasks/`, replies from `results/` posted back via `chat.postMessage` (in-thread for mentions, top-level for DMs).
- **File round-trip** (added in 98e188b):
  - Inbound: any files attached to a DM or @mention are downloaded into `$SUTANDO_WORKSPACE/slack-inbox/` and the local path is surfaced in the task body as `[File attached: /path]`. Slack file URLs require the bot token in an `Authorization: Bearer` header (they're not public), so the bridge does its own urllib download.
  - Outbound: result bodies may include `[file:]`/`[send:]`/`[attach:]` markers. Paths allowlist-gated via `_is_path_sendable()` (same `os.path.realpath` + `startswith` sanitizer the discord/telegram bridges use — fail-closed). Uploads via `files_upload_v2` (`files.upload` deprecated 2025-03).
- **No-events-hint** (added in 26bceee): if zero events arrive within 60s of boot, log a diagnostic pointing at Event Subscriptions config. Surfaces the most-common install trap in 1 minute instead of silence.
- TOFU onboarding at `~/.claude/channels/slack/access.json` (same schema as Telegram).
- Result-body markers honored: `[no-send]`, `[REPLIED]`, `[deduped: ...]`.
- Username cache for `users.info` lookups (rate-limited at 100/min).
- `tests/slack-bridge-access.test.py` — structural regression guard for the security-critical bits (TOFU None-vs-empty-set, `tofu_onboard` race-guard + 0o600 chmod, fail-closed sender check, ACCESS_FILE path parity).
- `tests/slack-bridge-allowlist.test.py` — behavioral test for `_is_path_sendable()`: 9 cases including symlink traversal that verifies the `os.path.realpath` sanitizer (CodeQL `py/path-injection` rule depends on this).
- `docs/slack-bridge.md` — full setup walkthrough + **Install gotchas** section covering the 6 Slack-UI traps hit during the real onboarding.
- `src/migrate.sh` adds `slack_bolt` to the pip line.
- `src/startup.sh` probes for `SLACK_BOT_TOKEN`, starts the daemon with the same Python-candidate sweep as `discord-bridge`.
- `src/verify-setup.sh` reports Slack config status.

## Why Bolt + Socket Mode (not raw urllib)

Telegram exposes a simple `getUpdates` long-poll endpoint that urllib handles in ~30 LoC. Slack's events API needs either a public HTTPS webhook (untenable on a personal laptop) OR Socket Mode (WebSocket). Bolt wraps the handshake, reconnect, ack, and signature verification — reproducing that on urllib is ~600+ LoC plus an ongoing maintenance tax. The dep is justified.

## Out of scope (deferred follow-ups)

- **Access tier propagation** (owner/team/other like Discord) — #869. Slack v0 is owner-only at the gate. Spawned from the first-onboarding asymmetry vs Discord.
- Slash commands (`/sutando ...`).
- Voice notes (no public Huddle audio API).

## Live install — for the next person doing this

1. Create a Slack app at https://api.slack.com/apps with the scopes listed in `docs/slack-bridge.md`.
2. Drop tokens into `~/.claude/channels/slack/.env`:
   ```
   SLACK_BOT_TOKEN=xoxb-...
   SLACK_APP_TOKEN=xapp-...
   ```
3. `pip3 install slack_bolt` (added to `src/migrate.sh`).
4. Restart via `bash src/startup.sh`.
5. First DM auto-onboards owner via TOFU (same as Telegram).

If you hit the 60-second-no-events state, read `docs/slack-bridge.md` install gotchas — every trap I hit during 2.5h of debugging is in there.

## Test plan

- [x] `python3 -m py_compile src/slack-bridge.py` — clean.
- [x] Module import smoke test (stubbed slack_bolt) — clean.
- [x] `python3 tests/slack-bridge-access.test.py` — passes (structural).
- [x] `python3 tests/slack-bridge-allowlist.test.py` — passes (behavioral, 9 cases including symlink traversal).
- [x] `npm test` — full Python + TS suite green locally.
- [x] CI on PR — `tsc + tests (clean install)` SUCCESS.
- [x] **Live: DM round-trips through tasks/results.** (Verified 2026-05-18 20:21 PT — task-1779160886238 → reply delivered to D0B4N6DSY90.)
- [x] **Live: TOFU onboards first sender as owner.** (Verified — `~/.claude/channels/slack/access.json` populated automatically.)
- [ ] Live: @mention in a channel produces an in-thread reply. (Optional follow-up — DM path verified.)
- [ ] Live: file attachment up + back (image, document). (Optional follow-up.)
- [ ] Live: protocol markers (`[no-send]`) are honored. (Tested in code; live-tested with discord/telegram, same code path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)