### PR TITLE
fix(voice): swap "use work" → "use native Web search" when googleSearch is on

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -303,16 +303,15 @@ function buildAgent(s: DiscordVoiceSession): MainAgent {
 			'Be natural, warm, and conversational. Keep responses to 1-2 sentences.',
 			'Discord voice channels are persistent — do NOT say "goodbye" or try to hang up. Just stop speaking when you have nothing more to add.',
 			'NEVER say "I\'m back", "Welcome back", "Working on it", or "task is queued". If the conversation resumes after a pause, just continue naturally.',
-			'NEVER fabricate specific details. If you don\'t know it, use the work tool to look it up.',
-			// When this surface has native googleSearch grounding enabled,
-			// nudge toward using it directly for current-info queries
-			// (news/scores/weather/stocks). Without this nudge the prior
-			// "use work for anything" lines bias the model toward delegation
-			// (~8-15s) over native grounding (~2-3s). Conditional on
-			// per-surface config: search:false → no nudge (capability absent).
+			// "Look it up" pointer — conditional on per-surface config.
+			// Search on → native Web grounding (~2-3s, in-conversation);
+			// search off → `work` tool fallback (round-trip ~8-15s).
+			// Earlier code had both a permanent "use work" line + a soft
+			// nudge; model read the imperative as imperative and the nudge
+			// as optional. One conditional line so only one path appears.
 			DISCORD_VOICE_GOOGLE_SEARCH
-				? 'You have built-in Web grounding for current-info queries (news, scores, weather, stocks, recent events). Use it directly when the question only needs a Web lookup — it returns faster.'
-				: '',
+				? 'NEVER fabricate specific details. If you don\'t know it, use your built-in Web search to look it up — it\'s faster than delegating, and the answer stays in the conversation.'
+				: 'NEVER fabricate specific details. If you don\'t know it, use the work tool to look it up.',
 			repoUrl ? `\n## Known info\nSutando GitHub repo: ${repoUrl}` : '',
 		].filter(Boolean).join('\n');
 	} else {

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -494,22 +494,17 @@ function buildAgent(callSession: CallSession): MainAgent {
 		instructions = instructions.filter(Boolean).join('\n');
 	}
 
-	// Grounding
+	// Grounding. The "look it up" pointer is conditional on per-surface
+	// config: native Web search when googleSearch is enabled (~2-3s, answer
+	// in conversation), `work` tool otherwise (round-trip ~8-15s). Earlier
+	// versions had a permanent "use work" line + a soft nudge toward native
+	// search — the model read the first as imperative and the nudge as
+	// optional, so it kept delegating even with search on. One conditional
+	// line so only one path is presented per config.
 	if (callSession.isOwner) {
-		instructions += '\n\nNEVER fabricate specific details. If you don\'t know it, use the work tool to look it up.';
-	}
-
-	// When this surface has Gemini's native googleSearch grounding enabled,
-	// nudge the model toward using it directly for current-info queries
-	// (news, scores, weather, stocks, recent events). Without this nudge,
-	// the instructions above strongly bias the model toward the `work` tool
-	// for any "look it up" request, which writes a task file + waits for
-	// Claude Code's WebSearch (~8-15s round-trip) instead of letting Gemini
-	// answer via its own grounding (~2-3s). Conditional on the per-surface
-	// config so a surface with googleSearch=false doesn't get advised to
-	// use a capability it doesn't have.
-	if (PHONE_GOOGLE_SEARCH) {
-		instructions += '\n\nYou have built-in Web grounding for current-info queries (news, scores, weather, stocks, recent events). Use it directly when the question only needs a Web lookup — it returns faster.';
+		instructions += PHONE_GOOGLE_SEARCH
+			? '\n\nNEVER fabricate specific details. If you don\'t know it, use your built-in Web search to look it up — it\'s faster than delegating, and the answer stays in the conversation.'
+			: '\n\nNEVER fabricate specific details. If you don\'t know it, use the work tool to look it up.';
 	}
 
 	const tools: ToolDefinition[] = [];


### PR DESCRIPTION
## Summary
Phone + discord-voice instructions had two conflicting lines:
1. **Permanent imperative:** `NEVER fabricate specific details. If you don't know it, use the work tool to look it up.`
2. **Soft conditional nudge** (PR #1004): `You have built-in Web grounding for current-info queries… use it directly when the question only needs a Web lookup — it returns faster.`

Model read (1) as binding and (2) as a hint. Net effect with `googleSearch:true`: still delegates to `work` (~8-15s round-trip) instead of using native grounding (~2-3s).

Collapse to one conditional line — same imperative shape, different pointer:
- `googleSearch:true` → `"…use your built-in Web search to look it up — it's faster than delegating, and the answer stays in the conversation."`
- `googleSearch:false` → unchanged (`"…use the work tool to look it up."`)

Only one path presented per config.

## Symptom this fixes
Phone test 2026-05-22 04:26-04:33 UTC (call `CAfcc8448a078b3f7b82d3c91d5de2be40`):
- Chi: "How is the injury of the players in both teams for the game tomorrow?"
- Phone: "I've delegated that task to the core agent." ← bug
- Chi: "Why can't you do it yourself?"
- Chi: "No, can you do your own search without using the core."
- Phone: *uses native search successfully* — model had the capability, the instructions just biased it away.

After this PR, the first turn should use native grounding without the explicit override.

## Scope
- `skills/phone-conversation/scripts/conversation-server.ts` — collapses 2 instruction blocks into 1 conditional line.
- `skills/discord-voice/scripts/discord-voice-server.ts` — same pattern.
- `src/voice-agent.ts` — **NOT** touched. That surface has a deeper structural bias (`DEFAULT BEHAVIOR: Call work for almost everything`) and needs separate consideration. Current PR is the minimum fix for the two surfaces where the conflict is one-line.

## Test plan
- [ ] Restart phone server (`pkill -f conversation-server` + npx tsx …). Verify startup log shows `googleSearch=true`.
- [ ] Call phone, ask "what's the NBA injury report for tomorrow's games" → should use native grounding (no `[Task] delegated` line in `/tmp/conversation-server.log`), reply in ≤5s.
- [ ] Repeat with a non-search query ("what's 2+2") → should answer directly (not delegate).
- [ ] Repeat with a research-heavy query ("write me a poem about X" / "explain quantum tunneling") → should still delegate to `work` (correct behavior — those need the brain, not just Web grounding).
- [ ] Flip phone config to `googleSearch:false`, restart, ask same Web query → should now delegate to `work` (no native search available).

## Risk
- Low. Single-line text change in instructions; no logic change. tsc-transpile clean. The "work" tool still exists and the model can call it for complex tasks — the change just removes the "use work to look it up" pointer when native search is the better path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)