### PR TITLE
fix(context-drop): TCC-stable AX trust + flipped priority + region-capture fallback

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -1,6 +1,7 @@
 import Cocoa
 import Carbon
 import UserNotifications
+import ApplicationServices
 
 // MARK: - Sutando Drop Menu Bar App
 // Replaces Automator Quick Action for context drops.
@@ -13,6 +14,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var hotKeyRefs: [EventHotKeyRef?] = []  // one entry per registered hotkey
     var hotKeyActions: [UInt32: String] = [:]  // hotkey id → action name
     var lastDropTime: Date = .distantPast
+    var screencaptureInFlight: Bool = false  // guards against stacked crosshair launches
     // Runtime state lives under the per-user workspace dir, not the repo
     // checkout. Mirrors src/workspace_default.py + src/workspace_default.ts
     // (PR #762 / #821). Resolution:
@@ -109,6 +111,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         DispatchQueue.main.async { [self] in
             setupMenuBar()
+            // Check Accessibility trust at startup. AX-related features
+            // (kAXSelectedTextAttribute reads in dropContext, synthetic Cmd+C
+            // via CGEventPost) silently fail when the bundle's TCC entry is
+            // stale — usually after a codesign identity change. Empirical
+            // case 2026-05-19: dropContext started returning "Nothing
+            // selected" for every app (Discord and TextEdit both) after
+            // Sutando.app was re-signed (ad-hoc Identifier=Sutando →
+            // cert-signed Identifier=com.sutando.menubar). The Accessibility
+            // TCC entry from the prior signature didn't transfer to the new
+            // binary; macOS silently returned AX errors without re-prompting.
+            // AXIsProcessTrustedWithOptions with prompt=true forces a
+            // re-bind: if the running binary's signature doesn't match any
+            // granted TCC row, the standard "Sutando wants Accessibility"
+            // dialog opens, and on Allow the TCC entry is recreated against
+            // the current signature. Idempotent when already trusted
+            // (returns true, no dialog). The result is also logged so future
+            // drift surfaces in the debug log on session 0.
+            let axOpts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+            let axTrusted = AXIsProcessTrustedWithOptions(axOpts)
+            logToFile("startup: AXIsProcessTrusted=\(axTrusted)")
             registerHotKey()
             watchResults()
             logToFile("App started, workspace=\(workspace)")
@@ -1261,78 +1283,233 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        // 2. Check clipboard for image (PNG)
-        if let imageData = NSPasteboard.general.data(forType: .png) {
-            do {
-                try imageData.write(to: URL(fileURLWithPath: dropImage))
-                let content = """
-                timestamp: \(timestamp)
-                type: image
-                path: \(dropImage)
-                \(ctxHeader)---
-                [Image dropped from clipboard]
-                """
-                appendLog(logFile, "[\(timestamp)] Dropped: image (\(imageData.count) bytes)")
-                writeTask(tasksDir, timestamp: timestamp, content: content)
-                notify("Sutando", "Image dropped (\(imageData.count / 1024)KB)")
-                return
-            } catch {}
-        }
-
-        // 3. Check clipboard for TIFF image (screenshots sometimes use TIFF)
-        if let tiffData = NSPasteboard.general.data(forType: .tiff),
-           let bitmapRep = NSBitmapImageRep(data: tiffData),
-           let pngData = bitmapRep.representation(using: .png, properties: [:]) {
-            do {
-                try pngData.write(to: URL(fileURLWithPath: dropImage))
-                let content = """
-                timestamp: \(timestamp)
-                type: image
-                path: \(dropImage)
-                \(ctxHeader)---
-                [Image dropped from clipboard]
-                """
-                appendLog(logFile, "[\(timestamp)] Dropped: image (\(pngData.count) bytes)")
-                writeTask(tasksDir, timestamp: timestamp, content: content)
-                notify("Sutando", "Image dropped (\(pngData.count / 1024)KB)")
-                return
-            } catch {}
-        }
-
-        // 4. Try to get selected text via Accessibility API
-        if let selected = getSelectedText(), !selected.isEmpty {
+        // Drop-resolution chain. All text paths run before any image path so
+        // lingering clipboard screenshots don't pre-empt selected-text drops.
+        //
+        // Text-emit helper — captures the AX/clipboard metadata block if
+        // present, writes the task, notifies. Returns true on success.
+        let emitText: (String, String?, String?, String?, String?, String) -> Void = {
+            [self] (selected, app, windowTitle, urlVal, axPath, source) in
+            var meta: [String] = []
+            if let a = app, !a.isEmpty { meta.append("app: \(a)") }
+            if let w = windowTitle, !w.isEmpty { meta.append("window: \(w)") }
+            if let u = urlVal, !u.isEmpty { meta.append("url: \(u)") }
+            if let p = axPath, !p.isEmpty { meta.append("ax_path: \(p)") }
+            let metaBlock = meta.isEmpty ? "" : meta.joined(separator: "\n") + "\n"
             let content = """
             timestamp: \(timestamp)
             type: text
-            \(ctxHeader)---
+            \(metaBlock)\(ctxHeader)---
             \(selected)
             """
-            appendLog(logFile, "[\(timestamp)] Dropped: \(selected.count) chars")
+            appendLog(logFile, "[\(timestamp)] Dropped: \(selected.count) chars (\(source))")
             writeTask(tasksDir, timestamp: timestamp, content: content)
             let snippet = String(selected.prefix(80)).replacingOccurrences(of: "\n", with: " ")
             notify("Sutando", "Dropped: \(snippet)\(selected.count > 80 ? "…" : "")")
+        }
+
+        // 2. ax-read (preferred text path; subprocess, has changeCount-safe
+        //    clipboard fallback + restores prior pasteboard).
+        if let axRead = invokeAxRead() {
+            let selected = (axRead["selected"] as? String) ?? ""
+            if !selected.isEmpty {
+                emitText(selected,
+                         axRead["app"] as? String,
+                         axRead["window_title"] as? String,
+                         axRead["url"] as? String,
+                         axRead["path"] as? String,
+                         "ax-read")
+                return
+            }
+        }
+
+        // 3. Legacy in-process AX (fallback when ax-read binary missing).
+        if let selected = getSelectedText(), !selected.isEmpty {
+            emitText(selected, nil, nil, nil, nil, "legacy-ax")
             return
         }
 
-        // 5. Fallback: simulate Cmd+C, read clipboard
+        // 4. Legacy Cmd+C simulation with changeCount guard. Async wait so the
+        //    main run loop is free to deliver the synthetic event. If still no
+        //    text after the wait, fall through to image branches and finally
+        //    the interactive screencapture fallback.
+        let pb = NSPasteboard.general
+        let priorChangeCount = pb.changeCount
         simulateCopy()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [self] in
-            if let text = NSPasteboard.general.string(forType: .string), !text.isEmpty {
-                let content = """
-                timestamp: \(timestamp)
-                type: text
-                \(ctxHeader)---
-                \(text)
-                """
-                appendLog(logFile, "[\(timestamp)] Dropped: \(text.count) chars")
-                writeTask(tasksDir, timestamp: timestamp, content: content)
-                let snippet = String(text.prefix(80)).replacingOccurrences(of: "\n", with: " ")
-                notify("Sutando", "Dropped: \(snippet)\(text.count > 80 ? "…" : "")")
-            } else {
-                notify("Sutando", "Nothing selected — select text first")
-                appendLog(logFile, "[\(timestamp)] Nothing selected")
+            if pb.changeCount > priorChangeCount,
+               let text = pb.string(forType: .string), !text.isEmpty {
+                emitText(text, nil, nil, nil, nil, "legacy-cmd+c")
+                return
+            }
+
+            // 5. Clipboard PNG.
+            if let imageData = pb.data(forType: .png) {
+                do {
+                    try imageData.write(to: URL(fileURLWithPath: dropImage))
+                    let content = """
+                    timestamp: \(timestamp)
+                    type: image
+                    path: \(dropImage)
+                    \(ctxHeader)---
+                    [Image dropped from clipboard]
+                    """
+                    appendLog(logFile, "[\(timestamp)] Dropped: image (\(imageData.count) bytes, clipboard-png)")
+                    writeTask(tasksDir, timestamp: timestamp, content: content)
+                    notify("Sutando", "Image dropped (\(imageData.count / 1024)KB)")
+                    return
+                } catch {}
+            }
+
+            // 6. Clipboard TIFF (some screenshot tools).
+            if let tiffData = pb.data(forType: .tiff),
+               let bitmapRep = NSBitmapImageRep(data: tiffData),
+               let pngData = bitmapRep.representation(using: .png, properties: [:]) {
+                do {
+                    try pngData.write(to: URL(fileURLWithPath: dropImage))
+                    let content = """
+                    timestamp: \(timestamp)
+                    type: image
+                    path: \(dropImage)
+                    \(ctxHeader)---
+                    [Image dropped from clipboard]
+                    """
+                    appendLog(logFile, "[\(timestamp)] Dropped: image (\(pngData.count) bytes, clipboard-tiff→png)")
+                    writeTask(tasksDir, timestamp: timestamp, content: content)
+                    notify("Sutando", "Image dropped (\(pngData.count / 1024)KB)")
+                    return
+                } catch {}
+            }
+
+            // 7. Last resort: interactive region capture. Esc cancels. Run on
+            //    a background queue so the main run loop stays responsive
+            //    while the user drags (waitUntilExit can take many seconds).
+            //    In-flight guard prevents stacked crosshairs from rapid ⌃C.
+            if self.screencaptureInFlight {
+                appendLog(logFile, "[\(timestamp)] screencapture already in flight, skipping")
+                return
+            }
+            self.screencaptureInFlight = true
+            appendLog(logFile, "[\(timestamp)] launching screencapture -i -c")
+            let priorPbChange = pb.changeCount
+            DispatchQueue.global(qos: .userInitiated).async { [self] in
+                defer { DispatchQueue.main.async { self.screencaptureInFlight = false } }
+                let cap = Process()
+                cap.launchPath = "/usr/sbin/screencapture"
+                cap.arguments = ["-i", "-c"]
+                cap.standardOutput = Pipe()
+                cap.standardError = Pipe()
+                do {
+                    try cap.run()
+                    cap.waitUntilExit()
+                } catch {
+                    DispatchQueue.main.async { [self] in
+                        appendLog(logFile, "[\(timestamp)] screencapture failed: \(error.localizedDescription)")
+                        notify("Sutando", "Nothing selected — screencapture unavailable")
+                    }
+                    return
+                }
+                DispatchQueue.main.async { [self] in
+                    if pb.changeCount > priorPbChange {
+                        if let png = pb.data(forType: .png) {
+                            do {
+                                try png.write(to: URL(fileURLWithPath: dropImage))
+                                let content = """
+                                timestamp: \(timestamp)
+                                type: image
+                                path: \(dropImage)
+                                \(ctxHeader)---
+                                [Image dropped via screen-region capture]
+                                """
+                                appendLog(logFile, "[\(timestamp)] Dropped: image (\(png.count) bytes, screencapture-region)")
+                                writeTask(tasksDir, timestamp: timestamp, content: content)
+                                notify("Sutando", "Region captured (\(png.count / 1024)KB)")
+                                return
+                            } catch {}
+                        }
+                        if let tiff = pb.data(forType: .tiff),
+                           let rep = NSBitmapImageRep(data: tiff),
+                           let png = rep.representation(using: .png, properties: [:]) {
+                            do {
+                                try png.write(to: URL(fileURLWithPath: dropImage))
+                                let content = """
+                                timestamp: \(timestamp)
+                                type: image
+                                path: \(dropImage)
+                                \(ctxHeader)---
+                                [Image dropped via screen-region capture]
+                                """
+                                appendLog(logFile, "[\(timestamp)] Dropped: image (\(png.count) bytes, screencapture-region tiff→png)")
+                                writeTask(tasksDir, timestamp: timestamp, content: content)
+                                notify("Sutando", "Region captured (\(png.count / 1024)KB)")
+                                return
+                            } catch {}
+                        }
+                    }
+                    notify("Sutando", "Cancelled — nothing dropped")
+                    appendLog(logFile, "[\(timestamp)] cancelled (screencapture esc / no clipboard change)")
+                }
             }
         }
+    }
+
+    // MARK: - ax-read subprocess (voice agent's read_selection primitive)
+    //
+    // Resolution order for the binary path:
+    //   1. $SUTANDO_MEMORY_DIR/skills/personal-deictic/ax-read  (current canonical)
+    //   2. $SUTANDO_PRIVATE_DIR/skills/personal-deictic/ax-read (legacy alias, PR #876)
+    //   3. ~/.sutando/memory-sync/skills/personal-deictic/ax-read (default)
+    //
+    // Returns nil when the binary is missing, doesn't execute cleanly, or
+    // returns malformed JSON — callers fall back to the legacy in-process path.
+
+    func resolveAxReadPath() -> String? {
+        let env = ProcessInfo.processInfo.environment
+        let suffix = "/skills/personal-deictic/ax-read"
+        let candidates = [
+            env["SUTANDO_MEMORY_DIR"].map { $0 + suffix },
+            env["SUTANDO_PRIVATE_DIR"].map { $0 + suffix },
+            NSString(string: "~/.sutando/memory-sync" + suffix).expandingTildeInPath,
+        ].compactMap { $0 }
+        let fm = FileManager.default
+        for path in candidates {
+            if fm.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+        return nil
+    }
+
+    func invokeAxRead() -> [String: Any]? {
+        guard let binPath = resolveAxReadPath() else { return nil }
+        let task = Process()
+        task.launchPath = binPath
+        task.arguments = []
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        task.standardOutput = outPipe
+        task.standardError = errPipe
+        do {
+            try task.run()
+        } catch {
+            return nil
+        }
+        // 3s deadline matches ax-read's max screencapture timeout (1s) plus
+        // headroom for Cmd+C fallback wait (120ms). Anything longer means the
+        // subprocess is stuck — fall back to legacy.
+        let deadline = Date().addingTimeInterval(3.0)
+        while task.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        if task.isRunning {
+            task.terminate()
+            return nil
+        }
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json
     }
 
     // MARK: - Screenshot Drop (⌥C)

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -253,8 +253,26 @@ if [ -f "$SUT_SRC" ] && { [ ! -f "$SUT_BIN" ] || [ "$SUT_SRC" -nt "$SUT_BIN" ]; 
       /usr/libexec/PlistBuddy \
         -c "Add :NSAppleEventsUsageDescription string 'Sutando reads your Finder selection to drop files into the agent task queue.'" \
         "$SUT_APP/Contents/Info.plist" 2>/dev/null || true
-      codesign --force --sign - "$SUT_APP" 2>/dev/null || true
-      echo "  ✓ Sutando.app synced + signed"
+      # Prefer a stable signing identity when one is installed so the TCC
+      # Accessibility grant survives rebuilds (cdhash churn). Falls back to
+      # ad-hoc when no such identity exists — public-repo users without a
+      # personal signing cert get the same behavior as before.
+      #
+      # The designated requirement is identifier-only on purpose: the
+      # grant binds to the bundle ID rather than cdhash, so a rebuild
+      # against the same identity satisfies the requirement without
+      # re-prompting. For installs without a cert, ad-hoc still requires
+      # re-grant on each rebuild — same as the legacy behavior.
+      SUT_SIGN_ID="$(security find-identity -v -p codesigning 2>/dev/null | awk '/"Sutando Dev"/{print $2; exit}')"
+      if [ -n "$SUT_SIGN_ID" ]; then
+        codesign --force --sign "$SUT_SIGN_ID" --identifier com.sutando.menubar \
+          --requirements '=designated => identifier "com.sutando.menubar"' \
+          "$SUT_APP" 2>/dev/null || codesign --force --sign - "$SUT_APP" 2>/dev/null || true
+        echo "  ✓ Sutando.app synced + signed (Sutando Dev + identifier-only DR)"
+      else
+        codesign --force --sign - "$SUT_APP" 2>/dev/null || true
+        echo "  ✓ Sutando.app synced + signed (ad-hoc; install \"Sutando Dev\" cert for stable TCC)"
+      fi
     fi
 
     if pgrep -f "src/Sutando/Sutando" > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Three changes on top of PR #891's ax-read subprocess groundwork to make ⌃C reliable:

1. **`AXIsProcessTrustedWithOptions(prompt:true)` at startup** — re-binds TCC Accessibility to the current binary after codesign identity changes. Without this, the prior grant orphans silently and AX queries fail with no re-prompt. The 2026-05-19 incident: I re-signed Sutando.app (ad-hoc → "Sutando Dev" cert) and AX queries started returning empty for every app (Discord *and* native TextEdit) despite the System Settings toggle still appearing on. `AXIsProcessTrusted=false` at startup proved it.
2. **Reorder dropContext: all text paths before all image paths.** Lingering screenshots were pre-empting text-selection drops — ⌃C with selected text in Discord would drop yesterday's PNG. New chain: ax-read → legacy AX → legacy Cmd+C with `changeCount` guard → clipboard PNG → clipboard TIFF → screen-region capture.
3. **`screencapture -i -c` last-resort fallback.** When nothing matched anywhere, instead of "Nothing selected" macOS now draws the crosshair so the user can drag-select a region to drop. Esc cancels cleanly. Runs on a background `DispatchQueue` so the main run loop stays responsive while the user drags. `screencaptureInFlight` instance bool guards against stacked crosshairs from rapid ⌃C.

## Why subprocess `invokeAxRead` works from the menu-bar agent now

The earlier failure mode in PR #891 (subprocess AX returning empty when spawned from `Sutando.app` LSUIElement=YES process context) was a TCC attribution issue, not a fundamental macOS quirk. The OS attributes the child's AX queries up the responsible-process chain to `Sutando.app`. When the bundle's TCC Accessibility entry didn't match the running binary's signature (cdhash mismatch from the prior ad-hoc sign), the AX queries silently returned empty for **every** target app — Discord, TextEdit, all of them. The startup `AXIsProcessTrustedWithOptions` call now forces a re-bind on first launch after any signature change, so the spawned `ax-read` inherits a current grant. Verified locally: with `AXIsProcessTrusted=true`, the subprocess returns `path=ax` for Discord selections.

## Out-of-band: codesign DR for cdhash stability

The startup AX-trust prompt only helps if the *grant* persists across rebuilds. For self-signed certs that aren't in the system trust store, TCC falls back to cdhash matching — every rebuild orphans the grant. Fix is to embed a permissive designated requirement at sign time:

```bash
codesign --force --sign <ident> \
  --requirements '=designated => identifier "com.sutando.menubar"' \
  Sutando.app
```

Then TCC stores the requirement at grant time and future rebuilds (same identifier, different cdhash) keep working. `src/startup.sh` now detects a "Sutando Dev" cert in the keychain and applies this requirement automatically; without that cert it falls back to ad-hoc (legacy behavior). Verified locally: rebuilt with different cdhash, `AXIsProcessTrusted=true` on first run.

A bare identifier-only DR is permissive — any binary signed with the same identifier inherits the grant. Stronger would be `identifier + anchor apple generic + cert leaf[Y]`. The permissive form is fine for personal-use Sutando but flagged here in case a future user installs an Apple Dev cert and wants tighter binding.

## Test plan

- [x] ⌃C with text selected in Discord → drops via ax-read (`path=ax`)
- [x] ⌃C with image in clipboard + text selected in Discord → text wins (regression of original image-pre-emption fixed)
- [x] ⌃C with nothing selected anywhere → screencapture crosshair fires
- [x] Esc during screencapture → "Cancelled — nothing dropped"
- [x] Rebuild stability: different cdhash + same identifier → AX trust persists
- [x] CI green (tsc + tests, license/cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)