### PR TITLE
fix(inline-tools): escape `app` in pressKey tool to prevent AppleScript injection

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -166,9 +166,16 @@ export const pressKeyTool: ToolDefinition = {
 	execution: 'inline',
 	async execute(args) {
 		const { key, modifiers = [], app } = args as { key: string; modifiers?: string[]; app?: string };
-		// Activate target app if specified
+		// Activate target app if specified. Escape `app` before embedding
+		// in the AppleScript string literal — without this, a value like
+		// `"; do shell script "rm -rf ~"; tell application "Finder` would
+		// break out of `tell application "..."` and run arbitrary
+		// AppleScript (and AppleScript can `do shell script`, so this is
+		// arbitrary code execution from a tool-call argument). Same
+		// escape pattern as `safeKey` below and `safeApp` in switchAppTool.
 		if (app) {
-			try { execSync(`osascript -e 'tell application "${app}" to activate'`, { timeout: 3_000 }); await new Promise(r => setTimeout(r, 300)); } catch {}
+			const safeApp = app.replace(/\\/g, '\\\\').replace(/'/g, "'\\''").replace(/"/g, '\\"');
+			try { execSync(`osascript -e 'tell application "${safeApp}" to activate'`, { timeout: 3_000 }); await new Promise(r => setTimeout(r, 300)); } catch {}
 		}
 		const keyMap: Record<string, number> = {
 			'enter': 36, 'return': 36, 'escape': 53, 'esc': 53, 'tab': 48,

--- a/tests/inline-tools-press-key-app-escape.test.ts
+++ b/tests/inline-tools-press-key-app-escape.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Security regression guard for `pressKeyTool` in src/inline-tools.ts.
+//
+// Pre-fix: the tool accepted an optional `app` parameter and embedded
+// it verbatim in `osascript -e 'tell application "${app}" to
+// activate'`. A value containing `"` could break out of the AppleScript
+// string literal and inject arbitrary AppleScript, which can shell out
+// via `do shell script "..."` — arbitrary code execution from a tool-
+// call argument.
+//
+// Adjacent code already had the right escape pattern:
+//   - line ~161 escapes the `key` parameter as `safeKey`
+//   - switchAppTool escapes its `app` as `safeApp`
+//
+// Only `pressKeyTool.execute`'s app-activation branch was missing the
+// escape. Pin the fix so a future refactor that re-introduces the raw
+// interpolation fails here.
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'src/inline-tools.ts'),
+	'utf-8',
+);
+
+describe('inline-tools pressKey app activation — AppleScript injection guard', () => {
+	it('does not interpolate raw `app` into the osascript tell-application command', () => {
+		assert.doesNotMatch(
+			SRC,
+			/tell application "\$\{app\}" to activate/,
+			'src/inline-tools.ts contains the raw `tell application "${app}"` pattern again — ' +
+				'a tool-call argument containing `"` would inject AppleScript and (via ' +
+				'`do shell script`) execute arbitrary commands. Escape `app` to `safeApp` first.',
+		);
+	});
+
+	it('uses safeApp (escaped) in the pressKey app-activation branch', () => {
+		const pressKeyBranch = SRC.match(/pressKeyTool[\s\S]*?Activate target app[\s\S]{0,500}/);
+		assert(pressKeyBranch, 'could not locate pressKeyTool app-activation branch');
+		assert.match(
+			pressKeyBranch[0],
+			/safeApp/,
+			'pressKeyTool must escape `app` to `safeApp` before passing to osascript ' +
+				'(see switchAppTool for the canonical pattern).',
+		);
+	});
+
+	it('the escape pattern is computed from app via .replace chain', () => {
+		assert.match(
+			SRC,
+			/safeApp\s*=\s*app\.replace\([\s\S]+?\.replace\([\s\S]+?\.replace\(/,
+			'safeApp must chain at least 3 .replace() calls (backslash, single-quote, double-quote) — see switchAppTool for canonical pattern',
+		);
+		assert.match(
+			SRC,
+			/safeApp[\s\S]+?\.replace\(\/"\/g,\s*'\\\\"'\)/,
+			'safeApp chain must include `.replace(/"/g, \'\\\\"\')` — the double-quote strip is the actual exploit-vector defense for the `tell application "X"` shape',
+		);
+	});
+
+	it('canonical escape pattern still in use in switchAppTool', () => {
+		assert.match(SRC, /switchAppTool[\s\S]+?safeApp\s*=\s*app/);
+	});
+});


### PR DESCRIPTION
## The bug (security)

`pressKeyTool` in `src/inline-tools.ts` accepted an optional `app` parameter and embedded it **raw** in an AppleScript command:

\`\`\`ts
if (app) {
  execSync(\`osascript -e 'tell application \"\${app}\" to activate'\`, ...);
}
\`\`\`

A value containing `\"` breaks out of the AppleScript string literal and injects arbitrary AppleScript. AppleScript supports `do shell script \"...\"`, so this is **arbitrary code execution from a tool-call argument**.

**PoC (would have worked pre-fix):**

\`\`\`ts
pressKey({
  key: 'space',
  app: '\"); do shell script \"rm -rf ~/sensitive\"; tell application \"Finder',
})
\`\`\`

The resulting AppleScript runs `do shell script \"rm -rf ~/sensitive\"`.

## Why this is the right fix

**Two other call sites in the same file already use the correct escape pattern:**

| Line | Tool | Escape var |
|---|---|---|
| ~161 | `pressKeyTool` (key fallback path) | `safeKey` |
| ~214 | `switchAppTool.execute` | `safeApp` |

Only `pressKeyTool`'s app-activation branch was missing the escape. Apply the same 3-step strip (backslash, single-quote, double-quote). No new abstraction needed — local fix where the bug lives, matches the established in-file pattern.

## Tests

`tests/inline-tools-press-key-app-escape.test.ts` — 4 source-grep architectural assertions:

| Case | Pins |
|---|---|
| raw `tell application \"\${app}\"` pattern absent | Pre-fix pattern fails here. |
| pressKey branch references `safeApp` | Post-fix shape. |
| `safeApp` computed via `.replace()` chain | All 3 strips present. |
| Chain includes `\"` strip | The actual exploit vector defense. |

Source-grep is the right shape — the actual `execSync` call spawns osascript and is OS-dependent; the security contract is \"escape `app` before embedding,\" which grep verifies precisely.

All 4 pass locally. `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)