### PR TITLE
fix(health-check): resolve default memory dir under workspace claude-home (not ~/.claude)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -51,10 +51,20 @@ from workspace_default import resolve_workspace, status_read_path  # noqa: E402
 WORKSPACE_DIR = resolve_workspace()
 
 def _default_memory_dir() -> str:
-    """Auto-detect Claude Code memory dir from repo path."""
+    """Claude Code memory dir under the workspace claude-home.
+
+    Mirrors how Claude Code itself resolves memory: <claude-home>/projects/
+    <slug>/memory. Pre-#1454 this hardcoded ~/.claude/projects/<slug>/memory,
+    which ignored the workspace-scoped CLAUDE_CONFIG_DIR — so on a migrated
+    install the probe read an empty/stale ~/.claude path instead of the
+    workspace memory dir (where Claude Code actually writes and the vault
+    syncs), which forced a SUTANDO_MEMORY_DIR override to compensate.
+    claude_home_path() honors CLAUDE_CONFIG_DIR, falling back to ~/.claude
+    only when it is unset (preserving the old path for ad-hoc launches).
+    """
     repo = Path(__file__).parent.parent.resolve()
     slug = str(repo).replace("/", "-")
-    return str(Path.home() / ".claude" / "projects" / slug / "memory")
+    return str(Path(claude_home_path()) / "projects" / slug / "memory")
 
 MEMORY_DIR = Path(os.environ.get("SUTANDO_MEMORY_DIR", _default_memory_dir()))
 


### PR DESCRIPTION
## Problem

`_default_memory_dir()` hardcoded `~/.claude/projects/<slug>/memory`:

```python
return str(Path.home() / ".claude" / "projects" / slug / "memory")
```

That predates the workspace revamp (#1454), which scopes Claude Code state to `$CLAUDE_CONFIG_DIR = <workspace>/.claude-sutando`. On a migrated install, Claude Code writes memory to `<workspace>/.claude-sutando/projects/<slug>/memory` and the M2 vault syncs it from there — but the health probe kept looking at the stale/empty `~/.claude` path, reporting "0 memory files" and effectively forcing a `SUTANDO_MEMORY_DIR` override to compensate.

## Fix

Use `claude_home_path()` (already imported from `util_paths`) so the default mirrors how Claude Code itself resolves memory — `<claude-home>/projects/<slug>/memory`. It honors `CLAUDE_CONFIG_DIR` and falls back to `~/.claude` only when unset, so ad-hoc launches keep the old path.

## Verification

```
CLAUDE_CONFIG_DIR set, SUTANDO_MEMORY_DIR unset
  → <workspace>/.claude-sutando/projects/<slug>/memory  (memory-dir: ok, 27 .md files)
both unset
  → ~/.claude/projects/<slug>/memory  (old fallback preserved)
```

With this, the `SUTANDO_MEMORY_DIR` override becomes unnecessary in normal runtime (CLAUDE_CONFIG_DIR is set by startup.sh).

## Scope

Single function; targets `staging-workspace-revamp` (the workspace-scoping / `.claude-sutando` concept lives on this line, not yet on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)