### PR TITLE
fix(bridges): single-instance guard via fcntl.flock (closes #1257)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -53,6 +53,7 @@ except ModuleNotFoundError:
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402
+from single_instance import acquire as _single_instance_acquire  # noqa: E402
 import discord_config  # noqa: E402  — Sutando workspace-local discord config (#1147)
 from util_paths import shared_personal_path  # noqa: E402
 from task_priority import default_priority_for_source  # noqa: E402
@@ -3833,4 +3834,5 @@ if __name__ == "__main__":
     if len(sys.argv) >= 4 and sys.argv[1] == "send":
         _send_via_rest(sys.argv[2], " ".join(sys.argv[3:]))
     else:
+        _single_instance_acquire("discord-bridge")
         client.run(TOKEN, log_handler=None)

--- a/src/single_instance.py
+++ b/src/single_instance.py
@@ -1,0 +1,57 @@
+"""Single-instance guard for long-running bridge daemons.
+
+Prevents two copies of the same bridge running simultaneously — a real
+failure mode when startup.sh and Sutando.app's launchd agent race at boot
+(observed 2026-05-xx: duplicate telegram-bridge caused API 409 errors;
+duplicate discord-bridge caused double task delivery).
+
+Usage (at the top of a bridge's main entry point):
+
+    from single_instance import acquire
+    acquire("telegram-bridge")   # or "discord-bridge" / "slack-bridge"
+
+The lock is an OS-level exclusive flock on a file in
+`$WORKSPACE/state/locks/<name>.lock`. It auto-releases on process death
+(OS closes all FDs), so no explicit cleanup is needed. The FD is kept in
+`_held_fds` to prevent CPython's GC from closing it early.
+
+Exit behavior: exits 0 (not 1) on lock contention so launchd's KeepAlive
+doesn't restart-loop when it's simply the second instance.
+"""
+from __future__ import annotations
+
+import fcntl
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_default import resolve_workspace  # noqa: E402
+
+_held_fds: list[int] = []  # keep refs so GC doesn't close them
+
+
+def acquire(name: str) -> None:
+    """Acquire an exclusive non-blocking lock for `name`.
+
+    If another process already holds the lock, prints a one-line message
+    to stderr and exits 0. Otherwise returns normally; caller continues.
+    """
+    lock_dir = resolve_workspace() / "state" / "locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / f"{name}.lock"
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        os.close(fd)
+        print(
+            f"[{name}] another instance already holds the lock — exiting cleanly.",
+            file=sys.stderr, flush=True,
+        )
+        os._exit(0)  # exit(0) so launchd KeepAlive doesn't restart-loop
+    # Overwrite PID so tooling can inspect who holds the lock.
+    os.ftruncate(fd, 0)
+    os.lseek(fd, 0, os.SEEK_SET)
+    os.write(fd, f"{os.getpid()}\n".encode())
+    _held_fds.append(fd)  # lock auto-releases on process exit (OS closes FD)

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -49,6 +49,7 @@ from task_priority import default_priority_for_source  # noqa: E402
 from result_markers import parse_markers  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
 from task_archive import find_task_file  # noqa: E402
+from single_instance import acquire as _single_instance_acquire  # noqa: E402
 
 try:
     from slack_bolt import App
@@ -771,6 +772,7 @@ def _recover_orphan_sending_files() -> int:
     return recovered
 
 def main():
+    _single_instance_acquire("slack-bridge")
     print("Slack bridge started. Socket Mode connecting...", flush=True)
     _recover_orphan_sending_files()
     # Prime the in-memory access cache so tofu_onboard() can detect external

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -35,6 +35,7 @@ from result_markers import parse_markers  # noqa: E402
 
 from workspace_default import resolve_workspace  # noqa: E402
 from task_archive import find_task_file  # noqa: E402
+from single_instance import acquire as _single_instance_acquire  # noqa: E402
 REPO = resolve_workspace()
 TASKS_DIR = REPO / "tasks"
 RESULTS_DIR = REPO / "results"
@@ -437,6 +438,7 @@ def _recover_orphan_sending_files() -> int:
 
 
 def main():
+    _single_instance_acquire("telegram-bridge")
     print(f"Telegram bridge started. Polling for messages...", flush=True)
     # Restart-safety: sweep orphan `.sending` files before the poll
     # loop starts. See _recover_orphan_sending_files for rationale.

--- a/tests/single-instance.test.py
+++ b/tests/single-instance.test.py
@@ -1,0 +1,118 @@
+"""Tests for src/single_instance.py.
+
+Covers:
+  (a) acquire() succeeds when no other holder — lock file written with PID.
+  (b) Second acquire() from a new process exits 0 (launchd-safe).
+  (c) Lock releases when the holder process dies — next acquire() wins.
+  (d) acquire() on two different names is independent (no cross-lock).
+
+Run: `python3 tests/single-instance.test.py`
+"""
+import importlib.util
+import os
+import sys
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _load_single_instance(workspace_dir: Path):
+    """Load single_instance with SUTANDO_WORKSPACE pointing at a temp dir."""
+    os.environ["SUTANDO_WORKSPACE"] = str(workspace_dir)
+    # Reload to pick up new env — module caches resolve_workspace() at call time.
+    spec = importlib.util.spec_from_file_location(
+        "single_instance", ROOT / "src" / "single_instance.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestSingleInstance(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+        os.environ["SUTANDO_WORKSPACE"] = str(self.workspace)
+
+    def tearDown(self):
+        os.environ.pop("SUTANDO_WORKSPACE", None)
+        self.tmp.cleanup()
+
+    # (a) First acquire writes PID to lock file and returns normally.
+    def test_first_acquire_writes_pid(self):
+        mod = _load_single_instance(self.workspace)
+        mod.acquire("test-bridge")
+        lock_path = self.workspace / "state" / "locks" / "test-bridge.lock"
+        self.assertTrue(lock_path.exists(), "lock file should be created")
+        pid_in_file = int(lock_path.read_text().strip())
+        self.assertEqual(pid_in_file, os.getpid())
+
+    # (b) Second process attempting the same lock exits 0.
+    def test_second_process_exits_zero(self):
+        mod = _load_single_instance(self.workspace)
+        mod.acquire("test-second")
+        # Spawn a child process that tries to acquire the same lock.
+        # It should exit 0 (not 1) because we hold it in this process.
+        child = subprocess.run(
+            [
+                sys.executable, "-c",
+                f"import sys; sys.path.insert(0, '{ROOT}/src');"
+                f"import os; os.environ['SUTANDO_WORKSPACE']='{self.workspace}';"
+                f"from single_instance import acquire; acquire('test-second')",
+            ],
+            capture_output=True,
+            timeout=10,
+        )
+        self.assertEqual(child.returncode, 0, "contending process should exit 0")
+        self.assertIn(b"already holds the lock", child.stderr)
+
+    # (c) Lock releases after holder dies — next acquire wins.
+    def test_lock_releases_after_holder_dies(self):
+        # Start a subprocess that acquires the lock and then waits.
+        holder = subprocess.Popen(
+            [
+                sys.executable, "-c",
+                f"import sys, time; sys.path.insert(0, '{ROOT}/src');"
+                f"import os; os.environ['SUTANDO_WORKSPACE']='{self.workspace}';"
+                f"from single_instance import acquire; acquire('test-release');"
+                f"time.sleep(30)",  # hold forever — we'll kill it
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # Give it a moment to acquire the lock.
+        time.sleep(0.3)
+        holder.terminate()
+        holder.wait(timeout=5)
+        # Now this process should be able to acquire.
+        mod = _load_single_instance(self.workspace)
+        # If lock still held, acquire() would call os._exit(0) — but since
+        # holder died, the OS released the flock and we should proceed normally.
+        try:
+            mod.acquire("test-release")
+        except SystemExit as e:
+            self.fail(f"acquire() exited after holder died: {e}")
+        lock_path = self.workspace / "state" / "locks" / "test-release.lock"
+        self.assertEqual(int(lock_path.read_text().strip()), os.getpid())
+
+    # (d) Different names are independent — acquiring name-A doesn't block name-B.
+    def test_different_names_are_independent(self):
+        mod = _load_single_instance(self.workspace)
+        mod.acquire("bridge-alpha")
+        # Acquiring a different name in the same process should also succeed.
+        try:
+            mod.acquire("bridge-beta")
+        except SystemExit as e:
+            self.fail(f"acquire('bridge-beta') exited unexpectedly: {e}")
+        for name in ("bridge-alpha", "bridge-beta"):
+            lock_path = self.workspace / "state" / "locks" / f"{name}.lock"
+            self.assertTrue(lock_path.exists(), f"{name} lock file missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- New `src/single_instance.py` helper: acquires an OS-level exclusive `flock` on `$WORKSPACE/state/locks/<name>.lock`. `LOCK_NB` = non-blocking: second instance gets `BlockingIOError`, prints a one-line message, and exits 0 (so launchd KeepAlive doesn't restart-loop). Lock auto-releases on process death.
- **telegram-bridge**: `acquire("telegram-bridge")` at top of `main()`
- **slack-bridge**: `acquire("slack-bridge")` at top of `main()`
- **discord-bridge**: `acquire("discord-bridge")` in the daemon branch only (not the `send` subcommand path, which is invoked by `dm-result.py` and must not contend)

## Why this helps

The 2026-05-xx incident had both startup.sh and Sutando.app's launchd agent launch copies of the same bridge. The `pgrep` guard in startup.sh only checks at launch time; if both launchers race, neither sees the other. The flock is the canonical single-instance primitive: whoever opens the lock file first wins, regardless of launch order or timing.

## Test plan

- [ ] `python3 -m py_compile src/single_instance.py src/telegram-bridge.py src/discord-bridge.py src/slack-bridge.py` passes
- [ ] Start `telegram-bridge.py` in one terminal; start a second — second should log `another instance already holds the lock` and exit 0
- [ ] `discord-bridge.py send <channel_id> hello` (subcommand) works without acquiring lock
- [ ] Lock file appears at `$WORKSPACE/state/locks/telegram-bridge.lock` containing the PID

🤖 Generated with [Claude Code](https://claude.com/claude-code)