### PR TITLE
feat(infra): discord-read.py — lightweight REST channel reader (recovery of #1528)

### DIFF
--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Read recent messages from a Discord channel via REST API.
+
+Exits after printing — never starts a persistent bot connection.
+
+Usage:
+    python3 src/discord-read.py <channel_id> [--limit N] [--after MSG_ID]
+
+Requires DISCORD_BOT_TOKEN in ~/.claude/channels/discord/.env or env var.
+"""
+import json
+import os
+import sys
+import urllib.request
+import urllib.parse
+from pathlib import Path
+
+CLAUDE_CONFIG = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude"))
+_env = CLAUDE_CONFIG / "channels" / "discord" / ".env"
+for line in (_env.read_text().splitlines() if _env.exists() else []):
+    k, _, v = line.partition("=")
+    if k.strip() == "DISCORD_BOT_TOKEN" and v.strip():
+        os.environ.setdefault("DISCORD_BOT_TOKEN", v.strip())
+
+TOKEN = os.environ.get("DISCORD_BOT_TOKEN", "")
+if not TOKEN:
+    print("Requires DISCORD_BOT_TOKEN in ~/.claude/channels/discord/.env", file=sys.stderr)
+    sys.exit(1)
+
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument("channel_id")
+parser.add_argument("--limit", type=int, default=10)
+parser.add_argument("--after", default=None, help="Snowflake ID — fetch messages after this ID")
+args = parser.parse_args()
+
+params = {"limit": str(args.limit)}
+if args.after:
+    params["after"] = args.after
+url = f"https://discord.com/api/v10/channels/{args.channel_id}/messages?" + urllib.parse.urlencode(params)
+req = urllib.request.Request(url, headers={
+    "Authorization": f"Bot {TOKEN}",
+    "User-Agent": "Sutando-reader/1.0",
+})
+try:
+    with urllib.request.urlopen(req, timeout=10) as r:
+        messages = json.loads(r.read())
+except Exception as e:
+    print(f"Error: {e}", file=sys.stderr)
+    sys.exit(1)
+
+for msg in reversed(messages):  # oldest first
+    author = msg.get("author", {}).get("username", "?")
+    content = msg.get("content", "")[:200]
+    ts = msg.get("timestamp", "")[:19]
+    print(f"[{ts}] {author}: {content}")

--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -15,8 +15,10 @@ import urllib.request
 import urllib.parse
 from pathlib import Path
 
-CLAUDE_CONFIG = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude"))
-_env = CLAUDE_CONFIG / "channels" / "discord" / ".env"
+sys.path.insert(0, str(Path(__file__).parent))
+from util_paths import claude_home_path  # noqa: E402
+
+_env = claude_home_path("channels", "discord", ".env")
 for line in (_env.read_text().splitlines() if _env.exists() else []):
     k, _, v = line.partition("=")
     if k.strip() == "DISCORD_BOT_TOKEN" and v.strip():
@@ -24,7 +26,7 @@ for line in (_env.read_text().splitlines() if _env.exists() else []):
 
 TOKEN = os.environ.get("DISCORD_BOT_TOKEN", "")
 if not TOKEN:
-    print("Requires DISCORD_BOT_TOKEN in ~/.claude/channels/discord/.env", file=sys.stderr)
+    print(f"Requires DISCORD_BOT_TOKEN in {_env}", file=sys.stderr)
     sys.exit(1)
 
 import argparse

--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -6,7 +6,10 @@ Exits after printing — never starts a persistent bot connection.
 Usage:
     python3 src/discord-read.py <channel_id> [--limit N] [--after MSG_ID]
 
-Requires DISCORD_BOT_TOKEN in ~/.claude/channels/discord/.env or env var.
+Requires DISCORD_BOT_TOKEN in $CLAUDE_CONFIG_DIR/channels/discord/.env
+(resolved via src/util_paths.py:claude_home_path; falls back to
+~/.claude/channels/discord/.env if neither CLAUDE_CONFIG_DIR nor CLAUDE_HOME
+is set) or set DISCORD_BOT_TOKEN directly as an env var.
 """
 import json
 import os

--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -6,10 +6,7 @@ Exits after printing — never starts a persistent bot connection.
 Usage:
     python3 src/discord-read.py <channel_id> [--limit N] [--after MSG_ID]
 
-Requires DISCORD_BOT_TOKEN in $CLAUDE_CONFIG_DIR/channels/discord/.env
-(resolved via src/util_paths.py:claude_home_path; falls back to
-~/.claude/channels/discord/.env if neither CLAUDE_CONFIG_DIR nor CLAUDE_HOME
-is set) or set DISCORD_BOT_TOKEN directly as an env var.
+Requires DISCORD_BOT_TOKEN in $CLAUDE_CONFIG_DIR/channels/discord/.env or env var.
 """
 import json
 import os


### PR DESCRIPTION
Recovery of #1528. The original PR was accidentally CLOSED during a triage attempt (owner directed close+reopen to force GitHub to recompute a stale CONFLICTING mergeability cache; the reopen API failed). Chi's branch `feat/discord-read-rest-channel-reader` appears to live on a fork, so a direct `gh pr create --head <branch>` against the main repo failed too.

This PR uses the EXACT same commits as #1528:
- `bf342a12` feat(infra): discord-read.py — lightweight REST channel reader (exits after read)
- `48f14643` fix(discord-read): use claude_home_path() instead of Path.home()/'.claude'

Pushed via `git fetch origin pull/1528/head` → push to new branch on the main repo. @sonichi's authorship is preserved on the commits.

**Apologies for the close mistake** — I'll be more conservative about API-side triage steps going forward (this is the second time today an irreversible-feeling action surprised me: the cherry-pick on #1515's branch earlier was the other). Worth filing as memory.

Closes #1528 (de facto, since that PR is now closed).