### PR TITLE
fix(sutando-migrate): auto-adopt legacy .env to repo root during commit

### DIFF
--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1811,15 +1811,20 @@ commit_main() {
             for _c in "$HOME/.sutando/workspace/.env" \
                       "${SUTANDO_WORKSPACE:+${SUTANDO_WORKSPACE/#\~/$HOME}/.env}" \
                       "$HOME/.sutando/.env"; do
-                [ -n "$_c" ] && [ -f "$_c" ] && grep -q '^GEMINI_API_KEY=.\+' "$_c" 2>/dev/null && { _legacy_env="$_c"; break; }
+                # `|| :` keeps the AND-list (and the loop) at status 0 under `set -e`
+                # when a candidate is absent.
+                [ -n "$_c" ] && [ -f "$_c" ] && grep -q '^GEMINI_API_KEY=.\+' "$_c" 2>/dev/null && { _legacy_env="$_c"; break; } || :
             done
             # Fallback: newest .env carrying the key anywhere under ~/.sutando.
+            # `|| true` — the find/grep/head pipeline returns non-zero when
+            # ~/.sutando is absent or nothing matches; without it `set -euo
+            # pipefail` would abort the whole commit (CI has no ~/.sutando).
             if [ -z "$_legacy_env" ]; then
                 _legacy_env="$(find "$HOME/.sutando" -maxdepth 4 -name .env -type f 2>/dev/null \
-                    -exec grep -l '^GEMINI_API_KEY=.\+' {} \; | xargs -r ls -t 2>/dev/null | head -1)"
+                    -exec grep -l '^GEMINI_API_KEY=.\+' {} \; | xargs -r ls -t 2>/dev/null | head -1 || true)"
             fi
             if [ -n "$_legacy_env" ]; then
-                [ -f "$_repo_env" ] && cp "$_repo_env" "$_repo_env.bak-$BACKUP_ID"
+                { [ -f "$_repo_env" ] && cp "$_repo_env" "$_repo_env.bak-$BACKUP_ID"; } || :
                 # Strip any stale `SUTANDO_WORKSPACE=` so the adopted secrets can't
                 # re-point this clone back at the old workspace (also silences the
                 # v0.8 deprecation nag). All other keys carry over verbatim.

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1792,6 +1792,49 @@ commit_main() {
         fi
     fi
 
+    # .env adoption — legacy installs kept secrets in `<old-workspace>/.env`,
+    # but startup.sh hard-requires them at repo root (`$REPO_DIR/.env`, with
+    # GEMINI_API_KEY). The per-file copy walk excludes `.env` (per-clone file),
+    # so without this the secrets stay stranded in the old workspace and the
+    # first post-migrate `startup.sh` bails ("`.env` not found"). Auto-adopt the
+    # legacy `.env` to repo root when repo root lacks a valid one — no human
+    # step. Skipped on phase-2 delete-only runs (no copy walk happened).
+    if [ "$DELETE_SOURCE" = "0" ]; then
+        local _repo_env="$REPO_DIR/.env"
+        if [ -f "$_repo_env" ] && grep -q '^GEMINI_API_KEY=.\+' "$_repo_env" 2>/dev/null; then
+            echo "  .env adopt: $_repo_env already valid — skip"
+        else
+            local _legacy_env="" _c
+            # Priority: legacy default workspace, the $SUTANDO_WORKSPACE override
+            # (value ignored for resolution since v0.8 but still a common .env home),
+            # then ~/.sutando/.env.
+            for _c in "$HOME/.sutando/workspace/.env" \
+                      "${SUTANDO_WORKSPACE:+${SUTANDO_WORKSPACE/#\~/$HOME}/.env}" \
+                      "$HOME/.sutando/.env"; do
+                [ -n "$_c" ] && [ -f "$_c" ] && grep -q '^GEMINI_API_KEY=.\+' "$_c" 2>/dev/null && { _legacy_env="$_c"; break; }
+            done
+            # Fallback: newest .env carrying the key anywhere under ~/.sutando.
+            if [ -z "$_legacy_env" ]; then
+                _legacy_env="$(find "$HOME/.sutando" -maxdepth 4 -name .env -type f 2>/dev/null \
+                    -exec grep -l '^GEMINI_API_KEY=.\+' {} \; | xargs -r ls -t 2>/dev/null | head -1)"
+            fi
+            if [ -n "$_legacy_env" ]; then
+                [ -f "$_repo_env" ] && cp "$_repo_env" "$_repo_env.bak-$BACKUP_ID"
+                # Strip any stale `SUTANDO_WORKSPACE=` so the adopted secrets can't
+                # re-point this clone back at the old workspace (also silences the
+                # v0.8 deprecation nag). All other keys carry over verbatim.
+                if grep -v '^SUTANDO_WORKSPACE=' "$_legacy_env" > "$_repo_env" 2>/dev/null \
+                   && grep -q '^GEMINI_API_KEY=.\+' "$_repo_env" 2>/dev/null; then
+                    echo "  .env adopt: $_legacy_env → $_repo_env ($(grep -cE '^[A-Z_]+=' "$_repo_env") keys; SUTANDO_WORKSPACE stripped)"
+                else
+                    echo "  .env adopt: adoption failed — set $_repo_env manually before startup.sh (source: $_legacy_env)" >&2
+                fi
+            else
+                echo "  .env adopt: no legacy .env with GEMINI_API_KEY found under ~/.sutando — set $_repo_env manually before startup.sh"
+            fi
+        fi
+    fi
+
     echo
     echo "sutando-migrate: COMMIT complete. Verify with: bash scripts/sutando-migrate.sh verify"
     echo "  rollback: bash scripts/sutando-migrate.sh rollback --backup-id $BACKUP_ID"


### PR DESCRIPTION
## Problem
Legacy installs kept secrets in `<old-workspace>/.env`, but the v0.8 model has `startup.sh` hard-require `.env` at **repo root** (with `GEMINI_API_KEY`). The per-file copy walk deliberately excludes `.env` (per-clone file), so after a migration the secrets stay stranded in the old workspace and the first `startup.sh` bails with "`.env` not found" — hit during a live cutover.

## Fix
A no-intervention `.env` adoption step at the end of the commit path (skipped on phase-2 delete-only runs):
- When repo root lacks a valid `.env`, discover the legacy one: old default workspace → `$SUTANDO_WORKSPACE` override → `~/.sutando/.env` → newest matching `.env` under `~/.sutando`.
- Adopt it to `$REPO_DIR/.env`; back up any existing to `.env.bak-$BACKUP_ID`.
- Strip any stale `SUTANDO_WORKSPACE=` so adopted secrets can't re-point the clone at the old workspace (also silences the v0.8 deprecation nag).

## Test
Discovery verified against a live legacy `~/.sutando/workspace/.env` (found it, 11 keys, zero input). `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)