### PR TITLE
feat(sutando-migrate): pre-flight scan + per-file progress reporter [DRAFT]

### DIFF
--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1509,10 +1509,17 @@ commit_main() {
     # ask y/N before any destructive write. Skipped on phase-2 delete-only runs
     # (no copy walk happens) and on explicit --no-confirm + non-TTY stdin.
     # Captures total file count for progress-bar denominator.
+    #
+    # CRITICAL: `exit N` inside the $(preflight_summary) subshell does NOT
+    # propagate to this parent — bash captures stdout + exit code into $? but
+    # does NOT abort the calling script. Without the explicit `|| exit $?`
+    # below, a user typing "n" at the confirm prompt would see "Aborted"
+    # but then backup_dest + commit_source would run anyway (data-equivalent
+    # bug: the user said no, the script does it). Catch the abort here.
     PROGRESS_N=0
     PROGRESS_TOTAL=0
     if [ "$DELETE_SOURCE" = "0" ] || [ -z "$ROLLBACK_ID" ]; then
-        PROGRESS_TOTAL="$(preflight_summary)"
+        PROGRESS_TOTAL="$(preflight_summary)" || exit $?
     fi
 
     backup_dest

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -587,6 +587,7 @@ MERGE_APPEND=0
 DELETE_SOURCE=0
 FORCE=0
 ROLLBACK_ID=""
+NO_CONFIRM=0
 
 EXPLAIN_PATH=""
 while [ $# -gt 0 ]; do
@@ -613,6 +614,7 @@ while [ $# -gt 0 ]; do
         --force) FORCE=1; shift ;;
         --respect-env) RESPECT_ENV=1; shift ;;
         --backup-id) ROLLBACK_ID="$2"; shift 2 ;;
+        --no-confirm|--yes|-y) NO_CONFIRM=1; shift ;;  # skip pre-flight prompt (for CI / scripted runs)
         --help|-h)
             sed -n '1,80p' "${BASH_SOURCE[0]}"
             exit 0
@@ -856,6 +858,103 @@ copy_preserving_mtime() {
     # Atomic: cp -p to sibling tmp then mv. -p preserves mtime + mode.
     local tmp="$dst.tmp.$$"
     cp -p "$src" "$tmp" && mv -f "$tmp" "$dst"
+}
+
+# Human-readable byte size: 1234 → "1.2 KB", 5242880 → "5.0 MB", etc.
+humanize_bytes() {
+    local b="$1"
+    [ -z "$b" ] && { echo "0 B"; return; }
+    awk -v b="$b" 'BEGIN{
+        split("B KB MB GB TB", u);
+        for (i=1; i<=5 && b>=1024; i++) b/=1024;
+        if (i==1) printf "%d %s", b, u[i]; else printf "%.1f %s", b, u[i];
+    }'
+}
+
+# Format seconds as "Nm Ms" or "Nh Mm" for human-readable durations.
+format_duration() {
+    local s="$1"
+    [ -z "$s" ] || [ "$s" -lt 1 ] && { echo "<1s"; return; }
+    if [ "$s" -lt 60 ]; then printf "%ds" "$s"
+    elif [ "$s" -lt 3600 ]; then printf "%dm %ds" $((s/60)) $((s%60))
+    else printf "%dh %dm" $((s/3600)) $(((s%3600)/60))
+    fi
+}
+
+# Pre-flight scan: count files + bytes across enabled sources, print summary,
+# emit estimated copy time, and (unless --no-confirm or non-TTY) prompt the
+# operator to confirm before any destructive write happens.
+#
+# Owner ask 2026-06-05: large-workspace migrations felt opaque — the user
+# waited a long time with no signal whether things were progressing. The
+# fix is two-pronged: (1) tell them upfront how big the job is, and (2)
+# emit per-file progress lines during the copy itself (see commit_source).
+#
+# Populates PROGRESS_TOTAL (set in commit_main) by side effect via echo to
+# stdout — the caller captures the count via $(...).
+preflight_summary() {
+    local _total_files=0 _total_bytes=0
+    local _per_source_lines=""
+    local tag src files bytes
+    for tag in A B C; do
+        case "$tag" in
+            A) src="$A_REAL_OK" ;;
+            B) src="$B_REAL_OK" ;;
+            C) src="$C_REAL_OK" ;;
+        esac
+        [ -z "$src" ] && continue
+        include_src "$tag" || continue
+        # Walk the same surface as commit_source — but conservatively (just
+        # count everything; quarantine + skip rules apply later). Overcount
+        # is acceptable; this is an estimate, not an audit.
+        files="$(find "$src" -type f 2>/dev/null | wc -l | tr -d ' ')"
+        bytes="$(find "$src" -type f -print0 2>/dev/null | xargs -0 stat -f '%z' 2>/dev/null \
+                 | awk '{s+=$1} END {print s+0}')"
+        # Linux fallback (BSD stat differs):
+        if [ -z "$bytes" ] || [ "$bytes" = "0" ]; then
+            bytes="$(find "$src" -type f -printf '%s\n' 2>/dev/null | awk '{s+=$1} END {print s+0}')"
+        fi
+        _total_files=$((_total_files + files))
+        _total_bytes=$((_total_bytes + bytes))
+        _per_source_lines+="  $tag ($src): $files files, $(humanize_bytes "$bytes")"$'\n'
+    done
+
+    # Rough ETA: 200 MB/s sustained APFS local. Conservative; SSD-bound media
+    # workloads land here. Spinning disks would be slower; cloud/network
+    # mounts unpredictable — caller should sanity-check the estimate.
+    local _bytes_per_sec=$((200 * 1024 * 1024))
+    local _eta_sec=$((_total_bytes / _bytes_per_sec))
+    [ "$_eta_sec" -lt 1 ] && _eta_sec=1
+
+    {
+        echo "sutando-migrate: pre-flight scan"
+        printf "%s" "$_per_source_lines"
+        echo "  TOTAL: $_total_files files, $(humanize_bytes "$_total_bytes")"
+        echo "  Estimated copy time: ~$(format_duration "$_eta_sec") at ~200 MB/s sustained (rough)"
+        echo
+    } >&2
+
+    # Confirm prompt — skipped on --no-confirm or when stdin is not a TTY
+    # (non-interactive runs: CI, cron, scripted batch).
+    if [ "$NO_CONFIRM" = "0" ] && [ -t 0 ]; then
+        printf "  Proceed with copy? [y/N]: " >&2
+        local _answer
+        read -r _answer
+        case "$_answer" in
+            y|Y|yes|YES) ;;
+            *)
+                echo "  Aborted by operator." >&2
+                exit 3
+                ;;
+        esac
+        echo >&2
+    elif [ "$NO_CONFIRM" = "0" ] && [ ! -t 0 ]; then
+        echo "  (non-interactive stdin; skipping confirm — pass --no-confirm to suppress this message)" >&2
+        echo >&2
+    fi
+
+    # Output total file count for the caller to capture (PROGRESS_TOTAL).
+    echo "$_total_files"
 }
 
 # SHA-256 verify (macOS shasum / Linux sha256sum). Returns 0 if hashes match.
@@ -1273,6 +1372,22 @@ commit_source() {
         fi
         cls="$(classify "$rel")"
         outcome="$(commit_one "$file" "$rel" "$tag" "$cls")"
+        # Per-file progress on stderr — visible feedback during the copy walk
+        # so long migrations don't feel like a hang. Skipped when PROGRESS_TOTAL
+        # is 0 (delete-source phase-2 path; pre-flight didn't run).
+        if [ "$PROGRESS_TOTAL" -gt 0 ]; then
+            PROGRESS_N=$((PROGRESS_N + 1))
+            _fsize="$(stat -f %z "$file" 2>/dev/null || stat -c %s "$file" 2>/dev/null || echo 0)"
+            printf "  [%d/%d] %s (%s) → %s\n" \
+                "$PROGRESS_N" "$PROGRESS_TOTAL" "${rel:0:60}" \
+                "$(humanize_bytes "$_fsize")" "$outcome" >&2
+            # Every 20 files: aggregate progress + ETA refinement
+            if [ $((PROGRESS_N % 20)) -eq 0 ] && [ "$PROGRESS_N" -lt "$PROGRESS_TOTAL" ]; then
+                _pct=$((PROGRESS_N * 100 / PROGRESS_TOTAL))
+                printf "  ─── progress: %d/%d (%d%%) ───\n" \
+                    "$PROGRESS_N" "$PROGRESS_TOTAL" "$_pct" >&2
+            fi
+        fi
         case "$outcome" in
             copied|src-wins-newer|src-newer|rehomed|rehomed-newer|merged|archived-stale|copied-stale)
                 n_copied=$((n_copied+1)) ;;
@@ -1389,6 +1504,16 @@ commit_main() {
     echo "  append:     $([ "$MERGE_APPEND" = "1" ] && echo "merge (Strategy B)" || echo "sidecar (Strategy C — default)")"
     echo "  delete src: $([ "$DELETE_SOURCE" = "1" ] && echo "yes (backup-id=$ROLLBACK_ID)" || echo "no — sources preserved (default; matches workspace_m1_no_auto_commit)")"
     echo
+
+    # Pre-flight scan: tell the operator how big the job is + estimated time +
+    # ask y/N before any destructive write. Skipped on phase-2 delete-only runs
+    # (no copy walk happens) and on explicit --no-confirm + non-TTY stdin.
+    # Captures total file count for progress-bar denominator.
+    PROGRESS_N=0
+    PROGRESS_TOTAL=0
+    if [ "$DELETE_SOURCE" = "0" ] || [ -z "$ROLLBACK_ID" ]; then
+        PROGRESS_TOTAL="$(preflight_summary)"
+    fi
 
     backup_dest
     echo

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1516,9 +1516,14 @@ commit_main() {
     # below, a user typing "n" at the confirm prompt would see "Aborted"
     # but then backup_dest + commit_source would run anyway (data-equivalent
     # bug: the user said no, the script does it). Catch the abort here.
+    # Preflight runs whenever there's a copy walk. The phase-2 delete-only
+    # path (--delete-source --backup-id) is the only invocation that skips
+    # the copy walk → skip preflight there too. Mini's polish at L1378
+    # already hard-errors on `--delete-source` without `--backup-id`, so
+    # the bare DELETE_SOURCE=0 check is sufficient.
     PROGRESS_N=0
     PROGRESS_TOTAL=0
-    if [ "$DELETE_SOURCE" = "0" ] || [ -z "$ROLLBACK_ID" ]; then
+    if [ "$DELETE_SOURCE" = "0" ]; then
         PROGRESS_TOTAL="$(preflight_summary)" || exit $?
     fi
 

--- a/tests/sutando-migrate-preflight.test.sh
+++ b/tests/sutando-migrate-preflight.test.sh
@@ -79,6 +79,33 @@ grep -q 'printf "  \\\[%d/%d\\\] %s (%s) → %s\\\\n"' "$MIGRATE" \
 grep -q "PROGRESS_TOTAL" "$MIGRATE" || { echo "  FAIL: PROGRESS_TOTAL variable missing"; fail=1; }
 grep -q "PROGRESS_N" "$MIGRATE" || { echo "  FAIL: PROGRESS_N counter missing"; fail=1; }
 
+# ── Test 6: abort-propagation guard at the preflight_summary call site
+# Critical: `exit N` inside $(preflight_summary) subshell doesn't propagate
+# to the parent script — bash captures stdout + exit code in $? but the
+# parent continues. Without the `|| exit $?` guard, a user typing "n" at
+# the confirm prompt would see "Aborted" but backup_dest + commit_source
+# would run anyway. Caught in self-cold-review 2026-06-06.
+grep -q 'PROGRESS_TOTAL="\$(preflight_summary)" || exit \$?' "$MIGRATE" \
+    || { echo "  FAIL: abort-propagation guard '|| exit \$?' missing on preflight_summary call site"; fail=1; }
+
+# ── Test 7: synthetic end-to-end abort behavior with stub preflight
+# Verify the guard pattern actually works: if the captured-subshell exits N,
+# the parent script also exits N AND the line after the assignment is NOT
+# reached. `|| true` on this line absorbs the non-zero so `set -e` doesn't
+# trip before we inspect $?.
+abort_test_result="$(bash -c '
+    fake_preflight() { echo "100"; exit 3; }
+    PROGRESS_TOTAL=0
+    PROGRESS_TOTAL="$(fake_preflight)" || exit $?
+    echo "REACHED_AFTER_FAKE_EXIT"
+' 2>&1)" && abort_test_code=0 || abort_test_code=$?
+if [ "$abort_test_code" = "3" ] && [ "$abort_test_result" = "" ]; then
+    :  # pass
+else
+    echo "  FAIL: abort-propagation pattern broken: code=$abort_test_code out=[$abort_test_result] (expected code=3 out=empty)"
+    fail=1
+fi
+
 # ── Report
 if [ "$fail" = "0" ]; then
     echo "ALL TESTS PASS"

--- a/tests/sutando-migrate-preflight.test.sh
+++ b/tests/sutando-migrate-preflight.test.sh
@@ -72,12 +72,18 @@ grep -q "Estimated copy time:" "$MIGRATE" || { echo "  FAIL: ETA line template m
 grep -q 'Proceed with copy? \[y/N\]' "$MIGRATE" || { echo "  FAIL: confirm prompt template missing"; fail=1; }
 
 # ── Test 5: progress reporter line shape in commit_source
-grep -q 'printf "  \\\[%d/%d\\\] %s (%s) → %s\\\\n"' "$MIGRATE" \
-    || grep -q '\\\[%d/%d\\\] %s' "$MIGRATE" \
-    || grep -q '\[%d/%d\] %s' "$MIGRATE" \
-    || { echo "  FAIL: per-file progress line format missing from commit_source"; fail=1; }
+# Single load-bearing assertion: the literal `[%d/%d]` substring must appear
+# in the migrate script. If the printf format changes upstream, this fails
+# loudly rather than silently passing on a looser fallback pattern (Mini's
+# nit on the original triple-fallback grep, 2026-06-06).
+grep -qF '[%d/%d]' "$MIGRATE" \
+    || { echo "  FAIL: per-file progress format '[%d/%d]' missing from commit_source"; fail=1; }
+# The PROGRESS_N increment must precede the printf — grep for the literal
+# accounting line so a refactor that moves the increment doesn't silently
+# break the denominator.
+grep -q 'PROGRESS_N=$((PROGRESS_N + 1))' "$MIGRATE" \
+    || { echo "  FAIL: 'PROGRESS_N=\$((PROGRESS_N + 1))' accounting missing"; fail=1; }
 grep -q "PROGRESS_TOTAL" "$MIGRATE" || { echo "  FAIL: PROGRESS_TOTAL variable missing"; fail=1; }
-grep -q "PROGRESS_N" "$MIGRATE" || { echo "  FAIL: PROGRESS_N counter missing"; fail=1; }
 
 # ── Test 6: abort-propagation guard at the preflight_summary call site
 # Critical: `exit N` inside $(preflight_summary) subshell doesn't propagate

--- a/tests/sutando-migrate-preflight.test.sh
+++ b/tests/sutando-migrate-preflight.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Focused tests for the pre-flight summary + per-file progress reporter added
+# to sutando-migrate.sh. Tests the helpers (humanize_bytes, format_duration)
+# directly + asserts pre-flight emits the expected summary lines + asserts
+# the progress reporter emits per-file lines with the right shape.
+#
+# Does NOT depend on the full commit_main flow (which has a pre-existing test
+# environment issue around DEST_REAL resolution, separate concern).
+#
+# Owner ask 2026-06-05: large-workspace migration UX (progress bar + pre-flight
+# size estimate + interactive confirm).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+MIGRATE="$REPO/scripts/sutando-migrate.sh"
+
+# Extract the helper functions into an isolated shell for testing.
+HELPERS="$(awk '
+    /^humanize_bytes\(\) \{/,/^}$/ { print; next }
+    /^format_duration\(\) \{/,/^}$/ { print; next }
+' "$MIGRATE")"
+
+fail=0
+
+# ── Test 1: humanize_bytes covers B / KB / MB / GB / TB
+result="$(bash -c "$HELPERS"$'\n'"humanize_bytes 0")"
+[ "$result" = "0 B" ] || { echo "  FAIL: humanize_bytes 0 → expected '0 B', got '$result'"; fail=1; }
+
+result="$(bash -c "$HELPERS"$'\n'"humanize_bytes 999")"
+[ "$result" = "999 B" ] || { echo "  FAIL: humanize_bytes 999 → expected '999 B', got '$result'"; fail=1; }
+
+result="$(bash -c "$HELPERS"$'\n'"humanize_bytes 1024")"
+[ "$result" = "1.0 KB" ] || { echo "  FAIL: humanize_bytes 1024 → expected '1.0 KB', got '$result'"; fail=1; }
+
+result="$(bash -c "$HELPERS"$'\n'"humanize_bytes 5242880")"
+[ "$result" = "5.0 MB" ] || { echo "  FAIL: humanize_bytes 5242880 → expected '5.0 MB', got '$result'"; fail=1; }
+
+result="$(bash -c "$HELPERS"$'\n'"humanize_bytes 2147483648")"
+[ "$result" = "2.0 GB" ] || { echo "  FAIL: humanize_bytes 2147483648 → expected '2.0 GB', got '$result'"; fail=1; }
+
+result="$(bash -c "$HELPERS"$'\n'"humanize_bytes 1099511627776")"
+[ "$result" = "1.0 TB" ] || { echo "  FAIL: humanize_bytes 1099511627776 → expected '1.0 TB', got '$result'"; fail=1; }
+
+# ── Test 2: format_duration covers <1s / s / m+s / h+m
+result="$(bash -c "$HELPERS"$'\n'"format_duration 0")"
+[ "$result" = "<1s" ] || { echo "  FAIL: format_duration 0 → expected '<1s', got '$result'"; fail=1; }
+
+result="$(bash -c "$HELPERS"$'\n'"format_duration 30")"
+[ "$result" = "30s" ] || { echo "  FAIL: format_duration 30 → expected '30s', got '$result'"; fail=1; }
+
+result="$(bash -c "$HELPERS"$'\n'"format_duration 90")"
+[ "$result" = "1m 30s" ] || { echo "  FAIL: format_duration 90 → expected '1m 30s', got '$result'"; fail=1; }
+
+result="$(bash -c "$HELPERS"$'\n'"format_duration 7200")"
+[ "$result" = "2h 0m" ] || { echo "  FAIL: format_duration 7200 → expected '2h 0m', got '$result'"; fail=1; }
+
+# ── Test 3: --no-confirm flag is recognized (doesn't bail out as unknown)
+out="$(bash "$MIGRATE" --no-confirm 2>&1 || true)"
+echo "$out" | grep -q "unknown option" && { echo "  FAIL: --no-confirm reported as unknown option"; fail=1; }
+echo "$out" | grep -qE "^Usage:|^sutando-migrate:" || { echo "  WARN: --no-confirm output unexpected (got '$out')"; }
+
+# ── Test 4: pre-flight summary function exists + has expected structure
+# We grep the script source for the function definition + key output lines
+# rather than invoking commit_main (which depends on DEST_REAL resolution
+# the test env doesn't replicate cleanly — separate pre-existing concern).
+grep -q "^preflight_summary() {" "$MIGRATE" || { echo "  FAIL: preflight_summary() function missing from migrate script"; fail=1; }
+grep -q "sutando-migrate: pre-flight scan" "$MIGRATE" || { echo "  FAIL: pre-flight scan header line missing"; fail=1; }
+grep -q "TOTAL: " "$MIGRATE" || { echo "  FAIL: TOTAL line template missing"; fail=1; }
+grep -q "Estimated copy time:" "$MIGRATE" || { echo "  FAIL: ETA line template missing"; fail=1; }
+grep -q 'Proceed with copy? \[y/N\]' "$MIGRATE" || { echo "  FAIL: confirm prompt template missing"; fail=1; }
+
+# ── Test 5: progress reporter line shape in commit_source
+grep -q 'printf "  \\\[%d/%d\\\] %s (%s) → %s\\\\n"' "$MIGRATE" \
+    || grep -q '\\\[%d/%d\\\] %s' "$MIGRATE" \
+    || grep -q '\[%d/%d\] %s' "$MIGRATE" \
+    || { echo "  FAIL: per-file progress line format missing from commit_source"; fail=1; }
+grep -q "PROGRESS_TOTAL" "$MIGRATE" || { echo "  FAIL: PROGRESS_TOTAL variable missing"; fail=1; }
+grep -q "PROGRESS_N" "$MIGRATE" || { echo "  FAIL: PROGRESS_N counter missing"; fail=1; }
+
+# ── Report
+if [ "$fail" = "0" ]; then
+    echo "ALL TESTS PASS"
+else
+    echo "TESTS FAILED"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Owner ask 2026-06-05 (Susan saw it during her workspace migration this morning): large-workspace migrations felt opaque — the user waited a long time during the copy step with no visible signal whether things were progressing.

Two-pronged fix:

1. **Pre-flight scan** — count files, sum bytes, ETA estimate, interactive y/N prompt before any destructive write
2. **Per-file progress reporter** — visible `[N/total]` lines during the copy walk so long migrations don't feel like a hang

## Decisions

- **Stuck with `cp -p`, not rsync.** Discussed live with @qingyun-wu — macOS ships rsync 2.6.9 (no `--info=progress2`, requires rsync ≥ 3.1 via brew). The cp + custom progress path is universal (no dep check), preserves the per-file atomicity primitive (sibling-tmp + rename), matches `commit_one()`'s per-file dispatch model exactly, and delivers ~95% of the perceived-UX win.
- **Phase 2 (parallelism via `xargs -P`) deferred** to a separate v0.3.1 issue. Real speedup on many-small-files but needs more careful test coverage around dest-dir fsync ordering + interleaved stderr.
- **Per-file atomicity unchanged.** `cp -p $tmp && mv -f $tmp $dst` in `copy_preserving_mtime()` is untouched.

## Code changes

| File | Change |
|---|---|
| `scripts/sutando-migrate.sh` | +125 lines: `humanize_bytes()` + `format_duration()` helpers, `preflight_summary()` function, `--no-confirm`/`--yes`/`-y` flag, progress reporter block inside `commit_source` loop |
| `tests/sutando-migrate-preflight.test.sh` | New: helper unit tests + function-structure assertions + flag recognition |

**Total:** +213 lines across 2 files.

## What the user sees now

Before the copy starts:
```
sutando-migrate: pre-flight scan
  A (/path/to/source-a): 1234 files, 567.8 MB
  C (/path/to/source-c): 89 files, 12.3 MB
  TOTAL: 1323 files, 580.1 MB
  Estimated copy time: ~3s at ~200 MB/s sustained (rough)

  Proceed with copy? [y/N]:
```

During the copy:
```
  [1/1323] notes/foo.md (4.2 KB) → copied
  [2/1323] notes/bar.md (1.1 KB) → identical-drop
  [3/1323] state/auth/device.json (256 B) → rehomed-newer
  ...
  ─── progress: 20/1323 (1%) ───
  [21/1323] notes/baz.md (8.0 KB) → src-wins-newer
  ...
```

## Tests

`bash tests/sutando-migrate-preflight.test.sh` — **ALL TESTS PASS**:

- `humanize_bytes` covers B / KB / MB / GB / TB (with proper KB+ floor)
- `format_duration` covers <1s / s / m+s / h+m
- `--no-confirm` flag is recognized (doesn't bail out as unknown)
- `preflight_summary()` function exists with expected output template
- Progress line format present in `commit_source`
- `PROGRESS_TOTAL` + `PROGRESS_N` counter variables present

## Pre-existing test failure (not regressed by this PR)

`tests/sutando-migrate.test.sh` (E2E) was already failing on `staging-workspace-revamp` BEFORE this commit — the test fixture sets `SUTANDO_WORKSPACE=$TMPDIR/dest` to override DEST_REAL, but after the config-driven resolution refactor, that env override is no longer honored for dest computation (sources still respect it). Backup tarball + commit walk run against the live workspace path instead of the test dest, causing all 7 file-presence assertions to fail.

Verified this fails identically with my changes stashed. Filing as separate concern; should not gate this PR.

## Test plan

- [ ] Read pre-flight output for shape (above) on a real workspace
- [ ] Confirm `--no-confirm` skips the y/N prompt (cron / scripted runs)
- [ ] Confirm non-TTY stdin emits the "skipping confirm" message + auto-proceeds
- [ ] Confirm progress lines appear during commit walk (run against a small fixture)
- [ ] Confirm `--delete-source --backup-id <id>` (phase-2 path) skips pre-flight + progress cleanly (no copy walk)
- [ ] Confirm ETA estimate doesn't break for empty source (0 bytes)
- [ ] Manually verify on a real migration (Susan's migrate scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)