### PR TITLE
feat(outbox-log): Phase B-1 — email-sender.py + WhatsApp send wrapper

### DIFF
--- a/skills/macos-tools/scripts/email-sender.py
+++ b/skills/macos-tools/scripts/email-sender.py
@@ -1,8 +1,27 @@
 #!/usr/bin/env python3
 """Send email via macOS Mail.app. Usage: python3 email-sender.py "to" "subject" "body" [--draft] [--cc "cc"]"""
 import subprocess, sys
+from pathlib import Path
 
 def escape(s): return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+_outbox_log = None
+
+
+def _get_outbox_log():
+    global _outbox_log
+    if _outbox_log is None:
+        try:
+            _src = str(Path(__file__).resolve().parent.parent.parent.parent / "src")
+            if _src not in sys.path:
+                sys.path.insert(0, _src)
+            import outbox_log as _ol
+            _outbox_log = _ol
+        except Exception:
+            pass
+    return _outbox_log
+
 
 def send(to, subject, body, cc=None, draft=False):
     action = "save m" if draft else "send m"
@@ -22,6 +41,10 @@ end tell'''
         print(f"Error: {r.stderr.strip()}", file=sys.stderr)
         sys.exit(1)
     print("Draft created." if draft else "Email sent.")
+    if not draft:
+        ol = _get_outbox_log()
+        if ol:
+            ol.append(channel_type="email", recipient=to, body=body)
 
 if __name__ == "__main__":
     if len(sys.argv) < 4:

--- a/skills/whatsapp/scripts/send.py
+++ b/skills/whatsapp/scripts/send.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""WhatsApp send wrapper — calls wacli and records the delivery to outbox_log.
+
+Usage:
+  python3 send.py --to "+14155551234" --message "Hello!"
+  python3 send.py --to "+14155551234" --message "$(cat /tmp/msg.txt)"
+
+Records channel_type="whatsapp" in <workspace>/state/outbox.log on success.
+Fails with a non-zero exit code and an error message if wacli fails.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+# Lazy outbox_log import — silently degrades if src/ is not importable.
+_outbox_log = None
+
+
+def _get_outbox_log():
+    global _outbox_log
+    if _outbox_log is None:
+        try:
+            _src = str(Path(__file__).resolve().parent.parent.parent.parent / "src")
+            if _src not in sys.path:
+                sys.path.insert(0, _src)
+            import outbox_log as _ol
+            _outbox_log = _ol
+        except Exception:
+            pass
+    return _outbox_log
+
+
+def send(to: str, message: str) -> None:
+    result = subprocess.run(
+        ["wacli", "send", "text", "--to", to, "--message", message],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"Error: {result.stderr.strip() or result.stdout.strip()}", file=sys.stderr)
+        sys.exit(result.returncode)
+    print(result.stdout, end="")
+    ol = _get_outbox_log()
+    if ol:
+        ol.append(channel_type="whatsapp", recipient=to, body=message)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Send a WhatsApp message via wacli.")
+    parser.add_argument("--to", required=True, help="Recipient phone in E.164 format (+countrycode…) or group JID")
+    parser.add_argument("--message", required=True, help="Message text to send")
+    args = parser.parse_args()
+    send(args.to, args.message)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/email-whatsapp-outbox.test.py
+++ b/tests/email-whatsapp-outbox.test.py
@@ -1,0 +1,140 @@
+"""Tests for outbox_log integration in email-sender.py and whatsapp/scripts/send.py.
+
+Phase B-1 of issue #932: skill-side senders write to outbox log.
+Run: python3 tests/email-whatsapp-outbox.test.py
+"""
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _load_module(name: str, rel_path: str):
+    """Load a module from a relative path, resetting its _outbox_log cache."""
+    path = ROOT / rel_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    # Don't cache under the same key across tests — fresh module per test.
+    spec.loader.exec_module(mod)
+    mod._outbox_log = None
+    return mod
+
+
+class TestEmailSenderOutboxLog(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+        os.environ["SUTANDO_WORKSPACE"] = str(self.workspace)
+
+    def tearDown(self):
+        os.environ.pop("SUTANDO_WORKSPACE", None)
+        self.tmp.cleanup()
+
+    def _outbox_entries(self) -> list[dict]:
+        path = self.workspace / "state" / "outbox.log"
+        if not path.is_file():
+            return []
+        return [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+
+    def test_send_writes_outbox_entry(self):
+        mod = _load_module("email_sender_test", "skills/macos-tools/scripts/email-sender.py")
+        fake = MagicMock()
+        fake.returncode = 0
+        with patch.object(mod.subprocess, "run", return_value=fake):
+            mod.send("bob@example.com", "Hello", "Body text", draft=False)
+
+        entries = self._outbox_entries()
+        self.assertEqual(len(entries), 1)
+        e = entries[0]
+        self.assertEqual(e["channel_type"], "email")
+        self.assertEqual(e["recipient"], "bob@example.com")
+        self.assertEqual(e["body_preview"], "Body text")
+        self.assertEqual(e["body_len"], len("Body text"))
+
+    def test_draft_does_not_write_outbox(self):
+        mod = _load_module("email_sender_draft_test", "skills/macos-tools/scripts/email-sender.py")
+        fake = MagicMock()
+        fake.returncode = 0
+        with patch.object(mod.subprocess, "run", return_value=fake):
+            mod.send("bob@example.com", "Hello", "Draft body", draft=True)
+
+        self.assertEqual(self._outbox_entries(), [])
+
+    def test_failed_send_does_not_write_outbox(self):
+        mod = _load_module("email_sender_fail_test", "skills/macos-tools/scripts/email-sender.py")
+        fake = MagicMock()
+        fake.returncode = 1
+        fake.stderr = "osascript: error"
+        with patch.object(mod.subprocess, "run", return_value=fake):
+            with self.assertRaises(SystemExit):
+                mod.send("bob@example.com", "Hello", "Body", draft=False)
+
+        self.assertEqual(self._outbox_entries(), [])
+
+
+class TestWhatsAppSendOutboxLog(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+        os.environ["SUTANDO_WORKSPACE"] = str(self.workspace)
+
+    def tearDown(self):
+        os.environ.pop("SUTANDO_WORKSPACE", None)
+        self.tmp.cleanup()
+
+    def _outbox_entries(self) -> list[dict]:
+        path = self.workspace / "state" / "outbox.log"
+        if not path.is_file():
+            return []
+        return [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+
+    def test_successful_send_writes_outbox_entry(self):
+        mod = _load_module("wa_send_test", "skills/whatsapp/scripts/send.py")
+        fake = MagicMock()
+        fake.returncode = 0
+        fake.stdout = "Message sent.\n"
+        with patch.object(mod.subprocess, "run", return_value=fake):
+            mod.send("+14155551234", "Hello WhatsApp!")
+
+        entries = self._outbox_entries()
+        self.assertEqual(len(entries), 1)
+        e = entries[0]
+        self.assertEqual(e["channel_type"], "whatsapp")
+        self.assertEqual(e["recipient"], "+14155551234")
+        self.assertEqual(e["body_preview"], "Hello WhatsApp!")
+        self.assertEqual(e["body_len"], len("Hello WhatsApp!"))
+
+    def test_failed_send_does_not_write_outbox(self):
+        mod = _load_module("wa_send_fail_test", "skills/whatsapp/scripts/send.py")
+        fake = MagicMock()
+        fake.returncode = 1
+        fake.stderr = "wacli: not authenticated"
+        fake.stdout = ""
+        with patch.object(mod.subprocess, "run", return_value=fake):
+            with self.assertRaises(SystemExit):
+                mod.send("+14155551234", "Should not log")
+
+        self.assertEqual(self._outbox_entries(), [])
+
+    def test_group_jid_recipient_recorded(self):
+        mod = _load_module("wa_group_test", "skills/whatsapp/scripts/send.py")
+        fake = MagicMock()
+        fake.returncode = 0
+        fake.stdout = ""
+        with patch.object(mod.subprocess, "run", return_value=fake):
+            mod.send("1234567890@g.us", "Group message")
+
+        entries = self._outbox_entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["recipient"], "1234567890@g.us")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Continues issue #932 Phase B-1 (skill-side senders → outbox_log). Follows the X/Twitter pattern from #1245.

**`skills/macos-tools/scripts/email-sender.py`**
- After successful `osascript` send (not draft), calls `outbox_log.append(channel_type="email", recipient=to, body=body)`
- Lazy-loads `outbox_log` from `src/` via `_get_outbox_log()` — osascript failures and draft mode are unaffected

**`skills/whatsapp/scripts/send.py`** (new file)
- Thin wrapper around `wacli send text --to <phone> --message <msg>`
- Records `channel_type="whatsapp", recipient=<phone_or_jid>` to outbox_log on success
- Fails with the same exit code as wacli on error
- Group JIDs (`123@g.us`) are handled the same as phone numbers

**`tests/email-whatsapp-outbox.test.py`**: 6 new tests
- Email: send→log entry, draft→no entry, osascript failure→no entry
- WhatsApp: success→log entry, wacli failure→no entry, group JID→recorded as recipient

## What's NOT covered yet in #932 Phase B-1

- iMessage (`imsg send`) — `imsg` binary not installed; will be a separate PR once the tool ships
- Dashboard Outbox tab (B-2) — follow-up PR

## Test plan

- [ ] `python3 tests/email-whatsapp-outbox.test.py` → 6/6 pass
- [ ] `python3 tests/outbox-log.test.py` → existing suite still passes
- [ ] `python3 skills/whatsapp/scripts/send.py --help` → argparse usage shown, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)