### PR TITLE
fix(discord-voice): reply in originating channel on peer-refusal, not owner DM — closes #1120

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -163,6 +163,11 @@ function getArg(name: string): string | undefined {
 }
 const GUILD_ID = getArg('guild');
 const CHANNEL_ID = getArg('channel');
+// Originating text channel + user for startup refusal replies (closes #1120).
+// When set, refusals (e.g. single-bot peer enforcement) are sent to the
+// originating channel instead of writing results/proactive-*.txt → owner DM.
+const REPLY_CHANNEL_ID = getArg('reply-channel');
+const REPLY_USER_ID = getArg('reply-user');
 
 // Owner-mode (issue #1016) — resolved from the workspace config
 // ($SUTANDO_WORKSPACE/config/discord-voice.json), NOT an env var and NOT a
@@ -1174,23 +1179,33 @@ async function start(): Promise<void> {
 			}
 		}
 		if (presentPeers.length > 0) {
-			console.error(`${ts()} [Setup] #1089 refusing to join: sutando peer(s) already present: ${presentPeers.join(', ')}`);
-			// Surface the refusal to the operator — without this they just see
-			// "nothing happens" when inviting a second bot to a channel that
-			// already has one. Drop a proactive result; the discord-bridge
-			// polls results/ and DMs proactive-*.txt to the owner. Best-effort:
-			// if the write fails the process still exits cleanly and
-			// Sutando.app's checkWatcher will retry once the peer leaves.
-			try {
-				const proactivePath = join(WORKSPACE_DIR, 'results', `proactive-${Date.now()}.txt`);
-				const channelName = (channel as any).name ?? CHANNEL_ID;
-				writeFileSync(
-					proactivePath,
-					`Skipping voice join in #${channelName} — peer already present: ${presentPeers.join(', ')}. ` +
-					`Single-bot enforcement (#1089); reinvite once they leave.\n`,
-				);
-			} catch (e) {
-				console.error(`${ts()} [Setup] #1089 couldn't surface refusal to operator:`, e);
+			const channelName = (channel as any).name ?? CHANNEL_ID;
+			const refusalMsg =
+				`Skipping voice join in #${channelName} — peer already present: ${presentPeers.join(', ')}. ` +
+				`Single-bot enforcement (#1089); reinvite once they leave.`;
+			console.error(`${ts()} [Setup] #1089 refusing to join: ${refusalMsg}`);
+			// Reply in the originating text channel (#1120) when we have a
+			// reply-channel ID (passed via --reply-channel by join_trigger.py).
+			// Falls back to the proactive-*.txt → owner-DM path when not set
+			// (e.g. server launched manually or from an older bridge version).
+			if (REPLY_CHANNEL_ID) {
+				try {
+					const replyCh = await client.channels.fetch(REPLY_CHANNEL_ID);
+					if (replyCh && 'send' in replyCh) {
+						const mention = REPLY_USER_ID ? `<@${REPLY_USER_ID}> ` : '';
+						await (replyCh as any).send(mention + refusalMsg);
+					}
+				} catch (e) {
+					console.error(`${ts()} [Setup] #1089 reply-channel send failed:`, e);
+				}
+			} else {
+				// Legacy fallback: write proactive-*.txt so the bridge DMs the owner.
+				try {
+					const proactivePath = join(WORKSPACE_DIR, 'results', `proactive-${Date.now()}.txt`);
+					writeFileSync(proactivePath, refusalMsg + '\n');
+				} catch (e) {
+					console.error(`${ts()} [Setup] #1089 couldn't surface refusal to operator:`, e);
+				}
 			}
 			process.exit(0); // clean exit — operator (Sutando.app checkWatcher) will retry later when peer leaves
 		}

--- a/skills/discord-voice/scripts/join_trigger.py
+++ b/skills/discord-voice/scripts/join_trigger.py
@@ -189,7 +189,9 @@ def _server_already_running(channel_id) -> bool:
     return False
 
 
-def _spawn_voice_server(guild_id, channel_id) -> bool:
+def _spawn_voice_server(
+    guild_id, channel_id, reply_channel_id=None, reply_user_id=None
+) -> bool:
     """Launch discord-voice-server.ts detached for guild+channel. Returns True
     on a successful spawn (the subprocess was started — not that it connected).
 
@@ -202,6 +204,10 @@ def _spawn_voice_server(guild_id, channel_id) -> bool:
     GEMINI_VOICE_API_KEY path) — matches the documented invocation. Detached
     via start_new_session so it survives the bridge restarting; stdout/stderr
     go to the workspace log so it isn't lost.
+
+    `reply_channel_id` and `reply_user_id`: when set, the server sends any
+    startup refusal (e.g. single-bot peer enforcement) to that text channel
+    instead of writing a proactive-*.txt file. Closes #1120.
     """
     if not _DISCORD_VOICE_SERVER.exists():
         return False
@@ -225,6 +231,10 @@ def _spawn_voice_server(guild_id, channel_id) -> bool:
         "--channel",
         str(channel_id),
     ]
+    if reply_channel_id is not None:
+        argv += ["--reply-channel", str(reply_channel_id)]
+    if reply_user_id is not None:
+        argv += ["--reply-user", str(reply_user_id)]
     try:
         subprocess.Popen(
             argv,
@@ -347,7 +357,13 @@ def handle_join_trigger(message) -> str:
     if _server_already_running(channel_id):
         return f"I'm already in **{channel_name}** — see you there."
 
-    if _spawn_voice_server(guild_id, channel_id):
+    # Thread the originating text channel + user so the voice server can reply
+    # there on startup refusals (e.g. peer enforcement) instead of writing to
+    # results/proactive-*.txt which DMs the owner via the bridge's poll loop.
+    reply_channel_id = getattr(getattr(message, "channel", None), "id", None)
+    reply_user_id = getattr(getattr(message, "author", None), "id", None)
+
+    if _spawn_voice_server(guild_id, channel_id, reply_channel_id, reply_user_id):
         # Queue context-prep AFTER successful spawn so the core only sees
         # the synthetic task when voice is actually on the way. No await /
         # block — voice and context-prep race; voice's first turn falls

--- a/tests/discord-voice-reply-where-invited.test.py
+++ b/tests/discord-voice-reply-where-invited.test.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for issue #1120 fix — join_trigger passes reply-channel/reply-user
+to the voice server so startup refusals go to the originating channel, not
+the owner's DMs via proactive-*.txt.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+REPO_ROOT = Path(__file__).parent.parent
+_SCRIPT = REPO_ROOT / "skills" / "discord-voice" / "scripts" / "join_trigger.py"
+
+# Load join_trigger without executing top-level subprocess / file-read calls.
+_spec = importlib.util.spec_from_file_location("join_trigger", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["join_trigger"] = _mod
+_spec.loader.exec_module(_mod)
+
+_spawn_voice_server = _mod._spawn_voice_server
+handle_join_trigger = _mod.handle_join_trigger
+
+
+def _make_message(channel_id="111", user_id="222", voice_channel=None):
+    """Construct a minimal mock discord.Message."""
+    msg = MagicMock()
+    msg.channel.id = channel_id
+    msg.author.id = user_id
+    # guild member's voice.channel (the voice room the owner is already in)
+    member = MagicMock()
+    if voice_channel is None:
+        voice_channel = MagicMock()
+        voice_channel.id = "vc-999"
+        voice_channel.name = "General"
+        voice_channel.guild.id = "guild-1"
+    member.voice.channel = voice_channel
+    msg.guild.get_member.return_value = member
+    msg.author.id = user_id
+    return msg
+
+
+class TestSpawnVoiceServerArgs(unittest.TestCase):
+    """_spawn_voice_server must pass --reply-channel and --reply-user when given."""
+
+    def _captured_argv(self, guild_id, channel_id, reply_ch=None, reply_user=None):
+        captured = {}
+
+        def fake_popen(argv, **kwargs):
+            captured["argv"] = argv
+            raise OSError("fake — don't actually spawn")
+
+        with patch("subprocess.Popen", side_effect=fake_popen):
+            _spawn_voice_server(guild_id, channel_id, reply_ch, reply_user)
+        return captured.get("argv", [])
+
+    def test_no_reply_ids_no_extra_flags(self):
+        argv = self._captured_argv("g1", "ch1")
+        self.assertNotIn("--reply-channel", argv)
+        self.assertNotIn("--reply-user", argv)
+
+    def test_reply_channel_added(self):
+        argv = self._captured_argv("g1", "ch1", reply_ch="TEXT_CH")
+        idx = argv.index("--reply-channel")
+        self.assertEqual(argv[idx + 1], "TEXT_CH")
+
+    def test_reply_user_added(self):
+        argv = self._captured_argv("g1", "ch1", reply_user="USER_ID")
+        idx = argv.index("--reply-user")
+        self.assertEqual(argv[idx + 1], "USER_ID")
+
+    def test_both_ids_added(self):
+        argv = self._captured_argv("g1", "ch1", reply_ch="TC", reply_user="UID")
+        self.assertIn("--reply-channel", argv)
+        self.assertIn("--reply-user", argv)
+
+    def test_guild_and_channel_still_present(self):
+        argv = self._captured_argv("g1", "ch1", reply_ch="TC")
+        self.assertIn("--guild", argv)
+        self.assertIn("--channel", argv)
+        self.assertEqual(argv[argv.index("--guild") + 1], "g1")
+        self.assertEqual(argv[argv.index("--channel") + 1], "ch1")
+
+    def test_none_ids_not_added(self):
+        argv = self._captured_argv("g1", "ch1", reply_ch=None, reply_user=None)
+        self.assertNotIn("--reply-channel", argv)
+        self.assertNotIn("--reply-user", argv)
+
+
+class TestHandleJoinTriggerThreadsReplyContext(unittest.TestCase):
+    """handle_join_trigger() must extract reply_channel_id/reply_user_id from
+    the message and pass them to _spawn_voice_server."""
+
+    def test_reply_channel_forwarded_to_spawn(self):
+        msg = _make_message(channel_id="CH123", user_id="USR456")
+        spawn_calls = []
+
+        def fake_spawn(guild_id, channel_id, reply_channel_id=None, reply_user_id=None):
+            spawn_calls.append({
+                "guild_id": guild_id,
+                "channel_id": channel_id,
+                "reply_channel_id": reply_channel_id,
+                "reply_user_id": reply_user_id,
+            })
+            return True
+
+        with patch.object(_mod, "_spawn_voice_server", fake_spawn), \
+             patch.object(_mod, "_server_already_running", return_value=False), \
+             patch.object(_mod, "_enqueue_context_prep_task"):
+            handle_join_trigger(msg)
+
+        self.assertEqual(len(spawn_calls), 1)
+        self.assertEqual(spawn_calls[0]["reply_channel_id"], "CH123")
+        self.assertEqual(spawn_calls[0]["reply_user_id"], "USR456")
+
+    def test_reply_channel_not_forwarded_when_server_already_running(self):
+        """When the server is already running, spawn is never called — no leak."""
+        msg = _make_message(channel_id="CH123", user_id="USR456")
+        spawn_calls = []
+
+        def fake_spawn(*args, **kwargs):
+            spawn_calls.append(kwargs)
+            return True
+
+        with patch.object(_mod, "_spawn_voice_server", fake_spawn), \
+             patch.object(_mod, "_server_already_running", return_value=True):
+            result = handle_join_trigger(msg)
+
+        self.assertEqual(spawn_calls, [])
+        self.assertIn("already in", result)
+
+    def test_no_channel_attr_does_not_raise(self):
+        """If message.channel has no id, reply_channel_id defaults to None."""
+        msg = MagicMock()
+        del msg.channel.id  # channel exists but has no .id
+        msg.author.id = "USR"
+        vc = MagicMock()
+        vc.id = "vc"
+        vc.name = "General"
+        vc.guild.id = "g"
+        msg.guild.get_member.return_value.voice.channel = vc
+
+        spawn_calls = []
+
+        def fake_spawn(guild_id, channel_id, reply_channel_id=None, reply_user_id=None):
+            spawn_calls.append(reply_channel_id)
+            return True
+
+        with patch.object(_mod, "_spawn_voice_server", fake_spawn), \
+             patch.object(_mod, "_server_already_running", return_value=False), \
+             patch.object(_mod, "_enqueue_context_prep_task"):
+            handle_join_trigger(msg)
+
+        self.assertEqual(spawn_calls, [None])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

When a bot is invited to a voice channel and can't join (peer already present — #1089 Layer-1 enforcement), the refusal was written to `results/proactive-*.txt` and DM'd to the owner. This PR threads the originating channel and user from the bridge through to `discord-voice-server.ts` so the refusal goes back to the channel and user that triggered the join.

**Three small changes:**

- **`skills/discord-voice/scripts/join_trigger.py`**: `_spawn_voice_server()` gains optional `reply_channel_id` / `reply_user_id` params; `handle_join_trigger()` extracts them from `message` and passes through. When provided, they become `--reply-channel` / `--reply-user` argv flags on the spawned subprocess.

- **`skills/discord-voice/scripts/discord-voice-server.ts`**: Reads `--reply-channel` / `--reply-user` via `getArg()`. In the Layer-1 refusal block, when `REPLY_CHANNEL_ID` is set, fetches the channel and sends a `<@user>` mention reply directly instead of writing `proactive-*.txt`. Keeps the proactive-*.txt path as a fallback when flags aren't present (manual test spawns, older bridge versions).

- **`tests/discord-voice-reply-where-invited.test.py`**: 9 tests — 6 for `_spawn_voice_server` arg forwarding, 3 for `handle_join_trigger` context threading. All pass on Python 3.9.

## Relationship to #1118

PR #1118 fixed the **owner-resolution** routing (wrong DM recipient). This PR fixes the **routing shape** — channel post vs. DM — which remains wrong even after #1118's fix. They're independent; this works with or without #1118.

## Test plan

- [ ] 9 unit tests in `tests/discord-voice-reply-where-invited.test.py` — all pass
- [ ] Manual: non-owner @-mentions bot to join a channel that already has a sutando peer → refusal appears as channel `<@user>` mention, not owner DM
- [ ] Manual: bot launched without `--reply-channel` (test spawn) → falls back to `proactive-*.txt` gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)