### PR TITLE
feat(quota-tracker): burn-rate EWMA + passes-left forecast (closes #1087)

### DIFF
--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -6,10 +6,19 @@ Usage:
   python3 read-quota.py              # human readable
   python3 read-quota.py --json       # machine readable
   python3 read-quota.py --gate       # exit 1 if exhausted
+
+Burn-rate tracking (closes #1087):
+  On each human/json read, tracks per-5min utilization delta via an EWMA
+  (alpha=0.3) stored in state/quota-burn-history.json. Outputs:
+    Burn rate: X.X%/pass (N samples)
+    Est. passes left: N (~Nm)
+  Skips the sample if a 5h reset occurred (util dropped) or the gap is
+  outside the 2min–2h window.
 """
 
 import json
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -28,14 +37,94 @@ sys.path.insert(0, str(_REPO_ROOT / "src"))
 try:
     from workspace_default import status_read_path  # noqa: E402
     _canonical = status_read_path("quota-state.json")
+    _burn_history_path = status_read_path("quota-burn-history.json")
 except ImportError:
     _canonical = None
+    _burn_history_path = None
 
 if _canonical is not None and _canonical.exists():
     QUOTA_FILE = _canonical
 else:
     print("No quota-state.json found. Is the credential proxy running?")
     sys.exit(1)
+
+BURN_HISTORY_FILE: Path | None = _burn_history_path
+
+# EWMA smoothing factor. 0.3 = ~3-sample half-life, responsive without noise.
+_EWMA_ALPHA = 0.3
+# Sample inclusion window: skip deltas from outside [MIN_GAP_S, MAX_GAP_S].
+_MIN_GAP_S = 120     # 2 min — same-pass double-reads shouldn't count
+_MAX_GAP_S = 7200    # 2 h — stale gap yields unreliable per-pass rate
+
+
+def _load_burn_history() -> dict:
+    if not BURN_HISTORY_FILE:
+        return {}
+    try:
+        return json.loads(BURN_HISTORY_FILE.read_text())
+    except Exception:
+        return {}
+
+
+def _save_burn_history(h: dict) -> None:
+    if not BURN_HISTORY_FILE:
+        return
+    try:
+        BURN_HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = BURN_HISTORY_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(h, indent=2))
+        tmp.rename(BURN_HISTORY_FILE)
+    except Exception:
+        pass
+
+
+def _update_burn_rate(current_util_5h: float) -> dict | None:
+    """Update burn-rate EWMA with the current 5h utilization sample.
+
+    Returns a dict with burn_rate_pct_per_pass and estimated_passes_left
+    if enough history exists, else None.
+    """
+    now = time.time()
+    h = _load_burn_history()
+    last_ts = h.get("last_read_ts")
+    last_util = h.get("last_util_5h")
+    ewma = h.get("burn_rate_5h_ewma")
+    samples = h.get("burn_samples", 0)
+
+    new_h = dict(h)
+    new_h["last_read_ts"] = now
+    new_h["last_util_5h"] = current_util_5h
+    new_h["schema_version"] = 1
+
+    result = None
+    if last_ts is not None and last_util is not None:
+        gap = now - last_ts
+        delta = current_util_5h - last_util
+        if _MIN_GAP_S <= gap <= _MAX_GAP_S and delta >= 0:
+            # Normalise delta to a "per 5-min pass" rate regardless of actual gap
+            per_pass = delta * (300.0 / gap)
+            if ewma is None:
+                ewma = per_pass
+                samples = 1
+            else:
+                ewma = _EWMA_ALPHA * per_pass + (1 - _EWMA_ALPHA) * ewma
+                samples = min(samples + 1, 99)
+            new_h["burn_rate_5h_ewma"] = ewma
+            new_h["burn_samples"] = samples
+
+    _save_burn_history(new_h)
+
+    ewma_final = new_h.get("burn_rate_5h_ewma")
+    if ewma_final and ewma_final > 0 and new_h.get("burn_samples", 0) >= 2:
+        remaining_pct = (1 - current_util_5h) * 100
+        passes_left = remaining_pct / (ewma_final * 100)
+        result = {
+            "burn_rate_pct_per_pass": round(ewma_final * 100, 2),
+            "burn_samples": new_h["burn_samples"],
+            "estimated_passes_left": round(passes_left, 1),
+            "estimated_minutes_left": round(passes_left * 5),
+        }
+    return result
 
 
 def main():
@@ -62,6 +151,11 @@ def main():
     if reset_7d:
         result["reset_7d"] = datetime.fromtimestamp(int(reset_7d)).isoformat()
 
+    if "--gate" not in sys.argv:
+        burn = _update_burn_rate(util_5h)
+        if burn:
+            result["burn"] = burn
+
     if "--json" in sys.argv:
         print(json.dumps(result, indent=2))
         return
@@ -77,6 +171,10 @@ def main():
     print(f"7d window: {int(util_7d * 100)}% used, {result['remaining_7d_pct']}% remaining")
     if reset_7d:
         print(f"  Resets: {datetime.fromtimestamp(int(reset_7d)).strftime('%H:%M %b %d')}")
+    if result.get("burn"):
+        b = result["burn"]
+        print(f"Burn rate: {b['burn_rate_pct_per_pass']}%/pass ({b['burn_samples']} samples)")
+        print(f"Est. passes left: {b['estimated_passes_left']} (~{b['estimated_minutes_left']}m)")
 
 
 if __name__ == "__main__":

--- a/tests/quota-burn-rate.test.py
+++ b/tests/quota-burn-rate.test.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Tests for burn-rate EWMA in skills/quota-tracker/scripts/read-quota.py (PR #1319).
+
+Covers _load_burn_history, _save_burn_history, and _update_burn_rate.
+
+Run: python3 tests/quota-burn-rate.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent
+_SCRIPT = REPO / "skills" / "quota-tracker" / "scripts" / "read-quota.py"
+
+
+def _load_module(workspace: Path):
+    """Load read-quota.py with a controlled workspace and a dummy quota-state.json."""
+    os.environ["SUTANDO_WORKSPACE"] = str(workspace)
+    sys.modules.pop("read_quota", None)
+    sys.modules.pop("read_quota_under_test", None)
+
+    # The module exits early if quota-state.json is missing. Create a minimal one.
+    state_dir = workspace / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    quota_file = state_dir / "quota-state.json"
+    if not quota_file.exists():
+        quota_file.write_text(json.dumps({"headers": {
+            "anthropic-ratelimit-unified-status": "allowed",
+            "anthropic-ratelimit-unified-5h-utilization": "0.1",
+            "anthropic-ratelimit-unified-remaining": "900",
+            "anthropic-ratelimit-unified-reset": "2026-05-28T12:50:00Z",
+        }}))
+
+    spec = importlib.util.spec_from_file_location("read_quota_under_test", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(REPO / "src"))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestBurnHistory(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="quota-burn-test-"))
+        self.mod = _load_module(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_load_returns_empty_on_missing_file(self):
+        self.mod.BURN_HISTORY_FILE = self.tmp / "state" / "nonexistent.json"
+        result = self.mod._load_burn_history()
+        self.assertEqual(result, {})
+
+    def test_save_and_load_roundtrip(self):
+        path = self.tmp / "state" / "burn.json"
+        self.mod.BURN_HISTORY_FILE = path
+        data = {"last_read_ts": 1234567.0, "burn_rate_5h_ewma": 0.002, "burn_samples": 5}
+        self.mod._save_burn_history(data)
+        loaded = self.mod._load_burn_history()
+        self.assertEqual(loaded["burn_samples"], 5)
+        self.assertAlmostEqual(loaded["burn_rate_5h_ewma"], 0.002)
+
+    def test_load_returns_empty_on_corrupt_file(self):
+        path = self.tmp / "state" / "corrupt.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not valid json {{")
+        self.mod.BURN_HISTORY_FILE = path
+        self.assertEqual(self.mod._load_burn_history(), {})
+
+
+class TestUpdateBurnRate(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="quota-burn-test-"))
+        self.mod = _load_module(self.tmp)
+        self.burn_file = self.tmp / "state" / "quota-burn-history.json"
+        self.mod.BURN_HISTORY_FILE = self.burn_file
+        self._t = 1_000_000.0  # controllable wall-clock
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _call(self, util: float, advance_s: float = 0.0):
+        self._t += advance_s
+        with patch.object(self.mod.time, "time", return_value=self._t):
+            return self.mod._update_burn_rate(util)
+
+    def test_first_call_returns_none(self):
+        result = self._call(0.10)
+        self.assertIsNone(result)
+
+    def test_second_call_gap_too_small_returns_none(self):
+        self._call(0.10)
+        # 60s < MIN_GAP_S (120s) → sample skipped, still no EWMA
+        result = self._call(0.12, advance_s=60)
+        self.assertIsNone(result)
+
+    def test_second_call_valid_gap_one_sample_returns_none(self):
+        self._call(0.10)
+        # 300s is within [120, 7200], delta positive → 1 sample → still None (need ≥2)
+        result = self._call(0.15, advance_s=300)
+        self.assertIsNone(result)
+
+    def test_two_valid_samples_returns_forecast_dict(self):
+        self._call(0.10)
+        self._call(0.15, advance_s=300)   # sample 1
+        result = self._call(0.20, advance_s=300)  # sample 2 → forecast
+        self.assertIsNotNone(result)
+        self.assertIn("burn_rate_pct_per_pass", result)
+        self.assertIn("burn_samples", result)
+        self.assertIn("estimated_passes_left", result)
+        self.assertIn("estimated_minutes_left", result)
+        self.assertEqual(result["burn_samples"], 2)
+
+    def test_gap_too_large_skips_sample(self):
+        self._call(0.10)
+        # 8000s > MAX_GAP_S (7200s) → skipped
+        result = self._call(0.15, advance_s=8000)
+        self.assertIsNone(result)
+
+    def test_decreasing_util_skips_sample(self):
+        self._call(0.20)
+        # delta < 0 (quota reset or read error) → sample excluded
+        result = self._call(0.10, advance_s=300)
+        self.assertIsNone(result)
+
+    def test_ewma_smoothing_applied(self):
+        alpha = self.mod._EWMA_ALPHA
+        # First valid sample: per_pass = 0.05 * (300/300) = 0.05 → ewma = 0.05
+        self._call(0.10)
+        self._call(0.15, advance_s=300)  # ewma initialised to 0.05
+
+        # Second valid sample: per_pass = 0.05 → ewma = alpha*0.05 + (1-alpha)*0.05 = 0.05
+        result = self._call(0.20, advance_s=300)
+        self.assertIsNotNone(result)
+        expected_ewma_pct = round(0.05 * 100, 2)
+        self.assertAlmostEqual(result["burn_rate_pct_per_pass"], expected_ewma_pct, places=1)
+
+    def test_estimated_passes_left_positive(self):
+        self._call(0.10)
+        self._call(0.15, advance_s=300)
+        result = self._call(0.20, advance_s=300)
+        self.assertIsNotNone(result)
+        self.assertGreater(result["estimated_passes_left"], 0)
+        # estimated_minutes_left ≈ passes_left * 5
+        self.assertAlmostEqual(
+            result["estimated_minutes_left"],
+            round(result["estimated_passes_left"] * 5),
+            delta=1,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1087. Revived from sonichi/sutando#1319 — Chi's commits with author/committer email rewritten to his CLA-mapped address.

## Two commits

1. **`feat(quota-tracker): burn-rate EWMA + passes-left forecast`** — Chi's original feature commit, rebased onto current main + 1 trivial import-line conflict resolved (took both `_canonical = status_read_path(...)` and `_burn_history_path = status_read_path(...)` since #1094 narrowed the surrounding `except` block in main).
2. **`test(quota-tracker): 11 tests for burn-rate EWMA (closes #1087 test gap)`** — Chi's original test commit, preserved.

Both author + committer emails rewritten from `wangchi@Chis-MacBook-Pro.local` (hostname-default, CLA-unmapped) to `4250911+sonichi@users.noreply.github.com` (Chi's CLA-mapped GitHub-noreply). Filter-branch rewrite preserves authorship attribution (still `Chi Wang`); CLA-Assistant should re-verify automatically.

## Why a new PR instead of reopening #1319

I force-pushed the CLA-mapped commits to `feat/quota-burn-rate-1087` before attempting `gh pr reopen 1319`. GitHub refused with "state cannot be changed. The feat/quota-burn-rate-1087 branch was force-pushed or recreated" — once a closed PR's branch has been force-pushed, reopen is mechanically impossible. The correct order would have been reopen first, then force-push; lesson learned (R14 in my local rules now amended).

## Verification done before opening

- ✅ `python3 -m py_compile skills/quota-tracker/scripts/read-quota.py` — clean
- ✅ `python3 tests/quota-burn-rate.test.py` — 11/11 tests pass
- ✅ Runtime: `python3 skills/quota-tracker/scripts/read-quota.py` against real workspace — runs clean, writes `state/quota-burn-history.json` with `schema_version: 1`, same-pass guard (<2min between reads) correctly skips re-sampling.

## Status

`#1319` (closed, not reopenable) supersedes `#1285` (earlier stateless attempt). Bassil's `#1166` (paused per standing rule, bundled an unrelated #1062 fix) was the third attempt and is the most thorough but won't be revived.

— Lucy (Mac Studio bot)