### PR TITLE
fix(health-check): remove duplicate check_battery/check_memory bodies (PR #1515)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1194,73 +1194,8 @@ def run_all_checks() -> list[dict]:
             checks.append({"name": "sutando-app", "status": "warn", "detail": f"detection failed (pgrep: {pgrep_err or 'unknown error'}) — actual app state unknown"})
 
     # Battery and memory health checks
-# -------------------------
 
-def check_battery() -> dict:
-    """Check power source and battery level (macOS only). Issue #1486."""
-    name = "battery"
-    warn_pct = int(os.environ.get("SUTANDO_BATTERY_WARN_PCT", "20"))
-    try:
-        result = subprocess.run(
-            ["pmset", "-g", "batt"],
-            capture_output=True, text=True, timeout=5
-        )
-        output = result.stdout
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        return {"name": name, "status": "ok", "detail": "pmset not available (not macOS or VM)"}
-
-    if "AC Power" in output:
-        # Plugged in — no concern, but extract percentage if available
-        import re
-        m = re.search(r'(\d+)%', output)
-        pct = int(m.group(1)) if m else None
-        detail = f"AC power" + (f", {pct}% charged" if pct is not None else "")
-        return {"name": name, "status": "ok", "detail": detail}
-
-    if "Battery Power" in output or "'Battery Power'" in output:
-        import re
-        m = re.search(r'(\d+)%', output)
-        pct = int(m.group(1)) if m else None
-        if pct is None:
-            return {"name": name, "status": "warn", "detail": "on battery — level unknown"}
-        if pct <= warn_pct:
-            return {"name": name, "status": "fail", "detail": f"on battery at {pct}% — critically low (threshold {warn_pct}%)"}
-        return {"name": name, "status": "warn", "detail": f"on battery at {pct}% — no AC power"}
-
-    return {"name": name, "status": "ok", "detail": "power state unknown"}
-
-def check_memory() -> dict:
-    """Warn when system memory is critically low — OOM kills crash mid-task. Issue #1485."""
-    name = "memory"
-    warn_mb = int(os.environ.get("SUTANDO_MEMORY_WARN_FREE_MB", "500"))
-    fail_mb = int(os.environ.get("SUTANDO_MEMORY_FAIL_FREE_MB", "200"))
-    try:
-        result = subprocess.run(
-            ["top", "-l", "1", "-s", "0", "-n", "0"],
-            capture_output=True, text=True, timeout=10
-        )
-        output = result.stdout
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        return {"name": name, "status": "ok", "detail": "top not available (non-macOS or VM)"}
-
-    import re as _re
-    m = _re.search(r'PhysMem:.+?(\d+)([MGT])\s+unused', output)
-    if not m:
-        return {"name": name, "status": "ok", "detail": "memory info unavailable"}
-
-    val, unit = int(m.group(1)), m.group(2)
-    free_mb = val * 1024 if unit == "G" else (val * 1024 if unit == "T" else val)
-
-    if free_mb <= fail_mb:
-        return {"name": name, "status": "fail",
-                "detail": f"{free_mb}M free — critically low (threshold {fail_mb}M)"}
-    if free_mb <= warn_mb:
-        return {"name": name, "status": "warn",
-                "detail": f"{free_mb}M free — low (threshold {warn_mb}M)"}
-    return {"name": name, "status": "ok", "detail": f"{free_mb}M free"}
-
-
-# Stuck-loop / queue-pileup detection — consequence-level signals that
+    # Stuck-loop / queue-pileup detection — consequence-level signals that
     # fire whether the watcher died, the proactive loop crashed mid-pass, or
     # both. Independent of which mechanism died.
     loop_stale_sec = int(os.environ.get("SUTANDO_HEALTH_LOOP_STALE_SEC", "600"))


### PR DESCRIPTION
Fixes the duplicate function definition bug reported in PR #1515 comments.

## Problem

`check_battery()` and `check_memory()` were defined twice:
- First (correct) at module level: lines 663 and 696
- Second (duplicate) inside `run_all_checks()`: lines 1199 and 1232

Python silently uses the second definition, making the first block dead code. The `# Stuck-loop` comment at line 1263 also had wrong indentation (column 0 instead of 4 spaces — it's inside `run_all_checks()`).

Root cause: the diff was constructed with two hunks for the call-site addition inside `run_all_checks()`. One hunk was correct (just the `checks.append()` lines); the other accidentally re-inserted the full function bodies at the call site.

## Fix

- Remove lines 1197-1261: the `# ---` separator + both duplicate function bodies (65 lines)
- Fix `# Stuck-loop` comment indentation (4 spaces, not 0)
- `python3 -m py_compile src/health-check.py` passes

## Test plan

- [x] `python3 -m py_compile src/health-check.py` — syntax ok
- [x] `grep -c 'def check_battery(' src/health-check.py` → 1
- [x] `grep -c 'def check_memory(' src/health-check.py` → 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)