### PR TITLE
feat(workspace): M1 Part 2 — workspace migration script + skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,16 @@ cleaner liveness probe than scanning `pgrep -f claude`.
 
 ## Durable per-host install state: `state/auth/`
 
+## Migration transition window (30-day reader-fallback)
+
+After `bash scripts/sutando-migrate.sh commit` lands, sources are preserved by default (per `feedback_workspace_m1_no_auto_commit`). The script's footer prints the phase-2 cleanup step, but the actual transition policy is: **readers should prefer the new canonical location first AND fall back to the legacy location for ~30 days**, emitting a one-line stderr deprecation warning when the fallback fires. This bridges the gap until any straggler writers (Sutando.app's Swift, backup tools, or in-flight services that hold pre-M0 fd's) have updated to the new path.
+
+After 30 days of observing zero source-side writes (visible by mtime check on the legacy paths), the cleanup is safe: `bash scripts/sutando-migrate.sh commit --delete-source --backup-id <id-from-phase-1>`. The legacy-state-detected nag in `health-check.py` + `init.sh` only clears once the cleanup runs.
+
+The reader-side fallback code is implemented in writers/readers separately — sibling PR scope, not part of the migration script itself.
+
+## Durable per-host install state: `state/auth/`
+
 `<workspace>/state/auth/` holds **per-host install/identity state**
 that survives across upgrades and MUST NOT be wiped by transient-state cleanup
 jobs (or by clear-on-restart logic that targets `state/*.json` generically).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Skill-PR destination: a skill is **coupled** (PR to `sonichi/sutando`) if it imp
 
 ## Workspace contract
 
-Sutando's file state lives in three concentric spaces — **Code** (`$SUTANDO_REPO_DIR`, the git checkout), **State** (`$SUTANDO_WORKSPACE`, per-user runtime), **Memory** (`$SUTANDO_MEMORY_DIR`, user-content synced across the fleet — legacy alias `$SUTANDO_PRIVATE_DIR` honored for one release per #870). See [`docs/workspace-design.md`](docs/workspace-design.md) for the 3-space mental model + "Quick decision: which space?" flowchart when adding new code or data.
+Sutando's file state lives in two concentric spaces (with the repo as the inferred container): **State** (the workspace — resolved via `bash scripts/sutando-config.sh workspace`; default `<repo>/workspace/`) and **Memory** (`$SUTANDO_MEMORY_DIR`, user-content synced across the fleet — legacy alias `$SUTANDO_PRIVATE_DIR` honored for one release per #870). The code itself (`<repo>/src/`, `<repo>/scripts/`, `<repo>/skills/`) is just "where this checkout is" — inferred, not configured. See [`docs/workspace-design.md`](docs/workspace-design.md) for the mental model + "Quick decision: which space?" flowchart when adding new code or data.
 
 All per-user mutable state — `tasks/`, `results/`, `state/`, `data/`, `logs/`, `notes/`, `build_log.md`, `pending-questions.md`, etc. — lives under a single **workspace** directory. Loose status/state `.json` files (`core-status.json`, `voice-state.json`, `contextual-chips.json`, `dynamic-content.json`, `quota-state.json`) live under `state/`; the workspace root holds only the top-level directories. Code, skills source, and repo configuration stay in the repo root (separate concern).
 
@@ -73,7 +73,7 @@ If `PERSONAL_CLAUDE.md` exists in the workspace root, read and follow it. It con
 
 ## Work Status
 
-Signal your work status to the workspace `core-status.json` so the web UI and `health-check.py` can display it. Write the **absolute** workspace path: the session cwd is the repo, so a bare `state/core-status.json` lands in `<repo>/state/` — where no reader looks. Readers resolve `$SUTANDO_WORKSPACE/state/core-status.json` via `status_read_path` (`src/workspace_default.py`).
+Signal your work status to the workspace `core-status.json` so the web UI and `health-check.py` can display it. Write the **absolute** workspace path: the session cwd is the repo, so a bare `state/core-status.json` lands in `<repo>/state/` — where no reader looks. Readers resolve `<workspace>/state/core-status.json` via `status_read_path` (`src/workspace_default.py`), where `<workspace>` = the M0 canonical (`<repo>/workspace/` by default; env-overridable as the legacy escape).
 
 ```bash
 CORE_STATUS="$(bash scripts/sutando-config.sh workspace)/state/core-status.json"
@@ -120,7 +120,7 @@ This ensures the dashboard, result-watcher, and timeout logic work the same rega
 
 ## Core liveness signal
 
-Each running sutando-core writes `$SUTANDO_WORKSPACE/state/cores/<hostname>.alive`
+Each running sutando-core writes `<workspace>/state/cores/<hostname>.alive`
 every 30 seconds (started by `src/startup.sh` as a background process; source
 at `src/core_heartbeat.py`). The file is per-host so multiple cores on
 different machines coexist; mtime is the cross-host "is this core alive?"
@@ -136,6 +136,22 @@ This is foundation for the lease-based multi-core scheduler — workers consult
 the alive directory to know who's available before assigning a claim. For
 single-machine use today it also gives `health-check.py` and the dashboard a
 cleaner liveness probe than scanning `pgrep -f claude`.
+
+## Durable per-host install state: `state/auth/`
+
+`<workspace>/state/auth/` holds **per-host install/identity state**
+that survives across upgrades and MUST NOT be wiped by transient-state cleanup
+jobs (or by clear-on-restart logic that targets `state/*.json` generically).
+Current contents:
+- `cloud-auth.json` — per-host cloud-side auth credentials
+- `device.json` — per-host device identity (UUID + provisioning metadata)
+
+Both are placed via M1 Part 2 (`scripts/sutando-migrate.sh`); pre-M1 they
+were loose at workspace root, mistreated as transient JSON snapshots and
+sometimes wiped. Treat `state/auth/` like `state/cores/<hostname>.alive` —
+per-host, structural, never overwritten by newest-mtime resolution across
+sources. Codex + Mini confirmed the destination + the exemption from cleanup
+in #design 2026-06-02.
 
 ## Memory
 

--- a/scripts/lint-workspace-resolution.sh
+++ b/scripts/lint-workspace-resolution.sh
@@ -50,7 +50,7 @@ PATTERN_REPO_WALK='Path\(__file__\)\.resolve\(\)\.parent\.parent'
 # branch when the wrapper script isn't reachable (e.g. non-checkout
 # installs). The fallback path is documented in each script's comments;
 # new contributors should still go through the wrapper.
-ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/startup\.sh|src/watch-tasks-stream\.sh|scripts/lint-workspace-resolution\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sweep-stranded-claims\.sh|skills/catchup-after-startup/scripts/catchup-after-startup\.sh|skills/overlay-apps/scripts/launch\.sh|skills/self-diagnose/scripts/gather\.sh|tests/[^/]+\.(test\.)?(py|ts))$'
+ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/startup\.sh|src/watch-tasks-stream\.sh|scripts/lint-workspace-resolution\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|skills/catchup-after-startup/scripts/catchup-after-startup\.sh|skills/overlay-apps/scripts/launch\.sh|skills/self-diagnose/scripts/gather\.sh|tests/[^/]+\.(test\.)?(py|ts))$'
 
 # Pick which files to scan.
 if [[ "$mode" == "--diff" ]]; then

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -11,6 +11,14 @@
 #   bash scripts/sutando-config.sh vault-enabled # print "true" or "false"
 #   bash scripts/sutando-config.sh vault-url     # print vault remote_url (may be empty)
 #   bash scripts/sutando-config.sh dump          # print full merged config as JSON
+#   bash scripts/sutando-config.sh subdirs       # print canonical workspace subdir list (one per line)
+#   bash scripts/sutando-config.sh bootstrap     # mkdir -p the canonical subdirs in the resolved workspace
+#
+# `bootstrap` is the idempotent setup step for the in-repo workspace introduced
+# in M0 (PR #1395). startup.sh runs this transitively via init.sh --auto, but
+# any context that doesn't go through startup.sh (e.g. a workspace path change
+# without service restart, a fresh clone where the user pokes at workspace/
+# directly) can call this to ensure the canonical layout exists.
 #
 # Stdout is the value (no trailing newline for scalar getters); stderr
 # carries any warnings from the loader (legacy env, .env drift). Returns
@@ -61,8 +69,30 @@ print(resolve_vault().get('remote_url', ''), end='')
     python3 -m src.sutando_config
     ;;
 
+  subdirs)
+    # Canonical workspace subdir list. Single source of truth — keep in sync
+    # with src/init.sh tier1's create_dir_if_missing calls AND with
+    # docs/workspace-config.md's layout section. If you add a subdir here,
+    # also document it (and consider whether init.sh / sutando-migrate.sh
+    # need to mention it).
+    printf 'state\ntasks\nresults\nresults/archive\nresults/calls\nnotes\nlogs\ndata\nconfig\ntelegram-inbox\n'
+    ;;
+
+  bootstrap)
+    # Resolve workspace, then mkdir -p the canonical subdirs. Idempotent.
+    # M1 (post-M0): ensures the in-repo workspace has the expected layout
+    # for any path resolved by the loader, regardless of whether startup.sh
+    # / init.sh have run since the path was set.
+    ws="$(bash "$0" workspace)"
+    if [ -z "$ws" ]; then echo "bootstrap: workspace path empty — config error" >&2; exit 1; fi
+    bash "$0" subdirs | while IFS= read -r d; do
+      mkdir -p "$ws/$d"
+    done
+    echo "workspace bootstrapped: $ws" >&2
+    ;;
+
   *)
-    echo "usage: $0 {workspace|vault-enabled|vault-url|dump}" >&2
+    echo "usage: $0 {workspace|vault-enabled|vault-url|dump|subdirs|bootstrap}" >&2
     exit 2
     ;;
 esac

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -624,12 +624,18 @@ banner "sources detected:"
 [ -n "$B_REAL_OK" ] && banner "  B (~/.sutando/workspace/):     $B_REAL_OK"
 [ -n "$C_REAL_OK" ] && banner "  C (SUTANDO_WORKSPACE env):     $C_REAL_OK"
 [ -z "$A_REAL_OK$B_REAL_OK$C_REAL_OK" ] && {
-    if [ "$JSON" = "1" ]; then
-        echo '{"dest":"'"$DEST_REAL"'","sources":{},"totals":{"unique_relpaths":0,"collisions":0,"identical_content":0,"genuine_conflicts":0,"by_class":{}},"notable_collisions":[]}'
-    else
-        echo "  (none — nothing to migrate; dest=$DEST_REAL is the only locus)"
-    fi
-    exit 0
+    # Rollback and verify don't need sources — they operate on dest alone.
+    case "$MODE" in
+        rollback|verify) ;;
+        *)
+            if [ "$JSON" = "1" ]; then
+                echo '{"dest":"'"$DEST_REAL"'","sources":{},"totals":{"unique_relpaths":0,"collisions":0,"identical_content":0,"genuine_conflicts":0,"by_class":{}},"notable_collisions":[]}'
+            else
+                echo "  (none — nothing to migrate; dest=$DEST_REAL is the only locus)"
+            fi
+            exit 0
+            ;;
+    esac
 }
 banner ""
 
@@ -743,7 +749,11 @@ report_cross_source() {
 BACKUP_ID=""
 
 backup_dest() {
-    BACKUP_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+    # Per-second ts collision possible when two commits happen in same second
+    # (test idempotency re-run + initial commit are the typical case). Append
+    # PID + random so each backup_dest call gets a unique BACKUP_ID. Without
+    # this, the second commit's tar would overwrite the first AND include it.
+    BACKUP_ID="$(date -u +%Y%m%dT%H%M%SZ)-p$$r$RANDOM"
     local backup_path="$DEST_REAL/state/migration-backup-$BACKUP_ID.tar.gz"
     mkdir -p "$DEST_REAL/state"
     # Backup only the workspace surface (avoid backing up the backup-in-progress).
@@ -756,7 +766,18 @@ backup_dest() {
         [ -e "$DEST_REAL/$sf" ] && surface+=("$sf")
     done
     if [ ${#surface[@]} -gt 0 ]; then
-        ( cd "$DEST_REAL" && tar -czf "$backup_path" "${surface[@]}" 2>/dev/null )
+        [ "${SUTANDO_MIGRATE_DEBUG:-0}" = "1" ] && echo "[debug] backup_dest surface: ${surface[*]}" >&2
+        # Tar to a system temp location (OUTSIDE dest/state/) to avoid the
+        # self-reference where tarring state/ also includes the partial
+        # backup tarball being written. Move atomically into state/ at end.
+        # Mini's intermittent test-failure trail led to this — exclude didn't
+        # work reliably across BSD/GNU tar.
+        local tmp_backup
+        tmp_backup="$(mktemp -t sutando-mig-backup.XXXXXX).tar.gz"
+        ( cd "$DEST_REAL" && tar -czf "$tmp_backup" "${surface[@]}" 2>/dev/null )
+        # Now delete the migration-backup-*.tar.gz entries from the tar so
+        # restoring doesn't repopulate them. Easier: just mv to final spot.
+        mv "$tmp_backup" "$backup_path"
         echo "sutando-migrate: backup → $backup_path"
     else
         # Empty dest — write an empty marker so rollback still has a known id
@@ -821,12 +842,15 @@ commit_one() {
                 fi
                 # Genuine collision: write loser as sidecar, keep dest as primary
                 # only if dest is newer. If src is newer, swap.
-                # Per Mini #design 2026-06-02 blocker #3: 3-way collisions
-                # overwrite the .legacy-DEST sidecar when a 3rd source replaces
-                # dest. Use timestamped + source-tagged sidecar names so each
-                # collision is preserved uniquely.
+                # Per Mini #design 2026-06-02 blocker #3 + flaky-test re-fix:
+                # uniqueness needs both per-second timestamp AND a serial counter
+                # (`date +%s` resolution is too coarse when commit_one fires
+                # multiple times within same second across sources).
+                # SIDECAR_SERIAL counter would live in subshell because
+                # commit_one's echo is captured via $(); use $RANDOM (per-call
+                # entropy from /dev/urandom-seeded bash PRNG) + $$ (pid) instead.
                 local ts_suffix
-                ts_suffix="$(date -u +%Y%m%dT%H%M%SZ)"
+                ts_suffix="$(date -u +%Y%m%dT%H%M%SZ)-p$$r$RANDOM"
                 if [ "$src_mt" -gt "$dst_mt" ]; then
                     # dest's content (whatever was there) goes to a sidecar.
                     # Name it .legacy-prior-<src_tag>-<ts> to convey "this is
@@ -988,14 +1012,27 @@ commit_one() {
 
 commit_source() {
     local tag="$1" src="$2"
+    local SENTINEL_PRESENT=0
+    any_source_sentinel "$tag" && SENTINEL_PRESENT=1
 
-    if any_source_sentinel "$tag" && [ "$FORCE" = "0" ] && [ "$DELETE_SOURCE" = "0" ]; then
-        echo "sutando-migrate: source $tag has prior migration sentinel — skip (use --force)"
-        return 0
+    # Mini #design 2026-06-02 new blocker #2: --delete-source must NOT re-run
+    # the commit walk when a sentinel exists (would duplicate appends + extra
+    # sidecars). Two-phase pattern: phase 1 does commit walk + writes sentinel;
+    # phase 2 (--delete-source --backup-id) skips commit walk + only does the
+    # delete walk against the existing dest landing.
+    local DO_COMMIT_WALK=1
+    if [ "$SENTINEL_PRESENT" = "1" ] && [ "$FORCE" = "0" ]; then
+        if [ "$DELETE_SOURCE" = "1" ]; then
+            DO_COMMIT_WALK=0  # phase 2 mode: skip commit, just delete
+            echo "--- Phase 2: --delete-source against source $tag (sentinel present; skip commit walk) ---"
+        else
+            echo "sutando-migrate: source $tag has prior migration sentinel — skip (use --force)"
+            return 0
+        fi
     fi
 
     echo
-    echo "--- Committing source $tag ($src) ---"
+    [ "$DO_COMMIT_WALK" = "1" ] && echo "--- Committing source $tag ($src) ---"
 
     # Reuse the same walk-list logic as scan_source (including B+C quarantine).
     local -a walk_paths=()
@@ -1031,6 +1068,11 @@ commit_source() {
     [ ${#walk_paths[@]} -eq 0 ] && { echo "  (nothing on surface; skip)"; return 0; }
 
     local n_copied=0 n_kept=0 n_skipped=0 n_sidecar=0 n_rehomed=0 n_identical=0 n_quarantined=0 n_other=0
+    # Phase 2 mode skips the commit walk entirely.
+    if [ "$DO_COMMIT_WALK" = "0" ]; then
+        # Skip ahead to the delete block (it walks walk_paths independently).
+        :
+    else
     local file rel cls outcome
     while IFS= read -r -d '' file; do
         rel="${file#"$src"/}"
@@ -1039,6 +1081,21 @@ commit_source() {
             state/migration-backup-*.tar.gz) continue ;;
             .DS_Store|*/.DS_Store|.gitkeep|*/.gitkeep) n_skipped=$((n_skipped+1)); continue ;;
         esac
+        # Mini #design 2026-06-02 new-blocker #4: recursive quarantine excludes.
+        # A custom dir like experiments/node_modules/ should be skipped even
+        # though experiments/ matched the quarantine catchall at top level.
+        # Walk rel segments and skip if ANY matches QUARANTINE_EXCLUDES.
+        local _skip_recursive=0
+        local _seg
+        IFS='/' read -ra _segs <<<"$rel"
+        for _seg in "${_segs[@]}"; do
+            for _ex in "${QUARANTINE_EXCLUDES[@]}"; do
+                [ "$_seg" = "$_ex" ] && { _skip_recursive=1; break 2; }
+            done
+        done
+        if [ "$_skip_recursive" = "1" ]; then
+            n_skipped=$((n_skipped+1)); continue
+        fi
         cls="$(classify "$rel")"
         outcome="$(commit_one "$file" "$rel" "$tag" "$cls")"
         case "$outcome" in
@@ -1059,16 +1116,19 @@ commit_source() {
         esac
     done < <(find "${walk_paths[@]}" -type f -print0 2>/dev/null)
 
-    echo "  copied:      $n_copied"
-    echo "  identical:   $n_identical (drop-dup, no real conflict)"
-    echo "  kept-dest:   $n_kept"
-    echo "  sidecar:     $n_sidecar"
-    [ "$n_quarantined" -gt 0 ] && echo "  quarantined: $n_quarantined (to <dest>/legacy/$tag/quarantine/)"
-    echo "  skipped:     $n_skipped"
-    [ "$n_other" -gt 0 ] && echo "  other:       $n_other"
+    fi  # DO_COMMIT_WALK guard
+    if [ "$DO_COMMIT_WALK" = "1" ]; then
+        echo "  copied:      $n_copied"
+        echo "  identical:   $n_identical (drop-dup, no real conflict)"
+        echo "  kept-dest:   $n_kept"
+        echo "  sidecar:     $n_sidecar"
+        [ "$n_quarantined" -gt 0 ] && echo "  quarantined: $n_quarantined (to <dest>/legacy/$tag/quarantine/)"
+        echo "  skipped:     $n_skipped"
+        [ "$n_other" -gt 0 ] && echo "  other:       $n_other"
 
-    touch "$(source_sentinel "$tag")"
-    echo "  sentinel:    $(source_sentinel "$tag")"
+        touch "$(source_sentinel "$tag")"
+        echo "  sentinel:    $(source_sentinel "$tag")"
+    fi
 
     # Per Mini #design 2026-06-02 blocker #4: --delete-source must actually
     # delete sources after sha verification. The two-phase pattern means
@@ -1088,8 +1148,11 @@ commit_source() {
             local cls_d
             cls_d="$(classify "$rel_d")"
             # In-flight + ephemeral classes were never copied; don't delete.
+            # Per Mini new-blocker #3: quarantine IS copied (to
+            # <dest>/legacy/<tag>/quarantine/<rel>) — must be considered
+            # for sha-verified deletion alongside other classes.
             case "$cls_d" in
-                skip-ephemeral|skip-unknown|inflight-guard|quarantine-unknown)
+                skip-ephemeral|skip-unknown|inflight-guard)
                     continue ;;
             esac
             # Find any dest landing whose content matches.
@@ -1102,10 +1165,12 @@ commit_source() {
                     matched="$cand"; break
                 fi
             done
-            # Also check timestamped sidecar globs at canonical-rel.
+            # Per Mini new-blocker #1: any legacy-* sidecar (any tag) might
+            # hold this source's content (dest-prior naming uses overwriting
+            # source's tag, not original). Walk all and sha-compare.
             if [ -z "$matched" ]; then
                 local g
-                for g in "$DEST_REAL/$rel_d.legacy-$tag-"* "$DEST_REAL/$rel_d.legacy-prior-from-$tag-"*; do
+                for g in "$DEST_REAL/$rel_d.legacy-"*; do
                     if [ -f "$g" ] && sha_match "$file" "$g"; then
                         matched="$g"; break
                     fi
@@ -1199,12 +1264,13 @@ verify_main() {
     while IFS=$'\t' read -r rel tag cls mt sz; do
         [ "$tag" = "DEST" ] && continue
         case "$cls" in
-            skip-ephemeral|skip-unknown|inflight-guard|quarantine-unknown)
-                # These classes intentionally don't land at a stable dest path;
-                # in-flight-guard is age-dependent; quarantine is content-preserved
-                # under legacy/<tag>/quarantine/ which we verify separately below.
+            skip-ephemeral|skip-unknown|inflight-guard)
                 pass=$((pass+1)); continue ;;
         esac
+        # Per Mini #design 2026-06-02 new-blocker #3: quarantine MUST be
+        # sha-verified at its dest landing, not pass-no-check. The walk below
+        # checks dst_quarantine (=$DEST_REAL/legacy/$tag/quarantine/$rel) via
+        # the standard cands loop.
         local src_root
         src_root="$(src_path_for_tag "$tag")"
         [ -z "$src_root" ] && { pass=$((pass+1)); continue; }
@@ -1219,15 +1285,19 @@ verify_main() {
         local dst_canonical="$DEST_REAL/$rel"
         local dst_sidecar_legacy="$DEST_REAL/legacy/$tag/$rel"
         local dst_quarantine="$DEST_REAL/legacy/$tag/quarantine/$rel"
-        # Per Mini #3 fix: timestamped+tagged sidecars at <path>.legacy-<tag>-<ts>
-        # or <path>.legacy-prior-from-<tag>-<ts>. Use a glob to match any.
+        # Per Mini #design 2026-06-02 new-blocker #1: dest-prior sidecars are
+        # named after the OVERWRITING source, not the original-content source.
+        # E.g. C's content might be at <path>.legacy-prior-from-A-<ts> (because
+        # A overwrote it). Looking only at legacy-$tag-* / legacy-prior-from-$tag-*
+        # for source C would miss C's content there. Walk ALL legacy-*-* sidecars
+        # and sha-compare to find the source's content regardless of tag.
         local landed=""
         local cands=()
         for c in "$dst_canonical" "$dst_sidecar_legacy" "$dst_quarantine"; do
             cands+=("$c")
         done
-        # Expand timestamped-sidecar globs for both src-loser and dest-prior cases.
-        for g in "$dst_canonical.legacy-$tag-"* "$dst_canonical.legacy-prior-from-$tag-"*; do
+        # All possible legacy-* sidecars at canonical-rel (any source tag).
+        for g in "$dst_canonical.legacy-"*; do
             [ -f "$g" ] && cands+=("$g")
         done
         for cand in "${cands[@]}"; do
@@ -1258,6 +1328,9 @@ verify_main() {
 }
 
 rollback_main() {
+    # Disable set -e for rollback's cleanup walks — they tolerate per-file
+    # failures (rm of non-existent files, grep no-match, tar of empty).
+    set +e
     [ -z "$ROLLBACK_ID" ] && {
         echo "rollback: --backup-id <id> required. Available backups:" >&2
         ls -1 "$DEST_REAL/state/migration-backup-"*.tar.gz 2>/dev/null | sed -E 's@.*migration-backup-(.+)\.tar\.gz@  \1@' >&2
@@ -1269,35 +1342,51 @@ rollback_main() {
         exit 2
     }
     echo "sutando-migrate: ROLLBACK from $backup_path"
-    # Clear sentinels for that backup id (idempotency)
-    rm -f "$DEST_REAL/state/.migrated-from-"*"-$ROLLBACK_ID" 2>/dev/null
+    # Clear sentinels for that backup id (idempotency).
+    # Note: glob may match zero files; suppress set -e via || true.
+    rm -f "$DEST_REAL/state/.migrated-from-"*"-$ROLLBACK_ID" 2>/dev/null || true
     # Untar into dest. BSD tar (macOS) overwrites by default; GNU tar (Linux)
     # also overwrites by default. Workspace surface only — never touches
     # state/migration-backup-*.tar.gz files (they're outside the tar).
-    ( cd "$DEST_REAL" && tar -xzf "$backup_path" ) || {
-        echo "rollback: extract failed" >&2
-        exit 1
-    }
+    # Empty backup (0-byte) means dest was empty at backup time; skip extract +
+    # rely solely on the cleanup walk below to restore to empty state.
+    if [ -s "$backup_path" ]; then
+        ( cd "$DEST_REAL" && tar -xzf "$backup_path" ) || {
+            echo "rollback: extract failed" >&2
+            exit 1
+        }
+    else
+        echo "rollback: empty backup (dest was bootstrap-only at backup time); skipping extract"
+    fi
     # Clean files added since backup that are NOT in the backup tarball.
     # Read tarball entries → reference set → find dest's surface files not in set → delete.
     local tar_listing
     tar_listing="$(mktemp -t sutando-rollback.XXXXXX)"
-    tar -tzf "$backup_path" 2>/dev/null > "$tar_listing"
-    local sd; for sd in "${WORKSPACE_SURFACE_DIRS[@]}" "${WORKSPACE_SURFACE_FILES[@]}"; do
+    if [ -s "$backup_path" ]; then
+        tar -tzf "$backup_path" 2>/dev/null > "$tar_listing" || true
+    else
+        : > "$tar_listing"  # empty backup: nothing to preserve, everything is "added since"
+    fi
+    [ "${SUTANDO_MIGRATE_DEBUG:-0}" = "1" ] && echo "[debug] tar_listing size=$(wc -l < "$tar_listing") backup_path size=$(stat -f %z "$backup_path")" >&2
+    local sd
+    [ "${SUTANDO_MIGRATE_DEBUG:-0}" = "1" ] && echo "[debug] rollback walk: DEST_REAL=$DEST_REAL" >&2
+    for sd in "${WORKSPACE_SURFACE_DIRS[@]}" "${WORKSPACE_SURFACE_FILES[@]}"; do
         [ ! -e "$DEST_REAL/$sd" ] && continue
-        find "$DEST_REAL/$sd" -type f 2>/dev/null | while IFS= read -r f; do
+        [ "${SUTANDO_MIGRATE_DEBUG:-0}" = "1" ] && echo "[debug] rollback walking $DEST_REAL/$sd" >&2
+        while IFS= read -r f; do
             local rel="${f#"$DEST_REAL"/}"
             # If this rel is NOT in the tar listing, it was added after backup → remove
             if ! grep -q "^${rel}$" "$tar_listing" 2>/dev/null; then
+                [ "${SUTANDO_MIGRATE_DEBUG:-0}" = "1" ] && echo "[debug] rollback rm $rel" >&2
                 rm -f "$f"
             fi
-        done
+        done < <(find "$DEST_REAL/$sd" -type f 2>/dev/null)
     done
-    rm -f "$tar_listing"
+    rm -f "$tar_listing" || true
     # Drop sentinels matching this backup id
-    rm -f "$DEST_REAL/state/.migrated-from-"*"-$ROLLBACK_ID" 2>/dev/null
+    rm -f "$DEST_REAL/state/.migrated-from-"*"-$ROLLBACK_ID" 2>/dev/null || true
     # Drop legacy/<src-tag>/ sidecars (only the script ever writes there)
-    rm -rf "$DEST_REAL/legacy" 2>/dev/null
+    rm -rf "$DEST_REAL/legacy" 2>/dev/null || true
     echo "rollback: OK — dest restored to backup $ROLLBACK_ID"
 }
 

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -91,6 +91,20 @@ WORKSPACE_SURFACE_DIRS=(
     "email-drafts"
     "agent-inbox"
 )
+
+# Per `feedback_per_source_surface_lists` 2026-06-02: dirs in Mini's #7
+# defensive set that EXIST at the sutando repo root as CODE (not workspace
+# data). Source A walks must SKIP these — otherwise migration would treat
+# `<repo>/docs/`, `<repo>/agents/`, etc. as workspace surface, migrate them
+# into `<workspace>/`, and `--delete-source` would delete the repo's own
+# documentation. Caught after owner's repo-root cleanup wiped `<repo>/docs/`
+# (recovered via git checkout HEAD -- docs/).
+SOURCE_A_EXCLUDE=(
+    "agents"
+    "docs"
+    "email-drafts"
+    "agent-inbox"
+)
 WORKSPACE_SURFACE_FILES=(
     "build_log.md"
     "conversation.log"
@@ -383,8 +397,18 @@ scan_source() {
     # roots; user-custom content like experiments/ obsidian-vault/ should be
     # quarantined per Lucy #design + owner direction 2026-06-02).
     local -a walk_paths=()
-    local sd sf
+    local sd sf _ex_a
     for sd in "${WORKSPACE_SURFACE_DIRS[@]}"; do
+        # Per feedback_per_source_surface_lists: Source A is the sutando
+        # repo, not a workspace. Skip dirs in SOURCE_A_EXCLUDE so we don't
+        # migrate repo code (e.g. <repo>/docs/) as workspace surface.
+        if [ "$tag" = "A" ]; then
+            local _skip_a=0
+            for _ex_a in "${SOURCE_A_EXCLUDE[@]}"; do
+                [ "$sd" = "$_ex_a" ] && _skip_a=1 && break
+            done
+            [ "$_skip_a" = "1" ] && continue
+        fi
         [ -d "$src/$sd" ] && walk_paths+=("$src/$sd")
     done
     for sf in "${WORKSPACE_SURFACE_FILES[@]}"; do
@@ -1036,8 +1060,18 @@ commit_source() {
 
     # Reuse the same walk-list logic as scan_source (including B+C quarantine).
     local -a walk_paths=()
-    local sd sf
+    local sd sf _ex_a
     for sd in "${WORKSPACE_SURFACE_DIRS[@]}"; do
+        # Per feedback_per_source_surface_lists: Source A is the sutando
+        # repo, not a workspace. Skip dirs in SOURCE_A_EXCLUDE so we don't
+        # migrate repo code (e.g. <repo>/docs/) as workspace surface.
+        if [ "$tag" = "A" ]; then
+            local _skip_a=0
+            for _ex_a in "${SOURCE_A_EXCLUDE[@]}"; do
+                [ "$sd" = "$_ex_a" ] && _skip_a=1 && break
+            done
+            [ "$_skip_a" = "1" ] && continue
+        fi
         [ -d "$src/$sd" ] && walk_paths+=("$src/$sd")
     done
     for sf in "${WORKSPACE_SURFACE_FILES[@]}"; do

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -398,11 +398,20 @@ scan_source() {
     # quarantined per Lucy #design + owner direction 2026-06-02).
     local -a walk_paths=()
     local sd sf _ex_a
+    # Per feedback_per_source_surface_lists 2026-06-02: detect whether THIS
+    # source path IS a sutando repo checkout (by content, not by tag) — if
+    # so, skip dirs that exist as repo code rather than workspace data
+    # (docs/, agents/, etc.). Detection: presence of `src/sutando_config.py`
+    # (or the same-shape sutando-config.sh) at source root. Owner clarified
+    # 2026-06-02 07:29: "We should only EXCLUDE them when they are in the
+    # sutando repo root." A custom workspace path that happens to live
+    # inside a sutando checkout should ALSO get the exclude.
+    local IS_SUTANDO_REPO=0
+    if [ -f "$src/src/sutando_config.py" ] || [ -f "$src/scripts/sutando-config.sh" ]; then
+        IS_SUTANDO_REPO=1
+    fi
     for sd in "${WORKSPACE_SURFACE_DIRS[@]}"; do
-        # Per feedback_per_source_surface_lists: Source A is the sutando
-        # repo, not a workspace. Skip dirs in SOURCE_A_EXCLUDE so we don't
-        # migrate repo code (e.g. <repo>/docs/) as workspace surface.
-        if [ "$tag" = "A" ]; then
+        if [ "$IS_SUTANDO_REPO" = "1" ]; then
             local _skip_a=0
             for _ex_a in "${SOURCE_A_EXCLUDE[@]}"; do
                 [ "$sd" = "$_ex_a" ] && _skip_a=1 && break
@@ -1061,11 +1070,20 @@ commit_source() {
     # Reuse the same walk-list logic as scan_source (including B+C quarantine).
     local -a walk_paths=()
     local sd sf _ex_a
+    # Per feedback_per_source_surface_lists 2026-06-02: detect whether THIS
+    # source path IS a sutando repo checkout (by content, not by tag) — if
+    # so, skip dirs that exist as repo code rather than workspace data
+    # (docs/, agents/, etc.). Detection: presence of `src/sutando_config.py`
+    # (or the same-shape sutando-config.sh) at source root. Owner clarified
+    # 2026-06-02 07:29: "We should only EXCLUDE them when they are in the
+    # sutando repo root." A custom workspace path that happens to live
+    # inside a sutando checkout should ALSO get the exclude.
+    local IS_SUTANDO_REPO=0
+    if [ -f "$src/src/sutando_config.py" ] || [ -f "$src/scripts/sutando-config.sh" ]; then
+        IS_SUTANDO_REPO=1
+    fi
     for sd in "${WORKSPACE_SURFACE_DIRS[@]}"; do
-        # Per feedback_per_source_surface_lists: Source A is the sutando
-        # repo, not a workspace. Skip dirs in SOURCE_A_EXCLUDE so we don't
-        # migrate repo code (e.g. <repo>/docs/) as workspace surface.
-        if [ "$tag" = "A" ]; then
+        if [ "$IS_SUTANDO_REPO" = "1" ]; then
             local _skip_a=0
             for _ex_a in "${SOURCE_A_EXCLUDE[@]}"; do
                 [ "$sd" = "$_ex_a" ] && _skip_a=1 && break

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1,0 +1,1224 @@
+#!/usr/bin/env bash
+# sutando-migrate.sh — M1 Part 2 recovery / migration CLI
+#
+# Migrates per-user workspace state from legacy locations to the canonical M0
+# in-repo workspace (<repo>/workspace/ by default; honors sutando.config.local.json
+# and $SUTANDO_WORKSPACE legacy env override).
+#
+# Sources auto-detected (any subset may be present):
+#   A  <repo>/                                — pre-M0 repo-root writes (notes/, state/,
+#                                                results/, tasks/, logs/, data/, build_log.md,
+#                                                conversation.log, pending-questions.md,
+#                                                session-state.md, context-drop.txt)
+#   B  ~/.sutando/workspace/                  — pre-M0 default fallback
+#   C  $SUTANDO_WORKSPACE  (env / .env)       — custom override (commonly the
+#                                                managed-sync workspace dir)
+#
+# Per-class action (file-class → strategy):
+#   structural-copy      notes/, data/, logs/, results/archive/, results/calls/,
+#                        config/, slack-inbox/, telegram-inbox/, tasks/archive/
+#   collision/keep-both  notes/*.md, data/* user files
+#   newest-mtime-wins    state/*.json snapshots, pending-questions.md,
+#                        session-state.md
+#   append-merge OR      build_log.md, conversation.log, context-drop.txt
+#     sidecar (default)
+#   re-home              loose root *.json (cloud-auth, device, contextual-chips,
+#                        voice-state, core-status) → <dest>/state/
+#   skip-ephemeral       *.alive, tasks/task-*.txt + results/task-*.txt <60s old,
+#                        migration-backup-*.tar.gz, .gitkeep, .DS_Store
+#   skip-vcs             .git/  (handled by separate sync-rehome script if
+#                        sync is in use; otherwise orphaned in source)
+#
+# Modes:
+#   scan      (default) — read-only audit; print per-source per-class action; exits 0
+#   commit    — actually do it (rsync -a + per-class strategy; backup first)
+#   verify    — post-migration: source-empty + dest-complete + hash match
+#   rollback  — restore <dest> from a prior migration-backup tarball
+#
+# Safety guarantees (per `feedback_design_quality`):
+#   - Idempotent at every phase; re-runnable after partial failure
+#   - Atomic per-file: rsync → sha256 verify → mark source-migrated → only then delete source (if --delete)
+#   - Backup <dest> to <dest>/state/migration-backup-<ts>.tar.gz before any commit-mode write
+#   - Refuses if realpath(dest) == realpath(any source)
+#   - Refuses to follow source symlinks (the #1149 footgun)
+#   - In-flight protection: tasks/*.txt + results/*.txt newer than $INFLIGHT_GUARD_SEC are skipped+warned
+#   - Loud failure on partial state (set -euo pipefail); no silent fallbacks
+#
+# Honors `feedback_workspace_m1_no_auto_commit`: this script mutates workspace
+# DATA but never runs `git commit` against any source/dest repo. The
+# sync-workspace.sh re-route is a separate concern (see sutando-plus's
+# sutando-migrate-sync.sh).
+#
+# Usage:
+#   bash scripts/sutando-migrate.sh                       # scan (dry-run)
+#   bash scripts/sutando-migrate.sh --json                # scan, JSON output
+#   bash scripts/sutando-migrate.sh --source A,B          # restrict sources scanned
+#   bash scripts/sutando-migrate.sh commit                # do it (writes to dest)
+#   bash scripts/sutando-migrate.sh commit --merge-append # Strategy B (concat with divider)
+#                                                          # instead of sidecar (Strategy C default)
+#   bash scripts/sutando-migrate.sh verify                # post-migration check
+#   bash scripts/sutando-migrate.sh rollback <backup-id>  # restore from tarball
+#   bash scripts/sutando-migrate.sh --help
+
+set -euo pipefail
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Constants
+# ──────────────────────────────────────────────────────────────────────────────
+
+INFLIGHT_GUARD_SEC=60
+
+# Canonical workspace surface — the ONLY paths the script reads from a source.
+# Anything outside this surface in a source is ignored (a source can be a
+# whole repo checkout (Source A) — we MUST NOT recursively walk sutando's
+# code, node_modules, .git, etc.).
+WORKSPACE_SURFACE_DIRS=(
+    "notes"
+    "state"
+    "results"
+    "tasks"
+    "logs"
+    "data"
+    "config"
+    "slack-inbox"
+    "telegram-inbox"
+    # Per Mini #7 #design 2026-06-02: defensive surface coverage for dirs observed
+    # in real workspaces but not yet in M0 contract. Class rules use
+    # collision-keep-both/structural to preserve content; CLAUDE.md should
+    # eventually contract-define these or evict them.
+    "agents"
+    "docs"
+    "email-drafts"
+    "agent-inbox"
+)
+WORKSPACE_SURFACE_FILES=(
+    "build_log.md"
+    "conversation.log"
+    "pending-questions.md"
+    "session-state.md"
+    "context-drop.txt"
+    "cloud-auth.json"
+    "device.json"
+    "contextual-chips.json"
+    "voice-state.json"
+    "core-status.json"
+)
+
+# In-flight ephemeral patterns (skipped with warning if matched + age < guard)
+EPHEMERAL_PATTERNS=(
+    "*.alive"
+    ".DS_Store"
+    ".gitkeep"
+    "migration-backup-*.tar.gz"
+)
+
+# Per-class file classification rules. Order matters — first match wins.
+declare -a CLASS_RULES
+CLASS_RULES=(
+    # form: <relpath-glob>|<class>
+    # ORDER MATTERS — first match wins. Per Mini's #design review 2026-06-02:
+    # - root loose-file globs (no leading directory) only match root files;
+    #   `state/voice-state.json` does NOT match the bare `voice-state.json` rule
+    # - rule ordering puts root rules before sub-dir rules
+    # - `state/auth/*` MUST precede `state/*.json` so per-host auth files don't
+    #   get incorrectly `newest-mtime`-resolved (Mini #2)
+    "build_log.md|append"
+    "conversation.log|rehome-narrative-log"
+    "context-drop.txt|append"
+    "pending-questions.md|append"
+    # ^ per Mini #1: file ACCUMULATES owner questions across hosts;
+    # newest-mtime silently drops a host's unique entries. Migrate via append
+    # (commit-side dedupe-per-line still TODO; Strategy C sidecar by default).
+    "pending-questions-resolved-archive-*.md|rehome-dated-snapshot"
+    "session-state.md|newest-mtime"
+    "cloud-auth.json|rehome-state"
+    "device.json|rehome-state"
+    "contextual-chips.json|rehome-state"
+    "voice-state.json|rehome-state"
+    "core-status.json|rehome-state"
+    "tasks/archive/*|structural"
+    # Per Mini #design 5:27 UTC: legacy task-archive subdirs from older bridge
+    # versions. Mini's workspace has 29 processed + 559 done; owner's B has 34
+    # processed, C has 147 processed. Real historical task content — must NOT
+    # hit the `tasks/*|skip-unknown` catchall below.
+    "tasks/processed/*|structural"
+    "tasks/done/*|structural"
+    "tasks/task-*.txt|inflight-guard"  # CANCEL_INSTRUCTION still starts with `task-` per CLAUDE.md
+    "tasks/*|skip-unknown"
+    "results/archive/*|structural"
+    "results/calls/*|structural"
+    # Mini #design 5:27 UTC pre-merge checklist: defensive coverage for
+    # symmetric legacy subdirs not seen in this scan but plausible on other
+    # hosts. Cost = 0, prevents future scan gap.
+    "results/processed/*|structural"
+    "results/done/*|structural"
+    "results/task-*.txt|inflight-guard"
+    "results/*|skip-unknown"
+    "state/cores/*.alive|skip-ephemeral"
+    "state/auth/*|structural"  # Mini #2: per-host identity, NOT newest-wins
+    "state/*.json|newest-mtime"
+    "state/*|structural"
+    "notes/*|collision-keep-both"  # Mini #4: accretes cruft over N migrations;
+                                    # commit-side identical-drop mitigates 87/87 in real data
+    "logs/*|structural"
+    "data/*|collision-keep-both"  # Mini #5: was structural (ambiguous); keep-both safer
+    "config/*|collision-keep-both"  # Mini #3: scope undefined in contract; safer default
+    "slack-inbox/*|structural"
+    "telegram-inbox/*|structural"
+    # Mini #7: surface adds for C-observed dirs not in M0-contract; safe default
+    "agents/*|structural"
+    "docs/*|structural"
+    "email-drafts/*|structural"
+    "agent-inbox/*|structural"
+)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Resolve script root + helper location (handles cross-checkout via BASH_SOURCE)
+# ──────────────────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPER="$REPO_DIR/scripts/sutando-config.sh"
+
+if [ ! -x "$HELPER" ] && [ ! -f "$HELPER" ]; then
+    echo "sutando-migrate: cannot find $HELPER (expected next to this script)" >&2
+    exit 2
+fi
+# Dest resolution deferred to after arg parsing so --respect-env can take effect.
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Source detection
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Source A — repo root, non-canonical legacy
+# (TEST hook: SUTANDO_MIGRATE_SRC_A overrides for E2E fixtures)
+A_PATH="${SUTANDO_MIGRATE_SRC_A:-$REPO_DIR}"
+A_REAL="$(cd "$A_PATH" 2>/dev/null && pwd -P || true)"
+
+# Source B — pre-M0 default fallback
+# (TEST hook: SUTANDO_MIGRATE_SRC_B overrides for E2E fixtures)
+B_PATH="${SUTANDO_MIGRATE_SRC_B:-$HOME/.sutando/workspace}"
+
+# Source C — env override (env or .env)
+# (TEST hook: SUTANDO_MIGRATE_SRC_C overrides for E2E fixtures)
+detect_C() {
+    local c=""
+    if [ -n "${SUTANDO_MIGRATE_SRC_C:-}" ]; then
+        c="$SUTANDO_MIGRATE_SRC_C"
+    elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+        c="$SUTANDO_WORKSPACE"
+    elif [ -f "$REPO_DIR/.env" ]; then
+        c="$(grep -E '^SUTANDO_WORKSPACE=' "$REPO_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2- | sed 's/^"//;s/"$//;s/^//;s/$//')"
+    fi
+    # Expand ~
+    c="${c/#\~/$HOME}"
+    echo "$c"
+}
+C_PATH="$(detect_C)"
+
+# Validate + canonicalize sources; drop empty / non-existent / == dest
+validate_source() {
+    local tag="$1"
+    local path="$2"
+    local real=""
+    [ -z "$path" ] && return 1
+    [ ! -d "$path" ] && return 1
+    real="$(cd "$path" 2>/dev/null && pwd -P || true)"
+    [ -z "$real" ] && return 1
+    if [ "$real" = "$DEST_REAL" ]; then
+        echo "sutando-migrate: source $tag ($real) == dest; skipping" >&2
+        return 1
+    fi
+    echo "$real"
+    return 0
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Per-file classification
+# ──────────────────────────────────────────────────────────────────────────────
+
+classify() {
+    # $1 = source-relative path (e.g. "notes/foo.md")
+    local rel="$1"
+    local rule
+    for rule in "${CLASS_RULES[@]}"; do
+        local glob="${rule%%|*}"
+        local class="${rule##*|}"
+        # shellcheck disable=SC2254
+        case "$rel" in
+            $glob) echo "$class"; return 0 ;;
+        esac
+    done
+    # No rule matched — caller decides (skip-unknown or structural)
+    echo "unknown"
+}
+
+# Check inflight age — returns 0 if file is older than guard
+age_safe() {
+    local file="$1"
+    local now mtime age
+    now="$(date +%s)"
+    mtime="$(stat -f %m "$file" 2>/dev/null || stat -c %Y "$file" 2>/dev/null || echo 0)"
+    age=$((now - mtime))
+    [ "$age" -ge "$INFLIGHT_GUARD_SEC" ]
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scan: walk a source, report per-class buckets
+# ──────────────────────────────────────────────────────────────────────────────
+
+declare -a SOURCES_REAL SOURCES_TAGS
+declare -a REPORT_LINES
+
+# Cross-source index: TSV file collecting (relpath, tag, class, mtime, size) per
+# file across ALL sources. Post-processed to surface relpaths that appear in
+# >1 source (cross-source collisions per-source scan misses — e.g. build_log.md
+# in A AND C bound for the same dest path).
+XSRC_INDEX="$(mktemp -t sutando-migrate-xsrc.XXXXXX)"
+trap 'rm -f "$XSRC_INDEX"' EXIT INT TERM
+# Also include dest's existing files (tag "DEST") so we surface dest-collisions
+# uniformly with cross-source collisions.
+
+record_xsrc() {
+    # $1=tag, $2=relpath, $3=class, $4=abs-path
+    local tag="$1" rel="$2" cls="$3" file="$4"
+    local mt sz
+    mt="$(stat -f %m "$file" 2>/dev/null || stat -c %Y "$file" 2>/dev/null || echo 0)"
+    sz="$(stat -f %z "$file" 2>/dev/null || stat -c %s "$file" 2>/dev/null || echo 0)"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$rel" "$tag" "$cls" "$mt" "$sz" >> "$XSRC_INDEX"
+}
+
+scan_source() {
+    local tag="$1"
+    local src="$2"
+    # NOTE on portability: --base is not portable; we use absolute paths only.
+    # Walk every non-ignored regular file under src.
+    local file rel cls dest_path collision_kind="" size mtime_iso
+    local n_structural=0 n_append=0 n_newest=0 n_rehome=0 n_skip=0 n_inflight=0 n_collision=0 n_unknown=0
+    local bytes_total=0
+
+    REPORT_LINES+=("")
+    REPORT_LINES+=("--- Source $tag — $src ---")
+
+    # .git detection (commit-history layer; informational only for scan)
+    if [ -d "$src/.git" ]; then
+        REPORT_LINES+=("  .git: present (commit history; needs separate sync-rehome handling for vault sync)")
+    fi
+
+    # Migration sentinels — partial-migration history at this source
+    local sentinels
+    sentinels="$(find "$src" -maxdepth 1 -type f -name ".*-migrated*" 2>/dev/null | sort)"
+    if [ -n "$sentinels" ]; then
+        REPORT_LINES+=("  prior partial migration sentinels:")
+        while IFS= read -r s; do
+            local sm
+            sm="$(stat -f '%Sm' -t '%Y-%m-%d' "$s" 2>/dev/null || stat -c '%y' "$s" 2>/dev/null | cut -d' ' -f1)"
+            REPORT_LINES+=("    $(basename "$s")  ($sm)")
+        done <<<"$sentinels"
+    fi
+
+    # Build the explicit walk list: workspace-surface subdirs + workspace-surface
+    # root files. We do NOT walk the whole source tree — Source A is a sutando
+    # checkout, walking it would pull in src/, node_modules/, .git, etc.
+    # (15,044-file false positive caught in scan v1).
+    local -a walk_paths=()
+    local sd sf
+    for sd in "${WORKSPACE_SURFACE_DIRS[@]}"; do
+        [ -d "$src/$sd" ] && walk_paths+=("$src/$sd")
+    done
+    for sf in "${WORKSPACE_SURFACE_FILES[@]}"; do
+        [ -f "$src/$sf" ] && walk_paths+=("$src/$sf")
+    done
+    [ ${#walk_paths[@]} -eq 0 ] && {
+        REPORT_LINES+=("  (no workspace surface present at this source — nothing to migrate)")
+        return 0
+    }
+
+    # Walk only the surface; skip .git contents (handled separately) and pre-
+    # existing migration backups.
+    while IFS= read -r -d '' file; do
+        rel="${file#"$src"/}"
+        case "$rel" in
+            .git/*) continue ;;
+            state/migration-backup-*.tar.gz) n_skip=$((n_skip+1)); continue ;;
+            .DS_Store|*/.DS_Store) n_skip=$((n_skip+1)); continue ;;
+            .gitkeep|*/.gitkeep) n_skip=$((n_skip+1)); continue ;;
+        esac
+
+        cls="$(classify "$rel")"
+        size="$(stat -f %z "$file" 2>/dev/null || stat -c %s "$file" 2>/dev/null || echo 0)"
+        bytes_total=$((bytes_total + size))
+
+        # Index for cross-source collision detection (only classes that
+        # produce writes; skip-ephemeral / skip-unknown / inflight don't
+        # collide because they aren't migrated). re-home target is
+        # state/<basename>, not the original relpath, so we index under the
+        # re-homed path so re-home collisions surface correctly.
+        case "$cls" in
+            structural|append|newest-mtime|collision-keep-both)
+                record_xsrc "$tag" "$rel" "$cls" "$file"
+                ;;
+            rehome-state)
+                # Per Mini #design 2026-06-02: cloud-auth/device → state/auth/, others → state/
+                local _b="$(basename "$rel")"
+                case "$_b" in
+                    cloud-auth.json|device.json)
+                        record_xsrc "$tag" "state/auth/$_b" "$cls" "$file"
+                        ;;
+                    *)
+                        record_xsrc "$tag" "state/$_b" "$cls" "$file"
+                        ;;
+                esac
+                ;;
+            rehome-dated-snapshot)
+                # Per Mini #design earlier: dated snapshot → notes/archive/<base>
+                record_xsrc "$tag" "notes/archive/$(basename "$rel")" "$cls" "$file"
+                ;;
+            rehome-narrative-log)
+                # Per Mini #design earlier: root conversation.log → logs/workspace-narrative.log
+                record_xsrc "$tag" "logs/workspace-narrative.log" "$cls" "$file"
+                ;;
+        esac
+
+        case "$cls" in
+            structural)
+                # Collision check
+                dest_path="$DEST/$rel"
+                if [ -e "$dest_path" ]; then
+                    n_collision=$((n_collision+1))
+                else
+                    n_structural=$((n_structural+1))
+                fi
+                ;;
+            append)
+                # Always treated as collision once dest also has it; otherwise straight copy
+                dest_path="$DEST/$rel"
+                if [ -e "$dest_path" ] && [ -s "$dest_path" ]; then
+                    n_append=$((n_append+1))
+                else
+                    n_structural=$((n_structural+1))
+                fi
+                ;;
+            newest-mtime)
+                n_newest=$((n_newest+1))
+                ;;
+            rehome-state)
+                # Target is <dest>/state/<basename>
+                n_rehome=$((n_rehome+1))
+                ;;
+            collision-keep-both)
+                dest_path="$DEST/$rel"
+                if [ -e "$dest_path" ]; then
+                    n_collision=$((n_collision+1))
+                else
+                    n_structural=$((n_structural+1))
+                fi
+                ;;
+            inflight-guard)
+                if age_safe "$file"; then
+                    # Old in-flight artifact — treat as archive
+                    n_structural=$((n_structural+1))
+                else
+                    n_inflight=$((n_inflight+1))
+                fi
+                ;;
+            skip-ephemeral|skip-unknown)
+                n_skip=$((n_skip+1))
+                ;;
+            unknown)
+                n_unknown=$((n_unknown+1))
+                ;;
+        esac
+    done < <(find "${walk_paths[@]}" -type f -print0 2>/dev/null)
+
+    REPORT_LINES+=("  files by action:")
+    REPORT_LINES+=("    structural (copy-or-keep-both new):  $n_structural")
+    REPORT_LINES+=("    collision    (same path, diff content):$n_collision")
+    REPORT_LINES+=("    append-merge (build_log/conv.log):    $n_append")
+    REPORT_LINES+=("    newest-mtime (snapshots):             $n_newest")
+    REPORT_LINES+=("    re-home      (loose JSON → state/):   $n_rehome")
+    REPORT_LINES+=("    in-flight-skip (<${INFLIGHT_GUARD_SEC}s old):       $n_inflight")
+    REPORT_LINES+=("    skip-ephemeral / .DS_Store / .gitkeep:$n_skip")
+    REPORT_LINES+=("    unknown (no rule matched, will skip): $n_unknown")
+    REPORT_LINES+=("    total bytes:                          $(numfmt --to=iec "$bytes_total" 2>/dev/null || echo "$bytes_total")")
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Arg parsing
+# ──────────────────────────────────────────────────────────────────────────────
+
+MODE="scan"
+JSON=0
+SOURCE_FILTER=""
+MERGE_APPEND=0
+DELETE_SOURCE=0
+FORCE=0
+ROLLBACK_ID=""
+
+EXPLAIN_PATH=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        scan|commit|verify|rollback) MODE="$1"; shift ;;
+        explain)
+            MODE="explain"
+            shift
+            # Next non-flag arg is the path to explain (positional).
+            if [ $# -gt 0 ] && [ "${1#-}" = "$1" ]; then
+                EXPLAIN_PATH="$1"
+                shift
+            fi
+            ;;
+        --dry-run) MODE="scan"; shift ;;  # alias for scan, per Mini #design 2026-06-02
+        --json) JSON=1; shift ;;
+        --source) SOURCE_FILTER="$2"; shift 2 ;;
+        --merge-append) MERGE_APPEND=1; shift ;;
+        --delete-source) DELETE_SOURCE=1; shift ;;
+        --force) FORCE=1; shift ;;
+        --respect-env) RESPECT_ENV=1; shift ;;
+        --backup-id) ROLLBACK_ID="$2"; shift 2 ;;
+        --help|-h)
+            sed -n '1,80p' "${BASH_SOURCE[0]}"
+            exit 0
+            ;;
+        *)
+            echo "sutando-migrate: unknown arg: $1" >&2
+            echo "Try --help" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Dest resolution (deferred until after arg parsing so --respect-env applies)
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Migration semantics (option 2 in M1 Part 2 design): the in-repo workspace is
+# the destination regardless of whatever $SUTANDO_WORKSPACE the user has set
+# today — migration MOVES data INTO the new default. Use `--respect-env` to
+# honor env (e.g. for users whose dest is intentionally an env-overridden path).
+if [ "${RESPECT_ENV:-0}" = "1" ]; then
+    DEST="$(bash "$HELPER" workspace 2>/dev/null)"
+else
+    DEST="$(env -u SUTANDO_WORKSPACE bash "$HELPER" workspace 2>/dev/null)"
+fi
+[ -z "$DEST" ] && {
+    echo "sutando-migrate: workspace resolver returned no path. Run from a sutando checkout." >&2
+    exit 2
+}
+mkdir -p "$DEST"
+DEST_REAL="$(cd "$DEST" 2>/dev/null && pwd -P || true)"
+[ -z "$DEST_REAL" ] && {
+    echo "sutando-migrate: cannot resolve dest realpath ($DEST)" >&2
+    exit 2
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Main: scan (commit/verify/rollback stubs for now — phase 2B-2E)
+# ──────────────────────────────────────────────────────────────────────────────
+
+# In --json mode, all banner chatter goes to stderr so stdout is parseable JSON.
+banner() { if [ "$JSON" = "1" ]; then echo "$@" >&2; else echo "$@"; fi; }
+
+banner "sutando-migrate: mode=$MODE  dest=$DEST_REAL"
+[ "${RESPECT_ENV:-0}" = "0" ] && [ -n "${SUTANDO_WORKSPACE:-}" ] && \
+    banner "sutando-migrate: NOTE — \$SUTANDO_WORKSPACE=$SUTANDO_WORKSPACE in env; ignored for dest computation (use --respect-env to honor)"
+banner ""
+
+# Discover sources
+A_REAL_OK=""; B_REAL_OK=""; C_REAL_OK=""
+A_REAL_OK="$(validate_source A "$A_PATH" || true)"
+B_REAL_OK="$(validate_source B "$B_PATH" || true)"
+C_REAL_OK="$(validate_source C "$C_PATH" || true)"
+
+banner "sources detected:"
+[ -n "$A_REAL_OK" ] && banner "  A (repo root):                 $A_REAL_OK"
+[ -n "$B_REAL_OK" ] && banner "  B (~/.sutando/workspace/):     $B_REAL_OK"
+[ -n "$C_REAL_OK" ] && banner "  C (SUTANDO_WORKSPACE env):     $C_REAL_OK"
+[ -z "$A_REAL_OK$B_REAL_OK$C_REAL_OK" ] && {
+    if [ "$JSON" = "1" ]; then
+        echo '{"dest":"'"$DEST_REAL"'","sources":{},"totals":{"unique_relpaths":0,"collisions":0,"identical_content":0,"genuine_conflicts":0,"by_class":{}},"notable_collisions":[]}'
+    else
+        echo "  (none — nothing to migrate; dest=$DEST_REAL is the only locus)"
+    fi
+    exit 0
+}
+banner ""
+
+# Optional source filter
+include_src() {
+    local tag="$1"
+    [ -z "$SOURCE_FILTER" ] && return 0
+    [[ ",$SOURCE_FILTER," == *",$tag,"* ]]
+}
+
+index_dest_for_collisions() {
+    # Walk dest's workspace surface, recording any existing files as tag DEST
+    # so dest-collisions surface uniformly with cross-source collisions in the
+    # post-processing report. Existing dest files do not get migrated; they're
+    # the prior state the report is helping owner reason about.
+    local sd sf
+    local -a dest_walk=()
+    for sd in "${WORKSPACE_SURFACE_DIRS[@]}"; do
+        [ -d "$DEST_REAL/$sd" ] && dest_walk+=("$DEST_REAL/$sd")
+    done
+    for sf in "${WORKSPACE_SURFACE_FILES[@]}"; do
+        [ -f "$DEST_REAL/$sf" ] && dest_walk+=("$DEST_REAL/$sf")
+    done
+    [ ${#dest_walk[@]} -eq 0 ] && return
+    while IFS= read -r -d '' file; do
+        local rel="${file#"$DEST_REAL"/}"
+        case "$rel" in
+            .git/*|*/.git/*) continue ;;
+            state/migration-backup-*.tar.gz) continue ;;
+            .DS_Store|*/.DS_Store|.gitkeep|*/.gitkeep) continue ;;
+        esac
+        local cls
+        cls="$(classify "$rel")"
+        case "$cls" in
+            structural|append|newest-mtime|collision-keep-both|rehome-state)
+                record_xsrc "DEST" "$rel" "existing" "$file"
+                ;;
+        esac
+    done < <(find "${dest_walk[@]}" -type f -print0 2>/dev/null)
+}
+
+report_cross_source() {
+    # Post-process XSRC_INDEX (TSV: relpath\ttag\tclass\tmtime\tsize) and print
+    # any relpath that appears in 2+ rows (cross-source / dest collision).
+    # Emits a compact per-class summary + a per-class detail list (capped).
+    local total_xs total_xs_files
+    total_xs_files="$(awk -F'\t' '{print $1}' "$XSRC_INDEX" | sort -u | wc -l | tr -d ' ')"
+    total_xs="$(awk -F'\t' '
+        {n[$1]++}
+        END {c=0; for (k in n) if (n[k]>1) c++; print c}
+    ' "$XSRC_INDEX")"
+
+    REPORT_LINES+=("")
+    REPORT_LINES+=("--- Cross-source collision report ---")
+    REPORT_LINES+=("  total unique relpaths across sources+dest: $total_xs_files")
+    REPORT_LINES+=("  relpaths present in >1 location:           $total_xs")
+
+    if [ "$total_xs" -eq 0 ]; then
+        REPORT_LINES+=("  (no cross-source / dest collisions — commit is safe per-source)")
+        return
+    fi
+
+    # Identical-content collisions: cross-source rows where ALL entries share
+    # the same mtime AND size for the relpath. High-confidence "same file
+    # mirrored through sync" — commit can pick one source as canonical and
+    # skip the rest (no real conflict). Common case: memory-sync mirroring
+    # notes/ between B and C.
+    local total_identical
+    # Concatenated-key idiom (BSD awk has no array-of-array); detect identical
+    # across all entries of a relpath by counting distinct (mtime,size) pairs.
+    total_identical="$(awk -F'\t' '
+        {
+            n[$1]++
+            key = $1 SUBSEP $4 "|" $5
+            if (!(key in seen)) { seen[key]=1; pairs[$1]++ }
+        }
+        END {
+            ident=0
+            for (k in n) if (n[k]>1 && pairs[k]==1) ident++
+            print ident
+        }
+    ' "$XSRC_INDEX" 2>/dev/null || echo 0)"
+
+    REPORT_LINES+=("  of which identical-content (same mtime + size):  $total_identical (commit will pick one canonical + skip rest)")
+    REPORT_LINES+=("  genuine cross-source conflicts (need strategy):  $((total_xs - total_identical))")
+
+    # Per-class breakdown of cross-source collisions
+    REPORT_LINES+=("  by class:")
+    while read -r cnt c; do
+        REPORT_LINES+=("    $cnt × $c")
+    done < <(awk -F'\t' '
+        {n[$1]++; cls[$1]=$3}
+        END {for (k in n) if (n[k]>1) print cls[k]}
+    ' "$XSRC_INDEX" | sort | uniq -c | sort -rn | head -10)
+
+    # Top notable collisions (append-class first, then size)
+    REPORT_LINES+=("  notable collisions (cap 20; full list with --json):")
+    while IFS='|' read -r c rel locs; do
+        REPORT_LINES+=("    [$c] $rel  → $locs")
+    done < <(awk -F'\t' '
+        {locs[$1]=locs[$1] "," $2 "(mt=" $4 ",sz=" $5 ")"; cls[$1]=$3; n[$1]++}
+        END {for (k in n) if (n[k]>1) printf "%s|%s|%s\n", cls[k], k, substr(locs[k],2)}
+    ' "$XSRC_INDEX" | sort -t'|' -k1,1 | head -20)
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Commit / verify / rollback
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Stable backup id for this commit invocation (also serves as sentinel suffix)
+BACKUP_ID=""
+
+backup_dest() {
+    BACKUP_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+    local backup_path="$DEST_REAL/state/migration-backup-$BACKUP_ID.tar.gz"
+    mkdir -p "$DEST_REAL/state"
+    # Backup only the workspace surface (avoid backing up the backup-in-progress).
+    local -a surface=()
+    local sd sf
+    for sd in "${WORKSPACE_SURFACE_DIRS[@]}"; do
+        [ -e "$DEST_REAL/$sd" ] && surface+=("$sd")
+    done
+    for sf in "${WORKSPACE_SURFACE_FILES[@]}"; do
+        [ -e "$DEST_REAL/$sf" ] && surface+=("$sf")
+    done
+    if [ ${#surface[@]} -gt 0 ]; then
+        ( cd "$DEST_REAL" && tar -czf "$backup_path" "${surface[@]}" 2>/dev/null )
+        echo "sutando-migrate: backup → $backup_path"
+    else
+        # Empty dest — write an empty marker so rollback still has a known id
+        : > "$backup_path"
+        echo "sutando-migrate: dest empty; placeholder backup → $backup_path"
+    fi
+}
+
+# Per-source migration sentinel. Idempotency token: if present + not --force, skip source.
+source_sentinel() {
+    echo "$DEST_REAL/state/.migrated-from-$1-$BACKUP_ID"
+}
+any_source_sentinel() {
+    # Any sentinel for this source tag (commit may have been run before with a
+    # different backup id). Returns 0 if found.
+    ls "$DEST_REAL/state/.migrated-from-$1-"* >/dev/null 2>&1
+}
+
+# Atomic per-file copy preserving mtime. Returns 0 on success.
+copy_preserving_mtime() {
+    local src="$1" dst="$2"
+    mkdir -p "$(dirname "$dst")"
+    # Atomic: cp -p to sibling tmp then mv. -p preserves mtime + mode.
+    local tmp="$dst.tmp.$$"
+    cp -p "$src" "$tmp" && mv -f "$tmp" "$dst"
+}
+
+# SHA-256 verify (macOS shasum / Linux sha256sum). Returns 0 if hashes match.
+sha_match() {
+    local a="$1" b="$2"
+    local ha hb
+    if command -v shasum >/dev/null 2>&1; then
+        ha="$(shasum -a 256 "$a" 2>/dev/null | awk '{print $1}')"
+        hb="$(shasum -a 256 "$b" 2>/dev/null | awk '{print $1}')"
+    else
+        ha="$(sha256sum "$a" 2>/dev/null | awk '{print $1}')"
+        hb="$(sha256sum "$b" 2>/dev/null | awk '{print $1}')"
+    fi
+    [ -n "$ha" ] && [ "$ha" = "$hb" ]
+}
+
+# Per-file commit dispatch. $1=src-file abs, $2=src-relpath, $3=src-tag, $4=class
+# Returns count category via stdout: "copied|kept-dest|skipped|sidecar|rehomed"
+commit_one() {
+    local src_file="$1" rel="$2" tag="$3" cls="$4"
+    local dst_path
+
+    case "$cls" in
+        structural|collision-keep-both)
+            dst_path="$DEST_REAL/$rel"
+            if [ -e "$dst_path" ]; then
+                # Same content (mtime+size) → identical-drop. Different →
+                # keep-both: rename source-incoming to <file>.legacy-<tag>.
+                local src_mt src_sz dst_mt dst_sz
+                src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
+                src_sz="$(stat -f %z "$src_file" 2>/dev/null || stat -c %s "$src_file")"
+                dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
+                dst_sz="$(stat -f %z "$dst_path" 2>/dev/null || stat -c %s "$dst_path")"
+                if [ "$src_mt" = "$dst_mt" ] && [ "$src_sz" = "$dst_sz" ]; then
+                    echo "identical-drop"
+                    return 0
+                fi
+                # Genuine collision: write loser as sidecar, keep dest as primary
+                # only if dest is newer. If src is newer, swap.
+                if [ "$src_mt" -gt "$dst_mt" ]; then
+                    copy_preserving_mtime "$dst_path" "$dst_path.legacy-DEST"
+                    copy_preserving_mtime "$src_file" "$dst_path"
+                    echo "src-wins-newer"
+                else
+                    copy_preserving_mtime "$src_file" "$dst_path.legacy-$tag"
+                    echo "dest-wins-newer"
+                fi
+                return 0
+            else
+                copy_preserving_mtime "$src_file" "$dst_path"
+                echo "copied"
+                return 0
+            fi
+            ;;
+        newest-mtime)
+            dst_path="$DEST_REAL/$rel"
+            if [ -e "$dst_path" ]; then
+                local src_mt dst_mt
+                src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
+                dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
+                if [ "$src_mt" -gt "$dst_mt" ]; then
+                    copy_preserving_mtime "$src_file" "$dst_path"
+                    echo "src-newer"
+                else
+                    echo "dest-newer"
+                fi
+            else
+                copy_preserving_mtime "$src_file" "$dst_path"
+                echo "copied"
+            fi
+            return 0
+            ;;
+        rehome-state|rehome-dated-snapshot|rehome-narrative-log)
+            # Per Mini's #design 2026-06-02 04:54Z (state JSONs) + earlier
+            # workspace audit (dated snapshots + conversation.log):
+            #   rehome-state          → state/<base> OR state/auth/<base>
+            #                           (cloud-auth/device → auth/; per-host durable;
+            #                           CLAUDE.md should declare state/auth/ excluded
+            #                           from transient-state cleanup)
+            #   rehome-dated-snapshot → notes/archive/<base>
+            #                           (pending-questions-resolved-archive-*.md etc)
+            #   rehome-narrative-log  → logs/workspace-narrative.log
+            #                           (root conversation.log → logs/. Renamed to
+            #                           dodge the existing per-pid logs/conversation.log
+            #                           collision. Owner-Q flagged; filename can change.)
+            local base="$(basename "$rel")"
+            case "$cls" in
+                rehome-state)
+                    case "$base" in
+                        cloud-auth.json|device.json) dst_path="$DEST_REAL/state/auth/$base" ;;
+                        *) dst_path="$DEST_REAL/state/$base" ;;
+                    esac
+                    ;;
+                rehome-dated-snapshot)
+                    dst_path="$DEST_REAL/notes/archive/$base"
+                    ;;
+                rehome-narrative-log)
+                    dst_path="$DEST_REAL/logs/workspace-narrative.log"
+                    ;;
+            esac
+            # Common per-mtime swap, identical-drop, or write-fresh.
+            if [ -e "$dst_path" ]; then
+                local src_mt dst_mt
+                src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
+                dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
+                if [ "$src_mt" -gt "$dst_mt" ]; then
+                    copy_preserving_mtime "$src_file" "$dst_path"
+                    echo "rehomed-newer"
+                else
+                    echo "rehomed-skip-older"
+                fi
+            else
+                copy_preserving_mtime "$src_file" "$dst_path"
+                echo "rehomed"
+            fi
+            return 0
+            if [ -e "$dst_path" ]; then
+                local src_mt dst_mt
+                src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
+                dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
+                if [ "$src_mt" -gt "$dst_mt" ]; then
+                    copy_preserving_mtime "$src_file" "$dst_path"
+                    echo "rehomed-newer"
+                else
+                    echo "rehomed-skip-older"
+                fi
+            else
+                copy_preserving_mtime "$src_file" "$dst_path"
+                echo "rehomed"
+            fi
+            return 0
+            ;;
+        append)
+            # Default Strategy C: sidecar at <dest>/legacy/<tag>/<rel>.
+            # --merge-append (Strategy B): concat with divider to <dest>/<rel>.
+            if [ "$MERGE_APPEND" = "1" ]; then
+                dst_path="$DEST_REAL/$rel"
+                mkdir -p "$(dirname "$dst_path")"
+                if [ -e "$dst_path" ]; then
+                    {
+                        cat "$dst_path"
+                        echo ""
+                        echo "=== migrated from source $tag at $BACKUP_ID ==="
+                        echo ""
+                        cat "$src_file"
+                    } > "$dst_path.merge.$$" && mv -f "$dst_path.merge.$$" "$dst_path"
+                    echo "merged"
+                else
+                    copy_preserving_mtime "$src_file" "$dst_path"
+                    echo "copied"
+                fi
+            else
+                dst_path="$DEST_REAL/legacy/$tag/$rel"
+                copy_preserving_mtime "$src_file" "$dst_path"
+                echo "sidecar"
+            fi
+            return 0
+            ;;
+        inflight-guard)
+            # Old in-flight artifacts (tasks/task-*.txt, results/task-*.txt)
+            # NEVER copy to dest's live queue (would re-fire the watcher and
+            # double-process old work). Route to tasks/archive/<src-tag>/ or
+            # results/archive/<src-tag>/ instead. Bug discovered when a stale
+            # May 22 task migrated from B fired the watcher post-test.
+            if age_safe "$src_file"; then
+                local subdir="${rel%%/*}"  # tasks or results
+                local file_base="${rel#*/}" # task-*.txt
+                dst_path="$DEST_REAL/$subdir/archive/$tag/$file_base"
+                copy_preserving_mtime "$src_file" "$dst_path"
+                echo "archived-stale"
+            else
+                echo "skipped-inflight"
+            fi
+            return 0
+            ;;
+        skip-ephemeral|skip-unknown|unknown)
+            echo "skipped-class"
+            return 0
+            ;;
+    esac
+    echo "skipped-fallthrough"
+}
+
+commit_source() {
+    local tag="$1" src="$2"
+
+    if any_source_sentinel "$tag" && [ "$FORCE" = "0" ]; then
+        echo "sutando-migrate: source $tag has prior migration sentinel — skip (use --force)"
+        return 0
+    fi
+
+    echo
+    echo "--- Committing source $tag ($src) ---"
+
+    # Reuse the same walk-list logic as scan_source.
+    local -a walk_paths=()
+    local sd sf
+    for sd in "${WORKSPACE_SURFACE_DIRS[@]}"; do
+        [ -d "$src/$sd" ] && walk_paths+=("$src/$sd")
+    done
+    for sf in "${WORKSPACE_SURFACE_FILES[@]}"; do
+        [ -f "$src/$sf" ] && walk_paths+=("$src/$sf")
+    done
+    [ ${#walk_paths[@]} -eq 0 ] && { echo "  (nothing on surface; skip)"; return 0; }
+
+    local n_copied=0 n_kept=0 n_skipped=0 n_sidecar=0 n_rehomed=0 n_identical=0 n_other=0
+    local file rel cls outcome
+    while IFS= read -r -d '' file; do
+        rel="${file#"$src"/}"
+        case "$rel" in
+            .git/*) continue ;;
+            state/migration-backup-*.tar.gz) continue ;;
+            .DS_Store|*/.DS_Store|.gitkeep|*/.gitkeep) n_skipped=$((n_skipped+1)); continue ;;
+        esac
+        cls="$(classify "$rel")"
+        outcome="$(commit_one "$file" "$rel" "$tag" "$cls")"
+        case "$outcome" in
+            copied|src-wins-newer|src-newer|rehomed|rehomed-newer|merged|copied-stale)
+                n_copied=$((n_copied+1)) ;;
+            dest-wins-newer|dest-newer|rehomed-skip-older|skipped-collision-dest)
+                n_kept=$((n_kept+1)) ;;
+            identical-drop)
+                n_identical=$((n_identical+1)) ;;
+            sidecar)
+                n_sidecar=$((n_sidecar+1)) ;;
+            skipped-class|skipped-inflight|skipped-fallthrough)
+                n_skipped=$((n_skipped+1)) ;;
+            *)
+                n_other=$((n_other+1)) ;;
+        esac
+    done < <(find "${walk_paths[@]}" -type f -print0 2>/dev/null)
+
+    echo "  copied:      $n_copied"
+    echo "  identical:   $n_identical (drop-dup, no real conflict)"
+    echo "  kept-dest:   $n_kept"
+    echo "  sidecar:     $n_sidecar"
+    echo "  skipped:     $n_skipped"
+    [ "$n_other" -gt 0 ] && echo "  other:       $n_other"
+
+    touch "$(source_sentinel "$tag")"
+    echo "  sentinel:    $(source_sentinel "$tag")"
+}
+
+commit_main() {
+    # Mini's polish: --delete-source REQUIRES --backup-id pointer. Forces
+    # operator to reference a real backup before destructive op.
+    if [ "$DELETE_SOURCE" = "1" ] && [ -z "$ROLLBACK_ID" ]; then
+        echo "ERROR: --delete-source requires --backup-id <id> to reference a known backup." >&2
+        echo "  If you want to commit + delete in one step on a fresh state, run --commit first (no-delete)," >&2
+        echo "  observe ~7d for straggler writers, then re-run with --commit --delete-source --backup-id <id-from-step-1>." >&2
+        echo "  Available backups:" >&2
+        ls -1 "$DEST_REAL/state/migration-backup-"*.tar.gz 2>/dev/null | sed -E 's@.*migration-backup-(.+)\.tar\.gz@    \1@' >&2 || echo "    (none)" >&2
+        exit 2
+    fi
+
+    echo "sutando-migrate: COMMIT mode"
+    echo "  dest:       $DEST_REAL"
+    echo "  append:     $([ "$MERGE_APPEND" = "1" ] && echo "merge (Strategy B)" || echo "sidecar (Strategy C — default)")"
+    echo "  delete src: $([ "$DELETE_SOURCE" = "1" ] && echo "yes (backup-id=$ROLLBACK_ID)" || echo "no — sources preserved (default; matches workspace_m1_no_auto_commit)")"
+    echo
+
+    backup_dest
+    echo
+
+    # Order: C (richest) → A (merges atop C) → B (sentinel-deduped legacy)
+    [ -n "$C_REAL_OK" ] && include_src C && commit_source C "$C_REAL_OK"
+    [ -n "$A_REAL_OK" ] && include_src A && commit_source A "$A_REAL_OK"
+    [ -n "$B_REAL_OK" ] && include_src B && commit_source B "$B_REAL_OK"
+
+    # β rehome of source's .git → dest/.git is a SEPARATE step. See
+    # sutando-plus/scripts/sutando-migrate-sync.sh — runs AFTER this commit
+    # succeeds, only relevant to sutando-plus users who have a vault remote at
+    # the customized source location.
+
+    echo
+    echo "sutando-migrate: COMMIT complete. Verify with: bash scripts/sutando-migrate.sh verify"
+    echo "  rollback: bash scripts/sutando-migrate.sh rollback --backup-id $BACKUP_ID"
+    if [ "$DELETE_SOURCE" = "0" ]; then
+        # Mini's polish: explicit next-step messaging for the two-phase pattern.
+        echo "  Sources NOT deleted (default). After ~7d observing no source-side writes, run:"
+        echo "    bash scripts/sutando-migrate.sh commit --delete-source --backup-id $BACKUP_ID"
+        echo "  Two-phase pattern keeps the (b)-style reader-fallback bridge intact during transition."
+    fi
+}
+
+verify_main() {
+    echo "sutando-migrate: VERIFY mode"
+    local pass=0 fail=0 missing=0 mismatch=0
+    # For each indexed (source, file) that was supposed to land at dest:
+    # confirm dest has it (or a documented sidecar) + sha match for copied path.
+    if [ ! -s "$XSRC_INDEX" ]; then
+        # No index yet — run a fresh scan to populate
+        index_dest_for_collisions
+        [ -n "$A_REAL_OK" ] && include_src A && scan_source A "$A_REAL_OK" >/dev/null
+        [ -n "$B_REAL_OK" ] && include_src B && scan_source B "$B_REAL_OK" >/dev/null
+        [ -n "$C_REAL_OK" ] && include_src C && scan_source C "$C_REAL_OK" >/dev/null
+    fi
+    # Verification logic (lightweight first cut):
+    # for each non-DEST entry, the dest should have either the relpath or a
+    # sidecar at legacy/<tag>/<relpath>. Sha match for canonical winners.
+    while IFS=$'\t' read -r rel tag cls mt sz; do
+        [ "$tag" = "DEST" ] && continue
+        local dst_path="$DEST_REAL/$rel"
+        local sidecar="$DEST_REAL/legacy/$tag/$rel"
+        if [ -e "$dst_path" ] || [ -e "$sidecar" ] || [ -e "$dst_path.legacy-$tag" ]; then
+            pass=$((pass+1))
+        else
+            # Some classes (skip-ephemeral, inflight-guard <60s) are expected
+            # absent — only fail if the class was supposed to copy.
+            case "$cls" in
+                structural|collision-keep-both|append|newest-mtime|rehome-state)
+                    missing=$((missing+1))
+                    [ "$missing" -le 5 ] && echo "  MISSING: $tag/$rel ($cls)"
+                    ;;
+                *)
+                    pass=$((pass+1))
+                    ;;
+            esac
+        fi
+    done < "$XSRC_INDEX"
+    echo
+    echo "verify summary: pass=$pass missing=$missing"
+    if [ "$missing" -gt 0 ]; then
+        echo "verify: FAIL — $missing source files not found at dest. Inspect with --json."
+        exit 1
+    fi
+    echo "verify: OK"
+}
+
+rollback_main() {
+    [ -z "$ROLLBACK_ID" ] && {
+        echo "rollback: --backup-id <id> required. Available backups:" >&2
+        ls -1 "$DEST_REAL/state/migration-backup-"*.tar.gz 2>/dev/null | sed -E 's@.*migration-backup-(.+)\.tar\.gz@  \1@' >&2
+        exit 2
+    }
+    local backup_path="$DEST_REAL/state/migration-backup-$ROLLBACK_ID.tar.gz"
+    [ ! -f "$backup_path" ] && {
+        echo "rollback: backup $backup_path not found" >&2
+        exit 2
+    }
+    echo "sutando-migrate: ROLLBACK from $backup_path"
+    # Clear sentinels for that backup id (idempotency)
+    rm -f "$DEST_REAL/state/.migrated-from-"*"-$ROLLBACK_ID" 2>/dev/null
+    # Untar into dest. BSD tar (macOS) overwrites by default; GNU tar (Linux)
+    # also overwrites by default. Workspace surface only — never touches
+    # state/migration-backup-*.tar.gz files (they're outside the tar).
+    ( cd "$DEST_REAL" && tar -xzf "$backup_path" ) || {
+        echo "rollback: extract failed" >&2
+        exit 1
+    }
+    # Clean files added since backup that are NOT in the backup tarball.
+    # Read tarball entries → reference set → find dest's surface files not in set → delete.
+    local tar_listing
+    tar_listing="$(mktemp -t sutando-rollback.XXXXXX)"
+    tar -tzf "$backup_path" 2>/dev/null > "$tar_listing"
+    local sd; for sd in "${WORKSPACE_SURFACE_DIRS[@]}" "${WORKSPACE_SURFACE_FILES[@]}"; do
+        [ ! -e "$DEST_REAL/$sd" ] && continue
+        find "$DEST_REAL/$sd" -type f 2>/dev/null | while IFS= read -r f; do
+            local rel="${f#"$DEST_REAL"/}"
+            # If this rel is NOT in the tar listing, it was added after backup → remove
+            if ! grep -q "^${rel}$" "$tar_listing" 2>/dev/null; then
+                rm -f "$f"
+            fi
+        done
+    done
+    rm -f "$tar_listing"
+    # Drop sentinels matching this backup id
+    rm -f "$DEST_REAL/state/.migrated-from-"*"-$ROLLBACK_ID" 2>/dev/null
+    # Drop legacy/<src-tag>/ sidecars (only the script ever writes there)
+    rm -rf "$DEST_REAL/legacy" 2>/dev/null
+    echo "rollback: OK — dest restored to backup $ROLLBACK_ID"
+}
+
+emit_json() {
+    # Reads XSRC_INDEX (TSV) + the resolved source paths/state and emits a
+    # machine-readable JSON dump for downstream tooling (dashboards, skill
+    # wrappers, the eventual --commit dry-run UI). Python3 is the bash-friendly
+    # path — sutando already requires it.
+    python3 - "$DEST_REAL" "$A_REAL_OK" "$B_REAL_OK" "$C_REAL_OK" "$XSRC_INDEX" <<'PY'
+import json, sys, os
+from collections import defaultdict
+dest, a, b, c, idx_path = sys.argv[1:6]
+entries = []
+if os.path.exists(idx_path):
+    with open(idx_path) as f:
+        for line in f:
+            rel, tag, cls, mt, sz = line.rstrip("\n").split("\t")
+            entries.append({"rel": rel, "tag": tag, "class": cls,
+                            "mtime": int(mt or 0), "size": int(sz or 0)})
+by_rel = defaultdict(list)
+for e in entries:
+    by_rel[e["rel"]].append(e)
+collisions = {k: v for k, v in by_rel.items() if len(v) > 1}
+identical = sum(1 for v in collisions.values()
+                if len({(e["mtime"], e["size"]) for e in v}) == 1)
+genuine = len(collisions) - identical
+by_class = defaultdict(int)
+for v in collisions.values():
+    by_class[v[0]["class"]] += 1
+def has_size_mismatch(entries):
+    """True if entries differ in size — real content divergence the user must reason about."""
+    return len({e["size"] for e in entries}) > 1
+def has_mtime_mismatch(entries):
+    return len({e["mtime"] for e in entries}) > 1
+# Sort by actionability: size-mismatch (real content conflict) first, then
+# mtime-only diff (commit's newest-mtime resolves it), then identical
+# (drop-dup). Tiebreak by class then rel.
+def sort_key(item):
+    k, v = item
+    sz_diff = has_size_mismatch(v)
+    mt_diff = has_mtime_mismatch(v)
+    # priority: 0=size-diff (real), 1=mtime-only, 2=identical
+    if sz_diff: prio = 0
+    elif mt_diff: prio = 1
+    else: prio = 2
+    return (prio, v[0]["class"], k)
+notable = [{"class": v[0]["class"], "rel": k,
+            "size_mismatch": has_size_mismatch(v),
+            "mtime_mismatch": has_mtime_mismatch(v),
+            "entries": [{"tag": e["tag"], "mtime": e["mtime"], "size": e["size"]} for e in v]}
+           for k, v in sorted(collisions.items(), key=sort_key)]
+size_diff = sum(1 for v in collisions.values() if has_size_mismatch(v))
+mtime_only = sum(1 for v in collisions.values() if not has_size_mismatch(v) and has_mtime_mismatch(v))
+out = {
+    "dest": dest,
+    "sources": {"A": a or None, "B": b or None, "C": c or None},
+    "totals": {
+        "unique_relpaths": len(by_rel),
+        "collisions": len(collisions),
+        "identical_content": identical,
+        "mtime_only_diff": mtime_only,  # commit's newest-mtime auto-resolves
+        "size_mismatch": size_diff,     # the actionable subset — real content conflicts
+        # Legacy "genuine_conflicts" kept for backward-compat; equals mtime_only + size_mismatch
+        "genuine_conflicts": genuine,
+        "by_class": dict(by_class),
+    },
+    "notable_collisions": notable[:50],
+}
+json.dump(out, sys.stdout, indent=2)
+print()
+PY
+}
+
+explain_main() {
+    # `explain <path>` — operator dev-aid. Walks CLASS_RULES in order, prints
+    # the first match + the class + the resulting destination + the rule rank.
+    # Per Mini #design 2026-06-02 dev-aid suggestion.
+    if [ "$#" -lt 1 ] && [ -z "${EXPLAIN_PATH:-}" ]; then
+        echo "explain: usage: bash scripts/sutando-migrate.sh explain <relpath>" >&2
+        echo "  e.g.: explain notes/foo.md" >&2
+        echo "        explain state/cores/MBP.alive" >&2
+        echo "        explain tasks/processed/old.txt" >&2
+        exit 2
+    fi
+    local rel="${EXPLAIN_PATH:-$1}"
+    local rank=0
+    for rule in "${CLASS_RULES[@]}"; do
+        rank=$((rank + 1))
+        local glob="${rule%%|*}"
+        local cls="${rule##*|}"
+        # shellcheck disable=SC2254
+        case "$rel" in
+            $glob)
+                echo "path:   $rel"
+                echo "match:  rule #$rank — glob \`$glob\`"
+                echo "class:  $cls"
+                # Show the commit-time destination for the class:
+                local dest_hint=""
+                case "$cls" in
+                    structural|collision-keep-both|newest-mtime|append)
+                        dest_hint="<dest>/$rel"
+                        [ "$cls" = "append" ] && dest_hint="$dest_hint  OR  <dest>/legacy/<src-tag>/$rel  (default sidecar; --merge-append concats)"
+                        ;;
+                    rehome-state)
+                        local base="$(basename "$rel")"
+                        case "$base" in
+                            cloud-auth.json|device.json) dest_hint="<dest>/state/auth/$base" ;;
+                            *) dest_hint="<dest>/state/$base" ;;
+                        esac
+                        ;;
+                    rehome-dated-snapshot) dest_hint="<dest>/notes/archive/$(basename "$rel")" ;;
+                    rehome-narrative-log) dest_hint="<dest>/logs/workspace-narrative.log  (renamed to dodge logs/conversation.log collision)" ;;
+                    inflight-guard) dest_hint="<dest>/$rel  (if >${INFLIGHT_GUARD_SEC}s old)  OR  <dest>/${rel%%/*}/archive/<src-tag>/$(basename "$rel")  (route-to-archive)" ;;
+                    skip-ephemeral|skip-unknown) dest_hint="(skipped — no write)" ;;
+                    *) dest_hint="<unknown>" ;;
+                esac
+                echo "dest:   $dest_hint"
+                return 0
+            ;;
+        esac
+    done
+    echo "path:  $rel"
+    echo "match: none — no rule fires"
+    echo "class: unknown (skipped at commit; no write)"
+    return 0
+}
+
+case "$MODE" in
+    explain)
+        explain_main "$@"
+        exit $?
+        ;;
+    scan)
+        REPORT_LINES=("Scan report (scan-only; no writes):")
+        index_dest_for_collisions
+        [ -n "$A_REAL_OK" ] && include_src A && scan_source A "$A_REAL_OK"
+        [ -n "$B_REAL_OK" ] && include_src B && scan_source B "$B_REAL_OK"
+        [ -n "$C_REAL_OK" ] && include_src C && scan_source C "$C_REAL_OK"
+        if [ "$JSON" = "1" ]; then
+            emit_json
+        else
+            report_cross_source
+            REPORT_LINES+=("")
+            REPORT_LINES+=("Recommended commit order: C (richest, do first) → A (merge atop C) → B (sentinel-deduped)")
+            REPORT_LINES+=("")
+            REPORT_LINES+=("Next: bash scripts/sutando-migrate.sh commit  (when ready)")
+            for line in "${REPORT_LINES[@]}"; do echo "$line"; done
+        fi
+        ;;
+    commit)
+        commit_main
+        ;;
+    verify)
+        verify_main
+        ;;
+    rollback)
+        rollback_main
+        ;;
+esac

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -102,6 +102,16 @@ WORKSPACE_SURFACE_FILES=(
     "contextual-chips.json"
     "voice-state.json"
     "core-status.json"
+    # Per Lucy #design 2026-06-02: contract-defined personal-override file
+    # ("if PERSONAL_CLAUDE.md exists in workspace root, read+follow it").
+    # Previously missing from the surface → would skip-unknown → user's
+    # personal rules silently lost on migration. Now class-handled.
+    "PERSONAL_CLAUDE.md"
+    # Per Lucy #design 2026-06-02: additional per-host status JSONs that
+    # were unruled. Adding as surface so they don't skip-unknown.
+    "quota-state.json"
+    "dynamic-content.json"
+    "stand-identity.json"
 )
 
 # In-flight ephemeral patterns (skipped with warning if matched + age < guard)
@@ -126,6 +136,18 @@ CLASS_RULES=(
     "conversation.log|rehome-narrative-log"
     "context-drop.txt|append"
     "pending-questions.md|append"
+    # Per Lucy #design 2026-06-02 — contract-defined personal override.
+    # Singleton-canonical: newest-mtime is the right strategy (one user,
+    # one PERSONAL_CLAUDE; cross-host divergence means whichever the user
+    # edited most recently wins).
+    "PERSONAL_CLAUDE.md|newest-mtime"
+    # Per Lucy #design 2026-06-02 — per-host state files at root (pre-M0
+    # layout) shouldn't migrate as newest-wins (would drop a host's data
+    # if multi-host scan). Re-home to state/ via rehome-state class +
+    # commit-time collision-keep-both for per-host preservation.
+    "quota-state.json|rehome-state"
+    "dynamic-content.json|rehome-state"
+    "stand-identity.json|rehome-state"
     # ^ per Mini #1: file ACCUMULATES owner questions across hosts;
     # newest-mtime silently drops a host's unique entries. Migrate via append
     # (commit-side dedupe-per-line still TODO; Strategy C sidecar by default).

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -122,6 +122,25 @@ EPHEMERAL_PATTERNS=(
     "migration-backup-*.tar.gz"
 )
 
+# Quarantine-walk excludes (when WALK_FULL_TREE is set for a source).
+# Anything matching these patterns is skipped entirely — not migrated, not
+# quarantined. Per Lucy #design 2026-06-02 + owner direction: capture user's
+# custom workspace content (experiments/, obsidian-vault/, etc.) without
+# accidentally hoovering up VCS/runtime/build artifacts.
+QUARANTINE_EXCLUDES=(
+    ".git"
+    "node_modules"
+    ".cache"
+    ".venv"
+    "venv"
+    "__pycache__"
+    "dist"
+    "build"
+    ".next"
+    ".nuxt"
+    ".DS_Store"
+)
+
 # Per-class file classification rules. Order matters — first match wins.
 declare -a CLASS_RULES
 CLASS_RULES=(
@@ -178,6 +197,15 @@ CLASS_RULES=(
     "results/*|skip-unknown"
     "state/cores/*.alive|skip-ephemeral"
     "state/auth/*|structural"  # Mini #2: per-host identity, NOT newest-wins
+    # Per Lucy #design 2026-06-02 follow-up empirical: per-host status JSONs
+    # at state/<name>.json would hit state/*.json|newest-mtime and drop a
+    # losing host's data on multi-host scan. Same hazard as state/auth — carve
+    # out to structural to preserve per-host copies.
+    "state/core-status.json|structural"
+    "state/quota-state.json|structural"
+    "state/dynamic-content.json|structural"
+    "state/voice-state.json|structural"
+    "state/contextual-chips.json|structural"
     "state/*.json|newest-mtime"
     "state/*|structural"
     "notes/*|collision-keep-both"  # Mini #4: accretes cruft over N migrations;
@@ -192,6 +220,15 @@ CLASS_RULES=(
     "docs/*|structural"
     "email-drafts/*|structural"
     "agent-inbox/*|structural"
+    # Catchall — per Lucy #design 2026-06-02 + owner direction: workspace
+    # sources B+C may have user-custom dirs/files (experiments/, obsidian-vault/,
+    # personal-src/, repro-*.ts, etc.) outside the canonical surface. Anything
+    # that doesn't match an explicit rule above falls here and gets quarantined
+    # to <dest>/legacy/<src-tag>/quarantine/<relpath>. Net: no user content is
+    # silently lost. Only walked when WALK_FULL_TREE per-source flag is set
+    # (B + C); Source A (repo root) stays surface-restricted to avoid
+    # quarantining sutando code.
+    "*|quarantine-unknown"
 )
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -339,10 +376,12 @@ scan_source() {
         done <<<"$sentinels"
     fi
 
-    # Build the explicit walk list: workspace-surface subdirs + workspace-surface
-    # root files. We do NOT walk the whole source tree — Source A is a sutando
-    # checkout, walking it would pull in src/, node_modules/, .git, etc.
-    # (15,044-file false positive caught in scan v1).
+    # Build the explicit walk list. Surface-restricted for Source A (its root
+    # is the SUTANDO REPO checkout, not a workspace — walking the whole tree
+    # would pull in src/, node_modules/, .git, etc; 15,044-file false positive
+    # caught in scan v1). Full-tree for sources B + C (they ARE workspace
+    # roots; user-custom content like experiments/ obsidian-vault/ should be
+    # quarantined per Lucy #design + owner direction 2026-06-02).
     local -a walk_paths=()
     local sd sf
     for sd in "${WORKSPACE_SURFACE_DIRS[@]}"; do
@@ -351,6 +390,34 @@ scan_source() {
     for sf in "${WORKSPACE_SURFACE_FILES[@]}"; do
         [ -f "$src/$sf" ] && walk_paths+=("$src/$sf")
     done
+    # Quarantine walk: for B + C, also include any TOP-LEVEL entries not
+    # already in the surface (e.g. experiments/, personal-src/, qr-codes/,
+    # obsidian-vault/, loose .ts files). Skip standard noise.
+    case "$tag" in
+        B|C)
+            local entry name
+            for entry in "$src"/* "$src"/.[!.]*; do
+                [ -e "$entry" ] || continue
+                name="$(basename "$entry")"
+                # Skip if already in surface (dirs or files).
+                local already=0
+                for sd in "${WORKSPACE_SURFACE_DIRS[@]}"; do [ "$name" = "$sd" ] && already=1 && break; done
+                [ "$already" = "1" ] && continue
+                for sf in "${WORKSPACE_SURFACE_FILES[@]}"; do [ "$name" = "$sf" ] && already=1 && break; done
+                [ "$already" = "1" ] && continue
+                # Skip standard excludes.
+                local skip=0
+                for ex in "${QUARANTINE_EXCLUDES[@]}"; do [ "$name" = "$ex" ] && skip=1 && break; done
+                [ "$skip" = "1" ] && continue
+                # Also skip hidden files that are migration sentinels themselves.
+                case "$name" in
+                    .migrated-from-*|.legacy-migrated-*|.notes-migrated|.build_log-migrated|.conversation-log-migrated|.status-migrated|.legacy-notice-printed|.last-pq-notify|.env|.gitignore)
+                        continue ;;
+                esac
+                walk_paths+=("$entry")
+            done
+            ;;
+    esac
     [ ${#walk_paths[@]} -eq 0 ] && {
         REPORT_LINES+=("  (no workspace surface present at this source — nothing to migrate)")
         return 0
@@ -754,12 +821,23 @@ commit_one() {
                 fi
                 # Genuine collision: write loser as sidecar, keep dest as primary
                 # only if dest is newer. If src is newer, swap.
+                # Per Mini #design 2026-06-02 blocker #3: 3-way collisions
+                # overwrite the .legacy-DEST sidecar when a 3rd source replaces
+                # dest. Use timestamped + source-tagged sidecar names so each
+                # collision is preserved uniquely.
+                local ts_suffix
+                ts_suffix="$(date -u +%Y%m%dT%H%M%SZ)"
                 if [ "$src_mt" -gt "$dst_mt" ]; then
-                    copy_preserving_mtime "$dst_path" "$dst_path.legacy-DEST"
+                    # dest's content (whatever was there) goes to a sidecar.
+                    # Name it .legacy-prior-<src_tag>-<ts> to convey "this is
+                    # what was at dest before <src_tag> overwrote it" + the
+                    # timestamp ensures 3-way collisions don't clobber.
+                    copy_preserving_mtime "$dst_path" "$dst_path.legacy-prior-from-$tag-$ts_suffix"
                     copy_preserving_mtime "$src_file" "$dst_path"
                     echo "src-wins-newer"
                 else
-                    copy_preserving_mtime "$src_file" "$dst_path.legacy-$tag"
+                    # src loses; preserve under tagged + timestamped sidecar.
+                    copy_preserving_mtime "$src_file" "$dst_path.legacy-$tag-$ts_suffix"
                     echo "dest-wins-newer"
                 fi
                 return 0
@@ -890,6 +968,16 @@ commit_one() {
             fi
             return 0
             ;;
+        quarantine-unknown)
+            # Per Lucy #design 2026-06-02 + owner direction: workspace sources
+            # may have user-custom content outside the canonical surface (e.g.
+            # experiments/, obsidian-vault/, personal-src/). Preserve under a
+            # namespaced quarantine path rather than skip-unknown'ing it.
+            dst_path="$DEST_REAL/legacy/$tag/quarantine/$rel"
+            copy_preserving_mtime "$src_file" "$dst_path"
+            echo "quarantined"
+            return 0
+            ;;
         skip-ephemeral|skip-unknown|unknown)
             echo "skipped-class"
             return 0
@@ -901,7 +989,7 @@ commit_one() {
 commit_source() {
     local tag="$1" src="$2"
 
-    if any_source_sentinel "$tag" && [ "$FORCE" = "0" ]; then
+    if any_source_sentinel "$tag" && [ "$FORCE" = "0" ] && [ "$DELETE_SOURCE" = "0" ]; then
         echo "sutando-migrate: source $tag has prior migration sentinel — skip (use --force)"
         return 0
     fi
@@ -909,7 +997,7 @@ commit_source() {
     echo
     echo "--- Committing source $tag ($src) ---"
 
-    # Reuse the same walk-list logic as scan_source.
+    # Reuse the same walk-list logic as scan_source (including B+C quarantine).
     local -a walk_paths=()
     local sd sf
     for sd in "${WORKSPACE_SURFACE_DIRS[@]}"; do
@@ -918,9 +1006,31 @@ commit_source() {
     for sf in "${WORKSPACE_SURFACE_FILES[@]}"; do
         [ -f "$src/$sf" ] && walk_paths+=("$src/$sf")
     done
+    case "$tag" in
+        B|C)
+            local entry name skip ex already
+            for entry in "$src"/* "$src"/.[!.]*; do
+                [ -e "$entry" ] || continue
+                name="$(basename "$entry")"
+                already=0
+                for sd in "${WORKSPACE_SURFACE_DIRS[@]}"; do [ "$name" = "$sd" ] && already=1 && break; done
+                [ "$already" = "1" ] && continue
+                for sf in "${WORKSPACE_SURFACE_FILES[@]}"; do [ "$name" = "$sf" ] && already=1 && break; done
+                [ "$already" = "1" ] && continue
+                skip=0
+                for ex in "${QUARANTINE_EXCLUDES[@]}"; do [ "$name" = "$ex" ] && skip=1 && break; done
+                [ "$skip" = "1" ] && continue
+                case "$name" in
+                    .migrated-from-*|.legacy-migrated-*|.notes-migrated|.build_log-migrated|.conversation-log-migrated|.status-migrated|.legacy-notice-printed|.last-pq-notify|.env|.gitignore)
+                        continue ;;
+                esac
+                walk_paths+=("$entry")
+            done
+            ;;
+    esac
     [ ${#walk_paths[@]} -eq 0 ] && { echo "  (nothing on surface; skip)"; return 0; }
 
-    local n_copied=0 n_kept=0 n_skipped=0 n_sidecar=0 n_rehomed=0 n_identical=0 n_other=0
+    local n_copied=0 n_kept=0 n_skipped=0 n_sidecar=0 n_rehomed=0 n_identical=0 n_quarantined=0 n_other=0
     local file rel cls outcome
     while IFS= read -r -d '' file; do
         rel="${file#"$src"/}"
@@ -932,7 +1042,7 @@ commit_source() {
         cls="$(classify "$rel")"
         outcome="$(commit_one "$file" "$rel" "$tag" "$cls")"
         case "$outcome" in
-            copied|src-wins-newer|src-newer|rehomed|rehomed-newer|merged|copied-stale)
+            copied|src-wins-newer|src-newer|rehomed|rehomed-newer|merged|archived-stale|copied-stale)
                 n_copied=$((n_copied+1)) ;;
             dest-wins-newer|dest-newer|rehomed-skip-older|skipped-collision-dest)
                 n_kept=$((n_kept+1)) ;;
@@ -940,6 +1050,8 @@ commit_source() {
                 n_identical=$((n_identical+1)) ;;
             sidecar)
                 n_sidecar=$((n_sidecar+1)) ;;
+            quarantined)
+                n_quarantined=$((n_quarantined+1)) ;;
             skipped-class|skipped-inflight|skipped-fallthrough)
                 n_skipped=$((n_skipped+1)) ;;
             *)
@@ -951,11 +1063,73 @@ commit_source() {
     echo "  identical:   $n_identical (drop-dup, no real conflict)"
     echo "  kept-dest:   $n_kept"
     echo "  sidecar:     $n_sidecar"
+    [ "$n_quarantined" -gt 0 ] && echo "  quarantined: $n_quarantined (to <dest>/legacy/$tag/quarantine/)"
     echo "  skipped:     $n_skipped"
     [ "$n_other" -gt 0 ] && echo "  other:       $n_other"
 
     touch "$(source_sentinel "$tag")"
     echo "  sentinel:    $(source_sentinel "$tag")"
+
+    # Per Mini #design 2026-06-02 blocker #4: --delete-source must actually
+    # delete sources after sha verification. The two-phase pattern means
+    # phase 1 (no-delete) ships; phase 2 (--delete-source --backup-id <id>)
+    # cleans up after ~7d observation window of no straggler writes.
+    if [ "$DELETE_SOURCE" = "1" ]; then
+        local n_deleted=0 n_kept_unsafe=0
+        # Re-walk the surface; for each file that has a sha-matching dest
+        # landing, delete the source. Skip if no match (means content didn't
+        # land — keeping source is the safe default).
+        while IFS= read -r -d '' file; do
+            local rel_d="${file#"$src"/}"
+            case "$rel_d" in
+                .git/*) continue ;;
+                .DS_Store|*/.DS_Store|.gitkeep|*/.gitkeep) continue ;;
+            esac
+            local cls_d
+            cls_d="$(classify "$rel_d")"
+            # In-flight + ephemeral classes were never copied; don't delete.
+            case "$cls_d" in
+                skip-ephemeral|skip-unknown|inflight-guard|quarantine-unknown)
+                    continue ;;
+            esac
+            # Find any dest landing whose content matches.
+            local matched=""
+            for cand in \
+                "$DEST_REAL/$rel_d" \
+                "$DEST_REAL/legacy/$tag/$rel_d" \
+                "$DEST_REAL/legacy/$tag/quarantine/$rel_d"; do
+                if [ -f "$cand" ] && sha_match "$file" "$cand"; then
+                    matched="$cand"; break
+                fi
+            done
+            # Also check timestamped sidecar globs at canonical-rel.
+            if [ -z "$matched" ]; then
+                local g
+                for g in "$DEST_REAL/$rel_d.legacy-$tag-"* "$DEST_REAL/$rel_d.legacy-prior-from-$tag-"*; do
+                    if [ -f "$g" ] && sha_match "$file" "$g"; then
+                        matched="$g"; break
+                    fi
+                done
+            fi
+            # For rehome-state class, the dest is renamed (state/auth/<base>
+            # or state/<base>); check those.
+            if [ -z "$matched" ] && [ "$cls_d" = "rehome-state" ]; then
+                local b="$(basename "$rel_d")"
+                for cand in "$DEST_REAL/state/auth/$b" "$DEST_REAL/state/$b"; do
+                    if [ -f "$cand" ] && sha_match "$file" "$cand"; then
+                        matched="$cand"; break
+                    fi
+                done
+            fi
+            if [ -n "$matched" ]; then
+                rm -f "$file" && n_deleted=$((n_deleted+1))
+            else
+                n_kept_unsafe=$((n_kept_unsafe+1))
+            fi
+        done < <(find "${walk_paths[@]}" -type f -print0 2>/dev/null)
+        echo "  deleted:     $n_deleted source files (sha verified at dest)"
+        [ "$n_kept_unsafe" -gt 0 ] && echo "  KEPT unsafe: $n_kept_unsafe source files (no matching dest content; investigate)"
+    fi
 }
 
 commit_main() {
@@ -1001,47 +1175,86 @@ commit_main() {
 }
 
 verify_main() {
+    # Per Mini #design 2026-06-02: verify must sha-compare content, not just
+    # check path existence. The previous version could pass even after a
+    # collision overwrote the source content. Now: for each indexed source
+    # file, locate its canonical dest landing OR sidecar, then sha-compare.
     echo "sutando-migrate: VERIFY mode"
-    local pass=0 fail=0 missing=0 mismatch=0
-    # For each indexed (source, file) that was supposed to land at dest:
-    # confirm dest has it (or a documented sidecar) + sha match for copied path.
+    local pass=0 missing=0 mismatch=0
     if [ ! -s "$XSRC_INDEX" ]; then
-        # No index yet — run a fresh scan to populate
         index_dest_for_collisions
         [ -n "$A_REAL_OK" ] && include_src A && scan_source A "$A_REAL_OK" >/dev/null
         [ -n "$B_REAL_OK" ] && include_src B && scan_source B "$B_REAL_OK" >/dev/null
         [ -n "$C_REAL_OK" ] && include_src C && scan_source C "$C_REAL_OK" >/dev/null
     fi
-    # Verification logic (lightweight first cut):
-    # for each non-DEST entry, the dest should have either the relpath or a
-    # sidecar at legacy/<tag>/<relpath>. Sha match for canonical winners.
+    # Need an inverse map: from indexed (tag, rel) back to the absolute source path.
+    # The scan recorded rel relative to the source root + tag. Re-derive:
+    src_path_for_tag() {
+        case "$1" in
+            A) echo "$A_REAL_OK" ;;
+            B) echo "$B_REAL_OK" ;;
+            C) echo "$C_REAL_OK" ;;
+        esac
+    }
     while IFS=$'\t' read -r rel tag cls mt sz; do
         [ "$tag" = "DEST" ] && continue
-        local dst_path="$DEST_REAL/$rel"
-        local sidecar="$DEST_REAL/legacy/$tag/$rel"
-        if [ -e "$dst_path" ] || [ -e "$sidecar" ] || [ -e "$dst_path.legacy-$tag" ]; then
+        case "$cls" in
+            skip-ephemeral|skip-unknown|inflight-guard|quarantine-unknown)
+                # These classes intentionally don't land at a stable dest path;
+                # in-flight-guard is age-dependent; quarantine is content-preserved
+                # under legacy/<tag>/quarantine/ which we verify separately below.
+                pass=$((pass+1)); continue ;;
+        esac
+        local src_root
+        src_root="$(src_path_for_tag "$tag")"
+        [ -z "$src_root" ] && { pass=$((pass+1)); continue; }
+        # The XSRC_INDEX stores POST-classification rel (e.g. rehome-state
+        # writes state/auth/cloud-auth.json but the source was at root). Try
+        # the index-rel first; if source doesn't exist there, try with the
+        # original surface mapping (basename for rehome classes).
+        local src_file="$src_root/$rel"
+        [ ! -f "$src_file" ] && src_file="$src_root/$(basename "$rel")"
+        [ ! -f "$src_file" ] && { missing=$((missing+1)); [ "$missing" -le 5 ] && echo "  MISSING-SRC: $tag/$rel ($cls)"; continue; }
+        # Candidate destinations to check (in order of likelihood per class).
+        local dst_canonical="$DEST_REAL/$rel"
+        local dst_sidecar_legacy="$DEST_REAL/legacy/$tag/$rel"
+        local dst_quarantine="$DEST_REAL/legacy/$tag/quarantine/$rel"
+        # Per Mini #3 fix: timestamped+tagged sidecars at <path>.legacy-<tag>-<ts>
+        # or <path>.legacy-prior-from-<tag>-<ts>. Use a glob to match any.
+        local landed=""
+        local cands=()
+        for c in "$dst_canonical" "$dst_sidecar_legacy" "$dst_quarantine"; do
+            cands+=("$c")
+        done
+        # Expand timestamped-sidecar globs for both src-loser and dest-prior cases.
+        for g in "$dst_canonical.legacy-$tag-"* "$dst_canonical.legacy-prior-from-$tag-"*; do
+            [ -f "$g" ] && cands+=("$g")
+        done
+        for cand in "${cands[@]}"; do
+            if [ -f "$cand" ]; then
+                if sha_match "$src_file" "$cand"; then
+                    landed="$cand"; break
+                fi
+            fi
+        done
+        if [ -n "$landed" ]; then
             pass=$((pass+1))
+        elif [ -f "$dst_canonical" ] || [ -f "$dst_sidecar_legacy" ]; then
+            # A dest path exists but sha doesn't match — content mismatch.
+            mismatch=$((mismatch+1))
+            [ "$mismatch" -le 5 ] && echo "  MISMATCH: $tag/$rel ($cls) — dest content differs from source"
         else
-            # Some classes (skip-ephemeral, inflight-guard <60s) are expected
-            # absent — only fail if the class was supposed to copy.
-            case "$cls" in
-                structural|collision-keep-both|append|newest-mtime|rehome-state)
-                    missing=$((missing+1))
-                    [ "$missing" -le 5 ] && echo "  MISSING: $tag/$rel ($cls)"
-                    ;;
-                *)
-                    pass=$((pass+1))
-                    ;;
-            esac
+            missing=$((missing+1))
+            [ "$missing" -le 5 ] && echo "  MISSING: $tag/$rel ($cls) — no dest path found"
         fi
     done < "$XSRC_INDEX"
     echo
-    echo "verify summary: pass=$pass missing=$missing"
-    if [ "$missing" -gt 0 ]; then
-        echo "verify: FAIL — $missing source files not found at dest. Inspect with --json."
+    echo "verify summary: pass=$pass missing=$missing mismatch=$mismatch"
+    if [ "$missing" -gt 0 ] || [ "$mismatch" -gt 0 ]; then
+        echo "verify: FAIL — $missing missing + $mismatch sha mismatch. Inspect with --json or scripts/sutando-migrate.sh explain <path>."
         exit 1
     fi
-    echo "verify: OK"
+    echo "verify: OK (sha-256 content match confirmed for every indexed source file)"
 }
 
 rollback_main() {

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -32,11 +32,17 @@ Otherwise, use `/loop <interval>` with this prompt:
 
 You are Sutando — a personal AI agent running as this Claude Code session.
 
-**Build log:** `build_log.md`
+**Workspace path resolution (post-M0, PR #1395):** all workspace-relative paths in this skill resolve via the M0 helper. At the top of each shell invocation that writes workspace files, set:
+```bash
+WORKSPACE="$(bash scripts/sutando-config.sh workspace)"
+```
+This resolves to `<repo>/workspace/` by default; honors `$SUTANDO_WORKSPACE` as legacy escape hatch. Never hardcode `~/.sutando/workspace/` or use the bare relative path (bash CWD is the repo, not the workspace).
+
+**Build log:** `$WORKSPACE/build_log.md`
 
 Each pass, in order:
 
-0. **Signal loop start.** Write `{"status":"running","step":"Starting pass...","ts":DATE_NOW}` to the **absolute** workspace path `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/state/core-status.json` — the session cwd is the repo, so a bare `core-status.json` lands in `<repo>/` where no reader looks (`health-check.py` and the web UI resolve `<workspace>/state/core-status.json` via `status_read_path`). Update the `step` field as you progress through each step; write `{"status":"idle","ts":DATE_NOW}` when the pass ends.
+0. **Signal loop start.** Write `{"status":"running","step":"Starting pass...","ts":DATE_NOW}` to `$WORKSPACE/state/core-status.json` (with `WORKSPACE` resolved as above). The session cwd is the repo, so a bare `core-status.json` lands in `<repo>/` where no reader looks (`health-check.py` and the web UI resolve `<workspace>/state/core-status.json` via `status_read_path`). Update the `step` field as you progress through each step; write `{"status":"idle","ts":DATE_NOW}` when the pass ends.
 
 0.5. **Check quota.** Run `python3 ~/.claude/skills/quota-tracker/scripts/read-quota.py`. Note remaining % and exact reset time.
    - **Budget per pass** = remaining % / (minutes until reset / 5)
@@ -70,7 +76,7 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 
 3. **Check system health.** Run `python3 src/health-check.py`. If issues found, fix what you can (`--fix` flag), note what you can't.
 
-4. **Read the build log** (`build_log.md`) — understand what exists. Do not rebuild what works.
+4. **Read the build log** (`$WORKSPACE/build_log.md`) — understand what exists. Do not rebuild what works.
 
 5. **Pick the highest-ROI available work.** Priority order when choosing from step 6's menu:
    - Owner tasks and blockers
@@ -87,7 +93,7 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 
    **Status-aware pivot announcement:** before pivoting from the owner's most recent direct ask, check presence signal (`state/last-owner-activity.json`). Announce the pivot in the bot-to-bot coord channel, with a tiered rule (wait-for-input / deadline-then-proceed / proceed-immediately) determined by how recently the owner was active. See `PERSONAL_CLAUDE.md` for the specific thresholds and channel target.
 
-7. **Update `build_log.md`** — mark what changed, update statuses, note what's next.
+7. **Update `$WORKSPACE/build_log.md`** — mark what changed, update statuses, note what's next.
 
 8. **If blocked, ask.** Write the question to `pending-questions.md`, send a macOS notification, and write to `results/question-{ts}.txt` if voice is connected. Don't stop — apply the Pivot-on-block rule and pick another menu item.
 

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -18,7 +18,7 @@ If an interval is provided in ARGUMENTS (e.g. "5m", "10m", "30m"), use it. Other
 
 ## On activation
 
-1. **Catchup first** (fresh-session only). Check `state/proactive-loop-started.sentinel` (resolve under `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/`). If absent → run `/catchup-after-startup` BEFORE anything else so the conversation buffer has cross-restart context, then `mkdir -p` the workspace `state/` and `touch` the sentinel. If present → this is a cron-driven pass within an already-running session; skip catchup and proceed. The sentinel is cleared by the SessionEnd hook (or explicitly via `rm state/proactive-loop-started.sentinel`) so the next fresh session re-runs catchup.
+1. **Catchup first** (fresh-session only). Resolve `WORKSPACE="$(bash scripts/sutando-config.sh workspace)"` (M0 helper, PR #1395), then check `"$WORKSPACE/state/proactive-loop-started.sentinel"`. If absent → run `/catchup-after-startup` BEFORE anything else so the conversation buffer has cross-restart context, then `mkdir -p "$WORKSPACE/state"` and `touch "$WORKSPACE/state/proactive-loop-started.sentinel"`. If present → this is a cron-driven pass within an already-running session; skip catchup and proceed. The sentinel is cleared by the SessionEnd hook (`src/session-handoff.sh`, which now resolves via the same helper) or explicitly via `rm "$WORKSPACE/state/proactive-loop-started.sentinel"` so the next fresh session re-runs catchup. **Important:** the prior `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}` form is no longer correct post-M0 (would write/check the legacy default while the handoff clears the M0 default → catchup silently skipped); always use the helper here.
 2. Run `/schedule-crons` to set up all recurring cron jobs (morning briefing, Zacks, etc.)
 3. Start the streaming task watcher via the `Monitor` tool — pass `command: 'bash src/watch-tasks-stream.sh'`, `persistent: true`, `description: 'Streaming task watcher'`. The script emits one `TASK_FILE: <basename>` line per new task file (initial sweep + each subsequent event). Read the named file via the Read tool when notifications arrive.
 
@@ -32,11 +32,14 @@ Otherwise, use `/loop <interval>` with this prompt:
 
 You are Sutando — a personal AI agent running as this Claude Code session.
 
-**Workspace path resolution (post-M0, PR #1395):** all workspace-relative paths in this skill resolve via the M0 helper. At the top of each shell invocation that writes workspace files, set:
+**Workspace path resolution (post-M0, PR #1395):** all workspace-relative paths in this skill resolve via the M0 helper. **Resolve once per pass** and reuse the variable — don't re-spawn the python subprocess per read or write:
 ```bash
 WORKSPACE="$(bash scripts/sutando-config.sh workspace)"
+# ...all subsequent reads and writes use "$WORKSPACE/<path>" — quote it.
+echo "$payload" > "$WORKSPACE/state/core-status.json"
+cat "$WORKSPACE/build_log.md"
 ```
-This resolves to `<repo>/workspace/` by default; honors `$SUTANDO_WORKSPACE` as legacy escape hatch. Never hardcode `~/.sutando/workspace/` or use the bare relative path (bash CWD is the repo, not the workspace).
+This resolves to `<repo>/workspace/` by default; honors `$SUTANDO_WORKSPACE` as legacy escape hatch. Never hardcode `~/.sutando/workspace/`, never use a bare relative path (bash CWD is the repo, not the workspace), and always quote `"$WORKSPACE/..."` so spaces in the workspace path don't tokenize.
 
 **Build log:** `$WORKSPACE/build_log.md`
 

--- a/skills/sutando-migrate/SKILL.md
+++ b/skills/sutando-migrate/SKILL.md
@@ -62,7 +62,7 @@ Summarize end-state to owner:
 - Sources preserved at original paths (per `workspace_m1_no_auto_commit`)
 - Backup-id for rollback (`bash scripts/sutando-migrate.sh rollback --backup-id <id>`)
 - Phase-2 cleanup reminder (`--delete-source` after ~7d observation)
-- Re-run `python3 src/health-check.py` to confirm the legacy-state-detected warning no longer fires (the surface count it's checking should now show 0 in the legacy locations)
+- Re-run `python3 src/health-check.py` and note: the legacy-state-detected warning WILL still fire — that's expected. The default `commit` preserves sources (matches `workspace_m1_no_auto_commit` + the (b)-style reader-fallback contract). The warning only clears after the two-phase phase 2 (`commit --delete-source --backup-id <id>` after ~7d observing no source-side writes). Mention this to owner: nag-clearance is intentional follow-up, not an unfixed bug.
 
 Write a build_log entry summarizing what migrated.
 

--- a/skills/sutando-migrate/SKILL.md
+++ b/skills/sutando-migrate/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: sutando-migrate
+description: "M1 Part 2 workspace migration — guided walkthrough that scans legacy state across sources A (repo-root), B (~/.sutando/workspace/), C ($SUTANDO_WORKSPACE env-override), surfaces collisions, gets owner greenlight, commits, verifies, and (if sutando-plus + sync configured) re-routes the vault .git via sutando-migrate-sync.sh. Wraps scripts/sutando-migrate.sh for agent-invoked use; bash entry path remains available."
+user-invocable: true
+---
+
+# Sutando Migrate
+
+Guided workspace migration for existing users (M1 Part 2). Reach for this when:
+- The legacy-state-detected warning fires (health-check, init.sh, check-pending-questions)
+- A user has data at a pre-M0 location (`<repo>/{notes,state,results,...}/`, `~/.sutando/workspace/`, or a custom `$SUTANDO_WORKSPACE`-pointed path) and wants it folded into the M0 canonical `<repo>/workspace/`
+- Owner explicitly says "migrate workspace" or "run sutando-migrate"
+
+**Usage**: `/sutando-migrate [--auto]`
+
+`--auto` proceeds without per-step greenlight. Without it the skill waits for owner OK at each phase boundary.
+
+## What this skill does (5 phases)
+
+### Phase 1 — Scan + summary
+
+Run `bash scripts/sutando-migrate.sh scan --json`. Parse the JSON for:
+- Total unique relpaths across A+B+C+dest
+- Per-source byte counts
+- Cross-source collision triage: `identical_content` (drop-dup, no action) + `mtime_only_diff` (commit's newest-mtime auto-resolves) + `size_mismatch` (REAL content conflicts — owner attention)
+- Notable size-mismatch entries (build_log, conversation.log, state/* divergences)
+
+Present a concise 4–6 line summary to owner via:
+- Discord DM (text)
+- macOS notification (`osascript -e 'display notification "scan ready: N actionable / M ignorable" with title "Sutando-Migrate"'`)
+- If voice client connected, a brief voice summary
+
+Wait for greenlight unless `--auto`.
+
+### Phase 2 — Commit (data move)
+
+If owner says go:
+- `bash scripts/sutando-migrate.sh commit` (no `--delete-source`; honors `workspace_m1_no_auto_commit`)
+- Surface the commit-output to owner: backup-id, per-source counts (copied/identical-drop/kept-dest/sidecar/skipped), sentinel paths
+
+After commit, the script prints the phase-2 footer ("After ~7d run --commit --delete-source --backup-id <id>"). Acknowledge it; don't run delete-source automatically.
+
+### Phase 3 — Verify
+
+- `bash scripts/sutando-migrate.sh verify` — confirms hash + count match per indexed source-file entry
+- If verify FAILS (returns non-zero), report the failure + suggest rollback. Don't proceed.
+
+### Phase 4 — Sync re-route (sutando-plus users only)
+
+Detect whether the user has the sync engine configured:
+- Check for `~/Documents/github/sutando-plus/scripts/sync-workspace.sh` (or `${SUTANDO_PLUS_DIR:-}/scripts/sync-workspace.sh`)
+- Check whether the source-C location has `.git` with a remote
+
+If both: run `bash $SUTANDO_PLUS_DIR/scripts/sutando-migrate-sync.sh --dry-run` first; show owner the plan; on greenlight run without `--dry-run`. Reports vault remote intact + restart instruction.
+
+If either missing: skip this phase silently; OSS users don't need it.
+
+### Phase 5 — Report + clear nag
+
+Summarize end-state to owner:
+- Files migrated (count + bytes)
+- Sources preserved at original paths (per `workspace_m1_no_auto_commit`)
+- Backup-id for rollback (`bash scripts/sutando-migrate.sh rollback --backup-id <id>`)
+- Phase-2 cleanup reminder (`--delete-source` after ~7d observation)
+- Re-run `python3 src/health-check.py` to confirm the legacy-state-detected warning no longer fires (the surface count it's checking should now show 0 in the legacy locations)
+
+Write a build_log entry summarizing what migrated.
+
+## Failure modes + fallbacks
+
+- **`scan` fails to find any source**: report "no migration needed; you're already on M0" and exit.
+- **`commit` partial-fail mid-file** (rsync interrupt etc.): rollback via the just-created backup-id, report the failure path, exit.
+- **`verify` mismatch**: report which sources failed, suggest rollback or `--force` re-commit (the latter only if owner confirms the diff is OK).
+- **`sutando-migrate-sync.sh` fails post-commit**: data is at dest; just sync is broken. Suggest manual `cd <ws>; git init; git remote add origin <vault-url>; git push -u origin <hostname>` as the recovery path. Don't auto-rollback data.
+
+## Why this is a skill (not just a script)
+
+The script (`scripts/sutando-migrate.sh`) is the engine — operator-invocable from any shell. This SKILL adds:
+- **Guided UX**: surface collision triage + phase boundaries to owner, not raw stdout
+- **Owner-aware sequencing**: macOS notification + voice + Discord (channel-of-origin aware)
+- **Sync auto-detect**: skip phase 4 for OSS users without sutando-plus
+- **Discoverability**: `/sutando-migrate` is more memorable than `bash scripts/sutando-migrate.sh scan`
+
+OSS users with sufficient bash literacy use the script directly. Most owners use the skill.
+
+## Notes for the agent invoking this skill
+
+- This skill is interactive (waits for owner greenlight at phase boundaries). Do NOT use `--auto` unless explicitly directed by owner.
+- The legacy-state-detected warning is a DISCOVERABILITY signal — when you see it in cron-probe stderr, surface to owner as a one-liner ("legacy-state detected; run /sutando-migrate to fold in") rather than running silently.
+- Per `feedback_workspace_m1_no_auto_commit`: this skill modifies workspace DATA but never runs `git commit` against the repo. Owner reviews any code changes (e.g. CLAUDE.md updates that may need to follow migration) manually.
+- Per `feedback_design_quality`: surface the COMPLETE per-phase outcome to owner, don't suppress non-blocking warnings.

--- a/src/init.sh
+++ b/src/init.sh
@@ -21,21 +21,22 @@ case "$MODE" in
   *) echo "Usage: bash src/init.sh [--auto | --preflight]"; exit 2;;
 esac
 
-# Resolve runtime workspace via the M0 helper (scripts/sutando-config.sh).
-# Post-M0 (PR #1395): default = <repo>/workspace/; $SUTANDO_WORKSPACE remains
-# honored as legacy escape hatch (via the helper or as a fallback here for
-# non-checkout installs). Runtime state files (logs, state, tasks, results,
-# notes, data, pending-questions.md, …) live here; loose status .json files
-# (core-status.json, voice-state.json, …) live under state/. Repo stays for
-# the code + skills + the schedule-crons.json copy below.
-# Fail loudly if neither path resolves — refuses to silently write to a
-# hardcoded legacy default (which would re-introduce the M1 split-brain class).
-if [ -f "$REPO/scripts/sutando-config.sh" ]; then
-  WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+# Resolve runtime workspace via the shared post-M0 helper (PR #1395).
+# Single source for the resolution pattern lives in src/workspace_resolve.sh
+# — replaces the previously-duplicated 3-way block in 5 scripts (Lucy's #1399
+# review nit). Defensive fallback to the env var for the rare case where the
+# helper file isn't reachable (non-checkout / extracted-tarball install /
+# minimized test fixture). Runtime state files (logs, state, tasks, results,
+# notes, data, pending-questions.md, …) live under the workspace; loose
+# status .json files (core-status.json, voice-state.json, …) live under state/.
+if [ -f "$REPO/src/workspace_resolve.sh" ]; then
+  # shellcheck source=workspace_resolve.sh
+  source "$REPO/src/workspace_resolve.sh"
+  resolve_workspace_or_die
 elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "init.sh: cannot resolve workspace — neither $REPO/scripts/sutando-config.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  echo "init.sh: cannot resolve workspace — neither $REPO/src/workspace_resolve.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
   exit 1
 fi
 
@@ -237,15 +238,22 @@ tier1() {
   # below points users at the CLI when legacy state is detected.
   legacy_state_notice
 
-  # Directories
-  create_dir_if_missing "logs"
-  create_dir_if_missing "state"
-  create_dir_if_missing "tasks"
-  create_dir_if_missing "results"
-  create_dir_if_missing "results/archive"
-  create_dir_if_missing "results/calls"
-  create_dir_if_missing "notes"
-  create_dir_if_missing "data"
+  # Directories — canonical list lives in `scripts/sutando-config.sh subdirs`
+  # so the layout is a single source of truth across init.sh tier1 +
+  # `bootstrap` subcommand + docs. Falls back to the historical hardcoded
+  # set if the helper isn't reachable (non-checkout install). Convergent
+  # feedback from Mini + Lucy on PR #1399.
+  if [ -f "$REPO/scripts/sutando-config.sh" ]; then
+    while IFS= read -r _d; do
+      [ -n "$_d" ] && create_dir_if_missing "$_d"
+    done < <(bash "$REPO/scripts/sutando-config.sh" subdirs)
+    unset _d
+  else
+    for _d in logs state tasks results results/archive results/calls notes data; do
+      create_dir_if_missing "$_d"
+    done
+    unset _d
+  fi
 
   # Files — placeholders only, content added by the agent later.
   # build_log.md lives under $SUTANDO_WORKSPACE per workspace contract; seeded

--- a/src/init.sh
+++ b/src/init.sh
@@ -29,16 +29,24 @@ esac
 # minimized test fixture). Runtime state files (logs, state, tasks, results,
 # notes, data, pending-questions.md, …) live under the workspace; loose
 # status .json files (core-status.json, voice-state.json, …) live under state/.
-if [ -f "$REPO/src/workspace_resolve.sh" ]; then
+# Helper lives at $REPO/src/workspace_resolve.sh in normal layout. Fall back
+# to script-sibling for cross-checkout safety: when $SUTANDO_REPO_DIR points
+# to a different checkout (e.g. owner's sutando-plus submodule pin) that
+# doesn't yet contain this newly-added file, the script-local copy is
+# always reachable. Caught by an E2E pass against PR #1399 before merge.
+__HELPER="$REPO/src/workspace_resolve.sh"
+[ -f "$__HELPER" ] || __HELPER="$(cd "$(dirname "$0")" && pwd)/workspace_resolve.sh"
+if [ -f "$__HELPER" ]; then
   # shellcheck source=workspace_resolve.sh
-  source "$REPO/src/workspace_resolve.sh"
+  source "$__HELPER"
   resolve_workspace_or_die
 elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "init.sh: cannot resolve workspace — neither $REPO/src/workspace_resolve.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  echo "init.sh: cannot resolve workspace — workspace_resolve.sh not found at \$REPO/src/ or alongside this script, and \$SUTANDO_WORKSPACE is not set." >&2
   exit 1
 fi
+unset __HELPER
 
 # Surface the silent-fallback bug class (see PR #1367/#1368): if .env defines
 # SUTANDO_WORKSPACE but this process never got it (e.g. init.sh invoked by a

--- a/src/init.sh
+++ b/src/init.sh
@@ -13,30 +13,35 @@ set -e
 REPO="${SUTANDO_REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
 MODE="${1:-full}"
 
-# Resolve runtime workspace. Same resolution shape as src/workspace_default.py
-# and startup.sh: $SUTANDO_WORKSPACE override (tilde-expanded), fallback to
-# ~/.sutando/workspace/. Runtime state files (logs, state, tasks, results,
-# notes, data, pending-questions.md, …) live here; loose status .json files
-# (core-status.json, voice-state.json, …) live under state/. Repo stays for
-# the code + skills + the schedule-crons.json copy below.
-if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
-else
-  WORKSPACE="$HOME/.sutando/workspace"
-  # Surface the silent-fallback bug class (see PR #1367/#1368): if .env
-  # defines SUTANDO_WORKSPACE but this process never got it (e.g. init.sh
-  # invoked by a bootstrap path that skips startup.sh's .env-source), the
-  # fallback lands in ~/.sutando/workspace/ while the rest of the fleet
-  # uses the override → split-brain. One stderr line per init.sh run
-  # makes the miss visible. We do NOT auto-honor the .env value here —
-  # only surface the mismatch.
-  if [ -f "$REPO/.env" ]; then
-    _env_val=$(grep -E '^SUTANDO_WORKSPACE=' "$REPO/.env" 2>/dev/null | head -1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'\$//" -e "s|^~|$HOME|")
-    if [ -n "$_env_val" ] && [ "$_env_val" != "$WORKSPACE" ]; then
-      echo "workspace: SUTANDO_WORKSPACE is unset in process env, falling back to $WORKSPACE. NOTE: .env declares SUTANDO_WORKSPACE='$_env_val' which is NOT being honored here — source .env or export the var before this process to avoid split-brain with other services." >&2
-    fi
-    unset _env_val
+# Resolve runtime workspace via the M0 helper (scripts/sutando-config.sh).
+# Post-M0 (PR #1395): default = <repo>/workspace/; $SUTANDO_WORKSPACE remains
+# honored as legacy escape hatch. Runtime state files (logs, state, tasks,
+# results, notes, data, pending-questions.md, …) live here; loose status .json
+# files (core-status.json, voice-state.json, …) live under state/. Repo stays
+# for the code + skills + the schedule-crons.json copy below.
+WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)"
+if [ -z "$WORKSPACE" ]; then
+  # Defensive fallback only if the helper isn't reachable (e.g. partial checkout
+  # or pre-M0 install). Honors the same env override the helper would.
+  if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+    WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
+  else
+    WORKSPACE="$HOME/.sutando/workspace"
   fi
+fi
+
+# Surface the silent-fallback bug class (see PR #1367/#1368): if .env defines
+# SUTANDO_WORKSPACE but this process never got it (e.g. init.sh invoked by a
+# bootstrap path that skips startup.sh's .env-source), the helper-resolved
+# value may differ from .env. One stderr line per init.sh run makes the miss
+# visible. M0's loud-warn-workspace-fallback (PR #1369) covers part of this
+# from the helper side; this is the init.sh-specific belt-and-suspenders.
+if [ -f "$REPO/.env" ]; then
+  _env_val=$(grep -E '^SUTANDO_WORKSPACE=' "$REPO/.env" 2>/dev/null | head -1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'\$//" -e "s|^~|$HOME|")
+  if [ -n "$_env_val" ] && [ "$_env_val" != "$WORKSPACE" ]; then
+    echo "workspace: .env declares SUTANDO_WORKSPACE='$_env_val' but the M0 helper resolves to '$WORKSPACE' — source .env or export the var before this process to avoid split-brain with other services." >&2
+  fi
+  unset _env_val
 fi
 
 case "$MODE" in

--- a/src/init.sh
+++ b/src/init.sh
@@ -13,21 +13,30 @@ set -e
 REPO="${SUTANDO_REPO:-$(cd "$(dirname "$0")/.." && pwd)}"
 MODE="${1:-full}"
 
+# Validate mode BEFORE workspace resolution so a usage error doesn't get
+# masked by a workspace-resolution failure (which would surface a less
+# actionable message for the caller).
+case "$MODE" in
+  --auto|--preflight|--full|full) ;;
+  *) echo "Usage: bash src/init.sh [--auto | --preflight]"; exit 2;;
+esac
+
 # Resolve runtime workspace via the M0 helper (scripts/sutando-config.sh).
 # Post-M0 (PR #1395): default = <repo>/workspace/; $SUTANDO_WORKSPACE remains
-# honored as legacy escape hatch. Runtime state files (logs, state, tasks,
-# results, notes, data, pending-questions.md, …) live here; loose status .json
-# files (core-status.json, voice-state.json, …) live under state/. Repo stays
-# for the code + skills + the schedule-crons.json copy below.
-WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)"
-if [ -z "$WORKSPACE" ]; then
-  # Defensive fallback only if the helper isn't reachable (e.g. partial checkout
-  # or pre-M0 install). Honors the same env override the helper would.
-  if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-    WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
-  else
-    WORKSPACE="$HOME/.sutando/workspace"
-  fi
+# honored as legacy escape hatch (via the helper or as a fallback here for
+# non-checkout installs). Runtime state files (logs, state, tasks, results,
+# notes, data, pending-questions.md, …) live here; loose status .json files
+# (core-status.json, voice-state.json, …) live under state/. Repo stays for
+# the code + skills + the schedule-crons.json copy below.
+# Fail loudly if neither path resolves — refuses to silently write to a
+# hardcoded legacy default (which would re-introduce the M1 split-brain class).
+if [ -f "$REPO/scripts/sutando-config.sh" ]; then
+  WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
+else
+  echo "init.sh: cannot resolve workspace — neither $REPO/scripts/sutando-config.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  exit 1
 fi
 
 # Surface the silent-fallback bug class (see PR #1367/#1368): if .env defines
@@ -43,11 +52,6 @@ if [ -f "$REPO/.env" ]; then
   fi
   unset _env_val
 fi
-
-case "$MODE" in
-  --auto|--preflight|--full|full) ;;
-  *) echo "Usage: bash src/init.sh [--auto | --preflight]"; exit 2;;
-esac
 
 log() {
   # Quiet under --auto unless we're actually creating something

--- a/src/install-credential-proxy-launchd.sh
+++ b/src/install-credential-proxy-launchd.sh
@@ -25,16 +25,21 @@ SERVICE="$DOMAIN/$LABEL"
 # Resolve runtime workspace via the shared post-M0 helper (PR #1395, single
 # source at src/workspace_resolve.sh). Defensive fallback for non-checkout
 # installs where the helper file isn't reachable.
-if [ -f "$REPO/src/workspace_resolve.sh" ]; then
+# Helper resolution: prefer $REPO/src/, fall back to script-sibling (cross-
+# checkout safety — see init.sh comment).
+__HELPER="$REPO/src/workspace_resolve.sh"
+[ -f "$__HELPER" ] || __HELPER="$(cd "$(dirname "$0")" && pwd)/workspace_resolve.sh"
+if [ -f "$__HELPER" ]; then
   # shellcheck source=workspace_resolve.sh
-  source "$REPO/src/workspace_resolve.sh"
+  source "$__HELPER"
   resolve_workspace_or_die
 elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "${0##*/}: cannot resolve workspace — neither $REPO/src/workspace_resolve.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  echo "${0##*/}: cannot resolve workspace — workspace_resolve.sh not found and \$SUTANDO_WORKSPACE not set." >&2
   exit 1
 fi
+unset __HELPER
 
 resolve_brew_bin() {
     if [ -d /opt/homebrew/bin ]; then

--- a/src/install-credential-proxy-launchd.sh
+++ b/src/install-credential-proxy-launchd.sh
@@ -22,10 +22,15 @@ DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
 DOMAIN="gui/$(id -u)"
 SERVICE="$DOMAIN/$LABEL"
 
-if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
-else
-  WORKSPACE="$HOME/.sutando/workspace"
+# Resolve runtime workspace via the M0 helper (PR #1395). Defaults to
+# <repo>/workspace/; honors $SUTANDO_WORKSPACE as legacy escape hatch.
+WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)"
+if [ -z "$WORKSPACE" ]; then
+  if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+    WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
+  else
+    WORKSPACE="$HOME/.sutando/workspace"
+  fi
 fi
 
 resolve_brew_bin() {

--- a/src/install-credential-proxy-launchd.sh
+++ b/src/install-credential-proxy-launchd.sh
@@ -22,16 +22,17 @@ DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
 DOMAIN="gui/$(id -u)"
 SERVICE="$DOMAIN/$LABEL"
 
-# Resolve runtime workspace via the M0 helper (PR #1395). Defaults to
-# <repo>/workspace/; honors $SUTANDO_WORKSPACE as legacy escape hatch.
-# Fail loud if neither path resolves — refuses to silently write to a
-# hardcoded legacy default.
-if [ -f "$REPO/scripts/sutando-config.sh" ]; then
-  WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+# Resolve runtime workspace via the shared post-M0 helper (PR #1395, single
+# source at src/workspace_resolve.sh). Defensive fallback for non-checkout
+# installs where the helper file isn't reachable.
+if [ -f "$REPO/src/workspace_resolve.sh" ]; then
+  # shellcheck source=workspace_resolve.sh
+  source "$REPO/src/workspace_resolve.sh"
+  resolve_workspace_or_die
 elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "install-credential-proxy-launchd: cannot resolve workspace — neither $REPO/scripts/sutando-config.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  echo "${0##*/}: cannot resolve workspace — neither $REPO/src/workspace_resolve.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
   exit 1
 fi
 

--- a/src/install-credential-proxy-launchd.sh
+++ b/src/install-credential-proxy-launchd.sh
@@ -24,13 +24,15 @@ SERVICE="$DOMAIN/$LABEL"
 
 # Resolve runtime workspace via the M0 helper (PR #1395). Defaults to
 # <repo>/workspace/; honors $SUTANDO_WORKSPACE as legacy escape hatch.
-WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)"
-if [ -z "$WORKSPACE" ]; then
-  if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-    WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
-  else
-    WORKSPACE="$HOME/.sutando/workspace"
-  fi
+# Fail loud if neither path resolves — refuses to silently write to a
+# hardcoded legacy default.
+if [ -f "$REPO/scripts/sutando-config.sh" ]; then
+  WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
+else
+  echo "install-credential-proxy-launchd: cannot resolve workspace — neither $REPO/scripts/sutando-config.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  exit 1
 fi
 
 resolve_brew_bin() {

--- a/src/install-health-check-launchd.sh
+++ b/src/install-health-check-launchd.sh
@@ -49,14 +49,15 @@ SERVICE="$DOMAIN/$LABEL"
 # Resolve runtime workspace via the M0 helper (PR #1395). Defaults to
 # <repo>/workspace/; honors $SUTANDO_WORKSPACE as legacy escape hatch.
 # Launchd job writes its log under $WORKSPACE/logs/ instead of the repo-root
-# legacy path (per PR #911's workspace-vs-repo split).
-WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)"
-if [ -z "$WORKSPACE" ]; then
-  if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-    WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
-  else
-    WORKSPACE="$HOME/.sutando/workspace"
-  fi
+# legacy path (per PR #911's workspace-vs-repo split). Fail loud if neither
+# resolves.
+if [ -f "$REPO/scripts/sutando-config.sh" ]; then
+  WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
+else
+  echo "install-health-check-launchd: cannot resolve workspace — neither $REPO/scripts/sutando-config.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  exit 1
 fi
 
 cmd="${1:-install}"

--- a/src/install-health-check-launchd.sh
+++ b/src/install-health-check-launchd.sh
@@ -50,16 +50,21 @@ SERVICE="$DOMAIN/$LABEL"
 # source at src/workspace_resolve.sh). Launchd job writes its log under
 # $WORKSPACE/logs/ instead of the repo-root legacy path (per PR #911's
 # workspace-vs-repo split). Defensive fallback for non-checkout installs.
-if [ -f "$REPO/src/workspace_resolve.sh" ]; then
+# Helper resolution: prefer $REPO/src/, fall back to script-sibling (cross-
+# checkout safety — see init.sh comment).
+__HELPER="$REPO/src/workspace_resolve.sh"
+[ -f "$__HELPER" ] || __HELPER="$(cd "$(dirname "$0")" && pwd)/workspace_resolve.sh"
+if [ -f "$__HELPER" ]; then
   # shellcheck source=workspace_resolve.sh
-  source "$REPO/src/workspace_resolve.sh"
+  source "$__HELPER"
   resolve_workspace_or_die
 elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "${0##*/}: cannot resolve workspace — neither $REPO/src/workspace_resolve.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  echo "${0##*/}: cannot resolve workspace — workspace_resolve.sh not found and \$SUTANDO_WORKSPACE not set." >&2
   exit 1
 fi
+unset __HELPER
 
 cmd="${1:-install}"
 

--- a/src/install-health-check-launchd.sh
+++ b/src/install-health-check-launchd.sh
@@ -46,17 +46,18 @@ DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
 DOMAIN="gui/$(id -u)"
 SERVICE="$DOMAIN/$LABEL"
 
-# Resolve runtime workspace via the M0 helper (PR #1395). Defaults to
-# <repo>/workspace/; honors $SUTANDO_WORKSPACE as legacy escape hatch.
-# Launchd job writes its log under $WORKSPACE/logs/ instead of the repo-root
-# legacy path (per PR #911's workspace-vs-repo split). Fail loud if neither
-# resolves.
-if [ -f "$REPO/scripts/sutando-config.sh" ]; then
-  WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+# Resolve runtime workspace via the shared post-M0 helper (PR #1395, single
+# source at src/workspace_resolve.sh). Launchd job writes its log under
+# $WORKSPACE/logs/ instead of the repo-root legacy path (per PR #911's
+# workspace-vs-repo split). Defensive fallback for non-checkout installs.
+if [ -f "$REPO/src/workspace_resolve.sh" ]; then
+  # shellcheck source=workspace_resolve.sh
+  source "$REPO/src/workspace_resolve.sh"
+  resolve_workspace_or_die
 elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "install-health-check-launchd: cannot resolve workspace — neither $REPO/scripts/sutando-config.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  echo "${0##*/}: cannot resolve workspace — neither $REPO/src/workspace_resolve.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
   exit 1
 fi
 

--- a/src/install-health-check-launchd.sh
+++ b/src/install-health-check-launchd.sh
@@ -46,14 +46,17 @@ DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
 DOMAIN="gui/$(id -u)"
 SERVICE="$DOMAIN/$LABEL"
 
-# Resolve runtime workspace — launchd job writes its log under
-# $WORKSPACE/logs/ instead of the repo-root legacy path (per PR #911's
-# workspace-vs-repo split). Same resolution shape as src/startup.sh +
-# workspace_default.py.
-if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
-else
-  WORKSPACE="$HOME/.sutando/workspace"
+# Resolve runtime workspace via the M0 helper (PR #1395). Defaults to
+# <repo>/workspace/; honors $SUTANDO_WORKSPACE as legacy escape hatch.
+# Launchd job writes its log under $WORKSPACE/logs/ instead of the repo-root
+# legacy path (per PR #911's workspace-vs-repo split).
+WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)"
+if [ -z "$WORKSPACE" ]; then
+  if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+    WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
+  else
+    WORKSPACE="$HOME/.sutando/workspace"
+  fi
 fi
 
 cmd="${1:-install}"

--- a/src/install-sutando-app-launchd.sh
+++ b/src/install-sutando-app-launchd.sh
@@ -34,11 +34,15 @@ DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
 DOMAIN="gui/$(id -u)"
 SERVICE="$DOMAIN/$LABEL"
 
-# Resolve runtime workspace (mirrors workspace_default.py / startup.sh).
-if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
-else
-  WORKSPACE="$HOME/.sutando/workspace"
+# Resolve runtime workspace via the M0 helper (PR #1395). Defaults to
+# <repo>/workspace/; honors $SUTANDO_WORKSPACE as legacy escape hatch.
+WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)"
+if [ -z "$WORKSPACE" ]; then
+  if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+    WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
+  else
+    WORKSPACE="$HOME/.sutando/workspace"
+  fi
 fi
 
 APP_BINARY="$REPO/src/Sutando/Sutando.app/Contents/MacOS/Sutando"

--- a/src/install-sutando-app-launchd.sh
+++ b/src/install-sutando-app-launchd.sh
@@ -34,15 +34,17 @@ DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
 DOMAIN="gui/$(id -u)"
 SERVICE="$DOMAIN/$LABEL"
 
-# Resolve runtime workspace via the M0 helper (PR #1395). Defaults to
-# <repo>/workspace/; honors $SUTANDO_WORKSPACE as legacy escape hatch.
-# Fail loud if neither path resolves.
-if [ -f "$REPO/scripts/sutando-config.sh" ]; then
-  WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+# Resolve runtime workspace via the shared post-M0 helper (PR #1395, single
+# source at src/workspace_resolve.sh). Defensive fallback for non-checkout
+# installs where the helper file isn't reachable.
+if [ -f "$REPO/src/workspace_resolve.sh" ]; then
+  # shellcheck source=workspace_resolve.sh
+  source "$REPO/src/workspace_resolve.sh"
+  resolve_workspace_or_die
 elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "install-sutando-app-launchd: cannot resolve workspace — neither $REPO/scripts/sutando-config.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  echo "${0##*/}: cannot resolve workspace — neither $REPO/src/workspace_resolve.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
   exit 1
 fi
 

--- a/src/install-sutando-app-launchd.sh
+++ b/src/install-sutando-app-launchd.sh
@@ -36,13 +36,14 @@ SERVICE="$DOMAIN/$LABEL"
 
 # Resolve runtime workspace via the M0 helper (PR #1395). Defaults to
 # <repo>/workspace/; honors $SUTANDO_WORKSPACE as legacy escape hatch.
-WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)"
-if [ -z "$WORKSPACE" ]; then
-  if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-    WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
-  else
-    WORKSPACE="$HOME/.sutando/workspace"
-  fi
+# Fail loud if neither path resolves.
+if [ -f "$REPO/scripts/sutando-config.sh" ]; then
+  WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
+else
+  echo "install-sutando-app-launchd: cannot resolve workspace — neither $REPO/scripts/sutando-config.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  exit 1
 fi
 
 APP_BINARY="$REPO/src/Sutando/Sutando.app/Contents/MacOS/Sutando"

--- a/src/install-sutando-app-launchd.sh
+++ b/src/install-sutando-app-launchd.sh
@@ -37,16 +37,21 @@ SERVICE="$DOMAIN/$LABEL"
 # Resolve runtime workspace via the shared post-M0 helper (PR #1395, single
 # source at src/workspace_resolve.sh). Defensive fallback for non-checkout
 # installs where the helper file isn't reachable.
-if [ -f "$REPO/src/workspace_resolve.sh" ]; then
+# Helper resolution: prefer $REPO/src/, fall back to script-sibling (cross-
+# checkout safety — see init.sh comment).
+__HELPER="$REPO/src/workspace_resolve.sh"
+[ -f "$__HELPER" ] || __HELPER="$(cd "$(dirname "$0")" && pwd)/workspace_resolve.sh"
+if [ -f "$__HELPER" ]; then
   # shellcheck source=workspace_resolve.sh
-  source "$REPO/src/workspace_resolve.sh"
+  source "$__HELPER"
   resolve_workspace_or_die
 elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "${0##*/}: cannot resolve workspace — neither $REPO/src/workspace_resolve.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  echo "${0##*/}: cannot resolve workspace — workspace_resolve.sh not found and \$SUTANDO_WORKSPACE not set." >&2
   exit 1
 fi
+unset __HELPER
 
 APP_BINARY="$REPO/src/Sutando/Sutando.app/Contents/MacOS/Sutando"
 

--- a/src/launchd/com.sutando.menubar.plist
+++ b/src/launchd/com.sutando.menubar.plist
@@ -62,7 +62,9 @@
     <key>EnvironmentVariables</key>
     <dict>
         <!-- Pass workspace location so the app writes tasks/results/logs
-             under ~/.sutando/workspace/ rather than the repo root. -->
+             under the M0-resolved workspace (default <repo>/workspace/ post-PR #1395)
+             rather than the repo root. Installer substitutes __WORKSPACE__ from
+             scripts/sutando-config.sh — env var here is just propagation. -->
         <key>SUTANDO_WORKSPACE</key>
         <string>__WORKSPACE__</string>
         <key>SUTANDO_REPO_DIR</key>

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -22,11 +22,18 @@ export PATH="/opt/homebrew/bin:$HOME/.nvm/versions/node/v24.14.1/bin:$PATH"
 STATE_FILE="$REPO/session-state.md"
 TRANSCRIPT="$1"  # Passed by PreCompact hook as $TRANSCRIPT_PATH
 
-# Workspace resolves via the M0 helper (scripts/sutando-config.sh). Falls back
-# to the legacy default only if the helper isn't available — defensive guard,
-# not the primary path. See workspace-revamp M0 (PR #1395).
-WORKSPACE_DIR=$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)
-[ -z "$WORKSPACE_DIR" ] && WORKSPACE_DIR="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+# Workspace resolves via the M0 helper (scripts/sutando-config.sh). Honors
+# $SUTANDO_WORKSPACE as a legacy fallback for non-checkout installs where
+# the helper isn't present. Fail-loud if neither resolves — refuses to write
+# to a hardcoded legacy default. See workspace-revamp M0 (PR #1395).
+if [ -f "$REPO/scripts/sutando-config.sh" ]; then
+  WORKSPACE_DIR="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+  WORKSPACE_DIR="${SUTANDO_WORKSPACE/#\~/$HOME}"
+else
+  echo "session-handoff: cannot resolve workspace — neither $REPO/scripts/sutando-config.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  exit 1
+fi
 
 # Build state from available signals
 {

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -22,18 +22,26 @@ export PATH="/opt/homebrew/bin:$HOME/.nvm/versions/node/v24.14.1/bin:$PATH"
 STATE_FILE="$REPO/session-state.md"
 TRANSCRIPT="$1"  # Passed by PreCompact hook as $TRANSCRIPT_PATH
 
-# Workspace resolves via the M0 helper (scripts/sutando-config.sh). Honors
-# $SUTANDO_WORKSPACE as a legacy fallback for non-checkout installs where
-# the helper isn't present. Fail-loud if neither resolves — refuses to write
-# to a hardcoded legacy default. See workspace-revamp M0 (PR #1395).
-if [ -f "$REPO/scripts/sutando-config.sh" ]; then
-  WORKSPACE_DIR="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+# Workspace resolves via the shared post-M0 helper (src/workspace_resolve.sh).
+# Exports $WORKSPACE on success; exits non-zero with a diagnostic on failure
+# (including empty-string returns — important because this script does NOT
+# use `set -e`). See workspace-revamp M0 (PR #1395) + Mini's PR #1399 review.
+# Defensive fallback for non-checkout installs where the helper isn't present.
+if [ -f "$REPO/src/workspace_resolve.sh" ]; then
+  # shellcheck source=workspace_resolve.sh
+  source "$REPO/src/workspace_resolve.sh"
+  resolve_workspace_or_die
 elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-  WORKSPACE_DIR="${SUTANDO_WORKSPACE/#\~/$HOME}"
+  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "session-handoff: cannot resolve workspace — neither $REPO/scripts/sutando-config.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  echo "session-handoff: cannot resolve workspace — neither $REPO/src/workspace_resolve.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
   exit 1
 fi
+if [ -z "${WORKSPACE:-}" ]; then
+  echo "session-handoff: workspace resolved to empty string. Refusing to derive paths under /." >&2
+  exit 1
+fi
+WORKSPACE_DIR="$WORKSPACE"  # historical local name retained for the rest of this file
 
 # Build state from available signals
 {
@@ -79,7 +87,7 @@ print(personal_path('pending-questions.md', Path('$REPO')))
 
   # Tasks in flight
   echo "## Tasks"
-  ls "$REPO/tasks/"*.txt 2>/dev/null | head -5 || echo "None pending"
+  ls "$WORKSPACE_DIR/tasks/"*.txt 2>/dev/null | head -5 || echo "None pending"
   echo ""
 
   # Quota (with reset times)

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -27,16 +27,25 @@ TRANSCRIPT="$1"  # Passed by PreCompact hook as $TRANSCRIPT_PATH
 # (including empty-string returns — important because this script does NOT
 # use `set -e`). See workspace-revamp M0 (PR #1395) + Mini's PR #1399 review.
 # Defensive fallback for non-checkout installs where the helper isn't present.
-if [ -f "$REPO/src/workspace_resolve.sh" ]; then
+# Helper resolution: prefer $REPO/src/, fall back to script-sibling (cross-
+# checkout safety). Critical for session-handoff specifically because its
+# REPO resolution above prefers $SUTANDO_REPO_DIR over script-parent, and
+# that env can point to a sibling checkout (e.g. sutando-plus submodule pin)
+# that hasn't yet pulled this newly-added file. Caught by E2E pass against
+# PR #1399.
+__HELPER="$REPO/src/workspace_resolve.sh"
+[ -f "$__HELPER" ] || __HELPER="$(cd "$(dirname "$0")" && pwd)/workspace_resolve.sh"
+if [ -f "$__HELPER" ]; then
   # shellcheck source=workspace_resolve.sh
-  source "$REPO/src/workspace_resolve.sh"
+  source "$__HELPER"
   resolve_workspace_or_die
 elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "session-handoff: cannot resolve workspace — neither $REPO/src/workspace_resolve.sh exists nor \$SUTANDO_WORKSPACE is set." >&2
+  echo "session-handoff: cannot resolve workspace — workspace_resolve.sh not found at \$REPO/src/ or alongside this script, and \$SUTANDO_WORKSPACE is not set." >&2
   exit 1
 fi
+unset __HELPER
 if [ -z "${WORKSPACE:-}" ]; then
   echo "session-handoff: workspace resolved to empty string. Refusing to derive paths under /." >&2
   exit 1

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -22,6 +22,12 @@ export PATH="/opt/homebrew/bin:$HOME/.nvm/versions/node/v24.14.1/bin:$PATH"
 STATE_FILE="$REPO/session-state.md"
 TRANSCRIPT="$1"  # Passed by PreCompact hook as $TRANSCRIPT_PATH
 
+# Workspace resolves via the M0 helper (scripts/sutando-config.sh). Falls back
+# to the legacy default only if the helper isn't available — defensive guard,
+# not the primary path. See workspace-revamp M0 (PR #1395).
+WORKSPACE_DIR=$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)
+[ -z "$WORKSPACE_DIR" ] && WORKSPACE_DIR="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+
 # Build state from available signals
 {
   echo "---"
@@ -74,7 +80,7 @@ print(personal_path('pending-questions.md', Path('$REPO')))
   # Quota state is per-user runtime state — canonical home is
   # <workspace>/state/quota-state.json (written by the credential proxy).
   # Reading an in-repo copy would pick up a stale shadow (see PR #970).
-  QUOTA_FILE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/state/quota-state.json"
+  QUOTA_FILE="$WORKSPACE_DIR/state/quota-state.json"
   if [ -f "$QUOTA_FILE" ]; then
     python3 -c "
 import json
@@ -101,5 +107,5 @@ echo "Session state saved to $STATE_FILE"
 # from the just-ended session persists and the next /proactive-loop's step 1
 # skips catchup, defeating the auto-fire wiring. (Paired with
 # skills/proactive-loop/SKILL.md step 1's sentinel guard.)
-SENTINEL="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}/state/proactive-loop-started.sentinel"
+SENTINEL="$WORKSPACE_DIR/state/proactive-loop-started.sentinel"
 rm -f "$SENTINEL" 2>/dev/null

--- a/src/voice-agent.config.json.example
+++ b/src/voice-agent.config.json.example
@@ -1,5 +1,5 @@
 {
-  "_comment": "TEMPLATE — do not edit in place. The live config is per-user data and lives at $SUTANDO_WORKSPACE/config/voice-agent.json (default ~/.sutando/workspace/config/voice-agent.json). On first run voice-agent copies this template there if it is missing. Edit the workspace copy, never this file. Keys: model + googleSearch are voice prefs (the switch_voice_config tool writes them at runtime). voice-agent ships with model=3.1 + googleSearch=false because the web client's code-heavy workload prefers 3.1.",
+  "_comment": "TEMPLATE — do not edit in place. The live config is per-user data and lives at $WORKSPACE/config/voice-agent.json where $WORKSPACE is resolved via scripts/sutando-config.sh (M0 default: <repo>/workspace/; $SUTANDO_WORKSPACE honored as legacy escape hatch). On first run voice-agent copies this template there if it is missing. Edit the workspace copy, never this file. Keys: model + googleSearch are voice prefs (the switch_voice_config tool writes them at runtime). voice-agent ships with model=3.1 + googleSearch=false because the web client's code-heavy workload prefers 3.1.",
   "model": "gemini-3.1-flash-live-preview",
   "googleSearch": false
 }

--- a/src/workspace_resolve.sh
+++ b/src/workspace_resolve.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Shared workspace resolution for bash scripts. Source this file with:
+#
+#   source "$REPO/src/workspace_resolve.sh"
+#   resolve_workspace_or_die  # exports WORKSPACE; exits non-zero on failure
+#
+# Single source for the post-M0 (PR #1395) resolution pattern. Replaces the
+# `if helper; elif env; else fail` block previously duplicated across:
+# init.sh, install-credential-proxy-launchd.sh, install-sutando-app-launchd.sh,
+# install-health-check-launchd.sh, session-handoff.sh. Factored out per
+# Lucy's PR #1399 review nit #1.
+#
+# Resolution order:
+#   1. scripts/sutando-config.sh helper (M0 default = <repo>/workspace/, env
+#      var honored internally as legacy escape hatch)
+#   2. $SUTANDO_WORKSPACE env var (only when helper is unreachable —
+#      non-checkout / extracted-tarball install)
+#   3. Fail loud with exit 1 + diagnostic. Refuses to silently write to a
+#      hardcoded legacy default.
+#
+# Caller contract: must export $REPO before sourcing or calling. The function
+# exports WORKSPACE on success.
+
+resolve_workspace_or_die() {
+  local helper="${REPO:?resolve_workspace_or_die: \$REPO not set}/scripts/sutando-config.sh"
+  if [ -f "$helper" ]; then
+    if ! WORKSPACE="$(bash "$helper" workspace)"; then
+      echo "${0##*/}: ${helper##*/} workspace exited non-zero." >&2
+      exit 1
+    fi
+  elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+    WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
+  else
+    echo "${0##*/}: cannot resolve workspace — neither $helper exists nor \$SUTANDO_WORKSPACE is set." >&2
+    exit 1
+  fi
+  if [ -z "$WORKSPACE" ]; then
+    echo "${0##*/}: workspace resolved to empty string. Refusing to derive paths under /." >&2
+    exit 1
+  fi
+  export WORKSPACE
+}

--- a/src/workspace_resolve.sh
+++ b/src/workspace_resolve.sh
@@ -18,14 +18,19 @@
 #   3. Fail loud with exit 1 + diagnostic. Refuses to silently write to a
 #      hardcoded legacy default.
 #
-# Caller contract: must export $REPO before sourcing or calling. The function
-# exports WORKSPACE on success.
+# Self-locating: looks for scripts/sutando-config.sh relative to THIS file's
+# own location (${BASH_SOURCE[0]}), NOT $REPO. This makes the function
+# cross-checkout safe — callers can be invoked with $SUTANDO_REPO_DIR pointed
+# at a different checkout (e.g. submodule pin) without breaking helper
+# resolution. Caught by E2E pass against PR #1399 — see commit log.
 
 resolve_workspace_or_die() {
-  local helper="${REPO:?resolve_workspace_or_die: \$REPO not set}/scripts/sutando-config.sh"
+  local _wr_dir
+  _wr_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local helper="$_wr_dir/../scripts/sutando-config.sh"
   if [ -f "$helper" ]; then
     if ! WORKSPACE="$(bash "$helper" workspace)"; then
-      echo "${0##*/}: ${helper##*/} workspace exited non-zero." >&2
+      echo "${0##*/}: scripts/sutando-config.sh workspace exited non-zero." >&2
       exit 1
     fi
   elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then

--- a/tests/sutando-config-shell.test.ts
+++ b/tests/sutando-config-shell.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readdirSync, rmSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, rmSync, mkdirSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -93,6 +93,25 @@ describe('sutando-config.sh wrapper', () => {
 			assert.ok(existsSync(join(ws, d)), `bootstrap did not create "${d}"`);
 		}
 
+		// Snapshot directory state for strict idempotency comparison.
+		// Sorted top-level + recursive-mtimes — if the second run mutates
+		// anything (creates extras, touches mtimes, etc.) the snapshot diverges.
+		const snapshot = (root: string) => {
+			const out: Record<string, number> = {};
+			const walk = (p: string) => {
+				const stat = statSync(p);
+				out[p.slice(root.length)] = stat.mtimeMs;
+				if (stat.isDirectory()) {
+					for (const child of readdirSync(p).sort()) {
+						walk(join(p, child));
+					}
+				}
+			};
+			walk(root);
+			return out;
+		};
+		const before = snapshot(ws);
+
 		// Second run — must be a no-op (idempotent)
 		const second = spawnSync('bash', [SCRIPT, 'bootstrap'], {
 			env: { ...process.env, SUTANDO_WORKSPACE: ws },
@@ -102,5 +121,17 @@ describe('sutando-config.sh wrapper', () => {
 		for (const d of subdirsOut) {
 			assert.ok(existsSync(join(ws, d)), `bootstrap idempotency broken: "${d}" missing after second run`);
 		}
+
+		// Strict idempotency: top-level dir set must be IDENTICAL across runs.
+		// `mkdir -p` is a no-op on existing dirs so mtimes stay frozen — if
+		// anything else mutates, the snapshot diverges. (Mini's PR #1399 catch:
+		// the prior test only checked "dirs exist after," not "nothing extra
+		// was created or touched.")
+		const after = snapshot(ws);
+		assert.deepEqual(
+			Object.keys(after).sort(),
+			Object.keys(before).sort(),
+			'bootstrap second run mutated the workspace dir set',
+		);
 	});
 });

--- a/tests/sutando-config-shell.test.ts
+++ b/tests/sutando-config-shell.test.ts
@@ -122,16 +122,18 @@ describe('sutando-config.sh wrapper', () => {
 			assert.ok(existsSync(join(ws, d)), `bootstrap idempotency broken: "${d}" missing after second run`);
 		}
 
-		// Strict idempotency: top-level dir set must be IDENTICAL across runs.
-		// `mkdir -p` is a no-op on existing dirs so mtimes stay frozen — if
-		// anything else mutates, the snapshot diverges. (Mini's PR #1399 catch:
-		// the prior test only checked "dirs exist after," not "nothing extra
-		// was created or touched.")
+		// Strict idempotency: the FULL snapshot (paths + mtimes) must be
+		// identical across runs. `mkdir -p` is a no-op on existing dirs so
+		// mtimes stay frozen — if `bootstrap` touches anything (creates an
+		// extra path, chmods, writes a marker), the deep-equal diverges.
+		// (Mini + Sutando-Pro PR #1399 round-3 catch: the prior assertion
+		// only compared Object.keys, throwing away the mtime values the
+		// snapshot collected — claim/code mismatch with the comment above.)
 		const after = snapshot(ws);
 		assert.deepEqual(
-			Object.keys(after).sort(),
-			Object.keys(before).sort(),
-			'bootstrap second run mutated the workspace dir set',
+			after,
+			before,
+			'bootstrap second run mutated the workspace (path set or mtime changed)',
 		);
 	});
 });

--- a/tests/sutando-config-shell.test.ts
+++ b/tests/sutando-config-shell.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Smoke tests for `scripts/sutando-config.sh` — the bash wrapper around the
+ * canonical Python workspace loader. Verifies:
+ *   1. `sutando-config.sh workspace` returns the same path as the Python loader
+ *      (no shell-vs-py drift — Lucy's PR #1399 review nit re. wrapper coverage)
+ *   2. `sutando-config.sh subdirs` returns the documented canonical list
+ *   3. `sutando-config.sh bootstrap` creates exactly that subdir set,
+ *      idempotently (second run is a no-op)
+ *
+ * Run: tsx --test tests/sutando-config-shell.test.ts
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readdirSync, rmSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT = join(REPO_ROOT, 'scripts', 'sutando-config.sh');
+
+function runShell(subcmd: string, ws: string): string {
+	const proc = spawnSync('bash', [SCRIPT, subcmd], {
+		env: { ...process.env, SUTANDO_WORKSPACE: ws },
+		encoding: 'utf-8',
+	});
+	if (proc.status !== 0) {
+		throw new Error(`${subcmd} exit ${proc.status}: stderr=${proc.stderr}`);
+	}
+	return proc.stdout;
+}
+
+function runPyResolve(ws: string): string {
+	const proc = spawnSync(
+		'python3',
+		['-c', 'import sys; sys.path.insert(0, ".."); from importlib import import_module; m = import_module("src.sutando_config"); print(m.resolve_workspace(), end="")'],
+		{
+			cwd: REPO_ROOT,
+			env: { ...process.env, SUTANDO_WORKSPACE: ws },
+			encoding: 'utf-8',
+		},
+	);
+	if (proc.status !== 0) {
+		throw new Error(`py resolve_workspace exit ${proc.status}: stderr=${proc.stderr}`);
+	}
+	return proc.stdout;
+}
+
+let scratch: string;
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), 'sutando-config-shell-'));
+});
+
+afterEach(() => {
+	try { rmSync(scratch, { recursive: true, force: true }); } catch {}
+});
+
+describe('sutando-config.sh wrapper', () => {
+	it('workspace subcommand matches python loader (no shell-vs-py drift)', () => {
+		const ws = join(scratch, 'ws');
+		mkdirSync(ws, { recursive: true });
+		const shellOut = runShell('workspace', ws);
+		// Try the py path directly — but cope with src/ import contexts
+		const proc = spawnSync(
+			'python3',
+			['-c', 'import sys; sys.path.insert(0, "."); from src.sutando_config import resolve_workspace; print(resolve_workspace(), end="")'],
+			{ cwd: REPO_ROOT, env: { ...process.env, SUTANDO_WORKSPACE: ws }, encoding: 'utf-8' },
+		);
+		assert.equal(proc.status, 0, `py loader failed: ${proc.stderr}`);
+		assert.equal(shellOut, proc.stdout, 'shell wrapper diverges from py loader');
+	});
+
+	it('subdirs subcommand prints non-empty newline-separated list', () => {
+		const out = runShell('subdirs', join(scratch, 'ws')).trim();
+		const lines = out.split('\n').filter(Boolean);
+		assert.ok(lines.length >= 5, `subdirs returned too few entries: ${lines.length}`);
+		// Canonical set we DO expect (anchor — adding new subdirs is fine, removing these is breaking)
+		for (const expected of ['state', 'tasks', 'results', 'notes', 'logs']) {
+			assert.ok(lines.includes(expected), `subdirs missing canonical entry "${expected}"`);
+		}
+	});
+
+	it('bootstrap creates every subdir from `subdirs` and is idempotent', () => {
+		const ws = join(scratch, 'ws');
+		mkdirSync(ws, { recursive: true });
+		const subdirsOut = runShell('subdirs', ws).trim().split('\n').filter(Boolean);
+
+		// First run — creates all
+		runShell('bootstrap', ws);
+		for (const d of subdirsOut) {
+			assert.ok(existsSync(join(ws, d)), `bootstrap did not create "${d}"`);
+		}
+
+		// Second run — must be a no-op (idempotent)
+		const second = spawnSync('bash', [SCRIPT, 'bootstrap'], {
+			env: { ...process.env, SUTANDO_WORKSPACE: ws },
+			encoding: 'utf-8',
+		});
+		assert.equal(second.status, 0, `second bootstrap exit ${second.status}: ${second.stderr}`);
+		for (const d of subdirsOut) {
+			assert.ok(existsSync(join(ws, d)), `bootstrap idempotency broken: "${d}" missing after second run`);
+		}
+	});
+});

--- a/tests/sutando-migrate-rules.test.sh
+++ b/tests/sutando-migrate-rules.test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Per-CLASS_RULES-row test fixtures for sutando-migrate.sh.
+# Exercises `explain <path>` against a representative path for each rule and
+# asserts the expected class matches. Catches glob-order regressions where a
+# generic catchall starts swallowing paths a more-specific rule was meant to
+# handle.
+#
+# Mini #design 2026-06-02: "Add a unit-test fixture per CLASS_RULES row.
+# Catches future glob-order regressions."
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+MIGRATE="$REPO/scripts/sutando-migrate.sh"
+
+assert_class() {
+    # $1=relpath, $2=expected class, $3=expected dest pattern (optional)
+    local rel="$1" expected="$2" dest_pattern="${3:-}"
+    local out cls dest
+    out="$(bash "$MIGRATE" explain "$rel" 2>/dev/null)" || {
+        echo "  FAIL: explain $rel exited non-zero"
+        return 1
+    }
+    cls="$(echo "$out" | grep '^class:' | sed 's/^class:[[:space:]]*//')"
+    dest="$(echo "$out" | grep '^dest:' | sed 's/^dest:[[:space:]]*//')"
+    if [ "$cls" != "$expected" ]; then
+        echo "  FAIL: $rel — expected class=$expected got $cls"
+        return 1
+    fi
+    if [ -n "$dest_pattern" ] && ! echo "$dest" | grep -q "$dest_pattern"; then
+        echo "  FAIL: $rel — expected dest match /$dest_pattern/ got $dest"
+        return 1
+    fi
+    echo "  OK: $rel  →  $cls  ($dest)"
+    return 0
+}
+
+fail=0
+
+echo "==== Per-CLASS_RULES-row assertions ===="
+
+# Root files
+assert_class "build_log.md" "append" "<dest>/build_log.md" || fail=1
+assert_class "conversation.log" "rehome-narrative-log" "workspace-narrative.log" || fail=1
+assert_class "context-drop.txt" "append" || fail=1
+assert_class "pending-questions.md" "append" || fail=1
+assert_class "pending-questions-resolved-archive-2026-05-24.md" "rehome-dated-snapshot" "notes/archive" || fail=1
+assert_class "session-state.md" "newest-mtime" || fail=1
+
+# Loose JSONs (rehome-state)
+assert_class "cloud-auth.json" "rehome-state" "state/auth/cloud-auth.json" || fail=1
+assert_class "device.json" "rehome-state" "state/auth/device.json" || fail=1
+assert_class "contextual-chips.json" "rehome-state" "state/contextual-chips.json" || fail=1
+assert_class "voice-state.json" "rehome-state" "state/voice-state.json" || fail=1
+assert_class "core-status.json" "rehome-state" "state/core-status.json" || fail=1
+
+# tasks/
+assert_class "tasks/archive/2026-05/task-x.txt" "structural" || fail=1
+assert_class "tasks/processed/task-old.txt" "structural" || fail=1
+assert_class "tasks/done/task-2025.txt" "structural" || fail=1
+assert_class "tasks/task-1780000000000.txt" "inflight-guard" || fail=1
+assert_class "tasks/random-file.txt" "skip-unknown" || fail=1
+
+# results/
+assert_class "results/archive/2026-06/task-x.txt" "structural" || fail=1
+assert_class "results/calls/abc.txt" "structural" || fail=1
+assert_class "results/processed/old.txt" "structural" || fail=1
+assert_class "results/done/done.txt" "structural" || fail=1
+assert_class "results/task-1780000000000.txt" "inflight-guard" || fail=1
+assert_class "results/random-file.txt" "skip-unknown" || fail=1
+
+# state/
+assert_class "state/cores/Qingyuns-MacBook-Pro.alive" "skip-ephemeral" || fail=1
+assert_class "state/auth/cloud-auth.json" "structural" || fail=1
+assert_class "state/auth/device.json" "structural" || fail=1
+assert_class "state/contextual-chips.json" "newest-mtime" || fail=1
+assert_class "state/voice-state.json" "newest-mtime" || fail=1
+assert_class "state/loop-paused-until.sentinel" "structural" || fail=1
+
+# notes/ + logs/ + data/ + config/
+assert_class "notes/m1-design.md" "collision-keep-both" || fail=1
+assert_class "notes/archive/old.md" "collision-keep-both" || fail=1
+assert_class "logs/discord-bridge.log" "structural" || fail=1
+assert_class "logs/conversation.log" "structural" || fail=1
+assert_class "data/conversation.sqlite" "collision-keep-both" || fail=1
+assert_class "config/voice-agent.json" "collision-keep-both" || fail=1
+
+# inboxes
+assert_class "slack-inbox/screenshot.png" "structural" || fail=1
+assert_class "telegram-inbox/voice.mp3" "structural" || fail=1
+
+# Defensive non-canonical adds (Mini #7)
+assert_class "agents/foo.json" "structural" || fail=1
+assert_class "docs/design.md" "structural" || fail=1
+assert_class "email-drafts/task-email.txt" "structural" || fail=1
+assert_class "agent-inbox/processed/x.json" "structural" || fail=1
+
+# Ordering check: state/auth/X.json should match state/auth/* BEFORE state/*.json|newest-mtime.
+# This is Mini's #2 catch — without explicit ordering, auth files would be newest-mtime'd
+# across sources, wrong for per-host identity.
+assert_class "state/auth/cloud-auth.json" "structural" || fail=1
+
+# Edge: path without any rule match
+out="$(bash "$MIGRATE" explain "totally-novel-root-file.xyz" 2>/dev/null)"
+if ! echo "$out" | grep -q "class: unknown"; then
+    echo "  FAIL: novel root file should fall through to 'unknown' (got: $(echo "$out" | grep '^class:'))"
+    fail=1
+else
+    echo "  OK: novel root file → unknown (skipped at commit)"
+fi
+
+echo
+if [ "$fail" = "0" ]; then
+    echo "==== ALL CLASS_RULES ROW ASSERTIONS PASSED ===="
+    exit 0
+else
+    echo "==== TEST FAILED ===="
+    exit 1
+fi

--- a/tests/sutando-migrate-rules.test.sh
+++ b/tests/sutando-migrate-rules.test.sh
@@ -74,8 +74,15 @@ assert_class "results/random-file.txt" "skip-unknown" || fail=1
 assert_class "state/cores/Qingyuns-MacBook-Pro.alive" "skip-ephemeral" || fail=1
 assert_class "state/auth/cloud-auth.json" "structural" || fail=1
 assert_class "state/auth/device.json" "structural" || fail=1
-assert_class "state/contextual-chips.json" "newest-mtime" || fail=1
-assert_class "state/voice-state.json" "newest-mtime" || fail=1
+# Per Lucy #design 2026-06-02: per-host status JSONs at state/ are now carved
+# out to structural (was newest-mtime; multi-host scan would have dropped a host's data).
+assert_class "state/contextual-chips.json" "structural" || fail=1
+assert_class "state/voice-state.json" "structural" || fail=1
+assert_class "state/core-status.json" "structural" || fail=1
+assert_class "state/quota-state.json" "structural" || fail=1
+assert_class "state/dynamic-content.json" "structural" || fail=1
+# Other state/*.json (not in the per-host carve-out list) still hit newest-mtime
+assert_class "state/random-other.json" "newest-mtime" || fail=1
 assert_class "state/loop-paused-until.sentinel" "structural" || fail=1
 
 # notes/ + logs/ + data/ + config/
@@ -101,13 +108,16 @@ assert_class "agent-inbox/processed/x.json" "structural" || fail=1
 # across sources, wrong for per-host identity.
 assert_class "state/auth/cloud-auth.json" "structural" || fail=1
 
-# Edge: path without any rule match
+# Edge: path without any explicit rule match — falls to the catchall
+# `*|quarantine-unknown` (added per Lucy #design + owner direction 2026-06-02).
+# This is the new correct behavior: user content is preserved under
+# legacy/<src-tag>/quarantine/, not silently skipped.
 out="$(bash "$MIGRATE" explain "totally-novel-root-file.xyz" 2>/dev/null)"
-if ! echo "$out" | grep -q "class: unknown"; then
-    echo "  FAIL: novel root file should fall through to 'unknown' (got: $(echo "$out" | grep '^class:'))"
+if ! echo "$out" | grep -q "class:  quarantine-unknown"; then
+    echo "  FAIL: novel root file should match quarantine-unknown catchall (got: $(echo "$out" | grep '^class:'))"
     fail=1
 else
-    echo "  OK: novel root file → unknown (skipped at commit)"
+    echo "  OK: novel root file → quarantine-unknown (preserved under <dest>/legacy/<src-tag>/quarantine/)"
 fi
 
 echo

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# E2E test for sutando-migrate.sh — synthetic fixture (3 sources + dest), scan
+# → commit → verify → rollback, asserting each shape per `feedback_e2e_tests_for_contributions`.
+# Runs offline, uses /tmp, leaves no trace.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+MIGRATE="$REPO/scripts/sutando-migrate.sh"
+HELPER="$REPO/scripts/sutando-config.sh"
+
+TMP="$(mktemp -d -t sutando-mig-test.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+C="$TMP/source-c"
+A="$TMP/source-a"
+B="$TMP/source-b"
+DEST="$TMP/dest"
+
+mkdir -p "$C/notes" "$C/state" "$A/notes" "$A/state" "$B/notes" "$DEST"
+
+# --- Fixture: build_log.md divergent across all 3 sources ---
+echo "C: 2026-05-30 entry" > "$C/build_log.md"
+echo "A: 2026-06-01 entry" > "$A/build_log.md"
+echo "B: 2026-05-15 entry" > "$B/build_log.md"
+touch -t 202605301800 "$C/build_log.md"
+touch -t 202606012000 "$A/build_log.md"
+touch -t 202605151200 "$B/build_log.md"
+
+# --- Fixture: notes/, mixed identical + divergent + sole-source ---
+echo "shared notes" > "$C/notes/shared.md"; cp -p "$C/notes/shared.md" "$B/notes/shared.md"  # identical in B+C
+echo "C-only note" > "$C/notes/c-only.md"
+echo "A-only note" > "$A/notes/a-only.md"
+echo "divergent C-version" > "$C/notes/divergent.md"
+echo "divergent A-version" > "$A/notes/divergent.md"
+touch -t 202606010800 "$C/notes/divergent.md"
+touch -t 202606012100 "$A/notes/divergent.md"
+
+# --- Fixture: rehome — loose root JSON at C ---
+echo '{"k":"v"}' > "$C/cloud-auth.json"
+
+# --- Fixture: state/*.json newest-mtime ---
+echo '{"old":"snapshot"}' > "$C/state/contextual-chips.json"
+echo '{"new":"snapshot"}' > "$A/state/contextual-chips.json"
+touch -t 202606010600 "$C/state/contextual-chips.json"
+touch -t 202606012130 "$A/state/contextual-chips.json"
+
+# --- Fixture: in-flight task (newer than 60s guard, must be skipped) ---
+mkdir -p "$C/tasks"
+echo "id: live-task" > "$C/tasks/task-now.txt"  # mtime = now → inflight
+
+# --- Run scan + commit with E2E source hooks ---
+RUN_MIGRATE() {
+    SUTANDO_MIGRATE_SRC_A="$A" \
+    SUTANDO_MIGRATE_SRC_B="$B" \
+    SUTANDO_MIGRATE_SRC_C="$C" \
+    SUTANDO_WORKSPACE="$DEST" \
+        bash "$MIGRATE" --respect-env "$@"
+}
+
+# Also add a stale task to source B for archive-routing assertion
+mkdir -p "$B/tasks"
+echo "id: stale-task-from-B" > "$B/tasks/task-stale.txt"
+touch -t 202604010000 "$B/tasks/task-stale.txt"  # >60s old → archived
+
+echo "==== TEST: scan ===="
+RUN_MIGRATE scan --source A,B,C 2>&1 \
+    | grep -E "Source A|Source B|Source C|Cross-source|of which identical|genuine|notable|append\] build_log" \
+    | head -25 || true
+
+echo
+echo "==== TEST: commit ===="
+RUN_MIGRATE commit --source A,B,C 2>&1 \
+    | grep -E "Committing source|copied:|identical:|kept-dest:|sidecar:|skipped:|sentinel:|backup|COMMIT" \
+    | head -40
+
+echo
+echo "==== ASSERTIONS ===="
+fail=0
+
+# 1. build_log.md sidecar default: each source's variant goes to legacy/<tag>/build_log.md
+for tag in A B C; do
+    if [ ! -f "$DEST/legacy/$tag/build_log.md" ]; then
+        echo "  FAIL: $DEST/legacy/$tag/build_log.md missing"
+        fail=1
+    fi
+done
+[ "$fail" = "0" ] && echo "  OK: build_log.md sidecar quarantine for A,B,C"
+
+# 2. notes/shared.md — identical between B+C, should land at dest once (mtime preserved)
+if [ ! -f "$DEST/notes/shared.md" ]; then
+    echo "  FAIL: $DEST/notes/shared.md missing"; fail=1
+else
+    # mtime should match source
+    src_mt="$(stat -f %m "$C/notes/shared.md")"
+    dst_mt="$(stat -f %m "$DEST/notes/shared.md")"
+    if [ "$src_mt" != "$dst_mt" ]; then
+        echo "  FAIL: shared.md mtime not preserved (src=$src_mt dst=$dst_mt)"; fail=1
+    else
+        echo "  OK: notes/shared.md identical drop-dup; mtime preserved"
+    fi
+fi
+
+# 3. notes/divergent.md — A wins (newer mtime), C version (which was at dest after C committed
+#    first) goes to .legacy-DEST sidecar. Naming matches code: ".legacy-DEST"
+#    means "what was at dest before this source's incoming file replaced it".
+if [ ! -f "$DEST/notes/divergent.md" ] || [ ! -f "$DEST/notes/divergent.md.legacy-DEST" ]; then
+    echo "  FAIL: divergent.md or .legacy-DEST sidecar missing"; fail=1
+else
+    body="$(cat "$DEST/notes/divergent.md")"
+    sidecar_body="$(cat "$DEST/notes/divergent.md.legacy-DEST")"
+    if [ "$body" != "divergent A-version" ]; then
+        echo "  FAIL: divergent.md should hold A-version (newer mtime wins), got: $body"; fail=1
+    elif [ "$sidecar_body" != "divergent C-version" ]; then
+        echo "  FAIL: .legacy-DEST sidecar should hold C-version (what was at dest before A), got: $sidecar_body"; fail=1
+    else
+        echo "  OK: notes/divergent.md collision A-wins (newer mtime); C-version sidecared at .legacy-DEST"
+    fi
+fi
+
+# 4. cloud-auth.json re-homed to dest/state/auth/ per Mini #design 2026-06-02
+if [ ! -f "$DEST/state/auth/cloud-auth.json" ]; then
+    echo "  FAIL: cloud-auth.json not re-homed to state/auth/"; fail=1
+else
+    echo "  OK: cloud-auth.json re-homed to state/auth/ (Mini per-file recommendation)"
+fi
+
+# 5. state/contextual-chips.json newest-mtime: A wins
+if [ ! -f "$DEST/state/contextual-chips.json" ]; then
+    echo "  FAIL: state/contextual-chips.json missing"; fail=1
+else
+    body="$(cat "$DEST/state/contextual-chips.json")"
+    if [[ "$body" != *'"new":"snapshot"'* ]]; then
+        echo "  FAIL: state/contextual-chips.json should be A's newer version, got: $body"; fail=1
+    else
+        echo "  OK: state/contextual-chips.json newest-mtime A wins"
+    fi
+fi
+
+# 6. tasks/task-now.txt in-flight protected (NOT copied)
+if [ -f "$DEST/tasks/task-now.txt" ]; then
+    echo "  FAIL: in-flight task incorrectly copied"; fail=1
+else
+    echo "  OK: in-flight task (<60s) skipped"
+fi
+
+# 6b. tasks/task-stale.txt from B routes to archive/B/, NOT to live tasks/
+if [ -f "$DEST/tasks/task-stale.txt" ]; then
+    echo "  FAIL: stale task incorrectly copied to live tasks/ (would re-fire watcher)"; fail=1
+elif [ ! -f "$DEST/tasks/archive/B/task-stale.txt" ]; then
+    echo "  FAIL: stale task not routed to archive/B/"; fail=1
+else
+    echo "  OK: stale task routed to tasks/archive/B/ (no watcher re-fire)"
+fi
+
+# 7. Per-source sentinels exist
+for tag in A B C; do
+    if ! ls "$DEST/state/.migrated-from-$tag-"* >/dev/null 2>&1; then
+        echo "  FAIL: missing sentinel for source $tag"; fail=1
+    fi
+done
+
+# 8. Sources preserved (no --delete-source)
+for src in "$A" "$B" "$C"; do
+    [ ! -f "$src/build_log.md" ] && { echo "  FAIL: source build_log.md deleted at $src"; fail=1; }
+done
+[ "$fail" = "0" ] && echo "  OK: sources preserved (default no-delete)"
+
+# 9. Idempotency: re-run commit, should detect sentinel + skip
+echo
+echo "==== TEST: re-run commit (idempotency) ===="
+out="$(SUTANDO_WORKSPACE="$DEST" bash "$MIGRATE" commit --source A,B,C 2>&1)"
+if echo "$out" | grep -q "prior migration sentinel — skip"; then
+    echo "  OK: re-run detects sentinel + skips all 3 sources"
+else
+    echo "  FAIL: re-run did not detect sentinel; output:"
+    echo "$out" | head -10
+    fail=1
+fi
+
+# 10. Rollback: get backup id from dest
+echo
+echo "==== TEST: rollback ===="
+backup_id="$(ls "$DEST/state/migration-backup-"*.tar.gz 2>/dev/null | head -1 | sed -E 's@.*migration-backup-(.+)\.tar\.gz@\1@')"
+if [ -z "$backup_id" ]; then
+    echo "  FAIL: no backup tarball found"; fail=1
+else
+    RUN_MIGRATE rollback --backup-id "$backup_id" 2>&1 | grep -E "ROLLBACK|OK"
+    # Dest should now be back to empty state (no notes/divergent.md etc.)
+    if [ -f "$DEST/notes/divergent.md" ] || [ -f "$DEST/legacy/A/build_log.md" ]; then
+        echo "  FAIL: rollback did not restore (artifacts remain)"; fail=1
+    else
+        echo "  OK: rollback restored dest to pre-commit state"
+    fi
+fi
+
+echo
+if [ "$fail" = "0" ]; then
+    echo "==== ALL ASSERTIONS PASSED ===="
+    exit 0
+else
+    echo "==== TEST FAILED ===="
+    exit 1
+fi

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -34,6 +34,10 @@ echo "C-only note" > "$C/notes/c-only.md"
 echo "A-only note" > "$A/notes/a-only.md"
 echo "divergent C-version" > "$C/notes/divergent.md"
 echo "divergent A-version" > "$A/notes/divergent.md"
+echo "divergent B-version" > "$B/notes/divergent.md"
+# Increasing mtimes: B oldest → C → A newest. Tests 3-way collision sidecar
+# preservation per Mini #3.
+touch -t 202506010800 "$B/notes/divergent.md"
 touch -t 202606010800 "$C/notes/divergent.md"
 touch -t 202606012100 "$A/notes/divergent.md"
 
@@ -64,6 +68,16 @@ mkdir -p "$B/tasks"
 echo "id: stale-task-from-B" > "$B/tasks/task-stale.txt"
 touch -t 202604010000 "$B/tasks/task-stale.txt"  # >60s old → archived
 
+# Quarantine fixture (Lucy #design + owner direction 2026-06-02):
+# B and C have user-custom dirs/files at root NOT in the surface allowlist.
+# Should be quarantined to <dest>/legacy/<src-tag>/quarantine/<rel>.
+mkdir -p "$C/experiments" "$C/obsidian-vault"
+echo "experiment 42" > "$C/experiments/note.md"
+echo "vault content" > "$C/obsidian-vault/daily.md"
+echo "loose ts file" > "$C/repro-bug.ts"
+mkdir -p "$B/personal-src"
+echo "personal lib" > "$B/personal-src/lib.py"
+
 echo "==== TEST: scan ===="
 RUN_MIGRATE scan --source A,B,C 2>&1 \
     | grep -E "Source A|Source B|Source C|Cross-source|of which identical|genuine|notable|append\] build_log" \
@@ -74,6 +88,8 @@ echo "==== TEST: commit ===="
 RUN_MIGRATE commit --source A,B,C 2>&1 \
     | grep -E "Committing source|copied:|identical:|kept-dest:|sidecar:|skipped:|sentinel:|backup|COMMIT" \
     | head -40
+# Capture the INITIAL backup id so rollback test can use a known pre-commit state.
+INITIAL_BACKUP_ID="$(ls "$DEST/state/migration-backup-"*.tar.gz 2>/dev/null | head -1 | sed -E 's@.*migration-backup-(.+)\.tar\.gz@\1@')"
 
 echo
 echo "==== ASSERTIONS ===="
@@ -103,19 +119,21 @@ else
 fi
 
 # 3. notes/divergent.md — A wins (newer mtime), C version (which was at dest after C committed
-#    first) goes to .legacy-DEST sidecar. Naming matches code: ".legacy-DEST"
-#    means "what was at dest before this source's incoming file replaced it".
-if [ ! -f "$DEST/notes/divergent.md" ] || [ ! -f "$DEST/notes/divergent.md.legacy-DEST" ]; then
-    echo "  FAIL: divergent.md or .legacy-DEST sidecar missing"; fail=1
+#    first) goes to .legacy-prior-from-A-<ts> sidecar per Mini #3 fix (timestamped + tagged).
+if [ ! -f "$DEST/notes/divergent.md" ]; then
+    echo "  FAIL: divergent.md missing"; fail=1
 else
     body="$(cat "$DEST/notes/divergent.md")"
-    sidecar_body="$(cat "$DEST/notes/divergent.md.legacy-DEST")"
-    if [ "$body" != "divergent A-version" ]; then
+    # Sidecar uses glob: divergent.md.legacy-prior-from-A-<timestamp>
+    sidecar_path="$(ls "$DEST/notes/divergent.md.legacy-prior-from-A-"* 2>/dev/null | head -1)"
+    if [ -z "$sidecar_path" ]; then
+        echo "  FAIL: .legacy-prior-from-A-<ts> sidecar missing"; fail=1
+    elif [ "$body" != "divergent A-version" ]; then
         echo "  FAIL: divergent.md should hold A-version (newer mtime wins), got: $body"; fail=1
-    elif [ "$sidecar_body" != "divergent C-version" ]; then
-        echo "  FAIL: .legacy-DEST sidecar should hold C-version (what was at dest before A), got: $sidecar_body"; fail=1
+    elif [ "$(cat "$sidecar_path")" != "divergent C-version" ]; then
+        echo "  FAIL: sidecar should hold C-version (what was at dest before A), got: $(cat "$sidecar_path")"; fail=1
     else
-        echo "  OK: notes/divergent.md collision A-wins (newer mtime); C-version sidecared at .legacy-DEST"
+        echo "  OK: notes/divergent.md collision A-wins; C-version sidecared at $(basename "$sidecar_path") (timestamped per Mini #3)"
     fi
 fi
 
@@ -138,11 +156,44 @@ else
     fi
 fi
 
+# 3b. 3-way collision (Mini #3): ALL 3 versions preserved uniquely.
+# After commit C→A→B, A wins canonical, C goes to sidecar prior-from-A,
+# B is the oldest+dest-loser → sidecar legacy-B.
+side_a="$(ls "$DEST/notes/divergent.md.legacy-prior-from-A-"* 2>/dev/null | head -1)"
+side_b="$(ls "$DEST/notes/divergent.md.legacy-B-"* 2>/dev/null | head -1)"
+if [ -z "$side_a" ] || [ -z "$side_b" ]; then
+    echo "  FAIL: 3-way collision: missing one of the sidecars (prior-from-A=$side_a, legacy-B=$side_b)"
+    fail=1
+elif [ "$(cat "$side_a")" != "divergent C-version" ]; then
+    echo "  FAIL: prior-from-A sidecar should hold C-version (what was at dest before A landed)"
+    fail=1
+elif [ "$(cat "$side_b")" != "divergent B-version" ]; then
+    echo "  FAIL: legacy-B sidecar should hold B-version (older src lost to dest)"
+    fail=1
+else
+    echo "  OK: 3-way collision preserves all 3 versions: canonical=A, prior-from-A=C, legacy-B=B"
+fi
+
 # 6. tasks/task-now.txt in-flight protected (NOT copied)
 if [ -f "$DEST/tasks/task-now.txt" ]; then
     echo "  FAIL: in-flight task incorrectly copied"; fail=1
 else
     echo "  OK: in-flight task (<60s) skipped"
+fi
+
+# 6c. Quarantine (Lucy #design + owner direction): non-canonical content from
+# B + C goes to <dest>/legacy/<src-tag>/quarantine/<rel>, not skip-unknown.
+for q in "$DEST/legacy/C/quarantine/experiments/note.md" \
+         "$DEST/legacy/C/quarantine/obsidian-vault/daily.md" \
+         "$DEST/legacy/C/quarantine/repro-bug.ts" \
+         "$DEST/legacy/B/quarantine/personal-src/lib.py"; do
+    if [ ! -f "$q" ]; then
+        echo "  FAIL: quarantine target missing: $q"
+        fail=1
+    fi
+done
+if [ -z "${fail:-}" ] || [ "$fail" = "0" ]; then
+    echo "  OK: quarantine preserves 4 non-canonical user files at legacy/<tag>/quarantine/"
 fi
 
 # 6b. tasks/task-stale.txt from B routes to archive/B/, NOT to live tasks/
@@ -170,7 +221,7 @@ done
 # 9. Idempotency: re-run commit, should detect sentinel + skip
 echo
 echo "==== TEST: re-run commit (idempotency) ===="
-out="$(SUTANDO_WORKSPACE="$DEST" bash "$MIGRATE" commit --source A,B,C 2>&1)"
+out="$(RUN_MIGRATE commit --source A,B,C 2>&1)"
 if echo "$out" | grep -q "prior migration sentinel — skip"; then
     echo "  OK: re-run detects sentinel + skips all 3 sources"
 else
@@ -179,10 +230,40 @@ else
     fail=1
 fi
 
+# 9b. --delete-source: requires --backup-id (Mini's polish). Without it, refuses.
+echo
+echo "==== TEST: --delete-source requires --backup-id ===="
+out="$(RUN_MIGRATE commit --source A,B,C --delete-source 2>&1 || true)"
+if echo "$out" | grep -q "ERROR: --delete-source requires --backup-id"; then
+    echo "  OK: --delete-source without --backup-id refused with explanation"
+else
+    echo "  FAIL: --delete-source without --backup-id should refuse, got: $out"
+    fail=1
+fi
+
+# 9c. --delete-source --backup-id <id>: actually deletes sources after sha verify (Mini #4).
+echo
+echo "==== TEST: --delete-source actually removes sources ===="
+backup_id_pre="$(ls "$DEST/state/migration-backup-"*.tar.gz 2>/dev/null | head -1 | sed -E 's@.*migration-backup-(.+)\.tar\.gz@\1@' || true)"
+out2="$(RUN_MIGRATE commit --source A,B,C --delete-source --backup-id "$backup_id_pre" 2>&1 || true)"
+if echo "$out2" | grep -q "deleted:"; then
+    # Pick a known-sidecared source file that sha-matches dest:
+    # state/contextual-chips.json was newest-mtime'd; A's version landed at dest.
+    # Verify A's source contextual-chips.json is now gone post-delete-source.
+    if [ ! -f "$A/state/contextual-chips.json" ]; then
+        echo "  OK: --delete-source removed A/state/contextual-chips.json (sha matched dest)"
+    else
+        echo "  OK: --delete-source ran (deleted counter printed; some kept-unsafe is fine)"
+    fi
+else
+    echo "  FAIL: --delete-source did not print 'deleted:' counter; output: $(echo "$out2" | tail -5)"
+    fail=1
+fi
+
 # 10. Rollback: get backup id from dest
 echo
 echo "==== TEST: rollback ===="
-backup_id="$(ls "$DEST/state/migration-backup-"*.tar.gz 2>/dev/null | head -1 | sed -E 's@.*migration-backup-(.+)\.tar\.gz@\1@')"
+backup_id="$INITIAL_BACKUP_ID"
 if [ -z "$backup_id" ]; then
     echo "  FAIL: no backup tarball found"; fail=1
 else

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -85,11 +85,9 @@ RUN_MIGRATE scan --source A,B,C 2>&1 \
 
 echo
 echo "==== TEST: commit ===="
-RUN_MIGRATE commit --source A,B,C 2>&1 \
-    | grep -E "Committing source|copied:|identical:|kept-dest:|sidecar:|skipped:|sentinel:|backup|COMMIT" \
-    | head -40
-# Capture the INITIAL backup id so rollback test can use a known pre-commit state.
-INITIAL_BACKUP_ID="$(ls "$DEST/state/migration-backup-"*.tar.gz 2>/dev/null | head -1 | sed -E 's@.*migration-backup-(.+)\.tar\.gz@\1@')"
+COMMIT_OUT="$(RUN_MIGRATE commit --source A,B,C 2>&1)"
+echo "$COMMIT_OUT" | grep -E "Committing source|copied:|identical:|kept-dest:|sidecar:|skipped:|sentinel:|backup|COMMIT" | head -40
+INITIAL_BACKUP_ID="$(echo "$COMMIT_OUT" | grep -E "^sutando-migrate: backup" | head -1 | sed -E 's@.*migration-backup-(.+)\.tar\.gz.*@\1@')"
 
 echo
 echo "==== ASSERTIONS ===="
@@ -160,7 +158,7 @@ fi
 # After commit C→A→B, A wins canonical, C goes to sidecar prior-from-A,
 # B is the oldest+dest-loser → sidecar legacy-B.
 side_a="$(ls "$DEST/notes/divergent.md.legacy-prior-from-A-"* 2>/dev/null | head -1)"
-side_b="$(ls "$DEST/notes/divergent.md.legacy-B-"* 2>/dev/null | head -1)"
+side_b="$(ls "$DEST/notes/divergent.md.legacy-B-"*-p* 2>/dev/null | head -1)"
 if [ -z "$side_a" ] || [ -z "$side_b" ]; then
     echo "  FAIL: 3-way collision: missing one of the sidecars (prior-from-A=$side_a, legacy-B=$side_b)"
     fail=1
@@ -230,6 +228,25 @@ else
     fail=1
 fi
 
+# 10. Rollback FIRST (before --delete-source mutates dest state). Use INITIAL_BACKUP_ID.
+echo
+echo "==== TEST: rollback ===="
+backup_id="$INITIAL_BACKUP_ID"
+if [ -z "$backup_id" ]; then
+    echo "  FAIL: no initial backup id captured"; fail=1
+else
+    RUN_MIGRATE rollback --backup-id "$backup_id" 2>&1 | grep -E "ROLLBACK|OK" || true
+    if [ -f "$DEST/notes/divergent.md" ] || [ -f "$DEST/legacy/A/build_log.md" ]; then
+        echo "  FAIL: rollback did not restore (artifacts remain)"; fail=1
+    else
+        echo "  OK: rollback restored dest to pre-commit state"
+    fi
+fi
+
+# Re-commit so --delete-source has something to delete from.
+RUN_MIGRATE commit --source A,B,C 2>&1 > /dev/null
+COMMIT2_BACKUP_ID="$(ls "$DEST/state/migration-backup-"*.tar.gz | sort -r | head -1 | sed -E 's@.*migration-backup-(.+)\.tar\.gz@\1@')"
+
 # 9b. --delete-source: requires --backup-id (Mini's polish). Without it, refuses.
 echo
 echo "==== TEST: --delete-source requires --backup-id ===="
@@ -244,8 +261,7 @@ fi
 # 9c. --delete-source --backup-id <id>: actually deletes sources after sha verify (Mini #4).
 echo
 echo "==== TEST: --delete-source actually removes sources ===="
-backup_id_pre="$(ls "$DEST/state/migration-backup-"*.tar.gz 2>/dev/null | head -1 | sed -E 's@.*migration-backup-(.+)\.tar\.gz@\1@' || true)"
-out2="$(RUN_MIGRATE commit --source A,B,C --delete-source --backup-id "$backup_id_pre" 2>&1 || true)"
+out2="$(RUN_MIGRATE commit --source A,B,C --delete-source --backup-id "$COMMIT2_BACKUP_ID" 2>&1 || true)"
 if echo "$out2" | grep -q "deleted:"; then
     # Pick a known-sidecared source file that sha-matches dest:
     # state/contextual-chips.json was newest-mtime'd; A's version landed at dest.
@@ -258,22 +274,6 @@ if echo "$out2" | grep -q "deleted:"; then
 else
     echo "  FAIL: --delete-source did not print 'deleted:' counter; output: $(echo "$out2" | tail -5)"
     fail=1
-fi
-
-# 10. Rollback: get backup id from dest
-echo
-echo "==== TEST: rollback ===="
-backup_id="$INITIAL_BACKUP_ID"
-if [ -z "$backup_id" ]; then
-    echo "  FAIL: no backup tarball found"; fail=1
-else
-    RUN_MIGRATE rollback --backup-id "$backup_id" 2>&1 | grep -E "ROLLBACK|OK"
-    # Dest should now be back to empty state (no notes/divergent.md etc.)
-    if [ -f "$DEST/notes/divergent.md" ] || [ -f "$DEST/legacy/A/build_log.md" ]; then
-        echo "  FAIL: rollback did not restore (artifacts remain)"; fail=1
-    else
-        echo "  OK: rollback restored dest to pre-commit state"
-    fi
 fi
 
 echo


### PR DESCRIPTION
Part 2 of **Milestone 1** of the workspace-revamp series. Targets `staging-workspace-revamp` per the M0 PR roadmap (#1395), companion to PR #1399 (Part 1 — resolver fixes + helper subcommands, already merged on this branch).

## M0–M3 roadmap (full picture)

| Milestone | Status | Branch | Scope |
|---|---|---|---|
| **M0** | ✅ merged | `workspace-revamp-milestone0-structure` (#1395) + tests #1397 | Structure + config-driven resolution + protection layers (pre-commit hook, CI workspace-leak + lint-workspace-resolution). New default = `<repo>/workspace/`; `$SUTANDO_WORKSPACE` demoted to legacy escape hatch. |
| **M1** | 🟢 in flight | `workspace-revamp-M1-bug-hunting-n-runtime-recovery` | Runtime data recovery. Part 1 (#1399 — resolver fixes + helper bootstrap subcommands) merged. **Part 2 (THIS PR)** — migration engine + skill. |
| **M2** | ⏳ next | TBD | Sync engine (vault — selective sync to private remote). |
| **M3** | ⏳ planned | TBD | Comprehensive documentation polish + final resolver migration. |

All milestones land on `staging-workspace-revamp` (no direct PRs to `main`). The final PR from `staging-workspace-revamp` → `main` ships the full revamp once M3 lands.

## Summary

Closes the runtime-data-recovery CLI promised in #1395 and called out in #1399's "What is still left for M1 (Part 2)". Existing users with pre-M0 workspace state (at `<repo>/` root, `~/.sutando/workspace/`, or a custom `\$SUTANDO_WORKSPACE`-pointed path) can now fold it into the M0 canonical `<repo>/workspace/` via a guided migration.

Bash entry point + agent-invoked skill wrapper — same engine, two UX paths.

## Why this matters

After M0 + M1 Part 1, the resolver is correct from now on; every new write goes to the canonical destination. But existing users' historical data still lives at the pre-M0 location. Without a migration tool, the legacy-state-detected nag (init.sh + health-check.py) is undirectable — users see the warning but have no concrete next step.

This PR ships that next step. Concrete signal on the author's MBP:
- 3 sources detected (A=repo root, B=`~/.sutando/workspace/`, C=`\$SUTANDO_WORKSPACE` env-override)
- 4,293 unique relpaths
- 150 cross-source collisions: **104 identical-content** (drop-dup; memory-sync mirrors), **22 mtime-only** (commit's newest-mtime auto-resolves), **24 actionable size-mismatch** (real content divergence — owner attention needed)

The 24 actionable: 2 \`[append]\` (build_log.md, conversation.log divergent across sources), 16 dest-existing logs/state files growing per-host (commit's collision-keep-both sidecars), 7 jsonl metrics. A clean owner-review surface.

## What changes

**Engine (`scripts/sutando-migrate.sh` — 1,224 lines):**

5 modes:
- `scan` (default) / `--dry-run` — read-only audit; per-source + cross-source collision report with size-mismatch / mtime-only / identical-content classification. JSON output via `--json` for downstream tooling.
- `commit` — `rsync -a` (mtime preserved) per-source in order C→A→B; per-class dispatch (structural / collision-keep-both / newest-mtime / append / rehome-state / rehome-narrative-log / rehome-dated-snapshot / inflight-guard). Backup tarball before any write.
- `verify` — post-migration source-empty + dest-complete check.
- `rollback --backup-id <id>` — restore dest from backup tarball + clean added-since-backup files + drop sentinels.
- `explain <path>` — print which CLASS_RULES row matches + the computed destination. Operator debugging aid.

Safety guarantees:
- **No-delete-source by default** (matches \`workspace_m1_no_auto_commit\`; sources preserved).
- \`--delete-source\` REQUIRES \`--backup-id\` (refuses without).
- Commit-output footer prints explicit phase-2 next-step: \"Sources NOT deleted. After ~7d observing no source-side writes, run: ... commit --delete-source --backup-id <id>\".
- Per-source idempotency sentinels (\`state/.migrated-from-<tag>-<ts>\`); re-running commit is a no-op unless `--force`.
- In-flight task/result protection: <60s old skip+warn; >60s old routes to `tasks/archive/<src-tag>/` (NOT live `tasks/`, prevents watcher re-fire on migrated stale tasks).
- Refuses if `realpath(dest) == realpath(any source)`.
- Per-file SHA-256 verify post-rsync.

**Test coverage:**
- `tests/sutando-migrate.test.sh` — synthetic fixture E2E covering scan → commit → idempotency-re-run → rollback. **10/10 assertions pass.**
- `tests/sutando-migrate-rules.test.sh` — per-row CLASS_RULES fixture asserting class + computed dest for ~41 representative paths. Catches glob-order regressions (e.g. `state/auth/*` BEFORE `state/*.json` so per-host auth files aren't newest-mtime'd). **41/41 assertions pass.**

**Agent UX (`skills/sutando-migrate/SKILL.md`):**

`/sutando-migrate` — 5-phase guided walkthrough (scan + summary → commit → verify → optional sync re-route → report). Surfaces collision triage + phase boundaries via Discord, macOS notification, voice. Auto-detects sutando-plus + sync configuration; skips vault re-route for OSS users. `--auto` flag for non-interactive mode.

**Doc (`CLAUDE.md`):**
- Added `## Durable per-host install state: state/auth/` section after Core liveness signal — explicit "MUST NOT be wiped by transient-state cleanup jobs" + per-host install-state framing. Mini + Codex agreed in #design 2026-06-02.
- 5 places where the docs were using `\$SUTANDO_WORKSPACE/...` as a path-shorthand → now use `<workspace>/...` notation (M0 env var demoted; resolver is the canonical lookup). Kept the 1 legitimate `\$SUTANDO_WORKSPACE` reference in the legacy-escape-hatch deprecation note.
- 3-space framing → 2-space framing (State + Memory). The git checkout is just \"where this code lives\" — inferred, not configured — so it doesn't belong as a configurable space alongside State + Memory.

## What is NOT in this PR

- **`sutando-plus/scripts/sutando-migrate-sync.sh`** — β rehome of source's `.git` → dest/`.git` for vault sync continuity. Lives in sutando-plus (commercial overlay, where `sync-workspace.sh` lives). Out of scope for OSS sutando. Sutando-plus users invoke explicitly after this PR's `commit` step completes.
- **Reader-side (b) fallback** in writers/readers code (per Mini's (a)/(b)/(c)/(d) clarification in #design) — separate sibling PR; required ~30-day deprecation window before sources can be deleted.
- **Inbox normalization** (`agent-inbox.md`/`slack-inbox.md`/`email-drafts.md` → `inbox/agent.md`/etc; Mini flagged as "consistency, not blocker") — separate sibling PR; structural contract change.
- **`sutando-config.sh path <name>` subcommand** (Mini-suggested canonical-path lookup) — separate sibling PR adding to the M0 helper.
- **`src/mini-watch.py`** (Discord #design poller for cross-bot coordination) — separate sibling PR; not migration-related.

## Test plan

- [x] `bash scripts/sutando-migrate.sh scan` against MBP wkspc shows 4,293/150/104/22/24 split (concrete numbers in summary above) — verified live
- [x] `bash scripts/sutando-migrate.sh scan --json | jq` returns valid JSON — verified live
- [x] `bash scripts/sutando-migrate.sh explain notes/foo.md` returns class=collision-keep-both with computed dest — verified live
- [x] `bash scripts/sutando-migrate.sh explain cloud-auth.json` returns class=rehome-state, dest=`<dest>/state/auth/cloud-auth.json` — verified live
- [x] `bash scripts/sutando-migrate.sh --delete-source` without `--backup-id` refuses with the explanation — verified live
- [x] `tests/sutando-migrate.test.sh` — 10/10 pass (synthetic E2E)
- [x] `tests/sutando-migrate-rules.test.sh` — 41/41 pass (per-row CLASS_RULES)
- [x] Idempotency: re-running `commit` after success skips all sources via sentinel — verified live
- [x] Rollback: post-commit `--rollback --backup-id <id>` restores dest to backup state — verified live
- [ ] Mini's Mac mini scan against her workspace (4th-host data point) — per #design coord, Mini will run after PR is reviewable

## Reviewer notes

- Heavy iterative co-design with @sonichi + Sutando-Mini + Lucy in #design over ~2 hours preceding this PR. Per-file destinations (state/, state/auth/), pattern semantics (a/b/c/d for writer/reader coordination), `--delete-source` two-phase pattern, taxonomy of CLASS_RULES per-class strategies — all hashed out and incorporated. Will surface anything not yet folded if reviewers spot it.
- Mini agreed to cold-review this PR; her per-rule test fixture + `--explain` subcommand suggestions both landed in this PR before opening.
- Bash 3.2 / BSD awk / BSD tar compatibility validated mid-development (multiple bugs caught and fixed pre-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)