### PR TITLE
fix(context-drop): detect empty Cmd+C via changeCount, stop dropping stale clipboard

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -1315,9 +1315,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // 5. Fallback: simulate Cmd+C, read clipboard
+        //
+        // Detect a real copy via NSPasteboard.changeCount (mirrors ax-read.swift in
+        // skills/personal-deictic). Without this, contenteditable surfaces (Discord
+        // input box, Notion, Slack, Linear, etc.) silently fall through: AX returns
+        // empty, simulated Cmd+C produces no copy when there's no highlighted range,
+        // and the read just picks up whatever was already on the clipboard — the
+        // drop then writes stale content. The changeCount check distinguishes
+        // "copy fired" from "clipboard was already populated" cleanly.
+        let pb = NSPasteboard.general
+        let priorChangeCount = pb.changeCount
         simulateCopy()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [self] in
-            if let text = NSPasteboard.general.string(forType: .string), !text.isEmpty {
+            if pb.changeCount > priorChangeCount,
+               let text = pb.string(forType: .string), !text.isEmpty {
                 let content = """
                 timestamp: \(timestamp)
                 type: text
@@ -1329,8 +1340,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 let snippet = String(text.prefix(80)).replacingOccurrences(of: "\n", with: " ")
                 notify("Sutando", "Dropped: \(snippet)\(text.count > 80 ? "…" : "")")
             } else {
-                notify("Sutando", "Nothing selected — select text first")
-                appendLog(logFile, "[\(timestamp)] Nothing selected")
+                notify("Sutando", "Nothing selected — highlight text first")
+                appendLog(logFile, "[\(timestamp)] Nothing selected (changeCount unchanged after Cmd+C)")
             }
         }
     }


### PR DESCRIPTION
## Summary
- ⌃C hotkey in Discord (and other contenteditable surfaces: Notion, Slack, Linear, etc.) was silently dropping whatever was on the clipboard instead of the user's current selection
- Root cause: AX returns empty for Electron contenteditable DIVs → fallback simulate Cmd+C produces no actual copy when there's no highlighted range → `NSPasteboard.string()` returns the prior clipboard contents → drop writes stale data
- Fix: snapshot `NSPasteboard.changeCount` before `simulateCopy()`, only accept the post-Cmd+C string if `changeCount` actually incremented. Same primitive `ax-read.swift` (skills/personal-deictic) uses for the voice agent's `read_selection` tool — bringing menubar-app ⌃C to parity.
- 14 LoC change in `dropContext()`. No new dependencies, no permission changes.

## Test plan
- [x] `swiftc -parse` clean
- [ ] Rebuild Sutando.app, install, grant Accessibility
- [ ] Repro the bug first: copy text in TextEdit → switch to Discord → click into input box (no selection) → ⌃C → confirm OLD behavior drops the TextEdit content
- [ ] Apply fix, rebuild, repeat → confirm NEW behavior notifies "Nothing selected — highlight text first" and does NOT write a stale task
- [ ] Positive path still works: select text in TextEdit → ⌃C → confirm dropped content matches selection (regression check on the happy path)
- [ ] Test in another contenteditable: Notion / Slack / Linear input → confirm same "Nothing selected" notification

## Context
Chi hit this today (2026-05-19): tried ⌃C from Discord input box, got dropped a copy of the Arize email from 2 minutes earlier. Investigation showed the Discord contenteditable + AX-empty + Cmd+C-noop + stale-clipboard pipeline. Voice agent's `read_selection` doesn't have this bug because `ax-read.swift` already uses the `changeCount` check (added per Chi 2026-05-13 X-compose-empty-selection regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)