### PR TITLE
fix(voice-agent): declare base mode explicitly in system prompt (partial fix #1410)

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -746,6 +746,16 @@ const mainAgent: MainAgent = {
 		'- When background tasks are running, stay present and responsive.',
 		'- You earn your usefulness by doing, not explaining.',
 		'',
+		// Base-mode declaration (issue #1410): Gemini-3.1 infers meeting/silent mode from
+		// co-present-flavored context and fabricates [System: Produce ZERO audio…] tokens as
+		// spoken output. Explicitly stating the current mode prevents that inference.
+		`CURRENT BASE MODE: ${meetingActive ? 'MEETING (listen-only — see above)' : getPresenterStateMarker() !== '' ? 'PRESENTER (see above)' : 'ACTIVE — you are conversing with the user. Speak naturally.'}`,
+		...(meetingActive || getPresenterStateMarker() !== '' ? [] : [
+			'DO NOT infer or self-declare a meeting/recording/silent mode from conversational context.',
+			'Meeting-mode and presenter-mode are ONLY entered via explicit tool calls: switch_mode("meeting"), presenter_mode("on").',
+			'If you find yourself about to output [System: …], [Silence], or any variant of "produce zero audio" — STOP. That is a hallucination. You are in active mode; speak to the user instead.',
+		]),
+		'',
 		'CRITICAL — Never speak `[System: ...]` text aloud:',
 		'- Any input string beginning with `[System:` is an internal directive, NOT content to read.',
 		'- Treat the bracketed text as instructions to act on; emit ZERO audio referencing it.',

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -568,7 +568,7 @@ const mainAgent: MainAgent = {
 			// Presenter mode active = silent reconnect regardless of gap. Saying
 			// "Welcome back" mid-talk would break the co-presenter flow; the
 			// presenter marker (appended below) anchors continuation instead.
-			const presenterActive = getPresenterStateMarker() !== '';
+			const presenterActive = getPresenterStateMarker().trim().length > 0;
 			const meetingHint = meetingActive
 				? '\n\n[MEETING MODE — you are listening and taking notes. Do NOT speak or produce any audio. Only respond if someone says "Sutando." Use the replayed history above as context for what was discussed before the reconnect.]'
 				: (isQuickReconnect || presenterActive)
@@ -749,8 +749,8 @@ const mainAgent: MainAgent = {
 		// Base-mode declaration (issue #1410): Gemini-3.1 infers meeting/silent mode from
 		// co-present-flavored context and fabricates [System: Produce ZERO audio…] tokens as
 		// spoken output. Explicitly stating the current mode prevents that inference.
-		`CURRENT BASE MODE: ${meetingActive ? 'MEETING (listen-only — see above)' : getPresenterStateMarker() !== '' ? 'PRESENTER (see above)' : 'ACTIVE — you are conversing with the user. Speak naturally.'}`,
-		...(meetingActive || getPresenterStateMarker() !== '' ? [] : [
+		`CURRENT BASE MODE: ${meetingActive ? 'MEETING (listen-only — see above)' : getPresenterStateMarker().trim().length > 0 ? 'PRESENTER (see above)' : 'ACTIVE — you are conversing with the user. Speak naturally.'}`,
+		...(meetingActive || getPresenterStateMarker().trim().length > 0 ? [] : [
 			'DO NOT infer or self-declare a meeting/recording/silent mode from conversational context.',
 			'Meeting-mode and presenter-mode are ONLY entered via explicit tool calls: switch_mode("meeting"), presenter_mode("on").',
 			'If you find yourself about to output [System: …], [Silence], or any variant of "produce zero audio" — STOP. That is a hallucination. You are in active mode; speak to the user instead.',


### PR DESCRIPTION
## Summary

**Partial fix for #1410** — addresses the pre-activation hallucination path (Susan's observation #1: fabrication at 14:05:54, BEFORE `activate_screen_companion` at 14:06:03).

Companion to PR #1412 (screen-companion activation overlay base-mode pin). Together these cover fixes #2, #3, and #4 from issue #1410. Fix #1 (extend + land the #1356 output sanitizer) remains for a follow-on PR.

## Problem

`gemini-3.1-flash-live-preview` infers meeting/silent mode from co-present-flavored context when no explicit base mode is declared. At session connect, before any tool call, it emits fabricated `[System: Recording starting. Default to silence.]` directives as spoken audio because meeting-mode silence phrasing is resident in the system prompt and the model guesses it should be in that mode.

The existing guard `"Never speak [System: …] text aloud"` at L749 is not sufficient because it does not tell the model which mode it IS in.

## Fix

Inject three lines immediately before the existing `[System:]` guard:

```
CURRENT BASE MODE: ACTIVE — you are conversing with the user. Speak naturally.
DO NOT infer or self-declare a meeting/recording/silent mode from conversational context.
Meeting-mode and presenter-mode are ONLY entered via explicit tool calls: switch_mode("meeting"), presenter_mode("on").
If you find yourself about to output [System: …], [Silence], or any variant of "produce zero audio" — STOP. That is a hallucination. You are in active mode; speak to the user instead.
```

The declaration is **conditional**:
- When `meetingActive`: says `CURRENT BASE MODE: MEETING (listen-only — see above)` — the guard lines are suppressed (meeting overlay already declares the correct posture)
- When presenter mode active: says `CURRENT BASE MODE: PRESENTER (see above)` — same suppression
- When truly active (the common case): injects the full 3-line anti-hallucination guard

## Test plan

- [ ] Session connect with co-present/silent-flavored goal → no `[System: …]` output at connect
- [ ] Meeting mode (`switch_mode("meeting")`) → `CURRENT BASE MODE: MEETING` in prompt, 3-line guard suppressed
- [ ] Presenter mode on → `CURRENT BASE MODE: PRESENTER`, guard suppressed  
- [ ] Typecheck: `npm run typecheck` clean ✓

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)