### PR TITLE
feat(migrations): 0001 — PRIVATE_DIR → MEMORY_DIR rename (closes #956)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ tests/*
 !tests/*.test.sh
 !tests/_helpers/
 !tests/_helpers/*.ts
+!tests/migrations/
+!tests/migrations/*.py
 skills/personal-*/
 tests/security/*.md
 !tests/security/*.md.example

--- a/migrations/0001-rename-private-dir-to-memory-dir.sh
+++ b/migrations/0001-rename-private-dir-to-memory-dir.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Migration 0001 — record SUTANDO_PRIVATE_DIR → SUTANDO_MEMORY_DIR rename (#876).
+#
+# Most installs are already post-rename (the alias in workspace_default.py has been
+# forwarding since #876). This script handles the edge case where a user's ~/.sutando/env
+# still contains the old key and performs the in-place rename so it's clean.
+# Idempotent: exits 0 with no mutation when the rename is already applied or neither
+# key is set.
+set -euo pipefail
+
+ENV_FILE="${SUTANDO_ENV_FILE:-$HOME/.sutando/env}"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "[0001] No $ENV_FILE — nothing to rename."
+  exit 0
+fi
+
+if ! grep -q "^SUTANDO_PRIVATE_DIR=" "$ENV_FILE" 2>/dev/null; then
+  echo "[0001] SUTANDO_PRIVATE_DIR not found in $ENV_FILE — already migrated or never set."
+  exit 0
+fi
+
+# In-place sed rename: SUTANDO_PRIVATE_DIR= → SUTANDO_MEMORY_DIR=
+if sed -i '' 's/^SUTANDO_PRIVATE_DIR=/SUTANDO_MEMORY_DIR=/' "$ENV_FILE" 2>/dev/null ||
+   sed -i  's/^SUTANDO_PRIVATE_DIR=/SUTANDO_MEMORY_DIR=/' "$ENV_FILE" 2>/dev/null; then
+  echo "[0001] Renamed SUTANDO_PRIVATE_DIR → SUTANDO_MEMORY_DIR in $ENV_FILE"
+else
+  echo "[0001] ERROR: sed rename failed" >&2
+  exit 1
+fi
+
+# Verify post-state
+if grep -q "^SUTANDO_PRIVATE_DIR=" "$ENV_FILE"; then
+  echo "[0001] ERROR: SUTANDO_PRIVATE_DIR still present after rename" >&2
+  exit 1
+fi
+echo "[0001] Verified: SUTANDO_PRIVATE_DIR absent, migration complete."

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,44 @@
+# Sutando Migration Scripts
+
+Migrations run once at startup (via `src/startup.sh`) and are tracked in
+`$SUTANDO_WORKSPACE/state/schema-version.json`. Applied migrations never run again.
+
+## Naming convention
+
+```
+NNNN-short-description.{sh,py}
+```
+
+- `NNNN` is a zero-padded 4-digit number, starting at `0001`.
+- Each number must be exactly 1 greater than the current highest number in `main`.
+- Two open PRs proposing the same number → CI fails (`tests/migrations/test_no_collision.py`).
+
+## Per-script contract
+
+| Requirement | Detail |
+|---|---|
+| **Idempotent** | Running the script a second time must be safe — check before mutating. |
+| **Exit 0** | Signals success; runner records the migration as applied. |
+| **Exit non-zero** | Signals failure; runner aborts startup and prints script path + exit code + stderr tail. |
+| **No side-effects on dry-run** | Scripts SHOULD respect `DRY_RUN=1` env and print what they would do without doing it. |
+
+## State file
+
+`$SUTANDO_WORKSPACE/state/schema-version.json`:
+
+```json
+{
+  "applied": [1, 2, 3],
+  "current": 3,
+  "engine_version_at_apply": "v0.1.0"
+}
+```
+
+Missing file → treated as `{"applied": [], "current": 0}` (fresh install).
+
+## Running manually
+
+```bash
+python3 src/run_migrations.py            # apply pending, exit 0 if none
+python3 src/run_migrations.py --dry-run  # print pending without applying
+```

--- a/src/run_migrations.py
+++ b/src/run_migrations.py
@@ -1,0 +1,187 @@
+"""Migration runner — applies pending NNNN-*.{sh,py} scripts under migrations/.
+
+Called by src/startup.sh before services launch. Also importable for testing.
+
+State lives at $SUTANDO_WORKSPACE/state/schema-version.json.
+Exit 0 = all pending migrations applied (or none pending).
+Exit non-zero = a migration script failed; startup should abort.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+
+# ── state schema ──────────────────────────────────────────────────────────────
+
+_EMPTY_STATE: dict = {"applied": [], "current": 0}
+
+
+def _state_path(workspace: Path) -> Path:
+    return workspace / "state" / "schema-version.json"
+
+
+def read_state(workspace: Path) -> dict:
+    p = _state_path(workspace)
+    if not p.exists():
+        return dict(_EMPTY_STATE)
+    try:
+        data = json.loads(p.read_text())
+        data.setdefault("applied", [])
+        data.setdefault("current", 0)
+        return data
+    except (json.JSONDecodeError, OSError):
+        return dict(_EMPTY_STATE)
+
+
+def write_state(workspace: Path, state: dict) -> None:
+    p = _state_path(workspace)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    # Atomic write: tmp + rename so a mid-write crash leaves a valid file.
+    fd, tmp = tempfile.mkstemp(dir=p.parent, prefix=".schema-version-")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(state, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, p)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# ── migration discovery ────────────────────────────────────────────────────────
+
+def _migrations_dir() -> Path:
+    return Path(__file__).resolve().parent.parent / "migrations"
+
+
+def list_pending(workspace: Path, migrations_dir: Optional[Path] = None) -> list[tuple[int, Path]]:
+    """Return [(N, path), ...] for migrations not yet in state['applied'], sorted."""
+    mdir = migrations_dir or _migrations_dir()
+    state = read_state(workspace)
+    applied: set[int] = set(state.get("applied", []))
+
+    pending: list[tuple[int, Path]] = []
+    if not mdir.is_dir():
+        return pending
+
+    for p in sorted(mdir.iterdir()):
+        name = p.name
+        if not p.is_file():
+            continue
+        if p.suffix not in (".sh", ".py"):
+            continue
+        parts = name.split("-", 1)
+        if not parts[0].isdigit() or len(parts[0]) != 4:
+            continue
+        n = int(parts[0])
+        if n not in applied:
+            pending.append((n, p))
+
+    return sorted(pending)
+
+
+# ── runner ────────────────────────────────────────────────────────────────────
+
+def run_migrations(
+    workspace: Path,
+    migrations_dir: Optional[Path] = None,
+    dry_run: bool = False,
+    engine_version: str = "",
+) -> int:
+    """Apply pending migrations. Returns 0 on success, 1 on failure."""
+    pending = list_pending(workspace, migrations_dir)
+
+    if not pending:
+        return 0
+
+    state = read_state(workspace)
+
+    for n, script in pending:
+        if dry_run:
+            print(f"[dry-run] would apply migration {n:04d}: {script.name}")
+            continue
+
+        print(f"  Applying migration {n:04d}: {script.name}")
+        env = {**os.environ, "SUTANDO_WORKSPACE": str(workspace), "DRY_RUN": "0"}
+
+        if script.suffix == ".sh":
+            cmd = ["bash", str(script)]
+        else:
+            cmd = [sys.executable, str(script)]
+
+        result = subprocess.run(cmd, env=env, capture_output=True, text=True)
+
+        if result.returncode != 0:
+            print(f"  ✗ Migration {n:04d} failed (exit {result.returncode}): {script}", file=sys.stderr)
+            if result.stderr.strip():
+                for line in result.stderr.strip().splitlines()[-10:]:
+                    print(f"    {line}", file=sys.stderr)
+            return 1
+
+        state["applied"] = sorted(set(state.get("applied", [])) | {n})
+        state["current"] = max(state.get("current", 0), n)
+        if engine_version:
+            state["engine_version_at_apply"] = engine_version
+        write_state(workspace, state)
+        print(f"  ✓ Migration {n:04d} applied")
+
+    return 0
+
+
+# ── workspace_default idempotent bootstrap ────────────────────────────────────
+
+_bootstrap_sentinel: bool = False
+
+
+def _bootstrap_on_import() -> None:
+    """Run migrations once on first import in manual claude sessions.
+
+    Sentinel-gated so repeated imports are cheap.
+    """
+    global _bootstrap_sentinel
+    if _bootstrap_sentinel:
+        return
+    _bootstrap_sentinel = True
+
+    try:
+        from workspace_default import resolve_workspace  # type: ignore[import]
+        workspace = Path(resolve_workspace())
+    except Exception:
+        return
+
+    try:
+        run_migrations(workspace)
+    except Exception:
+        pass
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    dry_run = "--dry-run" in sys.argv
+
+    try:
+        from workspace_default import resolve_workspace  # type: ignore[import]
+        workspace = Path(resolve_workspace())
+    except ImportError:
+        # Fallback when run outside the repo (e.g. in tests with a fake home).
+        ws_env = os.environ.get("SUTANDO_WORKSPACE", "")
+        if ws_env:
+            workspace = Path(ws_env).expanduser()
+        else:
+            workspace = Path.home() / ".sutando" / "workspace"
+
+    return run_migrations(workspace, dry_run=dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -182,6 +182,13 @@ mkdir -p tasks results data
 # notes/post-mortem-dm-flood-2026-04-15.md.
 python3 "$REPO/src/archive-stale-results.py" || true
 
+# Run workspace migrations (pre-service, single-writer by construction).
+# Aborts startup if any migration exits non-zero.
+if ! python3 "$REPO/src/run_migrations.py"; then
+  echo "  ✗ Migration failed — fix the error above and restart."
+  exit 1
+fi
+
 # Core heartbeat — per-host alive signal under state/cores/<hostname>.alive.
 # Foundation for multi-core / cross-machine "who's running?" checks. Single
 # instance per host; gracefully cleans up its .alive file on SIGTERM.

--- a/tests/migrations/conftest.py
+++ b/tests/migrations/conftest.py
@@ -1,0 +1,43 @@
+"""Shared pytest fixtures for migration tests."""
+from __future__ import annotations
+
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Make src/ importable.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path) -> Path:
+    """Return a tmp dir wired as $HOME + fake ~/.sutando/env."""
+    workspace = tmp_path / ".sutando" / "workspace"
+    (workspace / "state").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture()
+def workspace(fake_home: Path) -> Path:
+    return fake_home / ".sutando" / "workspace"
+
+
+@pytest.fixture()
+def migrations_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "migrations"
+    d.mkdir()
+    return d
+
+
+def make_migration(migrations_dir: Path, number: int, body: str = "exit 0", suffix: str = ".sh") -> Path:
+    """Write a migration script NNNN-test<suffix> and return its path."""
+    p = migrations_dir / f"{number:04d}-test{suffix}"
+    if suffix == ".sh":
+        p.write_text(f"#!/bin/bash\n{body}\n")
+        p.chmod(0o755)
+    else:
+        p.write_text(textwrap.dedent(body))
+    return p

--- a/tests/migrations/test_0001_rename_private_dir.py
+++ b/tests/migrations/test_0001_rename_private_dir.py
@@ -1,0 +1,76 @@
+"""Tests for migrations/0001-rename-private-dir-to-memory-dir.sh."""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+MIGRATION = Path(__file__).resolve().parents[2] / "migrations" / "0001-rename-private-dir-to-memory-dir.sh"
+
+
+def run_migration(env_file: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(MIGRATION)],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "SUTANDO_ENV_FILE": str(env_file)},
+    )
+
+
+def test_renames_old_var(tmp_path: Path) -> None:
+    env_file = tmp_path / "env"
+    env_file.write_text("SUTANDO_PRIVATE_DIR=/foo/bar\n")
+
+    result = run_migration(env_file)
+
+    assert result.returncode == 0
+    content = env_file.read_text()
+    assert "SUTANDO_MEMORY_DIR=/foo/bar" in content
+    assert "SUTANDO_PRIVATE_DIR" not in content
+
+
+def test_idempotent_when_already_renamed(tmp_path: Path) -> None:
+    env_file = tmp_path / "env"
+    env_file.write_text("SUTANDO_MEMORY_DIR=/foo/bar\n")
+
+    result = run_migration(env_file)
+
+    assert result.returncode == 0
+    content = env_file.read_text()
+    assert content == "SUTANDO_MEMORY_DIR=/foo/bar\n"
+    assert "SUTANDO_PRIVATE_DIR" not in content
+
+
+def test_idempotent_when_neither_set(tmp_path: Path) -> None:
+    env_file = tmp_path / "env"
+    env_file.write_text("OTHER_VAR=hello\n")
+
+    result = run_migration(env_file)
+
+    assert result.returncode == 0
+    assert env_file.read_text() == "OTHER_VAR=hello\n"
+
+
+def test_preserves_other_vars(tmp_path: Path) -> None:
+    env_file = tmp_path / "env"
+    env_file.write_text("OTHER_VAR=bar\nSUTANDO_PRIVATE_DIR=/baz\nANOTHER=qux\n")
+
+    result = run_migration(env_file)
+
+    assert result.returncode == 0
+    content = env_file.read_text()
+    assert "OTHER_VAR=bar" in content
+    assert "ANOTHER=qux" in content
+    assert "SUTANDO_MEMORY_DIR=/baz" in content
+    assert "SUTANDO_PRIVATE_DIR" not in content
+
+
+def test_no_env_file(tmp_path: Path) -> None:
+    env_file = tmp_path / "nonexistent_env"
+
+    result = run_migration(env_file)
+
+    assert result.returncode == 0
+    assert not env_file.exists()

--- a/tests/migrations/test_no_collision.py
+++ b/tests/migrations/test_no_collision.py
@@ -1,0 +1,58 @@
+"""CI guard: migration number must be max(applied in main) + 1.
+
+Fails if:
+  - Two scripts share the same 4-digit prefix in the local migrations/ dir.
+  - Any proposed number is not exactly max_applied + 1
+    (catches gaps and duplicate numbers across concurrent PRs).
+
+Run by CI on every PR that touches migrations/.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "migrations"
+_NUMBER_RE = re.compile(r"^(\d{4})-")
+
+
+def _migration_numbers() -> list[int]:
+    nums: list[int] = []
+    if not _MIGRATIONS_DIR.is_dir():
+        return nums
+    for p in _MIGRATIONS_DIR.iterdir():
+        if not p.is_file():
+            continue
+        if p.suffix not in (".sh", ".py"):
+            continue
+        m = _NUMBER_RE.match(p.name)
+        if m:
+            nums.append(int(m.group(1)))
+    return sorted(nums)
+
+
+def test_no_duplicate_numbers() -> None:
+    """No two migration scripts may share the same 4-digit prefix."""
+    nums = _migration_numbers()
+    seen: set[int] = set()
+    dupes: list[int] = []
+    for n in nums:
+        if n in seen:
+            dupes.append(n)
+        seen.add(n)
+    assert not dupes, f"Duplicate migration numbers found: {dupes}"
+
+
+def test_contiguous_sequence() -> None:
+    """Numbers must form a contiguous sequence 0001, 0002, …, N with no gaps."""
+    nums = _migration_numbers()
+    if not nums:
+        return  # no migrations yet — nothing to check
+    expected = list(range(1, max(nums) + 1))
+    assert nums == expected, (
+        f"Migration numbers are not contiguous.\n"
+        f"  Expected: {expected}\n"
+        f"  Got:      {nums}\n"
+        f"  Missing:  {sorted(set(expected) - set(nums))}"
+    )

--- a/tests/migrations/test_runner_no_migrations_yet.py
+++ b/tests/migrations/test_runner_no_migrations_yet.py
@@ -1,0 +1,87 @@
+"""Baseline harness validation — runner exits 0 when nothing to apply."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from run_migrations import list_pending, read_state, run_migrations, write_state
+from tests.migrations.conftest import make_migration  # noqa: F401 (used via fixture param)
+
+
+def test_no_migrations_fresh_state(workspace: Path, migrations_dir: Path) -> None:
+    """Empty migrations dir + no state file → 0 pending, exit 0."""
+    assert list_pending(workspace, migrations_dir) == []
+    assert run_migrations(workspace, migrations_dir) == 0
+
+
+def test_state_defaults_when_missing(workspace: Path) -> None:
+    """Missing schema-version.json → treated as empty state."""
+    state = read_state(workspace)
+    assert state["applied"] == []
+    assert state["current"] == 0
+
+
+def test_write_then_read_state(workspace: Path) -> None:
+    state = {"applied": [1, 2], "current": 2, "engine_version_at_apply": "v0.1.0"}
+    write_state(workspace, state)
+    loaded = read_state(workspace)
+    assert loaded["applied"] == [1, 2]
+    assert loaded["current"] == 2
+    assert loaded["engine_version_at_apply"] == "v0.1.0"
+
+
+def test_pending_excludes_already_applied(workspace: Path, migrations_dir: Path) -> None:
+    make_migration(migrations_dir, 1)
+    make_migration(migrations_dir, 2)
+    write_state(workspace, {"applied": [1], "current": 1})
+    pending = list_pending(workspace, migrations_dir)
+    assert len(pending) == 1
+    assert pending[0][0] == 2
+
+
+def test_run_applies_script_and_records(workspace: Path, migrations_dir: Path) -> None:
+    make_migration(migrations_dir, 1, body="exit 0")
+    rc = run_migrations(workspace, migrations_dir)
+    assert rc == 0
+    state = read_state(workspace)
+    assert 1 in state["applied"]
+    assert state["current"] == 1
+
+
+def test_run_stops_on_failure(workspace: Path, migrations_dir: Path) -> None:
+    make_migration(migrations_dir, 1, body="exit 0")
+    make_migration(migrations_dir, 2, body="exit 1")
+    make_migration(migrations_dir, 3, body="exit 0")
+    rc = run_migrations(workspace, migrations_dir)
+    assert rc == 1
+    state = read_state(workspace)
+    assert 1 in state["applied"]
+    assert 2 not in state["applied"]
+    assert 3 not in state["applied"]
+
+
+def test_dry_run_does_not_mutate_state(workspace: Path, migrations_dir: Path) -> None:
+    make_migration(migrations_dir, 1)
+    rc = run_migrations(workspace, migrations_dir, dry_run=True)
+    assert rc == 0
+    state = read_state(workspace)
+    assert state["applied"] == []
+
+
+def test_python_migration_runs(workspace: Path, migrations_dir: Path) -> None:
+    make_migration(migrations_dir, 1, body="import sys; sys.exit(0)", suffix=".py")
+    rc = run_migrations(workspace, migrations_dir)
+    assert rc == 0
+    state = read_state(workspace)
+    assert 1 in state["applied"]
+
+
+def test_idempotent_rerun(workspace: Path, migrations_dir: Path) -> None:
+    """Running the runner twice on the same workspace applies each migration once."""
+    make_migration(migrations_dir, 1)
+    run_migrations(workspace, migrations_dir)
+    rc = run_migrations(workspace, migrations_dir)
+    assert rc == 0
+    state = read_state(workspace)
+    assert state["applied"].count(1) == 1


### PR DESCRIPTION
## Summary

First concrete migration using the Phase 1 registry from #1122. Records the `SUTANDO_PRIVATE_DIR → SUTANDO_MEMORY_DIR` env-var rename from #876 as migration `0001`.

**Depends on PR #1122** (migrations Phase 1 framework). The `migrations/` dir and `src/run_migrations.py` runner come from that PR — merge #1122 first.

## Behavior

`migrations/0001-rename-private-dir-to-memory-dir.sh`:

- If `~/.sutando/env` has `SUTANDO_PRIVATE_DIR=`, renames it to `SUTANDO_MEMORY_DIR=` in-place
- If only `SUTANDO_MEMORY_DIR=` present, or neither → exits 0 (already migrated)
- Verifies post-state: `SUTANDO_PRIVATE_DIR` absent after rename
- Controlled by `SUTANDO_ENV_FILE` env var override (defaults to `~/.sutando/env`)

After merge: fresh `python3 src/run_migrations.py` bumps `state/schema-version.json` from `current: 0` to `current: 1`.

## Tests

5 tests in `tests/migrations/test_0001_rename_private_dir.py` — all passing.  
16/16 total migration tests passing (includes Phase 1 runner harness).

## Merge order

1. #1122 (Phase 1 framework)
2. This PR (#956)

🤖 Generated with [Claude Code](https://claude.com/claude-code)