### PR TITLE
fix(discord-voice): add action + capability grounding guards (closes #1102)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -469,6 +469,14 @@ function buildAgent(s: DiscordVoiceSession): MainAgent {
 			DISCORD_VOICE_GOOGLE_SEARCH
 				? 'NEVER fabricate specific details. If you don\'t know it, use your built-in Web search to look it up — it\'s faster than delegating, and the answer stays in the conversation. If your built-in search returns nothing useful, OR the question needs deeper-than-one-lookup research (multi-step, multiple sources, file reading), call the work tool — it routes to the core agent which can do extensive research.'
 				: 'NEVER fabricate specific details. If you don\'t know it, use the work tool to look it up.',
+			// Action-grounding: prevent the model from narrating tool calls it
+			// didn't make. Observed on 2026-05-25 (Susan): voice said "Opening
+			// the Sutando repository" with no tool_call in sqlite. Guard forces
+			// the action-before-announcement contract. Per issue #1102.
+			'ACTION GROUNDING: If you say you are doing something (opening, searching, sending, checking), you MUST call the corresponding tool first. Never announce an action you have not actually taken.',
+			// Capability inventory: prevent feature invention (voice hallucinated
+			// "co-presentation mode" for "za warudo", which has no such meaning).
+			'CAPABILITY GROUNDING: When asked what you can do, list ONLY capabilities described in this prompt. If asked about a feature you don\'t recognise, say "I\'m not sure about that one" rather than guessing.',
 			repoUrl ? `\n## Known info\nSutando GitHub repo: ${repoUrl}` : '',
 		].filter(Boolean).join('\n');
 	} else {


### PR DESCRIPTION
## Summary

Two hallucination patterns observed on Susan's server (2026-05-25, per issue #1102):

- **False tool narration**: voice said "Opening the Sutando repository" with no `tool_call` row in sqlite — claimed an action it hadn't taken
- **Feature invention**: voice invented "co-presentation navigation mode" for "za warudo" — a feature that doesn't exist

Adds two guardrails to the owner-tier system prompt in `buildAgent()`:

- **ACTION GROUNDING**: must call the tool before claiming the action (fixes false-narration)
- **CAPABILITY GROUNDING**: describe only capabilities listed in the prompt, not invented ones (fixes feature hallucination)

Both are append-only to the existing `instructions` array; no prompt re-ordering.

## Test plan
- [ ] Voice a task like "search for X" — confirm tool is invoked before (or without) speech about searching
- [ ] Ask "what can you do?" — confirm no invented capabilities
- [ ] Ask about "za warudo" or similar — confirm "I'm not sure about that one" rather than invention

🤖 Generated with [Claude Code](https://claude.com/claude-code)