### PR TITLE
docs(claude.md): update standalone skill routing to sonichi/sutando-skills-community

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Read `CONTRIBUTING.md` and follow its "Before opening any PR or issue" section. 
 - Respect the V1-workspace hold list (`workspace_default.{py,ts}`, `sync-memory.sh`, `claude_home_path`, `agent-registry` paths)
 - After `update-branch`, CLA-Assistant may not auto-rerun — try `@cla-assistant check` comment or close+reopen if stuck
 
-Skill-PR destination: a skill is **coupled** (PR to `sonichi/sutando`) if it imports from `src/` or another skill, modifies main-repo files, or is tightly bound to a feature there (e.g. `skills/phone-conversation/`). A skill is **standalone** (PR to `sonichi/sutando-skills`) if it ships its own scripts/binaries, reads files but doesn't import main-repo modules, and works against any checkout. If unsure, ask in #design.
+Skill-PR destination: a skill is **coupled** (PR to `sonichi/sutando`) if it imports from `src/` or another skill, modifies main-repo files, or is tightly bound to a feature there (e.g. `skills/phone-conversation/`). A skill is **standalone** (PR to `sonichi/sutando-skills-community`) if it ships its own scripts/binaries, reads files but doesn't import main-repo modules, and works against any checkout. If unsure, ask in #design.
 
 ## Workspace contract
 


### PR DESCRIPTION
## Summary

- `sonichi/sutando-skills` is a private fleet-sync repo (Chi's personal skills)
- `sonichi/sutando-skills-community` is the new public community destination for standalone skill contributions
- Updates the skill routing line to point to the correct repo

Resolves the dangling reference in CLAUDE.md that directed standalone skill PRs to a private repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stand: Echo Act IV Pro