### PR TITLE
[workspace-migration] fix: install-claude-hooks + verify-setup + 2 test fixtures resolve workspace correctly

### DIFF
--- a/scripts/test-event-log.sh
+++ b/scripts/test-event-log.sh
@@ -12,6 +12,7 @@
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
 N_WRITERS="${1:-50}"
 M_EVENTS="${2:-50}"
 
@@ -21,9 +22,14 @@ from pathlib import Path
 from datetime import date
 
 REPO = Path("$REPO")
+WORKSPACE = Path("$WORKSPACE")
 N = $N_WRITERS
 M = $M_EVENTS
-LOG = REPO / "logs" / f"events-{date.today()}.jsonl"
+# Read from the workspace-anchored log file that event_log.py actually
+# writes to (src/event_log.py:57 — LOGS_DIR = WORKSPACE_DIR / "logs").
+# Previously read from REPO/logs/, which silently mismatched the writer
+# and produced false-positive PASS / FAIL depending on stale state.
+LOG = WORKSPACE / "logs" / f"events-{date.today()}.jsonl"
 
 if LOG.exists():
     LOG.unlink()

--- a/scripts/test-migrate-bundle.sh
+++ b/scripts/test-migrate-bundle.sh
@@ -53,7 +53,11 @@ REQUIRED+=("^sutando-migration/memory/MEMORY\\.md$")
 REQUIRED+=("^sutando-migration/setup-new-mac\\.sh$")
 
 # Notes (PR #343 addition).
-if [ -d "$REPO/notes" ] && [ "$(find "$REPO/notes" -name '*.md' | wc -l | tr -d ' ')" -gt 0 ]; then
+# Post-#769 notes/ lives under $SUTANDO_WORKSPACE (per the workspace contract),
+# not $REPO/notes. Reading the repo path falsely passed on workspace-only
+# setups and falsely required notes/ to be in the bundle on repo-only ones.
+NOTES_DIR="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/notes"
+if [ -d "$NOTES_DIR" ] && [ "$(find "$NOTES_DIR" -name '*.md' | wc -l | tr -d ' ')" -gt 0 ]; then
   REQUIRED+=("^sutando-migration/notes/.*\\.md$")
 fi
 

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -54,10 +54,18 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SETTINGS="$REPO_DIR/.claude/settings.json"
 
 # Hook specs: each line is "<event>|<command>".  Order = install order.
+#
+# Paths to session-handoff.sh / check-pending-tasks.sh resolve at hook-fire
+# time via ${SUTANDO_REPO_DIR:-$HOME/Desktop/sutando} — matches the
+# convention used by session-handoff.sh's auto-detect (CLAUDE.md
+# "$SUTANDO_REPO_DIR (added in #831 cleanup) names the public-repo
+# checkout") and by skills/catchup-after-startup's installer.  Hardcoding
+# $HOME/Desktop/sutando broke users with checkouts under
+# ~/Documents/sutando/sutando — the hook would silently never run.
 HOOKS=(
   "PreCompact|cp \"\$TRANSCRIPT_PATH\" \"\$HOME/Desktop/sutando-conversations/\$(date +%Y-%m-%dT%H-%M-%S).jsonl\""
-  "PreCompact|bash \$HOME/Desktop/sutando/src/session-handoff.sh \"\$TRANSCRIPT_PATH\""
-  "Stop|bash \$HOME/Desktop/sutando/src/check-pending-tasks.sh"
+  "PreCompact|bash \"\${SUTANDO_REPO_DIR:-\$HOME/Desktop/sutando}/src/session-handoff.sh\" \"\$TRANSCRIPT_PATH\""
+  "Stop|bash \"\${SUTANDO_REPO_DIR:-\$HOME/Desktop/sutando}/src/check-pending-tasks.sh\""
 )
 
 # Deprecated hooks to uninstall on re-run.  Each line: "<event>|<substring>".
@@ -70,6 +78,11 @@ DEPRECATED_HOOKS=(
   # firing killed the live Monitor watcher every turn). Cleanup-by-re-run
   # added in #1083 follow-up.
   "Stop|watch-tasks-stream.pid"
+  # Hardcoded $HOME/Desktop/sutando paths replaced with
+  # ${SUTANDO_REPO_DIR:-...}.  Substring match on the bare hardcoded
+  # path catches the old hook regardless of which version installed it.
+  "PreCompact|\$HOME/Desktop/sutando/src/session-handoff.sh"
+  "Stop|\$HOME/Desktop/sutando/src/check-pending-tasks.sh"
 )
 
 if ! command -v jq >/dev/null 2>&1; then

--- a/src/verify-setup.sh
+++ b/src/verify-setup.sh
@@ -2,6 +2,11 @@
 # Sutando setup verification — checks everything a new user needs
 # Usage: bash src/verify-setup.sh
 
+# Workspace directory — per-user runtime state lives here, not in the repo.
+# Honors $SUTANDO_WORKSPACE override; default ~/.sutando/workspace matches
+# the workspace contract (CLAUDE.md "Workspace contract" / docs/workspace-design.md).
+WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+
 PASS=0
 FAIL=0
 WARN=0
@@ -121,11 +126,12 @@ echo ""
 echo "Directories:"
 
 for d in tasks results notes; do
-  if [ -d "$d" ]; then
-    pass "$d/"
+  full="$WORKSPACE/$d"
+  if [ -d "$full" ]; then
+    pass "$d/ → $full"
   else
-    mkdir -p "$d"
-    pass "$d/ (created)"
+    mkdir -p "$full"
+    pass "$d/ (created) → $full"
   fi
 done
 


### PR DESCRIPTION
## Summary

4 sites where install/verify scripts and test fixtures were either repo-anchored (so failed for users whose checkout isn't `~/Desktop/sutando`) or read/wrote paths that didn't match the production resolver.

## Bugs fixed

### 1. `src/install-claude-hooks.sh:58-60` (audit bug 6)

Hook command strings hardcoded `$HOME/Desktop/sutando/src/session-handoff.sh` and `.../check-pending-tasks.sh`. Users with checkouts under `~/Documents/sutando/sutando` had the hook silently never fire — the shell would try to bash a path that didn't exist.

**Fix:** use `${SUTANDO_REPO_DIR:-$HOME/Desktop/sutando}` (resolved at hook-fire time). This matches the convention from CLAUDE.md ("`$SUTANDO_REPO_DIR` … names the public-repo checkout for scripts … that need the source tree") and the auto-detect pattern in `src/session-handoff.sh`.

Added two DEPRECATED_HOOKS entries so re-running the installer auto-migrates existing installs with hardcoded paths — the substring-match cleanup machinery added in #1083 follow-up already does the heavy lifting.

### 2. `src/verify-setup.sh:123-128` (audit bug 10)

`for d in tasks results notes; do mkdir -p "$d"` — relative paths, silently created in cwd. Run from `~/Documents/sutando/sutando` → dirs land in the repo root. Run from anywhere else → dirs land there. Neither matches `$SUTANDO_WORKSPACE/{tasks,results,notes}` where production reads.

**Fix:** explicit `WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"` at top of script; loop uses `"$WORKSPACE/$d"`. Output now shows the absolute resolved path so the user can verify.

### 3. `scripts/test-event-log.sh:23,26` (audit bug 28)

Test wrote `LOG = REPO / "logs" / f"events-{date.today()}.jsonl"`, but production `src/event_log.py:57` writes to `LOGS_DIR = WORKSPACE_DIR / "logs"`. The test would silently false-pass or false-fail depending on whether stale `$REPO/logs/events-*.jsonl` existed.

**Fix:** test reads `LOG = WORKSPACE / "logs" / ...` matching the production writer.

### 4. `scripts/test-migrate-bundle.sh:56` (audit bug 29)

`[ -d "$REPO/notes" ]` for bundle-required-files check. Post-#769 `notes/` moved to `$SUTANDO_WORKSPACE/notes`, so the test asserted on a path that no longer exists for workspace-only setups.

**Fix:** check `NOTES_DIR="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/notes"` instead.

## Empirical verification — all four PoCs

```
# 1. verify-setup with SUTANDO_WORKSPACE=/tmp/vsetup-test-NNNN
  ✓ tasks/ (created) → /tmp/vsetup-test-NNNN/tasks
  ✓ results/ (created) → /tmp/vsetup-test-NNNN/results
  ✓ notes/ (created) → /tmp/vsetup-test-NNNN/notes
```

```
# 2. install-claude-hooks on empty settings.json
install-claude-hooks: added=3 skipped=0 removed=0
→ hook command "bash \"${SUTANDO_REPO_DIR:-$HOME/Desktop/sutando}/src/session-handoff.sh\" \"$TRANSCRIPT_PATH\"" lands verbatim
```

```
# 3. install-claude-hooks on settings.json seeded with the OLD hardcoded paths
install-claude-hooks: added=3 skipped=0 removed=2
→ final settings.json contains only the new ${SUTANDO_REPO_DIR:-...} form; old hardcoded entries are gone
```

```
# 4. test-event-log resolved path matches event_log.LOGS_DIR
Production:  /Users/<user>/.sutando/workspace/logs/events-2026-05-28.jsonl
Test reader: /Users/<user>/.sutando/workspace/logs/events-2026-05-28.jsonl
```

## What is NOT in this PR

`scripts/test-results-health.sh:25,27` (audit bugs 30, 31) is the obvious sibling fix to ship together, but it depends on `scripts/results-health.sh` itself being workspace-anchored (PR #1276). Bundling the test fix with #1276 instead — test + script stay together, no temporal coupling between this PR and #1276's merge order.

Branched off current `upstream/main` (0 commits behind at branch time).

Refs v3 workspace-contract audit, bugs 6, 10, 28, 29 (master log: `workspace/notes/cwd-audit-v3-2026-05-27.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)