### PR TITLE
fix(slack-bridge): write task timestamp in UTC, not local time

### DIFF
--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -356,7 +356,7 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
     priority = default_priority_for_source("slack", access_tier)
     task_file.write_text(
         f"id: {task_id}\n"
-        f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%S')}Z\n"
+        f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"
         f"task: {user_task_text}\n"
         f"source: slack\n"
         f"channel_id: {channel}\n"


### PR DESCRIPTION
## Summary

Follow-up to #909. Susan's PR fixed the local-time-mislabeled-as-UTC timestamp bug in `discord-bridge.py` + `telegram-bridge.py`, but `slack-bridge.py:359` had the same pattern and was missed.

One-line change:
- before: `time.strftime('%Y-%m-%dT%H:%M:%S')Z` (local time + literal Z)
- after: `time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())` (real UTC)

Matches the already-correct pattern in the same file at `:161`.

## Test plan

- [x] Diff: 1 file, +1/-1
- [x] Pattern matches existing UTC-emitting code paths in the same file (`slack-bridge.py:161`) and in sibling bridges merged via #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)