### PR TITLE
fix(schedule-crons): step 4 actively starts watch-tasks-stream via Monitor (closes #954 follow-up)

### DIFF
--- a/skills/schedule-crons/SKILL.md
+++ b/skills/schedule-crons/SKILL.md
@@ -25,7 +25,7 @@ Each entry has:
    - Skip if a job with matching prompt/name already exists
    - If `prompt_skill` is set, invoke it as `/skill-name`
    - Call CronCreate with the cron expression and prompt
-4. Ensure a task watcher is running. The canonical pattern is the `Monitor` tool streaming `bash src/watch-tasks-stream.sh` (started by the CLI session itself, not by this skill). If `pgrep -f watch-tasks` finds nothing, prompt the CLI to start it — don't kick off `bash src/watch-tasks.sh` (retired 2026-05-14).
+4. Start the streaming task watcher via the `Monitor` tool — pass `command: 'bash src/watch-tasks-stream.sh'`, `persistent: true`, `description: 'Streaming task watcher'`. The script emits one `TASK_FILE: <basename>` line per new task file (initial sweep + each subsequent event). Read the named file via the Read tool when notifications arrive. (Pattern mirrors `/proactive-loop` activation step 2 — both bootstrap paths land here, so post-#954 CLI startup via `/schedule-crons` immediately gets a watcher; no gap until the first `main-loop` cron fire.) If `pgrep -f watch-tasks-stream` already shows a running watcher, skip the Monitor call — the existing one continues. Don't kick off `bash src/watch-tasks.sh` (retired 2026-05-14).
 5. Confirm what was scheduled
 
 ## Adding New Crons


### PR DESCRIPTION
## Summary

Post-merge review on #954 by Lucy caught a real gap: after bootstrap swap from `/proactive-loop` to `/schedule-crons`, the task watcher no longer started at CLI startup.

**Before:** `/schedule-crons` step 4 only said "ensure a watcher is running, prompt the CLI to start it" — passive. No Monitor invocation, no actual watcher start.

**After #954:** CLI booted via `/schedule-crons` → no watcher started → `main-loop` cron fires every 5 min → `/proactive-loop` step 2 starts the watcher 5 min later. ~5-min startup gap where voice / Discord / owner tasks queue unprocessed. Sutando.app's `checkWatcher` keystroke is a backup but shouldn't be load-bearing.

**Fix:** Step 4 now mirrors `/proactive-loop` activation step 2 — actively invokes `Monitor` with `command: 'bash src/watch-tasks-stream.sh'`, `persistent: true`. Existing watcher (`pgrep`) → skip the Monitor call.

## On Lucy's other question (crons.example.json missing curate-loop / act-loop)

Not fixing that — `curate-loop` / `act-loop` reference *personal* skills (`personal-curate-loop` / `personal-act-loop`) which live in `~/.claude/skills/` (private memory-sync), not the public repo. Fresh public-install doesn't have them. So `crons.example.json` correctly continues to ship just `main-loop` → `/proactive-loop` for fresh installs; personal-skill users add their own entries to the gitignored `crons.json`.

## Test plan

- [x] Diff verified (1 line changed in skills/schedule-crons/SKILL.md step 4)
- [ ] Next CLI restart via the new bootstrap (#954) confirms watcher comes up immediately — `pgrep -f watch-tasks-stream` should show one running before the first cron fires.

## Refs

- #954 — bootstrap swap that introduced the gap
- Lucy's review: discord #dev 2026-05-21 05:21Z (message id 1506889567566037003)
- `feedback_skill_edit_requires_session_restart` — Mini's session may not pick this up until the SKILL.md reload recipe runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)