### PR TITLE
fix(discord-bridge): REST catch-up missed DMs on reconnect (restart-safety)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2019,6 +2019,11 @@ client = discord.Client(intents=intents)
 @client.event
 async def on_ready():
     print(f"Discord bridge ready: {client.user}")
+    # Restart-safety: REST-catch-up missed DMs from the disconnect
+    # window. Discord gateway IDENTIFY (post-RESUME-expiry reconnect)
+    # does NOT replay `MESSAGE_CREATE` events that arrived during the
+    # gap. See `_catchup_missed_dms` for the replay flow.
+    client.loop.create_task(_catchup_missed_dms())
     # Start polling loops
     client.loop.create_task(poll_results())
     client.loop.create_task(poll_approved())
@@ -2101,6 +2106,18 @@ async def _handle_discord_message(message, force=False):
     text = message.content or ""
     is_dm = isinstance(message.channel, discord.DMChannel)
     channel_name = getattr(message.channel, 'name', 'DM')
+
+    # Advance the DM checkpoint immediately for any DM we observe —
+    # whether or not we end up processing it as an owner task. The
+    # checkpoint's purpose is "REST-catch-up should not re-replay this
+    # ID on the next reconnect"; recording it now (before downstream
+    # filters drop the message) avoids the catch-up loop replaying
+    # the same out-of-allowlist / out-of-tier message forever.
+    if is_dm and hasattr(message, "id"):
+        try:
+            _update_dm_checkpoint(message.channel.id, message.id)
+        except Exception as e:
+            print(f"  [dm-checkpoint] update failed: {e}", flush=True)
 
     print(f"  [msg] #{channel_name} @{username}: {text[:80]} (mentions: {[str(m) for m in message.mentions]}, is_dm: {is_dm}, embeds: {len(message.embeds)}, type: {message.type}, ref: {message.reference is not None})", flush=True)
     # Debug: log message snapshots for forwarded messages
@@ -2739,6 +2756,105 @@ async def poll_approved():
         except Exception as e:
             print(f"  Approved poll error: {e}")
         await asyncio.sleep(3)
+
+
+# Discord gateway disconnect that outlasts the RESUME window forces
+# discord.py into a full IDENTIFY reconnect — and IDENTIFY does NOT
+# replay `MESSAGE_CREATE` events that arrived during the gap. They're
+# lost. Real incident pattern: a >75-minute disconnect strands an
+# owner DM; the next morning the bridge has no record of it.
+#
+# The fix: track the last DM message ID we observed per channel, and
+# on every `on_ready` (which fires on full reconnect), REST-fetch
+# messages since the checkpoint and replay them through
+# `_handle_discord_message`. Discord message IDs are Snowflake-
+# monotonic so `after=<id>` reliably returns only newer messages.
+DM_CHECKPOINT_FILE = REPO / "state" / "discord-dm-checkpoint.json"
+
+def _atomic_write_dm_checkpoint(data: dict) -> None:
+    """Write JSON atomically — same shape as _atomic_write_pending_replies."""
+    try:
+        DM_CHECKPOINT_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = DM_CHECKPOINT_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(data))
+        tmp.replace(DM_CHECKPOINT_FILE)
+    except Exception:
+        pass
+
+
+def _load_dm_checkpoint() -> dict:
+    """Read `state/discord-dm-checkpoint.json`. Maps
+    `channel_id (str) → last_processed_message_id (str)`. Returns
+    `{}` on missing/malformed file (fail-open)."""
+    try:
+        if not DM_CHECKPOINT_FILE.exists():
+            return {}
+        data = json.loads(DM_CHECKPOINT_FILE.read_text())
+        if not isinstance(data, dict):
+            return {}
+        return {
+            str(k): str(v)
+            for k, v in data.items()
+            if isinstance(v, (str, int))
+        }
+    except Exception:
+        return {}
+
+
+def _update_dm_checkpoint(channel_id: int, message_id: int) -> None:
+    """Atomically advance the per-channel checkpoint to `message_id`.
+    Only writes if the new id is strictly greater (forward-only)."""
+    current = _load_dm_checkpoint()
+    new_id_str = str(message_id)
+    channel_str = str(channel_id)
+    old_id_str = current.get(channel_str, "0")
+    try:
+        if int(new_id_str) <= int(old_id_str):
+            return
+    except (ValueError, TypeError):
+        pass
+    current[channel_str] = new_id_str
+    _atomic_write_dm_checkpoint(current)
+
+
+async def _catchup_missed_dms():
+    """Restart-safety: on full reconnect (after gateway IDENTIFY),
+    replay any DM messages that arrived during the disconnect window.
+
+    For each channel in the DM checkpoint, fetch messages with
+    `after=<last_seen_id>` via Discord REST and dispatch each one
+    through `_handle_discord_message`. Bounded at 50 messages per
+    channel per pass.
+    """
+    checkpoint = _load_dm_checkpoint()
+    if not checkpoint:
+        return
+    for channel_id_str, last_seen_str in checkpoint.items():
+        try:
+            channel = client.get_channel(int(channel_id_str))
+            if channel is None:
+                try:
+                    channel = await client.fetch_channel(int(channel_id_str))
+                except Exception as e:
+                    print(f"  [dm-catchup] could not resolve channel {channel_id_str}: {e}", flush=True)
+                    continue
+            if not isinstance(channel, discord.DMChannel):
+                continue
+            after_obj = discord.Object(id=int(last_seen_str))
+            replayed = 0
+            async for msg in channel.history(after=after_obj, limit=50, oldest_first=True):
+                # Checkpoint advancement happens inside
+                # `_handle_discord_message` for any DM.
+                try:
+                    await _handle_discord_message(msg)
+                    replayed += 1
+                except Exception as e:
+                    print(f"  [dm-catchup] replay failed for msg {msg.id}: {e}", flush=True)
+                    break
+            if replayed:
+                print(f"  [dm-catchup] replayed {replayed} missed DM(s) on channel {channel_id_str}", flush=True)
+        except Exception as e:
+            print(f"  [dm-catchup] channel {channel_id_str} failed: {e}", flush=True)
 
 
 PENDING_REPLIES_FILE = REPO / "state" / "discord-pending-replies.json"

--- a/tests/discord-bridge-dm-catchup.test.py
+++ b/tests/discord-bridge-dm-catchup.test.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Regression guard for restart-safety #2: Discord REST-catch-up of
+missed DMs after a gateway IDENTIFY reconnect.
+
+## The bug (the one that hit Vasiliy on 2026-05-21)
+
+Discord gateway disconnect that outlasts the RESUME window forces
+discord.py into a full IDENTIFY reconnect. IDENTIFY does NOT replay
+`MESSAGE_CREATE` events that arrived during the gap — they're lost.
+
+Real incident: 21:14 PT, owner sent "B + A in that order" via Discord
+DM during a >75-minute disconnect. Next morning the bridge had no
+record of it; the message was only recoverable via manual REST fetch.
+
+## The fix
+
+Track the last DM message ID we successfully observed per channel in
+`state/discord-dm-checkpoint.json`. On every `on_ready` (full
+reconnect after gateway IDENTIFY), call `_catchup_missed_dms()`
+which REST-fetches messages with `after=<last_seen_id>` from each
+checkpointed channel and replays them through `_handle_discord_message`.
+Discord message IDs are Snowflake-monotonic so `after=<id>` is
+reliable.
+
+## What this test covers
+
+The checkpoint storage (read/write/advance semantics) is pure I/O and
+fully testable. The catch-up loop itself requires discord.py
+mocking which is more involved — we exercise the pure parts directly
+and source-grep-assert the wiring.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Set workspace BEFORE importing the bridge — it captures state-file
+# paths at module-load time.
+_WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-dm-catchup-test-")
+os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
+(Path(_WORKSPACE_TMP) / "state").mkdir(parents=True, exist_ok=True)
+
+
+def _load(name: str, path: Path):
+    if "discord" not in sys.modules:
+        stub = types.ModuleType("discord")
+        stub.Intents = type("Intents", (), {"default": staticmethod(lambda: type("I", (), {"message_content": False})())})
+        stub.Client = type("Client", (), {"__init__": lambda self, **kw: None, "event": staticmethod(lambda fn: fn)})
+        stub.File = type("File", (), {})
+        stub.DMChannel = type("DMChannel", (), {})
+        stub.Object = lambda id: type("Object", (), {"id": id})()
+        sys.modules["discord"] = stub
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+bridge = _load("discord_bridge", REPO / "src" / "discord-bridge.py")
+
+
+def _clear_checkpoint():
+    """Remove the checkpoint file between tests."""
+    f = bridge.DM_CHECKPOINT_FILE
+    if f.exists():
+        f.unlink()
+
+
+def test_load_returns_empty_when_file_missing():
+    """Fail-open: a missing checkpoint file returns `{}`. Catch-up
+    becomes a no-op (no channels to scan), but the bridge starts."""
+    _clear_checkpoint()
+    assert bridge._load_dm_checkpoint() == {}
+
+
+def test_load_returns_empty_on_malformed_json():
+    """Same fail-open shape: corrupt file → empty checkpoint, not crash."""
+    _clear_checkpoint()
+    bridge.DM_CHECKPOINT_FILE.write_text("{ this is not json")
+    assert bridge._load_dm_checkpoint() == {}
+
+
+def test_load_returns_empty_on_non_dict_root():
+    """`null`, lists, strings at the root level — all fail-open."""
+    _clear_checkpoint()
+    bridge.DM_CHECKPOINT_FILE.write_text('["not", "a", "dict"]')
+    assert bridge._load_dm_checkpoint() == {}
+
+
+def test_update_advances_forward_only():
+    """Checkpoint advances monotonically — older IDs are ignored
+    (handles the catch-up replay case where messages are processed
+    in any order but the checkpoint only moves forward)."""
+    _clear_checkpoint()
+    bridge._update_dm_checkpoint(channel_id=12345, message_id=100)
+    bridge._update_dm_checkpoint(channel_id=12345, message_id=200)
+    bridge._update_dm_checkpoint(channel_id=12345, message_id=150)  # backwards
+    bridge._update_dm_checkpoint(channel_id=12345, message_id=50)   # way backwards
+    cp = bridge._load_dm_checkpoint()
+    assert cp.get("12345") == "200", (
+        f"checkpoint should be at 200 (highest seen), got {cp.get('12345')!r}"
+    )
+
+
+def test_update_per_channel_independent():
+    """Multiple channels track independently — checkpoint shape is
+    `{channel_id: last_msg_id}` so two channels don't shadow each
+    other."""
+    _clear_checkpoint()
+    bridge._update_dm_checkpoint(channel_id=111, message_id=1000)
+    bridge._update_dm_checkpoint(channel_id=222, message_id=2000)
+    bridge._update_dm_checkpoint(channel_id=111, message_id=1500)
+    cp = bridge._load_dm_checkpoint()
+    assert cp.get("111") == "1500"
+    assert cp.get("222") == "2000"
+
+
+def test_update_persists_atomically():
+    """Atomic-write contract: file is never empty/corrupt mid-write.
+    Exercise the tmp+rename path indirectly by writing and reading."""
+    _clear_checkpoint()
+    bridge._update_dm_checkpoint(channel_id=42, message_id=9999)
+    # Direct file read (bypassing the loader) to confirm the on-disk
+    # content is valid JSON.
+    raw = bridge.DM_CHECKPOINT_FILE.read_text()
+    parsed = json.loads(raw)
+    assert parsed.get("42") == "9999"
+
+
+def test_update_handles_string_message_id():
+    """Defensive: message ids from Discord arrive as ints. If a
+    future caller passes a string, the int comparison must still work."""
+    _clear_checkpoint()
+    bridge._update_dm_checkpoint(channel_id=42, message_id=100)
+    # _update_dm_checkpoint signature uses int(message_id) → str
+    # internally. Pin that re-passing the same id is idempotent.
+    bridge._update_dm_checkpoint(channel_id=42, message_id=100)
+    cp = bridge._load_dm_checkpoint()
+    assert cp.get("42") == "100"
+
+
+def test_load_filters_malformed_entries():
+    """Hand-edited checkpoint with bad shape: keep the good entries,
+    drop the bad ones — don't crash, don't lose all state to one
+    bad row."""
+    _clear_checkpoint()
+    bridge.DM_CHECKPOINT_FILE.write_text(json.dumps({
+        "good_channel": "12345",
+        "another_good": "67890",
+        "bad_channel": None,           # not str/int
+        "another_bad": {"nested": "no"},  # not str/int
+    }))
+    cp = bridge._load_dm_checkpoint()
+    assert cp.get("good_channel") == "12345"
+    assert cp.get("another_good") == "67890"
+    assert "bad_channel" not in cp
+    assert "another_bad" not in cp
+
+
+def test_source_wires_catchup_into_on_ready():
+    """Architectural assertion: the catch-up coroutine must be
+    scheduled from `on_ready` so it fires on every reconnect (full
+    IDENTIFY). Without this wiring, the checkpoint advances but
+    nothing replays after a gap. Source-grep so a future refactor
+    that drops the wire fails loudly."""
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    # The exact wiring shape: `client.loop.create_task(_catchup_missed_dms())`
+    # inside the `on_ready` function.
+    import re
+    on_ready_block = re.search(
+        r"async def on_ready\(\):(.*?)(?=^(?:async )?def )",
+        src, re.MULTILINE | re.DOTALL,
+    )
+    assert on_ready_block, "could not locate on_ready in discord-bridge.py"
+    body = on_ready_block.group(1)
+    assert "_catchup_missed_dms" in body, (
+        "on_ready does NOT schedule _catchup_missed_dms — the catch-up "
+        "won't fire on reconnect, leaving the original bug (lost DMs "
+        "during IDENTIFY-reconnect) open."
+    )
+    assert "create_task" in body, (
+        "_catchup_missed_dms must be scheduled via create_task so it "
+        "runs in parallel with the other poll loops (not awaited)."
+    )
+
+
+def test_source_wires_checkpoint_update_into_handler():
+    """Architectural: `_handle_discord_message` must call
+    `_update_dm_checkpoint` for DMs. Without this, the checkpoint
+    never advances and every reconnect tries to replay messages
+    from time 0 (or hits the 50-message limit and loses everything
+    older). Pin via grep."""
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    import re
+    handler_block = re.search(
+        r"async def _handle_discord_message\(.*?\):(.*?)(?=^(?:async )?def )",
+        src, re.MULTILINE | re.DOTALL,
+    )
+    assert handler_block, "could not locate _handle_discord_message"
+    body = handler_block.group(1)
+    assert "_update_dm_checkpoint" in body, (
+        "_handle_discord_message does NOT call _update_dm_checkpoint — "
+        "the catch-up checkpoint will never advance, defeating the fix."
+    )
+
+
+def main():
+    failures = []
+    for fn in (
+        test_load_returns_empty_when_file_missing,
+        test_load_returns_empty_on_malformed_json,
+        test_load_returns_empty_on_non_dict_root,
+        test_update_advances_forward_only,
+        test_update_per_channel_independent,
+        test_update_persists_atomically,
+        test_update_handles_string_message_id,
+        test_load_filters_malformed_entries,
+        test_source_wires_catchup_into_on_ready,
+        test_source_wires_checkpoint_update_into_handler,
+    ):
+        try:
+            fn()
+            print(f"  ✓ {fn.__name__}")
+        except AssertionError as e:
+            failures.append(f"{fn.__name__}: {e}")
+            print(f"  ✗ {fn.__name__}")
+    if failures:
+        print("\nFailures:")
+        for f in failures:
+            print(f"  {f}")
+        sys.exit(1)
+    print("All DM-catchup tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The bug

Discord gateway disconnect that outlasts the RESUME window forces discord.py into a full IDENTIFY reconnect. **IDENTIFY does NOT replay `MESSAGE_CREATE` events that arrived during the gap** — they're LOST.

The window is short: any network blip / ngrok hiccup that exceeds the RESUME window (tens of seconds) is enough. Symptom is silence — the bridge never sees the message, no operator signal, recovery requires manual REST fetch.

## Fix

Per-channel checkpoint in `state/discord-dm-checkpoint.json` mapping `channel_id → last_observed_message_id`. Discord message IDs are Snowflake-monotonic so `after=<id>` is a reliable cursor.

| Component | Purpose |
|---|---|
| `_update_dm_checkpoint` | Atomic tmp+rename; forward-only advance |
| `_load_dm_checkpoint` | Fail-open on missing/corrupt |
| `_handle_discord_message` | Advances checkpoint for every DM (before filters) |
| `_catchup_missed_dms()` | REST-fetches `after=<last_id>` per channel; dispatches each through handler. Scheduled from `on_ready` |

`on_ready` fires on IDENTIFY (not RESUME), so catch-up triggers exactly when prior-session gaps could have produced losses. Bounded at 50 messages per channel per pass.

## Tests

`tests/discord-bridge-dm-catchup.test.py` — 10 cases. Checkpoint storage + architectural source-grep wiring assertions.

All 10 pass locally.

## Test plan

- [x] `python3 tests/discord-bridge-dm-catchup.test.py` — 10/10 pass
- [ ] Manual: stop discord-bridge.py, send a DM, wait 1 min, restart bridge. Verify a task file appears for the missed DM and processing happens normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)