### PR TITLE
feat(migrate): hook bridge for Option D — auto-re-install Sutando hooks + notice (#design 2026-06-07)

### DIFF
--- a/scripts/sutando-config-hooks.sh
+++ b/scripts/sutando-config-hooks.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+# sutando-config-hooks.sh — hook helper for the per-runtime CLAUDE_CONFIG_DIR
+# migration (Option D from #design 2026-06-07 design discussion).
+#
+# Background: when Sutando migrates a user from `~/.claude/` to a per-runtime
+# `$CLAUDE_CONFIG_DIR` (typically `<workspace>/.claude-sutando/`), hooks that
+# reference literal `~/.claude/hooks/...` paths in their `command:` strings
+# can't move cleanly. Owner's design (Option D, 01:38Z): drop those hooks at
+# migration time and (i) auto-re-install Sutando-owned hooks pointing at the
+# correct workspace paths, and (ii) print a notice listing dropped non-Sutando
+# entries so the user can re-add manually.
+#
+# This script is parametric on the target settings.json path — unlike the two
+# existing installers (`src/install-claude-hooks.sh` writes to repo's
+# `.claude/settings.json`; `skills/catchup-after-startup/scripts/install-hook.sh`
+# writes to `~/.claude/settings.json`), this one can target any settings.json,
+# making it suitable for `$CLAUDE_CONFIG_DIR/settings.json` post-migration.
+#
+# Subcommands:
+#   detect-missing <settings.json>
+#       Returns 0 if all known Sutando hooks are present, 1 if any missing.
+#       Prints a list of missing hooks to stderr.
+#
+#   install <settings.json> [--with-catchup-hook] [--with-project-hooks]
+#       Idempotent re-install of Sutando hook entries. Default: catchup hook
+#       only (the SessionEnd → session-handoff.sh entry from #1056). Add
+#       --with-project-hooks to also install the PreCompact + Stop entries
+#       from src/install-claude-hooks.sh.
+#
+#   migration-notice <old-settings.json> <new-settings.json>
+#       Diff hook command strings between old and new. Print user-facing notice
+#       listing entries that were dropped during migration (i.e. were in old
+#       but not new), filtered to non-Sutando ones — those need manual re-add.
+#
+# Usage examples:
+#   bash scripts/sutando-config-hooks.sh detect-missing "$CLAUDE_CONFIG_DIR/settings.json"
+#   bash scripts/sutando-config-hooks.sh install "$CLAUDE_CONFIG_DIR/settings.json"
+#   bash scripts/sutando-config-hooks.sh migration-notice ~/.claude/settings.json "$CLAUDE_CONFIG_DIR/settings.json"
+#
+# Exit codes:
+#   0 — success
+#   1 — operation failed (missing hooks for detect; jq edit failed for install)
+#   2 — jq missing
+#   3 — invalid args
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 2
+fi
+
+# Sutando-owned hook commands (canonical forms — must match what the existing
+# installers write, so detect-missing recognizes them). The catchup hook
+# resolves SUTANDO_REPO_DIR/src/session-handoff.sh; the project hooks live in
+# project-level .claude/settings.json (NOT user-level), so they're not part of
+# this migration's scope unless --with-project-hooks is set.
+#
+# Per `feedback_claude_code_hook_scoping`: catchup hook is USER-level (fires
+# everywhere), project hooks are PROJECT-level (fire only when Claude runs in
+# this repo). The migration target is USER-level CLAUDE_CONFIG_DIR.
+
+_catchup_hook_command() {
+  # Mirror skills/catchup-after-startup/scripts/install-hook.sh logic.
+  if [ -n "${SUTANDO_REPO_DIR:-}" ]; then
+    echo "bash \"$SUTANDO_REPO_DIR/src/session-handoff.sh\" \"\${TRANSCRIPT_PATH:-}\""
+  else
+    echo "bash \"$REPO_DIR/src/session-handoff.sh\" \"\${TRANSCRIPT_PATH:-}\""
+  fi
+}
+
+_known_sutando_substrings() {
+  # Stable substrings identifying Sutando-owned hooks in any settings.json,
+  # used by migration-notice to filter what NOT to flag. Match on command
+  # contains. Order doesn't matter.
+  cat <<EOF
+src/session-handoff.sh
+src/check-pending-tasks.sh
+src/watch-tasks-stream.sh
+sutando/src/
+sutando-plus/scripts/sync-workspace.sh
+EOF
+}
+
+cmd_detect_missing() {
+  local settings="${1:-}"
+  if [ -z "$settings" ]; then
+    echo "usage: detect-missing <settings.json>" >&2
+    exit 3
+  fi
+  if [ ! -f "$settings" ]; then
+    echo "detect-missing: $settings — file not found" >&2
+    echo "  (treating as missing all Sutando hooks)" >&2
+    exit 1
+  fi
+  local want_cmd; want_cmd="$(_catchup_hook_command)"
+  # Check SessionEnd entries for the catchup hook (the one we auto-install).
+  local found
+  found="$(jq --arg cmd "$want_cmd" '
+    [.hooks.SessionEnd // [] | .[] | .hooks // [] | .[] | select(.type=="command" and .command==$cmd)] | length
+  ' "$settings" 2>/dev/null || echo 0)"
+  if [ "${found:-0}" -ge 1 ]; then
+    echo "detect-missing: ok — catchup hook present"
+    return 0
+  else
+    echo "detect-missing: MISSING — SessionEnd catchup hook not found in $settings" >&2
+    echo "  expected command: $want_cmd" >&2
+    return 1
+  fi
+}
+
+cmd_install() {
+  local settings="${1:-}"; shift || true
+  if [ -z "$settings" ]; then
+    echo "usage: install <settings.json> [--with-catchup-hook] [--with-project-hooks]" >&2
+    exit 3
+  fi
+  local with_catchup=1  # default on
+  local with_project=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --with-catchup-hook) with_catchup=1; shift ;;
+      --no-catchup-hook) with_catchup=0; shift ;;
+      --with-project-hooks) with_project=1; shift ;;
+      *) echo "install: unknown flag $1" >&2; exit 3 ;;
+    esac
+  done
+
+  mkdir -p "$(dirname "$settings")"
+  [ -f "$settings" ] || echo '{}' > "$settings"
+
+  if [ "$with_catchup" = "1" ]; then
+    local cmd; cmd="$(_catchup_hook_command)"
+    # Idempotent jq edit: skip if an equivalent command already exists.
+    local exists
+    exists="$(jq --arg cmd "$cmd" '
+      [.hooks.SessionEnd // [] | .[] | .hooks // [] | .[] | select(.type=="command" and .command==$cmd)] | length
+    ' "$settings")"
+    if [ "${exists:-0}" -ge 1 ]; then
+      echo "install: SessionEnd catchup hook already present — skipping"
+    else
+      local tmp; tmp="$(mktemp)"
+      jq --arg cmd "$cmd" '
+        .hooks //= {} | .hooks.SessionEnd //= [] | .hooks.SessionEnd += [{
+          "hooks": [{"type": "command", "command": $cmd}]
+        }]
+      ' "$settings" > "$tmp"
+      mv "$tmp" "$settings"
+      echo "install: added SessionEnd catchup hook → $settings"
+    fi
+  fi
+
+  if [ "$with_project" = "1" ]; then
+    # Project hooks installation. These belong in REPO/.claude/settings.json,
+    # not user-level settings.json. The flag exists for callers that want
+    # one-stop install of both classes; for migration use, default-off.
+    local pre1="cp \"\$TRANSCRIPT_PATH\" \"\$HOME/Desktop/sutando-conversations/\$(date +%Y-%m-%dT%H-%M-%S).jsonl\""
+    local pre2="bash \"$REPO_DIR/src/session-handoff.sh\" \"\$TRANSCRIPT_PATH\""
+    local stop1="bash \"$REPO_DIR/src/check-pending-tasks.sh\""
+    for spec in "PreCompact|$pre1" "PreCompact|$pre2" "Stop|$stop1"; do
+      local event="${spec%%|*}"
+      local cmd="${spec#*|}"
+      local exists
+      exists="$(jq --arg ev "$event" --arg cmd "$cmd" '
+        [.hooks[$ev] // [] | .[] | .hooks // [] | .[] | select(.type=="command" and .command==$cmd)] | length
+      ' "$settings")"
+      if [ "${exists:-0}" -ge 1 ]; then
+        echo "install: $event project hook already present — skipping"
+      else
+        local tmp; tmp="$(mktemp)"
+        jq --arg ev "$event" --arg cmd "$cmd" '
+          .hooks //= {} | .hooks[$ev] //= [] | .hooks[$ev] += [{
+            "hooks": [{"type": "command", "command": $cmd}]
+          }]
+        ' "$settings" > "$tmp"
+        mv "$tmp" "$settings"
+        echo "install: added $event project hook → $settings"
+      fi
+    done
+  fi
+}
+
+cmd_migration_notice() {
+  local old="${1:-}"; local new="${2:-}"
+  if [ -z "$old" ] || [ -z "$new" ]; then
+    echo "usage: migration-notice <old-settings.json> <new-settings.json>" >&2
+    exit 3
+  fi
+  if [ ! -f "$old" ]; then
+    # No old settings.json — nothing to drop.
+    return 0
+  fi
+  # Build comparable command strings: <event>|<command>.
+  local _flatten_jq='
+    [(.hooks // {}) | to_entries[] | .key as $ev | (.value // [] | .[] | .hooks // [] | .[] | select(.type=="command") | "\($ev)|\(.command)")] | sort | .[]
+  '
+  local _tmp_old _tmp_new
+  _tmp_old="$(mktemp)"; _tmp_new="$(mktemp)"
+  jq -r "$_flatten_jq" "$old" > "$_tmp_old" 2>/dev/null || true
+  if [ -f "$new" ]; then
+    jq -r "$_flatten_jq" "$new" > "$_tmp_new" 2>/dev/null || true
+  else
+    : > "$_tmp_new"
+  fi
+  # Lines in old but not new = dropped.
+  local _tmp_dropped; _tmp_dropped="$(mktemp)"
+  comm -23 "$_tmp_old" "$_tmp_new" > "$_tmp_dropped" || true
+
+  # Filter out Sutando-owned hooks (we know those got migrated by the install
+  # subcommand or are simply re-installable from canonical sources).
+  local _tmp_third; _tmp_third="$(mktemp)"
+  local sutando_pat; sutando_pat="$(_known_sutando_substrings | paste -sd '|' -)"
+  grep -vE "$sutando_pat" "$_tmp_dropped" > "$_tmp_third" || true
+
+  if [ -s "$_tmp_third" ]; then
+    echo
+    echo "~ Hooks dropped during migration (literal ~/.claude/ paths or third-party scripts can't move to workspace automatically):"
+    while IFS='|' read -r ev cmd; do
+      [ -z "$ev" ] && continue
+      # Truncate long commands for display.
+      local disp="$cmd"
+      [ "${#disp}" -gt 120 ] && disp="${disp:0:117}..."
+      echo "    - $ev: $disp"
+    done < "$_tmp_third"
+    echo "  Re-add manually by editing $new under \"hooks\" — match the existing entry shape."
+    echo "  For Sutando-owned hooks (auto-restored): no action needed."
+  fi
+
+  rm -f "$_tmp_old" "$_tmp_new" "$_tmp_dropped" "$_tmp_third"
+}
+
+# Main dispatch
+MODE="${1:-}"; shift || true
+case "$MODE" in
+  detect-missing) cmd_detect_missing "$@" ;;
+  install) cmd_install "$@" ;;
+  migration-notice) cmd_migration_notice "$@" ;;
+  ""|--help|-h|help)
+    cat <<EOF
+sutando-config-hooks.sh — hook helper for per-runtime CLAUDE_CONFIG_DIR migration
+
+Subcommands:
+  detect-missing <settings.json>
+  install <settings.json> [--with-catchup-hook] [--with-project-hooks]
+  migration-notice <old-settings.json> <new-settings.json>
+
+See file header for design context (Option D from #design 2026-06-07).
+EOF
+    [ "$MODE" = "" ] && exit 3 || exit 0
+    ;;
+  *)
+    echo "sutando-config-hooks: unknown subcommand: $MODE" >&2
+    echo "Try: bash $0 --help" >&2
+    exit 3
+    ;;
+esac

--- a/scripts/sutando-config-hooks.sh
+++ b/scripts/sutando-config-hooks.sh
@@ -84,6 +84,20 @@ sutando-plus/scripts/sync-workspace.sh
 EOF
 }
 
+_validate_json() {
+  # Per Mini's PR #1500 review: previously the script silently `|| true`'d past
+  # malformed JSON, hiding real corruption (manual edits gone wrong, partial
+  # writes). This validator gives a clean error message instead.
+  local file="$1"
+  if ! jq empty "$file" 2>/dev/null; then
+    echo "error: $file is not valid JSON — fix or back up + re-init" >&2
+    echo "  diagnostic:" >&2
+    jq empty "$file" 2>&1 | sed 's/^/    /' >&2 || true
+    return 1
+  fi
+  return 0
+}
+
 cmd_detect_missing() {
   local settings="${1:-}"
   if [ -z "$settings" ]; then
@@ -94,6 +108,9 @@ cmd_detect_missing() {
     echo "detect-missing: $settings — file not found" >&2
     echo "  (treating as missing all Sutando hooks)" >&2
     exit 1
+  fi
+  if ! _validate_json "$settings"; then
+    return 1
   fi
   local want_cmd; want_cmd="$(_catchup_hook_command)"
   # Check SessionEnd entries for the catchup hook (the one we auto-install).
@@ -130,6 +147,12 @@ cmd_install() {
 
   mkdir -p "$(dirname "$settings")"
   [ -f "$settings" ] || echo '{}' > "$settings"
+  # Validate JSON before any jq edit — per Mini's PR #1500 review, malformed
+  # input would previously cause `mv tmp settings` to silently overwrite with
+  # a partial state.
+  if ! _validate_json "$settings"; then
+    exit 1
+  fi
 
   if [ "$with_catchup" = "1" ]; then
     local cmd; cmd="$(_catchup_hook_command)"
@@ -190,6 +213,18 @@ cmd_migration_notice() {
   fi
   if [ ! -f "$old" ]; then
     # No old settings.json — nothing to drop.
+    return 0
+  fi
+  # Per Mini's PR #1500 review: validate input JSON instead of silently
+  # `|| true`'ing through malformed files. Warn-but-continue here (vs hard
+  # error in detect/install) since migration-notice is informational and
+  # malformed input simply means "we can't compute the diff cleanly."
+  if ! _validate_json "$old"; then
+    echo "  (migration-notice: skipping — old settings.json malformed)" >&2
+    return 0
+  fi
+  if [ -f "$new" ] && ! _validate_json "$new"; then
+    echo "  (migration-notice: skipping — new settings.json malformed)" >&2
     return 0
   fi
   # Build comparable command strings: <event>|<command>.

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -589,6 +589,7 @@ FORCE=0
 ROLLBACK_ID=""
 NO_CONFIRM=0
 NO_CLAUDE_IMPORT=0
+NO_HOOK_BRIDGE=0
 
 EXPLAIN_PATH=""
 while [ $# -gt 0 ]; do
@@ -617,6 +618,7 @@ while [ $# -gt 0 ]; do
         --backup-id) ROLLBACK_ID="$2"; shift 2 ;;
         --no-confirm|--yes|-y) NO_CONFIRM=1; shift ;;  # skip pre-flight prompt (for CI / scripted runs)
         --no-claude-import) NO_CLAUDE_IMPORT=1; shift ;;  # skip auto-invocation of sutando-shell-setup.sh --import after commit (advanced; see Lucy's Maddy report 2026-06-06)
+        --no-hook-bridge) NO_HOOK_BRIDGE=1; shift ;;  # skip auto-invocation of sutando-config-hooks.sh (Option D from #design 2026-06-07; see scripts/sutando-config-hooks.sh header)
         --help|-h)
             sed -n '1,80p' "${BASH_SOURCE[0]}"
             exit 0
@@ -1709,6 +1711,34 @@ commit_main() {
             fi
         fi
     fi  # DELETE_SOURCE gate for slug-rename bridge
+
+    # Hook bridge — Option D from owner's #design 2026-06-07 design discussion.
+    # Auto-re-install Sutando-owned hooks into the per-runtime CLAUDE_CONFIG_DIR/settings.json
+    # and print a notice listing any third-party hooks that referenced
+    # ~/.claude/hooks/... paths (which can't move automatically). See
+    # scripts/sutando-config-hooks.sh header for the full rationale.
+    # Opt out with --no-hook-bridge.
+    if [ "$NO_HOOK_BRIDGE" = "0" ] && [ "$DELETE_SOURCE" = "0" ]; then
+        local _hook_helper="$(dirname "$0")/sutando-config-hooks.sh"
+        local _new_ccd; _new_ccd="$(bash "$(dirname "$0")/sutando-config.sh" claude-sutando-config-dir 2>/dev/null || true)"
+        local _new_settings="${_new_ccd}/settings.json"
+        local _old_settings="$HOME/.claude/settings.json"
+        if [ -x "$_hook_helper" ] || [ -f "$_hook_helper" ]; then
+            if [ -n "$_new_ccd" ]; then
+                echo
+                echo "sutando-migrate: bridging hooks via sutando-config-hooks.sh ..."
+                # Idempotent install of catchup hook; project hooks are repo-level (already in repo's .claude/settings.json).
+                bash "$_hook_helper" install "$_new_settings" --with-catchup-hook || \
+                    echo "  hook install: failed (rc=$?) — re-run manually: bash scripts/sutando-config-hooks.sh install \"$_new_settings\"" >&2
+                # Show dropped third-party hooks (non-Sutando) the user needs to re-add.
+                bash "$_hook_helper" migration-notice "$_old_settings" "$_new_settings" || true
+            else
+                echo "  hook bridge: skipped (couldn't resolve claude-sutando-config-dir; check sutando.config.local.json)" >&2
+            fi
+        else
+            echo "  hook bridge: skipped (scripts/sutando-config-hooks.sh not found at expected path; run manually after migrate)"
+        fi
+    fi
 
     echo
     echo "sutando-migrate: COMMIT complete. Verify with: bash scripts/sutando-migrate.sh verify"

--- a/tests/sutando-config-hooks.test.sh
+++ b/tests/sutando-config-hooks.test.sh
@@ -74,6 +74,26 @@ bash "$SCRIPT" detect-missing "$T/does-not-exist.json" >/dev/null 2>&1
 bash "$SCRIPT" bogus-subcommand >/dev/null 2>&1
 [ "$?" = "3" ]; report "$?" "invalid subcommand exits 3"
 
+# Test 9: malformed JSON in detect-missing — explicit error + exit 1
+# (per Mini's PR #1500 review — previously this silently fell through)
+echo 'not valid json {{{' > "$T/malformed.json"
+err_out="$(bash "$SCRIPT" detect-missing "$T/malformed.json" 2>&1)"
+rc="$?"
+[ "$rc" = "1" ] && echo "$err_out" | grep -q "not valid JSON"
+report "$?" "detect-missing emits explicit error + exit 1 on malformed JSON"
+
+# Test 10: malformed JSON in install — refuses to edit
+err_out2="$(bash "$SCRIPT" install "$T/malformed.json" 2>&1)"
+rc2="$?"
+[ "$rc2" = "1" ] && echo "$err_out2" | grep -q "not valid JSON"
+report "$?" "install refuses to edit malformed JSON (exit 1)"
+
+# Test 11: malformed JSON in migration-notice — skip cleanly, exit 0
+err_out3="$(bash "$SCRIPT" migration-notice "$T/malformed.json" "$T/new.json" 2>&1)"
+rc3="$?"
+[ "$rc3" = "0" ] && echo "$err_out3" | grep -q "malformed"
+report "$?" "migration-notice skips malformed input cleanly (exit 0 + warn)"
+
 rm -rf "$T"
 echo
 echo "Results: $pass passed, $fail failed"

--- a/tests/sutando-config-hooks.test.sh
+++ b/tests/sutando-config-hooks.test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# tests/sutando-config-hooks.test.sh — E2E smoke for scripts/sutando-config-hooks.sh
+#
+# Coverage:
+#   1. detect-missing returns 1 on empty settings, 0 after install
+#   2. install is idempotent (re-run doesn't duplicate the entry)
+#   3. install --with-project-hooks adds PreCompact + Stop entries
+#   4. migration-notice flags non-Sutando hooks while filtering Sutando-owned
+#
+# Run: bash tests/sutando-config-hooks.test.sh
+# Exit: 0 = all pass, 1 = failure
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_DIR/scripts/sutando-config-hooks.sh"
+
+pass=0; fail=0
+report() {
+  if [ "$1" = "0" ]; then
+    echo "  PASS: $2"; pass=$((pass+1))
+  else
+    echo "  FAIL: $2"; fail=$((fail+1))
+  fi
+}
+
+# Test 1: detect-missing on empty returns 1
+T="$(mktemp -d)"
+echo '{}' > "$T/s.json"
+bash "$SCRIPT" detect-missing "$T/s.json" >/dev/null 2>&1
+[ "$?" = "1" ]; report "$?" "detect-missing returns 1 on empty settings"
+
+# Test 2: install adds the catchup hook
+bash "$SCRIPT" install "$T/s.json" >/dev/null 2>&1
+catchup_count="$(jq '[.hooks.SessionEnd[].hooks[] | select(.command | contains("session-handoff.sh"))] | length' "$T/s.json")"
+[ "$catchup_count" -ge 1 ]; report "$?" "install adds SessionEnd catchup hook"
+
+# Test 3: detect-missing returns 0 after install
+bash "$SCRIPT" detect-missing "$T/s.json" >/dev/null 2>&1
+[ "$?" = "0" ]; report "$?" "detect-missing returns 0 after install"
+
+# Test 4: idempotent re-install (count stays at 1)
+bash "$SCRIPT" install "$T/s.json" >/dev/null 2>&1
+catchup_count_after="$(jq '[.hooks.SessionEnd[].hooks[] | select(.command | contains("session-handoff.sh"))] | length' "$T/s.json")"
+[ "$catchup_count_after" = "$catchup_count" ]; report "$?" "install is idempotent (catchup count unchanged on re-run)"
+
+# Test 5: --with-project-hooks adds PreCompact + Stop
+bash "$SCRIPT" install "$T/s.json" --with-project-hooks >/dev/null 2>&1
+precompact_count="$(jq '[.hooks.PreCompact[].hooks[]] | length' "$T/s.json" 2>/dev/null || echo 0)"
+stop_count="$(jq '[.hooks.Stop[].hooks[]] | length' "$T/s.json" 2>/dev/null || echo 0)"
+[ "$precompact_count" -ge 2 ] && [ "$stop_count" -ge 1 ]; report "$?" "--with-project-hooks adds PreCompact + Stop entries"
+
+# Test 6: migration-notice filters Sutando hooks, flags third-party
+cat > "$T/old.json" << 'EOJ'
+{
+  "hooks": {
+    "SessionEnd": [
+      {"hooks": [{"type": "command", "command": "bash $HOME/Documents/github/sutando/src/session-handoff.sh"}]},
+      {"hooks": [{"type": "command", "command": "bash $HOME/.claude/hooks/third-party.sh"}]}
+    ]
+  }
+}
+EOJ
+echo '{}' > "$T/new.json"
+notice_out="$(bash "$SCRIPT" migration-notice "$T/old.json" "$T/new.json" 2>&1)"
+echo "$notice_out" | grep -q "third-party.sh"; report "$?" "migration-notice flags third-party hook"
+echo "$notice_out" | grep -qv "session-handoff.sh"; report "$?" "migration-notice filters out Sutando hook (session-handoff.sh)"
+
+# Test 7: detect-missing on non-existent file returns 1
+bash "$SCRIPT" detect-missing "$T/does-not-exist.json" >/dev/null 2>&1
+[ "$?" = "1" ]; report "$?" "detect-missing returns 1 on missing file"
+
+# Test 8: invalid subcommand exits 3
+bash "$SCRIPT" bogus-subcommand >/dev/null 2>&1
+[ "$?" = "3" ]; report "$?" "invalid subcommand exits 3"
+
+rm -rf "$T"
+echo
+echo "Results: $pass passed, $fail failed"
+[ "$fail" = "0" ]


### PR DESCRIPTION
## Summary

Owner's #design 2026-06-07 design call (**Option D**, 01:38Z msg `1512994165556904148`): when migrating from `~/.claude/` to a per-runtime `\$CLAUDE_CONFIG_DIR`, **drop hook entries with literal `~/.claude/hooks/...` paths** (they can't move automatically) **and**:
- auto-re-install Sutando-owned hooks into the new CLAUDE_CONFIG_DIR
- print a user-facing notice listing dropped third-party entries so user can re-add manually

This PR ships both pieces.

## Changes

**1. `scripts/sutando-config-hooks.sh` (NEW)** — parametric hook helper, 3 subcommands:
- `detect-missing <settings.json>` → 0 if catchup hook present, 1 if missing
- `install <settings.json> [--with-catchup-hook] [--with-project-hooks]` → idempotent jq-edit; default catchup-only
- `migration-notice <old> <new>` → diff command strings, print user-facing notice listing dropped non-Sutando entries

**2. `scripts/sutando-migrate.sh` (WIRE)** — adds hook-bridge step in `commit_main`, after the existing slug-rename bridge:
- resolves new CLAUDE_CONFIG_DIR via `bash scripts/sutando-config.sh claude-sutando-config-dir`
- calls `install <new>/settings.json` (idempotent)
- calls `migration-notice ~/.claude/settings.json <new>/settings.json`
- new `--no-hook-bridge` flag (matches existing `--no-claude-import` pattern)
- skipped on phase-2 delete-only runs

**3. `tests/sutando-config-hooks.test.sh` (NEW)** — 9 E2E checks, all PASS:

| # | Test | Result |
|---|---|---|
| 1 | detect-missing returns 1 on empty settings | ✅ |
| 2 | install adds SessionEnd catchup hook | ✅ |
| 3 | detect-missing returns 0 after install | ✅ |
| 4 | install is idempotent (count unchanged on re-run) | ✅ |
| 5 | --with-project-hooks adds PreCompact + Stop entries | ✅ |
| 6 | migration-notice flags third-party hook | ✅ |
| 7 | migration-notice filters out Sutando hook (session-handoff.sh) | ✅ |
| 8 | detect-missing returns 1 on missing file | ✅ |
| 9 | invalid subcommand exits 3 | ✅ |

## staging-workspace-revamp milestone summary

| Milestone | Status | PRs |
|---|---|---|
| **M0** — in-repo workspace default | ✅ shipped | #1395, #1397 |
| **M1** — bug-hunting / runtime-recovery | ✅ shipped | #1399, #1403, #1406, #1432, #1437, #1496 |
| **M2** — legacy `\$SUTANDO_WORKSPACE` env removal | ✅ v0.8 cut (#1440) | #1440, #1478 |
| **M3** — legacy `.sutando/workspace` namespace sweep | ✅ shipped 2026-06-06 | #1490 (Path B) |
| **M4** — hook bridge for Option D migration | 🟢 active (this PR) | **this PR** |

## Test plan

- [ ] CI green
- [ ] Reviewer pick: @sonichi (Chi), @Lucy-Studio-Susan, @Sutando-Pro, @Sutando-Mini — anyone for design review
- [ ] @Lucy-Studio-Susan — Maddy verify (post-merge): does `bash scripts/sutando-migrate.sh --commit` on a node with `~/.claude/settings.json` containing a third-party hook now (a) auto-install the catchup hook + (b) print the notice listing the third-party entry?

## Refs

- Owner pivot to Option D: #design msg `1512994165556904148` (01:38Z)
- Owner direction to add scripts: msg `1512995280369488004` (01:43Z)
- Plan posted before coding: result file (auto-routed to #design)
- Issue #1499 (auth-carry followup) — independent, not blocked here
- Adjacent PRs: #1490 (Path B sweep, merged), #1496 (cold-start hardening, merged), #1454 (staging→main rollup, open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)