### PR TITLE
Restore #819 (revert #1359) — fixes follow in #1365

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "libsodium-wrappers": "^0.8.4",
         "playwright": "^1.58.2",
         "ws": "^8.20.0",
+        "yaml": "^2.9.0",
         "zod": "^3.24.0"
       },
       "devDependencies": {
@@ -3125,6 +3126,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "libsodium-wrappers": "^0.8.4",
     "playwright": "^1.58.2",
     "ws": "^8.20.0",
+    "yaml": "^2.9.0",
     "zod": "^3.24.0"
   },
   "optionalDependencies": {

--- a/skills/screen-companion/SKILL.md
+++ b/skills/screen-companion/SKILL.md
@@ -117,7 +117,7 @@ Configs still cannot grant tools the active VoiceSession doesn't already expose 
 
 What IS persisted by default:
 - **Text transcript** of the spoken conversation, in `<workspace>/data/screen-companion-<sessionId>.jsonl`. Same convention as `phone-conversation/conversation-server.ts` + `discord-voice/discord-voice-server.ts`.
-- **Notes the user explicitly asks Sutando to take** — saved to `<workspace>/notes/` once a `take_note` tool lands (planned; see issue #797). Today, "remember this" requests are persisted only as part of the conversation transcript above.
+- **Notes the user explicitly asks Sutando to take** — saved to `<workspace>/notes/` via the `take_note` tool. "Remember this" / "note that" requests during a session land as `.md` files under `notes/` with a `screen-companion` tag.
 
 What is NOT persisted by default:
 - Vision frames (the screenshots themselves) — sent to Gemini Live and discarded.

--- a/skills/screen-companion/configs/guided-setup.yaml
+++ b/skills/screen-companion/configs/guided-setup.yaml
@@ -80,18 +80,20 @@ system_prompt_overlay: |
   - DO NOT click, type, or take action for the user. You narrate; they
     act. The user keeps full control.
 
-# tools_allow — advisory schema for v0. These three tools are PLANNED but
-# not yet registered anywhere in the codebase (greppable: zero hits outside
-# this skill); guided-setup as shipped relies only on push-mode vision
-# frames + Gemini Live's conversational capabilities, so no tool calls are
-# actually required to operate. The list documents design intent for the
-# follow-up PR that lands real implementations. Until then, Gemini sees
-# this list in the activation payload as guidance, not enforcement
-# (see SKILL.md "Trust + scope"). Renaming or registering each is the
-# next-step decision per sonichi's PR #794 review finding #1.
+  SPEECH REQUIREMENT — never emit silence as a response:
+  - Every user voice input must get an audible spoken reply, even if
+    short. Never go silent. If you're still scanning, say so out loud:
+    "Give me a second to look" or "I'm watching the screen".
+  - If the user says something ambiguous ("hello?", "can you hear me?",
+    just your name), respond with a one-line acknowledgment so they know
+    you're listening: "Yes, I'm here." / "I hear you — what next?"
+  - If you genuinely have nothing to say about the current screen, say
+    so: "Nothing to act on yet — let me know when you're ready." Do NOT
+    stay silent.
+
 tools_allow:
-  - vision_query        # PLANNED: query the current screen frame (pull-mode look-up)
-  - take_note           # PLANNED: save observations to notes/ (e.g., "user got bot token at 15:42")
-  - look_up_reference   # PLANNED: look up doc pages if they ask about a setting
+  - vision_query        # pull-mode screen-frame lookup (on-demand, no continuous stream required)
+  - take_note           # save observations to notes/ (e.g., "user got bot token at 15:42")
+  - look_up_reference   # look up doc pages / field meanings via DuckDuckGo instant answer
 
 goal_template: "Helping the user: {goal}"

--- a/skills/screen-companion/configs/pair-debug.yaml
+++ b/skills/screen-companion/configs/pair-debug.yaml
@@ -66,6 +66,16 @@ system_prompt_overlay: |
   - Change the subject to a larger refactor unless the user asks.
   - Diagnose beyond what you can see on screen.
 
+  SPEECH REQUIREMENT — never emit silence as a response:
+  - Every user voice input must get an audible spoken reply, even if
+    short. Never go silent. If you're still scanning, say so out loud:
+    "Give me a second to look" or "I'm watching the screen".
+  - If the user says something ambiguous ("hello?", "can you hear me?",
+    just your name), respond with a one-line acknowledgment so they know
+    you're listening: "Yes, I'm here." / "I hear you — what next?"
+  - If you genuinely have nothing to say about the current screen, say
+    so: "Nothing concerning on this view so far." Do NOT stay silent.
+
 goal_template: "Debugging: {goal}"
 
 # tools_allow — advisory (PLANNED, not yet registered). See guided-setup.yaml

--- a/skills/screen-companion/configs/pair-review-code.yaml
+++ b/skills/screen-companion/configs/pair-review-code.yaml
@@ -75,6 +75,16 @@ system_prompt_overlay: |
   - Speculate about code you can't see on screen.
   - Run any git or gh commands unprompted.
 
+  SPEECH REQUIREMENT — never emit silence as a response:
+  - Every user voice input must get an audible spoken reply, even if
+    short. Never go silent. If you're still scanning, say so out loud:
+    "Give me a second to look" or "I'm watching the screen".
+  - If the user says something ambiguous ("hello?", "can you hear me?",
+    just your name), respond with a one-line acknowledgment so they know
+    you're listening: "Yes, I'm here." / "I hear you — what next?"
+  - If you genuinely have nothing to say about the current screen, say
+    so: "Nothing concerning on this view so far." Do NOT stay silent.
+
 goal_template: "Reviewing: {goal}"
 
 # tools_allow — advisory (PLANNED, not yet registered). See guided-setup.yaml

--- a/skills/screen-companion/scripts/load-config.ts
+++ b/skills/screen-companion/scripts/load-config.ts
@@ -2,14 +2,14 @@
  * Screen Companion — config loader (shared between activate.ts CLI and
  * the inline tool `activate_guided_setup`).
  *
- * YAML parsing: spawn python3 (avoids adding js-yaml as an npm dep —
- * same pattern as src/oc-profile-catalog.ts).
+ * YAML parsing: native via the 'yaml' npm package. (Earlier python3 shell
+ * approach broke when no PyYAML was on PATH; the npm dep eliminates that.)
  */
 
-import { readdirSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { spawnSync } from 'node:child_process';
+import { parse as parseYamlString } from 'yaml';
 
 const SKILL_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
 const CONFIGS_DIR = join(SKILL_DIR, 'configs');
@@ -30,29 +30,20 @@ export interface ScreenCompanionConfig {
 	goal_template?: string;
 }
 
-// LaunchAgent's PATH (`/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`) finds
-// Homebrew's python3 first, which has no PyYAML — `import yaml` fails at
-// runtime when activation is triggered from voice. Try a list of common
-// python3 binaries and pick the first one that can import yaml. macOS's
-// `/usr/bin/python3` ships PyYAML by default, so the system Python is the
-// usual winner here.
-const PYTHON_CANDIDATES = ['/usr/bin/python3', '/opt/homebrew/bin/python3', 'python3'];
-const YAML_SCRIPT = 'import sys, json, yaml; print(json.dumps(yaml.safe_load(open(sys.argv[1]))))';
+// YAML parsing: native via the 'yaml' npm package. Earlier versions
+// shelled out to python3 with PyYAML, which broke on fresh macOS installs
+// where neither /usr/bin/python3 nor /opt/homebrew/bin/python3 had PyYAML
+// installed. The 'yaml' npm dep is small, dependency-free at runtime, and
+// removes the PATH-resolution gotcha (LaunchAgent's PATH preferred
+// Homebrew Python, which lacks PyYAML).
 
 export function parseYaml(path: string): unknown {
-	const errors: string[] = [];
-	for (const py of PYTHON_CANDIDATES) {
-		const result = spawnSync(py, ['-c', YAML_SCRIPT, path], { encoding: 'utf-8' });
-		if (result.error) {
-			errors.push(`${py}: ${result.error.message}`);
-			continue;
-		}
-		if (result.status === 0) return JSON.parse(result.stdout);
-		errors.push(`${py}: ${result.stderr.trim().split('\n').pop()}`);
+	try {
+		const text = readFileSync(path, 'utf-8');
+		return parseYamlString(text);
+	} catch (e) {
+		throw new Error(`YAML parse failed for ${path}: ${(e as Error).message}`);
 	}
-	throw new Error(
-		`YAML parse failed for ${path}: no python3 with PyYAML found. Tried: ${errors.join('; ')}`,
-	);
 }
 
 export function validateConfig(raw: unknown, path: string): ScreenCompanionConfig {

--- a/skills/screen-companion/tools.ts
+++ b/skills/screen-companion/tools.ts
@@ -14,9 +14,17 @@
 // to the owner about screen sharing if vision isn't already streaming.
 
 import { z } from 'zod';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { loadConfig, discoverConfigs, renderGoal } from './scripts/load-config.js';
-import { registerVisionOnContributor, callUpdateTools, callRestoreTools } from '../../src/vision-tools.js';
+import { registerVisionOnContributor, callUpdateTools, callRestoreTools, captureSendFrame } from '../../src/vision-tools.js';
+
+function resolveWorkspace(): string {
+	const env = process.env.SUTANDO_WORKSPACE;
+	if (env) return env.replace(/^~/, process.env.HOME ?? '');
+	return join(process.env.HOME ?? '', '.sutando', 'workspace');
+}
 
 // Contributor for the screen-share-started system note. Tells Gemini the
 // screen-companion catalog is available AND names the configs the user can
@@ -47,7 +55,7 @@ let activeMode: string | null = null;
 
 // Tools that must always remain available in screen-companion mode:
 // activate_screen_companion (mode-switch), deactivate_screen_companion (exit).
-const ALWAYS_RETAIN = new Set(['activate_screen_companion', 'deactivate_screen_companion']);
+const ALWAYS_RETAIN = new Set(['activate_screen_companion', 'deactivate_screen_companion', 'switch_mode']);
 
 const activateScreenCompanionTool: ToolDefinition = {
 	name: 'activate_screen_companion',
@@ -158,4 +166,142 @@ const deactivateScreenCompanionTool: ToolDefinition = {
 	},
 };
 
-export const tools: ToolDefinition[] = [activateScreenCompanionTool, deactivateScreenCompanionTool];
+// --- vision_query -----------------------------------------------------------
+//
+// Pull-mode screen-frame lookup. Captures the current screen and sends it to
+// Gemini as vision input, then returns a prompt for Gemini to answer. Does NOT
+// require push-mode to be running — designed for modes where the user calls it
+// on demand rather than streaming continuously.
+
+const visionQueryTool: ToolDefinition = {
+	name: 'vision_query',
+	description:
+		'Capture the current screen and look at it to answer a specific question. ' +
+		'Use in pull-mode screen-companion sessions when you need to check what\'s on screen without streaming continuously. ' +
+		'Pass question= to frame what you\'re looking for (e.g. "Is the bot token field visible?"). ' +
+		'The frame is sent to your vision context — answer based on what you see.',
+	parameters: z.object({
+		question: z
+			.string()
+			.optional()
+			.describe('What to look for or answer from the current screen. E.g. "Is the OAuth2 scope list visible?" or "What does the error message say?"'),
+	}),
+	execution: 'inline',
+	async execute(args) {
+		const { question } = (args ?? {}) as { question?: string };
+		const r = await captureSendFrame('screen');
+		if (!r.ok) {
+			return {
+				status: 'failed',
+				error: r.error,
+				hint: 'Screen-capture server may not be running. Start it with `bash src/startup.sh`.',
+			};
+		}
+		return {
+			status: 'frame_sent',
+			source: r.source,
+			question: question ?? null,
+			_note: question
+				? `Frame is in your vision context. Answer: ${question}`
+				: 'Frame is in your vision context. Describe what you see and continue the conversation.',
+		};
+	},
+};
+
+// --- take_note --------------------------------------------------------------
+//
+// Save an observation to notes/ with screen-companion frontmatter tag.
+// Uses the workspace notes dir (same as save_note inline tool).
+
+const takeNoteTool: ToolDefinition = {
+	name: 'take_note',
+	description:
+		'Save an observation or note during a screen-companion session. ' +
+		'Use when the user says "remember this", "note that", or when you observe something worth keeping ' +
+		'(e.g. "user got the bot token at 15:42"). ' +
+		'Saves to notes/ with a screen-companion tag and ISO timestamp.',
+	parameters: z.object({
+		content: z.string().describe('The observation or note to save. Plain text, 1–3 sentences.'),
+		title: z.string().optional().describe('Short title for the note. Auto-generated from content if omitted.'),
+	}),
+	execution: 'inline',
+	async execute(args) {
+		const { content, title } = (args ?? {}) as { content: string; title?: string };
+		const date = new Date();
+		const dateStr = date.toISOString().slice(0, 10);
+		const timeStr = date.toISOString().slice(0, 19).replace('T', ' ');
+		const autoTitle = title ?? content.slice(0, 60).replace(/[^a-zA-Z0-9 ]/g, '').trim();
+		const slug = `sc-${date.toISOString().slice(0, 16).replace(/[T:]/g, '-')}-${autoTitle.toLowerCase().slice(0, 30).replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')}`;
+		const md = `---\ntitle: "${autoTitle}"\ndate: ${dateStr}\ntags: [screen-companion, observation]\n---\n\n*Recorded at ${timeStr}*\n\n${content}\n`;
+		try {
+			const notesDir = join(resolveWorkspace(), 'notes');
+			mkdirSync(notesDir, { recursive: true });
+			writeFileSync(join(notesDir, `${slug}.md`), md);
+			return { status: 'saved', title: autoTitle, slug, path: `notes/${slug}.md` };
+		} catch (e) {
+			return { status: 'failed', error: String(e) };
+		}
+	},
+};
+
+// --- look_up_reference ------------------------------------------------------
+//
+// Look up documentation or reference material for a setting/API/UI element.
+// v1: web search via DuckDuckGo Instant Answer API (no key required), then
+// fall back to fetching the top result URL. Returns a short summary.
+
+const lookUpReferenceTool: ToolDefinition = {
+	name: 'look_up_reference',
+	description:
+		'Look up documentation or reference material for a setting, API field, or UI element the user is confused about. ' +
+		'Use when the user asks what a field means, what value to enter, or what a permission does. ' +
+		'E.g. "What is the \'Bot Token Type\' field in Discord?", "What OAuth scopes do I need for reading DMs?". ' +
+		'Returns a short authoritative summary.',
+	parameters: z.object({
+		query: z.string().describe('The question or term to look up. Be specific: include the product name and context. E.g. "Discord bot token type field meaning".'),
+	}),
+	execution: 'inline',
+	async execute(args) {
+		const { query } = (args ?? {}) as { query: string };
+		try {
+			// DuckDuckGo Instant Answer API — no key, returns JSON with Abstract field
+			const ddgUrl = `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
+			const ddgRes = await fetch(ddgUrl, { headers: { 'User-Agent': 'Sutando/1.0' }, signal: AbortSignal.timeout(8_000) });
+			const ddg = await ddgRes.json() as { Abstract?: string; AbstractURL?: string; RelatedTopics?: Array<{ Text?: string; FirstURL?: string }> };
+
+			if (ddg.Abstract && ddg.Abstract.length > 20) {
+				return {
+					status: 'found',
+					summary: ddg.Abstract,
+					source_url: ddg.AbstractURL ?? null,
+					query,
+				};
+			}
+
+			// Fallback: use top RelatedTopic text
+			const related = ddg.RelatedTopics?.find(t => t.Text && t.Text.length > 20);
+			if (related?.Text) {
+				return {
+					status: 'found',
+					summary: related.Text,
+					source_url: related.FirstURL ?? null,
+					query,
+				};
+			}
+
+			return {
+				status: 'not_found',
+				query,
+				hint: `No instant answer found. Suggest the user search "${query}" in their browser, or ask them to read the relevant field label aloud so you can explain from context.`,
+			};
+		} catch (err) {
+			return {
+				status: 'failed',
+				error: (err as Error)?.message ?? String(err),
+				hint: 'Reference lookup failed (network or API error). Explain from context or ask the user to read the field aloud.',
+			};
+		}
+	},
+};
+
+export const tools: ToolDefinition[] = [activateScreenCompanionTool, deactivateScreenCompanionTool, visionQueryTool, takeNoteTool, lookUpReferenceTool];

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -430,6 +430,20 @@ async function captureAndSend(source: VisionSource): Promise<{ ok: boolean; erro
 	return { ok: true };
 }
 
+/** Capture a single frame from `sourceName` (default 'screen') and send it to
+ *  the active Gemini Live session as vision input. Pull-mode one-shot — does
+ *  not require push mode to be running. Returns `{ ok: false }` if no session
+ *  is connected or the source is unknown. */
+export async function captureSendFrame(sourceName?: string): Promise<{ ok: boolean; source?: string; error?: string }> {
+	try {
+		const source = resolveSource(sourceName);
+		const r = await captureAndSend(source);
+		return r.ok ? { ok: true, source: source.name } : r;
+	} catch (err) {
+		return { ok: false, error: (err as Error)?.message ?? String(err) };
+	}
+}
+
 async function tick(): Promise<void> {
 	if (inFlight || !activeSource) return; // skip overlap — slow camera or slow disk
 	inFlight = true;


### PR DESCRIPTION
## What this does

Restores #819 by reverting #1359. Single commit (`874bf6a` = `git revert e956d1c --no-edit`). Exactly the inverse of #1359, no opportunistic changes.

## Why this PR is pure restoration

Per owner's review-isolation request (2026-05-31): keep #1362 as the **single clean restoration**, and put all subsequent bug fixes (canned-loop / silence / take_note / etc.) in #1365 stacked on top of this branch.

That way:
- **This PR** can be reviewed as "undo #1359, restore #819" — 1 commit, mechanical
- **#1365** is the **fix layer** — reviewable in isolation as the bug fixes that should have been there before #819 originally merged

## After this PR lands

`main` returns to including:
- `1781559` feat(screen-companion): implement vision_query, take_note, look_up_reference (#819)

All fixes (SPEECH REQUIREMENT removal, sanitizer Phase 1+2 detector, stale co-pres goal strip, npm-deps loud-fail, test repros, etc.) → PR #1365 will land them on top.

## Incident note

PR #819 was merged at 2026-05-31 02:23Z without explicit owner authorization. PR #1359 was opened as a revert; a "test" of the new merge-guardrail hook misfired and landed the revert on main at 03:35Z (env-var-prefix bypass in the regex, since fixed). #1362 reopens the door so the fixes (now in #1365) can land.

— Lucy (Mac Studio bot)
