### PR TITLE
fix(watch-tasks): Mode-A EPIPE + Mode-B PPID-1 orphan guard (#1088)

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -67,13 +67,31 @@ echo "$$" > "$PID_FILE"
 # Cleanup on any exit path (SIGINT, SIGTERM, normal exit) so the file
 # doesn't outlive the process on a clean shutdown. Dirty exits (SIGKILL,
 # panic) skip the trap — the Stop hook + startup reaper cover those.
-trap 'rm -f "$PID_FILE"' EXIT
+# ORPHAN_GUARD_PID is set below; guard may not be spawned yet when the
+# trap fires on very early exit, so coerce to empty if unset (-).
+trap 'rm -f "$PID_FILE"; kill "${ORPHAN_GUARD_PID:-}" 2>/dev/null' EXIT INT TERM
+
+# Mode-B orphan guard (#1088): exit if this watcher is reparented to launchd
+# (PPID=1), which happens when the parent shell exits without SIGTERMing us.
+# Polls every 10 s — cheap stat, catches the PPID=1 case that Mode-A's
+# printf-EPIPE path misses (pipe may still be live even when parent is gone).
+# Uses $$ to name the *main* script's PID (bash passes $$ unchanged into
+# subshells; $BASHPID would give the subshell's own PID).
+(
+  while sleep 10; do
+    ppid="$(ps -o ppid= -p $$ 2>/dev/null | tr -d ' ')"
+    [ "$ppid" = "1" ] && kill "$$" && break
+  done
+) &
+ORPHAN_GUARD_PID=$!
 
 # Initial sweep — surface any pre-existing tasks that arrived during a
 # restart gap.
 shopt -s nullglob
 for f in "$TASKS_DIR"/*.txt; do
-  echo "TASK_FILE: $(basename "$f")"
+  # Mode-A EPIPE guard: printf returns non-zero immediately on broken pipe;
+  # break the loop rather than waiting for kernel buffer to fill (~100 events).
+  printf 'TASK_FILE: %s\n' "$(basename "$f")" || break
 done
 shopt -u nullglob
 
@@ -107,7 +125,10 @@ fswatch \
     *.txt)
       parent="$(dirname "$path")"
       if [ "$parent" = "$TASKS_DIR_ABS" ] && [ -f "$path" ]; then
-        echo "TASK_FILE: $(basename "$path")"
+        # Mode-A EPIPE guard (#1088): printf returns non-zero at the first
+        # failed kernel write — exits the pipeline subshell immediately
+        # rather than buffering ~100 events before the write finally fails.
+        printf 'TASK_FILE: %s\n' "$(basename "$path")" || exit 0
       fi
       ;;
   esac

--- a/tests/watch-tasks-orphan-guard.test.py
+++ b/tests/watch-tasks-orphan-guard.test.py
@@ -1,0 +1,89 @@
+"""
+Regression guard for the two orphan-leak fixes in src/watch-tasks-stream.sh
+(issue #1088).
+
+Mode A (EPIPE-on-dead-reader): watcher used `echo` which silently buffers
+~100 events in the kernel pipe after the consumer dies.  Fix: `printf || exit 0`
+/ `printf || break` — printf returns non-zero immediately on EPIPE.
+
+Mode B (PPID=1 reparenting): parent shell exits without SIGTERMing the watcher;
+watcher lives until host reboot.  Fix: background orphan-guard subshell that
+checks PPID every 10 s and sends SIGTERM when PPID becomes 1.
+"""
+import re
+import sys
+from pathlib import Path
+
+SRC = (Path(__file__).resolve().parent.parent / "src" / "watch-tasks-stream.sh").read_text()
+
+PASS = True
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    global PASS
+    status = "ok" if condition else "FAIL"
+    print(f"[{status}] {name}" + (f" — {detail}" if detail else ""))
+    if not condition:
+        PASS = False
+
+
+# Mode A: printf-EPIPE guard in the streaming loop (main event path)
+check(
+    "streaming loop uses printf || exit 0 (not bare echo) for Mode-A EPIPE",
+    bool(re.search(r"printf\s+'TASK_FILE[^']*'\s+[^|]+\|\|\s+exit\s+0", SRC)),
+    "expect: printf 'TASK_FILE: %s\\n' ... || exit 0",
+)
+
+# Mode A: printf-EPIPE guard in the initial scan
+check(
+    "initial scan uses printf || break (not bare echo) for Mode-A EPIPE",
+    bool(re.search(r"printf\s+'TASK_FILE[^']*'\s+[^|]+\|\|\s+break", SRC)),
+    "expect: printf 'TASK_FILE: %s\\n' ... || break",
+)
+
+# Mode A: no bare `echo "TASK_FILE:` anywhere (all emit paths must use printf)
+check(
+    "no bare echo TASK_FILE remains in the script",
+    "echo \"TASK_FILE:" not in SRC and "echo 'TASK_FILE:" not in SRC,
+    "all TASK_FILE emit lines must use printf, not echo",
+)
+
+# Mode B: orphan guard subshell present
+check(
+    "orphan-guard subshell polls PPID for Mode-B reparenting",
+    bool(re.search(r"ppid=.*ps\s+-o\s+ppid=\s+-p\s+\$\$", SRC)),
+    "expect: ppid=$(ps -o ppid= -p $$) in a background loop",
+)
+
+# Mode B: orphan guard kills the main process when PPID=1
+check(
+    "orphan guard kills $$ when ppid is 1",
+    bool(re.search(r'"\$ppid"\s*=\s*"1".*kill.*\$\$', SRC, re.DOTALL))
+    or bool(re.search(r"\$ppid.*=.*1.*&&.*kill.*\$\$", SRC)),
+    "expect: [ \"$ppid\" = \"1\" ] && kill \"$$\"",
+)
+
+# Mode B: orphan guard PID captured so the EXIT trap can clean it up
+check(
+    "ORPHAN_GUARD_PID captured after background subshell",
+    "ORPHAN_GUARD_PID=$!" in SRC,
+    "expect: ORPHAN_GUARD_PID=$! immediately after ( ... ) &",
+)
+
+# Mode B: EXIT trap kills the orphan guard on clean shutdown
+check(
+    "EXIT trap kills ORPHAN_GUARD_PID on exit",
+    bool(re.search(r"trap.*ORPHAN_GUARD_PID.*EXIT", SRC, re.DOTALL))
+    or bool(re.search(r"kill.*ORPHAN_GUARD_PID.*2>/dev/null.*EXIT", SRC)),
+    "trap must include kill $ORPHAN_GUARD_PID and EXIT",
+)
+
+# Mode B: trap covers TERM so SIGTERM fires the cleanup
+check(
+    "EXIT trap also covers INT and TERM signals",
+    bool(re.search(r"trap\s+'[^']+'\s+EXIT\s+INT\s+TERM", SRC))
+    or bool(re.search(r"trap\s+'[^']+'\s+EXIT.*TERM", SRC)),
+    "expect: trap '...' EXIT INT TERM",
+)
+
+sys.exit(0 if PASS else 1)


### PR DESCRIPTION
## Summary

Two distinct orphan-leak paths confirmed by Lucy's POC script in #1088:

- **Mode A (EPIPE-on-dead-reader)**: `echo` buffers ~100 events in the kernel pipe after the consumer (Monitor tool) dies. At real DM traffic rates (few events/day), this is a silent multi-day gap — events written by the bridge, swallowed before Claude sees them. Root cause of the 4h DM gap on 2026-05-23.
- **Mode B (PPID=1 reparenting)**: parent shell exits without SIGTERMing the watcher; watcher reparented to launchd runs until reboot, dropping every subsequent event.

## Fixes

**Mode A** — replace `echo "TASK_FILE:..."` with `printf 'TASK_FILE: %s\n' "$(basename...)" || exit 0` (loop) / `|| break` (initial scan). `printf` returns non-zero at the first failed kernel write rather than waiting for buffer fill.

**Mode B** — background orphan-guard subshell polls `ps -o ppid= -p $$` every 10s and sends SIGTERM to the main script when PPID becomes 1. EXIT/INT/TERM trap kills the guard and removes the PID file on any shutdown path.

```bash
(
  while sleep 10; do
    ppid="$(ps -o ppid= -p $$ 2>/dev/null | tr -d ' ')"
    [ "$ppid" = "1" ] && kill "$$" && break
  done
) &
ORPHAN_GUARD_PID=$!
trap 'rm -f "$PID_FILE"; kill "${ORPHAN_GUARD_PID:-}" 2>/dev/null' EXIT INT TERM
```

## Test plan

- [x] 8 structural tests in `tests/watch-tasks-orphan-guard.test.py` — all passing
  - Mode-A: `printf || exit 0` in streaming loop
  - Mode-A: `printf || break` in initial scan
  - Mode-A: no bare `echo TASK_FILE` remains
  - Mode-B: orphan-guard subshell polls PPID
  - Mode-B: kills `$$` when PPID=1
  - Mode-B: `ORPHAN_GUARD_PID=$!` captured
  - Mode-B: EXIT trap kills guard
  - Mode-B: trap covers INT and TERM signals

Closes #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)