### PR TITLE
feat(discord-bridge): include channel_name + guild_name in task file

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2702,11 +2702,13 @@ async def _handle_discord_message(message, force=False):
 
     priority = default_priority_for_source("discord", access_tier)
     # channel_name / guild_name: human-readable labels so the task-consumer can
-    # disambiguate "is this Sutando #dev or Susan-fleet WIRE ep012?" without
-    # grepping numeric IDs against a memory file. DM channels have no `.name`
-    # attr; DMs have no guild. Default to "DM" for both.
-    channel_name = getattr(message.channel, "name", None) or "DM"
-    guild_name = message.guild.name if message.guild else "DM"
+    # disambiguate one team channel from another without grepping numeric IDs
+    # against a memory file. DM channels have no `.name` attr; DMs have no
+    # guild. Default to "DM" for both. Newline-sanitize so a Discord name
+    # containing \n (rare but possible) can't inject a spurious metadata
+    # line into the task file's k:v shape (per qingyun review on #1077).
+    channel_name = (getattr(message.channel, "name", None) or "DM").replace("\n", " ")
+    guild_name = (message.guild.name if message.guild else "DM").replace("\n", " ")
     task_file.write_text(
         f"id: {task_id}\n"
         f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2701,12 +2701,20 @@ async def _handle_discord_message(message, force=False):
                 print(f"  [auto-react] {react_emoji} failed: {e}", flush=True)
 
     priority = default_priority_for_source("discord", access_tier)
+    # channel_name / guild_name: human-readable labels so the task-consumer can
+    # disambiguate "is this Sutando #dev or Susan-fleet WIRE ep012?" without
+    # grepping numeric IDs against a memory file. DM channels have no `.name`
+    # attr; DMs have no guild. Default to "DM" for both.
+    channel_name = getattr(message.channel, "name", None) or "DM"
+    guild_name = message.guild.name if message.guild else "DM"
     task_file.write_text(
         f"id: {task_id}\n"
         f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"
         f"task: {user_task_text}\n"
         f"source: discord\n"
         f"channel_id: {message.channel.id}\n"
+        f"channel_name: {channel_name}\n"
+        f"guild_name: {guild_name}\n"
         f"source_message_id: {message.id}\n"
         f"user_id: {message.author.id}\n"
         f"access_tier: {access_tier}\n"


### PR DESCRIPTION
Task files currently carry numeric `channel_id` only — the task-consumer (core agent reading from `tasks/`) has no human-readable label for the originating channel, so distinguishing one team channel from another requires grepping numeric IDs against a separately-maintained channel-reference memory file. That's fragile and routinely misroutes cross-team messages.

## Change

`src/discord-bridge.py` — two additional lines in the task body:

```
channel_name: <discord channel name>  # or "DM" if no .name attr
guild_name: <discord guild name>      # or "DM" if not in a guild
```

DM channels have no `.name` attribute and no `.guild`, so both default to `"DM"`.

## Backward compat

Additive — existing consumers parse line-by-line k:v and ignore unknown keys.

## Motivation

Proposed by the operator after a real misroute incident: a task arrived from a numeric channel ID that the core agent had to guess (against a memory file) wasn't on the expected guild. With these fields the disambiguation is immediate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)