### PR TITLE
docs(claude-router): point interactive review at codex plugin; cross-ref install steps

### DIFF
--- a/skills/claude-router/SKILL.md
+++ b/skills/claude-router/SKILL.md
@@ -27,6 +27,12 @@ ARGUMENTS: $ARGUMENTS
 
 If the request explicitly names `codex` or `gemini`, honor that directly.
 
+## When NOT to Use
+
+- **Interactive code review or task hand-off from this Claude Code session** → use the `/codex:*` plugin commands directly (`/codex:review`, `/codex:adversarial-review`, `/codex:rescue`, `/codex:status`). The router is for programmatic delegation from scripts, cron, and bridges — it goes through the `claude-codex` skill's bash wrapper, not the plugin.
+
+  If you don't see `/codex:*` slash-commands, install the plugin via the 4 commands documented in `skills/claude-codex/SKILL.md` ("When NOT to Use" section).
+
 ## Default Behavior
 
 - Default review-oriented prompts to Codex.


### PR DESCRIPTION
## Summary

- claude-router routes between `codex` and `gemini` via `route-ai.sh` for **programmatic** delegation (scripts/cron/bridges). With the openai/codex-plugin-cc plugin now available, **interactive** review work from a Claude Code session belongs on `/codex:review` (and friends), not the router.
- Adds a "When NOT to Use" section directing readers at `/codex:review`, `/codex:adversarial-review`, `/codex:rescue`, `/codex:status`.
- Cross-references `skills/claude-codex/SKILL.md` (PR #1010) for the 4-command plugin install block — single source of truth, no duplication.

## Why no runtime change

`route-ai.sh` is invoked from contexts (script, cron, Discord bridge sandbox) that don't have access to slash-commands anyway. Plugin-presence detection there would be dead code. The doc tune handles the human reader; the script handles its existing programmatic surface unchanged.

## Test plan

- [x] `route-ai.sh` behavior unchanged (no code touched)
- [x] Cross-ref to `claude-codex/SKILL.md` install section is accurate (verified against PR #1010 branch)
- [ ] Once #1010 merges first, the cross-ref resolves cleanly

## Stack

Depends on (but does not require) PR #1010 being merged first for the cross-reference target to exist on main. Both can land in either order; if this lands first, the cross-ref is a forward reference until #1010 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)