### PR TITLE
fix(tests): unblock 23 tests — sqlite flag + remove duplicate screen-companion skill

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "tsx src/voice-agent.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test tests/*.test.ts && npm run test:py",
+    "test": "NODE_OPTIONS=--experimental-sqlite tsx --test tests/*.test.ts && npm run test:py",
     "test:py": "for f in tests/*.test.py; do echo \"--- $f ---\" && python3 \"$f\" || exit 1; done"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Two unrelated environment blockers that together broke 23 of 285 TS tests.

### 1. `node:sqlite` needs `--experimental-sqlite` flag

`task-bridge.ts` → `conversation-store.ts` → `import { DatabaseSync } from 'node:sqlite'`

Node v22.11.0 requires `--experimental-sqlite` to use the built-in SQLite module. Without it, all 4 task-bridge test files fail at import time with `ERR_UNKNOWN_BUILTIN_MODULE`.

**Fix:** `NODE_OPTIONS=--experimental-sqlite` added to the `test` npm script.

### 2. Duplicate `activate_screen_companion` tool

`~/.sutando/workspace/skills/screen-companion/` was an outdated copy of the repo skill (1 tool: `activate_screen_companion` only, no `deactivate`). The skill-loader loaded both the repo and workspace versions, causing `assertUniqueToolNames()` to throw during `inline-tools.ts` module initialization — breaking every test that imports inline-tools (7 tests total).

**Fix:** Removed the workspace copy. The configs were identical to the repo version; the repo has the newer version with both tools.

## Result

```
# tests 285
# pass 285
# fail 0
```

Was 262/285 before this fix.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)