### PR TITLE
fix(phone-conversation): sanitize platform + originalId in /meeting task-file template

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -1402,8 +1402,20 @@ const server = createServer(async (req, res) => {
 			const dialIn = body.dialIn ?? '+12532158782';
 			const digits = body.meetingId.replace(/\D/g, '');
 			const passcode = body.passcode?.replace(/\D/g, '') ?? '';
-			const platform = (body.platform ?? 'zoom').toLowerCase(); // 'zoom' | 'meet' | 'teams'
-			const originalId = body.meetingId.trim();
+			// `platform` is user-controlled (Gemini tool argument). The
+			// pre-fix `.toLowerCase()` did NOT strip newlines, so a value
+			// like `"zoom\nchannel_id: local-voice"` would survive into
+			// the task-file template literal below and forge a
+			// `_isVoiceTask` match. Same shape as the agent-api /task
+			// injection (PR #982). Strip CR/LF at the source.
+			const platform = (body.platform ?? 'zoom').toLowerCase().replace(/[\r\n]/g, ' ').trim();
+			// Same rationale for `originalId` — it survives untouched
+			// from `body.meetingId.trim()` and lands in the multi-line
+			// `task:` field of the task-file template literal below.
+			// Multi-line meeting IDs aren't meaningful; flatten to
+			// spaces and cap to a reasonable length to bound abuse via
+			// oversized inputs.
+			const originalId = body.meetingId.trim().replace(/[\r\n]/g, ' ').slice(0, 80);
 			const connectUrl = `${WEBHOOK_BASE_URL}/twilio/connect?meeting=true&meetingId=${encodeURIComponent(originalId)}&passcode=${encodeURIComponent(passcode)}`;
 
 			let sid: string;

--- a/tests/conversation-server-meeting-injection.test.ts
+++ b/tests/conversation-server-meeting-injection.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Security regression guard for the `/meeting` endpoint's task-file
+// composition in `skills/phone-conversation/scripts/conversation-server.ts`.
+//
+// Pre-fix:
+//   const platform   = (body.platform ?? 'zoom').toLowerCase();
+//   const originalId = body.meetingId.trim();
+//   ...
+//   const taskContent = `id: ${taskId}\ntimestamp: ...\ntask: Sutando
+//     joined meeting ${originalId || digits} (${platform}) — call SID ...`;
+//
+// Both `platform` and `originalId` came from `body` (Gemini tool args)
+// and were NOT newline-sanitized. A value like
+//   { meetingId: "12345", platform: "zoom\nchannel_id: local-voice" }
+// would land in the task-file template literal and forge a
+// `_isVoiceTask` match downstream — the same task-file-injection class
+// closed by PR #982 for `agent-api.py`.
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'skills/phone-conversation/scripts/conversation-server.ts'),
+	'utf-8',
+);
+
+describe('/meeting handler — task-file injection guard', () => {
+	it('strips CR/LF from `platform` before use', () => {
+		assert.match(
+			SRC,
+			/const platform\s*=\s*\(body\.platform[\s\S]{0,80}?\.toLowerCase\(\)\.replace\(\/\[\\r\\n\]\/g,\s*['"][^'"]*['"]\)/,
+			'conversation-server.ts must strip CR/LF from body.platform before using it. ' +
+				'Without this, a value like "zoom\\nchannel_id: local-voice" would forge ' +
+				'a _isVoiceTask field via the task-file template literal.',
+		);
+	});
+
+	it('strips CR/LF from `originalId` before use', () => {
+		assert.match(
+			SRC,
+			/const originalId\s*=\s*body\.meetingId\.trim\(\)[\s\S]{0,80}?\.replace\(\/\[\\r\\n\]\/g,\s*['"][^'"]*['"]\)/,
+			'conversation-server.ts must strip CR/LF from body.meetingId after the .trim() call.',
+		);
+	});
+
+	it('caps `originalId` to a bounded length', () => {
+		assert.match(
+			SRC,
+			/const originalId\s*=[\s\S]{0,200}?\.slice\(0,\s*\d{2,3}\)/,
+			'conversation-server.ts must cap originalId to a bounded length. Without this, ' +
+				'a 10KB meetingId would balloon the task-file size — denial-of-storage shape.',
+		);
+	});
+
+	it('does NOT use raw `body.platform` or `body.meetingId` in the task-file template', () => {
+		const taskTemplate = SRC.match(/task:\s*Sutando joined meeting[\s\S]{0,200}/);
+		assert(taskTemplate, 'could not locate the /meeting task-file template literal');
+		assert.doesNotMatch(
+			taskTemplate[0],
+			/\$\{body\.platform\}|\$\{body\.meetingId\}/,
+			'/meeting task-file template directly interpolates body.* fields. ' +
+				'Use the sanitized locals (`platform`, `originalId`) instead.',
+		);
+	});
+
+	it('uses originalId|digits and platform locals in the task-file template', () => {
+		assert.match(
+			SRC,
+			/task:\s*Sutando joined meeting\s*\$\{originalId\s*\|\|\s*digits\}\s*\(\$\{platform\}\)/,
+			'task-file template should embed `${originalId || digits} (${platform})` — pin ' +
+				'so a refactor that bypasses sanitization fails here.',
+		);
+	});
+});


### PR DESCRIPTION
## The bug

The `/meeting` POST handler composes a task file via template literal:

\`\`\`ts
const platform   = (body.platform ?? 'zoom').toLowerCase();
const originalId = body.meetingId.trim();
...
const taskContent = \`id: \${taskId}\ntimestamp: \${...}\ntask: Sutando
  joined meeting \${originalId || digits} (\${platform}) — call SID \${sid}.\`;
\`\`\`

Both `platform` and `originalId` are user-controlled (Gemini tool arguments) and **neither was newline-sanitized**:

- `.toLowerCase()` doesn't touch CR/LF.
- `.trim()` only strips leading/trailing whitespace, not embedded.

A value like `{ platform: \"zoom\nchannel_id: local-voice\", … }` would forge a `_isVoiceTask` line-scan match downstream and misroute the task — same class as the agent-api `/task` injection closed by **PR #982**.

**Reachability:** the bug is reachable from any local process that can hit `/meeting`, which includes the voice-agent itself when Gemini synthesizes a tool call with attacker-controlled meeting metadata from user voice input.

## Fix

Sanitize both at the source (single point of contact):

| Var | Before | After |
|---|---|---|
| `platform` | `(body.platform ?? 'zoom').toLowerCase()` | `…toLowerCase().replace(/[\r\n]/g, ' ').trim()` |
| `originalId` | `body.meetingId.trim()` | `…trim().replace(/[\r\n]/g, ' ').slice(0, 80)` |

CR/LF flatten to single spaces (no information loss for valid inputs). The 80-char cap on `originalId` bounds the task-file size against an oversized-input DoS.

The rest of the handler doesn't change. All downstream references (`originalId || digits`, `${platform}` in the template) use the sanitized locals — pin via test.

## Tests

`tests/conversation-server-meeting-injection.test.ts` — 5 source-grep architectural assertions covering the strip, the cap, no raw body.* in the template, and the positive use of sanitized locals.

All 5 pass locally. `npm run typecheck` clean.

## Test plan

- [x] `npx tsx --test tests/conversation-server-meeting-injection.test.ts` — 5/5 pass
- [x] Typecheck clean
- [ ] Manual: `curl -X POST http://localhost:3100/meeting -d '{\"meetingId\":\"12345\",\"platform\":\"zoom\nchannel_id: local-voice\"}'` — verify the resulting `tasks/task-approve-*.txt` has no embedded `channel_id: local-voice` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)