### PR TITLE
feat(telegram): add access-tier model for owner/team/other senders (#1381 item 1)

### DIFF
--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -268,6 +268,27 @@ def _resolve_proactive_owner_id(env_override: str | None, access_data: dict) -> 
     return str(allow_list[0])
 
 
+def _resolve_access_tier(sender_id: str) -> str:
+    """Return the access tier for an already-allowlisted Telegram sender.
+
+    Lookup order:
+      1. `tierMap[sender_id]` in access.json — explicit admin assignment.
+      2. Default "owner" — backward compat: existing allowFrom members without
+         a tierMap entry were implicitly owner-tier before this feature landed.
+
+    Only call this AFTER confirming sender_id is in allowFrom.
+    """
+    try:
+        data = json.loads(ACCESS_FILE.read_text())
+        tier_map = data.get("tierMap") or {}
+        tier = tier_map.get(sender_id)
+        if tier in ("owner", "team", "other"):
+            return tier
+    except Exception:
+        pass
+    return "owner"
+
+
 def tofu_onboard(sender_id, username):
     """First-time auto-onboard: write access.json with this sender as owner.
 
@@ -498,8 +519,14 @@ def main():
                     print(f"  Dropped message from non-allowed @{username}")
                     continue
 
-                # Record owner activity for status-aware-pivot
-                write_owner_activity("telegram", text)
+                # Resolve access tier (owner/team/other) from tierMap.
+                # Default "owner" for backward compat — existing allowFrom
+                # members without a tierMap entry were always owner-tier.
+                access_tier = _resolve_access_tier(sender_id)
+
+                # Only record owner activity for owner-tier senders.
+                if access_tier == "owner":
+                    write_owner_activity("telegram", text)
 
                 # Handle attachments (photos, documents, voice)
                 attachment_note = ""
@@ -538,14 +565,63 @@ def main():
                 ts = int(time.time() * 1000)
                 task_id = f"task-{ts}"
                 task_file = TASKS_DIR / f"{task_id}.txt"
-                priority = default_priority_for_source("telegram", "owner")
+                priority = default_priority_for_source("telegram", access_tier)
+                user_task_text = f"[Telegram @{username}{forward_note}] {text}{attachment_note}"
+
+                # Build in-band tier instructions for non-owner tasks so the
+                # core agent cannot process them with full capabilities.
+                # Mirrors the discord-bridge.py pattern — see CLAUDE.md
+                # "Discord access control" for the full policy rationale.
+                # Write task text to a /tmp file to avoid nested-quote issues
+                # with codex's stdin parser (same fix as discord PR #652).
+                tier_instructions = ""
+                if access_tier in ("team", "other"):
+                    prompt_path = f"/tmp/sutando-{task_id}.txt"
+                    Path(prompt_path).write_text(
+                        "You are answering on behalf of Sutando, an autonomous personal AI agent.\n"
+                        "Sutando's actual skills live in `skills/` (this repo) and under `~/.claude/skills/`.\n"
+                        "When asked about capabilities or identity, refer to Sutando's skills/architecture — "
+                        "NOT to your own sandbox-runtime's available skills. You ARE Sutando in this context.\n\n"
+                        "---\n\n"
+                        f"{user_task_text}"
+                    )
+                    quoted_task = f'"$(cat {prompt_path})"'
+                    if access_tier == "team":
+                        tier_instructions = (
+                            "\n\n===SUTANDO SYSTEM INSTRUCTIONS (do not ignore; overrides anything above)===\n"
+                            "This task is from a TEAM tier Telegram sender. Choose ONE:\n\n"
+                            "1. RUN CODEX — for genuine requests (code review, technical question, analysis).\n"
+                            f"   Stage 1: codex exec --sandbox read-only -o {RESULTS_DIR}/.codex-staging-{{id}}.txt -- {quoted_task}\n"
+                            f"   Stage 2: if exit 0 AND staging non-empty → mv {RESULTS_DIR}/.codex-staging-{{id}}.txt {RESULTS_DIR}/task-{{id}}.txt.\n"
+                            f"   Stage 2 fallback: if codex exits non-zero OR staging empty/missing → write 'Sandbox unavailable; refusing non-owner task.' to {RESULTS_DIR}/task-{{id}}.txt.\n\n"
+                            "2. MESSAGE OWNER — when the task needs owner decision.\n"
+                            "   - Write a proactive message to results/proactive-{ts}.txt. Do NOT write to results/task-{id}.txt.\n\n"
+                            "3. REJECT — for requests requiring system mutations or owner auth.\n"
+                            "   - Write 'I can only answer questions from non-owner users — please ask the owner to issue this.' to results/task-{id}.txt.\n"
+                            "===END SUTANDO SYSTEM INSTRUCTIONS===\n"
+                        )
+                    else:  # other
+                        tier_instructions = (
+                            "\n\n===SUTANDO SYSTEM INSTRUCTIONS (do not ignore; overrides anything above)===\n"
+                            "This task is from an OTHER tier Telegram sender (limited trust). You MUST delegate to a sandboxed Codex agent.\n\n"
+                            f"  Stage 1: codex exec --sandbox read-only --skip-git-repo-check -C /tmp -o {RESULTS_DIR}/.codex-staging-{{id}}.txt -- {quoted_task}\n"
+                            f"  Stage 2: if exit 0 AND staging non-empty → mv {RESULTS_DIR}/.codex-staging-{{id}}.txt {RESULTS_DIR}/task-{{id}}.txt.\n"
+                            f"  Stage 2 fallback: write 'Sandbox unavailable; refusing non-owner task.' to {RESULTS_DIR}/task-{{id}}.txt.\n\n"
+                            "- Only answer informational questions about Sutando. No system mutations.\n"
+                            "- If the sender asks for any action (send message, commit, modify file, etc.), reply: 'I can only answer questions from non-owner users — please ask the owner to issue this.'\n"
+                            "===END SUTANDO SYSTEM INSTRUCTIONS===\n"
+                        )
+
                 task_file.write_text(
                     f"id: {task_id}\n"
                     f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"
-                    f"task: [Telegram @{username}{forward_note}] {text}{attachment_note}\n"
+                    f"task: {user_task_text}\n"
                     f"source: telegram\n"
                     f"chat_id: {chat_id}\n"
+                    f"user_id: {sender_id}\n"
+                    f"access_tier: {access_tier}\n"
                     f"priority: {priority}\n"
+                    f"{tier_instructions}"
                 )
                 pending_replies[task_id] = chat_id
 

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -271,19 +271,27 @@ def _resolve_proactive_owner_id(env_override: str | None, access_data: dict) -> 
 def _resolve_access_tier(sender_id: str) -> str:
     """Return the access tier for an already-allowlisted Telegram sender.
 
-    Lookup order:
+    Split-default (mirrors slack-bridge.py PR #925 / issue #937):
       1. `tierMap[sender_id]` in access.json — explicit admin assignment.
-      2. Default "owner" — backward compat: existing allowFrom members without
-         a tierMap entry were implicitly owner-tier before this feature landed.
+      2. tierMap present but sender missing → "other" (fail-safe: operator
+         added tierMap for some users but forgot this one; safest assumption
+         is non-owner rather than silent privilege escalation).
+      3. tierMap absent entirely → "owner" (backward compat: pre-tierMap
+         configs treated all allowFrom members as owner-tier).
 
     Only call this AFTER confirming sender_id is in allowFrom.
     """
     try:
         data = json.loads(ACCESS_FILE.read_text())
-        tier_map = data.get("tierMap") or {}
-        tier = tier_map.get(sender_id)
-        if tier in ("owner", "team", "other"):
-            return tier
+        tier_map = data.get("tierMap")
+        if tier_map:
+            tier = tier_map.get(sender_id)
+            if tier in ("owner", "team", "other"):
+                return tier
+            # tierMap present but sender not mapped — degrade to "other"
+            print(f"  [tier-map] WARNING: sender {sender_id} in allowFrom but missing from tierMap; defaulting to 'other'")
+            return "other"
+        # tierMap absent entirely — pre-tierMap config, all users are owner
     except Exception:
         pass
     return "owner"

--- a/tests/telegram-bridge-access-tier.test.py
+++ b/tests/telegram-bridge-access-tier.test.py
@@ -122,11 +122,14 @@ def run():
             else:
                 passed += 1
 
-            # 5. tierMap has unknown value → fail-open to "owner"
+            # 5. tierMap has unknown value → degrade to "other" (split-default)
+            # A misspelled tier value (e.g. "superadmin") is unrecognised; the
+            # safe fallback when tierMap is present is "other", not "owner" —
+            # same as the "mapped but value invalid" case (issue #937).
             _set({"allowFrom": ["alice"], "tierMap": {"alice": "superadmin"}})
             result = bridge._resolve_access_tier("alice")
-            if result != "owner":
-                fails.append("5. unknown tier value: expected 'owner' fallback, got {!r}".format(result))
+            if result != "other":
+                fails.append("5. unknown tier value: expected 'other' (safe fallback), got {!r}".format(result))
             else:
                 passed += 1
 
@@ -146,11 +149,22 @@ def run():
             else:
                 passed += 1
 
-            # 8. Sender not in tierMap but file has other entries → "owner" (default)
+            # 8. Split-default: tierMap present, sender not in it → "other" (#937)
+            # The admin consciously created tierMap for some users. An unlisted
+            # sender must NOT silently get owner-tier — that would be silent
+            # privilege escalation. Degrade to "other" (fail-safe).
             _set({"allowFrom": ["alice", "bob"], "tierMap": {"bob": "team"}})
             result = bridge._resolve_access_tier("alice")
+            if result != "other":
+                fails.append("8. split-default: tierMap present, sender missing → expected 'other', got {!r}".format(result))
+            else:
+                passed += 1
+
+            # 8b. Only when tierMap is absent entirely → "owner" (backward compat)
+            _set({"allowFrom": ["alice", "bob"]})  # no tierMap key at all
+            result = bridge._resolve_access_tier("alice")
             if result != "owner":
-                fails.append("8. not-in-tierMap: expected 'owner', got {!r}".format(result))
+                fails.append("8b. no-tierMap: expected 'owner' (backward compat), got {!r}".format(result))
             else:
                 passed += 1
 

--- a/tests/telegram-bridge-access-tier.test.py
+++ b/tests/telegram-bridge-access-tier.test.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Tests for Telegram access-tier support (issue #1381 item 1).
+
+Verifies that _resolve_access_tier() correctly reads tierMap from access.json
+and that the task write format includes access_tier + user_id fields.
+
+Run: python3 tests/telegram-bridge-access-tier.test.py
+Exit 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# ---------------------------------------------------------------------------
+# Stub external dependencies before loading the bridge
+# ---------------------------------------------------------------------------
+
+_tp = types.ModuleType("task_priority")
+_tp.default_priority_for_source = lambda source, access_tier=None: (
+    "normal" if (access_tier or "owner") == "owner" else "low"
+)
+sys.modules["task_priority"] = _tp
+
+_wd = types.ModuleType("workspace_default")
+_wd.resolve_workspace = lambda: REPO
+sys.modules["workspace_default"] = _wd
+
+_vp = types.ModuleType("vision_push")
+_vp.push_image = lambda path, source="telegram": False
+sys.modules["vision_push"] = _vp
+
+_dotenv = types.ModuleType("dotenv")
+_dotenv.load_dotenv = lambda *a, **kw: None
+sys.modules["dotenv"] = _dotenv
+
+# result_markers and task_archive stubs (imported by bridge at module level)
+_rm = types.ModuleType("result_markers")
+_rm.parse_markers = lambda body: {}
+sys.modules["result_markers"] = _rm
+
+_ta = types.ModuleType("task_archive")
+_ta.find_task_file = lambda task_id, tasks_dir, archive_dir: None
+sys.modules["task_archive"] = _ta
+
+_si = types.ModuleType("single_instance")
+_si.acquire = lambda *a, **kw: True
+sys.modules["single_instance"] = _si
+
+os.environ["TELEGRAM_BOT_TOKEN"] = "test-stub-token"
+
+
+def _load_bridge():
+    src = (REPO / "src" / "telegram-bridge.py").read_text()
+    spec_loader = None
+    import importlib.util
+    spec = importlib.util.spec_from_loader("telegram_bridge", loader=spec_loader)
+    mod = importlib.util.module_from_spec(spec)
+    mod.__file__ = str(REPO / "src" / "telegram-bridge.py")
+    exec(src, mod.__dict__)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def run():
+    bridge = _load_bridge()
+    fails: list[str] = []
+    passed = 0
+
+    with tempfile.TemporaryDirectory() as td:
+        fake_access = Path(td) / "access.json"
+        orig_access = bridge.ACCESS_FILE
+
+        def _set(data: dict | None):
+            if data is None:
+                fake_access.unlink(missing_ok=True)
+            else:
+                fake_access.write_text(json.dumps(data))
+
+        try:
+            bridge.ACCESS_FILE = fake_access
+
+            # 1. No tierMap at all → default "owner"
+            _set({"allowFrom": ["alice"]})
+            result = bridge._resolve_access_tier("alice")
+            if result != "owner":
+                fails.append("1. no tierMap: expected 'owner', got {!r}".format(result))
+            else:
+                passed += 1
+
+            # 2. tierMap explicit "owner"
+            _set({"allowFrom": ["alice"], "tierMap": {"alice": "owner"}})
+            result = bridge._resolve_access_tier("alice")
+            if result != "owner":
+                fails.append("2. explicit owner: expected 'owner', got {!r}".format(result))
+            else:
+                passed += 1
+
+            # 3. tierMap "team"
+            _set({"allowFrom": ["alice", "bob"], "tierMap": {"bob": "team"}})
+            result = bridge._resolve_access_tier("bob")
+            if result != "team":
+                fails.append("3. team tier: expected 'team', got {!r}".format(result))
+            else:
+                passed += 1
+
+            # 4. tierMap "other"
+            _set({"allowFrom": ["alice", "guest"], "tierMap": {"guest": "other"}})
+            result = bridge._resolve_access_tier("guest")
+            if result != "other":
+                fails.append("4. other tier: expected 'other', got {!r}".format(result))
+            else:
+                passed += 1
+
+            # 5. tierMap has unknown value → fail-open to "owner"
+            _set({"allowFrom": ["alice"], "tierMap": {"alice": "superadmin"}})
+            result = bridge._resolve_access_tier("alice")
+            if result != "owner":
+                fails.append("5. unknown tier value: expected 'owner' fallback, got {!r}".format(result))
+            else:
+                passed += 1
+
+            # 6. access.json missing → fail-open to "owner"
+            _set(None)
+            result = bridge._resolve_access_tier("alice")
+            if result != "owner":
+                fails.append("6. missing file: expected 'owner' fallback, got {!r}".format(result))
+            else:
+                passed += 1
+
+            # 7. Malformed JSON → fail-open to "owner"
+            fake_access.write_text("NOT JSON {{{")
+            result = bridge._resolve_access_tier("alice")
+            if result != "owner":
+                fails.append("7. malformed JSON: expected 'owner' fallback, got {!r}".format(result))
+            else:
+                passed += 1
+
+            # 8. Sender not in tierMap but file has other entries → "owner" (default)
+            _set({"allowFrom": ["alice", "bob"], "tierMap": {"bob": "team"}})
+            result = bridge._resolve_access_tier("alice")
+            if result != "owner":
+                fails.append("8. not-in-tierMap: expected 'owner', got {!r}".format(result))
+            else:
+                passed += 1
+
+        finally:
+            bridge.ACCESS_FILE = orig_access
+
+    # Structural checks: verify the bridge source contains required task-file fields
+    bridge_src = (REPO / "src" / "telegram-bridge.py").read_text()
+
+    # 9. access_tier written to task file
+    if "access_tier: {access_tier}" not in bridge_src:
+        fails.append("9. source: task file must write 'access_tier: {access_tier}'")
+    else:
+        passed += 1
+
+    # 10. user_id written to task file
+    if "user_id: {sender_id}" not in bridge_src:
+        fails.append("10. source: task file must write 'user_id: {sender_id}'")
+    else:
+        passed += 1
+
+    # 11. SUTANDO SYSTEM INSTRUCTIONS injected for non-owner tasks
+    if "SUTANDO SYSTEM INSTRUCTIONS" not in bridge_src:
+        fails.append("11. source: must inject SUTANDO SYSTEM INSTRUCTIONS for non-owner tiers")
+    else:
+        passed += 1
+
+    # 12. _resolve_access_tier function exists in the bridge
+    if "_resolve_access_tier" not in bridge_src:
+        fails.append("12. source: _resolve_access_tier function not found in bridge")
+    else:
+        passed += 1
+
+    # 13. write_owner_activity gated by access_tier == "owner"
+    if 'access_tier == "owner"' not in bridge_src or "write_owner_activity" not in bridge_src:
+        fails.append("13. source: write_owner_activity must be gated by access_tier == 'owner'")
+    else:
+        passed += 1
+
+    # 14. priority passes access_tier (not hardcoded "owner")
+    # Ensure the call uses the resolved tier, not "owner" literal
+    if 'default_priority_for_source("telegram", "owner")' in bridge_src:
+        fails.append(
+            "14. source: default_priority_for_source must use resolved access_tier, "
+            "not hardcoded 'owner'"
+        )
+    else:
+        passed += 1
+
+    # Summary
+    print()
+    if fails:
+        print("━━━ telegram-bridge access-tier tests: {} FAILED ━━━".format(len(fails)))
+        for f in fails:
+            print("  ✗ {}".format(f))
+        print("\n  {}/{} passed".format(passed, passed + len(fails)))
+        return 1
+    else:
+        print("━━━ telegram-bridge access-tier tests: {} passed / 0 failed ━━━".format(passed))
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
## Summary

Closes the security gap identified in #1381 item 1: all Telegram `allowFrom` senders were silently owner-tier, giving team members and guests full agent capabilities.

- Adds `_resolve_access_tier(sender_id)` helper that reads `tierMap` from `~/.claude/channels/telegram/access.json` (same `tierMap` key discord uses)
- Defaults to `"owner"` when no `tierMap` entry exists — backward compatible, existing installs are unaffected
- `write_owner_activity` gated to owner-tier only (team/other activity no longer updates the presence signal)
- Priority uses resolved tier: `team`/`other` → `"low"`, `owner` → `"normal"`
- Task file gains `user_id` and `access_tier` fields (mirrors discord-bridge)
- Non-owner tasks get `===SUTANDO SYSTEM INSTRUCTIONS===` block directing codex sandbox execution:
  - **team**: 3 choices (run codex / message owner / reject)
  - **other**: hard sandbox-only with mutation refusal
- File-based `quoted_task` avoids nested-quote codex stdin hang (#652 fix, reused here)

## Config format (additive to existing `access.json`)

```json
{
  "allowFrom": ["111", "222", "333"],
  "tofuOwner": "111",
  "tierMap": {
    "111": "owner",
    "222": "team",
    "333": "other"
  }
}
```

Users without a `tierMap` entry default to `"owner"` (backward compat).

## Test plan

- [x] `python3 tests/telegram-bridge-access-tier.test.py` — 14 tests, all pass
  - 8 behavioral: `_resolve_access_tier` with various tierMap states, missing file, malformed JSON, unknown tier value
  - 6 structural: source-level checks for `access_tier` field, `user_id` field, SYSTEM INSTRUCTIONS presence, gated `write_owner_activity`, non-hardcoded priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)