### PR TITLE
fix(health): broaden Sutando-app pgrep to match installed .app path

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -314,7 +314,9 @@ def render_dashboard() -> str:
         cards.append(f'<div class="card full"><h2>Capabilities Matrix</h2>{matrix_html}</div>')
 
     # Keyboard shortcuts
-    sutando_running = subprocess.run(["/usr/bin/pgrep", "-f", "src/Sutando/Sutando"], capture_output=True).returncode == 0
+    # Match both the dev-built binary (`<repo>/src/Sutando/Sutando`) and the
+    # distributed .app (`/Applications/Sutando.app/Contents/MacOS/Sutando`).
+    sutando_running = subprocess.run(["/usr/bin/pgrep", "-f", "(Sutando|MacOS)/Sutando"], capture_output=True).returncode == 0
     shortcut_status = '<span class="ok">✓</span> Sutando app running' if sutando_running else '<span class="bad">✗</span> Sutando app not running'
     cards.append(f"""<div class="card">
 <h2>Keyboard Shortcuts</h2>

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -979,9 +979,12 @@ def run_all_checks() -> list[dict]:
     # time the discord-bridge / owner triggers a voice session.
     checks.append(check_discord_voice())
 
-    # Sutando menu bar app (optional — only check if binary exists)
-    sutando_bin = REPO_DIR / "src" / "Sutando" / "Sutando"
-    if sutando_bin.exists():
+    # Sutando menu bar app — check either dev-built binary or installed .app.
+    # On the distributed .app path the dev binary doesn't ship; we still want
+    # the menu bar check to run so dashboard reports accurate status.
+    dev_bin = REPO_DIR / "src" / "Sutando" / "Sutando"
+    app_bin = Path("/Applications/Sutando.app/Contents/MacOS/Sutando")
+    if dev_bin.exists() or app_bin.exists():
         # Distinguish pgrep failures (exit code != 0 and != 1) from a real
         # no-match (exit code 1). Pre-fix the bare try/except swallowed
         # subprocess errors AND empty results into a single "no pids" path,
@@ -994,7 +997,7 @@ def run_all_checks() -> list[dict]:
         pids: list[str] = []
         try:
             result = subprocess.run(
-                ["/usr/bin/pgrep", "-f", "Sutando/Sutando"],
+                ["/usr/bin/pgrep", "-f", "(Sutando|MacOS)/Sutando"],
                 capture_output=True, text=True, timeout=5,
             )
             if result.returncode == 0:
@@ -1012,12 +1015,16 @@ def run_all_checks() -> list[dict]:
 
         if pgrep_status == "ok-running" and pids:
             check = {"name": "sutando-app", "status": "ok", "detail": f"running (⌃C/⌃V/⌃M)"}
-            mark_stale_if_outdated(
-                check,
-                REPO_DIR / "src" / "Sutando" / "main.swift",
-                "src/Sutando/Sutando",
-                binary_path=REPO_DIR / "src" / "Sutando" / "Sutando",
-            )
+            # Staleness check is meaningful only in the dev workflow — the
+            # .app binary and bundled main.swift share a build mtime, so a
+            # comparison there is always equal. Skip when dev_bin missing.
+            if dev_bin.exists():
+                mark_stale_if_outdated(
+                    check,
+                    REPO_DIR / "src" / "Sutando" / "main.swift",
+                    "(Sutando|MacOS)/Sutando",
+                    binary_path=dev_bin,
+                )
             checks.append(check)
         elif pgrep_status == "ok-stopped":
             checks.append({"name": "sutando-app", "status": "warn", "detail": "not running — hotkeys disabled"})


### PR DESCRIPTION
## Problem

`dashboard.py` and `health-check.py` used a hardcoded pgrep pattern of `src/Sutando/Sutando` (the dev-build path). The distributed `.app`'s binary lives at `/Applications/Sutando.app/Contents/MacOS/Sutando`, so on a normal install the dashboard shows "✗ Sutando app not running" even when the app is alive and running.

Additionally, `health-check.py` gated the Sutando check on `sutando_bin.exists()` (the dev binary). On a distributed install the dev binary is never present, so the check was silently skipped entirely — no status line either way.

## Fix

- `dashboard.py`: broaden pattern from `src/Sutando/Sutando` to `(Sutando|MacOS)/Sutando`
- `health-check.py`:
  - Check for either `dev_bin` (dev workflow) or `app_bin` (`/Applications/Sutando.app/...`) before running the pgrep
  - Broaden pattern to `(Sutando|MacOS)/Sutando` to match both binary paths
  - Keep the staleness check gated on `dev_bin.exists()` — bundled `.app` and its bundled `main.swift` share a build mtime, so that comparison is always equal for installed apps

## Test

On a machine with Sutando.app installed (but no dev binary):

```bash
/usr/bin/pgrep -f "(Sutando|MacOS)/Sutando"  # should return the app PID
# vs previously:
/usr/bin/pgrep -f "src/Sutando/Sutando"       # returns nothing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)