### PR TITLE
fix(browser-tools): open_url logs url + rejects whitespace early

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -212,6 +212,13 @@ export const closeTabTool: ToolDefinition = {
 
 // --- Open URL ---
 
+// Strip query string for log lines so signed/OAuth URLs don't leak token
+// query-params to the logfile verbatim. The error-return path keeps the full
+// URL so callers/users still see exactly what they tried to open. Per
+// Susan's PR #919 review: regex strip is safer than `new URL()`-based
+// redaction since the failure path is often an unparseable URL.
+const redactQuery = (u: string): string => JSON.stringify(u.replace(/\?.*$/, '?…'));
+
 export const openUrlTool: ToolDefinition = {
 	name: 'open_url',
 	description:
@@ -233,9 +240,19 @@ export const openUrlTool: ToolDefinition = {
 			console.log(`${ts()} [OpenURL] rejected empty url`);
 			return { error: 'Failed to open: empty URL' };
 		}
+		// `\s` already covers U+00A0 nbsp + U+3000 ideographic space + U+2028/2029
+		// + U+FEFF BOM. The uncaught class is zero-width characters
+		// (U+200B/200C/200D/2060) — none are in `\s` and none are stripped by
+		// `.trim()`. An LLM/voice transcription emitting one would slip
+		// through and fail opaquely at osascript again. Reject both up front
+		// for symmetric observable errors. Per Susan's PR #919 review.
 		if (/\s/.test(url)) {
-			console.log(`${ts()} [OpenURL] rejected url with whitespace: ${JSON.stringify(url)}`);
+			console.log(`${ts()} [OpenURL] rejected url with whitespace: ${redactQuery(url)}`);
 			return { error: `Failed to open: URL contains whitespace (got ${JSON.stringify(url)})` };
+		}
+		if (/[\u200B\u200C\u200D\u2060]/.test(url)) {
+			console.log(`${ts()} [OpenURL] rejected url with zero-width char: ${redactQuery(url)}`);
+			return { error: `Failed to open: URL contains zero-width character (got ${JSON.stringify(url)})` };
 		}
 		// Escape backslashes first, then quotes — prevents shell injection via osascript
 		const safeUrl = url.replace(/\\/g, '\\\\').replace(/'/g, "'\\''").replace(/"/g, '\\"');
@@ -271,7 +288,7 @@ export const openUrlTool: ToolDefinition = {
 			// reaches the log, leaving "Invalid URL entered. (5)" with no
 			// hint of what URL voice actually passed. 2026-05-19 incident:
 			// three back-to-back open_url failures with no observable arg.
-			console.log(`${ts()} [OpenURL] FAILED url=${JSON.stringify(url)} err=${err instanceof Error ? err.message : err}`);
+			console.log(`${ts()} [OpenURL] FAILED url=${redactQuery(url)} err=${err instanceof Error ? err.message : err}`);
 			return { error: `Failed to open ${url}: ${err instanceof Error ? err.message : err}` };
 		}
 	},

--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -221,7 +221,22 @@ export const openUrlTool: ToolDefinition = {
 	}),
 	execution: 'inline',
 	async execute(args) {
-		const { url } = args as { url: string };
+		const { url: rawUrl } = args as { url: string };
+		// Normalize spoken-URL artifacts before handing to osascript. The LLM
+		// sometimes passes a URL with surrounding whitespace from voice
+		// transcription, or with embedded spaces that AppleScript / Chrome
+		// reject as "Invalid URL entered. (5)" — opaque error. Trim and
+		// reject-up-front so the caller gets a clear diagnostic + the
+		// arg appears in the log, instead of three silent osascript errors.
+		const url = (rawUrl || '').trim();
+		if (!url) {
+			console.log(`${ts()} [OpenURL] rejected empty url`);
+			return { error: 'Failed to open: empty URL' };
+		}
+		if (/\s/.test(url)) {
+			console.log(`${ts()} [OpenURL] rejected url with whitespace: ${JSON.stringify(url)}`);
+			return { error: `Failed to open: URL contains whitespace (got ${JSON.stringify(url)})` };
+		}
 		// Escape backslashes first, then quotes — prevents shell injection via osascript
 		const safeUrl = url.replace(/\\/g, '\\\\').replace(/'/g, "'\\''").replace(/"/g, '\\"');
 		// Parse target origin (scheme + host + port). If unparseable, fall back to new-tab behavior.
@@ -251,6 +266,12 @@ export const openUrlTool: ToolDefinition = {
 			console.log(`${ts()} [OpenURL] ${reused ? 'reused active tab' : 'opened new tab'}: ${url}`);
 			return { status: reused ? 'reused' : 'opened', url };
 		} catch (err) {
+			// Log the URL too — the prior version returned the URL only in the
+			// error string, which voice-agent's stdout strips by the time it
+			// reaches the log, leaving "Invalid URL entered. (5)" with no
+			// hint of what URL voice actually passed. 2026-05-19 incident:
+			// three back-to-back open_url failures with no observable arg.
+			console.log(`${ts()} [OpenURL] FAILED url=${JSON.stringify(url)} err=${err instanceof Error ? err.message : err}`);
 			return { error: `Failed to open ${url}: ${err instanceof Error ? err.message : err}` };
 		}
 	},


### PR DESCRIPTION
## Summary

Tonight's debug surfaced a gap: voice agent's `open_url` failed 3x with `execution error: Google Chrome got an error: Invalid URL entered. (5)` but logs/voice-agent.log didn't show the URL arg. The prior catch returned the URL only in the error string, which voice's stdout strips before logging.

## Changes

- **Trim + reject whitespace** in URLs before handing to osascript. The LLM occasionally passes voice-transcription artifacts ("github . com slash ...") that Chrome rejects with the opaque (5). Catching them here surfaces a clear error AND logs the raw arg.
- **Log url + err** on the catch path. Non-whitespace failures (Chrome scripting blocked, no front window) now leave a diagnoseable trace.

No behavior change for valid URLs.

## Test plan

- [x] Compiles clean (`tsc`)
- [ ] Voice says "open github . com" (with spaces) → reply contains "URL contains whitespace (got ...)" instead of three osascript retries
- [ ] Voice says "open https://github.com" → opens normally, log shows `[OpenURL] opened new tab: https://github.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)