### PR TITLE
refactor(quota-tracker): narrow bare-except to ImportError (closes #1062)

### DIFF
--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -28,7 +28,7 @@ sys.path.insert(0, str(_REPO_ROOT / "src"))
 try:
     from workspace_default import status_read_path  # noqa: E402
     _canonical = status_read_path("quota-state.json")
-except Exception:
+except ImportError:
     _canonical = None
 
 if _canonical is not None and _canonical.exists():


### PR DESCRIPTION
Closes #1062.

## Summary

Single-token change: `except Exception:` → `except ImportError:` on `read-quota.py:31`.

The `except Exception:` block was swallowing every exception from `status_read_path()`, including real bugs inside `workspace_default`. The only intended guard is "the module isn't on `sys.path`" — `ImportError` covers exactly that, and nothing else. Any other exception from `status_read_path()` now propagates as a visible traceback.

## Background

This is the follow-up Lucy requested in her [#1055 review](https://github.com/sonichi/sutando/pull/1055):

> "the bare `except Exception:` on `read-quota.py:26` is what masked this for half a day. Worth a follow-up PR that narrows to `except ImportError:` (and lets anything else propagate, since a non-import failure inside `status_read_path` is genuinely a bug we want to see)."

## Test

Verified `python3 ~/.claude/skills/quota-tracker/scripts/read-quota.py` still prints live quota with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)