### PR TITLE
feat(dashboard): Phase B-2 — Outbox tab (issue #932)

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -32,6 +32,7 @@ REPO_DIR = Path(__file__).parent.parent
 sys.path.insert(0, str(Path(__file__).parent))
 from workspace_default import resolve_workspace, status_read_path  # noqa: E402
 from util_paths import personal_path, shared_personal_path  # noqa: E402
+import outbox_log  # noqa: E402
 WORKSPACE_DIR = resolve_workspace()
 PORT = 7844
 
@@ -165,6 +166,63 @@ def get_system_stats() -> dict:
         "uptime": datetime.now().strftime("%H:%M"),
         "quota": get_quota_status(),
     }
+
+
+_CHANNEL_LABELS: dict[str, str] = {
+    "discord_dm": "discord-dm",
+    "discord_channel": "discord-ch",
+    "slack_dm": "slack-dm",
+    "slack_channel": "slack-ch",
+    "telegram": "telegram",
+    "email": "email",
+    "whatsapp": "whatsapp",
+    "x_twitter": "x/twitter",
+    "imessage": "imessage",
+}
+
+
+def get_outbox(limit: int = 20) -> list[dict]:
+    """Return the most-recent `limit` outbox entries, newest-first."""
+    entries = outbox_log.read_recent(limit=limit)
+    return list(reversed(entries))
+
+
+def render_outbox_card(entries: list[dict]) -> str:
+    if not entries:
+        return '<div class="card full"><h2>Outbox</h2><span style="color:#333;font-size:12px">No outbound messages logged yet.</span></div>'
+    rows = ""
+    for e in entries:
+        iso = e.get("iso_ts", "")
+        time_str = iso[11:16] if len(iso) >= 16 else iso  # HH:MM
+        ch = e.get("channel_type", "?")
+        label = _CHANNEL_LABELS.get(ch, ch)
+        recipient = e.get("recipient_label") or e.get("recipient", "?")
+        # Truncate long recipients (phone numbers, long IDs).
+        if len(recipient) > 28:
+            recipient = recipient[:26] + ".."
+        preview = e.get("body_preview", "")
+        if len(preview) > 60:
+            preview = preview[:58] + ".."
+        rows += (
+            f'<tr style="border-bottom:1px solid #1a1a2a">'
+            f'<td style="padding:4px 6px;color:#444;white-space:nowrap">{time_str}</td>'
+            f'<td style="padding:4px 6px;color:#4a8aaa;white-space:nowrap">{label}</td>'
+            f'<td style="padding:4px 6px;color:#888;white-space:nowrap">{recipient}</td>'
+            f'<td style="padding:4px 6px;color:#aaa">{preview}</td>'
+            f'</tr>\n'
+        )
+    return (
+        '<div class="card full"><h2>Outbox</h2>'
+        '<table style="width:100%;font-size:11px;border-collapse:collapse">'
+        '<tr style="color:#555;text-align:left">'
+        '<th style="padding:4px 6px">Time</th>'
+        '<th style="padding:4px 6px">Channel</th>'
+        '<th style="padding:4px 6px">Recipient</th>'
+        '<th style="padding:4px 6px">Preview</th>'
+        '</tr>'
+        + rows
+        + '</table></div>'
+    )
 
 
 HTML = """<!DOCTYPE html>
@@ -330,6 +388,9 @@ def render_dashboard() -> str:
 <div style="margin:4px 0"><kbd style="background:#222;color:#aaa;padding:2px 6px;border-radius:3px;font-family:monospace">⌃V</kbd> Toggle voice</div>
 <div style="margin:4px 0"><kbd style="background:#222;color:#aaa;padding:2px 6px;border-radius:3px;font-family:monospace">⌃M</kbd> Toggle mute</div>
 </div></div>""")
+
+    # Outbox
+    cards.append(render_outbox_card(get_outbox()))
 
     # Quick links
     cards.append(f"""<div class="card full">

--- a/tests/dashboard-outbox.test.py
+++ b/tests/dashboard-outbox.test.py
@@ -1,0 +1,122 @@
+"""Tests for dashboard.py Outbox tab — Phase B-2 of issue #932.
+
+Run: python3 tests/dashboard-outbox.test.py
+"""
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+import outbox_log  # noqa: E402
+import dashboard   # noqa: E402
+
+
+def _write_outbox(workspace: Path, entries: list[dict]) -> None:
+    state = workspace / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    (state / "outbox.log").write_text(
+        "\n".join(json.dumps(e) for e in entries) + "\n",
+        encoding="utf-8",
+    )
+
+
+class TestGetOutbox(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+        os.environ["SUTANDO_WORKSPACE"] = str(self.workspace)
+
+    def tearDown(self):
+        os.environ.pop("SUTANDO_WORKSPACE", None)
+        self.tmp.cleanup()
+
+    def test_returns_empty_list_when_no_log(self):
+        self.assertEqual(dashboard.get_outbox(), [])
+
+    def test_returns_newest_first(self):
+        now = time.time()
+        _write_outbox(self.workspace, [
+            {"ts": now - 100, "iso_ts": "2026-05-27T01:00:00Z", "channel_type": "email", "recipient": "a@b.com", "body_preview": "older", "body_len": 5},
+            {"ts": now, "iso_ts": "2026-05-27T02:00:00Z", "channel_type": "x_twitter", "recipient": "broadcast", "body_preview": "newer", "body_len": 5},
+        ])
+        entries = dashboard.get_outbox(limit=20)
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0]["channel_type"], "x_twitter")  # newest first
+        self.assertEqual(entries[1]["channel_type"], "email")
+
+    def test_respects_limit(self):
+        now = time.time()
+        _write_outbox(self.workspace, [
+            {"ts": now + i, "iso_ts": "2026-05-27T00:00:00Z", "channel_type": "discord_dm",
+             "recipient": f"user{i}", "body_preview": "hi", "body_len": 2}
+            for i in range(30)
+        ])
+        entries = dashboard.get_outbox(limit=5)
+        self.assertLessEqual(len(entries), 5)
+
+
+class TestRenderOutboxCard(unittest.TestCase):
+    def test_empty_state_message(self):
+        html = dashboard.render_outbox_card([])
+        self.assertIn("No outbound messages logged yet", html)
+        self.assertIn("card full", html)
+
+    def test_renders_table_with_entries(self):
+        entries = [
+            {"ts": 1.0, "iso_ts": "2026-05-27T03:15:00Z", "channel_type": "x_twitter",
+             "recipient": "broadcast", "body_preview": "Tweet content", "body_len": 13},
+            {"ts": 0.9, "iso_ts": "2026-05-27T03:10:00Z", "channel_type": "email",
+             "recipient": "alice@example.com", "body_preview": "Email body", "body_len": 10},
+        ]
+        html = dashboard.render_outbox_card(entries)
+        self.assertIn("<table", html)
+        self.assertIn("x/twitter", html)
+        self.assertIn("email", html)
+        self.assertIn("03:15", html)
+        self.assertIn("Tweet content", html)
+
+    def test_channel_type_label_mapping(self):
+        for ch_type, expected_label in dashboard._CHANNEL_LABELS.items():
+            html = dashboard.render_outbox_card([
+                {"ts": 1.0, "iso_ts": "2026-05-27T00:00:00Z", "channel_type": ch_type,
+                 "recipient": "r", "body_preview": "p", "body_len": 1}
+            ])
+            self.assertIn(expected_label, html, f"label missing for {ch_type}")
+
+    def test_long_recipient_truncated(self):
+        long_id = "1" * 35
+        html = dashboard.render_outbox_card([
+            {"ts": 1.0, "iso_ts": "2026-05-27T00:00:00Z", "channel_type": "discord_dm",
+             "recipient": long_id, "body_preview": "hi", "body_len": 2}
+        ])
+        # Truncated form should appear, not the full 35-char string
+        self.assertNotIn(long_id, html)
+        self.assertIn("..", html)
+
+    def test_uses_recipient_label_over_recipient_id(self):
+        html = dashboard.render_outbox_card([
+            {"ts": 1.0, "iso_ts": "2026-05-27T00:00:00Z", "channel_type": "discord_dm",
+             "recipient": "9999999", "recipient_label": "Alice (owner) DM",
+             "body_preview": "hi", "body_len": 2}
+        ])
+        self.assertIn("Alice (owner) DM", html)
+        self.assertNotIn("9999999", html)
+
+    def test_long_preview_truncated(self):
+        long_preview = "A" * 80
+        html = dashboard.render_outbox_card([
+            {"ts": 1.0, "iso_ts": "2026-05-27T00:00:00Z", "channel_type": "email",
+             "recipient": "bob@x.com", "body_preview": long_preview, "body_len": 80}
+        ])
+        self.assertNotIn(long_preview, html)
+        self.assertIn("..", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a full-width **Outbox** card to the dashboard at port 7844. Shows the 20 most-recent outbound messages from `state/outbox.log`, sorted newest-first.

**Columns**: Time (HH:MM) · Channel (human label) · Recipient (or `recipient_label` if set) · Preview (≤60 chars)

**Channel labels** mapped: discord-dm, discord-ch, slack-dm, slack-ch, telegram, email, whatsapp, x/twitter, imessage.

Empty-state message shown when log is absent or empty.

## New code in `src/dashboard.py`

- `_CHANNEL_LABELS` — mapping table `channel_type → display label`
- `get_outbox(limit=20)` — calls `outbox_log.read_recent()`, reverses to newest-first
- `render_outbox_card(entries)` — HTML table card inserted before "Quick Links"
- One-line `import outbox_log` at module level (src/ already on sys.path)

## Test plan

- [ ] `python3 tests/dashboard-outbox.test.py` → 9/9 pass
- [ ] `curl -s http://localhost:7844 | grep -c "Outbox"` → 1 (card heading visible)
- [ ] With entries in `state/outbox.log`, dashboard shows them; without, shows "No outbound messages logged yet."

## Depends on

- Phase B-1: #1245 (X/Twitter), #1246 (email + WhatsApp) — fills the log with entries for the tab to display. Dashboard tab works independently (just shows empty state until those PRs land).

Part of issue #932 (Phase B-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)