### PR TITLE
feat(multi-core): Phase 2c — channel-affinity + pool metrics (closes #884)

### DIFF
--- a/scripts/install-core-pool.sh
+++ b/scripts/install-core-pool.sh
@@ -36,11 +36,21 @@ WORKSPACE="${WORKSPACE/#\~/$HOME}"
 mkdir -p "$WORKSPACE/logs"
 mkdir -p "$WORKSPACE/state/cores"
 
-# Resolve claude binary. Caller's $PATH may not include the install dir
-# on launchd-spawned processes, so capture absolute path now.
+# Resolve repo root so the heartbeat sidecar plists can address
+# `src/core_heartbeat.py` by absolute path. This script lives at
+# `<repo>/scripts/install-core-pool.sh`.
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Resolve claude + python3 binaries. Caller's $PATH may not include the
+# install dirs on launchd-spawned processes, so capture absolute paths now.
 CLAUDE_BIN="$(command -v claude || true)"
 if [ -z "$CLAUDE_BIN" ]; then
   echo "error: 'claude' CLI not found on \$PATH" >&2
+  exit 1
+fi
+PYTHON_BIN="$(command -v python3 || true)"
+if [ -z "$PYTHON_BIN" ]; then
+  echo "error: 'python3' not found on \$PATH (needed for heartbeat sidecar)" >&2
   exit 1
 fi
 
@@ -95,13 +105,18 @@ fi
 shopt -s nullglob
 for existing in "$LAUNCH_AGENTS"/com.sutando.core-[0-9]*.plist; do
   base="$(basename "$existing")"
-  # Extract the index (e.g. com.sutando.core-3.plist -> 3)
-  idx="${base#com.sutando.core-}"
-  idx="${idx%.plist}"
+  # Two flavors land in this glob:
+  #   com.sutando.core-<N>.plist           — the claude session
+  #   com.sutando.core-<N>-heartbeat.plist — its heartbeat sidecar
+  # Extract the index from either and check shrink-bound.
+  stem="${base#com.sutando.core-}"
+  stem="${stem%.plist}"          # e.g. "3" or "3-heartbeat"
+  idx="${stem%-heartbeat}"       # "3" in both cases
   if ! [[ "$idx" =~ ^[0-9]+$ ]]; then continue; fi
   if [ "$idx" -gt "$N" ]; then
+    label="${base%.plist}"
     echo "removing stale pool member: $base"
-    launchctl bootout "$DOMAIN/com.sutando.core-$idx" 2>/dev/null || true
+    launchctl bootout "$DOMAIN/$label" 2>/dev/null || true
     rm -f "$existing"
   fi
 done
@@ -146,6 +161,45 @@ PLIST_EOF
   launchctl bootout "$DOMAIN/com.sutando.core-$i" 2>/dev/null || true
   launchctl bootstrap "$DOMAIN" "$PLIST"
   echo "installed: com.sutando.core-$i (workspace=$WORKSPACE)"
+
+  # Heartbeat sidecar — always-on writer of `state/cores/core-$i.alive`.
+  # Required by `claim_task.py:_is_alive()` for channel-affinity (#884).
+  # Without it, the affinity check sees the handler's .alive file missing
+  # → treats handler as dead → falls back to race-claim on every task,
+  # silently defeating the sticky-handler design.
+  HEART_PLIST="$LAUNCH_AGENTS/com.sutando.core-$i-heartbeat.plist"
+  cat > "$HEART_PLIST" <<HEART_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+                       "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.sutando.core-$i-heartbeat</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$PYTHON_BIN</string>
+    <string>$REPO_DIR/src/core_heartbeat.py</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>SUTANDO_CORE_ID</key><string>$i</string>
+    <key>SUTANDO_WORKSPACE</key><string>$WORKSPACE</string>
+    <key>PATH</key><string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ThrottleInterval</key><integer>10</integer>
+  <key>StandardOutPath</key>
+  <string>$WORKSPACE/logs/core-$i-heartbeat.log</string>
+  <key>StandardErrorPath</key>
+  <string>$WORKSPACE/logs/core-$i-heartbeat.err</string>
+</dict>
+</plist>
+HEART_EOF
+  launchctl bootout "$DOMAIN/com.sutando.core-$i-heartbeat" 2>/dev/null || true
+  launchctl bootstrap "$DOMAIN" "$HEART_PLIST"
+  echo "installed: com.sutando.core-$i-heartbeat"
 done
 
 echo

--- a/scripts/install-core-pool.sh
+++ b/scripts/install-core-pool.sh
@@ -59,6 +59,21 @@ mkdir -p "$LAUNCH_AGENTS"
 UID_VAL="$(id -u)"
 DOMAIN="gui/$UID_VAL"
 
+# launchctl bootout is async — the service can still be in the "unloading"
+# state when bootstrap fires, surfacing as "Bootstrap failed: 5: Input/output
+# error". Retry bootstrap a few times with backoff before giving up. Observed
+# 2026-05-19 on a 3-core re-install after the first slot's bootout.
+bootstrap_with_retry() {
+  local plist="$1"
+  local i
+  for i in 1 2 3 4 5; do
+    if launchctl bootstrap "$DOMAIN" "$plist" 2>/dev/null; then return 0; fi
+    sleep 0.5
+  done
+  # Final attempt with stderr visible so the script aborts with diagnostic.
+  launchctl bootstrap "$DOMAIN" "$plist"
+}
+
 # Regression guard: Phase 2a ships the launchd plumbing + claim primitive,
 # but NOT the `/proactive-loop-pool` skill. If we install plists that invoke
 # a non-existent skill, launchd's KeepAlive will restart the failing claude
@@ -159,7 +174,7 @@ for i in $(seq 1 "$N"); do
 PLIST_EOF
   # bootout first (idempotent — succeeds if not loaded) then bootstrap.
   launchctl bootout "$DOMAIN/com.sutando.core-$i" 2>/dev/null || true
-  launchctl bootstrap "$DOMAIN" "$PLIST"
+  bootstrap_with_retry "$PLIST"
   echo "installed: com.sutando.core-$i (workspace=$WORKSPACE)"
 
   # Heartbeat sidecar — always-on writer of `state/cores/core-$i.alive`.
@@ -198,7 +213,7 @@ PLIST_EOF
 </plist>
 HEART_EOF
   launchctl bootout "$DOMAIN/com.sutando.core-$i-heartbeat" 2>/dev/null || true
-  launchctl bootstrap "$DOMAIN" "$HEART_PLIST"
+  bootstrap_with_retry "$HEART_PLIST"
   echo "installed: com.sutando.core-$i-heartbeat"
 done
 

--- a/scripts/pool-metrics.py
+++ b/scripts/pool-metrics.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Report metrics for the multi-core agent pool (#880, #884).
+
+Pairs task files with their corresponding result files via task ID, then
+reports total task time (sum of per-task processing latencies), wallclock
+time (max end - min start), per-channel breakdown, and per-core distribution.
+
+Usage:
+    python3 scripts/pool-metrics.py [--since=MINUTES]
+
+Defaults to --since=15 (last 15 minutes). Reads from $SUTANDO_WORKSPACE
+(or ~/.sutando/workspace).
+
+Output:
+    A summary table per channel, then the pool-level rollup.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+
+def workspace_root() -> Path:
+    env = os.environ.get("SUTANDO_WORKSPACE")
+    if env:
+        return Path(os.path.expanduser(env))
+    return Path.home() / ".sutando" / "workspace"
+
+
+TASK_FILENAME_RE = re.compile(r"^task-(?P<id>[a-zA-Z0-9._-]+?)(?:\.claimed-core-(?P<core>[a-zA-Z0-9._-]+))?\.txt$")
+
+
+def parse_task_metadata(text: str) -> dict[str, str]:
+    """Pull simple `key: value` fields from a task body.
+
+    Tasks have the format:
+        id: ...
+        timestamp: ...
+        task: [Discord @qingyunwu] ...
+        source: discord
+        channel_id: 1485653767402553457
+        ...
+
+    We only need a few fields, so a flat line-scan is sufficient.
+    """
+    out: dict[str, str] = {}
+    for raw in text.splitlines():
+        if ":" in raw:
+            k, _, v = raw.partition(":")
+            k = k.strip()
+            v = v.strip()
+            if k and v:
+                out[k] = v
+    return out
+
+
+def collect_pairs(ws: Path, since_sec: float) -> list[dict]:
+    """Scan tasks (live + archived) and results, pair them by ID, return
+    a list of paired records. `since_sec` filters to tasks whose mtime is
+    within the last `since_sec` seconds (use a wide value for a full pool
+    test run)."""
+    now = time.time()
+    cutoff = now - since_sec
+    tasks_dirs = [ws / "tasks", ws / "tasks" / "archive"]
+    results_dirs = [ws / "results", ws / "results" / "archive"]
+
+    # Index results by task ID for fast lookup.
+    result_index: dict[str, tuple[Path, float]] = {}
+    for rdir in results_dirs:
+        if not rdir.exists():
+            continue
+        for p in rdir.rglob("task-*.txt"):
+            m = TASK_FILENAME_RE.match(p.name)
+            if not m:
+                continue
+            tid = m.group("id")
+            mtime = p.stat().st_mtime
+            # Keep the latest result for any given task id
+            if tid not in result_index or mtime > result_index[tid][1]:
+                result_index[tid] = (p, mtime)
+
+    pairs: list[dict] = []
+    for tdir in tasks_dirs:
+        if not tdir.exists():
+            continue
+        for p in tdir.rglob("task-*.txt"):
+            m = TASK_FILENAME_RE.match(p.name)
+            if not m:
+                continue
+            tid = m.group("id")
+            assigned_core = m.group("core")  # may be None if not yet claimed
+            mtime = p.stat().st_mtime
+            if mtime < cutoff:
+                continue
+            try:
+                body = p.read_text(errors="replace")
+            except OSError:
+                continue
+            meta = parse_task_metadata(body)
+            result = result_index.get(tid)
+            pairs.append({
+                "task_id": tid,
+                "task_path": p,
+                "task_mtime": mtime,
+                "core": assigned_core or meta.get("claimed_core", "?"),
+                "channel_id": meta.get("channel_id", "(none)"),
+                "source": meta.get("source", "?"),
+                "priority": meta.get("priority", "normal"),
+                "result_path": result[0] if result else None,
+                "result_mtime": result[1] if result else None,
+                "latency_sec": (result[1] - mtime) if result else None,
+            })
+    return pairs
+
+
+def fmt_seconds(s: float | None) -> str:
+    if s is None:
+        return "—"
+    if s < 1:
+        return f"{s*1000:.0f}ms"
+    if s < 60:
+        return f"{s:.1f}s"
+    if s < 3600:
+        return f"{s/60:.1f}min"
+    return f"{s/3600:.1f}h"
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--since", type=int, default=15, help="Look back N minutes (default 15)")
+    args = ap.parse_args(argv[1:])
+
+    ws = workspace_root()
+    since_sec = args.since * 60
+    pairs = collect_pairs(ws, since_sec)
+
+    if not pairs:
+        print(f"No tasks in the last {args.since} min under {ws}")
+        return 0
+
+    completed = [p for p in pairs if p["result_mtime"] is not None]
+    pending = [p for p in pairs if p["result_mtime"] is None]
+
+    # Per-channel rollup
+    by_channel: dict[str, list[dict]] = defaultdict(list)
+    for p in pairs:
+        by_channel[p["channel_id"]].append(p)
+
+    # Per-core rollup
+    by_core: dict[str, list[dict]] = defaultdict(list)
+    for p in completed:
+        by_core[p["core"]].append(p)
+
+    print(f"Pool metrics — last {args.since} min under {ws}")
+    print(f"  Window: {args.since*60}s")
+    print(f"  Tasks observed: {len(pairs)} ({len(completed)} completed, {len(pending)} pending)")
+    print()
+
+    # Pool-level totals
+    if completed:
+        total_task_time = sum(p["latency_sec"] for p in completed)
+        wallclock_start = min(p["task_mtime"] for p in completed)
+        wallclock_end = max(p["result_mtime"] for p in completed)
+        wallclock = wallclock_end - wallclock_start
+        speedup = total_task_time / wallclock if wallclock > 0 else 0
+        print("Pool totals:")
+        print(f"  total task time (sum of per-task latency): {fmt_seconds(total_task_time)}")
+        print(f"  wallclock time (max end - min start):      {fmt_seconds(wallclock)}")
+        print(f"  speedup ratio (total / wallclock):         {speedup:.2f}x  (1.00 = serial, >1.00 = parallel)")
+        print()
+
+    # Per-channel
+    if by_channel:
+        print("Per-channel:")
+        print(f"  {'channel_id':40} {'tasks':>6} {'avg latency':>12} {'cores':>10}")
+        for ch, items in sorted(by_channel.items()):
+            done = [i for i in items if i["latency_sec"] is not None]
+            avg = sum(i["latency_sec"] for i in done) / len(done) if done else None
+            cores_seen = sorted({i["core"] for i in done if i["core"] != "?"})
+            cores_str = ",".join(cores_seen) if cores_seen else "—"
+            print(f"  {ch[:40]:40} {len(items):>6} {fmt_seconds(avg):>12} {cores_str:>10}")
+        print()
+
+    # Per-core
+    if by_core:
+        print("Per-core:")
+        print(f"  {'core':>6} {'tasks':>6} {'total time':>12} {'channels handled':>20}")
+        for core, items in sorted(by_core.items()):
+            total = sum(i["latency_sec"] for i in items)
+            channels = sorted({i["channel_id"] for i in items})
+            ch_str = ",".join(c[-8:] for c in channels)  # last 8 chars to keep table narrow
+            print(f"  {core:>6} {len(items):>6} {fmt_seconds(total):>12} {ch_str:>20}")
+        print()
+
+    # Affinity verification — for each channel, did all tasks go to one core?
+    print("Channel-affinity health (within this window):")
+    bad = 0
+    for ch, items in sorted(by_channel.items()):
+        done = [i for i in items if i["core"] != "?" and i["latency_sec"] is not None]
+        if not done:
+            continue
+        cores = sorted({i["core"] for i in done})
+        if len(cores) > 1:
+            print(f"  ⚠ {ch}: split across cores {cores} ({len(done)} tasks). Possible cause: handler-died or idle-window-elapsed.")
+            bad += 1
+    if bad == 0:
+        print("  ✓ every channel served by exactly one core within the window")
+    print()
+
+    if pending:
+        print("Pending tasks (not yet completed):")
+        for p in pending[:10]:
+            age = time.time() - p["task_mtime"]
+            print(f"  task-{p['task_id']}  channel={p['channel_id']}  age={fmt_seconds(age)}  core={p['core']}")
+        if len(pending) > 10:
+            print(f"  ... ({len(pending) - 10} more)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/uninstall-core-pool.sh
+++ b/scripts/uninstall-core-pool.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-# Uninstall the multi-core agent pool — stops every com.sutando.core-<N>.plist
-# (where <N> is purely numeric) and removes the plist files. Logs under
-# $SUTANDO_WORKSPACE/logs/core-*.log are kept (not deleted) so post-mortem of
-# any pool incident remains possible.
+# Uninstall the multi-core agent pool — stops every pool plist and removes
+# the files. Two flavors are installed per slot and both are torn down here:
+#   com.sutando.core-<N>.plist            — the claude session
+#   com.sutando.core-<N>-heartbeat.plist  — the .alive heartbeat sidecar
+# The glob `com.sutando.core-[0-9]*.plist` catches both because the heartbeat
+# label starts with a digit immediately after `core-`. Logs under
+# $SUTANDO_WORKSPACE/logs/core-*.log{,err} are kept (not deleted) so
+# post-mortem of any pool incident remains possible.
 #
 # CRITICAL: the glob pattern is `com.sutando.core-[0-9]*.plist`, NOT
 # `com.sutando.core-*.plist`. The narrower pattern is intentional — the

--- a/skills/proactive-loop-pool/SKILL.md
+++ b/skills/proactive-loop-pool/SKILL.md
@@ -34,18 +34,39 @@ Identical to `/proactive-loop` — `/schedule-crons` and the streaming task watc
 
 ## The claim step (what's different from /proactive-loop)
 
-When the task watcher emits `TASK_FILE: <basename>` for a new task, **before** reading the file:
+When the task watcher emits `TASK_FILE: <basename>` for a new task, **before** reading the task body, run the claim step. There are two flavors:
+
+### Plain claim (no channel affinity)
+
+For voice / phone / un-channeled tasks, or as a fallback when the task body has no `channel_id:` field:
 
 1. Extract the task ID from the filename (`task-<id>.txt` → `<id>`).
 2. Run: `python3 src/claim_task.py <id> $SUTANDO_CORE_ID`
-3. Outcomes:
-   - **Exit 0** → claim won. The script prints the renamed path (`tasks/task-<id>.claimed-core-<n>.txt`). Read THIS path, not the original.
-   - **Exit 1** → claim lost (another pool session won). Skip this task entirely — no Read, no processing, no result file.
-   - **Exit 2** → usage / validation error. Log and skip.
+3. Exit 0 → claim won, read the printed path; Exit 1 → skip; Exit 2 → log and skip.
+
+### Channel-affinity claim (Discord / Telegram / Slack)
+
+For tasks with a `channel_id:` field in the body (`#884`):
+
+1. Extract the task ID from the filename.
+2. Peek at the task body (without claiming yet) to read the `channel_id:` line. (Use `head` / `grep` — don't run a full Read tool yet since other cores may grab the task first.)
+3. Run: `python3 src/claim_task.py <id> $SUTANDO_CORE_ID <channel_id>`
+4. Outcomes:
+   - **Exit 0** → claim won. Script prints the renamed path (`tasks/task-<id>.claimed-core-<n>.txt`). Read THIS path. Your core is now the channel's handler for the next 30 min (default `SUTANDO_CORE_IDLE_THRESHOLD_SEC`).
+   - **Exit 1** → respect-handler OR lost-race. Either another core is the channel's active handler, or another core won the race-claim. Skip this task entirely.
+   - **Exit 2** → validation error. Log and skip.
+
+The affinity machinery is **inside** `claim_task.py` — your only responsibility is to pass `channel_id` when present. The script reads `state/cores/channel-<id>.handler` and `state/cores/core-<n>.alive` to decide whether you're allowed to claim.
 
 Use the renamed `task-<id>.claimed-core-<n>.txt` path for all subsequent reads + result writes. The bridges look for results by task ID, so writing to `results/task-<id>.txt` (without the `claimed-core-<n>` suffix) still routes correctly.
 
 **Initial sweep on session start**: the watcher's initial sweep emits TASK_FILE events for any pre-existing files. Run the claim step on each; expect to win some and lose others depending on which sibling session got there first.
+
+### Why channel affinity matters
+
+Without it, three follow-up Discord messages on the same topic would scatter across the 3 cores. Each core would run a partial proactive-loop pass and write a partial result; the latest task's result would carry the consolidated reply via `[deduped:]` marker. That's wasteful — 3× quota burn for 1× user-visible reply.
+
+With affinity, all 3 tasks land on the same core; that core has the conversational context in its session memory and produces one coherent reply. Quota burn matches what a single-core setup would have done.
 
 ## The rest of the loop
 

--- a/src/claim_task.py
+++ b/src/claim_task.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Atomic-rename claim primitive for the multi-core agent pool (#880).
+"""Atomic-rename claim primitive for the multi-core agent pool (#880, #884).
 
 A new task lands as `<workspace>/tasks/task-<id>.txt`. A core session claims
 it by atomic-rename:
@@ -14,19 +14,31 @@ first-rename-wins. Single-Mac strict subset of the same coordination
 protocol; same primitive, no sync gap.
 
 CLI:
-    python3 src/claim_task.py <task-id> <core-id>
+    python3 src/claim_task.py <task-id> <core-id> [<channel-id>]
 
 Exit codes:
     0 — claim succeeded; new path printed to stdout
-    1 — claim failed (task already claimed by another core, or doesn't exist)
+    1 — claim failed (task already claimed by another core, or doesn't exist,
+        OR this core is not the channel's current handler and the handler is
+        still alive — i.e. channel-affinity is respected)
     2 — usage error
 
 Library:
-    from claim_task import claim
+    from claim_task import claim, claim_with_affinity
     claimed_path = claim(task_id, core_id, workspace=None)
-    if claimed_path is None:
-        # lost the race
-        ...
+    claimed_path = claim_with_affinity(task_id, core_id, channel_id, workspace=None)
+
+Channel-affinity (#884):
+    `claim_with_affinity()` adds sticky-handler semantics. The first core to
+    claim a task from channel-X becomes the channel's handler; subsequent
+    tasks from channel-X land on that core within IDLE_THRESHOLD (30 min by
+    default, env: SUTANDO_CORE_IDLE_THRESHOLD_SEC). If the handler core's
+    .alive heartbeat goes stale (>90s) — i.e. it crashed — any core may
+    claim again, auto-rebalancing. After IDLE_THRESHOLD of channel
+    inactivity, the handler entry expires and the next task races freely.
+
+    `channel_id=None` is the no-affinity fallback (voice tasks, etc.),
+    delegating to plain `claim()`.
 """
 from __future__ import annotations
 
@@ -84,16 +96,164 @@ def claim(task_id: str, core_id: str, workspace: Path | None = None) -> Path | N
         return None
 
 
+# ---------------------------------------------------------------------------
+# Channel-affinity layer (#884). Adds sticky-handler semantics on top of the
+# plain `claim()` primitive. Only invoked when caller passes channel_id.
+# ---------------------------------------------------------------------------
+
+DEFAULT_IDLE_THRESHOLD_SEC = 30 * 60   # 30 min — chat-pattern cohesion
+ALIVE_THRESHOLD_SEC = 90               # 3 missed 30s heartbeats = dead
+
+import json
+import time
+
+
+def _idle_threshold_sec() -> int:
+    """Read SUTANDO_CORE_IDLE_THRESHOLD_SEC env var, fallback to default.
+    Non-numeric / negative inputs fall back to the default."""
+    raw = os.environ.get("SUTANDO_CORE_IDLE_THRESHOLD_SEC")
+    if not raw:
+        return DEFAULT_IDLE_THRESHOLD_SEC
+    try:
+        val = int(raw)
+        if val <= 0:
+            return DEFAULT_IDLE_THRESHOLD_SEC
+        return val
+    except ValueError:
+        return DEFAULT_IDLE_THRESHOLD_SEC
+
+
+def _validate_channel_id(channel_id: str) -> str:
+    """Same allowlist as task/core IDs — only alphanumerics + `-` + `_` + `.`.
+    Reject path separators so a hostile channel_id can't escape state/cores/."""
+    return _validate_id(channel_id, "channel_id")
+
+
+def _handler_path(ws: Path, channel_id: str) -> Path:
+    return ws / "state" / "cores" / f"channel-{channel_id}.handler"
+
+
+def _alive_path(ws: Path, core_id: str) -> Path:
+    return ws / "state" / "cores" / f"core-{core_id}.alive"
+
+
+def _read_handler(path: Path) -> dict | None:
+    """Read the handler JSON. Return None on any error (missing, malformed,
+    permission). Treating any read failure as 'no handler' keeps the algorithm
+    forward-progressing — at worst a transient read error causes a single
+    extra race-claim, never a deadlock."""
+    try:
+        return json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _write_handler(path: Path, core_id: str, when: float) -> None:
+    """Write the handler entry atomically (temp file + rename) so a concurrent
+    reader never sees a half-written JSON. Best-effort: errors swallowed —
+    a missed handler-write doesn't break the claim, just means the next core
+    might race-claim the next task on this channel. Trade-off in favor of
+    progress over strict accounting."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + f".tmp-{os.getpid()}")
+        tmp.write_text(json.dumps({"core_id": core_id, "last_handled_at": when}))
+        os.rename(tmp, path)  # atomic on same FS
+    except OSError:
+        pass
+
+
+def _is_alive(ws: Path, core_id: str, now: float) -> bool:
+    """A core is alive if its .alive heartbeat mtime is younger than
+    ALIVE_THRESHOLD_SEC. If the file is missing, treat as dead — newly-started
+    cores write the heartbeat before claiming, so a missing file means
+    'never started' or 'cleanly shut down,' both of which release the channel."""
+    p = _alive_path(ws, core_id)
+    try:
+        mtime = p.stat().st_mtime
+    except (FileNotFoundError, OSError):
+        return False
+    return (now - mtime) < ALIVE_THRESHOLD_SEC
+
+
+def claim_with_affinity(
+    task_id: str,
+    core_id: str,
+    channel_id: str | None,
+    workspace: Path | None = None,
+) -> Path | None:
+    """Claim a task, honoring per-channel sticky-handler affinity (#884).
+
+    Semantics:
+      - channel_id=None → delegate to plain claim() (no affinity).
+      - Channel has a fresh handler (within IDLE_THRESHOLD) AND that handler
+        is alive (heartbeat < 90s) AND it's NOT this core: return None
+        (respect the handler).
+      - Channel has a fresh handler AND that handler is alive AND it IS this
+        core: claim normally + update handler.last_handled_at on success.
+      - Channel has a stale handler (idle expired OR handler core dead) OR
+        no handler: race-claim; on success write/refresh the handler with
+        this core_id + now.
+
+    Returns the claim path on success, None on lost race / respect-handler.
+    Raises ValueError on invalid inputs.
+    """
+    task_id = _validate_id(task_id, "task_id")
+    core_id = _validate_id(core_id, "core_id")
+    if channel_id is None:
+        return claim(task_id, core_id, workspace=workspace)
+    channel_id = _validate_channel_id(channel_id)
+
+    ws = workspace if workspace is not None else _workspace_root()
+    now = time.time()
+    handler_p = _handler_path(ws, channel_id)
+    handler = _read_handler(handler_p)
+    idle_threshold = _idle_threshold_sec()
+
+    handler_is_fresh = (
+        handler is not None
+        and isinstance(handler.get("last_handled_at"), (int, float))
+        and (now - handler["last_handled_at"]) < idle_threshold
+    )
+
+    if handler_is_fresh:
+        handler_core = str(handler.get("core_id", ""))
+        if not handler_core:
+            # Malformed handler — treat as no handler, race-claim.
+            handler_is_fresh = False
+        elif _is_alive(ws, handler_core, now):
+            # Handler is fresh AND alive — respect it.
+            if core_id != handler_core:
+                return None
+            # I am the handler — claim normally + refresh handler mtime.
+            result = claim(task_id, core_id, workspace=ws)
+            if result is not None:
+                _write_handler(handler_p, core_id, now)
+            return result
+        # Handler fresh but dead → fall through to race-claim path
+
+    # Race-claim path: any core may attempt, kernel decides. Winner refreshes
+    # the handler file with their core_id + now.
+    result = claim(task_id, core_id, workspace=ws)
+    if result is not None:
+        _write_handler(handler_p, core_id, now)
+    return result
+
+
 def _main(argv: list[str]) -> int:
-    if len(argv) != 3:
+    if len(argv) not in (3, 4):
         print(
-            "usage: claim_task.py <task-id-without-task-prefix-or-.txt-suffix> <core-id>",
+            "usage: claim_task.py <task-id> <core-id> [<channel-id>]",
             file=sys.stderr,
         )
         return 2
     task_id, core_id = argv[1], argv[2]
+    channel_id = argv[3] if len(argv) == 4 else None
     try:
-        result = claim(task_id, core_id)
+        if channel_id:
+            result = claim_with_affinity(task_id, core_id, channel_id)
+        else:
+            result = claim(task_id, core_id)
     except ValueError as e:
         print(f"claim_task: {e}", file=sys.stderr)
         return 2

--- a/src/core_heartbeat.py
+++ b/src/core_heartbeat.py
@@ -1,25 +1,31 @@
 #!/usr/bin/env python3
-"""Per-host heartbeat for sutando-core sessions.
+"""Per-slot heartbeat for sutando-core sessions.
 
-Writes a small JSON file at `<workspace>/state/cores/<hostname>.alive` every
-30 seconds while running. The file's content reports the core's pid, host,
-start time, last beat, and a free-form status string; the file's mtime is
-the cross-host "is this core still up?" signal.
+Writes a small JSON file at `<workspace>/state/cores/core-<id>.alive` every
+30 seconds while running. `<id>` is `$SUTANDO_CORE_ID` (set per-slot by the
+pool launchd plist) — falls back to `default` for the legacy single-core
+install where the env var is unset. The file's content reports the core's
+pid, host, start time, last beat, and a free-form status string; the file's
+mtime is the "is this core still up?" signal that the claim primitive
+(`src/claim_task.py`) consumes.
 
-Why
----
+Why per-slot, not per-host
+--------------------------
 Today's "is the core alive?" check reads `core-status.json` at the workspace
 root — a single file written by the proactive-loop each pass. That's fine
-for a single-machine install: one core, one status. The moment we want
-multi-core (multiple Claude Code sessions sharing a workspace, or sutando
-running on both Mac Studio + MacBook against a synced workspace), one file
-can no longer represent N processes.
+for a single-machine, single-core install. The moment we want multi-core
+(N parallel claude sessions on one Mac sharing a workspace, #880), one file
+can no longer represent N processes — and the original per-host scheme
+(`<hostname>.alive`, pre-#885) had all N pool cores overwriting the same
+file, so `claim_task.py:_is_alive(core_id)` (which reads `core-<id>.alive`
+per #884's channel-affinity) saw "file missing → dead" for every check.
+Channel-affinity silently fell through to plain race-claim on every task.
 
-Per-host file at `state/cores/<hostname>.alive`:
+Per-slot file at `state/cores/core-<id>.alive`:
   • Each running core writes only its own file (no contention).
-  • Any process can read the directory to see who's alive across the fleet.
+  • Any process can read the directory to see who's alive across the pool.
   • mtime is the authoritative liveness signal (younger than ~90s = alive).
-  • Future lease-based scheduler consumes this to know who can pick up work.
+  • Filename matches what `claim_task.py:_alive_path()` reads — no drift.
 
 This script is intentionally tiny and standalone — startup.sh launches it as
 a background process. SIGTERM/SIGINT clean up the .alive file so a graceful
@@ -58,13 +64,25 @@ CORES_DIR = WORKSPACE / "state" / "cores"
 
 def _hostname() -> str:
     """Short hostname without domain. Mirrors what sync-memory.sh uses for
-    machine-<host>/ dirs, so the .alive file is recognizable across the
-    fleet's other state files."""
+    machine-<host>/ dirs, so the .alive file's payload is recognizable across
+    the fleet's other state files."""
     return socket.gethostname().split(".")[0]
 
 
+def _core_id() -> str:
+    """Resolve the per-slot id used in the .alive filename.
+
+    Reads `$SUTANDO_CORE_ID` (set by the pool launchd plist, see
+    `scripts/install-core-pool.sh`). For the legacy single-core install
+    (startup.sh path, env unset), falls back to `default` — a stable sentinel
+    that won't collide with pool slot numbers (1..N) and keeps the filename
+    parseable. Reject empty/whitespace-only env to avoid `core-.alive`."""
+    raw = os.environ.get("SUTANDO_CORE_ID", "").strip()
+    return raw if raw else "default"
+
+
 def _alive_path() -> Path:
-    return CORES_DIR / f"{_hostname()}.alive"
+    return CORES_DIR / f"core-{_core_id()}.alive"
 
 
 def write_beat(status: str = "running") -> None:
@@ -74,6 +92,7 @@ def write_beat(status: str = "running") -> None:
     target = _alive_path()
     payload = {
         "host": _hostname(),
+        "core_id": _core_id(),
         "pid": os.getpid(),
         "started_at": _STARTED_AT,
         "last_beat_at": time.time(),

--- a/tests/claim-task.test.py
+++ b/tests/claim-task.test.py
@@ -16,6 +16,7 @@ import multiprocessing as mp
 import os
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -134,6 +135,148 @@ class ClaimTaskTests(unittest.TestCase):
     def test_validation_allows_realistic_ids(self):
         self._write_task("1779170589673")
         result = claim("1779170589673", "1", workspace=self.ws)
+        self.assertIsNotNone(result)
+
+
+# ---------------------------------------------------------------------------
+# Channel-affinity tests (#884)
+# ---------------------------------------------------------------------------
+
+from claim_task import claim_with_affinity, ALIVE_THRESHOLD_SEC  # noqa: E402
+
+
+class ChannelAffinityTests(unittest.TestCase):
+    """Sticky-handler semantics: same channel → same core within IDLE_THRESHOLD;
+    dead handler → auto-rebalance within ALIVE_THRESHOLD; idle channel →
+    race-claim."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self.tmp.name)
+        (self.ws / "tasks").mkdir()
+        (self.ws / "state" / "cores").mkdir(parents=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write_task(self, task_id: str) -> Path:
+        p = self.ws / "tasks" / f"task-{task_id}.txt"
+        p.write_text("body\n")
+        return p
+
+    def _touch_alive(self, core_id: str, age_sec: float = 0) -> None:
+        """Write a fresh heartbeat for core <core_id>. age_sec lets the test
+        backdate the mtime to simulate a dead heartbeat."""
+        p = self.ws / "state" / "cores" / f"core-{core_id}.alive"
+        p.write_text(f'{{"core_id": "{core_id}"}}')
+        if age_sec > 0:
+            past = os.path.getmtime(p) - age_sec
+            os.utime(p, (past, past))
+
+    def test_first_task_claims_and_writes_handler(self):
+        self._write_task("a")
+        self._touch_alive("1")
+        result = claim_with_affinity("a", "1", "ch-X", workspace=self.ws)
+        self.assertIsNotNone(result)
+        # Handler should now point to core-1
+        handler_p = self.ws / "state" / "cores" / "channel-ch-X.handler"
+        self.assertTrue(handler_p.exists())
+        import json as _json
+        data = _json.loads(handler_p.read_text())
+        self.assertEqual(data["core_id"], "1")
+        self.assertIn("last_handled_at", data)
+
+    def test_subsequent_task_same_channel_sticks_to_handler(self):
+        # core-1 handles first task in channel ch-X.
+        self._write_task("a")
+        self._touch_alive("1")
+        self._touch_alive("2")
+        claim_with_affinity("a", "1", "ch-X", workspace=self.ws)
+        # Now task-b arrives in same channel. core-2 attempts → should be
+        # refused (handler-respect); core-1 should win.
+        self._write_task("b")
+        c2_attempt = claim_with_affinity("b", "2", "ch-X", workspace=self.ws)
+        self.assertIsNone(c2_attempt, "core-2 should not claim while core-1 is fresh handler")
+        c1_attempt = claim_with_affinity("b", "1", "ch-X", workspace=self.ws)
+        self.assertIsNotNone(c1_attempt, "core-1 should win as fresh handler")
+
+    def test_different_channel_does_not_steal_handler(self):
+        # core-1 handles ch-X. New task in ch-Y → core-2 should be free
+        # to claim it (different channel).
+        self._write_task("a")
+        self._touch_alive("1")
+        self._touch_alive("2")
+        claim_with_affinity("a", "1", "ch-X", workspace=self.ws)
+        self._write_task("b")
+        result = claim_with_affinity("b", "2", "ch-Y", workspace=self.ws)
+        self.assertIsNotNone(result, "core-2 should claim ch-Y (different channel)")
+        # ch-Y handler now points to core-2
+        handler_p = self.ws / "state" / "cores" / "channel-ch-Y.handler"
+        import json as _json
+        self.assertEqual(_json.loads(handler_p.read_text())["core_id"], "2")
+
+    def test_dead_handler_releases_to_other_core(self):
+        # core-1 handles ch-X, then dies. core-2 should be able to claim
+        # the next ch-X task once core-1's heartbeat goes stale.
+        self._write_task("a")
+        self._touch_alive("1")
+        self._touch_alive("2")
+        claim_with_affinity("a", "1", "ch-X", workspace=self.ws)
+        # Backdate core-1's heartbeat — simulate crash.
+        self._touch_alive("1", age_sec=ALIVE_THRESHOLD_SEC + 30)
+        self._touch_alive("2")  # core-2 still fresh
+        self._write_task("b")
+        result = claim_with_affinity("b", "2", "ch-X", workspace=self.ws)
+        self.assertIsNotNone(result, "core-2 should claim ch-X after handler dies")
+        # Handler now points to core-2
+        handler_p = self.ws / "state" / "cores" / "channel-ch-X.handler"
+        import json as _json
+        self.assertEqual(_json.loads(handler_p.read_text())["core_id"], "2")
+
+    def test_idle_channel_releases_for_race(self):
+        # core-1 handles ch-X, then the channel goes idle past IDLE_THRESHOLD.
+        # Next task → race-claim, any core can win.
+        import json as _json
+        self._write_task("a")
+        self._touch_alive("1")
+        self._touch_alive("2")
+        claim_with_affinity("a", "1", "ch-X", workspace=self.ws)
+        # Manually age the handler beyond IDLE_THRESHOLD.
+        handler_p = self.ws / "state" / "cores" / "channel-ch-X.handler"
+        data = _json.loads(handler_p.read_text())
+        data["last_handled_at"] = time.time() - (31 * 60)  # 31 min ago
+        handler_p.write_text(_json.dumps(data))
+        # Now core-2 should be able to claim (race-claim path).
+        self._write_task("b")
+        result = claim_with_affinity("b", "2", "ch-X", workspace=self.ws)
+        self.assertIsNotNone(result, "core-2 should claim after channel idle expires")
+
+    def test_no_channel_id_falls_back_to_plain_claim(self):
+        # channel_id=None: voice tasks etc. Plain race-claim, no handler tracking.
+        self._write_task("a")
+        result = claim_with_affinity("a", "1", None, workspace=self.ws)
+        self.assertIsNotNone(result)
+        # No handler file should be created
+        handlers = list((self.ws / "state" / "cores").glob("channel-*.handler"))
+        self.assertEqual(handlers, [], "no handler file for channel-less task")
+
+    def test_channel_id_validation_rejects_traversal(self):
+        self._write_task("a")
+        self._touch_alive("1")
+        for bad in ["../etc", "a/b", "..", ".", "", ".dotfile"]:
+            with self.assertRaises(ValueError, msg=f"should reject channel_id {bad!r}"):
+                claim_with_affinity("a", "1", bad, workspace=self.ws)
+
+    def test_malformed_handler_falls_back_to_race(self):
+        # If handler file is corrupted (not valid JSON), treat as no handler.
+        self._write_task("a")
+        self._touch_alive("1")
+        self._touch_alive("2")
+        handler_p = self.ws / "state" / "cores" / "channel-ch-X.handler"
+        handler_p.parent.mkdir(parents=True, exist_ok=True)
+        handler_p.write_text("not valid json {{{")
+        # core-2 should be able to claim despite the malformed handler
+        result = claim_with_affinity("a", "2", "ch-X", workspace=self.ws)
         self.assertIsNotNone(result)
 
 

--- a/tests/core-heartbeat.test.py
+++ b/tests/core-heartbeat.test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for src/core_heartbeat.py — per-host liveness signal.
+"""Tests for src/core_heartbeat.py — per-slot liveness signal.
 
 Run: python3 tests/core-heartbeat.test.py
 Exit: 0 on pass, 1 on fail.
@@ -24,33 +24,72 @@ def _short_host() -> str:
 
 class TestHeartbeatWrite(unittest.TestCase):
     def setUp(self):
-        self._saved_env = os.environ.get("SUTANDO_WORKSPACE")
+        self._saved_workspace = os.environ.get("SUTANDO_WORKSPACE")
+        self._saved_core_id = os.environ.get("SUTANDO_CORE_ID")
         self.tmp = Path(tempfile.mkdtemp(prefix="core-heartbeat-"))
         os.environ["SUTANDO_WORKSPACE"] = str(self.tmp)
+        # Unset SUTANDO_CORE_ID by default — tests opt in by setting it.
+        # Default heartbeat path under unset is `core-default.alive`.
+        os.environ.pop("SUTANDO_CORE_ID", None)
         # Force re-import so module picks up the new env.
         sys.modules.pop("core_heartbeat", None)
 
     def tearDown(self):
-        if self._saved_env is not None:
-            os.environ["SUTANDO_WORKSPACE"] = self._saved_env
-        elif "SUTANDO_WORKSPACE" in os.environ:
-            del os.environ["SUTANDO_WORKSPACE"]
+        for k, v in (
+            ("SUTANDO_WORKSPACE", self._saved_workspace),
+            ("SUTANDO_CORE_ID", self._saved_core_id),
+        ):
+            if v is not None:
+                os.environ[k] = v
+            elif k in os.environ:
+                del os.environ[k]
         import shutil
         shutil.rmtree(self.tmp, ignore_errors=True)
         sys.modules.pop("core_heartbeat", None)
 
-    def test_write_beat_creates_per_host_file(self):
+    def test_write_beat_creates_default_slot_file_when_core_id_unset(self):
+        """Legacy single-core path: env var unset → file is `core-default.alive`.
+        Matches the fallback in `_core_id()` and keeps single-core installs
+        working without forcing them to set SUTANDO_CORE_ID."""
         import core_heartbeat
         core_heartbeat.write_beat()
-        alive_path = self.tmp / "state" / "cores" / f"{_short_host()}.alive"
+        alive_path = self.tmp / "state" / "cores" / "core-default.alive"
         self.assertTrue(alive_path.is_file(), f"expected {alive_path} to exist")
 
+    def test_write_beat_creates_per_slot_file_when_core_id_set(self):
+        """Pool path: SUTANDO_CORE_ID=N → file is `core-N.alive`. This is the
+        filename `claim_task.py:_is_alive()` reads; without alignment, the
+        channel-affinity (#884) handler check returns False on every call."""
+        os.environ["SUTANDO_CORE_ID"] = "5"
+        sys.modules.pop("core_heartbeat", None)
+        import core_heartbeat
+        core_heartbeat.write_beat()
+        alive_path = self.tmp / "state" / "cores" / "core-5.alive"
+        self.assertTrue(alive_path.is_file(), f"expected {alive_path} to exist")
+        # And the legacy/default file MUST NOT be written alongside — that
+        # would race with another slot writing the same path.
+        legacy_path = self.tmp / "state" / "cores" / "core-default.alive"
+        self.assertFalse(legacy_path.exists(), "default slot file leaked while CORE_ID was set")
+
+    def test_blank_core_id_falls_back_to_default(self):
+        """Whitespace-only / empty env value collapses to `default` rather
+        than producing the malformed filename `core-.alive`."""
+        os.environ["SUTANDO_CORE_ID"] = "   "
+        sys.modules.pop("core_heartbeat", None)
+        import core_heartbeat
+        core_heartbeat.write_beat()
+        self.assertTrue((self.tmp / "state" / "cores" / "core-default.alive").is_file())
+        self.assertFalse((self.tmp / "state" / "cores" / "core-.alive").exists())
+
     def test_write_beat_payload_schema(self):
+        os.environ["SUTANDO_CORE_ID"] = "2"
+        sys.modules.pop("core_heartbeat", None)
         import core_heartbeat
         core_heartbeat.write_beat(status="custom-status")
-        data = json.loads((self.tmp / "state" / "cores" / f"{_short_host()}.alive").read_text())
+        data = json.loads((self.tmp / "state" / "cores" / "core-2.alive").read_text())
         # Required fields
         self.assertEqual(data["host"], _short_host())
+        self.assertEqual(data["core_id"], "2")
         self.assertEqual(data["pid"], os.getpid())
         self.assertEqual(data["status"], "custom-status")
         self.assertEqual(data["schema_version"], 1)
@@ -64,15 +103,15 @@ class TestHeartbeatWrite(unittest.TestCase):
         a concurrent reader at the destination path never sees a half-file."""
         import core_heartbeat
         core_heartbeat.write_beat()
-        alive = self.tmp / "state" / "cores" / f"{_short_host()}.alive"
-        tmp = self.tmp / "state" / "cores" / f"{_short_host()}.alive.tmp"
+        alive = self.tmp / "state" / "cores" / "core-default.alive"
+        tmp = self.tmp / "state" / "cores" / "core-default.alive.tmp"
         self.assertTrue(alive.exists())
         self.assertFalse(tmp.exists(), "tmp file should have been renamed away")
 
     def test_write_beat_overwrites_on_second_call(self):
         import core_heartbeat
         core_heartbeat.write_beat(status="first")
-        path = self.tmp / "state" / "cores" / f"{_short_host()}.alive"
+        path = self.tmp / "state" / "cores" / "core-default.alive"
         first_data = json.loads(path.read_text())
         time.sleep(0.01)
         core_heartbeat.write_beat(status="second")
@@ -99,7 +138,11 @@ class TestHeartbeatCli(unittest.TestCase):
 
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp(prefix="core-heartbeat-cli-"))
-        self.env = {**os.environ, "SUTANDO_WORKSPACE": str(self.tmp)}
+        # CLI tests exercise the pool path: pin SUTANDO_CORE_ID to a known
+        # value so we can assert against `core-<id>.alive` deterministically.
+        # Strip any inherited SUTANDO_CORE_ID first to avoid env leakage.
+        base_env = {k: v for k, v in os.environ.items() if k != "SUTANDO_CORE_ID"}
+        self.env = {**base_env, "SUTANDO_WORKSPACE": str(self.tmp), "SUTANDO_CORE_ID": "3"}
 
     def tearDown(self):
         import shutil
@@ -112,10 +155,11 @@ class TestHeartbeatCli(unittest.TestCase):
             env=self.env, capture_output=True, text=True, timeout=10,
         )
         self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
-        alive = self.tmp / "state" / "cores" / f"{_short_host()}.alive"
+        alive = self.tmp / "state" / "cores" / "core-3.alive"
         self.assertTrue(alive.is_file())
         data = json.loads(alive.read_text())
         self.assertEqual(data["status"], "smoke")
+        self.assertEqual(data["core_id"], "3")
 
     def test_sigterm_cleans_up_alive_file(self):
         """Graceful shutdown removes the .alive file so peers see the core
@@ -127,7 +171,7 @@ class TestHeartbeatCli(unittest.TestCase):
             env=self.env,
         )
         # Wait for first beat to land.
-        alive = self.tmp / "state" / "cores" / f"{_short_host()}.alive"
+        alive = self.tmp / "state" / "cores" / "core-3.alive"
         for _ in range(40):
             if alive.exists():
                 break


### PR DESCRIPTION
## Summary

Phase 2c of the multi-core agent pool — channel-affinity with sticky-handler + idle-release + dead-handler-failover semantics. **Stacked on PR #883**.

**Closes #884.** Tracks the parent #880.

## Algorithm

`claim_with_affinity(task_id, core_id, channel_id)` in `src/claim_task.py`:

| Handler state | Action |
|---|---|
| Fresh (mtime < 30min) AND alive (heartbeat < 90s) AND me → claim, refresh handler |
| Fresh AND alive AND not me → return None (respect handler) |
| Fresh AND dead (heartbeat stale) → race-claim, winner takes over |
| Idle (mtime > 30min) OR missing → race-claim, winner writes handler |

Voice / un-channeled tasks (`channel_id=None`) bypass → plain race-claim.

`IDLE_THRESHOLD` (default 30 min) configurable via `SUTANDO_CORE_IDLE_THRESHOLD_SEC`.

## Eval (per always-propose-eval rule)

**Synthetic correctness — CI-gating (8 new tests + 7 existing = 15 total):**

- first task claims AND writes handler ✓
- subsequent task same channel sticks to handler core ✓
- different channel does NOT steal handler ✓
- dead handler releases to other core (heartbeat-aged via `os.utime`) ✓
- idle channel releases for race (handler mtime-aged past 30 min) ✓
- channel_id=None falls back to plain claim, no handler file written ✓
- channel_id validation rejects path traversal (`..`, `/`, `.dotfile`) ✓
- malformed handler JSON treated as missing (forward-progress, no deadlock) ✓

**Real-user demo (per owner request):**
`scripts/pool-metrics.py --since 15` produces the eval numbers the owner asked for. Output sections:
- Pool totals: **total task time** (sum of per-task latency), **wallclock time** (max end - min start), speedup ratio.
- Per-channel rollup: tasks, avg latency, cores-seen.
- Per-core rollup: tasks, total time, channels handled.
- Channel-affinity health check: flags any channel served by >1 core within window.

Smoke-tested against the live workspace; output renders correctly.

## How owner tests (post-merge of #882, #883, this)

```bash
git pull
bash skills/install.sh
# Add to .env:  SUTANDO_CORE_POOL_SIZE=3
bash src/startup.sh
# Create 6 channels in Sutando server, post bursts of related tasks each.
# Wait for them to drain, then:
python3 scripts/pool-metrics.py --since 15
```

Expected: speedup ratio >1.5x; "every channel served by exactly one core" ✓.

## Phase 2c-known-limitations

- **Side-effect helper done-flag gate still not wired in** (Phase 2d). Crash-then-replay window can fire a side effect twice; rare given heartbeat freshness.
- **Boot-time orphan-scan watchdog still not wired in** (Phase 2d). A session that claims and then crashes leaves the claim file stranded until owner manually renames it back. Mitigation: pool restart via `bash scripts/uninstall-core-pool.sh && bash src/startup.sh` releases all orphans.

## Test plan

- [x] `python3 tests/claim-task.test.py` — 15/15 pass
- [x] `python3 scripts/pool-metrics.py --since 60` smoke test on live workspace — renders correct output
- [x] No new ESLint / type errors (`npx tsc --noEmit` clean — no TS changes in this PR)
- [ ] Owner local install test (planned: 6-channel burst test)

Stacks on #883 (Phase 2b stub). Eventually rebases to main once #882 → #883 → this merge sequence completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)