### PR TITLE
fix(discord-voice): #1600 M2+M3 — bare-name / CJK summons wake the group-active gate (叫不醒)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -2057,7 +2057,11 @@ async function createVoiceSession(connection: VoiceConnection, client: Client): 
 				// utterance — not only while meetingEntered. decideForTurn only
 				// (no meetingMode flipping on this path).
 				if (!VOICE_CONTROLLER && s.gate && !s.meetingEntered && ((s as any)._humanCount ?? 1) >= 2) {
-					decideForTurn(s.gate, item.content);
+					// forceGate=true (#1600 M3): the group regime must re-acquire the
+					// addressed bit even with no SUTANDO_PEER_NAMES configured, else
+					// decideForTurn's no-peer early-return skips the update and a
+					// reconnect-cleared gate stays muted — the bare-name "叫不醒".
+					decideForTurn(s.gate, item.content, true);
 				}
 				if (!VOICE_CONTROLLER && s.gate && s.meetingEntered) {
 					const addressed = decideForTurn(s.gate, item.content) !== 'drop';

--- a/skills/discord-voice/scripts/name-gate.ts
+++ b/skills/discord-voice/scripts/name-gate.ts
@@ -135,6 +135,50 @@ export function createGate(cfg: GateConfig): GateState {
 	};
 }
 
+// CJK address/imperative verbs — a Chinese summons names the bot then issues a
+// request ("露西帮我看下屏幕" = Lucy, help me look at the screen). These are the
+// CJK analogue of ADDRESS_VERBS: a mention verb like 说 (said) is deliberately
+// EXCLUDED so "露西说的那个" (the thing Lucy said) is NOT treated as a summons.
+const CJK_ADDRESS_VERBS = [
+	'帮', '给', '打开', '看', '查', '告诉', '搜', '读', '念', '设置', '播放',
+	'放', '调', '找', '显示', '截', '复制', '粘贴', '开', '关', '解释', '翻译',
+	'记', '存', '发', '回答', '听', '过来', '醒',
+];
+
+/**
+ * Bare-name / CJK-imperative summons (#1600 M2). The greet/comma/verb matchers
+ * in isAddressedBy MISS the single most common live call pattern — a bare name
+ * with nothing after it ("Lucy" / "Lucy." / "Loosey") and a Chinese name +
+ * imperative ("露西帮我看下屏幕"). Both are unambiguous summons yet matched
+ * NEITHER isAddressedBy NOR isWakePhrase, so after a reconnect cleared the
+ * sticky addressed bit the group-active gate stayed muted ("叫不醒"). This is
+ * OR-ed into the addressing decision (decideForTurn), NOT into isWakePhrase —
+ * a bare name ANSWERS one turn but does not flip meeting→active (that still
+ * needs a deliberate wake phrase), preserving the no-false-wake property.
+ *
+ * Safe against passing mentions: rule (1) fires ONLY when the WHOLE normalized
+ * utterance IS the name ("I told Lucy" → "i told lucy" ≠ "lucy" → no match);
+ * rule (2) fires only on a CJK name at the very start immediately followed by
+ * an imperative verb (mention verbs like 说 are excluded).
+ */
+export function isBareSummons(text: string, names: string[]): boolean {
+	if (!text || names.length === 0) return false;
+	const norm = normalizeSpoken(text);
+	if (!norm) return false;
+	for (const raw of names) {
+		const n = normalizeSpoken(raw);
+		if (!n) continue;
+		// (1) bare standalone name — the entire utterance is just the name.
+		if (norm === n) return true;
+		// (2) CJK name at the start + (optional space) + an imperative/request verb.
+		if (/[一-鿿]/.test(n) && norm.startsWith(n)) {
+			const rest = norm.slice(n.length).trimStart();
+			if (rest && CJK_ADDRESS_VERBS.some(v => rest.startsWith(v))) return true;
+		}
+	}
+	return false;
+}
+
 /**
  * Detect an explicit "standby / go quiet" command. Standby phrases are bare
  * command words ("standby", "待命"), not name-addressed imperatives, so this is
@@ -165,16 +209,22 @@ export function isStandby(text: string, standbyVariants: string[]): boolean {
  * and (via createGate) starts silent. Legacy mode keeps the old "no peer →
  * always allow" shortcut so non-meeting single-bot deployments are unchanged.
  */
-export function decideForTurn(state: GateState, userText: string): Decision {
+export function decideForTurn(state: GateState, userText: string, forceGate = false): Decision {
 	// Standby: explicit "go silent but stay" — re-silences until next name cue.
 	if (isStandby(userText, state.standbyVariants)) {
 		state.lastAddressedToMe = false;
 		return 'drop';
 	}
 	// Legacy single-bot (no peers, not meeting mode): gate disabled, allow all.
-	if (!state.cfg.meetingMode && state.otherVariants.length === 0) return 'allow';
-	const haveMyName = isAddressedBy(userText, state.nameVariants);
-	const haveOtherName = state.otherVariants.length > 0 && isAddressedBy(userText, state.otherVariants);
+	// forceGate overrides this — the population-aware group regime (#1600 M3)
+	// needs real addressing gating even with no peer instances configured, so it
+	// can re-acquire the sticky addressed bit after a reconnect cleared it
+	// (otherwise this early-return would skip the lastAddressedToMe update and
+	// the group-active gate would stay muted = "叫不醒").
+	if (!forceGate && !state.cfg.meetingMode && state.otherVariants.length === 0) return 'allow';
+	const haveMyName = isAddressedBy(userText, state.nameVariants) || isBareSummons(userText, state.nameVariants);
+	const haveOtherName = state.otherVariants.length > 0
+		&& (isAddressedBy(userText, state.otherVariants) || isBareSummons(userText, state.otherVariants));
 	if (haveMyName) state.lastAddressedToMe = true;
 	else if (haveOtherName) state.lastAddressedToMe = false;
 	return state.lastAddressedToMe ? 'allow' : 'drop';

--- a/tests/discord-voice-classifier-stall-repro.test.ts
+++ b/tests/discord-voice-classifier-stall-repro.test.ts
@@ -1,0 +1,109 @@
+/**
+ * #1600 M2 + M3 — ACCEPTANCE gate for the group-active "叫不醒" wake-path fix.
+ *
+ * Was a red repro (current behavior characterized); now the fix is in, so the
+ * bare-name MISS cases flip to WAKE and the muted-reply chain plays. Covers the
+ * real 2026-06-10 Susan+Chi session call phrasings (from workspace sqlite).
+ *
+ * The two compounding mechanisms this gates:
+ *  M2 — bare "Lucy" / "Lucy." / "Loosey" and CJK "露西帮我看下屏幕" matched
+ *       NEITHER isAddressedBy NOR isWakePhrase → never addressed. Fixed by
+ *       isBareSummons (bare standalone name + CJK name-imperative).
+ *  M3 — after a reconnect cleared the sticky addressed bit (restore-active sets
+ *       lastAddressedToMe=false), the group-active gate required addressing; the
+ *       bare-name miss left it muted, so the model's generated reply was
+ *       suppressed ("🔇[muted] 当然可以…"). Fixed because the widened matcher +
+ *       forceGate re-acquire the addressed bit → gate opens → reply plays.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { decideSpeak } from '../skills/discord-voice/scripts/speak-gate.ts';
+import { isAddressedBy, isWakePhrase, isBareSummons, createGate, decideForTurn } from '../skills/discord-voice/scripts/name-gate.ts';
+
+const NAMES = ['Lucy', 'Lucie', 'Luci', 'Loosey', '露西', '露茜'];
+// How the live (legacy, no-controller) gate now derives "addressed": the
+// deterministic matchers, widened with isBareSummons.
+const detAddressed = (t: string) => isAddressedBy(t, NAMES) || isWakePhrase(t, NAMES) || isBareSummons(t, NAMES);
+
+describe('#1600 M2 — bare-name / CJK-imperative now wake (was 叫不醒)', () => {
+	it('bare standalone name → addressed', () => {
+		assert.equal(detAddressed('Lucy'), true);
+		assert.equal(detAddressed('Lucy.'), true);
+		assert.equal(detAddressed('Loosey'), true);
+		assert.equal(detAddressed('露西'), true);
+	});
+	it('CJK name + imperative → addressed', () => {
+		assert.equal(detAddressed('露西帮我看下屏幕'), true);
+		assert.equal(detAddressed('露西，帮我看下屏幕'), true);
+		assert.equal(detAddressed('露西打开那个链接'), true);
+	});
+	it('still matches the greet / comma / verb forms', () => {
+		assert.equal(detAddressed('Lucy, can you turn the brightness up'), true);
+		assert.equal(detAddressed('Hi Lucy, wake up'), true);
+		assert.equal(detAddressed('Loosey are you there'), true);
+	});
+	it('does NOT over-match passing mentions (no false interjection)', () => {
+		assert.equal(detAddressed('I told Lucy the answer'), false);
+		assert.equal(detAddressed('thanks Lucy'), false);
+		assert.equal(detAddressed('露西说的那个问题'), false);   // 说 = mention, not a summons
+		assert.equal(detAddressed('露西说的对'), false);
+	});
+	it('isBareSummons is precise on its own', () => {
+		assert.equal(isBareSummons('Lucy', NAMES), true);
+		assert.equal(isBareSummons('lucy.', NAMES), true);
+		assert.equal(isBareSummons('hey everyone Lucy is here', NAMES), false);
+		assert.equal(isBareSummons('露西帮我', NAMES), true);
+		assert.equal(isBareSummons('露西讲个笑话', NAMES), false); // 讲 not in the imperative set
+	});
+});
+
+describe('#1600 M3 — reconnect-cleared group gate re-opens on a bare name', () => {
+	// Reproduce the live chain WITHOUT a controller and WITHOUT peer names
+	// (PEER_NAMES defaults empty) — exactly Susan's config.
+	const mkGate = () => createGate({ instanceName: 'Lucy', nameAliases: ['Loosey', '露西'], primary: true, meetingMode: false });
+
+	it('after restore-active cleared the bit, an UNADDRESSED group turn stays muted', () => {
+		const g = mkGate();
+		g.lastAddressedToMe = false;                       // what reconnect restore-active leaves
+		decideForTurn(g, 'so what do you think about the design', true);
+		const d = decideSpeak({ humanCount: 2, meetingMode: false, addressedToMe: g.lastAddressedToMe, allowAck: false, forceAudible: false });
+		assert.equal(d.speak, false, 'unaddressed group turn correctly stays silent (no false interjection)');
+	});
+
+	it('a bare "Lucy" re-acquires the addressed bit → reply NOT muted', () => {
+		const g = mkGate();
+		g.lastAddressedToMe = false;                       // muted post-reconnect
+		decideForTurn(g, 'Lucy', true);                    // the call that used to miss
+		assert.equal(g.lastAddressedToMe, true, 'forceGate + isBareSummons re-acquired addressing');
+		const d = decideSpeak({ humanCount: 2, meetingMode: false, addressedToMe: g.lastAddressedToMe, allowAck: false, forceAudible: false });
+		assert.equal(d.speak, true, 'gate opens → the generated reply plays (M3 unmuted)');
+		assert.equal(d.reason, 'group-active-addressed');
+	});
+
+	it('CJK summon also re-opens the gate', () => {
+		const g = mkGate();
+		g.lastAddressedToMe = false;
+		decideForTurn(g, '露西帮我看下屏幕', true);
+		assert.equal(g.lastAddressedToMe, true);
+		assert.equal(decideSpeak({ humanCount: 2, meetingMode: false, addressedToMe: g.lastAddressedToMe, allowAck: false, forceAudible: false }).speak, true);
+	});
+});
+
+describe('REAL Chi-session checklist — all calls now wake', () => {
+	const WAKES = [
+		'Hey, Lucy, will you open up that link and tell me the title',
+		'Yeah, hi Lucy, connected to Discord screen.',
+		'Lucy, can you turn the brightness up.',
+		'Lucy, show me some new stuff.',
+		'Lucy, what time is it?',
+		'Hi Lucy, can you hear me?',
+		'Lucy, show me your favorite dog breed.',
+		'Hi Lucy',
+		'Lucy, wake up.',
+		'Lucy, 我和驰需要讨论一个事情，你可以 stay in meeting mode 吗？',
+		'Lucy', 'Lucy.', 'Loosey',          // the bare-name calls that used to 叫不醒
+	];
+	for (const t of WAKES) {
+		it(`✅ wakes: ${JSON.stringify(t.slice(0, 40))}`, () => assert.equal(detAddressed(t), true));
+	}
+});


### PR DESCRIPTION
## What

Fixes the remaining two #1600 wake-path failures (**M2** bare-name miss + **M3** active-mode mis-mute) that made the #1427 meeting-buddy unwakeable in group active mode. Companion to #1601 (M1, reconnect latch reset). Targets the #1427 meeting-buddy branch.

## Root cause (one chain)

reconnect (M1) → restore-active sets `lastAddressedToMe=false` → group-active gate now requires addressing → Susan calls bare **"Lucy"** → `isAddressedBy` **misses** (M2) → the gate mutes the model's *generated* reply (M3: `🔇[muted] 当然可以…`). Bare `"Lucy"` / `"Lucy."` / `"Loosey"` and `"露西帮我看下屏幕"` matched **neither** `isAddressedBy` **nor** `isWakePhrase` — the single most common call pattern was exactly the one that missed. Compounded because `PEER_NAMES` defaults empty, so `decideForTurn`'s no-peer early-return also skipped updating the gate.

## Changes (minimal, M2/M3-only — M1 is #1601)

- **`name-gate.ts`** — new pure `isBareSummons(text, names)`: bare standalone name (whole utterance == name) + CJK name-imperative (`露西` + 帮/打开/看/…). OR-ed into `decideForTurn`. Precise against passing mentions — `"I told Lucy"` / `"露西说的那个"` do **not** match (mention verb 说 excluded). **Not** wired into `isWakePhrase` — a bare name *answers one turn* but does not flip meeting→active, so the no-false-wake property holds. **(M2)**
- **`name-gate.ts`** — `decideForTurn(state, text, forceGate=false)`: `forceGate` overrides the no-peer "gate disabled" early-return so the population-aware group regime re-acquires the addressed bit even with no `SUTANDO_PEER_NAMES`. Default `false` → every other call site unchanged. **(M3)**
- **`discord-voice-server.ts`** — pass `forceGate=true` at the single legacy group-active call site.

## Verification

- **432/432 voice tests green.**
- `tests/discord-voice-classifier-stall-repro.test.ts` flipped from red repro → green acceptance: bare/CJK summons now wake; **unaddressed group turns still stay silent** (no false interjection — the property #1600 verified was clean); the reconnect→bare-name→unmuted chain asserted end-to-end on Susan's exact config (no controller, no peer names).
- Real 2026-06-10 Chi-session call phrasings all wake (incl. the bare-name calls that 叫不醒).

🎙 **Voice-touching → needs Susan's manual live test** (talk in a group VC, call bare "Lucy", confirm it answers) before merge.

Issue: #1600. Scope: M2+M3. M1 = #1601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)