### PR TITLE
refactor(task-bridge): unified skip-marker detection via detectSkipMarker() (closes #896 task-bridge)

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -64,6 +64,22 @@ mkdirSync(RESULT_DIR, { recursive: true });
 
 function ts(): string { return new Date().toISOString().slice(11, 23); }
 
+/** Detect a skip marker at the start of a result body (#896).
+ * Mirrors the SKIP phase of src/result_markers.py:parse_markers().
+ * Returns the skip reason string if matched, null otherwise.
+ * Recognised skip markers (case-insensitive where noted):
+ *   [no-send]           → "no-send"
+ *   [REPLIED]           → "REPLIED"
+ *   [deduped: task-X]   → "deduped:task-X" */
+function detectSkipMarker(text: string): string | null {
+	const t = text.trimStart();
+	if (/^\[no-send\]/i.test(t)) return 'no-send';
+	if (/^\[REPLIED\]/.test(t)) return 'REPLIED';
+	const m = /^\[deduped:\s*([^\]]+)\]/i.exec(t);
+	if (m) return `deduped:${m[1].trim()}`;
+	return null;
+}
+
 /**
  * Write a chat-path task file so the dashboard tracks chat-originated work.
  * Called by the core agent (Claude Code) when it accepts a non-trivial task from chat.
@@ -662,13 +678,12 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					setTimeout(() => archiveFile(path, 'results', `voice-${Date.now()}`), 10_000);
 					continue;
 				}
-				// Deduped-marker result: agent consolidated this task's reply
-				// into another task's result file. Mark this task done silently
-				// and archive — no Discord post, no voice narration, no timeout.
-				// Format: first line is "[deduped: <other-task-id>]" (rest of
-				// file optional, displayed as the result body in the UI).
-				if (file.startsWith('task-') && /^\s*\[deduped:\s*task-/i.test(result)) {
-					console.log(`${ts()} [TaskBridge] ${taskId} is deduped marker; archiving silently`);
+				// Skip-marker result: agent marked this task as deduped, no-send,
+				// or already-replied. Archive silently — no Discord post, no voice
+				// narration, no timeout. Unified via detectSkipMarker() (#896).
+				const _skipReason = file.startsWith('task-') ? detectSkipMarker(result) : null;
+				if (_skipReason) {
+					console.log(`${ts()} [TaskBridge] ${taskId} has skip marker [${_skipReason}]; archiving silently`);
 					_sendTaskStatus?.(taskId, 'done', result.slice(0, 60), result);
 					_deliveredResults.add(file);
 					_pendingTasks.delete(taskId);

--- a/tests/bridge-marker-no-leak.test.py
+++ b/tests/bridge-marker-no-leak.test.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
 Structural cross-check that every bridge routes its result-marker decisions
-through `src/result_markers.py:parse_markers` (#873). This is the
-no-leak invariant guard: as long as each bridge calls the unified parser,
-the per-bridge implementations can't drift back to hand-rolled startswith
-checks that miss markers and ship them as literal text.
+through a unified parser. This is the no-leak invariant guard: as long as
+each bridge calls the parser, the per-bridge implementations can't drift
+back to hand-rolled startswith checks that miss markers and ship them as
+literal text.
 
 Why structural and not behavioral: behavioral cross-bridge testing would
 require importing each bridge module, which has side effects (Bolt App
@@ -14,14 +14,16 @@ parse_markers call with a hand-rolled regex again?" — at near-zero cost
 and zero import surface.
 
 Guards:
-  1. src/slack-bridge.py imports parse_markers from result_markers
-  2. src/telegram-bridge.py imports parse_markers from result_markers
-  3. Each bridge's marker-handling block calls parse_markers(...)
-  4. result_markers.py exposes the public surface parse_markers + Action
+  1. src/result_markers.py exposes public surface parse_markers + Action
+  2. src/slack-bridge.py imports and calls parse_markers
+  3. src/telegram-bridge.py imports and calls parse_markers
+  4. src/task-bridge.ts has detectSkipMarker() covering all three skip
+     markers ([no-send], [REPLIED], [deduped:]) — TS analog of the skip
+     phase in result_markers.py (#896)
+  5. Behavior smoke test of the Python parser itself
 
-Discord and task-bridge are NOT yet wired through the unified parser in
-this PR (intentional — landing slack + telegram first as the high-impact
-bug fixes). When they're refactored in a follow-up, add their guards here.
+When discord-bridge.py is wired through parse_markers (PR #1174), add a
+guard here matching the pattern in guards 2 and 3.
 
 Run: python3 tests/bridge-marker-no-leak.test.py
 Exit: 0 on pass, 1 on fail.
@@ -82,7 +84,30 @@ def main() -> int:
             "the unified-parser wire-through likely got dropped"
         )
 
-    # 4. Behavior smoke test of the parser itself
+    # 4. Task-bridge (TypeScript) has detectSkipMarker() covering all skip
+    #    markers (#896). The TS port doesn't share the Python module but must
+    #    handle the same three skip markers so no marker leaks through voice.
+    tb_ts = REPO / "src" / "task-bridge.ts"
+    tb_ts_src = tb_ts.read_text()
+    if "detectSkipMarker" not in tb_ts_src:
+        return fail(
+            "src/task-bridge.ts missing detectSkipMarker() function — "
+            "skip markers ([no-send],[REPLIED],[deduped:]) not handled (#896)"
+        )
+    for marker in ("no-send", "REPLIED", "deduped"):
+        if marker not in tb_ts_src:
+            return fail(
+                f"src/task-bridge.ts detectSkipMarker does not cover [{marker}] — "
+                "incomplete skip-marker support (#896)"
+            )
+    # Must call detectSkipMarker in the result-processing loop, not just define it.
+    if tb_ts_src.count("detectSkipMarker(") < 2:
+        return fail(
+            "src/task-bridge.ts defines detectSkipMarker but appears not to call it "
+            "in the result-processing loop (#896)"
+        )
+
+    # 5. Behavior smoke test of the Python parser itself
     sys.path.insert(0, str(REPO / "src"))
     from result_markers import parse_markers
 
@@ -107,7 +132,7 @@ def main() -> int:
     if not any(a.kind == "attach" for a in r.actions):
         return fail("parse_markers did not emit an attach action")
 
-    print("PASS: bridges route marker decisions through parse_markers + parser strips all markers from body.")
+    print("PASS: bridges route marker decisions through unified parser; task-bridge detectSkipMarker covers all skip markers; parser strips all markers from body.")
     return 0
 
 


### PR DESCRIPTION
## Problem

`src/task-bridge.ts` only handled the `[deduped:]` skip marker via a one-off regex. The `[no-send]` and `[REPLIED]` markers were silently ignored — result bodies containing these markers were narrated to the voice agent as literal text instead of being archived.

This is the TypeScript-side complement to the Python `parse_markers()` work in #873. See also #1174 (discord-bridge part, already in review).

## Solution

Add `detectSkipMarker(text: string): string | null` — a minimal TS analog of the SKIP phase in `src/result_markers.py:parse_markers()`. It recognizes:

- `[no-send]` → `"no-send"`
- `[REPLIED]` → `"REPLIED"`
- `[deduped: task-X]` → `"deduped:task-X"`

Replace the ad-hoc regex at `startResultWatcher` with a `detectSkipMarker()` call so all three skip markers silently archive the result file without voice narration, Discord post, or timeout trigger.

## Test

Extends `tests/bridge-marker-no-leak.test.py` with a new guard (4) that:
- Verifies `detectSkipMarker` function exists in `task-bridge.ts`
- Verifies it covers all three skip markers (`no-send`, `REPLIED`, `deduped`)
- Verifies it is called inside the result-processing loop (not just defined)

```
$ python3 tests/bridge-marker-no-leak.test.py
PASS: bridges route marker decisions through unified parser; task-bridge detectSkipMarker covers all skip markers; parser strips all markers from body.
```

## Notes

- `[channel:]` and `[file:|send:|attach:]` markers are Discord/Telegram concepts; task-bridge doesn't route to channels or attach files, so they're intentionally excluded from the TS port.
- The discord-bridge guard for this test file belongs with PR #1174 (where that wiring lives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)