### PR TITLE
fix(discord-voice): record user utterances at speech-time — fix reversed utterance/tool_call order (closes #1584)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -1338,6 +1338,11 @@ function pcm16ToWav(pcm: Buffer, sampleRate = 16000): Buffer {
 // the audio pipeline, never throws into it. Mirrors describeScreenshot's REST
 // generateContent pattern (src/browser-tools.ts).
 async function transcribeAndRecordUtterance(s: DiscordVoiceSession, userId: string, pcm: Buffer): Promise<void> {
+	// Speech-end time, captured at entry (this fn is invoked from resampler.on('end'),
+	// i.e. the moment the utterance ended). STT below takes ~3s, so we stamp the recorded
+	// row with THIS time, not the post-STT write time — otherwise the utterance sorts AFTER
+	// the tool_call it preceded ("记录反了", Susan 2026-06-09).
+	const _utteranceTsUnix = Date.now() / 1000;
 	// Prefer the GENERAL (paid) key for this background recording STT so it does
 	// NOT compete with — and exhaust — the live voice session's free voice key.
 	// One STT call per utterance per speaker blew GEMINI_VOICE_API_KEY's free-tier
@@ -1458,6 +1463,7 @@ async function transcribeAndRecordUtterance(s: DiscordVoiceSession, userId: stri
 			speakerName: spk?.name,
 			speakerType: 'human',
 			spoken: true,
+			tsUnix: _utteranceTsUnix,  // speech-end time, not post-STT write time (fixes 记录反了)
 		});
 		console.log(`${ts()} [STT] recorded ${userId} (${spk?.name ?? '?'}): "${transcript.slice(0, 60)}"`);
 	} catch (err) {

--- a/src/conversation-store.ts
+++ b/src/conversation-store.ts
@@ -469,6 +469,12 @@ export interface SpeakerMeta {
 	speakerName?: string;      // display name (nickname || username)
 	speakerType?: 'human' | 'agent';
 	spoken?: boolean;          // false = generated but name-gate suppressed (no audio played)
+	// Override the row timestamp (epoch SECONDS). Default is Date.now() at write time.
+	// Needed for per-speaker STT (#1427, Susan 2026-06-09): a user utterance is WRITTEN
+	// ~3s after it was spoken (STT latency), so stamping it at write time sorts it AFTER
+	// the tool_call it actually preceded ("记录反了"). Pass the speech-end time so the
+	// recorded order matches reality.
+	tsUnix?: number;
 }
 
 /** Record a conversation turn. Source is derived from `role` (`phone-*` →
@@ -484,7 +490,7 @@ export function recordConversation(role: string, text: string, sessionId?: strin
 	try {
 		if (source === 'discord-voice') {
 			stmt.run(
-				Date.now() / 1000, kindFromRole(role), text, null, sessionId ?? null,
+				meta?.tsUnix ?? Date.now() / 1000, kindFromRole(role), text, null, sessionId ?? null,
 				meta?.speakerId ?? null,
 				meta?.speakerName ?? null,
 				meta?.speakerType ?? null,


### PR DESCRIPTION
Fixes #1584.

## Problem (observability — independent of any gate)
A user-utterance row is written to the `discord_voice` table at **STT-completion time** (~3s after the user spoke, per-speaker STT latency). The `tool_call` row is written at fire time. So the utterance gets a later `ts_unix` and **sorts AFTER the tool_call it actually preceded** — the sqlite log reads time-reversed.

## Fix
Stamp the utterance at **speech-time**, captured at `transcribeAndRecordUtterance` entry (= utterance end, before the STT round-trip). `SpeakerMeta` gains optional `tsUnix` (epoch seconds); the `discord_voice` insert uses `meta.tsUnix ?? Date.now()/1000` (backward-compatible — all other callers unchanged).

## Live test — before / after (2026-06-09)
```bash
sqlite3 "$SUTANDO_WORKSPACE/data/conversation.sqlite" \
 "SELECT datetime(ts_unix,'unixepoch','localtime') t, kind, substr(text,1,40) txt
  FROM discord_voice ORDER BY ts_unix DESC LIMIT 6;"
```
**BEFORE** — reversed:
```
09:38:35  tool_call  open_url
09:38:37  user       "打开...repository"     ← user AFTER tool_call
```
**AFTER** — correct:
```
10:55:13  user       "Lucy, can you open ... GitHub"   ← user BEFORE tool_call
10:55:14  tool_call  open_github_url
```

## Scope note
This PR is **observability only**. The separate dispatch-gate STT-wait fix (the gate blocking legit requests — a different concern) was removed from this PR per review and is tracked on its own.
