### PR TITLE
docs(CLAUDE.md): add Slack access control section mirroring Discord's (closes #895)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,22 @@ To allow additional senders after onboarding: add their numeric Telegram user ID
 
 Telegram tasks include an `access_tier` field set by the bridge (same tiers as Discord).
 
+## Slack access control
+
+Slack tasks include an `access_tier` field set by the bridge:
+- **owner**: Full access — process normally with all capabilities.
+- **team**: Delegate to sandboxed agent (`codex exec --sandbox read-only`). No system mutations.
+- **other**: Delegate to sandboxed agent. Information only — answer questions about Sutando.
+
+Tier resolution uses `tierMap` in `~/.claude/channels/slack/access.json`:
+- `tierMap` absent → every `allowFrom` user defaults to `"owner"` (preserves pre-tierMap behavior).
+- `tierMap` present, uid missing → degrades to `"other"` (fail-safe — prevents silent escalation when operator forgets to add a tierMap line).
+- `tierMap` present, uid present → use the mapped tier.
+
+Non-owner tasks are processed via the sandboxed path — never with full core agent capabilities.
+
+**In-band enforcement** matches Discord: non-owner task files include a `===SUTANDO SYSTEM INSTRUCTIONS===` block injected by the bridge. Follow those instructions verbatim; they specify the exact `codex exec --sandbox read-only` command and constrain what you're allowed to do with the result.
+
 ## Discord access control
 
 Discord tasks include an `access_tier` field set by the bridge:


### PR DESCRIPTION
## Summary

- Adds `## Slack access control` section to `CLAUDE.md` immediately before `## Discord access control` (closes #895)
- Documents the same tier model (owner/team/other) and sandboxing rules that Discord has
- Accurately reflects `src/slack-bridge.py` tier resolution logic:
  - `tierMap` absent → defaults to `"owner"` (pre-tierMap backward compat)
  - `tierMap` present + uid missing → degrades to `"other"` (fail-safe, not `"owner"`)
  - `tierMap` present + uid present → mapped tier

> **Note**: the proposed section in the issue says "users without a tierMap entry default to owner" — that's only true when `tierMap` is absent. When `tierMap` exists but the uid is missing, `slack-bridge.py:336` explicitly degrades to `"other"` to prevent silent privilege escalation. The section here reflects the actual code behavior.

## Test plan

- [x] Diff reviewed — section accurately mirrors `src/slack-bridge.py:187–339`
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)