### PR TITLE
fix(workspace): learn-collector + learn-log-tail route state through resolve_workspace (closes #949 #952)

### DIFF
--- a/src/learn-collector.py
+++ b/src/learn-collector.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""learn-collector — emit JSONL events to state/learning-{instance}.jsonl.
+
+Layer 1 of the loop-redesign learning system (per
+notes/loop-redesign-goal-iteration-2026-05-03.md).
+
+Watches:
+- tasks/                          new task files                   -> kind="incoming"
+- tasks/archive/                  task -> archive transitions      -> kind="archived"
+- results/archive/<YYYY-MM>/      new result files (durable home)  -> kind="produced"
+
+Schema (pointer-based — derivable fields read from the file when needed):
+  {"ts","instance","source","kind","data":{"task_id","path"}}
+
+`results/` itself is intentionally NOT watched — the discord-bridge moves
+files to `results/archive/<YYYY-MM>/` faster than a 5s poll catches, so
+the durable archive is the reliable signal.
+
+Other event kinds emitted by the collector itself:
+  source="collector", kind in {"started","heartbeat","stopped","loop_error"}
+
+State files (gitignored, sync via memory-sync):
+  state/learning-<instance>.jsonl     — append-only event log
+  state/learning-<instance>.cursor    — per-directory ctime/mtime cursor for restart
+  state/learning-<instance>.heartbeat — single ISO timestamp of last poll (separate
+                                        from the jsonl so the event log isn't drowned)
+
+Env vars:
+  SUTANDO_ROOT                       override repo root (else __file__/..)
+  LEARN_COLLECTOR_INTERVAL_S         poll cadence (default 5)
+  LEARN_COLLECTOR_HEARTBEAT_S        heartbeat cadence (default 60)
+
+Run:
+  python3 src/learn-collector.py
+"""
+
+import json
+import os
+import socket
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT_ENV = os.environ.get("SUTANDO_ROOT")
+ROOT = Path(ROOT_ENV).resolve() if ROOT_ENV else Path(__file__).resolve().parents[1]
+
+STATE_DIR = ROOT / "state"
+TASKS_DIR = ROOT / "tasks"
+ARCHIVE_DIR = TASKS_DIR / "archive"
+RESULTS_ARCHIVE_DIR = ROOT / "results" / "archive"
+
+POLL_INTERVAL_S = int(os.environ.get("LEARN_COLLECTOR_INTERVAL_S", "5"))
+HEARTBEAT_S = int(os.environ.get("LEARN_COLLECTOR_HEARTBEAT_S", "60"))
+
+
+def resolve_instance() -> str:
+    identity_path = ROOT / "stand-identity.json"
+    if identity_path.exists():
+        try:
+            data = json.loads(identity_path.read_text())
+            machine = data.get("machine") or data.get("instance")
+            if machine:
+                return machine
+        except Exception:
+            pass
+    host = socket.gethostname().lower().replace(".local", "")
+    if "mini" in host:
+        return "mini"
+    if "macbook" in host or "mbp" in host:
+        return "macbook"
+    return host or "unknown"
+
+
+INSTANCE = resolve_instance()
+JSONL_PATH = STATE_DIR / f"learning-{INSTANCE}.jsonl"
+CURSOR_PATH = STATE_DIR / f"learning-{INSTANCE}.cursor"
+HEARTBEAT_PATH = STATE_DIR / f"learning-{INSTANCE}.heartbeat"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def emit(source: str, kind: str, data: dict) -> None:
+    """Atomic append to the JSONL via os.write + O_APPEND.
+
+    Both daemons (learn-collector + learn-log-tail) share this file. A
+    single os.write call is atomic up to PIPE_BUF (512 on macOS, 4096 on
+    Linux), so concurrent appends don't interleave for events under that
+    size. Per cold review on PR #590.
+    """
+    STATE_DIR.mkdir(exist_ok=True)
+    event = {
+        "ts": now_iso(),
+        "instance": INSTANCE,
+        "source": source,
+        "kind": kind,
+        "data": data,
+    }
+    line = (json.dumps(event, ensure_ascii=False) + "\n").encode("utf-8")
+    fd = os.open(str(JSONL_PATH), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+    try:
+        os.write(fd, line)
+    finally:
+        os.close(fd)
+
+
+def load_cursor() -> dict:
+    if not CURSOR_PATH.exists():
+        return {}
+    try:
+        return json.loads(CURSOR_PATH.read_text())
+    except Exception:
+        return {}
+
+
+def save_cursor(cursor: dict) -> None:
+    STATE_DIR.mkdir(exist_ok=True)
+    tmp = CURSOR_PATH.with_suffix(".cursor.tmp")
+    tmp.write_text(json.dumps(cursor))
+    tmp.replace(CURSOR_PATH)
+
+
+def rel_path(p: Path) -> str:
+    try:
+        return str(p.relative_to(ROOT))
+    except ValueError:
+        return str(p)
+
+
+def scan_dir(directory: Path, cursor_key: str, cursor: dict, source: str, kind: str, recursive: bool) -> int:
+    """Emit events for files whose freshness time exceeds the cursor.
+
+    "Freshness" is `max(st_mtime, st_ctime)`. ctime updates on rename, which
+    catches files moved into archive/ via `mv` (mtime alone misses these
+    because mv preserves mtime).
+
+    Updates `cursor[cursor_key]` to the max freshness seen. Returns count emitted.
+    """
+    if not directory.exists():
+        return 0
+    last_seen = cursor.get(cursor_key, 0.0)
+    new_max = last_seen
+    iterator = directory.rglob("task-*.txt") if recursive else directory.glob("task-*.txt")
+    count = 0
+    for p in iterator:
+        try:
+            st = p.stat()
+            freshness = max(st.st_mtime, st.st_ctime)
+        except OSError:
+            continue
+        if freshness <= last_seen:
+            continue
+        emit(source, kind, {"task_id": p.stem, "path": rel_path(p)})
+        count += 1
+        if freshness > new_max:
+            new_max = freshness
+    if new_max > last_seen:
+        cursor[cursor_key] = new_max
+    return count
+
+
+def write_heartbeat() -> None:
+    STATE_DIR.mkdir(exist_ok=True)
+    HEARTBEAT_PATH.write_text(now_iso() + "\n")
+
+
+def main() -> int:
+    cursor = load_cursor()
+    is_first_run = not cursor
+    if is_first_run:
+        bootstrap_now = time.time()
+        cursor = {
+            "tasks": bootstrap_now,
+            "tasks_archive": bootstrap_now,
+            "results_archive": bootstrap_now,
+        }
+        save_cursor(cursor)
+    emit(
+        "collector",
+        "started",
+        {
+            "interval_s": POLL_INTERVAL_S,
+            "heartbeat_s": HEARTBEAT_S,
+            "jsonl": rel_path(JSONL_PATH),
+            "cursor_loaded": not is_first_run,
+        },
+    )
+    last_heartbeat = time.time()
+    while True:
+        try:
+            scan_dir(TASKS_DIR, "tasks", cursor, "tasks", "incoming", recursive=False)
+            # recursive=True: the bridge archives to tasks/archive/<YYYY-MM>/
+            # (same pattern as results/archive/). Top-level-only would miss
+            # every bridge-driven archive move.
+            scan_dir(ARCHIVE_DIR, "tasks_archive", cursor, "tasks", "archived", recursive=True)
+            scan_dir(RESULTS_ARCHIVE_DIR, "results_archive", cursor, "results", "produced", recursive=True)
+            save_cursor(cursor)
+            now = time.time()
+            if now - last_heartbeat >= HEARTBEAT_S:
+                # Heartbeat goes to its own single-line file so the event log
+                # stays uncluttered. Liveness probes stat the heartbeat file.
+                write_heartbeat()
+                last_heartbeat = now
+        except Exception as e:
+            emit("collector", "loop_error", {"error": repr(e)})
+        time.sleep(POLL_INTERVAL_S)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main() or 0)
+    except KeyboardInterrupt:
+        emit("collector", "stopped", {})
+        sys.exit(0)

--- a/src/learn-collector.py
+++ b/src/learn-collector.py
@@ -42,13 +42,17 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent))
+from workspace_default import resolve_workspace  # noqa: E402
+
 ROOT_ENV = os.environ.get("SUTANDO_ROOT")
 ROOT = Path(ROOT_ENV).resolve() if ROOT_ENV else Path(__file__).resolve().parents[1]
 
-STATE_DIR = ROOT / "state"
-TASKS_DIR = ROOT / "tasks"
+WORKSPACE = resolve_workspace()
+STATE_DIR = WORKSPACE / "state"
+TASKS_DIR = WORKSPACE / "tasks"
 ARCHIVE_DIR = TASKS_DIR / "archive"
-RESULTS_ARCHIVE_DIR = ROOT / "results" / "archive"
+RESULTS_ARCHIVE_DIR = WORKSPACE / "results" / "archive"
 
 POLL_INTERVAL_S = int(os.environ.get("LEARN_COLLECTOR_INTERVAL_S", "5"))
 HEARTBEAT_S = int(os.environ.get("LEARN_COLLECTOR_HEARTBEAT_S", "60"))

--- a/src/learn-log-tail.py
+++ b/src/learn-log-tail.py
@@ -46,11 +46,15 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent))
+from workspace_default import resolve_workspace  # noqa: E402
+
 ROOT_ENV = os.environ.get("SUTANDO_ROOT")
 ROOT = Path(ROOT_ENV).resolve() if ROOT_ENV else Path(__file__).resolve().parents[1]
 
-STATE_DIR = ROOT / "state"
-LOGS_DIR = ROOT / "logs"
+WORKSPACE = resolve_workspace()
+STATE_DIR = WORKSPACE / "state"
+LOGS_DIR = WORKSPACE / "logs"
 
 POLL_INTERVAL_S = int(os.environ.get("LEARN_LOG_TAIL_INTERVAL_S", "5"))
 EXCERPT_MAX = 250

--- a/src/learn-log-tail.py
+++ b/src/learn-log-tail.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""learn-log-tail — emit JSONL events from filtered log lines.
+
+Phase 2a of the loop-redesign learning system. Pre-filters bridge / voice /
+phone logs into a tight JSONL of high-signal events so the summarizer
+(Phase 2c subagent) can read pre-cooked events instead of grep-ing
+raw 30MB logs at run-time.
+
+Tails (configurable via state/learn-filters.json):
+- logs/discord-bridge.log
+- logs/voice-agent.log
+- logs/conversation-server.log
+- logs/telegram-bridge.log
+
+Each tailer maintains a byte-offset cursor in
+state/learning-<instance>.log-cursor so restart resumes from where it
+left off (no replay, no skip).
+
+Schema (matches learn-collector.py):
+  {"ts","instance","source","kind","data":{"byte_offset","excerpt"}}
+
+Source is the relative log path. Kind is one of the configured filter
+labels (skip / replied / error / msg / etc.). Excerpt is the first
+~250 chars of the matched line — pointer-style; full context recoverable
+from {log_path, byte_offset}.
+
+State files (gitignored):
+  state/learning-<instance>.jsonl       — shared with learn-collector
+  state/learning-<instance>.log-cursor  — per-log byte-offset
+  state/learning-<instance>.heartbeat   — touched every poll (shared with collector)
+
+Env vars:
+  SUTANDO_ROOT                       override repo root
+  LEARN_LOG_TAIL_INTERVAL_S          poll cadence (default 5)
+
+Run:
+  python3 src/learn-log-tail.py
+"""
+
+import json
+import os
+import re
+import socket
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT_ENV = os.environ.get("SUTANDO_ROOT")
+ROOT = Path(ROOT_ENV).resolve() if ROOT_ENV else Path(__file__).resolve().parents[1]
+
+STATE_DIR = ROOT / "state"
+LOGS_DIR = ROOT / "logs"
+
+POLL_INTERVAL_S = int(os.environ.get("LEARN_LOG_TAIL_INTERVAL_S", "5"))
+EXCERPT_MAX = 250
+
+
+# Default filter set. Each entry: (log_filename, kind_label, regex).
+# A line emits an event tagged with the FIRST matching kind. Lines that
+# match no filter are silently dropped (not the same as appended).
+#
+# `replied` uses \b instead of ^\s* so a future log-format change that
+# adds timestamp/level prefixes (e.g. `15:30:00Z [INFO] Replied: ...`)
+# still matches without a regex update. Per cold review on PR #590.
+DEFAULT_FILTERS = [
+    # discord-bridge: routing + outgoing reply confirmations
+    ("discord-bridge.log", "skip",    r"\[skip\]"),
+    ("discord-bridge.log", "replied", r"\bReplied:"),
+    ("discord-bridge.log", "error",   r"\b(ERROR|Exception|Traceback|TypeError)\b"),
+    # voice-agent: transport health + tool errors
+    ("voice-agent.log",    "transport", r"transport (1006|1011|1007|connected|closed)"),
+    ("voice-agent.log",    "error",     r"\b(ERROR|Exception|Traceback)\b"),
+    ("voice-agent.log",    "delegated", r"\bdelegated\b"),
+    # conversation-server: phone call lifecycle
+    ("conversation-server.log", "call_event", r"\b(call_started|call_ended|hangup|summary)"),
+    ("conversation-server.log", "error",      r"\b(ERROR|Exception|Traceback)\b"),
+    # telegram-bridge: same shape as discord
+    ("telegram-bridge.log", "skip",    r"\[skip\]"),
+    ("telegram-bridge.log", "replied", r"\bReplied:"),
+    ("telegram-bridge.log", "error",   r"\b(ERROR|Exception|Traceback)\b"),
+]
+
+
+def resolve_instance() -> str:
+    identity_path = ROOT / "stand-identity.json"
+    if identity_path.exists():
+        try:
+            data = json.loads(identity_path.read_text())
+            machine = data.get("machine") or data.get("instance")
+            if machine:
+                return machine
+        except Exception:
+            pass
+    host = socket.gethostname().lower().replace(".local", "")
+    if "mini" in host:
+        return "mini"
+    if "macbook" in host or "mbp" in host:
+        return "macbook"
+    return host or "unknown"
+
+
+INSTANCE = resolve_instance()
+JSONL_PATH = STATE_DIR / f"learning-{INSTANCE}.jsonl"
+CURSOR_PATH = STATE_DIR / f"learning-{INSTANCE}.log-cursor"
+HEARTBEAT_PATH = STATE_DIR / f"learning-{INSTANCE}.heartbeat"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def emit(source: str, kind: str, data: dict) -> None:
+    """Atomic append to the JSONL via os.write + O_APPEND.
+
+    Both daemons (learn-collector + learn-log-tail) share this file. A
+    single os.write call is atomic up to PIPE_BUF (512 on macOS, 4096 on
+    Linux), so concurrent appends don't interleave for events under that
+    size. Most events stay well under 512 bytes; a worst-case log-line
+    excerpt with multi-byte chars + json overhead can push past, in which
+    case interleaving is theoretically possible. Acceptable risk for
+    Phase 2; per-daemon JSONL is the upgrade path if interleaving shows
+    up in practice. Per cold review on PR #590.
+    """
+    STATE_DIR.mkdir(exist_ok=True)
+    event = {
+        "ts": now_iso(),
+        "instance": INSTANCE,
+        "source": source,
+        "kind": kind,
+        "data": data,
+    }
+    line = (json.dumps(event, ensure_ascii=False) + "\n").encode("utf-8")
+    fd = os.open(str(JSONL_PATH), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+    try:
+        os.write(fd, line)
+    finally:
+        os.close(fd)
+
+
+def load_cursor() -> dict:
+    if not CURSOR_PATH.exists():
+        return {}
+    try:
+        return json.loads(CURSOR_PATH.read_text())
+    except Exception:
+        return {}
+
+
+def save_cursor(cursor: dict) -> None:
+    STATE_DIR.mkdir(exist_ok=True)
+    tmp = CURSOR_PATH.with_suffix(".log-cursor.tmp")
+    tmp.write_text(json.dumps(cursor))
+    tmp.replace(CURSOR_PATH)
+
+
+def load_filters() -> list:
+    """Custom filters can override the default set via state/learn-filters.json.
+
+    Format: [["log_filename", "kind", "regex"], ...]
+    """
+    custom = STATE_DIR / "learn-filters.json"
+    if custom.exists():
+        try:
+            return [tuple(t) for t in json.loads(custom.read_text())]
+        except Exception:
+            pass
+    return DEFAULT_FILTERS
+
+
+def compile_filters(filters: list) -> dict:
+    """Group filters by log filename, compile regexes."""
+    grouped: dict = {}
+    for log_name, kind, pattern in filters:
+        grouped.setdefault(log_name, []).append((kind, re.compile(pattern)))
+    return grouped
+
+
+def rel_path(p: Path) -> str:
+    try:
+        return str(p.relative_to(ROOT))
+    except ValueError:
+        return str(p)
+
+
+def tail_log(log_path: Path, kind_filters: list, cursor: dict) -> int:
+    """Read new bytes from log_path beyond the cursor, emit one event per
+    matching line. Returns count emitted.
+
+    Handles log rotation (file shorter than cursor): resets to 0, emits a
+    `rotated` event so the summarizer knows.
+    """
+    if not log_path.exists():
+        return 0
+    key = log_path.name
+    last_offset = cursor.get(key, 0)
+    try:
+        size = log_path.stat().st_size
+    except OSError:
+        return 0
+    if size < last_offset:
+        # Log was rotated/truncated; reset.
+        emit(rel_path(log_path), "rotated", {"prev_offset": last_offset, "new_size": size})
+        last_offset = 0
+    if size == last_offset:
+        return 0
+    count = 0
+    with log_path.open("rb") as f:
+        f.seek(last_offset)
+        chunk = f.read()
+    # Only consume up to the LAST newline. A trailing partial line (writer
+    # mid-flush) gets left for the next iteration so we don't emit a
+    # truncated excerpt and skip the rest. Per cold review on PR #590.
+    last_nl = chunk.rfind(b"\n")
+    if last_nl == -1:
+        # Chunk has no complete line yet; wait for next poll.
+        return 0
+    consumable = chunk[: last_nl + 1]
+    new_offset = last_offset + len(consumable)
+    text = consumable.decode("utf-8", errors="replace")
+    pos = last_offset
+    for line in text.splitlines(keepends=True):
+        line_offset = pos
+        pos += len(line.encode("utf-8"))
+        stripped = line.rstrip("\n").rstrip("\r")
+        if not stripped:
+            continue
+        for kind, pattern in kind_filters:
+            if pattern.search(stripped):
+                excerpt = stripped[:EXCERPT_MAX]
+                emit(rel_path(log_path), kind, {
+                    "byte_offset": line_offset,
+                    "excerpt": excerpt,
+                })
+                count += 1
+                break
+    cursor[key] = new_offset
+    return count
+
+
+def main() -> int:
+    cursor = load_cursor()
+    is_first_run = not cursor
+    filters_grouped = compile_filters(load_filters())
+
+    if is_first_run:
+        # Bootstrap: don't replay history. Set cursor to current end-of-file
+        # for each watched log.
+        for log_name in filters_grouped:
+            log_path = LOGS_DIR / log_name
+            if log_path.exists():
+                try:
+                    cursor[log_name] = log_path.stat().st_size
+                except OSError:
+                    cursor[log_name] = 0
+        save_cursor(cursor)
+
+    emit(
+        "log-tail",
+        "started",
+        {
+            "interval_s": POLL_INTERVAL_S,
+            "filters_loaded": sum(len(v) for v in filters_grouped.values()),
+            "logs_watched": list(filters_grouped.keys()),
+            "cursor_loaded": not is_first_run,
+        },
+    )
+
+    while True:
+        try:
+            for log_name, kind_filters in filters_grouped.items():
+                log_path = LOGS_DIR / log_name
+                tail_log(log_path, kind_filters, cursor)
+            save_cursor(cursor)
+            HEARTBEAT_PATH.write_text(now_iso() + "\n")
+        except Exception as e:
+            emit("log-tail", "loop_error", {"error": repr(e)})
+        time.sleep(POLL_INTERVAL_S)
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main() or 0)
+    except KeyboardInterrupt:
+        emit("log-tail", "stopped", {})
+        sys.exit(0)

--- a/tests/learn-collector-log-tail.test.py
+++ b/tests/learn-collector-log-tail.test.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Tests for src/learn-collector.py and src/learn-log-tail.py (#586 + #590)"""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+collector = _load("learn_collector", REPO / "src" / "learn-collector.py")
+log_tail = _load("learn_log_tail", REPO / "src" / "learn-log-tail.py")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_root(tmp: str) -> Path:
+    root = Path(tmp)
+    (root / "state").mkdir(exist_ok=True)
+    (root / "tasks").mkdir(exist_ok=True)
+    (root / "results" / "archive").mkdir(parents=True, exist_ok=True)
+    (root / "logs").mkdir(exist_ok=True)
+    return root
+
+
+# ---------------------------------------------------------------------------
+# learn-collector tests
+# ---------------------------------------------------------------------------
+
+class TestResolveInstance(unittest.TestCase):
+    def test_stand_identity_machine(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            identity = root / "stand-identity.json"
+            identity.write_text(json.dumps({"machine": "mini"}))
+            with unittest.mock.patch.object(collector, "ROOT", root):
+                inst = collector.resolve_instance()
+            self.assertEqual(inst, "mini")
+
+    def test_stand_identity_instance_key(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            (root / "stand-identity.json").write_text(json.dumps({"instance": "studio"}))
+            with unittest.mock.patch.object(collector, "ROOT", root):
+                inst = collector.resolve_instance()
+            self.assertEqual(inst, "studio")
+
+    def test_hostname_fallback_mbp(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            import socket
+            with unittest.mock.patch.object(collector, "ROOT", root), \
+                 unittest.mock.patch("socket.gethostname", return_value="bassils-mbp.local"):
+                inst = collector.resolve_instance()
+            self.assertEqual(inst, "macbook")
+
+    def test_hostname_fallback_mini(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            with unittest.mock.patch.object(collector, "ROOT", root), \
+                 unittest.mock.patch("socket.gethostname", return_value="mac-mini.local"):
+                inst = collector.resolve_instance()
+            self.assertEqual(inst, "mini")
+
+
+class TestEmit(unittest.TestCase):
+    def test_emit_writes_valid_jsonl(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            jsonl = root / "state" / "learning-test.jsonl"
+            with unittest.mock.patch.object(collector, "STATE_DIR", root / "state"), \
+                 unittest.mock.patch.object(collector, "JSONL_PATH", jsonl), \
+                 unittest.mock.patch.object(collector, "INSTANCE", "test"):
+                collector.emit("tasks", "incoming", {"task_id": "task-123", "path": "tasks/task-123.txt"})
+            lines = jsonl.read_text().splitlines()
+            self.assertEqual(len(lines), 1)
+            event = json.loads(lines[0])
+            self.assertEqual(event["source"], "tasks")
+            self.assertEqual(event["kind"], "incoming")
+            self.assertEqual(event["instance"], "test")
+            self.assertIn("ts", event)
+            self.assertIn("task_id", event["data"])
+
+    def test_emit_appends(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            jsonl = root / "state" / "learning-test.jsonl"
+            with unittest.mock.patch.object(collector, "STATE_DIR", root / "state"), \
+                 unittest.mock.patch.object(collector, "JSONL_PATH", jsonl), \
+                 unittest.mock.patch.object(collector, "INSTANCE", "test"):
+                collector.emit("tasks", "incoming", {"task_id": "t1"})
+                collector.emit("results", "produced", {"task_id": "t1"})
+            lines = jsonl.read_text().splitlines()
+            self.assertEqual(len(lines), 2)
+
+
+class TestCursorPersistence(unittest.TestCase):
+    def test_save_and_load_cursor(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            cursor_path = root / "state" / "learning-test.cursor"
+            with unittest.mock.patch.object(collector, "STATE_DIR", root / "state"), \
+                 unittest.mock.patch.object(collector, "CURSOR_PATH", cursor_path):
+                cursor = {"tasks": 1234567890.0}
+                collector.save_cursor(cursor)
+                loaded = collector.load_cursor()
+            self.assertEqual(loaded, cursor)
+
+    def test_load_cursor_missing_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            cursor_path = root / "state" / "nonexistent.cursor"
+            with unittest.mock.patch.object(collector, "CURSOR_PATH", cursor_path):
+                result = collector.load_cursor()
+            self.assertEqual(result, {})
+
+
+class TestScanDir(unittest.TestCase):
+    def test_emits_new_task_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            tasks_dir = root / "tasks"
+            (tasks_dir / "task-111.txt").write_text("hello")
+            jsonl = root / "state" / "learning-test.jsonl"
+            cursor = {}
+            with unittest.mock.patch.object(collector, "STATE_DIR", root / "state"), \
+                 unittest.mock.patch.object(collector, "JSONL_PATH", jsonl), \
+                 unittest.mock.patch.object(collector, "ROOT", root), \
+                 unittest.mock.patch.object(collector, "INSTANCE", "test"):
+                count = collector.scan_dir(tasks_dir, "tasks", cursor, "tasks", "incoming", recursive=False)
+            self.assertEqual(count, 1)
+            event = json.loads(jsonl.read_text().splitlines()[0])
+            self.assertEqual(event["kind"], "incoming")
+            self.assertIn("task_id", event["data"])
+
+    def test_cursor_prevents_duplicate_emit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            tasks_dir = root / "tasks"
+            tf = tasks_dir / "task-222.txt"
+            tf.write_text("hello")
+            jsonl = root / "state" / "learning-test.jsonl"
+            cursor = {}
+            with unittest.mock.patch.object(collector, "STATE_DIR", root / "state"), \
+                 unittest.mock.patch.object(collector, "JSONL_PATH", jsonl), \
+                 unittest.mock.patch.object(collector, "ROOT", root), \
+                 unittest.mock.patch.object(collector, "INSTANCE", "test"):
+                collector.scan_dir(tasks_dir, "tasks", cursor, "tasks", "incoming", recursive=False)
+                count2 = collector.scan_dir(tasks_dir, "tasks", cursor, "tasks", "incoming", recursive=False)
+            self.assertEqual(count2, 0)
+
+    def test_missing_dir_returns_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            nonexistent = root / "no-such-dir"
+            jsonl = root / "state" / "learning-test.jsonl"
+            cursor = {}
+            with unittest.mock.patch.object(collector, "STATE_DIR", root / "state"), \
+                 unittest.mock.patch.object(collector, "JSONL_PATH", jsonl), \
+                 unittest.mock.patch.object(collector, "INSTANCE", "test"):
+                count = collector.scan_dir(nonexistent, "x", cursor, "x", "incoming", recursive=False)
+            self.assertEqual(count, 0)
+
+
+# ---------------------------------------------------------------------------
+# learn-log-tail tests
+# ---------------------------------------------------------------------------
+
+class TestCompileFilters(unittest.TestCase):
+    def test_groups_by_log_name(self):
+        filters = [
+            ("discord-bridge.log", "skip", r"\[skip\]"),
+            ("discord-bridge.log", "error", r"ERROR"),
+            ("voice-agent.log", "error", r"ERROR"),
+        ]
+        grouped = log_tail.compile_filters(filters)
+        self.assertIn("discord-bridge.log", grouped)
+        self.assertIn("voice-agent.log", grouped)
+        self.assertEqual(len(grouped["discord-bridge.log"]), 2)
+        self.assertEqual(len(grouped["voice-agent.log"]), 1)
+
+    def test_compiles_regex(self):
+        filters = [("discord-bridge.log", "error", r"\bERROR\b")]
+        grouped = log_tail.compile_filters(filters)
+        kind, pattern = grouped["discord-bridge.log"][0]
+        self.assertEqual(kind, "error")
+        self.assertIsNotNone(pattern.search("ERROR: something bad"))
+        self.assertIsNone(pattern.search("no errors here"))
+
+
+class TestTailLog(unittest.TestCase):
+    def _patched_emit(self, root, events_out):
+        def _emit(source, kind, data):
+            events_out.append({"source": source, "kind": kind, "data": data})
+        return _emit
+
+    def test_emits_matching_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            log_path = root / "logs" / "discord-bridge.log"
+            log_path.write_text("[skip] some message\n")
+            cursor = {}
+            filters = [("skip", __import__("re").compile(r"\[skip\]"))]
+            events = []
+            with unittest.mock.patch.object(log_tail, "emit", self._patched_emit(root, events)):
+                count = log_tail.tail_log(log_path, filters, cursor)
+            self.assertEqual(count, 1)
+            self.assertEqual(events[0]["kind"], "skip")
+
+    def test_does_not_replay_on_second_poll(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            log_path = root / "logs" / "discord-bridge.log"
+            log_path.write_text("[skip] once\n")
+            cursor = {}
+            filters = [("skip", __import__("re").compile(r"\[skip\]"))]
+            events = []
+            with unittest.mock.patch.object(log_tail, "emit", self._patched_emit(root, events)):
+                log_tail.tail_log(log_path, filters, cursor)
+                count2 = log_tail.tail_log(log_path, filters, cursor)
+            self.assertEqual(count2, 0)
+
+    def test_handles_missing_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            log_path = root / "logs" / "nonexistent.log"
+            cursor = {}
+            filters = [("error", __import__("re").compile(r"ERROR"))]
+            events = []
+            with unittest.mock.patch.object(log_tail, "emit", self._patched_emit(root, events)):
+                count = log_tail.tail_log(log_path, filters, cursor)
+            self.assertEqual(count, 0)
+
+    def test_handles_log_rotation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            log_path = root / "logs" / "discord-bridge.log"
+            log_path.write_text("ERROR: bad\n")
+            cursor = {"discord-bridge.log": 9999}  # cursor beyond file size
+            filters = [("error", __import__("re").compile(r"ERROR"))]
+            events = []
+            with unittest.mock.patch.object(log_tail, "emit", self._patched_emit(root, events)):
+                log_tail.tail_log(log_path, filters, cursor)
+            rotated_events = [e for e in events if e["kind"] == "rotated"]
+            self.assertTrue(rotated_events, "expected a 'rotated' event on offset reset")
+
+    def test_first_match_wins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            log_path = root / "logs" / "discord-bridge.log"
+            log_path.write_text("[skip] but also ERROR here\n")
+            cursor = {}
+            import re
+            filters = [
+                ("skip", re.compile(r"\[skip\]")),
+                ("error", re.compile(r"ERROR")),
+            ]
+            events = []
+            with unittest.mock.patch.object(log_tail, "emit", self._patched_emit(root, events)):
+                log_tail.tail_log(log_path, filters, cursor)
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0]["kind"], "skip")
+
+    def test_partial_line_not_consumed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            log_path = root / "logs" / "discord-bridge.log"
+            log_path.write_bytes(b"[skip] complete\npartial no newline")
+            cursor = {}
+            filters = [("skip", __import__("re").compile(r"\[skip\]"))]
+            events = []
+            with unittest.mock.patch.object(log_tail, "emit", self._patched_emit(root, events)):
+                log_tail.tail_log(log_path, filters, cursor)
+            self.assertEqual(len(events), 1)
+            # cursor should be at end of "complete\n", not end of file
+            self.assertLess(cursor["discord-bridge.log"], log_path.stat().st_size)
+
+
+class TestLoadFilters(unittest.TestCase):
+    def test_default_filters_returned_without_custom_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            with unittest.mock.patch.object(log_tail, "STATE_DIR", root / "state"):
+                filters = log_tail.load_filters()
+            self.assertIs(filters, log_tail.DEFAULT_FILTERS)
+
+    def test_custom_filters_loaded_from_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _fake_root(tmp)
+            custom = root / "state" / "learn-filters.json"
+            custom.write_text(json.dumps([["mylog.log", "custom_kind", r"CUSTOM"]]))
+            with unittest.mock.patch.object(log_tail, "STATE_DIR", root / "state"):
+                filters = log_tail.load_filters()
+            self.assertEqual(len(filters), 1)
+            self.assertEqual(filters[0][1], "custom_kind")
+
+
+class TestDefaultFilterCoverage(unittest.TestCase):
+    def test_discord_bridge_filters_defined(self):
+        logs = {f[0] for f in log_tail.DEFAULT_FILTERS}
+        self.assertIn("discord-bridge.log", logs)
+
+    def test_voice_agent_filters_defined(self):
+        logs = {f[0] for f in log_tail.DEFAULT_FILTERS}
+        self.assertIn("voice-agent.log", logs)
+
+    def test_conversation_server_filters_defined(self):
+        logs = {f[0] for f in log_tail.DEFAULT_FILTERS}
+        self.assertIn("conversation-server.log", logs)
+
+    def test_telegram_bridge_filters_defined(self):
+        logs = {f[0] for f in log_tail.DEFAULT_FILTERS}
+        self.assertIn("telegram-bridge.log", logs)
+
+    def test_error_pattern_in_all_logs(self):
+        for log_name, kind, pattern in log_tail.DEFAULT_FILTERS:
+            if kind == "error":
+                import re
+                self.assertIsNotNone(re.compile(pattern).search("ERROR: something"), f"{log_name} error pattern broken")
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import unittest.mock
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    for cls in [
+        TestResolveInstance, TestEmit, TestCursorPersistence, TestScanDir,
+        TestCompileFilters, TestTailLog, TestLoadFilters, TestDefaultFilterCoverage,
+    ]:
+        suite.addTests(loader.loadTestsFromTestCase(cls))
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/tests/learn-collector-log-tail.test.py
+++ b/tests/learn-collector-log-tail.test.py
@@ -310,6 +310,62 @@ class TestLoadFilters(unittest.TestCase):
             self.assertEqual(filters[0][1], "custom_kind")
 
 
+class TestWorkspacePaths(unittest.TestCase):
+    """Verify both daemons route state files through resolve_workspace (#949)."""
+
+    def test_collector_state_dir_under_workspace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp) / "workspace"
+            ws.mkdir()
+            with unittest.mock.patch.dict(os.environ, {"SUTANDO_WORKSPACE": str(ws)}):
+                mod = _load("lc_ws", REPO / "src" / "learn-collector.py")
+            self.assertEqual(str(mod.STATE_DIR), str(ws / "state"))
+
+    def test_collector_tasks_dir_under_workspace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp) / "workspace"
+            ws.mkdir()
+            with unittest.mock.patch.dict(os.environ, {"SUTANDO_WORKSPACE": str(ws)}):
+                mod = _load("lc_ws2", REPO / "src" / "learn-collector.py")
+            self.assertEqual(str(mod.TASKS_DIR), str(ws / "tasks"))
+
+    def test_collector_results_archive_under_workspace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp) / "workspace"
+            ws.mkdir()
+            with unittest.mock.patch.dict(os.environ, {"SUTANDO_WORKSPACE": str(ws)}):
+                mod = _load("lc_ws3", REPO / "src" / "learn-collector.py")
+            self.assertEqual(str(mod.RESULTS_ARCHIVE_DIR), str(ws / "results" / "archive"))
+
+    def test_log_tail_state_dir_under_workspace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp) / "workspace"
+            ws.mkdir()
+            with unittest.mock.patch.dict(os.environ, {"SUTANDO_WORKSPACE": str(ws)}):
+                mod = _load("lt_ws", REPO / "src" / "learn-log-tail.py")
+            self.assertEqual(str(mod.STATE_DIR), str(ws / "state"))
+
+    def test_log_tail_logs_dir_under_workspace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = Path(tmp) / "workspace"
+            ws.mkdir()
+            with unittest.mock.patch.dict(os.environ, {"SUTANDO_WORKSPACE": str(ws)}):
+                mod = _load("lt_ws2", REPO / "src" / "learn-log-tail.py")
+            self.assertEqual(str(mod.LOGS_DIR), str(ws / "logs"))
+
+    def test_collector_state_dir_not_under_repo(self):
+        self.assertFalse(
+            str(collector.STATE_DIR).startswith(str(REPO)),
+            f"STATE_DIR {collector.STATE_DIR} should not be inside repo {REPO}",
+        )
+
+    def test_log_tail_state_dir_not_under_repo(self):
+        self.assertFalse(
+            str(log_tail.STATE_DIR).startswith(str(REPO)),
+            f"STATE_DIR {log_tail.STATE_DIR} should not be inside repo {REPO}",
+        )
+
+
 class TestDefaultFilterCoverage(unittest.TestCase):
     def test_discord_bridge_filters_defined(self):
         logs = {f[0] for f in log_tail.DEFAULT_FILTERS}
@@ -345,6 +401,7 @@ if __name__ == "__main__":
     for cls in [
         TestResolveInstance, TestEmit, TestCursorPersistence, TestScanDir,
         TestCompileFilters, TestTailLog, TestLoadFilters, TestDefaultFilterCoverage,
+        TestWorkspacePaths,
     ]:
         suite.addTests(loader.loadTestsFromTestCase(cls))
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
## Problem

`learn-collector.py` and `learn-log-tail.py` computed `STATE_DIR` from `ROOT = Path(__file__).resolve().parents[1]` (the repo checkout). This caused `state/learning-{instance}.jsonl`, `.cursor`, `.heartbeat`, and `.log-cursor` to land in `<repo>/state/` — polluting `git status` and diverging from the workspace contract established in #940.

Closes #949. Also resolves the `feedback_curate_split_brain_state_path` footgun noted in #952.

## Fix

Both files:
1. Import `resolve_workspace` from `workspace_default`  
2. Compute `WORKSPACE = resolve_workspace()` 
3. Use `WORKSPACE` for all mutable-state paths (`STATE_DIR`, `TASKS_DIR`, `LOGS_DIR`, `RESULTS_ARCHIVE_DIR`)  
4. Keep `ROOT` for code-adjacent reads (`stand-identity.json`, display via `rel_path()`)

**Stacks on PR #586 / #590** (`feat/learn-collector-log-tail-586-590-clean`). The fix is isolated to path setup — zero behavior change.

## Tests

7 new tests in `TestWorkspacePaths`:
- `STATE_DIR` / `TASKS_DIR` / `RESULTS_ARCHIVE_DIR` (collector) resolve under `$SUTANDO_WORKSPACE`
- `STATE_DIR` / `LOGS_DIR` (log-tail) resolve under `$SUTANDO_WORKSPACE`
- `SUTANDO_WORKSPACE` env override honored (verified via `importlib` reload)
- Neither daemon's `STATE_DIR` starts with the repo path

33/33 tests passing (26 pre-existing + 7 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)