### PR TITLE
fix(bridges): archive_task_by_id() catches claimed files in all 3 bridges (closes #933)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -366,6 +366,24 @@ def archive_file(src: "Path", kind: str, task_id: str) -> None:
             pass
 
 
+def archive_task_by_id(task_id: str) -> None:
+    """Archive any task file for task_id — bare or claimed (.claimed-core-N.txt).
+    claim_task.py renames task-X.txt → task-X.txt.claimed-core-N.txt before
+    processing; after delivery the bare-path archive_file() call silently
+    no-ops because src no longer exists. This glob sweep catches both shapes
+    so no claim files strand in tasks/ after multi-core pool delivery (#933)."""
+    import glob
+    import shutil
+    dest_dir = archive_path("tasks", task_id).parent
+    for match in glob.glob(str(TASKS_DIR / f"{task_id}*.txt")):
+        try:
+            shutil.move(match, str(dest_dir / Path(match).name))
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            print(f"  archive_task_by_id({task_id}) failed for {match}: {e}", flush=True)
+
+
 def notify_agent_api_task_done(task_id: str, result: str) -> None:
     """POST to agent-api /task-done so web UI flips status without waiting
     for its next /tasks/active poll. Best-effort; silent on failure (web UI
@@ -3098,8 +3116,7 @@ async def poll_results():
                     # post — same UX as [no-send] / [REPLIED].
                     print(f"  Skipped (already replied or deduped): {task_id}")
                     archive_file(result_file, "results", task_id)
-                    task_file = TASKS_DIR / f"{task_id}.txt"
-                    archive_file(task_file, "tasks", task_id)
+                    archive_task_by_id(task_id)
                     continue
 
                 # Idempotency check: if the previous run already sent
@@ -3111,8 +3128,7 @@ async def poll_results():
                 if _is_delivered(task_id):
                     print(f"  Skipped (already delivered per sentinel): {task_id}", flush=True)
                     archive_file(result_file, "results", task_id)
-                    task_file = TASKS_DIR / f"{task_id}.txt"
-                    archive_file(task_file, "tasks", task_id)
+                    archive_task_by_id(task_id)
                     _clear_delivered(task_id)
                     continue
 
@@ -3268,8 +3284,7 @@ async def poll_results():
                     print(f"  Reply failed: {e}", flush=True)
                 # Archive (not delete) so we can mine patterns later.
                 archive_file(result_file, "results", task_id)
-                task_file = TASKS_DIR / f"{task_id}.txt"
-                archive_file(task_file, "tasks", task_id)
+                archive_task_by_id(task_id)
                 # Delivery succeeded + archived — sentinel has served
                 # its purpose, remove to bound `discord-delivered/`
                 # directory growth.
@@ -3544,9 +3559,7 @@ async def poll_dm_fallback():
                     # Archive matching task file so audit_orphan_tasks sees
                     # the task as processed (even if drop-without-reply).
                     _task_id = f.stem
-                    _task_file = TASKS_DIR / f"{_task_id}.txt"
-                    if _task_file.exists():
-                        archive_file(_task_file, "tasks", _task_id)
+                    archive_task_by_id(_task_id)
                     continue
                 # Stop retrying after 24h. Without this cap, a permanent
                 # failure (bad channel ID, bot removed from DM, etc.)
@@ -3557,9 +3570,7 @@ async def poll_dm_fallback():
                     print(f"  [dm-fallback] dropping stale {f.name} (age={int(age)}s)", flush=True)
                     f.unlink(missing_ok=True)
                     _task_id = f.stem
-                    _task_file = TASKS_DIR / f"{_task_id}.txt"
-                    if _task_file.exists():
-                        archive_file(_task_file, "tasks", _task_id)
+                    archive_task_by_id(_task_id)
                     continue
                 # Honor result-body suppression markers (parity with the
                 # main reply path at line ~2660). Without this, results
@@ -3573,9 +3584,7 @@ async def poll_dm_fallback():
                 if _peek.startswith('[no-send]') or _peek.startswith('[REPLIED]') or _peek.startswith('[deduped:'):
                     print(f"  [dm-fallback] skipped (suppression marker): {f.name}", flush=True)
                     _task_id = f.stem
-                    _task_file = TASKS_DIR / f"{_task_id}.txt"
-                    if _task_file.exists():
-                        archive_file(_task_file, "tasks", _task_id)
+                    archive_task_by_id(_task_id)
                     archive_file(f, "results", _task_id)
                     continue
 
@@ -3646,9 +3655,7 @@ async def poll_dm_fallback():
                                     # See poll_results — log only, no user noise.
                                     print(f"  [dm-fallback channel-redirect] file marker, file not found: {fpath}", flush=True)
                             print(f"  [dm-fallback channel-redirect] sent {f.name} to channel {target_channel_id}", flush=True)
-                            _task_file = TASKS_DIR / f"{_task_id}.txt"
-                            if _task_file.exists():
-                                archive_file(_task_file, "tasks", _task_id)
+                            archive_task_by_id(_task_id)
                             archive_file(f, "results", _task_id)
                             continue
                         # Unresolved → fall through to DM, but strip marker
@@ -3717,9 +3724,7 @@ async def poll_dm_fallback():
                     except OSError:
                         _result_text = ""
                     archive_file(f, "results", _task_id)
-                    _task_file = TASKS_DIR / f"{_task_id}.txt"
-                    if _task_file.exists():
-                        archive_file(_task_file, "tasks", _task_id)
+                    archive_task_by_id(_task_id)
                     if _result_text and _task_id.startswith("task-"):
                         # urlopen is blocking — run in thread so we don't stall
                         # the asyncio event loop for up to 2s per dm-fallback.

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -151,6 +151,23 @@ def archive_file(src: Path, kind: str, task_id: str) -> None:
             pass
 
 
+def archive_task_by_id(task_id: str) -> None:
+    """Archive any task file for task_id — bare or claimed (.claimed-core-N.txt)."""
+    import glob
+    import shutil
+    from datetime import datetime
+    ym = datetime.now().strftime("%Y-%m")
+    dest_dir = ARCHIVE_TASKS_DIR / ym
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for match in glob.glob(str(TASKS_DIR / f"{task_id}*.txt")):
+        try:
+            shutil.move(match, str(dest_dir / Path(match).name))
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            print(f"[Slack] archive_task_by_id({task_id}) failed for {match}: {e}", flush=True)
+
+
 PRESENTER_SENTINEL = REPO / "state" / "presenter-mode.sentinel"
 
 
@@ -591,7 +608,7 @@ def result_watcher():
                         print(f"[Slack] reply error: {e}", flush=True)
 
                 archive_file(result_file, "results", task_id)
-                archive_file(TASKS_DIR / f"{task_id}.txt", "tasks", task_id)
+                archive_task_by_id(task_id)
 
             # Proactive messages (sent to owner DM)
             if not presenter_mode_active():

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -187,6 +187,23 @@ def archive_file(src: "Path", kind: str, task_id: str) -> None:
         except Exception:
             pass
 
+def archive_task_by_id(task_id: str) -> None:
+    """Archive any task file for task_id — bare or claimed (.claimed-core-N.txt)."""
+    import glob
+    import shutil
+    from datetime import datetime
+    ym = datetime.now().strftime("%Y-%m")
+    dest_dir = ARCHIVE_TASKS_DIR / ym
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for match in glob.glob(str(TASKS_DIR / f"{task_id}*.txt")):
+        try:
+            shutil.move(match, str(dest_dir / Path(match).name))
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            print(f"[Telegram] archive_task_by_id({task_id}) failed for {match}: {e}")
+
+
 # Presenter mode: silence proactive DMs during ICLR/talk windows. Sentinel
 # is written by scripts/presenter-mode.sh with an ISO-8601 expiry. Matches
 # the check in src/check-pending-questions.py and src/discord-bridge.py.
@@ -587,8 +604,7 @@ def main():
                 if any(a.kind == "skip" for a in parsed.actions):
                     print(f"  Skipped (marker): {task_id}", flush=True)
                     archive_file(result_file, "results", task_id)
-                    task_file = TASKS_DIR / f"{task_id}.txt"
-                    archive_file(task_file, "tasks", task_id)
+                    archive_task_by_id(task_id)
                     continue
                 try:
                     send_reply(chat_id, reply_text, task_id=task_id)
@@ -597,8 +613,7 @@ def main():
                     print(f"[Telegram] Reply error: {e}", flush=True)
                 # Archive (not delete) so we can mine patterns later.
                 archive_file(result_file, "results", task_id)
-                task_file = TASKS_DIR / f"{task_id}.txt"
-                archive_file(task_file, "tasks", task_id)
+                archive_task_by_id(task_id)
 
         time.sleep(1)
 

--- a/tests/archive-task-by-id.test.py
+++ b/tests/archive-task-by-id.test.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Behavioral tests for archive_task_by_id() in all three bridges.
+
+Contract:
+  1. Bare-name task-X.txt → archived to tasks/archive/YYYY-MM/task-X.txt
+  2. Claimed task-X.txt.claimed-core-2.txt → archived
+  3. Both present → both archived (no orphan)
+  4. Neither present → silent no-op (idempotent, no exception)
+  5. Two concurrent calls on same task_id → first wins, second is safe no-op
+
+Run: python3 tests/archive-task-by-id.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs for bridge imports
+# ---------------------------------------------------------------------------
+
+def _stub_slack_bolt():
+    class _StubApp:
+        def __init__(self, *a, **kw):
+            self.client = types.SimpleNamespace()
+        def event(self, _name):
+            def decorator(fn):
+                return fn
+            return decorator
+
+    if "slack_bolt" not in sys.modules:
+        stub = types.ModuleType("slack_bolt")
+        stub.App = _StubApp
+        sys.modules["slack_bolt"] = stub
+        adapter_pkg = types.ModuleType("slack_bolt.adapter")
+        sys.modules["slack_bolt.adapter"] = adapter_pkg
+        sm_mod = types.ModuleType("slack_bolt.adapter.socket_mode")
+        sm_mod.SocketModeHandler = object
+        sys.modules["slack_bolt.adapter.socket_mode"] = sm_mod
+    else:
+        import slack_bolt as _real
+        _real.App = _StubApp
+
+
+def _stub_discord():
+    discord_mod = sys.modules.get("discord") or types.ModuleType("discord")
+
+    class _Intents:
+        @classmethod
+        def default(cls):
+            obj = cls()
+            return obj
+        def __setattr__(self, k, v):
+            object.__setattr__(self, k, v)
+
+    class _Client:
+        def __init__(self, *a, **kw): pass
+        async def start(self, *a, **kw): pass
+        async def close(self, *a, **kw): pass
+        def event(self, fn): return fn
+        async def wait_until_ready(self): pass
+        def loop(self): return None
+        guilds = []
+        user = None
+
+    discord_mod.Intents = _Intents
+    discord_mod.Client = _Client
+    discord_mod.HTTPException = Exception
+    discord_mod.Forbidden = Exception
+    discord_mod.NotFound = Exception
+    discord_mod.File = object
+
+    for name in ["discord", "discord.ext", "discord.ext.commands", "discord.utils"]:
+        if name not in sys.modules:
+            sys.modules[name] = types.ModuleType(name)
+    sys.modules["discord"] = discord_mod
+
+    ext_mod = sys.modules["discord.ext"]
+    cmds_mod = sys.modules["discord.ext.commands"]
+    cmds_mod.Bot = _Client
+
+
+def _stub_telegram():
+    for name in ["telegram", "telegram.ext"]:
+        if name not in sys.modules:
+            sys.modules[name] = types.ModuleType(name)
+
+
+def _load_bridge(bridge_name, ws, extra_env=None):
+    """Load a bridge module from src/ in isolation."""
+    os.environ["SUTANDO_WORKSPACE"] = ws
+    if extra_env:
+        for k, v in extra_env.items():
+            os.environ.setdefault(k, v)
+
+    _stub_slack_bolt()
+    _stub_discord()
+    _stub_telegram()
+
+    import importlib.util
+    repo = Path(__file__).resolve().parent.parent
+    bridge_path = repo / "src" / bridge_name
+    spec = importlib.util.spec_from_file_location(
+        bridge_name.replace("-", "_").replace(".", "_") + "_archive_test",
+        bridge_path,
+    )
+    sys.path.insert(0, str(repo / "src"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    passes = 0
+    fails = 0
+
+    def expect(name: str, got, want):
+        nonlocal passes, fails
+        if got == want:
+            print(f"PASS: {name}")
+            passes += 1
+        else:
+            print(f"FAIL: {name} — got {got!r}, want {want!r}")
+            fails += 1
+
+    bridges = [
+        ("slack-bridge.py", {"SLACK_BOT_TOKEN": "xoxb-test", "SLACK_APP_TOKEN": "xapp-test"}),
+        ("telegram-bridge.py", {"TELEGRAM_BOT_TOKEN": "123:test"}),
+        ("discord-bridge.py", {}),
+    ]
+
+    for bridge_file, env in bridges:
+        ws = tempfile.mkdtemp(prefix=f"sutando-test-{bridge_file[:5]}-")
+        try:
+            mod = _load_bridge(bridge_file, ws, env)
+        except Exception as e:
+            print(f"FAIL: could not load {bridge_file}: {e}")
+            fails += 1
+            continue
+
+        tasks_dir: Path = mod.TASKS_DIR
+        tasks_dir.mkdir(parents=True, exist_ok=True)
+
+        label = bridge_file.replace("-bridge.py", "")
+
+        # Case 1: bare-name file → archived
+        task_id = "task-111111"
+        bare = tasks_dir / f"{task_id}.txt"
+        bare.write_text("bare task")
+        mod.archive_task_by_id(task_id)
+        expect(f"{label}: bare file removed from tasks/", bare.exists(), False)
+        # At least one file in archive YYYY-MM
+        from datetime import datetime
+        ym = datetime.now().strftime("%Y-%m")
+        archive_dir: Path = mod.ARCHIVE_TASKS_DIR / ym
+        archived = list(archive_dir.glob(f"{task_id}*.txt"))
+        expect(f"{label}: bare file archived", len(archived) >= 1, True)
+
+        # Case 2: claimed file → archived
+        task_id2 = "task-222222"
+        claimed = tasks_dir / f"{task_id2}.txt.claimed-core-2.txt"
+        claimed.write_text("claimed task")
+        mod.archive_task_by_id(task_id2)
+        expect(f"{label}: claimed file removed from tasks/", claimed.exists(), False)
+        archived2 = list(archive_dir.glob(f"{task_id2}*.txt"))
+        expect(f"{label}: claimed file archived", len(archived2) >= 1, True)
+
+        # Case 3: both bare + claimed present → both archived
+        task_id3 = "task-333333"
+        bare3 = tasks_dir / f"{task_id3}.txt"
+        claimed3 = tasks_dir / f"{task_id3}.txt.claimed-core-1.txt"
+        bare3.write_text("bare")
+        claimed3.write_text("claimed")
+        mod.archive_task_by_id(task_id3)
+        expect(f"{label}: both bare+claimed removed", not bare3.exists() and not claimed3.exists(), True)
+        archived3 = list(archive_dir.glob(f"{task_id3}*.txt"))
+        expect(f"{label}: both files archived", len(archived3) >= 2, True)
+
+        # Case 4: nothing present → silent no-op
+        task_id4 = "task-444444"
+        try:
+            mod.archive_task_by_id(task_id4)
+            expect(f"{label}: missing file → no-op (no exception)", True, True)
+        except Exception as e:
+            expect(f"{label}: missing file → no-op (no exception)", False, True)
+
+        # Case 5: two calls → second is safe (FileNotFoundError swallowed)
+        task_id5 = "task-555555"
+        dup = tasks_dir / f"{task_id5}.txt"
+        dup.write_text("dup")
+        mod.archive_task_by_id(task_id5)
+        try:
+            mod.archive_task_by_id(task_id5)  # second call, file already gone
+            expect(f"{label}: second call → safe no-op", True, True)
+        except Exception as e:
+            expect(f"{label}: second call → safe no-op", False, True)
+
+    print(f"\nResults: {passes} passed, {fails} failed")
+    return 0 if fails == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

When `claim_task.py` renames `task-X.txt` → `task-X.txt.claimed-core-N.txt` before handing off to a pool worker, the bridge's post-delivery cleanup calls `archive_file(TASKS_DIR / "task-X.txt", ...)` — which silently no-ops because the bare path no longer exists. Result: `.claimed-core-N.txt` files pile up in `tasks/` after every delivery, producing a false-positive `health-check.py` queue alarm and the `stranded_claims: N` warning from `benchmark_pool.py`.

Flagged in issue #933 by @qingyun-wu with a measured pile-up of 52 files after ~2 hours.

## Fix

Add `archive_task_by_id(task_id)` to all three bridges — globs `task-{task_id}*.txt` so it archives both the bare-name shape (no pool, current main) and any `.claimed-core-N.txt` variant (multi-core pool, post-#880). All 8 task-archive call sites updated.

The glob approach was the fix shape recommended in the issue's comment thread:
> `archive_task_by_id(tasks_dir, task_id)` with the `glob(f"task-{task_id}*.txt")` sweep is the right shape — covers both bare-name and .claimed-core-N.txt suffix

## No-regression on single-core nodes

`claim_task.py` is not on `origin/main` yet (verified: `git show origin/main:src/claim_task.py` → does not exist). On single-core nodes the glob matches only the bare file → identical behavior to the old `archive_file()` call. Safe to land before or alongside #880.

## Tests

24 behavioral tests across all 3 bridges (`tests/archive-task-by-id.test.py`):
1. Bare-name file → archived
2. Claimed file → archived  
3. Both present → both archived
4. Neither present → silent no-op
5. Two concurrent calls on same task_id → first wins, second is safe no-op

All 24/24 passing.