### PR TITLE
fix(quota-tracker): narrow bare except to ImportError (closes #1062)

### DIFF
--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -28,7 +28,7 @@ sys.path.insert(0, str(_REPO_ROOT / "src"))
 try:
     from workspace_default import status_read_path  # noqa: E402
     _canonical = status_read_path("quota-state.json")
-except Exception:
+except ImportError:
     _canonical = None
 
 if _canonical is not None and _canonical.exists():


### PR DESCRIPTION
## Summary

Per Lucy's #1055 review (item 1): the bare `except Exception:` on `read-quota.py:26` masked a path off-by-one for half a day — any unexpected error set `_canonical = None` and printed the misleading "not found" message instead of surfacing the real failure.

The only anticipated failure at this call site is `ImportError` (workspace_default not importable because sys.path is wrong). Narrowing to `ImportError`:
- Lets `AttributeError`, `TypeError`, disk errors, and any other unexpected exceptions propagate to the caller
- Makes silent fallback failures visible instead of swallowing them

## Change

```python
# Before
except Exception:
    _canonical = None

# After
except ImportError:
    _canonical = None
```

One line changed. No behavior change for the normal path or for missing-module installs.

## Test plan
- [ ] `python3 skills/quota-tracker/scripts/read-quota.py` on a machine with `workspace_default` importable → same output as before
- [ ] On a machine where the import fails → same "not found" message (ImportError still caught)

🤖 Generated with [Claude Code](https://claude.com/claude-code)