### PR TITLE
docs(work-status): write core-status.json to absolute workspace path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,14 @@ If `PERSONAL_CLAUDE.md` exists in the workspace root, read and follow it. It con
 
 ## Work Status
 
-Signal your work status to `state/core-status.json` so the web UI can display it:
-- Start of significant work: `echo '{"status":"running","step":"<description>","ts":<epoch>}' > state/core-status.json`
-- When done: `echo '{"status":"idle","ts":<epoch>}' > state/core-status.json`
+Signal your work status to the workspace `core-status.json` so the web UI and `health-check.py` can display it. Write the **absolute** workspace path: the session cwd is the repo, so a bare `state/core-status.json` lands in `<repo>/state/` — where no reader looks. Readers resolve `<workspace>/state/core-status.json` via `status_read_path` (`src/workspace_default.py`).
+
+```bash
+CORE_STATUS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/state/core-status.json"
+echo '{"status":"running","step":"<description>","ts":<epoch>}' > "$CORE_STATUS"   # start of significant work
+echo '{"status":"idle","ts":<epoch>}' > "$CORE_STATUS"                            # when done
+```
+
 This applies to all work — proactive loop passes, voice tasks, user requests, code changes.
 
 ## Chat-path task tracking (issue #585)


### PR DESCRIPTION
## Problem

The **Work Status** section of `CLAUDE.md` told agents to write status with a bare relative path:

```
echo '{...}' > state/core-status.json
```

But a proactive-loop / voice / task session runs with **cwd = the repo**, so the write lands in `<repo>/state/core-status.json`. Every reader — `health-check.py`, the web UI — resolves `<workspace>/state/core-status.json` via `status_read_path()` in `src/workspace_default.py`.

The two paths never meet. Observed this pass: `health-check.py` reported a false

```
⚠ core-proactive-loop  warn  running for 961s ... last heartbeat > 600s ago
```

while the loop was running normally — and the web UI showed a stale `step`. The repo also accumulates a junk `<repo>/state/` directory from these mis-targeted writes.

## Fix

Doc-only. Rewrites the recipe to write the **absolute** workspace path, matching the canonical write location documented at `workspace_default.py:status_path` (`<workspace>/state/<name>`):

```bash
CORE_STATUS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/state/core-status.json"
echo '{...}' > "$CORE_STATUS"
```

## Not in scope (follow-ups)

- The proactive-loop `SKILL.md` step 0 has the same bare-path wording.
- `<repo>/state/` also collects `learning-mac-mini.*` files — a separate code-side writer not honoring the workspace helper. Worth a `workspace_default`-based fix per `feedback_curate_split_brain_state_path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)