### PR TITLE
fix(catchup-after-startup): detect submodule/worktree checkouts + de-flake commits section

### DIFF
--- a/skills/catchup-after-startup/scripts/catchup-after-startup.sh
+++ b/skills/catchup-after-startup/scripts/catchup-after-startup.sh
@@ -22,7 +22,9 @@ if [ -n "${SUTANDO_REPO_DIR:-}" ]; then
 else
   REPO=""
   for _cand in "$HOME/Desktop/sutando" "$HOME/Documents/sutando/sutando" "$HOME/Documents/sutando" "$HOME/sutando" "$(pwd)"; do
-    if [ -f "$_cand/CLAUDE.md" ] && [ -d "$_cand/skills" ] && [ -d "$_cand/.git" ]; then
+    # -e not -d: in a submodule/worktree checkout `.git` is a file (gitdir
+    # pointer), not a directory, so -d would reject an otherwise-valid repo.
+    if [ -f "$_cand/CLAUDE.md" ] && [ -d "$_cand/skills" ] && [ -e "$_cand/.git" ]; then
       REPO="$_cand"; break
     fi
   done
@@ -253,15 +255,24 @@ fi
 
 # 8. Recent commits across branches
 print_section "Recent commits (this repo, last $HOURS h)"
-if [ -d "$REPO/.git" ]; then
-  git_rows=$(git -C "$REPO" log --all --since="${HOURS} hours ago" \
-    --pretty='  %h %ad  %s (%an, %D)' --date=format:'%m-%d %H:%M' 2>&1 | head -25) || git_rows="__FAIL__"
-  if [ "$git_rows" = "__FAIL__" ]; then
-    say "(git failed)"
-  elif [ -z "$git_rows" ]; then
-    say "(none)"
+# -e not -d: a submodule/worktree checkout has `.git` as a file, not a dir.
+if [ -e "$REPO/.git" ]; then
+  # Capture first, trim second. Piping `git log` straight into `head` lets
+  # head close the pipe after 25 lines, which can SIGPIPE git (exit 141) and,
+  # under `set -o pipefail`, trip a false "(git failed)" — a flaky race that
+  # bites whenever the window holds >25 commits. Capturing the full output in
+  # the `if` keeps git's real exit status as the only failure signal; the
+  # later head runs on a plain string and cannot affect it.
+  if git_rows=$(git -C "$REPO" log --all --since="${HOURS} hours ago" \
+      --pretty='  %h %ad  %s (%an, %D)' --date=format:'%m-%d %H:%M' 2>&1); then
+    git_rows=$(printf '%s\n' "$git_rows" | head -25)
+    if [ -z "$git_rows" ]; then
+      say "(none)"
+    else
+      echo "$git_rows"
+    fi
   else
-    echo "$git_rows"
+    say "(git failed)"
   fi
 else
   say "(no .git at $REPO)"


### PR DESCRIPTION
## Problem

In a **submodule** or **worktree** checkout, `.git` is a *file* (a `gitdir:` pointer) rather than a directory. `catchup-after-startup.sh` tested `[ -d "$REPO/.git" ]` in two places, so on such a checkout:

- The repo **auto-detect** probe rejected an otherwise-valid checkout (even with `CLAUDE.md` + `skills/` present and `git` fully functional).
- The **"Recent commits"** section short-circuited to `(no .git at $REPO)` — even though `git -C "$REPO" log` works perfectly.

Once that gate is opened, a second, *flaky* bug surfaces in the same section: `git log … | head -25` under `set -o pipefail` intermittently prints `(git failed)`. When the window holds >25 commits, `head` closes the pipe after 25 lines, `git` receives SIGPIPE (exit 141), and `pipefail` propagates it as a pipeline failure.

## Fix

1. **`-d` → `-e`** at both the auto-detect probe and the commits-section gate. `-e` accepts a `.git` that is a file *or* a directory, so normal, submodule, and worktree checkouts all pass.
2. **Decouple `head` from git's pipe.** Capture `git log` output inside the `if` (so git's real exit status is the only failure signal), then trim with `head` on a plain string where a SIGPIPE can't affect git.

## Verification

On a submodule checkout (public `sutando` pinned inside a private super-repo, `.git` = `gitdir: ../.git/modules/sutando`):

- Before: `## Recent commits` → `(no .git at $REPO)`.
- After the `-e` fix: section entered git path but flaked — `(git failed)` on ~1 in 3 runs.
- After both fixes: **8/8 runs** populate the commits list reliably.
- Auto-detect also now finds the repo when `SUTANDO_REPO_DIR` is unset and cwd is the submodule.

`bash -n` clean. No `set -e` in the script, so the decoupled `printf … | head` assignment is safe. Scope is limited to the two `.git` checks and the one pipeline; no behavior change for plain-directory checkouts.

Follow-up to #1056.