### PR TITLE
fix(inline-tools): gate slideControlTool/fullscreenTool on presenter-mode sentinel

### DIFF
--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -20,6 +20,10 @@ import { resolveWorkspace, statusPath, statusReadPath } from './workspace_defaul
 // resolveWorkspace() is the canonical TS helper introduced in #821.
 const WORKSPACE_DIR = resolveWorkspace();
 
+// Gate slide-control + fullscreen on presenter-mode.sentinel.
+// Issue #1171: registering these globally causes Gemini to fire them on greetings.
+const _presenterActive = existsSync(join(WORKSPACE_DIR, 'state', 'presenter-mode.sentinel'));
+
 // Code-adjacent paths (skills/, etc.) ship with the repo checkout, NOT the
 // workspace. Compute REPO_ROOT from this file's URL so the resolution
 // survives any cwd drift at startup. Used by the skill-loader below.
@@ -1089,7 +1093,7 @@ export const inlineTools = assertUniqueToolNames([
 	volumeTool, brightnessTool, clipboardTool,
 	cancelTaskTool, toggleTasksTool, getCurrentTimeTool, getCoreStatusTool,
 	joinGmeetTool, lookupMeetingIdTool, callContactTool,
-	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, slideControlTool, fullscreenTool,
+	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool, ...(_presenterActive ? [slideControlTool, fullscreenTool] : []),
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
 	recentContextTool,
 	sendVisionFrameTool, startVisionTool, stopVisionTool,
@@ -1110,7 +1114,7 @@ export const ownerOnlyTools = [
 	pressKeyTool, scrollTool, switchTabTool, closeTabTool, openUrlTool,
 	switchAppTool, captureScreenTool, typeTextTool,
 	clipboardTool, cancelTaskTool, toggleTasksTool,
-	joinGmeetTool, callContactTool, slideControlTool, fullscreenTool,
+	joinGmeetTool, callContactTool, ...(_presenterActive ? [slideControlTool, fullscreenTool] : []),
 	showViewTool, readNoteTool, saveNoteTool, deleteNoteTool,
 	recentContextTool,
 	describeScreenTool, clickTool, pointAtTool, scrollAndDescribeTool, screenRecordTool, openFileTool, playVideoTool, pauseVideoTool, resumeVideoTool, replayVideoTool, closeVideoTool,

--- a/tests/inline-tools-presenter-gate.test.ts
+++ b/tests/inline-tools-presenter-gate.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Regression guard for the presenter-mode sentinel gate (#1171).
+//
+// Before this fix slideControlTool + fullscreenTool were unconditionally
+// included in inlineTools/ownerOnlyTools, so Gemini fired them on greetings
+// (3 unprovoked copres_next_anchor in <40s on a "can you hear me?" session).
+// The fix gates EXPOSURE at module load on state/presenter-mode.sentinel.
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'src/inline-tools.ts'),
+	'utf-8',
+);
+
+const GATED_SPREAD = /\.\.\.\(_presenterActive\s*\?\s*\[\s*slideControlTool\s*,\s*fullscreenTool\s*\]\s*:\s*\[\s*\]\s*\)/;
+
+function extractBlock(startMarker: string, endMarker: string): string {
+	const startIdx = SRC.indexOf(startMarker);
+	const endIdx = SRC.indexOf(endMarker, startIdx);
+	if (startIdx < 0 || endIdx < 0) return '';
+	return SRC.slice(startIdx, endIdx + endMarker.length);
+}
+
+const INLINE_TOOLS_BLOCK = extractBlock(
+	'export const inlineTools = assertUniqueToolNames(',
+	']);',
+);
+const OWNER_ONLY_BLOCK = extractBlock(
+	'export const ownerOnlyTools = [',
+	'];',
+);
+
+describe('inline-tools — presenter-mode sentinel gate (#1171)', () => {
+	it('declares _presenterActive derived from existsSync(...presenter-mode.sentinel)', () => {
+		assert.match(
+			SRC,
+			/_presenterActive\s*=\s*existsSync\(\s*join\(WORKSPACE_DIR,\s*['"]state['"]\s*,\s*['"]presenter-mode\.sentinel['"]\s*\)\s*\)/,
+		);
+	});
+
+	it('inlineTools contains the _presenterActive-gated spread', () => {
+		assert.ok(INLINE_TOOLS_BLOCK);
+		assert.match(INLINE_TOOLS_BLOCK, GATED_SPREAD);
+	});
+
+	it('ownerOnlyTools contains the _presenterActive-gated spread', () => {
+		assert.ok(OWNER_ONLY_BLOCK);
+		assert.match(OWNER_ONLY_BLOCK, GATED_SPREAD);
+	});
+
+	it('no bare slideControlTool/fullscreenTool outside the gated spread (inlineTools)', () => {
+		const stripped = INLINE_TOOLS_BLOCK.replace(GATED_SPREAD, '');
+		assert.doesNotMatch(stripped, /slideControlTool|fullscreenTool/);
+	});
+
+	it('no bare slideControlTool/fullscreenTool outside the gated spread (ownerOnlyTools)', () => {
+		const stripped = OWNER_ONLY_BLOCK.replace(GATED_SPREAD, '');
+		assert.doesNotMatch(stripped, /slideControlTool|fullscreenTool/);
+	});
+
+	it('#1171 issue reference present in gate comment', () => {
+		assert.match(SRC, /#1171/);
+	});
+
+	it('_presenterActive declared before inlineTools array literal', () => {
+		const presenterIdx = SRC.indexOf('_presenterActive');
+		const inlineToolsIdx = SRC.indexOf('export const inlineTools');
+		assert.ok(presenterIdx > 0 && inlineToolsIdx > 0);
+		assert.ok(presenterIdx < inlineToolsIdx);
+	});
+});


### PR DESCRIPTION
Closes #1171

## Problem
`slideControlTool` and `fullscreenTool` were registered globally in both `inlineTools` and `ownerOnlyTools` arrays. Gemini sees them on every turn and incorrectly fires `slide_control`/`fullscreen` on greetings and unrelated utterances.

## Fix
Gate exposure on `state/presenter-mode.sentinel` at module-load time:

```typescript
const _presenterActive = existsSync(join(WORKSPACE_DIR, 'state', 'presenter-mode.sentinel'));
```

Both arrays now use a spread conditional — tools are only registered when a presentation session is active:
```typescript
...(_presenterActive ? [slideControlTool, fullscreenTool] : [])
```

The sentinel is written by `scripts/presenter-mode.sh start N` and removed when the session ends, so the tools appear and disappear exactly when needed.

## Test plan
- [ ] Start voice session without sentinel → `slide_control`/`fullscreen` absent from tool list
- [ ] `bash scripts/presenter-mode.sh start 30` → restart voice agent → tools present
- [ ] `bash scripts/presenter-mode.sh stop` → restart → tools absent again
- [ ] Greetings ("hey", "how are you") no longer trigger spurious slide_control calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)