### PR TITLE
fix(voice): accept new AI Studio key formats

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -56,27 +56,26 @@ let generateSpeech: ((text: string, opts: { category: string; label: string }) =
 // Config
 // =============================================================================
 
-// Shape check: a valid Google AI Studio key starts with "AIza" and is
-// typically 39 chars (v1 format). Catches common misconfigurations
-// (truncated paste, wrong variable, stale template value) at startup
-// instead of letting the voice session fail silently on connect.
+// Shape check: catch common misconfigurations (truncated paste, wrong
+// variable, stale template value) at startup instead of letting the voice
+// session fail silently on connect. Do not pin this to a fixed prefix:
+// Google has issued multiple AI Studio API-key formats over time.
 function assertGeminiKey(name: string, value: string): void {
 	if (!value) { console.error(`Error: ${name} is required`); process.exit(1); }
-	// Upper bound of 60 (vs canonical ~39) gives headroom for Google key
-	// format rotations — Mini flagged they rotated once (2020→2023) and a
-	// tight bound would fail-fast on legitimate future keys.
-	const looksValid = value.startsWith('AIza') && value.length >= 35 && value.length <= 60;
+	const looksValid =
+		value === value.trim()
+		&& value.length >= 20
+		&& value.length <= 200
+		&& !/\s/.test(value)
+		&& value !== 'your-gemini-key';
 	if (!looksValid) {
 		// Do NOT interpolate anything derived from `value` into the log —
 		// CodeQL's js/clear-text-logging treats env vars matching the KEY
 		// heuristic as taint sources, and any PropRead of that source
-		// (e.g. `value.length`, `value.startsWith(...)`) flows into the
-		// console.error sink. The previous `${value.length}` + prefix-ok
-		// diagnostic was why #44 wouldn't close after #486. Keep the log
-		// static: name + expected format + remediation URL.
+		// (e.g. `value.length`) flows into the console.error sink. Keep the
+		// log static: name + expected format + remediation URL.
 		console.error(
-			`Error: ${name} does not look like a Google AI Studio key ` +
-			`(expected "AIza..." 35-60 chars). ` +
+			`Error: ${name} does not look like a Google AI Studio key. ` +
 			`Rotate at https://ai.google.dev → "Get API key" and update .env.`
 		);
 		process.exit(1);

--- a/tests/voice-agent-key-format.test.ts
+++ b/tests/voice-agent-key-format.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'src/voice-agent.ts'),
+	'utf8',
+);
+
+describe('voice-agent Gemini API key validation', () => {
+	it('does not pin Google AI Studio keys to the legacy AIza prefix', () => {
+		assert.doesNotMatch(
+			SRC,
+			/startsWith\(['"]AIza['"]\)|expected ["']AIza/,
+			'AI Studio now issues multiple API key formats; startup must not reject valid non-AIza keys.',
+		);
+	});
+
+	it('still rejects obvious placeholder values', () => {
+		assert.match(
+			SRC,
+			/value !== ['"]your-gemini-key['"]/,
+			'startup should still fail fast for the .env.example placeholder key.',
+		);
+	});
+});


### PR DESCRIPTION
What changed, and why?

Google AI Studio now issues Gemini API keys in formats that do not always start with the legacy `AIza` prefix. `voice-agent.ts` still rejected every non-`AIza` value at startup, which made valid newer keys fail before the Gemini client could try them. This PR relaxes the local shape check to reject empty, whitespace, overlong, and template values without pinning a provider-specific prefix.

Files / sections to review first

- `src/voice-agent.ts`: `assertGeminiKey()` startup validation
- `tests/voice-agent-key-format.test.ts`: regression guard against reintroducing the fixed `AIza` assumption

What user behavior or bug does this prove?

A user-provided Google AI Studio key beginning with `AQ...` was rejected with `Error: GEMINI_API_KEY does not look like a Google AI Studio key (expected "AIza..." 35-60 chars)`. After this change, the same key gets past startup validation and the voice agent reaches Gemini setup.

Duplicate / necessity checks

- `gh pr list --repo sonichi/sutando --state open --limit 30 --search "Gemini API key"` found no duplicate fix.
- `gh pr list --repo sonichi/sutando --state all --limit 30 --search "AI Studio key"` found the older merged validator PR, not a current fix.
- `gh pr list --repo sonichi/sutando --state all --limit 30 --search "AIza"` found only older merged CodeQL / validator PRs.
- `gh issue list --repo sonichi/sutando --state all --limit 30 --search "AIza"` found no duplicate issue.
- `git show origin/main:src/voice-agent.ts | rg "startsWith\('AIza'\)|expected \"AIza"` confirms the stale prefix gate is still on current `origin/main`.

Tests run

- `npm run typecheck` -> pass
- `npm test` -> pass

Failing-before / passing-after evidence

- Before: current `origin/main` contains `value.startsWith('AIza')` and the static startup error text `expected "AIza..."`, so newer `AQ...` AI Studio keys are rejected before API setup.
- After: the local startup run with the newer-format key reached `Gemini setup complete`; the added regression test passes and would fail if the fixed `AIza` gate returned.

Edge cases / non-happy paths checked

- Empty keys still fail via the existing required check.
- Whitespace-containing keys are still rejected.
- The `.env.example` placeholder `your-gemini-key` is still rejected.
- Very long values are still rejected rather than logged or passed through.

Migrations, config, permissions, rollback, deployment risks

N/A. This changes only startup validation. Invalid keys that pass this broader shape check will still be rejected by the Gemini API.

Known gaps / follow-up

This does not perform a network key validation call at startup; it keeps startup validation local and low-cost.
