### PR TITLE
chore(package-lock): resync engines.node to match package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "typescript": "^6.0.2"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.5.0"
       },
       "optionalDependencies": {
         "@cartesia/cartesia-js": "^3.0.0"


### PR DESCRIPTION
## What
`package-lock.json`'s root-package `engines.node` was `>=22.0.0`; `package.json` declares `>=22.5.0`. `npm install` resynced the lockfile — this commits the 1-line correction.

## Why
Pre-existing lockfile/package.json drift, surfaced incidentally while running `npm install` to populate the discord-voice deps on a fresh checkout (the deps were declared but `node_modules` was stale). No functional change — just keeps the lockfile and package.json in agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)