### PR TITLE
fix(health-check): show source paths in multi-bridge-process warn

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -874,9 +874,21 @@ def run_all_checks() -> list[dict]:
             checks.append({"name": name, "status": "warn", "detail": "configured but not running"})
             continue
 
-        # Check 1: Multiple processes (zombie/duplicate)
+        # Check 1: Multiple processes (zombie/duplicate).
+        # Show source paths so it's clear whether these are expected
+        # app-bundle vs dev-repo coexistence or accidental duplicate spawns.
         if len(pids) > 1:
-            checks.append({"name": name, "status": "warn", "detail": f"multiple processes ({len(pids)} PIDs: {','.join(pids)})"})
+            def _pid_script(pid: str) -> str:
+                try:
+                    r = subprocess.run(["/bin/ps", "-p", pid, "-o", "command="],
+                                       capture_output=True, text=True, timeout=3)
+                    parts = r.stdout.strip().split()
+                    py_args = [p for p in parts if p.endswith(".py")]
+                    return py_args[-1] if py_args else "?"
+                except Exception:
+                    return "?"
+            pid_paths = ", ".join(f"{p}:{_pid_script(p)}" for p in pids)
+            checks.append({"name": name, "status": "warn", "detail": f"multiple processes ({len(pids)} PIDs: {pid_paths})"})
             continue
 
         # Check 2: Log file freshness — prefer logs/ (where startup.sh writes)

--- a/tests/health-check-bridge-multi-pid.test.py
+++ b/tests/health-check-bridge-multi-pid.test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Regression guard: health-check multiple-bridge-process warn shows source paths.
+
+Before this fix, the warn read:
+  "multiple processes (2 PIDs: 25023,25065)"
+
+That gave no hint whether the two instances were an expected app-bundle +
+dev-repo coexistence or an accidental duplicate spawn of the same script.
+After the fix the warn reads:
+  "multiple processes (2 PIDs: 25023:/Applications/Sutando.app/.../discord-bridge.py,
+                                 25065:/Users/.../sutando/src/discord-bridge.py)"
+
+These tests verify the new path-enriched format via source-grep (no live
+process required).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = (REPO / "src" / "health-check.py").read_text(encoding="utf-8")
+
+
+def test_pid_script_helper_defined():
+    """health-check.py defines a _pid_script helper for path extraction."""
+    assert "_pid_script" in SRC, (
+        "_pid_script helper not found in health-check.py — "
+        "multiple-bridge warn will not show source paths"
+    )
+
+
+def test_pid_script_uses_ps_command():
+    """_pid_script extracts the script path from `ps -p <pid> -o command=`."""
+    assert '"-o", "command="' in SRC or "command=" in SRC, (
+        "health-check.py doesn't call `ps -o command=` to extract bridge script path"
+    )
+
+
+def test_pid_paths_in_warn_detail():
+    """The multi-pid warn uses pid_paths (enriched with source paths)."""
+    assert "pid_paths" in SRC, (
+        "pid_paths variable not found — multi-pid warn won't include source paths"
+    )
+
+
+def test_warn_format_uses_pid_paths():
+    """The actual warn detail string uses pid_paths, not the bare pids join."""
+    # Old pattern: f"...PIDs: {','.join(pids)})"
+    # New pattern: f"...PIDs: {pid_paths})"
+    assert "pid_paths}" in SRC, (
+        "multi-pid warn detail does not reference pid_paths — "
+        "source paths won't appear in health-check output"
+    )
+
+
+def test_py_args_extraction():
+    """_pid_script filters for .py args to find the script path."""
+    assert ".endswith(\".py\")" in SRC or '.endswith(".py")' in SRC, (
+        "_pid_script does not filter for .py args — may return wrong path component"
+    )
+
+
+def main():
+    tests = [
+        test_pid_script_helper_defined,
+        test_pid_script_uses_ps_command,
+        test_pid_paths_in_warn_detail,
+        test_warn_format_uses_pid_paths,
+        test_py_args_extraction,
+    ]
+    failures = []
+    for fn in tests:
+        try:
+            fn()
+            print(f"  ✓ {fn.__name__}")
+        except AssertionError as e:
+            failures.append(f"{fn.__name__}: {e}")
+            print(f"  ✗ {fn.__name__}: {e}")
+    print()
+    if failures:
+        print(f"{len(failures)} test(s) failed ({len(tests) - len(failures)} passed).")
+        sys.exit(1)
+    print(f"All {len(tests)} bridge-multi-pid tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

When `health-check.py` detects multiple PIDs for the same bridge script, the warning previously showed only the raw PIDs:

```
discord-bridge.py: multiple processes (2 PIDs: 25023,25065)
```

After this fix, it shows the full source path per PID:

```
discord-bridge.py: multiple processes (2 PIDs: 25023:/Applications/Sutando.app/.../discord-bridge.py, 25065:/Users/.../sutando/src/discord-bridge.py)
```

This makes the warning immediately actionable — operators can tell at a glance whether the two instances are expected app-bundle + dev-repo coexistence or a zombie duplicate.

## Tests

5 tests in `tests/health-check-bridge-multi-pid.test.py` — all pass.

Closes companion to #1079.