### PR TITLE
fix(dm-result-test): isolate discord_config.load_config in _with_access_json

### DIFF
--- a/tests/dm-result-send-dm.test.py
+++ b/tests/dm-result-send-dm.test.py
@@ -96,14 +96,20 @@ def _restore_transport(original):
 
 
 def _with_access_json(content, fn):
+    # Also blank out discord_config.load_config so the real workspace
+    # discord-config.json (which may have `owner` set) doesn't override
+    # the access_data-driven resolution paths under test.
     original = dm.ACCESS_JSON
+    original_load_config = dm.discord_config.load_config
     tmp = Path(tempfile.mkdtemp(prefix="sutando-dm-test-")) / "access.json"
     tmp.write_text(json.dumps(content))
     dm.ACCESS_JSON = tmp
+    dm.discord_config.load_config = lambda: {}
     try:
         fn()
     finally:
         dm.ACCESS_JSON = original
+        dm.discord_config.load_config = original_load_config
         tmp.unlink()
         tmp.parent.rmdir()
 


### PR DESCRIPTION
## Problem

`tests/dm-result-send-dm.test.py` was failing on any system where `discord-config.json` has an `owner` field set (real production installs).

`_with_access_json()` mocked `ACCESS_JSON` correctly but didn't suppress `discord_config.load_config()`, which reads the real `<workspace>/state/discord-config.json`. When that file has `owner: "<real-id>"`, `discord_config.resolve_owner_id(access_data)` returns that real ID at step 2 — before ever reaching the `tierMap` fallback path the tests were trying to exercise.

Result: `test_tier_map_resolution_skips_bot_lookup` fails with `AssertionError` (DM opens with real owner ID, not test's `tier-owner-id`). All subsequent tests never ran.

## Fix

In `_with_access_json()`, save and restore `dm.discord_config.load_config` alongside `ACCESS_JSON`, substituting `lambda: {}` so:
- No real workspace config leaks into tests
- `tierMap`-based resolution paths are exercised as intended
- `bot-filter` fallback path is exercised as intended (no config-driven owner short-circuits it)

## Tests

```
All send_dm integration tests passed.
```

5/5 tests passing (were 0/5 on any system with owner set in discord-config.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)