### PR TITLE
refactor(slack-bridge): mtime-based cache for load_allowed/load_tier_map (closes #894)

### DIFF
--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -169,19 +169,54 @@ def presenter_mode_active() -> bool:
 
 ACCESS_FILE = Path.home() / ".claude" / "channels" / "slack" / "access.json"
 
+# Mtime-based access-config cache (issue #894). Both load_allowed() and
+# load_tier_map() read the same file — we re-parse only when the file's
+# mtime changes so the I/O cost is amortized across the daemon's lifetime.
+_access_cache: dict = {}
+_access_cache_lock = threading.Lock()
+
+
+def _load_access_json() -> tuple:
+    """Return (allowed_set_or_None, tier_map_dict) from access.json.
+
+    Re-reads the file only when its mtime changes; returns cached values
+    on every other call. `allowed` is None when the file is absent (TOFU-
+    eligible), set() when explicitly empty, or a populated set. `tier_map`
+    is always a dict (empty when the key is absent or the file is missing).
+    """
+    global _access_cache
+    try:
+        exists = ACCESS_FILE.exists()
+        mtime: object = ACCESS_FILE.stat().st_mtime if exists else None
+    except OSError:
+        exists, mtime = False, None
+
+    with _access_cache_lock:
+        if _access_cache.get("_mtime") == mtime:
+            return _access_cache["allowed"], _access_cache["tier_map"]
+
+        if not exists:
+            allowed = None
+            tier_map: dict = {}
+        else:
+            try:
+                data = json.loads(ACCESS_FILE.read_text())
+                allowed = set(data.get("allowFrom", []))
+                tier_map = data.get("tierMap") or {}
+            except (json.JSONDecodeError, OSError):
+                allowed = set()
+                tier_map = {}
+
+        _access_cache = {"_mtime": mtime, "allowed": allowed, "tier_map": tier_map}
+        return allowed, tier_map
+
 
 def load_allowed():
     """Return set of allowed Slack user IDs, or None if access.json missing.
 
     None vs empty-set: file-missing means never-configured (TOFU-eligible);
     empty allowFrom means admin explicitly locked it down (no TOFU)."""
-    try:
-        data = json.loads(ACCESS_FILE.read_text())
-        return set(data.get("allowFrom", []))
-    except FileNotFoundError:
-        return None
-    except Exception:
-        return set()
+    return _load_access_json()[0]
 
 
 def load_tier_map() -> dict:
@@ -189,11 +224,7 @@ def load_tier_map() -> dict:
     empty dict if missing. Recognized tiers: "owner", "team", "other".
     Unmapped users default to "owner" — preserves the pre-tierMap behavior
     where every entry in `allowFrom` was treated as owner-tier."""
-    try:
-        data = json.loads(ACCESS_FILE.read_text())
-        return data.get("tierMap") or {}
-    except Exception:
-        return {}
+    return _load_access_json()[1]
 
 
 def tofu_onboard(user_id: str, username: str | None) -> set:

--- a/tests/slack-bridge-access.test.py
+++ b/tests/slack-bridge-access.test.py
@@ -46,17 +46,29 @@ def main() -> int:
 
     src = BRIDGE.read_text()
 
-    # 1. load_allowed returns None on FileNotFoundError
+    # 1. load_allowed returns None when ACCESS_FILE is missing.
+    #    The None vs empty-set distinction is load-bearing for TOFU onboarding.
+    #    Originally enforced in load_allowed() itself; after #894 the None path
+    #    lives in the shared _load_access_json() helper — check both shapes.
     load_match = re.search(
-        r"def load_allowed\(\):\s*\n([\s\S]{0,1500}?)(?=\n\ndef |\Z)",
+        r"def load_allowed\(\)[^:]*:\s*\n([\s\S]{0,1500}?)(?=\n\ndef |\Z)",
         src,
     )
     if not load_match:
         return fail("`load_allowed` function not found")
     block = load_match.group(1)
-    if not re.search(r"except\s+FileNotFoundError:\s*\n\s+return\s+None", block):
-        return fail("load_allowed must `return None` on FileNotFoundError "
+    # Shape A (pre-#894): function catches FileNotFoundError and returns None
+    has_shape_a = bool(re.search(r"except\s+FileNotFoundError:\s*\n\s+return\s+None", block))
+    # Shape B (post-#894): function delegates to a helper that sets allowed=None
+    has_shape_b = bool(re.search(r"_load_access_json\(\)", block))
+    if not has_shape_a and not has_shape_b:
+        return fail("load_allowed must either return None on FileNotFoundError directly "
+                    "or delegate to _load_access_json() which handles the None case "
                     "(TOFU relies on None vs empty-set distinction)", block)
+    # For shape B, verify the helper actually produces None on missing file.
+    if has_shape_b and not re.search(r"allowed\s*=\s*None", src):
+        return fail("_load_access_json() must set allowed=None when file is absent "
+                    "(TOFU relies on None vs empty-set distinction)", src)
 
     # 2. tofu_onboard exists with race-guard + 0o600 chmod
     tofu_match = re.search(

--- a/tests/slack-bridge-tier-map.test.py
+++ b/tests/slack-bridge-tier-map.test.py
@@ -197,6 +197,46 @@ def main() -> int:
         _resolve_tier("Uteam", tm_multi),
         "team",
     )
+
+    # --- Mtime-based cache tests (issue #894) ---
+    # load_allowed() and load_tier_map() both delegate to _load_access_json(),
+    # which caches the parsed result by file mtime so repeated calls within a
+    # burst don't re-read the file on every _write_task invocation.
+
+    import time as _time
+
+    load_allowed = mod.load_allowed
+
+    # Case 12: second call without file change returns same object (cache hit).
+    _write_access(mod, {"allowFrom": ["Ucached"], "tierMap": {"Ucached": "owner"}})
+    tm_first = load_tier_map()
+    tm_second = load_tier_map()
+    expect("repeated call same mtime → identical object", tm_first is tm_second, True)
+
+    # Case 13: load_allowed() cache hit — same object.
+    al_first = load_allowed()
+    al_second = load_allowed()
+    expect("load_allowed same mtime → identical object", al_first is al_second, True)
+
+    # Case 14: mtime bump invalidates cache → new value returned.
+    # Use os.utime to advance mtime without waiting a full second.
+    import os as _os
+    new_payload = {"allowFrom": ["Ucached", "Unew"], "tierMap": {"Ucached": "owner", "Unew": "team"}}
+    mod.ACCESS_FILE.write_text(json.dumps(new_payload))
+    future_mtime = _time.time() + 1  # 1 s ahead guarantees a different mtime
+    _os.utime(mod.ACCESS_FILE, (future_mtime, future_mtime))
+    tm_after = load_tier_map()
+    expect("mtime bump → cache miss, new tier_map", tm_after.get("Unew"), "team")
+
+    # Case 15: file deleted → None for allowed (TOFU-eligible), {} for tier_map.
+    # The prior call cached mtime=T; deleting the file makes stat() raise
+    # OSError → mtime=None ≠ T → natural cache miss; no need to clear cache.
+    mod.ACCESS_FILE.unlink(missing_ok=True)
+    al_deleted = load_allowed()
+    tm_deleted = load_tier_map()
+    expect("deleted file → load_allowed returns None", al_deleted, None)
+    expect("deleted file → load_tier_map returns {}", tm_deleted, {})
+
     print(f"Results: {passes} passed, {fails} failed")
     return 0 if fails == 0 else 1
 


### PR DESCRIPTION
## Summary

- `load_allowed()` and `load_tier_map()` both read `access.json` on every `_write_task` call — O(N) I/O for N Slack events in a long-running daemon
- Introduce `_load_access_json()`: checks `stat().st_mtime` before re-parsing; only re-reads when the file changes
- Both helpers become thin wrappers returning `[0]` / `[1]` from the cached tuple
- The `None` vs `set()` TOFU contract is preserved (`allowed = None` when file absent, in the shared helper)

## Tests

- `tests/slack-bridge-tier-map.test.py`: 5 new cache tests (same-mtime returns identical object, mtime bump invalidates, deleted file → None/{}). 19/19 pass.
- `tests/slack-bridge-access.test.py`: structural check updated to accept both the pre-#894 `except FileNotFoundError: return None` shape and the new `_load_access_json()` delegation shape. Still passes.

## Test plan

- [ ] `python3 tests/slack-bridge-tier-map.test.py` → 19 passed
- [ ] `python3 tests/slack-bridge-access.test.py` → 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)