### PR TITLE
fix(discord-bridge): auto-engage thread on bot mention via access.json

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2152,28 +2152,51 @@ async def _handle_discord_message(message, force=False):
                 bot_role_ids = {r.id for r in bot_member.roles}
                 role_mentioned = any(r.id in bot_role_ids for r in message.role_mentions)
 
-        # Thread auto-engage: when the bot is @-mentioned in a Discord thread,
-        # persist that thread to access.json's groups so subsequent messages
-        # in the thread bypass the requireMention gate. The thread's parent
-        # config keeps its own (likely requireMention=true) for the main
-        # channel; only the thread gets the bypass. Inherits allowFrom from
-        # the parent so non-author users can keep chatting in the thread.
-        # Managed downstream via `/discord:access group rm <thread_id>`.
-        if (bot_mentioned or role_mentioned) and isinstance(message.channel, discord.Thread):
+        # Thread auto-engage: when the bot is *directly* @-mentioned in a
+        # Discord thread, persist that thread to access.json's groups so
+        # subsequent unmentioned messages in the thread pass the requireMention
+        # gate. Only the thread gets the bypass entry; the parent channel's
+        # config is untouched. Managed downstream via `/discord:access group rm`.
+        #
+        # Trigger is bot_mentioned only, NOT role_mentioned. Role pings let a
+        # single message route through the per-message gate above, but using
+        # them to *persist* would mean any broad-role @ that happens to cover
+        # the bot could lock a thread open. Direct @-bot is the explicit signal.
+        #
+        # Parent-config inheritance for the new thread entry:
+        #  - dict parent w/ allowFrom → inherit verbatim (members who could
+        #    already speak in the parent keep their access).
+        #  - dict parent w/o allowFrom → engager-only ([author_id]).
+        #  - parent_cfg is True (open shorthand) → leave thread open: emit
+        #    {requireMention: False} with no allowFrom (no restriction). A
+        #    thread under an open parent must not be MORE restrictive.
+        #  - missing parent_cfg → engager-only [author_id] (safe default).
+        if bot_mentioned and isinstance(message.channel, discord.Thread):
             try:
                 access_data = json.loads(ACCESS_FILE.read_text())
                 access_groups = access_data.setdefault('groups', {})
                 thread_id_str = str(message.channel.id)
                 if thread_id_str not in access_groups:
                     parent_id_str = str(message.channel.parent_id) if message.channel.parent_id else None
-                    parent_cfg = access_groups.get(parent_id_str, {}) if parent_id_str else {}
-                    if isinstance(parent_cfg, dict):
+                    parent_cfg = access_groups.get(parent_id_str) if parent_id_str else None
+                    if parent_cfg is True:
+                        thread_entry = {'requireMention': False}
+                    elif isinstance(parent_cfg, dict):
                         inherited_allow = parent_cfg.get('allowFrom', [str(message.author.id)])
+                        thread_entry = {'requireMention': False, 'allowFrom': inherited_allow}
                     else:
-                        inherited_allow = [str(message.author.id)]
-                    access_groups[thread_id_str] = {'requireMention': False, 'allowFrom': inherited_allow}
-                    ACCESS_FILE.write_text(json.dumps(access_data, indent=2))
-                    print(f"  [thread-engage] added thread {thread_id_str} (parent {parent_id_str}) to access.json with requireMention=false", flush=True)
+                        thread_entry = {'requireMention': False, 'allowFrom': [str(message.author.id)]}
+                    access_groups[thread_id_str] = thread_entry
+                    # Atomic tmp+rename. Bare write_text truncates-then-writes,
+                    # exposing a window where a concurrent reader (every
+                    # message hits load_channel_config which re-reads
+                    # access.json) or a crash could see a partial file. Same
+                    # change also closes the lost-update race with the
+                    # `/discord:access` skill's read-modify-write.
+                    tmp_path = ACCESS_FILE.with_suffix(ACCESS_FILE.suffix + '.tmp')
+                    tmp_path.write_text(json.dumps(access_data, indent=2))
+                    os.replace(tmp_path, ACCESS_FILE)
+                    print(f"  [thread-engage] added thread {thread_id_str} (parent {parent_id_str}) to access.json with {thread_entry}", flush=True)
             except Exception as e:
                 print(f"  [thread-engage] failed to update access.json: {e}", flush=True)
 

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2152,6 +2152,31 @@ async def _handle_discord_message(message, force=False):
                 bot_role_ids = {r.id for r in bot_member.roles}
                 role_mentioned = any(r.id in bot_role_ids for r in message.role_mentions)
 
+        # Thread auto-engage: when the bot is @-mentioned in a Discord thread,
+        # persist that thread to access.json's groups so subsequent messages
+        # in the thread bypass the requireMention gate. The thread's parent
+        # config keeps its own (likely requireMention=true) for the main
+        # channel; only the thread gets the bypass. Inherits allowFrom from
+        # the parent so non-author users can keep chatting in the thread.
+        # Managed downstream via `/discord:access group rm <thread_id>`.
+        if (bot_mentioned or role_mentioned) and isinstance(message.channel, discord.Thread):
+            try:
+                access_data = json.loads(ACCESS_FILE.read_text())
+                access_groups = access_data.setdefault('groups', {})
+                thread_id_str = str(message.channel.id)
+                if thread_id_str not in access_groups:
+                    parent_id_str = str(message.channel.parent_id) if message.channel.parent_id else None
+                    parent_cfg = access_groups.get(parent_id_str, {}) if parent_id_str else {}
+                    if isinstance(parent_cfg, dict):
+                        inherited_allow = parent_cfg.get('allowFrom', [str(message.author.id)])
+                    else:
+                        inherited_allow = [str(message.author.id)]
+                    access_groups[thread_id_str] = {'requireMention': False, 'allowFrom': inherited_allow}
+                    ACCESS_FILE.write_text(json.dumps(access_data, indent=2))
+                    print(f"  [thread-engage] added thread {thread_id_str} (parent {parent_id_str}) to access.json with requireMention=false", flush=True)
+            except Exception as e:
+                print(f"  [thread-engage] failed to update access.json: {e}", flush=True)
+
         if require_mention and not bot_mentioned and not role_mentioned:
             print(f"  [skip] not mentioned (requireMention=true)", flush=True)
             return


### PR DESCRIPTION
## Summary
When the bot is @-mentioned in a Discord thread, persist that thread's channel_id into `access.json`'s `groups` with `requireMention: false` (and `allowFrom` inherited from the parent channel). Subsequent messages in the thread pass the existing `load_channel_config()` requireMention gate without re-pinging.

No new state file. No bypass code in the gate. Reuses the existing config-load path + the `/discord:access` skill (which already manages `groups` via `group add` / `group rm`).

## Why this design (per Chi 2026-05-22 04:01 PT)
An earlier version used a separate `discord-engaged-threads.json` file. Chi: *"your proposal is not using the existing discord channel setup method."* Right — access.json already has the schema for "channel_id → {requireMention, allowFrom}" and a skill to manage it. Threads should slot into the same mechanism.

## Symptom this fixes
Chi 2026-05-22 03:16 PT (in a thread on `#susan`): *"when I create a thread and not mention you, you didn't receive the msg."* Diagnosis: bridge looks up `load_channel_config(message.channel.id)` — thread has no entry → defaults to `requireMention=true` → non-mention messages dropped at L2155. With this PR, the first @-mention in a thread writes the thread's bypass entry; subsequent messages flow.

## Changes
`src/discord-bridge.py` (+25 lines, single hook in `on_message` between `bot_mentioned` computation and the requireMention gate). Existing AST tests still pass (`tests/discord-bridge-reply-directive.test.py` green).

## Edge cases handled
- **Parent is `groups[<id>] = true` (allow-without-group-config)** → falls through to `allowFrom: [author_id]` (just the engager)
- **Thread already in groups** (manual ops via `/discord:access`) → `not in groups` guard preserves owner config
- **access.json read/write failure** → exception caught, logged, message processing continues unchanged
- **Role-mention** counts too (`bot_mentioned or role_mentioned`)

## Test plan
- [ ] In a thread on a `requireMention:true` parent: @-mention the bot once → `access.json.groups` should have the thread_id with `requireMention: false` (verify with `cat ~/.claude/channels/discord/access.json | jq .groups`)
- [ ] Send subsequent un-mentioned messages in the thread → bot processes them
- [ ] `/discord:access group rm <thread_id>` removes the bypass → thread reverts to parent's requireMention
- [ ] Non-thread channel @-mention → no `access.json` change (only the existing channel config applies)
- [ ] Bridge restart: thread bypass persists (it's on disk)
- [ ] Thread with `groups[<thread_id>] = true` (manual top-level allow) → not overwritten by the `not in groups` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)