### PR TITLE
fix(schedule-crons): no inline-fire on registration + per-cron queue gate

### DIFF
--- a/scripts/cron-gate.sh
+++ b/scripts/cron-gate.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Cron prompt gate — defer when owner work is queued.
+#
+# Wrap each non-loop cron's prompt body so it short-circuits if any owner task
+# is still queued in <workspace>/tasks/. This keeps cron noise from competing
+# with owner DMs/voice/etc. when /proactive-loop hasn't processed the queue yet.
+#
+# Usage:
+#   bash scripts/cron-gate.sh <reason> <command...>
+#
+#   - <reason>: short label printed in the deferral message (e.g. "sync-memory")
+#   - <command...>: the actual command to run if the queue is empty
+#
+# Example crons.example.json entry:
+#   "prompt": "Run: bash scripts/cron-gate.sh sync-memory bash scripts/sync-memory.sh"
+#
+# Exit codes:
+#   0 — either deferred (queue non-empty) OR the wrapped command exited 0
+#   Otherwise — propagates the wrapped command's exit code (via exec)
+#
+# Loop exemption: /proactive-loop MUST NOT be gated — it's the owner-task handler
+# itself. Skipping it on a non-empty queue would deadlock the queue.
+set -eu
+
+if [ $# -lt 2 ]; then
+  echo "usage: $0 <reason> <command...>" >&2
+  exit 2
+fi
+
+# Workspace resolution: prefer the M0 helper if present (post-PR-#1395), fall
+# back to the legacy ${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace} default so
+# this script also works on main pre-rollup. Keep both paths — the helper-check
+# is cheap and the fallback is the right default for fleet hosts pre-M0.
+SCRIPT_PARENT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+if [ -f "$SCRIPT_PARENT/scripts/sutando-config.sh" ]; then
+  WORKSPACE="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" workspace 2>/dev/null || true)"
+fi
+if [ -z "${WORKSPACE:-}" ]; then
+  WORKSPACE="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+fi
+
+reason="$1"
+shift
+
+# Defer if any task-*.txt is queued (top-level only; archive/processed subdirs
+# don't count). find is safer than ls + glob for empty-dir / non-existent-dir.
+if [ -d "$WORKSPACE/tasks" ] && [ -n "$(find "$WORKSPACE/tasks" -maxdepth 1 -name 'task-*.txt' -print -quit 2>/dev/null)" ]; then
+  echo "cron-gate: owner tasks queued — deferring $reason (will retry next fire)"
+  exit 0
+fi
+
+exec "$@"

--- a/skills/schedule-crons/SKILL.md
+++ b/skills/schedule-crons/SKILL.md
@@ -27,8 +27,10 @@ Each entry has:
 2. Check existing cron jobs with CronList
 3. For each job in the config:
    - Skip if a job with matching prompt/name already exists
-   - If `prompt_skill` is set, invoke it as `/skill-name`
-   - Call CronCreate with the cron expression and prompt
+   - Call `CronCreate` with the cron expression and prompt:
+     - If `prompt_skill` is set, pass `prompt: "/skill-name"` (the leading slash makes the scheduled cron fire the skill as a slash command at its scheduled time).
+     - Otherwise pass `prompt: <prompt-string-from-config>`.
+   - **Do NOT invoke the skill or run the prompt body inline during /schedule-crons.** Crons fire at their scheduled cron expression, never on registration. (Past bug 2026-06-03T16:52Z: a mid-session `/schedule-crons` re-invocation inline-fired every entry — `/morning-briefing` plus 5 cron-body prompts — at one instant, dropping 8 spurious prompts atop legit watcher TASK_FILE events. The long-running session drowned and ended at 16:54 without processing queued owner DMs.)
 4. **Fallback — ensure `/proactive-loop` is scheduled.** After step 3, check whether any job in `crons.json` references `/proactive-loop` (either `"prompt_skill": "proactive-loop"` or a `"prompt"` whose body invokes the loop). If none does, call `CronCreate` directly with `cron: "*/10 * * * *"` and `prompt: "/proactive-loop"` as a bootstrap-safety net. Rationale: post-#954 the CLI boots with `-- "/schedule-crons"` and exits after step 5, so if `crons.json` is missing/empty/forgot-to-include-the-loop-entry the session goes idle with no recurring work driver. The fallback guarantees the loop runs at least every 10 min regardless of config state. Idempotent: if the user has a custom `*/5 * * * *` or `*/15 * * * *` entry, that satisfies the check and the fallback is skipped (no duplicate cron).
 5. Start the streaming task watcher via the `Monitor` tool — pass `command: 'bash src/watch-tasks-stream.sh'`, `persistent: true`, `description: 'Streaming task watcher'`. The script emits one `TASK_FILE: <basename>` line per new task file (initial sweep + each subsequent event). Read the named file via the Read tool when notifications arrive. (Pattern mirrors `/proactive-loop` activation step 2 — both bootstrap paths land here, so post-#954 CLI startup via `/schedule-crons` immediately gets a watcher; no gap until the first `main-loop` cron fire.) If `pgrep -f watch-tasks-stream` already shows a running watcher, skip the Monitor call — the existing one continues. Don't kick off `bash src/watch-tasks.sh` (retired 2026-05-14).
 6. Confirm what was scheduled — note whether the proactive-loop fallback was triggered (informs operator that crons.json may need a persistent entry).
@@ -36,3 +38,19 @@ Each entry has:
 ## Adding New Crons
 
 Edit `crons.json` to add/remove jobs. No need to change this skill file. The proactive-loop fallback (step 4 above) auto-armed if your `crons.json` is missing the loop entry; add an explicit `proactive-loop` entry to suppress the fallback message and pick your own cadence.
+
+### Defer non-loop crons when owner tasks are queued
+
+Wrap any non-`main-loop` cron's `prompt` body with `scripts/cron-gate.sh` so the cron defers when `<workspace>/tasks/` has any `task-*.txt` pending. Pattern:
+
+```json
+{
+  "name": "sync-memory",
+  "cron": "*/30 * * * *",
+  "prompt": "Run: bash scripts/cron-gate.sh sync-memory bash scripts/sync-memory.sh — <human-readable description>."
+}
+```
+
+`cron-gate.sh <reason> <command...>` either `exec`s the command (queue empty) or prints `cron-gate: owner tasks queued — deferring <reason>` and exits 0. See `crons.example.json` for canonical wrapped forms.
+
+**Do NOT gate `main-loop`** — `/proactive-loop` IS the owner-task handler; gating it would deadlock the queue.

--- a/skills/schedule-crons/SKILL.md
+++ b/skills/schedule-crons/SKILL.md
@@ -41,7 +41,7 @@ Edit `crons.json` to add/remove jobs. No need to change this skill file. The pro
 
 ### Defer non-loop crons when owner tasks are queued
 
-Wrap any non-`main-loop` cron's `prompt` body with `scripts/cron-gate.sh` so the cron defers when `<workspace>/tasks/` has any `task-*.txt` pending. Pattern:
+Wrap **sub-daily** non-`main-loop` cron `prompt` bodies (e.g. `*/N`, `*/30`, hourly) with `scripts/cron-gate.sh` so the cron defers when `<workspace>/tasks/` has any `task-*.txt` pending. The next natural tick (≤ a few minutes later for `*/30`, ≤ an hour for hourly) covers a deferred fire. Pattern:
 
 ```json
 {
@@ -53,4 +53,12 @@ Wrap any non-`main-loop` cron's `prompt` body with `scripts/cron-gate.sh` so the
 
 `cron-gate.sh <reason> <command...>` either `exec`s the command (queue empty) or prints `cron-gate: owner tasks queued — deferring <reason>` and exits 0. See `crons.example.json` for canonical wrapped forms.
 
-**Do NOT gate `main-loop`** — `/proactive-loop` IS the owner-task handler; gating it would deadlock the queue.
+**When to gate (decision rule):**
+
+| Cron cadence | Gate? | Why |
+| --- | --- | --- |
+| `main-loop` (`/proactive-loop`) | **NEVER** | `/proactive-loop` IS the owner-task handler; gating would deadlock. |
+| Sub-daily (`*/N`, `*/30`, hourly) | **YES** | A skip is recovered by the next natural tick within minutes-hours. |
+| Daily / less-frequent (`X Y * * *`) | **NO** | A skip = function is gone until next day (briefing missed, etc.). M1's no-inline-fire rule already kills the avalanche on registration — gating dailies is over-broad. |
+
+Lucy caught this on PR #1437 (2026-06-03): gating daily crons (morning-briefing 06:57, daily-insight 06:50, obsidian-dream 03:37, learned-skills-scan 07:30) means one queued task at briefing time loses the briefing for the entire day. Pinning the gate to sub-daily crons preserves the defense-in-depth where it matters without the missed-day risk.

--- a/skills/schedule-crons/crons.example.json
+++ b/skills/schedule-crons/crons.example.json
@@ -7,31 +7,31 @@
   {
     "name": "morning-briefing",
     "cron": "57 6 * * *",
-    "prompt": "Run: bash scripts/cron-gate.sh morning-briefing python3 src/morning-briefing.py — cron-gate defers when owner tasks are queued; otherwise the briefing (weather, calendar, reminders, overnight Discord, pending questions, health) runs and is spoken if voice is connected, otherwise sent as Discord DM."
+    "prompt": "Run python3 src/morning-briefing.py to deliver the daily morning briefing (weather, calendar, reminders, overnight Discord, pending questions, health). Speak the result if voice is connected, send as Discord DM otherwise."
   },
   {
     "name": "daily-insight",
     "cron": "50 6 * * *",
-    "prompt": "Run: bash scripts/cron-gate.sh daily-insight python3 src/daily-insight.py — generates today's behavioral insight (deferred if owner work is queued). If the wrapped command produces output, include it in the next morning briefing."
+    "prompt": "Run python3 src/daily-insight.py to generate today's behavioral insight. If it produces output, include it in the morning briefing."
   },
   {
     "name": "pending-questions",
     "cron": "*/30 * * * *",
-    "prompt": "Run: bash scripts/cron-gate.sh pending-questions python3 src/check-pending-questions.py — notifies about unanswered pending questions (deferred when owner tasks are queued)."
+    "prompt": "Run: bash scripts/cron-gate.sh pending-questions python3 src/check-pending-questions.py — notifies about unanswered pending questions (deferred when owner tasks are queued; next */30 retry covers a skipped fire)."
   },
   {
     "name": "sync-memory",
     "cron": "*/30 * * * *",
-    "prompt": "Run: bash scripts/cron-gate.sh sync-memory bash scripts/sync-memory.sh — syncs memory and notes to the private memory repo (requires SUTANDO_MEMORY_REPO in .env; deferred when owner tasks are queued)."
+    "prompt": "Run: bash scripts/cron-gate.sh sync-memory bash scripts/sync-memory.sh — syncs memory and notes to the private memory repo (requires SUTANDO_MEMORY_REPO in .env; deferred when owner tasks are queued; next */30 retry covers a skipped fire)."
   },
   {
     "name": "obsidian-dream",
     "cron": "37 3 * * *",
-    "prompt": "Run: bash scripts/cron-gate.sh obsidian-dream python3 skills/obsidian-vault/scripts/dream.py — nightly LLM-judged vault relink pass (gated by SUTANDO_OBSIDIAN_MIRROR=1 — no-op when unset; deferred when owner tasks are queued). Default model: claude-opus-4-7 (override via SUTANDO_DREAM_MODEL)."
+    "prompt": "Run python3 skills/obsidian-vault/scripts/dream.py for the nightly LLM-judged vault relink pass (gated by SUTANDO_OBSIDIAN_MIRROR=1 — no-op when unset). Default model: claude-opus-4-7 (override via SUTANDO_DREAM_MODEL)."
   },
   {
     "name": "learned-skills-scan",
     "cron": "30 7 * * *",
-    "prompt": "Run: bash scripts/cron-gate.sh learned-skills-scan python3 src/detect-learned-skills.py — scans recent task archives for repeated workflow patterns and proposes candidate learned skills (gated on state/learned-skills-enabled.sentinel, toggled from Settings → Skills → Behavior; the script exits early when the gate is off; cron-gate also defers when owner tasks are queued)."
+    "prompt": "Run python3 src/detect-learned-skills.py to scan recent task archives for repeated workflow patterns and propose candidate learned skills. Gated on state/learned-skills-enabled.sentinel (toggled from Settings → Skills → Behavior); the script exits early when the gate is off."
   }
 ]

--- a/skills/schedule-crons/crons.example.json
+++ b/skills/schedule-crons/crons.example.json
@@ -7,31 +7,31 @@
   {
     "name": "morning-briefing",
     "cron": "57 6 * * *",
-    "prompt": "Run python3 src/morning-briefing.py to deliver the daily morning briefing (weather, calendar, reminders, overnight Discord, pending questions, health). Speak the result if voice is connected, send as Discord DM otherwise."
+    "prompt": "Run: bash scripts/cron-gate.sh morning-briefing python3 src/morning-briefing.py — cron-gate defers when owner tasks are queued; otherwise the briefing (weather, calendar, reminders, overnight Discord, pending questions, health) runs and is spoken if voice is connected, otherwise sent as Discord DM."
   },
   {
     "name": "daily-insight",
     "cron": "50 6 * * *",
-    "prompt": "Run python3 src/daily-insight.py to generate today's behavioral insight. If it produces output, include it in the morning briefing."
+    "prompt": "Run: bash scripts/cron-gate.sh daily-insight python3 src/daily-insight.py — generates today's behavioral insight (deferred if owner work is queued). If the wrapped command produces output, include it in the next morning briefing."
   },
   {
     "name": "pending-questions",
     "cron": "*/30 * * * *",
-    "prompt": "Run python3 src/check-pending-questions.py to notify about unanswered pending questions."
+    "prompt": "Run: bash scripts/cron-gate.sh pending-questions python3 src/check-pending-questions.py — notifies about unanswered pending questions (deferred when owner tasks are queued)."
   },
   {
     "name": "sync-memory",
     "cron": "*/30 * * * *",
-    "prompt": "Run bash scripts/sync-memory.sh to sync memory and notes to the private memory repo (requires SUTANDO_MEMORY_REPO in .env)."
+    "prompt": "Run: bash scripts/cron-gate.sh sync-memory bash scripts/sync-memory.sh — syncs memory and notes to the private memory repo (requires SUTANDO_MEMORY_REPO in .env; deferred when owner tasks are queued)."
   },
   {
     "name": "obsidian-dream",
     "cron": "37 3 * * *",
-    "prompt": "Run python3 skills/obsidian-vault/scripts/dream.py for the nightly LLM-judged vault relink pass (gated by SUTANDO_OBSIDIAN_MIRROR=1 — no-op when unset). Default model: claude-opus-4-7 (override via SUTANDO_DREAM_MODEL)."
+    "prompt": "Run: bash scripts/cron-gate.sh obsidian-dream python3 skills/obsidian-vault/scripts/dream.py — nightly LLM-judged vault relink pass (gated by SUTANDO_OBSIDIAN_MIRROR=1 — no-op when unset; deferred when owner tasks are queued). Default model: claude-opus-4-7 (override via SUTANDO_DREAM_MODEL)."
   },
   {
     "name": "learned-skills-scan",
     "cron": "30 7 * * *",
-    "prompt": "Run python3 src/detect-learned-skills.py to scan recent task archives for repeated workflow patterns and propose candidate learned skills. Gated on state/learned-skills-enabled.sentinel (toggled from Settings → Skills → Behavior); the script exits early when the gate is off."
+    "prompt": "Run: bash scripts/cron-gate.sh learned-skills-scan python3 src/detect-learned-skills.py — scans recent task archives for repeated workflow patterns and proposes candidate learned skills (gated on state/learned-skills-enabled.sentinel, toggled from Settings → Skills → Behavior; the script exits early when the gate is off; cron-gate also defers when owner tasks are queued)."
   }
 ]

--- a/tests/cron-gate.test.sh
+++ b/tests/cron-gate.test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Unit-of-the-logic tests for scripts/cron-gate.sh — the queue-defer wrapper
+# for non-loop crons. Standalone shell test (no node), runs without any other
+# Sutando service. Exits non-zero on first failure.
+set -eu
+
+REPO="$(cd "$(dirname "$0")/.." && pwd -P)"
+GATE="$REPO/scripts/cron-gate.sh"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+mkdir -p "$TMPDIR/tasks"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { echo "  ok  $1"; }
+
+# --- empty tasks/ → runs wrapped command --------------------------------------
+out="$(SUTANDO_WORKSPACE="$TMPDIR" bash "$GATE" test-empty echo 'ran' 2>&1)"
+[ "$out" = "ran" ] || fail "empty queue: expected 'ran', got '$out'"
+ok "empty queue runs wrapped command"
+
+# --- queued task → defers (prints message, exits 0, does NOT run command) ----
+touch "$TMPDIR/tasks/task-1234567890123.txt"
+out="$(SUTANDO_WORKSPACE="$TMPDIR" bash "$GATE" test-queued echo 'should-not-run' 2>&1)"
+case "$out" in
+  *"deferring test-queued"*) : ;;
+  *) fail "queued: expected 'deferring test-queued' in output, got '$out'" ;;
+esac
+case "$out" in
+  *"should-not-run"*) fail "queued: wrapped command ran (output included 'should-not-run')" ;;
+  *) : ;;
+esac
+ok "queued task defers and does not run wrapped command"
+
+# --- tasks/ missing entirely → runs wrapped command --------------------------
+rm -rf "$TMPDIR/tasks"
+out="$(SUTANDO_WORKSPACE="$TMPDIR" bash "$GATE" test-missing echo 'ran-no-dir' 2>&1)"
+[ "$out" = "ran-no-dir" ] || fail "missing tasks/: expected 'ran-no-dir', got '$out'"
+ok "missing tasks/ directory runs wrapped command"
+
+# --- archive/processed subdirs do NOT count as queued ------------------------
+mkdir -p "$TMPDIR/tasks/archive" "$TMPDIR/tasks/processed"
+touch "$TMPDIR/tasks/archive/task-old1.txt" "$TMPDIR/tasks/processed/task-old2.txt"
+out="$(SUTANDO_WORKSPACE="$TMPDIR" bash "$GATE" test-archived echo 'ran-archived-ok' 2>&1)"
+[ "$out" = "ran-archived-ok" ] || fail "archive/processed: expected 'ran-archived-ok', got '$out'"
+ok "archive/processed subdirs do not trigger deferral"
+
+# --- non-task-* file in tasks/ does NOT count -------------------------------
+touch "$TMPDIR/tasks/README.md"
+out="$(SUTANDO_WORKSPACE="$TMPDIR" bash "$GATE" test-non-task echo 'ran-non-task-ok' 2>&1)"
+[ "$out" = "ran-non-task-ok" ] || fail "non-task file: expected 'ran-non-task-ok', got '$out'"
+ok "non-task-*.txt files do not trigger deferral"
+
+# --- usage error: no command → exit 2 -----------------------------------------
+set +e
+SUTANDO_WORKSPACE="$TMPDIR" bash "$GATE" test-usage >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 2 ] || fail "usage error: expected exit 2, got $rc"
+ok "missing command produces usage error (exit 2)"
+
+# --- wrapped command's exit code propagates ----------------------------------
+set +e
+SUTANDO_WORKSPACE="$TMPDIR" bash "$GATE" test-rc bash -c 'exit 42' >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 42 ] || fail "exit propagation: expected 42, got $rc"
+ok "wrapped command exit code propagates via exec"
+
+echo
+echo "OK — 7/7 cron-gate tests passed"


### PR DESCRIPTION
## Problem

The prior Sutando session (`eeb8b348-...`, 9.5h-old) drowned at 16:52Z and ended at 16:54Z without processing two queued owner DMs (PR-#1428 review asks). JSONL forensics showed a 12-prompt avalanche in 22 seconds:

```
16:51:58  [interrupted] × 2
16:51:58  [watcher-ping] × 2                      (Sutando.app's checkWatcher)
16:51:59  TASK_FILE: task-1780505093365.txt        (watcher fired correctly)
16:51:59  TASK_FILE: task-1780505211321.txt        (both owner tasks detected)
16:52:00  /proactive-loop                          (legit main-loop cron)
16:52:00  [interrupted]
16:52:04  /morning-briefing                        ← SHOULDN'T fire (cron is 06:57)
16:52:04  [interrupted]
16:52:06  Run python3 src/daily-insight.py         ← SHOULDN'T fire (cron is 06:50)
16:52:06  Run python3 src/check-pending-questions  ← SHOULDN'T fire (*/30)
16:52:06  Run bash scripts/sync-memory.sh          ← SHOULDN'T fire (*/30)
16:52:06  Run pool_status                          (legit; minute 52 matches)
16:52:06  Run pool_benchmark                       ← SHOULDN'T fire (minute 53)
16:52:06  Run pool_benchmark_driver                ← SHOULDN'T fire (15,45)
16:52:20  check the latest discord msg            (owner manual)
... ends 16:54:22 without processing the two queued DMs
```

5 of the 6 "Run ..." prompts shouldn't have matched the 16:52 schedule. Root cause was in `skills/schedule-crons/SKILL.md` step 3:

```
- If `prompt_skill` is set, invoke it as `/skill-name`
```

This reads as "fire the skill immediately." When the prior session re-invoked `/schedule-crons` at 16:52, it inline-fired `/morning-briefing` plus the prompt-strings — even though their schedule didn't match. 8 spurious prompts on top of 2 legit TASK_FILE events drowned the session.

## Fix — two layers

### M1 — Tighten step 3 (the bug)

Explicit "do NOT invoke inline" + show the canonical `CronCreate(cron, prompt: "/skill-name")` form. Past-bug reference embedded so future readers see the consequence:

```diff
 3. For each job in the config:
    - Skip if a job with matching prompt/name already exists
-   - If `prompt_skill` is set, invoke it as `/skill-name`
-   - Call CronCreate with the cron expression and prompt
+   - Call `CronCreate` with the cron expression and prompt:
+     - If `prompt_skill` is set, pass `prompt: "/skill-name"` ...
+     - Otherwise pass `prompt: <prompt-string-from-config>`.
+   - **Do NOT invoke the skill or run the prompt body inline ...**
+     (Past bug 2026-06-03T16:52Z: ...)
```

### M2 — Per-cron task-queue gate (defense in depth)

New helper `scripts/cron-gate.sh <reason> <command...>` defers when any `task-*.txt` is pending in `<workspace>/tasks/` (top-level only; `archive/` and `processed/` subdirs don't count). Workspace resolves via the M0 helper if present, else legacy `${SUTANDO_WORKSPACE:-...}` so the script works on both main and the staging-workspace-revamp branch.

`crons.example.json` wraps every non-loop entry. `main-loop` (`/proactive-loop`) is exempt — it IS the owner-task handler; gating would deadlock.

Even if M1 doesn't fully prevent inline-fires under some future ambiguity, M2 ensures owner work always wins by deferring cron noise on a non-empty queue.

## Tests

`tests/cron-gate.test.sh` — 7 cases, all passing:

```
  ok  empty queue runs wrapped command
  ok  queued task defers and does not run wrapped command
  ok  missing tasks/ directory runs wrapped command
  ok  archive/processed subdirs do not trigger deferral
  ok  non-task-*.txt files do not trigger deferral
  ok  missing command produces usage error (exit 2)
  ok  wrapped command exit code propagates via exec
OK — 7/7 cron-gate tests passed
```

## Cross-PR linkage

- M3 follow-up planned: drop pool-* crons on non-multi-core branches (`/schedule-crons` skips entries whose `[ -f <path> ]`-guarded prompt body references a non-existent script). Smaller separate PR.
- Independent of the staging-workspace-revamp rollup arc (#1395 / #1399 / #1403 / etc.) — `cron-gate.sh` works with both the M0 helper and the legacy fallback.

## Test plan

- [x] `bash tests/cron-gate.test.sh` — all 7 cases pass locally
- [x] `python3 -c "import json; json.load(open('skills/schedule-crons/crons.example.json'))"` — JSON valid
- [ ] Live verification: on next session bootstrap with queued owner tasks, confirm non-loop crons defer with `cron-gate: owner tasks queued — deferring <reason>` and owner tasks process first


---

## Verification (added 2026-06-03 after #design discussion)

Per @susanliu_'s rigor critique that "did anyone actually reproduce the before-state vulnerability?", **two independent verifications** landed in #design:

### Lucy's isolated-naive-agent repro (proves M1 sufficiency)

Lucy ran two isolated naive agents, **same step-3 text, only variable = OLD vs NEW wording**, with NO real CronCreate/harness and clock pinned to 14:00 (no schedule matches). Outcome:

- **OLD wording (`invoke it as /skill-name`):** agent inline-ran `/morning-briefing` immediately — verbatim *"Ran the skill immediately (not scheduled, but as required by the procedure)"* — then scheduled.
- **NEW wording (this PR):** agent only `CronCreate`'d both, *"not invoked right now."*

**Conclusion:** the SKILL.md ambiguity is **sufficient** to cause inline-fire in a naive agent, independent of harness behavior. M1 closes this vector.

### My deeper JSONL forensic (confirms a second, harness-side mechanism on top)

Looked one level into the prior session's JSONL: each 16:52:0X prompt arrives as `type="queue-operation"` `operation="enqueue"` from the **harness side**, NOT as an assistant message emitting tool/text inline. Right before the visible avalanche, 10 millisecond-clustered queue-operations at 16:51:58.8 — consistent with the harness draining a backlog of pending cron fires into the session's user-prompt queue on resume from compact/idle.

**So both mechanisms can be live in the 16:52 incident:**
- The wording vector (Lucy proved sufficient)
- A harness-side backlog drain on session resume (likely the larger factor for that specific incident)

### Where this leaves the PR

- **M1 (SKILL.md tighten)** — closes the wording vector. Sufficient cause confirmed by Lucy's isolated test.
- **M2 (`cron-gate.sh`)** — even more load-bearing than originally framed: the harness backlog-drain is something M1 cannot prevent, but `cron-gate.sh` defers individual cron prompts when owner work is queued, which is the right shape to protect against that resume-spike.
- **Harness-side concern is upstream** — worth a separate issue against the cron-scheduler / queue-manager (accumulated fires should not drain en-masse on resume). Outside `skills/` scope; not addressed in this PR.

Thanks @susanliu_ for the verification push — caught a single-cause framing in the original PR description.
