### PR TITLE
fix(friction-detector): honor free-form pending-questions.md sections (#1404)

### DIFF
--- a/src/friction-detector.py
+++ b/src/friction-detector.py
@@ -13,10 +13,12 @@ Output: results/friction-{date}.txt
 
 import json
 import os
+import re
 import sys
 import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
 from util_paths import personal_path, shared_personal_path  # noqa: E402
@@ -29,15 +31,10 @@ RESULTS_DIR = WORKSPACE / "results"
 def check_pending_questions():
     """Find questions unanswered for >24h.
 
-    pending-questions.md uses sections like:
-        ## Question Title
-        - **Asked:** 2026-04-06
-        - **Question:** ...
-        - **Status:** unanswered
-
-    A previous version of this parser looked for lines starting with `- [`
-    which never matched the actual format, so it always returned an empty
-    list and friction-detector silently missed every unanswered question.
+    pending-questions.md is free-form: sections start with ## Title and
+    may or may not carry **Status:** markers. Per the #1265 / #1404
+    convention: a section is open unless it is explicitly resolved.
+    Sections above a `# Resolved` divider are ignored entirely.
     """
     pq = Path(personal_path("pending-questions.md", WORKSPACE))
     if not pq.exists():
@@ -46,26 +43,38 @@ def check_pending_questions():
     if "(No pending questions)" in content or not content.strip():
         return []
 
+    # Discard resolved section (below a `# Resolved` / `# Done` divider).
+    content = re.split(r'^#\s+(?:Resolved|Done)\b', content, maxsplit=1, flags=re.MULTILINE)[0]
+
+    _RESOLVED_STATUS = re.compile(
+        r'\*\*Status:\*\*\s*(?:resolved|answered|done|complete)',
+        re.IGNORECASE,
+    )
+
     issues = []
     today = datetime.now().date()
+    current_title: Optional[str] = None
+    current_asked: Optional[str] = None
+    current_body_lines: list = []
 
-    # Walk sections — each starts with `## Title`. Inside the section, look
-    # for `Status: unanswered` and an `Asked:` date.
-    current_title = None
-    current_asked = None
-    current_status = None
-
-    def flush():
-        if current_title and current_status == "unanswered":
-            age_str = ""
-            if current_asked:
-                try:
-                    asked_date = datetime.fromisoformat(current_asked).date()
-                    age_days = (today - asked_date).days
-                    age_str = f" ({age_days}d old)"
-                except ValueError:
-                    pass
-            issues.append(f"Pending question unanswered{age_str}: {current_title[:80]}")
+    def flush() -> None:
+        if not current_title:
+            return
+        body = "\n".join(current_body_lines)
+        # Skip explicitly resolved sections.
+        if _RESOLVED_STATUS.search(body):
+            return
+        age_str = ""
+        if current_asked:
+            try:
+                asked_date = datetime.fromisoformat(current_asked).date()
+                age_days = (today - asked_date).days
+                if age_days < 1:
+                    return  # not stale yet
+                age_str = f" ({age_days}d old)"
+            except ValueError:
+                pass
+        issues.append(f"Pending question unanswered{age_str}: {current_title[:80]}")
 
     for line in content.split("\n"):
         stripped = line.strip()
@@ -73,21 +82,16 @@ def check_pending_questions():
             flush()
             current_title = stripped[3:].strip()
             current_asked = None
-            current_status = None
+            current_body_lines = []
             continue
-        # Match `- **Asked:** 2026-04-06`
-        if "**Asked:**" in stripped:
-            try:
-                current_asked = stripped.split("**Asked:**", 1)[1].strip().split()[0]
-            except IndexError:
-                pass
-        # Match `- **Status:** unanswered`
-        if "**Status:**" in stripped:
-            try:
-                current_status = stripped.split("**Status:**", 1)[1].strip().lower().split()[0]
-            except IndexError:
-                pass
-    flush()  # don't forget the last section
+        if current_title is not None:
+            current_body_lines.append(stripped)
+            if "**Asked:**" in stripped:
+                try:
+                    current_asked = stripped.split("**Asked:**", 1)[1].strip().split()[0]
+                except IndexError:
+                    pass
+    flush()
 
     return issues
 

--- a/tests/friction-detector-pending-questions.test.py
+++ b/tests/friction-detector-pending-questions.test.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Tests for friction-detector.py check_pending_questions() free-form parsing.
+
+Guards against the #1404 regression: old parser required **Status:** markers
+that free-form pending-questions.md files never write — causing undercount to 0.
+
+Per #1265 / #1404 convention:
+- A ## section is open unless it carries an explicit resolved status.
+- Sections below a `# Resolved` divider are excluded.
+
+Run: python3 tests/friction-detector-pending-questions.test.py
+Exit: 0 = pass, 1 = fail
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+# Load friction-detector (hyphenated filename) via importlib.
+import importlib
+import importlib.util
+_SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(_SRC_DIR))
+_spec = importlib.util.spec_from_file_location("friction_detector", _SRC_DIR / "friction-detector.py")
+_fd_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_fd_mod)
+
+
+def _make_module_with_pq(pq_content: str) -> list:
+    """Call check_pending_questions with a temp pending-questions.md file."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(pq_content)
+        pq_path = Path(f.name)
+
+    original = _fd_mod.personal_path
+
+    def patched_personal_path(name, workspace=None):
+        if name == "pending-questions.md":
+            return str(pq_path)
+        return original(name, workspace)
+
+    _fd_mod.personal_path = patched_personal_path
+    try:
+        result = _fd_mod.check_pending_questions()
+    finally:
+        _fd_mod.personal_path = original
+        pq_path.unlink(missing_ok=True)
+    return result
+
+
+# Dates for testing
+_OLD = (datetime.now() - timedelta(days=3)).date().isoformat()
+_NEW = datetime.now().date().isoformat()
+
+
+class TestCheckPendingQuestionsFreForm(unittest.TestCase):
+
+    def test_free_form_no_status_counted_as_open(self):
+        """A section with no **Status:** field is open (free-form convention)."""
+        content = f"""# Pending Questions
+
+## Should we use Postgres or SQLite?
+- **Asked:** {_OLD}
+- Context: perf requirements unclear.
+"""
+        result = _make_module_with_pq(content)
+        self.assertTrue(
+            any("Postgres" in r or "SQLite" in r for r in result),
+            f"Free-form section should be counted as open. Got: {result}",
+        )
+
+    def test_explicit_resolved_status_skipped(self):
+        """A section with **Status:** resolved is excluded."""
+        content = f"""# Pending Questions
+
+## Old answered question
+- **Asked:** {_OLD}
+- **Status:** resolved
+"""
+        result = _make_module_with_pq(content)
+        self.assertEqual(result, [], f"Resolved section should be excluded. Got: {result}")
+
+    def test_below_resolved_divider_excluded(self):
+        """Sections below `# Resolved` are not counted."""
+        content = f"""# Pending Questions
+
+## Open question
+- **Asked:** {_OLD}
+
+# Resolved
+
+## Already done
+- **Asked:** {_OLD}
+"""
+        result = _make_module_with_pq(content)
+        self.assertTrue(
+            any("Open question" in r for r in result),
+            f"Open question should be present. Got: {result}",
+        )
+        self.assertFalse(
+            any("Already done" in r for r in result),
+            f"Section below # Resolved should be excluded. Got: {result}",
+        )
+
+    def test_none_open_placeholder_returns_empty(self):
+        """Standard '(none open)' content returns empty."""
+        content = "# Pending Questions\n\n_(none open)_\n"
+        result = _make_module_with_pq(content)
+        self.assertEqual(result, [])
+
+    def test_fresh_question_not_stale(self):
+        """A question asked today is not reported as stale."""
+        content = f"""# Pending Questions
+
+## Fresh today
+- **Asked:** {_NEW}
+"""
+        result = _make_module_with_pq(content)
+        self.assertEqual(result, [], f"Today's question should not be stale. Got: {result}")
+
+    def test_multiple_sections_counted(self):
+        """Multiple open free-form sections are all reported."""
+        content = f"""# Pending Questions
+
+## First question
+- **Asked:** {_OLD}
+
+## Second question
+- **Asked:** {_OLD}
+"""
+        result = _make_module_with_pq(content)
+        self.assertEqual(len(result), 2, f"Both sections should be counted. Got: {result}")
+
+    def test_explicit_answered_status_skipped(self):
+        """**Status:** answered (case-insensitive) is excluded."""
+        content = f"""# Pending Questions
+
+## Answered question
+- **Asked:** {_OLD}
+- **Status:** Answered
+"""
+        result = _make_module_with_pq(content)
+        self.assertEqual(result, [])
+
+    def test_age_included_in_output(self):
+        """Age in days should appear in the output for old questions."""
+        content = f"""# Pending Questions
+
+## Old question
+- **Asked:** {_OLD}
+"""
+        result = _make_module_with_pq(content)
+        self.assertTrue(result, "Should have at least one result")
+        self.assertIn("d old", result[0], f"Age not in output: {result[0]}")
+
+
+class TestFreFormParserStructural(unittest.TestCase):
+    """Structural checks on the source code to confirm the fix is in place."""
+
+    SRC = (Path(__file__).resolve().parent.parent / "src" / "friction-detector.py").read_text()
+
+    def test_does_not_require_status_unanswered(self):
+        """Parser must NOT gate on current_status == 'unanswered' (old bug)."""
+        self.assertNotIn(
+            "current_status == \"unanswered\"",
+            self.SRC,
+            "Parser must not require **Status: unanswered** — free-form files never write this.",
+        )
+
+    def test_resolved_divider_honored(self):
+        """Parser must split on `# Resolved` divider."""
+        self.assertIn("Resolved", self.SRC)
+        self.assertIn("re.split", self.SRC)
+
+    def test_explicit_resolved_regex_present(self):
+        """Parser must recognize explicit resolved/answered/done status."""
+        self.assertIn("resolved|answered|done|complete", self.SRC)
+
+
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(__import__("__main__"))
+    runner = unittest.TextTestRunner(verbosity=0)
+    result = runner.run(suite)
+    if result.wasSuccessful():
+        print(f"All {result.testsRun} friction-detector-pending-questions tests passed.")
+        sys.exit(0)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Fixes the remaining consumer from issue #1404. Sibling fixes: #1405 (dashboard), #1511 (agent-api). This PR closes the `friction-detector.py` gap.

**Problem:** `check_pending_questions()` required `**Status:** unanswered` to count a section as open. Free-form `pending-questions.md` files never write this marker — so the function always returned 0 issues even with genuinely-open questions.

**Fix:** Align with the #1265 / `check-pending-questions.py` convention:
- A `## ` section is **open** unless it carries an explicit `**Status:** resolved/answered/done/complete`
- Sections below a `# Resolved` divider are excluded entirely
- `**Asked:**` age threshold preserved (< 1 day not stale)

Also adds `import re` and `from typing import Optional` which were missing.

## Test plan

- [x] `python3 tests/friction-detector-pending-questions.test.py` — 11 tests pass
  - Free-form no-status section counted as open ✓
  - Explicit `**Status:** resolved/answered` excluded ✓
  - `# Resolved` divider excludes everything below ✓
  - Today's question not stale (< 1 day) ✓
  - Multiple sections all counted ✓
  - `_(none open)_` placeholder returns empty ✓
  - Structural checks: no `current_status == "unanswered"`, re.split present, resolved regex present ✓
- [x] `python3 -m py_compile src/friction-detector.py` — syntax ok

Partially closes #1404 (alongside #1405 + #1511).

🤖 Generated with [Claude Code](https://claude.com/claude-code)