### PR TITLE
fix(context-drop): drop kCGWindowName read so ax-read needs no Screen Recording

### DIFF
--- a/skills/context-drop/Sources/ax-read/main.swift
+++ b/skills/context-drop/Sources/ax-read/main.swift
@@ -40,13 +40,19 @@ import Foundation
 // NSWorkspace.shared.frontmostApplication returns nil from processes not
 // attached to the GUI WindowServer session (LSUIElement agents, launchd
 // daemons). CGWindowListCopyWindowInfo works from any process context — it
-// queries the window server directly. kCGWindowOwnerName + OwnerPID don't
-// require Screen Recording permission; only kCGWindowName does.
+// queries the window server directly.
+//
+// We deliberately read ONLY kCGWindowOwnerName + kCGWindowOwnerPID — those
+// don't require any TCC grant. kCGWindowName (the window title) DOES
+// require Screen Recording permission, and since ax-read is rebuilt via
+// `swift build` (ad-hoc signed, hash changes every build), that grant
+// would orphan and re-prompt on every rebuild. The window title is fetched
+// via the AX path (kAXTitleAttribute) below instead — only needs
+// Accessibility permission, which is granted once to Sutando.app.
 
 struct FrontmostInfo {
     let name: String
     let pid: pid_t
-    let windowName: String
 }
 
 func frontmostFromCGWindowList() -> FrontmostInfo? {
@@ -61,8 +67,7 @@ func frontmostFromCGWindowList() -> FrontmostInfo? {
               let pidNum = window[kCGWindowOwnerPID as String] as? Int else {
             continue
         }
-        let winName = (window[kCGWindowName as String] as? String) ?? ""
-        return FrontmostInfo(name: name, pid: pid_t(pidNum), windowName: winName)
+        return FrontmostInfo(name: name, pid: pid_t(pidNum))
     }
     return nil
 }
@@ -128,13 +133,12 @@ var windowTitle: String
 if let f = frontInfo {
     appName = f.name
     pid = f.pid
-    windowTitle = f.windowName
 } else {
     let frontmostApp = NSWorkspace.shared.frontmostApplication
     appName = frontmostApp?.localizedName ?? ""
     pid = frontmostApp?.processIdentifier ?? -1
-    windowTitle = ""
 }
+windowTitle = ""
 
 if pid < 0 {
     emit(["path": "none"])
@@ -143,16 +147,15 @@ if pid < 0 {
 
 let appRef = AXUIElementCreateApplication(pid)
 
-// AX window title (more reliable than kCGWindowName, which needs Screen Recording).
-if windowTitle.isEmpty {
-    var focusedWindow: AnyObject?
-    if AXUIElementCopyAttributeValue(appRef, kAXFocusedWindowAttribute as CFString, &focusedWindow) == .success,
-       let win = focusedWindow {
-        var titleValue: AnyObject?
-        if AXUIElementCopyAttributeValue(win as! AXUIElement, kAXTitleAttribute as CFString, &titleValue) == .success,
-           let t = titleValue as? String {
-            windowTitle = t
-        }
+// AX window title — kAXTitleAttribute needs only Accessibility permission,
+// not Screen Recording. This is the sole source of the title.
+var focusedWindow: AnyObject?
+if AXUIElementCopyAttributeValue(appRef, kAXFocusedWindowAttribute as CFString, &focusedWindow) == .success,
+   let win = focusedWindow {
+    var titleValue: AnyObject?
+    if AXUIElementCopyAttributeValue(win as! AXUIElement, kAXTitleAttribute as CFString, &titleValue) == .success,
+       let t = titleValue as? String {
+        windowTitle = t
     }
 }
 


### PR DESCRIPTION
## Problem

Owner reported macOS repeatedly prompts for Screen Recording permission when using the `^C` context-drop hotkey, even on plain-text drops where no screen content is involved. The prompt re-fires per invocation regardless of whether `ax-read` was just rebuilt.

## Root cause

`ax-read`'s `frontmostFromCGWindowList()` reads `kCGWindowName` from `CGWindowListCopyWindowInfo` to populate the frontmost window's title. That specific key requires Screen Recording permission — the existing in-file comment already acknowledged this. Because `ax-read` is built via `swift build` (ad-hoc signed, no developer identity), its code signature changes on every rebuild and macOS TCC treats each build as a new app, orphaning the prior grant. On Sequoia, the grant additionally doesn't appear to persist reliably across launches even within one binary.

## Fix

Stop reading `kCGWindowName`. The window title was already being fetched as a fallback via `kAXTitleAttribute` — the code's own comment called it *"more reliable than kCGWindowName"*. Make that AX read the sole source: it only needs Accessibility permission, which Sutando.app already holds and which is stable across rebuilds.

## Changes

- Remove `windowName` from `FrontmostInfo` struct.
- Remove the `kCGWindowName` read in `frontmostFromCGWindowList()`.
- Remove the `if windowTitle.isEmpty` guard on the AX block — runs unconditionally now (windowTitle is always empty when control reaches it).
- Expand the MARK comment to document the intentional omission so a future contributor doesn't re-add the kCGWindowName read.

Net: +20 / -17 lines in one file.

## Verification

Rebuilt the binary (`bash skills/context-drop/build.sh` — 1.5s) and ran it directly:

```
$ ./skills/context-drop/ax-read
{"app":"Discord","path":"none","selected":"","url":"","window_title":"@sutando - Discord"}
```

Window title populates cleanly from the AX path. No Screen Recording prompt fired.

## Quality note

For most apps the AX-reported title and `kCGWindowName` are the same string, and the AX path was already preferred as "more reliable" by the original author's comment. In the failure cases where `kCGWindowName` previously returned empty (TCC denial or genuinely empty), the AX fallback was filling in anyway — so this PR has the same output in the common case and is strictly better when `kCGWindowName` would have been empty. Possible regression case is an app whose AX title is shorter/different from `kCGWindowName` — none observed in smoke testing, and the original code already accepted that risk via its "more reliable" framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)