### PR TITLE
fix(voice/phone): system-prompt anti-hallucination guards (closes #1102)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -428,6 +428,12 @@ function buildAgent(s: DiscordVoiceSession): MainAgent {
 			DISCORD_VOICE_GOOGLE_SEARCH
 				? 'NEVER fabricate specific details. If you don\'t know it, use your built-in Web search to look it up — it\'s faster than delegating, and the answer stays in the conversation. If your built-in search returns nothing useful, OR the question needs deeper-than-one-lookup research (multi-step, multiple sources, file reading), call the work tool — it routes to the core agent which can do extensive research.'
 				: 'NEVER fabricate specific details. If you don\'t know it, use the work tool to look it up.',
+			'',
+			'## Anti-hallucination guards (closes #1102)',
+			'- NEVER narrate a tool call you have NOT actually made. Do not say "I\'m opening the repository", "Let me check the screen", "I\'m searching for that" unless you have already called the corresponding tool in this turn.',
+			'- NEVER invent capabilities. The work tool delegates to a core agent — its scope is described in the work tool\'s description. Do NOT claim za-warudo or any other phrase enables features outside the tools listed in this prompt.',
+			'- For questions about THIS specific project (features, commands, code, what a phrase means in the codebase), ALWAYS call work. Your built-in knowledge does not include this codebase, so synthesizing from it produces hallucinations. Say "I don\'t know — let me check" or call work, never guess.',
+			'- Between work calls, do NOT fill silence with synthesized prose from built-in knowledge. A short "Let me check" is fine; a paragraph of confabulated detail is not.',
 			repoUrl ? `\n## Known info\nSutando GitHub repo: ${repoUrl}` : '',
 		].filter(Boolean).join('\n');
 	} else {

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -538,6 +538,12 @@ function buildAgent(callSession: CallSession): MainAgent {
 		instructions += PHONE_GOOGLE_SEARCH
 			? '\n\nNEVER fabricate specific details. If you don\'t know it, use your built-in Web search to look it up — it\'s faster than delegating, and the answer stays in the conversation. If your built-in search returns nothing useful, OR the question needs deeper-than-one-lookup research (multi-step, multiple sources, file reading), call the work tool — it routes to the core agent which can do extensive research.'
 			: '\n\nNEVER fabricate specific details. If you don\'t know it, use the work tool to look it up.';
+		// Anti-hallucination guards (closes #1102). Mirrors the discord-voice block.
+		instructions += '\n\n## Anti-hallucination guards (closes #1102)';
+		instructions += '\n- NEVER narrate a tool call you have NOT actually made. Do not say "I\'m opening the repository", "Let me check the screen", "I\'m searching for that" unless you have already called the corresponding tool in this turn.';
+		instructions += '\n- NEVER invent capabilities. The work tool delegates to a core agent — its scope is described in the work tool\'s description. Do NOT claim za-warudo or any other phrase enables features outside the tools listed.';
+		instructions += '\n- For questions about THIS specific project (features, commands, code, what a phrase means in the codebase), ALWAYS call work. Your built-in knowledge does not include this codebase, so synthesizing from it produces hallucinations. Say "I don\'t know — let me check" or call work, never guess.';
+		instructions += '\n- Between work calls, do NOT fill silence with synthesized prose from built-in knowledge. A short "Let me check" is fine; a paragraph of confabulated detail is not.';
 	}
 
 	const tools: ToolDefinition[] = [];


### PR DESCRIPTION
## Summary
Adds 4 explicit anti-hallucination rules to the owner-tier system prompt in both `discord-voice` and `phone-conversation` `buildAgent()`. Pairs with #1103 (now MERGEABLE) — that PR strengthened *when* to call `work`; this PR strengthens *what not to say* between/around `work` calls.

## The 4 rules

1. **NEVER narrate a tool call not actually made.** Catches "I'm opening the repository" / "Let me check the screen" phantom narration — today's #1102-flagged class A hallucination.
2. **NEVER invent capabilities.** Tool scope is what the work-tool description says, period. Catches "za warudo enables co-presentation navigation" — class B from today's audit.
3. **Project-specific questions ALWAYS call work.** Built-in knowledge does not include this codebase. Catches "za warudo is from JoJo's Bizarre Adventure" answered as-if-it's-the-codebase-meaning — class C.
4. **Between work calls, don't fill silence with synthesized built-in-knowledge prose.** Catches the "while waiting on work result, agent confabulates a paragraph" pattern Susan observed in sqlite earlier (msg-id `1508502999088107731`, sqlite ep012-recording lines 11-23 of the script).

## Why a separate PR from #1103

Issue #1102 has two halves:
- **A) work-tool description** — tells the model WHEN to call work. Done in #1103.
- **B) system-prompt hardening** — tells the model what NOT to say between work calls. This PR.

Half (A) lands the model in `work` more reliably; half (B) keeps it from confabulating in the gaps. Both are needed — work-routing alone doesn't fix mid-turn hallucination.

## voice-agent.ts unchanged
`src/voice-agent.ts` already has equivalent guards (lines 713-719 — "NEVER pretend you called a tool", "ALWAYS delegate to work for missing context"). This PR brings the two `skills/` voice surfaces to parity.

## Test plan
- [x] `npx tsc --noEmit -p .` clean
- [ ] Live test on Susan's voice channel after merge. The specific hallucinations seen earlier today (sqlite ep012-recording lines 11-23: "I'm searching the Sutando repository", "za warudo enables co-presentation") should not reproduce.

## Closes
- Closes #1102 — the system-prompt half is now addressed alongside #1103's work-tool-description half.

— Lucy (Mac Studio bot)