### PR TITLE
feat: rename SUTANDO_PRIVATE_DIR → SUTANDO_MEMORY_DIR (closes #870)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Never commit directly to main. Always work on a feature branch.
 
 ## Workspace contract
 
-Sutando's file state lives in three concentric spaces — **Code** (`$SUTANDO_REPO_DIR`, the git checkout), **State** (`$SUTANDO_WORKSPACE`, per-user runtime), **Memory** (`$SUTANDO_PRIVATE_DIR`, user-content synced across the fleet). See [`docs/workspace-design.md`](docs/workspace-design.md) for the 3-space mental model + "Quick decision: which space?" flowchart when adding new code or data.
+Sutando's file state lives in three concentric spaces — **Code** (`$SUTANDO_REPO_DIR`, the git checkout), **State** (`$SUTANDO_WORKSPACE`, per-user runtime), **Memory** (`$SUTANDO_MEMORY_DIR`, user-content synced across the fleet — legacy alias `$SUTANDO_PRIVATE_DIR` honored for one release per #870). See [`docs/workspace-design.md`](docs/workspace-design.md) for the 3-space mental model + "Quick decision: which space?" flowchart when adding new code or data.
 
 All per-user mutable state — `tasks/`, `results/`, `state/`, `data/`, `logs/`, `notes/`, `build_log.md`, `pending-questions.md`, `contextual-chips.json`, `core-status.json`, etc. — lives under a single **workspace** directory. Code, skills source, and repo configuration stay in the repo root (separate concern).
 

--- a/docs/workspace-contract.md
+++ b/docs/workspace-contract.md
@@ -84,8 +84,8 @@ Walk the question top-to-bottom and stop at the first match:
 1. **Is the file checked into git?** → `REPO_DIR`. (Source code, scripts, docs, tests, package.json.)
 2. **Is the file a stable cross-machine reference Claude can read on session start?** (e.g., `CLAUDE.md`, README) → `REPO_DIR`.
 3. **Otherwise — does it mutate during runtime?** → `WORKSPACE_DIR`. (Tasks, results, state, logs, notes, build_log, pending-questions, status JSON.)
-4. **Is it per-machine personal state?** (Stand identity, avatar) → `personal_path()` (honors `SUTANDO_PRIVATE_DIR` first).
-5. **Is it fleet-shared user state?** (Notes, shared memory) → `shared_personal_path()` (honors `SUTANDO_PRIVATE_DIR` first, falls back to workspace).
+4. **Is it per-machine personal state?** (Stand identity, avatar) → `personal_path()` (honors `SUTANDO_MEMORY_DIR` first; legacy `SUTANDO_PRIVATE_DIR` falls through for one release per #870).
+5. **Is it fleet-shared user state?** (Notes, shared memory) → `shared_personal_path()` (honors `SUTANDO_MEMORY_DIR` first, falls back to workspace; legacy `SUTANDO_PRIVATE_DIR` honored for one release per #870).
 
 ## Related PRs
 

--- a/skills/MANIFEST.md
+++ b/skills/MANIFEST.md
@@ -11,7 +11,7 @@ A manifest-loaded skill is a directory containing:
 - `tools.ts` (if `manifest.tools` is set) — exports `tools: ToolDefinition[]`, picked up at agent startup
 - optional `server.py` / `start.sh` / other runtime infrastructure the tools rely on
 
-At voice-agent startup, `loadSkillManifestTools()` in `src/inline-tools.ts` scans the public `skills/` directory **and** the optional `$SUTANDO_PRIVATE_DIR/skills/` directory, dynamically imports each tools entry point, and merges the exported tool definitions into `inlineTools`.
+At voice-agent startup, `loadSkillManifestTools()` in `src/inline-tools.ts` scans the public `skills/` directory **and** the optional `$SUTANDO_MEMORY_DIR/skills/` directory (legacy `$SUTANDO_PRIVATE_DIR` honored for one release per #870), dynamically imports each tools entry point, and merges the exported tool definitions into `inlineTools`.
 
 The same `inlineTools` list is also pushed into the phone agent's tool table (see `skills/phone-conversation/scripts/conversation-server.ts:587`), so any tool a manifest-loaded skill contributes is automatically available to:
 
@@ -53,7 +53,7 @@ Tools that need an instant response (sub-second round-trip) live in `src/inline-
 ```text
 1. Build dirsToScan = [
      <repo>/skills,
-     $SUTANDO_PRIVATE_DIR/skills (if set)
+     $SUTANDO_MEMORY_DIR/skills (if set; legacy $SUTANDO_PRIVATE_DIR also honored)
    ]
 2. For each dir, read each subdirectory:
    - If no manifest.json, skip.
@@ -71,13 +71,13 @@ Order: public first, then private. If a private skill shares a tool name with a 
 
 ## Currently active manifest skills
 
-Run `grep -l '"enabled": true' skills/*/manifest.json $SUTANDO_PRIVATE_DIR/skills/*/manifest.json` for the live list.
+Run `grep -l '"enabled": true' skills/*/manifest.json "$SUTANDO_MEMORY_DIR/skills"/*/manifest.json` for the live list (legacy users may need `$SUTANDO_PRIVATE_DIR` in place of the new var).
 
 As of 2026-05-03, the public repo has no manifest-loaded tools shipping by default; the four currently-active manifest skills all live in the private dir:
 
 | Skill | Tools contributed | Notes |
 |---|---|---|
-| `voice-context` | `set_voice_context`, `list_voice_contexts` | Switches the active per-talk voice script via `$SUTANDO_PRIVATE_DIR/voice-contexts/active`. Restarts voice-agent on switch so the new context loads. |
+| `voice-context` | `set_voice_context`, `list_voice_contexts` | Switches the active per-talk voice script via `$SUTANDO_MEMORY_DIR/voice-contexts/active` (legacy `$SUTANDO_PRIVATE_DIR` honored). Restarts voice-agent on switch so the new context loads. |
 | `talk-highlight` | `highlight_slide`, `presenter_mode`, `fullscreen_presenter`, `set_active_slides` | Drives on-stage slide highlights during live talks via the local highlight server (`localhost:7877`). `highlight_slide` glows a topic key and dims siblings; `presenter_mode` toggles the session-level talk flag; `fullscreen_presenter` switches the slide window into fullscreen; `set_active_slides` swaps the deck pointer (`talk-slides/active`) so the same server can drive different decks across a session. |
 | `personal-deictic` | `read_selection` | Reads the macOS selected text + cursor via the `ax-read` Swift binary; foundation for "this/that" deictic edits. |
 | `personal-talk-prep` | (none — script-only skill, invoked via `/personal-talk-prep`) | Listed for completeness; no manifest tools. |
@@ -86,7 +86,7 @@ When a Sutando user enables a new manifest skill, the tool name appears in `[ski
 
 ## How to add a new manifest-loaded skill
 
-1. Create `skills/<name>/manifest.json` (or `$SUTANDO_PRIVATE_DIR/skills/<name>/manifest.json` for personal tools).
+1. Create `skills/<name>/manifest.json` (or `$SUTANDO_MEMORY_DIR/skills/<name>/manifest.json` for personal tools; legacy `$SUTANDO_PRIVATE_DIR` honored for one release per #870).
 2. Set `"enabled": true`, `"access_tier": "owner"`, `"tools": "./tools.ts"`.
 3. Write `tools.ts` that exports `tools: ToolDefinition[]`. Each tool needs `name`, `description`, `parameters` (a Zod schema), `execution: 'inline'`, and an `execute()` function. Reuse the shape from existing skills.
 4. Restart voice-agent: `launchctl kickstart -k gui/$(id -u)/com.sutando.voice-agent`.

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -53,8 +53,18 @@ import { hostname } from 'node:os';
 import { resolveWorkspace } from '../../../src/workspace_default.js';
 
 // Personal-asset path resolver — twin of util_paths.py / voice-agent.ts:personalPath.
+// Reads $SUTANDO_MEMORY_DIR (canonical post-#870), honors legacy $SUTANDO_PRIVATE_DIR
+// as a fallback with a one-release deprecation warning on every read.
 function personalPath(filename: string): string {
-	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+	let privateRoot = process.env.SUTANDO_MEMORY_DIR;
+	if (!privateRoot && process.env.SUTANDO_PRIVATE_DIR) {
+		console.warn(
+			'[conversation-server] DEPRECATION: SUTANDO_PRIVATE_DIR is the old name ' +
+				'for the memory dir; set SUTANDO_MEMORY_DIR instead (this alias will ' +
+				'be removed in the next release). See #870.',
+		);
+		privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+	}
 	if (privateRoot) {
 		const root = privateRoot.replace(/^~/, process.env.HOME || '');
 		const host = hostname().split('.')[0];

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -49,7 +49,7 @@ export const openFileTool: ToolDefinition = {
 		'If the user says "open the log" or similar, ASK which log they mean (voice-agent, discord-bridge, etc.) — do NOT guess. ' +
 		'Known files: "diagnostic tracker" or "diagnostics" = /tmp/phone-diagnostics-tracker.html, ' +
 		'"voice diagnostics" = /tmp/voice-diagnostics-tracker.html, ' +
-		'"voice context" / "the voice context file" / "the active context" = $SUTANDO_PRIVATE_DIR/voice-contexts/<active>.txt where <active> is the trimmed contents of $SUTANDO_PRIVATE_DIR/voice-contexts/active. Pass it with the env-var expanded by you, or as $SUTANDO_PRIVATE_DIR/voice-contexts/<active>.txt — both work. ' +
+		'"voice context" / "the voice context file" / "the active context" = $SUTANDO_MEMORY_DIR/voice-contexts/<active>.txt where <active> is the trimmed contents of $SUTANDO_MEMORY_DIR/voice-contexts/active (legacy users may have $SUTANDO_PRIVATE_DIR set instead — either expands). Pass it with the env-var expanded by you, or as $SUTANDO_MEMORY_DIR/voice-contexts/<active>.txt — both work. ' +
 		'Pass `app` when the user names a specific app ("open with Sublime Text", "open the SQLite db in TablePlus") OR when recent conversation makes the intended app clear (e.g. user just said "I\'ll review this in VS Code"). Without `app`, macOS uses its default handler for that file type — leave unset when the default is fine. ' +
 		'Pass `fullscreen=true` if the user wants the file opened in fullscreen — works generically for any file type via Cmd+Ctrl+F to whichever app the OS routed the file to (QuickTime → Present mode, Preview → fullscreen PDF, Chrome → fullscreen page, etc.).',
 	parameters: z.object({
@@ -64,7 +64,7 @@ export const openFileTool: ToolDefinition = {
 		try {
 			if (!path) return { error: 'No path provided. Pass an absolute file path. (For the most recent recording, call play_video — it auto-finds the file.)' };
 			// Expand $VAR / ${VAR} env-var references and ~ in the path so Sutando
-			// can pass paths like "$SUTANDO_PRIVATE_DIR/voice-contexts/X.txt"
+			// can pass paths like "$SUTANDO_MEMORY_DIR/voice-contexts/X.txt"
 			// without us hardcoding a fallback root. Track any unset variables so
 			// we can surface them as a clear diagnostic rather than letting the
 			// silently-empty substitution flow through to a generic "file not
@@ -778,10 +778,11 @@ export const createChatTaskTool: ToolDefinition = {
 
 /** All inline tools — import and spread into your tools list */
 // ─── Notes tools ─────────────────────────────────────────
-// Resolve at module-init: $SUTANDO_PRIVATE_DIR/notes (canonical) when set,
-// else <workspace>/notes (legacy fallback). Notes are SHARED across the
-// fleet so they live at the top-level private dir, not under machine-<host>/.
-import { sharedPersonalPath } from './util_paths.js';
+// Resolve at module-init: $SUTANDO_MEMORY_DIR/notes (canonical) when set
+// (legacy $SUTANDO_PRIVATE_DIR honored via sharedPersonalPath()), else
+// <workspace>/notes fallback. Notes are SHARED across the fleet so they live
+// at the top-level memory dir, not under machine-<host>/.
+import { sharedPersonalPath, memoryDirEnv } from './util_paths.js';
 const NOTES_DIR = sharedPersonalPath('notes', WORKSPACE_DIR);
 
 export const showViewTool: ToolDefinition = {
@@ -961,14 +962,15 @@ function assertUniqueToolNames(tools: ToolDefinition[]): ToolDefinition[] {
 // access_tier values: "owner" (default if omitted) | "any_caller".
 async function loadSkillManifestTools(): Promise<{ owner: ToolDefinition[]; anyCaller: ToolDefinition[] }> {
 	// Scan the public-repo `skills/` dir AND the optional private skills dir
-	// pointed to by `$SUTANDO_PRIVATE_DIR/skills/` (e.g.
-	// `~/.sutando-memory-sync/skills/`). The private dir lets users keep
-	// personal tooling with real per-file git history outside the public repo.
-	// Order: public first, then private — same-name skills loaded from
-	// private take precedence (last one wins via the dup-name guard below if
-	// any; in practice they should be uniquely named).
+	// pointed to by `$SUTANDO_MEMORY_DIR/skills/` (legacy `$SUTANDO_PRIVATE_DIR`
+	// honored via memoryDirEnv(); e.g. `~/.sutando/memory-sync/skills/`). The
+	// private dir lets users keep personal tooling with real per-file git
+	// history outside the public repo. Order: public first, then private —
+	// same-name skills loaded from private take precedence (last one wins via
+	// the dup-name guard below if any; in practice they should be uniquely
+	// named).
 	const dirsToScan: string[] = [join(REPO_ROOT, 'skills')];
-	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+	const privateRoot = memoryDirEnv();
 	if (privateRoot) {
 		const expanded = privateRoot.replace(/^~/, process.env.HOME || '');
 		dirsToScan.push(join(expanded, 'skills'));
@@ -1032,7 +1034,7 @@ const personalAllTools = [...personalTools.owner, ...personalTools.anyCaller];
 // what each one does.
 function loadCoreDocumentedSkills(): { name: string; description: string }[] {
 	const dirsToScan: string[] = [join(REPO_ROOT, 'skills')];
-	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+	const privateRoot = memoryDirEnv();
 	if (privateRoot) {
 		const expanded = privateRoot.replace(/^~/, process.env.HOME || '');
 		dirsToScan.push(join(expanded, 'skills'));

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -45,9 +45,12 @@ TRANSCRIPT="$1"  # Passed by PreCompact hook as $TRANSCRIPT_PATH
   gh pr list --repo sonichi/sutando --state open --limit 5 2>/dev/null || echo "(couldn't fetch)"
   echo ""
 
-  # Pending questions — canonical home is private machine-<host>/ post-migration.
-  # Resolves via util_paths.personal_path() with cwd fallback.
-  PQ_PATH=$(SUTANDO_PRIVATE_DIR="${SUTANDO_PRIVATE_DIR:-}" python3 -c "
+  # Pending questions — canonical home is memory-dir machine-<host>/ post-migration.
+  # Resolves via util_paths.personal_path() with cwd fallback. Pass through both
+  # the canonical SUTANDO_MEMORY_DIR and the legacy SUTANDO_PRIVATE_DIR; the
+  # helper prefers the new name and honors the legacy one with a deprecation
+  # warning for one release (#870).
+  PQ_PATH=$(SUTANDO_MEMORY_DIR="${SUTANDO_MEMORY_DIR:-}" SUTANDO_PRIVATE_DIR="${SUTANDO_PRIVATE_DIR:-}" python3 -c "
 import sys; sys.path.insert(0, '$REPO/src')
 from util_paths import personal_path
 from pathlib import Path

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -1,10 +1,16 @@
 """Resolve personal-asset paths with private-dir-first lookup.
 
 Each Stand has its own identity + avatar. These files are gitignored and
-machine-local. Canonical home is `$SUTANDO_PRIVATE_DIR/machine-<hostname>/`
+machine-local. Canonical home is `$SUTANDO_MEMORY_DIR/machine-<hostname>/`
 so they live with the rest of the per-machine memory under the private
 sync repo. Public-workspace fallback is preserved so existing installs
 keep working until they migrate.
+
+The env var `SUTANDO_MEMORY_DIR` is the canonical name per the 2026-05-18
+workspace-design RFC (#858, Decision 2). The legacy name `SUTANDO_PRIVATE_DIR`
+is honored as a fallback for one release with a deprecation warning on
+every read (cron environments miss startup-only warnings, so logging at
+every resolution is intentional).
 
 Usage:
     from util_paths import personal_path
@@ -14,9 +20,39 @@ Usage:
 from __future__ import annotations
 import os
 import socket
+import sys
 from pathlib import Path
 
 REPO_DIR = Path(__file__).resolve().parent.parent
+
+
+def _memory_dir_env() -> str | None:
+    """Return the resolved memory-dir env value, preferring the new name.
+
+    Lookup order:
+      1. `SUTANDO_MEMORY_DIR` (canonical post-#858 / #870)
+      2. `SUTANDO_PRIVATE_DIR` (legacy, with deprecation warning emitted
+         to stderr on every read — not just once at startup; cron and
+         launchd environments miss startup-only warnings).
+
+    Returns the raw env value (caller must `os.path.expanduser` if needed),
+    or None when neither is set."""
+    new = os.environ.get("SUTANDO_MEMORY_DIR")
+    if new:
+        return new
+    legacy = os.environ.get("SUTANDO_PRIVATE_DIR")
+    if legacy:
+        # Every-read deprecation warning. This is loud by design — the
+        # legacy alias will drop in the next release and silent users
+        # would otherwise miss the cutover. See #870 for the rename plan.
+        print(
+            "[util_paths.py] DEPRECATION: SUTANDO_PRIVATE_DIR is the old name "
+            "for the memory dir; set SUTANDO_MEMORY_DIR instead (this alias "
+            "will be removed in the next release). See #870.",
+            file=sys.stderr,
+        )
+        return legacy
+    return None
 
 
 def _workspace_root() -> Path:
@@ -45,7 +81,7 @@ def _workspace_root() -> Path:
 
 
 def _private_machine_dir() -> Path | None:
-    root = os.environ.get("SUTANDO_PRIVATE_DIR")
+    root = _memory_dir_env()
     if not root:
         return None
     expanded = os.path.expanduser(root)
@@ -56,7 +92,9 @@ def _private_machine_dir() -> Path | None:
 def personal_path(filename: str, workspace: Path | None = None) -> Path:
     """Resolve a personal-asset path.
 
-    Order: `$SUTANDO_PRIVATE_DIR/machine-<host>/<filename>` → `<workspace>/<filename>`.
+    Order: `$SUTANDO_MEMORY_DIR/machine-<host>/<filename>` → `<workspace>/<filename>`.
+    (Legacy `$SUTANDO_PRIVATE_DIR` is honored as a fallback with a
+    deprecation warning — see `_memory_dir_env()`.)
     For files known to live under `assets/` in the public workspace
     (currently `stand-avatar.png`), also tries `<workspace>/assets/<filename>`
     before falling back to `<workspace>/<filename>`.
@@ -94,7 +132,9 @@ def shared_personal_path(filename: str, workspace: Path | None = None) -> Path:
     """Resolve a shared-private path (notes, build_log, etc.) — files that
     sync across all of an owner's machines, not per-machine state.
 
-    Order: `$SUTANDO_PRIVATE_DIR/<filename>` (top-level, shared) → `<workspace>/<filename>`.
+    Order: `$SUTANDO_MEMORY_DIR/<filename>` (top-level, shared) → `<workspace>/<filename>`.
+    (Legacy `$SUTANDO_PRIVATE_DIR` is honored as a fallback with a
+    deprecation warning — see `_memory_dir_env()`.)
 
     Difference vs `personal_path`: this resolves to the top-level private dir,
     NOT `machine-<host>/`. Use for files like notes/, where every Mac in
@@ -105,7 +145,7 @@ def shared_personal_path(filename: str, workspace: Path | None = None) -> Path:
     """
     ws = workspace if workspace is not None else _workspace_root()
 
-    root = os.environ.get("SUTANDO_PRIVATE_DIR")
+    root = _memory_dir_env()
     if root:
         private = Path(os.path.expanduser(root)) / filename
         if private.exists():

--- a/src/util_paths.ts
+++ b/src/util_paths.ts
@@ -2,11 +2,11 @@
 //
 // Two helpers, one for per-machine state, one for shared-across-fleet state:
 //
-//   personalPath(filename)          — `$SUTANDO_PRIVATE_DIR/machine-<host>/<filename>`
+//   personalPath(filename)          — `$SUTANDO_MEMORY_DIR/machine-<host>/<filename>`
 //                                     For files where each Mac has its own copy
 //                                     (stand-identity.json, pending-questions.md).
 //
-//   sharedPersonalPath(filename)    — `$SUTANDO_PRIVATE_DIR/<filename>`
+//   sharedPersonalPath(filename)    — `$SUTANDO_MEMORY_DIR/<filename>`
 //                                     For files synced across the whole fleet
 //                                     (notes/, build_log.md).
 //
@@ -16,6 +16,12 @@
 // via resolveWorkspace() — NOT process.cwd(). Pre-#839 fixes the fallback was
 // cwd, which silently produced the wrong path on hosts where the caller's
 // cwd drifted from the workspace dir.
+//
+// Env var `SUTANDO_MEMORY_DIR` is the canonical name post-#858 / #870. The
+// legacy alias `SUTANDO_PRIVATE_DIR` is honored as a fallback for one release
+// with a deprecation warning logged to stderr on every read (cron / launchd
+// environments miss startup-only warnings, so logging at every resolution is
+// intentional).
 
 import { existsSync } from 'node:fs';
 import { hostname } from 'node:os';
@@ -26,10 +32,40 @@ function expandHome(p: string): string {
 	return p.replace(/^~/, process.env.HOME || '');
 }
 
+/**
+ * Return the resolved memory-dir env value, preferring the new name.
+ *
+ * Lookup order:
+ *   1. `SUTANDO_MEMORY_DIR` (canonical post-#858 / #870)
+ *   2. `SUTANDO_PRIVATE_DIR` (legacy, with deprecation warning emitted to
+ *      stderr on every read — not just once at startup; cron and launchd
+ *      environments miss startup-only warnings).
+ *
+ * Returns the raw env value (caller must expandHome if needed), or undefined
+ * when neither is set.
+ */
+export function memoryDirEnv(): string | undefined {
+	const next = process.env.SUTANDO_MEMORY_DIR;
+	if (next) return next;
+	const legacy = process.env.SUTANDO_PRIVATE_DIR;
+	if (legacy) {
+		// Every-read deprecation warning. Loud by design — the legacy alias
+		// will drop in the next release and silent users would otherwise miss
+		// the cutover. See #870 for the rename plan.
+		console.warn(
+			'[util_paths.ts] DEPRECATION: SUTANDO_PRIVATE_DIR is the old name ' +
+				'for the memory dir; set SUTANDO_MEMORY_DIR instead (this alias ' +
+				'will be removed in the next release). See #870.',
+		);
+		return legacy;
+	}
+	return undefined;
+}
+
 /** Per-machine resolver. */
 export function personalPath(filename: string, workspace?: string): string {
 	const ws = workspace ?? resolveWorkspace();
-	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+	const privateRoot = memoryDirEnv();
 	if (privateRoot) {
 		const root = expandHome(privateRoot);
 		const host = hostname().split('.')[0];
@@ -57,7 +93,7 @@ export function personalPath(filename: string, workspace?: string): string {
 /** Shared-across-fleet resolver (top-level private dir, not per-machine). */
 export function sharedPersonalPath(filename: string, workspace?: string): string {
 	const ws = workspace ?? resolveWorkspace();
-	const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+	const privateRoot = memoryDirEnv();
 	if (privateRoot) {
 		const root = expandHome(privateRoot);
 		const candidate = join(root, filename);

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -41,7 +41,7 @@ import { workTool, startResultWatcher, startContextDropWatcher, startNoteViewing
 import { buildSutandoSystemPrompt, buildVoiceAgentContext } from './voice-context.js';
 import { classifyTransportClose, type ClassifiedClose } from './voice-error-classifier.js';
 
-import { personalPath, sharedPersonalPath } from './util_paths.js';
+import { personalPath, sharedPersonalPath, memoryDirEnv } from './util_paths.js';
 
 // Cartesia is loaded dynamically at the bottom of the config section so
 // the `@cartesia/cartesia-js` package is only required when the user has
@@ -582,19 +582,20 @@ const mainAgent: MainAgent = {
 		'Every Sutando evolves differently based on what its user needs. You earned your name and identity.',
 		(() => { try { const si = JSON.parse(readFileSync(personalPath('stand-identity.json'), 'utf-8')); return si.name ? `Your Stand name is ${si.name}. Origin: ${si.nameOrigin || 'earned through use'}. When asked your name or who you are, say "I\'m Sutando — ${si.name}."` : ''; } catch { return ''; } })(),
 		// Optional context file — for presentations, meeting prep, etc. (gitignored)
-		// Reads $SUTANDO_PRIVATE_DIR/voice-contexts/<active>.txt where <active> is
-		// the trimmed contents of $SUTANDO_PRIVATE_DIR/voice-contexts/active.
+		// Reads $SUTANDO_MEMORY_DIR/voice-contexts/<active>.txt where <active> is
+		// the trimmed contents of $SUTANDO_MEMORY_DIR/voice-contexts/active
+		// (legacy $SUTANDO_PRIVATE_DIR honored via memoryDirEnv()).
 		// Falls back to public-repo voice-context.txt when the env var is unset
 		// or the pointer/file is missing. Switcher tool: set_voice_context(name)
 		// from skills/personal-voice-context/ writes the pointer.
 		(() => {
 			// Log which voice-context file was loaded so the operator can see at
-			// a glance whether the dynamic loader picked up the private dir or
+			// a glance whether the dynamic loader picked up the memory dir or
 			// fell through to the public fallback. Silent loads are hard to
 			// debug — Apr 29 spent 30+ minutes diff'ing files because the load
 			// path was opaque.
 			try {
-				const privateRoot = process.env.SUTANDO_PRIVATE_DIR;
+				const privateRoot = memoryDirEnv();
 				if (privateRoot) {
 					const root = privateRoot.replace(/^~/, process.env.HOME || '');
 					const pointerPath = join(root, 'voice-contexts', 'active');

--- a/tests/util-paths-memory-dir.test.py
+++ b/tests/util-paths-memory-dir.test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Tests for the SUTANDO_PRIVATE_DIR -> SUTANDO_MEMORY_DIR rename (#870).
+
+Verifies:
+  1. SUTANDO_MEMORY_DIR is honored as the canonical env var.
+  2. SUTANDO_PRIVATE_DIR is honored as a legacy fallback.
+  3. SUTANDO_MEMORY_DIR wins when both are set.
+  4. A deprecation warning is emitted on every read of the legacy alias.
+  5. Neither set -> None (no warning).
+
+Run: python3 tests/util-paths-memory-dir.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+import io
+import os
+import socket
+import sys
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+# Import after sys.path setup
+from util_paths import (  # noqa: E402
+    _memory_dir_env,
+    _private_machine_dir,
+    shared_personal_path,
+)
+
+
+def clear_env():
+    for k in ("SUTANDO_MEMORY_DIR", "SUTANDO_PRIVATE_DIR"):
+        os.environ.pop(k, None)
+
+
+class MemoryDirEnvTests(unittest.TestCase):
+    def setUp(self):
+        clear_env()
+
+    def tearDown(self):
+        clear_env()
+
+    def test_unset_returns_none(self):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            self.assertIsNone(_memory_dir_env())
+        self.assertEqual(buf.getvalue(), "")  # no warning when unset
+
+    def test_new_var_returned(self):
+        os.environ["SUTANDO_MEMORY_DIR"] = "/tmp/new-memory"
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            self.assertEqual(_memory_dir_env(), "/tmp/new-memory")
+        self.assertEqual(buf.getvalue(), "")  # new var: no warning
+
+    def test_legacy_var_returned_with_warning(self):
+        os.environ["SUTANDO_PRIVATE_DIR"] = "/tmp/legacy-private"
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            self.assertEqual(_memory_dir_env(), "/tmp/legacy-private")
+        self.assertIn("DEPRECATION", buf.getvalue())
+        self.assertIn("SUTANDO_PRIVATE_DIR", buf.getvalue())
+        self.assertIn("SUTANDO_MEMORY_DIR", buf.getvalue())
+
+    def test_new_wins_when_both_set(self):
+        os.environ["SUTANDO_MEMORY_DIR"] = "/tmp/new"
+        os.environ["SUTANDO_PRIVATE_DIR"] = "/tmp/legacy"
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            self.assertEqual(_memory_dir_env(), "/tmp/new")
+        # No warning when new wins — legacy path not consulted.
+        self.assertEqual(buf.getvalue(), "")
+
+    def test_every_read_warns(self):
+        # Cron environments miss startup-only warnings, so the warning must
+        # fire on every call, not just first. Regression guard for #870.
+        os.environ["SUTANDO_PRIVATE_DIR"] = "/tmp/legacy"
+        for _ in range(3):
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                _memory_dir_env()
+            self.assertIn("DEPRECATION", buf.getvalue())
+
+
+class PrivateMachineDirTests(unittest.TestCase):
+    def setUp(self):
+        clear_env()
+
+    def tearDown(self):
+        clear_env()
+
+    def test_returns_none_when_unset(self):
+        with redirect_stderr(io.StringIO()):
+            self.assertIsNone(_private_machine_dir())
+
+    def test_new_var_drives_machine_dir(self):
+        os.environ["SUTANDO_MEMORY_DIR"] = "/tmp/memdir"
+        host = socket.gethostname().split(".")[0]
+        with redirect_stderr(io.StringIO()):
+            p = _private_machine_dir()
+        self.assertEqual(p, Path(f"/tmp/memdir/machine-{host}"))
+
+    def test_legacy_var_drives_machine_dir(self):
+        os.environ["SUTANDO_PRIVATE_DIR"] = "/tmp/legacy-dir"
+        host = socket.gethostname().split(".")[0]
+        with redirect_stderr(io.StringIO()):
+            p = _private_machine_dir()
+        self.assertEqual(p, Path(f"/tmp/legacy-dir/machine-{host}"))
+
+
+class SharedPersonalPathTests(unittest.TestCase):
+    def setUp(self):
+        clear_env()
+
+    def tearDown(self):
+        clear_env()
+
+    def test_resolves_via_new_var(self):
+        os.environ["SUTANDO_MEMORY_DIR"] = "/tmp/mem"
+        with redirect_stderr(io.StringIO()):
+            p = shared_personal_path("MEMORY.md", workspace=Path("/tmp/ws"))
+        # Neither path exists -> returns preferred memory-dir path.
+        self.assertEqual(p, Path("/tmp/mem/MEMORY.md"))
+
+    def test_resolves_via_legacy_var(self):
+        os.environ["SUTANDO_PRIVATE_DIR"] = "/tmp/legacy-mem"
+        with redirect_stderr(io.StringIO()):
+            p = shared_personal_path("MEMORY.md", workspace=Path("/tmp/ws"))
+        self.assertEqual(p, Path("/tmp/legacy-mem/MEMORY.md"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/util-paths-memory-dir.test.ts
+++ b/tests/util-paths-memory-dir.test.ts
@@ -1,0 +1,91 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * Tests for the SUTANDO_PRIVATE_DIR -> SUTANDO_MEMORY_DIR rename (#870) in
+ * src/util_paths.ts. Mirrors tests/util-paths-memory-dir.test.py.
+ *
+ * Covers:
+ *   1. SUTANDO_MEMORY_DIR is the canonical name.
+ *   2. SUTANDO_PRIVATE_DIR is honored as a legacy fallback.
+ *   3. SUTANDO_MEMORY_DIR wins when both are set.
+ *   4. A deprecation warning is emitted on every read of the legacy alias
+ *      (cron / launchd environments miss startup-only warnings).
+ *   5. Neither set -> undefined (no warning).
+ */
+
+import { memoryDirEnv } from '../src/util_paths.js';
+
+function clearEnv() {
+	delete process.env.SUTANDO_MEMORY_DIR;
+	delete process.env.SUTANDO_PRIVATE_DIR;
+}
+
+function captureWarn<T>(fn: () => T): { value: T; warnings: string[] } {
+	const warnings: string[] = [];
+	const orig = console.warn;
+	console.warn = (...args: unknown[]) => {
+		warnings.push(args.map(String).join(' '));
+	};
+	try {
+		const value = fn();
+		return { value, warnings };
+	} finally {
+		console.warn = orig;
+	}
+}
+
+describe('memoryDirEnv (#870 rename)', () => {
+	it('returns undefined and emits no warning when neither var is set', () => {
+		clearEnv();
+		const { value, warnings } = captureWarn(memoryDirEnv);
+		assert.equal(value, undefined);
+		assert.deepEqual(warnings, []);
+	});
+
+	it('returns SUTANDO_MEMORY_DIR with no warning', () => {
+		clearEnv();
+		process.env.SUTANDO_MEMORY_DIR = '/tmp/new-memory';
+		const { value, warnings } = captureWarn(memoryDirEnv);
+		assert.equal(value, '/tmp/new-memory');
+		assert.deepEqual(warnings, []);
+		clearEnv();
+	});
+
+	it('falls back to SUTANDO_PRIVATE_DIR with a deprecation warning', () => {
+		clearEnv();
+		process.env.SUTANDO_PRIVATE_DIR = '/tmp/legacy-private';
+		const { value, warnings } = captureWarn(memoryDirEnv);
+		assert.equal(value, '/tmp/legacy-private');
+		assert.equal(warnings.length, 1);
+		assert.match(warnings[0], /DEPRECATION/);
+		assert.match(warnings[0], /SUTANDO_PRIVATE_DIR/);
+		assert.match(warnings[0], /SUTANDO_MEMORY_DIR/);
+		clearEnv();
+	});
+
+	it('prefers SUTANDO_MEMORY_DIR when both are set (no warning)', () => {
+		clearEnv();
+		process.env.SUTANDO_MEMORY_DIR = '/tmp/new';
+		process.env.SUTANDO_PRIVATE_DIR = '/tmp/legacy';
+		const { value, warnings } = captureWarn(memoryDirEnv);
+		assert.equal(value, '/tmp/new');
+		assert.deepEqual(warnings, []);
+		clearEnv();
+	});
+
+	it('emits the deprecation warning on EVERY read, not just first', () => {
+		// Regression guard: cron / launchd environments miss startup-only
+		// warnings, so the alias must warn loudly every time it's resolved.
+		clearEnv();
+		process.env.SUTANDO_PRIVATE_DIR = '/tmp/legacy';
+		const { warnings } = captureWarn(() => {
+			memoryDirEnv();
+			memoryDirEnv();
+			memoryDirEnv();
+		});
+		assert.equal(warnings.length, 3);
+		for (const w of warnings) assert.match(w, /DEPRECATION/);
+		clearEnv();
+	});
+});


### PR DESCRIPTION
## Summary
- Renames the Memory-space env var from `SUTANDO_PRIVATE_DIR` to `SUTANDO_MEMORY_DIR` so vocabulary matches the 3-space mental model (Code / State / Memory) ratified in #858 Decision 2.
- One-release alias: `SUTANDO_PRIVATE_DIR` continues to work as a fallback, with a deprecation warning emitted to stderr on every read (cron / launchd miss startup-only warnings — every-read is intentional).
- 10 Python + 5 TS unit tests cover precedence, legacy fallback, deprecation-on-every-read, and the both-set-prefer-new case.

## What changed

**New helper (single source of truth for the lookup):**
- Python — `_memory_dir_env()` in `src/util_paths.py`
- TypeScript — `memoryDirEnv()` exported from `src/util_paths.ts`

Both return `SUTANDO_MEMORY_DIR` when set, else `SUTANDO_PRIVATE_DIR` with a `DEPRECATION` warning, else `None`/`undefined`.

**Call-site updates:**
- `src/util_paths.{py,ts}` — `personal_path()` / `personalPath()` + `shared_personal_path()` / `sharedPersonalPath()` route through the helper.
- `src/inline-tools.ts` — `loadSkillManifestTools()`, `loadCoreDocumentedSkills()`, and the `open_file` tool description.
- `src/voice-agent.ts` — voice-context dynamic loader.
- `skills/phone-conversation/scripts/conversation-server.ts` — inline `personalPath()` twin (kept inline to avoid pulling main repo's util_paths.ts through the skill's import surface).
- `src/session-handoff.sh` — passes both env vars through to the python child.
- Docs: `CLAUDE.md`, `docs/workspace-contract.md`, `skills/MANIFEST.md`.

## Risk to existing users

**None.** Anyone with only `SUTANDO_PRIVATE_DIR` set:
1. Keeps working — value still resolves correctly through the legacy path.
2. Sees a one-line `DEPRECATION` warning on stderr per read.
3. Can migrate at their own pace by renaming the env var in their shell rc / launchd plist / `.env`.

The legacy alias will be removed in the next release.

## Test plan

- [x] `python3 tests/util-paths-memory-dir.test.py` — 10/10 pass
- [x] `npx tsx --test tests/util-paths-memory-dir.test.ts` — 5/5 pass
- [x] `python3 tests/workspace-default.test.py` — still 27/27 pass
- [x] `npx tsc --noEmit` clean
- [ ] CI on the PR

Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)