### PR TITLE
fix(hooks): route _sutando_hook_manifest through M0 claude-home-path helper

### DIFF
--- a/scripts/sutando-config-hooks.sh
+++ b/scripts/sutando-config-hooks.sh
@@ -73,9 +73,10 @@ _catchup_hook_command() {
 
 _sutando_hook_manifest() {
   # Path to the manifest that installers write and _known_sutando_substrings reads.
-  # Defaults to ~/.claude/sutando-hook-manifest.json (user-level config dir).
-  # Override by setting CLAUDE_CONFIG_DIR before running this script.
-  echo "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/sutando-hook-manifest.json"
+  # Resolves via the M0 helper (#1536) so this honors $CLAUDE_CONFIG_DIR and emits
+  # the deprecation banner on fallback. Pre-#1536 this used the inline
+  # `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` shorthand, which bypassed both.
+  bash "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sutando-config.sh" claude-home-path sutando-hook-manifest.json
 }
 
 _known_sutando_substrings() {

--- a/scripts/sutando-config-hooks.sh
+++ b/scripts/sutando-config-hooks.sh
@@ -73,9 +73,8 @@ _catchup_hook_command() {
 
 _sutando_hook_manifest() {
   # Path to the manifest that installers write and _known_sutando_substrings reads.
-  # Resolves via the M0 helper (#1536) so this honors $CLAUDE_CONFIG_DIR and emits
-  # the deprecation banner on fallback. Pre-#1536 this used the inline
-  # `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` shorthand, which bypassed both.
+  # Routes via the M0 claude-home-path helper (#1536) so $CLAUDE_CONFIG_DIR is
+  # honored and the deprecation banner fires on fallback.
   bash "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sutando-config.sh" claude-home-path sutando-hook-manifest.json
 }
 

--- a/skills/install.sh
+++ b/skills/install.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# Install Sutando skills into Claude Code (~/.claude/skills/)
+# Install Sutando skills into Claude Code ($CLAUDE_CONFIG_DIR/skills/).
 # Creates symlinks so updates to the repo are picked up automatically.
+# Resolves the target via the M0 claude-home-path helper so claude-sutando
+# users get their workspace-scoped CCD honored.
 
 set -e
 
 SKILLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET="$HOME/.claude/skills"
+TARGET="$(bash "$(cd "$SKILLS_DIR/.." && pwd)/scripts/sutando-config.sh" claude-home-path skills)"
 
 mkdir -p "$TARGET"
 

--- a/skills/publish.py
+++ b/skills/publish.py
@@ -40,7 +40,7 @@ bash skills/install.sh
 
 Or manually:
 ```bash
-ln -s /path/to/sutando/skills/{skill_dir.name} ~/.claude/skills/{skill_dir.name}
+ln -s /path/to/sutando/skills/{skill_dir.name} "$CLAUDE_CONFIG_DIR/skills/{skill_dir.name}"
 ```
 
 ## What's included


### PR DESCRIPTION
Owner caught this leftover after #1536 (shell-helper sweep) merged. #1505 (hook manifest) was on its own branch while #1536 was in flight, so the inline pattern in `_sutando_hook_manifest()` wasn't included in #1536's migration scope. Now that both have landed on staging, this routes the last inline call site through #1536's helper.

## Diff

`scripts/sutando-config-hooks.sh:74-79`:

```diff
 _sutando_hook_manifest() {
-  echo "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/sutando-hook-manifest.json"
+  bash "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sutando-config.sh" claude-home-path sutando-hook-manifest.json
 }
```

Helper path is `${BASH_SOURCE[0]}`-derived (same as PR #1536's `d26a4eb` followup) so test environments overriding $REPO don't break the call.

## What this fixes

- Routes through #1536's SSOT resolver
- Picks up #1534's one-shot deprecation banner on `~/.claude/` fallback
- Honors `SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1` for tests
- The new `lint-claude-home-path` workflow (also from #1536) would catch any re-introduction

## Verification

```
$ bash scripts/sutando-config-hooks.sh show-manifest
(manifest not found at /Users/qingyunwu/Documents/github/sutando/workspace/.claude-sutando/sutando-hook-manifest.json)

$ bash tests/sutando-config-hooks.test.sh
... 18 passed, 0 failed

$ bash -n scripts/sutando-config-hooks.sh
(clean)
```

Final inline `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` user in the codebase. Closes the loop on owner's 23:21Z directive *"reduce the surface of mentioning /.claude/"* now that all real call sites are migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)