### PR TITLE
feat(telegram-bridge): preserve forward-from attribution in task body

### DIFF
--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -98,6 +98,42 @@ TASKS_DIR.mkdir(parents=True, exist_ok=True)
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
 
+def extract_forward_note(msg: dict) -> str:
+    """Return a ` [forwarded from ...]` suffix for a Telegram message dict.
+
+    Handles Bot API 7.0+ `forward_origin` (user / hidden_user / chat / channel)
+    and legacy `forward_from` / `forward_sender_name`. Returns "" for
+    non-forwarded messages or unknown `forward_origin.type` values so the
+    bridge fails open rather than crashing on future Telegram additions.
+    """
+    fwd_origin = msg.get("forward_origin") or {}
+    if fwd_origin:
+        fwd_type = fwd_origin.get("type")
+        if fwd_type == "user":
+            u = fwd_origin.get("sender_user", {})
+            name = u.get("username") or u.get("first_name") or "unknown"
+            return f" [forwarded from @{name}]"
+        if fwd_type == "hidden_user":
+            name = fwd_origin.get("sender_user_name", "hidden")
+            return f" [forwarded from {name}]"
+        if fwd_type == "chat":
+            chat = fwd_origin.get("sender_chat", {})
+            name = chat.get("title") or chat.get("username") or "channel"
+            return f" [forwarded from chat: {name}]"
+        if fwd_type == "channel":
+            chat = fwd_origin.get("chat", {})
+            name = chat.get("title") or chat.get("username") or "channel"
+            return f" [forwarded from channel: {name}]"
+        return ""
+    if "forward_from" in msg:
+        u = msg["forward_from"]
+        name = u.get("username") or u.get("first_name") or "unknown"
+        return f" [forwarded from @{name}]"
+    if "forward_sender_name" in msg:
+        return f" [forwarded from {msg['forward_sender_name']}]"
+    return ""
+
+
 def write_owner_activity(channel: str, summary: str) -> None:
     """Record owner activity — see src/discord-bridge.py for schema."""
     try:
@@ -387,38 +423,7 @@ def main():
                 if not text and not attachment_note:
                     continue
 
-                # Forwarded message attribution. Telegram populates
-                # `forward_origin` (Bot API 7.0+) or the legacy `forward_from` /
-                # `forward_sender_name` fields when the user forwards a message.
-                # Without this, the bridge attributes Boris-forwarded-by-Chi
-                # to Chi alone and the original sender's name disappears.
-                forward_note = ""
-                fwd_origin = msg.get("forward_origin") or {}
-                if fwd_origin:
-                    fwd_type = fwd_origin.get("type")
-                    if fwd_type == "user":
-                        u = fwd_origin.get("sender_user", {})
-                        name = u.get("username") or u.get("first_name") or "unknown"
-                        forward_note = f" [forwarded from @{name}]"
-                    elif fwd_type == "hidden_user":
-                        name = fwd_origin.get("sender_user_name", "hidden")
-                        forward_note = f" [forwarded from {name}]"
-                    elif fwd_type == "chat":
-                        chat = fwd_origin.get("sender_chat", {})
-                        name = chat.get("title") or chat.get("username") or "channel"
-                        forward_note = f" [forwarded from chat: {name}]"
-                    elif fwd_type == "channel":
-                        chat = fwd_origin.get("chat", {})
-                        name = chat.get("title") or chat.get("username") or "channel"
-                        forward_note = f" [forwarded from channel: {name}]"
-                else:
-                    # Legacy fallback for older Bot API responses.
-                    if "forward_from" in msg:
-                        u = msg["forward_from"]
-                        name = u.get("username") or u.get("first_name") or "unknown"
-                        forward_note = f" [forwarded from @{name}]"
-                    elif "forward_sender_name" in msg:
-                        forward_note = f" [forwarded from {msg['forward_sender_name']}]"
+                forward_note = extract_forward_note(msg)
 
                 print(f"  @{username}{forward_note}: {text}{attachment_note}")
 

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -387,7 +387,40 @@ def main():
                 if not text and not attachment_note:
                     continue
 
-                print(f"  @{username}: {text}{attachment_note}")
+                # Forwarded message attribution. Telegram populates
+                # `forward_origin` (Bot API 7.0+) or the legacy `forward_from` /
+                # `forward_sender_name` fields when the user forwards a message.
+                # Without this, the bridge attributes Boris-forwarded-by-Chi
+                # to Chi alone and the original sender's name disappears.
+                forward_note = ""
+                fwd_origin = msg.get("forward_origin") or {}
+                if fwd_origin:
+                    fwd_type = fwd_origin.get("type")
+                    if fwd_type == "user":
+                        u = fwd_origin.get("sender_user", {})
+                        name = u.get("username") or u.get("first_name") or "unknown"
+                        forward_note = f" [forwarded from @{name}]"
+                    elif fwd_type == "hidden_user":
+                        name = fwd_origin.get("sender_user_name", "hidden")
+                        forward_note = f" [forwarded from {name}]"
+                    elif fwd_type == "chat":
+                        chat = fwd_origin.get("sender_chat", {})
+                        name = chat.get("title") or chat.get("username") or "channel"
+                        forward_note = f" [forwarded from chat: {name}]"
+                    elif fwd_type == "channel":
+                        chat = fwd_origin.get("chat", {})
+                        name = chat.get("title") or chat.get("username") or "channel"
+                        forward_note = f" [forwarded from channel: {name}]"
+                else:
+                    # Legacy fallback for older Bot API responses.
+                    if "forward_from" in msg:
+                        u = msg["forward_from"]
+                        name = u.get("username") or u.get("first_name") or "unknown"
+                        forward_note = f" [forwarded from @{name}]"
+                    elif "forward_sender_name" in msg:
+                        forward_note = f" [forwarded from {msg['forward_sender_name']}]"
+
+                print(f"  @{username}{forward_note}: {text}{attachment_note}")
 
                 # Write as task (same format as voice bridge)
                 ts = int(time.time() * 1000)
@@ -397,7 +430,7 @@ def main():
                 task_file.write_text(
                     f"id: {task_id}\n"
                     f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%S')}Z\n"
-                    f"task: [Telegram @{username}] {text}{attachment_note}\n"
+                    f"task: [Telegram @{username}{forward_note}] {text}{attachment_note}\n"
                     f"source: telegram\n"
                     f"chat_id: {chat_id}\n"
                     f"priority: {priority}\n"

--- a/tests/telegram-bridge-forward-attribution.test.py
+++ b/tests/telegram-bridge-forward-attribution.test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Behavioral tests for telegram-bridge.extract_forward_note().
+
+Pins the parsing surface added in PR #905: when a Telegram user forwards a
+message, the bridge must preserve original-sender attribution in the task
+header so downstream agents can tell "Chi forwarded Boris's note" from
+"Chi wrote this".
+
+Run: python3 tests/telegram-bridge-forward-attribution.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+
+def load_bridge_module():
+    """Load src/telegram-bridge.py as a module. See telegram-bridge-tofu.test.py
+    for why we monkeypatch TELEGRAM_BOT_TOKEN and use importlib."""
+    os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-placeholder-token")
+    spec = importlib.util.spec_from_file_location(
+        "telegram_bridge", REPO / "src" / "telegram-bridge.py"
+    )
+    bridge = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(bridge)
+    return bridge
+
+
+CASES = [
+    (
+        "non-forwarded msg",
+        {"text": "hello world"},
+        "",
+    ),
+    (
+        "forward_origin user with username",
+        {
+            "text": "hi",
+            "forward_origin": {
+                "type": "user",
+                "sender_user": {"id": 999, "username": "alice", "first_name": "Alice"},
+            },
+        },
+        " [forwarded from @alice]",
+    ),
+    (
+        "forward_origin user only first_name",
+        {
+            "text": "hi",
+            "forward_origin": {
+                "type": "user",
+                "sender_user": {"id": 999, "first_name": "Alice"},
+            },
+        },
+        " [forwarded from @Alice]",
+    ),
+    (
+        "forward_origin hidden_user",
+        {
+            "text": "hi",
+            "forward_origin": {
+                "type": "hidden_user",
+                "sender_user_name": "Anonymous Sender",
+            },
+        },
+        " [forwarded from Anonymous Sender]",
+    ),
+    (
+        "forward_origin channel",
+        {
+            "text": "hi",
+            "forward_origin": {
+                "type": "channel",
+                "chat": {"id": -1001, "title": "Some News", "username": "some_news"},
+                "message_id": 42,
+            },
+        },
+        " [forwarded from channel: Some News]",
+    ),
+    (
+        "forward_origin chat (group)",
+        {
+            "text": "hi",
+            "forward_origin": {
+                "type": "chat",
+                "sender_chat": {"id": -1001, "title": "Some Group"},
+            },
+        },
+        " [forwarded from chat: Some Group]",
+    ),
+    (
+        "legacy forward_from",
+        {
+            "text": "hi",
+            "forward_from": {"id": 999, "username": "legacy_user"},
+        },
+        " [forwarded from @legacy_user]",
+    ),
+    (
+        "legacy forward_sender_name",
+        {
+            "text": "hi",
+            "forward_sender_name": "Anonymous Legacy",
+        },
+        " [forwarded from Anonymous Legacy]",
+    ),
+    (
+        "unknown forward_origin.type falls through gracefully",
+        {
+            "text": "hi",
+            "forward_origin": {"type": "future_unknown_kind", "stuff": "xyz"},
+        },
+        "",
+    ),
+]
+
+
+def main():
+    bridge = load_bridge_module()
+    fn = bridge.extract_forward_note
+    failed = 0
+    for name, msg, expected in CASES:
+        got = fn(msg)
+        ok = got == expected
+        status = "PASS" if ok else "FAIL"
+        print(f"  [{status}] {name}: got={got!r} expected={expected!r}")
+        if not ok:
+            failed += 1
+    total = len(CASES)
+    print(f"\n{total - failed}/{total} passed.")
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

When the owner forwards a message from a third party into Telegram, the bridge silently drops the original sender's identity. The task body reads `[Telegram @owner] <forwarded words>` — the original author's name doesn't appear, future readers can't tell which words are the owner's vs which are forwarded.

## Fix

Parse Telegram Bot API 7.0+'s `forward_origin` field (covers user, hidden_user, chat, and channel forwards) plus the legacy `forward_from` / `forward_sender_name` fallback for older responses. Append `[forwarded from <name>]` to the task header.

```diff
- task: [Telegram @owner] <forwarded words>
+ task: [Telegram @owner [forwarded from @other]] <forwarded words>
```

## What's NOT changed

- Sender identity for access-list check stays the **forwarder** (`msg["from"]["id"]`) — that's who's authorized to drop messages into the bridge. Attribution only affects what the downstream agent reads.
- All four `forward_origin.type` variants handled (user / hidden_user / chat / channel) — falls through gracefully for unknown types.
- Non-forwarded messages: zero behavior change (no `[forwarded from ...]` suffix).

## Test plan

- [ ] Forward a public-username message → `[forwarded from @username]`.
- [ ] Forward a message from a hidden-account user → `[forwarded from <display_name>]`.
- [ ] Forward a channel message → `[forwarded from channel: <title>]`.
- [ ] Forward a regular non-forwarded reply → no suffix.
- [ ] Sender access-list check still uses `msg["from"]["id"]` (the forwarder).