### PR TITLE
feat(workspace): lazy-resolve refactor — Hybrid C pattern (PR-1 of N)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,54 @@ See existing skills for examples. Install with `bash skills/install.sh`.
 - **web-client.ts**: The entire web UI is an inline HTML template literal. Do NOT use TypeScript-only syntax (like `as Type` casts) inside the embedded `<script>` block — the browser runs it as plain JS.
 - All scripts should work from a fresh clone with minimal setup
 
+### Lazy config access
+
+**Workspace is process-scoped — resolved once at first use, stable for the lifetime of the process.** Do not capture it at module-import time (eager top-of-file `WORKSPACE_DIR = resolve_workspace()` is forbidden), and do not re-resolve it on every call inside hot loops (that's overkill — `resolve_workspace()` costs ~14µs per call, the process-scoped cache costs ~20ns).
+
+**Use `get_workspace()` from `workspace_default` for every workspace access.** It returns the cached process workspace, or accepts an explicit override for tests/special callers.
+
+❌ Eager module-level capture (forbidden):
+```python
+WORKSPACE_DIR = resolve_workspace()          # captured once at import
+def archive_old():
+    if not (WORKSPACE_DIR / "results").is_dir(): ...
+```
+
+✅ Hybrid keyword-only DI (preferred):
+```python
+from workspace_default import get_workspace
+
+def archive_old(*, workspace: Optional[Path] = None) -> int:
+    workspace = get_workspace(workspace)
+    results = workspace / "results"
+    ...
+```
+
+```typescript
+import { getWorkspace } from './workspace_default.js';
+
+export async function archiveOld(opts: { workspace?: string } = {}): Promise<void> {
+    const workspace = getWorkspace(opts.workspace);
+    const results = join(workspace, 'results');
+    ...
+}
+```
+
+**Why this pattern:**
+- **Process-scoped semantics**: workspace doesn't change mid-process in normal operation, so resolve once + cache. No `WorkspaceContext` framework, no per-call resolve, no env hacks.
+- **Function signature documents the dependency**: an AI agent reading `def archive_old(*, workspace: Optional[Path] = None)` immediately knows this function needs a workspace and can be redirected.
+- **Zero callsite diff**: production callers omit the argument (`archive_old()`) and get the cached default. No call site update churn.
+- **Tests inject directly**: `archive_old(workspace=tmp_ws)` for per-call override, or `_reset_workspace_cache_for_tests()` in setUp + write `sutando.config.local.json` for process-wide reset. No `$SUTANDO_WORKSPACE` env hacks.
+- **`*` makes `workspace` keyword-only**: prevents positional misuse, keeps the parameter contract crystal clear.
+
+**Entry points** (CLI `main()`, daemon startup): same hybrid signature. The script's `__main__` block calls `main()` without arguments → default-from-config. Tests call `main(workspace=tmp_ws)`.
+
+**Library helpers imported across modules**: same hybrid signature. The optional `workspace` arg makes the dependency explicit at the import site.
+
+**Audit before submitting:**
+- `grep -n "= resolve_workspace()" <file>` and `grep -n "= resolveWorkspace()" <file>` — should return zero module-level matches. Only `get_workspace()` calls inside function bodies are allowed.
+- Module-level constants like `WORKSPACE_DIR`, `RESULTS_DIR`, `STATE_DIR` derived from `resolve_workspace()` are forbidden.
+
 ## Before starting a PR
 
 The goal of this phase is to confirm the PR is necessary at all. In rough order of "what kills the PR earliest":

--- a/docs/workspace-contract.md
+++ b/docs/workspace-contract.md
@@ -1,134 +1,251 @@
-# Workspace Contract
+# Workspace Contract — v0.8
 
-> ⚠️ **Stale examples — read with care.** The principle below (code in repo, runtime state in workspace) is current. But the **specific examples + the `WORKSPACE_DIR` resolution recipe** in this doc are pre-M0 and recommend `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}` shell snippets that no longer match the canonical resolver (per PR #1395). Treat this file as historical context.
->
-> **For the current contract, use:**
-> - **Shell:** `WORKSPACE="$(bash scripts/sutando-config.sh workspace)"` then `"$WORKSPACE/..."`.
-> - **Python:** `from workspace_default import resolve_workspace; ws = resolve_workspace()`.
-> - **TypeScript:** `import { resolveWorkspace } from './workspace_default.js'; const ws = resolveWorkspace()`.
-> - **Default location:** `<repo>/workspace/` (M0 in-repo). `$SUTANDO_WORKSPACE` is honored as a legacy escape hatch with a one-time deprecation warning.
-> - **Config:** see [`workspace-config.md`](workspace-config.md) for `sutando.config.local.json`.
-> - **Mental model:** see [`workspace-design.md`](workspace-design.md) for the 2-space framing (State + Memory).
+**Version:** v0.8 (current target). Predecessors: pre-M0 (env-honored, scattered defaults), M0 (in-repo default + config-driven resolver, env still legacy-honored).
 
-Every file Sutando reads or writes lives in one of two locations. Knowing which is which prevents an entire class of split-brain bugs.
+**Status (2026-06-03):** The contract below describes the **target** v0.8 shape. M0 (in-repo default, config-driven resolver) shipped via PRs #1395 + #1397 + #1399 + #1403. The v0.8 "no env override" strip is partial — `$SUTANDO_WORKSPACE` still works as a deprecation-warned legacy escape today; **PR #1440 strips it from `src/sutando_config.{py,ts}` + adds bootstrap auto-migration in `src/startup.sh`**. After #1440 merges, the resolver-level contract below is fully true. The `docs/workspace-contract-v0.8.md` adjunct (PR #1384) carries the original design rationale; this file is the operational source of truth.
 
-## The rule
-
-**`REPO_DIR` is source-tree-only. All user / runtime state goes through `WORKSPACE_DIR`. Default to `WORKSPACE_DIR` for any new path; reach for `REPO_DIR` only when you're reading code or git-tree metadata.**
-
-This is the strong form of the split. If you find yourself typing `REPO_DIR / "<filename>"` for any file that isn't checked into git and read by code, that's almost certainly the bug pattern this contract prevents.
-
-## What goes where
-
-| Concept | Path on this machine | What lives here | Use it when |
-|---|---|---|---|
-| **Source tree (`REPO_DIR`)** | wherever you cloned the repo (e.g. `~/Documents/github/sutando`) | `src/`, `skills/`, `scripts/`, `docs/`, `tests/`, `CLAUDE.md`, `package.json` — anything that's in git and is part of the codebase. | Exec'ing a source script. Running `git -C` against the tree. Reading a checked-in file (docs, sample config, source). |
-| **Workspace (`WORKSPACE_DIR`)** | **Post-M0:** `<repo>/workspace/` (default), resolved via `bash scripts/sutando-config.sh workspace`. `$SUTANDO_WORKSPACE` honored as legacy escape hatch. *(Pre-M0 default was `~/.sutando/workspace/`.)* | Per-user mutable runtime state: `tasks/`, `results/`, `state/`, `data/`, `logs/`, `notes/`, `build_log.md`, `pending-questions.md`, anything else the running agent generates or accumulates. Loose status `.json` files (`core-status.json`, `voice-state.json`, `contextual-chips.json`, `dynamic-content.json`, `quota-state.json`) live under `state/` — use the `status_path` / `statusPath` helpers. | Always, unless one of the three "use REPO_DIR" cases above applies. |
-
-The two paths **can** be the same (default for fresh installs without `SUTANDO_WORKSPACE`), but designing for them as separate is the right structural shape — multiple Sutando nodes on one machine, separate-from-code workspace, OSS readers running the engine without polluting their own git tree.
-
-## Code review test
-
-For every `REPO_DIR / "..."` (or equivalent `Path(__file__).parent.parent / "..."`) in a PR diff, the reviewer should ask: *"Is this path a source-code file, a script being exec'd, or a `git -C` cwd?"* If the answer is no, the path belongs under `WORKSPACE_DIR`.
-
-## Resolution rules — Python
-
-```python
-# Source tree — for reading source files, exec'ing scripts, git cwd
-REPO_DIR = Path(__file__).resolve().parent.parent
-
-# Runtime state — for tasks/, results/, state/, data/, logs/, notes/,
-# build_log.md, pending-questions.md, etc. (status .json files: state/)
-from workspace_default import resolve_workspace
-WORKSPACE_DIR = resolve_workspace()
-```
-
-For files that live under a *user-shared* private dir (the memory-sync repo), use the helpers in `src/util_paths.py`:
-
-```python
-from util_paths import personal_path, shared_personal_path
-
-# Per-machine personal asset (stand-identity.json, stand-avatar.png)
-si = personal_path("stand-identity.json")
-
-# Fleet-shared file (notes/, build_log if you want it shared)
-notes = shared_personal_path("notes")
-```
-
-These honor `SUTANDO_WORKSPACE` by default — don't pass `REPO_DIR` explicitly.
-
-## Resolution rules — TypeScript
-
-```typescript
-// Runtime state — match the Python helper's contract
-const WORKSPACE_DIR =
-  process.env.SUTANDO_WORKSPACE ||
-  join(homedir(), '.sutando', 'workspace');
-
-// Source tree
-const REPO_DIR = new URL('..', import.meta.url).pathname;  // adjust depth
-```
-
-## Resolution rules — Shell
-
-```bash
-# Workspace state (tasks/, results/, etc.)
-TASKS_DIR="$(bash scripts/sutando-config.sh workspace)/tasks"   # post-M0 canonical; helper handles legacy escape hatch internally
-
-# Source tree — derive from script location, not from $SUTANDO_WORKSPACE
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-SCRIPT_PARENT="$(cd "$SCRIPT_DIR/.." && pwd)"
-```
-
-## Common mistakes (the bug class this contract prevents)
-
-1. **`Path(__file__).parent.parent / "<runtime-file>"`.** This gives the source tree; on an env-pinned host it diverges from where bridges read. Use `WORKSPACE_DIR` for runtime state. The strong rule: if you're typing `REPO_DIR / "..."` for anything that isn't source code, you're probably in this bug class.
-2. **`$SUTANDO_WORKSPACE` as input to a Claude-project-key sed-map.** Claude's project memory dir keys on the launch CWD, not on the workspace. Use `SCRIPT_PARENT` for that lookup. (Bug fixed in `scripts/sync-memory.sh` by this PR; was silently skipping 8+ memory files for 5+ weeks.)
-3. **Hard-coding a startup gate around `NGROK_AUTHTOKEN` when a `TWILIO_WEBHOOK_URL` tunnel is the alternative.** Different shape but same family — code assumed one path when the design supports two. (Fixed for `conversation-server.ts` by this PR.)
-4. **Passing `REPO_DIR` explicitly to `personal_path()` / `shared_personal_path()`.** The helpers default to the right thing now; the explicit arg forces source-tree resolution. Drop the arg unless you genuinely need a non-workspace path. (Cleaned up in `dashboard.py` by this PR.)
-
-## How to decide for new code
-
-Walk the question top-to-bottom and stop at the first match:
-
-1. **Is the file checked into git?** → `REPO_DIR`. (Source code, scripts, docs, tests, package.json.)
-2. **Is the file a stable cross-machine reference Claude can read on session start?** (e.g., `CLAUDE.md`, README) → `REPO_DIR`.
-3. **Otherwise — does it mutate during runtime?** → `WORKSPACE_DIR`. (Tasks, results, state, logs, notes, build_log, pending-questions, status JSON.)
-4. **Is it per-machine personal state?** (Stand identity, avatar) → `personal_path()` (honors `SUTANDO_MEMORY_DIR` first; legacy `SUTANDO_PRIVATE_DIR` falls through for one release per #870).
-5. **Is it fleet-shared user state?** (Notes, shared memory) → `shared_personal_path()` (honors `SUTANDO_MEMORY_DIR` first, falls back to workspace; legacy `SUTANDO_PRIVATE_DIR` honored for one release per #870).
-
-## Related PRs
-
-- **#762** — established the workspace default (`~/.sutando/workspace/`) and migration from legacy repo-root fallback.
-- **#775** — applied the two-variable split (`REPO_DIR` + `WORKSPACE_DIR`) to `agent-api.py`, `github-webhook.py`, `task-bridge.ts`.
-- **This PR** — applies the same split to `health-check.py`, `conversation-server.ts`, `sync-memory.sh`, `util_paths.py`, `dashboard.py`. Documents the contract.
-
-Any code in the OSS tree that still uses the old pattern is a fix candidate — file an issue or open a PR following the same shape.
+**One-sentence summary**: The workspace is `<repo>/workspace/`, period. It is gitignored, computed (no env override), and ephemeral; durability is a separate concern handled by the vault.
 
 ---
 
-## Existing-repo installs: trigger the migration (or pin `SUTANDO_WORKSPACE` as stop-gap)
+## 1. The contract
 
-If your loop / cron / scripts polled `<repo>/tasks/` directly before #762 (and any component — Python or TS — that hardcoded the repo path via `Path(__file__).parent.parent` or `new URL('..', import.meta.url)` is still doing so), you'll see a silent **path divergence**:
+### 1.1 Location
 
-- The bridge (and any caller of `resolve_workspace()`) writes new tasks to the canonical default `~/.sutando/workspace/tasks/`.
-- Any component still reading from `<repo>/tasks/` via a relative path won't see them.
-- Result: new tasks never reach the loop. Observed 2026-05-16 — 7 owner DMs orphaned over 19 minutes before the divergence was caught.
-
-**Preferred fix (post-#1170):** run `bash scripts/sutando-migrate.sh --dry-run` to preview, then `--commit` to relocate `<repo>/{tasks,results,state,notes,build_log.md,conversation.log,…}` into `~/.sutando/workspace/`. The CLI is the only auto-mover post-#1169 (option B); the old `_migrate_from_legacy` auto-fire was removed because it ran destructively on every `resolve_workspace()` call and bit synced workspaces via symlink-following iterdir(). After migration, both sides agree on the canonical default and no env var is needed.
-
-> **Historical note:** before #1170 (2026-05-26) the Python and bash twins of these migrators ran automatically on every `resolve_workspace()` call / `init.sh --auto` startup. That auto-fire is gone; both code paths now only emit a one-time stderr notice when legacy state is detected and route users to the CLI above. The `sutando-migrate.sh` CLI itself ships in a follow-up PR — until then, `mv` the listed paths manually.
-
-**Stop-gap (if migration won't run):** pin `SUTANDO_WORKSPACE` in `.env` at the repo root and restart the bridges:
-
-```bash
-SUTANDO_WORKSPACE=/full/path/to/your/repo
+```
+<repo>/workspace/    ← workspace root (gitignored)
 ```
 
-**Caveat:** this revives the git-status-pollution antipattern that #762 was designed to escape (every `tasks/`, `results/`, `state/` write shows up in `git status`). Use sparingly; prefer the migration when possible.
+Resolved by `bash scripts/sutando-config.sh workspace` (the M0 helper). Helpers in Python (`from workspace_default import resolve_workspace`), TypeScript (`import { resolveWorkspace } from './workspace_default.js'`), and Swift (`AppDelegate.workspace`) read from `sutando.config.{json,local.json}` with `<repo>/workspace/` as the baked-in default.
 
-**Fresh installs** can skip this entirely — the `~/.sutando/workspace/` default works because nothing else polls the repo path.
+**Hard rules (after #1440):**
+- The workspace is **always** at `<repo>/workspace/` by default. The location is specified via the config file (`sutando.config.{json,local.json}` → `workspace.path`); the per-clone `sutando.config.local.json` (gitignored) is where users override, if they choose to.
+- **No env override** — neither `$SUTANDO_WORKSPACE` nor any other env var redirects the resolver.
+- The whole `/workspace/` tree is gitignored (single entry in repo `.gitignore`).
+- Workspace is computed by the helpers — never by a per-script fallback.
 
-## Orphan symlinks (post-migration cleanup)
+> ⚠️ **Cost of overriding `workspace.path` outside `<repo>/workspace/`.** The in-repo default is what unlocks Claude Code's cwd-anchored features:
+>
+> - **CLAUDE.md auto-load** — Claude Code reads the project's `CLAUDE.md` automatically when cwd is inside the repo. Move workspace outside and the workspace-rooted `PERSONAL_CLAUDE.md` stops being auto-loaded.
+> - **Skills auto-discovery** — workspace-rooted `skills/` is auto-discovered when workspace is under cwd. Outside the repo, sessions need an explicit `--add-dir <workspace>` to see them.
+> - **Project-slug session transcripts** — Claude Code names session JSONLs by cwd-derived slug; an out-of-repo workspace fragments the transcript history.
+> - **Hook scope** — `<claude-config>/hooks/*` fires scoped to cwd. Out-of-repo workspace breaks the association.
+> - **No `--add-dir` flag needed** — built-in. Out-of-repo workspace forces an explicit `--add-dir <workspace>` per session.
+>
+> Only override if you have a clear reason (shared workspace across multiple checkouts; custom storage for size / encryption / quota). Otherwise, accept the default.
 
-If you hand-created any symlinks against the legacy `~/.sutando-memory-sync/...` path before the auto-migration moved it to `~/.sutando/memory-sync/`, those symlinks are now stale (the target moved out from under them). `scripts/sync-memory.sh` (post-#835) scans `~/.sutando/`, `~/.claude/skills/`, and `~/.config/` for orphaned symlinks the first time it actually triggers the migration and emits one `rm + ln -s` recipe per orphan to stderr. Run the printed pairs to re-point them at the canonical path. Subsequent runs skip the scan (no false positives).
+**Today's deprecation path:** `$SUTANDO_WORKSPACE` set in the environment fires a one-time bold-red stderr warning pointing at `scripts/sutando-migrate.sh`. After #1440 merges, the value is not honored even with the warning. Hosts with the env var set are auto-migrated by `src/startup.sh` on first run post-merge (run `sutando-migrate.sh --commit`, then compress the original folder in place + unset the env).
+
+**Why in-repo:** the workspace inherits Claude Code's cwd privileges — CLAUDE.md auto-load, skills auto-discovery, project-slug for session transcripts, hook scope, no `--add-dir` needed. Putting it anywhere else forfeits these.
+
+### 1.2 Layout
+
+```
+<repo>/workspace/
+├── tasks/                  ← inbound message queue (bridges write, agent reads)
+│   ├── archive/<yyyy-mm>/  ← processed task files (auto-rotated)
+│   └── processed/          ← in-flight working state
+├── results/                ← outbound reply queue (agent writes, bridges deliver)
+├── state/                  ← cross-process status JSON (one writer per file)
+│   ├── core-status.json
+│   ├── voice-state.json
+│   ├── contextual-chips.json
+│   ├── quota-state.json
+│   ├── auth/               ← durable per-host install state (.alive sentinels, device IDs)
+│   └── cores/<host>.alive  ← per-host liveness signal
+├── logs/                   ← append-only chrono streams (bridges, watchers, sync)
+├── notes/                  ← long-form human-readable content
+├── data/                   ← durable input data (datasets, fetched feeds)
+├── relay/                  ← inter-session continuity notes (consumed by catchup)
+├── skills/                 ← user's personal/custom skills (local-only)
+├── build_log.md            ← single-file done/in-flight/next snapshot (append-only)
+└── pending-questions.md    ← unanswered questions awaiting owner input
+```
+
+The workspace root holds **only** the top-level dirs above plus the two markdown files. Loose `.json` files belong under `state/`. The repo root holds code/skills/config (a separate concern).
+
+### 1.3 Decision guide
+
+When the agent writes a new file under `<repo>/workspace/`, walk this list top-to-bottom and stop at the first match:
+
+1. **Inbound channel message?** → `tasks/task-{id}.txt`. The bridges write these.
+2. **Reply to a task?** → `results/task-{id}.txt`. Bridge polls + delivers. See CLAUDE.md "Result-body protocol markers" for `[deduped:]`, `[no-send]`, `[channel:]`, `[file:]`.
+3. **Cross-process status JSON another component polls?** → `state/`.
+4. **Per-host durable install state** (`.alive` heartbeats, device UUIDs, cloud-auth) → `state/auth/`. Exempt from transient-state cleanup.
+5. **Append-only chrono event stream?** → `logs/<component>.log`.
+6. **Long-form human-readable content?** → `notes/<slug>.md`.
+7. **Done/in-flight/next snapshot?** → append to `build_log.md`.
+8. **Blocked question for the owner?** → append to `pending-questions.md`.
+9. **Durable input data?** → `data/<topic>/`.
+10. **Continuity note for the next session?** → `relay/relay-<ts>.md` (consumed by `/catchup-after-startup`).
+11. **Personal skill the user adds for their own use?** → `skills/<skill-name>/` (local-only, not contributed to `skills/` at the repo root).
+
+If two layers seem to fit, prefer the more specific one (state JSON beats logs beats notes).
+
+### 1.4 Confidentiality
+
+The workspace is user-specific. **NEVER disclose workspace content** — tasks, results, notes, state, build_log, pending-questions — to any party outside the owner without explicit per-disclosure approval. Default-deny: when in doubt, ask first. Strategic / competitive / financial / personal content stays owner-DM only.
+
+This applies even when a public PR / issue would benefit from quoting workspace content. Bots **paraphrase** workspace state into public artifacts; they never quote verbatim.
+
+**Mechanisms enforcing this:**
+
+- **Blanket `.gitignore`** — the whole `/workspace/` subtree is a single gitignore entry. Workspace files cannot be accidentally staged, committed, or pushed; trying to add one prints "ignored by .gitignore." `sutando.config.local.json` is gitignored for the same reason.
+- **Pre-commit + CI guard layers** — `scripts/check-workspace-not-tracked.sh` (pre-commit hook) and the equivalent CI check (see `docs/workspace-config.md` "Protection layers") fail the build if anything under `/workspace/` is tracked or if `sutando.config.local.json` is staged. Multi-layer defense: gitignore is the floor, hooks + CI are the ceiling.
+- **Per-channel access tiers** — every bridge (Discord, Slack, Telegram) tags incoming tasks with `access_tier: owner | team | other`. Only `owner` tasks get full agent capabilities; `team` and `other` are delegated to `codex exec --sandbox read-only`, which cannot read workspace files outside its sandbox path. The bridge enforces this in-band by injecting a `===SUTANDO SYSTEM INSTRUCTIONS===` block into every non-owner task body — the agent follows those instructions verbatim and never processes the user-supplied content directly. See CLAUDE.md "Discord/Slack/Telegram access control."
+- **TOFU + allowlist for owner identity** — first DM to a bridge auto-enrolls the sender as owner and writes `$CLAUDE_CONFIG_DIR/channels/<surface>/access.json`. Subsequent senders are checked against `allowFrom`; absent or non-matching senders fall through to non-owner tiers (no implicit owner promotion).
+- **Sandboxed delegation for team/other** — non-owner tasks run under `codex exec --sandbox read-only`. The sandbox blocks filesystem writes and restricts reads to the agent's working directory, so workspace `state/`, `notes/`, `build_log.md`, etc. are unreachable to non-owner tiers even if the user-supplied prompt tries to coax otherwise.
+- **Result-body delivery markers** — `[no-send]`, `[deduped: task-X]`, `[REPLIED]`, `[channel: <id>]` route or suppress bot replies *at the bridge layer*, not the agent layer. Even if the agent writes a confidential result, a `[no-send]` marker prevents it from reaching any user-facing surface.
+- **Memory split (shared vs private)** — memory and notes live under `$SUTANDO_MEMORY_DIR` (default: `$CLAUDE_CONFIG_DIR/projects/.../memory/`), separate from the public repo. `scripts/sync-memory.sh` syncs to a private repo (`$SUTANDO_MEMORY_REPO`); never to a public one. Memory content is loaded into agent context, never into PR bodies or commit messages.
+- **Per-host install state under `state/auth/`** — `cloud-auth.json`, `device.json`, and other per-host credentials are scoped to one host's workspace and exempted from transient-state cleanup. They never sync via `sync-memory.sh` (which targets `memory/` + `notes/` only) or via `sync-workspace.sh` (which excludes `state/auth/` by path).
+- **Channel-confidentiality routing rule** (operational) — codified in the `feedback_channel_confidentiality` memory: strategic / competitive / financial content goes to owner-DM only, never to shared channels. When the owner asks "what's pending?" in a public channel, the agent lists only audience-appropriate items.
+
+### 1.5 Expansion (user-side)
+
+The user can add their own top-level subdirs (e.g. `drafts/`, `research/`, `screenshots/`, `inbox/`). New dirs are automatically gitignored (the whole `/workspace/` tree is) and inherit the §1.4 default-deny posture.
+
+**Agent-facing rules for custom subdirs** — what content goes there, when the agent reads/writes them, retention — belong in `PERSONAL_CLAUDE.md` (per-user overrides). CLAUDE.md (shared) describes the built-in shape; `PERSONAL_CLAUDE.md` describes the per-user extension.
+
+### 1.6 Archive / cleanup
+
+Workspace bloat distracts Claude Code's cwd-anchored discovery (large `git status`, slow project-slug indexing, big tab-completion sets). Mitigation: a nightly cron archives older content.
+
+- `tasks/processed/` and `logs/` older than 30 days → `archive/<yyyy-mm>/`.
+- Suggested cron: 03:30 local. Script: `scripts/archive-workspace.sh` *(forthcoming — not yet shipped)*.
+- `notes/` and `data/` are user content — never auto-archived. User manages.
+- `build_log.md` is append-only — never archived. Owner manually rotates if it gets unwieldy (>500KB).
+
+## 2. Resolution (implementation)
+
+Path computation is centralized; do NOT reinvent the fallback per-script.
+
+- **Python:** `from workspace_default import resolve_workspace` → `Path`
+- **TypeScript:** `import { resolveWorkspace } from './workspace_default.js'` → `string`
+- **Swift:** `AppDelegate.workspace` (split alongside `repoRoot` for code-adjacent paths)
+- **Shell:** `WORKSPACE="$(bash scripts/sutando-config.sh workspace)"` then `"$WORKSPACE/..."`. The shared `src/workspace_resolve.sh` helper wraps this for scripts that source it.
+
+**Resolution order (post-#1440):**
+1. `sutando.config.local.json` → `workspace.path` (per-clone override, gitignored).
+2. `sutando.config.json` → `workspace.path` (tracked defaults at repo root).
+3. `<repo>/workspace/` baked-in default.
+
+**Today (pre-#1440):** `$SUTANDO_WORKSPACE` env var is honored as a legacy escape hatch ahead of step 1, with a one-time deprecation warning. PR #1440 removes that step.
+
+## 3. Migration from earlier versions
+
+Users running with `$SUTANDO_WORKSPACE` pointing outside the repo (pre-M0 layout, or any pre-v0.8 host):
+
+1. **`bash scripts/sutando-migrate.sh --dry-run`** — scan all three potential source locations (repo root, `~/.sutando/workspace/`, `$SUTANDO_WORKSPACE` env) and surface collisions before any move.
+2. **`bash scripts/sutando-migrate.sh --commit`** — relocate content into `<repo>/workspace/` with rule-driven class resolution (`structural`, `newest-mtime`, `keep-both`, `append`, etc.). Per M1 Part 2 (#1403) + #1406.
+3. **Post-#1440 auto-flow**: `src/startup.sh` detects `$SUTANDO_WORKSPACE` set with data and invokes the migration automatically, then compresses the original folder in place as `<legacy>-pre-v0.8-<ts>.tar.gz` (recoverable via `tar -xzf`) so stale processes hit `ENOENT` instead of writing to a divergent path.
+4. **After migration**, unset `$SUTANDO_WORKSPACE` in shell rc + `.env`. The startup script already unsets it for child processes; cleaning the source is a one-time operator step.
+
+**Edge case** — users with multiple repo checkouts pointing at one shared workspace lose that pattern under v0.8. Workaround: pick one canonical checkout, OR filesystem-symlink `<repoB>/workspace → <repoA>/workspace` (no tooling).
+
+## 4. Vault (overview only)
+
+The workspace is intentionally ephemeral: delete the repo and the workspace dies. The **vault** is the separate durability layer that persists content across reclones and syncs across hosts.
+
+- `$SUTANDO_VAULT` — the durability env var. Defaults exist; user can override.
+- Default content: memories. The user can extend the sync allowlist.
+- Sync mechanism: scripts/cron-driven (today `scripts/sync-memory.sh`; future `sync-vault.sh`).
+- Cross-host topology, room collaboration, allowlist format, secret push-gate, conflict policy — **all out of scope here**. See `docs/vault-design.md` *(forthcoming)*.
+
+## 5. Locked decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Workspace = `<repo>/workspace/`, **computed**, no env override (post-#1440) | Claude Code cwd-privilege capture; structural simplicity |
+| 2 | Whole `/workspace/` tree gitignored | Prevents tracked-pollution anti-pattern (the historic `Path(__file__).parent.parent` regression) |
+| 3 | Top-level dirs (tasks/results/state/logs/notes/data/relay/skills) + 2 .md files | Matches the decision guide; agent has a single answer for each write |
+| 4 | Confidentiality default-deny | Workspace = owner-private; bots paraphrase, never quote |
+| 5 | Custom user dirs allowed, documented in PERSONAL_CLAUDE.md | Per-user expansion without polluting shared CLAUDE.md |
+| 6 | `state/auth/` exempt from cleanup | Per-host install state (cloud-auth, device.json, .alive sentinels) must survive transient-state sweeps |
+| 7 | Nightly archive of stale `tasks/processed/` + `logs/` | Bounds cwd bloat (script forthcoming — not yet shipped) |
+| 8 | Vault is a separate doc / separate concern | Workspace contract = location + structure only; durability is its own design |
+| 9 | Auto-migration on bootstrap (post-#1440) | Operators don't have to remember `sutando-migrate.sh`; legacy env-pointed data is preserved as `<legacy>-pre-v0.8-<ts>.tar.gz` |
+
+## 6. What's NOT in this doc
+
+These belong in the vault-design doc, not here:
+- Multi-host sync topology
+- Room collaboration (multi-user shared content)
+- Tier model (LOCAL / MACHINE / AGENT / ROOM)
+- Per-tier git remote layout
+- Allowlist format + push-gate (secret scanning)
+- Conflict resolution policy
+- Vault creation / invite flow
+- `identity_<scope>.json` and the scopes registry
+
+This is intentional. This doc (the workspace contract) defines location + structure. The vault doc defines durability + sharing. Keeping them separate lets each evolve at its own pace.
+
+## 7. FAQ
+
+**Q: Can I use a workspace dir other than `<repo>/workspace/`?**
+
+A: Yes. Override `workspace.path` in your gitignored `sutando.config.local.json`:
+
+```json
+{
+  "workspace": {
+    "path": "/some/other/absolute/path"
+  }
+}
+```
+
+**But do it mindfully** — the in-repo default is what unlocks Claude Code's cwd-anchored features (CLAUDE.md + PERSONAL_CLAUDE.md auto-load, skills auto-discovery without `--add-dir`, project-slug session transcripts, hook scope). If you override outside the repo, you forfeit these and have to compensate (explicit `--add-dir <workspace>` per launch; fragmented session-transcript history). See §1.1's ⚠️ callout for the full breakdown.
+
+Common legitimate reasons to override: shared workspace across multiple checkouts; custom storage location for size / encryption / quota.
+
+**Q: Why isn't `$SUTANDO_WORKSPACE` honored anymore?**
+
+A: It was the legacy escape hatch (pre-M0). Two problems with env-based overrides:
+
+1. Two processes inheriting the env at different times read different values (cron jobs, launchd jobs, ad-hoc shells) — silent split-brain.
+2. The env var doesn't survive a fresh `git clone`. New machines / checkouts don't see your override; the default applies inconsistently.
+
+`sutando.config.local.json` solves both: it lives at a known path (gitignored), every process reads it the same way, and a new clone gets a clean state with the default.
+
+**Q: How do I migrate an existing workspace from a pre-v0.8 layout?**
+
+A: **You shouldn't have to do anything — `src/startup.sh` auto-migrates on first boot post-#1440** when it detects `$SUTANDO_WORKSPACE` set with data at the env-pointed path. It runs `sutando-migrate.sh --commit` for you, then compresses the original folder in place as `<legacy>-pre-v0.8-<ts>.tar.gz` so stale processes hit `ENOENT` instead of writing to a divergent dir.
+
+**If for any reason the auto-migration didn't happen** (e.g. you launched a service directly without going through `startup.sh`, or your `$SUTANDO_WORKSPACE` was unset at startup but set later), just ask Sutando: *"migrate my workspace"* or *"my workspace is in the wrong place — fix it"*. Sutando will run the migration script for you, with diagnostics + collision detection.
+
+**If you'd rather run it manually** (you want full visibility, you're testing the migration on a sandbox checkout, etc.):
+
+```bash
+bash scripts/sutando-migrate.sh --dry-run    # preview what would move — sources scanned: repo root, ~/.sutando/workspace/, $SUTANDO_WORKSPACE env
+bash scripts/sutando-migrate.sh --commit     # actually relocate
+bash scripts/sutando-migrate.sh --explain <path>   # walk the class-resolution rules for a single path
+```
+
+Sources scanned (A/B/C):
+- **A** — repo root (any loose runtime files at the top of the checkout from pre-M0 installs).
+- **B** — `~/.sutando/workspace/` (the pre-M0 default location).
+- **C** — `$SUTANDO_WORKSPACE` env (the legacy escape hatch path).
+
+Collisions are surfaced before any move — the script never silently overwrites.
+
+**Q: My workspace ended up in a weird place after I forgot to migrate. What now?**
+
+A: Run `bash scripts/sutando-migrate.sh --dry-run` to confirm what's where, then `--commit` to move it. If the old location has been compressed into a tarball by the auto-migration, `tar -xzf <legacy>-pre-v0.8-<ts>.tar.gz -C <legacy-parent>` to expand for inspection.
+
+**Q: What if I want the workspace on a different filesystem (e.g. an external SSD for size reasons) but still inside the repo's git-tracked path?**
+
+A: Use a filesystem-level symlink: `ln -s /Volumes/MyExtSSD/sutando-workspace <repo>/workspace`. The gitignore covers the link target; the helper resolves through the symlink. This keeps cwd-anchored features intact while letting you control physical storage.
+
+## 8. Shipping history
+
+| Milestone | PR(s) | What landed | Date |
+|---|---|---|---|
+| **M0** — in-repo default + config-driven resolution | [#1395](https://github.com/sonichi/sutando/pull/1395), [#1397](https://github.com/sonichi/sutando/pull/1397) | `sutando.config.{json,local.json}` loader; helper at `scripts/sutando-config.sh`; default flipped from `~/.sutando/workspace/` to `<repo>/workspace/` | 2026-06-01 |
+| **M1 phase 1** — resolver hardening | [#1399](https://github.com/sonichi/sutando/pull/1399) | Helper bootstrap subcommands; resolver fixes | 2026-06-02 |
+| **M1 part 2** — migration tool | [#1403](https://github.com/sonichi/sutando/pull/1403), [#1406](https://github.com/sonichi/sutando/pull/1406) | `scripts/sutando-migrate.sh` + `/sutando-migrate` skill; class-rule resolution; `--explain` / `--dry-run` / `--commit` modes; sources A/B/C scan | 2026-06-02 |
+| **claude-config M0+M1** | [#1415](https://github.com/sonichi/sutando/pull/1415) | `claude-sutando` shell wrapper; workspace-scoped `CLAUDE_CONFIG_DIR` | 2026-06-02 |
+| **catchup PID-stamp sentinel** | [#1431](https://github.com/sonichi/sutando/pull/1431) | Crash-safe restart detection for `/catchup-after-startup` | 2026-06-03 |
+| **sync-memory SCRIPT_PARENT** | [#1432](https://github.com/sonichi/sutando/pull/1432) | Anchor helper lookup to `$SCRIPT_PARENT` instead of `$REPO_DIR` (fixes a stale-pin failure) | 2026-06-03 |
+| **schedule-crons no-inline-fire + queue gate** | [#1437](https://github.com/sonichi/sutando/pull/1437) | Closes the SKILL.md `invoke it as /skill-name` ambiguity that caused mid-session avalanche; `scripts/cron-gate.sh` defers sub-daily crons when owner work is queued | 2026-06-03 |
+| **v0.8 env strip + auto-migration** | [#1440](https://github.com/sonichi/sutando/pull/1440) (draft) | Strip `$SUTANDO_WORKSPACE` from resolver; bootstrap auto-migration + compress-in-place; bold-red deprecation warnings | in flight 2026-06-03 |
+| **workspace contract v0.8 spec** | [#1384](https://github.com/sonichi/sutando/pull/1384) (draft) | The design doc that this file makes operationally true | in flight 2026-06-03 |
+| **CLAUDE.md §Workspace restructure** | [#1379](https://github.com/sonichi/sutando/pull/1379) (draft) | Agent-facing decision guide + `<repo>/workspace/` paths | in flight 2026-06-03 |

--- a/src/archive-stale-results.py
+++ b/src/archive-stale-results.py
@@ -30,18 +30,19 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from workspace_default import resolve_workspace  # noqa: E402
+from workspace_default import get_workspace  # noqa: E402
 
-# results/ is per-user runtime state — lives under $SUTANDO_WORKSPACE
-# (default ~/.sutando/workspace/), not the repo checkout. Pre-#762 this
+# results/ is per-user runtime state — lives under the v0.8 workspace
+# (default <repo>/workspace/), not the repo checkout. Pre-#762 this
 # resolved to <repo>/results/ which doesn't exist post-migration; the
-# archiver silently no-op'd because `if not RESULTS.is_dir()` short-circuits
+# archiver silently no-op'd because `if not results.is_dir()` short-circuits
 # the whole sweep. The DM-flood prevention this script was built for was
-# defeated until this fix.
-WORKSPACE = resolve_workspace()
-RESULTS = WORKSPACE / "results"
+# defeated until this fix. Workspace is resolved via the optional `workspace`
+# argument on `main()` (hybrid DI pattern, per CONTRIBUTING.md "Lazy config
+# access") — defaults to the process-scoped cache, tests inject directly.
 
 RETENTION_HOURS = int(os.environ.get("RETENTION_HOURS", "24"))
 # Case-insensitive compare — without `.lower()`, `DRY_RUN=No` or `DRY_RUN=FALSE`
@@ -50,18 +51,20 @@ RETENTION_HOURS = int(os.environ.get("RETENTION_HOURS", "24"))
 DRY_RUN = os.environ.get("DRY_RUN", "").strip().lower() not in ("", "0", "false", "no")
 
 
-def main() -> int:
-    if not RESULTS.is_dir():
+def main(*, workspace: Optional[Path] = None) -> int:
+    workspace = get_workspace(workspace)
+    results = workspace / "results"
+    if not results.is_dir():
         print("  [retention] results/ missing — nothing to do")
         return 0
 
     cutoff = time.time() - RETENTION_HOURS * 3600
     archive_name = datetime.now().strftime("archive-%Y-%m-%d")
-    archive_dir = RESULTS / archive_name
+    archive_dir = results / archive_name
 
     moved = 0
     errors = 0
-    for f in RESULTS.iterdir():
+    for f in results.iterdir():
         if not f.is_file():
             continue
         if f.suffix != ".txt":

--- a/src/call-stats.py
+++ b/src/call-stats.py
@@ -21,18 +21,19 @@ import sys
 from collections import Counter
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
-from workspace_default import resolve_workspace  # noqa: E402
-
-CALLS_FILE = resolve_workspace() / "results" / "calls" / "calls.jsonl"
+from workspace_default import get_workspace  # noqa: E402
 
 
-def load_calls():
-    if not CALLS_FILE.exists():
+def load_calls(*, workspace: Optional[Path] = None):
+    workspace = get_workspace(workspace)
+    calls_file = workspace / "results" / "calls" / "calls.jsonl"
+    if not calls_file.exists():
         return []
     calls = []
-    for line in CALLS_FILE.read_text().splitlines():
+    for line in calls_file.read_text().splitlines():
         if not line.strip():
             continue
         try:
@@ -150,14 +151,14 @@ def format_text(stats, window_label):
     return "\n".join(lines)
 
 
-def main():
+def main(*, workspace: Optional[Path] = None):
     ap = argparse.ArgumentParser()
     ap.add_argument("--days", type=int, default=7, help="Window in days (default 7)")
     ap.add_argument("--all", action="store_true", help="All time (overrides --days)")
     ap.add_argument("--json", action="store_true", help="JSON output")
     args = ap.parse_args()
 
-    calls = load_calls()
+    calls = load_calls(workspace=workspace)
     if args.all:
         filtered = calls
         window = "all time"

--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -13,29 +13,24 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
 from util_paths import personal_path  # noqa: E402
-from workspace_default import resolve_workspace  # noqa: E402
-
-WORKSPACE = resolve_workspace()
-PQ_FILE = Path(personal_path("pending-questions.md", WORKSPACE))
-RESULTS_DIR = WORKSPACE / "results"
-LAST_NOTIFY_FILE = WORKSPACE / ".last-pq-notify"
-VOICE_LOG = WORKSPACE / "logs" / "voice-agent.log"
-PRESENTER_SENTINEL = WORKSPACE / "state" / "presenter-mode.sentinel"
+from workspace_default import get_workspace  # noqa: E402
 
 
-def presenter_mode_active():
+def presenter_mode_active(workspace: Path):
     """True if scripts/presenter-mode.sh has been started and the expiry
     timestamp in the sentinel is still in the future. Silences all
     notifications for the ICLR talk window. Stale sentinels (past-expiry)
     are ignored and return False — the next `status` / `stop` call will
     remove the file."""
-    if not PRESENTER_SENTINEL.exists():
+    presenter_sentinel = workspace / "state" / "presenter-mode.sentinel"
+    if not presenter_sentinel.exists():
         return False
     try:
-        expire_iso = PRESENTER_SENTINEL.read_text().strip()
+        expire_iso = presenter_sentinel.read_text().strip()
         # Require an ISO-8601-ish prefix (starts with a digit). Without
         # this guard, malformed sentinel content like "garbage" compares
         # LESS than any real now_iso ("2" < "g" in ASCII) and the mode
@@ -50,15 +45,16 @@ def presenter_mode_active():
         return False
 
 
-def voice_client_connected():
+def voice_client_connected(workspace: Path):
     """True if the most recent [Health] line in voice-agent.log shows client=true.
     When the voice client is offline, dm-fallback already delivers question-*.txt
     files via Discord DM — writing one would double-DM with notify_discord_dm."""
-    if not VOICE_LOG.exists():
+    voice_log = workspace / "logs" / "voice-agent.log"
+    if not voice_log.exists():
         return False
     try:
         # Read the tail efficiently: open at end, walk back ~16KB
-        with VOICE_LOG.open('rb') as f:
+        with voice_log.open('rb') as f:
             f.seek(0, 2)
             size = f.tell()
             f.seek(max(0, size - 16384))
@@ -71,7 +67,7 @@ def voice_client_connected():
     return False
 
 
-def get_waiting_questions():
+def get_waiting_questions(workspace: Path):
     """Parse pending-questions.md — matches both legacy `## Q1 — Title` and
     the current `## Title` / `- **Status:** unanswered` format.
 
@@ -81,9 +77,10 @@ def get_waiting_questions():
     Sections with an explicit status of "resolved" / "done" / "answered"
     are skipped so the old structured format still works correctly.
     """
-    if not PQ_FILE.exists():
+    pq_file = Path(personal_path("pending-questions.md", workspace))
+    if not pq_file.exists():
         return []
-    content = PQ_FILE.read_text()
+    content = pq_file.read_text()
     # Only the active region counts. Resolved questions are kept below a
     # top-level "# Resolved" divider (audit trail), not deleted — without
     # this cut the heading-agnostic split below sweeps the whole file and
@@ -110,11 +107,12 @@ def get_waiting_questions():
     return questions
 
 
-def should_notify():
+def should_notify(workspace: Path):
     """Only notify once per hour to avoid spam."""
-    if not LAST_NOTIFY_FILE.exists():
+    last_notify_file = workspace / ".last-pq-notify"
+    if not last_notify_file.exists():
         return True
-    last = LAST_NOTIFY_FILE.stat().st_mtime
+    last = last_notify_file.stat().st_mtime
     return (time.time() - last) > 3600  # 1 hour
 
 
@@ -126,10 +124,10 @@ def notify_macos(count, titles):
     ], capture_output=True)
 
 
-def notify_voice(questions):
+def notify_voice(questions, workspace: Path):
     """Write to results/ so voice agent can speak it."""
     ts = int(time.time() * 1000)
-    path = RESULTS_DIR / f"question-{ts}.txt"
+    path = workspace / "results" / f"question-{ts}.txt"
     titles = [q["title"] for q in questions]
     path.write_text(
         f"You have {len(questions)} pending question{'s' if len(questions) > 1 else ''} waiting for your answer: "
@@ -138,12 +136,12 @@ def notify_voice(questions):
     )
 
 
-def notify_discord_dm(questions):
+def notify_discord_dm(questions, workspace: Path):
     """Write a proactive-*.txt file so discord-bridge DMs the owner.
     Owner asked (2026-04-09, while traveling) to receive pending-question
     pings as DMs instead of just macOS notifications."""
     ts = int(time.time())
-    path = RESULTS_DIR / f"proactive-pending-q-{ts}.txt"
+    path = workspace / "results" / f"proactive-pending-q-{ts}.txt"
     lines = [
         f"⚠️ {len(questions)} pending question{'s' if len(questions) > 1 else ''} waiting:",
         "",
@@ -157,17 +155,18 @@ def notify_discord_dm(questions):
     path.write_text("\n".join(lines))
 
 
-def main():
+def main(*, workspace: Optional[Path] = None):
+    workspace = get_workspace(workspace)
     force = "--force" in sys.argv
-    questions = get_waiting_questions()
+    questions = get_waiting_questions(workspace)
     if not questions:
         return
 
-    if not force and presenter_mode_active():
+    if not force and presenter_mode_active(workspace):
         print(f"(presenter-mode) {len(questions)} pending questions — suppressed")
         return
 
-    if not force and not should_notify():
+    if not force and not should_notify(workspace):
         print(f"(cooldown) {len(questions)} pending questions — skipping notification")
         return
 
@@ -180,14 +179,14 @@ def main():
     # Voice result — only when voice is actually connected. When offline, the
     # discord-bridge dm-fallback would deliver question-*.txt as a duplicate
     # of notify_discord_dm below. Skipping cuts the spam in half.
-    if voice_client_connected():
-        notify_voice(questions)
+    if voice_client_connected(workspace):
+        notify_voice(questions, workspace)
 
     # Discord DM to owner (via discord-bridge poll_proactive)
-    notify_discord_dm(questions)
+    notify_discord_dm(questions, workspace)
 
     # Update last notify time
-    LAST_NOTIFY_FILE.write_text(str(int(time.time())))
+    (workspace / ".last-pq-notify").write_text(str(int(time.time())))
 
     print(f"Notified: {count} pending questions")
 

--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -11,23 +11,19 @@ import sys
 from collections import Counter, defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
 from util_paths import shared_personal_path  # noqa: E402
-from workspace_default import resolve_workspace  # noqa: E402
-
-WORKSPACE = resolve_workspace()
-CALLS_FILE = WORKSPACE / "results" / "calls" / "calls.jsonl"
-RESULTS_DIR = WORKSPACE / "results"
-STATE_DIR = WORKSPACE / "state"
-NOTES_DIR = Path(shared_personal_path("notes", WORKSPACE))
+from workspace_default import get_workspace  # noqa: E402
 
 
-def load_calls():
-    if not CALLS_FILE.exists():
+def load_calls(workspace: Path):
+    calls_file = workspace / "results" / "calls" / "calls.jsonl"
+    if not calls_file.exists():
         return []
     calls = []
-    for line in CALLS_FILE.read_text().splitlines():
+    for line in calls_file.read_text().splitlines():
         if line.strip():
             try:
                 calls.append(json.loads(line))
@@ -89,9 +85,10 @@ def analyze_topics(calls):
     return topics.most_common(10)
 
 
-def analyze_task_patterns():
+def analyze_task_patterns(workspace: Path):
     """Look at recent task results for patterns."""
-    task_files = sorted(RESULTS_DIR.glob("task-*.txt"), key=lambda f: f.stat().st_mtime, reverse=True)
+    results_dir = workspace / "results"
+    task_files = sorted(results_dir.glob("task-*.txt"), key=lambda f: f.stat().st_mtime, reverse=True)
     sources = Counter()
     for f in task_files[:50]:
         content = f.read_text()
@@ -106,9 +103,10 @@ def analyze_task_patterns():
     return sources
 
 
-def analyze_note_activity():
+def analyze_note_activity(workspace: Path):
     """Check note creation patterns."""
-    notes = list(NOTES_DIR.glob("*.md"))
+    notes_dir = Path(shared_personal_path("notes", workspace))
+    notes = list(notes_dir.glob("*.md"))
     recent = [n for n in notes if n.stat().st_mtime > (datetime.now().timestamp() - 7 * 86400)]
     tags = Counter()
     for n in notes:
@@ -123,8 +121,8 @@ def analyze_note_activity():
     return {"total": len(notes), "recent_7d": len(recent), "top_tags": tags.most_common(5)}
 
 
-def generate_insight():
-    calls = load_calls()
+def generate_insight(workspace: Path):
+    calls = load_calls(workspace)
     insights = []
 
     if calls:
@@ -158,7 +156,7 @@ def generate_insight():
                 f"Setting a timer or agenda could reclaim significant time."
             )
 
-    note_stats = analyze_note_activity()
+    note_stats = analyze_note_activity(workspace)
     if note_stats["recent_7d"] > 5:
         insights.append(
             f"You've created {note_stats['recent_7d']} notes in the last 7 days "
@@ -171,7 +169,7 @@ def generate_insight():
             f"You were actively noting ideas before — might be worth capturing what you're learning this week."
         )
 
-    task_sources = analyze_task_patterns()
+    task_sources = analyze_task_patterns(workspace)
     if task_sources:
         top_source = task_sources.most_common(1)[0]
         insights.append(
@@ -187,14 +185,16 @@ def generate_insight():
     return best
 
 
-def main():
+def main(*, workspace: Optional[Path] = None):
+    workspace = get_workspace(workspace)
     today = datetime.now().strftime("%Y-%m-%d")
-    output_path = RESULTS_DIR / f"insight-{today}.txt"
+    output_path = workspace / "results" / f"insight-{today}.txt"
     # Sentinel survives discord-bridge's `dm-fallback` unlink of the
     # results file, so repeat invocations (morning-briefing, cron, manual
     # test) on the same day don't regenerate + re-DM the insight.
-    STATE_DIR.mkdir(parents=True, exist_ok=True)
-    sentinel = STATE_DIR / f"daily-insight-{today}.sentinel"
+    state_dir = workspace / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    sentinel = state_dir / f"daily-insight-{today}.sentinel"
 
     if sentinel.exists():
         cached = sentinel.read_text()
@@ -202,7 +202,7 @@ def main():
         print(cached)
         return
 
-    insight = generate_insight()
+    insight = generate_insight(workspace)
     output_path.write_text(insight)
     sentinel.write_text(insight)
     print(f"Daily insight → {output_path}")

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -119,9 +119,13 @@ OWNER_ACTIVITY_FILE = STATE_DIR / "last-owner-activity.json"
 # drift, even with "keep in sync" comments).
 from send_allowlist import (  # noqa: E402
     SEND_ALLOWED_PREFIXES,
-    SEND_ALLOWED_ROOTS,
     is_path_sendable as _is_path_sendable_shared,
 )
+# Note: `SEND_ALLOWED_ROOTS` was a module-level tuple pre-#1442; now it is
+# the function `send_allowed_roots(workspace)` (workspace-derived, lazy-
+# resolved). Discord-bridge doesn't read the tuple directly — file allowlist
+# checks go through `_is_path_sendable_shared(path)` which calls the function
+# internally.
 
 
 _FENCE_LINE = re.compile(r"^\s{0,3}(`{3,}|~{3,})\s*([^\s`~][^`~]*)?\s*$")

--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -34,9 +34,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from util_paths import claude_home_path  # noqa: E402
-from workspace_default import resolve_workspace  # noqa: E402
+from workspace_default import get_workspace  # noqa: E402
 import discord_config  # noqa: E402  — workspace-local Sutando discord config (#1147)
-REPO = resolve_workspace()
 ACCESS_JSON = claude_home_path("channels", "discord", "access.json")
 SSE_STATUS_URL = "http://localhost:8080/sse-status"
 
@@ -185,7 +184,7 @@ def _load_token() -> str:
     """Read DISCORD_BOT_TOKEN from the first env file that has it."""
     for env_path in [
         claude_home_path("channels", "discord", ".env"),
-        REPO / ".env",
+        get_workspace() / ".env",
     ]:
         if not env_path.exists():
             continue

--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -51,9 +51,12 @@ import sys as _sys
 _sys.path.insert(0, str(Path(__file__).resolve().parent))
 from send_allowlist import (  # noqa: E402
     is_path_sendable as _is_path_sendable,
-    SEND_ALLOWED_PREFIXES as _SEND_ALLOWED_PREFIXES,
-    SEND_ALLOWED_ROOTS as _SEND_ALLOWED_ROOTS,
 )
+# Note: SEND_ALLOWED_PREFIXES + SEND_ALLOWED_ROOTS are referenced as bare
+# identifiers in the rejected-files log string at line ~386 below, not
+# read as values. Post-#1442 SEND_ALLOWED_ROOTS is now a function
+# (`send_allowed_roots(workspace)`); the log line keeps the old names for
+# operator continuity.
 
 
 _FENCE_LINE = re.compile(r"^\s{0,3}(`{3,}|~{3,})\s*([^\s`~][^`~]*)?\s*$")

--- a/src/event_log.py
+++ b/src/event_log.py
@@ -48,13 +48,10 @@ import time
 from pathlib import Path
 from typing import Any
 
-__all__ = ["log_event", "get_log_path", "LOGS_DIR"]
+__all__ = ["log_event", "get_log_path"]
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from workspace_default import resolve_workspace  # noqa: E402
-
-WORKSPACE_DIR = resolve_workspace()
-LOGS_DIR = WORKSPACE_DIR / "logs"
+from workspace_default import get_workspace  # noqa: E402
 
 _CACHED_MACHINE: str | None = None
 
@@ -68,7 +65,7 @@ def _machine_id() -> str:
     try:
         sys.path.insert(0, str(Path(__file__).parent))
         from util_paths import personal_path
-        identity = personal_path("stand-identity.json", workspace=WORKSPACE_DIR)
+        identity = personal_path("stand-identity.json", workspace=get_workspace())
         if identity.exists():
             _CACHED_MACHINE = json.loads(identity.read_text()).get("machine", "") or "unknown"
         else:
@@ -85,7 +82,7 @@ def get_log_path(when: float | None = None) -> Path:
     Sutando's human-readable logging."""
     ts = when if when is not None else time.time()
     date = time.strftime("%Y-%m-%d", time.localtime(ts))
-    return LOGS_DIR / f"events-{date}.jsonl"
+    return get_workspace() / "logs" / f"events-{date}.jsonl"
 
 
 def log_event(kind: str, **fields: Any) -> None:
@@ -113,8 +110,8 @@ def log_event(kind: str, **fields: Any) -> None:
             except (TypeError, ValueError):
                 event[k] = repr(v)
 
-        LOGS_DIR.mkdir(parents=True, exist_ok=True)
         path = get_log_path(now)
+        path.parent.mkdir(parents=True, exist_ok=True)
         line = json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
         # Single write() for atomicity on POSIX.
         with path.open("ab") as fh:

--- a/src/friction-detector.py
+++ b/src/friction-detector.py
@@ -17,16 +17,14 @@ import sys
 import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
 from util_paths import personal_path, shared_personal_path  # noqa: E402
-from workspace_default import resolve_workspace  # noqa: E402
-
-WORKSPACE = resolve_workspace()
-RESULTS_DIR = WORKSPACE / "results"
+from workspace_default import get_workspace  # noqa: E402
 
 
-def check_pending_questions():
+def check_pending_questions(workspace: Path):
     """Find questions unanswered for >24h.
 
     pending-questions.md uses sections like:
@@ -39,7 +37,7 @@ def check_pending_questions():
     which never matched the actual format, so it always returned an empty
     list and friction-detector silently missed every unanswered question.
     """
-    pq = Path(personal_path("pending-questions.md", WORKSPACE))
+    pq = Path(personal_path("pending-questions.md", workspace))
     if not pq.exists():
         return []
     content = pq.read_text()
@@ -92,10 +90,10 @@ def check_pending_questions():
     return issues
 
 
-def check_stale_tasks():
+def check_stale_tasks(workspace: Path):
     """Find task files older than 1 hour (should be processed within minutes)."""
     issues = []
-    tasks_dir = WORKSPACE / "tasks"
+    tasks_dir = workspace / "tasks"
     if not tasks_dir.exists():
         return []
     now = datetime.now().timestamp()
@@ -127,11 +125,11 @@ def check_github_issues():
     return issues
 
 
-def check_overdue_reminders():
+def check_overdue_reminders(workspace: Path):
     """Check macOS Reminders for overdue items."""
     issues = []
     try:
-        script = WORKSPACE.parent.parent / ".claude" / "skills" / "macos-tools" / "scripts" / "reminders.py"
+        script = workspace.parent.parent / ".claude" / "skills" / "macos-tools" / "scripts" / "reminders.py"
         if not script.exists():
             return []
         # Use sys.executable: friction-detector runs via cron (launchd-managed);
@@ -156,10 +154,10 @@ def check_stale_results():
     return []
 
 
-def check_notes_without_follow_up():
+def check_notes_without_follow_up(workspace: Path):
     """Find notes tagged 'action' or 'todo' that are >7 days old."""
     issues = []
-    notes_dir = Path(shared_personal_path("notes", WORKSPACE))
+    notes_dir = Path(shared_personal_path("notes", workspace))
     if not notes_dir.exists():
         return []
     now = datetime.now().timestamp()
@@ -203,9 +201,10 @@ def check_notes_without_follow_up():
     return issues
 
 
-def main():
+def main(*, workspace: Optional[Path] = None):
+    workspace = get_workspace(workspace)
     today = datetime.now().strftime("%Y-%m-%d")
-    output_path = RESULTS_DIR / f"friction-{today}.txt"
+    output_path = workspace / "results" / f"friction-{today}.txt"
 
     # Don't regenerate if already done today
     if output_path.exists():
@@ -214,11 +213,11 @@ def main():
         return
 
     all_issues = []
-    all_issues.extend(check_pending_questions())
-    all_issues.extend(check_stale_tasks())
+    all_issues.extend(check_pending_questions(workspace))
+    all_issues.extend(check_stale_tasks(workspace))
     all_issues.extend(check_github_issues())
-    all_issues.extend(check_overdue_reminders())
-    all_issues.extend(check_notes_without_follow_up())
+    all_issues.extend(check_overdue_reminders(workspace))
+    all_issues.extend(check_notes_without_follow_up(workspace))
 
     if not all_issues:
         summary = "No friction detected today. Everything is clean."

--- a/src/github-webhook.py
+++ b/src/github-webhook.py
@@ -27,16 +27,14 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 
 # Two separate concerns (per qingyun review on PR #775):
-# - REPO  = source tree (this file's parent.parent) — for loading .env from
-#           the checkout root. Stays anchored regardless of SUTANDO_WORKSPACE.
-# - WORKSPACE_DIR = runtime state (resolve_workspace()) — for tasks/ writes so
-#           the workspace-aware watcher picks them up.
+# - REPO         = source tree (this file's parent.parent) — for loading .env from
+#                  the checkout root. Stays anchored.
+# - tasks dir    = runtime state via `get_workspace() / "tasks"` — resolved lazily
+#                  per the v0.8 `Lazy config access` pattern (CONTRIBUTING.md).
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from workspace_default import resolve_workspace  # noqa: E402
+from workspace_default import get_workspace  # noqa: E402
 
-WORKSPACE_DIR = resolve_workspace()
-TASKS_DIR = WORKSPACE_DIR / "tasks"
 PORT = int(sys.argv[sys.argv.index("--port") + 1]) if "--port" in sys.argv else 7847
 
 # Load .env from the repo root (not workspace) so launchctl / systemd managed
@@ -151,8 +149,9 @@ class WebhookHandler(BaseHTTPRequestHandler):
         if task_text:
             task_id = f"task-gh-{int(time.time() * 1000)}"
             task_content = f"id: {task_id}\ntimestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\ntask: {task_text}\nsource: github\n"
-            TASKS_DIR.mkdir(exist_ok=True)
-            (TASKS_DIR / f"{task_id}.txt").write_text(task_content)
+            tasks_dir = get_workspace() / "tasks"
+            tasks_dir.mkdir(exist_ok=True)
+            (tasks_dir / f"{task_id}.txt").write_text(task_content)
             print(f"[{time.strftime('%H:%M:%S')}] {event_type}/{payload.get('action', '')} → {task_id}")
 
         self.send_response(200)

--- a/src/init.sh
+++ b/src/init.sh
@@ -40,24 +40,27 @@ if [ -f "$__HELPER" ]; then
   # shellcheck source=workspace_resolve.sh
   source "$__HELPER"
   resolve_workspace_or_die
-elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "init.sh: cannot resolve workspace — workspace_resolve.sh not found at \$REPO/src/ or alongside this script, and \$SUTANDO_WORKSPACE is not set." >&2
+  echo "init.sh: cannot resolve workspace — workspace_resolve.sh not found at \$REPO/src/ or alongside this script." >&2
   exit 1
 fi
 unset __HELPER
 
-# Surface the silent-fallback bug class (see PR #1367/#1368): if .env defines
-# SUTANDO_WORKSPACE but this process never got it (e.g. init.sh invoked by a
-# bootstrap path that skips startup.sh's .env-source), the helper-resolved
-# value may differ from .env. One stderr line per init.sh run makes the miss
-# visible. M0's loud-warn-workspace-fallback (PR #1369) covers part of this
-# from the helper side; this is the init.sh-specific belt-and-suspenders.
+# v0.8 deprecation nag (init.sh-side belt-and-suspenders for the resolver
+# warning). If `.env` declares a SUTANDO_WORKSPACE line, it's no longer
+# honored — surface once per init.sh run so the operator cleans up. The
+# resolver fires its own bold-red warning when the env var is set in the
+# process environment; this catches the `.env` declaration case for boot
+# paths that don't source .env into the env (launchd, cron, direct invokes).
 if [ -f "$REPO/.env" ]; then
   _env_val=$(grep -E '^SUTANDO_WORKSPACE=' "$REPO/.env" 2>/dev/null | head -1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'\$//" -e "s|^~|$HOME|")
-  if [ -n "$_env_val" ] && [ "$_env_val" != "$WORKSPACE" ]; then
-    echo "workspace: .env declares SUTANDO_WORKSPACE='$_env_val' but the M0 helper resolves to '$WORKSPACE' — source .env or export the var before this process to avoid split-brain with other services." >&2
+  if [ -n "$_env_val" ]; then
+    if [ -t 2 ]; then
+      printf '\033[1;31m%s\033[0m\n' \
+        "workspace: .env declares SUTANDO_WORKSPACE='$_env_val' but the env var is no longer honored (removed in v0.8). Delete the .env line, and if needed move the value to sutando.config.local.json under workspace.path. The M0 helper resolves to '$WORKSPACE'." >&2
+    else
+      echo "workspace: .env declares SUTANDO_WORKSPACE='$_env_val' but the env var is no longer honored (removed in v0.8). Delete the .env line, and if needed move the value to sutando.config.local.json under workspace.path. The M0 helper resolves to '$WORKSPACE'." >&2
+    fi
   fi
   unset _env_val
 fi

--- a/src/install-credential-proxy-launchd.sh
+++ b/src/install-credential-proxy-launchd.sh
@@ -33,10 +33,8 @@ if [ -f "$__HELPER" ]; then
   # shellcheck source=workspace_resolve.sh
   source "$__HELPER"
   resolve_workspace_or_die
-elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  echo "${0##*/}: cannot resolve workspace — workspace_resolve.sh not found and \$SUTANDO_WORKSPACE not set." >&2
+  echo "${0##*/}: cannot resolve workspace — workspace_resolve.sh not found. v0.8 contract requires the helper; \$SUTANDO_WORKSPACE is no longer honored." >&2
   exit 1
 fi
 unset __HELPER

--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -16,16 +16,12 @@ import sys
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Optional
 from urllib.request import urlopen
 from urllib.error import URLError
 
 sys.path.insert(0, str(Path(__file__).parent))
-from workspace_default import resolve_workspace  # noqa: E402
-
-WORKSPACE = resolve_workspace()
-RESULTS_DIR = WORKSPACE / "results"
-LOGS_DIR = WORKSPACE / "logs"
-STATE_DIR = WORKSPACE / "state"
+from workspace_default import get_workspace  # noqa: E402
 
 # Weather codes → one-word description
 WEATHER_CODES = {
@@ -182,9 +178,9 @@ def get_reminders() -> list[str]:
         return []
 
 
-def get_overnight_discord() -> list[str]:
+def get_overnight_discord(workspace: Path) -> list[str]:
     """Read last 8 hours of Discord DMs from the bridge log."""
-    log = LOGS_DIR / "discord-bridge.log"
+    log = workspace / "logs" / "discord-bridge.log"
     if not log.exists():
         return []
     try:
@@ -204,9 +200,9 @@ def get_overnight_discord() -> list[str]:
         return []
 
 
-def get_pending_questions() -> list[str]:
+def get_pending_questions(workspace: Path) -> list[str]:
     """Return unanswered questions from pending-questions.md."""
-    pq = WORKSPACE / "pending-questions.md"
+    pq = workspace / "pending-questions.md"
     if not pq.exists():
         return []
     content = pq.read_text()
@@ -225,7 +221,7 @@ def get_pending_questions() -> list[str]:
     return questions
 
 
-def get_health_issues() -> list[str]:
+def get_health_issues(workspace: Path) -> list[str]:
     """Run health check and return only the failed/warn items, concisely."""
     hc = Path(__file__).parent / "health-check.py"
     if not hc.exists():
@@ -234,7 +230,7 @@ def get_health_issues() -> list[str]:
         r = subprocess.run(
             [sys.executable, str(hc)],
             capture_output=True, text=True, timeout=30,
-            cwd=str(WORKSPACE)
+            cwd=str(workspace)
         )
         issues = []
         for line in r.stdout.splitlines():
@@ -254,10 +250,10 @@ def get_health_issues() -> list[str]:
         return []
 
 
-def get_daily_insight() -> str | None:
+def get_daily_insight(workspace: Path) -> str | None:
     """Get today's behavioral insight from daily-insight.py (cached via sentinel)."""
     today = datetime.now().strftime("%Y-%m-%d")
-    sentinel = STATE_DIR / f"daily-insight-{today}.sentinel"
+    sentinel = workspace / "state" / f"daily-insight-{today}.sentinel"
     if sentinel.exists():
         return sentinel.read_text().strip() or None
     # Not yet generated — run it
@@ -268,7 +264,7 @@ def get_daily_insight() -> str | None:
         r = subprocess.run(
             [sys.executable, str(hc)],
             capture_output=True, text=True, timeout=20,
-            cwd=str(WORKSPACE)
+            cwd=str(workspace)
         )
         if r.returncode == 0 and sentinel.exists():
             return sentinel.read_text().strip() or None
@@ -339,10 +335,14 @@ def synthesize(weather, events, reminders, discord_msgs, pending_qs, health_issu
     return " ".join(parts)
 
 
-def main():
+def main(*, workspace: Optional[Path] = None):
+    workspace = get_workspace(workspace)
+    state_dir = workspace / "state"
+    results_dir = workspace / "results"
+
     # Check sentinel — don't repeat if already run today
     today = datetime.now().strftime("%Y-%m-%d")
-    sentinel = STATE_DIR / f"morning-briefing-{today}.sentinel"
+    sentinel = state_dir / f"morning-briefing-{today}.sentinel"
     if sentinel.exists() and "--force" not in sys.argv:
         print(f"Morning briefing already delivered today ({today}). Use --force to re-run.")
         return
@@ -359,16 +359,16 @@ def main():
     reminders = get_reminders()
     print(f"  reminders: {len(reminders)} due")
 
-    discord_msgs = get_overnight_discord()
+    discord_msgs = get_overnight_discord(workspace)
     print(f"  discord overnight: {len(discord_msgs)} messages")
 
-    insight = get_daily_insight()
+    insight = get_daily_insight(workspace)
     print(f"  insight: {'yes' if insight else 'none'}")
 
-    pending_qs = get_pending_questions()
+    pending_qs = get_pending_questions(workspace)
     print(f"  pending questions: {len(pending_qs)}")
 
-    health_issues = get_health_issues()
+    health_issues = get_health_issues(workspace)
     print(f"  health issues: {len(health_issues)}")
 
     # Synthesize
@@ -376,13 +376,13 @@ def main():
 
     # Write voice result
     ts = int(time.time() * 1000)
-    result_file = RESULTS_DIR / f"proactive-morning-{ts}.txt"
-    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    result_file = results_dir / f"proactive-morning-{ts}.txt"
+    results_dir.mkdir(parents=True, exist_ok=True)
     result_file.write_text(narrative)
     print(f"  → {result_file.name}")
 
     # Mark as done today
-    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    state_dir.mkdir(parents=True, exist_ok=True)
     sentinel.write_text(datetime.now().isoformat())
 
     print(f"\nBriefing delivered:\n{narrative}")

--- a/src/scan-call-logs.py
+++ b/src/scan-call-logs.py
@@ -11,13 +11,18 @@ Usage:
 import json, re, sys, os
 from pathlib import Path
 from datetime import datetime
+from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
-from workspace_default import resolve_workspace  # noqa: E402
+from workspace_default import get_workspace  # noqa: E402
 
-_WORKSPACE = resolve_workspace()
-CALLS_FILE = _WORKSPACE / "results" / "calls" / "calls.jsonl"
-STATE_FILE = _WORKSPACE / "results" / "calls" / ".scan-state.json"
+
+def _calls_file(workspace: Path) -> Path:
+    return workspace / "results" / "calls" / "calls.jsonl"
+
+
+def _state_file(workspace: Path) -> Path:
+    return workspace / "results" / "calls" / ".scan-state.json"
 
 # --- Detection patterns ---
 
@@ -356,23 +361,29 @@ def scan_entry(entry: dict):
     }
 
 
-def load_state() -> dict:
-    if STATE_FILE.exists():
-        return json.loads(STATE_FILE.read_text())
+def load_state(*, workspace: Optional[Path] = None) -> dict:
+    workspace = get_workspace(workspace)
+    state_file = _state_file(workspace)
+    if state_file.exists():
+        return json.loads(state_file.read_text())
     return {"last_scanned_index": 0}
 
 
-def save_state(state: dict):
-    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-    STATE_FILE.write_text(json.dumps(state, indent=2))
+def save_state(state: dict, *, workspace: Optional[Path] = None):
+    workspace = get_workspace(workspace)
+    state_file = _state_file(workspace)
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(json.dumps(state, indent=2))
 
 
-def main():
-    if not CALLS_FILE.exists():
+def main(*, workspace: Optional[Path] = None):
+    workspace = get_workspace(workspace)
+    calls_file = _calls_file(workspace)
+    if not calls_file.exists():
         print("No call logs found.")
         return
 
-    entries = [json.loads(l) for l in CALLS_FILE.read_text().strip().split('\n') if l.strip()]
+    entries = [json.loads(l) for l in calls_file.read_text().strip().split('\n') if l.strip()]
     as_json = "--json" in sys.argv
     scan_all = "--all" in sys.argv
 
@@ -384,7 +395,7 @@ def main():
         n = int(sys.argv[idx + 1]) if idx + 1 < len(sys.argv) else 10
         start = max(0, len(entries) - n)
     else:
-        state = load_state()
+        state = load_state(workspace=workspace)
         start = state.get("last_scanned_index", 0)
 
     to_scan = entries[start:]
@@ -402,7 +413,7 @@ def main():
             results.append(result)
 
     # Save state
-    save_state({"last_scanned_index": len(entries), "last_scan": datetime.now().isoformat()})
+    save_state({"last_scanned_index": len(entries), "last_scan": datetime.now().isoformat()}, workspace=workspace)
 
     if as_json:
         print(json.dumps({"scanned": len(to_scan), "with_issues": len(results), "results": results}, indent=2))
@@ -422,13 +433,15 @@ def main():
                 print()
 
 
-def summary():
+def summary(*, workspace: Optional[Path] = None):
     """Print a quality trend summary grouped by date."""
-    if not CALLS_FILE.exists():
+    workspace = get_workspace(workspace)
+    calls_file = _calls_file(workspace)
+    if not calls_file.exists():
         print("No call logs found.")
         return
 
-    entries = [json.loads(l) for l in CALLS_FILE.read_text().strip().split('\n') if l.strip()]
+    entries = [json.loads(l) for l in calls_file.read_text().strip().split('\n') if l.strip()]
     from collections import Counter
 
     by_date = {}

--- a/src/send_allowlist.py
+++ b/src/send_allowlist.py
@@ -43,31 +43,39 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from workspace_default import resolve_workspace  # noqa: E402
+from workspace_default import get_workspace  # noqa: E402
 from util_paths import shared_personal_path  # noqa: E402
 
-_REPO = resolve_workspace()
 
-# Owner-relative + machine-local roots. Files under these roots are
-# delivered to Discord as attachments without further checks.
-SEND_ALLOWED_ROOTS: tuple[str, ...] = (
-    str(_REPO / "results"),
-    str(_REPO / "notes"),
-    # Notes canonical home (private dir) — once saved by save_note,
-    # paths reference the private location. Both old and new paths
-    # allowed during the transition; resolver picks whichever exists.
-    str(shared_personal_path("notes", _REPO)),
-    str(_REPO / "docs"),
-    str(Path.home() / "Desktop" / "iclr-backups"),
-    str(Path.home() / "Documents" / "sutando-launch-assets"),
-)
+def send_allowed_roots(workspace: Path) -> tuple[str, ...]:
+    """Owner-relative + machine-local roots. Files under these roots are
+    delivered to Discord as attachments without further checks.
+
+    Computed per-call from the active workspace (lazy-resolve, per
+    CONTRIBUTING.md "Lazy config access"). Pre-#1442 this was a module-
+    level tuple captured at import time.
+    """
+    return (
+        str(workspace / "results"),
+        str(workspace / "notes"),
+        # Notes canonical home (private dir) — once saved by save_note,
+        # paths reference the private location. Both old and new paths
+        # allowed during the transition; resolver picks whichever exists.
+        str(shared_personal_path("notes", workspace)),
+        str(workspace / "docs"),
+        str(Path.home() / "Desktop" / "iclr-backups"),
+        str(Path.home() / "Documents" / "sutando-launch-assets"),
+    )
+
 
 # Prefix forms — files whose realpath starts with any of these strings
 # are deliverable. Covers temp-file artifacts the agent generates
 # (`/tmp/sutando-recording-*.mov`, `/tmp/echo-screenshot-*.png`, etc.)
-# without needing to enumerate every filename.
+# without needing to enumerate every filename. Static — no workspace
+# dependency, so kept as a module-level constant.
 SEND_ALLOWED_PREFIXES: tuple[str, ...] = (
     "/tmp/sutando-",
     "/private/tmp/sutando-",
@@ -76,10 +84,10 @@ SEND_ALLOWED_PREFIXES: tuple[str, ...] = (
 )
 
 
-def is_path_sendable(fpath: str) -> bool:
+def is_path_sendable(fpath: str, *, workspace: Optional[Path] = None) -> bool:
     """True iff `fpath` is a regular file AND its `realpath` resolves
-    under one of ``SEND_ALLOWED_ROOTS`` or starts with one of
-    ``SEND_ALLOWED_PREFIXES``.
+    under one of the workspace-derived allowed roots or starts with one
+    of ``SEND_ALLOWED_PREFIXES``.
 
     Single source of truth for the file-attachment-delivery policy.
     Mirrors the shape used by ``_is_path_sendable`` in both call sites
@@ -90,13 +98,14 @@ def is_path_sendable(fpath: str) -> bool:
     allowed root/prefix all return False. Callers should fail-closed
     on False (log + skip; never deliver the file).
     """
+    workspace = get_workspace(workspace)
     if not os.path.isfile(fpath):
         return False
     try:
         real = os.path.realpath(fpath)
     except OSError:
         return False
-    for root in SEND_ALLOWED_ROOTS:
+    for root in send_allowed_roots(workspace):
         root_real = os.path.realpath(root)
         if real == root_real or real.startswith(root_real + os.sep):
             return True

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -77,6 +77,71 @@ else
 fi
 if [ $missing -eq 1 ]; then echo ""; echo "Fix the above and try again."; exit 1; fi
 
+# v0.8 auto-migration: $SUTANDO_WORKSPACE is no longer honored by the resolver.
+# If still set (shell rc, .env, launchd plist), detect any data at the env-
+# pointed path and relocate to the new default before services start.
+#
+# Sentinel guard: state/auth/migrated-from-env.txt under the NEW workspace
+# records a successful migration so a re-run doesn't retry. Sentinel is in
+# state/auth/ specifically because that subtree is exempt from transient-state
+# cleanup (per CLAUDE.md "Durable per-host install state").
+#
+# Failure mode: if sutando-migrate.sh --commit exits non-zero (collision that
+# can't be auto-resolved, etc.), startup ABORTS — refusing to proceed with
+# split state. Operator runs `bash scripts/sutando-migrate.sh --dry-run` to
+# diagnose.
+if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
+  _ws_legacy="${SUTANDO_WORKSPACE/#\~/$HOME}"
+  _ws_new="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null || true)"
+  _migrate_sentinel="${_ws_new}/state/auth/migrated-from-env.txt"
+
+  if [ -n "$_ws_new" ] && [ ! -f "$_migrate_sentinel" ] \
+     && [ -d "$_ws_legacy" ] && [ -n "$(ls -A "$_ws_legacy" 2>/dev/null)" ]; then
+    # Red banner so the operator notices the one-shot relocation.
+    if [ -t 2 ]; then
+      printf '\033[1;31m📦 sutando v0.8 auto-migration: $SUTANDO_WORKSPACE points at %s with data; relocating to %s (one-shot).\033[0m\n' \
+        "$_ws_legacy" "$_ws_new" >&2
+    else
+      printf 'sutando v0.8 auto-migration: $SUTANDO_WORKSPACE points at %s with data; relocating to %s (one-shot).\n' \
+        "$_ws_legacy" "$_ws_new" >&2
+    fi
+
+    if bash "$REPO/scripts/sutando-migrate.sh" --commit; then
+      mkdir -p "$(dirname "$_migrate_sentinel")"
+      printf 'migrated_from=%s\nmigrated_at=%s\nhostname=%s\n' \
+        "$_ws_legacy" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(hostname)" \
+        > "$_migrate_sentinel"
+      echo "✅ auto-migration complete — data moved into $_ws_new/" >&2
+
+      # Compress the original folder in place + replace the directory with the
+      # tarball. Two goals (per owner directive 2026-06-03 18:36Z):
+      #   1) Preserve the original data as a recovery archive — `tar -xzf` to
+      #      restore.
+      #   2) Replace the directory with a single file so any stale process /
+      #      cron / launchd job still referencing the env-pointed path hits
+      #      ENOENT instead of silently writing to a divergent dir.
+      _legacy_archive="${_ws_legacy%/}-pre-v0.8-$(date -u +%Y%m%dT%H%M%SZ).tar.gz"
+      if tar -czf "$_legacy_archive" -C "$(dirname "$_ws_legacy")" "$(basename "$_ws_legacy")" 2>/dev/null; then
+        rm -rf "$_ws_legacy"
+        echo "📦 archived → $_legacy_archive" >&2
+        echo "   to restore: tar -xzf '$_legacy_archive' -C $(dirname "$_ws_legacy")" >&2
+      else
+        echo "⚠️  archive of $_ws_legacy failed — leaving in place. Old processes may still write there." >&2
+      fi
+    else
+      echo "❌ auto-migration failed — refusing to start with split state." >&2
+      echo "   Diagnose: bash scripts/sutando-migrate.sh --dry-run" >&2
+      echo "   Inspect:  ls -la $_ws_legacy $_ws_new" >&2
+      exit 1
+    fi
+  fi
+
+  # Whether migrated or not, unset $SUTANDO_WORKSPACE so child processes
+  # (init.sh, bridges, voice-agent, etc.) get the v0.8 contract directly and
+  # the resolver's deprecation nag stops firing on every subprocess spawn.
+  unset SUTANDO_WORKSPACE
+fi
+
 # Exercise the new config loader as a startup banner. Surfaces:
 #   • $SUTANDO_WORKSPACE legacy-escape-hatch warning (if env is set)
 #   • .env-drift warning (if .env declares a value but config resolves differently)
@@ -206,21 +271,18 @@ echo ""
 bash "$REPO/skills/install.sh" 2>/dev/null || true
 
 # Resolve the runtime workspace via the canonical loader (M0 cutover).
-# The loader implements the full resolution order:
-#   1. $SUTANDO_WORKSPACE env var (legacy escape hatch; warn once)
-#   2. sutando.config.local.json -> workspace.path (per-clone override)
-#   3. sutando.config.json -> workspace.path (tracked defaults)
-#   4. ${REPO_DIR}/workspace baked-in default
+# The loader (v0.8 — env override removed) implements:
+#   1. sutando.config.local.json -> workspace.path (per-clone override)
+#   2. sutando.config.json -> workspace.path (tracked defaults)
+#   3. ${REPO_DIR}/workspace baked-in default
 # Inline fallback retained for the rare case where the wrapper isn't
 # present (extracted-tarball install, etc.). All service logs + tasks/
 # results land under $WORKSPACE/logs etc. instead of the repo-root legacy
 # paths. health-check + dashboard already read from $WORKSPACE/logs.
 if [ -f "$REPO/scripts/sutando-config.sh" ]; then
   WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
-elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-  WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
 else
-  WORKSPACE="$HOME/.sutando/workspace"
+  WORKSPACE="$REPO/workspace"
 fi
 mkdir -p "$WORKSPACE/logs" "$WORKSPACE/tasks" "$WORKSPACE/results" "$WORKSPACE/data" "$WORKSPACE/state"
 LOGS_DIR="$WORKSPACE/logs"

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -7,10 +7,13 @@ go through `load_config()` so that the contract is enforced in one place
 rather than re-implemented per-service.
 
 Resolution order (highest layer wins):
-  1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn on use)
-  2. `sutando.config.local.json` (per-clone override, gitignored)
-  3. `sutando.config.json` (tracked defaults at repo root)
-  4. Baked-in default (`{repo_root}/workspace`)
+  1. `sutando.config.local.json` (per-clone override, gitignored)
+  2. `sutando.config.json` (tracked defaults at repo root)
+  3. Baked-in default (`{repo_root}/workspace`)
+
+`$SUTANDO_WORKSPACE` is no longer honored (removed in v0.8). If set, a
+one-time stderr warning fires pointing at `scripts/sutando-migrate.sh`
+for relocation of any data still living at the env-pointed path.
 
 Deep-merge semantics: `.local.json` is merged over the tracked defaults.
 Dicts deep-merge; arrays REPLACE wholesale (not unioned). This matches the
@@ -180,6 +183,25 @@ _DOTENV_DRIFT_WARN_PRINTED = False
 _UNKNOWN_KEYS_WARN_PRINTED = False
 
 
+def _color_warn(msg: str) -> str:
+    """Wrap `msg` in bold-red ANSI when stderr is a TTY; pass through otherwise.
+
+    Keeps the v0.8 deprecation warnings (`$SUTANDO_WORKSPACE no longer honored`,
+    `.env declares stale SUTANDO_WORKSPACE`) eye-catching in interactive
+    terminals so operators actually notice and migrate, while keeping log
+    captures (`script`, `tee`, journald, GitHub Actions) free of escape
+    sequences. `NO_COLOR=1` honored as a hard opt-out (see no-color.org).
+    """
+    if os.environ.get("NO_COLOR"):
+        return msg
+    try:
+        if sys.stderr.isatty():
+            return f"\033[1;31m{msg}\033[0m"
+    except Exception:
+        pass
+    return msg
+
+
 def _warn_unknown_top_level_keys(cfg: Dict[str, Any], path: Path) -> None:
     """Emit a one-time stderr warning if the resolved config has top-level
     keys the loader doesn't recognize. Helps catch typos like `workspce`
@@ -262,57 +284,43 @@ _HARDCODED_WORKSPACE_DEFAULT_REL = "workspace"  # relative to repo root
 def resolve_workspace(repo_root: Optional[Path] = None) -> Path:
     """Resolve the workspace directory per the canonical contract.
 
-    Order:
-      1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn once).
-      2. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
-      3. `{repo_root}/workspace` baked-in default.
+    Order (v0.8 — `$SUTANDO_WORKSPACE` env override removed):
+      1. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
+      2. `{repo_root}/workspace` baked-in default.
 
     Does NOT create the directory; the caller decides. Returns an absolute
     `Path`.
 
-    The env-var warning fires at most once per process so log noise is
-    bounded. The warning is informational — env still wins, so existing
-    users don't break on the switch. Migration path: copy the env value
-    into `sutando.config.local.json` → `workspace.path` and unset the env.
+    If `$SUTANDO_WORKSPACE` is set in the environment, fires a one-time
+    stderr migration-nag warning pointing at `scripts/sutando-migrate.sh`
+    but does NOT honor the env value (the legacy escape hatch was removed
+    in v0.8 per `docs/workspace-contract-v0.8.md`).
     """
     global _LEGACY_ENV_WARN_PRINTED, _DOTENV_DRIFT_WARN_PRINTED
 
     env_val = os.environ.get("SUTANDO_WORKSPACE", "").strip()
-    if env_val:
-        if not _LEGACY_ENV_WARN_PRINTED:
-            _LEGACY_ENV_WARN_PRINTED = True
-            # The warning intentionally OMITS the env value. Embedding a path
-            # in the message string makes the warning "path-shaped": a caller
-            # that mishandles stderr (`$(... 2>&1)` then `mkdir -p "$captured"`)
-            # would build a nested folder tree because bash tokenizes the `/`
-            # chars inside the value. Discovered 2026-06-02 — rogue folder at
-            # <repo>/sutando config: $SUTANDO_WORKSPACE is set ('/var/folders/.../...,
-            # full diagnosis in workspace/results/task-1780442649943.txt.
-            # Users debugging the value can `echo $SUTANDO_WORKSPACE`.
-            print(
-                "sutando config: $SUTANDO_WORKSPACE is set; honoring "
-                "as legacy escape hatch. To silence, move the value into "
-                "sutando.config.local.json under workspace.path and unset the env.",
-                file=sys.stderr,
-            )
-        # Preserve the pre-cutover semantic: only resolve when the env value
-        # is RELATIVE (anchor to cwd, surface the misconfig). For absolute
-        # paths, return as-is so symlinked paths like /tmp -> /private/tmp on
-        # macOS don't get rewritten — that broke the workspace_default test
-        # that compared paths string-equality.
-        target = Path(env_val).expanduser()
-        if not target.is_absolute():
-            anchored = (Path.cwd() / target).resolve()
-            # Same path-shape risk as the main `is set` warning above —
-            # values omitted. Users debugging can `echo $SUTANDO_WORKSPACE`
-            # and `pwd` to reconstruct what got anchored to where.
-            print(
-                "sutando config: $SUTANDO_WORKSPACE is relative — "
-                "anchored to CWD (cross-process drift; set an absolute path).",
-                file=sys.stderr,
-            )
-            return anchored
-        return target
+    if env_val and not _LEGACY_ENV_WARN_PRINTED:
+        _LEGACY_ENV_WARN_PRINTED = True
+        # The warning intentionally OMITS the env value. Embedding a path
+        # in the message string makes the warning "path-shaped": a caller
+        # that mishandles stderr (`$(... 2>&1)` then `mkdir -p "$captured"`)
+        # would build a nested folder tree because bash tokenizes the `/`
+        # chars inside the value. Discovered 2026-06-02 — rogue folder at
+        # <repo>/sutando config: $SUTANDO_WORKSPACE is set ('/var/folders/.../...,
+        # full diagnosis in workspace/results/task-1780442649943.txt.
+        # Users debugging the value can `echo $SUTANDO_WORKSPACE`.
+        print(
+            _color_warn(
+                "sutando config: $SUTANDO_WORKSPACE is set but NO LONGER HONORED "
+                "(removed in v0.8). Workspace resolves only from "
+                "sutando.config.{json,local.json} or the {repoRoot}/workspace "
+                "baked-in default. If existing workspace data lives at the "
+                "$SUTANDO_WORKSPACE path, run `bash scripts/sutando-migrate.sh "
+                "--dry-run` then `--commit` to relocate. Unset the env to "
+                "silence this warning."
+            ),
+            file=sys.stderr,
+        )
 
     cfg = load_config(repo_root)
     root = repo_root or _CACHE_REPO_ROOT
@@ -328,25 +336,24 @@ def resolve_workspace(repo_root: Optional[Path] = None) -> Path:
     else:
         resolved = (root / _HARDCODED_WORKSPACE_DEFAULT_REL).resolve()
 
-    # M0 .env-drift warning: if the env var is UNSET but `.env` declares one,
-    # the user has a stale `.env` line that the new contract bypasses. Surface
-    # once per process so they migrate to `sutando.config.local.json` and
-    # delete the `.env` line. Loader does NOT honor `.env` values — only the
-    # process env. This is the "Detect SUTANDO_WORKSPACE from .env file and
-    # give warning" bullet from Milestone 0.
+    # .env-drift warning: if `.env` still carries a stale SUTANDO_WORKSPACE
+    # line, surface it once per process so the operator can clean it up.
+    # (v0.8: the env var is no longer honored regardless of whether it's set
+    # in the shell or in .env; the warning is purely cleanup guidance.)
     if not _DOTENV_DRIFT_WARN_PRINTED:
         _DOTENV_DRIFT_WARN_PRINTED = True
         dotenv_val = detect_env_workspace_in_dotenv(repo_root)
-        if dotenv_val and Path(dotenv_val).resolve() != resolved:
+        if dotenv_val:
             # Same path-shape risk — values omitted. Users debugging can
             # `grep SUTANDO_WORKSPACE .env` and `bash scripts/sutando-config.sh
             # workspace` to compare.
             print(
-                "sutando config: .env declares SUTANDO_WORKSPACE but the resolved "
-                "workspace differs (config-driven). The .env line is NOT honored by "
-                "the new loader — move the value to sutando.config.local.json under "
-                "workspace.path and delete the .env line, or `source .env` before "
-                "launching processes that need the override.",
+                _color_warn(
+                    "sutando config: .env declares SUTANDO_WORKSPACE but the env var "
+                    "is no longer honored (removed in v0.8). Workspace resolves "
+                    "config-driven. Delete the .env line and, if needed, move the "
+                    "value to sutando.config.local.json under workspace.path."
+                ),
                 file=sys.stderr,
             )
 

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -299,6 +299,15 @@ def resolve_workspace(repo_root: Optional[Path] = None) -> Path:
     global _LEGACY_ENV_WARN_PRINTED, _DOTENV_DRIFT_WARN_PRINTED
 
     env_val = os.environ.get("SUTANDO_WORKSPACE", "").strip()
+
+    # Test-only escape hatch: when `SUTANDO_TEST_MODE=1` is set, honor
+    # `$SUTANDO_WORKSPACE` silently. This preserves the v0.8 contract for
+    # end users (no env override; warning + ignore) while letting the test
+    # suite redirect workspace to per-test tmp dirs without rewriting every
+    # test fixture. Production code MUST NOT set `SUTANDO_TEST_MODE`.
+    if env_val and os.environ.get("SUTANDO_TEST_MODE") == "1":
+        return Path(env_val).expanduser().resolve()
+
     if env_val and not _LEGACY_ENV_WARN_PRINTED:
         _LEGACY_ENV_WARN_PRINTED = True
         # The warning intentionally OMITS the env value. Embedding a path

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -7,11 +7,14 @@
  * Python services (bridges, health-check) and TS services (voice-agent,
  * task-bridge) land in the same workspace.
  *
- * Resolution order (highest layer wins):
- *   1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn on use)
- *   2. `sutando.config.local.json` (per-clone override, gitignored)
- *   3. `sutando.config.json` (tracked defaults at repo root)
- *   4. Baked-in default (`{repo_root}/workspace`)
+ * Resolution order (highest layer wins, v0.8 — env override removed):
+ *   1. `sutando.config.local.json` (per-clone override, gitignored)
+ *   2. `sutando.config.json` (tracked defaults at repo root)
+ *   3. Baked-in default (`{repo_root}/workspace`)
+ *
+ * `$SUTANDO_WORKSPACE` is no longer honored. If set in the environment,
+ * a one-time stderr warning fires pointing at `scripts/sutando-migrate.sh`
+ * for relocation of any data still living at the env-pointed path.
  *
  * No external deps — stdlib only.
  */
@@ -173,6 +176,25 @@ let _legacyEnvWarnPrinted = false;
 let _dotenvDriftWarnPrinted = false;
 let _unknownKeysWarnPrinted = false;
 
+/**
+ * Wrap `msg` in bold-red ANSI when stderr is a TTY; pass through otherwise.
+ *
+ * Keeps the v0.8 deprecation warnings ($SUTANDO_WORKSPACE no longer honored,
+ * .env declares stale SUTANDO_WORKSPACE) eye-catching in interactive terminals
+ * so operators actually notice and migrate, while keeping log captures (script,
+ * tee, journald, GitHub Actions) free of escape sequences. `NO_COLOR=1` honored
+ * as a hard opt-out (see no-color.org).
+ */
+function _colorWarn(msg: string): string {
+	if (process.env.NO_COLOR) return msg;
+	try {
+		if (process.stderr.isTTY) return `\x1b[1;31m${msg}\x1b[0m`;
+	} catch {
+		// ignore
+	}
+	return msg;
+}
+
 /** Test-only: clear the per-process cache. */
 export function resetCacheForTests(): void {
 	_cache = undefined;
@@ -235,25 +257,30 @@ const HARDCODED_WORKSPACE_DEFAULT_REL = 'workspace';
 /**
  * Resolve the workspace directory per the canonical contract.
  *
- * Order:
- *   1. `$SUTANDO_WORKSPACE` env var (legacy escape hatch; warn once).
- *   2. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
- *   3. `{repoRoot}/workspace` baked-in default.
+ * Order (v0.8 — `$SUTANDO_WORKSPACE` no longer honored):
+ *   1. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
+ *   2. `{repoRoot}/workspace` baked-in default.
+ *
+ * If `$SUTANDO_WORKSPACE` is set in the environment, prints a one-time
+ * migration-nag warning pointing at `scripts/sutando-migrate.sh` but does
+ * NOT honor the env value (the legacy escape hatch was removed in v0.8
+ * per `docs/workspace-contract-v0.8.md`).
  *
  * Returns an absolute path. Does NOT create the directory.
  */
 export function resolveWorkspace(repoRoot?: string): string {
 	const envVal = process.env.SUTANDO_WORKSPACE?.trim();
-	if (envVal) {
-		if (!_legacyEnvWarnPrinted) {
-			_legacyEnvWarnPrinted = true;
-			process.stderr.write(
-				`sutando config: $SUTANDO_WORKSPACE is set ('${envVal}'); honoring as legacy escape ` +
-					`hatch. To silence, move the value into \`sutando.config.local.json\` under ` +
-					`\`workspace.path\` and unset the env.\n`,
-			);
-		}
-		return resolve(envVal.replace(/^~/, homedir()));
+	if (envVal && !_legacyEnvWarnPrinted) {
+		_legacyEnvWarnPrinted = true;
+		process.stderr.write(
+			_colorWarn(
+				`sutando config: $SUTANDO_WORKSPACE='${envVal}' is set but NO LONGER HONORED ` +
+					`(removed in v0.8). The workspace now resolves from sutando.config.{json,local.json} ` +
+					`or the {repoRoot}/workspace baked-in default. If you have existing workspace data at ` +
+					`'${envVal}', run \`bash scripts/sutando-migrate.sh --dry-run\` to preview a relocation, ` +
+					`then \`--commit\`. Unset $SUTANDO_WORKSPACE in your shell + .env to silence this warning.`,
+			) + '\n',
+		);
 	}
 
 	const cfg = loadConfig(repoRoot);
@@ -268,18 +295,21 @@ export function resolveWorkspace(repoRoot?: string): string {
 		resolved = resolve(join(root, HARDCODED_WORKSPACE_DEFAULT_REL));
 	}
 
-	// M0 .env-drift warning: if the env var is UNSET but `.env` declares one,
-	// surface the stale .env line once per process. See sutando_config.py for
-	// the design rationale — this is the TS twin of the same behavior.
+	// .env-drift warning: if `.env` still carries a stale SUTANDO_WORKSPACE line,
+	// surface it once per process so the operator can clean it up.
+	// (v0.8: the env var is no longer honored regardless of whether it's set in
+	// the shell or in .env; the warning is purely cleanup guidance.)
 	if (!_dotenvDriftWarnPrinted) {
 		_dotenvDriftWarnPrinted = true;
 		const dotenvVal = detectEnvWorkspaceInDotenv(repoRoot);
-		if (dotenvVal && resolve(dotenvVal) !== resolved) {
+		if (dotenvVal) {
 			process.stderr.write(
-				`sutando config: .env declares SUTANDO_WORKSPACE='${dotenvVal}', but resolved workspace ` +
-					`is ${resolved} (config-driven). The .env line is NOT honored by the new loader — ` +
-					`move the value to \`sutando.config.local.json\` under \`workspace.path\` and delete the ` +
-					`.env line, or \`source .env\` before launching processes that need the override.\n`,
+				_colorWarn(
+					`sutando config: .env declares SUTANDO_WORKSPACE='${dotenvVal}' but the env var is no ` +
+						`longer honored (removed in v0.8). Resolved workspace is ${resolved} (config-driven). ` +
+						`Delete the .env line and, if needed, move the value to \`sutando.config.local.json\` ` +
+						`under \`workspace.path\`.`,
+				) + '\n',
 			);
 		}
 	}

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -270,6 +270,16 @@ const HARDCODED_WORKSPACE_DEFAULT_REL = 'workspace';
  */
 export function resolveWorkspace(repoRoot?: string): string {
 	const envVal = process.env.SUTANDO_WORKSPACE?.trim();
+
+	// Test-only escape hatch: when `SUTANDO_TEST_MODE=1` is set, honor
+	// `$SUTANDO_WORKSPACE` silently. This preserves the v0.8 contract for
+	// end users (no env override; warning + ignore) while letting the test
+	// suite redirect workspace to per-test tmp dirs without rewriting every
+	// test fixture. Production code MUST NOT set `SUTANDO_TEST_MODE`.
+	if (envVal && process.env.SUTANDO_TEST_MODE === '1') {
+		return resolve(envVal.replace(/^~/, homedir()));
+	}
+
 	if (envVal && !_legacyEnvWarnPrinted) {
 		_legacyEnvWarnPrinted = true;
 		process.stderr.write(

--- a/src/workspace_default.py
+++ b/src/workspace_default.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
+from typing import Optional
 
 
 _DEFAULT_SUBPATH = (".sutando", "workspace")
@@ -480,3 +481,53 @@ def resolve_workspace(migrate: bool = True) -> Path:
             pass  # never break resolution
 
     return target
+
+
+# Process-scoped workspace cache. Workspace is NOT dynamically switchable
+# in normal Sutando operation — one process, one repo, one workspace. The
+# cache pays the ~14us resolve cost once on first use, then returns the
+# cached Path on subsequent calls (module-level var lookup, ~20ns).
+#
+# Tests override two ways:
+#  - explicit per-call: my_function(workspace=tmp_ws)
+#  - process-wide reset: _reset_workspace_cache_for_tests() in setUp
+#
+# Both bypass the cache without env hacks. Production code never calls
+# _reset_workspace_cache_for_tests().
+_PROCESS_WORKSPACE: Optional[Path] = None
+
+
+def get_workspace(workspace: Optional[Path] = None) -> Path:
+    """Process-scoped workspace getter for the `Lazy config access` pattern.
+
+    Functions that need a workspace path accept an optional keyword-only
+    `workspace` argument and resolve it via this helper:
+
+        def my_function(*, workspace: Optional[Path] = None) -> int:
+            workspace = get_workspace(workspace)
+            ...
+
+    Behavior:
+      - `workspace=None` (production callers): returns the process-scoped
+        cached value, resolving once on first call.
+      - `workspace=<path>` (tests / special callers): returns the passed-in
+        path verbatim, bypassing the cache.
+
+    Workspace is process-scoped, not dynamically switchable. See
+    CONTRIBUTING.md "Lazy config access" for the full pattern.
+    """
+    global _PROCESS_WORKSPACE
+    if workspace is not None:
+        return workspace
+    if _PROCESS_WORKSPACE is None:
+        _PROCESS_WORKSPACE = resolve_workspace()
+    return _PROCESS_WORKSPACE
+
+
+def _reset_workspace_cache_for_tests() -> None:
+    """Test helper. Clears the process-scoped workspace cache so the next
+    `get_workspace()` call resolves afresh (typically against a tmp-dir
+    `sutando.config.local.json` written by the test setUp). Production code
+    MUST NOT call this."""
+    global _PROCESS_WORKSPACE
+    _PROCESS_WORKSPACE = None

--- a/src/workspace_resolve.sh
+++ b/src/workspace_resolve.sh
@@ -10,13 +10,11 @@
 # install-health-check-launchd.sh, session-handoff.sh. Factored out per
 # Lucy's PR #1399 review nit #1.
 #
-# Resolution order:
-#   1. scripts/sutando-config.sh helper (M0 default = <repo>/workspace/, env
-#      var honored internally as legacy escape hatch)
-#   2. $SUTANDO_WORKSPACE env var (only when helper is unreachable —
-#      non-checkout / extracted-tarball install)
-#   3. Fail loud with exit 1 + diagnostic. Refuses to silently write to a
-#      hardcoded legacy default.
+# Resolution order (v0.8 — env override removed):
+#   1. scripts/sutando-config.sh helper (<repo>/workspace/ resolved via
+#      sutando.config.{json,local.json} or the baked-in default).
+#   2. Fail loud with exit 1 + diagnostic. Refuses to silently write to a
+#      hardcoded legacy default OR a now-unhonored env var.
 #
 # Self-locating: looks for scripts/sutando-config.sh relative to THIS file's
 # own location (${BASH_SOURCE[0]}), NOT $REPO. This makes the function
@@ -33,10 +31,8 @@ resolve_workspace_or_die() {
       echo "${0##*/}: scripts/sutando-config.sh workspace exited non-zero." >&2
       exit 1
     fi
-  elif [ -n "${SUTANDO_WORKSPACE:-}" ]; then
-    WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
   else
-    echo "${0##*/}: cannot resolve workspace — neither $helper exists nor \$SUTANDO_WORKSPACE is set." >&2
+    echo "${0##*/}: cannot resolve workspace — $helper does not exist. v0.8 contract requires the helper; \$SUTANDO_WORKSPACE is no longer honored." >&2
     exit 1
   fi
   if [ -z "$WORKSPACE" ]; then

--- a/tests/_helpers/temp-workspace.ts
+++ b/tests/_helpers/temp-workspace.ts
@@ -37,6 +37,10 @@ export function setupTempWorkspace(name: string): {
 } {
 	const workspace = mkdtempSync(join(tmpdir(), `sutando-test-${name}-`));
 	process.env.SUTANDO_WORKSPACE = workspace;
+	// v0.8: env override removed for end-users. Tests get a private
+	// escape hatch via SUTANDO_TEST_MODE=1, honored silently by
+	// resolveWorkspace() in src/sutando_config.{py,ts}.
+	process.env.SUTANDO_TEST_MODE = '1';
 	return {
 		workspace,
 		cleanup: () => {
@@ -45,6 +49,10 @@ export function setupTempWorkspace(name: string): {
 			} catch {
 				/* idempotent */
 			}
+			// Clear the test-only escape hatch so subsequent tests in the
+			// same process can exercise the production v0.8 code path.
+			delete process.env.SUTANDO_WORKSPACE;
+			delete process.env.SUTANDO_TEST_MODE;
 		},
 	};
 }

--- a/tests/agent-state-endpoint.test.ts
+++ b/tests/agent-state-endpoint.test.ts
@@ -69,6 +69,7 @@ describe('/sse-status + /mute-state — agent state plumbing (PR #418)', () => {
 					// so concurrent test processes can't race on the file. Same
 					// SUTANDO_WORKSPACE env override the rest of the test suite uses.
 					SUTANDO_WORKSPACE: TEMP_WORKSPACE,
+					SUTANDO_TEST_MODE: '1',  // v0.8: enable env-override-in-test escape hatch
 				},
 				// 'ignore' prevents the pipe buffer from filling in CI (stdout isn't drained),
 				// which would block the child and cause the /sse-status poll to time out.

--- a/tests/bridges-sending-orphan-recovery.test.py
+++ b/tests/bridges-sending-orphan-recovery.test.py
@@ -37,6 +37,7 @@ REPO = Path(__file__).resolve().parent.parent
 # `RESULTS_DIR = REPO / "results"` at module-load time.
 _WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-orphan-recovery-test-")
 os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token-not-real")
 

--- a/tests/core-heartbeat.test.py
+++ b/tests/core-heartbeat.test.py
@@ -27,6 +27,7 @@ class TestHeartbeatWrite(unittest.TestCase):
         self._saved_env = os.environ.get("SUTANDO_WORKSPACE")
         self.tmp = Path(tempfile.mkdtemp(prefix="core-heartbeat-"))
         os.environ["SUTANDO_WORKSPACE"] = str(self.tmp)
+        os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
         # Force re-import so module picks up the new env.
         sys.modules.pop("core_heartbeat", None)
 

--- a/tests/discord-bridge-allowlist.test.py
+++ b/tests/discord-bridge-allowlist.test.py
@@ -56,8 +56,10 @@ def main() -> int:
     # inline in discord-bridge.py (legacy) or in src/send_allowlist.py
     # (post-refactor, PR #1029) — both shapes satisfy the contract. We
     # scan both sources and use whichever has the function definition.
+    # Accept either the legacy `(fpath: str)` signature or the post-#1442
+    # Hybrid C signature `(fpath: str, *, workspace: Optional[Path] = None)`.
     HELPER_RE = re.compile(
-        r"def (?:_)?is_path_sendable\(fpath:\s*str\)\s*->\s*bool:\s*\n([\s\S]{0,2000}?)(?=\n\ndef |\n\n[A-Z]|\Z)",
+        r"def (?:_)?is_path_sendable\(fpath:\s*str(?:,\s*\*,\s*workspace:[^)]*)?\)\s*->\s*bool:\s*\n([\s\S]{0,2000}?)(?=\n\ndef |\n\n[A-Z]|\Z)",
     )
     helper_body = None
     found_in = None
@@ -99,10 +101,14 @@ def main() -> int:
             helper_body,
         )
 
-    # 3. Both ROOTS and PREFIXES consulted
-    if "SEND_ALLOWED_ROOTS" not in helper_body or "SEND_ALLOWED_PREFIXES" not in helper_body:
+    # 3. Both ROOTS and PREFIXES consulted. Post-#1442 the legacy module-
+    # level `SEND_ALLOWED_ROOTS` tuple is the workspace-derived function
+    # `send_allowed_roots(workspace)`; accept either shape.
+    has_roots = ("SEND_ALLOWED_ROOTS" in helper_body or "send_allowed_roots(" in helper_body)
+    if not has_roots or "SEND_ALLOWED_PREFIXES" not in helper_body:
         return fail(
-            "_is_path_sendable must check both SEND_ALLOWED_ROOTS and SEND_ALLOWED_PREFIXES",
+            "_is_path_sendable must check both SEND_ALLOWED_ROOTS (or send_allowed_roots(workspace)) "
+            "and SEND_ALLOWED_PREFIXES",
             helper_body,
         )
 

--- a/tests/discord-bridge-attachment-filename-sanitize.test.py
+++ b/tests/discord-bridge-attachment-filename-sanitize.test.py
@@ -36,6 +36,7 @@ REPO = Path(__file__).resolve().parent.parent
 
 _WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-discord-filename-test-")
 os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 # `discord-bridge.py` reads its token from `~/.claude/channels/discord/.env`
 # (file path), not from `os.environ["DISCORD_BOT_TOKEN"]`, and `exit(1)`s
 # at module load when the file is missing. CI has no such file. Stub the

--- a/tests/discord-bridge-delivery-sentinel.test.py
+++ b/tests/discord-bridge-delivery-sentinel.test.py
@@ -51,6 +51,7 @@ REPO = Path(__file__).resolve().parent.parent
 
 _WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-delivery-sentinel-test-")
 os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
 (Path(_WORKSPACE_TMP) / "state").mkdir(parents=True, exist_ok=True)
 

--- a/tests/discord-bridge-dm-catchup.test.py
+++ b/tests/discord-bridge-dm-catchup.test.py
@@ -44,6 +44,7 @@ REPO = Path(__file__).resolve().parent.parent
 # paths at module-load time.
 _WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-dm-catchup-test-")
 os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
 (Path(_WORKSPACE_TMP) / "state").mkdir(parents=True, exist_ok=True)
 

--- a/tests/init-script.test.ts
+++ b/tests/init-script.test.ts
@@ -29,6 +29,7 @@ function runInit(repoDir: string, mode?: '--auto' | '--preflight'): RunResult {
 			...process.env,
 			SUTANDO_REPO: repoDir,
 			SUTANDO_WORKSPACE: join(repoDir, '.workspace'),
+			SUTANDO_TEST_MODE: '1',  // v0.8: enable env-override-in-test escape hatch
 			HOME: repoDir + '/.fake-home',
 		},
 		encoding: 'utf-8',

--- a/tests/outbox-log.test.py
+++ b/tests/outbox-log.test.py
@@ -20,12 +20,14 @@ class TestOutboxAppend(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.workspace = Path(self.tmp.name)
         os.environ["SUTANDO_WORKSPACE"] = str(self.workspace)
+        os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
         # Some helper modules cache resolve_workspace via module-level constants;
         # outbox_log does NOT cache (calls _outbox_path() fresh on each append)
         # so we don't need to reload.
 
     def tearDown(self):
         os.environ.pop("SUTANDO_WORKSPACE", None)
+        os.environ.pop("SUTANDO_TEST_MODE", None)
         self.tmp.cleanup()
 
     def _read(self) -> list[dict]:

--- a/tests/quota-burn-rate.test.py
+++ b/tests/quota-burn-rate.test.py
@@ -25,6 +25,7 @@ _SCRIPT = REPO / "skills" / "quota-tracker" / "scripts" / "read-quota.py"
 def _load_module(workspace: Path):
     """Load read-quota.py with a controlled workspace and a dummy quota-state.json."""
     os.environ["SUTANDO_WORKSPACE"] = str(workspace)
+    os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
     sys.modules.pop("read_quota", None)
     sys.modules.pop("read_quota_under_test", None)
 

--- a/tests/send-allowlist-shared.test.py
+++ b/tests/send-allowlist-shared.test.py
@@ -117,21 +117,24 @@ def test_send_allowlist_module_has_documented_set():
     quietly break the echo skill's file delivery — make a tightening
     update this test deliberately."""
     src = (SRC / "send_allowlist.py").read_text()
+    # Post-#1442 the module-level `_REPO` capture is gone; the roots are
+    # built inside `send_allowed_roots(workspace)` via `workspace / "..."`.
+    # Accept either the legacy `_REPO / "..."` form or the new
+    # `workspace / "..."` form so the test works against both shapes.
+    def has_root(name: str) -> bool:
+        return f'_REPO / "{name}"' in src or f'workspace / "{name}"' in src
+
     must_appear = [
         # Prefixes
         '"/tmp/sutando-"',
         '"/private/tmp/sutando-"',
         '"/tmp/echo-"',
         '"/private/tmp/echo-"',
-        # Roots — checking the path components since the literals are
-        # built via `str(_REPO / "results")` etc.
-        '_REPO / "results"',
-        '_REPO / "notes"',
-        '_REPO / "docs"',
         '"Desktop"',
         '"Documents"',
     ]
     missing = [s for s in must_appear if s not in src]
+    missing += [f'<root>/{n}' for n in ('results', 'notes', 'docs') if not has_root(n)]
     assert missing == [], (
         f"send_allowlist.py missing documented allowlist entries: {missing}. "
         f"If you intentionally tightened the policy, update this test."

--- a/tests/single-instance.test.py
+++ b/tests/single-instance.test.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(ROOT / "src"))
 def _load_single_instance(workspace_dir: Path):
     """Load single_instance with SUTANDO_WORKSPACE pointing at a temp dir."""
     os.environ["SUTANDO_WORKSPACE"] = str(workspace_dir)
+    os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
     # Reload to pick up new env — module caches resolve_workspace() at call time.
     spec = importlib.util.spec_from_file_location(
         "single_instance", ROOT / "src" / "single_instance.py"
@@ -38,9 +39,11 @@ class TestSingleInstance(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.workspace = Path(self.tmp.name)
         os.environ["SUTANDO_WORKSPACE"] = str(self.workspace)
+        os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 
     def tearDown(self):
         os.environ.pop("SUTANDO_WORKSPACE", None)
+        os.environ.pop("SUTANDO_TEST_MODE", None)
         self.tmp.cleanup()
 
     # (a) First acquire writes PID to lock file and returns normally.
@@ -62,7 +65,7 @@ class TestSingleInstance(unittest.TestCase):
             [
                 sys.executable, "-c",
                 f"import sys; sys.path.insert(0, '{ROOT}/src');"
-                f"import os; os.environ['SUTANDO_WORKSPACE']='{self.workspace}';"
+                f"import os; os.environ['SUTANDO_WORKSPACE']='{self.workspace}'; os.environ['SUTANDO_TEST_MODE']='1';"
                 f"from single_instance import acquire; acquire('test-second')",
             ],
             capture_output=True,
@@ -78,7 +81,7 @@ class TestSingleInstance(unittest.TestCase):
             [
                 sys.executable, "-c",
                 f"import sys, time; sys.path.insert(0, '{ROOT}/src');"
-                f"import os; os.environ['SUTANDO_WORKSPACE']='{self.workspace}';"
+                f"import os; os.environ['SUTANDO_WORKSPACE']='{self.workspace}'; os.environ['SUTANDO_TEST_MODE']='1';"
                 f"from single_instance import acquire; acquire('test-release');"
                 f"time.sleep(30)",  # hold forever — we'll kill it
             ],

--- a/tests/slack-bridge-orphan-recovery.test.py
+++ b/tests/slack-bridge-orphan-recovery.test.py
@@ -26,6 +26,7 @@ def _load_bridge(workspace: Path):
     os.environ["SLACK_BOT_TOKEN"] = "xoxb-test-token"
     os.environ["SLACK_APP_TOKEN"] = "xapp-test-token"
     os.environ["SUTANDO_WORKSPACE"] = str(workspace)
+    os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 
     # Remove any cached module so env takes effect on fresh import.
     sys.modules.pop("slack_bridge_under_test", None)

--- a/tests/slack-bridge-task-timeout.test.py
+++ b/tests/slack-bridge-task-timeout.test.py
@@ -28,6 +28,7 @@ def _load_bridge(workspace: Path):
     os.environ["SLACK_BOT_TOKEN"] = "xoxb-test-token"
     os.environ["SLACK_APP_TOKEN"] = "xapp-test-token"
     os.environ["SUTANDO_WORKSPACE"] = str(workspace)
+    os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
     os.environ["SLACK_TASK_TIMEOUT_SEC"] = "600"
 
     sys.modules.pop("slack_bridge_timeout_under_test", None)

--- a/tests/sutando-config-shell.test.ts
+++ b/tests/sutando-config-shell.test.ts
@@ -22,7 +22,7 @@ const SCRIPT = join(REPO_ROOT, 'scripts', 'sutando-config.sh');
 
 function runShell(subcmd: string, ws: string): string {
 	const proc = spawnSync('bash', [SCRIPT, subcmd], {
-		env: { ...process.env, SUTANDO_WORKSPACE: ws },
+		env: { ...process.env, SUTANDO_WORKSPACE: ws, SUTANDO_TEST_MODE: '1' },
 		encoding: 'utf-8',
 	});
 	if (proc.status !== 0) {
@@ -37,7 +37,7 @@ function runPyResolve(ws: string): string {
 		['-c', 'import sys; sys.path.insert(0, ".."); from importlib import import_module; m = import_module("src.sutando_config"); print(m.resolve_workspace(), end="")'],
 		{
 			cwd: REPO_ROOT,
-			env: { ...process.env, SUTANDO_WORKSPACE: ws },
+			env: { ...process.env, SUTANDO_WORKSPACE: ws, SUTANDO_TEST_MODE: '1' },
 			encoding: 'utf-8',
 		},
 	);
@@ -66,7 +66,7 @@ describe('sutando-config.sh wrapper', () => {
 		const proc = spawnSync(
 			'python3',
 			['-c', 'import sys; sys.path.insert(0, "."); from src.sutando_config import resolve_workspace; print(resolve_workspace(), end="")'],
-			{ cwd: REPO_ROOT, env: { ...process.env, SUTANDO_WORKSPACE: ws }, encoding: 'utf-8' },
+			{ cwd: REPO_ROOT, env: { ...process.env, SUTANDO_WORKSPACE: ws, SUTANDO_TEST_MODE: '1' }, encoding: 'utf-8' },
 		);
 		assert.equal(proc.status, 0, `py loader failed: ${proc.stderr}`);
 		assert.equal(shellOut, proc.stdout, 'shell wrapper diverges from py loader');
@@ -114,7 +114,7 @@ describe('sutando-config.sh wrapper', () => {
 
 		// Second run — must be a no-op (idempotent)
 		const second = spawnSync('bash', [SCRIPT, 'bootstrap'], {
-			env: { ...process.env, SUTANDO_WORKSPACE: ws },
+			env: { ...process.env, SUTANDO_WORKSPACE: ws, SUTANDO_TEST_MODE: '1' },
 			encoding: 'utf-8',
 		});
 		assert.equal(second.status, 0, `second bootstrap exit ${second.status}: ${second.stderr}`);

--- a/tests/sutando-config.test.py
+++ b/tests/sutando-config.test.py
@@ -74,17 +74,25 @@ class TestSutandoConfig(unittest.TestCase):
         self._tmp.cleanup()
 
     # ------------------------------------------------------------------ #
-    #  1. Env var precedence over .local.json                            #
+    #  1. v0.8: env var IGNORED; .local.json wins                         #
     # ------------------------------------------------------------------ #
 
-    def test_env_var_precedence_over_local_json(self):
+    def test_env_var_ignored_in_favor_of_local_json(self):
+        # v0.8 contract: `$SUTANDO_WORKSPACE` is no longer honored.
+        # Setting it must NOT override `sutando.config.local.json`; the
+        # resolver emits a one-time deprecation warning and returns the
+        # config-resolved path. Test guards against accidental re-enable of
+        # the legacy precedence (which was the v0.7 / M0 / M1 behavior).
         _write_config(self.repo, "sutando.config.json",
                       {"workspace": {"path": "${REPO_DIR}/workspace"}})
         _write_config(self.repo, "sutando.config.local.json",
                       {"workspace": {"path": "/from/local"}})
         os.environ["SUTANDO_WORKSPACE"] = "/from/env"
+        # SUTANDO_TEST_MODE is NOT set here — we test the production code
+        # path that ignores the env var.
+        os.environ.pop("SUTANDO_TEST_MODE", None)
         resolved = resolve_workspace(repo_root=self.repo)
-        self.assertEqual(str(resolved), str(Path("/from/env").resolve()))
+        self.assertEqual(str(resolved), str(Path("/from/local").resolve()))
 
     # ------------------------------------------------------------------ #
     #  2. Deep-merge: dicts merge, arrays REPLACE                        #
@@ -309,23 +317,26 @@ class TestSutandoConfig(unittest.TestCase):
             resolve_claude_sutando_config_dir(repo_root=self.repo)
         self.assertIn("workspace-sub-folder invariant", str(cm.exception))
 
-    def test_claude_sutando_config_dir_honors_env_workspace_override(self):
-        # Owner-raised: if user sets $SUTANDO_WORKSPACE to a custom path,
-        # the returned ccd path must be `<custom>/.claude-sutando` (string-prefix
-        # consistent with resolve_workspace's return value, not the symlink-
-        # canonicalized form). Regression test: pre-fix code returned
-        # `/private/tmp/.../.claude-sutando` on macOS when env pointed to /tmp.
+    def test_claude_sutando_config_dir_lands_at_config_workspace(self):
+        # v0.8: `$SUTANDO_WORKSPACE` is no longer honored. The previous
+        # version of this test asserted ccd followed the env-overridden
+        # workspace; now it must follow the config-resolved workspace.
+        # The string-prefix invariant the caller relies on (ccd is always
+        # `<workspace>/.claude-sutando`) still holds.
         with tempfile.TemporaryDirectory() as ws_dir:
             old_env = os.environ.get("SUTANDO_WORKSPACE")
-            os.environ["SUTANDO_WORKSPACE"] = ws_dir
+            os.environ["SUTANDO_WORKSPACE"] = ws_dir  # set, but should be ignored
+            os.environ.pop("SUTANDO_TEST_MODE", None)
             try:
                 _write_config(self.repo, "sutando.config.json", {})
                 _reset_cache_for_tests()
                 ws = resolve_workspace(repo_root=self.repo)
                 ccd = resolve_claude_sutando_config_dir(repo_root=self.repo)
-                # The exact behavior the owner asked about:
+                # Workspace falls back to the baked-in default (env ignored):
+                self.assertEqual(str(ws), str((self.repo / "workspace").resolve()))
+                # Ccd lands under the resolved workspace, not env:
                 self.assertEqual(str(ccd), str(ws / ".claude-sutando"))
-                # And the string-prefix invariant the caller relies on:
+                # String-prefix invariant the caller relies on:
                 self.assertTrue(str(ccd).startswith(str(ws)))
             finally:
                 if old_env is None:

--- a/tests/sutando-config.test.ts
+++ b/tests/sutando-config.test.ts
@@ -61,16 +61,23 @@ describe('sutando_config loader', () => {
 	};
 
 	// ------------------------------------------------------------------ //
-	//  1. Env var precedence over .local.json                            //
+	//  1. v0.8: env var IGNORED; .local.json wins                         //
 	// ------------------------------------------------------------------ //
 
-	it('env var takes precedence over .local.json', () => {
+	it('env var is ignored in favor of .local.json (v0.8)', () => {
+		// v0.8 contract: `$SUTANDO_WORKSPACE` is no longer honored.
+		// Setting it must NOT override `sutando.config.local.json`; the
+		// resolver emits a one-time deprecation warning and returns the
+		// config-resolved path. Test guards against accidental re-enable of
+		// the legacy precedence (v0.7 / M0 / M1 behavior).
 		writeConfig(repo, 'sutando.config.json', { workspace: { path: '${REPO_DIR}/workspace' } });
 		writeConfig(repo, 'sutando.config.local.json', { workspace: { path: '/from/local' } });
 		process.env.SUTANDO_WORKSPACE = '/from/env';
+		// SUTANDO_TEST_MODE must not be set — we test the production code path.
+		delete process.env.SUTANDO_TEST_MODE;
 		try {
 			const resolved = resolveWorkspace(repo);
-			assert.equal(resolved, resolve('/from/env'));
+			assert.equal(resolved, resolve('/from/local'));
 		} finally {
 			restoreEnvAndRepo();
 		}

--- a/tests/task-bridge-stop-at-task-delimiter.test.ts
+++ b/tests/task-bridge-stop-at-task-delimiter.test.ts
@@ -15,6 +15,7 @@ import { join } from 'node:path';
 // expecting `false` passed *by accident* — file-not-found → false.)
 const TMP = mkdtempSync(join(tmpdir(), 'sutando-isvoice-test-'));
 process.env.SUTANDO_WORKSPACE = TMP;
+process.env.SUTANDO_TEST_MODE = '1';  // v0.8: opt-in env-honor
 mkdirSync(join(TMP, 'tasks'), { recursive: true });
 
 const { _isVoiceTask } = await import('../src/task-bridge.js');

--- a/tests/telegram-bridge-proactive-owner-resolution.test.py
+++ b/tests/telegram-bridge-proactive-owner-resolution.test.py
@@ -32,6 +32,7 @@ REPO = Path(__file__).resolve().parent.parent
 
 _WORKSPACE_TMP = tempfile.mkdtemp(prefix="sutando-telegram-resolve-test-")
 os.environ["SUTANDO_WORKSPACE"] = _WORKSPACE_TMP
+os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token-not-real")
 
 

--- a/tests/workspace-default-relative-env.test.py
+++ b/tests/workspace-default-relative-env.test.py
@@ -44,12 +44,13 @@ def test_relative_env_path_is_anchored_to_cwd_absolute():
     """Bug fix regression guard. A relative `SUTANDO_WORKSPACE` MUST
     NOT survive resolution — anchor to CWD-at-resolve-time so two
     processes (different CWDs) don't silently split-brain on the same
-    env value."""
+    env value. v0.8: env honored only under SUTANDO_TEST_MODE=1."""
     snap = _clear_env()
     tmp = Path(tempfile.mkdtemp(prefix="sutando-ws-cwd-"))
     original_cwd = Path.cwd()
     os.chdir(tmp)
     os.environ["SUTANDO_WORKSPACE"] = "myws"  # deliberately relative
+    os.environ["SUTANDO_TEST_MODE"] = "1"
     try:
         result = ws.resolve_workspace(migrate=False)
         assert result.is_absolute(), (
@@ -61,32 +62,40 @@ def test_relative_env_path_is_anchored_to_cwd_absolute():
     finally:
         os.chdir(original_cwd)
         del os.environ["SUTANDO_WORKSPACE"]
+        os.environ.pop("SUTANDO_TEST_MODE", None)
         _restore_env(snap)
 
 
 def test_absolute_env_path_unchanged():
-    """Backwards compat: absolute `SUTANDO_WORKSPACE` returned as-is."""
+    """Backwards compat: absolute `SUTANDO_WORKSPACE` returned as-is.
+    v0.8: env honored only under SUTANDO_TEST_MODE=1."""
     snap = _clear_env()
     abs_path = Path(tempfile.mkdtemp(prefix="sutando-ws-abs-"))
     os.environ["SUTANDO_WORKSPACE"] = str(abs_path)
+    os.environ["SUTANDO_TEST_MODE"] = "1"
     try:
         result = ws.resolve_workspace(migrate=False)
-        assert result == abs_path
+        # Resolver canonicalizes /var/folders/... → /private/var/... on macOS.
+        assert result == abs_path.resolve()
     finally:
         del os.environ["SUTANDO_WORKSPACE"]
+        os.environ.pop("SUTANDO_TEST_MODE", None)
         _restore_env(snap)
 
 
 def test_tilde_in_env_path_is_expanded():
-    """`~` expansion preserved — existing contract."""
+    """`~` expansion preserved — existing contract.
+    v0.8: env honored only under SUTANDO_TEST_MODE=1."""
     snap = _clear_env()
     os.environ["SUTANDO_WORKSPACE"] = "~/sutando-tilde-test"
+    os.environ["SUTANDO_TEST_MODE"] = "1"
     try:
         result = ws.resolve_workspace(migrate=False)
         assert "~" not in str(result), f"tilde not expanded: {result}"
         assert str(result).startswith(str(Path.home()))
     finally:
         del os.environ["SUTANDO_WORKSPACE"]
+        os.environ.pop("SUTANDO_TEST_MODE", None)
         _restore_env(snap)
 
 

--- a/tests/workspace-default.test.py
+++ b/tests/workspace-default.test.py
@@ -24,6 +24,27 @@ from workspace_default import (  # noqa: E402
 )
 
 
+# v0.8: the resolver ignores `$SUTANDO_WORKSPACE` for end-users (warn + ignore).
+# Tests in this file redirect workspace via env to exercise migration paths.
+# The `SUTANDO_TEST_MODE=1` escape hatch (added in PR #1440) re-enables env
+# honor silently for the test suite. Individual tests that need to exercise
+# the production code path (env-ignored) clear SUTANDO_TEST_MODE in-test.
+_SAVED_TEST_MODE = None
+
+
+def setUpModule():
+    global _SAVED_TEST_MODE
+    _SAVED_TEST_MODE = os.environ.get("SUTANDO_TEST_MODE")
+    os.environ["SUTANDO_TEST_MODE"] = "1"
+
+
+def tearDownModule():
+    if _SAVED_TEST_MODE is None:
+        os.environ.pop("SUTANDO_TEST_MODE", None)
+    else:
+        os.environ["SUTANDO_TEST_MODE"] = _SAVED_TEST_MODE
+
+
 class TestWorkspaceDefault(unittest.TestCase):
     def setUp(self):
         self._saved_env = os.environ.get("SUTANDO_WORKSPACE")
@@ -43,14 +64,39 @@ class TestWorkspaceDefault(unittest.TestCase):
         self.assertEqual(d.parent.parent, Path.home())
         self.assertEqual(d, Path.home() / ".sutando" / "workspace")
 
-    def test_resolve_uses_env_when_set(self):
+    def test_resolve_uses_env_when_test_mode_set(self):
+        # v0.8: `$SUTANDO_WORKSPACE` is no longer honored in production.
+        # The test-only escape hatch `SUTANDO_TEST_MODE=1` keeps env-redirect
+        # available for the test suite without weakening the user-facing
+        # contract. Without `SUTANDO_TEST_MODE`, the env value would be
+        # warned + ignored.
+        # Note: resolver calls `.resolve()`, which canonicalizes /tmp -> /private/tmp
+        # on macOS via symlink; the expected path applies the same resolution.
         os.environ["SUTANDO_WORKSPACE"] = "/tmp/test-ws"
-        # migrate=False to keep this test purely about resolution semantics.
-        self.assertEqual(resolve_workspace(migrate=False), Path("/tmp/test-ws"))
+        os.environ["SUTANDO_TEST_MODE"] = "1"
+        try:
+            self.assertEqual(resolve_workspace(migrate=False), Path("/tmp/test-ws").resolve())
+        finally:
+            os.environ.pop("SUTANDO_TEST_MODE", None)
 
-    def test_resolve_expanduser_on_tilde(self):
+    def test_resolve_expanduser_on_tilde_with_test_mode(self):
+        # v0.8: env honored only under SUTANDO_TEST_MODE=1 (test-only).
         os.environ["SUTANDO_WORKSPACE"] = "~/custom-ws"
-        self.assertEqual(resolve_workspace(migrate=False), Path.home() / "custom-ws")
+        os.environ["SUTANDO_TEST_MODE"] = "1"
+        try:
+            self.assertEqual(
+                resolve_workspace(migrate=False),
+                (Path.home() / "custom-ws").resolve(),
+            )
+        finally:
+            os.environ.pop("SUTANDO_TEST_MODE", None)
+
+    def test_resolve_ignores_env_in_production_path(self):
+        # v0.8 contract: without SUTANDO_TEST_MODE, env is warned + ignored.
+        os.environ["SUTANDO_WORKSPACE"] = "/tmp/should-be-ignored"
+        os.environ.pop("SUTANDO_TEST_MODE", None)
+        # Falls back to the in-repo default (env ignored).
+        self.assertEqual(resolve_workspace(migrate=False), ROOT / "workspace")
 
     def test_resolve_falls_back_to_default_when_env_unset(self):
         # Post-M0: fallback is the in-repo workspace path (<repo>/workspace),
@@ -179,14 +225,16 @@ class TestMigrationFromLegacy(unittest.TestCase):
         self.assertFalse(moved_2)  # second run finds target populated, bails
 
     def test_resolve_workspace_skips_legacy_migration_when_env_set(self):
-        """When SUTANDO_WORKSPACE is set, the LEGACY migration (tasks/results/state)
-        is skipped. The notes in-repo migration runs independently — see the
-        separate test class for that."""
+        """When SUTANDO_WORKSPACE is set (with SUTANDO_TEST_MODE=1 to opt in
+        under v0.8), the LEGACY migration (tasks/results/state) is skipped.
+        The notes in-repo migration runs independently — see the separate
+        test class for that."""
         self._seed_legacy_runtime()
         os.environ["SUTANDO_WORKSPACE"] = str(self.target)
         with patch.object(workspace_default, "_legacy_repo_root", return_value=self.legacy):
             ws = resolve_workspace(migrate=True)
-        self.assertEqual(ws, self.target)
+        # Compare against resolved expected (macOS /private symlink-canonical).
+        self.assertEqual(ws, self.target.resolve())
         # Legacy state should be UNTOUCHED — env pin bypasses _migrate_from_legacy.
         self.assertTrue((self.legacy / "tasks" / "task-1.txt").exists())
 
@@ -639,7 +687,9 @@ class TestPostMigrationDisableBehavior(unittest.TestCase):
         """resolve_workspace(migrate=True) must NOT move any legacy file."""
         with patch.object(workspace_default, "_legacy_repo_root", return_value=self.legacy):
             ws = resolve_workspace(migrate=True)
-        self.assertEqual(ws, self.workspace)
+        # Resolved equality — resolver canonicalizes /var/folders/... → /private/var/...
+        # on macOS via symlink.
+        self.assertEqual(ws, self.workspace.resolve())
         # Legacy files unchanged
         self.assertTrue((self.legacy / "notes" / "x.md").is_file())
         self.assertTrue((self.legacy / "build_log.md").is_file())
@@ -673,7 +723,7 @@ class TestPostMigrationDisableBehavior(unittest.TestCase):
             buf = StringIO()
             with patch.object(sys, "stderr", buf):
                 ws = resolve_workspace(migrate=False)
-            self.assertEqual(ws, self.workspace)
+            self.assertEqual(ws, self.workspace.resolve())
             # _legacy_repo_root() must NOT be called when migrate=False
             mock_repo.assert_not_called()
             # No stderr output


### PR DESCRIPTION
## Summary

Foundation commit for the workspace lazy-resolve refactor. Establishes the **Hybrid C pattern** — `def fn(*, workspace: Optional[Path] = None)` + `workspace = get_workspace(workspace)` first line. Process-scoped cache, AI-readable signatures, zero callsite churn for production code.

Owner directive 2026-06-04: pick Hybrid C over Context-first after explicit pros/cons. Context-first too aggressive for Sutando (cascade refactor + fat ctx + callsite churn). Hybrid C signature-level dependency declaration is more AI-readable.

## Scope (PR-1 / N)

1. **`get_workspace(workspace=None)`** in `src/workspace_default.py` — process-scoped cache (resolves once, ~14µs first call → ~0.03µs cached; benchmarked 1M calls).
2. **Companion `_reset_workspace_cache_for_tests()`** for setUp clearing.
3. **POC migration** in `src/archive-stale-results.py` — module-level `WORKSPACE = resolve_workspace()` removed. `main(*, workspace: Optional[Path] = None)` signature.
4. **CONTRIBUTING.md "Lazy config access"** section — rule + audit grep commands.

## Acceptance criteria (per owner directive)

- [ ] `grep -R "= resolve_workspace()" src` → 0 module-level matches
- [ ] `grep -R "WORKSPACE_DIR" src` → 0 module-level captures
- [ ] tests no longer use `SUTANDO_WORKSPACE` / `SUTANDO_TEST_MODE`

Will be satisfied after PR-2..5 land.

## Follow-up PRs

- PR-2: simple entry points (10 files: morning-briefing, friction-detector, daily-insight, call-stats, scan-call-logs, send_allowlist, event_log, dm-result, check-pending-questions, github-webhook)
- PR-3: complex daemons (agent-api, health-check, dashboard)
- PR-4: 3 bridges (discord, slack, telegram)
- PR-5: 5 TS files + test migration + delete `SUTANDO_TEST_MODE` escape hatch (introduced in #1440 as v0.8 stopgap)

## Test plan

- [ ] CI green (TS tsc + Python tests)
- [ ] Smoke test `python3 src/archive-stale-results.py` against real workspace — unchanged behavior
- [ ] Smoke test `main(workspace=tmp_dir)` — overrides cache, no env hack
- [ ] Benchmark perf: cached `get_workspace()` matches module-level var lookup (~0.03µs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)