### PR TITLE
[workspace-migration] fix(marketing skills): TTS + viral-video outputs land in workspace, not repo (5 sites)

### DIFF
--- a/skills/gemini-tts/scripts/synthesize.sh
+++ b/skills/gemini-tts/scripts/synthesize.sh
@@ -24,11 +24,14 @@ TEXT="${ARGS[*]-}"
 [[ -n "$TEXT" ]] || { echo "Usage: synthesize.sh [--voice <name>] [--out <path>] [--model <id>] -- \"text\"" >&2; exit 2; }
 
 REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+# results/ lives at workspace per docs/workspace-contract.md; .env stays at
+# repo per §5 (Code-adjacent secrets). v3 audit #1149-class.
+WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
 KEY="${GEMINI_API_KEY:-$(grep -E '^GEMINI_API_KEY=' "$REPO/.env" 2>/dev/null | cut -d= -f2-)}"
 KEY="${KEY%\"}"; KEY="${KEY#\"}"; KEY="${KEY%\'}"; KEY="${KEY#\'}"
 [[ -n "$KEY" ]] || { echo "GEMINI_API_KEY missing (set env or add to .env)" >&2; exit 1; }
 
-[[ -n "$OUT" ]] || OUT="$REPO/results/gemini-tts-$(date +%s).mp3"
+[[ -n "$OUT" ]] || OUT="$WORKSPACE/results/gemini-tts-$(date +%s).mp3"
 mkdir -p "$(dirname "$OUT")"
 
 # Gemini TTS API: generateContent with audio modality + voice config

--- a/skills/make-viral-video/scripts/asset_cache.py
+++ b/skills/make-viral-video/scripts/asset_cache.py
@@ -41,8 +41,13 @@ from typing import Optional
 
 
 REPO = Path(__file__).resolve().parents[3]
-CACHE_DIR = REPO / "state" / "viral-cache" / "fetched_assets"
-INDEX_FILE = REPO / "state" / "viral-cache" / "index.json"
+# state/ lives at $SUTANDO_WORKSPACE per docs/workspace-contract.md, not under repo.
+# Pre-fix cache + index landed in <repo>/state/viral-cache/ polluting git status
+# on workspace-pinned installs (v3 audit #1149-class).
+import os as _os
+_WORKSPACE = Path(_os.environ.get("SUTANDO_WORKSPACE") or (Path.home() / ".sutando" / "workspace"))
+CACHE_DIR = _WORKSPACE / "state" / "viral-cache" / "fetched_assets"
+INDEX_FILE = _WORKSPACE / "state" / "viral-cache" / "index.json"
 
 
 def _ensure_cache_dir():

--- a/skills/make-viral-video/scripts/build.sh
+++ b/skills/make-viral-video/scripts/build.sh
@@ -15,6 +15,9 @@ set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
 SKILL_DIR="$REPO/skills/make-viral-video"
+# state/ + viral-* output dirs live under workspace per docs/workspace-contract.md.
+# Pre-fix the output landed in <repo>/state/ polluting git status (v3 audit).
+WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
 
 TOPIC=""
 SOURCE_URL=""
@@ -41,7 +44,7 @@ done
 [[ -n "$TOPIC" ]] || { echo "ERROR: --topic required" >&2; exit 2; }
 [[ -n "$SOURCE_URL" ]] || { echo "ERROR: --source required" >&2; exit 2; }
 
-[[ -n "$OUT_DIR" ]] || OUT_DIR="$REPO/state/viral-$(date +%s)"
+[[ -n "$OUT_DIR" ]] || OUT_DIR="$WORKSPACE/state/viral-$(date +%s)"
 mkdir -p "$OUT_DIR/artifacts" "$OUT_DIR/fetched_assets" "$OUT_DIR/frames"
 LOG="$OUT_DIR/build.log"
 

--- a/skills/openai-tts/scripts/synthesize.sh
+++ b/skills/openai-tts/scripts/synthesize.sh
@@ -19,11 +19,14 @@ TEXT="${ARGS[*]-}"
 [[ -n "$TEXT" ]] || { echo "Usage: synthesize.sh [--voice <name>] [--out <path>] -- \"text\"" >&2; exit 2; }
 
 REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+# results/ lives at workspace per docs/workspace-contract.md; .env at repo
+# per §5 (Code-adjacent secrets). v3 audit #1149-class.
+WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
 KEY="${OPENAI_API_KEY:-$(grep -E '^OPENAI_API_KEY=' "$REPO/.env" 2>/dev/null | cut -d= -f2-)}"
 KEY="${KEY%\"}"; KEY="${KEY#\"}"; KEY="${KEY%\'}"; KEY="${KEY#\'}"
 [[ -n "$KEY" ]] || { echo "OPENAI_API_KEY missing" >&2; exit 1; }
 
-[[ -n "$OUT" ]] || OUT="$REPO/results/openai-tts-$(date +%s).mp3"
+[[ -n "$OUT" ]] || OUT="$WORKSPACE/results/openai-tts-$(date +%s).mp3"
 mkdir -p "$(dirname "$OUT")"
 
 curl -sSf https://api.openai.com/v1/audio/speech \


### PR DESCRIPTION
## Summary

4 marketing-class skill scripts wrote outputs to `$REPO/results/` or `$REPO/state/`. Per docs/workspace-contract.md these belong at $SUTANDO_WORKSPACE.

| File | L# | Pre-fix | Fix |
|------|-----|---------|-----|
| skills/gemini-tts/scripts/synthesize.sh | 31 | $REPO/results/...mp3 | $WORKSPACE/results/ |
| skills/openai-tts/scripts/synthesize.sh | 26 | $REPO/results/...mp3 | $WORKSPACE/results/ |
| skills/make-viral-video/scripts/asset_cache.py | 44,45 | $REPO/state/viral-cache/ | $WORKSPACE/state/viral-cache/ |
| skills/make-viral-video/scripts/build.sh | 44 | $REPO/state/viral-$ts | $WORKSPACE/state/viral-$ts |

## Symptom on workspace-pinned installs

- TTS mp3 stranded in repo/results/ — bridges polling workspace/results/ never picked up the audio
- viral-video cache + build artifacts polluted repo/state/ → unstaged 'untracked file' noise in `git status`

## Fix

Each script gets a `WORKSPACE=${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}` next to existing `REPO`. Output paths swap from $REPO/{results,state}/ to $WORKSPACE/...

`asset_cache.py` uses `_WORKSPACE = Path(env or default)` directly (Python module).

## Empirical verification

```
$ python3 -c '...; import asset_cache as m; print(m.CACHE_DIR)'
CACHE_DIR  = /Users/.../.sutando/workspace/state/viral-cache/fetched_assets
INDEX_FILE = /Users/.../.sutando/workspace/state/viral-cache/index.json
```

All 4 files pass `bash -n` / `ast.parse`.

## Related

- v3 audit: notes/cwd-poc-v3-{3,4}-skills-{ai,jq}.md
- PR #1271-#1279 sibling batches

— Lucy (Mac Studio bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)