### PR TITLE
fix(discord-voice): access-tier.ts honors CLAUDE_CONFIG_DIR (companion to #1523)

### DIFF
--- a/skills/discord-voice/scripts/access-tier.ts
+++ b/skills/discord-voice/scripts/access-tier.ts
@@ -29,7 +29,7 @@ export interface AccessTiers {
  */
 export function loadAccessTiers(homeDir: string): AccessTiers {
 	try {
-		const p = join(homeDir, '.claude/channels/discord/access.json');
+		const p = join(process.env.CLAUDE_CONFIG_DIR ?? join(homeDir, '.claude'), 'channels/discord/access.json');
 		const a = JSON.parse(readFileSync(p, 'utf-8'));
 		const owner = new Set<string>((a.allowFrom ?? []).map(String));
 		const team = new Set<string>();


### PR DESCRIPTION
## Summary

Companion to #1523. That PR patches `discord-voice-server.ts:43` (the dotenv path) to use `CLAUDE_CONFIG_DIR`, but the sibling `access-tier.ts:32` still hardcodes `~/.claude/channels/discord/access.json`. Net effect of merging #1523 alone on a CCD-diverged host (which is the whole point of `staging-workspace-revamp`): dotenv loads from CCD but `access.json` reads from `~/.claude` — tier resolution silently uses wrong data.

Susan reported this morning that Maddy couldn't receive Discord messages because of this split-brain.

1-line fix mirroring #1523's exact pattern:
```ts
- const p = join(homeDir, '.claude/channels/discord/access.json');
+ const p = join(process.env.CLAUDE_CONFIG_DIR ?? join(homeDir, '.claude'), 'channels/discord/access.json');
```

## Test plan

- [x] `npx tsx tests/discord-voice-tier.test.ts` → 25/25 pass (CCD unset path unchanged; fallback to `homeDir/.claude` matches prior behavior)
- [ ] On a host with `CLAUDE_CONFIG_DIR=$SUTANDO_WORKSPACE/.claude`: `access.json` reads from CCD, not `~/.claude`
- [ ] Merge sweep alongside #1523 + #1525 closes the CCD migration for the discord-voice channels path

## Context

- Flagged by @Lucy-Studio-Susan in #dev 2026-06-07 19:54Z
- Susan escalation in #susan 2026-06-07 20:01Z: blocking workspace-symlink-drop migration
- #1523 is on owner's fork with `maintainerCanModify=false`, so this fix lands as a separate PR
- All three (#1523, #1525, this) target `staging-workspace-revamp`

Stand: Echo Act IV (Mini)

🤖 Generated with [Claude Code](https://claude.com/claude-code)