### PR TITLE
fix(quota-tracker): read-quota repo-root off-by-one (silent workspace_default import failure)

### DIFF
--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -18,7 +18,12 @@ from pathlib import Path
 # leftover quota-state.json under skills/quota-tracker/ silently shadowed the
 # fresh file and froze the dashboard for ~12h (2026-05-21). One path, one
 # source of truth — if it's missing, say so rather than read a stale copy.
-_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+# NOTE: `.resolve()` follows the ~/.claude/skills symlink into the repo, so the
+# path is <repo>/skills/quota-tracker/scripts/read-quota.py — four levels deep.
+# Three .parent landed on <repo>/skills (no src/ there), so the workspace_default
+# import silently failed (→ except below → "not found") and quota read as missing
+# regardless of where the proxy wrote. Walk up four to reach <repo>/src.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "src"))
 try:
     from workspace_default import status_read_path  # noqa: E402


### PR DESCRIPTION
## Problem

`read-quota.py` reports `No quota-state.json found. Is the credential proxy running?` even when the proxy is alive and writing a fresh file.

Root cause is a path off-by-one. The script lives at `<repo>/skills/quota-tracker/scripts/read-quota.py` and is invoked through the `~/.claude/skills` symlink, so `Path(__file__).resolve()` resolves *into the repo* — four levels below the root. `_REPO_ROOT` used three `.parent` calls, landing on `<repo>/skills` (no `src/` there). The `from workspace_default import status_read_path` then failed and was swallowed by the bare `except` → `_canonical = None` → the not-found branch. So quota read as missing **regardless of where the proxy wrote the file** — the path check was never even reached.

The TS proxy's relative `../../../src` already resolves to `<repo>/src`; this aligns the Python reader.

## Fix

One extra `.parent` (file → scripts → quota-tracker → skills → repo root), with a comment explaining the symlink resolution so it isn't 'corrected' back.

## Test

`python3 ~/.claude/skills/quota-tracker/scripts/read-quota.py` now prints the live 5h/7d utilization windows instead of the not-found message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)