### PR TITLE
fix(slack-bridge): skip Discord [channel:] redirect markers before claiming (#1401)

### DIFF
--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -732,6 +732,17 @@ def result_watcher():
                 for f in list(RESULTS_DIR.iterdir()):
                     if not (f.name.startswith("proactive-") and f.suffix == ".txt"):
                         continue
+                    # Peek before claiming: skip Discord-targeted proactive files.
+                    # [channel: <17-20 digit snowflake>] is a Discord-only marker;
+                    # claiming it here dumps the literal text to Slack DM instead.
+                    # Leave it for discord-bridge to claim. (#1401)
+                    try:
+                        peek = f.read_text(errors="ignore").lstrip()
+                    except OSError:
+                        continue
+                    if peek.startswith("[channel:") and \
+                            re.match(r'\[channel:\s*\d{17,20}\]', peek):
+                        continue
                     claim = f.with_suffix(".sending")
                     try:
                         f.rename(claim)

--- a/tests/slack-bridge-channel-redirect-guard.test.py
+++ b/tests/slack-bridge-channel-redirect-guard.test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Structural regression test for the slack-bridge [channel:] redirect guard (2026-06-07).
+
+Guards against the race condition where slack-bridge claims a proactive file
+starting with `[channel: <snowflake>]` before discord-bridge can process it.
+The fix: peek at file content BEFORE rename-claim and skip Discord-targeted
+proactive files. (#1401, incident 2026-06-01)
+
+Run: python3 tests/slack-bridge-channel-redirect-guard.test.py
+Exit: 0 = all pass, 1 = failure
+"""
+from __future__ import annotations
+import re
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = (REPO / "src" / "slack-bridge.py").read_text()
+
+
+class TestSlackBridgeChannelRedirectGuard(unittest.TestCase):
+
+    def test_peek_before_claim_guard_present(self):
+        """The source must contain a peek-before-claim guard for [channel:] redirects.
+
+        Without this guard, slack-bridge wins the proactive-file rename race and sends
+        the literal '[channel: <id>] <body>' text to the owner's Slack DM instead of
+        the intended Discord channel (#1401, incident 2026-06-01).
+        """
+        self.assertIn(
+            "[channel:",
+            SRC,
+            "slack-bridge.py must contain a [channel:] guard — see #1401",
+        )
+
+    def test_peek_occurs_before_rename(self):
+        """The peek (read_text / read) must appear before the rename call in the
+        proactive-file processing block.
+
+        This is the structural invariant: you can't claim a file before you know
+        whether to skip it.
+        """
+        # Find the proactive-file processing block (bounded by the 'proactive-' name check).
+        proactive_block_start = SRC.find("proactive-")
+        self.assertGreater(proactive_block_start, 0, "proactive-file loop not found")
+
+        # Find peek in the code after the proactive-file check
+        peek_pos = SRC.find("peek", proactive_block_start)
+        self.assertGreater(peek_pos, 0, "peek variable not found after proactive- block")
+
+        # Find rename after the proactive-file check
+        rename_pos = SRC.find(".rename(", proactive_block_start)
+        self.assertGreater(rename_pos, 0, "rename call not found after proactive- block")
+
+        # Peek must come BEFORE rename
+        self.assertLess(
+            peek_pos,
+            rename_pos,
+            "peek must appear before .rename() in the proactive-file processing block. "
+            "Without this ordering, the guard doesn't work — slack-bridge would claim "
+            "the file before checking its content.",
+        )
+
+    def test_snowflake_regex_present(self):
+        """The guard must use a Discord snowflake regex (17-20 digits) to avoid
+        false-positive matches on Slack channel IDs (which start with C/D prefix,
+        not pure digits).
+        """
+        self.assertIn(
+            r"\d{17,20}",
+            SRC,
+            "Snowflake regex (\\d{17,20}) must be present to distinguish Discord "
+            "channel IDs from Slack channel IDs",
+        )
+
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestSlackBridgeChannelRedirectGuard)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)


### PR DESCRIPTION
## Summary

Closes #1401. Fixes a race condition where slack-bridge claims a proactive file intended for Discord before discord-bridge can process it.

**Incident (2026-06-01):** `proactive-*.txt` starting with `[channel: 1509576272920182874]` was claimed by slack-bridge, which has no `[channel:]` handler, so it sent the literal text (including the marker) to the owner's Slack DM. The Discord `#design` channel never received the post.

## Fix

Peek at file content before rename-claim. Skip if body starts with `[channel: <17-20 digit snowflake>]` — this is a Discord-specific marker (Discord snowflakes are 17-20 digits; Slack channel IDs use `C`/`D` prefix, so no false-positive risk).

The peek-before-claim approach is the same as Chi's local fix on `fix/slack-bridge-channel-redirect-1401` (commit 7bd9b8b). This implementation mirrors it.

## Test plan

- [x] `python3 -m py_compile` — syntax ok
- [ ] Integration: write `proactive-test.txt` with `[channel: 1509576272920182874]\ntest body` — verify slack-bridge skips it, discord-bridge delivers it

Closes #1401.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)