### PR TITLE
feat(conversation-store): dedup migration + UNIQUE INDEX (closes #941)

### DIFF
--- a/scripts/dedup_conversation_store.py
+++ b/scripts/dedup_conversation_store.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Dedup migration for conversation.sqlite (closes #941 Part 1).
+
+Removes duplicate rows from the per-surface event tables, sessions, and
+session_events before adding UNIQUE INDEXes to those tables.  Duplicate
+rows are produced when import scripts are re-run without --reload (the
+documented behaviour), or when multiple writers race on the same session.
+
+Natural-key tuples used to detect duplicates:
+  voice / phone / discord_voice  (ts_unix, session_id, kind, text)
+  sessions                        (ts_unix, source, session_id)
+  session_events                  (ts_unix, source, session_id, event_name)
+
+The lowest rowid wins — it preserves insertion order as closely as possible.
+
+Usage:
+    python3 scripts/dedup-conversation-store.py             # dry-run
+    python3 scripts/dedup-conversation-store.py --commit    # apply
+    python3 scripts/dedup-conversation-store.py --db /path  # override DB path
+
+Safety:
+  - Defaults to dry-run; --commit required to write.
+  - Aborts if voice-agent or phone-conversation-server processes are alive
+    (same guard used by --reload in the import scripts).
+  - Wraps every table in a transaction; rolls back on any error.
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from workspace_default import resolve_workspace  # noqa: E402
+
+WORKSPACE = resolve_workspace(migrate=False)
+DEFAULT_DB = WORKSPACE / "data" / "conversation.sqlite"
+
+# Natural keys: the minimal set of columns whose combination must be unique.
+# For the per-surface tables ts_unix alone is NOT sufficient (two tool_call
+# rows in the same millisecond differ by text); text alone is not sufficient;
+# (ts_unix, session_id, kind, text) together form a practical unique tuple.
+SURFACE_TABLES = ("voice", "phone", "discord_voice")
+SURFACE_KEY = "ts_unix, session_id, kind, text"
+
+SESSION_KEY = "ts_unix, source, session_id"
+EVENT_KEY = "ts_unix, source, session_id, event_name"
+
+
+def _is_alive(pattern: str) -> bool:
+    try:
+        out = subprocess.check_output(["pgrep", "-f", pattern], text=True)
+        return bool(out.strip())
+    except subprocess.CalledProcessError:
+        return False
+
+
+def _check_services(force: bool) -> None:
+    running = []
+    if _is_alive("voice-agent"):
+        running.append("voice-agent")
+    if _is_alive("conversation-server"):
+        running.append("conversation-server (phone)")
+    if running and not force:
+        print(
+            f"Error: live service(s) detected: {', '.join(running)}.\n"
+            "Stop them before deduplicating, or pass --force to override.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _count_dups(cur: sqlite3.Cursor, table: str, key: str) -> int:
+    cur.execute(
+        f"SELECT SUM(cnt - 1) FROM "
+        f"(SELECT COUNT(*) AS cnt FROM {table} GROUP BY {key} HAVING cnt > 1)"
+    )
+    row = cur.fetchone()
+    return int(row[0] or 0)
+
+
+def _dedup_table(
+    cur: sqlite3.Cursor,
+    table: str,
+    key: str,
+    dry_run: bool,
+) -> int:
+    """Delete duplicate rows, keeping the lowest rowid per key group.
+    Returns the number of rows removed."""
+    total = _count_dups(cur, table, key)
+    if total == 0:
+        return 0
+    if dry_run:
+        return total
+    # Keep the row with the smallest rowid in each duplicate group.
+    cur.execute(
+        f"DELETE FROM {table} WHERE rowid NOT IN "
+        f"(SELECT MIN(rowid) FROM {table} GROUP BY {key})"
+    )
+    return cur.rowcount
+
+
+def run(db_path: Path, dry_run: bool, force: bool) -> None:
+    if not db_path.exists():
+        print(f"Database not found: {db_path}")
+        sys.exit(0)
+
+    _check_services(force)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+
+    total_removed = 0
+    try:
+        cur.execute("BEGIN")
+        for table in SURFACE_TABLES:
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                (table,),
+            )
+            if not cur.fetchone():
+                print(f"  {table}: (table absent — skip)")
+                continue
+            removed = _dedup_table(cur, table, SURFACE_KEY, dry_run)
+            total_removed += removed
+            label = "would remove" if dry_run else "removed"
+            print(f"  {table}: {label} {removed} duplicate row(s)")
+
+        for table, key in [("sessions", SESSION_KEY), ("session_events", EVENT_KEY)]:
+            cur.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                (table,),
+            )
+            if not cur.fetchone():
+                print(f"  {table}: (table absent — skip)")
+                continue
+            removed = _dedup_table(cur, table, key, dry_run)
+            total_removed += removed
+            label = "would remove" if dry_run else "removed"
+            print(f"  {table}: {label} {removed} duplicate row(s)")
+
+        if dry_run:
+            conn.rollback()
+            print(
+                f"\nDry-run: {total_removed} duplicate row(s) found. "
+                "Re-run with --commit to apply."
+            )
+        else:
+            conn.commit()
+            print(f"\nCommitted: {total_removed} duplicate row(s) removed.")
+    except Exception as exc:
+        conn.rollback()
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Apply the deduplication (default: dry-run only).",
+    )
+    parser.add_argument(
+        "--db",
+        metavar="PATH",
+        help=f"Override DB path (default: {DEFAULT_DB})",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Skip the live-service check.",
+    )
+    args = parser.parse_args()
+
+    db_path = Path(args.db) if args.db else DEFAULT_DB
+    run(db_path=db_path, dry_run=not args.commit, force=args.force)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/conversation-store.ts
+++ b/src/conversation-store.ts
@@ -218,6 +218,38 @@ function init(): void {
 			}
 		}
 
+		// UNIQUE INDEX migration (closes #941 Part 2).
+		// Guards re-runs of import scripts from inserting duplicate rows.
+		// Uses natural-key tuples that represent one logical event.
+		// If the DB already has duplicates (pre-migration state), CREATE UNIQUE
+		// INDEX will throw — catch and log: run scripts/dedup-conversation-store.py
+		// first, then restart to retry.
+		const uniqueIndexes: [string, string][] = [
+			['voice',          'ts_unix, session_id, kind, text'],
+			['phone',          'ts_unix, session_id, kind, text'],
+			['discord_voice',  'ts_unix, session_id, kind, text'],
+			['sessions',       'ts_unix, source, session_id'],
+			['session_events', 'ts_unix, source, session_id, event_name'],
+		];
+		for (const [table, cols] of uniqueIndexes) {
+			const idxName = `idx_${table}_unique`;
+			const alreadyExists = (
+				db.prepare(
+					"SELECT name FROM sqlite_master WHERE type='index' AND name=?",
+				).get(idxName) as { name: string } | undefined
+			);
+			if (alreadyExists) continue;
+			try {
+				db.exec(`CREATE UNIQUE INDEX ${idxName} ON ${table}(${cols})`);
+			} catch (e) {
+				console.error(
+					`[conversation-store] could not add UNIQUE INDEX on ${table} — ` +
+					'run scripts/dedup-conversation-store.py --commit first, then restart.',
+					e,
+				);
+			}
+		}
+
 		// Convenience views — thin wrappers that add a human-readable `time`
 		// column (local-time) and default-sort by ts_unix DESC. DROP+CREATE so
 		// definitions stay in lock-step with the surface tables and any

--- a/tests/dedup-conversation-store.test.py
+++ b/tests/dedup-conversation-store.test.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+Tests for scripts/dedup-conversation-store.py (closes #941 Part 1).
+
+Guards:
+  1. Duplicate rows in voice/phone/discord_voice are removed; distinct rows survive.
+  2. Duplicate rows in sessions are removed; distinct rows survive.
+  3. Duplicate rows in session_events are removed; distinct rows survive.
+  4. Dry-run mode reports duplicates without changing the DB.
+  5. No-op on a clean DB (zero duplicates → zero rows removed).
+  6. The lowest rowid survives for each duplicate group.
+  7. Tables absent from the DB are silently skipped (no crash).
+"""
+
+import sqlite3
+import sys
+import tempfile
+import os
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+# Patch workspace_default before importing dedup module
+import types
+_fake_ws = types.ModuleType("workspace_default")
+_fake_ws.resolve_workspace = lambda migrate=False: Path(tempfile.mkdtemp())
+sys.modules.setdefault("workspace_default", _fake_ws)
+
+import dedup_conversation_store as dedup  # type: ignore
+
+PASS = 0
+FAIL = 0
+
+
+def ok(label: str) -> None:
+    global PASS
+    PASS += 1
+    print(f"PASS  {label}")
+
+
+def fail(label: str, reason: str) -> None:
+    global FAIL
+    FAIL += 1
+    print(f"FAIL  {label}: {reason}")
+
+
+def _make_db(path: Path) -> sqlite3.Connection:
+    """Create a minimal DB with all 5 tables."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        CREATE TABLE voice (
+            id INTEGER PRIMARY KEY,
+            ts_unix REAL NOT NULL,
+            kind TEXT NOT NULL,
+            text TEXT,
+            duration_ms INTEGER,
+            session_id TEXT
+        );
+        CREATE TABLE phone (
+            id INTEGER PRIMARY KEY,
+            ts_unix REAL NOT NULL,
+            kind TEXT NOT NULL,
+            text TEXT,
+            duration_ms INTEGER,
+            session_id TEXT
+        );
+        CREATE TABLE discord_voice (
+            id INTEGER PRIMARY KEY,
+            ts_unix REAL NOT NULL,
+            kind TEXT NOT NULL,
+            text TEXT,
+            duration_ms INTEGER,
+            session_id TEXT
+        );
+        CREATE TABLE sessions (
+            ts_unix REAL NOT NULL,
+            source TEXT NOT NULL,
+            session_id TEXT,
+            call_sid TEXT,
+            caller TEXT,
+            is_owner INTEGER,
+            is_meeting INTEGER,
+            duration_ms INTEGER NOT NULL,
+            transcript_lines INTEGER,
+            tool_count INTEGER,
+            pending_tasks INTEGER
+        );
+        CREATE TABLE session_events (
+            ts_unix REAL NOT NULL,
+            source TEXT NOT NULL,
+            session_id TEXT,
+            call_sid TEXT,
+            event_name TEXT NOT NULL
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def test_surface_table_dups_removed():
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        conn = _make_db(db_path)
+        # Insert 3 rows: 2 duplicates + 1 distinct
+        conn.executemany(
+            "INSERT INTO voice (ts_unix, kind, text, session_id) VALUES (?, ?, ?, ?)",
+            [
+                (1000.0, "user", "hello", "s1"),   # original
+                (1000.0, "user", "hello", "s1"),   # dup
+                (2000.0, "agent", "world", "s1"),  # distinct
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        dedup.run(db_path=db_path, dry_run=False, force=True)
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT ts_unix, kind, text, session_id FROM voice ORDER BY ts_unix").fetchall()
+        conn.close()
+
+        if len(rows) == 2 and rows[0] == (1000.0, "user", "hello", "s1") and rows[1] == (2000.0, "agent", "world", "s1"):
+            ok("surface dup removed, distinct row survives")
+        else:
+            fail("surface dup removed, distinct row survives", f"got {rows}")
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_sessions_dups_removed():
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        conn = _make_db(db_path)
+        conn.executemany(
+            "INSERT INTO sessions (ts_unix, source, session_id, duration_ms) VALUES (?, ?, ?, ?)",
+            [
+                (3000.0, "voice", "sess-1", 60000),
+                (3000.0, "voice", "sess-1", 60000),  # dup
+                (4000.0, "phone", "sess-2", 120000),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        dedup.run(db_path=db_path, dry_run=False, force=True)
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT ts_unix, source, session_id FROM sessions ORDER BY ts_unix").fetchall()
+        conn.close()
+
+        if len(rows) == 2:
+            ok("sessions dup removed")
+        else:
+            fail("sessions dup removed", f"expected 2 rows, got {len(rows)}: {rows}")
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_session_events_dups_removed():
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        conn = _make_db(db_path)
+        conn.executemany(
+            "INSERT INTO session_events (ts_unix, source, session_id, event_name) VALUES (?, ?, ?, ?)",
+            [
+                (5000.0, "voice", "s1", "session_started"),
+                (5000.0, "voice", "s1", "session_started"),  # dup
+                (6000.0, "voice", "s1", "session_ended"),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        dedup.run(db_path=db_path, dry_run=False, force=True)
+
+        conn = sqlite3.connect(str(db_path))
+        rows = conn.execute("SELECT event_name FROM session_events ORDER BY ts_unix").fetchall()
+        conn.close()
+
+        if len(rows) == 2:
+            ok("session_events dup removed")
+        else:
+            fail("session_events dup removed", f"expected 2 rows, got {len(rows)}")
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_dry_run_does_not_modify():
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        conn = _make_db(db_path)
+        conn.executemany(
+            "INSERT INTO voice (ts_unix, kind, text, session_id) VALUES (?, ?, ?, ?)",
+            [(1.0, "user", "hi", "s1"), (1.0, "user", "hi", "s1")],
+        )
+        conn.commit()
+        conn.close()
+
+        dedup.run(db_path=db_path, dry_run=True, force=True)
+
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute("SELECT COUNT(*) FROM voice").fetchone()[0]
+        conn.close()
+
+        if count == 2:
+            ok("dry-run does not remove rows")
+        else:
+            fail("dry-run does not remove rows", f"row count changed to {count}")
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_noop_on_clean_db():
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        conn = _make_db(db_path)
+        conn.executemany(
+            "INSERT INTO voice (ts_unix, kind, text, session_id) VALUES (?, ?, ?, ?)",
+            [(1.0, "user", "a", "s1"), (2.0, "user", "b", "s1")],
+        )
+        conn.commit()
+        conn.close()
+
+        # Capture count report by running dedup
+        dedup.run(db_path=db_path, dry_run=False, force=True)
+
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute("SELECT COUNT(*) FROM voice").fetchone()[0]
+        conn.close()
+
+        if count == 2:
+            ok("no-op on clean db")
+        else:
+            fail("no-op on clean db", f"row count changed from 2 to {count}")
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_lowest_rowid_survives():
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        conn = _make_db(db_path)
+        conn.execute(
+            "INSERT INTO voice (ts_unix, kind, text, session_id) VALUES (?, ?, ?, ?)",
+            (1.0, "user", "msg", "s1"),
+        )
+        first_rowid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        conn.execute(
+            "INSERT INTO voice (ts_unix, kind, text, session_id) VALUES (?, ?, ?, ?)",
+            (1.0, "user", "msg", "s1"),
+        )
+        conn.commit()
+        conn.close()
+
+        dedup.run(db_path=db_path, dry_run=False, force=True)
+
+        conn = sqlite3.connect(str(db_path))
+        surviving_rowid = conn.execute("SELECT rowid FROM voice").fetchone()[0]
+        conn.close()
+
+        if surviving_rowid == first_rowid:
+            ok("lowest rowid survives")
+        else:
+            fail("lowest rowid survives", f"expected rowid {first_rowid}, got {surviving_rowid}")
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+def test_absent_table_skipped():
+    with tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False) as f:
+        db_path = Path(f.name)
+    try:
+        # Create a DB with only the voice table — other tables absent
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE voice (
+                id INTEGER PRIMARY KEY,
+                ts_unix REAL NOT NULL,
+                kind TEXT NOT NULL,
+                text TEXT,
+                duration_ms INTEGER,
+                session_id TEXT
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        # Should not crash even with missing phone/discord_voice/sessions/session_events
+        try:
+            dedup.run(db_path=db_path, dry_run=False, force=True)
+            ok("absent tables skipped without crash")
+        except Exception as e:
+            fail("absent tables skipped without crash", str(e))
+    finally:
+        db_path.unlink(missing_ok=True)
+
+
+# Run all tests
+test_surface_table_dups_removed()
+test_sessions_dups_removed()
+test_session_events_dups_removed()
+test_dry_run_does_not_modify()
+test_noop_on_clean_db()
+test_lowest_rowid_survives()
+test_absent_table_skipped()
+
+print(f"\nResults: {PASS} passed, {FAIL} failed")
+sys.exit(0 if FAIL == 0 else 1)


### PR DESCRIPTION
## Summary

Closes #941 (F5 follow-up from #791 review — unique-key idempotency for conversation.sqlite).

### Part 1 — `scripts/dedup_conversation_store.py`

One-shot dedup script that must run before Part 2's UNIQUE INDEX can create cleanly on a DB with existing duplicate rows:

- Removes duplicate rows from `voice`, `phone`, `discord_voice`, `sessions`, `session_events`
- Natural-key tuples:
  - Surface tables: `(ts_unix, session_id, kind, text)`
  - `sessions`: `(ts_unix, source, session_id)`
  - `session_events`: `(ts_unix, source, session_id, event_name)`
- Keeps lowest `rowid` per group (preserves original insertion order)
- **Defaults to dry-run** — `--commit` required to write
- Guards against live `voice-agent` / `conversation-server` processes (`--force` to override)
- Silently skips tables absent from the DB

### Part 2 — `src/conversation-store.ts` UNIQUE INDEX migration

After the existing column-drop migrations in `init()`:
- Attempts `CREATE UNIQUE INDEX idx_{table}_unique ON {table}(...)` for each table
- Idempotent — skips tables that already have the index
- On a DB with existing duplicates (pre-dedup state), the `CREATE UNIQUE INDEX` throws a constraint error — caught and logged with a recommendation to run the dedup script first, then restart

### Tests

7 behavioral tests in `tests/dedup-conversation-store.test.py`:
1. Surface-table duplicates removed, distinct rows survive
2. `sessions` duplicates removed
3. `session_events` duplicates removed
4. Dry-run mode reports count without modifying DB
5. No-op on clean DB (zero dups → zero rows removed)
6. Lowest `rowid` survives in each duplicate group
7. Absent tables silently skipped (no crash)

### Migration guide (for existing installations)

```bash
# 1. Stop voice-agent and conversation-server first
# 2. Preview what will be removed
python3 scripts/dedup_conversation_store.py

# 3. Apply if satisfied
python3 scripts/dedup_conversation_store.py --commit

# 4. Restart services — conversation-store.ts will now create the UNIQUE INDEXes
```