### PR TITLE
fix(screen-companion): deactivate_screen_companion missing async

### DIFF
--- a/skills/screen-companion/tools.ts
+++ b/skills/screen-companion/tools.ts
@@ -152,7 +152,7 @@ const deactivateScreenCompanionTool: ToolDefinition = {
 		'Exit screen-companion mode and restore the full tool surface. Call this when the user says "exit", "stop the mode", "done", or otherwise indicates they want to leave the current screen-companion mode and return to normal operation.',
 	parameters: z.object({}),
 	execution: 'inline',
-	execute(_args) {
+	async execute(_args) {
 		const exitedMode = activeMode;
 		activeMode = null;
 		const restored = callRestoreTools();


### PR DESCRIPTION
Fast-follow fix to #819's take_note-async fix. Same Promise-interface bug, different tool.

## Repro (live tonight on Mac Studio)

`voice-agent.log` 02:42:37 after owner said "exit" / "stop the mode":
```
02:42:37.375 [Tool] result: deactivate_screen_companion (error, 0ms)
02:42:37.376 [Error] tool: Tool "deactivate_screen_companion" failed: tool2.execute(...).then is not a function (error)
```

Then 4+ subsequent voice turns all blocked with "I'm sorry, I'm having trouble with my tools" — degraded session recovery loop.

## Cause

`skills/screen-companion/tools.ts:155` — `execute(_args)` is sync (returns plain object). Voice-agent runtime calls `tool.execute(...).then(...)` expecting a Promise.

## Fix

1 word: `execute(_args)` → `async execute(_args)`. JS will wrap the returned object in `Promise.resolve` automatically. Verified locally: `returns Promise === true`.

## Lucy review-miss disclosure

When fixing #819's take_note same-pattern bug, I only fixed the one that showed in voice-agent.log instead of grep-checking every sync `execute()` in tools.ts. The deactivate sync existed pre-#819 (introduced by [#818](https://github.com/sonichi/sutando/pull/818), 2026-05-23) but was latent until tonight's first call. Lesson logged: when fixing a class-of-bug, grep the whole file for siblings.

## Test

- Verified `async execute` returns Promise post-fix (local TypeScript runtime check)
- All 5 tools in `skills/screen-companion/tools.ts` now use `async execute` consistently

Closes the same class as #819's take_note fix. Safe to squash-merge.

— Lucy (Mac Studio bot)