### PR TITLE
fix(sutando-migrate): M1 Part 2 follow-ups (bucket/DEST/narrative-log)

### DIFF
--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1011,6 +1011,21 @@ commit_one() {
             local _tmp="$dst_path.append.$$"
             local _redirect_rc=0
             if [ -e "$dst_path" ]; then
+                # Idempotency guard (Lucy #1407, folded into #1406 2026-06-02):
+                # if THIS source's divider marker is already present in the
+                # canonical narrative log, skip re-appending. Cheap single-line
+                # grep -qF check via the source-tag-specific header substring.
+                # Without this, re-running `commit` against the same surviving
+                # source (e.g. accidentally, or after an aborted --delete-source)
+                # would re-append the same source content again, growing
+                # workspace-narrative.log linearly with each commit. The
+                # divider header includes mtime + size but the tag substring
+                # alone is sufficient — only one append per source-tag should
+                # ever land in the canonical log.
+                if grep -qF "migrated from source $tag " "$dst_path" 2>/dev/null; then
+                    echo "append-skip-idempotent"
+                    return 0
+                fi
                 # Append with divider header. Concat in canonical order.
                 {
                     cat "$dst_path"

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -367,7 +367,7 @@ scan_source() {
     # NOTE on portability: --base is not portable; we use absolute paths only.
     # Walk every non-ignored regular file under src.
     local file rel cls dest_path collision_kind="" size mtime_iso
-    local n_structural=0 n_append=0 n_newest=0 n_rehome=0 n_skip=0 n_inflight=0 n_collision=0 n_unknown=0
+    local n_structural=0 n_append=0 n_newest=0 n_rehome=0 n_skip=0 n_inflight=0 n_collision=0 n_unknown=0 n_quarantine=0
     local bytes_total=0
 
     REPORT_LINES+=("")
@@ -528,6 +528,15 @@ scan_source() {
                 # Target is <dest>/state/<basename>
                 n_rehome=$((n_rehome+1))
                 ;;
+            rehome-narrative-log|rehome-dated-snapshot)
+                # Same bucket as rehome-state for display purposes (loose root file → canonical sub-path)
+                n_rehome=$((n_rehome+1))
+                ;;
+            quarantine-unknown)
+                # Catchall for user content under non-canonical relpaths (Source B/C only).
+                # Counted separately so users see the quarantine footprint in scan output.
+                n_quarantine=$((n_quarantine+1))
+                ;;
             collision-keep-both)
                 dest_path="$DEST/$rel"
                 if [ -e "$dest_path" ]; then
@@ -559,6 +568,7 @@ scan_source() {
     REPORT_LINES+=("    append-merge (build_log/conv.log):    $n_append")
     REPORT_LINES+=("    newest-mtime (snapshots):             $n_newest")
     REPORT_LINES+=("    re-home      (loose JSON → state/):   $n_rehome")
+    REPORT_LINES+=("    quarantine   (non-canonical → legacy/<src>/quarantine/): $n_quarantine")
     REPORT_LINES+=("    in-flight-skip (<${INFLIGHT_GUARD_SEC}s old):       $n_inflight")
     REPORT_LINES+=("    skip-ephemeral / .DS_Store / .gitkeep:$n_skip")
     REPORT_LINES+=("    unknown (no rule matched, will skip): $n_unknown")
@@ -618,7 +628,12 @@ done
 # the destination regardless of whatever $SUTANDO_WORKSPACE the user has set
 # today — migration MOVES data INTO the new default. Use `--respect-env` to
 # honor env (e.g. for users whose dest is intentionally an env-overridden path).
-if [ "${RESPECT_ENV:-0}" = "1" ]; then
+# TEST hook: SUTANDO_MIGRATE_DEST overrides for E2E fixtures (symmetric with
+# SUTANDO_MIGRATE_SRC_{A,B,C}). Takes precedence over both the resolver and
+# --respect-env so test fixtures can pin DEST without cloning the whole repo.
+if [ -n "${SUTANDO_MIGRATE_DEST:-}" ]; then
+    DEST="$SUTANDO_MIGRATE_DEST"
+elif [ "${RESPECT_ENV:-0}" = "1" ]; then
     DEST="$(bash "$HELPER" workspace 2>/dev/null)"
 else
     DEST="$(env -u SUTANDO_WORKSPACE bash "$HELPER" workspace 2>/dev/null)"
@@ -922,19 +937,19 @@ commit_one() {
             fi
             return 0
             ;;
-        rehome-state|rehome-dated-snapshot|rehome-narrative-log)
+        rehome-state|rehome-dated-snapshot)
             # Per Mini's #design 2026-06-02 04:54Z (state JSONs) + earlier
-            # workspace audit (dated snapshots + conversation.log):
+            # workspace audit (dated snapshots):
             #   rehome-state          → state/<base> OR state/auth/<base>
             #                           (cloud-auth/device → auth/; per-host durable;
             #                           CLAUDE.md should declare state/auth/ excluded
             #                           from transient-state cleanup)
             #   rehome-dated-snapshot → notes/archive/<base>
             #                           (pending-questions-resolved-archive-*.md etc)
-            #   rehome-narrative-log  → logs/workspace-narrative.log
-            #                           (root conversation.log → logs/. Renamed to
-            #                           dodge the existing per-pid logs/conversation.log
-            #                           collision. Owner-Q flagged; filename can change.)
+            # Both are SNAPSHOT classes — newest-mtime is the right strategy
+            # (newest = most accurate; older is stale-by-definition). Narrative
+            # logs are a separate class (rehome-narrative-log) since they are
+            # APPEND-ONLY ACCUMULATORS where newest-mtime is data-lossy.
             local base="$(basename "$rel")"
             case "$cls" in
                 rehome-state)
@@ -946,11 +961,8 @@ commit_one() {
                 rehome-dated-snapshot)
                     dst_path="$DEST_REAL/notes/archive/$base"
                     ;;
-                rehome-narrative-log)
-                    dst_path="$DEST_REAL/logs/workspace-narrative.log"
-                    ;;
             esac
-            # Common per-mtime swap, identical-drop, or write-fresh.
+            # Per-mtime swap, identical-drop, or write-fresh.
             if [ -e "$dst_path" ]; then
                 local src_mt dst_mt
                 src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
@@ -966,19 +978,45 @@ commit_one() {
                 echo "rehomed"
             fi
             return 0
+            ;;
+        rehome-narrative-log)
+            # APPEND-ONLY ACCUMULATOR (per-host voice-agent transcript history).
+            # Pre-fix (2026-06-02) this shared the rehome-state/dated-snapshot
+            # newest-mtime path, which silently dropped the larger file when
+            # the newer one was smaller. Data-loss bug caught on owner's MBP:
+            # Source A had 261K of voice-transcript history (mtime May 17);
+            # Source C had a 2K phone-call snippet (mtime May 20, newer);
+            # newest-mtime kept C's 2K and discarded A's 261K. Same failure
+            # class as `state/*.json|newest-mtime` we previously carved out for
+            # per-host state (#design 2026-06-02). General rule baked in here:
+            # snapshot → newest-mtime; append-only/accumulator → append.
+            # Strategy: concat each source's content to the canonical dest
+            # with a divider header carrying src-tag + mtime + size so the
+            # downstream reader can split if needed.
+            dst_path="$DEST_REAL/logs/workspace-narrative.log"
+            mkdir -p "$(dirname "$dst_path")"
+            local src_mt src_sz
+            src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
+            src_sz="$(stat -f %z "$src_file" 2>/dev/null || stat -c %s "$src_file")"
             if [ -e "$dst_path" ]; then
-                local src_mt dst_mt
-                src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
-                dst_mt="$(stat -f %m "$dst_path" 2>/dev/null || stat -c %Y "$dst_path")"
-                if [ "$src_mt" -gt "$dst_mt" ]; then
-                    copy_preserving_mtime "$src_file" "$dst_path"
-                    echo "rehomed-newer"
-                else
-                    echo "rehomed-skip-older"
-                fi
+                # Append with divider header. Concat in canonical order; the
+                # tmp+mv pattern is atomic and preserves dest if append fails.
+                {
+                    cat "$dst_path"
+                    echo ""
+                    echo "=== migrated from source $tag (mtime $src_mt, size ${src_sz}B) ==="
+                    echo ""
+                    cat "$src_file"
+                } > "$dst_path.append.$$" && mv -f "$dst_path.append.$$" "$dst_path"
+                echo "appended"
             else
-                copy_preserving_mtime "$src_file" "$dst_path"
-                echo "rehomed"
+                # First write — include header so future appends slot in cleanly.
+                {
+                    echo "=== migrated from source $tag (mtime $src_mt, size ${src_sz}B) ==="
+                    echo ""
+                    cat "$src_file"
+                } > "$dst_path.append.$$" && mv -f "$dst_path.append.$$" "$dst_path"
+                echo "appended-fresh"
             fi
             return 0
             ;;

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -998,16 +998,37 @@ commit_one() {
             local src_mt src_sz
             src_mt="$(stat -f %m "$src_file" 2>/dev/null || stat -c %Y "$src_file")"
             src_sz="$(stat -f %z "$src_file" 2>/dev/null || stat -c %s "$src_file")"
+            # Mini #design 2026-06-02 08:10Z: an `{ ... } > tmp && mv ...`
+            # compound on a single line is NOT covered by `set -e` for its
+            # left-side failure — the compound returns non-zero but execution
+            # falls through to the next statement (which echo'd "appended").
+            # If commit_one()'s caller treats that echo as success and proceeds
+            # to delete the source, a half-written append becomes data-lossy.
+            # Fix: split into separate commands so each failure path either
+            # returns explicitly or trips the script's `set -e`. Atomicity is
+            # still preserved (tmp file is dropped on failure; dest is untouched
+            # until mv succeeds).
+            local _tmp="$dst_path.append.$$"
+            local _redirect_rc=0
             if [ -e "$dst_path" ]; then
-                # Append with divider header. Concat in canonical order; the
-                # tmp+mv pattern is atomic and preserves dest if append fails.
+                # Append with divider header. Concat in canonical order.
                 {
                     cat "$dst_path"
                     echo ""
                     echo "=== migrated from source $tag (mtime $src_mt, size ${src_sz}B) ==="
                     echo ""
                     cat "$src_file"
-                } > "$dst_path.append.$$" && mv -f "$dst_path.append.$$" "$dst_path"
+                } > "$_tmp" || _redirect_rc=$?
+                if [ "$_redirect_rc" -ne 0 ]; then
+                    rm -f "$_tmp"
+                    echo "append-failed-redirect" >&2
+                    return 1
+                fi
+                mv -f "$_tmp" "$dst_path" || {
+                    rm -f "$_tmp"
+                    echo "append-failed-mv" >&2
+                    return 1
+                }
                 echo "appended"
             else
                 # First write — include header so future appends slot in cleanly.
@@ -1015,7 +1036,17 @@ commit_one() {
                     echo "=== migrated from source $tag (mtime $src_mt, size ${src_sz}B) ==="
                     echo ""
                     cat "$src_file"
-                } > "$dst_path.append.$$" && mv -f "$dst_path.append.$$" "$dst_path"
+                } > "$_tmp" || _redirect_rc=$?
+                if [ "$_redirect_rc" -ne 0 ]; then
+                    rm -f "$_tmp"
+                    echo "append-failed-redirect" >&2
+                    return 1
+                fi
+                mv -f "$_tmp" "$dst_path" || {
+                    rm -f "$_tmp"
+                    echo "append-failed-mv" >&2
+                    return 1
+                }
                 echo "appended-fresh"
             fi
             return 0


### PR DESCRIPTION
## Summary

Three follow-up fixes for `scripts/sutando-migrate.sh` surfaced during PR #1403's E2E gates on owner's MBP migration. All approved out-of-band by Mini + Lucy in #design (2026-06-02) as clean follow-ups, **not approval blockers** for #1403 (which has merged).

1. **Scan report missing `quarantine-unknown` bucket** — synthetic B fixture with 7 files (4 canonical + 3 non-canonical) showed only 4 in the action breakdown; the 3 quarantined files committed correctly but were invisible in `scan`'s summary. UX gap — operator reads silent quarantine as "didn't migrate" and may `rm` wrongly. Adds `n_quarantine` counter + scan-bucket display line; `rehome-narrative-log` and `rehome-dated-snapshot` also fold into the `rehome` bucket (previously fell through the case statement uncounted).

2. **No `SUTANDO_MIGRATE_DEST` env hook** — script derived dest from `REPO_DIR` (= script's `SCRIPT_DIR/..`); to run against a custom dest you had to clone the whole repo and call the script from inside the clone. Asymmetric with the existing `SUTANDO_MIGRATE_SRC_{A,B,C}` E2E hooks. Adds pre-arg-parsing override symmetric with src hooks; takes precedence over the resolver AND `--respect-env`.

3. **`rehome-narrative-log` class is data-lossy** — shared the `rehome-state` / `rehome-dated-snapshot` newest-mtime handler, which silently **dropped the larger file when the newer one was smaller**. Caught on owner's MBP: Source A had 261K of voice-agent transcript history (mtime May 17); Source C had a 2K phone-call snippet (mtime May 20, newer); newest-mtime kept C's 2K and discarded A's 261K. Only `<repo>/conversation.log` preserved A's content; was sidecar'd manually before `--delete-source` would have erased it.

   **General rule baked in**: snapshot → newest-mtime; append-only / accumulator → append. Same failure class as `state/*.json|newest-mtime` previously carved out for per-host state (#design 2026-06-02). Narrative-log now appends each source's content to `<dest>/logs/workspace-narrative.log` with a divider header carrying src-tag + mtime + size, mirroring Mini's spec.

Also removes a dead-code duplicate block (post-`return 0`) that was unreachable post-shared-handler.

`find -prune` perf nit (Mini, #1403 review) acknowledged but deferred to a separate perf-only PR — non-blocking for correctness.

## Test plan

- [x] Existing `tests/sutando-migrate-rules.test.sh` — all rule assertions pass
- [x] Existing `tests/sutando-migrate.test.sh` — full lifecycle (scan / commit / verify / rollback / --delete-source) pass
- [x] Manual smoke: 2-source narrative-log fixture (B old+larger, C newer+smaller) → dest contains BOTH contents with divider headers; A's 261K-equivalent preserved alongside C's 2K-equivalent (vs. pre-fix where A's was dropped)
- [x] Synthetic B fixture with quarantine: scan now shows `quarantine: 3` for `obsidian-vault/` / `experiments/` / `personal-src/`; commit still routes them to `<workspace>/legacy/B/quarantine/*` (sha-verified)
- [x] DEST env hook: scan + commit against `/tmp/dest` without cloning the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)