### PR TITLE
fix(telegram-bridge): from __future__ import annotations — fixes py3.9 crash

### DIFF
--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -6,6 +6,13 @@ Works alongside the voice task bridge. Runs as a background daemon.
 Usage: python3 src/telegram-bridge.py
 """
 
+# startup.sh launches this via bare `python3`, which is /usr/bin/python3 (3.9)
+# on stock macOS. PEP-604 unions (`str | None`) are evaluated at def-time on
+# 3.9 and raise TypeError, crashing the bridge on import. Lazy annotations
+# (PEP 563) make every annotation in this file a string — never evaluated —
+# so 3.9 is safe. Must precede all other imports.
+from __future__ import annotations
+
 import json
 import os
 import sys


### PR DESCRIPTION
## Problem

`telegram-bridge` has been **silently down** — it crashes on import. `src/telegram-bridge.py:313`:

```python
def send_reply(chat_id, text, task_id: str | None = None):
```

`str | None` is a PEP-604 union. `startup.sh:350` launches the bridge via bare `python3`, which on stock macOS is `/usr/bin/python3` = **Python 3.9.6**. On 3.9 the annotation is evaluated at def-time and raises:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

→ the module never finishes importing, the bridge never starts. (Found via `logs/telegram-bridge.log` traceback when the owner asked "is telegram fixed?".)

## Fix

One line — `from __future__ import annotations` (PEP 563) at the top of the file. Makes every annotation a lazy string, never evaluated at runtime, so 3.9 is safe. Same fix class as the earlier health-check py39-typing work.

Verified: `python3 -m py_compile` clean on 3.9; bridge restarted and is running (`health-check.py` → `✓ telegram-bridge ok`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)