### PR TITLE
refactor(obsidian-mirror): use canonical resolve_workspace() from workspace_default (#1378)

### DIFF
--- a/src/obsidian-mirror.py
+++ b/src/obsidian-mirror.py
@@ -31,14 +31,8 @@ import time
 from pathlib import Path
 from typing import Optional
 
-
-# ---- Path resolution ----
-
-def resolve_workspace() -> Path:
-    ws = os.environ.get("SUTANDO_WORKSPACE")
-    if ws:
-        return Path(ws).expanduser()
-    return Path.home() / ".sutando" / "workspace"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_default import resolve_workspace  # noqa: E402
 
 
 TASK_ID_RE = re.compile(r"^task-(.+)\.txt$")


### PR DESCRIPTION
## What

Part of #1378 sub-item 1 (workspace-resolution dedup).

`src/obsidian-mirror.py` had its own 5-line copy of `resolve_workspace()`:

```python
def resolve_workspace() -> Path:
    ws = os.environ.get("SUTANDO_WORKSPACE")
    if ws:
        return Path(ws).expanduser()
    return Path.home() / ".sutando" / "workspace"
```

This patch replaces it with the canonical import from `src/workspace_default.py` — the same helper `health-check.py`, `dashboard.py`, `dm-result.py`, `agent-api.py`, `daily-insight.py`, and others already use. Uses the same `sys.path.insert` + `from workspace_default import resolve_workspace` pattern established in those files.

## Why it matters

Any rule change to workspace resolution (e.g. the loud-warn-on-fallback added in #1369) must currently be applied to all 7 copies separately. After this patch one fewer copy exists — future changes propagate automatically to obsidian-mirror.

## Tests

- `python3 src/obsidian-mirror.py --help` passes (script starts correctly with the import).
- Full test suite: 329 TS tests, 43 Python tests — 0 failures.

## Part of

#1378 sub-item 1: workspace-resolution consolidation. Remaining callers with local copies: `skills/screen-companion/tools.ts` (active PR #1409), `skills/overlay-apps/app/control-server.js`, `skills/overlay-apps/app/main.js` (CommonJS — needs separate treatment), `skills/agent-registry/scripts/_workspace_resolve.py` (standalone by design, intentional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)