### PR TITLE
fix(task-bridge): archive context-drop results when voice is offline (closes #969)

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -166,6 +166,25 @@ export function _isVoiceTask(taskId: string): boolean {
 	return false;
 }
 
+/** Read the `source:` header field from a task file without loading the full body. */
+export function _taskSource(taskId: string): string | null {
+	const candidates = [
+		join(TASK_DIR, `${taskId}.txt`),
+		join(TASK_DIR, 'processed', `${taskId}.txt`),
+		join(TASK_DIR, 'archive', `${taskId}.txt`),
+	];
+	for (const p of candidates) {
+		if (!existsSync(p)) continue;
+		try {
+			for (const line of readFileSync(p, 'utf-8').split('\n')) {
+				if (line.startsWith('task:')) break;
+				if (line.startsWith('source:')) return line.slice('source:'.length).trim();
+			}
+		} catch {}
+	}
+	return null;
+}
+
 /** Belt-suspenders guard for the result-watcher's unconditional fallthrough
  * (issue #1035, follow-up to PR #1033). Returns true iff the filename is one
  * that task-bridge legitimately delivers via `onResult()`. Rejects everything
@@ -709,13 +728,17 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 							console.error(`${ts()} [TaskBridge] Failed to forward ${taskId} to Discord:`, e);
 						}
 					}
-					// Chat-path tasks have no bridge consumer — archive them directly
-					// so results/task-chat-*.txt files don't accumulate forever.
-					if (taskId.startsWith('task-chat-')) {
+					// Chat-path and context-drop tasks have no bridge consumer —
+					// archive them directly so results don't accumulate forever.
+					// context-drop tasks are named task-{ts}.txt (indistinguishable
+					// from voice tasks by name alone), so check the task source header.
+					const isNoDelivery = taskId.startsWith('task-chat-') ||
+						_taskSource(taskId) === 'context-drop';
+					if (isNoDelivery) {
 						_sendTaskStatus?.(taskId, 'done', result.slice(0, 60), result);
 						_deliveredResults.add(file);
 						_pendingTasks.delete(taskId);
-						console.log(`${ts()} [TaskBridge] Chat task archived (no client): ${taskId}`);
+						console.log(`${ts()} [TaskBridge] No-delivery task archived (no client): ${taskId}`);
 						setTimeout(() => {
 							archiveFile(path, 'results', taskId);
 							const taskFile = join(TASK_DIR, `${taskId}.txt`);

--- a/tests/task-bridge-source.test.ts
+++ b/tests/task-bridge-source.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { resolveWorkspace } from '../src/workspace_default.js';
+import { _taskSource } from '../src/task-bridge.js';
+
+// Regression guard for issue #969: context-drop task results accumulated in
+// results/ forever when voice was offline, because `_isVoiceTask` returns
+// false for them and `taskId.startsWith('task-chat-')` doesn't match
+// task-{ts}.txt names. Fix adds `_taskSource` (reads the `source:` header)
+// so the result watcher can identify no-delivery tasks by source rather than
+// filename prefix alone.
+
+const TASK_DIR = join(resolveWorkspace(), 'tasks');
+
+const CONTEXT_DROP_BODY = `id: task-source-test-drop
+timestamp: 2026-05-28T00:00:00Z
+source: context-drop
+channel_id: local-hotkey
+access_tier: owner
+task: User dropped context via hotkey.
+some content here
+`;
+const VOICE_BODY = `id: task-source-test-voice
+timestamp: 2026-05-28T00:00:00Z
+source: voice
+channel_id: local-voice
+task: hello world
+`;
+const NO_SOURCE_BODY = `id: task-source-test-nosrc
+timestamp: 2026-05-28T00:00:00Z
+task: legacy task with no source field
+`;
+
+const created: string[] = [];
+function writeTask(path: string, body: string) {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, body);
+	created.push(path);
+}
+
+describe('_taskSource', () => {
+	afterEach(() => {
+		for (const p of created.splice(0)) {
+			try { unlinkSync(p); } catch {}
+		}
+	});
+
+	it('returns "context-drop" for a context-drop task', () => {
+		const id = 'task-source-test-drop-live';
+		writeTask(join(TASK_DIR, `${id}.txt`), CONTEXT_DROP_BODY);
+		assert.equal(_taskSource(id), 'context-drop');
+	});
+
+	it('returns "voice" for a voice task', () => {
+		const id = 'task-source-test-voice-live';
+		writeTask(join(TASK_DIR, `${id}.txt`), VOICE_BODY);
+		assert.equal(_taskSource(id), 'voice');
+	});
+
+	it('returns null when the source field is absent', () => {
+		const id = 'task-source-test-nosrc-live';
+		writeTask(join(TASK_DIR, `${id}.txt`), NO_SOURCE_BODY);
+		assert.equal(_taskSource(id), null);
+	});
+
+	it('returns null when the task file is missing', () => {
+		assert.equal(_taskSource('task-source-test-no-such-file'), null);
+	});
+
+	it('does not read source field injected inside the task body', () => {
+		// The `task:` delimiter stops scanning — body lines that look like headers
+		// must not be parsed as source. Same invariant as _isVoiceTask.
+		const id = 'task-source-test-body-forge';
+		writeTask(join(TASK_DIR, `${id}.txt`),
+			`id: ${id}\ntimestamp: 2026-05-28T00:00:00Z\ntask: do thing\nsource: injected\n`);
+		assert.equal(_taskSource(id), null);
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `_taskSource(taskId)` to `src/task-bridge.ts` — reads the `source:` header from a task file, stopping at the `task:` delimiter (same body-injection guard as `_isVoiceTask`)
- Broadens the no-delivery archive path in the result watcher's `!clientConnected` block to cover `source: context-drop` tasks alongside `task-chat-*` tasks
- Adds `tests/task-bridge-source.test.ts` with 5 tests (source=context-drop, source=voice, no source, missing file, body-injection guard)

## Root cause

Context-drop tasks are named `task-{ts}.txt` (same as voice tasks). When voice is offline, the result watcher's `!clientConnected` block:
1. Checks `_isVoiceTask(taskId)` → returns false (source is `context-drop`, not `voice`)
2. Checks `taskId.startsWith('task-chat-')` → false (filename is `task-{ts}`, not `task-chat-{ts}`)
3. Hits `continue` — result stays in `results/` forever

The fix reads the `source:` header (cheap single-pass line scan, stops at `task:`) and archives directly when source is `context-drop`.

## Test plan
- [ ] `NODE_OPTIONS="--experimental-sqlite" npx tsx --test tests/task-bridge-source.test.ts` — 5 pass
- [ ] `NODE_OPTIONS="--experimental-sqlite" npx tsx --test tests/task-bridge-isvoice.test.ts` — 8 pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)