### PR TITLE
fix(restart-voice-agent): resolve workspace via M0 helper (followup to #1400)

### DIFF
--- a/scripts/restart-voice-agent.sh
+++ b/scripts/restart-voice-agent.sh
@@ -70,8 +70,8 @@ fi
 # "already running" — a silent no-op from the LaunchAgent's perspective.
 # Remove the file and force-kill any lingering workers before kickstart so the
 # new instance can start cleanly.
-WORKSPACE="${SUTANDO_WORKSPACE:-${HOME}/.sutando/workspace}"
-WORKSPACE="${WORKSPACE/#\~/${HOME}}"
+SCRIPT_PARENT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+WORKSPACE="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" workspace)"
 PID_FILE="${WORKSPACE}/.voice-agent.pid"
 if [ -f "${PID_FILE}" ]; then
   STALE_PID="$(cat "${PID_FILE}" 2>/dev/null || true)"


### PR DESCRIPTION
## Summary

`scripts/restart-voice-agent.sh:73` (added by #1400, 2026-06-03) used the legacy `WORKSPACE="${SUTANDO_WORKSPACE:-${HOME}/.sutando/workspace}"` fallback pattern. Caught by owner via Discord 2026-06-06 11:44Z. `scripts/lint-workspace-resolution.sh` confirms — the file shows up in the baseline-offenders list.

## Fix

Replace the legacy fallback + tilde-expansion line with the canonical helper call:

```diff
-WORKSPACE="${SUTANDO_WORKSPACE:-${HOME}/.sutando/workspace}"
-WORKSPACE="${WORKSPACE/#\~/${HOME}}"
+SCRIPT_PARENT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+WORKSPACE="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" workspace)"
```

**No defensive else-branch fallback** — the script shells `launchctl kickstart -k gui/<uid>/com.sutando.voice-agent`, so it's tightly coupled to a sutando checkout. If the helper isn't reachable, the launchctl service isn't registered either; failing loud via the helper's natural error path beats papering over with a hardcoded `~/.sutando/workspace/` default that may or may not exist.

The helper itself honors `$SUTANDO_WORKSPACE` as the legacy escape hatch (with the documented one-time deprecation warning) — that contract is preserved.

## Tests

The CI workflow `.github/workflows/lint-workspace-resolution.yml` runs `scripts/lint-workspace-resolution.sh --diff` on every PR targeting `staging-workspace-revamp`. That's the regression guard against re-introduction.

Local verification:
```
$ BASE_REF=origin/staging-workspace-revamp bash scripts/lint-workspace-resolution.sh --diff
✓ no new workspace-resolution anti-patterns in this diff.

$ bash -c '...resolve...'   # smoke
WORKSPACE=/Users/qingyunwu/Documents/github/sutando/workspace
exists
```

## Why this wasn't caught by CI on #1400

Worth investigating separately: PR #1400 targeted `main`, not `staging-workspace-revamp`. The lint workflow runs on both, and the added line clearly matches `PATTERN_HARDCODED_HOME` (`\.sutando/workspace`). Either the workflow was skipped (path filter? cancelled?) or it was overridden — followup-able but not part of this fix.

## Out-of-scope but related

`skills/agent-registry/scripts/_workspace_resolve.py` re-implements its own resolution chain (documented workaround for SessionStart-hook fresh-shell env-loss). Not in ALLOWED list; another candidate for a separate migration PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)