### PR TITLE
chore(start-cli): swap bootstrap from /proactive-loop to /schedule-crons

### DIFF
--- a/scripts/start-cli.sh
+++ b/scripts/start-cli.sh
@@ -67,7 +67,7 @@ if ! command -v tmux > /dev/null 2>&1; then
   echo "  ⚠ tmux not found — running without tmux wrapper"
   echo "    (Sutando.app's watcher-auto-restart won't work; brew install tmux to enable)"
   exec claude --name "$SESSION" --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
-    -- "/proactive-loop"
+    -- "/schedule-crons"
 fi
 
 # Explicit -S socket path so Sutando.app (which runs under a different
@@ -96,11 +96,11 @@ tmux -S "$TMUX_SOCKET" set-option -g mouse on 2>/dev/null || true
 if [ -t 1 ]; then
   exec tmux -S "$TMUX_SOCKET" new-session -A -s "$SESSION" \
     claude --name "$SESSION" --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
-    -- "/proactive-loop"
+    -- "/schedule-crons"
 else
   tmux -S "$TMUX_SOCKET" new-session -d -s "$SESSION" \
     claude --name "$SESSION" --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
-    -- "/proactive-loop"
+    -- "/schedule-crons"
   echo "Started $SESSION detached. Attach via Open Core CLI in menu bar, or:"
   echo "  tmux -S $TMUX_SOCKET attach -t $SESSION"
 fi


### PR DESCRIPTION
## Summary
- CLI session no longer runs the legacy `/proactive-loop` skill on startup
- CURATE (`/personal-curate-loop`) and ACT (`/personal-act-loop`) now fire entirely from cron entries (already armed in-session via CronCreate + persisted in `skills/schedule-crons/crons.json`)
- `/schedule-crons` arms the cron jobs and starts the task watcher — same end state, no loop bootstrap needed

Three identical replacements at lines 70/99/103 (no-tmux exec, interactive tmux exec, detached tmux exec).

## Test plan
- [x] Syntax verified locally
- [ ] Next CLI restart picks up new bootstrap; verify cron entries materialize + watcher starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)