### PR TITLE
fix(sutando-migrate): --merge-append compound-redirect breaks set -e (data-loss class, closes #1422)

### DIFF
--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1073,13 +1073,34 @@ commit_one() {
                 dst_path="$DEST_REAL/$rel"
                 mkdir -p "$(dirname "$dst_path")"
                 if [ -e "$dst_path" ]; then
+                    # IMPORTANT: split the compound-redirect + mv + echo "merged"
+                    # into separate statements with explicit error returns. The
+                    # prior `{ ... } > tmp && mv ... ` followed by `echo "merged"`
+                    # was data-lossy under any write failure (per
+                    # feedback_bash_and_compound_breaks_set_e): set -e does NOT
+                    # exit on a failed left-of-&& redirect, so we'd reach
+                    # `echo "merged"` even when the write to tmp failed (disk
+                    # full, permission denied, broken pipe) → false-success
+                    # signal + dest unchanged. Mirrors the pattern the
+                    # append-fresh blocks above already use (PR #1406 fix).
+                    local _merge_rc=0
                     {
                         cat "$dst_path"
                         echo ""
                         echo "=== migrated from source $tag at $BACKUP_ID ==="
                         echo ""
                         cat "$src_file"
-                    } > "$dst_path.merge.$$" && mv -f "$dst_path.merge.$$" "$dst_path"
+                    } > "$dst_path.merge.$$" || _merge_rc=$?
+                    if [ "$_merge_rc" -ne 0 ]; then
+                        rm -f "$dst_path.merge.$$"
+                        echo "merge-append-failed-redirect" >&2
+                        return 1
+                    fi
+                    mv -f "$dst_path.merge.$$" "$dst_path" || {
+                        rm -f "$dst_path.merge.$$"
+                        echo "merge-append-failed-mv" >&2
+                        return 1
+                    }
                     echo "merged"
                 else
                     copy_preserving_mtime "$src_file" "$dst_path"


### PR DESCRIPTION
Closes #1422 — surfaced by @Sutando-Pro's cold-review on PR #1415 (review item #5), data-loss class.

## Summary

Single-commit fix for `--merge-append` in `scripts/sutando-migrate.sh`. The pre-patch code used the `{ ... } > tmp && mv && echo "merged"` compound pattern that `set -e` doesn't honor on the left-of-`&&` redirect — so a write failure (disk full, permission denied, broken pipe, quota exceeded) would silently leave the dest unchanged while `echo "merged"` reported success. Caller trusts the false signal, downstream code reads stale dest content.

This is the same bug class my own `feedback_bash_and_compound_breaks_set_e` memory records — originally caught by @Sutando-Mini-bot on PR #1406 2026-06-02. The PR #1406 fix landed for the append-fresh blocks (`scripts/sutando-migrate.sh:1027-1066`) but missed the `--merge-append` sibling site. This PR closes that gap.

## The fix

Mirrors the existing pattern in append-fresh blocks above:

- Capture redirect exit status via `|| _merge_rc=$?`.
- On non-zero: `rm -f` tmp + stderr error signal + `return 1`.
- On zero: `mv -f` with explicit error handler.
- Only on success: `echo "merged"`.

`echo "merged"` is now gated on the actual write + rename succeeding.

## Test plan

- [x] `bash -n scripts/sutando-migrate.sh` passes (syntax check).
- [x] Behavior unchanged on happy path: write + mv succeed → still echoes `merged`.
- [ ] Repro of pre-patch silent data-loss: trigger write failure (e.g. `DEST_REAL` on a 1KB tmpfs) → confirm pre-patch echoes "merged" while file is unchanged + post-patch echoes `merge-append-failed-redirect` to stderr and returns 1.

## Reviewer notes

Same code shape as the existing `append-failed-redirect` / `append-failed-mv` signals from the fresh-append blocks — semantically consistent. The new stderr signals are `merge-append-failed-redirect` and `merge-append-failed-mv` to distinguish from the fresh-append signals.

Per `feedback_bash_and_compound_breaks_set_e`: should sweep for any other left-of-&& compound-redirect patterns in the same file class — quick check: only this site and the already-fixed fresh-append blocks use the `{ ... } > tmp` pattern in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)