### PR TITLE
test(archive-stale-results): 15 tests for retention + dry-run + edge cases

### DIFF
--- a/build_log.md
+++ b/build_log.md
@@ -96,3 +96,19 @@
 
 **Pending push go-ahead** (new this pass):
 - `feat/cross-node-sync-config-1044` (15 tests, `a072033`)
+
+## Pass 214 (2026-05-25)
+
+**fix(watch-tasks-stream): Node .mjs closes both orphan paths (closes #1088)** (commit `8751618` on `fix/watch-tasks-orphan-1088`):
+- `src/watch-tasks-stream.mjs` (new) — Node implementation replaces fswatch bash script
+  - **Mode A (EPIPE)**: `process.stdout.on('error')` handler exits on EPIPE/EBADF; 30s heartbeat (`HEARTBEAT_INTERVAL_MS` override) forces EPIPE detection when tasks dir is quiet
+  - **Mode B (PPID reparent)**: polls `process.ppid` every 10s, exits when parent gone; also handles SIGHUP
+  - Inline `bumpAttemptsCounter()` (no external Python dep, graceful degradation)
+  - Workspace resolution: SUTANDO_WORKSPACE → ~/.sutando/workspace (no fswatch dep)
+- `src/watch-tasks-stream.sh` — updated to thin wrapper (`exec node watch-tasks-stream.mjs`)
+- 15 tests in `tests/watch-tasks-stream-orphan.test.py` — all passing (T14 validates EPIPE exits in ≤5s)
+- Issue filed by Susan Xueqing Liu; reproduces 2026-05-23 4h task-loss incident (3 owner DMs unprocessed)
+- Note: cherry-pick to merge/stando-sync conflicted (stando-sync has divergent .mjs); will resolve at merge time
+
+**Pending push go-ahead** (new this pass):
+- `fix/watch-tasks-orphan-1088` (15 tests, `8751618`)

--- a/build_log.md
+++ b/build_log.md
@@ -1,0 +1,98 @@
+
+## Pass 207 (2026-05-25)
+
+**fix(health-check): multi-bridge source-path warn** (commit `d9a384c` on main):
+- `multiple processes` warn now shows full script paths per PID
+- Before: `2 PIDs: 25023,25065` — opaque, unactionable
+- After: `25023:/Applications/Sutando.app/.../discord-bridge.py, 25065:/Users/.../sutando/src/discord-bridge.py`
+- Root cause of dual-bridge: app-bundle startup.sh + dev repo both launched bridges at 5:20AM — different source paths, different workspaces
+- 5 structural tests in `tests/health-check-bridge-multi-pid.test.py`
+
+**Push go-ahead needed**: `main` branch has this commit (not yet pushed to origin/main).
+
+## Pass 208–209 (2026-05-25)
+
+**feat(content): Ep4 LinkedIn park walk post — READY TO POST**
+- Created `notes/linkedin-ep4-park-walk-final.md` — polished LinkedIn copy for Ep4
+- Text-only (Option C), no filming required — full narrative arc from Twitter thread expanded for LinkedIn
+- Supersedes `linkedin-ep4-draft.md` (that file has the stale Meeting Gap/Linear angle)
+- Status: copy-paste ready; posting window Tue–Thu 8–10am or 12–1pm local
+
+**feat(obsidian): mirror script + 44 tests** (already on `merge/stando-sync`, commit `34ecea7`):
+- `src/obsidian-mirror.py` — sonichi #1082 port, idempotency bug fixed in `_write_result_mirror`
+- `tests/obsidian-mirror.test.py` — 44 tests, all passing, importlib import pattern for hyphenated filename
+- `skills/obsidian-vault/SKILL.md`, `manifest.json`, `scripts/dream.py`, `tools.ts` ported
+
+**Pending push go-aheads**:
+- `port/watch-tasks-attempts-stando-63` (10 tests, `4852e48`)
+- `port/share-screen-standalone-1073` (4 tests, `6f3eca0`)
+- `port/result-channel-key-1090` (48 tests, `c138b2d`)
+- `port/za-warudo-mention-precedence-1091` (11 tests, `2b5828c`)
+- `port/codeql-stack-trace-1092` (10 tests, `cf10b7f`)
+- `merge/stando-sync` (162 commits ahead of origin/main)
+- `main` (health-check + obsidian-vault commits)
+- `fix/slack-bridge-py39-annotations` (3 tests added, commit `990fc11`)
+
+## Pass 210 (2026-05-25)
+
+**test(slack-bridge): py39 regression guard** (commit `990fc11` on `fix/slack-bridge-py39-annotations`):
+- Added 3 structural tests: `from __future__ import annotations` present + at top + `str | None` still exists
+- Branch now push-ready (was missing tests per "every script ships with tests" rule)
+
+**content(ep4): confirmed final LinkedIn post fixed + memory updated**:
+- `notes/linkedin-ep4-park-walk-final.md` corrected to Bassil's confirmed "THIS IS IT" version (shorter)
+- Earlier pass had an unapproved expanded draft — replaced with the exact confirmed text from memory
+- `project-always-on-content.md` memory updated: "filming pending" → text-only, files listed
+
+**Push go-ahead needed** (new additions this pass):
+- `fix/slack-bridge-py39-annotations` (3 tests, `990fc11`)
+
+## Pass 211 (2026-05-25)
+
+**feat(x-post): thread subcommand** (commit `07445a0` on `feat/x-post-thread-command`):
+- `skills/x-twitter/x-post.py` — added `thread` subcommand: reads `---`-delimited file, posts each section as reply-to-previous chain
+- `--dry-run` flag prints all tweets without API call; `--delay` controls inter-tweet gap (default 2s)
+- 9 tests in `tests/x-post-thread.test.py` — all passing
+- **Unlocks**: `python3 skills/x-twitter/x-post.py thread --file <path>` for Ep4, Ep5, WWDC threads
+
+**feat(content): WWDC June 10 dev thread file created** (`skills/x-twitter/threads/wwdc-2026-dev-thread.txt`):
+- 7-tweet dev angle: "Build your own proactive agent before Apple ships theirs"
+- Ready to post June 10 with: `python3 skills/x-twitter/x-post.py thread --file skills/x-twitter/threads/wwdc-2026-dev-thread.txt`
+- The note at `notes/wwdc-june10-dev-twitter-thread.md` referenced this file but it didn't exist — gap closed
+
+**Outreach signals (fresh scan 05:57 May 25):**
+- 12 signals, same as yesterday — no new companies, no fills
+- Carta CoS (Chief Product Officer) now day 3 — still open, highest urgency
+- Still blocked on HUNTER_API_KEY + INSTANTLY_API_KEY
+
+**Push go-ahead needed** (new this pass):
+- `feat/x-post-thread-command` (9 tests, `07445a0`)
+
+## Pass 212 (2026-05-25)
+
+**feat(content): Ep5 barber thread file + test** (commit `05181a4` on `feat/x-post-thread-command`):
+- `skills/x-twitter/threads/always-on-ep5-barber.txt` — 5-tweet thread for Ep5 barber chair delegation story
+- The concept note referenced this file but it didn't exist (same gap as WWDC dev thread, now closed)
+- 10/10 tests passing (added `test_ep5_thread_file_parseable`)
+- Post command: `python3 skills/x-twitter/x-post.py thread --file skills/x-twitter/threads/always-on-ep5-barber.txt`
+
+**Note (from Discord log):** agent-universe PR #48 (WebView OAuth fix) already merged — task was processed and result archived correctly.
+
+**All thread files now complete:**
+- Ep4: `always-on-ep4-park-walk.txt` (6 tweets) ✓
+- Ep5: `always-on-ep5-barber.txt` (5 tweets) ✓ NEW
+- Ep6 (park-demo): `always-on-ep6-park-demo.txt` ✓
+- WWDC dev (June 10): `wwdc-2026-dev-thread.txt` (7 tweets) ✓
+
+## Pass 213 (2026-05-25)
+
+**feat(cross-node-sync): configurable scope via JSON config (closes #1044)** (commit `a072033` on `feat/cross-node-sync-config-1044`):
+- `skills/cross-node-sync/scripts/setup-rsync-sync.sh` — reads `$SUTANDO_WORKSPACE/config/cross-node-sync.json` to enable/disable memory/notes/assets/data scopes independently
+- `_scope_enabled()` bash function with inline Python JSON parsing; falls back to all-enabled on missing file or invalid JSON
+- `skills/cross-node-sync/config/cross-node-sync.example.json` — example config ships with skill
+- 15 tests in `tests/cross-node-sync-config.test.py` — all passing; uses `patched_sync_peer()` context manager to work around `.env` loading that overrides env vars
+- Filed by Susan Xueqing Liu — enables per-operator customization without script PRs
+- Cherry-picked onto `merge/stando-sync` (`42fb28d`)
+
+**Pending push go-ahead** (new this pass):
+- `feat/cross-node-sync-config-1044` (15 tests, `a072033`)

--- a/scripts/lint-cwd-writes.py
+++ b/scripts/lint-cwd-writes.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+lint-cwd-writes.py — flag bare cwd() calls outside canonical workspace resolvers.
+
+Code that resolves workspace paths via process.cwd() / Path.cwd() / os.getcwd()
+instead of the canonical helpers (resolve_workspace / resolveWorkspace) re-introduces
+the workspace-vs-repo split-brain bug closed in the 2026-05-18 audit (#863).
+
+Usage:
+    python3 scripts/lint-cwd-writes.py [files...]
+
+    files   Explicit list of .py / .ts / .js / .mjs files to check.
+            Defaults to src/**/*.py and src/**/*.ts.
+
+Exit codes:
+    0  All files clean
+    1  One or more violations found
+
+Allowlist policy:
+    Python — Path.cwd() / os.getcwd() are allowed ONLY in:
+        src/workspace_default.py  (the canonical resolver itself)
+        src/util_paths.py         (path utility helpers)
+
+    TypeScript/JS — process.cwd() is allowed ONLY in:
+        src/workspace_default.ts  (the canonical resolver itself)
+        src/util_paths.ts         (path utility helpers)
+        Any *_helpers* or *test* path
+        Inline-tool REPO_ROOT uses (src/inline-tools.ts — post #848 approved)
+        src/browser-tools.ts      (REPO_ROOT-relative, post-audit approved)
+
+    Comments (lines starting with //, #, or /*, or containing // cwd) are ignored.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+
+# --- Python allowlist ---
+PY_ALLOWED_FILES = {
+    "src/workspace_default.py",
+    "src/util_paths.py",
+}
+
+# --- TS/JS allowlist ---
+TS_ALLOWED_FILES = {
+    "src/workspace_default.ts",
+    "src/util_paths.ts",
+    "src/inline-tools.ts",
+    "src/browser-tools.ts",
+}
+TS_ALLOWED_PATTERNS = [
+    re.compile(r"[_\-]helper"),
+    re.compile(r"\.test\."),
+    re.compile(r"tests/"),
+]
+
+# Patterns that indicate a cwd call (not in a comment)
+PY_CWD_RE = re.compile(r"\b(?:Path\.cwd|os\.getcwd)\s*\(")
+TS_CWD_RE = re.compile(r"\bprocess\.cwd\s*\(")
+
+# Comment patterns — lines where cwd appears only as documentation
+PY_COMMENT_RE = re.compile(r"^\s*#")
+TS_COMMENT_RE = re.compile(r"^\s*(?://|/\*|\*)")
+INLINE_COMMENT_RE = re.compile(r"//.*cwd|#.*cwd")  # cwd in trailing comment
+
+
+def is_py_allowed(rel_path: str) -> bool:
+    return rel_path in PY_ALLOWED_FILES
+
+
+def is_ts_allowed(rel_path: str) -> bool:
+    if rel_path in TS_ALLOWED_FILES:
+        return True
+    for pat in TS_ALLOWED_PATTERNS:
+        if pat.search(rel_path):
+            return True
+    return False
+
+
+def check_py(path: Path) -> list[tuple[int, str]]:
+    """Return list of (lineno, line) violations for a Python file."""
+    rel = str(path.relative_to(REPO_ROOT))
+    if is_py_allowed(rel):
+        return []
+    violations = []
+    try:
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if PY_COMMENT_RE.match(line):
+                continue
+            # Strip inline trailing comments before matching
+            code_part = re.split(r"#", line)[0]
+            if PY_CWD_RE.search(code_part):
+                violations.append((i, line.rstrip()))
+    except Exception:
+        pass
+    return violations
+
+
+def check_ts(path: Path) -> list[tuple[int, str]]:
+    """Return list of (lineno, line) violations for a TS/JS file."""
+    rel = str(path.relative_to(REPO_ROOT))
+    if is_ts_allowed(rel):
+        return []
+    violations = []
+    try:
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if TS_COMMENT_RE.match(line):
+                continue
+            # Strip inline trailing // comments
+            code_part = re.split(r"//", line)[0]
+            if TS_CWD_RE.search(code_part):
+                violations.append((i, line.rstrip()))
+    except Exception:
+        pass
+    return violations
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    file_args = [a for a in argv if not a.startswith("--")]
+    if file_args:
+        paths = [Path(f) for f in file_args]
+    else:
+        paths = sorted((REPO_ROOT / "src").glob("*.py")) + \
+                sorted((REPO_ROOT / "src").glob("*.ts")) + \
+                sorted((REPO_ROOT / "src").glob("*.mjs"))
+
+    violations = 0
+    for path in paths:
+        if not path.exists():
+            print(f"SKIP   {path}  (not found)", file=sys.stderr)
+            continue
+        suffix = path.suffix.lower()
+        if suffix == ".py":
+            hits = check_py(path)
+        elif suffix in (".ts", ".js", ".mjs"):
+            hits = check_ts(path)
+        else:
+            continue
+        for lineno, line in hits:
+            try:
+                rel = path.relative_to(REPO_ROOT)
+            except ValueError:
+                rel = path
+            print(f"FAIL   {rel}:{lineno}  — bare cwd() call outside canonical resolver")
+            print(f"       {line[:120]}")
+            violations += 1
+
+    if violations:
+        print(f"\n{violations} violation(s) — use resolve_workspace() / resolveWorkspace() instead of bare cwd().")
+        sys.exit(1)
+    elif file_args:
+        print("All files clean.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lint-py39-annotations.py
+++ b/scripts/lint-py39-annotations.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+lint-py39-annotations.py — flag src/*.py files that use PEP-604 union syntax
+(X | Y in type annotations) without `from __future__ import annotations`.
+
+PEP-604 bare union syntax (e.g. `str | None`) requires Python 3.10+.
+Adding `from __future__ import annotations` (PEP-563) makes it work on 3.9
+because annotations become strings evaluated lazily.
+
+Usage:
+    python3 scripts/lint-py39-annotations.py [--fix] [files...]
+
+    --fix   Add `from __future__ import annotations` to flagged files.
+    files   Explicit list of .py files to check (default: src/*.py).
+
+Exit codes:
+    0  All files clean (or all fixed)
+    1  One or more violations found (without --fix)
+"""
+
+import ast
+import re
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+DEFAULT_GLOB = "src/*.py"
+
+# Regex: a bare `|` between two identifiers or bracketed types in annotation
+# position. We use AST-level detection (more reliable than regex), but the
+# regex is used as a fast pre-filter to skip files that can't possibly match.
+_UNION_RE = re.compile(r"\w[\w\[\], ]*\s*\|\s*[\w\[\], ]*\w")
+
+
+def has_future_annotations(source: str) -> bool:
+    """Return True if the file already has `from __future__ import annotations`."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "__future__" and any(
+                alias.name == "annotations" for alias in node.names
+            ):
+                return True
+    return False
+
+
+def uses_union_syntax(source: str) -> bool:
+    """Return True if source uses `X | Y` type union syntax."""
+    if not _UNION_RE.search(source):
+        return False
+    # AST walk: look for BinOp with BitOr operator in annotation contexts.
+    # Python 3.10+ parses `X | Y` as ast.BinOp(op=ast.BitOr) in annotations;
+    # on 3.9 this is only valid under `from __future__ import annotations`
+    # (where annotations are strings, not evaluated). We detect via regex
+    # on annotation source positions since 3.9's ast doesn't produce BinOp
+    # for annotation unions.
+    #
+    # Strategy: use tokenize to find `|` tokens inside annotation positions.
+    # Simpler approach: look for function/variable annotations with `|`.
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+
+    lines = source.splitlines()
+
+    def _annotation_contains_union(ann) -> bool:
+        if ann is None:
+            return False
+        # On Python 3.10+, `X | Y` parses as BinOp(BitOr)
+        if isinstance(ann, ast.BinOp) and isinstance(ann.op, ast.BitOr):
+            return True
+        # Recurse into subscripts, tuples, etc.
+        for child in ast.walk(ann):
+            if child is ann:
+                continue
+            if isinstance(child, ast.BinOp) and isinstance(child.op, ast.BitOr):
+                return True
+        # Fallback: check raw annotation line for `|` pattern
+        # (handles cases where ast doesn't parse BinOp on older Pythons)
+        start = getattr(ann, "lineno", None)
+        end = getattr(ann, "end_lineno", None)
+        if start and end:
+            snippet = " ".join(lines[start - 1 : end])
+            if _UNION_RE.search(snippet):
+                return True
+        return False
+
+    for node in ast.walk(tree):
+        # Function argument annotations and return annotation
+        if isinstance(node, ast.FunctionDef) or isinstance(node, ast.AsyncFunctionDef):
+            if _annotation_contains_union(node.returns):
+                return True
+            for arg in node.args.args + node.args.posonlyargs + node.args.kwonlyargs:
+                if _annotation_contains_union(arg.annotation):
+                    return True
+            if node.args.vararg and _annotation_contains_union(node.args.vararg.annotation):
+                return True
+            if node.args.kwarg and _annotation_contains_union(node.args.kwarg.annotation):
+                return True
+        # Variable annotations (x: int | None = ...)
+        if isinstance(node, ast.AnnAssign):
+            if _annotation_contains_union(node.annotation):
+                return True
+    return False
+
+
+def _insert_future_annotations(source: str) -> str:
+    """Insert `from __future__ import annotations` after any module docstring."""
+    lines = source.splitlines(keepends=True)
+    insert_at = 0
+    # Skip shebang
+    if lines and lines[0].startswith("#!"):
+        insert_at = 1
+    # Skip module docstring (string literal as first statement)
+    try:
+        tree = ast.parse(source)
+        for node in tree.body:
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+                insert_at = node.end_lineno  # insert after docstring line
+            break
+    except SyntaxError:
+        pass
+    # Skip leading comment lines if no docstring consumed them
+    while insert_at < len(lines) and lines[insert_at].startswith("#"):
+        insert_at += 1
+    future_line = "from __future__ import annotations\n"
+    # Don't double-insert
+    if future_line in lines:
+        return source
+    lines.insert(insert_at, future_line)
+    return "".join(lines)
+
+
+def lint_file(path: Path, fix: bool = False) -> bool:
+    """
+    Check a single file. Return True if clean (no violation or fixed),
+    False if violation found (and not fixing).
+    """
+    source = path.read_text(encoding="utf-8")
+    if has_future_annotations(source):
+        return True
+    if not uses_union_syntax(source):
+        return True
+    # Violation found
+    if fix:
+        new_source = _insert_future_annotations(source)
+        path.write_text(new_source, encoding="utf-8")
+        print(f"FIXED  {path}")
+        return True
+    print(f"FAIL   {path}  — uses X|Y union syntax but missing `from __future__ import annotations`")
+    return False
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    fix = "--fix" in argv
+    file_args = [a for a in argv if not a.startswith("--")]
+
+    if file_args:
+        paths = [Path(f) for f in file_args]
+    else:
+        paths = sorted((REPO_ROOT / "src").glob("*.py"))
+
+    violations = 0
+    for path in paths:
+        if not path.exists():
+            print(f"SKIP   {path}  (not found)", file=sys.stderr)
+            continue
+        ok = lint_file(path, fix=fix)
+        if not ok:
+            violations += 1
+
+    if violations:
+        print(f"\n{violations} file(s) need `from __future__ import annotations`")
+        print("Re-run with --fix to add it automatically.")
+        sys.exit(1)
+    elif file_args or fix:
+        print("All files clean.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -375,6 +375,21 @@ def archive_path(kind: str, task_id: str) -> "Path":
     return month_dir / f"{task_id}.txt"
 
 
+def find_task_file(tasks_dir: "Path", task_id: str):
+    """Return the actual on-disk path for task_id.
+
+    claim_task.py (#884) renames task-{id}.txt → task-{id}.claimed-core-N.txt
+    atomically. Callers that hard-code the bare .txt path silently no-op on
+    archive because the file no longer exists under that name (#933).
+    """
+    from pathlib import Path as _Path
+    bare = _Path(tasks_dir) / f"{task_id}.txt"
+    if bare.exists():
+        return bare
+    matches = list(_Path(tasks_dir).glob(f"{task_id}.claimed-core-*.txt"))
+    return matches[0] if matches else None
+
+
 def archive_file(src: "Path", kind: str, task_id: str) -> None:
     """Move src into the archive. Silent on failure — archive is for later
     analysis, not critical path. Chi's 2026-04-18 ask: "instead of deleting
@@ -3035,8 +3050,9 @@ async def poll_results():
                     # post — same UX as [no-send] / [REPLIED].
                     print(f"  Skipped (already replied or deduped): {task_id}")
                     archive_file(result_file, "results", task_id)
-                    task_file = TASKS_DIR / f"{task_id}.txt"
-                    archive_file(task_file, "tasks", task_id)
+                    _tf = find_task_file(TASKS_DIR, task_id)
+                    if _tf:
+                        archive_file(_tf, "tasks", task_id)
                     continue
                 try:
                     # Extract optional [reply: <message_id>] directive — the
@@ -3093,7 +3109,8 @@ async def poll_results():
                         reply_text = channel_pattern.sub('', reply_text).strip()
                         task_tier = "other"
                         try:
-                            task_body = (TASKS_DIR / f"{task_id}.txt").read_text()
+                            _tf_read = find_task_file(TASKS_DIR, task_id)
+                            task_body = _tf_read.read_text() if _tf_read else ""
                             for ln in task_body.splitlines():
                                 if ln.startswith("access_tier:"):
                                     task_tier = ln.split(":", 1)[1].strip() or "other"
@@ -3183,8 +3200,9 @@ async def poll_results():
                     print(f"  Reply failed: {e}", flush=True)
                 # Archive (not delete) so we can mine patterns later.
                 archive_file(result_file, "results", task_id)
-                task_file = TASKS_DIR / f"{task_id}.txt"
-                archive_file(task_file, "tasks", task_id)
+                _tf = find_task_file(TASKS_DIR, task_id)
+                if _tf:
+                    archive_file(_tf, "tasks", task_id)
         await asyncio.sleep(1)
 
 
@@ -3381,9 +3399,9 @@ async def poll_dm_fallback():
                     # Archive matching task file so audit_orphan_tasks sees
                     # the task as processed (even if drop-without-reply).
                     _task_id = f.stem
-                    _task_file = TASKS_DIR / f"{_task_id}.txt"
-                    if _task_file.exists():
-                        archive_file(_task_file, "tasks", _task_id)
+                    _tf = find_task_file(TASKS_DIR, _task_id)
+                    if _tf:
+                        archive_file(_tf, "tasks", _task_id)
                     continue
                 # Stop retrying after 24h. Without this cap, a permanent
                 # failure (bad channel ID, bot removed from DM, etc.)
@@ -3394,9 +3412,9 @@ async def poll_dm_fallback():
                     print(f"  [dm-fallback] dropping stale {f.name} (age={int(age)}s)", flush=True)
                     f.unlink(missing_ok=True)
                     _task_id = f.stem
-                    _task_file = TASKS_DIR / f"{_task_id}.txt"
-                    if _task_file.exists():
-                        archive_file(_task_file, "tasks", _task_id)
+                    _tf = find_task_file(TASKS_DIR, _task_id)
+                    if _tf:
+                        archive_file(_tf, "tasks", _task_id)
                     continue
                 # Honor result-body suppression markers (parity with the
                 # main reply path at line ~2660). Without this, results
@@ -3410,9 +3428,9 @@ async def poll_dm_fallback():
                 if _peek.startswith('[no-send]') or _peek.startswith('[REPLIED]') or _peek.startswith('[deduped:'):
                     print(f"  [dm-fallback] skipped (suppression marker): {f.name}", flush=True)
                     _task_id = f.stem
-                    _task_file = TASKS_DIR / f"{_task_id}.txt"
-                    if _task_file.exists():
-                        archive_file(_task_file, "tasks", _task_id)
+                    _tf = find_task_file(TASKS_DIR, _task_id)
+                    if _tf:
+                        archive_file(_tf, "tasks", _task_id)
                     archive_file(f, "results", _task_id)
                     continue
 
@@ -3439,7 +3457,8 @@ async def poll_dm_fallback():
                     # task file (the same shape Discord uses).
                     task_tier = "other"
                     try:
-                        task_body = (TASKS_DIR / f"{_task_id}.txt").read_text()
+                        _tf_read = find_task_file(TASKS_DIR, _task_id)
+                        task_body = _tf_read.read_text() if _tf_read else ""
                         for ln in task_body.splitlines():
                             if ln.startswith("access_tier:"):
                                 task_tier = ln.split(":", 1)[1].strip() or "other"
@@ -3483,9 +3502,9 @@ async def poll_dm_fallback():
                                     # See poll_results — log only, no user noise.
                                     print(f"  [dm-fallback channel-redirect] file marker, file not found: {fpath}", flush=True)
                             print(f"  [dm-fallback channel-redirect] sent {f.name} to channel {target_channel_id}", flush=True)
-                            _task_file = TASKS_DIR / f"{_task_id}.txt"
-                            if _task_file.exists():
-                                archive_file(_task_file, "tasks", _task_id)
+                            _tf = find_task_file(TASKS_DIR, _task_id)
+                            if _tf:
+                                archive_file(_tf, "tasks", _task_id)
                             archive_file(f, "results", _task_id)
                             continue
                         # Unresolved → fall through to DM, but strip marker
@@ -3554,9 +3573,9 @@ async def poll_dm_fallback():
                     except OSError:
                         _result_text = ""
                     archive_file(f, "results", _task_id)
-                    _task_file = TASKS_DIR / f"{_task_id}.txt"
-                    if _task_file.exists():
-                        archive_file(_task_file, "tasks", _task_id)
+                    _tf = find_task_file(TASKS_DIR, _task_id)
+                    if _tf:
+                        archive_file(_tf, "tasks", _task_id)
                     if _result_text and _task_id.startswith("task-"):
                         # urlopen is blocking — run in thread so we don't stall
                         # the asyncio event loop for up to 2s per dm-fallback.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -874,9 +874,21 @@ def run_all_checks() -> list[dict]:
             checks.append({"name": name, "status": "warn", "detail": "configured but not running"})
             continue
 
-        # Check 1: Multiple processes (zombie/duplicate)
+        # Check 1: Multiple processes (zombie/duplicate).
+        # Show source paths so it's clear whether these are expected
+        # app-bundle vs dev-repo coexistence or accidental duplicate spawns.
         if len(pids) > 1:
-            checks.append({"name": name, "status": "warn", "detail": f"multiple processes ({len(pids)} PIDs: {','.join(pids)})"})
+            def _pid_script(pid: str) -> str:
+                try:
+                    r = subprocess.run(["/bin/ps", "-p", pid, "-o", "command="],
+                                       capture_output=True, text=True, timeout=3)
+                    parts = r.stdout.strip().split()
+                    py_args = [p for p in parts if p.endswith(".py")]
+                    return py_args[-1] if py_args else "?"
+                except Exception:
+                    return "?"
+            pid_paths = ", ".join(f"{p}:{_pid_script(p)}" for p in pids)
+            checks.append({"name": name, "status": "warn", "detail": f"multiple processes ({len(pids)} PIDs: {pid_paths})"})
             continue
 
         # Check 2: Log file freshness — prefer logs/ (where startup.sh writes)

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -130,6 +130,20 @@ def write_owner_activity(channel: str, summary: str) -> None:
         print(f"  [owner-activity] write failed: {e}", flush=True)
 
 
+def find_task_file(tasks_dir: Path, task_id: str):
+    """Return the actual on-disk path for task_id.
+
+    claim_task.py (#884) renames task-{id}.txt → task-{id}.claimed-core-N.txt
+    atomically. Callers that hard-code the bare .txt path silently no-op on
+    archive because the file no longer exists under that name (#933).
+    """
+    bare = tasks_dir / f"{task_id}.txt"
+    if bare.exists():
+        return bare
+    matches = list(tasks_dir.glob(f"{task_id}.claimed-core-*.txt"))
+    return matches[0] if matches else None
+
+
 def archive_file(src: Path, kind: str, task_id: str) -> None:
     """Move src into archive/<tasks|results>/YYYY-MM/ instead of deleting.
     Matches the behavior of telegram-bridge.py / discord-bridge.py."""
@@ -591,7 +605,9 @@ def result_watcher():
                         print(f"[Slack] reply error: {e}", flush=True)
 
                 archive_file(result_file, "results", task_id)
-                archive_file(TASKS_DIR / f"{task_id}.txt", "tasks", task_id)
+                _tf = find_task_file(TASKS_DIR, task_id)
+                if _tf:
+                    archive_file(_tf, "tasks", task_id)
 
             # Proactive messages (sent to owner DM)
             if not presenter_mode_active():

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -166,6 +166,21 @@ def write_owner_activity(channel: str, summary: str) -> None:
         print(f"  [owner-activity] write failed: {e}")
 
 
+def find_task_file(tasks_dir: "Path", task_id: str):
+    """Return the actual on-disk path for task_id.
+
+    claim_task.py (#884) renames task-{id}.txt → task-{id}.claimed-core-N.txt
+    atomically. Callers that hard-code the bare .txt path silently no-op on
+    archive because the file no longer exists under that name (#933).
+    """
+    from pathlib import Path as _Path
+    bare = _Path(tasks_dir) / f"{task_id}.txt"
+    if bare.exists():
+        return bare
+    matches = list(_Path(tasks_dir).glob(f"{task_id}.claimed-core-*.txt"))
+    return matches[0] if matches else None
+
+
 def archive_file(src: "Path", kind: str, task_id: str) -> None:
     """Move src into archive/<tasks|results>/YYYY-MM/ instead of deleting.
     Silent on failure. Chi's ask 2026-04-18: archive tasks + results for
@@ -587,8 +602,9 @@ def main():
                 if any(a.kind == "skip" for a in parsed.actions):
                     print(f"  Skipped (marker): {task_id}", flush=True)
                     archive_file(result_file, "results", task_id)
-                    task_file = TASKS_DIR / f"{task_id}.txt"
-                    archive_file(task_file, "tasks", task_id)
+                    _tf = find_task_file(TASKS_DIR, task_id)
+                    if _tf:
+                        archive_file(_tf, "tasks", task_id)
                     continue
                 try:
                     send_reply(chat_id, reply_text, task_id=task_id)
@@ -597,8 +613,9 @@ def main():
                     print(f"[Telegram] Reply error: {e}", flush=True)
                 # Archive (not delete) so we can mine patterns later.
                 archive_file(result_file, "results", task_id)
-                task_file = TASKS_DIR / f"{task_id}.txt"
-                archive_file(task_file, "tasks", task_id)
+                _tf = find_task_file(TASKS_DIR, task_id)
+                if _tf:
+                    archive_file(_tf, "tasks", task_id)
 
         time.sleep(1)
 

--- a/tests/archive-stale-results.test.py
+++ b/tests/archive-stale-results.test.py
@@ -234,6 +234,56 @@ with tempfile.TemporaryDirectory() as td:
         fail("T12: all stale files archived", f"{len(remaining)} remaining out={proc.stdout.strip()[:80]}")
 
 # ---------------------------------------------------------------------------
+# T13 — mixed fresh+stale: only stale archived, fresh untouched
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stale = results / "task-old.txt"
+    stale.write_text("old")
+    os.utime(stale, (time.time() - 48 * 3600,) * 2)
+    fresh = results / "task-new.txt"
+    fresh.write_text("new")
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    if not stale.exists() and fresh.exists() and proc.returncode == 0:
+        ok("T13: mixed fresh+stale — only stale moved, fresh stays")
+    else:
+        fail("T13: mixed fresh+stale", f"stale={stale.exists()} fresh={fresh.exists()}")
+
+# ---------------------------------------------------------------------------
+# T14 — RETENTION_HOURS=0 archives every .txt file regardless of age
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    for name in ("a.txt", "b.txt", "c.txt"):
+        (results / name).write_text("content")
+    proc = run_script(ws, {"RETENTION_HOURS": "0"})
+    remaining = list(results.glob("*.txt"))
+    if not remaining and proc.returncode == 0:
+        ok("T14: RETENTION_HOURS=0 archives all .txt files immediately")
+    else:
+        fail("T14: RETENTION_HOURS=0", f"{len(remaining)} .txt remaining")
+
+# ---------------------------------------------------------------------------
+# T15 — .sending files are NOT archived (only .txt suffix is touched)
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    sending = results / "proactive-1748000000.sending"
+    sending.write_text("in-flight")
+    os.utime(sending, (time.time() - 48 * 3600,) * 2)
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    if sending.exists():
+        ok("T15: .sending files are not archived (only .txt suffix is in scope)")
+    else:
+        fail("T15: .sending files untouched", ".sending file was incorrectly archived")
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 print(f"\n{PASS}/{PASS+FAIL} tests passed")

--- a/tests/archive-stale-results.test.py
+++ b/tests/archive-stale-results.test.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Tests for src/archive-stale-results.py — retention + dry-run logic."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SCRIPT = REPO_ROOT / "src" / "archive-stale-results.py"
+
+PASS = 0
+FAIL = 0
+
+def ok(label):
+    global PASS; PASS += 1; print(f"PASS  {label}")
+
+def fail(label, detail=""):
+    global FAIL; FAIL += 1
+    print(f"FAIL  {label}" + (f": {detail}" if detail else ""))
+
+
+def run_script(workspace: Path, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    env = {**os.environ, "SUTANDO_WORKSPACE": str(workspace)}
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True, text=True, env=env
+    )
+
+
+# ---------------------------------------------------------------------------
+# T1 — script exists
+# ---------------------------------------------------------------------------
+if SCRIPT.exists():
+    ok("T1: archive-stale-results.py exists")
+else:
+    fail("T1: archive-stale-results.py exists")
+
+# ---------------------------------------------------------------------------
+# T2 — script has module docstring
+# ---------------------------------------------------------------------------
+content = SCRIPT.read_text() if SCRIPT.exists() else ""
+lines = content.splitlines()
+body = "\n".join(l for l in lines if not l.startswith("#!")).lstrip()
+if body.startswith('"""') or body.startswith("'''"):
+    ok("T2: script has module docstring")
+else:
+    fail("T2: script has module docstring")
+
+# ---------------------------------------------------------------------------
+# T3 — no-op when results/ directory doesn't exist
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    # results/ intentionally absent
+    proc = run_script(ws)
+    if proc.returncode == 0 and "missing" in proc.stdout:
+        ok("T3: exits 0 and reports 'missing' when results/ absent")
+    else:
+        fail("T3: exits 0 when results/ absent", f"rc={proc.returncode} out={proc.stdout.strip()[:80]}")
+
+# ---------------------------------------------------------------------------
+# T4 — archives files older than RETENTION_HOURS
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stale = results / "task-old.txt"
+    stale.write_text("stale result")
+    # Set mtime to 48h ago
+    old_time = time.time() - 48 * 3600
+    os.utime(stale, (old_time, old_time))
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    # File should be gone from results/
+    if not stale.exists() and proc.returncode == 0:
+        ok("T4: archives stale files older than RETENTION_HOURS")
+    else:
+        fail("T4: archives stale files", f"exists={stale.exists()} rc={proc.returncode} out={proc.stdout.strip()[:80]}")
+
+# ---------------------------------------------------------------------------
+# T5 — skips files newer than cutoff
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    fresh = results / "task-fresh.txt"
+    fresh.write_text("fresh result")
+    # mtime = now (definitely within 24h)
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    if fresh.exists() and proc.returncode == 0:
+        ok("T5: skips fresh files within RETENTION_HOURS cutoff")
+    else:
+        fail("T5: skips fresh files", f"exists={fresh.exists()} out={proc.stdout.strip()[:80]}")
+
+# ---------------------------------------------------------------------------
+# T6 — skips non-.txt files
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    non_txt = results / "task-old.json"
+    non_txt.write_text("{}")
+    old_time = time.time() - 48 * 3600
+    os.utime(non_txt, (old_time, old_time))
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    if non_txt.exists():
+        ok("T6: skips non-.txt files even if stale")
+    else:
+        fail("T6: skips non-.txt files", "non-txt file was moved")
+
+# ---------------------------------------------------------------------------
+# T7 — skips subdirectories (archive-* dirs are not touched)
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    archive_sub = results / "archive-2026-01-01"
+    archive_sub.mkdir()
+    old_file_in_archive = archive_sub / "task-old.txt"
+    old_file_in_archive.write_text("archived")
+    old_time = time.time() - 48 * 3600
+    os.utime(old_file_in_archive, (old_time, old_time))
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    if old_file_in_archive.exists():
+        ok("T7: does not touch files inside existing archive-* subdirs")
+    else:
+        fail("T7: does not touch archive-* subdir files", "file inside archive was moved")
+
+# ---------------------------------------------------------------------------
+# T8 — DRY_RUN=1 prints but does not move files
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stale = results / "task-stale.txt"
+    stale.write_text("old result")
+    old_time = time.time() - 48 * 3600
+    os.utime(stale, (old_time, old_time))
+    proc = run_script(ws, {"RETENTION_HOURS": "24", "DRY_RUN": "1"})
+    if stale.exists() and "would archive" in proc.stdout:
+        ok("T8: DRY_RUN=1 prints 'would archive' without moving file")
+    else:
+        fail("T8: DRY_RUN=1 dry-run mode", f"exists={stale.exists()} out={proc.stdout.strip()[:80]}")
+
+# ---------------------------------------------------------------------------
+# T9 — DRY_RUN case-insensitivity: 'No' and 'FALSE' disable dry-run
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stale = results / "task-casetest.txt"
+    stale.write_text("old")
+    old_time = time.time() - 48 * 3600
+    os.utime(stale, (old_time, old_time))
+    proc_no = run_script(ws, {"RETENTION_HOURS": "24", "DRY_RUN": "No"})
+    # DRY_RUN=No should NOT be dry-run (file should be moved)
+    if not stale.exists():
+        ok("T9: DRY_RUN=No treats 'No' as falsy — file is moved (not dry-run)")
+    else:
+        fail("T9: DRY_RUN=No should disable dry-run", f"file still exists; out={proc_no.stdout.strip()[:80]}")
+
+# ---------------------------------------------------------------------------
+# T10 — archive directory named archive-YYYY-MM-DD
+# ---------------------------------------------------------------------------
+import re
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stale = results / "task-dating.txt"
+    stale.write_text("old")
+    old_time = time.time() - 48 * 3600
+    os.utime(stale, (old_time, old_time))
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    archive_dirs = [d for d in results.iterdir() if d.is_dir() and d.name.startswith("archive-")]
+    if archive_dirs and re.match(r"archive-\d{4}-\d{2}-\d{2}", archive_dirs[0].name):
+        ok(f"T10: archive dir named correctly ({archive_dirs[0].name})")
+    else:
+        fail("T10: archive dir named archive-YYYY-MM-DD", f"dirs={[d.name for d in results.iterdir() if d.is_dir()]}")
+
+# ---------------------------------------------------------------------------
+# T11 — archived file is inside archive-YYYY-MM-DD/
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stale = results / "task-moved.txt"
+    stale.write_text("old")
+    old_time = time.time() - 48 * 3600
+    os.utime(stale, (old_time, old_time))
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    archive_dirs = [d for d in results.iterdir() if d.is_dir()]
+    if archive_dirs:
+        archived = list(archive_dirs[0].iterdir())
+        if any(f.name == "task-moved.txt" for f in archived):
+            ok("T11: archived file found inside archive-YYYY-MM-DD/")
+        else:
+            fail("T11: file inside archive dir", f"archive contents={[f.name for f in archived]}")
+    else:
+        fail("T11: archive dir created", "no archive dir found")
+
+# ---------------------------------------------------------------------------
+# T12 — multiple stale files all archived in same pass
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stales = []
+    for i in range(3):
+        f = results / f"task-multi-{i}.txt"
+        f.write_text(f"old {i}")
+        old_time = time.time() - 48 * 3600
+        os.utime(f, (old_time, old_time))
+        stales.append(f)
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    remaining = [f for f in stales if f.exists()]
+    if not remaining and proc.returncode == 0:
+        ok("T12: all 3 stale files archived in single pass")
+    else:
+        fail("T12: all stale files archived", f"{len(remaining)} remaining out={proc.stdout.strip()[:80]}")
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print(f"\n{PASS}/{PASS+FAIL} tests passed")
+if __name__ == "__main__":
+    pass

--- a/tests/cwd-lint.test.py
+++ b/tests/cwd-lint.test.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lint-cwd-writes.py (issue #863 — ban bare cwd() outside resolvers)."""
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "lint-cwd-writes.py"
+
+spec = importlib.util.spec_from_file_location("lint_cwd", SCRIPT)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+check_py = mod.check_py
+check_ts = mod.check_ts
+
+PASS = 0
+FAIL = 0
+
+def ok(label):
+    global PASS
+    PASS += 1
+    print(f"PASS  {label}")
+
+def fail(label, detail=""):
+    global FAIL
+    FAIL += 1
+    print(f"FAIL  {label}" + (f": {detail}" if detail else ""))
+
+
+# ---------------------------------------------------------------------------
+# T1 — script exists
+# ---------------------------------------------------------------------------
+if SCRIPT.exists():
+    ok("T1: lint script exists at scripts/lint-cwd-writes.py")
+else:
+    fail("T1: lint script exists at scripts/lint-cwd-writes.py")
+
+# ---------------------------------------------------------------------------
+# T2 — detects Path.cwd() in Python file
+# ---------------------------------------------------------------------------
+with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False,
+                                  dir=REPO_ROOT / "src") as tf:
+    tf.write("from pathlib import Path\ncwd = Path.cwd()\n")
+    viol_py = Path(tf.name)
+try:
+    hits = check_py(viol_py)
+    if hits and hits[0][0] == 2:
+        ok("T2: check_py detects Path.cwd() at correct line")
+    else:
+        fail("T2: check_py detects Path.cwd() at correct line", f"hits={hits}")
+finally:
+    viol_py.unlink(missing_ok=True)
+
+# ---------------------------------------------------------------------------
+# T3 — detects os.getcwd() in Python file
+# ---------------------------------------------------------------------------
+with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False,
+                                  dir=REPO_ROOT / "src") as tf:
+    tf.write("import os\np = os.getcwd()\n")
+    viol_py2 = Path(tf.name)
+try:
+    hits = check_py(viol_py2)
+    if hits and hits[0][0] == 2:
+        ok("T3: check_py detects os.getcwd()")
+    else:
+        fail("T3: check_py detects os.getcwd()", f"hits={hits}")
+finally:
+    viol_py2.unlink(missing_ok=True)
+
+# ---------------------------------------------------------------------------
+# T4 — ignores Path.cwd() in a Python comment
+# ---------------------------------------------------------------------------
+with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False,
+                                  dir=REPO_ROOT / "src") as tf:
+    tf.write("# Previously used Path.cwd() here — now uses resolve_workspace()\n")
+    comment_py = Path(tf.name)
+try:
+    hits = check_py(comment_py)
+    if not hits:
+        ok("T4: check_py ignores Path.cwd() in a comment line")
+    else:
+        fail("T4: check_py ignores Path.cwd() in a comment line", f"hits={hits}")
+finally:
+    comment_py.unlink(missing_ok=True)
+
+# ---------------------------------------------------------------------------
+# T5 — allows Path.cwd() in workspace_default.py (canonical resolver)
+# ---------------------------------------------------------------------------
+workspace_py = REPO_ROOT / "src" / "workspace_default.py"
+if workspace_py.exists():
+    hits = check_py(workspace_py)
+    if not hits:
+        ok("T5: check_py allows Path.cwd() in src/workspace_default.py")
+    else:
+        fail("T5: check_py allows Path.cwd() in src/workspace_default.py",
+             f"{len(hits)} violation(s) flagged in allowed file")
+else:
+    ok("T5: workspace_default.py not present — skip (no violations possible)")
+
+# ---------------------------------------------------------------------------
+# T6 — detects process.cwd() in TS file
+# ---------------------------------------------------------------------------
+with tempfile.NamedTemporaryFile(suffix=".ts", mode="w", delete=False,
+                                  dir=REPO_ROOT / "src") as tf:
+    tf.write("const d = process.cwd();\n")
+    viol_ts = Path(tf.name)
+try:
+    hits = check_ts(viol_ts)
+    if hits and hits[0][0] == 1:
+        ok("T6: check_ts detects process.cwd() in TS file")
+    else:
+        fail("T6: check_ts detects process.cwd() in TS file", f"hits={hits}")
+finally:
+    viol_ts.unlink(missing_ok=True)
+
+# ---------------------------------------------------------------------------
+# T7 — ignores process.cwd() in a TS comment
+# ---------------------------------------------------------------------------
+with tempfile.NamedTemporaryFile(suffix=".ts", mode="w", delete=False,
+                                  dir=REPO_ROOT / "src") as tf:
+    tf.write("// was: process.cwd() — now uses resolveWorkspace()\n")
+    comment_ts = Path(tf.name)
+try:
+    hits = check_ts(comment_ts)
+    if not hits:
+        ok("T7: check_ts ignores process.cwd() in a TS comment line")
+    else:
+        fail("T7: check_ts ignores process.cwd() in a TS comment line", f"hits={hits}")
+finally:
+    comment_ts.unlink(missing_ok=True)
+
+# ---------------------------------------------------------------------------
+# T8 — allows process.cwd() in workspace_default.ts
+# ---------------------------------------------------------------------------
+workspace_ts = REPO_ROOT / "src" / "workspace_default.ts"
+if workspace_ts.exists():
+    hits = check_ts(workspace_ts)
+    if not hits:
+        ok("T8: check_ts allows process.cwd() in src/workspace_default.ts")
+    else:
+        fail("T8: check_ts allows process.cwd() in src/workspace_default.ts",
+             f"{len(hits)} violation(s) flagged in allowed file")
+else:
+    ok("T8: workspace_default.ts not present — skip")
+
+# ---------------------------------------------------------------------------
+# T9 — allows process.cwd() in approved inline-tools.ts
+# ---------------------------------------------------------------------------
+inline_ts = REPO_ROOT / "src" / "inline-tools.ts"
+if inline_ts.exists():
+    hits = check_ts(inline_ts)
+    if not hits:
+        ok("T9: check_ts allows process.cwd() in approved src/inline-tools.ts")
+    else:
+        fail("T9: check_ts allows process.cwd() in approved src/inline-tools.ts",
+             f"{len(hits)} violation(s)")
+else:
+    ok("T9: inline-tools.ts not present — skip")
+
+# ---------------------------------------------------------------------------
+# T10 — CLI exits 0 for clean src/ directory
+# ---------------------------------------------------------------------------
+proc = subprocess.run(
+    [sys.executable, str(SCRIPT)],
+    capture_output=True, text=True, cwd=str(REPO_ROOT)
+)
+if proc.returncode == 0:
+    ok("T10: CLI exits 0 — all src/ files currently clean")
+else:
+    fail("T10: CLI exits 0 — all src/ files currently clean",
+         proc.stdout.strip()[:200])
+
+# ---------------------------------------------------------------------------
+# T11 — CLI exits 1 for a violating file
+# ---------------------------------------------------------------------------
+with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False,
+                                  dir=REPO_ROOT / "src") as tf:
+    tf.write("import os\nbase = os.getcwd()\n")
+    viol3 = Path(tf.name)
+try:
+    proc2 = subprocess.run(
+        [sys.executable, str(SCRIPT), str(viol3)],
+        capture_output=True, text=True, cwd=str(REPO_ROOT)
+    )
+    if proc2.returncode == 1:
+        ok("T11: CLI exits 1 for a file with os.getcwd() outside allowed paths")
+    else:
+        fail("T11: CLI exits 1 for a violating file", f"rc={proc2.returncode}")
+finally:
+    viol3.unlink(missing_ok=True)
+
+# ---------------------------------------------------------------------------
+# T12 — script has module docstring
+# ---------------------------------------------------------------------------
+content = SCRIPT.read_text()
+lines = content.splitlines()
+body = "\n".join(l for l in lines if not l.startswith("#!")).lstrip()
+if body.startswith('"""') or body.startswith("'''"):
+    ok("T12: lint script has module docstring")
+else:
+    fail("T12: lint script has module docstring")
+
+# ---------------------------------------------------------------------------
+# T13 — ignores process.cwd() in inline trailing TS comment
+# ---------------------------------------------------------------------------
+with tempfile.NamedTemporaryFile(suffix=".ts", mode="w", delete=False,
+                                  dir=REPO_ROOT / "src") as tf:
+    tf.write("const ws = resolveWorkspace(); // previously process.cwd()\n")
+    trailing_ts = Path(tf.name)
+try:
+    hits = check_ts(trailing_ts)
+    if not hits:
+        ok("T13: check_ts ignores process.cwd() in trailing inline comment")
+    else:
+        fail("T13: check_ts ignores process.cwd() in trailing inline comment", f"hits={hits}")
+finally:
+    trailing_ts.unlink(missing_ok=True)
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print(f"\n{PASS}/{PASS+FAIL} tests passed")
+if __name__ == "__main__":
+    pass

--- a/tests/health-check-bridge-multi-pid.test.py
+++ b/tests/health-check-bridge-multi-pid.test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Regression guard: health-check multiple-bridge-process warn shows source paths.
+
+Before this fix, the warn read:
+  "multiple processes (2 PIDs: 25023,25065)"
+
+That gave no hint whether the two instances were an expected app-bundle +
+dev-repo coexistence or an accidental duplicate spawn of the same script.
+After the fix the warn reads:
+  "multiple processes (2 PIDs: 25023:/Applications/Sutando.app/.../discord-bridge.py,
+                                 25065:/Users/.../sutando/src/discord-bridge.py)"
+
+These tests verify the new path-enriched format via source-grep (no live
+process required).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = (REPO / "src" / "health-check.py").read_text(encoding="utf-8")
+
+
+def test_pid_script_helper_defined():
+    """health-check.py defines a _pid_script helper for path extraction."""
+    assert "_pid_script" in SRC, (
+        "_pid_script helper not found in health-check.py — "
+        "multiple-bridge warn will not show source paths"
+    )
+
+
+def test_pid_script_uses_ps_command():
+    """_pid_script extracts the script path from `ps -p <pid> -o command=`."""
+    assert '"-o", "command="' in SRC or "command=" in SRC, (
+        "health-check.py doesn't call `ps -o command=` to extract bridge script path"
+    )
+
+
+def test_pid_paths_in_warn_detail():
+    """The multi-pid warn uses pid_paths (enriched with source paths)."""
+    assert "pid_paths" in SRC, (
+        "pid_paths variable not found — multi-pid warn won't include source paths"
+    )
+
+
+def test_warn_format_uses_pid_paths():
+    """The actual warn detail string uses pid_paths, not the bare pids join."""
+    # Old pattern: f"...PIDs: {','.join(pids)})"
+    # New pattern: f"...PIDs: {pid_paths})"
+    assert "pid_paths}" in SRC, (
+        "multi-pid warn detail does not reference pid_paths — "
+        "source paths won't appear in health-check output"
+    )
+
+
+def test_py_args_extraction():
+    """_pid_script filters for .py args to find the script path."""
+    assert ".endswith(\".py\")" in SRC or '.endswith(".py")' in SRC, (
+        "_pid_script does not filter for .py args — may return wrong path component"
+    )
+
+
+def main():
+    tests = [
+        test_pid_script_helper_defined,
+        test_pid_script_uses_ps_command,
+        test_pid_paths_in_warn_detail,
+        test_warn_format_uses_pid_paths,
+        test_py_args_extraction,
+    ]
+    failures = []
+    for fn in tests:
+        try:
+            fn()
+            print(f"  ✓ {fn.__name__}")
+        except AssertionError as e:
+            failures.append(f"{fn.__name__}: {e}")
+            print(f"  ✗ {fn.__name__}: {e}")
+    print()
+    if failures:
+        print(f"{len(failures)} test(s) failed ({len(tests) - len(failures)} passed).")
+        sys.exit(1)
+    print(f"All {len(tests)} bridge-multi-pid tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/py39-annotation-lint.test.py
+++ b/tests/py39-annotation-lint.test.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lint-py39-annotations.py (issue #961 — py3.9 baseline)."""
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "lint-py39-annotations.py"
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+spec = importlib.util.spec_from_file_location("lint_py39", SCRIPT)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+has_future_annotations = mod.has_future_annotations
+uses_union_syntax = mod.uses_union_syntax
+lint_file = mod.lint_file
+_insert_future_annotations = mod._insert_future_annotations
+
+PASS = 0
+FAIL = 0
+
+def ok(label):
+    global PASS
+    PASS += 1
+    print(f"PASS  {label}")
+
+def fail(label, detail=""):
+    global FAIL
+    FAIL += 1
+    print(f"FAIL  {label}" + (f": {detail}" if detail else ""))
+
+
+# ---------------------------------------------------------------------------
+# T1 — script file exists
+# ---------------------------------------------------------------------------
+if SCRIPT.exists():
+    ok("T1: lint script exists at scripts/lint-py39-annotations.py")
+else:
+    fail("T1: lint script exists at scripts/lint-py39-annotations.py")
+
+# ---------------------------------------------------------------------------
+# T2 — has_future_annotations: detects present
+# ---------------------------------------------------------------------------
+SRC_WITH = "from __future__ import annotations\nimport os\n"
+if has_future_annotations(SRC_WITH):
+    ok("T2: has_future_annotations detects present import")
+else:
+    fail("T2: has_future_annotations detects present import")
+
+# ---------------------------------------------------------------------------
+# T3 — has_future_annotations: detects absent
+# ---------------------------------------------------------------------------
+SRC_WITHOUT = "import os\nimport sys\n"
+if not has_future_annotations(SRC_WITHOUT):
+    ok("T3: has_future_annotations returns False when absent")
+else:
+    fail("T3: has_future_annotations returns False when absent")
+
+# ---------------------------------------------------------------------------
+# T4 — uses_union_syntax: detects X | Y in function arg annotation
+# ---------------------------------------------------------------------------
+SRC_ARG_UNION = "def f(x: str | None): pass\n"
+if uses_union_syntax(SRC_ARG_UNION):
+    ok("T4: uses_union_syntax detects str|None in arg annotation")
+else:
+    fail("T4: uses_union_syntax detects str|None in arg annotation")
+
+# ---------------------------------------------------------------------------
+# T5 — uses_union_syntax: detects X | Y in return annotation
+# ---------------------------------------------------------------------------
+SRC_RET_UNION = "def f() -> int | None: return None\n"
+if uses_union_syntax(SRC_RET_UNION):
+    ok("T5: uses_union_syntax detects int|None in return annotation")
+else:
+    fail("T5: uses_union_syntax detects int|None in return annotation")
+
+# ---------------------------------------------------------------------------
+# T6 — uses_union_syntax: detects X | Y in variable annotation
+# ---------------------------------------------------------------------------
+SRC_VAR_UNION = "x: str | None = None\n"
+if uses_union_syntax(SRC_VAR_UNION):
+    ok("T6: uses_union_syntax detects str|None in variable annotation")
+else:
+    fail("T6: uses_union_syntax detects str|None in variable annotation")
+
+# ---------------------------------------------------------------------------
+# T7 — uses_union_syntax: does NOT flag X | Y inside a docstring
+# ---------------------------------------------------------------------------
+SRC_DOC_UNION = '''def f():
+    """Returns dict with keys:
+       "foo": str | None,
+    """
+    pass
+'''
+if not uses_union_syntax(SRC_DOC_UNION):
+    ok("T7: uses_union_syntax ignores X|Y inside docstrings")
+else:
+    fail("T7: uses_union_syntax ignores X|Y inside docstrings")
+
+# ---------------------------------------------------------------------------
+# T8 — uses_union_syntax: no false positive on bitwise OR in expressions
+# ---------------------------------------------------------------------------
+SRC_BITWISE = "def f(x, y):\n    return x | y\n"
+if not uses_union_syntax(SRC_BITWISE):
+    ok("T8: uses_union_syntax no false positive on bitwise OR in expressions")
+else:
+    fail("T8: uses_union_syntax no false positive on bitwise OR in expressions")
+
+# ---------------------------------------------------------------------------
+# T9 — lint_file: clean file (has future + union) → returns True
+# ---------------------------------------------------------------------------
+SRC_CLEAN = "from __future__ import annotations\ndef f(x: str | None): pass\n"
+with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as tf:
+    tf.write(SRC_CLEAN)
+    clean_path = Path(tf.name)
+try:
+    result = lint_file(clean_path, fix=False)
+    if result:
+        ok("T9: lint_file returns True for file with future import + union syntax")
+    else:
+        fail("T9: lint_file returns True for file with future import + union syntax")
+finally:
+    clean_path.unlink(missing_ok=True)
+
+# ---------------------------------------------------------------------------
+# T10 — lint_file: violating file → returns False
+# ---------------------------------------------------------------------------
+SRC_VIOL = "import os\ndef f(x: str | None): pass\n"
+with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as tf:
+    tf.write(SRC_VIOL)
+    viol_path = Path(tf.name)
+try:
+    result = lint_file(viol_path, fix=False)
+    if not result:
+        ok("T10: lint_file returns False for violating file (union without future)")
+    else:
+        fail("T10: lint_file returns False for violating file (union without future)")
+finally:
+    viol_path.unlink(missing_ok=True)
+
+# ---------------------------------------------------------------------------
+# T11 — lint_file --fix: adds from __future__ import annotations
+# ---------------------------------------------------------------------------
+SRC_VIOL2 = "import os\ndef f(x: str | None): pass\n"
+with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as tf:
+    tf.write(SRC_VIOL2)
+    fix_path = Path(tf.name)
+try:
+    result = lint_file(fix_path, fix=True)
+    fixed_content = fix_path.read_text()
+    if result and "from __future__ import annotations" in fixed_content:
+        ok("T11: lint_file --fix inserts from __future__ import annotations")
+    else:
+        fail("T11: lint_file --fix inserts from __future__ import annotations",
+             f"result={result}, has_future={'from __future__' in fixed_content}")
+finally:
+    fix_path.unlink(missing_ok=True)
+
+# ---------------------------------------------------------------------------
+# T12 — _insert_future_annotations: doesn't double-insert
+# ---------------------------------------------------------------------------
+SRC_ALREADY = "from __future__ import annotations\nimport os\ndef f(x: str | None): pass\n"
+new_src = _insert_future_annotations(SRC_ALREADY)
+count = new_src.count("from __future__ import annotations")
+if count == 1:
+    ok("T12: _insert_future_annotations doesn't double-insert")
+else:
+    fail("T12: _insert_future_annotations doesn't double-insert", f"count={count}")
+
+# ---------------------------------------------------------------------------
+# T13 — CLI: exits 0 for clean src/ directory (no current violations)
+# ---------------------------------------------------------------------------
+proc = subprocess.run(
+    [sys.executable, str(SCRIPT)],
+    capture_output=True, text=True,
+    cwd=str(REPO_ROOT)
+)
+if proc.returncode == 0:
+    ok("T13: CLI exits 0 — all src/*.py currently clean (no py3.9 violations)")
+else:
+    fail("T13: CLI exits 0 — all src/*.py currently clean", proc.stdout.strip())
+
+# ---------------------------------------------------------------------------
+# T14 — CLI: exits 1 for a temp violating file
+# ---------------------------------------------------------------------------
+SRC_VIOL3 = "import os\ndef bad(x: dict | None): pass\n"
+with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as tf:
+    tf.write(SRC_VIOL3)
+    viol_path2 = Path(tf.name)
+try:
+    proc2 = subprocess.run(
+        [sys.executable, str(SCRIPT), str(viol_path2)],
+        capture_output=True, text=True,
+        cwd=str(REPO_ROOT)
+    )
+    if proc2.returncode == 1:
+        ok("T14: CLI exits 1 for a file with union syntax missing future import")
+    else:
+        fail("T14: CLI exits 1 for violating file", f"rc={proc2.returncode} stdout={proc2.stdout[:80]}")
+finally:
+    viol_path2.unlink(missing_ok=True)
+
+# ---------------------------------------------------------------------------
+# T15 — script has module docstring (describes what it does)
+# ---------------------------------------------------------------------------
+content = SCRIPT.read_text()
+# Skip shebang line before checking for docstring
+lines = content.splitlines()
+body = "\n".join(l for l in lines if not l.startswith("#!")).lstrip()
+if body.startswith('"""') or body.startswith("'''"):
+    ok("T15: lint script has module docstring")
+else:
+    fail("T15: lint script has module docstring")
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print(f"\n{PASS}/{PASS+FAIL} tests passed")
+if __name__ == "__main__":
+    pass

--- a/tests/stranded-claim-files.test.py
+++ b/tests/stranded-claim-files.test.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Tests for find_task_file() fix — stranded .claimed-core-N.txt files (issue #933).
+
+Verifies that each bridge's find_task_file() helper correctly resolves the
+actual on-disk path for a task, whether bare or claimed by claim_task.py.
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+
+PASS = 0
+FAIL = 0
+
+def ok(label):
+    global PASS
+    PASS += 1
+    print(f"PASS  {label}")
+
+def fail(label, detail=""):
+    global FAIL
+    FAIL += 1
+    print(f"FAIL  {label}" + (f": {detail}" if detail else ""))
+
+
+# ---------------------------------------------------------------------------
+# Load find_task_file from each bridge
+# ---------------------------------------------------------------------------
+def _load_fn(bridge_path: Path, fn_name: str):
+    spec = importlib.util.spec_from_file_location("_bridge_mod", bridge_path)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    except Exception:
+        pass
+    return getattr(mod, fn_name, None)
+
+
+slack_ftf = _load_fn(REPO_ROOT / "src" / "slack-bridge.py", "find_task_file")
+telegram_ftf = _load_fn(REPO_ROOT / "src" / "telegram-bridge.py", "find_task_file")
+discord_ftf = _load_fn(REPO_ROOT / "src" / "discord-bridge.py", "find_task_file")
+
+
+# ---------------------------------------------------------------------------
+# T1 — slack-bridge has find_task_file (structural AST check — bridge exits
+#      early without tokens so runtime import is not possible)
+# ---------------------------------------------------------------------------
+import ast as _ast
+def _has_fn(path: Path, name: str) -> bool:
+    try:
+        tree = _ast.parse(path.read_text())
+        return any(isinstance(n, _ast.FunctionDef) and n.name == name for n in _ast.walk(tree))
+    except Exception:
+        return False
+
+if _has_fn(REPO_ROOT / "src" / "slack-bridge.py", "find_task_file"):
+    ok("T1: slack-bridge.py defines find_task_file")
+else:
+    fail("T1: slack-bridge.py defines find_task_file")
+
+# ---------------------------------------------------------------------------
+# T2 — telegram-bridge has find_task_file
+# ---------------------------------------------------------------------------
+if _has_fn(REPO_ROOT / "src" / "telegram-bridge.py", "find_task_file"):
+    ok("T2: telegram-bridge.py defines find_task_file")
+else:
+    fail("T2: telegram-bridge.py defines find_task_file")
+
+# ---------------------------------------------------------------------------
+# T3 — discord-bridge has find_task_file
+# ---------------------------------------------------------------------------
+if callable(discord_ftf):
+    ok("T3: discord-bridge.py exports find_task_file (runtime import)")
+else:
+    fail("T3: discord-bridge.py exports find_task_file (runtime import)")
+
+# ---------------------------------------------------------------------------
+# Shared helper for actual logic tests
+# ---------------------------------------------------------------------------
+def import_ftf_from_source():
+    """Inline find_task_file implementation extracted from slack-bridge.py source."""
+    src = (REPO_ROOT / "src" / "slack-bridge.py").read_text()
+    # Extract just the helper function
+    import ast, textwrap
+    tree = ast.parse(src)
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "find_task_file":
+            start = node.lineno - 1
+            end = node.end_lineno
+            lines = src.splitlines()[start:end]
+            code = textwrap.dedent("\n".join(lines))
+            ns = {"Path": Path}
+            exec(compile(code, "<test>", "exec"), ns)
+            return ns["find_task_file"]
+    return None
+
+ftf = import_ftf_from_source()
+
+# ---------------------------------------------------------------------------
+# T4 — finds bare task file when it exists
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as d:
+    td = Path(d)
+    task_id = "task-1234567890000"
+    bare = td / f"{task_id}.txt"
+    bare.write_text("id: task-1234567890000\n")
+    result = ftf(td, task_id)
+    if result == bare:
+        ok("T4: find_task_file returns bare .txt when it exists")
+    else:
+        fail("T4: find_task_file returns bare .txt when it exists", f"got {result}")
+
+# ---------------------------------------------------------------------------
+# T5 — finds claimed file when bare doesn't exist
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as d:
+    td = Path(d)
+    task_id = "task-9999999990000"
+    claimed = td / f"{task_id}.claimed-core-2.txt"
+    claimed.write_text("id: task-9999999990000\n")
+    result = ftf(td, task_id)
+    if result == claimed:
+        ok("T5: find_task_file returns .claimed-core-N.txt when bare absent")
+    else:
+        fail("T5: find_task_file returns .claimed-core-N.txt when bare absent", f"got {result}")
+
+# ---------------------------------------------------------------------------
+# T6 — returns None when neither bare nor claimed exists
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as d:
+    td = Path(d)
+    result = ftf(td, "task-0000000000000")
+    if result is None:
+        ok("T6: find_task_file returns None when no matching file exists")
+    else:
+        fail("T6: find_task_file returns None when no matching file exists", f"got {result}")
+
+# ---------------------------------------------------------------------------
+# T7 — prefers bare over claimed when both exist (shouldn't happen, but safe)
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as d:
+    td = Path(d)
+    task_id = "task-1111111110000"
+    bare = td / f"{task_id}.txt"
+    bare.write_text("id: task-1111111110000\n")
+    claimed = td / f"{task_id}.claimed-core-1.txt"
+    claimed.write_text("id: task-1111111110000\n")
+    result = ftf(td, task_id)
+    if result == bare:
+        ok("T7: find_task_file prefers bare .txt when both bare and claimed exist")
+    else:
+        fail("T7: find_task_file prefers bare .txt when both bare and claimed exist", f"got {result}")
+
+# ---------------------------------------------------------------------------
+# T8 — slack-bridge.py: archive call uses find_task_file (no bare literal)
+# ---------------------------------------------------------------------------
+content = (REPO_ROOT / "src" / "slack-bridge.py").read_text()
+# The single archive call for tasks should no longer use the bare string
+bare_call = 'archive_file(TASKS_DIR / f"{task_id}.txt", "tasks"'
+if bare_call not in content:
+    ok("T8: slack-bridge.py archive path uses find_task_file, not bare literal")
+else:
+    fail("T8: slack-bridge.py archive path uses find_task_file, not bare literal",
+         "bare literal still present")
+
+# ---------------------------------------------------------------------------
+# T9 — telegram-bridge.py: archive calls use find_task_file
+# ---------------------------------------------------------------------------
+content_tg = (REPO_ROOT / "src" / "telegram-bridge.py").read_text()
+bare_tg = 'archive_file(task_file, "tasks"'
+if bare_tg not in content_tg:
+    ok("T9: telegram-bridge.py archive path uses find_task_file, not bare literal")
+else:
+    fail("T9: telegram-bridge.py archive path uses find_task_file, not bare literal")
+
+# ---------------------------------------------------------------------------
+# T10 — discord-bridge.py: main poll_results archive uses find_task_file
+# ---------------------------------------------------------------------------
+content_dc = (REPO_ROOT / "src" / "discord-bridge.py").read_text()
+# Count remaining bare archive patterns vs find_task_file usages
+import re
+bare_archive = re.findall(r'archive_file\(TASKS_DIR / f"\{task_id\}\.txt"', content_dc)
+bare_archive += re.findall(r'archive_file\(TASKS_DIR / f"\{_task_id\}\.txt"', content_dc)
+ftf_archive = re.findall(r'find_task_file\(TASKS_DIR', content_dc)
+if len(bare_archive) == 0 and len(ftf_archive) >= 5:
+    ok(f"T10: discord-bridge.py has {len(ftf_archive)} find_task_file calls, 0 bare archive paths")
+else:
+    fail("T10: discord-bridge.py bare archive literal check",
+         f"bare={len(bare_archive)}, ftf_calls={len(ftf_archive)}")
+
+# ---------------------------------------------------------------------------
+# T11 — discord-bridge.py: tier-read sites also use find_task_file
+# ---------------------------------------------------------------------------
+tier_bare = re.findall(r'TASKS_DIR / f"\{task_id\}\.txt"\)\.read_text\(\)', content_dc)
+tier_bare += re.findall(r'TASKS_DIR / f"\{_task_id\}\.txt"\)\.read_text\(\)', content_dc)
+if len(tier_bare) == 0:
+    ok("T11: discord-bridge.py tier-read sites use find_task_file (no bare .read_text())")
+else:
+    fail("T11: discord-bridge.py tier-read sites use find_task_file",
+         f"{len(tier_bare)} bare read_text calls remain")
+
+# ---------------------------------------------------------------------------
+# T12 — find_task_file docstring mentions #933
+# ---------------------------------------------------------------------------
+dc_src = (REPO_ROOT / "src" / "discord-bridge.py").read_text()
+if "#933" in dc_src:
+    ok("T12: discord-bridge.py find_task_file docstring references issue #933")
+else:
+    fail("T12: discord-bridge.py find_task_file docstring references issue #933")
+
+# ---------------------------------------------------------------------------
+# T13 — write sites (task creation) unchanged — still use bare path
+# ---------------------------------------------------------------------------
+slack_src = (REPO_ROOT / "src" / "slack-bridge.py").read_text()
+if 'task_file = TASKS_DIR / f"{task_id}.txt"' in slack_src:
+    ok("T13: slack-bridge.py task-write site still uses bare path (write, not archive)")
+else:
+    fail("T13: slack-bridge.py task-write site still uses bare path")
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print(f"\n{PASS}/{PASS+FAIL} tests passed")
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
## Summary

`src/archive-stale-results.py` is the startup DM-flood prevention guard (post-mortem: `notes/post-mortem-dm-flood-2026-04-15.md`) — it had zero test coverage.

## What's covered

`tests/archive-stale-results.test.py` — 15 tests:

| # | Test |
|---|------|
| T1 | script file exists |
| T2 | module has docstring |
| T3 | exits 0 with "missing" message when `results/` absent |
| T4 | archives stale files older than `RETENTION_HOURS` |
| T5 | skips fresh files within cutoff |
| T6 | skips non-`.txt` files even if stale |
| T7 | does not touch files inside existing `archive-*` subdirs |
| T8 | `DRY_RUN=1` prints "would archive" without moving |
| T9 | `DRY_RUN=No` is correctly treated as falsy (not dry-run) |
| T10 | archive dir named `archive-YYYY-MM-DD` |
| T11 | archived file appears inside `archive-YYYY-MM-DD/` |
| T12 | 3 stale files archived in one pass |
| T13 | mixed fresh+stale — only stale moved, fresh untouched |
| T14 | `RETENTION_HOURS=0` archives everything immediately |
| T15 | `.sending` files (in-flight proactive claims) are NOT archived |

All 15 pass on Python 3.9.

## Notes

- Uses `SUTANDO_WORKSPACE` override to give each test a clean isolated workspace
- Tests run the script via `subprocess.run` to exercise the real code path including the `workspace_default` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)