### PR TITLE
feat(use-cases): add self-healing-install to the showcase

### DIFF
--- a/community-use-cases/self-healing-install.md
+++ b/community-use-cases/self-healing-install.md
@@ -1,0 +1,10 @@
+---
+slug: self-healing-install
+title: "Your app install failed — your own agent fixed it, unattended"
+summary: "A blocked install fixes itself: your local Sutando clears the false 'damaged' flag, kills the stale processes, and tells the developer what broke — before you're even back at your desk."
+youtubeId: PTO7dmlOhUg
+xUrl: https://x.com/i/status/2057316263488020871
+submitted_at: 2026-05-21T07:08:00Z
+---
+
+A user installs an AG2 app and macOS blocks it as "damaged" — a false alarm, but the app won't open. The user is mid-day and has no 30 minutes to book a debug call with the developer. Their own Sutando — a personal AI agent running locally on their Mac — diagnoses the false flag, clears the quarantine attribute, kills the stale processes that were also breaking the UI, and DMs the developer the root cause. By the time the user is free, the incident is already closed. Useful for anyone who installs developer tools and can't always reach the developer the moment something breaks.


### PR DESCRIPTION
Adds a `community-use-cases/` entry for the **self-healing install** use case, so it lands on sutando.ai's "Use cases" section (the showcase sync job stages `community-use-cases/*.md` entries on merge).

**The use case:** a user's AG2 app install is blocked by a false macOS "damaged" flag; their local Sutando clears the quarantine attribute, kills the stale processes also breaking the UI, and DMs the developer the root cause — unattended, before the user is back at their desk.

**Entry:** `community-use-cases/self-healing-install.md`
- Outcome-framed title, verified against the `submit-use-case` framing checker (`--dry-run` passes).
- Links the @sutando-ai YouTube video (`PTO7dmlOhUg`) + the X post.
- No thumbnail file — the entry carries `youtubeId` so the showcase can use the video thumbnail; a still can be dropped at `community-use-cases/thumbnails/self-healing-install.jpg` later if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)