### PR TITLE
fix(security): close Discord-attachment RCE via filename → fast-path shell injection

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -76,7 +76,7 @@ function personalPath(filename: string): string {
 	}
 	return filename;
 }
-import { execSync, spawn, type ChildProcess } from 'node:child_process';
+import { execSync, execFileSync, spawn, type ChildProcess } from 'node:child_process';
 import { isAllowedAudioPath } from './audio_path_guard.js';
 import { VoiceSession, type ToolDefinition, type MainAgent } from 'bodhi-realtime-agent';
 import { WebSocketServer, WebSocket } from 'ws';
@@ -307,7 +307,15 @@ function tryFastPath(callSession: CallSession, task: string): Promise<unknown> |
 			const image = execSync('ls -t /tmp/discord-inbox/*.jpg /tmp/discord-inbox/*.png 2>/dev/null | head -1', { timeout: 3000 }).toString().trim();
 			const video = execSync('ls -t /tmp/sutando-recording-*-narrated-subtitled.mov /tmp/sutando-recording-*-narrated.mov /tmp/sutando-recording-*.mov 2>/dev/null | head -1', { timeout: 3000 }).toString().trim();
 			if (image && video) {
-				const result = execSync(`bash ~/.claude/skills/video-concat/scripts/prepend-image.sh "${image}" "${video}" 3`, { timeout: 60000 }).toString().trim();
+				// Defense-in-depth: even after discord-bridge sanitizes
+				// inbound attachment filenames, use execFileSync so the
+				// path strings are argv entries, not shell-spliced.
+				// Pre-fix: a filename like `x"; touch /tmp/pwn; #.jpg`
+				// from a Discord attachment would break out of the
+				// double-quoted shell argument and execute the injected
+				// command.
+				const scriptPath = `${process.env.HOME}/.claude/skills/video-concat/scripts/prepend-image.sh`;
+				const result = execFileSync('bash', [scriptPath, image, video, '3'], { timeout: 60000 }).toString().trim();
 				const parsed = JSON.parse(result);
 				callSession.pendingTasks++;
 				setTimeout(() => {

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -400,6 +400,37 @@ TASKS_DIR.mkdir(parents=True, exist_ok=True)
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 INBOX_DIR.mkdir(exist_ok=True)
 
+
+def _safe_attachment_basename(filename: str) -> str:
+    """Sanitize a Discord attachment filename for safe filesystem +
+    downstream-shell use.
+
+    Discord allows arbitrary filenames (incl. spaces, quotes, semicolons,
+    backticks, `$`, `..`) and the bridge previously saved them verbatim
+    via ``INBOX_DIR / f"{ts}_{att.filename}"``. Several downstream sites
+    glob `/tmp/discord-inbox/*` and embed the resulting path in a shell
+    command (e.g. ``skills/phone-conversation/scripts/conversation-server.ts``
+    fast path: ``execSync(\\`bash .../prepend-image.sh "${image}" ...\\`)``).
+    A filename like ``x"; touch /tmp/pwn; #.jpg`` would close the quoted
+    shell argument and execute attacker-supplied commands.
+
+    Mirrors the ``_safe_id`` shape from ``src/agent-api.py``: keep
+    alphanumerics + ``._-``; replace everything else with ``_``. Also
+    strips path-traversal (``..``) and caps length to bound DoS via
+    multi-kilobyte filenames. Preserves the extension when present so
+    glob patterns like ``*.jpg`` keep matching legitimate uploads.
+    """
+    name = filename or "file"
+    dot = name.rfind(".")
+    if dot > 0 and dot >= len(name) - 9:
+        base, ext = name[:dot], name[dot + 1:]
+    else:
+        base, ext = name, ""
+    safe_base = re.sub(r"[^a-zA-Z0-9_\-.]", "_", base).strip("._") or "file"
+    safe_ext = re.sub(r"[^a-zA-Z0-9]", "", ext)[:8]
+    safe_base = safe_base[:80]
+    return f"{safe_base}.{safe_ext}" if safe_ext else safe_base
+
 # Presenter mode: when scripts/presenter-mode.sh is active, the bridge
 # must not send proactive DMs to the owner. The sentinel contains an
 # ISO-8601 expiry; see scripts/presenter-mode.sh for the contract.
@@ -2301,7 +2332,10 @@ async def _handle_discord_message(message, force=False):
                 if embed.description: parts.append(embed.description)
             # Download snapshot attachments (forwarded images/files)
             for att in getattr(snap_msg, 'attachments', []):
-                local_path = INBOX_DIR / f"{int(time.time()*1000)}_{att.filename}"
+                # Sanitize filename — Discord lets users upload arbitrary
+                # names; raw interpolation into a downstream shell command
+                # is the RCE class closed by this PR.
+                local_path = INBOX_DIR / f"{int(time.time()*1000)}_{_safe_attachment_basename(att.filename)}"
                 try:
                     await att.save(local_path)
                     parts.append(f"[File attached: {local_path}]")
@@ -2354,7 +2388,10 @@ async def _handle_discord_message(message, force=False):
     # Handle attachments
     attachment_note = ""
     for att in message.attachments:
-        local_path = INBOX_DIR / f"{int(time.time()*1000)}_{att.filename}"
+        # Sanitize filename — see _safe_attachment_basename docstring for
+        # the RCE class this closes (downstream shell interpolation of
+        # the saved path in conversation-server.ts fast path).
+        local_path = INBOX_DIR / f"{int(time.time()*1000)}_{_safe_attachment_basename(att.filename)}"
         try:
             await att.save(local_path)
             attachment_note += f"\n[File attached: {local_path}]"

--- a/tests/conversation-server-fastpath-execfile.test.ts
+++ b/tests/conversation-server-fastpath-execfile.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Defense-in-depth layer for the Discord-attachment-RCE fix.
+// `src/discord-bridge.py` now sanitizes attachment filenames before
+// saving them to `/tmp/discord-inbox/`. This file pins the parallel
+// fix on the use site: the phone-conversation fast path that consumed
+// `/tmp/discord-inbox/*.jpg` paths must use execFileSync, not
+// shell-spliced execSync.
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'skills/phone-conversation/scripts/conversation-server.ts'),
+	'utf-8',
+);
+
+describe('conversation-server fast path — execFile for video-concat', () => {
+	it('imports execFileSync', () => {
+		assert.match(
+			SRC,
+			/import\s*\{[^}]*execFileSync[^}]*\}\s*from\s*['"]node:child_process['"]/,
+			'conversation-server.ts must import execFileSync from node:child_process.',
+		);
+	});
+
+	it('uses execFileSync(\'bash\', [scriptPath, image, video, \'3\']) for prepend-image', () => {
+		assert.match(
+			SRC,
+			/execFileSync\(\s*['"]bash['"]\s*,\s*\[\s*scriptPath\s*,\s*image\s*,\s*video\s*,/,
+			'fast path must use execFileSync(\'bash\', [scriptPath, image, video, \'3\']) — argv form ' +
+				'so neither image nor video gets spliced into a shell command.',
+		);
+	});
+
+	it('does NOT use execSync with template-literal `bash ... "${image}"`', () => {
+		assert.doesNotMatch(
+			SRC,
+			/execSync\(`bash[^`]*\$\{image\}/,
+			'conversation-server.ts contains the raw `execSync(\`bash ... "${image}"\`)` pattern again — ' +
+				'this is the exact RCE vector closed by this PR. Use execFileSync.',
+		);
+	});
+});

--- a/tests/discord-bridge-attachment-filename-sanitize.test.py
+++ b/tests/discord-bridge-attachment-filename-sanitize.test.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Security regression guard for Discord attachment filename sanitization.
+
+`src/discord-bridge.py` saves Discord attachments to /tmp/discord-inbox/
+with the filename interpolated raw:
+
+    local_path = INBOX_DIR / f"{int(time.time()*1000)}_{att.filename}"
+
+Discord lets users upload arbitrary filenames including spaces, quotes,
+semicolons, backticks, and `$`. Several downstream sites then glob
+`/tmp/discord-inbox/*` and embed the resulting path in a shell command,
+e.g. `skills/phone-conversation/scripts/conversation-server.ts`
+(pre-fix):
+
+    execSync(`bash .../prepend-image.sh "${image}" "${video}" 3`)
+
+A filename like `x"; touch /tmp/pwn; #.jpg` would close the quoted shell
+argument and execute attacker-supplied commands when the owner triggers
+the concat fast path during a phone call. RCE via Discord attachment
+filename.
+
+The fix is two layers:
+  1. `_safe_attachment_basename()` sanitizes filenames at the save site
+     (defense at the boundary — pinned by this test).
+  2. conversation-server.ts switches the fast path from execSync to
+     execFileSync (defense at the use — pinned by a separate .ts test).
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+_WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-discord-filename-test-")
+os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
+
+
+def _load(name: str, path: Path):
+    if "discord" not in sys.modules:
+        import types
+        stub = types.ModuleType("discord")
+        stub.Intents = type("Intents", (), {"default": staticmethod(lambda: type("I", (), {"message_content": False})())})
+        stub.Client = type("Client", (), {"__init__": lambda self, **kw: None, "event": staticmethod(lambda fn: fn)})
+        stub.File = type("File", (), {})
+        sys.modules["discord"] = stub
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+bridge = _load("discord_bridge", REPO / "src" / "discord-bridge.py")
+sanitize = bridge._safe_attachment_basename
+
+
+def test_normal_filename_preserved():
+    assert sanitize("photo.jpg") == "photo.jpg"
+    assert sanitize("Screenshot 2026-05-22.png") == "Screenshot_2026-05-22.png"
+    assert sanitize("report-final-v2.pdf") == "report-final-v2.pdf"
+
+
+def test_shell_injection_strip():
+    """The core bug fix — characters that break out of quoted shell
+    arguments must be stripped."""
+    result = sanitize('x"; touch /tmp/pwn; #.jpg')
+    assert '"' not in result, f"double quote survived: {result!r}"
+    assert ';' not in result, f"semicolon survived: {result!r}"
+    assert '#' not in result, f"hash survived: {result!r}"
+    assert result.endswith(".jpg"), f"extension lost: {result!r}"
+
+
+def test_backtick_and_dollar_strip():
+    result = sanitize("evil`whoami`.png")
+    assert '`' not in result
+    result = sanitize("evil$IFS.png")
+    assert '$' not in result
+
+
+def test_path_traversal_strip():
+    result = sanitize("../../../etc/passwd")
+    assert '/' not in result, f"slash survived: {result!r}"
+    assert '..' not in result, f"dotdot survived: {result!r}"
+
+
+def test_empty_filename_falls_back():
+    assert sanitize("") != ""
+    assert sanitize(";;;;") != ""
+    assert sanitize("...") != ""
+
+
+def test_extension_preserved_when_short():
+    for ext in ("jpg", "png", "pdf", "mp4", "mov", "txt", "md"):
+        result = sanitize(f"file.{ext}")
+        assert result.endswith(f".{ext}"), f"extension .{ext} not preserved: {result!r}"
+
+
+def test_unicode_replaced():
+    result = sanitize("файл.jpg")
+    assert all(ord(c) < 128 for c in result), f"non-ASCII survived: {result!r}"
+    assert result.endswith(".jpg")
+
+
+def test_overlong_filename_capped():
+    result = sanitize("a" * 10000 + ".jpg")
+    assert len(result) <= 100, f"length not capped: len={len(result)}"
+
+
+def main():
+    failures = []
+    for fn in (
+        test_normal_filename_preserved,
+        test_shell_injection_strip,
+        test_backtick_and_dollar_strip,
+        test_path_traversal_strip,
+        test_empty_filename_falls_back,
+        test_extension_preserved_when_short,
+        test_unicode_replaced,
+        test_overlong_filename_capped,
+    ):
+        try:
+            fn()
+            print(f"  ✓ {fn.__name__}")
+        except AssertionError as e:
+            failures.append(f"{fn.__name__}: {e}")
+            print(f"  ✗ {fn.__name__}")
+    if failures:
+        print("\nFailures:")
+        for f in failures:
+            print(f"  {f}")
+        sys.exit(1)
+    print(f"All {8} attachment-filename-sanitize tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The bug (security — RCE)

Two-stage chain that lets a Discord user achieve **arbitrary code execution** on the owner's machine.

### Stage 1: discord-bridge saves attachment filenames verbatim

`src/discord-bridge.py` (two sites, lines 2304 + 2357):

\`\`\`python
local_path = INBOX_DIR / f\"{int(time.time()*1000)}_{att.filename}\"
\`\`\`

Discord allows arbitrary filenames: spaces, quotes, semicolons, backticks, `$`, `..`. An attacker uploads `x\"; touch /tmp/pwn; #.jpg`. The bridge saves it as `/tmp/discord-inbox/1779392000000_x\"; touch /tmp/pwn; #.jpg`.

### Stage 2: conversation-server fast path shell-splices the path

`skills/phone-conversation/scripts/conversation-server.ts:310`:

\`\`\`ts
const image = execSync('ls -t /tmp/discord-inbox/*.jpg ...').toString().trim();
const result = execSync(\`bash .../prepend-image.sh \"\${image}\" \"\${video}\" 3\`, ...);
\`\`\`

When the owner is on a phone call and says \"prepend image to video,\" the `image` glob picks up the malicious filename. execSync (`/bin/sh -c`) expansion:

\`\`\`bash
bash .../prepend-image.sh \"/tmp/discord-inbox/.._x\"; touch /tmp/pwn; #.jpg\" \"...\" 3
\`\`\`

The first arg to `bash` is `\"/tmp/discord-inbox/..._x\"`; the closing `\"` ends the argument. Then `; touch /tmp/pwn` runs as a shell command, then `; #.jpg\" ...` is a comment.

**Concrete RCE from a Discord attachment + a single voice trigger from the owner.**

## Fix — two layers

### Layer A: sanitize at the boundary

`src/discord-bridge.py`: new `_safe_attachment_basename()` helper. Mirrors `_safe_id` from `src/agent-api.py`. Applied at both attachment save sites.

### Layer B: defense-in-depth at the use

`skills/phone-conversation/scripts/conversation-server.ts`: switch the fast path from
\`\`\`ts
execSync(\`bash .../prepend-image.sh \"\${image}\" \"\${video}\" 3\`)
\`\`\`
to
\`\`\`ts
const scriptPath = \`\${process.env.HOME}/.claude/skills/video-concat/scripts/prepend-image.sh\`;
execFileSync('bash', [scriptPath, image, video, '3'], ...);
\`\`\`

`execFileSync` bypasses `/bin/sh -c`. Closes the injection class regardless of filename content.

## Tests

8 cases on the sanitizer, 3 cases on the execFileSync wiring. All 11 pass locally; `npm run typecheck` clean; Python syntax clean.

## Test plan

- [x] `python3 tests/discord-bridge-attachment-filename-sanitize.test.py` — 8/8 pass
- [x] `npx tsx --test tests/conversation-server-fastpath-execfile.test.ts` — 3/3 pass
- [x] Typecheck clean
- [ ] Manual: upload Discord attachment named `pwn\"; touch /tmp/pwn-RCE; #.jpg`; verify saved path has shell-meta chars stripped and `/tmp/pwn-RCE` does NOT appear after triggering the fast path

🤖 Generated with [Claude Code](https://claude.com/claude-code)