### PR TITLE
feat(discord-bridge): emit parent_message_id for replies

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2827,6 +2827,15 @@ async def _handle_discord_message(message, force=False):
     # line into the task file's k:v shape (per qingyun review on #1077).
     channel_name = (getattr(message.channel, "name", None) or "DM").replace("\n", " ")
     guild_name = (message.guild.name if message.guild else "DM").replace("\n", " ")
+    # When this message is a reply, emit the parent's id so the core agent can
+    # re-fetch the full original on demand rather than relying on the lossy
+    # 400-char `[Replying to ...]` snippet. Mirrors how the official Claude
+    # Discord plugin works (reference by message_id + fetch).
+    parent_msg_line = (
+        f"parent_message_id: {message.reference.message_id}\n"
+        if getattr(message, "reference", None) and message.reference.message_id
+        else ""
+    )
     task_file.write_text(
         f"id: {task_id}\n"
         f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"
@@ -2836,6 +2845,7 @@ async def _handle_discord_message(message, force=False):
         f"channel_name: {channel_name}\n"
         f"guild_name: {guild_name}\n"
         f"source_message_id: {message.id}\n"
+        f"{parent_msg_line}"
         f"user_id: {message.author.id}\n"
         f"access_tier: {access_tier}\n"
         f"priority: {priority}\n"


### PR DESCRIPTION
## Summary
When an inbound Discord message is a reply, write `parent_message_id` (the referenced message's id) into the task file alongside `source_message_id`. This lets the core agent re-fetch the full original message on demand instead of relying on the lossy 400-char `[Replying to ...]` snippet (`ref_content[:400]`), which has capped reply context since #248.

## Why
The reply-context block truncates the quoted message at 400 chars (introduced with the feature in #248, unchanged in main). For long parents (e.g. a multi-PR summary), everything past 400 chars is dropped and unrecoverable — the task carried only `source_message_id` (the sender's own message), never the parent's id. Emitting `parent_message_id` makes the original recoverable without bloating the task file, mirroring the reference-by-id + fetch model the official Claude Discord plugin uses.

## Details
- Only emitted when `message.reference` is present; task-file k:v shape is otherwise unchanged.
- No change to the existing `[Replying to ...]` snippet — purely additive.

## Test plan
- [ ] Reply to a bot message in a DM → task file contains `parent_message_id: <parent id>`
- [ ] Send a non-reply message → no `parent_message_id` line, shape unchanged