### PR TITLE
fix(quota-tracker): vendor launchd credential-proxy outside TCC-protected paths

### DIFF
--- a/src/install-credential-proxy-launchd.sh
+++ b/src/install-credential-proxy-launchd.sh
@@ -5,22 +5,33 @@
 # automatic restart on crash + ThrottleInterval to prevent the EADDRINUSE
 # crash-loop described in issue #1086.
 #
+# TCC safety: launchd's bash has no Documents/Desktop access grant, so the
+# job must not read anything that resolves into the repo checkout (commonly
+# ~/Documents/... or ~/Desktop/... — including through the
+# ~/.claude/skills/quota-tracker/scripts symlink). Install therefore VENDORS
+# the job into $LAUNCHD_DIR (outside TCC scope): the proxy is esbuild-bundled
+# to a single node-runnable .mjs and the wrapper is copied next to it. After
+# pulling changes to credential-proxy.ts, re-run install to re-vendor.
+#
 # Usage:
 #   bash src/install-credential-proxy-launchd.sh             # install
 #   bash src/install-credential-proxy-launchd.sh --uninstall # remove
 #   bash src/install-credential-proxy-launchd.sh --status    # print job state
 #
-# Idempotent: re-running install bootouts the existing job and reloads so a
-# git pull that changes the template is picked up.
+# Idempotent: re-running install bootouts the existing job, re-vendors, and
+# reloads so a git pull that changes the template or proxy is picked up.
 
 set -e
 
 LABEL="com.sutando.credential-proxy"
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 TEMPLATE="$REPO/src/launchd/$LABEL.plist"
+WRAPPER_SRC="$REPO/src/launchd/credential-proxy-wrapper.sh"
 DEST="$HOME/Library/LaunchAgents/$LABEL.plist"
 DOMAIN="gui/$(id -u)"
 SERVICE="$DOMAIN/$LABEL"
+LAUNCHD_DIR="$HOME/.sutando/launchd"
+PROXY_SRC="$HOME/.claude/skills/quota-tracker/scripts/credential-proxy.ts"
 
 if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   WORKSPACE="${SUTANDO_WORKSPACE/#\~/$HOME}"
@@ -57,20 +68,33 @@ case "$cmd" in
             echo "ERROR: template not found: $TEMPLATE" >&2
             exit 1
         fi
-        if [ ! -f "$HOME/.claude/skills/quota-tracker/scripts/credential-proxy.ts" ]; then
+        if [ ! -f "$PROXY_SRC" ]; then
             echo "ERROR: quota-tracker skill not found at ~/.claude/skills/quota-tracker/" >&2
             echo "  Install it first — credential-proxy.ts is the proxy target." >&2
             exit 1
         fi
+        ESBUILD="$REPO/node_modules/.bin/esbuild"
+        if [ ! -x "$ESBUILD" ]; then
+            echo "ERROR: esbuild not found at $ESBUILD — run npm install in the repo first." >&2
+            exit 1
+        fi
         BREW_BIN="$(resolve_brew_bin)"
         echo "Installing $LABEL"
-        echo "  repo:      $REPO"
-        echo "  workspace: $WORKSPACE"
-        echo "  brew bin:  $BREW_BIN"
+        echo "  repo:       $REPO"
+        echo "  workspace:  $WORKSPACE"
+        echo "  vendor dir: $LAUNCHD_DIR"
+        echo "  brew bin:   $BREW_BIN"
         mkdir -p "$HOME/Library/LaunchAgents"
         mkdir -p "$WORKSPACE/logs"
+        mkdir -p "$LAUNCHD_DIR"
+        # Vendor: single node-runnable bundle (proxy + its repo-local imports),
+        # so the launchd job never reads through the repo checkout at runtime.
+        "$ESBUILD" "$PROXY_SRC" --bundle --platform=node --format=esm \
+            --outfile="$LAUNCHD_DIR/credential-proxy.mjs" --log-level=warning
+        cp "$WRAPPER_SRC" "$LAUNCHD_DIR/credential-proxy-wrapper.sh"
+        chmod +x "$LAUNCHD_DIR/credential-proxy-wrapper.sh"
         sed \
-            -e "s|__REPO__|$REPO|g" \
+            -e "s|__LAUNCHD_DIR__|$LAUNCHD_DIR|g" \
             -e "s|__WORKSPACE__|$WORKSPACE|g" \
             -e "s|__BREW_BIN__|$BREW_BIN|g" \
             -e "s|__HOME__|$HOME|g" \
@@ -83,6 +107,7 @@ case "$cmd" in
         echo "  • View status:  bash $0 --status"
         echo "  • Uninstall:    bash $0 --uninstall"
         echo "  • Logs:         $WORKSPACE/logs/credential-proxy.log"
+        echo "  • After changing credential-proxy.ts: re-run install to re-vendor."
         ;;
     --uninstall|uninstall)
         echo "Uninstalling $LABEL"
@@ -93,6 +118,8 @@ case "$cmd" in
         else
             echo "  (no plist on disk; nothing to remove)"
         fi
+        rm -f "$LAUNCHD_DIR/credential-proxy.mjs" "$LAUNCHD_DIR/credential-proxy-wrapper.sh"
+        rmdir "$LAUNCHD_DIR" 2>/dev/null || true
         echo "Done."
         ;;
     --status|status)

--- a/src/launchd/com.sutando.credential-proxy.plist
+++ b/src/launchd/com.sutando.credential-proxy.plist
@@ -20,11 +20,18 @@
       exec'ing the real proxy, so the first boot after a manual run
       doesn't immediately fail with EADDRINUSE.
     - StandardOut/Err → workspace logs (not /tmp) so postmortems work.
+    - TCC safety: launchd's bash has no Documents/Desktop access grant, so
+      ProgramArguments and WorkingDirectory must NOT resolve into the repo
+      checkout (commonly under ~/Documents or ~/Desktop — reading anything
+      there fails with "Operation not permitted", exit 126 crash-loop).
+      The installer vendors the wrapper + an esbuild bundle of the proxy
+      into __LAUNCHD_DIR__ (outside TCC scope) and points this job there.
 
   Placeholders substituted by install-credential-proxy-launchd.sh:
-    __REPO__      — absolute path to the sutando repo checkout
-    __WORKSPACE__ — absolute path to $SUTANDO_WORKSPACE
-    __BREW_BIN__  — /opt/homebrew/bin or /usr/local/bin
+    __LAUNCHD_DIR__ — vendored job dir (default $HOME/.sutando/launchd)
+    __WORKSPACE__   — absolute path to $SUTANDO_WORKSPACE
+    __BREW_BIN__    — /opt/homebrew/bin or /usr/local/bin
+    __HOME__        — the user's home directory
 -->
 <plist version="1.0">
 <dict>
@@ -34,11 +41,11 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
-        <string>__REPO__/src/launchd/credential-proxy-wrapper.sh</string>
+        <string>__LAUNCHD_DIR__/credential-proxy-wrapper.sh</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>__REPO__</string>
+    <string>__HOME__</string>
 
     <key>KeepAlive</key>
     <true/>

--- a/src/launchd/credential-proxy-wrapper.sh
+++ b/src/launchd/credential-proxy-wrapper.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Wrapper for launchd-managed credential-proxy.
-# 
+#
+# Runs the esbuild-bundled proxy (credential-proxy.mjs) that the installer
+# vendors NEXT TO this script, outside any TCC-protected directory. launchd's
+# bash has no Documents/Desktop TCC grant, so nothing in this job's runtime
+# path may resolve into the repo checkout — not the wrapper, not the proxy
+# script, not its imports. The bundle's only runtime dependency is `node`.
+#
 # Kills any stale holder of port 7846 before starting, preventing the
 # EADDRINUSE crash-loop that occurs when a manually-started process is still
 # running when launchd tries to bootstrap (issue #1086).
@@ -10,39 +16,26 @@
 
 set -euo pipefail
 
-# Resolve the credential-proxy script path (tilde-expanded at run time).
-PROXY_SCRIPT="$HOME/.claude/skills/quota-tracker/scripts/credential-proxy.ts"
+# The installer copies this wrapper and the bundle into the same directory.
+PROXY_BUNDLE="$(cd "$(dirname "$0")" && pwd)/credential-proxy.mjs"
 
-# Resolve npx — launchd doesn't inherit the user's shell PATH.
-resolve_npx() {
+# Resolve node — launchd doesn't inherit the user's shell PATH.
+resolve_node() {
     for p in \
-        /opt/homebrew/bin/npx \
-        /usr/local/bin/npx \
-        "$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin/npx" \
-        "$HOME/.volta/bin/npx"
+        /opt/homebrew/bin/node \
+        /usr/local/bin/node \
+        "$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin/node" \
+        "$HOME/.volta/bin/node"
     do
         [ -x "$p" ] && { echo "$p"; return; }
     done
-    command -v npx 2>/dev/null || { echo "ERROR: npx not found" >&2; exit 1; }
-}
-
-# Resolve tsx — prefer direct binary to avoid npx overhead on restart paths.
-resolve_tsx() {
-    for p in \
-        /opt/homebrew/bin/tsx \
-        /usr/local/bin/tsx \
-        "$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin/tsx" \
-        "$HOME/.volta/bin/tsx"
-    do
-        [ -x "$p" ] && { echo "$p"; return; }
-    done
-    return 1  # fall through to npx tsx
+    command -v node 2>/dev/null || { echo "ERROR: node not found" >&2; exit 1; }
 }
 
 PORT=7846
 
 # Kill any stale process holding port 7846. Defensive: only kill if the
-# holder is running credential-proxy.ts (same script); avoids killing
+# holder is running credential-proxy (same target); avoids killing
 # unrelated processes that coincidentally claimed the port.
 kill_stale_holder() {
     local pid
@@ -61,11 +54,10 @@ kill_stale_holder() {
 
 kill_stale_holder
 
-# Resolve and run.
-TSX_BIN=$(resolve_tsx 2>/dev/null) || true
-if [ -n "${TSX_BIN:-}" ]; then
-    exec "$TSX_BIN" "$PROXY_SCRIPT"
-else
-    NPX_BIN=$(resolve_npx)
-    exec "$NPX_BIN" tsx "$PROXY_SCRIPT"
+if [ ! -f "$PROXY_BUNDLE" ]; then
+    echo "ERROR: bundle not found at $PROXY_BUNDLE — re-run src/install-credential-proxy-launchd.sh" >&2
+    exit 1
 fi
+
+NODE_BIN=$(resolve_node)
+exec "$NODE_BIN" "$PROXY_BUNDLE"


### PR DESCRIPTION
## Problem

The launchd job installed by `src/install-credential-proxy-launchd.sh` crash-loops with exit 126 (`Operation not permitted`, one respawn per ThrottleInterval, forever) whenever the repo checkout lives under a TCC-protected folder — `~/Documents` or `~/Desktop`, including the canonical `~/Desktop/sutando` location. launchd's `bash` has no TCC grant, so it cannot read the wrapper script, the `WorkingDirectory`, or the proxy script.

The subtle part: the proxy script is affected even though it nominally lives at `~/.claude/skills/quota-tracker/scripts/credential-proxy.ts` — that `scripts/` dir is a **symlink into the repo**, and TCC applies to the real path. Its `../../../src/workspace_default.js` import resolves into the repo too. Relocating only the wrapper is not enough.

## Fix

Vendor the whole job at install time into `~/.sutando/launchd` (outside TCC scope):

- **esbuild-bundle** `credential-proxy.ts` + its `src/workspace_default` import into a single node-runnable `credential-proxy.mjs` (the proxy uses only node built-ins, so the bundle's sole runtime dependency is `node`; esbuild is already in `node_modules` via tsx)
- copy the **wrapper** next to the bundle; it now resolves `node` instead of tsx/npx and `exec`s the bundle
- **plist**: `ProgramArguments` → `__LAUNCHD_DIR__/credential-proxy-wrapper.sh`, `WorkingDirectory` → `$HOME`

Re-running install re-vendors, so a `git pull` that changes the proxy is picked up — same idempotency contract the installer already documents. `--uninstall` removes the vendored files.

## Verification (field-tested on a `~/Documents` checkout)

- Before: `launchctl print` showed exit 126 crash-loop, log full of `Operation not permitted`
- After: bootstrap clean; `state = running`; **KeepAlive verified by kill-test** (killed the proxy pid, launchd respawned it within ThrottleInterval); quota headers captured end-to-end through the supervised proxy (`read-quota.py` reports both windows)
- `plutil -lint` on the substituted plist: OK, zero unsubstituted placeholders
- Installer remains idempotent over a pre-existing manual proxy (wrapper's stale-holder kill takes the port over cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)