### PR TITLE
fix(phone-conversation): anti-hallucination wrapper on work-tool results (closes #1244)

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -544,6 +544,13 @@ function buildAgent(callSession: CallSession): MainAgent {
 				'## Known info',
 				(() => { try { const url = execSync('git remote get-url origin', { timeout: 2_000 }).toString().trim().replace(/\.git$/, ''); return `Sutando GitHub repo: ${url}`; } catch { return ''; } })(),
 				ownerLocalDateContext(),
+				// Session-level anti-hallucination backstop (cherry-picked from
+				// bassilkhilo-ag2's parallel PR #1249). Pre-warms the model
+				// with the constraint at session-open so the rule is in scope
+				// BEFORE any result-injection wrapper lands. Combined with the
+				// per-result wrapper below at conversation-server.ts:405, the
+				// model gets the rule twice: at boot and at delivery.
+				'TOOL RESULT TRUTHFULNESS: When a work task result is empty or says nothing was found, you MUST say "nothing scheduled" or "nothing found" — never invent, guess, or fill with plausible-sounding calendar events, emails, or other items. Fabricated events mislead the owner and are worse than silence.',
 				'',
 				'## Style',
 				'Be natural, warm, and conversational. Keep responses to 1-2 sentences.',

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -419,10 +419,19 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			// Cache result so duplicate requests get instant replay
 			if (!callSession.taskResultCache) callSession.taskResultCache = new Map();
 			callSession.taskResultCache.set(taskDescription, result);
+			// Anti-hallucination wrapping. See sonichi/sutando#1244 — Gemini
+			// was filling silence with plausible-sounding fabrications when
+			// the work tool returned empty/sparse content. Two layers:
+			// (1) a RESULT_EMPTY sentinel on truly-empty results so the model
+			// has an explicit "say nothing" signal instead of an empty string
+			// it can pattern-fill; (2) an explicit "items present verbatim"
+			// guardrail on every result.
+			const isEmpty = result.length === 0;
+			const injectedText = isEmpty
+				? `[Task result for "${taskDescription}"]\nRESULT_EMPTY — the tool returned no items.\n\nTell the caller plainly that there is nothing to report (e.g. "nothing scheduled", "your inbox is empty", "no matches"). Do NOT invent, guess, or extrapolate any items. Use only the literal RESULT_EMPTY signal.`
+				: `[Task result for "${taskDescription}"]\n${result}\n\nReport this result to the caller now. Only reference items that appear verbatim in the result above — do NOT invent, fabricate, or extrapolate items that aren't there.`;
 			// Queue result — will be injected on next turn.end to avoid interrupting speech
-			callSession.resultQueue.push({
-				text: `[Task result for "${taskDescription}"]\n${result}\n\nReport this result to the caller now.`,
-			});
+			callSession.resultQueue.push({ text: injectedText });
 			return;
 		}
 		if (Date.now() - startTime > POLL_TIMEOUT_MS) {

--- a/tests/conversation-server-no-hallucination.test.ts
+++ b/tests/conversation-server-no-hallucination.test.ts
@@ -59,4 +59,20 @@ describe('conversation-server — anti-hallucination on work-tool results (sonic
 			'result injection must continue to use callSession.resultQueue.push so the existing turn-end drain logic still fires.',
 		);
 	});
+
+	it('pre-warms the system prompt with TOOL RESULT TRUTHFULNESS clause', () => {
+		// Cherry-picked from bassilkhilo-ag2's parallel PR #1249 — session-level
+		// backstop so the constraint is in scope BEFORE the per-result wrapper
+		// lands. Defense in depth: model gets the rule at boot + at delivery.
+		assert.match(
+			SRC,
+			/TOOL RESULT TRUTHFULNESS/,
+			'system prompt must include a TOOL RESULT TRUTHFULNESS clause as session-level anti-hallucination backstop.',
+		);
+		assert.match(
+			SRC,
+			/TOOL RESULT TRUTHFULNESS[\s\S]{0,400}?Fabricated events mislead the owner/,
+			'TOOL RESULT TRUTHFULNESS clause must include the rationale (fabricated events mislead owner) so the model understands the priority.',
+		);
+	});
 });

--- a/tests/conversation-server-no-hallucination.test.ts
+++ b/tests/conversation-server-no-hallucination.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Pin the fix for sonichi/sutando#1244 — voice agent fabricated calendar
+// events ("design review at 10 AM, marketing campaign planning, virtual
+// coffee with a client") when the work tool returned no events. Root cause:
+// the result wrapper said "Report this result to the caller now" but
+// contained no anti-invention guard, and an empty `result` string gave the
+// model an empty pattern to fill.
+//
+// Fix wraps the injected result with two layers:
+//   (1) RESULT_EMPTY sentinel on truly-empty results
+//   (2) "only items present verbatim" guardrail on every result
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'skills/phone-conversation/scripts/conversation-server.ts'),
+	'utf-8',
+);
+
+describe('conversation-server — anti-hallucination on work-tool results (sonichi#1244)', () => {
+	it('detects truly-empty results via result.length === 0', () => {
+		assert.match(
+			SRC,
+			/const\s+isEmpty\s*=\s*result\.length\s*===\s*0/,
+			'must detect empty results with strict-equal length check on the trimmed result string.',
+		);
+	});
+
+	it('emits a RESULT_EMPTY sentinel for empty results', () => {
+		assert.match(
+			SRC,
+			/RESULT_EMPTY/,
+			'the empty-result wrapper must contain the literal RESULT_EMPTY sentinel so the model has an explicit "say nothing" signal.',
+		);
+	});
+
+	it('explicitly bars invention on empty results', () => {
+		assert.match(
+			SRC,
+			/RESULT_EMPTY[\s\S]{0,300}?Do NOT invent/i,
+			'the empty-result wrapper must explicitly bar invention/extrapolation.',
+		);
+	});
+
+	it('explicitly bars invention on non-empty results too', () => {
+		assert.match(
+			SRC,
+			/items that appear verbatim[\s\S]{0,200}?do NOT invent/i,
+			'non-empty result wrapper must require items appear verbatim AND bar invention — silence-filling can also happen with sparse-but-not-empty results.',
+		);
+	});
+
+	it('still pushes onto the existing resultQueue (no behavioral regression)', () => {
+		assert.match(
+			SRC,
+			/callSession\.resultQueue\.push\(\s*\{\s*text:\s*injectedText\s*\}\s*\)/,
+			'result injection must continue to use callSession.resultQueue.push so the existing turn-end drain logic still fires.',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Voice agent fabricated calendar events on a real owner phone call when the `work` tool returned NO events for the queried date — model said *"design review at 10 AM, marketing campaign planning, virtual coffee with a client"* when the real result was empty. Owner caught it mid-call.

Root cause: the result-injection wrapper at `conversation-server.ts:405` said *"Report this result to the caller now"* but contained no anti-invention guard, AND an empty `result` string gave the model an empty pattern to fill rather than an explicit signal to say nothing.

## The fix

Two layers on the same code block:

**(1) `RESULT_EMPTY` sentinel for truly-empty results.** If `result.length === 0` after trim, wrap as:

```
[Task result for "X"]
RESULT_EMPTY — the tool returned no items.

Tell the caller plainly that there is nothing to report (e.g. "nothing scheduled",
"your inbox is empty", "no matches"). Do NOT invent, guess, or extrapolate
any items. Use only the literal RESULT_EMPTY signal.
```

**(2) Verbatim-only guardrail on non-empty results.** Even when the result has content, append:

> Only reference items that appear verbatim in the result above — do NOT invent, fabricate, or extrapolate items that aren't there.

Sparse results (e.g. a tool returns "1 event") were the other class of failure where the model would add plausible-sounding extras around the real item.

## Why conservative empty detection

`isEmpty` uses `result.length === 0` only (the result has already been `.trim()`'d earlier in the same block). I considered including patterns like "no events" / "inbox is empty", but that risks false positives (e.g. "no events scheduled BUT 2 reminders to follow up on" should NOT be wrapped as empty). The strict-length check is correct on its own; the universal guardrail handles non-empty-but-sparse cases.

## What this doesn't fix

- **#1243 (date math off-by-one)** — separate fix already shipped as #1248. Correlated bug (wrong-date queries return empty, then this layer kicks in), but independent fixes.
- **Tool results that the model misreads** — this fix bars *invention*; it doesn't help if the model misinterprets actual content. Different bug class.

## Test plan

- [x] `tests/conversation-server-no-hallucination.test.ts` — 5 structural assertions (5/5 pass)
- [x] tsx --test green locally
- [ ] Real-call dogfood: phone in a query for a known-empty date, confirm the agent says "nothing scheduled" rather than inventing events

Closes #1244. Pairs with #1248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)