### PR TITLE
feat(discord-voice): per-channel owner-mode config (#1016)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ skills/schedule-crons/crons.json
 # ships only the *.example templates — never commit a live config here.
 src/voice-agent.config.json
 skills/phone-conversation/config.json
+# discord-voice config is per-user data (Discord channel ids, owner-mode) and
+# lives in $SUTANDO_WORKSPACE/config/discord-voice.json. The repo ships only
+# config.json.example as a template — never commit a live config.json here.
+skills/discord-voice/config.json
 src/Sutando/Sutando
 # NativeMic.swift was removed in PR #329 and keeps getting re-added by
 # search-and-replace sweeps that leave a stale copy in the working tree

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ logs/*
 !logs/.gitkeep
 state/*
 !state/.gitkeep
+# Per-user workspace configs (e.g. config/discord-voice.json). Live configs
+# carry per-user data and must never be committed from a repo-root workspace
+# install — the repo ships <skill>/config.json.example templates instead.
+config/*.json
 AGENT_LOOP.md
 PENDING.md
 pending-questions.md

--- a/skills/discord-voice/SKILL.md
+++ b/skills/discord-voice/SKILL.md
@@ -61,19 +61,45 @@ DISCORD_VOICE_SERVER=1 \
 Optional env:
 - `VOICE_MODEL` / `VOICE_NATIVE_AUDIO_MODEL` — mirrors `voice-agent.ts`.
 - `SUTANDO_WORKSPACE` — workspace root for tasks/results/data/logs.
-- `DISCORD_VOICE_OWNER` — legacy fallback (see **Trust boundary**). `=true` treats every speaker as owner; default `false`.
-
 `DISCORD_VOICE_SERVER=1` flips the polymorphic `dismiss` tool (`src/meeting-tools.ts`) into "SIGTERM self" mode instead of its default Zoom AppleScript path. Without it, asking Sutando to "leave"/"dismiss" in the channel would try to leave a (non-existent) Zoom meeting.
+
+## Owner-mode config
+
+Owner-mode is set in `skills/discord-voice/config.json` (not an env var). Two keys:
+
+- `owner_mode` — skill-wide default (boolean). `false` by default.
+- `channels` — per-voice-channel override map: `{ "<voice_channel_id>": { "owner_mode": true } }`. The channel entry is an object so it stays extensible.
+
+Resolution for a given channel: `channels[<channel_id>].owner_mode` if that entry exists, else the skill-wide `owner_mode`, else `false`. A fresh `config.json` (`owner_mode: false`, `channels: {}`) runs every channel read-only.
+
+```json
+{
+  "model": "gemini-2.5-flash-native-audio-preview-12-2025",
+  "googleSearch": true,
+  "owner_mode": false,
+  "channels": {
+    "111111111111111111": { "owner_mode": true }
+  }
+}
+```
+
+## Trust boundary — read this before enabling owner-mode
+
+`owner_mode: false` is the **safe default**: non-owner speakers in the voice channel get the read-only tool surface (current time, status checks, lookups) but NOT owner-tier `work`, file edits, or message sends.
+
+`owner_mode: true` — whether set skill-wide or per-channel via `channels` — is the opt-in for **single-operator personal-use mode**: it inherits owner-tier privileges to every speaker in the channel. It has a sharp edge — anyone who can speak in the same voice channel can delegate `work`, edit files, send messages, anything the proactive loop can do. Only enable it for voice channels whose membership is fully trusted (your own Lounge, never community/public). Prefer the per-channel `channels` override over the skill-wide `owner_mode` so a trusted-channel grant doesn't leak to every channel the bot joins.
 
 ## Trust boundary — per-speaker access tiers
 
-Owner-tier tools are gated **per speaker**, by Discord user id, not per channel. Each turn is attributed to the speaker who started it, and tools are gated by that speaker's tier — read from the same `~/.claude/channels/discord/access.json` the discord-bridge uses, so the two never drift:
+Independently of `owner_mode`, owner-tier tools are gated **per speaker**, by Discord user id. Each turn is attributed to the speaker who started it, and tools are gated by that speaker's tier — read from the same `~/.claude/channels/discord/access.json` the discord-bridge uses, so the two never drift:
 
 - **owner** — an id in the top-level `allowFrom` of `access.json`. Full tool surface: `work`, `dismiss`, screen-share, file edits, message sends.
 - **team** — an id in any `groups[*].allowFrom` (per-channel trusted circle: peers, collaborators) that is not also owner. Read-only inline tools + configurable tools + `dismiss`; no `work` / file edits. (`dismiss` is intentional: a teammate can end the bot's voice session — useful when the owner isn't present to close the room; the owner can rejoin via DM.)
 - **other** — anyone else speaking in the channel. Read-only inline tools only (time, status, lookups).
 
-This is exactly the model `discord-bridge.py` uses (top-level `allowFrom` = owner, `groups[*].allowFrom` = team), so the same `access.json` is never read two ways. If `allowFrom` is empty, the gate falls back to the legacy process-global `DISCORD_VOICE_OWNER` flag.
+`owner_mode: true` and the per-speaker tiers compose: a speaker gets the owner surface when `owner_mode` is on for the channel **or** their id resolves to the owner tier.
+
+This is exactly the model `discord-bridge.py` uses (top-level `allowFrom` = owner, `groups[*].allowFrom` = team), so the same `access.json` is never read two ways. If `allowFrom` is empty, the gate falls back to the channel-wide `owner_mode` resolved from `config.json` (see **Owner-mode config** above).
 
 This means the bot can sit safely in a shared/multi-person voice channel: a non-owner speaker physically cannot trigger owner-tier tools — the gate runs at tool-execution time, so even if the model tries, the call is denied.
 

--- a/skills/discord-voice/SKILL.md
+++ b/skills/discord-voice/SKILL.md
@@ -60,17 +60,29 @@ DISCORD_VOICE_SERVER=1 \
 
 Optional env:
 - `VOICE_MODEL` / `VOICE_NATIVE_AUDIO_MODEL` — mirrors `voice-agent.ts`.
-- `SUTANDO_WORKSPACE` — workspace root for tasks/results/data/logs.
+- `SUTANDO_WORKSPACE` — workspace root for tasks/results/data/logs **and the per-user config** (see below).
+
 `DISCORD_VOICE_SERVER=1` flips the polymorphic `dismiss` tool (`src/meeting-tools.ts`) into "SIGTERM self" mode instead of its default Zoom AppleScript path. Without it, asking Sutando to "leave"/"dismiss" in the channel would try to leave a (non-existent) Zoom meeting.
 
-## Owner-mode config
+## Config — per-user, lives in the workspace
 
-Owner-mode is set in `skills/discord-voice/config.json` (not an env var). Two keys:
+This skill's config carries **per-user data** (your Discord channel ids, your owner-mode choices), so it does NOT live in the git repo. It lives in the workspace:
 
-- `owner_mode` — skill-wide default (boolean). `false` by default.
+```
+$SUTANDO_WORKSPACE/config/discord-voice.json
+```
+
+(default `~/.sutando/workspace/config/discord-voice.json`; `$SUTANDO_WORKSPACE` is resolved by the canonical workspace helper).
+
+The repo ships a committed **template** — `skills/discord-voice/config.json.example` — with the safe defaults. On first run, if the workspace config is missing, the server copies the template into place; you then edit the workspace copy. (If the copy can't happen, the server falls back to the built-in defaults — `owner_mode: false`, every channel read-only.) **Never commit a live `discord-voice.json` back into the repo** — it's per-user data, not code.
+
+Keys:
+
+- `model` / `googleSearch` — voice model + Web-grounding preference (defaults: `gemini-2.5-flash-native-audio-preview-12-2025`, `true`).
+- `owner_mode` — skill-wide owner-mode default (boolean). `false` by default.
 - `channels` — per-voice-channel override map: `{ "<voice_channel_id>": { "owner_mode": true } }`. The channel entry is an object so it stays extensible.
 
-Resolution for a given channel: `channels[<channel_id>].owner_mode` if that entry exists, else the skill-wide `owner_mode`, else `false`. A fresh `config.json` (`owner_mode: false`, `channels: {}`) runs every channel read-only.
+Resolution for a given channel: `channels[<channel_id>].owner_mode` if that entry exists, else the skill-wide `owner_mode`, else `false`. A fresh config (`owner_mode: false`, `channels: {}`) runs every channel read-only.
 
 ```json
 {
@@ -87,7 +99,7 @@ Resolution for a given channel: `channels[<channel_id>].owner_mode` if that entr
 
 `owner_mode: false` is the **safe default**: non-owner speakers in the voice channel get the read-only tool surface (current time, status checks, lookups) but NOT owner-tier `work`, file edits, or message sends.
 
-`owner_mode: true` — whether set skill-wide or per-channel via `channels` — is the opt-in for **single-operator personal-use mode**: it inherits owner-tier privileges to every speaker in the channel. It has a sharp edge — anyone who can speak in the same voice channel can delegate `work`, edit files, send messages, anything the proactive loop can do. Only enable it for voice channels whose membership is fully trusted (your own Lounge, never community/public). Prefer the per-channel `channels` override over the skill-wide `owner_mode` so a trusted-channel grant doesn't leak to every channel the bot joins.
+`owner_mode: true` — whether set skill-wide or per-channel via `channels` — is the opt-in for **single-operator personal-use mode**: it inherits owner-tier privileges to every speaker in the channel. It has a sharp edge — anyone who can speak in the same voice channel can delegate `work`, edit files, send messages, anything the proactive loop can do. Only enable it for voice channels whose membership is fully trusted (your own Lounge, never community/public). Prefer the per-channel `channels` override over the skill-wide `owner_mode` so a trusted-channel grant doesn't leak to every channel the bot joins. Set it in the workspace config (`$SUTANDO_WORKSPACE/config/discord-voice.json`), never the committed `.example` template.
 
 ## Trust boundary — per-speaker access tiers
 

--- a/skills/discord-voice/config.json
+++ b/skills/discord-voice/config.json
@@ -1,4 +1,6 @@
 {
   "model": "gemini-2.5-flash-native-audio-preview-12-2025",
-  "googleSearch": true
+  "googleSearch": true,
+  "owner_mode": false,
+  "channels": {}
 }

--- a/skills/discord-voice/config.json
+++ b/skills/discord-voice/config.json
@@ -1,6 +1,0 @@
-{
-  "model": "gemini-2.5-flash-native-audio-preview-12-2025",
-  "googleSearch": true,
-  "owner_mode": false,
-  "channels": {}
-}

--- a/skills/discord-voice/config.json.example
+++ b/skills/discord-voice/config.json.example
@@ -1,0 +1,7 @@
+{
+  "_comment": "TEMPLATE — do not edit in place. The live config is per-user data and lives at $SUTANDO_WORKSPACE/config/discord-voice.json (default ~/.sutando/workspace/config/discord-voice.json). On first run discord-voice-server copies this template there if it is missing. Edit the workspace copy, never this file. Keys: model + googleSearch are voice prefs; owner_mode + channels are the trust-boundary knobs (issue #1016) — see SKILL.md before enabling owner-mode.",
+  "model": "gemini-2.5-flash-native-audio-preview-12-2025",
+  "googleSearch": true,
+  "owner_mode": false,
+  "channels": {}
+}

--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -41,7 +41,7 @@ _dotenvConfig({ path: join(process.env.HOME ?? '', '.claude/channels/discord/.en
 
 import { fileURLToPath } from 'node:url';
 import { voiceApiKey } from '../../../src/voice-key.js';
-import { loadVoiceConfig } from '../../../src/voice-config.js';
+import { loadVoiceConfig, resolveOwnerMode } from '../../../src/voice-config.js';
 import { execSync, spawn } from 'node:child_process';
 import { VoiceSession, type ToolDefinition, type MainAgent } from 'bodhi-realtime-agent';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
@@ -142,9 +142,23 @@ const CHANNEL_ID = getArg('channel');
 // Set owner_mode=true (skill-wide or per-channel) to inherit owner privileges
 // to every speaker — only safe in voice channels whose membership is fully
 // trusted (single-operator Lounge, not community/public). See SKILL.md.
-const _channelConfig = CHANNEL_ID ? DISCORD_VOICE_CONFIG.channels[CHANNEL_ID] : undefined;
-const TREAT_AS_OWNER =
-	_channelConfig?.owner_mode ?? DISCORD_VOICE_CONFIG.owner_mode ?? false;
+// resolveOwnerMode (src/voice-config.ts) is fail-closed: it grants ONLY on the
+// boolean literal `true`, so a hand-edited config with a string `"true"` /
+// `"false"` / null / number can't silently flip the trust boundary. It also
+// preserves precedence — a channel that explicitly sets owner_mode:false still
+// overrides a skill-wide owner_mode:true.
+const TREAT_AS_OWNER = resolveOwnerMode(DISCORD_VOICE_CONFIG, CHANNEL_ID);
+
+// Legacy env warning (issue #1016) — owner-mode used to be a coarse global
+// env flag. It's now config-driven (`owner_mode` in the workspace config).
+// If the old var is still set, warn once so the operator knows it's inert.
+if (process.env.DISCORD_VOICE_OWNER !== undefined) {
+	console.warn(
+		'[discord-voice] DISCORD_VOICE_OWNER is set but no longer takes effect — ' +
+		'owner-mode is now config-driven (`owner_mode` in the workspace config, ' +
+		'$SUTANDO_WORKSPACE/config/discord-voice.json; see SKILL.md).',
+	);
+}
 
 if (!GEMINI_API_KEY) { console.error('Error: GEMINI_API_KEY required'); process.exit(1); }
 if (!DISCORD_BOT_TOKEN) { console.error('Error: DISCORD_BOT_TOKEN required'); process.exit(1); }

--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -21,13 +21,16 @@
  * ## Env
  *   DISCORD_BOT_TOKEN  — bot token (~/.claude/channels/discord/.env)
  *   GEMINI_API_KEY (or GEMINI_VOICE_API_KEY) — required; voiceApiKey()
- *   VOICE_MODEL — text/STT model; native-audio model + googleSearch live
- *                 in skills/discord-voice/config.json (see src/voice-config.ts)
- *   SUTANDO_WORKSPACE  — workspace root for tasks/results/data
+ *   VOICE_MODEL — text/STT model; native-audio model + googleSearch +
+ *                 owner_mode/channels live in the per-user config at
+ *                 $SUTANDO_WORKSPACE/config/discord-voice.json — NOT a
+ *                 committed repo file (the repo ships config.json.example
+ *                 as a template; see src/voice-config.ts for the schema)
+ *   SUTANDO_WORKSPACE  — workspace root for tasks/results/data + config
  */
 
 import { config as _dotenvConfig } from 'dotenv';
-import { mkdirSync, writeFileSync, appendFileSync, existsSync, readFileSync, unlinkSync } from 'node:fs';
+import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, existsSync, readFileSync, unlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { resolveWorkspace } from '../../../src/workspace_default.js';
 import { recordConversation, recordSession } from '../../../src/conversation-store.js';
@@ -81,10 +84,29 @@ const TASK_POLL_TIMEOUT_MS = 300_000;
 const OWNER_NAME = process.env.owner ?? '';
 
 const VOICE_MODEL = process.env.VOICE_MODEL || 'gemini-2.5-flash';
-// Per-skill voice config (native-audio model + googleSearch) lives in
-// skills/discord-voice/config.json. Schema + defaults: src/voice-config.ts.
+// Per-user voice config (native-audio model + googleSearch + owner_mode +
+// channels) is data, not code: it lives in the workspace, NOT in the git repo.
+//   live config: $SUTANDO_WORKSPACE/config/discord-voice.json
+//   template:    skills/discord-voice/config.json.example (committed)
+// On first run, if the workspace config is missing, the committed .example
+// template is copied into place so the operator has a file to edit. If the
+// copy fails (or the template is gone), loadVoiceConfig falls back to its
+// built-in safe defaults. Schema + defaults: src/voice-config.ts.
 const _discordSkillDir = dirname(dirname(fileURLToPath(import.meta.url)));
-const DISCORD_VOICE_CONFIG = loadVoiceConfig(join(_discordSkillDir, 'config.json'));
+const DISCORD_VOICE_CONFIG_PATH = join(WORKSPACE_DIR, 'config', 'discord-voice.json');
+if (!existsSync(DISCORD_VOICE_CONFIG_PATH)) {
+	const _exampleConfigPath = join(_discordSkillDir, 'config.json.example');
+	try {
+		mkdirSync(dirname(DISCORD_VOICE_CONFIG_PATH), { recursive: true });
+		if (existsSync(_exampleConfigPath)) {
+			copyFileSync(_exampleConfigPath, DISCORD_VOICE_CONFIG_PATH);
+			console.log(`${new Date().toISOString().slice(11, 23)} [discord-voice] seeded config from template → ${DISCORD_VOICE_CONFIG_PATH}`);
+		}
+	} catch (e) {
+		console.warn(`${new Date().toISOString().slice(11, 23)} [discord-voice] could not seed config at ${DISCORD_VOICE_CONFIG_PATH}: ${(e as Error).message} — using built-in defaults`);
+	}
+}
+const DISCORD_VOICE_CONFIG = loadVoiceConfig(DISCORD_VOICE_CONFIG_PATH);
 const VOICE_NATIVE_AUDIO_MODEL = DISCORD_VOICE_CONFIG.model;
 const DISCORD_VOICE_GOOGLE_SEARCH = DISCORD_VOICE_CONFIG.googleSearch;
 
@@ -109,8 +131,9 @@ function getArg(name: string): string | undefined {
 const GUILD_ID = getArg('guild');
 const CHANNEL_ID = getArg('channel');
 
-// Owner-mode (issue #1016) — resolved from skills/discord-voice/config.json,
-// NOT an env var. Resolution order:
+// Owner-mode (issue #1016) — resolved from the workspace config
+// ($SUTANDO_WORKSPACE/config/discord-voice.json), NOT an env var and NOT a
+// committed repo file. Resolution order:
 //   1. config.channels[CHANNEL_ID].owner_mode  (per-channel override)
 //   2. config.owner_mode                       (skill-wide default)
 //   3. false                                   (safe default)

--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -95,13 +95,6 @@ const DISCORD_VOICE_GOOGLE_SEARCH = DISCORD_VOICE_CONFIG.googleSearch;
 // this, treat the session as hung and force a reconnect. Env-overridable.
 const WATCHDOG_STALL_MS = Number(process.env.SUTANDO_WATCHDOG_STALL_MS) || 20000;
 
-// Default false (safe): non-owner speakers in the voice channel get the
-// read-only tool surface but NOT owner-tier work/file-edit/message-send.
-// Set DISCORD_VOICE_OWNER=true explicitly to inherit owner privileges to
-// every speaker — only safe in voice channels whose membership is fully
-// trusted (single-operator Lounge, not community/public).
-const TREAT_AS_OWNER = (process.env.DISCORD_VOICE_OWNER ?? 'false') === 'true';
-
 // --- Per-speaker access tier (owner / team / other) -------------------------
 // Tier logic lives in ./access-tier.ts (pure + unit-tested). A Gemini Live
 // session's tool list is fixed at session start, so the tier is enforced
@@ -115,6 +108,20 @@ function getArg(name: string): string | undefined {
 }
 const GUILD_ID = getArg('guild');
 const CHANNEL_ID = getArg('channel');
+
+// Owner-mode (issue #1016) — resolved from skills/discord-voice/config.json,
+// NOT an env var. Resolution order:
+//   1. config.channels[CHANNEL_ID].owner_mode  (per-channel override)
+//   2. config.owner_mode                       (skill-wide default)
+//   3. false                                   (safe default)
+// Default false (safe): non-owner speakers in the voice channel get the
+// read-only tool surface but NOT owner-tier work/file-edit/message-send.
+// Set owner_mode=true (skill-wide or per-channel) to inherit owner privileges
+// to every speaker — only safe in voice channels whose membership is fully
+// trusted (single-operator Lounge, not community/public). See SKILL.md.
+const _channelConfig = CHANNEL_ID ? DISCORD_VOICE_CONFIG.channels[CHANNEL_ID] : undefined;
+const TREAT_AS_OWNER =
+	_channelConfig?.owner_mode ?? DISCORD_VOICE_CONFIG.owner_mode ?? false;
 
 if (!GEMINI_API_KEY) { console.error('Error: GEMINI_API_KEY required'); process.exit(1); }
 if (!DISCORD_BOT_TOKEN) { console.error('Error: DISCORD_BOT_TOKEN required'); process.exit(1); }

--- a/src/voice-config-switch.ts
+++ b/src/voice-config-switch.ts
@@ -27,7 +27,11 @@ import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { VOICE_CONFIG_DEFAULTS, type VoiceConfig } from './voice-config.js';
 import { resolveWorkspace } from './workspace_default.js';
 
-const PRESETS: Record<'search' | 'no-search', VoiceConfig> = {
+// Presets carry only the two knobs this tool switches (model + googleSearch);
+// owner_mode / channels are merged in from VOICE_CONFIG_DEFAULTS at write time.
+type VoiceConfigPreset = Pick<VoiceConfig, 'model' | 'googleSearch'>;
+
+const PRESETS: Record<'search' | 'no-search', VoiceConfigPreset> = {
 	search: { model: 'gemini-2.5-flash-native-audio-preview-12-2025', googleSearch: true },
 	'no-search': { model: 'gemini-3.1-flash-live-preview', googleSearch: false },
 };

--- a/src/voice-config.ts
+++ b/src/voice-config.ts
@@ -15,7 +15,12 @@
  * surface copies the template into the workspace if the live config is
  * missing. Schema:
  *
- *   { "model": "gemini-2.5-flash-native-audio-preview-12-2025", "googleSearch": true }
+ *   {
+ *     "model": "gemini-2.5-flash-native-audio-preview-12-2025",
+ *     "googleSearch": true,
+ *     "owner_mode": false,
+ *     "channels": { "<voice_channel_id>": { "owner_mode": true } }
+ *   }
  *
  * Missing file → defaults. Partial file → fill in missing keys from defaults.
  *
@@ -28,27 +33,49 @@
  * web client's code-heavy workload) ship a `.example` template carrying that
  * override. Phone inherits the default; discord-voice's template carries it
  * too, so a fresh install behaves identically.
+ *
+ * `owner_mode` / `channels` are the discord-voice trust-boundary knobs
+ * (issue #1016) — `owner_mode` is the skill-wide default and `channels[id]`
+ * is a per-voice-channel override. They replaced the coarse global env flag
+ * the skill previously used. Both default to a safe read-only posture.
  */
 
 import { readFileSync, existsSync } from 'fs';
 
+/** Per-channel override entry. Object-shaped so it stays extensible. */
+export interface VoiceChannelConfig {
+	owner_mode?: boolean;
+}
+
 export interface VoiceConfig {
 	model: string;
 	googleSearch: boolean;
+	/** Skill-wide default for owner-mode. Safe default: false (read-only). */
+	owner_mode: boolean;
+	/** Per-channel overrides, keyed by voice channel id. */
+	channels: Record<string, VoiceChannelConfig>;
 }
 
 export const VOICE_CONFIG_DEFAULTS: VoiceConfig = {
 	model: 'gemini-2.5-flash-native-audio-preview-12-2025',
 	googleSearch: true,
+	owner_mode: false,
+	channels: {},
 };
 
 export function loadVoiceConfig(configPath: string): VoiceConfig {
-	if (!existsSync(configPath)) return { ...VOICE_CONFIG_DEFAULTS };
+	if (!existsSync(configPath)) return { ...VOICE_CONFIG_DEFAULTS, channels: {} };
 	try {
 		const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
-		return { ...VOICE_CONFIG_DEFAULTS, ...raw };
+		return {
+			...VOICE_CONFIG_DEFAULTS,
+			...raw,
+			// channels is a nested object — spread can't deep-merge, so take the
+			// file's map verbatim when present, else fall back to the empty default.
+			channels: raw.channels ?? {},
+		};
 	} catch (e) {
 		console.warn(`[voice-config] failed to parse ${configPath}, using defaults: ${(e as Error).message}`);
-		return { ...VOICE_CONFIG_DEFAULTS };
+		return { ...VOICE_CONFIG_DEFAULTS, channels: {} };
 	}
 }

--- a/src/voice-config.ts
+++ b/src/voice-config.ts
@@ -63,6 +63,40 @@ export const VOICE_CONFIG_DEFAULTS: VoiceConfig = {
 	channels: {},
 };
 
+/**
+ * Resolve the effective owner-mode for a discord-voice channel — fail-closed.
+ *
+ * The config is raw JSON spread into `VoiceConfig`, so a hand-edited file can
+ * carry a non-boolean value (string `"false"`, `null`, a number, a typo). A
+ * loose `?? false` / truthy check would treat the *string* `"false"` as
+ * truthy and grant owner tier to every speaker — a trust-boundary bug. Owner
+ * mode is therefore granted ONLY when the value is the boolean literal `true`;
+ * every other shape fails closed to `false`.
+ *
+ * Precedence (must NOT collapse to an OR of the two levels — that would break
+ * a channel's explicit opt-out of a skill-wide default):
+ *   1. If the channel entry exists AND carries an `owner_mode` key, that key
+ *      decides — `=== true` grants, present-but-not-`true` (incl. `false`)
+ *      denies. A channel-explicit `false` correctly overrides a skill default
+ *      of `true`.
+ *   2. Otherwise the skill-wide `config.owner_mode` decides (`=== true`).
+ *   3. Otherwise `false`.
+ */
+export function resolveOwnerMode(
+	config: VoiceConfig,
+	channelId?: string,
+): boolean {
+	const channelEntry =
+		channelId !== undefined ? config.channels?.[channelId] : undefined;
+	if (
+		channelEntry &&
+		Object.prototype.hasOwnProperty.call(channelEntry, 'owner_mode')
+	) {
+		return channelEntry.owner_mode === true;
+	}
+	return config.owner_mode === true;
+}
+
 export function loadVoiceConfig(configPath: string): VoiceConfig {
 	if (!existsSync(configPath)) return { ...VOICE_CONFIG_DEFAULTS, channels: {} };
 	try {

--- a/tests/voice-config-owner-mode.test.ts
+++ b/tests/voice-config-owner-mode.test.ts
@@ -1,0 +1,130 @@
+// Unit tests for resolveOwnerMode (src/voice-config.ts) — the fail-closed
+// owner-mode resolver for discord-voice (issue #1016, PR #1017 review fix).
+//
+// The discord-voice config is raw JSON spread into VoiceConfig, so a
+// hand-edited file can carry a non-boolean owner_mode (string "false", null,
+// a number, a typo). A loose `?? false` / truthy check would treat the STRING
+// "false" as truthy and grant owner tier to every speaker — a trust-boundary
+// bug. resolveOwnerMode must grant ONLY on the boolean literal `true`, and
+// must preserve channel-over-skill precedence (a channel-explicit `false`
+// overrides a skill-default `true`).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveOwnerMode, type VoiceConfig } from '../src/voice-config.ts';
+
+// A VoiceConfig is `{ model, googleSearch, owner_mode, channels }`, but the
+// owner_mode/channels fields are the only ones resolveOwnerMode reads. Cast
+// loosely so we can exercise the malformed shapes a real edited file produces.
+function cfg(partial: Partial<VoiceConfig> & Record<string, unknown>): VoiceConfig {
+	return {
+		model: 'gemini-2.5-flash-native-audio-preview-12-2025',
+		googleSearch: true,
+		owner_mode: false,
+		channels: {},
+		...partial,
+	} as VoiceConfig;
+}
+
+const CH = '1485653767402553457';
+
+test('boolean true at skill level → owner', () => {
+	assert.equal(resolveOwnerMode(cfg({ owner_mode: true })), true);
+});
+
+test('boolean false at skill level → non-owner', () => {
+	assert.equal(resolveOwnerMode(cfg({ owner_mode: false })), false);
+});
+
+test('string "true" at skill level fails closed → non-owner', () => {
+	assert.equal(resolveOwnerMode(cfg({ owner_mode: 'true' as unknown as boolean })), false);
+});
+
+test('string "false" at skill level fails closed → non-owner (would be truthy under ??)', () => {
+	// The headline bug: a non-empty string is truthy. `?? false` / `value ||`
+	// would grant owner here. Strict `=== true` denies.
+	assert.equal(resolveOwnerMode(cfg({ owner_mode: 'false' as unknown as boolean })), false);
+});
+
+test('null at skill level fails closed → non-owner', () => {
+	assert.equal(resolveOwnerMode(cfg({ owner_mode: null as unknown as boolean })), false);
+});
+
+test('number 1 at skill level fails closed → non-owner', () => {
+	assert.equal(resolveOwnerMode(cfg({ owner_mode: 1 as unknown as boolean })), false);
+});
+
+test('missing channelId arg → uses skill-level only', () => {
+	assert.equal(resolveOwnerMode(cfg({ owner_mode: true })), true);
+	assert.equal(resolveOwnerMode(cfg({ owner_mode: false })), false);
+});
+
+test('channelId given but no channel entry → falls back to skill-level', () => {
+	assert.equal(resolveOwnerMode(cfg({ owner_mode: true }), CH), true);
+	assert.equal(resolveOwnerMode(cfg({ owner_mode: false }), CH), false);
+});
+
+test('channel entry without owner_mode key → falls back to skill-level', () => {
+	// Channel entry exists but carries no owner_mode key (e.g. some future
+	// per-channel knob). Must defer to the skill-wide default.
+	assert.equal(
+		resolveOwnerMode(cfg({ owner_mode: true, channels: { [CH]: {} } }), CH),
+		true,
+	);
+	assert.equal(
+		resolveOwnerMode(cfg({ owner_mode: false, channels: { [CH]: {} } }), CH),
+		false,
+	);
+});
+
+test('channel owner_mode:true → owner (overrides skill false)', () => {
+	assert.equal(
+		resolveOwnerMode(cfg({ owner_mode: false, channels: { [CH]: { owner_mode: true } } }), CH),
+		true,
+	);
+});
+
+test('PRECEDENCE: channel-explicit false overrides skill-default true → non-owner', () => {
+	// The critical opt-out case: a channel that explicitly opts OUT must not
+	// be re-granted by the skill-wide default. An OR-collapse would break this.
+	assert.equal(
+		resolveOwnerMode(cfg({ owner_mode: true, channels: { [CH]: { owner_mode: false } } }), CH),
+		false,
+	);
+});
+
+test('malformed channel owner_mode (string "true") fails closed → non-owner', () => {
+	// Channel entry HAS an owner_mode key but it's a string. Present-but-not-
+	// boolean-true must deny — and must NOT fall through to the skill default.
+	assert.equal(
+		resolveOwnerMode(
+			cfg({ owner_mode: true, channels: { [CH]: { owner_mode: 'true' as unknown as boolean } } }),
+			CH,
+		),
+		false,
+	);
+});
+
+test('malformed channel owner_mode (null) fails closed → non-owner', () => {
+	assert.equal(
+		resolveOwnerMode(
+			cfg({ owner_mode: true, channels: { [CH]: { owner_mode: null as unknown as boolean } } }),
+			CH,
+		),
+		false,
+	);
+});
+
+test('malformed channel owner_mode (number) fails closed → non-owner', () => {
+	assert.equal(
+		resolveOwnerMode(
+			cfg({ owner_mode: true, channels: { [CH]: { owner_mode: 1 as unknown as boolean } } }),
+			CH,
+		),
+		false,
+	);
+});
+
+test('default config (owner_mode:false, no channels) → non-owner', () => {
+	assert.equal(resolveOwnerMode(cfg({}), CH), false);
+});


### PR DESCRIPTION
## What changed

Per-channel owner-mode for discord-voice (replacing the coarse global `DISCORD_VOICE_OWNER` env var), with the config moved **out of the git repo** into per-user workspace state — the data-vs-code split.

The repo is meant to be shareable, so per-user data (Discord channel ids, owner-mode choices) must not live in a committed file.

- **`skills/discord-voice/config.json`** — **deleted** (`git rm`). It was git-tracked and carried per-user data.
- **`skills/discord-voice/config.json.example`** — new committed **template** with the safe defaults (`model`, `googleSearch: true`, `owner_mode: false`, `channels: {}`) plus an explanatory `_comment`.
- **Live config location** — `$SUTANDO_WORKSPACE/config/discord-voice.json`, resolved via the canonical `resolveWorkspace()` helper (`src/workspace_default.ts`). `config/` is created if missing.
- **`skills/discord-voice/scripts/discord-voice-server.ts`** — points `loadVoiceConfig` at the workspace path. On first run, if the workspace config is missing, the committed `.example` template is copied into place; if the copy can't happen, `loadVoiceConfig` falls back to its built-in safe defaults.
- **`src/voice-config.ts`** — `loadVoiceConfig(path)` was already path-agnostic, so it needs no behavior change; only the doc comment is updated to describe where each surface's config lives. `VoiceConfig` / `VoiceChannelConfig` / `owner_mode` / `channels` schema unchanged.
- **`.gitignore`** — ignores `skills/discord-voice/config.json` so a casual `git add .` can't resurrect a live config into the repo.
- **`skills/discord-voice/SKILL.md`** — config docs rewritten: config lives at `$SUTANDO_WORKSPACE/config/discord-voice.json`, repo ships `config.json.example`. Owner-mode trust-boundary warnings preserved.

## Scoping — voice-agent / phone unaffected

`loadVoiceConfig` is shared by three surfaces (voice-agent, phone-conversation, discord-voice). Each caller passes its own config path:

- `voice-agent.ts` → `src/voice-agent.config.json` (committed, model/search prefs only — no per-user data)
- `conversation-server.ts` (phone) → `skills/phone-conversation/config.json` (likewise)
- `discord-voice-server.ts` → `$SUTANDO_WORKSPACE/config/discord-voice.json` ← only this changed

Because the path is a caller argument, only discord-voice's path moved. voice-agent and phone keep their committed configs untouched. `voice-config-switch.ts` only writes `voice-agent.config.json` and is unrelated to discord-voice.

## Config schema (unchanged)

```json
{
  "model": "gemini-2.5-flash-native-audio-preview-12-2025",
  "googleSearch": true,
  "owner_mode": false,
  "channels": {
    "<voice_channel_id>": { "owner_mode": true }
  }
}
```

Resolution for a given channel: `channels[CHANNEL_ID].owner_mode` if that entry exists, else the skill-wide `owner_mode`, else `false`.

## Why per-channel owner-mode

The previous `DISCORD_VOICE_OWNER` env flag was global — it flipped owner privileges on for *every* voice channel the bot joined. Per #1016, owner-mode should be a per-channel decision so a trusted single-operator Lounge can run owner-mode without leaking those privileges to any other channel.

## Behavior unchanged by default

No workspace config file → seed from the `.example` template (or fall back to built-in defaults if the seed fails) → `owner_mode: false`, `channels: {}` → every channel runs read-only (`access_tier: other`), exactly today's default. Verified with a smoke test: seed-from-example, arbitrary-channel resolution, and no-file fallback all yield `owner_mode: false`.

Out of scope: the per-speaker recognition gap (the other half of #1016) is not touched here.

## Review fixes applied (fleet review — Maddy / Lucy / MacBook)

Three follow-up fixes pushed in commit `53a58b1`:

1. **owner_mode strict validation (HIGH severity).** The discord-voice config is raw JSON spread into `VoiceConfig`, so a hand-edited non-boolean value — e.g. `"owner_mode": "false"` (a *string*) — was truthy under the old `channels[id]?.owner_mode ?? config.owner_mode ?? false` resolution and silently granted owner tier to **every** speaker. New `resolveOwnerMode()` helper in `src/voice-config.ts` grants owner-mode **only** on the boolean literal `true`; any non-boolean (string, `null`, number, malformed) fails closed to `false`. Precedence is preserved — the helper checks for the `owner_mode` key's *presence* on the channel entry, so a channel that explicitly sets `owner_mode: false` still overrides a skill-default `owner_mode: true` (no OR-collapse of the two levels). 15 new tests in `tests/voice-config-owner-mode.test.ts` cover string `"true"`/`"false"`, `null`, number, missing channel entry, malformed channel `owner_mode`, and the channel-explicit-`false`-over-skill-default-`true` precedence case.
2. **`.gitignore`.** Added `config/*.json` near the `tasks/`/`results/`/`state/` workspace-ignore block so a live `$SUTANDO_WORKSPACE/config/*.json` can't be accidentally committed from a repo-root workspace install.
3. **Legacy-env warn.** `discord-voice-server.ts` now emits a single `console.warn` at startup if `DISCORD_VOICE_OWNER` is still set — the legacy env var no longer takes effect now that owner-mode is config-driven.

## Verification

- `npm run typecheck` (`tsc --noEmit`) — passes.
- All 219 TS tests pass, including the new `voice-config-owner-mode` suite (15 tests).
- `grep` for `DISCORD_VOICE_OWNER` across code + docs — no remaining functional references (only the new legacy-warn check).
- Smoke test of `loadVoiceConfig` against a temp workspace — seed/resolve/fallback all correct.
- All three `loadVoiceConfig` callers re-checked: voice-agent and phone unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
