### PR TITLE
feat(claude-config): import-UX policy — --migrate→--import rename + copy+warn + weight-reduction excludes

### DIFF
--- a/scripts/sutando-shell-setup.sh
+++ b/scripts/sutando-shell-setup.sh
@@ -633,12 +633,15 @@ EOF
       --exclude='debug/'
       --exclude='plugins/*/cache/'
       --exclude='statsig/'
-      # Secret-safety (Mini PR #1415 review #4): channel bot tokens are
-      # host-specific and shouldn't propagate via this copy. They'd also land
-      # in the M2 vault-sync include set without an explicit opt-out, leaking
-      # tokens to remote vault. Same logic for stale auth backups.
-      --exclude='channels/*/*.env'
-      --exclude='channels/*/access.json.bak*'
+      # NOTE: channels/*/*.env (bot tokens) + channels/*/access.json.bak*
+      # are intentionally COPIED in this version. Owner directive 2026-06-03
+      # (PR #1424 import-UX thread): option (B) "copy + warn" — bridges work
+      # immediately post-import, user gets an explicit vault-sync warning
+      # at end-of-import flagging the secret files that were copied. The
+      # earlier exclude (Mini PR #1415 review #4) was the secret-safety
+      # baseline; this is the user-experience layer on top, accepting the
+      # vault-sync coordination burden in exchange for zero-friction
+      # bridges. See the post-rsync warning block below.
       # Runtime artifacts that won't survive a rehome anyway.
       --exclude='*.sock'
       --exclude='*.pid'
@@ -702,19 +705,28 @@ EOF
     echo "sutando-shell-setup $INVOKED_AS: done."
     echo "  ${SOURCE_DIR} is unchanged. To prune later, verify the new tree works first, then:"
     echo "    rm -rf '${SOURCE_DIR}/projects/${THIS_PROJECT_SLUG}/'  # only this project's slug"
-    # Mini PR #1415 review #4: channels/*/*.env were intentionally NOT copied
-    # (host-specific tokens). Tell the user how to manually rehome them if they
-    # want the bridges working from the new location.
-    if compgen -G "${SOURCE_DIR}/channels/*/*.env" > /dev/null 2>&1; then
+    # Vault-sync warning (option (B) from the import-UX thread 2026-06-03):
+    # bot tokens + auth backups were copied this time (no exclude). The
+    # bridges will work immediately, but the M2 vault sync engine — when
+    # it lands — will include these files in the synced bundle unless the
+    # user adds an exclude. Surface the exact paths so the user can add
+    # them to their vault sync exclude policy.
+    if compgen -G "${CLAUDE_DIR}/channels/*/*.env" > /dev/null 2>&1; then
       echo
-      echo "  ⚠ Channel bot tokens (channels/*/*.env) NOT copied — they're host-specific."
-      echo "    If you want bridges to work from the new CLAUDE_CONFIG_DIR, manually rehome:"
-      echo "      for env in '${SOURCE_DIR}/channels/'*/.env; do"
-      echo "        ch=\"\$(basename \"\$(dirname \"\$env\")\")\""
-      echo "        mkdir -p '${CLAUDE_DIR}/channels/'\"\$ch\""
-      echo "        cp \"\$env\" '${CLAUDE_DIR}/channels/'\"\$ch\"/.env"
-      echo "      done"
-      echo "    Each .env is mode 600. Manual cp preserves mode."
+      echo "  ⚠ Imported host-specific secrets — review before vault sync:"
+      for env in "${CLAUDE_DIR}/channels/"*/*.env; do
+        [ -f "$env" ] && echo "      ${env#${CLAUDE_DIR}/}  (mode $(stat -f '%Mp%Lp' "$env" 2>/dev/null || stat -c '%a' "$env" 2>/dev/null))"
+      done
+      if compgen -G "${CLAUDE_DIR}/channels/*/access.json.bak*" > /dev/null 2>&1; then
+        for bak in "${CLAUDE_DIR}/channels/"*/access.json.bak*; do
+          [ -f "$bak" ] && echo "      ${bak#${CLAUDE_DIR}/}"
+        done
+      fi
+      echo
+      echo "    These files contain bot tokens / stale auth state and are host-coupled."
+      echo "    If you sync this workspace to a remote (M2 vault), add an exclude rule"
+      echo "    for channels/*/*.env + channels/*/access.json.bak* in your sync policy"
+      echo "    BEFORE the next sync to avoid leaking secrets remotely."
     fi
     exit 0
     ;;

--- a/scripts/sutando-shell-setup.sh
+++ b/scripts/sutando-shell-setup.sh
@@ -645,6 +645,14 @@ EOF
       # Runtime artifacts that won't survive a rehome anyway.
       --exclude='*.sock'
       --exclude='*.pid'
+      # Weight-reduction excludes (owner directive 2026-06-03, PR #1424
+      # import-UX thread). These are heavy claude-code state artifacts that
+      # have NO Sutando dependency and either auto-regenerate or are
+      # rarely-used past-session data. Saves ~150 MB / 3700+ files on a
+      # typical owner profile.
+      --exclude='shell-snapshots/'   # zsh snapshots, auto-regen per invocation
+      --exclude='history.jsonl'      # per-session command history, rebuilds
+      --exclude='file-history/'      # 102 MB / 3618 files; past-session edit-undo blobs
     )
 
     echo "sutando-shell-setup $INVOKED_AS"

--- a/scripts/sutando-shell-setup.sh
+++ b/scripts/sutando-shell-setup.sh
@@ -726,23 +726,29 @@ EOF
     # Enumerate both patterns explicitly: `channels/*/.env` (dotfile form,
     # the standard bot-token shape) + `channels/*/*.env` (any other .env
     # variant like relay-client.env).
+    # Redirect to stderr (Lucy PR #1429 review nit): the vault-sync warning
+    # is the highest-stakes line in this script (data-loss / secret-leak
+    # prevention), and the source-missing / rsync-missing errors above
+    # already go to stderr. Parity dictates this warning should too — and
+    # it ensures the warning is visible even if the user pipes stdout
+    # somewhere (e.g. `sutando-shell-setup --import > install.log`).
     _secrets_found=0
     for env in "${CLAUDE_DIR}/channels/"*/.env "${CLAUDE_DIR}/channels/"*/*.env "${CLAUDE_DIR}/channels/"*/access.json.bak*; do
       [ -f "$env" ] || continue
       if [ "$_secrets_found" = "0" ]; then
-        echo
-        echo "  ⚠ Imported host-specific secrets — review before vault sync:"
+        echo >&2
+        echo "  ⚠ Imported host-specific secrets — review before vault sync:" >&2
         _secrets_found=1
       fi
       _mode="$(stat -f '%Mp%Lp' "$env" 2>/dev/null || stat -c '%a' "$env" 2>/dev/null || echo '?')"
-      echo "      ${env#${CLAUDE_DIR}/}  (mode $_mode)"
+      echo "      ${env#${CLAUDE_DIR}/}  (mode $_mode)" >&2
     done
     if [ "$_secrets_found" = "1" ]; then
-      echo
-      echo "    These files contain bot tokens / stale auth state and are host-coupled."
-      echo "    If you sync this workspace to a remote (M2 vault), add an exclude rule"
-      echo "    for channels/*/.env + channels/*/*.env + channels/*/access.json.bak*"
-      echo "    in your sync policy BEFORE the next sync to avoid leaking secrets remotely."
+      echo >&2
+      echo "    These files contain bot tokens / stale auth state and are host-coupled." >&2
+      echo "    If you sync this workspace to a remote (M2 vault), add an exclude rule" >&2
+      echo "    for channels/*/.env + channels/*/*.env + channels/*/access.json.bak*" >&2
+      echo "    in your sync policy BEFORE the next sync to avoid leaking secrets remotely." >&2
     fi
     exit 0
     ;;

--- a/scripts/sutando-shell-setup.sh
+++ b/scripts/sutando-shell-setup.sh
@@ -21,12 +21,18 @@
 #   bash scripts/sutando-shell-setup.sh --commit       # append to rc file (idempotent)
 #   bash scripts/sutando-shell-setup.sh --auto         # one-shot prompt path used by startup.sh
 #   bash scripts/sutando-shell-setup.sh --check        # exit 0 if alias present + path matches; 1 otherwise
-#   bash scripts/sutando-shell-setup.sh --migrate      # rsync ~/.claude → <workspace>/.claude-sutando (idempotent, non-destructive)
+#   bash scripts/sutando-shell-setup.sh --import       # rsync ~/.claude → <workspace>/.claude-sutando (idempotent, non-destructive)
 #   bash scripts/sutando-shell-setup.sh --repair-paths # re-pin hardcoded SOURCE_DIR paths in runtime files to CLAUDE_DIR (idempotent)
+#
+# Deprecated aliases (kept for one release):
+#   --migrate      # alias for --import; emits a stderr deprecation warning. Per
+#                  # `feedback_import_not_migrate`: "import" describes the
+#                  # actual non-destructive-copy semantic; "migrate" implied a
+#                  # one-way structural change.
 #
 # Modifier flags (can combine with any MODE-setting flag):
 #   --force         # override the "user-defined claude-sutando() function detected" guard in --commit
-#   --from=<PATH>   # for --migrate / --repair-paths: ALSO rewrite this OLD claude-config-dir
+#   --from=<PATH>   # for --import / --repair-paths: ALSO rewrite this OLD claude-config-dir
 #                   # location (in addition to the default SOURCE_CLAUDE_CONFIG_DIR / ~/.claude).
 #                   # Use when the workspace was moved: previously-rewritten paths point at the
 #                   # old workspace's .claude-sutando; --from re-pins them to the current target.
@@ -49,6 +55,14 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 MODE="dry-run"
 FORCE=0
 FROM_DIR=""
+# INVOKED_AS — the literal flag the user passed for the MODE-setting choice.
+# Used in status messages so they echo back what the user typed (e.g. when
+# `--migrate` is the deprecated alias, we still say "sutando-shell-setup
+# --migrate: done." rather than the canonical name they didn't use).
+INVOKED_AS=""
+# Deprecation tracking — set when a deprecated alias was used so the case-arm
+# can print a single stderr warning on top of the normal flow.
+DEPRECATED_FLAG_MIGRATE=0
 
 # Parse args in two passes so modifiers (`--force`, `--from=PATH`) get
 # parsed regardless of where they appear relative to the MODE-setting flag.
@@ -69,11 +83,14 @@ done
 for arg in "$@"; do
   case "$arg" in
     --force|--from=*) ;;  # consumed by pass 1
-    --commit)  MODE="commit"; break ;;
-    --auto)    MODE="auto"; break ;;
-    --check)   MODE="check"; break ;;
-    --migrate) MODE="migrate"; break ;;
-    --repair-paths) MODE="repair-paths"; break ;;
+    --commit)  MODE="commit"; INVOKED_AS="--commit"; break ;;
+    --auto)    MODE="auto"; INVOKED_AS="--auto"; break ;;
+    --check)   MODE="check"; INVOKED_AS="--check"; break ;;
+    --import)  MODE="import"; INVOKED_AS="--import"; break ;;
+    # Deprecated 1-release alias for --import (per `feedback_import_not_migrate`).
+    # Routes to the same case-arm + sets the deprecation-warning flag.
+    --migrate) MODE="import"; INVOKED_AS="--migrate"; DEPRECATED_FLAG_MIGRATE=1; break ;;
+    --repair-paths) MODE="repair-paths"; INVOKED_AS="--repair-paths"; break ;;
     --help|-h)
       sed -n '1,40p' "$0" | grep -E '^#' | sed 's/^# *//'
       exit 0
@@ -83,7 +100,7 @@ for arg in "$@"; do
 done
 
 # Resolve THIS repo's target path via the config loader. Used for --check
-# (smoke-test that THIS checkout resolves cleanly) and for --migrate. The
+# (smoke-test that THIS checkout resolves cleanly) and for --import. The
 # function we install below does its own per-invocation resolve based on the
 # caller's cwd, so this CLAUDE_DIR isn't baked into the rc file — multiple
 # Sutando checkouts on the same machine each map to their own .claude-sutando.
@@ -222,7 +239,7 @@ user_defined_function_present() {
 }
 
 # Helper: rewrite hardcoded SOURCE_DIR/ → CLAUDE_DIR/ in runtime-critical
-# files under CLAUDE_DIR. Shared by --migrate (post-rsync) and --repair-paths
+# files under CLAUDE_DIR. Shared by --import (post-rsync) and --repair-paths
 # (standalone re-pin without rsync — useful when the workspace moves).
 #
 # Why an allowlist (+globbed patterns) instead of recursive sed:
@@ -526,7 +543,16 @@ EOF
     exit 0
     ;;
 
-  migrate)
+  import)
+    # Deprecation warning for the legacy alias --migrate. Per
+    # `feedback_import_not_migrate`: the rename happened because "migrate"
+    # implied a one-way structural change; the actual semantic is a
+    # non-destructive copy with source preserved (= "import"). Keep the
+    # alias working for one release; users get a single stderr nudge.
+    if [ "$DEPRECATED_FLAG_MIGRATE" = "1" ]; then
+      echo "⚠ --migrate is deprecated, use --import instead. (Behavior is identical.)" >&2
+      echo "  The --migrate alias will be removed in a future release." >&2
+    fi
     # Mirror ~/.claude → $CLAUDE_DIR via rsync. Non-destructive: source stays
     # intact so manual `claude` (without the alias) keeps working against the
     # original tree. Idempotent: rsync -a only re-copies changed files based
@@ -546,12 +572,12 @@ EOF
     # Companion to CLAUDE_CONFIG_DIR (the destination where Sutando writes to).
     SOURCE_DIR="${SOURCE_CLAUDE_CONFIG_DIR:-$HOME/.claude}"
     if [ ! -d "$SOURCE_DIR" ]; then
-      echo "sutando-shell-setup --migrate: source $SOURCE_DIR doesn't exist; nothing to copy" >&2
+      echo "sutando-shell-setup $INVOKED_AS: source $SOURCE_DIR doesn't exist; nothing to copy" >&2
       echo "  (set SOURCE_CLAUDE_CONFIG_DIR to override the migration source location)" >&2
       exit 1
     fi
     if ! command -v rsync >/dev/null 2>&1; then
-      echo "sutando-shell-setup --migrate: rsync not found on PATH; install it or copy manually" >&2
+      echo "sutando-shell-setup $INVOKED_AS: rsync not found on PATH; install it or copy manually" >&2
       exit 1
     fi
 
@@ -618,7 +644,7 @@ EOF
       --exclude='*.pid'
     )
 
-    echo "sutando-shell-setup --migrate"
+    echo "sutando-shell-setup $INVOKED_AS"
     echo "  Source           : $SOURCE_DIR"
     echo "  Target           : $CLAUDE_DIR"
     echo "  Mode             : non-destructive copy (source preserved)"
@@ -656,7 +682,7 @@ EOF
     # which fails on macOS's stock bash 3.2).
     reply_lc="$(printf '%s' "$reply" | tr '[:upper:]' '[:lower:]')"
     if [ "$reply_lc" != "y" ]; then
-      echo "sutando-shell-setup --migrate: aborted by user"
+      echo "sutando-shell-setup $INVOKED_AS: aborted by user"
       exit 2
     fi
 
@@ -673,7 +699,7 @@ EOF
     _rewrite_runtime_paths
 
     echo
-    echo "sutando-shell-setup --migrate: done."
+    echo "sutando-shell-setup $INVOKED_AS: done."
     echo "  ${SOURCE_DIR} is unchanged. To prune later, verify the new tree works first, then:"
     echo "    rm -rf '${SOURCE_DIR}/projects/${THIS_PROJECT_SLUG}/'  # only this project's slug"
     # Mini PR #1415 review #4: channels/*/*.env were intentionally NOT copied
@@ -697,14 +723,14 @@ EOF
     # Standalone path re-pin. Runs ONLY the sed pass — no rsync, no project
     # discovery, no preview/confirm. Use case: workspace moved (mv / rename /
     # config-driven relocate) and previously-rewritten paths in the migrated
-    # tree are now stale. Re-running --migrate would be heavy (full rsync from
+    # tree are now stale. Re-running --import would be heavy (full rsync from
     # ~/.claude) and unnecessary if no source-side changes have happened.
     #
     # Also useful immediately after upgrading to a version of this script that
     # adds the rewrite pass — re-pins a previously-migrated tree without a
     # fresh rsync.
     if [ ! -d "$CLAUDE_DIR" ]; then
-      echo "sutando-shell-setup --repair-paths: target $CLAUDE_DIR doesn't exist; run --migrate first" >&2
+      echo "sutando-shell-setup --repair-paths: target $CLAUDE_DIR doesn't exist; run --import first" >&2
       exit 1
     fi
     echo "sutando-shell-setup --repair-paths"

--- a/scripts/sutando-shell-setup.sh
+++ b/scripts/sutando-shell-setup.sh
@@ -711,22 +711,30 @@ EOF
     # it lands — will include these files in the synced bundle unless the
     # user adds an exclude. Surface the exact paths so the user can add
     # them to their vault sync exclude policy.
-    if compgen -G "${CLAUDE_DIR}/channels/*/*.env" > /dev/null 2>&1; then
-      echo
-      echo "  ⚠ Imported host-specific secrets — review before vault sync:"
-      for env in "${CLAUDE_DIR}/channels/"*/*.env; do
-        [ -f "$env" ] && echo "      ${env#${CLAUDE_DIR}/}  (mode $(stat -f '%Mp%Lp' "$env" 2>/dev/null || stat -c '%a' "$env" 2>/dev/null))"
-      done
-      if compgen -G "${CLAUDE_DIR}/channels/*/access.json.bak*" > /dev/null 2>&1; then
-        for bak in "${CLAUDE_DIR}/channels/"*/access.json.bak*; do
-          [ -f "$bak" ] && echo "      ${bak#${CLAUDE_DIR}/}"
-        done
+    #
+    # Glob note: bash's `*` does NOT match dot-prefixed names by default
+    # (unlike rsync's `*` which does). So `channels/*/*.env` would catch
+    # `relay-client.env` but MISS the canonical `channels/discord/.env`.
+    # Enumerate both patterns explicitly: `channels/*/.env` (dotfile form,
+    # the standard bot-token shape) + `channels/*/*.env` (any other .env
+    # variant like relay-client.env).
+    _secrets_found=0
+    for env in "${CLAUDE_DIR}/channels/"*/.env "${CLAUDE_DIR}/channels/"*/*.env "${CLAUDE_DIR}/channels/"*/access.json.bak*; do
+      [ -f "$env" ] || continue
+      if [ "$_secrets_found" = "0" ]; then
+        echo
+        echo "  ⚠ Imported host-specific secrets — review before vault sync:"
+        _secrets_found=1
       fi
+      _mode="$(stat -f '%Mp%Lp' "$env" 2>/dev/null || stat -c '%a' "$env" 2>/dev/null || echo '?')"
+      echo "      ${env#${CLAUDE_DIR}/}  (mode $_mode)"
+    done
+    if [ "$_secrets_found" = "1" ]; then
       echo
       echo "    These files contain bot tokens / stale auth state and are host-coupled."
       echo "    If you sync this workspace to a remote (M2 vault), add an exclude rule"
-      echo "    for channels/*/*.env + channels/*/access.json.bak* in your sync policy"
-      echo "    BEFORE the next sync to avoid leaking secrets remotely."
+      echo "    for channels/*/.env + channels/*/*.env + channels/*/access.json.bak*"
+      echo "    in your sync policy BEFORE the next sync to avoid leaking secrets remotely."
     fi
     exit 0
     ;;

--- a/tests/sutando-shell-setup-argparse.test.sh
+++ b/tests/sutando-shell-setup-argparse.test.sh
@@ -240,6 +240,56 @@ assert_rc "[brace] old-pattern brace-overall rc=0 even with cat-dst fail (proves
 rm -rf "$TMP"
 
 # ----------------------------------------------------------------------
+# Import-UX tests: --import/--migrate alias, deprecation warning, exclude
+# policy (post-this-PR work).
+# ----------------------------------------------------------------------
+
+echo ""
+echo "Import-UX (--import / --migrate alias / weight-reduction excludes):"
+
+# (a) --import is the canonical flag — invocation should NOT print
+#     deprecation warning.
+out=$(bash "$SETUP" --import 2>&1 </dev/null) || true
+if printf '%s' "$out" | grep -qF -- "--migrate is deprecated"; then
+  assert_fail "--import does NOT print deprecation warning" "found warning in output"
+else
+  assert_pass "--import does NOT print deprecation warning"
+fi
+
+# (b) --migrate works (still routes through) AND prints the deprecation warning
+out=$(bash "$SETUP" --migrate 2>&1 </dev/null) || true
+assert_contains "--migrate prints deprecation warning" "$out" "--migrate is deprecated"
+assert_contains "--migrate routes to --import flow (header line)" "$out" "sutando-shell-setup --migrate"
+
+# (c) INVOKED_AS echoes back what the user typed — --migrate user sees
+#     '--migrate' in status, --import user sees '--import'.
+out=$(bash "$SETUP" --import 2>&1 </dev/null) || true
+assert_contains "--import echoes --import in status line" "$out" "sutando-shell-setup --import"
+
+# (d) Weight-reduction excludes are present in the rsync-filter
+#     declaration block (grep the source, not the runtime, since the dry-run
+#     preview is truncated to 50 lines and may not show every filter).
+filters_block=$(sed -n "/RSYNC_FILTERS+=(/,/^    )/p" "$SETUP")
+for excl in "shell-snapshots/" "history.jsonl" "file-history/"; do
+  if printf '%s' "$filters_block" | grep -qF -- "--exclude='$excl'"; then
+    assert_pass "exclude '$excl' present in RSYNC_FILTERS"
+  else
+    assert_fail "exclude '$excl' missing from RSYNC_FILTERS" "see scripts/sutando-shell-setup.sh"
+  fi
+done
+
+# (e) channels/*/*.env + channels/*/access.json.bak* are NOT in the
+#     exclude list (the (B) copy + warn shift). The pre-fix versions had
+#     these as excludes; reverting them is the core of this PR.
+for not_excl in "channels/*/*.env" "channels/*/access.json.bak"; do
+  if printf '%s' "$filters_block" | grep -qF -- "--exclude='$not_excl"; then
+    assert_fail "exclude '$not_excl' should be ABSENT (copy + warn policy)" "see filter block"
+  else
+    assert_pass "exclude '$not_excl' absent (copy + warn policy)"
+  fi
+done
+
+# ----------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to PR #1424 (merged) implementing the import-UX policy locked in the 2026-06-03 owner thread. Targets `staging-workspace-revamp` per owner directive.

## Summary

5 commits implementing:

1. **`--migrate` → `--import` rename** with 1-release deprecation alias.
2. **Copy + warn policy** for channel secrets (revert PR #1424 baseline excludes + add explicit vault-sync stderr warning).
3. **Weight-reduction excludes** for the heavy claude-code state artifacts that have no Sutando dependency (~150 MB / 3700+ files saved per import on a typical profile).
4. **Regression test additions** — 9 new assertions, 31 total in `tests/sutando-shell-setup-argparse.test.sh`.

## The 5 commits

| SHA | Concern |
|---|---|
| `091025e` | Rename `--migrate` → `--import`. `INVOKED_AS` variable threads the literal flag the user passed into status messages. `--migrate` kept as a deprecated 1-release alias that prints a stderr warning. Per `feedback_import_not_migrate`. |
| `354d8f5` | Revert PR #1424's `channels/*/*.env` + `channels/*/access.json.bak*` excludes. Add a post-import stderr warning enumerating each imported secret file with its mode, plus an explicit "add an exclude rule for these in your M2 vault sync policy BEFORE the next sync" guidance. Option (B) from the owner thread. |
| `642885f` | Smoke-caught regression to `354d8f5`: the warning loop used bash glob `channels/*/*.env` which doesn't match dot-prefixed names (rsync's `*` does; bash's doesn't). Result: warning missed the canonical `channels/discord/.env` etc. and only listed `relay-client.env` + `*.bak*` files. Fixed by enumerating 3 explicit patterns: `channels/*/.env` + `channels/*/*.env` + `channels/*/access.json.bak*`. |
| `4e44d84` | Add weight-reduction excludes: `shell-snapshots/` (auto-regen per zsh invocation), `history.jsonl` (rebuilds), `file-history/` (102 MB / 3618 files of past-session edit-undo blobs, no Sutando dependency). |
| `99e35cd` | 9 new test assertions in the argparse suite: rename + deprecation (4), weight-reduction exclude presence (3), copy + warn reverse-assertions (2). Now 31 ✓ / 0 ✗. |

## What this PR is NOT

- **Auto-trigger UX** (wire into `src/startup.sh` first-time prompt-once-per-host) — held for a separate PR per "single concern per PR". Owner's auto-trigger directive from the same thread is the next step.
- **Pruning previously-imported `shell-snapshots/` / `history.jsonl` / `file-history/` from existing target trees.** Current --import is rsync's default (add-only). `--delete` semantics would also wipe user customizations under `CLAUDE_DIR`. Held for a separate design call.
- **Updates to `tests/sutando-shell-setup.test.sh`** (the older 11-assertion suite) — those tests still pass because `--migrate` works as an alias. Cosmetic-only — can update in a follow-up if reviewers want.

## Decisions from the owner thread (locked-in policy)

| Path | Decision |
|---|---|
| `channels/*/*.env` (bot tokens) | **COPY + warn** |
| `channels/*/access.json` | **COPY** (current; never excluded) |
| `channels/*/access.json.bak*` | **COPY** (per owner — audit-trail value) |
| `shell-snapshots/*` | EXCLUDE |
| `history.jsonl` | EXCLUDE |
| `file-history/*` | EXCLUDE |
| `projects/<other-slug>/*` | EXCLUDE (PR #1424 baseline) |
| `debug/` / `plugins/*/cache/` / `statsig/` | EXCLUDE (PR #1424 baseline) |
| `*.sock` / `*.pid` | EXCLUDE (PR #1424 baseline) |

## Test plan

- [x] `bash -n` clean
- [x] `bash tests/sutando-shell-setup-argparse.test.sh` → 31 ✓ / 0 ✗
- [x] Live smoke: `bash scripts/sutando-shell-setup.sh --import` runs end-to-end, prints the new vault-sync warning with all 7 secret-class files (4 bot tokens + relay-client + 2 auth-backups), exits 0.
- [x] Live smoke: `bash scripts/sutando-shell-setup.sh --migrate` prints the deprecation warning + still runs the import flow.
- [x] Live smoke: `bash scripts/sutando-shell-setup.sh --repair-paths --from=/` still rejects (PR #1424 validation untouched).
- [ ] Pre-existing `tests/sutando-shell-setup.test.sh` runs cleanly with `--migrate` still routing via the alias (CI).
- [ ] CI on the PR.

## Reviewer notes

- The `--migrate` → `--import` rename is intentionally NOT a deprecation-and-removal. Both keep working for one release; status messages echo whichever the user typed. After we observe nobody's hit by the deprecation in real usage, follow-up PR drops `--migrate` entirely.
- The `642885f` smoke-caught regression is filed inline (not as a separate issue) because it's a fix to code that's only on this branch — the prior commit broke and this one fixed before the PR opened. Per `feedback_per_file_pattern_audit`: the dotglob gotcha is documented in the helper to prevent future regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
