### PR TITLE
fix(discord-voice): default DISCORD_VOICE_OWNER to false (safe)

### DIFF
--- a/skills/discord-voice/SKILL.md
+++ b/skills/discord-voice/SKILL.md
@@ -61,21 +61,21 @@ DISCORD_VOICE_SERVER=1 \
 Optional env:
 - `VOICE_MODEL` / `VOICE_NATIVE_AUDIO_MODEL` — mirrors `voice-agent.ts`.
 - `SUTANDO_WORKSPACE` — workspace root for tasks/results/data/logs.
-- `DISCORD_VOICE_OWNER` — `true` (default) treats every speaker in the voice channel as the owner — see **Trust boundary** below.
+- `DISCORD_VOICE_OWNER` — `false` (default) gates owner-tier tools (`work`, file edits, message sends) to the configured `owner` env; non-owner speakers still get the safe read-only surface. Set `=true` to inherit owner privileges to every speaker — only safe in fully-trusted single-operator channels. See **Trust boundary** below.
 
 `DISCORD_VOICE_SERVER=1` flips the polymorphic `dismiss` tool (`src/meeting-tools.ts`) into "SIGTERM self" mode instead of its default Zoom AppleScript path. Without it, asking Sutando to "leave"/"dismiss" in the channel would try to leave a (non-existent) Zoom meeting.
 
-## Trust boundary — read this before inviting the bot anywhere shared
+## Trust boundary — read this before flipping the default
 
-`DISCORD_VOICE_OWNER=true` is the deliberate default for a personal-use bot and it has a sharp edge: **anyone who can speak in the same voice channel inherits owner-tier `work` privileges** — full task delegation, file edits, message sends, anything the proactive loop can do.
+`DISCORD_VOICE_OWNER=false` is the **safe default**: non-owner speakers in the voice channel get the read-only tool surface (current time, status checks, lookups) but NOT owner-tier `work`, file edits, or message sends. Only the configured `owner` env (your own Discord user id) gets the full surface.
 
-This is fine because every Sutando install runs its own bot in its own guild, and the operator controls who they let into the voice channel. But it means:
+`DISCORD_VOICE_OWNER=true` is the opt-in for **single-operator personal-use mode**: it inherits owner-tier privileges to every speaker in the channel. It has a sharp edge — anyone who can speak in the same voice channel can delegate `work`, edit files, send messages, anything the proactive loop can do. Only flip this on for voice channels whose membership is fully trusted (your own Lounge, never community/public).
+
+Either way:
 
 - Don't invite the bot to a voice channel you don't trust the membership of.
-- Don't leave the bot connected to a public/community voice channel unattended.
-- If you want a shared / community deployment, set `DISCORD_VOICE_OWNER=false` — that gates `work` and the other owner-only tools to the configured `owner` env. (Non-owner callers still get the safe read-only tools.)
-
-There is no per-user ACL inside the voice channel; the unit of trust is "who's allowed in the channel" (Discord channel permissions own that), not "who's speaking right now".
+- Don't leave the bot connected to a public/community voice channel unattended on `=true`.
+- There is no per-user ACL inside the voice channel; the unit of trust is "who's allowed in the channel" (Discord channel permissions own that), not "who's speaking right now".
 
 ## DM-triggered join
 

--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -77,7 +77,12 @@ const VOICE_MODEL = process.env.VOICE_MODEL || 'gemini-2.5-flash';
 const VOICE_NATIVE_AUDIO_MODEL =
 	process.env.VOICE_NATIVE_AUDIO_MODEL || 'gemini-3.1-flash-live-preview';
 
-const TREAT_AS_OWNER = (process.env.DISCORD_VOICE_OWNER ?? 'true') !== 'false';
+// Default false (safe): non-owner speakers in the voice channel get the
+// read-only tool surface but NOT owner-tier work/file-edit/message-send.
+// Set DISCORD_VOICE_OWNER=true explicitly to inherit owner privileges to
+// every speaker — only safe in voice channels whose membership is fully
+// trusted (single-operator Lounge, not community/public).
+const TREAT_AS_OWNER = (process.env.DISCORD_VOICE_OWNER ?? 'false') === 'true';
 
 // CLI: --guild <id> --channel <voice_channel_id>
 function getArg(name: string): string | undefined {


### PR DESCRIPTION
## Summary
- Flip `DISCORD_VOICE_OWNER` default from `true` → `false` in `skills/discord-voice/scripts/discord-voice-server.ts`.
- Update the env var description + the Trust boundary section in `skills/discord-voice/SKILL.md` so docs match the new safe default.

## Why
The old default meant any speaker in the voice channel inherited owner-tier `work` / file-edit / message-send privileges. Fine for a single-operator Lounge — sharp edge to ship as the default. Anyone joining a channel the bot was in could delegate `work` or edit files just by speaking.

Now non-owner speakers get the read-only tool surface (lookups, status checks); only the configured `owner` env gets the owner-tier surface. To restore the previous behavior, set `DISCORD_VOICE_OWNER=true` explicitly (single-operator personal-use mode).

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Owner speaking with default env: still has full surface (env `owner` matches caller id → unchanged)
- [ ] Non-owner speaking with default env: gets read-only tools only
- [ ] `DISCORD_VOICE_OWNER=true` explicitly: every speaker gets owner surface (legacy behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)