### PR TITLE
fix(wire-list): skip cleanly when YOUTUBE_API_KEY is unset

### DIFF
--- a/scripts/regen-wire-list.py
+++ b/scripts/regen-wire-list.py
@@ -245,6 +245,15 @@ def main():
     )
     args = ap.parse_args()
 
+    if not os.environ.get("YOUTUBE_API_KEY"):
+        # Optional enrichment job: with no API key configured there is nothing
+        # to regen. Skip cleanly (exit 0) instead of hard-failing — the
+        # scheduled workflow runs on every fork, and a fork without the secret
+        # set should not email a failure notification every day. The downstream
+        # "Open PR if changed" step then sees no diff and no-ops.
+        print("YOUTUBE_API_KEY not set — skipping WIRE list regen (no-op).")
+        return
+
     uploads_playlist = resolve_uploads_playlist(PLAYLIST_ID)
     items = fetch_playlist_videos(uploads_playlist)
     if not items:


### PR DESCRIPTION
## Problem

The `regen-wire-list` scheduled workflow (added in #915, enhanced in #1351) runs on every fork. On any fork **without** the `YOUTUBE_API_KEY` secret configured, `scripts/regen-wire-list.py` hard-fails on the first API call:

```
RuntimeError: YOUTUBE_API_KEY not set
```

Because the job is on a daily `schedule:` cron, this emails a **failure notification every single day** to fork owners who haven't (and may never) set the secret. The WIRE list is optional enrichment — a missing key should be a no-op, not a hard error.

## Fix

Guard `main()` so a missing/empty `YOUTUBE_API_KEY` is a clean exit-0 no-op (9 lines). The optional regen simply doesn't run, and the downstream "Open PR if changed" step sees no diff and no-ops.

```python
if not os.environ.get("YOUTUBE_API_KEY"):
    print("YOUTUBE_API_KEY not set — skipping WIRE list regen (no-op).")
    return
```

## Verification

- `python3 -m py_compile scripts/regen-wire-list.py` — passes
- `env -u YOUTUBE_API_KEY python3 scripts/regen-wire-list.py --dry-run` → prints the skip message, **exits 0**
- No behavior change when the key **is** set — falls through to the existing path unchanged.

The guard sits at the very top of `main()`, before any API call, so no network access is attempted when the key is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)