### PR TITLE
feat(proactive-notify): add queue, voice, macos_notif action modules

### DIFF
--- a/skills/proactive-notify/scripts/actions/macos_notif.py
+++ b/skills/proactive-notify/scripts/actions/macos_notif.py
@@ -1,0 +1,38 @@
+"""macOS notification action — fires a desktop notification via osascript.
+
+Suitable for fyi-tier pings that should surface as a banner without
+interrupting a call or sending a message.
+
+Env:
+  SUTANDO_NOTIF_TITLE — notification title (default: "Sutando")
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+_DEFAULT_TITLE = "Sutando"
+
+
+def send(ping, body: str) -> dict:
+    title = os.environ.get("SUTANDO_NOTIF_TITLE") or _DEFAULT_TITLE
+    # Escape for AppleScript string literal (double-quoted).
+    def _esc(s: str) -> str:
+        return s.replace("\\", "\\\\").replace('"', '\\"')
+
+    script = f'display notification "{_esc(body)}" with title "{_esc(title)}"'
+    try:
+        subprocess.run(
+            ["osascript", "-e", script],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        return {"ok": True, "id": "notif"}
+    except FileNotFoundError:
+        return {"ok": False, "error": "osascript not found"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "osascript timed out"}
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or b"").decode().strip()
+        return {"ok": False, "error": stderr or f"osascript exit {e.returncode}"}

--- a/skills/proactive-notify/scripts/actions/queue.py
+++ b/skills/proactive-notify/scripts/actions/queue.py
@@ -1,0 +1,38 @@
+"""Queue action — appends the ping to a local JSONL file for later review.
+
+Used for fyi-tier pings and quiet-hours downgrades.  A morning-briefing or
+drain-queue script can consume and clear the file.
+
+State: $WORKSPACE/skills/proactive-notify/state/queue.jsonl
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "src"))
+from workspace_default import resolve_workspace  # noqa: E402
+
+_QUEUE_FILE = resolve_workspace() / "skills" / "proactive-notify" / "state" / "queue.jsonl"
+
+
+def send(ping, body: str) -> dict:
+    """Append entry to the queue file.  Always succeeds unless the FS is full."""
+    ts = datetime.now(timezone.utc)
+    entry_id = f"q-{ts.strftime('%Y%m%dT%H%M%SZ')}"
+    record = {
+        "id": entry_id,
+        "ts": ts.isoformat(),
+        "ping": str(getattr(ping, "name", "") or ""),
+        "urgency": str(getattr(ping, "urgency", "fyi") or "fyi"),
+        "body": body,
+    }
+    try:
+        _QUEUE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with _QUEUE_FILE.open("a") as f:
+            f.write(json.dumps(record) + "\n")
+        return {"ok": True, "id": entry_id}
+    except OSError as e:
+        return {"ok": False, "error": str(e)}

--- a/skills/proactive-notify/scripts/actions/voice.py
+++ b/skills/proactive-notify/scripts/actions/voice.py
@@ -1,0 +1,29 @@
+"""Voice action — speaks the ping body via the voice agent's result bridge.
+
+Writes $WORKSPACE/results/proactive-{ts}.txt so task-bridge picks it up and
+narrates it through the active voice session.
+
+The channel router only routes here when presence.voice_client_connected is
+True, but send() is tolerant of the case where it isn't.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "src"))
+from workspace_default import resolve_workspace  # noqa: E402
+
+_RESULTS_DIR = resolve_workspace() / "results"
+
+
+def send(ping, body: str) -> dict:
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    result_path = _RESULTS_DIR / f"proactive-{ts}.txt"
+    try:
+        _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        result_path.write_text(body)
+        return {"ok": True, "id": ts}
+    except OSError as e:
+        return {"ok": False, "error": str(e)}

--- a/tests/proactive-notify-actions-queue-voice-notif.test.py
+++ b/tests/proactive-notify-actions-queue-voice-notif.test.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Tests for proactive-notify queue / voice / macos_notif action modules."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+REPO = Path(__file__).resolve().parent.parent
+ACTIONS_DIR = REPO / "skills" / "proactive-notify" / "scripts" / "actions"
+
+
+def _load(name: str):
+    path = ACTIONS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# queue action
+# ---------------------------------------------------------------------------
+
+class TestQueueModuleExists(unittest.TestCase):
+    def test_file_exists(self):
+        self.assertTrue((ACTIONS_DIR / "queue.py").exists())
+
+    def test_send_callable(self):
+        q = _load("queue")
+        self.assertTrue(callable(q.send))
+
+
+class TestQueueSend(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._ws = Path(self._tmp.name)
+        # Patch resolve_workspace inside the already-loaded module.
+        self._q = _load("queue")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _send(self, body="hello"):
+        fake_ping = MagicMock()
+        fake_ping.name = "test-ping"
+        fake_ping.urgency = "fyi"
+        queue_file = self._ws / "skills" / "proactive-notify" / "state" / "queue.jsonl"
+        with patch.object(self._q, "_QUEUE_FILE", queue_file):
+            return self._q.send(fake_ping, body), queue_file
+
+    def test_returns_ok(self):
+        result, _ = self._send()
+        self.assertTrue(result["ok"])
+
+    def test_id_starts_with_q(self):
+        result, _ = self._send()
+        self.assertTrue(result["id"].startswith("q-"))
+
+    def test_file_created(self):
+        _, queue_file = self._send()
+        self.assertTrue(queue_file.exists())
+
+    def test_entry_is_valid_json(self):
+        _, queue_file = self._send("some body text")
+        line = queue_file.read_text().strip()
+        record = json.loads(line)
+        self.assertEqual(record["body"], "some body text")
+
+    def test_record_has_required_fields(self):
+        _, queue_file = self._send("msg")
+        record = json.loads(queue_file.read_text().strip())
+        for field in ("id", "ts", "ping", "urgency", "body"):
+            self.assertIn(field, record)
+
+    def test_record_ping_and_urgency(self):
+        _, queue_file = self._send()
+        record = json.loads(queue_file.read_text().strip())
+        self.assertEqual(record["ping"], "test-ping")
+        self.assertEqual(record["urgency"], "fyi")
+
+    def test_second_send_appends(self):
+        _, queue_file = self._send("first")
+        with patch.object(self._q, "_QUEUE_FILE", queue_file):
+            fake = MagicMock()
+            fake.name = "p2"
+            fake.urgency = "important"
+            self._q.send(fake, "second")
+        lines = [l for l in queue_file.read_text().splitlines() if l.strip()]
+        self.assertEqual(len(lines), 2)
+
+    def test_oserror_returns_not_ok(self):
+        # Point at a read-only directory so mkdir raises OSError.
+        import os
+        ro_dir = self._ws / "readonly_parent"
+        ro_dir.mkdir(parents=True, exist_ok=True)
+        ro_dir.chmod(0o444)
+        queue_file = ro_dir / "subdir" / "queue.jsonl"
+        try:
+            fake = MagicMock()
+            fake.name = "ping"
+            fake.urgency = "fyi"
+            with patch.object(self._q, "_QUEUE_FILE", queue_file):
+                result = self._q.send(fake, "msg")
+            self.assertFalse(result["ok"])
+            self.assertIsInstance(result["error"], str)
+        finally:
+            ro_dir.chmod(0o755)
+
+    def test_creates_parent_dirs(self):
+        deep = self._ws / "a" / "b" / "c" / "queue.jsonl"
+        with patch.object(self._q, "_QUEUE_FILE", deep):
+            result = self._q.send(MagicMock(), "test")
+        self.assertTrue(result["ok"])
+        self.assertTrue(deep.exists())
+
+
+# ---------------------------------------------------------------------------
+# voice action
+# ---------------------------------------------------------------------------
+
+class TestVoiceModuleExists(unittest.TestCase):
+    def test_file_exists(self):
+        self.assertTrue((ACTIONS_DIR / "voice.py").exists())
+
+    def test_send_callable(self):
+        v = _load("voice")
+        self.assertTrue(callable(v.send))
+
+
+class TestVoiceSend(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._ws = Path(self._tmp.name)
+        self._v = _load("voice")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _send(self, body="speak this"):
+        results_dir = self._ws / "results"
+        with patch.object(self._v, "_RESULTS_DIR", results_dir):
+            return self._v.send(MagicMock(), body), results_dir
+
+    def test_returns_ok(self):
+        result, _ = self._send()
+        self.assertTrue(result["ok"])
+
+    def test_id_is_timestamp_string(self):
+        result, _ = self._send()
+        self.assertIsInstance(result["id"], str)
+        self.assertGreater(len(result["id"]), 0)
+
+    def test_result_file_created(self):
+        result, results_dir = self._send("hello voice")
+        ts = result["id"]
+        expected = results_dir / f"proactive-{ts}.txt"
+        self.assertTrue(expected.exists())
+
+    def test_result_file_contains_body(self):
+        result, results_dir = self._send("say something")
+        ts = result["id"]
+        content = (results_dir / f"proactive-{ts}.txt").read_text()
+        self.assertEqual(content, "say something")
+
+    def test_filename_starts_with_proactive(self):
+        _, results_dir = self._send()
+        files = list(results_dir.glob("proactive-*.txt"))
+        self.assertEqual(len(files), 1)
+
+    def test_oserror_returns_not_ok(self):
+        bad_dir = self._ws / "results"
+        bad_dir.mkdir(parents=True, exist_ok=True)
+        # Make the directory read-only so writing fails.
+        bad_dir.chmod(0o444)
+        try:
+            with patch.object(self._v, "_RESULTS_DIR", bad_dir):
+                result = self._v.send(MagicMock(), "fail")
+            self.assertFalse(result["ok"])
+        finally:
+            bad_dir.chmod(0o755)
+
+    def test_creates_results_dir_if_absent(self):
+        results_dir = self._ws / "new_results"
+        with patch.object(self._v, "_RESULTS_DIR", results_dir):
+            result = self._v.send(MagicMock(), "body")
+        self.assertTrue(result["ok"])
+        self.assertTrue(results_dir.exists())
+
+
+# ---------------------------------------------------------------------------
+# macos_notif action
+# ---------------------------------------------------------------------------
+
+class TestMacosNotifModuleExists(unittest.TestCase):
+    def test_file_exists(self):
+        self.assertTrue((ACTIONS_DIR / "macos_notif.py").exists())
+
+    def test_send_callable(self):
+        m = _load("macos_notif")
+        self.assertTrue(callable(m.send))
+
+    def test_default_title_constant(self):
+        m = _load("macos_notif")
+        self.assertEqual(m._DEFAULT_TITLE, "Sutando")
+
+
+class TestMacosNotifSend(unittest.TestCase):
+    def setUp(self):
+        self._m = _load("macos_notif")
+
+    def _send(self, body="ping", env=None):
+        import subprocess
+        env = env or {}
+        mock_run = MagicMock(return_value=MagicMock(returncode=0))
+        with patch.dict("os.environ", env, clear=True):
+            with patch("subprocess.run", mock_run):
+                result = self._m.send(MagicMock(), body)
+        return result, mock_run
+
+    def test_returns_ok_on_success(self):
+        result, _ = self._send()
+        self.assertTrue(result["ok"])
+
+    def test_id_is_notif(self):
+        result, _ = self._send()
+        self.assertEqual(result["id"], "notif")
+
+    def test_calls_osascript(self):
+        _, mock_run = self._send("hi")
+        call_args = mock_run.call_args[0][0]
+        self.assertEqual(call_args[0], "osascript")
+        self.assertEqual(call_args[1], "-e")
+
+    def test_body_in_script(self):
+        _, mock_run = self._send("meeting soon")
+        script = mock_run.call_args[0][0][2]
+        self.assertIn("meeting soon", script)
+
+    def test_default_title_used(self):
+        _, mock_run = self._send(env={})
+        script = mock_run.call_args[0][0][2]
+        self.assertIn("Sutando", script)
+
+    def test_custom_title_from_env(self):
+        _, mock_run = self._send(env={"SUTANDO_NOTIF_TITLE": "MyBot"})
+        script = mock_run.call_args[0][0][2]
+        self.assertIn("MyBot", script)
+
+    def test_file_not_found_returns_not_ok(self):
+        import subprocess
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = self._m.send(MagicMock(), "test")
+        self.assertFalse(result["ok"])
+        self.assertIn("osascript not found", result["error"])
+
+    def test_timeout_returns_not_ok(self):
+        import subprocess
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("osascript", 5)):
+            result = self._m.send(MagicMock(), "test")
+        self.assertFalse(result["ok"])
+        self.assertIn("timed out", result["error"])
+
+    def test_called_process_error_returns_not_ok(self):
+        import subprocess
+        err = subprocess.CalledProcessError(1, "osascript", stderr=b"permission denied")
+        with patch("subprocess.run", side_effect=err):
+            result = self._m.send(MagicMock(), "test")
+        self.assertFalse(result["ok"])
+        self.assertIn("permission denied", result["error"])
+
+    def test_body_with_double_quotes_escaped(self):
+        _, mock_run = self._send('say "hi"')
+        script = mock_run.call_args[0][0][2]
+        # Raw double quotes must not appear unescaped inside AppleScript string
+        # (the body was 'say "hi"', should become 'say \\"hi\\"')
+        self.assertIn('\\"hi\\"', script)
+
+    def test_body_with_backslash_escaped(self):
+        _, mock_run = self._send("path\\to\\file")
+        script = mock_run.call_args[0][0][2]
+        self.assertIn("path\\\\to\\\\file", script)
+
+
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    for cls in [
+        TestQueueModuleExists, TestQueueSend,
+        TestVoiceModuleExists, TestVoiceSend,
+        TestMacosNotifModuleExists, TestMacosNotifSend,
+    ]:
+        suite.addTests(loader.loadTestsFromTestCase(cls))
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)


### PR DESCRIPTION
## Problem

`channel-policy.yaml.example` references three action channel names —
`queue`, `voice`, and `macos_notif` — but none of those modules existed
under `skills/proactive-notify/scripts/actions/`. The runner does
`importlib.import_module(f"actions.{channel}")`, so any ping routed to
these channels failed with `ModuleNotFoundError` at runtime:

- `fyi`-tier pings: default channel is `queue` → silent failure every run
- Quiet-hours downgrades: `important` → `queue`, `critical` → stays as `sms`
- Voice-client-connected override: routes all tiers to `voice` → failure
- macOS notification: no path to send desktop banner

## Solution

Add three new action modules:

### `queue.py`
Appends to `$WORKSPACE/skills/proactive-notify/state/queue.jsonl` as
newline-delimited JSON entries (id, ts, ping name, urgency, body).
Idempotent directory creation; OSError returns `{"ok": False, "error": ...}`.

### `voice.py`
Writes `$WORKSPACE/results/proactive-{ts}.txt` — the standard path
polled by `task-bridge.ts` for narration to the active voice session.

### `macos_notif.py`
Fires `osascript` for a macOS desktop notification banner.  Properly
escapes backslashes and double-quotes in the body/title before
interpolating into the AppleScript string literal. Custom title via
`SUTANDO_NOTIF_TITLE` env var (default: "Sutando").  Catches
`FileNotFoundError`, `TimeoutExpired`, and `CalledProcessError`.

## Tests

`tests/proactive-notify-actions-queue-voice-notif.test.py` — 34 tests:
- `TestQueueModuleExists` (2) + `TestQueueSend` (9): append logic, JSONL
  format, directory creation, error propagation
- `TestVoiceModuleExists` (2) + `TestVoiceSend` (7): file naming, content,
  dir creation, error path
- `TestMacosNotifModuleExists` (3) + `TestMacosNotifSend` (11): osascript
  call shape, title env override, all failure modes, injection escaping

All 34 pass on Python 3.9.

## Checklist
- [x] `queue.py` — fyi + quiet-hours sink
- [x] `voice.py` — voice session narration
- [x] `macos_notif.py` — desktop notification banner
- [x] 34 tests, all green
- [x] No hardcoded owner literals (follows SKILL.md "No personal literals in code")

🤖 Generated with [Claude Code](https://claude.com/claude-code)