### PR TITLE
fix(core): self-heal the 1M usage-credit-gate wedge + fix watchdog silent no-op

### DIFF
--- a/scripts/start-cli.sh
+++ b/scripts/start-cli.sh
@@ -21,6 +21,21 @@ cd "$REPO"
 TMUX_SOCKET="/tmp/sutando-tmux.sock"
 SESSION="sutando-core"
 
+# Optional context-window pin (graceful-degradation hook for the 1M
+# usage-credit-gate wedge — see src/health-check.py recover_core_if_wedged).
+# When SUTANDO_CORE_MODEL is set we pass it through as `--model`; otherwise we
+# add NO flag, so the core inherits the user's global model (e.g. `opus[1m]`
+# from ~/.claude/settings.json) and 1M stays the default — we never disable it.
+# health-check's --recover-core escalation only sets SUTANDO_CORE_MODEL=opus
+# AFTER a 1M restart fails to hold, so a re-wedging core falls back to standard
+# 200K context (no gate) and keeps working instead of looping. The
+# ${arr[@]+...} guard keeps an empty array safe on bash 3.2 even under `set -u`
+# (mirrors the empty-array care in PR #1391).
+MODEL_ARGS=()
+if [ -n "${SUTANDO_CORE_MODEL:-}" ]; then
+  MODEL_ARGS=(--model "$SUTANDO_CORE_MODEL")
+fi
+
 # --restart: kill any existing session before starting fresh. Without this,
 # the script's "already running → attach" path returns and the old session
 # keeps running.
@@ -66,7 +81,7 @@ fi
 if ! command -v tmux > /dev/null 2>&1; then
   echo "  ⚠ tmux not found — running without tmux wrapper"
   echo "    (Sutando.app's watcher-auto-restart won't work; brew install tmux to enable)"
-  exec claude --name "$SESSION" --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
+  exec claude --name "$SESSION" ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
     -- "/schedule-crons"
 fi
 
@@ -104,11 +119,11 @@ tmux -S "$TMUX_SOCKET" bind -n WheelDownPane send-keys -M 2>/dev/null || true
 #     start detached so we don't hang, server keeps running.
 if [ -t 1 ]; then
   exec tmux -S "$TMUX_SOCKET" new-session -A -s "$SESSION" \
-    claude --name "$SESSION" --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
+    claude --name "$SESSION" ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
     -- "/schedule-crons"
 else
   tmux -S "$TMUX_SOCKET" new-session -d -s "$SESSION" \
-    claude --name "$SESSION" --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
+    claude --name "$SESSION" ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
     -- "/schedule-crons"
   echo "Started $SESSION detached. Attach via Open Core CLI in menu bar, or:"
   echo "  tmux -S $TMUX_SOCKET attach -t $SESSION"

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -8,6 +8,7 @@ Usage:
   python3 src/health-check.py --fix            # attempt to fix issues
   python3 src/health-check.py --emit-task      # write tasks/task-health-*.txt on failure
   python3 src/health-check.py --notify-on-fail # macOS notification on failure
+  python3 src/health-check.py --notify-slack   # DM the owner on Slack on failure (remote, core-independent)
 
 Checks:
   - macOS TCC Documents-folder access (when repo is under ~/Documents)
@@ -24,6 +25,7 @@ import socket
 import subprocess
 import sys
 import time
+import urllib.request
 from pathlib import Path
 from typing import Optional
 
@@ -1310,11 +1312,173 @@ def notify_for_failures(
         pass
 
 
+def _slack_failures(checks: list[dict]) -> list[dict]:
+    """Failures worth a remote owner DM.
+
+    Same hard-failure statuses as notify_for_failures, but drops benign
+    on-demand `warn`s (e.g. discord-voice / conversation-server "not running
+    (on-demand)") — those are the steady state for per-session processes and
+    would spam the owner's DM every cooldown window. The signals that matter
+    for a remote watchdog (stuck core-proactive-loop, task-queue pileup, a
+    bridge that's actually down) all survive this filter.
+    """
+    out = []
+    for c in checks:
+        st = c["status"]
+        if st in ("down", "missing", "not_loaded", "fail", "stale"):
+            out.append(c)
+        elif st == "warn" and "on-demand" not in (c.get("detail") or ""):
+            out.append(c)
+    return out
+
+
+def _slack_token_from_env_file() -> str:
+    """Read SLACK_BOT_TOKEN from $REPO/.env. The launchd-supervised fallback
+    runs with a minimal environment (no sourced .env), so $SLACK_BOT_TOKEN is
+    usually absent there — but the bridge keeps it in .env. Reading the file
+    directly keeps the watchdog self-sufficient without putting the secret in
+    the world-readable LaunchAgents plist. Returns "" if absent/unreadable."""
+    env_path = REPO_DIR / ".env"
+    try:
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if line.startswith("SLACK_BOT_TOKEN="):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except Exception:
+        pass
+    return ""
+
+
+def _slack_owner_creds() -> "tuple[str, str] | None":
+    """Return (bot_token, owner_user_id) for a direct Slack DM, or None.
+
+    Token from $SLACK_BOT_TOKEN (same one the slack bridge uses), falling back
+    to $REPO/.env for the minimal-env launchd path; owner from
+    ~/.claude/channels/slack/access.json (`tofuOwner`, else first `allowFrom`).
+    Both must be present — otherwise there's no one to DM.
+    """
+    token = os.environ.get("SLACK_BOT_TOKEN", "").strip() or _slack_token_from_env_file()
+    if not token:
+        return None
+    access = Path.home() / ".claude" / "channels" / "slack" / "access.json"
+    try:
+        data = json.loads(access.read_text())
+    except Exception:
+        return None
+    owner = data.get("tofuOwner")
+    if not owner:
+        allow = data.get("allowFrom") or []
+        owner = allow[0] if allow else None
+    if not owner:
+        return None
+    return token, owner
+
+
+def _slack_api(token: str, method: str, payload: dict) -> dict:
+    """Minimal Slack Web API POST via urllib (no slack_bolt dependency, so
+    this works in the launchd-supervised fallback even if the bridge venv
+    isn't on the path). Returns the parsed JSON response."""
+    req = urllib.request.Request(
+        f"https://slack.com/api/{method}",
+        data=json.dumps(payload).encode(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def _default_slack_sender(text: str) -> bool:
+    """Open a DM to the owner and post `text`. Returns True on success."""
+    creds = _slack_owner_creds()
+    if not creds:
+        return False
+    token, owner = creds
+    try:
+        opened = _slack_api(token, "conversations.open", {"users": owner})
+        if not opened.get("ok"):
+            return False
+        channel = opened["channel"]["id"]
+        posted = _slack_api(token, "chat.postMessage", {"channel": channel, "text": text})
+        return bool(posted.get("ok"))
+    except Exception:
+        return False
+
+
+def notify_slack_for_failures(
+    checks: list[dict],
+    state_file: Optional[Path] = None,
+    sender=None,
+) -> None:
+    """DM the owner on Slack when health checks fail — a remote-visible
+    surface that does NOT depend on the core agent being alive.
+
+    This is the watchdog the owner asked for: when the core session wedges
+    (e.g. loops on the 1M-context usage-credit API error), `core-heartbeat`
+    keeps beating from its own background process, so `_any_core_alive()`
+    stays True and `emit_task_for_failures` stays silent — but the
+    `core-proactive-loop` check flips to `warn` and this DMs Slack anyway.
+    Deliberately NOT gated on core liveness, for exactly that reason.
+
+    Same dedup contract as notify_for_failures (per-failure-set hash, 1h
+    cooldown) but a separate state file so the Slack and macOS surfaces never
+    suppress each other. The dedup hash is recorded only on a SUCCESSFUL send,
+    so a transient Slack/API outage doesn't silence the alert for an hour.
+    `sender` is injected by tests to avoid real API calls.
+    """
+    failures = _slack_failures(checks)
+    if not failures:
+        return
+
+    if state_file is None:
+        state_file = WORKSPACE_DIR / "state" / "health-last-slacked.json"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+
+    set_key = "|".join(sorted(c["name"] for c in failures))
+    hash_key = hashlib.sha256(set_key.encode()).hexdigest()[:16]
+    now_ms = int(time.time() * 1000)
+    cooldown_ms = 3600 * 1000  # 1h — matches the macOS + emit-task surfaces
+
+    history: dict = {}
+    try:
+        if state_file.exists():
+            history = json.loads(state_file.read_text())
+    except Exception:
+        history = {}
+
+    if now_ms - history.get(hash_key, 0) < cooldown_ms:
+        return
+
+    lines = [f"• {c['name']}: {c['status']} ({c['detail']})" for c in failures[:5]]
+    extra = f"\n…(+{len(failures) - 5} more)" if len(failures) > 5 else ""
+    text = (
+        f":rotating_light: *Sutando health check* — {len(failures)} issue(s):\n"
+        + "\n".join(lines)
+        + extra
+    )
+
+    send = sender or _default_slack_sender
+    if not send(text):
+        # Send failed — don't record dedup, so the next tick retries.
+        return
+
+    history[hash_key] = now_ms
+    cutoff = now_ms - (24 * 3600 * 1000)
+    history = {k: v for k, v in history.items() if v >= cutoff}
+    try:
+        state_file.write_text(json.dumps(history))
+    except Exception:
+        pass
+
+
 def main():
     as_json = "--json" in sys.argv
     do_fix = "--fix" in sys.argv
     do_emit = "--emit-task" in sys.argv
     do_notify = "--notify-on-fail" in sys.argv
+    do_notify_slack = "--notify-slack" in sys.argv
     quiet = "--quiet" in sys.argv or "-q" in sys.argv
 
     checks = run_all_checks()
@@ -1328,6 +1492,14 @@ def main():
     # can suppress the other.
     if do_notify:
         notify_for_failures(checks)
+
+    # Optional: remote Slack DM surface. Unlike --notify-on-fail (local
+    # macOS notification) and --emit-task (needs a live core to read the
+    # task), this reaches the owner off-machine and fires even when the core
+    # session is wedged but its heartbeat process still ticks. Intended for
+    # the launchd-supervised fallback invocation so outages self-report.
+    if do_notify_slack:
+        notify_slack_for_failures(checks)
 
     # Emit-task: when NOT running --fix, the initial check IS the residual,
     # so emit here BEFORE the early-exit paths (--json return, --quiet

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9,6 +9,7 @@ Usage:
   python3 src/health-check.py --emit-task      # write tasks/task-health-*.txt on failure
   python3 src/health-check.py --notify-on-fail # macOS notification on failure
   python3 src/health-check.py --notify-slack   # DM the owner on Slack on failure (remote, core-independent)
+  python3 src/health-check.py --recover-core   # auto-restart the core when alive-but-wedged (guarded)
 
 Checks:
   - macOS TCC Documents-folder access (when repo is under ~/Documents)
@@ -1333,19 +1334,34 @@ def _slack_failures(checks: list[dict]) -> list[dict]:
 
 
 def _slack_token_from_env_file() -> str:
-    """Read SLACK_BOT_TOKEN from $REPO/.env. The launchd-supervised fallback
-    runs with a minimal environment (no sourced .env), so $SLACK_BOT_TOKEN is
-    usually absent there — but the bridge keeps it in .env. Reading the file
+    """Read SLACK_BOT_TOKEN from disk. The launchd-supervised fallback runs
+    with a minimal environment (no sourced .env), so $SLACK_BOT_TOKEN is
+    usually absent there — but the token persists on disk. Reading the file
     directly keeps the watchdog self-sufficient without putting the secret in
-    the world-readable LaunchAgents plist. Returns "" if absent/unreadable."""
-    env_path = REPO_DIR / ".env"
-    try:
-        for line in env_path.read_text().splitlines():
-            line = line.strip()
-            if line.startswith("SLACK_BOT_TOKEN="):
-                return line.split("=", 1)[1].strip().strip('"').strip("'")
-    except Exception:
-        pass
+    the world-readable LaunchAgents plist. Returns "" if absent/unreadable.
+
+    Order matters: the slack bridge's canonical token location is
+    ~/.claude/channels/slack/.env (startup.sh sources exactly that file before
+    launching the bridge — see src/startup.sh). The original implementation
+    only checked $REPO/.env, where the token does NOT live on a standard
+    install — so the watchdog DM silently no-op'd (creds=None) and the owner
+    got no alert at all. Check the channel .env first, then fall back to
+    $REPO/.env for hosts that keep it there instead.
+    """
+    candidates = [
+        Path.home() / ".claude" / "channels" / "slack" / ".env",
+        REPO_DIR / ".env",
+    ]
+    for env_path in candidates:
+        try:
+            for line in env_path.read_text().splitlines():
+                line = line.strip()
+                if line.startswith("SLACK_BOT_TOKEN="):
+                    val = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    if val:
+                        return val
+        except Exception:
+            continue
     return ""
 
 
@@ -1353,7 +1369,8 @@ def _slack_owner_creds() -> "tuple[str, str] | None":
     """Return (bot_token, owner_user_id) for a direct Slack DM, or None.
 
     Token from $SLACK_BOT_TOKEN (same one the slack bridge uses), falling back
-    to $REPO/.env for the minimal-env launchd path; owner from
+    to the on-disk .env files (channel .env first, then $REPO/.env) for the
+    minimal-env launchd path; owner from
     ~/.claude/channels/slack/access.json (`tofuOwner`, else first `allowFrom`).
     Both must be present — otherwise there's no one to DM.
     """
@@ -1473,12 +1490,247 @@ def notify_slack_for_failures(
         pass
 
 
+# ---------------------------------------------------------------------------
+# Core wedge auto-recovery (--recover-core)
+# ---------------------------------------------------------------------------
+#
+# The 2026-06-02 outage: the core session crossed into 1M extended context,
+# hit the interactive `/usage-credits` gate — which CANNOT be pre-authorized
+# for an unattended agent (it's a per-session, account-side toggle, no
+# settings key / env var / CLI flag exists) — and then looped on the API
+# error. core_heartbeat.py runs as its own process, so the core still "looked
+# alive" while no task ever drained. --notify-slack makes that VISIBLE; this
+# makes it SELF-HEALING.
+#
+# Recovery action is the one mechanism we already own and trust:
+# `scripts/start-cli.sh --restart`. A restarted session starts fresh under the
+# standard context boundary; because the /usage-credits enable persists
+# ACCOUNT-WIDE once a human sets it (and on Max/Team plans 1M is included with
+# no gate at all), the restarted core keeps 1M and re-clears the gate by
+# itself. Queued task files survive a restart (the bridge is file-based), so
+# no work is lost. 1M therefore stays the DEFAULT — we never disable it.
+#
+# Heavily guarded, because auto-restarting a 24/7 agent is consequential:
+#   - Fires only on a CONFIRMED, SUSTAINED wedge: core process alive AND the
+#     oldest queued task older than RECOVER_WEDGE_SEC AND the core didn't just
+#     boot — observed on two passes ≥ RECOVER_CONFIRM_SEC apart. Never a blip.
+#   - RECOVER_COOLDOWN_SEC between restarts.
+#   - Hard cap of RECOVER_MAX_PER_HOUR; past that it DMs "giving up" and stops,
+#     so a pathological wedge can't become a restart loop.
+#   - Graceful degradation: the FIRST restart of an episode keeps 1M; if the
+#     wedge recurs (the 1M restart didn't hold), the next restart pins
+#     SUTANDO_CORE_MODEL=opus (standard 200K) so the agent keeps WORKING.
+#   - DMs the owner before each restart, so recovery is never itself silent.
+#
+# All side-effecting collaborators are injectable so the escalation / cooldown
+# / give-up logic is unit-tested without real restarts or Slack calls. Only
+# wired into the launchd fallback job (its own process, outside the core), and
+# start-cli.sh has its own from-inside-core guard — two independent guarantees
+# the recovery never runs from within the session it would kill.
+
+RECOVER_WEDGE_SEC = int(os.environ.get("SUTANDO_RECOVER_WEDGE_SEC", "600"))        # task stuck this long = wedged
+RECOVER_CONFIRM_SEC = int(os.environ.get("SUTANDO_RECOVER_CONFIRM_SEC", "120"))    # wedge must persist across passes
+RECOVER_COOLDOWN_SEC = int(os.environ.get("SUTANDO_RECOVER_COOLDOWN_SEC", "1800")) # min gap between restarts
+RECOVER_MAX_PER_HOUR = int(os.environ.get("SUTANDO_RECOVER_MAX_PER_HOUR", "3"))
+
+
+def _oldest_pending_task_age(now: float, tasks_dir: Optional[Path] = None) -> "int | None":
+    """Age in seconds of the oldest top-level tasks/*.txt, or None if the queue
+    is empty. Mirrors check_task_queue's globbing (top-level only; archive/
+    excluded). This is the precise wedge signal for recovery: a healthy core
+    drains a task in seconds-to-minutes, so a task sitting for RECOVER_WEDGE_SEC
+    while the core process is alive means the core is stuck — regardless of what
+    core-status.json last said (check_core_proactive_loop misses a wedge that
+    happens while status reads 'idle', because it only flags 'running')."""
+    if tasks_dir is None:
+        tasks_dir = WORKSPACE_DIR / "tasks"
+    try:
+        files = [p for p in tasks_dir.glob("*.txt") if p.is_file()]
+    except OSError:
+        return None
+    if not files:
+        return None
+    try:
+        oldest = min(f.stat().st_mtime for f in files)
+    except OSError:
+        return None
+    return int(now - oldest)
+
+
+def _core_started_within(seconds: float, workspace: Optional[Path] = None, now: Optional[float] = None) -> bool:
+    """True if the freshest LIVE core heartbeat reports started_at within the
+    last `seconds`. Guards against restarting a core that only just booted and
+    hasn't had time to drain the queue yet (its tasks look 'old' but it's
+    catching up, not wedged)."""
+    if workspace is None:
+        workspace = WORKSPACE_DIR
+    if now is None:
+        now = time.time()
+    cores_dir = workspace / "state" / "cores"
+    if not cores_dir.is_dir():
+        return False
+    youngest_start = None
+    for alive_file in cores_dir.glob("*.alive"):
+        try:
+            if now - alive_file.stat().st_mtime >= 90.0:
+                continue  # stale heartbeat — not a live core
+            data = json.loads(alive_file.read_text())
+        except (OSError, ValueError):
+            continue
+        started = data.get("started_at")
+        if isinstance(started, (int, float)):
+            if youngest_start is None or started > youngest_start:
+                youngest_start = started
+    if youngest_start is None:
+        return False
+    return (now - youngest_start) < seconds
+
+
+def _default_core_restart(standard_context: bool) -> bool:
+    """Run scripts/start-cli.sh --restart out-of-process. When standard_context
+    is True, pin SUTANDO_CORE_MODEL=opus so the restarted core runs in the
+    standard 200K window (graceful degradation). Returns True if the restart
+    command exited 0."""
+    script = REPO_DIR / "scripts" / "start-cli.sh"
+    if not script.exists():
+        return False
+    env = dict(os.environ)
+    # launchd's minimal PATH won't find homebrew tmux; start-cli.sh needs it.
+    env["PATH"] = "/opt/homebrew/bin:/usr/local/bin:" + env.get("PATH", "/usr/bin:/bin")
+    if standard_context:
+        env["SUTANDO_CORE_MODEL"] = "opus"
+    try:
+        proc = subprocess.run(
+            ["/bin/bash", str(script), "--restart"],
+            env=env, capture_output=True, text=True, timeout=120,
+        )
+        return proc.returncode == 0
+    except Exception:
+        return False
+
+
+def recover_core_if_wedged(
+    state_file: Optional[Path] = None,
+    now: Optional[float] = None,
+    alive_fn=None,
+    oldest_age_fn=None,
+    just_booted_fn=None,
+    restart_fn=None,
+    sender=None,
+) -> "dict | None":
+    """Auto-restart the core when it is alive-but-wedged. Returns a dict
+    describing the action taken (for tests / observability), or None when no
+    action was warranted. See the module comment above for the guard rationale.
+    All side-effecting collaborators are injectable for tests.
+    """
+    if now is None:
+        now = time.time()
+    if state_file is None:
+        state_file = WORKSPACE_DIR / "state" / "core-recovery.json"
+    alive_fn = alive_fn or _any_core_alive
+    oldest_age_fn = oldest_age_fn or (lambda: _oldest_pending_task_age(now))
+    just_booted_fn = just_booted_fn or (lambda: _core_started_within(RECOVER_WEDGE_SEC, now=now))
+    restart_fn = restart_fn or _default_core_restart
+    send = sender or _default_slack_sender
+
+    try:
+        state = json.loads(state_file.read_text()) if state_file.exists() else {}
+    except Exception:
+        state = {}
+    if not isinstance(state, dict):
+        state = {}
+
+    def _save():
+        try:
+            state_file.parent.mkdir(parents=True, exist_ok=True)
+            state_file.write_text(json.dumps(state))
+        except Exception:
+            pass
+
+    oldest_age = oldest_age_fn()
+    wedged = (
+        alive_fn()
+        and oldest_age is not None
+        and oldest_age > RECOVER_WEDGE_SEC
+        and not just_booted_fn()
+    )
+
+    if not wedged:
+        # Healthy (or no queued work / core down / just booted). Clear the
+        # in-progress wedge observation so a future wedge starts its
+        # confirmation window fresh. last_restart / history are preserved.
+        if state.get("wedge_first_seen"):
+            state["wedge_first_seen"] = 0
+            _save()
+        return None
+
+    # Confirmation window: require the wedge to persist across passes so a
+    # single anomalous read (clock skew, a half-written file) can't trigger.
+    first_seen = state.get("wedge_first_seen") or 0
+    if not first_seen:
+        state["wedge_first_seen"] = now
+        _save()
+        return {"action": "observed", "oldest_age": oldest_age}
+    if now - first_seen < RECOVER_CONFIRM_SEC:
+        return {"action": "confirming", "oldest_age": oldest_age, "for": int(now - first_seen)}
+
+    # Cooldown between restarts.
+    last_restart = state.get("last_restart") or 0
+    if last_restart and now - last_restart < RECOVER_COOLDOWN_SEC:
+        return {"action": "cooldown", "oldest_age": oldest_age, "since_restart": int(now - last_restart)}
+
+    # Give-up cap: prune restart history to the trailing hour.
+    history = [t for t in (state.get("restart_history") or []) if isinstance(t, (int, float)) and now - t < 3600]
+    if len(history) >= RECOVER_MAX_PER_HOUR:
+        # DM once per give-up episode (deduped via gave_up_at).
+        if not state.get("gave_up_at") or now - state["gave_up_at"] > 3600:
+            send(
+                ":octagonal_sign: *Sutando core auto-recovery gave up* — restarted "
+                f"{len(history)}× in the last hour and the core is still wedged "
+                f"(oldest task stuck {oldest_age // 60} min). Needs manual attention: "
+                "check the CLI / `/usage-credits`."
+            )
+            state["gave_up_at"] = now
+            _save()
+        return {"action": "gave_up", "restarts_last_hour": len(history)}
+
+    # Escalation: the FIRST restart in the trailing hour keeps 1M; if we're
+    # wedged again after a prior restart, that restart didn't hold — degrade to
+    # standard 200K context so the agent keeps working instead of re-wedging.
+    standard_context = len(history) >= 1
+    mode = "standard" if standard_context else "1m"
+    ctx_note = (
+        "in standard 200K context (the 1M restart didn't hold)" if standard_context
+        else "keeping 1M context"
+    )
+    send(
+        f":hourglass: *Sutando core wedged* — oldest task stuck {oldest_age // 60} min "
+        f"while the core process is alive (likely the 1M usage-credit gate or a "
+        f"stalled turn). Auto-restarting {ctx_note}. Queued tasks are preserved."
+    )
+
+    if not restart_fn(standard_context):
+        # Restart launch failed — don't burn a cooldown/history slot, and keep
+        # wedge_first_seen so we stay confirmed and retry on the next pass.
+        return {"action": "restart_failed", "mode": mode}
+
+    history.append(now)
+    state["restart_history"] = history
+    state["last_restart"] = now
+    state["last_restart_mode"] = mode
+    state["wedge_first_seen"] = 0  # re-observe after the restart settles
+    state.pop("gave_up_at", None)
+    _save()
+    return {"action": "restarted", "mode": mode, "oldest_age": oldest_age, "restarts_last_hour": len(history)}
+
+
 def main():
     as_json = "--json" in sys.argv
     do_fix = "--fix" in sys.argv
     do_emit = "--emit-task" in sys.argv
     do_notify = "--notify-on-fail" in sys.argv
     do_notify_slack = "--notify-slack" in sys.argv
+    do_recover = "--recover-core" in sys.argv
     quiet = "--quiet" in sys.argv or "-q" in sys.argv
 
     checks = run_all_checks()
@@ -1500,6 +1752,15 @@ def main():
     # the launchd-supervised fallback invocation so outages self-report.
     if do_notify_slack:
         notify_slack_for_failures(checks)
+
+    # Optional: auto-recover a wedged core (alive-but-stuck) by restarting it.
+    # Independent of the checks list — keys off the queue-drain + heartbeat
+    # signals directly (see recover_core_if_wedged). Intended for the
+    # launchd-supervised fallback so the core self-heals from the 1M-gate wedge
+    # without waiting for a human. Heavily guarded (confirm window, cooldown,
+    # give-up cap); a no-op when the core is healthy.
+    if do_recover:
+        recover_core_if_wedged()
 
     # Emit-task: when NOT running --fix, the initial check IS the residual,
     # so emit here BEFORE the early-exit paths (--json return, --quiet

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -30,6 +30,11 @@ import urllib.request
 from pathlib import Path
 from typing import Optional
 
+try:
+    import fcntl  # POSIX file locking for the recovery critical section
+except ImportError:  # non-POSIX (e.g. Windows) — the lock degrades to a no-op
+    fcntl = None
+
 REPO_DIR = Path(__file__).parent.parent
 sys.path.insert(0, str(Path(__file__).parent))
 from util_paths import shared_personal_path  # noqa: E402
@@ -1514,13 +1519,23 @@ def notify_slack_for_failures(
 #   - Fires only on a CONFIRMED, SUSTAINED wedge: core process alive AND the
 #     oldest queued task older than RECOVER_WEDGE_SEC AND the core didn't just
 #     boot — observed on two passes ≥ RECOVER_CONFIRM_SEC apart. Never a blip.
-#   - RECOVER_COOLDOWN_SEC between restarts.
+#   - Identity + progress gating (so a legitimately long-running single task is
+#     not killed mid-work): the SAME oldest task must persist across the window
+#     (a draining queue surfaces a different oldest each pass → resets) AND
+#     core-status.json must not advance (a core making progress isn't wedged).
+#     Residual: a long single task that NEVER updates its status is still
+#     indistinguishable from a wedge by external signals — bounded by the
+#     cooldown + give-up cap, and such tasks should heartbeat core-status.json.
+#   - RECOVER_COOLDOWN_SEC between restarts; an exclusive flock on the state
+#     file serializes the decision so a manual + launchd run can't double-fire.
 #   - Hard cap of RECOVER_MAX_PER_HOUR; past that it DMs "giving up" and stops,
 #     so a pathological wedge can't become a restart loop.
 #   - Graceful degradation: the FIRST restart of an episode keeps 1M; if the
 #     wedge recurs (the 1M restart didn't hold), the next restart pins
 #     SUTANDO_CORE_MODEL=opus (standard 200K) so the agent keeps WORKING.
-#   - DMs the owner before each restart, so recovery is never itself silent.
+#   - DMs the owner before each restart and records whether the DM succeeded
+#     (last_restart_dm_sent) + logs failures, so a restart is never invisible
+#     even if Slack is down — recovery still proceeds (recovery > notification).
 #
 # All side-effecting collaborators are injectable so the escalation / cooldown
 # / give-up logic is unit-tested without real restarts or Slack calls. Only
@@ -1534,14 +1549,22 @@ RECOVER_COOLDOWN_SEC = int(os.environ.get("SUTANDO_RECOVER_COOLDOWN_SEC", "1800"
 RECOVER_MAX_PER_HOUR = int(os.environ.get("SUTANDO_RECOVER_MAX_PER_HOUR", "3"))
 
 
-def _oldest_pending_task_age(now: float, tasks_dir: Optional[Path] = None) -> "int | None":
-    """Age in seconds of the oldest top-level tasks/*.txt, or None if the queue
-    is empty. Mirrors check_task_queue's globbing (top-level only; archive/
-    excluded). This is the precise wedge signal for recovery: a healthy core
-    drains a task in seconds-to-minutes, so a task sitting for RECOVER_WEDGE_SEC
-    while the core process is alive means the core is stuck — regardless of what
-    core-status.json last said (check_core_proactive_loop misses a wedge that
-    happens while status reads 'idle', because it only flags 'running')."""
+def _oldest_pending_task(now: float, tasks_dir: Optional[Path] = None) -> "tuple[str, int] | None":
+    """(identity, age_seconds) of the oldest top-level tasks/*.txt, or None if
+    the queue is empty. Mirrors check_task_queue's globbing (top-level only;
+    archive/ excluded). This is the precise wedge signal for recovery: a healthy
+    core drains a task in seconds-to-minutes, so a task sitting for
+    RECOVER_WEDGE_SEC while the core process is alive means the core is stuck —
+    regardless of what core-status.json last said (check_core_proactive_loop
+    misses a wedge that happens while status reads 'idle', because it only flags
+    'running').
+
+    The identity is `"<name>|<int(mtime)>"`. Recovery requires the SAME identity
+    to persist across the confirm window before restarting (PR #1428 review,
+    blocker 3): if the oldest task changes (a task drained → a different oldest)
+    or its mtime moves (the file was rewritten/reprocessed), the queue is
+    draining, not wedged, and the observation resets — so a busy-but-healthy
+    backlog never triggers a restart."""
     if tasks_dir is None:
         tasks_dir = WORKSPACE_DIR / "tasks"
     try:
@@ -1551,10 +1574,29 @@ def _oldest_pending_task_age(now: float, tasks_dir: Optional[Path] = None) -> "i
     if not files:
         return None
     try:
-        oldest = min(f.stat().st_mtime for f in files)
+        oldest = min(files, key=lambda p: p.stat().st_mtime)
+        mtime = oldest.stat().st_mtime
     except OSError:
         return None
-    return int(now - oldest)
+    return (f"{oldest.name}|{int(mtime)}", int(now - mtime))
+
+
+def _core_status_ts(workspace: Optional[Path] = None) -> "float | None":
+    """Current core-status.json `ts`, or None if unavailable. Used as a
+    progress signal: a core actively working (even a long single task that
+    periodically updates status per CLAUDE.md) advances this; a core looping on
+    the usage-credit API error cannot complete a turn to update it. If it
+    advances across the confirm window, recovery treats the core as making
+    progress and resets — so legitimately long work isn't restarted out from
+    under itself (PR #1428 review, blocker 3)."""
+    if workspace is None:
+        workspace = WORKSPACE_DIR
+    try:
+        data = json.loads(status_read_path("core-status.json", workspace).read_text())
+        ts = data.get("ts")
+        return ts if isinstance(ts, (int, float)) else None
+    except Exception:
+        return None
 
 
 def _core_started_within(seconds: float, workspace: Optional[Path] = None, now: Optional[float] = None) -> bool:
@@ -1613,7 +1655,8 @@ def recover_core_if_wedged(
     state_file: Optional[Path] = None,
     now: Optional[float] = None,
     alive_fn=None,
-    oldest_age_fn=None,
+    oldest_task_fn=None,
+    status_ts_fn=None,
     just_booted_fn=None,
     restart_fn=None,
     sender=None,
@@ -1622,106 +1665,173 @@ def recover_core_if_wedged(
     describing the action taken (for tests / observability), or None when no
     action was warranted. See the module comment above for the guard rationale.
     All side-effecting collaborators are injectable for tests.
+
+    The whole load→decide→restart→save sequence runs under an exclusive,
+    non-blocking flock on `<state_file>.lock` (PR #1428 review, suggestion):
+    a manual `--recover-core` from the CLI and the launchd job firing in the
+    same window must not both clear the cooldown and issue duplicate restarts.
+    A second concurrent invocation returns {"action": "locked"} and no-ops.
     """
     if now is None:
         now = time.time()
     if state_file is None:
         state_file = WORKSPACE_DIR / "state" / "core-recovery.json"
     alive_fn = alive_fn or _any_core_alive
-    oldest_age_fn = oldest_age_fn or (lambda: _oldest_pending_task_age(now))
+    oldest_task_fn = oldest_task_fn or (lambda: _oldest_pending_task(now))
+    status_ts_fn = status_ts_fn or _core_status_ts
     just_booted_fn = just_booted_fn or (lambda: _core_started_within(RECOVER_WEDGE_SEC, now=now))
     restart_fn = restart_fn or _default_core_restart
     send = sender or _default_slack_sender
 
     try:
-        state = json.loads(state_file.read_text()) if state_file.exists() else {}
+        state_file.parent.mkdir(parents=True, exist_ok=True)
     except Exception:
-        state = {}
-    if not isinstance(state, dict):
-        state = {}
+        pass
 
-    def _save():
+    # Serialize the critical section (suggestion: no concurrent double-restart).
+    lock_path = state_file.with_name(state_file.name + ".lock")
+    lock_fh = None
+    if fcntl is not None:
         try:
-            state_file.parent.mkdir(parents=True, exist_ok=True)
-            state_file.write_text(json.dumps(state))
+            lock_fh = open(lock_path, "w")
+            fcntl.flock(lock_fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            # Another recovery invocation holds the lock — skip this pass.
+            if lock_fh is not None:
+                lock_fh.close()
+            return {"action": "locked"}
+
+    try:
+        try:
+            state = json.loads(state_file.read_text()) if state_file.exists() else {}
         except Exception:
-            pass
+            state = {}
+        if not isinstance(state, dict):
+            state = {}
 
-    oldest_age = oldest_age_fn()
-    wedged = (
-        alive_fn()
-        and oldest_age is not None
-        and oldest_age > RECOVER_WEDGE_SEC
-        and not just_booted_fn()
-    )
+        def _save():
+            try:
+                state_file.write_text(json.dumps(state))
+            except Exception:
+                pass
 
-    if not wedged:
-        # Healthy (or no queued work / core down / just booted). Clear the
-        # in-progress wedge observation so a future wedge starts its
-        # confirmation window fresh. last_restart / history are preserved.
-        if state.get("wedge_first_seen"):
+        def _reset_observation():
             state["wedge_first_seen"] = 0
-            _save()
-        return None
+            state["wedge_task"] = None
+            state["wedge_status_ts"] = None
 
-    # Confirmation window: require the wedge to persist across passes so a
-    # single anomalous read (clock skew, a half-written file) can't trigger.
-    first_seen = state.get("wedge_first_seen") or 0
-    if not first_seen:
-        state["wedge_first_seen"] = now
+        oldest = oldest_task_fn()                    # (identity, age) | None
+        cur_key = oldest[0] if oldest else None
+        oldest_age = oldest[1] if oldest else None
+        status_ts = status_ts_fn()
+        wedged = (
+            alive_fn()
+            and oldest is not None
+            and oldest_age > RECOVER_WEDGE_SEC
+            and not just_booted_fn()
+        )
+
+        if not wedged:
+            # Healthy / no queued work / core down / just booted. Clear any
+            # in-progress observation so a future wedge starts fresh.
+            # last_restart / history are preserved (cooldown + give-up survive).
+            if state.get("wedge_first_seen") or state.get("wedge_task") is not None:
+                _reset_observation()
+                _save()
+            return None
+
+        # Identity + progress gating (blocker 3): age alone can't tell a wedge
+        # from a legitimately long single task. Reset the confirmation window if
+        # EITHER the oldest task changed (queue draining → a different oldest, or
+        # the file was rewritten → new mtime) OR the core advanced core-status.json
+        # (it's making progress, not looping). Only a SAME-task, NO-progress
+        # streak across the window is treated as a real wedge.
+        prev_key = state.get("wedge_task")
+        prev_status_ts = state.get("wedge_status_ts")
+        first_seen = state.get("wedge_first_seen") or 0
+        progressed = (
+            isinstance(prev_status_ts, (int, float))
+            and isinstance(status_ts, (int, float))
+            and status_ts > prev_status_ts
+        )
+        if (not first_seen) or prev_key != cur_key or progressed:
+            state["wedge_first_seen"] = now
+            state["wedge_task"] = cur_key
+            state["wedge_status_ts"] = status_ts
+            _save()
+            return {"action": "observed", "oldest_age": oldest_age, "task": cur_key}
+
+        if now - first_seen < RECOVER_CONFIRM_SEC:
+            return {"action": "confirming", "oldest_age": oldest_age, "for": int(now - first_seen)}
+
+        # Cooldown between restarts.
+        last_restart = state.get("last_restart") or 0
+        if last_restart and now - last_restart < RECOVER_COOLDOWN_SEC:
+            return {"action": "cooldown", "oldest_age": oldest_age, "since_restart": int(now - last_restart)}
+
+        # Give-up cap: prune restart history to the trailing hour.
+        history = [t for t in (state.get("restart_history") or []) if isinstance(t, (int, float)) and now - t < 3600]
+        if len(history) >= RECOVER_MAX_PER_HOUR:
+            # DM once per give-up episode. Record gave_up_at only on a SUCCESSFUL
+            # send so a Slack outage doesn't silence the give-up alert for an hour.
+            if not state.get("gave_up_at") or now - state["gave_up_at"] > 3600:
+                if send(
+                    ":octagonal_sign: *Sutando core auto-recovery gave up* — restarted "
+                    f"{len(history)}× in the last hour and the core is still wedged "
+                    f"(oldest task stuck {oldest_age // 60} min). Needs manual attention: "
+                    "check the CLI / `/usage-credits`."
+                ):
+                    state["gave_up_at"] = now
+                    _save()
+                else:
+                    print("[recover-core] WARNING: give-up DM to owner failed", flush=True)
+            return {"action": "gave_up", "restarts_last_hour": len(history)}
+
+        # Escalation: the FIRST restart in the trailing hour keeps 1M; if we're
+        # wedged again after a prior restart, that restart didn't hold — degrade
+        # to standard 200K context so the agent keeps working instead of re-wedging.
+        standard_context = len(history) >= 1
+        mode = "standard" if standard_context else "1m"
+        ctx_note = (
+            "in standard 200K context (the 1M restart didn't hold)" if standard_context
+            else "keeping 1M context"
+        )
+        # DM the owner BEFORE restarting. Capture the result (blocker 2): if the
+        # DM fails we still restart (recovery > notification — don't leave the
+        # core wedged because Slack is down), but we record dm_sent=False and log
+        # to stderr/launchd so the restart is never invisible.
+        dm_ok = send(
+            f":hourglass: *Sutando core wedged* — oldest task stuck {oldest_age // 60} min "
+            f"while the core process is alive (likely the 1M usage-credit gate or a "
+            f"stalled turn). Auto-restarting {ctx_note}. Queued tasks are preserved."
+        )
+        if not dm_ok:
+            print(f"[recover-core] WARNING: wedge-restart DM failed; restarting anyway (mode={mode})", flush=True)
+
+        if not restart_fn(standard_context):
+            # Restart launch failed — don't burn a cooldown/history slot, and
+            # keep the observation so we stay confirmed and retry next pass.
+            return {"action": "restart_failed", "mode": mode, "dm_sent": dm_ok}
+
+        history.append(now)
+        state["restart_history"] = history
+        state["last_restart"] = now
+        state["last_restart_mode"] = mode
+        state["last_restart_dm_sent"] = dm_ok
+        _reset_observation()  # re-observe after the restart settles
+        state.pop("gave_up_at", None)
         _save()
-        return {"action": "observed", "oldest_age": oldest_age}
-    if now - first_seen < RECOVER_CONFIRM_SEC:
-        return {"action": "confirming", "oldest_age": oldest_age, "for": int(now - first_seen)}
-
-    # Cooldown between restarts.
-    last_restart = state.get("last_restart") or 0
-    if last_restart and now - last_restart < RECOVER_COOLDOWN_SEC:
-        return {"action": "cooldown", "oldest_age": oldest_age, "since_restart": int(now - last_restart)}
-
-    # Give-up cap: prune restart history to the trailing hour.
-    history = [t for t in (state.get("restart_history") or []) if isinstance(t, (int, float)) and now - t < 3600]
-    if len(history) >= RECOVER_MAX_PER_HOUR:
-        # DM once per give-up episode (deduped via gave_up_at).
-        if not state.get("gave_up_at") or now - state["gave_up_at"] > 3600:
-            send(
-                ":octagonal_sign: *Sutando core auto-recovery gave up* — restarted "
-                f"{len(history)}× in the last hour and the core is still wedged "
-                f"(oldest task stuck {oldest_age // 60} min). Needs manual attention: "
-                "check the CLI / `/usage-credits`."
-            )
-            state["gave_up_at"] = now
-            _save()
-        return {"action": "gave_up", "restarts_last_hour": len(history)}
-
-    # Escalation: the FIRST restart in the trailing hour keeps 1M; if we're
-    # wedged again after a prior restart, that restart didn't hold — degrade to
-    # standard 200K context so the agent keeps working instead of re-wedging.
-    standard_context = len(history) >= 1
-    mode = "standard" if standard_context else "1m"
-    ctx_note = (
-        "in standard 200K context (the 1M restart didn't hold)" if standard_context
-        else "keeping 1M context"
-    )
-    send(
-        f":hourglass: *Sutando core wedged* — oldest task stuck {oldest_age // 60} min "
-        f"while the core process is alive (likely the 1M usage-credit gate or a "
-        f"stalled turn). Auto-restarting {ctx_note}. Queued tasks are preserved."
-    )
-
-    if not restart_fn(standard_context):
-        # Restart launch failed — don't burn a cooldown/history slot, and keep
-        # wedge_first_seen so we stay confirmed and retry on the next pass.
-        return {"action": "restart_failed", "mode": mode}
-
-    history.append(now)
-    state["restart_history"] = history
-    state["last_restart"] = now
-    state["last_restart_mode"] = mode
-    state["wedge_first_seen"] = 0  # re-observe after the restart settles
-    state.pop("gave_up_at", None)
-    _save()
-    return {"action": "restarted", "mode": mode, "oldest_age": oldest_age, "restarts_last_hour": len(history)}
+        return {
+            "action": "restarted", "mode": mode, "oldest_age": oldest_age,
+            "restarts_last_hour": len(history), "dm_sent": dm_ok,
+        }
+    finally:
+        if lock_fh is not None:
+            try:
+                fcntl.flock(lock_fh, fcntl.LOCK_UN)
+            except Exception:
+                pass
+            lock_fh.close()
 
 
 def main():

--- a/src/install-health-check-launchd.sh
+++ b/src/install-health-check-launchd.sh
@@ -13,12 +13,16 @@
 #     ~/Library/LaunchAgents/com.sutando.health-check-fallback.plist
 #   - Loads it via `launchctl bootstrap gui/$UID` (the modern Sequoia idiom).
 #   - Result: macOS runs `python3 src/health-check.py --emit-task
-#     --notify-on-fail --notify-slack --quiet` every 5min, independent of any
-#     other Sutando process. Failures surface as tasks (for the agent to act
-#     on), macOS notifications (so the human sees them even if all of Sutando
-#     is dead), AND a direct Slack DM to the owner (remote-visible self-report
-#     for outages — fires even when the core loop is wedged). The Slack DM
-#     no-ops if no token / owner is configured.
+#     --notify-on-fail --notify-slack --recover-core --quiet` every 5min,
+#     independent of any other Sutando process. Failures surface as tasks (for
+#     the agent to act on), macOS notifications (so the human sees them even if
+#     all of Sutando is dead), AND a direct Slack DM to the owner (remote-visible
+#     self-report for outages — fires even when the core loop is wedged). The
+#     Slack DM no-ops if no token / owner is configured.
+#   - --recover-core additionally self-heals an alive-but-wedged core (the
+#     2026-06-02 1M usage-credit-gate loop) by restarting it via start-cli.sh,
+#     guarded by a confirm window + cooldown + 3/hr give-up cap. No-op when
+#     healthy; keeps 1M on the first restart, degrades to 200K only if it recurs.
 #
 # What the user sees first time they install:
 #   - One macOS "Background Item Added" notification banner (Apple's own UX,
@@ -127,7 +131,8 @@ case "$cmd" in
         echo
         echo "Sutando — Health Check (fallback) is now running every 5min."
         echo "  • Failures fire macOS notifications + write tasks/task-health-*.txt"
-        echo "  • Plus a Slack DM to the owner if SLACK_BOT_TOKEN (.env) + access.json are set"
+        echo "  • Plus a Slack DM to the owner if SLACK_BOT_TOKEN (channel/.env) + access.json are set"
+        echo "  • Auto-restarts an alive-but-wedged core (guarded; keeps 1M, no-op when healthy)"
         echo "  • View status:  bash $0 --status"
         echo "  • Uninstall:    bash $0 --uninstall"
         echo "  • Disable temporarily: System Settings → General → Login Items"

--- a/src/install-health-check-launchd.sh
+++ b/src/install-health-check-launchd.sh
@@ -13,10 +13,12 @@
 #     ~/Library/LaunchAgents/com.sutando.health-check-fallback.plist
 #   - Loads it via `launchctl bootstrap gui/$UID` (the modern Sequoia idiom).
 #   - Result: macOS runs `python3 src/health-check.py --emit-task
-#     --notify-on-fail --quiet` every 5min, independent of any other Sutando
-#     process. Failures surface as tasks (for the agent to act on) AND as
-#     macOS notifications (so the human sees them even if all of Sutando is
-#     dead).
+#     --notify-on-fail --notify-slack --quiet` every 5min, independent of any
+#     other Sutando process. Failures surface as tasks (for the agent to act
+#     on), macOS notifications (so the human sees them even if all of Sutando
+#     is dead), AND a direct Slack DM to the owner (remote-visible self-report
+#     for outages — fires even when the core loop is wedged). The Slack DM
+#     no-ops if no token / owner is configured.
 #
 # What the user sees first time they install:
 #   - One macOS "Background Item Added" notification banner (Apple's own UX,
@@ -125,6 +127,7 @@ case "$cmd" in
         echo
         echo "Sutando — Health Check (fallback) is now running every 5min."
         echo "  • Failures fire macOS notifications + write tasks/task-health-*.txt"
+        echo "  • Plus a Slack DM to the owner if SLACK_BOT_TOKEN (.env) + access.json are set"
         echo "  • View status:  bash $0 --status"
         echo "  • Uninstall:    bash $0 --uninstall"
         echo "  • Disable temporarily: System Settings → General → Login Items"

--- a/src/launchd/com.sutando.health-check-fallback.plist
+++ b/src/launchd/com.sutando.health-check-fallback.plist
@@ -21,8 +21,13 @@
 
   Behavior:
     - Fires every 300s (StartInterval).
-    - Runs `python3 src/health-check.py --emit-task --notify-on-fail --quiet`.
-    - Surfaces failures as tasks/task-health-*.txt AND macOS notifications.
+    - Runs `python3 src/health-check.py --emit-task --notify-on-fail
+      --notify-slack --quiet`.
+    - Surfaces failures as tasks/task-health-*.txt, macOS notifications, AND
+      a direct Slack DM to the owner (remote-visible; fires even when the core
+      session is wedged but its heartbeat process still ticks). The Slack DM
+      no-ops cleanly if SLACK_BOT_TOKEN (env or $REPO/.env) or the owner id in
+      ~/.claude/channels/slack/access.json is missing.
     - ThrottleInterval=60 prevents crash-loop thrash.
     - Exit-only job (KeepAlive omitted) — launchd waits StartInterval, fires
       again, no zombie process between runs.
@@ -40,6 +45,7 @@
         <string>__REPO__/src/health-check.py</string>
         <string>--emit-task</string>
         <string>--notify-on-fail</string>
+        <string>--notify-slack</string>
         <string>--quiet</string>
     </array>
 

--- a/src/launchd/com.sutando.health-check-fallback.plist
+++ b/src/launchd/com.sutando.health-check-fallback.plist
@@ -22,12 +22,19 @@
   Behavior:
     - Fires every 300s (StartInterval).
     - Runs `python3 src/health-check.py --emit-task --notify-on-fail
-      --notify-slack --quiet`.
+      --notify-slack --recover-core --quiet`.
     - Surfaces failures as tasks/task-health-*.txt, macOS notifications, AND
       a direct Slack DM to the owner (remote-visible; fires even when the core
       session is wedged but its heartbeat process still ticks). The Slack DM
-      no-ops cleanly if SLACK_BOT_TOKEN (env or $REPO/.env) or the owner id in
-      ~/.claude/channels/slack/access.json is missing.
+      no-ops cleanly if SLACK_BOT_TOKEN (channel .env / $REPO/.env / env) or the
+      owner id in ~/.claude/channels/slack/access.json is missing.
+    - --recover-core: when the core is alive-but-wedged (heartbeat ticking but
+      the task queue isn't draining — the 2026-06-02 1M usage-credit-gate loop
+      signature), auto-restarts it via scripts/start-cli.sh --restart. Heavily
+      guarded (sustained-wedge confirm window, 30min cooldown, 3/hr give-up cap)
+      and a clean no-op when the core is healthy. Keeps 1M on the first restart;
+      degrades to standard 200K only if the wedge recurs. Runs here, in launchd's
+      own process — never from inside the core session it would kill.
     - ThrottleInterval=60 prevents crash-loop thrash.
     - Exit-only job (KeepAlive omitted) — launchd waits StartInterval, fires
       again, no zombie process between runs.
@@ -46,6 +53,7 @@
         <string>--emit-task</string>
         <string>--notify-on-fail</string>
         <string>--notify-slack</string>
+        <string>--recover-core</string>
         <string>--quiet</string>
     </array>
 

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -654,7 +654,13 @@ def _check_task_timeouts() -> None:
             if info.get("timed_out"):
                 continue
             if now - info.get("submitted_at", now) > TASK_TIMEOUT_SEC:
-                info["timed_out"] = True
+                # Collect only — do NOT set timed_out here. Marking before the
+                # send means a single Slack API hiccup (which raises below and
+                # is merely logged) leaves the flag True forever, so the next
+                # pass's `if info.get("timed_out"): continue` skips it and the
+                # user never sees the warning — recreating the exact silent
+                # no-op this watchdog exists to prevent. Mark only AFTER a
+                # successful send. (Per @sonichi PR #1428 review, blocker 1.)
                 to_notify.append((task_id, info["channel"], info.get("thread_ts")))
     if not to_notify:
         return
@@ -668,9 +674,18 @@ def _check_task_timeouts() -> None:
     for task_id, channel, thread_ts in to_notify:
         try:
             _send_reply(channel, thread_ts, msg, task_id=task_id)
-            print(f"  [timeout] notified Slack for {task_id} after {TASK_TIMEOUT_SEC}s", flush=True)
         except Exception as e:
+            # Send failed — leave timed_out unset so the next pass retries.
             print(f"[Slack] timeout notify failed for {task_id}: {e}", flush=True)
+            continue
+        # Notified once, successfully. Mark so we don't repeat. The entry may
+        # have been popped by result_watcher if a real result landed meanwhile
+        # — guard with get() so we don't resurrect a delivered task.
+        with pending_replies_lock:
+            entry = pending_replies.get(task_id)
+            if entry is not None:
+                entry["timed_out"] = True
+        print(f"  [timeout] notified Slack for {task_id} after {TASK_TIMEOUT_SEC}s", flush=True)
 
 
 def result_watcher():

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -280,10 +280,20 @@ def tofu_onboard(user_id: str, username: str | None) -> set:
 
 
 # Track which Slack channel/thread to reply into for each task we wrote.
-# Keyed by task_id; value is {channel, thread_ts} so we can reply in-thread
-# for @mentions and at top-level for DMs.
+# Keyed by task_id; value is {channel, thread_ts, submitted_at, timed_out}
+# so we can reply in-thread for @mentions and at top-level for DMs, and so
+# the result_watcher can detect tasks the core never answered.
 pending_replies: dict[str, dict] = {}
 pending_replies_lock = threading.Lock()
+
+# Per-task timeout. Mirrors task-bridge.ts's DEFAULT_TASK_TIMEOUT_MS (10 min):
+# if the core session wedges (e.g. hits the 1M-context usage-credit gate and
+# loops on the API error), no result file is ever written and the Slack user
+# gets silence. After this many seconds we post a one-time "still working /
+# may have hit a limit" reply so the failure is visible instead of silent.
+# The pending entry is KEPT after notifying, so if the core later recovers and
+# writes a result, the real answer still gets delivered. 0 disables.
+TASK_TIMEOUT_SEC = int(os.environ.get("SLACK_TASK_TIMEOUT_SEC", "600"))
 
 # Username cache — users.info is rate-limited (Tier 4 = 100/min). One
 # cache lookup per known user saves a network hop on every DM. Cache
@@ -443,7 +453,12 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
         f"priority: {priority}\n"
     )
     with pending_replies_lock:
-        pending_replies[task_id] = {"channel": channel, "thread_ts": thread_ts}
+        pending_replies[task_id] = {
+            "channel": channel,
+            "thread_ts": thread_ts,
+            "submitted_at": time.time(),
+            "timed_out": False,
+        }
 
     global _event_count
     with _event_count_lock:
@@ -620,12 +635,53 @@ def _send_reply(channel: str, thread_ts: str | None, text: str, task_id: str | N
                 pass
 
 
+def _check_task_timeouts() -> None:
+    """Post a one-time reply for tasks the core never answered in time.
+
+    Without this, a wedged core session (e.g. stuck looping on the
+    1M-context usage-credit API error) leaves the Slack task orphaned in
+    pending_replies forever — the user just sees silence. We mark the entry
+    `timed_out` (so we notify at most once) but DO NOT pop it: if the core
+    later recovers and writes results/<task_id>.txt, the normal reply path
+    still delivers the real answer.
+    """
+    if TASK_TIMEOUT_SEC <= 0:
+        return
+    now = time.time()
+    to_notify = []
+    with pending_replies_lock:
+        for task_id, info in pending_replies.items():
+            if info.get("timed_out"):
+                continue
+            if now - info.get("submitted_at", now) > TASK_TIMEOUT_SEC:
+                info["timed_out"] = True
+                to_notify.append((task_id, info["channel"], info.get("thread_ts")))
+    if not to_notify:
+        return
+    mins = TASK_TIMEOUT_SEC // 60
+    msg = (
+        f":hourglass_flowing_sand: Still working on this — it's been over "
+        f"{mins} min with no result. The core session may have hit a context "
+        f"or usage-credit limit (check the Sutando CLI / `/usage-credits`). "
+        f"I'll still post the answer here if it finishes."
+    )
+    for task_id, channel, thread_ts in to_notify:
+        try:
+            _send_reply(channel, thread_ts, msg, task_id=task_id)
+            print(f"  [timeout] notified Slack for {task_id} after {TASK_TIMEOUT_SEC}s", flush=True)
+        except Exception as e:
+            print(f"[Slack] timeout notify failed for {task_id}: {e}", flush=True)
+
+
 def result_watcher():
     """Background thread: polls results/ for replies + proactive messages."""
     heartbeat_file = REPO / "state" / "slack-bridge.heartbeat"
     last_heartbeat = 0.0
     while True:
         try:
+            # Surface tasks the core never answered (timeout → visible reply).
+            _check_task_timeouts()
+
             # Replies to pending tasks
             with pending_replies_lock:
                 pending_ids = list(pending_replies.keys())

--- a/tests/health-check-notify-slack.test.py
+++ b/tests/health-check-notify-slack.test.py
@@ -189,6 +189,54 @@ def case_h_history_pruned_after_24h() -> list[str]:
     return fails
 
 
+def case_i_token_read_prefers_channel_env() -> list[str]:
+    """Regression: the watchdog read SLACK_BOT_TOKEN from $REPO/.env only, but
+    the bridge keeps it in ~/.claude/channels/slack/.env (startup.sh sources
+    exactly that). On a standard install $REPO/.env has no token, so creds
+    resolved to None and the DM silently no-op'd — the watchdog looked
+    installed but never fired. Token resolution must check the channel .env
+    first, then fall back to $REPO/.env.
+
+    Redirects HOME (Path.home() honors $HOME on POSIX) and hc.REPO_DIR so the
+    real path-resolution code runs against temp files."""
+    import os
+    fails = []
+    saved_home = os.environ.get("HOME")
+    saved_repo = hc.REPO_DIR
+    saved_env_token = os.environ.pop("SLACK_BOT_TOKEN", None)  # force the file path
+    try:
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as repo:
+            os.environ["HOME"] = home
+            hc.REPO_DIR = Path(repo)
+            chan = Path(home) / ".claude" / "channels" / "slack"
+            chan.mkdir(parents=True, exist_ok=True)
+            (Path(repo) / ".env").write_text("SLACK_BOT_TOKEN=xoxb-from-repo\n")
+            (chan / ".env").write_text('SLACK_BOT_TOKEN="xoxb-from-channel"\n')
+
+            tok = hc._slack_token_from_env_file()
+            if tok != "xoxb-from-channel":
+                fails.append(f"i) channel .env should win, got {tok!r}")
+
+            # Remove the channel token → must fall back to $REPO/.env.
+            (chan / ".env").write_text("OTHER=1\n")
+            tok2 = hc._slack_token_from_env_file()
+            if tok2 != "xoxb-from-repo":
+                fails.append(f"i) fallback to $REPO/.env failed, got {tok2!r}")
+
+            # Neither present → empty string (no crash).
+            (Path(repo) / ".env").write_text("OTHER=2\n")
+            tok3 = hc._slack_token_from_env_file()
+            if tok3 != "":
+                fails.append(f"i) absent token should be '', got {tok3!r}")
+    finally:
+        if saved_home is not None:
+            os.environ["HOME"] = saved_home
+        if saved_env_token is not None:
+            os.environ["SLACK_BOT_TOKEN"] = saved_env_token
+        hc.REPO_DIR = saved_repo
+    return fails
+
+
 def main() -> int:
     cases = [
         ("a", case_a_all_ok_no_send),
@@ -199,6 +247,7 @@ def main() -> int:
         ("f", case_f_different_set_sends),
         ("g", case_g_failed_send_not_recorded),
         ("h", case_h_history_pruned_after_24h),
+        ("i", case_i_token_read_prefers_channel_env),
     ]
     all_failures = []
     for label, fn in cases:

--- a/tests/health-check-notify-slack.test.py
+++ b/tests/health-check-notify-slack.test.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Tests for the remote Slack-DM health watchdog (`notify_slack_for_failures`
+and `_slack_failures`) in src/health-check.py.
+
+Motivated by the 2026-06-02 incident: the core session wedged on the
+1M-context usage-credit API error and looped silently. The core heartbeat
+process kept ticking, so `_any_core_alive()` stayed True and the existing
+emit-task surface stayed quiet; Slack just went dark. This watchdog DMs the
+owner directly — a remote surface that does NOT depend on the core agent and
+is NOT gated on core liveness.
+
+Covers:
+  a) all-ok input            → no send, no state file
+  b) on-demand-only warns    → no send (benign steady state, would spam)
+  c) filter keeps stuck-loop warn + hard-down, drops on-demand warn
+  d) first call              → sends, records dedup state
+  e) same set < 1h           → cooldown suppresses duplicate send
+  f) different set           → new hash, new send
+  g) failed send             → dedup NOT recorded (retries next tick)
+  h) 24h pruning             → history file doesn't grow unboundedly
+
+Run: python3 tests/health-check-notify-slack.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import json
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+
+def make_checks(*statuses_names_details):
+    """[(status, name, detail), ...] → list of check dicts."""
+    return [{"name": n, "status": s, "detail": d} for (s, n, d) in statuses_names_details]
+
+
+def recording_sender():
+    sent: list[str] = []
+    return sent, (lambda text: (sent.append(text) or True))
+
+
+def failing_sender(text):
+    return False
+
+
+def case_a_all_ok_no_send() -> list[str]:
+    fails = []
+    sent, send = recording_sender()
+    with tempfile.TemporaryDirectory() as td:
+        state = Path(td) / "slack.json"
+        hc.notify_slack_for_failures(
+            make_checks(("ok", "svcA", "port 1"), ("ok", "svcB", "port 2")),
+            state_file=state, sender=send,
+        )
+        if sent:
+            fails.append("a) all-ok input triggered a Slack DM")
+        if state.exists():
+            fails.append("a) all-ok input wrote dedup state")
+    return fails
+
+
+def case_b_on_demand_only_no_send() -> list[str]:
+    fails = []
+    sent, send = recording_sender()
+    with tempfile.TemporaryDirectory() as td:
+        state = Path(td) / "slack.json"
+        hc.notify_slack_for_failures(
+            make_checks(
+                ("warn", "discord-voice", "not running (on-demand)"),
+                ("warn", "conversation-server", "not running (on-demand)"),
+            ),
+            state_file=state, sender=send,
+        )
+        if sent:
+            fails.append("b) on-demand-only warns triggered a Slack DM (spam risk)")
+    return fails
+
+
+def case_c_filter_keeps_actionable() -> list[str]:
+    fails = []
+    checks = make_checks(
+        ("warn", "core-proactive-loop", "running for 900s on 'triage' — last heartbeat > 600s ago"),
+        ("warn", "discord-voice", "not running (on-demand)"),
+        ("warn", "task-queue", "5 tasks queued, oldest 700s — watcher or core may be stuck"),
+        ("down", "voice-agent", "port 9900"),
+        ("ok", "web-client", "port 3100"),
+    )
+    got = sorted(c["name"] for c in hc._slack_failures(checks))
+    want = ["core-proactive-loop", "task-queue", "voice-agent"]
+    if got != want:
+        fails.append(f"c) filter returned {got}, want {want}")
+    return fails
+
+
+def case_d_first_send_records_state() -> list[str]:
+    fails = []
+    sent, send = recording_sender()
+    with tempfile.TemporaryDirectory() as td:
+        state = Path(td) / "slack.json"
+        hc.notify_slack_for_failures(
+            make_checks(("down", "voice-agent", "port 9900")),
+            state_file=state, sender=send,
+        )
+        if len(sent) != 1:
+            fails.append(f"d) first call should send once, sent {len(sent)}")
+        if not state.exists():
+            fails.append("d) first successful send did not record dedup state")
+    return fails
+
+
+def case_e_cooldown_suppresses() -> list[str]:
+    fails = []
+    sent, send = recording_sender()
+    with tempfile.TemporaryDirectory() as td:
+        state = Path(td) / "slack.json"
+        checks = make_checks(("down", "voice-agent", "port 9900"))
+        hc.notify_slack_for_failures(checks, state_file=state, sender=send)
+        hc.notify_slack_for_failures(checks, state_file=state, sender=send)
+        if len(sent) != 1:
+            fails.append(f"e) within-cooldown second call sent again (total {len(sent)})")
+    return fails
+
+
+def case_f_different_set_sends() -> list[str]:
+    fails = []
+    sent, send = recording_sender()
+    with tempfile.TemporaryDirectory() as td:
+        state = Path(td) / "slack.json"
+        hc.notify_slack_for_failures(
+            make_checks(("down", "voice-agent", "x")), state_file=state, sender=send)
+        hc.notify_slack_for_failures(
+            make_checks(("down", "discord-bridge", "x"), ("warn", "task-queue", "stuck")),
+            state_file=state, sender=send)
+        if len(sent) != 2:
+            fails.append(f"f) two distinct sets should send twice, sent {len(sent)}")
+    return fails
+
+
+def case_g_failed_send_not_recorded() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        state = Path(td) / "slack.json"
+        hc.notify_slack_for_failures(
+            make_checks(("down", "voice-agent", "x")),
+            state_file=state, sender=failing_sender,
+        )
+        if state.exists():
+            fails.append("g) failed send recorded dedup state — would suppress retry for 1h")
+        # And a subsequent successful send for the same set must go through.
+        sent, send = recording_sender()
+        hc.notify_slack_for_failures(
+            make_checks(("down", "voice-agent", "x")),
+            state_file=state, sender=send,
+        )
+        if len(sent) != 1:
+            fails.append("g) retry after a failed send did not go through")
+    return fails
+
+
+def case_h_history_pruned_after_24h() -> list[str]:
+    fails = []
+    sent, send = recording_sender()
+    with tempfile.TemporaryDirectory() as td:
+        state = Path(td) / "slack.json"
+        now_ms = int(time.time() * 1000)
+        state.write_text(json.dumps({
+            "stale_hash_aaaaaaaa": now_ms - (25 * 3600 * 1000),
+            "fresh_hash_bbbbbbbb": now_ms - (10 * 60 * 1000),
+        }))
+        hc.notify_slack_for_failures(
+            make_checks(("down", "new-failure", "x")),
+            state_file=state, sender=send,
+        )
+        history = json.loads(state.read_text())
+        if "stale_hash_aaaaaaaa" in history:
+            fails.append("h) 25h-old entry was not pruned")
+        if "fresh_hash_bbbbbbbb" not in history:
+            fails.append("h) 10min-old entry was wrongly pruned")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a", case_a_all_ok_no_send),
+        ("b", case_b_on_demand_only_no_send),
+        ("c", case_c_filter_keeps_actionable),
+        ("d", case_d_first_send_records_state),
+        ("e", case_e_cooldown_suppresses),
+        ("f", case_f_different_set_sends),
+        ("g", case_g_failed_send_not_recorded),
+        ("h", case_h_history_pruned_after_24h),
+    ]
+    all_failures = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            all_failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if all_failures:
+        print(f"\n{len(all_failures)} failure(s)")
+        return 1
+    print("\nAll Slack-watchdog invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/health-check-recover-core.test.py
+++ b/tests/health-check-recover-core.test.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+Tests for the core wedge auto-recovery (`recover_core_if_wedged`) in
+src/health-check.py.
+
+Motivated by the 2026-06-02 incident: the core crossed into 1M extended
+context, hit the interactive `/usage-credits` gate (which cannot be
+pre-authorized for an unattended agent), and looped silently — alive (heartbeat
+ticking) but draining nothing. --notify-slack makes that visible; this makes it
+self-healing by restarting the core via scripts/start-cli.sh --restart, with
+1M preserved on the first attempt and a graceful 200K fallback if it recurs.
+
+Because auto-restarting a 24/7 agent is consequential, the guards are the whole
+point. These cover:
+  a) healthy / no queued work        → no action, no restart, no DM
+  b) wedged but core just booted     → no action (catching up, not stuck)
+  c) wedged, first observation       → "observed", no restart (confirm window)
+  d) wedged, within confirm window   → "confirming", no restart
+  e) wedged + confirmed              → restart in 1M mode (keeps 1M), DM sent
+  f) within cooldown after a restart → no second restart
+  g) recurs after cooldown           → escalates to standard 200K context
+  h) give-up cap (3/hr)              → DMs "gave up", stops restarting
+  i) restart launch fails            → no cooldown/history burned, retries
+  j) core down (not alive)           → no action even with an old task
+
+Run: python3 tests/health-check-recover-core.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+# Pin thresholds so the test is independent of any SUTANDO_RECOVER_* env override
+# present in the runner's environment.
+hc.RECOVER_WEDGE_SEC = 600
+hc.RECOVER_CONFIRM_SEC = 120
+hc.RECOVER_COOLDOWN_SEC = 1800
+hc.RECOVER_MAX_PER_HOUR = 3
+
+
+class Harness:
+    """Drives recover_core_if_wedged with injected, recording collaborators."""
+
+    def __init__(self, state_file: Path):
+        self.state_file = state_file
+        self.sent: list[str] = []
+        self.restart_calls: list[bool] = []
+        self.restart_ok = True
+
+    def sender(self, text):
+        self.sent.append(text)
+        return True
+
+    def restart(self, standard_context):
+        self.restart_calls.append(standard_context)
+        return self.restart_ok
+
+    def run(self, now, alive=True, age=900, booted=False):
+        return hc.recover_core_if_wedged(
+            state_file=self.state_file,
+            now=now,
+            alive_fn=lambda: alive,
+            oldest_age_fn=lambda: age,
+            just_booted_fn=lambda: booted,
+            restart_fn=self.restart,
+            sender=self.sender,
+        )
+
+
+def case_a_healthy_no_action() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td) / "rec.json")
+        # alive but no queued work (age None)
+        r = h.run(now=1_000_000, alive=True, age=None)
+        if r is not None:
+            fails.append(f"a) healthy (no queue) acted: {r}")
+        if h.restart_calls or h.sent:
+            fails.append("a) healthy triggered restart/DM")
+    return fails
+
+
+def case_b_just_booted_never_restarts() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td) / "rec.json")
+        # Even with an old task, a just-booted core is catching up, not wedged.
+        h.run(now=1_000_000, age=5000, booted=True)
+        r = h.run(now=1_000_500, age=5000, booted=True)
+        if h.restart_calls:
+            fails.append(f"b) restarted a just-booted core: {r}")
+    return fails
+
+
+def case_c_first_observation_no_restart() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td) / "rec.json")
+        r = h.run(now=1_000_000, age=900)
+        if not r or r.get("action") != "observed":
+            fails.append(f"c) first wedge should be 'observed', got {r}")
+        if h.restart_calls:
+            fails.append("c) first observation restarted (no confirm window)")
+        if h.sent:
+            fails.append("c) first observation DM'd prematurely")
+    return fails
+
+
+def case_d_within_confirm_window_no_restart() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td) / "rec.json")
+        h.run(now=1_000_000, age=900)                 # observe
+        r = h.run(now=1_000_060, age=960)             # +60s < CONFIRM(120)
+        if not r or r.get("action") != "confirming":
+            fails.append(f"d) within confirm window should be 'confirming', got {r}")
+        if h.restart_calls:
+            fails.append("d) restarted within confirm window")
+    return fails
+
+
+def case_e_confirmed_restart_keeps_1m() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td) / "rec.json")
+        h.run(now=1_000_000, age=900)                 # observe
+        r = h.run(now=1_000_200, age=900)             # +200s > CONFIRM → restart
+        if not r or r.get("action") != "restarted":
+            fails.append(f"e) confirmed wedge should restart, got {r}")
+        if r and r.get("mode") != "1m":
+            fails.append(f"e) first restart must keep 1M, mode={r.get('mode')}")
+        if h.restart_calls != [False]:
+            fails.append(f"e) first restart should pass standard_context=False, got {h.restart_calls}")
+        if len(h.sent) != 1:
+            fails.append(f"e) restart should DM owner once, sent {len(h.sent)}")
+    return fails
+
+
+def case_f_cooldown_blocks_second_restart() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td) / "rec.json")
+        h.run(now=1_000_000, age=900)                 # observe
+        h.run(now=1_000_200, age=900)                 # restart #1
+        # Re-observe + re-confirm while still inside the 1800s cooldown.
+        h.run(now=1_000_300, age=1000)                # observe (post-restart reset)
+        r = h.run(now=1_000_500, age=1200)            # confirmed but within cooldown
+        if r and r.get("action") == "restarted":
+            fails.append("f) restarted again within cooldown window")
+        if h.restart_calls != [False]:
+            fails.append(f"f) cooldown should leave a single restart, got {h.restart_calls}")
+    return fails
+
+
+def case_g_recurrence_escalates_to_standard() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td) / "rec.json")
+        h.run(now=1_000_000, age=900)                 # observe
+        h.run(now=1_000_200, age=900)                 # restart #1 (1m)
+        # After cooldown, the wedge persists → escalate to standard 200K.
+        t2 = 1_000_200 + hc.RECOVER_COOLDOWN_SEC + 50
+        h.run(now=t2, age=1500)                        # re-observe
+        r = h.run(now=t2 + 200, age=1500)             # restart #2
+        if not r or r.get("action") != "restarted":
+            fails.append(f"g) recurrence should restart again, got {r}")
+        if r and r.get("mode") != "standard":
+            fails.append(f"g) 2nd restart must degrade to standard, mode={r.get('mode')}")
+        if h.restart_calls != [False, True]:
+            fails.append(f"g) escalation should be [1m=False, standard=True], got {h.restart_calls}")
+    return fails
+
+
+def case_h_give_up_cap() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        sf = Path(td) / "rec.json"
+        h = Harness(sf)
+        now = 2_000_000
+        # Pre-seed 3 restarts within the trailing hour, cooldown already passed,
+        # and a confirmed wedge observation — the next action must be give-up.
+        sf.write_text(json.dumps({
+            "wedge_first_seen": now - 500,
+            "last_restart": now - hc.RECOVER_COOLDOWN_SEC - 10,
+            "restart_history": [now - 3000, now - 2000, now - hc.RECOVER_COOLDOWN_SEC - 10],
+            "last_restart_mode": "standard",
+        }))
+        r = h.run(now=now, age=1800)
+        if not r or r.get("action") != "gave_up":
+            fails.append(f"h) 4th restart in an hour should give up, got {r}")
+        if h.restart_calls:
+            fails.append("h) gave-up state still restarted")
+        if len(h.sent) != 1 or "gave up" not in h.sent[0].lower():
+            fails.append(f"h) give-up should DM once with a 'gave up' message, sent {h.sent}")
+        # Dedup: a second pass in the same give-up episode must not re-DM.
+        r2 = h.run(now=now + 60, age=1900)
+        if len(h.sent) != 1:
+            fails.append(f"h) give-up DM not deduped, sent {len(h.sent)}")
+    return fails
+
+
+def case_i_failed_restart_does_not_burn_state() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        sf = Path(td) / "rec.json"
+        h = Harness(sf)
+        h.restart_ok = False
+        h.run(now=1_000_000, age=900)                 # observe
+        r = h.run(now=1_000_200, age=900)             # confirmed → restart attempt FAILS
+        if not r or r.get("action") != "restart_failed":
+            fails.append(f"i) failed restart should report 'restart_failed', got {r}")
+        st = json.loads(sf.read_text())
+        if st.get("last_restart"):
+            fails.append("i) failed restart recorded a cooldown timestamp")
+        if st.get("restart_history"):
+            fails.append("i) failed restart recorded history (would count toward give-up)")
+        if not st.get("wedge_first_seen"):
+            fails.append("i) failed restart cleared the confirmation, would re-delay retry")
+        # Next pass with a working restart must now succeed.
+        h.restart_ok = True
+        r2 = h.run(now=1_000_400, age=950)
+        if not r2 or r2.get("action") != "restarted":
+            fails.append(f"i) retry after failed restart did not restart, got {r2}")
+    return fails
+
+
+def case_j_core_down_no_action() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td) / "rec.json")
+        # Heartbeat dead → not our case (process-death restart is Sutando.app's
+        # job); recovery handles only alive-but-wedged.
+        r = h.run(now=1_000_000, alive=False, age=5000)
+        if r is not None or h.restart_calls:
+            fails.append(f"j) acted on a dead core: {r}, restarts={h.restart_calls}")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a", case_a_healthy_no_action),
+        ("b", case_b_just_booted_never_restarts),
+        ("c", case_c_first_observation_no_restart),
+        ("d", case_d_within_confirm_window_no_restart),
+        ("e", case_e_confirmed_restart_keeps_1m),
+        ("f", case_f_cooldown_blocks_second_restart),
+        ("g", case_g_recurrence_escalates_to_standard),
+        ("h", case_h_give_up_cap),
+        ("i", case_i_failed_restart_does_not_burn_state),
+        ("j", case_j_core_down_no_action),
+    ]
+    all_failures = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            all_failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if all_failures:
+        print(f"\n{len(all_failures)} failure(s)")
+        return 1
+    print("\nAll core-recovery invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/health-check-recover-core.test.py
+++ b/tests/health-check-recover-core.test.py
@@ -22,6 +22,14 @@ point. These cover:
   h) give-up cap (3/hr)              → DMs "gave up", stops restarting
   i) restart launch fails            → no cooldown/history burned, retries
   j) core down (not alive)           → no action even with an old task
+  k) draining backlog (oldest task   → never restarts (queue is healthy, just
+     differs each pass)                 busy) — review blocker 3
+  l) core makes progress             → resets, never restarts a long live task;
+     (core-status.json advances)        a FROZEN status with same task does fire
+  m) concurrent invocation (lock     → second caller no-ops with "locked"
+     held)                              — review suggestion
+  n) restart DM fails                → still restarts, records dm_sent=False
+                                        — review blocker 2
 
 Run: python3 tests/health-check-recover-core.test.py
 Exit code: 0 on pass, 1 on fail.
@@ -56,21 +64,24 @@ class Harness:
         self.sent: list[str] = []
         self.restart_calls: list[bool] = []
         self.restart_ok = True
+        self.send_ok = True
 
     def sender(self, text):
         self.sent.append(text)
-        return True
+        return self.send_ok
 
     def restart(self, standard_context):
         self.restart_calls.append(standard_context)
         return self.restart_ok
 
-    def run(self, now, alive=True, age=900, booted=False):
+    def run(self, now, alive=True, age=900, key="t1", status_ts=None, booted=False):
+        oldest = (key, age) if age is not None else None
         return hc.recover_core_if_wedged(
             state_file=self.state_file,
             now=now,
             alive_fn=lambda: alive,
-            oldest_age_fn=lambda: age,
+            oldest_task_fn=lambda: oldest,
+            status_ts_fn=lambda: status_ts,
             just_booted_fn=lambda: booted,
             restart_fn=self.restart,
             sender=self.sender,
@@ -81,8 +92,7 @@ def case_a_healthy_no_action() -> list[str]:
     fails = []
     with tempfile.TemporaryDirectory() as td:
         h = Harness(Path(td) / "rec.json")
-        # alive but no queued work (age None)
-        r = h.run(now=1_000_000, alive=True, age=None)
+        r = h.run(now=1_000_000, alive=True, age=None)  # alive, empty queue
         if r is not None:
             fails.append(f"a) healthy (no queue) acted: {r}")
         if h.restart_calls or h.sent:
@@ -94,11 +104,10 @@ def case_b_just_booted_never_restarts() -> list[str]:
     fails = []
     with tempfile.TemporaryDirectory() as td:
         h = Harness(Path(td) / "rec.json")
-        # Even with an old task, a just-booted core is catching up, not wedged.
         h.run(now=1_000_000, age=5000, booted=True)
-        r = h.run(now=1_000_500, age=5000, booted=True)
+        h.run(now=1_000_500, age=5000, booted=True)
         if h.restart_calls:
-            fails.append(f"b) restarted a just-booted core: {r}")
+            fails.append("b) restarted a just-booted core")
     return fails
 
 
@@ -109,10 +118,8 @@ def case_c_first_observation_no_restart() -> list[str]:
         r = h.run(now=1_000_000, age=900)
         if not r or r.get("action") != "observed":
             fails.append(f"c) first wedge should be 'observed', got {r}")
-        if h.restart_calls:
-            fails.append("c) first observation restarted (no confirm window)")
-        if h.sent:
-            fails.append("c) first observation DM'd prematurely")
+        if h.restart_calls or h.sent:
+            fails.append("c) first observation restarted/DM'd prematurely")
     return fails
 
 
@@ -120,8 +127,8 @@ def case_d_within_confirm_window_no_restart() -> list[str]:
     fails = []
     with tempfile.TemporaryDirectory() as td:
         h = Harness(Path(td) / "rec.json")
-        h.run(now=1_000_000, age=900)                 # observe
-        r = h.run(now=1_000_060, age=960)             # +60s < CONFIRM(120)
+        h.run(now=1_000_000, age=900)
+        r = h.run(now=1_000_060, age=960)            # +60s < CONFIRM(120)
         if not r or r.get("action") != "confirming":
             fails.append(f"d) within confirm window should be 'confirming', got {r}")
         if h.restart_calls:
@@ -133,8 +140,8 @@ def case_e_confirmed_restart_keeps_1m() -> list[str]:
     fails = []
     with tempfile.TemporaryDirectory() as td:
         h = Harness(Path(td) / "rec.json")
-        h.run(now=1_000_000, age=900)                 # observe
-        r = h.run(now=1_000_200, age=900)             # +200s > CONFIRM → restart
+        h.run(now=1_000_000, age=900)
+        r = h.run(now=1_000_200, age=900)            # +200s > CONFIRM → restart
         if not r or r.get("action") != "restarted":
             fails.append(f"e) confirmed wedge should restart, got {r}")
         if r and r.get("mode") != "1m":
@@ -143,6 +150,8 @@ def case_e_confirmed_restart_keeps_1m() -> list[str]:
             fails.append(f"e) first restart should pass standard_context=False, got {h.restart_calls}")
         if len(h.sent) != 1:
             fails.append(f"e) restart should DM owner once, sent {len(h.sent)}")
+        if r and r.get("dm_sent") is not True:
+            fails.append(f"e) successful DM should record dm_sent=True, got {r.get('dm_sent')}")
     return fails
 
 
@@ -150,11 +159,10 @@ def case_f_cooldown_blocks_second_restart() -> list[str]:
     fails = []
     with tempfile.TemporaryDirectory() as td:
         h = Harness(Path(td) / "rec.json")
-        h.run(now=1_000_000, age=900)                 # observe
-        h.run(now=1_000_200, age=900)                 # restart #1
-        # Re-observe + re-confirm while still inside the 1800s cooldown.
-        h.run(now=1_000_300, age=1000)                # observe (post-restart reset)
-        r = h.run(now=1_000_500, age=1200)            # confirmed but within cooldown
+        h.run(now=1_000_000, age=900)
+        h.run(now=1_000_200, age=900)                # restart #1
+        h.run(now=1_000_300, age=1000)               # observe (post-restart reset)
+        r = h.run(now=1_000_500, age=1200)           # confirmed but within cooldown
         if r and r.get("action") == "restarted":
             fails.append("f) restarted again within cooldown window")
         if h.restart_calls != [False]:
@@ -166,12 +174,11 @@ def case_g_recurrence_escalates_to_standard() -> list[str]:
     fails = []
     with tempfile.TemporaryDirectory() as td:
         h = Harness(Path(td) / "rec.json")
-        h.run(now=1_000_000, age=900)                 # observe
-        h.run(now=1_000_200, age=900)                 # restart #1 (1m)
-        # After cooldown, the wedge persists → escalate to standard 200K.
+        h.run(now=1_000_000, age=900)
+        h.run(now=1_000_200, age=900)                # restart #1 (1m)
         t2 = 1_000_200 + hc.RECOVER_COOLDOWN_SEC + 50
-        h.run(now=t2, age=1500)                        # re-observe
-        r = h.run(now=t2 + 200, age=1500)             # restart #2
+        h.run(now=t2, age=1500)                       # re-observe
+        r = h.run(now=t2 + 200, age=1500)            # restart #2
         if not r or r.get("action") != "restarted":
             fails.append(f"g) recurrence should restart again, got {r}")
         if r and r.get("mode") != "standard":
@@ -185,12 +192,16 @@ def case_h_give_up_cap() -> list[str]:
     fails = []
     with tempfile.TemporaryDirectory() as td:
         sf = Path(td) / "rec.json"
+        sf.parent.mkdir(parents=True, exist_ok=True)
         h = Harness(sf)
         now = 2_000_000
         # Pre-seed 3 restarts within the trailing hour, cooldown already passed,
-        # and a confirmed wedge observation — the next action must be give-up.
+        # and a confirmed wedge observation on the SAME task the harness reports
+        # ("t1") — the next action must be give-up.
         sf.write_text(json.dumps({
             "wedge_first_seen": now - 500,
+            "wedge_task": "t1",
+            "wedge_status_ts": None,
             "last_restart": now - hc.RECOVER_COOLDOWN_SEC - 10,
             "restart_history": [now - 3000, now - 2000, now - hc.RECOVER_COOLDOWN_SEC - 10],
             "last_restart_mode": "standard",
@@ -203,7 +214,7 @@ def case_h_give_up_cap() -> list[str]:
         if len(h.sent) != 1 or "gave up" not in h.sent[0].lower():
             fails.append(f"h) give-up should DM once with a 'gave up' message, sent {h.sent}")
         # Dedup: a second pass in the same give-up episode must not re-DM.
-        r2 = h.run(now=now + 60, age=1900)
+        h.run(now=now + 60, age=1900)
         if len(h.sent) != 1:
             fails.append(f"h) give-up DM not deduped, sent {len(h.sent)}")
     return fails
@@ -215,8 +226,8 @@ def case_i_failed_restart_does_not_burn_state() -> list[str]:
         sf = Path(td) / "rec.json"
         h = Harness(sf)
         h.restart_ok = False
-        h.run(now=1_000_000, age=900)                 # observe
-        r = h.run(now=1_000_200, age=900)             # confirmed → restart attempt FAILS
+        h.run(now=1_000_000, age=900)
+        r = h.run(now=1_000_200, age=900)            # confirmed → restart attempt FAILS
         if not r or r.get("action") != "restart_failed":
             fails.append(f"i) failed restart should report 'restart_failed', got {r}")
         st = json.loads(sf.read_text())
@@ -226,7 +237,6 @@ def case_i_failed_restart_does_not_burn_state() -> list[str]:
             fails.append("i) failed restart recorded history (would count toward give-up)")
         if not st.get("wedge_first_seen"):
             fails.append("i) failed restart cleared the confirmation, would re-delay retry")
-        # Next pass with a working restart must now succeed.
         h.restart_ok = True
         r2 = h.run(now=1_000_400, age=950)
         if not r2 or r2.get("action") != "restarted":
@@ -238,11 +248,101 @@ def case_j_core_down_no_action() -> list[str]:
     fails = []
     with tempfile.TemporaryDirectory() as td:
         h = Harness(Path(td) / "rec.json")
-        # Heartbeat dead → not our case (process-death restart is Sutando.app's
-        # job); recovery handles only alive-but-wedged.
         r = h.run(now=1_000_000, alive=False, age=5000)
         if r is not None or h.restart_calls:
             fails.append(f"j) acted on a dead core: {r}, restarts={h.restart_calls}")
+    return fails
+
+
+def case_k_draining_backlog_never_restarts() -> list[str]:
+    """A busy-but-healthy core surfaces a DIFFERENT oldest task each pass as it
+    drains the queue. The identity check must reset the window every time, so
+    the confirm window never completes and no restart fires (review blocker 3)."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td) / "rec.json")
+        actions = [
+            h.run(now=1_000_000, age=900, key="taskA"),
+            h.run(now=1_000_200, age=900, key="taskB"),
+            h.run(now=1_000_400, age=900, key="taskC"),
+            h.run(now=1_000_600, age=900, key="taskD"),
+        ]
+        if h.restart_calls:
+            fails.append(f"k) restarted a draining (healthy) backlog: {h.restart_calls}")
+        if any(a is None or a.get("action") != "observed" for a in actions):
+            fails.append(f"k) draining backlog should stay 'observed', got {[a and a.get('action') for a in actions]}")
+    return fails
+
+
+def case_l_progress_resets_long_task() -> list[str]:
+    """Same oldest task across passes, but core-status.json advances → the core
+    is making progress on a long task, not wedged → reset, no restart. A FROZEN
+    status (same task, status unchanged) DOES restart — proving it's the
+    progress signal, not mere status presence, that protects the task."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td) / "rec.json")
+        h.run(now=1_000_000, age=900, key="t1", status_ts=1000)
+        r = h.run(now=1_000_200, age=960, key="t1", status_ts=1100)  # advanced
+        if not r or r.get("action") != "observed":
+            fails.append(f"l) advancing status should reset to 'observed', got {r}")
+        if h.restart_calls:
+            fails.append("l) restarted a core that is making progress")
+    with tempfile.TemporaryDirectory() as td:
+        h = Harness(Path(td) / "rec.json")
+        h.run(now=2_000_000, age=900, key="t1", status_ts=1000)
+        r = h.run(now=2_000_200, age=960, key="t1", status_ts=1000)  # frozen → wedged
+        if not r or r.get("action") != "restarted":
+            fails.append(f"l) frozen status with same stuck task should restart, got {r}")
+    return fails
+
+
+def case_m_lock_prevents_concurrent_restart() -> list[str]:
+    """A second concurrent invocation, while another holds the recovery lock,
+    must no-op with 'locked' (review suggestion — no double-restart)."""
+    if hc.fcntl is None:
+        return []  # no POSIX locking on this platform; lock degrades to no-op
+    import fcntl
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        sf = Path(td) / "rec.json"
+        sf.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = sf.with_name(sf.name + ".lock")
+        holder = open(lock_path, "w")
+        fcntl.flock(holder, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            h = Harness(sf)
+            r = h.run(now=1_000_000, age=900)
+            if r != {"action": "locked"}:
+                fails.append(f"m) concurrent call should be 'locked', got {r}")
+            if h.restart_calls:
+                fails.append("m) concurrent call restarted despite held lock")
+        finally:
+            fcntl.flock(holder, fcntl.LOCK_UN)
+            holder.close()
+    return fails
+
+
+def case_n_failed_dm_still_restarts_and_records() -> list[str]:
+    """If the wedge-restart DM fails, recovery still restarts (recovery >
+    notification) but records dm_sent=False so the restart isn't invisible
+    (review blocker 2)."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        sf = Path(td) / "rec.json"
+        h = Harness(sf)
+        h.send_ok = False
+        h.run(now=1_000_000, age=900)
+        r = h.run(now=1_000_200, age=900)
+        if not r or r.get("action") != "restarted":
+            fails.append(f"n) should still restart when DM fails, got {r}")
+        if r and r.get("dm_sent") is not False:
+            fails.append(f"n) failed DM should record dm_sent=False, got {r.get('dm_sent')}")
+        if h.restart_calls != [False]:
+            fails.append(f"n) should have restarted once, got {h.restart_calls}")
+        st = json.loads(sf.read_text())
+        if st.get("last_restart_dm_sent") is not False:
+            fails.append(f"n) state should record last_restart_dm_sent=False, got {st.get('last_restart_dm_sent')}")
     return fails
 
 
@@ -258,6 +358,10 @@ def main() -> int:
         ("h", case_h_give_up_cap),
         ("i", case_i_failed_restart_does_not_burn_state),
         ("j", case_j_core_down_no_action),
+        ("k", case_k_draining_backlog_never_restarts),
+        ("l", case_l_progress_resets_long_task),
+        ("m", case_m_lock_prevents_concurrent_restart),
+        ("n", case_n_failed_dm_still_restarts_and_records),
     ]
     all_failures = []
     for label, fn in cases:

--- a/tests/slack-bridge-task-timeout.test.py
+++ b/tests/slack-bridge-task-timeout.test.py
@@ -114,6 +114,34 @@ class TestCheckTaskTimeouts(unittest.TestCase):
         self.mod._check_task_timeouts()
         self.assertEqual(self.calls, [])
 
+    def test_send_failure_retries(self):
+        """Regression (PR #1428 review, blocker 1): a failed _send_reply must
+        NOT mark the task timed_out, or one Slack hiccup silences the warning
+        forever — recreating the silent no-op this watchdog exists to fix."""
+        self._seed("task-old", 700)
+
+        def boom(channel, thread_ts, text, task_id=None):
+            raise RuntimeError("slack 500")
+
+        self.mod._send_reply = boom
+        self.mod._check_task_timeouts()
+        with self.mod.pending_replies_lock:
+            self.assertFalse(
+                self.mod.pending_replies["task-old"]["timed_out"],
+                "a failed send must leave timed_out unset so the next pass retries",
+            )
+
+        # Next pass with a working sender must retry and then mark it sent.
+        self.mod._send_reply = (
+            lambda channel, thread_ts, text, task_id=None: self.calls.append(
+                {"task_id": task_id, "channel": channel, "text": text}
+            )
+        )
+        self.mod._check_task_timeouts()
+        self.assertEqual([c["task_id"] for c in self.calls], ["task-old"])
+        with self.mod.pending_replies_lock:
+            self.assertTrue(self.mod.pending_replies["task-old"]["timed_out"])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/slack-bridge-task-timeout.test.py
+++ b/tests/slack-bridge-task-timeout.test.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Tests for _check_task_timeouts() in src/slack-bridge.py.
+
+Guards the silent-fail fix: when the core session wedges (e.g. loops on the
+1M-context usage-credit API error), no results/<task>.txt is ever written and
+the Slack user just sees silence. The result_watcher now posts a one-time
+"still working / may have hit a limit" reply after SLACK_TASK_TIMEOUT_SEC, and
+KEEPS the pending entry so a late real result is still delivered.
+
+Run: python3 tests/slack-bridge-task-timeout.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+import importlib.util
+import os
+import sys
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load_bridge(workspace: Path):
+    """Load slack-bridge.py with stubbed slack_bolt and a temp workspace."""
+    os.environ["SLACK_BOT_TOKEN"] = "xoxb-test-token"
+    os.environ["SLACK_APP_TOKEN"] = "xapp-test-token"
+    os.environ["SUTANDO_WORKSPACE"] = str(workspace)
+    os.environ["SLACK_TASK_TIMEOUT_SEC"] = "600"
+
+    sys.modules.pop("slack_bridge_timeout_under_test", None)
+
+    class _StubApp:
+        def __init__(self, *a, **kw):
+            self.client = types.SimpleNamespace()
+        def event(self, _name):
+            return lambda fn: fn
+
+    try:
+        import slack_bolt as _bolt
+        _bolt.App = _StubApp
+    except ImportError:
+        stub = types.ModuleType("slack_bolt")
+        stub.App = _StubApp
+        sys.modules["slack_bolt"] = stub
+
+    for pkg in ("slack_bolt.adapter", "slack_bolt.adapter.socket_mode"):
+        if pkg not in sys.modules:
+            m = types.ModuleType(pkg)
+            if pkg.endswith("socket_mode"):
+                m.SocketModeHandler = object
+            sys.modules[pkg] = m
+
+    sys.path.insert(0, str(REPO / "src"))
+    spec = importlib.util.spec_from_file_location(
+        "slack_bridge_timeout_under_test", REPO / "src" / "slack-bridge.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestCheckTaskTimeouts(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="slack-timeout-test-"))
+        self.mod = _load_bridge(self.tmp)
+        self.calls = []
+        # Capture replies instead of hitting Slack.
+        self.mod._send_reply = (
+            lambda channel, thread_ts, text, task_id=None: self.calls.append(
+                {"task_id": task_id, "channel": channel, "text": text}
+            )
+        )
+        with self.mod.pending_replies_lock:
+            self.mod.pending_replies.clear()
+
+    def _seed(self, task_id, age_sec, **extra):
+        info = {
+            "channel": "D1",
+            "thread_ts": None,
+            "submitted_at": time.time() - age_sec,
+            "timed_out": False,
+        }
+        info.update(extra)
+        with self.mod.pending_replies_lock:
+            self.mod.pending_replies[task_id] = info
+
+    def test_stale_task_notified_fresh_left_alone(self):
+        self._seed("task-old", 700)        # past 600s timeout
+        self._seed("task-fresh", 10)       # well within
+        self.mod._check_task_timeouts()
+        notified = [c["task_id"] for c in self.calls]
+        self.assertEqual(notified, ["task-old"])
+        self.assertIn("usage-credit", self.calls[0]["text"])
+
+    def test_notify_once_only(self):
+        self._seed("task-old", 700)
+        self.mod._check_task_timeouts()
+        self.mod._check_task_timeouts()
+        self.assertEqual(len(self.calls), 1, "should not re-notify a timed-out task")
+
+    def test_entry_retained_for_late_result(self):
+        self._seed("task-old", 700)
+        self.mod._check_task_timeouts()
+        with self.mod.pending_replies_lock:
+            self.assertIn("task-old", self.mod.pending_replies)
+            self.assertTrue(self.mod.pending_replies["task-old"]["timed_out"])
+
+    def test_zero_disables(self):
+        self.mod.TASK_TIMEOUT_SEC = 0
+        self._seed("task-old", 9999)
+        self.mod._check_task_timeouts()
+        self.assertEqual(self.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/start-cli-model-pin.test.py
+++ b/tests/start-cli-model-pin.test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Tests that scripts/start-cli.sh honors $SUTANDO_CORE_MODEL (PR #1428).
+
+The recovery escalation in src/health-check.py restarts a re-wedging core with
+SUTANDO_CORE_MODEL=opus so it falls back to standard 200K context. This verifies
+the launch script actually threads that through:
+  - unset  → NO --model flag (core inherits the global model; 1M stays default)
+  - set    → `--model <value>` injected before the other claude flags
+
+Drives the no-tmux fallback branch (the bare `exec claude …`) with a stub
+`claude` that records its argv, and a stub `pgrep` that always reports "not
+running" so the test is independent of any live sutando-core on the host.
+
+Run: python3 tests/start-cli-model-pin.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "start-cli.sh"
+
+
+def _launch_argv(model_env: "str | None") -> list[str]:
+    """Run start-cli.sh through its no-tmux fallback and return claude's argv."""
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        bind = td / "bin"
+        bind.mkdir()
+        args_file = td / "argv.txt"
+
+        # Stub claude: record argv (one per line), exit 0.
+        claude = bind / "claude"
+        claude.write_text('#!/bin/bash\nprintf "%s\\n" "$@" > "$ARGS_FILE"\n')
+        claude.chmod(0o755)
+        # Stub pgrep: always "no match" so the already-running guard passes.
+        pgrep = bind / "pgrep"
+        pgrep.write_text("#!/bin/bash\nexit 1\n")
+        pgrep.chmod(0o755)
+
+        env = {
+            "PATH": f"{bind}:/usr/bin:/bin",   # no tmux, no brew → fallback path
+            "HOME": str(td),
+            "ARGS_FILE": str(args_file),
+        }
+        if model_env is not None:
+            env["SUTANDO_CORE_MODEL"] = model_env
+
+        subprocess.run(
+            ["/bin/bash", str(SCRIPT)],
+            env=env, capture_output=True, text=True, timeout=30,
+        )
+        if not args_file.exists():
+            return []
+        return [ln for ln in args_file.read_text().splitlines() if ln != ""]
+
+
+def case_default_no_model_flag() -> list[str]:
+    fails = []
+    argv = _launch_argv(None)
+    if not argv:
+        return ["default) claude was never exec'd (fallback path didn't run)"]
+    if "--model" in argv:
+        fails.append(f"default) unexpected --model in argv (1M should stay default): {argv}")
+    if "--name" not in argv or "sutando-core" not in argv:
+        fails.append(f"default) sanity: expected --name sutando-core, got {argv}")
+    return fails
+
+
+def case_env_set_injects_model() -> list[str]:
+    fails = []
+    argv = _launch_argv("opus")
+    if not argv:
+        return ["set) claude was never exec'd (fallback path didn't run)"]
+    if "--model" not in argv:
+        fails.append(f"set) --model not injected when SUTANDO_CORE_MODEL=opus: {argv}")
+    else:
+        i = argv.index("--model")
+        if i + 1 >= len(argv) or argv[i + 1] != "opus":
+            fails.append(f"set) --model not followed by 'opus': {argv}")
+        # Must precede --remote-control (matches the launch line ordering).
+        if "--remote-control" in argv and argv.index("--remote-control") < i:
+            fails.append(f"set) --model should come before --remote-control: {argv}")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("default", case_default_no_model_flag),
+        ("env-set", case_env_set_injects_model),
+    ]
+    all_failures = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            all_failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if all_failures:
+        print(f"\n{len(all_failures)} failure(s)")
+        return 1
+    print("\nstart-cli.sh model-pin threading is correct.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

A user reported **silent failures on Slack**: mid-task, Sutando simply stopped responding. The CLI screenshot showed the core session looping on `API Error: Usage credits required for 1M context` — every turn failing, nothing draining.

Two failures stacked (2026-06-02):
1. **The wedge** — the long-running core crossed 200K into **1M extended context**, hit the interactive `/usage-credits` gate, and looped on the API error. `core_heartbeat.py` runs as its own process, so the core *looked* alive while draining nothing.
2. **The silence** — the Slack bridge waited forever for a result file that the wedged core never wrote. No feedback to the user.

Confirmed against Claude Code v2.1.161: the 1M `/usage-credits` enable **cannot be pre-authorized** for an unattended agent (no settings key / env var / CLI flag; it's a per-session, account-side toggle). So an unattended core in 1M is structurally prone to this wedge.

## Fix — keep 1M the default; make the core self-healing

Builds on the prior watchdog commit (Slack per-task timeout + remote DM, which made the outage *visible*). This makes it impossible to stay silent and lets the core *recover on its own* — **without disabling 1M** (most users, esp. subscriptions, have it; on Max/Team it's gateless).

1. **Fix the watchdog's silent no-op.** `_slack_token_from_env_file` read only `$REPO/.env`, but the bridge keeps `SLACK_BOT_TOKEN` in `~/.claude/channels/slack/.env` (startup.sh sources exactly that). On a stock install creds resolved to `None` and the DM **never fired** — the watchdog looked installed but was mute. Now reads the channel `.env` first, then `$REPO/.env`.

2. **`--recover-core` (new).** When the core is *alive-but-wedged* (oldest queued task older than `RECOVER_WEDGE_SEC` while the heartbeat ticks — the precise loop signature, and it catches the idle-wedge `check_core_proactive_loop` misses since that only flags `status="running"`), auto-restart via `scripts/start-cli.sh --restart`. A restarted session re-clears the gate itself (the enable persists account-wide once set) and **queued task files survive the restart**, so 1M stays default and no work is lost. Heavily guarded: sustained-wedge confirm window, 30-min cooldown, 3/hr give-up cap (then DMs "gave up"), never-from-inside-the-core, and a DM before each restart. Clean no-op when healthy.

3. **Graceful degradation (opt-in).** `start-cli.sh` honors `$SUTANDO_CORE_MODEL`. First restart keeps 1M; if the wedge *recurs*, the next restart pins `--model opus` (standard 200K, no gate) so the agent keeps **working** instead of re-looping. Default unchanged — 1M is never disabled for everyone.

Wired `--recover-core` into the launchd fallback job (its own process, every 5 min) so the core self-reports **and** self-heals off-machine.

## Tests

- `tests/health-check-recover-core.test.py` — 10 cases: confirm window, cooldown, escalation to standard, give-up cap + DM dedup, failed-restart retry (no burned cooldown), just-booted + dead-core guards.
- `tests/health-check-notify-slack.test.py` — `+case i`: token read prefers channel `.env`, falls back to `$REPO/.env`, empty when absent.
- Full `tests/health-check*.test.py` suite passes; `start-cli.sh` model threading verified (empty default keeps 1M, `--model opus` when set).

## Deploy note

Run `bash src/install-health-check-launchd.sh` to (re)load the fallback job (no-ops safely without a Slack token/owner). The one-time human prevention remains: enable `/usage-credits` once (persists account-wide); this is the safety net for when it slips anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)