### PR TITLE
fix(notes): mkdir -p the notes dir before save_note write

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -6,7 +6,7 @@
  */
 
 import { execSync, execFileSync } from 'node:child_process';
-import { writeFileSync, unlinkSync, readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { writeFileSync, unlinkSync, readdirSync, readFileSync, existsSync, statSync, mkdirSync } from 'node:fs';
 import { join, extname, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
@@ -838,6 +838,10 @@ export const saveNoteTool: ToolDefinition = {
 		const tagList = tags ? tags.split(',').map(t => t.trim()) : ['personal'];
 		const md = `---\ntitle: ${title}\ndate: ${date}\ntags: [${tagList.join(', ')}]\n---\n\n${content}\n`;
 		try {
+			// NOTES_DIR resolves against the workspace, which may not have a
+			// notes/ subdir yet on a fresh install — create it before writing
+			// so the first save_note never fails with ENOENT.
+			mkdirSync(NOTES_DIR, { recursive: true });
 			writeFileSync(join(NOTES_DIR, `${slug}.md`), md);
 			return { status: 'saved', title, slug, path: `notes/${slug}.md` };
 		} catch (e) { return { error: String(e) }; }


### PR DESCRIPTION
## Problem

A `save_note` call failed for the owner with a generic "issue saving the file" error. Root cause: `save_note` resolves `NOTES_DIR` against the workspace (correct since #842), but never ensures the `notes/` subdirectory actually exists. On a fresh install — or any workspace where no note has been saved yet — `writeFileSync` throws `ENOENT` and the inline tool returns it as a caught `{ error }`.

## Fix

Add `mkdirSync(NOTES_DIR, { recursive: true })` immediately before the `writeFileSync` in `saveNoteTool.execute`. One-liner, idempotent, no behavior change when the directory already exists.

## Notes

- The path-resolution half of this class of bug (resolving against the workspace rather than `process.cwd()`) was already fixed upstream in #842 — this PR only closes the remaining "directory may not exist yet" gap.
- Observed in a deployed build where the voice-agent's `process.cwd()` was the app bundle; that build predates #842. This PR makes `save_note` robust regardless.

## Test

`mkdirSync(..., { recursive: true })` is a no-op when the dir exists and creates it (with parents) when it doesn't; the subsequent `writeFileSync` then always has a valid target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)