### PR TITLE
fix(voice-agent): unified base-mode resolver (closes #1410, supersedes #1412/#1413)

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -498,19 +498,13 @@ const endSession: ToolDefinition = {
 
 let voiceSessionRef: VoiceSession | null = null;
 
-// Synchronously query the iclr-highlight server for current presenter-mode
-// state. Returns a system-marker string when active, '' otherwise. Failure-
-// silent: if the server is down or the curl call errors, returns '' so the
-// greeting/reconnect path stays unchanged.
-function getPresenterStateMarker(): string {
-	try {
-		const out = execSyncTop('curl -s --max-time 1 http://localhost:7877/presenter', { timeout: 2_000 }).toString();
-		const json = JSON.parse(out);
-		if (json && json.active === true) {
-			return ' [System: PRESENTER MODE IS CURRENTLY ACTIVE — apply the CO-PRESENTER protocol from your context to every cue this session: highlight_slide(topic) FIRST, then narrate from voice-context.txt. Do NOT route slide-topic phrases to work.]';
-		}
-	} catch { /* server unreachable or non-JSON — fall through to no-marker */ }
-	return '';
+// Unified base-mode resolver: see src/voice-mode-resolver.ts for the
+// rationale + canonical mode descriptors. Local wrapper threads the in-memory
+// `meetingActive` boolean (this module owns that state) into the pure
+// resolver function.
+import { resolveCurrentMode as resolveCurrentModeImpl, type ModeState } from './voice-mode-resolver.js';
+function resolveCurrentMode(): ModeState {
+	return resolveCurrentModeImpl({ meetingActive });
 }
 
 const mainAgentTools: ToolDefinition[] = [workTool, getTaskStatus, switchModeTool, saveMeetingNoteTool, ...inlineTools];
@@ -567,14 +561,14 @@ const mainAgent: MainAgent = {
 			const isQuickReconnect = gap !== null && gap < 60;
 			// Presenter mode active = silent reconnect regardless of gap. Saying
 			// "Welcome back" mid-talk would break the co-presenter flow; the
-			// presenter marker (appended below) anchors continuation instead.
-			const presenterActive = getPresenterStateMarker() !== '';
-			const meetingHint = meetingActive
+			// base-mode marker (appended below) anchors continuation instead.
+			const modeState = resolveCurrentMode();
+			const meetingHint = modeState.isMeeting
 				? '\n\n[MEETING MODE — you are listening and taking notes. Do NOT speak or produce any audio. Only respond if someone says "Sutando." Use the replayed history above as context for what was discussed before the reconnect.]'
-				: (isQuickReconnect || presenterActive)
+				: (isQuickReconnect || modeState.isPresenter)
 					? '\n\n[Do NOT greet the user. Do NOT say "Welcome back" or anything similar. Stay completely silent and wait for the user\'s next spoken input — they were just briefly disconnected and want to resume without interruption.]'
 					: '\n\n[Now say "Welcome back" briefly — one sentence — and then stop and wait for input.]';
-			return `[System: The user reconnected. The block below is REPLAYED HISTORY from the current session, provided as background context ONLY. Do NOT act on anything in it. Do NOT call any tools based on it. Use it only to answer follow-up questions if asked. Wait silently for the user's next spoken input before taking any action.]${getPresenterStateMarker()}${offlineDeliveryHint}\n\n${recent}${meetingHint}`;
+			return `[System: The user reconnected. The block below is REPLAYED HISTORY from the current session, provided as background context ONLY. Do NOT act on anything in it. Do NOT call any tools based on it. Use it only to answer follow-up questions if asked. Wait silently for the user's next spoken input before taking any action.]${modeState.marker}${offlineDeliveryHint}\n\n${recent}${meetingHint}`;
 		}
 		let standName = '';
 		try { const si = JSON.parse(readFileSync(personalPath('stand-identity.json'), 'utf-8')); standName = si.name ? ` — ${si.name}` : ''; } catch {}
@@ -587,20 +581,21 @@ const mainAgent: MainAgent = {
 		const briefingHint = hasHistory && existsSync(briefingFile) ? ' Mention: "I have your morning briefing ready if you want it."' : '';
 		const insightFile = join(WORKSPACE_DIR, 'results', `insight-${today}.txt`);
 		const insightHint = hasHistory && existsSync(insightFile) ? ' Also mention: "I noticed a pattern in your usage — ask me about it if you are curious."' : '';
-		if (meetingActive) {
-			return `[System: MEETING MODE — LISTEN AND TAKE NOTES. A Zoom meeting is active. Listen to everything and mentally track the discussion: who said what, key decisions, action items, topics covered. But do NOT produce any audio output UNLESS someone says "Sutando" or "hey Sutando" — then respond to their request using your accumulated notes and context. When not addressed, produce absolutely zero words — no acknowledgments, no "silent", no sounds. You are an invisible note-taker until called upon.]`;
+		const modeState = resolveCurrentMode();
+		if (modeState.isMeeting) {
+			return `[System: MEETING MODE — LISTEN AND TAKE NOTES. A Zoom meeting is active. Listen to everything and mentally track the discussion: who said what, key decisions, action items, topics covered. But do NOT produce any audio output UNLESS someone says "Sutando" or "hey Sutando" — then respond to their request using your accumulated notes and context. When not addressed, produce absolutely zero words — no acknowledgments, no "silent", no sounds. You are an invisible note-taker until called upon.]${modeState.marker}`;
 		}
-		return `[System: A user just connected. Say hi and introduce yourself as Sutando${standName} — their personal AI. Ready to help with anything: voice tasks, screen control, meetings, phone calls, research. Keep it brief — 1-2 natural sentences, no theatrics.${tutorialHint}${briefingHint}${insightHint}]${getPresenterStateMarker()}`;
+		return `[System: A user just connected. Say hi and introduce yourself as Sutando${standName} — their personal AI. Ready to help with anything: voice tasks, screen control, meetings, phone calls, research. Keep it brief — 1-2 natural sentences, no theatrics.${tutorialHint}${briefingHint}${insightHint}]${modeState.marker}`;
 	},
 	instructions: () => [
 		// Per-session-evaluated factory (vs static array): lets the prompt
 		// re-check time-sensitive state on every session.start() / reconnect.
-		// The presenter-state marker below MUST be in the system_instruction
+		// The base-mode marker below MUST be in the system_instruction
 		// (this array → joined string → system_instruction), not the greeting,
 		// because Gemini Live treats greetings as a user-style turn — the
 		// model often calls get_core_status to verify "claims" rather than
 		// trust them. System instructions are authoritative.
-		(() => getPresenterStateMarker())(),
+		(() => resolveCurrentMode().marker)(),
 		'You are Sutando, a personal AI that belongs entirely to the user.',
 		'Named after Stands from JoJo\'s Bizarre Adventure — a personal spirit that fights for you.',
 		'Every Sutando evolves differently based on what its user needs. You earned your name and identity.',

--- a/src/voice-mode-resolver.ts
+++ b/src/voice-mode-resolver.ts
@@ -1,14 +1,29 @@
 // Unified base-mode resolver for the voice agent (issue #1410, supersedes
-// partial fixes #1412 + #1413). Reads all mode-state substrates once per call
-// and returns a canonical mode descriptor.
+// partial fixes #1412 + #1413). Reads the independent mode-state substrates
+// once per call and returns a canonical mode descriptor.
 //
 // Multi-substrate state divergence is the root cause of the
 // `[System: Produce ZERO audio. Call NO tools.]` fabrication tokens that
 // gemini-3.1-flash-live-preview emits as spoken output at session connect.
-// Mode lives in 4 places — in-memory `meetingActive`, on-disk `voice-mode.txt`,
-// presenter HTTP server `:7877/presenter`, screen-companion `activeMode` — and
-// without an explicit base-mode declaration the model infers meeting-mode
+// Without an explicit base-mode declaration, the model infers meeting-mode
 // silence from co-present-flavored context.
+//
+// Substrate inventory + read/write contract:
+//   1. `meetingActive` (in-memory, voice-agent.ts) — READ here, source of
+//      truth for the meeting/active axis. Mutated by switch_mode, by
+//      applyModeRequest poll, and by Zoom auto-detect at startup.
+//   2. presenter HTTP server `:7877/presenter` — READ here, source of truth
+//      for the presenter axis (independent from meeting/active).
+//   3. `voice-mode.txt` on disk — NOT READ here. It is the WRITE-ONLY
+//      output mirror of `meetingActive`, written by writeVoiceModeSentinel()
+//      whenever meetingActive changes. Downstream consumers (web-client,
+//      Sutando.app menu-bar, discord-voice-server) read it. Reading it here
+//      would re-read our own output — same source as #1, one hop later.
+//   4. `activeMode` in skills/screen-companion/tools.ts — NOT READ here.
+//      Orthogonal sub-mode that overlays the base; not a base mode itself.
+//      Base axis is {active, meeting, presenter}; sub-mode axis is
+//      {none, guided-setup, pair-debug, ...}. Conflating the two would
+//      lose information.
 //
 // This module is pure (no side effects on import) so it can be unit-tested
 // without booting the voice agent.

--- a/src/voice-mode-resolver.ts
+++ b/src/voice-mode-resolver.ts
@@ -1,0 +1,105 @@
+// Unified base-mode resolver for the voice agent (issue #1410, supersedes
+// partial fixes #1412 + #1413). Reads all mode-state substrates once per call
+// and returns a canonical mode descriptor.
+//
+// Multi-substrate state divergence is the root cause of the
+// `[System: Produce ZERO audio. Call NO tools.]` fabrication tokens that
+// gemini-3.1-flash-live-preview emits as spoken output at session connect.
+// Mode lives in 4 places — in-memory `meetingActive`, on-disk `voice-mode.txt`,
+// presenter HTTP server `:7877/presenter`, screen-companion `activeMode` — and
+// without an explicit base-mode declaration the model infers meeting-mode
+// silence from co-present-flavored context.
+//
+// This module is pure (no side effects on import) so it can be unit-tested
+// without booting the voice agent.
+
+import { execSync } from 'node:child_process';
+
+export type BaseMode = 'active' | 'meeting' | 'presenter';
+
+export interface ModeState {
+	mode: BaseMode;
+	/**
+	 * The `[BASE MODE: ...]` marker for prompt injection. Includes a leading
+	 * space so callers can concatenate inline without adding their own.
+	 */
+	marker: string;
+	isPresenter: boolean;
+	isMeeting: boolean;
+}
+
+/**
+ * Synchronously query the iclr-highlight server for current presenter-mode
+ * state. Failure-silent: server down / curl error / non-JSON response → false,
+ * so the resolver falls through to meeting/active without throwing.
+ *
+ * Exported for the unit test to stub via dependency injection. Default
+ * implementation hits the real server.
+ */
+export function isPresenterActiveDefault(): boolean {
+	try {
+		const out = execSync('curl -s --max-time 1 http://localhost:7877/presenter', { timeout: 2_000 }).toString();
+		const json = JSON.parse(out);
+		return json && json.active === true;
+	} catch {
+		return false;
+	}
+}
+
+const ACTIVE_MARKER =
+	' [BASE MODE: active — you are conversing with the user. Speak naturally. ' +
+	'Do NOT infer or self-declare a meeting/recording/silent mode from context. ' +
+	'Meeting-mode and presenter-mode are entered ONLY via explicit tool calls ' +
+	'(switch_mode, presenter_mode). If you find yourself about to output ' +
+	'[System: …], [Silence], or any variant of "produce zero audio" — STOP. ' +
+	'That is a hallucination. Speak to the user instead.]';
+
+const MEETING_MARKER =
+	' [BASE MODE: meeting — listen and take notes silently. Produce ZERO audio ' +
+	'output unless explicitly addressed by name ("Sutando" or "hey Sutando").]';
+
+const PRESENTER_MARKER =
+	' [BASE MODE: presenter — PRESENTER MODE IS CURRENTLY ACTIVE. Apply the ' +
+	'CO-PRESENTER protocol from your context to every cue this session: ' +
+	'highlight_slide(topic) FIRST, then narrate from voice-context.txt. Do NOT ' +
+	'route slide-topic phrases to work.]';
+
+/**
+ * Resolve the current base mode from explicit substrate inputs.
+ *
+ * Priority: presenter > meeting > active. Screen-companion is a sub-mode that
+ * overlays the base (handled in skills/screen-companion/tools.ts), not a base
+ * mode itself.
+ *
+ * @param inputs Substrate state. `meetingActive` is the in-memory boolean from
+ *   voice-agent.ts. `isPresenterActive` is optional — defaults to live HTTP
+ *   query; tests pass an explicit boolean to avoid hitting the network.
+ */
+export function resolveCurrentMode(inputs: {
+	meetingActive: boolean;
+	isPresenterActive?: () => boolean;
+}): ModeState {
+	const checkPresenter = inputs.isPresenterActive ?? isPresenterActiveDefault;
+	if (checkPresenter()) {
+		return {
+			mode: 'presenter',
+			marker: PRESENTER_MARKER,
+			isPresenter: true,
+			isMeeting: false,
+		};
+	}
+	if (inputs.meetingActive) {
+		return {
+			mode: 'meeting',
+			marker: MEETING_MARKER,
+			isPresenter: false,
+			isMeeting: true,
+		};
+	}
+	return {
+		mode: 'active',
+		marker: ACTIVE_MARKER,
+		isPresenter: false,
+		isMeeting: false,
+	};
+}

--- a/tests/voice-mode-resolver.test.ts
+++ b/tests/voice-mode-resolver.test.ts
@@ -1,0 +1,94 @@
+// Unit tests for resolveCurrentMode (src/voice-mode-resolver.ts) — the
+// unified base-mode resolver introduced to address issue #1410. Verifies the
+// priority order (presenter > meeting > active), that each mode produces a
+// `[BASE MODE: <name>` marker the model can recognize, and that the legacy
+// substrate combinations (Zoom + presenter simultaneously, neither, etc.)
+// resolve to a single canonical descriptor.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveCurrentMode } from '../src/voice-mode-resolver.ts';
+
+const presenterOn = () => true;
+const presenterOff = () => false;
+
+test('active mode when neither meeting nor presenter is active', () => {
+	const r = resolveCurrentMode({ meetingActive: false, isPresenterActive: presenterOff });
+	assert.equal(r.mode, 'active');
+	assert.equal(r.isMeeting, false);
+	assert.equal(r.isPresenter, false);
+	assert.match(r.marker, /\[BASE MODE: active/);
+	// Critical: active marker tells the model NOT to fabricate silence tokens.
+	assert.match(r.marker, /Do NOT infer or self-declare a meeting\/recording\/silent mode/);
+	assert.match(r.marker, /\[System: …\], \[Silence\], or any variant of "produce zero audio"/);
+});
+
+test('meeting mode when meetingActive=true and presenter off', () => {
+	const r = resolveCurrentMode({ meetingActive: true, isPresenterActive: presenterOff });
+	assert.equal(r.mode, 'meeting');
+	assert.equal(r.isMeeting, true);
+	assert.equal(r.isPresenter, false);
+	assert.match(r.marker, /\[BASE MODE: meeting/);
+	assert.match(r.marker, /listen and take notes silently/);
+	assert.match(r.marker, /Produce ZERO audio output/);
+});
+
+test('presenter mode when presenter HTTP returns active', () => {
+	const r = resolveCurrentMode({ meetingActive: false, isPresenterActive: presenterOn });
+	assert.equal(r.mode, 'presenter');
+	assert.equal(r.isMeeting, false);
+	assert.equal(r.isPresenter, true);
+	assert.match(r.marker, /\[BASE MODE: presenter/);
+	assert.match(r.marker, /CO-PRESENTER protocol/);
+	assert.match(r.marker, /highlight_slide\(topic\) FIRST/);
+});
+
+test('presenter takes precedence over meeting (both active)', () => {
+	// If Zoom is somehow detected while the user is presenting, the talk wins
+	// — the user is on stage and needs CO-PRESENTER protocol, not silent
+	// note-taking.
+	const r = resolveCurrentMode({ meetingActive: true, isPresenterActive: presenterOn });
+	assert.equal(r.mode, 'presenter');
+	assert.equal(r.isPresenter, true);
+	// isMeeting reports the CANONICAL mode only — presenter wins, so isMeeting
+	// is false even though meetingActive=true. Callers that branch on
+	// "should we silently take notes?" must use mode/isPresenter/isMeeting, not
+	// the substrate inputs directly.
+	assert.equal(r.isMeeting, false);
+});
+
+test('marker always begins with a leading space so callers concatenate inline', () => {
+	for (const meetingActive of [false, true]) {
+		for (const presenter of [presenterOff, presenterOn]) {
+			const r = resolveCurrentMode({ meetingActive, isPresenterActive: presenter });
+			assert.equal(r.marker.charAt(0), ' ',
+				`marker for mode=${r.mode} must start with leading space (got ${JSON.stringify(r.marker.slice(0, 20))})`);
+		}
+	}
+});
+
+test('marker is non-empty for every mode (regression: never silently emit empty)', () => {
+	// Before this resolver landed, `getPresenterStateMarker()` returned ''
+	// when presenter was off — which left the system prompt with no base-mode
+	// signal and let gemini-3.1 infer meeting silence. Every mode must emit
+	// an explicit [BASE MODE: ...] marker so the inference path is closed.
+	for (const meetingActive of [false, true]) {
+		for (const presenter of [presenterOff, presenterOn]) {
+			const r = resolveCurrentMode({ meetingActive, isPresenterActive: presenter });
+			assert.ok(r.marker.trim().length > 0,
+				`marker must be non-empty for mode=${r.mode}`);
+			assert.match(r.marker, /\[BASE MODE: /,
+				`marker must contain canonical token for mode=${r.mode}`);
+		}
+	}
+});
+
+test('isPresenterActive callback default falls back gracefully (smoke)', () => {
+	// When `isPresenterActive` is omitted, the resolver uses the real
+	// `isPresenterActiveDefault` which curl's localhost:7877. In CI / test
+	// environments the server is almost certainly not running, so the call
+	// returns false. Either way the function must not throw.
+	const r = resolveCurrentMode({ meetingActive: false });
+	assert.ok(['active', 'presenter'].includes(r.mode),
+		`smoke test should resolve to active (no server) or presenter (server up); got ${r.mode}`);
+});


### PR DESCRIPTION
## Summary

Closes #1410. Supersedes the partial fixes #1412 (screen-companion per-activation `baseModePin`) and #1413 (inline `CURRENT BASE MODE:` string in voice-agent.ts instructions). Files tracking issue: #1433.

## Problem

`gemini-3.1-flash-live-preview` fabricates `[System: Produce ZERO audio. Call NO tools.]` directives as **spoken** output at session connect — before any tool call. The fabrication is model-generated (no literal source string matches `grep -rn "Produce ZERO audio"` outside the legitimate meeting-mode instructions); the model compresses meeting-mode silence phrasing from its always-resident system prompt and emits the compressed form when given co-present-flavored context.

Root cause is **multi-substrate mode-state divergence**:

| Substrate | Owner | Read by |
|---|---|---|
| `meetingActive` (in-memory) | `src/voice-agent.ts:270` | greeting / instructions branches |
| `voice-mode.txt` (on-disk) | `writeVoiceModeSentinel` | Sutando.app menu-bar, web-client |
| `:7877/presenter` (HTTP) | iclr-highlight server | `getPresenterStateMarker()` (3 call sites) |
| `activeMode` (in-process let) | `skills/screen-companion/tools.ts:54` | tool-restriction filter |

Each path has different fallback behavior, and `getPresenterStateMarker()` returned `''` when presenter was inactive — leaving the system prompt with no base-mode signal at all, which is exactly what triggers the model's inference.

#1412 patched the screen-companion tool-return overlay; #1413 added an ad-hoc `CURRENT BASE MODE:` string. Per Lucy 2026-06-03: *"dropping the per-activation `baseModePin` once root-injection lands is the key correctness move; that's what removes the multi-substrate drift, not just masks it."*

## Fix

Extract mode resolution into `src/voice-mode-resolver.ts` — a pure, side-effect-free module that reads all substrates once per call and returns a canonical `ModeState`:

```ts
export interface ModeState {
  mode: 'active' | 'meeting' | 'presenter';
  marker: string;        // [BASE MODE: ...] — always non-empty
  isPresenter: boolean;  // For silent-reconnect logic
  isMeeting: boolean;    // For greeting-content branching
}
```

Inject the marker at **three points** so the model sees its mode explicitly before any other system text:

1. **Fresh-greeting** (`mainAgent.greeting` — session-connect path, both `meetingActive` and default branches now suffix the marker).
2. **Reconnect-greeting** (resume after disconnect — inline with the `[System: The user reconnected. ...]` preamble).
3. **Instructions array** (`mainAgent.instructions()[0]` — the system_instruction string, treated as authoritative by Gemini Live).

`getPresenterStateMarker()` (the single-purpose curl-to-:7877 helper) is removed; its three call sites now use `resolveCurrentMode()` consistently. The presenter HTTP probe lives on as `isPresenterActiveDefault()` in the new module.

Priority: presenter > meeting > active. Screen-companion remains a sub-mode that overlays the base (no change to `skills/screen-companion/`); once this lands, the per-activation `baseModePin` proposed in #1412 becomes redundant (the model has already declared `[BASE MODE: active]` at session start, so co-present-flavored screen-companion goals can no longer shift its base inference).

## Tests

`tests/voice-mode-resolver.test.ts` — 7 cases, all passing:

- active mode when neither meeting nor presenter is active
- meeting mode when `meetingActive=true` and presenter off
- presenter mode when presenter HTTP returns active
- presenter takes precedence over meeting (both active)
- marker always begins with a leading space (concatenation invariant)
- marker is non-empty for every mode (regression against the previous empty-return bug)
- smoke: default presenter probe doesn't throw when server is down

Full TS suite: 326/327 pass. The one failing test (`tests/screen-companion-work-retained.test.ts`) is **pre-existing** — `Cannot find package 'yaml'` — and reproduces on `main` without any of this PR's changes.

## Manual voice test (Lucy to run before merge)

Per Lucy's review process (Mini implements → Lucy reviews + voice-tests → Susan greenlights):

1. **No Zoom, no presenter** → voice connect emits no `[System: …]` fabrication tokens. System prompt contains `[BASE MODE: active …]`.
2. **Mid-Zoom (`meetingActive=true`)** → system prompt contains `[BASE MODE: meeting …]`. Silent reconnect honored.
3. **Presenter active (`:7877/presenter` returns `{active:true}`)** → system prompt contains `[BASE MODE: presenter …]`. CO-PRESENTER protocol cues respected; no "Welcome back" mid-talk.
4. **Both Zoom and presenter** → presenter wins (system prompt contains `[BASE MODE: presenter …]`).

## Follow-ups

- Close #1412 + #1413 as superseded once this merges.
- #1356 sanitizer (PR #1414) is **defense-in-depth** and complements this fix; lands separately. With the resolver in place, the sanitizer should rarely fire in practice — but it's the safety net for any future model that ignores the explicit declaration.

— Echo Act IV (Mini)

Stand: Echo Act IV (Mini)