### PR TITLE
feat(discord-voice): tee operational log to logs/discord-voice.log

### DIFF
--- a/skills/discord-voice/SKILL.md
+++ b/skills/discord-voice/SKILL.md
@@ -147,3 +147,5 @@ If you don't want screen-sharing, the rest of the skill (voice conversation, too
 `SIGTERM`/`SIGINT` triggers `cleanupSession()` which calls `connection.destroy()` (sends Discord voice-gateway disconnect frame) and `voiceSession.close()`. The handler then waits 1.5s before `process.exit(0)` so the disconnect frame actually flushes — without that delay, Discord pins the bot in-channel until its own 60-90s heartbeat timeout.
 
 Transcripts + session metrics land in `conversation.sqlite` — the shared `conversation` and `sessions` tables (also used by voice + phone) — and are mirrored into the shared `logs/conversation.log` text log.
+
+Operational/diagnostic output (the `[Setup]`/`[Voice]`/`[Tool]`/`[VoiceSession]`/`[Dismiss]` lines) is tee'd to `$SUTANDO_WORKSPACE/logs/discord-voice.log` — the discord-voice counterpart to `logs/discord-bridge.log` and `logs/voice-agent.log` — so the operational history survives a process exit.

--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -76,6 +76,11 @@ import {
 const GEMINI_API_KEY = voiceApiKey();
 const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN ?? '';
 const WORKSPACE_DIR = resolveWorkspace();
+// Operational/diagnostic log — the [Setup]/[Voice]/[Tool]/[VoiceSession]/
+// [Dismiss] lines that otherwise only hit stdout. Mirrors discord-bridge.log
+// and voice-agent.log so discord-voice's operational history survives a
+// process exit. Tee'd from console.log/console.error below (fail-soft).
+const DISCORD_VOICE_LOG = join(WORKSPACE_DIR, 'logs', 'discord-voice.log');
 const DATA_DIR = join(WORKSPACE_DIR, 'data');
 const RESULTS_DIR = process.env.DISCORD_VOICE_RESULTS_DIR || join(WORKSPACE_DIR, 'results');
 const TASKS_DIR = join(WORKSPACE_DIR, 'tasks');
@@ -205,6 +210,34 @@ function appendConversationLog(role: string, text: string): void {
 		mkdirSync(dirname(CONVERSATION_LOG), { recursive: true });
 		appendFileSync(CONVERSATION_LOG, `${new Date().toISOString()}|${role}|${text.replace(/\n/g, ' ')}\n`);
 	} catch {}
+}
+
+// --- Operational log tee ----------------------------------------------------
+// console.log/console.error still write to stdout exactly as before; each call
+// is ALSO appended (ISO-timestamped) to logs/discord-voice.log. Mirrors the
+// appendConversationLog pattern above — mkdirSync guard + fail-soft try/catch
+// so a disk/permission error degrades silently to stdout-only and can NEVER
+// crash the voice session.
+function appendOperationalLog(level: string, args: unknown[]): void {
+	try {
+		const line = args
+			.map((a) => (typeof a === 'string' ? a : a instanceof Error ? (a.stack ?? a.message) : String(a)))
+			.join(' ');
+		mkdirSync(dirname(DISCORD_VOICE_LOG), { recursive: true });
+		appendFileSync(DISCORD_VOICE_LOG, `${new Date().toISOString()} ${level} ${line}\n`);
+	} catch {}
+}
+{
+	const _origLog = console.log.bind(console);
+	const _origError = console.error.bind(console);
+	console.log = (...args: unknown[]): void => {
+		_origLog(...args);
+		appendOperationalLog('LOG', args);
+	};
+	console.error = (...args: unknown[]): void => {
+		_origError(...args);
+		appendOperationalLog('ERR', args);
+	};
 }
 
 // --- Audio conversion helpers ----------------------------------------------


### PR DESCRIPTION
## Problem

`skills/discord-voice/scripts/discord-voice-server.ts` wrote all its operational/diagnostic output — the `[Setup]` / `[Voice]` / `[Tool]` / `[VoiceSession]` / `[Dismiss]` lines — via `console.log` / `console.error` to **stdout only**. Unlike discord-bridge (`logs/discord-bridge.log`) and voice-agent (`logs/voice-agent.log`), discord-voice had no equivalent log file, so its operational history was lost when the process exited.

## The change

Tee `console.log` / `console.error` to `$SUTANDO_WORKSPACE/logs/discord-voice.log`:

- New `DISCORD_VOICE_LOG` constant defined right after `WORKSPACE_DIR` resolves.
- Each `console.log` / `console.error` call still writes to stdout exactly as before **and** appends an ISO-timestamped line (`<ts> LOG ...` / `<ts> ERR ...`) to the log file. `Error` args are serialized with their stack.
- Mirrors the existing `CONVERSATION_LOG` pattern in the same file: `appendFileSync`, an `mkdirSync(dirname(...), {recursive:true})` guard, and a fail-soft `try/catch`.

## Fail-soft

The file append is wrapped in `try/catch` — a disk-full or permission error degrades the tee silently to stdout-only and can **never** crash the voice session. Tool behavior, prompts, and the access-tier / config logic are untouched; this is purely additive logging.

No log rotation in this PR — append-mode tee only (a follow-up concern).

## Verification

- `npm run typecheck` passes.
- The tee logic was exercised in isolation: stdout output is preserved unchanged, lines land in the log file ISO-timestamped, error stacks are captured, and the `mkdirSync` guard creates the `logs/` dir when missing.
- `skills/discord-voice/SKILL.md` updated with a one-line note pointing operators at `$SUTANDO_WORKSPACE/logs/discord-voice.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)