### PR TITLE
docs(discord-voice): note strict-literal `true` parse on DISCORD_VOICE_OWNER

### DIFF
--- a/skills/discord-voice/SKILL.md
+++ b/skills/discord-voice/SKILL.md
@@ -61,7 +61,7 @@ DISCORD_VOICE_SERVER=1 \
 Optional env:
 - `VOICE_MODEL` / `VOICE_NATIVE_AUDIO_MODEL` — mirrors `voice-agent.ts`.
 - `SUTANDO_WORKSPACE` — workspace root for tasks/results/data/logs.
-- `DISCORD_VOICE_OWNER` — legacy fallback (see **Trust boundary**). `=true` treats every speaker as owner; default `false`.
+- `DISCORD_VOICE_OWNER` — legacy fallback (see **Trust boundary**). `=true` treats every speaker as owner; default `false`. **Strict parse** (per PR #973): only the literal string `true` enables owner mode; `=1`, `=TRUE`, `=yes` all fall through to the safe surface.
 
 `DISCORD_VOICE_SERVER=1` flips the polymorphic `dismiss` tool (`src/meeting-tools.ts`) into "SIGTERM self" mode instead of its default Zoom AppleScript path. Without it, asking Sutando to "leave"/"dismiss" in the channel would try to leave a (non-existent) Zoom meeting.
 


### PR DESCRIPTION
## Summary

- One-line addition to the `DISCORD_VOICE_OWNER` env doc in `skills/discord-voice/SKILL.md`: `=1`, `=TRUE`, `=yes` (and any other truthy-looking string) do NOT enable owner mode — only the literal lowercase `true` does, per PR #973's strict-parse hardening
- Trust-boundary section already reflects the per-speaker tier model from PR #984; this is a separate doc tune on the legacy fallback flag

Pure docs — no behavior change.

## Test plan

- [x] Read updated bullet: still grammatical, still anchored on the legacy-fallback role
- [x] Verify the `(process.env.DISCORD_VOICE_OWNER ?? 'false') === 'true'` parser at `skills/discord-voice/scripts/discord-voice-server.ts` matches the doc claim (literal === comparison; only `true` passes)
- [ ] No CI risk — single-line markdown edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)