### PR TITLE
fix(zoom): close command-injection via passcode in `open <url>` calls

### DIFF
--- a/skills/zoom/tools.ts
+++ b/skills/zoom/tools.ts
@@ -66,9 +66,18 @@ export const summonTool: ToolDefinition = {
 				// 2026-04-29 after a phone-summon test where the meeting never
 				// actually opened on Studio.
 				console.log(`${ts()} [Summon] Joining via zoommtg:// deeplink`);
+				// URL-encode the passcode — arbitrary string from the caller
+				// (Gemini tool arg or $ZOOM_PERSONAL_PASSCODE). Pre-fix it was
+				// spliced raw into BOTH the URL AND a shell command, so a
+				// passcode like `"; rm -rf ~/.config; #` would break out of
+				// the quoted shell argument and execute. cleanId is digit-only
+				// (`.replace(/\D/g, '')`) so safe; pwd needs the encode pass.
 				let zoomUrl = `zoommtg://zoom.us/join?confno=${cleanId}`;
-				if (pwd) zoomUrl += `&pwd=${pwd}`;
-				execSync(`open "${zoomUrl}"`, { timeout: 10_000 });
+				if (pwd) zoomUrl += `&pwd=${encodeURIComponent(pwd)}`;
+				// execFileSync — `open` receives the URL as a single argv
+				// entry, never spliced into a shell string. Closes the shell-
+				// injection class entirely.
+				execFileSync('open', [zoomUrl], { timeout: 10_000 });
 
 				// Wait briefly for Zoom to register the deeplink, then enter the
 				// combined Join-and-wait-for-meeting loop below. Per Mini's PR #546
@@ -375,12 +384,15 @@ export const joinZoomTool: ToolDefinition = {
 
 			if (!alreadyIn) {
 				const zoomRunning = (() => { try { execSync('pgrep -f "zoom.us"', { timeout: 2_000 }); return true; } catch { return false; } })();
+				// Same shell-injection fix as the summonTool join path above —
+				// pwd is arbitrary caller input. URL-encode + execFileSync.
 				if (zoomRunning) {
-					execSync(`open "https://zoom.us/j/${cleanId}${pwd ? '?pwd=' + pwd : ''}"`, { timeout: 10_000 });
+					const webUrl = `https://zoom.us/j/${cleanId}${pwd ? `?pwd=${encodeURIComponent(pwd)}` : ''}`;
+					execFileSync('open', [webUrl], { timeout: 10_000 });
 				} else {
 					let zoomUrl = `zoommtg://zoom.us/join?confno=${cleanId}`;
-					if (pwd) zoomUrl += `&pwd=${pwd}`;
-					execSync(`open "${zoomUrl}"`, { timeout: 10_000 });
+					if (pwd) zoomUrl += `&pwd=${encodeURIComponent(pwd)}`;
+					execFileSync('open', [zoomUrl], { timeout: 10_000 });
 				}
 
 				// Click Join button if preview window appears

--- a/tests/zoom-skill-command-injection.test.ts
+++ b/tests/zoom-skill-command-injection.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Security regression guard for `skills/zoom/tools.ts`.
+//
+// Pre-fix: three call sites used the shape
+//   execSync(`open "${zoomUrl}"`)
+// where `zoomUrl` interpolated the user-controlled `pwd` field directly:
+//   zoomUrl = `zoommtg://zoom.us/join?confno=${cleanId}&pwd=${pwd}`;
+//
+// `pwd` comes from `passcode ?? getZoomPasscode()` — Gemini tool argument
+// or `$ZOOM_PERSONAL_PASSCODE`. A passcode like `"; rm -rf ~/.config; #`
+// would break out of the quoted shell argument in execSync (which uses
+// `/bin/sh -c`) and execute arbitrary commands.
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'skills/zoom/tools.ts'),
+	'utf-8',
+);
+
+describe('zoom tools — command-injection guard', () => {
+	it('does not use execSync with template-literal `open "${zoomUrl}"`', () => {
+		assert.doesNotMatch(
+			SRC,
+			/execSync\(`open\s*"\$\{[a-zA-Z]*[uU]rl\}/,
+			'skills/zoom/tools.ts contains the raw `execSync(\`open "${...Url}"\`)` pattern again — ' +
+				'this splices user-controlled `pwd` into a shell command. Use execFileSync(\'open\', [url]) instead.',
+		);
+	});
+
+	it('uses execFileSync(\'open\', [...]) for the Zoom URL open call', () => {
+		assert.match(
+			SRC,
+			/execFileSync\(\s*['"]open['"]\s*,\s*\[/,
+			'skills/zoom/tools.ts must use `execFileSync(\'open\', [url])` to invoke `open` — the array form ' +
+				'bypasses `/bin/sh -c` so no value spliced into argv is interpreted as shell syntax.',
+		);
+	});
+
+	it('URL-encodes `pwd` before embedding in the deeplink URL', () => {
+		assert.match(
+			SRC,
+			/encodeURIComponent\(pwd\)/,
+			'skills/zoom/tools.ts must URL-encode `pwd` before embedding in the deeplink URL ' +
+				'(defense-in-depth: prevents `&` / `#` / non-ASCII in passcodes from confusing the URL).',
+		);
+	});
+
+	it('all three open-URL sites use the safe pattern (no leftover execSync template-literals)', () => {
+		const matches = SRC.match(/execSync\(`open\s*"\$\{/g);
+		assert.equal(
+			matches,
+			null,
+			`Found ${matches?.length} occurrence(s) of the unsafe shell-template-literal pattern. ` +
+				'Every site that opens a user-controlled URL must use execFileSync.',
+		);
+	});
+});


### PR DESCRIPTION
## The bug (security)

`skills/zoom/tools.ts` has three call sites of the shape:

\`\`\`ts
execSync(\`open \"\${zoomUrl}\"\`, { timeout: 10_000 });
\`\`\`

where `zoomUrl` interpolates the user-controlled `pwd` field directly:

\`\`\`ts
let zoomUrl = \`zoommtg://zoom.us/join?confno=\${cleanId}\`;
if (pwd) zoomUrl += \`&pwd=\${pwd}\`;
\`\`\`

`pwd` is `passcode ?? getZoomPasscode()` — either a Gemini tool argument or `$ZOOM_PERSONAL_PASSCODE` env. `cleanId` is safe (digit-only via `.replace(/\\D/g, '')`); `pwd` is arbitrary text.

execSync uses `/bin/sh -c`, so a passcode like `\"; rm -rf ~/.config; #` breaks out of the quoted shell argument. Concrete expansion:

\`\`\`bash
open \"zoommtg://zoom.us/join?confno=12345&pwd=\";rm -rf ~/.config;#\"
\`\`\`

The first arg to `open` is `\"zoommtg://..&pwd=\"`, then `;rm -rf ~/.config` runs as a shell command, then `#\"` is a comment.

**Three sites affected:**

| Line | Path |
|---|---|
| 71 | `summonTool` zoommtg:// join |
| 388 | `join_zoom` Zoom-running web fallback |
| 392 | `join_zoom` Zoom-not-running zoommtg:// fallback |

## Fix

**Two layers:**

1. **URL-encode `pwd` before embedding.** Defense-in-depth: even with execFileSync, an unencoded `&`/`#`/non-ASCII passcode would confuse `open`'s URL parsing or Zoom's deeplink handler.

2. **Switch all three sites from**
   \`\`\`ts
   execSync(\`open \"\${url}\"\`)
   \`\`\`
   **to**
   \`\`\`ts
   execFileSync('open', [url])
   \`\`\`
   `execFileSync` bypasses `/bin/sh -c` entirely — `open` receives the URL as a single argv entry. Closes the shell-injection class regardless of what's in the URL.

`execFileSync` was already imported at the top of the file — zero-cost API swap.

## Tests

`tests/zoom-skill-command-injection.test.ts` — 4 source-grep architectural assertions.

All 4 pass locally. `npm run typecheck` clean.

## Test plan

- [x] `npx tsx --test tests/zoom-skill-command-injection.test.ts` — 4/4 pass
- [x] Typecheck clean
- [ ] Manual: set `ZOOM_PERSONAL_PASSCODE='\"; touch /tmp/pwn; #'` then call summon — verify no `/tmp/pwn` file appears post-call (or rerun pre-fix and confirm it DOES appear, then verify post-fix it does not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)