### PR TITLE
fix(discord-bridge,dm-result): honor access.json top-level "owner" field

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -3347,15 +3347,18 @@ async def poll_proactive():
                             access_data = {}
                         allow_list = access_data.get("allowFrom") or []
                         tier_map = access_data.get("tierMap") or {}
-                        if not allow_list:
+                        # #1117: explicit top-level `owner` wins over tierMap+allowFrom fallback.
+                        owner_id = (access_data.get("owner") or "").strip() or None
+                        if not owner_id and not allow_list:
                             print(f"  [proactive] no owner in allowFrom, skipping {f.name}")
                             f.unlink(missing_ok=True)
                             continue
                         # Preferred: the tier-tagged owner if one exists in allowFrom.
-                        owner_id = next(
-                            (uid for uid in allow_list if tier_map.get(uid) == "owner"),
-                            None,
-                        )
+                        if owner_id is None:
+                            owner_id = next(
+                                (uid for uid in allow_list if tier_map.get(uid) == "owner"),
+                                None,
+                            )
                         # Fallback: first non-bot user, list order preserved.
                         if owner_id is None:
                             for uid in allow_list:

--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -310,6 +310,17 @@ def _resolve_owner_id(token):
         data = json.loads(ACCESS_JSON.read_text())
     except Exception:
         return ""
+
+    # Layer 1 (#1117): consult the explicit top-level `owner` field before
+    # the legacy tierMap → allowFrom fallback chain. `/discord:access` writes
+    # this as the canonical owner id; the fallback below is best-effort and
+    # mis-routed on Susan's Mac Studio on 2026-05-25 when `tierMap` was null
+    # and `allowFrom[0]` was a non-owner human. Mirrors the same precedence
+    # added to `src/discord-bridge.py:poll_proactive` in this PR.
+    explicit_owner = (data.get("owner") or "").strip()
+    if explicit_owner:
+        return explicit_owner
+
     allow = data.get("allowFrom") or []
     if not allow:
         return ""


### PR DESCRIPTION
## Summary

- `_poll_proactive` (discord-bridge.py) and `_resolve_owner_id` (dm-result.py) walked `env → tierMap → allowFrom[0]` for owner resolution. When `tierMap` is null and `allowFrom[0]` is a non-owner human, DMs silently routed to the wrong account.
- `access.json` already carries a canonical `"owner"` field written by `/discord:access`; both resolvers ignored it.
- This patch inserts a check for the explicit `"owner"` field between the env-var and the legacy fallback chain. ~4 logical lines per file.

## Why it matters

Confirmed live on Mac Studio 2026-05-25: Lucy's Layer-1 voice-join refusal (from #1109) wrote a `proactive-*.txt`, the bridge resolved owner_id to `allowFrom[0]` (a non-owner human), and DM'd that user three times. The owner got nothing.

The two adjacent merged PRs that touched this code (#846, #985) made the resolution **deterministic** but kept the **best-effort fallback** behavior. Neither read `access_data.get("owner")`.

## Diff size

```
 src/discord-bridge.py | 13 ++++++++-----
 src/dm-result.py      | 11 +++++++++++
 2 files changed, 19 insertions(+), 5 deletions(-)
```

## Test plan

- [ ] With `SUTANDO_DM_OWNER_ID` unset and `tierMap: null` in access.json, restart the bridge — confirm proactive DMs route to `access_data["owner"]` and not `allowFrom[0]`.
- [ ] With `SUTANDO_DM_OWNER_ID` set, confirm env-var still wins (back-compat).
- [ ] With no env, no `owner` field, and a populated `allowFrom`, confirm the legacy tierMap → first-non-bot fallback still works for users who haven't run `/discord:access` yet.

— Lucy (Mac Studio bot)