### PR TITLE
feat(voice-skills): strip delivery-routing markers from voice narration (#1381 item 3)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -399,10 +399,14 @@ function delegateTask(s: DiscordVoiceSession, taskDescription: string): Promise<
 			console.log(`${ts()} [Task] result ${taskId} (${Date.now() - startTime}ms): ${result.slice(0, 200)}`);
 			s.events.push({ event: `task_result:${taskId}:${Date.now() - startTime}ms`, timestamp: new Date().toISOString() });
 			try { unlinkSync(resultPath); } catch {}
+			// Strip [channel: <id>] redirect — voice session can't route to
+			// Discord/Slack channels; narrate remaining content (mirrors Telegram).
+			const resultForNarration = result.replace(/^\s*\[channel:[^\]]+\]\s*\n?/i, '').trim() || result;
+			if (resultForNarration !== result) console.log(`${ts()} [Task] ${taskId} [channel:] redirect stripped`);
 			if (!s.taskResultCache) s.taskResultCache = new Map();
-			s.taskResultCache.set(taskDescription, result);
+			s.taskResultCache.set(taskDescription, resultForNarration);
 			s.resultQueue.push({
-				text: `[Task result for "${taskDescription}"]\n${result}\n\nReport this result to the user now.`,
+				text: `[Task result for "${taskDescription}"]\n${resultForNarration}\n\nReport this result to the user now.`,
 			});
 			return;
 		}

--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -399,10 +399,14 @@ function delegateTask(s: DiscordVoiceSession, taskDescription: string): Promise<
 			console.log(`${ts()} [Task] result ${taskId} (${Date.now() - startTime}ms): ${result.slice(0, 200)}`);
 			s.events.push({ event: `task_result:${taskId}:${Date.now() - startTime}ms`, timestamp: new Date().toISOString() });
 			try { unlinkSync(resultPath); } catch {}
-			// Strip [channel: <id>] redirect — voice session can't route to
-			// Discord/Slack channels; narrate remaining content (mirrors Telegram).
-			const resultForNarration = result.replace(/^\s*\[channel:[^\]]+\]\s*\n?/i, '').trim() || result;
-			if (resultForNarration !== result) console.log(`${ts()} [Task] ${taskId} [channel:] redirect stripped`);
+			// Strip delivery-routing markers — voice session can't route to
+			// Discord/Slack channels or attach files. Narrate remaining content
+			// (mirrors Telegram). [file:/send:/attach:] can appear anywhere.
+			const resultForNarration = result
+				.replace(/^\s*\[channel:[^\]]+\]\s*\n?/i, '')
+				.replace(/\[(?:file|send|attach):[^\]]+\]/gi, '')
+				.trim() || result;
+			if (resultForNarration !== result) console.log(`${ts()} [Task] ${taskId} delivery markers stripped`);
 			if (!s.taskResultCache) s.taskResultCache = new Map();
 			s.taskResultCache.set(taskDescription, resultForNarration);
 			s.resultQueue.push({

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -450,8 +450,12 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			archivePhoneFile(resultPath, 'results', taskId);
 			archivePhoneFile(taskPath, 'tasks', taskId);
 			// Cache result so duplicate requests get instant replay
+			// Strip [channel: <id>] redirect — phone can't route to Discord/Slack
+			// channels; narrate remaining content (mirrors Telegram's behavior).
+			const resultForNarration = result.replace(/^\s*\[channel:[^\]]+\]\s*\n?/i, '').trim() || result;
+			if (resultForNarration !== result) console.log(`${ts()} [Phone] [channel:] redirect stripped from task result`);
 			if (!callSession.taskResultCache) callSession.taskResultCache = new Map();
-			callSession.taskResultCache.set(taskDescription, result);
+			callSession.taskResultCache.set(taskDescription, resultForNarration);
 			// Anti-hallucination wrapping. See sonichi/sutando#1244 — Gemini
 			// was filling silence with plausible-sounding fabrications when
 			// the work tool returned empty/sparse content. Two layers:
@@ -459,10 +463,10 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			// has an explicit "say nothing" signal instead of an empty string
 			// it can pattern-fill; (2) an explicit "items present verbatim"
 			// guardrail on every result.
-			const isEmpty = result.length === 0;
+			const isEmpty = resultForNarration.length === 0;
 			const injectedText = isEmpty
 				? `[Task result for "${taskDescription}"]\nRESULT_EMPTY — the tool returned no items.\n\nTell the caller plainly that there is nothing to report (e.g. "nothing scheduled", "your inbox is empty", "no matches"). Do NOT invent, guess, or extrapolate any items. Use only the literal RESULT_EMPTY signal.`
-				: `[Task result for "${taskDescription}"]\n${result}\n\nReport this result to the caller now. Only reference items that appear verbatim in the result above — do NOT invent, fabricate, or extrapolate items that aren't there.`;
+				: `[Task result for "${taskDescription}"]\n${resultForNarration}\n\nReport this result to the caller now. Only reference items that appear verbatim in the result above — do NOT invent, fabricate, or extrapolate items that aren't there.`;
 			// Queue result — will be injected on next turn.end to avoid interrupting speech
 			callSession.resultQueue.push({ text: injectedText });
 			return;

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -450,10 +450,14 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			archivePhoneFile(resultPath, 'results', taskId);
 			archivePhoneFile(taskPath, 'tasks', taskId);
 			// Cache result so duplicate requests get instant replay
-			// Strip [channel: <id>] redirect — phone can't route to Discord/Slack
-			// channels; narrate remaining content (mirrors Telegram's behavior).
-			const resultForNarration = result.replace(/^\s*\[channel:[^\]]+\]\s*\n?/i, '').trim() || result;
-			if (resultForNarration !== result) console.log(`${ts()} [Phone] [channel:] redirect stripped from task result`);
+			// Strip delivery-routing markers — phone can't route to Discord/Slack
+			// channels or attach files. [file:/send:/attach:] can appear anywhere.
+			// Narrate remaining content; mirrors Telegram's behavior.
+			const resultForNarration = result
+				.replace(/^\s*\[channel:[^\]]+\]\s*\n?/i, '')
+				.replace(/\[(?:file|send|attach):[^\]]+\]/gi, '')
+				.trim() || result;
+			if (resultForNarration !== result) console.log(`${ts()} [Phone] delivery markers stripped from task result`);
 			if (!callSession.taskResultCache) callSession.taskResultCache = new Map();
 			callSession.taskResultCache.set(taskDescription, resultForNarration);
 			// Anti-hallucination wrapping. See sonichi/sutando#1244 — Gemini

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -678,10 +678,14 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 						continue;
 					}
 					console.log(`${ts()} [TaskBridge] Voice-only result: ${file} (${result.slice(0, 80)})`);
-					// Strip [channel: <id>] redirect — voice can't route to Discord/Slack
-					// channels. Narrate remaining content; mirrors Telegram's behavior.
-					const _voiceNarration = result.replace(/^\s*\[channel:[^\]]+\]\s*\n?/i, '').trim() || result;
-					if (_voiceNarration !== result) console.log(`${ts()} [TaskBridge] [channel:] redirect stripped from voice-only result`);
+					// Strip delivery-routing markers — voice can't route to channels or
+					// attach files. [channel:] must be first line; [file:/send:/attach:]
+					// can appear anywhere. Narrate remaining content; mirrors Telegram.
+					const _voiceNarration = result
+						.replace(/^\s*\[channel:[^\]]+\]\s*\n?/i, '')
+						.replace(/\[(?:file|send|attach):[^\]]+\]/gi, '')
+						.trim() || result;
+					if (_voiceNarration !== result) console.log(`${ts()} [TaskBridge] delivery markers stripped from voice-only result`);
 					onResult(_voiceNarration);
 					_deliveredResults.add(file);
 					setTimeout(() => archiveFile(path, 'results', `voice-${Date.now()}`), 10_000);
@@ -791,10 +795,14 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					_deliveredResults.add(file);
 					_pendingTasks.delete(taskId);
 					logConversation('core-agent', `[task:${taskId}] ${result.slice(0, LOG_LINE_MAX_CHARS)}`);
-					// Strip [channel: <id>] redirect — voice can't route to Discord/Slack
-					// channels. Narrate remaining content; mirrors Telegram's behavior.
-					const _narration = result.replace(/^\s*\[channel:[^\]]+\]\s*\n?/i, '').trim() || result;
-					if (_narration !== result) console.log(`${ts()} [TaskBridge] [channel:] redirect stripped from task result`);
+					// Strip delivery-routing markers — voice can't route to channels or
+					// attach files. [channel:] must be first line; [file:/send:/attach:]
+					// can appear anywhere. Narrate remaining content; mirrors Telegram.
+					const _narration = result
+						.replace(/^\s*\[channel:[^\]]+\]\s*\n?/i, '')
+						.replace(/\[(?:file|send|attach):[^\]]+\]/gi, '')
+						.trim() || result;
+					if (_narration !== result) console.log(`${ts()} [TaskBridge] delivery markers stripped from task result`);
 					onResult(_narration);
 					// Notify agent-api directly, then delete file
 					try {

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -678,7 +678,11 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 						continue;
 					}
 					console.log(`${ts()} [TaskBridge] Voice-only result: ${file} (${result.slice(0, 80)})`);
-					onResult(result);
+					// Strip [channel: <id>] redirect — voice can't route to Discord/Slack
+					// channels. Narrate remaining content; mirrors Telegram's behavior.
+					const _voiceNarration = result.replace(/^\s*\[channel:[^\]]+\]\s*\n?/i, '').trim() || result;
+					if (_voiceNarration !== result) console.log(`${ts()} [TaskBridge] [channel:] redirect stripped from voice-only result`);
+					onResult(_voiceNarration);
 					_deliveredResults.add(file);
 					setTimeout(() => archiveFile(path, 'results', `voice-${Date.now()}`), 10_000);
 					continue;
@@ -787,7 +791,11 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 					_deliveredResults.add(file);
 					_pendingTasks.delete(taskId);
 					logConversation('core-agent', `[task:${taskId}] ${result.slice(0, LOG_LINE_MAX_CHARS)}`);
-					onResult(result);
+					// Strip [channel: <id>] redirect — voice can't route to Discord/Slack
+					// channels. Narrate remaining content; mirrors Telegram's behavior.
+					const _narration = result.replace(/^\s*\[channel:[^\]]+\]\s*\n?/i, '').trim() || result;
+					if (_narration !== result) console.log(`${ts()} [TaskBridge] [channel:] redirect stripped from task result`);
+					onResult(_narration);
 					// Notify agent-api directly, then delete file
 					try {
 						fetch('http://localhost:7843/task-done', {

--- a/tests/conversation-server-no-hallucination.test.ts
+++ b/tests/conversation-server-no-hallucination.test.ts
@@ -23,8 +23,8 @@ describe('conversation-server — anti-hallucination on work-tool results (sonic
 	it('detects truly-empty results via result.length === 0', () => {
 		assert.match(
 			SRC,
-			/const\s+isEmpty\s*=\s*result\.length\s*===\s*0/,
-			'must detect empty results with strict-equal length check on the trimmed result string.',
+			/const\s+isEmpty\s*=\s*\w+\.length\s*===\s*0/,
+			'must detect empty results with strict-equal length check on the result string (variable may be renamed e.g. resultForNarration after marker-stripping).',
 		);
 	});
 

--- a/tests/voice-skill-channel-redirect-strip.test.py
+++ b/tests/voice-skill-channel-redirect-strip.test.py
@@ -1,9 +1,10 @@
-"""Structural tests: [channel: <id>] redirect is stripped (not narrated) in
+"""Structural tests: delivery-routing markers are stripped (not narrated) in
 the three voice-skill result-injection paths.
 
 Voice surfaces (phone, discord-voice, task-bridge) cannot route to Discord /
-Slack channels. The correct behavior mirrors Telegram: strip the [channel:]
-marker from the first line and narrate the remaining content.
+Slack channels or attach files. The correct behavior mirrors Telegram: strip
+[channel:] from the first line and strip [file:/send:/attach:] markers
+anywhere in the body, then narrate the remaining content.
 
 These tests grep the source for the required logic without running a live
 server — same pattern used by other structural test files in tests/.
@@ -17,8 +18,9 @@ PHONE_SRV = REPO / "skills/phone-conversation/scripts/conversation-server.ts"
 DVOICE_SRV = REPO / "skills/discord-voice/scripts/discord-voice-server.ts"
 TASK_BRIDGE = REPO / "src/task-bridge.ts"
 
-# Regex substring that must appear in each TS source
+# Regex substrings that must appear in each TS source
 CHANNEL_PATTERN = r"[channel:[^\]]+\]"
+FILE_PATTERN = r"(?:file|send|attach):[^\]]+\]"
 
 passed = 0
 failed = 0
@@ -48,6 +50,12 @@ if CHANNEL_PATTERN in phone_src:
 else:
     fail(name, f"pattern {CHANNEL_PATTERN!r} not found in {PHONE_SRV.name}")
 
+name = "phone: [file:/send:/attach:] strip regex present"
+if FILE_PATTERN in phone_src:
+    ok(name)
+else:
+    fail(name, f"pattern {FILE_PATTERN!r} not found in {PHONE_SRV.name}")
+
 name = "phone: strip is before result injection (resultForNarration used in injectedText)"
 for_narration_pos = phone_src.find("resultForNarration")
 inject_pos = phone_src.find("injectedText")
@@ -57,11 +65,11 @@ else:
     fail(name, f"resultForNarration_pos={for_narration_pos} inject_pos={inject_pos} — strip must precede injection")
 
 name = "phone: fallback preserves result when strip produces empty string"
-# Pattern: `|| result` or `|| resultForNarration` used as fallback
-if "|| result" in phone_src[phone_src.find(CHANNEL_PATTERN):phone_src.find(CHANNEL_PATTERN) + 200]:
+# Pattern: `|| result` used as fallback
+if "|| result" in phone_src[phone_src.find(CHANNEL_PATTERN):phone_src.find(CHANNEL_PATTERN) + 300]:
     ok(name)
 else:
-    fail(name, "no || result fallback within 200 chars of strip regex")
+    fail(name, "no || result fallback within 300 chars of strip regex")
 
 # --- discord-voice-server.ts ---
 
@@ -70,6 +78,12 @@ if CHANNEL_PATTERN in dvoice_src:
     ok(name)
 else:
     fail(name, f"pattern {CHANNEL_PATTERN!r} not found in {DVOICE_SRV.name}")
+
+name = "discord-voice: [file:/send:/attach:] strip regex present"
+if FILE_PATTERN in dvoice_src:
+    ok(name)
+else:
+    fail(name, f"pattern {FILE_PATTERN!r} not found in {DVOICE_SRV.name}")
 
 name = "discord-voice: strip is before resultQueue.push (resultForNarration used)"
 dv_for_narration_pos = dvoice_src.find("resultForNarration")
@@ -81,10 +95,10 @@ else:
 
 name = "discord-voice: fallback preserves result when strip produces empty string"
 dv_pattern_pos = dvoice_src.find(CHANNEL_PATTERN)
-if "|| result" in dvoice_src[dv_pattern_pos:dv_pattern_pos + 200]:
+if "|| result" in dvoice_src[dv_pattern_pos:dv_pattern_pos + 300]:
     ok(name)
 else:
-    fail(name, "no || result fallback within 200 chars of strip regex")
+    fail(name, "no || result fallback within 300 chars of strip regex")
 
 # --- task-bridge.ts ---
 
@@ -94,8 +108,13 @@ if CHANNEL_PATTERN in bridge_src:
 else:
     fail(name, f"pattern {CHANNEL_PATTERN!r} not found in {TASK_BRIDGE.name}")
 
+name = "task-bridge: [file:/send:/attach:] strip regex present"
+if FILE_PATTERN in bridge_src:
+    ok(name)
+else:
+    fail(name, f"pattern {FILE_PATTERN!r} not found in {TASK_BRIDGE.name}")
+
 name = "task-bridge: strip is before onResult call for task-* fallthrough path"
-# The main narration variable _narration or similar
 narration_var_pos = bridge_src.find("_narration")
 on_result_pos = bridge_src.find("onResult(_narration)")
 if narration_var_pos != -1 and on_result_pos != -1 and narration_var_pos < on_result_pos:

--- a/tests/voice-skill-channel-redirect-strip.test.py
+++ b/tests/voice-skill-channel-redirect-strip.test.py
@@ -1,0 +1,116 @@
+"""Structural tests: [channel: <id>] redirect is stripped (not narrated) in
+the three voice-skill result-injection paths.
+
+Voice surfaces (phone, discord-voice, task-bridge) cannot route to Discord /
+Slack channels. The correct behavior mirrors Telegram: strip the [channel:]
+marker from the first line and narrate the remaining content.
+
+These tests grep the source for the required logic without running a live
+server — same pattern used by other structural test files in tests/.
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+PHONE_SRV = REPO / "skills/phone-conversation/scripts/conversation-server.ts"
+DVOICE_SRV = REPO / "skills/discord-voice/scripts/discord-voice-server.ts"
+TASK_BRIDGE = REPO / "src/task-bridge.ts"
+
+# Regex substring that must appear in each TS source
+CHANNEL_PATTERN = r"[channel:[^\]]+\]"
+
+passed = 0
+failed = 0
+
+
+def ok(name: str) -> None:
+    global passed
+    passed += 1
+    print(f"  PASS  {name}")
+
+
+def fail(name: str, reason: str) -> None:
+    global failed
+    failed += 1
+    print(f"  FAIL  {name}: {reason}")
+
+
+phone_src = PHONE_SRV.read_text()
+dvoice_src = DVOICE_SRV.read_text()
+bridge_src = TASK_BRIDGE.read_text()
+
+# --- conversation-server.ts ---
+
+name = "phone: [channel:] strip regex present"
+if CHANNEL_PATTERN in phone_src:
+    ok(name)
+else:
+    fail(name, f"pattern {CHANNEL_PATTERN!r} not found in {PHONE_SRV.name}")
+
+name = "phone: strip is before result injection (resultForNarration used in injectedText)"
+for_narration_pos = phone_src.find("resultForNarration")
+inject_pos = phone_src.find("injectedText")
+if for_narration_pos != -1 and inject_pos != -1 and for_narration_pos < inject_pos:
+    ok(name)
+else:
+    fail(name, f"resultForNarration_pos={for_narration_pos} inject_pos={inject_pos} — strip must precede injection")
+
+name = "phone: fallback preserves result when strip produces empty string"
+# Pattern: `|| result` or `|| resultForNarration` used as fallback
+if "|| result" in phone_src[phone_src.find(CHANNEL_PATTERN):phone_src.find(CHANNEL_PATTERN) + 200]:
+    ok(name)
+else:
+    fail(name, "no || result fallback within 200 chars of strip regex")
+
+# --- discord-voice-server.ts ---
+
+name = "discord-voice: [channel:] strip regex present"
+if CHANNEL_PATTERN in dvoice_src:
+    ok(name)
+else:
+    fail(name, f"pattern {CHANNEL_PATTERN!r} not found in {DVOICE_SRV.name}")
+
+name = "discord-voice: strip is before resultQueue.push (resultForNarration used)"
+dv_for_narration_pos = dvoice_src.find("resultForNarration")
+dv_queue_pos = dvoice_src.find("resultQueue.push(", dv_for_narration_pos) if dv_for_narration_pos != -1 else -1
+if dv_for_narration_pos != -1 and dv_queue_pos != -1 and dv_for_narration_pos < dv_queue_pos:
+    ok(name)
+else:
+    fail(name, f"resultForNarration_pos={dv_for_narration_pos} queue_pos={dv_queue_pos} — strip must precede push")
+
+name = "discord-voice: fallback preserves result when strip produces empty string"
+dv_pattern_pos = dvoice_src.find(CHANNEL_PATTERN)
+if "|| result" in dvoice_src[dv_pattern_pos:dv_pattern_pos + 200]:
+    ok(name)
+else:
+    fail(name, "no || result fallback within 200 chars of strip regex")
+
+# --- task-bridge.ts ---
+
+name = "task-bridge: [channel:] strip regex present"
+if CHANNEL_PATTERN in bridge_src:
+    ok(name)
+else:
+    fail(name, f"pattern {CHANNEL_PATTERN!r} not found in {TASK_BRIDGE.name}")
+
+name = "task-bridge: strip is before onResult call for task-* fallthrough path"
+# The main narration variable _narration or similar
+narration_var_pos = bridge_src.find("_narration")
+on_result_pos = bridge_src.find("onResult(_narration)")
+if narration_var_pos != -1 and on_result_pos != -1 and narration_var_pos < on_result_pos:
+    ok(name)
+else:
+    fail(name, f"_narration_pos={narration_var_pos} onResult_pos={on_result_pos} — strip must precede onResult")
+
+name = "task-bridge: strip is before onResult call for voice-only path"
+voice_narration_pos = bridge_src.find("_voiceNarration")
+voice_on_result_pos = bridge_src.find("onResult(_voiceNarration)")
+if voice_narration_pos != -1 and voice_on_result_pos != -1 and voice_narration_pos < voice_on_result_pos:
+    ok(name)
+else:
+    fail(name, f"_voiceNarration_pos={voice_narration_pos} onResult_pos={voice_on_result_pos} — strip must precede onResult")
+
+# Summary
+print(f"\n{passed + failed} tests: {passed} passed, {failed} failed")
+sys.exit(0 if failed == 0 else 1)


### PR DESCRIPTION
## Summary

Closes part of #1381 item 3 — delivery-routing markers were not handled in phone, discord-voice, or task-bridge voice surfaces. Without this fix:
- A result starting with `[channel: 1234567890123456789]` would be narrated verbatim (including the bracket-id string)
- A result containing `[file: /tmp/report.pdf]` would be narrated as "bracket file colon slash tmp slash report dot pdf bracket"

Voice surfaces can't redirect to Discord/Slack channels or attach files — the messaging bridges handle those. The correct behavior mirrors **Telegram's**: strip the marker(s) and narrate the remaining content.

## Changes

**`[channel: <id>]` strip** (first line only, per protocol spec):
- `skills/phone-conversation/scripts/conversation-server.ts`
- `skills/discord-voice/scripts/discord-voice-server.ts`
- `src/task-bridge.ts` (both voice-only path and task-* fallthrough path)

**`[file:/send:/attach: <path>]` strip** (global — can appear anywhere in body):
- Same three files as above
- Handles multiple inline file markers in a single result body
- Fallback `|| result` preserved so a marker-only body doesn't produce silent narration

## Test plan

- [x] `python3 tests/voice-skill-channel-redirect-strip.test.py` — 12 structural cases (expanded from 9), all passing
- [x] `npx tsc --noEmit` — clean

## Context

From CLAUDE.md: _"Telegram silently drops it — no concept of 'channels' on that surface."_ Same rationale applies to voice surfaces for both `[channel:]` redirects and `[file:]` attachments. Companion to PRs #1555 and #1556 which handled `[deduped:]`/`[no-send]`/`[REPLIED]` skip markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)