### PR TITLE
fix(bridges): write task timestamps in UTC, not local time

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2570,7 +2570,7 @@ async def _handle_discord_message(message, force=False):
     priority = default_priority_for_source("discord", access_tier)
     task_file.write_text(
         f"id: {task_id}\n"
-        f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%S')}Z\n"
+        f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"
         f"task: {user_task_text}\n"
         f"source: discord\n"
         f"channel_id: {message.channel.id}\n"

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -434,7 +434,7 @@ def main():
                 priority = default_priority_for_source("telegram", "owner")
                 task_file.write_text(
                     f"id: {task_id}\n"
-                    f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%S')}Z\n"
+                    f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"
                     f"task: [Telegram @{username}{forward_note}] {text}{attachment_note}\n"
                     f"source: telegram\n"
                     f"chat_id: {chat_id}\n"


### PR DESCRIPTION
## Summary

- `discord-bridge.py` and `telegram-bridge.py` wrote the task `timestamp:` field with `time.strftime(...)` (local time) plus a literal `Z` suffix claiming UTC — so on any non-UTC host the timestamp was off by the host's UTC offset (4h on an EDT host).
- Fix: pass `time.gmtime()` so the value is genuinely UTC. Two one-line changes.
- Matches the already-correct `now_iso` at `telegram-bridge.py:154` (which the buggy line in the same file was inconsistent with).

## Why it matters

Most consumers key off file mtime, so blast radius is low — but any logic that computes task **staleness** from `timestamp:` is silently wrong. Observed live: a ~1-minute-old task was misjudged as 4h stale.

## Test plan

- [x] `git diff` confirms exactly 2 one-line changes; `time` is imported in both files
- [ ] After deploy, confirm a freshly-written Discord/Telegram task `timestamp:` matches `date -u`

Closes #908
