### PR TITLE
fix(cwd-lint): extend coverage to skills/ — fix 3 violations (#863)

### DIFF
--- a/skills/call-diagnostics/scripts/diagnose.py
+++ b/skills/call-diagnostics/scripts/diagnose.py
@@ -28,9 +28,7 @@ from pathlib import Path
 #   1. --metrics <path>           — explicit jsonl override (back-compat)
 #   2. data/conversation.sqlite   — primary as of #603 (sessions table)
 #   3. data/call-metrics.jsonl    — frozen archive fallback
-_cwd_path = Path.cwd() / "data" / "call-metrics.jsonl"
-_script_path = Path(__file__).resolve().parents[3] / "data" / "call-metrics.jsonl"
-METRICS_PATH = _cwd_path if _cwd_path.exists() else _script_path
+METRICS_PATH = Path(__file__).resolve().parents[3] / "data" / "call-metrics.jsonl"
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 from workspace_default import resolve_workspace  # noqa: E402

--- a/skills/gws-gmail-voice/tools.ts
+++ b/skills/gws-gmail-voice/tools.ts
@@ -31,10 +31,11 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
+import { resolveWorkspace } from '../../src/workspace_default.js';
 
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 
-const CACHE_PATH = join(process.cwd(), 'state', 'external-cache', 'inbox-important.json');
+const CACHE_PATH = join(resolveWorkspace(), 'state', 'external-cache', 'inbox-important.json');
 // 30 min TTL: balances cache-hit rate (~95% at 30min vs ~70% at 15min) against
 // staleness. Live gws fallback covers the freshness edge case anyway. Per Mini PR #704 review.
 const CACHE_MAX_AGE_MS = 30 * 60 * 1000;

--- a/skills/obsidian-vault/tools.ts
+++ b/skills/obsidian-vault/tools.ts
@@ -165,7 +165,7 @@ const runDreamTool: ToolDefinition = {
     parameters: z.object({}),
     execute: async () => {
         try {
-            const scriptPath = `${process.env.SUTANDO_REPO_DIR || process.cwd()}/skills/obsidian-vault/scripts/dream.py`;
+            const scriptPath = new URL('./scripts/dream.py', import.meta.url).pathname;
             // Fire-and-forget: detach so the voice turn returns immediately.
             // `--force` bypasses the SUTANDO_OBSIDIAN_MIRROR opt-in gate
             // because this is an explicit user invocation (the user said

--- a/tests/cwd-lint.test.py
+++ b/tests/cwd-lint.test.py
@@ -11,15 +11,22 @@ set but the write lands in the repo root.  Issue #863.
 
 ## What is checked
 
-TypeScript (src/ + scripts/):
+TypeScript (src/ + scripts/ + skills/):
   - Fail on any non-comment line containing `process.cwd()`
-  - Allowlist: none needed (workspace_default.ts / util_paths.ts mention it
-    only in docblocks; the canonical resolver uses $env + homedir(), not cwd)
+  - Allowlist: skills/obsidian-vault/tools.ts used process.cwd() as a repo-dir
+    fallback for a Python script path — fixed in #1601-class PR; no allowlist
+    entries needed after the fix.
 
-Python (src/ + scripts/):
+Python (src/ + scripts/ + skills/):
   - Fail on any non-comment line containing `Path.cwd()` or `os.getcwd()`
-  - Allowlist: src/workspace_default.py (uses Path.cwd() for relative-path
-    anchor in _expand_tilde, which is correct and intentional)
+  - Allowlist:
+    - src/workspace_default.py (uses Path.cwd() for relative-path anchor in
+      _expand_tilde, which is correct and intentional)
+    - skills/open-sutando-ref/scripts/resolve.py (last-resort os.getcwd()
+      fallback when walking up dirs looking for .git root — not workspace
+      resolution)
+    - skills/agent-registry/scripts/registry-client.py (passes os.getcwd() as
+      metadata "cwd" field to subprocess, not as workspace path)
 
 Read-only static analysis; no fixtures, no networking.  Runs in <300 ms.
 """
@@ -31,6 +38,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 SRC  = REPO / "src"
 SCRIPTS = REPO / "scripts"
+SKILLS = REPO / "skills"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -69,11 +77,11 @@ def _scan_files(roots: list[Path], extensions: tuple[str, ...]) -> list[Path]:
 # ---------------------------------------------------------------------------
 
 TS_CWD_RE = re.compile(r'\bprocess\.cwd\(\)')
-TS_ALLOWLIST: set[str] = set()  # no files need allowlisting today
+TS_ALLOWLIST: set[str] = set()  # no legitimate uses in src/scripts/skills after fixes
 
 def check_ts_cwd() -> list[str]:
     failures = []
-    ts_files = _scan_files([SRC, SCRIPTS], (".ts", ".tsx", ".js", ".mjs"))
+    ts_files = _scan_files([SRC, SCRIPTS, SKILLS], (".ts", ".tsx", ".js", ".mjs"))
     for path in ts_files:
         rel = path.relative_to(REPO)
         if str(rel) in TS_ALLOWLIST:
@@ -90,12 +98,14 @@ def check_ts_cwd() -> list[str]:
 
 PY_CWD_RE = re.compile(r'\bPath\.cwd\(\)|\bos\.getcwd\(\)')
 PY_ALLOWLIST = {
-    "src/workspace_default.py",  # uses Path.cwd() to anchor relative env-var paths
+    "src/workspace_default.py",                              # relative env-var path anchor
+    "skills/open-sutando-ref/scripts/resolve.py",            # git-root finder (not workspace)
+    "skills/agent-registry/scripts/registry-client.py",     # subprocess cwd metadata field
 }
 
 def check_py_cwd() -> list[str]:
     failures = []
-    py_files = _scan_files([SRC, SCRIPTS], (".py",))
+    py_files = _scan_files([SRC, SCRIPTS, SKILLS], (".py",))
     for path in py_files:
         rel = path.relative_to(REPO)
         if str(rel) in PY_ALLOWLIST:
@@ -120,6 +130,9 @@ def sanity_checks() -> list[str]:
     for f in ("src/workspace_default.ts", "src/workspace_default.py"):
         if not (REPO / f).exists():
             errs.append(f"canonical resolver '{f}' is missing")
+    # skills/ directory must exist (so we don't silently skip it)
+    if not SKILLS.exists():
+        errs.append(f"skills/ directory missing at {SKILLS}")
     return errs
 
 
@@ -153,6 +166,6 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
-    ts_count = len(_scan_files([SRC, SCRIPTS], (".ts", ".tsx", ".js", ".mjs")))
-    py_count = len(_scan_files([SRC, SCRIPTS], (".py",)))
+    ts_count = len(_scan_files([SRC, SCRIPTS, SKILLS], (".ts", ".tsx", ".js", ".mjs")))
+    py_count = len(_scan_files([SRC, SCRIPTS, SKILLS], (".py",)))
     print(f"cwd-lint: OK — {ts_count} TS files, {py_count} Python files, 0 violations")


### PR DESCRIPTION
## Summary

- `cwd-lint` only scanned `src/` and `scripts/`; `skills/` was invisible, allowing 3 violations to accumulate undetected
- Fixes all 3, adds allowlist entries for 2 legitimate non-workspace uses, extends lint to cover 45 TS + 77 Python files (up from 27+37)

## Violations fixed

| File | Old | Fixed |
|------|-----|-------|
| `skills/gws-gmail-voice/tools.ts` | `process.cwd()/state/...` | `resolveWorkspace()/state/...` |
| `skills/obsidian-vault/tools.ts` | `SUTANDO_REPO_DIR\|\|process.cwd()` for script path | `import.meta.url`-relative URL |
| `skills/call-diagnostics/scripts/diagnose.py` | `Path.cwd()/"data"/...` dual-probe | `__file__`-relative path directly |

## Allowlisted (legitimate)

- `skills/open-sutando-ref/scripts/resolve.py`: `os.getcwd()` last-resort in a `.git`-root finder — not workspace resolution
- `skills/agent-registry/scripts/registry-client.py`: `os.getcwd()` as subprocess `cwd` metadata field — not a workspace path

## Test plan

- [x] `python3 tests/cwd-lint.test.py` → `OK — 45 TS files, 77 Python files, 0 violations`
- [x] `gws-gmail-voice` cache now lands in `$SUTANDO_WORKSPACE/state/external-cache/` (correct) instead of `<repo>/state/external-cache/` (wrong when `SUTANDO_WORKSPACE` is set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)