### PR TITLE
feat: SUTANDO_HOST_LABEL override for Memory machine-<host>/ paths (closes #871)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ Never commit directly to main. Always work on a feature branch.
 
 Sutando's file state lives in three concentric spaces — **Code** (`$SUTANDO_REPO_DIR`, the git checkout), **State** (`$SUTANDO_WORKSPACE`, per-user runtime), **Memory** (`$SUTANDO_MEMORY_DIR`, user-content synced across the fleet — legacy alias `$SUTANDO_PRIVATE_DIR` honored for one release per #870). See [`docs/workspace-design.md`](docs/workspace-design.md) for the 3-space mental model + "Quick decision: which space?" flowchart when adding new code or data.
 
+Per-machine Memory paths nest under `$SUTANDO_MEMORY_DIR/machine-<label>/`. The `<label>` defaults to the system hostname; set `SUTANDO_HOST_LABEL` to pin a stable identity if you've renamed your Mac in System Settings and your bot lost continuity, or if your hostname flips between Wi-Fi / Ethernet suffixes (#871).
+
 All per-user mutable state — `tasks/`, `results/`, `state/`, `data/`, `logs/`, `notes/`, `build_log.md`, `pending-questions.md`, `contextual-chips.json`, `core-status.json`, etc. — lives under a single **workspace** directory. Code, skills source, and repo configuration stay in the repo root (separate concern).
 
 **Resolution (every service reads the same):**

--- a/docs/workspace-contract.md
+++ b/docs/workspace-contract.md
@@ -84,7 +84,7 @@ Walk the question top-to-bottom and stop at the first match:
 1. **Is the file checked into git?** → `REPO_DIR`. (Source code, scripts, docs, tests, package.json.)
 2. **Is the file a stable cross-machine reference Claude can read on session start?** (e.g., `CLAUDE.md`, README) → `REPO_DIR`.
 3. **Otherwise — does it mutate during runtime?** → `WORKSPACE_DIR`. (Tasks, results, state, logs, notes, build_log, pending-questions, status JSON.)
-4. **Is it per-machine personal state?** (Stand identity, avatar) → `personal_path()` (honors `SUTANDO_MEMORY_DIR` first; legacy `SUTANDO_PRIVATE_DIR` falls through for one release per #870).
+4. **Is it per-machine personal state?** (Stand identity, avatar) → `personal_path()` (honors `SUTANDO_MEMORY_DIR` first; legacy `SUTANDO_PRIVATE_DIR` falls through for one release per #870). The per-machine subdirectory is `machine-<label>/` where `<label>` defaults to the system hostname but can be pinned via `SUTANDO_HOST_LABEL` (#871) — set this if you've renamed your Mac in System Settings and want to keep Memory continuity, or if your hostname flips between Wi-Fi / Ethernet suffixes.
 5. **Is it fleet-shared user state?** (Notes, shared memory) → `shared_personal_path()` (honors `SUTANDO_MEMORY_DIR` first, falls back to workspace; legacy `SUTANDO_PRIVATE_DIR` honored for one release per #870).
 
 ## Related PRs

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -55,6 +55,7 @@ import { resolveWorkspace } from '../../../src/workspace_default.js';
 // Personal-asset path resolver — twin of util_paths.py / voice-agent.ts:personalPath.
 // Reads $SUTANDO_MEMORY_DIR (canonical post-#870), honors legacy $SUTANDO_PRIVATE_DIR
 // as a fallback with a one-release deprecation warning on every read.
+// Per-machine label resolves via $SUTANDO_HOST_LABEL override → hostname (#871).
 function personalPath(filename: string): string {
 	let privateRoot = process.env.SUTANDO_MEMORY_DIR;
 	if (!privateRoot && process.env.SUTANDO_PRIVATE_DIR) {
@@ -67,7 +68,11 @@ function personalPath(filename: string): string {
 	}
 	if (privateRoot) {
 		const root = privateRoot.replace(/^~/, process.env.HOME || '');
-		const host = hostname().split('.')[0];
+		const labelOverride = process.env.SUTANDO_HOST_LABEL;
+		const host =
+			labelOverride && labelOverride.trim()
+				? labelOverride.trim()
+				: hostname().split('.')[0];
 		const candidate = join(root, `machine-${host}`, filename);
 		if (existsSync(candidate)) return candidate;
 	}

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -80,13 +80,33 @@ def _workspace_root() -> Path:
         return Path.home() / ".sutando" / "workspace"
 
 
+def _host_label() -> str:
+    """Return the per-machine label used in `machine-<label>/` Memory paths.
+
+    Resolution:
+      1. `SUTANDO_HOST_LABEL` env var (override) — for users who rename their
+         Mac in System Settings or whose hostname changes between Wi-Fi /
+         Ethernet (different mDNS suffixes), pinning the label keeps Memory
+         continuity across the rename.
+      2. `socket.gethostname().split('.')[0]` — today's default.
+
+    Empty / whitespace-only overrides are treated as unset so a stray empty
+    env-var entry can't silently collapse all hosts into `machine-/`.
+
+    Issue #871 (RFC #858 Decision 3).
+    """
+    override = os.environ.get("SUTANDO_HOST_LABEL")
+    if override and override.strip():
+        return override.strip()
+    return socket.gethostname().split(".")[0]
+
+
 def _private_machine_dir() -> Path | None:
     root = _memory_dir_env()
     if not root:
         return None
     expanded = os.path.expanduser(root)
-    host = socket.gethostname().split(".")[0]
-    return Path(expanded) / f"machine-{host}"
+    return Path(expanded) / f"machine-{_host_label()}"
 
 
 def personal_path(filename: str, workspace: Path | None = None) -> Path:

--- a/src/util_paths.ts
+++ b/src/util_paths.ts
@@ -33,6 +33,27 @@ function expandHome(p: string): string {
 }
 
 /**
+ * Return the per-machine label used in `machine-<label>/` Memory paths.
+ *
+ * Resolution:
+ *   1. `SUTANDO_HOST_LABEL` env var (override) — for users who rename their
+ *      Mac in System Settings or whose hostname changes between Wi-Fi /
+ *      Ethernet (different mDNS suffixes), pinning the label keeps Memory
+ *      continuity across the rename.
+ *   2. `hostname().split('.')[0]` — today's default.
+ *
+ * Empty / whitespace-only overrides are treated as unset so a stray empty
+ * env-var entry can't silently collapse all hosts into `machine-/`.
+ *
+ * Issue #871 (RFC #858 Decision 3).
+ */
+export function hostLabel(): string {
+	const override = process.env.SUTANDO_HOST_LABEL;
+	if (override && override.trim()) return override.trim();
+	return hostname().split('.')[0];
+}
+
+/**
  * Return the resolved memory-dir env value, preferring the new name.
  *
  * Lookup order:
@@ -68,7 +89,7 @@ export function personalPath(filename: string, workspace?: string): string {
 	const privateRoot = memoryDirEnv();
 	if (privateRoot) {
 		const root = expandHome(privateRoot);
-		const host = hostname().split('.')[0];
+		const host = hostLabel();
 		const candidate = join(root, `machine-${host}`, filename);
 		if (existsSync(candidate)) return candidate;
 	}
@@ -83,7 +104,7 @@ export function personalPath(filename: string, workspace?: string): string {
 	// check fails gracefully.
 	if (privateRoot) {
 		const root = expandHome(privateRoot);
-		const host = hostname().split('.')[0];
+		const host = hostLabel();
 		return join(root, `machine-${host}`, filename);
 	}
 	if (filename === 'stand-avatar.png') return join(ws, 'assets', filename);

--- a/tests/util-paths-host-label.test.py
+++ b/tests/util-paths-host-label.test.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Tests for SUTANDO_HOST_LABEL (#871).
+
+Verifies:
+  1. Unset → falls back to hostname.
+  2. Set → override returned (trimmed).
+  3. Empty / whitespace-only → treated as unset (don't collapse to `machine-/`).
+  4. `_private_machine_dir()` composes `machine-<label>/` with the override.
+
+Run: python3 tests/util-paths-host-label.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+import io
+import os
+import socket
+import sys
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from util_paths import _host_label, _private_machine_dir  # noqa: E402
+
+
+def clear_env():
+    for k in ("SUTANDO_MEMORY_DIR", "SUTANDO_PRIVATE_DIR", "SUTANDO_HOST_LABEL"):
+        os.environ.pop(k, None)
+
+
+class HostLabelTests(unittest.TestCase):
+    def setUp(self):
+        clear_env()
+
+    def tearDown(self):
+        clear_env()
+
+    def test_unset_falls_back_to_hostname(self):
+        expected = socket.gethostname().split(".")[0]
+        self.assertEqual(_host_label(), expected)
+
+    def test_override_used_verbatim(self):
+        os.environ["SUTANDO_HOST_LABEL"] = "my-stable-mac"
+        self.assertEqual(_host_label(), "my-stable-mac")
+
+    def test_override_is_trimmed(self):
+        os.environ["SUTANDO_HOST_LABEL"] = "  studio-2  "
+        self.assertEqual(_host_label(), "studio-2")
+
+    def test_empty_override_falls_back(self):
+        # Regression guard: an empty env var must NOT collapse the path to
+        # `machine-/`. A user setting `export SUTANDO_HOST_LABEL=` should get
+        # default hostname behavior, not a broken path.
+        os.environ["SUTANDO_HOST_LABEL"] = ""
+        self.assertEqual(_host_label(), socket.gethostname().split(".")[0])
+
+    def test_whitespace_only_override_falls_back(self):
+        os.environ["SUTANDO_HOST_LABEL"] = "   "
+        self.assertEqual(_host_label(), socket.gethostname().split(".")[0])
+
+    def test_private_machine_dir_uses_override(self):
+        os.environ["SUTANDO_MEMORY_DIR"] = "/tmp/mem"
+        os.environ["SUTANDO_HOST_LABEL"] = "pinned"
+        with redirect_stderr(io.StringIO()):
+            p = _private_machine_dir()
+        self.assertEqual(p, Path("/tmp/mem/machine-pinned"))
+
+    def test_private_machine_dir_uses_hostname_when_unset(self):
+        os.environ["SUTANDO_MEMORY_DIR"] = "/tmp/mem"
+        expected_host = socket.gethostname().split(".")[0]
+        with redirect_stderr(io.StringIO()):
+            p = _private_machine_dir()
+        self.assertEqual(p, Path(f"/tmp/mem/machine-{expected_host}"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/util-paths-host-label.test.ts
+++ b/tests/util-paths-host-label.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { hostname } from 'node:os';
+
+/**
+ * Tests for SUTANDO_HOST_LABEL (#871) in src/util_paths.ts. Twin of
+ * tests/util-paths-host-label.test.py.
+ *
+ * Covers:
+ *   1. Unset → falls back to hostname.
+ *   2. Set → override returned (trimmed).
+ *   3. Empty / whitespace-only → treated as unset (don't collapse to
+ *      `machine-/`).
+ *   4. `personalPath()` composes `machine-<label>/` with the override.
+ */
+
+import { hostLabel, personalPath } from '../src/util_paths.js';
+
+function clearEnv() {
+	delete process.env.SUTANDO_MEMORY_DIR;
+	delete process.env.SUTANDO_PRIVATE_DIR;
+	delete process.env.SUTANDO_HOST_LABEL;
+}
+
+describe('hostLabel (#871 override)', () => {
+	it('falls back to the system hostname when unset', () => {
+		clearEnv();
+		assert.equal(hostLabel(), hostname().split('.')[0]);
+	});
+
+	it('returns the override verbatim', () => {
+		clearEnv();
+		process.env.SUTANDO_HOST_LABEL = 'my-stable-mac';
+		assert.equal(hostLabel(), 'my-stable-mac');
+		clearEnv();
+	});
+
+	it('trims whitespace from the override', () => {
+		clearEnv();
+		process.env.SUTANDO_HOST_LABEL = '  studio-2  ';
+		assert.equal(hostLabel(), 'studio-2');
+		clearEnv();
+	});
+
+	it('falls back to hostname on empty override', () => {
+		// Regression guard: empty env var must not produce `machine-/`.
+		clearEnv();
+		process.env.SUTANDO_HOST_LABEL = '';
+		assert.equal(hostLabel(), hostname().split('.')[0]);
+		clearEnv();
+	});
+
+	it('falls back to hostname on whitespace-only override', () => {
+		clearEnv();
+		process.env.SUTANDO_HOST_LABEL = '   ';
+		assert.equal(hostLabel(), hostname().split('.')[0]);
+		clearEnv();
+	});
+
+	it('personalPath composes machine-<label>/ with the override', () => {
+		clearEnv();
+		process.env.SUTANDO_MEMORY_DIR = '/tmp/mem';
+		process.env.SUTANDO_HOST_LABEL = 'pinned';
+		// Path doesn't exist on disk, so personalPath returns the preferred
+		// memory-dir path for the caller's existsSync() check.
+		const p = personalPath('stand-identity.json', '/tmp/ws');
+		assert.equal(p, '/tmp/mem/machine-pinned/stand-identity.json');
+		clearEnv();
+	});
+});


### PR DESCRIPTION
## Summary
- Adds `SUTANDO_HOST_LABEL` as an optional override for the per-machine Memory subdir naming, on top of today's hostname-based default. Implements **Decision 3** from RFC #858.
- Empty / whitespace-only overrides are treated as unset so a stray `export SUTANDO_HOST_LABEL=` can't silently collapse all hosts into `machine-/`.
- 7 Python + 6 TS unit tests.

**Stacked on #876** (the `SUTANDO_PRIVATE_DIR` → `SUTANDO_MEMORY_DIR` rename). Once #876 merges, rebase the base to `main` and this lands cleanly.

## Why

Today, per-machine Memory state lives at `$SUTANDO_MEMORY_DIR/machine-$(hostname)/` where the hostname is derived live. Two known failure modes:

1. **System Settings rename.** Renaming a Mac flips `hostname` and the bot starts a fresh per-machine state — pending-questions.md, stand-identity.json, etc. all orphaned.
2. **Network-driven mDNS flip.** Some macs report different `hostname` between Wi-Fi and Ethernet (Bonjour suffix changes). Same orphan problem.

The override gives stable identity to users who hit this without forcing onboarding friction on the 95% who don't (env var is purely optional).

## What changed

**New helper (single source of truth):**
- Python — `_host_label()` in `src/util_paths.py`
- TypeScript — `hostLabel()` exported from `src/util_paths.ts`

Both: prefer `SUTANDO_HOST_LABEL` (trimmed) → fall back to `hostname().split('.')[0]`. Empty / whitespace-only override is treated as unset.

**Call-site updates:**
- `src/util_paths.py` — `_private_machine_dir()` composes via `_host_label()`.
- `src/util_paths.ts` — `personalPath()` composes via `hostLabel()`.
- `skills/phone-conversation/scripts/conversation-server.ts` — inline `personalPath()` twin honors the override.

**Swift:** `src/Sutando/main.swift` doesn't currently resolve hostname-based paths (it manages workspace/repo-root only), so no Swift code change in this PR. If/when Swift gains per-machine Memory awareness, the same env-var pattern applies.

**Docs:**
- `CLAUDE.md` — one-liner under workspace-contract.
- `docs/workspace-contract.md` — flow-step 4 mentions the override.

## Test plan

- [x] `python3 tests/util-paths-host-label.test.py` — 7/7 pass
- [x] `npx tsx --test tests/util-paths-host-label.test.ts` — 6/6 pass
- [x] `python3 tests/util-paths-memory-dir.test.py` — still 10/10 pass (regression guard)
- [x] `npx tsx --test tests/util-paths-memory-dir.test.ts` — still 5/5 pass
- [x] `npx tsc --noEmit` clean
- [ ] CI on the PR

Endorsement: liususan091219 / Mac Studio (PR #858 review) — "The 'Mac renamed in System Settings → identity churn' failure mode is real; the override gives stable identity to users who hit it without forcing onboarding friction on the 95% who don't."

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)