### PR TITLE
docs(workspace-design): mark Memory env-var rename as shipped

### DIFF
--- a/docs/workspace-design.md
+++ b/docs/workspace-design.md
@@ -24,7 +24,7 @@ If you can't place a path on this flowchart in 5 seconds, the path probably want
 |---|---|---|---|---|
 | **Code** | Source of truth for behavior | `$SUTANDO_REPO_DIR` (git checkout) | Public git (`sonichi/sutando`) | Persistent; updated by `git pull` |
 | **State** | Per-user runtime, mostly machine-local | `$SUTANDO_WORKSPACE` (default `<repo>/workspace/`) | None — per-machine | Ephemeral; rebuildable; rotates |
-| **Memory** | User-content the user reads + edits | `$SUTANDO_PRIVATE_DIR` (proposed rename → `SUTANDO_MEMORY_DIR`) | Private git per fleet (`<user>-sutando-memory.git`) | Persistent; user-authored |
+| **Memory** | User-content the user reads + edits | `$SUTANDO_MEMORY_DIR` (legacy alias `$SUTANDO_PRIVATE_DIR` honored for one release per #870) | Private git per fleet (`<user>-sutando-memory.git`) | Persistent; user-authored |
 
 Within Memory, two flavors:
 - **Shared** (top-level): one copy across the fleet. Examples: `notes/`, `build_log.md`, `memory/*.md`.


### PR DESCRIPTION
## One-line doc fix

TL;DR table in `docs/workspace-design.md` described the **Memory** space's env var as `\$SUTANDO_PRIVATE_DIR (proposed rename → SUTANDO_MEMORY_DIR)`. The rename actually shipped in #870 — `\$SUTANDO_MEMORY_DIR` is canonical, `\$SUTANDO_PRIVATE_DIR` is the legacy alias honored for one release.

Owner flagged the staleness 2026-06-04 03:06Z while reading the doc.

## Scope kept tight

Honoring owner's "real pain only" directive (2026-06-04 03:02Z), this PR fixes only the precise line owner pointed at. There are ~8 other stale refs in the same doc — `\$SUTANDO_PRIVATE_DIR` on L80 / L87 (similar rename staleness), and `\$SUTANDO_WORKSPACE`-as-env-override on L26 / L61 (post-#1440 the env is no longer honored either). Those are noted for a separate broader sweep PR if owner wants one; not auto-included here to avoid scope creep.

## Diff

```diff
- | **Memory** | User-content the user reads + edits | `\$SUTANDO_PRIVATE_DIR` (proposed rename → `SUTANDO_MEMORY_DIR`) | Private git per fleet (`<user>-sutando-memory.git`) | Persistent; user-authored |
+ | **Memory** | User-content the user reads + edits | `\$SUTANDO_MEMORY_DIR` (legacy alias `\$SUTANDO_PRIVATE_DIR` honored for one release per #870) | Private git per fleet (`<user>-sutando-memory.git`) | Persistent; user-authored |
```