### PR TITLE
feat(startup): write .credentials.source.json sidecar on env-token-persist (#1504)

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -127,7 +127,7 @@ json.dump({'claudeAiOauth':{'accessToken':t}}, open(p,'w'))
           _p="$_ccd/.credentials.source.json" _v="$_env_var_used" python3 -c "
 import json,os,datetime
 p=os.environ['_p']; v=os.environ['_v']
-json.dump({'source':'env','env_var':v,'carried_at':datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),'persist_block_version':1},open(p,'w'))
+json.dump({'source':'env','env_var':v,'carried_at':datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),'persist_block_version':1},open(p,'w'))
 " 2>/dev/null && chmod 600 "$_ccd/.credentials.source.json" || true
         else
           echo "  ~ env-token-persist: write failed (check target perms + python3 on PATH)"

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -122,6 +122,13 @@ json.dump({'claudeAiOauth':{'accessToken':t}}, open(p,'w'))
 " 2>/dev/null; then
           chmod 600 "$_ccd/.credentials.json"
           echo "  ~ env-token-persist: wrote .credentials.json from \$$_env_var_used (mode 600)"
+          # Sidecar provenance file (#1504) — never read by Claude Code.
+          # Records how this credentials file was produced for audit/migration tools.
+          _p="$_ccd/.credentials.source.json" _v="$_env_var_used" python3 -c "
+import json,os,datetime
+p=os.environ['_p']; v=os.environ['_v']
+json.dump({'source':'env','env_var':v,'carried_at':datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),'persist_block_version':1},open(p,'w'))
+" 2>/dev/null && chmod 600 "$_ccd/.credentials.source.json" || true
         else
           echo "  ~ env-token-persist: write failed (check target perms + python3 on PATH)"
         fi


### PR DESCRIPTION
## Summary

Follow-up to #1503 (env-token-persist, merged). Implements the optional sidecar file proposed in #1504.

After writing `.credentials.json` from an env token, also writes:

```
$CLAUDE_CONFIG_DIR/.credentials.source.json
```

Contents:
```json
{
  "source": "env",
  "env_var": "CLAUDE_CODE_OAUTH_TOKEN",
  "carried_at": "2026-06-07T03:00:00Z",
  "persist_block_version": 1
}
```

**Claude Code never reads this file.** It's purely for audit/migration tools.

## Use cases

- **Audit**: "how did `.credentials.json` appear?" — env-carry (this PR) vs auth-carry (#1496) vs manually placed
- **Migration**: future runtime-recovery tools can detect env-token-sourced creds + re-derive on env rotation
- **Stale token debugging**: `carried_at` shows when the token was persisted vs the last env rotation

## Implementation

7 lines added in the existing env-token-persist `if` block. Sidecar write failure is non-fatal (`|| true`). `chmod 600` matches `.credentials.json`.

## Test plan

- [x] `bash -n src/startup.sh` — syntax ok
- [ ] Run startup with `CLAUDE_CODE_OAUTH_TOKEN=test` set, verify `.credentials.source.json` appears with correct schema
- [ ] Verify sidecar absence when `SUTANDO_NO_PERSIST_TOKEN=1` (the outer guard skips the whole block)
- [ ] Verify sidecar absent when auth-carry succeeds (`.credentials.json` already present before env-persist check)

Closes #1504.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)