### PR TITLE
feat(scripts): bash claude-home-path helper + migrate 15 sites + lint (Option A sweep)

### DIFF
--- a/.github/workflows/lint-claude-home-path.yml
+++ b/.github/workflows/lint-claude-home-path.yml
@@ -1,0 +1,36 @@
+name: lint-claude-home-path
+
+# CI lint: refuse PRs that introduce NEW inline `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`.
+#
+# All shell-side Claude home path resolution MUST go through the M0 helper:
+#   $(bash scripts/sutando-config.sh claude-home-path [subpath...])
+#
+# This workflow runs `scripts/lint-claude-home-path.sh --diff`, which scans
+# only ADDED lines in the PR — legacy offenders are migrated as part of the
+# sweep that introduces this lint and not flagged here.
+#
+# Companion to `lint-workspace-resolution.yml`. Together they enforce that
+# all path resolution goes through the documented helpers.
+
+on:
+  pull_request:
+    branches: [main, staging-workspace-revamp]
+  push:
+    branches: [main, staging-workspace-revamp]
+
+jobs:
+  lint-claude-home-path:
+    name: refuse new inline CLAUDE_CONFIG_DIR fallback
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Checkout (with full history for base-ref diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run lint in --diff mode
+        env:
+          BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || 'HEAD~1' }}
+        run: bash scripts/lint-claude-home-path.sh --diff

--- a/scripts/lint-claude-home-path.sh
+++ b/scripts/lint-claude-home-path.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Sutando lint: forbid inline `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` in shell.
+#
+# Bash callers MUST resolve Claude Code's per-user home via the M0 helper:
+#
+#   $(bash scripts/sutando-config.sh claude-home-path [subpath...])
+#
+# instead of the inline `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` shorthand.
+# Two reasons:
+#
+#   1. The helper centralizes the resolution order ($CLAUDE_CONFIG_DIR →
+#      $CLAUDE_HOME → ~/.claude/), mirroring src/util_paths.py:claude_home_path.
+#   2. The helper emits the deprecation-on-fallback banner (#1534) when
+#      neither CCD nor CLAUDE_HOME is set — the inline form silently falls
+#      back to ~/.claude/, defeating the visibility #1534 was designed to add.
+#
+# This lint catches new inline uses on ADDED lines (PR diff). Existing
+# legacy offenders are migrated as part of the sweep that introduces this
+# lint; future contributors get a CI failure if they reintroduce the
+# pattern. Tracking issue / motivation: owner directive 2026-06-07
+# (`why we still have /.claude/?` DM, response at task-1780871881546).
+#
+# Allowed files (the helper itself + comments documenting the anti-pattern):
+#   scripts/sutando-config.sh
+#   src/startup.sh
+#   scripts/lint-claude-home-path.sh  (this file)
+#
+# Companion lint for the WRITE-FROM source path (SOURCE_CLAUDE_CONFIG_DIR)
+# is OUT OF SCOPE here — that env var has different semantics (migration
+# read-side, per src/util_paths.py docstring) and the matching pattern is
+# explicitly allowed.
+#
+# Usage:
+#   bash scripts/lint-claude-home-path.sh          # scan whole tree
+#   bash scripts/lint-claude-home-path.sh --diff   # scan only added/modified lines vs BASE_REF
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+mode="${1:-all}"
+
+# Pattern: matches both `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` and the rare
+# inverted ordering. Excludes SOURCE_CLAUDE_CONFIG_DIR (different concept).
+PATTERN_INLINE='\$\{CLAUDE_CONFIG_DIR:-\$HOME/\.claude\}'
+
+# Allowed files — may reference the anti-pattern in comments / docstrings.
+ALLOWED='^(scripts/sutando-config\.sh|src/startup\.sh|scripts/lint-claude-home-path\.sh|tests/[^/]+\.(test\.)?sh)$'
+
+if [[ "$mode" == "--diff" ]]; then
+  base="${BASE_REF:-origin/main}"
+  files="$(git diff --name-only --diff-filter=AM "$base"...HEAD -- '*.sh' '*.bash')"
+else
+  files="$(git ls-files -- '*.sh' '*.bash')"
+fi
+
+if [[ -z "$files" ]]; then
+  echo "lint-claude-home-path: nothing to scan (mode=$mode)"
+  exit 0
+fi
+
+found=0
+while IFS= read -r f; do
+  [[ -f "$f" ]] || continue
+  if [[ "$f" =~ $ALLOWED ]]; then
+    continue
+  fi
+  if [[ "$mode" == "--diff" ]]; then
+    # Only flag lines ADDED in the diff (not surrounding context).
+    # git diff prefix: '+' (added), ' ' (context), '-' (removed).
+    added="$(git diff "$base"...HEAD -- "$f" | awk '/^\+[^+]/ {print substr($0, 2)}')"
+    matches="$(echo "$added" | grep -E "$PATTERN_INLINE" || true)"
+  else
+    matches="$(grep -E "$PATTERN_INLINE" "$f" || true)"
+  fi
+  if [[ -n "$matches" ]]; then
+    found=1
+    echo "lint-claude-home-path: forbidden inline pattern in $f"
+    while IFS= read -r line; do
+      echo "  $line"
+    done <<< "$matches"
+  fi
+done <<< "$files"
+
+if [[ "$found" -eq 1 ]]; then
+  cat >&2 <<'EOF'
+
+ERROR: One or more files use the inline `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`
+pattern. This bypasses the M0 helper + #1534 deprecation banner.
+
+Fix: replace each occurrence with the helper. Examples:
+
+  Before:
+    _CHAN_BASE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/channels"
+
+  After:
+    _CHAN_BASE="$(bash "$REPO_DIR/scripts/sutando-config.sh" claude-home-path channels)"
+
+  Before:
+    PROXY="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/quota-tracker/scripts/credential-proxy.ts"
+
+  After:
+    PROXY="$(bash "$REPO_DIR/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/credential-proxy.ts)"
+
+See `scripts/sutando-config.sh` for the helper's resolution order and the
+`SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1` opt-out.
+EOF
+  exit 1
+fi
+
+echo "lint-claude-home-path: clean (mode=$mode, scanned $(wc -l <<< "$files" | tr -d ' ') files)"
+exit 0

--- a/scripts/stage-readiness.sh
+++ b/scripts/stage-readiness.sh
@@ -142,7 +142,7 @@ else
 fi
 
 # 6) quota
-QUOTA_OUT=$(python3 "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/quota-tracker/scripts/read-quota.py" 2>/dev/null || echo "")
+QUOTA_OUT=$(python3 "$(bash "$REPO/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/read-quota.py)" 2>/dev/null || echo "")
 REM=$(echo "$QUOTA_OUT" | grep -oE '[0-9]+% remaining' | head -1 | grep -oE '[0-9]+')
 if [ -n "${REM:-}" ]; then
     if [ "$REM" -ge 10 ]; then

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -105,6 +105,49 @@ print(resolve_claude_sutando_config_dir(), end='')
 "
     ;;
 
+  claude-home-path)
+    # Resolve a path under Claude Code's per-user home, mirroring
+    # `src/util_paths.py:claude_home_path()` for shell scripts. Use this
+    # instead of the inline `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` anti-pattern
+    # so the deprecation-banner-on-fallback (added in #1534 for Python)
+    # also fires from bash callers when CLAUDE_CONFIG_DIR is unset.
+    #
+    # Resolution order (matches src/util_paths.py:claude_home_path):
+    #   1. $CLAUDE_CONFIG_DIR (per-runtime, workspace-scoped post-migrate)
+    #   2. $CLAUDE_HOME (legacy alt-host override, kept for tests)
+    #   3. ~/.claude/ (default — vanilla `claude` users; banner fires)
+    #
+    # Usage:
+    #   bash scripts/sutando-config.sh claude-home-path                            # base only
+    #   bash scripts/sutando-config.sh claude-home-path channels discord .env     # joined sub-path
+    #   bash scripts/sutando-config.sh claude-home-path skills quota-tracker/scripts/read-quota.py
+    #
+    # Banner suppression: SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1
+    if [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
+      _chp_base="$CLAUDE_CONFIG_DIR"
+    elif [ -n "${CLAUDE_HOME:-}" ]; then
+      _chp_base="$CLAUDE_HOME"
+    else
+      _chp_base="$HOME/.claude"
+      if [ "${SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER:-0}" != "1" ]; then
+        echo "claude-home-path: \$CLAUDE_CONFIG_DIR not set — falling back to ~/.claude/. Set CLAUDE_CONFIG_DIR before starting Sutando services (the \`claude-sutando\` shell function and src/startup.sh set it; ad-hoc launches must too) so channels/skills/hooks/sessions resolve to the workspace-scoped per-runtime location post-#1454. Suppress with SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1." >&2
+      fi
+    fi
+    # Expand leading ~ if present (covers e.g. CLAUDE_HOME=~/.claude-alt).
+    _chp_base="${_chp_base/#\~/$HOME}"
+    # Drop the subcommand from "$@" so remaining args are sub-path components.
+    shift
+    if [ "$#" -eq 0 ]; then
+      printf '%s' "$_chp_base"
+    else
+      _chp_joined="$_chp_base"
+      for _p in "$@"; do
+        _chp_joined="$_chp_joined/$_p"
+      done
+      printf '%s' "$_chp_joined"
+    fi
+    ;;
+
   core-config-dir-env-name)
     # v0.9 — print the env var name of the matching core_config_dirs entry.
     # Optional second arg picks by id or type; defaults to first type=claude.

--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -166,7 +166,7 @@ fi
 # back via `find … | head -1` to whichever sibling memory dir landed first
 # (alphabetical). Bug silently skipped real memory writes for 5+ weeks
 # before being caught. See docs/workspace-contract.md.
-MEMORY_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/$(echo "$SCRIPT_PARENT" | sed 's|/|-|g')/memory"
+MEMORY_DIR="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" claude-home-path "projects/$(echo "$SCRIPT_PARENT" | sed 's|/|-|g')/memory")"
 NOTES_DIR="$REPO_DIR/notes"
 LOG="/tmp/sync-memory.log"
 LOCK_DIR="/tmp/sync-memory.lock.d"
@@ -200,7 +200,7 @@ fi
 
 # Auto-detect memory dir (may vary by machine)
 if [ ! -d "$MEMORY_DIR" ]; then
-    MEMORY_DIR=$(find "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects" -name "memory" -type d 2>/dev/null | head -1)
+    MEMORY_DIR=$(find "$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" claude-home-path projects)" -name "memory" -type d 2>/dev/null | head -1)
 fi
 
 if [ ! -d "$SYNC_DIR" ]; then

--- a/skills/catchup-after-startup/scripts/catchup-after-startup.sh
+++ b/skills/catchup-after-startup/scripts/catchup-after-startup.sh
@@ -55,7 +55,7 @@ HOURS="${1:-${CATCHUP_HOURS:-3}}"
 # need to re-run install-hook.sh after the rename event. Idempotent + quiet
 # when nothing to migrate. The same script is also called from install-hook.sh.
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-python3 "$HERE/migrate-settings-hooks.py" "$(bash "$REPO/scripts/sutando-config.sh" claude-home-path settings.json)" 2>&1 | sed 's/^/  /' >&2 || true
+python3 "$HERE/migrate-settings-hooks.py" "$(bash "$(cd "$HERE/../../.." && pwd)/scripts/sutando-config.sh" claude-home-path settings.json)" 2>&1 | sed 's/^/  /' >&2 || true
 
 print_section() { echo; echo "## $1"; echo; }
 say() { echo "$@"; }
@@ -160,7 +160,7 @@ fi
 # the source of truth for "what was happening last session".
 print_section "Previous-session transcript (last $HOURS h)"
 proj_slug=$(echo "$REPO" | sed 's|/|-|g')
-proj_dir="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path "projects/$proj_slug")"
+proj_dir="$(bash "$(cd "$HERE/../../.." && pwd)/scripts/sutando-config.sh" claude-home-path "projects/$proj_slug")"
 if [ -d "$proj_dir" ]; then
   # Most-recent .jsonl untouched in the last minute — skips the CURRENT
   # session's transcript (which the live process is still writing to).

--- a/skills/catchup-after-startup/scripts/catchup-after-startup.sh
+++ b/skills/catchup-after-startup/scripts/catchup-after-startup.sh
@@ -55,7 +55,7 @@ HOURS="${1:-${CATCHUP_HOURS:-3}}"
 # need to re-run install-hook.sh after the rename event. Idempotent + quiet
 # when nothing to migrate. The same script is also called from install-hook.sh.
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-python3 "$HERE/migrate-settings-hooks.py" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json" 2>&1 | sed 's/^/  /' >&2 || true
+python3 "$HERE/migrate-settings-hooks.py" "$(bash "$REPO/scripts/sutando-config.sh" claude-home-path settings.json)" 2>&1 | sed 's/^/  /' >&2 || true
 
 print_section() { echo; echo "## $1"; echo; }
 say() { echo "$@"; }
@@ -160,7 +160,7 @@ fi
 # the source of truth for "what was happening last session".
 print_section "Previous-session transcript (last $HOURS h)"
 proj_slug=$(echo "$REPO" | sed 's|/|-|g')
-proj_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/$proj_slug"
+proj_dir="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path "projects/$proj_slug")"
 if [ -d "$proj_dir" ]; then
   # Most-recent .jsonl untouched in the last minute — skips the CURRENT
   # session's transcript (which the live process is still writing to).

--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -139,7 +139,7 @@ fi
 find "$REPO/results" -maxdepth 1 -type f -name "*.txt" -mmin "-$((SECONDS_AGO/60))" 2>/dev/null | head -20 > "$OUT/results-recent-paths.txt" || true
 
 # 8) Quota state
-_QUOTA_SCRIPT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/quota-tracker/scripts/read-quota.py"
+_QUOTA_SCRIPT="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/read-quota.py)"
 if [ -f "$_QUOTA_SCRIPT" ]; then
 	python3 "$_QUOTA_SCRIPT" 2>&1 | head -10 > "$OUT/quota.txt" || true
 fi

--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -139,7 +139,7 @@ fi
 find "$REPO/results" -maxdepth 1 -type f -name "*.txt" -mmin "-$((SECONDS_AGO/60))" 2>/dev/null | head -20 > "$OUT/results-recent-paths.txt" || true
 
 # 8) Quota state
-_QUOTA_SCRIPT="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/read-quota.py)"
+_QUOTA_SCRIPT="$(bash "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/read-quota.py)"
 if [ -f "$_QUOTA_SCRIPT" ]; then
 	python3 "$_QUOTA_SCRIPT" 2>&1 | head -10 > "$OUT/quota.txt" || true
 fi

--- a/src/init.sh
+++ b/src/init.sh
@@ -332,7 +332,7 @@ preflight() {
   done
 
   # External channel envs — Discord / Telegram bot tokens live outside the repo .env
-  _CHAN_BASE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/channels"
+  _CHAN_BASE="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels)"
   optional_total=$((optional_total + 1))
   if [ -f "$_CHAN_BASE/discord/.env" ] && grep -qE '^DISCORD_BOT_TOKEN=.+' "$_CHAN_BASE/discord/.env"; then
     optional_ok=$((optional_ok + 1))

--- a/src/init.sh
+++ b/src/init.sh
@@ -332,7 +332,11 @@ preflight() {
   done
 
   # External channel envs — Discord / Telegram bot tokens live outside the repo .env
-  _CHAN_BASE="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels)"
+  # Resolve via BASH_SOURCE (not $REPO) so the helper invocation works even
+  # when tests/callers override $REPO to a scratch dir that doesn't contain
+  # the helper. Init.sh is always co-located with scripts/sutando-config.sh
+  # in the canonical Sutando checkout.
+  _CHAN_BASE="$(bash "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts/sutando-config.sh" claude-home-path channels)"
   optional_total=$((optional_total + 1))
   if [ -f "$_CHAN_BASE/discord/.env" ] && grep -qE '^DISCORD_BOT_TOKEN=.+' "$_CHAN_BASE/discord/.env"; then
     optional_ok=$((optional_ok + 1))

--- a/src/install-credential-proxy-launchd.sh
+++ b/src/install-credential-proxy-launchd.sh
@@ -68,7 +68,7 @@ case "$cmd" in
             echo "ERROR: template not found: $TEMPLATE" >&2
             exit 1
         fi
-        _PROXY_SCRIPT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/quota-tracker/scripts/credential-proxy.ts"
+        _PROXY_SCRIPT="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/credential-proxy.ts)"
         if [ ! -f "$_PROXY_SCRIPT" ]; then
             echo "ERROR: quota-tracker skill not found at $_PROXY_SCRIPT" >&2
             echo "  Install it first — credential-proxy.ts is the proxy target." >&2

--- a/src/launchd/credential-proxy-wrapper.sh
+++ b/src/launchd/credential-proxy-wrapper.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # launchd plist exports it (claude-sutando installs); otherwise falls back to
 # ~/.claude. launchd itself doesn't inherit shell env, so this fallback is the
 # vanilla-claude default unless the plist's EnvironmentVariables sets it.
-PROXY_SCRIPT="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/quota-tracker/scripts/credential-proxy.ts"
+PROXY_SCRIPT="$(bash "$(cd "$(dirname "$0")/../.." && pwd)/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/credential-proxy.ts)"
 
 # Resolve npx — launchd doesn't inherit the user's shell PATH.
 resolve_npx() {

--- a/src/notify.sh
+++ b/src/notify.sh
@@ -14,7 +14,7 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 TS=$(date +%s%3N)
 
 # Load tokens from channel configs
-CLAUDE_CFG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CLAUDE_CFG_DIR="$(bash "$REPO_DIR/scripts/sutando-config.sh" claude-home-path)"
 DISCORD_TOKEN=$(grep DISCORD_BOT_TOKEN "$CLAUDE_CFG_DIR/channels/discord/.env" 2>/dev/null | cut -d= -f2-)
 DISCORD_USER_ID=$(python3 -c "import json; print(json.load(open('$CLAUDE_CFG_DIR/channels/discord/access.json')).get('allowFrom',[''])[0])" 2>/dev/null)
 

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -494,7 +494,7 @@ fi
 # 0. Credential proxy for quota tracking (port 7846)
 if ! lsof -i :7846 > /dev/null 2>&1; then
   echo "  Starting credential proxy (port 7846)..."
-  npx tsx "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/quota-tracker/scripts/credential-proxy.ts" > /tmp/credential-proxy.log 2>&1 &
+  npx tsx "$(bash "$REPO/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/credential-proxy.ts)" > /tmp/credential-proxy.log 2>&1 &
   sleep 1
   if lsof -i :7846 > /dev/null 2>&1; then
     echo "  ✓ credential proxy"
@@ -661,7 +661,7 @@ echo ""
 # 6. Telegram bridge (optional — needs TELEGRAM_BOT_TOKEN, skip with SKIP_TELEGRAM=1)
 if [ "${SKIP_TELEGRAM:-}" = "1" ]; then
   echo "  ~ telegram bridge (skipped via SKIP_TELEGRAM)"
-elif _TG_ENV="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/channels/telegram/.env"; [ -f "$_TG_ENV" ] && grep -q "TELEGRAM_BOT_TOKEN=" "$_TG_ENV" 2>/dev/null; then
+elif _TG_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels/telegram/.env)"; [ -f "$_TG_ENV" ] && grep -q "TELEGRAM_BOT_TOKEN=" "$_TG_ENV" 2>/dev/null; then
   if ! pgrep -f "telegram-bridge" > /dev/null 2>&1; then
     echo "  Starting Telegram bridge..."
     python3 src/telegram-bridge.py > "$LOGS_DIR/telegram-bridge.log" 2>&1 &
@@ -681,7 +681,7 @@ fi
 # right one in the first place avoids the wasted process + traceback noise.
 # Probe a fixed list of candidates in priority order; first one with discord.py
 # wins. Same probe is also what's used in the bridge's rescue fallback.
-if _DC_ENV="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/channels/discord/.env"; [ -f "$_DC_ENV" ] && grep -q "DISCORD_BOT_TOKEN=" "$_DC_ENV" 2>/dev/null; then
+if _DC_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels/discord/.env)"; [ -f "$_DC_ENV" ] && grep -q "DISCORD_BOT_TOKEN=" "$_DC_ENV" 2>/dev/null; then
   PYTHON_WITH_DISCORD=""
   for _p in /opt/homebrew/bin/python3 /usr/local/bin/python3 python3; do
     if command -v "$_p" >/dev/null 2>&1 && "$_p" -c "import discord" 2>/dev/null; then
@@ -717,7 +717,7 @@ fi
 # 7b. Slack bridge (optional — needs SLACK_BOT_TOKEN + SLACK_APP_TOKEN + slack_bolt)
 # Probes the same Python-interpreter candidates as the discord bridge so a
 # fresh-install miniconda env doesn't silently miss slack_bolt.
-if _SL_ENV="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/channels/slack/.env"; [ -f "$_SL_ENV" ] && grep -q "SLACK_BOT_TOKEN=" "$_SL_ENV" 2>/dev/null; then
+if _SL_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels/slack/.env)"; [ -f "$_SL_ENV" ] && grep -q "SLACK_BOT_TOKEN=" "$_SL_ENV" 2>/dev/null; then
   PYTHON_WITH_SLACK=""
   for _p in /opt/homebrew/bin/python3 /usr/local/bin/python3 python3; do
     if command -v "$_p" >/dev/null 2>&1 && "$_p" -c "import slack_bolt" 2>/dev/null; then

--- a/src/verify-setup.sh
+++ b/src/verify-setup.sh
@@ -67,7 +67,7 @@ if [ -f .env ]; then
   else
     warn "Twilio not configured (optional — phone features disabled)"
   fi
-  _CHAN_BASE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/channels"
+  _CHAN_BASE="$(bash "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts/sutando-config.sh" claude-home-path channels)"
   if [ -f "$_CHAN_BASE/telegram/.env" ]; then
     pass "Telegram bot configured"
   else

--- a/tests/sutando-config-claude-home-path.test.sh
+++ b/tests/sutando-config-claude-home-path.test.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# tests/sutando-config-claude-home-path.test.sh — E2E smoke for the shell
+# `claude-home-path` subcommand on scripts/sutando-config.sh.
+#
+# Mirrors tests/util-paths-ccd-banner.test.py (the Python-side test for
+# src/util_paths.py:claude_home_path). 4 cases, 12 assertions:
+#
+#   1. CLAUDE_CONFIG_DIR set       → no banner, resolves under CCD
+#   2. CLAUDE_HOME set (CCD unset) → no banner, resolves under CLAUDE_HOME
+#   3. Both unset                  → banner fires on stderr, falls back to ~/.claude/
+#   4. SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1 → silenced, still falls back
+#
+# Run: bash tests/sutando-config-claude-home-path.test.sh
+# Exit: 0 = all pass, 1 = failure
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_DIR/scripts/sutando-config.sh"
+
+pass=0; fail=0
+report() {
+  if [ "$1" = "0" ]; then
+    echo "  PASS: $2"; pass=$((pass+1))
+  else
+    echo "  FAIL: $2"; fail=$((fail+1))
+  fi
+}
+
+# -- Test 1: CCD set → no banner, resolves under CCD ------------------------
+echo "[1] CLAUDE_CONFIG_DIR set → no banner, resolves under CCD"
+T1="$(mktemp -d)"
+out1="$(CLAUDE_CONFIG_DIR="$T1" bash "$SCRIPT" claude-home-path channels discord access.json 2>/dev/null)"
+err1="$(CLAUDE_CONFIG_DIR="$T1" bash "$SCRIPT" claude-home-path channels discord access.json 2>&1 >/dev/null)"
+[ "$out1" = "$T1/channels/discord/access.json" ]; report "$?" "resolves under CCD"
+[ -z "$err1" ]; report "$?" "no fallback banner on stderr"
+rm -rf "$T1"
+
+# -- Test 2: CLAUDE_HOME set (CCD unset) → no banner ------------------------
+echo "[2] CLAUDE_HOME set (CCD unset) → no banner, resolves under CLAUDE_HOME"
+T2="$(mktemp -d)"
+out2="$(env -u CLAUDE_CONFIG_DIR CLAUDE_HOME="$T2" bash "$SCRIPT" claude-home-path channels discord access.json 2>/dev/null)"
+err2="$(env -u CLAUDE_CONFIG_DIR CLAUDE_HOME="$T2" bash "$SCRIPT" claude-home-path channels discord access.json 2>&1 >/dev/null)"
+[ "$out2" = "$T2/channels/discord/access.json" ]; report "$?" "resolves under CLAUDE_HOME"
+[ -z "$err2" ]; report "$?" "no banner — CLAUDE_HOME is a test override, not the deprecated path"
+rm -rf "$T2"
+
+# -- Test 3: Both unset → banner fires on stderr, falls back ----------------
+echo "[3] CCD + CLAUDE_HOME unset → banner fires, falls back to ~/.claude/"
+out3="$(env -u CLAUDE_CONFIG_DIR -u CLAUDE_HOME -u SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER bash "$SCRIPT" claude-home-path channels discord access.json 2>/dev/null)"
+err3="$(env -u CLAUDE_CONFIG_DIR -u CLAUDE_HOME -u SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER bash "$SCRIPT" claude-home-path channels discord access.json 2>&1 >/dev/null)"
+[ "$out3" = "$HOME/.claude/channels/discord/access.json" ]; report "$?" "resolves under ~/.claude/ default"
+echo "$err3" | grep -q "CLAUDE_CONFIG_DIR not set"; report "$?" "fallback banner present on stderr"
+
+# -- Test 4: SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1 → silenced --------------
+echo "[4] SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1 → no banner, still falls back"
+out4="$(env -u CLAUDE_CONFIG_DIR -u CLAUDE_HOME SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1 bash "$SCRIPT" claude-home-path channels discord access.json 2>/dev/null)"
+err4="$(env -u CLAUDE_CONFIG_DIR -u CLAUDE_HOME SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1 bash "$SCRIPT" claude-home-path channels discord access.json 2>&1 >/dev/null)"
+[ "$out4" = "$HOME/.claude/channels/discord/access.json" ]; report "$?" "resolves under ~/.claude/ default (suppression only silences banner)"
+[ -z "$err4" ]; report "$?" "no banner with suppression env var set"
+
+# -- Test 5: base only (no sub-path) ----------------------------------------
+echo "[5] base only (no sub-path) → just \$CLAUDE_CONFIG_DIR"
+T5="$(mktemp -d)"
+out5="$(CLAUDE_CONFIG_DIR="$T5" bash "$SCRIPT" claude-home-path 2>/dev/null)"
+[ "$out5" = "$T5" ]; report "$?" "base-only resolution returns just \$CLAUDE_CONFIG_DIR"
+rm -rf "$T5"
+
+# -- Test 6: multi-arg sub-path joining -------------------------------------
+echo "[6] multi-arg sub-path joining"
+T6="$(mktemp -d)"
+out6="$(CLAUDE_CONFIG_DIR="$T6" bash "$SCRIPT" claude-home-path skills quota-tracker scripts read-quota.py 2>/dev/null)"
+[ "$out6" = "$T6/skills/quota-tracker/scripts/read-quota.py" ]; report "$?" "multi-arg sub-path joins with /"
+rm -rf "$T6"
+
+# -- Test 7: single-arg sub-path with embedded slashes ----------------------
+echo "[7] single-arg sub-path with embedded slashes"
+T7="$(mktemp -d)"
+out7="$(CLAUDE_CONFIG_DIR="$T7" bash "$SCRIPT" claude-home-path "skills/quota-tracker/scripts/read-quota.py" 2>/dev/null)"
+[ "$out7" = "$T7/skills/quota-tracker/scripts/read-quota.py" ]; report "$?" "single-arg with embedded slashes preserves them"
+rm -rf "$T7"
+
+echo
+echo "Results: $pass passed, $fail failed"
+[ "$fail" = "0" ]


### PR DESCRIPTION
## Workspace-revamp milestone scope

| Layer | Status | This PR |
|---|---|---|
| M0 — workspace location helper | shipped | — |
| M1 — migration (`scripts/sutando-migrate.sh`) | shipped | — |
| M2 — sync engine | shipped | — |
| M3 — staging→main rollup (#1454) | open | — |
| **Channels-migration banner closure** (this PR) | bash-side SSOT closes the loop from #1534 (Python-side banner) | **adds shell helper + migrates 15 sites + lint** |

## Summary

Owner directive 2026-06-07 22:38Z ("Option A" + "ship sweep separately") following the 22:35Z DM question — *"Why we still have /.claude/?"* — while reviewing #1505.

That question surfaced a systemic gap: **15 bash call sites use the inline `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` pattern**, bypassing the M0 SSOT and the deprecation banner I added in #1534 (`src/util_paths.py:claude_home_path()`). The Python side honored the banner; bash had no SSOT analog.

This PR closes the bash side of the channels-migration banner story shipped in #1534.

## What ships

### 1. New shell helper — `scripts/sutando-config.sh claude-home-path`

Mirrors `src/util_paths.py:claude_home_path()` resolution order:
- `$CLAUDE_CONFIG_DIR` → `$CLAUDE_HOME` → `~/.claude/`

Emits the same one-shot stderr deprecation banner when falling back to `~/.claude/`. Suppressible via `SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1` (same env var #1534 introduced for Python). `CLAUDE_HOME` is a test override and does NOT trigger the banner.

Usage:
```bash
$(bash scripts/sutando-config.sh claude-home-path)                              # base only
$(bash scripts/sutando-config.sh claude-home-path channels discord .env)        # joined sub-path
$(bash scripts/sutando-config.sh claude-home-path skills/quota-tracker/scripts/read-quota.py)
```

### 2. Migrated 15 inline call sites across 11 files

| File | Sites | Use |
|---|---|---|
| `scripts/stage-readiness.sh` | 1 | quota-tracker invocation |
| `scripts/sync-memory.sh` | 2 | memory project lookup + projects scan |
| `src/verify-setup.sh` | 1 | channels base |
| `skills/self-diagnose/scripts/gather.sh` | 1 | quota-tracker invocation |
| `src/init.sh` | 1 | channels base |
| `skills/catchup-after-startup/scripts/catchup-after-startup.sh` | 2 | settings.json + project dir |
| `src/install-credential-proxy-launchd.sh` | 1 | credential-proxy script path |
| `src/startup.sh` | 4 | credential-proxy + 3 channel env paths |
| `src/notify.sh` | 1 | CLAUDE_CFG_DIR base |
| `src/launchd/credential-proxy-wrapper.sh` | 1 | credential-proxy script path |

Each site now calls the helper via `bash "$REPO/scripts/sutando-config.sh" claude-home-path <subpath>` (or equivalent path-to-helper computed locally where `REPO_DIR` isn't set).

**NOT migrated** (intentionally): `${SOURCE_CLAUDE_CONFIG_DIR:-$HOME/.claude}` flavors in `scripts/sutando-shell-setup.sh` (2 sites). Per `src/util_paths.py:claude_home_path()` docstring, `SOURCE_CLAUDE_CONFIG_DIR` is the migration READ-FROM env var and has separate semantics. Stays inline.

### 3. Tests + lint

- **`tests/sutando-config-claude-home-path.test.sh`** — 7 cases, 11 assertions, all PASS locally. Mirrors `tests/util-paths-ccd-banner.test.py` (CCD set / CLAUDE_HOME set / both-unset-banner-fires / suppression) + 3 path-joining cases (base only, multi-arg, embedded slashes).
- **`scripts/lint-claude-home-path.sh`** — refuses NEW inline patterns on ADDED lines in PR diffs (same pattern as `lint-workspace-resolution.sh`). Existing legacy offenders this PR doesn't touch are not flagged (none remain after this sweep).
- **`.github/workflows/lint-claude-home-path.yml`** — CI runs the lint on PRs to `main` + `staging-workspace-revamp`.

Allowed files in the lint (may reference the anti-pattern in comments/docstrings): `scripts/sutando-config.sh`, `src/startup.sh`, `scripts/lint-claude-home-path.sh`, `tests/*`.

## Net diff

```
14 files changed, 292 insertions(+), 15 deletions(-)
```

## Test plan

- [x] `bash tests/sutando-config-claude-home-path.test.sh` → 11/11 PASS locally
- [x] `bash scripts/lint-claude-home-path.sh` → "clean (mode=all, scanned 88 files)"
- [x] All 11 modified scripts pass `bash -n` syntax check
- [x] Helper smoke-tested via `CLAUDE_CONFIG_DIR=/tmp/x bash scripts/sutando-config.sh claude-home-path channels discord .env` → `/tmp/x/channels/discord/.env`
- [ ] CI: tsc + tests, lint-workspace-resolution, workspace-leak-check, license/cla
- [ ] CI: NEW lint-claude-home-path (self-check)

## Refs

- Owner directive 2026-06-07 22:38Z (DM)
- #1534 (Python-side banner — this PR's parallel on the bash side)
- #1454 (M3 staging→main rollup — same milestone family)
- #1505 (PR that triggered the question; remains independently mergeable, will pick up the helper automatically once both land)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
