### PR TITLE
fix(phone-conversation): archive task-phone-*.txt after result is consumed (#1235)

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -47,7 +47,7 @@
 import { config as _dotenvConfig } from 'dotenv';
 _dotenvConfig({ path: new URL('../../../.env', import.meta.url).pathname, override: true });
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync, symlinkSync } from 'node:fs';
+import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync, symlinkSync, renameSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { voiceApiKey } from '../../../src/voice-key.js';
@@ -123,6 +123,20 @@ const RESULTS_DIR = process.env.PHONE_RESULTS_DIR || join(WORKSPACE_DIR, 'result
 const TASKS_DIR = join(WORKSPACE_DIR, 'tasks');
 const TASK_POLL_INTERVAL_MS = 500;
 const TASK_TIMEOUT_MS = 120_000;
+
+/** Move a phone task file to tasks/archive/YYYY-MM/ (mirrors task-bridge archiveFile).
+ *  Falls back to unlink so stale files never accumulate in tasks/. */
+function archivePhoneTask(taskPath: string, taskId: string): void {
+	try {
+		if (!existsSync(taskPath)) return;
+		const ym = new Date().toISOString().slice(0, 7);
+		const destDir = join(TASKS_DIR, 'archive', ym);
+		mkdirSync(destDir, { recursive: true });
+		renameSync(taskPath, join(destDir, `${taskId}.txt`));
+	} catch {
+		try { unlinkSync(taskPath); } catch {}
+	}
+}
 const OWNER_NAME = process.env.owner ?? '';
 const OWNER_NUMBER = process.env.OWNER_NUMBER ?? '';
 
@@ -399,6 +413,7 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			console.log(`${ts()} [Task] result for ${taskId} (${Date.now() - startTime}ms): ${result.slice(0, 200)}`);
 			callSession.events.push({ event: `task_result:${taskId}:${Date.now() - startTime}ms`, timestamp: new Date().toISOString() });
 			try { unlinkSync(resultPath); } catch {}
+			archivePhoneTask(taskPath, taskId);
 			// Cache result so duplicate requests get instant replay
 			if (!callSession.taskResultCache) callSession.taskResultCache = new Map();
 			callSession.taskResultCache.set(taskDescription, result);
@@ -412,6 +427,7 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			clearInterval(poll);
 			callSession.pendingTasks = Math.max(0, callSession.pendingTasks - 1);
 			console.log(`${ts()} [Task] timeout for ${taskId}`);
+			archivePhoneTask(taskPath, taskId);
 			try {
 				(callSession.voiceSession as any).transport.sendContent([
 					{ role: 'user', text: `[Task "${taskDescription}" timed out — still being worked on. Let the caller know.]` },

--- a/tests/conversation-server-task-archive.test.ts
+++ b/tests/conversation-server-task-archive.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression guard: conversation-server must archive task-phone-*.txt after
+ * the result is consumed, not leave them in tasks/ indefinitely.
+ *
+ * Background (sonichi/sutando#1235): delegateTask() wrote a task file to
+ * tasks/ and polled for the result in results/. On result receipt it unlinked
+ * the result file but never touched the task file. After a busy day of calls,
+ * tasks/ fills with stale task-phone-*.txt files that the archive watcher
+ * never cleans up (it only archives processed task-bridge tasks).
+ *
+ * The fix adds archivePhoneTask() — mirrors task-bridge archiveFile() — and
+ * calls it from both the success path and the timeout path.
+ *
+ * Guards:
+ *  1. `renameSync` is imported from node:fs (needed by archive move)
+ *  2. `archivePhoneTask` function is present and uses renameSync
+ *  3. `archivePhoneTask(taskPath, taskId)` is called after unlinkSync(resultPath) in success path
+ *  4. `archivePhoneTask(taskPath, taskId)` is called in the timeout path
+ *  5. archivePhoneTask falls back to unlinkSync on rename error (fail-safe)
+ *  6. Archive destination is tasks/archive/YYYY-MM/ (matches task-bridge pattern)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'skills/phone-conversation/scripts/conversation-server.ts'),
+	'utf-8',
+);
+
+// Extract just the archivePhoneTask function body for targeted assertions.
+const fnMatch = SRC.match(/function archivePhoneTask\([\s\S]*?\n\}/);
+const FN_BODY = fnMatch ? fnMatch[0] : '';
+
+// Extract the delegateTask poll loop body.
+const pollMatch = SRC.match(/const poll = setInterval\(\(\) => \{[\s\S]*?\}, TASK_POLL_INTERVAL_MS\)/);
+const POLL_BODY = pollMatch ? pollMatch[0] : '';
+
+describe('conversation-server — phone task archive (#1235)', () => {
+	it('imports renameSync from node:fs', () => {
+		assert.match(
+			SRC,
+			/import\s*\{[^}]*renameSync[^}]*\}\s*from\s*['"]node:fs['"]/,
+			'renameSync must be imported from node:fs',
+		);
+	});
+
+	it('defines archivePhoneTask function', () => {
+		assert.ok(FN_BODY.length > 0, 'archivePhoneTask function not found in conversation-server.ts');
+		assert.ok(
+			FN_BODY.includes('renameSync'),
+			'archivePhoneTask must use renameSync to move the task file',
+		);
+	});
+
+	it('calls archivePhoneTask after unlinkSync(resultPath) in success path', () => {
+		// The call must appear in the poll interval body, after the result unlink.
+		assert.ok(POLL_BODY.length > 0, 'poll setInterval body not found in source');
+		const unlinkPos = POLL_BODY.indexOf('unlinkSync(resultPath)');
+		const archivePos = POLL_BODY.indexOf('archivePhoneTask(taskPath, taskId)');
+		assert.ok(unlinkPos >= 0, 'unlinkSync(resultPath) not found in poll body');
+		assert.ok(archivePos >= 0, 'archivePhoneTask(taskPath, taskId) not called in poll body');
+		assert.ok(
+			archivePos > unlinkPos,
+			'archivePhoneTask must be called AFTER unlinkSync(resultPath) in success path',
+		);
+	});
+
+	it('calls archivePhoneTask in the timeout path', () => {
+		// Find the timeout block: after `POLL_TIMEOUT_MS` check
+		const timeoutMatch = SRC.match(/if\s*\(Date\.now\(\)\s*-\s*startTime\s*>\s*POLL_TIMEOUT_MS\)[\s\S]*?}\s*},\s*TASK_POLL_INTERVAL_MS/);
+		assert.ok(timeoutMatch, 'timeout block not found in source');
+		assert.ok(
+			timeoutMatch[0].includes('archivePhoneTask(taskPath, taskId)'),
+			'archivePhoneTask must be called in the timeout path to clean up stale task files',
+		);
+	});
+
+	it('archivePhoneTask falls back to unlinkSync on rename error', () => {
+		assert.ok(FN_BODY.length > 0, 'archivePhoneTask function not found');
+		assert.ok(
+			FN_BODY.includes('unlinkSync'),
+			'archivePhoneTask must fall back to unlinkSync when rename fails (fail-safe)',
+		);
+	});
+
+	it('archive destination uses tasks/archive/YYYY-MM pattern', () => {
+		assert.ok(FN_BODY.length > 0, 'archivePhoneTask function not found');
+		assert.ok(
+			FN_BODY.includes("'archive'"),
+			"archive destination must include 'archive' subdirectory",
+		);
+		assert.ok(
+			FN_BODY.includes('.slice(0, 7)'),
+			'archive destination must use YYYY-MM date prefix (isoString.slice(0, 7))',
+		);
+	});
+});


### PR DESCRIPTION
Fixes #1235.

## Summary

- `conversation-server.ts`: adds `archivePhoneTask()` helper; calls it from both the poll-success path and the poll-timeout path
- Adds `renameSync` to the `node:fs` import
- Adds 6 structural tests in `tests/conversation-server-task-archive.test.ts`

## Problem

`delegateTask()` polled for `results/task-phone-{ts}.txt` and on receipt:
1. ✅ Called `unlinkSync(resultPath)` — result cleaned up
2. ❌ Never touched `taskPath` — task file left in `tasks/` forever

After a day of phone calls, `tasks/` fills with stale `task-phone-*.txt` files. The `task-bridge.ts` archive watcher never cleans them up — it only processes task-bridge-originated tasks.

## Fix

```typescript
/** Move a phone task file to tasks/archive/YYYY-MM/ (mirrors task-bridge archiveFile).
 *  Falls back to unlink so stale files never accumulate in tasks/. */
function archivePhoneTask(taskPath: string, taskId: string): void {
    try {
        if (!existsSync(taskPath)) return;
        const ym = new Date().toISOString().slice(0, 7);
        const destDir = join(TASKS_DIR, 'archive', ym);
        mkdirSync(destDir, { recursive: true });
        renameSync(taskPath, join(destDir, `${taskId}.txt`));
    } catch {
        try { unlinkSync(taskPath); } catch {}
    }
}
```

Called in two places:
1. **Success path**: after `unlinkSync(resultPath)` when the result arrives
2. **Timeout path**: when the 5-min poll timeout fires (task may still be running but session moved on)

## Tests

6/6 pass:
1. `renameSync` imported from `node:fs`
2. `archivePhoneTask` defined and uses `renameSync`
3. Called after `unlinkSync(resultPath)` in success path
4. Called in the timeout path
5. Falls back to `unlinkSync` on rename error
6. Archive destination uses `tasks/archive/YYYY-MM` pattern