### PR TITLE
fix(test): set SUTANDO_WORKSPACE in init-script tests

### DIFF
--- a/tests/init-script.test.ts
+++ b/tests/init-script.test.ts
@@ -23,8 +23,16 @@ interface RunResult { stdout: string; stderr: string; status: number | null }
 function runInit(repoDir: string, mode?: '--auto' | '--preflight'): RunResult {
 	const args = ['bash', INIT_SH];
 	if (mode) args.push(mode);
+	// init.sh resolves WORKSPACE from $SUTANDO_WORKSPACE (or $HOME/.sutando/workspace).
+	// Point WORKSPACE at repoDir so Tier 1 creates files/dirs where the tests
+	// expect them (directly under scratch, not inside a nested .sutando tree).
 	const proc = spawnSync(args[0]!, args.slice(1), {
-		env: { ...process.env, SUTANDO_REPO: repoDir, HOME: repoDir + '/.fake-home' },
+		env: {
+			...process.env,
+			SUTANDO_REPO: repoDir,
+			SUTANDO_WORKSPACE: repoDir,
+			HOME: repoDir + '/.fake-home',
+		},
 		encoding: 'utf-8',
 	});
 	return { stdout: proc.stdout, stderr: proc.stderr, status: proc.status };


### PR DESCRIPTION
## Summary

Fixes 7 failing tests in `init-script.test.ts` caused by PR #911's workspace split.

## Problem

PR #911 moved runtime state (logs, state, tasks, placeholder files) from `$SUTANDO_REPO` to `$SUTANDO_WORKSPACE` (defaults to `$HOME/.sutando/workspace`). The test's `runInit()` function only set `SUTANDO_REPO` to the scratch dir, so the script created files in `$scratch/.fake-home/.sutando/workspace/` while the assertions checked `$scratch/` directly.

Result: 7 tests failed with ENOENT / "expected directory" errors:

- `is idempotent — second invocation does not error or recreate`
- `creates pending-questions.md with an empty placeholder`
- `creates contextual-chips.json with a parseable shape`
- `creates core-status.json initialised to idle`
- `creates voice-state.json initialised to disconnected`
- `runs both tiers by default (no flag)`
- `creates every expected directory in an empty repo` (logs/ only)

## Fix

Pass `SUTANDO_WORKSPACE=$repoDir` in the test environment so `create_file_if_missing` / `create_dir_if_missing` write to the scratch directory where the assertions expect them.

```diff
env: {
  ...process.env,
  SUTANDO_REPO: repoDir,
+ SUTANDO_WORKSPACE: repoDir,
  HOME: repoDir + "/.fake-home",
},
```

## Testing

```console
$ npx node --test tests/init-script.test.ts
# tests 18
# suites 5
# pass 18
# fail 0
```

Before: 11 pass / 7 fail → After: 18 pass / 0 fail.