### PR TITLE
feat(voice): opt-in dead-air narration during long delegated tasks

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -53,7 +53,7 @@ import { fileURLToPath } from 'node:url';
 import { voiceApiKey } from '../../../src/voice-key.js';
 import { loadVoiceConfig } from '../../../src/voice-config.js';
 import { hostname } from 'node:os';
-import { resolveWorkspace } from '../../../src/workspace_default.js';
+import { resolveWorkspace, statusReadPath } from '../../../src/workspace_default.js';
 
 // Personal-asset path resolver — twin of util_paths.py / voice-agent.ts:personalPath.
 // Reads $SUTANDO_MEMORY_DIR (canonical post-#870), honors legacy $SUTANDO_PRIVATE_DIR
@@ -341,6 +341,8 @@ interface CallSession {
 	events: { event: string; timestamp: string }[];
 	// Per-call channel-scan state (results/<callSid>.task-*.txt pull path).
 	channelScanHandle?: NodeJS.Timeout;
+	// Per-call dead-air narration poller (opt-in: SUTANDO_VOICE_DEADAIR=1).
+	progressNarrPoller?: NodeJS.Timeout;
 	// Safety-net against silent unlinkSync failures — `name -> first-seen ms`,
 	// pruned at 60s/tick so it can't grow unbounded for long calls.
 	channelScanSeen?: Map<string, number>;
@@ -1111,6 +1113,41 @@ async function createCallSession(params: {
 		}
 	}, 3000);
 
+	// --- Per-call dead-air narration (opt-in: SUTANDO_VOICE_DEADAIR=1) ---------
+	// When a delegated task runs long, the caller otherwise hears silence. Poll
+	// core-status.step and inject a brief "still on it" nudge once work has been
+	// running past a (phone-tuned, longer) threshold. Per-call dedup state so
+	// concurrent calls are independent. OFF by default.
+	if (process.env.SUTANDO_VOICE_DEADAIR === '1') {
+		const THRESHOLD_S = 20;   // phone UX: longer than web before first nudge
+		const MIN_GAP_S = 30;
+		const FRESH_S = 120;
+		let runningSince = 0;
+		let lastNarrateAt = 0;
+		callSession.progressNarrPoller = setInterval(() => {
+			if (callSession.hangingUp || !activeCalls.has(callSession.callSid)) { runningSince = 0; return; }
+			try {
+				const p = statusReadPath('core-status.json', WORKSPACE_DIR);
+				if (!existsSync(p)) return;
+				const s = JSON.parse(readFileSync(p, 'utf-8'));
+				const nowS = Math.floor(Date.now() / 1000);
+				const ageS = typeof s.ts === 'number' ? nowS - s.ts : 9999;
+				const step = typeof s.step === 'string' ? s.step.trim() : '';
+				const active = s.status === 'running' && !!step && ageS < FRESH_S;
+				if (!active) { runningSince = 0; lastNarrateAt = 0; return; }
+				if (runningSince === 0) runningSince = nowS;
+				const waited = nowS - runningSince;
+				if (waited < THRESHOLD_S) return;
+				if ((nowS - lastNarrateAt) < MIN_GAP_S) return;    // absolute cooldown — rapid step churn can't bypass it
+				lastNarrateAt = nowS;
+				(callSession.voiceSession as any)?.transport?.sendContent?.([
+					{ role: 'user', text: `[System: A background task is still running (current step: "${step}", ~${waited}s elapsed). Give the caller ONE short, natural reassurance that you're still working on it. Do NOT invent or guess results, do NOT repeat a prior reassurance, do NOT say goodbye.]` },
+				], true);
+			} catch { /* best-effort; never crash the call over narration */ }
+		}, 3000);
+		callSession.progressNarrPoller.unref?.();
+	}
+
 	return callSession;
 }
 
@@ -1127,6 +1164,7 @@ function cleanupCall(callSid: string): void {
 	import('../../../src/browser-tools.js').then(bt => bt.onCallEnd()).catch(() => {});
 	session.cleanupNarration?.();
 	try { if (session.channelScanHandle) clearInterval(session.channelScanHandle); } catch {}
+	try { if (session.progressNarrPoller) clearInterval(session.progressNarrPoller); } catch {}
 	try { unlinkSync('/tmp/sutando-playback-pause'); } catch {}
 	try { unlinkSync('/tmp/sutando-playback-path'); } catch {}
 

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -105,7 +105,7 @@ const HOST = process.env.HOST || '0.0.0.0';
 // "default to sutando/ so Claude Code subprocess picks up CLAUDE.md" comment
 // — voice-agent no longer spawns Claude Code (task-bridge handles that via
 // the file pipeline); the dual-use rationale is obsolete.
-import { resolveWorkspace, statusPath } from './workspace_default.js';
+import { resolveWorkspace, statusPath, statusReadPath } from './workspace_default.js';
 const WORKSPACE_DIR = resolveWorkspace();
 const PIDFILE = join(WORKSPACE_DIR, '.voice-agent.pid');
 const DEFAULT_THREAD_KEY = 'sutando_main';
@@ -1272,8 +1272,46 @@ async function main() {
 	session.eventBus.subscribe('turn.end', () => _duck('off'));
 	session.eventBus.subscribe('turn.interrupted', () => _duck('off'));
 
+	// --- Voice dead-air narration (opt-in: SUTANDO_VOICE_DEADAIR=1) -----------
+	// When a delegated `work` task runs long, the user otherwise hears silence
+	// while the core processes. Poll core-status.step and, once work has been
+	// running past a threshold, inject a brief "still on it" nudge so the dead
+	// air is filled. OFF by default. `runningSince` is tracked locally (reset
+	// when work goes idle/stale) so sub-threshold quick tasks stay silent and
+	// the `ts` field (last-write time, not task-start) can't mislead us.
+	let deadairPoller: ReturnType<typeof setInterval> | null = null;
+	if (process.env.SUTANDO_VOICE_DEADAIR === '1') {
+		const THRESHOLD_S = 15;   // continuous work before the first nudge
+		const MIN_GAP_S = 25;     // min seconds between nudges on the same span
+		const FRESH_S = 120;      // core-status must be this fresh to count as active
+		let runningSince = 0;
+		let lastNarrateAt = 0;
+		deadairPoller = setInterval(() => {
+			try {
+				if (!session.sessionManager.isActive || !session.clientConnected) { runningSince = 0; return; }
+				const p = statusReadPath('core-status.json', WORKSPACE_DIR);
+				if (!existsSync(p)) return;
+				const s = JSON.parse(readFileSync(p, 'utf-8'));
+				const nowS = Math.floor(Date.now() / 1000);
+				const ageS = typeof s.ts === 'number' ? nowS - s.ts : 9999;
+				const step = typeof s.step === 'string' ? s.step.trim() : '';
+				const active = s.status === 'running' && !!step && ageS < FRESH_S;
+				if (!active) { runningSince = 0; lastNarrateAt = 0; return; }
+				if (runningSince === 0) runningSince = nowS;       // start of a work span
+				const waited = nowS - runningSince;
+				if (waited < THRESHOLD_S) return;                  // too quick → stay silent
+				if ((nowS - lastNarrateAt) < MIN_GAP_S) return;    // absolute cooldown — rapid step churn can't bypass it
+				lastNarrateAt = nowS;
+				injectText(session, `[System: A background task is still running (current step: "${step}", ~${waited}s elapsed). Give the user ONE short, natural reassurance that you're still working on it. Do NOT invent or guess results, do NOT repeat a prior reassurance verbatim, do NOT say goodbye.]`);
+			} catch { /* best-effort; never crash the session over narration */ }
+		}, 3000);
+		deadairPoller.unref?.();  // never keep the process alive on its own
+		console.log(`${ts()} [DeadAir] voice progress narration enabled (SUTANDO_VOICE_DEADAIR=1)`);
+	}
+
 	const shutdown = async () => {
 		console.log(`\n${ts()} Shutting down...`);
+		if (deadairPoller) clearInterval(deadairPoller);
 		writeVoiceMetrics();
 		setVisionSession(null);
 		setSessionToolUpdater(null, []);


### PR DESCRIPTION
## What
Opt-in **dead-air narration** for voice + phone sessions. When the agent delegates a long-running task and the line goes quiet, it speaks a brief progress update ("still working on that — <step>…") instead of leaving silence, then stops once the task completes.

## Why
During multi-second tool calls the user hears nothing and often assumes the call dropped. A short spoken progress cue keeps the session feeling alive.

## How
- Reads the agent's `core-status.json` (`step` field) on a poll and injects a short narration via the existing `transport.sendContent` / `injectText` path.
- `voice-agent.ts`: 15s dead-air threshold, 25s min-gap cooldown, `runningSince` reset-on-idle, absolute cooldown.
- `conversation-server.ts` (phone): 20s threshold / 30s min-gap; poller cleared in `cleanupCall`.

## Flag-gated (OFF by default)
No behavior change unless `SUTANDO_VOICE_DEADAIR=1`. The poller isn't even created when the flag is unset.

## Testing
Exercised locally on both surfaces; `tsc --noEmit` clean.

## Known limitations (disclosed)
- **Single-call assumption.** The poller is per-call but reads the *global* `core-status.json`. With multiple *concurrent* phone calls, narration reflects the agent's single global work state, so simultaneous callers could hear each other's step text. Fine for single-user/owner deployments; a multi-session deployment would want per-session task scoping. Flagged for reviewer awareness.
- Status read is a small synchronous file read on the poll interval — negligible at expected call volumes; could move async if high-concurrency becomes a goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
