### PR TITLE
perf(discord-voice): hoist log mkdirSync + switch to createWriteStream (closes #1053)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -30,7 +30,7 @@
  */
 
 import { config as _dotenvConfig } from 'dotenv';
-import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, existsSync, readFileSync, readdirSync, unlinkSync } from 'node:fs';
+import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, existsSync, readFileSync, readdirSync, unlinkSync, createWriteStream } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { resolveWorkspace } from '../../../src/workspace_default.js';
 import { recordConversation, recordSession, recordToolCall } from '../../../src/conversation-store.js';
@@ -203,6 +203,8 @@ if (!GUILD_ID || !CHANNEL_ID) {
 mkdirSync(DATA_DIR, { recursive: true });
 mkdirSync(RESULTS_DIR, { recursive: true });
 mkdirSync(TASKS_DIR, { recursive: true });
+mkdirSync(dirname(DISCORD_VOICE_LOG), { recursive: true });
+const _opLogStream = createWriteStream(DISCORD_VOICE_LOG, { flags: 'a' });
 
 const ts = () => new Date().toISOString().slice(11, 23);
 const google = createGoogleGenerativeAI({ apiKey: GEMINI_API_KEY });
@@ -251,8 +253,7 @@ function appendOperationalLog(level: string, args: unknown[]): void {
 		const line = args
 			.map((a) => (typeof a === 'string' ? a : a instanceof Error ? (a.stack ?? a.message) : String(a)))
 			.join(' ');
-		mkdirSync(dirname(DISCORD_VOICE_LOG), { recursive: true });
-		appendFileSync(DISCORD_VOICE_LOG, `${new Date().toISOString()} ${level} ${line}\n`);
+		_opLogStream.write(`${new Date().toISOString()} ${level} ${line}\n`);
 	} catch {}
 }
 {


### PR DESCRIPTION
## Summary

Two perf nits from Lucy's review of #1026 (operational log tee), both in `appendOperationalLog`:

**1. mkdirSync on every log call → hoisted to module-init**
`mkdirSync(dirname(DISCORD_VOICE_LOG), { recursive: true })` was running on every `console.log` / `console.error` invocation (tool results, latency markers, error events). Moved alongside `DATA_DIR` / `RESULTS_DIR` / `TASKS_DIR` at module-init (line ~203). One syscall at boot, zero on the hot path.

**2. appendFileSync (sync, blocks event loop) → createWriteStream (async, non-blocking)**
`appendFileSync` holds the event loop for the duration of the write — a real cost on discord-voice's turn-latency hot path. Replaced with a single `createWriteStream(DISCORD_VOICE_LOG, { flags: 'a' })` opened at module-init (`_opLogStream`). Fix #1 falls out for free since the stream constructor opens the file once.

Behavior identical: every `console.log` / `console.error` still tees to `logs/discord-voice.log` with the same ISO-timestamp + level format. Fail-soft `try/catch` degrades silently on write error.

Closes #1053. Flagged by @liususan091219 in #1026 review (2026-05-22).

## Test plan

- [ ] Start discord-voice; confirm `logs/discord-voice.log` populates with timestamped lines
- [ ] No file-descriptor leak (single stream open at boot, not per-write)

🤖 Generated with [Claude Code](https://claude.com/claude-code)