### PR TITLE
fix(bridges): single-instance file lock guard (closes #1257)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -56,6 +56,7 @@ from workspace_default import resolve_workspace  # noqa: E402
 import discord_config  # noqa: E402  — Sutando workspace-local discord config (#1147)
 from util_paths import shared_personal_path  # noqa: E402
 from task_priority import default_priority_for_source  # noqa: E402
+from single_instance import acquire  # noqa: E402
 REPO = resolve_workspace()
 
 # discord-voice "magic word" join trigger (issue: za-warudo summon). The
@@ -3770,4 +3771,5 @@ if __name__ == "__main__":
     if len(sys.argv) >= 4 and sys.argv[1] == "send":
         _send_via_rest(sys.argv[2], " ".join(sys.argv[3:]))
     else:
+        acquire("discord-bridge")  # exits cleanly if another instance is running (#1257)
         client.run(TOKEN, log_handler=None)

--- a/src/single_instance.py
+++ b/src/single_instance.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Single-instance guard for Sutando bridge processes (closes #1257).
+
+Usage:
+    from single_instance import acquire
+    acquire("telegram-bridge")  # exits cleanly if another instance holds the lock
+"""
+from __future__ import annotations
+
+import fcntl
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_default import resolve_workspace  # noqa: E402
+
+_held_fds: list[int] = []  # keep refs so GC doesn't close them
+
+
+def acquire(name: str) -> None:
+    """Acquire an exclusive per-name file lock.
+
+    Exits cleanly (os._exit(0)) if another process already holds it so
+    launchd / startup.sh don't restart-loop on a normal second-instance
+    rejection.  Lock auto-releases on process death because the OS closes
+    all fds at that point (SIGTERM, crash, or clean exit).
+    """
+    lock_dir = resolve_workspace() / "state" / "locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / f"{name}.lock"
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        print(
+            f"[{name}] another instance already holds the lock at {lock_path}; "
+            "exiting cleanly.",
+            file=sys.stderr,
+        )
+        os._exit(0)  # exit 0 so launchd doesn't restart-loop
+    # Write PID for debugging.
+    os.ftruncate(fd, 0)
+    os.write(fd, f"{os.getpid()}\n".encode())
+    _held_fds.append(fd)  # lock auto-releases on process death (OS closes all fds)

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -48,6 +48,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from task_priority import default_priority_for_source  # noqa: E402
 from result_markers import parse_markers  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
+from single_instance import acquire  # noqa: E402
 
 try:
     from slack_bolt import App
@@ -665,6 +666,7 @@ def _no_events_hint_thread():
 
 
 def main():
+    acquire("slack-bridge")  # exits cleanly if another instance is running (#1257)
     print("Slack bridge started. Socket Mode connecting...", flush=True)
     threading.Thread(target=result_watcher, name="slack-result-watcher", daemon=True).start()
     threading.Thread(target=_no_events_hint_thread, name="slack-no-events-hint", daemon=True).start()

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -34,6 +34,7 @@ from task_priority import default_priority_for_source  # noqa: E402
 from result_markers import parse_markers  # noqa: E402
 
 from workspace_default import resolve_workspace  # noqa: E402
+from single_instance import acquire  # noqa: E402
 REPO = resolve_workspace()
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
@@ -402,6 +403,7 @@ def send_reply(chat_id, text, task_id: str | None = None):
             print(f"  file marker, file not found — likely a prose quotation: {fpath}", flush=True)
 
 def main():
+    acquire("telegram-bridge")  # exits cleanly if another instance is running (#1257)
     print(f"Telegram bridge started. Polling for messages...", flush=True)
     offset = None
     allowed = load_allowed()

--- a/tests/single-instance.test.py
+++ b/tests/single-instance.test.py
@@ -1,0 +1,76 @@
+"""Tests for src/single_instance.py — fcntl-based single-instance guard."""
+from __future__ import annotations
+
+import fcntl
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(SRC))
+
+import single_instance
+
+
+class TestAcquire(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self._ws = Path(self._td.name)
+        # Patch the name as imported into single_instance (from workspace_default import resolve_workspace)
+        patcher = patch.object(single_instance, "resolve_workspace", return_value=self._ws)
+        self._mock = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self._td.cleanup)
+        single_instance._held_fds.clear()
+
+    def test_lock_file_created(self) -> None:
+        single_instance.acquire("test-bridge")
+        lock_path = self._ws / "state" / "locks" / "test-bridge.lock"
+        self.assertTrue(lock_path.exists())
+
+    def test_lock_file_contains_pid(self) -> None:
+        single_instance.acquire("test-bridge")
+        lock_path = self._ws / "state" / "locks" / "test-bridge.lock"
+        content = lock_path.read_text().strip()
+        self.assertEqual(content, str(os.getpid()))
+
+    def test_fd_kept_alive(self) -> None:
+        initial_count = len(single_instance._held_fds)
+        single_instance.acquire("test-bridge-2")
+        self.assertEqual(len(single_instance._held_fds), initial_count + 1)
+
+    def test_second_acquire_exits_zero(self) -> None:
+        """Second process trying the same lock must exit 0 (not crash-loop launchd)."""
+        lock_dir = self._ws / "state" / "locks"
+        lock_dir.mkdir(parents=True, exist_ok=True)
+        lock_path = lock_dir / "test-bridge.lock"
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write(
+                f"import sys\n"
+                f"sys.path.insert(0, r'{SRC}')\n"
+                f"import single_instance\n"
+                f"from pathlib import Path\n"
+                f"from unittest.mock import patch\n"
+                f"with patch.object(single_instance, 'resolve_workspace', return_value=Path(r'{self._ws}')):\n"
+                f"    single_instance.acquire('test-bridge')\n"
+            )
+            script_path = f.name
+
+        try:
+            result = subprocess.run([sys.executable, script_path], capture_output=True)
+        finally:
+            os.unlink(script_path)
+            os.close(fd)
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        self.assertIn(b"already holds the lock", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- New `src/single_instance.py` — 40-line `fcntl.flock`-based single-instance guard
- Wire `acquire()` into `telegram-bridge.py`, `discord-bridge.py`, `slack-bridge.py`

Fixes the duplicate-bridge symptom from #1257: Telegram gets 409 errors, Discord re-sends the same task IDs via dm-fallback, and `health-check --fix` can't resolve it.

## How it works

```python
from single_instance import acquire
acquire("telegram-bridge")  # exits cleanly if another instance is running
```

`fcntl.LOCK_EX | LOCK_NB` — non-blocking exclusive lock on `$SUTANDO_WORKSPACE/state/locks/{name}.lock`. If another process holds it, print a diagnostic and call `os._exit(0)` (exit 0 so launchd does not restart-loop). Lock auto-releases on process death (OS closes all fds on SIGTERM/crash/exit). No cleanup needed.

## Test plan

- [x] `test_lock_file_created` — lock file appears under workspace
- [x] `test_lock_file_contains_pid` — file holds current PID
- [x] `test_fd_kept_alive` — fd appended to module list (GC-safe)
- [x] `test_second_acquire_exits_zero` — subprocess holding lock → second acquire exits 0 with diagnostic stderr

Run: `python3 tests/single-instance.test.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)