### PR TITLE
feat(skills): inline-tool loader scans $SUTANDO_WORKSPACE/skills/

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -974,15 +974,14 @@ function assertUniqueToolNames(tools: ToolDefinition[]): ToolDefinition[] {
 // owner-tier tools only when the caller is the verified owner. Manifest
 // access_tier values: "owner" (default if omitted) | "any_caller".
 async function loadSkillManifestTools(): Promise<{ owner: ToolDefinition[]; anyCaller: ToolDefinition[] }> {
-	// Scan the public-repo `skills/` dir AND the optional private skills dir
+	// Scan the public-repo `skills/` dir, the per-user workspace
+	// `$SUTANDO_WORKSPACE/skills/`, AND the optional private skills dir
 	// pointed to by `$SUTANDO_MEMORY_DIR/skills/` (legacy `$SUTANDO_PRIVATE_DIR`
 	// honored via memoryDirEnv(); e.g. `~/.sutando/memory-sync/skills/`). The
 	// private dir lets users keep personal tooling with real per-file git
-	// history outside the public repo. Order: public first, then private —
-	// same-name skills loaded from private take precedence (last one wins via
-	// the dup-name guard below if any; in practice they should be uniquely
-	// named).
-	const dirsToScan: string[] = [join(REPO_ROOT, 'skills')];
+	// history outside the public repo. Order: public first, then workspace,
+	// then private — last-write-wins for same-name skills.
+	const dirsToScan: string[] = [join(REPO_ROOT, 'skills'), join(WORKSPACE_DIR, 'skills')];
 	const privateRoot = memoryDirEnv();
 	if (privateRoot) {
 		const expanded = privateRoot.replace(/^~/, process.env.HOME || '');
@@ -1046,7 +1045,7 @@ const personalAllTools = [...personalTools.owner, ...personalTools.anyCaller];
 // a tools.ts. Don't try to align them — they're correctly sync/async for
 // what each one does.
 function loadCoreDocumentedSkills(): { name: string; description: string }[] {
-	const dirsToScan: string[] = [join(REPO_ROOT, 'skills')];
+	const dirsToScan: string[] = [join(REPO_ROOT, 'skills'), join(WORKSPACE_DIR, 'skills')];
 	const privateRoot = memoryDirEnv();
 	if (privateRoot) {
 		const expanded = privateRoot.replace(/^~/, process.env.HOME || '');


### PR DESCRIPTION
## Summary
- Adds `$SUTANDO_WORKSPACE/skills/` to the inline-tool loader's scan list, in both `loadSkillManifestTools()` (voice-inline tools) and `loadCoreDocumentedSkills()` (core-documented manifests). Repo `skills/` is still scanned first; the existing `$SUTANDO_MEMORY_DIR/skills/` path is unchanged.
- New order: **repo → workspace → memory-dir**. Last-write-wins for same-name skills, matching the prior convention.

## Why
Lets users park personal or per-machine inline-tool skills under their workspace without forking the repo and without coupling to the memory-sync path. The motivating case: moving `voice-bubble/` out of the repo into `$SUTANDO_WORKSPACE/skills/voice-bubble/` so an owner can iterate locally without touching the public tree. Memory-dir was the only escape hatch before, and it's overloaded with cross-fleet sync semantics that don't fit per-machine skills.

## Test plan
- [ ] Restart voice-agent with a `manifest.json` + `tools.ts` under `$SUTANDO_WORKSPACE/skills/<name>/`; log line confirms `[skill-loader] loaded N tool(s) from <name> [tier=...] ($SUTANDO_WORKSPACE/skills)`.
- [ ] With no workspace skill present, behavior is unchanged (repo + memory-dir scanning only).
- [ ] Same-name skill in repo + workspace: workspace wins (last-write per `dirsToScan` order).
- [ ] `tools.ts` in the workspace dir resolves `node_modules` (currently requires a symlink to the repo's `node_modules` for skills that import packages — documented for a follow-up if we want to ship a per-skill `package.json` story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)