### PR TITLE
refactor(workspace): remove status_read_path legacy-root fallback

### DIFF
--- a/src/workspace_default.py
+++ b/src/workspace_default.py
@@ -281,17 +281,9 @@ def status_path(name: str, workspace: Path | None = None) -> Path:
 
 
 def status_read_path(name: str, workspace: Path | None = None) -> Path:
-    """READ location of a status file: prefer `state/<name>`, fall back to the
-    legacy workspace-root `<name>` so an un-migrated install keeps working for
-    one release. Returns the `state/` path when neither exists (caller handles
-    missing). The fallback branch is removed the release after this one.
-    """
+    """READ location of a status file: `state/<name>`. Caller handles missing."""
     ws = workspace if workspace is not None else resolve_workspace()
-    new = ws / "state" / name
-    if new.exists():
-        return new
-    legacy = ws / name
-    return legacy if legacy.exists() else new
+    return ws / "state" / name
 
 
 def _migrate_root_status(workspace: Path) -> bool:

--- a/src/workspace_default.ts
+++ b/src/workspace_default.ts
@@ -16,7 +16,6 @@
  *   2. ~/.sutando/workspace/
  */
 
-import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -36,16 +35,8 @@ export function statusPath(name: string, workspace?: string): string {
 	return join(workspace ?? resolveWorkspace(), 'state', name);
 }
 
-/**
- * READ location of a status file: prefer `state/<name>`, fall back to the
- * legacy workspace-root `<name>` so an un-migrated install keeps working for
- * one release. Returns the `state/` path when neither exists. The fallback
- * branch is removed the release after this one.
- */
+/** READ location of a status file: `state/<name>`. Caller handles missing. */
 export function statusReadPath(name: string, workspace?: string): string {
 	const ws = workspace ?? resolveWorkspace();
-	const p = join(ws, 'state', name);
-	if (existsSync(p)) return p;
-	const legacy = join(ws, name);
-	return existsSync(legacy) ? legacy : p;
+	return join(ws, 'state', name);
 }

--- a/tests/workspace-default.test.py
+++ b/tests/workspace-default.test.py
@@ -431,7 +431,7 @@ class TestInRepoBuildLogMigration(unittest.TestCase):
 
 class TestStatusPathHelpers(unittest.TestCase):
     """Tests for `status_path` (write location) and `status_read_path`
-    (read location with one-release legacy-root fallback)."""
+    (read location — always `state/<name>` after legacy fallback was removed)."""
 
     def setUp(self):
         self.workspace = Path(tempfile.mkdtemp(prefix="ws-status-"))
@@ -443,20 +443,21 @@ class TestStatusPathHelpers(unittest.TestCase):
         p = status_path("core-status.json", self.workspace)
         self.assertEqual(p, self.workspace / "state" / "core-status.json")
 
-    def test_read_path_prefers_state(self):
+    def test_read_path_returns_state_when_file_exists(self):
         (self.workspace / "state").mkdir(parents=True)
         (self.workspace / "state" / "core-status.json").write_text("{}")
-        (self.workspace / "core-status.json").write_text("{}")  # legacy too
         self.assertEqual(
             status_read_path("core-status.json", self.workspace),
             self.workspace / "state" / "core-status.json",
         )
 
-    def test_read_path_falls_back_to_legacy_root(self):
+    def test_read_path_ignores_legacy_root_file(self):
+        # Legacy fallback removed: state/ path is always returned even when
+        # a bare workspace-root file exists. _migrate_root_status handles moves.
         (self.workspace / "core-status.json").write_text("{}")
         self.assertEqual(
             status_read_path("core-status.json", self.workspace),
-            self.workspace / "core-status.json",
+            self.workspace / "state" / "core-status.json",
         )
 
     def test_read_path_returns_state_path_when_neither_exists(self):


### PR DESCRIPTION
## Summary

- Removes the `state/<name>` → `<workspace>/<name>` legacy fallback from `status_read_path()` (Python) and `statusReadPath()` (TypeScript)
- Drops now-unused `existsSync` import from `workspace_default.ts`

## Context

PR #940 introduced a one-release compatibility shim so un-migrated installs could read status files from the workspace root while `_migrate_root_status()` moved them into `state/` on first startup. Issue #943 tracked the removal.

The migration has been running since #940 merged. Any install that started after that has already had its files relocated. Removing the fallback now makes both helpers a single-line resolver: `ws / "state" / name`.

## Test plan

- [ ] Existing `workspace-default.test.py` and `workspace-default.test.ts` (if present) still pass
- [ ] Health-check, dashboard, agent-api, and quota-tracker all read status files from `state/` — verify by running `python3 src/health-check.py` on a workspace with files in `state/`

Closes #943, #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)