### PR TITLE
feat(workspace): loud-warn when fallback masks a .env override

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -23,6 +23,20 @@ if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
   WORKSPACE="$HOME/.sutando/workspace"
+  # Surface the silent-fallback bug class (see PR #1367/#1368): if .env
+  # defines SUTANDO_WORKSPACE but this process never got it (e.g. init.sh
+  # invoked by a bootstrap path that skips startup.sh's .env-source), the
+  # fallback lands in ~/.sutando/workspace/ while the rest of the fleet
+  # uses the override → split-brain. One stderr line per init.sh run
+  # makes the miss visible. We do NOT auto-honor the .env value here —
+  # only surface the mismatch.
+  if [ -f "$REPO/.env" ]; then
+    _env_val=$(grep -E '^SUTANDO_WORKSPACE=' "$REPO/.env" 2>/dev/null | head -1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'\$//" -e "s|^~|$HOME|")
+    if [ -n "$_env_val" ] && [ "$_env_val" != "$WORKSPACE" ]; then
+      echo "workspace: SUTANDO_WORKSPACE is unset in process env, falling back to $WORKSPACE. NOTE: .env declares SUTANDO_WORKSPACE='$_env_val' which is NOT being honored here — source .env or export the var before this process to avoid split-brain with other services." >&2
+    fi
+    unset _env_val
+  fi
 fi
 
 case "$MODE" in

--- a/src/workspace_default.py
+++ b/src/workspace_default.py
@@ -374,6 +374,37 @@ def _migrate_conversation_log(workspace: Path) -> bool:
 
 
 _AUTO_MIGRATE_NOTICE_PRINTED = False
+_FALLBACK_WARN_PRINTED = False
+
+
+def _grep_env_for_workspace() -> str | None:
+    """Best-effort: read `SUTANDO_WORKSPACE=` from the repo's .env file.
+
+    Walks up from this module's resolved path to find the nearest `.env`,
+    then scans for a `SUTANDO_WORKSPACE=` line. Returns the (tilde-expanded)
+    value or None on any failure — never raises. Used only to enrich the
+    fallback-warn message below; resolution itself does NOT consume this
+    value, so a user who genuinely wants the default still gets it.
+    """
+    try:
+        cur = Path(__file__).resolve()
+        for _ in range(5):
+            cur = cur.parent
+            if cur == cur.parent:  # filesystem root
+                return None
+            env_file = cur / ".env"
+            if env_file.is_file():
+                for line in env_file.read_text().splitlines():
+                    s = line.strip()
+                    if s.startswith("SUTANDO_WORKSPACE="):
+                        val = s.split("=", 1)[1].strip()
+                        if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
+                            val = val[1:-1]
+                        return str(Path(val).expanduser()) if val else None
+                return None
+    except Exception:
+        pass
+    return None
 
 
 def resolve_workspace(migrate: bool = True) -> Path:
@@ -440,6 +471,27 @@ def resolve_workspace(migrate: bool = True) -> Path:
             target = anchored
     else:
         target = default_workspace_dir()
+        # Surface the silent-fallback bug class (see PR #1367/#1368): if .env
+        # defines SUTANDO_WORKSPACE but the process never got it (e.g. a
+        # SessionStart hook, launchd service, or any process that didn't
+        # `source .env`), the caller silently lands in `~/.sutando/workspace/`
+        # while the rest of the fleet uses the override → split-brain. One
+        # stderr line per process makes the miss visible. We do NOT auto-honor
+        # the .env value here — that's a behavior change and lives in callers
+        # that opt into it (e.g. skills/agent-registry/scripts/_workspace_resolve.py).
+        global _FALLBACK_WARN_PRINTED
+        if not _FALLBACK_WARN_PRINTED:
+            _FALLBACK_WARN_PRINTED = True
+            env_file_val = _grep_env_for_workspace()
+            if env_file_val and env_file_val != str(target):
+                print(
+                    f"workspace: SUTANDO_WORKSPACE is unset in process env, "
+                    f"falling back to {target}. NOTE: .env declares "
+                    f"SUTANDO_WORKSPACE={env_file_val!r} which is NOT being "
+                    f"honored here — `source .env` or export the var before "
+                    f"this process to avoid split-brain with other services.",
+                    file=sys.stderr,
+                )
 
     # One-time notice if legacy-state evidence exists, pointing at the
     # explicit CLI (to land in a follow-up PR). Process-local guard so we

--- a/src/workspace_default.ts
+++ b/src/workspace_default.ts
@@ -16,14 +16,72 @@
  *   2. ~/.sutando/workspace/
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join, parse } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+let _fallbackWarnPrinted = false;
+
+/**
+ * Best-effort: read `SUTANDO_WORKSPACE=` from the repo's .env file.
+ *
+ * Walks up from this module's resolved path to find the nearest `.env`,
+ * then scans for a `SUTANDO_WORKSPACE=` line. Returns the (tilde-expanded)
+ * value or undefined on any failure — never throws. Used only to enrich
+ * the fallback-warn message below; resolution itself does NOT consume
+ * this value, so a user who genuinely wants the default still gets it.
+ */
+function grepEnvForWorkspace(): string | undefined {
+	try {
+		let cur = fileURLToPath(import.meta.url);
+		for (let i = 0; i < 5; i++) {
+			cur = dirname(cur);
+			if (cur === parse(cur).root) return undefined;
+			const envFile = join(cur, '.env');
+			if (existsSync(envFile)) {
+				for (const line of readFileSync(envFile, 'utf8').split('\n')) {
+					const s = line.trim();
+					if (s.startsWith('SUTANDO_WORKSPACE=')) {
+						let val = s.split('=').slice(1).join('=').trim();
+						if (val.length >= 2 && val[0] === val[val.length - 1] && (val[0] === '"' || val[0] === "'")) {
+							val = val.slice(1, -1);
+						}
+						return val ? val.replace(/^~/, homedir()) : undefined;
+					}
+				}
+				return undefined;
+			}
+		}
+	} catch {
+		// Best-effort; never block resolution on .env probe failures.
+	}
+	return undefined;
+}
 
 export function resolveWorkspace(): string {
 	const env = process.env.SUTANDO_WORKSPACE?.trim();
 	if (env) return env.replace(/^~/, homedir());
-	return join(homedir(), '.sutando', 'workspace');
+	const fallback = join(homedir(), '.sutando', 'workspace');
+	// Surface the silent-fallback bug class (see PR #1367/#1368): if .env
+	// defines SUTANDO_WORKSPACE but the process never got it (e.g. a service
+	// started outside `bash src/startup.sh`), the caller silently lands in
+	// the default while the rest of the fleet uses the override → split-brain.
+	// One stderr line per process makes the miss visible. We do NOT auto-honor
+	// the .env value here — that's a behavior change and lives in callers
+	// that opt into it (e.g. skills/agent-registry/scripts/_workspace_resolve.py).
+	if (!_fallbackWarnPrinted) {
+		_fallbackWarnPrinted = true;
+		const envFileVal = grepEnvForWorkspace();
+		if (envFileVal && envFileVal !== fallback) {
+			process.stderr.write(
+				`workspace: SUTANDO_WORKSPACE is unset in process env, falling back to ${fallback}. ` +
+				`NOTE: .env declares SUTANDO_WORKSPACE='${envFileVal}' which is NOT being honored here — ` +
+				`source .env or export the var before this process to avoid split-brain with other services.\n`
+			);
+		}
+	}
+	return fallback;
 }
 
 /**


### PR DESCRIPTION
## Summary

When a process resolves the workspace without `SUTANDO_WORKSPACE` in its env but `.env` defines the var, the fallback silently lands in `~/.sutando/workspace/` while the rest of the fleet uses the override. Two services with the same `.env` then split-brain — one writes to `~/.sutando/workspace/state/...`, another reads from `.env`-specified `state/...`. Invisible: no error, just empty/stale state. (This is exactly the bug class that produced #1367 in `startup.sh` and #1368 in `skills/agent-registry/`.)

This PR adds a **one-line stderr warning** that fires once per process when the fallback masks a `.env` override. Resolution behavior does NOT change — callers who genuinely want the default still get it (no `.env` override → no warn → fallback as before).

## What changes

Applied to all three workspace resolvers — kept in parity:

- `src/workspace_default.py` — adds `_grep_env_for_workspace()` helper + warn block in `resolve_workspace()`.
- `src/workspace_default.ts` — adds `grepEnvForWorkspace()` helper + warn block in `resolveWorkspace()`.
- `src/init.sh` — inline grep/cut/sed of `$REPO/.env` + warn block in the workspace-resolution branch.

The warn message looks like:

```
workspace: SUTANDO_WORKSPACE is unset in process env, falling back to /Users/me/.sutando/workspace.
NOTE: .env declares SUTANDO_WORKSPACE='/Users/me/Documents/sutando-workspace' which is NOT being honored
here — source .env or export the var before this process to avoid split-brain with other services.
```

Behavior matrix:

| env var | .env has override | result | warn? |
|---|---|---|---|
| set | (any) | use env value | no |
| unset | yes, different from default | use default | **YES** |
| unset | no, or matches default | use default | no |
| unset | no `.env` found | use default | no |

## Why "warn-only" (not auto-honor)

`skills/agent-registry/scripts/_workspace_resolve.py` (#1368) is Option B — it auto-honors the `.env` value when the env var is missing. That's the right behavior for an out-of-band hook (SessionStart) where there's no realistic way to source `.env` first.

The src/ resolvers are different: they run inside processes that **could** have sourced `.env` themselves. Auto-honoring would mask the upstream bug ("why didn't the bootstrap source `.env`?"). Warn-only forces the upstream fix while keeping the existing fallback semantics.

## Tier 1A of the prevention plan

Owner greenlit four tiers earlier today:
- **Tier 1A** ← this PR: loud-warn on fallback (lowest cost, ~99% catch for this class)
- **Tier 1B**: clean-shell CI smoke test — separate PR, follow-up
- **Tier 2**: unified `scripts/source-env.sh` helper + per-script env manifest
- **Tier 3**: drop default fallback entirely (long-term; breaks first-time installers)

## Test plan

Verified locally across 6 scenarios — all pass:
- env set / PY → no warn ✅
- env set / TS → no warn ✅
- env set / SH → no warn ✅
- env unset + `.env` override / PY → WARN ✅
- env unset + `.env` override / TS → WARN ✅
- env unset + `.env` override / SH → WARN ✅

Reviewers can repro by `env -i HOME=/tmp/x PATH=$PATH bash -c "python3 -c 'from src.workspace_default import resolve_workspace; resolve_workspace(migrate=False)'"` from a checkout with `.env` containing `SUTANDO_WORKSPACE=...`.

## Related

- #1367 (startup.sh ordering)
- #1368 (agent-registry — Option B auto-honor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)