### PR TITLE
[workspace-migration] fix(scripts): 5 sh scripts read/write workspace state, not repo (P1 batch)

### DIFF
--- a/scripts/presenter-mode.sh
+++ b/scripts/presenter-mode.sh
@@ -25,8 +25,13 @@
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-SENTINEL="$REPO/state/presenter-mode.sentinel"
-mkdir -p "$REPO/state"
+# Sentinel is workspace state per docs/workspace-contract.md (state/ lives
+# under $SUTANDO_WORKSPACE, NOT under repo). Pre-fix the sentinel was written
+# to repo/state/, but bridge consumers (discord-bridge, check-pending-questions)
+# read from workspace/state/ — silent split-brain (v3 audit 2026-05-27).
+WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+SENTINEL="$WORKSPACE/state/presenter-mode.sentinel"
+mkdir -p "$WORKSPACE/state"
 
 cmd="${1:-status}"
 

--- a/scripts/query-conversation.sh
+++ b/scripts/query-conversation.sh
@@ -11,7 +11,12 @@
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-DB="${SUTANDO_CONVERSATION_DB:-$REPO_DIR/data/conversation.sqlite}"
+# data/ is workspace state per docs/workspace-contract.md, NOT under repo.
+# The sibling import-conversation-log.py correctly resolves data/ via workspace;
+# query-conversation.sh diverged and pointed at repo/data/ which is stale.
+# v3 audit 2026-05-27.
+WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+DB="${SUTANDO_CONVERSATION_DB:-$WORKSPACE/data/conversation.sqlite}"
 
 if [[ ! -f "$DB" ]]; then
 	echo "error: $DB does not exist yet — no conversations recorded" >&2

--- a/scripts/results-health.sh
+++ b/scripts/results-health.sh
@@ -28,7 +28,11 @@ for arg in "$@"; do
 done
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-RESULTS="$REPO/results"
+# results/ is workspace state per docs/workspace-contract.md, NOT under repo.
+# Pre-fix scanned repo/results/ which is stale legacy on workspace-pinned
+# installs; workspace/results/ is where the active queue lives (v3 audit).
+WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+RESULTS="$WORKSPACE/results"
 
 if [ ! -d "$RESULTS" ]; then
 	[ "$QUIET" -eq 0 ] && echo "results/ missing — nothing to check"

--- a/scripts/stage-readiness.sh
+++ b/scripts/stage-readiness.sh
@@ -21,6 +21,10 @@
 set -uo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
+# Workspace dir for runtime state (logs/, state/) per docs/workspace-contract.md.
+# Pre-fix the log+sentinel reads pointed at repo/logs/ + repo/state/ which are
+# stale legacy on workspace-pinned installs (v3 audit 2026-05-27).
+WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
 QUIET=0
 for arg in "$@"; do case "$arg" in -q|--quiet) QUIET=1 ;; esac; done
 
@@ -46,7 +50,7 @@ fail() { printf "  \033[31m✗ FAIL\033[0m  %-${WIDTH}s %s\n" "$1" "$2"; FAIL=$(
 # 1) voice-agent
 if lsof -iTCP:9900 -sTCP:LISTEN >/dev/null 2>&1; then
     # Check for a Health tick in the last 60s.
-    VLOG="$REPO/logs/voice-agent.log"
+    VLOG="$WORKSPACE/logs/voice-agent.log"
     if [ -f "$VLOG" ] && [ $(($(date +%s) - $(stat_mtime "$VLOG"))) -lt 60 ]; then
         pass "voice-agent" "port 9900 listening, log fresh (<60s)"
     else
@@ -61,7 +65,7 @@ fi
 # so a raw grep will always report historical FATALs from before a prior fix
 # was installed and fail this check forever. Use the last "Watching for
 # context drops" line as the startup marker; count FATALs only after it.
-VLOG="$REPO/logs/voice-agent.log"
+VLOG="$WORKSPACE/logs/voice-agent.log"
 if [ -f "$VLOG" ]; then
     last_start=$(grep -n "Watching for context drops" "$VLOG" 2>/dev/null | tail -1 | cut -d: -f1)
     last_start="${last_start:-1}"
@@ -126,7 +130,7 @@ fi
 # check-pending-questions (PR #432 fixup). String comparison treats "garbage" as
 # GREATER than any real ISO timestamp — without the digit-prefix guard, malformed
 # sentinel content would appear active forever.
-SENT="$REPO/state/presenter-mode.sentinel"
+SENT="$WORKSPACE/state/presenter-mode.sentinel"
 if [ -f "$SENT" ]; then
     expire_iso=$(cat "$SENT")
     now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/scripts/tail-events.sh
+++ b/scripts/tail-events.sh
@@ -13,6 +13,10 @@
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Logs are workspace state per docs/workspace-contract.md, not under repo.
+# Pre-fix tail-events read repo/logs/ which is stale; canonical home is
+# $SUTANDO_WORKSPACE/logs/ (v3 audit 2026-05-27).
+WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
 DATE="$(date +%Y-%m-%d)"
 TAIL_N=20
 FOLLOW=true
@@ -28,7 +32,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-LOG_FILE="$REPO/logs/events-$DATE.jsonl"
+LOG_FILE="$WORKSPACE/logs/events-$DATE.jsonl"
 
 if [[ ! -f "$LOG_FILE" ]]; then
     echo "tail-events: no file at $LOG_FILE" >&2


### PR DESCRIPTION
## Summary

5 `scripts/*.sh` files of the same #1149-class as the bridges fixed in PR #1272 / #1275: they resolve state via `\$REPO/state/`, `\$REPO/logs/`, `\$REPO/results/`, `\$REPO/data/` (local source-tree path) instead of `\$SUTANDO_WORKSPACE` — silent split-brain on workspace-pinned installs.

## Sites fixed

| File | Pre-fix | Symptom |
|------|---------|---------|
| `scripts/presenter-mode.sh:28-29,45,52,63,68` | sentinel at `\$REPO/state/presenter-mode.sentinel` | Bridges read sentinel from workspace; writer used repo → **presenter mode never actually muted anything** |
| `scripts/results-health.sh:31,33-55` | scans `\$REPO/results/` | Health metric counted stale repo dir, ignored live workspace queue |
| `scripts/stage-readiness.sh:49,64,129` | voice-agent log + sentinel via `\$REPO` | Pre-flight checks read empty repo dirs, false WARNs on log staleness |
| `scripts/tail-events.sh:31` | event log tail from `\$REPO/logs/` | Tail target empty on workspace-pinned installs |
| `scripts/query-conversation.sh:14` | sqlite DB default `\$REPO_DIR/data/` | Diverged from sibling `import-conversation-log.py` which correctly resolves workspace |

## Fix shape (mechanical, same pattern across all 5)

Keep `REPO` (legitimate source-tree concerns like `.env`, `sys.path` inserts) and add a parallel:

```bash
WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
```

Then state/data/logs/results reads/writes use `\$WORKSPACE` instead of `\$REPO`. Per-file: 5-10 line diff.

## Tested

- `bash -n` on all 5 files: syntax OK
- Each file's previously-known stale-output condition resolved on this install (e.g. `bash scripts/presenter-mode.sh status` now reads workspace/state/, sees the actual sentinel state instead of always reporting "inactive")

## Followup

These 5 scripts are currently in the ALLOWLIST in `tests/state-paths-adoption.test.py` (PR #1273). They should be REMOVED from ALLOWLIST once both this PR and #1273 land — that's the test-as-fix-verification mechanism designed in #1273.

## Related

- v3 audit: `notes/cwd-audit-v3-2-scripts.md`
- #1149 / #1263 — original incidents
- PR #1271 — `sutando-migrate.sh`
- PR #1272 — `check-pending-tasks.sh` (same class)
- PR #1273 — CI gate widened (these 5 currently allowlisted)
- PR #1274 — `.env` lookup × 3 bridges (WIP)
- PR #1275 — `notify.sh` + `session-handoff.sh` (same class)

— Lucy (Mac Studio bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)