### PR TITLE
fix(py39): add from __future__ import annotations to remaining files

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -11,6 +11,9 @@ Usage:
 Auto-refreshes every 15 seconds.
 """
 
+from __future__ import annotations
+
+
 import http.server
 import json
 import os

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -31,6 +31,9 @@ File round-trip:
                files_upload_v2.
 """
 
+from __future__ import annotations
+
+
 import json
 import mimetypes
 import os

--- a/tests/task-priority.test.py
+++ b/tests/task-priority.test.py
@@ -4,6 +4,8 @@
 Run: python3 tests/task-priority.test.py
 Exit: 0 on pass, 1 on fail.
 """
+from __future__ import annotations
+
 import os
 import sys
 import tempfile


### PR DESCRIPTION
## Problem

`dashboard.py`, `slack-bridge.py`, and `tests/task-priority.test.py` use Python 3.10+ `X | None` union syntax in type annotations. On Python 3.9.6 (macOS Xcode toolchain — the default on many Mac systems), this raises a `TypeError` at import time.

`telegram-bridge.py` already has the guard from a previous fix.

## Fix

Add `from __future__ import annotations` (PEP 563) to the three remaining files. This makes all annotations lazy strings at runtime, restoring Python 3.9 compatibility with zero behavior change.

## Files changed

- `src/dashboard.py` — added guard after module docstring
- `src/slack-bridge.py` — added guard after module docstring  
- `tests/task-priority.test.py` — added guard after module docstring

## Test

```bash
python3.9 -c "import ast; ast.parse(open('src/dashboard.py').read()); print('ok')"
python3.9 -c "import ast; ast.parse(open('src/slack-bridge.py').read()); print('ok')"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)