### PR TITLE
fix(tests): restore 329/329 green — node:sqlite flag + dm-result isolation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "tsx src/voice-agent.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test tests/*.test.ts && npm run test:py",
+    "test": "tsx --experimental-sqlite --test tests/*.test.ts && npm run test:py",
     "test:py": "for f in tests/*.test.py; do echo \"--- $f ---\" && python3 \"$f\" || exit 1; done"
   },
   "dependencies": {

--- a/tests/dm-result-send-dm.test.py
+++ b/tests/dm-result-send-dm.test.py
@@ -97,13 +97,20 @@ def _restore_transport(original):
 
 def _with_access_json(content, fn):
     original = dm.ACCESS_JSON
+    # Isolate from the real workspace discord-config.json — its `owner` field
+    # takes priority (step 2 in resolve_owner_id) and would shadow any tierMap
+    # set in the test's access.json.  Returning {} makes load_config a no-op so
+    # only the supplied access.json drives resolution.
+    original_load_config = dm.discord_config.load_config
     tmp = Path(tempfile.mkdtemp(prefix="sutando-dm-test-")) / "access.json"
     tmp.write_text(json.dumps(content))
     dm.ACCESS_JSON = tmp
+    dm.discord_config.load_config = lambda: {}
     try:
         fn()
     finally:
         dm.ACCESS_JSON = original
+        dm.discord_config.load_config = original_load_config
         tmp.unlink()
         tmp.parent.rmdir()
 


### PR DESCRIPTION
## Summary
- Restores the full test suite to 329/329 green
- Adds the `--experimental-sqlite` flag where `node:sqlite` is imported under current Node
- Isolates `_with_access_json` test state so dm-result tests no longer leak access.json between cases

## Test plan
- [x] `329/329` passing locally on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)