### PR TITLE
[replaces #1101] fix(discord-voice): lead with INSTANCE_NAME in voice agent identity

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -127,6 +127,12 @@ const ALLOWED_BOT_USER_IDS = new Set(
 		.split(',').map(s => s.trim()).filter(Boolean)
 );
 
+// Per-instance display name (e.g. "Lucy" on Mac Studio, "Maddy" on MacBook).
+// When set, the voice-agent system prompt leads with the instance name so
+// Gemini answers "who are you" with the instance name, not the generic
+// "Sutando". Empty / unset = generic-Sutando identity (backwards-compatible).
+const INSTANCE_NAME = process.env.SUTANDO_INSTANCE_NAME ?? '';
+
 // Hung-session watchdog threshold. A Gemini Live session can silently stall —
 // audio keeps flowing in but it stops emitting turn.end, with no transport
 // close event to trigger the reconnect path. If utterances have piled up
@@ -400,8 +406,12 @@ function buildAgent(s: DiscordVoiceSession): MainAgent {
 			catch { return ''; }
 		})();
 		instructions = [
-			`You are Sutando, a personal AI assistant. You are in a Discord voice channel with your owner${OWNER_NAME ? ` ${OWNER_NAME}` : ''}.`,
-			'YOU are Sutando — the AI assistant. The person speaking is your OWNER, a human. Do NOT confuse yourself with them.',
+			INSTANCE_NAME
+				? `You are ${INSTANCE_NAME}, a Sutando instance — a personal AI assistant. You are in a Discord voice channel with your owner${OWNER_NAME ? ` ${OWNER_NAME}` : ''}. When the owner asks who you are, answer with "${INSTANCE_NAME}", not "Sutando".`
+				: `You are Sutando, a personal AI assistant. You are in a Discord voice channel with your owner${OWNER_NAME ? ` ${OWNER_NAME}` : ''}.`,
+			INSTANCE_NAME
+				? `YOU are ${INSTANCE_NAME} — a Sutando AI assistant. The person speaking is your OWNER, a human. Do NOT confuse yourself with them.`
+				: 'YOU are Sutando — the AI assistant. The person speaking is your OWNER, a human. Do NOT confuse yourself with them.',
 			'You have full capabilities — use the work tool for anything: check the screen, send emails, look things up, make calls, browse the web, or check results of previous tasks.',
 			'',
 			'## How to think',
@@ -432,7 +442,9 @@ function buildAgent(s: DiscordVoiceSession): MainAgent {
 		].filter(Boolean).join('\n');
 	} else {
 		instructions = [
-			'You are Sutando, an AI assistant in a Discord voice channel.',
+			INSTANCE_NAME
+				? `You are ${INSTANCE_NAME}, a Sutando AI assistant in a Discord voice channel. When asked who you are, answer with "${INSTANCE_NAME}".`
+				: 'You are Sutando, an AI assistant in a Discord voice channel.',
 			'Be helpful and conversational. You can answer general knowledge questions, do translations, and have conversations.',
 			'You cannot access files, control the screen, or delegate tasks.',
 			'Keep responses to 1-2 sentences.',


### PR DESCRIPTION
> **Replaces #1101**, which auto-closed when the fork `liususan091219/sutando-fork` was briefly deleted+recreated. GitHub disallows reopening across fork-recreation. Same branch + same commits.

---

Today Susan said "Hi Lucy" and the voice agent replied "Im Sutando, not Lucy." Because the system prompt literally says "You are Sutando" and `SUTANDO_INSTANCE_NAME` was not referenced in the identity lines on current main.

## Fix

When `SUTANDO_INSTANCE_NAME` is set, lead the identity lines with the instance name and tell the model explicitly to answer with that name when asked who it is. Falls back to the generic "Sutando" wording when the env var is empty (backwards-compatible). Applied to both owner and non-owner instruction blocks.

## Test

- [x] `npx tsc --noEmit -p .` clean.
- [ ] Manual: with `SUTANDO_INSTANCE_NAME=Lucy`, ask "who are you" in voice — expect "Lucy".
- [ ] Manual: unset `SUTANDO_INSTANCE_NAME`, ask "who are you" — expect "Sutando" (backwards-compatible).

— Lucy (Mac Studio bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)