### PR TITLE
fix(screen-companion): revert 056b1c5 — SPEECH REQUIREMENT block was the wrong fix for #1356 (closes #1372)

### DIFF
--- a/skills/screen-companion/configs/guided-setup.yaml
+++ b/skills/screen-companion/configs/guided-setup.yaml
@@ -80,17 +80,6 @@ system_prompt_overlay: |
   - DO NOT click, type, or take action for the user. You narrate; they
     act. The user keeps full control.
 
-  SPEECH REQUIREMENT — never emit silence as a response:
-  - Every user voice input must get an audible spoken reply, even if
-    short. Never go silent. If you're still scanning, say so out loud:
-    "Give me a second to look" or "I'm watching the screen".
-  - If the user says something ambiguous ("hello?", "can you hear me?",
-    just your name), respond with a one-line acknowledgment so they know
-    you're listening: "Yes, I'm here." / "I hear you — what next?"
-  - If you genuinely have nothing to say about the current screen, say
-    so: "Nothing to act on yet — let me know when you're ready." Do NOT
-    stay silent.
-
 tools_allow:
   - vision_query        # pull-mode screen-frame lookup (on-demand, no continuous stream required)
   - take_note           # save observations to notes/ (e.g., "user got bot token at 15:42")

--- a/skills/screen-companion/configs/pair-debug.yaml
+++ b/skills/screen-companion/configs/pair-debug.yaml
@@ -66,16 +66,6 @@ system_prompt_overlay: |
   - Change the subject to a larger refactor unless the user asks.
   - Diagnose beyond what you can see on screen.
 
-  SPEECH REQUIREMENT — never emit silence as a response:
-  - Every user voice input must get an audible spoken reply, even if
-    short. Never go silent. If you're still scanning, say so out loud:
-    "Give me a second to look" or "I'm watching the screen".
-  - If the user says something ambiguous ("hello?", "can you hear me?",
-    just your name), respond with a one-line acknowledgment so they know
-    you're listening: "Yes, I'm here." / "I hear you — what next?"
-  - If you genuinely have nothing to say about the current screen, say
-    so: "Nothing concerning on this view so far." Do NOT stay silent.
-
 goal_template: "Debugging: {goal}"
 
 # tools_allow — advisory (PLANNED, not yet registered). See guided-setup.yaml

--- a/skills/screen-companion/configs/pair-review-code.yaml
+++ b/skills/screen-companion/configs/pair-review-code.yaml
@@ -75,16 +75,6 @@ system_prompt_overlay: |
   - Speculate about code you can't see on screen.
   - Run any git or gh commands unprompted.
 
-  SPEECH REQUIREMENT — never emit silence as a response:
-  - Every user voice input must get an audible spoken reply, even if
-    short. Never go silent. If you're still scanning, say so out loud:
-    "Give me a second to look" or "I'm watching the screen".
-  - If the user says something ambiguous ("hello?", "can you hear me?",
-    just your name), respond with a one-line acknowledgment so they know
-    you're listening: "Yes, I'm here." / "I hear you — what next?"
-  - If you genuinely have nothing to say about the current screen, say
-    so: "Nothing concerning on this view so far." Do NOT stay silent.
-
 goal_template: "Reviewing: {goal}"
 
 # tools_allow — advisory (PLANNED, not yet registered). See guided-setup.yaml


### PR DESCRIPTION
Closes #1372. Restructured from the earlier "stale-goal guard" scope after analysis showed `056b1c5` itself is the wrong fix — see #1372 issue body for the full reasoning.


## Root cause now identified (#1356): `gemini-2.5-flash-native-audio-preview-12-2025`

The sqlite log shows the `[Silence]` bug coincides **100%** with the `gemini-2.5-flash-native-audio-preview-12-2025` activation window: all 43 `[Silence]` / `Silence.` events fall inside `[2026-05-26 17:24:32 ET → 2026-05-30 16:27:30 ET]`; **zero** occur under `gemini-3.1-flash-live-preview` (755 silent-free assistant turns since the 5/30 swap). This is direct proof `056b1c5` was **inert as a #1356 fix** — silences continued after the SPEECH REQUIREMENT block landed (7 more events) and only stopped on the model swap, not on the prompt patch. See #1356 for the full evidence + model-period table.

## What this PR does

**Reverts `056b1c5`**: removes the SPEECH REQUIREMENT block from all 3 screen-companion configs (`guided-setup.yaml`, `pair-debug.yaml`, `pair-review-code.yaml`). Restores the pre-band-aid state. 31 line deletions, 0 additions.

## Why revert

`056b1c5` was a prompt-side band-aid for #1356 that:

1. **Misdiagnosed** the cause (assumed prompt-side; actual cause is Gemini Live STT-side — silence also occurs on post-startup greeting where no screen-companion mode is active)
2. **Misplaced** the fix (per-skill yaml overlays; root cause is at voice-agent transport / Gemini config layer)
3. **Didn't eliminate the bug** — and the sqlite evidence now shows why: 7 `[Silence]` events occurred *after* `056b1c5` landed (5/30 ≈16:21 ET); the rate only dropped to zero on the model swap to `gemini-3.1` (~16:47 ET), not on the prompt patch. (#1356 issue body: *"tested via a SPEECH REQUIREMENT rule patch — did not eliminate the bug."*)
4. **Introduced a worse side effect**: verbatim phrase templates (`"Yes, I'm here."` / `"I hear you — what next?"` / `"I'm watching the screen."`) became Gemini's fixed-canned-response template under confused-state. Concrete incident 2026-05-31 04:26Z. Three consecutive identical replies observed for ~20 min until the user backed out.

## What comes after

This PR is **draft until the proper #1356 fix is appended**. The proper fix lives in voice-agent / Gemini layer, not screen-companion configs:

- voice-agent.ts Silence-token filter — drop `Silence.` / `[Silence]` / `<ctrl[0-9]+>` before serving to user (the "path 2" `056b1c5` itself acknowledged as a separate followup)
- or: retry-on-silence at voice-agent transport
- or: Gemini config tweaks (model variants / speech settings)

Once the proper fix lands, this PR will flip from Draft to Ready and the revert+fix ship together. Reverting alone (without the followup) would restore #1356's silence symptom — but that's the **honest pre-band-aid state** of the bug, not a regression.

## Verification

`grep -c stalePrescriptionPatterns skills/screen-companion/tools.ts` = 0 (was never added — earlier scoping iteration was abandoned).

`grep -c "SPEECH REQUIREMENT" skills/screen-companion/configs/*.yaml` after this revert = 0 (was 3 before).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>