### PR TITLE
fix(sync-memory): honor explicit SUTANDO_MEMORY_DIR override

### DIFF
--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -145,7 +145,21 @@ fi
 # back via `find … | head -1` to whichever sibling memory dir landed first
 # (alphabetical). Bug silently skipped real memory writes for 5+ weeks
 # before being caught. See docs/workspace-contract.md.
-MEMORY_DIR="$HOME/.claude/projects/$(echo "$SCRIPT_PARENT" | sed 's|/|-|g')/memory"
+#
+# Explicit override (SUTANDO_MEMORY_DIR): the SCRIPT_PARENT heuristic assumes the
+# memory was created under the SAME checkout that now runs this script. That
+# breaks on MULTI-CHECKOUT installs — e.g. the agent + its memory live under
+# `~/Documents/github/sutando` (old checkout's project key), but a cron invokes
+# this script from a different checkout (`…/sutando-plus/sutando`), whose project
+# key has an empty/absent memory dir → falls through to the unreliable
+# `find … | head -1`. Honoring an explicit SUTANDO_MEMORY_DIR lets such installs
+# point at the real dir. Unset = identical to prior behavior (backward-compatible);
+# additive, so it composes with whatever invocation/deployment layout you choose.
+if [ -n "${SUTANDO_MEMORY_DIR:-}" ]; then
+  MEMORY_DIR="${SUTANDO_MEMORY_DIR/#\~/$HOME}"
+else
+  MEMORY_DIR="$HOME/.claude/projects/$(echo "$SCRIPT_PARENT" | sed 's|/|-|g')/memory"
+fi
 NOTES_DIR="$REPO_DIR/notes"
 LOG="/tmp/sync-memory.log"
 LOCK_DIR="/tmp/sync-memory.lock.d"


### PR DESCRIPTION
## Problem

`scripts/sync-memory.sh` locates the per-project memory dir from `SCRIPT_PARENT` (the checkout that runs the script):

```sh
MEMORY_DIR="$HOME/.claude/projects/$(echo "$SCRIPT_PARENT" | sed 's|/|-|g')/memory"
```

This assumes the memory was created under the **same** checkout that now runs sync-memory. On **multi-checkout installs** that's false: the agent + its memory live under one checkout's project key (e.g. `~/Documents/github/sutando` → `…-Documents-github-sutando/memory`, the real 72-file dir), but a cron may invoke this script from a **different** checkout (e.g. `…/sutando-plus/sutando` → `…-sutando-plus-sutando/memory`, which doesn't exist). The non-existent key then falls through to the unreliable `find … | head -1` fallback, which silently syncs the wrong dir (or nothing).

**Field repro:** a node running sync-memory from a sibling checkout reported `No changes to sync` while real memory edits sat unsynced in the original checkout's dir. (Same *class* as the prior REPO_DIR bug the existing comment documents — the SCRIPT_PARENT heuristic just moved where the wrong assumption lives.)

## Fix

Honor an explicit `SUTANDO_MEMORY_DIR` when set; otherwise behavior is **byte-identical** to before.

```sh
if [ -n "${SUTANDO_MEMORY_DIR:-}" ]; then
  MEMORY_DIR="${SUTANDO_MEMORY_DIR/#\~/$HOME}"
else
  MEMORY_DIR="$HOME/.claude/projects/$(echo "$SCRIPT_PARENT" | sed 's|/|-|g')/memory"
fi
```

- **Additive + backward-compatible** — unset = no change; the `find … | head -1` last-resort fallback is untouched.
- **Composable** — works alongside any invocation/deployment layout (run-from-canonical-checkout, symlink, etc.); it just adds a robust explicit pin.
- Operators on multi-checkout hosts set `SUTANDO_MEMORY_DIR` in `.env`.

## Verification

- `bash -n` clean.
- With `SUTANDO_MEMORY_DIR` set → resolves to the real 72-`.md`-file dir.
- Unset → byte-identical to prior `SCRIPT_PARENT` resolution.