### PR TITLE
[workspace-migration] fix(env-lookup): read .env from source tree, not workspace (3 sites)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -57,6 +57,11 @@ import discord_config  # noqa: E402  — Sutando workspace-local discord config 
 from util_paths import shared_personal_path  # noqa: E402
 from task_priority import default_priority_for_source  # noqa: E402
 REPO = resolve_workspace()
+# Source-tree root for reading checked-in files like .env (which lives
+# at `<repo>/.env`, NOT under workspace). The misnamed `REPO` var above
+# actually holds workspace per the historical refactor; P3 will rename.
+# Pattern matches src/github-webhook.py per qingyun review on PR #775.
+_SRC_TREE = Path(__file__).resolve().parent.parent
 
 # discord-voice "magic word" join trigger (issue: za-warudo summon). The
 # bridge stays a THIN hook — it only detects "owner + join phrase" and hands
@@ -466,7 +471,7 @@ def presenter_mode_active():
 TEAM_TIER_OWNER = ""
 LOCAL_MACHINE = ""
 try:
-    env_file = REPO / ".env"
+    env_file = _SRC_TREE / ".env"
     if env_file.exists():
         for line in env_file.read_text().splitlines():
             if line.startswith("SUTANDO_TEAM_TIER_OWNER="):

--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -36,6 +36,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402
 import discord_config  # noqa: E402  — workspace-local Sutando discord config (#1147)
 REPO = resolve_workspace()
+# Source-tree root for reading checked-in files like .env (which lives
+# at `<repo>/.env`, NOT under workspace). The misnamed `REPO` above
+# actually holds workspace; P3 will rename. Pattern from
+# src/github-webhook.py per qingyun review on PR #775.
+_SRC_TREE = Path(__file__).resolve().parent.parent
 ACCESS_JSON = Path.home() / ".claude" / "channels" / "discord" / "access.json"
 SSE_STATUS_URL = "http://localhost:8080/sse-status"
 
@@ -184,7 +189,7 @@ def _load_token() -> str:
     """Read DISCORD_BOT_TOKEN from the first env file that has it."""
     for env_path in [
         Path.home() / ".claude" / "channels" / "discord" / ".env",
-        REPO / ".env",
+        _SRC_TREE / ".env",
     ]:
         if not env_path.exists():
             continue

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -37,6 +37,11 @@ from workspace_default import resolve_workspace  # noqa: E402
 REPO = resolve_workspace()
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
+# Source-tree root for reading checked-in files like .env (which lives
+# at `<repo>/.env`, NOT under workspace). The misnamed `REPO` above
+# actually holds workspace; P3 will rename. Pattern from
+# src/github-webhook.py per qingyun review on PR #775.
+_SRC_TREE = Path(__file__).resolve().parent.parent
 
 # Allowlist for paths that may be sent via Telegram [file: /path] markers.
 # Mirrors _is_path_sendable() in discord-bridge.py.
@@ -75,7 +80,7 @@ def _is_path_sendable(fpath: str) -> bool:
 
 try:
     from dotenv import load_dotenv
-    load_dotenv(REPO / ".env")
+    load_dotenv(_SRC_TREE / ".env")
 except ImportError:
     pass  # python-dotenv not installed — token loaded from channels config below
 


### PR DESCRIPTION
## Summary

3 sites silently fail to load `.env` because they look up at `REPO / ".env"` where `REPO = resolve_workspace()` (variable name lies — actually returns workspace, not source tree). `.env` lives in the **source-tree root** (`<repo>/.env`), NOT under workspace.

| Site | Symptom |
|------|---------|
| `src/discord-bridge.py:469` | `TEAM_TIER_OWNER` env never loaded → access-tier detection broken |
| `src/telegram-bridge.py:78` | `load_dotenv` miss → Telegram token only works if shell env happened to have it |
| `src/dm-result.py:186-188` | REST-fallback path's `DISCORD_BOT_TOKEN` lookup miss |

All three are same #1149-class root: the misleadingly-named `REPO` variable holds workspace, but the call sites assumed it was source-tree.

Identified during the 2026-05-27 workspace-contract audit; PoCs at `notes/cwd-poc-v3-1-src.md`.

## Fix

Introduce a separate `_SRC_TREE = Path(__file__).resolve().parent.parent` constant in each file, alongside the existing (misleadingly-named) `REPO`. The `.env` reads now use `_SRC_TREE`.

```diff
+# Source-tree root for reading checked-in files like .env...
+_SRC_TREE = Path(__file__).resolve().parent.parent
 ...
-    env_file = REPO / ".env"
+    env_file = _SRC_TREE / ".env"
```

Pattern matches `src/github-webhook.py:30-38` per @qingyun-wu review on PR #775 (explicit two-name distinction: source-tree-for-code vs workspace-for-state).

**Minimal-diff approach**: leaves `REPO = resolve_workspace()` lines as-is for now. The full rename `REPO → WORKSPACE_DIR` is part of the cosmetic P3 batch (88 cosmetic items from v3 audit). Just adds one new constant + changes 3 buggy call sites. Per-file: +7 / -1.

## Tested

- All three modules still import without error after change (smoke test confirmed)
- Diff is mechanical: same `_SRC_TREE` pattern in each file's header + the `.env` site swap

## Related

- v3 audit: `notes/cwd-audit-v3-2026-05-27.md`
- PR #1271 — `sutando-migrate.sh` (existing-user migration)
- PR #1272 — `check-pending-tasks.sh` (Stop hook same class)
- PR #1273 — `state-paths-adoption.test` widened to scripts/+.sh
- #1149 — original workspace-contract data-loss incident
- #1263 — voice-agent state/voice-mode.request cwd-relative (same class)

— Lucy (Mac Studio bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)