### PR TITLE
feat(util-paths): SUTANDO_HOST_LABEL stable-identity override for per-machine Memory paths (closes #871)

### DIFF
--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -80,13 +80,23 @@ def _workspace_root() -> Path:
         return Path.home() / ".sutando" / "workspace"
 
 
+def host_label() -> str:
+    """Return the stable host identifier for per-machine Memory paths.
+
+    Priority:
+      1. `$SUTANDO_HOST_LABEL` — explicit override (useful when the Mac has
+         been renamed in System Settings and the hostname keeps changing).
+      2. `socket.gethostname()` short form — the default pre-#871 behavior.
+    """
+    return os.environ.get("SUTANDO_HOST_LABEL") or socket.gethostname().split(".")[0]
+
+
 def _private_machine_dir() -> Path | None:
     root = _memory_dir_env()
     if not root:
         return None
     expanded = os.path.expanduser(root)
-    host = socket.gethostname().split(".")[0]
-    return Path(expanded) / f"machine-{host}"
+    return Path(expanded) / f"machine-{host_label()}"
 
 
 def personal_path(filename: str, workspace: Path | None = None) -> Path:

--- a/src/util_paths.ts
+++ b/src/util_paths.ts
@@ -62,13 +62,25 @@ export function memoryDirEnv(): string | undefined {
 	return undefined;
 }
 
+/**
+ * Return the stable host identifier for per-machine Memory paths.
+ *
+ * Priority:
+ *   1. `$SUTANDO_HOST_LABEL` — explicit override (useful when the Mac has
+ *      been renamed in System Settings and the hostname keeps changing).
+ *   2. `hostname()` short form — the default pre-#871 behavior.
+ */
+export function hostLabel(): string {
+	return process.env.SUTANDO_HOST_LABEL || hostname().split('.')[0];
+}
+
 /** Per-machine resolver. */
 export function personalPath(filename: string, workspace?: string): string {
 	const ws = workspace ?? resolveWorkspace();
 	const privateRoot = memoryDirEnv();
 	if (privateRoot) {
 		const root = expandHome(privateRoot);
-		const host = hostname().split('.')[0];
+		const host = hostLabel();
 		const candidate = join(root, `machine-${host}`, filename);
 		if (existsSync(candidate)) return candidate;
 	}
@@ -83,7 +95,7 @@ export function personalPath(filename: string, workspace?: string): string {
 	// check fails gracefully.
 	if (privateRoot) {
 		const root = expandHome(privateRoot);
-		const host = hostname().split('.')[0];
+		const host = hostLabel();
 		return join(root, `machine-${host}`, filename);
 	}
 	if (filename === 'stand-avatar.png') return join(ws, 'assets', filename);

--- a/tests/util-paths-memory-dir.test.py
+++ b/tests/util-paths-memory-dir.test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Tests for the SUTANDO_PRIVATE_DIR -> SUTANDO_MEMORY_DIR rename (#870).
+"""Tests for the SUTANDO_PRIVATE_DIR -> SUTANDO_MEMORY_DIR rename (#870)
+and the SUTANDO_HOST_LABEL stable-identity override (#871).
 
 Verifies:
   1. SUTANDO_MEMORY_DIR is honored as the canonical env var.
@@ -7,6 +8,9 @@ Verifies:
   3. SUTANDO_MEMORY_DIR wins when both are set.
   4. A deprecation warning is emitted on every read of the legacy alias.
   5. Neither set -> None (no warning).
+  6. SUTANDO_HOST_LABEL overrides hostname() in _private_machine_dir().
+  7. host_label() returns SUTANDO_HOST_LABEL when set.
+  8. host_label() falls back to hostname short-form when unset.
 
 Run: python3 tests/util-paths-memory-dir.test.py
 Exit: 0 on pass, 1 on fail.
@@ -26,12 +30,13 @@ sys.path.insert(0, str(ROOT / "src"))
 from util_paths import (  # noqa: E402
     _memory_dir_env,
     _private_machine_dir,
+    host_label,
     shared_personal_path,
 )
 
 
 def clear_env():
-    for k in ("SUTANDO_MEMORY_DIR", "SUTANDO_PRIVATE_DIR"):
+    for k in ("SUTANDO_MEMORY_DIR", "SUTANDO_PRIVATE_DIR", "SUTANDO_HOST_LABEL"):
         os.environ.pop(k, None)
 
 
@@ -129,6 +134,51 @@ class SharedPersonalPathTests(unittest.TestCase):
         with redirect_stderr(io.StringIO()):
             p = shared_personal_path("MEMORY.md", workspace=Path("/tmp/ws"))
         self.assertEqual(p, Path("/tmp/legacy-mem/MEMORY.md"))
+
+
+class HostLabelTests(unittest.TestCase):
+    """SUTANDO_HOST_LABEL stable-identity override (#871)."""
+
+    def setUp(self):
+        clear_env()
+        import importlib
+        import util_paths as _up
+        importlib.reload(_up)
+
+    def tearDown(self):
+        clear_env()
+        import importlib
+        import util_paths as _up
+        importlib.reload(_up)
+
+    def test_host_label_default_is_hostname(self):
+        expected = socket.gethostname().split(".")[0]
+        self.assertEqual(host_label(), expected)
+
+    def test_host_label_env_override(self):
+        os.environ["SUTANDO_HOST_LABEL"] = "my-stable-mac"
+        import importlib
+        import util_paths as _up
+        importlib.reload(_up)
+        self.assertEqual(_up.host_label(), "my-stable-mac")
+
+    def test_private_machine_dir_uses_host_label(self):
+        os.environ["SUTANDO_MEMORY_DIR"] = "/tmp/memdir"
+        os.environ["SUTANDO_HOST_LABEL"] = "lab-mini"
+        import importlib
+        import util_paths as _up
+        importlib.reload(_up)
+        with redirect_stderr(io.StringIO()):
+            p = _up._private_machine_dir()
+        self.assertEqual(p, Path("/tmp/memdir/machine-lab-mini"))
+
+    def test_private_machine_dir_default_hostname_unchanged(self):
+        os.environ["SUTANDO_MEMORY_DIR"] = "/tmp/memdir"
+        # No SUTANDO_HOST_LABEL set — should use actual hostname
+        host = socket.gethostname().split(".")[0]
+        with redirect_stderr(io.StringIO()):
+            p = _private_machine_dir()
+        self.assertEqual(p, Path(f"/tmp/memdir/machine-{host}"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `SUTANDO_HOST_LABEL` env var as an explicit override for the per-machine Memory path (`$SUTANDO_MEMORY_DIR/machine-<host>/`)
- Implements the override in both Python (`src/util_paths.py`) and TypeScript (`src/util_paths.ts`) helpers
- Exposes `host_label()` (Python) / `hostLabel()` (TS) as public helpers for the Swift component to mirror (Swift adoption tracked in stando repo per architecture split — out of scope for this PR per issue #871 scope)

**Why**: When a Mac is renamed in System Settings, the hostname changes and the per-machine Memory dir silently rotates to a new path — `pending-questions.md`, `stand-identity.json`, etc. are orphaned in the old dir. `SUTANDO_HOST_LABEL=my-stable-mac` pins the path regardless of hostname churn. Unset = hostname (today's behavior, no regressions).

## Changes

| File | Change |
|------|--------|
| `src/util_paths.py` | Add `host_label()`, use it in `_private_machine_dir()` |
| `src/util_paths.ts` | Add `hostLabel()`, use it in both branches of `personalPath()` |
| `tests/util-paths-memory-dir.test.py` | 4 new tests: default-to-hostname, env-override, `_private_machine_dir` uses label, backward-compat; 14/14 pass |

## Test plan

- [x] `python3 tests/util-paths-memory-dir.test.py` → 14/14 pass
- [x] `npm run typecheck` → clean
- [x] `python3 scripts/check-utc-z-strftime.py` → pass
- [x] Pre-existing TS test failures (5) are on main, not introduced here

🤖 Generated with [Claude Code](https://claude.com/claude-code)