### PR TITLE
fix(discord-bridge): check DISCORD_BOT_TOKEN env var before .env file

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -66,13 +66,14 @@ except Exception:  # pragma: no cover
     def _push_vision_image(path: str, source: str = "discord") -> bool:  # type: ignore
         return False
 
-# Load token from channels config
-TOKEN = ""
-channels_env = Path.home() / ".claude" / "channels" / "discord" / ".env"
-if channels_env.exists():
-    for line in channels_env.read_text().splitlines():
-        if line.startswith("DISCORD_BOT_TOKEN="):
-            TOKEN = line.split("=", 1)[1].strip()
+# Load token — env var takes precedence (allows test injection without a real .env file)
+TOKEN = os.environ.get("DISCORD_BOT_TOKEN", "")
+if not TOKEN:
+    channels_env = Path.home() / ".claude" / "channels" / "discord" / ".env"
+    if channels_env.exists():
+        for line in channels_env.read_text().splitlines():
+            if line.startswith("DISCORD_BOT_TOKEN="):
+                TOKEN = line.split("=", 1)[1].strip()
 
 if not TOKEN:
     print("DISCORD_BOT_TOKEN not set in ~/.claude/channels/discord/.env")


### PR DESCRIPTION
## Problem

`discord-bridge.py` reads `DISCORD_BOT_TOKEN` exclusively from `~/.claude/channels/discord/.env` at module-load time. There is no fallback to `os.environ`. This causes test suites that inject a stub token via `os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")` to fail with:

```
DISCORD_BOT_TOKEN not set in ~/.claude/channels/discord/.env
```

Affects VasiliyRad PRs #1046 (`bridges-sending-orphan-recovery.test.py`) and #1048 (`discord-bridge-delivery-sentinel.test.py`) — both set the env var before import but the bridge never checked it.

## Fix

Check `os.environ.get("DISCORD_BOT_TOKEN")` first; fall back to the `.env` file. This is the same pattern already used by `telegram-bridge.py` (lines 102–104).

## Impact

- Unblocks CI on #1046 and #1048 (their tests already do the right thing — the bridge just needs to cooperate)
- Operators who set `DISCORD_BOT_TOKEN` as a real env var now get it picked up without needing the file
- No behavior change for existing deployments that use the `.env` file

🤖 Generated with [Claude Code](https://claude.ai/claude-code)