### PR TITLE
feat(discord-voice): meeting mode — manual toggle + idle auto-enter (#1105)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -150,6 +150,48 @@ const SUTANDO_PEER_ENFORCEMENT_DISABLED = process.env.SUTANDO_PEER_ENFORCEMENT_D
 // this, treat the session as hung and force a reconnect. Env-overridable.
 const WATCHDOG_STALL_MS = Number(process.env.SUTANDO_WATCHDOG_STALL_MS) || 20000;
 
+// --- Meeting mode (issue #1105) -----------------------------------------------
+// Mirrors voice-agent.ts meetingActive — audio output is suppressed in meeting
+// mode while Gemini keeps transcribing. Persists across Gemini reconnects.
+//
+// Control surface:
+//   state/voice-mode.request  — written by Sutando.app menu-bar toggle (same as voice-agent)
+//   state/voice-mode.txt      — current mode sentinel (read by Sutando.app for badge)
+//
+// Auto-mode: when SUTANDO_VOICE_AUTO_MEETING_AFTER_SEC is set and non-zero,
+// discord-voice automatically flips to meeting mode after that many seconds of
+// user silence. Any user speech exits auto-meeting-mode immediately.
+const VOICE_MODE_TXT = join(WORKSPACE_DIR, 'state', 'voice-mode.txt');
+const VOICE_MODE_REQUEST = join(WORKSPACE_DIR, 'state', 'voice-mode.request');
+const AUTO_MEETING_SEC = Number(process.env.SUTANDO_VOICE_AUTO_MEETING_AFTER_SEC || 0);
+const AUTO_MEETING_MS = AUTO_MEETING_SEC > 0 ? AUTO_MEETING_SEC * 1_000 : 0;
+
+let meetingMode = false;
+
+function writeMeetingModeSentinel(): void {
+	try {
+		mkdirSync(join(WORKSPACE_DIR, 'state'), { recursive: true });
+		writeFileSync(VOICE_MODE_TXT, meetingMode ? 'meeting' : 'active');
+	} catch {}
+}
+
+function applyModeRequest(): void {
+	try {
+		const req = readFileSync(VOICE_MODE_REQUEST, 'utf-8').trim().toLowerCase();
+		unlinkSync(VOICE_MODE_REQUEST);
+		const want = req === 'meeting';
+		if (meetingMode === want) return;
+		meetingMode = want;
+		writeMeetingModeSentinel();
+		console.log(`[Meeting] mode → ${want ? 'meeting' : 'active'} (external request)`);
+	} catch { /* no request file — normal */ }
+}
+
+// Read initial state from voice-mode.txt (shared with voice-agent when both are running)
+try { meetingMode = readFileSync(VOICE_MODE_TXT, 'utf-8').trim() === 'meeting'; } catch {}
+// Poll for mode-request file from Sutando.app menu-bar toggle
+setInterval(applyModeRequest, 1_000);
+
 // --- Per-speaker access tier (owner / team / other) -------------------------
 // Tier logic lives in ./access-tier.ts (pure + unit-tested). A Gemini Live
 // session's tool list is fixed at session start, so the tier is enforced
@@ -871,6 +913,8 @@ async function createVoiceSession(connection: VoiceConnection, client: Client): 
 	let outChunks = 0;
 	sessionAny.handleAudioOutput = (data: string) => {
 		sessionAny.notificationQueue?.markAudioReceived?.();
+		// Meeting mode: suppress audio output; Gemini keeps transcribing.
+		if (meetingMode) return;
 		try {
 			const pcm24Mono = Buffer.from(data, 'base64');
 			const pcm48Stereo = upsample24MonoTo48Stereo(pcm24Mono);
@@ -896,10 +940,12 @@ async function createVoiceSession(connection: VoiceConnection, client: Client): 
 		const items = session.conversationContext.items;
 		if (items.length < lastProcessedIdx) lastProcessedIdx = 0;
 		const lastText = s.transcript.length > 0 ? s.transcript[s.transcript.length - 1].text : null;
+		let latestUserText = '';
 		for (const item of items.slice(lastProcessedIdx)) {
 			if (item.content === lastText) continue;
 			if (item.role === 'user') {
 				s.transcript.push({ role: 'user', text: item.content });
+				latestUserText = item.content;
 				// utterance event push removed per #1052 — canonical record is
 				// the discord_voice-table row written by recordConversation
 				// below. session_events keeps only lifecycle entries to stop
@@ -916,6 +962,17 @@ async function createVoiceSession(connection: VoiceConnection, client: Client): 
 			}
 		}
 		lastProcessedIdx = items.length;
+
+		// Auto-meeting wake-word: any user turn containing the bot's name exits
+		// meeting mode so the bot can respond. Names are case-insensitive.
+		if (AUTO_MEETING_MS > 0 && meetingMode && latestUserText) {
+			const wake = /\b(sutando|lucy)\b/i;
+			if (wake.test(latestUserText)) {
+				meetingMode = false;
+				writeMeetingModeSentinel();
+				console.log(`${ts()} [Meeting] wake-word exit — user addressed the bot`);
+			}
+		}
 
 		if (s.resultQueue.length > 0) {
 			const queued = s.resultQueue.splice(0);
@@ -1082,7 +1139,30 @@ async function createVoiceSession(connection: VoiceConnection, client: Client): 
 			return;
 		}
 		subscribeUser(s, userId);
+		// Auto-meeting: any user speech resets the idle clock and exits meeting mode.
+		(s as any).lastUserAudioTs = Date.now();
+		if (AUTO_MEETING_MS > 0 && meetingMode) {
+			meetingMode = false;
+			writeMeetingModeSentinel();
+			console.log(`${ts()} [Meeting] auto-exit — user started speaking`);
+		}
 	});
+
+	// Auto-meeting idle watchdog: flip to meeting mode after SUTANDO_VOICE_AUTO_MEETING_AFTER_SEC
+	// seconds of no user speech. Disabled when env var is unset (default).
+	if (AUTO_MEETING_MS > 0) {
+		const autoMeetingWatch = setInterval(() => {
+			if (s.closing) { clearInterval(autoMeetingWatch); return; }
+			const last = (s as any).lastUserAudioTs as number || 0;
+			if (!meetingMode && last > 0 && Date.now() - last > AUTO_MEETING_MS) {
+				meetingMode = true;
+				writeMeetingModeSentinel();
+				console.log(`${ts()} [Meeting] auto-enter — ${AUTO_MEETING_SEC}s of user silence`);
+			}
+		}, 5_000);
+		(s as any)._autoMeetingHandle = autoMeetingWatch;
+	}
+
 	// Start the constant-rate ticker that flushes audio to Gemini every 20ms.
 	startAudioTicker(s);
 
@@ -1107,6 +1187,7 @@ function cleanupSession(s: DiscordVoiceSession): void {
 	try { clearInterval((s as any)._outTickHandle); } catch {}
 	try { clearInterval((s as any)._watchdogHandle); } catch {}
 	try { clearInterval((s as any)._channelScanHandle); } catch {}
+	try { clearInterval((s as any)._autoMeetingHandle); } catch {}
 	try { s.player.stop(true); } catch {}
 	try { s.connection.destroy(); } catch {}
 

--- a/tests/discord-voice-meeting-mode.test.py
+++ b/tests/discord-voice-meeting-mode.test.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Structural tests for meeting mode in skills/discord-voice/scripts/discord-voice-server.ts.
+
+Verifies the implementation of issue #1105 (manual + auto meeting mode):
+  - Module-level state constants (VOICE_MODE_TXT, VOICE_MODE_REQUEST, AUTO_MEETING_MS)
+  - writeMeetingModeSentinel() writes to workspace-relative state/voice-mode.txt
+  - applyModeRequest() reads request file, applies mode, unlinks
+  - handleAudioOutput gates pushAudio on meetingMode
+  - speaking.on('start') resets lastUserAudioTs and exits auto-meeting
+  - Auto-meeting idle watchdog flips meetingMode after timeout
+  - Wake-word detection exits meeting mode on turn.end
+  - cleanupSession clears _autoMeetingHandle
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "skills" / "discord-voice" / "scripts" / "discord-voice-server.ts"
+
+
+def _src() -> str:
+    return SRC.read_text(encoding="utf-8")
+
+
+class TestMeetingModeConstants(unittest.TestCase):
+    """Module-level constants and state."""
+
+    def test_voice_mode_txt_uses_workspace(self) -> None:
+        src = _src()
+        self.assertIn("VOICE_MODE_TXT", src)
+        # Must derive from WORKSPACE_DIR, not a bare path
+        self.assertIn("join(WORKSPACE_DIR", src)
+
+    def test_voice_mode_request_defined(self) -> None:
+        src = _src()
+        self.assertIn("VOICE_MODE_REQUEST", src)
+
+    def test_auto_meeting_ms_from_env(self) -> None:
+        src = _src()
+        self.assertIn("SUTANDO_VOICE_AUTO_MEETING_AFTER_SEC", src)
+        self.assertIn("AUTO_MEETING_MS", src)
+
+    def test_meeting_mode_flag_defined(self) -> None:
+        src = _src()
+        self.assertIn("let meetingMode = false", src)
+
+    def test_initial_state_read_from_sentinel(self) -> None:
+        src = _src()
+        # Initial mode read from voice-mode.txt at startup
+        self.assertIn("VOICE_MODE_TXT", src)
+        self.assertIn("=== 'meeting'", src)
+
+    def test_mode_request_poll_interval(self) -> None:
+        src = _src()
+        # setInterval(applyModeRequest, ...) must be present
+        self.assertIn("setInterval(applyModeRequest", src)
+
+
+class TestWriteMeetingModeSentinel(unittest.TestCase):
+    """writeMeetingModeSentinel() writes state/voice-mode.txt via WORKSPACE_DIR."""
+
+    def test_function_defined(self) -> None:
+        src = _src()
+        self.assertIn("function writeMeetingModeSentinel", src)
+
+    def test_writes_to_voice_mode_txt(self) -> None:
+        src = _src()
+        # writeFileSync(VOICE_MODE_TXT, ...)
+        self.assertIn("writeFileSync(VOICE_MODE_TXT", src)
+
+    def test_mkdirSync_for_state_dir(self) -> None:
+        src = _src()
+        # mkdirSync guard present in sentinel writer
+        # Find the writeMeetingModeSentinel function body
+        match = re.search(r"function writeMeetingModeSentinel\(\)[^}]+}", src, re.DOTALL)
+        self.assertIsNotNone(match)
+        body = match.group(0)  # type: ignore[union-attr]
+        self.assertIn("mkdirSync", body)
+
+
+class TestApplyModeRequest(unittest.TestCase):
+    """applyModeRequest() consumes the request file and updates meetingMode."""
+
+    def test_function_defined(self) -> None:
+        src = _src()
+        self.assertIn("function applyModeRequest", src)
+
+    def test_reads_request_file(self) -> None:
+        src = _src()
+        # readFileSync(VOICE_MODE_REQUEST, ...)
+        self.assertIn("readFileSync(VOICE_MODE_REQUEST", src)
+
+    def test_unlinks_request_file(self) -> None:
+        src = _src()
+        # unlinkSync(VOICE_MODE_REQUEST) — consumed on apply
+        self.assertIn("unlinkSync(VOICE_MODE_REQUEST)", src)
+
+    def test_calls_write_sentinel(self) -> None:
+        src = _src()
+        match = re.search(r"function applyModeRequest\(\)[^}]+}", src, re.DOTALL)
+        self.assertIsNotNone(match)
+        body = match.group(0)  # type: ignore[union-attr]
+        self.assertIn("writeMeetingModeSentinel", body)
+
+
+class TestAudioOutputGate(unittest.TestCase):
+    """handleAudioOutput skips pushAudio when meetingMode is true."""
+
+    def test_meeting_mode_guard_present(self) -> None:
+        src = _src()
+        # Find the handleAudioOutput block and verify meetingMode check
+        handle_idx = src.find("sessionAny.handleAudioOutput = ")
+        self.assertGreater(handle_idx, 0)
+        block = src[handle_idx: handle_idx + 400]
+        self.assertIn("meetingMode", block)
+
+    def test_early_return_on_meeting_mode(self) -> None:
+        src = _src()
+        handle_idx = src.find("sessionAny.handleAudioOutput = ")
+        block = src[handle_idx: handle_idx + 400]
+        self.assertIn("if (meetingMode) return", block)
+
+    def test_push_audio_after_meeting_check(self) -> None:
+        src = _src()
+        handle_idx = src.find("sessionAny.handleAudioOutput = ")
+        block = src[handle_idx: handle_idx + 600]
+        meeting_pos = block.find("meetingMode")
+        push_pos = block.find("pushAudio")
+        # pushAudio must appear AFTER the meetingMode guard
+        self.assertGreater(push_pos, meeting_pos)
+
+
+class TestAutoMeetingIdleWatchdog(unittest.TestCase):
+    """Auto-meeting idle watchdog and wake-word exit."""
+
+    def test_auto_meeting_watchdog_interval(self) -> None:
+        src = _src()
+        self.assertIn("_autoMeetingHandle", src)
+        self.assertIn("AUTO_MEETING_MS", src)
+
+    def test_watchdog_flips_meeting_mode(self) -> None:
+        src = _src()
+        # Should set meetingMode = true and write sentinel
+        watchdog_idx = src.find("_autoMeetingHandle")
+        # The region around the auto-meeting watchdog should have meetingMode = true
+        region = src[max(0, watchdog_idx - 500): watchdog_idx + 200]
+        self.assertIn("meetingMode = true", region)
+
+    def test_speaking_start_resets_idle_clock(self) -> None:
+        src = _src()
+        # lastUserAudioTs must be updated on speaking.start
+        self.assertIn("lastUserAudioTs", src)
+
+    def test_speaking_start_exits_auto_meeting(self) -> None:
+        src = _src()
+        # When user starts speaking, auto-meeting exits.
+        # The exit block is placed after subscribeUser() inside the speaking.on('start')
+        # handler, so search in a larger window that covers the whole handler + tail.
+        speaking_idx = src.find("connection.receiver.speaking.on('start'")
+        self.assertGreater(speaking_idx, 0)
+        region = src[speaking_idx: speaking_idx + 1800]
+        self.assertIn("meetingMode = false", region)
+
+    def test_wake_word_detection_present(self) -> None:
+        src = _src()
+        # Wake-word regex for bot names
+        self.assertIn("wake", src.lower())
+        self.assertIn("sutando", src.lower())
+
+    def test_cleanup_clears_auto_meeting_handle(self) -> None:
+        src = _src()
+        cleanup_idx = src.find("function cleanupSession")
+        self.assertGreater(cleanup_idx, 0)
+        body = src[cleanup_idx: cleanup_idx + 600]
+        self.assertIn("_autoMeetingHandle", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Manual mode**: polls `state/voice-mode.request` every 1s (same file Sutando.app menu-bar toggle already writes for voice-agent). Reading `state/voice-mode.txt` on startup stays in sync when both voice-agent and discord-voice run in the same workspace.
- **Audio gate**: `handleAudioOutput` returns early when `meetingMode=true` — Gemini keeps transcribing (STT stays live) but no audio reaches the Discord player
- **Auto mode** (opt-in via `SUTANDO_VOICE_AUTO_MEETING_AFTER_SEC=N`): 5s watchdog flips to meeting mode after N seconds of user silence; any `speaking.start` event or wake-word ("sutando" / "lucy") in a transcript turn exits auto-meeting-mode
- No new deps; ~80 LOC in `discord-voice-server.ts`; 22/22 structural tests

## Scope of change

One file modified (`discord-voice-server.ts`), one test file added. The module-level meeting state mirrors how `voice-agent.ts` manages `meetingActive` — no shared module needed because each process owns its own state and shares via `state/voice-mode.txt`.

## Test plan

- [x] `python3 tests/discord-voice-meeting-mode.test.py -v` → 22/22 pass
- [x] `npx tsc --noEmit` → clean
- Manual test: set `SUTANDO_VOICE_AUTO_MEETING_AFTER_SEC=30`, join voice channel, stay silent 30s → bot stops speaking; say "Lucy" → bot resumes

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)