### PR TITLE
[workspace-migration] fix(deal-finder): RESULTS_DIR resolves via workspace, not misnamed REPO_ROOT

### DIFF
--- a/skills/deal-finder/scripts/scan.py
+++ b/skills/deal-finder/scripts/scan.py
@@ -26,11 +26,19 @@ import urllib.request
 from pathlib import Path
 
 SKILL_DIR = Path(__file__).resolve().parents[1]
-WORKSPACE = SKILL_DIR.parents[1]
+# Misleading var name in the pre-fix code: `WORKSPACE = SKILL_DIR.parents[1]`
+# computed to the REPO root, not the workspace. The .env load (load_env below)
+# correctly wants the repo path so it stays here under a clearer name. Per
+# docs/workspace-contract.md, `results/` lives at $SUTANDO_WORKSPACE, NOT under
+# repo — fixed by resolving via the canonical helper.
+REPO_ROOT = SKILL_DIR.parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+from workspace_default import resolve_workspace  # noqa: E402
+_WORKSPACE = resolve_workspace()
 STATE_DIR = SKILL_DIR / "state"
 SEEN_PATH = STATE_DIR / "seen.json"
 CRITERIA_PATH = STATE_DIR / "criteria.json"
-RESULTS_DIR = WORKSPACE / "results"
+RESULTS_DIR = _WORKSPACE / "results"
 
 UA = (
     "Sutando-Personal-Agent/1.0 "
@@ -46,7 +54,7 @@ HDRS = {
 
 def load_env():
     env = {}
-    env_path = WORKSPACE / ".env"
+    env_path = REPO_ROOT / ".env"
     if env_path.exists():
         for line in env_path.read_text().splitlines():
             line = line.strip()


### PR DESCRIPTION
## Summary

`skills/deal-finder/scripts/scan.py` had a misleading `WORKSPACE` variable (`SKILL_DIR.parents[1]` = repo root, NOT the workspace). The `RESULTS_DIR` derived from it landed Telegram proactive notifications at `<repo>/results/` while the bridge polls `<workspace>/results/` → silent stranding (v3 audit #1149-class).

## Fix

- Rename misleading `WORKSPACE` → `REPO_ROOT` (true content)
- Add real `_WORKSPACE = resolve_workspace()` for state writes
- `RESULTS_DIR = _WORKSPACE / 'results'` (canonical bridge-polled path)
- `load_env`: keep `REPO_ROOT / '.env'` (correct, .env is at repo root per workspace-design.md §5)
- STATE_DIR stays at skills/deal-finder/state/ — skill-local state is a separate design question; defer.

## Empirical verification

```
$ python3 -c "... import scan; print(scan.RESULTS_DIR)"
RESULTS_DIR: /Users/.../.sutando/workspace/results   ← now correct
REPO_ROOT:   /Users/.../Documents/sutando/sutando
STATE_DIR:   /Users/.../skills/deal-finder/state
```

## Related

- v3 audit: notes/cwd-poc-v3-3-skills-ai.md (deal-finder × 4)
- PR #1271-#1277 sibling batches

— Lucy (Mac Studio bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)