### PR TITLE
feat(sync-workspace): wsId↔folder discovery — path in commit msg + status pairing

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -545,8 +545,13 @@ _init_impl() {
     if [ "$_do_commit" = "0" ]; then
         log "_init_impl: nothing to commit on init (already-initialized re-run, or empty workspace)"
     else
+        # Commit message includes path=<workspace_path> so a peer host
+        # browsing the vault can map `host/<host>/<wsId>` back to a local
+        # folder via `git log host/<host>/<wsId>` without an extra metadata
+        # file. The path is the absolute workspace directory on the host
+        # that initialized this branch.
         # shellcheck disable=SC2086  # intentional word-split on $_empty_flag
-        git commit -q $_empty_flag -m "Initial workspace-vault sync: bootstrap host=${SUTANDO_HOST_OVERRIDE:-$(hostname)}"
+        git commit -q $_empty_flag -m "Initial workspace-vault sync: bootstrap host=${SUTANDO_HOST_OVERRIDE:-$(hostname)} path=${WORKSPACE_DIR}"
         log "_init_impl: initial commit created"
 
         local host_ws_seg
@@ -732,7 +737,9 @@ _push_only_impl() {
         return 1
     fi
 
-    git commit -q -m "Sync ${SUTANDO_HOST_OVERRIDE:-$(hostname)} $(date +%Y-%m-%dT%H:%M)"
+    # Same path= suffix as _init_impl — see comment there. Cross-host
+    # wsId → folder discovery works from `git log host/<host>/<wsId>`.
+    git commit -q -m "Sync ${SUTANDO_HOST_OVERRIDE:-$(hostname)} $(date +%Y-%m-%dT%H:%M) path=${WORKSPACE_DIR}"
 
     local host_ws_seg
     host_ws_seg="$(_host_ws_segment)"
@@ -760,9 +767,13 @@ cmd_status() {
     echo "REPO_DIR:      $REPO_DIR"
     echo "VAULT_URL:     ${VAULT_URL:-<unset>}"
     # Surface the wsId only if it exists — don't generate just for status.
+    # Pair it with the local workspace path on the same line so the
+    # wsId↔folder mapping is visually unambiguous for the operator.
     local ws_id_file="$WORKSPACE_DIR/.sutando-vault/ws-id"
     if [ -f "$ws_id_file" ]; then
-        echo "WS_ID:         $(tr -d '[:space:]' < "$ws_id_file")"
+        local _ws_id_val
+        _ws_id_val="$(tr -d '[:space:]' < "$ws_id_file")"
+        echo "WS_ID:         ${_ws_id_val}  ← this id identifies workspace ${WORKSPACE_DIR}"
     elif [ -d "$WORKSPACE_DIR/.git" ]; then
         # Legacy: workspace was --init'd before the wsId scheme landed. Push
         # path goes to host/<hostname> instead of host/<hostname>/<wsId>.

--- a/tests/sync-workspace.test.sh
+++ b/tests/sync-workspace.test.sh
@@ -1107,6 +1107,59 @@ fi
 
 # ============================================================================
 echo
+echo "==== Test 25: --status pairs WS_ID with local workspace path (wsId↔folder discovery) ===="
+# After --init, --status output should include a line that pairs the WS_ID
+# with the workspace's absolute path on the local host. This is the
+# same-host discovery half of the wsId UX work.
+
+rm -rf "$FIXTURE_WS"
+mkdir -p "$FIXTURE_WS"
+rm -rf "$FIXTURE_VAULT" && git init -q --bare "$FIXTURE_VAULT"
+run_sync --init 2>&1 | head -3 >/dev/null || true
+
+status_out=$(run_sync --status 2>&1 || true)
+if echo "$status_out" | grep -E '^WS_ID:' | grep -q "$FIXTURE_WS"; then
+  echo "  OK: --status WS_ID line pairs the wsId with its local workspace path"; pass=$((pass+1))
+else
+  echo "  FAIL: --status WS_ID line missing local workspace path; output: $status_out"; fail=$((fail+1))
+fi
+
+# ============================================================================
+echo
+echo "==== Test 26: commit messages carry path= for cross-host wsId↔folder discovery ===="
+# Both init and push commit messages should include `path=<workspace_path>`
+# so a peer host browsing the vault can map host/<host>/<wsId> back to a
+# local folder via `git log host/<host>/<wsId>`.
+
+rm -rf "$FIXTURE_WS"
+mkdir -p "$FIXTURE_WS"
+rm -rf "$FIXTURE_VAULT" && git init -q --bare "$FIXTURE_VAULT"
+run_sync --init 2>&1 | head -3 >/dev/null || true
+
+# Verify the init bootstrap commit carries path=
+init_msg=$(git --git-dir="$FIXTURE_VAULT" log -1 --pretty=%s "$HOST_BRANCH" 2>/dev/null || echo "")
+case "$init_msg" in
+  *"path=$FIXTURE_WS"*)
+    echo "  OK: init commit message includes path=$FIXTURE_WS"; pass=$((pass+1)) ;;
+  *)
+    echo "  FAIL: init commit missing path=; msg: $init_msg"; fail=$((fail+1)) ;;
+esac
+
+# Trigger a push by writing a tracked-path file, then verify the push commit
+mkdir -p "$FIXTURE_WS/notes"
+echo "n" > "$FIXTURE_WS/notes/push-msg-test.md"
+run_sync --push-only 2>&1 | head -3 >/dev/null || true
+
+push_msg=$(git --git-dir="$FIXTURE_VAULT" log -1 --pretty=%s "$HOST_BRANCH" 2>/dev/null || echo "")
+case "$push_msg" in
+  *"path=$FIXTURE_WS"*)
+    echo "  OK: push commit message includes path=$FIXTURE_WS"; pass=$((pass+1)) ;;
+  *)
+    echo "  FAIL: push commit missing path=; msg: $push_msg"; fail=$((fail+1)) ;;
+esac
+
+# ============================================================================
+echo
 echo "===================="
 echo "Total: $((pass+fail)) — pass: $pass, fail: $fail"
 exit $fail


### PR DESCRIPTION
Owner ask: *"the new workspace ID design is working now. can we figure out ways to help user know which local folder each WS id correspond to?"*

Two complementary, additive surfaces — no new schema, no new subcommand:

## (A) `--status` pairs WS_ID with workspace path

Before:
```
WORKSPACE_DIR: /Users/qing/.../workspace
...
WS_ID:         a3f9c2
```

After:
```
WORKSPACE_DIR: /Users/qing/.../workspace
...
WS_ID:         a3f9c2  ← this id identifies workspace /Users/qing/.../workspace
```

Operator on the local host runs `bash scripts/sync-workspace.sh --status` and sees the wsId↔folder mapping in one glance — no need to mentally cross-reference the two lines.

## (B) Commit messages include `path=<workspace_path>`

Before:
```
Initial workspace-vault sync: bootstrap host=MBP
Sync MBP 2026-06-05T01:30
```

After:
```
Initial workspace-vault sync: bootstrap host=MBP path=/Users/qing/.../workspace
Sync MBP 2026-06-05T01:30 path=/Users/qing/.../workspace
```

A user on host A browsing the vault can map an unfamiliar `host/<host>/<wsId>` branch back to a local folder on the originating host:
```
$ git log host/MBP/a3f9c2 -1 --oneline
1aabb2c Sync MBP 2026-06-05T01:30 path=/Users/qing/Documents/github/sutando-plus/workspace
```

Cross-host discovery for free, no extra metadata file.

## Tests

**72/72 hermetic pass** (2 new):

- **Test 25** — `--status` after `--init` includes the workspace path on the same line as `WS_ID:`.
- **Test 26** — both init bootstrap commit AND subsequent push commit carry `path=<workspace_path>` on the vault host branch.

## Milestone status

| Milestone | Status |
|---|---|
| M0 — in-repo workspace default + config-driven resolution | ✅ shipped |
| M1 — migration script + skill + supporting hardening | ✅ shipped |
| v0.8 — strip `$SUTANDO_WORKSPACE` from resolver + auto-migration | ✅ shipped |
| M2 — sync engine (workspace-as-git-repo + vault URL + gitignore carrier) | ✅ shipped |
| wsId scheme (#1459) — per-workspace branch identity | ✅ shipped |
| leak fix (#1460) — rules in `.git/info/exclude` to stop outer-tree leak | 🟢 approved, pending merge |
| **wsId UX polish (this PR)** — same-host + cross-host folder discovery | 🟡 this PR |
| M3 — docs sweep + dogfooding + E2E | 🟡 in flight |

## Followups (NOT this PR)

Owner asked separately about a config-driven `CLAUDE_CONFIG_DIR` override with a generic `core_config_dir` schema (`type` / `name` / `value`). Separate PR — config-schema + helper + `claude-sutando` wrapper changes, no code overlap with this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)