### PR TITLE
feat(ci): quiet mode for Python standalone tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,27 @@ jobs:
       - name: Run tests
         run: npm test
         if: hashFiles('tests/**/*.test.ts') != ''
+
+      # Run standalone Python tests (*.test.py) — stdlib-only, no deps needed.
+      # Covers telegram-bridge TOFU tri-state, slack-bridge tier-map, discord-bridge
+      # access tiers, result-markers, and more. See #897.
+      #
+      # Quiet mode: suppress PASS lines (only FAIL + summary shown) to keep CI
+      # log compact across 32+ test files. Non-zero exit on any failure.
+      - name: Run Python standalone tests
+        run: |
+          failed=0
+          while IFS= read -r f; do
+            echo "→ $f"
+            output=$(python3 "$f" 2>&1)
+            rc=$?
+            # Always show FAIL lines and summary
+            echo "$output" | grep -E 'FAIL|^Results:' || true
+            if [ $rc -ne 0 ]; then
+              # Test failed — emit full output (PASS + FAIL + traceback) so
+              # debugging info isn't dropped on ImportError / uncaught exception.
+              echo "$output"
+              failed=1
+            fi
+          done < <(find tests -name '*.test.py' -not -path '*/node_modules/*' | sort)
+          exit "$failed"


### PR DESCRIPTION
## Summary

Follow-up per @sonichi review feedback on #928.

Adds quiet mode to the Python test CI step: suppress verbose PASS lines and only show:
- FAIL lines (always)
- Summary lines (`Results: X passed, Y failed`, etc.) (always)
- PASS lines (only on failure, for context)

### Before (verbose)
```
→ tests/slack-bridge-tier-map.test.py
PASS: Uowner unmapped → owner default
PASS: Uteam mapped → team
PASS: Uother mapped → other
... 10 lines
Results: 10 passed, 0 failed
```
× 32 files = ~400 lines

### After (quiet)
```
→ tests/slack-bridge-tier-map.test.py
Results: 10 passed, 0 failed
```
× 32 files = ~70 lines

On failure, full PASS + FAIL context is shown so CI log remains actionable.

### Testing

All 32 tests pass locally. No changes to individual test files — filtering is in the CI step only.

## Also filed

- Issue #937 — tracking split-default tier resolution for discord-bridge + telegram-bridge (per sonichi review feedback on #925)