### PR TITLE
fix(voice/phone/discord-voice): unify work-tool description + force tool call for project-specific questions

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -429,8 +429,11 @@ function buildAgent(s: DiscordVoiceSession): MainAgent {
 		tools.push({
 			name: 'work',
 			description:
-				'Do the work. Call this for action requests — sending a message, looking something up, ' +
-				'researching, editing files, generating images, video editing, scheduling. ' +
+				'Do the work. Call this for ANYTHING beyond simple greetings — questions, actions, ' +
+				'research, writing, translation, file changes, system queries, explanations, analysis. ' +
+				'CRITICAL: when asked about THIS specific project (features, commands, code, history, ' +
+				'decisions, what a tool does, how a flow works), ALWAYS call work — your built-in ' +
+				'knowledge does not include this codebase, so guessing produces hallucinations. ' +
 				'Do NOT use this for scrolling or switching apps — use the scroll and switch_app tools instead.',
 			parameters: z.object({
 				task: z.string().describe('Full description of the task to perform'),

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -650,8 +650,11 @@ function buildAgent(callSession: CallSession): MainAgent {
 		tools.push({
 			name: 'work',
 			description:
-				'Do the work. Call this for action requests — calling someone, looking something up, ' +
-				'sending a message, scheduling, researching, editing files, generating images, changing subtitle colors, video editing. ' +
+				'Do the work. Call this for ANYTHING beyond simple greetings — questions, actions, ' +
+				'research, writing, translation, file changes, system queries, explanations, analysis. ' +
+				'CRITICAL: when asked about THIS specific project (features, commands, code, history, ' +
+				'decisions, what a tool does, how a flow works), ALWAYS call work — your built-in ' +
+				'knowledge does not include this codebase, so guessing produces hallucinations. ' +
 				'Do NOT use this for scrolling or switching apps — use the scroll and switch_app tools instead.',
 			parameters: z.object({
 				task: z.string().describe('Full description of the task to perform'),
@@ -1364,8 +1367,11 @@ const server = createServer(async (req, res) => {
 			const workTool: ToolDefinition = {
 				name: 'work',
 				description:
-					'Do the work. Call this for action requests — calling someone, looking something up, ' +
-					'sending a message, scheduling, researching, editing files, generating images, changing subtitle colors, video editing.',
+					'Do the work. Call this for ANYTHING beyond simple greetings — questions, actions, ' +
+					'research, writing, translation, file changes, system queries, explanations, analysis. ' +
+					'CRITICAL: when asked about THIS specific project (features, commands, code, history, ' +
+					'decisions, what a tool does, how a flow works), ALWAYS call work — your built-in ' +
+					'knowledge does not include this codebase, so guessing produces hallucinations.',
 				parameters: z.object({
 					task: z.string().describe('Full description of the task to perform'),
 				}),

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -205,8 +205,11 @@ export function setTaskStatusCallback(fn: (taskId: string, status: string, text:
 export const workTool: ToolDefinition = {
 	name: 'work',
 	description:
-		'Do the work. Call this for anything beyond simple greetings — questions, actions, ' +
+		'Do the work. Call this for ANYTHING beyond simple greetings — questions, actions, ' +
 		'research, writing, translation, file changes, system queries, explanations, analysis. ' +
+		'CRITICAL: when asked about THIS specific project (features, commands, code, history, ' +
+		'decisions, what a tool does, how a flow works), ALWAYS call work — your built-in ' +
+		'knowledge does not include this codebase, so guessing produces hallucinations. ' +
 		'This is how Sutando thinks and acts. Results are spoken back when ready.',
 	parameters: z.object({
 		task: z.string().describe('Full description of the task to perform'),


### PR DESCRIPTION
Closes part of #1102.

## Summary

Today voice agent hallucinated about features ("za warudo activates co-presentation") and tools ("Opening the Sutando repository" with no tool_call row) because the three voice surfaces had three slightly different action-framed work-tool descriptions — "researching" was buried mid-list of action verbs. Model read work as "do things", not "find things out".

## Fix

Unify all three surfaces on the cleaner wording PLUS a CRITICAL clause forcing tool use for project-specific questions:

> Do the work. Call this for ANYTHING beyond simple greetings — questions, actions, research, writing, translation, file changes, system queries, explanations, analysis. CRITICAL: when asked about THIS specific project (features, commands, code, history, decisions, what a tool does, how a flow works), ALWAYS call work — your built-in knowledge does not include this codebase, so guessing produces hallucinations.

Touched:
- `src/task-bridge.ts:208` (workTool used by voice-agent.ts on port 9900)
- `skills/discord-voice/scripts/discord-voice-server.ts:432`
- `skills/phone-conversation/scripts/conversation-server.ts:653, :1370`

## Closes / Related

Related: #1102 (broader grounding guards). This is the work-tool description half; the system-prompt half is still open.

— Lucy (Mac Studio bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)