### PR TITLE
fix(slack-bridge): default missing tierMap entries to 'other' instead of 'owner'

### DIFF
--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -318,13 +318,25 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
     else:
         thread_ts = None
 
-    # Resolve access_tier from `tierMap`. Unmapped users default to "owner"
-    # — preserves the pre-tierMap contract (everything in allowFrom was
-    # treated as owner). Mapping a user to "team" or "other" downgrades them.
-    # See CLAUDE.md "Discord access control" for the broader policy this
-    # mirrors. The core agent reads access_tier from the task body and is
-    # expected to delegate non-owner tasks to a sandboxed agent.
-    access_tier = load_tier_map().get(user_id, "owner")
+    # Resolve access_tier from `tierMap`.
+    # Two cases for unmapped users:
+    #   1. tierMap absent (pre-tierMap config) → "owner" (backward compat)
+    #   2. tierMap present but uid missing → "other" (fail-safe, prevents
+    #      silent privilege escalation when operator forgets a tierMap line)
+    # See #893 for the rationale behind the split default.
+    tier_map = load_tier_map()
+    if user_id in tier_map:
+        access_tier = tier_map[user_id]
+    elif tier_map:
+        # tierMap exists but uid is missing — degrade to "other"
+        print(
+            f"  [tier-map] WARNING: User {user_id} in allowFrom but missing from tierMap; defaulting to 'other'",
+            flush=True,
+        )
+        access_tier = "other"
+    else:
+        # tierMap absent entirely — pre-tierMap config, all users are owner
+        access_tier = "owner"
     if access_tier not in ("owner", "team", "other"):
         # Unknown tier value in config → degrade safely to "other" rather
         # than treating as owner.

--- a/tests/slack-bridge-tier-map.test.py
+++ b/tests/slack-bridge-tier-map.test.py
@@ -100,10 +100,11 @@ def main() -> int:
         "tierMap": {"Uteam": "team", "Uother": "other"},
     })
     tm = load_tier_map()
-    expect("Uowner unmapped → owner default", tm.get("Uowner", "owner"), "owner")
-    expect("Uteam mapped → team", tm.get("Uteam", "owner"), "team")
-    expect("Uother mapped → other", tm.get("Uother", "owner"), "other")
-    expect("Uunknown unmapped → owner default", tm.get("Uunknown", "owner"), "owner")
+    expect("Uteam mapped → team", tm.get("Uteam"), "team")
+    expect("Uother mapped → other", tm.get("Uother"), "other")
+    # load_tier_map() returns raw dict; _write_task handles the split default.
+    # When tierMap is non-empty and uid is missing, caller should use "other".
+    expect("Uowner in raw tierMap → None (not mapped)", tm.get("Uowner"), None)
 
     # Case 2: tierMap completely absent (pre-tierMap config). Everyone defaults to owner.
     _write_access(mod, {
@@ -112,7 +113,6 @@ def main() -> int:
     })
     tm = load_tier_map()
     expect("absent tierMap returns empty dict", tm, {})
-    expect("absent tierMap → all default to owner", tm.get("Uolduser", "owner"), "owner")
 
     # Case 3: tierMap with unknown tier value — caller-side fail-safe check.
     # load_tier_map() itself just returns the map; the caller in _write_task
@@ -139,7 +139,64 @@ def main() -> int:
     tm = load_tier_map()
     expect("missing file → empty dict", tm, {})
 
-    print()
+    # --- Caller-side split-default logic tests ---
+    # Mirrors the _write_task access_tier resolution in slack-bridge.py.
+    # Rules:
+    #   uid in tierMap → use mapped value
+    #   tierMap non-empty, uid missing → "other" (fail-safe, #893)
+    #   tierMap empty/absent → "owner" (pre-tierMap compat)
+    #   unknown tier value → degrade to "other"
+    def _resolve_tier(uid: str, tier_map: dict) -> str:
+        if uid in tier_map:
+            tier = tier_map[uid]
+        elif tier_map:
+            tier = "other"
+        else:
+            tier = "owner"
+        if tier not in ("owner", "team", "other"):
+            tier = "other"
+        return tier
+
+    # Case 7: tierMap present, uid missing → "other" (the #893 fix)
+    expect(
+        "tierMap non-empty, uid missing → 'other'",
+        _resolve_tier("Unewguy", {"Uteam": "team"}),
+        "other",
+    )
+
+    # Case 8: tierMap absent → "owner" (backward compat)
+    expect(
+        "tierMap absent → 'owner'",
+        _resolve_tier("Uolduser", {}),
+        "owner",
+    )
+
+    # Case 9: uid in tierMap → mapped value
+    expect(
+        "uid mapped to 'team' → 'team'",
+        _resolve_tier("Uteam", {"Uteam": "team"}),
+        "team",
+    )
+
+    # Case 10: unknown tier value → degrade to "other"
+    expect(
+        "unknown tier value → 'other'",
+        _resolve_tier("Ubad", {"Ubad": "rando"}),
+        "other",
+    )
+
+    # Case 11: tierMap present, multiple uids, one missing
+    tm_multi = {"Uteam": "team", "Uother": "other"}
+    expect(
+        "mixed tierMap, unmapped uid → 'other'",
+        _resolve_tier("Umissing", tm_multi),
+        "other",
+    )
+    expect(
+        "mixed tierMap, mapped uid → correct tier",
+        _resolve_tier("Uteam", tm_multi),
+        "team",
+    )
     print(f"Results: {passes} passed, {fails} failed")
     return 0 if fails == 0 else 1
 


### PR DESCRIPTION
## Summary

Fixes #893 — silent privilege escalation when `tierMap` exists but a user ID is missing from it.

## Problem

When `tierMap` is present in `access.json` but a user ID in `allowFrom` has no corresponding `tierMap` entry, the current code defaults that user to `"owner"`:

```python
access_tier = load_tier_map().get(user_id, "owner")
```

This is **correct** when `tierMap` is completely absent (pre-tierMap configs), but **unsafe** when `tierMap` exists — the operator added a tierMap (opting into tiered access) but forgot one entry, and that user silently gets full owner privileges.

Concrete scenario from #893:
> Owner adds Bassil to `allowFrom` for the first time, forgets the tierMap line → Bassil silently gets owner tier instead of team.

## Fix

Split the unmapped-user default into two paths:

| Condition | Default | Rationale |
|-----------|---------|-----------|
| `tierMap` absent | `"owner"` | Backward compat with pre-tierMap configs |
| `tierMap` present, uid missing | `"other"` | Fail-safe — operator opted into tiers, missing entry = least privilege |

Logs a warning when the fail-safe fires so operators can fix their config.

## Testing

14 tests pass (up from 10). Added 5 new caller-side split-default tests:

- Case 7: tierMap non-empty, uid missing → `"other"` (the #893 fix)
- Case 8: tierMap absent → `"owner"` (backward compat preserved)
- Case 9: uid mapped to `"team"` → `"team"`
- Case 10: unknown tier value → degrade to `"other"`
- Case 11: mixed tierMap, unmapped uid → `"other"`, mapped → correct tier

```console
$ python3 tests/slack-bridge-tier-map.test.py
Results: 14 passed, 0 failed
```

## Changes

- `src/slack-bridge.py`: Replace `.get(uid, "owner")` with explicit 3-branch tier resolution
- `tests/slack-bridge-tier-map.test.py`: Updated raw-map assertions + 5 new caller-side tests