### PR TITLE
fix(startup): self-heal stand-identity.json mis-placed at state/ by pre-#1540 migrate

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -434,6 +434,20 @@ fi
 mkdir -p "$WORKSPACE/logs" "$WORKSPACE/tasks" "$WORKSPACE/results" "$WORKSPACE/data" "$WORKSPACE/state"
 LOGS_DIR="$WORKSPACE/logs"
 
+# Self-heal: stand-identity.json was misclassified `rehome-state` by pre-#1540
+# `sutando-migrate.sh`, which put it at `<workspace>/state/stand-identity.json`.
+# Its reader (`personal_path()` / `personalPath()`) resolves
+# `$SUTANDO_MEMORY_DIR/machine-<host>/<file>` → `<workspace>/<file>` ROOT —
+# never `state/`. Affected hosts lost their Stand name (fell back to "Sutando")
+# silently. #1540 fixed the migration tool; this one-shot mv un-strands hosts
+# that already ran the old migration. Idempotent + safe: only fires when state/
+# has the file AND root does not, so subsequent boots and unaffected hosts
+# (never ran old migrate, or have a configured Stand name at root) are no-op.
+if [ -f "$WORKSPACE/state/stand-identity.json" ] && [ ! -e "$WORKSPACE/stand-identity.json" ]; then
+  mv "$WORKSPACE/state/stand-identity.json" "$WORKSPACE/stand-identity.json"
+  echo "[startup] self-heal: moved stand-identity.json from state/ → workspace root (pre-#1540 migrate followup)" >&2
+fi
+
 # Offer to set up the `claude-sutando` shell alias once per host. The helper
 # resolves CLAUDE_CONFIG_DIR via `bash scripts/sutando-config.sh claude-sutando-config-dir`
 # (driven by `claude_sutando_config_dir.subdir` in sutando.config.json; default

--- a/tests/startup-stand-identity-self-heal.test.sh
+++ b/tests/startup-stand-identity-self-heal.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Verifies src/startup.sh self-heal for pre-#1540 stand-identity.json misplacement.
+#
+# The self-heal block (added in PR #1542) moves
+# <workspace>/state/stand-identity.json → <workspace>/stand-identity.json when
+# state/ has the file AND root does not. Idempotent on subsequent runs and
+# no-op when both/neither side has the file.
+#
+# Why a test: the self-heal is irreversible (mv, not cp) on the FIRST host
+# that runs the patched startup. A typo in the guard condition that turned
+# `! -e` into `-e` would clobber a freshly-configured stand-identity at root
+# with the legacy state/ file. The guard order matters; pin it.
+set -euo pipefail
+
+# Extract the self-heal block from startup.sh (no full startup.sh execution —
+# that boots the whole stack). Match by the unique marker phrase in the comment.
+HEAL_BLOCK='if [ -f "$WORKSPACE/state/stand-identity.json" ] && [ ! -e "$WORKSPACE/stand-identity.json" ]; then
+  mv "$WORKSPACE/state/stand-identity.json" "$WORKSPACE/stand-identity.json"
+  echo "[startup] self-heal: moved stand-identity.json from state/ → workspace root (pre-#1540 migrate followup)" >&2
+fi'
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Assertion: the block exists at the expected place in src/startup.sh — if it
+# moved or got rewritten, the rest of this test is stale and the maintainer
+# should re-author the extraction.
+grep -q 'self-heal: moved stand-identity.json' "$REPO/src/startup.sh" \
+  || { echo "FAIL: self-heal block not found in src/startup.sh — test is stale"; exit 1; }
+
+run_heal() {
+  local _ws="$1"
+  WORKSPACE="$_ws" bash -c "$HEAL_BLOCK" 2>&1
+}
+
+# Case 1: legacy state/ has the file, root does NOT → mv fires
+T1=$(mktemp -d)
+mkdir -p "$T1/state"
+echo '{"name":"Maddy"}' > "$T1/state/stand-identity.json"
+out1=$(run_heal "$T1")
+[ -f "$T1/stand-identity.json" ] || { echo "FAIL case 1: file not at root after heal"; exit 1; }
+[ ! -e "$T1/state/stand-identity.json" ] || { echo "FAIL case 1: file still at state/ after heal"; exit 1; }
+[[ "$out1" == *"self-heal: moved"* ]] || { echo "FAIL case 1: missing heal log"; exit 1; }
+rm -rf "$T1"
+
+# Case 2: root already has the file (configured fresh post-#1540) → no-op
+T2=$(mktemp -d)
+mkdir -p "$T2/state"
+echo '{"name":"Fresh"}' > "$T2/stand-identity.json"
+echo '{"name":"Legacy"}' > "$T2/state/stand-identity.json"
+out2=$(run_heal "$T2")
+fresh_contents=$(cat "$T2/stand-identity.json")
+[ "$fresh_contents" = '{"name":"Fresh"}' ] || { echo "FAIL case 2: root file was clobbered"; exit 1; }
+[ -f "$T2/state/stand-identity.json" ] || { echo "FAIL case 2: state/ file disappeared on no-op"; exit 1; }
+[[ -z "$out2" ]] || { echo "FAIL case 2: heal fired on no-op path"; exit 1; }
+rm -rf "$T2"
+
+# Case 3: neither side has the file → no-op
+T3=$(mktemp -d)
+mkdir -p "$T3/state"
+out3=$(run_heal "$T3")
+[ ! -e "$T3/stand-identity.json" ] || { echo "FAIL case 3: file appeared from nowhere"; exit 1; }
+[[ -z "$out3" ]] || { echo "FAIL case 3: heal fired on no-op path"; exit 1; }
+rm -rf "$T3"
+
+# Case 4: idempotent — run heal twice on case-1 fixture
+T4=$(mktemp -d)
+mkdir -p "$T4/state"
+echo '{"name":"Maddy"}' > "$T4/state/stand-identity.json"
+run_heal "$T4" >/dev/null
+out4=$(run_heal "$T4")
+[[ -z "$out4" ]] || { echo "FAIL case 4: second invocation fired (not idempotent)"; exit 1; }
+[ -f "$T4/stand-identity.json" ] || { echo "FAIL case 4: file vanished on second run"; exit 1; }
+rm -rf "$T4"
+
+echo "OK — all 4 self-heal cases pass"


### PR DESCRIPTION
**Targets `staging-workspace-revamp`** — followup to #1540.

## Milestone summary

| | Status | Notes |
|---|---|---|
| M0 | ✅ shipped (#1395 + #1397) | In-repo `workspace/` default + helper SSOT |
| M1 | ✅ shipped | Workspace migration + reader fallback |
| M2 | ✅ shipped | Channels migration (#1505/#1506/#1507/#1509/#1510/#1511, #1534, #1536, #1538, #1539) |
| **M3** | in flight (#1454) | Staging → main rollup — this PR is one of the last followups |

## Problem

Hosts that ran `scripts/sutando-migrate.sh` BEFORE [#1540](https://github.com/sonichi/sutando/pull/1540) landed have `stand-identity.json` at `<workspace>/state/`, where the reader (`personal_path()` / `personalPath()`) doesn't look. Symptom: voice / discord-voice silently fall back to the literal `"Sutando"` Stand name — no crash, no error log.

#1540 fixes the migration tool going forward (reclassifies `stand-identity.json` from `rehome-state` → `newest-mtime`). But hosts that already migrated stay broken until they manually `mv state/stand-identity.json stand-identity.json`.

## Fix

One-shot heal in `src/startup.sh`, after `WORKSPACE` resolution + `mkdir -p`:

```bash
if [ -f "$WORKSPACE/state/stand-identity.json" ] && [ ! -e "$WORKSPACE/stand-identity.json" ]; then
  mv "$WORKSPACE/state/stand-identity.json" "$WORKSPACE/stand-identity.json"
  echo "[startup] self-heal: moved stand-identity.json from state/ → workspace root (pre-#1540 migrate followup)" >&2
fi
```

Idempotent. Fires on next Sutando startup for affected hosts; no-op for everyone else (state/ side empty after the move).

## Why it lives in `src/startup.sh` (and not the migration tool)

`sutando-migrate.sh` is one-shot per host — already-migrated hosts won't re-run it after #1540 lands. `src/startup.sh` runs every Sutando boot, so the heal eventually fires on every affected host without manual intervention.

## Safety

The guard is `[ -f state/<file> ] && [ ! -e root/<file> ]`. The `! -e` (not exists at root) is load-bearing — a typo turning it into `-e` (exists at root) would clobber a fresh-configured root file with the legacy state/ content. Test case 2 in `tests/startup-stand-identity-self-heal.test.sh` pins exactly this — root file untouched when both sides exist.

## Verify

```bash
bash tests/startup-stand-identity-self-heal.test.sh
# OK — all 4 self-heal cases pass
```

4 cases covered:
- (1) state/ has file, root empty → heal fires, file at root, log line emitted
- (2) **root already has file, state/ also has file** → no-op, root file NOT clobbered
- (3) Neither side has file → no-op
- (4) Idempotent — second invocation after heal fired is no-op

## Risk

Adds a single guarded `mv` + echo to `src/startup.sh`. Worst-case if the heal misfires somehow: a host's `stand-identity.json` ends up at root, where the reader explicitly looks — same outcome as #1540 itself.

## Follow-ups (out-of-scope)

Mentioned in my #1540 review + DM to owner:
- Reader-contract test for the broader CLASS_RULES table (so future misclassifications fail at PR-review time, not after silent prod drift).
- Health-check probe: `personal_path('stand-identity.json').exists()` — fail loud rather than silent fallback to "Sutando".
- Symmetric Python/TS migration-side static check.

These prevent the class of bug. Separate small followups after #1454 lands.
