### PR TITLE
fix(discord-bridge): pop reply-anchor INTO a var before downstream read

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2751,11 +2751,13 @@ async def poll_results():
                 import re
                 reply_text = result_file.read_text().strip()
                 channel = pending_replies.pop(task_id)
-                # Anchor is consumed alongside the channel — both belong to
-                # the same in-flight task and become stale together. Use pop
-                # not del so a missing entry (crash-recovered task) doesn't
-                # raise.
-                pending_reply_anchors.pop(task_id, None)
+                # Capture anchor BEFORE pop so the auto-thread block below
+                # can use it. The previous version popped+forgot, leaving
+                # `pending_reply_anchors.get(task_id)` at line ~2810 always
+                # returning None — symptom: replies appeared as fresh
+                # messages instead of quote-replies. Caught by live test
+                # 2026-05-22 ~03:00 UTC: "it's not a quote reply".
+                source_message_anchor = pending_reply_anchors.pop(task_id, None)
                 save_pending_replies()
                 # Skip sending if already replied directly (core agent used MCP).
                 # Clean up the result AND task files so the watcher doesn't
@@ -2801,7 +2803,7 @@ async def poll_results():
                         _thread_cls = getattr(discord, 'Thread', None)
                         is_thread = _thread_cls is not None and isinstance(channel, _thread_cls)
                         if not is_thread:
-                            reply_to_id = pending_reply_anchors.get(task_id)
+                            reply_to_id = source_message_anchor
 
                     # Extract optional [channel: <channel_id>] redirect — the
                     # agent can route a DM-originated reply to a different


### PR DESCRIPTION
## Bug
PR #1002 added auto-thread of replies to the triggering message via `pending_reply_anchors`. Live-tested 2026-05-22 ~03:00 UTC: replies still appeared as fresh messages, not quote-replies. Chi: *"it's not a quote reply"*.

## Root cause
In `poll_results`, the anchor was popped immediately after the channel pop:
```python
channel = pending_replies.pop(task_id)
pending_reply_anchors.pop(task_id, None)   # ← removed from dict
...  # ~50 lines later
reply_to_id = pending_reply_anchors.get(task_id)   # ← always None now
```

## Fix
Capture into a local:
```python
channel = pending_replies.pop(task_id)
source_message_anchor = pending_reply_anchors.pop(task_id, None)
...
if reply_to_id is None and not is_thread:
    reply_to_id = source_message_anchor
```

## Why the unit test missed it
`tests/discord-bridge-reply-directive.test.py` exercises two paths: explicit `[reply: <id>]` directive (passes) and no-directive (passes). The no-directive case passed coincidentally because the test fixture never populates `pending_reply_anchors` for that task_id — so the buggy `.get()` returned None, and the test asserted "no reference set". The bug + the test gap canceled out.

## Test plan
- [ ] Unit test still green: `python3 tests/discord-bridge-reply-directive.test.py` (all 3 cases pass)
- [ ] **Live**: restart bridge, send a message in a regular channel, agent replies → quote-reply visible
- [ ] In-thread: send a message in a thread, agent replies → no quote anchor (thread context only)
- [ ] Could add a 4th unit test case explicitly populating `pending_reply_anchors[task_id]` and asserting the reference WAS set, to prevent future regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)