### PR TITLE
fix(sync-workspace): git rm a TRACKED in-tree .gitignore so the inner/outer leak can't recur

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -414,9 +414,23 @@ generate_exclude() {
 
     # Migration: an in-tree .gitignore is the leak source — drop it. The
     # rules now live in .git/info/exclude (per-clone, opaque to outer).
+    #
+    # If it is TRACKED — an older host committed it to the vault, and its own
+    # `!.gitignore` rule self-tracks it — a plain `rm -f` deletes only the
+    # local copy: the file is re-materialized on the next peer pull/merge, so
+    # the inner/outer leak (workspace content showing in the OUTER repo's
+    # status; see the boundary note above) recurs forever. `git rm` instead, so
+    # the untrack is committed and propagates through the vault history — the
+    # file then disappears from every device on its next pull. Fall back to
+    # `rm -f` when untracked (fresh local cruft, or pre-first-commit --init).
     if [ -f "$legacy_gitignore" ] && [ "$DRY_RUN" != "1" ]; then
-        rm -f "$legacy_gitignore"
-        log "generate_exclude: removed legacy in-tree $legacy_gitignore (rules moved to .git/info/exclude)"
+        if git -C "$WORKSPACE_DIR" ls-files --error-unmatch .gitignore >/dev/null 2>&1; then
+            git -C "$WORKSPACE_DIR" rm -q -f .gitignore
+            log "generate_exclude: git-rm'd TRACKED in-tree $legacy_gitignore (untrack propagates via vault; rules live in .git/info/exclude)"
+        else
+            rm -f "$legacy_gitignore"
+            log "generate_exclude: removed untracked in-tree $legacy_gitignore (rules moved to .git/info/exclude)"
+        fi
     fi
 
     if [ ! -d "$WORKSPACE_DIR/.git/info" ]; then

--- a/tests/sync-workspace-gitignore-untrack.test.sh
+++ b/tests/sync-workspace-gitignore-untrack.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Test that generate_exclude UNTRACKS a tracked in-tree `workspace/.gitignore`
+# (via `git rm`) rather than only `rm -f`-ing it.
+#
+# Why: the whitelist `.gitignore` carries `!notes/` un-ignore rules. When the
+# workspace lives inside another git repo (e.g. a submodule), the outer repo's
+# `workspace/*` deny is overridden by those deeper-dir un-ignores, leaking
+# workspace content into the OUTER repo's `git status` (data-leak reproduced
+# 2026-06-04 — see the boundary note in generate_exclude). The fix moved rules
+# to `.git/info/exclude` and deletes the in-tree `.gitignore`. But an older
+# host committed `workspace/.gitignore` to the vault (its `!.gitignore` rule
+# self-tracks it), so a plain `rm -f` only deletes the local copy — the file
+# returns on the next peer pull and the leak recurs. `git rm` makes the
+# untrack a committed change that propagates through the vault.
+
+set -u
+# NOTE: deliberately not `set -e` — accumulate failures via `fail=1`.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+SYNC="$REPO/scripts/sync-workspace.sh"
+
+fail=0
+
+# ── Structural ──────────────────────────────────────────────────────────────
+EXCL_BLOCK="$(awk '/^generate_exclude\(\) \{/,/^}$/' "$SYNC")"
+
+# Test 1: gates the tracked-vs-untracked decision on ls-files --error-unmatch.
+echo "$EXCL_BLOCK" | grep -q 'ls-files --error-unmatch .gitignore' \
+    || { echo "  FAIL: T1 — generate_exclude does not probe tracked state via 'ls-files --error-unmatch .gitignore'"; fail=1; }
+
+# Test 2: untracks via `git rm` (not only rm -f) for the tracked case.
+echo "$EXCL_BLOCK" | grep -Eq 'git -C "\$WORKSPACE_DIR" rm .* \.gitignore' \
+    || { echo "  FAIL: T2 — generate_exclude does not 'git rm' the tracked in-tree .gitignore"; fail=1; }
+
+# Test 3: still has the rm -f fallback for the untracked case.
+echo "$EXCL_BLOCK" | grep -q 'rm -f "\$legacy_gitignore"' \
+    || { echo "  FAIL: T3 — generate_exclude lost the rm -f fallback for the untracked case"; fail=1; }
+
+# Test 4: the whole block is still skipped under --dry-run (no mutation).
+echo "$EXCL_BLOCK" | grep -q 'DRY_RUN" != "1" \] *; then\|DRY_RUN" != "1" \]' \
+    || { echo "  FAIL: T4 — the .gitignore-removal block is no longer dry-run guarded"; fail=1; }
+
+# ── E2E: mirror the deletion logic and prove tracked → staged deletion ───────
+# (Sourcing the script triggers the dispatcher + global lock; like the sibling
+# tests, we mirror the decision and exercise it on real git repos.)
+_drop_legacy_gitignore() {  # arg: workspace dir
+    local WORKSPACE_DIR="$1"
+    local legacy_gitignore="$WORKSPACE_DIR/.gitignore"
+    [ -f "$legacy_gitignore" ] || return 0
+    if git -C "$WORKSPACE_DIR" ls-files --error-unmatch .gitignore >/dev/null 2>&1; then
+        git -C "$WORKSPACE_DIR" rm -q -f .gitignore
+    else
+        rm -f "$legacy_gitignore"
+    fi
+}
+
+TMP="$(mktemp -d -t sutando-sync-gi-untrack.XXXXXX)"
+
+# Case A: TRACKED .gitignore → must be staged-deleted (git rm), not just gone.
+mkdir -p "$TMP/tracked"
+git -C "$TMP/tracked" init -q
+printf '*\n!.gitignore\n!notes/\n' > "$TMP/tracked/.gitignore"
+git -C "$TMP/tracked" add .gitignore
+git -C "$TMP/tracked" -c user.email=t@t -c user.name=t commit -q -m base
+_drop_legacy_gitignore "$TMP/tracked"
+# Disk: gone.
+[ -e "$TMP/tracked/.gitignore" ] && { echo "  FAIL: T5 — tracked .gitignore still on disk after drop"; fail=1; }
+# Index: staged as a deletion (so a commit propagates the untrack to the vault).
+if ! git -C "$TMP/tracked" diff --cached --name-status | grep -q '^D[[:space:]]\+.gitignore$'; then
+    echo "  FAIL: T6 — tracked .gitignore was not staged as a deletion (a plain rm -f would leave it tracked in HEAD)"; fail=1
+fi
+# And it is no longer tracked.
+git -C "$TMP/tracked" ls-files --error-unmatch .gitignore >/dev/null 2>&1 \
+    && { echo "  FAIL: T7 — .gitignore still tracked after drop"; fail=1; }
+
+# Case B: UNTRACKED .gitignore → plain rm -f, nothing staged.
+mkdir -p "$TMP/untracked"
+git -C "$TMP/untracked" init -q
+printf '*\n!notes/\n' > "$TMP/untracked/.gitignore"   # present but never added
+_drop_legacy_gitignore "$TMP/untracked"
+[ -e "$TMP/untracked/.gitignore" ] && { echo "  FAIL: T8 — untracked .gitignore still on disk after drop"; fail=1; }
+if [ -n "$(git -C "$TMP/untracked" diff --cached --name-only)" ]; then
+    echo "  FAIL: T9 — untracked case staged something (should be a plain rm -f)"; fail=1
+fi
+
+rm -rf "$TMP"
+
+# ── Report ──────────────────────────────────────────────────────────────────
+if [ "$fail" = "0" ]; then
+    echo "ALL TESTS PASS"
+else
+    echo "TESTS FAILED"
+    exit 1
+fi


### PR DESCRIPTION
## Problem

`generate_exclude` removes the legacy in-tree `workspace/.gitignore` — whose whitelist `!notes/` un-ignore rules **leak workspace content into an OUTER repo's `git status`** when the workspace is nested inside another git repo (a submodule). That leak, and the move of the rules to `.git/info/exclude` (opaque to the outer repo), are documented in the boundary note right above the function (data-leak reproduced 2026-06-04).

But the removal used `rm -f`, which only deletes the **local** copy. The file's own `!.gitignore` rule **self-tracks** it, and an older host committed `workspace/.gitignore` to the vault. So a local `rm -f` is undone on the **next peer pull/merge** — the file returns and the leak recurs on every device, forever. (`rm -f` even leaves it tracked in `HEAD`, so nothing propagates the removal.)

## Fix

When the in-tree `.gitignore` is **tracked**, `git rm` it instead of `rm -f`, so the untrack is a committed change that propagates through the vault history — the file then disappears from every device on its next pull. Keep `rm -f` for the **untracked** case (fresh local cruft, or pre-first-commit during `--init`).

```diff
-        rm -f "$legacy_gitignore"
+        if git -C "$WORKSPACE_DIR" ls-files --error-unmatch .gitignore >/dev/null 2>&1; then
+            git -C "$WORKSPACE_DIR" rm -q -f .gitignore
+        else
+            rm -f "$legacy_gitignore"
+        fi
```

## Observed

On a Mac mini whose sutando checkout is a git **submodule**, the vault-tracked `workspace/.gitignore` (from a laptop's bootstrap commit) re-exposed `workspace/notes/`, `workspace/.claude-sutando/` etc. as untracked in the **outer** submodule's `git status`, despite the outer `workspace/*` deny — risking an accidental commit of private workspace content into the code repo.

## Tests

`tests/sync-workspace-gitignore-untrack.test.sh` — 4 structural + 5 E2E: tracked `.gitignore` → staged **deletion** (so a commit propagates the untrack) and no longer tracked; untracked `.gitignore` → plain `rm -f`, nothing staged. `bash -n` clean; existing `sync-workspace-uninit-guard.test.sh` still passes.

## Related

Distinct from #1546 (which isolates `--init` so it can't hijack a parent repo). Both are facets of running the in-place workspace-vault scheme inside a parent git repo / submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
