### PR TITLE
fix(proactive-loop): write core-status.json to absolute workspace path (closes #951)

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -35,7 +35,7 @@ You are Sutando — a personal AI agent running as this Claude Code session.
 
 Each pass, in order:
 
-0. **Signal loop start.** Write `{"status":"running","step":"Starting pass...","ts":DATE_NOW}` to `core-status.json`. Update the `step` field as you progress through each step. Write `{"status":"idle","ts":DATE_NOW}` when the pass ends.
+0. **Signal loop start.** Write `{"status":"running","step":"Starting pass...","ts":DATE_NOW}` to the **absolute** workspace path `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/state/core-status.json` — the session cwd is the repo, so a bare `core-status.json` lands in `<repo>/` where no reader looks (`health-check.py` and the web UI resolve `<workspace>/state/core-status.json` via `status_read_path`). Update the `step` field as you progress through each step; write `{"status":"idle","ts":DATE_NOW}` when the pass ends.
 
 0.5. **Check quota.** Run `python3 ~/.claude/skills/quota-tracker/scripts/read-quota.py`. Note remaining % and exact reset time.
    - **Budget per pass** = remaining % / (minutes until reset / 5)


### PR DESCRIPTION
Closes #951.

## Problem

`skills/proactive-loop/SKILL.md` step 0 instructed the loop to write a bare relative `core-status.json`. The session cwd is the repo root, so the file lands at `<repo>/core-status.json` — while every reader (`health-check.py`, the web UI) resolves `<workspace>/state/core-status.json` via `status_read_path` (`src/workspace_default.py`).

Same split-brain #947 fixed for the CLAUDE.md "Work Status" recipe. Symptom: `health-check.py` false-warns `core-proactive-loop ... heartbeat > 600s` while the loop runs fine, and the web UI shows stale status.

## Fix

Step 0 now names the absolute path `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/state/core-status.json`, matching `workspace_default.py:status_path` and the CLAUDE.md fix from #947.

## Sibling check (per #951)

Grepped `core-status.json` across `skills/*/SKILL.md`:
- `skills/proactive-loop/SKILL.md` — the writer, fixed here.
- `skills/cross-node-sync/SKILL.md` — only lists `core-status.json` in a sync-exclusion bullet (per-node state, not synced). Not a writer; no fix needed.

No other bare-path writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)