### PR TITLE
feat(outbox-log): visibility log for all outbound bridge sends

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2818,6 +2818,17 @@ async def poll_results():
                             ref = discord.MessageReference(message_id=reply_to_id, channel_id=channel.id, fail_if_not_exists=False) if (first and reply_to_id) else None
                             await channel.send(chunk, reference=ref)
                             first = False
+                        try:
+                            import outbox_log
+                            ch_type = "discord_dm" if isinstance(channel, discord.DMChannel) else "discord_channel"
+                            outbox_log.append(
+                                channel_type=ch_type,
+                                recipient=str(channel.id),
+                                body=clean_text,
+                                task_id=task_id,
+                            )
+                        except Exception:
+                            pass
 
                     # Send files (allowlist-gated; see _is_path_sendable)
                     for fpath in files:
@@ -2943,6 +2954,16 @@ async def poll_proactive():
                         if clean_text:
                             for chunk in _chunk_for_discord(clean_text):
                                 await dm.send(chunk)
+                            try:
+                                import outbox_log
+                                outbox_log.append(
+                                    channel_type="discord_dm",
+                                    recipient=str(owner_id),
+                                    body=clean_text,
+                                    task_id=f.stem,
+                                )
+                            except Exception:
+                                pass
                         for fpath in files:
                             fpath = os.path.expanduser(fpath.strip())
                             if _is_path_sendable(fpath):
@@ -3089,6 +3110,16 @@ async def poll_dm_fallback():
                             if text_only:
                                 for chunk in _chunk_for_discord(text_only):
                                     await target_channel.send(chunk)
+                                try:
+                                    import outbox_log
+                                    outbox_log.append(
+                                        channel_type="discord_channel",
+                                        recipient=str(target_channel_id),
+                                        body=text_only,
+                                        task_id=_task_id,
+                                    )
+                                except Exception:
+                                    pass
                             for fpath in file_list:
                                 fpath = os.path.expanduser(fpath.strip())
                                 if _is_path_sendable(fpath):

--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -256,6 +256,16 @@ def send_dm(text: str) -> bool:
     print(
         f"dm-result: sent to DM ({len(text)} chars in {len(chunks)} chunk(s)) via channel {channel_id}"
     )
+    try:
+        import outbox_log
+        outbox_log.append(
+            channel_type="discord_dm",
+            recipient=str(owner_id),
+            body=text,
+            recipient_label="owner DM (via dm-result.py)",
+        )
+    except Exception:
+        pass
     return True
 
 

--- a/src/outbox_log.py
+++ b/src/outbox_log.py
@@ -1,0 +1,130 @@
+"""Outbox visibility log — single append-only sink for outbound messages.
+
+Every bridge (Discord, Slack, Telegram, …) and every owner-facing skill that
+sends messages to a non-owner audience writes one JSON-line per delivery to
+`<workspace>/state/outbox.log`. Owner can then audit what Sutando has said
+on their behalf via `tail -f`, the dashboard Outbox tab (follow-up PR), or
+ad-hoc `jq` queries.
+
+Schema (one JSON object per line, newline-delimited):
+
+    {
+      "ts": 1779253245.123,
+      "iso_ts": "2026-05-19T22:04:05Z",
+      "core_id": "1" | "2" | "legacy" | "unknown",
+      "channel_type": "discord_dm" | "discord_channel" |
+                      "slack_dm" | "slack_channel" |
+                      "telegram",
+      "recipient": "<user_id or channel_id>",
+      "recipient_label": "Qingyun (owner) DM" | "#dev" | ...   (optional, best-effort),
+      "task_id": "<originating task id>"                       (optional),
+      "body_preview": "<first 200 chars of body, single line>",
+      "body_len": <int>
+    }
+
+Design choices:
+- Append-only line-delimited JSON: tail/jq friendly, no rotation required at
+  this volume (a few hundred entries a day).
+- `body_preview` is a one-line collapse capped at 200 chars — surfaces enough
+  context for audit without bloating the log or leaking long secrets.
+- Calls into `append()` MUST NOT raise. Observability never blocks delivery.
+- File location resolved through `workspace_default.resolve_workspace()` so
+  bridges and dashboard read the same place.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+# Match the bridge convention — src/ is on path so a sibling import works.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from workspace_default import resolve_workspace  # noqa: E402
+
+
+_PREVIEW_MAX = 200
+
+
+def _outbox_path() -> Path:
+    return resolve_workspace() / "state" / "outbox.log"
+
+
+def _preview(body: str) -> str:
+    """Collapse newlines into pilcrows and cap to _PREVIEW_MAX chars."""
+    flat = body.replace("\r\n", "\n").replace("\n", " ¶ ").strip()
+    if len(flat) > _PREVIEW_MAX:
+        return flat[: _PREVIEW_MAX - 1] + "…"
+    return flat
+
+
+def append(
+    *,
+    channel_type: str,
+    recipient: str,
+    body: str,
+    core_id: str | None = None,
+    task_id: str | None = None,
+    recipient_label: str | None = None,
+) -> None:
+    """Append one entry to the outbox log.
+
+    Never raises — outbox visibility must not block message delivery. If the
+    workspace path can't be resolved or the file can't be written, the call
+    silently no-ops. Bridges should call this immediately after a successful
+    `send` (not before — we log what actually went out, not what was attempted).
+    """
+    try:
+        path = _outbox_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        now = time.time()
+        entry: dict = {
+            "ts": now,
+            "iso_ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)),
+            "core_id": core_id or os.environ.get("SUTANDO_CORE_ID", "unknown"),
+            "channel_type": channel_type,
+            "recipient": recipient,
+            "body_preview": _preview(body),
+            "body_len": len(body),
+        }
+        if task_id:
+            entry["task_id"] = task_id
+        if recipient_label:
+            entry["recipient_label"] = recipient_label
+        line = json.dumps(entry, ensure_ascii=False) + "\n"
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line)
+    except Exception:
+        # Outbox is observability — never crash the send path.
+        pass
+
+
+def read_recent(limit: int = 50) -> list[dict]:
+    """Return the last `limit` entries (oldest first), best-effort.
+
+    Used by the dashboard Outbox tab (follow-up PR) and by ad-hoc operator
+    queries. Silently skips malformed lines so a single corrupt entry can't
+    blank the view.
+    """
+    try:
+        path = _outbox_path()
+        if not path.is_file():
+            return []
+        with open(path, "r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except Exception:
+        return []
+    out: list[dict] = []
+    for line in lines[-limit:]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -455,7 +455,7 @@ def _send_file(channel: str, thread_ts: str | None, fpath: str) -> bool:
         return False
 
 
-def _send_reply(channel: str, thread_ts: str | None, text: str) -> None:
+def _send_reply(channel: str, thread_ts: str | None, text: str, task_id: str | None = None) -> None:
     """Post a reply via chat.postMessage with marker extraction.
 
     Honors the unified marker protocol from `src/result_markers.py` (#873):
@@ -489,6 +489,7 @@ def _send_reply(channel: str, thread_ts: str | None, text: str) -> None:
     # Post the text body in 4000-char chunks (Slack's per-message limit is
     # 40k chars but readability suffers above ~4k).
     if clean_text:
+        all_chunks_sent = True
         for i in range(0, len(clean_text), 4000):
             kwargs = {"channel": channel, "text": clean_text[i:i + 4000]}
             if thread_ts:
@@ -497,7 +498,22 @@ def _send_reply(channel: str, thread_ts: str | None, text: str) -> None:
                 app.client.chat_postMessage(**kwargs)
             except Exception as e:
                 print(f"[Slack] chat_postMessage failed: {e}", flush=True)
+                all_chunks_sent = False
                 break
+        if all_chunks_sent:
+            # Slack channel id starts with D (DM), C (public/private channel),
+            # G (legacy group). Best-effort classification for the audit log.
+            ch_type = "slack_dm" if channel.startswith("D") else "slack_channel"
+            try:
+                import outbox_log
+                outbox_log.append(
+                    channel_type=ch_type,
+                    recipient=channel,
+                    body=clean_text,
+                    task_id=task_id,
+                )
+            except Exception:
+                pass
 
     # Then upload each file. Fail-closed via _is_path_sendable.
     for fpath in file_paths:
@@ -554,7 +570,7 @@ def result_watcher():
                     print(f"  Skipped (marker): {task_id}", flush=True)
                 else:
                     try:
-                        _send_reply(target["channel"], target.get("thread_ts"), reply_text)
+                        _send_reply(target["channel"], target.get("thread_ts"), reply_text, task_id=task_id)
                         print(f"  Replied to {target['channel']}: {reply_text[:80]}...", flush=True)
                     except Exception as e:
                         print(f"[Slack] reply error: {e}", flush=True)

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -310,7 +310,7 @@ def send_file(chat_id, file_path, caption=""):
         print(f"  Send file failed: {e}")
         return {"ok": False}
 
-def send_reply(chat_id, text):
+def send_reply(chat_id, text, task_id: str | None = None):
     import re
     # Extract file paths: [file: /path/to/file] or [send: /path/to/file]
     file_pattern = re.compile(r'\[(?:file|send|attach):\s*([^\]]+)\]')
@@ -321,6 +321,16 @@ def send_reply(chat_id, text):
     if clean_text:
         for i in range(0, len(clean_text), 4000):
             api("sendMessage", chat_id=chat_id, text=clean_text[i:i+4000])
+        try:
+            import outbox_log
+            outbox_log.append(
+                channel_type="telegram",
+                recipient=str(chat_id),
+                body=clean_text,
+                task_id=task_id,
+            )
+        except Exception:
+            pass
 
     # Send files (allowlist-gated; see _is_path_sendable)
     for fpath in files:
@@ -499,7 +509,7 @@ def main():
                     archive_file(task_file, "tasks", task_id)
                     continue
                 try:
-                    send_reply(chat_id, reply_text)
+                    send_reply(chat_id, reply_text, task_id=task_id)
                     print(f"  Replied to {chat_id}: {reply_text[:80]}...", flush=True)
                 except Exception as e:
                     print(f"[Telegram] Reply error: {e}", flush=True)

--- a/tests/outbox-log.test.py
+++ b/tests/outbox-log.test.py
@@ -1,0 +1,152 @@
+"""Unit tests for src/outbox_log.py.
+
+Run: `python3 tests/outbox-log.test.py`
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+import outbox_log  # noqa: E402
+
+
+class TestOutboxAppend(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+        os.environ["SUTANDO_WORKSPACE"] = str(self.workspace)
+        # Some helper modules cache resolve_workspace via module-level constants;
+        # outbox_log does NOT cache (calls _outbox_path() fresh on each append)
+        # so we don't need to reload.
+
+    def tearDown(self):
+        os.environ.pop("SUTANDO_WORKSPACE", None)
+        self.tmp.cleanup()
+
+    def _read(self) -> list[dict]:
+        path = self.workspace / "state" / "outbox.log"
+        if not path.is_file():
+            return []
+        return [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+    def test_append_writes_one_jsonl_entry(self):
+        outbox_log.append(
+            channel_type="discord_channel",
+            recipient="C09XYZ",
+            body="Hello world",
+            core_id="2",
+        )
+        rows = self._read()
+        self.assertEqual(len(rows), 1)
+        r = rows[0]
+        self.assertEqual(r["channel_type"], "discord_channel")
+        self.assertEqual(r["recipient"], "C09XYZ")
+        self.assertEqual(r["core_id"], "2")
+        self.assertEqual(r["body_preview"], "Hello world")
+        self.assertEqual(r["body_len"], len("Hello world"))
+        self.assertIn("ts", r)
+        self.assertIn("iso_ts", r)
+
+    def test_append_collapses_newlines_in_preview(self):
+        outbox_log.append(
+            channel_type="discord_dm",
+            recipient="1025828152183885925",
+            body="line one\nline two\nline three",
+        )
+        r = self._read()[0]
+        self.assertIn("¶", r["body_preview"])
+        self.assertNotIn("\n", r["body_preview"])
+        # body_len preserves the original (pre-collapse) length.
+        self.assertEqual(r["body_len"], len("line one\nline two\nline three"))
+
+    def test_append_truncates_long_preview(self):
+        body = "x" * 500
+        outbox_log.append(channel_type="telegram", recipient="123", body=body)
+        r = self._read()[0]
+        self.assertLessEqual(len(r["body_preview"]), 200)
+        self.assertTrue(r["body_preview"].endswith("…"))
+        self.assertEqual(r["body_len"], 500)
+
+    def test_append_preserves_utf8(self):
+        body = "中文测试 🎉"
+        outbox_log.append(channel_type="discord_dm", recipient="1025828152183885925", body=body)
+        r = self._read()[0]
+        self.assertEqual(r["body_preview"], body)
+        # Raw file should contain UTF-8, not \uXXXX escapes.
+        raw = (self.workspace / "state" / "outbox.log").read_text(encoding="utf-8")
+        self.assertIn("中文测试", raw)
+        self.assertIn("🎉", raw)
+
+    def test_optional_fields_emitted_when_provided(self):
+        outbox_log.append(
+            channel_type="slack_channel",
+            recipient="C09XYZ",
+            body="...",
+            task_id="task-1779253146729",
+            recipient_label="#dev",
+        )
+        r = self._read()[0]
+        self.assertEqual(r["task_id"], "task-1779253146729")
+        self.assertEqual(r["recipient_label"], "#dev")
+
+    def test_optional_fields_omitted_when_absent(self):
+        outbox_log.append(channel_type="telegram", recipient="123", body="x")
+        r = self._read()[0]
+        self.assertNotIn("task_id", r)
+        self.assertNotIn("recipient_label", r)
+
+    def test_core_id_falls_back_to_env(self):
+        os.environ["SUTANDO_CORE_ID"] = "test-core"
+        try:
+            outbox_log.append(channel_type="telegram", recipient="123", body="x")
+            r = self._read()[0]
+            self.assertEqual(r["core_id"], "test-core")
+        finally:
+            os.environ.pop("SUTANDO_CORE_ID", None)
+
+    def test_core_id_unknown_when_neither_provided(self):
+        os.environ.pop("SUTANDO_CORE_ID", None)
+        outbox_log.append(channel_type="telegram", recipient="123", body="x")
+        r = self._read()[0]
+        self.assertEqual(r["core_id"], "unknown")
+
+    def test_append_never_raises_on_bad_workspace(self):
+        # Point workspace at a path the test user cannot write to.
+        os.environ["SUTANDO_WORKSPACE"] = "/nonexistent/cannot/create/here"
+        # Must not raise.
+        outbox_log.append(channel_type="telegram", recipient="123", body="x")
+
+    def test_append_appends_not_overwrites(self):
+        for i in range(3):
+            outbox_log.append(channel_type="telegram", recipient=str(i), body=f"msg {i}")
+        rows = self._read()
+        self.assertEqual(len(rows), 3)
+        self.assertEqual([r["recipient"] for r in rows], ["0", "1", "2"])
+
+    def test_read_recent_returns_last_n(self):
+        for i in range(10):
+            outbox_log.append(channel_type="telegram", recipient=str(i), body=f"m{i}")
+        rows = outbox_log.read_recent(limit=3)
+        self.assertEqual([r["recipient"] for r in rows], ["7", "8", "9"])
+
+    def test_read_recent_empty_when_no_file(self):
+        self.assertEqual(outbox_log.read_recent(), [])
+
+    def test_read_recent_skips_malformed_lines(self):
+        outbox_log.append(channel_type="telegram", recipient="ok", body="x")
+        # Corrupt the file by injecting a non-JSON line.
+        path = self.workspace / "state" / "outbox.log"
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write("not-json-at-all\n")
+        outbox_log.append(channel_type="telegram", recipient="ok2", body="y")
+        rows = outbox_log.read_recent()
+        self.assertEqual([r["recipient"] for r in rows], ["ok", "ok2"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `state/outbox.log` — a single append-only audit trail of every message any Sutando bridge sends, so owner can answer "what did Sutando just send and to whom?" without grepping per-bridge logs.

Origin: owner safety concern in Discord 2026-05-19 — "if Sutando DMs another user, can I see what was sent?" Investigation showed Discord/Telegram DMs are hard-coded to owner (code-enforced safe), but channel posts via `[channel:]` redirect and the skill-side fan-outs (wacli/iMessage/Mail/X) currently leave no audit trail.

This is **Phase A** — the three running bridges. **Phase B** (follow-up issue) wraps the skill-side fan-outs (wacli / iMessage / Mail / X) and adds a dashboard Outbox tab.

## What's logged (Phase A)

| Bridge | Call site | What it captures |
|---|---|---|
| `discord-bridge.py` | task reply (`channel.send`), proactive DM (`dm.send`), `[channel:]` redirect (`target_channel.send`) | DM + channel posts |
| `slack-bridge.py` | `_send_reply()` after chunk loop succeeds | DM (D-prefix) + channel (C-prefix) classification |
| `telegram-bridge.py` | `send_reply()` after chunk loop | sendMessage targets |
| `dm-result.py` | `send_dm()` after all chunks delivered | owner DM fallback path |

## Schema

One JSON-line per delivery in `<workspace>/state/outbox.log`:
```json
{
  "ts": 1779253245.123,
  "iso_ts": "2026-05-19T22:04:05Z",
  "core_id": "1",
  "channel_type": "discord_channel",
  "recipient": "1504379900050673747",
  "body_preview": "**[core: 1]** Hi! Here is the…",
  "body_len": 1843,
  "task_id": "task-1779253146729",
  "recipient_label": "#dev"
}
```

`recipient_label` and `task_id` are optional (emitted when known).

## Design choices

- **`append()` never raises** — observability never blocks delivery. If the workspace path can't be resolved or the file isn't writable, the call silently no-ops.
- **Logged AFTER successful send**, not before — captures what actually went out (Discord/Slack/Telegram have a `break` on send failure that prevents the log call).
- **UTF-8 preserved** (`ensure_ascii=False`) so Chinese / emoji are human-readable, not `\uXXXX` escapes.
- **`body_preview` is one-line capped at 200 chars** — surfaces enough audit context without bloating the log or leaking secrets.
- **`read_recent(limit)`** helper for ad-hoc + dashboard consumers; tolerates malformed lines so one corrupt entry can't blank the view.

## Audit usage today

```
tail -f $SUTANDO_WORKSPACE/state/outbox.log | jq .
jq 'select(.channel_type=="discord_channel")' state/outbox.log | head -20
jq -r '"\(.iso_ts)\t\(.core_id)\t\(.channel_type)\t\(.recipient)\t\(.body_preview)"' state/outbox.log | tail -20
```

## Test plan

- [x] 13 new cases in `tests/outbox-log.test.py`: append-writes-one-jsonl, newline-collapse, 200-char truncation, UTF-8 roundtrip, optional-field shape (present + absent), `core_id` env fallback + `unknown` default, never-raises-on-bad-workspace, append-not-overwrite, `read_recent` tail + malformed-skip semantics. `python3 tests/outbox-log.test.py` → 13/13 OK.
- [x] Existing result-markers suite still green (`python3 tests/result-markers.test.py` → 24/24 OK).
- [ ] Restart all three bridges in a live workspace; confirm `state/outbox.log` accumulates entries on real Discord/Telegram/Slack traffic and that nothing breaks the send path when the workspace is read-only.

## Phase B (deliberately out of scope here)

- Dashboard Outbox tab (`src/dashboard.py`)
- Skill-side instrumentation: wrap `wacli send`, iMessage `osascript`, Mail draft+send, X-post — the actually-arbitrary-recipient fan-outs. These are where the owner's safety concern bites hardest; Phase A only covers the bridges that currently DM owner only.

Tracks #880 (multi-core quality bar — continuous benchmark + systematic fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)