### PR TITLE
feat(task-bridge): attempts counter on task files (restart-safety)

### DIFF
--- a/src/task_bump_attempts.py
+++ b/src/task_bump_attempts.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Bump the `attempts:` counter on a task file (restart-safety #4).
+
+Called by `src/watch-tasks-stream.sh` before each `TASK_FILE: <name>`
+emit. Implementation notes:
+
+  - Inserts `attempts: 1` BEFORE the `task:` delimiter line for fresh
+    tasks (no existing `attempts:` field).
+  - Increments existing `attempts:` lines by 1.
+  - Position matters: task-file parsers across the codebase stop
+    scanning at `task:` (the body delimiter); fields AFTER `task:`
+    are invisible to them. The counter must precede.
+  - Atomic write via tmp + rename — never leaves a half-written file
+    on disk. On any error, log to stderr and exit 0 (a missed bump
+    is non-fatal; the agent reads a slightly-stale count).
+  - Idempotent on malformed files: a file with no `task:` line is
+    left untouched (defensive — non-task files in tasks/ should not
+    get a phantom `attempts:` header).
+
+Usage:
+  python3 src/task_bump_attempts.py <absolute-path-to-task-file>
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+_ATTEMPTS_RE = re.compile(r"^attempts:\s*(\d+)")
+
+
+def bump_attempts(file_path: Path) -> int:
+    """Bump the `attempts:` counter on `file_path`. Returns the new
+    count (or 0 on no-op / error).
+
+    No-op cases (returns 0, file untouched):
+      - File missing.
+      - File has no `task:` line (malformed / not a task file).
+      - Read/write error.
+    """
+    try:
+        raw = file_path.read_text(encoding="utf-8")
+    except OSError:
+        return 0
+    lines = raw.split("\n")
+    task_idx = next(
+        (i for i, ln in enumerate(lines) if ln.startswith("task:")),
+        -1,
+    )
+    if task_idx < 0:
+        # Not a well-formed task file — leave it alone.
+        return 0
+    attempts_idx = next(
+        (i for i in range(task_idx) if lines[i].startswith("attempts:")),
+        -1,
+    )
+    if attempts_idx >= 0:
+        m = _ATTEMPTS_RE.match(lines[attempts_idx])
+        new_count = (int(m.group(1)) + 1) if m else 1
+        lines[attempts_idx] = f"attempts: {new_count}"
+    else:
+        new_count = 1
+        lines.insert(task_idx, "attempts: 1")
+    updated = "\n".join(lines)
+    try:
+        tmp = file_path.with_suffix(file_path.suffix + ".tmp")
+        tmp.write_text(updated, encoding="utf-8")
+        tmp.replace(file_path)
+    except OSError as e:
+        print(f"[task_bump_attempts] write failed for {file_path}: {e}", file=sys.stderr)
+        return 0
+    return new_count
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: task_bump_attempts.py <task-file-path>", file=sys.stderr)
+        return 2
+    bump_attempts(Path(argv[1]))
+    # Always exit 0 — a missed bump is non-fatal, the watcher must
+    # still emit `TASK_FILE: <name>` for the agent.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -49,8 +49,14 @@ TASKS_DIR_ABS="$(cd "$TASKS_DIR" && pwd -P)"
 
 # Initial sweep — surface any pre-existing tasks that arrived during a
 # restart gap.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 shopt -s nullglob
 for f in "$TASKS_DIR"/*.txt; do
+  # Restart-safety #4: bump the `attempts:` counter BEFORE emit.
+  # Initial-sweep emissions either reflect a fresh-on-disk task or a
+  # leftover from a prior crash; bumping conveys retry-count
+  # semantics to the agent (attempts > 1 → agent treats as retry).
+  python3 "$SCRIPT_DIR/task_bump_attempts.py" "$f" 2>/dev/null || true
   echo "TASK_FILE: $(basename "$f")"
 done
 shopt -u nullglob
@@ -85,6 +91,10 @@ fswatch \
     *.txt)
       parent="$(dirname "$path")"
       if [ "$parent" = "$TASKS_DIR_ABS" ] && [ -f "$path" ]; then
+        # Restart-safety #4: bump `attempts:` BEFORE emit. For
+        # fresh-file events this sets attempts=1; fswatch dedupe
+        # prevents same-session double-bumps from burst events.
+        python3 "$SCRIPT_DIR/task_bump_attempts.py" "$path" 2>/dev/null || true
         echo "TASK_FILE: $(basename "$path")"
       fi
       ;;

--- a/tests/task-bump-attempts.test.py
+++ b/tests/task-bump-attempts.test.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Regression guard for restart-safety #4: task-file `attempts:` counter.
+
+## The bug
+
+If the agent crashes mid-task with non-idempotent side effects already
+executed but the archive of result + task files never ran, on restart
+the task file is still in `tasks/`. The watcher re-emits it and the
+agent re-processes — potentially re-executing the side effect.
+
+## The fix
+
+`src/task_bump_attempts.py` increments an `attempts:` counter on every
+emission. Wired into `src/watch-tasks-stream.sh` (initial sweep + new-
+file event). Insertion point is BEFORE the `task:` delimiter line
+(parsers stop at `task:`; fields after are invisible).
+
+## What this test covers
+
+The bumper script's pure logic. Watcher integration is asserted via
+source-grep so a refactor that drops the bumper call from either of
+the two emit paths fails loudly.
+"""
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "task_bump_attempts", REPO / "src" / "task_bump_attempts.py"
+)
+bumper = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bumper)
+
+TMP = Path(tempfile.mkdtemp(prefix="sutando-bump-attempts-test-"))
+
+
+def _make(name: str, content: str) -> Path:
+    p = TMP / name
+    p.write_text(content)
+    return p
+
+
+def test_fresh_task_gets_attempts_1():
+    """No `attempts:` field present → `attempts: 1` inserted, position
+    must be BEFORE the `task:` line."""
+    p = _make(
+        "fresh.txt",
+        "id: task-1\ntimestamp: 2026-05-22\ntask: do the thing\n",
+    )
+    n = bumper.bump_attempts(p)
+    assert n == 1, f"expected new count 1, got {n}"
+    content = p.read_text()
+    assert "attempts: 1" in content
+    lines = content.split("\n")
+    a_idx = next(i for i, ln in enumerate(lines) if ln.startswith("attempts:"))
+    t_idx = next(i for i, ln in enumerate(lines) if ln.startswith("task:"))
+    assert a_idx < t_idx, (
+        f"attempts: at line {a_idx} but task: at line {t_idx} — "
+        f"parsers stop at task: so attempts must come first"
+    )
+
+
+def test_existing_attempts_increment():
+    p = _make(
+        "retry.txt",
+        "id: task-2\nattempts: 1\ntimestamp: 2026-05-22\ntask: retry me\n",
+    )
+    n = bumper.bump_attempts(p)
+    assert n == 2
+    content = p.read_text()
+    # Exactly one attempts: line
+    attempts_lines = [l for l in content.split("\n") if l.startswith("attempts:")]
+    assert len(attempts_lines) == 1
+    assert attempts_lines[0] == "attempts: 2"
+
+
+def test_high_count_increment():
+    p = _make("high.txt", "id: task-h\nattempts: 47\ntask: many retries\n")
+    n = bumper.bump_attempts(p)
+    assert n == 48
+
+
+def test_missing_task_line_untouched():
+    """Defensive: malformed file (no task: line) is left alone. The
+    bumper should not mangle non-task files that somehow ended up in
+    tasks/."""
+    original = "this is not a task file\nno task line here\n"
+    p = _make("malformed.txt", original)
+    n = bumper.bump_attempts(p)
+    assert n == 0
+    assert p.read_text() == original
+
+
+def test_no_tmp_file_left():
+    """Atomic write: tmp + rename must clean up the .tmp suffix."""
+    p = _make("tmp.txt", "id: task-tmp\ntask: x\n")
+    bumper.bump_attempts(p)
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    assert not tmp.exists(), f".tmp file left on disk: {tmp}"
+
+
+def test_three_sequential_bumps():
+    """Watcher-restart pattern: bump-emit, bump-emit, bump-emit.
+    Counter advances by 1 each time."""
+    p = _make("seq.txt", "id: task-seq\ntask: many bumps\n")
+    assert bumper.bump_attempts(p) == 1
+    assert bumper.bump_attempts(p) == 2
+    assert bumper.bump_attempts(p) == 3
+    content = p.read_text()
+    attempts_lines = [l for l in content.split("\n") if l.startswith("attempts:")]
+    assert len(attempts_lines) == 1
+    assert attempts_lines[0] == "attempts: 3"
+
+
+def test_missing_file_no_error():
+    """Bumper on non-existent file returns 0, doesn't raise."""
+    n = bumper.bump_attempts(TMP / "nonexistent.txt")
+    assert n == 0
+
+
+def test_cli_invocation():
+    """The CLI entry point `python3 src/task_bump_attempts.py <file>`
+    must work — that's what the .sh watcher calls."""
+    p = _make("cli.txt", "id: task-cli\ntask: cli call\n")
+    res = subprocess.run(
+        [sys.executable, str(REPO / "src" / "task_bump_attempts.py"), str(p)],
+        capture_output=True, text=True, timeout=5,
+    )
+    assert res.returncode == 0, f"CLI exited {res.returncode}, stderr={res.stderr}"
+    assert "attempts: 1" in p.read_text()
+
+
+def test_watcher_wires_bumper_in_initial_sweep_and_stream():
+    """Architectural source-grep: the watcher must invoke the bumper
+    BOTH from the initial-sweep loop AND from the fswatch stream
+    callback. Without both, one of the two emit paths breaks the
+    contract (fresh-emit vs restart-emit)."""
+    src = (REPO / "src" / "watch-tasks-stream.sh").read_text()
+    bumper_calls = src.count("task_bump_attempts.py")
+    assert bumper_calls >= 2, (
+        f"Expected >=2 calls to task_bump_attempts.py in the watcher "
+        f"(initial sweep + stream branch); found {bumper_calls}."
+    )
+    # Position check: split on the actual fswatch command (start-of-line
+    # `fswatch \`), not the word in comments. One call must precede
+    # (initial sweep loop), the other must follow (stream callback).
+    import re
+    split = re.search(r"^fswatch\s+\\$", src, re.MULTILINE)
+    assert split, "could not locate `fswatch \\` command line"
+    sweep_section = src[:split.start()]
+    stream_section = src[split.start():]
+    assert "task_bump_attempts.py" in sweep_section, (
+        "initial sweep loop does NOT call task_bump_attempts.py"
+    )
+    assert "task_bump_attempts.py" in stream_section, (
+        "fswatch stream branch does NOT call task_bump_attempts.py"
+    )
+
+
+def main():
+    failures = []
+    for fn in (
+        test_fresh_task_gets_attempts_1,
+        test_existing_attempts_increment,
+        test_high_count_increment,
+        test_missing_task_line_untouched,
+        test_no_tmp_file_left,
+        test_three_sequential_bumps,
+        test_missing_file_no_error,
+        test_cli_invocation,
+        test_watcher_wires_bumper_in_initial_sweep_and_stream,
+    ):
+        try:
+            fn()
+            print(f"  ✓ {fn.__name__}")
+        except AssertionError as e:
+            failures.append(f"{fn.__name__}: {e}")
+            print(f"  ✗ {fn.__name__}")
+        except Exception as e:
+            failures.append(f"{fn.__name__}: {type(e).__name__}: {e}")
+            print(f"  ✗ {fn.__name__}")
+    if failures:
+        print("\nFailures:")
+        for f in failures:
+            print(f"  {f}")
+        sys.exit(1)
+    print(f"All {9} attempts-counter tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The bug

If the agent crashes mid-task with non-idempotent side effects already executed (Discord message sent, file written, API call made), but the archive of result + task files never ran, on restart the task file is still in `tasks/`. The watcher re-emits it and the agent re-processes — potentially re-executing the side effect.

This PR ships a signal from watcher → agent: \"I think this is a retry.\" Agent-side handling (skip / fold / log) is a separate per-task convention.

## Fix

`src/task_bump_attempts.py` — Python helper that atomically bumps the `attempts:` counter. Wired into `src/watch-tasks-stream.sh` (both initial sweep AND fswatch stream branch):

| Case | Effect |
|---|---|
| Fresh task drop | `attempts: 1` inserted |
| Re-emit (watcher-restart leftover, or fswatch burst-event past dedupe) | counter advances by 1 |

**Insertion point: BEFORE the `task:` delimiter line.** Parsers stop at `task:`, so anything after is invisible — the counter must precede.

**Atomic write**: tmp + rename. Bumper failure is non-fatal.

## What agents should do

Read `attempts:`. If `> 1`, treat as a retry:

- Check delivery sentinels (already wired by the prior idempotency-sentinel PR for `poll_results`) before re-sending messages.
- Inspect prior outputs for the same `task_id`; skip or fold.
- Log the retry for observability.

This PR ships the contract, not the agent-side handling.

## Tests

`tests/task-bump-attempts.test.py` — 9 cases. Bumper semantics (insertion position, atomic write, increments, malformed/missing-file handling, CLI invocation) + architectural source-grep pins.

All 9 pass locally.

## Test plan

- [x] `python3 tests/task-bump-attempts.test.py` — 9/9 pass
- [ ] Manual: drop a test task into `tasks/`, verify `attempts: 1` appears. Restart the watcher, verify it bumps to `attempts: 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)