### PR TITLE
fix(schedule-crons): remove learned-skills-scan from crons.example.json (#1569)

### DIFF
--- a/skills/schedule-crons/crons.example.json
+++ b/skills/schedule-crons/crons.example.json
@@ -28,10 +28,5 @@
     "name": "obsidian-dream",
     "cron": "37 3 * * *",
     "prompt": "Run python3 skills/obsidian-vault/scripts/dream.py for the nightly LLM-judged vault relink pass (gated by SUTANDO_OBSIDIAN_MIRROR=1 — no-op when unset). Default model: claude-opus-4-7 (override via SUTANDO_DREAM_MODEL)."
-  },
-  {
-    "name": "learned-skills-scan",
-    "cron": "30 7 * * *",
-    "prompt": "Run python3 src/detect-learned-skills.py to scan recent task archives for repeated workflow patterns and propose candidate learned skills. Gated on state/learned-skills-enabled.sentinel (toggled from Settings → Skills → Behavior); the script exits early when the gate is off."
   }
 ]

--- a/tests/start-cli-model-pin.test.py
+++ b/tests/start-cli-model-pin.test.py
@@ -43,7 +43,9 @@ def _launch_argv(model_env: "str | None") -> list[str]:
         pgrep.chmod(0o755)
 
         env = {
-            "PATH": f"{bind}:/usr/bin:/bin",   # no tmux, no brew → fallback path
+            # /usr/bin excluded intentionally: tmux lives there on Ubuntu CI
+            # and the test targets the no-tmux fallback exec path.
+            "PATH": f"{bind}:/bin",
             "HOME": str(td),
             "ARGS_FILE": str(args_file),
         }


### PR DESCRIPTION
## Problem

Closes #1569

\`skills/schedule-crons/crons.example.json\` references \`python3 src/detect-learned-skills.py\` in the \`learned-skills-scan\` entry. That script **does not exist on \`main\`** — it was added in anticipation of PR #1521 (\`feat/detect-learned-skills\`) which is still in review. Users who copy the example to their \`crons.json\` see a \`FileNotFoundError\` each day at 07:30 when the cron fires.

## Change

Removes the \`learned-skills-scan\` entry from \`crons.example.json\`. PR #1521 will re-add it when it merges.

**Second commit**: fixes \`tests/start-cli-model-pin.test.py\` to exclude \`/usr/bin\` from the stub PATH. On Ubuntu CI, \`tmux\` lives at \`/usr/bin/tmux\`, causing the test to take the async tmux path instead of the intended synchronous fallback exec path — a race condition that failed the test. This fix is unrelated to the cron change but was caught during CI investigation.