### PR TITLE
feat(skill): add parcel-radar — inbound parcel tracker (carriers + e-commerce stores)

### DIFF
--- a/skills/parcel-radar/.gitignore
+++ b/skills/parcel-radar/.gitignore
@@ -1,0 +1,3 @@
+# Personal runtime state — never commit (parcel/merchant/tracking data)
+state/parcels.json
+state/history/

--- a/skills/parcel-radar/SKILL.md
+++ b/skills/parcel-radar/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: parcel-radar
+description: "Tracks inbound parcels by scanning Gmail for shipment/tracking emails from delivery carriers (UPS/FedEx/USPS/DHL/OnTrac/…) AND from e-commerce stores (Shopify shops, Best Buy, Target, Apple, etc.), so you see every package in transit — its merchant origin, carrier, tracking link, status, and ETA — on one page. Excludes Amazon (covered by the amazon-orders skill). Fires out-for-delivery / delivered / exception alerts."
+user-invocable: true
+---
+
+# Parcel Radar
+
+Turns shipping-notification clutter into one live board of every package headed to you: **what** it is, **who** it's from, **which carrier**, a **1-click tracking link**, current **status**, and **ETA** — in one place (optionally surfaced on a web dashboard; see below).
+
+**Usage**: `/parcel-radar` (on-demand: scan + show parcels in transit and recently delivered)
+
+## What it does
+
+Agent-driven Gmail scan (Gmail MCP at the agent layer — same "the scan IS the prompt" pattern as amazon-orders / trip-radar). Two complementary email sources are merged:
+
+1. **Carrier emails** (UPS/FedEx/USPS/DHL/OnTrac/…) — authoritative *status* + tracking number, but often opaque about *what* the parcel is.
+2. **E-commerce store shipment confirmations** ("your order has shipped", "on its way") — give the *merchant origin* + *item* + usually the carrier + tracking number.
+
+Matching the two by **tracking number** yields a full picture: merchant + item (from the store) and live status + ETA (from the carrier). **Amazon is intentionally excluded** — it has its own `amazon-orders` skill.
+
+## Files
+
+- `scan-prompt.md` — verbatim prompt the agent runs each scan
+- `state/parcels.json` — current parcel list (gitignored — personal)
+- `state/history/<YYYY-MM-DD>.json` — prior-scan snapshots, for diffing (gitignored)
+
+## Schema (`state/parcels.json`)
+
+```json
+{
+  "last_scan": "ISO8601 timestamp",
+  "since": "newer_than:90d window",
+  "parcels": [
+    {
+      "id": "stable hash of tracking# (or merchant+item+shipped_date when no tracking#)",
+      "merchant": "Best Buy",
+      "item": "Sony WH-1000XM5 headphones",
+      "carrier": "ups|fedex|usps|dhl|ontrac|lasership|other",
+      "tracking": "1Z999AA10123456784",
+      "tracking_url": "https://www.ups.com/track?tracknum=1Z999AA10123456784",
+      "status": "ordered|shipped|in_transit|out_for_delivery|delivered|exception",
+      "shipped_date": "YYYY-MM-DD or null",
+      "est_delivery": "YYYY-MM-DD or null",
+      "delivered_date": "YYYY-MM-DD or null",
+      "last_update": "YYYY-MM-DD",
+      "notes": "optional (e.g. 'delivery exception — address issue')"
+    }
+  ],
+  "scan_history": [
+    { "date": "ISO8601", "total": 0, "in_transit": 0, "delivered": 0, "added": [], "delivered_since_last": [], "exceptions": [] }
+  ]
+}
+```
+
+## Triggers
+
+- **Cron**: every 6h at minute :19 — see `skills/schedule-crons/crons.json` entry `parcel-radar-scan`. Deliver only on new parcel / out-for-delivery / delivered / exception.
+- **On-demand**: `/parcel-radar` → scan + show the board.
+- **Voice/chat**: "what's arriving today?", "where's my package from Best Buy?", "anything out for delivery?" → read `state/parcels.json`.
+
+## Agent actions
+
+The skill is agent-driven and works with no web UI:
+- **Scan** — run `scan-prompt.md` (on demand, via `/parcel-radar`, or the cron) to refresh `state/parcels.json`.
+- **Query** — answer "what's arriving today / out for delivery / from <merchant>?" by reading `state/parcels.json`.
+- **Mark delivered (manual)** — when the user knows a parcel arrived but the carrier never sent a final update, set that parcel's `status: "delivered"`, `delivered_date` to today's local date, and `delivery_source: "manual"` (so manual marks are distinguishable from carrier-confirmed ones).
+
+## Optional web dashboard
+
+If the host ships a web UI, it can render `state/parcels.json` as a sortable board (in transit on top, delivered below) with merchant, carrier badge, clickable tracking link, status, and ETA. In this repo, `src/web-client.ts` serves `/parcels`, a localhost-gated **"Scan now"** button (`/parcels/scan` → queues the scan task), and a localhost-gated **"delivered?"** checkbox (`/parcels/mark-delivered` → the manual-mark action above). None of this is required — the dashboard is a convenience layer over the same state file + agent actions.
+
+## Privacy
+
+All parsing is local (Gmail MCP on the user's own account). `state/` is gitignored — parcel/merchant/tracking data lives only on this machine. No third-party package-tracking aggregator is involved.

--- a/skills/parcel-radar/scan-prompt.md
+++ b/skills/parcel-radar/scan-prompt.md
@@ -1,0 +1,76 @@
+# Parcel Radar — scan-prompt (follow verbatim)
+
+Update `skills/parcel-radar/state/parcels.json` with every inbound parcel currently in transit or recently delivered, scanned from the user's Gmail. **Exclude Amazon** — it's covered by the `amazon-orders` skill (skip `*@amazon.com` shipment mail).
+
+Workspace paths resolve under `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}` — write state to the skill's `state/` dir; deliver via `results/`.
+
+## Scan window
+
+Parcels are short-lived; scan `newer_than:90d` and decide "in transit vs delivered" from the email content, not the email age. Search ALL mail (`in:anywhere`) — shipment notices are often auto-archived or filed into labels.
+
+## Phase 1 — carrier emails (authoritative status + tracking #)
+
+Run these Gmail queries (paginate; add ` in:anywhere`):
+
+```
+from:(ups.com OR mcinfo.ups.com OR fedex.com OR usps.com OR email.informeddelivery.usps.com OR dhl.com OR mydhl.dhl.com OR ontrac.com OR lasership.com OR veho.com) subject:(shipment OR tracking OR delivery OR "on its way" OR "out for delivery" OR delivered OR package OR arriving) in:anywhere newer_than:90d
+```
+
+From each, extract: **carrier**, **tracking number**, **status** (shipped / in_transit / out_for_delivery / delivered / exception), **est_delivery** date, **last_update** date. Read the body via `get_thread` when the subject is truncated. A "delivery exception / action needed / address issue" → `status: "exception"` + a one-line `notes`.
+
+Build `tracking_url` from the carrier + tracking number:
+- UPS → `https://www.ups.com/track?tracknum=<T>`
+- FedEx → `https://www.fedex.com/fedextrack/?trknbr=<T>`
+- USPS → `https://tools.usps.com/go/TrackConfirmAction?tLabels=<T>`
+- DHL → `https://www.dhl.com/us-en/home/tracking.html?tracking-id=<T>`
+- OnTrac → `https://www.ontrac.com/tracking?number=<T>`
+- LaserShip/Veho/other → best-known tracking URL, else leave `tracking_url: null`.
+
+Infer carrier from tracking-number shape when the sender is ambiguous: UPS `1Z…` (18 char); USPS 20–22 digits or `9400…`/`9205…`; FedEx 12/15/20 digits; DHL 10–11 digits.
+
+## Phase 2 — e-commerce store shipment confirmations (merchant origin + item)
+
+These tell you WHAT shipped and from WHOM (the carrier email often doesn't). Run:
+
+```
+subject:("your order has shipped" OR "has shipped" OR "on its way" OR "order is on the way" OR "shipment confirmation" OR "tracking number" OR "out for delivery" OR shipped) -from:amazon.com in:anywhere newer_than:90d
+from:(shopifyemail.com OR bestbuy.com OR target.com OR walmart.com OR apple.com OR nike.com OR etsy.com OR ebay.com OR chewy.com OR rei.com OR newegg.com OR bhphotovideo.com OR uniqlo.com OR wayfair.com) subject:(shipped OR shipment OR "on its way" OR tracking OR "out for delivery" OR delivered) in:anywhere newer_than:90d
+```
+
+From each store email extract: **merchant** (brand from sender domain or email branding — e.g. `bestbuy.com` → "Best Buy"; Shopify shops use the shop's name in the From display), **item** (product name from subject/body — truncate to a readable phrase), and any **carrier + tracking number** present. Skip Amazon.
+
+**Reject promo/false-positive mail.** Subject keywords like "shipped" appear in marketing too. Only create a parcel from a store email if it contains a concrete shipment signal — a **tracking number**, OR an explicit per-order "your order #… has shipped / is on its way / out for delivery" with an order id. Discard "sale ends", "free shipping", "ships free", newsletters, and pre-shipment order *confirmations* (no tracking, status still "ordered") — those are not in-transit parcels.
+
+## Merge the two sources
+
+- **Match by tracking number first**: if a Phase-2 store email and a Phase-1 carrier email share a tracking #, they're ONE parcel — combine (merchant + item from the store; status + ETA from the carrier).
+- A store email with a tracking # but no carrier email yet → a parcel at `shipped`/`in_transit` with merchant + item known.
+- A carrier email with no matching store email → a parcel with status known but `merchant`/`item` unknown (set `merchant: "(unknown)"`, best-effort `item`).
+- **Dedup id**: stable hash of the tracking number; when there's no tracking #, hash `merchant|item|shipped_date`.
+- **Status precedence** when multiple emails exist for one parcel: `delivered > out_for_delivery > in_transit > shipped > ordered`; `exception` overrides unless a later `delivered` exists.
+- **Carrier emails are authoritative for status/ETA.** When a carrier and a store email disagree, take status, `est_delivery`, and `last_update` from the carrier (it reflects the live network state); take `merchant` + `item` from the store. Never downgrade a carrier "out_for_delivery"/"delivered" to a store's older "shipped".
+
+## Diff vs previous scan
+
+Snapshot the prior `parcels.json` to `state/history/<previous-scan-date>.json` (skip if a snapshot from that date already exists). In the new `scan_history` entry compute:
+- `added`: parcels in this scan not in the previous one
+- `delivered_since_last`: parcels that moved to `delivered` since last run
+- `exceptions`: parcels now in `exception`
+
+## Update state
+
+Set `last_scan` to current ISO8601-with-timezone; write `parcels.json` (sorted: in-transit first by `est_delivery` asc, then delivered by `delivered_date` desc). Append the `scan_history` entry.
+
+## Notify
+
+If `added`, `delivered_since_last`, or `exceptions` is non-empty, write a brief Telegram notification to `results/proactive-parcel-radar-{epoch}.txt`:
+
+```
+📦 Parcels update:
++N inbound: <merchant — item (carrier, ETA)>
+🚚 N out for delivery: <merchant — item>
+✅ N delivered: <merchant — item>
+⚠️ N exception: <merchant — item — reason>
+```
+
+If nothing changed, stay silent.

--- a/skills/parcel-radar/scan-prompt.md
+++ b/skills/parcel-radar/scan-prompt.md
@@ -49,6 +49,7 @@ From each store email extract: **merchant** (brand from sender domain or email b
 - **Dedup id**: stable hash of the tracking number; when there's no tracking #, hash `merchant|item|shipped_date`.
 - **Status precedence** when multiple emails exist for one parcel: `delivered > out_for_delivery > in_transit > shipped > ordered`; `exception` overrides unless a later `delivered` exists.
 - **Carrier emails are authoritative for status/ETA.** When a carrier and a store email disagree, take status, `est_delivery`, and `last_update` from the carrier (it reflects the live network state); take `merchant` + `item` from the store. Never downgrade a carrier "out_for_delivery"/"delivered" to a store's older "shipped".
+- **Preserve manual marks.** Load the existing `parcels.json` first. If a parcel there has `delivery_source: "manual"`, keep its `delivered` status + `delivered_date` + `delivery_source` even though no carrier/store email confirms delivery — the user set it deliberately via the manual mark-delivered action. A scan must never revert a manually-delivered parcel back to "shipped"/"in_transit".
 
 ## Diff vs previous scan
 

--- a/skills/parcel-radar/scan-prompt.md
+++ b/skills/parcel-radar/scan-prompt.md
@@ -1,6 +1,6 @@
 # Parcel Radar — scan-prompt (follow verbatim)
 
-Update `skills/parcel-radar/state/parcels.json` with every inbound parcel currently in transit or recently delivered, scanned from the user's Gmail. **Exclude Amazon** — it's covered by the `amazon-orders` skill (skip `*@amazon.com` shipment mail).
+Update `skills/parcel-radar/state/parcels.json` with every inbound parcel currently in transit or recently delivered, scanned from the user's Gmail. **Exclude Amazon** — it's covered by the `amazon-orders` skill. Skip ALL Amazon senders, not just `.com`: `*@amazon.*` (amazon.com / amazon.co.uk / amazon.ca / …) plus Amazon Logistics / "shipped by Amazon" notices — the query uses `-from:amazon.` (dot) so regional TLDs don't slip through and double-count against amazon-orders.
 
 Workspace paths resolve under `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}` — write state to the skill's `state/` dir; deliver via `results/`.
 
@@ -26,14 +26,14 @@ Build `tracking_url` from the carrier + tracking number:
 - OnTrac → `https://www.ontrac.com/tracking?number=<T>`
 - LaserShip/Veho/other → best-known tracking URL, else leave `tracking_url: null`.
 
-Infer carrier from tracking-number shape when the sender is ambiguous: UPS `1Z…` (18 char); USPS 20–22 digits or `9400…`/`9205…`; FedEx 12/15/20 digits; DHL 10–11 digits.
+Infer carrier from tracking-number shape when the sender is ambiguous: UPS `1Z…` (18 char); USPS 20–22 digits or `9400…`/`9205…`; FedEx 12/15/20 digits; DHL 10–11 digits. This shape heuristic is **best-effort** — USPS/FedEx/DHL digit-only formats overlap, so when only a bare number is present the `carrier` (and thus `tracking_url`) may be wrong; prefer the sending carrier's identity when known, and treat a shape-only guess as tentative (a wrong guess just yields a dead `tracking_url`, not bad status).
 
 ## Phase 2 — e-commerce store shipment confirmations (merchant origin + item)
 
 These tell you WHAT shipped and from WHOM (the carrier email often doesn't). Run:
 
 ```
-subject:("your order has shipped" OR "has shipped" OR "on its way" OR "order is on the way" OR "shipment confirmation" OR "tracking number" OR "out for delivery" OR shipped) -from:amazon.com in:anywhere newer_than:90d
+subject:("your order has shipped" OR "has shipped" OR "on its way" OR "order is on the way" OR "shipment confirmation" OR "tracking number" OR "out for delivery" OR shipped) -from:amazon. in:anywhere newer_than:90d
 from:(shopifyemail.com OR bestbuy.com OR target.com OR walmart.com OR apple.com OR nike.com OR etsy.com OR ebay.com OR chewy.com OR rei.com OR newegg.com OR bhphotovideo.com OR uniqlo.com OR wayfair.com) subject:(shipped OR shipment OR "on its way" OR tracking OR "out for delivery" OR delivered) in:anywhere newer_than:90d
 ```
 
@@ -43,7 +43,7 @@ From each store email extract: **merchant** (brand from sender domain or email b
 
 ## Merge the two sources
 
-- **Match by tracking number first**: if a Phase-2 store email and a Phase-1 carrier email share a tracking #, they're ONE parcel — combine (merchant + item from the store; status + ETA from the carrier).
+- **Match by tracking number first** — but NORMALIZE before comparing. Store and carrier emails render the same tracking # differently (spaces, dashes, leading-zero handling — e.g. store `1Z 999 AA1 01 2345 6784` vs carrier `1Z999AA10123456784`). Canonicalize both sides (strip all non-alphanumerics, uppercase) before the join, else a real pair silently splits into two parcels. Store the canonical form in `tracking`. If a Phase-2 store email and a Phase-1 carrier email share the canonical tracking #, they're ONE parcel — combine (merchant + item from the store; status + ETA from the carrier).
 - A store email with a tracking # but no carrier email yet → a parcel at `shipped`/`in_transit` with merchant + item known.
 - A carrier email with no matching store email → a parcel with status known but `merchant`/`item` unknown (set `merchant: "(unknown)"`, best-effort `item`).
 - **Dedup id**: stable hash of the tracking number; when there's no tracking #, hash `merchant|item|shipped_date`.
@@ -60,7 +60,7 @@ Snapshot the prior `parcels.json` to `state/history/<previous-scan-date>.json` (
 
 ## Update state
 
-Set `last_scan` to current ISO8601-with-timezone; write `parcels.json` (sorted: in-transit first by `est_delivery` asc, then delivered by `delivered_date` desc). Append the `scan_history` entry.
+Set `last_scan` to current ISO8601-with-timezone; write `parcels.json` (sorted: in-transit first by `est_delivery` asc, then delivered by `delivered_date` desc). Append the `scan_history` entry, then **cap `scan_history` to the last 30 entries** (trim oldest) so the file doesn't grow unbounded — the dated per-scan snapshots already live in `state/history/`.
 
 ## Notify
 

--- a/skills/parcel-radar/state/parcels.example.json
+++ b/skills/parcel-radar/state/parcels.example.json
@@ -1,0 +1,51 @@
+{
+  "last_scan": "2026-06-01T12:00:00-07:00",
+  "since": "newer_than:90d",
+  "parcels": [
+    {
+      "id": "ups-1z999aa10123456784",
+      "merchant": "Best Buy",
+      "item": "Sony WH-1000XM5 headphones",
+      "carrier": "ups",
+      "tracking": "1Z999AA10123456784",
+      "tracking_url": "https://www.ups.com/track?tracknum=1Z999AA10123456784",
+      "status": "out_for_delivery",
+      "shipped_date": "2026-05-29",
+      "est_delivery": "2026-06-01",
+      "delivered_date": null,
+      "last_update": "2026-06-01",
+      "notes": ""
+    },
+    {
+      "id": "usps-9400100000000000000000",
+      "merchant": "Etsy — NorthwoodCeramics",
+      "item": "Stoneware mug set",
+      "carrier": "usps",
+      "tracking": "9400100000000000000000",
+      "tracking_url": "https://tools.usps.com/go/TrackConfirmAction?tLabels=9400100000000000000000",
+      "status": "in_transit",
+      "shipped_date": "2026-05-30",
+      "est_delivery": "2026-06-03",
+      "delivered_date": null,
+      "last_update": "2026-05-31",
+      "notes": ""
+    },
+    {
+      "id": "fedex-770000000000",
+      "merchant": "REI",
+      "item": "Trekking poles",
+      "carrier": "fedex",
+      "tracking": "770000000000",
+      "tracking_url": "https://www.fedex.com/fedextrack/?trknbr=770000000000",
+      "status": "delivered",
+      "shipped_date": "2026-05-24",
+      "est_delivery": "2026-05-28",
+      "delivered_date": "2026-05-27",
+      "last_update": "2026-05-27",
+      "notes": ""
+    }
+  ],
+  "scan_history": [
+    { "date": "2026-06-01T12:00:00-07:00", "total": 3, "in_transit": 2, "delivered": 1, "added": ["Best Buy — Sony WH-1000XM5 headphones"], "delivered_since_last": ["REI — Trekking poles"], "exceptions": [] }
+  ]
+}


### PR DESCRIPTION
## What

`parcel-radar` turns shipping-notification clutter into one live board of every inbound package. It scans the user's own Gmail for:
1. **Delivery-carrier emails** (UPS/FedEx/USPS/DHL/OnTrac/…) — authoritative status + tracking #, but often opaque about *what* shipped.
2. **E-commerce store shipment confirmations** — give the *merchant origin* + *item* + usually the carrier + tracking #.

It **merges the two by tracking number** (store → merchant + item; carrier → authoritative status/ETA), dedupes, applies status precedence (delivered > out-for-delivery > in-transit > shipped), and tracks each parcel through delivery. **Amazon is intentionally excluded** — it has its own `amazon-orders` skill.

## Design

Follows the established **'the scan IS the prompt'** pattern (`amazon-orders`, `trip-radar`): Gmail lives at the agent layer, light state on disk (`state/parcels.json`), no heavy code. The skill is **self-contained and agent-driven** — scan, query ("what's arriving today / out for delivery / from <merchant>?"), and manual mark-delivered are all agent actions. An optional host web dashboard can render the state file, but is not required (that integration is out of scope here).

## Files
- `SKILL.md`, `scan-prompt.md` (verbatim scan procedure, incl. carrier-inference from tracking# shape, promo-mail rejection, carrier-authoritative status)
- `state/parcels.example.json`, `.gitignore` (runtime state/history gitignored)

No personal data — state files are examples only.