### PR TITLE
feat(wire-newsroom): v1 recurring loop pieces 1+2 (news-survey + material-ready)

### DIFF
--- a/skills/wire-newsroom/scripts/material-ready-check.py
+++ b/skills/wire-newsroom/scripts/material-ready-check.py
@@ -9,7 +9,7 @@ the gate fires.
 Air's editorial gate v1 (from #bot2bot 2026-06-06 21:28Z):
   HARD GATE — fires only when ALL three are true:
     1. >=3 verified receipts (verifiability >= 0.8, fresh_hours <= 7*24)
-    2. >=1 fresh ≤7d hook (fresh_hours <= 24, any beat)
+    2. >=1 fresh hook (fresh_hours <= 168 = 7d; ideal sub-24h tracked separately)
     3. >=2 beats represented in the above-threshold pool
 
   SOFT TIE-BREAKERS (used to rank when multiple topics qualify):
@@ -123,8 +123,10 @@ def apply_gate(all_items_by_beat: dict[tuple[str, str], list[dict]]) -> dict:
 
     # Hard gate 1: verified receipts (verifiability >= 0.8, fresh_hours <= 7d)
     receipts = [i for i in all_items if i["verifiability"] >= 0.8 and i["fresh_hours"] <= WINDOW_DAYS * 24]
-    # Hard gate 2: fresh hook (fresh_hours <= 24)
-    fresh_hooks = [i for i in all_items if i["fresh_hours"] <= 24]
+    # Hard gate 2: fresh hook (fresh_hours <= 7d per Air's gate v1; sub-24h is the ideal but not the hard bar)
+    fresh_hooks = [i for i in all_items if i["fresh_hours"] <= WINDOW_DAYS * 24]
+    # Sub-24h hooks tracked separately for the "ideal" soft signal
+    sub_24h_hooks = [i for i in fresh_hooks if i["fresh_hours"] <= 24]
     # Hard gate 3: beats represented (in above-threshold pool)
     beats = sorted({i["beat"] for i in all_items})
 
@@ -138,9 +140,10 @@ def apply_gate(all_items_by_beat: dict[tuple[str, str], list[dict]]) -> dict:
 
     if not fresh_hooks:
         ready = False
-        reasons.append("hard-gate FAIL: no fresh <=24h hook available")
+        reasons.append("hard-gate FAIL: no fresh <=7d hook available")
     else:
-        reasons.append(f"hard-gate PASS: {len(fresh_hooks)} fresh <=24h hooks")
+        ideal_note = f", incl. {len(sub_24h_hooks)} sub-24h" if sub_24h_hooks else ", none sub-24h"
+        reasons.append(f"hard-gate PASS: {len(fresh_hooks)} fresh <=7d hooks{ideal_note}")
 
     if len(beats) < 2:
         ready = False
@@ -186,9 +189,10 @@ def write_material_ready(verdict: dict) -> Path | None:
             f.write("## Receipts (verified, fresh ≤7d)\n\n")
             for r in verdict["receipts"][:8]:
                 f.write(f"- **[{r['title']}]({r['url']})** — score={r['score']:.2f} ({r['beat']}, fresh={r['fresh_hours']:.0f}h)\n")
-            f.write("\n## Fresh hooks (≤24h)\n\n")
+            f.write("\n## Fresh hooks (≤7d; ideal sub-24h tagged)\n\n")
             for h in verdict["fresh_hooks"][:5]:
-                f.write(f"- **[{h['title']}]({h['url']})** — {h['beat']}, fresh={h['fresh_hours']:.1f}h\n")
+                ideal = " ⭐sub-24h" if h["fresh_hours"] <= 24 else ""
+                f.write(f"- **[{h['title']}]({h['url']})** — {h['beat']}, fresh={h['fresh_hours']:.1f}h{ideal}\n")
             f.write("\n## Next: angle call (human)\n\n")
             f.write("This material cleared the gate. Fleet should propose 1-2 angle picks in #design within 12h, "
                     "Chi adjudicates the final angle, then Air's script template fills in.\n")

--- a/skills/wire-newsroom/scripts/material-ready-check.py
+++ b/skills/wire-newsroom/scripts/material-ready-check.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+"""Material-ready threshold check v1 — Piece 2 of WIRE recurring loop.
+
+Reads candidate files emitted by overnight-news-survey.py across all fleet
+beats, applies Air's editorial gate v1, and emits a material-ready file when
+the gate fires.
+
+Air's editorial gate v1 (from #bot2bot 2026-06-06 21:28Z):
+  HARD GATE — fires only when ALL three are true:
+    1. >=3 verified receipts (verifiability >= 0.8, fresh_hours <= 7*24)
+    2. >=1 fresh ≤7d hook (fresh_hours <= 24, any beat)
+    3. >=2 beats represented in the above-threshold pool
+
+  SOFT TIE-BREAKERS (used to rank when multiple topics qualify):
+    a. corroborating 2nd case for same root cause
+    b. cross-lane convergence (multiple beats ranking the same topic high)
+    c. live-demo fix available (in-flight Sutando PR that demos the fix)
+
+  Below-bar = HOLD (do not ship-thin).
+
+Output: notes/sutando-wire/material-ready/YYYY-MM-DD-<topic>.md (only when gate fires).
+
+Run nightly after overnight-news-survey.py:
+  03:23 local: python3 skills/wire-newsroom/scripts/material-ready-check.py
+"""
+
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from collections import defaultdict
+
+WORKSPACE = Path(os.environ.get("SUTANDO_WORKSPACE", str(Path.home() / ".sutando" / "workspace")))
+WIRE_DIR = WORKSPACE / "notes" / "sutando-wire"
+CANDIDATES_DIR = WIRE_DIR / "candidates"
+MATERIAL_READY_DIR = WIRE_DIR / "material-ready"
+WINDOW_DAYS = 7  # consider last 7 days of candidate files
+
+
+def load_recent_candidates() -> dict[tuple[str, str], list[dict]]:
+    """Read candidate-list files emitted in the last WINDOW_DAYS days.
+
+    Returns {(bot, beat): [items]} with items parsed back from the markdown.
+    """
+    out: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    if not CANDIDATES_DIR.exists():
+        return out
+    now = datetime.now(timezone.utc)
+    cutoff = now.timestamp() - WINDOW_DAYS * 86400
+    for f in CANDIDATES_DIR.glob("*.md"):
+        if f.stat().st_mtime < cutoff:
+            continue
+        content = f.read_text(errors="ignore")
+        bot, beat = _parse_frontmatter(content)
+        if not bot:
+            continue
+        items = _parse_above_threshold_section(content)
+        out[(bot, beat)].extend(items)
+    return out
+
+
+def _parse_frontmatter(content: str) -> tuple[str | None, str | None]:
+    m = re.search(r"^bot:\s*(\S+)", content, re.M)
+    bot = m.group(1) if m else None
+    m = re.search(r"^beat:\s*(\S+)", content, re.M)
+    beat = m.group(1) if m else None
+    return bot, beat
+
+
+def _parse_above_threshold_section(content: str) -> list[dict]:
+    """Pull the above-threshold bullet list back out of the markdown."""
+    lines = content.splitlines()
+    in_section = False
+    items = []
+    for line in lines:
+        if line.startswith("## Above-threshold"):
+            in_section = True
+            continue
+        if line.startswith("## ") and in_section:
+            break
+        if not in_section:
+            continue
+        # bullet pattern: - **[title](url)** — score=X.XX (fresh=N.Nh, thesis=X.XX, verif=X.XX) [source]
+        m = re.match(
+            r"- \*\*\[([^\]]+)\]\(([^)]+)\)\*\* — score=([\d.]+) "
+            r"\(fresh=([\d.]+)h, thesis=([\d.]+), verif=([\d.]+)\) \[([^\]]+)\]",
+            line,
+        )
+        if not m:
+            continue
+        items.append({
+            "title": m.group(1),
+            "url": m.group(2),
+            "score": float(m.group(3)),
+            "fresh_hours": float(m.group(4)),
+            "thesis_score": float(m.group(5)),
+            "verifiability": float(m.group(6)),
+            "source": m.group(7),
+        })
+    return items
+
+
+def apply_gate(all_items_by_beat: dict[tuple[str, str], list[dict]]) -> dict:
+    """Apply Air's hard gate.
+
+    Returns {
+        "ready": bool,
+        "reasons": list[str],         # why we're at this verdict
+        "supporting_receipts": list,  # items satisfying receipts gate
+        "fresh_hook": dict | None,
+        "beats_represented": list[str],
+    }
+    """
+    # Flatten everything above-threshold across beats
+    all_items: list[dict] = []
+    for (_bot, beat), items in all_items_by_beat.items():
+        for i in items:
+            i = dict(i)
+            i["beat"] = beat
+            all_items.append(i)
+
+    # Hard gate 1: verified receipts (verifiability >= 0.8, fresh_hours <= 7d)
+    receipts = [i for i in all_items if i["verifiability"] >= 0.8 and i["fresh_hours"] <= WINDOW_DAYS * 24]
+    # Hard gate 2: fresh hook (fresh_hours <= 24)
+    fresh_hooks = [i for i in all_items if i["fresh_hours"] <= 24]
+    # Hard gate 3: beats represented (in above-threshold pool)
+    beats = sorted({i["beat"] for i in all_items})
+
+    reasons = []
+    ready = True
+    if len(receipts) < 3:
+        ready = False
+        reasons.append(f"hard-gate FAIL: only {len(receipts)} verified receipts (need >= 3)")
+    else:
+        reasons.append(f"hard-gate PASS: {len(receipts)} verified receipts")
+
+    if not fresh_hooks:
+        ready = False
+        reasons.append("hard-gate FAIL: no fresh <=24h hook available")
+    else:
+        reasons.append(f"hard-gate PASS: {len(fresh_hooks)} fresh <=24h hooks")
+
+    if len(beats) < 2:
+        ready = False
+        reasons.append(f"hard-gate FAIL: only 1 beat represented ({beats[0] if beats else '-'}); need >= 2")
+    else:
+        reasons.append(f"hard-gate PASS: {len(beats)} beats represented ({', '.join(beats)})")
+
+    return {
+        "ready": ready,
+        "reasons": reasons,
+        "receipts": receipts,
+        "fresh_hooks": fresh_hooks,
+        "beats_represented": beats,
+        "total_above_threshold": len(all_items),
+    }
+
+
+def write_material_ready(verdict: dict) -> Path | None:
+    date = datetime.now(timezone.utc).date()
+    MATERIAL_READY_DIR.mkdir(parents=True, exist_ok=True)
+    if verdict["ready"]:
+        topic_slug = _propose_topic_slug(verdict)
+        out_path = MATERIAL_READY_DIR / f"{date}-READY-{topic_slug}.md"
+    else:
+        out_path = MATERIAL_READY_DIR / f"{date}-HOLD.md"
+
+    now = datetime.now(timezone.utc).isoformat()
+    with out_path.open("w") as f:
+        f.write("---\n")
+        f.write(f"title: material-ready check {date}\n")
+        f.write(f"generated_at: {now}\n")
+        f.write(f"ready: {'true' if verdict['ready'] else 'false'}\n")
+        f.write(f"beats_represented: [{', '.join(verdict['beats_represented'])}]\n")
+        f.write("tags: [sutando-wire, material-ready, recurring-loop]\n")
+        f.write("---\n\n")
+        f.write(f"# Material-ready check — {date}\n\n")
+        f.write("## Verdict\n\n")
+        for reason in verdict["reasons"]:
+            sym = "✅" if "PASS" in reason else "❌"
+            f.write(f"- {sym} {reason}\n")
+        f.write("\n")
+        if verdict["ready"]:
+            f.write("## Receipts (verified, fresh ≤7d)\n\n")
+            for r in verdict["receipts"][:8]:
+                f.write(f"- **[{r['title']}]({r['url']})** — score={r['score']:.2f} ({r['beat']}, fresh={r['fresh_hours']:.0f}h)\n")
+            f.write("\n## Fresh hooks (≤24h)\n\n")
+            for h in verdict["fresh_hooks"][:5]:
+                f.write(f"- **[{h['title']}]({h['url']})** — {h['beat']}, fresh={h['fresh_hours']:.1f}h\n")
+            f.write("\n## Next: angle call (human)\n\n")
+            f.write("This material cleared the gate. Fleet should propose 1-2 angle picks in #design within 12h, "
+                    "Chi adjudicates the final angle, then Air's script template fills in.\n")
+        else:
+            f.write("## Status\n\n")
+            f.write(f"HOLD — not ship-thin. {verdict['total_above_threshold']} items above 0.7 threshold this cycle. "
+                    "Re-checking nightly.\n")
+    return out_path
+
+
+def _propose_topic_slug(verdict: dict) -> str:
+    """Pick a topic slug from the highest-scoring receipt's title."""
+    if not verdict["receipts"]:
+        return "topic"
+    top = max(verdict["receipts"], key=lambda r: r["score"])
+    slug = re.sub(r"[^a-z0-9-]+", "-", top["title"].lower())
+    return slug[:48].strip("-")
+
+
+def main():
+    items_by_beat = load_recent_candidates()
+    if not items_by_beat:
+        print("no candidate files in last 7d — run overnight-news-survey.py first")
+        sys.exit(0)
+    verdict = apply_gate(items_by_beat)
+    out_path = write_material_ready(verdict)
+    print(f"wrote {out_path} (ready={verdict['ready']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/wire-newsroom/scripts/overnight-news-survey.py
+++ b/skills/wire-newsroom/scripts/overnight-news-survey.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# ruff: noqa: UP006, UP007 — supports older Python on fleet hosts (3.9)
+from __future__ import annotations
+"""Overnight news-survey trigger v1 — Piece 1 of WIRE recurring loop.
+
+For each enabled beat config under notes/sutando-wire/source-list-*.md,
+fetch the per-source URLs/APIs, score candidates, and emit a candidate-list
+to notes/sutando-wire/candidates/YYYY-MM-DD-<bot>-<beat>.md.
+
+Per spec (notes/sutando-wire/jun13-readiness-spec-3-pieces.md):
+- No silent skip — empty list emits a "ran, found nothing" note.
+- Rate-limited sources retry next night; don't crash the run.
+- Same item across beats emits once with overlap recorded.
+
+v1 source coverage (easy tier):
+- GitHub releases via `gh api repos/{owner}/{repo}/releases`
+- PyPI version-bumps via `pypi.org/pypi/{pkg}/json`
+- HN front-page filter via Algolia search API
+
+Skip in v1 (medium/hard tier — punted to v2):
+- Discord/Slack platform changelogs (scrape)
+- Vendor blog scraping
+- X searches
+- arxiv abstracts
+
+Run nightly via cron (workspace cron schedule):
+  03:07 local: python3 skills/wire-newsroom/scripts/overnight-news-survey.py
+
+Outputs:
+  notes/sutando-wire/candidates/YYYY-MM-DD-<bot>-<beat>.md
+"""
+
+import os
+import sys
+import json
+import urllib.request
+import urllib.error
+import urllib.parse
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+WORKSPACE = Path(os.environ.get("SUTANDO_WORKSPACE", str(Path.home() / ".sutando" / "workspace")))
+WIRE_DIR = WORKSPACE / "notes" / "sutando-wire"
+CANDIDATES_DIR = WIRE_DIR / "candidates"
+TIMEOUT = 10  # seconds per HTTP request
+
+
+def http_get_json(url: str, headers: dict | None = None) -> dict | list | None:
+    """Fetch JSON; return None on any error so one bad source doesn't kill the run."""
+    try:
+        req = urllib.request.Request(url, headers=headers or {})
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+            return json.loads(r.read())
+    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError, TimeoutError) as e:
+        print(f"  [warn] fetch failed: {url} → {e}", file=sys.stderr)
+        return None
+
+
+def score_item(*, fresh_hours: float, thesis_score: float, verifiability: float) -> float:
+    """Per spec: 0.4 * fresh + 0.4 * thesis + 0.2 * verif. Threshold 0.7."""
+    if fresh_hours <= 24:
+        fresh_score = 1.0
+    elif fresh_hours <= 168:  # 7 days
+        fresh_score = 0.7
+    elif fresh_hours <= 720:  # 30 days
+        fresh_score = 0.4
+    else:
+        fresh_score = 0.2
+    return 0.4 * fresh_score + 0.4 * thesis_score + 0.2 * verifiability
+
+
+def fetch_github_releases(repo: str, since_hours: int = 48, thesis_score: float = 0.7) -> list[dict]:
+    """List releases from a GitHub repo published in the last `since_hours`."""
+    data = http_get_json(f"https://api.github.com/repos/{repo}/releases",
+                         headers={"User-Agent": "sutando-wire-newsroom/0.1",
+                                  "Accept": "application/vnd.github+json"})
+    if not isinstance(data, list):
+        return []
+    now = datetime.now(timezone.utc)
+    out = []
+    for r in data[:5]:  # most-recent 5
+        try:
+            published = datetime.fromisoformat(r["published_at"].replace("Z", "+00:00"))
+        except (KeyError, ValueError):
+            continue
+        delta_h = (now - published).total_seconds() / 3600
+        if delta_h > since_hours:
+            continue
+        out.append({
+            "url": r.get("html_url", ""),
+            "title": f"{repo}: {r.get('name') or r.get('tag_name', '')}",
+            "source": f"GH:{repo}",
+            "fresh_hours": delta_h,
+            "thesis_score": thesis_score,
+            "verifiability": 1.0,  # release notes = primary
+            "summary": (r.get("body") or "")[:200].strip().replace("\n", " "),
+            "published": published.isoformat(),
+        })
+    return out
+
+
+def fetch_pypi_release(pkg: str, since_hours: int = 168, thesis_score: float = 0.7) -> list[dict]:
+    """Check PyPI for a newer release in the last `since_hours`."""
+    data = http_get_json(f"https://pypi.org/pypi/{pkg}/json")
+    if not data or "info" not in data:
+        return []
+    info = data["info"]
+    version = info.get("version", "")
+    releases = data.get("releases", {}).get(version, [])
+    if not releases:
+        return []
+    try:
+        upload = datetime.fromisoformat(releases[0]["upload_time_iso_8601"].replace("Z", "+00:00"))
+    except (KeyError, ValueError, IndexError):
+        return []
+    now = datetime.now(timezone.utc)
+    delta_h = (now - upload).total_seconds() / 3600
+    if delta_h > since_hours:
+        return []
+    return [{
+        "url": info.get("project_url") or info.get("home_page", "") or f"https://pypi.org/project/{pkg}/",
+        "title": f"PyPI {pkg} {version}",
+        "source": f"PyPI:{pkg}",
+        "fresh_hours": delta_h,
+        "thesis_score": thesis_score,
+        "verifiability": 1.0,
+        "summary": (info.get("summary") or "")[:200],
+        "published": upload.isoformat(),
+    }]
+
+
+def fetch_hn_front_page(query: str, since_hours: int = 24, thesis_score: float = 0.5) -> list[dict]:
+    """HN Algolia search for stories matching `query` within the window."""
+    cutoff_ts = int((datetime.now(timezone.utc) - timedelta(hours=since_hours)).timestamp())
+    url = (f"http://hn.algolia.com/api/v1/search?query={urllib.parse.quote(query)}"
+           f"&tags=story&numericFilters=created_at_i>{cutoff_ts}&hitsPerPage=10")
+    data = http_get_json(url)
+    if not data or "hits" not in data:
+        return []
+    out = []
+    now = datetime.now(timezone.utc)
+    for hit in data["hits"][:5]:
+        try:
+            created = datetime.fromtimestamp(hit["created_at_i"], tz=timezone.utc)
+        except (KeyError, ValueError):
+            continue
+        delta_h = (now - created).total_seconds() / 3600
+        out.append({
+            "url": hit.get("url") or f"https://news.ycombinator.com/item?id={hit['objectID']}",
+            "title": hit.get("title", "")[:160],
+            "source": f"HN:{query}",
+            "fresh_hours": delta_h,
+            "thesis_score": thesis_score,  # raw HN hits get a lower default thesis score
+            "verifiability": 0.6,  # secondary source by default
+            "summary": (hit.get("story_text") or hit.get("comment_text") or "")[:200].replace("\n", " "),
+            "published": created.isoformat(),
+            "hn_points": hit.get("points", 0),
+        })
+    return out
+
+
+# Mini-substrate beat config (v1 hard-coded; future: parse source-list-*.md frontmatter)
+MINI_SUBSTRATE_SOURCES = {
+    "github_releases": [
+        ("openai/swarm", 0.9),
+        ("microsoft/autogen", 0.9),
+        ("sonichi/sutando", 1.0),
+        ("sonichi/bodhi_realtime_agent", 1.0),
+        ("langchain-ai/langchain", 0.7),
+        ("langchain-ai/langgraph", 0.8),
+        ("crewAIInc/crewAI", 0.7),
+        ("modelcontextprotocol/specification", 0.9),
+    ],
+    "pypi": [
+        ("autogen-core", 0.9),
+        ("autogen-agentchat", 0.9),
+        ("autogen-ext", 0.9),
+        ("langgraph", 0.8),
+        ("crewai", 0.7),
+    ],
+    "hn_searches": [
+        ("multi-agent", 0.5),
+        ("agentic", 0.5),
+        ("MCP", 0.4),
+        ("autogen", 0.7),
+    ],
+}
+
+
+def collect_mini_substrate() -> list[dict]:
+    items: list[dict] = []
+    for repo, thesis in MINI_SUBSTRATE_SOURCES["github_releases"]:
+        items.extend(fetch_github_releases(repo, since_hours=48, thesis_score=thesis))
+    for pkg, thesis in MINI_SUBSTRATE_SOURCES["pypi"]:
+        items.extend(fetch_pypi_release(pkg, since_hours=168, thesis_score=thesis))
+    for q, thesis in MINI_SUBSTRATE_SOURCES["hn_searches"]:
+        items.extend(fetch_hn_front_page(q, since_hours=24, thesis_score=thesis))
+    return items
+
+
+def render_candidate_file(out_path: Path, bot: str, beat: str, items: list[dict]) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    sorted_items = sorted(items, key=lambda i: -i["score"])
+    above_threshold = [i for i in sorted_items if i["score"] >= 0.7]
+    with out_path.open("w") as f:
+        f.write("---\n")
+        f.write(f"title: {bot}/{beat} candidates {datetime.now(timezone.utc).date()}\n")
+        f.write(f"generated_at: {now}\n")
+        f.write(f"bot: {bot}\n")
+        f.write(f"beat: {beat}\n")
+        f.write(f"total_items_scored: {len(items)}\n")
+        f.write(f"above_threshold: {len(above_threshold)}\n")
+        f.write("tags: [sutando-wire, candidates, overnight-survey, " + bot + "]\n")
+        f.write("---\n\n")
+        if not items:
+            f.write(f"# {bot}/{beat} candidates — {datetime.now(timezone.utc).date()}\n\n")
+            f.write("**Ran successfully, found nothing.** No items matched the source list within the freshness window.\n\n")
+            f.write("Possible reasons: no fresh releases this cycle, all sources rate-limited or down, source-list needs widening.\n")
+            return
+        f.write(f"# {bot}/{beat} candidates — {datetime.now(timezone.utc).date()}\n\n")
+        f.write(f"Scored {len(items)} items; {len(above_threshold)} above 0.7 threshold.\n\n")
+        if above_threshold:
+            f.write("## Above-threshold (>= 0.7)\n\n")
+            for i in above_threshold:
+                f.write(f"- **[{i['title']}]({i['url']})** — score={i['score']:.2f} "
+                        f"(fresh={i['fresh_hours']:.1f}h, thesis={i['thesis_score']:.2f}, verif={i['verifiability']:.2f}) "
+                        f"[{i['source']}]\n")
+                if i.get("summary"):
+                    f.write(f"  > {i['summary']}\n")
+        sub_threshold = [i for i in sorted_items if i["score"] < 0.7]
+        if sub_threshold:
+            f.write("\n## Sub-threshold (kept for re-scoring next cycle)\n\n")
+            for i in sub_threshold[:10]:
+                f.write(f"- [{i['title']}]({i['url']}) — score={i['score']:.2f} [{i['source']}]\n")
+
+
+def main():
+    bot = os.environ.get("SUTANDO_BOT_NAME", "mini")
+    beat = "substrate"
+    items = collect_mini_substrate()
+    for i in items:
+        i["score"] = score_item(fresh_hours=i["fresh_hours"],
+                                thesis_score=i["thesis_score"],
+                                verifiability=i["verifiability"])
+    today = datetime.now(timezone.utc).date()
+    out_path = CANDIDATES_DIR / f"{today}-{bot}-{beat}.md"
+    render_candidate_file(out_path, bot, beat, items)
+    print(f"wrote {out_path} ({len(items)} items, "
+          f"{sum(1 for i in items if i['score'] >= 0.7)} above threshold)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Ships **Piece 1** (`overnight-news-survey.py`) — per-Sutando per-beat cron'd nightly news-survey trigger. Scores candidates (0.4 fresh + 0.4 thesis + 0.2 verif, threshold 0.7), emits `notes/sutando-wire/candidates/YYYY-MM-DD-<bot>-<beat>.md`.
- Ships **Piece 2** (`material-ready-check.py`) — Air's editorial hard gate (≥3 verified receipts + ≥1 fresh ≤24h hook + ≥2 beats represented). Emits READY or HOLD files into `notes/sutando-wire/material-ready/`.
- Test-ran on Mini's substrate beat: 19 candidates, 14 above-threshold. Material-ready correctly HOLDs on single-beat representation pending other Sutandos' surveys.
- Closes 2 of 3 Jun 13 readiness items (Piece 3 narration-fits-beat QC is Pro's lane).

Spec: `notes/sutando-wire/jun13-readiness-spec-3-pieces.md` (Mini) + Air's recipe at `notes/sutando-wire/recurring-loop-recipe-from-shipped-episodes.md`.

## Test plan
- [x] `python3 skills/wire-newsroom/scripts/overnight-news-survey.py` → writes candidate file ✅
- [x] `python3 skills/wire-newsroom/scripts/material-ready-check.py` → writes verdict file ✅
- [ ] CI green on the repo's existing tsc + python tests (no new tests added — Mini will follow up with `tests/wire-newsroom.test.py` in a follow-up PR if scope requires)
- [ ] Air verifies threshold logic matches his editorial gate v1
- [ ] Pro verifies the candidate-file format is consumable for Piece 3 QC

## Follow-ups (out of scope for this PR)
- `skills/wire-newsroom/SKILL.md` for discoverability
- Workspace cron wire (`schedule-crons` entry)
- Source-list parsing (replace Mini's hard-coded sources w/ source-list-*.md frontmatter)
- HN search query tightening (current "autogen" catches noise)
- Per-Sutando beat-config plumbing (Air WIRE / Lucy governance / Pro infra)

Stand: Echo Act IV (Mini)

🤖 Generated with [Claude Code](https://claude.com/claude-code)