### PR TITLE
feat(health-check): warn when RAM is critically low (closes #1485)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -773,6 +773,49 @@ def check_task_queue(threshold_count: int = 3, threshold_age_sec: int = 300) -> 
     return {"name": name, "status": "ok", "detail": f"{len(files)} task(s), oldest {oldest_age}s"}
 
 
+def check_system_memory() -> dict:
+    """Warn when RAM is critically low — OOM guard (closes #1485).
+
+    Fires when psutil reports >= SUTANDO_MEMORY_WARN_THRESHOLD_PCT used
+    (default 80).  On macOS, also checks the compressor (compressed-swap)
+    size: a compressor larger than 50% of total RAM indicates severe pressure
+    even when psutil's 'available' (free + inactive) still looks non-zero.
+    """
+    name = "system-memory"
+    try:
+        import psutil
+    except ImportError:
+        return {"name": name, "status": "warn", "detail": "psutil not installed (pip install psutil)"}
+
+    threshold_pct = int(os.environ.get("SUTANDO_MEMORY_WARN_THRESHOLD_PCT", "80"))
+    mem = psutil.virtual_memory()
+    total_gb = mem.total / 1024 ** 3
+    avail_gb = mem.available / 1024 ** 3
+    used_pct = mem.percent
+
+    status = "warn" if used_pct >= threshold_pct else "ok"
+    detail = f"{used_pct:.0f}% used ({avail_gb:.1f}/{total_gb:.0f} GB avail)"
+
+    if sys.platform == "darwin":
+        try:
+            vm_out = subprocess.check_output(["vm_stat"], text=True, timeout=3)
+            comp_pages = 0
+            for line in vm_out.splitlines():
+                if "Pages stored in compressor:" in line:
+                    comp_pages = int(line.split(":")[1].strip().rstrip("."))
+                    break
+            if comp_pages:
+                comp_gb = comp_pages * 16384 / 1024 ** 3
+                detail += f"; compressor {comp_gb:.1f} GB"
+                if comp_gb > total_gb * 0.5:
+                    detail += " (severe pressure)"
+                    status = "warn"
+        except Exception:
+            pass
+
+    return {"name": name, "status": status, "detail": detail}
+
+
 def check_notes_split_brain() -> "dict | None":
     """Detect notes/ split-brain (#1266): overlapping .md files in both
     <repo>/notes/ and <workspace>/notes/ — fires only when the two paths differ."""
@@ -1133,6 +1176,7 @@ def run_all_checks() -> list[dict]:
     queue_count = int(os.environ.get("SUTANDO_HEALTH_QUEUE_COUNT", "3"))
     checks.append(check_core_proactive_loop(threshold_sec=loop_stale_sec))
     checks.append(check_task_queue(threshold_count=queue_count, threshold_age_sec=queue_age_sec))
+    checks.append(check_system_memory())
 
     return checks
 

--- a/tests/health-check-system-memory.test.py
+++ b/tests/health-check-system-memory.test.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Tests for check_system_memory() added to health-check.py (closes #1485).
+
+Covers:
+  a) Normal memory (below threshold) → ok status
+  b) High usage (≥ threshold) → warn status
+  c) macOS compressor > 50% of total RAM → warn with 'severe pressure' in detail
+  d) psutil missing → warn with install hint
+  e) Custom threshold via SUTANDO_MEMORY_WARN_THRESHOLD_PCT env var
+
+Run: python3 tests/health-check-system-memory.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+import unittest.mock as mock
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+_MISSING = object()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_psutil(percent: float, total_gb: float = 16.0, avail_gb: float = 4.0):
+    m = types.ModuleType("psutil")
+
+    class _VM:
+        pass
+
+    vm = _VM()
+    vm.total = int(total_gb * 1024 ** 3)
+    vm.available = int(avail_gb * 1024 ** 3)
+    vm.percent = percent
+    m.virtual_memory = lambda: vm
+    return m
+
+
+_VM_STAT_OK = "\n".join([
+    "Mach Virtual Memory Statistics: (page size of 16384 bytes)",
+    "Pages free:                         200000.",
+    "Pages stored in compressor:          50000.",   # ~0.8 GB  — well below 50% of 16 GB
+])
+
+_VM_STAT_SEVERE = "\n".join([
+    "Mach Virtual Memory Statistics: (page size of 16384 bytes)",
+    "Pages free:                          30000.",
+    "Pages stored in compressor:         600000.",   # ~9.2 GB — >50% of 16 GB
+])
+
+
+def _set_psutil(module_or_none):
+    """Install a psutil mock (or None to trigger ImportError). Returns (old, was_missing)."""
+    old = sys.modules.get("psutil", _MISSING)
+    sys.modules["psutil"] = module_or_none
+    return old
+
+
+def _restore_psutil(old):
+    if old is _MISSING:
+        sys.modules.pop("psutil", None)
+    else:
+        sys.modules["psutil"] = old
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+def case_a_normal_ok():
+    """Below default threshold (80%) → ok."""
+    fails = []
+    old = _set_psutil(_make_psutil(percent=50.0, total_gb=16.0, avail_gb=8.0))
+    try:
+        with mock.patch.object(hc.subprocess, "check_output", return_value=_VM_STAT_OK):
+            r = hc.check_system_memory()
+    finally:
+        _restore_psutil(old)
+    if r["status"] != "ok":
+        fails.append(f"a) 50% used (threshold=80) should be ok, got {r['status']} ({r['detail']})")
+    if "50%" not in r["detail"]:
+        fails.append(f"a) detail should include used%, got: {r['detail']}")
+    return fails
+
+
+def case_b_high_usage_warn():
+    """At or above default threshold (80%) → warn."""
+    fails = []
+    old = _set_psutil(_make_psutil(percent=85.0, total_gb=16.0, avail_gb=2.0))
+    try:
+        with mock.patch.object(hc.subprocess, "check_output", return_value=_VM_STAT_OK):
+            r = hc.check_system_memory()
+    finally:
+        _restore_psutil(old)
+    if r["status"] != "warn":
+        fails.append(f"b) 85% used (threshold=80) should be warn, got {r['status']}")
+    return fails
+
+
+def case_c_compressor_severe():
+    """Compressor > 50% of total RAM → warn with 'severe pressure' detail."""
+    fails = []
+    # Percent below threshold so the only trigger is the compressor size.
+    old = _set_psutil(_make_psutil(percent=70.0, total_gb=16.0, avail_gb=5.0))
+    try:
+        with mock.patch("sys.platform", "darwin"):
+            with mock.patch.object(hc.subprocess, "check_output", return_value=_VM_STAT_SEVERE):
+                r = hc.check_system_memory()
+    finally:
+        _restore_psutil(old)
+    if r["status"] != "warn":
+        fails.append(f"c) severe compressor should be warn, got {r['status']}")
+    if "severe pressure" not in r["detail"]:
+        fails.append(f"c) detail should mention 'severe pressure', got: {r['detail']}")
+    if "compressor" not in r["detail"]:
+        fails.append(f"c) detail should mention compressor size, got: {r['detail']}")
+    return fails
+
+
+def case_d_psutil_missing():
+    """psutil not importable → warn with install hint."""
+    fails = []
+    # Setting sys.modules['psutil'] = None causes `import psutil` to raise ImportError.
+    old = _set_psutil(None)
+    try:
+        r = hc.check_system_memory()
+    finally:
+        _restore_psutil(old)
+    if r["status"] != "warn":
+        fails.append(f"d) psutil missing should be warn, got {r['status']}")
+    if "psutil" not in r["detail"].lower():
+        fails.append(f"d) detail should mention psutil, got: {r['detail']}")
+    return fails
+
+
+def case_e_custom_threshold():
+    """SUTANDO_MEMORY_WARN_THRESHOLD_PCT overrides the default 80."""
+    fails = []
+    old = _set_psutil(_make_psutil(percent=70.0, total_gb=16.0, avail_gb=5.0))
+    saved_env = os.environ.get("SUTANDO_MEMORY_WARN_THRESHOLD_PCT", _MISSING)
+    os.environ["SUTANDO_MEMORY_WARN_THRESHOLD_PCT"] = "60"
+    try:
+        with mock.patch.object(hc.subprocess, "check_output", return_value=_VM_STAT_OK):
+            r = hc.check_system_memory()
+    finally:
+        _restore_psutil(old)
+        if saved_env is _MISSING:
+            os.environ.pop("SUTANDO_MEMORY_WARN_THRESHOLD_PCT", None)
+        else:
+            os.environ["SUTANDO_MEMORY_WARN_THRESHOLD_PCT"] = saved_env
+    if r["status"] != "warn":
+        fails.append(f"e) 70% used at custom threshold=60 should be warn, got {r['status']}")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    cases = [
+        ("a", case_a_normal_ok),
+        ("b", case_b_high_usage_warn),
+        ("c", case_c_compressor_severe),
+        ("d", case_d_psutil_missing),
+        ("e", case_e_custom_threshold),
+    ]
+    all_failures = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            all_failures.extend(fails)
+            print(f"  FAIL case {label}")
+            for f in fails:
+                print(f"    {f}")
+        else:
+            print(f"  PASS case {label}")
+
+    total = len(cases)
+    failed = len(all_failures)
+    print(f"\nResults: {total - failed}/{total} passed")
+    return 1 if all_failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

Sutando proactive tasks can spawn memory-heavy subprocesses. With no awareness of system memory, an OOM condition silently freezes the host — the machine becomes unresponsive and requires a forced power-button restart. Reproduced live on 2026-06-08: Cursor wrote 2.1 GB in 313s (disk write storm), driving the 24 GB machine to ~115 MB free RAM and 20.6 GB in the compressor before the freeze.

Issue: #1485

## Fix

Adds `check_system_memory()` to `src/health-check.py`:

- **Usage % threshold**: fires `warn` when `psutil.virtual_memory().percent >= SUTANDO_MEMORY_WARN_THRESHOLD_PCT` (default 80). Configurable so constrained machines can lower the bar.
- **macOS compressor check**: reads `vm_stat` for "Pages stored in compressor". A compressor > 50% of total RAM means the kernel is under severe memory pressure even when psutil's `available` (free + inactive) looks non-zero — this is the case that caused the 2026-06-08 freeze (78% psutil, but 20.6/24 GB in the compressor). Appends `; compressor N.N GB (severe pressure)` to the detail and upgrades status to `warn`.
- **psutil absence**: degrades gracefully to `warn` with an install hint rather than crashing the health check.

Both `SUTANDO_MEMORY_WARN_THRESHOLD_PCT` and the 50%-compressor constant are the only new tunables; no new env vars needed for baseline behavior.

## Test

```bash
python3 src/health-check.py
# New line: ⚠ system-memory  warn  78% used (5.4/24 GB avail); compressor 20.6 GB (severe pressure)
```

## Why no separate script

The issue hints at a per-task memory watcher; that's follow-up work (#1485 scope). This PR delivers the static health-check gate — cheapest path to surface "the machine is dangerously low on memory" in the existing `health-check.py` output that operators already monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)