### PR TITLE
fix(health-check): bridge staleness check ignores foreign-checkout processes (#1650 followup)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1035,11 +1035,17 @@ def run_all_checks() -> list[dict]:
         # not in effect because nobody restarted the bridge after merge).
         try:
             src_file = REPO_DIR / "src" / f"{name}.py"
-            if src_file.exists() and pids:
+            # Same cross-checkout guard as mark_stale_if_outdated: only a
+            # process belonging to THIS checkout is ours to judge stale.
+            # Deliberately scoped to the staleness comparison — checks 1-3/5/6
+            # keep the unfiltered pids so "running"/heartbeat/inode semantics
+            # for a bridge launched from another clone are unchanged.
+            own_pids = _filter_pids_this_checkout(pids) if pids else []
+            if src_file.exists() and own_pids:
                 src_mtime = src_file.stat().st_mtime
                 # Use ps to get process start time as Unix epoch
                 ps_out = subprocess.run(
-                    ["/bin/ps", "-o", "lstart=", "-p", pids[0]],
+                    ["/bin/ps", "-o", "lstart=", "-p", own_pids[0]],
                     capture_output=True, text=True, timeout=5
                 ).stdout.strip()
                 if ps_out:


### PR DESCRIPTION
## What

The followup deliberately scoped out of #1650: the bridges' inline **Check 4** pgreps `{name}\.py$` — which matches a bridge launched from **any** clone on the machine — then compares this repo's src mtime against that foreign process's start time. Same perpetual cross-checkout `stale — restart needed` false positive #1650 fixed for the tsx services, just on the bridge path.

## How

Filter through `_filter_pids_this_checkout` (the helper #1650 introduces) for the **staleness comparison only**. Checks 1-3/5/6 keep the unfiltered pid list, so "running", heartbeat, dead-inode, and log-content semantics for a bridge running from another clone are unchanged — the exact semantics concern that kept this out of #1650.

## Verification

Synthetic A/B repro (foreign fake bridge `python3 /tmp/fakebridge/telegram-bridge.py` with cwd outside the repo; this repo's `telegram-bridge.py` given an uncommitted edit + mtime +2h so the git cross-check doesn't suppress):

| | telegram-bridge check |
|---|---|
| pre-fix | `♻ stale — running but code is 120 min newer than process` |
| post-fix | `✓ ok — running` |

"Running" detection confirmed intact post-fix (the foreign process still counts for liveness, as before).

## Stacking

Based on `fix/health-stale-cross-checkout` (#1650) since it uses `_filter_pids_this_checkout` from that branch — same pattern as #1653. GitHub retargets to `main` automatically when #1650 merges. Suggested merge order: #1653 → #1650 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)