### PR TITLE
fix(test): kill process group on teardown to prevent stale web-client leak (#918 fix)

### DIFF
--- a/tests/agent-state-endpoint.test.ts
+++ b/tests/agent-state-endpoint.test.ts
@@ -73,6 +73,13 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 				// 'ignore' prevents the pipe buffer from filling in CI (stdout isn't drained),
 				// which would block the child and cause the /sse-status poll to time out.
 				stdio: 'ignore',
+				// detached: true creates a new process group for the entire subtree
+				// (npm → tsx → node). Without this, child.kill() only kills the npm
+				// wrapper — tsx and the actual node web-client survive, keeping the
+				// port bound and corrupting the next test run (observed: stale PID
+				// with deleted workspace → core-status ENOENT → stale:true → tmux
+				// scrape sees sutando-core active → every test gets state:'working').
+				detached: true,
 			}
 		);
 		// Wait up to 20s for server to start listening. CI cold-start on `npx tsx`
@@ -89,17 +96,20 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 	});
 
 	after(async () => {
-		// Hang-safe teardown: SIGTERM, wait up to 2s, SIGKILL fallback. Without
-		// awaiting exit, the live child-process handle keeps node --test alive
-		// past the CI job timeout (observed: 9m43s hangs after #423 merged).
-		if (child && !child.killed) {
+		// Hang-safe teardown: SIGTERM the process GROUP, wait up to 2s, SIGKILL
+		// group fallback. Without group-kill, only the npm wrapper exits and the
+		// tsx/node children keep the port bound — causing the next test run to
+		// silently connect to a stale server (see detached: true comment above).
+		// Without awaiting exit, the live child-process handle keeps node --test
+		// alive past the CI job timeout (observed: 9m43s hangs after #423 merged).
+		if (child?.pid && !child.killed) {
 			await new Promise<void>((resolve) => {
 				const hardKill = setTimeout(() => {
-					try { child.kill('SIGKILL'); } catch { /* already dead */ }
+					try { process.kill(-child.pid!, 'SIGKILL'); } catch { /* already dead */ }
 					resolve();
 				}, 2_000);
 				child.once('exit', () => { clearTimeout(hardKill); resolve(); });
-				child.kill('SIGTERM');
+				try { process.kill(-child.pid!, 'SIGTERM'); } catch { resolve(); }
 			});
 		}
 		// Remove the per-test-process workspace temp dir wholesale.


### PR DESCRIPTION
## Root cause

`npx tsx` spawns a multi-process chain: **npm → tsx → node**. The previous teardown sent `SIGTERM`/`SIGKILL` only to the **direct child** (`npm exec`), leaving the actual `tsx`/`node` web-client processes alive — still holding the test port (18081).

On the **next test run**:
- `before()` polls the port → gets 200 from the **stale server** instead of the newly spawned one
- Stale server has a **deleted temp workspace** → `core-status.json` ENOENT → `stale: true` → tmux scrape sees `sutando-core` active → `effectiveAgentState()` returns `'working'` for every request
- All state-checking tests fail with `actual: 'working'`, regardless of track resets in `beforeEach`

This explains the 6 consistent failures that appeared to be unrelated to recent changes — they only fail when a previous test run's teardown leaked the server process.

## Fix

- Spawn with `detached: true` → creates a new **process group** for the entire npm→tsx→node subtree
- Teardown uses `process.kill(-child.pid!, signal)` (negative PID = send to process group) so all descendants die together
- Guard updated to `child?.pid` for null safety

## Test

- All 9 subtests pass
- Port 18081 is verified CLOSED after each run (no leak)
- Two consecutive runs confirmed clean (previously: second run always failed)

## See also

- Stale process symptom: `{"state":"working","label":"Bash"}` regardless of `/mute-state?state=idle` resets
- Root signal: tmux scrape returning `working` when workspace temp dir is deleted

🤖 Generated with [Claude Code](https://claude.ai/claude-code)