### PR TITLE
feat(multi-core): Phase 2b stub + startup.sh integration (tracks #880)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,8 @@ bash src/startup.sh
 ```
 This also starts the screen capture server (needs terminal for Screen Recording permission).
 
+**Multi-core pool (opt-in, #880).** To run N parallel claude sessions sharing this workspace, add `SUTANDO_CORE_POOL_SIZE=3` (or any N≥2) to `.env` and re-run `bash src/startup.sh`. The startup script installs N launchd-managed cores via `scripts/install-core-pool.sh`; the install pre-flight refuses if the `/proactive-loop-pool` skill isn't yet installed at `~/.claude/skills/proactive-loop-pool/`, so today's default is safe to enable even before Phase 2b lands. `bash src/restart.sh` honors the same env var (it delegates to startup.sh). Disable: remove the env var + run `bash scripts/uninstall-core-pool.sh`.
+
 ## Skills
 
 Use skills installed in ~/.claude/skills/ when available. Prefer existing skills over writing new code from scratch.

--- a/skills/proactive-loop-pool/SKILL.md
+++ b/skills/proactive-loop-pool/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: proactive-loop-pool
+description: "Pool-aware variant of /proactive-loop for the multi-core agent pool (#880). Each session in the pool runs this skill; the only behavioral diff vs /proactive-loop is a claim step before processing each task."
+user-invocable: true
+---
+
+# Proactive Loop (Pool-Aware)
+
+Variant of `/proactive-loop` that's safe to run in N parallel claude sessions sharing one workspace. The **only behavioral difference** from `/proactive-loop` is step 1 — task pickup goes through the atomic-rename claim before reading the task file. Losing the claim race means another session is processing the task; this session walks away. The rest of the loop body is unchanged.
+
+This skill exists for the multi-core pool installed by `bash scripts/install-core-pool.sh N`. Each launchd-managed core session in the pool invokes `/proactive-loop-pool` instead of `/proactive-loop`.
+
+**Single-core users**: keep using `/proactive-loop`. This skill is only useful when N > 1 sessions exist; in single-core mode it adds claim overhead with no benefit.
+
+**Usage**: `/proactive-loop-pool [interval]`
+
+ARGUMENTS: $ARGUMENTS
+
+## Required env vars
+
+Each pool session sets these via its launchd plist (see `scripts/install-core-pool.sh`):
+- `SUTANDO_CORE_ID` — this session's 1-based core ID (e.g. `1`, `2`, `3`).
+- `SUTANDO_CORE_POOL_SIZE` — total pool size (informational; not enforced by this skill).
+- `SUTANDO_WORKSPACE` — shared workspace path (same as all other Sutando components).
+
+If `SUTANDO_CORE_ID` is unset, abort with a clear error: "proactive-loop-pool requires SUTANDO_CORE_ID — are you sure you meant to invoke this instead of /proactive-loop?"
+
+## Activation, scheduling, watcher
+
+Identical to `/proactive-loop` — `/schedule-crons` and the streaming task watcher start the same way. See `~/.claude/skills/proactive-loop/SKILL.md` for the full body, or follow these steps verbatim:
+
+1. `/schedule-crons` to set up recurring crons.
+2. Start the streaming task watcher via the `Monitor` tool.
+
+## The claim step (what's different from /proactive-loop)
+
+When the task watcher emits `TASK_FILE: <basename>` for a new task, **before** reading the file:
+
+1. Extract the task ID from the filename (`task-<id>.txt` → `<id>`).
+2. Run: `python3 src/claim_task.py <id> $SUTANDO_CORE_ID`
+3. Outcomes:
+   - **Exit 0** → claim won. The script prints the renamed path (`tasks/task-<id>.claimed-core-<n>.txt`). Read THIS path, not the original.
+   - **Exit 1** → claim lost (another pool session won). Skip this task entirely — no Read, no processing, no result file.
+   - **Exit 2** → usage / validation error. Log and skip.
+
+Use the renamed `task-<id>.claimed-core-<n>.txt` path for all subsequent reads + result writes. The bridges look for results by task ID, so writing to `results/task-<id>.txt` (without the `claimed-core-<n>` suffix) still routes correctly.
+
+**Initial sweep on session start**: the watcher's initial sweep emits TASK_FILE events for any pre-existing files. Run the claim step on each; expect to win some and lose others depending on which sibling session got there first.
+
+## The rest of the loop
+
+Identical to `/proactive-loop`'s numbered steps 2-11:
+
+2. Check pending questions.
+3. Check system health.
+4. Read the build log.
+5. Pick highest-ROI work.
+6. Act on it.
+7. Update build_log.
+8. If blocked, ask.
+9. Ensure the streaming watcher is running.
+10. Monitor Discord.
+11. Heartbeat.
+
+These steps run independently per session. Quota / active-engagement / presenter-mode skip conditions all apply per-session — each pool member checks them on its own pass.
+
+## Phase 2a known limitations
+
+This skill ships in Phase 2a of #880. Two pieces are NOT yet wired in:
+
+- **Done-flag side-effect gate** (Phase 2b). Without it, the rare crash-then-replay window can fire a side effect twice. Mitigation today: rare crashes within the few-second window between claim and side-effect-completion.
+- **Boot-time orphan watchdog** (Phase 2b). If a pool session crashes after claiming but before processing, the claim file is stranded until owner manually renames it back. Mitigation today: `launchctl bootout <core> && launchctl bootstrap <core>` re-runs the session which won't re-claim a stale file (but won't release it either — manual rename needed).
+
+For "let me try it tonight" the limitations above are acceptable. Phase 2b ships the watchdog + done-flag gate.
+
+## Disabling the pool
+
+To revert to single-core:
+1. Remove `SUTANDO_CORE_POOL_SIZE` from `.env` (or set to 1).
+2. Run `bash scripts/uninstall-core-pool.sh` to remove the launchd plists.
+3. `bash src/restart.sh` to restart the foreground core.

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -428,6 +428,30 @@ done
 echo ""
 open "http://localhost:8080"
 
+# Multi-core agent pool (#880). Opt-in via $SUTANDO_CORE_POOL_SIZE in .env.
+# Default `1` (today's single-core behavior); set to N>=2 to install N
+# launchd-managed claude sessions that share the workspace. The install
+# script's pre-flight refuses if the `/proactive-loop-pool` skill isn't
+# present yet, so this line is safe to keep enabled even before Phase 2b
+# lands. `|| true` ensures startup proceeds to the foreground core launch
+# even if the pool install errors (e.g. launchctl unavailable, claude not
+# on PATH). Re-running startup is idempotent — the install script does
+# `bootout`-then-`bootstrap` on each plist, no zombies.
+#
+# Sanitize the env var FIRST so a non-numeric value (typo, comment dangling
+# in .env) doesn't blow up under `set -e` from `[ ... -gt 1 ]` returning
+# exit 2 on non-numeric input. Treat anything non-digit as `1` (skip install).
+__pool_size="${SUTANDO_CORE_POOL_SIZE:-1}"
+case "$__pool_size" in
+    ''|*[!0-9]*) __pool_size=1 ;;
+esac
+if [ "$__pool_size" -gt 1 ]; then
+    echo ""
+    echo "Installing multi-core pool (SUTANDO_CORE_POOL_SIZE=$__pool_size)..."
+    bash "$REPO/scripts/install-core-pool.sh" "$__pool_size" || true
+fi
+unset __pool_size
+
 # Delegate to scripts/start-cli.sh — canonical sutando-core launch command.
 # Single source of truth so Sutando.app's Restart Core menu can invoke the
 # same launch path without duplicating the tmux + claude flags.


### PR DESCRIPTION
## Summary

Ships the pieces needed for owner to test the multi-core pool end-to-end. **Stacked on PR #882** (Phase 2a primitive).

- `skills/proactive-loop-pool/SKILL.md` — pool-aware variant of `/proactive-loop`. Only behavioral diff: claim step before task pickup.
- `src/startup.sh` integration — env-gated install call. Owner-facing command stays `bash src/startup.sh`.
- `CLAUDE.md` doc note in the Startup section.

## Owner test path (after this PR merges)

```bash
git pull
bash skills/install.sh    # symlinks proactive-loop-pool into ~/.claude/skills/
# Add to .env:  SUTANDO_CORE_POOL_SIZE=3
bash src/startup.sh
```

`bash src/restart.sh` honors the same env var (delegates to startup.sh at L50). To disable: remove the env var + `bash scripts/uninstall-core-pool.sh`.

## Regression layers (verified locally)

The `set -e` startup.sh required care; an un-sanitized `[ "abc" -gt 1 ]` would exit 2 and halt startup. Sanitization via `case "$__pool_size" in ''|*[!0-9]*) __pool_size=1 ;; esac` before the numeric comparison covers the failure mode.

Verified outputs:
- env unset → "would skip (size=1)"
- env=3 → "would install pool size=3"
- env=abc → "would skip (size=1 — sanitized)"
- env=1 → "would skip"

Plus the existing safety net from #882: install script's pre-flight refuses if the `/proactive-loop-pool` skill isn't installed; the narrow glob protects `com.sutando.core-agent.plist`; `|| true` on the install call ensures startup completes even if install errors.

## Sutando.app interaction

`Restart Core` menu delegates only to `scripts/start-cli.sh`, NOT to `startup.sh`. So Restart Core doesn't trigger pool install — and shouldn't, because the launchd pool plists are persistent (`KeepAlive=true`). Install-once, run-forever. The single-core foreground claude session restarts; the launchd-managed pool members keep going independently.

`bash src/restart.sh` DOES go through startup.sh (line 50 `exec bash startup.sh`), so it WILL trigger a re-install (idempotent — bootout-then-bootstrap, no zombies).

## Eval (per always-propose-eval)

- **Synthetic — correctness (manual local test)**: 4 sanitization cases above. Passes.
- **Synthetic — install pre-flight**: re-tested after this PR's skill is in `skills/`; the install script now finds the skill and proceeds (previously refused).
- **Real-user — manual demo**: owner runs the test path above. Expected behavior: pool installs, 3 launchd cores start, each calls `/proactive-loop-pool`, each claims-or-skips on task pickup, drains queue in parallel. Quota concern: 3 sessions all polling burns quota faster — owner should monitor `python3 ~/.claude/skills/quota-tracker/scripts/read-quota.py` after enabling.
- **Phase 2b followup work** (separate PR after this lands): boot-time orphan watchdog + done-flag side-effect gate. The skill's "Phase 2a known limitations" section documents what's missing.

## Test plan

- [x] `bash -n src/startup.sh` syntax check
- [x] 4 sanitization cases manually verified (env unset / 3 / abc / 1)
- [x] Install script's pre-flight finds the new skill once `skills/install.sh` runs (verified via path inspection)
- [x] `bash src/restart.sh` ends with `exec bash startup.sh` — confirmed honors the env var
- [ ] Owner full end-to-end test (post-merge): install + restart + watch pool spin up

Stacks on #882 (Phase 2a). Tracks #880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)