### PR TITLE
feat(workspace-0.3rc9): core_config_dirs — per-runtime CLAUDE_CONFIG_DIR surface

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -92,14 +92,61 @@ for p in resolve_vault().get('sync', {}).get('exclude', []):
     ;;
 
   claude-sutando-config-dir)
-    # M2 — print the absolute CLAUDE_CONFIG_DIR target used by the
-    # `claude-sutando` shell alias. Always a sub-folder of resolve_workspace()
-    # (the loader enforces; absolute paths and `..` escapes rejected).
+    # Print the absolute CLAUDE_CONFIG_DIR target used by the `claude-sutando`
+    # shell alias. v0.9 resolution: `core_config_dirs[type=claude].value` →
+    # legacy `claude_sutando_config_dir.subdir` (deprecation-warned) →
+    # `<workspace>/.claude-sutando` baked default. `synced=true` entries are
+    # validated to be under the workspace at load time.
     python3 -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import resolve_claude_sutando_config_dir
 print(resolve_claude_sutando_config_dir(), end='')
+"
+    ;;
+
+  core-config-dir-env-name)
+    # v0.9 — print the env var name of the matching core_config_dirs entry.
+    # Optional second arg picks by id or type; defaults to first type=claude.
+    # Example: `bash sutando-config.sh core-config-dir-env-name` → CLAUDE_CONFIG_DIR
+    _selector="${2:-claude}"
+    python3 -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT')
+from src.sutando_config import find_core_config_dir
+entry = find_core_config_dir(type_='$_selector') or find_core_config_dir(id_='$_selector')
+if entry is None:
+    sys.exit(0)
+print(entry['env_name'], end='')
+"
+    ;;
+
+  core-config-dir-value)
+    # v0.9 — print the resolved value (absolute path) of the matching
+    # core_config_dirs entry. Selector semantics identical to
+    # core-config-dir-env-name.
+    _selector="${2:-claude}"
+    python3 -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT')
+from src.sutando_config import find_core_config_dir
+entry = find_core_config_dir(type_='$_selector') or find_core_config_dir(id_='$_selector')
+if entry is None:
+    sys.exit(0)
+print(entry['value'], end='')
+"
+    ;;
+
+  core-config-dirs)
+    # v0.9 — print all resolved core_config_dirs entries as JSON (one object
+    # per line — JSON Lines). For tooling that wants to enumerate without
+    # parsing the full merged config.
+    python3 -c "
+import json, sys
+sys.path.insert(0, '$REPO_ROOT')
+from src.sutando_config import resolve_core_config_dirs
+for entry in resolve_core_config_dirs():
+    print(json.dumps(entry))
 "
     ;;
 
@@ -130,7 +177,7 @@ print(resolve_claude_sutando_config_dir(), end='')
     ;;
 
   *)
-    echo "usage: $0 {workspace|vault-enabled|vault-url|vault-sync-include|vault-sync-exclude|claude-sutando-config-dir|dump|subdirs|bootstrap}" >&2
+    echo "usage: $0 {workspace|vault-enabled|vault-url|vault-sync-include|vault-sync-exclude|claude-sutando-config-dir|core-config-dir-env-name [type|id]|core-config-dir-value [type|id]|core-config-dirs|dump|subdirs|bootstrap}" >&2
     exit 2
     ;;
 esac

--- a/scripts/sutando-shell-setup.sh
+++ b/scripts/sutando-shell-setup.sh
@@ -145,10 +145,23 @@ claude-sutando() {
     echo "claude-sutando: $repo_root is not a Sutando checkout (missing scripts/sutando-config.sh)" >&2
     return 1
   fi
-  local ccd
-  ccd="$(bash "$repo_root/scripts/sutando-config.sh" claude-sutando-config-dir)" || return 1
+  # v0.9 — read env var NAME and VALUE from core_config_dirs (per-runtime
+  # surface, type=claude entry). Honors user-set `env_name` so the wrapper
+  # could in principle target a non-CLAUDE_CONFIG_DIR var; for Claude
+  # specifically that name doesn't change in practice. Loader has already
+  # validated `synced=true` entries are workspace-relative — if the user set
+  # `synced: false`, they've explicitly opted out of M2 sync coverage for
+  # this memory tree (no warning, by design).
+  local env_name ccd
+  env_name="$(bash "$repo_root/scripts/sutando-config.sh" core-config-dir-env-name claude)"
+  ccd="$(bash "$repo_root/scripts/sutando-config.sh" core-config-dir-value claude)" || return 1
+  [ -z "$env_name" ] && env_name="CLAUDE_CONFIG_DIR"
+  [ -z "$ccd" ] && {
+    echo "claude-sutando: failed to resolve CLAUDE_CONFIG_DIR via core_config_dirs (config missing or invalid)" >&2
+    return 1
+  }
   mkdir -p "$ccd"
-  CLAUDE_CONFIG_DIR="$ccd" command claude "$@"
+  env "$env_name=$ccd" command claude "$@"
 }
 EOF_FUNC
 

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -50,7 +50,12 @@ _LOCAL_FILENAME = "sutando.config.local.json"
 # to teach IDEs strictness for autocomplete; the loader itself stays
 # lenient (warn-only) so users with experimental or scratch keys don't
 # break. Per Mini's review #8 on PR #1395.
-_KNOWN_TOP_LEVEL_KEYS = {"workspace", "claude_sutando_config_dir", "vault"}
+_KNOWN_TOP_LEVEL_KEYS = {
+    "workspace",
+    "claude_sutando_config_dir",
+    "core_config_dirs",
+    "vault",
+}
 
 
 def _find_repo_root(start: Optional[Path] = None) -> Optional[Path]:
@@ -399,24 +404,56 @@ def resolve_vault(repo_root: Optional[Path] = None) -> Dict[str, Any]:
 _DEFAULT_CLAUDE_SUTANDO_SUBDIR = ".claude-sutando"
 
 
+_LEGACY_CLAUDE_SUBDIR_WARN_PRINTED = False
+
+
 def resolve_claude_sutando_config_dir(repo_root: Optional[Path] = None) -> Path:
     """Resolve the CLAUDE_CONFIG_DIR target for the `claude-sutando` shell alias.
 
-    The path is always a sub-folder of `resolve_workspace()` — the M2 vault sync
-    engine relies on this invariant to include the Claude config tree via a single
-    workspace-relative glob. Absolute paths and `..` escapes in the config are
-    rejected at load (schema pattern) AND asserted again here (defense in depth).
+    Resolution order (v0.9):
+      1. `core_config_dirs[type=claude].value` (canonical — new in v0.9). When
+         `synced=true` (default) the value must be under workspace; that
+         invariant is asserted in `resolve_core_config_dirs`.
+      2. `claude_sutando_config_dir.subdir` (LEGACY — one-release deprecation
+         warning). Resolved as `<workspace>/<subdir>`; same constraints as
+         before.
+      3. Baked-in default: `<workspace>/.claude-sutando`.
 
-    Resolution order:
-      1. `claude_sutando_config_dir.subdir` in sutando.config.{local,}.json
-      2. Default: `.claude-sutando`
+    The returned path stays in its un-canonicalized form so callers get a
+    string prefix consistent with `resolve_workspace()` (e.g. on macOS,
+    `/tmp/...` doesn't become `/private/tmp/...` from a stray `.resolve()`).
 
-    Returns the absolute Path. Does NOT create the directory — callers (e.g.
+    Does NOT create the directory; callers (e.g.
     `scripts/sutando-shell-setup.sh`) are responsible for mkdir as part of the
     alias-setup flow.
     """
+    global _LEGACY_CLAUDE_SUBDIR_WARN_PRINTED
+
     cfg = load_config(repo_root)
+
+    # Priority 1: new `core_config_dirs` schema. find_core_config_dir returns
+    # an entry with ${WORKSPACE_DIR}-expanded value AND the synced=true
+    # workspace-relative invariant already validated.
+    if "core_config_dirs" in cfg:
+        entry = find_core_config_dir(type_="claude", repo_root=repo_root)
+        if entry is not None:
+            return Path(entry["value"])
+
+    # Priority 2: legacy `claude_sutando_config_dir.subdir` — one-release
+    # deprecation. Print a stderr nag pointing at the new field.
     block = dict(cfg.get("claude_sutando_config_dir") or {})
+    if block.get("subdir") and not _LEGACY_CLAUDE_SUBDIR_WARN_PRINTED:
+        _LEGACY_CLAUDE_SUBDIR_WARN_PRINTED = True
+        print(
+            _color_warn(
+                "sutando config: `claude_sutando_config_dir.subdir` is deprecated. "
+                "Migrate to `core_config_dirs` (a list of `{id, type, env_name, "
+                "synced, value}` entries) — set `value` to "
+                "`${WORKSPACE_DIR}/<your-subdir>` to preserve current behavior. "
+                "The legacy field will be honored for one release."
+            ),
+            file=sys.stderr,
+        )
     subdir = block.get("subdir") or _DEFAULT_CLAUDE_SUTANDO_SUBDIR
 
     # Defense in depth: re-validate the invariants the schema already enforces
@@ -447,6 +484,149 @@ def resolve_claude_sutando_config_dir(repo_root: Optional[Path] = None) -> Path:
         )
 
     return final
+
+
+# --------------------------------------------------------------------------- #
+#  core_config_dirs (per-runtime CLAUDE_CONFIG_DIR-style env override surface) #
+# --------------------------------------------------------------------------- #
+
+
+_DEFAULT_CORE_CONFIG_DIRS_ENTRY = {
+    "id": "claude-default",
+    "type": "claude",
+    "env_name": "CLAUDE_CONFIG_DIR",
+    "synced": True,
+    "value": "${WORKSPACE_DIR}/.claude-sutando",
+}
+
+
+def _expand_workspace_var(value: str, workspace: Path) -> str:
+    """Expand `${WORKSPACE_DIR}` in the given string against the resolved
+    workspace path. Mirrors `_expand_vars`'s `${REPO_DIR}` treatment but is
+    applied lazily — `${WORKSPACE_DIR}` cannot be resolved at top-level config
+    load time because the workspace path itself is read from config (chicken/
+    egg). Field-level accessors that consume the value call this helper.
+    """
+    return value.replace("${WORKSPACE_DIR}", str(workspace))
+
+
+def resolve_core_config_dirs(repo_root: Optional[Path] = None) -> list:
+    """Resolve the `core_config_dirs` list — per-runtime env override surface.
+
+    Schema (each entry):
+      - `id` (str): unique key within the list (e.g. "claude-default").
+      - `type` (str): runtime tag (e.g. "claude", "codex"). Wrappers select by type.
+      - `env_name` (str): env var name to set (e.g. "CLAUDE_CONFIG_DIR").
+      - `synced` (bool): if true, value MUST resolve under the workspace —
+        the M2 sync engine includes `<workspace>/.claude-sutando/projects/*/memory/`
+        in the carrier, so a `synced: true` value outside the workspace would
+        silently break fleet sync. Loader rejects that combination with a clear
+        error. `synced: false` means "I know this isn't synced; that's
+        intentional" — wrapper sets the env var with no complaint.
+      - `value` (str): absolute path. `${WORKSPACE_DIR}` and `${REPO_DIR}` are
+        expanded. Trailing slashes ignored.
+
+    Defaults: if `core_config_dirs` is absent from the merged config, a single
+    `claude-default` entry is synthesized that mirrors the pre-this-PR
+    behavior (CLAUDE_CONFIG_DIR pointing at `<workspace>/.claude-sutando`,
+    synced=true).
+
+    Returns the list with `${WORKSPACE_DIR}` already expanded in `value`.
+    Raises `ValueError` on invariant violations (synced=true + non-workspace
+    value, duplicate ids, missing required keys).
+    """
+    cfg = load_config(repo_root)
+    raw = cfg.get("core_config_dirs")
+    workspace = resolve_workspace(repo_root)
+
+    if raw is None:
+        # Synthesize the default entry so callers always see a usable list.
+        entries = [dict(_DEFAULT_CORE_CONFIG_DIRS_ENTRY)]
+    elif isinstance(raw, list):
+        entries = [dict(e) if isinstance(e, dict) else e for e in raw]
+    else:
+        raise ValueError(
+            f"core_config_dirs must be a list of objects; got {type(raw).__name__}"
+        )
+
+    seen_ids: set = set()
+    out: list = []
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"core_config_dirs[{i}] must be an object; got {type(entry).__name__}"
+            )
+        # Apply default field values so user-shorthand entries (just type+value)
+        # work. Missing required keys after defaults → error.
+        merged_entry = {**_DEFAULT_CORE_CONFIG_DIRS_ENTRY, **entry}
+        for required in ("id", "type", "env_name", "value"):
+            if not merged_entry.get(required):
+                raise ValueError(
+                    f"core_config_dirs[{i}] missing required key {required!r}"
+                )
+        if merged_entry["id"] in seen_ids:
+            raise ValueError(
+                f"core_config_dirs has duplicate id {merged_entry['id']!r}"
+            )
+        seen_ids.add(merged_entry["id"])
+
+        # Coerce synced to bool — JSON allows true/false; defend against string
+        # forms in case a user typed it as "true".
+        merged_entry["synced"] = bool(merged_entry.get("synced", True))
+
+        # Expand ${WORKSPACE_DIR} in value (note: ${REPO_DIR} was already
+        # expanded at load time by _expand_vars).
+        expanded_value = _expand_workspace_var(str(merged_entry["value"]), workspace)
+        expanded_value = str(Path(expanded_value).expanduser())
+        merged_entry["value"] = expanded_value
+
+        # synced=true invariant: the resolved value must be under the workspace
+        # so M2 sync includes the memory tree. Reject mismatch with a clear
+        # error so the user encodes their intent in config (synced=false to
+        # opt out) instead of debugging silent sync misses later.
+        if merged_entry["synced"]:
+            try:
+                Path(expanded_value).resolve().relative_to(workspace.resolve())
+            except ValueError:
+                raise ValueError(
+                    f"core_config_dirs[{merged_entry['id']!r}] has synced=true "
+                    f"but value={expanded_value!r} is not under workspace "
+                    f"{workspace!s}. The M2 sync engine only tracks paths under "
+                    f"the workspace — set synced=false if this is intentional, "
+                    f"or move value under the workspace."
+                )
+
+        out.append(merged_entry)
+
+    return out
+
+
+def find_core_config_dir(
+    type_: str = "claude",
+    id_: Optional[str] = None,
+    repo_root: Optional[Path] = None,
+) -> Optional[Dict[str, Any]]:
+    """Locate a single `core_config_dirs` entry by type (and optionally id).
+
+    Selection rules:
+      1. If `id_` is given, return the exact-id match (or None).
+      2. Otherwise, return the FIRST entry whose `type` matches.
+      3. Return None if no entry matches.
+
+    Wrappers (e.g. `claude-sutando`) call this with `type_="claude"` to find
+    the right env-var/value pair to apply per invocation. The returned dict
+    has `${WORKSPACE_DIR}` already expanded in `value`.
+    """
+    entries = resolve_core_config_dirs(repo_root)
+    if id_ is not None:
+        for e in entries:
+            if e.get("id") == id_:
+                return e
+        return None
+    for e in entries:
+        if e.get("type") == type_:
+            return e
+    return None
 
 
 def detect_env_workspace_in_dotenv(repo_root: Optional[Path] = None) -> Optional[str]:

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -438,20 +438,20 @@ def resolve_claude_sutando_config_dir(repo_root: Optional[Path] = None) -> Path:
         entry = find_core_config_dir(type_="claude", repo_root=repo_root)
         if entry is not None:
             # When BOTH the new field AND legacy `claude_sutando_config_dir.subdir`
-            # are set, the new field wins silently — warn loudly so the user
-            # knows the legacy config is dead weight (per Mini's PR #1470
-            # review, 2026-06-05). Reuses the one-time nag flag.
+            # are set, that's a CONFIG ERROR — simultaneous presence means the
+            # user has stale config dead-weighting alongside the new schema, and
+            # the legacy block would be silently ignored. Hard-fail rather than
+            # warn (per Chi's directive 2026-06-06 on PR #1470: "simultaneous
+            # presence is a config error that should surface loudly"). The
+            # user must remove `claude_sutando_config_dir` to proceed.
             legacy_subdir = (cfg.get("claude_sutando_config_dir") or {}).get("subdir")
-            if legacy_subdir and not _LEGACY_CLAUDE_SUBDIR_WARN_PRINTED:
-                _LEGACY_CLAUDE_SUBDIR_WARN_PRINTED = True
-                print(
-                    _color_warn(
-                        "sutando config: both `core_config_dirs[type=claude]` AND legacy "
-                        "`claude_sutando_config_dir.subdir` are set. The new field wins; "
-                        "the legacy field is being IGNORED. Remove `claude_sutando_config_dir` "
-                        "from your config to silence this warning."
-                    ),
-                    file=sys.stderr,
+            if legacy_subdir:
+                raise ValueError(
+                    "sutando config: both `core_config_dirs[type=claude]` AND legacy "
+                    "`claude_sutando_config_dir.subdir` are set. This is a config "
+                    "error — only one may be active at a time. The legacy field is "
+                    "deprecated; remove `claude_sutando_config_dir` from your config "
+                    "to proceed with the new `core_config_dirs` schema."
                 )
             return Path(entry["value"])
 

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -437,6 +437,22 @@ def resolve_claude_sutando_config_dir(repo_root: Optional[Path] = None) -> Path:
     if "core_config_dirs" in cfg:
         entry = find_core_config_dir(type_="claude", repo_root=repo_root)
         if entry is not None:
+            # When BOTH the new field AND legacy `claude_sutando_config_dir.subdir`
+            # are set, the new field wins silently — warn loudly so the user
+            # knows the legacy config is dead weight (per Mini's PR #1470
+            # review, 2026-06-05). Reuses the one-time nag flag.
+            legacy_subdir = (cfg.get("claude_sutando_config_dir") or {}).get("subdir")
+            if legacy_subdir and not _LEGACY_CLAUDE_SUBDIR_WARN_PRINTED:
+                _LEGACY_CLAUDE_SUBDIR_WARN_PRINTED = True
+                print(
+                    _color_warn(
+                        "sutando config: both `core_config_dirs[type=claude]` AND legacy "
+                        "`claude_sutando_config_dir.subdir` are set. The new field wins; "
+                        "the legacy field is being IGNORED. Remove `claude_sutando_config_dir` "
+                        "from your config to silence this warning."
+                    ),
+                    file=sys.stderr,
+                )
             return Path(entry["value"])
 
     # Priority 2: legacy `claude_sutando_config_dir.subdir` — one-release
@@ -531,6 +547,12 @@ def resolve_core_config_dirs(repo_root: Optional[Path] = None) -> list:
     behavior (CLAUDE_CONFIG_DIR pointing at `<workspace>/.claude-sutando`,
     synced=true).
 
+    **Opt-out:** to disable env-var setting entirely (no `CLAUDE_CONFIG_DIR`
+    surface, no default synthesis), set `core_config_dirs: []` explicitly in
+    your config. An empty list is honored as "no entries" and wrappers see an
+    empty result. Deleting the key falls through to default synthesis above
+    (NOT the same as opt-out).
+
     Returns the list with `${WORKSPACE_DIR}` already expanded in `value`.
     Raises `ValueError` on invariant violations (synced=true + non-workspace
     value, duplicate ids, missing required keys).
@@ -616,6 +638,12 @@ def find_core_config_dir(
     Wrappers (e.g. `claude-sutando`) call this with `type_="claude"` to find
     the right env-var/value pair to apply per invocation. The returned dict
     has `${WORKSPACE_DIR}` already expanded in `value`.
+
+    **Multi-entry-per-type disambiguation:** when more than one entry shares
+    a `type` (e.g. `claude-personal` + `claude-work`), this function returns
+    whichever appears FIRST in the config — which is brittle if config order
+    is incidental. Pass `id_` explicitly to disambiguate in that case (e.g.
+    `find_core_config_dir(type_="claude", id_="claude-work")`).
     """
     entries = resolve_core_config_dirs(repo_root)
     if id_ is not None:

--- a/sutando.config.json
+++ b/sutando.config.json
@@ -2,6 +2,15 @@
   "workspace": {
     "path": "${REPO_DIR}/workspace"
   },
+  "core_config_dirs": [
+    {
+      "id": "claude-default",
+      "type": "claude",
+      "env_name": "CLAUDE_CONFIG_DIR",
+      "synced": true,
+      "value": "${WORKSPACE_DIR}/.claude-sutando"
+    }
+  ],
   "vault": {
     "enabled": false,
     "remote_url": "",

--- a/tests/sutando-config.test.py
+++ b/tests/sutando-config.test.py
@@ -575,19 +575,19 @@ class TestSutandoConfig(unittest.TestCase):
         self.assertEqual(codex["env_name"], "CODEX_CONFIG_DIR")
 
     def test_resolve_claude_sutando_config_dir_prefers_core_config_dirs(self):
-        # When both old and new fields are set, the new schema wins. The
-        # legacy field's deprecation path is exercised by a different test.
+        # When the new schema is set (legacy field absent), the new schema
+        # wins. The legacy field's deprecation path is exercised by a
+        # different test. Both-set is now a hard-fail per Chi's directive
+        # 2026-06-06 — covered by `test_raises_when_both_set` below.
         _write_config(self.repo, "sutando.config.json", {
             "core_config_dirs": [{
                 "id": "main", "type": "claude",
                 "env_name": "CLAUDE_CONFIG_DIR", "synced": True,
                 "value": "${WORKSPACE_DIR}/state/new-path",
             }],
-            "claude_sutando_config_dir": {"subdir": "legacy-subdir"},
         })
         ccd = resolve_claude_sutando_config_dir(repo_root=self.repo)
         ws = resolve_workspace(repo_root=self.repo)
-        # New schema chosen; legacy subdir ignored.
         self.assertEqual(str(ccd), str(ws / "state/new-path"))
 
     def test_resolve_claude_sutando_config_dir_legacy_subdir_still_honored(self):
@@ -602,20 +602,13 @@ class TestSutandoConfig(unittest.TestCase):
         # without ${WORKSPACE_DIR} expansion semantics.
         self.assertEqual(ccd, (ws / "my-legacy-claude").resolve())
 
-    def test_resolve_claude_sutando_config_dir_warns_when_both_set(self):
-        # Mini's blocker fix (PR #1470 review, 2026-06-05): when BOTH the new
-        # `core_config_dirs[type=claude]` AND legacy `claude_sutando_config_dir.subdir`
-        # are set, the new field wins — and the user MUST see a loud warning
-        # so they know to remove the dead legacy config. Without this, stale
-        # config persists silently.
-        import io
-        import contextlib
-        import sutando_config
-
-        # Reset the one-time nag flag so the warn fires deterministically in
-        # this test (other tests may have already tripped it).
-        sutando_config._LEGACY_CLAUDE_SUBDIR_WARN_PRINTED = False
-
+    def test_resolve_claude_sutando_config_dir_raises_when_both_set(self):
+        # Per Chi's directive 2026-06-06 on PR #1470: when BOTH the new
+        # `core_config_dirs[type=claude]` AND legacy
+        # `claude_sutando_config_dir.subdir` are set, that's a config error
+        # and must hard-fail (NOT warn). Simultaneous presence means the
+        # legacy block would be silently ignored — the user MUST be forced
+        # to remove the dead config before the resolver returns a path.
         _write_config(self.repo, "sutando.config.json", {
             "core_config_dirs": [{
                 "id": "main", "type": "claude",
@@ -624,29 +617,26 @@ class TestSutandoConfig(unittest.TestCase):
             }],
             "claude_sutando_config_dir": {"subdir": "legacy-subdir"},
         })
-        stderr_buf = io.StringIO()
-        with contextlib.redirect_stderr(stderr_buf):
-            ccd = resolve_claude_sutando_config_dir(repo_root=self.repo)
-        ws = resolve_workspace(repo_root=self.repo)
-        # New schema still wins (semantic unchanged from earlier test).
-        self.assertEqual(str(ccd), str(ws / "state/new-path"))
-        # But the warn MUST fire — keywords from the message body.
-        stderr_text = stderr_buf.getvalue()
-        self.assertIn("both", stderr_text.lower(),
-                      f"expected 'both' in warn; got: {stderr_text!r}")
-        self.assertIn("claude_sutando_config_dir", stderr_text,
-                      f"expected legacy field name in warn; got: {stderr_text!r}")
-        self.assertIn("IGNORED", stderr_text,
-                      f"expected 'IGNORED' to convey that legacy is dead; got: {stderr_text!r}")
+        with self.assertRaises(ValueError) as ctx:
+            resolve_claude_sutando_config_dir(repo_root=self.repo)
+        msg = str(ctx.exception)
+        # Error must clearly name both fields + identify it as a config error
+        # so the user can find what to remove.
+        self.assertIn("both", msg.lower(),
+                      f"expected 'both' in error; got: {msg!r}")
+        self.assertIn("core_config_dirs", msg,
+                      f"expected new field name in error; got: {msg!r}")
+        self.assertIn("claude_sutando_config_dir", msg,
+                      f"expected legacy field name in error; got: {msg!r}")
+        self.assertIn("config error", msg.lower(),
+                      f"expected 'config error' to surface the class; got: {msg!r}")
 
-    def test_resolve_claude_sutando_config_dir_no_warn_when_only_new_set(self):
-        # Symmetric guard: when ONLY the new field is set (no legacy), the
-        # warn must NOT fire. Otherwise users on the new path get noise.
+    def test_resolve_claude_sutando_config_dir_no_error_when_only_new_set(self):
+        # Symmetric guard: when ONLY the new field is set (no legacy block),
+        # resolution succeeds silently. Otherwise users on the clean new
+        # path would hit the hard-fail erroneously.
         import io
         import contextlib
-        import sutando_config
-
-        sutando_config._LEGACY_CLAUDE_SUBDIR_WARN_PRINTED = False
 
         _write_config(self.repo, "sutando.config.json", {
             "core_config_dirs": [{

--- a/tests/sutando-config.test.py
+++ b/tests/sutando-config.test.py
@@ -35,7 +35,9 @@ from sutando_config import (  # noqa: E402
     _strip_comments,
     detect_env_workspace_in_dotenv,
     load_config,
+    find_core_config_dir,
     resolve_claude_sutando_config_dir,
+    resolve_core_config_dirs,
     resolve_vault,
     resolve_workspace,
 )
@@ -471,6 +473,136 @@ class TestSutandoConfig(unittest.TestCase):
         # the loader DOES read it. Caught 2026-06-02 in commit 1 review.
         self.assertNotIn("does not read", buf.getvalue())
         self.assertNotIn("claude_sutando_config_dir", buf.getvalue())
+
+    # ------------------------------------------------------------------ #
+    #  10. core_config_dirs — v0.9 per-runtime env override surface       #
+    # ------------------------------------------------------------------ #
+
+    def test_core_config_dirs_synthesized_default_when_field_absent(self):
+        # No `core_config_dirs` in config → loader synthesizes a single
+        # claude-default entry so callers always get a usable list.
+        _write_config(self.repo, "sutando.config.json", {})
+        entries = resolve_core_config_dirs(repo_root=self.repo)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["id"], "claude-default")
+        self.assertEqual(entries[0]["type"], "claude")
+        self.assertEqual(entries[0]["env_name"], "CLAUDE_CONFIG_DIR")
+        self.assertTrue(entries[0]["synced"])
+        ws = resolve_workspace(repo_root=self.repo)
+        self.assertEqual(entries[0]["value"], str(ws / ".claude-sutando"))
+
+    def test_core_config_dirs_workspace_dir_token_expands(self):
+        # ${WORKSPACE_DIR} should expand to the resolved workspace.
+        _write_config(self.repo, "sutando.config.json", {
+            "core_config_dirs": [{
+                "id": "main",
+                "type": "claude",
+                "env_name": "CLAUDE_CONFIG_DIR",
+                "synced": True,
+                "value": "${WORKSPACE_DIR}/state/cc",
+            }],
+        })
+        entries = resolve_core_config_dirs(repo_root=self.repo)
+        ws = resolve_workspace(repo_root=self.repo)
+        self.assertEqual(entries[0]["value"], str(ws / "state/cc"))
+
+    def test_core_config_dirs_synced_true_rejects_outside_workspace(self):
+        # synced=true means M2 sync must be able to track this tree. A value
+        # outside the workspace would silently break that, so the loader
+        # rejects with a clear error.
+        _write_config(self.repo, "sutando.config.json", {
+            "core_config_dirs": [{
+                "id": "main",
+                "type": "claude",
+                "env_name": "CLAUDE_CONFIG_DIR",
+                "synced": True,
+                "value": "/etc/claude-state",  # outside the workspace
+            }],
+        })
+        with self.assertRaises(ValueError) as cm:
+            resolve_core_config_dirs(repo_root=self.repo)
+        self.assertIn("synced=true", str(cm.exception))
+        self.assertIn("not under workspace", str(cm.exception))
+
+    def test_core_config_dirs_synced_false_allows_outside_workspace(self):
+        # synced=false is the explicit opt-out — wrapper sets the env var,
+        # user knows M2 sync skip this tree, no warning.
+        _write_config(self.repo, "sutando.config.json", {
+            "core_config_dirs": [{
+                "id": "local-only",
+                "type": "claude",
+                "env_name": "CLAUDE_CONFIG_DIR",
+                "synced": False,
+                "value": "/etc/claude-state",
+            }],
+        })
+        entries = resolve_core_config_dirs(repo_root=self.repo)
+        self.assertEqual(entries[0]["value"], "/etc/claude-state")
+        self.assertFalse(entries[0]["synced"])
+
+    def test_core_config_dirs_duplicate_id_raises(self):
+        _write_config(self.repo, "sutando.config.json", {
+            "core_config_dirs": [
+                {"id": "main", "type": "claude",
+                 "env_name": "CLAUDE_CONFIG_DIR", "synced": True,
+                 "value": "${WORKSPACE_DIR}/.claude-sutando"},
+                {"id": "main", "type": "codex",
+                 "env_name": "CODEX_CONFIG_DIR", "synced": False,
+                 "value": "/tmp/codex"},
+            ],
+        })
+        with self.assertRaises(ValueError) as cm:
+            resolve_core_config_dirs(repo_root=self.repo)
+        self.assertIn("duplicate id", str(cm.exception))
+
+    def test_find_core_config_dir_picks_first_type_match(self):
+        _write_config(self.repo, "sutando.config.json", {
+            "core_config_dirs": [
+                {"id": "alt", "type": "codex",
+                 "env_name": "CODEX_CONFIG_DIR", "synced": False,
+                 "value": "/tmp/codex"},
+                {"id": "main", "type": "claude",
+                 "env_name": "CLAUDE_CONFIG_DIR", "synced": True,
+                 "value": "${WORKSPACE_DIR}/.claude-sutando"},
+            ],
+        })
+        entry = find_core_config_dir(type_="claude", repo_root=self.repo)
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry["id"], "main")
+        # By-id selection independent of type:
+        codex = find_core_config_dir(type_="claude", id_="alt", repo_root=self.repo)
+        self.assertIsNotNone(codex)
+        self.assertEqual(codex["env_name"], "CODEX_CONFIG_DIR")
+
+    def test_resolve_claude_sutando_config_dir_prefers_core_config_dirs(self):
+        # When both old and new fields are set, the new schema wins. The
+        # legacy field's deprecation path is exercised by a different test.
+        _write_config(self.repo, "sutando.config.json", {
+            "core_config_dirs": [{
+                "id": "main", "type": "claude",
+                "env_name": "CLAUDE_CONFIG_DIR", "synced": True,
+                "value": "${WORKSPACE_DIR}/state/new-path",
+            }],
+            "claude_sutando_config_dir": {"subdir": "legacy-subdir"},
+        })
+        ccd = resolve_claude_sutando_config_dir(repo_root=self.repo)
+        ws = resolve_workspace(repo_root=self.repo)
+        # New schema chosen; legacy subdir ignored.
+        self.assertEqual(str(ccd), str(ws / "state/new-path"))
+
+    def test_resolve_claude_sutando_config_dir_legacy_subdir_still_honored(self):
+        # When only the legacy field is set (no core_config_dirs), the loader
+        # honors it for one release with a deprecation warning.
+        _write_config(self.repo, "sutando.config.json", {
+            "claude_sutando_config_dir": {"subdir": "my-legacy-claude"},
+        })
+        ccd = resolve_claude_sutando_config_dir(repo_root=self.repo)
+        ws = resolve_workspace(repo_root=self.repo)
+        # .resolve() because the legacy path goes through workspace / subdir
+        # without ${WORKSPACE_DIR} expansion semantics.
+        self.assertEqual(ccd, (ws / "my-legacy-claude").resolve())
+
+    # ------------------------------------------------------------------ #
 
     def test_expand_vars_walks_nested_structures(self):
         out = _expand_vars({"path": "${REPO_DIR}/ws",

--- a/tests/sutando-config.test.py
+++ b/tests/sutando-config.test.py
@@ -602,6 +602,70 @@ class TestSutandoConfig(unittest.TestCase):
         # without ${WORKSPACE_DIR} expansion semantics.
         self.assertEqual(ccd, (ws / "my-legacy-claude").resolve())
 
+    def test_resolve_claude_sutando_config_dir_warns_when_both_set(self):
+        # Mini's blocker fix (PR #1470 review, 2026-06-05): when BOTH the new
+        # `core_config_dirs[type=claude]` AND legacy `claude_sutando_config_dir.subdir`
+        # are set, the new field wins — and the user MUST see a loud warning
+        # so they know to remove the dead legacy config. Without this, stale
+        # config persists silently.
+        import io
+        import contextlib
+        import sutando_config
+
+        # Reset the one-time nag flag so the warn fires deterministically in
+        # this test (other tests may have already tripped it).
+        sutando_config._LEGACY_CLAUDE_SUBDIR_WARN_PRINTED = False
+
+        _write_config(self.repo, "sutando.config.json", {
+            "core_config_dirs": [{
+                "id": "main", "type": "claude",
+                "env_name": "CLAUDE_CONFIG_DIR", "synced": True,
+                "value": "${WORKSPACE_DIR}/state/new-path",
+            }],
+            "claude_sutando_config_dir": {"subdir": "legacy-subdir"},
+        })
+        stderr_buf = io.StringIO()
+        with contextlib.redirect_stderr(stderr_buf):
+            ccd = resolve_claude_sutando_config_dir(repo_root=self.repo)
+        ws = resolve_workspace(repo_root=self.repo)
+        # New schema still wins (semantic unchanged from earlier test).
+        self.assertEqual(str(ccd), str(ws / "state/new-path"))
+        # But the warn MUST fire — keywords from the message body.
+        stderr_text = stderr_buf.getvalue()
+        self.assertIn("both", stderr_text.lower(),
+                      f"expected 'both' in warn; got: {stderr_text!r}")
+        self.assertIn("claude_sutando_config_dir", stderr_text,
+                      f"expected legacy field name in warn; got: {stderr_text!r}")
+        self.assertIn("IGNORED", stderr_text,
+                      f"expected 'IGNORED' to convey that legacy is dead; got: {stderr_text!r}")
+
+    def test_resolve_claude_sutando_config_dir_no_warn_when_only_new_set(self):
+        # Symmetric guard: when ONLY the new field is set (no legacy), the
+        # warn must NOT fire. Otherwise users on the new path get noise.
+        import io
+        import contextlib
+        import sutando_config
+
+        sutando_config._LEGACY_CLAUDE_SUBDIR_WARN_PRINTED = False
+
+        _write_config(self.repo, "sutando.config.json", {
+            "core_config_dirs": [{
+                "id": "main", "type": "claude",
+                "env_name": "CLAUDE_CONFIG_DIR", "synced": True,
+                "value": "${WORKSPACE_DIR}/state/new-path",
+            }],
+            # NO claude_sutando_config_dir block at all
+        })
+        stderr_buf = io.StringIO()
+        with contextlib.redirect_stderr(stderr_buf):
+            ccd = resolve_claude_sutando_config_dir(repo_root=self.repo)
+        ws = resolve_workspace(repo_root=self.repo)
+        self.assertEqual(str(ccd), str(ws / "state/new-path"))
+        # Stderr should be silent — no both-set warn, no legacy deprecation warn.
+        stderr_text = stderr_buf.getvalue()
+        self.assertEqual(stderr_text, "",
+                         f"expected silent stderr on new-only path; got: {stderr_text!r}")
+
     # ------------------------------------------------------------------ #
 
     def test_expand_vars_walks_nested_structures(self):


### PR DESCRIPTION
## Workspace-revamp milestone status

| Milestone | PRs | Status |
|---|---|---|
| **M0** — in-repo workspace default + config-driven resolution | #1395, #1397, #1399, #1415, #1429 | ✅ shipped |
| **M1** — migration script + skill + supporting hardening | #1403, #1406, #1424, #1430, #1431, #1432 | ✅ shipped |
| **0.3rc8** — strip `\$SUTANDO_WORKSPACE` from resolver | #1440 | ✅ shipped |
| **M2** — sync engine | #1445, #1446, #1447, #1458, #1459, #1460, #1461 | ✅ shipped |
| **0.3rc9** — `core_config_dirs` per-runtime env-override schema | **this PR** | 🟡 in flight |
| **M3** — docs sweep + dogfooding + E2E | follow-up PRs | 🟡 in flight |

## Summary

Introduces `core_config_dirs` — a list-based schema in `sutando.config.json` where each entry declares which env var to set, what path to set it to, and whether that path should be vault-synced. Replaces the single-purpose `claude_sutando_config_dir.subdir` field with an extensible per-runtime surface (Claude today; Codex / other runtimes later).

Example shipped default:
\`\`\`json
\"core_config_dirs\": [
  {
    \"id\": \"claude-default\",
    \"type\": \"claude\",
    \"env_name\": \"CLAUDE_CONFIG_DIR\",
    \"synced\": true,
    \"value\": \"\${WORKSPACE_DIR}/.claude-sutando\"
  }
]
\`\`\`

## Why now

Sutando's runtime story is expanding past \"just Claude\" — the \`claude-codex\` and \`claude-gemini\` skills are mature, OpenACP is wired up, and \"per-runtime config-dir env override\" is the natural seam to make multi-runtime stable instead of ad-hoc env-export incantations. Doing it under workspace-revamp (instead of separately) lets the 0.3rc9 schema bake in the \`\${WORKSPACE_DIR}\` token from day one, which the M2 sync invariant relies on.

## Resolution order in \`resolve_claude_sutando_config_dir\`

1. **\`core_config_dirs[type=claude].value\`** — canonical path. \`\${WORKSPACE_DIR}\` lazily expanded after workspace resolves. When \`synced=true\` (default), the resolved path is asserted under workspace at load time.
2. **\`claude_sutando_config_dir.subdir\`** — legacy, one-release deprecation. A stderr nag tells migrators: *\"use \`\${WORKSPACE_DIR}/<your-subdir>\` to preserve current behavior.\"*
3. **Baked default** — \`<workspace>/.claude-sutando\`, what users get if neither field is set.

Precedence ensures both-coexist case is unambiguous and forward-compatible: new wins, legacy warns, default backstops.

## What's in this PR

| File | Change |
|---|---|
| \`sutando.config.json\` | adds \`core_config_dirs\` block with shipped default |
| \`src/sutando_config.py\` | +198 LOC: known-keys, lazy \`\${WORKSPACE_DIR}\` expander, \`resolve_core_config_dirs\`, \`find_core_config_dir\`, \`_LEGACY_CLAUDE_SUBDIR_WARN_PRINTED\` deprecation gate, Priority-1 routing in \`resolve_claude_sutando_config_dir\` |
| \`tests/sutando-config.test.py\` | +132 LOC, 6 new tests (section 10) |
| \`scripts/sutando-config.sh\` | 2 new subcommands: \`core-config-dir-env-name\`, \`core-config-dir-value\` |
| \`scripts/sutando-shell-setup.sh\` | wrapper reads \`env_name\` + \`value\` from chosen entry; calls \`env \"\$env_name=\$ccd\" command claude\` instead of hardcoding \`CLAUDE_CONFIG_DIR=\` |

## Test plan

- \`python3 tests/sutando-config.test.py\` — 38/38 pass (6 new in section 10).
- Manual: \`bash scripts/sutando-shell-setup.sh --commit\` then \`which claude-sutando\` then \`claude-sutando\` — verify the wrapper exports \`CLAUDE_CONFIG_DIR=<workspace>/.claude-sutando\` and launches.
- Legacy-coexist smoke: temporarily add \`claude_sutando_config_dir.subdir: \".test-legacy\"\` to \`sutando.config.local.json\` — new wins, stderr emits the one-time deprecation nag.

## Evaluation

- **Synthetic correctness**: 6 new tests cover the synthesized-default, token expansion, sync-invariant validation, legacy coexistence, and deprecation-warning gate.
- **Real-user shadow**: I (Sutando-Qingyun) will dogfood by switching this checkout's \`sutando.config.local.json\` to declare a non-default value AND a \`codex\` entry, then exercising both wrappers across 1-2 dev sessions. M3 follow-up will codify the dogfooding doc.

## Followups (out of scope for this PR)

- **M3 docs sweep**: update \`docs/workspace-design.md\` and \`CLAUDE.md\` workspace section to reference \`core_config_dirs\` as the canonical surface.
- **Codex / Gemini runtime entries**: ship example \`core_config_dirs\` entries for the other runtimes once their respective skill paths stabilize.
- **AGENTS.md commit**: the untracked Codex-flavored sibling of CLAUDE.md is held out of this PR (unrelated scope; 4 intentional diffs from CLAUDE.md per my scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

