### PR TITLE
fix(inline-tools): gate slideControlTool exposure on presenter-mode sentinel (#1171)

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -20,6 +20,12 @@ import { resolveWorkspace, statusPath, statusReadPath } from './workspace_defaul
 // resolveWorkspace() is the canonical TS helper introduced in #821.
 const WORKSPACE_DIR = resolveWorkspace();
 
+// Gate slide-control exposure on presenter-mode sentinel (#1171).
+// Checked once at module load — voice-agent must restart for the gate to flip.
+// The presenter-mode.sh workflow always runs before the voice agent, so the
+// contract holds: no spurious copres_next_anchor/slide_control firings on greetings.
+const PRESENTER_ACTIVE = existsSync(join(WORKSPACE_DIR, 'state', 'presenter-mode.sentinel'));
+
 // Code-adjacent paths (skills/, etc.) ship with the repo checkout, NOT the
 // workspace. Compute REPO_ROOT from this file's URL so the resolution
 // survives any cwd drift at startup. Used by the skill-loader below.
@@ -1089,7 +1095,8 @@ export const inlineTools = assertUniqueToolNames([
 	volumeTool, brightnessTool, clipboardTool,
 	cancelTaskTool, toggleTasksTool, getCurrentTimeTool, getCoreStatusTool,
 	joinGmeetTool, lookupMeetingIdTool, callContactTool,
-	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, slideControlTool, fullscreenTool,
+	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, fullscreenTool,
+	...(PRESENTER_ACTIVE ? [slideControlTool] : []),
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
 	recentContextTool,
 	sendVisionFrameTool, startVisionTool, stopVisionTool,
@@ -1110,7 +1117,8 @@ export const ownerOnlyTools = [
 	pressKeyTool, scrollTool, switchTabTool, closeTabTool, openUrlTool,
 	switchAppTool, captureScreenTool, typeTextTool,
 	clipboardTool, cancelTaskTool, toggleTasksTool,
-	joinGmeetTool, callContactTool, slideControlTool, fullscreenTool,
+	joinGmeetTool, callContactTool, fullscreenTool,
+	...(PRESENTER_ACTIVE ? [slideControlTool] : []),
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
 	recentContextTool,
 	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool,

--- a/tests/inline-tools-presenter-gate.test.py
+++ b/tests/inline-tools-presenter-gate.test.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Structural guard: slideControlTool must be gated on the presenter-mode sentinel
+at module-load time, not exposed unconditionally (#1171).
+
+Why: inline tools are registered globally with bodhi VoiceSession; Gemini sees
+their descriptions every turn and fires them spuriously on greetings when no
+presentation is active. The fix gates exposure on
+`state/presenter-mode.sentinel` so the description is never visible unless the
+sentinel is present when voice-agent starts.
+
+Guards:
+  1. PRESENTER_ACTIVE sentinel guard present in src/inline-tools.ts
+  2. The sentinel path uses WORKSPACE_DIR (not a bare/repo-relative path)
+  3. slideControlTool is conditionally spread (not unconditionally listed) in inlineTools
+  4. slideControlTool is conditionally spread in ownerOnlyTools
+  5. slideControlTool is NOT unconditionally listed in either array
+  6. The condition references PRESENTER_ACTIVE (not a bare existsSync call inline)
+
+Run: python3 tests/inline-tools-presenter-gate.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+
+from pathlib import Path
+import sys
+import re
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def fail(msg: str, ctx: str = "") -> int:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    if ctx:
+        print("---context---", file=sys.stderr)
+        print(ctx[:1500], file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    src = REPO / "src" / "inline-tools.ts"
+    if not src.exists():
+        return fail(f"{src} not found")
+    text = src.read_text()
+
+    # 1. PRESENTER_ACTIVE const must be defined
+    if "PRESENTER_ACTIVE" not in text:
+        return fail("src/inline-tools.ts missing PRESENTER_ACTIVE const — sentinel gate not added (#1171)")
+
+    # 2. Must check the sentinel via WORKSPACE_DIR, not a bare/relative path
+    # Pattern: existsSync(join(WORKSPACE_DIR, ... 'presenter-mode.sentinel'))
+    if "existsSync(join(WORKSPACE_DIR" not in text:
+        return fail(
+            "src/inline-tools.ts PRESENTER_ACTIVE check must use existsSync(join(WORKSPACE_DIR, ...)) "
+            "— bare or repo-relative sentinel paths would silently break when cwd != repo (#1171)"
+        )
+    if "presenter-mode.sentinel" not in text:
+        return fail("src/inline-tools.ts PRESENTER_ACTIVE check must reference 'presenter-mode.sentinel'")
+
+    # 3 & 4. slideControlTool must be spread conditionally, not listed unconditionally
+    # Find the inlineTools array and ownerOnlyTools array blocks.
+    # Strategy: after the sentinel guard is added, any unconditional `slideControlTool,`
+    # reference inside the array bodies is the regression we're guarding against.
+    # We look for the spread form: ...(PRESENTER_ACTIVE ? [slideControlTool] : [])
+    if "...(PRESENTER_ACTIVE ? [slideControlTool] : [])" not in text:
+        return fail(
+            "src/inline-tools.ts must use ...(PRESENTER_ACTIVE ? [slideControlTool] : []) "
+            "to conditionally include slideControlTool (#1171)"
+        )
+
+    # 5. No unconditional bare `slideControlTool,` references in the exported arrays
+    # (The export const line and the definition line are fine; the array entries are not)
+    # We allow: `export const slideControlTool`, tool definition body, and the spread.
+    # We disallow: `slideControlTool,` appearing outside the spread context.
+    bare_unconditional = re.compile(
+        r'(?<!\.\.\()slideControlTool,',
+    )
+    # Strip the definition block + export line to focus on array entries.
+    # Simple heuristic: find occurrences of `slideControlTool,` not preceded by `[` or `? [`
+    # More precisely: any `slideControlTool,` not part of `[slideControlTool]`
+    non_conditional = re.compile(r'(?<!\[)slideControlTool,(?! *\] *:)')
+    # Find all lines with slideControlTool, and check each
+    problem_lines = []
+    for i, line in enumerate(text.splitlines(), 1):
+        stripped = line.strip()
+        # Skip: the const definition, the export statement, and the conditional spread
+        if stripped.startswith('export const slideControlTool'):
+            continue
+        if 'PRESENTER_ACTIVE' in stripped:
+            continue
+        if stripped.startswith('//'):
+            continue
+        # Flag if slideControlTool appears as a bare array element
+        if re.search(r'\bslideControlTool\b', stripped) and 'PRESENTER_ACTIVE' not in stripped:
+            # Allow inside tool definition body (lines between the definition and closing `}`)
+            # Simple check: if it's in an array context (no `name:`, no `description:` nearby)
+            # Just check: is it a standalone `slideControlTool,` in an array?
+            if re.search(r'^\s*(?:.*,\s*)?slideControlTool,', line) and 'export const slideControlTool' not in line:
+                problem_lines.append(f"  line {i}: {stripped}")
+
+    if problem_lines:
+        return fail(
+            "src/inline-tools.ts still has unconditional slideControlTool array entries:\n"
+            + "\n".join(problem_lines),
+            "Remove bare slideControlTool, entries and use ...(PRESENTER_ACTIVE ? [slideControlTool] : [])"
+        )
+
+    # 6. PRESENTER_ACTIVE is referenced in the spread (already checked by guard 3)
+    # Confirmed by check 3+4.
+
+    print("PASS: slideControlTool is gated on PRESENTER_ACTIVE sentinel in inlineTools and ownerOnlyTools.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `PRESENTER_ACTIVE` sentinel check at module load in `src/inline-tools.ts` (closes #1171)
- `slideControlTool` is spread into `inlineTools` and `ownerOnlyTools` only when `state/presenter-mode.sentinel` is present
- When sentinel is absent, Gemini never sees the `slide_control` description → can't fire it on greetings or filler utterances
- Sentinel check uses `existsSync(join(WORKSPACE_DIR, 'state', 'presenter-mode.sentinel'))` — workspace-resolved, not repo-relative

## Background

`slide_control` was unconditionally registered as a global inline tool. Gemini saw its description every turn and fired it spuriously on greetings/silence even when no presentation was active. The tool body had no intent guard, and the spurious `tool_call` entries landed in voice sqlite, wasting tokens and noising up observability.

Susan's MBP bot (Maddy) filed this after observing 3 unprovoked `copres_next_anchor` firings in <40s on a greeting — the OSS-visible analog is `slide_control`.

## Trade-off

Toggling `presenter-mode.sh start N` mid-session won't hot-reload the tool list (voice-agent must restart). The existing workflow already runs `presenter-mode.sh` before the voice agent, so the contract holds in normal use.

## Test plan

- [x] `python3 tests/inline-tools-presenter-gate.test.py` — PASS
- [ ] Manual: start voice agent without sentinel → `slide_control` absent from tool list
- [ ] Manual: `bash scripts/presenter-mode.sh start 60`, restart voice agent → `slide_control` present

## Related

- #1102 — discord-voice system prompt tightening (adjacent observability angle)
- Closed #436 — same sentinel, different bug class

🤖 Generated with [Claude Code](https://claude.com/claude-code)