### PR TITLE
fix(za-warudo): strip @-mention prefix + bypass requireMention for owner

### DIFF
--- a/skills/discord-voice/scripts/join_trigger.py
+++ b/skills/discord-voice/scripts/join_trigger.py
@@ -97,16 +97,23 @@ def message_is_join_phrase(text: str, join_phrase: str | None = None) -> bool:
     punctuation users add. Exact-match above covers the no-trailing-content
     case.
 
+    Leading `<@id>` / `<@!id>` / `<@&roleid>` Discord mentions are stripped
+    before matching — users summoning via "@Lucy za warudo" in a guild text
+    channel produce "<@1494...> za warudo" as raw content; without
+    stripping, that wouldn't startswith("za warudo").
+
     Pure function — no I/O when `join_phrase` is supplied; tests pass it
     explicitly.
     """
+    import re as _re
     if not text:
         return False
     phrase = (join_phrase if join_phrase is not None else load_join_phrase())
     phrase = (phrase or "").strip().lower()
     if not phrase:
         return False
-    trimmed = text.strip().lower()
+    stripped = _re.sub(r'^(?:\s*<@[!&]?\d+>\s*)+', '', text)
+    trimmed = stripped.strip().lower()
     if trimmed == phrase:
         return True
     if trimmed.startswith(phrase):

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2271,6 +2271,29 @@ async def _handle_discord_message(message, force=False):
             except Exception as e:
                 print(f"  [thread-engage] failed to update access.json: {e}", flush=True)
 
+        # Magic-word fast path: an owner saying the join phrase MUST bypass
+        # requireMention — otherwise the magic word can't fire in any guild
+        # text channel where the bot isn't @-mentioned. Check before the
+        # requireMention skip so "za warudo" in #General (no mention) still
+        # summons the voice spawn for the owner.
+        try:
+            if str(message.author.id) in load_allowed() and _dv_message_is_join_phrase(text):
+                print(f"  [join-trigger] owner @{message.author} said the join phrase — summoning discord-voice (bypassing requireMention)", flush=True)
+                try:
+                    reply = _dv_handle_join_trigger(message)
+                except Exception as e:
+                    print(f"  [join-trigger] handler raised: {e}", flush=True)
+                    reply = "Couldn't process the voice-join request — check the bridge log."
+                try:
+                    if reply:
+                        for chunk in _chunk_for_discord(reply):
+                            await message.channel.send(chunk)
+                except Exception as e:
+                    print(f"  [join-trigger] reply send failed: {e}", flush=True)
+                return
+        except Exception as e:
+            print(f"  [join-trigger] early-path raised: {e}", flush=True)
+
         if require_mention and not bot_mentioned and not role_mentioned:
             print(f"  [skip] not mentioned (requireMention=true)", flush=True)
             return


### PR DESCRIPTION
Two bugs in #1080's bridge integration surfaced during 2026-05-24 owner testing — the magic word doesn't fire in either of the most common owner-summoning patterns.

## Bug A: `requireMention=true` precedes join-phrase check

`src/discord-bridge.py` runs the `requireMention` filter before reaching the join-phrase branch. In a guild channel where the owner says a bare \"za warudo\" with no @-mention, the message gets skipped at the `requireMention` gate before the magic-word path can fire.

**Fix:** Add an owner+phrase fast-path (gated on `load_allowed()`) **before** the `requireMention` skip. The magic word is an explicit owner command — `requireMention` shouldn't apply to it.

## Bug B: `message_is_join_phrase` doesn't handle @-mention prefix

`skills/discord-voice/scripts/join_trigger.py:message_is_join_phrase()` does `text.strip()` then checks startswith(phrase). When the owner summons via \"@Lucy za warudo\" in a guild channel, the raw text is \"<@1494...> za warudo\" — doesn't startswith(\"za warudo\") → no match.

**Fix:** Strip leading `<@id>` / `<@!id>` / `<@&roleid>` mention prefixes (with surrounding whitespace) before the phrase match.

## Verification

End-to-end tested in 2026-05-24 session — bare \"za warudo\" in a guild channel (no @-mention) now fires:

\`\`\`
[join-trigger] owner @susanliu_ said the join phrase — summoning discord-voice (bypassing requireMention)
\`\`\`

Context-prep handoff via #1033's per-channel pull namespace works as expected.

Unit tests for new mention-prefix stripping: **7/7 pass** — bare phrase, single @-prefixed, multi-mention, with punctuation, false-positive (\"za warudonow\"), role mention, and leading/trailing whitespace.

## Diff size

2 files, 31 insertions / 1 deletion.

---

— Lucy (Mac Studio bot)