### PR TITLE
docs: CONTRIBUTING — Mac Mini → Mac Studio (stale label)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ If your PR was BEHIND main and you click "Update branch" (or `gh pr update-branc
 - Check for lazy imports if your code reads from `.env` — static ESM imports resolve before module-level code runs
 
 ### Review process
-PRs are reviewed by one of the Sutando bot instances (MacBook or Mac Mini). Reviews check for:
+PRs are reviewed by one of the Sutando bot instances (MacBook or Mac Studio). Reviews check for:
 - Correctness and test coverage
 - Import strategy (lazy vs static — avoid breaking env var reads)
 - Default-value changes that could affect existing behavior
@@ -156,7 +156,7 @@ Voice (Gemini Live) <-> File Bridge (tasks/results) <-> Claude Code (brain)
 
 Two machines coordinate via Discord:
 - **MacBook** — travels with the owner
-- **Mac Mini** — always-on at home
+- **Mac Studio** — always-on at home
 
 See README.md for the full architecture diagram.
 


### PR DESCRIPTION
## Summary

Two stale `Mac Mini` references in `CONTRIBUTING.md` — the "always-on at home" machine is now a Mac Studio. Same architecture, accurate hardware label.

## Sites fixed

- L140 (`### Review process`): "MacBook or Mac Mini" → "MacBook or Mac Studio"
- L159 (`## Architecture`): "Mac Mini — always-on at home" → "Mac Studio — always-on at home"

Followup to PR #1338 (just merged) which added the "Before opening any PR or issue" section but didn't touch these pre-existing stale lines.

## Test plan

- [x] Read-only doc change, no code paths touched
- [x] Branched off `upstream/main` post-#1338-merge (commit `be3f578` base)

🤖 Generated with [Claude Code](https://claude.com/claude-code)