### PR TITLE
feat(startup.sh): redirect service logs to $WORKSPACE/logs

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -142,7 +142,24 @@ echo ""
 # Install Claude Code skills (runs every startup, idempotent)
 bash "$REPO/skills/install.sh" 2>/dev/null || true
 
-# Create tasks/ and results/ directories
+# Resolve the runtime workspace (separate from $REPO so per-user state lives
+# outside the git checkout). Same resolution shape as src/workspace_default.py:
+#   1. $SUTANDO_WORKSPACE env override (tilde-expand if needed)
+#   2. ~/.sutando/workspace/ (canonical default)
+#
+# All service logs + tasks/results land under $WORKSPACE/logs etc. instead of
+# the repo-root legacy paths. health-check + dashboard already read from
+# $WORKSPACE/logs — this redirects the writes to match.
+if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
+else
+  WORKSPACE="$HOME/.sutando/workspace"
+fi
+mkdir -p "$WORKSPACE/logs" "$WORKSPACE/tasks" "$WORKSPACE/results" "$WORKSPACE/data"
+LOGS_DIR="$WORKSPACE/logs"
+
+# Legacy repo-root tasks/results/data still created for back-compat with
+# scripts that haven't migrated yet; safe no-op once everything's switched.
 mkdir -p tasks results data
 
 # Archive stale results/*.txt (>24h) BEFORE any service starts iterating
@@ -182,7 +199,7 @@ fi
 # 1. Voice agent (Gemini Live on port 9900)
 if ! lsof -i :9900 > /dev/null 2>&1; then
   echo "  Starting voice agent (port 9900)..."
-  npx tsx src/voice-agent.ts > logs/voice-agent.log 2>&1 &
+  npx tsx src/voice-agent.ts > "$LOGS_DIR/voice-agent.log" 2>&1 &
   echo "  ✓ voice agent"
 else
   echo "  ✓ voice agent (already running)"
@@ -191,7 +208,7 @@ fi
 # 2. Web client (port 8080)
 if ! lsof -i :8080 > /dev/null 2>&1; then
   echo "  Starting web client (port 8080)..."
-  npx tsx src/web-client.ts > logs/web-client.log 2>&1 &
+  npx tsx src/web-client.ts > "$LOGS_DIR/web-client.log" 2>&1 &
   echo "  ✓ web client"
 else
   echo "  ✓ web client (already running)"
@@ -200,7 +217,7 @@ fi
 # 3. Dashboard (port 7844)
 if ! lsof -i :7844 > /dev/null 2>&1; then
   echo "  Starting dashboard (port 7844)..."
-  python3 src/dashboard.py > logs/dashboard.log 2>&1 &
+  python3 src/dashboard.py > "$LOGS_DIR/dashboard.log" 2>&1 &
   echo "  ✓ dashboard"
 else
   echo "  ✓ dashboard (already running)"
@@ -209,7 +226,7 @@ fi
 # 4. Agent API (port 7843)
 if ! lsof -i :7843 > /dev/null 2>&1; then
   echo "  Starting agent API (port 7843)..."
-  python3 src/agent-api.py > logs/agent-api.log 2>&1 &
+  python3 src/agent-api.py > "$LOGS_DIR/agent-api.log" 2>&1 &
   echo "  ✓ agent API"
 else
   echo "  ✓ agent API (already running)"
@@ -222,7 +239,7 @@ fi
 if ! lsof -i :7845 > /dev/null 2>&1; then
   if [ "$PERM_OK" -eq 1 ]; then
     echo "  Starting screen capture (port 7845)..."
-    python3 src/screen-capture-server.py > logs/screen-capture.log 2>&1 &
+    python3 src/screen-capture-server.py > "$LOGS_DIR/screen-capture.log" 2>&1 &
     echo "  ✓ screen capture"
   else
     echo "  ⊘ screen capture skipped — grant Screen Recording perm first, then re-run startup.sh"
@@ -310,7 +327,7 @@ if [ "${SKIP_TELEGRAM:-}" = "1" ]; then
 elif [ -f "$HOME/.claude/channels/telegram/.env" ] && grep -q "TELEGRAM_BOT_TOKEN=" "$HOME/.claude/channels/telegram/.env" 2>/dev/null; then
   if ! pgrep -f "telegram-bridge" > /dev/null 2>&1; then
     echo "  Starting Telegram bridge..."
-    python3 src/telegram-bridge.py > logs/telegram-bridge.log 2>&1 &
+    python3 src/telegram-bridge.py > "$LOGS_DIR/telegram-bridge.log" 2>&1 &
     echo "  ✓ telegram bridge"
   else
     echo "  ✓ telegram bridge (already running)"
@@ -339,7 +356,7 @@ if [ -f "$HOME/.claude/channels/discord/.env" ] && grep -q "DISCORD_BOT_TOKEN=" 
     echo "  ~ discord bridge (no python with discord.py — run: /opt/homebrew/bin/pip3 install discord.py)"
   elif ! pgrep -f "discord-bridge" > /dev/null 2>&1; then
     echo "  Starting Discord bridge with $PYTHON_WITH_DISCORD..."
-    "$PYTHON_WITH_DISCORD" src/discord-bridge.py > logs/discord-bridge.log 2>&1 &
+    "$PYTHON_WITH_DISCORD" src/discord-bridge.py > "$LOGS_DIR/discord-bridge.log" 2>&1 &
     echo "  ✓ discord bridge"
   else
     echo "  ✓ discord bridge (already running)"
@@ -365,7 +382,7 @@ if [ -f "$HOME/.claude/channels/slack/.env" ] && grep -q "SLACK_BOT_TOKEN=" "$HO
     echo "  Starting Slack bridge with $PYTHON_WITH_SLACK..."
     # Source the env file so SLACK_BOT_TOKEN / SLACK_APP_TOKEN reach the child.
     set -a; . "$HOME/.claude/channels/slack/.env"; set +a
-    "$PYTHON_WITH_SLACK" src/slack-bridge.py > logs/slack-bridge.log 2>&1 &
+    "$PYTHON_WITH_SLACK" src/slack-bridge.py > "$LOGS_DIR/slack-bridge.log" 2>&1 &
     echo "  ✓ slack bridge"
   else
     echo "  ✓ slack bridge (already running)"
@@ -440,7 +457,7 @@ for port_name in $VERIFY_PORTS; do
   if lsof -i :"$port" > /dev/null 2>&1; then
     echo "  ✓ $name (port $port)"
   else
-    echo "  ✗ $name (port $port) — check logs/${name}.log"
+    echo "  ✗ $name (port $port) — check $LOGS_DIR/${name}.log"
   fi
 done
 echo ""


### PR DESCRIPTION
## Summary

Closes the workspace-vs-repo path mismatch that surfaced today as false-positive `voice-agent.log "not found"` health-check warnings. The repo-rooted `logs/` dir was a legacy from before PR #821/#859 moved runtime state to `$SUTANDO_WORKSPACE`.

## Changes

- Resolve `$WORKSPACE` at top of service-start block (env override `$SUTANDO_WORKSPACE`, fallback `~/.sutando/workspace/`)
- All 8 service log redirections updated: voice-agent, web-client, dashboard, agent-api, screen-capture, telegram-bridge, discord-bridge, slack-bridge → `"$LOGS_DIR/$name.log"`
- `mkdir -p $WORKSPACE/{logs,tasks,results,data}` for fresh installs
- Diagnostic-failure hint also points at `$LOGS_DIR`
- Legacy repo-root `tasks/ results/ data/` mkdir kept for back-compat

## Why this is shell-only

The services emit to stdout/stderr — they never open log files directly. `startup.sh` redirects the streams. So the migration is a one-file diff; no TypeScript / Python changes needed.

## Test plan

- [x] `bash -n src/startup.sh` clean
- [x] Resolution snippet smoke-tested: `$LOGS_DIR` resolves to `/Users/wangchi/.sutando/workspace/logs` (already exists with current logs from bridges that landed there via other paths)
- [ ] Full restart cycle: kill all services, run `bash src/startup.sh`, verify new logs land in `$WORKSPACE/logs/*.log` and health-check stops complaining
- [ ] Verify `lsof -i :9900` still finds voice-agent (redirect target shouldn't affect listener)

🤖 Generated with [Claude Code](https://claude.com/claude-code)