### PR TITLE
[WIP] fix(conversation-store): stable conversational sequence via insertion-order id

### DIFF
--- a/scripts/query-conversation.sh
+++ b/scripts/query-conversation.sh
@@ -65,6 +65,6 @@ SELECT datetime(ts_unix, 'unixepoch', 'localtime') AS ts,
        substr(text, 1, 200) AS text_preview
 FROM conversation
 $where_clause
-ORDER BY ts_unix DESC
+ORDER BY rowid DESC
 LIMIT $limit;
 "

--- a/src/conversation-store.ts
+++ b/src/conversation-store.ts
@@ -46,7 +46,14 @@ function init(): void {
 		db.exec('PRAGMA journal_mode = WAL');
 		db.exec('PRAGMA busy_timeout = 1000');
 		db.exec(`
+			-- id: monotonic insertion-order key — the canonical conversational
+			-- sequence. Replay a conversation by ORDER BY id, never by ts_unix
+			-- alone: agent rows are stamped with a calibrated heard-offset
+			-- (audio-out time + offset), so ts_unix can disagree with the true
+			-- turn order and a pure ts_unix sort scrambles an exchange. ts_unix
+			-- stays for time-range filters ("what did we say around 9pm").
 			CREATE TABLE IF NOT EXISTS conversation (
+				id         INTEGER PRIMARY KEY,
 				ts_unix    REAL NOT NULL,
 				role       TEXT NOT NULL,
 				text       TEXT NOT NULL,


### PR DESCRIPTION
## Problem

A sequential conversation read back from the store must not scramble — but ordering the `conversation` table by `ts_unix` alone does scramble it:

- Agent rows are stamped with a **calibrated heard-offset** (audio-out time + `HEARD_OFFSET_SEC`, the discord-voice "when the user actually heard it" timestamp). That puts agent rows on a different time basis than user rows — an agent reply's `ts_unix` can land *after* the next user turn.
- Same-/near-millisecond rows reorder arbitrarily under a pure `ts_unix` sort.

Either way, replaying an exchange ordered by `ts_unix` can show the reply before the question, or interleave turns wrong.

## Fix

- **`conversation` table**: add `id INTEGER PRIMARY KEY` — a monotonic insertion-order key (aliases SQLite's `rowid`). Rows are inserted in true turn order (the text `conversation.log` is append-only; the sqlite mirror follows it row-for-row), so `id` is the canonical conversational sequence.
- **`query-conversation.sh`**: `ORDER BY rowid` instead of `ORDER BY ts_unix`, so results come back in true conversational order regardless of timestamp drift. `rowid` works on both the new schema and pre-existing DBs — no migration needed.

`ts_unix` stays indexed and is still the right key for time-range queries ("what did we say around 9pm"). The rule: **filter by `ts_unix`, order by `id`/`rowid`.**

## Scope

Addresses the **ordering** half of #791 review finding 5 (sutando#9708). The idempotency / unique-key half is intentionally not in this PR — the live `conversation.sqlite` already has duplicate rows, so `CREATE UNIQUE INDEX` needs a dedup migration first; that's a separate change.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Fresh DB: 3 turns written via `recordConversation`; `query-conversation.sh --last` returns them in true insertion order (newest-first); `ORDER BY id` confirms 1/2/3 sequence.
- [x] `rowid` ordering verified to work without the explicit `id` column (pre-existing-DB compatibility).

— Lucy (Mac Studio bot)