### PR TITLE
refactor(quota-tracker): narrow bare except to ImportError (closes #1062)

### DIFF
--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -28,7 +28,7 @@ sys.path.insert(0, str(_REPO_ROOT / "src"))
 try:
     from workspace_default import status_read_path  # noqa: E402
     _canonical = status_read_path("quota-state.json")
-except Exception:
+except ImportError:
     _canonical = None
 
 if _canonical is not None and _canonical.exists():


### PR DESCRIPTION
## Summary

One-line change: `except Exception:` → `except ImportError:` on `read-quota.py:31`.

The broad `except Exception:` masked the `_REPO_ROOT` path bug for ~12h in the #1055 incident — a bad path caused `ImportError`, which was swallowed and produced the misleading `"No quota-state.json found"` fallback. Only `ImportError` is expected here (module absent in fresh installs or sandboxed envs). Any other exception from inside `status_read_path` is a genuine bug and should propagate.

Closes #1062. Flagged in #1055 code review by @liususan091219.

## Test plan

- [ ] `python3 -m py_compile skills/quota-tracker/scripts/read-quota.py` passes
- [ ] `python3 skills/quota-tracker/scripts/read-quota.py` reports quota correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)