### PR TITLE
fix(telegram-bridge): deliver briefing/insight/friction results to owner DM

### DIFF
--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -566,8 +566,17 @@ def main():
                 not presenter_mode_active()
                 and should_claim_proactive(OWNER_ACTIVITY_FILE, "telegram")
             ):
+                # discord-bridge.poll_dm_fallback handles briefing-/insight-/
+                # friction-*.txt via FALLBACK_PREFIXES; telegram-bridge only
+                # matched `proactive-`, so morning-briefing output (which
+                # writes `results/briefing-{date}.txt` per the skill
+                # contract) was silently archived without reaching Telegram.
+                # Treat the same prefixes as proactive-equivalent so
+                # cron-originated results land in the owner's DM regardless
+                # of which bridge is the active channel.
+                PROACTIVE_PREFIXES = ("proactive-", "briefing-", "insight-", "friction-")
                 for f in RESULTS_DIR.iterdir():
-                    if f.name.startswith("proactive-") and f.suffix == ".txt":
+                    if any(f.name.startswith(p) for p in PROACTIVE_PREFIXES) and f.suffix == ".txt":
                         # Claim-by-rename: atomic move to a `.sending`
                         # suffix before reading, so a concurrent poll
                         # (same bridge, or a race with discord-bridge)


### PR DESCRIPTION
## Summary
`poll_proactive()` in `src/telegram-bridge.py` matched only `proactive-*.txt`, so cron-originated results from the morning-briefing skill (writes `results/briefing-{date}.txt` per its contract) plus `daily-insight.py` and `friction-detector.py` were silently archived without ever reaching the owner's Telegram DM.

`discord-bridge.py` already handles those prefixes via `FALLBACK_PREFIXES` in `poll_dm_fallback`. Telegram now mirrors the same set in its single match predicate — no other behavior change.

## Root cause
Manifested today as: morning-briefing skill generated `briefing-2026-05-30.txt`, file landed in `results/`, archiver moved it to `archive/2026-05/` without `send_reply` ever being called. Discord users were unaffected because the fallback path covers them.

## Diff
1 file, +10/-1. The widened prefix set is a strict superset of the previous behavior; existing `proactive-*` delivery is untouched.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('src/telegram-bridge.py').read())"` — ok
- [x] Manually re-delivered today's briefing by copying it to `proactive-briefing-<ts>.txt` — owner received it.
- [ ] After merge + bridge restart: tomorrow's morning briefing lands in Telegram without manual intervention.

Merged to amkunte/sutando in https://github.com/amkunte/sutando/pull/50; opening here for upstream parity with the discord-bridge fallback list.