### PR TITLE
fix(startup): v0.8 cold-start hardening — auth-carry + discord python fallback

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -48,6 +48,17 @@ if [ -x "$REPO/scripts/sutando-config.sh" ]; then
   _ccd_err="$(mktemp -t startup-ccd.XXXXXX)"
   if _ccd="$(bash "$REPO/scripts/sutando-config.sh" claude-sutando-config-dir 2>"$_ccd_err")"; then
     mkdir -p "$_ccd"
+    # Auth-carry (v0.8 cold-start fix). Seed credentials + onboarding state from
+    # $HOME/.claude/ so a cold `claude` core doesn't dead-end at the login wall
+    # before reaching /schedule-crons. Idempotent — only copies when the
+    # per-runtime dir lacks the file. Without this, the watcher never starts on
+    # a fresh node (see Lucy's #design 2026-06-06 17:12Z heads-up, Bug 1).
+    for _seed in .credentials.json .claude.json; do
+      if [ ! -f "$_ccd/$_seed" ] && [ -f "$HOME/.claude/$_seed" ]; then
+        cp "$HOME/.claude/$_seed" "$_ccd/$_seed"
+        [ "$_seed" = ".credentials.json" ] && chmod 600 "$_ccd/$_seed"
+      fi
+    done
     export CLAUDE_CONFIG_DIR="$_ccd"
   else
     echo "startup: claude_sutando_config_dir invalid — refusing to start" >&2
@@ -602,8 +613,19 @@ if _DC_ENV="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/channels/discord/.env"; [ -f "$_
       break
     fi
   done
+  # Fallback (v0.8 cold-start fix). If none of the probed candidates had
+  # discord.py importable (PATH stripped by launchctl, conda shim shadowing
+  # homebrew, etc.) but plain `python3` is on PATH, hand the bridge to it
+  # anyway. If discord.py is truly missing, the bridge surfaces a clean
+  # ImportError in its log on first invocation — much better diagnostic than
+  # a silent skip masquerading as "discord-bridge offline" (Lucy's #design
+  # 2026-06-06 17:12Z heads-up, Bug 2).
+  if [ -z "$PYTHON_WITH_DISCORD" ] && command -v python3 >/dev/null 2>&1; then
+    PYTHON_WITH_DISCORD="python3"
+    echo "  ~ discord bridge falling back to PATH python3 (no probed interp had discord.py)"
+  fi
   if [ -z "$PYTHON_WITH_DISCORD" ]; then
-    echo "  ~ discord bridge (no python with discord.py — run: /opt/homebrew/bin/pip3 install discord.py)"
+    echo "  ~ discord bridge (no python3 on PATH — run: /opt/homebrew/bin/pip3 install discord.py)"
   elif ! pgrep -f "discord-bridge" > /dev/null 2>&1; then
     echo "  Starting Discord bridge with $PYTHON_WITH_DISCORD..."
     "$PYTHON_WITH_DISCORD" src/discord-bridge.py > "$LOGS_DIR/discord-bridge.log" 2>&1 &

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -50,13 +50,34 @@ if [ -x "$REPO/scripts/sutando-config.sh" ]; then
     mkdir -p "$_ccd"
     # Auth-carry (v0.8 cold-start fix). Seed credentials + onboarding state from
     # $HOME/.claude/ so a cold `claude` core doesn't dead-end at the login wall
-    # before reaching /schedule-crons. Idempotent — only copies when the
-    # per-runtime dir lacks the file. Without this, the watcher never starts on
-    # a fresh node (see Lucy's #design 2026-06-06 17:12Z heads-up, Bug 1).
+    # (.credentials.json) or trust-folder prompt (.claude.json) before reaching
+    # /schedule-crons. Idempotent — only copies when the per-runtime dir lacks
+    # the file. Without this, the watcher never starts on a fresh node (see
+    # Lucy's #design 2026-06-06 17:12Z heads-up, Bug 1).
+    #
+    # Single-tenant assumption (Pro 21:18Z + Lucy 21:25Z reviews on PR #1496):
+    # this whole-file copy binds the per-runtime dir to whatever account
+    # $HOME/.claude owns — .claude.json carries `oauthAccount`, `userID`, the
+    # `projects` map (per-dir history + MCP approval state), and `mcpServers`.
+    # Fine for the current single-user-Mac reality. If per-runtime ever means
+    # per-account, narrow this carry to onboarding flags only.
+    #
+    # Sync caveat: if CLAUDE_CONFIG_DIR lives under workspace/ and
+    # workspace-sync is on, .claude.json propagates across the fleet. Trust
+    # entries keyed by absolute checkout path don't collide between hosts.
+    # Followup: consider narrowing CLAUDE_CONFIG_DIR to a per-host non-synced
+    # subdir.
     for _seed in .credentials.json .claude.json; do
       if [ ! -f "$_ccd/$_seed" ] && [ -f "$HOME/.claude/$_seed" ]; then
-        cp "$HOME/.claude/$_seed" "$_ccd/$_seed"
-        [ "$_seed" = ".credentials.json" ] && chmod 600 "$_ccd/$_seed"
+        # Mini 21:23Z: defensive log on cp failure (read-only target, disk full).
+        # Lucy 21:25Z: log on success too so a stale-source case (expired creds
+        # carried forward + masked by the idempotent guard) is diagnosable.
+        if cp "$HOME/.claude/$_seed" "$_ccd/$_seed" 2>/dev/null; then
+          [ "$_seed" = ".credentials.json" ] && chmod 600 "$_ccd/$_seed"
+          echo "  ~ auth-carry: seeded $_seed from \$HOME/.claude/"
+        else
+          echo "  ~ auth-carry: cp failed for $_seed (check target perms + disk)"
+        fi
       fi
     done
     export CLAUDE_CONFIG_DIR="$_ccd"
@@ -615,17 +636,18 @@ if _DC_ENV="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/channels/discord/.env"; [ -f "$_
   done
   # Fallback (v0.8 cold-start fix). If none of the probed candidates had
   # discord.py importable (PATH stripped by launchctl, conda shim shadowing
-  # homebrew, etc.) but plain `python3` is on PATH, hand the bridge to it
-  # anyway. If discord.py is truly missing, the bridge surfaces a clean
-  # ImportError in its log on first invocation — much better diagnostic than
-  # a silent skip masquerading as "discord-bridge offline" (Lucy's #design
-  # 2026-06-06 17:12Z heads-up, Bug 2).
-  if [ -z "$PYTHON_WITH_DISCORD" ] && command -v python3 >/dev/null 2>&1; then
+  # homebrew, etc.) the original loop fell through silently. Per Lucy's
+  # PR #1496 review: probe PATH `python3` for `import discord` before
+  # falling back to it — avoids handing the bridge a guaranteed-fail
+  # interpreter that would crash-loop on every boot. If THAT probe also
+  # fails, keep the labeled skip with the pip-install hint (names the
+  # missing dep + fix at the startup console).
+  if [ -z "$PYTHON_WITH_DISCORD" ] && command -v python3 >/dev/null 2>&1 && python3 -c "import discord" 2>/dev/null; then
     PYTHON_WITH_DISCORD="python3"
-    echo "  ~ discord bridge falling back to PATH python3 (no probed interp had discord.py)"
+    echo "  ~ discord bridge using PATH python3 (no probed interp matched; PATH python3 has discord.py)"
   fi
   if [ -z "$PYTHON_WITH_DISCORD" ]; then
-    echo "  ~ discord bridge (no python3 on PATH — run: /opt/homebrew/bin/pip3 install discord.py)"
+    echo "  ~ discord bridge (no python with discord.py — run: /opt/homebrew/bin/pip3 install discord.py)"
   elif ! pgrep -f "discord-bridge" > /dev/null 2>&1; then
     echo "  Starting Discord bridge with $PYTHON_WITH_DISCORD..."
     "$PYTHON_WITH_DISCORD" src/discord-bridge.py > "$LOGS_DIR/discord-bridge.log" 2>&1 &


### PR DESCRIPTION
## Summary

Two related cold-start bugs in `src/startup.sh`, surfaced by Lucy in #design 17:12Z (msg `1512881497244893316`) while recovering Maddy after sleep. Both block self-recovery on a v0.8 node.

- **🔴 Bug 1 — auth-carry on per-runtime `CLAUDE_CONFIG_DIR`** (the real blocker). PR #1470's per-runtime config dir is fresh on first run → no `.credentials.json`, no `.claude.json` → `claude` core dead-ends at login wall → never reaches `/schedule-crons` → watcher never starts. PR #1475's `--import` only carries memory, not credentials.
- **🟠 Bug 2 — `PYTHON_WITH_DISCORD` detection silently skips.** Narrow candidate probe falls through with `PYTHON_WITH_DISCORD=""` on hosts where PATH is stripped (launchctl, conda shim), even when plain `python3 src/discord-bridge.py` works. Symptom: discord-bridge silently absent.

### Fixes

- **Bug 1:** between `mkdir -p "$_ccd"` and `export CLAUDE_CONFIG_DIR`, copy `.credentials.json` + `.claude.json` from `$HOME/.claude/` if the per-runtime dir lacks them. Idempotent + preserves mode 600.
- **Bug 2:** if no probed candidate had discord.py, fall back to PATH `python3`. If discord.py is truly missing the bridge surfaces a clean `ImportError` in its log — much better diagnostic than silent skip.

### E2E verified inline before push

| Test | Fixture | Command | Expected | Result |
|---|---|---|---|---|
| Bug 1 idempotent copy | fresh `_ccd` + `$HOME/.claude/.credentials.json` + `.claude.json` present | run extracted patch loop | both files copied, `.credentials.json` mode `600` | ✅ PASS |
| Bug 1 no overwrite | re-run with `.claude.json` already present | re-run loop | preserved | ✅ PASS |
| Bug 2 fallback fires | empty probe candidates + `python3` on PATH | run fallback block | `PYTHON_WITH_DISCORD=python3` | ✅ PASS |
| syntax | n/a | `bash -n src/startup.sh` | exit 0 | ✅ PASS |

## staging-workspace-revamp milestone summary

| Milestone | Status | PRs |
|---|---|---|
| **M0** — in-repo workspace default | ✅ shipped | #1395, #1397 |
| **M1** — bug-hunting / runtime-recovery | 🟢 active (this PR adds to M1) | #1399, #1403, #1406, #1432, #1437 …, **this PR** |
| **M2** — legacy `$SUTANDO_WORKSPACE` env removal | ✅ v0.8 cut (#1440) | #1440, #1478 |
| **M3** — legacy `.sutando/workspace` namespace sweep | ✅ shipped 2026-06-06 | #1490 (Path B) |

This PR is M1-scope: a runtime-recovery hardening that closes the cold-start dead-end Lucy diagnosed on Maddy.

## Test plan

- [ ] @Sutando-Mini — design review (owner asked specifically)
- [ ] @Lucy-Studio-Susan — verify on Maddy: clean cold-start to working watcher, no login wall (the original reporter)
- [ ] CI green
- [ ] Owner merge

## Refs

- Lucy's #design 17:12Z heads-up: msg `1512881497244893316`
- Sutando-Pro corroboration: 17:30Z
- Adjacent PRs: #1470 (`core_config_dirs`), #1475 (`--import` for memory carry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)