### PR TITLE
fix(sync-workspace): re-push a commit the remote never received on a clean tree

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -895,8 +895,45 @@ _push_only_impl() {
     git add -A
     if git diff --cached --quiet; then
         log "_push_only_impl: nothing to commit"
-        echo "sync-workspace: nothing to push (clean working tree)"
-        return 0
+        # A clean tree does NOT mean "done": a prior push may have failed (auth
+        # blip, network, the recovered-from case during first --init) leaving a
+        # local commit that the remote never received. Without this, a transient
+        # push failure leaves the host branch silently stale until the NEXT
+        # content change happens to create a fresh commit.
+        #
+        # Check the remote AUTHORITATIVELY with ls-remote rather than the local
+        # remote-tracking ref: a fetch without --prune leaves a stale
+        # refs/remotes/origin/... ref after the remote branch is gone, which
+        # would falsely read as "up to date" and skip the recovery push.
+        local host_ws_seg local_sha remote_out ls_rc remote_sha
+        host_ws_seg="$(_host_ws_segment)"
+        local_sha="$(git rev-parse HEAD 2>/dev/null || echo "")"
+        remote_out="$(git ls-remote --heads origin "host/${host_ws_seg}" 2>/dev/null)"; ls_rc=$?
+        remote_sha="$(printf '%s\n' "$remote_out" | awk 'NR==1{print $1}')"
+        if [ -z "$local_sha" ]; then
+            echo "sync-workspace: nothing to push (no local commit yet)"
+            return 0
+        fi
+        if [ "$ls_rc" -ne 0 ]; then
+            # Couldn't reach the remote to verify — don't thrash a push that
+            # would also fail; report softly and let the next tick retry.
+            echo "sync-workspace: nothing to push (clean tree; could not reach remote to verify)"
+            return 0
+        fi
+        if [ "$remote_sha" = "$local_sha" ]; then
+            echo "sync-workspace: nothing to push (clean working tree, remote up to date)"
+            return 0
+        fi
+        # ls-remote succeeded but the host branch is missing or behind HEAD →
+        # the local commit was never (fully) pushed. Push it now.
+        if git push origin "HEAD:refs/heads/host/${host_ws_seg}" 2>&1 | tee -a "$LOG" >/dev/null; then
+            log "_push_only_impl: pushed previously-unpushed commit(s) to host/${host_ws_seg}"
+            echo "sync-workspace: pushed previously-unpushed commit(s) to host/${host_ws_seg}"
+            return 0
+        fi
+        log "_push_only_impl: push of unpushed commit(s) failed"
+        echo "sync-workspace: push failed (clean tree, unpushed commit); check $LOG" >&2
+        return 1
     fi
 
     # Mass-deletion tripwire (carried over from sync-memory.sh)

--- a/tests/sync-workspace.test.sh
+++ b/tests/sync-workspace.test.sh
@@ -1241,6 +1241,38 @@ fi
 
 # ============================================================================
 echo
+echo "==== Test 28: clean tree re-pushes a commit the remote never received (push-retry gap) ===="
+# Regression: a failed/lost initial push left the host branch stale because
+# _push_only_impl returned early on a clean tree without checking whether the
+# remote actually has HEAD. Authoritative ls-remote check now recovers it.
+T28_ROOT="$TEST_ROOT/t28"; mkdir -p "$T28_ROOT"
+T28_VAULT="$T28_ROOT/vault.git"; git init -q --bare "$T28_VAULT"
+T28_WS="$T28_ROOT/ws"; mkdir -p "$T28_WS/notes"; echo "n" > "$T28_WS/notes/t28.md"
+t28_env=(SUTANDO_REPO_DIR="$FIXTURE_REPO" SUTANDO_WORKSPACE="$T28_WS" SUTANDO_TEST_MODE=1 SUTANDO_WS_ID_OVERRIDE=t28ws SUTANDO_HOST_OVERRIDE=t28host)
+T28_BR="refs/heads/host/t28host/t28ws"
+env "${t28_env[@]}" bash "$SYNC" --vault-url "$T28_VAULT" --init >/dev/null 2>&1
+# Simulate a lost / never-completed push: branch gone from the vault, tree clean.
+git --git-dir="$T28_VAULT" update-ref -d "$T28_BR" 2>/dev/null
+t28_out=$(env "${t28_env[@]}" bash "$SYNC" --vault-url "$T28_VAULT" --push-only 2>&1)
+if git --git-dir="$T28_VAULT" show-ref --quiet "$T28_BR"; then
+  echo "  OK: clean-tree --push-only restored the unpushed branch to the vault"; pass=$((pass+1))
+else
+  echo "  FAIL: branch not restored; push-only output: $t28_out"; fail=$((fail+1))
+fi
+case "$t28_out" in
+  *"previously-unpushed"*) echo "  OK: push-only reported the recovery push"; pass=$((pass+1)) ;;
+  *) echo "  FAIL: no recovery-push message: $t28_out"; fail=$((fail+1)) ;;
+esac
+# A subsequent clean tick, remote now up to date, must stay a no-op (not re-push forever).
+t28_noop=$(env "${t28_env[@]}" bash "$SYNC" --vault-url "$T28_VAULT" --push-only 2>&1)
+case "$t28_noop" in
+  *"remote up to date"*) echo "  OK: subsequent clean tick is a no-op (remote up to date)"; pass=$((pass+1)) ;;
+  *"previously-unpushed"*) echo "  FAIL: re-pushed when remote already up to date: $t28_noop"; fail=$((fail+1)) ;;
+  *) echo "  FAIL: unexpected no-op output: $t28_noop"; fail=$((fail+1)) ;;
+esac
+
+# ============================================================================
+echo
 echo "===================="
 echo "Total: $((pass+fail)) — pass: $pass, fail: $fail"
 exit $fail


### PR DESCRIPTION
## Problem

`_push_only_impl` (and the default pull+push tick) returns early whenever the working tree is clean:

```sh
git add -A
if git diff --cached --quiet; then
    echo "sync-workspace: nothing to push (clean working tree)"
    return 0          # <-- never checks whether the remote actually has HEAD
fi
```

But a clean tree does **not** mean the remote is in sync. If a prior push failed — an auth blip, a network drop, or the recover-after-first-`--init` case — the local commit was never received by the vault, and there are no new changes to produce a fresh commit. The host branch then stays **silently stale** until some unrelated content change happens to trigger the next commit+push.

This was hit live during workspace-sync setup this session: the first `--init` push failed on auth, and neither a re-`--init` nor `--push-only` would retry the existing commit — it had to be pushed by hand.

## Fix

On a clean tree, check the remote **authoritatively** with `git ls-remote` and push `HEAD` when the host branch is missing or behind:

- `ls-remote` (not the local `refs/remotes/origin/...` tracking ref) — a `fetch` without `--prune` leaves a stale tracking ref after the remote branch is gone, which would falsely read as "up to date" and skip recovery.
- Remote unreachable (`ls-remote` non-zero) → report softly and let the next tick retry, rather than thrashing a push that would also fail.
- Remote already has `HEAD` → unchanged no-op.

## Test

Adds **Test 28**: `--init`, delete the host branch from the bare vault (simulating a lost push), then a clean-tree `--push-only` must (a) restore the branch and (b) report the recovery; a subsequent clean tick with the remote up to date must stay a no-op (no re-push loop). Verified the fixed vs. original behavior directly:

```
MY (fixed):  clean tree + remote branch missing → "pushed previously-unpushed commit(s)" → RESTORED
ORIGINAL:    same scenario → "nothing to push (clean working tree)" → still-missing
```

Existing suite: no regression (same 71 OK / same pre-existing early-exit in sandbox; Test 4 clean-no-op still passes).

## Scope

Single concern; touches only `_push_only_impl` + the new test. Targets `staging-workspace-revamp` (where the sync-workspace code lives; not yet on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)