### PR TITLE
feat(health-check): probe stand-identity.json at reader paths (#1543 layer 2)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -37,7 +37,7 @@ except ImportError:  # non-POSIX (e.g. Windows) — the lock degrades to a no-op
 
 REPO_DIR = Path(__file__).parent.parent
 sys.path.insert(0, str(Path(__file__).parent))
-from util_paths import shared_personal_path  # noqa: E402
+from util_paths import personal_path, shared_personal_path  # noqa: E402
 from workspace_default import resolve_workspace, status_read_path  # noqa: E402
 
 # Workspace = runtime-state root (tasks/, results/, state/). REPO_DIR stays the
@@ -773,6 +773,30 @@ def check_task_queue(threshold_count: int = 3, threshold_age_sec: int = 300) -> 
     return {"name": name, "status": "ok", "detail": f"{len(files)} task(s), oldest {oldest_age}s"}
 
 
+def check_stand_identity() -> dict:
+    """Warn when stand-identity.json is missing from all reader paths (#1543 layer 2).
+
+    personal_path() checks $SUTANDO_MEMORY_DIR/machine-<host>/ then <workspace>/
+    in that order. If neither exists the Stand name falls back to the literal
+    "Sutando" default — a symptom of the v0.8 migration misclassifying the file
+    (rehome-state → state/) rather than landing it at the workspace root where
+    the reader expects it (fixed in #1540 / #1542).
+    """
+    name = "stand-identity"
+    si = personal_path("stand-identity.json", WORKSPACE_DIR)
+    if si.exists():
+        return {"name": name, "status": "ok", "detail": str(si)}
+    return {
+        "name": name,
+        "status": "warn",
+        "detail": (
+            "stand-identity.json not found at any reader path — Stand name falls back to 'Sutando'. "
+            "If you ran v0.8 migrate before fix #1540, check whether the file landed in "
+            f"{WORKSPACE_DIR}/state/ and move it to {WORKSPACE_DIR}/."
+        ),
+    }
+
+
 def check_notes_split_brain() -> "dict | None":
     """Detect notes/ split-brain (#1266): overlapping .md files in both
     <repo>/notes/ and <workspace>/notes/ — fires only when the two paths differ."""
@@ -1133,6 +1157,7 @@ def run_all_checks() -> list[dict]:
     queue_count = int(os.environ.get("SUTANDO_HEALTH_QUEUE_COUNT", "3"))
     checks.append(check_core_proactive_loop(threshold_sec=loop_stale_sec))
     checks.append(check_task_queue(threshold_count=queue_count, threshold_age_sec=queue_age_sec))
+    checks.append(check_stand_identity())
 
     return checks
 

--- a/tests/health-check-stand-identity.test.py
+++ b/tests/health-check-stand-identity.test.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Tests for check_stand_identity() added to health-check.py (#1543 layer 2).
+
+personal_path() searches:
+  1. $SUTANDO_MEMORY_DIR/machine-<host>/stand-identity.json
+  2. <workspace>/stand-identity.json  (fallback)
+
+If neither exists the Stand name silently falls back to "Sutando" — this check
+surfaces that so the operator knows to run the v0.8 migration fix (#1540/#1542).
+
+Covers:
+  a) File not found at any reader path → warn with migration hint
+  b) File found under SUTANDO_MEMORY_DIR/machine-<host>/ → ok
+  c) File found under workspace fallback → ok
+
+Run: python3 tests/health-check-stand-identity.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest.mock as mock
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+def case_a_file_missing_warn():
+    """stand-identity.json not found at any reader path → warn with migration hint."""
+    fails = []
+    # personal_path() returns a path that does not exist.
+    with mock.patch.object(hc, "personal_path", return_value=Path("/nonexistent/path/stand-identity.json")):
+        r = hc.check_stand_identity()
+    if r["status"] != "warn":
+        fails.append(f"a) missing stand-identity.json should be warn, got {r['status']}")
+    if "stand-identity.json" not in r["detail"]:
+        fails.append(f"a) detail should mention stand-identity.json, got: {r['detail']}")
+    # Migration hint must be present — the whole point of this check is actionability.
+    if "migrate" not in r["detail"].lower() and "move" not in r["detail"].lower() and "#1540" not in r["detail"]:
+        fails.append(f"a) detail should include migration hint, got: {r['detail']}")
+    return fails
+
+
+def case_b_file_found_memory_dir_ok():
+    """File exists under SUTANDO_MEMORY_DIR/machine-<host>/ → ok."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        mem_machine = td / "machine-testhost"
+        mem_machine.mkdir(parents=True)
+        si_path = mem_machine / "stand-identity.json"
+        si_path.write_text('{"stand_name": "My Stand"}')
+        with mock.patch.object(hc, "personal_path", return_value=si_path):
+            r = hc.check_stand_identity()
+    if r["status"] != "ok":
+        fails.append(f"b) found stand-identity.json should be ok, got {r['status']} ({r['detail']})")
+    if str(si_path) not in r["detail"]:
+        fails.append(f"b) detail should include the path, got: {r['detail']}")
+    return fails
+
+
+def case_c_file_found_workspace_fallback_ok():
+    """File exists under <workspace>/ (fallback path) → ok."""
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        si_path = td / "stand-identity.json"
+        si_path.write_text('{"stand_name": "My Stand"}')
+        with mock.patch.object(hc, "personal_path", return_value=si_path):
+            r = hc.check_stand_identity()
+    if r["status"] != "ok":
+        fails.append(f"c) workspace-fallback stand-identity.json should be ok, got {r['status']} ({r['detail']})")
+    if str(si_path) not in r["detail"]:
+        fails.append(f"c) detail should include the resolved path, got: {r['detail']}")
+    return fails
+
+
+def case_d_check_name_field():
+    """Result dict must always have name='stand-identity' regardless of outcome."""
+    fails = []
+    # Missing case
+    with mock.patch.object(hc, "personal_path", return_value=Path("/nonexistent")):
+        r_miss = hc.check_stand_identity()
+    if r_miss.get("name") != "stand-identity":
+        fails.append(f"d) missing path: name should be 'stand-identity', got {r_miss.get('name')}")
+    # Found case
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "stand-identity.json"
+        p.write_text("{}")
+        with mock.patch.object(hc, "personal_path", return_value=p):
+            r_found = hc.check_stand_identity()
+    if r_found.get("name") != "stand-identity":
+        fails.append(f"d) found path: name should be 'stand-identity', got {r_found.get('name')}")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    cases = [
+        ("a", case_a_file_missing_warn),
+        ("b", case_b_file_found_memory_dir_ok),
+        ("c", case_c_file_found_workspace_fallback_ok),
+        ("d", case_d_check_name_field),
+    ]
+    all_failures = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            all_failures.extend(fails)
+            print(f"  FAIL case {label}")
+            for f in fails:
+                print(f"    {f}")
+        else:
+            print(f"  PASS case {label}")
+
+    total = len(cases)
+    failed = len(all_failures)
+    print(f"\nResults: {total - failed}/{total} passed")
+    return 1 if all_failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

`stand-identity.json` was misclassified as `rehome-state` (→ `<workspace>/state/`) in the v0.8 migration, but its reader `personal_path()` checks `$SUTANDO_MEMORY_DIR/machine-<host>/` then `<workspace>/` — never `state/`. Affected hosts silently fell back to the literal `"Sutando"` Stand name. Fixed in #1540 / #1542, but existing affected hosts have no signal that something is wrong.

Issue: #1543 (layer 2 / P1)

## Fix

Adds `check_stand_identity()` to `src/health-check.py`:

```
⚠ stand-identity  warn  stand-identity.json not found at any reader path — Stand name falls
                         back to 'Sutando'. If you ran v0.8 migrate before fix #1540, check
                         whether the file landed in <workspace>/state/ and move it to <workspace>/.
```

- Uses `personal_path('stand-identity.json')` — exactly the reader's resolution order
- `ok` with resolved path when the file exists
- `warn` with migration hint when absent (directs operator to check `state/` for the misplaced file)
- Imports `personal_path` alongside the existing `shared_personal_path` import (same module)

## Scope

This is layer 2 (P1) of the three-layer plan in #1543:
- Layer 1 (P0, contract test) — `tests/migrate-reader-contract.test.py` — pending #1454 landing
- **Layer 2 (P1, health probe)** — this PR
- Layer 3 (P2, static lint) — `scripts/lint-class-rules.sh` — separate follow-up

Layers are independent; layer 2 does not require layer 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)