### PR TITLE
feat(discord-voice): push bridge-delivered text into the active voice session

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -32,6 +32,7 @@
 import { config as _dotenvConfig } from 'dotenv';
 import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, existsSync, readFileSync, unlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { createServer, type Server, type IncomingMessage } from 'node:http';
 import { resolveWorkspace } from '../../../src/workspace_default.js';
 import { recordConversation, recordSession } from '../../../src/conversation-store.js';
 import { type Tier, loadAccessTiers, effectiveTier, toolAllowed, toolNeed } from './access-tier.js';
@@ -915,6 +916,102 @@ function cleanupSession(s: DiscordVoiceSession): void {
 	console.log(`${ts()} [Voice] session finalized: ${s.sessionId} (${durationMs}ms, ${s.transcript.length} turns)`);
 }
 
+// --- Text control server ----------------------------------------------------
+// Tiny localhost-only HTTP server so out-of-process callers — chiefly the
+// Discord bridge (src/discord-bridge.py) — can push text into the live voice
+// session. discord-voice-server has no `messageCreate` handler, so text posted
+// in its voice channel never reaches the voice agent; this server is how the
+// bridge closes that gap.
+//
+// Mirrors src/vision-tools.ts's startVisionControlServer: localhost-bound,
+// JSON, fail-soft on EADDRINUSE (another discord-voice-server owns the port).
+// The transport — `transport.sendContent([{role:'user', text}], false)` — is
+// the SAME mechanism vision-tools uses to inject hidden context turns and the
+// resultQueue drain uses to inject task results. turnComplete=false so the
+// text lands as conversation context without forcing a generation.
+//
+//   GET  /voice/state   → {channelId, sessionReady}
+//   POST /voice/text    {text, source}  → inject one user-role text turn
+//
+// 7845 screen-capture, 7846 credential-proxy, 7847 vision-control — 7848 free.
+const VOICE_CONTROL_PORT = Number(process.env.DISCORD_VOICE_CONTROL_PORT) || 7848;
+let voiceControlServer: Server | null = null;
+
+function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+	return new Promise((resolve) => {
+		const chunks: Buffer[] = [];
+		req.on('data', (c: Buffer) => chunks.push(c));
+		req.on('end', () => {
+			if (chunks.length === 0) return resolve({});
+			try { resolve(JSON.parse(Buffer.concat(chunks).toString('utf-8')) as Record<string, unknown>); }
+			catch { resolve({}); }
+		});
+		req.on('error', () => resolve({}));
+	});
+}
+
+/** Inject a text turn into the active session. Returns false (no throw) when
+ *  there's no live session or the transport rejects — callers must not break. */
+function injectVoiceText(text: string): boolean {
+	const s = active;
+	if (!s || s.closing) return false;
+	const transport = (s.voiceSession as any)?.transport;
+	if (!transport || typeof transport.sendContent !== 'function') return false;
+	if (transport.isConnected === false) return false;
+	try {
+		// turnComplete=false → context-only, no generation forced. Same call
+		// shape as vision-tools' screen-share context hints.
+		transport.sendContent([{ role: 'user', text }], false);
+		return true;
+	} catch (err) {
+		console.warn(`${ts()} [VoiceText] inject failed: ${(err as Error)?.message ?? err}`);
+		return false;
+	}
+}
+
+function startVoiceControlServer(port: number = VOICE_CONTROL_PORT): void {
+	if (voiceControlServer) return;
+	const srv = createServer(async (req, res) => {
+		const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+		const respond = (status: number, body: unknown) => {
+			res.writeHead(status, { 'Content-Type': 'application/json' });
+			res.end(JSON.stringify(body));
+		};
+		if (url.pathname === '/voice/state' && req.method === 'GET') {
+			const s = active;
+			return respond(200, {
+				channelId: s && !s.closing ? s.channelId : null,
+				sessionReady: !!(s && !s.closing && (s.voiceSession as any)?.transport),
+			});
+		}
+		if (url.pathname === '/voice/text' && req.method === 'POST') {
+			const body = await readJsonBody(req);
+			const text = typeof body.text === 'string' ? body.text.trim() : '';
+			const source = typeof body.source === 'string' ? body.source : 'external';
+			if (!text) return respond(400, { status: 'failed', error: 'empty text' });
+			const ok = injectVoiceText(`[${source}] ${text}`);
+			if (ok) console.log(`${ts()} [VoiceText] injected (${source}): ${text.slice(0, 120)}`);
+			return respond(ok ? 200 : 409, ok ? { status: 'injected' } : { status: 'failed', error: 'no active session' });
+		}
+		respond(404, { error: 'not found' });
+	});
+	srv.on('error', (err: NodeJS.ErrnoException) => {
+		// EADDRINUSE — another discord-voice-server already owns the port.
+		// Don't crash and don't claim it; leave voiceControlServer null so
+		// our shutdown is a no-op (we never want to close someone else's).
+		if (err.code === 'EADDRINUSE') {
+			console.warn(`${ts()} [VoiceText] control port ${port} in use; skipping (another discord-voice-server?)`);
+			voiceControlServer = null;
+			return;
+		}
+		console.error(`${ts()} [VoiceText] control server error: ${err.message}`);
+	});
+	srv.listen(port, '127.0.0.1', () => {
+		console.log(`${ts()} [VoiceText] text control server listening on 127.0.0.1:${port}`);
+	});
+	voiceControlServer = srv;
+}
+
 // --- Bootstrap --------------------------------------------------------------
 
 async function start(): Promise<void> {
@@ -961,6 +1058,9 @@ async function start(): Promise<void> {
 
 	const session = await createVoiceSession(connection);
 	active = session;
+	// Text control server — lets the Discord bridge push channel text into
+	// this live session (discord-voice-server has no messageCreate handler).
+	startVoiceControlServer();
 	console.log(`${ts()} [Setup] audio bridge live — speak in the channel`);
 
 	connection.on(VoiceConnectionStatus.Disconnected, async () => {
@@ -982,6 +1082,7 @@ async function start(): Promise<void> {
 // its own heartbeat timeout (~60-90s).
 function shutdownAfterFlush(code: number): void {
 	if (active) { try { cleanupSession(active); } catch {} }
+	if (voiceControlServer) { try { voiceControlServer.close(); } catch {} voiceControlServer = null; }
 	setTimeout(() => process.exit(code), 1500);
 }
 process.on('SIGINT', () => shutdownAfterFlush(0));

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -66,6 +66,17 @@ except Exception:  # pragma: no cover
     def _push_vision_image(path: str, source: str = "discord") -> bool:  # type: ignore
         return False
 
+# Voice-text helper — pushes bridge-delivered channel text into an active
+# discord-voice session so the voice agent ingests it as conversation context
+# (discord-voice-server has no messageCreate handler). Mirrors _push_vision_image:
+# best-effort, import failure or unreachable voice server leaves delivery
+# unchanged.
+try:
+    from voice_text_push import push_text as _push_voice_text  # noqa: E402
+except Exception:  # pragma: no cover
+    def _push_voice_text(text: str, channel_id, source: str = "discord-bridge") -> bool:  # type: ignore
+        return False
+
 # Load token from channels config
 TOKEN = ""
 channels_env = Path.home() / ".claude" / "channels" / "discord" / ".env"
@@ -2936,6 +2947,15 @@ async def poll_results():
                             )
                         except Exception:
                             pass
+                        # If a discord-voice session is live in this channel,
+                        # also push the text into it — discord-voice-server
+                        # has no messageCreate handler, so otherwise the voice
+                        # agent never sees what the bridge posted. Fail-soft:
+                        # no-op when no session is active for this channel.
+                        try:
+                            _push_voice_text(clean_text, channel.id, source="discord-bridge")
+                        except Exception:
+                            pass
 
                     # Send files (allowlist-gated; see _is_path_sendable)
                     for fpath in files:
@@ -3240,6 +3260,16 @@ async def poll_dm_fallback():
                                         body=text_only,
                                         task_id=_task_id,
                                     )
+                                except Exception:
+                                    pass
+                                # Mirror poll_results: push the redirected text
+                                # into a discord-voice session if one is live in
+                                # the target channel. This is the trigger case —
+                                # a result routed via [channel: <voice-channel>]
+                                # to a channel where discord-voice is running.
+                                # Fail-soft: no-op without an active session.
+                                try:
+                                    _push_voice_text(text_only, target_channel_id, source="discord-bridge")
                                 except Exception:
                                     pass
                             for fpath in file_list:

--- a/src/voice_text_push.py
+++ b/src/voice_text_push.py
@@ -1,0 +1,92 @@
+"""Small helper for pushing text into an active discord-voice session.
+
+Used by the Discord bridge (and any other Python integration) to inject text
+the bridge delivers into a Discord channel into Gemini Live's conversation
+context when a discord-voice session is live in that same channel. No-op when
+no voice session is reachable — the message still posts to the channel through
+the regular delivery path.
+
+discord-voice-server (skills/discord-voice/scripts/discord-voice-server.ts) has
+no `messageCreate` handler, so text posted in its voice channel never reaches
+the voice agent. This helper closes that gap by injecting the text directly
+into the live VoiceSession's conversation context.
+
+Contract mirrors `vision_push.py` (which pushes image frames into voice via the
+vision-tools HTTP control server). The discord-voice-server exposes a tiny
+localhost-only control server:
+  - GET  /voice/state  →  {channelId, sessionReady}   liveness + which channel
+  - POST /voice/text   {text, source}                 inject one text turn
+
+Single-shot helper: checks the session is up AND serving the target channel,
+then POSTs the text. Fail-soft on every error path — a push failure must never
+break message delivery.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+
+# discord-voice-server's text control server. 7845 is screen-capture, 7846 is
+# credential-proxy, 7847 is the vision control server (voice-agent) — 7848 free.
+VOICE_TEXT_PORT = int(os.environ.get("DISCORD_VOICE_CONTROL_PORT", "7848"))
+VOICE_TEXT_BASE = f"http://127.0.0.1:{VOICE_TEXT_PORT}"
+
+
+def _post(path: str, body: bytes, content_type: str, timeout: float = 3.0) -> tuple[int, bytes]:
+    req = urllib.request.Request(
+        f"{VOICE_TEXT_BASE}{path}",
+        data=body,
+        headers={"Content-Type": content_type},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read() if e.fp else b""
+    except (urllib.error.URLError, ConnectionRefusedError, TimeoutError, OSError):
+        return 0, b""
+
+
+def active_voice_channel(timeout: float = 1.0) -> str | None:
+    """Return the channel id of the active discord-voice session, or None.
+
+    None when no voice session is up, the control server isn't listening, or
+    the session reports it isn't ready to accept content.
+    """
+    try:
+        with urllib.request.urlopen(f"{VOICE_TEXT_BASE}/voice/state", timeout=timeout) as resp:
+            data = json.loads(resp.read())
+        if not data.get("sessionReady"):
+            return None
+        ch = data.get("channelId")
+        return str(ch) if ch else None
+    except Exception:
+        return None
+
+
+def push_text(text: str, channel_id: str | int, source: str = "discord-bridge") -> bool:
+    """Inject *text* into the active discord-voice session for *channel_id*.
+
+    Returns True if the text was accepted. Silently returns False if no voice
+    session is live for that channel — callers must not break on this, because
+    the message has already been (or will be) delivered to the channel through
+    the regular bridge path.
+    """
+    text = (text or "").strip()
+    if not text:
+        return False
+
+    target = str(channel_id)
+    active = active_voice_channel()
+    # No session, or the session is serving a different channel — no-op.
+    if active is None or active != target:
+        return False
+
+    payload = json.dumps({"text": text, "source": source}).encode("utf-8")
+    status, _ = _post("/voice/text", payload, "application/json")
+    return 200 <= status < 300


### PR DESCRIPTION
## The gap

The Discord bridge already pushes **image** attachments into a live discord-voice (Gemini Live) session — `_push_vision_image` / `src/vision_push.py`, called from the on-message attachment handler. It does **not** push text.

`discord-voice-server.ts` has no `messageCreate` handler — it never reads text posted in its voice channel. So any message the bridge **delivers into** a voice channel — including a `results/` body routed there via the `[channel: <id>]` redirect marker — is never seen by the voice agent.

## The change

Mirrors the image path exactly:

- **`src/voice_text_push.py`** — new helper analogous to `vision_push.py`. `urllib` POST to a localhost control server: `GET /voice/state` for liveness + which channel is active, `POST /voice/text` to inject. Fail-soft on every error path (`URLError` / `ConnectionRefused` / non-200) — returns `False`, never raises. No-op when no session is active for the target channel (channel-match gate, on top of `vision_push.py`'s `is_voice_ready`-equivalent check).

- **`discord-voice-server.ts`** — adds a tiny localhost-only text control server (port `7848`, env `DISCORD_VOICE_CONTROL_PORT`), mirroring `vision-tools.ts`'s `startVisionControlServer`: localhost-bound, JSON, fail-soft on `EADDRINUSE` (another server owns the port). `/voice/text` injects via `transport.sendContent([{role:'user', text}], false)` — the **same mechanism** `vision-tools.ts` uses for screen-share context hints and the discord-voice `resultQueue` drain uses for task results. `turnComplete=false` → context-only, no forced generation. Started after the session is live, closed on shutdown.

  (The discord-voice-server runs its own `VoiceSession`; it does not — and the vision-tools control server on `:7847` is owned by `voice-agent.ts`, not discord-voice-server — so a matching control server on the discord-voice side is the transport that lets the bridge reach a discord-voice session. `transport.sendContent` is the proven text-inject path the session already uses internally.)

- **`discord-bridge.py`** — wires `_push_voice_text` into both outbound delivery paths (`poll_results` normal/redirected delivery; `poll_dm_fallback` channel-redirect) **after** the message is sent to the channel. The trigger case: a `results/` body routed via `[channel: <voice-channel-id>]` to a channel where discord-voice is running — the text lands in the voice agent's session.

## Fail-soft / additive

Purely additive — a channel **without** an active voice session is delivered exactly as before. A push failure (no session, WS error, server down, port unbound) returns `False` and is wrapped in `try/except` at the call site; it can **never** break message delivery or crash the bridge — exactly like the image path.

## Verification

- `python3 -m py_compile src/discord-bridge.py src/voice_text_push.py` — clean.
- `npm run typecheck` — passes.
- Helper fail-soft confirmed with no server listening (`push_text` → `False`, no exception).
- End-to-end against a mock control server matching the `/voice/state` + `/voice/text` contract: matching-channel push delivers, non-matching-channel is a no-op, `sessionReady=false` is a no-op, int and str channel ids both work.
- `discord-bridge` test suite passes (the one unrelated `slack-bridge-allowlist` failure is pre-existing — `slack-bridge.py` uses `str | None` on Python 3.9; confirmed identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)