### PR TITLE
[workspace-migration] fix(voice paths): callsFile + gws-gmail cache + phone scan-script (3 sites, mixed direction)

### DIFF
--- a/skills/gws-gmail-voice/tools.ts
+++ b/skills/gws-gmail-voice/tools.ts
@@ -31,10 +31,14 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
+import { resolveWorkspace } from '../../src/workspace_default.js';
 
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 
-const CACHE_PATH = join(process.cwd(), 'state', 'external-cache', 'inbox-important.json');
+// Resolve via the workspace contract — process.cwd() was a #1149-class bug:
+// when voice-agent is started from anywhere other than the repo root, the
+// cache lookup would land at the wrong location entirely. v3 audit 2026-05-27.
+const CACHE_PATH = join(resolveWorkspace(), 'state', 'external-cache', 'inbox-important.json');
 // 30 min TTL: balances cache-hit rate (~95% at 30min vs ~70% at 15min) against
 // staleness. Live gws fallback covers the freshness edge case anyway. Per Mini PR #704 review.
 const CACHE_MAX_AGE_MS = 30 * 60 * 1000;

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -119,6 +119,9 @@ const TWILIO_PHONE_NUMBER = process.env.TWILIO_PHONE_NUMBER ?? '';
 const NGROK_AUTHTOKEN = process.env.NGROK_AUTHTOKEN ?? '';
 const PORT = Number(process.env.PHONE_PORT) || 3100;
 const WORKSPACE_DIR = resolveWorkspace();
+// Repo root for code-tree paths (e.g. src/scan-call-logs.py). Matches the
+// canonical two-name pattern in src/github-webhook.py per qingyun PR #775 review.
+const REPO_DIR = new URL('../../..', import.meta.url).pathname.replace(/\/$/, '');
 const RESULTS_DIR = process.env.PHONE_RESULTS_DIR || join(WORKSPACE_DIR, 'results');
 const TASKS_DIR = join(WORKSPACE_DIR, 'tasks');
 const TASK_POLL_INTERVAL_MS = 500;
@@ -1145,9 +1148,14 @@ function cleanupCall(callSid: string): void {
 		events: session.events,
 	});
 
-	// Auto-scan the latest call for issues (async, best effort)
+	// Auto-scan the latest call for issues (async, best effort).
+	// scan-call-logs.py is CODE (lives in repo's src/), not state. Pre-fix
+	// joined WORKSPACE_DIR/src/scan-call-logs.py which resolved to a non-
+	// existent path and the spawn silently failed (post-call auto-scan was
+	// dead since written). The inverse mistake — CODE under STATE — was
+	// flagged in the 2026-05-27 v3 audit (notes/cwd-poc-v3-4-skills-jq.md).
 	try {
-		const scanScript = join(WORKSPACE_DIR, 'src', 'scan-call-logs.py');
+		const scanScript = join(REPO_DIR, 'src', 'scan-call-logs.py');
 		spawn('python3', [scanScript, '--last', '1', '--json'], { stdio: 'pipe', detached: true })
 			.on('close', (code) => { if (code === 0) console.log(`${ts()} [Phone] call scan complete`); });
 	} catch { /* best effort */ }

--- a/src/voice-context.ts
+++ b/src/voice-context.ts
@@ -65,8 +65,10 @@ export function buildVoiceAgentContext(): string {
 		} catch { /* best effort */ }
 	}
 
-	// Read recent phone call summaries (last 3 calls)
-	const callsFile = join(REPO_DIR, 'results', 'calls', 'calls.jsonl');
+	// Read recent phone call summaries (last 3 calls). calls.jsonl lives under
+	// workspace/results/calls/ per docs/workspace-contract.md — REPO_DIR for
+	// state was the #1149-class bug. v3 audit 2026-05-27.
+	const callsFile = join(WORKSPACE_DIR, 'results', 'calls', 'calls.jsonl');
 	if (existsSync(callsFile)) {
 		try {
 			const callLines = readFileSync(callsFile, 'utf-8').trim().split('\n').filter(Boolean);


### PR DESCRIPTION
## Summary

3 voice/phone-surface sites flagged by v3 audit — same #1149-class but **mixed direction**:

| File | L# | Pre-fix | Bug shape | Post-fix |
|------|-----|---------|-----------|----------|
| `src/voice-context.ts` | 69 | `REPO_DIR/results/calls/...` | forward (state under repo) | `WORKSPACE_DIR/results/...` |
| `skills/gws-gmail-voice/tools.ts` | 37 | `process.cwd()/state/...` | cwd-implicit | `resolveWorkspace()/state/...` |
| `skills/phone-conversation/scripts/conversation-server.ts` | 1150 | `WORKSPACE_DIR/src/scan-call-logs.py` | **inverse** (code under state) | `REPO_DIR/src/...` |

## Why the inverse one matters

`conversation-server.ts:1150` spawns `scan-call-logs.py` after every call as a best-effort post-call audit. Pre-fix it resolved to `<workspace>/src/scan-call-logs.py` — a path that has never existed (scan-call-logs.py is CODE, lives at `<repo>/src/`). The `try { ... } catch { /* best effort */ }` swallowed the spawn failure, so this feature has been silently dead since written. v3 PoC caught it.

## Fix

- voice-context.ts: swap REPO_DIR → WORKSPACE_DIR for results/calls path
- gws-gmail-voice: import resolveWorkspace + use it
- conversation-server.ts: add REPO_DIR derived from import.meta.url, use for scan-call-logs.py

## Tested

`npx tsc --noEmit` clean on all 3 files.

## Voice-agent.ts:641 deferred

That site's bare-relative `readFileSync('voice-context.txt')` has interaction with the personal-skill symlink + memory-dir fallback — separate PR after more design thought.

## Related

- v3 audit: notes/cwd-poc-v3-{1,3,4}.md
- PR #1271-#1280 sibling P0/P1 batches

— Lucy (Mac Studio bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)