### PR TITLE
fix(workspace_default): skip notes migration when in-repo notes/ is a symlink (closes #1149)

### DIFF
--- a/src/workspace_default.py
+++ b/src/workspace_default.py
@@ -166,6 +166,24 @@ def _migrate_inrepo_notes(workspace: Path) -> bool:
     inrepo_notes = repo_root / "notes"
     if not inrepo_notes.is_dir():
         return False
+    # #1149: if `notes/` is a symlink (e.g. the canonical memory-sync setup
+    # where `<repo>/notes` -> `~/.sutando/memory-sync/notes/`), skip migration
+    # entirely. The "in-repo notes" semantic doesn't apply — the files live
+    # in the link target, not in the repo. shutil.move on a symlinked dir's
+    # contents would MOVE the link target's files into the workspace, which
+    # is destructive (the symlink target loses the files). Caught the hard
+    # way 2026-05-25 when `tests/discord_config.test.py` set
+    # SUTANDO_WORKSPACE to a tmpdir; this migration moved 38 memory-sync
+    # files into the tmpdir; `tempfile.TemporaryDirectory` cleanup deleted
+    # them. 37 git-recovered; 1 uncommitted unrecoverable.
+    if inrepo_notes.is_symlink():
+        # Sentinel write still desired so subsequent calls short-circuit.
+        try:
+            workspace.mkdir(parents=True, exist_ok=True)
+            sentinel.touch()
+        except Exception:
+            pass
+        return False
     # Only operate on regular md/txt files at the top level of in-repo notes/.
     # Subdirectories (e.g. `notes/media/`, `notes/projects/`) and the historic
     # memory-sync symlink convention are left alone — they may have their own

--- a/tests/workspace_default_symlink_skip.test.py
+++ b/tests/workspace_default_symlink_skip.test.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Tests that `workspace_default._migrate_inrepo_notes` does NOT touch the
+in-repo `notes/` dir when it's a symlink.
+
+Closes #1149.
+
+Background: on 2026-05-25 a test in #1148 set `SUTANDO_WORKSPACE` to a
+`tempfile.TemporaryDirectory()`. The legacy-notes migration walked
+`<repo>/notes/` (which on the canonical memory-sync setup is a symlink
+to `~/.sutando/memory-sync/notes/`), saw 38 `.md` files, and ran
+`shutil.move` on each — moving them OUT of the memory-sync target and
+INTO the tmpdir. When the test exited, `tempfile`'s cleanup deleted
+the tmpdir, destroying the files. 37 of 38 were recoverable from git
+(`git checkout HEAD -- notes/`); the 38th was an uncommitted file
+(`notes/competitive-matrix-2026-05-26.md`) and unrecoverable.
+
+The fix: if `<repo>/notes/` is a symlink, skip the migration. This is
+the canonical memory-sync setup, and the files belong to the symlink
+target (memory-sync repo), not to the in-repo location.
+
+Run: python3 tests/workspace_default_symlink_skip.test.py
+Exit: 0 on pass, 1 on fail.
+
+Stdlib-only (no pytest) — matches the repo's standalone-test convention.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+
+_FAILURES: list[str] = []
+
+
+def fail(msg: str) -> None:
+    _FAILURES.append(msg)
+    print(f"FAIL: {msg}", file=sys.stderr)
+
+
+def expect(cond: bool, label: str) -> None:
+    if not cond:
+        fail(label)
+
+
+def test_symlinked_notes_dir_is_skipped():
+    """The bug scenario: `<repo>/notes/` is a symlink to a separate dir
+    holding the real files. `_migrate_inrepo_notes` MUST leave both
+    locations untouched and just drop the sentinel."""
+    import workspace_default as wd
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        # Pretend repo
+        fake_repo = tmp_path / "repo"
+        fake_repo.mkdir()
+        # The "memory-sync" target where notes really live
+        sync_target = tmp_path / "memory-sync" / "notes"
+        sync_target.mkdir(parents=True)
+        (sync_target / "important.md").write_text("# important — must survive\n")
+        (sync_target / "other.md").write_text("# other\n")
+        # Repo's notes/ symlinks to the sync target
+        (fake_repo / "notes").symlink_to(sync_target)
+
+        # Workspace = a different dir
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        # Stub _legacy_repo_root() to point at our fake repo
+        original_repo_root = wd._legacy_repo_root
+        wd._legacy_repo_root = lambda: fake_repo
+        try:
+            result = wd._migrate_inrepo_notes(workspace)
+        finally:
+            wd._legacy_repo_root = original_repo_root
+
+        expect(result is False, "_migrate_inrepo_notes returned True; should be False on symlink skip")
+        expect(
+            (sync_target / "important.md").exists(),
+            "symlink target file was MOVED — should remain at link target",
+        )
+        expect(
+            (sync_target / "other.md").exists(),
+            "symlink target file was MOVED — should remain at link target",
+        )
+        expect(
+            not (workspace / "notes" / "important.md").exists(),
+            "file appeared in workspace — migration should have been skipped",
+        )
+        expect(
+            (workspace / ".notes-migrated").exists(),
+            "sentinel should still be dropped so we short-circuit next call",
+        )
+
+
+def test_real_directory_still_migrates():
+    """Sanity: when `notes/` is a real dir (not a symlink), migration
+    still runs as before. The symlink-skip is the *only* added gate."""
+    import workspace_default as wd
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_repo = tmp_path / "repo"
+        fake_repo.mkdir()
+        # Real dir, not symlink
+        inrepo_notes = fake_repo / "notes"
+        inrepo_notes.mkdir()
+        (inrepo_notes / "note1.md").write_text("# note1\n")
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        original_repo_root = wd._legacy_repo_root
+        wd._legacy_repo_root = lambda: fake_repo
+        try:
+            result = wd._migrate_inrepo_notes(workspace)
+        finally:
+            wd._legacy_repo_root = original_repo_root
+
+        expect(result is True, "real-dir migration should have returned True")
+        expect(
+            (workspace / "notes" / "note1.md").exists(),
+            "real-dir file should have moved to workspace",
+        )
+        expect(
+            not (inrepo_notes / "note1.md").exists(),
+            "real-dir source file should be gone after move",
+        )
+
+
+def test_sentinel_short_circuits_subsequent_calls():
+    """Even on the symlink-skip path, the sentinel must be written so
+    repeated `resolve_workspace()` calls don't re-traverse the symlink."""
+    import workspace_default as wd
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        fake_repo = tmp_path / "repo"
+        fake_repo.mkdir()
+        sync_target = tmp_path / "memory-sync" / "notes"
+        sync_target.mkdir(parents=True)
+        (sync_target / "x.md").write_text("# x\n")
+        (fake_repo / "notes").symlink_to(sync_target)
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        original_repo_root = wd._legacy_repo_root
+        wd._legacy_repo_root = lambda: fake_repo
+        try:
+            wd._migrate_inrepo_notes(workspace)
+            # Second call should short-circuit via sentinel and return False
+            result2 = wd._migrate_inrepo_notes(workspace)
+        finally:
+            wd._legacy_repo_root = original_repo_root
+
+        expect(result2 is False, "sentinel short-circuit failed (returned non-False)")
+        # And the file should still be intact
+        expect((sync_target / "x.md").exists(), "second-call regression: file went missing")
+
+
+def main() -> int:
+    tests = [
+        test_symlinked_notes_dir_is_skipped,
+        test_real_directory_still_migrates,
+        test_sentinel_short_circuits_subsequent_calls,
+    ]
+    for t in tests:
+        try:
+            t()
+        except Exception as exc:  # noqa: BLE001
+            fail(f"{t.__name__} raised: {exc!r}")
+
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} failure(s) in {len(tests)} tests", file=sys.stderr)
+        return 1
+    print(f"PASS: {len(tests)} workspace-default symlink-skip tests")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1149.

## Problem

`_migrate_inrepo_notes` walks `<repo>/notes/` regardless of whether it's a real dir or a symlink. In the canonical memory-sync setup where `<repo>/notes/` → `~/.sutando/memory-sync/notes/`, the migration `shutil.move`s files OUT of the link target and INTO the configured workspace.

In production this is mostly latent (workspaces match). In test contexts that set `SUTANDO_WORKSPACE` to a tmpdir, the migration moves files into the tmpdir; when `tempfile.TemporaryDirectory` cleans up, the files are destroyed.

**2026-05-25 incident**: `tests/discord_config.test.py` (PR #1148) set `SUTANDO_WORKSPACE` to a tmpdir → migration moved 38 memory-sync notes into the tmpdir → cleanup deleted them. 37 recovered via \`git checkout HEAD -- notes/\`, 1 (uncommitted) unrecoverable.

## Fix

If `inrepo_notes.is_symlink()`, skip the migration. The "in-repo notes" semantic doesn't apply — files live at the link target, not in the repo. Sentinel is still written so repeated `resolve_workspace()` calls short-circuit.

This also helps the **production** case: a user with a memory-sync symlink no longer has their notes silently relocated on a workspace upgrade.

## Tests

3 standalone tests in `tests/workspace_default_symlink_skip.test.py` (stdlib-only, runs under repo's `*.test.py` convention):

- `test_symlinked_notes_dir_is_skipped` — the bug repro; verifies files stay at link target
- `test_real_directory_still_migrates` — sanity: existing behavior preserved when notes/ is a real dir
- `test_sentinel_short_circuits_subsequent_calls` — sentinel still written on symlink-skip path

All pass.

## Companion memory

Saved `feedback_test_workspace_env_triggers_destructive_migration` to memory with the test-side workaround until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)