### PR TITLE
feat(task-bridge): voice-only push channel via voice-*.txt filename

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -586,6 +586,24 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 				const result = readFileSync(path, 'utf-8').trim();
 				if (!result) continue;
 				const taskId = file.replace('.txt', '');
+
+				// Voice-only push channel: files named `voice-*.txt` are spoken
+				// by the voice agent on next turn, OR held in queue until the
+				// voice client reconnects. Discord-bridge skips them. Use this
+				// when the content is meaningless on Discord (e.g. a draft
+				// meant for voice to TYPE into a text field). Per Chi's
+				// 2026-05-20 02:25 ask after the proactive-* race.
+				if (file.startsWith('voice-')) {
+					if (!clientConnected) {
+						// Hold in queue; don't archive. Next poll will try again.
+						continue;
+					}
+					console.log(`${ts()} [TaskBridge] Voice-only result: ${file} (${result.slice(0, 80)})`);
+					onResult(result);
+					_deliveredResults.add(file);
+					setTimeout(() => archiveFile(path, 'results', `voice-${Date.now()}`), 10_000);
+					continue;
+				}
 				// Deduped-marker result: agent consolidated this task's reply
 				// into another task's result file. Mark this task done silently
 				// and archive — no Discord post, no voice narration, no timeout.


### PR DESCRIPTION
## Summary

Closes the race condition Chi hit tonight (~02:18): writing `results/proactive-*.txt` to push something to voice always falls back to Discord-DM via `discord-bridge.py:2868` (poll_proactive picks up proactive-* and DMs unconditionally). Even if voice is connected at write time, the proactive file gets claimed and archived before voice picks it up. Result: confusion when voice doesn't know the context minutes later.

## Changes

- **`src/task-bridge.ts`** (the only file changed): result-watcher detects `voice-*.txt` files. If client connected → `onResult(text)` to voice session. If not → leave the file in place, retry next poll. After delivery, archive.

- **`src/discord-bridge.py`**: no change needed. Its `FALLBACK_PREFIXES` doesn't include `voice-`, and `poll_proactive` only picks up `proactive-*`. So discord-bridge already ignores `voice-*.txt`.

## Use cases

- Background agent has content for voice to READ or TYPE (LinkedIn reply, dictation, walkthrough step). Voice speaks on next turn.
- Cross-session: write voice-*.txt → voice picks up on next connect. Survives voice-disconnect cycles.

## Test plan

- [x] Filename pattern doesn't match any discord-bridge / poll_proactive filter
- [ ] Write `results/voice-test.txt` with voice connected → spoken + archived
- [ ] Write `results/voice-test.txt` with voice disconnected → persists in queue, delivered after voice reconnect
- [x] task-bridge.ts builds clean (TS compiler exits 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)