### PR TITLE
fix(security): scrub e.message from 3 more web-client.ts res.end sites (closes #1119)

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -3741,8 +3741,9 @@ const server = createServer((req, res) => {
 				res.writeHead(200, { 'Content-Type': 'application/json' });
 				res.end(JSON.stringify({ ok: true }));
 			} catch (e) {
+				console.error('[web-client] /note-viewing parse failed:', e);
 				res.writeHead(400, { 'Content-Type': 'application/json' });
-				res.end(JSON.stringify({ error: e instanceof Error ? e.message : 'parse failed' }));
+				res.end(JSON.stringify({ error: 'note-viewing parse failed' }));
 			}
 		});
 		return;
@@ -3802,8 +3803,9 @@ const server = createServer((req, res) => {
 			},
 		);
 		proxyReq.on('error', (e) => {
+			console.error('[web-client] overlay control proxy failed:', e);
 			res.writeHead(502, { 'Content-Type': 'application/json' });
-			res.end(JSON.stringify({ ok: false, error: 'overlay control proxy failed: ' + e.message }));
+			res.end(JSON.stringify({ ok: false, error: 'overlay control proxy failed' }));
 		});
 		req.pipe(proxyReq);
 		return;
@@ -3819,8 +3821,9 @@ const server = createServer((req, res) => {
 			res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
 			res.end(renderSubscriptionsHtml(raw));
 		} catch (e: any) {
+			console.error('[web-client] /paidsubscriptions render failed:', e);
 			res.writeHead(500, { 'Content-Type': 'text/plain' });
-			res.end('Error reading subscriptions: ' + (e?.message || String(e)));
+			res.end('Error reading subscriptions');
 		}
 		return;
 	}


### PR DESCRIPTION
## Summary

PR #1114 fixed 6 catch sites flagged by CodeQL `js/stack-trace-exposure` warnings (#49 / #50 / #51). Lucy's post-merge audit caught 3 sibling sites with the same exposure pattern that CodeQL didn't flag (different upstream flow-analysis paths). Issue #1119 documented the gap.

This PR applies the identical #1114 pattern (server-side `console.error(...)` + generic body label) to the 3 missed sites.

## Sites changed

| Line | Endpoint | Was | Now |
|---|---|---|---|
| 3744 | `/note-viewing` POST | `e instanceof Error ? e.message : 'parse failed'` | `'note-viewing parse failed'` |
| 3806 | overlay control proxy | `'overlay control proxy failed: ' + e.message` | `'overlay control proxy failed'` |
| 3823 | `/paidsubscriptions` HTML | `'Error reading subscriptions: ' + (e?.message || String(e))` | `'Error reading subscriptions'` |

Each adds a `console.error('[web-client] /endpoint failed:', e)` so diagnostic info stays in stderr.

## Why these and not others

Audited the file for `e.message`/`err.message`/`String(e)` patterns. Remaining occurrences (lines 1492, 1704, 2119, 2799, 3205, 3456, 3474) are all either:
- Client-side JavaScript (browser-side `dbg` / status text — not server-side leak)
- Stored in private state (`_parse_error` in the local data object, never sent in a response)

Only the 3 above leaked through `res.end(...)` to a network response, matching the CodeQL pattern class.

## Closes

- Closes #1119

## Test plan

- [x] `npx tsc --noEmit -p .` clean
- [ ] Manual: trigger each endpoint failure → confirm response body is generic + full error in stderr
- [ ] CodeQL re-scan after merge should report clean for these sites

## Cold-review attribution

I (sonichi via Sutando-Mini) cold-reviewed #1114 with "addresses exactly the 6 catch sites flagged, no drive-by changes" — trusted CodeQL's coverage. @liususan091219 caught the gap in post-merge audit. This PR is the follow-up.