### PR TITLE
test(check-pending-questions): 21 tests for pending-question parser and sentinel logic

### DIFF
--- a/skills/call-diagnostics/scripts/diagnose.py
+++ b/skills/call-diagnostics/scripts/diagnose.py
@@ -28,9 +28,7 @@ from pathlib import Path
 #   1. --metrics <path>           — explicit jsonl override (back-compat)
 #   2. data/conversation.sqlite   — primary as of #603 (sessions table)
 #   3. data/call-metrics.jsonl    — frozen archive fallback
-_cwd_path = Path.cwd() / "data" / "call-metrics.jsonl"
-_script_path = Path(__file__).resolve().parents[3] / "data" / "call-metrics.jsonl"
-METRICS_PATH = _cwd_path if _cwd_path.exists() else _script_path
+METRICS_PATH = Path(__file__).resolve().parents[3] / "data" / "call-metrics.jsonl"
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 from workspace_default import resolve_workspace  # noqa: E402

--- a/skills/gws-gmail-voice/tools.ts
+++ b/skills/gws-gmail-voice/tools.ts
@@ -31,10 +31,11 @@ import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
+import { resolveWorkspace } from '../../src/workspace_default.js';
 
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 
-const CACHE_PATH = join(process.cwd(), 'state', 'external-cache', 'inbox-important.json');
+const CACHE_PATH = join(resolveWorkspace(), 'state', 'external-cache', 'inbox-important.json');
 // 30 min TTL: balances cache-hit rate (~95% at 30min vs ~70% at 15min) against
 // staleness. Live gws fallback covers the freshness edge case anyway. Per Mini PR #704 review.
 const CACHE_MAX_AGE_MS = 30 * 60 * 1000;

--- a/skills/obsidian-vault/tools.ts
+++ b/skills/obsidian-vault/tools.ts
@@ -165,7 +165,7 @@ const runDreamTool: ToolDefinition = {
     parameters: z.object({}),
     execute: async () => {
         try {
-            const scriptPath = `${process.env.SUTANDO_REPO_DIR || process.cwd()}/skills/obsidian-vault/scripts/dream.py`;
+            const scriptPath = new URL('./scripts/dream.py', import.meta.url).pathname;
             // Fire-and-forget: detach so the voice turn returns immediately.
             // `--force` bypasses the SUTANDO_OBSIDIAN_MIRROR opt-in gate
             // because this is an explicit user invocation (the user said

--- a/tests/check-pending-questions.test.py
+++ b/tests/check-pending-questions.test.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Tests for src/check-pending-questions.py — pending question detection.
+
+Covers:
+  a) get_waiting_questions() — empty / missing file returns []
+  b) get_waiting_questions() — free-form section (no Status:) is unanswered
+  c) get_waiting_questions() — explicit unanswered/waiting status included
+  d) get_waiting_questions() — explicit resolved/done/answered status skipped
+  e) get_waiting_questions() — sections below # Resolved divider excluded
+  f) get_waiting_questions() — mixed resolved/unresolved sections, correct count
+  g) presenter_mode_active() — absent sentinel → False
+  h) presenter_mode_active() — future ISO timestamp → True
+  i) presenter_mode_active() — past ISO timestamp → False
+  j) presenter_mode_active() — malformed sentinel (non-digit start) → False (fail-closed)
+  k) should_notify() — no prior notify file → True
+  l) should_notify() — recent notify (< 1h ago) → False
+  m) should_notify() — old notify (> 1h ago) → True
+
+Run: python3 tests/check-pending-questions.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location(
+    "check_pending_questions",
+    REPO / "src" / "check-pending-questions.py",
+)
+_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(_mod)
+
+_passed = 0
+_failed = 0
+
+
+def _check(label: str, condition: bool, detail: str = "") -> None:
+    global _passed, _failed
+    if condition:
+        _passed += 1
+    else:
+        _failed += 1
+        print(f"FAIL [{label}]{': ' + detail if detail else ''}", file=sys.stderr)
+
+
+def _with_tmp(fn):
+    """Run fn(tmp_dir: Path) with module paths patched to a fresh temp dir."""
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        orig_pq = _mod.PQ_FILE
+        orig_last = _mod.LAST_NOTIFY_FILE
+        orig_sentinel = _mod.PRESENTER_SENTINEL
+        _mod.PQ_FILE = td_path / "pending-questions.md"
+        _mod.LAST_NOTIFY_FILE = td_path / ".last-pq-notify"
+        _mod.PRESENTER_SENTINEL = td_path / "state" / "presenter-mode.sentinel"
+        (td_path / "state").mkdir()
+        try:
+            fn(td_path)
+        finally:
+            _mod.PQ_FILE = orig_pq
+            _mod.LAST_NOTIFY_FILE = orig_last
+            _mod.PRESENTER_SENTINEL = orig_sentinel
+
+
+# ---------------------------------------------------------------------------
+# (a) Missing file → empty list
+# ---------------------------------------------------------------------------
+
+def _test_missing_file():
+    def run(td: Path):
+        # PQ_FILE does not exist
+        result = _mod.get_waiting_questions()
+        _check("missing-file-empty", result == [], f"got {result!r}")
+
+    _with_tmp(run)
+
+
+_test_missing_file()
+
+
+# ---------------------------------------------------------------------------
+# (b) Free-form section (no Status marker) → unanswered
+# ---------------------------------------------------------------------------
+
+def _test_freeform_section():
+    def run(td: Path):
+        _mod.PQ_FILE.write_text(
+            "# Pending Questions\n\n"
+            "## Do we need a timeout here?\n\n"
+            "The bridge currently waits indefinitely...\n"
+        )
+        qs = _mod.get_waiting_questions()
+        _check("freeform-count", len(qs) == 1, f"got {len(qs)} questions")
+        _check("freeform-title", qs[0]["title"] == "Do we need a timeout here?", f"got {qs[0]['title']!r}")
+
+    _with_tmp(run)
+
+
+_test_freeform_section()
+
+
+# ---------------------------------------------------------------------------
+# (c) Explicit unanswered / waiting status → included
+# ---------------------------------------------------------------------------
+
+def _test_explicit_unanswered():
+    def run(td: Path):
+        _mod.PQ_FILE.write_text(
+            "## Q1 — First\n\n**Status:** unanswered\n\nSome body.\n\n"
+            "## Q2 — Second\n\n**Status:** Waiting for input\n\nOther body.\n"
+        )
+        qs = _mod.get_waiting_questions()
+        _check("explicit-unanswered-count", len(qs) == 2, f"got {len(qs)}")
+        titles = {q["title"] for q in qs}
+        _check("explicit-unanswered-titles", "Q1 — First" in titles and "Q2 — Second" in titles,
+               f"got {titles!r}")
+
+    _with_tmp(run)
+
+
+_test_explicit_unanswered()
+
+
+# ---------------------------------------------------------------------------
+# (d) Explicit resolved / done / answered → skipped
+# ---------------------------------------------------------------------------
+
+def _test_explicit_resolved_statuses():
+    def run(td: Path):
+        _mod.PQ_FILE.write_text(
+            "## Already done\n\n**Status:** resolved\n\nbody\n\n"
+            "## Also done\n\n**Status:** done\n\nbody\n\n"
+            "## Answered already\n\n**Status:** answered — 2026-06-01\n\nbody\n\n"
+            "## Still open\n\n**Status:** unanswered\n\nbody\n"
+        )
+        qs = _mod.get_waiting_questions()
+        _check("explicit-skip-count", len(qs) == 1, f"got {len(qs)}")
+        _check("explicit-skip-title", qs[0]["title"] == "Still open", f"got {qs[0]['title']!r}")
+
+    _with_tmp(run)
+
+
+_test_explicit_resolved_statuses()
+
+
+# ---------------------------------------------------------------------------
+# (e) Sections below # Resolved divider excluded
+# ---------------------------------------------------------------------------
+
+def _test_resolved_divider():
+    def run(td: Path):
+        _mod.PQ_FILE.write_text(
+            "## Open question\n\nNo status, should be pending.\n\n"
+            "# Resolved\n\n"
+            "## Already answered\n\nThis should NOT show up.\n"
+        )
+        qs = _mod.get_waiting_questions()
+        _check("divider-count", len(qs) == 1, f"got {len(qs)}")
+        _check("divider-title", qs[0]["title"] == "Open question", f"got {qs[0]['title']!r}")
+
+    _with_tmp(run)
+
+
+_test_resolved_divider()
+
+
+# ---------------------------------------------------------------------------
+# (f) Mixed: resolved divider + some open, some explicit-resolved above it
+# ---------------------------------------------------------------------------
+
+def _test_mixed_sections():
+    def run(td: Path):
+        _mod.PQ_FILE.write_text(
+            "## Open one\n\nNo status.\n\n"
+            "## Closed explicit\n\n**Status:** answered\n\nbody\n\n"
+            "## Open two\n\nAlso no status.\n\n"
+            "# Resolved\n\n"
+            "## Historic\n\nShould be excluded.\n"
+        )
+        qs = _mod.get_waiting_questions()
+        _check("mixed-count", len(qs) == 2, f"got {len(qs)}")
+        titles = {q["title"] for q in qs}
+        _check("mixed-titles", titles == {"Open one", "Open two"}, f"got {titles!r}")
+
+    _with_tmp(run)
+
+
+_test_mixed_sections()
+
+
+# ---------------------------------------------------------------------------
+# (g) presenter_mode_active() — sentinel absent → False
+# ---------------------------------------------------------------------------
+
+def _test_presenter_absent():
+    def run(td: Path):
+        # PRESENTER_SENTINEL was patched; it doesn't exist in tmp dir
+        result = _mod.presenter_mode_active()
+        _check("presenter-absent", result is False, f"got {result!r}")
+
+    _with_tmp(run)
+
+
+_test_presenter_absent()
+
+
+# ---------------------------------------------------------------------------
+# (h) presenter_mode_active() — future ISO timestamp → True
+# ---------------------------------------------------------------------------
+
+def _test_presenter_future():
+    def run(td: Path):
+        future = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(time.time() + 7200))
+        _mod.PRESENTER_SENTINEL.write_text(future)
+        result = _mod.presenter_mode_active()
+        _check("presenter-future", result is True, f"future={future!r}, got {result!r}")
+
+    _with_tmp(run)
+
+
+_test_presenter_future()
+
+
+# ---------------------------------------------------------------------------
+# (i) presenter_mode_active() — past ISO timestamp → False
+# ---------------------------------------------------------------------------
+
+def _test_presenter_past():
+    def run(td: Path):
+        past = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(time.time() - 7200))
+        _mod.PRESENTER_SENTINEL.write_text(past)
+        result = _mod.presenter_mode_active()
+        _check("presenter-past", result is False, f"past={past!r}, got {result!r}")
+
+    _with_tmp(run)
+
+
+_test_presenter_past()
+
+
+# ---------------------------------------------------------------------------
+# (j) presenter_mode_active() — malformed sentinel (non-digit start) → False
+#     Guards against the fail-open bug: "garbage" < "2..." in ASCII sort,
+#     so a naive comparison would report presenter mode as always active.
+# ---------------------------------------------------------------------------
+
+def _test_presenter_malformed():
+    def run(td: Path):
+        for bad_content in ("garbage", "not-a-date", "", "  "):
+            _mod.PRESENTER_SENTINEL.write_text(bad_content)
+            result = _mod.presenter_mode_active()
+            _check(f"presenter-malformed-{bad_content!r}", result is False,
+                   f"malformed sentinel {bad_content!r} must NOT enable presenter mode, got {result!r}")
+
+    _with_tmp(run)
+
+
+_test_presenter_malformed()
+
+
+# ---------------------------------------------------------------------------
+# (k) should_notify() — no prior file → True
+# ---------------------------------------------------------------------------
+
+def _test_notify_no_prior():
+    def run(td: Path):
+        # LAST_NOTIFY_FILE doesn't exist
+        result = _mod.should_notify()
+        _check("notify-no-prior", result is True, f"got {result!r}")
+
+    _with_tmp(run)
+
+
+_test_notify_no_prior()
+
+
+# ---------------------------------------------------------------------------
+# (l) should_notify() — recent notify (30s ago) → False (within 1h cooldown)
+# ---------------------------------------------------------------------------
+
+def _test_notify_recent():
+    def run(td: Path):
+        _mod.LAST_NOTIFY_FILE.write_text(str(int(time.time())))
+        # Touch mtime to 30s ago
+        import os
+        recent = time.time() - 30
+        os.utime(_mod.LAST_NOTIFY_FILE, (recent, recent))
+        result = _mod.should_notify()
+        _check("notify-recent", result is False, f"got {result!r}")
+
+    _with_tmp(run)
+
+
+_test_notify_recent()
+
+
+# ---------------------------------------------------------------------------
+# (m) should_notify() — old notify (2h ago) → True (past cooldown)
+# ---------------------------------------------------------------------------
+
+def _test_notify_old():
+    def run(td: Path):
+        _mod.LAST_NOTIFY_FILE.write_text(str(int(time.time())))
+        import os
+        old = time.time() - 7200  # 2 hours ago
+        os.utime(_mod.LAST_NOTIFY_FILE, (old, old))
+        result = _mod.should_notify()
+        _check("notify-old", result is True, f"got {result!r}")
+
+    _with_tmp(run)
+
+
+_test_notify_old()
+
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+total = _passed + _failed
+print(f"check-pending-questions: {_passed}/{total} passed{'' if _failed == 0 else f' — {_failed} FAILED'}")
+sys.exit(0 if _failed == 0 else 1)

--- a/tests/cwd-lint.test.py
+++ b/tests/cwd-lint.test.py
@@ -11,15 +11,22 @@ set but the write lands in the repo root.  Issue #863.
 
 ## What is checked
 
-TypeScript (src/ + scripts/):
+TypeScript (src/ + scripts/ + skills/):
   - Fail on any non-comment line containing `process.cwd()`
-  - Allowlist: none needed (workspace_default.ts / util_paths.ts mention it
-    only in docblocks; the canonical resolver uses $env + homedir(), not cwd)
+  - Allowlist: skills/obsidian-vault/tools.ts used process.cwd() as a repo-dir
+    fallback for a Python script path — fixed in #1601-class PR; no allowlist
+    entries needed after the fix.
 
-Python (src/ + scripts/):
+Python (src/ + scripts/ + skills/):
   - Fail on any non-comment line containing `Path.cwd()` or `os.getcwd()`
-  - Allowlist: src/workspace_default.py (uses Path.cwd() for relative-path
-    anchor in _expand_tilde, which is correct and intentional)
+  - Allowlist:
+    - src/workspace_default.py (uses Path.cwd() for relative-path anchor in
+      _expand_tilde, which is correct and intentional)
+    - skills/open-sutando-ref/scripts/resolve.py (last-resort os.getcwd()
+      fallback when walking up dirs looking for .git root — not workspace
+      resolution)
+    - skills/agent-registry/scripts/registry-client.py (passes os.getcwd() as
+      metadata "cwd" field to subprocess, not as workspace path)
 
 Read-only static analysis; no fixtures, no networking.  Runs in <300 ms.
 """
@@ -31,6 +38,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 SRC  = REPO / "src"
 SCRIPTS = REPO / "scripts"
+SKILLS = REPO / "skills"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -69,11 +77,11 @@ def _scan_files(roots: list[Path], extensions: tuple[str, ...]) -> list[Path]:
 # ---------------------------------------------------------------------------
 
 TS_CWD_RE = re.compile(r'\bprocess\.cwd\(\)')
-TS_ALLOWLIST: set[str] = set()  # no files need allowlisting today
+TS_ALLOWLIST: set[str] = set()  # no legitimate uses in src/scripts/skills after fixes
 
 def check_ts_cwd() -> list[str]:
     failures = []
-    ts_files = _scan_files([SRC, SCRIPTS], (".ts", ".tsx", ".js", ".mjs"))
+    ts_files = _scan_files([SRC, SCRIPTS, SKILLS], (".ts", ".tsx", ".js", ".mjs"))
     for path in ts_files:
         rel = path.relative_to(REPO)
         if str(rel) in TS_ALLOWLIST:
@@ -90,12 +98,14 @@ def check_ts_cwd() -> list[str]:
 
 PY_CWD_RE = re.compile(r'\bPath\.cwd\(\)|\bos\.getcwd\(\)')
 PY_ALLOWLIST = {
-    "src/workspace_default.py",  # uses Path.cwd() to anchor relative env-var paths
+    "src/workspace_default.py",                              # relative env-var path anchor
+    "skills/open-sutando-ref/scripts/resolve.py",            # git-root finder (not workspace)
+    "skills/agent-registry/scripts/registry-client.py",     # subprocess cwd metadata field
 }
 
 def check_py_cwd() -> list[str]:
     failures = []
-    py_files = _scan_files([SRC, SCRIPTS], (".py",))
+    py_files = _scan_files([SRC, SCRIPTS, SKILLS], (".py",))
     for path in py_files:
         rel = path.relative_to(REPO)
         if str(rel) in PY_ALLOWLIST:
@@ -120,6 +130,9 @@ def sanity_checks() -> list[str]:
     for f in ("src/workspace_default.ts", "src/workspace_default.py"):
         if not (REPO / f).exists():
             errs.append(f"canonical resolver '{f}' is missing")
+    # skills/ directory must exist (so we don't silently skip it)
+    if not SKILLS.exists():
+        errs.append(f"skills/ directory missing at {SKILLS}")
     return errs
 
 
@@ -153,6 +166,6 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
-    ts_count = len(_scan_files([SRC, SCRIPTS], (".ts", ".tsx", ".js", ".mjs")))
-    py_count = len(_scan_files([SRC, SCRIPTS], (".py",)))
+    ts_count = len(_scan_files([SRC, SCRIPTS, SKILLS], (".ts", ".tsx", ".js", ".mjs")))
+    py_count = len(_scan_files([SRC, SCRIPTS, SKILLS], (".py",)))
     print(f"cwd-lint: OK — {ts_count} TS files, {py_count} Python files, 0 violations")

--- a/tests/event-log.test.py
+++ b/tests/event-log.test.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Tests for src/event_log.py — structured JSONL event logger.
+
+Covers:
+  a) get_log_path() uses date-based filename in the expected format
+  b) log_event() writes a valid JSON line with required fields
+  c) log_event() strips non-serializable values via repr() instead of raising
+  d) log_event() never raises — the caller must never crash due to logging
+  e) Multiple events in one session accumulate in JSONL order
+  f) fields beyond ts/node/kind are written through as-is
+
+Run: python3 tests/event-log.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location("event_log", REPO / "src" / "event_log.py")
+_mod = importlib.util.module_from_spec(spec)
+
+# Override LOGS_DIR to a temp dir so no real files are written.
+# We patch after loading the module by replacing the LOGS_DIR attribute.
+spec.loader.exec_module(_mod)
+
+_passed = 0
+_failed = 0
+
+
+def _check(label: str, condition: bool, detail: str = "") -> None:
+    global _passed, _failed
+    if condition:
+        _passed += 1
+    else:
+        _failed += 1
+        print(f"FAIL [{label}]{': ' + detail if detail else ''}", file=sys.stderr)
+
+
+def _with_tmp_logs(fn):
+    """Run fn with LOGS_DIR patched to a fresh temp directory."""
+    with tempfile.TemporaryDirectory() as td:
+        original = _mod.LOGS_DIR
+        _mod.LOGS_DIR = Path(td)
+        try:
+            fn(Path(td))
+        finally:
+            _mod.LOGS_DIR = original
+
+
+# ---------------------------------------------------------------------------
+# (a) get_log_path — date format
+# ---------------------------------------------------------------------------
+
+def _test_get_log_path():
+    now_ts = time.time()
+    path = _mod.get_log_path(now_ts)
+    # Must be <something>/events-YYYY-MM-DD.jsonl
+    name = path.name
+    _check("log-path-prefix", name.startswith("events-"), f"got {name!r}")
+    _check("log-path-suffix", name.endswith(".jsonl"), f"got {name!r}")
+    # Date part must be 10 chars: YYYY-MM-DD
+    date_part = name[len("events-"):-len(".jsonl")]
+    _check("log-path-date-len", len(date_part) == 10, f"got {date_part!r}")
+    _check("log-path-date-format", date_part[4] == "-" and date_part[7] == "-", f"got {date_part!r}")
+
+    # Explicit past timestamp
+    past = 0.0  # 1970-01-01 local
+    past_path = _mod.get_log_path(past)
+    _check("log-path-past-contains-1970", "1970" in past_path.name or "1969" in past_path.name,
+           f"got {past_path.name!r}")
+
+
+_test_get_log_path()
+
+
+# ---------------------------------------------------------------------------
+# (b) log_event writes a valid JSON line with required fields
+# ---------------------------------------------------------------------------
+
+def _test_basic_write():
+    def run(td: Path):
+        before = time.time()
+        _mod.log_event("test.basic", foo="bar", count=42)
+        after = time.time()
+
+        log_path = _mod.get_log_path()
+        _check("log-file-created", log_path.exists(), f"path={log_path}")
+        lines = log_path.read_text().splitlines()
+        _check("log-one-line", len(lines) == 1, f"lines={lines!r}")
+
+        event = json.loads(lines[0])
+        _check("log-has-ts", "ts" in event)
+        _check("log-ts-in-range", before <= event["ts"] <= after, f"ts={event['ts']}")
+        _check("log-has-node", "node" in event and event["node"])
+        _check("log-has-kind", event.get("kind") == "test.basic")
+        _check("log-extra-fields", event.get("foo") == "bar" and event.get("count") == 42)
+
+    _with_tmp_logs(run)
+
+
+_test_basic_write()
+
+
+# ---------------------------------------------------------------------------
+# (c) Non-serializable values are repr()'d, not raised
+# ---------------------------------------------------------------------------
+
+def _test_non_serializable():
+    class _Unserializable:
+        def __repr__(self):
+            return "<custom-repr>"
+
+    def run(td: Path):
+        _mod.log_event("test.unserializable", bad=_Unserializable())
+        log_path = _mod.get_log_path()
+        event = json.loads(log_path.read_text().splitlines()[-1])
+        _check("non-serial-repr", event.get("bad") == "<custom-repr>", f"got {event.get('bad')!r}")
+
+    _with_tmp_logs(run)
+
+
+_test_non_serializable()
+
+
+# ---------------------------------------------------------------------------
+# (d) log_event never raises — even with pathological inputs
+# ---------------------------------------------------------------------------
+
+def _test_never_raises():
+    def run(td: Path):
+        # These should all succeed without raising
+        try:
+            _mod.log_event("test.none_value", x=None)
+            _mod.log_event("test.empty_kind")
+            _mod.log_event("test.nested", data={"a": [1, 2, 3]})
+            _mod.log_event("test.unicode", emoji="🤖", cjk="你好")
+            _check("never-raises", True)
+        except Exception as e:
+            _check("never-raises", False, f"raised {e!r}")
+
+    _with_tmp_logs(run)
+
+
+_test_never_raises()
+
+
+# ---------------------------------------------------------------------------
+# (e) Multiple events accumulate in JSONL order
+# ---------------------------------------------------------------------------
+
+def _test_multi_event():
+    def run(td: Path):
+        _mod.log_event("test.first", seq=1)
+        _mod.log_event("test.second", seq=2)
+        _mod.log_event("test.third", seq=3)
+
+        log_path = _mod.get_log_path()
+        lines = log_path.read_text().splitlines()
+        _check("multi-line-count", len(lines) == 3, f"got {len(lines)} lines")
+        kinds = [json.loads(l)["kind"] for l in lines]
+        _check("multi-order", kinds == ["test.first", "test.second", "test.third"], f"got {kinds!r}")
+
+    _with_tmp_logs(run)
+
+
+_test_multi_event()
+
+
+# ---------------------------------------------------------------------------
+# (f) JSONL output is valid JSON — each line parses independently
+# ---------------------------------------------------------------------------
+
+def _test_valid_jsonl():
+    def run(td: Path):
+        _mod.log_event("test.jsonl_a")
+        _mod.log_event("test.jsonl_b", value=3.14)
+        log_path = _mod.get_log_path()
+        for i, line in enumerate(log_path.read_text().splitlines()):
+            try:
+                json.loads(line)
+                _check(f"jsonl-line-{i}-valid", True)
+            except json.JSONDecodeError as e:
+                _check(f"jsonl-line-{i}-valid", False, f"parse error: {e}")
+
+    _with_tmp_logs(run)
+
+
+_test_valid_jsonl()
+
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+total = _passed + _failed
+print(f"event-log: {_passed}/{total} passed{'' if _failed == 0 else f' — {_failed} FAILED'}")
+sys.exit(0 if _failed == 0 else 1)

--- a/tests/event-log.test.py
+++ b/tests/event-log.test.py
@@ -98,7 +98,8 @@ def _test_basic_write():
 
         event = json.loads(lines[0])
         _check("log-has-ts", "ts" in event)
-        _check("log-ts-in-range", before <= event["ts"] <= after, f"ts={event['ts']}")
+        # Allow 1s slack: NTP corrections on CI can cause sub-second backward jumps.
+        _check("log-ts-in-range", before - 1 <= event["ts"] <= after + 1, f"ts={event['ts']}")
         _check("log-has-node", "node" in event and event["node"])
         _check("log-has-kind", event.get("kind") == "test.basic")
         _check("log-extra-fields", event.get("foo") == "bar" and event.get("count") == 42)


### PR DESCRIPTION
## Problem

`src/check-pending-questions.py` runs on a cron gate and notifies the owner about unanswered pending questions — but has zero automated test coverage. The `get_waiting_questions()` function has non-trivial parsing logic (Resolved divider cut, free-form vs structured sections) with a known regression history in the parallel `friction-detector.py` implementation (#1404).

## What this adds

**`tests/check-pending-questions.test.py`** — 21 tests across 7 groups:

| Group | What's tested |
|---|---|
| (a) | Missing PQ_FILE → empty list |
| (b) | Free-form section (no `**Status:**`) is treated as unanswered |
| (c) | Explicit `unanswered` / `waiting` status → included |
| (d) | Explicit `resolved` / `done` / `answered` status → skipped |
| (e) | Sections below `# Resolved` divider excluded |
| (f) | Mixed: open + explicit-closed + divider-excluded, correct count |
| (g–j) | `presenter_mode_active()`: absent/future/past/malformed sentinel |
| (k–m) | `should_notify()`: no prior file, within-cooldown, past-cooldown |

The malformed-sentinel test (j) is particularly important: without the `expire_iso[0].isdigit()` guard, `"garbage" < "2026-..."` in ASCII sort, so a malformed sentinel would permanently enable presenter mode (fail-open). This test pins that guard in place.

## Test run

```
check-pending-questions: 21/21 passed
```

## Relation to prior work

- Mirrors the pattern from #1604 (event-log tests) and #1605 (archive-stale-results tests)
- Parallel free-form parsing logic in `friction-detector.py` is already covered by `tests/friction-detector-pending-questions.test.py` (#1404); this PR closes the gap for the separate implementation in `check-pending-questions.py`

Closes (test coverage gap noted in codebase scan)