### PR TITLE
feat(voice): work-tool both-approaches (misheard-confirm + transcript)

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -301,6 +301,22 @@ export const workTool: ToolDefinition = {
 		// shape as agent-api.py's /task endpoint after PR #982; consumers
 		// (`_isVoiceTask`, `parse_priority_from_text`) stop scanning at
 		// the first `task:` line.
+		// Attach a short window of recent conversation AFTER the `task:` line so
+		// the core can self-correct a misheard/garbled transcript (per Chi: "the
+		// voice agent may mishear and pass the wrong transcripts"). It lands in
+		// the task BODY (everything after `task:`), so it cannot forge header
+		// fields — consumers stop scanning headers at the first `task:` line.
+		// Best-effort: empty string if no log/session yet.
+		let contextBlock = '';
+		try {
+			const recent = getRecentConversation(4);
+			if (recent) {
+				contextBlock =
+					`\n\n--- recent voice transcript (may contain ASR errors; if the task above ` +
+					`seems garbled or doesn't match this, infer the true intent from it or ask to ` +
+					`confirm before acting) ---\n${recent}\n`;
+			}
+		} catch { /* best effort — never block delegation on context attach */ }
 		const content =
 			`id: ${taskId}\n` +
 			`timestamp: ${timestamp}\n` +
@@ -309,7 +325,7 @@ export const workTool: ToolDefinition = {
 			`user_id: ${ownerId}\n` +
 			`access_tier: owner\n` +
 			`priority: urgent\n` +
-			`task: ${task}\n`;
+			`task: ${task}${contextBlock}\n`;
 		writeFileSync(join(TASK_DIR, `${taskId}.txt`), content);
 		// Resolve per-task timeout. 0 → no timeout. Negative or NaN → default.
 		// Cap at 6 hours to prevent runaway pending-state if the voice agent

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -718,6 +718,7 @@ const mainAgent: MainAgent = {
 		'- If you KNOW the answer from your instructions or context, answer directly. Only delegate to work for questions you genuinely cannot answer.',
 		'- DEICTIC SCREEN REFERENCES: When the user uses a deictic word ("this", "that", "it", "this part", "fix this", "what does this say") without obvious conversational antecedent, FIRST call read_selection to capture what they\'re pointing at on screen. Then act on the returned selection/window context. Only ask a clarifying question if read_selection returns empty AND no prior conversation context resolves the reference. Default to read_selection over "which one do you mean?" — the user is usually pointing.',
 		'- MISSING CONTEXT: When the user references something you don\'t have context for ("the draft", "what we discussed", "type that", "send what I asked for"), ALWAYS delegate to work. The core agent has the full conversation history and knows what was discussed. Never guess or ask the user to repeat — just call work.',
+		'- MISHEARD-RISK CONFIRM (distinct from MISSING CONTEXT): if the request came through GARBLED or you are genuinely unsure you transcribed it correctly — noisy audio, a phrase that does not parse, or two equally-likely readings of WHAT to delegate — do ONE brief read-back of your understanding ("You want me to X — right?") before calling work, rather than delegating a possibly-wrong transcript. Keep it to a single short confirm. If the request is clear, SKIP this and call work normally — the core also receives the recent transcript and can self-correct, so do NOT over-confirm; only when you are genuinely unsure of the words.',
 		(() => meetingActive
 			? '- IN MEETING MODE: When addressed by name, answer DIRECTLY from what you heard in the meeting. Do NOT call work — the core agent cannot hear the meeting audio and has no context. You are the one who listened. Summarize discussions, decisions, and action items from your own memory of the conversation.'
 			: '- When in doubt, call work.'
@@ -1262,6 +1263,18 @@ async function main() {
 		userHasInterrupted = true;
 		console.log(`${ts()} [VoiceSession] user interrupt detected — userHasInterrupted=true`);
 	});
+
+	// Audio-duck relay: flag the slide server (localhost:7877) when Sutando is
+	// producing audio, so the deck ducks the active slide video under the
+	// narration. turn.start → speaking on; turn.end / turn.interrupted → off.
+	// Fire-and-forget; failures are harmless (deck just won't duck). Decouples
+	// ducking from Gemini tool-call timing entirely. (Observe-talk feature.)
+	const _duck = (mode: 'on' | 'off') => {
+		try { fetch(`http://localhost:7877/speaking/${mode}`, { method: 'POST' }).catch(() => {}); } catch {}
+	};
+	session.eventBus.subscribe('turn.start', () => _duck('on'));
+	session.eventBus.subscribe('turn.end', () => _duck('off'));
+	session.eventBus.subscribe('turn.interrupted', () => _duck('off'));
 
 	const shutdown = async () => {
 		console.log(`\n${ts()} Shutting down...`);


### PR DESCRIPTION
## Summary
- **voice-agent.ts** — narrow **MISHEARD-RISK CONFIRM**: when a voice ask came through garbled or is genuinely ambiguous about *what* to delegate, do one brief read-back before calling `work`. Distinct from MISSING-CONTEXT (which still delegates); conservative, so clear requests get no added friction.
- **task-bridge.ts `workTool`** — attach a 4-line recent-conversation window to the task **body** (after the `task:` line, so it can't forge headers) so the core can self-correct a misheard transcript even when the read-back doesn't fire.
- Also folds in the prior uncommitted auto-duck relay (`turn.start`/`end`/`interrupted` → `POST /speaking`) so main stays clean. typecheck clean.

Both approaches per Chi's #talk direction 2026-05-28 — voice-side confirm + core-side self-correct.

## Test plan
- [ ] Voice: a garbled/ambiguous ask triggers one read-back before `work`; a clear ask does not.
- [ ] Core: a misheard transcript self-corrects from the attached recent-conversation window.
- [ ] Auto-duck: speaking events POST `/speaking` as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
