### PR TITLE
test(daily-insight): 22 behavioral tests for pure analysis functions

### DIFF
--- a/build_log.md
+++ b/build_log.md
@@ -96,3 +96,19 @@
 
 **Pending push go-ahead** (new this pass):
 - `feat/cross-node-sync-config-1044` (15 tests, `a072033`)
+
+## Pass 214 (2026-05-25)
+
+**fix(watch-tasks-stream): Node .mjs closes both orphan paths (closes #1088)** (commit `8751618` on `fix/watch-tasks-orphan-1088`):
+- `src/watch-tasks-stream.mjs` (new) — Node implementation replaces fswatch bash script
+  - **Mode A (EPIPE)**: `process.stdout.on('error')` handler exits on EPIPE/EBADF; 30s heartbeat (`HEARTBEAT_INTERVAL_MS` override) forces EPIPE detection when tasks dir is quiet
+  - **Mode B (PPID reparent)**: polls `process.ppid` every 10s, exits when parent gone; also handles SIGHUP
+  - Inline `bumpAttemptsCounter()` (no external Python dep, graceful degradation)
+  - Workspace resolution: SUTANDO_WORKSPACE → ~/.sutando/workspace (no fswatch dep)
+- `src/watch-tasks-stream.sh` — updated to thin wrapper (`exec node watch-tasks-stream.mjs`)
+- 15 tests in `tests/watch-tasks-stream-orphan.test.py` — all passing (T14 validates EPIPE exits in ≤5s)
+- Issue filed by Susan Xueqing Liu; reproduces 2026-05-23 4h task-loss incident (3 owner DMs unprocessed)
+- Note: cherry-pick to merge/stando-sync conflicted (stando-sync has divergent .mjs); will resolve at merge time
+
+**Pending push go-ahead** (new this pass):
+- `fix/watch-tasks-orphan-1088` (15 tests, `8751618`)

--- a/build_log.md
+++ b/build_log.md
@@ -1,0 +1,98 @@
+
+## Pass 207 (2026-05-25)
+
+**fix(health-check): multi-bridge source-path warn** (commit `d9a384c` on main):
+- `multiple processes` warn now shows full script paths per PID
+- Before: `2 PIDs: 25023,25065` — opaque, unactionable
+- After: `25023:/Applications/Sutando.app/.../discord-bridge.py, 25065:/Users/.../sutando/src/discord-bridge.py`
+- Root cause of dual-bridge: app-bundle startup.sh + dev repo both launched bridges at 5:20AM — different source paths, different workspaces
+- 5 structural tests in `tests/health-check-bridge-multi-pid.test.py`
+
+**Push go-ahead needed**: `main` branch has this commit (not yet pushed to origin/main).
+
+## Pass 208–209 (2026-05-25)
+
+**feat(content): Ep4 LinkedIn park walk post — READY TO POST**
+- Created `notes/linkedin-ep4-park-walk-final.md` — polished LinkedIn copy for Ep4
+- Text-only (Option C), no filming required — full narrative arc from Twitter thread expanded for LinkedIn
+- Supersedes `linkedin-ep4-draft.md` (that file has the stale Meeting Gap/Linear angle)
+- Status: copy-paste ready; posting window Tue–Thu 8–10am or 12–1pm local
+
+**feat(obsidian): mirror script + 44 tests** (already on `merge/stando-sync`, commit `34ecea7`):
+- `src/obsidian-mirror.py` — sonichi #1082 port, idempotency bug fixed in `_write_result_mirror`
+- `tests/obsidian-mirror.test.py` — 44 tests, all passing, importlib import pattern for hyphenated filename
+- `skills/obsidian-vault/SKILL.md`, `manifest.json`, `scripts/dream.py`, `tools.ts` ported
+
+**Pending push go-aheads**:
+- `port/watch-tasks-attempts-stando-63` (10 tests, `4852e48`)
+- `port/share-screen-standalone-1073` (4 tests, `6f3eca0`)
+- `port/result-channel-key-1090` (48 tests, `c138b2d`)
+- `port/za-warudo-mention-precedence-1091` (11 tests, `2b5828c`)
+- `port/codeql-stack-trace-1092` (10 tests, `cf10b7f`)
+- `merge/stando-sync` (162 commits ahead of origin/main)
+- `main` (health-check + obsidian-vault commits)
+- `fix/slack-bridge-py39-annotations` (3 tests added, commit `990fc11`)
+
+## Pass 210 (2026-05-25)
+
+**test(slack-bridge): py39 regression guard** (commit `990fc11` on `fix/slack-bridge-py39-annotations`):
+- Added 3 structural tests: `from __future__ import annotations` present + at top + `str | None` still exists
+- Branch now push-ready (was missing tests per "every script ships with tests" rule)
+
+**content(ep4): confirmed final LinkedIn post fixed + memory updated**:
+- `notes/linkedin-ep4-park-walk-final.md` corrected to Bassil's confirmed "THIS IS IT" version (shorter)
+- Earlier pass had an unapproved expanded draft — replaced with the exact confirmed text from memory
+- `project-always-on-content.md` memory updated: "filming pending" → text-only, files listed
+
+**Push go-ahead needed** (new additions this pass):
+- `fix/slack-bridge-py39-annotations` (3 tests, `990fc11`)
+
+## Pass 211 (2026-05-25)
+
+**feat(x-post): thread subcommand** (commit `07445a0` on `feat/x-post-thread-command`):
+- `skills/x-twitter/x-post.py` — added `thread` subcommand: reads `---`-delimited file, posts each section as reply-to-previous chain
+- `--dry-run` flag prints all tweets without API call; `--delay` controls inter-tweet gap (default 2s)
+- 9 tests in `tests/x-post-thread.test.py` — all passing
+- **Unlocks**: `python3 skills/x-twitter/x-post.py thread --file <path>` for Ep4, Ep5, WWDC threads
+
+**feat(content): WWDC June 10 dev thread file created** (`skills/x-twitter/threads/wwdc-2026-dev-thread.txt`):
+- 7-tweet dev angle: "Build your own proactive agent before Apple ships theirs"
+- Ready to post June 10 with: `python3 skills/x-twitter/x-post.py thread --file skills/x-twitter/threads/wwdc-2026-dev-thread.txt`
+- The note at `notes/wwdc-june10-dev-twitter-thread.md` referenced this file but it didn't exist — gap closed
+
+**Outreach signals (fresh scan 05:57 May 25):**
+- 12 signals, same as yesterday — no new companies, no fills
+- Carta CoS (Chief Product Officer) now day 3 — still open, highest urgency
+- Still blocked on HUNTER_API_KEY + INSTANTLY_API_KEY
+
+**Push go-ahead needed** (new this pass):
+- `feat/x-post-thread-command` (9 tests, `07445a0`)
+
+## Pass 212 (2026-05-25)
+
+**feat(content): Ep5 barber thread file + test** (commit `05181a4` on `feat/x-post-thread-command`):
+- `skills/x-twitter/threads/always-on-ep5-barber.txt` — 5-tweet thread for Ep5 barber chair delegation story
+- The concept note referenced this file but it didn't exist (same gap as WWDC dev thread, now closed)
+- 10/10 tests passing (added `test_ep5_thread_file_parseable`)
+- Post command: `python3 skills/x-twitter/x-post.py thread --file skills/x-twitter/threads/always-on-ep5-barber.txt`
+
+**Note (from Discord log):** agent-universe PR #48 (WebView OAuth fix) already merged — task was processed and result archived correctly.
+
+**All thread files now complete:**
+- Ep4: `always-on-ep4-park-walk.txt` (6 tweets) ✓
+- Ep5: `always-on-ep5-barber.txt` (5 tweets) ✓ NEW
+- Ep6 (park-demo): `always-on-ep6-park-demo.txt` ✓
+- WWDC dev (June 10): `wwdc-2026-dev-thread.txt` (7 tweets) ✓
+
+## Pass 213 (2026-05-25)
+
+**feat(cross-node-sync): configurable scope via JSON config (closes #1044)** (commit `a072033` on `feat/cross-node-sync-config-1044`):
+- `skills/cross-node-sync/scripts/setup-rsync-sync.sh` — reads `$SUTANDO_WORKSPACE/config/cross-node-sync.json` to enable/disable memory/notes/assets/data scopes independently
+- `_scope_enabled()` bash function with inline Python JSON parsing; falls back to all-enabled on missing file or invalid JSON
+- `skills/cross-node-sync/config/cross-node-sync.example.json` — example config ships with skill
+- 15 tests in `tests/cross-node-sync-config.test.py` — all passing; uses `patched_sync_peer()` context manager to work around `.env` loading that overrides env vars
+- Filed by Susan Xueqing Liu — enables per-operator customization without script PRs
+- Cherry-picked onto `merge/stando-sync` (`42fb28d`)
+
+**Pending push go-ahead** (new this pass):
+- `feat/cross-node-sync-config-1044` (15 tests, `a072033`)

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -874,9 +874,21 @@ def run_all_checks() -> list[dict]:
             checks.append({"name": name, "status": "warn", "detail": "configured but not running"})
             continue
 
-        # Check 1: Multiple processes (zombie/duplicate)
+        # Check 1: Multiple processes (zombie/duplicate).
+        # Show source paths so it's clear whether these are expected
+        # app-bundle vs dev-repo coexistence or accidental duplicate spawns.
         if len(pids) > 1:
-            checks.append({"name": name, "status": "warn", "detail": f"multiple processes ({len(pids)} PIDs: {','.join(pids)})"})
+            def _pid_script(pid: str) -> str:
+                try:
+                    r = subprocess.run(["/bin/ps", "-p", pid, "-o", "command="],
+                                       capture_output=True, text=True, timeout=3)
+                    parts = r.stdout.strip().split()
+                    py_args = [p for p in parts if p.endswith(".py")]
+                    return py_args[-1] if py_args else "?"
+                except Exception:
+                    return "?"
+            pid_paths = ", ".join(f"{p}:{_pid_script(p)}" for p in pids)
+            checks.append({"name": name, "status": "warn", "detail": f"multiple processes ({len(pids)} PIDs: {pid_paths})"})
             continue
 
         # Check 2: Log file freshness — prefer logs/ (where startup.sh writes)

--- a/tests/daily-insight-analyzers.test.py
+++ b/tests/daily-insight-analyzers.test.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Behavioral tests for `src/daily-insight.py` pure analysis functions.
+
+Functions under test — all are pure (list-in, value-out, no file I/O):
+
+  analyze_call_timing(calls)   — (hour_counts, day_counts) Counters
+  analyze_call_duration(calls) — dict of duration stats | None
+  analyze_topics(calls)        — top-10 [(word, count)] from summaries
+
+Run: python3 tests/daily-insight-analyzers.test.py
+Exit: 0 on pass, non-zero on fail.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_SRC = REPO / "src"
+
+# -----------------------------------------------------------------------
+# Module loader — daily-insight.py resolves CALLS_FILE / NOTES_DIR at
+# import time; redirect workspace to a temp dir so load_calls() is a
+# no-op and note scanning finds no files.
+# -----------------------------------------------------------------------
+_WS = tempfile.mkdtemp(prefix="sutando-test-insight-")
+os.environ["SUTANDO_WORKSPACE"] = _WS
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+for _n in ("daily_insight", "daily-insight", "workspace_default", "util_paths"):
+    sys.modules.pop(_n, None)
+
+_spec = importlib.util.spec_from_file_location("daily_insight", _SRC / "daily-insight.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+analyze_call_timing = _mod.analyze_call_timing
+analyze_call_duration = _mod.analyze_call_duration
+analyze_topics = _mod.analyze_topics
+
+# -----------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------
+
+PASS = 0
+FAIL = 0
+
+
+def ok(label: str) -> None:
+    global PASS
+    PASS += 1
+    print(f"PASS  {label}")
+
+
+def fail(label: str, detail: str = "") -> None:
+    global FAIL
+    FAIL += 1
+    print(f"FAIL  {label}" + (f": {detail}" if detail else ""))
+
+
+def _call(start_time: str = "", duration: int = 0, summary: str = "") -> dict:
+    c: dict = {}
+    if start_time:
+        c["start_time"] = start_time
+    if duration:
+        c["duration_seconds"] = duration
+    if summary:
+        c["summary"] = summary
+    return c
+
+
+# -----------------------------------------------------------------------
+# analyze_call_timing
+# -----------------------------------------------------------------------
+
+# T1 — empty list → both counters empty
+hour_c, day_c = analyze_call_timing([])
+if not hour_c and not day_c:
+    ok("T1: analyze_call_timing([]) → both counters empty")
+else:
+    fail("T1: empty list", f"hour_c={dict(hour_c)} day_c={dict(day_c)}")
+
+# T2 — single call at known hour → hour counter incremented
+# 2026-05-26T14:00:00Z → hour 14 (UTC), Tuesday
+hour_c, day_c = analyze_call_timing([_call("2026-05-26T14:00:00Z")])
+if hour_c.get(14) == 1:
+    ok("T2: single call at 14:00Z → hour 14 count = 1")
+else:
+    fail("T2: hour counter", f"hour_c={dict(hour_c)}")
+
+# T3 — day-of-week counter incremented
+# 2026-05-26 is a Tuesday
+hour_c, day_c = analyze_call_timing([_call("2026-05-26T09:00:00Z")])
+if day_c.get("Tuesday") == 1:
+    ok("T3: 2026-05-26 (Tuesday) → day_counts['Tuesday'] = 1")
+else:
+    fail("T3: day counter", f"day_c={dict(day_c)}")
+
+# T4 — multiple calls accumulate counts in the same hour
+calls = [
+    _call("2026-05-26T10:00:00Z"),
+    _call("2026-05-26T10:30:00Z"),
+    _call("2026-05-26T15:00:00Z"),
+]
+hour_c, day_c = analyze_call_timing(calls)
+if hour_c.get(10) == 2 and hour_c.get(15) == 1:
+    ok("T4: two calls at 10:xx, one at 15:xx → hour 10 count=2, hour 15 count=1")
+else:
+    fail("T4: accumulate hours", f"hour_c={dict(hour_c)}")
+
+# T5 — malformed timestamp → skipped, no crash, counter still works for valid calls
+calls = [
+    {"start_time": "not-a-date"},
+    _call("2026-05-26T08:00:00Z"),
+]
+hour_c, day_c = analyze_call_timing(calls)
+if hour_c.get(8) == 1 and sum(hour_c.values()) == 1:
+    ok("T5: malformed timestamp skipped, valid call still counted")
+else:
+    fail("T5: malformed ts skip", f"hour_c={dict(hour_c)}")
+
+# T6 — call with no start_time field → skipped
+calls = [{"duration_seconds": 120}, _call("2026-05-26T11:00:00Z")]
+hour_c, day_c = analyze_call_timing(calls)
+if sum(hour_c.values()) == 1:
+    ok("T6: call with no start_time field skipped gracefully")
+else:
+    fail("T6: no start_time skip", f"hour_c total={sum(hour_c.values())}")
+
+# T7 — +00:00 offset parsed (not just Z suffix)
+hour_c, day_c = analyze_call_timing([_call("2026-05-26T16:00:00+00:00")])
+if hour_c.get(16) == 1:
+    ok("T7: +00:00 offset timestamp parsed (hour 16 counted)")
+else:
+    fail("T7: +00:00 offset", f"hour_c={dict(hour_c)}")
+
+# -----------------------------------------------------------------------
+# analyze_call_duration
+# -----------------------------------------------------------------------
+
+# T8 — empty list → None
+result = analyze_call_duration([])
+if result is None:
+    ok("T8: analyze_call_duration([]) → None")
+else:
+    fail("T8: empty → None", f"got {result!r}")
+
+# T9 — single call: count=1, avg correct, longest = avg
+result = analyze_call_duration([_call(duration=120)])
+if result is not None and result["count"] == 1 and result["avg_minutes"] == 2.0 and result["longest_minutes"] == 2.0:
+    ok("T9: single 120s call → count=1, avg=2.0min, longest=2.0min")
+else:
+    fail("T9: single call stats", f"result={result}")
+
+# T10 — avg_minutes rounds to 1 decimal
+# 3 calls: 60+90+90 = 240s → avg=80s = 1.3min
+result = analyze_call_duration([_call(duration=60), _call(duration=90), _call(duration=90)])
+if result is not None and result["avg_minutes"] == 1.3 and result["longest_minutes"] == 1.5:
+    ok("T10: avg_minutes and longest_minutes rounded to 1 decimal (240s / 3 = 80s = 1.3 min)")
+else:
+    fail("T10: rounding", f"result={result}")
+
+# T11 — long_call_pct: calls >2× average are counted
+# avg = 60s; a 130s call is >2×60 = long
+result = analyze_call_duration([_call(duration=60), _call(duration=60), _call(duration=60), _call(duration=130)])
+# avg = (60+60+60+130)/4 = 77.5s; 2*77.5 = 155; 130 < 155 → 0 long calls
+# Let's use more extreme: avg around 60, one very long call
+result = analyze_call_duration([_call(duration=60), _call(duration=60), _call(duration=300)])
+# avg = (60+60+300)/3 = 140s; 2*140 = 280; 300 > 280 → 1 long call out of 3 → 33.3%
+if result is not None and result["long_call_pct"] > 0:
+    ok(f"T11: 1/3 calls >2× average → long_call_pct={result['long_call_pct']}% (>0)")
+else:
+    fail("T11: long_call_pct", f"result={result}")
+
+# T12 — duration=0 skipped
+result = analyze_call_duration([{"duration_seconds": 0}, _call(duration=120)])
+if result is not None and result["count"] == 1:
+    ok("T12: duration=0 skipped, only valid call counted (count=1)")
+else:
+    fail("T12: zero duration skip", f"result={result}")
+
+# T13 — non-numeric duration skipped
+result = analyze_call_duration([{"duration_seconds": "unknown"}, _call(duration=60)])
+if result is not None and result["count"] == 1:
+    ok("T13: non-numeric duration skipped gracefully (count=1)")
+else:
+    fail("T13: non-numeric duration", f"result={result}")
+
+# T14 — all durations zero → None (no valid durations)
+result = analyze_call_duration([{"duration_seconds": 0}, {"duration_seconds": 0}])
+if result is None:
+    ok("T14: all durations zero → None")
+else:
+    fail("T14: all zero → None", f"got {result!r}")
+
+# -----------------------------------------------------------------------
+# analyze_topics
+# -----------------------------------------------------------------------
+
+# T15 — empty list → empty result
+result = analyze_topics([])
+if result == []:
+    ok("T15: analyze_topics([]) → empty list")
+else:
+    fail("T15: empty → []", f"got {result!r}")
+
+# T16 — short words (≤4 chars) filtered out
+result = analyze_topics([_call(summary="the cat sat and did run")])
+words = [w for w, _ in result]
+short_leaked = [w for w in words if len(w) <= 4]
+if not short_leaked:
+    ok("T16: short words (≤4 chars) filtered out of topics")
+else:
+    fail("T16: short word filter", f"leaked: {short_leaked}")
+
+# T17 — common stop-words filtered out
+# "about", "their", "there", "would", etc. should not appear
+result = analyze_topics([_call(summary="about their ideas would there should which where")])
+words = [w for w, _ in result]
+stop_leaked = [w for w in words if w in {"about", "their", "there", "would", "should", "which", "where"}]
+if not stop_leaked:
+    ok("T17: stop-words (about/their/there/would/should/which/where) filtered out")
+else:
+    fail("T17: stop-word filter", f"leaked: {stop_leaked}")
+
+# T18 — substantive words counted and returned
+result = analyze_topics([
+    _call(summary="machine learning pipeline"),
+    _call(summary="machine learning dashboard"),
+])
+words = [w for w, _ in result]
+if "machine" in words and "learning" in words:
+    ok("T18: 'machine' and 'learning' both appear (>4 chars, not stop-words)")
+else:
+    fail("T18: substantive words in result", f"words={words}")
+
+# T19 — topic counts reflect repetition frequency
+result = analyze_topics([
+    _call(summary="scheduling meeting scheduling meeting scheduling"),
+    _call(summary="scheduling followup"),
+])
+# "scheduling" appears 4x, "meeting" 2x, "followup" 1x
+counts = dict(result)
+if counts.get("scheduling", 0) > counts.get("meeting", 0) > counts.get("followup", 0):
+    ok("T19: scheduling > meeting > followup (frequency order preserved)")
+else:
+    fail("T19: topic frequency order", f"counts={counts}")
+
+# T20 — at most 10 topics returned
+# Create 15 distinct long-enough words
+words_input = " ".join([f"keyword{i:02d}" for i in range(15)])
+result = analyze_topics([_call(summary=words_input)])
+if len(result) <= 10:
+    ok(f"T20: analyze_topics returns at most 10 topics (got {len(result)})")
+else:
+    fail("T20: top-10 cap", f"returned {len(result)} topics")
+
+# T21 — punctuation stripped from word boundaries
+result = analyze_topics([_call(summary="scheduling. meeting! pipeline? dashboard,")])
+words = [w for w, _ in result]
+punctuated = [w for w in words if any(c in w for c in ".,!?()[]{}:;\"'")]
+if not punctuated:
+    ok("T21: punctuation stripped from word boundaries (no leaked punctuation in topics)")
+else:
+    fail("T21: punctuation strip", f"leaked punctuation in: {punctuated}")
+
+# T22 — calls with no summary field → skipped gracefully
+result = analyze_topics([{"duration_seconds": 60}, _call(summary="analysis pipeline")])
+words = [w for w, _ in result]
+if "analysis" in words or "pipeline" in words:
+    ok("T22: call with no summary skipped; valid summary still processed")
+else:
+    fail("T22: missing summary field", f"words={words}")
+
+# -----------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------
+print(f"\n{PASS}/{PASS + FAIL} tests passed")
+if FAIL:
+    sys.exit(1)

--- a/tests/health-check-bridge-multi-pid.test.py
+++ b/tests/health-check-bridge-multi-pid.test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Regression guard: health-check multiple-bridge-process warn shows source paths.
+
+Before this fix, the warn read:
+  "multiple processes (2 PIDs: 25023,25065)"
+
+That gave no hint whether the two instances were an expected app-bundle +
+dev-repo coexistence or an accidental duplicate spawn of the same script.
+After the fix the warn reads:
+  "multiple processes (2 PIDs: 25023:/Applications/Sutando.app/.../discord-bridge.py,
+                                 25065:/Users/.../sutando/src/discord-bridge.py)"
+
+These tests verify the new path-enriched format via source-grep (no live
+process required).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = (REPO / "src" / "health-check.py").read_text(encoding="utf-8")
+
+
+def test_pid_script_helper_defined():
+    """health-check.py defines a _pid_script helper for path extraction."""
+    assert "_pid_script" in SRC, (
+        "_pid_script helper not found in health-check.py — "
+        "multiple-bridge warn will not show source paths"
+    )
+
+
+def test_pid_script_uses_ps_command():
+    """_pid_script extracts the script path from `ps -p <pid> -o command=`."""
+    assert '"-o", "command="' in SRC or "command=" in SRC, (
+        "health-check.py doesn't call `ps -o command=` to extract bridge script path"
+    )
+
+
+def test_pid_paths_in_warn_detail():
+    """The multi-pid warn uses pid_paths (enriched with source paths)."""
+    assert "pid_paths" in SRC, (
+        "pid_paths variable not found — multi-pid warn won't include source paths"
+    )
+
+
+def test_warn_format_uses_pid_paths():
+    """The actual warn detail string uses pid_paths, not the bare pids join."""
+    # Old pattern: f"...PIDs: {','.join(pids)})"
+    # New pattern: f"...PIDs: {pid_paths})"
+    assert "pid_paths}" in SRC, (
+        "multi-pid warn detail does not reference pid_paths — "
+        "source paths won't appear in health-check output"
+    )
+
+
+def test_py_args_extraction():
+    """_pid_script filters for .py args to find the script path."""
+    assert ".endswith(\".py\")" in SRC or '.endswith(".py")' in SRC, (
+        "_pid_script does not filter for .py args — may return wrong path component"
+    )
+
+
+def main():
+    tests = [
+        test_pid_script_helper_defined,
+        test_pid_script_uses_ps_command,
+        test_pid_paths_in_warn_detail,
+        test_warn_format_uses_pid_paths,
+        test_py_args_extraction,
+    ]
+    failures = []
+    for fn in tests:
+        try:
+            fn()
+            print(f"  ✓ {fn.__name__}")
+        except AssertionError as e:
+            failures.append(f"{fn.__name__}: {e}")
+            print(f"  ✗ {fn.__name__}: {e}")
+    print()
+    if failures:
+        print(f"{len(failures)} test(s) failed ({len(tests) - len(failures)} passed).")
+        sys.exit(1)
+    print(f"All {len(tests)} bridge-multi-pid tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `tests/daily-insight-analyzers.test.py` with 22 behavioral tests covering the three pure functions in `src/daily-insight.py`
- These functions were completely untested — `daily-insight.py` had no test file at all
- No file I/O required: call fixtures are built inline; module imported into a temp workspace

## Functions under test

| Function | Tests | Key cases |
|---|---|---|
| `analyze_call_timing(calls)` | T1–T7 | Empty → empty counters; hour bucket correct; day-of-week correct; accumulation; malformed ts skipped; missing field skipped; +00:00 offset parsed |
| `analyze_call_duration(calls)` | T8–T14 | Empty → None; single call avg/longest; 1-decimal rounding; long_call_pct >2× threshold; duration=0 skipped; non-numeric skipped; all-zero → None |
| `analyze_topics(calls)` | T15–T22 | Empty → []; ≤4-char words filtered; stop-words filtered; substantive words returned; frequency order preserved; top-10 cap; punctuation stripped; missing summary field skipped |

## Test plan

- [x] 22/22 tests pass (`python3 tests/daily-insight-analyzers.test.py`)
- [x] Fixed `Counter.total()` → `sum(counter.values())` for Python 3.9 compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)