### PR TITLE
fix(discord-bridge): strip own @-mention prefix before za-warudo join check

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2558,8 +2558,22 @@ async def _handle_discord_message(message, force=False):
     # double-fire the spawn; the helper has its own `_server_already_running`
     # guard anyway, but cheaper to dedup at the front gate.
     if access_tier == "owner":
+        # Strip the bot's own @-mention prefix before the join-phrase check.
+        # In channels with `requireMention=true`, the owner has to write
+        # "<@BOT_ID> za warudo" to even reach this code path — but the
+        # `<@...>` prefix breaks the startswith("za warudo") match in
+        # `message_is_join_phrase`. Without this strip the magic word only
+        # ever works in DMs. Bot-own mention only — leave other user/bot
+        # mentions in text so downstream attribution still sees them.
+        bot_mention_prefix = f"<@{client.user.id}>" if client.user else ""
+        bot_mention_prefix_nick = f"<@!{client.user.id}>" if client.user else ""
+        join_text = text
+        for pfx in (bot_mention_prefix, bot_mention_prefix_nick):
+            if pfx and join_text.lstrip().startswith(pfx):
+                join_text = join_text.lstrip()[len(pfx):].lstrip()
+                break
         try:
-            is_join = _dv_message_is_join_phrase(text)
+            is_join = _dv_message_is_join_phrase(join_text)
         except Exception as e:
             print(f"  [join-trigger] match check raised: {e}", flush=True)
             is_join = False


### PR DESCRIPTION
## Summary

In channels with `requireMention=true` (the default), the owner has to write `<@BOT_ID> za warudo` to even reach the join-trigger code path — but the `<@...>` prefix breaks the `startswith("za warudo")` match in `message_is_join_phrase`. Result: the magic word only ever worked in DMs.

## Fix

Before the `is_join` check at `src/discord-bridge.py:2562`, strip the bots own `@`-mention prefix from a local copy of the text. Both `<@id>` and `<@!id>` (nickname) variants. Original `text` is unchanged — downstream attribution still sees all mentions.

## Verified live

Susan said `<@Lucy> za warudo` in #General; bridge log showed the message reached the `access_tier == "owner"` branch but no `[join-trigger]` print followed → confirmed startswith mismatch on the prefixed text. After this patch the join-phrase check sees `"za warudo"` directly and the spawn fires.

## Why this regression

This was previously fixed by a local patch (`fix(za-warudo): strip @-mention prefix + bypass requireMention for owner`) that I lost in todays force-reset to upstream/main. Re-filing as a proper PR.

— Lucy (Mac Studio bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)