### PR TITLE
feat(discord): checklist UI — [checklist] marker renders button components (#1104)

### DIFF
--- a/skills/checklist-respond/SKILL.md
+++ b/skills/checklist-respond/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: checklist-respond
+description: "Render Discord button checklists from [checklist] markers in bot replies. Handles button clicks with per-voter state persistence."
+user-invocable: false
+---
+
+# Checklist Respond
+
+Adds interactive button checklists to Discord bot replies. When a result contains a `[checklist]` marker, discord-bridge renders the items as clickable Discord buttons instead of plain text. Clicks are tracked per voter.
+
+## Usage (in bot replies)
+
+Inline form:
+```
+[checklist: Yes | No | Maybe]
+```
+
+Block form (with markdown list below):
+```
+Pick a direction:
+[checklist]
+- Option A
+- Option B
+- Option C
+```
+
+Original reply text is preserved above the buttons (mis-fires are visible and non-blocking).
+
+## Click behavior
+
+- Any allowlisted Discord user can click
+- Clicking again toggles the selection off
+- Vote summary shows per-voter side-by-side: `• Item — ✅ Alice, ✅ Bob`
+- State persisted to `$SUTANDO_WORKSPACE/state/checklists/<msg_id>.json`
+
+## Architecture
+
+- `scripts/checklist_render.py` — pure helpers (parse, build, state, render). No I/O.
+- `src/discord-bridge.py` — `on_interaction` handler + `_maybe_post_checklist` intercept in `poll_results`.
+- Gracefully absent: `_CHECKLIST_SKILL_AVAILABLE` flag; bridge starts normally if skill not installed.
+
+## Phases
+
+- **Phase 1 (this PR)**: explicit `[checklist]` opt-in marker
+- **Phase 2 (future)**: auto-detect heuristic for lettered-option / yes-no / ≥3-item list replies
+
+Design from issue #1104 (Lucy + Chi, 2026-05-25).

--- a/skills/checklist-respond/scripts/checklist_render.py
+++ b/skills/checklist-respond/scripts/checklist_render.py
@@ -1,0 +1,158 @@
+"""Render a checklist as Discord Components V2 buttons and manage click state.
+
+Used by discord-bridge.py's on_interaction handler and the [checklist] marker
+post-processor. Pure helpers — no I/O, fully unit-testable.
+
+Design from issue #1104 (Lucy + Chi 2026-05-25):
+- Phase 1: explicit [checklist] opt-in marker (this module)
+- Phase 2: auto-detect heuristic (future)
+- Owner pref: preserve original text below buttons, voter-per-row style
+- MVP rollout: [checklist] marker → list items become buttons
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+# Maximum buttons per Discord row (Discord API limit).
+_ROW_LIMIT = 5
+# Maximum rows per message (Discord API limit).
+_MAX_ROWS = 5
+# Prefix stored in button custom_id to identify our checklist interactions.
+CUSTOM_ID_PREFIX = "ck:"
+
+
+def parse_checklist_marker(text: str) -> Optional[tuple[list[str], str]]:
+    """Parse a [checklist] marker from bot reply text.
+
+    Returns (items, body_without_marker) or None if no marker.
+
+    Supported forms:
+      [checklist: item1 | item2 | item3]  — inline pipe-separated
+      [checklist]                          — uses the markdown list below the marker
+    """
+    # Inline form: [checklist: a | b | c]
+    m = re.search(r'\[checklist:\s*([^\]]+)\]', text, re.IGNORECASE)
+    if m:
+        raw = m.group(1)
+        items = [i.strip() for i in raw.split("|") if i.strip()]
+        body = text[:m.start()].rstrip() + "\n" + text[m.end():].lstrip()
+        return items, body.strip()
+
+    # Bare marker [checklist] followed by a markdown list
+    m = re.search(r'\[checklist\]', text, re.IGNORECASE)
+    if m:
+        after = text[m.end():]
+        items = re.findall(r'^\s*[-*]\s+(.+)$', after, re.MULTILINE)
+        if items:
+            body = text[:m.start()].rstrip()
+            return items, body.strip()
+
+    return None
+
+
+def build_view_spec(items: list[str], msg_id: str) -> list[dict]:
+    """Return a serialisable list of row-specs for the Discord view.
+
+    Each row-spec: {"buttons": [{"label": str, "custom_id": str, "style": str}]}
+    The caller (discord-bridge.py) converts this into discord.ui.View buttons.
+
+    custom_id format: "ck:<msg_id>:<item_index>"
+    """
+    rows: list[dict] = []
+    row_buttons: list[dict] = []
+    for idx, item in enumerate(items):
+        if len(row_buttons) >= _ROW_LIMIT:
+            rows.append({"buttons": row_buttons})
+            row_buttons = []
+        if len(rows) >= _MAX_ROWS:
+            break  # Discord hard cap
+        row_buttons.append({
+            "label": item[:80],  # Discord button label limit
+            "custom_id": f"{CUSTOM_ID_PREFIX}{msg_id}:{idx}",
+            "style": "secondary",  # grey = unchecked default
+        })
+    if row_buttons:
+        rows.append({"buttons": row_buttons})
+    return rows
+
+
+def load_state(state_dir: Path, msg_id: str) -> dict:
+    """Load persisted checklist state for a message. Returns {} if missing."""
+    p = state_dir / "checklists" / f"{msg_id}.json"
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return {}
+
+
+def save_state(state_dir: Path, msg_id: str, state: dict) -> None:
+    """Persist checklist click state for a message."""
+    d = state_dir / "checklists"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{msg_id}.json").write_text(json.dumps(state))
+
+
+def apply_click(
+    state: dict,
+    item_idx: int,
+    clicker_id: str,
+    clicker_name: str,
+    items: list[str],
+) -> dict:
+    """Record a button click and return the updated state.
+
+    State schema:
+      {"items": [str, ...], "votes": {"<item_idx>": {"<user_id>": "<name>", ...}}}
+
+    Per owner pref (#1104 comment): per-voter side-by-side, not aggregate tally.
+    Clicking again toggles off (deselects).
+    """
+    state.setdefault("items", items)
+    votes: dict[str, dict] = state.setdefault("votes", {})
+    key = str(item_idx)
+    item_votes: dict = votes.setdefault(key, {})
+    if clicker_id in item_votes:
+        del item_votes[clicker_id]  # toggle off
+    else:
+        item_votes[clicker_id] = clicker_name
+    return state
+
+
+def render_vote_summary(state: dict) -> str:
+    """Render the current vote state as plain text for the message body.
+
+    Format (per owner pref — per-voter side-by-side):
+      • Item text — ✅ Alice, ❌ Bob
+    Items with no votes are rendered without a vote suffix.
+    """
+    items: list[str] = state.get("items", [])
+    votes: dict = state.get("votes", {})
+    lines = []
+    for idx, item in enumerate(items):
+        item_votes = votes.get(str(idx), {})
+        if item_votes:
+            voter_tags = ", ".join(
+                f"✅ {name}" for name in item_votes.values()
+            )
+            lines.append(f"• {item} — {voter_tags}")
+        else:
+            lines.append(f"• {item}")
+    return "\n".join(lines)
+
+
+def parse_custom_id(custom_id: str) -> Optional[tuple[str, int]]:
+    """Parse custom_id → (msg_id, item_idx) or None if not ours."""
+    if not custom_id.startswith(CUSTOM_ID_PREFIX):
+        return None
+    rest = custom_id[len(CUSTOM_ID_PREFIX):]
+    parts = rest.rsplit(":", 1)
+    if len(parts) != 2:
+        return None
+    try:
+        return parts[0], int(parts[1])
+    except ValueError:
+        return None

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -59,6 +59,21 @@ from util_paths import shared_personal_path  # noqa: E402
 from task_priority import default_priority_for_source  # noqa: E402
 from task_archive import find_task_file  # noqa: E402
 from result_markers import parse_markers  # noqa: E402
+# Checklist skill helpers (optional — gracefully absent if skill not installed)
+try:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "skills" / "checklist-respond" / "scripts"))
+    from checklist_render import (  # noqa: E402
+        parse_checklist_marker,
+        build_view_spec,
+        load_state,
+        save_state,
+        apply_click,
+        render_vote_summary,
+        parse_custom_id,
+    )
+    _CHECKLIST_SKILL_AVAILABLE = True
+except ImportError:
+    _CHECKLIST_SKILL_AVAILABLE = False
 REPO = resolve_workspace()
 
 # discord-voice "magic word" join trigger (issue: za-warudo summon). The
@@ -2149,6 +2164,126 @@ async def on_message_edit(before, after):
     await _handle_discord_message(after, force=True)
 
 
+# ---------------------------------------------------------------------------
+# Discord checklist interaction handler (issue #1104)
+# Handles button clicks on messages posted with [checklist] marker.
+# No-op when checklist skill is not installed (_CHECKLIST_SKILL_AVAILABLE=False).
+# ---------------------------------------------------------------------------
+
+async def _post_checklist(channel, text: str, items: list, original_body: str) -> None:
+    """Post a message with Discord button components for a checklist.
+
+    Preserves original text below the buttons (owner pref: mis-fires are a non-event).
+    """
+    if not _CHECKLIST_SKILL_AVAILABLE:
+        await channel.send(original_body)
+        return
+
+    view = discord.ui.View(timeout=None)
+    # Placeholder message id — we need to send first, then update with real id.
+    # Build buttons with a temp prefix; on_interaction uses the real message id.
+    for idx, item in enumerate(items[:25]):  # Discord UI limit
+        btn = discord.ui.Button(
+            label=item[:80],
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"ck:pending:{idx}",
+        )
+        view.add_item(btn)
+
+    content = original_body + ("\n\n" if original_body else "") + "━━━━━━━━━━\n" + "\n".join(f"• {i}" for i in items)
+    msg = await channel.send(content, view=view)
+
+    # Rebuild view with real message id in custom_ids
+    view2 = discord.ui.View(timeout=None)
+    for idx, item in enumerate(items[:25]):
+        btn = discord.ui.Button(
+            label=item[:80],
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"ck:{msg.id}:{idx}",
+        )
+        view2.add_item(btn)
+    await msg.edit(view=view2)
+
+    # Persist initial state
+    state_dir = REPO / "state"
+    save_state(state_dir, str(msg.id), {"items": items, "votes": {}})
+
+
+@client.event
+async def on_interaction(interaction: discord.Interaction) -> None:
+    """Handle Discord button clicks for checklist items (issue #1104).
+
+    Allowlist-gated: only allowed senders can click. Unknown buttons are ignored.
+    """
+    if not _CHECKLIST_SKILL_AVAILABLE:
+        return
+    try:
+        custom_id = interaction.data.get("custom_id", "")
+        parsed = parse_custom_id(custom_id)
+        if parsed is None:
+            return  # not our button
+
+        msg_id, item_idx = parsed
+        clicker_id = str(interaction.user.id)
+
+        # Access control — only allowlisted users can interact
+        if clicker_id not in load_allowed():
+            await interaction.response.send_message("Not authorised.", ephemeral=True)
+            return
+
+        state_dir = REPO / "state"
+        state = load_state(state_dir, msg_id)
+        if not state:
+            await interaction.response.defer()
+            return
+
+        state = apply_click(state, item_idx, clicker_id, interaction.user.display_name, state.get("items", []))
+        save_state(state_dir, msg_id, state)
+
+        # Rebuild the view with updated button styles (checked = green, unchecked = grey)
+        items: list[str] = state.get("items", [])
+        voted_indices = {int(k) for k, v in state.get("votes", {}).items() if v}
+        view = discord.ui.View(timeout=None)
+        for idx, item in enumerate(items[:25]):
+            checked = idx in voted_indices
+            btn = discord.ui.Button(
+                label=item[:80],
+                style=discord.ButtonStyle.success if checked else discord.ButtonStyle.secondary,
+                custom_id=f"ck:{msg_id}:{idx}",
+            )
+            view.add_item(btn)
+
+        # Update the message with vote summary appended
+        summary = render_vote_summary(state)
+        orig_content = interaction.message.content or ""
+        # Strip old summary block if present (marked by ━━ separator)
+        sep = "━━━━━━━━━━"
+        if sep in orig_content:
+            orig_content = orig_content[:orig_content.index(sep)].rstrip()
+        new_content = orig_content + f"\n\n{sep}\n{summary}" if orig_content else summary
+        await interaction.response.edit_message(content=new_content, view=view)
+    except Exception as e:
+        print(f"  [checklist] on_interaction error: {e}", flush=True)
+        try:
+            await interaction.response.defer()
+        except Exception:
+            pass
+
+
+async def _maybe_post_checklist(channel, text: str) -> bool:
+    """Check if text has a [checklist] marker; if so, post as buttons and return True."""
+    if not _CHECKLIST_SKILL_AVAILABLE:
+        return False
+    result = parse_checklist_marker(text)
+    if result is None:
+        return False
+    items, body = result
+    if not items:
+        return False
+    await _post_checklist(channel, text, items, body)
+    return True
+
+
 async def _handle_discord_message(message, force=False):
     if message.author == client.user:
         return
@@ -3281,6 +3416,11 @@ async def poll_results():
                     files = [a.value for a in _parsed.actions if a.kind == "attach"]
 
                     # Send text — fence-aware chunker preserves triple-backtick code blocks
+                    # Checklist marker intercept: if [checklist] present, render as
+                    # Discord buttons and skip the normal send path. (#1104)
+                    if clean_text and await _maybe_post_checklist(channel, clean_text):
+                        clean_text = None  # already sent as checklist
+
                     # First chunk uses message_reference (if set); subsequent chunks
                     # are fresh — Discord allows only one reply-anchor per message,
                     # and split-chunk continuation isn't itself a reply.

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2210,7 +2210,7 @@ async def _post_checklist(channel, text: str, items: list, original_body: str) -
 
 
 @client.event
-async def on_interaction(interaction: discord.Interaction) -> None:
+async def on_interaction(interaction: "discord.Interaction") -> None:
     """Handle Discord button clicks for checklist items (issue #1104).
 
     Allowlist-gated: only allowed senders can click. Unknown buttons are ignored.

--- a/tests/discord-bridge-checklist-wiring.test.py
+++ b/tests/discord-bridge-checklist-wiring.test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Structural regression test: discord-bridge.py checklist wiring (issue #1104).
+
+Checks that the bridge contains the necessary imports, event handler, and
+poll_results intercept without requiring Discord API access.
+
+Run: python3 tests/discord-bridge-checklist-wiring.test.py
+Exit: 0 = pass, 1 = fail
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = (REPO / "src" / "discord-bridge.py").read_text()
+
+
+class TestChecklistWiring(unittest.TestCase):
+
+    def test_checklist_render_import_present(self):
+        """discord-bridge.py must import from checklist_render (guarded by try/except)."""
+        self.assertIn("from checklist_render import", SRC)
+
+    def test_import_is_guarded_by_try_except(self):
+        """Import must be wrapped in try/except so the bridge starts without the skill."""
+        try_pos = SRC.find("try:")
+        import_pos = SRC.find("from checklist_render import")
+        except_pos = SRC.find("_CHECKLIST_SKILL_AVAILABLE = False")
+        self.assertGreater(import_pos, try_pos, "checklist import must be inside try block")
+        self.assertGreater(except_pos, import_pos, "_CHECKLIST_SKILL_AVAILABLE = False must follow import")
+
+    def test_on_interaction_handler_present(self):
+        """on_interaction event handler must exist for button click processing."""
+        self.assertIn("async def on_interaction(", SRC)
+
+    def test_on_interaction_decorated(self):
+        """on_interaction must be registered with @client.event."""
+        ci_pos = SRC.find("async def on_interaction(")
+        # Search backward for @client.event
+        snippet = SRC[max(0, ci_pos - 200):ci_pos]
+        self.assertIn("@client.event", snippet)
+
+    def test_on_interaction_calls_parse_custom_id(self):
+        """on_interaction must use parse_custom_id to validate the button."""
+        ci_start = SRC.find("async def on_interaction(")
+        # Find the end of this function (next top-level @client.event or async def)
+        ci_end = SRC.find("\n@client.event", ci_start + 1)
+        if ci_end == -1:
+            ci_end = SRC.find("\nasync def _handle_discord_message", ci_start + 1)
+        handler_body = SRC[ci_start:ci_end]
+        self.assertIn("parse_custom_id", handler_body)
+
+    def test_on_interaction_access_control_present(self):
+        """on_interaction must check load_allowed() — no unauthenticated clicks."""
+        ci_start = SRC.find("async def on_interaction(")
+        ci_end = SRC.find("\nasync def _handle_discord_message", ci_start + 1)
+        handler_body = SRC[ci_start:ci_end]
+        self.assertIn("load_allowed()", handler_body)
+
+    def test_maybe_post_checklist_present(self):
+        """_maybe_post_checklist helper must exist as the poll_results intercept."""
+        self.assertIn("async def _maybe_post_checklist(", SRC)
+
+    def test_poll_results_intercept_present(self):
+        """poll_results must call _maybe_post_checklist before the normal send path."""
+        intercept_pos = SRC.find("await _maybe_post_checklist(")
+        self.assertGreater(intercept_pos, 0, "_maybe_post_checklist call not found in poll_results")
+        # The intercept must come before the first chunk-send for that result
+        send_pos = SRC.find("for chunk in _chunk_for_discord(clean_text)", intercept_pos)
+        self.assertGreater(send_pos, intercept_pos,
+            "_maybe_post_checklist must precede the chunk-send loop")
+
+    def test_checklist_skill_availability_flag(self):
+        """_CHECKLIST_SKILL_AVAILABLE flag must guard on_interaction and helper."""
+        self.assertIn("_CHECKLIST_SKILL_AVAILABLE", SRC)
+        # Both the import guard and the on_interaction guard must reference it
+        occurrences = SRC.count("_CHECKLIST_SKILL_AVAILABLE")
+        self.assertGreaterEqual(occurrences, 3,
+            "Expected ≥3 references: import-true, import-false, on_interaction guard")
+
+    def test_state_persisted_via_save_state(self):
+        """on_interaction must persist click state via save_state."""
+        ci_start = SRC.find("async def on_interaction(")
+        ci_end = SRC.find("\nasync def _handle_discord_message", ci_start + 1)
+        handler_body = SRC[ci_start:ci_end]
+        self.assertIn("save_state(", handler_body)
+
+
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(__import__("__main__"))
+    runner = unittest.TextTestRunner(verbosity=0)
+    result = runner.run(suite)
+    if result.wasSuccessful():
+        print(f"All {result.testsRun} discord-bridge-checklist-wiring tests passed.")
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/tests/discord-checklist-render.test.py
+++ b/tests/discord-checklist-render.test.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Unit tests for skills/checklist-respond/scripts/checklist_render.py.
+
+Run: python3 tests/discord-checklist-render.test.py
+Exit: 0 = all pass, 1 = failure
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "skills" / "checklist-respond" / "scripts"))
+from checklist_render import (
+    CUSTOM_ID_PREFIX,
+    apply_click,
+    build_view_spec,
+    parse_checklist_marker,
+    parse_custom_id,
+    render_vote_summary,
+    save_state,
+    load_state,
+)
+
+
+class TestParseChecklistMarker(unittest.TestCase):
+
+    def test_inline_pipe_form(self):
+        text = "Pick one: [checklist: Yes | No | Maybe]"
+        result = parse_checklist_marker(text)
+        self.assertIsNotNone(result)
+        items, body = result
+        self.assertEqual(items, ["Yes", "No", "Maybe"])
+        self.assertNotIn("[checklist", body)
+
+    def test_bare_marker_with_list(self):
+        text = "Options:\n[checklist]\n- Alpha\n- Beta\n- Gamma"
+        result = parse_checklist_marker(text)
+        self.assertIsNotNone(result)
+        items, body = result
+        self.assertEqual(items, ["Alpha", "Beta", "Gamma"])
+        self.assertNotIn("[checklist]", body.lower())
+
+    def test_no_marker_returns_none(self):
+        self.assertIsNone(parse_checklist_marker("plain text"))
+        self.assertIsNone(parse_checklist_marker(""))
+
+    def test_bare_marker_no_list_returns_none(self):
+        # [checklist] with no markdown list below is not a valid checklist
+        self.assertIsNone(parse_checklist_marker("[checklist]\nNo list here."))
+
+    def test_case_insensitive(self):
+        text = "[CHECKLIST: A | B]"
+        result = parse_checklist_marker(text)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], ["A", "B"])
+
+    def test_asterisk_list_items(self):
+        text = "[checklist]\n* One\n* Two"
+        result = parse_checklist_marker(text)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], ["One", "Two"])
+
+
+class TestBuildViewSpec(unittest.TestCase):
+
+    def test_single_row(self):
+        items = ["A", "B", "C"]
+        rows = build_view_spec(items, "msg123")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(len(rows[0]["buttons"]), 3)
+
+    def test_custom_id_format(self):
+        rows = build_view_spec(["X", "Y"], "msg42")
+        cid0 = rows[0]["buttons"][0]["custom_id"]
+        self.assertTrue(cid0.startswith(CUSTOM_ID_PREFIX))
+        self.assertIn("msg42", cid0)
+        self.assertIn(":0", cid0)
+
+    def test_row_wraps_at_5(self):
+        items = [str(i) for i in range(6)]
+        rows = build_view_spec(items, "m")
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(len(rows[0]["buttons"]), 5)
+        self.assertEqual(len(rows[1]["buttons"]), 1)
+
+    def test_max_rows_25_items(self):
+        items = [str(i) for i in range(30)]
+        rows = build_view_spec(items, "m")
+        self.assertLessEqual(len(rows), 5)
+
+    def test_label_truncated_to_80(self):
+        long_item = "x" * 100
+        rows = build_view_spec([long_item], "m")
+        self.assertLessEqual(len(rows[0]["buttons"][0]["label"]), 80)
+
+    def test_default_style_secondary(self):
+        rows = build_view_spec(["A"], "m")
+        self.assertEqual(rows[0]["buttons"][0]["style"], "secondary")
+
+
+class TestApplyClick(unittest.TestCase):
+
+    def test_first_click_adds_vote(self):
+        state = apply_click({}, 0, "u1", "Alice", ["A", "B"])
+        self.assertIn("u1", state["votes"]["0"])
+
+    def test_second_click_toggles_off(self):
+        state = {"items": ["A"], "votes": {"0": {"u1": "Alice"}}}
+        state = apply_click(state, 0, "u1", "Alice", ["A"])
+        self.assertNotIn("u1", state["votes"]["0"])
+
+    def test_two_voters_independent(self):
+        state = apply_click({}, 0, "u1", "Alice", ["A"])
+        state = apply_click(state, 0, "u2", "Bob", ["A"])
+        self.assertIn("u1", state["votes"]["0"])
+        self.assertIn("u2", state["votes"]["0"])
+
+    def test_different_items_independent(self):
+        state = apply_click({}, 0, "u1", "Alice", ["A", "B"])
+        state = apply_click(state, 1, "u1", "Alice", ["A", "B"])
+        self.assertIn("u1", state["votes"]["0"])
+        self.assertIn("u1", state["votes"]["1"])
+
+
+class TestRenderVoteSummary(unittest.TestCase):
+
+    def test_no_votes(self):
+        state = {"items": ["A", "B"], "votes": {}}
+        summary = render_vote_summary(state)
+        self.assertIn("• A", summary)
+        self.assertIn("• B", summary)
+        self.assertNotIn("✅", summary)
+
+    def test_with_vote(self):
+        state = {"items": ["A", "B"], "votes": {"0": {"u1": "Alice"}}}
+        summary = render_vote_summary(state)
+        self.assertIn("✅ Alice", summary)
+        self.assertIn("• B\n", summary + "\n")
+
+    def test_empty_state(self):
+        self.assertEqual(render_vote_summary({}), "")
+
+
+class TestParseCustomId(unittest.TestCase):
+
+    def test_valid(self):
+        cid = f"{CUSTOM_ID_PREFIX}msg999:3"
+        result = parse_custom_id(cid)
+        self.assertEqual(result, ("msg999", 3))
+
+    def test_invalid_prefix(self):
+        self.assertIsNone(parse_custom_id("other:msg:0"))
+
+    def test_non_int_index(self):
+        self.assertIsNone(parse_custom_id(f"{CUSTOM_ID_PREFIX}msg:notint"))
+
+    def test_msg_id_with_colons(self):
+        # msg_id itself may contain colons (Discord snowflake won't, but defensive)
+        cid = f"{CUSTOM_ID_PREFIX}abc:def:2"
+        result = parse_custom_id(cid)
+        self.assertEqual(result, ("abc:def", 2))
+
+
+class TestStatePersistence(unittest.TestCase):
+
+    def test_save_and_load(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_dir = Path(tmpdir)
+            state = {"items": ["X"], "votes": {"0": {"u1": "Alice"}}}
+            save_state(state_dir, "msg1", state)
+            loaded = load_state(state_dir, "msg1")
+            self.assertEqual(loaded, state)
+
+    def test_load_missing_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            loaded = load_state(Path(tmpdir), "nonexistent")
+            self.assertEqual(loaded, {})
+
+
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(__import__("__main__"))
+    runner = unittest.TextTestRunner(verbosity=0)
+    result = runner.run(suite)
+    if result.wasSuccessful():
+        print(f"All {result.testsRun} discord-checklist-render tests passed.")
+        sys.exit(0)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Closes #1104 Phase 1. Adds explicit \`[checklist]\` opt-in marker support: bot replies containing the marker are rendered as Discord button rows instead of plain text, with per-voter click state.

## What ships

**New skill** \`skills/checklist-respond/\`:
- \`scripts/checklist_render.py\` — pure helpers: parse marker, build Discord view spec, apply click (toggle), render per-voter vote summary. No I/O, fully unit-tested.

**\`src/discord-bridge.py\`** additions:
- Optional import of \`checklist_render\` behind try/except — bridge starts normally if skill not installed (\`_CHECKLIST_SKILL_AVAILABLE = False\`)
- \`on_interaction\` event handler: validates \`custom_id\` via \`parse_custom_id\`, gates on \`load_allowed()\`, toggles per-voter state, re-renders view with ✅ (checked) / grey (unchecked) button styles + vote summary
- \`_maybe_post_checklist\`: intercept in \`poll_results\` before the normal chunk-send — if \`[checklist]\` found, posts buttons; otherwise falls through to existing path
- State persisted to \`$WORKSPACE/state/checklists/<msg_id>.json\`

## Usage

Inline form:
\`\`\`
[checklist: Yes | No | Maybe]
\`\`\`

Block form:
\`\`\`
Pick a direction:
[checklist]
- Option A
- Option B  
- Option C
\`\`\`

Original reply text is preserved above the buttons (owner pref: mis-fires are non-events, not UX traps).

## Design decisions (per #1104 comment)

- ✅ Original text preserved below buttons
- ✅ Per-voter side-by-side (`• Item — ✅ Alice`) not aggregate tally
- ✅ Allowlist-scoped clicks (only \`load_allowed()\` users)
- ✅ Phase 1: explicit \`[checklist]\` marker (Phase 2: auto-detect heuristic — follow-up)
- ✅ Toggle: click again to deselect

## Test plan

- [x] \`python3 tests/discord-checklist-render.test.py\` — 25 unit tests pass
- [x] \`python3 tests/discord-bridge-checklist-wiring.test.py\` — 10 structural tests pass
- [x] \`python3 -m py_compile src/discord-bridge.py\` — syntax ok
- [x] \`npm run typecheck\` — clean
- [ ] Live test: reply with \`[checklist: A | B | C]\` — verify buttons render
- [ ] Live test: click a button — verify ✅ style + vote summary updates
- [ ] Live test: click again — verify deselect (grey)
- [ ] Live test: bridge starts without \`skills/checklist-respond/\` installed — no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)