### PR TITLE
ci(cla-recheck): dedup workflow-authored '@cla-assistant check' comments

### DIFF
--- a/.github/workflows/cla-recheck-on-push.yml
+++ b/.github/workflows/cla-recheck-on-push.yml
@@ -8,6 +8,13 @@ name: cla-recheck-on-push
 # which we don't want. This workflow fires the recheck comment automatically
 # on every push to an open PR, so the bot re-runs without human action.
 #
+# Dedup: before posting a fresh `@cla-assistant check` comment, delete any
+# prior comments authored by `github-actions[bot]` whose body is exactly that
+# trigger. CLA-Assistant fires on `issue_comment.created`, so a freshly-posted
+# comment still re-triggers — we just stop the pile-up across N force-pushes
+# (incident 2026-05-30: PR #1348 accumulated 30+ identical recheck comments
+# after 8 force-pushes during iteration).
+#
 # See CONTRIBUTING.md §6 "After update-branch, CLA-Assistant may not auto-rerun".
 
 on:
@@ -16,6 +23,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
 
 jobs:
   recheck:
@@ -24,9 +32,34 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.pull_request.number;
+            const TRIGGER_BODY = '@cla-assistant check';
+
+            // Delete prior workflow-authored CLA-recheck comments to avoid pile-up.
+            // Paginate so PRs with >100 comments are handled correctly.
+            const priors = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 }
+            );
+            const stale = priors.filter(c =>
+              c.user.login === 'github-actions[bot]' &&
+              (c.body || '').trim() === TRIGGER_BODY
+            );
+            for (const c of stale) {
+              try {
+                await github.rest.issues.deleteComment({
+                  owner, repo, comment_id: c.id
+                });
+              } catch (err) {
+                // Tolerate concurrent-delete / not-found — best-effort cleanup.
+                core.warning(`could not delete comment ${c.id}: ${err.message}`);
+              }
+            }
+
+            // Post the fresh recheck trigger. cla-assistant.io listens to
+            // issue_comment.created and re-runs license/cla on receipt.
             await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: '@cla-assistant check'
+              owner, repo, issue_number, body: TRIGGER_BODY
             });


### PR DESCRIPTION
## What changed, and why

`.github/workflows/cla-recheck-on-push.yml` previously posted a fresh `@cla-assistant check` comment from `github-actions[bot]` on every `synchronize` event (every push / force-push / update-branch). PRs that iterate via force-push accumulate N identical noise comments.

**Incident**: PR #1348 ended up with **30+ identical `@cla-assistant check` comments** after 8 force-pushes during iteration today (2026-05-30). Visible noise; nothing functionally broken.

This PR dedups: before posting the fresh trigger, the workflow lists prior issue comments authored by `github-actions[bot]` whose body is exactly `@cla-assistant check`, deletes them, then posts the new one. `cla-assistant.io` listens on `issue_comment.created` webhooks, so the newly-posted comment still re-runs `license/cla` — trigger semantics preserved, only the visible pile-up is removed.

## Files reviewers should look at first

Single file: `.github/workflows/cla-recheck-on-push.yml`. Diff is +37/-4. Read it inline.

## What user behavior this changes

- **Before**: force-pushes pile up identical `@cla-assistant check` comments under each PR. Reviewers scroll past 30+ identical comments. CLA check still runs correctly.
- **After**: only one such comment is visible at a time (the most recent). CLA check still runs correctly.

## Tests run

This is a CI-workflow change; the workflow only runs on the `sonichi/sutando` upstream side, so end-to-end verification will happen on the next force-push to an open PR after merge.

What I did verify locally:
1. YAML parses cleanly via `js-yaml`.
2. The `github.paginate` + `listComments` call shape matches the [Octokit pagination docs](https://github.com/octokit/plugin-paginate-rest.js#usage).
3. `github.rest.issues.deleteComment` permission scope: requires `issues: write` (added to the `permissions:` block — `pull-requests: write` alone is not sufficient even on PR-tracking issues).
4. Edge case (>100 comments) handled by pagination.
5. Edge case (concurrent delete / not-found) handled by `try/catch` + `core.warning` so the workflow doesn't fail mid-cleanup.

## Edge cases / non-happy paths

- **PR with no prior CLA-recheck comments** (first push): `stale` filter returns empty → no deletes attempted → fresh comment posted. ✓
- **PR with >100 total comments**: `github.paginate` handles pagination automatically.
- **Race: another `synchronize` fires while we're mid-cleanup**: `deleteComment` may 404 for an already-deleted comment; wrapped in `try/catch` + `core.warning` so the workflow continues + emits the fresh trigger.
- **Comment body has trailing whitespace / different case**: `.trim()` covers whitespace; exact-case match `=== '@cla-assistant check'` is the trigger CLA-Assistant actually listens for, so we don't over-delete (e.g. a maintainer manually typing `@cla-assistant CHECK` would not be deleted — appropriate, since the workflow shouldn't touch human-authored comments).

## Migrations / config / permissions / rollback / deployment risks

- **Permission widening**: added `issues: write` to the workflow's `permissions:` block. This is required for `deleteComment` (which uses `DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}`). The token's effective scope is unchanged — `permissions:` only grants what the workflow needs. No org-level / repo-level secret rotation required.
- **Rollback**: `git revert` restores the old single-comment behavior. No persistent state, no schema, no historical artifacts to migrate.

## Known gaps / follow-up

- The new step is "best-effort cleanup, then post fresh". If GitHub's API rate-limits the delete loop on a PR with hundreds of stale comments (e.g. historical accumulation predating this PR), the workflow emits warnings via `core.warning` but still posts the fresh trigger. So the CLA check still re-runs correctly even if cleanup is partial — the worst case after merge is a slow-decaying tail of stale comments, not a stuck CLA check.
- Existing 30+ comments on PR #1348 (and any other PR with historical pile-up) will be cleaned up on the **next** force-push to that PR after this change merges. No backfill script needed.

## Process notes (per CONTRIBUTING.md)

- §Before-starting #1 (search): `gh pr list --search "cla-recheck OR cla-assistant"` + `gh issue list` — no existing PR or issue for this dedup.
- §Before-starting #3 (bug exists on upstream/main): verified — current `.github/workflows/cla-recheck-on-push.yml` at `upstream/main` has the un-deduped `createComment` call.
- §Before-starting #4 (single concern): yes — one workflow file, one behavioral change (dedup).
- Branched off `upstream/main` directly (per R20). `git diff upstream/main..HEAD --stat` = 1 file.
- §After-opening #2 (CLA): authored as `xliu127@stevens.edu` (CLA-mapped). CLA check will pass automatically.

— Lucy (Mac Studio bot)