### PR TITLE
fix(startup): stop setting git committer.* — it CLA-blocks every fleet PR

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -14,26 +14,20 @@ cd "$REPO"
 # $SUTANDO_ROOT.
 export SUTANDO_ROOT="$REPO"
 
-# Git committer attribution from stand-identity.json (opt-in, no env var).
-# The repo-local `user.email` (set to the GitHub privacy noreply) is the
-# AUTHOR — CLA-Assistant resolves it to the owner's GitHub account, gating
-# the PR check. The COMMITTER is free to carry per-host attribution so that
-# `git log --format='%h %an / %cn %s'` distinguishes which Sutando host
-# crafted each commit (Mini, MacBook, …). Without this, all bot commits
-# share both fields and you lose track of which fleet host did the work.
+# Git committer attribution: REMOVED (2026-05-21). This block used to set
+# committer.name/committer.email from stand-identity.json so `git log %cn`
+# showed which fleet host crafted a commit. But git 2.31+ honors committer.*
+# config natively, making the COMMITTER a non-GitHub identity
+# (`<host>@noreply.sutando.local`) — and CLA-Assistant gates on BOTH the
+# author AND the committer. Result: every fleet commit was CLA-blocked
+# (PR #947 and others, 2026-05-21). Per-host attribution is not worth
+# blocking every PR; if still wanted, carry it in a commit-message trailer
+# (CLA-Assistant ignores trailers), never in the committer identity.
 #
-# Silent fall-through on every "no identity" path: missing file, missing
-# jq, empty/malformed fields. OSS users see no change — they don't ship a
-# stand-identity.json. Fleet hosts opt in by virtue of having one.
-if [ -f "$REPO/stand-identity.json" ] && command -v jq > /dev/null 2>&1; then
-  _stand_name=$(jq -r '.name // empty' "$REPO/stand-identity.json" 2>/dev/null)
-  _stand_machine=$(jq -r '.machine // empty' "$REPO/stand-identity.json" 2>/dev/null)
-  if [ -n "$_stand_name" ] && [ -n "$_stand_machine" ]; then
-    git -C "$REPO" config committer.name "$_stand_name"
-    git -C "$REPO" config committer.email "${_stand_machine}@noreply.sutando.local"
-  fi
-  unset _stand_name _stand_machine
-fi
+# Actively clear any stale committer.* a prior startup wrote, so every
+# fleet host self-heals on its next boot.
+git -C "$REPO" config --unset committer.name 2>/dev/null || true
+git -C "$REPO" config --unset committer.email 2>/dev/null || true
 
 # Auto-bootstrap: create-if-missing files and dirs that the agent + skills
 # expect to exist (logs, state, tasks, results, notes, contextual-chips.json,


### PR DESCRIPTION
## Problem

`src/startup.sh` derived `committer.name` / `committer.email` from `stand-identity.json` on every boot, so `git log %cn` would show which fleet host (Mini, MacBook…) crafted a commit. The block's comment explicitly reasoned that only the **author** gates CLA-Assistant, so the committer was "free to carry per-host attribution."

That reasoning is wrong. **git 2.31+ honors `committer.*` config natively**, so the committer became `<host>@noreply.sutando.local` — a non-GitHub identity with no CLA signature. **CLA-Assistant checks both author and committer.**

Result: every commit authored on a fleet host failed the CLA gate on the committer field alone, even with a CLA-signed author. PR #947 and others were blocked this way; multiple contributors reported being stuck.

Verified on this machine — commit `54d78a7`:
```
author:    Chi Wang <4250911+sonichi@users.noreply.github.com>   ✅ CLA-signed
committer: Echo Act IV (Mini) <mac-mini@noreply.sutando.local>   ❌ no GitHub user
```

## Fix

- Remove the `committer.*`-setting block from `startup.sh`.
- Additionally `--unset committer.name/email` on every startup, so any host that already has the stale keys in `.git/config` **self-heals on next boot** — no manual per-host cleanup.

After this, committer falls back to `user.*` (the CLA-signed GitHub-noreply identity), matching the author.

## Note

Per-host attribution isn't worth blocking every PR. If it's still wanted, it belongs in a commit-message **trailer** (CLA-Assistant ignores trailers) — not the committer identity. Out of scope here; this PR just unblocks the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)