### PR TITLE
perf(discord-voice): hoist mkdirSync + switch to WriteStream for op log (#1053)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -30,7 +30,8 @@
  */
 
 import { config as _dotenvConfig } from 'dotenv';
-import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, existsSync, readFileSync, readdirSync, unlinkSync } from 'node:fs';
+import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, existsSync, readFileSync, readdirSync, unlinkSync, createWriteStream } from 'node:fs';
+import type { WriteStream } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { resolveWorkspace } from '../../../src/workspace_default.js';
 import { recordConversation, recordSession, recordToolCall } from '../../../src/conversation-store.js';
@@ -203,6 +204,14 @@ if (!GUILD_ID || !CHANNEL_ID) {
 mkdirSync(DATA_DIR, { recursive: true });
 mkdirSync(RESULTS_DIR, { recursive: true });
 mkdirSync(TASKS_DIR, { recursive: true });
+mkdirSync(dirname(DISCORD_VOICE_LOG), { recursive: true });
+
+// Non-blocking append stream for the operational log. Opened once at init so
+// appendOperationalLog pays no per-call mkdirSync/appendFileSync syscall cost.
+let _opLogStream: WriteStream | null = null;
+try {
+	_opLogStream = createWriteStream(DISCORD_VOICE_LOG, { flags: 'a' });
+} catch {}
 
 const ts = () => new Date().toISOString().slice(11, 23);
 const google = createGoogleGenerativeAI({ apiKey: GEMINI_API_KEY });
@@ -251,8 +260,7 @@ function appendOperationalLog(level: string, args: unknown[]): void {
 		const line = args
 			.map((a) => (typeof a === 'string' ? a : a instanceof Error ? (a.stack ?? a.message) : String(a)))
 			.join(' ');
-		mkdirSync(dirname(DISCORD_VOICE_LOG), { recursive: true });
-		appendFileSync(DISCORD_VOICE_LOG, `${new Date().toISOString()} ${level} ${line}\n`);
+		_opLogStream?.write(`${new Date().toISOString()} ${level} ${line}\n`);
 	} catch {}
 }
 {

--- a/tests/discord-voice-log-stream.test.ts
+++ b/tests/discord-voice-log-stream.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression guard: discord-voice operational log must use a single WriteStream
+ * opened at module init, not appendFileSync+mkdirSync on every console.log call.
+ *
+ * Background (sonichi/sutando#1053): the previous appendOperationalLog() ran
+ * mkdirSync + appendFileSync on EVERY log line — both block the event loop and
+ * the syscall cost is non-trivial on a turn-latency-sensitive voice session.
+ * The fix opens one WriteStream at init; appendOperationalLog writes to it.
+ *
+ * These are structural source tests — they verify the fix shape without needing
+ * to import the full discord-voice-server (which has complex module-level side
+ * effects and requires Discord.js / Gemini / prism-media runtime deps).
+ *
+ * Guards:
+ *  1. `createWriteStream` is imported from node:fs
+ *  2. `_opLogStream` WriteStream is declared at module scope
+ *  3. `mkdirSync(dirname(DISCORD_VOICE_LOG))` is hoisted to the init block (not in appendOperationalLog)
+ *  4. `appendOperationalLog` uses `_opLogStream?.write` (non-blocking)
+ *  5. `appendOperationalLog` does NOT contain `appendFileSync` (blocking path removed)
+ *  6. `appendOperationalLog` does NOT contain `mkdirSync` (per-call syscall removed)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(
+	join(__dirname, '../skills/discord-voice/scripts/discord-voice-server.ts'),
+	'utf8',
+);
+
+// Extract the appendOperationalLog function body for targeted assertions.
+const fnMatch = SRC.match(
+	/function appendOperationalLog\([\s\S]*?\n\}/,
+);
+const FN_BODY = fnMatch ? fnMatch[0] : '';
+
+describe('discord-voice operational log stream (#1053)', () => {
+	it('imports createWriteStream from node:fs', () => {
+		assert.match(
+			SRC,
+			/import\s*\{[^}]*createWriteStream[^}]*\}\s*from\s*['"]node:fs['"]/,
+			'createWriteStream must be imported from node:fs',
+		);
+	});
+
+	it('declares _opLogStream WriteStream at module scope', () => {
+		assert.ok(
+			SRC.includes('_opLogStream: WriteStream | null'),
+			'_opLogStream must be declared as WriteStream | null at module scope',
+		);
+	});
+
+	it('hoists mkdirSync(dirname(DISCORD_VOICE_LOG)) to the init block', () => {
+		// The call must appear OUTSIDE appendOperationalLog — i.e. before the
+		// function declaration in the source.
+		const fnStart = SRC.indexOf('function appendOperationalLog(');
+		const mkdirPos = SRC.indexOf('mkdirSync(dirname(DISCORD_VOICE_LOG)');
+		assert.ok(mkdirPos >= 0, 'mkdirSync(dirname(DISCORD_VOICE_LOG)) must be present in source');
+		assert.ok(
+			mkdirPos < fnStart,
+			'mkdirSync(dirname(DISCORD_VOICE_LOG)) must be hoisted BEFORE appendOperationalLog — not inside it',
+		);
+	});
+
+	it('appendOperationalLog uses _opLogStream?.write (non-blocking)', () => {
+		assert.ok(FN_BODY, 'appendOperationalLog function not found in source');
+		assert.ok(
+			FN_BODY.includes('_opLogStream?.write('),
+			'appendOperationalLog must write via _opLogStream?.write() for non-blocking I/O',
+		);
+	});
+
+	it('appendOperationalLog does not call appendFileSync (blocking path removed)', () => {
+		assert.ok(FN_BODY, 'appendOperationalLog function not found in source');
+		assert.ok(
+			!FN_BODY.includes('appendFileSync'),
+			'appendOperationalLog must NOT call appendFileSync — blocking sync I/O on hot log path',
+		);
+	});
+
+	it('appendOperationalLog does not call mkdirSync (per-call syscall removed)', () => {
+		assert.ok(FN_BODY, 'appendOperationalLog function not found in source');
+		assert.ok(
+			!FN_BODY.includes('mkdirSync'),
+			'appendOperationalLog must NOT call mkdirSync — dir creation is hoisted to module init',
+		);
+	});
+});


### PR DESCRIPTION
Fixes #1053.

## Summary

- `skills/discord-voice/scripts/discord-voice-server.ts`: hoist `mkdirSync(dirname(DISCORD_VOICE_LOG))` to the module-init block; open one `WriteStream` there; replace `appendFileSync+mkdirSync` in `appendOperationalLog` with `_opLogStream?.write()`
- Adds 6 structural tests in `tests/discord-voice-log-stream.test.ts`

## Problem

Per Lucy's review of #1026:

1. `mkdirSync(dirname(DISCORD_VOICE_LOG), { recursive: true })` ran on **every** `console.log`/`console.error` call — idempotent but still a syscall on a hot path
2. `appendFileSync` blocks the event loop; discord-voice's turn latency is actively being tuned and a sync write per log line is a real cost

## Fix

```typescript
// Before: per-call in appendOperationalLog
function appendOperationalLog(level, args) {
  try {
    mkdirSync(dirname(DISCORD_VOICE_LOG), { recursive: true });  // ← every call
    appendFileSync(DISCORD_VOICE_LOG, `...`);                    // ← blocking
  } catch {}
}

// After: init-time dir create + stream open
mkdirSync(dirname(DISCORD_VOICE_LOG), { recursive: true });  // hoisted
let _opLogStream: WriteStream | null = null;
try { _opLogStream = createWriteStream(DISCORD_VOICE_LOG, { flags: 'a' }); } catch {}

function appendOperationalLog(level, args) {
  try {
    _opLogStream?.write(`...`);  // non-blocking, no syscall overhead
  } catch {}
}
```

Log format, timestamp, and fail-soft `try/catch` are unchanged.

## Tests

6/6 pass:
1. `createWriteStream` imported from `node:fs`
2. `_opLogStream: WriteStream | null` declared at module scope
3. `mkdirSync(dirname(DISCORD_VOICE_LOG))` hoisted before function declaration
4. `appendOperationalLog` uses `_opLogStream?.write()`
5. `appendOperationalLog` does NOT call `appendFileSync`
6. `appendOperationalLog` does NOT call `mkdirSync`