### PR TITLE
fix(discord-voice): grace-verify owner-presence before exit — prevent false-positive leave at join time (#1659)

### DIFF
--- a/skills/discord-voice/scripts/discord-voice-server.ts
+++ b/skills/discord-voice/scripts/discord-voice-server.ts
@@ -2739,10 +2739,30 @@ async function start(): Promise<void> {
 			} catch (e) {
 				console.error(`${ts()} [Setup] owner-presence announcement injection failed:`, e);
 			}
-			setTimeout(() => {
+			// Grace-verify before exit (#1659): Discord can emit a transient
+			// voice-state churn at join time while channels.cache is not yet
+			// fully populated, causing a false-positive "last owner left".
+			// Re-fetch real membership after a short wait and abort if an
+			// owner is still present.
+			setTimeout(async () => {
+				try {
+					const guild = oldState.guild ?? newState.guild;
+					if (guild) {
+						await guild.members.fetch();
+						const freshCh = guild.channels.cache.get(CHANNEL_ID ?? '');
+						const freshMembers = (freshCh as any)?.members as Map<string, { id: string }> | undefined;
+						const freshIds = freshMembers ? [...freshMembers.values()].map((m) => m.id) : [];
+						if (!shouldLeaveOnOwnerExit(leaverId, freshIds, ACCESS.owner)) {
+							console.error(`${ts()} [Setup] owner-presence: grace-verify — owner still present, aborting leave`);
+							return;
+						}
+					}
+				} catch (e) {
+					console.error(`${ts()} [Setup] owner-presence: grace-verify failed:`, e);
+				}
 				try { connection.destroy(); } catch {}
 				process.exit(0);
-			}, 2500);
+			}, 3000);
 		});
 	}
 


### PR DESCRIPTION
Closes #1659

## Root cause

Within ~2s of the bot joining, Discord can emit a transient `voiceStateUpdate` (voice-server reallocation, or an incompletely-populated `channels.cache`). The owner-presence handler read membership from `channels.cache.get(CHANNEL_ID)` — which was stale at join time — and saw `remainingIds = []` even though the owner never left. `shouldLeaveOnOwnerExit` returned `true` and the bot exited while the owner was demonstrably still present (audio chunks continued past the "last owner left" log line).

## Fix

Replace the unconditional 2.5s exit timer with a **3s grace-verify**:
1. Wait 3s (instead of 2.5s)
2. Call `guild.members.fetch()` to force a fresh API read (bypasses the stale cache)
3. Re-check `shouldLeaveOnOwnerExit` with the refreshed member list
4. Abort the leave if an owner is now found present; log `grace-verify — owner still present`

Real owner departures still trigger exit (3s later). The join-time race self-corrects (owner's ID is back in `freshIds` after the fetch).

## Test

7/7 `tests/discord-voice-owner-presence.test.ts` green (unchanged — the decision logic `shouldLeaveOnOwnerExit` is untouched; only the runtime exit path changed).

Stacks on #1427.