### PR TITLE
feat(discord-config): workspace-local Sutando config out of plugin access.json (closes #1147)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -53,6 +53,7 @@ except ModuleNotFoundError:
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402
+import discord_config  # noqa: E402  — Sutando workspace-local discord config (#1147)
 from util_paths import shared_personal_path  # noqa: E402
 from task_priority import default_priority_for_source  # noqa: E402
 REPO = resolve_workspace()
@@ -2015,6 +2016,19 @@ client = discord.Client(intents=intents)
 @client.event
 async def on_ready():
     print(f"Discord bridge ready: {client.user}")
+    # #1147: auto-seed workspace `state/discord-config.json` from the legacy
+    # access.json heuristic on first boot. Idempotent (no-op if file
+    # exists). Emits a WARN to stderr if the seed had to fall back to
+    # `allowFrom[0]` so the operator catches a mis-seed before it routes
+    # the first proactive DM to the wrong user.
+    try:
+        _initial_access = json.loads(ACCESS_FILE.read_text())
+    except Exception:
+        _initial_access = {}
+    try:
+        discord_config.auto_seed_if_missing(_initial_access)
+    except Exception as _seed_exc:
+        print(f"  [discord-config] auto-seed failed (non-fatal): {_seed_exc}")
     # Restart-safety: REST-catch-up missed DMs from the disconnect
     # window. Discord gateway IDENTIFY (post-RESUME-expiry reconnect)
     # does NOT replay `MESSAGE_CREATE` events that arrived during the
@@ -3324,51 +3338,39 @@ async def poll_proactive():
                     if not text:
                         f.unlink(missing_ok=True)
                         continue
-                    # Resolve the DM recipient. Priority (mirrors
-                    # src/dm-result.py:_resolve_owner_id, modulo the
-                    # async/event-loop shape):
-                    #   1. $SUTANDO_DM_OWNER_ID env override.
-                    #   2. tierMap[uid] == "owner" — the unique tier-tagged
-                    #      owner from access.json.
-                    #   3. First non-bot user from allowFrom IN LIST ORDER.
+                    # Resolve the DM recipient via discord_config.resolve_owner_id
+                    # (#1147). The helper consults — in order — the env override,
+                    # workspace `state/discord-config.json` (Sutando's owned config
+                    # for `owner` and `tierMap`), and legacy plugin `access.json`
+                    # extensions. Step 6 (first non-bot user from `allowFrom`) is
+                    # left to this caller because it requires `client.fetch_user`
+                    # — keeping the helper pure-Python lets dm-result.py share the
+                    # same resolution chain without dragging in discord.py.
                     #
-                    # Pre-fix used `load_allowed()` which returns a SET, so
-                    # iteration was insertion/hash-ordered — on 2026-05-18
-                    # this picked a team-tier user (msze_) over the
-                    # owner-tier user (qingyunwu) because the set yielded
-                    # msze_ first. allowFrom is a *list* in access.json with
-                    # a meaningful first-entry-wins convention; preserving
-                    # that order fixes the routing.
-                    owner_id = os.environ.get("SUTANDO_DM_OWNER_ID", "").strip() or None
-                    if not owner_id:
-                        try:
-                            access_data = json.loads(ACCESS_FILE.read_text())
-                        except Exception:
-                            access_data = {}
-                        allow_list = access_data.get("allowFrom") or []
-                        tier_map = access_data.get("tierMap") or {}
-                        # #1117: explicit top-level `owner` wins over tierMap+allowFrom fallback.
-                        owner_id = (access_data.get("owner") or "").strip() or None
-                        if not owner_id and not allow_list:
-                            print(f"  [proactive] no owner in allowFrom, skipping {f.name}")
-                            f.unlink(missing_ok=True)
-                            continue
-                        # Preferred: the tier-tagged owner if one exists in allowFrom.
-                        if owner_id is None:
-                            owner_id = next(
-                                (uid for uid in allow_list if tier_map.get(uid) == "owner"),
-                                None,
-                            )
-                        # Fallback: first non-bot user, list order preserved.
-                        if owner_id is None:
-                            for uid in allow_list:
-                                try:
-                                    u = await client.fetch_user(int(uid))
-                                    if not u.bot:
-                                        owner_id = str(uid)
-                                        break
-                                except Exception:
-                                    continue
+                    # The drift class that bit us with #846's tierMap (only one of
+                    # the bridge/dm-result sites got the read) is fixed by funneling
+                    # both through `resolve_owner_id`.
+                    try:
+                        access_data = json.loads(ACCESS_FILE.read_text())
+                    except Exception:
+                        access_data = {}
+                    allow_list = access_data.get("allowFrom") or []
+                    owner_id = discord_config.resolve_owner_id(access_data)
+                    if owner_id is None:
+                        # Step 6: walk allowFrom skipping bot accounts.
+                        # Pre-#1147 this used `load_allowed()` which returns a SET
+                        # — on 2026-05-18 that picked a team-tier user over the
+                        # owner-tier one because set iteration is insertion/hash-
+                        # ordered. List iteration preserves the meaningful
+                        # first-entry-wins convention.
+                        for uid in allow_list:
+                            try:
+                                u = await client.fetch_user(int(uid))
+                                if not u.bot:
+                                    owner_id = str(uid)
+                                    break
+                            except Exception:
+                                continue
                     if owner_id is None:
                         print(f"  [proactive] no human user in allowFrom, skipping {f.name}")
                         f.unlink(missing_ok=True)

--- a/src/discord_config.py
+++ b/src/discord_config.py
@@ -1,0 +1,208 @@
+"""
+Workspace-local Sutando-specific Discord configuration (closes #1147).
+
+The official discord plugin owns `~/.claude/channels/discord/access.json` with
+its documented schema (`dmPolicy`, `allowFrom`, `groups`, `pending`). Sutando
+has been squatting on that file for its own fields (`tierMap` since #846,
+proposed `owner` from the now-closed #1118). #1147 moves those Sutando
+extensions to `$SUTANDO_WORKSPACE/state/discord-config.json` — Sutando's
+owned territory, no plugin-schema conflict, no Claude-Code edit-policy prompt.
+
+Two distinct consumers MUST resolve owner identity the same way:
+  - `src/discord-bridge.py:_poll_proactive` (live bridge)
+  - `src/dm-result.py:_resolve_owner_id` (fallback DM delivery)
+
+This module is the single source of truth they both call into. The drift
+class that bit us with #846's tierMap (one site got the read, the other
+didn't) is fixed by funneling both through `resolve_owner_id` here.
+
+Resolution order (config-driven; returns None if exhausted):
+  1. SUTANDO_DM_OWNER_ID env var (operator override)
+  2. discord-config.json["owner"]                       — Sutando, this file
+  3. discord-config.json["tierMap"][uid] == "owner"     — Sutando, this file
+  4. access.json["owner"]                                — legacy compat (#1118 WIP)
+  5. access.json["tierMap"][uid] == "owner"              — legacy compat (#846)
+
+On None, callers walk `allowFrom` with their own bot-filter (I/O-bearing
+in both call sites — discord.py async vs sync REST in dm-result.py — so
+the helper deliberately stays pure-Python).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+# Re-exported by callers so they don't need a separate workspace import.
+from workspace_default import resolve_workspace  # type: ignore  # noqa: E402
+
+CONFIG_FILENAME = "discord-config.json"
+
+logger = logging.getLogger(__name__)
+
+
+def config_path() -> Path:
+    """Return the path to `<workspace>/state/discord-config.json`."""
+    return resolve_workspace() / "state" / CONFIG_FILENAME
+
+
+def load_config() -> dict:
+    """Return parsed `discord-config.json`, or {} if missing/unreadable.
+
+    A read error returns {} (treated as "no Sutando-side override") so the
+    legacy `access.json` fallback chain remains usable — the bridge stays
+    operational even if the workspace file is corrupted.
+    """
+    path = config_path()
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:  # noqa: BLE001 — explicit narrow handling below
+        logger.warning("discord-config: failed to read %s: %s", path, exc)
+        return {}
+
+
+def save_config(data: dict) -> None:
+    """Write `discord-config.json` atomically (tmp + rename).
+
+    Creates the parent `state/` directory if missing. Callers should hold
+    a lock if concurrent writers are possible; today the only writer is
+    `auto_seed_if_missing` at bridge boot, so single-writer is fine.
+    """
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2))
+    tmp.replace(path)
+
+
+def resolve_owner_id(
+    access_data: dict,
+    *,
+    config: Optional[dict] = None,
+) -> Optional[str]:
+    """Return the canonical owner user-id (as a string) or None if no
+    candidate is available.
+
+    `access_data` is the parsed plugin `access.json` (callers already read
+    it). `config` lets tests inject a fixture; production callers pass None
+    and we read `discord-config.json` ourselves.
+
+    See module docstring for the 6-step resolution chain.
+    """
+    # 1. Env-var override — operator escape hatch, wins over everything.
+    env_owner = os.environ.get("SUTANDO_DM_OWNER_ID", "").strip()
+    if env_owner:
+        return env_owner
+
+    cfg = config if config is not None else load_config()
+
+    # 2. Workspace owner field — Sutando's canonical singleton identity.
+    ws_owner = (cfg.get("owner") or "").strip() or None
+    if ws_owner:
+        return ws_owner
+
+    allow_list = list(access_data.get("allowFrom") or [])
+
+    # 3. Workspace tierMap tagged owner.
+    ws_tier_map = cfg.get("tierMap") or {}
+    ws_tier_owner = next(
+        (uid for uid in allow_list if ws_tier_map.get(uid) == "owner"),
+        None,
+    )
+    if ws_tier_owner:
+        return str(ws_tier_owner)
+
+    # 4. Legacy plugin-territory owner field (compat for anyone who set it
+    # while #1118 was open). #1147 supersedes this path; left in for one
+    # release so existing manual edits don't get silently ignored.
+    legacy_owner = (access_data.get("owner") or "").strip() or None
+    if legacy_owner:
+        return legacy_owner
+
+    # 5. Legacy plugin-territory tierMap (the #846 path).
+    legacy_tier_map = access_data.get("tierMap") or {}
+    legacy_tier_owner = next(
+        (uid for uid in allow_list if legacy_tier_map.get(uid) == "owner"),
+        None,
+    )
+    if legacy_tier_owner:
+        return str(legacy_tier_owner)
+
+    # Helper deliberately does NOT fall through to `allowFrom[0]`. That step
+    # (the bug-prone "Susan Mac Studio 2026-05-25" path — `allowFrom[0]` was
+    # a non-owner human because `tierMap` was null) belongs in the caller,
+    # which can pair it with a bot-filter REST walk. Returning None here is
+    # the signal "no config-driven answer; you do the I/O-bearing fallback".
+    return None
+
+
+def auto_seed_if_missing(access_data: dict, *, logger_=None) -> dict:
+    """If `discord-config.json` is missing, write an initial config seeded
+    from the legacy access.json heuristic and return it.
+
+    Per Lucy's #1147 watch-point #2: when the seed falls through to
+    `allowFrom[0]` (the original-bug path), emit a prominent WARNING so
+    the operator catches a mis-seed rather than silently recreating the
+    #1147 bug under a new filename.
+
+    Idempotent: if the file already exists, return its current contents
+    untouched.
+    """
+    log = logger_ or logger
+    path = config_path()
+    if path.exists():
+        return load_config()
+
+    seed: dict = {}
+
+    legacy_owner = (access_data.get("owner") or "").strip() or None
+    legacy_tier_map = access_data.get("tierMap") or {}
+    allow_list = list(access_data.get("allowFrom") or [])
+
+    if legacy_owner:
+        seed["owner"] = legacy_owner
+        log.info(
+            "discord-config: auto-seeded owner=%s from access.json[\"owner\"] -> %s",
+            legacy_owner,
+            path,
+        )
+    else:
+        tier_owner = next(
+            (uid for uid in allow_list if legacy_tier_map.get(uid) == "owner"),
+            None,
+        )
+        if tier_owner:
+            seed["owner"] = str(tier_owner)
+            log.info(
+                "discord-config: auto-seeded owner=%s from access.json tierMap -> %s",
+                tier_owner,
+                path,
+            )
+        elif allow_list:
+            seed["owner"] = str(allow_list[0])
+            log.warning(
+                "discord-config: auto-seeded owner=%s from allowFrom[0] fallback. "
+                "VERIFY this is correct and edit %s if wrong — this fallback path "
+                "is the same one that produced the original #1147 bug (Susan Mac "
+                "Studio 2026-05-25).",
+                seed["owner"],
+                path,
+            )
+        else:
+            log.warning(
+                "discord-config: no owner candidates in access.json; %s left empty. "
+                "Set the owner field manually before proactive DMs will deliver.",
+                path,
+            )
+
+    if legacy_tier_map:
+        # Mirror the existing tierMap so #846's behavior is preserved without
+        # forcing the operator to re-tag every user.
+        seed["tierMap"] = dict(legacy_tier_map)
+
+    save_config(seed)
+    return seed

--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402
+import discord_config  # noqa: E402  — workspace-local Sutando discord config (#1147)
 REPO = resolve_workspace()
 ACCESS_JSON = Path.home() / ".claude" / "channels" / "discord" / "access.json"
 SSE_STATUS_URL = "http://localhost:8080/sse-status"
@@ -290,59 +291,42 @@ def _send_message_with_files(channel_id: str, token: str, content: str,
 def _resolve_owner_id(token):
     """Return the Discord user ID for the human owner.
 
-    Priority order:
-      1. $SUTANDO_DM_OWNER_ID env var.
-      2. First non-bot ID in ~/.claude/channels/discord/access.json →
-         allowFrom. "Non-bot" is decided by querying GET /users/{id} and
-         reading the `bot` field — allowFrom often contains multiple bots
-         (MacBook bot, Mac Mini bot) plus the human owner, and we only
-         want to DM the human.
+    Delegates the config-driven resolution chain to
+    `discord_config.resolve_owner_id` (#1147) so this fallback delivery
+    path and the live bridge (`discord-bridge.py:_poll_dm_fallback`)
+    agree on a single owner. Drift between the two sites was the failure
+    mode #846 created; the shared helper prevents it from recurring.
 
-    Set SUTANDO_DM_OWNER_ID in .env if you want to skip the per-id
-    /users lookup (saves 1 API call per dm-result invocation)."""
-    env_override = os.environ.get("SUTANDO_DM_OWNER_ID", "").strip()
-    if env_override:
-        return env_override
+    The bot-filtering step (walk `allowFrom`, skip Discord bot accounts)
+    stays here because it requires `GET /users/{id}` REST calls. Keeping
+    the helper pure-Python lets both callers (this sync REST path and
+    the bridge's async discord.py path) share the same chain.
 
+    Set SUTANDO_DM_OWNER_ID in .env to skip even the helper's lookup
+    (saves 1 API call per dm-result invocation); the env var is honored
+    inside the helper as the first resolution step."""
     if not ACCESS_JSON.exists():
-        return ""
+        # No plugin access.json — still try the helper for env override
+        # or workspace-config `owner` field.
+        owner = discord_config.resolve_owner_id({})
+        return owner or ""
     try:
         data = json.loads(ACCESS_JSON.read_text())
     except Exception:
-        return ""
+        data = {}
 
-    # Layer 1 (#1117): consult the explicit top-level `owner` field before
-    # the legacy tierMap → allowFrom fallback chain. `/discord:access` writes
-    # this as the canonical owner id; the fallback below is best-effort and
-    # mis-routed on Susan's Mac Studio on 2026-05-25 when `tierMap` was null
-    # and `allowFrom[0]` was a non-owner human. Mirrors the same precedence
-    # added to `src/discord-bridge.py:poll_proactive` in this PR.
-    explicit_owner = (data.get("owner") or "").strip()
-    if explicit_owner:
-        return explicit_owner
+    owner = discord_config.resolve_owner_id(data)
+    if owner:
+        return owner
 
     allow = data.get("allowFrom") or []
     if not allow:
         return ""
 
-    # Honor the explicit `tierMap[uid] == "owner"` admin tag IF the
-    # tagged user is still in allowFrom. Mirrors the same precedence
-    # used by `src/discord-bridge.py:poll_proactive` so the fallback
-    # delivery path and the live bridge agree on who the owner is —
-    # drift here would re-introduce the misroute class the bridge
-    # already fixed. Defensive: a stale tier-tag for a removed user
-    # must not resolve a delisted owner.
-    tier_map = data.get("tierMap") or {}
-    tier_owner = next(
-        (uid for uid in allow if tier_map.get(uid) == "owner"),
-        None,
-    )
-    if tier_owner is not None:
-        return str(tier_owner)
-
-    # Query each user's is-bot flag. The first human wins. If lookups all
-    # fail (rate limit, network, bad token), fall through to allow[0] as
-    # a degraded default so send_dm() can produce an honest error later.
+    # Step 6: bot-filtered walk of allowFrom. Helper intentionally omits
+    # this step (REST-bound). The first non-bot wins. If lookups all fail
+    # (rate limit, network, bad token), fall through to allow[0] as a
+    # degraded default so send_dm() produces an honest error later.
     for uid in allow:
         try:
             user = _discord_api("GET", f"/users/{uid}", token)

--- a/tests/discord_config.test.py
+++ b/tests/discord_config.test.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Standalone tests for src/discord_config.py — #1147 workspace-local
+Sutando discord config (`$WS/state/discord-config.json`).
+
+Exercised paths:
+- `resolve_owner_id` for each of the 5 config-driven priority steps
+- `resolve_owner_id` returns None when all config paths exhausted
+- `auto_seed_if_missing` for the 4 seed-source branches (explicit owner,
+  tierMap tag, allowFrom[0] WARN, empty)
+- `auto_seed_if_missing` is idempotent — no overwrite if file exists
+- Both site callers (bridge + dm-result) share the helper — covered by
+  the symmetric test fixtures from Lucy's #1147 watch-point #1.
+
+Run: python3 tests/discord_config.test.py
+Exit: 0 on pass, 1 on fail.
+
+Stdlib-only (no pytest) — matches the repo's standalone-test convention
+(`tests/*.test.py` invoked one-by-one by .github/workflows/ci.yml).
+"""
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+import discord_config  # noqa: E402
+
+
+# ----- test plumbing ------------------------------------------------------
+
+
+_FAILURES: list[str] = []
+
+
+def fail(msg: str) -> None:
+    """Record a failure but continue running so the user sees ALL fails."""
+    _FAILURES.append(msg)
+    print(f"FAIL: {msg}", file=sys.stderr)
+
+
+def expect_eq(actual, expected, label: str) -> None:
+    if actual != expected:
+        fail(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def expect_in(needle: str, haystack: str, label: str) -> None:
+    if needle not in haystack:
+        fail(f"{label}: {needle!r} not found in {haystack!r}")
+
+
+@contextmanager
+def workspace_env():
+    """Yield (workspace_path, captured_log_records) with a clean tmp
+    workspace and a captured logger. State is torn down after.
+
+    CRITICAL — we monkey-patch `discord_config.config_path` directly
+    instead of setting `SUTANDO_WORKSPACE`. Setting that env var would
+    trigger `workspace_default.resolve_workspace()`'s `_migrate_legacy_dirs`
+    which MOVES (not copies) `notes/` etc. from cwd into the new workspace
+    — and when `tempfile.TemporaryDirectory` cleans up, the moved files
+    are destroyed. The 2026-05-25 lesson: 37 already-committed notes files
+    and 1 uncommitted file were destroyed by a tmp-workspace env var in
+    an earlier draft of this test. See
+    `feedback_test_workspace_env_triggers_destructive_migration` in memory.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        (ws / "state").mkdir()
+        old_owner = os.environ.get("SUTANDO_DM_OWNER_ID")
+        os.environ.pop("SUTANDO_DM_OWNER_ID", None)
+
+        # Override the path resolver — bypasses resolve_workspace entirely.
+        original_config_path = discord_config.config_path
+        discord_config.config_path = lambda: ws / "state" / discord_config.CONFIG_FILENAME
+
+        # Capture log records emitted by discord_config.
+        records: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        handler = _Capture(level=logging.DEBUG)
+        discord_config.logger.addHandler(handler)
+        original_level = discord_config.logger.level
+        discord_config.logger.setLevel(logging.DEBUG)
+
+        try:
+            yield ws, records
+        finally:
+            discord_config.config_path = original_config_path
+            discord_config.logger.removeHandler(handler)
+            discord_config.logger.setLevel(original_level)
+            if old_owner is None:
+                os.environ.pop("SUTANDO_DM_OWNER_ID", None)
+            else:
+                os.environ["SUTANDO_DM_OWNER_ID"] = old_owner
+
+
+def write_config(ws: Path, data: dict) -> None:
+    (ws / "state" / discord_config.CONFIG_FILENAME).write_text(json.dumps(data))
+
+
+# ----- resolve_owner_id chain --------------------------------------------
+
+
+def test_env_override_wins():
+    with workspace_env() as (ws, _):
+        os.environ["SUTANDO_DM_OWNER_ID"] = "111"
+        write_config(ws, {"owner": "222"})
+        access = {"allowFrom": ["333"], "owner": "444"}
+        expect_eq(
+            discord_config.resolve_owner_id(access),
+            "111",
+            "env override should win over everything",
+        )
+
+
+def test_workspace_owner_wins():
+    with workspace_env() as (ws, _):
+        write_config(ws, {"owner": "222"})
+        access = {
+            "allowFrom": ["999"],
+            "owner": "444",
+            "tierMap": {"999": "owner"},
+        }
+        expect_eq(
+            discord_config.resolve_owner_id(access),
+            "222",
+            "workspace owner should beat legacy access.json fields",
+        )
+
+
+def test_workspace_tier_map():
+    with workspace_env() as (ws, _):
+        write_config(ws, {"tierMap": {"333": "owner", "444": "team"}})
+        access = {"allowFrom": ["444", "333", "555"]}
+        expect_eq(
+            discord_config.resolve_owner_id(access),
+            "333",
+            "workspace tierMap[uid]=owner should resolve",
+        )
+
+
+def test_legacy_owner_field():
+    """Compat path #1118 manual edits (one release of grace)."""
+    with workspace_env() as (_, _):
+        access = {"allowFrom": ["999"], "owner": "555"}
+        expect_eq(
+            discord_config.resolve_owner_id(access),
+            "555",
+            "legacy access.owner should resolve when workspace empty",
+        )
+
+
+def test_legacy_tier_map():
+    """Compat path #846 — Sutando tag in access.json."""
+    with workspace_env() as (_, _):
+        access = {
+            "allowFrom": ["111", "222", "333"],
+            "tierMap": {"222": "owner", "333": "team"},
+        }
+        expect_eq(
+            discord_config.resolve_owner_id(access),
+            "222",
+            "legacy access.tierMap[uid]=owner should resolve",
+        )
+
+
+def test_returns_none_when_exhausted():
+    with workspace_env() as (_, _):
+        access = {"allowFrom": ["111", "222"]}
+        expect_eq(
+            discord_config.resolve_owner_id(access),
+            None,
+            "no config path matches → None (caller does bot-filter)",
+        )
+
+
+def test_empty_access_returns_none():
+    with workspace_env() as (_, _):
+        expect_eq(
+            discord_config.resolve_owner_id({}),
+            None,
+            "empty access dict + empty workspace = None",
+        )
+
+
+def test_stale_tier_tag_for_de_listed_user():
+    """A `tierMap` tag for someone NOT in allowFrom must NOT resolve them."""
+    with workspace_env() as (ws, _):
+        write_config(ws, {"tierMap": {"999": "owner"}})
+        access = {"allowFrom": ["111", "222"]}
+        expect_eq(
+            discord_config.resolve_owner_id(access),
+            None,
+            "stale tier tag must not resolve a de-listed user",
+        )
+
+
+def test_injected_config_overrides_disk():
+    with workspace_env() as (ws, _):
+        write_config(ws, {"owner": "from-disk"})
+        out = discord_config.resolve_owner_id({}, config={"owner": "from-arg"})
+        expect_eq(out, "from-arg", "config= kwarg must bypass disk read")
+
+
+# ----- auto_seed_if_missing ----------------------------------------------
+
+
+def test_seed_from_explicit_owner():
+    with workspace_env() as (ws, records):
+        access = {"allowFrom": ["111"], "owner": "999"}
+        seed = discord_config.auto_seed_if_missing(access)
+        expect_eq(seed.get("owner"), "999", "seed should propagate access.owner")
+        if not (ws / "state" / discord_config.CONFIG_FILENAME).exists():
+            fail("seed file should exist on disk after auto_seed_if_missing")
+        msgs = [r.getMessage() for r in records]
+        if not any("auto-seeded owner=999" in m for m in msgs):
+            fail(f"expected INFO log of seed source; got: {msgs!r}")
+
+
+def test_seed_from_tier_map_tag():
+    with workspace_env() as (ws, records):
+        access = {
+            "allowFrom": ["111", "222"],
+            "tierMap": {"222": "owner"},
+        }
+        seed = discord_config.auto_seed_if_missing(access)
+        expect_eq(seed.get("owner"), "222", "tierMap tag should drive seed")
+        expect_eq(
+            seed.get("tierMap"),
+            {"222": "owner"},
+            "tierMap should be mirrored into seed",
+        )
+
+
+def test_seed_warns_on_allow_from_fallback():
+    """Lucy #1147 watch-point #2 — operator must see a WARN if seed
+    falls through to allowFrom[0]. Silence here recreates the bug."""
+    with workspace_env() as (ws, records):
+        access = {"allowFrom": ["123"]}  # no owner, no tierMap
+        seed = discord_config.auto_seed_if_missing(access)
+        expect_eq(seed.get("owner"), "123", "fallback seeds from allowFrom[0]")
+        warns = [
+            r for r in records if r.levelno >= logging.WARNING
+        ]
+        joined = " | ".join(r.getMessage() for r in warns)
+        expect_in("allowFrom[0]", joined, "WARN must mention allowFrom[0] path")
+        expect_in("VERIFY", joined, "WARN must instruct operator to VERIFY")
+
+
+def test_seed_warns_on_empty():
+    with workspace_env() as (ws, records):
+        seed = discord_config.auto_seed_if_missing({})
+        expect_eq(seed, {}, "no candidates → empty seed")
+        warns = [r for r in records if r.levelno >= logging.WARNING]
+        joined = " | ".join(r.getMessage() for r in warns)
+        expect_in(
+            "no owner candidates",
+            joined,
+            "WARN must surface when there's nothing to seed",
+        )
+
+
+def test_seed_is_idempotent():
+    with workspace_env() as (ws, _):
+        write_config(ws, {"owner": "existing-owner-id"})
+        access = {"allowFrom": ["should-not-overwrite"]}
+        seed = discord_config.auto_seed_if_missing(access)
+        expect_eq(
+            seed.get("owner"),
+            "existing-owner-id",
+            "idempotent: existing file must not be overwritten",
+        )
+        on_disk = json.loads(
+            (ws / "state" / discord_config.CONFIG_FILENAME).read_text()
+        )
+        expect_eq(
+            on_disk.get("owner"),
+            "existing-owner-id",
+            "disk state must match (no rewrite)",
+        )
+
+
+def test_save_load_roundtrip():
+    with workspace_env() as (ws, _):
+        discord_config.save_config({"owner": "rt", "tierMap": {"rt": "owner"}})
+        loaded = discord_config.load_config()
+        expect_eq(loaded.get("owner"), "rt", "roundtrip owner")
+        expect_eq(
+            loaded.get("tierMap"),
+            {"rt": "owner"},
+            "roundtrip tierMap",
+        )
+
+
+def test_load_returns_empty_on_corrupt_file():
+    """Corrupt JSON must not crash — return {} so the legacy fallback
+    chain keeps the bridge operational."""
+    with workspace_env() as (ws, records):
+        path = ws / "state" / discord_config.CONFIG_FILENAME
+        path.write_text("{not-valid-json")
+        expect_eq(
+            discord_config.load_config(),
+            {},
+            "corrupt JSON must degrade to empty dict",
+        )
+        warns = [r for r in records if r.levelno >= logging.WARNING]
+        joined = " | ".join(r.getMessage() for r in warns)
+        expect_in("failed to read", joined, "WARN must surface read failure")
+
+
+# ----- runner -------------------------------------------------------------
+
+
+def main() -> int:
+    tests = [
+        test_env_override_wins,
+        test_workspace_owner_wins,
+        test_workspace_tier_map,
+        test_legacy_owner_field,
+        test_legacy_tier_map,
+        test_returns_none_when_exhausted,
+        test_empty_access_returns_none,
+        test_stale_tier_tag_for_de_listed_user,
+        test_injected_config_overrides_disk,
+        test_seed_from_explicit_owner,
+        test_seed_from_tier_map_tag,
+        test_seed_warns_on_allow_from_fallback,
+        test_seed_warns_on_empty,
+        test_seed_is_idempotent,
+        test_save_load_roundtrip,
+        test_load_returns_empty_on_corrupt_file,
+    ]
+    for t in tests:
+        try:
+            t()
+        except Exception as exc:  # noqa: BLE001
+            fail(f"{t.__name__} raised: {exc!r}")
+
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} failure(s) in {len(tests)} tests", file=sys.stderr)
+        return 1
+    print(f"PASS: {len(tests)} discord_config tests")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements the design from #1147. Moves Sutando-specific Discord config (`tierMap`, proposed `owner`) off plugin-managed `~/.claude/channels/discord/access.json` into workspace-local `$SUTANDO_WORKSPACE/state/discord-config.json`.

Per @liususan091219's LGTM on the design + watch-points:
- ✅ **Symmetric site**: single `discord_config.resolve_owner_id` helper called by BOTH `discord-bridge.py:_poll_dm_fallback` AND `dm-result.py:_resolve_owner_id`. The #846 drift class (one site got tierMap, the other didn't) is structurally prevented.
- ✅ **Auto-seed warning**: `auto_seed_if_missing` WARN-logs when seeding from `allowFrom[0]` so the operator catches a mis-seed (Susan Mac Studio 2026-05-25 scenario) rather than silently recreating the bug.

## Files

- **NEW** `src/discord_config.py` — workspace-local config helper (load/save/resolve/auto-seed)
- **NEW** `tests/discord_config.test.py` — 16 standalone tests (stdlib-only, runs under repo's `*.test.py` convention)
- `src/discord-bridge.py` — wire auto-seed on `on_ready`, refactor `_poll_dm_fallback` resolution
- `src/dm-result.py` — refactor `_resolve_owner_id` to call the helper

## Resolution chain

```
1. SUTANDO_DM_OWNER_ID env override
2. workspace["discord-config.json"]["owner"]               ← Sutando, NEW
3. workspace["discord-config.json"]["tierMap"][uid]=="owner"
4. access.json["owner"]                                     ← legacy compat
5. access.json["tierMap"][uid]=="owner"                     ← legacy compat (#846)
6. (caller) bot-filtered walk of access.json["allowFrom"]   ← I/O, stays in caller
```

Step 6 stays in callers because it requires REST `GET /users/{id}` lookups — keeping the helper pure-Python lets sync (urllib) and async (discord.py) call sites share the chain.

## Migration

- Bridge auto-creates `state/discord-config.json` on next restart, seeded from the legacy heuristic. Idempotent.
- No user action required for users whose `allowFrom[0]` IS the owner (Chi's case).
- Legacy `access.json["owner"]` + `access.json["tierMap"]` read as fallback (graceful — supports compat for at least one release).

## Live-test ask

@liususan091219 — ready for your live-test against the same scenario that caught #1118 (`allowFrom[0]` not the owner, no `tierMap` tag). The recording you posted on #1118 should reproduce the failure on `main` and resolve correctly on this branch after `state/discord-config.json` is seeded (auto-creates on bridge restart, OR drop a manual `{"owner": "<your-id>"}`).

Closes #1147.
Replaces #1118 (closed by author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)