### PR TITLE
fix(ccd): remaining hardcoded ~/.claude channel paths → CLAUDE_CONFIG_DIR

### DIFF
--- a/skills/bot2bot-post/post.py
+++ b/skills/bot2bot-post/post.py
@@ -29,8 +29,9 @@ import urllib.request
 import urllib.error
 from pathlib import Path
 
-ACCESS_JSON = Path.home() / ".claude" / "channels" / "discord" / "access.json"
-ENV_FILE = Path.home() / ".claude" / "channels" / "discord" / ".env"
+_claude_config = Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude")))
+ACCESS_JSON = _claude_config / "channels" / "discord" / "access.json"
+ENV_FILE = _claude_config / "channels" / "discord" / ".env"
 VALID_KINDS = {"claim", "blocked", "done", "ping", "opinion"}
 
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1355,7 +1355,7 @@ def _slack_token_from_env_file() -> str:
     $REPO/.env for hosts that keep it there instead.
     """
     candidates = [
-        Path.home() / ".claude" / "channels" / "slack" / ".env",
+        claude_home_path("channels", "slack", ".env"),
         REPO_DIR / ".env",
     ]
     for env_path in candidates:
@@ -1383,7 +1383,7 @@ def _slack_owner_creds() -> "tuple[str, str] | None":
     token = os.environ.get("SLACK_BOT_TOKEN", "").strip() or _slack_token_from_env_file()
     if not token:
         return None
-    access = Path.home() / ".claude" / "channels" / "slack" / "access.json"
+    access = claude_home_path("channels", "slack", "access.json")
     try:
         data = json.loads(access.read_text())
     except Exception:


### PR DESCRIPTION
## Summary

Completes the CLAUDE_CONFIG_DIR migration started in PR #1514 (discord-bridge.py) and PR #1523 (discord-voice-server.ts).

Two remaining files still used direct `Path.home() / ".claude"` paths instead of `claude_home_path()` / `CLAUDE_CONFIG_DIR`:

- **`src/health-check.py`** — `check_slack_bridge()` watchdog had two Slack channel paths (token `.env` + `access.json`) bypassing `claude_home_path()`. Fixed to use `claude_home_path("channels", "slack", ...)`.
- **`skills/bot2bot-post/post.py`** — `ACCESS_JSON` + `ENV_FILE` pointing at `~/.claude/channels/discord/`. Adds `_claude_config` resolution (same pattern as discord-bridge.py).

`discord-voice-server.ts` excluded — covered by open PR #1523.

After this + #1523 + #1514 merge: no remaining direct `~/.claude/channels/` references in the audited src + skills directories.

## Test plan
- [ ] `health-check.py` Slack watchdog still loads token when `CLAUDE_CONFIG_DIR` is unset (falls back to `~/.claude`)
- [ ] `health-check.py` Slack watchdog loads from workspace config when `CLAUDE_CONFIG_DIR=<workspace>/.claude-sutando`
- [ ] `bot2bot-post/post.py` posts correctly without `CLAUDE_CONFIG_DIR` set

Found via full `~/.claude` path audit prompted by susanliu_'s grep in the #1514 thread (2026-06-07T15:22).

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)