### PR TITLE
feat(health-check): track discord-voice-server (on-demand)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -670,6 +670,44 @@ def check_core_proactive_loop(threshold_sec: int = 600) -> dict:
     return {"name": name, "status": "ok", "detail": f"running ({age}s ago)"}
 
 
+def check_discord_voice() -> dict:
+    """Detect the discord-voice-server process — an on-demand voice session
+    process under skills/discord-voice/scripts/discord-voice-server.ts.
+
+    Like conversation-server, this is NOT a long-lived daemon: it's launched
+    per Discord voice session and SIGTERM'd by the `dismiss` tool when the
+    session ends. So "not running" is the expected steady state, not an error
+    — this returns a soft `warn` ("not running (on-demand)") when down and
+    `ok` when up, mirroring the conversation-server check. `warn` keeps it out
+    of the `N issue(s) found` error count (main() treats only down/missing/
+    not_loaded/fail as issues; warn is excluded).
+
+    Detection: `pgrep -f discord-voice-server` — the process has no listening
+    port, unlike conversation-server (port 3100), so it can't use check_port.
+    The detail string deliberately contains the word "running" in both states
+    so the dashboard's service filter (src/dashboard.py — keeps checks whose
+    detail mentions "port"/"running") surfaces it either way.
+    """
+    name = "discord-voice"
+    try:
+        result = subprocess.run(
+            ["/usr/bin/pgrep", "-f", "discord-voice-server"],
+            capture_output=True, text=True, timeout=5,
+        )
+        pids = [p for p in result.stdout.strip().split("\n") if p] if result.returncode == 0 else []
+    except (subprocess.TimeoutExpired, OSError):
+        pids = []
+    if pids:
+        check = {"name": name, "status": "ok", "detail": "running"}
+        mark_stale_if_outdated(
+            check,
+            REPO_DIR / "skills" / "discord-voice" / "scripts" / "discord-voice-server.ts",
+            "discord-voice-server.ts",
+        )
+        return check
+    return {"name": name, "status": "warn", "detail": "not running (on-demand)"}
+
+
 def check_task_queue(threshold_count: int = 3, threshold_age_sec: int = 300) -> dict:
     """Detect a task-queue pileup — tasks/ directory growing without
     being drained. Independent of which watcher / loop is dying: the queue
@@ -934,6 +972,12 @@ def run_all_checks() -> list[dict]:
             pass
 
         checks.append({"name": name, "status": status, "detail": detail})
+
+    # Discord voice server — on-demand process (launched per voice session,
+    # SIGTERM'd by the `dismiss` tool). Soft-warn when down, like
+    # conversation-server. Always checked: discord-voice can be started any
+    # time the discord-bridge / owner triggers a voice session.
+    checks.append(check_discord_voice())
 
     # Sutando menu bar app (optional — only check if binary exists)
     sutando_bin = REPO_DIR / "src" / "Sutando" / "Sutando"


### PR DESCRIPTION
## What changed

`discord-voice-server` (`skills/discord-voice/scripts/discord-voice-server.ts`) is an on-demand process — launched per Discord voice session and SIGTERM'd by the `dismiss` tool when the session ends. It was the only such process **not** tracked by `src/health-check.py` or the dashboard, unlike `discord-bridge` / `voice-agent` / `conversation-server`.

- **`src/health-check.py`**: new `check_discord_voice()` probe, wired into `run_all_checks()` near the messaging-bridge / conversation-server section.
- **Dashboard**: no code change needed. `src/dashboard.py` renders `health-check.py`'s `--json` output and filters services by checks whose `detail` mentions `"port"` or `"running"`. The new check's detail contains `"running"` in **both** states, so it flows through automatically and appears in the dashboard's Services card.

## Mirrors the conversation-server on-demand pattern

`conversation-server` already models an on-demand process gracefully: soft `warn` ("not running (starts on demand)") when down, `ok` when up — a down state is the *expected* steady state, not an error. `check_discord_voice()` mirrors this exactly:

- `ok` when running, `warn` ("not running (on-demand)") when not.
- A down `discord-voice` does **not** increment the `N issue(s) found` error count — `main()` counts only `down`/`missing`/`not_loaded`/`fail`/`stale` as issues; `warn` is excluded.
- Detection is via `pgrep -f discord-voice-server` instead of `check_port`, because `discord-voice-server` has no listening port (`conversation-server` uses port 3100). This matches the existing pgrep-based bridge detection style.
- Stale-code detection wired via `mark_stale_if_outdated` when the process is running.

## Why

`discord-voice-server` was untracked — a crashed or stale voice-session process was invisible to operators. This closes that gap with the same graceful on-demand treatment used for `conversation-server`.

## Verification

- `python3 src/health-check.py` — `discord-voice  warn  not running (on-demand)` line renders; issue count unaffected (the 2 pre-existing issues are stale `voice-agent`/`sutando-app`, unrelated).
- Simulated a running `discord-voice-server` process → check reports `ok` with detail `running`.
- Confirmed the dashboard `--json` service filter includes `discord-voice` in both up and down states.
- `npm run typecheck` passes clean (change is Python-only; ran as a sanity check).
- Purely additive monitoring — no tool/prompt/voice behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)