### PR TITLE
fix(discord-voice): move turnSpeakers.add after bot filter + self-audio guard (#1465)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -718,6 +718,12 @@ function subscribeUser(s: DiscordVoiceSession, userId: string): void {
 
 	let chunks = 0;
 	resampler.on('data', (pcm16Mono: Buffer) => {
+		// Defense-in-depth: never pipe our own TTS output back to Gemini as
+		// user input. Discord echoes the bot's own speaking event back to its
+		// receiver; if the isBot check above raced (fetch error → isBot=false),
+		// this guard catches the audio before it reaches handleAudioFromClient.
+		// (#1465)
+		if (userId === s.client.user?.id) return;
 		chunks++;
 		try { (s.voiceSession as any).handleAudioFromClient(pcm16Mono); } catch {}
 		(s as any)._noteSpoken?.();
@@ -1081,9 +1087,6 @@ async function createVoiceSession(connection: VoiceConnection, client: Client): 
 
 	// Subscribe to anyone currently speaking, and to anyone who starts.
 	connection.receiver.speaking.on('start', async (userId) => {
-		// Attribute this speaker to the in-progress turn. The gate resolves
-		// the turn's effective tier across the whole set (cleared on turn.end).
-		s.turnSpeakers.add(userId);
 		// Bot/human discrimination (#1096). Discord's gateway exposes `User.bot`;
 		// without this check the receiver would happily pipe peer-bot audio to
 		// Gemini, which both wastes API quota and causes attribution errors
@@ -1106,6 +1109,12 @@ async function createVoiceSession(connection: VoiceConnection, client: Client): 
 			console.log(`${ts()} [Voice] ignoring bot user ${userId} (not in SUTANDO_ALLOWED_BOT_USER_IDS)`);
 			return;
 		}
+		// Attribute this speaker to the in-progress turn only after confirming
+		// they are not a filtered bot. Bots excluded above must not pollute
+		// turnSpeakers — effectiveTier() reads that set to gate tool access,
+		// and a bot userId resolves to a non-owner tier, potentially blocking
+		// the owner's tools during overlapping speech. (#1465)
+		s.turnSpeakers.add(userId);
 		subscribeUser(s, userId);
 	});
 	// Start the constant-rate ticker that flushes audio to Gemini every 20ms.

--- a/tests/discord-voice-bot-speaker-attribution.test.py
+++ b/tests/discord-voice-bot-speaker-attribution.test.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Structural regression test for the discord-voice bot-speaker attribution fix (#1465).
+
+Guards two invariants in skills/discord-voice/scripts/discord-voice-server.ts:
+
+1. turnSpeakers.add(userId) must appear AFTER the isBot check in the speaking.start
+   handler. Before this fix, bots added to turnSpeakers (even when correctly excluded
+   from audio subscription) caused effectiveTier() to resolve to 'other', blocking
+   the owner's tools during any turn overlapping with bot speech.
+
+2. subscribeUser's PCM data handler must contain a self-audio guard
+   (userId === s.client.user?.id) as defense-in-depth against the case where the
+   isBot check races (catch path sets isBot=false, subscribing the bot temporarily).
+
+Run: python3 tests/discord-voice-bot-speaker-attribution.test.py
+Exit: 0 = all pass, 1 = failure
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = (REPO / "skills" / "discord-voice" / "scripts" / "discord-voice-server.ts").read_text()
+
+_FAILURES: list[str] = []
+
+
+def fail(msg: str) -> None:
+    _FAILURES.append(msg)
+    print(f"FAIL: {msg}", file=sys.stderr)
+
+
+def check_turnspeakers_after_bot_filter() -> None:
+    """turnSpeakers.add must appear after the isBot guard, not before it.
+
+    The speaking.start handler must:
+      1. Fetch isBot (with botFlagCache)
+      2. Return early if (isBot && !ALLOWED_BOT_USER_IDS.has(userId))
+      3. THEN call turnSpeakers.add(userId)
+
+    If turnSpeakers.add appears before the bot check, filtered bots contaminate
+    the tier gate and can drop the owner's effective tier to 'other'.
+    """
+    # Find the speaking.start handler block
+    handler_match = re.search(
+        r"connection\.receiver\.speaking\.on\('start'.*?subscribeUser\(s, userId\);?\s*\}\);",
+        SRC,
+        re.DOTALL,
+    )
+    if not handler_match:
+        fail("Could not locate speaking.start handler in discord-voice-server.ts")
+        return
+
+    handler = handler_match.group(0)
+
+    # Find positions of the key constructs within the handler
+    bot_filter_pos = handler.find("!ALLOWED_BOT_USER_IDS.has(userId)")
+    turnspeakers_pos = handler.find("turnSpeakers.add(userId)")
+
+    if bot_filter_pos == -1:
+        fail("Could not find bot filter (ALLOWED_BOT_USER_IDS check) in speaking.start handler")
+        return
+
+    if turnspeakers_pos == -1:
+        fail("Could not find turnSpeakers.add(userId) in speaking.start handler")
+        return
+
+    if turnspeakers_pos <= bot_filter_pos:
+        fail(
+            f"turnSpeakers.add(userId) appears at position {turnspeakers_pos} BEFORE the "
+            f"bot filter at {bot_filter_pos} — bots will contaminate the tier gate. "
+            "turnSpeakers.add must come after the ALLOWED_BOT_USER_IDS guard."
+        )
+    else:
+        print(f"OK: turnSpeakers.add is after bot filter ({bot_filter_pos} < {turnspeakers_pos})")
+
+
+def check_self_audio_guard() -> None:
+    """subscribeUser's data handler must drop chunks from the bot's own userId.
+
+    The guard `if (userId === s.client.user?.id) return;` prevents our own TTS
+    output from being fed back to Gemini as user input when the bot's speaking
+    event is incorrectly subscribed (e.g., on isBot fetch error).
+    """
+    # Find subscribeUser function body
+    func_match = re.search(
+        r"function subscribeUser\(.*?\n\}",
+        SRC,
+        re.DOTALL,
+    )
+    if not func_match:
+        fail("Could not locate subscribeUser function in discord-voice-server.ts")
+        return
+
+    func_body = func_match.group(0)
+
+    # Check for the self-audio guard
+    if "userId === s.client.user?.id" not in func_body:
+        fail(
+            "subscribeUser data handler is missing the self-audio guard "
+            "(userId === s.client.user?.id). Without this, the bot's own TTS "
+            "output can be fed back to Gemini as user input on isBot fetch errors."
+        )
+    else:
+        print("OK: self-audio guard present in subscribeUser data handler")
+
+    # The guard must appear before the handleAudioFromClient *call* (not comment).
+    # Strip single-line comments before searching to avoid matching the guard's
+    # own explanatory comment "// ... reaches handleAudioFromClient" at an earlier pos.
+    func_body_no_comments = re.sub(r"//[^\n]*", "", func_body)
+    guard_pos = func_body_no_comments.find("userId === s.client.user?.id")
+    handle_pos = func_body_no_comments.find("handleAudioFromClient")
+    if guard_pos != -1 and handle_pos != -1 and guard_pos >= handle_pos:
+        fail(
+            f"Self-audio guard at position {guard_pos} appears AFTER "
+            f"handleAudioFromClient call at {handle_pos} — the guard must precede the call."
+        )
+    elif guard_pos != -1 and handle_pos != -1:
+        print(f"OK: self-audio guard precedes handleAudioFromClient call ({guard_pos} < {handle_pos})")
+
+
+def check_bot_filter_present() -> None:
+    """The ALLOWED_BOT_USER_IDS bot filter must still be present (not accidentally removed)."""
+    if "ALLOWED_BOT_USER_IDS.has(userId)" not in SRC:
+        fail(
+            "Bot filter (ALLOWED_BOT_USER_IDS.has(userId)) is missing from "
+            "discord-voice-server.ts — the speaking.start handler must still "
+            "exclude non-allowlisted bots from audio subscription."
+        )
+    else:
+        print("OK: ALLOWED_BOT_USER_IDS bot filter present")
+
+
+if __name__ == "__main__":
+    check_bot_filter_present()
+    check_turnspeakers_after_bot_filter()
+    check_self_audio_guard()
+
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} test(s) failed.", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print("\nAll checks passed.")
+        sys.exit(0)


### PR DESCRIPTION
## Summary

Closes #1465. Fixes two related cross-hearing issues in `skills/discord-voice/scripts/discord-voice-server.ts`:

- **Fix 1 (turnSpeakers contamination):** `turnSpeakers.add(userId)` was called at the top of the `speaking.start` handler, _before_ the `isBot` check. Filtered bots (peer bots not in `ALLOWED_BOT_USER_IDS`) still landed in `turnSpeakers`. Since `effectiveTier()` reads that set to gate owner-tier tool access, a bot userId resolving to a non-owner tier could deny the owner's tools during overlapping speech. Moved `turnSpeakers.add` to _after_ the bot filter so only real speakers (humans + explicitly allowlisted bots) are attributed.

- **Fix 2 (self-audio guard, defense-in-depth):** Added `if (userId === s.client.user?.id) return` at the top of the `subscribeUser` PCM data handler. Prevents our own TTS output from being piped back to Gemini as user input in the event the `isBot` check above races (the `catch` path sets `isBot = false`, which would cause subscription). This is belt-and-suspenders for the self-echo path.

## Test plan

- [ ] Join a Discord voice channel with a peer Sutando bot in the same channel — confirm bot speech no longer appears in `v_discord_voice` rows attributed to the controller
- [ ] Confirm owner tool-tier is unaffected when the bot is actively speaking TTS (no spurious `non-owner tier` denials during playback)
- [ ] `speaking.start` fires for a non-allowlisted bot → bot is skipped, `turnSpeakers` does not contain the bot userId → `currentTier()` returns correct owner tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)