### PR TITLE
feat(discord-voice): per-speaker ASR for accurate multi-user attribution (#1456)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -48,6 +48,7 @@ import { loadVoiceConfig, resolveOwnerMode } from '../../../src/voice-config.js'
 import { execSync, spawn } from 'node:child_process';
 import { VoiceSession, type ToolDefinition, type MainAgent } from 'bodhi-realtime-agent';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { GoogleGenAI } from '@google/genai';
 import { z } from 'zod';
 import { Client, GatewayIntentBits, ChannelType } from 'discord.js';
 import {
@@ -303,6 +304,71 @@ function upsample24MonoTo48Stereo(pcm: Buffer): Buffer {
 		out[off + 2] = v; out[off + 3] = v;
 	}
 	return Buffer.from(out.buffer, out.byteOffset, out.byteLength);
+}
+
+// --- Per-speaker ASR (recording layer only, parallel to Gemini Live) --------
+
+const _perSpeakerGenAI = new GoogleGenAI({ apiKey: GEMINI_API_KEY });
+
+/**
+ * Transcribe a single utterance from one speaker using Gemini Flash
+ * (generateContent with inline audio). Called from subscribeUser's
+ * resampler.on('end') after each utterance completes.
+ *
+ * The per-user resampled PCM is 16 kHz mono s16le — send as WAV with
+ * a minimal 44-byte header so Gemini accepts the MIME type `audio/wav`.
+ *
+ * Best-effort: errors are logged but never propagate.
+ */
+async function transcribeUtterance(
+	pcmChunks: Buffer[],
+	userId: string,
+	sessionId: string,
+): Promise<void> {
+	if (pcmChunks.length === 0) return;
+	try {
+		const pcm = Buffer.concat(pcmChunks);
+		const sampleRate = 16000;
+		const channels = 1;
+		const bitsPerSample = 16;
+		const byteRate = sampleRate * channels * (bitsPerSample / 8);
+		const blockAlign = channels * (bitsPerSample / 8);
+		const dataSize = pcm.length;
+		const header = Buffer.alloc(44);
+		header.write('RIFF', 0, 'ascii');
+		header.writeUInt32LE(36 + dataSize, 4);
+		header.write('WAVE', 8, 'ascii');
+		header.write('fmt ', 12, 'ascii');
+		header.writeUInt32LE(16, 16);
+		header.writeUInt16LE(1, 20);
+		header.writeUInt16LE(channels, 22);
+		header.writeUInt32LE(sampleRate, 24);
+		header.writeUInt32LE(byteRate, 28);
+		header.writeUInt16LE(blockAlign, 32);
+		header.writeUInt16LE(bitsPerSample, 34);
+		header.write('data', 36, 'ascii');
+		header.writeUInt32LE(dataSize, 40);
+		const wav = Buffer.concat([header, pcm]);
+		const b64 = wav.toString('base64');
+
+		const resp = await _perSpeakerGenAI.models.generateContent({
+			model: 'gemini-2.0-flash',
+			contents: [{
+				role: 'user',
+				parts: [
+					{ inlineData: { mimeType: 'audio/wav', data: b64 } },
+					{ text: 'Transcribe this audio exactly. Output only the transcript, no commentary.' },
+				],
+			}],
+		});
+		const transcript = resp.text?.trim();
+		if (transcript) {
+			recordConversation('discord-user', transcript, sessionId, userId);
+			console.log(`${ts()} [ASR] ${userId}: "${transcript.slice(0, 80)}"`);
+		}
+	} catch (e) {
+		console.error(`${ts()} [ASR] transcription failed for ${userId}:`, e);
+	}
 }
 
 // --- Active session ---------------------------------------------------------
@@ -717,11 +783,13 @@ function subscribeUser(s: DiscordVoiceSession, userId: string): void {
 	opusStream.pipe(decoder).pipe(resampler);
 
 	let chunks = 0;
+	const _asrBuffer: Buffer[] = [];
 	resampler.on('data', (pcm16Mono: Buffer) => {
 		chunks++;
 		try { (s.voiceSession as any).handleAudioFromClient(pcm16Mono); } catch {}
 		(s as any)._noteSpoken?.();
 		s.lastUserAudioAt = Date.now();
+		_asrBuffer.push(pcm16Mono);
 		if (chunks === 1) console.log(`${ts()} [Voice] first chunk: ${pcm16Mono.length}B`);
 	});
 	resampler.on('end', () => {
@@ -732,6 +800,13 @@ function subscribeUser(s: DiscordVoiceSession, userId: string): void {
 		// a hang apart from a normal pause.
 		(s as any).lastSpeakStopTs = Date.now();
 		(s as any).utterancesSinceTurn = ((s as any).utterancesSinceTurn || 0) + 1;
+		// Per-speaker ASR: transcribe this utterance and record with the
+		// speaker's userId so multi-human turns are attributed correctly in
+		// the discord_voice table. Runs in parallel to the Gemini Live turn
+		// — this is the recording layer only. (#1456)
+		if (_asrBuffer.length > 0) {
+			void transcribeUtterance(_asrBuffer.splice(0), userId, s.sessionId);
+		}
 		triggerSilenceBurst(s);
 	});
 	resampler.on('error', (e) => {

--- a/src/conversation-store.ts
+++ b/src/conversation-store.ts
@@ -105,6 +105,17 @@ function init(): void {
 				if (!hasKind) {
 					db.exec('ALTER TABLE discord_voice RENAME TO discord_voice_legacy');
 					console.log('[conversation-store] renamed legacy discord_voice → discord_voice_legacy (different schema)');
+				} else {
+					// Add speaker_id column if missing (introduced in #1456 per-speaker ASR).
+					const hasSpeakerId = cols.some(c => c.name === 'speaker_id');
+					if (!hasSpeakerId) {
+						try {
+							db.exec('ALTER TABLE discord_voice ADD COLUMN speaker_id TEXT');
+							console.log('[conversation-store] added speaker_id column to discord_voice');
+						} catch (e) {
+							console.error('[conversation-store] speaker_id migration failed (non-fatal):', e);
+						}
+					}
 				}
 			}
 		} catch (e) {
@@ -145,11 +156,13 @@ function init(): void {
 				kind        TEXT    NOT NULL,
 				text        TEXT,
 				duration_ms INTEGER,
-				session_id  TEXT
+				session_id  TEXT,
+				speaker_id  TEXT
 			);
 			CREATE INDEX IF NOT EXISTS idx_discord_voice_ts ON discord_voice(ts_unix);
 			CREATE INDEX IF NOT EXISTS idx_discord_voice_kind_ts ON discord_voice(kind, ts_unix);
 			CREATE INDEX IF NOT EXISTS idx_discord_voice_session ON discord_voice(session_id, ts_unix);
+			CREATE INDEX IF NOT EXISTS idx_discord_voice_speaker ON discord_voice(speaker_id, ts_unix);
 
 			-- Per-session rollup. Kept — different concern from the per-event log.
 			-- Per-tool-call rows live in surface tables (kind='tool_call'),
@@ -239,7 +252,7 @@ function init(): void {
 				FROM phone ORDER BY ts_unix DESC;
 			CREATE VIEW v_discord_voice AS
 				SELECT id, datetime(ts_unix,'unixepoch','localtime') AS time,
-					ts_unix, kind, text, duration_ms, session_id
+					ts_unix, kind, text, duration_ms, session_id, speaker_id
 				FROM discord_voice ORDER BY ts_unix DESC;
 			CREATE VIEW v_sessions AS
 				SELECT datetime(ts_unix,'unixepoch','localtime') AS time,
@@ -267,7 +280,7 @@ function init(): void {
 			'INSERT INTO phone (ts_unix, kind, text, duration_ms, session_id) VALUES (?, ?, ?, ?, ?)',
 		);
 		turnStmt['discord-voice'] = db.prepare(
-			'INSERT INTO discord_voice (ts_unix, kind, text, duration_ms, session_id) VALUES (?, ?, ?, ?, ?)',
+			'INSERT INTO discord_voice (ts_unix, kind, text, duration_ms, session_id, speaker_id) VALUES (?, ?, ?, ?, ?, ?)',
 		);
 		sessionInsertStmt = db.prepare(`
 			INSERT INTO sessions (
@@ -443,13 +456,17 @@ function migrateLegacyIfNeeded(d: DatabaseSync): void {
 /** Record a conversation turn. Source is derived from `role` (`phone-*` →
  *  phone, `discord-*` → discord_voice, otherwise voice); `kind` is
  *  normalized (user / agent / peer / SESSION_END / other). Best-effort. */
-export function recordConversation(role: string, text: string, sessionId?: string): void {
+export function recordConversation(role: string, text: string, sessionId?: string, speakerId?: string): void {
 	init();
 	const source = sourceFromRole(role);
 	const stmt = turnStmt[source];
 	if (!stmt) return;
 	try {
-		stmt.run(Date.now() / 1000, kindFromRole(role), text, null, sessionId ?? null);
+		if (source === 'discord-voice') {
+			stmt.run(Date.now() / 1000, kindFromRole(role), text, null, sessionId ?? null, speakerId ?? null);
+		} else {
+			stmt.run(Date.now() / 1000, kindFromRole(role), text, null, sessionId ?? null);
+		}
 	} catch (e) {
 		console.error('[conversation-store] insert failed:', e);
 	}

--- a/tests/discord-voice-per-speaker-asr.test.py
+++ b/tests/discord-voice-per-speaker-asr.test.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Structural tests for per-speaker ASR in discord-voice-server.ts (#1456).
+
+Verifies:
+1. GoogleGenAI is imported from @google/genai
+2. _perSpeakerGenAI is declared at module level
+3. transcribeUtterance function exists
+4. WAV header construction is present (44-byte header)
+5. subscribeUser buffers PCM chunks (_asrBuffer)
+6. subscribeUser calls transcribeUtterance on utterance end (resampler.on('end'))
+7. conversation-store: discord_voice table has speaker_id column in CREATE TABLE
+8. conversation-store: recordConversation accepts speakerId parameter
+9. speaker_id is included in turnStmt INSERT for discord-voice
+
+Run: python3 tests/discord-voice-per-speaker-asr.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DISCORD_VOICE_SERVER = REPO / "skills" / "discord-voice" / "scripts" / "discord-voice-server.ts"
+CONVERSATION_STORE = REPO / "src" / "conversation-store.ts"
+
+_FAILURES: list[str] = []
+
+
+def fail(msg: str, ctx: str = "") -> None:
+    _FAILURES.append(msg)
+    print(f"FAIL: {msg}", file=sys.stderr)
+    if ctx:
+        print("--- context ---", file=sys.stderr)
+        print(ctx[:400], file=sys.stderr)
+
+
+def expect(cond: bool, label: str, ctx: str = "") -> None:
+    if not cond:
+        fail(label, ctx)
+
+
+def main() -> None:
+    for path in [DISCORD_VOICE_SERVER, CONVERSATION_STORE]:
+        if not path.exists():
+            fail(f"file not found: {path}")
+            sys.exit(1)
+
+    src = DISCORD_VOICE_SERVER.read_text()
+    store = CONVERSATION_STORE.read_text()
+
+    # 1. GoogleGenAI imported
+    expect(
+        "GoogleGenAI" in src and "@google/genai" in src,
+        "discord-voice-server.ts: must import GoogleGenAI from @google/genai",
+    )
+
+    # 2. _perSpeakerGenAI declared at module level
+    expect(
+        "_perSpeakerGenAI" in src,
+        "discord-voice-server.ts: must declare _perSpeakerGenAI at module level",
+    )
+
+    # 3. transcribeUtterance function exists
+    expect(
+        "async function transcribeUtterance(" in src,
+        "discord-voice-server.ts: must define async function transcribeUtterance",
+    )
+
+    # 4. WAV header (44-byte) construction in transcribeUtterance
+    fn_match = re.search(
+        r"async function transcribeUtterance\(.*?\n\}",
+        src,
+        re.DOTALL,
+    )
+    fn_body = fn_match.group(0) if fn_match else ""
+    expect(fn_body != "", "discord-voice-server.ts: transcribeUtterance must exist", fn_body[:100])
+    expect(
+        "RIFF" in fn_body and "WAVE" in fn_body and "audio/wav" in fn_body,
+        "discord-voice-server.ts: transcribeUtterance must build WAV header and use audio/wav MIME",
+        ctx=fn_body[:400],
+    )
+
+    # 5. _asrBuffer declared inside subscribeUser
+    sub_match = re.search(
+        r"function subscribeUser\(.*?\n\}",
+        src,
+        re.DOTALL,
+    )
+    sub_body = sub_match.group(0) if sub_match else ""
+    expect(sub_body != "", "discord-voice-server.ts: subscribeUser must exist")
+    expect(
+        "_asrBuffer" in sub_body,
+        "discord-voice-server.ts: subscribeUser must declare _asrBuffer for per-user PCM buffering",
+        ctx=sub_body[:400],
+    )
+
+    # 6. transcribeUtterance called in resampler.on('end') inside subscribeUser
+    expect(
+        "transcribeUtterance" in sub_body,
+        "discord-voice-server.ts: subscribeUser must call transcribeUtterance on utterance end",
+        ctx=sub_body[:600],
+    )
+
+    # 7. discord_voice table has speaker_id column
+    expect(
+        "speaker_id  TEXT" in store or "speaker_id TEXT" in store,
+        "conversation-store.ts: discord_voice CREATE TABLE must include speaker_id TEXT column",
+    )
+
+    # 8. recordConversation accepts speakerId param
+    rc_match = re.search(r"export function recordConversation\([^)]+\)", store)
+    rc_sig = rc_match.group(0) if rc_match else ""
+    expect(
+        "speakerId" in rc_sig,
+        "conversation-store.ts: recordConversation must accept speakerId parameter",
+        ctx=rc_sig,
+    )
+
+    # 9. turnStmt INSERT for discord-voice includes speaker_id
+    expect(
+        "INSERT INTO discord_voice" in store and "speaker_id" in store,
+        "conversation-store.ts: discord-voice INSERT statement must include speaker_id column",
+    )
+
+    # Summary
+    if _FAILURES:
+        print(f"\n{len(_FAILURES)} test(s) FAILED:", file=sys.stderr)
+        for f in _FAILURES:
+            print(f"  - {f}", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print(f"All 9 structural tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #1456

## Problem

In a Discord voice channel with 2+ humans, all audio feeds into one Gemini Live session → one merged transcript per turn → all utterances attributed to one speaker. Multi-user Discord voice sessions produce mis-attributed or missing rows in `v_discord_voice`.

## Approach (sonichi option 1 from #1456)

Add a **parallel recording layer** using Gemini Flash `generateContent` with inline audio. Each user's already-separate resampled PCM stream (from `subscribeUser`) gets buffered per utterance, then sent to Gemini Flash for transcription when the utterance ends (silence gate). The resulting transcript is recorded with `speaker_id = userId`.

The Gemini Live session is **unchanged** — it still drives the live conversation. This is recording-only.

## Changes

**`src/conversation-store.ts`**
- Add `speaker_id TEXT` column to `discord_voice` table schema
- `ALTER TABLE ADD COLUMN` migration for existing databases (idempotent)
- Update `v_discord_voice` view to include `speaker_id`
- Extend `recordConversation(role, text, sessionId, speakerId?)` with optional 4th param (only used for `discord-voice` source)
- Update `turnStmt['discord-voice']` INSERT to `VALUES (?, ?, ?, ?, ?, ?)` with `speaker_id`

**`skills/discord-voice/scripts/discord-voice-server.ts`**
- Import `GoogleGenAI` from `@google/genai` (already in package.json)
- Add `_perSpeakerGenAI` at module level
- Add `transcribeUtterance(pcmChunks, userId, sessionId)` async helper: builds WAV header, encodes to base64, calls `gemini-2.0-flash` `generateContent`, records with `speaker_id`
- In `subscribeUser`: collect PCM chunks into `_asrBuffer[]` alongside the existing Gemini Live feed; on `resampler.on('end')` (utterance complete), call `void transcribeUtterance(...)` — fire-and-forget, never blocks the sync path

**`tests/discord-voice-per-speaker-asr.test.py`**
- 9 structural tests — all pass

## Query pattern

```sql
-- Per-speaker attribution view:
SELECT speaker_id, text, datetime(ts_unix,'unixepoch','localtime') AS time
FROM discord_voice
WHERE speaker_id IS NOT NULL
ORDER BY ts_unix DESC;
```

The existing `v_discord_voice` view includes all rows (with and without `speaker_id`). New queries that care about per-speaker attribution filter `WHERE speaker_id IS NOT NULL`.

## Test plan

- [x] `python3 tests/discord-voice-per-speaker-asr.test.py` → 9 passed
- [x] `npx tsc --noEmit` → clean
- [x] `node -e "import('@google/genai').then(m => console.log(typeof m.GoogleGenAI))"` → function
- [ ] Integration: join voice channel with 2 users, verify separate `speaker_id` rows in `v_discord_voice`

🤖 Generated with [Claude Code](https://claude.com/claude-code)