### PR TITLE
fix(ccd): skill-hints guard paths — ~/.claude/skills → $CLAUDE_CONFIG_DIR

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2743,7 +2743,7 @@ async def _handle_discord_message(message, force=False):
     if access_tier in ("team", "other"):
         codex_prompt_text = (
             "You are answering on behalf of Sutando, an autonomous personal AI agent.\n"
-            "Sutando's actual skills live in `skills/` (this repo) and under `~/.claude/skills/`.\n"
+            "Sutando's actual skills live in `skills/` (this repo) and under `$CLAUDE_CONFIG_DIR/skills/`.\n"
             "When asked about capabilities or identity, refer to Sutando's skills/architecture — "
             "NOT to your own sandbox-runtime's available skills. You ARE Sutando in this context.\n\n"
             "---\n\n"
@@ -2901,8 +2901,11 @@ async def _handle_discord_message(message, force=False):
     # Inject skill instructions for owner tasks so the agent follows the
     # notify-before-work and transcription protocol after compaction.
     # Only injected when the referenced skills are installed on this node.
-    _notify_py = Path(os.path.expanduser("~/.claude/skills/task-progress/scripts/notify.py"))
-    _transcribe_py = Path(os.path.expanduser("~/.claude/skills/audio-transcribe/scripts/transcribe.py"))
+    # CCD-resolved (PR #1525 pattern): never hardcode ~/.claude — nodes may relocate
+    # the config dir via $CLAUDE_CONFIG_DIR.
+    _claude_config = Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude")))
+    _notify_py = _claude_config / "skills/task-progress/scripts/notify.py"
+    _transcribe_py = _claude_config / "skills/audio-transcribe/scripts/transcribe.py"
     discord_skill_hints = ""
     if access_tier == "owner" and (_notify_py.exists() or _transcribe_py.exists()):
         channel_id_str = str(message.channel.id)
@@ -2914,7 +2917,7 @@ async def _handle_discord_message(message, force=False):
         step = 1
         if _notify_py.exists():
             notify_cmd = (
-                f"python3 ~/.claude/skills/task-progress/scripts/notify.py"
+                f"python3 {_notify_py}"
                 f" --source discord --channel-id {channel_id_str}"
             )
             if has_audio:
@@ -2924,7 +2927,7 @@ async def _handle_discord_message(message, force=False):
             step += 1
         if has_audio and _transcribe_py.exists():
             attached_path = attachment_note.split("[File attached: ")[-1].rstrip("]").split("\n")[0]
-            lines.append(f"{step}. TRANSCRIBE: python3 ~/.claude/skills/audio-transcribe/scripts/transcribe.py '{attached_path}'")
+            lines.append(f"{step}. TRANSCRIBE: python3 {_transcribe_py} '{attached_path}'")
             step += 1
         lines.append(f"{step}. Process transcript and write result to results/{task_id}.txt")
         discord_skill_hints = "\n" + "\n".join(lines) + "\n"

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -462,15 +462,18 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
     # Inject skill instructions so the agent follows the notify-before-work and
     # transcription protocol even after conversation compaction wipes context.
     # Only injected for owner tasks when the referenced skills are installed.
-    _notify_py = Path(os.path.expanduser("~/.claude/skills/task-progress/scripts/notify.py"))
-    _transcribe_py = Path(os.path.expanduser("~/.claude/skills/audio-transcribe/scripts/transcribe.py"))
+    # CCD-resolved (PR #1525 pattern): never hardcode ~/.claude — nodes may relocate
+    # the config dir via $CLAUDE_CONFIG_DIR.
+    _claude_config = Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude")))
+    _notify_py = _claude_config / "skills/task-progress/scripts/notify.py"
+    _transcribe_py = _claude_config / "skills/audio-transcribe/scripts/transcribe.py"
     skill_hints = ""
     if access_tier == "owner" and (_notify_py.exists() or _transcribe_py.exists()):
         hints_lines = ["===SKILL INSTRUCTIONS (follow before any other action)==="]
         step = 1
         if _notify_py.exists():
             notify_cmd = (
-                f"python3 ~/.claude/skills/task-progress/scripts/notify.py"
+                f"python3 {_notify_py}"
                 f" --source slack --channel-id {channel}"
                 f' --message "On it — back in a moment."'
             )
@@ -484,7 +487,7 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
                         f'   Update notify message to: --message "Got your voice message, give me a moment."'
                     )
                 hints_lines.append(
-                    f"{step}. TRANSCRIBE: python3 ~/.claude/skills/audio-transcribe/scripts/transcribe.py '{attached_path}'"
+                    f"{step}. TRANSCRIBE: python3 {_transcribe_py} '{attached_path}'"
                 )
                 step += 1
         hints_lines.append(f"{step}. Then process and write result to results/{task_id}.txt")

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -554,8 +554,11 @@ def main():
                 # Inject skill instructions so the agent follows notify-before-work
                 # and transcription protocol even after conversation compaction.
                 # Only injected when the referenced skills are installed on this node.
-                _notify_py = Path(os.path.expanduser("~/.claude/skills/task-progress/scripts/notify.py"))
-                _transcribe_py = Path(os.path.expanduser("~/.claude/skills/audio-transcribe/scripts/transcribe.py"))
+                # CCD-resolved (PR #1525 pattern): never hardcode ~/.claude — nodes may relocate
+                # the config dir via $CLAUDE_CONFIG_DIR.
+                _claude_config = Path(os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude")))
+                _notify_py = _claude_config / "skills/task-progress/scripts/notify.py"
+                _transcribe_py = _claude_config / "skills/audio-transcribe/scripts/transcribe.py"
                 has_audio_attach = attachment_note and any(
                     attachment_note.lower().find(ext) != -1
                     for ext in (".m4a", ".mp3", ".ogg", ".opus", ".oga", ".wav", ".webm", ".aac")
@@ -566,7 +569,7 @@ def main():
                     step = 1
                     if _notify_py.exists():
                         notify_cmd = (
-                            f"python3 ~/.claude/skills/task-progress/scripts/notify.py"
+                            f"python3 {_notify_py}"
                             f" --source telegram --chat-id {chat_id}"
                         )
                         if has_audio_attach:
@@ -576,7 +579,7 @@ def main():
                         step += 1
                     if has_audio_attach and _transcribe_py.exists():
                         attached_path = attachment_note.split("[File attached: ")[-1].rstrip("]").split("\n")[0]
-                        lines.append(f"{step}. TRANSCRIBE: python3 ~/.claude/skills/audio-transcribe/scripts/transcribe.py '{attached_path}'")
+                        lines.append(f"{step}. TRANSCRIBE: python3 {_transcribe_py} '{attached_path}'")
                         step += 1
                     lines.append(f"{step}. Process transcript and write result to results/{task_id}.txt")
                     tg_skill_hints = "\n" + "\n".join(lines) + "\n"


### PR DESCRIPTION
Follow-up to #1467 (merged today). Its skill-instruction injection hardcoded `~/.claude/skills/` in all three bridges — guards **and** injected command text, 6 sites — bypassing `CLAUDE_CONFIG_DIR`. This is the same class #1525 cleaned up; on nodes with a relocated config dir the existence guards check a tree the config doesn't point to.

## Change
- Per-bridge `_claude_config` local (the #1525 / bot2bot-post pattern): `Path(os.environ.get("CLAUDE_CONFIG_DIR", ~/.claude))`
- Injected command text now carries the **resolved absolute path** — self-describing task files shouldn't depend on the agent's shell env
- Paths kept as single slash-joined segments so the source stays greppable (`tests/bridge-skill-hints-injection.test.py` passes unmodified)
- Also fixed the sandbox-instructions docs string in discord-bridge (`~/.claude/skills` → `$CLAUDE_CONFIG_DIR/skills`)

## Test plan
- [x] Full local Python suite green (incl. the 22-case bridge-skill-hints-injection test, unmodified)
- [x] All three bridges parse clean

Note: `skills/install.sh` still targets hardcoded `~/.claude/skills` — left out of scope here (single concern); flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)