### PR TITLE
feat(quota-tracker): EWMA burn-rate forecast + pass-budget prediction

### DIFF
--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -28,7 +28,7 @@ sys.path.insert(0, str(_REPO_ROOT / "src"))
 try:
     from workspace_default import status_read_path  # noqa: E402
     _canonical = status_read_path("quota-state.json")
-except Exception:
+except ImportError:
     _canonical = None
 
 if _canonical is not None and _canonical.exists():

--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -8,10 +8,14 @@ Usage:
   python3 read-quota.py --gate       # exit 1 if exhausted
 """
 
+from __future__ import annotations
+
 import json
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 # Canonical (and only) home is <workspace>/state/quota-state.json, written by
 # the credential proxy. The skill-dir / cwd fallbacks were removed: a stale
@@ -26,16 +30,85 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "src"))
 try:
-    from workspace_default import status_read_path  # noqa: E402
+    from workspace_default import status_read_path, resolve_workspace  # noqa: E402
     _canonical = status_read_path("quota-state.json")
+    _workspace: Optional[Path] = Path(str(resolve_workspace()))
 except ImportError:
     _canonical = None
+    _workspace = None
 
 if _canonical is not None and _canonical.exists():
     QUOTA_FILE = _canonical
 else:
     print("No quota-state.json found. Is the credential proxy running?")
     sys.exit(1)
+
+_BURN_HISTORY_FILE: Optional[Path] = (
+    _workspace / "state" / "quota-burn-history.json" if _workspace else None
+)
+_EWMA_ALPHA = 0.3
+_MAX_HISTORY = 60  # ~5h at 5min cadence
+
+
+def _load_history() -> dict:
+    if _BURN_HISTORY_FILE is None or not _BURN_HISTORY_FILE.exists():
+        return {"samples": [], "ewma_pct_per_min": None}
+    try:
+        raw = json.loads(_BURN_HISTORY_FILE.read_text())
+        # Migrate old list format (pre-#1087) to new dict format
+        if isinstance(raw, list):
+            return {"samples": [], "ewma_pct_per_min": None}
+        return raw
+    except (json.JSONDecodeError, OSError):
+        return {"samples": [], "ewma_pct_per_min": None}
+
+
+def _save_history(history: dict) -> None:
+    if _BURN_HISTORY_FILE is None:
+        return
+    try:
+        _BURN_HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _BURN_HISTORY_FILE.write_text(json.dumps(history, indent=2))
+    except OSError:
+        pass
+
+
+def _update_burn_rate(util_5h: float) -> dict:
+    """Record utilization sample, update EWMA burn rate, return forecast stats."""
+    now = time.time()
+    history = _load_history()
+    samples: list = history.get("samples", [])
+    ewma: Optional[float] = history.get("ewma_pct_per_min")
+
+    if samples:
+        prev = samples[-1]
+        dt_min = (now - prev["ts"]) / 60.0
+        if dt_min > 0:
+            delta_pct = (util_5h - prev["util_5h"]) * 100
+            # Only count positive consumption; ignore resets and gaps > 30 min
+            if delta_pct > 0 and dt_min < 30:
+                rate = delta_pct / dt_min
+                ewma = rate if ewma is None else (1 - _EWMA_ALPHA) * ewma + _EWMA_ALPHA * rate
+
+    samples.append({"ts": now, "util_5h": util_5h})
+    if len(samples) > _MAX_HISTORY:
+        samples = samples[-_MAX_HISTORY:]
+
+    _save_history({"samples": samples, "ewma_pct_per_min": ewma})
+
+    remaining_pct = (1 - util_5h) * 100
+    if ewma and ewma > 0:
+        minutes_to_exhaustion = remaining_pct / ewma
+        passes_remaining = minutes_to_exhaustion / 5
+    else:
+        minutes_to_exhaustion = None
+        passes_remaining = None
+
+    return {
+        "burn_rate_pct_per_min": round(ewma, 4) if ewma is not None else None,
+        "estimated_minutes_to_exhaustion": round(minutes_to_exhaustion) if minutes_to_exhaustion is not None else None,
+        "estimated_passes_remaining": round(passes_remaining, 1) if passes_remaining is not None else None,
+    }
 
 
 def main():
@@ -48,6 +121,8 @@ def main():
     reset_5h = headers.get("anthropic-ratelimit-unified-5h-reset", "")
     reset_7d = headers.get("anthropic-ratelimit-unified-7d-reset", "")
 
+    burn = _update_burn_rate(util_5h)
+
     result = {
         "status": status,
         "available": status == "allowed",
@@ -55,6 +130,7 @@ def main():
         "utilization_7d": util_7d,
         "remaining_5h_pct": round((1 - util_5h) * 100),
         "remaining_7d_pct": round((1 - util_7d) * 100),
+        **burn,
     }
 
     if reset_5h:
@@ -77,6 +153,13 @@ def main():
     print(f"7d window: {int(util_7d * 100)}% used, {result['remaining_7d_pct']}% remaining")
     if reset_7d:
         print(f"  Resets: {datetime.fromtimestamp(int(reset_7d)).strftime('%H:%M %b %d')}")
+    if burn["burn_rate_pct_per_min"] is not None:
+        rate_str = f"{burn['burn_rate_pct_per_min']:.3f}%/min"
+        passes_str = (
+            f"  (~{burn['estimated_passes_remaining']:.0f} passes left)"
+            if burn["estimated_passes_remaining"] is not None else ""
+        )
+        print(f"Burn rate: {rate_str}{passes_str}")
 
 
 if __name__ == "__main__":

--- a/tests/quota-bare-except.test.py
+++ b/tests/quota-bare-except.test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Structural test for the bare-except narrowing in read-quota.py (issue #1062).
+
+## Problem (issue #1062)
+
+`skills/quota-tracker/scripts/read-quota.py` had a bare `except Exception:`
+around the workspace_default import:
+
+    try:
+        from workspace_default import status_read_path
+        _canonical = status_read_path("quota-state.json")
+    except Exception:           # ← too broad
+        _canonical = None
+
+When #1055 fixed the _REPO_ROOT path off-by-one, the original bug had been an
+`ImportError` — "No module named 'workspace_default'". The broad except swallowed
+it for ~12h, setting _canonical=None and emitting the misleading "No
+quota-state.json found" fallback instead of surfacing the real error.
+
+If status_read_path() raises any other exception (e.g. a future refactor adds an
+unexpected error for a real config issue), we want it to propagate so it shows
+in cron pass logs — not silently fall through to the same misleading message.
+
+## Fix (this PR)
+
+Narrowed to `except ImportError:` so only the "module not on sys.path" case is
+suppressed; all other exceptions propagate.
+
+Run: python3 tests/quota-bare-except.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+READ_QUOTA = REPO / "skills" / "quota-tracker" / "scripts" / "read-quota.py"
+
+_FAILURES: list[str] = []
+
+
+def fail(msg: str, ctx: str = "") -> None:
+    _FAILURES.append(msg)
+    print(f"FAIL: {msg}", file=sys.stderr)
+    if ctx:
+        print("--- context ---", file=sys.stderr)
+        print(ctx[:400], file=sys.stderr)
+
+
+def expect(cond: bool, label: str, ctx: str = "") -> None:
+    if not cond:
+        fail(label, ctx)
+
+
+def main() -> None:
+    if not READ_QUOTA.exists():
+        fail(f"file not found: {READ_QUOTA}")
+        sys.exit(1)
+
+    src = READ_QUOTA.read_text()
+    lines = src.splitlines()
+
+    # 1. No bare `except Exception:` around the workspace_default import block
+    bare_except_lines = [
+        ln.strip() for ln in lines
+        if re.match(r"\s*except\s+Exception\s*:", ln)
+    ]
+    expect(
+        len(bare_except_lines) == 0,
+        f"read-quota.py: bare 'except Exception:' must be narrowed to 'except ImportError:' "
+        f"(found {len(bare_except_lines)} site(s))",
+        ctx="\n".join(bare_except_lines[:3]),
+    )
+
+    # 2. `except ImportError:` present — the correct narrow form
+    import_error_lines = [
+        ln.strip() for ln in lines
+        if re.match(r"\s*except\s+ImportError\s*:", ln)
+    ]
+    expect(
+        len(import_error_lines) >= 1,
+        "read-quota.py: must have 'except ImportError:' to handle module-not-found case",
+    )
+
+    # 3. The import block structure is intact — try/except still wraps workspace_default import
+    expect(
+        "from workspace_default import status_read_path" in src,
+        "read-quota.py: 'from workspace_default import status_read_path' must still be present",
+    )
+
+    # 4. _canonical = None fallback still present in except block
+    expect(
+        "_canonical = None" in src,
+        "read-quota.py: '_canonical = None' fallback in except block must still be present",
+    )
+
+    # 5. No other broad except blocks introduced around status_read_path
+    # (ensure the fix didn't accidentally add a new bare except elsewhere)
+    broad_except_elsewhere = [
+        ln.strip() for ln in lines
+        if re.match(r"\s*except\s+Exception\s*:", ln)
+        and "workspace_default" not in "\n".join(
+            lines[max(0, lines.index(ln) - 5): lines.index(ln) + 2]
+        )
+    ]
+    expect(
+        len(broad_except_elsewhere) == 0,
+        f"read-quota.py: no new bare 'except Exception:' blocks should be introduced "
+        f"(found {len(broad_except_elsewhere)} site(s))",
+        ctx="\n".join(broad_except_elsewhere[:3]),
+    )
+
+    # Summary
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} test(s) FAILED:", file=sys.stderr)
+        for f in _FAILURES:
+            print(f"  - {f}", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print("All 5 tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/quota-burn-rate.test.py
+++ b/tests/quota-burn-rate.test.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Structural test for quota-tracker predictive burn-rate (issue #1087).
+
+## What this checks
+
+`skills/quota-tracker/scripts/read-quota.py` gains EWMA burn-rate prediction:
+- History file at <workspace>/state/quota-burn-history.json
+- EWMA alpha=0.3, samples capped at 60 entries
+- New output keys: burn_rate_pct_per_min, estimated_minutes_to_exhaustion,
+  estimated_passes_remaining
+- Human-readable: "Burn rate: X.XXX%/min  (~N passes left)"
+- Positive-only delta filter + 30-min gap guard prevent resets skewing the rate
+
+Run: python3 tests/quota-burn-rate.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+READ_QUOTA = REPO / "skills" / "quota-tracker" / "scripts" / "read-quota.py"
+
+_FAILURES: list[str] = []
+
+
+def fail(msg: str, ctx: str = "") -> None:
+    _FAILURES.append(msg)
+    print(f"FAIL: {msg}", file=sys.stderr)
+    if ctx:
+        print("--- context ---", file=sys.stderr)
+        print(ctx[:400], file=sys.stderr)
+
+
+def expect(cond: bool, label: str, ctx: str = "") -> None:
+    if not cond:
+        fail(label, ctx)
+
+
+def main() -> None:
+    if not READ_QUOTA.exists():
+        fail(f"file not found: {READ_QUOTA}")
+        sys.exit(1)
+
+    src = READ_QUOTA.read_text()
+    lines = src.splitlines()
+
+    # 1. resolve_workspace imported alongside status_read_path
+    expect(
+        "resolve_workspace" in src,
+        "read-quota.py: must import resolve_workspace from workspace_default",
+    )
+
+    # 2. _BURN_HISTORY_FILE defined using _workspace
+    expect(
+        "_BURN_HISTORY_FILE" in src,
+        "read-quota.py: _BURN_HISTORY_FILE variable must be defined",
+    )
+    expect(
+        "_workspace" in src,
+        "read-quota.py: _workspace variable must be resolved from resolve_workspace()",
+    )
+
+    # 3. EWMA alpha constant present
+    ewma_lines = [ln for ln in lines if re.search(r"_EWMA_ALPHA\s*=\s*0\.\d+", ln)]
+    expect(
+        len(ewma_lines) >= 1,
+        "read-quota.py: _EWMA_ALPHA constant must be defined",
+    )
+
+    # 4. History capped (_MAX_HISTORY or similar slicing)
+    expect(
+        "_MAX_HISTORY" in src,
+        "read-quota.py: _MAX_HISTORY cap must be defined to bound history size",
+    )
+
+    # 5. Positive-delta guard present (ignore resets/decreases)
+    expect(
+        "delta_pct > 0" in src,
+        "read-quota.py: positive-delta guard (delta_pct > 0) must be present to filter resets",
+    )
+
+    # 6. Gap guard present (ignore long pauses to prevent rate-spike)
+    expect(
+        "dt_min < 30" in src,
+        "read-quota.py: gap guard (dt_min < 30) must be present to ignore long pauses",
+    )
+
+    # 7. burn_rate_pct_per_min in result dict
+    expect(
+        "burn_rate_pct_per_min" in src,
+        "read-quota.py: 'burn_rate_pct_per_min' key must appear in output",
+    )
+
+    # 8. estimated_minutes_to_exhaustion in result dict
+    expect(
+        "estimated_minutes_to_exhaustion" in src,
+        "read-quota.py: 'estimated_minutes_to_exhaustion' key must appear in output",
+    )
+
+    # 9. estimated_passes_remaining in result dict
+    expect(
+        "estimated_passes_remaining" in src,
+        "read-quota.py: 'estimated_passes_remaining' key must appear in output",
+    )
+
+    # 10. Human-readable output includes "Burn rate:"
+    expect(
+        "Burn rate:" in src,
+        "read-quota.py: human-readable output must include 'Burn rate:' line",
+    )
+
+    # 11. passes left shown in human-readable output
+    expect(
+        "passes left" in src,
+        "read-quota.py: human-readable output must include 'passes left' forecast",
+    )
+
+    # 12. History file path lives in state/ subdir
+    expect(
+        '"state"' in src or "'state'" in src or 'state/quota-burn-history.json' in src,
+        "read-quota.py: burn history file must be under state/ directory",
+    )
+
+    # 13. _load_history guards against missing file and JSON decode errors
+    expect(
+        "_load_history" in src,
+        "read-quota.py: _load_history() function must be defined",
+    )
+    expect(
+        "json.JSONDecodeError" in src or "JSONDecodeError" in src,
+        "read-quota.py: _load_history must guard against JSONDecodeError",
+    )
+
+    # 14. _save_history uses mkdir(parents=True) to create state/ if needed
+    expect(
+        "_save_history" in src,
+        "read-quota.py: _save_history() function must be defined",
+    )
+    expect(
+        "mkdir" in src,
+        "read-quota.py: _save_history must mkdir parents before writing",
+    )
+
+    # 15. Still has except ImportError: (from #1165 fix — carried forward)
+    import_error_lines = [
+        ln.strip() for ln in lines
+        if re.match(r"\s*except\s+ImportError\s*:", ln)
+    ]
+    expect(
+        len(import_error_lines) >= 1,
+        "read-quota.py: must retain 'except ImportError:' from #1165 (no bare except Exception:)",
+    )
+
+    # 16. No bare except Exception: reintroduced
+    bare_except_lines = [
+        ln.strip() for ln in lines
+        if re.match(r"\s*except\s+Exception\s*:", ln)
+    ]
+    expect(
+        len(bare_except_lines) == 0,
+        f"read-quota.py: bare 'except Exception:' must not appear "
+        f"(found {len(bare_except_lines)} site(s))",
+        ctx="\n".join(bare_except_lines[:3]),
+    )
+
+    # 17. File is valid Python (syntax check)
+    try:
+        ast.parse(src)
+    except SyntaxError as exc:
+        fail(f"read-quota.py: syntax error — {exc}")
+
+    # Summary
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} test(s) FAILED:", file=sys.stderr)
+        for f in _FAILURES:
+            print(f"  - {f}", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print("All 17 tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds EWMA (α=0.3) burn-rate tracking to `read-quota.py`: records `util_5h` samples in `<workspace>/state/quota-burn-history.json`, computes `pct/min` consumption rate per pass
- New output keys: `burn_rate_pct_per_min`, `estimated_minutes_to_exhaustion`, `estimated_passes_remaining` (in both `--json` and human-readable output)
- Positive-delta filter + 30-min gap guard prevent quota resets and session pauses from spiking the EWMA rate
- History capped at 60 samples (~5h at 5min cadence) to bound file size
- Also carries forward the `except ImportError:` narrowing from #1165 (not yet merged)

## Test plan

- [ ] `python3 tests/quota-burn-rate.test.py` → All 17 tests passed
- [ ] `python3 tests/quota-bare-except.test.py` → All 5 tests passed (carried-forward fix)
- [ ] Run `python3 read-quota.py` twice in succession — second call shows a burn rate line
- [ ] Run `python3 read-quota.py --json` — output includes the three new keys
- [ ] Verify `<workspace>/state/quota-burn-history.json` is created/updated on each run

Closes #1087

🤖 Generated with [Claude Code](https://claude.com/claude-code)