### PR TITLE
fix(zoom): make zoom a manifest-loaded skill (#976 conformance)

### DIFF
--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -118,9 +118,9 @@ mdfind "kMDItemKind == 'PDF'" -onlyin ~/Documents  # by file type in a folder
 
 **Meeting join** — join Zoom or Google Meet with computer audio:
 ```bash
-npx tsx -e "import 'dotenv/config'; import { joinZoomTool } from './src/inline-tools.ts'; joinZoomTool.execute({}, null).then(r => console.log(JSON.stringify(r)))"
+npx tsx -e "import 'dotenv/config'; import { joinZoomTool } from './skills/zoom/tools.ts'; joinZoomTool.execute({}, null).then(r => console.log(JSON.stringify(r)))"
 npx tsx -e "import 'dotenv/config'; import { joinGmeetTool } from './src/inline-tools.ts'; joinGmeetTool.execute({ meetingCode: 'abc-defg-hij' }, null).then(r => console.log(JSON.stringify(r)))"
-npx tsx -e "import 'dotenv/config'; import { summonTool } from './src/inline-tools.ts'; summonTool.execute({}, null).then(r => console.log(JSON.stringify(r)))"
+npx tsx -e "import 'dotenv/config'; import { summonTool } from './skills/zoom/tools.ts'; summonTool.execute({}, null).then(r => console.log(JSON.stringify(r)))"
 ```
 - `joinZoomTool` — Zoom desktop app + computer audio (no screen share)
 - `joinGmeetTool` — Chrome browser + computer audio + camera off

--- a/skills/zoom/SKILL.md
+++ b/skills/zoom/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: zoom
+description: "Zoom meeting control for Sutando's voice and phone agents — contributes the summon (join + screen share), dismiss (leave meeting), and join_zoom (join with computer audio, no share) inline tools."
+when_to_use: "Loaded automatically at agent startup as a manifest skill — its tools fire when the user says 'summon', 'share my screen', 'start zoom', 'join the zoom', 'dismiss', 'leave zoom', etc. Not directly slash-invoked."
+---
+
+# Zoom
+
+Manifest-loaded skill that contributes three Zoom inline tools into the agent's runtime tool table. Picked up at startup by `loadSkillManifestTools()` in `src/inline-tools.ts` and merged into `inlineTools` + `ownerOnlyTools`, so the tools reach both the web voice agent and the phone agent for owner callers.
+
+## Tools
+
+- **`summon`** — opens Zoom (via the `zoommtg://` deeplink), joins the meeting, retries the Join click, and starts screen sharing so the user can see and control the Mac remotely. Optionally dials in via the phone server for voice. Use for "summon", "share my screen", "start zoom", "let me see your screen".
+- **`dismiss`** — leaves the current Zoom meeting (stops screen share, opens the leave dialog, confirms; force-kills Zoom if windows linger). Use for "dismiss", "leave zoom", "end meeting", "hang up zoom".
+- **`join_zoom`** — joins a Zoom meeting via the desktop app with computer audio, no screen share. Use for "join the zoom", "join meeting", or when the user provides a meeting ID.
+
+## Configuration
+
+- **`ZOOM_DEFAULT_SHARE_SCREEN`** (non-secret, in `manifest.json` `config`) — `"true"` by default. Set to `"false"` in the host environment to make `summon` skip screen sharing unless the caller explicitly passes `shareScreen: true`.
+- **`ZOOM_PERSONAL_MEETING_ID`**, **`ZOOM_PERSONAL_PASSCODE`** (secrets — host `.env` only, never in the manifest) — the personal-room defaults used when `summon` / `join_zoom` are called without an explicit meeting ID.
+
+## Notes
+
+- Extracted from `src/meeting-tools.ts` in issue #786.
+- Converted from a static hard-import into core to a manifest-loaded skill in issue #976, so core no longer has a compile-time dependency on `skills/zoom/tools.ts` and the skill is genuinely optional.
+- `skills/discord-voice` intentionally overrides `dismiss` with a Discord-specific implementation (SIGTERM self instead of Zoom AppleScript); its dedupe-by-name loop keeps the override and drops this skill's `dismiss`.

--- a/skills/zoom/manifest.json
+++ b/skills/zoom/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "zoom",
+  "enabled": true,
+  "access_tier": "owner",
+  "description": "Zoom meeting control for the voice/phone agents — contributes the `summon` (join + screen share), `dismiss` (leave meeting), and `join_zoom` (join with computer audio, no share) inline tools. Manifest-loaded so core stays free of a compile-time dependency on this skill (#976 conformance).",
+  "tools": "./tools.ts",
+  "config": {
+    "ZOOM_DEFAULT_SHARE_SCREEN": "true"
+  }
+}

--- a/skills/zoom/tools.ts
+++ b/skills/zoom/tools.ts
@@ -446,3 +446,12 @@ if result.stdout.strip():
 		}
 	},
 };
+
+/**
+ * Manifest entry point — `loadSkillManifestTools()` in src/inline-tools.ts
+ * dynamic-imports this module and merges `tools` into the agent tool table
+ * (#976 conformance).  The individual named exports above are kept for skills
+ * that import a tool directly to override or extend Zoom behaviour (e.g.
+ * skills/discord-voice's dismiss override).
+ */
+export const tools: ToolDefinition[] = [summonTool, dismissTool, joinZoomTool];

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -145,9 +145,11 @@ export const openFileTool: ToolDefinition = {
 	},
 };
 
-// Re-export Zoom tools from skill
-export { summonTool, dismissTool, joinZoomTool } from '../skills/zoom/tools.js';
-import { summonTool, dismissTool, joinZoomTool } from '../skills/zoom/tools.js';
+// Zoom tools (summon, dismiss, join_zoom) are NOT imported here — they live in
+// the manifest-loaded skill `skills/zoom/` (manifest.json + tools.ts) and reach
+// `inlineTools` / `ownerOnlyTools` via the loadSkillManifestTools() path below
+// (#976 conformance). Core no longer has a compile-time dependency on the skill,
+// so it is genuinely optional.
 // Re-export remaining meeting tools
 export { joinGmeetTool, lookupMeetingIdTool, callContactTool } from './meeting-tools.js';
 import { joinGmeetTool, lookupMeetingIdTool, callContactTool } from './meeting-tools.js';
@@ -1086,8 +1088,8 @@ export const inlineTools = assertUniqueToolNames([
 	pressKeyTool, scrollTool, switchTabTool, closeTabTool, openUrlTool,
 	switchAppTool, captureScreenTool, typeTextTool,
 	volumeTool, brightnessTool, clipboardTool,
-	cancelTaskTool, toggleTasksTool, getCurrentTimeTool, getCoreStatusTool, summonTool, dismissTool,
-	joinZoomTool, joinGmeetTool, lookupMeetingIdTool, callContactTool,
+	cancelTaskTool, toggleTasksTool, getCurrentTimeTool, getCoreStatusTool,
+	joinGmeetTool, lookupMeetingIdTool, callContactTool,
 	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, slideControlTool, fullscreenTool,
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
 	recentContextTool,
@@ -1108,8 +1110,8 @@ export const ownerOnlyTools = [
 	volumeTool, brightnessTool,
 	pressKeyTool, scrollTool, switchTabTool, closeTabTool, openUrlTool,
 	switchAppTool, captureScreenTool, typeTextTool,
-	clipboardTool, cancelTaskTool, toggleTasksTool, summonTool, dismissTool,
-	joinZoomTool, joinGmeetTool, callContactTool, slideControlTool, fullscreenTool,
+	clipboardTool, cancelTaskTool, toggleTasksTool,
+	joinGmeetTool, callContactTool, slideControlTool, fullscreenTool,
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
 	recentContextTool,
 	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool,


### PR DESCRIPTION
Closes #976.

## What changed

`skills/zoom/` contained only `tools.ts` (no `manifest.json`, no `SKILL.md`), and its tools were **static hard-imported** into core at `src/inline-tools.ts`:

```ts
export { summonTool, dismissTool, joinZoomTool } from '../skills/zoom/tools.js';
import { summonTool, dismissTool, joinZoomTool } from '../skills/zoom/tools.js';
```

This gave core a compile-time dependency on the skill — it could not be removed without breaking the build, so the skill was not actually optional.

- **Add `skills/zoom/manifest.json`** — `name`, `enabled: true`, `access_tier: owner`, `description`, `tools: "./tools.ts"`, and a `config` block with `ZOOM_DEFAULT_SHARE_SCREEN: "true"` (the non-secret share-screen default flag read by `tools.ts`). Secrets (`ZOOM_PERSONAL_MEETING_ID`, `ZOOM_PERSONAL_PASSCODE`) stay in host `.env` and are **not** in the manifest.
- **Add `skills/zoom/SKILL.md`** — frontmatter (`name`, `description`, `when_to_use`) plus a tool/config overview, matching the style of other skills.
- **Add `export const tools: ToolDefinition[]` to `skills/zoom/tools.ts`** — the manifest loader (`loadSkillManifestTools()`) requires a module-level `tools` array, and the file previously exported the three tools only as individual named exports. The named exports are **kept** (direct-import override skills like `discord-voice` reference them); the new `tools` array is the manifest entry point.
- **Remove the static import/re-export** at `src/inline-tools.ts` and the named `summon`/`dismiss`/`joinZoom` references in the `inlineTools` and `ownerOnlyTools` arrays. The tools now arrive through the manifest-loader path via `...personalAllTools` (into `inlineTools`) and `...personalTools.owner` (into `ownerOnlyTools`).

## Why

`skills/MANIFEST.md` is the skill-packaging contract: a skill contributing runtime tools must declare them via `manifest.json` and be loaded dynamically — not static-imported into core. This is the #976 conformance finding. After this change core has no compile-time dependency on `skills/zoom/`, so the skill is genuinely optional like `gws-gmail-voice` and `screen-companion`.

## Verification

- **Typecheck:** `npm run typecheck` (`tsc --noEmit`) passes. (Note: `tsconfig.json` has `include: ["src"]`, so `skills/zoom/tools.ts` was never in the typecheck graph anyway — same as the other manifest skills' `tools.ts`.)
- **Tests:** all 204 TS tests pass (`tsx --test tests/*.test.ts`).
- **Runtime tool-table check:** imported `src/inline-tools.ts` and confirmed the skill-loader logs `loaded 3 tool(s) from zoom [tier=owner]`; `summon`, `dismiss`, `join_zoom` are present in `inlineTools` (count back to 50, matching pre-change) and `ownerOnlyTools`, absent from `anyCallerTools`, with **no duplicate tool names** (the `assertUniqueToolNames` guard passes).
- **Consumer check:** grepped every consumer of `summonTool`/`dismissTool`/`joinZoomTool` and of the removed `inline-tools.ts` re-export. No consumer imported the named re-export — `voice-agent.ts`, `conversation-server.ts`, and `discord-voice-server.ts` all consume the tool *arrays* (`inlineTools` / `ownerOnlyTools` / etc.). `discord-voice` builds its own `dismiss` override and relies on dedupe-by-name, unaffected.
- **Phone-agent path:** `skills/phone-conversation/scripts/conversation-server.ts` (lines 643–645) pushes every `inlineTools` entry into owner call sessions via a dedupe-by-name loop. Since the zoom tools are now part of `inlineTools` (verified above), they reach the phone tool table exactly as before.

### Caveat — runtime check recommended

The phone-agent path was verified statically (consumer grep + tool-array membership check + reading the `conversation-server.ts` push loop) but **not** exercised against a live phone call. The verification is strong — the phone agent's only dependency is `inlineTools` membership, which the runtime check confirms — but a quick owner phone call exercising `summon` (or `join_zoom` / `dismiss`) after deploy would close the loop with certainty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)