### PR TITLE
test(ci): expand PEP-604 union-annotation lint scope to skills/**/*.py

### DIFF
--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -15,6 +15,7 @@ Burn-rate tracking (closes #1087):
   Skips the sample if a 5h reset occurred (util dropped) or the gap is
   outside the 2min–2h window.
 """
+from __future__ import annotations
 
 # PEP 604 unions (`Path | None`) below are evaluated at import/def time, which
 # raises TypeError on Python 3.9 (the system python3 on some hosts). Defer all

--- a/tests/python39-union-annotations.test.py
+++ b/tests/python39-union-annotations.test.py
@@ -17,9 +17,11 @@ the future import. The bridge crashed silently on every Mac running stock python
 
 This test is the CI gate that prevents the same class of regression.
 
-Scan scope: `src/*.py` (primary). Skills and tests are excluded — they're not launched
-by `startup.sh` directly and the scan would produce too much noise from third-party
-vendored code.
+Scan scope: `src/*.py` + `skills/**/*.py`. Tests and third-party vendored code
+(__pycache__, node_modules) are excluded. Skills are included because cron-path
+scripts in skills/ can also crash on Python 3.9 hosts — #1385 fixed two such
+instances in quota-tracker and deal-finder; this broader scope prevents the
+class from recurring (closes #1386).
 
 Run: python3 tests/python39-union-annotations.test.py
 Exit: 0 on pass, 1 on fail.
@@ -32,6 +34,9 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 SRC = REPO / "src"
+SKILLS = REPO / "skills"
+
+_EXCLUDE = ("/__pycache__/", "/node_modules/", "/personal-")
 
 
 def _contains_bitor(node: ast.expr) -> bool:
@@ -98,8 +103,9 @@ def check_file(path: Path) -> str | None:
 
 def test_no_bare_union_annotations() -> None:
     failures = []
-    for path in sorted(SRC.glob("*.py")):
-        if "/__pycache__/" in str(path):
+    paths = list(SRC.glob("*.py")) + list(SKILLS.rglob("*.py") if SKILLS.exists() else [])
+    for path in sorted(paths):
+        if any(ex in str(path) for ex in _EXCLUDE):
             continue
         msg = check_file(path)
         if msg:


### PR DESCRIPTION
## Summary

Closes #1386.

Expands the PEP-604 union-annotation lint in `tests/python39-union-annotations.test.py` from `src/*.py` only to `src/*.py` + `skills/**/*.py`. The broader scope catches the class of regression that hit `telegram-bridge.py` in #960 before contributors add new `str | None` annotations to skill scripts.

**Exclusions:** `__pycache__/`, `node_modules/`, `skills/personal-*/` (gitignored personal skills — not present in CI checkout).

Two files caught by the expanded scope are fixed here:
- `skills/deal-finder/scripts/scan.py` — add `from __future__ import annotations`
- `skills/quota-tracker/scripts/read-quota.py` — add `from __future__ import annotations`

**Merge order note:** PR #1385 (by @amkunte) also fixes these two same files. Both changes are additive and identical, so they conflict. Suggestion: merge #1385 first (Susan APPROVED, Chi LGTM), then rebase this PR to drop the already-applied file hunks. The test will pass either way once both are applied — the lint expansion is this PR's primary contribution.

## Test plan

- [ ] `python3 tests/python39-union-annotations.test.py` → all 3 cases pass (verified locally)
- [ ] CI `tsc + tests` passes

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)