### PR TITLE
lint(ci): add check-py39-union-annotations.py gate (#961 Option A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
       - name: UTC timestamp check
         run: python3 scripts/check-utc-z-strftime.py
 
+      # Catches PEP-604 X|Y union annotations without __future__.annotations
+      # (Python 3.9 incompatible). Issue #961 / #960.
+      - name: Python 3.9 union annotation check
+        run: python3 scripts/check-py39-union-annotations.py
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/scripts/check-py39-union-annotations.py
+++ b/scripts/check-py39-union-annotations.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+CI gate: catch PEP-604 `X | Y` union syntax in annotation positions
+without `from __future__ import annotations` (Python 3.9 incompatible).
+
+Background (#961 / #960): The telegram-bridge outage on 2026-05-?? was caused
+by a `str | None` annotation that crashed the bridge on import under Python 3.9
+(stock macOS python3 = 3.9.x on Apple CLT). PEP-604 `X | Y` union syntax in
+annotations requires Python 3.10+ OR `from __future__ import annotations` as
+the first non-docstring import.
+
+FLAGGED — a file in SCAN_DIRS that:
+  1. uses `X | Y` syntax in an annotation position (variable, arg, return type), AND
+  2. does NOT have `from __future__ import annotations`
+
+NOT flagged:
+  - Files with `from __future__ import annotations` present (runtime-safe on 3.9)
+  - BitOr in non-annotation contexts (bit operations, dict unions {**a} | {**b}, etc.)
+  - Files that don't parse cleanly (syntax errors reported separately)
+
+Exit 1 on any hit, 0 otherwise. Run from the repo root.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+SCAN_DIRS = ("src", "skills")
+SCAN_GLOBS = ("*.py",)
+
+
+def _has_bitor(node: ast.expr) -> bool:
+    for n in ast.walk(node):
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.BitOr):
+            return True
+    return False
+
+
+def annotation_union_lines(tree: ast.Module) -> list[int]:
+    """Return line numbers of PEP-604 union annotations in the tree."""
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        # Variable annotations: x: int | None = ...
+        if isinstance(node, ast.AnnAssign) and node.annotation:
+            if _has_bitor(node.annotation):
+                hits.append(node.col_offset and node.lineno or node.lineno)
+        # Function signatures
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            # Return type
+            if node.returns and _has_bitor(node.returns):
+                hits.append(node.lineno)
+            # All argument annotations
+            all_args = (
+                node.args.args
+                + node.args.posonlyargs
+                + node.args.kwonlyargs
+                + ([node.args.vararg] if node.args.vararg else [])
+                + ([node.args.kwarg] if node.args.kwarg else [])
+            )
+            for arg in all_args:
+                if arg.annotation and _has_bitor(arg.annotation):
+                    hits.append(arg.lineno)
+    return hits
+
+
+def check_file(path: Path) -> list[str]:
+    src = path.read_text(encoding="utf-8", errors="replace")
+    if "from __future__ import annotations" in src:
+        return []
+    try:
+        tree = ast.parse(src, filename=str(path))
+    except SyntaxError as exc:
+        return [f"{path}:{exc.lineno}: SyntaxError — {exc.msg}"]
+    lines = annotation_union_lines(tree)
+    return [f"{path}:{ln}: PEP-604 X|Y annotation without __future__.annotations" for ln in lines]
+
+
+def main() -> int:
+    violations: list[str] = []
+    for scan_dir in SCAN_DIRS:
+        root = Path(scan_dir)
+        if not root.exists():
+            continue
+        for glob in SCAN_GLOBS:
+            for f in sorted(root.rglob(glob)):
+                violations.extend(check_file(f))
+
+    if violations:
+        print(f"FAIL: {len(violations)} file(s) use PEP-604 X|Y union annotations")
+        print("      without `from __future__ import annotations` (Python 3.9 incompatible).")
+        print()
+        for v in violations:
+            print(f"  {v}")
+        print()
+        print("Fix: add `from __future__ import annotations` as the first non-docstring import,")
+        print("     or upgrade the baseline to Python 3.10+.")
+        return 1
+
+    total = sum(
+        len(list(Path(d).rglob(g)))
+        for d in SCAN_DIRS
+        for g in SCAN_GLOBS
+        if Path(d).exists()
+    )
+    print(f"Results: {total} Python files checked, 0 violations.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/deal-finder/scripts/scan.py
+++ b/skills/deal-finder/scripts/scan.py
@@ -12,6 +12,8 @@ Notifies on the first sight of any listing matching criteria.json:
 - SMS via Twilio REST (TWILIO_* + OWNER_NUMBER from .env)
 - Telegram via results/proactive-{ts}.txt (telegram-bridge picks it up)
 """
+from __future__ import annotations
+
 import argparse
 import collections
 import datetime as dt

--- a/tests/check-py39-union-annotations.test.py
+++ b/tests/check-py39-union-annotations.test.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Structural tests for scripts/check-py39-union-annotations.py.
+
+Verifies the script's logic by feeding synthetic AST fixtures and running
+the full CLI against temp directories — no dependency on the live src/ tree.
+"""
+
+import ast
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check-py39-union-annotations.py"
+
+# ---------------------------------------------------------------------------
+# Import the helpers directly (annotation_union_lines, check_file)
+# ---------------------------------------------------------------------------
+import importlib.util
+
+spec = importlib.util.spec_from_file_location("lint", SCRIPT)
+lint = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+spec.loader.exec_module(lint)  # type: ignore[union-attr]
+
+
+def _parse(src: str) -> ast.Module:
+    return ast.parse(textwrap.dedent(src))
+
+
+class TestAnnotationUnionLines(unittest.TestCase):
+    """annotation_union_lines() — pure AST detection."""
+
+    def test_clean_file_no_hits(self) -> None:
+        tree = _parse(
+            """
+            def foo(x: int, y: str) -> bool:
+                z: int = 1
+            """
+        )
+        self.assertEqual(lint.annotation_union_lines(tree), [])
+
+    def test_variable_annotation_flagged(self) -> None:
+        tree = _parse("x: int | None = 1\n")
+        lines = lint.annotation_union_lines(tree)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0], 1)
+
+    def test_return_type_flagged(self) -> None:
+        tree = _parse(
+            """
+            def foo() -> int | None:
+                return None
+            """
+        )
+        lines = lint.annotation_union_lines(tree)
+        self.assertIn(2, lines)
+
+    def test_arg_annotation_flagged(self) -> None:
+        tree = _parse(
+            """
+            def bar(x: str | int) -> None:
+                pass
+            """
+        )
+        lines = lint.annotation_union_lines(tree)
+        self.assertTrue(len(lines) >= 1)
+
+    def test_async_def_flagged(self) -> None:
+        tree = _parse(
+            """
+            async def baz(x: str | None) -> int | None:
+                pass
+            """
+        )
+        lines = lint.annotation_union_lines(tree)
+        self.assertGreaterEqual(len(lines), 2)
+
+    def test_bit_or_in_expression_not_flagged(self) -> None:
+        tree = _parse(
+            """
+            x = 1 | 2
+            y = {'a': 1} | {'b': 2}
+            """
+        )
+        self.assertEqual(lint.annotation_union_lines(tree), [])
+
+    def test_kwonly_arg_annotation_flagged(self) -> None:
+        tree = _parse(
+            """
+            def fn(*, key: str | int) -> None:
+                pass
+            """
+        )
+        lines = lint.annotation_union_lines(tree)
+        self.assertTrue(len(lines) >= 1)
+
+
+class TestCheckFile(unittest.TestCase):
+    """check_file() — file-level guard and integration."""
+
+    def _write(self, content: str, suffix: str = ".py") -> Path:
+        f = tempfile.NamedTemporaryFile(
+            mode="w", suffix=suffix, delete=False, encoding="utf-8"
+        )
+        f.write(textwrap.dedent(content))
+        f.flush()
+        return Path(f.name)
+
+    def test_future_annotations_suppresses_flag(self) -> None:
+        p = self._write(
+            """
+            from __future__ import annotations
+            def foo(x: str | None) -> int | None:
+                pass
+            """
+        )
+        self.assertEqual(lint.check_file(p), [])
+
+    def test_missing_future_triggers_flag(self) -> None:
+        p = self._write(
+            """
+            def foo(x: str | None) -> None:
+                pass
+            """
+        )
+        result = lint.check_file(p)
+        self.assertTrue(len(result) >= 1)
+        self.assertIn("PEP-604", result[0])
+
+    def test_syntax_error_reported(self) -> None:
+        p = self._write("def (broken:\n")
+        result = lint.check_file(p)
+        self.assertTrue(len(result) == 1)
+        self.assertIn("SyntaxError", result[0])
+
+    def test_clean_file_returns_empty(self) -> None:
+        p = self._write(
+            """
+            def foo(x: int, y: str) -> bool:
+                return True
+            """
+        )
+        self.assertEqual(lint.check_file(p), [])
+
+
+class TestCLI(unittest.TestCase):
+    """End-to-end CLI exit codes."""
+
+    def _run(self, scan_dirs: dict[str, str]) -> subprocess.CompletedProcess:
+        with tempfile.TemporaryDirectory() as td:
+            for rel, content in scan_dirs.items():
+                p = Path(td) / rel
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text(textwrap.dedent(content), encoding="utf-8")
+            return subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                capture_output=True,
+                text=True,
+                cwd=td,
+            )
+
+    def test_exit_0_on_clean_codebase(self) -> None:
+        result = self._run(
+            {
+                "src/clean.py": """\
+                from __future__ import annotations
+                def foo(x: str | None) -> int | None:
+                    pass
+                """,
+            }
+        )
+        self.assertEqual(result.returncode, 0)
+
+    def test_exit_1_on_violation(self) -> None:
+        result = self._run(
+            {
+                "src/bad.py": """\
+                def foo(x: str | None) -> None:
+                    pass
+                """,
+            }
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("PEP-604", result.stdout)
+
+    def test_exit_0_when_scan_dirs_absent(self) -> None:
+        result = self._run({})
+        self.assertEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `scripts/check-py39-union-annotations.py`: AST-based CI gate that scans `src/` and `skills/` for PEP-604 `X | Y` union annotations used in annotation positions (variable annotations, function return types, argument annotations) without `from __future__ import annotations` — the root cause of the #960 telegram-bridge outage on Python 3.9
- Wires the check into `.github/workflows/ci.yml` alongside the existing UTC timestamp gate (runs before Node deps install — no deps needed)
- Fixes the 5 violations found in `skills/deal-finder/scripts/scan.py` by adding the `__future__` import
- 14/14 structural tests in `tests/check-py39-union-annotations.test.py` covering AST detection, file-level guard, CLI exit codes

## What the gate catches

```
def foo(x: str | None) -> int | None:   # ← FLAGGED (no __future__)
    pass

from __future__ import annotations
def foo(x: str | None) -> int | None:   # ← OK (runtime-safe on 3.9)
    pass

x = flags | NEW_FLAG                    # ← OK (non-annotation BitOr)
```

## Test plan

- [x] `python3 scripts/check-py39-union-annotations.py` → `Results: 52 Python files checked, 0 violations.`
- [x] `python3 tests/check-py39-union-annotations.test.py -v` → 14/14 pass
- [x] CI step added after UTC timestamp check, before Node setup

Closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)