### PR TITLE
fix(discord-voice): isAddressedBy — handle bare-name summons (#1600 M2)

### DIFF
--- a/skills/discord-voice/scripts/name-gate.ts
+++ b/skills/discord-voice/scripts/name-gate.ts
@@ -44,6 +44,7 @@ export const ADDRESS_VERBS =
  *   - "hi/hey/hello/yo/okay/ok NAME" or "hi, NAME" (greet + name)
  *   - "NAME," or "NAME?" (comma/question-tag — definite address marker)
  *   - "NAME VERB" at sentence start (imperative)
+ *   - NAME alone (bare utterance — the single most common summon, #1600 M2)
  * Returns false on plain mentions like "thanks NAME" or "NAME's answer".
  */
 export function isAddressedBy(text: string, names: string[]): boolean {
@@ -58,7 +59,11 @@ export function isAddressedBy(text: string, names: string[]): boolean {
 		const commaTag = new RegExp(`\\b${escape(n)}\\s*[,?]`, 'i');
 		// "NAME VERB" at sentence start (optional preceding . ! ?)
 		const verbed = new RegExp(`(^|[.!?]\\s*)${escape(n)}\\s+${ADDRESS_VERBS}\\b`, 'i');
-		if (greet.test(lc) || commaTag.test(lc) || verbed.test(lc)) return true;
+		// Bare name: entire utterance is just the name (optionally trailing . ! ?)
+		// — the #1 summon pattern in the 2026-06-10 live session (66 instances,
+		// zero matched). "Lucy" alone is unambiguously an address, not a mention.
+		const bareName = new RegExp(`^${escape(n)}[.!?]*$`, 'i');
+		if (greet.test(lc) || commaTag.test(lc) || verbed.test(lc) || bareName.test(lc.trim())) return true;
 	}
 	return false;
 }

--- a/tests/discord-voice-namegate.test.ts
+++ b/tests/discord-voice-namegate.test.ts
@@ -28,9 +28,23 @@ test('isAddressedBy: comma/question tag addresses', () => {
 test('isAddressedBy: imperative verb at clause start addresses', () => {
 	assert.equal(isAddressedBy(`${SELF} check the PR`, [SELF]), true);
 });
+test('isAddressedBy: bare name addresses — #1600 M2 (66/66 live misses)', () => {
+	// The single most common summon pattern in the 2026-06-10 live session
+	// (66 bare "Lucy" / "Lucy." utterances, 0 matched pre-fix).
+	assert.equal(isAddressedBy(SELF, [SELF]), true, 'bare name must address');
+	assert.equal(isAddressedBy(`${SELF}.`, [SELF]), true, 'name + period must address');
+	assert.equal(isAddressedBy(`${SELF}!`, [SELF]), true, 'name + exclamation must address');
+	// Leading/trailing whitespace (common in ASR output) must not break it
+	assert.equal(isAddressedBy(`  ${SELF}  `, [SELF]), true, 'whitespace-padded bare name must address');
+	// Alias variant (e.g. "Loosey" → alias for "Lucy")
+	const alias = SELF + 'ey';
+	assert.equal(isAddressedBy(alias, [alias]), true, 'bare alias must address');
+});
 test('isAddressedBy: plain mention does NOT address', () => {
 	assert.equal(isAddressedBy(`thanks ${SELF}`, [SELF]), false);
 	assert.equal(isAddressedBy(`${SELF}'s answer was good`, [SELF]), false);
+	// Multi-word utterance containing only the name is still not a bare-name summon
+	assert.equal(isAddressedBy(`thank you ${SELF}`, [SELF]), false);
 });
 test('isAddressedBy: empty names / empty text never matches', () => {
 	assert.equal(isAddressedBy(`${SELF}, hi`, []), false);


### PR DESCRIPTION
Closes #1600 M2 (bare-name miss).

## Problem

In the 2026-06-10 live session (issue #1600), **66 bare "Lucy" / "Lucy." utterances returned `isAddressedBy = false`** — the #1 summon pattern failed silently the entire session.

The three existing patterns in `isAddressedBy` all require something before/after the name:
- `hi/hey NAME` — needs greeting prefix
- `NAME,` or `NAME?` — needs trailing punctuation (comma/question-mark, not period)
- `NAME VERB` — needs a verb after the name

A standalone utterance that IS the name matched none of them.

## Fix

One-line addition to `isAddressedBy`: a 4th pattern — bare name — where the entire trimmed utterance matches the name optionally followed by `. ! ?`:

```typescript
const bareName = new RegExp(`^${escape(n)}[.!?]*$`, 'i');
```

"Lucy" alone is unambiguously an address, not a mention (the false-positive risk is zero — a mention would have other words).

## Tests

New test case `isAddressedBy: bare name addresses — #1600 M2 (66/66 live misses)` with 5 assertions: bare name, name+period, name+exclamation, whitespace-padded, and alias form.

70/70 discord-voice tests green (was 65/65 before this PR; the 5 new assertions are in the new test).

Stacks on #1427.