### PR TITLE
feat(agent-registry): local agent registry + overlay manager UI

### DIFF
--- a/skills/agent-registry/SKILL.md
+++ b/skills/agent-registry/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: agent-registry
+description: Local Agent Registry — a standalone, dependency-free service that tracks running Claude Code (and other) agent instances. Agents self-register on startup and heartbeat while alive; the Electron overlay and Sutando dashboard read the live list. Use when you need to know which coding agents are running, where, and since when.
+---
+
+# Agent Registry
+
+A thin **local** service that tracks running agent instances. Claude Code
+instances register themselves on startup (via a SessionStart hook) and
+heartbeat while alive; consumers read the live list over a localhost HTTP API.
+
+This is **not** the AG2 Workforce Hub app. It is a small local service that can
+*optionally* mirror its state to an AG2 hub using the hub connection layer
+(`ag2_workforce.hub.client`) — see "Optional: AG2 Hub mirroring" below — but the
+core service has zero third-party dependencies and works entirely offline.
+
+## Components
+
+```
+skills/agent-registry/
+├── scripts/registry-service.py   # the HTTP service + SQLite store
+├── scripts/registry-client.py    # CLI: register / heartbeat / deregister / list / watch
+└── hooks/session-start.sh        # Claude Code SessionStart hook
+```
+
+- **DB:** `<workspace>/data/agent-registry.db` (SQLite, auto-created)
+- **Discovery file:** `<workspace>/state/agent-registry.json` — written by the
+  service with the bound port so clients find it without a hardcoded port.
+- **Port:** binds `127.0.0.1`, first free port from `7847` upward.
+
+## Running the service
+
+It is **startable by Sutando** three ways, in order of preference:
+
+1. **Auto-start (default).** Any `registry-client.py` call with `--autostart`
+   launches the service detached if it is not already running. The
+   SessionStart hook passes `--autostart`, so the first Claude Code session to
+   start brings the registry up.
+2. **From `startup.sh`.** For an always-on registry, add to `src/startup.sh`:
+   `python3 skills/agent-registry/scripts/registry-service.py &`
+3. **By hand:** `python3 skills/agent-registry/scripts/registry-service.py`
+
+## Registering Claude Code instances
+
+Add the SessionStart hook to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [
+        { "type": "command",
+          "command": "bash skills/agent-registry/hooks/session-start.sh" }
+      ] }
+    ]
+  }
+}
+```
+
+On session start the hook backgrounds `registry-client.py watch`, which
+registers the instance, heartbeats every 30s, and deregisters when the session
+ends. If it is killed ungracefully the entry ages out via heartbeat staleness
+(`> 90s` → `stale`; stopped/stale rows are pruned after 1h).
+
+## HTTP API
+
+| Method | Path          | Body                          | Returns                  |
+|--------|---------------|-------------------------------|--------------------------|
+| POST   | `/register`   | `{name, cwd, pid, host?, meta?}` | `{id}`                |
+| POST   | `/heartbeat`  | `{id}`                        | `{ok, status}`           |
+| POST   | `/deregister` | `{id}`                        | `{ok}`                   |
+| GET    | `/agents`     | —                             | `{agents:[...], count}`  |
+| GET    | `/health`     | —                             | `{ok, count, uptime}`    |
+
+Each agent record: `id, name, cwd, pid, host, started_at, last_heartbeat,
+heartbeat_age, status, meta`. `status` is `active` / `stale` / `stopped`.
+
+## CLI quick reference
+
+```bash
+C=skills/agent-registry/scripts/registry-client.py
+python3 $C list                                  # show the registry
+python3 $C register --name claude-code --pid $$  # register (prints id)
+python3 $C heartbeat  --id <ID>
+python3 $C deregister --id <ID>
+python3 $C watch --name claude-code --pid <PID> --autostart   # used by the hook
+```
+
+## Other agents (Kimi Code, etc.)
+
+The service is agent-agnostic — `name` is free-form, so any agent registers the
+same way (`--name kimi-code`). What is agent-specific is the *registration
+trigger*: Claude Code uses a SessionStart hook; another agent needs its own
+equivalent (a startup hook, plugin, or a launch-command wrapper that runs
+`registry-client.py watch`).
+
+## Optional: AG2 Hub mirroring
+
+To announce registry state to an AG2 hub, a future extension can open a
+`RemoteHubClient` (`ag2_workforce.hub.client`) and post agent join/leave events.
+This is deliberately *not* in the core service — it stays dependency-free and
+local-first. Add it as a separate module that subscribes to registry changes.

--- a/skills/agent-registry/hooks/session-start.sh
+++ b/skills/agent-registry/hooks/session-start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Claude Code SessionStart hook — Agent Registry registration.
+#
+# Registers this Claude Code instance with the local Agent Registry service
+# and heartbeats until the session ends. The service is auto-started if it is
+# not already running (--autostart).
+#
+# Install: add to .claude/settings.json under hooks.SessionStart, e.g.
+#   { "hooks": { "SessionStart": [
+#       { "hooks": [ { "type": "command",
+#         "command": "bash <skill>/hooks/session-start.sh" } ] } ] } }
+#
+# The registration process is backgrounded so it never delays session start.
+# It lives in the session's process group: when Claude Code exits, it receives
+# SIGTERM and deregisters cleanly. If it is killed ungracefully, the registry
+# ages the entry out via heartbeat staleness instead.
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 "$SKILL_DIR/scripts/registry-client.py" watch \
+  --name "claude-code" \
+  --cwd "${CLAUDE_PROJECT_DIR:-$PWD}" \
+  --pid "$PPID" \
+  --interval 30 \
+  --autostart \
+  >/dev/null 2>&1 &
+
+exit 0

--- a/skills/agent-registry/scripts/registry-client.py
+++ b/skills/agent-registry/scripts/registry-client.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Agent Registry client / CLI.
+
+Used by the Claude Code SessionStart hook to register an instance and keep it
+heartbeating, and usable by hand to inspect the registry.
+
+Commands:
+  register   --name --cwd --pid [--meta JSON] [--autostart]   -> prints id
+  heartbeat  --id ID
+  deregister --id ID
+  list                                                        -> table
+  watch      --name --cwd --pid [--interval N] [--autostart]
+             register, then heartbeat until the watched pid exits, then
+             deregister. This is the one-shot command the hook backgrounds.
+
+The service is located via the discovery file written by registry-service.py
+(<workspace>/state/agent-registry.json). With --autostart, the client launches
+the service detached if it is not already running.
+"""
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SERVICE = os.path.join(SCRIPT_DIR, "registry-service.py")
+
+
+def resolve_workspace():
+    env = os.environ.get("SUTANDO_WORKSPACE")
+    if env:
+        return os.path.abspath(os.path.expanduser(env))
+    return os.path.expanduser("~/.sutando/workspace")
+
+
+WORKSPACE = resolve_workspace()
+DISCOVERY_PATH = os.path.join(WORKSPACE, "state", "agent-registry.json")
+
+
+def read_discovery():
+    try:
+        with open(DISCOVERY_PATH) as fh:
+            return json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+
+
+def http(method, url, payload=None, timeout=4):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read() or b"{}")
+
+
+def service_url(autostart=False):
+    """Return a base URL for a healthy service, starting it if asked."""
+    disc = read_discovery()
+    if disc and _healthy(disc["url"]):
+        return disc["url"]
+    if not autostart:
+        return None
+    return _start_service()
+
+
+def _healthy(base):
+    try:
+        return http("GET", base + "/health", timeout=2).get("ok") is True
+    except (urllib.error.URLError, OSError, ValueError):
+        return False
+
+
+def _start_service():
+    log_dir = os.path.join(WORKSPACE, "logs")
+    os.makedirs(log_dir, exist_ok=True)
+    log = open(os.path.join(log_dir, "agent-registry.log"), "a")
+    subprocess.Popen(
+        [sys.executable, SERVICE],
+        stdout=log,
+        stderr=log,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,  # survives the Claude session that spawned it
+    )
+    for _ in range(50):  # wait up to ~5s for the service to come up
+        time.sleep(0.1)
+        disc = read_discovery()
+        if disc and _healthy(disc["url"]):
+            return disc["url"]
+    return None
+
+
+def pid_alive(pid):
+    """True if pid is running. A pid of 0/None means 'nothing to watch'."""
+    if not pid or pid <= 0:
+        return True
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by another user
+    except OSError:
+        return False
+
+
+def cmd_register(args, base):
+    meta = {}
+    if args.meta:
+        try:
+            meta = json.loads(args.meta)
+        except json.JSONDecodeError:
+            print("warning: --meta is not valid JSON, ignoring", file=sys.stderr)
+    result = http("POST", base + "/register", {
+        "name": args.name,
+        "cwd": args.cwd or os.getcwd(),
+        "pid": args.pid,
+        "host": os.uname().nodename,
+        "meta": meta,
+    })
+    return result.get("id")
+
+
+def cmd_watch(args, base):
+    agent_id = cmd_register(args, base)
+    if not agent_id:
+        print("watch: registration failed", file=sys.stderr)
+        return 1
+    print(agent_id, flush=True)
+    interval = max(5, args.interval)
+    try:
+        while pid_alive(args.pid):
+            time.sleep(interval)
+            if not pid_alive(args.pid):
+                break
+            try:
+                http("POST", base + "/heartbeat", {"id": agent_id})
+            except (urllib.error.URLError, OSError):
+                pass  # transient — keep trying
+    finally:
+        try:
+            http("POST", base + "/deregister", {"id": agent_id})
+        except (urllib.error.URLError, OSError):
+            pass
+    return 0
+
+
+def cmd_list(base):
+    data = http("GET", base + "/agents")
+    agents = data.get("agents", [])
+    if not agents:
+        print("(no agents registered)")
+        return
+    print(f"{'STATUS':<8} {'NAME':<16} {'PID':<8} {'HB AGE':<8} CWD")
+    for a in agents:
+        print(
+            f"{a['status']:<8} {a['name']:<16} {str(a['pid']):<8} "
+            f"{str(a['heartbeat_age'])+'s':<8} {a.get('cwd') or ''}"
+        )
+
+
+def main():
+    p = argparse.ArgumentParser(description="Agent Registry client")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    for name in ("register", "watch"):
+        sp = sub.add_parser(name)
+        sp.add_argument("--name", default="claude-code")
+        sp.add_argument("--cwd", default=None)
+        sp.add_argument("--pid", type=int, default=0)
+        sp.add_argument("--meta", default=None)
+        sp.add_argument("--autostart", action="store_true")
+        if name == "watch":
+            sp.add_argument("--interval", type=int, default=30)
+
+    sp = sub.add_parser("heartbeat")
+    sp.add_argument("--id", required=True)
+    sp = sub.add_parser("deregister")
+    sp.add_argument("--id", required=True)
+    sub.add_parser("list")
+
+    args = p.parse_args()
+
+    # SIGTERM -> clean exit so cmd_watch's finally deregisters the agent when
+    # the Claude session's process group is torn down.
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+
+    autostart = getattr(args, "autostart", False)
+    base = service_url(autostart=autostart)
+    if base is None:
+        print("agent-registry service not reachable", file=sys.stderr)
+        return 2
+
+    if args.command == "register":
+        agent_id = cmd_register(args, base)
+        if not agent_id:
+            return 1
+        print(agent_id)
+        return 0
+    if args.command == "watch":
+        return cmd_watch(args, base)
+    if args.command == "heartbeat":
+        http("POST", base + "/heartbeat", {"id": args.id})
+        return 0
+    if args.command == "deregister":
+        http("POST", base + "/deregister", {"id": args.id})
+        return 0
+    if args.command == "list":
+        cmd_list(base)
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/agent-registry/scripts/registry-service.py
+++ b/skills/agent-registry/scripts/registry-service.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Local Agent Registry service.
+
+A standalone, dependency-free local service that tracks running Claude Code
+agents. Claude Code instances register themselves on startup (via the
+SessionStart hook) and heartbeat while alive; consumers — the Electron overlay,
+the dashboard — read the live list over a localhost HTTP API.
+
+This is intentionally NOT the AG2 Workforce Hub app. It is a thin local
+service. Hub mirroring (announcing registry state to an AG2 hub via
+``ag2_workforce.hub.client``) is an optional, separable extension — see
+SKILL.md — and is deliberately left out of this core service.
+
+Design notes:
+  * stdlib only (http.server + sqlite3) — no pip install, ever.
+  * binds 127.0.0.1 only; never exposed off-host.
+  * writes a discovery file so clients find the port without hardcoding it.
+
+API:
+  POST /register    {name, cwd, pid, host?, meta?}  -> {id}
+  POST /heartbeat   {id}                            -> {ok, status}
+  POST /deregister  {id}                            -> {ok}
+  GET  /agents                                      -> {agents: [...]}
+  GET  /health                                      -> {ok, count, uptime}
+"""
+
+import json
+import os
+import sqlite3
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+HOST = "127.0.0.1"
+DEFAULT_PORT = 7847
+PORT_RANGE = 20  # try DEFAULT_PORT .. DEFAULT_PORT+PORT_RANGE
+
+STALE_SECS = 90      # no heartbeat for this long -> "stale"
+PRUNE_SECS = 3600    # stopped/stale rows older than this are deleted
+
+STARTED_AT = time.time()
+
+
+def resolve_workspace():
+    """Resolve the Sutando workspace per the workspace contract (CLAUDE.md)."""
+    env = os.environ.get("SUTANDO_WORKSPACE")
+    if env:
+        return os.path.abspath(os.path.expanduser(env))
+    return os.path.expanduser("~/.sutando/workspace")
+
+
+WORKSPACE = resolve_workspace()
+DB_PATH = os.path.join(WORKSPACE, "data", "agent-registry.db")
+DISCOVERY_PATH = os.path.join(WORKSPACE, "state", "agent-registry.json")
+
+_db_lock = threading.Lock()
+_db = None
+
+
+def db():
+    global _db
+    if _db is None:
+        os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+        _db = sqlite3.connect(DB_PATH, check_same_thread=False)
+        _db.row_factory = sqlite3.Row
+        _db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agents (
+                id             TEXT PRIMARY KEY,
+                name           TEXT NOT NULL,
+                cwd            TEXT,
+                pid            INTEGER,
+                host           TEXT,
+                started_at     REAL NOT NULL,
+                last_heartbeat REAL NOT NULL,
+                status         TEXT NOT NULL,
+                meta           TEXT
+            )
+            """
+        )
+        _db.commit()
+    return _db
+
+
+def now():
+    return time.time()
+
+
+def make_id(name, pid):
+    return f"{name}-{pid}-{int(now())}-{os.urandom(2).hex()}"
+
+
+def row_to_agent(row):
+    age = now() - row["last_heartbeat"]
+    status = row["status"]
+    if status != "stopped" and age > STALE_SECS:
+        status = "stale"
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "cwd": row["cwd"],
+        "pid": row["pid"],
+        "host": row["host"],
+        "started_at": row["started_at"],
+        "last_heartbeat": row["last_heartbeat"],
+        "heartbeat_age": round(age, 1),
+        "status": status,
+        "meta": json.loads(row["meta"]) if row["meta"] else {},
+    }
+
+
+def prune(conn):
+    cutoff = now() - PRUNE_SECS
+    conn.execute(
+        "DELETE FROM agents WHERE last_heartbeat < ? "
+        "AND status IN ('stopped','stale')",
+        (cutoff,),
+    )
+
+
+# --- API operations (all guarded by _db_lock) ----------------------------
+
+def op_register(body):
+    name = (body.get("name") or "agent").strip()
+    pid = int(body.get("pid") or 0)
+    agent_id = body.get("id") or make_id(name, pid)
+    ts = now()
+    with _db_lock:
+        conn = db()
+        conn.execute(
+            """
+            INSERT INTO agents
+                (id, name, cwd, pid, host, started_at, last_heartbeat, status, meta)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?)
+            ON CONFLICT(id) DO UPDATE SET
+                name=excluded.name, cwd=excluded.cwd, pid=excluded.pid,
+                host=excluded.host, last_heartbeat=excluded.last_heartbeat,
+                status='active', meta=excluded.meta
+            """,
+            (
+                agent_id, name, body.get("cwd"), pid, body.get("host"),
+                ts, ts, json.dumps(body.get("meta") or {}),
+            ),
+        )
+        conn.commit()
+    return {"ok": True, "id": agent_id}
+
+
+def op_heartbeat(body):
+    agent_id = body.get("id")
+    if not agent_id:
+        return {"ok": False, "error": "missing id"}, 400
+    with _db_lock:
+        conn = db()
+        cur = conn.execute(
+            "UPDATE agents SET last_heartbeat=?, status='active' "
+            "WHERE id=? AND status!='stopped'",
+            (now(), agent_id),
+        )
+        conn.commit()
+        if cur.rowcount == 0:
+            return {"ok": False, "error": "unknown id"}, 404
+    return {"ok": True, "status": "active"}
+
+
+def op_deregister(body):
+    agent_id = body.get("id")
+    if not agent_id:
+        return {"ok": False, "error": "missing id"}, 400
+    with _db_lock:
+        conn = db()
+        conn.execute(
+            "UPDATE agents SET status='stopped', last_heartbeat=? WHERE id=?",
+            (now(), agent_id),
+        )
+        conn.commit()
+    return {"ok": True}
+
+
+def op_agents():
+    with _db_lock:
+        conn = db()
+        prune(conn)
+        conn.commit()
+        rows = conn.execute(
+            "SELECT * FROM agents ORDER BY started_at DESC"
+        ).fetchall()
+    agents = [row_to_agent(r) for r in rows]
+    return {"agents": agents, "count": len(agents)}
+
+
+def op_health():
+    with _db_lock:
+        conn = db()
+        n = conn.execute("SELECT COUNT(*) AS c FROM agents").fetchone()["c"]
+    return {"ok": True, "count": n, "uptime": round(now() - STARTED_AT, 1)}
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args):
+        pass  # quiet — this is a background service
+
+    def _send(self, payload, code=200):
+        data = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _body(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        if not length:
+            return {}
+        try:
+            return json.loads(self.rfile.read(length) or b"{}")
+        except json.JSONDecodeError:
+            return {}
+
+    def do_GET(self):
+        if self.path == "/agents":
+            self._send(op_agents())
+        elif self.path == "/health":
+            self._send(op_health())
+        else:
+            self._send({"error": "not found"}, 404)
+
+    def do_POST(self):
+        try:
+            body = self._body()
+            if self.path == "/register":
+                self._send(op_register(body))
+            elif self.path == "/heartbeat":
+                result = op_heartbeat(body)
+                self._send(*result) if isinstance(result, tuple) else self._send(result)
+            elif self.path == "/deregister":
+                result = op_deregister(body)
+                self._send(*result) if isinstance(result, tuple) else self._send(result)
+            else:
+                self._send({"error": "not found"}, 404)
+        except Exception as exc:  # never let a bad request kill the thread
+            self._send({"error": str(exc)}, 500)
+
+
+def write_discovery(port):
+    os.makedirs(os.path.dirname(DISCOVERY_PATH), exist_ok=True)
+    tmp = DISCOVERY_PATH + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(
+            {
+                "host": HOST,
+                "port": port,
+                "pid": os.getpid(),
+                "url": f"http://{HOST}:{port}",
+                "started_at": STARTED_AT,
+            },
+            fh,
+        )
+    os.replace(tmp, DISCOVERY_PATH)
+
+
+def remove_discovery():
+    try:
+        os.unlink(DISCOVERY_PATH)
+    except FileNotFoundError:
+        pass
+
+
+def main():
+    server = None
+    for port in range(DEFAULT_PORT, DEFAULT_PORT + PORT_RANGE):
+        try:
+            server = ThreadingHTTPServer((HOST, port), Handler)
+            break
+        except OSError:
+            continue
+    if server is None:
+        print("agent-registry: no free port found", file=sys.stderr)
+        sys.exit(1)
+
+    bound_port = server.server_address[1]
+    write_discovery(bound_port)
+    print(f"agent-registry listening on http://{HOST}:{bound_port}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        remove_discovery()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds infrastructure for tracking running agent instances and managing desktop overlays from the Sutando web UI. Three related pieces, one commit each:

- **`skills/agent-registry/`** — a standalone, dependency-free local service that tracks running Claude Code (and other) agent instances. stdlib-only HTTP service + SQLite store, a CLI client (`register`/`heartbeat`/`deregister`/`list`/`watch` with `--autostart`), and a Claude Code SessionStart hook for self-registration + heartbeat. Not the AG2 Workforce Hub app — a thin, local-first service that can optionally mirror state to a hub later.
- **`src/overlay-manager-ui.ts` + `src/web-client.ts`** — an `/overlays` management view listing the desktop overlay applications with open/close/show/hide and opacity/always-on-top controls. `web-client` proxies `/api/overlays/*` to the overlay app's control server (located via a discovery file), so the browser needs no CORS or port handling.
- **`skills/electron-overlay-dimming/`** — documents the focus-based overlay auto-dimming pattern as a reusable skill.

## Testing

- Agent registry: register / list / heartbeat / deregister / `watch --autostart` all verified end-to-end; SessionStart hook tested.
- Overlay manager: list / open / close / show / hide / config verified through the web UI proxy.

## Notes

- The companion Electron overlay app lives in a separate local project (`~/projects/benchmark-overlay`) and is not part of this repo/PR.
- The SessionStart hook is installed per-user via `.claude/settings.local.json` (gitignored) — not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)