### PR TITLE
fix(agent-api): close SSRF bypass via IPv4-mapped IPv6 hostnames

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -236,6 +236,21 @@ def _is_safe_callback_url(url: str) -> tuple[bool, str]:
             for net in private_ranges:
                 if addr in net:
                     return False, f"private IP: {addr}"
+            # IPv4-mapped IPv6 bypass guard. ipaddress's cross-family `in`
+            # check returns False (an IPv6Address is never in an IPv4Network),
+            # so a hostname that resolves to e.g. `::ffff:127.0.0.1` would
+            # otherwise pass the loop above. Project the mapped IPv4 onto
+            # the IPv4 private-range checks to close the bypass. Same
+            # applies to IPv4-compatible IPv6 (`::a.b.c.d`), exposed via
+            # `IPv6Address.ipv4_mapped` for the v4-mapped form;
+            # `sixtofour` / `teredo` are public-routable tunneling and
+            # don't need this projection.
+            if isinstance(addr, ipaddress.IPv6Address):
+                v4 = addr.ipv4_mapped
+                if v4 is not None:
+                    for net in private_ranges:
+                        if isinstance(net, ipaddress.IPv4Network) and v4 in net:
+                            return False, f"private IP (via IPv4-mapped IPv6 {addr}): {v4}"
         except ValueError:
             return False, f"invalid address: {sockaddr[0]}"
     return True, "ok"

--- a/tests/agent-api-ssrf-ipv4-mapped-ipv6.test.py
+++ b/tests/agent-api-ssrf-ipv4-mapped-ipv6.test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Security regression guard: `_is_safe_callback_url` must reject IPv4-mapped
+IPv6 hostnames that point at private IPv4 ranges.
+
+The function loops over `getaddrinfo` results and checks each
+`ipaddress.ip_address(...)` against a list of private networks
+(127.0.0.0/8, 10.0.0.0/8, fc00::/7, etc.). For IPv4-mapped IPv6
+addresses like `::ffff:127.0.0.1`, the loop returns False:
+
+    >>> ipaddress.ip_address('::ffff:127.0.0.1') in ipaddress.ip_network('127.0.0.0/8')
+    False  # cross-family `in` always returns False
+
+So a webhook URL of `https://[::ffff:127.0.0.1]/exfil` would pass the
+SSRF check even though it resolves to localhost. Practical exploit is
+TLS-gated (no public cert covers IPv6 IP literals), but defense-in-
+depth says the validator should catch it — the function's docstring
+explicitly claims to block "Hostnames that resolve to private IPs."
+
+The fix projects `IPv6Address.ipv4_mapped` onto the IPv4 private-range
+checks. This test pins:
+
+  1. Bypass is closed for IPv4-mapped IPv6 → loopback.
+  2. Bypass is closed for IPv4-mapped IPv6 → RFC1918.
+  3. Pre-existing behavior on plain IPv4 private IPs is preserved.
+  4. Public IPv6 (Cloudflare 2606:4700::) still passes.
+  5. Plain IPv6 loopback `::1` still rejected.
+
+We monkey-patch `socket.getaddrinfo` so the test doesn't depend on DNS
+or networking — pure validation logic.
+"""
+
+import importlib.util
+import socket
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+api = _load("agent_api", REPO / "src" / "agent-api.py")
+
+
+def _stub_getaddrinfo(addr_str: str, family: int):
+    def fake(_host, _port, _af=None, _sock=None, *args, **kwargs):
+        if family == socket.AF_INET6:
+            return [(family, socket.SOCK_STREAM, 0, "", (addr_str, 0, 0, 0))]
+        return [(family, socket.SOCK_STREAM, 0, "", (addr_str, 0))]
+
+    return fake
+
+
+def _with_stub(addr_str: str, family: int, fn):
+    original = api.socket.getaddrinfo
+    api.socket.getaddrinfo = _stub_getaddrinfo(addr_str, family)
+    try:
+        fn()
+    finally:
+        api.socket.getaddrinfo = original
+
+
+def test_ipv4_mapped_ipv6_loopback_is_blocked():
+    """The core bypass. `https://[::ffff:127.0.0.1]/` resolves to the
+    IPv4-mapped IPv6 form of 127.0.0.1. The pre-fix code passed it;
+    the new code MUST reject it via the `IPv6Address.ipv4_mapped`
+    projection onto the private-IPv4 ranges."""
+    def run():
+        safe, reason = api._is_safe_callback_url("https://example.test/")
+        assert safe is False, (
+            "IPv4-mapped IPv6 loopback bypassed SSRF check — "
+            f"reason returned: {reason!r}. The fix's ipv4_mapped projection "
+            "should have caught 127.0.0.1."
+        )
+        assert "127.0.0.1" in reason, f"reason should mention 127.0.0.1: {reason}"
+
+    _with_stub("::ffff:127.0.0.1", socket.AF_INET6, run)
+
+
+def test_ipv4_mapped_ipv6_rfc1918_is_blocked():
+    """Same bypass class for RFC1918 (10.0.0.0/8) targets."""
+    def run():
+        safe, reason = api._is_safe_callback_url("https://example.test/")
+        assert safe is False, (
+            "IPv4-mapped IPv6 → 10.0.0.5 bypassed SSRF check — "
+            f"reason returned: {reason!r}"
+        )
+        assert "10.0.0.5" in reason, f"reason should mention 10.0.0.5: {reason}"
+
+    _with_stub("::ffff:10.0.0.5", socket.AF_INET6, run)
+
+
+def test_plain_ipv4_loopback_still_blocked():
+    """Backwards-compat: no regression on plain-IPv4 loopback check."""
+    def run():
+        safe, reason = api._is_safe_callback_url("https://example.test/")
+        assert safe is False
+        assert "127.0.0.1" in reason
+
+    _with_stub("127.0.0.1", socket.AF_INET, run)
+
+
+def test_plain_ipv6_loopback_still_blocked():
+    """Backwards-compat: `::1` rejected by existing `::1/128` range."""
+    def run():
+        safe, reason = api._is_safe_callback_url("https://example.test/")
+        assert safe is False
+        assert "::1" in reason
+
+    _with_stub("::1", socket.AF_INET6, run)
+
+
+def test_public_ipv6_still_passes():
+    """Backwards-compat: a public IPv6 (Cloudflare DNS 2606:4700:4700::1111)
+    must still pass. Defends against an over-zealous fix that rejects
+    all IPv6 by accident."""
+    def run():
+        safe, reason = api._is_safe_callback_url("https://example.test/")
+        assert safe is True, f"public IPv6 rejected: {reason}"
+
+    _with_stub("2606:4700:4700::1111", socket.AF_INET6, run)
+
+
+def test_public_ipv4_still_passes():
+    """Sanity: a public IPv4 (Cloudflare DNS 1.1.1.1) must still pass."""
+    def run():
+        safe, reason = api._is_safe_callback_url("https://example.test/")
+        assert safe is True, f"public IPv4 rejected: {reason}"
+
+    _with_stub("1.1.1.1", socket.AF_INET, run)
+
+
+def main():
+    test_ipv4_mapped_ipv6_loopback_is_blocked()
+    test_ipv4_mapped_ipv6_rfc1918_is_blocked()
+    test_plain_ipv4_loopback_still_blocked()
+    test_plain_ipv6_loopback_still_blocked()
+    test_public_ipv6_still_passes()
+    test_public_ipv4_still_passes()
+    print("All SSRF IPv4-mapped-IPv6 tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Security: SSRF bypass

`_is_safe_callback_url` in `src/agent-api.py` loops `getaddrinfo` results against a private-IP range list. For IPv4-mapped IPv6 addresses (`::ffff:127.0.0.1` and similar), Python's `ipaddress` cross-family `in` check is always False:

\`\`\`python
>>> import ipaddress
>>> ipaddress.ip_address('::ffff:127.0.0.1') in ipaddress.ip_network('127.0.0.0/8')
False  # cross-family
\`\`\`

So a webhook URL of `https://[::ffff:127.0.0.1]/exfil` passes the validator even though it resolves to localhost. Same gap for any RFC1918 target (`::ffff:10.0.0.5` → 10.0.0.5).

**Practical exploit is TLS-gated** — no public cert covers IPv6 IP literals, so `urllib.request.urlopen` on this URL fails certificate validation. But defense-in-depth says the validator MUST catch it — the docstring explicitly claims to block *"Hostnames that resolve to private IPs"* and the SSRF allowlist is the canonical guard for callback URLs.

## Fix

After the existing per-address loop, if the address is an `IPv6Address` with `ipv4_mapped` set, project the mapped IPv4 onto the IPv4 private-range checks. Catches the bypass with no change to the existing IPv4 / pure-IPv6 paths.

**Note on 6to4 / Teredo:** 6to4 (`2002::/16`) and Teredo (`2001::/32`) are public-routable IPv6 tunneling schemes whose embedded IPv4 is the *encapsulating endpoint*, not the destination — projecting those onto private-IPv4 checks would generate false positives. Only v4-mapped (`::ffff:0:0/96`) needs the projection.

## Tests

`tests/agent-api-ssrf-ipv4-mapped-ipv6.test.py` (6 cases). Monkey-patches `socket.getaddrinfo` so each case deterministically simulates a DNS response — no network dependency.

| Case | Pins |
|---|---|
| `test_ipv4_mapped_ipv6_loopback_is_blocked` | **The core bypass closed** — `::ffff:127.0.0.1` rejected. |
| `test_ipv4_mapped_ipv6_rfc1918_is_blocked` | `::ffff:10.0.0.5` (RFC1918 generalization) rejected. |
| `test_plain_ipv4_loopback_still_blocked` | No regression on plain `127.0.0.1`. |
| `test_plain_ipv6_loopback_still_blocked` | No regression on plain `::1`. |
| `test_public_ipv6_still_passes` | Public IPv6 (Cloudflare DNS) still allowed — guards against over-zealous fix that rejects all IPv6. |
| `test_public_ipv4_still_passes` | Public IPv4 (1.1.1.1) still allowed. |

## Test plan

- [x] `python3 tests/agent-api-ssrf-ipv4-mapped-ipv6.test.py` — 6/6 pass
- [x] `python3 -c "import ast; ast.parse(open('src/agent-api.py').read())"` — syntax check
- [ ] Manual: register a webhook with `https://[::ffff:127.0.0.1]/`, trigger a task completion, verify `[webhook] BLOCKED` appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)