### PR TITLE
fix(startup): honor sutando-migrate's per-source sentinels — close Lucy's Bug #2 re-migrate loop

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -108,7 +108,19 @@ if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   _ws_new="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null || true)"
   _migrate_sentinel="${_ws_new}/state/auth/migrated-from-env.txt"
 
+  # Bug #2 fix (Lucy's Maddy report 2026-06-06): also honor sutando-migrate.sh's
+  # OWN per-source sentinels (`state/.migrated-from-<tag>-<backup_id>`) — created
+  # when the operator runs `sutando-migrate --commit` manually instead of letting
+  # startup.sh auto-trigger it. Without this, manual-migrate flows leave SUTANDO_WORKSPACE
+  # set + legacy dir non-empty (migrate copies but doesn't rm legacy — only startup
+  # does that), so each boot re-fires the auto-migration loop.
+  _migrate_script_sentinels_present=0
+  if [ -n "$_ws_new" ] && ls "$_ws_new"/state/.migrated-from-* >/dev/null 2>&1; then
+    _migrate_script_sentinels_present=1
+  fi
+
   if [ -n "$_ws_new" ] && [ ! -f "$_migrate_sentinel" ] \
+     && [ "$_migrate_script_sentinels_present" = "0" ] \
      && [ -d "$_ws_legacy" ] && [ -n "$(ls -A "$_ws_legacy" 2>/dev/null)" ]; then
 
     _legacy_real="$(_realpath "$_ws_legacy")"

--- a/tests/startup-re-migrate-loop.test.sh
+++ b/tests/startup-re-migrate-loop.test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Test for Bug #2 fix (Lucy's Maddy report 2026-06-06): startup.sh's auto-migration
+# loop when `sutando-migrate --commit` was run manually.
+#
+# Root cause: startup.sh gated on its OWN sentinel (`state/auth/migrated-from-env.txt`),
+# which only gets created if startup.sh auto-triggered the migration. When the
+# operator runs `sutando-migrate --commit` directly (e.g., per Lucy's flow), the
+# migrate script creates its own per-source sentinels (`state/.migrated-from-A/B/C-<backup_id>`)
+# but NOT startup's. Then on next boot, startup sees SUTANDO_WORKSPACE still set
+# AND the legacy dir still non-empty (migrate doesn't rm legacy — only startup does)
+# AND its own sentinel missing → re-fires auto-migration. Loop.
+#
+# Fix: also honor sutando-migrate's per-source sentinels. If any
+# `state/.migrated-from-*` files exist at the resolved workspace, treat it as
+# "already migrated" and skip the auto-migration block.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+STARTUP="$REPO/src/startup.sh"
+
+fail=0
+
+# ── Test 1: structural — gate condition references migrate-script sentinels
+grep -qF '_migrate_script_sentinels_present' "$STARTUP" \
+    || { echo "  FAIL: gate variable _migrate_script_sentinels_present missing from startup.sh"; fail=1; }
+grep -qF '/state/.migrated-from-*' "$STARTUP" \
+    || { echo "  FAIL: migrate-script sentinel glob pattern missing from startup.sh"; fail=1; }
+
+# ── Test 2: gate condition includes the new check
+grep -qF '[ "$_migrate_script_sentinels_present" = "0" ]' "$STARTUP" \
+    || { echo "  FAIL: gate condition doesn't include migrate-script sentinel check"; fail=1; }
+
+# ── Test 3: detection logic E2E — extract the lines + run them against fixtures
+# The detection block is short enough to extract + exercise in isolation.
+
+# Fixture: tmp _ws_new with `state/.migrated-from-C-<backup_id>` present
+TMP_PRESENT="$(mktemp -d -t startup-test.XXXXXX)"
+mkdir -p "$TMP_PRESENT/state"
+touch "$TMP_PRESENT/state/.migrated-from-C-20260606T030000Z-p1r1"
+
+# Synth: run the detection snippet against the fixture
+detection_result="$(bash -c "
+    _ws_new='$TMP_PRESENT'
+    _migrate_script_sentinels_present=0
+    if [ -n \"\$_ws_new\" ] && ls \"\$_ws_new\"/state/.migrated-from-* >/dev/null 2>&1; then
+        _migrate_script_sentinels_present=1
+    fi
+    echo \"\$_migrate_script_sentinels_present\"
+")"
+
+if [ "$detection_result" != "1" ]; then
+    echo "  FAIL: detection didn't recognize present migrate-script sentinel (got '$detection_result', expected '1')"
+    fail=1
+fi
+
+rm -rf "$TMP_PRESENT"
+
+# Fixture: tmp _ws_new with NO sentinels — detection should return 0
+TMP_ABSENT="$(mktemp -d -t startup-test.XXXXXX)"
+mkdir -p "$TMP_ABSENT/state"
+# (no .migrated-from-* files)
+
+detection_result="$(bash -c "
+    _ws_new='$TMP_ABSENT'
+    _migrate_script_sentinels_present=0
+    if [ -n \"\$_ws_new\" ] && ls \"\$_ws_new\"/state/.migrated-from-* >/dev/null 2>&1; then
+        _migrate_script_sentinels_present=1
+    fi
+    echo \"\$_migrate_script_sentinels_present\"
+")"
+
+if [ "$detection_result" != "0" ]; then
+    echo "  FAIL: detection returned positive on absent sentinels (got '$detection_result', expected '0')"
+    fail=1
+fi
+
+rm -rf "$TMP_ABSENT"
+
+# ── Report
+if [ "$fail" = "0" ]; then
+    echo "ALL TESTS PASS"
+else
+    echo "TESTS FAILED"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Closes Bug #2 of 5 from Lucy's Maddy v0.8 migration report (2026-06-06 #design).

`src/startup.sh`'s auto-migration block re-fired on every boot when the operator ran `sutando-migrate --commit` manually instead of letting startup.sh auto-trigger it.

## Root cause

`startup.sh:106-112` checked only for **its own** sentinel: `<workspace>/state/auth/migrated-from-env.txt`. That sentinel is created **only** when `startup.sh` itself drives the migration (L144-147).

When the operator runs `bash scripts/sutando-migrate.sh --commit` directly (Lucy's flow on Maddy):
1. Migrate creates its **own** per-source sentinels at `<workspace>/state/.migrated-from-A/B/C-<backup_id>` (see `sutando-migrate.sh:845-851`).
2. Migrate does **NOT** rm the legacy `_ws_legacy` dir (only `startup.sh` does that at L156).
3. Migrate does **NOT** write `startup.sh`'s `migrated-from-env.txt` sentinel.
4. Next boot: `startup.sh` sees `$SUTANDO_WORKSPACE` still set + legacy dir still non-empty + its own sentinel missing → fires auto-migration AGAIN. Loop.

## Fix

Add a second sentinel check in the gate. If any `state/.migrated-from-*` files exist at the resolved workspace, treat it as "already migrated" and skip the auto-migration block.

```bash
_migrate_script_sentinels_present=0
if [ -n "$_ws_new" ] && ls "$_ws_new"/state/.migrated-from-* >/dev/null 2>&1; then
    _migrate_script_sentinels_present=1
fi

if [ -n "$_ws_new" ] && [ ! -f "$_migrate_sentinel" ] \
   && [ "$_migrate_script_sentinels_present" = "0" ] \
   && [ -d "$_ws_legacy" ] && [ -n "$(ls -A "$_ws_legacy" 2>/dev/null)" ]; then
   # ...
```

After this, the `unset $SUTANDO_WORKSPACE` at L172 still fires so child processes see the v0.8 contract directly; only the destructive auto-migration block is gated.

## Tests

`tests/startup-re-migrate-loop.test.sh`:
- Structural assertion: `_migrate_script_sentinels_present` variable + glob pattern + gate condition all present in `startup.sh`
- E2E detection (present): synth fixture with `state/.migrated-from-C-<id>` present → detection returns `1` (skip migration)
- E2E detection (absent): fixture with NO sentinels → detection returns `0` (would proceed with migration if other conditions met)
- **ALL TESTS PASS**

## Diff stats

2 files changed, +99 lines (~10-line startup.sh edit + ~90-line test).

## Related

- Lucy's Maddy report 2026-06-06 #design
- PR #1475 — Bug #1 fix (auto-`--import` + slug-rename bridge)
- Next: Bug #3 (`tar -czf` on media-heavy workspace freezes)

## Test plan

- [ ] Read the new gate check at the top of the existing `if [ -n "$SUTANDO_WORKSPACE" ]; then` block
- [ ] Run `bash tests/startup-re-migrate-loop.test.sh` locally — confirm ALL TESTS PASS
- [ ] On a host with `state/.migrated-from-*` sentinels present + `$SUTANDO_WORKSPACE` still set: verify next boot does NOT re-fire the auto-migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)