### PR TITLE
fix(sync-memory): anchor helper lookup to SCRIPT_PARENT, not REPO_DIR

### DIFF
--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -205,18 +205,35 @@ fi
 # The same convention is documented in this script's pre-2026-05-11 history
 # ("notes/ bidirectional rsync removed: both nodes now symlink").
 # Workspace resolution goes through the canonical loader (M0 cutover).
+#
+# Helper lookup uses SCRIPT_PARENT (this script's own repo root), NOT
+# $REPO_DIR. They're equal on healthy single-checkout hosts but differ when
+# $SUTANDO_REPO_DIR is set to point at another checkout — most commonly
+# a sutando-plus submodule pin that lags main and is missing the helper
+# entirely. In that case, conditioning the lookup on REPO_DIR false-negatives
+# (helper "not found" at the pin path even though it exists right beside
+# this script) and silently falls through to the L213 legacy default
+# (~/.sutando/workspace/), which is wrong on M0 hosts. Caught 2026-06-03
+# on MBP where SUTANDO_REPO_DIR pointed at the pre-M0 submodule pin and
+# sync-memory was reading the legacy workspace instead of the in-repo one.
+# Anchoring the lookup to SCRIPT_PARENT means it works regardless of
+# REPO_DIR drift — the helper and this script ship in the same commit.
+#
 # Fallback retains the legacy inline default for the rare case where the
-# wrapper isn't present (e.g. extracted-archive install).
-if [ -f "$REPO_DIR/scripts/sutando-config.sh" ]; then
-    WS_DIR="$(bash "$REPO_DIR/scripts/sutando-config.sh" workspace)"
+# wrapper isn't present (e.g. extracted-archive install where SCRIPT_PARENT
+# itself lost the helper).
+if [ -f "$SCRIPT_PARENT/scripts/sutando-config.sh" ]; then
+    WS_DIR="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" workspace)"
 else
     WS_DIR="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
 fi
-# Disambiguation guard: if a host has SUTANDO_WORKSPACE pointing at a public-repo
-# checkout (legacy semantic), the symlink-bootstrap below would point at
-# `<repo>/notes` not the workspace `notes/`. Detect via `.git` presence + skip.
+# Disambiguation guard: if WS_DIR points at a public-repo checkout (a
+# legacy-shaped SUTANDO_WORKSPACE value, or — on truly broken installs —
+# a SCRIPT_PARENT that's a public repo not a workspace), the symlink
+# bootstrap below would write a symlink at `<repo>/notes` not the
+# workspace `notes/`. Detect via `.git` presence at WS_DIR + skip.
 if [ -d "$WS_DIR/.git" ]; then
-    log "skipping workspace-symlink bootstrap: SUTANDO_WORKSPACE='$WS_DIR' looks like a public-repo checkout, not a workspace. Set SUTANDO_WORKSPACE=$HOME/.sutando/workspace per CLAUDE.md and re-run."
+    log "skipping workspace-symlink bootstrap: '$WS_DIR' looks like a public-repo checkout (.git/ present), not a workspace. Run 'bash $SCRIPT_PARENT/scripts/sutando-config.sh workspace' to see the canonical workspace path; unset SUTANDO_WORKSPACE to use the in-repo default."
     WS_DIR=""
 fi
 if [ -n "$WS_DIR" ]; then

--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -37,7 +37,10 @@
 # to ~/.sutando/memory-sync/. The auto-detect handles both the new convention
 # (~/.sutando/memory-sync/) and the legacy convention (~/.sutando-memory-sync/)
 # so a sync clone with this script copied in keeps working through the move.
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+_self="${BASH_SOURCE[0]:-$0}"
+if command -v realpath >/dev/null 2>&1; then _self="$(realpath "$_self")"; fi
+SCRIPT_DIR="$(cd "$(dirname "$_self")" && pwd)"
+unset _self
 SCRIPT_PARENT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Load .env from the sutando workspace early — non-interactive shells (cron,


### PR DESCRIPTION
## Summary
- Anchor sync-memory.sh's M0 helper lookup to `\$SCRIPT_PARENT` (this script's own repo root) instead of `\$REPO_DIR` (which equals `\$SUTANDO_REPO_DIR` when set).
- Update the disambiguation-guard error message at L219 — previously cited stale post-M0 advice (\"set SUTANDO_WORKSPACE\"), now points at the helper output as canonical truth.

## Why this matters

`\$SUTANDO_REPO_DIR` can point at a sutando-plus submodule pin that lags main and doesn't yet carry `scripts/sutando-config.sh`. On those hosts the L210 conditional false-negatives, the lookup falls through to the L213 legacy default (`~/.sutando/workspace/`), and sync-memory reads the WRONG workspace on M0 hosts.

Same drift family as #1366's skill-symlink-pin staleness — submodule pin can lag main, runtime-loaded paths off the pin get stale content.

## Verified on MBP host (live repro)

Before fix (sync-memory output):
\`\`\`
sync-memory: WARN — /Users/qingyunwu/.sutando/workspace/notes is a real dir, not a symlink to ...
\`\`\`
(legacy path — wrong on M0)

After fix:
\`\`\`
sync-memory: WARN — /Users/qingyunwu/Documents/github/sutando/workspace/notes is a real dir, not a symlink to ...
\`\`\`
(M0 canonical path — correct)

The WARN still fires because the workspace/notes is a real dir that needs the operator's manual rsync+symlink reconcile — but that's the EXISTING migration step the script's been telling people about. The fix is that it's now telling them the right path to reconcile.

## Scope: single file

Inventory grep confirmed sync-memory.sh was the only vulnerable site:
- \`scripts/sutando-migrate.sh:254\` derives REPO_DIR from \`\$SCRIPT_DIR/..\` (SCRIPT_PARENT-equivalent) — safe.
- \`src/watch-tasks-stream.sh:41,66\` uses \`\$__REPO_ROOT\` computed at L24 from \`\$__SCRIPT_DIR/..\` (SCRIPT_PARENT-equivalent) — safe.
- \`skills/catchup-after-startup/scripts/catchup-after-startup.sh:40\` already detects + warns on this case defensively.

No other call sites in the repo use the \`\$REPO_DIR/scripts/sutando-config.sh\` pattern.

## Connection to recent PRs

- Sibling concern to **#1431** (PID-stamp gate for catchup sentinel + watcher). #1431 fixes the gate-check side; this fixes the workspace-resolution side. Both are M0-rollout follow-ups exposed by real-host usage.
- Re-validates the parked **sync-memory fleet-coherence** pending-question from 2026-06-02 — that question framed the issue narrowly as \"L213 is hardcoded fallback\" but missed the upstream cause (REPO_DIR drift). With this PR, the helper-first arm fires correctly on M0 hosts and the legacy fallback returns to being defense-in-depth only.

## Test plan
- [x] `bash scripts/sync-memory.sh` runs without legacy-path WARNs on this MBP (where \`\$SUTANDO_REPO_DIR\` points at a stale sutando-plus pin).
- [x] `bash -n` syntax check passes.
- [ ] Reviewer: confirm SCRIPT_PARENT is computed at L40-41 of the same script and is always set by the time L210 runs.
- [ ] Reviewer: confirm no test fixtures depend on the old \"set SUTANDO_WORKSPACE per CLAUDE.md\" wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)