### PR TITLE
fix(discord-voice): reply where invited, not via owner-DM fallback (closes #1120)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -1175,22 +1175,35 @@ async function start(): Promise<void> {
 		}
 		if (presentPeers.length > 0) {
 			console.error(`${ts()} [Setup] #1089 refusing to join: sutando peer(s) already present: ${presentPeers.join(', ')}`);
-			// Surface the refusal to the operator — without this they just see
-			// "nothing happens" when inviting a second bot to a channel that
-			// already has one. Drop a proactive result; the discord-bridge
-			// polls results/ and DMs proactive-*.txt to the owner. Best-effort:
-			// if the write fails the process still exits cleanly and
-			// Sutando.app's checkWatcher will retry once the peer leaves.
-			try {
-				const proactivePath = join(WORKSPACE_DIR, 'results', `proactive-${Date.now()}.txt`);
-				const channelName = (channel as any).name ?? CHANNEL_ID;
-				writeFileSync(
-					proactivePath,
-					`Skipping voice join in #${channelName} — peer already present: ${presentPeers.join(', ')}. ` +
-					`Single-bot enforcement (#1089); reinvite once they leave.\n`,
-				);
-			} catch (e) {
-				console.error(`${ts()} [Setup] #1089 couldn't surface refusal to operator:`, e);
+			// #1120: if the spawner threaded --reply-channel and --reply-user
+			// through, post the refusal in that channel (mentioning the
+			// inviter) — "reply where invited" instead of falling back to
+			// owner-DM. The previous proactive-*.txt path stays as fallback
+			// only when those args are absent (out-of-band spawns, manual
+			// testing).
+			const channelName = (channel as any).name ?? CHANNEL_ID;
+			const refusalText =
+				`Skipping voice join in #${channelName} — peer already present: ${presentPeers.join(', ')}. ` +
+				`Single-bot enforcement (#1089); reinvite once they leave.`;
+			const REPLY_CHANNEL_ID = getArg('reply-channel');
+			const REPLY_USER_ID = getArg('reply-user');
+			if (REPLY_CHANNEL_ID) {
+				try {
+					const replyCh = await client.channels.fetch(REPLY_CHANNEL_ID);
+					if (replyCh && 'send' in replyCh) {
+						const mention = REPLY_USER_ID ? `<@${REPLY_USER_ID}> ` : '';
+						await (replyCh as any).send(mention + refusalText);
+					}
+				} catch (e) {
+					console.error(`${ts()} [Setup] #1120 channel-reply failed; falling back to proactive-*.txt:`, e);
+				}
+			} else {
+				try {
+					const proactivePath = join(WORKSPACE_DIR, 'results', `proactive-${Date.now()}.txt`);
+					writeFileSync(proactivePath, refusalText + '\n');
+				} catch (e) {
+					console.error(`${ts()} [Setup] #1089 couldn't surface refusal to operator:`, e);
+				}
 			}
 			process.exit(0); // clean exit — operator (Sutando.app checkWatcher) will retry later when peer leaves
 		}

--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -1187,17 +1187,26 @@ async function start(): Promise<void> {
 				`Single-bot enforcement (#1089); reinvite once they leave.`;
 			const REPLY_CHANNEL_ID = getArg('reply-channel');
 			const REPLY_USER_ID = getArg('reply-user');
+			// Track whether the channel-reply was actually delivered. If not — for ANY
+			// reason: arg absent, fetch threw, channel isn't text-capable, send threw —
+			// fall back to proactive-*.txt so the operator still sees the refusal.
+			// (Per @bassilkhilo-ag2's #1132 review: prior shape logged "falling back to
+			// proactive-*.txt" on catch but didn't actually write it, silently dropping
+			// the #1089 refusal when the channel send failed.)
+			let channelReplyDelivered = false;
 			if (REPLY_CHANNEL_ID) {
 				try {
 					const replyCh = await client.channels.fetch(REPLY_CHANNEL_ID);
 					if (replyCh && 'send' in replyCh) {
 						const mention = REPLY_USER_ID ? `<@${REPLY_USER_ID}> ` : '';
 						await (replyCh as any).send(mention + refusalText);
+						channelReplyDelivered = true;
 					}
 				} catch (e) {
-					console.error(`${ts()} [Setup] #1120 channel-reply failed; falling back to proactive-*.txt:`, e);
+					console.error(`${ts()} [Setup] #1120 channel-reply failed:`, e);
 				}
-			} else {
+			}
+			if (!channelReplyDelivered) {
 				try {
 					const proactivePath = join(WORKSPACE_DIR, 'results', `proactive-${Date.now()}.txt`);
 					writeFileSync(proactivePath, refusalText + '\n');

--- a/skills/discord-voice/scripts/join_trigger.py
+++ b/skills/discord-voice/scripts/join_trigger.py
@@ -189,7 +189,7 @@ def _server_already_running(channel_id) -> bool:
     return False
 
 
-def _spawn_voice_server(guild_id, channel_id) -> bool:
+def _spawn_voice_server(guild_id, channel_id, reply_channel_id=None, reply_user_id=None) -> bool:
     """Launch discord-voice-server.ts detached for guild+channel. Returns True
     on a successful spawn (the subprocess was started — not that it connected).
 
@@ -197,6 +197,13 @@ def _spawn_voice_server(guild_id, channel_id) -> bool:
       env -u GEMINI_API_KEY DISCORD_VOICE_SERVER=1 \
         npx tsx skills/discord-voice/scripts/discord-voice-server.ts \
         --guild <GUILD_ID> --channel <VC_ID>
+
+    Optional `reply_channel_id` + `reply_user_id` (#1120): when provided, the
+    spawned voice-server uses them to post the Layer-1 refusal message back
+    to the originating text-channel (mentioning the inviting user), instead
+    of writing a proactive-*.txt that falls back to owner-DM. "Reply where
+    invited" — feedback Susan gave when the refusal DM mis-landed on a
+    non-owner due to access.json ordering.
 
     `GEMINI_API_KEY` is unset for the child (the voice server uses its own
     GEMINI_VOICE_API_KEY path) — matches the documented invocation. Detached
@@ -225,6 +232,10 @@ def _spawn_voice_server(guild_id, channel_id) -> bool:
         "--channel",
         str(channel_id),
     ]
+    if reply_channel_id is not None:
+        argv.extend(["--reply-channel", str(reply_channel_id)])
+    if reply_user_id is not None:
+        argv.extend(["--reply-user", str(reply_user_id)])
     try:
         subprocess.Popen(
             argv,
@@ -347,7 +358,14 @@ def handle_join_trigger(message) -> str:
     if _server_already_running(channel_id):
         return f"I'm already in **{channel_name}** — see you there."
 
-    if _spawn_voice_server(guild_id, channel_id):
+    # #1120: pass the originating channel + user so the spawned voice-server
+    # can route Layer-1 refusal messages back where invited (mentioning the
+    # inviter) instead of falling back to owner-DM via proactive-*.txt.
+    # Safe to pass None for either if the message lacks them.
+    reply_channel_id = getattr(getattr(message, "channel", None), "id", None)
+    reply_user_id = getattr(getattr(message, "author", None), "id", None)
+
+    if _spawn_voice_server(guild_id, channel_id, reply_channel_id, reply_user_id):
         # Queue context-prep AFTER successful spawn so the core only sees
         # the synthetic task when voice is actually on the way. No await /
         # block — voice and context-prep race; voice's first turn falls


### PR DESCRIPTION
> **Scope revised 2026-05-26**: this PR's earlier mention-join fast-path was flagged by @sonichi as duplicate of the existing `za warudo` magic-word path (both fired `_dv_handle_join_trigger`). Removed that piece. PR is now narrowly the **#1120 reply-where-invited** fix.

## Summary

When a Sutando bot is @-mentioned in a channel to join voice ("Lucy can you join voice"), every response — success, error, refusal — used to route back through the proactive-DM path that mis-routes to `allowFrom[0]` when the explicit `owner` field isn't set (the same failure mode #1147/#1148 address at the bridge level).

This patch threads the originating channel + user ID through from the bridge → `join_trigger.py` → `discord-voice-server.ts`, so Layer-1 refusals and other voice-spawn outcomes post to the channel where the user invited the bot, not to the owner's DMs.

## Changes

- **`skills/discord-voice/scripts/join_trigger.py`** — `_spawn_voice_server` accepts `reply_channel_id` + `reply_user_id` kwargs; `handle_join_trigger` extracts them from the `message` object and forwards.
- **`skills/discord-voice/scripts/discord-voice-server.ts`** — read `--reply-channel`/`--reply-user` via `getArg()`; use in the Layer-1 refusal block to post in the originating channel (`client.channels.fetch(...).send(...)`) with `proactive-*.txt` fallback when the args are absent (ad-hoc/test spawns).

`+49/-18` across 2 files. `npx tsc --noEmit` clean.

Closes #1120.