### PR TITLE
fix(proactive-routing): handle non-bridge channels (voice / github-commits) — closes residual half of #988

### DIFF
--- a/src/proactive_routing.py
+++ b/src/proactive_routing.py
@@ -1,24 +1,26 @@
 """Channel routing for proactive owner-notification messages.
 
-`results/proactive-*.txt` files are polled by ALL configured bridges
-(`src/discord-bridge.py:poll_proactive` and `src/telegram-bridge.py`'s
-proactive loop). The pre-fix arrangement relied on a race: whichever
-bridge's polling loop reached the file first did an atomic-rename
-claim and delivered the message; the other bridge's next poll found
-the file gone and silently skipped.
+Background: `results/proactive-*.txt` files are polled by ALL
+configured bridges (`src/discord-bridge.py:poll_proactive` and
+`src/telegram-bridge.py:main` proactive loop). The pre-fix arrangement
+relied on a race: whichever bridge's polling loop reached the file
+first did an atomic-rename claim (`f.with_suffix(".sending")`) and
+delivered the message; the other bridge's next poll found the file
+gone and silently skipped.
 
 The race-claim was correct as "deliver at most once" but wrong as
 "deliver where the owner expects to read it." A user with both
-Discord and Telegram allowlisted saw proactive messages randomly
-land on one channel or the other based on poll timing — a Discord-
-context follow-up could land on Telegram and vice versa.
+Discord and Telegram allowlisted would see proactive messages
+randomly land on one channel or the other based on poll timing —
+on 2026-05-20 a Discord-context follow-up landed on Telegram and
+the owner asked "Why have you sent me the message on Telegram? It
+looks like a bug — I was only checking messages from you on Discord."
 
 Fix: route proactive messages to the channel where the owner was
 **most recently active**. Both bridges already record activity via
-`write_owner_activity(channel, summary)` ->
-`state/last-owner-activity.json`. This module reads that state file
-and tells the calling bridge whether it should claim the next
-proactive file.
+`write_owner_activity(channel, summary)` → `state/last-owner-activity.json`.
+This module reads that state file and tells the calling bridge
+whether it should claim the next proactive file.
 
 Default (no state file yet, or a malformed one): Discord wins.
 Discord is the canonical first-channel install path; new installs
@@ -29,6 +31,22 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+
+# Channels whose bridges actually deliver `proactive-*.txt` files.
+# Other producers write `last-owner-activity.json` with channel values
+# like `"voice"` (voice agent registered an utterance) or
+# `"github-commits"` (auto-poll observed a new commit) — those are
+# activity-tracking signals, NOT message-delivery channels. When the
+# last activity was on a non-bridge channel, proactive messages must
+# still get delivered SOMEWHERE rather than stranded: Discord is the
+# default (the canonical first-channel install path).
+#
+# Per @rickchen007 PR #35 review: pre-fix, only `discord`/`telegram`
+# were treated as recognized — and an unrecognized value (`voice`,
+# `github-commits`, anything else) returned False for BOTH bridges,
+# silently stranding the proactive file in `results/` until the
+# next discord/telegram message restored a known activity channel.
+BRIDGE_CHANNELS = frozenset({"discord", "telegram"})
 
 
 def should_claim_proactive(state_file_path: Path, this_channel: str) -> bool:
@@ -43,14 +61,17 @@ def should_claim_proactive(state_file_path: Path, this_channel: str) -> bool:
         ``True`` iff the calling bridge is the destination for proactive
         messages right now. The decision rule:
 
-          1. State file present and parseable -> claim only when
-             ``data["channel"] == this_channel``.
-          2. State file missing, unreadable, or malformed -> claim only
-             when ``this_channel == "discord"``. Discord is the default
-             so a fresh install (no activity history yet) doesn't
-             silently duplicate to every configured bridge.
-          3. State file present but ``data["channel"]`` is empty or
-             absent -> same default as (2).
+          1. State file says ``data["channel"]`` is a known BRIDGE
+             channel (discord / telegram) → claim only when
+             ``last_channel == this_channel``. This is the message-
+             routing match — owner was last reading there, follow-up
+             goes there.
+          2. State file missing / unreadable / malformed / no-channel
+             / channel-not-a-string / channel-not-a-bridge (e.g.
+             ``voice``, ``github-commits``) → default Discord. Owner
+             messages must not get stranded when the last activity
+             was on a non-bridge surface; Discord is the canonical
+             first-channel install path.
 
     Pure function — no side effects, no logging. Callers handle
     skip/continue control flow.
@@ -69,4 +90,12 @@ def should_claim_proactive(state_file_path: Path, this_channel: str) -> bool:
     if not isinstance(last_channel, str) or not last_channel:
         return this_channel == "discord"
 
-    return last_channel == this_channel
+    # If the last-active channel is a known bridge, match strictly so
+    # only that bridge claims.
+    if last_channel in BRIDGE_CHANNELS:
+        return last_channel == this_channel
+
+    # Non-bridge channel (voice / github-commits / etc.): the owner
+    # most recently interacted on a surface that doesn't deliver DMs.
+    # Default Discord rather than strand the proactive file.
+    return this_channel == "discord"

--- a/tests/proactive-routing.test.py
+++ b/tests/proactive-routing.test.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python3
 """Unit tests for `proactive_routing.should_claim_proactive`.
 
-`results/proactive-*.txt` files were polled by every configured bridge,
-and whichever bridge's polling loop reached the file first did the
-atomic-rename claim. The race produced unpredictable cross-channel
+## What this guards
+
+The owner reported on 2026-05-20:
+
+> Why have you sent me the message on Telegram? Is in response to our
+> Discord communication? It looks like a bug — I was only checking
+> messages from you on Discord in response to my messages on Discord.
+
+Root cause: `results/proactive-*.txt` files were polled by every
+configured bridge, and whichever bridge's polling loop reached the file
+first did the atomic-rename claim. Both bridges had matching code
+(rename → send → unlink); the race produced unpredictable cross-channel
 delivery, with proactive owner-notifications landing on whichever
 bridge happened to win that iteration.
 
@@ -12,9 +21,11 @@ Fix: `should_claim_proactive(state_file, this_channel)` consults
 bridge is the last-active channel. Default-to-Discord on missing or
 malformed state so fresh installs route predictably.
 
-This test file pins every branch of the decision rule.
+This test file pins every branch of the decision rule so a future
+refactor cannot reintroduce the cross-channel-leak class.
 """
 
+import importlib.util
 import json
 import os
 import sys
@@ -28,6 +39,10 @@ from proactive_routing import should_claim_proactive  # noqa: E402
 
 
 def _with_state(content, fn):
+    """Run fn(state_file) with a temp state file written from content.
+    If content is None, the file is absent. If content is a string, it
+    is written verbatim (lets us test malformed JSON). Otherwise
+    `json.dumps(content)` is used."""
     tmp = Path(tempfile.mkdtemp(prefix="sutando-proactive-test-"))
     state = tmp / "last-owner-activity.json"
     if content is not None:
@@ -44,77 +59,150 @@ def _with_state(content, fn):
 
 
 def test_discord_active_routes_to_discord():
-    """Owner's last activity was on Discord — Discord claims, Telegram
-    skips. The headline case."""
+    """Owner's last activity was on Discord — Discord bridge claims,
+    Telegram skips. The headline case from the 2026-05-20 report."""
+
     def run(state):
         assert should_claim_proactive(state, "discord") is True
         assert should_claim_proactive(state, "telegram") is False
+
     _with_state({"channel": "discord", "ts": 1779339000}, run)
 
 
 def test_telegram_active_routes_to_telegram():
-    """Symmetric: Telegram-recent activity -> Telegram claims, Discord
-    skips."""
+    """Symmetric: Telegram-recent activity → Telegram claims, Discord
+    skips. Confirms the rule is bidirectional (not Discord-favored)."""
+
     def run(state):
         assert should_claim_proactive(state, "discord") is False
         assert should_claim_proactive(state, "telegram") is True
+
     _with_state({"channel": "telegram", "ts": 1779339000}, run)
 
 
 def test_missing_state_file_defaults_to_discord():
-    """Fresh install -> Discord wins by default. Exactly one bridge
-    claims (the race-leak class is closed)."""
+    """Fresh install / no activity yet → Discord wins by default. Two
+    bridges polling at the same time on a fresh install must NOT both
+    claim (the original race). Discord-default ensures exactly one
+    bridge claims."""
+
     def run(state):
+        # state file does not exist (passed None to _with_state)
         assert not state.exists()
         assert should_claim_proactive(state, "discord") is True
         assert should_claim_proactive(state, "telegram") is False
+
     _with_state(None, run)
 
 
 def test_malformed_state_file_defaults_to_discord():
-    """Corrupt state file -> fail closed (default discord). Must not
-    raise — the polling loop would silently die otherwise."""
+    """Corrupt state file → fail closed (default discord). Must not
+    raise — the polling loop would silently die otherwise. Default-
+    to-discord matches the missing-file case for predictability."""
+
     def run(state):
         assert should_claim_proactive(state, "discord") is True
         assert should_claim_proactive(state, "telegram") is False
+
     _with_state("{ this is not json", run)
 
 
 def test_state_file_missing_channel_field_defaults_to_discord():
     """A state file written by an older bridge version (no `channel`
-    field) or by a partial mid-write -> default to discord."""
+    field) or by a partial mid-write → default to discord. Don't
+    surprise the user by routing to an unexpected channel."""
+
     def run(state):
         assert should_claim_proactive(state, "discord") is True
         assert should_claim_proactive(state, "telegram") is False
+
     _with_state({"ts": 1779339000}, run)
 
 
 def test_state_file_empty_channel_string_defaults_to_discord():
     """`{"channel": ""}` — distinct from missing channel; pin it
-    handles the same way."""
+    handles the same way. Future writers that emit an empty channel
+    string must not silently route to telegram."""
+
     def run(state):
         assert should_claim_proactive(state, "discord") is True
         assert should_claim_proactive(state, "telegram") is False
+
     _with_state({"channel": "", "ts": 1779339000}, run)
 
 
 def test_state_file_non_dict_root_defaults_to_discord():
-    """A state file whose root is a list/scalar (corruption) ->
-    default. Pin the type guard."""
+    """A state file whose root is a list/scalar (corruption) → default.
+    The `data.get("channel")` call would AttributeError on a non-dict
+    without this guard; pin that the function returns False (skip) for
+    non-discord callers."""
+
     def run(state):
         assert should_claim_proactive(state, "discord") is True
         assert should_claim_proactive(state, "telegram") is False
+
     _with_state(["not a dict"], run)
 
 
-def test_unknown_channel_value_does_not_match_anyone():
-    """`{"channel": "slack"}` — channel value not "discord" or
-    "telegram". Neither bridge should claim. Strict equality, no
-    fallback to Discord in this case — silence is correct."""
+def test_voice_channel_defaults_to_discord():
+    """Per @rickchen007 PR #35 review: `state/last-owner-activity.json`
+    is written with channel values beyond `discord`/`telegram` —
+    `"voice"` is a real value the voice agent writes on every owner
+    utterance. Pre-fix, the strict `last_channel == this_channel`
+    rule returned False for BOTH bridges in this case, stranding
+    the proactive file in `results/`.
+
+    Post-fix: non-bridge channels default to Discord (canonical
+    first-channel install path)."""
+
     def run(state):
-        assert should_claim_proactive(state, "discord") is False
+        assert should_claim_proactive(state, "discord") is True, (
+            "voice-channel-active must route to Discord — otherwise the "
+            "proactive file is stranded until the owner next DMs"
+        )
         assert should_claim_proactive(state, "telegram") is False
+
+    _with_state({"channel": "voice", "ts": 1779339000}, run)
+
+
+def test_github_commits_channel_defaults_to_discord():
+    """Same shape: the github-commit auto-poll writes `{"channel":
+    "github-commits"}` on every observed commit. Must NOT strand the
+    proactive file."""
+
+    def run(state):
+        assert should_claim_proactive(state, "discord") is True
+        assert should_claim_proactive(state, "telegram") is False
+
+    _with_state({"channel": "github-commits", "ts": 1779339000}, run)
+
+
+def test_unrecognized_channel_defaults_to_discord():
+    """Generalization: an arbitrary non-bridge channel name (e.g.
+    `"slack"`, `"matrix"`, future channels not yet implemented) also
+    defaults to Discord rather than stranding the message. The pre-
+    fix behavior was strict equality which silently dropped the
+    proactive — exactly the bug @rickchen007 identified."""
+
+    def run(state):
+        assert should_claim_proactive(state, "discord") is True
+        assert should_claim_proactive(state, "telegram") is False
+
     _with_state({"channel": "slack", "ts": 1779339000}, run)
+
+
+def test_bridge_channels_set_is_documented():
+    """Pin the BRIDGE_CHANNELS constant: a future contributor adding
+    a new bridge (e.g. matrix) must update both this constant AND
+    add a corresponding `test_<channel>_active_routes_to_<channel>`.
+    Without this pin, the constant could silently widen and break the
+    "non-bridge defaults to Discord" contract."""
+    from proactive_routing import BRIDGE_CHANNELS
+    assert BRIDGE_CHANNELS == frozenset({"discord", "telegram"}), (
+        f"BRIDGE_CHANNELS changed to {BRIDGE_CHANNELS!r}. If you added a "
+        f"new bridge, add a corresponding routing test AND update this "
+        f"assertion deliberately."
+    )
 
 
 def main():
@@ -125,7 +213,10 @@ def main():
     test_state_file_missing_channel_field_defaults_to_discord()
     test_state_file_empty_channel_string_defaults_to_discord()
     test_state_file_non_dict_root_defaults_to_discord()
-    test_unknown_channel_value_does_not_match_anyone()
+    test_voice_channel_defaults_to_discord()
+    test_github_commits_channel_defaults_to_discord()
+    test_unrecognized_channel_defaults_to_discord()
+    test_bridge_channels_set_is_documented()
     print("All proactive-routing tests passed.")
 
 


### PR DESCRIPTION
## The bug — surfaced by @rickchen007 on fork PR #35

PR #988 introduced `should_claim_proactive` to route `proactive-*.txt` files to the bridge whose channel the owner was last active on. But `state/last-owner-activity.json` is written by **more producers than just the discord-bridge and telegram-bridge**. Concrete values real installs write:

- `{\"channel\": \"voice\", ...}` — voice agent on every owner utterance
- `{\"channel\": \"github-commits\", ...}` — github auto-poll on every observed new commit

These are activity-tracking signals, not message-delivery channels.

Pre-fix #988 used strict `last_channel == this_channel`. For `{\"channel\": \"voice\"}`:

\`\`\`
should_claim_proactive(state, \"discord\")  -> False
should_claim_proactive(state, \"telegram\") -> False
\`\`\`

→ **No bridge claims the `proactive-*.txt` file.** The owner notification is silently stranded in `results/` until the owner next sends a Discord/Telegram message that restores a recognized channel.

Voice is a very common last-active surface — owner using voice agent writes voice activity, then a downstream task generates a proactive, all bridges skip → silence.

## Fix

`BRIDGE_CHANNELS = frozenset({\"discord\", \"telegram\"})` — the set of channels whose bridges actually compete for proactive files. Routing rule:

| Condition | Action |
|---|---|
| `last_channel ∈ BRIDGE_CHANNELS` | strict match (`last_channel == this_channel`) |
| anything else (incl. `voice` / `github-commits` / missing / malformed) | default Discord |

Discord-as-default preserves the existing \"new install → Discord\" behavior AND closes the strand class.

## Tests

11 tests in `tests/proactive-routing.test.py`:

- Removed the test that asserted the buggy \"both False\" behavior
- Added `test_voice_channel_defaults_to_discord` (the concrete bug)
- Added `test_github_commits_channel_defaults_to_discord`
- Added `test_unrecognized_channel_defaults_to_discord` (general rule)
- Added `test_bridge_channels_set_is_documented` (pins the constant so future contributors must update test AND set together)

All 11 pass locally.

## Acknowledgements

@rickchen007 caught this on fork PR #35. Same fix landing here closes the residual half of #988 upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)