### PR TITLE
feat(discord-bridge): @-mention owner when a non-owner auto-seeds a thread (#1498 follow-up)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -540,6 +540,27 @@ def load_channel_allowed(channel_id):
         return None
     return cfg[1]
 
+def _should_notify_owner_on_seed(sender_id, owner_ids):
+    """True iff a thread auto-seed should @-mention the owner.
+
+    Fires only when a NON-OWNER seeds the thread: an auto-opened thread can
+    otherwise quietly accumulate sandboxed (non-owner) replies the owner never
+    sees, because the @-mention is what reaches the owner's Discord client even
+    when they aren't following the thread. Owner-seeded threads need no ping —
+    the owner is already there. False when there is no owner to mention.
+    """
+    owners = {str(o) for o in (owner_ids or [])}
+    return bool(owners) and str(sender_id) not in owners
+
+def _format_seed_notice(owner_id, author_mention, parent_label, thread_id_str):
+    """Inline notice posted to a freshly auto-seeded thread. Pure (no I/O)."""
+    return (
+        f"<@{owner_id}> 🌱 Auto-seeded this thread to access.json "
+        f"(first message from {author_mention}, parent {parent_label}). "
+        f"Tier still resolves by sender identity — non-owners stay sandboxed. "
+        f"`/discord:access group rm {thread_id_str}` to undo."
+    )
+
 def load_channel_auto_react(channel_id):
     """Return list of emoji strings to auto-react with on each new message in this
     channel, or empty list if not configured. Reactions land at gateway-event
@@ -2310,6 +2331,18 @@ async def _handle_discord_message(message, force=False):
                     tmp_path.write_text(json.dumps(access_data, indent=2))
                     os.replace(tmp_path, ACCESS_FILE)
                     print(f"  [thread-engage] added thread {thread_id_str} (parent {parent_id_str}) to access.json with {thread_entry}", flush=True)
+                    # Owner-visibility ping (one-shot, first seed only): when a
+                    # non-owner seeds the thread, @-mention the owner inline so an
+                    # auto-opened thread can't silently accumulate sandboxed replies
+                    # the owner never sees (#1498 slip-risk).
+                    owner_ids = access_data.get('allowFrom', [])
+                    if _should_notify_owner_on_seed(message.author.id, owner_ids):
+                        try:
+                            parent_label = f"#{message.channel.parent.name}" if message.channel.parent else str(parent_id_str)
+                            await message.channel.send(
+                                _format_seed_notice(owner_ids[0], message.author.mention, parent_label, thread_id_str))
+                        except Exception as e:
+                            print(f"  [thread-engage] owner-notice send failed: {e}", flush=True)
             except Exception as e:
                 print(f"  [thread-engage] failed to update access.json: {e}", flush=True)
 

--- a/tests/discord-bridge-thread-seed-owner-notice.test.py
+++ b/tests/discord-bridge-thread-seed-owner-notice.test.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+Tests for the thread-seed owner-visibility notice in discord-bridge.py.
+
+When the bridge auto-seeds a thread into access.json (the #1498 path), a
+non-owner can quietly accumulate sandboxed replies the owner never sees. The
+fix posts an inline @-mention to the owner on first seed — but ONLY when a
+non-owner did the seeding (owner-seeded threads need no ping).
+
+Helpers under test (pure / testable):
+  - _should_notify_owner_on_seed(sender_id, owner_ids): gating predicate
+  - _format_seed_notice(owner_id, author_mention, parent_label, thread_id): body
+
+Run: python3 tests/discord-bridge-thread-seed-owner-notice.test.py
+Exit 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Stub minimal discord module BEFORE the bridge is exec'd.
+_discord_stub = types.ModuleType("discord")
+
+
+class _Intents:
+    @classmethod
+    def default(cls):
+        i = cls()
+        i.message_content = False
+        i.members = False
+        return i
+
+
+class _Client:
+    def __init__(self, *args, **kwargs):
+        self.user = None
+        self.loop = types.SimpleNamespace(create_task=lambda *a, **kw: None)
+    def event(self, fn):
+        return fn
+    def get_channel(self, _id):
+        return None
+
+
+_discord_stub.Intents = _Intents
+_discord_stub.Client = _Client
+_discord_stub.MessageType = types.SimpleNamespace(default=0, reply=1)
+_discord_stub.File = lambda *a, **kw: None
+_discord_stub.DMChannel = type("_DMChannel", (), {})
+_discord_stub.Thread = type("_Thread", (), {})
+sys.modules["discord"] = _discord_stub
+
+
+def load_bridge():
+    """Exec the bridge module without running its main()."""
+    src = (REPO / "src" / "discord-bridge.py").read_text()
+    fake_env_dir = Path.home() / ".claude" / "channels" / "discord"
+    fake_env = fake_env_dir / ".env"
+    if not fake_env.exists():
+        fake_env_dir.mkdir(parents=True, exist_ok=True)
+        fake_env.write_text("DISCORD_BOT_TOKEN=test-stub-token\n")
+    spec = importlib.util.spec_from_loader("bridge", loader=None)
+    bridge = importlib.util.module_from_spec(spec)
+    bridge.__file__ = str(REPO / "src" / "discord-bridge.py")
+    exec(src, bridge.__dict__)
+    return bridge
+
+
+bridge = load_bridge()
+
+
+# ---------------------------------------------------------------------------
+# _should_notify_owner_on_seed
+# ---------------------------------------------------------------------------
+
+def case_non_owner_seeder_notifies() -> list[str]:
+    fails = []
+    # Non-owner seeds (sender not in owner list) → notify.
+    if not bridge._should_notify_owner_on_seed("999", ["111", "222"]):
+        fails.append("a) non-owner seeder should notify")
+    # int sender id vs str owner ids → still notifies (type-agnostic compare).
+    if not bridge._should_notify_owner_on_seed(999, ["111"]):
+        fails.append("a) int sender_id vs str owner_ids should still notify")
+    return fails
+
+
+def case_owner_seeder_skips() -> list[str]:
+    fails = []
+    # Owner seeds their own thread → no ping (str match).
+    if bridge._should_notify_owner_on_seed("111", ["111", "222"]):
+        fails.append("b) owner seeder should NOT notify")
+    # int owner id in list, str sender → coerced match, no ping.
+    if bridge._should_notify_owner_on_seed("111", [111, 222]):
+        fails.append("b) int owner_ids should coerce-match str sender")
+    # int sender matching int owner → no ping.
+    if bridge._should_notify_owner_on_seed(111, [111]):
+        fails.append("b) int sender matching int owner should NOT notify")
+    return fails
+
+
+def case_no_owner_never_notifies() -> list[str]:
+    fails = []
+    # No owner to mention → never notify (avoid <@> with empty id).
+    if bridge._should_notify_owner_on_seed("999", []):
+        fails.append("c) empty owner list should NOT notify")
+    if bridge._should_notify_owner_on_seed("999", None):
+        fails.append("c) None owner list should NOT notify")
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# _format_seed_notice
+# ---------------------------------------------------------------------------
+
+def case_notice_body() -> list[str]:
+    fails = []
+    body = bridge._format_seed_notice("111", "<@999>", "#general", "555")
+    # @-mention is what reaches the owner's client — must be present.
+    if "<@111>" not in body:
+        fails.append("d) notice must @-mention the owner")
+    if "<@999>" not in body:
+        fails.append("d) notice should name the seeding author")
+    if "#general" not in body:
+        fails.append("d) notice should name the parent channel")
+    # The undo affordance must reference the seeded thread id.
+    if "group rm 555" not in body:
+        fails.append("d) notice should include the group-rm undo for the thread id")
+    return fails
+
+
+def main() -> int:
+    cases = [
+        ("a-non-owner", case_non_owner_seeder_notifies),
+        ("b-owner-skip", case_owner_seeder_skips),
+        ("c-no-owner", case_no_owner_never_notifies),
+        ("d-body", case_notice_body),
+    ]
+    failures: list[str] = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nAll thread-seed owner-notice invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

When the bridge auto-seeds a Discord thread into `access.json` (the #1498 path), post **one** inline `<@owner> 🌱 Auto-seeded this thread…` message into that thread — but **only** when the seeder is a non-owner.

## Why

An auto-opened thread can quietly accumulate sandboxed (non-owner) replies the owner never sees: the access tier resolves by *sender identity*, so non-owners stay sandboxed, but nothing surfaces the new thread to the owner if they aren't following it. The `@`-mention is what reaches the owner's Discord client. Owner-seeded threads need no ping — the owner is already there.

This closes the slip-risk noted during #1498 review.

## How

Two pure, unit-tested helpers in `discord-bridge.py`:

- `_should_notify_owner_on_seed(sender_id, owner_ids)` — gating predicate. Fires iff there is an owner to mention **and** the seeder is not that owner. Type-agnostic compare (int snowflake vs str both work).
- `_format_seed_notice(owner_id, author_mention, parent_label, thread_id)` — the inline body. Includes the owner mention, the seeding author, the parent channel, and a `/discord:access group rm <thread_id>` undo affordance.

The seed branch calls them one-shot, inside the existing `if thread_id_str not in access_groups:` guard, so it fires only on first seed. Send is wrapped in try/except — a notice failure never breaks seeding.

## Scope note

Targeting fires for **any** non-owner seed, not only open-parent threads. That's deliberate: the slip-risk exists regardless of how the thread was opened.

## Test

`tests/discord-bridge-thread-seed-owner-notice.test.py` — 4 cases (non-owner notifies + int/str coercion, owner skips, empty/None owner never notifies, body contents). All pass; `py_compile` clean.

Stand: Echo Act IV

🤖 Generated with [Claude Code](https://claude.com/claude-code)