### PR TITLE
feat(workspace): M0 — in-repo workspace default + config-driven resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,9 +150,10 @@ PORT=9900
 # If not set, all webhook payloads are rejected (fail-closed).
 # GITHUB_WEBHOOK_SECRET=your-webhook-secret-here
 
-# sutando workspace — set when src/ is a symlink into a packaged app bundle,
-# so the bridges write tasks/results into the user workspace rather than
-# the bundle's copy of src/. Leave unset for a normal git-clone install.
+# sutando workspace — for a normal git-clone install you don't need this.
+# Workspace location is configured via sutando.config.local.json (see
+# docs/workspace-config.md). The env var is honored as a legacy escape
+# hatch only and emits a deprecation warning at startup.
 # SUTANDO_WORKSPACE=/path/to/workspace
 
 # Optional: WhatsApp via wacli (CLI — not used by Node startup, for the agent).

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Sutando pre-commit hook: refuse commits that include workspace/ contents.
+#
+# The in-repo workspace at `<repo>/workspace/` holds per-user runtime state
+# (tasks, results, notes, state, logs, etc.) that must NEVER be committed
+# to the shared repo. The .gitignore (workspace/* with !workspace/.gitkeep)
+# is the first line of defense; this hook is the second — it catches:
+#
+#   • git add -f workspace/foo.txt           (force-add bypasses .gitignore)
+#   • git add workspace/data.json            (explicit add of a "skip" path
+#                                              that gitignore would have skipped
+#                                              under `git add .` but not under
+#                                              an explicit pathspec)
+#   • IDEs / AI assistants that stage files without consulting .gitignore
+#
+# Installation (per-clone, one-time):
+#   git config core.hooksPath .githooks
+#
+# Or copy/symlink: ln -s ../../.githooks/pre-commit .git/hooks/pre-commit
+#
+# Escape hatch (for the rare case you really need to commit something under
+# workspace/ — e.g. updating .gitkeep itself, or shipping a doc):
+#   git commit --no-verify
+#
+# Whitelist (paths that ARE allowed to be committed under workspace/):
+#   • workspace/.gitkeep      — required so the directory ships on fresh clone
+#
+# Exit non-zero refuses the commit; exit 0 lets it through.
+
+set -euo pipefail
+
+# Staged paths added or modified in this commit. We check both A (added) and
+# M (modified) because a file could be added in an earlier commit and modified
+# in this one — still want to refuse if it's under workspace/.
+staged="$(git diff --cached --name-only --diff-filter=AM)"
+
+# Filter to paths under workspace/, then drop the allowed whitelist entries.
+# `|| true` so grep's exit-1-on-no-match doesn't kill the script under set -e.
+offenders="$(printf '%s\n' "$staged" \
+  | grep -E '^workspace/' \
+  | grep -vxF 'workspace/.gitkeep' \
+  || true)"
+
+if [[ -n "$offenders" ]]; then
+  printf '\n\033[31m✖ pre-commit refusing: workspace/ contents must not be committed.\033[0m\n\n'
+  printf 'The following staged paths live under workspace/, which holds per-user runtime\n'
+  printf 'state (tasks, results, notes, state, logs). Move them out of workspace/ before\n'
+  printf 'committing, or unstage them with: git reset HEAD <path>\n\n'
+  printf '%s\n' "$offenders" | sed 's/^/  /'
+  printf '\nIf you really need to commit this (e.g. updating workspace/.gitkeep itself),\n'
+  printf 'pass --no-verify to git commit. Use sparingly.\n\n'
+  exit 1
+fi
+
+exit 0

--- a/.github/workflows/lint-workspace-resolution.yml
+++ b/.github/workflows/lint-workspace-resolution.yml
@@ -1,0 +1,37 @@
+name: lint-workspace-resolution
+
+# CI lint: refuse PRs that introduce NEW direct workspace-path resolution.
+#
+# All workspace path resolution MUST go through `src/sutando_config.{py,ts}`
+# (or `src/workspace_default.{py,ts}` once they delegate to the loader).
+# This workflow runs `scripts/lint-workspace-resolution.sh --diff`, which
+# scans only ADDED lines in the PR — existing legacy offenders are not
+# flagged here. They get migrated as part of the M0 cutover (separate
+# commit on this branch) and tracked separately.
+#
+# Together with the local pre-commit hook + the workspace-leak-check CI
+# workflow, this forms a third defense layer specifically against the
+# "code that bypasses the loader" failure mode.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lint-workspace-resolution:
+    name: refuse new direct workspace-path resolution
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Checkout (with full history for base-ref diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run lint in --diff mode
+        env:
+          BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || 'HEAD~1' }}
+        run: bash scripts/lint-workspace-resolution.sh --diff

--- a/.github/workflows/workspace-leak-check.yml
+++ b/.github/workflows/workspace-leak-check.yml
@@ -1,0 +1,82 @@
+name: workspace-leak-check
+
+# CI mirror of `.githooks/pre-commit`. Refuses PRs that introduce files
+# under `workspace/` (with the single exception of `workspace/.gitkeep`).
+#
+# Purpose: per Milestone 0 of the workspace-revamp work, in-repo workspace/
+# holds per-user runtime state (tasks, results, notes, state, logs, etc.)
+# that must never be committed. The local pre-commit hook is the first line
+# of defense, but it only fires for users who ran `git config core.hooksPath
+# .githooks` after cloning. This workflow catches anyone who didn't, who
+# bypassed the hook with --no-verify, or who edited the PR via the GitHub
+# web UI.
+#
+# Scope is intentionally narrow for M0 — only workspace/. Future expansion
+# could add scans for accidentally-staged .env, hardcoded credentials, or
+# the sutando.config.local.json file (already in .gitignore but force-add
+# could slip it past).
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  workspace-leak-check:
+    name: refuse workspace/ contents in commits
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Checkout (with full history for base-ref diff)
+        uses: actions/checkout@v4
+        with:
+          # Need depth=0 (or at least enough to reach the base) so the diff
+          # below can compare HEAD against the PR base. Without this, a
+          # shallow clone makes `git diff origin/main...HEAD` fail to find
+          # a merge base on long-lived branches.
+          fetch-depth: 0
+
+      - name: Check for workspace/ leak
+        run: |
+          set -euo pipefail
+
+          # For pull_request: base is github.base_ref. For push to main:
+          # diff against the previous commit so a direct push that adds
+          # workspace/ still trips.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_ref="origin/${{ github.base_ref }}"
+            diff_args="$base_ref...HEAD"
+          else
+            base_ref="${{ github.event.before }}"
+            # First push to a branch has before=0000000... — fall back to
+            # the parent of HEAD in that case.
+            if [[ "$base_ref" =~ ^0+$ ]]; then
+              diff_args="HEAD~1...HEAD"
+            else
+              diff_args="$base_ref...HEAD"
+            fi
+          fi
+
+          # Added or modified paths in the PR diff. Same filter as the local
+          # pre-commit hook: anything under workspace/, except .gitkeep.
+          changed="$(git diff --name-only --diff-filter=AM $diff_args)"
+          offenders="$(printf '%s\n' "$changed" \
+            | grep -E '^workspace/' \
+            | grep -vxF 'workspace/.gitkeep' \
+            || true)"
+
+          if [[ -n "$offenders" ]]; then
+            echo "::error::workspace/ contents detected — these files must not be committed:"
+            printf '%s\n' "$offenders" | sed 's/^/  • /'
+            echo ""
+            echo "workspace/ holds per-user runtime state (tasks, results, notes, state, logs)"
+            echo "and is gitignored. Remove these files from the PR or move them outside workspace/."
+            echo ""
+            echo "If you cloned recently, install the local pre-commit hook to catch this earlier:"
+            echo "  git config core.hooksPath .githooks"
+            exit 1
+          fi
+
+          echo "✓ No workspace/ leaks in this diff."

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,16 @@ voice-state.json
 
 # Single-instance lock written by src/voice-agent.ts (acquirePidLock).
 .voice-agent.pid
+
+# Per-clone Sutando config overrides — workspace path, vault remote, etc.
+# Tracked defaults live in sutando.config.json; .local.json carries the
+# machine-specific overrides (different workspace location, different vault
+# remote per host) and must never be committed.
+sutando.config.local.json
+
+# In-repo workspace (M0 default). Everything user-runtime — tasks/, results/,
+# state/, notes/, build_log.md, etc. — lives under workspace/ and must never
+# be committed. .gitkeep is the exception so the directory ships in fresh
+# clones for a zero-config first run.
+workspace/*
+!workspace/.gitkeep

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Sutando
 
-You are operating as part of Sutando — a personal AI agent that belongs entirely to the user. This is the Sutando implementation workspace.
+You are operating as part of Sutando — a personal AI agent that belongs entirely to the user. This is the Sutando implementation overview.
 
 ## Identity
 
@@ -45,7 +45,6 @@ Read `CONTRIBUTING.md` and follow its "Before opening any PR or issue" section. 
 - Confirm your git author email is GH-mapped — not `*.local` (macOS hostname auto-fill) or `noreply@anthropic.com` (Claude Code default). CLA-Assistant silently leaves the check PENDING on unmappable emails.
 - Single concern per PR; no bundled refactors
 - Confirm the bug exists on `upstream/main` before adding a fix
-- Respect the V1-workspace hold list (`workspace_default.{py,ts}`, `sync-memory.sh`, `claude_home_path`, `agent-registry` paths)
 - After `update-branch`, CLA-Assistant may not auto-rerun — try `@cla-assistant check` comment or close+reopen if stuck
 
 Skill-PR destination: a skill is **coupled** (PR to `sonichi/sutando`) if it imports from `src/` or another skill, modifies main-repo files, or is tightly bound to a feature there (e.g. `skills/phone-conversation/`). A skill is **standalone** (PR to `sonichi/sutando-skills`) if it ships its own scripts/binaries, reads files but doesn't import main-repo modules, and works against any checkout. If unsure, ask in #design.
@@ -58,19 +57,15 @@ All per-user mutable state — `tasks/`, `results/`, `state/`, `data/`, `logs/`,
 
 **Resolution (every service reads the same):**
 
-1. `$SUTANDO_WORKSPACE` env var (override; `~` is expanded).
-2. `~/.sutando/workspace/` (default).
-
-The default deliberately avoids `~/Library/Application Support/sutando/` — that path is Sutando.app's territory (Chromium-style Cache/, GPUCache/, Cookies/, blob_storage/, etc.); the user-task workspace lives under its own hidden home-relative dir so the two concerns never collide. Historic anti-pattern: bridges fell back to the script's repo root via `Path(__file__).resolve().parent.parent`, which polluted `git status` and — when invoked from an app-bundled `src/` symlink — stranded owner DMs in a bundle-tasks/ dir while the watcher polled workspace-tasks/.
+**Default:** the workspace lives at `<repo>/workspace/` (in-repo). To override, edit `sutando.config.local.json` (per-clone, gitignored) — see [`docs/workspace-config.md`](docs/workspace-config.md). The `$SUTANDO_WORKSPACE` env var is honored as a legacy escape hatch with a one-time deprecation warning. Historic anti-pattern: bridges fell back to the script's repo root via `Path(__file__).resolve().parent.parent`, which polluted `git status` and — when invoked from an app-bundled `src/` symlink — stranded owner DMs in a bundle-tasks/ dir while the watcher polled workspace-tasks/.
 
 **Use the helper, don't reinvent the fallback:**
 - Python: `from workspace_default import resolve_workspace` → returns a `Path`.
 - TypeScript: `import { resolveWorkspace } from './workspace_default.js'` → returns a `string` (added in #821).
 - Swift: `AppDelegate.workspace` property in `src/Sutando/main.swift` (added in #837 — split alongside `repoRoot` for code-adjacent paths).
 
-Separately, `SUTANDO_REPO_DIR` (added in #831 cleanup) names the public-repo checkout for scripts like `sync-memory.sh` and `session-handoff.sh` that need the source tree. Do NOT conflate with `SUTANDO_WORKSPACE` — they live in different dirs (`~/Desktop/sutando` vs `~/.sutando/workspace/`).
+For full details on resolution order, overrides, and the protection layers (pre-commit hook + CI), see [`docs/workspace-config.md`](docs/workspace-config.md).
 
-For existing-repo migration + the stop-gap env, and the orphan-symlink cleanup (post-#835): see [`docs/workspace-contract.md`](docs/workspace-contract.md).
 
 ## Personal overrides
 
@@ -78,10 +73,10 @@ If `PERSONAL_CLAUDE.md` exists in the workspace root, read and follow it. It con
 
 ## Work Status
 
-Signal your work status to the workspace `core-status.json` so the web UI and `health-check.py` can display it. Write the **absolute** workspace path: the session cwd is the repo, so a bare `state/core-status.json` lands in `<repo>/state/` — where no reader looks. Readers resolve `<workspace>/state/core-status.json` via `status_read_path` (`src/workspace_default.py`).
+Signal your work status to the workspace `core-status.json` so the web UI and `health-check.py` can display it. Write the **absolute** workspace path: the session cwd is the repo, so a bare `state/core-status.json` lands in `<repo>/state/` — where no reader looks. Readers resolve `$SUTANDO_WORKSPACE/state/core-status.json` via `status_read_path` (`src/workspace_default.py`).
 
 ```bash
-CORE_STATUS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/state/core-status.json"
+CORE_STATUS="$(bash scripts/sutando-config.sh workspace)/state/core-status.json"
 echo '{"status":"running","step":"<description>","ts":<epoch>}' > "$CORE_STATUS"   # start of significant work
 echo '{"status":"idle","ts":<epoch>}' > "$CORE_STATUS"                            # when done
 ```
@@ -125,7 +120,7 @@ This ensures the dashboard, result-watcher, and timeout logic work the same rega
 
 ## Core liveness signal
 
-Each running sutando-core writes `<workspace>/state/cores/<hostname>.alive`
+Each running sutando-core writes `$SUTANDO_WORKSPACE/state/cores/<hostname>.alive`
 every 30 seconds (started by `src/startup.sh` as a background process; source
 at `src/core_heartbeat.py`). The file is per-host so multiple cores on
 different machines coexist; mtime is the cross-host "is this core alive?"
@@ -201,7 +196,7 @@ When you need user input on a decision or are blocked:
 
 On each proactive loop pass, check `pending-questions.md` for unanswered items and surface them when the user is available.
 
-## Workspace layout
+## Project layout
 
 - Vision + docs: `README.md` (this directory)
 - Voice agent: `src/voice-agent.ts`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ bash src/startup.sh
 1. **What happened** — describe the issue clearly
 2. **Steps to reproduce** — numbered steps someone else can follow
 3. **Expected behavior** — what should have happened
-4. **Logs** — paste relevant lines from `$SUTANDO_WORKSPACE/logs/*.log` (defaults to `~/.sutando/workspace/logs/`; the old `<repo>/logs/` path was moved to the workspace per the workspace contract — `src/startup.sh` now writes to `$WORKSPACE/logs/`)
+4. **Logs** — paste relevant lines from `<repo>/workspace/logs/*.log` (the default in-repo workspace; see [`docs/workspace-config.md`](docs/workspace-config.md) for overrides)
 5. **Environment** — macOS version, Node.js version, Claude Code version
 
 **Bonus (highly valued):**

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,14 +1,14 @@
 # Known Issues
 
-## Workspace contract migration in progress
+## Workspace contract — Milestone 0 (in-repo default)
 
-The 3-space workspace contract (Code / Workspace / Memory — see [`docs/workspace-design.md`](docs/workspace-design.md)) is in the middle of a transition. Some existing scripts and skills still write per-user state into the repo (`<repo>/tasks/`, `<repo>/results/`, `<repo>/state/`, `<repo>/logs/`, `<repo>/data/`, etc.) instead of `$SUTANDO_WORKSPACE/`.
+The workspace now defaults to `<repo>/workspace/` (in-repo). Configuration goes through [`sutando.config.local.json`](docs/workspace-config.md) — the loader resolves the path with a clear precedence order (config file > legacy env var > baked-in default).
 
-**Effect for users**: depending on how a script was invoked, runtime state may end up in either location. On a workspace-pinned install, state written to the repo path is invisible to readers that look in `$SUTANDO_WORKSPACE`. Symptoms include sentinels that never trigger, scans that miss live data, or reply-context that doesn't reach the bot.
+**For existing users** with `SUTANDO_WORKSPACE` set in `.env` or shell init: the env var is still honored, and you'll see a one-time deprecation warning at startup pointing you at the config file. No action required for now; migrate when convenient.
 
-**Status**: A migration CLI (`scripts/sutando-migrate.sh`) is queued in PR #1271 to move existing repo-anchored state into the workspace. Per-site fixes for individual scripts are tracked in PRs #1272–#1334 (filed but held in draft until the V1 contract is finalized). The path-resolution audit (`workspace-contract-audit` skill) catches new violations at PR time.
+**For users with state in the old default location** (`~/.sutando/workspace/`): the upcoming Milestone 1 recovery skill (`bash scripts/sutando-migrate.sh`) will help you audit and move existing runtime data into the in-repo workspace.
 
-If you hit a path-resolution oddity, check whether your script is reading from the repo vs `$SUTANDO_WORKSPACE` and report the file/line in an issue.
+If you hit a path-resolution oddity, check the resolved workspace via `bash scripts/sutando-config.sh workspace` and report the file/line in an issue.
 
 ## Task status flickers in web UI after API restart
 

--- a/docs/memory-sync.md
+++ b/docs/memory-sync.md
@@ -62,7 +62,7 @@ The script self-heals if the local sync clone gets stuck on a non-`main` branch.
 | Variable | Default | Notes |
 |---|---|---|
 | `SUTANDO_MEMORY_REPO` | (required) | git URL of your private memory repo |
-| `SUTANDO_WORKSPACE` | `~/Desktop/sutando` | path to your sutando working tree |
+| `SUTANDO_WORKSPACE` | `<repo>/workspace/` (M0 default) | path to your workspace; legacy escape hatch — prefer `sutando.config.local.json` (see [`workspace-config.md`](workspace-config.md)) |
 | `SUTANDO_MEMORY_SYNC_DIR` | `~/.sutando/memory-sync` | local clone path |
 
 ## Optional: notes/ as a symlink

--- a/docs/sutando-config.schema.json
+++ b/docs/sutando-config.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/sonichi/sutando/blob/main/docs/sutando-config.schema.json",
+  "title": "Sutando config",
+  "description": "Contract for sutando.config.json and sutando.config.local.json. The loader (src/sutando_config.{py,ts}) deep-merges the two and expands ${REPO_DIR} in every string value before validating against this schema. Keys whose name starts with `_` are stripped before validation (comment convention used in the .example file).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Workspace location config. Resolution order: $SUTANDO_WORKSPACE env (legacy escape hatch, warn) > sutando.config.local.json > sutando.config.json > baked-in default ${REPO_DIR}/workspace.",
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Absolute or ${REPO_DIR}-relative path to the workspace directory. The loader expands ${REPO_DIR} to the directory containing this file (== git toplevel for a sane checkout)."
+        }
+      }
+    },
+    "vault": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Vault (durable knowledge sync) config. Off by default; opt-in by setting enabled=true in sutando.config.local.json plus a remote_url. The sync engine (M2) reads sync.include + sync.exclude to decide what flows to the remote.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Master switch for vault sync. When false, no remote pushes regardless of other vault settings."
+        },
+        "remote_url": {
+          "type": "string",
+          "description": "URL of the remote git repo that holds the synced workspace subset. Empty string means unconfigured."
+        },
+        "sync": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "What to sync. Include is an allowlist of paths relative to the workspace root; exclude carves out machine-local noise from within included paths. Arrays REPLACE on merge (not unioned) — overriding in .local.json wipes the defaults for that array.",
+          "properties": {
+            "include": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "description": "Workspace-relative paths to sync. Trailing slash convention indicates a directory."
+            },
+            "exclude": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "description": "Workspace-relative paths to skip during sync. Glob patterns supported (e.g. '*.heartbeat')."
+            }
+          }
+        },
+        "interval_seconds": {
+          "type": "integer",
+          "minimum": 60,
+          "default": 1800,
+          "description": "Seconds between sync runs when sync is enabled. Minimum 60 to avoid hammering the remote."
+        }
+      }
+    }
+  }
+}

--- a/docs/workspace-config.md
+++ b/docs/workspace-config.md
@@ -1,0 +1,103 @@
+# Workspace configuration
+
+Sutando keeps **per-user runtime state** (tasks, results, notes, state, logs, etc.) under `<repo>/workspace/`, separate from the tracked code in the rest of the repo. This doc covers how the workspace path is resolved and how to override it.
+
+## The default
+
+```
+<repo>/workspace/
+```
+
+That's it for a fresh clone — no setup, no env var, no config file. The directory is gitignored except for `.gitkeep`, so user data never sneaks into commits.
+
+## Resolution order (highest wins)
+
+1. **`$SUTANDO_WORKSPACE` env var** — legacy escape hatch. Honored, but the loader prints a one-time warning suggesting you migrate to the config file.
+2. **`sutando.config.local.json`** → `workspace.path` — per-clone override. Gitignored.
+3. **`sutando.config.json`** → `workspace.path` — tracked default. The repo ships `${REPO_DIR}/workspace`.
+4. **Baked-in fallback** — `${REPO_DIR}/workspace`, used if neither config file exists.
+
+`${REPO_DIR}` in any config string expands to the directory containing the config file (== git toplevel for a sane checkout).
+
+## The two config files
+
+**`sutando.config.json`** — tracked, shared across all clones. Defines the contract + defaults:
+
+```json
+{
+  "workspace": {
+    "path": "${REPO_DIR}/workspace"
+  },
+  "vault": { ... }
+}
+```
+
+**`sutando.config.local.json`** — gitignored, per-clone overrides. Optional — empty file or missing file both mean "use defaults":
+
+```json
+{
+  "workspace": {
+    "path": "/Volumes/MyExternalSSD/sutando-workspace"
+  }
+}
+```
+
+A sample is shipped as `sutando.config.local.json.example`. Copy + edit, or start from scratch — the loader tolerates any subset of fields.
+
+Keys whose name starts with `_` (e.g. `_comment`) are stripped before validation, so the `.example` file can carry inline documentation without affecting runtime.
+
+## Three common overrides
+
+```json
+// 1. Move workspace outside the repo (e.g. shared between clones)
+{ "workspace": { "path": "/Users/you/.sutando/workspace" } }
+
+// 2. Enable vault sync to a private remote
+{ "vault": { "enabled": true, "remote_url": "https://vault.example.com/you/workspace.git" } }
+
+// 3. Both
+{
+  "workspace": { "path": "/Users/you/.sutando/workspace" },
+  "vault": { "enabled": true, "remote_url": "https://vault.example.com/you/workspace.git" }
+}
+```
+
+## Use the loader, never reinvent the fallback
+
+| Language | API |
+|---|---|
+| Python | `from sutando_config import resolve_workspace, resolve_vault, load_config` |
+| TypeScript | `import { resolveWorkspace, resolveVault, loadConfig } from './sutando_config.js'` |
+| Swift | `SutandoConfig.resolveWorkspace()` / `SutandoConfig.loadConfig()` |
+| Bash | `WORKSPACE="$(bash scripts/sutando-config.sh workspace)"` |
+
+`src/workspace_default.{py,ts}` (the legacy resolver) now delegates to the loader transparently — existing callers don't need code changes.
+
+## Protection layers
+
+The workspace must never end up in commits. Three layers enforce this:
+
+1. **`.gitignore`** — `workspace/*` with a `!workspace/.gitkeep` exception. Prevents `git add .` from picking up runtime files.
+2. **Local pre-commit hook** — `.githooks/pre-commit` refuses any commit whose staged files include `workspace/`-prefixed paths (except `.gitkeep`). Auto-installed by `src/startup.sh`; one-time manual install via `bash scripts/install-git-hooks.sh`.
+3. **CI workspace-leak check** — `.github/workflows/workspace-leak-check.yml` mirrors the hook on every PR + push to main. Catches anyone who bypassed the local hook.
+
+Escape hatch for the rare legitimate case (updating `.gitkeep` itself): `git commit --no-verify`.
+
+## CI lint: forbid new direct resolution
+
+`.github/workflows/lint-workspace-resolution.yml` refuses PRs that introduce new code outside the loader reading `$SUTANDO_WORKSPACE` directly, hardcoding `~/.sutando/workspace`, or using the historic `Path(__file__).resolve().parent.parent` walk-up. Existing legacy offenders are not flagged (the CI uses `--diff` mode); they're migrated separately.
+
+## Migrating from the old default
+
+Older installs used `~/.sutando/workspace/` as the default. If you have one:
+
+- **Path-only override:** add `{"workspace":{"path":"/Users/you/.sutando/workspace"}}` to `sutando.config.local.json`. Done.
+- **Move into the in-repo default:** copy your old workspace contents into `<repo>/workspace/`. The loader will emit a `.env` drift warning if your `.env` still declares `SUTANDO_WORKSPACE=` — remove that line once you've migrated.
+
+The M1 milestone will ship a dedicated recovery skill (`bash scripts/sutando-migrate.sh`) for users who want a guided audit + move.
+
+## Related
+
+- `CLAUDE.md` § Workspace contract — the project-wide contract this doc operationalizes
+- `docs/sutando-config.schema.json` — JSON Schema for the config file (editor autocomplete + validation)
+- `sutando.config.local.json.example` — annotated override sample at the repo root

--- a/docs/workspace-contract.md
+++ b/docs/workspace-contract.md
@@ -1,5 +1,7 @@
 # Workspace Contract
 
+> **Note:** For the current setup, see [`workspace-config.md`](workspace-config.md) — workspace now defaults to `<repo>/workspace/` and is configured via `sutando.config.local.json`. The principle below still holds: code lives in the repo, runtime state lives in the workspace; only the default location moved.
+
 Every file Sutando reads or writes lives in one of two locations. Knowing which is which prevents an entire class of split-brain bugs.
 
 ## The rule

--- a/docs/workspace-design.md
+++ b/docs/workspace-design.md
@@ -1,6 +1,6 @@
 # Workspace design — the 3-space model
 
-**Status:** RFC. Open alignment decisions appear inline as "Decisions" at the bottom; reactions welcome in the matching tracking issue.
+**Status:** Ratified. The 3-space model is now the operational contract — see [`docs/workspace-config.md`](workspace-config.md) for the current runtime behavior. The Decisions section at the bottom is preserved as a record of the design choices.
 
 ## Why this doc exists
 
@@ -23,7 +23,7 @@ If you can't place a path on this flowchart in 5 seconds, the path probably want
 | Space | Purpose | Lives at | Sync | Lifecycle |
 |---|---|---|---|---|
 | **Code** | Source of truth for behavior | `$SUTANDO_REPO_DIR` (git checkout) | Public git (`sonichi/sutando`) | Persistent; updated by `git pull` |
-| **State** | Per-user runtime, mostly machine-local | `$SUTANDO_WORKSPACE` (default `~/.sutando/workspace/`) | None — per-machine | Ephemeral; rebuildable; rotates |
+| **State** | Per-user runtime, mostly machine-local | `$SUTANDO_WORKSPACE` (default `<repo>/workspace/`) | None — per-machine | Ephemeral; rebuildable; rotates |
 | **Memory** | User-content the user reads + edits | `$SUTANDO_PRIVATE_DIR` (proposed rename → `SUTANDO_MEMORY_DIR`) | Private git per fleet (`<user>-sutando-memory.git`) | Persistent; user-authored |
 
 Within Memory, two flavors:
@@ -58,7 +58,7 @@ Per-user runtime state. Machine-local by default. Rebuildable.
 - TypeScript: `import { resolveWorkspace } from './workspace_default.js'` (post-#821).
 - Swift: `AppDelegate.workspace` (post-#837).
 
-**Lives at:** `$SUTANDO_WORKSPACE` or `~/.sutando/workspace/` (default).
+**Lives at:** `$SUTANDO_WORKSPACE` or `<repo>/workspace/` (default). The pre-M0 default `~/.sutando/workspace/` is honored as a legacy escape hatch when the env var is set, with a one-time migration warning.
 
 **Sync model:** none by default. Each Mac has its own State. If a user wants to inspect across machines they'd do it manually.
 

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Sutando git hooks installer.
+#
+# Wires `.githooks/` (tracked in the repo) as the active hooks directory for
+# this clone via `git config core.hooksPath .githooks`. This is the standard
+# "tracked hooks + per-clone opt-in" pattern — keeps the hooks shared in the
+# repo while letting individual users disable them if needed (`git config
+# --unset core.hooksPath`).
+#
+# Idempotent: re-running prints "already installed" without changing anything.
+#
+# Run once after cloning:
+#     bash scripts/install-git-hooks.sh
+#
+# Or fold into `bash src/startup.sh` if you want it on every boot.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+if [[ ! -d ".githooks" ]]; then
+  echo "✖ .githooks/ directory not found at $REPO_ROOT" >&2
+  echo "  Are you in a Sutando checkout?" >&2
+  exit 1
+fi
+
+current="$(git config --get core.hooksPath 2>/dev/null || true)"
+
+if [[ "$current" == ".githooks" ]]; then
+  echo "✓ git hooks already installed (core.hooksPath = .githooks)"
+  exit 0
+fi
+
+if [[ -n "$current" && "$current" != ".githooks" ]]; then
+  echo "⚠ git config core.hooksPath is currently '$current' (custom)." >&2
+  echo "  Overwriting with .githooks. Your previous setting is lost — re-set" >&2
+  echo "  it manually after if you need to chain." >&2
+fi
+
+git config core.hooksPath .githooks
+echo "✓ Installed Sutando git hooks (core.hooksPath -> .githooks)"
+echo ""
+echo "  Hooks active for this clone:"
+ls -1 .githooks/ | sed 's/^/    • /'
+echo ""
+echo "  To disable later: git config --unset core.hooksPath"

--- a/scripts/lint-workspace-resolution.sh
+++ b/scripts/lint-workspace-resolution.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Sutando lint: forbid direct workspace-path resolution outside the loader.
+#
+# All path resolution for the workspace MUST go through
+# `src/sutando_config.{py,ts}` (or the wrappers in `src/workspace_default.{py,ts}`
+# once they delegate to the loader). This lint catches code that bypasses
+# the loader and tries to discover the workspace by:
+#
+#   • reading $SUTANDO_WORKSPACE directly  (process.env.SUTANDO_WORKSPACE,
+#     os.environ["SUTANDO_WORKSPACE"], os.getenv("SUTANDO_WORKSPACE"))
+#   • hardcoding the legacy default path  (~/.sutando/workspace/)
+#   • using the historic anti-pattern of walking up from __file__  (the
+#     `Path(__file__).resolve().parent.parent` pattern that broke when
+#     services launched from an app bundle's symlinked src/)
+#
+# Allowed files (the loader + thin compat wrappers):
+#   src/sutando_config.py
+#   src/sutando_config.ts
+#   src/workspace_default.py
+#   src/workspace_default.ts
+#   scripts/lint-workspace-resolution.sh  (this file)
+#
+# Usage:
+#   bash scripts/lint-workspace-resolution.sh         # scan whole tree
+#   bash scripts/lint-workspace-resolution.sh --diff  # scan only added/modified lines vs base
+#
+# The CI workflow `.github/workflows/lint-workspace-resolution.yml` calls
+# this script with --diff so existing offenders stay un-flagged until
+# explicit migration. Local scan (no flag) shows everything so authors
+# can spot legacy debt voluntarily.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+mode="${1:-all}"  # all | --diff
+
+# Patterns that signal direct workspace resolution.
+# Each pattern is a single ERE alternation we feed grep -E.
+PATTERN_ENV='(process\.env|process\.env\[)["'\'']?SUTANDO_WORKSPACE|os\.environ(\.get)?\(["'\'']SUTANDO_WORKSPACE|os\.getenv\(["'\'']SUTANDO_WORKSPACE'
+PATTERN_HARDCODED_HOME='\.sutando/workspace'
+PATTERN_REPO_WALK='Path\(__file__\)\.resolve\(\)\.parent\.parent'
+
+# Allowed files — these may legitimately reference the patterns above
+# because they implement the resolution contract.
+ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|scripts/lint-workspace-resolution\.sh|scripts/install-git-hooks\.sh)$'
+
+# Pick which files to scan.
+if [[ "$mode" == "--diff" ]]; then
+  base="${BASE_REF:-origin/main}"
+  # Added or modified files vs base.
+  files="$(git diff --name-only --diff-filter=AM "$base"...HEAD)"
+else
+  # All tracked files of relevant types.
+  files="$(git ls-files -- '*.py' '*.ts' '*.tsx' '*.sh' '*.bash')"
+fi
+
+if [[ -z "$files" ]]; then
+  echo "✓ no files to scan"
+  exit 0
+fi
+
+offenders=""
+
+for f in $files; do
+  # Skip non-existing (file deleted in this diff) + non-text + allowed files.
+  [[ -f "$f" ]] || continue
+  [[ "$f" =~ \.(py|ts|tsx|sh|bash)$ ]] || continue
+  if grep -E -q "$ALLOWED" <<< "$f"; then continue; fi
+
+  if [[ "$mode" == "--diff" ]]; then
+    # Only flag lines ADDED in the diff (begin with `+` but not `+++`).
+    added="$(git diff "$base"...HEAD -- "$f" | grep -E '^\+[^+]' || true)"
+    if grep -E -q "$PATTERN_ENV|$PATTERN_HARDCODED_HOME|$PATTERN_REPO_WALK" <<< "$added"; then
+      hits="$(grep -E -n "$PATTERN_ENV|$PATTERN_HARDCODED_HOME|$PATTERN_REPO_WALK" <<< "$added" | head -3 || true)"
+      offenders+="  • $f"$'\n'"$hits"$'\n'
+    fi
+  else
+    if grep -E -l "$PATTERN_ENV|$PATTERN_HARDCODED_HOME|$PATTERN_REPO_WALK" "$f" >/dev/null 2>&1; then
+      hits="$(grep -E -n "$PATTERN_ENV|$PATTERN_HARDCODED_HOME|$PATTERN_REPO_WALK" "$f" | head -3 || true)"
+      offenders+="  • $f"$'\n'"$hits"$'\n'
+    fi
+  fi
+done
+
+if [[ -n "$offenders" ]]; then
+  if [[ "$mode" == "--diff" ]]; then
+    echo "✖ lint refused: new code introduces direct workspace-path resolution."
+  else
+    echo "ℹ existing files reference direct workspace-path resolution:"
+  fi
+  echo ""
+  printf '%s' "$offenders"
+  echo ""
+  echo "All resolution MUST go through src/sutando_config.{py,ts}."
+  echo "  Python: from src.sutando_config import resolve_workspace"
+  echo "  TS:     import { resolveWorkspace } from './sutando_config.js'"
+  if [[ "$mode" == "--diff" ]]; then
+    exit 1
+  fi
+fi
+
+if [[ "$mode" == "--diff" ]]; then
+  echo "✓ no new workspace-resolution anti-patterns in this diff."
+fi
+exit 0

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Bash wrapper around src/sutando_config.py.
+#
+# Shell scripts can call this instead of inlining `${SUTANDO_WORKSPACE:-...}`
+# defaults — keeping the resolution contract in one place (the Python loader)
+# and avoiding the split-brain bug class where bash + Python compute different
+# workspace paths from the same env.
+#
+# Usage:
+#   bash scripts/sutando-config.sh workspace     # print resolved workspace path
+#   bash scripts/sutando-config.sh vault-enabled # print "true" or "false"
+#   bash scripts/sutando-config.sh vault-url     # print vault remote_url (may be empty)
+#   bash scripts/sutando-config.sh dump          # print full merged config as JSON
+#
+# Stdout is the value (no trailing newline for scalar getters); stderr
+# carries any warnings from the loader (legacy env, .env drift). Returns
+# non-zero only on malformed config.
+#
+# Migration target — replace patterns like:
+#   WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+# with:
+#   WORKSPACE="$(bash scripts/sutando-config.sh workspace)"
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+cmd="${1:-workspace}"
+
+case "$cmd" in
+  workspace)
+    # `python3 -c` instead of `-m` so we don't pollute argv[0] with a module
+    # path that confuses the loader's exe-anchored repo discovery.
+    python3 -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT')
+from src.sutando_config import resolve_workspace
+print(resolve_workspace(), end='')
+"
+    ;;
+
+  vault-enabled)
+    python3 -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT')
+from src.sutando_config import resolve_vault
+print('true' if resolve_vault().get('enabled') else 'false', end='')
+"
+    ;;
+
+  vault-url)
+    python3 -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT')
+from src.sutando_config import resolve_vault
+print(resolve_vault().get('remote_url', ''), end='')
+"
+    ;;
+
+  dump)
+    python3 -m src.sutando_config
+    ;;
+
+  *)
+    echo "usage: $0 {workspace|vault-enabled|vault-url|dump}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/sweep-stranded-claims.sh
+++ b/scripts/sweep-stranded-claims.sh
@@ -2,7 +2,8 @@
 # One-shot cleanup: move stranded .claimed-core-*.txt files from tasks/ to
 # tasks/archive/YYYY-MM/ (#933). Run once after deploying the bridge fix.
 set -e
-WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORKSPACE="$(bash "$REPO_ROOT/scripts/sutando-config.sh" workspace)"
 TASKS_DIR="$WORKSPACE/tasks"
 YM=$(date +%Y-%m)
 DEST="$TASKS_DIR/archive/$YM"

--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -204,7 +204,14 @@ fi
 #
 # The same convention is documented in this script's pre-2026-05-11 history
 # ("notes/ bidirectional rsync removed: both nodes now symlink").
-WS_DIR="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+# Workspace resolution goes through the canonical loader (M0 cutover).
+# Fallback retains the legacy inline default for the rare case where the
+# wrapper isn't present (e.g. extracted-archive install).
+if [ -f "$REPO_DIR/scripts/sutando-config.sh" ]; then
+    WS_DIR="$(bash "$REPO_DIR/scripts/sutando-config.sh" workspace)"
+else
+    WS_DIR="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+fi
 # Disambiguation guard: if a host has SUTANDO_WORKSPACE pointing at a public-repo
 # checkout (legacy semantic), the symlink-bootstrap below would point at
 # `<repo>/notes` not the workspace `notes/`. Detect via `.git` presence + skip.

--- a/skills/catchup-after-startup/scripts/catchup-after-startup.sh
+++ b/skills/catchup-after-startup/scripts/catchup-after-startup.sh
@@ -30,7 +30,14 @@ else
   done
   REPO="${REPO:-$HOME/Desktop/sutando}"   # falls through to the conventional path if probe finds nothing
 fi
-WS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+# Workspace resolution goes through the canonical loader (M0 cutover).
+# Falls back to the legacy inline default only if the wrapper script
+# isn't present (e.g. catchup invoked from outside the repo).
+if [ -f "$REPO/scripts/sutando-config.sh" ]; then
+  WS="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+else
+  WS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+fi
 # Hours window: positional arg wins (so /catchup-after-startup 12 works as
 # documented), env var second, default 3h. Pre-review the script only read
 # CATCHUP_HOURS — the documented `[hours]` arg was silently ignored (Mini #1).

--- a/skills/overlay-apps/scripts/launch.sh
+++ b/skills/overlay-apps/scripts/launch.sh
@@ -10,7 +10,15 @@ set -e
 
 SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 APP_SRC="$SKILL_DIR/app"
-WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+REPO_ROOT="$(cd "$SKILL_DIR/../.." && pwd)"
+# Workspace resolution goes through the canonical loader (M0 cutover).
+# Fallback to the legacy inline default keeps the script working if the
+# wrapper isn't present (e.g. skill installed outside a sutando checkout).
+if [ -f "$REPO_ROOT/scripts/sutando-config.sh" ]; then
+  WORKSPACE="$(bash "$REPO_ROOT/scripts/sutando-config.sh" workspace)"
+else
+  WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+fi
 APP_DIR="$WORKSPACE/overlay-apps/benchmark-overlay"
 
 mkdir -p "$APP_DIR"

--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -47,9 +47,18 @@ mkdir -p "$OUT"
 # #769 review obs 4. Dual-path was added so pre-#762 installs don't
 # silently lose cold-review-log access; safe to remove after every node
 # has resolved its workspace at least once.
-WS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
-if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-	NOTES_DIR="$SUTANDO_WORKSPACE/notes"
+# Workspace resolution goes through the canonical loader (M0 cutover).
+# Fallback to the legacy inline default keeps the script working in odd
+# host configurations where the wrapper isn't reachable.
+if [ -f "$REPO/scripts/sutando-config.sh" ]; then
+	WS="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+else
+	WS="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+fi
+# NOTES_DIR remains a dual-path: prefer workspace/notes, fall back to repo/notes
+# for pre-#762 installs (per Lucy's #769 obs 4, drop-after 2026-08-15).
+if [ -d "$WS/notes" ]; then
+	NOTES_DIR="$WS/notes"
 else
 	NOTES_DIR="$REPO/notes"
 fi

--- a/src/Sutando/SutandoConfig.swift
+++ b/src/Sutando/SutandoConfig.swift
@@ -1,0 +1,272 @@
+// SutandoConfig.swift — Swift twin of src/sutando_config.{py,ts}.
+//
+// Canonical loader for sutando.config.json + sutando.config.local.json,
+// shared by the macOS menubar app (Sutando.app). Same resolution order,
+// deep-merge semantics, comment-stripping, and ${REPO_DIR} expansion
+// as the Python and TypeScript twins — must agree byte-for-byte on the
+// resolved workspace so menubar app + bridges + voice agent all land in
+// the same directory.
+//
+// Resolution order (highest wins):
+//   1. $SUTANDO_WORKSPACE env var (legacy escape hatch; warn once)
+//   2. sutando.config.local.json (per-clone override, gitignored)
+//   3. sutando.config.json (tracked defaults at repo root)
+//   4. Baked-in default ({repoRoot}/workspace)
+//
+// Foundation-only — no extra deps. Swift 5+.
+
+import Foundation
+
+enum SutandoConfig {
+
+    // ---------------------------------------------------------------------
+    //  File discovery
+    // ---------------------------------------------------------------------
+
+    private static let configFilename = "sutando.config.json"
+    private static let localFilename = "sutando.config.local.json"
+    private static let hardcodedWorkspaceDefaultRel = "workspace"
+
+    /// Walk upward from `start` until we find a directory containing
+    /// `sutando.config.json`. Returns nil if not found within 6 hops.
+    /// Anchors on the config file rather than `.git/` so app bundles +
+    /// symlinked installs resolve correctly.
+    private static func findRepoRoot(start: String) -> String? {
+        var cur = (start as NSString).standardizingPath
+        for _ in 0..<6 {
+            let candidate = (cur as NSString).appendingPathComponent(configFilename)
+            if FileManager.default.fileExists(atPath: candidate) {
+                return cur
+            }
+            let parent = (cur as NSString).deletingLastPathComponent
+            if parent == cur { return nil }  // filesystem root
+            cur = parent
+        }
+        return nil
+    }
+
+    // ---------------------------------------------------------------------
+    //  JSON loading + comment stripping
+    // ---------------------------------------------------------------------
+
+    /// Recursively drop dict keys whose name starts with `_`.
+    /// Comment convention: `_comment`, `_note`, etc. are stripped before
+    /// validation so the `.example` file can carry inline documentation
+    /// without polluting the runtime schema.
+    private static func stripComments(_ obj: Any) -> Any {
+        if let dict = obj as? [String: Any] {
+            var out: [String: Any] = [:]
+            for (k, v) in dict where !k.hasPrefix("_") {
+                out[k] = stripComments(v)
+            }
+            return out
+        }
+        if let arr = obj as? [Any] {
+            return arr.map { stripComments($0) }
+        }
+        return obj
+    }
+
+    /// Read + parse a JSON file, strip comment keys, return the dict.
+    /// Empty/missing file → empty dict. Parse error → throws.
+    private static func loadJson(at path: String) throws -> [String: Any] {
+        guard FileManager.default.fileExists(atPath: path) else { return [:] }
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        guard !data.isEmpty else { return [:] }
+        guard let trimmed = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return [:] }
+        guard let trimmedData = trimmed.data(using: .utf8) else { return [:] }
+        let parsed = try JSONSerialization.jsonObject(with: trimmedData, options: [])
+        guard let dict = parsed as? [String: Any] else {
+            throw NSError(
+                domain: "SutandoConfig", code: 1,
+                userInfo: [NSLocalizedDescriptionKey:
+                    "sutando config: \(path) top-level must be a JSON object"]
+            )
+        }
+        return stripComments(dict) as? [String: Any] ?? [:]
+    }
+
+    // ---------------------------------------------------------------------
+    //  Deep merge + variable expansion
+    // ---------------------------------------------------------------------
+
+    /// Recursively merge `override` into `base`. Dicts merge; everything
+    /// else (arrays, scalars) is REPLACED. Returns a new dict.
+    private static func deepMerge(
+        _ base: [String: Any], _ override: [String: Any]
+    ) -> [String: Any] {
+        var out = base
+        for (k, v) in override {
+            if let vDict = v as? [String: Any],
+               let baseDict = out[k] as? [String: Any] {
+                out[k] = deepMerge(baseDict, vDict)
+            } else {
+                out[k] = v
+            }
+        }
+        return out
+    }
+
+    /// Expand `${REPO_DIR}` in every string value of the config tree.
+    /// Other variables pass through untouched.
+    private static func expandVars(_ obj: Any, repoDir: String) -> Any {
+        let token = "${REPO_DIR}"
+        if let s = obj as? String {
+            return s.replacingOccurrences(of: token, with: repoDir)
+        }
+        if let dict = obj as? [String: Any] {
+            var out: [String: Any] = [:]
+            for (k, v) in dict { out[k] = expandVars(v, repoDir: repoDir) }
+            return out
+        }
+        if let arr = obj as? [Any] {
+            return arr.map { expandVars($0, repoDir: repoDir) }
+        }
+        return obj
+    }
+
+    // ---------------------------------------------------------------------
+    //  Top-level loader (per-process cache)
+    // ---------------------------------------------------------------------
+
+    nonisolated(unsafe) private static var cache: [String: Any]?
+    nonisolated(unsafe) private static var cacheRepoRoot: String?
+    nonisolated(unsafe) private static var legacyEnvWarnPrinted = false
+    nonisolated(unsafe) private static var dotenvDriftWarnPrinted = false
+
+    /// Load + merge sutando config from disk. Memoized per-process.
+    ///
+    /// `repoRoot` is the directory containing `sutando.config.json`;
+    /// defaults to `findRepoRoot(start:)` from the executable's parent
+    /// (matching the historical AppDelegate.repoRoot CLAUDE.md walk-up).
+    ///
+    /// Throws on parse errors; missing files are tolerated.
+    static func loadConfig(repoRoot explicitRoot: String? = nil) throws -> [String: Any] {
+        if let c = cache, explicitRoot == nil || explicitRoot == cacheRepoRoot {
+            return c
+        }
+        let root: String?
+        if let r = explicitRoot {
+            root = r
+        } else {
+            // Walk up from the executable, matching AppDelegate.repoRoot.
+            let exe = URL(fileURLWithPath: CommandLine.arguments[0])
+                .resolvingSymlinksInPath()
+                .deletingLastPathComponent().path
+            root = findRepoRoot(start: exe)
+        }
+        guard let r = root else {
+            cache = [:]
+            cacheRepoRoot = nil
+            return [:]
+        }
+        let defaults = try loadJson(at: (r as NSString).appendingPathComponent(configFilename))
+        let overrides = try loadJson(at: (r as NSString).appendingPathComponent(localFilename))
+        let merged = deepMerge(defaults, overrides)
+        let expanded = expandVars(merged, repoDir: r) as? [String: Any] ?? [:]
+        cache = expanded
+        cacheRepoRoot = r
+        return expanded
+    }
+
+    /// Test-only: clear the per-process cache.
+    static func resetCacheForTests() {
+        cache = nil
+        cacheRepoRoot = nil
+        legacyEnvWarnPrinted = false
+        dotenvDriftWarnPrinted = false
+    }
+
+    // ---------------------------------------------------------------------
+    //  Public path resolvers
+    // ---------------------------------------------------------------------
+
+    /// Resolve the workspace directory per the canonical contract.
+    /// Returns an absolute path. Does NOT create the directory.
+    ///
+    /// Order:
+    ///   1. $SUTANDO_WORKSPACE env (legacy escape hatch; warn once on stderr)
+    ///   2. config workspace.path (deep-merged)
+    ///   3. {repoRoot}/workspace baked-in default
+    static func resolveWorkspace(repoRoot explicitRoot: String? = nil) -> String {
+        let env = ProcessInfo.processInfo.environment["SUTANDO_WORKSPACE"]?
+            .trimmingCharacters(in: .whitespaces)
+        if let env = env, !env.isEmpty {
+            if !legacyEnvWarnPrinted {
+                legacyEnvWarnPrinted = true
+                FileHandle.standardError.write(Data((
+                    "sutando config: $SUTANDO_WORKSPACE is set ('\(env)'); honoring as legacy escape " +
+                    "hatch. To silence, move the value into `sutando.config.local.json` under " +
+                    "`workspace.path` and unset the env.\n"
+                ).utf8))
+            }
+            return (env as NSString).expandingTildeInPath
+        }
+
+        let cfg = (try? loadConfig(repoRoot: explicitRoot)) ?? [:]
+        let root = explicitRoot ?? cacheRepoRoot
+        let resolved: String
+        if let ws = cfg["workspace"] as? [String: Any],
+           let path = ws["path"] as? String, !path.isEmpty {
+            resolved = (path as NSString).expandingTildeInPath
+        } else if let r = root {
+            resolved = (r as NSString).appendingPathComponent(hardcodedWorkspaceDefaultRel)
+        } else {
+            resolved = NSHomeDirectory() + "/.sutando/workspace"
+        }
+
+        // .env drift warning (mirrors the Python + TS twins)
+        if !dotenvDriftWarnPrinted {
+            dotenvDriftWarnPrinted = true
+            if let dotenvVal = detectEnvWorkspaceInDotenv(repoRoot: explicitRoot),
+               (dotenvVal as NSString).standardizingPath != (resolved as NSString).standardizingPath {
+                FileHandle.standardError.write(Data((
+                    "sutando config: .env declares SUTANDO_WORKSPACE='\(dotenvVal)', but resolved " +
+                    "workspace is \(resolved) (config-driven). The .env line is NOT honored by " +
+                    "the new loader — move the value to `sutando.config.local.json` under " +
+                    "`workspace.path` and delete the .env line, or `source .env` before launching " +
+                    "processes that need the override.\n"
+                ).utf8))
+            }
+        }
+
+        return resolved
+    }
+
+    /// Scan the repo's `.env` for SUTANDO_WORKSPACE=. Best-effort.
+    static func detectEnvWorkspaceInDotenv(repoRoot explicitRoot: String? = nil) -> String? {
+        let root: String?
+        if let r = explicitRoot { root = r }
+        else {
+            let exe = URL(fileURLWithPath: CommandLine.arguments[0])
+                .resolvingSymlinksInPath()
+                .deletingLastPathComponent().path
+            root = findRepoRoot(start: exe)
+        }
+        guard let r = root else { return nil }
+        let envFile = (r as NSString).appendingPathComponent(".env")
+        guard FileManager.default.fileExists(atPath: envFile),
+              let text = try? String(contentsOfFile: envFile, encoding: .utf8) else {
+            return nil
+        }
+        for rawLine in text.split(separator: "\n") {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("#") || !line.contains("=") { continue }
+            let parts = line.split(separator: "=", maxSplits: 1).map(String.init)
+            guard parts.count == 2, parts[0].trimmingCharacters(in: .whitespaces) == "SUTANDO_WORKSPACE" else {
+                continue
+            }
+            var v = parts[1].trimmingCharacters(in: .whitespaces)
+            if v.count >= 2,
+               let first = v.first, let last = v.last,
+               first == last, (first == "\"" || first == "'") {
+                v = String(v.dropFirst().dropLast())
+            }
+            if v.isEmpty { return nil }
+            return (v as NSString).expandingTildeInPath
+        }
+        return nil
+    }
+}

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -16,23 +16,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var lastDropTime: Date = .distantPast
     var screencaptureInFlight: Bool = false  // guards against stacked crosshair launches
     // Runtime state lives under the per-user workspace dir, not the repo
-    // checkout. Mirrors src/workspace_default.py + src/workspace_default.ts
-    // (PR #762 / #821). Resolution:
-    //   1. $SUTANDO_WORKSPACE (override; ~ expansion supported)
-    //   2. ~/.sutando/workspace/ (canonical default)
+    // checkout. **Delegates to SutandoConfig.resolveWorkspace()** as of the
+    // M0 cutover (was inline env-check + hardcoded ~/.sutando/workspace
+    // fallback). The Swift loader twin lives at
+    // src/Sutando/SutandoConfig.swift and matches src/sutando_config.{py,ts}
+    // byte-for-byte. Resolution order:
+    //   1. $SUTANDO_WORKSPACE env var (legacy escape hatch; warn once)
+    //   2. sutando.config.local.json -> workspace.path (per-clone override)
+    //   3. sutando.config.json -> workspace.path (tracked defaults)
+    //   4. ${REPO_DIR}/workspace baked-in default
     //
     // Pre-#762 main.swift wrote tasks/logs/state under the repo checkout via
     // CLAUDE.md walk-up. Post-#762 that dir no longer exists, so writeTask
-    // silently failed (try? write returns nil if parent dir missing) — the
-    // bug Chi hit 2026-05-18 where context-drop notified + logged but the
-    // bridge never saw the task.
-    let workspace: String = {
-        let env = ProcessInfo.processInfo.environment["SUTANDO_WORKSPACE"]?.trimmingCharacters(in: .whitespaces)
-        if let env = env, !env.isEmpty {
-            return (env as NSString).expandingTildeInPath
-        }
-        return NSHomeDirectory() + "/.sutando/workspace"
-    }()
+    // silently failed — the bug Chi hit 2026-05-18 where context-drop
+    // notified + logged but the bridge never saw the task.
+    let workspace: String = SutandoConfig.resolveWorkspace()
 
     // Repo checkout for skills-adjacent paths (assets, src/*.py, scripts/*.sh)
     // that ship alongside the code. Same CLAUDE.md walk-up used before #762.

--- a/src/migrate.sh
+++ b/src/migrate.sh
@@ -301,7 +301,7 @@ fi
 # Compile Sutando app
 echo "Compiling Sutando menu bar app..."
 cd "$REPO/src/Sutando"
-swiftc -O -o Sutando main.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation 2>/dev/null && echo "  ✓ Sutando compiled" || echo "  ⚠ Compile failed — run manually"
+swiftc -O -o Sutando main.swift SutandoConfig.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation 2>/dev/null && echo "  ✓ Sutando compiled" || echo "  ⚠ Compile failed — run manually"
 cd "$REPO"
 
 # Python deps

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -51,6 +51,30 @@ else
 fi
 if [ $missing -eq 1 ]; then echo ""; echo "Fix the above and try again."; exit 1; fi
 
+# Exercise the new config loader as a startup banner. Surfaces:
+#   • $SUTANDO_WORKSPACE legacy-escape-hatch warning (if env is set)
+#   • .env-drift warning (if .env declares a value but config resolves differently)
+#   • config parse errors (fails fast before init.sh tries to write to a bad path)
+#
+# stdout is discarded (just the JSON dump); stderr passes through so the user
+# sees diagnostics live. A non-zero exit means malformed config — the parse
+# error is already on stderr from this same invocation.
+#
+# Note: the actual workspace path used below in `WORKSPACE=...` still comes
+# from the legacy resolver in this file. Wiring it to come from the loader
+# is a follow-up change — this banner is the early-warning layer.
+if ! python3 -m src.sutando_config >/dev/null; then
+  echo "  ✗ sutando.config.json is malformed — fix the parse error above."
+  exit 1
+fi
+
+# Wire the tracked git hooks. Idempotent — re-running prints "already
+# installed" and exits 0. Done at startup so users don't have to remember
+# `bash scripts/install-git-hooks.sh` after cloning. If a user only ever
+# explores the repo without running startup.sh, the standalone script is
+# still there as a fallback (mentioned in README).
+bash "$REPO/scripts/install-git-hooks.sh" >/dev/null 2>&1 || true
+
 # Auto-bootstrap: create-if-missing files and dirs that the agent + skills
 # expect to exist (logs, state, tasks, results, notes, contextual-chips.json,
 # pending-questions.md, build_log.md, crons.json, …). Idempotent — safe to
@@ -155,15 +179,19 @@ echo ""
 # Install Claude Code skills (runs every startup, idempotent)
 bash "$REPO/skills/install.sh" 2>/dev/null || true
 
-# Resolve the runtime workspace (separate from $REPO so per-user state lives
-# outside the git checkout). Same resolution shape as src/workspace_default.py:
-#   1. $SUTANDO_WORKSPACE env override (tilde-expand if needed)
-#   2. ~/.sutando/workspace/ (canonical default)
-#
-# All service logs + tasks/results land under $WORKSPACE/logs etc. instead of
-# the repo-root legacy paths. health-check + dashboard already read from
-# $WORKSPACE/logs — this redirects the writes to match.
-if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+# Resolve the runtime workspace via the canonical loader (M0 cutover).
+# The loader implements the full resolution order:
+#   1. $SUTANDO_WORKSPACE env var (legacy escape hatch; warn once)
+#   2. sutando.config.local.json -> workspace.path (per-clone override)
+#   3. sutando.config.json -> workspace.path (tracked defaults)
+#   4. ${REPO_DIR}/workspace baked-in default
+# Inline fallback retained for the rare case where the wrapper isn't
+# present (extracted-tarball install, etc.). All service logs + tasks/
+# results land under $WORKSPACE/logs etc. instead of the repo-root legacy
+# paths. health-check + dashboard already read from $WORKSPACE/logs.
+if [ -f "$REPO/scripts/sutando-config.sh" ]; then
+  WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
   WORKSPACE="$HOME/.sutando/workspace"
@@ -314,7 +342,7 @@ fi
 # Kill any running instance so the fresh binary can take over.
 if [ -f "$SUT_SRC" ] && { [ ! -f "$SUT_BIN" ] || [ "$SUT_SRC" -nt "$SUT_BIN" ]; }; then
   echo "  Compiling Sutando (source newer than binary)..."
-  if (cd "$REPO/src/Sutando" && swiftc -O -o Sutando main.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation 2>/dev/null); then
+  if (cd "$REPO/src/Sutando" && swiftc -O -o Sutando main.swift SutandoConfig.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation 2>/dev/null); then
     echo "  ✓ Sutando compiled"
 
     # Sync the fresh binary into the .app bundle if one exists, ensure the

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -1,0 +1,358 @@
+"""Canonical loader for `sutando.config.json` / `sutando.config.local.json`.
+
+The config file is the M0 contract for where Sutando's per-user runtime state
+lives. This module is the SINGLE place that reads those files. All path-
+resolution callers (`resolve_workspace`, vault sync engine, future services)
+go through `load_config()` so that the contract is enforced in one place
+rather than re-implemented per-service.
+
+Resolution order (highest layer wins):
+  1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn on use)
+  2. `sutando.config.local.json` (per-clone override, gitignored)
+  3. `sutando.config.json` (tracked defaults at repo root)
+  4. Baked-in default (`{repo_root}/workspace`)
+
+Deep-merge semantics: `.local.json` is merged over the tracked defaults.
+Dicts deep-merge; arrays REPLACE wholesale (not unioned). This matches the
+`.example` file pattern documented in the docstrings — users override only
+the keys they want.
+
+`${REPO_DIR}` in any string value expands to the directory containing the
+config file (== git toplevel for a sane checkout). Other ${VAR}s are not
+expanded; this is config, not shell.
+
+Comment convention: any top- or nested-level key whose name starts with `_`
+is treated as a comment and stripped before validation. This lets the
+`.example` file carry inline documentation without polluting the runtime
+schema.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import warnings
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# --------------------------------------------------------------------------- #
+#  File discovery                                                             #
+# --------------------------------------------------------------------------- #
+
+_CONFIG_FILENAME = "sutando.config.json"
+_LOCAL_FILENAME = "sutando.config.local.json"
+
+
+def _find_repo_root(start: Optional[Path] = None) -> Optional[Path]:
+    """Walk upward from `start` (default: this module's parent) until we find
+    a directory containing `sutando.config.json`. Returns None if not found
+    within 6 hops — that's deep enough for any sane checkout layout.
+
+    We anchor on the config file rather than `.git/` because:
+      - app bundles + symlinked installs may lack `.git/` in the resolved path
+      - users running outside a git checkout (CI, tarball install) still get
+        a working loader as long as the config sits beside it
+    """
+    cur = (start or Path(__file__).resolve().parent).resolve()
+    for _ in range(6):
+        if (cur / _CONFIG_FILENAME).is_file():
+            return cur
+        if cur == cur.parent:  # filesystem root
+            return None
+        cur = cur.parent
+    return None
+
+
+# --------------------------------------------------------------------------- #
+#  JSON loading + comment stripping                                           #
+# --------------------------------------------------------------------------- #
+
+
+def _strip_comments(obj: Any) -> Any:
+    """Recursively drop dict keys whose name starts with `_` (comment convention).
+
+    Lists are walked element-wise; scalars pass through. Returns a new structure
+    — the input is not mutated.
+    """
+    if isinstance(obj, dict):
+        return {k: _strip_comments(v) for k, v in obj.items() if not k.startswith("_")}
+    if isinstance(obj, list):
+        return [_strip_comments(v) for v in obj]
+    return obj
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    """Read + parse a JSON file, strip comment keys, return the resulting dict.
+
+    Empty file is treated as `{}` (defensive: a freshly-touched `.local.json`
+    is valid). Parse errors raise with a clear message.
+    """
+    if not path.is_file():
+        return {}
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"sutando config: failed to parse {path}: {e.msg} at line {e.lineno} col {e.colno}"
+        ) from e
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"sutando config: {path} top-level must be a JSON object, got {type(data).__name__}"
+        )
+    return _strip_comments(data)
+
+
+# --------------------------------------------------------------------------- #
+#  Deep merge + variable expansion                                            #
+# --------------------------------------------------------------------------- #
+
+
+def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge `override` into `base`. Dicts merge; everything else
+    (lists, scalars, None) is REPLACED by the override.
+
+    Returns a new dict; inputs are not mutated.
+    """
+    out: Dict[str, Any] = dict(base)
+    for k, v in override.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def _expand_vars(obj: Any, repo_dir: Path) -> Any:
+    """Expand `${REPO_DIR}` in every string value of the config tree.
+
+    Only `${REPO_DIR}` is recognized — other variables pass through untouched
+    (the loader is not a shell). Walks dicts + lists; scalars other than strings
+    are returned as-is.
+    """
+    token = "${REPO_DIR}"
+    if isinstance(obj, str):
+        return obj.replace(token, str(repo_dir))
+    if isinstance(obj, dict):
+        return {k: _expand_vars(v, repo_dir) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_expand_vars(v, repo_dir) for v in obj]
+    return obj
+
+
+# --------------------------------------------------------------------------- #
+#  Top-level loader                                                           #
+# --------------------------------------------------------------------------- #
+
+
+# Cache the resolved config per-process so repeated calls don't re-read disk
+# or re-print warnings. None means "not yet loaded"; the cached value is the
+# merged + expanded dict.
+_CACHE: Optional[Dict[str, Any]] = None
+_CACHE_REPO_ROOT: Optional[Path] = None
+_LEGACY_ENV_WARN_PRINTED = False
+_DOTENV_DRIFT_WARN_PRINTED = False
+
+
+def _reset_cache_for_tests() -> None:
+    """Test-only: clear the per-process cache so unit tests can swap configs.
+
+    Production code never calls this. Importing in tests is intentional —
+    keeps the public surface honest.
+    """
+    global _CACHE, _CACHE_REPO_ROOT, _LEGACY_ENV_WARN_PRINTED, _DOTENV_DRIFT_WARN_PRINTED
+    _CACHE = None
+    _CACHE_REPO_ROOT = None
+    _LEGACY_ENV_WARN_PRINTED = False
+    _DOTENV_DRIFT_WARN_PRINTED = False
+
+
+def load_config(repo_root: Optional[Path] = None) -> Dict[str, Any]:
+    """Load + merge sutando config from disk. Memoized per-process.
+
+    `repo_root` is the directory holding `sutando.config.json`; defaults to
+    the result of `_find_repo_root()`. Pass an explicit Path in tests.
+
+    Returns the deep-merged, ${REPO_DIR}-expanded config dict. Missing files
+    are tolerated (defaults file optional too, in which case caller falls
+    through to the hardcoded resolver default — see `resolve_workspace`).
+
+    Raises `RuntimeError` only for parse errors (malformed JSON) or
+    structurally-invalid top-level (non-object).
+    """
+    global _CACHE, _CACHE_REPO_ROOT
+    if _CACHE is not None and (repo_root is None or repo_root == _CACHE_REPO_ROOT):
+        return _CACHE
+
+    root = repo_root or _find_repo_root()
+    if root is None:
+        # No config file anywhere in the search path; return an empty config.
+        # Callers will fall back to baked-in defaults.
+        _CACHE = {}
+        _CACHE_REPO_ROOT = None
+        return _CACHE
+
+    defaults = _load_json(root / _CONFIG_FILENAME)
+    overrides = _load_json(root / _LOCAL_FILENAME)
+    merged = _deep_merge(defaults, overrides)
+    expanded = _expand_vars(merged, root)
+
+    _CACHE = expanded
+    _CACHE_REPO_ROOT = root
+    return expanded
+
+
+# --------------------------------------------------------------------------- #
+#  Public path resolvers                                                      #
+# --------------------------------------------------------------------------- #
+
+
+_HARDCODED_WORKSPACE_DEFAULT_REL = "workspace"  # relative to repo root
+
+
+def resolve_workspace(repo_root: Optional[Path] = None) -> Path:
+    """Resolve the workspace directory per the canonical contract.
+
+    Order:
+      1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn once).
+      2. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
+      3. `{repo_root}/workspace` baked-in default.
+
+    Does NOT create the directory; the caller decides. Returns an absolute
+    `Path`.
+
+    The env-var warning fires at most once per process so log noise is
+    bounded. The warning is informational — env still wins, so existing
+    users don't break on the switch. Migration path: copy the env value
+    into `sutando.config.local.json` → `workspace.path` and unset the env.
+    """
+    global _LEGACY_ENV_WARN_PRINTED, _DOTENV_DRIFT_WARN_PRINTED
+
+    env_val = os.environ.get("SUTANDO_WORKSPACE", "").strip()
+    if env_val:
+        if not _LEGACY_ENV_WARN_PRINTED:
+            _LEGACY_ENV_WARN_PRINTED = True
+            print(
+                f"sutando config: $SUTANDO_WORKSPACE is set ({env_val!r}); honoring "
+                f"as legacy escape hatch. To silence, move the value into "
+                f"`sutando.config.local.json` under `workspace.path` and unset the env.",
+                file=sys.stderr,
+            )
+        return Path(env_val).expanduser().resolve()
+
+    cfg = load_config(repo_root)
+    root = repo_root or _CACHE_REPO_ROOT
+    cfg_path = (cfg.get("workspace") or {}).get("path")
+    if cfg_path:
+        resolved = Path(cfg_path).expanduser().resolve()
+    elif root is None:
+        # No config and no repo root — fall back to the historic default so we
+        # don't break ad-hoc invocations outside a checkout. workspace_default.py
+        # has the same behavior; preserving it here avoids regressions on
+        # services that import this loader before the cutover.
+        resolved = Path.home().joinpath(".sutando", "workspace").resolve()
+    else:
+        resolved = (root / _HARDCODED_WORKSPACE_DEFAULT_REL).resolve()
+
+    # M0 .env-drift warning: if the env var is UNSET but `.env` declares one,
+    # the user has a stale `.env` line that the new contract bypasses. Surface
+    # once per process so they migrate to `sutando.config.local.json` and
+    # delete the `.env` line. Loader does NOT honor `.env` values — only the
+    # process env. This is the "Detect SUTANDO_WORKSPACE from .env file and
+    # give warning" bullet from Milestone 0.
+    if not _DOTENV_DRIFT_WARN_PRINTED:
+        _DOTENV_DRIFT_WARN_PRINTED = True
+        dotenv_val = detect_env_workspace_in_dotenv(repo_root)
+        if dotenv_val and Path(dotenv_val).resolve() != resolved:
+            print(
+                f"sutando config: .env declares SUTANDO_WORKSPACE={dotenv_val!r}, but "
+                f"resolved workspace is {resolved} (config-driven). The .env line is "
+                f"NOT honored by the new loader — move the value to "
+                f"`sutando.config.local.json` under `workspace.path` and delete the .env "
+                f"line, or `source .env` before launching processes that need the override.",
+                file=sys.stderr,
+            )
+
+    return resolved
+
+
+def resolve_vault(repo_root: Optional[Path] = None) -> Dict[str, Any]:
+    """Return the resolved vault subtree from config.
+
+    Schema (after deep-merge + expansion):
+      {
+        "enabled": bool,
+        "remote_url": str,
+        "sync": {"include": [str, ...], "exclude": [str, ...]},
+        "interval_seconds": int,
+      }
+
+    Missing config returns `{"enabled": False, ...}` with safe defaults so
+    callers can branch on `cfg["enabled"]` without KeyError. The vault sync
+    engine (M2) is the primary consumer.
+    """
+    cfg = load_config(repo_root)
+    vault = dict(cfg.get("vault") or {})
+    vault.setdefault("enabled", False)
+    vault.setdefault("remote_url", "")
+    sync = dict(vault.get("sync") or {})
+    sync.setdefault("include", [])
+    sync.setdefault("exclude", [])
+    vault["sync"] = sync
+    vault.setdefault("interval_seconds", 1800)
+    return vault
+
+
+def detect_env_workspace_in_dotenv(repo_root: Optional[Path] = None) -> Optional[str]:
+    """Scan the repo's `.env` for `SUTANDO_WORKSPACE=` and return the value if
+    found, else None. Used by the startup banner to warn users that their .env
+    declares a workspace path that the loader is bypassing in favor of config.
+
+    Best-effort: silent on file-not-found or read errors. Strips surrounding
+    quotes and expands `~`.
+
+    Triggers the .env warning bullet from Milestone 0.
+    """
+    root = repo_root or _find_repo_root()
+    if root is None:
+        return None
+    env_file = root / ".env"
+    if not env_file.is_file():
+        return None
+    try:
+        for line in env_file.read_text(encoding="utf-8").splitlines():
+            s = line.strip()
+            if s.startswith("#") or "=" not in s:
+                continue
+            key, _, val = s.partition("=")
+            if key.strip() != "SUTANDO_WORKSPACE":
+                continue
+            v = val.strip()
+            if len(v) >= 2 and v[0] == v[-1] and v[0] in ('"', "'"):
+                v = v[1:-1]
+            return str(Path(v).expanduser()) if v else None
+    except OSError:
+        return None
+    return None
+
+
+# --------------------------------------------------------------------------- #
+#  CLI: `python3 -m src.sutando_config` prints the merged config for debug    #
+# --------------------------------------------------------------------------- #
+
+
+if __name__ == "__main__":  # pragma: no cover — operator-facing CLI
+    # All diagnostic output goes to stdout so a caller can suppress it with
+    # `>/dev/null` while still seeing the WARNINGS that resolve_workspace()
+    # itself emits to stderr (legacy env, .env drift, parse errors). That
+    # gives `bash src/startup.sh` a clean "warnings only" surface from this
+    # call.
+    cfg = load_config()
+    workspace = resolve_workspace()  # emits stderr warnings if any
+    env_val = detect_env_workspace_in_dotenv()
+    print(json.dumps(cfg, indent=2, default=str))
+    print(f"\n# resolved workspace: {workspace}")
+    if env_val:
+        print(f"# .env declares SUTANDO_WORKSPACE={env_val!r}")

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -1,0 +1,301 @@
+/**
+ * Canonical loader for `sutando.config.json` / `sutando.config.local.json`.
+ *
+ * Twin of `src/sutando_config.py`. Same resolution order, same deep-merge
+ * semantics, same comment-stripping, same `${REPO_DIR}` expansion. Both
+ * languages must agree byte-for-byte on the resolved config so that
+ * Python services (bridges, health-check) and TS services (voice-agent,
+ * task-bridge) land in the same workspace.
+ *
+ * Resolution order (highest layer wins):
+ *   1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn on use)
+ *   2. `sutando.config.local.json` (per-clone override, gitignored)
+ *   3. `sutando.config.json` (tracked defaults at repo root)
+ *   4. Baked-in default (`{repo_root}/workspace`)
+ *
+ * No external deps — stdlib only.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, isAbsolute, join, parse, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// --------------------------------------------------------------------------- //
+//  File discovery                                                             //
+// --------------------------------------------------------------------------- //
+
+const CONFIG_FILENAME = 'sutando.config.json';
+const LOCAL_FILENAME = 'sutando.config.local.json';
+
+/**
+ * Walk upward from `start` until we find a directory containing
+ * `sutando.config.json`. Returns undefined if not found within 6 hops.
+ * Anchors on the config file rather than `.git/` so app bundles + symlinked
+ * installs still resolve correctly.
+ */
+function findRepoRoot(start?: string): string | undefined {
+	let cur = resolve(start ?? dirname(fileURLToPath(import.meta.url)));
+	for (let i = 0; i < 6; i++) {
+		if (existsSync(join(cur, CONFIG_FILENAME))) return cur;
+		const parent = dirname(cur);
+		if (parent === cur) return undefined;
+		cur = parent;
+	}
+	return undefined;
+}
+
+// --------------------------------------------------------------------------- //
+//  JSON loading + comment stripping                                           //
+// --------------------------------------------------------------------------- //
+
+type Json = string | number | boolean | null | { [k: string]: Json } | Json[];
+
+/**
+ * Recursively drop dict keys whose name starts with `_` (comment convention).
+ * Lists are walked element-wise; scalars pass through.
+ */
+function stripComments(obj: Json): Json {
+	if (Array.isArray(obj)) return obj.map(stripComments);
+	if (obj !== null && typeof obj === 'object') {
+		const out: { [k: string]: Json } = {};
+		for (const [k, v] of Object.entries(obj)) {
+			if (!k.startsWith('_')) out[k] = stripComments(v);
+		}
+		return out;
+	}
+	return obj;
+}
+
+/**
+ * Read + parse a JSON file, strip comment keys, return the resulting object.
+ * Empty file is treated as `{}`. Parse errors throw with a clear message.
+ */
+function loadJsonFile(path: string): { [k: string]: Json } {
+	if (!existsSync(path)) return {};
+	const text = readFileSync(path, 'utf8').trim();
+	if (!text) return {};
+	let data: Json;
+	try {
+		data = JSON.parse(text);
+	} catch (e) {
+		const msg = e instanceof Error ? e.message : String(e);
+		throw new Error(`sutando config: failed to parse ${path}: ${msg}`);
+	}
+	if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+		throw new Error(`sutando config: ${path} top-level must be a JSON object, got ${typeof data}`);
+	}
+	const stripped = stripComments(data);
+	return stripped as { [k: string]: Json };
+}
+
+// --------------------------------------------------------------------------- //
+//  Deep merge + variable expansion                                            //
+// --------------------------------------------------------------------------- //
+
+/**
+ * Recursively merge `override` into `base`. Dicts merge; everything else
+ * (arrays, scalars, null) is REPLACED by the override. Returns a new object;
+ * inputs are not mutated.
+ */
+function deepMerge(
+	base: { [k: string]: Json },
+	override: { [k: string]: Json },
+): { [k: string]: Json } {
+	const out: { [k: string]: Json } = { ...base };
+	for (const [k, v] of Object.entries(override)) {
+		const existing = out[k];
+		if (
+			v !== null &&
+			typeof v === 'object' &&
+			!Array.isArray(v) &&
+			existing !== null &&
+			typeof existing === 'object' &&
+			!Array.isArray(existing)
+		) {
+			out[k] = deepMerge(existing as { [k: string]: Json }, v as { [k: string]: Json });
+		} else {
+			out[k] = v;
+		}
+	}
+	return out;
+}
+
+/**
+ * Expand `${REPO_DIR}` in every string value of the config tree. Only that
+ * token is recognized — other variables pass through untouched. Walks dicts
+ * + arrays; non-string scalars are returned as-is.
+ */
+function expandVars(obj: Json, repoDir: string): Json {
+	const token = '${REPO_DIR}';
+	if (typeof obj === 'string') return obj.split(token).join(repoDir);
+	if (Array.isArray(obj)) return obj.map((v) => expandVars(v, repoDir));
+	if (obj !== null && typeof obj === 'object') {
+		const out: { [k: string]: Json } = {};
+		for (const [k, v] of Object.entries(obj)) out[k] = expandVars(v, repoDir);
+		return out;
+	}
+	return obj;
+}
+
+// --------------------------------------------------------------------------- //
+//  Top-level loader                                                           //
+// --------------------------------------------------------------------------- //
+
+let _cache: { [k: string]: Json } | undefined;
+let _cacheRepoRoot: string | undefined;
+let _legacyEnvWarnPrinted = false;
+let _dotenvDriftWarnPrinted = false;
+
+/** Test-only: clear the per-process cache. */
+export function resetCacheForTests(): void {
+	_cache = undefined;
+	_cacheRepoRoot = undefined;
+	_legacyEnvWarnPrinted = false;
+	_dotenvDriftWarnPrinted = false;
+}
+
+/**
+ * Load + merge sutando config from disk. Memoized per-process.
+ *
+ * `repoRoot` is the directory holding `sutando.config.json`; defaults to
+ * the result of `findRepoRoot()`. Pass an explicit path in tests.
+ *
+ * Throws only for parse errors (malformed JSON) or structurally-invalid
+ * top-level (non-object). Missing files are tolerated and yield `{}`.
+ */
+export function loadConfig(repoRoot?: string): { [k: string]: Json } {
+	if (_cache !== undefined && (repoRoot === undefined || repoRoot === _cacheRepoRoot)) {
+		return _cache;
+	}
+	const root = repoRoot ?? findRepoRoot();
+	if (root === undefined) {
+		_cache = {};
+		_cacheRepoRoot = undefined;
+		return _cache;
+	}
+	const defaults = loadJsonFile(join(root, CONFIG_FILENAME));
+	const overrides = loadJsonFile(join(root, LOCAL_FILENAME));
+	const merged = deepMerge(defaults, overrides);
+	const expanded = expandVars(merged, root) as { [k: string]: Json };
+	_cache = expanded;
+	_cacheRepoRoot = root;
+	return expanded;
+}
+
+// --------------------------------------------------------------------------- //
+//  Public path resolvers                                                      //
+// --------------------------------------------------------------------------- //
+
+const HARDCODED_WORKSPACE_DEFAULT_REL = 'workspace';
+
+/**
+ * Resolve the workspace directory per the canonical contract.
+ *
+ * Order:
+ *   1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn once).
+ *   2. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
+ *   3. `{repoRoot}/workspace` baked-in default.
+ *
+ * Returns an absolute path. Does NOT create the directory.
+ */
+export function resolveWorkspace(repoRoot?: string): string {
+	const envVal = process.env.SUTANDO_WORKSPACE?.trim();
+	if (envVal) {
+		if (!_legacyEnvWarnPrinted) {
+			_legacyEnvWarnPrinted = true;
+			process.stderr.write(
+				`sutando config: $SUTANDO_WORKSPACE is set ('${envVal}'); honoring as legacy escape ` +
+					`hatch. To silence, move the value into \`sutando.config.local.json\` under ` +
+					`\`workspace.path\` and unset the env.\n`,
+			);
+		}
+		return resolve(envVal.replace(/^~/, homedir()));
+	}
+
+	const cfg = loadConfig(repoRoot);
+	const root = repoRoot ?? _cacheRepoRoot;
+	const ws = (cfg.workspace as { [k: string]: Json } | undefined)?.path;
+	let resolved: string;
+	if (typeof ws === 'string' && ws) {
+		resolved = resolve(ws.replace(/^~/, homedir()));
+	} else if (root === undefined) {
+		resolved = resolve(join(homedir(), '.sutando', 'workspace'));
+	} else {
+		resolved = resolve(join(root, HARDCODED_WORKSPACE_DEFAULT_REL));
+	}
+
+	// M0 .env-drift warning: if the env var is UNSET but `.env` declares one,
+	// surface the stale .env line once per process. See sutando_config.py for
+	// the design rationale — this is the TS twin of the same behavior.
+	if (!_dotenvDriftWarnPrinted) {
+		_dotenvDriftWarnPrinted = true;
+		const dotenvVal = detectEnvWorkspaceInDotenv(repoRoot);
+		if (dotenvVal && resolve(dotenvVal) !== resolved) {
+			process.stderr.write(
+				`sutando config: .env declares SUTANDO_WORKSPACE='${dotenvVal}', but resolved workspace ` +
+					`is ${resolved} (config-driven). The .env line is NOT honored by the new loader — ` +
+					`move the value to \`sutando.config.local.json\` under \`workspace.path\` and delete the ` +
+					`.env line, or \`source .env\` before launching processes that need the override.\n`,
+			);
+		}
+	}
+	return resolved;
+}
+
+/**
+ * Vault config with defaults filled in. Missing config yields
+ * `{ enabled: false, ... }` so callers can branch on `cfg.enabled` safely.
+ */
+export interface VaultConfig {
+	enabled: boolean;
+	remote_url: string;
+	sync: { include: string[]; exclude: string[] };
+	interval_seconds: number;
+}
+
+export function resolveVault(repoRoot?: string): VaultConfig {
+	const cfg = loadConfig(repoRoot);
+	const vault = (cfg.vault as { [k: string]: Json } | undefined) ?? {};
+	const sync = (vault.sync as { [k: string]: Json } | undefined) ?? {};
+	const includeRaw = sync.include;
+	const excludeRaw = sync.exclude;
+	return {
+		enabled: typeof vault.enabled === 'boolean' ? vault.enabled : false,
+		remote_url: typeof vault.remote_url === 'string' ? vault.remote_url : '',
+		sync: {
+			include: Array.isArray(includeRaw) ? includeRaw.filter((v): v is string => typeof v === 'string') : [],
+			exclude: Array.isArray(excludeRaw) ? excludeRaw.filter((v): v is string => typeof v === 'string') : [],
+		},
+		interval_seconds: typeof vault.interval_seconds === 'number' ? vault.interval_seconds : 1800,
+	};
+}
+
+/**
+ * Scan the repo's `.env` for `SUTANDO_WORKSPACE=` and return the value if
+ * found, else undefined. Used by the startup banner to warn users that their
+ * `.env` declares a workspace path that the loader is bypassing in favor of
+ * config. Best-effort: silent on file-not-found or read errors.
+ */
+export function detectEnvWorkspaceInDotenv(repoRoot?: string): string | undefined {
+	const root = repoRoot ?? findRepoRoot();
+	if (root === undefined) return undefined;
+	const envFile = join(root, '.env');
+	if (!existsSync(envFile)) return undefined;
+	try {
+		for (const line of readFileSync(envFile, 'utf8').split('\n')) {
+			const s = line.trim();
+			if (s.startsWith('#') || !s.includes('=')) continue;
+			const [key, ...rest] = s.split('=');
+			if (key.trim() !== 'SUTANDO_WORKSPACE') continue;
+			let v = rest.join('=').trim();
+			if (v.length >= 2 && v[0] === v[v.length - 1] && (v[0] === '"' || v[0] === "'")) {
+				v = v.slice(1, -1);
+			}
+			return v ? v.replace(/^~/, homedir()) : undefined;
+		}
+	} catch {
+		// Best-effort.
+	}
+	return undefined;
+}

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -20,20 +20,27 @@
 
 set -u
 
-# Resolve TASKS_DIR. Priority: explicit positional arg → $SUTANDO_WORKSPACE/tasks
-# → canonical default `~/.sutando/workspace/tasks` (matching
-# `workspace_default.resolve_workspace()` — the shared contract every bridge
-# already follows). The bridges (discord-bridge.py, telegram-bridge.py,
-# dm-result.py — see PRs #708/#720/#722/#723) write to that default when env
-# is unset; if this watcher fell back to `<repo>/tasks/` instead, the bridges
-# would write to one dir and the watcher would poll another, so owner DMs land
-# silently. Diagnosed 2026-05-15 (~3 dropped DMs over 17 min) and again
-# 2026-05-16 (~45 min silent gap when the Monitor was started without
-# SUTANDO_WORKSPACE exported into its env) — second incident motivated
-# replacing the legacy `<repo>/tasks` fallback with the workspace default so
-# the divergence can't happen even when callers forget to export.
+__SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+__REPO_ROOT="$(cd "$__SCRIPT_DIR/.." && pwd)"
+
+# Resolve TASKS_DIR. Priority: explicit positional arg → canonical loader
+# (env + config + default) — matching `workspace_default.resolve_workspace()`,
+# the shared contract every bridge already follows via the M0 cutover.
+# The bridges (discord-bridge.py, telegram-bridge.py, dm-result.py — see PRs
+# #708/#720/#722/#723) write to the resolved workspace; if this watcher fell
+# back to `<repo>/tasks/` instead, the bridges would write to one dir and the
+# watcher would poll another, so owner DMs land silently. Diagnosed 2026-05-15
+# (~3 dropped DMs over 17 min) and again 2026-05-16 (~45 min silent gap when
+# the Monitor was started without SUTANDO_WORKSPACE exported into its env) —
+# second incident motivated replacing the legacy `<repo>/tasks` fallback with
+# the workspace default so the divergence can't happen even when callers
+# forget to export. M0 cutover delegates this to scripts/sutando-config.sh,
+# with the inline legacy-default fallback retained for non-checkout installs.
 if [ -n "${1:-}" ]; then
   TASKS_DIR="$1"
+elif [ -f "$__REPO_ROOT/scripts/sutando-config.sh" ]; then
+  __WS="$(bash "$__REPO_ROOT/scripts/sutando-config.sh" workspace)"
+  TASKS_DIR="$__WS/tasks"
 elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   TASKS_DIR="$SUTANDO_WORKSPACE/tasks"
 else
@@ -53,10 +60,12 @@ TASKS_DIR_ABS="$(cd "$TASKS_DIR" && pwd -P)"
 # the session and turn into an orphan. The trap below removes the file on a
 # clean exit; the Stop hook removes it after the kill on dirty exits.
 #
-# Same workspace resolution as TASKS_DIR (above): explicit env override,
-# else canonical default. Living under state/ matches the workspace contract
+# Same workspace resolution as TASKS_DIR (above): M0 cutover routes through
+# the canonical loader. Living under state/ matches the workspace contract
 # in CLAUDE.md (loose status/state files belong there).
-if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+if [ -f "$__REPO_ROOT/scripts/sutando-config.sh" ]; then
+  STATE_DIR="$(bash "$__REPO_ROOT/scripts/sutando-config.sh" workspace)/state"
+elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   STATE_DIR="${SUTANDO_WORKSPACE/#\~/$HOME}/state"
 else
   STATE_DIR="$HOME/.sutando/workspace/state"

--- a/src/workspace_default.py
+++ b/src/workspace_default.py
@@ -410,88 +410,39 @@ def _grep_env_for_workspace() -> str | None:
 def resolve_workspace(migrate: bool = True) -> Path:
     """Resolve the workspace directory per the canonical contract.
 
-    Order:
-      1. `$SUTANDO_WORKSPACE` env var, expanded (`~` honored).
-      2. `~/.sutando/workspace/`.
+    **Delegates to `src/sutando_config.py::resolve_workspace`** as of the
+    M0 cutover. The new loader implements the resolution order:
 
-    Returns a `Path` — does NOT create the directory; the caller decides.
+      1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn once)
+      2. `sutando.config.local.json` → `workspace.path` (per-clone override)
+      3. `sutando.config.json` → `workspace.path` (tracked defaults)
+      4. `${REPO_DIR}/workspace` baked-in default
 
-    **Auto-migration disabled (closes #1169 option B, 2026-05-26.)**
+    This wrapper is preserved so existing callers don't need code changes —
+    the function name + signature + return type are unchanged. Behavior
+    differs in two ways from the pre-cutover version:
 
-    Previously this function auto-ran 5 destructive migrators
-    (`_migrate_from_legacy`, `_migrate_inrepo_notes`,
-    `_migrate_inrepo_build_log`, `_migrate_root_status`,
-    `_migrate_conversation_log`) on every call. The semantic was
-    "implicit one-way `shutil.move` whenever the resolver sees an
-    eligible source" — which destroyed an uncommitted file on
-    2026-05-25 when `tests/discord_config.test.py` set
-    `SUTANDO_WORKSPACE=tmpdir` and the symlinked `<repo>/notes/`
-    (memory-sync target) was relocated into the tmpdir, then deleted
-    when `tempfile.TemporaryDirectory` cleaned up. See incident
-    write-up at the top of #1169.
+      - Default location is `${REPO_DIR}/workspace` (in-repo), not
+        `~/.sutando/workspace/`. Users with `$SUTANDO_WORKSPACE` set keep
+        their old location with a one-time warning.
+      - `.env` declarations of `SUTANDO_WORKSPACE` no longer leak into
+        resolution when the env var itself is unset — only the env var
+        in the process environment matters. A separate one-time warning
+        fires if `.env` declares a value that disagrees with the resolved
+        workspace.
 
-    The five migrators remain defined in this module (their bodies
-    are untouched and their direct-call tests still pass); they are
-    no longer dispatched from `resolve_workspace()`. They will be
-    re-introduced via an explicit `sutando-migrate` CLI in a
-    follow-up — opt-in, with `--dry-run`, `--commit`, and a
-    once-per-host sentinel. Users with legacy in-repo state will see
-    a one-time stderr notice the first time this function runs
-    pointing them at the CLI.
-
-    The `migrate` keyword is kept for backwards compatibility with
-    callers that previously passed `migrate=False`. Passing
-    `migrate=False` ALSO skips the legacy-state stderr notice — the
-    function stays pure (no scan, no I/O on the legacy root, no
-    stderr output beyond the relative-path warning). Pass
-    `migrate=True` (the default) to let the one-time notice fire.
+    The legacy-state notice (pointing users at `scripts/sutando-migrate.sh`)
+    remains here — same behavior as before, gated by `migrate=True`.
     """
     global _AUTO_MIGRATE_NOTICE_PRINTED
 
-    env = os.environ.get("SUTANDO_WORKSPACE", "").strip()
-    if env:
-        target = Path(env).expanduser()
-        # A relative `SUTANDO_WORKSPACE` resolves against CWD, which
-        # differs between launchd-managed services, systemd units, and
-        # bare-shell launches. Two processes inheriting the same env
-        # var would then mkdir/read in DIFFERENT directories — silent
-        # split-brain, same anti-pattern this module already warns about
-        # for the `Path(__file__).resolve().parent.parent` fallback.
-        # Normalize to an absolute path against the current CWD and
-        # warn loudly so the misconfig surfaces. `.resolve()` collapses
-        # `..` segments too.
-        if not target.is_absolute():
-            anchored = (Path.cwd() / target).resolve()
-            print(
-                f"workspace: SUTANDO_WORKSPACE={env!r} is relative — anchored to "
-                f"{anchored} (CWD-dependent; set an absolute path to avoid "
-                f"cross-process drift)",
-                file=sys.stderr,
-            )
-            target = anchored
-    else:
-        target = default_workspace_dir()
-        # Surface the silent-fallback bug class (see PR #1367/#1368): if .env
-        # defines SUTANDO_WORKSPACE but the process never got it (e.g. a
-        # SessionStart hook, launchd service, or any process that didn't
-        # `source .env`), the caller silently lands in `~/.sutando/workspace/`
-        # while the rest of the fleet uses the override → split-brain. One
-        # stderr line per process makes the miss visible. We do NOT auto-honor
-        # the .env value here — that's a behavior change and lives in callers
-        # that opt into it (e.g. skills/agent-registry/scripts/_workspace_resolve.py).
-        global _FALLBACK_WARN_PRINTED
-        if not _FALLBACK_WARN_PRINTED:
-            _FALLBACK_WARN_PRINTED = True
-            env_file_val = _grep_env_for_workspace()
-            if env_file_val and env_file_val != str(target):
-                print(
-                    f"workspace: SUTANDO_WORKSPACE is unset in process env, "
-                    f"falling back to {target}. NOTE: .env declares "
-                    f"SUTANDO_WORKSPACE={env_file_val!r} which is NOT being "
-                    f"honored here — `source .env` or export the var before "
-                    f"this process to avoid split-brain with other services.",
-                    file=sys.stderr,
-                )
+    # Delegate the actual resolution to the new loader. Local import keeps
+    # the module-level import graph clean and makes the dependency obvious
+    # at the only call site that needs it. Plain `import` (no `from .`)
+    # because callers typically add `src/` to sys.path and load both modules
+    # as flat top-level (see scripts/*.py for the pattern).
+    import sutando_config  # type: ignore[import-untyped]
+    target = sutando_config.resolve_workspace()
 
     # One-time notice if legacy-state evidence exists, pointing at the
     # explicit CLI (to land in a follow-up PR). Process-local guard so we

--- a/src/workspace_default.ts
+++ b/src/workspace_default.ts
@@ -16,72 +16,36 @@
  *   2. ~/.sutando/workspace/
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { dirname, join, parse } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 
-let _fallbackWarnPrinted = false;
+import { resolveWorkspace as _resolveWorkspaceFromConfig } from './sutando_config.js';
 
 /**
- * Best-effort: read `SUTANDO_WORKSPACE=` from the repo's .env file.
+ * Resolve the workspace directory per the canonical contract.
  *
- * Walks up from this module's resolved path to find the nearest `.env`,
- * then scans for a `SUTANDO_WORKSPACE=` line. Returns the (tilde-expanded)
- * value or undefined on any failure — never throws. Used only to enrich
- * the fallback-warn message below; resolution itself does NOT consume
- * this value, so a user who genuinely wants the default still gets it.
+ * **Delegates to `src/sutando_config.ts::resolveWorkspace`** as of the
+ * M0 cutover. The new loader implements the resolution order:
+ *
+ *   1. $SUTANDO_WORKSPACE env var (legacy escape hatch; warn once)
+ *   2. sutando.config.local.json -> workspace.path (per-clone override)
+ *   3. sutando.config.json -> workspace.path (tracked defaults)
+ *   4. ${REPO_DIR}/workspace baked-in default
+ *
+ * This wrapper is preserved so existing callers don't need code changes
+ * — the export name + signature + return type are unchanged. Behavior
+ * differs in two ways from the pre-cutover version:
+ *
+ *   - Default location is ${REPO_DIR}/workspace (in-repo), not
+ *     ~/.sutando/workspace/. Users with $SUTANDO_WORKSPACE set keep
+ *     their old location with a one-time warning.
+ *   - .env declarations of SUTANDO_WORKSPACE no longer leak into
+ *     resolution when the env var itself is unset. The loader emits
+ *     a one-time stderr warning if .env disagrees with the resolved
+ *     workspace.
  */
-function grepEnvForWorkspace(): string | undefined {
-	try {
-		let cur = fileURLToPath(import.meta.url);
-		for (let i = 0; i < 5; i++) {
-			cur = dirname(cur);
-			if (cur === parse(cur).root) return undefined;
-			const envFile = join(cur, '.env');
-			if (existsSync(envFile)) {
-				for (const line of readFileSync(envFile, 'utf8').split('\n')) {
-					const s = line.trim();
-					if (s.startsWith('SUTANDO_WORKSPACE=')) {
-						let val = s.split('=').slice(1).join('=').trim();
-						if (val.length >= 2 && val[0] === val[val.length - 1] && (val[0] === '"' || val[0] === "'")) {
-							val = val.slice(1, -1);
-						}
-						return val ? val.replace(/^~/, homedir()) : undefined;
-					}
-				}
-				return undefined;
-			}
-		}
-	} catch {
-		// Best-effort; never block resolution on .env probe failures.
-	}
-	return undefined;
-}
-
 export function resolveWorkspace(): string {
-	const env = process.env.SUTANDO_WORKSPACE?.trim();
-	if (env) return env.replace(/^~/, homedir());
-	const fallback = join(homedir(), '.sutando', 'workspace');
-	// Surface the silent-fallback bug class (see PR #1367/#1368): if .env
-	// defines SUTANDO_WORKSPACE but the process never got it (e.g. a service
-	// started outside `bash src/startup.sh`), the caller silently lands in
-	// the default while the rest of the fleet uses the override → split-brain.
-	// One stderr line per process makes the miss visible. We do NOT auto-honor
-	// the .env value here — that's a behavior change and lives in callers
-	// that opt into it (e.g. skills/agent-registry/scripts/_workspace_resolve.py).
-	if (!_fallbackWarnPrinted) {
-		_fallbackWarnPrinted = true;
-		const envFileVal = grepEnvForWorkspace();
-		if (envFileVal && envFileVal !== fallback) {
-			process.stderr.write(
-				`workspace: SUTANDO_WORKSPACE is unset in process env, falling back to ${fallback}. ` +
-				`NOTE: .env declares SUTANDO_WORKSPACE='${envFileVal}' which is NOT being honored here — ` +
-				`source .env or export the var before this process to avoid split-brain with other services.\n`
-			);
-		}
-	}
-	return fallback;
+	return _resolveWorkspaceFromConfig();
 }
 
 /**

--- a/sutando.config.json
+++ b/sutando.config.json
@@ -1,0 +1,29 @@
+{
+  "workspace": {
+    "path": "${REPO_DIR}/workspace"
+  },
+  "vault": {
+    "enabled": false,
+    "remote_url": "",
+    "sync": {
+      "include": [
+        "notes/",
+        "skills/",
+        "tasks/archive/",
+        "state/cores/"
+      ],
+      "exclude": [
+        "tasks/",
+        "results/",
+        "state/core-status.json",
+        "state/quota-state.json",
+        "state/voice-state.json",
+        "voice-state.json",
+        "*.heartbeat",
+        "logs/",
+        "tmp/"
+      ]
+    },
+    "interval_seconds": 1800
+  }
+}

--- a/sutando.config.local.json.example
+++ b/sutando.config.local.json.example
@@ -1,0 +1,21 @@
+{
+  "_comment": "Copy this file to sutando.config.local.json and edit. Everything is optional — omit any field to fall through to the default in sutando.config.json. The .local.json file is gitignored.",
+
+  "workspace": {
+    "_comment": "Override the workspace location. Default is ${REPO_DIR}/workspace (in-repo). Set this only if you want the workspace outside the repo (e.g. on a different volume).",
+    "path": "/absolute/path/to/your/workspace"
+  },
+
+  "vault": {
+    "_comment": "Enable + point at your private remote git repo to sync notes/memory/archives off-host.",
+    "enabled": true,
+    "remote_url": "https://vault.example.com/<your-user>/workspace.git",
+    "_comment_sync": "Override the default include/exclude lists from sutando.config.json if you want a different sync surface on this host.",
+    "sync": {
+      "include": [
+        "notes/",
+        "memory/"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

**Milestone 0** of the workspace-revamp series. Replaces the per-user env-var contract (`$SUTANDO_WORKSPACE` → `~/.sutando/workspace/`) with a config-file contract that defaults to `<repo>/workspace/`.

This PR targets the `staging-workspace-revamp` integration branch. **Subsequent milestones land on the same staging branch.** Once M0–M3 land, a final PR from `staging-workspace-revamp` → `main` will ship the full revamp.

## Milestone roadmap

| Milestone | Branch | Scope |
|---|---|---|
| **M0 (this PR)** | `workspace-revamp-milestone0-structure` | structure + config-driven resolution + protections |
| M1 | (future) | runtime data recovery (audit + move existing user state) |
| M2 | (future) | sync engine (vault — selective sync to private remote) |
| M3 | (future) | comprehensive documentation polish + resolver migration |

End-state goal: a new user clone → run → working Sutando with zero env-var setup; existing users keep working with a one-time deprecation warning + a future recovery skill (M1) to relocate state.

## What lands in M0

**Contract (resolution order, highest wins):**
1. `$SUTANDO_WORKSPACE` env var — **legacy escape hatch**, one-time deprecation warning at startup.
2. `sutando.config.local.json` → `workspace.path` — per-clone override, gitignored.
3. `sutando.config.json` → `workspace.path` — tracked defaults.
4. Baked-in fallback `${REPO_DIR}/workspace`.

**Loaders (byte-for-byte identical across 4 languages):**
- Python — `src/sutando_config.py`
- TypeScript — `src/sutando_config.ts`
- Swift — `src/Sutando/SutandoConfig.swift`
- Bash wrapper — `scripts/sutando-config.sh`

**Cutover (transparent — existing callers unaffected):**
- `src/workspace_default.{py,ts}` now delegate to the loader
- `src/Sutando/main.swift` AppDelegate.workspace uses SutandoConfig
- 7 bash scripts route through the wrapper, retaining the inline legacy default as fallback for non-checkout installs
- `src/startup.sh` exercises the loader at boot (drift warnings + parse errors surface early)

**Protection layers:**
- `.gitignore`: `workspace/*` with `!workspace/.gitkeep` exception
- `.githooks/pre-commit`: refuses commits with `workspace/` content, auto-installed at startup
- `.github/workflows/workspace-leak-check.yml`: CI mirror of the pre-commit hook
- `.github/workflows/lint-workspace-resolution.yml`: refuses NEW code that bypasses the loader (uses `--diff` mode so existing legacy offenders are unaffected)

**Docs:**
- `docs/workspace-config.md`: new operational reference
- `docs/sutando-config.schema.json`: JSON Schema for autocomplete + validation
- `CLAUDE.md`, `CONTRIBUTING.md`, `KNOWN_ISSUES.md`, `docs/memory-sync.md`, `docs/workspace-design.md`, `docs/workspace-contract.md`: updated for in-repo default + config-first framing

## Compatibility

Existing installs with `$SUTANDO_WORKSPACE` set continue to work — the loader honors the value with a one-time deprecation warning naming the migration path. **No flag day.** M1 will ship a recovery skill (`bash scripts/sutando-migrate.sh`) for users who want to move data from the legacy default location into the in-repo workspace.

## Stats

33 files changed, +1745/-211. Touches scripts/loaders/hooks/CI/docs — no test changes (existing tests covered by the workspace_default cutover delegation).

## Test plan

- [ ] Fresh clone (no `.env`, no env var) → `bash src/startup.sh` lands cleanly at `<repo>/workspace/`
- [ ] Existing install with `$SUTANDO_WORKSPACE` set → loader prints legacy-escape-hatch warning once, services keep using the env-pinned path
- [ ] Existing install with `SUTANDO_WORKSPACE` in `.env` (but not shell env) → loader prints drift warning
- [ ] `git add -f workspace/test.txt && git commit` → pre-commit hook refuses
- [ ] PR diff includes `workspace/foo.txt` → CI workspace-leak-check fails
- [ ] PR diff introduces `os.environ.get("SUTANDO_WORKSPACE")` outside the loader → CI lint-workspace-resolution fails
- [ ] `python3 -m src.sutando_config` smoke-runs the loader CLI
- [ ] `bash scripts/sutando-config.sh workspace` prints the resolved path
- [ ] Swift app rebuilds via `swiftc main.swift SutandoConfig.swift -framework ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)