### PR TITLE
fix(watch-tasks): close both orphan-leak paths (EPIPE buffer + PPID reparent)

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -94,7 +94,7 @@ shopt -u nullglob
 # parent shell exits the watcher reparents to launchd (PPID=1) and runs
 # indefinitely with no consumer, silently dropping every event.
 cleanup() { kill 0 2>/dev/null; }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT HUP INT TERM
 
 # Stream subsequent events. -l 0.5 = 500ms latency batch (fswatch coalesces
 # burst events). --event Created --event Renamed catches new file

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -85,10 +85,16 @@ _tmux_wake() {
 # restart gap.
 shopt -s nullglob
 for f in "$TASKS_DIR"/*.txt; do
-  echo "TASK_FILE: $(basename "$f")"
+  printf 'TASK_FILE: %s\n' "$(basename "$f")" || exit 0
   _tmux_wake
 done
 shopt -u nullglob
+
+# Clean up fswatch on exit (Mode B fix — #1088). Without this, when the
+# parent shell exits the watcher reparents to launchd (PPID=1) and runs
+# indefinitely with no consumer, silently dropping every event.
+cleanup() { kill 0 2>/dev/null; }
+trap cleanup EXIT INT TERM
 
 # Stream subsequent events. -l 0.5 = 500ms latency batch (fswatch coalesces
 # burst events). --event Created --event Renamed catches new file
@@ -110,6 +116,10 @@ shopt -u nullglob
 #    rename — including the source path AFTER the file has moved out.
 #    `[ -f "$path" ]` filters those rename-OUT-of-watched-dir events.
 #    Caught 2026-05-03 #1 (PR #572).
+#
+# Mode A fix (#1088): `|| exit 0` on printf — if the consumer pipe is
+# dead, the first failed write exits immediately instead of silently
+# buffering ~100 events into the kernel pipe buffer.
 fswatch \
   -l 0.5 \
   --event Created \
@@ -120,7 +130,7 @@ fswatch \
     *.txt)
       parent="$(dirname "$path")"
       if [ "$parent" = "$TASKS_DIR_ABS" ] && [ -f "$path" ]; then
-        echo "TASK_FILE: $(basename "$path")"
+        printf 'TASK_FILE: %s\n' "$(basename "$path")" || exit 0
         _tmux_wake
       fi
       ;;


### PR DESCRIPTION
## Summary
- Closes #1088 — two distinct orphan paths in `src/watch-tasks-stream.sh` that cause silent event loss.

## What changed

**Mode A fix (EPIPE-on-dead-reader):** Replace `echo` with `printf ... || exit 0` in both the initial sweep and the fswatch loop. When the consumer pipe is dead, `printf` returns non-zero on the first failed write — `|| exit 0` makes the watcher exit immediately instead of silently buffering ~100 events into the kernel pipe buffer before noticing.

**Mode B fix (PPID=1 reparent):** Add an EXIT/INT/TERM trap that runs `kill 0` (kills the entire process group including fswatch). When the parent shell exits for any reason, the trap fires and tears down fswatch instead of leaving it orphaned under launchd (PPID=1) indefinitely.

## Diff size
1 file, 12 insertions, 2 deletions.

## Test plan
- [x] `bash -n src/watch-tasks-stream.sh` — syntax clean
- [ ] Mode A: start watcher, kill consumer, write event → watcher exits immediately (not after ~100 events)
- [ ] Mode B: start watcher, kill parent shell → fswatch also dies (not reparented to PPID=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)