### PR TITLE
fix(post-migration): voice-agent + stage-readiness workspace-path leftovers

### DIFF
--- a/scripts/stage-readiness.sh
+++ b/scripts/stage-readiness.sh
@@ -167,8 +167,20 @@ if [ -n "${AVAIL_GB:-}" ]; then
     fi
 fi
 
-# 8) memory-sync age
-SYNC_HEAD="$HOME/.sutando-memory-sync/.git/FETCH_HEAD"
+# 8) memory-sync age — resolve memory dir per the workspace contract:
+# $SUTANDO_MEMORY_DIR (canonical, since #870) → $SUTANDO_PRIVATE_DIR (legacy
+# alias) → default $HOME/.sutando/memory-sync. Fall back to the pre-migration
+# $HOME/.sutando-memory-sync only when no nested dir exists yet (older hosts
+# that haven't moved over).
+MEMORY_DIR="${SUTANDO_MEMORY_DIR:-${SUTANDO_PRIVATE_DIR:-}}"
+if [ -z "$MEMORY_DIR" ]; then
+    if [ -d "$HOME/.sutando/memory-sync" ]; then
+        MEMORY_DIR="$HOME/.sutando/memory-sync"
+    else
+        MEMORY_DIR="$HOME/.sutando-memory-sync"
+    fi
+fi
+SYNC_HEAD="$MEMORY_DIR/.git/FETCH_HEAD"
 if [ -f "$SYNC_HEAD" ]; then
     age_sec=$(($(date +%s) - $(stat_mtime "$SYNC_HEAD")))
     age_h=$((age_sec / 3600))

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -272,8 +272,8 @@ let meetingActive = false;
 // Presenter mode is tracked separately by the iclr-highlight server on :7877.
 function writeVoiceModeSentinel() {
 	try {
-		mkdirSync('state', { recursive: true });
-		writeFileSync('state/voice-mode.txt', meetingActive ? 'meeting' : 'active');
+		mkdirSync(join(WORKSPACE_DIR, 'state'), { recursive: true });
+		writeFileSync(join(WORKSPACE_DIR, 'state', 'voice-mode.txt'), meetingActive ? 'meeting' : 'active');
 	} catch {}
 }
 
@@ -283,8 +283,9 @@ function writeVoiceModeSentinel() {
 // apply so requests don't re-fire.
 function applyModeRequest() {
 	try {
-		const req = readFileSync('state/voice-mode.request', 'utf-8').trim().toLowerCase();
-		unlinkSync('state/voice-mode.request');
+		const reqPath = join(WORKSPACE_DIR, 'state', 'voice-mode.request');
+		const req = readFileSync(reqPath, 'utf-8').trim().toLowerCase();
+		unlinkSync(reqPath);
 		const want = req === 'meeting';
 		if (meetingActive === want) return; // no-op if already in that mode
 		meetingActive = want;


### PR DESCRIPTION
## Workspace-migration cleanup (2 of 3)

Two small post-migration fixes from the workspace-migration audit (2026-05-27) — one commit each on a single branch so you can review/squash as one PR.

### Commit 1: `voice-agent.ts` — `state/voice-mode.{txt,request}` workspace-absolute

Three relative paths at `src/voice-agent.ts:275-287` didn't use `WORKSPACE_DIR` (already imported via `resolveWorkspace()` at line 109). When voice-agent's cwd differs from `$SUTANDO_WORKSPACE`, the sentinel files landed in the wrong location and the menu-bar / web-client readers saw stale state.

Fix: `join(WORKSPACE_DIR, 'state', ...)` consistently, matching the rest of the file.

### Commit 2: `scripts/stage-readiness.sh` — `$SUTANDO_MEMORY_DIR` resolution

Line 171 hardcoded `$HOME/.sutando-memory-sync/.git/FETCH_HEAD` (pre-#870 path). Post-migration the canonical location is `$HOME/.sutando/memory-sync/`, so the probe always missed `FETCH_HEAD` on migrated hosts and the memory-sync age check silently passed regardless of actual sync state.

Fix: same resolution chain documented in `CLAUDE.md` —

    $SUTANDO_MEMORY_DIR → $SUTANDO_PRIVATE_DIR (legacy alias) → $HOME/.sutando/memory-sync
                                                                 (fallback: $HOME/.sutando-memory-sync)

The existing warn-branch at lines 188-192 already shows whichever sync-script path actually exists, so user-facing messaging stays correct.

### What's NOT in this PR

The audit also listed `src/init.sh:182-208` as a candidate (relative `state/`-creation paths). On re-inspection, `create_dir_if_missing` / `create_file_if_missing` already use `$WORKSPACE/$path` internally, so the relative argument is correct — no change needed.

### Verified locally

- `tsc --noEmit` — clean
- `bash -n scripts/stage-readiness.sh` — clean
- Resolution test on this host: `SYNC_HEAD = /Users/wangchi/.sutando/memory-sync/.git/FETCH_HEAD` (exists ✓)

### Audit reference

`~/.sutando/workspace/notes/workspace-migration-audit-2026-05-27.md` — Sections 1 + 7a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
