### PR TITLE
fix(pointer-teacher): route POINTER_CMD_PATH through resolveWorkspace() (closes #934)

### DIFF
--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -9,6 +9,7 @@ import { join } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { demoStateRef } from './recording-state.js';
+import { resolveWorkspace } from './workspace_default.js';
 
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 
@@ -450,10 +451,12 @@ export const clickTool: ToolDefinition = {
 // prompt format without re-running that POC — both choices are load-bearing.
 const POINTER_MODEL = process.env.POINTER_MODEL || 'gemini-3-flash-preview';
 // IPC: Sutando.app watches <workspace>/state via DispatchSource and flies the
-// bezier pointer to whatever lands here. process.cwd() is the repo root for
-// core (same convention as VOICE_SESSION_CONTEXT_PATH / tasks/ / results/),
-// which is also what the Swift app resolves as `workspace`.
-const POINTER_CMD_PATH = join(process.cwd(), 'state', 'pointer-cmd.json');
+// bezier pointer to whatever lands here. Go through resolveWorkspace() so we
+// agree with the Swift side's `AppDelegate.workspace` (added in #837) — not
+// process.cwd(), which silently bifurcates when SUTANDO_WORKSPACE points
+// anywhere other than the launch CWD (closes #934).
+const POINTER_STATE_DIR = join(resolveWorkspace(), 'state');
+const POINTER_CMD_PATH = join(POINTER_STATE_DIR, 'pointer-cmd.json');
 
 // Atomic publish to the pointer IPC file. The temp name is unique per call
 // (pid + ms + random) — a fixed per-process name lets two overlapping point_at
@@ -461,7 +464,7 @@ const POINTER_CMD_PATH = join(process.cwd(), 'state', 'pointer-cmd.json');
 // atomic and the Swift side's monotonic `ts` guard decides which command wins,
 // so no lock is needed.
 function publishPointerCmd(cmd: Record<string, unknown>): void {
-	mkdirSync(join(process.cwd(), 'state'), { recursive: true });
+	mkdirSync(POINTER_STATE_DIR, { recursive: true });
 	const tmpCmd = `${POINTER_CMD_PATH}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 9)}.tmp`;
 	writeFileSync(tmpCmd, JSON.stringify(cmd));
 	renameSync(tmpCmd, POINTER_CMD_PATH);


### PR DESCRIPTION
## Summary

- `src/browser-tools.ts` was resolving the pointer IPC path via `process.cwd()`. Now uses `resolveWorkspace()` per the workspace contract.
- Mirrors the Swift side, which already routes through `AppDelegate.workspace` (= `resolveWorkspace()`).
- Closes #934 (Vidhu's follow-up flag from #889).

## Why

`process.cwd()` works on this node only by coincidence — Sutando.app launches services from the repo root, and on the dev machine `~/Desktop/sutando/state/` happens to be the same APFS inode as `~/.sutando/workspace/state/` (firmlinked). The moment anyone (a) moves the repo, (b) sets `SUTANDO_WORKSPACE` to a non-CWD path, or (c) launches from a different directory, the IPC silently bifurcates: Sutando.app reads `<workspace>/state/pointer-cmd.json`, `point_at` writes `<cwd>/state/pointer-cmd.json`, the watcher never fires, the pointer never flies, the voice agent says nothing. No error.

Same family of bug as #835 (orphan symlinks).

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Sanity: with `SUTANDO_WORKSPACE` unset, `point_at("button")` writes to `~/.sutando/workspace/state/pointer-cmd.json` (the helper default)
- [ ] Sanity: with `SUTANDO_WORKSPACE=/tmp/sw-test`, `point_at(...)` writes to `/tmp/sw-test/state/pointer-cmd.json`
- [ ] End-to-end (after Sutando.app rebuild): both writer and reader see the same file

🤖 Generated with [Claude Code](https://claude.com/claude-code)