### PR TITLE
fix(install-claude-hooks): drop Stop watcher-kill hook (kills Monitor every turn)

### DIFF
--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
 # install-claude-hooks.sh — idempotent install of Sutando-owned project-level
-# Claude Code hooks (PreCompact + Stop). Pairs with the in-#1065 PID-file
-# Stop-hook cleanup; also covers the previously-uninstaller'd entries that
-# existed manually on dev machines.
+# Claude Code hooks (PreCompact + Stop).
 #
 # Per `feedback_claude_code_hook_scoping`: sutando hooks belong at PROJECT-level
 # `.claude/settings.json` (gitignored, per-machine), NOT user-level
 # `~/.claude/settings.json` — they only fire when Claude runs in this project
 # context, not in unrelated sessions.
 #
-# Hooks installed (4):
+# Hooks installed (3):
 #   PreCompact  → cp $TRANSCRIPT_PATH ~/Desktop/sutando-conversations/...
 #   PreCompact  → bash src/session-handoff.sh "$TRANSCRIPT_PATH"
 #   Stop        → bash src/check-pending-tasks.sh
-#   Stop        → watcher-cleanup PID kill (the #1065 fix for #1061 / #1063)
+#
+# Historical note: a 4th hook (`Stop` → watcher-cleanup PID kill, the #1065
+# fix) was removed 2026-05-24.  Claude Code's `Stop` event fires on
+# turn-end (after every assistant response), NOT session-end — so the
+# PID-kill block killed the live Monitor watcher every turn, triggering an
+# exit-143 + Monitor-restart cycle.  Watcher orphan-cleanup is handled by
+# the `Reap any stale watch-tasks-stream watcher` block in
+# `src/startup.sh` (defense-in-depth: PID-file + cmdline-check before
+# kill), which runs at every session start.  See the original #1061 /
+# #1063 / #1065 thread for the orphan-watcher background.
 #
 # Note: Lucy's #1056 ships a SEPARATE installer for the SessionStop hook
 # (skills/catchup-after-startup/scripts/install-hook.sh).  Those events
@@ -28,9 +35,15 @@
 #   bash src/install-claude-hooks.sh
 #
 # Exit codes:
-#   0 — all 4 hooks present after run (some may have been pre-existing)
+#   0 — all 3 hooks present after run (some may have been pre-existing)
 #   1 — settings.json malformed / jq edit failed
 #   2 — jq missing (required for atomic edit)
+#
+# Existing installs: this script is install-only, not uninstall.  If your
+# settings.json already has the watcher-kill Stop hook from a previous
+# install, remove it manually:
+#   jq 'del(.hooks.Stop[0].hooks[] | select(.command | contains("watch-tasks-stream.pid")))' \
+#     .claude/settings.json > /tmp/s.json && mv /tmp/s.json .claude/settings.json
 
 set -u
 
@@ -42,7 +55,6 @@ HOOKS=(
   "PreCompact|cp \"\$TRANSCRIPT_PATH\" \"\$HOME/Desktop/sutando-conversations/\$(date +%Y-%m-%dT%H-%M-%S).jsonl\""
   "PreCompact|bash \$HOME/Desktop/sutando/src/session-handoff.sh \"\$TRANSCRIPT_PATH\""
   "Stop|bash \$HOME/Desktop/sutando/src/check-pending-tasks.sh"
-  "Stop|PID_FILE=\"\${SUTANDO_WORKSPACE:-\$HOME/.sutando/workspace}/state/watch-tasks-stream.pid\"; if [ -f \"\$PID_FILE\" ]; then PID=\$(cat \"\$PID_FILE\" 2>/dev/null); [ -n \"\$PID\" ] && kill \"\$PID\" 2>/dev/null; rm -f \"\$PID_FILE\"; fi; exit 0"
 )
 
 if ! command -v jq >/dev/null 2>&1; then


### PR DESCRIPTION
## Problem

Claude Code's `Stop` event fires on **turn-end** (after every assistant response), not session-end. The PID-kill block installed by `src/install-claude-hooks.sh` (from #1065) was killing the live Monitor watcher every turn — triggering an exit-143 + Monitor-restart cycle.

Visible in real time today (2026-05-24 PT afternoon):

```
Monitor watcher spawns → bash watcher writes PID file → turn ends
→ Stop hook reads PID, kills watcher → bash exits 143 → Monitor task fails
→ Sutando.app's checkWatcher Timer sees no `pgrep watch-tasks` → sends
  "watcher" keystroke to tmux pane → CLI session starts fresh Monitor
→ ... repeats every turn-end
```

Tasks delivered to the brief watcher-gap got delayed (caught by initial-sweep on next restart), but the cycle adds latency + log noise on every turn.

## Fix

Drop the `Stop` watcher-kill hook from `HOOKS=(...)` in `src/install-claude-hooks.sh`. Hooks installed shrinks from 4 → 3:

| event | command | status |
|---|---|---|
| PreCompact | `cp $TRANSCRIPT_PATH ~/Desktop/sutando-conversations/...` | unchanged |
| PreCompact | `bash src/session-handoff.sh ...` | unchanged |
| Stop | `bash src/check-pending-tasks.sh` | unchanged |
| Stop | watcher-cleanup PID kill | **removed** |

## Why it's safe

Orphan-cleanup defense-in-depth already exists in `src/startup.sh`:

```bash
# Reap any stale watch-tasks-stream watcher from a prior session...
WATCHER_PID_FILE="$WORKSPACE/state/watch-tasks-stream.pid"
if [ -f "$WATCHER_PID_FILE" ]; then
  STALE_PID="$(cat "$WATCHER_PID_FILE" 2>/dev/null || true)"
  if [ -n "$STALE_PID" ] && ps -p "$STALE_PID" -o args= 2>/dev/null | grep -q "watch-tasks-stream"; then
    kill "$STALE_PID" 2>/dev/null || true
    echo "  ✓ reaped stale watch-tasks-stream watcher (pid $STALE_PID)"
  fi
  rm -f "$WATCHER_PID_FILE"
fi
```

This runs at every session start: PID-file + `ps -o args=` cmdline check before kill (so a recycled PID can't accidentally target an unrelated process). The Stop hook was a redundant second layer — and given the actual `Stop` semantics, an actively-harmful one.

## Trade-off

On a clean session exit (Ctrl+C / ⌘Q / `/exit`), the watcher becomes a brief orphan until next session start, when startup.sh reaps it. No tasks lost in that gap — the next session's Monitor initial-sweep picks up anything written to `tasks/` during the orphan window.

## Migration for existing installs

This script is install-only, not uninstall. Users whose `settings.json` already has the watcher-kill Stop hook need to manually remove it. A `jq` recipe is in the updated script header:

```bash
jq 'del(.hooks.Stop[0].hooks[] | select(.command | contains("watch-tasks-stream.pid")))' \
  .claude/settings.json > /tmp/s.json && mv /tmp/s.json .claude/settings.json
```

## References

- #1061 — original orphan-watcher report (Susan, 4h DM-loss)
- #1063 — Susan's heartbeat + SIGPIPE fix (closed in favor of #1065)
- #1065 — PID-file + Stop-hook cleanup (introduced what this PR removes)
- #1074 — orphan-task recovery at startup (different concern, not affected)

The #1061 underlying bug (orphan watcher survives consumer-pipe close on macOS 26.4 per Bassil's repro) is **NOT addressed** by this PR — that's a separate fix (PPID self-check or heartbeat) still TBD. This PR only removes the harmful turn-end-fires Stop hook; the original orphan-watcher fix path needs its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)