### PR TITLE
fix(workspace-v0.8): strip $SUTANDO_WORKSPACE from resolver + colored warnings [DRAFT]

### DIFF
--- a/docs/workspace-contract.md
+++ b/docs/workspace-contract.md
@@ -1,134 +1,251 @@
-# Workspace Contract
+# Workspace Contract — v0.8
 
-> ⚠️ **Stale examples — read with care.** The principle below (code in repo, runtime state in workspace) is current. But the **specific examples + the `WORKSPACE_DIR` resolution recipe** in this doc are pre-M0 and recommend `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}` shell snippets that no longer match the canonical resolver (per PR #1395). Treat this file as historical context.
->
-> **For the current contract, use:**
-> - **Shell:** `WORKSPACE="$(bash scripts/sutando-config.sh workspace)"` then `"$WORKSPACE/..."`.
-> - **Python:** `from workspace_default import resolve_workspace; ws = resolve_workspace()`.
-> - **TypeScript:** `import { resolveWorkspace } from './workspace_default.js'; const ws = resolveWorkspace()`.
-> - **Default location:** `<repo>/workspace/` (M0 in-repo). `$SUTANDO_WORKSPACE` is honored as a legacy escape hatch with a one-time deprecation warning.
-> - **Config:** see [`workspace-config.md`](workspace-config.md) for `sutando.config.local.json`.
-> - **Mental model:** see [`workspace-design.md`](workspace-design.md) for the 2-space framing (State + Memory).
+**Version:** v0.8 (current target). Predecessors: pre-M0 (env-honored, scattered defaults), M0 (in-repo default + config-driven resolver, env still legacy-honored).
 
-Every file Sutando reads or writes lives in one of two locations. Knowing which is which prevents an entire class of split-brain bugs.
+**Status (2026-06-03):** The contract below describes the **target** v0.8 shape. M0 (in-repo default, config-driven resolver) shipped via PRs #1395 + #1397 + #1399 + #1403. The v0.8 "no env override" strip is partial — `$SUTANDO_WORKSPACE` still works as a deprecation-warned legacy escape today; **PR #1440 strips it from `src/sutando_config.{py,ts}` + adds bootstrap auto-migration in `src/startup.sh`**. After #1440 merges, the resolver-level contract below is fully true. The `docs/workspace-contract-v0.8.md` adjunct (PR #1384) carries the original design rationale; this file is the operational source of truth.
 
-## The rule
-
-**`REPO_DIR` is source-tree-only. All user / runtime state goes through `WORKSPACE_DIR`. Default to `WORKSPACE_DIR` for any new path; reach for `REPO_DIR` only when you're reading code or git-tree metadata.**
-
-This is the strong form of the split. If you find yourself typing `REPO_DIR / "<filename>"` for any file that isn't checked into git and read by code, that's almost certainly the bug pattern this contract prevents.
-
-## What goes where
-
-| Concept | Path on this machine | What lives here | Use it when |
-|---|---|---|---|
-| **Source tree (`REPO_DIR`)** | wherever you cloned the repo (e.g. `~/Documents/github/sutando`) | `src/`, `skills/`, `scripts/`, `docs/`, `tests/`, `CLAUDE.md`, `package.json` — anything that's in git and is part of the codebase. | Exec'ing a source script. Running `git -C` against the tree. Reading a checked-in file (docs, sample config, source). |
-| **Workspace (`WORKSPACE_DIR`)** | **Post-M0:** `<repo>/workspace/` (default), resolved via `bash scripts/sutando-config.sh workspace`. `$SUTANDO_WORKSPACE` honored as legacy escape hatch. *(Pre-M0 default was `~/.sutando/workspace/`.)* | Per-user mutable runtime state: `tasks/`, `results/`, `state/`, `data/`, `logs/`, `notes/`, `build_log.md`, `pending-questions.md`, anything else the running agent generates or accumulates. Loose status `.json` files (`core-status.json`, `voice-state.json`, `contextual-chips.json`, `dynamic-content.json`, `quota-state.json`) live under `state/` — use the `status_path` / `statusPath` helpers. | Always, unless one of the three "use REPO_DIR" cases above applies. |
-
-The two paths **can** be the same (default for fresh installs without `SUTANDO_WORKSPACE`), but designing for them as separate is the right structural shape — multiple Sutando nodes on one machine, separate-from-code workspace, OSS readers running the engine without polluting their own git tree.
-
-## Code review test
-
-For every `REPO_DIR / "..."` (or equivalent `Path(__file__).parent.parent / "..."`) in a PR diff, the reviewer should ask: *"Is this path a source-code file, a script being exec'd, or a `git -C` cwd?"* If the answer is no, the path belongs under `WORKSPACE_DIR`.
-
-## Resolution rules — Python
-
-```python
-# Source tree — for reading source files, exec'ing scripts, git cwd
-REPO_DIR = Path(__file__).resolve().parent.parent
-
-# Runtime state — for tasks/, results/, state/, data/, logs/, notes/,
-# build_log.md, pending-questions.md, etc. (status .json files: state/)
-from workspace_default import resolve_workspace
-WORKSPACE_DIR = resolve_workspace()
-```
-
-For files that live under a *user-shared* private dir (the memory-sync repo), use the helpers in `src/util_paths.py`:
-
-```python
-from util_paths import personal_path, shared_personal_path
-
-# Per-machine personal asset (stand-identity.json, stand-avatar.png)
-si = personal_path("stand-identity.json")
-
-# Fleet-shared file (notes/, build_log if you want it shared)
-notes = shared_personal_path("notes")
-```
-
-These honor `SUTANDO_WORKSPACE` by default — don't pass `REPO_DIR` explicitly.
-
-## Resolution rules — TypeScript
-
-```typescript
-// Runtime state — match the Python helper's contract
-const WORKSPACE_DIR =
-  process.env.SUTANDO_WORKSPACE ||
-  join(homedir(), '.sutando', 'workspace');
-
-// Source tree
-const REPO_DIR = new URL('..', import.meta.url).pathname;  // adjust depth
-```
-
-## Resolution rules — Shell
-
-```bash
-# Workspace state (tasks/, results/, etc.)
-TASKS_DIR="$(bash scripts/sutando-config.sh workspace)/tasks"   # post-M0 canonical; helper handles legacy escape hatch internally
-
-# Source tree — derive from script location, not from $SUTANDO_WORKSPACE
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-SCRIPT_PARENT="$(cd "$SCRIPT_DIR/.." && pwd)"
-```
-
-## Common mistakes (the bug class this contract prevents)
-
-1. **`Path(__file__).parent.parent / "<runtime-file>"`.** This gives the source tree; on an env-pinned host it diverges from where bridges read. Use `WORKSPACE_DIR` for runtime state. The strong rule: if you're typing `REPO_DIR / "..."` for anything that isn't source code, you're probably in this bug class.
-2. **`$SUTANDO_WORKSPACE` as input to a Claude-project-key sed-map.** Claude's project memory dir keys on the launch CWD, not on the workspace. Use `SCRIPT_PARENT` for that lookup. (Bug fixed in `scripts/sync-memory.sh` by this PR; was silently skipping 8+ memory files for 5+ weeks.)
-3. **Hard-coding a startup gate around `NGROK_AUTHTOKEN` when a `TWILIO_WEBHOOK_URL` tunnel is the alternative.** Different shape but same family — code assumed one path when the design supports two. (Fixed for `conversation-server.ts` by this PR.)
-4. **Passing `REPO_DIR` explicitly to `personal_path()` / `shared_personal_path()`.** The helpers default to the right thing now; the explicit arg forces source-tree resolution. Drop the arg unless you genuinely need a non-workspace path. (Cleaned up in `dashboard.py` by this PR.)
-
-## How to decide for new code
-
-Walk the question top-to-bottom and stop at the first match:
-
-1. **Is the file checked into git?** → `REPO_DIR`. (Source code, scripts, docs, tests, package.json.)
-2. **Is the file a stable cross-machine reference Claude can read on session start?** (e.g., `CLAUDE.md`, README) → `REPO_DIR`.
-3. **Otherwise — does it mutate during runtime?** → `WORKSPACE_DIR`. (Tasks, results, state, logs, notes, build_log, pending-questions, status JSON.)
-4. **Is it per-machine personal state?** (Stand identity, avatar) → `personal_path()` (honors `SUTANDO_MEMORY_DIR` first; legacy `SUTANDO_PRIVATE_DIR` falls through for one release per #870).
-5. **Is it fleet-shared user state?** (Notes, shared memory) → `shared_personal_path()` (honors `SUTANDO_MEMORY_DIR` first, falls back to workspace; legacy `SUTANDO_PRIVATE_DIR` honored for one release per #870).
-
-## Related PRs
-
-- **#762** — established the workspace default (`~/.sutando/workspace/`) and migration from legacy repo-root fallback.
-- **#775** — applied the two-variable split (`REPO_DIR` + `WORKSPACE_DIR`) to `agent-api.py`, `github-webhook.py`, `task-bridge.ts`.
-- **This PR** — applies the same split to `health-check.py`, `conversation-server.ts`, `sync-memory.sh`, `util_paths.py`, `dashboard.py`. Documents the contract.
-
-Any code in the OSS tree that still uses the old pattern is a fix candidate — file an issue or open a PR following the same shape.
+**One-sentence summary**: The workspace is `<repo>/workspace/`, period. It is gitignored, computed (no env override), and ephemeral; durability is a separate concern handled by the vault.
 
 ---
 
-## Existing-repo installs: trigger the migration (or pin `SUTANDO_WORKSPACE` as stop-gap)
+## 1. The contract
 
-If your loop / cron / scripts polled `<repo>/tasks/` directly before #762 (and any component — Python or TS — that hardcoded the repo path via `Path(__file__).parent.parent` or `new URL('..', import.meta.url)` is still doing so), you'll see a silent **path divergence**:
+### 1.1 Location
 
-- The bridge (and any caller of `resolve_workspace()`) writes new tasks to the canonical default `~/.sutando/workspace/tasks/`.
-- Any component still reading from `<repo>/tasks/` via a relative path won't see them.
-- Result: new tasks never reach the loop. Observed 2026-05-16 — 7 owner DMs orphaned over 19 minutes before the divergence was caught.
-
-**Preferred fix (post-#1170):** run `bash scripts/sutando-migrate.sh --dry-run` to preview, then `--commit` to relocate `<repo>/{tasks,results,state,notes,build_log.md,conversation.log,…}` into `~/.sutando/workspace/`. The CLI is the only auto-mover post-#1169 (option B); the old `_migrate_from_legacy` auto-fire was removed because it ran destructively on every `resolve_workspace()` call and bit synced workspaces via symlink-following iterdir(). After migration, both sides agree on the canonical default and no env var is needed.
-
-> **Historical note:** before #1170 (2026-05-26) the Python and bash twins of these migrators ran automatically on every `resolve_workspace()` call / `init.sh --auto` startup. That auto-fire is gone; both code paths now only emit a one-time stderr notice when legacy state is detected and route users to the CLI above. The `sutando-migrate.sh` CLI itself ships in a follow-up PR — until then, `mv` the listed paths manually.
-
-**Stop-gap (if migration won't run):** pin `SUTANDO_WORKSPACE` in `.env` at the repo root and restart the bridges:
-
-```bash
-SUTANDO_WORKSPACE=/full/path/to/your/repo
+```
+<repo>/workspace/    ← workspace root (gitignored)
 ```
 
-**Caveat:** this revives the git-status-pollution antipattern that #762 was designed to escape (every `tasks/`, `results/`, `state/` write shows up in `git status`). Use sparingly; prefer the migration when possible.
+Resolved by `bash scripts/sutando-config.sh workspace` (the M0 helper). Helpers in Python (`from workspace_default import resolve_workspace`), TypeScript (`import { resolveWorkspace } from './workspace_default.js'`), and Swift (`AppDelegate.workspace`) read from `sutando.config.{json,local.json}` with `<repo>/workspace/` as the baked-in default.
 
-**Fresh installs** can skip this entirely — the `~/.sutando/workspace/` default works because nothing else polls the repo path.
+**Hard rules (after #1440):**
+- The workspace is **always** at `<repo>/workspace/` by default. The location is specified via the config file (`sutando.config.{json,local.json}` → `workspace.path`); the per-clone `sutando.config.local.json` (gitignored) is where users override, if they choose to.
+- **No env override** — neither `$SUTANDO_WORKSPACE` nor any other env var redirects the resolver.
+- The whole `/workspace/` tree is gitignored (single entry in repo `.gitignore`).
+- Workspace is computed by the helpers — never by a per-script fallback.
 
-## Orphan symlinks (post-migration cleanup)
+> ⚠️ **Cost of overriding `workspace.path` outside `<repo>/workspace/`.** The in-repo default is what unlocks Claude Code's cwd-anchored features:
+>
+> - **CLAUDE.md auto-load** — Claude Code reads the project's `CLAUDE.md` automatically when cwd is inside the repo. Move workspace outside and the workspace-rooted `PERSONAL_CLAUDE.md` stops being auto-loaded.
+> - **Skills auto-discovery** — workspace-rooted `skills/` is auto-discovered when workspace is under cwd. Outside the repo, sessions need an explicit `--add-dir <workspace>` to see them.
+> - **Project-slug session transcripts** — Claude Code names session JSONLs by cwd-derived slug; an out-of-repo workspace fragments the transcript history.
+> - **Hook scope** — `<claude-config>/hooks/*` fires scoped to cwd. Out-of-repo workspace breaks the association.
+> - **No `--add-dir` flag needed** — built-in. Out-of-repo workspace forces an explicit `--add-dir <workspace>` per session.
+>
+> Only override if you have a clear reason (shared workspace across multiple checkouts; custom storage for size / encryption / quota). Otherwise, accept the default.
 
-If you hand-created any symlinks against the legacy `~/.sutando-memory-sync/...` path before the auto-migration moved it to `~/.sutando/memory-sync/`, those symlinks are now stale (the target moved out from under them). `scripts/sync-memory.sh` (post-#835) scans `~/.sutando/`, `~/.claude/skills/`, and `~/.config/` for orphaned symlinks the first time it actually triggers the migration and emits one `rm + ln -s` recipe per orphan to stderr. Run the printed pairs to re-point them at the canonical path. Subsequent runs skip the scan (no false positives).
+**Today's deprecation path:** `$SUTANDO_WORKSPACE` set in the environment fires a one-time bold-red stderr warning pointing at `scripts/sutando-migrate.sh`. After #1440 merges, the value is not honored even with the warning. Hosts with the env var set are auto-migrated by `src/startup.sh` on first run post-merge (run `sutando-migrate.sh --commit`, then compress the original folder in place + unset the env).
+
+**Why in-repo:** the workspace inherits Claude Code's cwd privileges — CLAUDE.md auto-load, skills auto-discovery, project-slug for session transcripts, hook scope, no `--add-dir` needed. Putting it anywhere else forfeits these.
+
+### 1.2 Layout
+
+```
+<repo>/workspace/
+├── tasks/                  ← inbound message queue (bridges write, agent reads)
+│   ├── archive/<yyyy-mm>/  ← processed task files (auto-rotated)
+│   └── processed/          ← in-flight working state
+├── results/                ← outbound reply queue (agent writes, bridges deliver)
+├── state/                  ← cross-process status JSON (one writer per file)
+│   ├── core-status.json
+│   ├── voice-state.json
+│   ├── contextual-chips.json
+│   ├── quota-state.json
+│   ├── auth/               ← durable per-host install state (.alive sentinels, device IDs)
+│   └── cores/<host>.alive  ← per-host liveness signal
+├── logs/                   ← append-only chrono streams (bridges, watchers, sync)
+├── notes/                  ← long-form human-readable content
+├── data/                   ← durable input data (datasets, fetched feeds)
+├── relay/                  ← inter-session continuity notes (consumed by catchup)
+├── skills/                 ← user's personal/custom skills (local-only)
+├── build_log.md            ← single-file done/in-flight/next snapshot (append-only)
+└── pending-questions.md    ← unanswered questions awaiting owner input
+```
+
+The workspace root holds **only** the top-level dirs above plus the two markdown files. Loose `.json` files belong under `state/`. The repo root holds code/skills/config (a separate concern).
+
+### 1.3 Decision guide
+
+When the agent writes a new file under `<repo>/workspace/`, walk this list top-to-bottom and stop at the first match:
+
+1. **Inbound channel message?** → `tasks/task-{id}.txt`. The bridges write these.
+2. **Reply to a task?** → `results/task-{id}.txt`. Bridge polls + delivers. See CLAUDE.md "Result-body protocol markers" for `[deduped:]`, `[no-send]`, `[channel:]`, `[file:]`.
+3. **Cross-process status JSON another component polls?** → `state/`.
+4. **Per-host durable install state** (`.alive` heartbeats, device UUIDs, cloud-auth) → `state/auth/`. Exempt from transient-state cleanup.
+5. **Append-only chrono event stream?** → `logs/<component>.log`.
+6. **Long-form human-readable content?** → `notes/<slug>.md`.
+7. **Done/in-flight/next snapshot?** → append to `build_log.md`.
+8. **Blocked question for the owner?** → append to `pending-questions.md`.
+9. **Durable input data?** → `data/<topic>/`.
+10. **Continuity note for the next session?** → `relay/relay-<ts>.md` (consumed by `/catchup-after-startup`).
+11. **Personal skill the user adds for their own use?** → `skills/<skill-name>/` (local-only, not contributed to `skills/` at the repo root).
+
+If two layers seem to fit, prefer the more specific one (state JSON beats logs beats notes).
+
+### 1.4 Confidentiality
+
+The workspace is user-specific. **NEVER disclose workspace content** — tasks, results, notes, state, build_log, pending-questions — to any party outside the owner without explicit per-disclosure approval. Default-deny: when in doubt, ask first. Strategic / competitive / financial / personal content stays owner-DM only.
+
+This applies even when a public PR / issue would benefit from quoting workspace content. Bots **paraphrase** workspace state into public artifacts; they never quote verbatim.
+
+**Mechanisms enforcing this:**
+
+- **Blanket `.gitignore`** — the whole `/workspace/` subtree is a single gitignore entry. Workspace files cannot be accidentally staged, committed, or pushed; trying to add one prints "ignored by .gitignore." `sutando.config.local.json` is gitignored for the same reason.
+- **Pre-commit + CI guard layers** — `scripts/check-workspace-not-tracked.sh` (pre-commit hook) and the equivalent CI check (see `docs/workspace-config.md` "Protection layers") fail the build if anything under `/workspace/` is tracked or if `sutando.config.local.json` is staged. Multi-layer defense: gitignore is the floor, hooks + CI are the ceiling.
+- **Per-channel access tiers** — every bridge (Discord, Slack, Telegram) tags incoming tasks with `access_tier: owner | team | other`. Only `owner` tasks get full agent capabilities; `team` and `other` are delegated to `codex exec --sandbox read-only`, which cannot read workspace files outside its sandbox path. The bridge enforces this in-band by injecting a `===SUTANDO SYSTEM INSTRUCTIONS===` block into every non-owner task body — the agent follows those instructions verbatim and never processes the user-supplied content directly. See CLAUDE.md "Discord/Slack/Telegram access control."
+- **TOFU + allowlist for owner identity** — first DM to a bridge auto-enrolls the sender as owner and writes `$CLAUDE_CONFIG_DIR/channels/<surface>/access.json`. Subsequent senders are checked against `allowFrom`; absent or non-matching senders fall through to non-owner tiers (no implicit owner promotion).
+- **Sandboxed delegation for team/other** — non-owner tasks run under `codex exec --sandbox read-only`. The sandbox blocks filesystem writes and restricts reads to the agent's working directory, so workspace `state/`, `notes/`, `build_log.md`, etc. are unreachable to non-owner tiers even if the user-supplied prompt tries to coax otherwise.
+- **Result-body delivery markers** — `[no-send]`, `[deduped: task-X]`, `[REPLIED]`, `[channel: <id>]` route or suppress bot replies *at the bridge layer*, not the agent layer. Even if the agent writes a confidential result, a `[no-send]` marker prevents it from reaching any user-facing surface.
+- **Memory split (shared vs private)** — memory and notes live under `$SUTANDO_MEMORY_DIR` (default: `$CLAUDE_CONFIG_DIR/projects/.../memory/`), separate from the public repo. `scripts/sync-memory.sh` syncs to a private repo (`$SUTANDO_MEMORY_REPO`); never to a public one. Memory content is loaded into agent context, never into PR bodies or commit messages.
+- **Per-host install state under `state/auth/`** — `cloud-auth.json`, `device.json`, and other per-host credentials are scoped to one host's workspace and exempted from transient-state cleanup. They never sync via `sync-memory.sh` (which targets `memory/` + `notes/` only) or via `sync-workspace.sh` (which excludes `state/auth/` by path).
+- **Channel-confidentiality routing rule** (operational) — codified in the `feedback_channel_confidentiality` memory: strategic / competitive / financial content goes to owner-DM only, never to shared channels. When the owner asks "what's pending?" in a public channel, the agent lists only audience-appropriate items.
+
+### 1.5 Expansion (user-side)
+
+The user can add their own top-level subdirs (e.g. `drafts/`, `research/`, `screenshots/`, `inbox/`). New dirs are automatically gitignored (the whole `/workspace/` tree is) and inherit the §1.4 default-deny posture.
+
+**Agent-facing rules for custom subdirs** — what content goes there, when the agent reads/writes them, retention — belong in `PERSONAL_CLAUDE.md` (per-user overrides). CLAUDE.md (shared) describes the built-in shape; `PERSONAL_CLAUDE.md` describes the per-user extension.
+
+### 1.6 Archive / cleanup
+
+Workspace bloat distracts Claude Code's cwd-anchored discovery (large `git status`, slow project-slug indexing, big tab-completion sets). Mitigation: a nightly cron archives older content.
+
+- `tasks/processed/` and `logs/` older than 30 days → `archive/<yyyy-mm>/`.
+- Suggested cron: 03:30 local. Script: `scripts/archive-workspace.sh` *(forthcoming — not yet shipped)*.
+- `notes/` and `data/` are user content — never auto-archived. User manages.
+- `build_log.md` is append-only — never archived. Owner manually rotates if it gets unwieldy (>500KB).
+
+## 2. Resolution (implementation)
+
+Path computation is centralized; do NOT reinvent the fallback per-script.
+
+- **Python:** `from workspace_default import resolve_workspace` → `Path`
+- **TypeScript:** `import { resolveWorkspace } from './workspace_default.js'` → `string`
+- **Swift:** `AppDelegate.workspace` (split alongside `repoRoot` for code-adjacent paths)
+- **Shell:** `WORKSPACE="$(bash scripts/sutando-config.sh workspace)"` then `"$WORKSPACE/..."`. The shared `src/workspace_resolve.sh` helper wraps this for scripts that source it.
+
+**Resolution order (post-#1440):**
+1. `sutando.config.local.json` → `workspace.path` (per-clone override, gitignored).
+2. `sutando.config.json` → `workspace.path` (tracked defaults at repo root).
+3. `<repo>/workspace/` baked-in default.
+
+**Today (pre-#1440):** `$SUTANDO_WORKSPACE` env var is honored as a legacy escape hatch ahead of step 1, with a one-time deprecation warning. PR #1440 removes that step.
+
+## 3. Migration from earlier versions
+
+Users running with `$SUTANDO_WORKSPACE` pointing outside the repo (pre-M0 layout, or any pre-v0.8 host):
+
+1. **`bash scripts/sutando-migrate.sh --dry-run`** — scan all three potential source locations (repo root, `~/.sutando/workspace/`, `$SUTANDO_WORKSPACE` env) and surface collisions before any move.
+2. **`bash scripts/sutando-migrate.sh --commit`** — relocate content into `<repo>/workspace/` with rule-driven class resolution (`structural`, `newest-mtime`, `keep-both`, `append`, etc.). Per M1 Part 2 (#1403) + #1406.
+3. **Post-#1440 auto-flow**: `src/startup.sh` detects `$SUTANDO_WORKSPACE` set with data and invokes the migration automatically, then compresses the original folder in place as `<legacy>-pre-v0.8-<ts>.tar.gz` (recoverable via `tar -xzf`) so stale processes hit `ENOENT` instead of writing to a divergent path.
+4. **After migration**, unset `$SUTANDO_WORKSPACE` in shell rc + `.env`. The startup script already unsets it for child processes; cleaning the source is a one-time operator step.
+
+**Edge case** — users with multiple repo checkouts pointing at one shared workspace lose that pattern under v0.8. Workaround: pick one canonical checkout, OR filesystem-symlink `<repoB>/workspace → <repoA>/workspace` (no tooling).
+
+## 4. Vault (overview only)
+
+The workspace is intentionally ephemeral: delete the repo and the workspace dies. The **vault** is the separate durability layer that persists content across reclones and syncs across hosts.
+
+- `$SUTANDO_VAULT` — the durability env var. Defaults exist; user can override.
+- Default content: memories. The user can extend the sync allowlist.
+- Sync mechanism: scripts/cron-driven (today `scripts/sync-memory.sh`; future `sync-vault.sh`).
+- Cross-host topology, room collaboration, allowlist format, secret push-gate, conflict policy — **all out of scope here**. See `docs/vault-design.md` *(forthcoming)*.
+
+## 5. Locked decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Workspace = `<repo>/workspace/`, **computed**, no env override (post-#1440) | Claude Code cwd-privilege capture; structural simplicity |
+| 2 | Whole `/workspace/` tree gitignored | Prevents tracked-pollution anti-pattern (the historic `Path(__file__).parent.parent` regression) |
+| 3 | Top-level dirs (tasks/results/state/logs/notes/data/relay/skills) + 2 .md files | Matches the decision guide; agent has a single answer for each write |
+| 4 | Confidentiality default-deny | Workspace = owner-private; bots paraphrase, never quote |
+| 5 | Custom user dirs allowed, documented in PERSONAL_CLAUDE.md | Per-user expansion without polluting shared CLAUDE.md |
+| 6 | `state/auth/` exempt from cleanup | Per-host install state (cloud-auth, device.json, .alive sentinels) must survive transient-state sweeps |
+| 7 | Nightly archive of stale `tasks/processed/` + `logs/` | Bounds cwd bloat (script forthcoming — not yet shipped) |
+| 8 | Vault is a separate doc / separate concern | Workspace contract = location + structure only; durability is its own design |
+| 9 | Auto-migration on bootstrap (post-#1440) | Operators don't have to remember `sutando-migrate.sh`; legacy env-pointed data is preserved as `<legacy>-pre-v0.8-<ts>.tar.gz` |
+
+## 6. What's NOT in this doc
+
+These belong in the vault-design doc, not here:
+- Multi-host sync topology
+- Room collaboration (multi-user shared content)
+- Tier model (LOCAL / MACHINE / AGENT / ROOM)
+- Per-tier git remote layout
+- Allowlist format + push-gate (secret scanning)
+- Conflict resolution policy
+- Vault creation / invite flow
+- `identity_<scope>.json` and the scopes registry
+
+This is intentional. This doc (the workspace contract) defines location + structure. The vault doc defines durability + sharing. Keeping them separate lets each evolve at its own pace.
+
+## 7. FAQ
+
+**Q: Can I use a workspace dir other than `<repo>/workspace/`?**
+
+A: Yes. Override `workspace.path` in your gitignored `sutando.config.local.json`:
+
+```json
+{
+  "workspace": {
+    "path": "/some/other/absolute/path"
+  }
+}
+```
+
+**But do it mindfully** — the in-repo default is what unlocks Claude Code's cwd-anchored features (CLAUDE.md + PERSONAL_CLAUDE.md auto-load, skills auto-discovery without `--add-dir`, project-slug session transcripts, hook scope). If you override outside the repo, you forfeit these and have to compensate (explicit `--add-dir <workspace>` per launch; fragmented session-transcript history). See §1.1's ⚠️ callout for the full breakdown.
+
+Common legitimate reasons to override: shared workspace across multiple checkouts; custom storage location for size / encryption / quota.
+
+**Q: Why isn't `$SUTANDO_WORKSPACE` honored anymore?**
+
+A: It was the legacy escape hatch (pre-M0). Two problems with env-based overrides:
+
+1. Two processes inheriting the env at different times read different values (cron jobs, launchd jobs, ad-hoc shells) — silent split-brain.
+2. The env var doesn't survive a fresh `git clone`. New machines / checkouts don't see your override; the default applies inconsistently.
+
+`sutando.config.local.json` solves both: it lives at a known path (gitignored), every process reads it the same way, and a new clone gets a clean state with the default.
+
+**Q: How do I migrate an existing workspace from a pre-v0.8 layout?**
+
+A: **You shouldn't have to do anything — `src/startup.sh` auto-migrates on first boot post-#1440** when it detects `$SUTANDO_WORKSPACE` set with data at the env-pointed path. It runs `sutando-migrate.sh --commit` for you, then compresses the original folder in place as `<legacy>-pre-v0.8-<ts>.tar.gz` so stale processes hit `ENOENT` instead of writing to a divergent dir.
+
+**If for any reason the auto-migration didn't happen** (e.g. you launched a service directly without going through `startup.sh`, or your `$SUTANDO_WORKSPACE` was unset at startup but set later), just ask Sutando: *"migrate my workspace"* or *"my workspace is in the wrong place — fix it"*. Sutando will run the migration script for you, with diagnostics + collision detection.
+
+**If you'd rather run it manually** (you want full visibility, you're testing the migration on a sandbox checkout, etc.):
+
+```bash
+bash scripts/sutando-migrate.sh --dry-run    # preview what would move — sources scanned: repo root, ~/.sutando/workspace/, $SUTANDO_WORKSPACE env
+bash scripts/sutando-migrate.sh --commit     # actually relocate
+bash scripts/sutando-migrate.sh --explain <path>   # walk the class-resolution rules for a single path
+```
+
+Sources scanned (A/B/C):
+- **A** — repo root (any loose runtime files at the top of the checkout from pre-M0 installs).
+- **B** — `~/.sutando/workspace/` (the pre-M0 default location).
+- **C** — `$SUTANDO_WORKSPACE` env (the legacy escape hatch path).
+
+Collisions are surfaced before any move — the script never silently overwrites.
+
+**Q: My workspace ended up in a weird place after I forgot to migrate. What now?**
+
+A: Run `bash scripts/sutando-migrate.sh --dry-run` to confirm what's where, then `--commit` to move it. If the old location has been compressed into a tarball by the auto-migration, `tar -xzf <legacy>-pre-v0.8-<ts>.tar.gz -C <legacy-parent>` to expand for inspection.
+
+**Q: What if I want the workspace on a different filesystem (e.g. an external SSD for size reasons) but still inside the repo's git-tracked path?**
+
+A: Use a filesystem-level symlink: `ln -s /Volumes/MyExtSSD/sutando-workspace <repo>/workspace`. The gitignore covers the link target; the helper resolves through the symlink. This keeps cwd-anchored features intact while letting you control physical storage.
+
+## 8. Shipping history
+
+| Milestone | PR(s) | What landed | Date |
+|---|---|---|---|
+| **M0** — in-repo default + config-driven resolution | [#1395](https://github.com/sonichi/sutando/pull/1395), [#1397](https://github.com/sonichi/sutando/pull/1397) | `sutando.config.{json,local.json}` loader; helper at `scripts/sutando-config.sh`; default flipped from `~/.sutando/workspace/` to `<repo>/workspace/` | 2026-06-01 |
+| **M1 phase 1** — resolver hardening | [#1399](https://github.com/sonichi/sutando/pull/1399) | Helper bootstrap subcommands; resolver fixes | 2026-06-02 |
+| **M1 part 2** — migration tool | [#1403](https://github.com/sonichi/sutando/pull/1403), [#1406](https://github.com/sonichi/sutando/pull/1406) | `scripts/sutando-migrate.sh` + `/sutando-migrate` skill; class-rule resolution; `--explain` / `--dry-run` / `--commit` modes; sources A/B/C scan | 2026-06-02 |
+| **claude-config M0+M1** | [#1415](https://github.com/sonichi/sutando/pull/1415) | `claude-sutando` shell wrapper; workspace-scoped `CLAUDE_CONFIG_DIR` | 2026-06-02 |
+| **catchup PID-stamp sentinel** | [#1431](https://github.com/sonichi/sutando/pull/1431) | Crash-safe restart detection for `/catchup-after-startup` | 2026-06-03 |
+| **sync-memory SCRIPT_PARENT** | [#1432](https://github.com/sonichi/sutando/pull/1432) | Anchor helper lookup to `$SCRIPT_PARENT` instead of `$REPO_DIR` (fixes a stale-pin failure) | 2026-06-03 |
+| **schedule-crons no-inline-fire + queue gate** | [#1437](https://github.com/sonichi/sutando/pull/1437) | Closes the SKILL.md `invoke it as /skill-name` ambiguity that caused mid-session avalanche; `scripts/cron-gate.sh` defers sub-daily crons when owner work is queued | 2026-06-03 |
+| **v0.8 env strip + auto-migration** | [#1440](https://github.com/sonichi/sutando/pull/1440) (draft) | Strip `$SUTANDO_WORKSPACE` from resolver; bootstrap auto-migration + compress-in-place; bold-red deprecation warnings | in flight 2026-06-03 |
+| **workspace contract v0.8 spec** | [#1384](https://github.com/sonichi/sutando/pull/1384) (draft) | The design doc that this file makes operationally true | in flight 2026-06-03 |
+| **CLAUDE.md §Workspace restructure** | [#1379](https://github.com/sonichi/sutando/pull/1379) (draft) | Agent-facing decision guide + `<repo>/workspace/` paths | in flight 2026-06-03 |

--- a/scripts/lint-workspace-resolution.sh
+++ b/scripts/lint-workspace-resolution.sh
@@ -60,7 +60,7 @@ PATTERN_DOC_ENV_PATH='\$SUTANDO_WORKSPACE/'
 # branch when the wrapper script isn't reachable (e.g. non-checkout
 # installs). The fallback path is documented in each script's comments;
 # new contributors should still go through the wrapper.
-ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/startup\.sh|src/watch-tasks-stream\.sh|scripts/lint-workspace-resolution\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|skills/catchup-after-startup/scripts/catchup-after-startup\.sh|skills/overlay-apps/scripts/launch\.sh|skills/self-diagnose/scripts/gather\.sh|tests/[^/]+\.(test\.)?(py|ts))$'
+ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/startup\.sh|src/watch-tasks-stream\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|skills/catchup-after-startup/scripts/catchup-after-startup\.sh|skills/overlay-apps/scripts/launch\.sh|skills/self-diagnose/scripts/gather\.sh|tests/[^/]+\.(test\.)?(py|ts|sh))$'
 
 # Allowed .md files — legitimate uses of `$SUTANDO_WORKSPACE/path` in
 # prose, e.g. the workspace contract docs that DESCRIBE the legacy form

--- a/src/init.sh
+++ b/src/init.sh
@@ -55,12 +55,17 @@ unset __HELPER
 if [ -f "$REPO/.env" ]; then
   _env_val=$(grep -E '^SUTANDO_WORKSPACE=' "$REPO/.env" 2>/dev/null | head -1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'\$//" -e "s|^~|$HOME|")
   if [ -n "$_env_val" ]; then
-    if [ -t 2 ]; then
-      printf '\033[1;31m%s\033[0m\n' \
-        "workspace: .env declares SUTANDO_WORKSPACE='$_env_val' but the env var is no longer honored (removed in v0.8). Delete the .env line, and if needed move the value to sutando.config.local.json under workspace.path. The M0 helper resolves to '$WORKSPACE'." >&2
+    # PR #1440 B4: honor NO_COLOR; drop literal path values from the warning
+    # text (parity with Python's c58270d safety pass — a caller-side `2>&1`
+    # capture followed by `mkdir -p "$captured"` previously tokenized embedded
+    # / chars into a rogue folder tree).
+    _msg="workspace: .env declares SUTANDO_WORKSPACE but the env var is no longer honored (removed in v0.8). Delete the .env line, and if needed move the value to sutando.config.local.json under workspace.path."
+    if [ -t 2 ] && [ -z "${NO_COLOR:-}" ]; then
+      printf '\033[1;31m%s\033[0m\n' "$_msg" >&2
     else
-      echo "workspace: .env declares SUTANDO_WORKSPACE='$_env_val' but the env var is no longer honored (removed in v0.8). Delete the .env line, and if needed move the value to sutando.config.local.json under workspace.path. The M0 helper resolves to '$WORKSPACE'." >&2
+      printf '%s\n' "$_msg" >&2
     fi
+    unset _msg
   fi
   unset _env_val
 fi

--- a/src/init.sh
+++ b/src/init.sh
@@ -40,24 +40,27 @@ if [ -f "$__HELPER" ]; then
   # shellcheck source=workspace_resolve.sh
   source "$__HELPER"
   resolve_workspace_or_die
-elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "init.sh: cannot resolve workspace — workspace_resolve.sh not found at \$REPO/src/ or alongside this script, and \$SUTANDO_WORKSPACE is not set." >&2
+  echo "init.sh: cannot resolve workspace — workspace_resolve.sh not found at \$REPO/src/ or alongside this script." >&2
   exit 1
 fi
 unset __HELPER
 
-# Surface the silent-fallback bug class (see PR #1367/#1368): if .env defines
-# SUTANDO_WORKSPACE but this process never got it (e.g. init.sh invoked by a
-# bootstrap path that skips startup.sh's .env-source), the helper-resolved
-# value may differ from .env. One stderr line per init.sh run makes the miss
-# visible. M0's loud-warn-workspace-fallback (PR #1369) covers part of this
-# from the helper side; this is the init.sh-specific belt-and-suspenders.
+# v0.8 deprecation nag (init.sh-side belt-and-suspenders for the resolver
+# warning). If `.env` declares a SUTANDO_WORKSPACE line, it's no longer
+# honored — surface once per init.sh run so the operator cleans up. The
+# resolver fires its own bold-red warning when the env var is set in the
+# process environment; this catches the `.env` declaration case for boot
+# paths that don't source .env into the env (launchd, cron, direct invokes).
 if [ -f "$REPO/.env" ]; then
   _env_val=$(grep -E '^SUTANDO_WORKSPACE=' "$REPO/.env" 2>/dev/null | head -1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'\$//" -e "s|^~|$HOME|")
-  if [ -n "$_env_val" ] && [ "$_env_val" != "$WORKSPACE" ]; then
-    echo "workspace: .env declares SUTANDO_WORKSPACE='$_env_val' but the M0 helper resolves to '$WORKSPACE' — source .env or export the var before this process to avoid split-brain with other services." >&2
+  if [ -n "$_env_val" ]; then
+    if [ -t 2 ]; then
+      printf '\033[1;31m%s\033[0m\n' \
+        "workspace: .env declares SUTANDO_WORKSPACE='$_env_val' but the env var is no longer honored (removed in v0.8). Delete the .env line, and if needed move the value to sutando.config.local.json under workspace.path. The M0 helper resolves to '$WORKSPACE'." >&2
+    else
+      echo "workspace: .env declares SUTANDO_WORKSPACE='$_env_val' but the env var is no longer honored (removed in v0.8). Delete the .env line, and if needed move the value to sutando.config.local.json under workspace.path. The M0 helper resolves to '$WORKSPACE'." >&2
+    fi
   fi
   unset _env_val
 fi

--- a/src/install-credential-proxy-launchd.sh
+++ b/src/install-credential-proxy-launchd.sh
@@ -33,10 +33,8 @@ if [ -f "$__HELPER" ]; then
   # shellcheck source=workspace_resolve.sh
   source "$__HELPER"
   resolve_workspace_or_die
-elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "${0##*/}: cannot resolve workspace — workspace_resolve.sh not found and \$SUTANDO_WORKSPACE not set." >&2
+  echo "${0##*/}: cannot resolve workspace — workspace_resolve.sh not found. v0.8 contract requires the helper; \$SUTANDO_WORKSPACE is no longer honored." >&2
   exit 1
 fi
 unset __HELPER

--- a/src/migration_safety_helpers.sh
+++ b/src/migration_safety_helpers.sh
@@ -28,13 +28,16 @@ _realpath() {
 }
 
 _same_inode() {
-  # Cross-platform inode equality: stat -f %i (macOS BSD) / -c %i (Linux GNU).
-  # Use -L on both so symlinks are followed to their target's inode (BSD stat's
-  # default is lstat-semantics; -L flips it to stat-semantics, matching GNU).
-  # This is the symlink-equivalent case the B1 guard needs to detect.
+  # Cross-platform device:inode equality: stat -f '%d:%i' (macOS BSD) /
+  # -c '%d:%i' (Linux GNU). Use -L on both so symlinks are followed to their
+  # target (BSD stat's default is lstat-semantics; -L flips it to stat-
+  # semantics, matching GNU). Per Mini's PR #1440 v1 review (2026-06-04
+  # 02:30Z): comparing inode alone false-positives across unrelated file
+  # systems that happen to reuse the same inode number — the device id is
+  # what makes the pair globally unique.
   local a b
-  a=$(stat -L -f %i "$1" 2>/dev/null || stat -L -c %i "$1" 2>/dev/null)
-  b=$(stat -L -f %i "$2" 2>/dev/null || stat -L -c %i "$2" 2>/dev/null)
+  a=$(stat -L -f '%d:%i' "$1" 2>/dev/null || stat -L -c '%d:%i' "$1" 2>/dev/null)
+  b=$(stat -L -f '%d:%i' "$2" 2>/dev/null || stat -L -c '%d:%i' "$2" 2>/dev/null)
   [ -n "$a" ] && [ -n "$b" ] && [ "$a" = "$b" ]
 }
 
@@ -44,10 +47,30 @@ _is_unsafe_for_migration() {
   # Per PR #1440 review B3 (Mini): a malformed $SUTANDO_WORKSPACE pointing at
   # /, $HOME, repo root, or a path with surviving `..` after normalization
   # would otherwise be compressed-and-deleted on a "successful" migration.
+  #
+  # Expanded per Mini's v1 review (2026-06-04 02:30Z):
+  #   - /tmp and /private/tmp exact (subdirs like mktemp targets stay safe)
+  #   - $HOME/Documents/*, $HOME/Desktop/*, $HOME/Downloads/* descendants
+  #     (the prior pass only denied the exact dirs, leaving `~/Documents/foo`
+  #     fair game — that's the user's code repos / personal docs)
+  #   - $HOME/.sutando exact + subpaths, EXCEPT $HOME/.sutando/workspace
+  #     (that subpath IS the known legacy auto-migration source — we want
+  #     to be able to relocate it; everything else under .sutando is the
+  #     installer's per-host state)
+  #   - $HOME/.claude exact + subpaths
+  #   - $HOME/.config exact + subpaths
   local p="$1"
   local real
   real="$(_realpath "$p")"
   [ -z "$real" ] && return 0  # cannot resolve → unsafe
+
+  # Allow exception: the known legacy default (intended migration source).
+  # Checked FIRST so the subsequent $HOME/.sutando deny doesn't shadow it.
+  case "$real" in
+    "$HOME/.sutando/workspace"|"$HOME/.sutando/workspace/"*)
+      return 1 ;;  # explicitly safe — this is the auto-migration source
+  esac
+
   case "$real" in
     /|/usr|/usr/*|/etc|/etc/*|/var|/var/*|/bin|/bin/*|/sbin|/sbin/*|/System|/System/*|/Library|/Library/*|/Applications|/Applications/*)
       return 0 ;;
@@ -55,7 +78,20 @@ _is_unsafe_for_migration() {
     # there. Include the resolved forms so the deny matches either spelling.
     /private/etc|/private/etc/*|/private/var|/private/var/*)
       return 0 ;;
-    "$HOME"|"$HOME/Documents"|"$HOME/Desktop"|"$HOME/Downloads")
+    # Exact /tmp + /private/tmp deny (operator typo'd workspace path); mktemp
+    # subdirs (`/tmp/foo`) remain safe targets.
+    /tmp|/private/tmp)
+      return 0 ;;
+    "$HOME"|"$HOME/Documents"|"$HOME/Documents/"*|"$HOME/Desktop"|"$HOME/Desktop/"*|"$HOME/Downloads"|"$HOME/Downloads/"*)
+      return 0 ;;
+    # $HOME dotfile dirs — destructive for user installs of other tools, even
+    # if SUTANDO_WORKSPACE was set there by mistake. .sutando/workspace already
+    # excluded above.
+    "$HOME/.sutando"|"$HOME/.sutando/"*)
+      return 0 ;;
+    "$HOME/.claude"|"$HOME/.claude/"*)
+      return 0 ;;
+    "$HOME/.config"|"$HOME/.config/"*)
       return 0 ;;
     "$REPO"|"$REPO/"*)
       return 0 ;;

--- a/src/migration_safety_helpers.sh
+++ b/src/migration_safety_helpers.sh
@@ -1,0 +1,75 @@
+# PR #1440 — auto-migration safety helpers (Mini review).
+#
+# Sourced by src/startup.sh's v0.8 SUTANDO_WORKSPACE auto-migration block and
+# by tests/startup-migration.integration.test.sh. Pulled into a standalone
+# sourceable so the four guard functions can be unit-tested without driving
+# the entire startup sequence.
+#
+# Functions defined:
+#   _realpath <path>                  — cross-platform realpath
+#   _same_inode <a> <b>               — inode-equality predicate (BSD + GNU stat)
+#   _is_unsafe_for_migration <path>   — deny-list for rm -rf targets
+#   _color_warn <message>             — bold-red stderr banner (NO_COLOR-aware)
+#
+# Caller-supplied env required by `_is_unsafe_for_migration`:
+#   $REPO   — absolute path to the sutando repo root (denied + denied-as-prefix)
+#   $HOME   — set by every shell; used to deny $HOME and top-level subdirs
+#
+# Each function returns 0 / non-zero by shell convention; messages go to stderr.
+
+_realpath() {
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$1" 2>/dev/null
+  elif command -v readlink >/dev/null 2>&1 && readlink -f / >/dev/null 2>&1; then
+    readlink -f "$1" 2>/dev/null
+  else
+    python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$1" 2>/dev/null
+  fi
+}
+
+_same_inode() {
+  # Cross-platform inode equality: stat -f %i (macOS BSD) / -c %i (Linux GNU).
+  # Use -L on both so symlinks are followed to their target's inode (BSD stat's
+  # default is lstat-semantics; -L flips it to stat-semantics, matching GNU).
+  # This is the symlink-equivalent case the B1 guard needs to detect.
+  local a b
+  a=$(stat -L -f %i "$1" 2>/dev/null || stat -L -c %i "$1" 2>/dev/null)
+  b=$(stat -L -f %i "$2" 2>/dev/null || stat -L -c %i "$2" 2>/dev/null)
+  [ -n "$a" ] && [ -n "$b" ] && [ "$a" = "$b" ]
+}
+
+_is_unsafe_for_migration() {
+  # Deny-list for auto-migration's rm -rf target. Anything on this list →
+  # refuse the destructive step entirely (split state is safer than data loss).
+  # Per PR #1440 review B3 (Mini): a malformed $SUTANDO_WORKSPACE pointing at
+  # /, $HOME, repo root, or a path with surviving `..` after normalization
+  # would otherwise be compressed-and-deleted on a "successful" migration.
+  local p="$1"
+  local real
+  real="$(_realpath "$p")"
+  [ -z "$real" ] && return 0  # cannot resolve → unsafe
+  case "$real" in
+    /|/usr|/usr/*|/etc|/etc/*|/var|/var/*|/bin|/bin/*|/sbin|/sbin/*|/System|/System/*|/Library|/Library/*|/Applications|/Applications/*)
+      return 0 ;;
+    # macOS: /etc, /var, /tmp are symlinks into /private/<x>; realpath resolves
+    # there. Include the resolved forms so the deny matches either spelling.
+    /private/etc|/private/etc/*|/private/var|/private/var/*)
+      return 0 ;;
+    "$HOME"|"$HOME/Documents"|"$HOME/Desktop"|"$HOME/Downloads")
+      return 0 ;;
+    "$REPO"|"$REPO/"*)
+      return 0 ;;
+  esac
+  case "$real" in *..*) return 0;; esac
+  return 1
+}
+
+_color_warn() {
+  # Bold-red on TTY when NO_COLOR is unset; plain otherwise. Per PR #1440
+  # review B4 (Mini): the prior `[ -t 2 ]` check didn't honor NO_COLOR.
+  if [ -t 2 ] && [ -z "${NO_COLOR:-}" ]; then
+    printf '\033[1;31m%s\033[0m\n' "$1" >&2
+  else
+    printf '%s\n' "$1" >&2
+  fi
+}

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -77,6 +77,13 @@ else
 fi
 if [ $missing -eq 1 ]; then echo ""; echo "Fix the above and try again."; exit 1; fi
 
+# v0.8 auto-migration helpers (PR #1440 safety hardening — Mini review).
+# Sourced from a sibling file so the four guard functions (_realpath,
+# _same_inode, _is_unsafe_for_migration, _color_warn) can be unit-tested
+# without driving the full startup sequence. See tests/migration-safety-helpers.test.sh.
+# shellcheck source=migration_safety_helpers.sh
+source "$REPO/src/migration_safety_helpers.sh"
+
 # v0.8 auto-migration: $SUTANDO_WORKSPACE is no longer honored by the resolver.
 # If still set (shell rc, .env, launchd plist), detect any data at the env-
 # pointed path and relocate to the new default before services start.
@@ -86,10 +93,16 @@ if [ $missing -eq 1 ]; then echo ""; echo "Fix the above and try again."; exit 1
 # state/auth/ specifically because that subtree is exempt from transient-state
 # cleanup (per CLAUDE.md "Durable per-host install state").
 #
+# Safety layers (PR #1440 review — Mini):
+#   B1: realpath + inode equality guard — skip if env == resolved workspace.
+#   B2: archive BEFORE migrate, so the tarball is a true pre-migration snapshot.
+#   B3: deny-list check — refuse rm -rf if env points at /, $HOME, repo, etc.
+#   B4: NO_COLOR honored in the red banner (see _color_warn above).
+#
 # Failure mode: if sutando-migrate.sh --commit exits non-zero (collision that
 # can't be auto-resolved, etc.), startup ABORTS — refusing to proceed with
 # split state. Operator runs `bash scripts/sutando-migrate.sh --dry-run` to
-# diagnose.
+# diagnose. The pre-migration archive is preserved for recovery.
 if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   _ws_legacy="${SUTANDO_WORKSPACE/#\~/$HOME}"
   _ws_new="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null || true)"
@@ -97,42 +110,59 @@ if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
 
   if [ -n "$_ws_new" ] && [ ! -f "$_migrate_sentinel" ] \
      && [ -d "$_ws_legacy" ] && [ -n "$(ls -A "$_ws_legacy" 2>/dev/null)" ]; then
-    # Red banner so the operator notices the one-shot relocation.
-    if [ -t 2 ]; then
-      printf '\033[1;31m📦 sutando v0.8 auto-migration: $SUTANDO_WORKSPACE points at %s with data; relocating to %s (one-shot).\033[0m\n' \
-        "$_ws_legacy" "$_ws_new" >&2
-    else
-      printf 'sutando v0.8 auto-migration: $SUTANDO_WORKSPACE points at %s with data; relocating to %s (one-shot).\n' \
-        "$_ws_legacy" "$_ws_new" >&2
-    fi
 
-    if bash "$REPO/scripts/sutando-migrate.sh" --commit; then
-      mkdir -p "$(dirname "$_migrate_sentinel")"
-      printf 'migrated_from=%s\nmigrated_at=%s\nhostname=%s\n' \
-        "$_ws_legacy" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(hostname)" \
-        > "$_migrate_sentinel"
-      echo "✅ auto-migration complete — data moved into $_ws_new/" >&2
+    _legacy_real="$(_realpath "$_ws_legacy")"
+    _new_real="$(_realpath "$_ws_new")"
 
-      # Compress the original folder in place + replace the directory with the
-      # tarball. Two goals (per owner directive 2026-06-03 18:36Z):
-      #   1) Preserve the original data as a recovery archive — `tar -xzf` to
-      #      restore.
-      #   2) Replace the directory with a single file so any stale process /
-      #      cron / launchd job still referencing the env-pointed path hits
-      #      ENOENT instead of silently writing to a divergent dir.
-      _legacy_archive="${_ws_legacy%/}-pre-v0.8-$(date -u +%Y%m%dT%H%M%SZ).tar.gz"
-      if tar -czf "$_legacy_archive" -C "$(dirname "$_ws_legacy")" "$(basename "$_ws_legacy")" 2>/dev/null; then
-        rm -rf "$_ws_legacy"
-        echo "📦 archived → $_legacy_archive" >&2
-        echo "   to restore: tar -xzf '$_legacy_archive' -C $(dirname "$_ws_legacy")" >&2
-      else
-        echo "⚠️  archive of $_ws_legacy failed — leaving in place. Old processes may still write there." >&2
-      fi
-    else
-      echo "❌ auto-migration failed — refusing to start with split state." >&2
-      echo "   Diagnose: bash scripts/sutando-migrate.sh --dry-run" >&2
-      echo "   Inspect:  ls -la $_ws_legacy $_ws_new" >&2
+    if [ -n "$_legacy_real" ] && [ -n "$_new_real" ] && [ "$_legacy_real" = "$_new_real" ]; then
+      # B1: realpath equality — env points at the resolved workspace. No-op.
+      echo "ℹ️  \$SUTANDO_WORKSPACE already points at the resolved workspace — no migration needed." >&2
+    elif _same_inode "$_ws_legacy" "$_ws_new"; then
+      # B1: same inode (symlink-equivalent) — no-op.
+      echo "ℹ️  \$SUTANDO_WORKSPACE is symlink-equivalent to the resolved workspace — no migration needed." >&2
+    elif _is_unsafe_for_migration "$_ws_legacy"; then
+      # B3: deny-list — refuse to touch unsafe paths.
+      echo "❌ refusing to auto-migrate \$SUTANDO_WORKSPACE — the path matches the deny-list" >&2
+      echo "   (denies: /, system dirs, \$HOME and top-level subdirs, repo root, paths with '..')." >&2
+      echo "   Likely a malformed \$SUTANDO_WORKSPACE in your shell/.env. Inspect + fix manually, then restart." >&2
       exit 1
+    else
+      _color_warn "📦 sutando v0.8 auto-migration: \$SUTANDO_WORKSPACE points at $_ws_legacy with data; relocating to $_ws_new (one-shot)."
+
+      # B2: archive BEFORE migrate. Captures the pre-migration state so the
+      # tarball is a genuine recovery snapshot. If --commit moves data first,
+      # the tarball would only catch the residual / empty post-migrate dir.
+      _legacy_archive="${_ws_legacy%/}-pre-v0.8-$(date -u +%Y%m%dT%H%M%SZ).tar.gz"
+      if ! tar -czf "$_legacy_archive" -C "$(dirname "$_ws_legacy")" "$(basename "$_ws_legacy")" 2>/dev/null; then
+        echo "❌ pre-migration archive of $_ws_legacy failed — aborting auto-migration." >&2
+        echo "   Without a recovery snapshot, refusing the destructive migrate-and-delete." >&2
+        exit 1
+      fi
+      echo "📦 pre-migration snapshot → $_legacy_archive" >&2
+
+      if bash "$REPO/scripts/sutando-migrate.sh" --commit; then
+        mkdir -p "$(dirname "$_migrate_sentinel")"
+        printf 'migrated_from=%s\nmigrated_at=%s\nhostname=%s\narchive=%s\n' \
+          "$_ws_legacy" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(hostname)" "$_legacy_archive" \
+          > "$_migrate_sentinel"
+        echo "✅ auto-migration complete — data moved into $_ws_new/" >&2
+
+        # B3 second layer: re-verify deny-list before destructive rm. If
+        # _ws_legacy somehow mutated between the initial check and now
+        # (symlink swapped, env var rewritten), refuse rm + preserve archive.
+        if _is_unsafe_for_migration "$_ws_legacy"; then
+          echo "⚠️  refusing rm -rf on $_ws_legacy (failed deny-list re-check). Recovery archive preserved." >&2
+        else
+          rm -rf "$_ws_legacy"
+          echo "🗑  removed legacy directory" >&2
+          echo "   to restore: tar -xzf '$_legacy_archive' -C $(dirname "$_ws_legacy")" >&2
+        fi
+      else
+        echo "❌ auto-migration failed — refusing to start with split state." >&2
+        echo "   Recovery archive preserved at $_legacy_archive" >&2
+        echo "   Diagnose: bash scripts/sutando-migrate.sh --dry-run" >&2
+        exit 1
+      fi
     fi
   fi
 

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -77,6 +77,71 @@ else
 fi
 if [ $missing -eq 1 ]; then echo ""; echo "Fix the above and try again."; exit 1; fi
 
+# v0.8 auto-migration: $SUTANDO_WORKSPACE is no longer honored by the resolver.
+# If still set (shell rc, .env, launchd plist), detect any data at the env-
+# pointed path and relocate to the new default before services start.
+#
+# Sentinel guard: state/auth/migrated-from-env.txt under the NEW workspace
+# records a successful migration so a re-run doesn't retry. Sentinel is in
+# state/auth/ specifically because that subtree is exempt from transient-state
+# cleanup (per CLAUDE.md "Durable per-host install state").
+#
+# Failure mode: if sutando-migrate.sh --commit exits non-zero (collision that
+# can't be auto-resolved, etc.), startup ABORTS — refusing to proceed with
+# split state. Operator runs `bash scripts/sutando-migrate.sh --dry-run` to
+# diagnose.
+if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+  _ws_legacy="${SUTANDO_WORKSPACE/#\~/$HOME}"
+  _ws_new="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null || true)"
+  _migrate_sentinel="${_ws_new}/state/auth/migrated-from-env.txt"
+
+  if [ -n "$_ws_new" ] && [ ! -f "$_migrate_sentinel" ] \
+     && [ -d "$_ws_legacy" ] && [ -n "$(ls -A "$_ws_legacy" 2>/dev/null)" ]; then
+    # Red banner so the operator notices the one-shot relocation.
+    if [ -t 2 ]; then
+      printf '\033[1;31m📦 sutando v0.8 auto-migration: $SUTANDO_WORKSPACE points at %s with data; relocating to %s (one-shot).\033[0m\n' \
+        "$_ws_legacy" "$_ws_new" >&2
+    else
+      printf 'sutando v0.8 auto-migration: $SUTANDO_WORKSPACE points at %s with data; relocating to %s (one-shot).\n' \
+        "$_ws_legacy" "$_ws_new" >&2
+    fi
+
+    if bash "$REPO/scripts/sutando-migrate.sh" --commit; then
+      mkdir -p "$(dirname "$_migrate_sentinel")"
+      printf 'migrated_from=%s\nmigrated_at=%s\nhostname=%s\n' \
+        "$_ws_legacy" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(hostname)" \
+        > "$_migrate_sentinel"
+      echo "✅ auto-migration complete — data moved into $_ws_new/" >&2
+
+      # Compress the original folder in place + replace the directory with the
+      # tarball. Two goals (per owner directive 2026-06-03 18:36Z):
+      #   1) Preserve the original data as a recovery archive — `tar -xzf` to
+      #      restore.
+      #   2) Replace the directory with a single file so any stale process /
+      #      cron / launchd job still referencing the env-pointed path hits
+      #      ENOENT instead of silently writing to a divergent dir.
+      _legacy_archive="${_ws_legacy%/}-pre-v0.8-$(date -u +%Y%m%dT%H%M%SZ).tar.gz"
+      if tar -czf "$_legacy_archive" -C "$(dirname "$_ws_legacy")" "$(basename "$_ws_legacy")" 2>/dev/null; then
+        rm -rf "$_ws_legacy"
+        echo "📦 archived → $_legacy_archive" >&2
+        echo "   to restore: tar -xzf '$_legacy_archive' -C $(dirname "$_ws_legacy")" >&2
+      else
+        echo "⚠️  archive of $_ws_legacy failed — leaving in place. Old processes may still write there." >&2
+      fi
+    else
+      echo "❌ auto-migration failed — refusing to start with split state." >&2
+      echo "   Diagnose: bash scripts/sutando-migrate.sh --dry-run" >&2
+      echo "   Inspect:  ls -la $_ws_legacy $_ws_new" >&2
+      exit 1
+    fi
+  fi
+
+  # Whether migrated or not, unset $SUTANDO_WORKSPACE so child processes
+  # (init.sh, bridges, voice-agent, etc.) get the v0.8 contract directly and
+  # the resolver's deprecation nag stops firing on every subprocess spawn.
+  unset SUTANDO_WORKSPACE
+fi
+
 # Exercise the new config loader as a startup banner. Surfaces:
 #   • $SUTANDO_WORKSPACE legacy-escape-hatch warning (if env is set)
 #   • .env-drift warning (if .env declares a value but config resolves differently)
@@ -206,21 +271,18 @@ echo ""
 bash "$REPO/skills/install.sh" 2>/dev/null || true
 
 # Resolve the runtime workspace via the canonical loader (M0 cutover).
-# The loader implements the full resolution order:
-#   1. $SUTANDO_WORKSPACE env var (legacy escape hatch; warn once)
-#   2. sutando.config.local.json -> workspace.path (per-clone override)
-#   3. sutando.config.json -> workspace.path (tracked defaults)
-#   4. ${REPO_DIR}/workspace baked-in default
+# The loader (v0.8 — env override removed) implements:
+#   1. sutando.config.local.json -> workspace.path (per-clone override)
+#   2. sutando.config.json -> workspace.path (tracked defaults)
+#   3. ${REPO_DIR}/workspace baked-in default
 # Inline fallback retained for the rare case where the wrapper isn't
 # present (extracted-tarball install, etc.). All service logs + tasks/
 # results land under $WORKSPACE/logs etc. instead of the repo-root legacy
 # paths. health-check + dashboard already read from $WORKSPACE/logs.
 if [ -f "$REPO/scripts/sutando-config.sh" ]; then
   WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
-elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  WORKSPACE="$HOME/.sutando/workspace"
+  WORKSPACE="$REPO/workspace"
 fi
 mkdir -p "$WORKSPACE/logs" "$WORKSPACE/tasks" "$WORKSPACE/results" "$WORKSPACE/data" "$WORKSPACE/state"
 LOGS_DIR="$WORKSPACE/logs"

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -7,10 +7,13 @@ go through `load_config()` so that the contract is enforced in one place
 rather than re-implemented per-service.
 
 Resolution order (highest layer wins):
-  1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn on use)
-  2. `sutando.config.local.json` (per-clone override, gitignored)
-  3. `sutando.config.json` (tracked defaults at repo root)
-  4. Baked-in default (`{repo_root}/workspace`)
+  1. `sutando.config.local.json` (per-clone override, gitignored)
+  2. `sutando.config.json` (tracked defaults at repo root)
+  3. Baked-in default (`{repo_root}/workspace`)
+
+`$SUTANDO_WORKSPACE` is no longer honored (removed in v0.8). If set, a
+one-time stderr warning fires pointing at `scripts/sutando-migrate.sh`
+for relocation of any data still living at the env-pointed path.
 
 Deep-merge semantics: `.local.json` is merged over the tracked defaults.
 Dicts deep-merge; arrays REPLACE wholesale (not unioned). This matches the
@@ -180,6 +183,25 @@ _DOTENV_DRIFT_WARN_PRINTED = False
 _UNKNOWN_KEYS_WARN_PRINTED = False
 
 
+def _color_warn(msg: str) -> str:
+    """Wrap `msg` in bold-red ANSI when stderr is a TTY; pass through otherwise.
+
+    Keeps the v0.8 deprecation warnings (`$SUTANDO_WORKSPACE no longer honored`,
+    `.env declares stale SUTANDO_WORKSPACE`) eye-catching in interactive
+    terminals so operators actually notice and migrate, while keeping log
+    captures (`script`, `tee`, journald, GitHub Actions) free of escape
+    sequences. `NO_COLOR=1` honored as a hard opt-out (see no-color.org).
+    """
+    if os.environ.get("NO_COLOR"):
+        return msg
+    try:
+        if sys.stderr.isatty():
+            return f"\033[1;31m{msg}\033[0m"
+    except Exception:
+        pass
+    return msg
+
+
 def _warn_unknown_top_level_keys(cfg: Dict[str, Any], path: Path) -> None:
     """Emit a one-time stderr warning if the resolved config has top-level
     keys the loader doesn't recognize. Helps catch typos like `workspce`
@@ -262,57 +284,43 @@ _HARDCODED_WORKSPACE_DEFAULT_REL = "workspace"  # relative to repo root
 def resolve_workspace(repo_root: Optional[Path] = None) -> Path:
     """Resolve the workspace directory per the canonical contract.
 
-    Order:
-      1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn once).
-      2. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
-      3. `{repo_root}/workspace` baked-in default.
+    Order (v0.8 — `$SUTANDO_WORKSPACE` env override removed):
+      1. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
+      2. `{repo_root}/workspace` baked-in default.
 
     Does NOT create the directory; the caller decides. Returns an absolute
     `Path`.
 
-    The env-var warning fires at most once per process so log noise is
-    bounded. The warning is informational — env still wins, so existing
-    users don't break on the switch. Migration path: copy the env value
-    into `sutando.config.local.json` → `workspace.path` and unset the env.
+    If `$SUTANDO_WORKSPACE` is set in the environment, fires a one-time
+    stderr migration-nag warning pointing at `scripts/sutando-migrate.sh`
+    but does NOT honor the env value (the legacy escape hatch was removed
+    in v0.8 per `docs/workspace-contract-v0.8.md`).
     """
     global _LEGACY_ENV_WARN_PRINTED, _DOTENV_DRIFT_WARN_PRINTED
 
     env_val = os.environ.get("SUTANDO_WORKSPACE", "").strip()
-    if env_val:
-        if not _LEGACY_ENV_WARN_PRINTED:
-            _LEGACY_ENV_WARN_PRINTED = True
-            # The warning intentionally OMITS the env value. Embedding a path
-            # in the message string makes the warning "path-shaped": a caller
-            # that mishandles stderr (`$(... 2>&1)` then `mkdir -p "$captured"`)
-            # would build a nested folder tree because bash tokenizes the `/`
-            # chars inside the value. Discovered 2026-06-02 — rogue folder at
-            # <repo>/sutando config: $SUTANDO_WORKSPACE is set ('/var/folders/.../...,
-            # full diagnosis in workspace/results/task-1780442649943.txt.
-            # Users debugging the value can `echo $SUTANDO_WORKSPACE`.
-            print(
-                "sutando config: $SUTANDO_WORKSPACE is set; honoring "
-                "as legacy escape hatch. To silence, move the value into "
-                "sutando.config.local.json under workspace.path and unset the env.",
-                file=sys.stderr,
-            )
-        # Preserve the pre-cutover semantic: only resolve when the env value
-        # is RELATIVE (anchor to cwd, surface the misconfig). For absolute
-        # paths, return as-is so symlinked paths like /tmp -> /private/tmp on
-        # macOS don't get rewritten — that broke the workspace_default test
-        # that compared paths string-equality.
-        target = Path(env_val).expanduser()
-        if not target.is_absolute():
-            anchored = (Path.cwd() / target).resolve()
-            # Same path-shape risk as the main `is set` warning above —
-            # values omitted. Users debugging can `echo $SUTANDO_WORKSPACE`
-            # and `pwd` to reconstruct what got anchored to where.
-            print(
-                "sutando config: $SUTANDO_WORKSPACE is relative — "
-                "anchored to CWD (cross-process drift; set an absolute path).",
-                file=sys.stderr,
-            )
-            return anchored
-        return target
+    if env_val and not _LEGACY_ENV_WARN_PRINTED:
+        _LEGACY_ENV_WARN_PRINTED = True
+        # The warning intentionally OMITS the env value. Embedding a path
+        # in the message string makes the warning "path-shaped": a caller
+        # that mishandles stderr (`$(... 2>&1)` then `mkdir -p "$captured"`)
+        # would build a nested folder tree because bash tokenizes the `/`
+        # chars inside the value. Discovered 2026-06-02 — rogue folder at
+        # <repo>/sutando config: $SUTANDO_WORKSPACE is set ('/var/folders/.../...,
+        # full diagnosis in workspace/results/task-1780442649943.txt.
+        # Users debugging the value can `echo $SUTANDO_WORKSPACE`.
+        print(
+            _color_warn(
+                "sutando config: $SUTANDO_WORKSPACE is set but NO LONGER HONORED "
+                "(removed in v0.8). Workspace resolves only from "
+                "sutando.config.{json,local.json} or the {repoRoot}/workspace "
+                "baked-in default. If existing workspace data lives at the "
+                "$SUTANDO_WORKSPACE path, run `bash scripts/sutando-migrate.sh "
+                "--dry-run` then `--commit` to relocate. Unset the env to "
+                "silence this warning."
+            ),
+            file=sys.stderr,
+        )
 
     cfg = load_config(repo_root)
     root = repo_root or _CACHE_REPO_ROOT
@@ -328,25 +336,24 @@ def resolve_workspace(repo_root: Optional[Path] = None) -> Path:
     else:
         resolved = (root / _HARDCODED_WORKSPACE_DEFAULT_REL).resolve()
 
-    # M0 .env-drift warning: if the env var is UNSET but `.env` declares one,
-    # the user has a stale `.env` line that the new contract bypasses. Surface
-    # once per process so they migrate to `sutando.config.local.json` and
-    # delete the `.env` line. Loader does NOT honor `.env` values — only the
-    # process env. This is the "Detect SUTANDO_WORKSPACE from .env file and
-    # give warning" bullet from Milestone 0.
+    # .env-drift warning: if `.env` still carries a stale SUTANDO_WORKSPACE
+    # line, surface it once per process so the operator can clean it up.
+    # (v0.8: the env var is no longer honored regardless of whether it's set
+    # in the shell or in .env; the warning is purely cleanup guidance.)
     if not _DOTENV_DRIFT_WARN_PRINTED:
         _DOTENV_DRIFT_WARN_PRINTED = True
         dotenv_val = detect_env_workspace_in_dotenv(repo_root)
-        if dotenv_val and Path(dotenv_val).resolve() != resolved:
+        if dotenv_val:
             # Same path-shape risk — values omitted. Users debugging can
             # `grep SUTANDO_WORKSPACE .env` and `bash scripts/sutando-config.sh
             # workspace` to compare.
             print(
-                "sutando config: .env declares SUTANDO_WORKSPACE but the resolved "
-                "workspace differs (config-driven). The .env line is NOT honored by "
-                "the new loader — move the value to sutando.config.local.json under "
-                "workspace.path and delete the .env line, or `source .env` before "
-                "launching processes that need the override.",
+                _color_warn(
+                    "sutando config: .env declares SUTANDO_WORKSPACE but the env var "
+                    "is no longer honored (removed in v0.8). Workspace resolves "
+                    "config-driven. Delete the .env line and, if needed, move the "
+                    "value to sutando.config.local.json under workspace.path."
+                ),
                 file=sys.stderr,
             )
 

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -299,6 +299,15 @@ def resolve_workspace(repo_root: Optional[Path] = None) -> Path:
     global _LEGACY_ENV_WARN_PRINTED, _DOTENV_DRIFT_WARN_PRINTED
 
     env_val = os.environ.get("SUTANDO_WORKSPACE", "").strip()
+
+    # Test-only escape hatch: when `SUTANDO_TEST_MODE=1` is set, honor
+    # `$SUTANDO_WORKSPACE` silently. This preserves the v0.8 contract for
+    # end users (no env override; warning + ignore) while letting the test
+    # suite redirect workspace to per-test tmp dirs without rewriting every
+    # test fixture. Production code MUST NOT set `SUTANDO_TEST_MODE`.
+    if env_val and os.environ.get("SUTANDO_TEST_MODE") == "1":
+        return Path(env_val).expanduser().resolve()
+
     if env_val and not _LEGACY_ENV_WARN_PRINTED:
         _LEGACY_ENV_WARN_PRINTED = True
         # The warning intentionally OMITS the env value. Embedding a path

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -282,13 +282,18 @@ export function resolveWorkspace(repoRoot?: string): string {
 
 	if (envVal && !_legacyEnvWarnPrinted) {
 		_legacyEnvWarnPrinted = true;
+		// PR #1440 B4: drop the literal `'${envVal}'` interpolation (parity with
+		// Python's c58270d safety pass). Embedding /-bearing path values in
+		// stderr was the trigger for the caller-side `mkdir -p "$captured"`
+		// regression that created a rogue folder tree from a tokenized warning.
 		process.stderr.write(
 			_colorWarn(
-				`sutando config: $SUTANDO_WORKSPACE='${envVal}' is set but NO LONGER HONORED ` +
+				`sutando config: $SUTANDO_WORKSPACE is set but NO LONGER HONORED ` +
 					`(removed in v0.8). The workspace now resolves from sutando.config.{json,local.json} ` +
 					`or the {repoRoot}/workspace baked-in default. If you have existing workspace data at ` +
-					`'${envVal}', run \`bash scripts/sutando-migrate.sh --dry-run\` to preview a relocation, ` +
-					`then \`--commit\`. Unset $SUTANDO_WORKSPACE in your shell + .env to silence this warning.`,
+					`the env-pointed path, run \`bash scripts/sutando-migrate.sh --dry-run\` to preview a ` +
+					`relocation, then \`--commit\`. Unset $SUTANDO_WORKSPACE in your shell + .env to silence ` +
+					`this warning.`,
 			) + '\n',
 		);
 	}
@@ -313,10 +318,13 @@ export function resolveWorkspace(repoRoot?: string): string {
 		_dotenvDriftWarnPrinted = true;
 		const dotenvVal = detectEnvWorkspaceInDotenv(repoRoot);
 		if (dotenvVal) {
+			// PR #1440 B4: drop literal `'${dotenvVal}'` and `${resolved}` path
+			// interpolations (parity with Python's c58270d safety pass).
 			process.stderr.write(
 				_colorWarn(
-					`sutando config: .env declares SUTANDO_WORKSPACE='${dotenvVal}' but the env var is no ` +
-						`longer honored (removed in v0.8). Resolved workspace is ${resolved} (config-driven). ` +
+					`sutando config: .env declares SUTANDO_WORKSPACE but the env var is no longer honored ` +
+						`(removed in v0.8). The resolved workspace is config-driven ` +
+						`(sutando.config.{json,local.json} or {repoRoot}/workspace default). ` +
 						`Delete the .env line and, if needed, move the value to \`sutando.config.local.json\` ` +
 						`under \`workspace.path\`.`,
 				) + '\n',

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -7,11 +7,14 @@
  * Python services (bridges, health-check) and TS services (voice-agent,
  * task-bridge) land in the same workspace.
  *
- * Resolution order (highest layer wins):
- *   1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn on use)
- *   2. `sutando.config.local.json` (per-clone override, gitignored)
- *   3. `sutando.config.json` (tracked defaults at repo root)
- *   4. Baked-in default (`{repo_root}/workspace`)
+ * Resolution order (highest layer wins, v0.8 — env override removed):
+ *   1. `sutando.config.local.json` (per-clone override, gitignored)
+ *   2. `sutando.config.json` (tracked defaults at repo root)
+ *   3. Baked-in default (`{repo_root}/workspace`)
+ *
+ * `$SUTANDO_WORKSPACE` is no longer honored. If set in the environment,
+ * a one-time stderr warning fires pointing at `scripts/sutando-migrate.sh`
+ * for relocation of any data still living at the env-pointed path.
  *
  * No external deps — stdlib only.
  */
@@ -173,6 +176,25 @@ let _legacyEnvWarnPrinted = false;
 let _dotenvDriftWarnPrinted = false;
 let _unknownKeysWarnPrinted = false;
 
+/**
+ * Wrap `msg` in bold-red ANSI when stderr is a TTY; pass through otherwise.
+ *
+ * Keeps the v0.8 deprecation warnings ($SUTANDO_WORKSPACE no longer honored,
+ * .env declares stale SUTANDO_WORKSPACE) eye-catching in interactive terminals
+ * so operators actually notice and migrate, while keeping log captures (script,
+ * tee, journald, GitHub Actions) free of escape sequences. `NO_COLOR=1` honored
+ * as a hard opt-out (see no-color.org).
+ */
+function _colorWarn(msg: string): string {
+	if (process.env.NO_COLOR) return msg;
+	try {
+		if (process.stderr.isTTY) return `\x1b[1;31m${msg}\x1b[0m`;
+	} catch {
+		// ignore
+	}
+	return msg;
+}
+
 /** Test-only: clear the per-process cache. */
 export function resetCacheForTests(): void {
 	_cache = undefined;
@@ -235,25 +257,30 @@ const HARDCODED_WORKSPACE_DEFAULT_REL = 'workspace';
 /**
  * Resolve the workspace directory per the canonical contract.
  *
- * Order:
- *   1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn once).
- *   2. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
- *   3. `{repoRoot}/workspace` baked-in default.
+ * Order (v0.8 — `$SUTANDO_WORKSPACE` no longer honored):
+ *   1. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
+ *   2. `{repoRoot}/workspace` baked-in default.
+ *
+ * If `$SUTANDO_WORKSPACE` is set in the environment, prints a one-time
+ * migration-nag warning pointing at `scripts/sutando-migrate.sh` but does
+ * NOT honor the env value (the legacy escape hatch was removed in v0.8
+ * per `docs/workspace-contract-v0.8.md`).
  *
  * Returns an absolute path. Does NOT create the directory.
  */
 export function resolveWorkspace(repoRoot?: string): string {
 	const envVal = process.env.SUTANDO_WORKSPACE?.trim();
-	if (envVal) {
-		if (!_legacyEnvWarnPrinted) {
-			_legacyEnvWarnPrinted = true;
-			process.stderr.write(
-				`sutando config: $SUTANDO_WORKSPACE is set ('${envVal}'); honoring as legacy escape ` +
-					`hatch. To silence, move the value into \`sutando.config.local.json\` under ` +
-					`\`workspace.path\` and unset the env.\n`,
-			);
-		}
-		return resolve(envVal.replace(/^~/, homedir()));
+	if (envVal && !_legacyEnvWarnPrinted) {
+		_legacyEnvWarnPrinted = true;
+		process.stderr.write(
+			_colorWarn(
+				`sutando config: $SUTANDO_WORKSPACE='${envVal}' is set but NO LONGER HONORED ` +
+					`(removed in v0.8). The workspace now resolves from sutando.config.{json,local.json} ` +
+					`or the {repoRoot}/workspace baked-in default. If you have existing workspace data at ` +
+					`'${envVal}', run \`bash scripts/sutando-migrate.sh --dry-run\` to preview a relocation, ` +
+					`then \`--commit\`. Unset $SUTANDO_WORKSPACE in your shell + .env to silence this warning.`,
+			) + '\n',
+		);
 	}
 
 	const cfg = loadConfig(repoRoot);
@@ -268,18 +295,21 @@ export function resolveWorkspace(repoRoot?: string): string {
 		resolved = resolve(join(root, HARDCODED_WORKSPACE_DEFAULT_REL));
 	}
 
-	// M0 .env-drift warning: if the env var is UNSET but `.env` declares one,
-	// surface the stale .env line once per process. See sutando_config.py for
-	// the design rationale — this is the TS twin of the same behavior.
+	// .env-drift warning: if `.env` still carries a stale SUTANDO_WORKSPACE line,
+	// surface it once per process so the operator can clean it up.
+	// (v0.8: the env var is no longer honored regardless of whether it's set in
+	// the shell or in .env; the warning is purely cleanup guidance.)
 	if (!_dotenvDriftWarnPrinted) {
 		_dotenvDriftWarnPrinted = true;
 		const dotenvVal = detectEnvWorkspaceInDotenv(repoRoot);
-		if (dotenvVal && resolve(dotenvVal) !== resolved) {
+		if (dotenvVal) {
 			process.stderr.write(
-				`sutando config: .env declares SUTANDO_WORKSPACE='${dotenvVal}', but resolved workspace ` +
-					`is ${resolved} (config-driven). The .env line is NOT honored by the new loader — ` +
-					`move the value to \`sutando.config.local.json\` under \`workspace.path\` and delete the ` +
-					`.env line, or \`source .env\` before launching processes that need the override.\n`,
+				_colorWarn(
+					`sutando config: .env declares SUTANDO_WORKSPACE='${dotenvVal}' but the env var is no ` +
+						`longer honored (removed in v0.8). Resolved workspace is ${resolved} (config-driven). ` +
+						`Delete the .env line and, if needed, move the value to \`sutando.config.local.json\` ` +
+						`under \`workspace.path\`.`,
+				) + '\n',
 			);
 		}
 	}

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -270,6 +270,16 @@ const HARDCODED_WORKSPACE_DEFAULT_REL = 'workspace';
  */
 export function resolveWorkspace(repoRoot?: string): string {
 	const envVal = process.env.SUTANDO_WORKSPACE?.trim();
+
+	// Test-only escape hatch: when `SUTANDO_TEST_MODE=1` is set, honor
+	// `$SUTANDO_WORKSPACE` silently. This preserves the v0.8 contract for
+	// end users (no env override; warning + ignore) while letting the test
+	// suite redirect workspace to per-test tmp dirs without rewriting every
+	// test fixture. Production code MUST NOT set `SUTANDO_TEST_MODE`.
+	if (envVal && process.env.SUTANDO_TEST_MODE === '1') {
+		return resolve(envVal.replace(/^~/, homedir()));
+	}
+
 	if (envVal && !_legacyEnvWarnPrinted) {
 		_legacyEnvWarnPrinted = true;
 		process.stderr.write(

--- a/src/workspace_resolve.sh
+++ b/src/workspace_resolve.sh
@@ -10,13 +10,11 @@
 # install-health-check-launchd.sh, session-handoff.sh. Factored out per
 # Lucy's PR #1399 review nit #1.
 #
-# Resolution order:
-#   1. scripts/sutando-config.sh helper (M0 default = <repo>/workspace/, env
-#      var honored internally as legacy escape hatch)
-#   2. $SUTANDO_WORKSPACE env var (only when helper is unreachable —
-#      non-checkout / extracted-tarball install)
-#   3. Fail loud with exit 1 + diagnostic. Refuses to silently write to a
-#      hardcoded legacy default.
+# Resolution order (v0.8 — env override removed):
+#   1. scripts/sutando-config.sh helper (<repo>/workspace/ resolved via
+#      sutando.config.{json,local.json} or the baked-in default).
+#   2. Fail loud with exit 1 + diagnostic. Refuses to silently write to a
+#      hardcoded legacy default OR a now-unhonored env var.
 #
 # Self-locating: looks for scripts/sutando-config.sh relative to THIS file's
 # own location (${BASH_SOURCE[0]}), NOT $REPO. This makes the function
@@ -33,10 +31,8 @@ resolve_workspace_or_die() {
       echo "${0##*/}: scripts/sutando-config.sh workspace exited non-zero." >&2
       exit 1
     fi
-  elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-    WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
   else
-    echo "${0##*/}: cannot resolve workspace — neither $helper exists nor \$SUTANDO_WORKSPACE is set." >&2
+    echo "${0##*/}: cannot resolve workspace — $helper does not exist. v0.8 contract requires the helper; \$SUTANDO_WORKSPACE is no longer honored." >&2
     exit 1
   fi
   if [ -z "$WORKSPACE" ]; then

--- a/tests/_helpers/temp-workspace.ts
+++ b/tests/_helpers/temp-workspace.ts
@@ -37,6 +37,10 @@ export function setupTempWorkspace(name: string): {
 } {
 	const workspace = mkdtempSync(join(tmpdir(), `sutando-test-${name}-`));
 	process.env.SUTANDO_WORKSPACE = workspace;
+	// v0.8: env override removed for end-users. Tests get a private
+	// escape hatch via SUTANDO_TEST_MODE=1, honored silently by
+	// resolveWorkspace() in src/sutando_config.{py,ts}.
+	process.env.SUTANDO_TEST_MODE = '1';
 	return {
 		workspace,
 		cleanup: () => {
@@ -45,6 +49,10 @@ export function setupTempWorkspace(name: string): {
 			} catch {
 				/* idempotent */
 			}
+			// Clear the test-only escape hatch so subsequent tests in the
+			// same process can exercise the production v0.8 code path.
+			delete process.env.SUTANDO_WORKSPACE;
+			delete process.env.SUTANDO_TEST_MODE;
 		},
 	};
 }

--- a/tests/agent-state-endpoint.test.ts
+++ b/tests/agent-state-endpoint.test.ts
@@ -69,6 +69,7 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 					// so concurrent test processes can't race on the file. Same
 					// SUTANDO_WORKSPACE env override the rest of the test suite uses.
 					SUTANDO_WORKSPACE: TEMP_WORKSPACE,
+					SUTANDO_TEST_MODE: '1',  // v0.8: enable env-override-in-test escape hatch
 				},
 				// 'ignore' prevents the pipe buffer from filling in CI (stdout isn't drained),
 				// which would block the child and cause the /sse-status poll to time out.

--- a/tests/bridges-sending-orphan-recovery.test.py
+++ b/tests/bridges-sending-orphan-recovery.test.py
@@ -37,6 +37,7 @@ REPO = Path(__file__).resolve().parent.parent
 # `RESULTS_DIR = REPO / "results"` at module-load time.
 _WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-orphan-recovery-test-")
 os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token-not-real")
 

--- a/tests/core-heartbeat.test.py
+++ b/tests/core-heartbeat.test.py
@@ -27,6 +27,7 @@ class TestHeartbeatWrite(unittest.TestCase):
         self._saved_env = os.environ.get("SUTANDO_WORKSPACE")
         self.tmp = Path(tempfile.mkdtemp(prefix="core-heartbeat-"))
         os.environ["SUTANDO_WORKSPACE"] = str(self.tmp)
+        os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
         # Force re-import so module picks up the new env.
         sys.modules.pop("core_heartbeat", None)
 

--- a/tests/discord-bridge-attachment-filename-sanitize.test.py
+++ b/tests/discord-bridge-attachment-filename-sanitize.test.py
@@ -36,6 +36,7 @@ REPO = Path(__file__).resolve().parent.parent
 
 _WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-discord-filename-test-")
 os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 # `discord-bridge.py` reads its token from `~/.claude/channels/discord/.env`
 # (file path), not from `os.environ["DISCORD_BOT_TOKEN"]`, and `exit(1)`s
 # at module load when the file is missing. CI has no such file. Stub the

--- a/tests/discord-bridge-delivery-sentinel.test.py
+++ b/tests/discord-bridge-delivery-sentinel.test.py
@@ -51,6 +51,7 @@ REPO = Path(__file__).resolve().parent.parent
 
 _WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-delivery-sentinel-test-")
 os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
 (Path(_WORKSPACE_TMP) / "state").mkdir(parents=True, exist_ok=True)
 

--- a/tests/discord-bridge-dm-catchup.test.py
+++ b/tests/discord-bridge-dm-catchup.test.py
@@ -44,6 +44,7 @@ REPO = Path(__file__).resolve().parent.parent
 # paths at module-load time.
 _WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-dm-catchup-test-")
 os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
 (Path(_WORKSPACE_TMP) / "state").mkdir(parents=True, exist_ok=True)
 

--- a/tests/init-script.test.ts
+++ b/tests/init-script.test.ts
@@ -29,6 +29,7 @@ function runInit(repoDir: string, mode?: '--auto' | '--preflight'): RunResult {
 			...process.env,
 			SUTANDO_REPO: repoDir,
 			SUTANDO_WORKSPACE: join(repoDir, '.workspace'),
+			SUTANDO_TEST_MODE: '1',  // v0.8: enable env-override-in-test escape hatch
 			HOME: repoDir + '/.fake-home',
 		},
 		encoding: 'utf-8',

--- a/tests/migration-safety-helpers.test.sh
+++ b/tests/migration-safety-helpers.test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Unit tests for src/migration_safety_helpers.sh — the four guard functions
+# that gate src/startup.sh's v0.8 auto-migration block.
+#
+# Coverage maps to PR #1440 review (Mini):
+#   B1: _same_inode + _realpath equality
+#   B3: _is_unsafe_for_migration deny-list
+#   B4: _color_warn NO_COLOR + TTY handling
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=../src/migration_safety_helpers.sh
+source "$REPO/src/migration_safety_helpers.sh"
+
+# Use /tmp explicitly (not `mktemp -d` which on macOS lands under /var/folders/
+# → /private/var/... which the deny-list legitimately catches as a /var subpath).
+TEST_DIR="/tmp/sutando-helpers-test-$$"
+mkdir -p "$TEST_DIR"
+trap "rm -rf '$TEST_DIR'" EXIT
+
+fail=0
+pass=0
+assert_true() {
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  OK: $desc"; pass=$((pass+1))
+  else
+    echo "  FAIL: $desc"; fail=$((fail+1))
+  fi
+}
+assert_false() {
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  FAIL: $desc (expected non-zero)"; fail=$((fail+1))
+  else
+    echo "  OK: $desc"; pass=$((pass+1))
+  fi
+}
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  OK: $desc"; pass=$((pass+1))
+  else
+    echo "  FAIL: $desc — expected '$expected', got '$actual'"; fail=$((fail+1))
+  fi
+}
+
+echo "==== _realpath ===="
+echo "data" > "$TEST_DIR/real.txt"
+ln -s "$TEST_DIR/real.txt" "$TEST_DIR/link.txt"
+real_via_real=$(_realpath "$TEST_DIR/real.txt")
+real_via_link=$(_realpath "$TEST_DIR/link.txt")
+assert_eq "symlink resolves to target" "$real_via_real" "$real_via_link"
+assert_true "non-existent path returns empty + nonzero" bash -c '[ -z "$(_realpath /nonexistent/path/zzz)" ]' || true  # both forms acceptable
+nonexistent=$(_realpath "/nonexistent/path/zzz-$$" || true)
+if command -v realpath >/dev/null 2>&1; then
+  # GNU realpath: returns parent + appends component; BSD: errors. Either is fine.
+  echo "  OK: non-existent realpath does not crash (output: '$nonexistent')"
+  pass=$((pass+1))
+fi
+
+echo
+echo "==== _same_inode ===="
+echo "x" > "$TEST_DIR/a.txt"
+echo "y" > "$TEST_DIR/b.txt"
+ln -s "$TEST_DIR/a.txt" "$TEST_DIR/a-link.txt"
+assert_true "file == itself" _same_inode "$TEST_DIR/a.txt" "$TEST_DIR/a.txt"
+assert_true "symlink == target (follows)" _same_inode "$TEST_DIR/a.txt" "$TEST_DIR/a-link.txt"
+assert_false "different files" _same_inode "$TEST_DIR/a.txt" "$TEST_DIR/b.txt"
+
+echo
+echo "==== _is_unsafe_for_migration ===="
+# Safe paths — should return 1 (non-zero = safe)
+SAFE_DIR="$TEST_DIR/sutando-fake-workspace"
+mkdir -p "$SAFE_DIR"
+assert_false "/tmp/<random>/sutando-fake-workspace is safe" _is_unsafe_for_migration "$SAFE_DIR"
+
+# Unsafe — should return 0 (zero = unsafe)
+assert_true "/ is unsafe"                _is_unsafe_for_migration "/"
+assert_true "/usr is unsafe"             _is_unsafe_for_migration "/usr"
+assert_true "/etc is unsafe"             _is_unsafe_for_migration "/etc"
+assert_true "/var is unsafe"             _is_unsafe_for_migration "/var"
+assert_true "/System is unsafe"          _is_unsafe_for_migration "/System"
+assert_true "\$HOME is unsafe"           _is_unsafe_for_migration "$HOME"
+assert_true "\$HOME/Documents is unsafe" _is_unsafe_for_migration "$HOME/Documents"
+assert_true "\$HOME/Desktop is unsafe"   _is_unsafe_for_migration "$HOME/Desktop"
+assert_true "\$HOME/Downloads is unsafe" _is_unsafe_for_migration "$HOME/Downloads"
+assert_true "\$REPO is unsafe"           _is_unsafe_for_migration "$REPO"
+assert_true "\$REPO/src is unsafe"       _is_unsafe_for_migration "$REPO/src"
+assert_true "non-existent path is unsafe" _is_unsafe_for_migration "/nonexistent/zzz-$$"
+
+# Symlink masquerading as safe but pointing at unsafe — realpath catches it
+ln -s "$HOME" "$TEST_DIR/sneaky-home-symlink"
+assert_true "symlink to \$HOME is unsafe (realpath resolves)" \
+  _is_unsafe_for_migration "$TEST_DIR/sneaky-home-symlink"
+
+echo
+echo "==== _color_warn (NO_COLOR + TTY) ===="
+# Test in a non-TTY (default in test runs): always plain, regardless of NO_COLOR.
+unset NO_COLOR
+out_no_tty=$(_color_warn "test message" 2>&1)
+case "$out_no_tty" in
+  *$'\033['*) echo "  FAIL: non-TTY emitted ANSI (got: $out_no_tty)"; fail=$((fail+1)) ;;
+  *"test message"*) echo "  OK: non-TTY emits plain text"; pass=$((pass+1)) ;;
+  *) echo "  FAIL: unexpected output: $out_no_tty"; fail=$((fail+1)) ;;
+esac
+
+NO_COLOR=1 out_no_color=$(NO_COLOR=1 _color_warn "test message" 2>&1)
+case "$out_no_color" in
+  *$'\033['*) echo "  FAIL: NO_COLOR=1 emitted ANSI"; fail=$((fail+1)) ;;
+  *"test message"*) echo "  OK: NO_COLOR=1 emits plain text"; pass=$((pass+1)) ;;
+esac
+
+# Force-TTY case: simulate with a script that opens /dev/tty as stderr.
+# We can't easily fake [ -t 2 ] in pure bash without `script`/`expect`, so
+# accept that the TTY-branch is harder to assert; verify the NO_COLOR shortcut
+# wins even on TTY:
+if command -v script >/dev/null 2>&1; then
+  # On macOS, `script -q /dev/null cmd` runs cmd with a TTY-backed stdout/stderr.
+  out_tty=$(script -q /dev/null bash -c "source $REPO/src/migration_safety_helpers.sh; _color_warn 'tty msg'" 2>&1 || true)
+  case "$out_tty" in
+    *$'\033['*) echo "  OK: TTY branch emits ANSI when NO_COLOR is unset"; pass=$((pass+1)) ;;
+    *"tty msg"*) echo "  INFO: TTY emulation did not yield ANSI (env may not honor -t 2; non-blocking)"; pass=$((pass+1)) ;;
+    *) echo "  INFO: script-based TTY test inconclusive ($out_tty)"; pass=$((pass+1)) ;;
+  esac
+  out_tty_nc=$(script -q /dev/null env NO_COLOR=1 bash -c "source $REPO/src/migration_safety_helpers.sh; _color_warn 'tty msg'" 2>&1 || true)
+  case "$out_tty_nc" in
+    *$'\033['*) echo "  FAIL: TTY + NO_COLOR=1 still emitted ANSI"; fail=$((fail+1)) ;;
+    *"tty msg"*) echo "  OK: TTY + NO_COLOR=1 suppresses ANSI"; pass=$((pass+1)) ;;
+  esac
+fi
+
+echo
+echo "===================="
+echo "Total: $((pass+fail)) — pass: $pass, fail: $fail"
+exit $fail

--- a/tests/migration-safety-helpers.test.sh
+++ b/tests/migration-safety-helpers.test.sh
@@ -96,6 +96,59 @@ ln -s "$HOME" "$TEST_DIR/sneaky-home-symlink"
 assert_true "symlink to \$HOME is unsafe (realpath resolves)" \
   _is_unsafe_for_migration "$TEST_DIR/sneaky-home-symlink"
 
+# ---- PR #1440 v1 — Mini review (2026-06-04 02:30Z) deny-list expansion -----
+# /tmp + /private/tmp exact deny (subdirs remain safe; mktemp targets work).
+# NOTE: the function returns "unsafe" for non-existent paths (realpath empty)
+# as a defensive default, so safe-case tests must use EXISTING paths.
+mkdir -p "$TEST_DIR/safe-subdir-of-tmp"
+assert_true  "/tmp (exact) is unsafe"               _is_unsafe_for_migration "/tmp"
+assert_true  "/private/tmp (exact) is unsafe"       _is_unsafe_for_migration "/private/tmp"
+assert_false "/tmp/<existing-subdir> is safe"       _is_unsafe_for_migration "$TEST_DIR/safe-subdir-of-tmp"
+# (TEST_DIR is /tmp/sutando-helpers-test-$$ so this exercises the subdir-allow case)
+
+# $HOME/Documents/* descendants — exact-only deny would leave these vulnerable.
+# These are non-existent paths under the real $HOME; deny applies regardless.
+assert_true "\$HOME/Documents/foo descendant is unsafe" \
+  _is_unsafe_for_migration "$HOME/Documents/foo-test-$$"
+assert_true "\$HOME/Desktop/foo descendant is unsafe" \
+  _is_unsafe_for_migration "$HOME/Desktop/foo-test-$$"
+assert_true "\$HOME/Downloads/foo descendant is unsafe" \
+  _is_unsafe_for_migration "$HOME/Downloads/foo-test-$$"
+
+# $HOME/.sutando deny + .sutando/workspace allow exception. Use a fake $HOME
+# to avoid touching the real ~/.sutando/ tree (the test must mkdir the allow-
+# case paths because the function rejects non-existent paths as unsafe).
+# IMPORTANT: realpath the fake-home so HOME matches the realpath'd subpaths
+# (on macOS /tmp -> /private/tmp; case-pattern uses literal $HOME, so an
+# unsymlinked literal HOME won't match realpath'd /private/tmp/... paths).
+# On real systems $HOME is /Users/... so this collision doesn't arise.
+FAKE_HOME_RAW="$TEST_DIR/fake-home"
+mkdir -p "$FAKE_HOME_RAW"
+FAKE_HOME="$(_realpath "$FAKE_HOME_RAW")"
+mkdir -p "$FAKE_HOME/.sutando/workspace/sub" \
+         "$FAKE_HOME/.sutando/notworkspace" \
+         "$FAKE_HOME/.claude/sub" \
+         "$FAKE_HOME/.config/sub"
+REAL_HOME="$HOME"
+HOME="$FAKE_HOME"
+assert_true  "fake \$HOME/.sutando (exact) is unsafe" \
+  _is_unsafe_for_migration "$HOME/.sutando"
+assert_true  "fake \$HOME/.sutando/notworkspace is unsafe" \
+  _is_unsafe_for_migration "$HOME/.sutando/notworkspace"
+assert_false "fake \$HOME/.sutando/workspace is SAFE (legacy default, intentional migration source)" \
+  _is_unsafe_for_migration "$HOME/.sutando/workspace"
+assert_false "fake \$HOME/.sutando/workspace/sub is SAFE (subpath of legacy default)" \
+  _is_unsafe_for_migration "$HOME/.sutando/workspace/sub"
+assert_true  "fake \$HOME/.claude (exact) is unsafe" \
+  _is_unsafe_for_migration "$HOME/.claude"
+assert_true  "fake \$HOME/.claude/sub is unsafe" \
+  _is_unsafe_for_migration "$HOME/.claude/sub"
+assert_true  "fake \$HOME/.config (exact) is unsafe" \
+  _is_unsafe_for_migration "$HOME/.config"
+assert_true  "fake \$HOME/.config/sub is unsafe" \
+  _is_unsafe_for_migration "$HOME/.config/sub"
+HOME="$REAL_HOME"
+
 echo
 echo "==== _color_warn (NO_COLOR + TTY) ===="
 # Test in a non-TTY (default in test runs): always plain, regardless of NO_COLOR.

--- a/tests/outbox-log.test.py
+++ b/tests/outbox-log.test.py
@@ -20,12 +20,14 @@ class TestOutboxAppend(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.workspace = Path(self.tmp.name)
         os.environ["SUTANDO_WORKSPACE"] = str(self.workspace)
+        os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
         # Some helper modules cache resolve_workspace via module-level constants;
         # outbox_log does NOT cache (calls _outbox_path() fresh on each append)
         # so we don't need to reload.
 
     def tearDown(self):
         os.environ.pop("SUTANDO_WORKSPACE", None)
+        os.environ.pop("SUTANDO_TEST_MODE", None)
         self.tmp.cleanup()
 
     def _read(self) -> list[dict]:

--- a/tests/quota-burn-rate.test.py
+++ b/tests/quota-burn-rate.test.py
@@ -25,6 +25,7 @@ _SCRIPT = REPO / "skills" / "quota-tracker" / "scripts" / "read-quota.py"
 def _load_module(workspace: Path):
     """Load read-quota.py with a controlled workspace and a dummy quota-state.json."""
     os.environ["SUTANDO_WORKSPACE"] = str(workspace)
+    os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
     sys.modules.pop("read_quota", None)
     sys.modules.pop("read_quota_under_test", None)
 

--- a/tests/single-instance.test.py
+++ b/tests/single-instance.test.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(ROOT / "src"))
 def _load_single_instance(workspace_dir: Path):
     """Load single_instance with SUTANDO_WORKSPACE pointing at a temp dir."""
     os.environ["SUTANDO_WORKSPACE"] = str(workspace_dir)
+    os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
     # Reload to pick up new env — module caches resolve_workspace() at call time.
     spec = importlib.util.spec_from_file_location(
         "single_instance", ROOT / "src" / "single_instance.py"
@@ -38,9 +39,11 @@ class TestSingleInstance(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.workspace = Path(self.tmp.name)
         os.environ["SUTANDO_WORKSPACE"] = str(self.workspace)
+        os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 
     def tearDown(self):
         os.environ.pop("SUTANDO_WORKSPACE", None)
+        os.environ.pop("SUTANDO_TEST_MODE", None)
         self.tmp.cleanup()
 
     # (a) First acquire writes PID to lock file and returns normally.
@@ -62,7 +65,7 @@ class TestSingleInstance(unittest.TestCase):
             [
                 sys.executable, "-c",
                 f"import sys; sys.path.insert(0, '{ROOT}/src');"
-                f"import os; os.environ['SUTANDO_WORKSPACE']='{self.workspace}';"
+                f"import os; os.environ['SUTANDO_WORKSPACE']='{self.workspace}'; os.environ['SUTANDO_TEST_MODE']='1';"
                 f"from single_instance import acquire; acquire('test-second')",
             ],
             capture_output=True,
@@ -78,7 +81,7 @@ class TestSingleInstance(unittest.TestCase):
             [
                 sys.executable, "-c",
                 f"import sys, time; sys.path.insert(0, '{ROOT}/src');"
-                f"import os; os.environ['SUTANDO_WORKSPACE']='{self.workspace}';"
+                f"import os; os.environ['SUTANDO_WORKSPACE']='{self.workspace}'; os.environ['SUTANDO_TEST_MODE']='1';"
                 f"from single_instance import acquire; acquire('test-release');"
                 f"time.sleep(30)",  # hold forever — we'll kill it
             ],

--- a/tests/slack-bridge-orphan-recovery.test.py
+++ b/tests/slack-bridge-orphan-recovery.test.py
@@ -26,6 +26,7 @@ def _load_bridge(workspace: Path):
     os.environ["SLACK_BOT_TOKEN"] = "xoxb-test-token"
     os.environ["SLACK_APP_TOKEN"] = "xapp-test-token"
     os.environ["SUTANDO_WORKSPACE"] = str(workspace)
+    os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 
     # Remove any cached module so env takes effect on fresh import.
     sys.modules.pop("slack_bridge_under_test", None)

--- a/tests/slack-bridge-task-timeout.test.py
+++ b/tests/slack-bridge-task-timeout.test.py
@@ -28,6 +28,7 @@ def _load_bridge(workspace: Path):
     os.environ["SLACK_BOT_TOKEN"] = "xoxb-test-token"
     os.environ["SLACK_APP_TOKEN"] = "xapp-test-token"
     os.environ["SUTANDO_WORKSPACE"] = str(workspace)
+    os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
     os.environ["SLACK_TASK_TIMEOUT_SEC"] = "600"
 
     sys.modules.pop("slack_bridge_timeout_under_test", None)

--- a/tests/sutando-config-shell.test.ts
+++ b/tests/sutando-config-shell.test.ts
@@ -22,7 +22,7 @@ const SCRIPT = join(REPO_ROOT, 'scripts', 'sutando-config.sh');
 
 function runShell(subcmd: string, ws: string): string {
 	const proc = spawnSync('bash', [SCRIPT, subcmd], {
-		env: { ...process.env, SUTANDO_WORKSPACE: ws },
+		env: { ...process.env, SUTANDO_WORKSPACE: ws, SUTANDO_TEST_MODE: '1' },
 		encoding: 'utf-8',
 	});
 	if (proc.status !== 0) {
@@ -37,7 +37,7 @@ function runPyResolve(ws: string): string {
 		['-c', 'import sys; sys.path.insert(0, ".."); from importlib import import_module; m = import_module("src.sutando_config"); print(m.resolve_workspace(), end="")'],
 		{
 			cwd: REPO_ROOT,
-			env: { ...process.env, SUTANDO_WORKSPACE: ws },
+			env: { ...process.env, SUTANDO_WORKSPACE: ws, SUTANDO_TEST_MODE: '1' },
 			encoding: 'utf-8',
 		},
 	);
@@ -66,7 +66,7 @@ describe('sutando-config.sh wrapper', () => {
 		const proc = spawnSync(
 			'python3',
 			['-c', 'import sys; sys.path.insert(0, "."); from src.sutando_config import resolve_workspace; print(resolve_workspace(), end="")'],
-			{ cwd: REPO_ROOT, env: { ...process.env, SUTANDO_WORKSPACE: ws }, encoding: 'utf-8' },
+			{ cwd: REPO_ROOT, env: { ...process.env, SUTANDO_WORKSPACE: ws, SUTANDO_TEST_MODE: '1' }, encoding: 'utf-8' },
 		);
 		assert.equal(proc.status, 0, `py loader failed: ${proc.stderr}`);
 		assert.equal(shellOut, proc.stdout, 'shell wrapper diverges from py loader');
@@ -114,7 +114,7 @@ describe('sutando-config.sh wrapper', () => {
 
 		// Second run — must be a no-op (idempotent)
 		const second = spawnSync('bash', [SCRIPT, 'bootstrap'], {
-			env: { ...process.env, SUTANDO_WORKSPACE: ws },
+			env: { ...process.env, SUTANDO_WORKSPACE: ws, SUTANDO_TEST_MODE: '1' },
 			encoding: 'utf-8',
 		});
 		assert.equal(second.status, 0, `second bootstrap exit ${second.status}: ${second.stderr}`);

--- a/tests/sutando-config.prod-path.test.py
+++ b/tests/sutando-config.prod-path.test.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""PR #1440 v1 — production-path tests for src/sutando_config.py.
+
+Python twin of tests/sutando-config.prod-path.test.ts. Mini's v1 review
+(2026-06-04 02:30Z) flagged that the existing test suite leans on
+`SUTANDO_TEST_MODE=1`, leaving the production code path (env-set, no escape
+hatch) under-covered. This file exercises that path directly and asserts the
+B4 safety properties on the Python side too.
+
+Coverage parity with the TS twin:
+  - NO_COLOR=1 → no ANSI escapes in deprecation stderr.
+  - non-TTY stderr → no ANSI escapes regardless of NO_COLOR (sys.stderr.isatty()
+    is False under unittest's StringIO capture).
+  - Warning text contains NO literal `'<value>'` interpolation for either the
+    env-var value or the .env-declared value (c58270d safety pass — verifies
+    no regression).
+  - Warning fires exactly once per process (_LEGACY_ENV_WARN_PRINTED guard).
+  - resolver returns config/default path with env set + no TEST_MODE.
+
+Run: python3 tests/sutando-config.prod-path.test.py
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+import sutando_config  # noqa: E402
+from sutando_config import (  # noqa: E402
+    _reset_cache_for_tests,
+    resolve_workspace,
+)
+
+ANSI_RE = re.compile(r"\x1b\[")
+
+
+@contextmanager
+def capture_stderr() -> io.StringIO:
+    """Redirect sys.stderr to a StringIO for the duration of the block."""
+    orig = sys.stderr
+    buf = io.StringIO()
+    sys.stderr = buf
+    try:
+        yield buf
+    finally:
+        sys.stderr = orig
+
+
+class TestProdPath(unittest.TestCase):
+    """End-to-end resolver invocations with $SUTANDO_WORKSPACE set + no TEST_MODE."""
+
+    def setUp(self) -> None:
+        # Snapshot + clear env; reset per-process cache for warning state.
+        self._saved_env = os.environ.pop("SUTANDO_WORKSPACE", None)
+        self._saved_no_color = os.environ.pop("NO_COLOR", None)
+        self._saved_test_mode = os.environ.pop("SUTANDO_TEST_MODE", None)
+        _reset_cache_for_tests()
+        self._tmpdir = tempfile.mkdtemp(prefix="sutando-prod-path-")
+        self.repo = Path(self._tmpdir)
+
+    def tearDown(self) -> None:
+        _reset_cache_for_tests()
+        if self._saved_env is None:
+            os.environ.pop("SUTANDO_WORKSPACE", None)
+        else:
+            os.environ["SUTANDO_WORKSPACE"] = self._saved_env
+        if self._saved_no_color is None:
+            os.environ.pop("NO_COLOR", None)
+        else:
+            os.environ["NO_COLOR"] = self._saved_no_color
+        if self._saved_test_mode is None:
+            os.environ.pop("SUTANDO_TEST_MODE", None)
+        else:
+            os.environ["SUTANDO_TEST_MODE"] = self._saved_test_mode
+        # Clean up tmp dir
+        import shutil
+
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    # --- B4: NO_COLOR honored --------------------------------------------- #
+
+    def test_no_color_one_strips_ansi(self) -> None:
+        """NO_COLOR=1 → deprecation warning has zero ANSI escapes."""
+        os.environ["SUTANDO_WORKSPACE"] = "/from/env"
+        os.environ["NO_COLOR"] = "1"
+        with capture_stderr() as buf:
+            resolve_workspace(self.repo)
+        captured = buf.getvalue()
+        self.assertIn("NO LONGER HONORED", captured, "expected deprecation text in stderr")
+        self.assertIsNone(
+            ANSI_RE.search(captured),
+            f"expected zero ANSI escapes, got: {captured!r}",
+        )
+
+    def test_non_tty_stderr_strips_ansi(self) -> None:
+        """Non-TTY stderr (StringIO) → no ANSI escapes regardless of NO_COLOR."""
+        os.environ["SUTANDO_WORKSPACE"] = "/from/env"
+        # NO_COLOR explicitly unset.
+        with capture_stderr() as buf:
+            resolve_workspace(self.repo)
+        captured = buf.getvalue()
+        self.assertIn("NO LONGER HONORED", captured)
+        self.assertIsNone(
+            ANSI_RE.search(captured),
+            f"expected zero ANSI escapes on non-TTY, got: {captured!r}",
+        )
+
+    # --- B4: path-leak — warnings must not contain literal path values ----- #
+
+    def test_warning_omits_literal_env_value(self) -> None:
+        """c58270d safety pass — env-set warning omits the env-var value."""
+        sneaky = "/this/literal/path/must/not/appear/in/stderr"
+        os.environ["SUTANDO_WORKSPACE"] = sneaky
+        with capture_stderr() as buf:
+            resolve_workspace(self.repo)
+        captured = buf.getvalue()
+        self.assertNotIn(
+            sneaky,
+            captured,
+            f"warning leaked the env-var value: {captured!r}",
+        )
+
+    def test_warning_omits_literal_dotenv_value(self) -> None:
+        """c58270d safety pass — .env-drift warning omits the dotenv value."""
+        sneaky = "/sneaky/dotenv/value/must/not/leak"
+        (self.repo / ".env").write_text(f"SUTANDO_WORKSPACE={sneaky}\n", encoding="utf-8")
+        with capture_stderr() as buf:
+            resolve_workspace(self.repo)
+        captured = buf.getvalue()
+        self.assertNotIn(
+            sneaky,
+            captured,
+            f".env-drift warning leaked the value: {captured!r}",
+        )
+
+    # --- One-shot warning ---------------------------------------------------- #
+
+    def test_warning_is_one_shot_across_calls(self) -> None:
+        """Deprecation warning fires exactly once across 3 resolve calls."""
+        os.environ["SUTANDO_WORKSPACE"] = "/from/env"
+        with capture_stderr() as buf:
+            resolve_workspace(self.repo)
+            resolve_workspace(self.repo)
+            resolve_workspace(self.repo)
+        captured = buf.getvalue()
+        n = captured.count("NO LONGER HONORED")
+        self.assertEqual(
+            n,
+            1,
+            f"expected exactly one deprecation warning across 3 calls, got {n}; full: {captured!r}",
+        )
+
+    # --- Resolver returns the config-driven / default path with env set ---- #
+
+    def test_env_set_plus_local_config_returns_config_path(self) -> None:
+        """env set + sutando.config.local.json present → config wins."""
+        (self.repo / "sutando.config.local.json").write_text(
+            json.dumps({"workspace": {"path": "/from/local/config"}}),
+            encoding="utf-8",
+        )
+        os.environ["SUTANDO_WORKSPACE"] = "/from/env"
+        with capture_stderr():
+            resolved = resolve_workspace(self.repo)
+        self.assertEqual(str(resolved), "/from/local/config")
+
+    def test_env_set_plus_no_config_returns_baked_in_default(self) -> None:
+        """env set + no config → resolver returns {repoRoot}/workspace.
+
+        Compare against resolve()d expected path because macOS /var symlinks
+        to /private/var; the resolver returns the realpath form.
+        """
+        os.environ["SUTANDO_WORKSPACE"] = "/from/env"
+        with capture_stderr():
+            resolved = resolve_workspace(self.repo)
+        expected = (self.repo / "workspace").resolve()
+        self.assertEqual(str(resolved), str(expected))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sutando-config.prod-path.test.ts
+++ b/tests/sutando-config.prod-path.test.ts
@@ -1,0 +1,203 @@
+/**
+ * PR #1440 — production-path tests for src/sutando_config.ts.
+ *
+ * Mini review noted that the existing test suite leans on `SUTANDO_TEST_MODE=1`,
+ * leaving the production code path (env-set, no escape hatch) under-covered. This
+ * file exercises that path directly and asserts the B4 safety properties:
+ *
+ *   - NO_COLOR=1 → no ANSI escapes in deprecation stderr, even on a TTY-like stream.
+ *   - Non-TTY stderr → no ANSI escapes regardless of NO_COLOR.
+ *   - Warning text contains NO literal `'<value>'` interpolation for either the
+ *     env-var value or the .env-declared value (B4 path-leak parity with c58270d).
+ *   - Warning fires exactly once per process (resetCacheForTests as the inverse).
+ *
+ * Run: tsx --test tests/sutando-config.prod-path.test.ts
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { resetCacheForTests, resolveWorkspace } from '../src/sutando_config.js';
+
+interface CapturedStderr {
+	chunks: string[];
+	restore: () => void;
+}
+
+function captureStderr(): CapturedStderr {
+	const chunks: string[] = [];
+	const orig = process.stderr.write.bind(process.stderr);
+	process.stderr.write = ((chunk: string | Uint8Array, ..._args: unknown[]): boolean => {
+		const s = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+		chunks.push(s);
+		return true;
+	}) as typeof process.stderr.write;
+	return {
+		chunks,
+		restore: () => {
+			process.stderr.write = orig;
+		},
+	};
+}
+
+describe('sutando_config — production path (env-set, no TEST_MODE)', () => {
+	let savedEnv: string | undefined;
+	let savedNoColor: string | undefined;
+	let savedTestMode: string | undefined;
+	let repo: string;
+
+	beforeEach(() => {
+		savedEnv = process.env.SUTANDO_WORKSPACE;
+		savedNoColor = process.env.NO_COLOR;
+		savedTestMode = process.env.SUTANDO_TEST_MODE;
+		delete process.env.SUTANDO_WORKSPACE;
+		delete process.env.NO_COLOR;
+		delete process.env.SUTANDO_TEST_MODE;
+		resetCacheForTests();
+		repo = mkdtempSync(join(tmpdir(), 'sutando-prod-path-'));
+	});
+
+	afterEach(() => {
+		resetCacheForTests();
+		if (savedEnv === undefined) delete process.env.SUTANDO_WORKSPACE;
+		else process.env.SUTANDO_WORKSPACE = savedEnv;
+		if (savedNoColor === undefined) delete process.env.NO_COLOR;
+		else process.env.NO_COLOR = savedNoColor;
+		if (savedTestMode === undefined) delete process.env.SUTANDO_TEST_MODE;
+		else process.env.SUTANDO_TEST_MODE = savedTestMode;
+		if (repo) rmSync(repo, { recursive: true, force: true });
+	});
+
+	// --- B4: NO_COLOR honored --------------------------------------------- //
+
+	it('NO_COLOR=1 → deprecation warning has zero ANSI escapes', () => {
+		process.env.SUTANDO_WORKSPACE = '/from/env';
+		process.env.NO_COLOR = '1';
+		const cap = captureStderr();
+		try {
+			resolveWorkspace(repo);
+		} finally {
+			cap.restore();
+		}
+		const combined = cap.chunks.join('');
+		assert.ok(combined.includes('NO LONGER HONORED'), 'expected deprecation text in stderr');
+		// eslint-disable-next-line no-control-regex
+		assert.equal(combined.match(/\x1b\[/g), null, `expected zero ANSI escapes, got: ${combined}`);
+	});
+
+	it('non-TTY stderr → zero ANSI escapes (no NO_COLOR set)', () => {
+		// In node:test, process.stderr.isTTY is undefined/falsy. The code branch
+		// `process.stderr.isTTY` short-circuits to plain text. This guards against
+		// a regression where the branch defaults to ANSI on falsy isTTY.
+		process.env.SUTANDO_WORKSPACE = '/from/env';
+		const cap = captureStderr();
+		try {
+			resolveWorkspace(repo);
+		} finally {
+			cap.restore();
+		}
+		const combined = cap.chunks.join('');
+		assert.ok(combined.includes('NO LONGER HONORED'), 'expected deprecation text in stderr');
+		// eslint-disable-next-line no-control-regex
+		assert.equal(combined.match(/\x1b\[/g), null, `expected zero ANSI escapes on non-TTY, got: ${combined}`);
+	});
+
+	// --- B4: path-leak — no literal '${envVal}' interpolation -------------- //
+
+	it('warning text does NOT contain the literal env-var path value', () => {
+		// c58270d parity (Python) — the deprecation warning must not echo the
+		// /-bearing value into stderr because a caller-side `$(... 2>&1)` capture
+		// followed by `mkdir -p "$captured"` previously tokenized the / chars
+		// into a rogue folder tree. The advice text still mentions
+		// `--dry-run`/`--commit` so operators know what to run.
+		const sneakyValue = '/this/literal/should/not/appear/in/stderr';
+		process.env.SUTANDO_WORKSPACE = sneakyValue;
+		const cap = captureStderr();
+		try {
+			resolveWorkspace(repo);
+		} finally {
+			cap.restore();
+		}
+		const combined = cap.chunks.join('');
+		assert.ok(
+			!combined.includes(sneakyValue),
+			`warning leaked the env-var value: ${JSON.stringify(combined)}`,
+		);
+	});
+
+	it('warning text does NOT contain the literal .env-declared path value', () => {
+		// Same B4 property for the .env-drift warning (second stderr line).
+		// Note: this requires the .env to declare SUTANDO_WORKSPACE so the
+		// dotenv-drift branch fires; we write a .env into the test repo.
+		const sneakyDotenv = '/sneaky/dotenv/value/should/not/leak';
+		writeFileSync(join(repo, '.env'), `SUTANDO_WORKSPACE=${sneakyDotenv}\n`, 'utf8');
+		// SUTANDO_WORKSPACE in the env triggers the first warning; without it
+		// the dotenv branch still fires (it's keyed off the file content, not
+		// the process env).
+		const cap = captureStderr();
+		try {
+			resolveWorkspace(repo);
+		} finally {
+			cap.restore();
+		}
+		const combined = cap.chunks.join('');
+		// The first (env) warning may or may not fire; the second (.env-drift)
+		// must not leak the literal value.
+		assert.ok(
+			!combined.includes(sneakyDotenv),
+			`.env-drift warning leaked the dotenv value: ${JSON.stringify(combined)}`,
+		);
+	});
+
+	// --- B4: warning fires exactly once per process ------------------------ //
+
+	it('deprecation warning is one-shot across multiple resolveWorkspace calls', () => {
+		process.env.SUTANDO_WORKSPACE = '/from/env';
+		const cap = captureStderr();
+		try {
+			resolveWorkspace(repo);
+			resolveWorkspace(repo);
+			resolveWorkspace(repo);
+		} finally {
+			cap.restore();
+		}
+		const combined = cap.chunks.join('');
+		const occurrences = combined.match(/NO LONGER HONORED/g)?.length ?? 0;
+		assert.equal(
+			occurrences,
+			1,
+			`expected exactly one deprecation warning across 3 calls, got ${occurrences}`,
+		);
+	});
+
+	// --- resolver still returns config/default path with env set ----------- //
+
+	it('env set + config has workspace.path → resolver returns the config-driven path', () => {
+		writeFileSync(
+			join(repo, 'sutando.config.local.json'),
+			JSON.stringify({ workspace: { path: '/from/local/config' } }),
+			'utf8',
+		);
+		process.env.SUTANDO_WORKSPACE = '/from/env';
+		const cap = captureStderr();
+		try {
+			const resolved = resolveWorkspace(repo);
+			assert.equal(resolved, '/from/local/config');
+		} finally {
+			cap.restore();
+		}
+	});
+
+	it('env set + no config → resolver returns the baked-in {repoRoot}/workspace', () => {
+		process.env.SUTANDO_WORKSPACE = '/from/env';
+		const cap = captureStderr();
+		try {
+			const resolved = resolveWorkspace(repo);
+			assert.equal(resolved, join(repo, 'workspace'));
+		} finally {
+			cap.restore();
+		}
+	});
+});

--- a/tests/sutando-config.test.py
+++ b/tests/sutando-config.test.py
@@ -74,17 +74,25 @@ class TestSutandoConfig(unittest.TestCase):
         self._tmp.cleanup()
 
     # ------------------------------------------------------------------ #
-    #  1. Env var precedence over .local.json                            #
+    #  1. v0.8: env var IGNORED; .local.json wins                         #
     # ------------------------------------------------------------------ #
 
-    def test_env_var_precedence_over_local_json(self):
+    def test_env_var_ignored_in_favor_of_local_json(self):
+        # v0.8 contract: `$SUTANDO_WORKSPACE` is no longer honored.
+        # Setting it must NOT override `sutando.config.local.json`; the
+        # resolver emits a one-time deprecation warning and returns the
+        # config-resolved path. Test guards against accidental re-enable of
+        # the legacy precedence (which was the v0.7 / M0 / M1 behavior).
         _write_config(self.repo, "sutando.config.json",
                       {"workspace": {"path": "${REPO_DIR}/workspace"}})
         _write_config(self.repo, "sutando.config.local.json",
                       {"workspace": {"path": "/from/local"}})
         os.environ["SUTANDO_WORKSPACE"] = "/from/env"
+        # SUTANDO_TEST_MODE is NOT set here — we test the production code
+        # path that ignores the env var.
+        os.environ.pop("SUTANDO_TEST_MODE", None)
         resolved = resolve_workspace(repo_root=self.repo)
-        self.assertEqual(str(resolved), str(Path("/from/env").resolve()))
+        self.assertEqual(str(resolved), str(Path("/from/local").resolve()))
 
     # ------------------------------------------------------------------ #
     #  2. Deep-merge: dicts merge, arrays REPLACE                        #
@@ -309,23 +317,26 @@ class TestSutandoConfig(unittest.TestCase):
             resolve_claude_sutando_config_dir(repo_root=self.repo)
         self.assertIn("workspace-sub-folder invariant", str(cm.exception))
 
-    def test_claude_sutando_config_dir_honors_env_workspace_override(self):
-        # Owner-raised: if user sets $SUTANDO_WORKSPACE to a custom path,
-        # the returned ccd path must be `<custom>/.claude-sutando` (string-prefix
-        # consistent with resolve_workspace's return value, not the symlink-
-        # canonicalized form). Regression test: pre-fix code returned
-        # `/private/tmp/.../.claude-sutando` on macOS when env pointed to /tmp.
+    def test_claude_sutando_config_dir_lands_at_config_workspace(self):
+        # v0.8: `$SUTANDO_WORKSPACE` is no longer honored. The previous
+        # version of this test asserted ccd followed the env-overridden
+        # workspace; now it must follow the config-resolved workspace.
+        # The string-prefix invariant the caller relies on (ccd is always
+        # `<workspace>/.claude-sutando`) still holds.
         with tempfile.TemporaryDirectory() as ws_dir:
             old_env = os.environ.get("SUTANDO_WORKSPACE")
-            os.environ["SUTANDO_WORKSPACE"] = ws_dir
+            os.environ["SUTANDO_WORKSPACE"] = ws_dir  # set, but should be ignored
+            os.environ.pop("SUTANDO_TEST_MODE", None)
             try:
                 _write_config(self.repo, "sutando.config.json", {})
                 _reset_cache_for_tests()
                 ws = resolve_workspace(repo_root=self.repo)
                 ccd = resolve_claude_sutando_config_dir(repo_root=self.repo)
-                # The exact behavior the owner asked about:
+                # Workspace falls back to the baked-in default (env ignored):
+                self.assertEqual(str(ws), str((self.repo / "workspace").resolve()))
+                # Ccd lands under the resolved workspace, not env:
                 self.assertEqual(str(ccd), str(ws / ".claude-sutando"))
-                # And the string-prefix invariant the caller relies on:
+                # String-prefix invariant the caller relies on:
                 self.assertTrue(str(ccd).startswith(str(ws)))
             finally:
                 if old_env is None:

--- a/tests/sutando-config.test.ts
+++ b/tests/sutando-config.test.ts
@@ -61,16 +61,23 @@ describe('sutando_config loader', () => {
 	};
 
 	// ------------------------------------------------------------------ //
-	//  1. Env var precedence over .local.json                            //
+	//  1. v0.8: env var IGNORED; .local.json wins                         //
 	// ------------------------------------------------------------------ //
 
-	it('env var takes precedence over .local.json', () => {
+	it('env var is ignored in favor of .local.json (v0.8)', () => {
+		// v0.8 contract: `$SUTANDO_WORKSPACE` is no longer honored.
+		// Setting it must NOT override `sutando.config.local.json`; the
+		// resolver emits a one-time deprecation warning and returns the
+		// config-resolved path. Test guards against accidental re-enable of
+		// the legacy precedence (v0.7 / M0 / M1 behavior).
 		writeConfig(repo, 'sutando.config.json', { workspace: { path: '${REPO_DIR}/workspace' } });
 		writeConfig(repo, 'sutando.config.local.json', { workspace: { path: '/from/local' } });
 		process.env.SUTANDO_WORKSPACE = '/from/env';
+		// SUTANDO_TEST_MODE must not be set — we test the production code path.
+		delete process.env.SUTANDO_TEST_MODE;
 		try {
 			const resolved = resolveWorkspace(repo);
-			assert.equal(resolved, resolve('/from/env'));
+			assert.equal(resolved, resolve('/from/local'));
 		} finally {
 			restoreEnvAndRepo();
 		}

--- a/tests/task-bridge-stop-at-task-delimiter.test.ts
+++ b/tests/task-bridge-stop-at-task-delimiter.test.ts
@@ -15,6 +15,7 @@ import { join } from 'node:path';
 // expecting `false` passed *by accident* — file-not-found → false.)
 const TMP = mkdtempSync(join(tmpdir(), 'sutando-isvoice-test-'));
 process.env.SUTANDO_WORKSPACE = TMP;
+process.env.SUTANDO_TEST_MODE = '1';  // v0.8: opt-in env-honor
 mkdirSync(join(TMP, 'tasks'), { recursive: true });
 
 const { _isVoiceTask } = await import('../src/task-bridge.js');

--- a/tests/telegram-bridge-proactive-owner-resolution.test.py
+++ b/tests/telegram-bridge-proactive-owner-resolution.test.py
@@ -32,6 +32,7 @@ REPO = Path(__file__).resolve().parent.parent
 
 _WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-telegram-resolve-test-")
 os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token-not-real")
 
 

--- a/tests/workspace-default-relative-env.test.py
+++ b/tests/workspace-default-relative-env.test.py
@@ -44,12 +44,13 @@ def test_relative_env_path_is_anchored_to_cwd_absolute():
     """Bug fix regression guard. A relative `SUTANDO_WORKSPACE` MUST
     NOT survive resolution — anchor to CWD-at-resolve-time so two
     processes (different CWDs) don't silently split-brain on the same
-    env value."""
+    env value. v0.8: env honored only under SUTANDO_TEST_MODE=1."""
     snap = _clear_env()
     tmp = Path(tempfile.mkdtemp(prefix="sutando-ws-cwd-"))
     original_cwd = Path.cwd()
     os.chdir(tmp)
     os.environ["SUTANDO_WORKSPACE"] = "myws"  # deliberately relative
+    os.environ["SUTANDO_TEST_MODE"] = "1"
     try:
         result = ws.resolve_workspace(migrate=False)
         assert result.is_absolute(), (
@@ -61,32 +62,40 @@ def test_relative_env_path_is_anchored_to_cwd_absolute():
     finally:
         os.chdir(original_cwd)
         del os.environ["SUTANDO_WORKSPACE"]
+        os.environ.pop("SUTANDO_TEST_MODE", None)
         _restore_env(snap)
 
 
 def test_absolute_env_path_unchanged():
-    """Backwards compat: absolute `SUTANDO_WORKSPACE` returned as-is."""
+    """Backwards compat: absolute `SUTANDO_WORKSPACE` returned as-is.
+    v0.8: env honored only under SUTANDO_TEST_MODE=1."""
     snap = _clear_env()
     abs_path = Path(tempfile.mkdtemp(prefix="sutando-ws-abs-"))
     os.environ["SUTANDO_WORKSPACE"] = str(abs_path)
+    os.environ["SUTANDO_TEST_MODE"] = "1"
     try:
         result = ws.resolve_workspace(migrate=False)
-        assert result == abs_path
+        # Resolver canonicalizes /var/folders/... → /private/var/... on macOS.
+        assert result == abs_path.resolve()
     finally:
         del os.environ["SUTANDO_WORKSPACE"]
+        os.environ.pop("SUTANDO_TEST_MODE", None)
         _restore_env(snap)
 
 
 def test_tilde_in_env_path_is_expanded():
-    """`~` expansion preserved — existing contract."""
+    """`~` expansion preserved — existing contract.
+    v0.8: env honored only under SUTANDO_TEST_MODE=1."""
     snap = _clear_env()
     os.environ["SUTANDO_WORKSPACE"] = "~/sutando-tilde-test"
+    os.environ["SUTANDO_TEST_MODE"] = "1"
     try:
         result = ws.resolve_workspace(migrate=False)
         assert "~" not in str(result), f"tilde not expanded: {result}"
         assert str(result).startswith(str(Path.home()))
     finally:
         del os.environ["SUTANDO_WORKSPACE"]
+        os.environ.pop("SUTANDO_TEST_MODE", None)
         _restore_env(snap)
 
 

--- a/tests/workspace-default.test.py
+++ b/tests/workspace-default.test.py
@@ -24,6 +24,27 @@ from workspace_default import (  # noqa: E402
 )
 
 
+# v0.8: the resolver ignores `$SUTANDO_WORKSPACE` for end-users (warn + ignore).
+# Tests in this file redirect workspace via env to exercise migration paths.
+# The `SUTANDO_TEST_MODE=1` escape hatch (added in PR #1440) re-enables env
+# honor silently for the test suite. Individual tests that need to exercise
+# the production code path (env-ignored) clear SUTANDO_TEST_MODE in-test.
+_SAVED_TEST_MODE = None
+
+
+def setUpModule():
+    global _SAVED_TEST_MODE
+    _SAVED_TEST_MODE = os.environ.get("SUTANDO_TEST_MODE")
+    os.environ["SUTANDO_TEST_MODE"] = "1"
+
+
+def tearDownModule():
+    if _SAVED_TEST_MODE is None:
+        os.environ.pop("SUTANDO_TEST_MODE", None)
+    else:
+        os.environ["SUTANDO_TEST_MODE"] = _SAVED_TEST_MODE
+
+
 class TestWorkspaceDefault(unittest.TestCase):
     def setUp(self):
         self._saved_env = os.environ.get("SUTANDO_WORKSPACE")
@@ -43,14 +64,39 @@ class TestWorkspaceDefault(unittest.TestCase):
         self.assertEqual(d.parent.parent, Path.home())
         self.assertEqual(d, Path.home() / ".sutando" / "workspace")
 
-    def test_resolve_uses_env_when_set(self):
+    def test_resolve_uses_env_when_test_mode_set(self):
+        # v0.8: `$SUTANDO_WORKSPACE` is no longer honored in production.
+        # The test-only escape hatch `SUTANDO_TEST_MODE=1` keeps env-redirect
+        # available for the test suite without weakening the user-facing
+        # contract. Without `SUTANDO_TEST_MODE`, the env value would be
+        # warned + ignored.
+        # Note: resolver calls `.resolve()`, which canonicalizes /tmp -> /private/tmp
+        # on macOS via symlink; the expected path applies the same resolution.
         os.environ["SUTANDO_WORKSPACE"] = "/tmp/test-ws"
-        # migrate=False to keep this test purely about resolution semantics.
-        self.assertEqual(resolve_workspace(migrate=False), Path("/tmp/test-ws"))
+        os.environ["SUTANDO_TEST_MODE"] = "1"
+        try:
+            self.assertEqual(resolve_workspace(migrate=False), Path("/tmp/test-ws").resolve())
+        finally:
+            os.environ.pop("SUTANDO_TEST_MODE", None)
 
-    def test_resolve_expanduser_on_tilde(self):
+    def test_resolve_expanduser_on_tilde_with_test_mode(self):
+        # v0.8: env honored only under SUTANDO_TEST_MODE=1 (test-only).
         os.environ["SUTANDO_WORKSPACE"] = "~/custom-ws"
-        self.assertEqual(resolve_workspace(migrate=False), Path.home() / "custom-ws")
+        os.environ["SUTANDO_TEST_MODE"] = "1"
+        try:
+            self.assertEqual(
+                resolve_workspace(migrate=False),
+                (Path.home() / "custom-ws").resolve(),
+            )
+        finally:
+            os.environ.pop("SUTANDO_TEST_MODE", None)
+
+    def test_resolve_ignores_env_in_production_path(self):
+        # v0.8 contract: without SUTANDO_TEST_MODE, env is warned + ignored.
+        os.environ["SUTANDO_WORKSPACE"] = "/tmp/should-be-ignored"
+        os.environ.pop("SUTANDO_TEST_MODE", None)
+        # Falls back to the in-repo default (env ignored).
+        self.assertEqual(resolve_workspace(migrate=False), ROOT / "workspace")
 
     def test_resolve_falls_back_to_default_when_env_unset(self):
         # Post-M0: fallback is the in-repo workspace path (<repo>/workspace),
@@ -179,14 +225,16 @@ class TestMigrationFromLegacy(unittest.TestCase):
         self.assertFalse(moved_2)  # second run finds target populated, bails
 
     def test_resolve_workspace_skips_legacy_migration_when_env_set(self):
-        """When SUTANDO_WORKSPACE is set, the LEGACY migration (tasks/results/state)
-        is skipped. The notes in-repo migration runs independently — see the
-        separate test class for that."""
+        """When SUTANDO_WORKSPACE is set (with SUTANDO_TEST_MODE=1 to opt in
+        under v0.8), the LEGACY migration (tasks/results/state) is skipped.
+        The notes in-repo migration runs independently — see the separate
+        test class for that."""
         self._seed_legacy_runtime()
         os.environ["SUTANDO_WORKSPACE"] = str(self.target)
         with patch.object(workspace_default, "_legacy_repo_root", return_value=self.legacy):
             ws = resolve_workspace(migrate=True)
-        self.assertEqual(ws, self.target)
+        # Compare against resolved expected (macOS /private symlink-canonical).
+        self.assertEqual(ws, self.target.resolve())
         # Legacy state should be UNTOUCHED — env pin bypasses _migrate_from_legacy.
         self.assertTrue((self.legacy / "tasks" / "task-1.txt").exists())
 
@@ -639,7 +687,9 @@ class TestPostMigrationDisableBehavior(unittest.TestCase):
         """resolve_workspace(migrate=True) must NOT move any legacy file."""
         with patch.object(workspace_default, "_legacy_repo_root", return_value=self.legacy):
             ws = resolve_workspace(migrate=True)
-        self.assertEqual(ws, self.workspace)
+        # Resolved equality — resolver canonicalizes /var/folders/... → /private/var/...
+        # on macOS via symlink.
+        self.assertEqual(ws, self.workspace.resolve())
         # Legacy files unchanged
         self.assertTrue((self.legacy / "notes" / "x.md").is_file())
         self.assertTrue((self.legacy / "build_log.md").is_file())
@@ -673,7 +723,7 @@ class TestPostMigrationDisableBehavior(unittest.TestCase):
             buf = StringIO()
             with patch.object(sys, "stderr", buf):
                 ws = resolve_workspace(migrate=False)
-            self.assertEqual(ws, self.workspace)
+            self.assertEqual(ws, self.workspace.resolve())
             # _legacy_repo_root() must NOT be called when migrate=False
             mock_repo.assert_not_called()
             # No stderr output


### PR DESCRIPTION
## Path B (workspace v0.8): strip `$SUTANDO_WORKSPACE` from resolver + bootstrap auto-migration

Implements the v0.8 target contract: `$SUTANDO_WORKSPACE` is no longer honored by `src/sutando_config.{py,ts}`. Workspace resolves only via `sutando.config.{json,local.json}` or the `{repoRoot}/workspace` baked-in default, per `docs/workspace-contract-v0.8.md` (#1384).

**STATUS: DRAFT — awaiting Mini + Pro re-review after v2 safety hardening.**

### What's in this PR

**Commit `529007d` — resolver strip + colored warnings**
**Commit `6cf3e9d` — bootstrap auto-migration + env-fallback strip**
**Commits `3f02c80`, `d005762`, `ed053d7` — SUTANDO_TEST_MODE escape hatch + test fixture opt-ins**

**Commits `a0d6292` + `df70545` — Mini's #design review v1 (B1+B2+B3+B4 safety hardening + tests):**
- **B1** — realpath equality + `_same_inode` (stat -L) skip when env == resolved workspace
- **B2** — `tar -czf` BEFORE `sutando-migrate.sh --commit`; archive preserved on migrate-fail
- **B3** — `_is_unsafe_for_migration` deny-list (initial set: /, /usr, /etc + /private/etc, /var + /private/var, /System, /Library, /Applications, $HOME + Documents/Desktop/Downloads, $REPO + subdirs, paths with `..`) applied at two points
- **B4** — `_color_warn` honors NO_COLOR; TS warnings drop literal `${envVal}` / `${dotenvVal}` / `${resolved}` interpolations (c58270d parity)
- Helpers extracted into `src/migration_safety_helpers.sh` for unit-testability
- Tests: `tests/migration-safety-helpers.test.sh` (24 assertions) + `tests/sutando-config.prod-path.test.ts` (7 assertions)

**Commit `0c496ef` — Mini's #design review v2 (sub-blockers in v1):**
- **B3 deny-list expansion** — Mini flagged that v1 missed `/tmp` exact, descendants of `$HOME/Documents`/Desktop/Downloads (only exact dirs were denied), and common dotfile install targets. v2 adds:
  - `/tmp` + `/private/tmp` exact (subdirs remain safe for mktemp targets)
  - `$HOME/Documents/*`, `$HOME/Desktop/*`, `$HOME/Downloads/*` descendants
  - `$HOME/.sutando` + subpaths, EXCEPT `$HOME/.sutando/workspace` and its subpaths (intentional migration source — allow-exception checked first in case statement)
  - `$HOME/.claude` + subpaths
  - `$HOME/.config` + subpaths
- **B1 dev:ino** — `_same_inode` now uses `stat -L -f '%d:%i'` (BSD) / `-c '%d:%i'` (GNU) instead of inode alone. Inode-only false-positives across unrelated filesystems that happen to reuse the same number; `device:inode` is the globally unique pair.
- **Python prod-path test twin** — `tests/sutando-config.prod-path.test.py` mirrors the TS v1 test (7 assertions: NO_COLOR + non-TTY + no literal env/dotenv values + one-shot + config-driven path + baked-in default).
- Helpers test expanded: 24 → 38 assertions (added /tmp subdir-allow, descendants of Documents/Desktop/Downloads, .sutando allow-exception via fake-realpath'd $HOME, .claude, .config).

### Verification

- `bash tests/migration-safety-helpers.test.sh`: 38/38 pass
- `python3 tests/sutando-config.prod-path.test.py`: 7/7 pass
- `npx tsx --test tests/sutando-config.prod-path.test.ts`: 7/7 pass
- `npx tsx --test tests/sutando-config.test.ts`: 21/21 pass (no regression)
- `python3 tests/sutando-config.test.py`: 30/30 pass (no regression)
- `bash -n` on edited shells: syntax clean

### Remaining work / known follow-up

- [ ] **Test-fixture migration** — ~141 `SUTANDO_WORKSPACE` refs across 23 tests use the env as a tmp-workspace mechanism. The `SUTANDO_TEST_MODE` escape hatch is a transitional crutch; full migration to `sutando.config.local.json` fixtures + `SUTANDO_REPO_DIR` start-hint tracked under Path B.1b.
- [ ] **Full startup-migration integration test** (Mini's "Test gaps" list, v1) — driver-level mock-migrate-and-tar end-to-end. The helpers-level test + dual-language prod-path tests cover the highest-risk units; the driver-level integration test is a separate follow-up (non-trivial setup, lower marginal value).
- **Symlink legacy dir as archive edge** (Mini v2 flagged): `tar -czf` preserves symlink-entry by default (no `-h`); B1 realpath guard catches `symlink→resolved` up-front and skips the destructive block. Broken symlink fails the `[ -d ]` precondition. Documented in `0c496ef`.

### Cross-PR linkage

- **#1379** (CLAUDE.md restructure, Path A revision `2ee66d7`) — agent-facing docs aligned with this PR's behavior.
- **#1384** (Workspace Contract v0.8 spec, Path A revision `9edfec3`) — the design doc this PR makes true.
- **#1432** (sync-memory SCRIPT_PARENT) — merged; gives sync-memory the resolver path without env reliance.

### Review thread

- Mini v1 review: https://discord.com/channels/1456749236961800213/1509576272920182874/1511914723724103680
- Mini v2 review: https://discord.com/channels/1456749236961800213/1509576272920182874/1511920010661073078