### PR TITLE
fix(watcher): break bump-attempts feedback loop with per-file cooldown

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -81,6 +81,9 @@ shopt -u nullglob
 #    rename — including the source path AFTER the file has moved out.
 #    `[ -f "$path" ]` filters those rename-OUT-of-watched-dir events.
 #    Caught 2026-05-03 #1 (PR #572).
+LAST_EMIT_BN=""
+LAST_EMIT_SEC=$SECONDS
+
 fswatch \
   -l 0.5 \
   --event Created \
@@ -89,13 +92,19 @@ fswatch \
 | while IFS= read -r path; do
   case "$path" in
     *.txt)
+      bn="$(basename "$path")"
+      # Dedup: task_bump_attempts.py uses atomic rename (tmp→file) which
+      # re-triggers fswatch's Renamed filter, causing an infinite loop.
+      # Suppress re-emission of the same basename within a 3s cooldown.
+      if [ "$bn" = "$LAST_EMIT_BN" ] && [ $(( SECONDS - LAST_EMIT_SEC )) -lt 3 ]; then
+        continue
+      fi
       parent="$(dirname "$path")"
       if [ "$parent" = "$TASKS_DIR_ABS" ] && [ -f "$path" ]; then
-        # Restart-safety #4: bump `attempts:` BEFORE emit. For
-        # fresh-file events this sets attempts=1; fswatch dedupe
-        # prevents same-session double-bumps from burst events.
         python3 "$SCRIPT_DIR/task_bump_attempts.py" "$path" 2>/dev/null || true
-        echo "TASK_FILE: $(basename "$path")"
+        echo "TASK_FILE: $bn"
+        LAST_EMIT_BN="$bn"
+        LAST_EMIT_SEC=$SECONDS
       fi
       ;;
   esac


### PR DESCRIPTION
## Summary
- `task_bump_attempts.py` uses atomic rename (`tmp.replace(file_path)`) which re-triggers fswatch's `--event Renamed` filter, creating an infinite emission loop
- Each emission calls bump → rename → fswatch event → emit → bump → repeat
- This killed the Monitor tool (output rate limit) after processing just one Telegram task, requiring manual restart
- Added a 3-second per-basename cooldown using `$SECONDS` to suppress re-emission of the same file within the dedup window

## Test plan
- [x] Verified fix breaks the loop — Monitor stays alive through multiple Telegram task cycles
- [x] New tasks with different basenames still emit immediately
- [ ] Verify a task re-created with the same basename after >3s is still detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)