### PR TITLE
fix(credential-proxy): idle timeout so hung connections don't block forever

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "tsx src/voice-agent.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test tests/*.test.ts && npm run test:py",
+    "test": "tsx --experimental-sqlite --test tests/*.test.ts && npm run test:py",
     "test:py": "for f in tests/*.test.py; do echo \"--- $f ---\" && python3 \"$f\" || exit 1; done"
   },
   "dependencies": {

--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -114,6 +114,13 @@ const server = createServer((req, res) => {
 			headers['authorization'] = `Bearer ${oauthToken}`;
 		}
 
+		// IDLE_TIMEOUT_MS: how long a streaming response can go silent before we
+		// treat the connection as hung and abort. Resets on every incoming chunk so
+		// normal slow-streaming responses (large completions) are never cut off —
+		// only truly stalled connections time out.  30 s is generous for any real
+		// network blip; the Anthropic API keeps chunks coming at least that fast.
+		const IDLE_TIMEOUT_MS = 30_000;
+
 		const upstream = httpsRequest(
 			{
 				hostname: upstreamUrl.hostname,
@@ -121,6 +128,7 @@ const server = createServer((req, res) => {
 				path: req.url,
 				method: req.method,
 				headers,
+				timeout: IDLE_TIMEOUT_MS,
 			} as RequestOptions,
 			(upRes) => {
 				// Extract rate limit headers
@@ -136,15 +144,31 @@ const server = createServer((req, res) => {
 				}
 
 				res.writeHead(upRes.statusCode!, upRes.headers);
+
+				// Reset the idle timeout on every incoming chunk so a legitimately
+				// slow streaming response (large completion) is never aborted.
+				let idleTimer = setTimeout(() => upstream.destroy(new Error('idle timeout')), IDLE_TIMEOUT_MS);
+				upRes.on('data', () => {
+					clearTimeout(idleTimer);
+					idleTimer = setTimeout(() => upstream.destroy(new Error('idle timeout')), IDLE_TIMEOUT_MS);
+				});
+				upRes.on('end', () => clearTimeout(idleTimer));
+				upRes.on('error', () => clearTimeout(idleTimer));
+
 				upRes.pipe(res);
 			},
 		);
 
+		// timeout fires when the socket stalls before the response headers arrive.
+		upstream.on('timeout', () => {
+			upstream.destroy(new Error('connect/headers timeout'));
+		});
+
 		upstream.on('error', (err) => {
 			console.error(`${ts()} [Proxy] Upstream error:`, err.message);
 			if (!res.headersSent) {
-				res.writeHead(502);
-				res.end('Bad Gateway');
+				res.writeHead(err.message.includes('timeout') ? 504 : 502);
+				res.end(err.message.includes('timeout') ? 'Gateway Timeout' : 'Bad Gateway');
 			}
 		});
 

--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -13,14 +13,14 @@
  */
 
 import { createServer, request as httpRequest, type RequestOptions } from 'node:http';
-import { request as httpsRequest } from 'node:https';
+import { request as httpsRequest, type RequestOptions as HttpsRequestOptions } from 'node:https';
 import { execSync } from 'node:child_process';
 import { writeFileSync, readFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { statusPath } from '../../../src/workspace_default.js';
 
-const PORT = 7846;
-const UPSTREAM = 'https://api.anthropic.com';
+const PORT = Number(process.env.CREDENTIAL_PROXY_PORT) || 7846;
+const UPSTREAM = process.env.CREDENTIAL_PROXY_UPSTREAM || 'https://api.anthropic.com';
 // Quota state is per-user runtime state — canonical home is <workspace>/state/.
 // Historically written into the skill dir; readers (dashboard.py, read-quota.py)
 // keep the skill-dir path as a last-resort fallback for one release.
@@ -73,13 +73,16 @@ function updateQuotaState(headers: Record<string, string>): void {
 	} catch { /* best effort */ }
 }
 
-// Verify token exists at startup
-const initToken = getOAuthToken();
-if (!initToken) {
-	console.error('No OAuth token found in macOS keychain. Is Claude Code logged in?');
-	process.exit(1);
+// Verify token exists at startup (skippable for tests via CREDENTIAL_PROXY_SKIP_OAUTH=1)
+const SKIP_OAUTH = process.env.CREDENTIAL_PROXY_SKIP_OAUTH === '1';
+if (!SKIP_OAUTH) {
+	const initToken = getOAuthToken();
+	if (!initToken) {
+		console.error('No OAuth token found in macOS keychain. Is Claude Code logged in?');
+		process.exit(1);
+	}
+	console.log(`${ts()} [Proxy] OAuth token loaded from keychain (will re-read on each request)`);
 }
-console.log(`${ts()} [Proxy] OAuth token loaded from keychain (will re-read on each request)`);
 
 const upstreamUrl = new URL(UPSTREAM);
 
@@ -88,14 +91,6 @@ const server = createServer((req, res) => {
 	req.on('data', (c) => chunks.push(c));
 	req.on('end', () => {
 		const body = Buffer.concat(chunks);
-
-		// Read token fresh from keychain each request (tokens get refreshed by active sessions)
-		const oauthToken = getOAuthToken();
-		if (!oauthToken) {
-			res.writeHead(502);
-			res.end('No OAuth token in keychain');
-			return;
-		}
 
 		const headers: Record<string, string | number | string[] | undefined> = {
 			...(req.headers as Record<string, string>),
@@ -108,10 +103,19 @@ const server = createServer((req, res) => {
 		delete headers['keep-alive'];
 		delete headers['transfer-encoding'];
 
-		// Inject OAuth token for auth requests
-		if (headers['authorization']) {
-			delete headers['authorization'];
-			headers['authorization'] = `Bearer ${oauthToken}`;
+		if (!SKIP_OAUTH) {
+			// Read token fresh from keychain each request (tokens get refreshed by active sessions)
+			const oauthToken = getOAuthToken();
+			if (!oauthToken) {
+				res.writeHead(502);
+				res.end('No OAuth token in keychain');
+				return;
+			}
+			// Inject OAuth token for auth requests
+			if (headers['authorization']) {
+				delete headers['authorization'];
+				headers['authorization'] = `Bearer ${oauthToken}`;
+			}
 		}
 
 		// IDLE_TIMEOUT_MS: how long a streaming response can go silent before we
@@ -119,12 +123,17 @@ const server = createServer((req, res) => {
 		// normal slow-streaming responses (large completions) are never cut off —
 		// only truly stalled connections time out.  30 s is generous for any real
 		// network blip; the Anthropic API keeps chunks coming at least that fast.
-		const IDLE_TIMEOUT_MS = 30_000;
+		// Override via CREDENTIAL_PROXY_IDLE_TIMEOUT_MS for tests.
+		const IDLE_TIMEOUT_MS = Number(process.env.CREDENTIAL_PROXY_IDLE_TIMEOUT_MS) || 30_000;
 
-		const upstream = httpsRequest(
+		const isHttps = upstreamUrl.protocol === 'https:';
+		const makeRequest = isHttps ? httpsRequest : httpRequest;
+		const upstreamPort = upstreamUrl.port ? Number(upstreamUrl.port) : (isHttps ? 443 : 80);
+
+		const upstream = makeRequest(
 			{
 				hostname: upstreamUrl.hostname,
-				port: 443,
+				port: upstreamPort,
 				path: req.url,
 				method: req.method,
 				headers,
@@ -169,6 +178,10 @@ const server = createServer((req, res) => {
 			if (!res.headersSent) {
 				res.writeHead(err.message.includes('timeout') ? 504 : 502);
 				res.end(err.message.includes('timeout') ? 'Gateway Timeout' : 'Bad Gateway');
+			} else {
+				// Headers already forwarded — can't change status, but must close
+				// the client connection so it doesn't hang indefinitely.
+				res.destroy();
 			}
 		});
 

--- a/tests/credential-proxy-idle-timeout.test.ts
+++ b/tests/credential-proxy-idle-timeout.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer, type Server, request as httpRequestFn } from 'node:http';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Credential-proxy idle-timeout regression tests.
+//
+// The proxy (skills/quota-tracker/scripts/credential-proxy.ts) previously had
+// no timeout at all — a network blip would hang the connection forever. Two
+// code paths are exercised:
+//
+//  1. Upstream accepts connection but never sends headers → proxy returns 504
+//     (the httpsRequest `timeout` option → upstream.on('timeout') → destroy).
+//
+//  2. Upstream sends headers + partial body then stalls → proxy closes the
+//     client connection within ~IDLE_TIMEOUT_MS (idle timer resets per chunk).
+//
+//  3. Upstream responds promptly → 200 forwarded, timer never fires.
+//
+// CREDENTIAL_PROXY_IDLE_TIMEOUT_MS=150 keeps the test fast.
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PROXY_SCRIPT = join(REPO, 'skills', 'quota-tracker', 'scripts', 'credential-proxy.ts');
+const IDLE_TIMEOUT_MS = 150;
+
+// Base proxy ports — well-separated to survive TIME_WAIT from a crashed prior run.
+const PROXY_PORT_STALL_HEADERS = 47847;  // test 1
+const PROXY_PORT_STALL_BODY    = 47857;  // test 2
+const PROXY_PORT_QUICK         = 47867;  // test 3
+
+function boundPort(server: Server): number {
+	return (server.address() as { port: number }).port;
+}
+
+function waitForPort(port: number, timeoutMs = 8000): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const deadline = Date.now() + timeoutMs;
+		function attempt() {
+			const req = httpRequestFn({ hostname: '127.0.0.1', port, path: '/', method: 'GET' }, () => resolve());
+			req.on('error', () => {
+				if (Date.now() > deadline) return reject(new Error(`port ${port} never opened within ${timeoutMs}ms`));
+				setTimeout(attempt, 50);
+			});
+			req.end();
+		}
+		attempt();
+	});
+}
+
+function spawnProxy(proxyPort: number, mockPort: number): ChildProcess {
+	const p = spawn(
+		'npx',
+		['tsx', '--experimental-sqlite', PROXY_SCRIPT],
+		{
+			env: {
+				...process.env,
+				CREDENTIAL_PROXY_PORT: String(proxyPort),
+				CREDENTIAL_PROXY_UPSTREAM: `http://127.0.0.1:${mockPort}`,
+				CREDENTIAL_PROXY_IDLE_TIMEOUT_MS: String(IDLE_TIMEOUT_MS),
+				CREDENTIAL_PROXY_SKIP_OAUTH: '1',
+			},
+			stdio: 'pipe',
+		},
+	);
+	p.stderr?.on('data', (d: Buffer) => process.stderr.write(`[proxy:${proxyPort}] ${d}`));
+	return p;
+}
+
+async function startMock(handler: Parameters<typeof createServer>[0]): Promise<Server> {
+	const srv = createServer(handler);
+	// listen(0) → OS picks a free port, avoiding TIME_WAIT collisions across runs.
+	await new Promise<void>((resolve) => srv.listen(0, '127.0.0.1', resolve));
+	return srv;
+}
+
+async function stopServer(srv: Server): Promise<void> {
+	await new Promise<void>((resolve) => srv.close(() => resolve()));
+}
+
+describe('credential-proxy idle timeout', { timeout: 20_000 }, () => {
+	// ── Test 1: upstream accepts connection but never sends headers ────────────
+	//    Expected: proxy returns 504 within ~IDLE_TIMEOUT_MS.
+
+	let stallHeadersMock: Server;
+	let stallHeadersProxy: ChildProcess;
+
+	before(async () => {
+		stallHeadersMock = await startMock((_req, _res) => { /* intentionally silent */ });
+		stallHeadersProxy = spawnProxy(PROXY_PORT_STALL_HEADERS, boundPort(stallHeadersMock));
+		await waitForPort(PROXY_PORT_STALL_HEADERS);
+	});
+
+	after(async () => {
+		stallHeadersProxy.kill();
+		await stopServer(stallHeadersMock);
+	});
+
+	it('returns 504 when upstream never sends headers (connect/headers timeout)', async () => {
+		const start = Date.now();
+		const statusCode = await new Promise<number>((resolve, reject) => {
+			const req = httpRequestFn(
+				{
+					hostname: '127.0.0.1',
+					port: PROXY_PORT_STALL_HEADERS,
+					path: '/v1/messages',
+					method: 'POST',
+					headers: { 'content-type': 'application/json', authorization: 'Bearer test-token' },
+				},
+				(res) => resolve(res.statusCode ?? 0),
+			);
+			req.on('error', reject);
+			req.end();
+		});
+		const elapsed = Date.now() - start;
+
+		assert.equal(statusCode, 504, `expected 504 Gateway Timeout, got ${statusCode}`);
+		// Resolve within 5× the configured timeout (generous for CI).
+		assert.ok(elapsed < IDLE_TIMEOUT_MS * 5, `took ${elapsed}ms — expected < ${IDLE_TIMEOUT_MS * 5}ms`);
+	});
+
+	// ── Test 2: upstream sends headers + partial body, then stalls ────────────
+	//    Expected: client connection closed within ~IDLE_TIMEOUT_MS.
+
+	it('closes client connection when upstream stalls mid-body (idle timer)', async () => {
+		const mock = await startMock((_req, res) => {
+			res.writeHead(200, { 'content-type': 'text/plain' });
+			res.write('partial body chunk');
+			// Deliberately never calls res.end() — mid-body stall.
+		});
+		const proxy = spawnProxy(PROXY_PORT_STALL_BODY, boundPort(mock));
+		try {
+			await waitForPort(PROXY_PORT_STALL_BODY);
+
+			const start = Date.now();
+			await new Promise<void>((resolve, reject) => {
+				const req = httpRequestFn(
+					{
+						hostname: '127.0.0.1',
+						port: PROXY_PORT_STALL_BODY,
+						path: '/v1/messages',
+						method: 'POST',
+						headers: { 'content-type': 'application/json', authorization: 'Bearer test-token' },
+					},
+					(res) => {
+						// Drain body; 'close' fires when the connection terminates.
+						res.resume();
+						res.on('close', resolve);
+					},
+				);
+				req.on('error', reject);
+				req.end();
+			});
+			const elapsed = Date.now() - start;
+
+			// Connection must close within 5× idle timeout, not hang forever.
+			assert.ok(elapsed < IDLE_TIMEOUT_MS * 5, `connection took ${elapsed}ms — idle timer may not have fired`);
+		} finally {
+			proxy.kill();
+			await stopServer(mock);
+		}
+	});
+
+	// ── Test 3: upstream responds promptly → no premature timeout ─────────────
+	//    Expected: 200 forwarded correctly.
+
+	it('proxies a prompt upstream response without premature timeout', async () => {
+		const mock = await startMock((_req, res) => {
+			res.writeHead(200, { 'content-type': 'application/json' });
+			res.end('{"id":"msg_test","type":"message"}');
+		});
+		const proxy = spawnProxy(PROXY_PORT_QUICK, boundPort(mock));
+		try {
+			await waitForPort(PROXY_PORT_QUICK);
+
+			const statusCode = await new Promise<number>((resolve, reject) => {
+				const req = httpRequestFn(
+					{
+						hostname: '127.0.0.1',
+						port: PROXY_PORT_QUICK,
+						path: '/v1/messages',
+						method: 'POST',
+						headers: { 'content-type': 'application/json', authorization: 'Bearer test-token' },
+					},
+					(res) => resolve(res.statusCode ?? 0),
+				);
+				req.on('error', reject);
+				req.end();
+			});
+
+			// Prompt responses must be forwarded as-is, not cut off by the idle timer.
+			assert.equal(statusCode, 200, `expected 200, got ${statusCode} — idle timer fired prematurely`);
+		} finally {
+			proxy.kill();
+			await stopServer(mock);
+		}
+	});
+});

--- a/tests/dm-result-send-dm.test.py
+++ b/tests/dm-result-send-dm.test.py
@@ -97,13 +97,20 @@ def _restore_transport(original):
 
 def _with_access_json(content, fn):
     original = dm.ACCESS_JSON
+    # Isolate from the real workspace discord-config.json — its `owner` field
+    # takes priority (step 2 in resolve_owner_id) and would shadow any tierMap
+    # set in the test's access.json.  Returning {} makes load_config a no-op so
+    # only the supplied access.json drives resolution.
+    original_load_config = dm.discord_config.load_config
     tmp = Path(tempfile.mkdtemp(prefix="sutando-dm-test-")) / "access.json"
     tmp.write_text(json.dumps(content))
     dm.ACCESS_JSON = tmp
+    dm.discord_config.load_config = lambda: {}
     try:
         fn()
     finally:
         dm.ACCESS_JSON = original
+        dm.discord_config.load_config = original_load_config
         tmp.unlink()
         tmp.parent.rmdir()
 


### PR DESCRIPTION
## Summary
- Adds a 30s idle timeout to the credential proxy so a hung upstream connection can no longer block the proxy forever (CRITICAL reliability fix)
- Closes the client socket on mid-body idle timeout instead of leaving it half-open
- Env-var overrides for the timeout values so tests can exercise the paths quickly
- 3 new integration tests covering the timeout paths

**Stacked on #1668** (includes its test-infra commit `bbf2322e`; will drop out automatically once #1668 merges).

## Test plan
- [x] 332/332 passing locally (329 baseline + 3 new integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)