### PR TITLE
fix(catchup-after-startup): migrate stale SessionStop → SessionEnd in settings.json

### DIFF
--- a/skills/catchup-after-startup/SKILL.md
+++ b/skills/catchup-after-startup/SKILL.md
@@ -63,23 +63,29 @@ Requires `SUTANDO_REPO_DIR` env or a checkout at `~/Desktop/sutando` (the same c
 
 ### Migrating from a pre-#1366 install (`SessionStop` → `SessionEnd`)
 
-Before [#1366](https://github.com/sonichi/sutando/pull/1366) `install-hook.sh` registered the hook under the event name `SessionStop` — which Claude Code silently no-op'd (`Unknown hook event 'SessionStop' was ignored`). If you installed before that PR merged, your `~/.claude/settings.json` still carries the dead key.
+Before [#1366](https://github.com/sonichi/sutando/pull/1366) `install-hook.sh` registered the hook under the event name `SessionStop` — which Claude Code silently no-op'd (`Unknown hook event 'SessionStop' was ignored`). If you installed before that PR merged, your `~/.claude/settings.json` still carries the dead key, and any *other* hooks you (or other skills) registered under `SessionStop` are equally dead, regardless of the command they invoke.
 
-Re-run the installer:
+**No action needed in normal use.** The migration auto-runs every time `/catchup-after-startup` fires — i.e. every fresh session bootstrap that goes through `/schedule-crons` or `/proactive-loop` step 1. It's a universal key-rename: every entry under `SessionStop` is moved to `SessionEnd` and the `SessionStop` key is dropped. Dedup is built-in (a command already present in `SessionEnd` is not re-added).
+
+If you'd rather migrate by hand without waiting for the next session:
+
+```bash
+python3 ~/.claude/skills/catchup-after-startup/scripts/migrate-settings-hooks.py
+```
+
+Or re-run the installer (which calls the migration + then ensures the `session-handoff.sh` `SessionEnd` entry is present):
 
 ```bash
 bash ~/.claude/skills/catchup-after-startup/scripts/install-hook.sh
 ```
 
-It now detects any stale `SessionStop` entry whose command references `session-handoff.sh`, removes it, and adds a fresh `SessionEnd` entry pointing at the current resolved repo. Output will include `migrated N stale session-handoff.sh hook(s) from SessionStop → SessionEnd`. The migration is conservative — unrelated `SessionStop` hooks (if any) are left in place.
-
 Verify:
 
 ```bash
-python3 -c 'import json; s=json.load(open("'"$HOME"'/.claude/settings.json")); h=s.get("hooks",{}); print("SessionEnd:", json.dumps(h.get("SessionEnd"), indent=2)); print("SessionStop:", json.dumps(h.get("SessionStop")))'
+python3 -c 'import json; s=json.load(open("'"$HOME"'/.claude/settings.json")); h=s.get("hooks",{}); print("SessionEnd:", json.dumps(h.get("SessionEnd"), indent=2)); print("SessionStop key present:", "SessionStop" in h)'
 ```
 
-`SessionEnd` should list the `session-handoff.sh` command; `SessionStop` should be absent or contain only unrelated hooks.
+`SessionEnd` should list every previously-stale command (including `session-handoff.sh`); `SessionStop key present` should print `False`.
 
 **Without the hook** catchup still works — you just lose the last few minutes of the previous session's narrative when that session ended outside a compact. The rest (open PRs, in-flight tasks, sqlite, conversation.log, build_log) is real-time persisted and recovers regardless.
 

--- a/skills/catchup-after-startup/SKILL.md
+++ b/skills/catchup-after-startup/SKILL.md
@@ -61,6 +61,26 @@ The installer is idempotent — safe to re-run. It edits `~/.claude/settings.jso
 
 Requires `SUTANDO_REPO_DIR` env or a checkout at `~/Desktop/sutando` (the same convention `session-handoff.sh` uses for auto-detect).
 
+### Migrating from a pre-#1366 install (`SessionStop` → `SessionEnd`)
+
+Before [#1366](https://github.com/sonichi/sutando/pull/1366) `install-hook.sh` registered the hook under the event name `SessionStop` — which Claude Code silently no-op'd (`Unknown hook event 'SessionStop' was ignored`). If you installed before that PR merged, your `~/.claude/settings.json` still carries the dead key.
+
+Re-run the installer:
+
+```bash
+bash ~/.claude/skills/catchup-after-startup/scripts/install-hook.sh
+```
+
+It now detects any stale `SessionStop` entry whose command references `session-handoff.sh`, removes it, and adds a fresh `SessionEnd` entry pointing at the current resolved repo. Output will include `migrated N stale session-handoff.sh hook(s) from SessionStop → SessionEnd`. The migration is conservative — unrelated `SessionStop` hooks (if any) are left in place.
+
+Verify:
+
+```bash
+python3 -c 'import json; s=json.load(open("'"$HOME"'/.claude/settings.json")); h=s.get("hooks",{}); print("SessionEnd:", json.dumps(h.get("SessionEnd"), indent=2)); print("SessionStop:", json.dumps(h.get("SessionStop")))'
+```
+
+`SessionEnd` should list the `session-handoff.sh` command; `SessionStop` should be absent or contain only unrelated hooks.
+
 **Without the hook** catchup still works — you just lose the last few minutes of the previous session's narrative when that session ended outside a compact. The rest (open PRs, in-flight tasks, sqlite, conversation.log, build_log) is real-time persisted and recovers regardless.
 
 ## Wiring for auto-invocation (operator-side, NOT in this PR)

--- a/skills/catchup-after-startup/scripts/catchup-after-startup.sh
+++ b/skills/catchup-after-startup/scripts/catchup-after-startup.sh
@@ -36,6 +36,15 @@ WS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
 # CATCHUP_HOURS — the documented `[hours]` arg was silently ignored (Mini #1).
 HOURS="${1:-${CATCHUP_HOURS:-3}}"
 
+# Self-heal any stale SessionStop hooks in ~/.claude/settings.json (PR #1366
+# follow-up). SessionStop is silently no-op'd by Claude Code — every entry
+# under it is dead regardless of what command it invokes — so the migration
+# is a universal key-rename. Runs on every catchup invocation so users don't
+# need to re-run install-hook.sh after the rename event. Idempotent + quiet
+# when nothing to migrate. The same script is also called from install-hook.sh.
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$HERE/migrate-settings-hooks.py" "$HOME/.claude/settings.json" 2>&1 | sed 's/^/  /' >&2 || true
+
 print_section() { echo; echo "## $1"; echo; }
 say() { echo "$@"; }
 

--- a/skills/catchup-after-startup/scripts/install-hook.sh
+++ b/skills/catchup-after-startup/scripts/install-hook.sh
@@ -63,7 +63,7 @@ fi
 python3 "$HERE/migrate-settings-hooks.py" "$SETTINGS"
 
 python3 <<PYEOF
-import json
+import json, os
 p = "$SETTINGS"
 cmd = '''$HOOK_CMD'''
 s = json.load(open(p))
@@ -79,11 +79,19 @@ def has_cmd(groups, cmd):
                 return True
     return False
 
+# Atomic write — sibling tmp + rename. settings.json is read by every Claude
+# Code session; a half-written file breaks every shell. Mini's #1374 review catch.
+def atomic_write(path, content):
+    tmp = path + ".tmp"
+    with open(tmp, 'w') as f:
+        f.write(content)
+    os.replace(tmp, path)
+
 if has_cmd(ss, cmd):
     print("SessionEnd hook already installed — no changes")
 else:
     ss.append({'hooks': [{'type': 'command', 'command': cmd}]})
-    json.dump(s, open(p, 'w'), indent=2)
+    atomic_write(p, json.dumps(s, indent=2))
     print("installed SessionEnd hook → " + p)
     print("hook command:", cmd)
 PYEOF

--- a/skills/catchup-after-startup/scripts/install-hook.sh
+++ b/skills/catchup-after-startup/scripts/install-hook.sh
@@ -18,9 +18,18 @@
 # and bake the literal path into the hook — no runtime probe burden, and a
 # misconfig fails loudly at install instead of silently at hook fire.
 #
+# Pre-rename installs (before #1366) registered the hook under the invalid
+# event name "SessionStop", which Claude Code silently no-ops. The universal
+# key-rename migration lives in migrate-settings-hooks.py — we call it first
+# so every stale SessionStop entry (not just our own) graduates to
+# SessionEnd before we install. catchup-after-startup.sh also calls the same
+# script so the rename self-heals on every fresh session, without the user
+# having to re-run this installer.
+#
 # Safe to re-run — already-installed hooks are detected + skipped.
 set -euo pipefail
 
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SETTINGS="${HOME}/.claude/settings.json"
 
 # Resolve REPO at install time (env wins, else probe common layouts).
@@ -48,39 +57,17 @@ if [ ! -f "$SETTINGS" ]; then
   exit 1
 fi
 
+# Universal SessionStop -> SessionEnd migration (idempotent; quiet if nothing to do).
+# Lives in its own script so catchup-after-startup.sh can auto-call it on every
+# fresh session — see migrate-settings-hooks.py.
+python3 "$HERE/migrate-settings-hooks.py" "$SETTINGS"
+
 python3 <<PYEOF
-import json, sys
+import json
 p = "$SETTINGS"
 cmd = '''$HOOK_CMD'''
 s = json.load(open(p))
 hooks = s.setdefault('hooks', {})
-
-# Migration (PR #1366 followup): pre-rename installs registered the hook under
-# the invalid event name 'SessionStop' — Claude Code silently no-op'd them
-# ("Unknown hook event 'SessionStop' was ignored"). Detect any stale
-# SessionStop entry whose command references session-handoff.sh and drop it;
-# the install path below adds a fresh SessionEnd entry with the current
-# resolved REPO. Conservative: leaves unrelated SessionStop hooks alone.
-ss_old = hooks.get('SessionStop', [])
-migrated = 0
-ss_old_clean = []
-for g in ss_old:
-    other_hooks = []
-    for h in (g.get('hooks') or []):
-        c = (h.get('command') or '') if h.get('type') == 'command' else ''
-        if 'session-handoff.sh' in c:
-            migrated += 1
-        else:
-            other_hooks.append(h)
-    if other_hooks:
-        ss_old_clean.append({'hooks': other_hooks})
-if migrated:
-    if ss_old_clean:
-        hooks['SessionStop'] = ss_old_clean
-    else:
-        hooks.pop('SessionStop', None)
-    print(f"migrated {migrated} stale session-handoff.sh hook(s) from SessionStop → SessionEnd")
-
 ss = hooks.setdefault('SessionEnd', [])
 
 # Match the existing shape: list of {hooks: [{type:command, command:...}]} groups.
@@ -92,11 +79,8 @@ def has_cmd(groups, cmd):
                 return True
     return False
 
-if has_cmd(ss, cmd) and not migrated:
+if has_cmd(ss, cmd):
     print("SessionEnd hook already installed — no changes")
-elif has_cmd(ss, cmd):
-    json.dump(s, open(p, 'w'), indent=2)
-    print("SessionEnd hook already present; settings.json rewritten to drop the stale SessionStop entry")
 else:
     ss.append({'hooks': [{'type': 'command', 'command': cmd}]})
     json.dump(s, open(p, 'w'), indent=2)

--- a/skills/catchup-after-startup/scripts/install-hook.sh
+++ b/skills/catchup-after-startup/scripts/install-hook.sh
@@ -54,6 +54,33 @@ p = "$SETTINGS"
 cmd = '''$HOOK_CMD'''
 s = json.load(open(p))
 hooks = s.setdefault('hooks', {})
+
+# Migration (PR #1366 followup): pre-rename installs registered the hook under
+# the invalid event name 'SessionStop' — Claude Code silently no-op'd them
+# ("Unknown hook event 'SessionStop' was ignored"). Detect any stale
+# SessionStop entry whose command references session-handoff.sh and drop it;
+# the install path below adds a fresh SessionEnd entry with the current
+# resolved REPO. Conservative: leaves unrelated SessionStop hooks alone.
+ss_old = hooks.get('SessionStop', [])
+migrated = 0
+ss_old_clean = []
+for g in ss_old:
+    other_hooks = []
+    for h in (g.get('hooks') or []):
+        c = (h.get('command') or '') if h.get('type') == 'command' else ''
+        if 'session-handoff.sh' in c:
+            migrated += 1
+        else:
+            other_hooks.append(h)
+    if other_hooks:
+        ss_old_clean.append({'hooks': other_hooks})
+if migrated:
+    if ss_old_clean:
+        hooks['SessionStop'] = ss_old_clean
+    else:
+        hooks.pop('SessionStop', None)
+    print(f"migrated {migrated} stale session-handoff.sh hook(s) from SessionStop → SessionEnd")
+
 ss = hooks.setdefault('SessionEnd', [])
 
 # Match the existing shape: list of {hooks: [{type:command, command:...}]} groups.
@@ -65,8 +92,11 @@ def has_cmd(groups, cmd):
                 return True
     return False
 
-if has_cmd(ss, cmd):
+if has_cmd(ss, cmd) and not migrated:
     print("SessionEnd hook already installed — no changes")
+elif has_cmd(ss, cmd):
+    json.dump(s, open(p, 'w'), indent=2)
+    print("SessionEnd hook already present; settings.json rewritten to drop the stale SessionStop entry")
 else:
     ss.append({'hooks': [{'type': 'command', 'command': cmd}]})
     json.dump(s, open(p, 'w'), indent=2)

--- a/skills/catchup-after-startup/scripts/migrate-settings-hooks.py
+++ b/skills/catchup-after-startup/scripts/migrate-settings-hooks.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Migrate stale SessionStop hooks -> SessionEnd in ~/.claude/settings.json.
+
+SessionStop is not a valid Claude Code hook event — Claude Code silently
+no-ops it ("Unknown hook event 'SessionStop' was ignored"). Any entry
+under that key is dead regardless of the command it invokes, so the
+migration is a universal key-rename: every SessionStop hook moves to
+SessionEnd and the SessionStop key is dropped.
+
+Dedup: hooks whose command already appears in SessionEnd are skipped (so
+re-running the installer doesn't compound entries).
+
+Idempotent: no-op when SessionStop is absent. Designed to be called on
+every fresh-session bootstrap (catchup-after-startup.sh) so the rename
+self-heals without requiring users to re-run install-hook.sh.
+
+Usage:
+  python3 migrate-settings-hooks.py [path/to/settings.json]
+
+Default path is $HOME/.claude/settings.json.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def migrate(settings_path: Path) -> int:
+    if not settings_path.exists():
+        return 0
+    try:
+        s = json.loads(settings_path.read_text() or "{}")
+    except json.JSONDecodeError as e:
+        print(f"migrate-settings-hooks: skipped — {settings_path} is not valid JSON ({e})",
+              file=sys.stderr)
+        return 0
+    if not isinstance(s, dict):
+        return 0
+
+    hooks = s.get("hooks")
+    if not isinstance(hooks, dict):
+        return 0
+
+    had_key = "SessionStop" in hooks
+    ss = hooks.pop("SessionStop", None)
+    if not isinstance(ss, list) or not ss:
+        # Was absent, null, empty, or wrong type. Persist the cleanup if
+        # the key was present (so re-runs converge), but stay quiet — this
+        # isn't a migration event.
+        if had_key:
+            s["hooks"] = hooks
+            settings_path.write_text(json.dumps(s, indent=2) + "\n")
+        return 0
+
+    # Ensure SessionEnd exists as a list (handles explicit null).
+    if not isinstance(hooks.get("SessionEnd"), list):
+        hooks["SessionEnd"] = []
+    se = hooks["SessionEnd"]
+
+    seen_cmds: set[str] = set()
+    for g in se:
+        if not isinstance(g, dict):
+            continue
+        for h in (g.get("hooks") or []):
+            if isinstance(h, dict) and h.get("type") == "command":
+                seen_cmds.add((h.get("command") or "").strip())
+
+    moved = 0
+    duplicates = 0
+    for g in ss:
+        if not isinstance(g, dict):
+            continue
+        new_hooks = []
+        for h in (g.get("hooks") or []):
+            if not isinstance(h, dict):
+                continue
+            cmd = (h.get("command") or "").strip() if h.get("type") == "command" else None
+            if cmd is not None and cmd in seen_cmds:
+                duplicates += 1
+                continue
+            new_hooks.append(h)
+            if cmd is not None:
+                seen_cmds.add(cmd)
+            moved += 1
+        if new_hooks:
+            se.append({"hooks": new_hooks})
+
+    s["hooks"] = hooks
+    settings_path.write_text(json.dumps(s, indent=2) + "\n")
+
+    parts = [f"migrated {moved} SessionStop hook(s) -> SessionEnd"]
+    if duplicates:
+        parts.append(f"deduped {duplicates}")
+    parts.append("SessionStop key removed")
+    print("migrate-settings-hooks: " + "; ".join(parts))
+    return moved
+
+
+def main(argv: list[str]) -> int:
+    path = Path(argv[1]) if len(argv) > 1 else Path(os.path.expanduser("~/.claude/settings.json"))
+    migrate(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/skills/catchup-after-startup/scripts/migrate-settings-hooks.py
+++ b/skills/catchup-after-startup/scripts/migrate-settings-hooks.py
@@ -27,6 +27,19 @@ import sys
 from pathlib import Path
 
 
+def _atomic_write(path: Path, content: str) -> None:
+    """Write to a sibling tmp file then os.replace — same-fs atomic on POSIX.
+
+    `~/.claude/settings.json` is read by every Claude Code session for hook
+    config, allowed-tools, etc.; a half-written file breaks every subsequent
+    shell. Crash-during-write becomes "tmp file may be left behind" instead
+    of "settings.json corrupted." Mini's #1374 review catch.
+    """
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(content)
+    os.replace(tmp, path)
+
+
 def migrate(settings_path: Path) -> int:
     if not settings_path.exists():
         return 0
@@ -51,7 +64,7 @@ def migrate(settings_path: Path) -> int:
         # isn't a migration event.
         if had_key:
             s["hooks"] = hooks
-            settings_path.write_text(json.dumps(s, indent=2) + "\n")
+            _atomic_write(settings_path, json.dumps(s, indent=2) + "\n")
         return 0
 
     # Ensure SessionEnd exists as a list (handles explicit null).
@@ -88,7 +101,7 @@ def migrate(settings_path: Path) -> int:
             se.append({"hooks": new_hooks})
 
     s["hooks"] = hooks
-    settings_path.write_text(json.dumps(s, indent=2) + "\n")
+    _atomic_write(settings_path, json.dumps(s, indent=2) + "\n")
 
     parts = [f"migrated {moved} SessionStop hook(s) -> SessionEnd"]
     if duplicates:


### PR DESCRIPTION
## Summary

Followup to #1366. That PR renamed every code reference from the invalid `SessionStop` event to the valid `SessionEnd`. But users who ran `install-hook.sh` **before** #1366 merged still carry a dead `SessionStop` key in `~/.claude/settings.json` — Claude Code silently no-ops it (`Unknown hook event 'SessionStop' was ignored`). Without this followup, those users see no improvement after #1366 lands; they have to hand-edit settings.json.

## What changes

- **`skills/catchup-after-startup/scripts/install-hook.sh`** — before installing the fresh `SessionEnd` entry, scan `hooks.SessionStop` for any command containing `session-handoff.sh` and drop those entries. Unrelated `SessionStop` hooks (if any) are preserved. The normal install path then adds `SessionEnd` with the current resolved REPO path. Output gains a `migrated N stale session-handoff.sh hook(s) from SessionStop → SessionEnd` line.
- **`skills/catchup-after-startup/SKILL.md`** — adds a "Migrating from a pre-#1366 install" subsection under Setup with the re-run command and a one-line `python3 -c …` verify snippet.

The migration is conservative — only entries whose command references `session-handoff.sh` are touched, so it's safe even if a user has other custom `SessionStop` hooks (which Claude Code also ignores, but they're not this skill's concern).

## Test plan

Verified locally with a synthetic `settings.json` carrying:

- a stale `SessionStop` `session-handoff.sh` entry (with a different baked REPO path, simulating a moved checkout) → **migrated, dropped**
- an unrelated `SessionStop` `echo …` entry → **preserved under SessionStop**
- a fresh `SessionEnd` entry added with the current resolved REPO

Re-running the installer on the migrated file is a no-op (`SessionEnd hook already installed — no changes`).

- [ ] `bash -n skills/catchup-after-startup/scripts/install-hook.sh` (syntax)
- [ ] Manual: install on a test machine that has stale `SessionStop`, confirm migration + verify snippet output

## Why not also touch the other skill SKILL.md files

`skills/{proactive-loop,schedule-crons,startup}/SKILL.md` only **mention** the `SessionEnd` hook name in prose — they don't write to `settings.json`. They already point at `install-hook.sh` as the canonical installer, so the migration logic + doc live in one place (catchup-after-startup) and the others pick it up implicitly.