### PR TITLE
feat(migrations): 0001 – rename SUTANDO_PRIVATE_DIR → SUTANDO_MEMORY_DIR

### DIFF
--- a/migrations/0001-rename-private-dir-to-memory-dir.sh
+++ b/migrations/0001-rename-private-dir-to-memory-dir.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Rename SUTANDO_PRIVATE_DIR → SUTANDO_MEMORY_DIR in $WORKSPACE/.env (#870)
+set -e
+WORKSPACE="${1:-}"
+ENV_FILE="$WORKSPACE/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "  0001: no .env found at $ENV_FILE — skipping (clean install)"
+  exit 0
+fi
+
+if ! grep -q "^SUTANDO_PRIVATE_DIR=" "$ENV_FILE" 2>/dev/null; then
+  echo "  0001: SUTANDO_PRIVATE_DIR not found in .env — already migrated"
+  exit 0
+fi
+
+if sed --version 2>/dev/null | grep -q 'GNU'; then
+  sed -i 's/^SUTANDO_PRIVATE_DIR=/SUTANDO_MEMORY_DIR=/' "$ENV_FILE"
+else
+  sed -i '' 's/^SUTANDO_PRIVATE_DIR=/SUTANDO_MEMORY_DIR=/' "$ENV_FILE"
+fi
+
+echo "  0001: renamed SUTANDO_PRIVATE_DIR → SUTANDO_MEMORY_DIR in $ENV_FILE"

--- a/tests/migrations/test_0001_rename_private_dir.py
+++ b/tests/migrations/test_0001_rename_private_dir.py
@@ -1,0 +1,70 @@
+"""Tests for migration 0001: SUTANDO_PRIVATE_DIR → SUTANDO_MEMORY_DIR (#956)."""
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+MIGRATION = Path(__file__).resolve().parent.parent.parent / "migrations" / "0001-rename-private-dir-to-memory-dir.sh"
+
+
+def _run(workspace: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["bash", str(MIGRATION), workspace], capture_output=True, text=True)
+
+
+class TestMigration0001(unittest.TestCase):
+    def test_renames_old_var(self) -> None:
+        with tempfile.TemporaryDirectory() as ws:
+            env = Path(ws) / ".env"
+            env.write_text("SUTANDO_PRIVATE_DIR=/some/path\nOTHER_VAR=keep\n")
+            result = _run(ws)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            content = env.read_text()
+            self.assertIn("SUTANDO_MEMORY_DIR=/some/path", content)
+            self.assertNotIn("SUTANDO_PRIVATE_DIR", content)
+            self.assertIn("OTHER_VAR=keep", content)
+
+    def test_idempotent_when_already_renamed(self) -> None:
+        with tempfile.TemporaryDirectory() as ws:
+            env = Path(ws) / ".env"
+            env.write_text("SUTANDO_MEMORY_DIR=/some/path\n")
+            result = _run(ws)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            content = env.read_text()
+            self.assertIn("SUTANDO_MEMORY_DIR=/some/path", content)
+            self.assertNotIn("SUTANDO_PRIVATE_DIR", content)
+
+    def test_idempotent_when_neither_set(self) -> None:
+        with tempfile.TemporaryDirectory() as ws:
+            env = Path(ws) / ".env"
+            env.write_text("OTHER_VAR=foo\n")
+            result = _run(ws)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OTHER_VAR=foo", env.read_text())
+
+    def test_no_env_file(self) -> None:
+        with tempfile.TemporaryDirectory() as ws:
+            result = _run(ws)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse((Path(ws) / ".env").exists())
+
+    def test_preserves_other_vars(self) -> None:
+        with tempfile.TemporaryDirectory() as ws:
+            env = Path(ws) / ".env"
+            env.write_text(
+                "SUTANDO_PRIVATE_DIR=/mem\n"
+                "DISCORD_BOT_TOKEN=abc123\n"
+                "SUTANDO_REPO_DIR=/repo\n"
+            )
+            result = _run(ws)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            content = env.read_text()
+            self.assertIn("SUTANDO_MEMORY_DIR=/mem", content)
+            self.assertIn("DISCORD_BOT_TOKEN=abc123", content)
+            self.assertIn("SUTANDO_REPO_DIR=/repo", content)
+            self.assertNotIn("SUTANDO_PRIVATE_DIR", content)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #956.

## Summary

- Adds `migrations/0001-rename-private-dir-to-memory-dir.sh` — renames the legacy `SUTANDO_PRIVATE_DIR` env var to `SUTANDO_MEMORY_DIR` in `$WORKSPACE/.env` on upgrade
- Idempotent: skips cleanly if already renamed, if the var is absent, or if no `.env` exists
- Handles macOS (`sed -i ''`) vs GNU (`sed -i`) sed difference

## Test plan

- [x] `test_renames_old_var` — confirms rename happens
- [x] `test_idempotent_when_already_renamed` — no double-rename
- [x] `test_idempotent_when_neither_set` — safe no-op
- [x] `test_no_env_file` — safe no-op when workspace has no .env
- [x] `test_preserves_other_vars` — DISCORD_BOT_TOKEN, SUTANDO_REPO_DIR etc. are untouched

All 5 tests pass: `python3 tests/migrations/test_0001_rename_private_dir.py`

After this PR merges into `feat/migrations-phase-1` and that base PR merges to `main`, a fresh `python3 src/run_migrations.py` will bump `state/schema-version.json` from `current: 0` → `current: 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)