### PR TITLE
fix(discord-voice): reply where invited, not via owner-DM fallback (closes #1120)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -163,6 +163,10 @@ function getArg(name: string): string | undefined {
 }
 const GUILD_ID = getArg('guild');
 const CHANNEL_ID = getArg('channel');
+// Originating text channel + user — used to route Layer-1 refusals back to
+// the channel where the bot was invited, not the owner's DMs (#1120).
+const REPLY_CHANNEL_ID = getArg('reply-channel');
+const REPLY_USER_ID = getArg('reply-user');
 
 // Owner-mode (issue #1016) — resolved from the workspace config
 // ($SUTANDO_WORKSPACE/config/discord-voice.json), NOT an env var and NOT a
@@ -1177,22 +1181,32 @@ async function start(): Promise<void> {
 		}
 		if (presentPeers.length > 0) {
 			console.error(`${ts()} [Setup] #1089 refusing to join: sutando peer(s) already present: ${presentPeers.join(', ')}`);
-			// Surface the refusal to the operator — without this they just see
-			// "nothing happens" when inviting a second bot to a channel that
-			// already has one. Drop a proactive result; the discord-bridge
-			// polls results/ and DMs proactive-*.txt to the owner. Best-effort:
-			// if the write fails the process still exits cleanly and
-			// Sutando.app's checkWatcher will retry once the peer leaves.
-			try {
-				const proactivePath = join(WORKSPACE_DIR, 'results', `proactive-${Date.now()}.txt`);
-				const channelName = (channel as any).name ?? CHANNEL_ID;
-				writeFileSync(
-					proactivePath,
-					`Skipping voice join in #${channelName} — peer already present: ${presentPeers.join(', ')}. ` +
-					`Single-bot enforcement (#1089); reinvite once they leave.\n`,
-				);
-			} catch (e) {
-				console.error(`${ts()} [Setup] #1089 couldn't surface refusal to operator:`, e);
+			const channelName = (channel as any).name ?? CHANNEL_ID;
+			const refusalText =
+				`Skipping voice join in #${channelName} — peer already present: ${presentPeers.join(', ')}. ` +
+				`Single-bot enforcement (#1089); reinvite once they leave.`;
+			// Route refusal to the originating text channel when available (#1120),
+			// falling back to proactive-*.txt → owner-DM if not supplied.
+			let replied = false;
+			if (REPLY_CHANNEL_ID) {
+				try {
+					const replyCh = await client.channels.fetch(REPLY_CHANNEL_ID);
+					if (replyCh && 'send' in replyCh) {
+						const mention = REPLY_USER_ID ? `<@${REPLY_USER_ID}> ` : '';
+						await (replyCh as any).send(`${mention}${refusalText}`);
+						replied = true;
+					}
+				} catch (e) {
+					console.error(`${ts()} [Setup] #1089 channel-reply failed, falling back:`, e);
+				}
+			}
+			if (!replied) {
+				try {
+					const proactivePath = join(WORKSPACE_DIR, 'results', `proactive-${Date.now()}.txt`);
+					writeFileSync(proactivePath, `${refusalText}\n`);
+				} catch (e) {
+					console.error(`${ts()} [Setup] #1089 couldn't surface refusal to operator:`, e);
+				}
 			}
 			process.exit(0); // clean exit — operator (Sutando.app checkWatcher) will retry later when peer leaves
 		}

--- a/skills/discord-voice/scripts/join_trigger.py
+++ b/skills/discord-voice/scripts/join_trigger.py
@@ -189,7 +189,12 @@ def _server_already_running(channel_id) -> bool:
     return False
 
 
-def _spawn_voice_server(guild_id, channel_id) -> bool:
+def _spawn_voice_server(
+    guild_id,
+    channel_id,
+    reply_channel_id=None,
+    reply_user_id=None,
+) -> bool:
     """Launch discord-voice-server.ts detached for guild+channel. Returns True
     on a successful spawn (the subprocess was started — not that it connected).
 
@@ -202,6 +207,10 @@ def _spawn_voice_server(guild_id, channel_id) -> bool:
     GEMINI_VOICE_API_KEY path) — matches the documented invocation. Detached
     via start_new_session so it survives the bridge restarting; stdout/stderr
     go to the workspace log so it isn't lost.
+
+    `reply_channel_id` / `reply_user_id`: when set, the voice server routes
+    Layer-1 refusals (peer-already-present) back to the originating text
+    channel instead of writing a proactive-*.txt for owner-DM delivery (#1120).
     """
     if not _DISCORD_VOICE_SERVER.exists():
         return False
@@ -225,6 +234,10 @@ def _spawn_voice_server(guild_id, channel_id) -> bool:
         "--channel",
         str(channel_id),
     ]
+    if reply_channel_id is not None:
+        argv += ["--reply-channel", str(reply_channel_id)]
+    if reply_user_id is not None:
+        argv += ["--reply-user", str(reply_user_id)]
     try:
         subprocess.Popen(
             argv,
@@ -359,7 +372,12 @@ def handle_join_trigger(message) -> str:
     if _server_already_running(channel_id):
         return f"I'm already in **{channel_name}** — see you there."
 
-    if _spawn_voice_server(guild_id, channel_id):
+    # Thread the originating text channel + author through to the voice server
+    # so Layer-1 refusals route back there instead of owner-DM (#1120).
+    reply_channel_id = getattr(getattr(message, "channel", None), "id", None)
+    reply_user_id = getattr(getattr(message, "author", None), "id", None)
+
+    if _spawn_voice_server(guild_id, channel_id, reply_channel_id, reply_user_id):
         # Queue context-prep AFTER successful spawn so the core only sees
         # the synthetic task when voice is actually on the way. No await /
         # block — voice and context-prep race; voice's first turn falls


### PR DESCRIPTION
## Summary
- Layer-1 peer-already-present refusals now post to the originating text channel instead of writing a `proactive-*.txt` that DMs the owner
- Threads `--reply-channel <id>` and `--reply-user <id>` from the `handle_join_trigger` message object through `_spawn_voice_server` to the voice server subprocess
- Falls back to `proactive-*.txt` when args aren't present (ad-hoc test spawns, manual `npx tsx` invocations)

## Changes
- `skills/discord-voice/scripts/join_trigger.py`: `_spawn_voice_server` accepts optional `reply_channel_id`/`reply_user_id`; `handle_join_trigger` extracts them from `message.channel.id` and `message.author.id`
- `skills/discord-voice/scripts/discord-voice-server.ts`: reads `--reply-channel`/`--reply-user` args; Layer-1 refusal block tries `channel.send()` first, falls back to proactive file

## Test plan
- [ ] Bot invited to VC that already has a peer: refusal appears in the text channel the invite came from, not in owner DMs
- [ ] Ad-hoc `npx tsx ... --guild G --channel C` (no reply args): refusal still surfaces via proactive-*.txt → owner DM (fallback path)
- [ ] TypeScript check: no new errors (two pre-existing errors on main unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)