### PR TITLE
fix(discord-voice): grounding guards — no fake tool narration, no capability hallucination (#1102)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -469,7 +469,11 @@ function buildAgent(s: DiscordVoiceSession): MainAgent {
 			DISCORD_VOICE_GOOGLE_SEARCH
 				? 'NEVER fabricate specific details. If you don\'t know it, use your built-in Web search to look it up — it\'s faster than delegating, and the answer stays in the conversation. If your built-in search returns nothing useful, OR the question needs deeper-than-one-lookup research (multi-step, multiple sources, file reading), call the work tool — it routes to the core agent which can do extensive research.'
 				: 'NEVER fabricate specific details. If you don\'t know it, use the work tool to look it up.',
-			repoUrl ? `\n## Known info\nSutando GitHub repo: ${repoUrl}` : '',
+				// Action-grounding guards — closes #1102 (tool-narration + capability hallucination)
+				'ACTION GROUNDING: When you say you are doing something (e.g. "opening", "searching", "sending"), you MUST invoke the corresponding tool. Do NOT narrate actions you did not perform.',
+				'CAPABILITY GROUNDING: When asked what tools or commands exist, list ONLY those documented in this prompt. If a capability not documented here is mentioned, say you\'re not sure rather than invent.',
+				'UNCERTAINTY: When uncertain about a fact, say "I don\'t know" or "I can look it up" — never guess.',
+				repoUrl ? `\n## Known info\nSutando GitHub repo: ${repoUrl}` : '',
 		].filter(Boolean).join('\n');
 	} else {
 		instructions = [

--- a/tests/discord-voice-grounding-guards.test.ts
+++ b/tests/discord-voice-grounding-guards.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Regression guard for the action-grounding + capability-grounding additions
+// to the discord-voice owner-tier system prompt (issue #1102).
+//
+// Observed on Lucy's server (2026-05-25):
+//   1. False tool narration: voice said "Opening the Sutando repository" with NO
+//      tool_call row in sqlite — model verbally claimed an action it didn't do.
+//   2. Feature invention: voice claimed "Za Warudo" activates "co-presentation
+//      navigation mode" — a fabricated capability that doesn't exist.
+//
+// Fix: three explicit grounding guards added to buildAgent()'s owner-tier
+// instructions block so the model is explicitly told not to narrate fake actions
+// and not to invent undocumented capabilities.
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'skills/discord-voice/scripts/discord-voice-server.ts'),
+	'utf-8',
+);
+
+describe('discord-voice buildAgent — grounding guards (#1102)', () => {
+	it('ACTION GROUNDING guard present: no narrating actions without tool invocation', () => {
+		assert.match(
+			SRC,
+			/ACTION GROUNDING.*MUST invoke the corresponding tool.*Do NOT narrate/s,
+			'discord-voice-server.ts must include the ACTION GROUNDING instruction in buildAgent.',
+		);
+	});
+
+	it('CAPABILITY GROUNDING guard present: list only documented tools/commands', () => {
+		assert.match(
+			SRC,
+			/CAPABILITY GROUNDING.*list ONLY those documented in this prompt/s,
+			'discord-voice-server.ts must include the CAPABILITY GROUNDING instruction in buildAgent.',
+		);
+	});
+
+	it('UNCERTAINTY guard present: say I don\'t know rather than guess', () => {
+		assert.match(
+			SRC,
+			/UNCERTAINTY.*uncertain about a fact.*never guess/s,
+			'discord-voice-server.ts must include the UNCERTAINTY instruction in buildAgent.',
+		);
+	});
+
+	it('grounding guards appear in the owner-tier instructions block (before the else branch)', () => {
+		const ownerBlock = SRC.match(/function buildAgent[\s\S]+?} else \{/)?.[0] ?? '';
+		assert.match(
+			ownerBlock,
+			/ACTION GROUNDING/,
+			'ACTION GROUNDING must be in the owner-tier (if isOwner) block, not the fallback block.',
+		);
+		assert.match(
+			ownerBlock,
+			/CAPABILITY GROUNDING/,
+			'CAPABILITY GROUNDING must be in the owner-tier block.',
+		);
+	});
+
+	it('grounding guards reference issue #1102 in the adjacent comment', () => {
+		assert.match(
+			SRC,
+			/#1102/,
+			'discord-voice-server.ts must reference issue #1102 in the grounding-guard comment.',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Two hallucination types observed by Lucy on 2026-05-25:

1. **False tool narration** — voice said "Opening the Sutando repository" with NO corresponding `tool_call` in sqlite. Model verbally claimed work it didn't do.
2. **Feature invention** — voice claimed "Za Warudo" activates "co-presentation navigation mode." Actual function: summon discord-voice into voice channel. The capability described was entirely fabricated.

## Fix

Three explicit grounding guards added to `buildAgent()`'s owner-tier instructions block in `discord-voice-server.ts`:

```typescript
'ACTION GROUNDING: When you say you are doing something (e.g. "opening", "searching", "sending"), you MUST invoke the corresponding tool. Do NOT narrate actions you did not perform.',
'CAPABILITY GROUNDING: When asked what tools or commands exist, list ONLY those documented in this prompt. If a capability not documented here is mentioned, say you\'re not sure rather than invent.',
'UNCERTAINTY: When uncertain about a fact, say "I don\'t know" or "I can look it up" — never guess.',
```

These complement the existing `NEVER fabricate specific details` line with the action-grounding half: what the model says it's doing must match what it actually invokes.

## Test plan

- [x] 5 structural tests in `tests/discord-voice-grounding-guards.test.ts` — all passing
  - ACTION GROUNDING present with "MUST invoke" + "Do NOT narrate"
  - CAPABILITY GROUNDING present with "list ONLY those documented"
  - UNCERTAINTY present with "never guess"
  - All three guards in owner-tier block (not fallback block)
  - Issue #1102 referenced in adjacent comment

Closes #1102

🤖 Generated with [Claude Code](https://claude.com/claude-code)