### PR TITLE
feat(sync): PR-2 — vault URL from config + --vault-url flag, sync-memory.sh deprecation

### DIFF
--- a/docs/memory-sync.md
+++ b/docs/memory-sync.md
@@ -1,5 +1,15 @@
 # Memory + notes sync across machines
 
+> **Update (PR-2, issue #1445 followup, 2026-06-04):** the canonical sync path is now `scripts/sync-workspace.sh` — workspace IS the git repo + per-host branch topology + 4-tier safety. The `scripts/sync-memory.sh` documented below is the legacy rsync-to-`~/.sutando/memory-sync/` flow; it still works (and emits a one-line deprecation banner on each invocation) but will be removed in PR-2.1 after dogfooding the new path. To migrate:
+>
+> 1. `bash scripts/sync-workspace.sh --init` once per machine — converts the workspace into a git repo
+> 2. Move vault URL from `.env` (`SUTANDO_MEMORY_REPO=...`) into `sutando.config.local.json` under `vault.remote_url`, OR pass `--vault-url <url>` per invocation
+> 3. Replace the cron entry calling `sync-memory.sh` with one calling `sync-workspace.sh` (see `skills/schedule-crons/crons.example.json` for the new entry)
+>
+> The rest of this doc covers the legacy script. Switch to `tests/sync-workspace.test.sh` + PR #1445 for the new architecture.
+
+---
+
 Sutando supports running the same agent identity across multiple machines (e.g. Mac mini + MacBook + Mac Studio). Each machine runs its own Claude Code session; a shared private git repo keeps the agent's memory and long-form notes consistent between them.
 
 The mechanism is intentionally minimal: a single shell script (`scripts/sync-memory.sh`) that's invoked on a cron tick. It pulls everyone's latest writes, copies this machine's local edits into the shared repo, commits with the hostname, and pushes.

--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -32,6 +32,24 @@
 #
 # Run: bash scripts/sync-memory.sh
 
+# --- PR-2 deprecation banner ---
+# As of PR-2 (issue #1445 followup, 2026-06-04), the canonical sync path is
+# `scripts/sync-workspace.sh` (workspace IS the git repo + branch-per-host
+# topology + 4-tier safety). This script's rsync-to-~/.sutando/memory-sync/
+# architecture remains supported during the transition window but will be
+# removed in PR-2.1 after observed dogfooding.
+#
+# Migration recipe:
+#   1. bash scripts/sync-workspace.sh --init   # convert workspace into a git repo
+#   2. Update your cron/launchd to call sync-workspace.sh instead of sync-memory.sh
+#   3. Move vault URL from .env (SUTANDO_MEMORY_REPO) to sutando.config.local.json
+#      under `vault.remote_url`
+#
+# Suppress this banner by setting SUTANDO_SYNC_MEMORY_SUPPRESS_DEPRECATION=1.
+if [ "${SUTANDO_SYNC_MEMORY_SUPPRESS_DEPRECATION:-0}" != "1" ]; then
+    echo "sync-memory: DEPRECATED — prefer scripts/sync-workspace.sh (see header for migration recipe; set SUTANDO_SYNC_MEMORY_SUPPRESS_DEPRECATION=1 to silence)." >&2
+fi
+
 # If SUTANDO_MEMORY_SYNC_DIR is not set, try to auto-detect: if the script
 # lives inside an existing memory-sync clone, use that. Otherwise default
 # to ~/.sutando/memory-sync/. The auto-detect handles both the new convention

--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -41,6 +41,16 @@
 # Env vars:
 #   SUTANDO_VAULT             — git URL of the private vault repo (REQUIRED)
 #                               Legacy alias: SUTANDO_MEMORY_REPO (honored one release)
+# Vault URL resolution (PR-2 — issue #1445 followup):
+#   1. --vault-url <url> CLI flag (tests, one-shot overrides; canonical for explicit)
+#   2. sutando.config.local.json → vault.remote_url (per-clone canonical)
+#   3. sutando.config.json → vault.remote_url (tracked default)
+#   4. .env SUTANDO_MEMORY_REPO (deprecated legacy alias; warn-and-honor for one release)
+#
+# Note: SUTANDO_VAULT env var (introduced in PR-1 = #1445) is REMOVED in PR-2.
+# Brand new, no users to deprecate; CLI flag + config-file is the canonical surface.
+#
+# Other env vars:
 #   SUTANDO_REPO_DIR          — path to sutando code checkout. Auto-detected from script path.
 #   NO_COLOR                  — suppress ANSI escapes in warnings (no-color.org)
 #   SUTANDO_SYNC_MAX_DELETE   — mass-deletion absolute tripwire (default 50)
@@ -56,19 +66,36 @@ set -euo pipefail
 
 DRY_RUN=0            # --dry-run: skip mutating ops, print "would: ..." instead
 FORCE_GITIGNORE=0    # --force-gitignore: overwrite existing .gitignore without warning
+VAULT_URL_FLAG=""    # --vault-url <url>: explicit vault URL override (PR-2)
 
-# Parse global flags out of $@ (leaves only the subcommand + its args).
+# Parse global flags out of $@ (leaves only the subcommand + its args). Two-arg
+# flags (`--vault-url <url>`) supported via _consume_next state; equals-form
+# (`--vault-url=<url>`) supported via prefix match.
 _args=()
+_consume_next=""
 for _arg in "$@"; do
+    if [ -n "$_consume_next" ]; then
+        case "$_consume_next" in
+            vault-url) VAULT_URL_FLAG="$_arg" ;;
+        esac
+        _consume_next=""
+        continue
+    fi
     case "$_arg" in
         --dry-run)         DRY_RUN=1 ;;
         --force-gitignore) FORCE_GITIGNORE=1 ;;
+        --vault-url)       _consume_next="vault-url" ;;
+        --vault-url=*)     VAULT_URL_FLAG="${_arg#--vault-url=}" ;;
         *)                 _args+=("$_arg") ;;
     esac
 done
+if [ -n "$_consume_next" ]; then
+    echo "sync-workspace: --$_consume_next requires a value" >&2
+    exit 2
+fi
 # Reset $@ to non-flag args
 set -- "${_args[@]:-}"
-unset _args
+unset _args _consume_next
 
 # --------------------------------------------------------------------------- #
 # Section 1 — Bootstrap (paths, env, config)                                   #
@@ -118,22 +145,27 @@ if [ -z "$WORKSPACE_DIR" ] || [ ! -d "$WORKSPACE_DIR" ]; then
     exit 1
 fi
 
-# Vault URL: SUTANDO_VAULT canonical; SUTANDO_MEMORY_REPO honored as legacy alias.
-VAULT_URL="${SUTANDO_VAULT:-${SUTANDO_MEMORY_REPO:-}}"
-if [ -n "${SUTANDO_MEMORY_REPO:-}" ] && [ -z "${SUTANDO_VAULT:-}" ]; then
-    echo "sync-workspace: SUTANDO_MEMORY_REPO is set; please rename to SUTANDO_VAULT (legacy alias honored this release)." >&2
+# Resolve vault URL via the PR-2 priority chain. The `.env` file was already
+# `set -a; . .env; set +a`-loaded above, so SUTANDO_MEMORY_REPO appears as an
+# env var if set in .env — no need to re-grep the file (eliminates the
+# var=$(grep | head | ...) set-e trap class entirely; see Mini #1445 v4 Medium).
+VAULT_URL=""
+
+# Priority 1: --vault-url CLI flag (explicit)
+if [ -n "$VAULT_URL_FLAG" ]; then
+    VAULT_URL="$VAULT_URL_FLAG"
 fi
-# Load from .env if still empty. NB: `grep ... | head -1 | ...` exits nonzero
-# when grep finds no match (e.g. .env without SUTANDO_VAULT), which under
-# `set -euo pipefail` propagates through pipefail and exits the script before
-# the SUTANDO_MEMORY_REPO fallback can run — `var=$(...)` assignment does NOT
-# exempt set -e from the subshell's failure. Trailing `|| true` on each
-# pipeline restores the intended fall-through semantics. Mini #1445 v4 Medium.
-if [ -z "$VAULT_URL" ] && [ -f "$REPO_DIR/.env" ]; then
-    VAULT_URL=$(grep -E '^SUTANDO_VAULT=' "$REPO_DIR/.env" | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'" || true)
-    if [ -z "$VAULT_URL" ]; then
-        VAULT_URL=$(grep -E '^SUTANDO_MEMORY_REPO=' "$REPO_DIR/.env" | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'" || true)
-    fi
+
+# Priority 2+3: sutando.config.{local,base}.json → vault.remote_url
+# (loader merges local + base + applies ${REPO_DIR} substitution)
+if [ -z "$VAULT_URL" ] && [ -f "$SCRIPT_PARENT/scripts/sutando-config.sh" ]; then
+    VAULT_URL="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" vault-url 2>/dev/null || true)"
+fi
+
+# Priority 4: legacy .env SUTANDO_MEMORY_REPO (warn-and-honor for one release)
+if [ -z "$VAULT_URL" ] && [ -n "${SUTANDO_MEMORY_REPO:-}" ]; then
+    VAULT_URL="$SUTANDO_MEMORY_REPO"
+    echo "sync-workspace: SUTANDO_MEMORY_REPO is deprecated; move vault URL to sutando.config.local.json under vault.remote_url." >&2
 fi
 
 # --------------------------------------------------------------------------- #

--- a/skills/schedule-crons/crons.example.json
+++ b/skills/schedule-crons/crons.example.json
@@ -20,9 +20,9 @@
     "prompt": "Run: bash scripts/cron-gate.sh pending-questions python3 src/check-pending-questions.py — notifies about unanswered pending questions (deferred when owner tasks are queued; next */30 retry covers a skipped fire)."
   },
   {
-    "name": "sync-memory",
+    "name": "sync-workspace",
     "cron": "*/30 * * * *",
-    "prompt": "Run: bash scripts/cron-gate.sh sync-memory bash scripts/sync-memory.sh — syncs memory and notes to the private memory repo (requires SUTANDO_MEMORY_REPO in .env; deferred when owner tasks are queued; next */30 retry covers a skipped fire)."
+    "prompt": "Run: bash scripts/cron-gate.sh sync-workspace bash scripts/sync-workspace.sh — syncs workspace (memory + notes + state/cores) to the private vault via per-host branch (requires vault.remote_url in sutando.config.local.json, or --vault-url flag; deferred when owner tasks are queued; next */30 retry covers a skipped fire). Replaces the legacy sync-memory entry (which used rsync to a separate ~/.sutando/memory-sync/ clone); sync-memory.sh still works during the transition but emits a deprecation banner."
   },
   {
     "name": "obsidian-dream",

--- a/tests/sync-workspace.test.sh
+++ b/tests/sync-workspace.test.sh
@@ -666,6 +666,60 @@ esac
 
 # ============================================================================
 echo
+echo "==== Test 19: graceful fall-through when sutando-config.sh vault-url returns empty (Pro #1446) ===="
+# Pro's hold flag: "is sutando-config.sh vault-url implemented, or does the
+# helper silently return empty and fall through to deprecated .env?"
+# This test stages the explicit fall-through path:
+#   - config has NO vault.remote_url (helper returns empty)
+#   - NO --vault-url flag
+#   - .env HAS SUTANDO_MEMORY_REPO
+# Expected: script resolves URL via .env legacy + emits deprecation warning.
+# Proves the silent-no-op DOES gracefully degrade (config helper empty → .env
+# fallback fires, not a crash, not a loop).
+
+# Verify the helper itself returns empty when no remote_url in config
+helper_out="$(SUTANDO_REPO_DIR="$FIXTURE_REPO" \
+              SUTANDO_WORKSPACE="$FIXTURE_WS" \
+              SUTANDO_TEST_MODE=1 \
+              bash "$FIXTURE_REPO/scripts/sutando-config.sh" vault-url 2>/dev/null)"
+if [ -z "$helper_out" ]; then
+  echo "  OK: sutando-config.sh vault-url returns empty when config has no remote_url"; pass=$((pass+1))
+else
+  echo "  FAIL: helper returned non-empty for config-without-remote_url: $helper_out"; fail=$((fail+1))
+fi
+
+# Stage the fall-through path: config empty + .env has legacy alias
+echo "SUTANDO_MEMORY_REPO=$FIXTURE_VAULT" > "$FIXTURE_REPO/.env"
+
+out_fallthru=$(env \
+    SUTANDO_REPO_DIR="$FIXTURE_REPO" \
+    SUTANDO_WORKSPACE="$FIXTURE_WS" \
+    SUTANDO_TEST_MODE=1 \
+    bash "$SYNC" --status 2>&1; echo "EXIT=$?")
+fallthru_exit=$(printf '%s' "$out_fallthru" | sed -n 's/^EXIT=//p' | tail -1)
+
+if [ "$fallthru_exit" = "0" ]; then
+  echo "  OK: --status exits 0 with empty config + legacy .env (graceful fall-through)"; pass=$((pass+1))
+else
+  echo "  FAIL: --status crashed/exited $fallthru_exit on fall-through: $out_fallthru"; fail=$((fail+1))
+fi
+
+case "$out_fallthru" in
+  *"SUTANDO_MEMORY_REPO is deprecated"*)
+    echo "  OK: deprecation warning fired (correct fall-through path used)"; pass=$((pass+1)) ;;
+  *) echo "  FAIL: no deprecation warning on fall-through — config-path might be silently winning"; fail=$((fail+1)) ;;
+esac
+
+case "$out_fallthru" in
+  *"$FIXTURE_VAULT"*)
+    echo "  OK: vault URL resolved via .env legacy after empty config"; pass=$((pass+1)) ;;
+  *) echo "  FAIL: vault URL not resolved at all: $out_fallthru"; fail=$((fail+1)) ;;
+esac
+
+rm -f "$FIXTURE_REPO/.env"
+
+# ============================================================================
+echo
 echo "===================="
 echo "Total: $((pass+fail)) — pass: $pass, fail: $fail"
 exit $fail

--- a/tests/sync-workspace.test.sh
+++ b/tests/sync-workspace.test.sh
@@ -96,7 +96,6 @@ COMMON_ENV=(
   SUTANDO_REPO_DIR="$FIXTURE_REPO"
   SUTANDO_WORKSPACE="$FIXTURE_WS"
   SUTANDO_TEST_MODE=1
-  SUTANDO_VAULT="$FIXTURE_VAULT"
 )
 
 SYNC="$FIXTURE_REPO/scripts/sync-workspace.sh"
@@ -107,8 +106,9 @@ HOST_BRANCH="refs/heads/host/${HOST}"
 LOCAL_SLUG=$(printf '%s' "$FIXTURE_REPO" | sed 's|/|-|g')
 LOCAL_MEM_DIR="$FIXTURE_WS/.claude-sutando/projects/${LOCAL_SLUG}/memory"
 
+# PR-2: SUTANDO_VAULT env var removed; tests pass vault via --vault-url flag.
 run_sync() {
-  env "${COMMON_ENV[@]}" bash "$SYNC" "$@"
+  env "${COMMON_ENV[@]}" bash "$SYNC" --vault-url "$FIXTURE_VAULT" "$@"
 }
 
 # ============================================================================
@@ -293,7 +293,7 @@ else
 fi
 
 # Now with --force-gitignore → should overwrite
-out_force=$(env "${COMMON_ENV[@]}" bash "$SYNC" --init --force-gitignore 2>&1 || true)
+out_force=$(env "${COMMON_ENV[@]}" bash "$SYNC" --vault-url "$FIXTURE_VAULT" --init --force-gitignore 2>&1 || true)
 if grep -q "my custom user edit" "$FIXTURE_WS/.gitignore"; then
   echo "  FAIL: --force-gitignore didn't overwrite (user edit still there)"; fail=$((fail+1))
 else
@@ -310,7 +310,7 @@ echo "==== Test 10: pull-side mass-deletion tripwire (Pro #1445 review fix #2) =
 # but the tripwire reset prevented push; let's force-push them now via SUTANDO_FORCE_SYNC).
 cd "$FIXTURE_WS"
 for i in $(seq 1 60); do echo "n$i" > "notes/note-$i.md"; done
-SUTANDO_FORCE_SYNC=1 env "${COMMON_ENV[@]}" bash "$SYNC" --push-only 2>&1 | head -3
+SUTANDO_FORCE_SYNC=1 env "${COMMON_ENV[@]}" bash "$SYNC" --vault-url "$FIXTURE_VAULT" --push-only 2>&1 | head -3
 cd - >/dev/null
 
 # Peer: clone, delete all 60 notes, push to host/peerhost2
@@ -362,7 +362,7 @@ PRE_LEGACY_NOTE_EXISTS="$([ -f "$FIXTURE_WS/notes/legacy-note.md" ] && echo yes 
 
 # Run --dry-run; should NOT mutate fs
 out_dryrun=$(SUTANDO_MEMORY_SYNC_DIR="$LEGACY_FIXTURE" \
-             env "${COMMON_ENV[@]}" bash "$SYNC" --migrate-from-legacy --dry-run 2>&1 || true)
+             env "${COMMON_ENV[@]}" bash "$SYNC" --vault-url "$FIXTURE_VAULT" --migrate-from-legacy --dry-run 2>&1 || true)
 case "$out_dryrun" in
   *"DRY-RUN"*)
     echo "  OK: --dry-run output contains DRY-RUN markers"; pass=$((pass+1)) ;;
@@ -395,7 +395,7 @@ echo "==== Test 12: pull-side delete-AND-add bypass (Mini #1445 v3 Medium fix) =
 # Reset host 1 to have the 60 notes pushed
 cd "$FIXTURE_WS"
 for i in $(seq 1 60); do echo "n$i" > "notes/note-$i.md"; done
-SUTANDO_FORCE_SYNC=1 env "${COMMON_ENV[@]}" bash "$SYNC" --push-only 2>&1 | head -3
+SUTANDO_FORCE_SYNC=1 env "${COMMON_ENV[@]}" bash "$SYNC" --vault-url "$FIXTURE_VAULT" --push-only 2>&1 | head -3
 cd - >/dev/null
 
 # Peer3: clone, delete all 60 notes, add 60 NEW files (net zero), push
@@ -465,17 +465,14 @@ fi
 
 # ============================================================================
 echo
-echo "==== Test 13: .env without SUTANDO_VAULT falls through to legacy (Mini #1445 v4 Medium) ===="
-# Setup: write .env with ONLY SUTANDO_MEMORY_REPO (legacy alias), no
-# SUTANDO_VAULT entry. Run --status WITHOUT SUTANDO_VAULT in env. Pre-fix,
-# the `grep '^SUTANDO_VAULT=' | head -1 | ...` pipeline returned nonzero
-# under set -euo pipefail and the script exited before the legacy-alias
-# fallback could run.
+echo "==== Test 13: .env SUTANDO_MEMORY_REPO legacy alias (PR-2 — deprecated but honored) ===="
+# PR-2 dropped SUTANDO_VAULT env-var support. The .env legacy alias
+# SUTANDO_MEMORY_REPO is still warn-and-honored for one release. Test:
+# write .env with SUTANDO_MEMORY_REPO + no --vault-url + no config field →
+# script resolves vault from .env legacy + prints deprecation warning.
 
-# Write .env with only the legacy alias
 echo "SUTANDO_MEMORY_REPO=$FIXTURE_VAULT" > "$FIXTURE_REPO/.env"
 
-# Run --status WITHOUT SUTANDO_VAULT in env
 out_legacy_alias=$(env \
     SUTANDO_REPO_DIR="$FIXTURE_REPO" \
     SUTANDO_WORKSPACE="$FIXTURE_WS" \
@@ -484,59 +481,188 @@ out_legacy_alias=$(env \
 legacy_exit=$(printf '%s' "$out_legacy_alias" | sed -n 's/^EXIT=//p' | tail -1)
 
 if [ "$legacy_exit" = "0" ]; then
-  echo "  OK: --status exits 0 when .env has only SUTANDO_MEMORY_REPO (no SUTANDO_VAULT)"; pass=$((pass+1))
+  echo "  OK: --status exits 0 with only SUTANDO_MEMORY_REPO in .env"; pass=$((pass+1))
 else
-  echo "  FAIL: --status exited $legacy_exit on legacy-alias .env (set-e tripped on grep): $out_legacy_alias"; fail=$((fail+1))
+  echo "  FAIL: --status exited $legacy_exit on legacy-alias .env: $out_legacy_alias"; fail=$((fail+1))
 fi
 
 case "$out_legacy_alias" in
-  *"SUTANDO_MEMORY_REPO"*)
+  *"SUTANDO_MEMORY_REPO is deprecated"*)
     echo "  OK: legacy-alias deprecation warning surfaced"; pass=$((pass+1)) ;;
   *) echo "  FAIL: legacy-alias deprecation warning missing: $out_legacy_alias"; fail=$((fail+1)) ;;
 esac
 
-# Cleanup so subsequent test runs aren't sticky
+case "$out_legacy_alias" in
+  *"$FIXTURE_VAULT"*)
+    echo "  OK: vault URL resolved from .env legacy alias"; pass=$((pass+1)) ;;
+  *) echo "  FAIL: vault URL not resolved from legacy .env: $out_legacy_alias"; fail=$((fail+1)) ;;
+esac
+
 rm -f "$FIXTURE_REPO/.env"
 
 # ============================================================================
 echo
-echo "==== Test 14: canonical .env with SUTANDO_VAULT entry (Mini #1445 v6 gap) ===="
-# Mirror of Test 13 but for the CANONICAL key (SUTANDO_VAULT=) rather than
-# the legacy alias. Test 13 covers the missing-key fallback path; this covers
-# the happy path via .env (vs Test 1-12 which set SUTANDO_VAULT via process env).
+echo "==== Test 14: --vault-url CLI flag (PR-2 — canonical explicit) ===="
+# Run --status WITHOUT any .env, WITHOUT SUTANDO_VAULT (removed in PR-2),
+# WITHOUT vault.remote_url in config — only --vault-url flag. Should resolve.
 
-echo "SUTANDO_VAULT=$FIXTURE_VAULT" > "$FIXTURE_REPO/.env"
+out_flag=$(env \
+    SUTANDO_REPO_DIR="$FIXTURE_REPO" \
+    SUTANDO_WORKSPACE="$FIXTURE_WS" \
+    SUTANDO_TEST_MODE=1 \
+    bash "$SYNC" --vault-url "$FIXTURE_VAULT" --status 2>&1; echo "EXIT=$?")
+flag_exit=$(printf '%s' "$out_flag" | sed -n 's/^EXIT=//p' | tail -1)
 
-out_canon=$(env \
+if [ "$flag_exit" = "0" ]; then
+  echo "  OK: --status exits 0 with --vault-url flag"; pass=$((pass+1))
+else
+  echo "  FAIL: --status exited $flag_exit on --vault-url: $out_flag"; fail=$((fail+1))
+fi
+
+case "$out_flag" in
+  *"$FIXTURE_VAULT"*)
+    echo "  OK: vault URL resolved from --vault-url flag"; pass=$((pass+1)) ;;
+  *) echo "  FAIL: vault URL not resolved from flag: $out_flag"; fail=$((fail+1)) ;;
+esac
+
+# Flag must NOT trigger legacy-alias deprecation warning
+case "$out_flag" in
+  *"SUTANDO_MEMORY_REPO is deprecated"*)
+    echo "  FAIL: --vault-url spuriously triggered legacy-alias warning"; fail=$((fail+1)) ;;
+  *)
+    echo "  OK: --vault-url does NOT trigger legacy-alias warning"; pass=$((pass+1)) ;;
+esac
+
+# ============================================================================
+echo
+echo "==== Test 15: vault.remote_url from sutando.config.local.json (PR-2 — canonical config) ===="
+# Write vault.remote_url into sutando.config.local.json + run with NO --vault-url
+# flag + NO .env → should resolve via config file (the recommended path).
+
+cat > "$FIXTURE_REPO/sutando.config.local.json" <<JSON
+{"vault": {"remote_url": "$FIXTURE_VAULT"}}
+JSON
+
+out_config=$(env \
     SUTANDO_REPO_DIR="$FIXTURE_REPO" \
     SUTANDO_WORKSPACE="$FIXTURE_WS" \
     SUTANDO_TEST_MODE=1 \
     bash "$SYNC" --status 2>&1; echo "EXIT=$?")
-canon_exit=$(printf '%s' "$out_canon" | sed -n 's/^EXIT=//p' | tail -1)
+config_exit=$(printf '%s' "$out_config" | sed -n 's/^EXIT=//p' | tail -1)
 
-if [ "$canon_exit" = "0" ]; then
-  echo "  OK: --status exits 0 with canonical SUTANDO_VAULT in .env"; pass=$((pass+1))
+if [ "$config_exit" = "0" ]; then
+  echo "  OK: --status exits 0 with vault.remote_url from local config"; pass=$((pass+1))
 else
-  echo "  FAIL: --status exited $canon_exit on canonical .env: $out_canon"; fail=$((fail+1))
+  echo "  FAIL: --status exited $config_exit on config-driven vault: $out_config"; fail=$((fail+1))
 fi
 
-# Canonical key MUST NOT trigger the legacy-alias deprecation warning
-case "$out_canon" in
-  *"please rename to SUTANDO_VAULT"*|*"SUTANDO_MEMORY_REPO is set"*)
-    echo "  FAIL: canonical .env spuriously triggered legacy-alias warning"; fail=$((fail+1)) ;;
-  *)
-    echo "  OK: canonical .env does NOT trigger legacy-alias warning"; pass=$((pass+1)) ;;
+case "$out_config" in
+  *"$FIXTURE_VAULT"*)
+    echo "  OK: vault URL resolved from sutando.config.local.json"; pass=$((pass+1)) ;;
+  *) echo "  FAIL: vault URL not resolved from config: $out_config"; fail=$((fail+1)) ;;
 esac
 
-# Vault URL resolved correctly from .env. Match by path-string presence rather
-# than `VAULT_URL: $val` to tolerate the column-aligned status output.
-case "$out_canon" in
-  *"$FIXTURE_VAULT"*)
-    echo "  OK: --status surfaced VAULT_URL from .env"; pass=$((pass+1)) ;;
-  *) echo "  FAIL: VAULT_URL not surfaced from canonical .env: $out_canon"; fail=$((fail+1)) ;;
+# Config-driven path must NOT trigger legacy deprecation warning
+case "$out_config" in
+  *"SUTANDO_MEMORY_REPO is deprecated"*)
+    echo "  FAIL: config-driven path spuriously triggered legacy warning"; fail=$((fail+1)) ;;
+  *)
+    echo "  OK: config-driven path does NOT trigger legacy warning"; pass=$((pass+1)) ;;
 esac
+
+# Cleanup: restore original empty local config
+echo '{}' > "$FIXTURE_REPO/sutando.config.local.json"
+
+# ============================================================================
+echo
+echo "==== Test 16: SUTANDO_VAULT env var is NO LONGER honored (PR-2 — removed) ===="
+# Pre-PR-2, SUTANDO_VAULT was the canonical env var. PR-2 removed it because
+# config-file + --vault-url cover both canonical and override cases. Setting
+# the env var alone (no flag, no config, no .env) should NOT resolve vault.
+
+out_removed=$(env \
+    SUTANDO_REPO_DIR="$FIXTURE_REPO" \
+    SUTANDO_WORKSPACE="$FIXTURE_WS" \
+    SUTANDO_TEST_MODE=1 \
+    SUTANDO_VAULT="$FIXTURE_VAULT" \
+    bash "$SYNC" --status 2>&1; echo "EXIT=$?")
+
+# Status should still exit 0 (it doesn't require vault to be resolved),
+# but VAULT_URL must NOT match $FIXTURE_VAULT
+case "$out_removed" in
+  *"$FIXTURE_VAULT"*)
+    echo "  FAIL: SUTANDO_VAULT env var was still honored (should be removed)"; fail=$((fail+1)) ;;
+  *)
+    echo "  OK: SUTANDO_VAULT env var ignored as expected"; pass=$((pass+1)) ;;
+esac
+
+# ============================================================================
+echo
+echo "==== Test 17: --vault-url priority over legacy .env (PR-2) ===="
+# Set BOTH --vault-url AND .env SUTANDO_MEMORY_REPO. Flag must win.
+
+OTHER_VAULT="$TEST_ROOT/other-vault.git"
+git init -q --bare "$OTHER_VAULT"
+echo "SUTANDO_MEMORY_REPO=$OTHER_VAULT" > "$FIXTURE_REPO/.env"
+
+out_pri=$(env \
+    SUTANDO_REPO_DIR="$FIXTURE_REPO" \
+    SUTANDO_WORKSPACE="$FIXTURE_WS" \
+    SUTANDO_TEST_MODE=1 \
+    bash "$SYNC" --vault-url "$FIXTURE_VAULT" --status 2>&1)
+
+# Flag value must be present
+case "$out_pri" in
+  *"$FIXTURE_VAULT"*)
+    echo "  OK: --vault-url wins over .env legacy"; pass=$((pass+1)) ;;
+  *) echo "  FAIL: --vault-url did not win over .env: $out_pri"; fail=$((fail+1)) ;;
+esac
+
+# .env value must NOT be the resolved vault (flag wins). Check that the
+# OTHER_VAULT path doesn't appear in the VAULT_URL line specifically — it may
+# appear elsewhere in status output but not as the resolved value.
+if printf '%s' "$out_pri" | grep -E "^VAULT_URL:" | grep -qF "$OTHER_VAULT"; then
+  echo "  FAIL: .env value used as VAULT_URL despite --vault-url flag"; fail=$((fail+1))
+else
+  echo "  OK: .env legacy value NOT picked when --vault-url present"; pass=$((pass+1))
+fi
 
 rm -f "$FIXTURE_REPO/.env"
+
+# ============================================================================
+echo
+echo "==== Test 18: sync-memory.sh deprecation banner (PR-2) ===="
+# sync-memory.sh stays functional but emits a one-line deprecation banner
+# pointing at sync-workspace.sh.
+
+# Copy the (real, modified) sync-memory.sh into the fixture
+cp "$REPO/scripts/sync-memory.sh" "$FIXTURE_REPO/scripts/"
+SYNC_MEM="$FIXTURE_REPO/scripts/sync-memory.sh"
+
+# Invoke with a flag that triggers early exit (e.g. SUTANDO_MEMORY_REPO unset
+# → script bails). We just want to see if the banner emits.
+out_banner=$(env \
+    SUTANDO_REPO_DIR="$FIXTURE_REPO" \
+    SUTANDO_WORKSPACE="$FIXTURE_WS" \
+    bash "$SYNC_MEM" 2>&1 || true)
+
+case "$out_banner" in
+  *"DEPRECATED"*"sync-workspace.sh"*)
+    echo "  OK: sync-memory.sh prints deprecation banner pointing at sync-workspace.sh"; pass=$((pass+1)) ;;
+  *) echo "  FAIL: sync-memory.sh missing deprecation banner: $out_banner" | head -5; fail=$((fail+1)) ;;
+esac
+
+# Suppress flag should silence it
+out_silent=$(env \
+    SUTANDO_REPO_DIR="$FIXTURE_REPO" \
+    SUTANDO_WORKSPACE="$FIXTURE_WS" \
+    SUTANDO_SYNC_MEMORY_SUPPRESS_DEPRECATION=1 \
+    bash "$SYNC_MEM" 2>&1 || true)
+
+case "$out_silent" in
+  *"DEPRECATED"*) echo "  FAIL: SUPPRESS flag did not silence deprecation banner"; fail=$((fail+1)) ;;
+  *) echo "  OK: SUTANDO_SYNC_MEMORY_SUPPRESS_DEPRECATION=1 silences banner"; pass=$((pass+1)) ;;
+esac
 
 # ============================================================================
 echo


### PR DESCRIPTION
## Milestone status (workspace-revamp M0–M3)

| Milestone | Status |
|---|---|
| M0-1 (workspace structure) | ✅ shipped (PR #1395) |
| M1-1 (migrate legacy workspace) | ✅ shipped (sutando-migrate skill) |
| M0-2 (`.claude_sutando/` in-repo) | ✅ shipped |
| M1-2 (migrate `.claude/` → `.claude-sutando/`) | ✅ shipped |
| **M2 (sync engine)** | **🟡 in-flight** (this PR is part of M2) |
| M3 (docs sweep + dogfooding + E2E) | ⏸ not yet started |

---

PR-2 followup to #1445. Owner directive 2026-06-04: vault URL resolution should mirror how workspace path is resolved (config-file canonical), not env-var canonical. Includes deprecation banner on the legacy script (Option C: parallel deprecation, no behavior change for existing users).

## Summary

- Vault URL resolver: priority chain is now `--vault-url <url>` → `sutando.config.local.json` (`vault.remote_url`) → `sutando.config.json` (tracked default) → `.env SUTANDO_MEMORY_REPO` (deprecated; warn-and-honor for one release)
- `SUTANDO_VAULT` env var (introduced in #1445) **removed** — brand new, no users to deprecate; CLI flag + config-file is the canonical surface
- `--vault-url <url>` CLI flag added (two forms: `--vault-url X` and `--vault-url=X`)
- `sync-memory.sh` keeps working with a one-line deprecation banner + migration recipe in the header (silence with `SUTANDO_SYNC_MEMORY_SUPPRESS_DEPRECATION=1`)
- Reference sweep (user-facing): `crons.example.json` + `docs/memory-sync.md`
- 48/48 tests pass (was 39 in #1445 v6); +9 new tests cover the new resolver chain, flag forms, env-var removal, priority, and deprecation banner

## Why Option C (parallel deprecation, not exec-shim)

The two scripts implement **different storage architectures**:
- `sync-memory.sh`: rsync to a separate `~/.sutando/memory-sync/` clone
- `sync-workspace.sh`: workspace IS the git repo, branch-per-host topology

A `exec sync-workspace.sh "$@"` shim would silently auto-init users' workspaces on first cron fire — destructive. Option C keeps both functional through the transition; PR-2.1 removes `sync-memory.sh` after dogfooding.

## Test plan

- [ ] `bash tests/sync-workspace.test.sh` — expect `Total: 48 — pass: 48, fail: 0`
- [ ] Smoke test `--vault-url` flag: `bash scripts/sync-workspace.sh --vault-url <url> --status` resolves cleanly
- [ ] Smoke test config-file: write `vault.remote_url` into `sutando.config.local.json`, run `--status`, see URL in output
- [ ] Smoke test legacy `.env`: only `SUTANDO_MEMORY_REPO=...` → see deprecation banner + URL resolves
- [ ] Smoke test `sync-memory.sh`: invoke → see deprecation banner; set `SUTANDO_SYNC_MEMORY_SUPPRESS_DEPRECATION=1` → no banner

## Not in scope (PR-2.1 / later)

- Removing `sync-memory.sh` entirely (waits for dogfooding observation)
- Doc sweep of `workspace-design.md` / `workspace-contract.md` (architectural docs, out-of-scope for user-facing PR-2)
- Internal-caller refs in `health-check.py` / `core_heartbeat.py` (those still use rsync flow; shim covers them during transition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)