### PR TITLE
fix(sync-memory): add mass-deletion tripwire before push

### DIFF
--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -405,6 +405,18 @@ if git diff --quiet && git diff --cached --quiet && [ -z "$(git ls-files --other
     echo "No changes to sync."
 else
     git add -A
+    # Mass-deletion tripwire: refuse to push a commit that removes a large number
+    # of files unless explicitly forced. A stale/divergent sync script or a bad
+    # rsync can wipe the shared memory repo; this backstop catches the staged
+    # deletions before they are pushed (incident 2026-05-30).
+    DELETED=$(git diff --cached --name-only --diff-filter=D | wc -l | tr -d ' ')
+    MAX_DELETE="${SUTANDO_SYNC_MAX_DELETE:-50}"
+    if [ "$DELETED" -gt "$MAX_DELETE" ] && [ "${SUTANDO_FORCE_SYNC:-0}" != "1" ]; then
+        log "ABORT: sync would delete $DELETED files (>$MAX_DELETE). Refusing to push. Set SUTANDO_FORCE_SYNC=1 to override."
+        echo "Sync aborted: would delete $DELETED files (mass-deletion tripwire). Set SUTANDO_FORCE_SYNC=1 to override." >&2
+        git reset -q
+        exit 1
+    fi
     git commit -m "Sync $(hostname) $(date +%Y-%m-%dT%H:%M)" 2>&1 | tee -a "$LOG" >/dev/null
     if git push 2>&1 | tee -a "$LOG" >/dev/null; then
         log "Pushed changes"


### PR DESCRIPTION
## Summary
- Adds a pre-push safety tripwire to `scripts/sync-memory.sh`: after `git add -A`, count staged deletions and **refuse to commit/push** if they exceed `SUTANDO_SYNC_MAX_DELETE` (default 50), unless `SUTANDO_FORCE_SYNC=1`.
- Backstop on the actual push step, so it catches a mass-deletion from **any** source — a stale/divergent sync script, a bad rsync, or an accidental `rm` in the sync clone.

## Why
On 2026-05-30 a scheduled sync nearly wiped the shared memory repo. The canonical script here is already safe (`rsync --update --checksum`, no `--delete`), but a **stale workspace-local copy** used `rsync -a --delete` and would have mirror-deleted ~840 of the repo's 868 notes. The canonical script's `git add -A; git push` would happily propagate such a deletion if it ever lands in the sync clone. This guard makes that class of accident fail closed.

## Behavior
- Normal sync (few/no deletions): unchanged.
- Sync staging > 50 deletions: aborts with a clear log + stderr message, unstages, exits 1.
- Intentional large pruning: set `SUTANDO_FORCE_SYNC=1` (or raise `SUTANDO_SYNC_MAX_DELETE`).

## Test plan
- [x] `bash -n scripts/sync-memory.sh` passes.
- [ ] Manual: stage >50 deletions in a sync clone, run script -> aborts without pushing.
- [ ] Manual: `SUTANDO_FORCE_SYNC=1` with >50 deletions -> proceeds.
- [ ] Normal small-change sync still pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)