### PR TITLE
[workspace-migration] fix(workspace-paths): notify.sh + session-handoff.sh read/write workspace, not repo

### DIFF
--- a/src/notify.sh
+++ b/src/notify.sh
@@ -11,6 +11,11 @@ MSG="$1"
 if [ -z "$MSG" ]; then echo "Usage: bash src/notify.sh 'message'"; exit 1; fi
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# Workspace dir for runtime state writes (proactive-*.txt is per-user state,
+# polled by the workspace-aware bridges per docs/workspace-contract.md).
+# Writing to REPO_DIR/results/ left messages stranded (the watcher polls
+# $SUTANDO_WORKSPACE/results/), same #1149-class as PR #1263.
+WORKSPACE_DIR="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
 TS=$(date +%s%3N)
 
 # Load tokens from channel configs
@@ -19,7 +24,8 @@ DISCORD_USER_ID=$(python3 -c "import json; print(json.load(open('$HOME/.claude/c
 
 # 1. Voice — write proactive message if voice agent is up
 if curl -s -o /dev/null -w "%{http_code}" http://localhost:9900 2>/dev/null | grep -q "426"; then
-  echo "$MSG" > "$REPO_DIR/results/proactive-$TS.txt"
+  mkdir -p "$WORKSPACE_DIR/results"
+  echo "$MSG" > "$WORKSPACE_DIR/results/proactive-$TS.txt"
 fi
 
 # 2. Discord DM

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -64,9 +64,12 @@ print(personal_path('pending-questions.md', Path('$REPO')))
   fi
   echo ""
 
-  # Tasks in flight
+  # Tasks in flight — canonical home is workspace per docs/workspace-contract.md.
+  # Reading from $REPO/tasks/ silently misses the live workspace queue on
+  # workspace-pinned installs (same #1149-class as PR #1263, PR #1272).
   echo "## Tasks"
-  ls "$REPO/tasks/"*.txt 2>/dev/null | head -5 || echo "None pending"
+  __WS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+  ls "$__WS/tasks/"*.txt 2>/dev/null | head -5 || echo "None pending"
   echo ""
 
   # Quota (with reset times)


### PR DESCRIPTION
## Summary

Two more #1149-class fixes flagged by the 2026-05-27 workspace-contract audit (`notes/cwd-audit-v3-1-src.md`):

| Site | Symptom |
|------|---------|
| `src/notify.sh:22` | Proactive messages written to `$REPO_DIR/results/`; watcher polls `$SUTANDO_WORKSPACE/results/` → notifications silently stranded |
| `src/session-handoff.sh:69` | `ls "$REPO/tasks/"*.txt` reads legacy in-repo tasks dir, misses live workspace queue (same observable as PR #1272 Stop hook bug) |

## Fix

Both files now resolve `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}` and use it for the runtime-state paths. `REPO_DIR`/`REPO` is preserved for legitimate source-tree concerns (session-handoff's git log + `health-check.py` invocations).

```diff
# notify.sh
+WORKSPACE_DIR="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
 ...
 if curl -s -o /dev/null -w "%{http_code}" http://localhost:9900 ... ; then
-  echo "$MSG" > "$REPO_DIR/results/proactive-$TS.txt"
+  mkdir -p "$WORKSPACE_DIR/results"
+  echo "$MSG" > "$WORKSPACE_DIR/results/proactive-$TS.txt"
 fi

# session-handoff.sh
   echo "## Tasks"
-  ls "$REPO/tasks/"*.txt 2>/dev/null | head -5 || echo "None pending"
+  __WS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+  ls "$__WS/tasks/"*.txt 2>/dev/null | head -5 || echo "None pending"
```

Each file: ~5-7 line diff. notify.sh additionally `mkdir -p` the workspace `results/` to handle fresh installs.

## Tested

- `bash -n` both files: syntax OK
- Manual: on this install, `bash src/session-handoff.sh /tmp/fakeTranscript.md 2>&1 | grep -A2 'Tasks'` now lists actual workspace tasks instead of empty `(None pending)` from stale repo dir

## Related

- v3 audit: `notes/cwd-audit-v3-1-src.md`
- PR #1271 — `sutando-migrate.sh`
- PR #1272 — `check-pending-tasks.sh` (same class, Stop hook)
- PR #1273 — state-paths-adoption.test widened to `scripts/+.sh`
- PR #1274 — `.env` lookup × 3 bridges (WIP per owner)
- #1149 — original workspace-contract data-loss
- #1263 — voice-agent post-migration leftover

Voice-agent.ts:641 bare relative `voice-context.txt` deferred to a separate PR — that one has interaction with the personal-skill symlink + memory-dir fallback that needs more design thought.

— Lucy (Mac Studio bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)