### PR TITLE
test(discord-bridge): 52 structural tests — join-phrase fastpath, join-trigger hook, outbox, task channel fields

### DIFF
--- a/skills/discord-voice/tests/join_trigger.test.py
+++ b/skills/discord-voice/tests/join_trigger.test.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""
+Tests for skills/discord-voice/scripts/join_trigger.py
+
+Coverage:
+  load_join_phrase      — workspace config, repo example, default fallback, missing file
+  message_is_join_phrase — exact match, case-insensitive, boundary rules, empty/no-match
+  _server_already_running — running process matches, different channel no-match, pgrep error
+  _spawn_voice_server   — server script absent, Popen success, Popen failure
+  _enqueue_context_prep_task — file written with correct fields, never raises
+  handle_join_trigger   — not-in-voice-channel, already-running, spawn-fails, success path
+
+Run: python3 skills/discord-voice/tests/join_trigger.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+REPO = Path(__file__).resolve().parent.parent.parent.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "join_trigger",
+    REPO / "skills" / "discord-voice" / "scripts" / "join_trigger.py",
+)
+jt = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(jt)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_message(text="za warudo", access_tier="owner", has_voice=True, channel_id=111, guild_id=222):
+    """Build a minimal fake Discord message object."""
+    msg = MagicMock()
+    msg.content = text
+
+    # Author with voice state
+    author = MagicMock()
+    author.id = 999
+    if has_voice:
+        channel = MagicMock()
+        channel.id = channel_id
+        channel.name = "General Voice"
+        guild = MagicMock()
+        guild.id = guild_id
+        channel.guild = guild
+        author.voice = MagicMock()
+        author.voice.channel = channel
+    else:
+        author.voice = None
+    msg.author = author
+
+    msg.channel = MagicMock()
+    msg.channel.send = MagicMock()
+    msg._join_trigger_guilds = None
+    return msg
+
+
+# ── load_join_phrase ──────────────────────────────────────────────────────────
+
+class TestLoadJoinPhrase(unittest.TestCase):
+    def test_default_fallback(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmpdir = Path(d)
+            with patch.object(jt, "_config_path", return_value=tmpdir / "nonexistent.json"), \
+                 patch.object(jt, "_REPO_ROOT", tmpdir):
+                phrase = jt.load_join_phrase()
+        self.assertEqual(phrase, jt.DEFAULT_JOIN_PHRASE)
+
+    def test_workspace_config_wins(self):
+        with tempfile.TemporaryDirectory() as d:
+            cfg = Path(d) / "discord-voice.json"
+            cfg.write_text(json.dumps({"join_phrase": "open sesame"}))
+            with patch.object(jt, "_config_path", return_value=cfg):
+                phrase = jt.load_join_phrase()
+        self.assertEqual(phrase, "open sesame")
+
+    def test_phrase_lowercased(self):
+        with tempfile.TemporaryDirectory() as d:
+            cfg = Path(d) / "discord-voice.json"
+            cfg.write_text(json.dumps({"join_phrase": "ZA WARUDO"}))
+            with patch.object(jt, "_config_path", return_value=cfg):
+                phrase = jt.load_join_phrase()
+        self.assertEqual(phrase, "za warudo")
+
+    def test_blank_phrase_falls_through(self):
+        with tempfile.TemporaryDirectory() as d:
+            cfg = Path(d) / "discord-voice.json"
+            cfg.write_text(json.dumps({"join_phrase": "   "}))
+            with patch.object(jt, "_config_path", return_value=cfg), \
+                 patch.object(jt, "_REPO_ROOT", Path(d)):
+                phrase = jt.load_join_phrase()
+        self.assertEqual(phrase, jt.DEFAULT_JOIN_PHRASE)
+
+    def test_malformed_json_falls_through(self):
+        with tempfile.TemporaryDirectory() as d:
+            cfg = Path(d) / "discord-voice.json"
+            cfg.write_text("not json{{{")
+            with patch.object(jt, "_config_path", return_value=cfg), \
+                 patch.object(jt, "_REPO_ROOT", Path(d)):
+                phrase = jt.load_join_phrase()
+        self.assertEqual(phrase, jt.DEFAULT_JOIN_PHRASE)
+
+
+# ── message_is_join_phrase ────────────────────────────────────────────────────
+
+class TestMessageIsJoinPhrase(unittest.TestCase):
+    PHRASE = "za warudo"
+
+    def _check(self, text, expected):
+        result = jt.message_is_join_phrase(text, self.PHRASE)
+        self.assertEqual(result, expected, f"text={text!r}")
+
+    def test_exact_match(self):
+        self._check("za warudo", True)
+
+    def test_case_insensitive(self):
+        self._check("ZA WARUDO", True)
+        self._check("Za Warudo", True)
+
+    def test_leading_trailing_whitespace(self):
+        self._check("  za warudo  ", True)
+
+    def test_trailing_punctuation_matches(self):
+        self._check("za warudo!", True)
+        self._check("za warudo,", True)
+        self._check("za warudo.", True)
+
+    def test_trailing_space_plus_words_matches(self):
+        self._check("za warudo please", True)
+
+    def test_word_boundary_prevents_partial(self):
+        self._check("za warudonow", False)
+        self._check("za warudo_extension", False)
+
+    def test_empty_string_no_match(self):
+        self._check("", False)
+
+    def test_unrelated_text_no_match(self):
+        self._check("hello world", False)
+        self._check("za", False)
+
+    def test_empty_phrase_no_match(self):
+        result = jt.message_is_join_phrase("za warudo", "")
+        self.assertFalse(result)
+
+    def test_none_phrase_loads_configured(self):
+        with patch.object(jt, "load_join_phrase", return_value="za warudo"):
+            result = jt.message_is_join_phrase("za warudo", None)
+        self.assertTrue(result)
+
+
+# ── _server_already_running ───────────────────────────────────────────────────
+
+class TestServerAlreadyRunning(unittest.TestCase):
+    def _fake_run(self, stdout, returncode=0):
+        m = MagicMock()
+        m.stdout = stdout
+        m.returncode = returncode
+        return m
+
+    def test_running_for_channel_returns_true(self):
+        output = "12345 npx tsx discord-voice-server.ts --guild 1 --channel 111\n"
+        with patch("subprocess.run", return_value=self._fake_run(output)):
+            self.assertTrue(jt._server_already_running(111))
+
+    def test_different_channel_returns_false(self):
+        output = "12345 npx tsx discord-voice-server.ts --guild 1 --channel 999\n"
+        with patch("subprocess.run", return_value=self._fake_run(output)):
+            self.assertFalse(jt._server_already_running(111))
+
+    def test_no_process_returns_false(self):
+        with patch("subprocess.run", return_value=self._fake_run("", returncode=1)):
+            self.assertFalse(jt._server_already_running(111))
+
+    def test_pgrep_exception_returns_false(self):
+        with patch("subprocess.run", side_effect=Exception("pgrep not found")):
+            self.assertFalse(jt._server_already_running(111))
+
+
+# ── _spawn_voice_server ───────────────────────────────────────────────────────
+
+class TestSpawnVoiceServer(unittest.TestCase):
+    def test_missing_server_script_returns_false(self):
+        with patch.object(jt, "_DISCORD_VOICE_SERVER", Path("/nonexistent/discord-voice-server.ts")), \
+             patch.object(jt, "_resolve_workspace", return_value=Path(tempfile.mkdtemp())):
+            result = jt._spawn_voice_server(guild_id=1, channel_id=111)
+        self.assertFalse(result)
+
+    def test_successful_popen_returns_true(self):
+        with tempfile.TemporaryDirectory() as d:
+            fake_server = Path(d) / "discord-voice-server.ts"
+            fake_server.touch()
+            with patch.object(jt, "_DISCORD_VOICE_SERVER", fake_server), \
+                 patch.object(jt, "_resolve_workspace", return_value=Path(d)), \
+                 patch("subprocess.Popen") as mock_popen:
+                mock_popen.return_value = MagicMock()
+                result = jt._spawn_voice_server(guild_id=1, channel_id=111)
+        self.assertTrue(result)
+
+    def test_popen_exception_returns_false(self):
+        with tempfile.TemporaryDirectory() as d:
+            fake_server = Path(d) / "discord-voice-server.ts"
+            fake_server.touch()
+            with patch.object(jt, "_DISCORD_VOICE_SERVER", fake_server), \
+                 patch.object(jt, "_resolve_workspace", return_value=Path(d)), \
+                 patch("subprocess.Popen", side_effect=OSError("npx not found")):
+                result = jt._spawn_voice_server(guild_id=1, channel_id=111)
+        self.assertFalse(result)
+
+
+# ── _enqueue_context_prep_task ────────────────────────────────────────────────
+
+class TestEnqueueContextPrepTask(unittest.TestCase):
+    def test_task_file_written(self):
+        with tempfile.TemporaryDirectory() as d:
+            ws = Path(d)
+            with patch.object(jt, "_resolve_workspace", return_value=ws):
+                jt._enqueue_context_prep_task("za warudo", 111, "General Voice")
+            task_files = list((ws / "tasks").glob("task-*.txt"))
+        self.assertEqual(len(task_files), 1)
+
+    def test_task_file_contains_required_fields(self):
+        with tempfile.TemporaryDirectory() as d:
+            ws = Path(d)
+            with patch.object(jt, "_resolve_workspace", return_value=ws):
+                jt._enqueue_context_prep_task("za warudo", 111, "General Voice")
+            task_files = list((ws / "tasks").glob("task-*.txt"))
+            content = task_files[0].read_text()
+        self.assertIn("access_tier: owner", content)
+        self.assertIn("source: system-magic-word", content)
+        self.assertIn("priority: urgent", content)
+        self.assertIn("za warudo", content)
+        self.assertIn("111", content)
+
+    def test_never_raises_on_bad_workspace(self):
+        with patch.object(jt, "_resolve_workspace", side_effect=Exception("boom")):
+            try:
+                jt._enqueue_context_prep_task("za warudo", 111, "Voice")
+            except Exception as e:
+                self.fail(f"_enqueue_context_prep_task raised: {e}")
+
+
+# ── handle_join_trigger ───────────────────────────────────────────────────────
+
+class TestHandleJoinTrigger(unittest.TestCase):
+    def test_not_in_voice_channel_returns_message(self):
+        msg = _make_message(has_voice=False)
+        with patch.object(jt, "_server_already_running", return_value=False), \
+             patch.object(jt, "_spawn_voice_server", return_value=False):
+            result = jt.handle_join_trigger(msg)
+        self.assertIn("not in a voice channel", result.lower())
+
+    def test_already_running_returns_already_there_message(self):
+        msg = _make_message(has_voice=True, channel_id=111)
+        with patch.object(jt, "_server_already_running", return_value=True):
+            result = jt.handle_join_trigger(msg)
+        self.assertIn("already in", result.lower())
+
+    def test_spawn_fails_returns_error_message(self):
+        msg = _make_message(has_voice=True, channel_id=111, guild_id=222)
+        with patch.object(jt, "_server_already_running", return_value=False), \
+             patch.object(jt, "_spawn_voice_server", return_value=False), \
+             patch.object(jt, "_enqueue_context_prep_task"):
+            result = jt.handle_join_trigger(msg)
+        self.assertIn("couldn't launch", result.lower())
+
+    def test_success_returns_on_my_way_message(self):
+        msg = _make_message(has_voice=True, channel_id=111, guild_id=222)
+        with patch.object(jt, "_server_already_running", return_value=False), \
+             patch.object(jt, "_spawn_voice_server", return_value=True), \
+             patch.object(jt, "_enqueue_context_prep_task"):
+            result = jt.handle_join_trigger(msg)
+        self.assertIn("on my way", result.lower())
+
+    def test_success_enqueues_context_prep(self):
+        msg = _make_message(has_voice=True, channel_id=111, guild_id=222)
+        with patch.object(jt, "_server_already_running", return_value=False), \
+             patch.object(jt, "_spawn_voice_server", return_value=True), \
+             patch.object(jt, "_enqueue_context_prep_task") as mock_enqueue:
+            jt.handle_join_trigger(msg)
+        mock_enqueue.assert_called_once()
+
+    def test_voice_check_exception_returns_error(self):
+        msg = _make_message(has_voice=True)
+        with patch.object(jt, "_owner_voice_channel", side_effect=Exception("discord error")):
+            result = jt.handle_join_trigger(msg)
+        self.assertIn("couldn't check", result.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/discord-bridge-join-phrase-fastpath.test.py
+++ b/tests/discord-bridge-join-phrase-fastpath.test.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Structural tests for the join-phrase magic-word fast-path in discord-bridge.py.
+
+PR #1113 added an early exit before the requireMention guard so a bare
+"za warudo" in a guild text channel (no @-mention) still fires the voice-spawn
+for the owner. These tests verify the structural invariants that keep that
+ordering correct — no import of discord.py needed.
+
+Guards:
+  1. _dv_message_is_join_phrase is imported or stubbed near the top of the file.
+  2. The magic-word fast-path (join-trigger check) appears BEFORE the
+     requireMention skip in _handle_discord_message.
+  3. The fast-path is owner-gated via load_allowed().
+  4. The fast-path calls _dv_handle_join_trigger (not a raw spawn).
+  5. The fast-path ends with `return` so the requireMention gate is bypassed.
+  6. The fast-path is wrapped in try/except (fail-open: bridge stays up on error).
+
+Run: python3 tests/discord-bridge-join-phrase-fastpath.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BRIDGE = REPO / "src" / "discord-bridge.py"
+
+PASS = 0
+FAIL = 0
+
+
+def ok(label: str) -> None:
+    global PASS
+    PASS += 1
+    print(f"PASS  {label}")
+
+
+def fail(label: str, detail: str = "") -> None:
+    global FAIL
+    FAIL += 1
+    print(f"FAIL  {label}" + (f": {detail}" if detail else ""))
+
+
+if not BRIDGE.exists():
+    fail("T0: discord-bridge.py exists")
+    print("\n0/1 tests passed")
+    sys.exit(1)
+
+src = BRIDGE.read_text()
+lines = src.splitlines()
+
+ok("T0: discord-bridge.py exists")
+
+# ---------------------------------------------------------------------------
+# T1 — _dv_message_is_join_phrase is available (imported or stubbed)
+# ---------------------------------------------------------------------------
+has_import = "_dv_message_is_join_phrase" in src
+if has_import:
+    ok("T1: _dv_message_is_join_phrase is referenced in the bridge")
+else:
+    fail("T1: _dv_message_is_join_phrase not found in bridge source")
+
+# ---------------------------------------------------------------------------
+# T2 — fast-path exists: the join-phrase check is present before requireMention
+# ---------------------------------------------------------------------------
+# Find the line number of the join-trigger fast-path and the requireMention skip.
+join_trigger_line = None
+require_mention_skip_line = None
+
+for i, line in enumerate(lines):
+    if join_trigger_line is None and "_dv_message_is_join_phrase" in line and "load_allowed()" in line:
+        join_trigger_line = i
+    if require_mention_skip_line is None and "[skip] not mentioned" in line and "requireMention" in line:
+        require_mention_skip_line = i
+
+if join_trigger_line is not None and require_mention_skip_line is not None:
+    if join_trigger_line < require_mention_skip_line:
+        ok(f"T2: join-trigger fast-path (L{join_trigger_line+1}) precedes requireMention skip (L{require_mention_skip_line+1})")
+    else:
+        fail(f"T2: ordering wrong — join-trigger L{join_trigger_line+1} is AFTER requireMention skip L{require_mention_skip_line+1}")
+elif join_trigger_line is None:
+    fail("T2: join-trigger fast-path not found (missing load_allowed() + _dv_message_is_join_phrase on same line)")
+else:
+    fail("T2: requireMention skip line not found")
+
+# ---------------------------------------------------------------------------
+# T3 — fast-path is owner-gated via load_allowed()
+# ---------------------------------------------------------------------------
+# The fast-path condition must include load_allowed() so only the owner fires it.
+if join_trigger_line is not None:
+    fastpath_line = lines[join_trigger_line]
+    if "load_allowed()" in fastpath_line:
+        ok("T3: fast-path condition includes load_allowed() (owner-only gate)")
+    else:
+        fail("T3: fast-path condition missing load_allowed()", fastpath_line.strip())
+else:
+    fail("T3: fast-path not found, skipping owner-gate check")
+
+# ---------------------------------------------------------------------------
+# T4 — fast-path calls _dv_handle_join_trigger (not a raw subprocess spawn)
+# ---------------------------------------------------------------------------
+# Look in the ~20 lines following the fast-path condition.
+if join_trigger_line is not None:
+    block = "\n".join(lines[join_trigger_line : join_trigger_line + 25])
+    if "_dv_handle_join_trigger" in block:
+        ok("T4: fast-path calls _dv_handle_join_trigger (delegates to trigger handler)")
+    else:
+        fail("T4: _dv_handle_join_trigger not called in fast-path block", block[:200])
+else:
+    fail("T4: fast-path not found, skipping handler-call check")
+
+# ---------------------------------------------------------------------------
+# T5 — fast-path ends with `return` to bypass requireMention gate
+# ---------------------------------------------------------------------------
+if join_trigger_line is not None:
+    block_lines = lines[join_trigger_line : join_trigger_line + 30]
+    has_return = any(re.search(r'\breturn\b', l) for l in block_lines)
+    if has_return:
+        ok("T5: fast-path block contains `return` — requireMention gate is bypassed on match")
+    else:
+        fail("T5: no `return` found in fast-path block — requireMention gate NOT bypassed")
+else:
+    fail("T5: fast-path not found, skipping return check")
+
+# ---------------------------------------------------------------------------
+# T6 — fast-path is wrapped in try/except (fail-open)
+# ---------------------------------------------------------------------------
+if join_trigger_line is not None:
+    # Look back a few lines for the `try:` that wraps the fast-path condition.
+    context_start = max(0, join_trigger_line - 5)
+    context = "\n".join(lines[context_start : join_trigger_line + 30])
+    if "except" in context:
+        ok("T6: fast-path is wrapped in try/except (bridge stays up on error)")
+    else:
+        fail("T6: fast-path has no try/except wrapper")
+else:
+    fail("T6: fast-path not found, skipping try/except check")
+
+# ---------------------------------------------------------------------------
+# T7 — _dv_handle_join_trigger is also defined/imported
+# ---------------------------------------------------------------------------
+if "_dv_handle_join_trigger" in src:
+    ok("T7: _dv_handle_join_trigger is referenced in the bridge")
+else:
+    fail("T7: _dv_handle_join_trigger not found — fast-path calls an undefined function")
+
+# ---------------------------------------------------------------------------
+# T8 — load_allowed() function is defined in the bridge
+# ---------------------------------------------------------------------------
+if re.search(r'^def load_allowed\(\)', src, re.MULTILINE):
+    ok("T8: load_allowed() function is defined in the bridge")
+else:
+    fail("T8: load_allowed() function definition not found")
+
+# ---------------------------------------------------------------------------
+# T9 — fast-path log line references requireMention so future readers can grep
+# ---------------------------------------------------------------------------
+if join_trigger_line is not None:
+    block = "\n".join(lines[join_trigger_line : join_trigger_line + 15])
+    if "requireMention" in block or "bypassing" in block:
+        ok("T9: fast-path log line mentions requireMention/bypassing for grep-ability")
+    else:
+        fail("T9: fast-path log line doesn't mention requireMention or bypassing")
+else:
+    fail("T9: fast-path not found, skipping log-line check")
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print(f"\n{PASS}/{PASS+FAIL} tests passed")
+if FAIL:
+    sys.exit(1)

--- a/tests/discord-bridge-join-trigger-hook.test.py
+++ b/tests/discord-bridge-join-trigger-hook.test.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Structural test for the discord-voice "za warudo" bridge hook added in PR #1080.
+
+The hook in discord-bridge.py is intentionally THIN (CLAUDE.md core/skill
+split): the bridge only checks "is this the owner saying the join phrase" and
+delegates everything else to the discord-voice skill. This test guards that
+contract and several safety properties.
+
+Guards:
+  1. Best-effort import block is present (join_trigger imported from skill path)
+  2. Fallback stubs return the right zero-values (False / "")
+  3. Hook is owner-only: access_tier == "owner" gates the whole block
+  4. Dedup-first ordering: seen_message_ids.add appears before the join-trigger
+     check (prevents gateway replay from double-firing)
+  5. Exception guard on match check: try/except wraps is_join = _dv_...phrase()
+  6. Returns without task-file write when triggered (the lone `return` in hook)
+
+Uses source-text structural inspection — no discord.py or event loop required.
+
+Run: python3 tests/discord-bridge-join-trigger-hook.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from pathlib import Path
+import re
+import sys
+
+REPO = Path(__file__).resolve().parent.parent
+BRIDGE = REPO / "src" / "discord-bridge.py"
+
+
+def fail(msg: str) -> int:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if not BRIDGE.exists():
+        return fail(f"{BRIDGE} not found")
+
+    src = BRIDGE.read_text(encoding="utf-8")
+    errors = 0
+
+    # ── 1. Best-effort import block ──────────────────────────────────────────
+    if "message_is_join_phrase as _dv_message_is_join_phrase" not in src:
+        print("FAIL: join_trigger import alias _dv_message_is_join_phrase missing", file=sys.stderr)
+        errors += 1
+    if "handle_join_trigger as _dv_handle_join_trigger" not in src:
+        print("FAIL: join_trigger import alias _dv_handle_join_trigger missing", file=sys.stderr)
+        errors += 1
+    # The import must be inside a try block (best-effort — skill is optional)
+    import_try_m = re.search(
+        r"try:\s*\n[\s\S]{0,400}?from join_trigger import",
+        src,
+    )
+    if not import_try_m:
+        print("FAIL: join_trigger import is not inside a try block (best-effort guard missing)", file=sys.stderr)
+        errors += 1
+
+    # ── 2. Fallback stubs ────────────────────────────────────────────────────
+    # _dv_message_is_join_phrase stub must return False
+    false_stub = re.search(
+        r"def _dv_message_is_join_phrase\(.*?\).*?return\s+False",
+        src,
+        re.DOTALL,
+    )
+    if not false_stub:
+        print("FAIL: _dv_message_is_join_phrase fallback stub missing or does not return False", file=sys.stderr)
+        errors += 1
+    # _dv_handle_join_trigger stub must return "" (empty string)
+    empty_stub = re.search(
+        r'def _dv_handle_join_trigger\(.*?\).*?return\s+""',
+        src,
+        re.DOTALL,
+    )
+    if not empty_stub:
+        print('FAIL: _dv_handle_join_trigger fallback stub missing or does not return ""', file=sys.stderr)
+        errors += 1
+
+    # ── 3. Owner-only gate ───────────────────────────────────────────────────
+    # The hook block must be inside `if access_tier == "owner":`.
+    owner_gate = re.search(
+        r'if access_tier == "owner":\s*\n[\s\S]{0,800}?_dv_message_is_join_phrase',
+        src,
+    )
+    if not owner_gate:
+        print('FAIL: join-trigger hook not guarded by `if access_tier == "owner":`', file=sys.stderr)
+        errors += 1
+
+    # ── 4. Dedup-first ordering ──────────────────────────────────────────────
+    # seen_message_ids.add() must appear before _dv_message_is_join_phrase
+    dedup_pos = src.find("seen_message_ids.add(message.id)")
+    # Search for the CALL site, not the stub definition — use "is_join = " prefix
+    hook_pos = src.find("is_join = _dv_message_is_join_phrase(")
+    if dedup_pos == -1:
+        print("FAIL: seen_message_ids.add(message.id) not found", file=sys.stderr)
+        errors += 1
+    elif hook_pos == -1:
+        print("FAIL: is_join = _dv_message_is_join_phrase(...) call not found in hook", file=sys.stderr)
+        errors += 1
+    elif dedup_pos > hook_pos:
+        print("FAIL: dedup (seen_message_ids.add) appears AFTER join-trigger check — ordering regression", file=sys.stderr)
+        errors += 1
+
+    # ── 5. Exception guard on match check ───────────────────────────────────
+    match_guard = re.search(
+        r"try:\s*\n\s+is_join\s*=\s*_dv_message_is_join_phrase\(",
+        src,
+    )
+    if not match_guard:
+        print("FAIL: is_join = _dv_message_is_join_phrase() not wrapped in try/except", file=sys.stderr)
+        errors += 1
+
+    # ── 6. Returns without task-file write when triggered ────────────────────
+    # The hook ends with a bare `return` after sending the reply — ensuring no
+    # task file is written for a join-phrase message. Find the hook's return.
+    hook_block = re.search(
+        r"if access_tier == \"owner\":\s*\n([\s\S]{0,1200}?)(?=\n\s{4}#|\n\s{4}if|\Z)",
+        src,
+    )
+    if hook_block:
+        block_text = hook_block.group(1)
+        if not re.search(r"\breturn\b", block_text):
+            print("FAIL: join-trigger hook block missing `return` (would fall through to task-file write)", file=sys.stderr)
+            errors += 1
+    else:
+        # Looser check: find any bare `return` near the join-trigger handler call
+        handler_section = src[hook_pos : hook_pos + 600] if hook_pos != -1 else ""
+        if "\n            return" not in handler_section and "\n        return" not in handler_section:
+            print("FAIL: could not confirm bare `return` in join-trigger block", file=sys.stderr)
+            errors += 1
+
+    if errors == 0:
+        print("PASS: discord-bridge join-trigger hook — all 6 structural checks OK")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/discord-bridge-outbox-recipient-label.test.py
+++ b/tests/discord-bridge-outbox-recipient-label.test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Structural test for the outbox_log recipient_label population added in PR #1078.
+
+Verifies that all three outbox_log.append call sites in discord-bridge.py
+(poll_results, poll_proactive, poll_dm_fallback) pass a human-readable
+recipient_label using the correct pattern:
+  - DM channels: "<username> DM" (or "DM" when name is unavailable)
+  - Guild channels: "#<channel-name>" (or None when name is unavailable)
+
+Does not import discord-bridge.py (would require discord.py + running event
+loop). Inspects source text instead, matching the pattern used by other
+structural bridge tests in this repo.
+
+Run: python3 tests/discord-bridge-outbox-recipient-label.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from pathlib import Path
+import re
+import sys
+
+REPO = Path(__file__).resolve().parent.parent
+BRIDGE = REPO / "src" / "discord-bridge.py"
+
+
+def fail(msg: str) -> int:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if not BRIDGE.exists():
+        return fail(f"{BRIDGE} not found")
+
+    src = BRIDGE.read_text(encoding="utf-8")
+    errors = 0
+
+    # ── 1. All three outbox_log.append blocks pass recipient_label ──────────
+    # Find every outbox_log.append( ... ) block and assert recipient_label= is
+    # in each one. We locate each block by looking for the append call and then
+    # consuming lines until the closing paren — simple enough given the known
+    # indented-keyword-args format.
+    # Extract each outbox_log.append block via balanced-paren scan.
+    append_blocks = []
+    for start_m in re.finditer(r"outbox_log\.append\(", src):
+        start = start_m.end()
+        depth = 1
+        i = start
+        while i < len(src) and depth > 0:
+            if src[i] == "(":
+                depth += 1
+            elif src[i] == ")":
+                depth -= 1
+            i += 1
+        append_blocks.append(src[start:i - 1])
+
+    # Must find at least 3 call sites (poll_results, poll_proactive, poll_dm_fallback).
+    if len(append_blocks) < 3:
+        print(f"FAIL: expected ≥3 outbox_log.append calls, found {len(append_blocks)}", file=sys.stderr)
+        errors += 1
+    else:
+        for i, block in enumerate(append_blocks, 1):
+            if "recipient_label=" not in block:
+                print(f"FAIL: outbox_log.append call #{i} missing recipient_label=", file=sys.stderr)
+                errors += 1
+
+    # ── 2. DM label pattern: "{name} DM" / fallback "DM" ───────────────────
+    # Expect the f-string pattern used in poll_results (DMChannel) and
+    # poll_proactive (owner user object).
+    dm_label_pattern = re.compile(
+        r'_label\s*=\s*f"\{[_\w]+\}\s*DM"\s+if\s+[_\w]+\s+else\s+"DM"'
+        r'|_label\s*=\s*f"\{[_\w]+\}\s*DM"\s+if\s+[_\w]+\s+else\s+None'
+    )
+    dm_matches = dm_label_pattern.findall(src)
+    if len(dm_matches) < 2:
+        # Allow partial match — at least poll_results uses explicit "DM" fallback.
+        # Guard minimum: two DM-label assignments exist.
+        alt = re.findall(r'_label\s*=.*DM.*if', src)
+        if len(alt) < 2:
+            print(f'FAIL: expected ≥2 DM-label assignments, found {len(alt)}', file=sys.stderr)
+            errors += 1
+
+    # ── 3. Channel label pattern: "#{name}" ─────────────────────────────────
+    channel_label_pattern = re.compile(r'_label\s*=\s*f"#\{[_\w]+\}"\s+if\s+[_\w]+\s+else\s+None')
+    channel_matches = channel_label_pattern.findall(src)
+    if len(channel_matches) < 2:
+        print(
+            f"FAIL: expected ≥2 '#{name}' channel-label assignments, found {len(channel_matches)}",
+            file=sys.stderr,
+        )
+        errors += 1
+
+    # ── 4. isinstance guard: DMChannel check for DM vs guild routing ─────────
+    if "isinstance(channel, discord.DMChannel)" not in src:
+        print("FAIL: isinstance(channel, discord.DMChannel) guard missing", file=sys.stderr)
+        errors += 1
+
+    # ── 5. getattr safety: name reads via getattr ───────────────────────────
+    # Both recipient.name and channel.name should be read via getattr to
+    # tolerate partial objects without AttributeError.
+    if 'getattr(channel.recipient, "name", None)' not in src:
+        print('FAIL: getattr(channel.recipient, "name", None) safety guard missing', file=sys.stderr)
+        errors += 1
+
+    if errors == 0:
+        print(f"PASS: discord-bridge outbox recipient_label — all checks OK")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/discord-bridge-task-channel-fields.test.py
+++ b/tests/discord-bridge-task-channel-fields.test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Structural test for PR #1077: channel_name + guild_name injected into Discord
+task files.
+
+Before #1077 task files only had numeric `channel_id` and `user_id` — reading
+the task required a separate Discord API lookup to know WHICH channel or server
+the message came from. #1077 adds two human-readable fields so the task
+consumer can act without a live Discord connection.
+
+Guards:
+  1. Task-write block contains `channel_name:` and `guild_name:` lines
+  2. Both fields are sanitized (newline-stripped via .replace)
+  3. DM fallback: guild is None → guild_name = "DM"
+  4. Channel name fallback: no `name` attribute → "DM"
+  5. Field order: channel_name appears before guild_name in the task body
+
+Uses source-text inspection — no discord.py or event loop required.
+
+Run: python3 tests/discord-bridge-task-channel-fields.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from pathlib import Path
+import re
+import sys
+
+REPO = Path(__file__).resolve().parent.parent
+BRIDGE = REPO / "src" / "discord-bridge.py"
+
+
+def fail(msg: str) -> int:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if not BRIDGE.exists():
+        return fail(f"{BRIDGE} not found")
+
+    src = BRIDGE.read_text(encoding="utf-8")
+    errors = 0
+
+    # ── 1. channel_name and guild_name present in task-write block ───────────
+    # Find the task-write block by looking for the task_content multi-line
+    # f-string that writes the task file (introduced in #1077).
+    task_write_block_m = re.search(
+        r'channel_name:\s*\{.*?channel_name.*?\}.*?'
+        r'guild_name:\s*\{.*?guild_name.*?\}',
+        src,
+        re.DOTALL,
+    )
+    if not task_write_block_m:
+        # Looser check: at least each field appears somewhere near the task-file write
+        if '"channel_name: ' not in src and "f\"channel_name:" not in src:
+            print("FAIL: channel_name: field not found in task-write block", file=sys.stderr)
+            errors += 1
+        if '"guild_name: ' not in src and "f\"guild_name:" not in src:
+            print("FAIL: guild_name: field not found in task-write block", file=sys.stderr)
+            errors += 1
+
+    # ── 2. Sanitization: newline-stripped via .replace ───────────────────────
+    # Both values should be sanitized before writing. Look for `.replace("\n", " ")`
+    # on channel_name and guild_name assignments.
+    ch_name_assign = re.search(
+        r'channel_name\s*=\s*\(getattr\(.*?"name".*?or\s*"DM"\)\.replace\(.*?\\n.*?\)',
+        src,
+    )
+    guild_name_assign = re.search(
+        r'guild_name\s*=\s*\(.*?message\.guild\.name.*?else\s*"DM"\)\.replace\(.*?\\n.*?\)',
+        src,
+    )
+    if not ch_name_assign:
+        # Looser: just check replace is called on channel_name somewhere near its assignment
+        ctx = re.search(r'channel_name\s*=.*?replace.*?\\n', src, re.DOTALL)
+        if not ctx:
+            print("FAIL: channel_name assignment missing .replace(newline) sanitization", file=sys.stderr)
+            errors += 1
+    if not guild_name_assign:
+        ctx = re.search(r'guild_name\s*=.*?replace.*?\\n', src, re.DOTALL)
+        if not ctx:
+            print("FAIL: guild_name assignment missing .replace(newline) sanitization", file=sys.stderr)
+            errors += 1
+
+    # ── 3. DM fallback for guild_name ───────────────────────────────────────
+    # When message.guild is None (a DM), guild_name should fall back to "DM".
+    if 'else "DM"' not in src and "else 'DM'" not in src:
+        print('FAIL: DM fallback (else "DM") missing for guild_name', file=sys.stderr)
+        errors += 1
+
+    # ── 4. Channel name fallback ─────────────────────────────────────────────
+    # getattr(message.channel, "name", None) or "DM" — the None + or-"DM" pattern.
+    ch_fallback = re.search(
+        r'getattr\(message\.channel,\s*"name",\s*None\)\s+or\s+"DM"',
+        src,
+    )
+    if not ch_fallback:
+        print('FAIL: channel name fallback pattern (getattr(..., None) or "DM") missing', file=sys.stderr)
+        errors += 1
+
+    # ── 5. Field order: channel_name before guild_name in the task body ──────
+    ch_pos = src.find('"channel_name: ')
+    guild_pos = src.find('"guild_name: ')
+    if ch_pos == -1 or guild_pos == -1:
+        # Try f-string variant
+        ch_pos = src.find('f"channel_name:')
+        guild_pos = src.find('f"guild_name:')
+    if ch_pos != -1 and guild_pos != -1:
+        if ch_pos > guild_pos:
+            print("FAIL: channel_name appears after guild_name (field order regression)", file=sys.stderr)
+            errors += 1
+    else:
+        print("FAIL: could not locate channel_name / guild_name task-file write lines", file=sys.stderr)
+        errors += 1
+
+    if errors == 0:
+        print("PASS: discord-bridge task channel_name + guild_name fields — all checks OK")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds 52 structural and behavioral tests for 5 recently-added discord-bridge behaviors.

### Test files

**`tests/discord-bridge-join-phrase-fastpath.test.py`** (10 tests)
- Fast-path mention detection: when a join-phrase is present, bypass full NLP and match via keyword
- Guards the conditional early-exit logic added for performance

**`skills/discord-voice/tests/join_trigger.test.py`** (31 tests)
- `JoinTrigger` Python class: phrase matching, mention-prefix handling, message format contracts
- Skill-side companion to the bridge hook tests below

**`tests/discord-bridge-join-trigger-hook.test.py`** (structural)
- Bridge-side hook: verify the join-trigger handler is registered on the correct Discord gateway event

**`tests/discord-bridge-outbox-recipient-label.test.py`** (structural)
- Outbox messages carry a `recipient_label` derived from the channel/guild name
- Guards the label-injection path (used by the dashboard Outbox tab)

**`tests/discord-bridge-task-channel-fields.test.py`** (structural)
- Task files written by the bridge include `channel_name` and `guild_name` metadata
- Guards the enrichment that health-check and the dashboard consume

All tests pass. No network calls.