### PR TITLE
feat(migrate): hook manifest for sutando-owned hook discovery (#1502)

### DIFF
--- a/scripts/sutando-config-hooks.sh
+++ b/scripts/sutando-config-hooks.sh
@@ -79,29 +79,33 @@ _sutando_hook_manifest() {
 }
 
 _known_sutando_substrings() {
-  # Read from the manifest first; fall back to the hardcoded list if the manifest
-  # is absent or unreadable. Manifest is written by install-claude-hooks.sh and
-  # skills/catchup-after-startup/scripts/install-hook.sh on each install run.
+  # Merge the manifest's registered substrings with the hardcoded fallback list,
+  # deduped. Manifest is written by install-claude-hooks.sh and
+  # skills/catchup-after-startup/scripts/install-hook.sh on each install run —
+  # but a host where only some installers have run yet (e.g. catchup but not
+  # project hooks) would have an incomplete manifest. Merging with the
+  # hardcoded fallback ensures the full known-Sutando set is always recognized,
+  # so migration-notice never false-positively flags a real Sutando hook as
+  # "dropped third-party" on partial-install hosts.
   # See: https://github.com/sonichi/sutando/issues/1502
   local manifest; manifest="$(_sutando_hook_manifest)"
+  local from_manifest=""
   if [ -f "$manifest" ]; then
-    local from_manifest
     from_manifest="$(jq -r '.sutando_owned_hooks // [] | .[].command_substring' "$manifest" 2>/dev/null || true)"
-    if [ -n "$from_manifest" ]; then
-      echo "$from_manifest"
-      return
-    fi
-    # Manifest exists but produced no output (empty list or jq error) — fall through.
   fi
   # Hardcoded fallback: the 5 stable substrings known at #1500 ship time.
-  # New installers should write to the manifest rather than extending this list.
-  cat <<EOF
+  # New installers should write to the manifest in addition (not instead of)
+  # the hardcoded list. The merge dedupes so manifest + hardcoded overlap is fine.
+  {
+    [ -n "$from_manifest" ] && echo "$from_manifest"
+    cat <<EOF
 src/session-handoff.sh
 src/check-pending-tasks.sh
 src/watch-tasks-stream.sh
 sutando/src/
 sutando-plus/scripts/sync-workspace.sh
 EOF
+  } | awk 'NF && !seen[$0]++'
 }
 
 # _write_hook_manifest <id> <command_substring> <installed_by>

--- a/scripts/sutando-config-hooks.sh
+++ b/scripts/sutando-config-hooks.sh
@@ -71,10 +71,30 @@ _catchup_hook_command() {
   fi
 }
 
+_sutando_hook_manifest() {
+  # Path to the manifest that installers write and _known_sutando_substrings reads.
+  # Defaults to ~/.claude/sutando-hook-manifest.json (user-level config dir).
+  # Override by setting CLAUDE_CONFIG_DIR before running this script.
+  echo "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/sutando-hook-manifest.json"
+}
+
 _known_sutando_substrings() {
-  # Stable substrings identifying Sutando-owned hooks in any settings.json,
-  # used by migration-notice to filter what NOT to flag. Match on command
-  # contains. Order doesn't matter.
+  # Read from the manifest first; fall back to the hardcoded list if the manifest
+  # is absent or unreadable. Manifest is written by install-claude-hooks.sh and
+  # skills/catchup-after-startup/scripts/install-hook.sh on each install run.
+  # See: https://github.com/sonichi/sutando/issues/1502
+  local manifest; manifest="$(_sutando_hook_manifest)"
+  if [ -f "$manifest" ]; then
+    local from_manifest
+    from_manifest="$(jq -r '.sutando_owned_hooks // [] | .[].command_substring' "$manifest" 2>/dev/null || true)"
+    if [ -n "$from_manifest" ]; then
+      echo "$from_manifest"
+      return
+    fi
+    # Manifest exists but produced no output (empty list or jq error) — fall through.
+  fi
+  # Hardcoded fallback: the 5 stable substrings known at #1500 ship time.
+  # New installers should write to the manifest rather than extending this list.
   cat <<EOF
 src/session-handoff.sh
 src/check-pending-tasks.sh
@@ -82,6 +102,30 @@ src/watch-tasks-stream.sh
 sutando/src/
 sutando-plus/scripts/sync-workspace.sh
 EOF
+}
+
+# _write_hook_manifest <id> <command_substring> <installed_by>
+# Idempotent: no-op if <id> is already present in the manifest.
+# Called by install-claude-hooks.sh and install-hook.sh after installing each hook.
+_write_hook_manifest() {
+  local id="$1" substring="$2" installed_by="$3"
+  local manifest; manifest="$(_sutando_hook_manifest)"
+  mkdir -p "$(dirname "$manifest")"
+  [ -f "$manifest" ] || printf '{"version":1,"sutando_owned_hooks":[]}\n' > "$manifest"
+  # Validate before edit (don't clobber a corrupt manifest with a worse one).
+  if ! jq empty "$manifest" 2>/dev/null; then
+    echo "  [manifest] $manifest is not valid JSON — skipping write (run jq-check to diagnose)" >&2
+    return 1
+  fi
+  # Idempotent: skip if id already present.
+  if jq -e --arg id "$id" '.sutando_owned_hooks // [] | map(.id == $id) | any' "$manifest" >/dev/null 2>&1; then
+    return 0
+  fi
+  local tmp; tmp="$(mktemp)"
+  jq --arg id "$id" --arg sub "$substring" --arg by "$installed_by" \
+    '.sutando_owned_hooks //= [] | .sutando_owned_hooks += [{"id":$id,"command_substring":$sub,"installed_by":$by}]' \
+    "$manifest" > "$tmp" && mv "$tmp" "$manifest"
+  echo "  [manifest] registered hook $id → $manifest"
 }
 
 _validate_json() {
@@ -272,6 +316,11 @@ case "$MODE" in
   detect-missing) cmd_detect_missing "$@" ;;
   install) cmd_install "$@" ;;
   migration-notice) cmd_migration_notice "$@" ;;
+  write-manifest) _write_hook_manifest "$@" ;;
+  show-manifest)
+    manifest="$(_sutando_hook_manifest)"
+    if [ -f "$manifest" ]; then cat "$manifest"; else echo "(manifest not found at $manifest)"; fi
+    ;;
   ""|--help|-h|help)
     cat <<EOF
 sutando-config-hooks.sh — hook helper for per-runtime CLAUDE_CONFIG_DIR migration
@@ -280,8 +329,11 @@ Subcommands:
   detect-missing <settings.json>
   install <settings.json> [--with-catchup-hook] [--with-project-hooks]
   migration-notice <old-settings.json> <new-settings.json>
+  write-manifest <id> <command_substring> <installed_by>
+  show-manifest
 
 See file header for design context (Option D from #design 2026-06-07).
+See https://github.com/sonichi/sutando/issues/1502 for manifest design.
 EOF
     [ "$MODE" = "" ] && exit 3 || exit 0
     ;;

--- a/skills/catchup-after-startup/scripts/install-hook.sh
+++ b/skills/catchup-after-startup/scripts/install-hook.sh
@@ -63,7 +63,8 @@ fi
 python3 "$HERE/migrate-settings-hooks.py" "$SETTINGS"
 
 python3 <<PYEOF
-import json, os
+import json, os, pathlib
+
 p = "$SETTINGS"
 cmd = '''$HOOK_CMD'''
 s = json.load(open(p))
@@ -94,4 +95,22 @@ else:
     atomic_write(p, json.dumps(s, indent=2))
     print("installed SessionEnd hook → " + p)
     print("hook command:", cmd)
+
+# Register in the sutando-hook-manifest so migration-notice can identify this
+# hook without relying on the hardcoded substring list. (#1502)
+manifest = pathlib.Path(os.environ.get("CLAUDE_CONFIG_DIR", str(pathlib.Path.home() / ".claude"))) / "sutando-hook-manifest.json"
+manifest.parent.mkdir(parents=True, exist_ok=True)
+if not manifest.exists():
+    manifest.write_text('{"version":1,"sutando_owned_hooks":[]}\n')
+try:
+    data = json.loads(manifest.read_text())
+    owned = data.setdefault("sutando_owned_hooks", [])
+    entry_id = "catchup-session-end"
+    if not any(e.get("id") == entry_id for e in owned):
+        owned.append({"id": entry_id, "command_substring": "src/session-handoff.sh",
+                      "installed_by": "skills/catchup-after-startup/scripts/install-hook.sh"})
+        atomic_write(str(manifest), json.dumps(data, indent=2))
+        print(f"  [manifest] registered {entry_id} → {manifest}")
+except Exception as e:
+    print(f"  [manifest] write skipped ({e})")
 PYEOF

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -141,3 +141,12 @@ for entry in "${DEPRECATED_HOOKS[@]}"; do
 done
 
 echo "install-claude-hooks: added=$ADDED skipped=$SKIPPED removed=$REMOVED → $SETTINGS"
+
+# Register hooks in the sutando-hook-manifest so migration-notice can identify
+# them without relying on the hardcoded substring list. (#1502)
+HOOKS_SCRIPT="$REPO_DIR/scripts/sutando-config-hooks.sh"
+if [ -f "$HOOKS_SCRIPT" ]; then
+  bash "$HOOKS_SCRIPT" write-manifest "project-pre-compact-handoff" "src/session-handoff.sh" "src/install-claude-hooks.sh" 2>/dev/null || true
+  bash "$HOOKS_SCRIPT" write-manifest "project-pre-compact-archive" "sutando-conversations/" "src/install-claude-hooks.sh" 2>/dev/null || true
+  bash "$HOOKS_SCRIPT" write-manifest "project-stop-pending-tasks" "src/check-pending-tasks.sh" "src/install-claude-hooks.sh" 2>/dev/null || true
+fi

--- a/tests/sutando-config-hooks.test.sh
+++ b/tests/sutando-config-hooks.test.sh
@@ -94,6 +94,41 @@ rc3="$?"
 [ "$rc3" = "0" ] && echo "$err_out3" | grep -q "malformed"
 report "$?" "migration-notice skips malformed input cleanly (exit 0 + warn)"
 
+# Test 12: write-manifest + show-manifest round-trip
+T12="$(mktemp -d)"
+export CLAUDE_CONFIG_DIR="$T12"
+bash "$SCRIPT" write-manifest "test-id" "src/custom-hook.sh" "src/installer.sh" >/dev/null 2>&1
+manifest_content="$(bash "$SCRIPT" show-manifest 2>/dev/null)"
+echo "$manifest_content" | jq -e '.sutando_owned_hooks | length >= 1' >/dev/null 2>&1
+report "$?" "write-manifest creates manifest with 1 entry"
+
+# Test 13: write-manifest is idempotent (same id twice → still 1 entry)
+bash "$SCRIPT" write-manifest "test-id" "src/custom-hook.sh" "src/installer.sh" >/dev/null 2>&1
+entry_count="$(bash "$SCRIPT" show-manifest 2>/dev/null | jq '.sutando_owned_hooks | length' 2>/dev/null || echo 0)"
+[ "$entry_count" = "1" ]; report "$?" "write-manifest is idempotent (same id → count stays at 1)"
+
+# Test 14: migration-notice uses manifest substrings when manifest exists
+# Custom hook in manifest (not in hardcoded list) should be filtered out
+bash "$SCRIPT" write-manifest "custom-corp-hook" "src/custom-hook.sh" "src/installer.sh" >/dev/null 2>&1
+cat > "$T12/old.json" << 'EOJ'
+{
+  "hooks": {
+    "SessionEnd": [
+      {"hooks": [{"type": "command", "command": "bash /repo/src/custom-hook.sh --arg"}]},
+      {"hooks": [{"type": "command", "command": "bash $HOME/.claude/hooks/unknown-third-party.sh"}]}
+    ]
+  }
+}
+EOJ
+echo '{}' > "$T12/new.json"
+notice14="$(bash "$SCRIPT" migration-notice "$T12/old.json" "$T12/new.json" 2>&1)"
+echo "$notice14" | grep -q "unknown-third-party.sh"
+report "$?" "migration-notice: manifest-registered hook flags unknown third-party"
+echo "$notice14" | grep -qv "custom-hook.sh"
+report "$?" "migration-notice: manifest-registered hook NOT flagged as dropped"
+unset CLAUDE_CONFIG_DIR
+rm -rf "$T12"
+
 rm -rf "$T"
 echo
 echo "Results: $pass passed, $fail failed"

--- a/tests/sutando-config-hooks.test.sh
+++ b/tests/sutando-config-hooks.test.sh
@@ -129,6 +129,37 @@ report "$?" "migration-notice: manifest-registered hook NOT flagged as dropped"
 unset CLAUDE_CONFIG_DIR
 rm -rf "$T12"
 
+# Test 15: partial manifest still recognizes ALL hardcoded fallback substrings
+# (regression guard for liususan091219's review on PR #1505: previous logic
+# returned ONLY manifest entries when manifest was non-empty, so a host where
+# only catchup-install had run would have migration-notice false-positively
+# flag the project hooks as "dropped third-party".)
+T15="$(mktemp -d)"
+export CLAUDE_CONFIG_DIR="$T15"
+# Manifest with ONLY catchup-session-end (simulating partial-install host).
+bash "$SCRIPT" write-manifest "catchup-session-end" "src/session-handoff.sh" "skills/catchup-after-startup/scripts/install-hook.sh" >/dev/null 2>&1
+# Build an old.json with a hardcoded-list hook + a real third-party hook.
+cat > "$T15/old.json" << 'EOJ'
+{
+  "hooks": {
+    "Stop": [
+      {"hooks": [{"type": "command", "command": "bash /repo/src/check-pending-tasks.sh"}]},
+      {"hooks": [{"type": "command", "command": "bash $HOME/.claude/hooks/random-corp-thing.sh"}]}
+    ]
+  }
+}
+EOJ
+echo '{}' > "$T15/new.json"
+notice15="$(bash "$SCRIPT" migration-notice "$T15/old.json" "$T15/new.json" 2>&1)"
+# check-pending-tasks.sh IS in the hardcoded fallback — must NOT be flagged as dropped.
+echo "$notice15" | grep -qv "check-pending-tasks.sh"
+report "$?" "migration-notice: partial-manifest preserves hardcoded fallback recognition"
+# random-corp-thing.sh IS NOT in either list — MUST be flagged.
+echo "$notice15" | grep -q "random-corp-thing.sh"
+report "$?" "migration-notice: partial-manifest still flags real third-party"
+unset CLAUDE_CONFIG_DIR
+rm -rf "$T15"
+
 rm -rf "$T"
 echo
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary

Implements the manifest design from #1502 (filed by Qingyun per Mini's PR #1500 review).

Replaces the hardcoded substring list in `_known_sutando_substrings()` with a manifest file at `$CLAUDE_CONFIG_DIR/sutando-hook-manifest.json`. Installers write to it; `migration-notice` reads from it.

## Changes

**`scripts/sutando-config-hooks.sh`** (84 lines added, 4 removed):
- `_sutando_hook_manifest()` — canonical manifest path helper (`CLAUDE_CONFIG_DIR`-aware)
- `_known_sutando_substrings()` — reads manifest first, falls back to hardcoded list if absent/empty (backward compatible)
- `_write_hook_manifest <id> <substring> <installed_by>` — idempotent manifest append
- New subcommands: `write-manifest` + `show-manifest`

**`src/install-claude-hooks.sh`**: calls `write-manifest` for 3 project hook entries after install

**`skills/catchup-after-startup/scripts/install-hook.sh`**: appends to manifest in the existing Python install block (`catchup-session-end` entry)

## Backward compatibility

- If manifest is missing or unreadable: falls back to the 5 hardcoded substrings from #1500 — no regression
- Existing installs self-populate on next re-run of either installer
- Manifest schema: `{"version":1, "sutando_owned_hooks": [{"id","command_substring","installed_by"}]}`

## Test plan

- [x] `bash -n` syntax check: all 3 scripts pass
- [x] `write-manifest`: creates manifest, writes entry, shows confirmation
- [x] Idempotent: second `write-manifest` with same id → silent no-op
- [x] `show-manifest`: prints JSON manifest
- [ ] `migration-notice`: verify dropped-hook output no longer flags Sutando-owned hooks when manifest is populated
- [ ] Re-run `install-claude-hooks.sh` on a fresh machine to confirm manifest auto-populates

Closes #1502.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)