### PR TITLE
docs: 'Before opening any PR or issue' checklist + PR template + CLAUDE.md pointer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+First-time contributor? Read CONTRIBUTING.md before submitting. The 6 checks
+below mirror the "Before opening any PR" section there. If you haven't run
+them, please do — it saves a lot of round-trips.
+-->
+
+## Closes
+
+<!-- e.g. closes #123. Leave empty if this isn't tied to an issue. -->
+
+## Summary
+
+<!-- 1-3 sentences. What problem does this solve? -->
+
+## Checklist
+
+- [ ] Confirmed no other open PR closes the same issue (`gh pr list --repo sonichi/sutando --search "closes #N"`)
+- [ ] Git author email matches my CLA-signed email (`git log -1 --format='%ae'` shows a GH-mapped email, not `*.local` or `noreply@anthropic.com`)
+- [ ] Single concern per PR — no bundled refactors / drive-by feature additions
+- [ ] Confirmed bug exists on `upstream/main` (or feature isn't already covered)
+- [ ] Test added (or N/A explained below)
+- [ ] Doesn't touch V1-workspace-hold areas (see `CONTRIBUTING.md` §5): `workspace_default.{py,ts}` / `sync-memory.sh` / `claude_home_path` / `agent-registry` paths
+
+## Test plan
+
+<!-- How did you verify this works? `npx tsc --noEmit` + actual run; tests; manual repro. Be specific. -->

--- a/.github/workflows/cla-recheck-on-push.yml
+++ b/.github/workflows/cla-recheck-on-push.yml
@@ -1,0 +1,32 @@
+name: cla-recheck-on-push
+
+# CLA-Assistant doesn't re-evaluate license/cla on push events — only on
+# pull_request.opened / reopened / synchronize-with-a-comment-trigger. When a
+# contributor pushes a fix after their first sign, or a maintainer clicks
+# "Update branch", the check stays PENDING until someone manually comments
+# `@cla-assistant check`. That blocks the PR on contributor availability,
+# which we don't want. This workflow fires the recheck comment automatically
+# on every push to an open PR, so the bot re-runs without human action.
+#
+# See CONTRIBUTING.md §6 "After update-branch, CLA-Assistant may not auto-rerun".
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  recheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '@cla-assistant check'
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,9 @@ Read `CONTRIBUTING.md` and follow its "Before opening any PR or issue" section. 
 - Single concern per PR; no bundled refactors
 - Confirm the bug exists on `upstream/main` before adding a fix
 - Respect the V1-workspace hold list (`workspace_default.{py,ts}`, `sync-memory.sh`, `claude_home_path`, `agent-registry` paths)
-- After `update-branch`, CLA-Assistant may not auto-rerun — try `recheck` comment or close+reopen if stuck
+- After `update-branch`, CLA-Assistant may not auto-rerun — try `@cla-assistant check` comment or close+reopen if stuck
 
-Skill-PR destination: new audit-style or standalone skills go to **`sonichi/sutando-skills`**, not `sonichi/sutando`. See `feedback_check_skill_pr_destination.md` for the coupled-vs-standalone distinction.
+Skill-PR destination: a skill is **coupled** (PR to `sonichi/sutando`) if it imports from `src/` or another skill, modifies main-repo files, or is tightly bound to a feature there (e.g. `skills/phone-conversation/`). A skill is **standalone** (PR to `sonichi/sutando-skills`) if it ships its own scripts/binaries, reads files but doesn't import main-repo modules, and works against any checkout. If unsure, ask in #design.
 
 ## Workspace contract
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,19 @@ Before creating a PR, check `gh pr list --state open` for an existing PR on the 
 
 Never commit directly to main. Always work on a feature branch.
 
+### Before opening any PR or issue
+
+Read `CONTRIBUTING.md` and follow its "Before opening any PR or issue" section. The short checklist:
+
+- Search existing open + recently-closed PRs/issues for duplicates (`gh pr list --search "closes #N"`)
+- Confirm your git author email is GH-mapped — not `*.local` (macOS hostname auto-fill) or `noreply@anthropic.com` (Claude Code default). CLA-Assistant silently leaves the check PENDING on unmappable emails.
+- Single concern per PR; no bundled refactors
+- Confirm the bug exists on `upstream/main` before adding a fix
+- Respect the V1-workspace hold list (`workspace_default.{py,ts}`, `sync-memory.sh`, `claude_home_path`, `agent-registry` paths)
+- After `update-branch`, CLA-Assistant may not auto-rerun — try `recheck` comment or close+reopen if stuck
+
+Skill-PR destination: new audit-style or standalone skills go to **`sonichi/sutando-skills`**, not `sonichi/sutando`. See `feedback_check_skill_pr_destination.md` for the coupled-vs-standalone distinction.
+
 ## Workspace contract
 
 Sutando's file state lives in three concentric spaces — **Code** (`$SUTANDO_REPO_DIR`, the git checkout), **State** (`$SUTANDO_WORKSPACE`, per-user runtime), **Memory** (`$SUTANDO_MEMORY_DIR`, user-content synced across the fleet — legacy alias `$SUTANDO_PRIVATE_DIR` honored for one release per #870). See [`docs/workspace-design.md`](docs/workspace-design.md) for the 3-space mental model + "Quick decision: which space?" flowchart when adding new code or data.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,85 @@ See existing skills for examples. Install with `bash skills/install.sh`.
 - **web-client.ts**: The entire web UI is an inline HTML template literal. Do NOT use TypeScript-only syntax (like `as Type` casts) inside the embedded `<script>` block — the browser runs it as plain JS.
 - All scripts should work from a fresh clone with minimal setup
 
+## Before opening any PR or issue
+
+Six checks save a lot of churn for both sides:
+
+### 1. Search for existing PRs / issues first
+
+The same fix has been opened in 10+ different PRs before (e.g. the bare-except narrow in `skills/quota-tracker/scripts/read-quota.py` had 10 attempts across multiple contributors before one landed). Before you open:
+
+```bash
+# Open + recently closed PRs that closed/referenced the same issue
+gh pr list --repo sonichi/sutando --state all --limit 30 --search "closes #N"
+
+# Open issues with related keywords
+gh issue list --repo sonichi/sutando --state open --search "your-keyword"
+```
+
+If someone else's PR is already in flight and CLA-blocked or just stale, prefer pinging them or rebasing their branch over opening a parallel one.
+
+### 2. CLA + git author email
+
+CLA-Assistant maps your commits to a GitHub user via the author email. Two pitfalls trip almost every new contributor:
+
+```bash
+# Check your most recent commit's author email
+git log -1 --format='%ae'
+
+# If it shows something like:
+#   user@Hostname.local                ← macOS hostname auto-fill
+#   noreply@anthropic.com              ← Claude Code default for bot commits
+# CLA-Assistant CANNOT map it to your GitHub account → check stays PENDING forever.
+
+# Fix it before pushing:
+git config user.email YOUR_GH_MAPPED_EMAIL
+git commit --amend --reset-author --no-edit   # rewrites only the latest commit
+# or for a fuller rewrite:
+git rebase -i origin/main   # mark each as 'edit', then --reset-author + continue
+```
+
+If you're running a Sutando bot that commits on your behalf, set the bot's `git config user.email` to your CLA-signed email locally (don't share the keychain — just configure git).
+
+### 3. Single concern per PR
+
+A PR that fixes "X" should not also bundle "while I was here, I cleaned up Y / refactored Z / added a new feature W". Split those:
+
+- One concern → one PR → one closes-link
+- Mixing concerns triples the review burden, increases revert blast radius, and makes merge conflicts harder
+- "Drive-by" cleanup that happens to land in the same hunk is fine; net-new scope is not
+
+### 4. Confirm the bug exists on `upstream/main`
+
+Before adding a fix:
+
+```bash
+git fetch upstream main
+git show upstream/main:path/to/file.py | grep -n "the buggy line"
+```
+
+If the bug is already fixed upstream, the PR is unnecessary. Save yourself + reviewer time.
+
+### 5. Respect the V1-workspace hold list
+
+The V1 workspace contract migration (3-space Code / Workspace / Memory model) is in design. PRs that touch the following are currently held — please don't open new ones in these areas until the contract is finalized:
+
+- `src/workspace_default.py` / `src/workspace_default.ts` resolution logic
+- `scripts/sync-memory.sh` path probing (`SUTANDO_MEMORY_DIR` / `SUTANDO_PRIVATE_DIR`)
+- new `claude_home_path()` helpers or similar path-derivation utilities
+- migration scaffolding in `skills/agent-registry/` paths
+
+If unsure, ask in #design before opening.
+
+### 6. After `update-branch`, CLA-Assistant may not auto-rerun
+
+If your PR was BEHIND main and you click "Update branch" (or `gh pr update-branch`), the new HEAD commit may show `license/cla` PENDING and never resolve. Known issue. Workarounds (in order):
+
+1. Wait — sometimes the bot catches up in ~10 minutes
+2. Comment `recheck` on the PR
+3. Close and reopen the PR (forces a `pull_request.reopened` webhook)
+4. Ask a maintainer to admin-merge if you've verified the underlying CLA is signed
+
 ## Pull requests
 
 - Keep PRs focused — one feature or fix per PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ If unsure, ask in #design before opening.
 If your PR was BEHIND main and you click "Update branch" (or `gh pr update-branch`), the new HEAD commit may show `license/cla` PENDING and never resolve. Known issue. Workarounds (in order):
 
 1. Wait — sometimes the bot catches up in ~10 minutes
-2. Comment `recheck` on the PR
+2. Comment `@cla-assistant check` on the PR
 3. Close and reopen the PR (forces a `pull_request.reopened` webhook)
 4. Ask a maintainer to admin-merge if you've verified the underlying CLA is signed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ If unsure, ask in #design before opening.
 
 ### 6. After `update-branch`, CLA-Assistant may not auto-rerun
 
-If your PR was BEHIND main and you click "Update branch" (or `gh pr update-branch`), the new HEAD commit may show `license/cla` PENDING and never resolve. Known issue. Workarounds (in order):
+If your PR was BEHIND main and you click "Update branch" (or `gh pr update-branch`), the new HEAD commit may show `license/cla` PENDING and never resolve. Known issue. In most cases `.github/workflows/cla-recheck-on-push.yml` will auto-fire the recheck comment for you on every push, but if the workflow is disabled or fails, the manual workarounds are (in order):
 
 1. Wait — sometimes the bot catches up in ~10 minutes
 2. Comment `@cla-assistant check` on the PR


### PR DESCRIPTION
Bakes lessons from recent PR churn into the docs so newcomers (human + bot) don't repeat them.

## What changes

### `CONTRIBUTING.md` — new section "Before opening any PR or issue"

Six checks before opening:

1. **Search existing PRs / issues first.** The bare-except narrow in quota-tracker had 10 attempts across 3+ authors before one landed. Includes the exact `gh pr list --search "closes #N"` recipe.
2. **CLA + git author email.** Two recurring pitfalls — `*.local` hostname auto-fill and `noreply@anthropic.com` bot default. Both leave `license/cla` PENDING forever because CLA-Assistant can't map them to a GitHub user. Includes the `git commit --amend --reset-author --no-edit` fix.
3. **Single concern per PR.** No bundled refactors / drive-by features. Triples review burden when mixed.
4. **Confirm the bug exists on `upstream/main`.** Saves time on bugs already fixed.
5. **Respect the V1-workspace hold list.** Lists the specific files/areas in current design freeze (workspace_default, sync-memory.sh path probing, claude_home_path helpers, agent-registry paths). Points to #design for questions.
6. **After `update-branch`, CLA-Assistant may not auto-rerun.** Documents the workaround chain: wait → `recheck` comment → close+reopen → admin-merge.

### `.github/PULL_REQUEST_TEMPLATE.md` (new file)

Pre-fills every new PR's body with a 6-item checklist mirroring the CONTRIBUTING.md section. GitHub auto-renders this template when the user clicks "Open PR" — fewer reviewer round-trips chasing the same questions.

### `CLAUDE.md` — "Before opening any PR or issue" subsection in `## Repo rules`

So any Sutando bot or fork-runner Claude Code session that loads CLAUDE.md as context also follows the same rules. Pointers to CONTRIBUTING.md for the long form, inline short checklist for fast lookup.

## Why

Tonight (2026-05-28→29) we hit every one of these patterns:

| pattern | tonight's instance |
|---|---|
| Duplicate PRs | #1062 had 10 close attempts (Chi 3 + Bassil 6 + Vasiliy 1); only Vasiliy's #1094 is still open |
| `*.local` CLA email | VasiliyRad PRs #1020 / #1046 / #1093 / #1094 all blocked once + had to amend with `vasiliy@live.com` |
| update-branch CLA stuck | #1265 / #1267 / #1268 / #1290 / #1289 / #1292 / #1299 / #1304 batch all hit it; required Chi admin-merge or re-sign |
| V1 workspace hold not communicated | #1264 / #1079 were ready-to-merge but had to skip — design still pending |
| Scope creep | #1267 bundled stuck-CONNECTING detection with the 1006-DNS-downgrade |

All 5 patterns are now documented in one place.

## Test plan

- [x] Existing `CONTRIBUTING.md` preserved + extended (insert before "## Pull requests"); no removed content
- [x] `.github/PULL_REQUEST_TEMPLATE.md` syntax-valid — GitHub renders Markdown checklists inline
- [x] `CLAUDE.md` insert lives under existing `## Repo rules` section; bots already load this file
- [ ] After merge, open a small test PR to confirm template auto-fills

🤖 Generated with [Claude Code](https://claude.com/claude-code)