### PR TITLE
[workspace-migration] fix(self-diagnose): gather scripts read workspace state, not repo (6 sites)

### DIFF
--- a/skills/self-diagnose/scripts/gather-remote.sh
+++ b/skills/self-diagnose/scripts/gather-remote.sh
@@ -248,7 +248,7 @@ DIFF_MD="$OUT/diff.md"
 } > "$DIFF_MD"
 
 # 5) Persist a copy of the diff under notes/ for review later.
-PERSIST="$LOCAL_REPO/notes/diagnose-cross-node-$(date +%Y-%m-%d).md"
+PERSIST="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/notes/diagnose-cross-node-$(date +%Y-%m-%d).md"
 cp "$DIFF_MD" "$PERSIST" 2>/dev/null || true
 
 echo "" >&2

--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -52,6 +52,11 @@ if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
 else
 	NOTES_DIR="$REPO/notes"
 fi
+# Lift workspace into a single var (parallels the NOTES_DIR pattern above).
+# build_log.md, pending-questions.md, logs/, results/ all live at workspace
+# per docs/workspace-contract.md — pre-fix gather.sh read them from $REPO and
+# produced empty/stale output on workspace-pinned installs (v3 audit 2026-05-27).
+WS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
 
 # Convert window to seconds for log filtering
 case "$WINDOW" in
@@ -97,13 +102,13 @@ if [ -n "$GH" ]; then
 fi
 
 # 3) Build log tail + pending questions + cold-review log (small files, copy whole)
-tail -150 "$REPO/build_log.md" > "$OUT/build_log-tail.md" 2>/dev/null || true
-cp "$REPO/pending-questions.md" "$OUT/pending-questions.md" 2>/dev/null || true
+tail -150 "$WS/build_log.md" > "$OUT/build_log-tail.md" 2>/dev/null || true
+cp "$WS/pending-questions.md" "$OUT/pending-questions.md" 2>/dev/null || true
 cp "$NOTES_DIR/cold-review-log.md" "$OUT/cold-review-log.md" 2>/dev/null || true
 
 # 4) Voice-agent log — filter to window, grep for signal lines, keep it bounded.
 # Signals: transport closes (1006/1011/1007/1008), errors, GoAway, setup complete, 1006/1011 numeric.
-VLOG="$REPO/logs/voice-agent.log"
+VLOG="$WS/logs/voice-agent.log"
 if [ -f "$VLOG" ]; then
 	awk -v since="$SINCE_ISO" '
 		# Approximate filter: log lines start with HH:MM:SS — we can'"'"'t easily compare dates,
@@ -116,7 +121,7 @@ if [ -f "$VLOG" ]; then
 fi
 
 # 5) Discord bridge log — last 200 non-dm-fallback lines
-DLOG="$REPO/logs/discord-bridge.log"
+DLOG="$WS/logs/discord-bridge.log"
 if [ -f "$DLOG" ]; then
 	grep -v "\[dm-fallback\]" "$DLOG" 2>/dev/null | tail -200 > "$OUT/discord-bridge-recent.txt" || true
 fi
@@ -130,7 +135,7 @@ fi
 # Use -mmin against SECONDS_AGO (not `-newer meta.txt` — meta.txt was created
 # at gather-start, so that would only match files written DURING the gather,
 # not files in the last $WINDOW).
-find "$REPO/results" -maxdepth 1 -type f -name "*.txt" -mmin "-$((SECONDS_AGO/60))" 2>/dev/null | head -20 > "$OUT/results-recent-paths.txt" || true
+find "$WS/results" -maxdepth 1 -type f -name "*.txt" -mmin "-$((SECONDS_AGO/60))" 2>/dev/null | head -20 > "$OUT/results-recent-paths.txt" || true
 
 # 8) Quota state
 if [ -f "$HOME/.claude/skills/quota-tracker/scripts/read-quota.py" ]; then


### PR DESCRIPTION
## Summary

`/self-diagnose`'s gather scripts pulled diagnostic state FROM `$REPO/` — all 6 sites should resolve via `$SUTANDO_WORKSPACE` per docs/workspace-contract.md. On workspace-pinned installs the output was silently empty/stale:

- build_log-tail.md: 0 lines ($REPO/build_log.md is stale)
- pending-questions.md: missing (file isn't in repo)
- voice-agent-size: missing ($REPO/logs/voice-agent.log doesn't exist)
- results-recent-paths.txt: empty (scanned empty $REPO/results)

## Sites fixed

| File | L# | Var | Fix |
|------|-----|-----|-----|
| gather.sh | 100 | build_log.md | $REPO → $WS |
| gather.sh | 101 | pending-questions.md | $REPO → $WS |
| gather.sh | 106 | VLOG | $REPO → $WS |
| gather.sh | 119 | DLOG | $REPO → $WS |
| gather.sh | 133 | results/ scan | $REPO → $WS |
| gather-remote.sh | 251 | PERSIST notes path | $LOCAL_REPO → workspace |

## Fix

`gather.sh`: add `WS=${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}` at top (parallels existing `NOTES_DIR` resolution above L50-54).
`gather-remote.sh`: inline env-or-default at single use site.

## Empirical verification

```
$ bash skills/self-diagnose/scripts/gather.sh 1h
build_log-tail.md: 150 lines           (was 0)
pending-questions.md: 80 bytes present  (was missing)
voice-agent-size: 1721 lines of workspace/logs/voice-agent.log
                                        (was missing — repo had no log)
```

## Related

- v3 audit: notes/cwd-poc-v3-5-rest.md
- PR #1271-#1278 sibling P0/P1 batches

— Lucy (Mac Studio bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)