### PR TITLE
feat(sync-workspace): install-workspace-sync.sh — launchd on macOS, cron on Linux (fixes the FDA crontab wall)

### DIFF
--- a/docs/workspace-sync.md
+++ b/docs/workspace-sync.md
@@ -34,10 +34,28 @@ If you only run Sutando on one machine, you don't need this.
    ```
    First run sets the workspace tree up as a git working copy, points at the configured remote, and pushes whatever's locally on disk as the initial commit on the per-host branch.
 
-4. **Add a cron entry** to run every 10–30 minutes:
-   ```cron
-   */15 * * * * cd /path/to/sutando && bash scripts/sync-workspace.sh
+4. **Schedule the recurring sync.** Use the installer — it picks the right
+   scheduler per OS (a per-user **LaunchAgent** on macOS, a **crontab** line on
+   Linux) and defaults to every 15 min:
+   ```bash
+   bash scripts/install-workspace-sync.sh                 # install (idempotent)
+   bash scripts/install-workspace-sync.sh --interval 600  # custom seconds
+   bash scripts/install-workspace-sync.sh --status        # check it's loaded
+   bash scripts/install-workspace-sync.sh --uninstall
    ```
+
+   > **macOS: prefer launchd, not a hand-written crontab.** The cron spool
+   > (`/var/at/tabs`) is TCC-protected — editing a crontab requires the
+   > controlling **terminal app** to have **Full Disk Access**, or `crontab`
+   > fails with `Operation not permitted` (the spool is root-owned and gated on
+   > the *responsible app*, not euid, so even setuid-root `crontab` is blocked).
+   > The installer's LaunchAgent needs no FDA, and — running in the `gui/<uid>`
+   > domain — also unlocks the login Keychain, sidestepping the `-25308` error
+   > (see Troubleshooting). To wire it by hand instead, a plain cron line works
+   > on Linux (and on macOS *if* your terminal has FDA):
+   > ```cron
+   > */15 * * * * cd /path/to/sutando && bash scripts/sync-workspace.sh
+   > ```
 
 Repeat the same steps on every machine in the fleet. All clone the same `vault.remote_url`. Each machine pushes to its own branch named `host/<hostname>/<wsId>` (per [#1459](https://github.com/sonichi/sutando/pull/1459)); the merge across branches happens on next pull.
 
@@ -166,7 +184,7 @@ The three migration symptoms below were observed pre-v0.3.0 and all shipped fixe
 - **Push fails with macOS Keychain error `-25308` over SSH or plain cron** — `gh auth` stores the GitHub token in macOS Keychain, which is bound to a GUI session by default. Plain SSH sessions / system-level crontabs can't unlock it. Three fixes (pick one):
   1. **SSH remote URL** *(recommended for headless/SSH)*: configure the vault with `git@github.com:user/vault.git` instead of HTTPS — SSH uses key-based auth, no Keychain involved. Switch with `git -C "$(bash scripts/sutando-config.sh workspace)" remote set-url origin git@github.com:user/vault.git`.
   2. **`GH_TOKEN` in `.env`**: add `GH_TOKEN=<personal-access-token>` to `<workspace>/.env` (resolve `<workspace>` via `bash scripts/sutando-config.sh workspace`). git and `gh` respect this env var without touching Keychain. *Note:* the M2 sync engine carries the workspace tree cross-host, so a `GH_TOKEN` in `<workspace>/.env` propagates to every fleet machine; that's typically desired for headless sync hosts, but worth being aware of for multi-host operators.
-  3. **launchd plist** *(existing workaround)*: run sync from a launchd plist scoped to your user GUI session (not system-level crontab), or unlock the keychain explicitly in the cron wrapper (`security unlock-keychain` — requires interactive password setup, not recommended for automation).
+  3. **launchd plist** *(recommended on macOS)*: run sync from a launchd plist scoped to your user GUI session (not system-level crontab) — `bash scripts/install-workspace-sync.sh` does exactly this for you. The `gui/<uid>` domain unlocks the login Keychain, and it also avoids the separate Full-Disk-Access wall that blocks `crontab` edits (see step 4 of Setup). Hand-rolled alternative: unlock the keychain in a cron wrapper (`security unlock-keychain` — requires interactive password setup, not recommended for automation).
 - **Merge conflicts on every tick** — Two hosts editing the same file in tight loops. Use append-only patterns or coordinate edits.
 
 ## Related

--- a/scripts/install-workspace-sync.sh
+++ b/scripts/install-workspace-sync.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Install / uninstall a recurring workspace-vault sync job — the right scheduler
+# for each OS, so you don't have to know the platform gotchas.
+#
+#   macOS → a per-user LaunchAgent in ~/Library/LaunchAgents/.
+#   Linux → an idempotent crontab line.
+#
+# Why not just tell macOS users to add a crontab line?
+#   1. FDA: the cron spool (/var/at/tabs) is TCC-protected. Editing a crontab
+#      needs the *controlling terminal app* to have Full Disk Access, or
+#      `crontab` fails with "Operation not permitted" (even though `crontab` is
+#      setuid root — TCC gates on the responsible app, not euid). The failure
+#      is silent-ish: the sync simply never gets scheduled.
+#   2. Keychain: a LaunchAgent in the `gui/<uid>` domain runs inside the user's
+#      GUI session, so it can unlock the login Keychain that `gh`-stored tokens
+#      live in — sidestepping the `-25308` error plain cron/SSH hits.
+#   launchd needs neither. It's also Apple's supported mechanism; cron is legacy.
+#
+# The job runs `sync-workspace.sh --default` (bidirectional pull+push) on an
+# interval. Run `--init` once first (see docs/workspace-sync.md) — this only
+# schedules the recurring tick.
+#
+# Usage:
+#   bash scripts/install-workspace-sync.sh                  # install (idempotent)
+#   bash scripts/install-workspace-sync.sh --interval 900   # seconds (default 900 = 15min)
+#   bash scripts/install-workspace-sync.sh --uninstall
+#   bash scripts/install-workspace-sync.sh --status
+#
+# Idempotent: re-running install replaces the existing job (macOS bootout +
+# bootstrap; Linux rewrites the marked crontab line), so a `git pull` that
+# changes this script is picked up by re-running it.
+
+set -euo pipefail
+
+LABEL="com.sutando.workspace-sync"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+SYNC="$REPO/scripts/sync-workspace.sh"
+INTERVAL=900   # seconds (15 min). Override with --interval.
+CMD="install"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --uninstall) CMD="uninstall" ;;
+        --status)    CMD="status" ;;
+        --install)   CMD="install" ;;
+        --interval)  INTERVAL="${2:?--interval needs a value}"; shift ;;
+        --interval=*) INTERVAL="${1#--interval=}" ;;
+        *) echo "install-workspace-sync: unknown arg '$1'. Try --uninstall / --status / --interval N." >&2; exit 2 ;;
+    esac
+    shift
+done
+
+case "$INTERVAL" in
+    ''|*[!0-9]*) echo "install-workspace-sync: --interval must be a positive integer (seconds)." >&2; exit 2 ;;
+esac
+[ "$INTERVAL" -ge 60 ] || { echo "install-workspace-sync: --interval must be >= 60 seconds." >&2; exit 2; }
+
+[ -f "$SYNC" ] || { echo "install-workspace-sync: $SYNC not found — run from a sutando checkout." >&2; exit 1; }
+
+# Log under the resolved workspace, not the repo (workspace-vs-repo split).
+if [ -f "$REPO/scripts/sutando-config.sh" ]; then
+    WORKSPACE="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null || true)"
+fi
+[ -n "${WORKSPACE:-}" ] || WORKSPACE="$REPO/workspace"
+LOG="$WORKSPACE/logs/workspace-sync.log"
+
+OS="$(uname -s)"
+
+# --------------------------------------------------------------------------- #
+# macOS — LaunchAgent                                                          #
+# --------------------------------------------------------------------------- #
+macos_plist_path() { echo "$HOME/Library/LaunchAgents/$LABEL.plist"; }
+macos_service()    { echo "gui/$(id -u)/$LABEL"; }
+
+macos_install() {
+    local dest; dest="$(macos_plist_path)"
+    mkdir -p "$HOME/Library/LaunchAgents" "$(dirname "$LOG")"
+    cat > "$dest" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>$SYNC</string>
+        <string>--default</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>$INTERVAL</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>WorkingDirectory</key>
+    <string>$REPO</string>
+    <key>StandardOutPath</key>
+    <string>$LOG</string>
+    <key>StandardErrorPath</key>
+    <string>$LOG</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>GIT_SSH_COMMAND</key>
+        <string>ssh -o BatchMode=yes</string>
+    </dict>
+</dict>
+</plist>
+PLIST
+    # bootout first so a changed plist is picked up (idempotent).
+    launchctl bootout "$(macos_service)" 2>/dev/null || true
+    launchctl bootstrap "gui/$(id -u)" "$dest"
+    echo "install-workspace-sync: installed LaunchAgent $LABEL (every ${INTERVAL}s)."
+    echo "  plist: $dest"
+    echo "  log:   $LOG"
+    echo "  No Full Disk Access required. Manage it in System Settings → General →"
+    echo "  Login Items → Allow in the Background."
+}
+
+macos_uninstall() {
+    launchctl bootout "$(macos_service)" 2>/dev/null || true
+    rm -f "$(macos_plist_path)"
+    echo "install-workspace-sync: removed LaunchAgent $LABEL."
+}
+
+macos_status() {
+    if launchctl print "$(macos_service)" >/dev/null 2>&1; then
+        echo "install-workspace-sync: $LABEL is LOADED."
+        launchctl print "$(macos_service)" 2>/dev/null | grep -E 'state|run interval|path' | sed 's/^/  /'
+    else
+        echo "install-workspace-sync: $LABEL is NOT loaded."
+    fi
+}
+
+# --------------------------------------------------------------------------- #
+# Linux / other — crontab                                                      #
+# --------------------------------------------------------------------------- #
+# Marker comment lets us find + replace our own line without disturbing others.
+CRON_MARKER="# $LABEL (managed by install-workspace-sync.sh)"
+
+cron_line() {
+    local mins=$(( INTERVAL / 60 ))
+    [ "$mins" -ge 1 ] || mins=1
+    if [ "$mins" -gt 59 ]; then
+        echo "install-workspace-sync: interval > 59min not expressible as */N on cron; capping at hourly." >&2
+        echo "0 * * * * cd $REPO && bash $SYNC --default >> $LOG 2>&1"
+    else
+        echo "*/$mins * * * * cd $REPO && bash $SYNC --default >> $LOG 2>&1"
+    fi
+}
+
+cron_current_without_ours() {
+    # Print existing crontab minus our marker + the line after it.
+    crontab -l 2>/dev/null | awk -v m="$CRON_MARKER" '
+        $0 == m { skip = 2 }
+        skip > 0 { skip--; next }
+        { print }'
+}
+
+cron_install() {
+    mkdir -p "$(dirname "$LOG")"
+    { cron_current_without_ours; echo "$CRON_MARKER"; cron_line; } | crontab -
+    echo "install-workspace-sync: installed crontab line (every $(( INTERVAL / 60 ))min)."
+    echo "  log: $LOG"
+}
+
+cron_uninstall() {
+    cron_current_without_ours | crontab -
+    echo "install-workspace-sync: removed crontab line."
+}
+
+cron_status() {
+    if crontab -l 2>/dev/null | grep -qF "$CRON_MARKER"; then
+        echo "install-workspace-sync: crontab line PRESENT:"
+        crontab -l 2>/dev/null | grep -A1 -F "$CRON_MARKER" | sed 's/^/  /'
+    else
+        echo "install-workspace-sync: no managed crontab line found."
+    fi
+}
+
+# --------------------------------------------------------------------------- #
+# Dispatch                                                                     #
+# --------------------------------------------------------------------------- #
+if [ "$OS" = "Darwin" ]; then
+    case "$CMD" in
+        install)   macos_install ;;
+        uninstall) macos_uninstall ;;
+        status)    macos_status ;;
+    esac
+else
+    case "$CMD" in
+        install)   cron_install ;;
+        uninstall) cron_uninstall ;;
+        status)    cron_status ;;
+    esac
+fi

--- a/tests/install-workspace-sync.test.sh
+++ b/tests/install-workspace-sync.test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Tests for scripts/install-workspace-sync.sh — the cross-platform installer
+# that schedules the workspace-vault sync (macOS → LaunchAgent, Linux → cron).
+#
+# launchctl/crontab E2E would mutate the real system, so (like the sibling
+# sync-workspace tests) we assert wiring structurally and mirror the pure
+# interval→schedule logic.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALLER="$REPO/scripts/install-workspace-sync.sh"
+
+fail=0
+
+# ── Structural ──────────────────────────────────────────────────────────────
+
+# Test 1: installer exists and is executable.
+[ -x "$INSTALLER" ] || { echo "  FAIL: T1 — $INSTALLER missing or not executable"; fail=1; }
+
+# Test 2: branches on OS (Darwin vs other).
+grep -q 'uname -s' "$INSTALLER" \
+    || { echo "  FAIL: T2 — does not detect OS via 'uname -s'"; fail=1; }
+grep -q '"\$OS" = "Darwin"' "$INSTALLER" \
+    || { echo "  FAIL: T2b — no Darwin branch"; fail=1; }
+
+# Test 3: macOS path uses launchd (bootstrap), NOT crontab.
+MACOS_FN="$(awk '/^macos_install\(\) \{/,/^}$/' "$INSTALLER")"
+echo "$MACOS_FN" | grep -q 'launchctl bootstrap' \
+    || { echo "  FAIL: T3 — macos_install does not 'launchctl bootstrap'"; fail=1; }
+echo "$MACOS_FN" | grep -q 'crontab' \
+    && { echo "  FAIL: T3b — macos_install touches crontab (must avoid the FDA-gated spool)"; fail=1; }
+
+# Test 4: Linux path installs a crontab line.
+grep -q '^cron_install()' "$INSTALLER" \
+    || { echo "  FAIL: T4 — no cron_install for the Linux path"; fail=1; }
+grep -q 'crontab -' "$INSTALLER" \
+    || { echo "  FAIL: T4b — Linux path does not write via 'crontab -'"; fail=1; }
+
+# Test 5: uninstall + status for both platforms.
+for fn in macos_uninstall macos_status cron_uninstall cron_status; do
+    grep -q "^$fn()" "$INSTALLER" || { echo "  FAIL: T5 — missing $fn"; fail=1; }
+done
+
+# Test 6: runs sync-workspace.sh in --default (bidirectional) mode.
+grep -q '\-\-default' "$INSTALLER" \
+    || { echo "  FAIL: T6 — job does not run sync-workspace.sh --default"; fail=1; }
+
+# Test 7: sets GIT_SSH_COMMAND BatchMode (non-interactive SSH for headless sync).
+grep -q 'GIT_SSH_COMMAND' "$INSTALLER" \
+    || { echo "  FAIL: T7 — does not set GIT_SSH_COMMAND for non-interactive SSH"; fail=1; }
+
+# Test 8: documents WHY launchd over cron (the FDA gotcha) so future readers
+# don't "simplify" it back to crontab on macOS.
+grep -qiE 'Full Disk Access|FDA|TCC' "$INSTALLER" \
+    || { echo "  FAIL: T8 — missing the FDA/TCC rationale comment"; fail=1; }
+
+# Test 9: syntax.
+bash -n "$INSTALLER" || { echo "  FAIL: T9 — bash -n syntax error"; fail=1; }
+
+# ── Logic: interval → cron schedule (mirror of cron_line) ───────────────────
+_cron_sched() {  # arg: interval seconds → prints the schedule field
+    local INTERVAL="$1" mins=$(( $1 / 60 ))
+    [ "$mins" -ge 1 ] || mins=1
+    if [ "$mins" -gt 59 ]; then echo "0 * * * *"; else echo "*/$mins * * * *"; fi
+}
+[ "$(_cron_sched 900)"  = "*/15 * * * *" ] || { echo "  FAIL: T10 — 900s should map to */15"; fail=1; }
+[ "$(_cron_sched 1020)" = "*/17 * * * *" ] || { echo "  FAIL: T11 — 1020s should map to */17"; fail=1; }
+[ "$(_cron_sched 3600)" = "0 * * * *" ]     || { echo "  FAIL: T12 — 3600s should cap to hourly"; fail=1; }
+
+# ── Report ──────────────────────────────────────────────────────────────────
+if [ "$fail" = "0" ]; then
+    echo "ALL TESTS PASS"
+else
+    echo "TESTS FAILED"
+    exit 1
+fi


### PR DESCRIPTION
## Problem

The Setup guide tells users to schedule the vault sync by hand:

```cron
*/15 * * * * cd /path/to/sutando && bash scripts/sync-workspace.sh
```

On **macOS** that can silently fail. The cron spool (`/var/at/tabs`) is **TCC-protected**: editing a crontab requires the controlling **terminal app** to have **Full Disk Access**, or `crontab` returns `Operation not permitted`. It gates on the *responsible app*, not euid — so even though `crontab` is setuid-root, the write is blocked. The result: the sync never gets scheduled, with no obvious error. (Reading — `crontab -l` — still works, which makes it more confusing.)

This is on top of the already-documented Keychain `-25308` issue, which also bites plain cron.

## Fix

Add **`scripts/install-workspace-sync.sh`** — one command that picks the right scheduler per OS:

- **macOS** → a per-user **LaunchAgent** in `~/Library/LaunchAgents/`. Needs **no Full Disk Access** (it never touches the protected cron spool), and — running in the `gui/<uid>` domain — also unlocks the login Keychain, so it sidesteps `-25308` too.
- **Linux** → an idempotent **crontab** line (marker-comment scoped, so re-install/uninstall only touch our own line).

```bash
bash scripts/install-workspace-sync.sh                 # install (idempotent)
bash scripts/install-workspace-sync.sh --interval 600  # custom seconds (default 900)
bash scripts/install-workspace-sync.sh --status
bash scripts/install-workspace-sync.sh --uninstall
```

The job runs `sync-workspace.sh --default` (bidirectional) with `GIT_SSH_COMMAND='ssh -o BatchMode=yes'` for headless SSH hosts. It mirrors the existing `src/install-*-launchd.sh` pattern (`bootout` + `bootstrap gui/$UID`, idempotent) but is cross-platform and self-contained (inline plist).

`docs/workspace-sync.md` now makes the installer the recommended Setup step and documents the FDA gotcha (and the manual cron line stays as the by-hand alternative).

## Why not extend `schedule-crons`?

`schedule-crons` schedules **harness** crons via `CronCreate` (Claude Code's own scheduler) — unaffected by FDA. This installer is specifically for the **system-level** vault-sync tick, which the repo previously left to a hand-written crontab line.

## Tests

`tests/install-workspace-sync.test.sh` — structural (macOS path uses launchd, **not** crontab; Linux path uses crontab; install/uninstall/status on both; `--default` + `GIT_SSH_COMMAND`; the FDA rationale comment is present so nobody "simplifies" it back to crontab) + interval→schedule logic (900→`*/15`, 1020→`*/17`, 3600→hourly cap) + `bash -n`. `--status` smoke-tested read-only.

## Related

Third of a small series hardening the in-place workspace-vault sync: #1546 (`--init` isolation vs. a parent submodule), #1547 (`git rm` a tracked in-tree `.gitignore`), and this (scheduling that actually works on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
