### PR TITLE
[replaces #1092] fix(security): scrub stack traces from HTTP error responses (CodeQL #49/#50/#51)

### DIFF
--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -338,7 +338,8 @@ export function startStreaming(
 		const info = startStream(source, fps ?? DEFAULT_FPS);
 		return { status: 'streaming', source: source.name, fps: info.fps, intervalMs: info.intervalMs, mode: 'pull' };
 	} catch (err) {
-		return { status: 'failed', error: (err as Error)?.message ?? String(err) };
+		console.error(`${ts()} [Vision] startStreaming threw: ${(err as Error)?.message ?? err}`);
+		return { status: 'failed', error: 'startStreaming failed' };
 	}
 }
 
@@ -417,7 +418,7 @@ export function submitFrame(data: Buffer, mimeType: string = 'image/jpeg'): { ok
 		return { ok: true };
 	} catch (err) {
 		console.error(`${ts()} [Vision] sendFile threw: ${(err as Error)?.message ?? err}`);
-		return { ok: false, error: (err as Error)?.message ?? String(err) };
+		return { ok: false, error: 'submitFrame failed' };
 	}
 }
 
@@ -489,7 +490,8 @@ export const sendVisionFrameTool: ToolDefinition = {
 			if (!r.ok) return { status: 'failed', error: r.error };
 			return { status: 'sent', source: source.name };
 		} catch (err) {
-			return { status: 'failed', error: (err as Error)?.message ?? String(err) };
+			console.error(`${ts()} [Vision] sendVisionFrameTool threw: ${(err as Error)?.message ?? err}`);
+			return { status: 'failed', error: 'captureAndSend failed' };
 		}
 	},
 };
@@ -532,7 +534,8 @@ export const startVisionTool: ToolDefinition = {
 			const info = startStream(source, fps ?? DEFAULT_FPS);
 			return { status: 'streaming', source: source.name, fps: info.fps, intervalMs: info.intervalMs };
 		} catch (err) {
-			return { status: 'failed', error: (err as Error)?.message ?? String(err) };
+			console.error(`${ts()} [Vision] startVisionTool threw: ${(err as Error)?.message ?? err}`);
+			return { status: 'failed', error: 'startStream failed' };
 		}
 	},
 };

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -3831,8 +3831,9 @@ const server = createServer((req, res) => {
 			res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' });
 			res.end(raw);
 		} catch (e: any) {
+			console.error('[web-client] /paidsubscriptions/data failed:', e);
 			res.writeHead(500, { 'Content-Type': 'application/json' });
-			res.end(JSON.stringify({ error: e?.message || String(e) }));
+			res.end(JSON.stringify({ error: 'failed to read subscriptions' }));
 		}
 		return;
 	}
@@ -3870,8 +3871,9 @@ const server = createServer((req, res) => {
 			res.writeHead(200, { 'Content-Type': 'application/json' });
 			res.end(JSON.stringify({ ok: true, task_id: taskId, message: 'Scan queued; the next proactive-loop pass will pick it up (~1 min). Refresh to see results.' }));
 		} catch (e: any) {
+			console.error('[web-client] /paidsubscriptions/scan failed:', e);
 			res.writeHead(500, { 'Content-Type': 'application/json' });
-			res.end(JSON.stringify({ ok: false, error: e?.message || String(e) }));
+			res.end(JSON.stringify({ ok: false, error: 'failed to enqueue scan' }));
 		}
 		return;
 	}


### PR DESCRIPTION
> **Replaces #1092**, auto-closed when the source fork was briefly deleted+recreated. GitHub disallows reopening across fork-recreation. Same branch + same commits.

---

## Summary
- Closes 3 open CodeQL `js/stack-trace-exposure` warnings on `main`:
  - **#49** `src/web-client.ts:3835` — `/paidsubscriptions/data` (LAN-reachable when `HTTP_HOST=0.0.0.0`)
  - **#50** `src/web-client.ts:3874` — `/paidsubscriptions/scan` (localhost-gated, but flagged via flow analysis)
  - **#51** `src/vision-tools.ts:583` — `/vision/*` control endpoints (127.0.0.1-bound; CodeQL flagged the `respond()` sink, sourced from 4 upstream catch blocks at lines 341/420/492/535)
- Pattern at all 6 sites: `error: e?.message || String(e)` in the response body. Replaced with server-side `console.error(...)` + generic label in the body.

## What changed
- `src/vision-tools.ts`: 4 catch blocks (`startStreaming`, `submitFrame`, `sendVisionFrameTool.execute`, `startVisionTool.execute`) — log full error via `console.error(\`${ts()} [Vision] ...\`)`, return `{ status: 'failed', error: '<op> failed' }`.
- `src/web-client.ts`: 2 catch blocks in `/paidsubscriptions/data` + `/paidsubscriptions/scan` — log via `console.error('[web-client] ...')`, return `'failed to read subscriptions'` / `'failed to enqueue scan'`.

Callers (Gemini tool consumers, the `/paidsubscriptions` UI fetch handler) branch on status code + `ok` flag — they don't depend on specific error text. Diagnostic info preserved server-side.

## Test plan
- [x] `npx tsc --noEmit` clean on changed files
- [ ] CodeQL re-scan after merge should clear #49 / #50 / #51
- [ ] Manual: trigger `/paidsubscriptions/data` failure → confirm 500 body is `{"error":"failed to read subscriptions"}`, full error in stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)