### PR TITLE
fix(discord-bridge): auto-thread replies to triggering message

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2789,8 +2789,19 @@ async def poll_results():
                     # when the channel is already a Discord thread — thread
                     # context anchors the reply implicitly, no extra quote
                     # needed.
-                    if reply_to_id is None and not isinstance(channel, discord.Thread):
-                        reply_to_id = pending_reply_anchors.get(task_id)
+                    #
+                    # getattr instead of bare `discord.Thread` so the
+                    # test-stub discord module (tests/discord-bridge-*.test.py)
+                    # — which intentionally omits Thread to keep the stub
+                    # surface small — doesn't AttributeError here. Production
+                    # discord.py always provides Thread; the getattr fallback
+                    # only matters under test, where treating "no Thread
+                    # class" as "channel isn't a thread" is correct.
+                    if reply_to_id is None:
+                        _thread_cls = getattr(discord, 'Thread', None)
+                        is_thread = _thread_cls is not None and isinstance(channel, _thread_cls)
+                        if not is_thread:
+                            reply_to_id = pending_reply_anchors.get(task_id)
 
                     # Extract optional [channel: <channel_id>] redirect — the
                     # agent can route a DM-originated reply to a different

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -1974,6 +1974,11 @@ def _should_welcome_first_post(message, welcome_channel_id, welcome_template_pat
 
 # Track pending replies: task_id -> channel
 pending_replies = {}
+# Track source message id per pending task so the result-sender can default
+# reply_to_id to the triggering message (visually threads the reply). Lives
+# in memory only — crash-recovery isn't critical; missing entry just means
+# the reply goes as a fresh message instead of a quote-reply.
+pending_reply_anchors: dict[str, int] = {}
 
 intents = discord.Intents.default()
 intents.message_content = True
@@ -2599,12 +2604,17 @@ async def _handle_discord_message(message, force=False):
         f"task: {user_task_text}\n"
         f"source: discord\n"
         f"channel_id: {message.channel.id}\n"
+        f"source_message_id: {message.id}\n"
         f"user_id: {message.author.id}\n"
         f"access_tier: {access_tier}\n"
         f"priority: {priority}\n"
         f"{tier_instructions.get(access_tier, tier_instructions['other'])}"
     )
     pending_replies[task_id] = message.channel
+    # Track source-message-id so the result-sender can auto-attach reply_to
+    # (visually thread the reply to the triggering message). Skipped when
+    # the channel is already a Discord thread — thread context is enough.
+    pending_reply_anchors[task_id] = message.id
     save_pending_replies()
 
     # Typing indicator
@@ -2741,6 +2751,11 @@ async def poll_results():
                 import re
                 reply_text = result_file.read_text().strip()
                 channel = pending_replies.pop(task_id)
+                # Anchor is consumed alongside the channel — both belong to
+                # the same in-flight task and become stale together. Use pop
+                # not del so a missing entry (crash-recovered task) doesn't
+                # raise.
+                pending_reply_anchors.pop(task_id, None)
                 save_pending_replies()
                 # Skip sending if already replied directly (core agent used MCP).
                 # Clean up the result AND task files so the watcher doesn't
@@ -2768,6 +2783,14 @@ async def poll_results():
                     reply_to_id = int(reply_match.group(1)) if reply_match else None
                     if reply_match:
                         reply_text = reply_pattern.sub('', reply_text).strip()
+                    # Auto-thread: if the agent didn't pick an explicit
+                    # [reply: <id>], default to the triggering message so the
+                    # reply appears quoted under what it's answering. Skip
+                    # when the channel is already a Discord thread — thread
+                    # context anchors the reply implicitly, no extra quote
+                    # needed.
+                    if reply_to_id is None and not isinstance(channel, discord.Thread):
+                        reply_to_id = pending_reply_anchors.get(task_id)
 
                     # Extract optional [channel: <channel_id>] redirect — the
                     # agent can route a DM-originated reply to a different


### PR DESCRIPTION
## Summary
- Bridge now defaults `reply_to_id` to the triggering message id when the agent's result has no explicit `[reply: <id>]` marker — replies appear as Discord quote-replies instead of orphaned channel messages.
- Skipped when the source channel is already a `discord.Thread` — thread context anchors the conversation implicitly, no quote needed (per Chi 2026-05-22 02:39).
- Task files now include `source_message_id: <id>` so the result-side has the anchor available even after a crash-recovery restart.

## Why
Tonight: multiple owner messages landed in `#dev` within 13s; my replies went as fresh messages and Chi couldn't tell which answered which (*"what are you answering? can you reply to the right msg?"* — 02:30 UTC). The bridge supported `[reply: <id>]` but the agent had no way to get the source message_id from the task file, so the marker was never set.

## Files
- `src/discord-bridge.py` (+23 lines):
  - New `pending_reply_anchors: dict[str, int]` alongside `pending_replies`
  - `source_message_id: {message.id}` added to task-file write
  - Result-send default + thread skip

## Test plan
- [ ] Send two messages quickly in a regular channel → both replies appear as quote-replies to their respective triggers
- [ ] Send a message inside a thread → reply appears in-thread without explicit quote-reply anchor (no visual `↳ replying to`)
- [ ] Explicit `[reply: <other_id>]` still wins over the auto-default
- [ ] Crash-recover restart: `pending_replies` reloads (existing behavior); missing `pending_reply_anchors` entry falls back to fresh-message send (no error)
- [ ] No regression on `[no-send]` / `[REPLIED]` / `[deduped: …]` skip paths
- [ ] `[channel: <id>]` redirect still clears `reply_to_id` (since the redirect channel won't have the anchor message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)