### PR TITLE
feat(skill): add trip-radar — proactive itinerary, concierge & timezone-correct calendar sync

### DIFF
--- a/skills/trip-radar/.gitignore
+++ b/skills/trip-radar/.gitignore
@@ -1,0 +1,6 @@
+# user trip data + learned prefs are runtime state, not source
+state/*.json
+!state/*.example.json
+state/history/
+state/corpus/*
+!state/corpus/.gitkeep

--- a/skills/trip-radar/SKILL.md
+++ b/skills/trip-radar/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: trip-radar
+description: "Auto-aggregates flight/hotel/car/train confirmations from email into a live itinerary, and — when it detects a NEW trip — proactively suggests hotels, restaurants, and activities tuned to your destination and your own past-travel preferences. Also fires check-in and flight-status reminders."
+user-invocable: true
+---
+
+# Trip Radar
+
+Turns the travel-confirmation clutter in your inbox into (1) a clean live itinerary and (2) a proactive concierge: the moment a new trip shows up, Sutando tells you *"NYC Jun 12–15 — based on your history, here are 3 hotels, 5 restaurants, and 2 activities worth booking."*
+
+**Usage**: `/trip-radar` (on-demand: show upcoming trips + refresh suggestions)
+
+## What it does
+
+Two cooperating loops:
+
+1. **Itinerary sync** — parse flight / hotel / car / train / Airbnb confirmation emails into `state/trips.json` (trips, each with dated segments). Runs daily + on demand. Diffing against the prior scan surfaces **new trips** and **changes** (delays, gate/seat changes, cancellations).
+2. **Concierge suggestions** — when a *new* trip is detected, derive the traveler's preferences from their own past-travel history and research destination-specific, taste-matched **hotels / restaurants / activities**, delivered as one proactive message. This is the part that makes it feel magic, not just a parser.
+
+## Why it fits Sutando
+
+- Leans on the **Gmail MCP** (read the user's own mail) + **proactive-loop** (detect + push) + **voice/Telegram** delivery — all existing infrastructure.
+- The preference model is **learned from the user's own data**, and refined over time (and via "learn from demonstration" corrections) — a durable, sticky capability rather than a generic search.
+
+## The preference model (`state/travel-preferences.json`)
+
+The clever, sticky part. Built once by mining past travel emails, then incrementally refined every scan (and editable by the user — corrections are honored):
+
+- **Lodging** — preferred chains/brands, neighborhood/area patterns, price tier, must-have amenities (gym, lounge, kitchen), loyalty programs.
+- **Dining** — cuisines, price level, vibe (fine-dining vs casual vs hole-in-the-wall), dietary constraints, reservation habits.
+- **Activities** — museums / outdoors / nightlife / food-tours mix; pace (packed vs relaxed).
+- **Logistics** — preferred airlines, seat, rental-car brand, loyalty numbers.
+
+Stored locally in the workspace; never leaves the machine.
+
+## Triggers
+
+- **Daily cron** (recommended `*/41 6 * * *` or similar off-peak; add to `schedule-crons`): run the scan-prompt; deliver only on new-trip / material-change / imminent-checkin.
+- **On-demand**: `/trip-radar` → show upcoming itinerary + (re)generate suggestions for the next trip.
+- **Voice/chat**: "what's my next trip?", "suggest restaurants for Miami", "where should I stay in NYC?" → read `state/trips.json` + run the suggestion step for the named destination.
+
+## Reminders it fires
+
+- **Check-in** — ~24h before each flight (airline + confirmation #).
+- **Day-of status** — flight delay / gate / cancellation (free aviation status source).
+- **Pre-trip prep** — a packing/logistics nudge 2 days out (weather at destination + any visa/TSA notes).
+
+## State
+
+- `state/trips.json` — current + recent trips (example shape in `state/trips.example.json`).
+- `state/travel-preferences.json` — the learned preference model.
+- `state/history/<date>.json` — prior-scan snapshots (diffing).
+
+## How to run
+
+The procedure is fully prescribed in **`scan-prompt.md`** — the agent follows it verbatim (same "the scan IS the prompt" pattern as morning-briefing / subscription-scanner: Gmail access lives at the agent layer, light state on disk, no heavy Python). `scripts/build_trip_state.py` is a thin helper that validates + merges the structured trip data the agent extracts.
+
+## Privacy
+
+All email parsing is local (Gmail MCP on the user's own account); the preference model and itineraries live only in the workspace. No third-party trip aggregator is involved.
+
+## Per-trip chat & document corpus
+
+Each trip keeps a document corpus under `state/corpus/<trip_id>/`:
+- **Chat about a trip** — on request ("must-visit in Nubra?", "authentic parathas in Delhi?"), answer using that trip's record + its corpus + web research.
+- **Ingest a document** — when the user supplies a PDF/image/doc (e.g. a PDF-only e-ticket the Gmail tools can't read), save it under `state/corpus/<trip_id>/` and extract its facts with the **Read tool** (Read natively handles PDFs + images — do NOT text/utf-8-parse) into `state/corpus/<trip_id>/_corpus.md`, and when it carries booking/itinerary detail, into the trip's record in `state/trips.json`.
+
+*Optional web dashboard:* a host web UI can surface these as a per-trip chat box + 📎 attach control (in this repo, `src/web-client.ts` wires `/trips/chat`, `/trips/upload`, and a `/trips/chat-result` poll, dispatching `from: trip-chat` / `from: trip-ingest` tasks). The skill is fully usable without any web UI — these are agent capabilities, not web-only.
+
+## Calendar sync — timezone-correct, idempotent
+
+On request, cross-check each flight/hotel segment against the user's Google Calendar (Calendar MCP) and (1) create any MISSING events, (2) correct any with wrong times — always with an explicit `timeZone` matching the segment's offset region (e.g. +05:30 → `Asia/Kolkata`), because Gmail's auto-add frequently mislabels timezones or drops legs.
+
+Idempotency is **structural**, not prompt-dependent: `build_trip_state.py` stamps a deterministic `uid` on every segment, and each synced event carries a hidden `[trip-radar:<uid>]` marker in its description. On every sync, match a segment to its event by that exact marker FIRST (then fall back to flight# + departure date to adopt pre-existing Gmail auto-events), create only truly-missing segments (embedding the marker + the segment's OWN confirmation# verbatim — never another segment's PNR), correct mismatches, and leave already-correct events untouched. Never delete unrelated events. Re-running is a no-op.
+
+*Optional web dashboard:* a host web UI can expose this as a per-trip "🗓 Check & sync to Calendar" button (in this repo, `/trips/calendar-sync` dispatches a `from: trip-calsync` task whose body prescribes the match→create/fix steps above). Not required — the sync is an agent capability.

--- a/skills/trip-radar/scan-prompt.md
+++ b/skills/trip-radar/scan-prompt.md
@@ -63,12 +63,13 @@ Use WebSearch/WebFetch for current, real options (never invent venues or prices 
 **Persist the suggestions onto the trip** (so they survive beyond the ephemeral delivery message and can be re-surfaced later or rendered by an optional web dashboard): write them into that trip's `suggestions` field in `state/trips.json` as:
 ```json
 "suggestions": {
+  "generated_at": "<ISO date you researched these>",
   "hotels":      [{"name": "...", "url": "...", "area": "...", "price": "$$$", "why": "..."}],
   "restaurants": [{"name": "...", "url": "...", "area": "...", "cuisine": "...", "why": "..."}],
   "activities":  [{"name": "...", "url": "...", "why": "..."}]
 }
 ```
-(When present, `url` makes `name` a link; `area`/`cuisine`/`price` are display meta alongside the `why` line.)
+(When present, `url` makes `name` a link; `area`/`cuisine`/`price` are display meta alongside the `why` line. `generated_at` lets the UI/agent flag stale prices/availability — re-research if it's weeks old before re-surfacing.)
 
 ## Deliver
 

--- a/skills/trip-radar/scan-prompt.md
+++ b/skills/trip-radar/scan-prompt.md
@@ -1,0 +1,89 @@
+# Trip Radar — scan-prompt (follow verbatim)
+
+You are running Trip Radar for the owner. Two phases: **(A) sync the itinerary**, then **(B) for any newly-detected trip, generate concierge suggestions**. Read `state/travel-preferences.json` first (build it via Phase 0 if missing).
+
+Workspace paths resolve under `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}` — write state to the skill's `state/` dir; deliver via `results/`.
+
+## Phase 0 — preference model (one-time build; refine each run)
+
+If `state/travel-preferences.json` is missing OR `--rebuild-prefs` is passed, mine the user's own past travel to learn preferences. Gmail queries (last ~3 years):
+```
+from:(no-reply@confirmation.marriott.com OR hilton.com OR hyatt.com OR ihg.com OR booking.com OR hotels.com OR airbnb.com OR expedia.com) subject:(confirmation OR reservation OR booking OR receipt)
+subject:(reservation OR "table for" OR "booking confirmed") from:(opentable.com OR resy.com OR exploretock.com OR sevenrooms.com)
+```
+From the hits, infer and write `travel-preferences.json` (schema below). Be conservative — only record patterns with ≥2 supporting data points; mark single-instance guesses `"confidence":"low"`. NEVER fabricate a loyalty number; only record ones that literally appear.
+
+If prefs exist, do a light refresh: fold in any new lodging/dining signal since `last_pref_refresh`.
+
+## Phase A — sync itinerary
+
+**Scan scope — search ALL mail, not just the inbox.** Travel confirmations are routinely archived or filed into labels (e.g. `2026_Travel`, `Travel_Imp`, `NYC`), and a far-ahead booking's confirmation is *old* — so an inbox-only or tight-recency scan misses real upcoming trips (observed 2026-06-01: a SFO→Delhi booking filed in `2026_Travel` from 4 months prior was missed). Two rules:
+1. **Cover labels + archived mail.** Append ` in:anywhere` to the queries below (includes archived + all labels; excludes only Spam/Trash). ALSO run `list_labels` and, for any label whose name matches `travel|trip|vacay|vacation|<year>` (e.g. `2026_Travel`, `Travel_Imp`), run a `label:"<name>"` sweep over the same senders/subjects.
+2. **Don't gate on email recency.** Use a wide window (`newer_than:1y`) or none, and decide "upcoming" by the **travel dates inside the email**, not by when the email arrived. A confirmation booked months ago for a future trip MUST surface.
+
+Gmail queries (paginate; add ` in:anywhere`; also sweep travel labels per rule 1):
+```
+from:(noreply@united.com OR delta.com OR aa.com OR alaskaair.com OR southwest.com OR jetblue.com OR ana.co.jp OR qatarairways.com OR emirates.com OR airindia.com OR aircanada.ca OR amadeus.com OR amexgbt.com OR mytrips.amexgbt.com) subject:(confirmation OR itinerary OR "e-ticket" OR "your trip" OR booking OR ticket OR boarding) in:anywhere newer_than:1y
+from:(marriott.com OR hilton.com OR hyatt.com OR ihg.com OR booking.com OR hotels.com OR airbnb.com OR fourseasons.com OR tajhotels.com OR oberoihotels.com OR xanterra.com) subject:(confirmation OR reservation OR "your stay" OR receipt) in:anywhere newer_than:1y
+from:(hertz.com OR avis.com OR enterprise.com OR turo.com OR amtrak.com OR trainline.com) subject:(confirmation OR reservation OR itinerary) in:anywhere newer_than:1y
+label:"2026_Travel" OR label:"Travel_Imp"   (+ any travel/trip/vacay label from list_labels)
+```
+Also catch travel-agent/aggregator bookings (Amex GBT/TripIt/Aeroplan) and forwarded confirmations (subject `Fwd:`), which often live only in a label, never the inbox.
+
+For each confirmation, extract: type (flight/hotel/car/train/lodging), confirmation #, provider, start/end datetimes + timezone, origin/destination (airport codes + city), and price if shown. Read the body via `get_thread` when the subject is truncated.
+
+**Group segments into trips.** A trip = a contiguous away-from-home window. Cluster segments whose dates overlap/adjoin and whose location is the same metro. Derive `trip.destination` (primary city), `trip.start`/`trip.end`, and attach segments. Use `scripts/build_trip_state.py` to validate + merge the extracted JSON into `state/trips.json` (it preserves `trip_id`, dedups by confirmation #, and snapshots the prior file to `state/history/<date>.json`).
+
+**Diff vs the prior snapshot** to compute:
+- `new_trips` — trips not present last scan.
+- `changes` — segment delays / gate / seat / cancellation / new segment added to an existing trip.
+
+## Phase A.5 — rich itinerary ingestion (docs, sheets, operator emails)
+
+Airline/hotel confirmations only give the skeleton. The DETAILED itinerary for a tour/road-trip (day-by-day route, overnight stops, named hotels, the operator's plan) usually lives in **a Google Doc/Sheet or a tour-operator email**, not a standard confirmation — and is exactly what users care about. For each upcoming trip, also look there:
+
+1. **Google Drive** — `mcp__claude_ai_Google_Drive__search_files` for docs/sheets matching the destination/operator/dates (e.g. `fullText contains 'Ladakh'`, `title contains '<destination>'`, mimeType doc/spreadsheet). Read the match with `read_file_content` (it renders Docs, Sheets, AND PDFs). Extract the day-by-day plan.
+2. **Operator / agent / aggregator emails** — search beyond airline/hotel senders: the tour operator (often a plain gmail/business address), Amex GBT, TripIt, "itinerary"/"confirmed itinerary" subjects. These carry the schedule + named lodging.
+3. **PDF e-tickets** — Air India and many carriers put the actual flight times ONLY in a PDF attachment; the email body is just "ticket attached." The Gmail tools here CANNOT read attachment bytes — so do NOT guess those dates. Either (a) read the same e-ticket if it's also saved in Drive (`read_file_content` handles PDF), or (b) mark the segment dates "verify" and ask the owner. Never fabricate flight times.
+
+Persist the rich plan onto the trip:
+- `trip.tour` = `{operator, name, dates, route, max_altitude, distance, bike, lodging, doc(view-url)}`
+- `trip.road_itinerary` = `[{date, stop, detail}, …]` (day-by-day). (An optional web dashboard renders both.)
+
+## Phase B — concierge suggestions (only for `new_trips`, or on-demand for a named destination)
+
+For each new trip, using `travel-preferences.json` + the destination + dates + trip purpose (infer business vs leisure from segment mix / day-of-week / past patterns), research and assemble:
+
+- **🏨 Hotels (3)** — match the user's lodging prefs (brand/area/tier/amenities). Prefer their loyalty chains. For each: name, neighborhood, ~nightly price, why-it-fits (1 line), booking link.
+- **🍽 Restaurants (4–6)** — match dining prefs (cuisine/price/vibe/dietary). Favor **places they haven't been** (cross-check past reservation history) and current standouts. For each: name, cuisine, neighborhood, why, reservation link if available.
+- **🎟 Activities/tours (1–3, optional)** — match the activity profile + trip length; skip if a tight business trip.
+
+Use WebSearch/WebFetch for current, real options (never invent venues or prices — if unsure, say "verify"). Keep it tight and skimmable.
+
+**Persist the suggestions onto the trip** (so they survive beyond the ephemeral delivery message and can be re-surfaced later or rendered by an optional web dashboard): write them into that trip's `suggestions` field in `state/trips.json` as:
+```json
+"suggestions": {
+  "hotels":      [{"name": "...", "url": "...", "area": "...", "price": "$$$", "why": "..."}],
+  "restaurants": [{"name": "...", "url": "...", "area": "...", "cuisine": "...", "why": "..."}],
+  "activities":  [{"name": "...", "url": "...", "why": "..."}]
+}
+```
+(When present, `url` makes `name` a link; `area`/`cuisine`/`price` are display meta alongside the `why` line.)
+
+## Deliver
+
+- **New trip detected** → write `results/proactive-tripradar-{epoch}.txt`:
+  ```
+  ✈️ Trip detected: <Destination> <start>–<end> (<purpose>)
+  🏨 Hotels: <3 with 1-line why + link>
+  🍽 Restaurants: <4–6 with link>
+  🎟 Do: <0–3>
+  (Reply "more hotels" / "cheaper" / "I prefer X" to refine — I'll learn it.)
+  ```
+- **Change detected** (delay/gate/cancel) → concise proactive alert.
+- **Imminent check-in** (flight <24h, no check-in seen) → reminder with airline + conf #.
+- **Nothing new / no change** → stay silent (write nothing). On-demand `/trip-radar` always replies (show upcoming itinerary even if unchanged).
+
+## Refinement = learning
+
+When the owner reacts ("too pricey", "I love sushi", "always book Hyatt", "hated that neighborhood"), update `travel-preferences.json` accordingly and confirm briefly — that's the flywheel that makes suggestions sharper each trip.

--- a/skills/trip-radar/scripts/build_trip_state.py
+++ b/skills/trip-radar/scripts/build_trip_state.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Validate + merge agent-extracted trips into state/trips.json, and emit the
+diff (new trips / changes) vs the prior scan.
+
+The agent (per scan-prompt.md) extracts travel confirmations from Gmail and
+writes them as a JSON array of trips to a temp file; this thin helper does the
+deterministic part: dedup by confirmation number, preserve stable trip_ids,
+snapshot the prior state for history/diffing, and print what's NEW or CHANGED
+so the agent knows whether to deliver a proactive message.
+
+Usage:
+    python3 build_trip_state.py <extracted_trips.json>
+        merge the extracted file into state/trips.json; print diff summary.
+    python3 build_trip_state.py --show
+        print the current upcoming itinerary (no write).
+
+Trip shape (see state/trips.example.json):
+    {"destination","start","end","purpose","segments":[
+        {"type","provider","confirmation","start","end","from","to","price","status"}]}
+
+py39-safe: `from __future__ import annotations`, timezone.utc (not datetime.UTC).
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+STATE = SKILL_DIR / "state"
+TRIPS = STATE / "trips.json"
+HISTORY = STATE / "history"
+
+
+def _load(path: Path) -> dict:
+    if not path.exists():
+        return {"trips": [], "last_scan": None}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {"trips": [], "last_scan": None}
+
+
+def _leg_route(seg: dict) -> str:
+    """A route/flight signature that distinguishes the legs of one booking.
+    Prefers explicit origin/destination; falls back to a flight code parsed
+    from the provider/name (e.g. 'Air India AI2479 (First)' → 'AI2479') so the
+    two domestic legs of a round-trip that share a confirmation# and carry NO
+    from/to fields don't collapse to the same key.
+    """
+    o = seg.get("from") or seg.get("origin") or ""
+    d = seg.get("to") or seg.get("destination") or ""
+    if o or d:
+        return f"{o}>{d}"
+    m = re.search(r"[A-Z]{2}\s?\d{2,4}", seg.get("provider") or seg.get("name") or "")
+    return m.group(0).replace(" ", "") if m else ""
+
+
+def _seg_key(seg: dict) -> str:
+    """Stable identity of a *leg*. Includes the route/flight signature, not the
+    date, so:
+    - the two legs of a round-trip (same confirmation#, different route) stay
+      DISTINCT (keying on conf# alone collided them into one),
+    - a reschedule (same conf# + route, new date) keeps the same key → reads as
+      a status/time change, not a drop + add.
+    When conf# is present but no route/flight signature can be derived, the start
+    date is the last-resort differentiator (rare; only when both are missing).
+    """
+    conf = (seg.get("confirmation") or "").strip().upper()
+    route = _leg_route(seg)
+    if conf and route:
+        return f"conf:{conf}|{seg.get('type')}|{route}"
+    if conf:
+        return f"conf:{conf}|{seg.get('type')}|{(seg.get('start') or '')[:10]}"
+    return f"{seg.get('type')}|{(seg.get('start') or '')[:10]}|{route}"
+
+
+def _seg_uid(trip_id: str, seg: dict) -> str:
+    """Deterministic, stable per-segment id used as the Google Calendar dedup
+    marker. Same segment → same uid across runs, so the calendar sync can match
+    an existing event structurally (by `[trip-radar:<uid>]` in its description)
+    instead of relying on fuzzy time/route matching."""
+    return "tr-" + _slug(trip_id) + "-" + _slug(_seg_key(seg))
+
+
+def _slug(s: str) -> str:
+    out = "".join(c if c.isalnum() else "-" for c in (s or "?").lower())
+    while "--" in out:
+        out = out.replace("--", "-")
+    return out.strip("-") or "trip"
+
+
+def _trip_id(trip: dict) -> str:
+    return f"{_slug(trip.get('destination'))}-{trip.get('start','?')[:10]}"
+
+
+def _conf_set(trip: dict) -> set:
+    return {(s.get("confirmation") or "").strip().upper()
+            for s in trip.get("segments", []) if (s.get("confirmation") or "").strip()}
+
+
+def _date_overlap(a: dict, b: dict) -> bool:
+    """True if two trips share a metro AND their [start,end] date ranges overlap."""
+    if _slug(a.get("destination")) != _slug(b.get("destination")):
+        return False
+    a0, a1 = (a.get("start") or "")[:10], (a.get("end") or a.get("start") or "")[:10]
+    b0, b1 = (b.get("start") or "")[:10], (b.get("end") or b.get("start") or "")[:10]
+    return a0 <= b1 and b0 <= a1
+
+
+def _is_future(seg: dict) -> bool:
+    return (seg.get("start") or "")[:10] >= datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _match_prior(trip: dict, priors: list, used: set):
+    """Find the prior trip this extraction refers to. Match on a shared
+    confirmation# first (stable across reschedules), then fall back to
+    same-metro + overlapping dates. Returns (index, prior) or None."""
+    ec = _conf_set(trip)
+    if ec:
+        for i, p in enumerate(priors):
+            if i not in used and (_conf_set(p) & ec):
+                return i, p
+    for i, p in enumerate(priors):
+        if i not in used and _date_overlap(trip, p):
+            return i, p
+    return None
+
+
+def merge(extracted: list[dict], prior: dict) -> tuple[dict, list, list]:
+    priors = prior.get("trips", [])
+    used: set = set()
+    merged: list[dict] = []
+    new_trips: list[str] = []
+    changes: list[str] = []
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    for trip in extracted:
+        m = _match_prior(trip, priors, used)
+        if m is None:
+            trip["trip_id"] = _trip_id(trip)
+            trip["first_seen"] = today
+            new_trips.append(trip["trip_id"])
+        else:
+            i, old = m
+            used.add(i)
+            # reuse the prior trip_id so a reschedule (date shift) does NOT mint
+            # a phantom "new trip"
+            trip["trip_id"] = old.get("trip_id") or _trip_id(old)
+            trip["first_seen"] = old.get("first_seen", today)
+            old_segs = {_seg_key(s): s for s in old.get("segments", [])}
+            new_segs = {_seg_key(s): s for s in trip.get("segments", [])}
+            tid = trip["trip_id"]
+            for k, s in new_segs.items():
+                if k not in old_segs:
+                    changes.append(f"{tid}: new segment {s.get('type')} {s.get('from','')}→{s.get('to','')}")
+                elif s.get("status") and s.get("status") != old_segs[k].get("status"):
+                    changes.append(f"{tid}: {s.get('type')} status {old_segs[k].get('status')}→{s.get('status')}")
+            # cancellation: a FUTURE prior segment that vanished from the new extraction
+            for k, s in old_segs.items():
+                if k not in new_segs and _is_future(s):
+                    changes.append(f"{tid}: {s.get('type')} {s.get('from','')}→{s.get('to','')} dropped — possible cancellation (verify)")
+        trip["last_seen"] = today
+        merged.append(trip)
+
+    # Carry forward prior trips this scan didn't re-surface but that are still
+    # upcoming — the Gmail query window may simply not have re-matched an older
+    # confirmation. Dropping them would lose real trips; only the agent removing
+    # a cancelled trip should delete one.
+    for i, p in enumerate(priors):
+        if i not in used and (p.get("end") or p.get("start") or "")[:10] >= today:
+            merged.append(p)
+
+    # Stamp deterministic per-segment uids (the calendar-sync dedup key) on
+    # every trip — matched, new, and carried-forward alike.
+    for t in merged:
+        tid = t.get("trip_id") or _trip_id(t)
+        for s in t.get("segments", []):
+            s["uid"] = _seg_uid(tid, s)
+
+    out = {"last_scan": datetime.now(timezone.utc).isoformat(),
+           "trips": sorted(merged, key=lambda t: t.get("start", ""))}
+    return out, new_trips, changes
+
+
+def cmd_show() -> None:
+    d = _load(TRIPS)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    upcoming = [t for t in d.get("trips", []) if (t.get("end") or "")[:10] >= today]
+    if not upcoming:
+        print("No upcoming trips on record.")
+        return
+    for t in upcoming:
+        print(f"- {t.get('destination')} {t.get('start','?')[:10]}–{t.get('end','?')[:10]} "
+              f"({t.get('purpose','?')}) — {len(t.get('segments', []))} segment(s)")
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    if not args or args[0] == "--show":
+        cmd_show()
+        return
+    extracted = json.loads(Path(args[0]).read_text())
+    if isinstance(extracted, dict):
+        extracted = extracted.get("trips", [])
+    prior = _load(TRIPS)
+    STATE.mkdir(parents=True, exist_ok=True)
+    HISTORY.mkdir(parents=True, exist_ok=True)
+    if TRIPS.exists():
+        snap = HISTORY / f"{datetime.now(timezone.utc).strftime('%Y-%m-%d')}.json"
+        if not snap.exists():
+            snap.write_text(TRIPS.read_text())
+    out, new_trips, changes = merge(extracted, prior)
+    TRIPS.write_text(json.dumps(out, indent=2, ensure_ascii=False) + "\n")
+    print(f"trips: {len(out['trips'])} | new: {len(new_trips)} | changes: {len(changes)}")
+    for tid in new_trips:
+        print(f"NEW_TRIP {tid}")
+    for c in changes:
+        print(f"CHANGE {c}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/trip-radar/scripts/build_trip_state.py
+++ b/skills/trip-radar/scripts/build_trip_state.py
@@ -77,12 +77,29 @@ def _seg_key(seg: dict) -> str:
     return f"{seg.get('type')}|{(seg.get('start') or '')[:10]}|{route}"
 
 
-def _seg_uid(trip_id: str, seg: dict) -> str:
-    """Deterministic, stable per-segment id used as the Google Calendar dedup
-    marker. Same segment → same uid across runs, so the calendar sync can match
-    an existing event structurally (by `[trip-radar:<uid>]` in its description)
-    instead of relying on fuzzy time/route matching."""
-    return "tr-" + _slug(trip_id) + "-" + _slug(_seg_key(seg))
+def _trip_anchor(trip: dict) -> str:
+    """A RESCHEDULE-STABLE trip identity for the calendar uid prefix.
+
+    NOT `trip_id`: `trip_id` embeds `trip.start` (`{slug(dest)}-{start[:10]}`),
+    so if the first segment is rescheduled to another day `trip.start` shifts →
+    `trip_id` changes → every segment uid changes → the `[trip-radar:<uid>]`
+    markers stop matching the existing calendar events → the sync creates
+    DUPLICATES instead of correcting in place (the whole point of the marker is
+    reschedule-stability). Anchor on the lexically-smallest confirmation# across
+    the trip's segments (stable when a date moves), falling back to the
+    destination slug when no conf# exists.
+    """
+    confs = sorted(_conf_set(trip))  # _conf_set upper-cases; stable across date shifts
+    return confs[0].lower() if confs else _slug(trip.get("destination"))
+
+
+def _seg_uid(trip: dict, seg: dict) -> str:
+    """Deterministic, reschedule-stable per-segment id used as the Google
+    Calendar dedup marker. Same segment → same uid across runs (and across
+    date reschedules), so the calendar sync matches an existing event
+    structurally (by `[trip-radar:<uid>]` in its description) instead of fuzzy
+    time/route matching."""
+    return "tr-" + _slug(_trip_anchor(trip)) + "-" + _slug(_seg_key(seg))
 
 
 def _slug(s: str) -> str:
@@ -176,9 +193,8 @@ def merge(extracted: list[dict], prior: dict) -> tuple[dict, list, list]:
     # Stamp deterministic per-segment uids (the calendar-sync dedup key) on
     # every trip — matched, new, and carried-forward alike.
     for t in merged:
-        tid = t.get("trip_id") or _trip_id(t)
         for s in t.get("segments", []):
-            s["uid"] = _seg_uid(tid, s)
+            s["uid"] = _seg_uid(t, s)
 
     out = {"last_scan": datetime.now(timezone.utc).isoformat(),
            "trips": sorted(merged, key=lambda t: t.get("start", ""))}

--- a/skills/trip-radar/state/travel-preferences.example.json
+++ b/skills/trip-radar/state/travel-preferences.example.json
@@ -1,0 +1,27 @@
+{
+  "last_pref_refresh": "2026-06-01",
+  "lodging": {
+    "preferred_chains": ["Four Seasons", "Park Hyatt", "Hyatt"],
+    "loyalty": [{"program": "World of Hyatt", "tier": "Globalist", "confidence": "high"}],
+    "area_pattern": "central/walkable, near client offices or waterfront",
+    "price_tier": "luxury",
+    "must_have": ["gym", "lounge access"],
+    "confidence": "high"
+  },
+  "dining": {
+    "cuisines": ["Japanese/sushi", "regional Italian", "modern Indian"],
+    "price_level": "$$$-$$$$",
+    "vibe": "chef-driven, reservations; occasional great hole-in-the-wall",
+    "dietary": [],
+    "confidence": "medium"
+  },
+  "activities": {
+    "profile": ["photography/landscape", "aviation", "fine dining", "occasional museums"],
+    "pace": "relaxed-with-1-marquee-thing-per-day"
+  },
+  "logistics": {
+    "airlines": ["United (1K)", "ANA"],
+    "seat": "aisle, exit row or business",
+    "rental_car": ["Hertz"]
+  }
+}

--- a/skills/trip-radar/state/trips.example.json
+++ b/skills/trip-radar/state/trips.example.json
@@ -1,0 +1,93 @@
+{
+  "last_scan": "2026-06-01T17:40:00+00:00",
+  "trips": [
+    {
+      "trip_id": "new-york-2026-06-12",
+      "destination": "New York, NY",
+      "start": "2026-06-12T08:30:00-07:00",
+      "end": "2026-06-15T18:00:00-04:00",
+      "purpose": "business",
+      "first_seen": "2026-06-01",
+      "last_seen": "2026-06-01",
+      "segments": [
+        {
+          "type": "flight",
+          "provider": "United",
+          "confirmation": "ABC123",
+          "start": "2026-06-12T08:30:00-07:00",
+          "end": "2026-06-12T17:05:00-04:00",
+          "from": "SFO",
+          "to": "JFK",
+          "price": 612.0,
+          "status": "confirmed"
+        },
+        {
+          "type": "flight",
+          "provider": "United",
+          "confirmation": "ABC123",
+          "start": "2026-06-15T18:00:00-04:00",
+          "end": "2026-06-15T21:20:00-07:00",
+          "from": "JFK",
+          "to": "SFO",
+          "price": null,
+          "status": "confirmed"
+        }
+      ],
+      "suggestions": {
+        "hotels": [
+          {
+            "name": "Park Hyatt New York",
+            "url": "https://www.hyatt.com/park-hyatt/nycph",
+            "area": "Midtown (57th St)",
+            "price": "$$$$",
+            "why": "your Hyatt-Globalist chain; walkable to Midtown offices"
+          },
+          {
+            "name": "The Greenwich Hotel",
+            "url": "https://www.thegreenwichhotel.com",
+            "area": "TriBeCa",
+            "price": "$$$$",
+            "why": "quiet, design-forward, near downtown dinners"
+          },
+          {
+            "name": "Hyatt Times Square",
+            "url": "https://www.hyatt.com",
+            "area": "Times Square",
+            "price": "$$$",
+            "why": "points-friendly fallback in your loyalty program"
+          }
+        ],
+        "restaurants": [
+          {
+            "name": "Sushi Noz",
+            "url": "https://www.sushinoz.com",
+            "area": "Upper East Side",
+            "cuisine": "Edomae sushi",
+            "why": "matches your sushi lean; haven't been"
+          },
+          {
+            "name": "Rezdôra",
+            "url": "https://www.rezdora.nyc",
+            "area": "Flatiron",
+            "cuisine": "Emilia-Romagna pasta",
+            "why": "regional Italian, chef-driven"
+          },
+          {
+            "name": "Semma",
+            "url": "https://www.semma.nyc",
+            "area": "West Village",
+            "cuisine": "South Indian",
+            "why": "modern Indian, Michelin"
+          }
+        ],
+        "activities": [
+          {
+            "name": "ICP photography exhibitions",
+            "url": "https://www.icp.org",
+            "why": "fits your photography interest; 1 marquee thing"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

`trip-radar` is a self-contained skill that turns the user's own travel mail into a proactive trip assistant:

1. **Itinerary sync** — parses flight/hotel/car/train/Airbnb confirmations (incl. archived + travel-label mail) into `state/trips.json`, grouped into trips with dated segments; diffs against the prior scan to surface new trips and changes (delays, seat/gate, cancellations).
2. **Preference model** — mines past lodging/dining from Gmail to learn brand/area/tier/cuisine prefs (conservative; never fabricates loyalty numbers).
3. **Concierge** — for each new trip, suggests hotels/restaurants/activities matched to history (favoring places not yet visited), with links.
4. **Calendar sync** — cross-checks each segment against Google Calendar and adds/corrects events **timezone-correctly** (explicit IANA `timeZone` per segment offset — Gmail's auto-add mislabels TZs / drops legs). **Idempotent by construction**: `build_trip_state.py` stamps a deterministic per-segment `uid`; synced events carry a hidden `[trip-radar:<uid>]` marker; sync matches by marker first (flight#+date fallback to adopt existing auto-events), so re-runs are no-ops.
5. **Per-trip corpus** — ingest PDFs/docs (e.g. PDF-only e-tickets the Gmail tools can't read) into a per-trip corpus via the Read tool; chat about a trip using its record + corpus.

## Design

Follows the established **'the scan IS the prompt'** pattern (morning-briefing, subscription-scanner): Gmail/Calendar/Drive live at the agent layer, light state on disk, `scripts/build_trip_state.py` is a thin py39-safe merge/diff/dedup helper. The skill is **agent-driven and works with no web UI**; an optional host dashboard can expose chat / ingest / calendar-sync as buttons (this repo's `src/web-client.ts` wires `/trips*`), but that integration is intentionally out of scope here.

## Files
- `SKILL.md`, `scan-prompt.md` (verbatim procedure)
- `scripts/build_trip_state.py` (+ idempotency uid stamping)
- `state/*.example.json`, `.gitignore` (runtime state/corpus/history are gitignored)

State files are examples only; no personal data included.