### PR TITLE
refactor(conversation-store): drop triple-encoded sessions JSON + duplicate events (closes #1052)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -762,13 +762,16 @@ async function createVoiceSession(connection: VoiceConnection): Promise<DiscordV
 				console.log(`${ts()} [Tool] ${e.toolName} (${e.execution})`);
 				if (!s._toolIdMap) s._toolIdMap = new Map();
 				s._toolIdMap.set(e.toolCallId, e.toolName);
-				s.events.push({ event: `tool_call:${e.toolName}`, timestamp: new Date().toISOString() });
+				// tool_call event push removed per #1052 — canonical record is
+				// the discord_voice-table row written in onToolResult via
+				// recordToolCall().
 			},
 			onToolResult: (e) => {
 				const toolName = s._toolIdMap?.get(e.toolCallId) || 'unknown';
 				console.log(`${ts()} [Tool] result: ${toolName} (${e.status}, ${e.durationMs}ms)`);
 				s.toolCalls.push({ name: toolName, durationMs: e.durationMs, timestamp: new Date().toISOString() });
-				s.events.push({ event: `tool_result:${toolName}:${e.durationMs}ms`, timestamp: new Date().toISOString() });
+				// tool_result event push removed per #1052 — recordToolCall
+				// below is the canonical write.
 				recordToolCall('discord-voice', toolName, e.durationMs, s.sessionId);
 			},
 			onError: (e) => console.error(`${ts()} [Error] ${e.component}: ${e.error.message} (${e.severity})`),
@@ -819,14 +822,17 @@ async function createVoiceSession(connection: VoiceConnection): Promise<DiscordV
 			if (item.content === lastText) continue;
 			if (item.role === 'user') {
 				s.transcript.push({ role: 'user', text: item.content });
-				s.events.push({ event: `user:${item.content}`, timestamp: new Date().toISOString() });
+				// utterance event push removed per #1052 — canonical record is
+				// the discord_voice-table row written by recordConversation
+				// below. session_events keeps only lifecycle entries to stop
+				// triple-encoding the same utterance.
 				// conversation.log is the primary; write it before the sqlite
 				// mirror so a row never exists in sqlite without a log line.
 				appendConversationLog('discord-user', item.content);
 				recordConversation('discord-user', item.content, s.sessionId);
 			} else if (item.role === 'assistant') {
 				s.transcript.push({ role: 'sutando', text: item.content });
-				s.events.push({ event: `sutando:${item.content}`, timestamp: new Date().toISOString() });
+				// utterance event push removed per #1052 — see comment above.
 				appendConversationLog('discord-agent', item.content);
 				recordConversation('discord-agent', item.content, s.sessionId);
 			}

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -775,14 +775,16 @@ async function createCallSession(params: {
 				// bodhi's onToolResult only provides toolCallId, not toolName.
 				if (!callSession._toolIdMap) callSession._toolIdMap = new Map();
 				callSession._toolIdMap.set(e.toolCallId, e.toolName);
-				callSession.events.push({ event: `tool_call:${e.toolName}`, timestamp: new Date().toISOString() });
+				// tool_call event push removed per #1052 — canonical record is
+				// the phone-table row written in onToolResult via recordToolCall().
 			},
 			onToolResult: (e) => {
 				// Resolve tool name from the map since e.toolName is undefined in onToolResult
 				const toolName = callSession._toolIdMap?.get(e.toolCallId) || 'unknown';
 				console.log(`${ts()} [Tool] result: ${toolName} (${e.status}, ${e.durationMs}ms)`);
 				callSession.toolCalls.push({ name: toolName, durationMs: e.durationMs, timestamp: new Date().toISOString() });
-				callSession.events.push({ event: `tool_result:${toolName}:${e.durationMs}ms`, timestamp: new Date().toISOString() });
+				// tool_result event push removed per #1052 — recordToolCall
+				// below is the canonical write (phone table, kind='tool_call').
 				recordToolCall('phone', toolName, e.durationMs, callSession.sessionId);
 				// Log REC indicator status for recording tools
 				if (toolName === 'record_screen_with_narration' || toolName === 'screen_record' || toolName === 'open_file') {
@@ -876,14 +878,14 @@ async function createCallSession(params: {
 			if (item.content === lastTranscriptText) continue;
 			if (item.role === 'user') {
 				callSession.transcript.push({ role: 'caller', text: item.content });
-				// 12s offset: Gemini STT commits transcript ~12s after the caller actually spoke
-				// (measured via iPad recording comparison on 2026-04-09). Without this, caller
-				// timestamps appear after Sutando's responses in the observability timeline.
-				callSession.events.push({ event: `caller:${item.content}`, timestamp: new Date(Date.now() - 12000).toISOString() });
+				// caller event push removed per #1052 — canonical record is
+				// the phone-table row written via recordConversation (called
+				// elsewhere in this server). session_events keeps only
+				// lifecycle entries to stop triple-encoding utterances.
 				try { appendFileSync(`/tmp/sutando-live-transcript-${callSession.callSid}.txt`, `[${new Date(Date.now() - 12000).toLocaleTimeString('en-US', {hour12:false})}] Caller: ${item.content}\n`); } catch {}
 			} else if (item.role === 'assistant') {
 				callSession.transcript.push({ role: 'sutando', text: item.content });
-				callSession.events.push({ event: `sutando:${item.content}`, timestamp: new Date().toISOString() });
+				// sutando event push removed per #1052 — see comment above.
 				try { appendFileSync(`/tmp/sutando-live-transcript-${callSession.callSid}.txt`, `[${new Date().toLocaleTimeString('en-US', {hour12:false})}] Sutando: ${item.content}\n`); } catch {}
 			}
 		}

--- a/skills/regression-search/scripts/diagnose-call.py
+++ b/skills/regression-search/scripts/diagnose-call.py
@@ -146,23 +146,49 @@ def find_metrics(call_sid: str) -> Optional[dict]:
     try:
         row = conn.execute(
             "SELECT ts_unix, source, session_id, call_sid, caller, is_owner, "
-            "is_meeting, duration_ms, transcript_lines, tool_count, pending_tasks, "
-            "tool_calls, events FROM sessions "
+            "is_meeting, duration_ms, transcript_lines, tool_count, pending_tasks "
+            "FROM sessions "
             "WHERE call_sid = ? OR session_id = ? ORDER BY ts_unix",
             (call_sid, call_sid),
         ).fetchone()
+        if not row:
+            return None
+        # Tool calls now live as surface-table rows with kind='tool_call'
+        # (per #1052 — the redundant sessions.tool_calls JSON column is gone).
+        # Rebuild the list from the matching surface table by session_id.
+        sid = row["session_id"]
+        tool_call_rows = conn.execute(
+            "SELECT ts_unix, text AS name, duration_ms FROM ("
+            "  SELECT ts_unix, text, duration_ms, session_id, kind FROM voice"
+            "  UNION ALL"
+            "  SELECT ts_unix, text, duration_ms, session_id, kind FROM phone"
+            "  UNION ALL"
+            "  SELECT ts_unix, text, duration_ms, session_id, kind FROM discord_voice"
+            ") WHERE session_id = ? AND kind = 'tool_call' ORDER BY ts_unix",
+            (sid,),
+        ).fetchall()
+        tool_calls = [
+            {
+                "name": r["name"],
+                "durationMs": r["duration_ms"],
+                "timestamp": _ts_iso(r["ts_unix"]),
+            }
+            for r in tool_call_rows
+        ]
+        # Lifecycle events now live in session_events (per #1052 — the
+        # redundant sessions.events JSON column is gone). Query by
+        # session_id OR call_sid since callers may pass either.
+        event_rows = conn.execute(
+            "SELECT ts_unix, event_name FROM session_events "
+            "WHERE session_id = ? OR call_sid = ? ORDER BY ts_unix",
+            (sid, row["call_sid"]),
+        ).fetchall()
+        events = [
+            {"event": r["event_name"], "timestamp": _ts_iso(r["ts_unix"])}
+            for r in event_rows
+        ]
     finally:
         conn.close()
-    if not row:
-        return None
-    try:
-        tool_calls = json.loads(row["tool_calls"]) if row["tool_calls"] else []
-    except (json.JSONDecodeError, TypeError):
-        tool_calls = []
-    try:
-        events = json.loads(row["events"]) if row["events"] else []
-    except (json.JSONDecodeError, TypeError):
-        events = []
     return {
         "timestamp": _ts_iso(row["ts_unix"]),
         "callSid": row["call_sid"] or row["session_id"],

--- a/src/conversation-store.ts
+++ b/src/conversation-store.ts
@@ -152,8 +152,9 @@ function init(): void {
 			CREATE INDEX IF NOT EXISTS idx_discord_voice_session ON discord_voice(session_id, ts_unix);
 
 			-- Per-session rollup. Kept — different concern from the per-event log.
-			-- tool_calls/events JSON columns preserved for at-a-glance / cross-version
-			-- compat; the per-tool-call rows now live in the surface tables.
+			-- Per-tool-call rows live in surface tables (kind='tool_call'),
+			-- per-event rows live in session_events. The old tool_calls/events
+			-- JSON columns are dropped post-init via the migration below.
 			CREATE TABLE IF NOT EXISTS sessions (
 				ts_unix          REAL    NOT NULL,
 				source           TEXT    NOT NULL,
@@ -165,9 +166,7 @@ function init(): void {
 				duration_ms      INTEGER NOT NULL,
 				transcript_lines INTEGER,
 				tool_count       INTEGER,
-				pending_tasks    INTEGER,
-				tool_calls       TEXT,
-				events           TEXT
+				pending_tasks    INTEGER
 			);
 			CREATE INDEX IF NOT EXISTS idx_sessions_ts ON sessions(ts_unix);
 			CREATE INDEX IF NOT EXISTS idx_sessions_source_ts ON sessions(source, ts_unix);
@@ -191,6 +190,33 @@ function init(): void {
 		// `tool_calls` tables into the new per-surface tables, then drop the
 		// legacy tables. Idempotent — gated on each surface table being empty.
 		migrateLegacyIfNeeded(db);
+
+		// Drop the redundant sessions.tool_calls / sessions.events JSON
+		// columns if a pre-#1052 db still has them. The atom rows now live
+		// in surface tables (kind='tool_call') and session_events
+		// respectively; the JSON cols were triple-encoding the same data.
+		// SQLite 3.35+ supports ALTER TABLE DROP COLUMN — guard via
+		// pragma_table_info so re-running this is a no-op.
+		const sessionCols = new Set(
+			(db.prepare("PRAGMA table_info(sessions)").all() as Array<{ name: string }>)
+				.map(c => c.name),
+		);
+		if (sessionCols.has('tool_calls')) {
+			try {
+				db.exec('ALTER TABLE sessions DROP COLUMN tool_calls');
+				console.log('[conversation-store] dropped sessions.tool_calls (redundant w/ surface tables)');
+			} catch (e) {
+				console.error('[conversation-store] could not drop sessions.tool_calls:', e);
+			}
+		}
+		if (sessionCols.has('events')) {
+			try {
+				db.exec('ALTER TABLE sessions DROP COLUMN events');
+				console.log('[conversation-store] dropped sessions.events (redundant w/ session_events)');
+			} catch (e) {
+				console.error('[conversation-store] could not drop sessions.events:', e);
+			}
+		}
 
 		// Convenience views — thin wrappers that add a human-readable `time`
 		// column (local-time) and default-sort by ts_unix DESC. DROP+CREATE so
@@ -246,8 +272,8 @@ function init(): void {
 		sessionInsertStmt = db.prepare(`
 			INSERT INTO sessions (
 				ts_unix, source, session_id, call_sid, caller, is_owner, is_meeting,
-				duration_ms, transcript_lines, tool_count, pending_tasks, tool_calls, events
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				duration_ms, transcript_lines, tool_count, pending_tasks
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`);
 		eventInsertStmt = db.prepare(`
 			INSERT INTO session_events (ts_unix, source, session_id, call_sid, event_name)
@@ -459,8 +485,14 @@ export interface SessionMetrics {
 	transcriptLines?: number | null;
 	toolCount?: number | null;
 	pendingTasks?: number | null;
-	toolCalls?: unknown;     // JSON-serializable array
-	events?: unknown;        // JSON-serializable array
+	/** No longer persisted (per #1052). Surface table rows with
+	 *  kind='tool_call' are canonical; this field is accepted only for
+	 *  backwards-compat with existing callers and silently ignored. */
+	toolCalls?: unknown;
+	/** Iterated for the session_events fan-out (lifecycle events). User /
+	 *  agent / tool_call / tool_result entries are filtered out — those
+	 *  atoms live in surface tables now (per #1052). */
+	events?: unknown;
 }
 
 /** Parse a value that should be a timestamp into unix seconds, or null. */
@@ -473,10 +505,21 @@ function tsToUnix(t: unknown): number | null {
 	return null;
 }
 
+// Event names whose substance already lives in a surface table row
+// (kind='user'/'agent'/'tool_call'). Filtered out of the session_events
+// fan-out so the same atom isn't recorded twice. Defense-in-depth: the
+// 3 surface servers also stopped pushing these into their in-memory
+// events array as of #1052; this filter catches anything missed +
+// protects against external callers passing them in m.events.
+const DUPLICATE_EVENT_PREFIXES = ['user:', 'caller:', 'sutando:', 'assistant:', 'tool_call:', 'tool_result:'];
+
 /**
- * Record per-session rollup. Also fans out toolCalls into the matching
- * surface table (kind='tool_call') and events into the unified
- * session_events table. Best-effort.
+ * Record per-session rollup. Also fans out lifecycle events (session_started,
+ * session_ended, error, task_*, etc.) into the unified session_events table.
+ * Tool calls are NOT fanned out here — each surface server writes them in
+ * real time via recordToolCall() inside its onToolResult hook. Utterance
+ * events with user:/sutando: prefixes are filtered out — they duplicate
+ * surface-table user/agent rows. Best-effort.
  */
 export function recordSession(m: SessionMetrics): void {
 	init();
@@ -495,26 +538,24 @@ export function recordSession(m: SessionMetrics): void {
 			m.transcriptLines ?? null,
 			m.toolCount ?? null,
 			m.pendingTasks ?? null,
-			m.toolCalls === undefined ? null : JSON.stringify(m.toolCalls),
-			m.events === undefined ? null : JSON.stringify(m.events),
 		);
 	} catch (e) {
 		console.error('[conversation-store] session insert failed:', e);
 	}
-	// Tool-call rows are NO LONGER fanned out here — each surface server
-	// writes them in real-time via recordToolCall() inside its onToolResult
-	// hook. Doing both would dup-insert. The `sessions.tool_calls` JSON column
-	// still persists the full per-session rollup for the sessions-table view.
-	// Fan out events into the unified event log (unchanged).
+	// Fan out LIFECYCLE events into session_events. Skip duplicates of
+	// surface-table rows (user/sutando/tool_call/tool_result) — those
+	// atoms are canonical in voice/phone/discord_voice tables now.
 	if (eventInsertStmt && Array.isArray(m.events)) {
 		for (const ev of m.events as Array<Record<string, unknown>>) {
+			const name = String(ev.event ?? 'unknown');
+			if (DUPLICATE_EVENT_PREFIXES.some(p => name.startsWith(p))) continue;
 			try {
 				eventInsertStmt.run(
 					tsToUnix(ev.timestamp) ?? nowUnix,
 					m.source,
 					m.sessionId ?? null,
 					m.callSid ?? null,
-					String(ev.event ?? 'unknown'),
+					name,
 				);
 			} catch (e) {
 				console.error('[conversation-store] session_events insert failed:', e);

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -951,7 +951,10 @@ async function main() {
 			},
 			onToolCall: (e) => {
 				voiceToolIdMap.set(e.toolCallId, e.toolName);
-				voiceEvents.push({ event: `tool_call:${e.toolName}`, timestamp: new Date().toISOString() });
+				// tool_call event push removed per #1052 — canonical record
+				// is the surface-table row written in onToolResult via
+				// recordToolCall(). Pushing here would duplicate in
+				// session_events.
 				console.log(`${ts()} [Tool] ${e.toolName} (${e.execution})`);
 				// Flag the web-client that a tool is in flight so the avatar
 				// can show the blue `.working` pulse and the menu bar can
@@ -971,7 +974,10 @@ async function main() {
 			onToolResult: (e) => {
 				const toolName = voiceToolIdMap.get(e.toolCallId) || 'unknown';
 				voiceToolCalls.push({ name: toolName, durationMs: e.durationMs, timestamp: new Date().toISOString() });
-				voiceEvents.push({ event: `tool_result:${toolName}:${e.durationMs}ms`, timestamp: new Date().toISOString() });
+				// tool_result event push removed per #1052 — recordToolCall
+				// below is the canonical write (surface table, kind='tool_call',
+				// duration_ms column). Pushing here would duplicate in
+				// session_events.
 				recordToolCall('voice', toolName, e.durationMs, SESSION_ID);
 				console.log(`${ts()} [Tool] result: ${toolName} (${e.status}, ${e.durationMs}ms)`);
 				// Clear the tool track; browser track takes over immediately.
@@ -1226,10 +1232,10 @@ async function main() {
 				console.log(`${ts()}   [${item.role}] ${item.content}`);
 				logConversation(item.role, item.content, SESSION_ID);
 				const evtRole = item.role === 'user' ? 'user' : 'sutando';
-				// 7s offset for user speech: Gemini STT commits transcript ~7s after
-				// the user actually spoke (measured via iPad recording comparison).
-				const evtTs = item.role === 'user' ? new Date(Date.now() - 7000).toISOString() : new Date().toISOString();
-				voiceEvents.push({ event: `${evtRole}:${item.content || ''}`, timestamp: evtTs });
+				// utterance event push removed per #1052 — canonical record is
+				// the voice-table row written by logConversation() above
+				// (kind='user'/'agent', ts_unix). session_events keeps only
+				// lifecycle entries to stop triple-encoding the same atom.
 				voiceTranscript.push({ role: evtRole, text: item.content || '' });
 				const label = item.role === 'user' ? 'User' : 'Sutando';
 				try { appendFileSync(liveTranscriptPath, `[${new Date().toLocaleTimeString('en-US', {hour12:false})}] ${label}: ${item.content}\n`); } catch {}


### PR DESCRIPTION
Closes #1052. Stacks on top of #1051 — the diff currently includes #1051's commits; once that merges this PR rebases to the clean redundancy-cleanup-only diff.

## Why

Per the table in #1052, three storage paths encode the same atoms:

| atom | source 1 (canonical post-#1051) | source 2 | source 3 |
|---|---|---|---|
| user / agent utterance | `voice` / `phone` / `discord_voice` row (per-utt) | `session_events` `event_name='user:<text>'` / `'sutando:<text>'` | `sessions.events` JSON |
| tool call | surface row `kind='tool_call'` (realtime, #1051) | `session_events` `event_name='tool_call:<name>'` / `'tool_result:...'` | `sessions.tool_calls` JSON |

Row-count proof on the live workspace db pre-this-PR: `voice` 3673 rows but `session_events` 20027 rows (the pre-#1051 `v_voice` query reading 'user:'/'sutando:'/'tool_call:' prefixes returned ~10574 rows — 3× the surface table for the same data). Cost: more disk, more confused readers (you can SELECT from any of 3 places and get the same number).

## What

Single source of truth per atom:
- **Utterances:** surface tables `voice` / `phone` / `discord_voice` only.
- **Tool calls:** surface tables only (`kind='tool_call'`, written real-time via `recordToolCall` from #1051).
- **Lifecycle events** (session_started, session_ended, error, task_delegated, etc.): `session_events` only.
- `sessions` keeps just the per-session rollup metadata (duration, transcript_lines, tool_count, etc.) — no more JSON columns.

## Schema change

```sql
ALTER TABLE sessions DROP COLUMN tool_calls;
ALTER TABLE sessions DROP COLUMN events;
```

Guarded via `PRAGMA table_info` so re-init is a no-op. SQLite 3.35+ required (node:sqlite ships with newer than that).

## Writer-side changes

| file | line(s) | dropped |
|---|---|---|
| `src/conversation-store.ts` | recordSession | `tool_calls` + `events` cols in INSERT; session_events fan-out filter for user:/caller:/sutando:/assistant:/tool_call:/tool_result: prefixes |
| `src/voice-agent.ts` | onToolCall, onToolResult, turn-handler | `tool_call:`, `tool_result:`, `${evtRole}:${content}` pushes |
| `skills/phone-conversation/scripts/conversation-server.ts` | onToolCall, onToolResult, turn-handler | `tool_call:`, `tool_result:`, `caller:`, `sutando:` pushes |
| `skills/discord-voice/scripts/discord-voice-server.ts` | onToolCall, onToolResult, turn-handler | `tool_call:`, `tool_result:`, `user:`, `sutando:` pushes |

Lifecycle pushes (`session_started`, `session_ended`, `error:`, `task_delegated:`, `task_result:`, `channel_result:`, `rec_indicator:`, `call_ended`) preserved across all 3 surfaces.

## Reader-side changes

- `skills/regression-search/scripts/diagnose-call.py:_build_transcript` already updated in #1051 to read surface tables (`UNION ALL` + `kind != 'tool_call'` filter).
- `skills/regression-search/scripts/diagnose-call.py:find_metrics` updated here:
  - tool_calls list rebuilt from surface tables (`UNION ALL` + `kind = 'tool_call' WHERE session_id = ?`)
  - events list pulled directly from `session_events WHERE session_id = ? OR call_sid = ?`
  - Output shape (`{name, durationMs, timestamp}` per tool call; `{event, timestamp}` per event) unchanged.

`SessionMetrics` interface keeps `toolCalls` + `events` fields for backwards compat with existing callers — silently ignored / filtered now instead of persisted.

## Verification

- ✅ tsc --noEmit clean
- ✅ Migration applied to live workspace db: sessions 13 → 11 columns; existing rows preserved with metadata intact
- ✅ All 3 surface servers (voice / phone / discord-voice) restart cleanly on the new code
- ✅ `diagnose-call.py` syntax check + structural rewrite

## Risks

- **External callers reading `sessions.tool_calls` or `sessions.events` JSON outside this repo will break post-merge.** Mitigation: anyone affected can rebuild the same data via the surface tables (for tool_calls) or session_events (for events). Migration log line prints when columns are dropped so the operator notices.
- **Historical sessions' JSON data is gone** — DROP COLUMN doesn't preserve dropped column data. Migration log makes this clear. Surface tables + session_events have all the same atoms going forward; pre-#1051 history was already partially recoverable from those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)