### PR TITLE
fix(watch-tasks): plug EPIPE-buffer + PPID=1-orphan leaks (closes #1088)

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -67,13 +67,15 @@ echo "$$" > "$PID_FILE"
 # Cleanup on any exit path (SIGINT, SIGTERM, normal exit) so the file
 # doesn't outlive the process on a clean shutdown. Dirty exits (SIGKILL,
 # panic) skip the trap — the Stop hook + startup reaper cover those.
+# Note: the trap is updated below once FSWATCH_PID and FIFO are known.
 trap 'rm -f "$PID_FILE"' EXIT
 
 # Initial sweep — surface any pre-existing tasks that arrived during a
-# restart gap.
+# restart gap. Use printf (not echo) so a dead consumer triggers EPIPE
+# immediately rather than buffering silently (Mode A fix, #1088).
 shopt -s nullglob
 for f in "$TASKS_DIR"/*.txt; do
-  echo "TASK_FILE: $(basename "$f")"
+  printf 'TASK_FILE: %s\n' "$(basename "$f")" || exit 0
 done
 shopt -u nullglob
 
@@ -97,18 +99,35 @@ shopt -u nullglob
 #    rename — including the source path AFTER the file has moved out.
 #    `[ -f "$path" ]` filters those rename-OUT-of-watched-dir events.
 #    Caught 2026-05-03 #1 (PR #572).
+#
+# Mode A fix (#1088): `printf ... || exit 0` makes EPIPE from a dead reader
+# propagate immediately (pipe buffer fills to ~64KB on macOS before a plain
+# `echo` would fail — at typical DM traffic that's days, not seconds).
+#
+# Mode B fix (#1088): fswatch runs as a background job writing to a temp FIFO
+# so we have its PID. The EXIT/INT/TERM trap kills it, preventing the
+# PPID=1 orphan that appeared in the 2026-05-23 4h event-loss incident.
+FIFO="$(mktemp -t watch-fifo-XXXXXX)"
+rm -f "$FIFO"
+mkfifo "$FIFO" || { rm -f "$PID_FILE"; exit 1; }
+
 fswatch \
   -l 0.5 \
   --event Created \
   --event Renamed \
-  "$TASKS_DIR" 2>/dev/null \
-| while IFS= read -r path; do
+  "$TASKS_DIR" 2>/dev/null > "$FIFO" &
+FSWATCH_PID=$!
+
+# Update trap now that we have both FSWATCH_PID and FIFO.
+trap 'kill "$FSWATCH_PID" 2>/dev/null; rm -f "$FIFO" "$PID_FILE"' EXIT INT TERM
+
+while IFS= read -r path; do
   case "$path" in
     *.txt)
       parent="$(dirname "$path")"
       if [ "$parent" = "$TASKS_DIR_ABS" ] && [ -f "$path" ]; then
-        echo "TASK_FILE: $(basename "$path")"
+        printf 'TASK_FILE: %s\n' "$(basename "$path")" || exit 0
       fi
       ;;
   esac
-done
+done < "$FIFO"


### PR DESCRIPTION
## Summary

- **Mode A (EPIPE-on-dead-reader):** Switch `echo` → `printf ... || exit 0` in both the initial scan and the main fswatch loop. `echo` buffers writes into the 64KB kernel pipe until it fills; at typical DM traffic (a few events/day) that takes days. `printf` returns non-zero on the first failed write, exiting the loop immediately when Monitor's consumer dies.

- **Mode B (PPID=1 reparent):** Replace the `fswatch ... | while read` pipeline with a temp FIFO + background job. We capture `FSWATCH_PID=$!` and update the EXIT/INT/TERM trap to `kill "$FSWATCH_PID"`. When the wrapper shell exits for any reason (Claude session compaction, ⌘Q, session restart), the trap fires and fswatch goes with it instead of reparenting to launchd.

Both failure modes together explain the 2026-05-23 ~4h event-loss incident (discord-bridge wrote task files correctly; watcher was alive but deaf).

Refs #1088 (re-filed per @sonichi's reset of #1061, POC by @liususan091219).

## Test plan

- [ ] `bash -n src/watch-tasks-stream.sh` — syntax check passes
- [ ] Start watcher, write a task file, confirm `TASK_FILE:` event arrives
- [ ] Kill the wrapper; confirm no orphaned `fswatch` process remains (`pgrep fswatch`)
- [ ] (Mode A) Run `bash src/watch-tasks-stream.sh | head -1`; confirm watcher exits when `head` exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)