### PR TITLE
fix(sync-workspace): handle unrelated histories on first cross-host pull (Codex P1.3)

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -189,6 +189,19 @@ die() {
     exit "${2:-1}"
 }
 
+# Host identity (used for `host/<host>` branch name + commit messages).
+# SUTANDO_HOST_OVERRIDE is a TEST-ONLY shim — set per-invocation so the
+# hermetic multi-host test can simulate two hosts from a single machine
+# (sutando-workspace.test.sh Test 23, Codex P1.3 reproducer). Not for
+# production use.
+_host() {
+    if [ -n "${SUTANDO_HOST_OVERRIDE:-}" ]; then
+        printf '%s\n' "$SUTANDO_HOST_OVERRIDE"
+    else
+        hostname | sed 's/\..*//'
+    fi
+}
+
 # --------------------------------------------------------------------------- #
 # Section 3 — Lock (atomic mkdir, POSIX, no flock dependency)                  #
 # --------------------------------------------------------------------------- #
@@ -381,7 +394,7 @@ _init_impl() {
         echo "DRY-RUN: would init workspace as git repo at $WORKSPACE_DIR" >&2
         echo "DRY-RUN: would set git remote origin = $VAULT_URL" >&2
         echo "DRY-RUN: would (re)generate .gitignore" >&2
-        echo "DRY-RUN: would stage + commit + push to refs/heads/host/$(hostname | sed 's/\..*//')" >&2
+        echo "DRY-RUN: would stage + commit + push to refs/heads/host/$(_host)" >&2
         # Still call generate_gitignore — its own dry-run logic will print the diff (no write)
         generate_gitignore || true
         return 0
@@ -420,11 +433,11 @@ _init_impl() {
     if git diff --cached --quiet; then
         log "_init_impl: nothing to commit on init (already-initialized re-run, or empty workspace)"
     else
-        git commit -q -m "Initial workspace-vault sync: bootstrap host=$(hostname)"
+        git commit -q -m "Initial workspace-vault sync: bootstrap host=${SUTANDO_HOST_OVERRIDE:-$(hostname)}"
         log "_init_impl: initial commit created"
 
         local host
-        host="$(hostname | sed 's/\..*//')"
+        host="$(_host)"
         if git push origin "HEAD:refs/heads/host/${host}" 2>&1 | tee -a "$LOG" >/dev/null; then
             log "_init_impl: pushed to origin host/${host}"
             echo "sync-workspace: initialized + pushed to host/${host}"
@@ -461,7 +474,7 @@ _pull_only_impl() {
 
     # Ensure we're on the host branch (idempotent)
     local host current_branch
-    host="$(hostname | sed 's/\..*//')"
+    host="$(_host)"
     current_branch="host/${host}"
     if [ "$(git symbolic-ref --short HEAD 2>/dev/null)" != "$current_branch" ]; then
         if git show-ref --quiet "refs/remotes/origin/${current_branch}"; then
@@ -488,8 +501,21 @@ _pull_only_impl() {
     local merged=0
     for peer in $peers; do
         [ "$peer" = "origin/${current_branch}" ] && continue
+        # P1.3 fix (Codex review on #1454): when two hosts each ran `--init`
+        # independently against the same vault, their initial commits have NO
+        # common ancestor. `git merge` then errors with "refusing to merge
+        # unrelated histories" — Codex repro'd against two fresh vault clones.
+        # Detect the no-merge-base case and pass `--allow-unrelated-histories`
+        # so the first cross-host merge roots both lineages. After that, the
+        # shared root exists and the flag becomes a no-op on subsequent peers.
+        local -a merge_args=(--no-edit)
+        if ! git merge-base HEAD "$peer" >/dev/null 2>&1; then
+            log "_pull_only_impl: $peer has unrelated history with HEAD; using --allow-unrelated-histories"
+            echo "sync-workspace: $peer has unrelated history with HEAD; merging with --allow-unrelated-histories" >&2
+            merge_args+=(--allow-unrelated-histories)
+        fi
         log "_pull_only_impl: merging $peer into $current_branch"
-        if git merge --no-edit "$peer" 2>&1 | tee -a "$LOG" >/dev/null; then
+        if git merge "${merge_args[@]}" "$peer" 2>&1 | tee -a "$LOG" >/dev/null; then
             merged=$((merged + 1))
         else
             log "_pull_only_impl: conflict merging $peer; resolving via --ours (use-local fallback)"
@@ -565,7 +591,7 @@ _push_only_impl() {
     [ -d ".git" ] || die "push-only: $WORKSPACE_DIR is not a git repo; run --init first"
 
     if [ "$DRY_RUN" = "1" ]; then
-        echo "DRY-RUN: would stage + commit + push to refs/heads/host/$(hostname | sed 's/\..*//')" >&2
+        echo "DRY-RUN: would stage + commit + push to refs/heads/host/$(_host)" >&2
         return 0
     fi
 
@@ -589,10 +615,10 @@ _push_only_impl() {
         return 1
     fi
 
-    git commit -q -m "Sync $(hostname) $(date +%Y-%m-%dT%H:%M)"
+    git commit -q -m "Sync ${SUTANDO_HOST_OVERRIDE:-$(hostname)} $(date +%Y-%m-%dT%H:%M)"
 
     local host
-    host="$(hostname | sed 's/\..*//')"
+    host="$(_host)"
     if git push origin "HEAD:refs/heads/host/${host}" 2>&1 | tee -a "$LOG" >/dev/null; then
         log "_push_only_impl: pushed to origin host/${host}"
         echo "sync-workspace: pushed to host/${host}"
@@ -730,7 +756,7 @@ _migrate_from_legacy_impl() {
 
     # 3. pending-questions.md (prefer machine-<host>/pending-questions.md if present)
     local host
-    host="$(hostname | sed 's/\..*//')"
+    host="$(_host)"
     local pq_src
     if [ -f "$legacy_dir/machine-${host}/pending-questions.md" ]; then
         pq_src="$legacy_dir/machine-${host}/pending-questions.md"

--- a/tests/sync-workspace.test.sh
+++ b/tests/sync-workspace.test.sh
@@ -888,6 +888,121 @@ echo '{}' > "$FIXTURE_REPO/sutando.config.local.json"
 
 # ============================================================================
 echo
+echo "==== Test 23: --pull-only handles unrelated histories across fresh hosts (Codex P1.3) ===="
+# Two hosts that each run `--init` from scratch against the SAME bare vault
+# produce TWO unrelated initial commits — no common ancestor. Pre-fix, the
+# first cross-host `git merge` died with "refusing to merge unrelated
+# histories" and `--pull-only` silently "succeeded" with 0 peers merged.
+# This test sets up that exact topology and verifies the second host's
+# pull-only succeeds AND surfaces the peer's content into the local
+# workspace.
+TEST23_VAULT="$TEST_ROOT/vault-23.git"
+git init -q --bare "$TEST23_VAULT"
+
+# Host A: fresh workspace + --init against the shared vault
+HOSTA_WS="$TEST_ROOT/hostA-ws"
+HOSTA_REPO="$TEST_ROOT/hostA-repo"
+mkdir -p "$HOSTA_WS" "$HOSTA_REPO/scripts" "$HOSTA_REPO/src"
+touch "$HOSTA_REPO/CLAUDE.md"
+git init -q "$HOSTA_REPO"
+cp "$REPO/scripts/sync-workspace.sh" "$HOSTA_REPO/scripts/"
+cp "$REPO/scripts/sutando-config.sh" "$HOSTA_REPO/scripts/"
+cp "$REPO/src/sutando_config.py" "$HOSTA_REPO/src/"
+cp "$FIXTURE_REPO/sutando.config.json" "$HOSTA_REPO/"
+HOSTA_SLUG=$(printf '%s' "$HOSTA_REPO" | sed 's|/|-|g')
+mkdir -p "$HOSTA_WS/.claude-sutando/projects/${HOSTA_SLUG}/memory"
+mkdir -p "$HOSTA_WS/notes"
+echo "from hostA" > "$HOSTA_WS/.claude-sutando/projects/${HOSTA_SLUG}/memory/feedback_hostA.md"
+echo "hostA note" > "$HOSTA_WS/notes/hostA-note.md"
+
+# Run --init on host A — hostname is the same across both hosts (same machine
+# running the test), so we override HOST per-invocation via the
+# SUTANDO_HOST_OVERRIDE test-only shim in the script.
+env -i HOME="$HOME" PATH="$PATH" \
+    SUTANDO_REPO_DIR="$HOSTA_REPO" \
+    SUTANDO_WORKSPACE="$HOSTA_WS" \
+    SUTANDO_TEST_MODE=1 \
+    SUTANDO_HOST_OVERRIDE=hostA \
+    bash "$HOSTA_REPO/scripts/sync-workspace.sh" --vault-url "$TEST23_VAULT" --init 2>&1 | tail -3 >/dev/null
+
+# Host B: ALSO fresh, ALSO --init, ALSO pushes to the SAME vault — but with
+# a DIFFERENT hostname → different host branch, independent root commit.
+HOSTB_WS="$TEST_ROOT/hostB-ws"
+HOSTB_REPO="$TEST_ROOT/hostB-repo"
+mkdir -p "$HOSTB_WS" "$HOSTB_REPO/scripts" "$HOSTB_REPO/src"
+touch "$HOSTB_REPO/CLAUDE.md"
+git init -q "$HOSTB_REPO"
+cp "$REPO/scripts/sync-workspace.sh" "$HOSTB_REPO/scripts/"
+cp "$REPO/scripts/sutando-config.sh" "$HOSTB_REPO/scripts/"
+cp "$REPO/src/sutando_config.py" "$HOSTB_REPO/src/"
+cp "$FIXTURE_REPO/sutando.config.json" "$HOSTB_REPO/"
+HOSTB_SLUG=$(printf '%s' "$HOSTB_REPO" | sed 's|/|-|g')
+mkdir -p "$HOSTB_WS/.claude-sutando/projects/${HOSTB_SLUG}/memory"
+mkdir -p "$HOSTB_WS/notes"
+echo "from hostB" > "$HOSTB_WS/.claude-sutando/projects/${HOSTB_SLUG}/memory/feedback_hostB.md"
+echo "hostB note" > "$HOSTB_WS/notes/hostB-note.md"
+
+env -i HOME="$HOME" PATH="$PATH" \
+    SUTANDO_REPO_DIR="$HOSTB_REPO" \
+    SUTANDO_WORKSPACE="$HOSTB_WS" \
+    SUTANDO_TEST_MODE=1 \
+    SUTANDO_HOST_OVERRIDE=hostB \
+    bash "$HOSTB_REPO/scripts/sync-workspace.sh" --vault-url "$TEST23_VAULT" --init 2>&1 | tail -3 >/dev/null
+
+# Verify two unrelated host branches exist in the vault
+HOSTA_SHA=$(git --git-dir="$TEST23_VAULT" rev-parse refs/heads/host/hostA 2>/dev/null || echo "")
+HOSTB_SHA=$(git --git-dir="$TEST23_VAULT" rev-parse refs/heads/host/hostB 2>/dev/null || echo "")
+if [ -n "$HOSTA_SHA" ] && [ -n "$HOSTB_SHA" ]; then
+  echo "  OK: host/hostA and host/hostB both pushed to vault"; pass=$((pass+1))
+else
+  echo "  FAIL: one or both host branches missing from vault (A=$HOSTA_SHA B=$HOSTB_SHA)"; fail=$((fail+1))
+fi
+
+# Confirm unrelated histories (the pre-condition that triggered the bug)
+MERGE_BASE=$(git --git-dir="$TEST23_VAULT" merge-base "$HOSTA_SHA" "$HOSTB_SHA" 2>/dev/null || echo "")
+if [ -z "$MERGE_BASE" ]; then
+  echo "  OK: hostA and hostB have NO common ancestor (unrelated histories — bug pre-condition)"; pass=$((pass+1))
+else
+  echo "  FAIL: hostA and hostB share ancestor $MERGE_BASE — test setup wrong"; fail=$((fail+1))
+fi
+
+# Now run --pull-only on host B → should merge hostA in via --allow-unrelated-histories
+PULL_OUT=$(env -i HOME="$HOME" PATH="$PATH" \
+    SUTANDO_REPO_DIR="$HOSTB_REPO" \
+    SUTANDO_WORKSPACE="$HOSTB_WS" \
+    SUTANDO_TEST_MODE=1 \
+    SUTANDO_HOST_OVERRIDE=hostB \
+    bash "$HOSTB_REPO/scripts/sync-workspace.sh" --vault-url "$TEST23_VAULT" --pull-only 2>&1)
+
+# Verify hostA's content surfaced into hostB's workspace
+HOSTA_VISIBLE_FILE="$HOSTB_WS/.claude-sutando/projects/${HOSTA_SLUG}/memory/feedback_hostA.md"
+assert_file_exists "hostA's memory file visible in hostB workspace after pull-only" "$HOSTA_VISIBLE_FILE"
+HOSTA_VISIBLE_NOTE="$HOSTB_WS/notes/hostA-note.md"
+assert_file_exists "hostA's note visible in hostB workspace after pull-only" "$HOSTA_VISIBLE_NOTE"
+
+# Verify hostB's OWN content still present (merge didn't wipe local)
+HOSTB_OWN_FILE="$HOSTB_WS/.claude-sutando/projects/${HOSTB_SLUG}/memory/feedback_hostB.md"
+assert_file_exists "hostB's own memory still present after pull-only" "$HOSTB_OWN_FILE"
+
+# Verify hostB's local git head is now a merge commit with 2 parents
+cd "$HOSTB_WS"
+PARENT_COUNT=$(git cat-file -p HEAD 2>/dev/null | grep -c "^parent " || echo 0)
+if [ "$PARENT_COUNT" -ge 2 ]; then
+  echo "  OK: hostB HEAD is a merge commit (2+ parents)"; pass=$((pass+1))
+else
+  echo "  FAIL: hostB HEAD has $PARENT_COUNT parents — expected merge commit"; fail=$((fail+1))
+fi
+cd "$REPO"
+
+# Confirm the new --allow-unrelated-histories log line fired (visible in stderr)
+if echo "$PULL_OUT" | grep -q "unrelated history"; then
+  echo "  OK: --pull-only logged 'unrelated history' detection"; pass=$((pass+1))
+else
+  echo "  FAIL: --pull-only did not log unrelated-history detection; output: $PULL_OUT"; fail=$((fail+1))
+fi
+
+# ============================================================================
+echo
 echo "===================="
 echo "Total: $((pass+fail)) — pass: $pass, fail: $fail"
 exit $fail


### PR DESCRIPTION
## Summary

Addresses the **third of Codex's three P1 findings** on #1454. P1.1 (`--commit` flag alias) and P1.2 (Swift v0.8 `$SUTANDO_WORKSPACE` contract) were already fixed on staging by `f2a6072`. P1.3 (unrelated histories on first cross-host pull) is the remaining one — and it is **live on owner's MBP × Mac Air pair right now** (vault host branches have no common ancestor).

### The bug

When two hosts each ran `bash scripts/sync-workspace.sh --init` against the same vault, each produced an independent root commit. The first cross-host `git merge` in `_pull_only_impl` then died with `refusing to merge unrelated histories`, and pull-only logged success with 0 peers merged.

```
$ git --git-dir=vault.git merge-base host/MBP host/MacAir
<empty>   # NO COMMON ANCESTOR
```

The existing test fixture branched the peer from `origin/host/${HOST}` (line 245) so peers shared history — that pattern silently misses the real fresh-host topology Codex flagged.

### The fix

In the peer-merge loop, detect missing merge-base via `git merge-base HEAD "\$peer"` and conditionally pass `--allow-unrelated-histories` only when no common ancestor exists. After the first cross-host merge roots both lineages, the flag becomes a no-op on subsequent peers.

Stderr line surfaces the detection so operators can confirm the safety-property is correctly identified during their first multi-host pull:

```
sync-workspace: origin/host/hostA has unrelated history with HEAD; merging with --allow-unrelated-histories
```

### Test 23 — hermetic multi-host

Adds Test 23 to `tests/sync-workspace.test.sh`: two fresh hosts each `--init` against the same bare vault, hostB then `--pull-only` succeeds, hostA's content surfaces into hostB's workspace, hostB's own content survives, and HEAD is a merge commit with 2 parents.

To make this hermetic from a single CI machine, adds a test-only `SUTANDO_HOST_OVERRIDE` env shim (sibling to `SUTANDO_TEST_MODE`; not honored without explicit opt-in; not for production). The 5 host-resolution sites in the script now go through a `_host()` helper that consults the override; raw `hostname` in commit-message strings uses an inline `\${SUTANDO_HOST_OVERRIDE:-\$(hostname)}` so production commit messages still carry the FQDN form (preserves visual continuity with existing vault commits like `Sync Qingyuns-MacBook-Pro-1279.local 2026-06-04T14:12`).

## Milestone status (workspace-revamp arc)

| Milestone | Status | Surface |
|---|---|---|
| M0 | ✅ Shipped | In-repo workspace + `sutando-config.sh` helper |
| M1 | ✅ Shipped | Recovery skill + `sutando-migrate.sh` + bug-hunt |
| claude-config | ✅ Shipped | `CLAUDE_CONFIG_DIR` per-workspace |
| v0.8 contract | ✅ Shipped | `$SUTANDO_WORKSPACE` removed prod-side (Python/TS/Swift) |
| M2 | ✅ Shipped | sync-workspace + vault URL from config + PR-3 gitignore carrier |
| **#1454 rollup** | 🟡 In review (this fixes P1.3) | staging → main |
| M3 | ⏳ Next | docs sweep + dogfooding + E2E |

## Test plan

- [x] Hermetic suite: `bash tests/sync-workspace.test.sh` — 65/65 pass (Test 23 = new)
- [x] Existing P1.1 + P1.2 tests: `python3 tests/sutando-migrate-argparse.test.py` (1/1), `python3 tests/sutando-config-swift.test.py` (2/2)
- [x] Repro the bug pre-fix: vault `merge-base` between MBP and Mac Air host branches confirmed empty
- [ ] Owner dogfood: after merge, run `bash scripts/sync-workspace.sh --pull-only` on MBP → should merge `host/Qingyun-Airs-MacBook-Air` cleanly via `--allow-unrelated-histories` log line (will produce a 46k-line first-merge diff in the working tree — expected; after the merge the vault has shared root)

## Known follow-ups

- After this merges to staging, the rollup PR #1454 body should fold in Mini's two non-blocking wording fixes (closes-list framing + non-revamp-commits acknowledgment) — addressed via a sibling PR-1454 body edit, not part of this code-level fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)