### PR TITLE
[workspace-migration] fix(voice-agent): resolve voice-context.txt fallback via import.meta.url, not cwd

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -638,9 +638,16 @@ const mainAgent: MainAgent = {
 				}
 			} catch {}
 			try {
-				const content = readFileSync('voice-context.txt', 'utf-8');
+				// Resolve fallback voice-context.txt relative to this source
+				// file (sits at the repo root, one dir above _voiceAgentDir =
+				// <repo>/src/).  Previously read bare 'voice-context.txt' which
+				// only worked when cwd was the repo root — broke for app-bundle
+				// launches and any cd'd invocation, silently falling through to
+				// "no context loaded".
+				const fallbackPath = join(_voiceAgentDir, '..', 'voice-context.txt');
+				const content = readFileSync(fallbackPath, 'utf-8');
 				const byteLen = Buffer.byteLength(content, 'utf-8');
-				console.log(`${ts()} [voice-context] loaded ${content.length} chars / ${byteLen} bytes from voice-context.txt (fallback)`);
+				console.log(`${ts()} [voice-context] loaded ${content.length} chars / ${byteLen} bytes from ${fallbackPath} (fallback)`);
 				return content;
 			} catch {
 				console.log(`${ts()} [voice-context] no context loaded (no env, no pointer, no fallback file)`);


### PR DESCRIPTION
## Summary

`src/voice-agent.ts:641` uses a bare `readFileSync('voice-context.txt', 'utf-8')` as the fallback when no `$SUTANDO_MEMORY_DIR/voice-contexts/active` pointer is set. The bare path resolves against process cwd, which is only the repo root for the documented `npx tsx src/voice-agent.ts` launch from `$REPO`. Every other launch path silently fell through to the "no context loaded" branch.

## Why it's silent

The control flow at L621-648 is:

```
try { /* read $MEMORY_DIR/voice-contexts/<pointer>.txt */ } catch {}
try { /* read 'voice-context.txt' (THE BUG) */ } catch {
  console.log('no context loaded');  // ← masked the missing fallback
  return '';
}
```

So when the fallback path fails (cwd != repo), the catch logs "no context loaded — no env, no pointer, no fallback file" — which is also the legitimate empty-context message when none of the three sources exist. Operators couldn't tell from the log line whether the fallback file was missing or the resolver was just wrong.

## Affected launch paths

- App-bundle launches (cwd = bundle dir, not repo)
- `cd /tmp && npx tsx <abspath>/src/voice-agent.ts` style invocation
- Sutando.app's planned launch path (#831 `SUTANDO_REPO_DIR` work) — the app starts the agent with cwd set to the app's working dir, not the checkout

## Fix

Anchor the fallback to the source file's location via `import.meta.url`. `_voiceAgentDir` already exists at L187 (`= dirname(fileURLToPath(import.meta.url)) = $REPO/src`). The fallback file sits one dir up at `$REPO/voice-context.txt`, so:

```typescript
const fallbackPath = join(_voiceAgentDir, '..', 'voice-context.txt');
const content = readFileSync(fallbackPath, 'utf-8');
```

The log line also prints the resolved absolute path now so future cwd-confusion is debuggable from the first run.

This intentionally keeps the fallback **repo-anchored**, not workspace. The audit explicitly tags this file as "public-repo voice-context.txt" — it's a checked-in asset, not per-user state. Workspace-anchoring would just create a *different* invisible failure mode (file simply doesn't exist there because nothing puts it there). The primary loader at L623-637 IS workspace/memory-dir anchored; this is the secondary public fallback.

## Empirical PoC

```
CWD=repo:  OLD reads OK         NEW reads OK
CWD=/tmp:  OLD reads MISSING    NEW reads OK
```

`npx tsc --noEmit` clean.

## Notes

- 1 site, 1 file. Smallest reasonable PR in this audit batch.
- Branched off current `upstream/main` (0 commits behind at branch time).
- Refs v3 workspace-contract audit, bug 11 (master log: `workspace/notes/cwd-audit-v3-2026-05-27.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)