### PR TITLE
feat(migrate): channels migration Option A+ (1)+(2)+(3) — auto-copy + banner + script fixes

### DIFF
--- a/scripts/probe-team-sandbox.sh
+++ b/scripts/probe-team-sandbox.sh
@@ -9,7 +9,9 @@
 #
 # Use before shipping changes to:
 #   - src/discord-bridge.py (tier classification / injection block)
-#   - ~/.claude/channels/discord/access.json
+#   - $CLAUDE_CONFIG_DIR/channels/discord/access.json (post-#1454; legacy
+#     location is ~/.claude/channels/discord/access.json for installs that
+#     haven't migrated yet)
 #   - any codex version bump
 #
 # Full validation log context: notes/team-tier-sandbox-validation.md

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -590,6 +590,7 @@ ROLLBACK_ID=""
 NO_CONFIRM=0
 NO_CLAUDE_IMPORT=0
 NO_HOOK_BRIDGE=0
+NO_CHANNEL_BRIDGE=0
 
 EXPLAIN_PATH=""
 while [ $# -gt 0 ]; do
@@ -619,6 +620,7 @@ while [ $# -gt 0 ]; do
         --no-confirm|--yes|-y) NO_CONFIRM=1; shift ;;  # skip pre-flight prompt (for CI / scripted runs)
         --no-claude-import) NO_CLAUDE_IMPORT=1; shift ;;  # skip auto-invocation of sutando-shell-setup.sh --import after commit (advanced; see Lucy's Maddy report 2026-06-06)
         --no-hook-bridge) NO_HOOK_BRIDGE=1; shift ;;  # skip auto-invocation of sutando-config-hooks.sh (Option D from #design 2026-06-07; see scripts/sutando-config-hooks.sh header)
+        --no-channel-bridge) NO_CHANNEL_BRIDGE=1; shift ;;  # skip auto-copy of $SOURCE_CLAUDE_CONFIG_DIR/channels/ → $CLAUDE_CONFIG_DIR/channels/ (Option A+ from #design 2026-06-07)
         --help|-h)
             sed -n '1,80p' "${BASH_SOURCE[0]}"
             exit 0
@@ -1737,6 +1739,51 @@ commit_main() {
             fi
         else
             echo "  hook bridge: skipped (scripts/sutando-config-hooks.sh not found at expected path; run manually after migrate)"
+        fi
+    fi
+
+    # Channel bridge — Option A+ from owner's #design 2026-06-07 design discussion.
+    # Copy $SOURCE_CLAUDE_CONFIG_DIR/channels/ (Sutando bridge access lists +
+    # .env tokens for discord/telegram/slack) into the per-runtime
+    # $CLAUDE_CONFIG_DIR/channels/ so bridges resolve to the workspace-scoped
+    # location after migration. Pre-#1454 the silent ~/.claude/channels/
+    # fallback in claude_home_path() made this "just work" — but a boot path
+    # that forgot to set CLAUDE_CONFIG_DIR would silently fall back, and the
+    # /channels/ symlink became load-bearing (Lucy in #design 2026-06-07 16:19Z).
+    # This bridge moves the channels store onto CCD so a CCD-set boot path is
+    # self-contained.
+    # Idempotent: skip if dest already populated. Honors $SOURCE_CLAUDE_CONFIG_DIR
+    # for the read-from location (defaults to ~/.claude/ — matches the legacy
+    # claude_home_path() fallback). Opt out with --no-channel-bridge.
+    if [ "$NO_CHANNEL_BRIDGE" = "0" ] && [ "$DELETE_SOURCE" = "0" ]; then
+        local _new_ccd_ch; _new_ccd_ch="$(bash "$(dirname "$0")/sutando-config.sh" claude-sutando-config-dir 2>/dev/null || true)"
+        local _src_channels="${SOURCE_CLAUDE_CONFIG_DIR:-$HOME/.claude}/channels"
+        local _dst_channels="${_new_ccd_ch}/channels"
+        if [ -z "$_new_ccd_ch" ]; then
+            echo "  channel bridge: skipped (couldn't resolve claude-sutando-config-dir; check sutando.config.local.json)" >&2
+        elif [ ! -d "$_src_channels" ]; then
+            echo "  channel bridge: skipped (no source $_src_channels — nothing to migrate)"
+        else
+            # Detect src/dst pointing at the same physical path (legacy symlink
+            # $SOURCE_CLAUDE_CONFIG_DIR/channels -> $CCD/channels). Without this
+            # check, cp -a would try to copy a directory into itself.
+            local _src_real _dst_real
+            _src_real="$(cd "$_src_channels" 2>/dev/null && pwd -P || echo "$_src_channels")"
+            _dst_real="$(cd "$_dst_channels" 2>/dev/null && pwd -P || echo "$_dst_channels")"
+            if [ "$_src_real" = "$_dst_real" ]; then
+                echo "  channel bridge: skipped (source and dest resolve to same path: $_src_real — already migrated or symlinked through)"
+            elif [ -d "$_dst_channels" ] && [ -n "$(ls -A "$_dst_channels" 2>/dev/null)" ]; then
+                echo "  channel bridge: skipped ($_dst_channels already populated — idempotent)"
+            else
+                echo
+                echo "sutando-migrate: bridging channels (Sutando bridge access lists + .env tokens) ..."
+                mkdir -p "$_dst_channels"
+                if cp -a "$_src_channels/." "$_dst_channels/" 2>/dev/null; then
+                    echo "  channel bridge: copied $_src_channels → $_dst_channels"
+                else
+                    echo "  channel bridge: copy failed (rc=$?) — re-run manually: cp -a \"$_src_channels/.\" \"$_dst_channels/\"" >&2
+                fi
+            fi
         fi
     fi
 

--- a/scripts/validate-access-tiers.py
+++ b/scripts/validate-access-tiers.py
@@ -29,7 +29,22 @@ import os
 import sys
 from pathlib import Path
 
-DEFAULT_PATH = Path.home() / ".claude" / "channels" / "discord" / "access.json"
+
+def _default_access_path() -> Path:
+    """Mirror src/util_paths.py:claude_home_path() resolution order without
+    importing it (this script lives under scripts/ and is invoked by ops/CI
+    that may not have src/ on PYTHONPATH). Resolution: $CLAUDE_CONFIG_DIR
+    → $CLAUDE_HOME → ~/.claude/. Tracks the same migration semantics as
+    bridges: post-#1454 the bridges' access.json lives under CCD."""
+    base = (
+        os.environ.get("CLAUDE_CONFIG_DIR")
+        or os.environ.get("CLAUDE_HOME")
+        or str(Path.home() / ".claude")
+    )
+    return Path(os.path.expanduser(base)) / "channels" / "discord" / "access.json"
+
+
+DEFAULT_PATH = _default_access_path()
 
 
 def violations(data: dict, bot_ids: set[str]) -> list[str]:

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -213,7 +213,40 @@ def claude_home_path(*subpath: str) -> Path:
     elif home_env:
         base = Path(os.path.expanduser(home_env))
     else:
+        _emit_claude_home_fallback_banner_once()
         base = Path.home() / ".claude"
     if not subpath:
         return base
     return base.joinpath(*subpath)
+
+
+# ---------------------------------------------------------------------------
+# Fallback-banner gate — fires ONCE per process when claude_home_path() lands
+# on the ~/.claude/ default because neither $CLAUDE_CONFIG_DIR nor $CLAUDE_HOME
+# was set. Owner directive #design 2026-06-07 (Option A+ for channels migration):
+# the silent ~/.claude/ fallback was load-bearing for any boot path that forgot
+# to set CCD; the banner makes that miswiring visible without forcing a hard
+# error in the deprecation window. Banner is suppressible via
+# $SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1 for tests / scripts that intentionally
+# exercise the ~/.claude/ path.
+# ---------------------------------------------------------------------------
+
+_CLAUDE_HOME_FALLBACK_BANNER_FIRED = False
+
+
+def _emit_claude_home_fallback_banner_once() -> None:
+    global _CLAUDE_HOME_FALLBACK_BANNER_FIRED
+    if _CLAUDE_HOME_FALLBACK_BANNER_FIRED:
+        return
+    if os.environ.get("SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER") == "1":
+        _CLAUDE_HOME_FALLBACK_BANNER_FIRED = True
+        return
+    _CLAUDE_HOME_FALLBACK_BANNER_FIRED = True
+    print(
+        "claude_home_path: $CLAUDE_CONFIG_DIR not set — falling back to ~/.claude/. "
+        "Set CLAUDE_CONFIG_DIR before starting Sutando services (the `claude-sutando` "
+        "shell function and src/startup.sh set it; ad-hoc launches must too) so "
+        "channels/skills/hooks/sessions resolve to the workspace-scoped per-runtime "
+        "location post-#1454. Suppress with SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1.",
+        file=sys.stderr,
+    )

--- a/tests/util-paths-ccd-banner.test.py
+++ b/tests/util-paths-ccd-banner.test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Tests for src/util_paths.py claude_home_path() fallback banner.
+
+Owner directive #design 2026-06-07 (Option A+ for channels migration):
+when CLAUDE_CONFIG_DIR is unset, claude_home_path() emits a stderr
+deprecation banner ONCE per process. CLAUDE_HOME (legacy test override)
+should NOT trigger the banner. CCD set should NOT trigger the banner.
+
+Run: python3 tests/util-paths-ccd-banner.test.py
+"""
+from __future__ import annotations
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "src"
+
+
+def _run_probe(env_overrides: dict[str, str | None]) -> tuple[str, str, int]:
+    """Run a minimal Python probe that imports util_paths and calls
+    claude_home_path() three times, then prints the resolved base.
+    Return (stdout, stderr, returncode). env_overrides=None unsets the key.
+    """
+    env = os.environ.copy()
+    # Always start from a clean slate for these vars.
+    for k in ("CLAUDE_CONFIG_DIR", "CLAUDE_HOME", "SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER"):
+        env.pop(k, None)
+    for k, v in env_overrides.items():
+        if v is None:
+            env.pop(k, None)
+        else:
+            env[k] = v
+    probe = f"""
+import sys
+sys.path.insert(0, {str(SRC)!r})
+from util_paths import claude_home_path
+# Call thrice to verify single-fire across calls.
+for _ in range(3):
+    p = claude_home_path('channels', 'discord', 'access.json')
+print('RESOLVED:', p, flush=True)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+def assert_eq(actual, expected, label):
+    if actual == expected:
+        print(f"  PASS: {label}")
+        return True
+    print(f"  FAIL: {label}\n    expected: {expected!r}\n    actual:   {actual!r}")
+    return False
+
+
+def assert_in(needle, haystack, label):
+    if needle in haystack:
+        print(f"  PASS: {label}")
+        return True
+    print(f"  FAIL: {label}\n    needle: {needle!r}\n    haystack: {haystack!r}")
+    return False
+
+
+def assert_not_in(needle, haystack, label):
+    if needle not in haystack:
+        print(f"  PASS: {label}")
+        return True
+    print(f"  FAIL: {label}\n    unexpectedly found: {needle!r}\n    in: {haystack!r}")
+    return False
+
+
+def main() -> int:
+    print("util_paths.py — CCD fallback banner tests")
+    print("=" * 50)
+    passed = []
+
+    # Test 1: CCD set → no banner, resolved path uses CCD.
+    print("\n[1] CLAUDE_CONFIG_DIR set → no banner, resolves under CCD")
+    with tempfile.TemporaryDirectory() as ccd:
+        out, err, rc = _run_probe({"CLAUDE_CONFIG_DIR": ccd})
+        passed.append(assert_eq(rc, 0, "exit 0"))
+        passed.append(assert_not_in(
+            "CLAUDE_CONFIG_DIR not set", err,
+            "no fallback banner on stderr"))
+        passed.append(assert_in(
+            f"RESOLVED: {ccd}/channels/discord/access.json", out,
+            "resolved path uses CCD"))
+
+    # Test 2: CLAUDE_HOME set (legacy test override) → no banner.
+    print("\n[2] CLAUDE_HOME set (CCD unset) → no banner, resolves under CLAUDE_HOME")
+    with tempfile.TemporaryDirectory() as home:
+        out, err, rc = _run_probe({"CLAUDE_HOME": home})
+        passed.append(assert_eq(rc, 0, "exit 0"))
+        passed.append(assert_not_in(
+            "CLAUDE_CONFIG_DIR not set", err,
+            "no fallback banner on stderr (CLAUDE_HOME is a test override, not the deprecated path)"))
+        passed.append(assert_in(
+            f"RESOLVED: {home}/channels/discord/access.json", out,
+            "resolved path uses CLAUDE_HOME"))
+
+    # Test 3: Both unset → banner fires ONCE.
+    print("\n[3] CCD + CLAUDE_HOME unset → banner fires ONCE, falls back to ~/.claude/")
+    out, err, rc = _run_probe({})
+    passed.append(assert_eq(rc, 0, "exit 0"))
+    passed.append(assert_in(
+        "CLAUDE_CONFIG_DIR not set", err,
+        "fallback banner present on stderr"))
+    # Count banner occurrences — should be exactly 1 even though we called the
+    # helper three times in the probe.
+    occurrences = err.count("CLAUDE_CONFIG_DIR not set")
+    passed.append(assert_eq(
+        occurrences, 1,
+        f"banner fires exactly once across 3 helper calls (got {occurrences})"))
+    home_default = str(Path.home() / ".claude")
+    passed.append(assert_in(
+        f"RESOLVED: {home_default}/channels/discord/access.json", out,
+        "resolved path uses ~/.claude/ default"))
+
+    # Test 4: Suppression env var set → no banner even when both unset.
+    print("\n[4] SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1 → no banner, still falls back")
+    out, err, rc = _run_probe({"SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER": "1"})
+    passed.append(assert_eq(rc, 0, "exit 0"))
+    passed.append(assert_not_in(
+        "CLAUDE_CONFIG_DIR not set", err,
+        "no banner with suppression env var set"))
+    home_default = str(Path.home() / ".claude")
+    passed.append(assert_in(
+        f"RESOLVED: {home_default}/channels/discord/access.json", out,
+        "resolved path still uses ~/.claude/ default (suppression only silences banner)"))
+
+    print("\n" + "=" * 50)
+    failed = passed.count(False)
+    print(f"Pass: {passed.count(True)} / {len(passed)}")
+    if failed:
+        print(f"Fail: {failed}")
+        return 1
+    print("All claude_home_path() banner contract tests pass.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Workspace-revamp milestone scope

| Layer | Status | This PR |
|---|---|---|
| M0 — workspace location (`<repo>/workspace/` via `bash scripts/sutando-config.sh workspace`) | shipped to `staging-workspace-revamp` | — |
| M1 — migration (`scripts/sutando-migrate.sh` + `/sutando-migrate` skill) | shipped to `staging-workspace-revamp` | **extends `commit_main()` with the channels bridge** |
| M2 — sync engine (`scripts/sync-workspace.sh`) | shipped to `staging-workspace-revamp` | — |
| M3 — staging→main rollup (#1454) | open, sonichi APPROVED, blocked on owner pick (this PR resolves the channels-migration scope gap Lucy flagged) | unblocks once merged + #1454 rebases |

## Summary

Owner's #design 2026-06-07 design call on the channels migration scope question that surfaced in #1454 review (Lucy: "the `~/.claude/channels/` symlink is load-bearing — once a boot path forgets to set CCD, the silent `~/.claude/channels/` fallback ships you the wrong store"). Owner picked **Option A+** — four pieces. This PR ships **(1)+(2)+(3)**. Piece (4) (30-day fallback removal) ships separately after the deprecation window.

Per owner directive 2026-06-07 21:32Z ("Ignore 1530. Just make all the changes from our side"), this PR includes the script-path fixes that overlap with PR #1530 — see Overlap section below.

## What ships

### (1) `scripts/sutando-migrate.sh` (+47/-0) — channel bridge

New block in `commit_main()` (between hook bridge + announce):
- Auto-copy `\$SOURCE_CLAUDE_CONFIG_DIR/channels/` → `\$CLAUDE_CONFIG_DIR/channels/` (discord/telegram/slack `access.json` + `.env` tokens) so bridges resolve to the workspace-scoped location after migration without relying on the silent `~/.claude/channels/` fallback in `claude_home_path()`.
- Same-physical-path detection for the legacy symlink case (`cp -a` would otherwise copy a directory into itself when `\$SOURCE_CLAUDE_CONFIG_DIR/channels` is already a symlink to `\$CLAUDE_CONFIG_DIR/channels`).
- New `--no-channel-bridge` flag, symmetric with `--no-hook-bridge`.
- Idempotent: skip if dest already populated.

### (2) `src/util_paths.py` (+33/-0) — one-shot fallback banner

`claude_home_path()` now emits a one-shot stderr banner when it falls back to `~/.claude/` because neither `\$CLAUDE_CONFIG_DIR` nor `\$CLAUDE_HOME` is set. Surfaces silent miswiring (was load-bearing pre-#1454 — a boot path that forgot to set CCD would silently fall back with no signal).

- Suppressible via `SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1` for tests / scripts that intentionally exercise the `~/.claude/` path.
- `CLAUDE_HOME` (legacy test override) does NOT trigger the banner.
- Fires once per process (gated by `_CLAUDE_HOME_FALLBACK_BANNER_FIRED`).

### (3) Hardcoded-path defaults

- `scripts/probe-team-sandbox.sh` (+3/-1) — doc-comment fix with explicit post-#1454 note + legacy-fallback callout.
- `scripts/validate-access-tiers.py` (+16/-1) — `DEFAULT_PATH` now resolves via an inline `_default_access_path()` that mirrors `claude_home_path()`'s resolution order (`\$CLAUDE_CONFIG_DIR` → `\$CLAUDE_HOME` → `~/.claude/`). Inline (rather than importing `util_paths`) because this script lives under `scripts/` and is invoked by ops/CI that may not have `src/` on `PYTHONPATH`.

### Test (`tests/util-paths-ccd-banner.test.py`, 149 lines)

4 cases, 13 assertions, all PASS locally:
- `[1]` CCD set → no banner + resolves under CCD.
- `[2]` CLAUDE_HOME set → no banner + resolves under CLAUDE_HOME (test override semantics preserved).
- `[3]` Both unset → banner fires **ONCE** across 3 helper calls + falls back to `~/.claude/`.
- `[4]` `SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1` → silenced + still falls back.

## Overlap with PR #1530 (sonichi)

PR #1530 covers a subset of piece (3) — same two scripts:
- `scripts/probe-team-sandbox.sh`: same comment fix, this PR's wording is slightly more verbose (3-line vs 1-line).
- `scripts/validate-access-tiers.py`: same goal but different mechanism. #1530 does `sys.path.insert(0, …/src)` then imports `claude_home_path` from `util_paths` (DRY, single source of truth). This PR inlines `_default_access_path()` (decoupled from `src/` being on `PYTHONPATH`).

PR #1530 also adds a new `src/discord-read.py` that's already in PR #1528 — likely the cause of #1530's `MERGEABLE: CONFLICTING`. Per owner directive, this PR ships ours; #1530 can rebase or close.

## Test plan

- [x] \`python3 tests/util-paths-ccd-banner.test.py\` → 13/13 PASS locally
- [ ] CI: tsc + tests (clean install)
- [ ] CI: refuse new direct workspace-path resolution
- [ ] CI: refuse workspace/ contents in commits
- [ ] Manual E2E: \`bash scripts/sutando-migrate.sh --dry-run\` on a host with \`~/.claude/channels/\` populated — verify channel-bridge dry-run preview shows the copy operation
- [ ] Manual E2E: \`bash scripts/sutando-migrate.sh commit\` on a test host — verify \`\$CLAUDE_CONFIG_DIR/channels/access.json\` exists post-migration
- [ ] Manual E2E: \`--no-channel-bridge\` flag suppresses the copy
- [ ] Manual E2E: invoke \`python3 scripts/validate-access-tiers.py\` without \`CLAUDE_CONFIG_DIR\` set — verify it resolves to \`~/.claude/channels/discord/access.json\`

## Not in this PR

- **Piece (4) — 30-day fallback removal.** Separate cleanup PR after the deprecation window.
- **AGENTS.md** (untracked locally) — appears identical to \`CLAUDE.md\` head; separate symlink-vs-copy decision needed.

## Refs

- Owner #design 2026-06-07 design discussion on channels-migration scope (parent of #1454)
- Lucy's #design 2026-06-07 16:19Z flag on \`~/.claude/channels/\` symlink being load-bearing
- PR #1500 (merged) — Option D for hooks, same parallel-decision shape as this
- PR #1530 (open) — sonichi's piece (3) variant; overlap discussed above
- PR #1454 — staging→main rollup this unblocks once merged