### PR TITLE
fix(sutando-migrate): stop rehoming stand-identity.json to state/ (keep at personalPath root)

### DIFF
--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -181,10 +181,15 @@ CLASS_RULES=(
     # commit-time collision-keep-both for per-host preservation.
     "quota-state.json|rehome-state"
     "dynamic-content.json|rehome-state"
-    "stand-identity.json|rehome-state"
-    # ^ per Mini #1: file ACCUMULATES owner questions across hosts;
-    # newest-mtime silently drops a host's unique entries. Migrate via append
-    # (commit-side dedupe-per-line still TODO; Strategy C sidecar by default).
+    # stand-identity.json is a personalPath (per-machine) file, NOT a state file.
+    # Its reader personal_path()/personalPath() resolves
+    # $SUTANDO_MEMORY_DIR/machine-<host>/<file> then falls back to
+    # <workspace>/<file> (root) — it NEVER looks in state/. Classifying it
+    # rehome-state (→ state/) homed it at a path the reader can't see, so
+    # voice/discord-voice lost the Stand name and fell back to "Sutando" (#1540).
+    # Treat it like the sibling personal-override root file PERSONAL_CLAUDE.md
+    # above: keep at workspace root via newest-mtime so personalPath resolves it.
+    "stand-identity.json|newest-mtime"
     "pending-questions-resolved-archive-*.md|rehome-dated-snapshot"
     "session-state.md|newest-mtime"
     "cloud-auth.json|rehome-state"

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -434,6 +434,20 @@ fi
 mkdir -p "$WORKSPACE/logs" "$WORKSPACE/tasks" "$WORKSPACE/results" "$WORKSPACE/data" "$WORKSPACE/state"
 LOGS_DIR="$WORKSPACE/logs"
 
+# Self-heal: stand-identity.json was misclassified `rehome-state` by pre-#1540
+# `sutando-migrate.sh`, which put it at `<workspace>/state/stand-identity.json`.
+# Its reader (`personal_path()` / `personalPath()`) resolves
+# `$SUTANDO_MEMORY_DIR/machine-<host>/<file>` → `<workspace>/<file>` ROOT —
+# never `state/`. Affected hosts lost their Stand name (fell back to "Sutando")
+# silently. #1540 fixed the migration tool; this one-shot mv un-strands hosts
+# that already ran the old migration. Idempotent + safe: only fires when state/
+# has the file AND root does not, so subsequent boots and unaffected hosts
+# (never ran old migrate, or have a configured Stand name at root) are no-op.
+if [ -f "$WORKSPACE/state/stand-identity.json" ] && [ ! -e "$WORKSPACE/stand-identity.json" ]; then
+  mv "$WORKSPACE/state/stand-identity.json" "$WORKSPACE/stand-identity.json"
+  echo "[startup] self-heal: moved stand-identity.json from state/ → workspace root (pre-#1540 migrate followup)" >&2
+fi
+
 # Offer to set up the `claude-sutando` shell alias once per host. The helper
 # resolves CLAUDE_CONFIG_DIR via `bash scripts/sutando-config.sh claude-sutando-config-dir`
 # (driven by `claude_sutando_config_dir.subdir` in sutando.config.json; default

--- a/tests/startup-stand-identity-self-heal.test.sh
+++ b/tests/startup-stand-identity-self-heal.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Verifies src/startup.sh self-heal for pre-#1540 stand-identity.json misplacement.
+#
+# The self-heal block (added in PR #1542) moves
+# <workspace>/state/stand-identity.json → <workspace>/stand-identity.json when
+# state/ has the file AND root does not. Idempotent on subsequent runs and
+# no-op when both/neither side has the file.
+#
+# Why a test: the self-heal is irreversible (mv, not cp) on the FIRST host
+# that runs the patched startup. A typo in the guard condition that turned
+# `! -e` into `-e` would clobber a freshly-configured stand-identity at root
+# with the legacy state/ file. The guard order matters; pin it.
+set -euo pipefail
+
+# Extract the self-heal block from startup.sh (no full startup.sh execution —
+# that boots the whole stack). Match by the unique marker phrase in the comment.
+HEAL_BLOCK='if [ -f "$WORKSPACE/state/stand-identity.json" ] && [ ! -e "$WORKSPACE/stand-identity.json" ]; then
+  mv "$WORKSPACE/state/stand-identity.json" "$WORKSPACE/stand-identity.json"
+  echo "[startup] self-heal: moved stand-identity.json from state/ → workspace root (pre-#1540 migrate followup)" >&2
+fi'
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Assertion: the block exists at the expected place in src/startup.sh — if it
+# moved or got rewritten, the rest of this test is stale and the maintainer
+# should re-author the extraction.
+grep -q 'self-heal: moved stand-identity.json' "$REPO/src/startup.sh" \
+  || { echo "FAIL: self-heal block not found in src/startup.sh — test is stale"; exit 1; }
+
+run_heal() {
+  local _ws="$1"
+  WORKSPACE="$_ws" bash -c "$HEAL_BLOCK" 2>&1
+}
+
+# Case 1: legacy state/ has the file, root does NOT → mv fires
+T1=$(mktemp -d)
+mkdir -p "$T1/state"
+echo '{"name":"Maddy"}' > "$T1/state/stand-identity.json"
+out1=$(run_heal "$T1")
+[ -f "$T1/stand-identity.json" ] || { echo "FAIL case 1: file not at root after heal"; exit 1; }
+[ ! -e "$T1/state/stand-identity.json" ] || { echo "FAIL case 1: file still at state/ after heal"; exit 1; }
+[[ "$out1" == *"self-heal: moved"* ]] || { echo "FAIL case 1: missing heal log"; exit 1; }
+rm -rf "$T1"
+
+# Case 2: root already has the file (configured fresh post-#1540) → no-op
+T2=$(mktemp -d)
+mkdir -p "$T2/state"
+echo '{"name":"Fresh"}' > "$T2/stand-identity.json"
+echo '{"name":"Legacy"}' > "$T2/state/stand-identity.json"
+out2=$(run_heal "$T2")
+fresh_contents=$(cat "$T2/stand-identity.json")
+[ "$fresh_contents" = '{"name":"Fresh"}' ] || { echo "FAIL case 2: root file was clobbered"; exit 1; }
+[ -f "$T2/state/stand-identity.json" ] || { echo "FAIL case 2: state/ file disappeared on no-op"; exit 1; }
+[[ -z "$out2" ]] || { echo "FAIL case 2: heal fired on no-op path"; exit 1; }
+rm -rf "$T2"
+
+# Case 3: neither side has the file → no-op
+T3=$(mktemp -d)
+mkdir -p "$T3/state"
+out3=$(run_heal "$T3")
+[ ! -e "$T3/stand-identity.json" ] || { echo "FAIL case 3: file appeared from nowhere"; exit 1; }
+[[ -z "$out3" ]] || { echo "FAIL case 3: heal fired on no-op path"; exit 1; }
+rm -rf "$T3"
+
+# Case 4: idempotent — run heal twice on case-1 fixture
+T4=$(mktemp -d)
+mkdir -p "$T4/state"
+echo '{"name":"Maddy"}' > "$T4/state/stand-identity.json"
+run_heal "$T4" >/dev/null
+out4=$(run_heal "$T4")
+[[ -z "$out4" ]] || { echo "FAIL case 4: second invocation fired (not idempotent)"; exit 1; }
+[ -f "$T4/stand-identity.json" ] || { echo "FAIL case 4: file vanished on second run"; exit 1; }
+rm -rf "$T4"
+
+echo "OK — all 4 self-heal cases pass"


### PR DESCRIPTION
## Problem
`stand-identity.json` is a **personalPath** (per-machine) file: its reader `personal_path()` / `personalPath()` resolves `$SUTANDO_MEMORY_DIR/machine-<host>/<file>`, then falls back to `<workspace>/<file>` (root). It **never** looks in `state/`.

`scripts/sutando-migrate.sh` classified it `rehome-state`, which homes it under `<workspace>/state/`. So after migration the file sat at a path the reader can't see → voice / discord-voice couldn't load the Stand name and fell back to the generic **"Sutando"**.

## Fix (migration-side only)
Reclassify `stand-identity.json` from `rehome-state` (→ `state/`) to `newest-mtime` (→ `<workspace>/stand-identity.json`, root), matching the sibling personal-override root file `PERSONAL_CLAUDE.md`. The file now lands at the path `personalPath` reads.

This fixes the root cause where it lives. The reader contract is correct as-is and is left untouched (an earlier revision of this PR also added a `state/` fallback to `personalPath`; that was dropped — fix the bug at its source, don't make the reader compensate).

## Already-migrated hosts
Hosts that already ran the old migration have the file at `state/`; a one-time `mv <workspace>/state/stand-identity.json <workspace>/stand-identity.json` un-strands them (done manually on the affected host).
