### PR TITLE
refactor(bridge-helpers): #1335 sub-PR-1 (task-archive) + sub-PR-2 (proactive-delivery) [WIP draft]

### DIFF
--- a/docs/bridge-helpers-design.md
+++ b/docs/bridge-helpers-design.md
@@ -86,9 +86,9 @@ sweep_orphan_sending_files(proactive_dir: Path, surface: str, instance: str) -> 
 - Instance identifier format (hostname or SUTANDO_HOST_LABEL).
 - Failure mode on rename collision.
 
-### 3. result markers — `src/result_markers.py` + `src/result-markers.ts`
+### 3. result markers — `src/result_markers.py` (and TS counterpart, TODO)
 
-**Status:** TODO. Marker parsing currently scattered across `src/discord-bridge.py:~3093-3251`, `src/telegram-bridge.py:~368-398` + `:~582-584`, `src/task-bridge.ts:~668-670`. Each surface re-parses with its own regex/prefix logic. Schema change = N-site edit.
+**Status:** **Python side already shipped in #873** — `src/result_markers.py` exists with `parse_markers()`. `discord-bridge.py`, `slack-bridge.py`, and `telegram-bridge.py` already `from result_markers import parse_markers`. TypeScript-side equivalent (`src/result-markers.ts`) for `task-bridge.ts` and the two voice surfaces (`phone-conversation`, `discord-voice`) is TODO if/when those surfaces need the same parse-time discipline.
 
 **Contract:**
 

--- a/docs/bridge-helpers-design.md
+++ b/docs/bridge-helpers-design.md
@@ -1,0 +1,209 @@
+# Bridge helpers — unified shared primitives
+
+Master design doc tracking the extraction of duplicated bridge primitives (issue [#1335](https://github.com/sonichi/sutando/issues/1335)). Each helper below ships as a focused sub-PR with its own parity test. This doc is the **behavioral contract** that both Python and TypeScript implementations must satisfy — when in doubt, the parity test is the arbiter.
+
+## Why
+
+Each surface (voice / phone / discord / telegram / slack) currently re-implements the same primitives. When a bug is found in one (e.g. #1046 orphan `.sending` recovery, #1235 phone archive missing), it needs the same fix applied in N files. Schema changes (#585 marker proposals, future restart-safety) require N-site edits. The cross-language boundary (TS for voice/phone, Python for discord/telegram/slack) prevents true code sharing, but a **documented contract + parity test** gives equivalent safety.
+
+## What stays out of scope
+
+Per #1335 "NOT NOW" list:
+
+- **Workspace path resolution** — V1 workspace contract (Qingyun's redesign, in flight) rewrites this layer entirely; extracting now is wasted work.
+- **Chunking** (Discord 2000 / Slack 4000 / Telegram 4096 char limits) — surface-specific thresholds.
+- **Audio streaming** — phone (Twilio) and discord-voice already in their own skills.
+
+## Cross-language contract pattern
+
+For each extracted primitive:
+
+1. **Two parallel implementations** — `src/<helper>.py` (Python) and `src/<helper>.ts` (TypeScript). They share the contract documented here, NOT runtime.
+2. **Same function name semantics** — `archive_file()` / `archiveFile()`, `parse_markers()` / `parseMarkers()`, etc. Snake-case vs camelCase per language convention, identical inputs/outputs/observable behavior.
+3. **Parity test** — `tests/<helper>-parity.test.py` exercises both impls against shared fixtures, asserts identical filesystem mutations / return values / error states. **Fails CI if either impl drifts.**
+4. **Cite the contract** — docstring + comment near each function points to this doc, so future contributors see the cross-language constraint.
+
+## Sub-PRs (ROI-ranked)
+
+### 1. task-archive helper — `src/task_archive.py` + `src/task-archive.ts`
+
+**Status:** Python module file exists from #1299 (only `find_task_file()`); TS module + the actual `archive_file()` extraction are TODO. **Unblocks #1237.**
+
+**Contract:**
+
+```
+archive_file(src_path: Path, kind: 'tasks' | 'results', task_id: str) -> None
+archiveFile(srcPath: string, kind: 'tasks' | 'results', taskId: string): void
+```
+
+**Behavior:**
+
+- If `src_path` does not exist → silent return (no error).
+- Otherwise: move `src_path` to `<base>/<kind>/archive/<YYYY-MM>/<task_id>.txt`. Create the parent directory recursively if needed.
+- `<base>` is **caller-supplied** (passed as a fourth optional parameter or set at module-import time). Why: TS callsites use `REPO_DIR`, Python callsites use `<workspace>`. This divergence pre-exists the refactor and is left to the V1-workspace redesign to unify; this helper only abstracts the move logic.
+- `YYYY-MM` is computed at call time from local time (matches the existing TS impl and Python `datetime.now().strftime("%Y-%m")`).
+- On exception: log a warning to stderr (TS: `console.error`, Python: `print(..., flush=True)`) and fall back to `unlink(missing_ok=True)`. The archive is non-critical-path; an unlink-fallback ensures we never leave stale task/result files.
+- Idempotent: calling twice with the same args (after the first call moved the file) → second call no-ops because src no longer exists.
+
+**Inputs the helper does NOT take:**
+
+- The archive's parent directory inside `<base>` is hardcoded as `<kind>/archive/<YYYY-MM>/`. Surface-specific archive paths (e.g. discord-bridge's `archive_path()` helper) are wrappers around this primitive that fix `<base>` per-surface.
+- The original `find_task_file()` (already in `src/task_archive.py` from #1299) handles the `claim-task.py`'s `.claimed-core-N` rename. Callers chain: `task_file = find_task_file(...) ; archive_file(task_file, ...)`.
+
+**Parity test fixtures:**
+
+- Fixture 1: src exists, kind=tasks → dest = `<base>/tasks/archive/YYYY-MM/<id>.txt`, src removed.
+- Fixture 2: src missing → no-op, no exception.
+- Fixture 3: dest dir doesn't exist → created recursively before move.
+- Fixture 4: move raises (simulate via permission error or read-only filesystem) → src is unlinked, no exception propagated.
+
+**Callsite migration:**
+
+- `src/task-bridge.ts:49` — remove local `archiveFile()`, `import { archiveFile } from './task-archive.js'`.
+- `src/discord-bridge.py:~352` — remove local `archive_file()`, `from task_archive import archive_file`.
+- `src/telegram-bridge.py:~171` — same.
+- `skills/phone-conversation/scripts/conversation-server.ts` (proposed in #1237) — should `import archiveFile from '../../../src/task-archive.js'` rather than inlining `archivePhoneFile`. **Track as a follow-up rebase** of #1237.
+
+### 2. proactive-delivery sweep — `src/proactive_delivery.py`
+
+**Why Python-only:** Proactive-`*.txt` files are delivered only by the Python bridges (discord/telegram/slack). TS-side voice agents don't deliver proactive messages.
+
+**Status:** TODO. Currently duplicated in `src/discord-bridge.py:~3322-3331` + `_recover_orphan_sending_files()` (#1046) and `src/telegram-bridge.py:~531-537` + same helper.
+
+**Contract:**
+
+```
+claim_proactive_file(src: Path, surface: str, instance: str) -> Path | None
+sweep_orphan_sending_files(proactive_dir: Path, surface: str, instance: str) -> int
+```
+
+- `claim_proactive_file`: atomically rename `proactive-<ts>.txt` → `proactive-<ts>.sending-<surface>-<instance>`. Returns the new path on success, `None` if already claimed by another instance.
+- `sweep_orphan_sending_files`: at startup, find any `.sending-<surface>-<instance>` files belonging to this instance (from a prior crashed run) and re-claim them for delivery. Returns count recovered.
+
+**Behavioral details to extract verbatim from #1046's existing impls:**
+
+- Sentinel TTL: how long a `.sending-*` file is considered "in flight" vs "orphan" (current discord impl: anything older than 5min when this process didn't write it → orphan).
+- Instance identifier format (hostname or SUTANDO_HOST_LABEL).
+- Failure mode on rename collision.
+
+### 3. result markers — `src/result_markers.py` + `src/result-markers.ts`
+
+**Status:** TODO. Marker parsing currently scattered across `src/discord-bridge.py:~3093-3251`, `src/telegram-bridge.py:~368-398` + `:~582-584`, `src/task-bridge.ts:~668-670`. Each surface re-parses with its own regex/prefix logic. Schema change = N-site edit.
+
+**Contract:**
+
+```python
+@dataclass
+class MarkerSet:
+    deduped: str | None         # task-id to consolidate replies under, if [deduped:] present
+    no_send: bool                # True if body starts with [no-send]
+    replied: bool                # True if body starts with [REPLIED]
+    channel_redirect: str | None # target channel ID if first line is [channel: ID]
+    files: list[str]             # paths from [file: ...], [send: ...], [attach: ...]
+
+def parse_markers(body: str) -> tuple[MarkerSet, str]
+```
+
+```typescript
+type MarkerSet = {
+  deduped: string | null;
+  noSend: boolean;
+  replied: boolean;
+  channelRedirect: string | null;
+  files: string[];
+};
+
+function parseMarkers(body: string): [MarkerSet, string]
+```
+
+**Behavior:**
+
+- Parse leading-line markers in order: `[deduped:]`, `[no-send]`, `[REPLIED]`, `[channel: ID]`.
+- Body lines starting with `[file: /path]` / `[send: /path]` / `[attach: /path]` collected into `files`.
+- Returns `(MarkerSet, stripped_body)` — caller decides delivery action from `MarkerSet`, sends `stripped_body` (with marker lines removed) as the user-facing content.
+- Markers are mutually exclusive in semantics (a `[deduped:]` task should not also produce a user-visible reply); the parser does NOT enforce this — surfaces decide.
+
+**Parity test fixtures** (per CLAUDE.md "Result-body protocol markers" spec):
+
+- Empty body → empty MarkerSet, unchanged body.
+- `[deduped: task-X]\n` → `deduped="task-X"`, stripped body = "".
+- `[no-send]\nbody` → `noSend=true`, stripped body = "body".
+- `[channel: 1234567890]\nrest` → `channelRedirect="1234567890"`, stripped body = "rest".
+- `[file: /tmp/x.png]\nbody` → `files=["/tmp/x.png"]`, stripped body retains the `[file:]` line (existing surfaces re-extract).
+- Markers in arbitrary positions: only the FIRST non-empty line is checked for `[channel:]` per CLAUDE.md spec; deduped/no-send/REPLIED only match at body start.
+
+### 4. task-file write format — `src/task_format.py` + `src/task-format.ts`
+
+**Status:** TODO. Each bridge + voice-agent hand-rolls the body. Typo or missed field = silent consumer break.
+
+**Contract:**
+
+```python
+def write_task(
+    out_path: Path, *,
+    id: str, timestamp: str, task: str,
+    source: str, channel_id: str, channel_name: str | None = None,
+    guild_name: str | None = None, source_message_id: str | None = None,
+    user_id: str, access_tier: Literal['owner', 'team', 'other'],
+    priority: Literal['urgent', 'normal', 'low'] = 'normal',
+    extras: dict[str, str] | None = None,
+) -> None
+```
+
+```typescript
+function writeTask(outPath: string, fields: TaskFields): void
+```
+
+**Behavior:**
+
+- Atomic write (tmpfile + rename) — task-bridge / discord-bridge consumers must never observe a partially-written task file.
+- Field order is fixed (matches existing `id: / timestamp: / task: / source: / channel_id: ...`).
+- Optional fields are omitted from output when None/null.
+- `extras` allows surface-specific fields (e.g. `source_message_id` from Discord, `tg_chat_id` from Telegram) without bloating the core schema.
+
+### 5. access-tier resolver — `src/access_tier.py`
+
+**Why Python-only:** Access control runs at bridge ingress (Python). TS-side voice/phone surfaces don't have tiers — they're always owner.
+
+**Status:** TODO. Currently `src/discord-bridge.py` and `src/telegram-bridge.py` each read `~/.claude/channels/<surface>/access.json` and inject their own tier-specific system instructions.
+
+**Contract:**
+
+```python
+def resolve_tier(surface: str, user_id: str) -> Literal['owner', 'team', 'other']
+
+def system_instructions_for_tier(tier: Literal['owner', 'team', 'other']) -> str | None
+```
+
+**Behavior:**
+
+- `resolve_tier`: look up `user_id` in `~/.claude/channels/<surface>/access.json` (`allowFrom` + `tierMap`). Owner tier returned if user_id is in `allowFrom` and absent from `tierMap` (preserves pre-tierMap behavior). Returns `'other'` if user_id is not in `allowFrom`.
+- `system_instructions_for_tier`: returns the in-band `===SUTANDO SYSTEM INSTRUCTIONS===` block to embed in non-owner task files. None for owner (no extra instructions needed).
+
+**Parity test:** N/A (Python-only). Unit test verifies tier resolution for each surface's access.json schema + the injected instruction content for team vs other.
+
+## Sub-PR landing order
+
+1. **task-archive** (sub-PR-1) — smallest, unblocks #1237.
+2. **proactive-delivery** (sub-PR-2) — Python-only, consolidates #1046's two-site fix.
+3. **result-markers** (sub-PR-3) — highest schema-change risk.
+4. **task-format** (sub-PR-4) — depends on (3) for marker parsing on the write side.
+5. **access-tier** (sub-PR-5) — Python-only, no cross-language constraint.
+
+Each sub-PR is independently revertible. None depends on a later sub-PR.
+
+## Non-goals
+
+- **Performance optimization.** The original impls are I/O bound on disk move/parse; the unified impls preserve identical I/O patterns.
+- **API additions.** This refactor exposes exactly the methods listed above. New functionality (e.g. archive compression, parallel sweep) is out of scope.
+- **Test-coverage growth.** Parity tests assert behavioral equivalence between Python and TS. Additional unit tests for new edge cases land separately.
+
+## Open questions (none blocking sub-PR-1)
+
+- **Module path from skills:** `skills/phone-conversation/scripts/conversation-server.ts` imports from `src/task-archive.ts` will need `'../../../src/task-archive.js'`. Verify this resolves cleanly under tsx + the current `tsconfig.json` `paths` config. If not: re-export from `skills/_shared/index.ts` (out-of-scope for sub-PR-1, file as follow-up).
+- **#1237 rebase strategy:** Once sub-PR-1 lands, do we rebase #1237 onto it (cleaner final state, blocks #1235 fix until then) or merge #1237 first with the local `archivePhoneFile` (faster #1235 fix, sub-PR-1 deletes the 4th copy after)? **Recommend (B) merge as-is** — #1235 has been bleeding for weeks; the temporary 4th copy is fine for a few days.
+
+---
+
+Issue: [#1335](https://github.com/sonichi/sutando/issues/1335)
+Owner-driven scope: Susan 2026-05-29 — "refactor 但是不能 break". Each sub-PR ships with a parity test; main branch never sees a half-extracted state.

--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -34,6 +34,7 @@ import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, createWriteStre
 import type { WriteStream } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { resolveWorkspace } from '../../../src/workspace_default.js';
+import { archiveFile } from '../../../src/task-archive.js';
 import { recordConversation, recordSession, recordToolCall } from '../../../src/conversation-store.js';
 import { resultBelongsTo, discordVoiceKey } from '../../../src/result-channel-key.js';
 import { personalPath } from '../../../src/util_paths.js';
@@ -398,7 +399,11 @@ function delegateTask(s: DiscordVoiceSession, taskDescription: string): Promise<
 			const result = readFileSync(resultPath, 'utf-8').trim();
 			console.log(`${ts()} [Task] result ${taskId} (${Date.now() - startTime}ms): ${result.slice(0, 200)}`);
 			s.events.push({ event: `task_result:${taskId}:${Date.now() - startTime}ms`, timestamp: new Date().toISOString() });
-			try { unlinkSync(resultPath); } catch {}
+			// Archive instead of unlink — routes through the shared
+			// task-archive helper (#1335 sub-PR-1) so discord-voice tasks
+			// land in the same <workspace>/results/archive/YYYY-MM/ bin as
+			// every other surface's tasks (closes the same class as #1235).
+			archiveFile(resultPath, 'results', taskId, WORKSPACE_DIR);
 			if (!s.taskResultCache) s.taskResultCache = new Map();
 			s.taskResultCache.set(taskDescription, result);
 			s.resultQueue.push({

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -54,6 +54,7 @@ import { voiceApiKey } from '../../../src/voice-key.js';
 import { loadVoiceConfig } from '../../../src/voice-config.js';
 import { hostname } from 'node:os';
 import { resolveWorkspace } from '../../../src/workspace_default.js';
+import { archiveFile } from '../../../src/task-archive.js';
 
 // Personal-asset path resolver — twin of util_paths.py / voice-agent.ts:personalPath.
 // Reads $SUTANDO_MEMORY_DIR (canonical post-#870), honors legacy $SUTANDO_PRIVATE_DIR
@@ -415,7 +416,11 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			const result = readFileSync(resultPath, 'utf-8').trim();
 			console.log(`${ts()} [Task] result for ${taskId} (${Date.now() - startTime}ms): ${result.slice(0, 200)}`);
 			callSession.events.push({ event: `task_result:${taskId}:${Date.now() - startTime}ms`, timestamp: new Date().toISOString() });
-			try { unlinkSync(resultPath); } catch {}
+			// Archive instead of unlink — closes #1235 by routing through
+			// the shared task-archive helper (#1335 sub-PR-1) so phone tasks
+			// land in the same <workspace>/results/archive/YYYY-MM/ bin as
+			// every other surface's tasks.
+			archiveFile(resultPath, 'results', taskId, WORKSPACE_DIR);
 			// Cache result so duplicate requests get instant replay
 			if (!callSession.taskResultCache) callSession.taskResultCache = new Map();
 			callSession.taskResultCache.set(taskDescription, result);

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -58,6 +58,7 @@ import discord_config  # noqa: E402  — Sutando workspace-local discord config 
 from util_paths import shared_personal_path  # noqa: E402
 from task_priority import default_priority_for_source  # noqa: E402
 from task_archive import find_task_file, archive_file as _archive_file_shared  # noqa: E402
+from proactive_delivery import recover_orphan_sending_files as _recover_orphan_sending_files_shared  # noqa: E402
 from result_markers import parse_markers  # noqa: E402
 REPO = resolve_workspace()
 
@@ -2009,52 +2010,11 @@ client = discord.Client(intents=intents)
 
 
 def _recover_orphan_sending_files() -> int:
-    """Restart-safety: rename any orphan `results/proactive-*.sending`
-    files back to `*.txt` so they get re-claimed on the next poll.
-    Returns the number of files recovered.
-
-    Atomic-claim-by-rename (`proactive-*.txt` → `.sending`) prevents
-    same-tick double-deliveries between concurrent poll iterations.
-    But if the bridge crashes BETWEEN the rename and the delivery,
-    the `.sending` file sits orphaned in `results/` — no poll
-    iteration ever looks at `.sending` suffixes, so the owner
-    notification is silently dropped until next manual intervention.
-
-    This function runs on startup to bring orphans back into the
-    polling stream. Idempotent: a second call sees no `.sending`
-    files and is a no-op. Fail-open: any per-file error is logged
-    but doesn't block the bridge from starting.
-    """
-    if not RESULTS_DIR.exists():
-        return 0
-    recovered = 0
-    for f in RESULTS_DIR.iterdir():
-        if not (f.name.startswith("proactive-") and f.suffix == ".sending"):
-            continue
-        target = f.with_suffix(".txt")
-        try:
-            # Don't clobber a same-named .txt that somehow re-appeared
-            # (e.g. an operator manually re-dropped the file). The
-            # atomic-claim invariant guarantees they don't normally
-            # coexist, but be defensive on startup.
-            if target.exists():
-                print(
-                    f"  [startup] skipping orphan recovery: {target.name} "
-                    f"already exists (collision with {f.name})",
-                    flush=True,
-                )
-                continue
-            f.rename(target)
-            recovered += 1
-            print(f"  [startup] recovered orphan {f.name} → {target.name}", flush=True)
-        except FileNotFoundError:
-            # Lost the race to another process; that's fine.
-            pass
-        except Exception as e:
-            print(f"  [startup] failed to recover {f.name}: {e}", flush=True)
-    if recovered:
-        print(f"  [startup] recovered {recovered} orphan .sending file(s)", flush=True)
-    return recovered
+    """Thin wrapper that pins ``results_dir`` to this surface's
+    ``RESULTS_DIR`` and delegates to the shared helper in
+    ``src/proactive_delivery.py``. See ``docs/bridge-helpers-design.md``
+    § proactive-delivery sweep for the contract (#1335 sub-PR-2)."""
+    return _recover_orphan_sending_files_shared(RESULTS_DIR)
 
 
 @client.event

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -57,7 +57,7 @@ from single_instance import acquire as _single_instance_acquire  # noqa: E402
 import discord_config  # noqa: E402  — Sutando workspace-local discord config (#1147)
 from util_paths import shared_personal_path  # noqa: E402
 from task_priority import default_priority_for_source  # noqa: E402
-from task_archive import find_task_file  # noqa: E402
+from task_archive import find_task_file, archive_file as _archive_file_shared  # noqa: E402
 from result_markers import parse_markers  # noqa: E402
 REPO = resolve_workspace()
 
@@ -353,20 +353,12 @@ def archive_path(kind: str, task_id: str) -> "Path":
 
 
 def archive_file(src: "Path", kind: str, task_id: str) -> None:
-    """Move src into the archive. Silent on failure — archive is for later
-    analysis, not critical path. Chi's 2026-04-18 ask: "instead of deleting
-    we should archive the tasks. It can be useful for self-improving"."""
-    try:
-        if src.exists():
-            import shutil
-            shutil.move(str(src), str(archive_path(kind, task_id)))
-    except Exception as e:
-        print(f"  archive_file({kind}, {task_id}) failed: {e}", flush=True)
-        # Fall back to unlink so we don't leave stale files.
-        try:
-            src.unlink(missing_ok=True)
-        except Exception:
-            pass
+    """Move src into the archive. Thin wrapper that pins ``base`` to this
+    surface's ``REPO`` and delegates to the shared helper in
+    ``src/task_archive.py``. The shared impl is the canonical one — see
+    ``docs/bridge-helpers-design.md`` § task-archive helper for the
+    cross-language contract."""
+    _archive_file_shared(src, kind, task_id, base=REPO)
 
 
 def notify_agent_api_task_done(task_id: str, result: str) -> None:

--- a/src/proactive_delivery.py
+++ b/src/proactive_delivery.py
@@ -1,0 +1,87 @@
+"""Shared proactive-delivery helpers (#1335 sub-PR-2).
+
+Python-only — proactive ``results/proactive-*.txt`` files are delivered
+only by the Python bridges (discord / telegram / slack). TypeScript-side
+voice agents do not deliver proactive messages.
+
+Currently exports:
+
+- ``recover_orphan_sending_files(results_dir)`` — startup-safety helper
+  that renames any orphan ``proactive-*.sending`` files back to
+  ``proactive-*.txt`` so the next poll iteration re-claims them. Closes
+  the bug class fixed in #1046 (where a bridge crash between the
+  atomic-claim rename and the actual delivery left the message
+  stranded forever, because no poll iteration ever looks at the
+  ``.sending`` suffix).
+
+Behavioral contract documented in ``docs/bridge-helpers-design.md``
+§ proactive-delivery sweep. Unit + parity tests live in
+``tests/proactive-delivery.test.py``.
+
+Usage::
+
+    from proactive_delivery import recover_orphan_sending_files
+
+    recover_orphan_sending_files(RESULTS_DIR)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def recover_orphan_sending_files(results_dir: Path) -> int:
+    """Rename orphan ``proactive-*.sending`` files back to ``.txt``.
+
+    Atomic-claim-by-rename (``proactive-*.txt`` → ``.sending``) prevents
+    same-tick double-deliveries between concurrent poll iterations. But
+    if the bridge crashes BETWEEN the rename and the delivery, the
+    ``.sending`` file sits orphaned — no poll iteration ever looks at
+    ``.sending`` suffixes, so the owner notification is silently
+    dropped until next manual intervention.
+
+    Run this on startup before the poll loop starts. Idempotent: a
+    second call sees no ``.sending`` files and is a no-op. Fail-open:
+    any per-file error is logged but does not block.
+
+    Returns the number of files recovered (0 if ``results_dir`` does
+    not exist).
+    """
+    if not results_dir.exists():
+        return 0
+    recovered = 0
+    for f in results_dir.iterdir():
+        if not (f.name.startswith("proactive-") and f.suffix == ".sending"):
+            continue
+        target = f.with_suffix(".txt")
+        try:
+            # Don't clobber a same-named .txt that somehow re-appeared
+            # (e.g. an operator manually re-dropped the file). The
+            # atomic-claim invariant guarantees they don't normally
+            # coexist, but be defensive on startup.
+            if target.exists():
+                print(
+                    f"  [startup] skipping orphan recovery: {target.name} "
+                    f"already exists (collision with {f.name})",
+                    flush=True,
+                )
+                continue
+            f.rename(target)
+            recovered += 1
+            print(
+                f"  [startup] recovered orphan {f.name} → {target.name}",
+                flush=True,
+            )
+        except FileNotFoundError:
+            # Lost the race to another process; that's fine.
+            pass
+        except Exception as exc:
+            print(
+                f"  [startup] failed to recover {f.name}: {exc}",
+                flush=True,
+            )
+    if recovered:
+        print(
+            f"  [startup] recovered {recovered} orphan .sending file(s)",
+            flush=True,
+        )
+    return recovered

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -49,6 +49,7 @@ from task_priority import default_priority_for_source  # noqa: E402
 from result_markers import parse_markers  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
 from task_archive import find_task_file, archive_file as _archive_file_shared  # noqa: E402
+from proactive_delivery import recover_orphan_sending_files as _recover_orphan_sending_files_shared  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
 
 try:
@@ -717,47 +718,11 @@ def _no_events_hint_thread():
 
 
 def _recover_orphan_sending_files() -> int:
-    """Restart-safety: rename any orphan `results/proactive-*.sending`
-    files back to `*.txt` so they get re-claimed on the next poll.
-    Returns the number of files recovered.
-
-    Atomic-claim-by-rename (`proactive-*.txt` → `.sending`) prevents
-    same-tick double-deliveries between concurrent poll iterations.
-    But if the bridge crashes BETWEEN the rename and the delivery,
-    the `.sending` file sits orphaned in `results/` — no poll
-    iteration ever looks at `.sending` suffixes, so the owner
-    notification is silently dropped until next manual intervention.
-
-    Mirrors `_recover_orphan_sending_files` in discord-bridge.py and
-    telegram-bridge.py (PR #1046). See those docstrings for the full
-    bug-class write-up.
-    """
-    if not RESULTS_DIR.exists():
-        return 0
-    recovered = 0
-    for f in RESULTS_DIR.iterdir():
-        if not (f.name.startswith("proactive-") and f.suffix == ".sending"):
-            continue
-        target = f.with_suffix(".txt")
-        try:
-            if target.exists():
-                print(
-                    f"  [startup] skipping orphan recovery: {target.name} "
-                    f"already exists (collision with {f.name})",
-                    flush=True,
-                )
-                continue
-            f.rename(target)
-            recovered += 1
-            print(f"  [startup] recovered orphan {f.name} → {target.name}", flush=True)
-        except FileNotFoundError:
-            # Lost the race to another process; fine.
-            pass
-        except Exception as e:
-            print(f"  [startup] failed to recover {f.name}: {e}", flush=True)
-    if recovered:
-        print(f"  [startup] recovered {recovered} orphan .sending file(s)", flush=True)
-    return recovered
+    """Thin wrapper that pins ``results_dir`` to this surface's
+    ``RESULTS_DIR`` and delegates to the shared helper in
+    ``src/proactive_delivery.py``. See ``docs/bridge-helpers-design.md``
+    § proactive-delivery sweep for the contract (#1335 sub-PR-2)."""
+    return _recover_orphan_sending_files_shared(RESULTS_DIR)
 
 def main():
     _single_instance_acquire("slack-bridge")

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -48,7 +48,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from task_priority import default_priority_for_source  # noqa: E402
 from result_markers import parse_markers  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
-from task_archive import find_task_file  # noqa: E402
+from task_archive import find_task_file, archive_file as _archive_file_shared  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
 
 try:
@@ -134,23 +134,11 @@ def write_owner_activity(channel: str, summary: str) -> None:
 
 def archive_file(src: Path, kind: str, task_id: str) -> None:
     """Move src into archive/<tasks|results>/YYYY-MM/ instead of deleting.
-    Matches the behavior of telegram-bridge.py / discord-bridge.py."""
-    try:
-        if not src.exists():
-            return
-        from datetime import datetime
-        import shutil
-        ym = datetime.now().strftime("%Y-%m")
-        base = ARCHIVE_TASKS_DIR if kind == "tasks" else ARCHIVE_RESULTS_DIR
-        dest_dir = base / ym
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
-    except Exception as e:
-        print(f"[Slack] archive_file({kind}, {task_id}) failed: {e}", flush=True)
-        try:
-            src.unlink(missing_ok=True)
-        except Exception:
-            pass
+    Thin wrapper that pins ``base`` to this surface's ``REPO`` and
+    delegates to the shared helper in ``src/task_archive.py``. See
+    ``docs/bridge-helpers-design.md`` § task-archive helper for the
+    cross-language contract."""
+    _archive_file_shared(src, kind, task_id, base=REPO)
 
 
 PRESENTER_SENTINEL = REPO / "state" / "presenter-mode.sentinel"

--- a/src/task-archive.ts
+++ b/src/task-archive.ts
@@ -1,0 +1,86 @@
+/**
+ * Task-file locator + shared archive helper (#1335 sub-PR-1).
+ *
+ * Two primitives:
+ *
+ * - `findTaskFile(tasksDir, taskId)` — locator that handles the
+ *   `.claimed-core-N` rename written by `claim_task.py` (#884). Bridge
+ *   archive calls that hard-code `task-{id}.txt` silently no-op after
+ *   claiming, leaving stranded files in `tasks/` forever.
+ *
+ * - `archiveFile(srcPath, kind, taskId, base)` — move `srcPath` into
+ *   `<base>/<kind>/archive/<YYYY-MM>/<task_id>.txt`. Replaces the
+ *   duplicated impl previously inline in `src/task-bridge.ts`. The Python
+ *   counterpart is `src/task_archive.py:archive_file`.
+ *
+ * The TypeScript and Python implementations share the behavioral contract
+ * documented in `docs/bridge-helpers-design.md` (sub-PR-1 section). A
+ * parity test at `tests/task-archive-parity.test.py` exercises both
+ * implementations against the same fixtures.
+ *
+ * Usage:
+ *
+ *   import { archiveFile, findTaskFile } from './task-archive.js';
+ *
+ *   const taskFile = findTaskFile(TASKS_DIR, taskId);
+ *   if (taskFile) {
+ *     archiveFile(taskFile, 'tasks', taskId, REPO_DIR);
+ *   }
+ */
+import { existsSync, mkdirSync, readdirSync, renameSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Return the actual task file path for `taskId`, or `null` if absent.
+ *
+ * Checks the bare name first (unclaimed), then scans for the claimed
+ * variant (`task-{id}.claimed-core-N.txt`). If multiple claimed variants
+ * exist (defensively — shouldn't happen), returns the first lexicographic
+ * match — the caller only needs one path to archive.
+ */
+export function findTaskFile(tasksDir: string, taskId: string): string | null {
+	const bare = join(tasksDir, `${taskId}.txt`);
+	if (existsSync(bare)) return bare;
+	let entries: string[];
+	try {
+		entries = readdirSync(tasksDir);
+	} catch {
+		return null;
+	}
+	const claimedPrefix = `${taskId}.claimed-core-`;
+	const matches = entries.filter(n => n.startsWith(claimedPrefix) && n.endsWith('.txt')).sort();
+	return matches.length > 0 ? join(tasksDir, matches[0]) : null;
+}
+
+/**
+ * Move `srcPath` to `<base>/<kind>/archive/<YYYY-MM>/<taskId>.txt`.
+ *
+ * Silent no-op if `srcPath` does not exist. On any move failure, falls
+ * back to `unlinkSync` so callers never leave stale task/result files
+ * behind. Logs failures to stderr.
+ *
+ * Contract: see `docs/bridge-helpers-design.md` § task-archive helper.
+ * Cross-language parity test: `tests/task-archive-parity.test.py`.
+ */
+export function archiveFile(
+	srcPath: string,
+	kind: 'tasks' | 'results',
+	taskId: string,
+	base: string,
+): void {
+	try {
+		if (!existsSync(srcPath)) return;
+		const ym = new Date().toISOString().slice(0, 7); // YYYY-MM
+		const destDir = join(base, kind, 'archive', ym);
+		mkdirSync(destDir, { recursive: true });
+		renameSync(srcPath, join(destDir, `${taskId}.txt`));
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.error(`archiveFile(${kind}, ${taskId}) failed: ${msg}`);
+		try {
+			unlinkSync(srcPath);
+		} catch {
+			/* ignore */
+		}
+	}
+}

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -14,6 +14,7 @@ import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { resolveWorkspace } from './workspace_default.js';
 import { recordConversation, recordSessionBoundary } from './conversation-store.js';
+import { archiveFile as archiveFileImpl } from './task-archive.js';
 
 const REPO_DIR = resolveWorkspace();
 const TASK_DIR = join(REPO_DIR, 'tasks');
@@ -43,19 +44,12 @@ function writeOwnerActivity(channel: string, summary: string): void {
 }
 
 /** Archive a task/result file into archive/<kind>/YYYY-MM/ instead of
- * deleting. Chi's 2026-04-18 ask: "instead of deleting we should archive
- * the tasks. It can be useful for self-improving". Silent on failure;
- * fall back to unlink so the system never leaves stale files behind. */
+ * deleting. Thin wrapper that pins `base` to this surface's REPO_DIR
+ * and delegates to the shared `archiveFile` in `./task-archive.js`. The
+ * shared impl is the canonical one — see `docs/bridge-helpers-design.md`
+ * § task-archive helper for the cross-language contract. */
 function archiveFile(srcPath: string, kind: 'tasks' | 'results', taskId: string): void {
-	try {
-		if (!existsSync(srcPath)) return;
-		const ym = new Date().toISOString().slice(0, 7); // YYYY-MM
-		const destDir = join(REPO_DIR, kind, 'archive', ym);
-		mkdirSync(destDir, { recursive: true });
-		renameSync(srcPath, join(destDir, `${taskId}.txt`));
-	} catch (err) {
-		try { unlinkSync(srcPath); } catch { /* ignore */ }
-	}
+	archiveFileImpl(srcPath, kind, taskId, REPO_DIR);
 }
 
 // Ensure dirs exist

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -29,7 +29,7 @@ Usage::
 from __future__ import annotations
 
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -69,7 +69,7 @@ def archive_file(
     try:
         if not src.exists():
             return
-        ym = datetime.now().strftime("%Y-%m")
+        ym = datetime.now(timezone.utc).strftime("%Y-%m")
         dest_dir = base / kind / "archive" / ym
         dest_dir.mkdir(parents=True, exist_ok=True)
         shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -1,20 +1,37 @@
-"""Task-file locator for archive calls (#933).
+"""Task-file locator + shared archive helper (#1335 sub-PR-1).
 
-claim_task.py (#884) renames task-{id}.txt → task-{id}.claimed-core-N.txt
-when a core claims work. Bridge archive calls that hard-code the bare
-task-{id}.txt path silently no-op after claiming, leaving stranded
-.claimed-core-N.txt files in tasks/ forever.
+Two primitives:
 
-Usage:
-    from task_archive import find_task_file
+- ``find_task_file(tasks_dir, task_id)`` — locator that handles the
+  ``.claimed-core-N`` rename written by ``claim_task.py`` (#884). Bridge
+  archive calls that hard-code ``task-{id}.txt`` silently no-op after
+  claiming, leaving stranded files in ``tasks/`` forever.
+
+- ``archive_file(src, kind, task_id, base)`` — move ``src`` into
+  ``<base>/<kind>/archive/<YYYY-MM>/<task_id>.txt``. Replaces the
+  duplicated impls previously in ``src/discord-bridge.py`` and
+  ``src/telegram-bridge.py``. The TypeScript counterpart is
+  ``src/task-archive.ts:archiveFile``.
+
+The TypeScript and Python implementations share the behavioral contract
+documented in ``docs/bridge-helpers-design.md`` (sub-PR-1 section). A
+parity test at ``tests/task-archive-parity.test.py`` exercises both
+implementations against the same fixtures.
+
+Usage::
+
+    from task_archive import find_task_file, archive_file
 
     task_file = find_task_file(TASKS_DIR, task_id)
     if task_file:
-        archive_file(task_file, "tasks", task_id)
+        archive_file(task_file, "tasks", task_id, base=WORKSPACE)
 """
 from __future__ import annotations
 
+import shutil
+from datetime import datetime
 from pathlib import Path
+from typing import Literal
 
 
 def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
@@ -30,3 +47,38 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
         return bare
     matches = sorted(tasks_dir.glob(f"{task_id}.claimed-core-*.txt"))
     return matches[0] if matches else None
+
+
+def archive_file(
+    src: Path,
+    kind: Literal["tasks", "results"],
+    task_id: str,
+    base: Path,
+) -> None:
+    """Move ``src`` to ``<base>/<kind>/archive/<YYYY-MM>/<task_id>.txt``.
+
+    Silent no-op if ``src`` does not exist. On any move failure, falls back
+    to ``unlink(missing_ok=True)`` so callers never leave stale task/result
+    files behind. Logs failures to stderr (Chi's 2026-04-18 ask: "instead
+    of deleting we should archive the tasks. It can be useful for
+    self-improving").
+
+    Contract: see ``docs/bridge-helpers-design.md`` § task-archive helper.
+    Cross-language parity test: ``tests/task-archive-parity.test.py``.
+    """
+    try:
+        if not src.exists():
+            return
+        ym = datetime.now().strftime("%Y-%m")
+        dest_dir = base / kind / "archive" / ym
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
+    except Exception as exc:
+        print(
+            f"archive_file({kind}, {task_id}) failed: {exc}",
+            flush=True,
+        )
+        try:
+            src.unlink(missing_ok=True)
+        except Exception:
+            pass

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -35,6 +35,7 @@ from result_markers import parse_markers  # noqa: E402
 
 from workspace_default import resolve_workspace  # noqa: E402
 from task_archive import find_task_file, archive_file as _archive_file_shared  # noqa: E402
+from proactive_delivery import recover_orphan_sending_files as _recover_orphan_sending_files_shared  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
 REPO = resolve_workspace()
 TASKS_DIR = REPO / "tasks"
@@ -391,37 +392,11 @@ def send_reply(chat_id, text, task_id: str | None = None):
             print(f"  file marker, file not found — likely a prose quotation: {fpath}", flush=True)
 
 def _recover_orphan_sending_files() -> int:
-    """Restart-safety: rename any orphan `results/proactive-*.sending`
-    files back to `*.txt` so they get re-claimed on the next poll.
-
-    Mirrors `_recover_orphan_sending_files` in discord-bridge.py.
-    See that docstring for the bug class this closes.
-    """
-    if not RESULTS_DIR.exists():
-        return 0
-    recovered = 0
-    for f in RESULTS_DIR.iterdir():
-        if not (f.name.startswith("proactive-") and f.suffix == ".sending"):
-            continue
-        target = f.with_suffix(".txt")
-        try:
-            if target.exists():
-                print(
-                    f"  [startup] skipping orphan recovery: {target.name} "
-                    f"already exists (collision with {f.name})",
-                    flush=True,
-                )
-                continue
-            f.rename(target)
-            recovered += 1
-            print(f"  [startup] recovered orphan {f.name} → {target.name}", flush=True)
-        except FileNotFoundError:
-            pass
-        except Exception as e:
-            print(f"  [startup] failed to recover {f.name}: {e}", flush=True)
-    if recovered:
-        print(f"  [startup] recovered {recovered} orphan .sending file(s)", flush=True)
-    return recovered
+    """Thin wrapper that pins ``results_dir`` to this surface's
+    ``RESULTS_DIR`` and delegates to the shared helper in
+    ``src/proactive_delivery.py``. See ``docs/bridge-helpers-design.md``
+    § proactive-delivery sweep for the contract (#1335 sub-PR-2)."""
+    return _recover_orphan_sending_files_shared(RESULTS_DIR)
 
 
 def main():

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -34,7 +34,7 @@ from task_priority import default_priority_for_source  # noqa: E402
 from result_markers import parse_markers  # noqa: E402
 
 from workspace_default import resolve_workspace  # noqa: E402
-from task_archive import find_task_file  # noqa: E402
+from task_archive import find_task_file, archive_file as _archive_file_shared  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
 REPO = resolve_workspace()
 TASKS_DIR = REPO / "tasks"
@@ -170,24 +170,11 @@ def write_owner_activity(channel: str, summary: str) -> None:
 
 def archive_file(src: "Path", kind: str, task_id: str) -> None:
     """Move src into archive/<tasks|results>/YYYY-MM/ instead of deleting.
-    Silent on failure. Chi's ask 2026-04-18: archive tasks + results for
-    later pattern-mining / self-improvement analysis."""
-    try:
-        if not src.exists():
-            return
-        from datetime import datetime
-        import shutil
-        ym = datetime.now().strftime("%Y-%m")
-        base = ARCHIVE_TASKS_DIR if kind == "tasks" else ARCHIVE_RESULTS_DIR
-        dest_dir = base / ym
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
-    except Exception as e:
-        print(f"[Telegram] archive_file({kind}, {task_id}) failed: {e}")
-        try:
-            src.unlink(missing_ok=True)
-        except Exception:
-            pass
+    Thin wrapper that pins ``base`` to this surface's ``REPO`` and
+    delegates to the shared helper in ``src/task_archive.py``. See
+    ``docs/bridge-helpers-design.md`` § task-archive helper for the
+    cross-language contract."""
+    _archive_file_shared(src, kind, task_id, base=REPO)
 
 # Presenter mode: silence proactive DMs during ICLR/talk windows. Sentinel
 # is written by scripts/presenter-mode.sh with an ISO-8601 expiry. Matches

--- a/tests/_helpers/task-archive-shim.ts
+++ b/tests/_helpers/task-archive-shim.ts
@@ -1,0 +1,26 @@
+/**
+ * Tiny CLI shim used by tests/task-archive-parity.test.py to invoke the
+ * TypeScript archiveFile() helper from a Python parity test.
+ *
+ * Reads a JSON payload from $PARITY_ARGS env var (avoiding argv-quoting
+ * issues across tsx --eval) and calls archiveFile() with the parsed args.
+ * Silent on success; errors propagate via console.error (the TS impl
+ * already does fallback unlink + console.error on failure).
+ *
+ * Usage from Python:
+ *   subprocess.run(
+ *       ['npx', 'tsx', 'tests/_helpers/task-archive-shim.ts'],
+ *       env={**os.environ, 'PARITY_ARGS': json.dumps(...)},
+ *       cwd=REPO_ROOT,
+ *   )
+ */
+import { archiveFile } from '../../src/task-archive.js';
+
+const raw = process.env.PARITY_ARGS;
+if (!raw) {
+	console.error('task-archive-shim: PARITY_ARGS env var not set');
+	process.exit(2);
+}
+
+const args = JSON.parse(raw) as { src: string; kind: 'tasks' | 'results'; taskId: string; base: string };
+archiveFile(args.src, args.kind, args.taskId, args.base);

--- a/tests/proactive-delivery.test.py
+++ b/tests/proactive-delivery.test.py
@@ -1,0 +1,93 @@
+"""Tests for src/proactive_delivery.py — recover_orphan_sending_files()
+(#1335 sub-PR-2).
+
+Closes the duplication that was previously inline in discord-bridge.py,
+telegram-bridge.py, and slack-bridge.py. Each call has been replaced
+with a thin wrapper that delegates to the shared helper.
+
+Python-only — no TS counterpart (proactive delivery is bridge-side).
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from proactive_delivery import recover_orphan_sending_files
+
+
+class TestRecoverOrphanSendingFiles(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.results = Path(self._td.name)
+        self.addCleanup(self._td.cleanup)
+
+    def _write(self, name: str, content: str = "body") -> Path:
+        p = self.results / name
+        p.write_text(content)
+        return p
+
+    def test_recovers_proactive_sending_to_txt(self) -> None:
+        self._write("proactive-1.sending", "orphaned")
+        recovered = recover_orphan_sending_files(self.results)
+        self.assertEqual(recovered, 1)
+        self.assertFalse((self.results / "proactive-1.sending").exists())
+        self.assertTrue((self.results / "proactive-1.txt").exists())
+        self.assertEqual((self.results / "proactive-1.txt").read_text(), "orphaned")
+
+    def test_skips_non_proactive_sending_files(self) -> None:
+        # Only proactive-*.sending should be touched. Other files left alone.
+        self._write("task-1.sending", "not proactive")
+        self._write("task-1.txt", "task body")
+        self._write("proactive-2.sending", "yes")
+        recovered = recover_orphan_sending_files(self.results)
+        self.assertEqual(recovered, 1)  # only proactive-2
+        self.assertTrue((self.results / "task-1.sending").exists())
+        self.assertTrue((self.results / "proactive-2.txt").exists())
+
+    def test_skips_collision_when_txt_exists(self) -> None:
+        # Defensive: if both .sending AND .txt exist, don't clobber the .txt.
+        self._write("proactive-3.sending", "old orphan")
+        self._write("proactive-3.txt", "new content")
+        recovered = recover_orphan_sending_files(self.results)
+        self.assertEqual(recovered, 0)
+        # Both files should still exist:
+        self.assertTrue((self.results / "proactive-3.sending").exists())
+        self.assertTrue((self.results / "proactive-3.txt").exists())
+        # .txt content untouched:
+        self.assertEqual((self.results / "proactive-3.txt").read_text(), "new content")
+
+    def test_returns_zero_when_dir_missing(self) -> None:
+        missing = Path("/tmp/proactive-delivery-test-missing-dir-xyz123")
+        if missing.exists():
+            missing.rmdir()
+        recovered = recover_orphan_sending_files(missing)
+        self.assertEqual(recovered, 0)
+
+    def test_returns_zero_when_no_sending_files(self) -> None:
+        self._write("task-5.txt", "regular task")
+        self._write("proactive-5.txt", "already delivered")
+        recovered = recover_orphan_sending_files(self.results)
+        self.assertEqual(recovered, 0)
+
+    def test_idempotent_second_call_noops(self) -> None:
+        self._write("proactive-6.sending", "first")
+        self.assertEqual(recover_orphan_sending_files(self.results), 1)
+        # Second call: orphan already recovered, no .sending files left:
+        self.assertEqual(recover_orphan_sending_files(self.results), 0)
+
+    def test_recovers_multiple_orphans(self) -> None:
+        self._write("proactive-7.sending", "a")
+        self._write("proactive-8.sending", "b")
+        self._write("proactive-9.sending", "c")
+        recovered = recover_orphan_sending_files(self.results)
+        self.assertEqual(recovered, 3)
+        self.assertTrue((self.results / "proactive-7.txt").exists())
+        self.assertTrue((self.results / "proactive-8.txt").exists())
+        self.assertTrue((self.results / "proactive-9.txt").exists())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/task-archive-parity.test.py
+++ b/tests/task-archive-parity.test.py
@@ -1,0 +1,156 @@
+"""Cross-language parity test for task-archive (#1335 sub-PR-1).
+
+Asserts that ``src/task_archive.py:archive_file()`` (Python) and
+``src/task-archive.ts:archiveFile()`` (TypeScript) produce **identical
+observable filesystem mutations** for the same fixtures.
+
+Why this matters: bridges using either impl must agree on archive layout.
+A drift between Python and TS would mean the same task-id archives to
+different paths depending on which bridge handled it, breaking the
+"bin-of-archived-tasks-by-month" mental model the archive is for.
+
+Contract documented in ``docs/bridge-helpers-design.md`` § task-archive
+helper. If you update the contract, update both impls AND this test.
+
+Strategy: for each fixture, run the Python helper against its own
+tempdir and the TS helper against a parallel tempdir, then compare the
+filesystem trees. They must match exactly (same dirs, same files, same
+contents). Per-impl unit tests live in tests/task-archive.test.py and
+tests/task-archive.test.ts.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+sys.path.insert(0, str(REPO_ROOT / "src"))
+from task_archive import archive_file as py_archive_file
+
+
+_SHIM_PATH = REPO_ROOT / "tests" / "_helpers" / "task-archive-shim.ts"
+
+
+def _ts_archive_file(src: Path, kind: str, task_id: str, base: Path) -> None:
+    """Invoke the TS archiveFile via tests/_helpers/task-archive-shim.ts.
+
+    Args go via the PARITY_ARGS env var (avoids argv-quoting pain across
+    tsx --eval). The shim itself calls archiveFile(), whose silent-on-
+    failure contract matches the Python impl — the test asserts via
+    filesystem state, not subprocess exit code."""
+    payload = json.dumps({
+        "src": str(src),
+        "kind": kind,
+        "taskId": task_id,
+        "base": str(base),
+    })
+    env = {**os.environ, "PARITY_ARGS": payload}
+    result = subprocess.run(
+        ["npx", "tsx", str(_SHIM_PATH)],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    # archiveFile() handles its own errors and falls back to unlink; the
+    # shim doesn't propagate them as non-zero exit codes. Only fail the
+    # test if the shim itself crashed before reaching archiveFile.
+    if result.returncode != 0 and "task-archive-shim" not in result.stderr:
+        raise RuntimeError(
+            f"ts shim crashed (non-helper error): {result.stderr}"
+        )
+
+
+def _fs_snapshot(root: Path) -> dict[str, str]:
+    """Return a dict of relative_path -> content for every file under root.
+    Used to compare filesystem state across Python/TS runs."""
+    if not root.exists():
+        return {}
+    snap: dict[str, str] = {}
+    for p in sorted(root.rglob("*")):
+        if p.is_file():
+            rel = p.relative_to(root).as_posix()
+            try:
+                snap[rel] = p.read_text()
+            except UnicodeDecodeError:
+                snap[rel] = f"<binary {p.stat().st_size}b>"
+    return snap
+
+
+@unittest.skipIf(shutil.which("npx") is None, "npx not on PATH; skipping cross-lang parity")
+class TestArchiveFileParity(unittest.TestCase):
+    """Each test runs the same fixture through Python and TS and asserts
+    identical filesystem state after."""
+
+    def _run_pair(self, setup):
+        """``setup(base)`` should:
+        1. Create input files (e.g. src/task-X.txt) inside ``base``.
+        2. Return ``(src_relpath, kind, task_id)``.
+        Both runs use a fresh base, so each impl starts with identical
+        precondition. After both run, the bases should be identical."""
+        py_base = Path(tempfile.mkdtemp(prefix="parity-py-"))
+        ts_base = Path(tempfile.mkdtemp(prefix="parity-ts-"))
+        self.addCleanup(lambda: shutil.rmtree(py_base, ignore_errors=True))
+        self.addCleanup(lambda: shutil.rmtree(ts_base, ignore_errors=True))
+
+        py_args = setup(py_base)
+        ts_args = setup(ts_base)
+        # Sanity-check the setups produced the same precondition:
+        self.assertEqual(_fs_snapshot(py_base), _fs_snapshot(ts_base),
+                         "fixture setup must be identical for both impls")
+
+        py_src_rel, kind, task_id = py_args
+        ts_src_rel, _, _ = ts_args
+        py_archive_file(py_base / py_src_rel, kind, task_id, base=py_base)
+        _ts_archive_file(ts_base / ts_src_rel, kind, task_id, base=ts_base)
+
+        py_state = _fs_snapshot(py_base)
+        ts_state = _fs_snapshot(ts_base)
+        self.assertEqual(py_state, ts_state,
+                         f"\nPython produced:\n{py_state}\n\nTS produced:\n{ts_state}")
+
+    def test_parity_moves_task_file(self):
+        def setup(base):
+            (base / "tasks").mkdir()
+            src = base / "tasks" / "task-A.txt"
+            src.write_text("hello task A")
+            return "tasks/task-A.txt", "tasks", "task-A"
+        self._run_pair(setup)
+
+    def test_parity_moves_result_file(self):
+        def setup(base):
+            (base / "results").mkdir()
+            src = base / "results" / "task-B.txt"
+            src.write_text("hello result B")
+            return "results/task-B.txt", "results", "task-B"
+        self._run_pair(setup)
+
+    def test_parity_silent_noop_when_src_missing(self):
+        def setup(base):
+            (base / "tasks").mkdir()
+            # No src file written.
+            return "tasks/task-missing.txt", "tasks", "task-missing"
+        self._run_pair(setup)
+
+    def test_parity_creates_archive_dir_recursively(self):
+        def setup(base):
+            (base / "tasks").mkdir()
+            src = base / "tasks" / "task-C.txt"
+            src.write_text("recursive mkdir")
+            # archive/ doesn't exist yet under base/tasks/; both impls
+            # must create it.
+            return "tasks/task-C.txt", "tasks", "task-C"
+        self._run_pair(setup)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/task-archive.test.py
+++ b/tests/task-archive.test.py
@@ -74,8 +74,8 @@ class TestArchiveFile(unittest.TestCase):
         self.addCleanup(self._td.cleanup)
 
     def _archive_dir(self, kind: str) -> Path:
-        from datetime import datetime
-        ym = datetime.now().strftime("%Y-%m")
+        from datetime import datetime, timezone
+        ym = datetime.now(timezone.utc).strftime("%Y-%m")
         return self.base / kind / "archive" / ym
 
     def test_moves_task_file(self) -> None:

--- a/tests/task-archive.test.py
+++ b/tests/task-archive.test.py
@@ -1,13 +1,20 @@
-"""Tests for src/task_archive.py — find_task_file() helper (closes #933)."""
+"""Tests for src/task_archive.py — find_task_file() + archive_file() helpers.
+
+Covers:
+- ``find_task_file()`` — #933 (the locator handling ``.claimed-core-N`` rename)
+- ``archive_file()`` — #1335 sub-PR-1 (shared archive primitive)
+"""
 from __future__ import annotations
 
+import os
+import stat
 import tempfile
 import unittest
 from pathlib import Path
 
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-from task_archive import find_task_file
+from task_archive import find_task_file, archive_file
 
 
 class TestFindTaskFile(unittest.TestCase):
@@ -49,6 +56,91 @@ class TestFindTaskFile(unittest.TestCase):
         result = find_task_file(self.tasks_dir, "task-000")
         self.assertIsNotNone(result)
         self.assertIn("claimed-core-", result.name)
+
+
+class TestArchiveFile(unittest.TestCase):
+    """Tests for the shared archive_file helper. Behavioral contract in
+    docs/bridge-helpers-design.md § task-archive helper. The TypeScript
+    counterpart `archiveFile()` must satisfy the same contract — see
+    tests/task-archive-parity.test.py for the cross-language assertion."""
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.base = Path(self._td.name)
+        self.tasks_dir = self.base / "tasks"
+        self.tasks_dir.mkdir()
+        self.results_dir = self.base / "results"
+        self.results_dir.mkdir()
+        self.addCleanup(self._td.cleanup)
+
+    def _archive_dir(self, kind: str) -> Path:
+        from datetime import datetime
+        ym = datetime.now().strftime("%Y-%m")
+        return self.base / kind / "archive" / ym
+
+    def test_moves_task_file(self) -> None:
+        src = self.tasks_dir / "task-1.txt"
+        src.write_text("body")
+        archive_file(src, "tasks", "task-1", base=self.base)
+        self.assertFalse(src.exists(), "src should be moved")
+        dest = self._archive_dir("tasks") / "task-1.txt"
+        self.assertTrue(dest.exists(), f"dest should exist at {dest}")
+        self.assertEqual(dest.read_text(), "body")
+
+    def test_moves_result_file(self) -> None:
+        src = self.results_dir / "task-2.txt"
+        src.write_text("result-body")
+        archive_file(src, "results", "task-2", base=self.base)
+        self.assertFalse(src.exists())
+        dest = self._archive_dir("results") / "task-2.txt"
+        self.assertTrue(dest.exists())
+        self.assertEqual(dest.read_text(), "result-body")
+
+    def test_silent_noop_when_src_missing(self) -> None:
+        missing = self.tasks_dir / "task-missing.txt"
+        # Should not raise:
+        archive_file(missing, "tasks", "task-missing", base=self.base)
+        # No archive dir should have been created (because we never got
+        # past the existence check):
+        self.assertFalse(self._archive_dir("tasks").exists())
+
+    def test_creates_archive_dir_recursively(self) -> None:
+        # No archive dir initially.
+        src = self.tasks_dir / "task-3.txt"
+        src.write_text("body")
+        self.assertFalse(self._archive_dir("tasks").exists())
+        archive_file(src, "tasks", "task-3", base=self.base)
+        self.assertTrue(self._archive_dir("tasks").exists())
+
+    def test_idempotent_second_call_noops(self) -> None:
+        src = self.tasks_dir / "task-4.txt"
+        src.write_text("body")
+        archive_file(src, "tasks", "task-4", base=self.base)
+        self.assertFalse(src.exists())
+        # Second call: src is gone, should silently no-op.
+        archive_file(src, "tasks", "task-4", base=self.base)
+        # And the archived file is still there with the original content:
+        dest = self._archive_dir("tasks") / "task-4.txt"
+        self.assertTrue(dest.exists())
+        self.assertEqual(dest.read_text(), "body")
+
+    def test_falls_back_to_unlink_when_move_fails(self) -> None:
+        """If the move operation fails (e.g. destination is unwritable),
+        the helper should unlink the source rather than leave it stranded."""
+        src = self.tasks_dir / "task-5.txt"
+        src.write_text("body")
+        # Make the *archive base* unwritable so mkdir(parents=True) fails.
+        # We do this by setting the kind dir as a non-directory file:
+        bad_kind_dir = self.base / "tasks-bad"
+        bad_kind_dir.write_text("not-a-dir")  # blocks mkdir on "tasks-bad/archive/..."
+        # Now point archive_file at base=self.base but with kind that
+        # resolves through the bad_kind_dir path. Simulate by passing a
+        # base that puts the archive on top of an existing file:
+        evil_base = self.base / "evil"
+        evil_base.write_text("not-a-dir")  # base path is a file, not a dir
+        archive_file(src, "tasks", "task-5", base=evil_base)
+        # src should have been unlinked (fallback):
+        self.assertFalse(src.exists(), "src should be unlinked after move failure")
 
 
 if __name__ == "__main__":

--- a/tests/task-archive.test.ts
+++ b/tests/task-archive.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for src/task-archive.ts (#1335 sub-PR-1).
+ *
+ * Covers the TypeScript `archiveFile` + `findTaskFile` impls in
+ * isolation. The cross-language parity assertion lives in
+ * tests/task-archive-parity.test.py.
+ *
+ * Behavioral contract: docs/bridge-helpers-design.md § task-archive helper.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { archiveFile, findTaskFile } from '../src/task-archive.js';
+
+function ymNow(): string {
+	return new Date().toISOString().slice(0, 7);
+}
+
+describe('findTaskFile', () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), 'find-task-'));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('returns the bare task file when present', () => {
+		writeFileSync(join(dir, 'task-123.txt'), 'body');
+		const result = findTaskFile(dir, 'task-123');
+		assert.equal(result, join(dir, 'task-123.txt'));
+	});
+
+	it('returns the claimed variant when bare is missing', () => {
+		writeFileSync(join(dir, 'task-456.claimed-core-2.txt'), 'body');
+		const result = findTaskFile(dir, 'task-456');
+		assert.equal(result, join(dir, 'task-456.claimed-core-2.txt'));
+	});
+
+	it('prefers bare over claimed when both exist', () => {
+		writeFileSync(join(dir, 'task-789.txt'), 'body');
+		writeFileSync(join(dir, 'task-789.claimed-core-1.txt'), 'body');
+		const result = findTaskFile(dir, 'task-789');
+		assert.equal(result, join(dir, 'task-789.txt'));
+	});
+
+	it('returns null when no file exists', () => {
+		const result = findTaskFile(dir, 'task-nonexistent');
+		assert.equal(result, null);
+	});
+
+	it('returns first lexicographic match among multiple claimed', () => {
+		writeFileSync(join(dir, 'task-000.claimed-core-3.txt'), 'body');
+		writeFileSync(join(dir, 'task-000.claimed-core-2.txt'), 'body');
+		const result = findTaskFile(dir, 'task-000');
+		// Sorted lex → claimed-core-2 comes before claimed-core-3.
+		assert.equal(result, join(dir, 'task-000.claimed-core-2.txt'));
+	});
+
+	it('returns null when the tasks dir does not exist', () => {
+		const ghost = join(dir, 'never-existed');
+		const result = findTaskFile(ghost, 'task-X');
+		assert.equal(result, null);
+	});
+});
+
+describe('archiveFile', () => {
+	let base: string;
+	let tasksDir: string;
+	let resultsDir: string;
+	const ym = ymNow();
+
+	beforeEach(() => {
+		base = mkdtempSync(join(tmpdir(), 'archive-'));
+		tasksDir = join(base, 'tasks');
+		resultsDir = join(base, 'results');
+		mkdirSync(tasksDir);
+		mkdirSync(resultsDir);
+	});
+
+	afterEach(() => {
+		rmSync(base, { recursive: true, force: true });
+	});
+
+	it('moves a task file into base/tasks/archive/YYYY-MM/', () => {
+		const src = join(tasksDir, 'task-1.txt');
+		writeFileSync(src, 'body');
+		archiveFile(src, 'tasks', 'task-1', base);
+		assert.equal(existsSync(src), false, 'src should be moved');
+		const dest = join(base, 'tasks', 'archive', ym, 'task-1.txt');
+		assert.equal(existsSync(dest), true, `dest should exist at ${dest}`);
+		assert.equal(readFileSync(dest, 'utf-8'), 'body');
+	});
+
+	it('moves a result file into base/results/archive/YYYY-MM/', () => {
+		const src = join(resultsDir, 'task-2.txt');
+		writeFileSync(src, 'result-body');
+		archiveFile(src, 'results', 'task-2', base);
+		assert.equal(existsSync(src), false);
+		const dest = join(base, 'results', 'archive', ym, 'task-2.txt');
+		assert.equal(existsSync(dest), true);
+		assert.equal(readFileSync(dest, 'utf-8'), 'result-body');
+	});
+
+	it('silently no-ops when src is missing', () => {
+		const missing = join(tasksDir, 'task-missing.txt');
+		// Should not throw:
+		archiveFile(missing, 'tasks', 'task-missing', base);
+		// No archive dir should have been created:
+		assert.equal(existsSync(join(base, 'tasks', 'archive')), false);
+	});
+
+	it('creates the archive dir recursively', () => {
+		const src = join(tasksDir, 'task-3.txt');
+		writeFileSync(src, 'body');
+		assert.equal(existsSync(join(base, 'tasks', 'archive')), false);
+		archiveFile(src, 'tasks', 'task-3', base);
+		assert.equal(existsSync(join(base, 'tasks', 'archive', ym)), true);
+	});
+
+	it('idempotent — second call no-ops because src is already gone', () => {
+		const src = join(tasksDir, 'task-4.txt');
+		writeFileSync(src, 'body');
+		archiveFile(src, 'tasks', 'task-4', base);
+		// Second call:
+		archiveFile(src, 'tasks', 'task-4', base);
+		// Archived file still there:
+		const dest = join(base, 'tasks', 'archive', ym, 'task-4.txt');
+		assert.equal(readFileSync(dest, 'utf-8'), 'body');
+	});
+
+	it('falls back to unlink when move fails', () => {
+		const src = join(tasksDir, 'task-5.txt');
+		writeFileSync(src, 'body');
+		// Make base unwritable by setting it to a non-dir path:
+		const evilBase = join(base, 'evil');
+		writeFileSync(evilBase, 'not-a-dir');
+		archiveFile(src, 'tasks', 'task-5', evilBase);
+		// src should have been unlinked (fallback):
+		assert.equal(existsSync(src), false, 'src should be unlinked after move failure');
+	});
+});


### PR DESCRIPTION
## Summary

**WIP draft per Susan 2026-05-29.** Stacked sub-PRs from the #1335 master refactor. Each sub-PR is a separate commit on this branch; each ships with its own behavioral contract, tests, and is independently revertible per `docs/bridge-helpers-design.md`.

Per Susan: "refactor 但是不能 break" + "phone/voice/discord-voice/etc 这些里能统一的都统一" + "可以 pr draft (wip) 不要 merge".

## Sub-PRs landed in this branch

### sub-PR-1 — task-archive helper

- **`src/task_archive.py`** — extend with `archive_file()` (was: only `find_task_file` from #1299)
- **`src/task-archive.ts`** (new) — TypeScript counterpart with the same contract
- **`docs/bridge-helpers-design.md`** (new) — behavioral contract for all 5 sub-PRs + parity-test pattern
- **6 surfaces** all now use the shared helper:
  - `src/task-bridge.ts` (voice / web)
  - `src/discord-bridge.py`
  - `src/telegram-bridge.py`
  - `src/slack-bridge.py`
  - `skills/phone-conversation/scripts/conversation-server.ts` (was `unlinkSync` → now archives — effectively closes #1235)
  - `skills/discord-voice/scripts/discord-voice-server.ts` (was `unlinkSync` → now archives)

### sub-PR-2 — proactive-delivery sweep

- **`src/proactive_delivery.py`** (new) — `recover_orphan_sending_files()`
- **`src/discord-bridge.py` / `telegram-bridge.py` / `slack-bridge.py`** — local `_recover_orphan_sending_files()` now delegates to the shared impl
- Closes the duplication pattern at the source of #1046 (orphan `.sending` recovery was applied to 3 files because no shared helper existed)
- Python-only (no TS counterpart — proactive delivery is bridge-side)

## Test plan (all green)

| Test | Count |
|---|---|
| Python — `task-archive` unit | **11/11** |
| Python — `proactive-delivery` unit | **7/7** |
| Python — `task-archive` parity (Python ↔ TS) | **4/4** |
| TypeScript — `task-archive` unit | **12/12** |
| `tsc --noEmit` | clean |
| `py_compile` on each modified bridge | OK |

**Total: 34 tests passing, zero regressions.**

## Cross-PR linkages

- **Effectively supersedes #1237** — sub-PR-1 routes `phone-conversation` through the shared helper, archiving result files instead of `unlinkSync`-ing them. The same defect as #1235; the bug is closed without #1237's local `archivePhoneFile()`.
- **Tracks #1335** — master refactor issue. Sub-PRs 3-5 (result-markers, task-format, access-tier resolver) will land as later commits or separate PRs.
- **Builds on #1299** — the existing `src/task_archive.py` (only `find_task_file`) is extended with `archive_file()` here.
- **Closes pattern from #1046** — orphan `.sending` recovery now in one place.

## Non-goals (deliberately deferred)

- **Workspace path resolution.** Per #1335 "NOT NOW" list — V1 workspace contract rewrites this layer entirely. Each bridge passes its own `base` (TS uses `REPO_DIR`, Python uses `REPO = resolve_workspace()`).
- **API additions.** Shared helpers expose exactly the same observable behavior as the original impls.

— Lucy (Mac Studio bot)