### PR TITLE
fix(inline-tools): gate slide_control on presenter-mode sentinel

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -20,6 +20,10 @@ import { resolveWorkspace, statusPath, statusReadPath } from './workspace_defaul
 // resolveWorkspace() is the canonical TS helper introduced in #821.
 const WORKSPACE_DIR = resolveWorkspace();
 
+// Presenter-mode sentinel — when absent, slide-control tool is omitted from
+// the registered tools list so it never fires spuriously on greetings (#1171).
+const _PRESENTER_ACTIVE = existsSync(join(WORKSPACE_DIR, 'state', 'presenter-mode.sentinel'));
+
 // Code-adjacent paths (skills/, etc.) ship with the repo checkout, NOT the
 // workspace. Compute REPO_ROOT from this file's URL so the resolution
 // survives any cwd drift at startup. Used by the skill-loader below.
@@ -1089,7 +1093,8 @@ export const inlineTools = assertUniqueToolNames([
 	volumeTool, brightnessTool, clipboardTool,
 	cancelTaskTool, toggleTasksTool, getCurrentTimeTool, getCoreStatusTool,
 	joinGmeetTool, lookupMeetingIdTool, callContactTool,
-	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, slideControlTool, fullscreenTool,
+	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, fullscreenTool,
+	...(_PRESENTER_ACTIVE ? [slideControlTool] : []),
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
 	recentContextTool,
 	sendVisionFrameTool, startVisionTool, stopVisionTool,
@@ -1110,7 +1115,8 @@ export const ownerOnlyTools = [
 	pressKeyTool, scrollTool, switchTabTool, closeTabTool, openUrlTool,
 	switchAppTool, captureScreenTool, typeTextTool,
 	clipboardTool, cancelTaskTool, toggleTasksTool,
-	joinGmeetTool, callContactTool, slideControlTool, fullscreenTool,
+	joinGmeetTool, callContactTool, fullscreenTool,
+	...(_PRESENTER_ACTIVE ? [slideControlTool] : []),
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
 	recentContextTool,
 	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool,


### PR DESCRIPTION
## Summary
Eliminates spurious `slide_control` tool firings on session-start and greetings when no presentation is active (#1171).

## Root cause
`slideControlTool` was registered in `inlineTools` + `ownerOnlyTools` unconditionally — Gemini saw its description on every turn and occasionally fired it on greetings or session-start noise, generating useless sqlite `tool_call` rows.

## Fix
Gate exposure at module load time via the existing `presenter-mode.sentinel`:

```typescript
// added after WORKSPACE_DIR declaration
const _PRESENTER_ACTIVE = existsSync(join(WORKSPACE_DIR, 'state', 'presenter-mode.sentinel'));

// inlineTools + ownerOnlyTools
...(_PRESENTER_ACTIVE ? [slideControlTool] : []),
```

When the sentinel is absent (normal session): Gemini never sees the `slide_control` description and can't fire it. When presenter mode is active (`bash scripts/presenter-mode.sh start N` before launching voice-agent): tool registers normally.

## Trade-off
Runtime toggle during a live session won't add `slide_control` after voice-agent is already running. The existing `presenter-mode.sh` workflow already requires restart anyway, so this contract holds.

## What's NOT changed
- `slideControlTool` export itself is unchanged — still exported for direct use by callers that know what they're doing
- Meeting tools (`joinGmeetTool`, `callContactTool`) intentionally left as-is: #1171 calls these "adjacent" but they don't have the same sentinel-based enable/disable UX

Closes #1171
Filed by Maddy, pattern verified by Lucy (personal skills already use this pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)