### PR TITLE
fix(discord-bridge): downgrade owner→team for bot senders in allowFrom

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2529,10 +2529,9 @@ async def _handle_discord_message(message, force=False):
 
     # Determine access tier
     access_tier = "other"
+    is_bot_sender = bool(getattr(message.author, "bot", False))
     if sender_id in allowed:
         access_tier = "owner"
-        # Record owner activity for status-aware-pivot in proactive loop
-        write_owner_activity("discord", text)
     else:
         # Check if team member (from channel allowlists)
         try:
@@ -2545,6 +2544,23 @@ async def _handle_discord_message(message, force=False):
                 access_tier = "team"
         except:
             pass
+
+    # Defensive filter: cross-fleet bot accounts that landed in `allowFrom`
+    # (intentionally or by accident) should never run with owner-tier — they
+    # can only ever speak as peers in shared channels. Per #ep013 2026-05-27
+    # bot-flood post-mortem (Mini + qingyun-sutando coord): Mini's bot
+    # user_id was added to MacBook's Discord global allowFrom, so his
+    # 22-task orphan-recovery flood arrived as owner-tier (full
+    # capabilities) instead of team-tier (sandboxed). Bridge-side
+    # downgrade prevents recurrence regardless of allowFrom hygiene.
+    if is_bot_sender and access_tier == "owner":
+        print(f"  [bot-sender-downgrade] @{username} (id={sender_id}) is a bot in allowFrom; downgrading owner→team")
+        access_tier = "team"
+
+    # Record owner activity AFTER the bot-downgrade so bot pings can't
+    # falsely trigger status-aware-pivot's "owner is active" branch.
+    if access_tier == "owner":
+        write_owner_activity("discord", text)
 
     # Dedup: skip if we've already processed this Discord message ID.
     # EXCEPTION: force=True means on_message_edit is reprocessing because the

--- a/tests/discord-bridge-bot-sender-tier-downgrade.test.py
+++ b/tests/discord-bridge-bot-sender-tier-downgrade.test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Regression test for the #ep013 2026-05-27 bot-flood post-mortem.
+
+Background: Sutando-Mini's bot user_id had been added to MacBook's Discord
+global `allowFrom`. When Mini ran `/task-orphan-check` and his per-orphan
+recovery sentinels fanned out across shared channels, every one of them
+landed in MacBook's bridge as `access_tier: owner` (full capabilities)
+instead of `team` (sandboxed). 21 of 22 orphans got promoted that way.
+
+Fix: bridge-side defensive downgrade. If the Discord author has
+`message.author.bot == True` AND lands in `access_tier: owner` via global
+allowFrom membership, downgrade to `team`. Owner identities should be
+human; cross-fleet bot mentions are peers, never owners.
+
+Guards (structural — does not exercise the live bridge):
+  1. `is_bot_sender = bool(getattr(message.author, "bot", False))` is
+     extracted near the access-tier determination.
+  2. A defensive downgrade block exists that flips owner→team when
+     `is_bot_sender` is true.
+  3. `write_owner_activity("discord", text)` is gated on the FINAL
+     access_tier value (after downgrade), so bot pings don't pollute
+     owner-activity tracking.
+
+Run: python3 tests/discord-bridge-bot-sender-tier-downgrade.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from pathlib import Path
+import re
+import sys
+
+REPO = Path(__file__).resolve().parent.parent
+BRIDGE = REPO / "src" / "discord-bridge.py"
+
+
+def main() -> int:
+    if not BRIDGE.exists():
+        print(f"FAIL: {BRIDGE} not found", file=sys.stderr)
+        return 1
+
+    src = BRIDGE.read_text()
+
+    # 1. Bot-author detection extracted.
+    if not re.search(
+        r'is_bot_sender\s*=\s*bool\s*\(\s*getattr\s*\(\s*message\.author\s*,\s*[\'"]bot[\'"]\s*,\s*False\s*\)\s*\)',
+        src,
+    ):
+        print(
+            "FAIL: missing is_bot_sender = bool(getattr(message.author, 'bot', False))",
+            file=sys.stderr,
+        )
+        return 1
+
+    # 2. Defensive downgrade block: when is_bot_sender AND access_tier == "owner",
+    #    set access_tier = "team". Match a few lines so a stray reorder is caught.
+    if not re.search(
+        r'if\s+is_bot_sender\s+and\s+access_tier\s*==\s*[\'"]owner[\'"]\s*:[\s\S]{0,400}?access_tier\s*=\s*[\'"]team[\'"]',
+        src,
+    ):
+        print(
+            "FAIL: missing defensive downgrade `if is_bot_sender and access_tier == \"owner\": ... access_tier = \"team\"`",
+            file=sys.stderr,
+        )
+        return 1
+
+    # 3. write_owner_activity is gated on access_tier == "owner" AFTER the
+    #    downgrade — not unconditionally inside the `if sender_id in allowed:`
+    #    block. Search for the gated form.
+    if not re.search(
+        r'if\s+access_tier\s*==\s*[\'"]owner[\'"]\s*:\s*\n\s+write_owner_activity\s*\(\s*[\'"]discord[\'"]\s*,\s*text\s*\)',
+        src,
+    ):
+        print(
+            "FAIL: write_owner_activity should be gated on final access_tier == 'owner' (after downgrade)",
+            file=sys.stderr,
+        )
+        return 1
+
+    # 4. write_owner_activity is NOT called inside the
+    #    `if sender_id in allowed:` block anymore (would re-introduce the leak
+    #    for bot senders that get downgraded later).
+    leak_pattern = re.search(
+        r'if\s+sender_id\s+in\s+allowed\s*:\s*\n\s+access_tier\s*=\s*[\'"]owner[\'"]\s*\n\s+(?:#[^\n]*\n\s+)?write_owner_activity',
+        src,
+    )
+    if leak_pattern:
+        print(
+            "FAIL: write_owner_activity should NOT be called inside the `if sender_id in allowed:` block — "
+            "it would fire before the bot-downgrade and pollute owner-activity tracking.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("PASS: discord-bridge.py cross-fleet bot-sender downgrade looks correct.")
+    print("  - is_bot_sender extracted from message.author.bot")
+    print("  - owner→team downgrade fires when is_bot_sender")
+    print("  - write_owner_activity gated on final access_tier (post-downgrade)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Bridge-side defensive filter for cross-fleet bot mentions: when a Discord message author is a bot (`message.author.bot == True`) and their user_id is in the global `allowFrom`, downgrade `access_tier` from `owner` → `team` instead of inheriting owner-tier from allowFrom membership.

This is MacBook's half of the split-work coord with Sutando-Mini in #ep013 on 2026-05-27 (00:58Z). Mini takes the `/task-orphan-check` SKILL.md patch separately.

## Background — #ep013 2026-05-27 bot-flood

Sutando-Mini ran `/task-orphan-check` on 22 stale tasks left from a crashed prior session. The skill's default branch fires a per-orphan recovery sentinel; Mini let all 22 fire without tier-aware filtering, fanning across #ep013 (13), #talk (4), voice channels (4), and DM (1).

Every one of those sentinels arrived at MacBook's bridge as `access_tier: owner` — full capabilities — instead of `team` (sandboxed via the team-tier system instructions). Reason: Mini's bot user_id was in MacBook's Discord global `allowFrom`, so the existing tier-determination promoted him to owner.

(Mini's bot2bot post-mortem: msg 1508994005290057770. qingyun-sutando reply with `feedback_mini_bot_in_macbook_discord_allowfrom` memory: msg 1508994167416819752. Split-work confirmation: msg 1508997784702025759.)

## Fix

In `src/discord-bridge.py`'s access-tier determination block:

1. Extract `is_bot_sender = bool(getattr(message.author, "bot", False))`.
2. After the existing `if sender_id in allowed: owner / else team` block, add a defensive downgrade:
   ```python
   if is_bot_sender and access_tier == "owner":
       print(f"  [bot-sender-downgrade] @{username} (id={sender_id}) is a bot in allowFrom; downgrading owner→team")
       access_tier = "team"
   ```
3. Move `write_owner_activity("discord", text)` so it only fires when the FINAL `access_tier` (post-downgrade) is `"owner"`. Bot pings should not trigger status-aware-pivot's "owner is active" branch.

## Why bridge-side and not just allowFrom hygiene

Chi can re-add a bot user_id to `allowFrom` at any time (legitimate intent: trust the cross-fleet bot to reach this node). The bridge-side downgrade makes that re-add safe: the bot can still reach the bridge but never with owner capabilities.

## Tests

- **New** `tests/discord-bridge-bot-sender-tier-downgrade.test.py` — three structural guards: `is_bot_sender` extraction, downgrade block exists, `write_owner_activity` gated on the final (post-downgrade) `access_tier`.
- **Existing** `tests/discord-bridge-access-tier.test.py` still passes (the `if sender_id in allowed: access_tier = "owner"` pattern is preserved).

Both green locally.

## Out of scope (follow-up)

Per Mini 2026-05-27 00:58Z: cross-fleet bot-mention tier should arguably be **derived** (peer/team) at the bridge layer rather than inheriting allowFrom at all. That's a separate issue; this PR ships the immediate defensive filter so the next bot-orphan-flood doesn't repeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)