### PR TITLE
fix(watcher): remove event-loop attempts-bump to eliminate residual re-emit drip (#1066/#1070 follow-up)

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -93,15 +93,24 @@ fswatch \
   case "$path" in
     *.txt)
       bn="$(basename "$path")"
-      # Dedup: task_bump_attempts.py uses atomic rename (tmp→file) which
-      # re-triggers fswatch's Renamed filter, causing an infinite loop.
-      # Suppress re-emission of the same basename within a 3s cooldown.
+      # Dedup cooldown (kept as belt-and-suspenders for any burst/repeat
+      # fires, e.g. FSEvents coalescing the Created flag on a path).
       if [ "$bn" = "$LAST_EMIT_BN" ] && [ $(( SECONDS - LAST_EMIT_SEC )) -lt 3 ]; then
         continue
       fi
       parent="$(dirname "$path")"
       if [ "$parent" = "$TASKS_DIR_ABS" ] && [ -f "$path" ]; then
-        python3 "$SCRIPT_DIR/task_bump_attempts.py" "$path" 2>/dev/null || true
+        # Do NOT bump attempts here. Writing the task file in response to an
+        # event re-triggers this very loop: #1066 made the bump an in-place
+        # write (no more Renamed), but on macOS FSEvents coalesces flags per
+        # path, so a recently-Created file re-reports Created on ANY later
+        # change — including our in-place bump — re-matching `--event Created`.
+        # With the bump still here, an unprocessed task re-fires once per
+        # cooldown window (the residual "drip" the 3s cooldown only throttles).
+        # Removing the event-loop write removes the self-trigger SOURCE
+        # entirely → zero re-emit, no drip. The attempts counter is still set
+        # on the initial sweep above (crash-recovery retry semantics); live
+        # arrivals are fresh by definition, so they don't need it.
         echo "TASK_FILE: $bn"
         LAST_EMIT_BN="$bn"
         LAST_EMIT_SEC=$SECONDS


### PR DESCRIPTION
## Why
Follow-up to #1066 + #1070, which stopped the fswatch self-trigger **flood**. A **residual drip** remains: on macOS, FSEvents coalesces event flags per path, so a recently-`Created` task file re-reports the `Created` flag on **any** later change — including #1066's in-place attempts-bump write. So the bump still re-matches the watcher's `--event Created`, and an unprocessed task re-fires **once per ~3s cooldown window**.

Isolated repro (confirms in-place write alone re-fires):
```sh
D=$(mktemp -d); printf 'id: t\ntask: x\n' > "$D/a.txt"
fswatch -l 0.3 --event Created --event Renamed "$D" > "$D/ev.log" &
sleep 1.2                                                  # drain initial create
python3 -c "open('$D/a.txt','w').write('id: t\nattempts: 1\ntask: x\n')"  # in-place
sleep 1.5   # → ev.log has 1 event for a.txt: the in-place write re-fired
```

## What
Remove the **event-loop** `task_bump_attempts.py` call. That write was the self-trigger *source*; with it gone there is nothing to re-fire (zero re-emit, no drip). #1070's 3s cooldown stays as belt-and-suspenders for burst/coalesced fires.

## Side effects — none meaningful
The attempts counter is still bumped on the **initial sweep** (crash-recovery: tasks left by a prior session surface with attempts>1). Only **live** arrivals no longer get `attempts: 1` written by the watcher — and live tasks are emitted once / processed once, so they're fresh by definition (consumers treat missing attempts as fresh). No retry/observability regression.

Deliberately *not* using a permanent seen-set (the other candidate): that would remove auto-re-surfacing of unprocessed tasks, grow memory unboundedly, and suppress a legitimate same-basename re-queue. Removing the event-loop write is the minimal, side-effect-free fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)