### PR TITLE
feat(slack-bridge): per-event access.json state probe to catch #899's wipe-race

### DIFF
--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -271,6 +271,21 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
     if not user_id:
         return None
 
+    # Per-event state probe — captures whether ACCESS_FILE exists at the moment
+    # _write_task runs, and its mtime if it does. This is the instrumentation
+    # asked for by #899 (intermittent file wipe + re-TOFU despite the race-guard
+    # in tofu_onboard). The wipe must be happening externally (Sutando.app
+    # Settings UI, manual rm, or an undiscovered code path), and the only way
+    # to catch it is to log the file's state on every inbound event. One line
+    # per event; cheap; bridges already log per-event.
+    try:
+        af_exists = ACCESS_FILE.exists()
+        af_mtime = ACCESS_FILE.stat().st_mtime if af_exists else None
+        print(f"  [access-probe] file_present={af_exists} mtime={af_mtime}", flush=True)
+    except Exception:
+        # Don't let a probe failure block real work; just skip the log line.
+        pass
+
     # Access control via TOFU
     allowed = load_allowed()
     if allowed is None:


### PR DESCRIPTION
Lands the cheap-instrumentation option from #899.

## What

Adds one log line at the top of `_write_task()`:

```
[access-probe] file_present=<bool> mtime=<float|None>
```

Wrapped in try/except so a probe failure can't block real work.

## Why

#899 reports `~/.claude/channels/slack/access.json` getting wiped and re-TOFU'd despite the race-guard in `tofu_onboard()` (`if ACCESS_FILE.exists(): return ...`). The wipe must be happening externally (Sutando.app Settings UI / manual rm / an undiscovered code path) — codebase grep + skills-dir grep turned up no in-tree deleter.

The probe brackets the next deletion to a ~5-second window between events, so a follow-up `fs_usage -f filesys ~/.claude/channels/slack/access.json` capture can identify the deleter PID. Without this we have no way to correlate.

## Cost

One print per inbound Slack event. Bridges already log per-event (`Wrote task ...`, `Replied to ...`); marginal noise is negligible.

## Test plan

- [x] `tests/slack-bridge-access.test.py` still passes (structural regex; no change to fail-closed behavior)
- [x] `tests/slack-bridge-tier-map.test.py` still passes (tierMap resolution unchanged)
- [x] `python3 -c "import ast; ast.parse(open('src/slack-bridge.py').read())"` clean
- [ ] After merge + bridge restart, next wipe (if it recurs) leaves a `file_present=False` line correlating with the deletion

Closes part of #899 (instrumentation only; the root-cause investigation continues).