### PR TITLE
fix(phone-conversation): archive task + result files instead of unlinking (closes #1235)

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -47,7 +47,7 @@
 import { config as _dotenvConfig } from 'dotenv';
 _dotenvConfig({ path: new URL('../../../.env', import.meta.url).pathname, override: true });
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync, symlinkSync } from 'node:fs';
+import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync, renameSync, symlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { voiceApiKey } from '../../../src/voice-key.js';
@@ -121,6 +121,25 @@ const PORT = Number(process.env.PHONE_PORT) || 3100;
 const WORKSPACE_DIR = resolveWorkspace();
 const RESULTS_DIR = process.env.PHONE_RESULTS_DIR || join(WORKSPACE_DIR, 'results');
 const TASKS_DIR = join(WORKSPACE_DIR, 'tasks');
+
+// Archive helper — matches src/task-bridge.ts:archiveFile() pattern so phone
+// tasks + results aren't left behind in tasks/ or results/ forever (#1235).
+// Same audit-trail rationale Chi quoted on 2026-04-18 ("instead of deleting
+// we should archive the tasks. It can be useful for self-improving"). Silent
+// on failure; falls back to unlink so the system never leaves stale files.
+function archivePhoneFile(srcPath: string, kind: 'tasks' | 'results', taskId: string): void {
+	try {
+		if (!existsSync(srcPath)) return;
+		const ym = new Date().toISOString().slice(0, 7); // YYYY-MM
+		const baseDir = kind === 'tasks' ? TASKS_DIR : RESULTS_DIR;
+		const destDir = join(baseDir, 'archive', ym);
+		mkdirSync(destDir, { recursive: true });
+		renameSync(srcPath, join(destDir, `${taskId}.txt`));
+	} catch {
+		try { unlinkSync(srcPath); } catch { /* ignore */ }
+	}
+}
+
 const TASK_POLL_INTERVAL_MS = 500;
 const TASK_TIMEOUT_MS = 120_000;
 const OWNER_NAME = process.env.owner ?? '';
@@ -415,7 +434,10 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			const result = readFileSync(resultPath, 'utf-8').trim();
 			console.log(`${ts()} [Task] result for ${taskId} (${Date.now() - startTime}ms): ${result.slice(0, 200)}`);
 			callSession.events.push({ event: `task_result:${taskId}:${Date.now() - startTime}ms`, timestamp: new Date().toISOString() });
-			try { unlinkSync(resultPath); } catch {}
+			// Archive both the result + task files so phone surfaces match the
+			// task-bridge.ts archiveFile() audit-trail pattern (#1235).
+			archivePhoneFile(resultPath, 'results', taskId);
+			archivePhoneFile(taskPath, 'tasks', taskId);
 			// Cache result so duplicate requests get instant replay
 			if (!callSession.taskResultCache) callSession.taskResultCache = new Map();
 			callSession.taskResultCache.set(taskDescription, result);
@@ -438,6 +460,10 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			clearInterval(poll);
 			callSession.pendingTasks = Math.max(0, callSession.pendingTasks - 1);
 			console.log(`${ts()} [Task] timeout for ${taskId}`);
+			// Archive the task file even on timeout — the work may still complete
+			// async on the core side, but the call's polling window is closed.
+			// Keep the audit trail and prevent indefinite accumulation.
+			archivePhoneFile(taskPath, 'tasks', taskId);
 			try {
 				(callSession.voiceSession as any).transport.sendContent([
 					{ role: 'user', text: `[Task "${taskDescription}" timed out — still being worked on. Let the caller know.]` },

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -126,7 +126,11 @@ const TASKS_DIR = join(WORKSPACE_DIR, 'tasks');
 // tasks + results aren't left behind in tasks/ or results/ forever (#1235).
 // Same audit-trail rationale Chi quoted on 2026-04-18 ("instead of deleting
 // we should archive the tasks. It can be useful for self-improving"). Silent
-// on failure; falls back to unlink so the system never leaves stale files.
+// on failure; falls back to unlink if renameSync throws for ANY reason
+// (ENOENT race / permission / disk-full) so we never leave stale files.
+// (Note: tasks/ → tasks/archive/ is same-filesystem by construction; EXDEV
+// won't fire — calling out renameSync-failed-for-any-reason rather than
+// implying cross-device portability per liususan091219's #1237 review.)
 function archivePhoneFile(srcPath: string, kind: 'tasks' | 'results', taskId: string): void {
 	try {
 		if (!existsSync(srcPath)) return;
@@ -426,6 +430,13 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 		if (callSession.hangingUp || !activeCalls.has(callSession.callSid)) {
 			clearInterval(poll);
 			callSession.pendingTasks = Math.max(0, callSession.pendingTasks - 1);
+			// Call ended before the result came back — archive the task file
+			// anyway so it doesn't linger in tasks/. The result-watcher in
+			// task-bridge.ts will pick up + archive `results/<task_id>.txt`
+			// independently if the core finishes the work later.
+			// (Per VasiliyRad's review on #1237 — closes the leak in the
+			// hang-up / call-not-active branch.)
+			archivePhoneFile(taskPath, 'tasks', taskId);
 			return;
 		}
 		if (existsSync(resultPath)) {
@@ -462,7 +473,10 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			console.log(`${ts()} [Task] timeout for ${taskId}`);
 			// Archive the task file even on timeout — the work may still complete
 			// async on the core side, but the call's polling window is closed.
-			// Keep the audit trail and prevent indefinite accumulation.
+			// Don't archive the result file here: if it eventually lands, the
+			// canonical result-watcher in src/task-bridge.ts will archive it
+			// via its own archiveFile() call. (Per liususan091219's #1237
+			// review — avoids redundant result-archive logic here.)
 			archivePhoneFile(taskPath, 'tasks', taskId);
 			try {
 				(callSession.voiceSession as any).transport.sendContent([

--- a/tests/conversation-server-archive-phone-tasks.test.ts
+++ b/tests/conversation-server-archive-phone-tasks.test.ts
@@ -1,0 +1,94 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Pin the #1235 fix: phone task + result files MUST be archived (not
+// unlink'd, not left behind in tasks/) after the result is consumed by
+// the in-call poll loop. Matches the canonical src/task-bridge.ts
+// archiveFile() audit-trail pattern Chi asked for 2026-04-18.
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'skills/phone-conversation/scripts/conversation-server.ts'),
+	'utf-8',
+);
+
+describe('conversation-server phone-task archiving (#1235)', () => {
+	it('imports renameSync from node:fs', () => {
+		assert.match(
+			SRC,
+			/import\s*\{[^}]*renameSync[^}]*\}\s*from\s*['"]node:fs['"]/,
+			'conversation-server.ts must import renameSync from node:fs — used by archivePhoneFile to move task/result files into archive/YYYY-MM/.',
+		);
+	});
+
+	it('defines an archivePhoneFile helper', () => {
+		assert.match(
+			SRC,
+			/function\s+archivePhoneFile\s*\(\s*srcPath\s*:\s*string\s*,\s*kind\s*:\s*['"]tasks['"]\s*\|\s*['"]results['"]\s*,\s*taskId\s*:\s*string\s*\)/,
+			'conversation-server.ts must define archivePhoneFile(srcPath, kind, taskId) — mirrors src/task-bridge.ts:archiveFile() signature so phone surfaces match the canonical audit-trail pattern.',
+		);
+	});
+
+	it('archive helper computes destDir as <baseDir>/archive/YYYY-MM', () => {
+		assert.match(
+			SRC,
+			/const\s+destDir\s*=\s*join\(\s*baseDir\s*,\s*['"]archive['"]\s*,\s*ym\s*\)/,
+			'archivePhoneFile must put files under archive/YYYY-MM/ (same partition scheme as task-bridge.ts).',
+		);
+	});
+
+	it('archive helper falls back to unlinkSync on rename failure', () => {
+		// The two unlinkSync calls are inside the archivePhoneFile helper's
+		// catch block — fallback when rename fails (cross-device, permission,
+		// etc.) so we never leave a stale file behind.
+		assert.match(
+			SRC,
+			/catch\s*\{\s*try\s*\{\s*unlinkSync\(\s*srcPath\s*\)\s*;?\s*\}\s*catch\s*\{[^}]*\}\s*\}/,
+			'archivePhoneFile must fall back to unlinkSync(srcPath) when renameSync throws — same defensive pattern as src/task-bridge.ts:archiveFile().',
+		);
+	});
+
+	it('result-consume branch archives both result + task (not just unlinks result)', () => {
+		// Match the in-call poll's result-consume sequence:
+		//   archivePhoneFile(resultPath, 'results', taskId);
+		//   archivePhoneFile(taskPath, 'tasks', taskId);
+		assert.match(
+			SRC,
+			/archivePhoneFile\(\s*resultPath\s*,\s*['"]results['"]\s*,\s*taskId\s*\)/,
+			'result-consume branch must archive resultPath via archivePhoneFile(_, "results", taskId).',
+		);
+		assert.match(
+			SRC,
+			/archivePhoneFile\(\s*taskPath\s*,\s*['"]tasks['"]\s*,\s*taskId\s*\)/,
+			'result-consume branch must ALSO archive taskPath via archivePhoneFile(_, "tasks", taskId) — closes the #1235 lingering-task-file leak.',
+		);
+	});
+
+	it('result-consume branch does NOT just unlinkSync(resultPath)', () => {
+		// Loose check — the *raw* `unlinkSync(resultPath)` pattern that #1235
+		// flagged (no surrounding archive call) should be gone. We allow
+		// unlinkSync(srcPath) inside the helper's fallback, but not the bare
+		// resultPath delete at the call-site.
+		assert.doesNotMatch(
+			SRC,
+			/try\s*\{\s*unlinkSync\(\s*resultPath\s*\)\s*;?\s*\}\s*catch\s*\{\s*\}\s*\/\/\s*Cache\s+result/,
+			'The pre-fix `try { unlinkSync(resultPath); } catch {} // Cache result` pattern (#1235 site) must be replaced with archivePhoneFile calls.',
+		);
+	});
+
+	it('timeout branch archives the task file (≥2 archivePhoneFile(taskPath,…) call-sites total)', () => {
+		// The result-consume branch + the POLL_TIMEOUT branch each archive
+		// the task file. Counting at least two call-sites for the
+		// archivePhoneFile(taskPath, "tasks", taskId) shape catches the case
+		// where the timeout branch was dropped. (A tighter regex against the
+		// exact `[Task] timeout` log message is brittle to logging-text
+		// changes; counting call-sites is more durable.)
+		const re = /archivePhoneFile\(\s*taskPath\s*,\s*['"]tasks['"]\s*,\s*taskId\s*\)/g;
+		const matches = SRC.match(re) ?? [];
+		assert.ok(
+			matches.length >= 2,
+			`Expected ≥2 archivePhoneFile(taskPath, "tasks", taskId) call-sites (result-consume + POLL_TIMEOUT), found ${matches.length}. POLL_TIMEOUT branch likely missing — otherwise long-running tasks that exceed POLL_TIMEOUT_MS leave the task file in tasks/ forever.`,
+		);
+	});
+});

--- a/tests/conversation-server-archive-phone-tasks.test.ts
+++ b/tests/conversation-server-archive-phone-tasks.test.ts
@@ -77,18 +77,19 @@ describe('conversation-server phone-task archiving (#1235)', () => {
 		);
 	});
 
-	it('timeout branch archives the task file (≥2 archivePhoneFile(taskPath,…) call-sites total)', () => {
-		// The result-consume branch + the POLL_TIMEOUT branch each archive
-		// the task file. Counting at least two call-sites for the
-		// archivePhoneFile(taskPath, "tasks", taskId) shape catches the case
-		// where the timeout branch was dropped. (A tighter regex against the
-		// exact `[Task] timeout` log message is brittle to logging-text
-		// changes; counting call-sites is more durable.)
+	it('all 3 poll-exit branches archive the task file (≥3 archivePhoneFile(taskPath,…) call-sites)', () => {
+		// Three poll-exit paths each archive the task file:
+		//   (A) result-consume — result arrives in time
+		//   (B) hang-up / call-not-active early return (VasiliyRad's #1237 review)
+		//   (C) POLL_TIMEOUT — call's polling window closes first
+		// All three must call archivePhoneFile(taskPath, "tasks", taskId) so
+		// no exit path leaks the task file. Counting call-sites is more durable
+		// than per-branch regex matching against logging text.
 		const re = /archivePhoneFile\(\s*taskPath\s*,\s*['"]tasks['"]\s*,\s*taskId\s*\)/g;
 		const matches = SRC.match(re) ?? [];
 		assert.ok(
-			matches.length >= 2,
-			`Expected ≥2 archivePhoneFile(taskPath, "tasks", taskId) call-sites (result-consume + POLL_TIMEOUT), found ${matches.length}. POLL_TIMEOUT branch likely missing — otherwise long-running tasks that exceed POLL_TIMEOUT_MS leave the task file in tasks/ forever.`,
+			matches.length >= 3,
+			`Expected ≥3 archivePhoneFile(taskPath, "tasks", taskId) call-sites (result-consume + hang-up early-return + POLL_TIMEOUT), found ${matches.length}. A poll-exit branch is missing — tasks will leak on that path.`,
 		);
 	});
 });


### PR DESCRIPTION
Closes #1235.

## Summary

The phone-conversation skill's in-call poll loop consumed result files via `unlinkSync(resultPath)` and never touched the task file in `tasks/`. This leaves `task-phone-*.txt` files in `tasks/` indefinitely, breaking the audit-trail pattern Chi quoted on 2026-04-18 ("instead of deleting we should archive the tasks. It can be useful for self-improving") that AG2 Space / Discord / Telegram already follow via `src/task-bridge.ts:archiveFile()`.

## Changes

- Adds `archivePhoneFile(srcPath, kind, taskId)` helper at the top-level of `conversation-server.ts` that mirrors `task-bridge.ts:archiveFile()` — moves the file to `<baseDir>/archive/YYYY-MM/<taskId>.txt` via `renameSync`, falls back to `unlinkSync` on failure (cross-device, permission, etc.) so stale files never accumulate.
- Replaces the single `unlinkSync(resultPath)` call in the result-consume branch (~line 401) with two archive calls — one for the result, one for the task.
- Adds the same task-file archive call in the POLL_TIMEOUT branch (~line 411) so long-running tasks that exceed POLL_TIMEOUT_MS also get cleaned up.
- Adds `renameSync` to the `node:fs` imports.

## Diff scope

```
 .../scripts/conversation-server.ts                 | 30 ++++++-
 ...conversation-server-archive-phone-tasks.test.ts | 94 ++++++++++++++++++++++
 2 files changed, 122 insertions(+), 2 deletions(-)
```

No new pip deps, no new npm deps, no behavior change beyond moving files instead of deleting (existing call-sites still consume the data correctly before the move).

## Tests

7 structural assertions in `tests/conversation-server-archive-phone-tasks.test.ts`:

- `renameSync` imported from `node:fs`
- `archivePhoneFile` helper defined with the right signature
- `destDir` computed as `<baseDir>/archive/YYYY-MM`
- helper falls back to `unlinkSync` on rename failure
- result-consume branch archives both result + task (not just result unlink)
- result-consume branch no longer matches the pre-fix `try { unlinkSync(resultPath); } catch {} // Cache result` pattern
- ≥2 `archivePhoneFile(taskPath, 'tasks', taskId)` call-sites total (result-consume + POLL_TIMEOUT)

All pass:

```
$ node --test tests/conversation-server-archive-phone-tasks.test.ts
ℹ pass 7
ℹ fail 0
```

## Repro

On the mini node where #1235 was diagnosed: 3 lingering `task-phone-*.txt` files in `tasks/`, 0 in `tasks/archive/`. After this fix lands + a deploy cycle, new phone tasks should land in `tasks/archive/YYYY-MM/` alongside AG2 Space / Discord / Telegram tasks.

## Notes

- The `unlinkSync(srcPath)` calls inside `archivePhoneFile`'s catch block are intentional — same defensive pattern as `src/task-bridge.ts:archiveFile()`. They only fire on renameSync failure (cross-device, permission), preventing stale files even when the archive move can't complete.
- Summary-task path (line ~1146) still uses the direct write — that result file is consumed by the next core re-entry, not the in-call poll, so the archive timing is different there. Out of scope for this PR.

## Refs

- Tracking issue: #1235
- Canonical pattern: `src/task-bridge.ts:50:archiveFile`

Filed by @sutando-qingyun-mini (Mac mini Sutando node).