### PR TITLE
fix(schedule-crons): remove cross-node-sync from default cron template

### DIFF
--- a/skills/cross-node-sync/SKILL.md
+++ b/skills/cross-node-sync/SKILL.md
@@ -59,15 +59,23 @@ export SUTANDO_PEER_NOTES_DIR="/Users/xliu/path/to/sutando/notes/"
 
 Get the peer's values with `ssh $SUTANDO_SYNC_PEER 'echo $HOME; ls -d ~/.claude/projects/-*sutando*'`.
 
-**Cron wiring (first install):** the `cross-node-sync` entry already lives in `skills/schedule-crons/crons.example.json`, so the usual first-time `cp skills/schedule-crons/crons.example.json skills/schedule-crons/crons.json` wires the 7-minute sync into the proactive-loop crons with no manual JSON editing. (7 min chosen to avoid `:00/:30` collision with other crons.)
+**Cron wiring (explicit opt-in):** as of #936, the `cross-node-sync` entry is **no longer** in `skills/schedule-crons/crons.example.json` — the default `cp ... crons.json` doesn't wire it. Cross-node-sync requires `SUTANDO_SYNC_PEER` + SSH peer auth + the per-file-frontmatter memory model, none of which apply to a single-host setup, so it's opt-in.
 
-**Cron wiring (upgrading an existing install):** if you cloned Sutando before this skill was added (or have a live `crons.json` that predates the example), the entry will be **missing** from your live file. Check with:
+If you want the 7-minute sync, add this block to your live `skills/schedule-crons/crons.json` (inside the top-level array):
 
-```bash
-jq '.jobs[].name' skills/schedule-crons/crons.json | grep cross-node-sync || echo "MISSING — add manually"
+```json
+{
+  "name": "cross-node-sync",
+  "cron": "*/7 * * * *",
+  "prompt": "Run bash skills/cross-node-sync/scripts/setup-rsync-sync.sh to sync memory/ + notes/ with the peer node (requires SUTANDO_SYNC_PEER in .env). Then regenerate MEMORY.md from frontmatter."
+}
 ```
 
-To add, copy the `cross-node-sync` block from `crons.example.json` into your `crons.json`'s `jobs` array. `feedback_sync_crons_json.md` in memory reminds to always mirror cron config changes between the two files so future re-copies work.
+(7 min chosen to avoid `:00/:30` collision with other crons.) Verify with:
+
+```bash
+jq '.[].name' skills/schedule-crons/crons.json | grep cross-node-sync || echo "MISSING — add manually"
+```
 
 **Manual sync (optional):**
 ```bash

--- a/skills/schedule-crons/crons.example.json
+++ b/skills/schedule-crons/crons.example.json
@@ -23,10 +23,5 @@
     "name": "sync-memory",
     "cron": "*/30 * * * *",
     "prompt": "Run bash scripts/sync-memory.sh to sync memory and notes to the private memory repo (requires SUTANDO_MEMORY_REPO in .env)."
-  },
-  {
-    "name": "cross-node-sync",
-    "cron": "*/7 * * * *",
-    "prompt": "Run bash skills/cross-node-sync/scripts/setup-rsync-sync.sh to sync memory/ + notes/ with the peer node (requires SUTANDO_SYNC_PEER in .env). Then regenerate MEMORY.md from frontmatter."
   }
 ]


### PR DESCRIPTION
## Summary

- Remove `cross-node-sync` from `skills/schedule-crons/crons.example.json` so new users don't auto-wire it
- Keeps the skill itself intact (`skills/cross-node-sync/`) — still available as explicit opt-in via its SKILL.md

## Why

`cross-node-sync` requires:
- `SUTANDO_SYNC_PEER` env var + SSH key pair between two physical nodes
- Per-file-frontmatter memory model as source of truth

Default new-user installs:
- have **no peer** (single-host) → rsync skips, but the chained `regenerate-memory-index.py` still fires
- start with **inline entries** in `MEMORY.md` (`# userEmail`, `# currentDate` from auto-memory init)

#806 just landed a defensive guard so regen refuses to clobber when 0 frontmatter entries + non-empty target. But the guard only fires at the *zero-entries* boundary. Once a user creates one frontmatter file, regen silently drops their remaining inline entries.

Per #758's PR description, the `dir-exists-but-zero-frontmatter-siblings` case was never validated end-to-end (the unchecked `@chetanunadkat to verify after his next sync` item).

Net: make the cron explicit opt-in. Single-host users don't need rsync-over-ssh; multi-host users add it deliberately when they set up peer auth.

## Test plan

- [x] `crons.example.json` parses as valid JSON after edit
- [x] `cross-node-sync` entry removed; other 5 default crons preserved
- [x] Existing users with already-copied `crons.json` are unaffected (this file is `.example` template only)

Refs #787 (the clobber bug), #806 (defensive guard, just merged), #758 (the auto-call wiring that introduced this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)