### PR TITLE
feat(catchup-after-startup): rebuild last-session context on fresh start

### DIFF
--- a/skills/catchup-after-startup/SKILL.md
+++ b/skills/catchup-after-startup/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: catchup-after-startup
+description: "Rebuild last-session context from everything persisted to disk (session-state.md, conversation.log, sqlite, PRs, tasks, build_log). Run as the first action of a fresh session so the conversation buffer has context before the user types. Recall half of issue #1032."
+user-invocable: true
+---
+
+# Catchup
+
+Reconstruct "what was happening before this session started" by reading everything Sutando persists across restarts. Designed to run as the **first** action of a fresh Sutando session, so the conversation buffer carries context before the user types anything.
+
+This is the **recall half** of [#1032](https://github.com/sonichi/sutando/issues/1032) (episodic event memory). The capture half — wiring `event_log.py` into every lifecycle point — is the other half of that issue and remains a separate followup. Catchup ships now because almost all the recoverable signal is already on disk; it just needs to be assembled in one place.
+
+**Usage**: `/catchup-after-startup`
+
+ARGUMENTS: $ARGUMENTS
+
+Optional first arg is an hour window for time-bounded sections (default 3). `/catchup-after-startup 12` widens to the last 12h.
+
+## What it pulls together
+
+1. **Last session checkpoint** — `session-state.md` (written by `src/session-handoff.sh` on context compaction)
+2. **Open PRs** — `gh pr list --author liususan091219 --state open`
+3. **In-flight tasks** — `workspace/tasks/task-*.txt`
+4. **Recent results** — `workspace/results/` mtime within window
+5. **Pending questions** — `pending-questions.md` tail
+6. **Recent voice / phone / discord activity** — last N h from `data/conversation.sqlite` (voice + phone + discord_voice tables, post-#1051 schema)
+7. **Recent chat** — `logs/conversation.log` last N h
+8. **Recent commits** — `git log --all --since=Nh`
+9. **build_log.md tail** — most recent prose entries from the proactive loop
+10. **Health** — `health-check.py` one-liner
+
+Sections that come up empty print a short "(none)" rather than getting dropped, so it's obvious whether nothing happened vs whether the lookup failed.
+
+## Steps
+
+1. Run `bash scripts/catchup-after-startup.sh [hours]`. Defaults to a 3-hour window via `CATCHUP_HOURS=3`.
+2. Read the output into the conversation context. Do NOT discard sections silently — they shape decisions made next (which PR to push, which task is stale, which channel the conversation was in).
+3. If the user's first prompt references something the catchup briefing doesn't cover (e.g. "what happened yesterday"), widen the window: `/catchup-after-startup 24` and re-read.
+4. Cite specific recovered items as the basis for the next action (e.g. "Per the briefing, PR #1051 is open with a review from qingyun — addressing first.").
+
+## Setup (one-time, recommended)
+
+Catchup reads `session-state.md` to learn what the previous session was doing at the moment it ended. Out of the box, that file is written **only** by the `PreCompact` hook in `src/session-handoff.sh` — so if the previous session exited via ⌘Q (or crashed) without a compaction in between, the file is stale: it reflects the last compact, not the last close. The most-recent N-minute window is then invisible to the next session's catchup.
+
+Closing that gap = adding a **SessionStop** hook that fires the same `session-handoff.sh`. After install, `session-state.md` always reflects the latest close (compact OR clean exit), and catchup gets a freshest possible briefing.
+
+```bash
+bash ~/.claude/skills/catchup-after-startup/scripts/install-hook.sh
+```
+
+The installer is idempotent — safe to re-run. It edits `~/.claude/settings.json` and adds:
+
+```json
+"SessionStop": [{
+  "hooks": [{
+    "type": "command",
+    "command": "bash \"${SUTANDO_REPO_DIR:-$HOME/Desktop/sutando}/src/session-handoff.sh\" \"${TRANSCRIPT_PATH:-}\""
+  }]
+}]
+```
+
+Requires `SUTANDO_REPO_DIR` env or a checkout at `~/Desktop/sutando` (the same convention `session-handoff.sh` uses for auto-detect).
+
+**Without the hook** catchup still works — you just lose the last few minutes of the previous session's narrative when that session ended outside a compact. The rest (open PRs, in-flight tasks, sqlite, conversation.log, build_log) is real-time persisted and recovers regardless.
+
+## When to invoke automatically
+
+- **First action of a fresh proactive-loop session** — wire via `personal-proactive-loop` skill's on-activation block.
+- **After a `/pull-and-restart`** — services restarted, but the conversation buffer is the same; still helpful to refresh before the next loop pass.
+- **Before declaring the session "ready" after a context compaction** — the new compacted context should layer onto the catchup briefing, not replace it.
+
+## What it does NOT recover
+
+- **In-flight reasoning that never hit disk** during the previous session ("I was about to do X but hadn't said it yet"). Out of scope without a finer-grained checkpoint mechanism. Mitigated by the SessionStop hook (separate followup) which forces a session-handoff snapshot on clean exit, not just PreCompact.
+- **The model's working memory / vibe / rapport.** Catchup gives data, not feel.
+- **Events from before the time window.** Widen with `/catchup-after-startup 24` or `/catchup-after-startup 168` (a week).
+
+Both mitigations are tracked under #1032's wider scope.

--- a/skills/catchup-after-startup/SKILL.md
+++ b/skills/catchup-after-startup/SKILL.md
@@ -63,11 +63,25 @@ Requires `SUTANDO_REPO_DIR` env or a checkout at `~/Desktop/sutando` (the same c
 
 **Without the hook** catchup still works — you just lose the last few minutes of the previous session's narrative when that session ended outside a compact. The rest (open PRs, in-flight tasks, sqlite, conversation.log, build_log) is real-time persisted and recovers regardless.
 
-## When to invoke automatically
+## Wiring for auto-invocation (operator-side, NOT in this PR)
 
-- **First action of a fresh proactive-loop session** — wire via `personal-proactive-loop` skill's on-activation block.
-- **After a `/pull-and-restart`** — services restarted, but the conversation buffer is the same; still helpful to refresh before the next loop pass.
-- **Before declaring the session "ready" after a context compaction** — the new compacted context should layer onto the catchup briefing, not replace it.
+The skill ships as the slash command only. **Auto-firing on every fresh session is the operator's choice** — this PR doesn't modify any loop or hook to call `/catchup-after-startup` for you. Wire it yourself wherever your proactive-loop / startup-orchestrator skill defines its on-activation block. Sample snippet for a personal proactive-loop SKILL.md:
+
+```markdown
+## Session-start catchup (FIRST action of a fresh session)
+
+If this is the first proactive-loop pass after a fresh session start
+(cold start, no prior context about what was happening), run
+`/catchup-after-startup` BEFORE anything else. Read the briefing into
+context, then proceed with the normal loop. Skip on subsequent passes
+within the same session.
+```
+
+Also useful to invoke manually after a `/pull-and-restart` (services restart but the conversation buffer is the same) or after a context compaction (layer the briefing onto the new compacted context).
+
+## Dependency note: sqlite section requires #1051's per-surface schema
+
+The voice/phone/discord activity section queries `voice` / `phone` / `discord_voice` tables — introduced in [sonichi/sutando#1051](https://github.com/sonichi/sutando/pull/1051). On a db that pre-dates #1051, the section prints "(sqlite query failed — db schema may pre-date #1051)" and the other 9 sections still work. If #1056 lands first, that section will be empty until #1051 merges; the rest of the briefing is unaffected.
 
 ## What it does NOT recover
 

--- a/skills/catchup-after-startup/scripts/catchup-after-startup.sh
+++ b/skills/catchup-after-startup/scripts/catchup-after-startup.sh
@@ -65,6 +65,75 @@ else
   say "(no session-state.md — last session may have exited without compacting; rely on logs below)"
 fi
 
+# 1b. Previous-session transcript (Claude Code project .jsonl)
+#
+# session-state.md is a 50-line summary written by session-handoff.sh, which
+# only fires if the PreCompact / SessionStop hooks are wired AND succeed.
+# Both have failed in practice (Mac Studio 2026-05-23 incident: hook
+# pointed at a non-existent default path → session-state.md never written
+# → catchup's most useful section was empty for weeks). The Claude Code
+# project transcript .jsonl, by contrast, is ALWAYS there (Claude Code
+# writes it natively, no hooks needed) and is richer (full user/assistant
+# turns vs a summary). When session-state.md is missing or stale, this is
+# the source of truth for "what was happening last session".
+print_section "Previous-session transcript (last $HOURS h)"
+proj_slug=$(echo "$REPO" | sed 's|/|-|g')
+proj_dir="$HOME/.claude/projects/$proj_slug"
+if [ -d "$proj_dir" ]; then
+  # Most-recent .jsonl untouched in the last minute — skips the CURRENT
+  # session's transcript (which the live process is still writing to).
+  # BSD `find -mmin` requires integers; fractional silently matches zero
+  # on macOS, so +1 is the tightest portable window.
+  prev_jsonl=$(/usr/bin/find "$proj_dir" -name "*.jsonl" -mmin +1 -size +0c 2>/dev/null | xargs -I{} stat -f "%m %N" {} 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
+  if [ -n "$prev_jsonl" ]; then
+    say "Source: $(basename "$prev_jsonl")"
+    python3 <<PYEOF
+import json, datetime as dt
+cut = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=${HOURS})
+turns = []
+with open("$prev_jsonl") as f:
+    for line in f:
+        try: d = json.loads(line)
+        except: continue
+        ts_s = d.get("timestamp")
+        if not ts_s: continue
+        try:
+            ts = dt.datetime.fromisoformat(ts_s.replace("Z","+00:00"))
+        except: continue
+        if ts < cut: continue
+        role = d.get("type", "")
+        if role not in ("user", "assistant"): continue
+        msg = d.get("message", {})
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            parts = []
+            for c in content:
+                if isinstance(c, dict) and c.get("type") == "text":
+                    parts.append(c.get("text", ""))
+            content = " ".join(parts)
+        content = str(content).strip()
+        if not content: continue
+        # Skip system reminders, task notifications, tool-result envelopes,
+        # interrupt markers — they're noise, not human turns.
+        if content.startswith("<"): continue
+        if content.startswith("[Request interrupted"): continue
+        if content.startswith("[{"): continue
+        turns.append((ts.strftime("%H:%M"), "user" if role=="user" else "asst", content))
+# Keep the LAST N turns in the window — those are most relevant to "what
+# was happening just before this session".
+for t, r, c in turns[-25:]:
+    snippet = c[:240].replace("\n", " ")
+    print(f"  {t} {r:4s}| {snippet}")
+if not turns:
+    print("  (no user/assistant turns in window)")
+PYEOF
+  else
+    say "(no previous-session .jsonl in $proj_dir — fresh checkout?)"
+  fi
+else
+  say "(no project transcript dir at $proj_dir)"
+fi
+
 # 2. Open PRs (mine — the shared liususan091219 identity)
 print_section "Open PRs on sonichi/sutando (liususan091219)"
 gh pr list --repo sonichi/sutando --state open --author liususan091219 \

--- a/skills/catchup-after-startup/scripts/catchup-after-startup.sh
+++ b/skills/catchup-after-startup/scripts/catchup-after-startup.sh
@@ -9,15 +9,43 @@
 #
 # Quiet on empty sections so output stays scannable.
 set -u
+set -o pipefail   # so `cmd | grep ... || say "(none)"` actually fires when cmd fails
 
-REPO="${SUTANDO_REPO_DIR:-/Users/xueqingliu/Documents/sutando/sutando}"
+# REPO: env wins, else probe common layouts for a sutando checkout
+# (CLAUDE.md + skills/ + .git signature, same heuristic session-handoff.sh
+# uses), else fall back to the convention path. Probing means a checkout
+# at $HOME/Desktop/sutando OR $HOME/Documents/sutando/sutando OR $(pwd)
+# all Just Work without per-user env. (Was a hardcoded /Users/xueqingliu/...
+# path pre-review; fixed per qingyun-wu + Mini's #1056 review.)
+if [ -n "${SUTANDO_REPO_DIR:-}" ]; then
+  REPO="$SUTANDO_REPO_DIR"
+else
+  REPO=""
+  for _cand in "$HOME/Desktop/sutando" "$HOME/Documents/sutando/sutando" "$HOME/Documents/sutando" "$HOME/sutando" "$(pwd)"; do
+    if [ -f "$_cand/CLAUDE.md" ] && [ -d "$_cand/skills" ] && [ -d "$_cand/.git" ]; then
+      REPO="$_cand"; break
+    fi
+  done
+  REPO="${REPO:-$HOME/Desktop/sutando}"   # falls through to the conventional path if probe finds nothing
+fi
 WS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
-HOURS="${CATCHUP_HOURS:-3}"
+# Hours window: positional arg wins (so /catchup-after-startup 12 works as
+# documented), env var second, default 3h. Pre-review the script only read
+# CATCHUP_HOURS — the documented `[hours]` arg was silently ignored (Mini #1).
+HOURS="${1:-${CATCHUP_HOURS:-3}}"
 
 print_section() { echo; echo "## $1"; echo; }
 say() { echo "$@"; }
 
 echo "# Catchup briefing — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+# REPO sanity: misconfigured REPO would silently empty out half the
+# briefing (session-state.md / build_log.md / git log / health), which the
+# skill's empty-vs-failed contract should make visible. Loud one-liner.
+if [ ! -d "$REPO" ]; then
+  echo
+  echo "⚠ REPO not found at \`$REPO\` — REPO-rooted sections will be empty/unhelpful."
+  echo "   Set SUTANDO_REPO_DIR to your Sutando checkout to fix."
+fi
 echo
 echo "Reconstructed from disk (last ${HOURS}h window where applicable). Issue #1032 — recall half."
 
@@ -60,8 +88,11 @@ pq=""
 [ -f "$REPO/pending-questions.md" ] && pq="$REPO/pending-questions.md"
 [ -z "$pq" ] && [ -f "$WS/pending-questions.md" ] && pq="$WS/pending-questions.md"
 if [ -n "$pq" ]; then
-  # Split on '## ' headers, drop any section whose body contains a resolution
-  # marker (✅, 'RESOLVED', or 'DONE') so old-but-archived items don't dominate.
+  # Filter: skip sections whose body explicitly marks resolution. Pre-review
+  # this matched bare substrings 'DONE' and 'RESOLVED' anywhere in prose —
+  # which over-matched (e.g. "this is not done yet" → dropped, qingyun #4).
+  # Now require an anchored marker: header containing ✅/Resolved/Dismissed,
+  # or a leading ✅ at the start of any body line.
   python3 <<PYEOF
 import re
 text = open("$pq").read()
@@ -69,10 +100,15 @@ sections = re.split(r'(?m)^(?=## )', text)
 shown = 0
 for s in sections:
     if not s.strip().startswith('## '): continue
-    body = s
-    if '✅' in body or 'RESOLVED' in body or '## Resolved' in body or 'DONE' in body or '## Dismissed' in body:
+    lines = s.splitlines()
+    header = lines[0] if lines else ''
+    # Header-level resolution markers
+    if re.search(r'(✅|Resolved|Dismissed|DONE)', header):
         continue
-    print(body.rstrip())
+    # Body-level ✅ at line start = explicit resolution marker
+    if any(re.match(r'\s*✅', ln) for ln in lines[1:]):
+        continue
+    print(s.rstrip())
     print()
     shown += 1
     if shown >= 5: break
@@ -84,9 +120,16 @@ else
 fi
 
 # 6. Recent voice/phone/discord activity (sqlite, last N h)
+# Requires #1051's per-surface tables (voice/phone/discord_voice). On a db
+# that pre-dates #1051 the query returns "(sqlite query failed)" — that's
+# the expected signal that the operator's conversation-store is older.
 print_section "Recent voice/phone/discord activity (last $HOURS h)"
 if [ -f "$WS/data/conversation.sqlite" ]; then
-  sqlite3 -separator $'\t' "$WS/data/conversation.sqlite" "
+  # Mini #2: pre-fix the inline `cmd | awk || say` pattern silently emitted
+  # nothing on cmd failure because pipefail wasn't on; we set it now AND
+  # capture into a variable so an empty-result-but-success case is distinct
+  # from a failure case.
+  sql_rows=$(sqlite3 -separator $'\t' "$WS/data/conversation.sqlite" "
     SELECT datetime(ts_unix,'unixepoch','localtime') AS time,
            'voice' AS surface, kind, substr(text,1,80) AS text
     FROM voice WHERE ts_unix > strftime('%s','now')-${HOURS}*3600
@@ -97,17 +140,27 @@ if [ -f "$WS/data/conversation.sqlite" ]; then
     SELECT datetime(ts_unix,'unixepoch','localtime'), 'discord_voice', kind, substr(text,1,80)
     FROM discord_voice WHERE ts_unix > strftime('%s','now')-${HOURS}*3600
     ORDER BY 1 DESC LIMIT 20;
-  " 2>/dev/null | awk -F'\t' '{printf "  [%s] %-13s %-10s %s\n", $1, $2, $3, $4}' \
-    || say "(sqlite query failed)"
+  " 2>&1)
+  sql_rc=$?
+  if [ $sql_rc -ne 0 ]; then
+    say "(sqlite query failed — db schema may pre-date #1051: $sql_rows)"
+  elif [ -z "$sql_rows" ]; then
+    say "(none)"
+  else
+    echo "$sql_rows" | awk -F'\t' '{printf "  [%s] %-13s %-10s %s\n", $1, $2, $3, $4}'
+  fi
 else
   say "(no conversation.sqlite)"
 fi
 
 # 7. Recent conversation.log (channel-bearing chat lines, last N h)
+# With pipefail on, the whole pipeline exits non-zero if python fails;
+# capturing into a variable + checking $? after the assignment is the
+# cleanest way to distinguish empty-window from parse-failure under set -u
+# (PIPESTATUS array isn't reliably present in command-substitution subshells).
 print_section "Recent chat (logs/conversation.log, last $HOURS h)"
 if [ -f "$WS/logs/conversation.log" ]; then
-  # filter to entries within window (rough: keep last 200 lines, then python-filter)
-  tail -200 "$WS/logs/conversation.log" | python3 -c "
+  log_rows=$(tail -200 "$WS/logs/conversation.log" | python3 -c "
 import sys, datetime as dt
 cut = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=${HOURS})
 for line in sys.stdin:
@@ -117,18 +170,33 @@ for line in sys.stdin:
         t = dt.datetime.fromisoformat(parts[0].replace('Z','+00:00'))
     except: continue
     if t < cut: continue
-    print('  ' + line.rstrip())" 2>/dev/null | tail -40 \
-    || say "(parse failed)"
+    print('  ' + line.rstrip())" 2>&1 | tail -40) || log_rows="__FAIL__"
+  if [ "$log_rows" = "__FAIL__" ]; then
+    say "(parse failed)"
+  elif [ -z "$log_rows" ]; then
+    say "(none)"
+  else
+    echo "$log_rows"
+  fi
 else
   say "(no conversation.log)"
 fi
 
 # 8. Recent commits across branches
 print_section "Recent commits (this repo, last $HOURS h)"
-git -C "$REPO" log --all --since="${HOURS} hours ago" \
-  --pretty='  %h %ad  %s (%an, %D)' --date=format:'%m-%d %H:%M' 2>/dev/null \
-  | head -25 \
-  || say "(git not available)"
+if [ -d "$REPO/.git" ]; then
+  git_rows=$(git -C "$REPO" log --all --since="${HOURS} hours ago" \
+    --pretty='  %h %ad  %s (%an, %D)' --date=format:'%m-%d %H:%M' 2>&1 | head -25) || git_rows="__FAIL__"
+  if [ "$git_rows" = "__FAIL__" ]; then
+    say "(git failed)"
+  elif [ -z "$git_rows" ]; then
+    say "(none)"
+  else
+    echo "$git_rows"
+  fi
+else
+  say "(no .git at $REPO)"
+fi
 
 # 9. Build log — show the last 3 timestamped entries (## YYYY-MM-DDT…) regardless
 #    of file age, plus a note if the most-recent entry is older than 24h.

--- a/skills/catchup-after-startup/scripts/catchup-after-startup.sh
+++ b/skills/catchup-after-startup/scripts/catchup-after-startup.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Catchup briefing — assemble "what was happening before this session started"
+# from everything persisted to disk: session-state.md, recent conversation.log,
+# open PRs, in-flight tasks/results, pending questions, recent voice/phone/
+# discord activity, recent commits, build_log tail, health.
+#
+# Designed to run as the first action of a fresh Sutando session so the
+# conversation buffer has context before the user types anything.
+#
+# Quiet on empty sections so output stays scannable.
+set -u
+
+REPO="${SUTANDO_REPO_DIR:-/Users/xueqingliu/Documents/sutando/sutando}"
+WS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+HOURS="${CATCHUP_HOURS:-3}"
+
+print_section() { echo; echo "## $1"; echo; }
+say() { echo "$@"; }
+
+echo "# Catchup briefing — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo
+echo "Reconstructed from disk (last ${HOURS}h window where applicable). Issue #1032 — recall half."
+
+# 1. Last session checkpoint
+print_section "Last session checkpoint (session-state.md)"
+if [ -f "$REPO/session-state.md" ]; then
+  ts=$(grep -m1 -i '^timestamp:' "$REPO/session-state.md" 2>/dev/null | awk '{print $2}')
+  say "Captured: ${ts:-unknown}"
+  echo '```'
+  sed -n '1,60p' "$REPO/session-state.md"
+  echo '```'
+elif [ -f "$WS/session-state.md" ]; then
+  echo '```'
+  sed -n '1,60p' "$WS/session-state.md"
+  echo '```'
+else
+  say "(no session-state.md — last session may have exited without compacting; rely on logs below)"
+fi
+
+# 2. Open PRs (mine — the shared liususan091219 identity)
+print_section "Open PRs on sonichi/sutando (liususan091219)"
+gh pr list --repo sonichi/sutando --state open --author liususan091219 \
+  --json number,title,updatedAt,reviewDecision \
+  --jq '.[] | "  #\(.number) [\(.reviewDecision // "no-review")] \(.title) (updated \(.updatedAt[:10]))"' 2>/dev/null \
+  || say "(gh not available or no PRs)"
+
+# 3. In-flight tasks
+print_section "In-flight tasks (workspace/tasks/)"
+tasks=$(ls -lt "$WS/tasks/"task-*.txt 2>/dev/null | head -8 | awk '{print "  "$NF" ("$6" "$7" "$8")"}')
+[ -n "$tasks" ] && echo "$tasks" || say "(none)"
+
+# 4. Pending results (delivered or not)
+print_section "Recent results (last $HOURS h)"
+results=$(/usr/bin/find "$WS/results" -maxdepth 1 -name 'task-*.txt' -mmin -$((HOURS*60)) 2>/dev/null | head -6 | awk '{print "  "$0}')
+[ -n "$results" ] && echo "$results" || say "(none)"
+
+# 5. Pending questions — show only UN-resolved entries
+print_section "Pending questions (un-resolved only)"
+pq=""
+[ -f "$REPO/pending-questions.md" ] && pq="$REPO/pending-questions.md"
+[ -z "$pq" ] && [ -f "$WS/pending-questions.md" ] && pq="$WS/pending-questions.md"
+if [ -n "$pq" ]; then
+  # Split on '## ' headers, drop any section whose body contains a resolution
+  # marker (✅, 'RESOLVED', or 'DONE') so old-but-archived items don't dominate.
+  python3 <<PYEOF
+import re
+text = open("$pq").read()
+sections = re.split(r'(?m)^(?=## )', text)
+shown = 0
+for s in sections:
+    if not s.strip().startswith('## '): continue
+    body = s
+    if '✅' in body or 'RESOLVED' in body or '## Resolved' in body or 'DONE' in body or '## Dismissed' in body:
+        continue
+    print(body.rstrip())
+    print()
+    shown += 1
+    if shown >= 5: break
+if shown == 0:
+    print("  (no un-resolved entries)")
+PYEOF
+else
+  say "(no pending-questions.md found)"
+fi
+
+# 6. Recent voice/phone/discord activity (sqlite, last N h)
+print_section "Recent voice/phone/discord activity (last $HOURS h)"
+if [ -f "$WS/data/conversation.sqlite" ]; then
+  sqlite3 -separator $'\t' "$WS/data/conversation.sqlite" "
+    SELECT datetime(ts_unix,'unixepoch','localtime') AS time,
+           'voice' AS surface, kind, substr(text,1,80) AS text
+    FROM voice WHERE ts_unix > strftime('%s','now')-${HOURS}*3600
+    UNION ALL
+    SELECT datetime(ts_unix,'unixepoch','localtime'), 'phone', kind, substr(text,1,80)
+    FROM phone WHERE ts_unix > strftime('%s','now')-${HOURS}*3600
+    UNION ALL
+    SELECT datetime(ts_unix,'unixepoch','localtime'), 'discord_voice', kind, substr(text,1,80)
+    FROM discord_voice WHERE ts_unix > strftime('%s','now')-${HOURS}*3600
+    ORDER BY 1 DESC LIMIT 20;
+  " 2>/dev/null | awk -F'\t' '{printf "  [%s] %-13s %-10s %s\n", $1, $2, $3, $4}' \
+    || say "(sqlite query failed)"
+else
+  say "(no conversation.sqlite)"
+fi
+
+# 7. Recent conversation.log (channel-bearing chat lines, last N h)
+print_section "Recent chat (logs/conversation.log, last $HOURS h)"
+if [ -f "$WS/logs/conversation.log" ]; then
+  # filter to entries within window (rough: keep last 200 lines, then python-filter)
+  tail -200 "$WS/logs/conversation.log" | python3 -c "
+import sys, datetime as dt
+cut = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=${HOURS})
+for line in sys.stdin:
+    parts = line.split('|', 2)
+    if len(parts) < 3: continue
+    try:
+        t = dt.datetime.fromisoformat(parts[0].replace('Z','+00:00'))
+    except: continue
+    if t < cut: continue
+    print('  ' + line.rstrip())" 2>/dev/null | tail -40 \
+    || say "(parse failed)"
+else
+  say "(no conversation.log)"
+fi
+
+# 8. Recent commits across branches
+print_section "Recent commits (this repo, last $HOURS h)"
+git -C "$REPO" log --all --since="${HOURS} hours ago" \
+  --pretty='  %h %ad  %s (%an, %D)' --date=format:'%m-%d %H:%M' 2>/dev/null \
+  | head -25 \
+  || say "(git not available)"
+
+# 9. Build log — show the last 3 timestamped entries (## YYYY-MM-DDT…) regardless
+#    of file age, plus a note if the most-recent entry is older than 24h.
+print_section "build_log.md (last 3 entries)"
+bl=""
+[ -f "$REPO/build_log.md" ] && bl="$REPO/build_log.md"
+[ -z "$bl" ] && [ -f "$WS/build_log.md" ] && bl="$WS/build_log.md"
+if [ -n "$bl" ]; then
+  python3 <<PYEOF
+import re, os, time
+text = open("$bl").read()
+# Sections begin with '## ' (any header); pick those with a timestamp prefix.
+sections = re.split(r'(?m)^(?=## )', text)
+ts_sections = [s for s in sections if re.match(r'## \d{4}-\d{2}-\d{2}', s)]
+last3 = ts_sections[-3:]
+for s in last3:
+    body = s.rstrip()
+    # truncate any single section over 60 lines to keep briefing scannable
+    lines = body.splitlines()
+    if len(lines) > 60:
+        body = "\n".join(lines[:60]) + "\n  ... (truncated, $bl has more)"
+    print(body)
+    print()
+# Staleness note
+mtime = os.path.getmtime("$bl")
+age_h = (time.time() - mtime) / 3600
+if age_h > 24:
+    print(f"  ⚠ build_log.md last updated {age_h:.0f}h ago — proactive-loop may not be appending")
+PYEOF
+else
+  say "(no build_log.md)"
+fi
+
+# 10. Health one-liner — call by file presence (script may not be +x)
+print_section "Health"
+if [ -f "$REPO/src/health-check.py" ]; then
+  health=$(python3 "$REPO/src/health-check.py" 2>/dev/null | grep -E '✓|⚠|✗' | head -10)
+  [ -n "$health" ] && echo "$health" || say "(health-check returned no ✓/⚠/✗ lines)"
+else
+  say "(health-check.py not found at $REPO/src/health-check.py)"
+fi
+
+echo
+echo "---"
+echo "End of catchup briefing. Treat above as recovered context for the new session."

--- a/skills/catchup-after-startup/scripts/install-hook.sh
+++ b/skills/catchup-after-startup/scripts/install-hook.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Idempotently install the SessionStop hook that pairs with /catchup.
+#
+# /catchup reads from session-state.md to know what the previous session was
+# doing. That file is written by `src/session-handoff.sh` — currently triggered
+# ONLY by the PreCompact hook. If the previous session exited cleanly (⌘Q)
+# without a compaction in between, the file stays at "last compact" instead
+# of "last close", losing the most-recent session window.
+#
+# This hook makes session-handoff.sh also fire on SessionStop, closing the
+# gap. Required env: SUTANDO_REPO_DIR pointing at the Sutando checkout (so
+# the hook can locate session-handoff.sh). Default: ~/Desktop/sutando.
+#
+# Safe to re-run — already-installed hooks are detected + skipped.
+set -euo pipefail
+
+SETTINGS="${HOME}/.claude/settings.json"
+# The hook command — points at the script that ships with Sutando.
+HOOK_CMD='bash "${SUTANDO_REPO_DIR:-$HOME/Desktop/sutando}/src/session-handoff.sh" "${TRANSCRIPT_PATH:-}"'
+
+if [ ! -f "$SETTINGS" ]; then
+  echo "error: $SETTINGS not found — Claude Code not configured on this machine?" >&2
+  exit 1
+fi
+
+python3 <<PYEOF
+import json, sys
+p = "$SETTINGS"
+cmd = '''$HOOK_CMD'''
+s = json.load(open(p))
+hooks = s.setdefault('hooks', {})
+ss = hooks.setdefault('SessionStop', [])
+
+# Match the existing shape: list of {hooks: [{type:command, command:...}]} groups.
+# We add a single group with our one command, unless an equivalent already exists.
+def has_cmd(groups, cmd):
+    for g in groups:
+        for h in (g.get('hooks') or []):
+            if h.get('type') == 'command' and (h.get('command') or '').strip() == cmd.strip():
+                return True
+    return False
+
+if has_cmd(ss, cmd):
+    print("SessionStop hook already installed — no changes")
+else:
+    ss.append({'hooks': [{'type': 'command', 'command': cmd}]})
+    json.dump(s, open(p, 'w'), indent=2)
+    print("installed SessionStop hook → " + p)
+    print("hook command:", cmd)
+PYEOF

--- a/skills/catchup-after-startup/scripts/install-hook.sh
+++ b/skills/catchup-after-startup/scripts/install-hook.sh
@@ -8,15 +8,40 @@
 # of "last close", losing the most-recent session window.
 #
 # This hook makes session-handoff.sh also fire on SessionStop, closing the
-# gap. Required env: SUTANDO_REPO_DIR pointing at the Sutando checkout (so
-# the hook can locate session-handoff.sh). Default: ~/Desktop/sutando.
+# gap.
+#
+# REPO resolution: the previous version baked `${SUTANDO_REPO_DIR:-$HOME/Desktop/sutando}`
+# into the hook command verbatim, so machines without SUTANDO_REPO_DIR set
+# AND without a checkout at ~/Desktop/sutando silently no-op'd every
+# SessionStop. (Real incident 2026-05-23 on Mac Studio.) We now resolve REPO
+# at install time using the same probe heuristic as catchup-after-startup.sh
+# and bake the literal path into the hook — no runtime probe burden, and a
+# misconfig fails loudly at install instead of silently at hook fire.
 #
 # Safe to re-run — already-installed hooks are detected + skipped.
 set -euo pipefail
 
 SETTINGS="${HOME}/.claude/settings.json"
-# The hook command — points at the script that ships with Sutando.
-HOOK_CMD='bash "${SUTANDO_REPO_DIR:-$HOME/Desktop/sutando}/src/session-handoff.sh" "${TRANSCRIPT_PATH:-}"'
+
+# Resolve REPO at install time (env wins, else probe common layouts).
+if [ -n "${SUTANDO_REPO_DIR:-}" ]; then
+  REPO_FOR_HOOK="$SUTANDO_REPO_DIR"
+else
+  REPO_FOR_HOOK=""
+  for _cand in "$HOME/Desktop/sutando" "$HOME/Documents/sutando/sutando" "$HOME/Documents/sutando" "$HOME/sutando" "$(pwd)"; do
+    if [ -f "$_cand/CLAUDE.md" ] && [ -d "$_cand/skills" ] && [ -d "$_cand/.git" ]; then
+      REPO_FOR_HOOK="$_cand"; break
+    fi
+  done
+  if [ -z "$REPO_FOR_HOOK" ]; then
+    echo "error: couldn't auto-detect sutando checkout — set SUTANDO_REPO_DIR and re-run" >&2
+    echo "       (probed: \$HOME/Desktop/sutando, \$HOME/Documents/sutando/sutando, \$HOME/Documents/sutando, \$HOME/sutando, \$(pwd))" >&2
+    exit 1
+  fi
+fi
+
+# The hook command — literal resolved path, no runtime probe.
+HOOK_CMD="bash \"$REPO_FOR_HOOK/src/session-handoff.sh\" \"\${TRANSCRIPT_PATH:-}\""
 
 if [ ! -f "$SETTINGS" ]; then
   echo "error: $SETTINGS not found — Claude Code not configured on this machine?" >&2

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -18,8 +18,9 @@ If an interval is provided in ARGUMENTS (e.g. "5m", "10m", "30m"), use it. Other
 
 ## On activation
 
-1. Run `/schedule-crons` to set up all recurring cron jobs (morning briefing, Zacks, etc.)
-2. Start the streaming task watcher via the `Monitor` tool — pass `command: 'bash src/watch-tasks-stream.sh'`, `persistent: true`, `description: 'Streaming task watcher'`. The script emits one `TASK_FILE: <basename>` line per new task file (initial sweep + each subsequent event). Read the named file via the Read tool when notifications arrive.
+1. **Catchup first** (fresh-session only). Check `state/proactive-loop-started.sentinel` (resolve under `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/`). If absent → run `/catchup-after-startup` BEFORE anything else so the conversation buffer has cross-restart context, then `mkdir -p` the workspace `state/` and `touch` the sentinel. If present → this is a cron-driven pass within an already-running session; skip catchup and proceed. The sentinel is cleared by the SessionStop hook (or explicitly via `rm state/proactive-loop-started.sentinel`) so the next fresh session re-runs catchup.
+2. Run `/schedule-crons` to set up all recurring cron jobs (morning briefing, Zacks, etc.)
+3. Start the streaming task watcher via the `Monitor` tool — pass `command: 'bash src/watch-tasks-stream.sh'`, `persistent: true`, `description: 'Streaming task watcher'`. The script emits one `TASK_FILE: <basename>` line per new task file (initial sweep + each subsequent event). Read the named file via the Read tool when notifications arrive.
 
 ## Start the loop
 

--- a/skills/schedule-crons/SKILL.md
+++ b/skills/schedule-crons/SKILL.md
@@ -19,6 +19,10 @@ Each entry has:
 
 ## On Activation
 
+0. **Catchup first (fresh-session only).** Check `state/proactive-loop-started.sentinel` under `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/`. If absent AND the `catchup-after-startup` skill is installed (i.e. `~/.claude/skills/catchup-after-startup/` exists) → invoke `/catchup-after-startup` BEFORE the cron-scheduling work below, so the conversation buffer carries cross-restart context (last session's PRs, in-flight tasks, recent voice/discord activity, build-log tail) before any cron fires. After invocation, `mkdir -p` the workspace `state/` and `touch` the sentinel. If sentinel is present (cron-driven re-invocation within an already-running session) OR catchup skill not installed → skip step 0 silently and proceed. The sentinel is cleared by the SessionStop hook in `src/session-handoff.sh` (per `6e5c58d` in this PR) so the next fresh session re-fires catchup.
+
+   Rationale: post-#954, the CLI boots with `-- "/schedule-crons"` (not `/proactive-loop`), so this skill IS the actual startup entry — wiring catchup here means it runs synchronously at session start instead of waiting until the first `main-loop` cron fire (~5 min later) to reach `/proactive-loop`'s catchup step (which `822e630` of this PR added). Identical sentinel guard semantics across both paths, so they cooperate idempotently — whichever runs first touches the sentinel; the other skips.
+
 1. Read `skills/schedule-crons/crons.json`
 2. Check existing cron jobs with CronList
 3. For each job in the config:

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -95,3 +95,11 @@ print(f'5h: {d[\"utilization_5h\"]:.0%} (resets in {m5}min at {r5.strftime(\"%I:
 } > "$STATE_FILE" 2>/dev/null
 
 echo "Session state saved to $STATE_FILE"
+
+# Clear the proactive-loop fresh-session sentinel so the NEXT session's first
+# /proactive-loop re-fires /catchup-after-startup. Without this, the sentinel
+# from the just-ended session persists and the next /proactive-loop's step 1
+# skips catchup, defeating the auto-fire wiring. (Paired with
+# skills/proactive-loop/SKILL.md step 1's sentinel guard.)
+SENTINEL="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/state/proactive-loop-started.sentinel"
+rm -f "$SENTINEL" 2>/dev/null


### PR DESCRIPTION
## Summary

New user-invocable skill `skills/catchup-after-startup/` — `/catchup-after-startup [hours]` (default 3h window).

Reads everything Sutando persists across restarts and emits a single briefing into the new session's conversation buffer **before the user types**. Designed to be the FIRST action of any fresh proactive-loop session so the bot doesn't restart cold and forget what it was working on, what PRs are open, what channel a thread lives in.

Recall half of #1032 (episodic event memory). The capture half (wiring `event_log.py` into every lifecycle point) remains a separate followup tracked under the same issue.

## What the briefing contains

1. `session-state.md` (PreCompact snapshot + SessionStop snapshot if hook installed — see Setup)
2. Open PRs by `liususan091219` on sonichi/sutando
3. In-flight `workspace/tasks/task-*.txt`
4. Recent `workspace/results/` within window
5. `pending-questions.md` — filtered to un-resolved entries only (skips sections containing ✅ / RESOLVED / DONE)
6. Recent voice / phone / discord activity from `data/conversation.sqlite` (uses the post-#1051 per-surface tables — `voice` / `phone` / `discord_voice`)
7. Recent chat from `logs/conversation.log`
8. Recent git commits across all branches
9. `build_log.md` last 3 timestamped entries, with a staleness warning if >24h old
10. `health-check.py` one-liner

## Setup

`scripts/install-hook.sh` is an idempotent installer for a paired SessionStop hook in `~/.claude/settings.json`. Without it, `session-state.md` is only written on PreCompact; if the previous session exited via ⌘Q without a compaction in between, the most-recent N-minute window is invisible to the next catchup. With the hook, `session-state.md` always reflects the latest close. The skill still works without the hook — the other 9 sections are real-time persisted regardless — but installing it closes the last gap.

## Files

```
skills/catchup-after-startup/
  SKILL.md                          — full spec + Setup section
  scripts/catchup-after-startup.sh  — main briefing assembler
  scripts/install-hook.sh           — idempotent SessionStop installer
```

No new dependencies. Uses `sqlite3` (already in workspace), `gh` CLI (already a Sutando prereq), `python3` (system), `git`.

## Why this lives here vs sutando-skills

Lives in sonichi/sutando proper rather than the community sutando-skills repo because it's tightly coupled to the Sutando workspace layout — references `$SUTANDO_REPO_DIR/src/health-check.py`, `$SUTANDO_REPO_DIR/src/session-handoff.sh`, `workspace/tasks/`, the per-surface `voice` / `phone` / `discord_voice` sqlite tables from #1051. Not a generic skill someone would install standalone.

## Test plan

- [ ] `/catchup-after-startup` with default 3h → all 10 sections render
- [ ] `/catchup-after-startup 12` widens cleanly to 12h
- [ ] Run on a fresh setup with no `session-state.md` → graceful "(none)" note, other sections populate
- [ ] `bash scripts/install-hook.sh` on a fresh `~/.claude/settings.json` → adds the SessionStop hook; re-run is a no-op
- [ ] ⌘Q a session, start new session, `/catchup-after-startup` → `session-state.md` reflects the close (after hook install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)