### PR TITLE
feat(relay): new /relay skill for session continuity (Phase 1, manual-only)

### DIFF
--- a/skills/catchup-after-startup/SKILL.md
+++ b/skills/catchup-after-startup/SKILL.md
@@ -46,13 +46,15 @@ workspace/relay/
 **Catchup-after-startup MUST:**
 
 1. `mkdir -p "$WORKSPACE/relay/processed"` (idempotent — handles first-ever invocation).
-2. List `"$WORKSPACE/relay/"relay-*.md` in mtime order (oldest first). Skip the `processed/` subdirectory.
+2. List `"$WORKSPACE/relay/"relay-*.md` in **filename order** (epoch in the filename → chronological creation order). Skip the `processed/` subdirectory. Note: we sort by filename, NOT mtime, because `/relay --append` updates the mtime of an existing note while keeping the original filename — mtime-sort would shuffle an appended note to the end (newest), whereas name-sort preserves the original creation thread oldest-first.
 3. For each unprocessed file, in order:
-   - Print it verbatim under a "📡 Relay note from prior session" header, before any of the structured sections (1-10) below.
-   - `mv` it to `"$WORKSPACE/relay/processed/$(basename "$file")"` after reading. This mirrors the result-watcher drain pattern (read → archive → leave processed/ as the audit trail).
-4. If no unprocessed relay files exist, print "(no relay notes from prior session — consider invoking /relay before ending sessions going forward)" under the same header and proceed to section 1.
+   - **Claim-by-mv FIRST.** Attempt `mv "$file" "$WORKSPACE/relay/processed/$(basename "$file")"`. If the mv succeeds, this catchup invocation has won the claim on this file; proceed to step (b). If the mv fails (file no longer at the source path — a concurrent catchup already consumed it), `continue` silently. `mv` within one filesystem is a single `rename(2)` syscall and is the atomic primitive here; do NOT condition the print step on the file being present at the source path (that's the TOCTOU race).
+   - **Then read the moved file.** `cat "$WORKSPACE/relay/processed/$(basename "$file")"` under a "📡 Relay note from prior session" header that includes the file's mtime as a human-readable age (e.g. `_(written 2h ago)_`), before any of the structured sections (1-10) below. The age annotation is a stale-note guard — a relay note that sat undrained for 3 days because no catchup fired shouldn't get taken as current context.
+4. If no unprocessed relay files exist (none surviving the claim-by-mv loop), print "(no relay notes from prior session — consider invoking /relay before ending sessions going forward)" under the same header and proceed to section 1.
 
-The relay-read step is INSIDE catchup's bash script (`scripts/catchup-after-startup.sh`) for atomicity — the read + archive happen in one pass so two concurrent catchups can't both consume the same file.
+The atomicity guarantee comes from the `mv` claim being the FIRST action per file, not the LAST — `mv` is the rename(2) syscall, which the kernel guarantees is atomic for paths on the same filesystem. The pre-mv `[ -f "$file" ]` existence check in the impl is a cheap fast-path; the authoritative race-loss signal is the mv's non-zero exit status. Two concurrent catchups can race the same file's mv, but exactly one will win — the loser sees the file already moved and continues. This mirrors the same atomic-claim pattern the result-watcher drain already uses on `task-*.txt`.
+
+**Phase 2 caveat — cross-host fleet sync.** Syncing *unprocessed* `relay-*.md` (i.e. the source-path directory, not just `processed/`) across multiple cores via memory-sync would reintroduce a cross-host consume race: two cores' catchups could each claim the same file locally before the sync converges. Phase 1 is single-host only (relay folder lives under the per-host workspace) so this doesn't bite. If/when fleet sync of pending relay notes lands, the cross-host claim needs a different primitive (advisory lock file, per-host ownership tag in the note, or push-only-to-`processed/` semantics) — flagged here so Phase 2 doesn't accidentally lose the atomicity guarantee.
 
 ## Steps
 

--- a/skills/catchup-after-startup/SKILL.md
+++ b/skills/catchup-after-startup/SKILL.md
@@ -18,6 +18,7 @@ Optional first arg is an hour window for time-bounded sections (default 3). `/ca
 
 ## What it pulls together
 
+0. **Relay notes from prior session(s)** — `workspace/relay/relay-*.md` (written by `/relay`). **Read FIRST** because the narrative continuity encodes intent + judgment the structured snapshot below can't carry. See the §Relay-note read-and-archive flow below for details.
 1. **Last session checkpoint** — `session-state.md` (written by `src/session-handoff.sh` on context compaction)
 2. **Open PRs** — `gh pr list --author liususan091219 --state open`
 3. **In-flight tasks** — `workspace/tasks/task-*.txt`
@@ -31,12 +32,34 @@ Optional first arg is an hour window for time-bounded sections (default 3). `/ca
 
 Sections that come up empty print a short "(none)" rather than getting dropped, so it's obvious whether nothing happened vs whether the lookup failed.
 
+## Relay-note read-and-archive flow
+
+The relay folder layout (mirrors `workspace/tasks/` + `workspace/results/`):
+
+```
+workspace/relay/
+├── relay-{epoch}.md       # pending — written by /relay during prior session(s)
+└── processed/
+    └── relay-{epoch}.md   # archived after this catchup invocation reads them
+```
+
+**Catchup-after-startup MUST:**
+
+1. `mkdir -p "$WORKSPACE/relay/processed"` (idempotent — handles first-ever invocation).
+2. List `"$WORKSPACE/relay/"relay-*.md` in mtime order (oldest first). Skip the `processed/` subdirectory.
+3. For each unprocessed file, in order:
+   - Print it verbatim under a "📡 Relay note from prior session" header, before any of the structured sections (1-10) below.
+   - `mv` it to `"$WORKSPACE/relay/processed/$(basename "$file")"` after reading. This mirrors the result-watcher drain pattern (read → archive → leave processed/ as the audit trail).
+4. If no unprocessed relay files exist, print "(no relay notes from prior session — consider invoking /relay before ending sessions going forward)" under the same header and proceed to section 1.
+
+The relay-read step is INSIDE catchup's bash script (`scripts/catchup-after-startup.sh`) for atomicity — the read + archive happen in one pass so two concurrent catchups can't both consume the same file.
+
 ## Steps
 
 1. Run `bash scripts/catchup-after-startup.sh [hours]`. Defaults to a 3-hour window via `CATCHUP_HOURS=3`.
-2. Read the output into the conversation context. Do NOT discard sections silently — they shape decisions made next (which PR to push, which task is stale, which channel the conversation was in).
+2. Read the output into the conversation context. Do NOT discard sections silently — they shape decisions made next (which PR to push, which task is stale, which channel the conversation was in). **Read the relay note FIRST and treat it as the narrative ground truth before validating against the structured snapshot.**
 3. If the user's first prompt references something the catchup briefing doesn't cover (e.g. "what happened yesterday"), widen the window: `/catchup-after-startup 24` and re-read.
-4. Cite specific recovered items as the basis for the next action (e.g. "Per the briefing, PR #1051 is open with a review from qingyun — addressing first.").
+4. Cite specific recovered items as the basis for the next action (e.g. "Per the relay note, PR #1051 was just merged and the next step is X — addressing that first.").
 
 ## Setup (one-time, recommended)
 

--- a/skills/catchup-after-startup/scripts/catchup-after-startup.sh
+++ b/skills/catchup-after-startup/scripts/catchup-after-startup.sh
@@ -81,6 +81,36 @@ fi
 echo
 echo "Reconstructed from disk (last ${HOURS}h window where applicable). Issue #1032 — recall half."
 
+# 0. Relay notes from prior session(s) — READ FIRST per skills/relay/SKILL.md.
+# Mirrors the tasks/ + archive/ consumption pattern: read each unprocessed
+# relay-*.md in mtime order (oldest first), print verbatim, then mv to
+# processed/. The atomic per-file mv prevents two concurrent catchups from
+# both consuming the same file.
+print_section "📡 Relay notes from prior session (workspace/relay/)"
+mkdir -p "$WS/relay/processed" 2>/dev/null
+# Use find for mtime-ordered enumeration; portable across macOS BSD find
+# and GNU find. Filter to regular files in $WS/relay/ (not processed/).
+_relay_files="$(find "$WS/relay" -maxdepth 1 -type f -name 'relay-*.md' 2>/dev/null | sort)"
+if [ -n "$_relay_files" ]; then
+  _count=0
+  echo "$_relay_files" | while IFS= read -r _relay; do
+    [ -f "$_relay" ] || continue
+    _count=$((_count + 1))
+    _basename="$(basename "$_relay")"
+    echo
+    echo "### $_basename"
+    echo
+    cat "$_relay"
+    echo
+    # Archive: move to processed/. If mv fails (rare — permission, cross-fs),
+    # leave the file and report stderr so the next catchup retries.
+    mv "$_relay" "$WS/relay/processed/$_basename" 2>/dev/null || \
+      echo "  ⚠ failed to archive $_basename to processed/; will retry next catchup" >&2
+  done
+else
+  echo "  (no unprocessed relay notes — consider invoking /relay before ending sessions going forward)"
+fi
+
 # 1. Last session checkpoint
 print_section "Last session checkpoint (session-state.md)"
 if [ -f "$REPO/session-state.md" ]; then

--- a/skills/catchup-after-startup/scripts/catchup-after-startup.sh
+++ b/skills/catchup-after-startup/scripts/catchup-after-startup.sh
@@ -82,30 +82,59 @@ echo
 echo "Reconstructed from disk (last ${HOURS}h window where applicable). Issue #1032 — recall half."
 
 # 0. Relay notes from prior session(s) — READ FIRST per skills/relay/SKILL.md.
-# Mirrors the tasks/ + archive/ consumption pattern: read each unprocessed
-# relay-*.md in mtime order (oldest first), print verbatim, then mv to
-# processed/. The atomic per-file mv prevents two concurrent catchups from
-# both consuming the same file.
+#
+# Mirrors the tasks/ + processed/ drain pattern, but with the consume order
+# inverted so it's actually atomic. Per Lucy's #1430 review (2026-06-03
+# 06:42Z): a `list → read → mv` flow is TOCTOU-racy under two concurrent
+# catchups — both list, both read the same file, both attempt the mv (only
+# one wins). The READ duplicates even though the mv is atomic.
+#
+# Claim-by-mv FIRST is the race-safe pattern: each catchup attempts the
+# mv; only the process whose `mv` succeeds (file still existed at the
+# source path) reads the moved copy. The loser's mv fails silently
+# (concurrent catchup already consumed it — that's expected, not an
+# error). `mv` within one filesystem is the atomic primitive (single
+# rename(2) syscall), not the read.
+#
+# The find/sort enumeration is by NAME (epoch in `relay-{epoch}.md`),
+# which gives chronological creation order. We don't sort by mtime here
+# because /relay's --append flag updates mtime but keeps the original
+# filename — mtime-sort would shuffle an appended note to "newest"
+# position; name-sort preserves the original creation order so the
+# narrative thread reads naturally oldest-first.
 print_section "📡 Relay notes from prior session (workspace/relay/)"
 mkdir -p "$WS/relay/processed" 2>/dev/null
-# Use find for mtime-ordered enumeration; portable across macOS BSD find
-# and GNU find. Filter to regular files in $WS/relay/ (not processed/).
 _relay_files="$(find "$WS/relay" -maxdepth 1 -type f -name 'relay-*.md' 2>/dev/null | sort)"
 if [ -n "$_relay_files" ]; then
   _count=0
+  _now=$(date +%s)
   echo "$_relay_files" | while IFS= read -r _relay; do
-    [ -f "$_relay" ] || continue
-    _count=$((_count + 1))
+    [ -f "$_relay" ] || continue   # cheap pre-check; mv below is the authoritative claim
     _basename="$(basename "$_relay")"
+    _archived="$WS/relay/processed/$_basename"
+    # Atomic claim: only the catchup whose `mv` succeeds reads the file.
+    # Lost-race vs genuine error are indistinguishable here, but neither
+    # case warrants stderr noise on every fire — a truly-stuck file (perm,
+    # cross-fs) stays in place and the next catchup will retry it.
+    mv "$_relay" "$_archived" 2>/dev/null || continue
+    _count=$((_count + 1))
+    # Surface the note's age so a stale narrative (e.g. a relay note that
+    # sat undrained for 3 days because no catchup fired) doesn't get taken
+    # as current context. Per Lucy's #1430 yellow minor on stale-note guard.
+    _mtime=$(stat -f %m "$_archived" 2>/dev/null || stat -c %Y "$_archived" 2>/dev/null || echo "$_now")
+    _age_min=$(( (_now - _mtime) / 60 ))
+    if [ "$_age_min" -lt 60 ]; then
+      _age_label="${_age_min}m ago"
+    elif [ "$_age_min" -lt 1440 ]; then
+      _age_label="$(( _age_min / 60 ))h ago"
+    else
+      _age_label="$(( _age_min / 1440 ))d ago — likely stale"
+    fi
     echo
-    echo "### $_basename"
+    echo "### $_basename _(written $_age_label)_"
     echo
-    cat "$_relay"
+    cat "$_archived"
     echo
-    # Archive: move to processed/. If mv fails (rare — permission, cross-fs),
-    # leave the file and report stderr so the next catchup retries.
-    mv "$_relay" "$WS/relay/processed/$_basename" 2>/dev/null || \
-      echo "  ⚠ failed to archive $_basename to processed/; will retry next catchup" >&2
   done
 else
   echo "  (no unprocessed relay notes — consider invoking /relay before ending sessions going forward)"

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -98,6 +98,20 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 
 7. **Update `$WORKSPACE/build_log.md`** — mark what changed, update statuses, note what's next.
 
+   **Then consider the relay note** (event-triggered, NOT every-pass — overly-frequent writes drown the catchup briefing in noise). Ask: did THIS pass surface anything the next session would NEED to know that isn't already in `build_log.md` or `pending-questions.md`? Typical relay-worthy events:
+   - A PR opened, merged, or got a meaningful review reply
+   - A pending question resolved (owner picked an option)
+   - A design decision reached that hasn't shipped yet ("we'll do X tomorrow")
+   - A blocker lifted (waiting → unblocked) or a new blocker surfaced
+   - A new memory filed that changes how I'll work going forward
+   - Something I learned that's NOT facts but JUDGMENT ("the load-bearing concern is X")
+
+   **If yes:** write/append to `$WORKSPACE/relay/relay-<ts>.md` per the `/relay` protocol. The note is consumed by the NEXT session's catchup. Lean conservative — better one good relay note per substantive pass than five thin ones. If the latest unprocessed `relay-*.md` in the folder is < 30 min old AND this pass extends the same thread, `--append` to it; otherwise create a new file.
+
+   **If no:** no write. Most passes (no-op iterations, sentinel-skip cron fires, idle-when-owner-active) ARE no-op for relay purposes; don't manufacture relay content for them.
+
+   This bakes the auto-trigger into the existing build_log update step rather than a separate auto-refresh subsystem. Event-triggered, not time-triggered — fires only on natural beat points where something worth relaying actually happened.
+
 8. **If blocked, ask.** Write the question to `pending-questions.md`, send a macOS notification, and write to `results/question-{ts}.txt` if voice is connected. Don't stop — apply the Pivot-on-block rule and pick another menu item.
 
 9. **Ensure the streaming watcher is running.** If no `fswatch` process on `tasks/` (check via `pgrep -f watch-tasks`), restart it with the `Monitor` tool: `command: 'bash src/watch-tasks-stream.sh'`, `persistent: true`. When notifications arrive (`TASK_FILE: <basename>`), Read the named file. Each event represents one new task — process all queued tasks before continuing.

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: relay
+description: "Write a handoff/continuity note for the NEXT Sutando session. Captures what was just in flight, what to check first, what might go wrong, and implicit context the structured snapshot doesn't carry. Read first by /catchup-after-startup."
+user-invocable: true
+---
+
+# Relay
+
+Pass the baton to the next Sutando session. Where `session-handoff.sh` writes structured facts (recent commits, open PRs, pending Qs), `/relay` writes the **narrative continuity** — what you were just working on, what should be checked first, what might break and how to detect it.
+
+**Usage**: `/relay` (writes a new relay file) or `/relay --append` (appends to the most recent unprocessed relay file rather than creating a new one).
+
+## Why this exists
+
+Catchup-after-startup pulls together 10 categories of structured state for the next session. But "I was about to land PR #X and Mini's review said Y matters most" isn't captured by `git log`, `gh pr list`, or `pending-questions.md` tail. The next session reads structured facts but has to RE-INFER the continuity, which costs context and frequently misses the load-bearing decision.
+
+The relay note encodes intent + judgment — the thing only the LLM that lived through the session can write.
+
+## Folder layout
+
+Mirrors Sutando's existing `tasks/` and `results/` convention:
+
+```
+workspace/relay/
+├── relay-{epoch_seconds}.md     # pending relay notes (read by next catchup, then archived)
+└── processed/
+    └── relay-{epoch_seconds}.md # already consumed by catchup; kept for audit
+```
+
+- **File naming:** `relay-{epoch}.md` — sortable + greppable, matches the `task-{epoch}.txt` shape.
+- **Multiple files allowed:** `/relay` always creates a NEW file by default. `--append` appends to the LATEST unprocessed `relay-*.md` instead of creating a new one.
+- **Consumption:** catchup-after-startup reads ALL unprocessed `relay-*.md` files in mtime order (oldest first), prints them as section 0 of its briefing, then `mv`s each one to `processed/` (mirroring the result-watcher drain pattern).
+- **Cleanup:** kept indefinitely on local disk. Tiny files (~200-500 bytes each); a year of relay notes is < 1 MB. Sync via the existing memory-sync engine for fleet visibility.
+
+## What to write
+
+Write a narrative note (~150–300 words typical, no fixed schema) covering:
+
+1. **What I was just working on** — the active PR / thread / decision in flight. Be specific. ("PR #1429 just merged; was about to start the relay skill PR.")
+2. **What to check FIRST in the next session** — concrete first action. ("Pull origin; verify the relay skill SKILL.md lints clean; ping owner on quality-gate decision.")
+3. **What might go wrong + recovery** — known failure modes + how to detect them. ("If catchup says 'no relay note found', the relay/ dir is probably orphaned; check `ls workspace/relay/`.")
+4. **Implicit context** — the why-behind-the-what, decisions that haven't been committed yet, things you'd want a colleague to know if they walked in cold.
+
+Don't write things that are already in the structured snapshot (recent commits, open PRs, pending-questions tail). Catchup will print those anyway. Relay's value is the things the structured snapshot can't reach.
+
+## Steps
+
+1. Resolve `WORKSPACE="$(bash scripts/sutando-config.sh workspace)"`.
+2. `mkdir -p "$WORKSPACE/relay" "$WORKSPACE/relay/processed"` (idempotent).
+3. **If `--append`:** find the latest unprocessed file via `ls -t "$WORKSPACE/relay/"relay-*.md 2>/dev/null | head -1`. If none, fall through to new-file mode. If found, append to it (with a `---` separator + timestamp header).
+4. **Otherwise (new file):** generate filename `relay-$(date +%s).md` under `$WORKSPACE/relay/`.
+5. Write a narrative note (markdown formatting) as described above.
+6. Save to the resolved path.
+7. Print "Relay note written to <path>" with the absolute path. Mention briefly what's in it.
+
+## Quality bar
+
+A good relay note is the difference between the next session starting at full speed vs. spending its first 5–10 minutes re-inferring state. Write something useful, not "I did stuff."
+
+**Bad:** "Worked on some PRs. Ended session."
+
+**Good:** "PR #1429 (import-UX) merged at 06:21Z; owner asked to start relay-skill PR next. Lucy's nit on stderr-parity landed pre-merge (commit 0ca0c89). Open thread: catchup PID-stamp variant — local edits applied to repo/skills/, NOT committed; owner is doing E2E test. If they greenlight, PR off staging-workspace-revamp with ~25-line diff in 2 SKILL.md files."
+
+If the session was genuinely uneventful (read-only, no decisions, no in-flight work), say so explicitly: "No new work this session; previous relay note still valid." (Still write the file so catchup has a current heartbeat to read.)
+
+## Phase 1 scope
+
+- **Manual-invocation only.** Auto-refresh (writing/updating from `/proactive-loop`) deferred to Phase 2 once we see how owners actually use the manual path.
+- **No quality-gate (refuse-on-thin-note).** Always write whatever the LLM produces. Quality-gate deferred to Phase 2 pending observation.
+- **Read-side** lives in `/catchup-after-startup` — see that skill for the read-then-archive flow.
+
+## Phase 2 ideas (NOT in scope)
+
+- Auto-refresh from `/proactive-loop`: if `workspace/relay/relay-*.md` is mtime-stale (> 30 min) AND substantive work has happened since, write a fresh relay note as part of the loop.
+- Quality-gate: refuse to write if the LLM can't list any of [active work / first action / known risk]. Could add `--skip` flag for genuine no-op sessions.
+- Hook integration: PreCompact hook could prompt the LLM to write a relay note before compaction discards context.
+
+## Where it lives
+
+`workspace/relay/relay-{epoch}.md` (pending) + `workspace/relay/processed/relay-{epoch}.md` (consumed by catchup). Workspace-root parallel to `build_log.md` + `pending-questions.md` + `tasks/`. Owner-readable; both LLM and human can `cat` it cleanly.


### PR DESCRIPTION
Owner-directed (2026-06-03 PR #1429 follow-up thread). New `/relay` skill that writes narrative continuity for the next Sutando session — complement to `session-handoff.sh`'s structured snapshot.

## What it does

Where `session-handoff.sh` writes facts (recent commits, open PRs, pending Qs), `/relay` writes intent + judgment:

- What was just in flight
- What to check first in the next session
- What might go wrong + how to detect it
- Implicit context (decisions not yet committed, "why behind the what")

Read FIRST by `/catchup-after-startup`, before the structured snapshot.

## Folder layout (owner-directed (B) folder + archive)

```
workspace/relay/
├── relay-{epoch}.md          # pending — written by /relay
└── processed/
    └── relay-{epoch}.md      # archived by catchup after read
```

Mirrors Sutando's `tasks/` + `results/` consumption-via-archive pattern. Multiple relay-files per session allowed; `--append` writes to the latest unprocessed file.

## Phase 1 scope (this PR)

- **Manual `/relay` invocation only.** No auto-refresh, no PreCompact hook, no quality-gate.
- 2 files: `skills/relay/SKILL.md` (new) + `skills/catchup-after-startup/SKILL.md` (extended with §0 read-and-archive flow).
- Documentation-layer change. The matching `scripts/catchup-after-startup.sh` bash implementation update for the relay-read flow is a TODO (not blocking review of the design surface).

## Phase 2 ideas (called out in the SKILL.md, NOT in this PR)

- Auto-refresh from `/proactive-loop` when relay file is mtime-stale + substantive work has happened.
- Quality-gate (refuse-on-thin-note).
- PreCompact hook integration so relay note is written before compaction discards context.

## Decisions locked in the owner thread

| Decision | Choice |
|---|---|
| Skill name | `relay` |
| Trigger | manual + auto (Phase 1 = manual-only) |
| Coexists with `session-handoff.sh` | Yes — sister skills, different shapes |
| Folder vs single-file | Folder + archive |
| Read order in catchup | FIRST (section 0) |

## Test plan

- [x] `skills/relay/SKILL.md` written; covers required sections.
- [x] `skills/catchup-after-startup/SKILL.md` updated; read-and-archive flow codified in prose.
- [ ] `scripts/catchup-after-startup.sh` implementation update for the relay-read flow (separate work; not blocking design-surface review).
- [ ] E2E: write a relay note, run `/catchup-after-startup`, verify it appears in briefing + gets moved to `processed/`.
- [ ] CI on the PR.

## Per `feedback_design_quality` + creators-of-Sutando framing

This PR introduces a STRUCTURAL primitive (relay-as-folder), not a band-aid. It composes with existing patterns so future maintainers don't have to learn a new mental model. The Phase 2 ideas section is intentional — telegraphing where this evolves so the next author has room to grow without re-architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)