### PR TITLE
fix(health): verify port 8080 serves the Sutando UI, not just that it's open

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -74,6 +74,30 @@ def check_port(port: int, name: str) -> dict:
         return {"name": name, "status": "error", "detail": str(e)}
 
 
+def check_web_client() -> dict:
+    """Port 8080 + response identity.
+
+    An occupancy-only probe reports "ok" when an unrelated process has
+    claimed 8080 (e.g. another project's dev server) while the real web
+    client never started — startup.sh skips it as "already running" and
+    the owner sees a 404 with health green. Verify the responder actually
+    serves the Sutando UI before calling it ok.
+    """
+    base = check_port(8080, "web-client")
+    if base["status"] != "ok":
+        return base
+    try:
+        with urllib.request.urlopen("http://127.0.0.1:8080/", timeout=3) as r:
+            body = r.read(4096).decode("utf-8", "replace")
+    except Exception as e:
+        return {"name": "web-client", "status": "warn",
+                "detail": f"port 8080 open but identity probe failed: {e}"}
+    if "<title>Sutando Web UI</title>" not in body:
+        return {"name": "web-client", "status": "down",
+                "detail": "port 8080 held by a NON-Sutando process — free it (lsof -nP -iTCP:8080 -sTCP:LISTEN) and re-run startup.sh"}
+    return base
+
+
 def check_launchd(label: str) -> dict:
     """Check if a launchd job is loaded and running."""
     try:
@@ -813,7 +837,7 @@ def run_all_checks() -> list[dict]:
     checks.append(check_voice_transport(voice_check))
     checks.append(check_bodhi_dist())
 
-    web_check = check_port(8080, "web-client")
+    web_check = check_web_client()
     if web_check["status"] == "ok":
         mark_stale_if_outdated(web_check, REPO_DIR / "src" / "web-client.ts", "web-client.ts")
     checks.append(web_check)

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -242,8 +242,14 @@ if ! lsof -i :8080 > /dev/null 2>&1; then
   echo "  Starting web client (port 8080)..."
   npx tsx src/web-client.ts > "$LOGS_DIR/web-client.log" 2>&1 &
   echo "  ✓ web client"
-else
+elif curl -s -m 3 http://127.0.0.1:8080/ | grep -q "<title>Sutando Web UI</title>"; then
   echo "  ✓ web client (already running)"
+else
+  # Occupied ≠ ours: an unrelated process (e.g. another project's dev
+  # server) on 8080 used to be reported as "already running" while the
+  # real client never started and the UI 404'd.
+  echo "  ⚠ port 8080 is held by a NON-Sutando process — web client NOT started."
+  echo "    Free the port (lsof -nP -iTCP:8080 -sTCP:LISTEN) and re-run startup.sh."
 fi
 
 # 3. Dashboard (port 7844)


### PR DESCRIPTION
## Problem

`startup.sh` and `health-check.py` equate "port 8080 occupied" with "web client running". When an unrelated process claims the port first (in the field: another project's `go run` dev server), `startup.sh` skips the launch with "✓ web client (already running)", health-check stays green, and the owner gets `404 page not found` from a UI that was never started.

## Fix (minimal, web-client only — the demonstrated failure)

- **health-check.py**: `check_web_client()` keeps the occupancy probe, then fetches `/` and requires the `<title>Sutando Web UI</title>` marker. Wrong responder → `✗ down` with a free-the-port remediation message; probe failure → `⚠ warn` (advisory).
- **startup.sh**: the "already running" branch curl-greps the same marker and warns loudly when the port is held by something else. It deliberately does **not** auto-kill the unknown process — that's the owner's call.

Other port checks (7843/7844/7845) are left as-is; they can adopt the same pattern in a follow-up if wanted.

## Verification

Recreated the incident end-to-end: real client → `✓ ok`; killed it and squatted 8080 with `python3 -m http.server` → `✗ down` + remediation, startup branch takes the warn path; restored client → `✓ ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)