### PR TITLE
fix(quota-tracker): narrow bare-except to ImportError

### DIFF
--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -28,7 +28,7 @@ sys.path.insert(0, str(_REPO_ROOT / "src"))
 try:
     from workspace_default import status_read_path  # noqa: E402
     _canonical = status_read_path("quota-state.json")
-except Exception:
+except ImportError:
     _canonical = None
 
 if _canonical is not None and _canonical.exists():


### PR DESCRIPTION
## Summary
- Closes #1062 — single-token fix: `except Exception:` → `except ImportError:` on `read-quota.py:25`.

## Why
The bare `except Exception:` masked a path bug (#1055) for 12h by swallowing `ImportError` and falling through to "No quota-state.json found." Narrowing to `ImportError` means only the expected failure mode (module not on path) is caught; any other exception from `status_read_path` propagates visibly in cron logs.

## Test plan
- [x] `python3 skills/quota-tracker/scripts/read-quota.py` prints live 5h/7d windows (verified)
- [ ] Remove `src/` from sys.path → raises `ImportError` → falls through to `_canonical = None` (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)