### PR TITLE
test(check-pending-questions): 18 behavioral tests for parsing + gate fns

### DIFF
--- a/tests/archive-stale-results.test.py
+++ b/tests/archive-stale-results.test.py
@@ -234,6 +234,56 @@ with tempfile.TemporaryDirectory() as td:
         fail("T12: all stale files archived", f"{len(remaining)} remaining out={proc.stdout.strip()[:80]}")
 
 # ---------------------------------------------------------------------------
+# T13 — mixed fresh+stale: only stale archived, fresh untouched
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stale = results / "task-old.txt"
+    stale.write_text("old")
+    os.utime(stale, (time.time() - 48 * 3600,) * 2)
+    fresh = results / "task-new.txt"
+    fresh.write_text("new")
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    if not stale.exists() and fresh.exists() and proc.returncode == 0:
+        ok("T13: mixed fresh+stale — only stale moved, fresh stays")
+    else:
+        fail("T13: mixed fresh+stale", f"stale={stale.exists()} fresh={fresh.exists()}")
+
+# ---------------------------------------------------------------------------
+# T14 — RETENTION_HOURS=0 archives every .txt file regardless of age
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    for name in ("a.txt", "b.txt", "c.txt"):
+        (results / name).write_text("content")
+    proc = run_script(ws, {"RETENTION_HOURS": "0"})
+    remaining = list(results.glob("*.txt"))
+    if not remaining and proc.returncode == 0:
+        ok("T14: RETENTION_HOURS=0 archives all .txt files immediately")
+    else:
+        fail("T14: RETENTION_HOURS=0", f"{len(remaining)} .txt remaining")
+
+# ---------------------------------------------------------------------------
+# T15 — .sending files are NOT archived (only .txt suffix is touched)
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    sending = results / "proactive-1748000000.sending"
+    sending.write_text("in-flight")
+    os.utime(sending, (time.time() - 48 * 3600,) * 2)
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    if sending.exists():
+        ok("T15: .sending files are not archived (only .txt suffix is in scope)")
+    else:
+        fail("T15: .sending files untouched", ".sending file was incorrectly archived")
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 print(f"\n{PASS}/{PASS+FAIL} tests passed")

--- a/tests/archive-stale-results.test.py
+++ b/tests/archive-stale-results.test.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Tests for src/archive-stale-results.py — retention + dry-run logic."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SCRIPT = REPO_ROOT / "src" / "archive-stale-results.py"
+
+PASS = 0
+FAIL = 0
+
+def ok(label):
+    global PASS; PASS += 1; print(f"PASS  {label}")
+
+def fail(label, detail=""):
+    global FAIL; FAIL += 1
+    print(f"FAIL  {label}" + (f": {detail}" if detail else ""))
+
+
+def run_script(workspace: Path, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    env = {**os.environ, "SUTANDO_WORKSPACE": str(workspace)}
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True, text=True, env=env
+    )
+
+
+# ---------------------------------------------------------------------------
+# T1 — script exists
+# ---------------------------------------------------------------------------
+if SCRIPT.exists():
+    ok("T1: archive-stale-results.py exists")
+else:
+    fail("T1: archive-stale-results.py exists")
+
+# ---------------------------------------------------------------------------
+# T2 — script has module docstring
+# ---------------------------------------------------------------------------
+content = SCRIPT.read_text() if SCRIPT.exists() else ""
+lines = content.splitlines()
+body = "\n".join(l for l in lines if not l.startswith("#!")).lstrip()
+if body.startswith('"""') or body.startswith("'''"):
+    ok("T2: script has module docstring")
+else:
+    fail("T2: script has module docstring")
+
+# ---------------------------------------------------------------------------
+# T3 — no-op when results/ directory doesn't exist
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    # results/ intentionally absent
+    proc = run_script(ws)
+    if proc.returncode == 0 and "missing" in proc.stdout:
+        ok("T3: exits 0 and reports 'missing' when results/ absent")
+    else:
+        fail("T3: exits 0 when results/ absent", f"rc={proc.returncode} out={proc.stdout.strip()[:80]}")
+
+# ---------------------------------------------------------------------------
+# T4 — archives files older than RETENTION_HOURS
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stale = results / "task-old.txt"
+    stale.write_text("stale result")
+    # Set mtime to 48h ago
+    old_time = time.time() - 48 * 3600
+    os.utime(stale, (old_time, old_time))
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    # File should be gone from results/
+    if not stale.exists() and proc.returncode == 0:
+        ok("T4: archives stale files older than RETENTION_HOURS")
+    else:
+        fail("T4: archives stale files", f"exists={stale.exists()} rc={proc.returncode} out={proc.stdout.strip()[:80]}")
+
+# ---------------------------------------------------------------------------
+# T5 — skips files newer than cutoff
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    fresh = results / "task-fresh.txt"
+    fresh.write_text("fresh result")
+    # mtime = now (definitely within 24h)
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    if fresh.exists() and proc.returncode == 0:
+        ok("T5: skips fresh files within RETENTION_HOURS cutoff")
+    else:
+        fail("T5: skips fresh files", f"exists={fresh.exists()} out={proc.stdout.strip()[:80]}")
+
+# ---------------------------------------------------------------------------
+# T6 — skips non-.txt files
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    non_txt = results / "task-old.json"
+    non_txt.write_text("{}")
+    old_time = time.time() - 48 * 3600
+    os.utime(non_txt, (old_time, old_time))
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    if non_txt.exists():
+        ok("T6: skips non-.txt files even if stale")
+    else:
+        fail("T6: skips non-.txt files", "non-txt file was moved")
+
+# ---------------------------------------------------------------------------
+# T7 — skips subdirectories (archive-* dirs are not touched)
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    archive_sub = results / "archive-2026-01-01"
+    archive_sub.mkdir()
+    old_file_in_archive = archive_sub / "task-old.txt"
+    old_file_in_archive.write_text("archived")
+    old_time = time.time() - 48 * 3600
+    os.utime(old_file_in_archive, (old_time, old_time))
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    if old_file_in_archive.exists():
+        ok("T7: does not touch files inside existing archive-* subdirs")
+    else:
+        fail("T7: does not touch archive-* subdir files", "file inside archive was moved")
+
+# ---------------------------------------------------------------------------
+# T8 — DRY_RUN=1 prints but does not move files
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stale = results / "task-stale.txt"
+    stale.write_text("old result")
+    old_time = time.time() - 48 * 3600
+    os.utime(stale, (old_time, old_time))
+    proc = run_script(ws, {"RETENTION_HOURS": "24", "DRY_RUN": "1"})
+    if stale.exists() and "would archive" in proc.stdout:
+        ok("T8: DRY_RUN=1 prints 'would archive' without moving file")
+    else:
+        fail("T8: DRY_RUN=1 dry-run mode", f"exists={stale.exists()} out={proc.stdout.strip()[:80]}")
+
+# ---------------------------------------------------------------------------
+# T9 — DRY_RUN case-insensitivity: 'No' and 'FALSE' disable dry-run
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stale = results / "task-casetest.txt"
+    stale.write_text("old")
+    old_time = time.time() - 48 * 3600
+    os.utime(stale, (old_time, old_time))
+    proc_no = run_script(ws, {"RETENTION_HOURS": "24", "DRY_RUN": "No"})
+    # DRY_RUN=No should NOT be dry-run (file should be moved)
+    if not stale.exists():
+        ok("T9: DRY_RUN=No treats 'No' as falsy — file is moved (not dry-run)")
+    else:
+        fail("T9: DRY_RUN=No should disable dry-run", f"file still exists; out={proc_no.stdout.strip()[:80]}")
+
+# ---------------------------------------------------------------------------
+# T10 — archive directory named archive-YYYY-MM-DD
+# ---------------------------------------------------------------------------
+import re
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stale = results / "task-dating.txt"
+    stale.write_text("old")
+    old_time = time.time() - 48 * 3600
+    os.utime(stale, (old_time, old_time))
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    archive_dirs = [d for d in results.iterdir() if d.is_dir() and d.name.startswith("archive-")]
+    if archive_dirs and re.match(r"archive-\d{4}-\d{2}-\d{2}", archive_dirs[0].name):
+        ok(f"T10: archive dir named correctly ({archive_dirs[0].name})")
+    else:
+        fail("T10: archive dir named archive-YYYY-MM-DD", f"dirs={[d.name for d in results.iterdir() if d.is_dir()]}")
+
+# ---------------------------------------------------------------------------
+# T11 — archived file is inside archive-YYYY-MM-DD/
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stale = results / "task-moved.txt"
+    stale.write_text("old")
+    old_time = time.time() - 48 * 3600
+    os.utime(stale, (old_time, old_time))
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    archive_dirs = [d for d in results.iterdir() if d.is_dir()]
+    if archive_dirs:
+        archived = list(archive_dirs[0].iterdir())
+        if any(f.name == "task-moved.txt" for f in archived):
+            ok("T11: archived file found inside archive-YYYY-MM-DD/")
+        else:
+            fail("T11: file inside archive dir", f"archive contents={[f.name for f in archived]}")
+    else:
+        fail("T11: archive dir created", "no archive dir found")
+
+# ---------------------------------------------------------------------------
+# T12 — multiple stale files all archived in same pass
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    ws = Path(td)
+    results = ws / "results"
+    results.mkdir()
+    stales = []
+    for i in range(3):
+        f = results / f"task-multi-{i}.txt"
+        f.write_text(f"old {i}")
+        old_time = time.time() - 48 * 3600
+        os.utime(f, (old_time, old_time))
+        stales.append(f)
+    proc = run_script(ws, {"RETENTION_HOURS": "24"})
+    remaining = [f for f in stales if f.exists()]
+    if not remaining and proc.returncode == 0:
+        ok("T12: all 3 stale files archived in single pass")
+    else:
+        fail("T12: all stale files archived", f"{len(remaining)} remaining out={proc.stdout.strip()[:80]}")
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print(f"\n{PASS}/{PASS+FAIL} tests passed")
+if __name__ == "__main__":
+    pass

--- a/tests/check-pending-questions.test.py
+++ b/tests/check-pending-questions.test.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Behavioral tests for `src/check-pending-questions.py`.
+
+Tests the parsing and gate functions in isolation — no macOS notifications
+are fired, no Discord DMs sent. The module-level path globals
+(PQ_FILE, LAST_NOTIFY_FILE, PRESENTER_SENTINEL, VOICE_LOG, RESULTS_DIR)
+are monkeypatched to tempdir fixtures so nothing touches the live workspace.
+
+Functions under test:
+  presenter_mode_active()  — checks sentinel file + expiry timestamp
+  get_waiting_questions()  — parses pending-questions.md sections
+  should_notify()          — 1-hour cooldown guard
+  voice_client_connected() — reads voice-agent.log [Health] lines
+
+Run: python3 tests/check-pending-questions.test.py
+Exit: 0 on pass, non-zero on fail.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_SRC = REPO / "src"
+
+# -----------------------------------------------------------------------
+# Module loader
+# -----------------------------------------------------------------------
+_WORKSPACE = tempfile.mkdtemp(prefix="sutando-test-pq-")
+os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+for _n in ("check-pending-questions", "workspace_default", "util_paths"):
+    sys.modules.pop(_n, None)
+
+_spec = importlib.util.spec_from_file_location(
+    "check_pending_questions", _SRC / "check-pending-questions.py"
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+# -----------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------
+
+PASS = 0
+FAIL = 0
+_TD = Path(_WORKSPACE)
+
+
+def ok(label: str) -> None:
+    global PASS
+    PASS += 1
+    print(f"PASS  {label}")
+
+
+def fail(label: str, detail: str = "") -> None:
+    global FAIL
+    FAIL += 1
+    print(f"FAIL  {label}" + (f": {detail}" if detail else ""))
+
+
+def _patch(sentinel=None, pq_file=None, last_notify=None, voice_log=None, results_dir=None):
+    """Context-manager-ish: set module paths to given values, restore on exit."""
+    class _Ctx:
+        def __enter__(self):
+            self._orig = {
+                "PRESENTER_SENTINEL": _mod.PRESENTER_SENTINEL,
+                "PQ_FILE": _mod.PQ_FILE,
+                "LAST_NOTIFY_FILE": _mod.LAST_NOTIFY_FILE,
+                "VOICE_LOG": _mod.VOICE_LOG,
+                "RESULTS_DIR": _mod.RESULTS_DIR,
+            }
+            if sentinel is not None:
+                _mod.PRESENTER_SENTINEL = sentinel
+            if pq_file is not None:
+                _mod.PQ_FILE = pq_file
+            if last_notify is not None:
+                _mod.LAST_NOTIFY_FILE = last_notify
+            if voice_log is not None:
+                _mod.VOICE_LOG = voice_log
+            if results_dir is not None:
+                _mod.RESULTS_DIR = results_dir
+            return self
+
+        def __exit__(self, *_):
+            for k, v in self._orig.items():
+                setattr(_mod, k, v)
+
+    return _Ctx()
+
+
+# -----------------------------------------------------------------------
+# presenter_mode_active() tests
+# -----------------------------------------------------------------------
+
+# T1 — no sentinel → False
+with tempfile.TemporaryDirectory() as td:
+    s = Path(td) / "presenter-mode.sentinel"
+    with _patch(sentinel=s):
+        if not _mod.presenter_mode_active():
+            ok("T1: no sentinel file → presenter_mode_active returns False")
+        else:
+            fail("T1: no sentinel", "got True when file absent")
+
+# T2 — sentinel with FUTURE timestamp → True (presenter mode active)
+with tempfile.TemporaryDirectory() as td:
+    s = Path(td) / "presenter-mode.sentinel"
+    future = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() + 3600))
+    s.write_text(future)
+    with _patch(sentinel=s):
+        if _mod.presenter_mode_active():
+            ok("T2: future-dated sentinel → presenter_mode_active returns True")
+        else:
+            fail("T2: future sentinel", f"got False for expiry={future}")
+
+# T3 — sentinel with PAST timestamp → False (expired)
+with tempfile.TemporaryDirectory() as td:
+    s = Path(td) / "presenter-mode.sentinel"
+    past = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - 3600))
+    s.write_text(past)
+    with _patch(sentinel=s):
+        if not _mod.presenter_mode_active():
+            ok("T3: expired sentinel → presenter_mode_active returns False")
+        else:
+            fail("T3: expired sentinel", f"got True for past expiry={past}")
+
+# T4 — malformed sentinel content (doesn't start with digit) → False (fail-closed)
+with tempfile.TemporaryDirectory() as td:
+    s = Path(td) / "presenter-mode.sentinel"
+    s.write_text("garbage content not an ISO date")
+    with _patch(sentinel=s):
+        if not _mod.presenter_mode_active():
+            ok("T4: malformed sentinel content → presenter_mode_active returns False (fail-closed)")
+        else:
+            fail("T4: malformed sentinel", "got True for non-ISO content")
+
+# -----------------------------------------------------------------------
+# get_waiting_questions() tests
+# -----------------------------------------------------------------------
+
+# T5 — no file → empty list
+with tempfile.TemporaryDirectory() as td:
+    pq = Path(td) / "pending-questions.md"
+    with _patch(pq_file=pq):
+        result = _mod.get_waiting_questions()
+        if result == []:
+            ok("T5: missing pending-questions.md → empty list")
+        else:
+            fail("T5: missing file", f"got {result}")
+
+# T6 — single unanswered question
+with tempfile.TemporaryDirectory() as td:
+    pq = Path(td) / "pending-questions.md"
+    pq.write_text(
+        "# Pending Questions\n\n"
+        "## Deploy timing for PR #1086\n"
+        "- **Status:** unanswered\n"
+        "- Asked: 2026-05-20\n"
+    )
+    with _patch(pq_file=pq):
+        result = _mod.get_waiting_questions()
+        if len(result) == 1 and "Deploy timing" in result[0]["title"]:
+            ok("T6: single unanswered section → returned in list")
+        else:
+            fail("T6: single unanswered", f"got {result}")
+
+# T7 — answered question NOT included
+with tempfile.TemporaryDirectory() as td:
+    pq = Path(td) / "pending-questions.md"
+    pq.write_text(
+        "## Resolved question\n"
+        "- **Status:** answered\n"
+        "- Answer: yes, ship it\n"
+    )
+    with _patch(pq_file=pq):
+        result = _mod.get_waiting_questions()
+        if result == []:
+            ok("T7: answered question not included in results")
+        else:
+            fail("T7: answered excluded", f"got {result}")
+
+# T8 — mixed: unanswered + answered → only unanswered returned
+with tempfile.TemporaryDirectory() as td:
+    pq = Path(td) / "pending-questions.md"
+    pq.write_text(
+        "# Pending Questions\n\n"
+        "## Unanswered one\n"
+        "- **Status:** unanswered\n\n"
+        "## Already resolved\n"
+        "- **Status:** answered\n\n"
+        "## Also waiting\n"
+        "- **Status:** Waiting on Bassil\n"
+    )
+    with _patch(pq_file=pq):
+        result = _mod.get_waiting_questions()
+        titles = [q["title"] for q in result]
+        if len(result) == 2 and "Unanswered one" in titles and "Also waiting" in titles:
+            ok("T8: mixed sections — only unanswered/waiting returned")
+        else:
+            fail("T8: mixed sections", f"titles={titles}")
+
+# T9 — legacy Q1 — Title format (## Q1 — Title) is recognized
+with tempfile.TemporaryDirectory() as td:
+    pq = Path(td) / "pending-questions.md"
+    pq.write_text(
+        "## Q1 — Should we merge PR 968 first?\n"
+        "- **Status:** unanswered\n"
+    )
+    with _patch(pq_file=pq):
+        result = _mod.get_waiting_questions()
+        if len(result) == 1 and "Q1 — Should we merge" in result[0]["title"]:
+            ok("T9: legacy Q1 — Title format recognized")
+        else:
+            fail("T9: legacy format", f"got {result}")
+
+# T10 — section with no **Status:** field → skipped
+with tempfile.TemporaryDirectory() as td:
+    pq = Path(td) / "pending-questions.md"
+    pq.write_text(
+        "## A question with no status field\n"
+        "- Just some notes, no status line\n"
+    )
+    with _patch(pq_file=pq):
+        result = _mod.get_waiting_questions()
+        if result == []:
+            ok("T10: section without **Status:** field skipped")
+        else:
+            fail("T10: no status field skipped", f"got {result}")
+
+# -----------------------------------------------------------------------
+# should_notify() tests
+# -----------------------------------------------------------------------
+
+# T11 — no .last-pq-notify file → should notify
+with tempfile.TemporaryDirectory() as td:
+    f = Path(td) / ".last-pq-notify"
+    with _patch(last_notify=f):
+        if _mod.should_notify():
+            ok("T11: no .last-pq-notify → should_notify returns True")
+        else:
+            fail("T11: no file → notify", "got False when file absent")
+
+# T12 — .last-pq-notify with mtime <1h ago → cooldown active → False
+with tempfile.TemporaryDirectory() as td:
+    f = Path(td) / ".last-pq-notify"
+    f.write_text(str(int(time.time())))
+    # mtime = now (definitely within 1h)
+    with _patch(last_notify=f):
+        if not _mod.should_notify():
+            ok("T12: recent .last-pq-notify → cooldown active → should_notify False")
+        else:
+            fail("T12: cooldown active", "got True for recent notify file")
+
+# T13 — .last-pq-notify with mtime >1h ago → should notify again
+with tempfile.TemporaryDirectory() as td:
+    f = Path(td) / ".last-pq-notify"
+    f.write_text("old")
+    # Set mtime to 2 hours ago
+    old_time = time.time() - 7201
+    os.utime(f, (old_time, old_time))
+    with _patch(last_notify=f):
+        if _mod.should_notify():
+            ok("T13: .last-pq-notify older than 1h → should_notify True")
+        else:
+            fail("T13: expired cooldown", "got False for file >1h old")
+
+# -----------------------------------------------------------------------
+# voice_client_connected() tests
+# -----------------------------------------------------------------------
+
+# T14 — no voice log → False
+with tempfile.TemporaryDirectory() as td:
+    vl = Path(td) / "voice-agent.log"
+    with _patch(voice_log=vl):
+        if not _mod.voice_client_connected():
+            ok("T14: no voice-agent.log → voice_client_connected returns False")
+        else:
+            fail("T14: no log file", "got True when file absent")
+
+# T15 — log with [Health] client=true → True
+with tempfile.TemporaryDirectory() as td:
+    vl = Path(td) / "voice-agent.log"
+    vl.write_text(
+        "[2026-05-26T10:00:00Z] Voice agent started\n"
+        "[2026-05-26T10:00:05Z] [Health] client=true streams=1\n"
+    )
+    with _patch(voice_log=vl):
+        if _mod.voice_client_connected():
+            ok("T15: log with [Health] client=true → voice_client_connected True")
+        else:
+            fail("T15: client=true", "got False")
+
+# T16 — log with [Health] client=false → False
+with tempfile.TemporaryDirectory() as td:
+    vl = Path(td) / "voice-agent.log"
+    vl.write_text(
+        "[2026-05-26T10:00:00Z] [Health] client=false streams=0\n"
+    )
+    with _patch(voice_log=vl):
+        if not _mod.voice_client_connected():
+            ok("T16: log with [Health] client=false → voice_client_connected False")
+        else:
+            fail("T16: client=false", "got True")
+
+# T17 — most recent [Health] line wins (last line overrides earlier True)
+with tempfile.TemporaryDirectory() as td:
+    vl = Path(td) / "voice-agent.log"
+    vl.write_text(
+        "[2026-05-26T10:00:00Z] [Health] client=true streams=1\n"
+        "[2026-05-26T10:00:10Z] [Health] client=false streams=0\n"
+    )
+    with _patch(voice_log=vl):
+        if not _mod.voice_client_connected():
+            ok("T17: most recent [Health] line wins — last=false → False")
+        else:
+            fail("T17: most recent [Health] wins", "got True — stale earlier line used")
+
+# T18 — log with no [Health] line → False
+with tempfile.TemporaryDirectory() as td:
+    vl = Path(td) / "voice-agent.log"
+    vl.write_text("Voice agent started\nSome log output, no health line.\n")
+    with _patch(voice_log=vl):
+        if not _mod.voice_client_connected():
+            ok("T18: log with no [Health] line → voice_client_connected False")
+        else:
+            fail("T18: no [Health] line", "got True")
+
+# -----------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------
+print(f"\n{PASS}/{PASS + FAIL} tests passed")
+if FAIL:
+    sys.exit(1)

--- a/tests/event-log.test.py
+++ b/tests/event-log.test.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Behavioral tests for `src/event_log.py`.
+
+`event_log` provides crash-safe structured event logging for every Sutando
+service. These tests guard the file-writing contract, JSONL format,
+field inclusion, non-serializable-value handling, and the atomicity-safe
+append behavior.
+
+Run: python3 tests/event-log.test.py
+Exit: 0 on pass, non-zero on fail.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_SRC = REPO / "src"
+
+# -----------------------------------------------------------------------
+# Module loader — fresh import with a controlled temp workspace so
+# log files don't land in the real workspace.
+# -----------------------------------------------------------------------
+_WORKSPACE = tempfile.mkdtemp(prefix="sutando-test-evlog-")
+os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+for _n in ("event_log", "workspace_default", "util_paths"):
+    sys.modules.pop(_n, None)
+
+_spec = importlib.util.spec_from_file_location("event_log", _SRC / "event_log.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+log_event = _mod.log_event
+get_log_path = _mod.get_log_path
+
+# -----------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------
+
+PASS = 0
+FAIL = 0
+
+
+def ok(label: str) -> None:
+    global PASS
+    PASS += 1
+    print(f"PASS  {label}")
+
+
+def fail(label: str, detail: str = "") -> None:
+    global FAIL
+    FAIL += 1
+    print(f"FAIL  {label}" + (f": {detail}" if detail else ""))
+
+
+def _last_event(path: Path) -> dict:
+    """Read the last JSONL line from `path` and parse it."""
+    line = path.read_text(encoding="utf-8").strip().splitlines()[-1]
+    return json.loads(line)
+
+
+def _events(path: Path) -> list[dict]:
+    """Read all JSONL events from `path`."""
+    return [json.loads(l) for l in path.read_text(encoding="utf-8").strip().splitlines() if l]
+
+
+# -----------------------------------------------------------------------
+# T1 — get_log_path returns a Path ending in events-YYYY-MM-DD.jsonl
+# -----------------------------------------------------------------------
+import re as _re
+_path = get_log_path()
+if isinstance(_path, Path) and _re.fullmatch(r"events-\d{4}-\d{2}-\d{2}\.jsonl", _path.name):
+    ok("T1: get_log_path() → events-YYYY-MM-DD.jsonl")
+else:
+    fail("T1: get_log_path() format", f"got {_path}")
+
+# -----------------------------------------------------------------------
+# T2 — get_log_path(when=ts) returns the correct local date for that ts
+# -----------------------------------------------------------------------
+# Use a fixed timestamp: 2024-03-15 12:00 UTC (well within UTC+4 Dubai too)
+_ts = 1710500400.0  # 2024-03-15 11:00:00 UTC
+_dated = get_log_path(when=_ts)
+# Local date may vary by timezone, but the format must hold.
+if _re.fullmatch(r"events-\d{4}-\d{2}-\d{2}\.jsonl", _dated.name):
+    ok(f"T2: get_log_path(when=ts) returns dated name: {_dated.name}")
+else:
+    fail("T2: get_log_path(when=ts) format", f"got {_dated.name}")
+
+# -----------------------------------------------------------------------
+# T3 — LOGS_DIR is under the test workspace (controlled env)
+# -----------------------------------------------------------------------
+if str(_mod.LOGS_DIR).startswith(_WORKSPACE):
+    ok("T3: LOGS_DIR is under $SUTANDO_WORKSPACE")
+else:
+    fail("T3: LOGS_DIR under workspace", f"LOGS_DIR={_mod.LOGS_DIR}")
+
+# -----------------------------------------------------------------------
+# T4 — log_event creates the JSONL file on first call
+# -----------------------------------------------------------------------
+path = get_log_path()
+path.unlink(missing_ok=True)  # start clean
+log_event("test.create")
+if path.exists():
+    ok("T4: log_event creates the JSONL file on first call")
+else:
+    fail("T4: log_event creates file", f"path={path}")
+
+# -----------------------------------------------------------------------
+# T5 — event has required fields: ts, node, kind
+# -----------------------------------------------------------------------
+log_event("test.fields")
+e = _last_event(get_log_path())
+if "ts" in e and "node" in e and "kind" in e:
+    ok("T5: event has required fields (ts, node, kind)")
+else:
+    fail("T5: required fields", f"event={e}")
+
+# -----------------------------------------------------------------------
+# T6 — `ts` is a float close to now
+# -----------------------------------------------------------------------
+log_event("test.ts_check")
+e = _last_event(get_log_path())
+delta = abs(e["ts"] - time.time())
+if isinstance(e["ts"], float) and delta < 5:
+    ok(f"T6: event ts is float close to now (delta={delta:.3f}s)")
+else:
+    fail("T6: event ts", f"ts={e['ts']} delta={delta}")
+
+# -----------------------------------------------------------------------
+# T7 — `kind` field matches the kind argument
+# -----------------------------------------------------------------------
+log_event("bridge.task_written")
+e = _last_event(get_log_path())
+if e["kind"] == "bridge.task_written":
+    ok("T7: event kind matches argument")
+else:
+    fail("T7: event kind", f"got={e['kind']!r}")
+
+# -----------------------------------------------------------------------
+# T8 — extra keyword fields are included in the event
+# -----------------------------------------------------------------------
+log_event("test.extra_fields", task_id="task-9999", tier="owner", count=7)
+e = _last_event(get_log_path())
+if e.get("task_id") == "task-9999" and e.get("tier") == "owner" and e.get("count") == 7:
+    ok("T8: extra keyword fields included in event")
+else:
+    fail("T8: extra fields", f"event={e}")
+
+# -----------------------------------------------------------------------
+# T9 — non-JSON-serializable values are stringified via repr()
+# -----------------------------------------------------------------------
+class _Unserializable:
+    def __repr__(self):
+        return "<Unserializable object>"
+
+log_event("test.repr_fallback", bad=_Unserializable())
+e = _last_event(get_log_path())
+if e.get("bad") == "<Unserializable object>":
+    ok("T9: non-JSON-serializable value stringified via repr()")
+else:
+    fail("T9: repr fallback", f"bad field={e.get('bad')!r}")
+
+# -----------------------------------------------------------------------
+# T10 — multiple log_event calls APPEND (not overwrite)
+# -----------------------------------------------------------------------
+path = get_log_path()
+before_count = len(_events(path))
+log_event("test.append_1")
+log_event("test.append_2")
+log_event("test.append_3")
+after_events = _events(path)
+if len(after_events) == before_count + 3:
+    ok(f"T10: multiple log_event calls append lines ({before_count}→{len(after_events)})")
+else:
+    fail("T10: append", f"before={before_count} after={len(after_events)}")
+
+# -----------------------------------------------------------------------
+# T11 — appended lines are valid JSONL (each line is valid JSON)
+# -----------------------------------------------------------------------
+path = get_log_path()
+lines = path.read_text(encoding="utf-8").strip().splitlines()
+bad_lines = []
+for i, line in enumerate(lines):
+    try:
+        json.loads(line)
+    except json.JSONDecodeError as exc:
+        bad_lines.append(f"line {i}: {exc}")
+if not bad_lines:
+    ok(f"T11: all {len(lines)} JSONL lines are valid JSON")
+else:
+    fail("T11: valid JSONL", f"{len(bad_lines)} bad lines: {bad_lines[:2]}")
+
+# -----------------------------------------------------------------------
+# T12 — log_event never raises (crash-safe) — even if logs dir is unwritable
+# -----------------------------------------------------------------------
+orig_logs = _mod.LOGS_DIR
+_mod.LOGS_DIR = Path("/nonexistent/no-write-permission/logs")
+try:
+    log_event("test.crash_safe")  # must not raise
+    ok("T12: log_event never raises (crash-safe on bad LOGS_DIR)")
+except Exception as exc:
+    fail("T12: crash-safe", f"raised: {exc}")
+finally:
+    _mod.LOGS_DIR = orig_logs
+
+# -----------------------------------------------------------------------
+# T13 — log_event with an empty kind string works (kind field is blank str)
+# -----------------------------------------------------------------------
+log_event("")
+e = _last_event(get_log_path())
+if e.get("kind") == "":
+    ok("T13: log_event with empty kind — kind field is empty string")
+else:
+    fail("T13: empty kind", f"kind={e.get('kind')!r}")
+
+# -----------------------------------------------------------------------
+# T14 — node field is a non-empty string (hostname fallback works)
+# -----------------------------------------------------------------------
+log_event("test.node_check")
+e = _last_event(get_log_path())
+if isinstance(e.get("node"), str) and e["node"]:
+    ok(f"T14: node field is non-empty string: {e['node']!r}")
+else:
+    fail("T14: node field", f"node={e.get('node')!r}")
+
+# -----------------------------------------------------------------------
+# T15 — event order is preserved (FIFO append)
+# -----------------------------------------------------------------------
+path = get_log_path()
+before_count = len(_events(path))
+log_event("test.order_a")
+log_event("test.order_b")
+log_event("test.order_c")
+after = _events(path)
+kinds = [e["kind"] for e in after[before_count:]]
+if kinds == ["test.order_a", "test.order_b", "test.order_c"]:
+    ok("T15: event order is preserved (FIFO append)")
+else:
+    fail("T15: order", f"kinds={kinds}")
+
+# -----------------------------------------------------------------------
+# T16 — ts field is rounded to 3 decimal places (ms precision)
+# -----------------------------------------------------------------------
+log_event("test.ts_precision")
+e = _last_event(get_log_path())
+ts_str = str(e["ts"])
+# After the decimal point, at most 3 digits
+decimal_part = ts_str.split(".")[-1] if "." in ts_str else ""
+if len(decimal_part) <= 3:
+    ok(f"T16: ts rounded to ≤3 decimal places (got: {e['ts']})")
+else:
+    fail("T16: ts precision", f"ts={e['ts']!r}")
+
+# -----------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------
+print(f"\n{PASS}/{PASS + FAIL} tests passed")
+if FAIL:
+    sys.exit(1)

--- a/tests/send-allowlist-is-path-sendable.test.py
+++ b/tests/send-allowlist-is-path-sendable.test.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Behavioral tests for `src/send_allowlist.py::is_path_sendable`.
+
+The companion `send-allowlist-shared.test.py` covers the architectural
+invariants (module exists, the right imports are present, constants are
+documented). This suite exercises the *runtime behavior* of
+`is_path_sendable()` — what it actually allows and blocks.
+
+Security-critical properties guarded here:
+  - Symlink-traversal: a symlink whose *name* starts with an allowed
+    prefix but whose realpath resolves outside the allowlist is rejected.
+  - Directory rejection: directories are never sendable (callers must
+    receive regular files only).
+  - Fail-closed default: anything not explicitly allowed returns False.
+  - No path-traversal bypass: `..` segments in the path are neutralised
+    by realpath before the allowlist check.
+  - Root-prefix false-match guard: `/tmp/sutando` (a dir) does NOT
+    qualify as a prefix match for `/tmp/sutando-recording-xyz.mov` —
+    the `-` in the recorded prefix is load-bearing.
+
+Run: python3 tests/send-allowlist-is-path-sendable.test.py
+Exit: 0 on pass, non-zero on fail.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_SRC = REPO / "src"
+
+# -----------------------------------------------------------------------
+# Module loader — import fresh with a temp workspace so the module-level
+# SEND_ALLOWED_ROOTS computation doesn't reference live workspace data.
+# -----------------------------------------------------------------------
+_WORKSPACE = tempfile.mkdtemp(prefix="sutando-test-ws-")
+os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+# Remove any previously cached copies so exec_module re-runs the
+# module-level code with the env we just set.
+for _mod_name in ("send_allowlist", "workspace_default", "util_paths"):
+    sys.modules.pop(_mod_name, None)
+
+_spec = importlib.util.spec_from_file_location("send_allowlist", _SRC / "send_allowlist.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+is_path_sendable = _mod.is_path_sendable
+
+# -----------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------
+
+PASS = 0
+FAIL = 0
+
+
+def ok(label: str) -> None:
+    global PASS
+    PASS += 1
+    print(f"PASS  {label}")
+
+
+def fail(label: str, detail: str = "") -> None:
+    global FAIL
+    FAIL += 1
+    msg = f"FAIL  {label}"
+    if detail:
+        msg += f": {detail}"
+    print(msg)
+
+
+def _tmp_file(prefix: str = "sutando-test-", suffix: str = ".txt", dir: str = "/tmp") -> str:
+    """Create a real regular file and return its path."""
+    fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=dir)
+    os.close(fd)
+    return path
+
+
+def _with_patched_roots(roots: tuple, fn):
+    """Run fn() with SEND_ALLOWED_ROOTS temporarily replaced."""
+    orig = _mod.SEND_ALLOWED_ROOTS
+    _mod.SEND_ALLOWED_ROOTS = roots
+    try:
+        return fn()
+    finally:
+        _mod.SEND_ALLOWED_ROOTS = orig
+
+
+# -----------------------------------------------------------------------
+# T1 — rejects nonexistent path (fail-closed)
+# -----------------------------------------------------------------------
+if not is_path_sendable("/nonexistent/path/file.txt"):
+    ok("T1: nonexistent path returns False")
+else:
+    fail("T1: nonexistent path returns False", "got True for a path that doesn't exist")
+
+# -----------------------------------------------------------------------
+# T2 — rejects empty string (fail-closed)
+# -----------------------------------------------------------------------
+if not is_path_sendable(""):
+    ok("T2: empty string returns False")
+else:
+    fail("T2: empty string returns False", "got True for empty string")
+
+# -----------------------------------------------------------------------
+# T3 — rejects a directory even if named with allowed prefix
+# -----------------------------------------------------------------------
+with tempfile.TemporaryDirectory(prefix="sutando-test-dir-", dir="/tmp") as d:
+    if not is_path_sendable(d):
+        ok("T3: directory returns False even with sutando- name")
+    else:
+        fail("T3: directory returns False", f"directory {d} was accepted")
+
+# -----------------------------------------------------------------------
+# T4 — accepts file whose realpath starts with /tmp/sutando-
+# -----------------------------------------------------------------------
+_f = _tmp_file(prefix="sutando-recording-", suffix=".mov")
+try:
+    if is_path_sendable(_f):
+        ok("T4: /tmp/sutando-*.mov accepted (prefix match)")
+    else:
+        fail("T4: /tmp/sutando-*.mov accepted", f"realpath={os.path.realpath(_f)}")
+finally:
+    os.unlink(_f)
+
+# -----------------------------------------------------------------------
+# T5 — accepts file whose realpath starts with /tmp/echo-
+# -----------------------------------------------------------------------
+_f = _tmp_file(prefix="echo-screenshot-", suffix=".png")
+try:
+    if is_path_sendable(_f):
+        ok("T5: /tmp/echo-*.png accepted (prefix match)")
+    else:
+        fail("T5: /tmp/echo-*.png accepted", f"realpath={os.path.realpath(_f)}")
+finally:
+    os.unlink(_f)
+
+# -----------------------------------------------------------------------
+# T6 — rejects /tmp file whose name does NOT match any allowed prefix
+# -----------------------------------------------------------------------
+_f = _tmp_file(prefix="notallowed-xyz-", suffix=".txt")
+try:
+    if not is_path_sendable(_f):
+        ok("T6: /tmp/notallowed-* rejected (no prefix match)")
+    else:
+        fail("T6: /tmp/notallowed-* rejected", f"file {_f} was unexpectedly accepted")
+finally:
+    os.unlink(_f)
+
+# -----------------------------------------------------------------------
+# T7 — symlink traversal: name starts with sutando- but realpath escapes
+#
+# A symlink at /tmp/sutando-evil.txt → /etc/passwd.
+# realpath resolves to /etc/passwd which does NOT start with /tmp/sutando-
+# or /private/tmp/sutando-, so is_path_sendable must return False.
+# -----------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    link = Path(td) / "sutando-evil.txt"
+    link.symlink_to("/etc/passwd")
+    # The symlink is in a non-prefix dir, so it's rejected for two reasons:
+    # (a) realpath = /etc/passwd — not in prefix, (b) not under any root.
+    if not is_path_sendable(str(link)):
+        ok("T7: symlink→/etc/passwd rejected via realpath collapse")
+    else:
+        fail("T7: symlink→/etc/passwd rejected", "symlink to /etc/passwd was accepted")
+
+# -----------------------------------------------------------------------
+# T8 — symlink FROM /tmp/sutando-* → outside allowed area rejected
+#
+# More targeted: the symlink's name is in the allowed prefix namespace
+# (/tmp/sutando-*), but the realpath resolves outside the allowlist.
+# This is the direct attack vector: name the symlink sutando-*, hope the
+# check only inspects the name.
+# -----------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    evil_target = Path(td) / "secret.txt"
+    evil_target.write_text("secret")
+    # Symlink inside /tmp at a sutando- prefix name
+    fd, link_path = tempfile.mkstemp(prefix="sutando-", suffix=".txt", dir="/tmp")
+    os.close(fd)
+    os.unlink(link_path)
+    try:
+        os.symlink(str(evil_target), link_path)
+        real = os.path.realpath(link_path)
+        # realpath → td/secret.txt which is outside all allowed prefixes/roots
+        if not is_path_sendable(link_path):
+            ok("T8: /tmp/sutando-<link>→outside accepted only by name — realpath defeats it")
+        else:
+            fail("T8: realpath-defeats-prefix-name-symlink", f"realpath={real}, was accepted")
+    finally:
+        try:
+            os.unlink(link_path)
+        except OSError:
+            pass
+
+# -----------------------------------------------------------------------
+# T9 — path traversal via `..` does NOT bypass the allowlist
+#
+# Construct a path like /tmp/sutando-<dir>/../../../etc/passwd.
+# realpath collapses the `..` so the check sees /etc/passwd, not the
+# sutando-* prefix path.
+# -----------------------------------------------------------------------
+with tempfile.TemporaryDirectory(prefix="sutando-traversal-", dir="/tmp") as td:
+    traversal = td + "/../../../etc/passwd"
+    real = os.path.realpath(traversal)
+    if not is_path_sendable(traversal):
+        ok(f"T9: path traversal ../../../etc/passwd rejected (realpath={real})")
+    else:
+        fail("T9: path traversal rejected", f"traversal to {real} was accepted")
+
+# -----------------------------------------------------------------------
+# T10 — root-based match: file directly in an allowed root → accepted
+# -----------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    allowed_root = Path(td) / "results"
+    allowed_root.mkdir()
+    test_file = allowed_root / "task-12345.txt"
+    test_file.write_text("result content")
+
+    def _t10():
+        return is_path_sendable(str(test_file))
+
+    if _with_patched_roots((str(allowed_root),), _t10):
+        ok("T10: file directly in allowed root accepted")
+    else:
+        fail("T10: file directly in allowed root accepted", f"file={test_file}")
+
+# -----------------------------------------------------------------------
+# T11 — root-based match: file in *subdirectory* of allowed root → accepted
+# -----------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    allowed_root = Path(td) / "results"
+    sub = allowed_root / "2026-05-26"
+    sub.mkdir(parents=True)
+    test_file = sub / "task-multi.txt"
+    test_file.write_text("content")
+
+    def _t11():
+        return is_path_sendable(str(test_file))
+
+    if _with_patched_roots((str(allowed_root),), _t11):
+        ok("T11: file in subdirectory of allowed root accepted")
+    else:
+        fail("T11: subdirectory of allowed root accepted", f"file={test_file}")
+
+# -----------------------------------------------------------------------
+# T12 — root-based: the root directory itself is NOT a file → rejected
+# -----------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    allowed_root = Path(td) / "results"
+    allowed_root.mkdir()
+
+    def _t12():
+        return is_path_sendable(str(allowed_root))
+
+    if not _with_patched_roots((str(allowed_root),), _t12):
+        ok("T12: the root directory itself (not a file) is rejected")
+    else:
+        fail("T12: root directory rejected", "directory was accepted as sendable")
+
+# -----------------------------------------------------------------------
+# T13 — false-prefix guard: /tmp/sutando (no trailing `-`) does NOT
+#        accidentally match /tmp/sutando-recording-xyz
+#
+# The SEND_ALLOWED_PREFIXES are /tmp/sutando- (WITH the dash). A bare
+# /tmp/sutando directory must not grant access to its own name.
+# -----------------------------------------------------------------------
+with tempfile.TemporaryDirectory(prefix="notallowed-prefix-", dir="/tmp") as td:
+    # File is in /tmp/notallowed-prefix-xxx/sutando-results.txt
+    # realpath won't start with /tmp/sutando- or /private/tmp/sutando-
+    test_file = Path(td) / "sutando-results.txt"
+    test_file.write_text("data")
+    if not is_path_sendable(str(test_file)):
+        ok("T13: file in non-prefix /tmp subdir rejected (starts with 'sutando' but wrong dir)")
+    else:
+        fail("T13: prefix substring safety", f"file={test_file} real={os.path.realpath(test_file)}")
+
+# -----------------------------------------------------------------------
+# T14 — root-based: sibling directory is NOT included (trailing-sep check)
+#
+# Allowed root = /tmp/xxx/results — file in /tmp/xxx/results-extra/f.txt
+# must NOT match (would be a false positive if only startswith() without
+# the trailing-sep guard were used).
+# -----------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    allowed_root = Path(td) / "results"
+    allowed_root.mkdir()
+    sibling = Path(td) / "results-extra"
+    sibling.mkdir()
+    sibling_file = sibling / "file.txt"
+    sibling_file.write_text("data")
+
+    def _t14():
+        return is_path_sendable(str(sibling_file))
+
+    if not _with_patched_roots((str(allowed_root),), _t14):
+        ok("T14: sibling dir results-extra/ not matched by results/ root (trailing-sep guard)")
+    else:
+        fail("T14: sibling dir trailing-sep guard", f"sibling {sibling_file} was accepted under root {allowed_root}")
+
+# -----------------------------------------------------------------------
+# T15 — symlink within allowed root pointing to real file also in root → accepted
+#
+# Legitimate use-case: agent creates a symlink alias inside results/.
+# The realpath of the symlink resolves to another file also under results/
+# so the allowlist check should accept it.
+# -----------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    allowed_root = Path(td) / "results"
+    allowed_root.mkdir()
+    real_file = allowed_root / "task-123.txt"
+    real_file.write_text("result")
+    link_file = allowed_root / "task-123-alias.txt"
+    link_file.symlink_to(real_file)
+
+    def _t15():
+        return is_path_sendable(str(link_file))
+
+    if _with_patched_roots((str(allowed_root),), _t15):
+        ok("T15: symlink→file within same allowed root accepted")
+    else:
+        fail("T15: intra-root symlink accepted", f"symlink {link_file}→{real_file}")
+
+# -----------------------------------------------------------------------
+# T16 — symlink within allowed root pointing OUTSIDE root → rejected
+# -----------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as outer, tempfile.TemporaryDirectory() as td:
+    allowed_root = Path(td) / "results"
+    allowed_root.mkdir()
+    outside_file = Path(outer) / "secret.txt"
+    outside_file.write_text("secret")
+    evil_link = allowed_root / "escape-link.txt"
+    evil_link.symlink_to(outside_file)
+
+    def _t16():
+        return is_path_sendable(str(evil_link))
+
+    if not _with_patched_roots((str(allowed_root),), _t16):
+        ok("T16: symlink within root→outside root rejected via realpath")
+    else:
+        fail("T16: intra-root escape-symlink rejected", f"link {evil_link}→{outside_file} was accepted")
+
+# -----------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------
+print(f"\n{PASS}/{PASS + FAIL} tests passed")
+if FAIL:
+    sys.exit(1)


### PR DESCRIPTION
## Summary

- Adds `tests/check-pending-questions.test.py` — first test coverage for `src/check-pending-questions.py`
- Tests the four core functions in isolation; no notifications fired, no live workspace mutations

## Tests (18/18 passing)

| Function | Tests | What's covered |
|----------|-------|---------------|
| `presenter_mode_active()` | T1–T4 | absent sentinel, future-dated, expired, malformed content (fail-closed) |
| `get_waiting_questions()` | T5–T10 | missing file, unanswered included, answered excluded, mixed sections, legacy Q1 format, no-status-field skipped |
| `should_notify()` | T11–T13 | no file, recent file (cooldown), >1h-old file |
| `voice_client_connected()` | T14–T18 | no log, client=true, client=false, most-recent-line-wins, no [Health] line |

## Test plan

- [x] `python3 tests/check-pending-questions.test.py` → 18/18 PASS
- [x] Module-level path globals monkeypatched to tempdir fixtures
- [x] No macOS notifications fired, no Discord DMs sent during tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)