### PR TITLE
fix(task-bridge): archive context-drop results when voice is offline (closes #969)

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -166,6 +166,40 @@ export function _isVoiceTask(taskId: string): boolean {
 	return false;
 }
 
+/** True iff taskId's task file has `source: context-drop` or `channel_id: local-hotkey`,
+ * OR has no `source:` line at all (legacy Swift writeTask() path, issue #969). */
+export function _isContextDropTask(taskId: string): boolean {
+	const candidates: string[] = [
+		join(TASK_DIR, `${taskId}.txt`),
+		join(TASK_DIR, 'processed', `${taskId}.txt`),
+		join(TASK_DIR, 'archive', `${taskId}.txt`),
+	];
+	const archiveRoot = join(TASK_DIR, 'archive');
+	if (existsSync(archiveRoot)) {
+		try {
+			for (const entry of readdirSync(archiveRoot)) {
+				if (!/^\d{4}-\d{2}$/.test(entry)) continue;
+				candidates.push(join(archiveRoot, entry, `${taskId}.txt`));
+			}
+		} catch {}
+	}
+	for (const p of candidates) {
+		if (!existsSync(p)) continue;
+		try {
+			const body = readFileSync(p, 'utf-8');
+			const headerLines: string[] = [];
+			for (const l of body.split('\n')) {
+				if (l.startsWith('task:')) break;
+				headerLines.push(l);
+			}
+			if (headerLines.some(l => l.startsWith('source: context-drop') || l.startsWith('channel_id: local-hotkey'))) return true;
+			// Legacy Swift path: no source field at all → treat as hotkey drop
+			if (!headerLines.some(l => l.startsWith('source:'))) return true;
+		} catch {}
+	}
+	return false;
+}
+
 /** Belt-suspenders guard for the result-watcher's unconditional fallthrough
  * (issue #1035, follow-up to PR #1033). Returns true iff the filename is one
  * that task-bridge legitimately delivers via `onResult()`. Rejects everything
@@ -716,6 +750,19 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 						_deliveredResults.add(file);
 						_pendingTasks.delete(taskId);
 						console.log(`${ts()} [TaskBridge] Chat task archived (no client): ${taskId}`);
+						setTimeout(() => {
+							archiveFile(path, 'results', taskId);
+							const taskFile = join(TASK_DIR, `${taskId}.txt`);
+							if (existsSync(taskFile)) archiveFile(taskFile, 'tasks', taskId);
+						}, 10_000);
+					}
+					// Context-drop tasks (hotkey / source: context-drop) have no bridge
+					// consumer — archive them directly so results don't pile up (#969).
+					if (file.startsWith('task-') && !taskId.startsWith('task-chat-') && _isContextDropTask(taskId)) {
+						_sendTaskStatus?.(taskId, 'done', result.slice(0, 60), result);
+						_deliveredResults.add(file);
+						_pendingTasks.delete(taskId);
+						console.log(`${ts()} [TaskBridge] Context-drop task archived (no client): ${taskId}`);
 						setTimeout(() => {
 							archiveFile(path, 'results', taskId);
 							const taskFile = join(TASK_DIR, `${taskId}.txt`);

--- a/tests/task-bridge-context-drop.test.ts
+++ b/tests/task-bridge-context-drop.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression guard for context-drop result archival (closes #969).
+ *
+ * Pre-fix: the offline branch in the result watcher archived task-chat-* and
+ * forwarded voice tasks, but context-drop results (source: context-drop /
+ * source-less legacy Swift tasks) fell through to `continue` and accumulated
+ * in results/ indefinitely.
+ *
+ * This test locks in _isContextDropTask detection across all three task-file
+ * locations: live, processed, and month-partitioned archive.
+ */
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { resolveWorkspace } from '../src/workspace_default.js';
+import { _isContextDropTask } from '../src/task-bridge.js';
+
+const TASK_DIR = join(resolveWorkspace(), 'tasks');
+
+const CONTEXT_DROP_BODY = `id: task-ctxdrop-test-aaa
+timestamp: 2026-05-28T00:00:00Z
+source: context-drop
+channel_id: local-hotkey
+access_tier: owner
+task: User dropped context via hotkey. Process this:
+some content
+`;
+
+const LEGACY_SWIFT_BODY = `id: task-ctxdrop-test-bbb
+timestamp: 2026-05-28T00:00:00Z
+task: User dropped context via hotkey. Process this:
+some content
+`;
+
+const VOICE_BODY = `id: task-ctxdrop-test-ccc
+timestamp: 2026-05-28T00:00:00Z
+source: voice
+channel_id: local-voice
+task: hello world
+`;
+
+const DISCORD_BODY = `id: task-ctxdrop-test-ddd
+timestamp: 2026-05-28T00:00:00Z
+source: discord
+channel_id: 1490906927675474030
+task: hello world
+`;
+
+const created: string[] = [];
+function writeTask(path: string, body: string) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, body);
+  created.push(path);
+}
+
+describe('_isContextDropTask', () => {
+  afterEach(() => {
+    for (const p of created.splice(0)) {
+      try { unlinkSync(p); } catch {}
+    }
+  });
+
+  it('returns true for source: context-drop in live tasks/', () => {
+    const id = 'task-ctxdrop-live-aaa';
+    writeTask(join(TASK_DIR, `${id}.txt`), CONTEXT_DROP_BODY);
+    assert.equal(_isContextDropTask(id), true);
+  });
+
+  it('returns true for legacy Swift task (no source field)', () => {
+    const id = 'task-ctxdrop-legacy-bbb';
+    writeTask(join(TASK_DIR, `${id}.txt`), LEGACY_SWIFT_BODY);
+    assert.equal(_isContextDropTask(id), true);
+  });
+
+  it('returns true for context-drop task in month-partitioned archive', () => {
+    const id = 'task-ctxdrop-archive-ccc';
+    const ym = new Date().toISOString().slice(0, 7);
+    writeTask(join(TASK_DIR, 'archive', ym, `${id}.txt`), CONTEXT_DROP_BODY);
+    assert.equal(_isContextDropTask(id), true);
+  });
+
+  it('returns false for voice task', () => {
+    const id = 'task-ctxdrop-voice-ddd';
+    writeTask(join(TASK_DIR, `${id}.txt`), VOICE_BODY);
+    assert.equal(_isContextDropTask(id), false);
+  });
+
+  it('returns false for discord task', () => {
+    const id = 'task-ctxdrop-discord-eee';
+    writeTask(join(TASK_DIR, `${id}.txt`), DISCORD_BODY);
+    assert.equal(_isContextDropTask(id), false);
+  });
+
+  it('returns false when task file does not exist', () => {
+    assert.equal(_isContextDropTask('task-ctxdrop-nonexistent-zzz'), false);
+  });
+});


### PR DESCRIPTION
Closes #969.

## Root cause

The offline branch in the result watcher (task-bridge.ts) had two special-case exits:
- `task-chat-*` → archive directly (no bridge consumer)
- voice tasks → forward to Discord DM

Context-drop results (written with `source: context-drop` / `channel_id: local-hotkey` by task-bridge's `watchContextDrop()`, or with NO source field by the legacy `main.swift` `writeTask()`) matched neither case. They fell through to the final `continue` and piled up in `results/` until the next boot ran `archive-stale-results.py`.

## Fix

Added `_isContextDropTask(taskId)` — same file-lookup pattern as `_isVoiceTask`. Detects:
- `source: context-drop`
- `channel_id: local-hotkey`
- No `source:` field at all (legacy Swift `writeTask()` path, issue #969 root cause)

Wired into the offline branch after `task-chat-*` archival.

## Test plan

- [x] `returns true for source: context-drop in live tasks/`
- [x] `returns true for legacy Swift task (no source field)`
- [x] `returns true for context-drop task in month-partitioned archive`
- [x] `returns false for voice task`
- [x] `returns false for discord task`
- [x] `returns false when task file does not exist`

Run: `NODE_OPTIONS=--experimental-sqlite npx tsx --test tests/task-bridge-context-drop.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)