### PR TITLE
feat(reliability): launchd-supervised credential-proxy with KeepAlive + ThrottleInterval (closes #1086)

### DIFF
--- a/src/install-credential-proxy-launchd.sh
+++ b/src/install-credential-proxy-launchd.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Install / uninstall the launchd-supervised credential-proxy job.
+#
+# Role: Replace the bare background process in startup.sh with an
+# OS-supervised daemon. The launchd job:
+#   - Starts on user login (RunAtLoad=true)
+#   - Restarts automatically on crash (KeepAlive=true)
+#   - Throttles restarts to 10s (ThrottleInterval) — prevents EADDRINUSE
+#     crash-loops (observed: 3500+ restarts in 30min when a stale process
+#     held port 7846)
+#   - Writes all output to $WORKSPACE/logs/credential-proxy-launchd.log
+#
+# After install, startup.sh's "if ! lsof -i :7846" block still works as
+# before — it just finds the port already up (launchd started it at login)
+# and skips the manual background spawn. The ANTHROPIC_BASE_URL export
+# in startup.sh is unchanged.
+#
+# Strictly opt-in: startup.sh does NOT call this. Run it once to enable
+# launchd supervision, then leave it — it persists across reboots.
+#
+# Usage:
+#   bash src/install-credential-proxy-launchd.sh             # install (idempotent)
+#   bash src/install-credential-proxy-launchd.sh --uninstall # remove (idempotent)
+#   bash src/install-credential-proxy-launchd.sh --status    # print job state
+#
+# Idempotent: re-running install bootouts the existing job before
+# bootstrapping the new one, so a template edit is picked up by re-running.
+
+set -e
+
+LABEL="com.sutando.credential-proxy"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE="$REPO/src/launchd/$LABEL.plist"
+DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
+DOMAIN="gui/$(id -u)"
+SERVICE="$DOMAIN/$LABEL"
+
+# Workspace resolution — same shape as startup.sh and workspace_default.py.
+if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
+else
+  WORKSPACE="$HOME/.sutando/workspace"
+fi
+
+cmd="${1:-install}"
+
+bootout_if_loaded() {
+    if launchctl print "$SERVICE" >/dev/null 2>&1; then
+        echo "  Existing job found, removing first..."
+        launchctl bootout "$SERVICE" 2>/dev/null || true
+        for _ in $(seq 1 10); do
+            launchctl print "$SERVICE" >/dev/null 2>&1 || break
+            sleep 0.3
+        done
+    fi
+}
+
+resolve_npx() {
+    # Prefer Homebrew npx, then nvm, then PATH.
+    if [ -x /opt/homebrew/bin/npx ]; then
+        echo /opt/homebrew/bin/npx
+    elif [ -x /usr/local/bin/npx ]; then
+        echo /usr/local/bin/npx
+    elif command -v npx >/dev/null 2>&1; then
+        command -v npx
+    else
+        echo "ERROR: npx not found — install Node.js first" >&2
+        exit 1
+    fi
+}
+
+resolve_node_bin() {
+    # Directory containing `node` — injected into PATH in the plist so
+    # tsx and any spawned subprocesses can find it.
+    local npx_path
+    npx_path="$(resolve_npx)"
+    dirname "$npx_path"
+}
+
+resolve_homebrew_bin() {
+    if [ -d /opt/homebrew/bin ]; then
+        echo /opt/homebrew/bin
+    elif [ -d /usr/local/bin ]; then
+        echo /usr/local/bin
+    else
+        echo /usr/bin
+    fi
+}
+
+resolve_credential_proxy() {
+    # canonical path: skill dir under ~/.claude
+    local skill_path="$HOME/.claude/skills/quota-tracker/scripts/credential-proxy.ts"
+    if [ -f "$skill_path" ]; then
+        echo "$skill_path"
+        return
+    fi
+    # fallback: symlink in project skills/
+    local proj_path="$REPO/skills/quota-tracker/scripts/credential-proxy.ts"
+    if [ -f "$proj_path" ]; then
+        echo "$proj_path"
+        return
+    fi
+    echo "ERROR: credential-proxy.ts not found at $skill_path or $proj_path" >&2
+    exit 1
+}
+
+case "$cmd" in
+    install)
+        if [ ! -f "$TEMPLATE" ]; then
+            echo "ERROR: template not found: $TEMPLATE" >&2
+            exit 1
+        fi
+
+        NPX_BIN="$(resolve_npx)"
+        NODE_BIN="$(resolve_node_bin)"
+        BREW_BIN="$(resolve_homebrew_bin)"
+        PROXY_TS="$(resolve_credential_proxy)"
+
+        echo "Installing $LABEL"
+        echo "  repo:       $REPO"
+        echo "  workspace:  $WORKSPACE"
+        echo "  npx:        $NPX_BIN"
+        echo "  node bin:   $NODE_BIN"
+        echo "  proxy:      $PROXY_TS"
+
+        mkdir -p "$HOME/Library/LaunchAgents"
+        mkdir -p "$WORKSPACE/logs"
+
+        sed \
+            -e "s|__REPO__|$REPO|g" \
+            -e "s|__WORKSPACE__|$WORKSPACE|g" \
+            -e "s|__NPX__|$NPX_BIN|g" \
+            -e "s|__NODE_BIN__|$NODE_BIN|g" \
+            -e "s|__HOMEBREW_BIN__|$BREW_BIN|g" \
+            -e "s|__CREDENTIAL_PROXY__|$PROXY_TS|g" \
+            -e "s|__HOME__|$HOME|g" \
+            "$TEMPLATE" > "$DEST"
+
+        bootout_if_loaded
+        launchctl bootstrap "$DOMAIN" "$DEST"
+        echo "  Loaded via $SERVICE"
+        echo
+        echo "Credential proxy is now launchd-supervised (KeepAlive + 10s throttle)."
+        echo "  • Logs:      $WORKSPACE/logs/credential-proxy-launchd.log"
+        echo "  • View status:  bash $0 --status"
+        echo "  • Uninstall:    bash $0 --uninstall"
+        echo "  • startup.sh still works as before — launchd starts proxy at login"
+        echo "    so startup.sh finds port 7846 already up and skips the spawn."
+        ;;
+
+    --uninstall|uninstall)
+        echo "Uninstalling $LABEL"
+        bootout_if_loaded
+        if [ -f "$DEST" ]; then
+            rm "$DEST"
+            echo "  Removed $DEST"
+        else
+            echo "  (no plist on disk; nothing to remove)"
+        fi
+        echo "Done."
+        ;;
+
+    --status|status)
+        echo "Service: $SERVICE"
+        if launchctl print "$SERVICE" >/dev/null 2>&1; then
+            launchctl print "$SERVICE" | grep -E '^\s+(state|pid|last exit code|runs|path)' || true
+        else
+            echo "  (not loaded)"
+        fi
+        ;;
+
+    *)
+        echo "Usage: $0 [install|--uninstall|--status]" >&2
+        exit 2
+        ;;
+esac

--- a/src/launchd/com.sutando.credential-proxy.plist
+++ b/src/launchd/com.sutando.credential-proxy.plist
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Sutando — credential-proxy launchd job (template).
+
+  Role: Persistent daemon that proxies Anthropic API calls to read rate-limit
+  headers and write quota-state.json. Without it the proactive loop is
+  quota-blind, the dashboard shows no progress bar, and --gate-passes can't
+  prevent over-run.
+
+  The live incident (2026-05-24): a stale manual credential-proxy.ts held
+  port 7846; the bare background job in startup.sh had no auto-restart, so
+  when the stale process was killed the quota proxy stayed down silently
+  for hours. This launchd job replaces the bare background job with
+  OS-supervised restart + throttle.
+
+  Installed by `bash src/install-credential-proxy-launchd.sh` after the
+  script substitutes __REPO__, __NPX__, __NODE_BIN__, __WORKSPACE__, and
+  __HOMEBREW_BIN__ with the user's actual paths. Do NOT load this template
+  directly — paths must be expanded first.
+
+  Behavior:
+    - KeepAlive=true: launchd restarts the proxy if it exits for any reason.
+    - ThrottleInterval=10: minimum 10s between restarts — prevents the
+      EADDRINUSE crash-loop (3500+ restarts in 30min, observed live) while
+      still recovering quickly from transient failures.
+    - RunAtLoad=true: starts immediately on bootstrap (user login / launchctl
+      load).
+    - All output goes to __WORKSPACE__/logs/credential-proxy-launchd.log.
+    - WorkingDirectory is the repo so workspace_default.py resolvers work.
+
+  Environment:
+    - SUTANDO_WORKSPACE: canonical workspace path so credential-proxy.ts
+      writes quota-state.json to the right place even without shell env.
+    - PATH: includes Homebrew + /usr/bin so `node` and helpers resolve.
+    - ANTHROPIC_BASE_URL is NOT set here — callers (startup.sh, CLAUDE.md)
+      continue to set it after confirming port 7846 is up.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.sutando.credential-proxy</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__NPX__</string>
+        <string>tsx</string>
+        <string>__CREDENTIAL_PROXY__</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__NODE_BIN__:__HOMEBREW_BIN__:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>SUTANDO_WORKSPACE</key>
+        <string>__WORKSPACE__</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__WORKSPACE__/logs/credential-proxy-launchd.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__WORKSPACE__/logs/credential-proxy-launchd.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/tests/install-credential-proxy-launchd.test.sh
+++ b/tests/install-credential-proxy-launchd.test.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# Tests for src/install-credential-proxy-launchd.sh
+#
+# Validates template rendering, path resolution helpers, and CLI modes.
+# Does NOT load/unload real launchd jobs — all tests use tmp dirs and
+# mocked launchctl to stay safe in CI and non-root contexts.
+
+set -u
+
+PASS=0
+FAIL=0
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/src/install-credential-proxy-launchd.sh"
+TEMPLATE="$(cd "$(dirname "$0")/.." && pwd)/src/launchd/com.sutando.credential-proxy.plist"
+
+ok() { echo "  PASS: $1"; ((PASS++)); }
+fail() { echo "  FAIL: $1"; ((FAIL++)); }
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    ok "$label"
+  else
+    fail "$label — expected to find: $needle"
+    echo "    in: $(echo "$haystack" | head -5)"
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    fail "$label — did NOT expect: $needle"
+  else
+    ok "$label"
+  fi
+}
+
+assert_exits() {
+  local label="$1" expected_code="$2"
+  shift 2
+  if "$@" >/dev/null 2>&1; then
+    actual=0
+  else
+    actual=$?
+  fi
+  if [ "$actual" = "$expected_code" ]; then
+    ok "$label"
+  else
+    fail "$label — expected exit $expected_code, got $actual"
+  fi
+}
+
+echo "=== install-credential-proxy-launchd.sh tests ==="
+
+# --- plist template exists and has required fields ---
+if [ -f "$TEMPLATE" ]; then
+  ok "plist template exists"
+else
+  fail "plist template missing: $TEMPLATE"
+fi
+
+plist_content="$(cat "$TEMPLATE" 2>/dev/null)"
+
+assert_contains "plist: Label is correct" "com.sutando.credential-proxy" "$plist_content"
+assert_contains "plist: KeepAlive key present" "<key>KeepAlive</key>" "$plist_content"
+assert_contains "plist: KeepAlive is true" "<true/>" "$plist_content"
+assert_contains "plist: ThrottleInterval key present" "<key>ThrottleInterval</key>" "$plist_content"
+assert_contains "plist: ThrottleInterval value is 10" "<integer>10</integer>" "$plist_content"
+assert_contains "plist: RunAtLoad key present" "<key>RunAtLoad</key>" "$plist_content"
+assert_contains "plist: SUTANDO_WORKSPACE env var" "<key>SUTANDO_WORKSPACE</key>" "$plist_content"
+assert_contains "plist: __NPX__ placeholder" "__NPX__" "$plist_content"
+assert_contains "plist: __CREDENTIAL_PROXY__ placeholder" "__CREDENTIAL_PROXY__" "$plist_content"
+assert_contains "plist: __WORKSPACE__ in log path" "__WORKSPACE__" "$plist_content"
+assert_contains "plist: __NODE_BIN__ in PATH" "__NODE_BIN__" "$plist_content"
+assert_contains "plist: ProcessType Background" "Background" "$plist_content"
+
+# No StartInterval — this is a persistent daemon, not a periodic job
+assert_not_contains "plist: no StartInterval (daemon not periodic)" "StartInterval" "$plist_content"
+
+# --- installer: usage / bad argument exits non-zero ---
+assert_exits "bad argument exits 2" 2 bash "$SCRIPT" --bogus-flag
+
+# --- installer: --status when not loaded is graceful ---
+# Temporarily mock launchctl to simulate "not loaded"
+TMP_BIN="$(mktemp -d)"
+cat > "$TMP_BIN/launchctl" <<'EOF'
+#!/bin/bash
+if [ "$1" = "print" ]; then
+  exit 1   # simulate "not loaded"
+fi
+EOF
+chmod +x "$TMP_BIN/launchctl"
+
+status_out="$(PATH="$TMP_BIN:$PATH" bash "$SCRIPT" --status 2>&1)"
+assert_contains "--status when not loaded prints 'not loaded'" "(not loaded)" "$status_out"
+rm -rf "$TMP_BIN"
+
+# --- template rendering: sed substitutions work ---
+TMP_WORK="$(mktemp -d)"
+FAKE_REPO="$TMP_WORK/repo"
+FAKE_WORKSPACE="$TMP_WORK/workspace"
+FAKE_NPX="$TMP_WORK/npx"
+FAKE_NODE_BIN="$TMP_WORK"
+FAKE_HOMEBREW="$TMP_WORK/homebrew"
+FAKE_PROXY="$TMP_WORK/credential-proxy.ts"
+FAKE_DEST="$TMP_WORK/output.plist"
+
+# Create required files for the test
+mkdir -p "$FAKE_REPO/src/launchd"
+mkdir -p "$FAKE_REPO/src"
+cp "$TEMPLATE" "$FAKE_REPO/src/launchd/com.sutando.credential-proxy.plist"
+touch "$FAKE_NPX"
+chmod +x "$FAKE_NPX"
+touch "$FAKE_PROXY"
+
+# Render the template manually (mirrors installer logic without launchctl)
+rendered="$(sed \
+    -e "s|__REPO__|$FAKE_REPO|g" \
+    -e "s|__WORKSPACE__|$FAKE_WORKSPACE|g" \
+    -e "s|__NPX__|$FAKE_NPX|g" \
+    -e "s|__NODE_BIN__|$FAKE_NODE_BIN|g" \
+    -e "s|__HOMEBREW_BIN__|$FAKE_HOMEBREW|g" \
+    -e "s|__CREDENTIAL_PROXY__|$FAKE_PROXY|g" \
+    -e "s|__HOME__|$TMP_WORK|g" \
+    "$TEMPLATE")"
+
+assert_contains "render: __REPO__ replaced" "$FAKE_REPO" "$rendered"
+assert_contains "render: __WORKSPACE__ replaced" "$FAKE_WORKSPACE" "$rendered"
+assert_contains "render: __NPX__ replaced" "$FAKE_NPX" "$rendered"
+assert_contains "render: __NODE_BIN__ replaced" "$FAKE_NODE_BIN" "$rendered"
+assert_contains "render: __CREDENTIAL_PROXY__ replaced" "$FAKE_PROXY" "$rendered"
+assert_not_contains "render: no raw __NPX__ placeholder remains" "__NPX__" "$rendered"
+assert_not_contains "render: no raw __WORKSPACE__ placeholder remains" "__WORKSPACE__" "$rendered"
+assert_not_contains "render: no raw __REPO__ placeholder remains" "__REPO__" "$rendered"
+assert_not_contains "render: no raw __CREDENTIAL_PROXY__ placeholder remains" "__CREDENTIAL_PROXY__" "$rendered"
+
+# Rendered output must still be valid plist XML
+if echo "$rendered" | grep -q '<?xml'; then
+  ok "render: output is XML"
+else
+  fail "render: output is not XML"
+fi
+
+rm -rf "$TMP_WORK"
+
+# --- installer: uninstall when plist absent is graceful ---
+TMP_BIN2="$(mktemp -d)"
+cat > "$TMP_BIN2/launchctl" <<'EOF'
+#!/bin/bash
+if [ "$1" = "print" ]; then exit 1; fi
+EOF
+chmod +x "$TMP_BIN2/launchctl"
+
+uninstall_out="$(HOME="$TMP_BIN2" PATH="$TMP_BIN2:$PATH" bash "$SCRIPT" --uninstall 2>&1)"
+assert_contains "uninstall when absent: graceful message" "nothing to remove" "$uninstall_out"
+rm -rf "$TMP_BIN2"
+
+# --- Summary ---
+echo
+TOTAL=$((PASS + FAIL))
+echo "Results: $PASS/$TOTAL passed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL TESTS PASSED"
+  exit 0
+fi


### PR DESCRIPTION
## Problem

The credential-proxy (port 7846) had no auto-restart. A stale manual `credential-proxy.ts` holding port 7846 caused the launchd job to crash-loop 3 500+ times on `EADDRINUSE` (no `ThrottleInterval` configured) while `quota-state.json` went unwritten — leaving the proactive loop quota-blind for hours with no automatic recovery. Reported in #1086 by @qingyun-wu.

## Fix

Three-file addition (no startup.sh changes — the installer is strictly opt-in):

### `src/launchd/com.sutando.credential-proxy.plist`

Template plist with:
- `KeepAlive=true` — launchd auto-restarts the proxy after any crash or clean exit
- `ThrottleInterval=10` — 10 s floor between restart attempts; eliminates the 3 500-iteration tight loop from the incident while still recovering within seconds from transient failures
- `RunAtLoad=true` — proxy starts at login, before the first Claude invocation
- Workspace-relative log paths (same convention as `com.sutando.health-check-fallback.plist`)

### `src/install-credential-proxy-launchd.sh`

Idempotent installer that renders the template with real paths and bootstraps via `launchctl bootstrap gui/$UID`. Mirrors `install-health-check-launchd.sh` exactly:
- `install` / `--uninstall` / `--status` modes
- `bootout_if_loaded` helper prevents race on re-install
- Substitutes `__REPO__`, `__WORKSPACE__`, `__NPX__`, `__NODE_BIN__`, `__CREDENTIAL_PROXY__`
- Strictly opt-in: `startup.sh` is not changed — it sees port 7846 up via launchd and exits the spawn block normally

### `tests/install-credential-proxy-launchd.test.sh`

27/27 tests:
- Plist field validation (KeepAlive, ThrottleInterval, KeepAlive=true, RunAtLoad, label)
- Template rendering (no raw `__PLACEHOLDER__` remains in the rendered output)
- CLI contract (bad-arg → exit 2; `--status` when not loaded; `--uninstall` when absent → graceful)

## What this does NOT do

- Does not touch `startup.sh` — operators opt in by running the installer
- Does not kill existing stale processes — the stale-port reconciliation sketch from #1086 is a follow-up; this PR fixes the `ThrottleInterval` gap which was the root cause of the 3 500-iteration loop

## Test plan
- [x] `bash tests/install-credential-proxy-launchd.test.sh` → 27/27 PASS
- [ ] Live install: `bash src/install-credential-proxy-launchd.sh` → launchd starts proxy on port 7846
- [ ] Kill the proxy manually → launchd restarts it within ~10 s
- [ ] `--status` → shows launchd job state
- [ ] `--uninstall` → removes job, port 7846 free

🤖 Generated with [Claude Code](https://claude.com/claude-code)