### PR TITLE
fix(phone-conversation): anchor system prompt to owner-local date (closes #1243)

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -125,6 +125,23 @@ const TASK_POLL_INTERVAL_MS = 500;
 const TASK_TIMEOUT_MS = 120_000;
 const OWNER_NAME = process.env.owner ?? '';
 const OWNER_NUMBER = process.env.OWNER_NUMBER ?? '';
+const OWNER_TZ = process.env.OWNER_TZ ?? 'America/Los_Angeles';
+
+// Build a date-context string injected into the system prompt at session-open
+// so Gemini resolves date-relative phrases ("tomorrow", "this Friday") against
+// the owner's local clock, not UTC or server-local. Without this, US-Pacific
+// owners get an off-by-one whenever a call lands after ~5pm PT (UTC midnight
+// rollover): the model says "tomorrow = May 28" when owner-local says May 27.
+// See sonichi/sutando#1243.
+function ownerLocalDateContext(now: Date = new Date()): string {
+	const tz = OWNER_TZ;
+	const today = now.toLocaleDateString('en-CA', { timeZone: tz }); // YYYY-MM-DD
+	const dayName = now.toLocaleDateString('en-US', { timeZone: tz, weekday: 'long' });
+	const timeStr = now.toLocaleTimeString('en-US', { timeZone: tz, hour: 'numeric', minute: '2-digit' });
+	const tomorrow = new Date(now.getTime() + 86_400_000).toLocaleDateString('en-CA', { timeZone: tz });
+	const yesterday = new Date(now.getTime() - 86_400_000).toLocaleDateString('en-CA', { timeZone: tz });
+	return `Owner-local time: ${dayName}, ${today}, ${timeStr} (${tz}). Tomorrow = ${tomorrow}. Yesterday = ${yesterday}. When the owner says "today", "tomorrow", "yesterday", "this week", etc., resolve against THESE owner-local dates — never against UTC or server-local time. Pass absolute YYYY-MM-DD values to tools (not relative phrases).`;
+}
 
 // Model configuration — text/STT model still env-driven; the native-audio
 // model + googleSearch grounding are per-user config: data, not code, so they
@@ -517,6 +534,7 @@ function buildAgent(callSession: CallSession): MainAgent {
 				'',
 				'## Known info',
 				(() => { try { const url = execSync('git remote get-url origin', { timeout: 2_000 }).toString().trim().replace(/\.git$/, ''); return `Sutando GitHub repo: ${url}`; } catch { return ''; } })(),
+				ownerLocalDateContext(),
 				'',
 				'## Style',
 				'Be natural, warm, and conversational. Keep responses to 1-2 sentences.',

--- a/tests/conversation-server-owner-local-date.test.ts
+++ b/tests/conversation-server-owner-local-date.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Pin the fix for sonichi/sutando#1243 — voice agent computed "tomorrow" wrong,
+// off by one day. Root cause: system prompt carried no owner-local date
+// anchor, so Gemini resolved date-relative phrases against UTC / server-local
+// instead of the owner's timezone. Whenever the call landed after ~5pm PT,
+// "tomorrow" rolled to UTC's tomorrow — one day ahead of owner-local.
+//
+// Fix injects a date-context line into the "## Known info" section at
+// session-open, naming the owner-local today/tomorrow/yesterday so the model
+// has explicit absolute YYYY-MM-DD values to pass to tools.
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'skills/phone-conversation/scripts/conversation-server.ts'),
+	'utf-8',
+);
+
+describe('conversation-server — owner-local date context (sonichi#1243)', () => {
+	it('reads OWNER_TZ from env with America/Los_Angeles default', () => {
+		assert.match(
+			SRC,
+			/const\s+OWNER_TZ\s*=\s*process\.env\.OWNER_TZ\s*\?\?\s*['"]America\/Los_Angeles['"]/,
+			'must read OWNER_TZ from env with a sensible default — env override lets non-Pacific owners fix without code change.',
+		);
+	});
+
+	it('defines an ownerLocalDateContext helper that computes today/tomorrow/yesterday', () => {
+		assert.match(
+			SRC,
+			/function\s+ownerLocalDateContext\s*\(/,
+			'must define an ownerLocalDateContext helper.',
+		);
+		assert.match(
+			SRC,
+			/toLocaleDateString\(['"]en-CA['"][^)]*timeZone:\s*tz/,
+			'helper must format dates with timeZone:tz so output is owner-local, not UTC.',
+		);
+	});
+
+	it('helper computes tomorrow and yesterday by adding/subtracting 86_400_000 ms', () => {
+		assert.match(
+			SRC,
+			/now\.getTime\(\)\s*\+\s*86[_]?400[_]?000/,
+			'tomorrow must be computed by adding 1 day in ms — naive Date.setDate() drifts across DST.',
+		);
+		assert.match(
+			SRC,
+			/now\.getTime\(\)\s*-\s*86[_]?400[_]?000/,
+			'yesterday must be computed by subtracting 1 day in ms.',
+		);
+	});
+
+	it('helper returns an explicit instruction to use owner-local dates (not UTC)', () => {
+		assert.match(
+			SRC,
+			/owner-local/i,
+			'helper output must use the phrase "owner-local" so the model anchors against the right clock.',
+		);
+		assert.match(
+			SRC,
+			/never\s+against\s+UTC/i,
+			'helper must explicitly tell the model NOT to resolve against UTC.',
+		);
+	});
+
+	it('injects ownerLocalDateContext() into the "## Known info" block', () => {
+		const re = /## Known info[\s\S]{0,400}?ownerLocalDateContext\(\)/;
+		assert.match(
+			SRC,
+			re,
+			'## Known info section must include ownerLocalDateContext() — that is where the date anchor is delivered to Gemini.',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Voice agent computed `tomorrow` off by one day on owner phone calls after the UTC date had rolled but owner-local hadn't (typical US-Pacific scenario: call lands after 5pm PT). The dispatched `work` task carried the wrong YYYY-MM-DD; the result was queried for the wrong day; on top of that, the agent sometimes confabulated events to fill the silence (see #1244 for the confabulation half).

Root cause: the `## Known info` section of the owner-call system prompt named the GitHub repo but had no clock anchor, so Gemini resolved date-relative phrases against UTC / server-local rather than the owner's tz.

Fix injects a one-line context block:

> Owner-local time: Tuesday, 2026-05-27, 8:45 PM (America/Los_Angeles). Tomorrow = 2026-05-28. Yesterday = 2026-05-26. When the owner says "today", "tomorrow", "yesterday", "this week", etc., resolve against THESE owner-local dates — never against UTC or server-local time. Pass absolute YYYY-MM-DD values to tools (not relative phrases).

Composed at session-open (so the value is fresh for each call, not pinned at process start). Reads `OWNER_TZ` from env with a sensible `America/Los_Angeles` default; non-Pacific owners override without a code change.

## Why ms-arithmetic for tomorrow/yesterday

`Date.setDate(today.getDate() + 1)` drifts on DST transition days when the date arithmetic happens in server-local time. `new Date(now.getTime() + 86_400_000)` plus `toLocaleDateString({timeZone: tz})` produces the correct owner-local date even across DST.

## What this PR does NOT fix

- **#1244 (hallucination on empty results)** — that's a separate bug. The two are correlated (wrong-date queries return empty, model fills the silence with plausible fabrications), but the fixes are independent.
- **Future ambiguous phrases** — "this Friday" still requires the model to reason about the current weekday; we surface today's day-name to make that easier but don't enforce it.

## Test plan

- [x] Added `tests/conversation-server-owner-local-date.test.ts` (5 structural assertions)
- [x] Passes locally (`npx tsx --test tests/conversation-server-owner-local-date.test.ts` — 5/5)
- [ ] Real-call dogfood: place a phone call after 5pm PT, ask "what's on my calendar tomorrow"; confirm the `work` task references owner-local tomorrow, not UTC tomorrow

Closes #1243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)