### PR TITLE
docs(readme): trending badge → May 17–19 range

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sutando
 
-[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ai-blue)](https://sutando.ai) [![GitHub Trending](https://img.shields.io/badge/GitHub_Trending-%231_Developer_(May_17)-FFD700?logo=github&logoColor=white)](https://github.com/trending/developers?since=daily)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uZHWXXmrCS) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Website](https://img.shields.io/badge/Web-sutando.ai-blue)](https://sutando.ai) [![GitHub Trending](https://img.shields.io/badge/GitHub_Trending-%231_Developer_(May_17%E2%80%9319)-FFD700?logo=github&logoColor=white)](https://github.com/trending/developers?since=daily)
 
 **My AI Stand — Realtime by Day, Rewriting Itself by Night.**
 **Summon my AI superpower.**


### PR DESCRIPTION
## Summary

Updates the GitHub Trending badge in the README from a single-day stamp `(May 17)` to a range `(May 17–19)`. Chi has held #1 on daily-trending-developers for three days running — verified live via github.com/trending/developers?since=daily a few minutes ago.

## Background

Mini parked a "Trendshift dynamic badge swap" from ep007 work — replace static with live-updating. Investigated tonight:
- Trendshift has per-developer pages (`trendshift.io/developers/<id>`) but the public badge endpoint pattern (`api/badge/repositories/<id>`) is documented only for repos.
- Their `/trending/developers` metric counts lifetime trending appearances (emilk leads at 284), not current daily rank — doesn't dynamically express what this badge claims.

So sticking with static + range for now. Revisitable if Trendshift documents a dev-badge endpoint or we build our own.

## Test plan

- [x] Verified via WebFetch: sonichi #1 on github.com/trending/developers?since=daily as of this commit
- [x] URL-encoded en-dash (`%E2%80%93`) renders correctly in shields.io
- [x] No other README changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)