### PR TITLE
fix(discord-voice): use CLAUDE_CONFIG_DIR for channels path

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -40,7 +40,7 @@ import { personalPath } from '../../../src/util_paths.js';
 import { type Tier, loadAccessTiers, effectiveTier, toolAllowed, toolNeed } from './access-tier.js';
 
 _dotenvConfig({ path: new URL('../../../.env', import.meta.url).pathname, override: true });
-_dotenvConfig({ path: join(process.env.HOME ?? '', '.claude/channels/discord/.env'), override: false });
+_dotenvConfig({ path: join(process.env.CLAUDE_CONFIG_DIR ?? join(process.env.HOME ?? '', '.claude'), 'channels/discord/.env'), override: false });
 
 import { fileURLToPath } from 'node:url';
 import { voiceApiKey } from '../../../src/voice-key.js';


### PR DESCRIPTION
## Summary

- Removes hardcoded `~/.claude/channels/discord/.env` path in `discord-voice-server.ts`
- Same `CLAUDE_CONFIG_DIR` resolution pattern as `discord-bridge.py` (PR #1514)
- Falls back to `~/.claude` when env var is unset — no migration needed for existing installs

Found via susanliu_'s grep in the #1514 thread (2026-06-07T15:22).

## Test plan
- [ ] Voice server starts normally without `CLAUDE_CONFIG_DIR` set (falls back to `~/.claude`)
- [ ] Voice server picks up token from workspace config when `CLAUDE_CONFIG_DIR=<workspace>/.claude-sutando`

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)