### PR TITLE
fix(watch-tasks-stream): printf+exit 0 to propagate EPIPE immediately (closes #1088 Mode A)

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -71,9 +71,11 @@ trap 'rm -f "$PID_FILE"' EXIT
 
 # Initial sweep — surface any pre-existing tasks that arrived during a
 # restart gap.
+# printf || exit 0: if Monitor's read end is already gone when we start,
+# the first write fails with EPIPE and we exit immediately (#1088 Mode A).
 shopt -s nullglob
 for f in "$TASKS_DIR"/*.txt; do
-  echo "TASK_FILE: $(basename "$f")"
+  printf 'TASK_FILE: %s\n' "$(basename "$f")" || exit 0
 done
 shopt -u nullglob
 
@@ -97,6 +99,12 @@ shopt -u nullglob
 #    rename — including the source path AFTER the file has moved out.
 #    `[ -f "$path" ]` filters those rename-OUT-of-watched-dir events.
 #    Caught 2026-05-03 #1 (PR #572).
+#
+# printf || exit 0: unlike `echo`, `printf` propagates EPIPE immediately
+# at the first failed kernel write, not after the kernel pipe buffer fills
+# (~100 events, ~64KB). When Monitor's read end closes (consumer exits or
+# session ends), the next event write exits immediately instead of silently
+# buffering for hours — fixes the 2026-05-23 4h DM-loss incident (#1088).
 fswatch \
   -l 0.5 \
   --event Created \
@@ -107,7 +115,7 @@ fswatch \
     *.txt)
       parent="$(dirname "$path")"
       if [ "$parent" = "$TASKS_DIR_ABS" ] && [ -f "$path" ]; then
-        echo "TASK_FILE: $(basename "$path")"
+        printf 'TASK_FILE: %s\n' "$(basename "$path")" || exit 0
       fi
       ;;
   esac

--- a/tests/watch-tasks-stream-epipe.test.py
+++ b/tests/watch-tasks-stream-epipe.test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Structural guards for src/watch-tasks-stream.sh EPIPE fixes (#1088).
+
+Mode A (EPIPE-on-dead-reader): the watcher silently buffered ~100 events
+into the kernel pipe before dying, causing a 4h DM-loss incident on
+2026-05-23. Fix: replace bare `echo` with `printf ... || exit 0` so the
+first failed write propagates EPIPE immediately.
+
+These tests verify the source has the correct shell patterns so a future
+refactor can't regress back to bare echo without failing CI.
+
+Run: python3 tests/watch-tasks-stream-epipe.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "src" / "watch-tasks-stream.sh"
+
+
+def fail(msg: str) -> int:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if not SRC.exists():
+        return fail(f"{SRC} not found")
+
+    src = SRC.read_text()
+
+    # A1: printf used for TASK_FILE output (not bare echo)
+    if 'echo "TASK_FILE:' in src or "echo 'TASK_FILE:" in src:
+        return fail(
+            "watch-tasks-stream.sh still uses bare echo for TASK_FILE output — "
+            "must use printf to propagate EPIPE immediately (#1088 Mode A)"
+        )
+
+    # A2: printf present for TASK_FILE
+    if "printf 'TASK_FILE:" not in src and 'printf "TASK_FILE:' not in src:
+        return fail(
+            "watch-tasks-stream.sh has no printf 'TASK_FILE:' call — "
+            "EPIPE fix (#1088) may be missing"
+        )
+
+    # A3: || exit pattern on TASK_FILE printf lines
+    # Both the initial sweep and the event loop must use || exit.
+    lines = src.splitlines()
+    task_file_printf_lines = [
+        (i + 1, line.strip())
+        for i, line in enumerate(lines)
+        if "printf" in line and "TASK_FILE" in line
+    ]
+    if not task_file_printf_lines:
+        return fail(
+            "No printf TASK_FILE lines found in watch-tasks-stream.sh"
+        )
+    for lineno, line in task_file_printf_lines:
+        if "|| exit" not in line:
+            return fail(
+                f"watch-tasks-stream.sh line {lineno}: printf TASK_FILE missing '|| exit' "
+                f"— EPIPE not propagated: {line!r} (#1088 Mode A)"
+            )
+
+    # A4: both initial sweep and event loop use printf (count >= 2 printf TASK_FILE lines)
+    if len(task_file_printf_lines) < 2:
+        return fail(
+            f"Only {len(task_file_printf_lines)} printf TASK_FILE line(s) found — "
+            "expected at least 2 (initial sweep + event loop) (#1088)"
+        )
+
+    print(
+        f"PASS: watch-tasks-stream.sh uses printf+exit for TASK_FILE output "
+        f"({len(task_file_printf_lines)} sites) — EPIPE propagates immediately (#1088)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

`src/watch-tasks-stream.sh` used bare `echo "TASK_FILE: ..."` to emit events. Unlike `printf`, `echo` does NOT propagate EPIPE immediately — it silently buffers writes into the kernel pipe buffer (~64KB on macOS, enough for ~100 events at our tiny payload size). When Monitor's read end closes (session compaction, restart, or ⌘Q), the watcher keeps buffering silently until the buffer fills.

This was the root cause of the 2026-05-23 incident: 3 owner DMs were correctly written to `tasks/` by discord-bridge but the running Claude session never received `TASK_FILE` events for ~4h (buffer never filled on low-DM traffic, watcher appeared alive).

Diagnosed and reproduced by Lucy (Mac Studio bot) in issue #1088.

## Fix

Replace both `echo "TASK_FILE: ..."` calls with `printf 'TASK_FILE: %s\n' ... || exit 0`:

- **Initial sweep** (lines 76–78): `printf ... || exit 0`
- **Event loop** (line 110): `printf ... || exit 0`

`printf` returns non-zero on EPIPE at the first failed kernel write. When Monitor's read end closes, the next event write exits immediately. When the watcher exits, the read end of the `fswatch | while` pipe closes, sending SIGPIPE to fswatch — no orphaned fswatch.

## Mode B note

Mode B (PPID=1 reparenting when no events are flowing) is not fixed here — the watcher could still sit idle as an orphan if no tasks arrive after the consumer exits. The existing PID-file + `startup.sh` reaper covers this on next restart. A follow-up PR can add a periodic stdout liveness check if Mode B becomes a real-world problem.

## Test

```bash
$ python3 tests/watch-tasks-stream-epipe.test.py
PASS: watch-tasks-stream.sh uses printf+exit for TASK_FILE output (2 sites) — EPIPE propagates immediately (#1088).
```

4 structural guards verifying `printf+exit` at both call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)