### PR TITLE
fix(ci): remove path filter so doc-only PRs don't sit BLOCKED forever

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'package.json'
-      - 'package-lock.json'
-      - 'tsconfig.json'
-      - 'src/**'
-      - 'tests/**'
-      - 'skills/**/*.ts'
-      - 'scripts/**'
-      - '.github/workflows/ci.yml'
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary

Fixes #900 — doc-only PRs sit in BLOCKED merge status because the CI workflow path filter never triggers the required check.

## Problem

The `pull_request` trigger in `ci.yml` has a `paths` filter that only runs for code changes. When a PR only touches docs, `.md` files, or `.env.example`, the workflow never fires → the required branch-protection check `tsc + tests (clean install)` is never reported → `gh pr view` shows `BLOCKED` indefinitely.

## Fix

Remove the `paths` filter entirely. CI now runs on every PR, guaranteeing the required check is always reported. Cost: ~1m per run on doc-only PRs — negligible compared to the operational pain of stuck PRs.

If CI cost becomes a concern, the dual-job pattern from #900 (Option 1) can be layered on top later.

## Testing

- No code changes — CI config only
- The workflow will validate itself on this PR (meta-circular)

## Changes

- `.github/workflows/ci.yml`: Remove `paths` filter from `pull_request` trigger (9 lines removed)