### PR TITLE
fix(sutando-migrate): use uname-s branch for preflight byte count (closes #1474)

### DIFF
--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -908,12 +908,15 @@ preflight_summary() {
         # count everything; quarantine + skip rules apply later). Overcount
         # is acceptable; this is an estimate, not an audit.
         files="$(find "$src" -type f 2>/dev/null | wc -l | tr -d ' ')"
-        bytes="$(find "$src" -type f -print0 2>/dev/null | xargs -0 stat -f '%z' 2>/dev/null \
-                 | awk '{s+=$1} END {print s+0}')"
-        # Linux fallback (BSD stat differs):
-        if [ -z "$bytes" ] || [ "$bytes" = "0" ]; then
-            bytes="$(find "$src" -type f -printf '%s\n' 2>/dev/null | awk '{s+=$1} END {print s+0}')"
-        fi
+        case "$(uname -s)" in
+            Darwin)
+                bytes="$(find "$src" -type f -print0 2>/dev/null | xargs -0 stat -f '%z' 2>/dev/null \
+                         | awk '{s+=$1} END {print s+0}')"
+                ;;
+            Linux|*)
+                bytes="$(find "$src" -type f -printf '%s\n' 2>/dev/null | awk '{s+=$1} END {print s+0}')"
+                ;;
+        esac
         _total_files=$((_total_files + files))
         _total_bytes=$((_total_bytes + bytes))
         _per_source_lines+="  $tag ($src): $files files, $(humanize_bytes "$bytes")"$'\n'

--- a/tests/sutando-migrate-preflight.test.sh
+++ b/tests/sutando-migrate-preflight.test.sh
@@ -112,6 +112,17 @@ else
     fail=1
 fi
 
+# ── Test 8: byte-count uses uname-s branch (not BSD stat -f '%z' on Linux)
+# The fix for #1474 replaces the stat -f '%z' + Linux fallback heuristic
+# with an explicit uname -s branch. Verify the script contains the branch
+# and does NOT contain the old fallback pattern.
+grep -q "case.*uname -s" "$MIGRATE" || { echo "  FAIL: uname -s branch missing from preflight byte-count"; fail=1; }
+grep -q 'Darwin)' "$MIGRATE" || { echo "  FAIL: Darwin) branch missing"; fail=1; }
+grep -q 'Linux|\*)' "$MIGRATE" || { echo "  FAIL: Linux|*) branch missing"; fail=1; }
+# The old heuristic-based fallback should be gone
+grep -q 'Linux fallback.*BSD stat' "$MIGRATE" && { echo "  FAIL: old Linux-fallback comment still present (should be removed)"; fail=1; }
+grep -q '\[ -z "\$bytes" \]' "$MIGRATE" && { echo "  FAIL: old fallback trigger '[ -z \$bytes ]' still present"; fail=1; }
+
 # ── Report
 if [ "$fail" = "0" ]; then
     echo "ALL TESTS PASS"


### PR DESCRIPTION
## Summary — closes #1474

Replace the BSD `stat -f '%z'` + heuristic Linux fallback with an explicit `uname -s` case branch in `preflight_summary()`.

### Bug

On Linux, `stat -f '%z'` means "filesystem stat" (GNU semantics), not file size. The `xargs -0 stat -f '%z'` pipeline produces non-empty, non-zero output (filesystem block info), so the `[ -z "$bytes" ] || [ "$bytes" = "0" ]` fallback trigger never fires. Result: wrong byte count → misleading ETA estimate.

### Fix

Branch by `uname -s` — exactly as proposed in #1474:
- **Darwin**: `stat -f '%z'` (BSD file size via xargs pipeline)
- **Linux|\\***: `find -printf '%s\\n'` (GNU, no stat needed)

This is the same cross-platform pattern already used by `stage-readiness.sh` and `catchup-after-startup.sh`.

### Why the other `stat -f` calls are fine

The other 15+ `stat -f` calls in sutando-migrate.sh all use the `stat -f %z ... || stat -c %s ...` short-circuit pattern: on Linux the first command exits non-zero (error), so `||` triggers the GNU fallback correctly. Only the preflight byte count used `xargs` piping, which produces wrong-but-non-empty output on Linux.

### Test

- Added Test 8: asserts `uname -s` branch exists, `Darwin)` and `Linux|*)` cases present, old heuristic fallback removed
- All 8 tests pass: `ALL TESTS PASS`

### Scope

- **Severity**: cosmetic — data integrity and copy correctness unaffected
- **Files**: `scripts/sutando-migrate.sh` (5 lines changed), `tests/sutando-migrate-preflight.test.sh` (11 lines added)
- **Target**: `staging-workspace-revamp` (same branch as PR #1473 which introduced preflight_summary)