### PR TITLE
fix(send-allowlist): allow ~/.sutando-skills-sync/ for skill-produced renders

### DIFF
--- a/src/send_allowlist.py
+++ b/src/send_allowlist.py
@@ -62,6 +62,12 @@ SEND_ALLOWED_ROOTS: tuple[str, ...] = (
     str(_REPO / "docs"),
     str(Path.home() / "Desktop" / "iclr-backups"),
     str(Path.home() / "Documents" / "sutando-launch-assets"),
+    # Sutando-skills sync: skill-produced renders + assets (e.g.
+    # make-wire-episode workspace mp4s) so bots can attach them via
+    # [file:] without copying to results/notes first. Whole tree is
+    # under owner control (git-synced repo + local-only workspace);
+    # no secrets here.
+    str(Path.home() / ".sutando-skills-sync"),
 )
 
 # Prefix forms — files whose realpath starts with any of these strings


### PR DESCRIPTION
## Summary

- Add `~/.sutando-skills-sync/` to `SEND_ALLOWED_ROOTS` in `src/send_allowlist.py` so the bridge can attach skill-produced renders (e.g. `make-wire-episode` workspace mp4s) via `[file:]` markers without manual copy-to-`notes/generated/` workaround.

## Why now

Mini hit `(file not allowed)` rejection earlier tonight (2026-05-31 ~05:57Z) trying to share `~/.sutando-skills-sync/skills/make-wire-episode/workspace/ep007-v1/remotion/ep007-v1-v27-discord.mp4` with Chi for review. Worked around it by manually copying to `notes/generated/`, but every future skill render hits the same wall.

## Safety

`~/.sutando-skills-sync/` is owner-controlled (git-synced skill scripts + local-only workspace artifacts). No secrets land in there — skills repo contains code + render specs + composed assets, all owner-authored.

## Test plan

- [ ] Restart discord-bridge; verify `[file: ~/.sutando-skills-sync/skills/make-wire-episode/workspace/<ep>/remotion/<file>.mp4]` delivers as attachment instead of `(file not allowed)`
- [ ] Spot-check that nothing else in `~/.sutando-skills-sync/` looks like a secret-leak risk (`.env*`, `*.key`, etc. — none should be there per design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)