### PR TITLE
fix(discord-voice): load stand-identity.json for per-node Stand name (supersedes #1110)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -35,6 +35,7 @@ import { join, dirname } from 'node:path';
 import { resolveWorkspace } from '../../../src/workspace_default.js';
 import { recordConversation, recordSession, recordToolCall } from '../../../src/conversation-store.js';
 import { resultBelongsTo } from '../../../src/result-channel-key.js';
+import { personalPath } from '../../../src/util_paths.js';
 import { type Tier, loadAccessTiers, effectiveTier, toolAllowed, toolNeed } from './access-tier.js';
 
 _dotenvConfig({ path: new URL('../../../.env', import.meta.url).pathname, override: true });
@@ -402,6 +403,15 @@ function buildAgent(s: DiscordVoiceSession): MainAgent {
 		instructions = [
 			`You are Sutando, a personal AI assistant. You are in a Discord voice channel with your owner${OWNER_NAME ? ` ${OWNER_NAME}` : ''}.`,
 			'YOU are Sutando — the AI assistant. The person speaking is your OWNER, a human. Do NOT confuse yourself with them.',
+			// Per-node Stand identity — mirrors src/voice-agent.ts:606 pattern.
+			// `stand-identity.json` carries name + nameOrigin for the bot on
+			// this machine (e.g. "Echo Act IV (Mini)" on the Mac mini, "Lucy"
+			// on Susan's Mac Studio). Loading it here lets the discord-voice
+			// agent answer "who are you" with the same Stand name the core
+			// voice-agent already uses — single per-node identity contract
+			// across surfaces, no parallel env var. Silent fall-through if
+			// the file is absent (kept the generic "You are Sutando" framing).
+			(() => { try { const si = JSON.parse(readFileSync(personalPath('stand-identity.json'), 'utf-8')); return si.name ? `Your Stand name is ${si.name}. Origin: ${si.nameOrigin || 'earned through use'}. When asked your name or who you are, say "I'm Sutando — ${si.name}."` : ''; } catch { return ''; } })(),
 			'You have full capabilities — use the work tool for anything: check the screen, send emails, look things up, make calls, browse the web, or check results of previous tasks.',
 			'',
 			'## How to think',
@@ -433,10 +443,15 @@ function buildAgent(s: DiscordVoiceSession): MainAgent {
 	} else {
 		instructions = [
 			'You are Sutando, an AI assistant in a Discord voice channel.',
+			// Per-node Stand identity — same load as owner-tier block above. Non-
+			// owner speakers also benefit from "this Sutando is named X" so
+			// "Hi Lucy" / "Hi Mini" doesn't get the rigid "I'm Sutando, not X"
+			// correction.
+			(() => { try { const si = JSON.parse(readFileSync(personalPath('stand-identity.json'), 'utf-8')); return si.name ? `Your Stand name is ${si.name}. When asked your name, say "I'm Sutando — ${si.name}."` : ''; } catch { return ''; } })(),
 			'Be helpful and conversational. You can answer general knowledge questions, do translations, and have conversations.',
 			'You cannot access files, control the screen, or delegate tasks.',
 			'Keep responses to 1-2 sentences.',
-		].join('\n');
+		].filter(Boolean).join('\n');
 	}
 
 	const tools: ToolDefinition[] = [];


### PR DESCRIPTION
## Summary

`skills/discord-voice/scripts/discord-voice-server.ts` was hardcoding "You are Sutando" in both owner and non-owner prompt blocks, ignoring `stand-identity.json` — the existing per-node identity file that `src/voice-agent.ts:579,606` already loads. When a user said "Hi Lucy" or "Hi Mini" to the bot in a Discord voice channel, the agent rigidly corrected with "I'm Sutando, not Lucy."

This PR mirrors the voice-agent.ts loading pattern in discord-voice-server.ts.

## Why supersedes #1110

#1110 added a parallel mechanism (`SUTANDO_INSTANCE_NAME` env var) for the same need. But `stand-identity.json` already exists per-node (carrying name + nameOrigin + machine + capabilities), is already loaded by the core voice-agent, and is the single source of truth Sutando uses across surfaces:

- `src/voice-agent.ts:579,606` — already injects "Your Stand name is X. ..."
- `src/dashboard.py:382`, `src/agent-api.py:431` — `/stand-identity` API endpoint
- `src/event_log.py:63` — cached `read_stand_identity()`
- `src/util_paths.py:17`, `util_paths.ts:7` — helper resolution
- `src/discord-bridge.py:482` — uses `machine` field
- `src/scan-call-logs.py:231` — fallback hint

Adding a separate env var (#1110) would fork the identity contract across surfaces with no benefit; loading the existing file keeps one mechanism.

## What changed

- Adds `personalPath` import from `../../../src/util_paths.js`
- **Owner-tier instruction block**: IIFE reads `personalPath('stand-identity.json')`, injects `Your Stand name is X. Origin: Y. When asked your name or who you are, say "I'm Sutando — X."` (verbatim shape from voice-agent.ts:606)
- **Non-owner-tier instruction block**: shorter variant of the same line (drops the Origin clause since non-owners don't need that depth)
- Both blocks silently fall through to the existing generic "You are Sutando" framing if the file is absent (try/catch returns `''`)
- Non-owner block now uses `.filter(Boolean).join('\n')` to drop the empty-string fallthrough (matches owner-block pattern)

## Verified

- `npx tsc --noEmit -p .` clean
- On this Mac mini, `stand-identity.json` has `name="Echo Act IV (Mini)"`, `nameOrigin="Echoes (Pink Floyd) — a Stand that resonates across channels"` — the IIFE returns the expected prompt line
- Manual voice test pending (system-prompt behavior change)

## Closes

- #1110 — superseded by this approach (single identity mechanism vs. parallel env var)