### PR TITLE
fix(voice): add work-tool fallback when native search insufficient

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -310,7 +310,7 @@ function buildAgent(s: DiscordVoiceSession): MainAgent {
 			// nudge; model read the imperative as imperative and the nudge
 			// as optional. One conditional line so only one path appears.
 			DISCORD_VOICE_GOOGLE_SEARCH
-				? 'NEVER fabricate specific details. If you don\'t know it, use your built-in Web search to look it up — it\'s faster than delegating, and the answer stays in the conversation.'
+				? 'NEVER fabricate specific details. If you don\'t know it, use your built-in Web search to look it up — it\'s faster than delegating, and the answer stays in the conversation. If your built-in search returns nothing useful, OR the question needs deeper-than-one-lookup research (multi-step, multiple sources, file reading), call the work tool — it routes to the core agent which can do extensive research.'
 				: 'NEVER fabricate specific details. If you don\'t know it, use the work tool to look it up.',
 			repoUrl ? `\n## Known info\nSutando GitHub repo: ${repoUrl}` : '',
 		].filter(Boolean).join('\n');

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -503,7 +503,7 @@ function buildAgent(callSession: CallSession): MainAgent {
 	// line so only one path is presented per config.
 	if (callSession.isOwner) {
 		instructions += PHONE_GOOGLE_SEARCH
-			? '\n\nNEVER fabricate specific details. If you don\'t know it, use your built-in Web search to look it up — it\'s faster than delegating, and the answer stays in the conversation.'
+			? '\n\nNEVER fabricate specific details. If you don\'t know it, use your built-in Web search to look it up — it\'s faster than delegating, and the answer stays in the conversation. If your built-in search returns nothing useful, OR the question needs deeper-than-one-lookup research (multi-step, multiple sources, file reading), call the work tool — it routes to the core agent which can do extensive research.'
 			: '\n\nNEVER fabricate specific details. If you don\'t know it, use the work tool to look it up.';
 	}
 


### PR DESCRIPTION
## Summary
Follow-up to #1007. The conditional search-on branch pointed the model at native Web grounding but left three failure modes uncovered:

1. **Native search unavailable mid-call** — googleSearch quota tripped, model returns "I don't have current info on that"
2. **Native search returns nothing useful** — model says it searched but the grounded answer is thin / wrong-shaped
3. **Query needs deeper research than a single Web lookup** — multi-step, multiple sources, file reading (e.g. "summarize this person's last 5 papers")

This PR adds a follow-on clause inside the same conditional pointing the model at the `work` tool for these cases, anchored as "the core agent which can do extensive research."

Per Chi 2026-05-22 04:53 PT Discord: *"shall we add a note for looking something up? Native search may be unavailable or fail, or the work requires extensive research."*

## Scope
- `skills/phone-conversation/scripts/conversation-server.ts` — single-line addition inside existing ternary
- `skills/discord-voice/scripts/discord-voice-server.ts` — same single-line addition
- `voice-agent.ts` — **NOT touched** (still tracked under #1008 for the structural-bias problem)

## Diff
2 files, +2 -2 lines. The "addition" reads as +2 because each ternary branch is one logical line; the line is replaced with a longer line in two files.

## Test plan
- [ ] Call phone, ask "what's the score of the NBA game" → still uses native search (happy path; no regression)
- [ ] Call phone, ask "summarize Yann LeCun's last 5 papers" → should delegate to `work` (mode 3; extensive research)
- [ ] Flip `PHONE_GOOGLE_SEARCH=false` temporarily, ask a Web query → still uses `work` (false-branch unchanged; smoke test)
- [ ] Eyeball rendered prompt in discord-voice has the new fallback line

## Risk
Low. Two single-line text changes inside existing ternaries. tsc-transpile clean. No logic change; just rounds out the conditional to point the model at the right tool for each failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)