### PR TITLE
refactor(voice-agent,phone): move config to workspace (data-vs-code split)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ skills/personal-*/
 tests/security/*.md
 !tests/security/*.md.example
 skills/schedule-crons/crons.json
+# voice-agent + phone-conversation configs are per-user data (model/grounding
+# prefs the operator tunes) and live in $SUTANDO_WORKSPACE/config/. The repo
+# ships only the *.example templates — never commit a live config here.
+src/voice-agent.config.json
+skills/phone-conversation/config.json
 src/Sutando/Sutando
 # NativeMic.swift was removed in PR #329 and keeps getting re-added by
 # search-and-replace sweeps that leave a stale copy in the working tree

--- a/skills/phone-conversation/config.json
+++ b/skills/phone-conversation/config.json
@@ -1,4 +1,0 @@
-{
-  "model": "gemini-2.5-flash-native-audio-preview-12-2025",
-  "googleSearch": true
-}

--- a/skills/phone-conversation/config.json.example
+++ b/skills/phone-conversation/config.json.example
@@ -1,0 +1,5 @@
+{
+  "_comment": "TEMPLATE — do not edit in place. The live config is per-user data and lives at $SUTANDO_WORKSPACE/config/phone-conversation.json (default ~/.sutando/workspace/config/phone-conversation.json). On first run conversation-server copies this template there if it is missing. Edit the workspace copy, never this file. Keys: model + googleSearch are voice prefs; phone ships with the package default 2.5+search:true.",
+  "model": "gemini-2.5-flash-native-audio-preview-12-2025",
+  "googleSearch": true
+}

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -47,7 +47,7 @@
 import { config as _dotenvConfig } from 'dotenv';
 _dotenvConfig({ path: new URL('../../../.env', import.meta.url).pathname, override: true });
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { mkdirSync, writeFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync, symlinkSync } from 'node:fs';
+import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync, symlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { voiceApiKey } from '../../../src/voice-key.js';
@@ -125,13 +125,32 @@ const TASK_TIMEOUT_MS = 120_000;
 const OWNER_NAME = process.env.owner ?? '';
 const OWNER_NUMBER = process.env.OWNER_NUMBER ?? '';
 
-// Model configuration — text/STT model still env-driven; native-audio model
-// + googleSearch grounding live in skills/phone-conversation/config.json
-// (schema: src/voice-config.ts). Phone ships with the package default
-// 2.5+search:true.
+// Model configuration — text/STT model still env-driven; the native-audio
+// model + googleSearch grounding are per-user config: data, not code, so they
+// live in the workspace, NOT in the git repo.
+//   live config: $SUTANDO_WORKSPACE/config/phone-conversation.json
+//   template:    skills/phone-conversation/config.json.example (committed)
+// On first run, if the workspace config is missing, the committed .example
+// template is copied into place so the operator has a file to edit. If the
+// copy fails (or the template is gone), loadVoiceConfig falls back to its
+// built-in defaults (schema: src/voice-config.ts). Phone ships with the
+// package default 2.5+search:true.
 const VOICE_MODEL = process.env.VOICE_MODEL || 'gemini-2.5-flash';
 const _phoneSkillDir = dirname(dirname(fileURLToPath(import.meta.url)));
-const PHONE_VOICE_CONFIG = loadVoiceConfig(join(_phoneSkillDir, 'config.json'));
+const PHONE_VOICE_CONFIG_PATH = join(WORKSPACE_DIR, 'config', 'phone-conversation.json');
+if (!existsSync(PHONE_VOICE_CONFIG_PATH)) {
+	const _exampleConfigPath = join(_phoneSkillDir, 'config.json.example');
+	try {
+		mkdirSync(dirname(PHONE_VOICE_CONFIG_PATH), { recursive: true });
+		if (existsSync(_exampleConfigPath)) {
+			copyFileSync(_exampleConfigPath, PHONE_VOICE_CONFIG_PATH);
+			console.log(`${new Date().toISOString().slice(11, 23)} [phone-conversation] seeded config from template → ${PHONE_VOICE_CONFIG_PATH}`);
+		}
+	} catch (e) {
+		console.warn(`${new Date().toISOString().slice(11, 23)} [phone-conversation] could not seed config at ${PHONE_VOICE_CONFIG_PATH}: ${(e as Error).message} — using built-in defaults`);
+	}
+}
+const PHONE_VOICE_CONFIG = loadVoiceConfig(PHONE_VOICE_CONFIG_PATH);
 const VOICE_NATIVE_AUDIO_MODEL = PHONE_VOICE_CONFIG.model;
 const PHONE_GOOGLE_SEARCH = PHONE_VOICE_CONFIG.googleSearch;
 

--- a/src/voice-agent.config.json
+++ b/src/voice-agent.config.json
@@ -1,4 +1,0 @@
-{
-  "model": "gemini-3.1-flash-live-preview",
-  "googleSearch": false
-}

--- a/src/voice-agent.config.json.example
+++ b/src/voice-agent.config.json.example
@@ -1,0 +1,5 @@
+{
+  "_comment": "TEMPLATE — do not edit in place. The live config is per-user data and lives at $SUTANDO_WORKSPACE/config/voice-agent.json (default ~/.sutando/workspace/config/voice-agent.json). On first run voice-agent copies this template there if it is missing. Edit the workspace copy, never this file. Keys: model + googleSearch are voice prefs (the switch_voice_config tool writes them at runtime). voice-agent ships with model=3.1 + googleSearch=false because the web client's code-heavy workload prefers 3.1.",
+  "model": "gemini-3.1-flash-live-preview",
+  "googleSearch": false
+}

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -26,7 +26,7 @@
 import 'dotenv/config';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { z } from 'zod';
-import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, mkdirSync, appendFileSync, writeFileSync, openSync, writeSync, closeSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, mkdirSync, copyFileSync, appendFileSync, writeFileSync, openSync, writeSync, closeSync } from 'node:fs';
 import { execSync as execSyncTop } from 'node:child_process';
 import { inlineTools, coreDocumentedSkills } from './inline-tools.js';
 import { setVisionSession, startVisionControlServer, stopVisionControlServer } from './vision-tools.js';
@@ -171,15 +171,34 @@ function acquirePidLock(): void {
 
 // Model configuration — override via .env for cost/quality tuning
 const VOICE_MODEL = process.env.VOICE_MODEL || 'gemini-2.5-flash';
-// Per-skill voice config (native-audio model + googleSearch grounding) lives
-// in voice-agent.config.json next to this file. Schema + defaults: see
+// Per-user voice config (native-audio model + googleSearch grounding) is
+// data, not code: it lives in the workspace, NOT in the git repo.
+//   live config: $SUTANDO_WORKSPACE/config/voice-agent.json
+//   template:    src/voice-agent.config.json.example (committed)
+// On first run, if the workspace config is missing, the committed .example
+// template is copied into place so the operator (and the switch_voice_config
+// tool) have a file to edit. If the copy fails (or the template is gone),
+// loadVoiceConfig falls back to its built-in defaults. Schema + defaults: see
 // src/voice-config.ts. voice-agent ships with model=3.1 + googleSearch=false
 // because the web client's code-heavy workload prefers 3.1 and the (key,
 // 3.1, googleSearch) combo trips a 1011 close on the VOICE key when search
-// is true. Phone + discord-voice inherit the package default (2.5+search).
+// is true. Phone inherits the package default (2.5+search).
 import { loadVoiceConfig } from './voice-config.js';
 const _voiceAgentDir = dirname(fileURLToPath(import.meta.url));
-const VOICE_AGENT_CONFIG = loadVoiceConfig(join(_voiceAgentDir, 'voice-agent.config.json'));
+const VOICE_AGENT_CONFIG_PATH = join(WORKSPACE_DIR, 'config', 'voice-agent.json');
+if (!existsSync(VOICE_AGENT_CONFIG_PATH)) {
+	const _exampleConfigPath = join(_voiceAgentDir, 'voice-agent.config.json.example');
+	try {
+		mkdirSync(dirname(VOICE_AGENT_CONFIG_PATH), { recursive: true });
+		if (existsSync(_exampleConfigPath)) {
+			copyFileSync(_exampleConfigPath, VOICE_AGENT_CONFIG_PATH);
+			console.log(`${new Date().toISOString().slice(11, 23)} [voice-agent] seeded config from template → ${VOICE_AGENT_CONFIG_PATH}`);
+		}
+	} catch (e) {
+		console.warn(`${new Date().toISOString().slice(11, 23)} [voice-agent] could not seed config at ${VOICE_AGENT_CONFIG_PATH}: ${(e as Error).message} — using built-in defaults`);
+	}
+}
+const VOICE_AGENT_CONFIG = loadVoiceConfig(VOICE_AGENT_CONFIG_PATH);
 const VOICE_NATIVE_AUDIO_MODEL = VOICE_AGENT_CONFIG.model;
 const VOICE_GOOGLE_SEARCH = VOICE_AGENT_CONFIG.googleSearch;
 const VOICE_NAME = process.env.VOICE_NAME || 'Puck';

--- a/src/voice-config-switch.ts
+++ b/src/voice-config-switch.ts
@@ -1,7 +1,10 @@
 /**
  * Voice tool: switch voice-agent's model + googleSearch preset at runtime.
  *
- * Writes `src/voice-agent.config.json` and kicks `launchctl kickstart -k
+ * Writes the per-user voice-agent config at
+ * `$SUTANDO_WORKSPACE/config/voice-agent.json` (data, not code — NOT a
+ * committed repo file; the repo ships voice-agent.config.json.example as a
+ * template) and kicks `launchctl kickstart -k
  * gui/$(id -u)/com.sutando.voice-agent` so voice-agent restarts and picks
  * up the new config. The web client auto-reconnects on restart, so the
  * user-visible flow is: spoken command → ack → ~2-3s silence → voice
@@ -17,12 +20,12 @@
  */
 
 import { z } from 'zod';
-import { writeFileSync, renameSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { writeFileSync, renameSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
 import { spawn } from 'node:child_process';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { VOICE_CONFIG_DEFAULTS, type VoiceConfig } from './voice-config.js';
+import { resolveWorkspace } from './workspace_default.js';
 
 const PRESETS: Record<'search' | 'no-search', VoiceConfig> = {
 	search: { model: 'gemini-2.5-flash-native-audio-preview-12-2025', googleSearch: true },
@@ -52,16 +55,16 @@ export const switchVoiceConfigTool: ToolDefinition = {
 			return { error: `Unknown preset "${preset}". Use "search" or "no-search".` };
 		}
 
-		// Resolve config path next to voice-agent.ts. import.meta.url resolves
-		// to this file's URL — both compiled .js and source .ts share the same
-		// parent dir (src/), so the config path is identical regardless of
-		// runtime.
-		const thisDir = dirname(fileURLToPath(import.meta.url));
-		const configPath = join(thisDir, 'voice-agent.config.json');
+		// The voice-agent config is per-user data — it lives in the workspace
+		// ($SUTANDO_WORKSPACE/config/voice-agent.json), NOT in the git repo.
+		// voice-agent reads from the same path; mkdir the config/ dir in case
+		// this switch fires before voice-agent has seeded it.
+		const configPath = join(resolveWorkspace(), 'config', 'voice-agent.json');
 
 		// Atomic write (tmp+rename) so a partial config never lands.
 		const tmpPath = `${configPath}.tmp-${process.pid}`;
 		try {
+			mkdirSync(join(resolveWorkspace(), 'config'), { recursive: true });
 			// Merge with defaults so the on-disk file is complete + auditable.
 			const next: VoiceConfig = { ...VOICE_CONFIG_DEFAULTS, ...cfg };
 			writeFileSync(tmpPath, JSON.stringify(next, null, 2) + '\n');

--- a/src/voice-config.ts
+++ b/src/voice-config.ts
@@ -1,8 +1,19 @@
 /**
- * Per-skill voice configuration loader.
+ * Per-surface voice configuration loader.
  *
- * Each voice surface (voice-agent, phone-conversation, discord-voice) ships a
- * sibling `config.json` (or `*.config.json` for core-resident surfaces). Schema:
+ * `loadVoiceConfig(path)` is path-agnostic — each caller decides where its
+ * config lives and passes the absolute path in. The config is per-user DATA
+ * (model + grounding prefs the operator tunes), not code, so it does NOT live
+ * in the git repo — it lives in the workspace:
+ *
+ *   - voice-agent        → `$SUTANDO_WORKSPACE/config/voice-agent.json`
+ *   - phone-conversation → `$SUTANDO_WORKSPACE/config/phone-conversation.json`
+ *   - discord-voice      → `$SUTANDO_WORKSPACE/config/discord-voice.json`
+ *
+ * Each surface ships a committed `*.example` template (`src/voice-agent.config
+ * .json.example`, `skills/<surface>/config.json.example`); on first run the
+ * surface copies the template into the workspace if the live config is
+ * missing. Schema:
  *
  *   { "model": "gemini-2.5-flash-native-audio-preview-12-2025", "googleSearch": true }
  *
@@ -14,9 +25,9 @@
  * works on either key but loses Web grounding by default — that's degrading
  * capability rather than picking a safe baseline). Surfaces that explicitly
  * want a different combo (e.g. voice-agent prefers 3.1 + search:false for the
- * web client's code-heavy workload) ship their own `config.json` with the
- * override. Phone and discord-voice inherit the default and don't need a file
- * unless they later want to diverge.
+ * web client's code-heavy workload) ship a `.example` template carrying that
+ * override. Phone inherits the default; discord-voice's template carries it
+ * too, so a fresh install behaves identically.
  */
 
 import { readFileSync, existsSync } from 'fs';


### PR DESCRIPTION
## What changed

Applies the data-vs-code config split to the two remaining voice surfaces — **voice-agent** and **phone-conversation** — mirroring **PR #1017** (which did this for discord-voice).

Both surfaces shipped git-tracked `config.json` files. Those configs carry per-user data (the model + Web-grounding prefs the operator tunes), and the repo is meant to be shareable, so the live config must not live in a committed file.

For **each** surface:

- The committed config was `git mv`'d to a committed **`.example` template** with the current values preserved, plus an explanatory `_comment`.
- The surface now resolves its **live config from the workspace** — `$SUTANDO_WORKSPACE/config/<surface>.json` — via the canonical `resolveWorkspace()` helper (`src/workspace_default.ts`). `config/` is `mkdir -p`'d if missing.
- **First run**: if the workspace config is absent, the committed `.example` template is copied into place (with a log line); if the copy fails, `loadVoiceConfig` falls back to its built-in defaults. This mirrors #1017's `discord-voice-server.ts` seed logic exactly.
- **`.gitignore`** ignores the old committed paths so a casual `git add .` can't resurrect a live config into the repo.

### voice-agent
- `src/voice-agent.config.json` → **deleted**; `src/voice-agent.config.json.example` → new committed template.
- Live config: `$SUTANDO_WORKSPACE/config/voice-agent.json`.
- `src/voice-config-switch.ts` (the `switch_voice_config` inline tool that writes voice-agent's config at runtime) now writes the workspace path too — so runtime preset switches still land where voice-agent reads.

### phone-conversation
- `skills/phone-conversation/config.json` → **deleted**; `skills/phone-conversation/config.json.example` → new committed template.
- Live config: `$SUTANDO_WORKSPACE/config/phone-conversation.json`.

### shared
- `src/voice-config.ts` — `loadVoiceConfig(path)` was already path-agnostic, so **no behavior change**; only the doc comment is updated to describe where each surface's config now lives. The `VoiceConfig` schema is **unchanged** — no `owner_mode`/`channels` (that is #1017's discord-voice-specific addition).
- **discord-voice is not touched** — that surface's split was done in #1017.

## Why

The repo is shareable; per-user config (model/grounding prefs) is data, not code, and belongs in `$SUTANDO_WORKSPACE/config/`, not a committed repo file. This completes the data-vs-code split started for discord-voice in #1017.

## Behavior preserved

voice-agent and phone are live core services. On first run the surface copies the `.example` template verbatim, so the live config has **identical values** (voice-agent `3.1` + `googleSearch:false`; phone `2.5` + `googleSearch:true`). Services pick up the new path on their next restart.

## Verification

- `npm run typecheck` (`tsc --noEmit`) — passes.
- Smoke test against a temp workspace: seed-from-`.example` and the no-file fallback both yield the correct per-surface defaults.
- `grep` for the deleted committed paths across `src/` + `skills/` — no remaining references (the only `config.json` hit is discord-voice, which is correct and out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)