### PR TITLE
fix(inline-tools): gate slide_control at exposure on presenter-mode sentinel (#1171)

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -20,6 +20,12 @@ import { resolveWorkspace, statusPath, statusReadPath } from './workspace_defaul
 // resolveWorkspace() is the canonical TS helper introduced in #821.
 const WORKSPACE_DIR = resolveWorkspace();
 
+// Gate slide-control at exposure time: if no presenter-mode sentinel exists,
+// Gemini never sees the slide_control tool description and can't fire it on
+// greetings or filler — closes the spurious tool_call noise reported in #1171.
+const PRESENTER_SENTINEL = join(WORKSPACE_DIR, 'state', 'presenter-mode.sentinel');
+export const presenterModeActive = existsSync(PRESENTER_SENTINEL);
+
 // Code-adjacent paths (skills/, etc.) ship with the repo checkout, NOT the
 // workspace. Compute REPO_ROOT from this file's URL so the resolution
 // survives any cwd drift at startup. Used by the skill-loader below.
@@ -1089,7 +1095,8 @@ export const inlineTools = assertUniqueToolNames([
 	volumeTool, brightnessTool, clipboardTool,
 	cancelTaskTool, toggleTasksTool, getCurrentTimeTool, getCoreStatusTool,
 	joinGmeetTool, lookupMeetingIdTool, callContactTool,
-	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, slideControlTool, fullscreenTool,
+	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, fullscreenTool,
+	...(presenterModeActive ? [slideControlTool] : []),
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
 	recentContextTool,
 	sendVisionFrameTool, startVisionTool, stopVisionTool,
@@ -1110,7 +1117,8 @@ export const ownerOnlyTools = [
 	pressKeyTool, scrollTool, switchTabTool, closeTabTool, openUrlTool,
 	switchAppTool, captureScreenTool, typeTextTool,
 	clipboardTool, cancelTaskTool, toggleTasksTool,
-	joinGmeetTool, callContactTool, slideControlTool, fullscreenTool,
+	joinGmeetTool, callContactTool, fullscreenTool,
+	...(presenterModeActive ? [slideControlTool] : []),
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
 	recentContextTool,
 	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool,

--- a/tests/inline-tools-presenter-gate.test.ts
+++ b/tests/inline-tools-presenter-gate.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Regression guard for the presenter-mode sentinel gate introduced in #1171.
+//
+// Before this fix, `slideControlTool` was unconditionally included in
+// `inlineTools` and `ownerOnlyTools`. Gemini saw its description ("next slide",
+// "previous slide", "go back") on every session turn — including greetings —
+// and fired spurious `tool_call` rows in voice sqlite (3 unprovoked
+// `copres_next_anchor` calls observed in <40s on a "can you hear me?" session).
+//
+// The fix gates EXPOSURE at module load: if `state/presenter-mode.sentinel`
+// is absent, `slideControlTool` is excluded from the tools arrays Gemini sees.
+// Gemini can't fire what it doesn't know about.
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'src/inline-tools.ts'),
+	'utf-8',
+);
+
+describe('inline-tools — presenter-mode sentinel gate (#1171)', () => {
+	it('exports presenterModeActive derived from PRESENTER_SENTINEL existsSync', () => {
+		assert.match(
+			SRC,
+			/export const presenterModeActive\s*=\s*existsSync\(PRESENTER_SENTINEL\)/,
+			'src/inline-tools.ts must export `presenterModeActive = existsSync(PRESENTER_SENTINEL)`.',
+		);
+	});
+
+	it('PRESENTER_SENTINEL points to state/presenter-mode.sentinel under WORKSPACE_DIR', () => {
+		assert.match(
+			SRC,
+			/PRESENTER_SENTINEL\s*=\s*join\(WORKSPACE_DIR,\s*['"]state['"]\s*,\s*['"]presenter-mode\.sentinel['"]\)/,
+			'PRESENTER_SENTINEL must be join(WORKSPACE_DIR, "state", "presenter-mode.sentinel").',
+		);
+	});
+
+	it('slideControlTool is conditionally spread into inlineTools based on presenterModeActive', () => {
+		assert.match(
+			SRC,
+			/\.\.\.\(presenterModeActive\s*\?\s*\[slideControlTool\]\s*:\s*\[\]\)/,
+			'slideControlTool must be spread conditionally: ...(presenterModeActive ? [slideControlTool] : []).',
+		);
+	});
+
+	it('slideControlTool is NOT unconditionally listed in inlineTools or ownerOnlyTools', () => {
+		// The old pattern was a bare `slideControlTool,` inside the array literal.
+		// After the fix both arrays use the spread form — a bare reference must not exist.
+		const toolArrayBlock = SRC.match(/export const inlineTools[\s\S]+?export const anyCallerTools/)?.[0] ?? '';
+		const ownerBlock = SRC.match(/export const ownerOnlyTools[\s\S]+?export const configurableTools/)?.[0] ?? '';
+		const combined = toolArrayBlock + ownerBlock;
+		assert.doesNotMatch(
+			combined,
+			/(?<!\[)slideControlTool(?!\s*\])/,
+			'slideControlTool must not appear bare (without conditional spread) in inlineTools or ownerOnlyTools.',
+		);
+	});
+
+	it('presenterModeActive gate comment references #1171', () => {
+		assert.match(
+			SRC,
+			/#1171/,
+			'src/inline-tools.ts must reference issue #1171 in the gate comment.',
+		);
+	});
+
+	it('presenterModeActive declaration precedes slideControlTool definition', () => {
+		const presenterIdx = SRC.indexOf('export const presenterModeActive');
+		const slideCtrlIdx = SRC.indexOf('export const slideControlTool');
+		assert.ok(
+			presenterIdx !== -1 && slideCtrlIdx !== -1,
+			'both presenterModeActive and slideControlTool must be present in the source',
+		);
+		assert.ok(
+			presenterIdx < slideCtrlIdx,
+			'presenterModeActive must be declared before slideControlTool so the gate reads the sentinel before the tool is defined.',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- `slideControlTool` was unconditionally registered in `inlineTools` and `ownerOnlyTools`, exposing its description ("next slide", "previous slide", "go back") to Gemini on every voice turn including greetings
- Gemini fired spurious `tool_call` rows in voice sqlite — 3 unprovoked `copres_next_anchor` calls in <40s on a "Can you hear me?" session (Lucy's observation 2026-05-26)
- Root cause pattern: inline-tool always-exposure + intent-check-too-late; tool fires before the guard runs → sqlite noise + wasted tokens

## Fix

Gate at exposure time, not effect time. At module load, read `state/presenter-mode.sentinel` via `existsSync`. If absent, `slideControlTool` is excluded from the tool arrays Gemini sees — it can't fire what it doesn't know about. `fullscreenTool` stays ungated (generic OS action, useful outside presentations).

```typescript
const PRESENTER_SENTINEL = join(WORKSPACE_DIR, 'state', 'presenter-mode.sentinel');
export const presenterModeActive = existsSync(PRESENTER_SENTINEL);

// in inlineTools / ownerOnlyTools:
...(presenterModeActive ? [slideControlTool] : [])
```

## Test plan

- [x] 6 structural tests in `tests/inline-tools-presenter-gate.test.ts` — all passing
  - `presenterModeActive` exported and derived from `existsSync(PRESENTER_SENTINEL)`
  - `PRESENTER_SENTINEL` points to `state/presenter-mode.sentinel` under `WORKSPACE_DIR`
  - `slideControlTool` spread conditionally in both `inlineTools` and `ownerOnlyTools`
  - No bare `slideControlTool` reference in either array
  - Issue `#1171` referenced in gate comment
  - `presenterModeActive` declared before `slideControlTool` definition

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)