### PR TITLE
fix(phone-conversation): archive task-phone-*.txt files on poll exit

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -47,7 +47,7 @@
 import { config as _dotenvConfig } from 'dotenv';
 _dotenvConfig({ path: new URL('../../../.env', import.meta.url).pathname, override: true });
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync, symlinkSync } from 'node:fs';
+import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync, symlinkSync, renameSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { voiceApiKey } from '../../../src/voice-key.js';
@@ -123,6 +123,16 @@ const RESULTS_DIR = process.env.PHONE_RESULTS_DIR || join(WORKSPACE_DIR, 'result
 const TASKS_DIR = join(WORKSPACE_DIR, 'tasks');
 const TASK_POLL_INTERVAL_MS = 500;
 const TASK_TIMEOUT_MS = 120_000;
+
+function archivePhoneTask(taskPath: string, taskId: string): void {
+	try {
+		if (!existsSync(taskPath)) return;
+		const ym = new Date().toISOString().slice(0, 7);
+		const destDir = join(TASKS_DIR, 'archive', ym);
+		mkdirSync(destDir, { recursive: true });
+		renameSync(taskPath, join(destDir, `${taskId}.txt`));
+	} catch { try { unlinkSync(taskPath); } catch { /* ignore */ } }
+}
 const OWNER_NAME = process.env.owner ?? '';
 const OWNER_NUMBER = process.env.OWNER_NUMBER ?? '';
 
@@ -390,6 +400,7 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 		if (callSession.hangingUp || !activeCalls.has(callSession.callSid)) {
 			clearInterval(poll);
 			callSession.pendingTasks = Math.max(0, callSession.pendingTasks - 1);
+			archivePhoneTask(taskPath, taskId);
 			return;
 		}
 		if (existsSync(resultPath)) {
@@ -399,6 +410,7 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			console.log(`${ts()} [Task] result for ${taskId} (${Date.now() - startTime}ms): ${result.slice(0, 200)}`);
 			callSession.events.push({ event: `task_result:${taskId}:${Date.now() - startTime}ms`, timestamp: new Date().toISOString() });
 			try { unlinkSync(resultPath); } catch {}
+			archivePhoneTask(taskPath, taskId);
 			// Cache result so duplicate requests get instant replay
 			if (!callSession.taskResultCache) callSession.taskResultCache = new Map();
 			callSession.taskResultCache.set(taskDescription, result);
@@ -411,6 +423,7 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 		if (Date.now() - startTime > POLL_TIMEOUT_MS) {
 			clearInterval(poll);
 			callSession.pendingTasks = Math.max(0, callSession.pendingTasks - 1);
+			archivePhoneTask(taskPath, taskId);
 			console.log(`${ts()} [Task] timeout for ${taskId}`);
 			try {
 				(callSession.voiceSession as any).transport.sendContent([

--- a/tests/phone-task-archive.test.py
+++ b/tests/phone-task-archive.test.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Structural regression test for issue #1235 — phone-conversation task archiving.
+
+Before fix: conversation-server.ts consumed the result file (unlinkSync) but
+left the task file (task-phone-*.txt) in tasks/ forever.
+
+After fix: archivePhoneTask() is called in all three poll-interval exit paths:
+  1. Call hang-up / call not active  →  archive before return
+  2. Result available (success path)  →  archive after unlinkSync(resultPath)
+  3. Timeout (POLL_TIMEOUT_MS)        →  archive before logging timeout
+
+Guards (structural — does not run the live server):
+  A. archivePhoneTask() helper exists and uses TASKS_DIR + archive/YYYY-MM/
+  B. Call in hang-up path (right before `return`)
+  C. Call in success path (right after unlinkSync(resultPath))
+  D. Call in timeout path (right before logging timeout)
+
+Run: python3 tests/phone-task-archive.test.py
+Exit: 0 = pass, 1 = fail.
+"""
+
+from pathlib import Path
+import re
+import sys
+
+REPO = Path(__file__).resolve().parent.parent
+CONV = REPO / "skills" / "phone-conversation" / "scripts" / "conversation-server.ts"
+
+
+def fail(msg: str, ctx: str = "") -> int:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    if ctx:
+        print("---context---", file=sys.stderr)
+        print(ctx[:1000], file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    if not CONV.exists():
+        return fail(f"{CONV} not found")
+
+    src = CONV.read_text()
+
+    # A. archivePhoneTask helper exists and uses archive/ + renameSync.
+    # The function is small (~8 lines); scan a 400-char window starting at its def.
+    helper_start = src.find("function archivePhoneTask(")
+    if helper_start == -1:
+        return fail("archivePhoneTask() helper function not found")
+    helper_window = src[helper_start : helper_start + 400]
+    if "archive" not in helper_window:
+        return fail("archivePhoneTask must put files under archive/", helper_window)
+    if "renameSync" not in helper_window:
+        return fail("archivePhoneTask must use renameSync (not unlinkSync only)", helper_window)
+
+    # B. Call in the hang-up / call-inactive early-exit path.
+    # Pattern: the hangingUp guard block ends with archivePhoneTask then return
+    if not re.search(
+        r"callSession\.hangingUp[\s\S]{0,300}?archivePhoneTask\s*\(\s*taskPath\s*,\s*taskId\s*\)[\s\S]{0,60}?return\s*;",
+        src,
+    ):
+        return fail(
+            "archivePhoneTask() must be called in the hang-up exit path before `return`"
+        )
+
+    # C. Call in the success path — after unlinkSync(resultPath).
+    # Pattern: unlinkSync(resultPath) ... archivePhoneTask(taskPath, taskId) within ~200 chars
+    if not re.search(
+        r"unlinkSync\s*\(\s*resultPath\s*\)[\s\S]{0,200}?archivePhoneTask\s*\(\s*taskPath\s*,\s*taskId\s*\)",
+        src,
+    ):
+        return fail(
+            "archivePhoneTask() must be called after unlinkSync(resultPath) in success path"
+        )
+
+    # D. Call in timeout path — before the timeout log line.
+    if not re.search(
+        r"archivePhoneTask\s*\(\s*taskPath\s*,\s*taskId\s*\)[\s\S]{0,100}?timeout for",
+        src,
+    ):
+        return fail(
+            "archivePhoneTask() must be called in the timeout path before logging timeout"
+        )
+
+    # E. renameSync is imported (needed by archivePhoneTask)
+    if not re.search(r"\brenameSync\b", src.split("from 'node:fs'")[0] + "from 'node:fs'"):
+        return fail("renameSync must be imported from 'node:fs'")
+    fs_import = re.search(r"import\s*\{[^}]+\}\s*from\s*'node:fs'", src)
+    if not fs_import or "renameSync" not in fs_import.group():
+        return fail("renameSync must appear in the node:fs import statement")
+
+    print("PASS: phone-conversation task archiving guards pass.")
+    print("  - archivePhoneTask() helper found with renameSync + archive/ path")
+    print("  - called in hang-up path before return")
+    print("  - called in success path after unlinkSync(resultPath)")
+    print("  - called in timeout path before timeout log")
+    print("  - renameSync imported from node:fs")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #1235.

## Problem

`conversation-server.ts` consumed result files correctly (`unlinkSync`) but never touched the task files — they lingered in `tasks/` forever. After 3 phone calls, 3 `task-phone-*.txt` files accumulate with no archive step.

## Root cause

Three poll-interval exit paths all missed the archive step:
1. **Call hang-up / call inactive** (early `return`) — task left dangling
2. **Result available (success)** — result unlinked, task not
3. **`POLL_TIMEOUT_MS` exceeded** — neither touched

## Fix

Added `archivePhoneTask()` helper (mirrors `task-bridge.ts:archiveFile()` — `renameSync` into `tasks/archive/YYYY-MM/`) and call it in all three paths. Also adds `renameSync` to the `node:fs` import (was missing).

## Tests

5 structural guards in `tests/phone-task-archive.test.py`:
- helper exists with `renameSync` + `archive/` path
- called in hang-up path before `return`
- called in success path after `unlinkSync(resultPath)`
- called in timeout path before timeout log
- `renameSync` in `node:fs` import