### PR TITLE
fix(discord-voice): persistent receiver subscription + PCM silence detect (#1095)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -116,6 +116,17 @@ const DISCORD_VOICE_CONFIG = loadVoiceConfig(DISCORD_VOICE_CONFIG_PATH);
 const VOICE_NATIVE_AUDIO_MODEL = DISCORD_VOICE_CONFIG.model;
 const DISCORD_VOICE_GOOGLE_SEARCH = DISCORD_VOICE_CONFIG.googleSearch;
 
+// Comma-separated Discord user IDs of BOT accounts whose audio SHOULD be
+// piped to Gemini despite User.bot=true. Defaults to empty — bots are auto-
+// ignored. Set this when you genuinely want a peer bot's voice processed
+// (rare; usually only for testing). Per #1096 — without this default-deny,
+// the receiver would pipe peer-bot audio to Gemini and cause attribution
+// errors like today's "the other speaker is a bot, not a human" misdiagnosis.
+const ALLOWED_BOT_USER_IDS = new Set(
+	(process.env.SUTANDO_ALLOWED_BOT_USER_IDS ?? '')
+		.split(',').map(s => s.trim()).filter(Boolean)
+);
+
 // Hung-session watchdog threshold. A Gemini Live session can silently stall —
 // audio keeps flowing in but it stops emitting turn.end, with no transport
 // close event to trigger the reconnect path. If utterances have piled up
@@ -274,6 +285,11 @@ interface DiscordVoiceSession {
 	taskResultCache?: Map<string, string>;
 	_toolIdMap?: Map<string, string>;
 	subscribedUsers: Set<string>;
+	client: Client;
+	// Cache of userId → isBot flag from User.bot. Populated lazily on first
+	// speaking.start for each speaker. Used to auto-ignore bot accounts so
+	// the receiver doesn't pipe peer-bot audio to Gemini.
+	botFlagCache: Map<string, boolean>;
 	// Every Discord user who contributed audio to the in-progress Gemini turn.
 	// Added on speaking.start, cleared on turn.end. The tier gate reads this
 	// set (not a live last-speaker pointer) so a tool call is attributed to
@@ -680,7 +696,7 @@ function subscribeUser(s: DiscordVoiceSession, userId: string): void {
 	console.log(`${ts()} [Voice] subscribed to user ${userId} (ffmpeg resample)`);
 }
 
-async function createVoiceSession(connection: VoiceConnection): Promise<DiscordVoiceSession> {
+async function createVoiceSession(connection: VoiceConnection, client: Client): Promise<DiscordVoiceSession> {
 	const bodhiPort = nextBodhiPort++;
 	// Encode guild + channel into the session id so channel-level diagnostics
 	// survive into the sessions table (recordSession has no guild/channel field).
@@ -734,6 +750,8 @@ async function createVoiceSession(connection: VoiceConnection): Promise<DiscordV
 		pendingTasks: 0,
 		closing: false,
 		subscribedUsers: new Set(),
+		client,
+		botFlagCache: new Map(),
 		turnSpeakers: new Set(),
 		audioPending: [],
 		toolCalls: [],
@@ -977,10 +995,32 @@ async function createVoiceSession(connection: VoiceConnection): Promise<DiscordV
 	(s as any)._channelScanHandle = channelScan;
 
 	// Subscribe to anyone currently speaking, and to anyone who starts.
-	connection.receiver.speaking.on('start', (userId) => {
+	connection.receiver.speaking.on('start', async (userId) => {
 		// Attribute this speaker to the in-progress turn. The gate resolves
 		// the turn's effective tier across the whole set (cleared on turn.end).
 		s.turnSpeakers.add(userId);
+		// Bot/human discrimination (#1096). Discord's gateway exposes `User.bot`;
+		// without this check the receiver would happily pipe peer-bot audio to
+		// Gemini, which both wastes API quota and causes attribution errors
+		// (today: a peer-bot's utterance was misattributed to the owner,
+		// triggering a misdiagnosis of "name-gate conflict from a second bot"
+		// when in fact the other account was a human). Cached per-user so we
+		// fetch once per speaker; degrades gracefully (subscribe anyway) if
+		// the fetch fails so this can never *block* an owner from being heard.
+		let isBot = s.botFlagCache.get(userId);
+		if (isBot === undefined) {
+			try {
+				const user = await s.client.users.fetch(userId);
+				isBot = !!user.bot;
+			} catch {
+				isBot = false;
+			}
+			s.botFlagCache.set(userId, isBot);
+		}
+		if (isBot && !ALLOWED_BOT_USER_IDS.has(userId)) {
+			console.log(`${ts()} [Voice] ignoring bot user ${userId} (not in SUTANDO_ALLOWED_BOT_USER_IDS)`);
+			return;
+		}
 		subscribeUser(s, userId);
 	});
 	// Start the constant-rate ticker that flushes audio to Gemini every 20ms.
@@ -1073,7 +1113,7 @@ async function start(): Promise<void> {
 	}
 	console.log(`${ts()} [Setup] voice connection ready`);
 
-	const session = await createVoiceSession(connection);
+	const session = await createVoiceSession(connection, client);
 	active = session;
 	console.log(`${ts()} [Setup] audio bridge live — speak in the channel`);
 

--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -671,8 +671,16 @@ function subscribeUser(s: DiscordVoiceSession, userId: string): void {
 	if (s.subscribedUsers.has(userId)) return;
 	s.subscribedUsers.add(userId);
 
+	// #1095 — Persistent subscription with PCM-side silence detection.
+	// The old per-utterance `EndBehaviorType.AfterSilence` ended the stream
+	// after 200ms of silence, then `speaking.on('start')` re-subscribed on the
+	// next utterance. Discord's receiver only delivers audio from the moment
+	// of subscribe — so every utterance lost ~20-100ms of leading audio (the
+	// initial /h/ of "Hi" reliably got eaten). Manual end keeps the stream
+	// open for the lifetime of the voice session; we synthesize the
+	// utterance-end signal from PCM idle instead of from the stream's `end`.
 	const opusStream = s.connection.receiver.subscribe(userId, {
-		end: { behavior: EndBehaviorType.AfterSilence, duration: 200 },
+		end: { behavior: EndBehaviorType.Manual },
 	});
 	const decoder = new prism.opus.Decoder({ frameSize: 960, channels: 2, rate: 48000 });
 	// Resample 48k stereo s16le → 16k mono s16le via ffmpeg (anti-aliased).
@@ -687,28 +695,48 @@ function subscribeUser(s: DiscordVoiceSession, userId: string): void {
 	opusStream.pipe(decoder).pipe(resampler);
 
 	let chunks = 0;
-	resampler.on('data', (pcm16Mono: Buffer) => {
-		chunks++;
-		try { (s.voiceSession as any).handleAudioFromClient(pcm16Mono); } catch {}
-		(s as any)._noteSpoken?.();
-		if (chunks === 1) console.log(`${ts()} [Voice] first chunk: ${pcm16Mono.length}B`);
-	});
-	resampler.on('end', () => {
-		s.subscribedUsers.delete(userId);
+	let inUtterance = false;
+	let silenceTimer: NodeJS.Timeout | null = null;
+	const SILENCE_END_MS = Number(process.env.SUTANDO_PCM_SILENCE_END_MS) || 200;
+	const fireUtteranceEnd = () => {
+		if (!inUtterance) return;
+		inUtterance = false;
 		console.log(`${ts()} [Voice] user ${userId} stopped speaking (${chunks} chunks) — silence burst`);
-		// Watchdog bookkeeping: an utterance just finished. A healthy Gemini
-		// fires turn.end within seconds; these counters let the watchdog tell
-		// a hang apart from a normal pause.
 		(s as any).lastSpeakStopTs = Date.now();
 		(s as any).utterancesSinceTurn = ((s as any).utterancesSinceTurn || 0) + 1;
 		triggerSilenceBurst(s);
+		chunks = 0; // reset per-utterance counter
+	};
+	resampler.on('data', (pcm16Mono: Buffer) => {
+		if (!inUtterance) {
+			inUtterance = true;
+			console.log(`${ts()} [Voice] first chunk: ${pcm16Mono.length}B`);
+		}
+		chunks++;
+		try { (s.voiceSession as any).handleAudioFromClient(pcm16Mono); } catch {}
+		(s as any)._noteSpoken?.();
+		// Reset the silence timer on every chunk; if no more chunks arrive
+		// within SILENCE_END_MS, fire utterance-end. Discord's receiver
+		// delivers no packets during silence, so absence-of-data is the
+		// signal here (replacing the old `EndBehaviorType.AfterSilence`).
+		if (silenceTimer) clearTimeout(silenceTimer);
+		silenceTimer = setTimeout(fireUtteranceEnd, SILENCE_END_MS);
+	});
+	resampler.on('end', () => {
+		// In Manual mode this fires only if the stream is explicitly destroyed
+		// (e.g. session cleanup). Treat as a final flush + unsubscribe.
+		if (silenceTimer) clearTimeout(silenceTimer);
+		fireUtteranceEnd();
+		s.subscribedUsers.delete(userId);
+		console.log(`${ts()} [Voice] receiver stream ended for ${userId} (session cleanup)`);
 	});
 	resampler.on('error', (e) => {
 		console.error(`${ts()} [Voice] resampler error for ${userId}:`, e);
+		if (silenceTimer) clearTimeout(silenceTimer);
 		s.subscribedUsers.delete(userId);
 	});
 	decoder.on('error', (e) => console.error(`${ts()} [Voice] decoder error for ${userId}:`, e));
-	console.log(`${ts()} [Voice] subscribed to user ${userId} (ffmpeg resample)`);
+	console.log(`${ts()} [Voice] subscribed to user ${userId} (ffmpeg resample, persistent)`);
 }
 
 async function createVoiceSession(connection: VoiceConnection, client: Client): Promise<DiscordVoiceSession> {

--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -127,6 +127,21 @@ const ALLOWED_BOT_USER_IDS = new Set(
 		.split(',').map(s => s.trim()).filter(Boolean)
 );
 
+// Username prefixes that identify a peer SUTANDO bot (distinct from any
+// other Discord bot like a music bot or MEE6). Used by #1089 single-bot
+// enforcement to decide who to refuse-join-against / leave-when-detected.
+// Override via `SUTANDO_PEER_USERNAME_PATTERNS=Foo,Bar` if the naming
+// convention drifts. Match: `username.startsWith(pattern)`, case-sensitive.
+const SUTANDO_PEER_USERNAME_PATTERNS = (process.env.SUTANDO_PEER_USERNAME_PATTERNS ?? 'Sutando-,Sutando_,Lucy-,Lucy_,Maddy,Mini')
+	.split(',').map(s => s.trim()).filter(Boolean);
+
+// Disable #1089 single-bot enforcement (testing-only). Set to "1" to allow
+// multiple sutando peers in the same voice channel without auto-leave. Defaults
+// to enabled. NEVER set in production — bypassing defeats the defense-in-depth
+// design where each peer self-declines AND the already-present peer auto-
+// leaves if a peer joins anyway.
+const SUTANDO_PEER_ENFORCEMENT_DISABLED = process.env.SUTANDO_PEER_ENFORCEMENT_DISABLED === '1';
+
 // Hung-session watchdog threshold. A Gemini Live session can silently stall —
 // audio keeps flowing in but it stops emitting turn.end, with no transport
 // close event to trigger the reconnect path. If utterances have piled up
@@ -1094,6 +1109,31 @@ async function start(): Promise<void> {
 		console.error(`Channel ${CHANNEL_ID} is not a voice channel`);
 		process.exit(1);
 	}
+
+	// #1089 single-bot enforcement, layer 1 (cooperative pre-join check). Scan
+	// current channel members; if any sutando peer is already in, refuse to
+	// join. Each peer self-declines so multiple instances never accidentally
+	// share one voice room. Disable via SUTANDO_PEER_ENFORCEMENT_DISABLED=1
+	// for testing the layer-2 path.
+	const looksLikeSutandoPeer = (username: string, isBot: boolean, userId: string): boolean => {
+		if (!isBot) return false;
+		if (userId === client.user?.id) return false; // myself
+		return SUTANDO_PEER_USERNAME_PATTERNS.some(p => username.startsWith(p));
+	};
+	if (!SUTANDO_PEER_ENFORCEMENT_DISABLED) {
+		const members = (channel as any).members as Map<string, { user: { username: string; bot: boolean; id: string; tag: string } }>;
+		const presentPeers: string[] = [];
+		for (const [, m] of members) {
+			if (looksLikeSutandoPeer(m.user.username, m.user.bot, m.user.id)) {
+				presentPeers.push(m.user.tag);
+			}
+		}
+		if (presentPeers.length > 0) {
+			console.error(`${ts()} [Setup] #1089 refusing to join: sutando peer(s) already present: ${presentPeers.join(', ')}`);
+			process.exit(0); // clean exit — operator (Sutando.app checkWatcher) will retry later when peer leaves
+		}
+	}
+
 	console.log(`${ts()} [Setup] joining voice channel #${(channel as any).name} in guild ${guild.name}`);
 
 	const connection = joinVoiceChannel({
@@ -1116,6 +1156,38 @@ async function start(): Promise<void> {
 	const session = await createVoiceSession(connection, client);
 	active = session;
 	console.log(`${ts()} [Setup] audio bridge live — speak in the channel`);
+
+	// #1089 single-bot enforcement, layer 2 (adversarial post-join watcher).
+	// If a sutando peer joins our channel despite layer 1 (race, env override,
+	// compromised peer), leave the channel after a short audible announcement.
+	if (!SUTANDO_PEER_ENFORCEMENT_DISABLED) {
+		client.on('voiceStateUpdate', (oldState, newState) => {
+			const justJoinedOurChannel = newState.channelId === CHANNEL_ID && oldState.channelId !== CHANNEL_ID;
+			if (!justJoinedOurChannel) return;
+			const u = newState.member?.user;
+			if (!u) return;
+			if (!looksLikeSutandoPeer(u.username, u.bot, u.id)) return;
+			console.error(`${ts()} [Setup] #1089 peer ${u.tag} joined while I was present — announcing + leaving`);
+			// Best-effort audio announcement. The text-injection goes through
+			// the Gemini Live transport so Lucy speaks before disconnecting.
+			// We don't wait for the actual TTS to complete — Gemini might
+			// reword the request — just give it a short window. Worst case
+			// (TTS no-shows) Lucy still leaves; the disconnect is the
+			// authoritative action.
+			try {
+				(session.voiceSession as any).transport.sendContent(
+					[{ role: 'user', text: `[System] Another Sutando bot (${u.tag}) just joined this voice channel. Say briefly: "I detected another Sutando bot — leaving." Then stop.` }],
+					true,
+				);
+			} catch (e) {
+				console.error(`${ts()} [Setup] #1089 announcement injection failed:`, e);
+			}
+			setTimeout(() => {
+				try { connection.destroy(); } catch {}
+				process.exit(0);
+			}, 3000);
+		});
+	}
 
 	connection.on(VoiceConnectionStatus.Disconnected, async () => {
 		try {


### PR DESCRIPTION
Stacked on #1098 (which is stacked on #1097).

## Summary

- Switch receiver subscribe from `EndBehaviorType.AfterSilence(200ms)` to `EndBehaviorType.Manual`. The opus stream stays open for the whole voice session.
- End-of-utterance is now detected PCM-side: a silence timer resets on every chunk; if `SUTANDO_PCM_SILENCE_END_MS` (default 200ms) elapses with no new chunks, fire the existing `lastSpeakStopTs` / `utterancesSinceTurn` / `triggerSilenceBurst` bookkeeping.
- The hung-session watchdog and silence-burst pump are unchanged in behavior — the same bookkeeping fields drive them; only the trigger source moved from stream-end to PCM-idle.

## Why

Discord receive only delivers audio from the moment of subscribe — so per-utterance re-subscribe lost ~20-100ms of leading audio on every utterance. The /h/ of "Hi" reliably got eaten. Todays evidence: ASR transcribed Susans "Hi Lucy can you hear me" as foreign-language fragments ("คือ", "Hidup sekarang", "by") because Gemini received a chopped lead.

## Closes

- Closes #1095. Stacks on #1098 (single-bot enforcement) and #1097 (User.bot detect) — both already merged-pending.

## Test plan

- [x] `npx tsc --noEmit -p .` clean.
- [ ] Manual: speak "Hi Lucy" — `[Voice] first chunk` log should still fire promptly but the chunk should arrive WITHIN milliseconds of the utterance start (not 20-100ms later). Compare conversation_log transcript fidelity vs. pre-PR.
- [ ] Manual: speak utterance → pause >200ms → speak again — expect TWO separate `silence burst` events, same as before.
- [ ] Manual: session cleanup — `resampler.on("end")` flushes silence timer + unsubscribes.

— Lucy (Mac Studio bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)