### PR TITLE
fix(phone-conversation): guard against result fabrication on empty work-task results (closes #1244)

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -402,9 +402,12 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			// Cache result so duplicate requests get instant replay
 			if (!callSession.taskResultCache) callSession.taskResultCache = new Map();
 			callSession.taskResultCache.set(taskDescription, result);
-			// Queue result — will be injected on next turn.end to avoid interrupting speech
+			// Queue result — will be injected on next turn.end to avoid interrupting speech.
+			// Empty results must be labelled so the model reports "nothing found" rather
+			// than filling the silence with confabulated events. See sonichi/sutando#1244.
+			const resultBody = result || '[RESULT_EMPTY: the task returned no data]';
 			callSession.resultQueue.push({
-				text: `[Task result for "${taskDescription}"]\n${result}\n\nReport this result to the caller now.`,
+				text: `[Task result for "${taskDescription}"]\n${resultBody}\n\nReport this result to the caller. ONLY read back items that appear verbatim in the result above. If the result is empty or says nothing found, say "nothing scheduled" / "nothing found" — do NOT invent or mention any events, emails, meetings, or items that are not explicitly listed in the result.`,
 			});
 			return;
 		}
@@ -517,6 +520,7 @@ function buildAgent(callSession: CallSession): MainAgent {
 				'',
 				'## Known info',
 				(() => { try { const url = execSync('git remote get-url origin', { timeout: 2_000 }).toString().trim().replace(/\.git$/, ''); return `Sutando GitHub repo: ${url}`; } catch { return ''; } })(),
+				'TOOL RESULT TRUTHFULNESS: When a work task result is empty or says nothing was found, you MUST say "nothing scheduled" or "nothing found" — never invent, guess, or fill with plausible-sounding calendar events, emails, or other items. Fabricated events mislead the owner and are worse than silence.',
 				'',
 				'## Style',
 				'Be natural, warm, and conversational. Keep responses to 1-2 sentences.',

--- a/tests/conversation-server-result-fabrication.test.ts
+++ b/tests/conversation-server-result-fabrication.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Pin the fix for sonichi/sutando#1244 — voice agent fabricates calendar
+// events when a work task returns empty results. Root cause: the result
+// injection text said only "Report this result to the caller now." with no
+// guard against empty payloads. Gemini Live filled the silence with
+// plausible-sounding fabrications (events, emails) the owner's calendar
+// didn't contain.
+//
+// Fix (two-part):
+//   1. Result injection: if result is empty, substitute [RESULT_EMPTY] and
+//      tell the model to say "nothing found" — not to invent items.
+//   2. System prompt: add TOOL RESULT TRUTHFULNESS clause in ## Known info
+//      so the constraint is set at session-open, not only per-result.
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'skills/phone-conversation/scripts/conversation-server.ts'),
+	'utf-8',
+);
+
+describe('conversation-server — result fabrication guard (sonichi#1244)', () => {
+	it('substitutes [RESULT_EMPTY] sentinel when result is falsy', () => {
+		assert.match(
+			SRC,
+			/RESULT_EMPTY/,
+			'must define a RESULT_EMPTY sentinel for empty task results — model uses it to say "nothing found" instead of fabricating events.',
+		);
+	});
+
+	it('result injection instructs model to only report items present in the result', () => {
+		assert.match(
+			SRC,
+			/ONLY read back items that appear verbatim in the result/,
+			'result injection text must contain an explicit "only verbatim" constraint so the model cannot add items not present in the result.',
+		);
+	});
+
+	it('result injection instructs model to say "nothing scheduled" on empty result', () => {
+		assert.match(
+			SRC,
+			/nothing scheduled.*nothing found|nothing found.*nothing scheduled/i,
+			'result injection must explicitly name the expected fallback phrase for empty results.',
+		);
+	});
+
+	it('system prompt contains TOOL RESULT TRUTHFULNESS clause', () => {
+		assert.match(
+			SRC,
+			/TOOL RESULT TRUTHFULNESS/,
+			'system prompt must include a named TOOL RESULT TRUTHFULNESS rule — a general fabrication warning is insufficient; the model needs an explicit per-result-empty constraint.',
+		);
+	});
+
+	it('TOOL RESULT TRUTHFULNESS clause forbids inventing events or items not in the result', () => {
+		assert.match(
+			SRC,
+			/never invent.*calendar events|never invent.*emails|never invent.*items/i,
+			'TOOL RESULT TRUTHFULNESS clause must explicitly forbid inventing calendar events, emails, or other items.',
+		);
+	});
+});


### PR DESCRIPTION
## Problem

During inbound phone calls, when the owner asked "what's on my calendar for tomorrow?" and the core agent returned an empty result (triggered by the off-by-one date bug from #1243), Gemini Live filled the silence with plausible-sounding calendar events that didn't exist: *"design review at 10 AM, marketing campaign planning, virtual coffee with a client."*

The owner caught it live: *"Marketing, I don't see that."*

Root cause (two gaps):
1. The result injection said only `"Report this result to the caller now."` — an empty payload gave Gemini no signal that "nothing" was the intended response.
2. The system prompt had a general `"NEVER fabricate specific details"` clause but no explicit per-result constraint, which Gemini reads as a knowledge-lookup restriction (go use Search/work), not as a prohibition on embellishing tool results.

## Fix

**Result injection (the primary gate):**

```diff
-text: `[Task result for "${taskDescription}"]\n${result}\n\nReport this result to the caller now.`
+const resultBody = result || '[RESULT_EMPTY: the task returned no data]';
+text: `[Task result for "${taskDescription}"]\n${resultBody}\n\nReport this result to the caller. ONLY read back items that appear verbatim in the result above. If the result is empty or says nothing found, say "nothing scheduled" / "nothing found" — do NOT invent or mention any events, emails, meetings, or items that are not explicitly listed in the result.`
```

**System prompt (session-open backstop):**

Adds `TOOL RESULT TRUTHFULNESS` clause to `## Known info` so the model enters every call knowing the rule — not just when an empty result lands.

## What this PR does NOT fix

- **#1243 (wrong date query)** — fixed separately by PR #1248. The two bugs are correlated (wrong-date query → empty result → fabrication), but the fixes are independent.

## Test plan

5 structural tests added to `tests/conversation-server-result-fabrication.test.ts`:

| Test | What it pins |
|------|-------------|
| `RESULT_EMPTY sentinel defined` | Empty-payload path must exist |
| `"only verbatim" instruction in injection` | Explicit constraint present |
| `"nothing scheduled"/"nothing found" in injection` | Named fallback phrases |
| `TOOL RESULT TRUTHFULNESS clause in system prompt` | Session-open backstop exists |
| `clause forbids inventing events or items` | Anti-confabulation content present |

All 5 pass; existing conversation-server tests (13 total) continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)