### PR TITLE
feat: observability + metering seam — source-agnostic local collector + strict Claude Code capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ state/*
 # carry per-user data and must never be committed from a repo-root workspace
 # install — the repo ships <skill>/config.json.example templates instead.
 config/*.json
+# ...except the shipped, in-repo defaults (Spine C source). These are CODE that
+# ships with the repo, not per-user data — they MUST be tracked.
+!config/sutando.config.defaults.json
+!config/sutando.config.schema.json
 AGENT_LOOP.md
 PENDING.md
 pending-questions.md
@@ -44,6 +48,10 @@ docs/youtube/
 core-status.json
 dynamic-content.json
 tests/*
+# Re-include nested test subdirectories so the tests/ tree can mirror src/
+# (tests/kernel/, tests/adapters/, tests/policy/, …) — the companion to the
+# recursive runner glob. Without this, relocated tests are silently untracked.
+!tests/*/
 !tests/*.test.ts
 !tests/*.test.py
 !tests/*.test.sh

--- a/config/sutando.config.defaults.json
+++ b/config/sutando.config.defaults.json
@@ -16,7 +16,8 @@
   "observability": {
     "sinks": [
       { "type": "jsonl-file" }
-    ]
+    ],
+    "export": null
   },
   "tenant": {
     "id": null,

--- a/config/sutando.config.defaults.json
+++ b/config/sutando.config.defaults.json
@@ -1,0 +1,33 @@
+{
+  "schema": 1,
+  "voice": {
+    "provider": "gemini-live",
+    "model": null
+  },
+  "telephony": {
+    "provider": "twilio"
+  },
+  "stt": {
+    "provider": "gemini"
+  },
+  "tts": {
+    "provider": "gemini"
+  },
+  "observability": {
+    "sinks": [
+      { "type": "jsonl-file" }
+    ]
+  },
+  "tenant": {
+    "id": null,
+    "mode": "byok"
+  },
+  "metering": {
+    "enabled": false,
+    "endpoint": null,
+    "batchMax": 100
+  },
+  "send": {
+    "allowedRoots": []
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "start": "tsx src/voice-agent.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test tests/*.test.ts && npm run test:py",
-    "test:py": "for f in tests/*.test.py; do echo \"--- $f ---\" && python3 \"$f\" || exit 1; done"
+    "test": "tsx --test 'tests/**/*.test.ts' && npm run test:py",
+    "test:py": "for f in $(find tests -name '*.test.py' | sort); do echo \"--- $f ---\" && python3 \"$f\" || exit 1; done"
   },
   "dependencies": {
     "@ai-sdk/google": "^1.2.0",

--- a/scripts/start-cli.sh
+++ b/scripts/start-cli.sh
@@ -36,6 +36,30 @@ if [ -n "${SUTANDO_CORE_MODEL:-}" ]; then
   MODEL_ARGS=(--model "$SUTANDO_CORE_MODEL")
 fi
 
+# ---- obs hooks (ALWAYS injected; export gated by config) --------------------
+# Register Claude Code hooks on every launch via `--settings` (merges with the
+# user's settings at highest precedence, per-session — no persistent file edit).
+# The hook command (obs-hook.sh) only ships a payload when an endpoint is
+# configured, so the contract is "always set the hooks, only export when told
+# where". Endpoint: $SUTANDO_OBS_ENDPOINT wins, else `observability.export` from
+# config/sutando.config.defaults.json. Exported so the hook — which runs in the
+# session's inherited env — resolves it at hook-time.
+OBS_ENDPOINT="${SUTANDO_OBS_ENDPOINT:-}"
+if [ -z "$OBS_ENDPOINT" ] && [ -f "$REPO/config/sutando.config.defaults.json" ] && command -v node > /dev/null 2>&1; then
+  OBS_ENDPOINT="$(SUTANDO_CFG="$REPO/config/sutando.config.defaults.json" node -e 'try{const c=require(process.env.SUTANDO_CFG);process.stdout.write((c.observability&&c.observability.export)||"")}catch(e){}' 2>/dev/null || true)"
+fi
+export SUTANDO_OBS_ENDPOINT="$OBS_ENDPOINT"
+
+OBS_HOOK="bash $REPO/src/adapters/executor/claude-code/hooks/obs-hook.sh"
+_h="{\"hooks\":[{\"type\":\"command\",\"command\":\"$OBS_HOOK\"}]}"                 # lifecycle events
+_t="{\"matcher\":\"*\",\"hooks\":[{\"type\":\"command\",\"command\":\"$OBS_HOOK\"}]}" # tool events (matched)
+HOOKS_JSON="{\"hooks\":{\"UserPromptSubmit\":[$_h],\"UserPromptExpansion\":[$_h],\"MessageDisplay\":[$_h],\"PreToolUse\":[$_t],\"PostToolUse\":[$_t],\"Stop\":[$_h],\"SessionStart\":[$_h],\"SessionEnd\":[$_h],\"PreCompact\":[$_h],\"Notification\":[$_h]}}"
+if [ -n "$OBS_ENDPOINT" ]; then
+  echo "obs hooks: → $OBS_ENDPOINT/ingest/claude-code-hooks (collector)"
+else
+  echo "obs hooks: registered (no export endpoint set — capture is a no-op until observability.export or SUTANDO_OBS_ENDPOINT is set)"
+fi
+
 # --restart: kill any existing session before starting fresh. Without this,
 # the script's "already running → attach" path returns and the old session
 # keeps running.
@@ -82,6 +106,7 @@ if ! command -v tmux > /dev/null 2>&1; then
   echo "  ⚠ tmux not found — running without tmux wrapper"
   echo "    (Sutando.app's watcher-auto-restart won't work; brew install tmux to enable)"
   exec claude --name "$SESSION" ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
+    --settings "$HOOKS_JSON" \
     -- "/schedule-crons"
 fi
 
@@ -120,10 +145,12 @@ tmux -S "$TMUX_SOCKET" bind -n WheelDownPane send-keys -M 2>/dev/null || true
 if [ -t 1 ]; then
   exec tmux -S "$TMUX_SOCKET" new-session -A -s "$SESSION" \
     claude --name "$SESSION" ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
+    --settings "$HOOKS_JSON" \
     -- "/schedule-crons"
 else
   tmux -S "$TMUX_SOCKET" new-session -d -s "$SESSION" \
     claude --name "$SESSION" ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
+    --settings "$HOOKS_JSON" \
     -- "/schedule-crons"
   echo "Started $SESSION detached. Attach via Open Core CLI in menu bar, or:"
   echo "  tmux -S $TMUX_SOCKET attach -t $SESSION"

--- a/src/adapters/executor/claude-code/hooks/obs-hook.sh
+++ b/src/adapters/executor/claude-code/hooks/obs-hook.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Thin Claude Code obs hook — forwards a raw hook payload (JSON on stdin) to the
+# Sutando collector IFF an export endpoint is configured.
+#
+# Claude Code is just ONE source for the collector: this hook posts to the
+# source-scoped route `/ingest/claude-code-hooks`, where the collector's
+# Claude-Code normalizer maps it. Other sources (voice, filewatcher, bridges)
+# post to their own `/ingest/<source>` on the SAME collector.
+#
+# The hook is ALWAYS registered (start-cli.sh injects it on every session), but
+# this script does nothing unless $SUTANDO_OBS_ENDPOINT is set — so capture is
+# opt-in via config (`observability.export`), per the "always set hooks, only
+# export when told where" contract.
+#
+# Must stay THIN: it runs on every tool call, so it never blocks (curl is capped
+# at 1s) and never fails the agent (errors swallowed, always exit 0). The
+# collector receives the raw hook JSON and does the mapping.
+
+# No endpoint configured → drain stdin and no-op (don't leave the pipe unread).
+if [ -z "${SUTANDO_OBS_ENDPOINT:-}" ]; then
+  cat > /dev/null 2>&1
+  exit 0
+fi
+
+curl -sS -m 1 -X POST "${SUTANDO_OBS_ENDPOINT%/}/ingest/claude-code-hooks" \
+  -H 'content-type: application/json' \
+  --data-binary @- > /dev/null 2>&1 || true
+
+exit 0

--- a/src/adapters/executor/claude-code/sources/_map-util.ts
+++ b/src/adapters/executor/claude-code/sources/_map-util.ts
@@ -18,6 +18,26 @@ export function num(v: unknown): number | undefined {
 	return typeof v === 'number' ? v : undefined;
 }
 
+/** Capture a value but cap large strings/objects so huge tool I/O can't bloat
+ *  events. Raise via SUTANDO_IO_CAP. */
+const IO_CAP = Number(process.env.SUTANDO_IO_CAP) || 16384;
+export function trunc(v: unknown): unknown {
+	if (v == null) return undefined;
+	if (typeof v === 'string') return v.length > IO_CAP ? v.slice(0, IO_CAP) + `…[+${v.length - IO_CAP} chars]` : v;
+	let s: string;
+	try { s = JSON.stringify(v); } catch { return String(v).slice(0, IO_CAP); }
+	return s.length > IO_CAP ? s.slice(0, IO_CAP) + `…[+${s.length - IO_CAP} chars]` : v;
+}
+
+/** All non-envelope hook fields — robust to the real payload using field names
+ *  the docs got wrong. */
+const COMMON_HOOK_KEYS = new Set(['hook_event_name', 'session_id', 'transcript_path', 'cwd', 'permission_mode', 'ts']);
+export function nonCommon(p: Record<string, unknown>): Record<string, unknown> {
+	const o: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(p)) if (!COMMON_HOOK_KEYS.has(k)) o[k] = trunc(v);
+	return o;
+}
+
 export function tsOf(recTs: number | undefined, ctx: MapContext): number {
 	return typeof recTs === 'number' ? recTs : ctx.receivedAt;
 }

--- a/src/adapters/executor/claude-code/sources/_map-util.ts
+++ b/src/adapters/executor/claude-code/sources/_map-util.ts
@@ -1,0 +1,72 @@
+/** Shared helpers for the Claude Code mappers. Pure. */
+
+import type { ObsEvent, Outcome } from '../../../../kernel/obs/types.js';
+import type { MapContext, ResourceAttrs } from './cc-records.js';
+import { actorFromResourceAttrs, traceIdFromSession } from './ids.js';
+
+export const CORE_SOURCE = 'core-cli';
+
+/** Drop keys whose value is `undefined` so mapper output deep-equals clean
+ *  golden objects (and serializes identically). */
+export function clean<T extends Record<string, unknown>>(o: T): T {
+	const out: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(o)) if (v !== undefined) out[k] = v;
+	return out as T;
+}
+
+export function num(v: unknown): number | undefined {
+	return typeof v === 'number' ? v : undefined;
+}
+
+export function tsOf(recTs: number | undefined, ctx: MapContext): number {
+	return typeof recTs === 'number' ? recTs : ctx.receivedAt;
+}
+
+export function tsBucket(ts: number): number {
+	return Math.floor(ts);
+}
+
+export function baseEvent(opts: {
+	res?: ResourceAttrs;
+	sessionId?: string;
+	kind: string;
+	outcome: Outcome;
+	ctx: MapContext;
+	ts: number;
+}): ObsEvent {
+	const sessionId = opts.sessionId ?? opts.res?.['session.id'];
+	return {
+		schema: 1,
+		ts: opts.ts,
+		trace_id: traceIdFromSession(sessionId),
+		node: opts.ctx.node,
+		source: CORE_SOURCE,
+		actor: actorFromResourceAttrs(opts.res),
+		kind: opts.kind,
+		outcome: opts.outcome,
+	};
+}
+
+/** Map a file-touching tool to its paired `file.*` event kind. */
+export function fileOpFor(toolName?: string): { kind: 'file.read' | 'file.change'; op?: string } | null {
+	switch (toolName) {
+		case 'Read':
+			return { kind: 'file.read' };
+		case 'Write':
+			return { kind: 'file.change', op: 'written' };
+		case 'Edit':
+		case 'MultiEdit':
+			return { kind: 'file.change', op: 'modified' };
+		default:
+			return null;
+	}
+}
+
+export function pathFromToolInput(input?: Record<string, unknown>): string | undefined {
+	if (!input) return undefined;
+	return (
+		(typeof input.file_path === 'string' ? input.file_path : undefined) ??
+		(typeof input.path === 'string' ? input.path : undefined) ??
+		(typeof input.notebook_path === 'string' ? input.notebook_path : undefined)
+	);
+}

--- a/src/adapters/executor/claude-code/sources/cc-hooks.ts
+++ b/src/adapters/executor/claude-code/sources/cc-hooks.ts
@@ -1,0 +1,184 @@
+/**
+ * The Claude Code hook INGEST CONTRACT — the strict wire shape the core's hook
+ * (`obs-hook.sh`) POSTs to `/ingest/claude-code-hooks`, plus the decoder that
+ * turns an `unknown` body into that typed shape.
+ *
+ * This is the "detect → strictly type" boundary. The collector hands a
+ * normalizer an `unknown` payload; `decodeClaudeCodeHook` validates it's a CC
+ * hook (an object with a non-empty string `hook_event_name`) and returns it as
+ * the discriminated `ClaudeCodeHook` union, so every downstream `switch` narrows
+ * with full type safety — no `as never`, no `Record<string, unknown>` guessing.
+ *
+ * `ClaudeCodeHook = KnownHook | UnknownHook`:
+ *   - KnownHook — one interface per modeled `hook_event_name`, literal-
+ *     discriminated, so a `switch` over it narrows each case to exact fields.
+ *   - UnknownHook — the forward-compatible escape hatch for not-yet-modeled
+ *     events (open index signature). Guard with `isKnownHook` BEFORE the switch
+ *     so the known union stays clean.
+ *
+ * Field names are verified against REAL Claude Code payloads (the docs were
+ * wrong on several: PostToolUse output is `tool_response` not `tool_output`;
+ * MessageDisplay streams `delta` chunks with a `final` flag; UserPromptSubmit
+ * uses `prompt`). Anything unverified rides per-event optionals or the
+ * UnknownHook index signature rather than being asserted.
+ */
+
+/** Keys present on every hook payload regardless of event. */
+export interface HookCommon {
+	session_id?: string;
+	transcript_path?: string;
+	cwd?: string;
+	permission_mode?: string;
+	ts?: number; // unix seconds, when the payload carries one
+}
+
+export interface UserPromptSubmitHook extends HookCommon {
+	hook_event_name: 'UserPromptSubmit';
+	prompt?: string;
+}
+
+export interface UserPromptExpansionHook extends HookCommon {
+	hook_event_name: 'UserPromptExpansion';
+	// payload shape unverified against real CC output → kept open
+	[k: string]: unknown;
+}
+
+export interface PreToolUseHook extends HookCommon {
+	hook_event_name: 'PreToolUse';
+	tool_name: string;
+	tool_input?: Record<string, unknown>;
+}
+
+export interface PostToolUseHook extends HookCommon {
+	hook_event_name: 'PostToolUse' | 'PostToolUseFailure';
+	tool_name: string;
+	tool_input?: Record<string, unknown>;
+	/** REAL field is `tool_response`; `tool_result`/`tool_output` are fallbacks
+	 *  from earlier inferred schemas, retained so a payload from any source maps. */
+	tool_response?: unknown;
+	tool_result?: unknown;
+	tool_output?: unknown;
+	error?: string;
+}
+
+export interface MessageDisplayHook extends HookCommon {
+	hook_event_name: 'MessageDisplay';
+	message_id?: string;
+	turn_id?: string;
+	delta?: string; // streamed text chunk
+	final?: boolean; // terminal chunk of a message
+}
+
+export interface StopHook extends HookCommon {
+	hook_event_name: 'Stop';
+}
+
+export interface SessionStartHook extends HookCommon {
+	hook_event_name: 'SessionStart';
+	source?: string;
+	model?: string;
+}
+
+export interface SessionEndHook extends HookCommon {
+	hook_event_name: 'SessionEnd';
+	end_reason?: string;
+}
+
+export interface PreCompactHook extends HookCommon {
+	hook_event_name: 'PreCompact';
+	trigger?: string;
+}
+
+export interface NotificationHook extends HookCommon {
+	hook_event_name: 'Notification';
+	notification_type?: string;
+}
+
+export interface SubagentStartHook extends HookCommon {
+	hook_event_name: 'SubagentStart';
+	agent_type?: string;
+}
+
+export interface SubagentStopHook extends HookCommon {
+	hook_event_name: 'SubagentStop';
+	agent_type?: string;
+}
+
+export interface TaskCreatedHook extends HookCommon {
+	hook_event_name: 'TaskCreated';
+	task_id?: string;
+	task_title?: string;
+}
+
+export interface TaskCompletedHook extends HookCommon {
+	hook_event_name: 'TaskCompleted';
+	task_id?: string;
+}
+
+/** The modeled hooks — a clean discriminated union (no string-typed member), so
+ *  a `switch (hook.hook_event_name)` narrows each case to its exact interface. */
+export type KnownHook =
+	| UserPromptSubmitHook
+	| UserPromptExpansionHook
+	| PreToolUseHook
+	| PostToolUseHook
+	| MessageDisplayHook
+	| StopHook
+	| SessionStartHook
+	| SessionEndHook
+	| PreCompactHook
+	| NotificationHook
+	| SubagentStartHook
+	| SubagentStopHook
+	| TaskCreatedHook
+	| TaskCompletedHook;
+
+export type KnownHookEventName = KnownHook['hook_event_name'];
+
+/** Forward-compatible escape hatch: any not-yet-modeled event. Kept OUT of the
+ *  `KnownHook` union so its string `hook_event_name` never pollutes narrowing. */
+export interface UnknownHook extends HookCommon {
+	hook_event_name: string;
+	[k: string]: unknown;
+}
+
+export type ClaudeCodeHook = KnownHook | UnknownHook;
+
+/** Runtime mirror of `KnownHookEventName` (the type can't produce a Set). The
+ *  `Set<KnownHookEventName>` element type makes a typo a compile error. */
+export const KNOWN_HOOK_EVENT_NAMES: ReadonlySet<KnownHookEventName> = new Set<KnownHookEventName>([
+	'UserPromptSubmit',
+	'UserPromptExpansion',
+	'PreToolUse',
+	'PostToolUse',
+	'PostToolUseFailure',
+	'MessageDisplay',
+	'Stop',
+	'SessionStart',
+	'SessionEnd',
+	'PreCompact',
+	'Notification',
+	'SubagentStart',
+	'SubagentStop',
+	'TaskCreated',
+	'TaskCompleted',
+]);
+
+/**
+ * Detect + strictly type. Returns the typed `ClaudeCodeHook` when `payload` is a
+ * plausible CC hook (object with a non-empty string `hook_event_name`), else
+ * `null` so the collector drops it. The single boundary cast lives HERE, after
+ * the runtime check — downstream code is cast-free.
+ */
+export function decodeClaudeCodeHook(payload: unknown): ClaudeCodeHook | null {
+	if (payload === null || typeof payload !== 'object') return null;
+	const name = (payload as { hook_event_name?: unknown }).hook_event_name;
+	if (typeof name !== 'string' || name.length === 0) return null;
+	return payload as ClaudeCodeHook;
+}
+
+/** Narrow a decoded hook to the modeled subset. Unknown/forward events fail this
+ *  and take the generic `cc.hook.<name>` path. */
+export function isKnownHook(hook: ClaudeCodeHook): hook is KnownHook {
+	return KNOWN_HOOK_EVENT_NAMES.has(hook.hook_event_name as KnownHookEventName);
+}

--- a/src/adapters/executor/claude-code/sources/cc-records.ts
+++ b/src/adapters/executor/claude-code/sources/cc-records.ts
@@ -1,0 +1,110 @@
+/**
+ * Input types for the Claude Code telemetry mappers — the shapes the three
+ * sources (OTel, hooks, .jsonl transcript) deliver. These are the ADAPTER's
+ * model of CC's default emissions; the mappers turn them into the kernel's
+ * `ObsEvent` / `UsageRecord`. Pure data; no behavior.
+ *
+ * A live source enriches each record with the host `node` and a `receivedAt`
+ * (for hook/.jsonl records that carry no reliable timestamp) before mapping —
+ * passed via `MapContext` so the mappers stay referentially transparent
+ * (no `Date.now()`/random inside a mapper, so output is byte-exact testable).
+ */
+
+import type { ObsEvent } from '../../../../kernel/obs/types.js';
+import type { UsageRecord } from '../../../../kernel/meter/types.js';
+
+/** OTel resource attributes ride on every OTLP record. All optional. */
+export interface ResourceAttrs {
+	'session.id'?: string;
+	'user.id'?: string;
+	'user.email'?: string;
+	'user.account_uuid'?: string;
+	'organization.id'?: string;
+	'app.version'?: string;
+	'terminal.type'?: string;
+	'app.entrypoint'?: string;
+	[k: string]: unknown;
+}
+
+export interface OtelMetricRecord {
+	name: string; // "claude_code.token.usage" | "claude_code.cost.usage" | ...
+	value: number;
+	ts?: number; // unix seconds
+	attrs?: Record<string, unknown>; // datapoint attrs (type, model, query_source, ...)
+	resource?: ResourceAttrs;
+}
+
+export interface OtelLogRecord {
+	event: string; // "claude_code.user_prompt" | "claude_code.tool_result" | ...
+	ts?: number;
+	attrs?: Record<string, unknown>;
+	resource?: ResourceAttrs;
+}
+
+export interface OtelSpanRecord {
+	name: string; // "claude_code.llm_request" | "claude_code.tool" | "claude_code.interaction"
+	spanId?: string;
+	parentSpanId?: string;
+	ts?: number;
+	durationMs?: number;
+	attrs?: Record<string, unknown>;
+	resource?: ResourceAttrs;
+}
+
+export type OtelRecord =
+	| { signal: 'metric'; metric: OtelMetricRecord }
+	| { signal: 'log'; log: OtelLogRecord }
+	| { signal: 'span'; span: OtelSpanRecord };
+
+/** A hook payload. Always carries the common keys; event-specific keys vary. */
+export interface HookPayload {
+	hook_event_name: string;
+	session_id?: string;
+	transcript_path?: string;
+	cwd?: string;
+	permission_mode?: string;
+	tool_name?: string;
+	tool_input?: Record<string, unknown>;
+	tool_output?: unknown;
+	error?: string;
+	source?: string; // SessionStart
+	model?: string;
+	end_reason?: string; // SessionEnd
+	trigger?: string; // PreCompact
+	notification_type?: string; // Notification
+	[k: string]: unknown;
+}
+
+/** One parsed line of the `~/.claude/.../<session>.jsonl` transcript. */
+export interface TranscriptLine {
+	type: string; // "assistant" | "tool_use" | "tool_result" | "session_start" | ...
+	ts?: number;
+	usage?: {
+		input_tokens?: number;
+		output_tokens?: number;
+		cache_read_tokens?: number;
+		cache_creation_tokens?: number;
+	};
+	model?: string;
+	request_id?: string;
+	session_id?: string;
+	tool_name?: string;
+	tool_input?: Record<string, unknown>;
+	tool_use_id?: string;
+	tool_output?: unknown;
+	error?: string | null;
+	source?: string;
+	[k: string]: unknown;
+}
+
+/** Host + timing context a live source injects so mappers stay pure. */
+export interface MapContext {
+	node: string;
+	receivedAt: number; // unix SECONDS; used when the record carries no ts
+}
+
+/** Every mapper returns this. */
+export interface MapResult {
+	events: ObsEvent[];
+	usage: UsageRecord[];
+}

--- a/src/adapters/executor/claude-code/sources/cc-records.ts
+++ b/src/adapters/executor/claude-code/sources/cc-records.ts
@@ -56,24 +56,9 @@ export type OtelRecord =
 	| { signal: 'log'; log: OtelLogRecord }
 	| { signal: 'span'; span: OtelSpanRecord };
 
-/** A hook payload. Always carries the common keys; event-specific keys vary. */
-export interface HookPayload {
-	hook_event_name: string;
-	session_id?: string;
-	transcript_path?: string;
-	cwd?: string;
-	permission_mode?: string;
-	tool_name?: string;
-	tool_input?: Record<string, unknown>;
-	tool_output?: unknown;
-	error?: string;
-	source?: string; // SessionStart
-	model?: string;
-	end_reason?: string; // SessionEnd
-	trigger?: string; // PreCompact
-	notification_type?: string; // Notification
-	[k: string]: unknown;
-}
+// Hook payloads now have a strict, discriminated home: `cc-hooks.ts`
+// (ClaudeCodeHook + decodeClaudeCodeHook). The old loose `HookPayload` flat
+// interface was removed in favor of that per-event union.
 
 /** One parsed line of the `~/.claude/.../<session>.jsonl` transcript. */
 export interface TranscriptLine {

--- a/src/adapters/executor/claude-code/sources/hook-map.ts
+++ b/src/adapters/executor/claude-code/sources/hook-map.ts
@@ -1,23 +1,30 @@
 /**
- * `hookMap(payload, ctx)` — map one Claude Code hook payload to spine primitives.
- * Hooks are OBS-ONLY (lifecycle / tool decisions; no authoritative tokens). The
- * ~29-event tail is covered by a forward-compatible default branch. File-op tool
- * hooks (Read/Write/Edit) additionally emit a paired `file.*` event — this is
- * how core-cli file consumption is recorded without instrumenting the core. Pure.
+ * `hookMap(hook, ctx)` — map ONE strictly-typed Claude Code hook to spine
+ * primitives. Input is the decoded `ClaudeCodeHook` union (see `cc-hooks.ts`),
+ * so every case narrows to its exact interface — no `as`, no field guessing.
+ *
+ * Hooks are OBS-ONLY (lifecycle / tool decisions; no authoritative tokens), so
+ * `usage` is always empty. Unknown / not-yet-modeled events take a forward-
+ * compatible `cc.hook.<snake(name)>` branch carrying every non-envelope field.
+ * File-op tool hooks (Read/Write/Edit) additionally emit a paired `file.*`
+ * event — this is how core-cli file consumption is recorded without
+ * instrumenting the core. Pure (no Date.now()/random; ts comes via ctx).
  */
 
 import type { ObsEvent, Outcome } from '../../../../kernel/obs/types.js';
-import type { HookPayload, MapContext, MapResult } from './cc-records.js';
-import { baseEvent, clean, fileOpFor, pathFromToolInput, tsOf } from './_map-util.js';
+import type { MapContext, MapResult } from './cc-records.js';
+import type { ClaudeCodeHook } from './cc-hooks.js';
+import { isKnownHook } from './cc-hooks.js';
+import { baseEvent, clean, fileOpFor, nonCommon, pathFromToolInput, trunc, tsOf } from './_map-util.js';
 
 function snake(s: string): string {
 	return s.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
 }
 
-export function hookMap(payload: HookPayload, ctx: MapContext): MapResult {
-	const ts = tsOf(typeof payload.ts === 'number' ? payload.ts : undefined, ctx);
-	const sessionId = payload.session_id;
-	const common = { session_id: sessionId, cwd: payload.cwd, permission_mode: payload.permission_mode };
+export function hookMap(hook: ClaudeCodeHook, ctx: MapContext): MapResult {
+	const ts = tsOf(typeof hook.ts === 'number' ? hook.ts : undefined, ctx);
+	const sessionId = hook.session_id;
+	const common = { session_id: sessionId, cwd: hook.cwd, permission_mode: hook.permission_mode };
 	const events: ObsEvent[] = [];
 
 	const ev = (kind: string, outcome: Outcome, data: Record<string, unknown>): ObsEvent => {
@@ -26,69 +33,77 @@ export function hookMap(payload: HookPayload, ctx: MapContext): MapResult {
 		return e;
 	};
 
-	const name = payload.hook_event_name;
-	switch (name) {
+	// Unknown / not-yet-modeled event → forward-compatible generic capture.
+	// Guard FIRST so the `switch` below sees only the clean `KnownHook` union.
+	if (!isKnownHook(hook)) {
+		events.push(ev('cc.hook.' + snake(hook.hook_event_name), 'ok', nonCommon(hook)));
+		return { events, usage: [] };
+	}
+
+	switch (hook.hook_event_name) {
 		case 'PreToolUse':
-			events.push(ev('tool.call', 'ok', { tool_name: payload.tool_name, tool_input: payload.tool_input }));
+			events.push(ev('tool.call', 'ok', { tool_name: hook.tool_name, tool_input: trunc(hook.tool_input) }));
 			break;
 		case 'PostToolUse':
 		case 'PostToolUseFailure': {
-			const outcome: Outcome = name === 'PostToolUseFailure' ? 'error' : 'ok';
+			const outcome: Outcome = hook.hook_event_name === 'PostToolUseFailure' ? 'error' : 'ok';
 			events.push(
 				ev('tool.result', outcome, {
-					tool_name: payload.tool_name,
-					tool_input: payload.tool_input,
-					tool_output: payload.tool_output,
-					error: payload.error,
+					tool_name: hook.tool_name,
+					tool_input: trunc(hook.tool_input),
+					// real field is `tool_response`; fall back to the inferred names
+					tool_output: trunc(hook.tool_response ?? hook.tool_result ?? hook.tool_output),
+					error: hook.error,
 				}),
 			);
-			const fo = fileOpFor(payload.tool_name);
-			const path = pathFromToolInput(payload.tool_input);
+			const fo = fileOpFor(hook.tool_name);
+			const path = pathFromToolInput(hook.tool_input);
 			if (fo && path) {
 				const fe = baseEvent({ sessionId, kind: fo.kind, outcome, ctx, ts });
 				fe.source_file = path;
-				fe.data = clean({ ...common, op: fo.op, tool_name: payload.tool_name });
+				fe.data = clean({ ...common, op: fo.op, tool_name: hook.tool_name });
 				events.push(fe);
 			}
 			break;
 		}
+		case 'UserPromptSubmit':
+			events.push(ev('cc.prompt', 'ok', { prompt: trunc(hook.prompt) }));
+			break;
+		case 'UserPromptExpansion':
+			// field shape unverified — capture whatever it actually sends
+			events.push(ev('cc.prompt_expansion', 'ok', nonCommon(hook)));
+			break;
+		case 'MessageDisplay':
+			// streamed in `delta` chunks; accumulated into one `cc.message` by the
+			// normalizer (stateful) — never produces an event from the pure mapper.
+			break;
 		case 'Stop':
 			events.push(ev('cc.hook.stop', 'ok', {}));
 			break;
 		case 'SessionStart':
-			events.push(ev('cc.hook.session_start', 'ok', { source: payload.source, model: payload.model }));
+			events.push(ev('cc.hook.session_start', 'ok', { source: hook.source, model: hook.model }));
 			break;
 		case 'SessionEnd':
-			events.push(ev('cc.hook.session_end', 'ok', { end_reason: payload.end_reason }));
+			events.push(ev('cc.hook.session_end', 'ok', { end_reason: hook.end_reason }));
 			break;
 		case 'PreCompact':
-			events.push(ev('cc.hook.pre_compact', 'ok', { trigger: payload.trigger }));
+			events.push(ev('cc.hook.pre_compact', 'ok', { trigger: hook.trigger }));
 			break;
 		case 'Notification':
-			events.push(ev('cc.hook.notification', 'ok', { notification_type: payload.notification_type }));
+			events.push(ev('cc.hook.notification', 'ok', { notification_type: hook.notification_type }));
 			break;
 		case 'SubagentStart':
-			events.push(ev('cc.hook.subagent_start', 'ok', { agent_type: payload.agent_type }));
+			events.push(ev('cc.hook.subagent_start', 'ok', { agent_type: hook.agent_type }));
 			break;
 		case 'SubagentStop':
-			events.push(ev('cc.hook.subagent_stop', 'ok', { agent_type: payload.agent_type }));
+			events.push(ev('cc.hook.subagent_stop', 'ok', { agent_type: hook.agent_type }));
 			break;
 		case 'TaskCreated':
-			events.push(ev('cc.hook.task_created', 'ok', { task_id: payload.task_id, task_title: payload.task_title }));
+			events.push(ev('cc.hook.task_created', 'ok', { task_id: hook.task_id, task_title: hook.task_title }));
 			break;
 		case 'TaskCompleted':
-			events.push(ev('cc.hook.task_completed', 'ok', { task_id: payload.task_id }));
+			events.push(ev('cc.hook.task_completed', 'ok', { task_id: hook.task_id }));
 			break;
-		default: {
-			// forward-compatible: cc.hook.<snake(event)> carrying the payload minus
-			// the common keys, so a not-yet-modeled hook still lands structured.
-			const rest: Record<string, unknown> = {};
-			for (const [k, v] of Object.entries(payload)) {
-				if (['hook_event_name', 'session_id', 'transcript_path', 'cwd', 'permission_mode', 'ts'].includes(k)) continue;
-				rest[k] = v;
-			}
-			events.push(ev('cc.hook.' + snake(name), 'ok', rest));
-		}
 	}
 
 	return { events, usage: [] };

--- a/src/adapters/executor/claude-code/sources/hook-map.ts
+++ b/src/adapters/executor/claude-code/sources/hook-map.ts
@@ -1,0 +1,95 @@
+/**
+ * `hookMap(payload, ctx)` — map one Claude Code hook payload to spine primitives.
+ * Hooks are OBS-ONLY (lifecycle / tool decisions; no authoritative tokens). The
+ * ~29-event tail is covered by a forward-compatible default branch. File-op tool
+ * hooks (Read/Write/Edit) additionally emit a paired `file.*` event — this is
+ * how core-cli file consumption is recorded without instrumenting the core. Pure.
+ */
+
+import type { ObsEvent, Outcome } from '../../../../kernel/obs/types.js';
+import type { HookPayload, MapContext, MapResult } from './cc-records.js';
+import { baseEvent, clean, fileOpFor, pathFromToolInput, tsOf } from './_map-util.js';
+
+function snake(s: string): string {
+	return s.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+}
+
+export function hookMap(payload: HookPayload, ctx: MapContext): MapResult {
+	const ts = tsOf(typeof payload.ts === 'number' ? payload.ts : undefined, ctx);
+	const sessionId = payload.session_id;
+	const common = { session_id: sessionId, cwd: payload.cwd, permission_mode: payload.permission_mode };
+	const events: ObsEvent[] = [];
+
+	const ev = (kind: string, outcome: Outcome, data: Record<string, unknown>): ObsEvent => {
+		const e = baseEvent({ sessionId, kind, outcome, ctx, ts });
+		e.data = clean({ ...common, ...data });
+		return e;
+	};
+
+	const name = payload.hook_event_name;
+	switch (name) {
+		case 'PreToolUse':
+			events.push(ev('tool.call', 'ok', { tool_name: payload.tool_name, tool_input: payload.tool_input }));
+			break;
+		case 'PostToolUse':
+		case 'PostToolUseFailure': {
+			const outcome: Outcome = name === 'PostToolUseFailure' ? 'error' : 'ok';
+			events.push(
+				ev('tool.result', outcome, {
+					tool_name: payload.tool_name,
+					tool_input: payload.tool_input,
+					tool_output: payload.tool_output,
+					error: payload.error,
+				}),
+			);
+			const fo = fileOpFor(payload.tool_name);
+			const path = pathFromToolInput(payload.tool_input);
+			if (fo && path) {
+				const fe = baseEvent({ sessionId, kind: fo.kind, outcome, ctx, ts });
+				fe.source_file = path;
+				fe.data = clean({ ...common, op: fo.op, tool_name: payload.tool_name });
+				events.push(fe);
+			}
+			break;
+		}
+		case 'Stop':
+			events.push(ev('cc.hook.stop', 'ok', {}));
+			break;
+		case 'SessionStart':
+			events.push(ev('cc.hook.session_start', 'ok', { source: payload.source, model: payload.model }));
+			break;
+		case 'SessionEnd':
+			events.push(ev('cc.hook.session_end', 'ok', { end_reason: payload.end_reason }));
+			break;
+		case 'PreCompact':
+			events.push(ev('cc.hook.pre_compact', 'ok', { trigger: payload.trigger }));
+			break;
+		case 'Notification':
+			events.push(ev('cc.hook.notification', 'ok', { notification_type: payload.notification_type }));
+			break;
+		case 'SubagentStart':
+			events.push(ev('cc.hook.subagent_start', 'ok', { agent_type: payload.agent_type }));
+			break;
+		case 'SubagentStop':
+			events.push(ev('cc.hook.subagent_stop', 'ok', { agent_type: payload.agent_type }));
+			break;
+		case 'TaskCreated':
+			events.push(ev('cc.hook.task_created', 'ok', { task_id: payload.task_id, task_title: payload.task_title }));
+			break;
+		case 'TaskCompleted':
+			events.push(ev('cc.hook.task_completed', 'ok', { task_id: payload.task_id }));
+			break;
+		default: {
+			// forward-compatible: cc.hook.<snake(event)> carrying the payload minus
+			// the common keys, so a not-yet-modeled hook still lands structured.
+			const rest: Record<string, unknown> = {};
+			for (const [k, v] of Object.entries(payload)) {
+				if (['hook_event_name', 'session_id', 'transcript_path', 'cwd', 'permission_mode', 'ts'].includes(k)) continue;
+				rest[k] = v;
+			}
+			events.push(ev('cc.hook.' + snake(name), 'ok', rest));
+		}
+	}
+
+	return { events, usage: [] };
+}

--- a/src/adapters/executor/claude-code/sources/hook-normalizer.ts
+++ b/src/adapters/executor/claude-code/sources/hook-normalizer.ts
@@ -1,0 +1,79 @@
+/**
+ * Claude Code hooks → spine primitives, as a composable collector Normalizer.
+ *
+ * Extends `AbstractNormalizer<ClaudeCodeHook>`, so the pipeline reads as
+ * "DETECT + strictly type, THEN map":
+ *
+ *   decode(unknown) → ClaudeCodeHook | null    (cc-hooks: the ingest contract)
+ *   map(ClaudeCodeHook) → { events, usage }     (hookMap + MessageDisplay accum)
+ *
+ * This is the CC-specific plug for the general kernel collector. It owns the
+ * CC-isms — the strict hook union, the real field names, MessageDisplay delta
+ * accumulation — and emits the universal ObsEvent vocabulary. The collector
+ * stays source-agnostic; Claude Code is just one registered source. Per the
+ * architecture rules, all Claude-isms live here, not in the kernel.
+ *
+ * Hooks are OBS-ONLY (no authoritative tokens) → `usage` is always empty.
+ *
+ * MessageDisplay streams in `delta` chunks with a `final` flag, so it's
+ * accumulated here (stateful, per message_id) into one `cc.message` per turn —
+ * the pure `hookMap` can't. Everything else goes through `hookMap`.
+ */
+
+import { AbstractNormalizer, EMPTY, type NormalizeContext, type NormalizeResult } from '../../../../kernel/collector/normalizer.js';
+import type { ObsEvent } from '../../../../kernel/obs/types.js';
+import type { ClaudeCodeHook, MessageDisplayHook } from './cc-hooks.js';
+import { decodeClaudeCodeHook, isKnownHook } from './cc-hooks.js';
+import { traceIdFromSession } from './ids.js';
+import { trunc } from './_map-util.js';
+import { hookMap } from './hook-map.js';
+
+export const CC_HOOKS_SOURCE = 'claude-code-hooks';
+
+export class ClaudeCodeHookNormalizer extends AbstractNormalizer<ClaudeCodeHook> {
+	readonly source = CC_HOOKS_SOURCE;
+	private readonly msgBuf = new Map<string, { text: string; sessionId: string; ts: number }>();
+
+	/** Detect + strictly type the raw hook body — the ingest boundary. */
+	decode(payload: unknown): ClaudeCodeHook | null {
+		return decodeClaudeCodeHook(payload);
+	}
+
+	/** Map the typed hook to spine primitives. MessageDisplay is accumulated
+	 *  (stateful); everything else is the pure `hookMap`. */
+	map(hook: ClaudeCodeHook, ctx: NormalizeContext): NormalizeResult {
+		if (isKnownHook(hook) && hook.hook_event_name === 'MessageDisplay') {
+			const e = this.accumulate(hook, ctx);
+			return e ? { events: [e], usage: [] } : EMPTY;
+		}
+		return hookMap(hook, ctx);
+	}
+
+	/** Buffer streamed MessageDisplay deltas by message id; flush one cc.message
+	 *  on the terminal (`final === true`) chunk. */
+	private accumulate(p: MessageDisplayHook, ctx: NormalizeContext): ObsEvent | null {
+		const id = p.message_id ?? p.turn_id;
+		if (!id) return null;
+		const buf = this.msgBuf.get(id) ?? { text: '', sessionId: p.session_id ?? 'unknown', ts: ctx.receivedAt };
+		if (typeof p.delta === 'string') buf.text += p.delta;
+		this.msgBuf.set(id, buf);
+		if (this.msgBuf.size > 200) {
+			// leak guard: drop the oldest if a `final` never arrives
+			const k = this.msgBuf.keys().next().value;
+			if (k) this.msgBuf.delete(k);
+		}
+		if (p.final !== true) return null;
+		this.msgBuf.delete(id);
+		return {
+			schema: 1,
+			ts: buf.ts,
+			trace_id: traceIdFromSession(buf.sessionId),
+			node: ctx.node,
+			source: 'core-cli',
+			actor: { user_id: 'core', channel: 'claude-code', access_tier: 'owner', tenant_id: null },
+			kind: 'cc.message',
+			outcome: 'ok',
+			data: { text: trunc(buf.text), message_id: String(id) },
+		};
+	}
+}

--- a/src/adapters/executor/claude-code/sources/ids.ts
+++ b/src/adapters/executor/claude-code/sources/ids.ts
@@ -1,0 +1,57 @@
+/**
+ * Claude Code id adoption (pure). The interactive core is a process we don't
+ * control, so we ADOPT its correlation ids rather than minting our own — that's
+ * how the three sources (OTel, hooks, .jsonl) agree on one trace per CC session
+ * without coordinating.
+ *
+ *   session.id  → trace_id   ("cc-sess:<id>")      one CC session = one trace
+ *   OTel spanId → span_id    ("sp_<id>")           pass-through, namespaced
+ *   request_id  → usage_id   ("cc:tok:<id>[:type]")the idempotency key
+ *   org.id      → tenant_id / actor.tenant_id
+ *   user.id     → actor.user_id (channel=claude-code, tier=owner)
+ */
+
+import type { Actor } from '../../../../kernel/obs/types.js';
+import type { ResourceAttrs } from './cc-records.js';
+
+export function traceIdFromSession(sessionId?: string): string {
+	return 'cc-sess:' + (sessionId && sessionId.length > 0 ? sessionId : 'unknown');
+}
+
+export function spanIdFromCcSpan(ccSpanId?: string): string | undefined {
+	return ccSpanId ? 'sp_' + ccSpanId : undefined;
+}
+
+/** `cc:tok:<request_id>` when a request_id is known (the cross-source idempotency
+ *  key); otherwise a coarser `cc:tok:<session>:<ts-bucket>` fallback. An optional
+ *  `typeSuffix` distinguishes per-type metric datapoints of the same request so
+ *  they don't clobber when metrics are the sole source. */
+export function usageIdFromRequest(
+	requestId: string | undefined,
+	fallback: { sessionId?: string; tsBucket?: number },
+	typeSuffix?: string,
+): string {
+	const base = requestId
+		? 'cc:tok:' + requestId
+		: 'cc:tok:' + (fallback.sessionId ?? 'unknown') + ':' + (fallback.tsBucket ?? 0);
+	return typeSuffix ? base + ':' + typeSuffix : base;
+}
+
+export function tenantFromResource(res?: ResourceAttrs): string | null {
+	const org = res?.['organization.id'];
+	return typeof org === 'string' && org.length > 0 ? org : null;
+}
+
+export function actorFromResourceAttrs(res?: ResourceAttrs): Actor {
+	const userId =
+		(typeof res?.['user.id'] === 'string' && (res['user.id'] as string)) ||
+		(typeof res?.['user.account_uuid'] === 'string' && (res['user.account_uuid'] as string)) ||
+		'core';
+	const actor: Actor = {
+		user_id: userId,
+		channel: 'claude-code',
+		access_tier: 'owner',
+		tenant_id: tenantFromResource(res),
+	};
+	return actor;
+}

--- a/src/adapters/executor/claude-code/sources/otel-map.ts
+++ b/src/adapters/executor/claude-code/sources/otel-map.ts
@@ -1,0 +1,245 @@
+/**
+ * `otelMap(rec, ctx)` — map one Claude Code OpenTelemetry record (metric, log,
+ * or span) to spine primitives. Pure: all wall-clock/host facts come from the
+ * record or `ctx`, never from `Date.now()`. See the routing table in
+ * docs/migration. Twin-less (mappers are TS-only; the executor sources are TS).
+ */
+
+import type { ObsEvent, Outcome, UsageAdvisory } from '../../../../kernel/obs/types.js';
+import type { UsageRecord } from '../../../../kernel/meter/types.js';
+import type { MapContext, MapResult, OtelLogRecord, OtelMetricRecord, OtelSpanRecord, OtelRecord } from './cc-records.js';
+import {
+	actorFromResourceAttrs,
+	spanIdFromCcSpan,
+	tenantFromResource,
+	traceIdFromSession,
+	usageIdFromRequest,
+} from './ids.js';
+import { CORE_SOURCE, baseEvent, clean, num, tsBucket, tsOf } from './_map-util.js';
+
+const TOKEN_SLOT: Record<string, string> = {
+	input: 'input_tokens',
+	output: 'output_tokens',
+	cacheRead: 'cache_read',
+	cacheCreation: 'cache_creation',
+};
+
+const COUNTER_KIND: Record<string, string> = {
+	'claude_code.lines_of_code.count': 'cc.code.lines',
+	'claude_code.commit.count': 'cc.git.commit',
+	'claude_code.pull_request.count': 'cc.git.pr',
+	'claude_code.session.count': 'cc.session.count',
+	'claude_code.active_time.total': 'cc.active_time',
+	'claude_code.code_edit_tool.decision': 'cc.tool.decision',
+};
+
+function mapMetric(m: OtelMetricRecord, ctx: MapContext): MapResult {
+	const res = m.resource;
+	const ts = tsOf(m.ts, ctx);
+	const sessionId = res?.['session.id'];
+	const a = m.attrs ?? {};
+	const requestId = typeof a.request_id === 'string' ? a.request_id : undefined;
+
+	if (m.name === 'claude_code.token.usage') {
+		const type = String(a.type ?? '');
+		const slot = TOKEN_SLOT[type];
+		const attrs: Record<string, unknown> = clean({
+			_cc_source: 'otel-metric',
+			model: a.model,
+			query_source: a.query_source,
+			type,
+		});
+		if (slot) attrs[slot] = m.value;
+		const usage: UsageRecord = {
+			schema: 1,
+			usage_id: usageIdFromRequest(requestId, { sessionId, tsBucket: tsBucket(ts) }, type),
+			ts,
+			tenant_id: tenantFromResource(res),
+			trace_id: traceIdFromSession(sessionId),
+			actor: actorFromResourceAttrs(res),
+			source: CORE_SOURCE,
+			meter: 'claude.tokens',
+			quantity: m.value,
+			unit: 'tokens',
+			provider: 'anthropic',
+			provider_ref: requestId ?? null,
+			attrs,
+		};
+		return { events: [], usage: [usage] };
+	}
+
+	if (m.name === 'claude_code.cost.usage') {
+		const usage: UsageRecord = {
+			schema: 1,
+			usage_id: usageIdFromRequest(requestId, { sessionId, tsBucket: tsBucket(ts) }, 'cost'),
+			ts,
+			tenant_id: tenantFromResource(res),
+			trace_id: traceIdFromSession(sessionId),
+			actor: actorFromResourceAttrs(res),
+			source: CORE_SOURCE,
+			meter: 'claude.cost',
+			quantity: m.value,
+			unit: 'usd',
+			provider: 'anthropic',
+			provider_ref: requestId ?? null,
+			attrs: clean({ _cc_source: 'otel-metric', model: a.model, cost_usd: m.value }),
+		};
+		return { events: [], usage: [usage] };
+	}
+
+	// counters → obs
+	const kind = COUNTER_KIND[m.name] ?? 'cc.metric.' + m.name.replace(/^claude_code\./, '');
+	const ev = baseEvent({ res, kind, outcome: 'ok', ctx, ts });
+	ev.data = clean({ value: m.value, ...a });
+	return { events: [ev], usage: [] };
+}
+
+function mapLog(l: OtelLogRecord, ctx: MapContext): MapResult {
+	const res = l.resource;
+	const ts = tsOf(l.ts, ctx);
+	const a = l.attrs ?? {};
+	const promptId = a['prompt.id'] ?? a.prompt_id;
+
+	const make = (kind: string, outcome: Outcome, data: Record<string, unknown>): ObsEvent => {
+		const ev = baseEvent({ res, kind, outcome, ctx, ts });
+		ev.data = clean({ prompt_id: promptId, ...data });
+		return ev;
+	};
+
+	switch (l.event) {
+		case 'claude_code.user_prompt':
+			return { events: [make('cc.prompt', 'ok', { prompt_length: a.prompt_length, prompt: a.prompt })], usage: [] };
+		case 'claude_code.tool_result': {
+			const outcome: Outcome = a.tool_decision === 'reject' ? 'denied' : a.error ? 'error' : 'ok';
+			return {
+				events: [
+					make('tool.result', outcome, {
+						tool_name: a.tool_name,
+						tool_decision: a.tool_decision,
+						decision_source: a.decision_source,
+						tool_use_id: a.tool_use_id,
+					}),
+				],
+				usage: [],
+			};
+		}
+		case 'claude_code.tool_decision':
+			return {
+				events: [make('cc.tool.decision', a.decision === 'reject' ? 'denied' : 'ok', { tool_name: a.tool_name, decision: a.decision })],
+				usage: [],
+			};
+		case 'claude_code.api_request':
+			return { events: [make('cc.api.request', 'ok', { body: a.body })], usage: [] };
+		case 'claude_code.api_response_body':
+			return {
+				events: [make('cc.api.response', typeof a.status_code === 'number' && a.status_code >= 400 ? 'error' : 'ok', { status_code: a.status_code })],
+				usage: [],
+			};
+		case 'mcp_server_connection':
+			return { events: [make('cc.mcp.connection', 'ok', { mcp_server: a['mcp_server.name'] ?? a.mcp_server })], usage: [] };
+		case 'permission_mode_changed':
+			return { events: [make('cc.permission.mode', 'ok', { new_mode: a.new_mode })], usage: [] };
+		default:
+			return { events: [make('cc.log.' + l.event.replace(/^claude_code\./, ''), 'ok', a)], usage: [] };
+	}
+}
+
+function mapSpan(s: OtelSpanRecord, ctx: MapContext): MapResult {
+	const res = s.resource;
+	const ts = tsOf(s.ts, ctx);
+	const a = s.attrs ?? {};
+	const spanId = spanIdFromCcSpan(s.spanId);
+	const parent = spanIdFromCcSpan(s.parentSpanId);
+	const withSpan = (e: ObsEvent): ObsEvent => {
+		if (spanId) e.span_id = spanId;
+		if (parent) e.parent_span_id = parent;
+		if (typeof s.durationMs === 'number') e.duration_ms = s.durationMs;
+		return e;
+	};
+
+	switch (s.name) {
+		case 'claude_code.interaction': {
+			const e = withSpan(baseEvent({ res, kind: 'cc.interaction', outcome: 'ok', ctx, ts }));
+			e.data = clean({ interaction_sequence: a['interaction.sequence'], user_prompt_length: a.user_prompt_length });
+			return { events: [e], usage: [] };
+		}
+		case 'claude_code.llm_request': {
+			const requestId = typeof a.request_id === 'string' ? a.request_id : undefined;
+			const sessionId = res?.['session.id'];
+			const input = num(a.input_tokens);
+			const output = num(a.output_tokens);
+			const advisory: UsageAdvisory = clean({
+				provider: 'anthropic',
+				model: typeof a.model === 'string' ? a.model : undefined,
+				input_tokens: input,
+				output_tokens: output,
+				cache_read: num(a.cache_read_tokens),
+				cache_creation: num(a.cache_creation_tokens),
+			});
+			const usage: UsageRecord = {
+				schema: 1,
+				usage_id: usageIdFromRequest(requestId, { sessionId, tsBucket: tsBucket(ts) }),
+				ts,
+				tenant_id: tenantFromResource(res),
+				trace_id: traceIdFromSession(sessionId),
+				actor: actorFromResourceAttrs(res),
+				source: CORE_SOURCE,
+				meter: 'claude.tokens',
+				quantity: (input ?? 0) + (output ?? 0),
+				unit: 'tokens',
+				provider: 'anthropic',
+				provider_ref: requestId ?? null,
+				attrs: clean({
+					_cc_source: 'otel-span',
+					model: a.model,
+					input_tokens: input,
+					output_tokens: output,
+					cache_read: num(a.cache_read_tokens),
+					cache_creation: num(a.cache_creation_tokens),
+				}),
+			};
+			const e = withSpan(baseEvent({ res, kind: 'cc.llm_request', outcome: a.success === false ? 'error' : 'ok', ctx, ts }));
+			e.usage = advisory;
+			e.data = clean({
+				request_id: requestId,
+				ttft_ms: a.ttft_ms,
+				stop_reason: a.stop_reason,
+				status_code: a.status_code,
+				query_source: a.query_source,
+			});
+			return { events: [e], usage: [usage] };
+		}
+		case 'claude_code.tool': {
+			const e = withSpan(baseEvent({ res, kind: 'tool.call', outcome: 'ok', ctx, ts }));
+			e.data = clean({ tool_name: a.tool_name, tool_use_id: a.tool_use_id, result_tokens: a.result_tokens });
+			if (typeof a.file_path === 'string') e.source_file = a.file_path;
+			return { events: [e], usage: [] };
+		}
+		case 'claude_code.tool.execution': {
+			const e = withSpan(baseEvent({ res, kind: 'cc.tool.execution', outcome: a.success === false ? 'error' : 'ok', ctx, ts }));
+			e.data = clean({ error: a.error });
+			return { events: [e], usage: [] };
+		}
+		case 'claude_code.tool.blocked_on_user': {
+			const e = withSpan(baseEvent({ res, kind: 'cc.tool.blocked', outcome: 'ok', ctx, ts }));
+			e.data = clean({ decision: a.decision, source: a.source });
+			return { events: [e], usage: [] };
+		}
+		default: {
+			const e = withSpan(baseEvent({ res, kind: 'cc.span.' + s.name.replace(/^claude_code\./, ''), outcome: 'ok', ctx, ts }));
+			e.data = clean(a);
+			return { events: [e], usage: [] };
+		}
+	}
+}
+
+export function otelMap(rec: OtelRecord, ctx: MapContext): MapResult {
+	switch (rec.signal) {
+		case 'metric':
+			return mapMetric(rec.metric, ctx);
+		case 'log':
+			return mapLog(rec.log, ctx);
+		case 'span':
+			return mapSpan(rec.span, ctx);
+	}
+}

--- a/src/adapters/executor/claude-code/sources/transcript-map.ts
+++ b/src/adapters/executor/claude-code/sources/transcript-map.ts
@@ -1,0 +1,78 @@
+/**
+ * `transcriptMap(line, ctx)` — map one `.jsonl` transcript line to spine
+ * primitives. The transcript is Anthropic-INTERNAL and fragile, so it is treated
+ * as ENRICHMENT/FALLBACK: usage records are stamped `_cc_source: "jsonl"` (the
+ * lowest triangulation rank) and unrecognized lines are DROPPED (drift-safe),
+ * never thrown on. Pure.
+ */
+
+import type { Outcome } from '../../../../kernel/obs/types.js';
+import type { UsageRecord } from '../../../../kernel/meter/types.js';
+import type { MapContext, MapResult, TranscriptLine } from './cc-records.js';
+import { actorFromResourceAttrs, traceIdFromSession, usageIdFromRequest } from './ids.js';
+import { CORE_SOURCE, baseEvent, clean, fileOpFor, num, pathFromToolInput, tsBucket, tsOf } from './_map-util.js';
+
+export function transcriptMap(line: TranscriptLine, ctx: MapContext): MapResult {
+	const ts = tsOf(line.ts, ctx);
+	const sessionId = line.session_id;
+
+	switch (line.type) {
+		case 'assistant': {
+			if (!line.usage) return { events: [], usage: [] };
+			const u = line.usage;
+			const requestId = line.request_id;
+			const input = num(u.input_tokens);
+			const output = num(u.output_tokens);
+			const usage: UsageRecord = {
+				schema: 1,
+				usage_id: usageIdFromRequest(requestId, { sessionId, tsBucket: tsBucket(ts) }),
+				ts,
+				tenant_id: null,
+				trace_id: traceIdFromSession(sessionId),
+				actor: actorFromResourceAttrs(undefined),
+				source: CORE_SOURCE,
+				meter: 'claude.tokens',
+				quantity: (input ?? 0) + (output ?? 0),
+				unit: 'tokens',
+				provider: 'anthropic',
+				provider_ref: requestId ?? null,
+				attrs: clean({
+					_cc_source: 'jsonl',
+					model: line.model,
+					input_tokens: input,
+					output_tokens: output,
+					cache_read: num(u.cache_read_tokens),
+					cache_creation: num(u.cache_creation_tokens),
+				}),
+			};
+			return { events: [], usage: [usage] };
+		}
+		case 'tool_use': {
+			const e = baseEvent({ sessionId, kind: 'tool.call', outcome: 'ok', ctx, ts });
+			e.data = clean({ tool_name: line.tool_name, tool_input: line.tool_input, tool_use_id: line.tool_use_id });
+			const events = [e];
+			const fo = fileOpFor(line.tool_name);
+			const path = pathFromToolInput(line.tool_input);
+			if (fo && path) {
+				const fe = baseEvent({ sessionId, kind: fo.kind, outcome: 'ok', ctx, ts });
+				fe.source_file = path;
+				fe.data = clean({ op: fo.op, tool_name: line.tool_name });
+				events.push(fe);
+			}
+			return { events, usage: [] };
+		}
+		case 'tool_result': {
+			const outcome: Outcome = line.error ? 'error' : 'ok';
+			const e = baseEvent({ sessionId, kind: 'tool.result', outcome, ctx, ts });
+			e.data = clean({ tool_use_id: line.tool_use_id, error: line.error ?? undefined });
+			return { events: [e], usage: [] };
+		}
+		case 'session_start': {
+			const e = baseEvent({ sessionId, kind: 'cc.transcript.session_start', outcome: 'ok', ctx, ts });
+			e.data = clean({ model: line.model, source: line.source });
+			return { events: [e], usage: [] };
+		}
+		default:
+			return { events: [], usage: [] }; // unrecognized → drop (schema-drift safe)
+	}
+}

--- a/src/adapters/executor/claude-code/sources/triangulate.ts
+++ b/src/adapters/executor/claude-code/sources/triangulate.ts
@@ -1,0 +1,62 @@
+/**
+ * `dedupUsage(records)` — collapse token-usage records that the three sources
+ * report for the SAME request, so no turn is double-counted and no single source
+ * is load-bearing. Pure and order-independent (does not mutate its input).
+ *
+ * Rule: group `claude.tokens` records by `provider_ref` (the request_id). Within
+ * a group, keep only the records from the single HIGHEST-rank source present and
+ * drop the rest:  otel-span (3) > otel-metric (2) > jsonl (1). So:
+ *   - span present  → keep the span's one record, drop metric + jsonl.
+ *   - only metrics  → keep all per-type metric records (they're the sole source).
+ *   - only jsonl    → keep the degraded-but-present fallback.
+ * Records with no `provider_ref` (coarse fallback) and non-token records pass
+ * through. A `claude.cost` record's USD is folded into the surviving token record
+ * of the same request as `attrs.cost_usd`, and the cost record is also kept.
+ */
+
+import type { UsageRecord } from '../../../../kernel/meter/types.js';
+
+const RANK: Record<string, number> = { 'otel-span': 3, 'otel-metric': 2, jsonl: 1 };
+
+function rankOf(r: UsageRecord): number {
+	const src = r.attrs?._cc_source;
+	return (typeof src === 'string' && RANK[src]) || 0;
+}
+
+export function dedupUsage(records: UsageRecord[]): UsageRecord[] {
+	const tokenGroups = new Map<string, UsageRecord[]>();
+	const others: UsageRecord[] = [];
+	for (const r of records) {
+		if (r.meter === 'claude.tokens' && r.provider_ref) {
+			const g = tokenGroups.get(r.provider_ref) ?? [];
+			g.push(r);
+			tokenGroups.set(r.provider_ref, g);
+		} else {
+			others.push(r);
+		}
+	}
+
+	// cost lookup (by request) for the fold
+	const costByRef = new Map<string, number>();
+	for (const r of others) {
+		if (r.meter === 'claude.cost' && r.provider_ref && typeof r.quantity === 'number') {
+			costByRef.set(r.provider_ref, r.quantity);
+		}
+	}
+
+	const survivors: UsageRecord[] = [];
+	for (const recs of tokenGroups.values()) {
+		const maxRank = Math.max(...recs.map(rankOf));
+		for (const r of recs) {
+			if (rankOf(r) !== maxRank) continue;
+			const cost = r.provider_ref ? costByRef.get(r.provider_ref) : undefined;
+			if (cost !== undefined && r.attrs?.cost_usd === undefined) {
+				survivors.push({ ...r, attrs: { ...r.attrs, cost_usd: cost } }); // no input mutation
+			} else {
+				survivors.push(r);
+			}
+		}
+	}
+
+	return [...survivors, ...others];
+}

--- a/src/boot/collector.ts
+++ b/src/boot/collector.ts
@@ -1,0 +1,35 @@
+/**
+ * Collector daemon — the composition root for Sutando's local collector.
+ *
+ * Builds the ONE source-agnostic kernel `Collector`, registers every available
+ * source `Normalizer` (Claude Code hooks today; voice-agent, filewatcher, and
+ * bridges next — same collector, just more `.register(...)` lines), and serves
+ * it over HTTP. There is NOT a per-source collector: this single process is the
+ * local floor for all telemetry, normalizing heterogeneous sources into one
+ * schema and (once a forward sink is configured) forwarding upstream.
+ *
+ * This file is the only place that knows about both the kernel collector and the
+ * concrete source adapters — the kernel never imports an adapter, the adapters
+ * never start a server. Wiring lives here.
+ *
+ *   SUTANDO_WORKSPACE=<dir> SUTANDO_OBS_PORT=4000 \
+ *     tsx src/boot/collector.ts
+ */
+
+import { Collector } from '../kernel/collector/collector.js';
+import { serveCollector } from '../kernel/collector/server.js';
+import { ClaudeCodeHookNormalizer } from '../adapters/executor/claude-code/sources/hook-normalizer.js';
+
+const collector = new Collector().register(new ClaudeCodeHookNormalizer());
+// Next sources plug in the SAME collector — one ingestion point, many normalizers:
+//   .register(new VoiceAgentNormalizer())
+//   .register(new FileWatcherNormalizer())
+
+const port = Number(process.env.SUTANDO_OBS_PORT) || 4000;
+serveCollector(collector, { port });
+
+const ws = process.env.SUTANDO_WORKSPACE ?? '~/.sutando/workspace';
+console.log('collector — one local ingestion point for all sources');
+console.log(`  sources:   ${collector.sources().join(', ') || '(none registered)'}`);
+console.log(`  listening: http://localhost:${port}/ingest/<source>`);
+console.log(`  writing:   ${ws}/logs/events-*.jsonl  (visualizer tails this)`);

--- a/src/kernel/__init__.py
+++ b/src/kernel/__init__.py
@@ -1,0 +1,14 @@
+"""Sutando platform kernel — the seams (config · obs · meter · ports · bus).
+
+Python twin tree of the TS kernel. Imported as a package so intra-kernel imports
+are relative and collision-safe (no bare ``import ids`` on a shared sys.path):
+
+    from kernel.obs import emit
+    from kernel.meter import record
+    from kernel.config import load_observability_config
+
+Requires the repo ``src/`` on ``sys.path`` (the same precondition that makes the
+``kernel`` package importable also resolves the flat ``workspace_default`` twin).
+"""
+
+from __future__ import annotations

--- a/src/kernel/_shared/__init__.py
+++ b/src/kernel/_shared/__init__.py
@@ -1,0 +1,6 @@
+"""Kernel-private shared helpers (id minting, node identity). Not a public API.
+
+    from kernel._shared import ids, node
+"""
+
+from __future__ import annotations

--- a/src/kernel/_shared/ids.py
+++ b/src/kernel/_shared/ids.py
@@ -1,0 +1,58 @@
+"""Id minting for the observability + metering spine. Zero dependencies.
+
+Twin of ``ids.ts`` — both languages MUST produce the same format (prefix +
+length + alphabet) so an id minted on either side is interchangeable.
+
+  - ``new_trace_id()`` / ``new_usage_id()`` -> ULID-style: a 48-bit millisecond
+    timestamp + 80 bits of randomness, Crockford base32, 26 chars, with a
+    2-char type prefix (``tr_`` / ``ux_``). Lexicographically TIME-SORTABLE
+    (the time component is the high-order chars), URL-safe, collision-resistant.
+  - ``new_span_id()`` -> ``sp_`` + 16 hex chars (8 random bytes). Spans need
+    uniqueness, not time-sortability.
+
+Crockford base32 omits I, L, O, U to avoid visual ambiguity. The matching
+regex is ``^(tr|ux)_[0-9A-HJKMNP-TV-Z]{26}$`` and ``^sp_[0-9a-f]{16}$``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+__all__ = ["ulid", "new_trace_id", "new_usage_id", "new_span_id"]
+
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_TIME_LEN = 10  # 10 base32 chars = 50 bits; holds a 48-bit ms timestamp
+_RAND_LEN = 16  # 16 base32 chars = 80 bits of randomness
+
+
+def _encode_time(ms: int, length: int) -> str:
+    out: list[str] = []
+    n = int(ms)
+    for _ in range(length):
+        out.append(_CROCKFORD[n % 32])
+        n //= 32
+    return "".join(reversed(out))
+
+
+def _encode_random(length: int) -> str:
+    return "".join(_CROCKFORD[b & 31] for b in os.urandom(length))
+
+
+def ulid(at_ms: int | None = None) -> str:
+    """Bare ULID-style body (no prefix). ``at_ms`` overridable for determinism."""
+    if at_ms is None:
+        at_ms = int(time.time() * 1000)
+    return _encode_time(at_ms, _TIME_LEN) + _encode_random(_RAND_LEN)
+
+
+def new_trace_id(at_ms: int | None = None) -> str:
+    return "tr_" + ulid(at_ms)
+
+
+def new_usage_id(at_ms: int | None = None) -> str:
+    return "ux_" + ulid(at_ms)
+
+
+def new_span_id() -> str:
+    return "sp_" + os.urandom(8).hex()

--- a/src/kernel/_shared/ids.ts
+++ b/src/kernel/_shared/ids.ts
@@ -1,0 +1,56 @@
+/**
+ * Id minting for the observability + metering spine. Zero dependencies.
+ *
+ * Twin of `ids.py` — both languages MUST produce the same format (prefix +
+ * length + alphabet) so an id minted on either side is interchangeable.
+ *
+ *   - `newTraceId()` / `newUsageId()` → ULID-style: a 48-bit millisecond
+ *     timestamp + 80 bits of randomness, Crockford base32, 26 chars, with a
+ *     2-char type prefix (`tr_` / `ux_`). Lexicographically TIME-SORTABLE
+ *     (the time component is the high-order chars), URL-safe, collision-resistant.
+ *   - `newSpanId()` → `sp_` + 16 hex chars (8 random bytes). Spans need
+ *     uniqueness, not time-sortability.
+ *
+ * Crockford base32 omits I, L, O, U to avoid visual ambiguity. The matching
+ * regex is `^(tr|ux)_[0-9A-HJKMNP-TV-Z]{26}$` and `^sp_[0-9a-f]{16}$`.
+ */
+
+import { randomBytes } from 'node:crypto';
+
+const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+const TIME_LEN = 10; // 10 base32 chars = 50 bits; holds a 48-bit ms timestamp
+const RAND_LEN = 16; // 16 base32 chars = 80 bits of randomness
+
+function encodeTime(ms: number, len: number): string {
+	let out = '';
+	let n = Math.floor(ms);
+	for (let i = 0; i < len; i++) {
+		out = CROCKFORD[n % 32] + out;
+		n = Math.floor(n / 32);
+	}
+	return out;
+}
+
+function encodeRandom(len: number): string {
+	const bytes = randomBytes(len);
+	let out = '';
+	for (let i = 0; i < len; i++) out += CROCKFORD[bytes[i] & 31];
+	return out;
+}
+
+/** Bare ULID-style body (no prefix). `at` overridable for testing/determinism. */
+export function ulid(at: number = Date.now()): string {
+	return encodeTime(at, TIME_LEN) + encodeRandom(RAND_LEN);
+}
+
+export function newTraceId(at?: number): string {
+	return 'tr_' + ulid(at);
+}
+
+export function newUsageId(at?: number): string {
+	return 'ux_' + ulid(at);
+}
+
+export function newSpanId(): string {
+	return 'sp_' + randomBytes(8).toString('hex');
+}

--- a/src/kernel/_shared/node.py
+++ b/src/kernel/_shared/node.py
@@ -1,0 +1,42 @@
+"""Node (machine) identity for the observability + metering spine.
+
+Every emitted event/usage record carries ``node`` -- which MACHINE produced it --
+so a multi-core fleet's events are attributable per host.
+
+Resolution (twin of ``node.ts``, intentionally identical and decoupled):
+  1. ``SUTANDO_NODE_ID`` env var (explicit override).
+  2. short hostname (first dot-segment).
+
+Deliberately does NOT reach into the workspace/memory layer to read
+``stand-identity.json`` -- that keeps the kernel free of the V1 hold-list
+(``util_paths``) dependency. A deployment that wants the stand-identity machine
+name as the node id has ``runtime/boot`` export ``SUTANDO_NODE_ID`` from it; the
+kernel just reads the env. Cached after first resolution.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+
+__all__ = ["node_id", "reset_node_id"]
+
+_cached: str | None = None
+
+
+def node_id() -> str:
+    global _cached
+    if _cached is not None:
+        return _cached
+    override = os.environ.get("SUTANDO_NODE_ID", "").strip()
+    if override:
+        _cached = override
+        return _cached
+    _cached = socket.gethostname().split(".")[0] or "unknown"
+    return _cached
+
+
+def reset_node_id() -> None:
+    """Test hook -- clears the cache so an env change takes effect."""
+    global _cached
+    _cached = None

--- a/src/kernel/_shared/node.ts
+++ b/src/kernel/_shared/node.ts
@@ -1,0 +1,36 @@
+/**
+ * Node (machine) identity for the observability + metering spine.
+ *
+ * Every emitted event/usage record carries `node` — which MACHINE produced it —
+ * so a multi-core fleet's events are attributable per host.
+ *
+ * Resolution (twin of `node.py`, intentionally identical and decoupled):
+ *   1. `SUTANDO_NODE_ID` env var (explicit override).
+ *   2. short hostname (first dot-segment).
+ *
+ * Deliberately does NOT reach into the workspace/memory layer to read
+ * `stand-identity.json` — that keeps the kernel free of the V1 hold-list
+ * (`util_paths`) dependency. A deployment that wants the stand-identity machine
+ * name as the node id has `runtime/boot` export `SUTANDO_NODE_ID` from it; the
+ * kernel just reads the env. Cached after first resolution.
+ */
+
+import { hostname } from 'node:os';
+
+let cached: string | undefined;
+
+export function nodeId(): string {
+	if (cached !== undefined) return cached;
+	const override = process.env.SUTANDO_NODE_ID?.trim();
+	if (override) {
+		cached = override;
+		return cached;
+	}
+	cached = hostname().split('.')[0] || 'unknown';
+	return cached;
+}
+
+/** Test hook — clears the cache so an env change takes effect. */
+export function resetNodeId(): void {
+	cached = undefined;
+}

--- a/src/kernel/collector/collector.ts
+++ b/src/kernel/collector/collector.ts
@@ -1,0 +1,121 @@
+/**
+ * Collector — the single, source-agnostic local ingestion point.
+ *
+ * ONE collector for ALL source types (there is no per-source collector).
+ * Emitters push payloads tagged with a `source`; the collector routes each to
+ * the `Normalizer` registered for that source, which maps it into the universal
+ * ObsEvent/UsageRecord schema, then the collector writes every result through
+ * the SAME sink-set (events) + usage ledger. That uniform write path is what
+ * keeps heterogeneous sources consistent AND what later forwards upstream: the
+ * sink-set is resolved from `observability.sinks`, so adding a forward sink fans
+ * every normalized event out to an upstream collector with zero changes here.
+ *
+ * Writes go DIRECTLY through the sink-set (not `obs.emit`) so source-derived
+ * ids/traces survive and nothing is sampled away — these events were already
+ * decided at the source.
+ *
+ * Transport-free on purpose (unit-testable without HTTP). `server.ts` is the
+ * thin HTTP shell; `src/boot/collector.ts` is the composition root that
+ * registers the available normalizers.
+ */
+
+import { nodeId } from '../_shared/node.js';
+import { sinkFromConfig, type Sink } from '../obs/sink.js';
+import { loadObservabilityConfig } from '../config/observability-config.js';
+import { writeLedger } from '../meter/meter.js';
+import type { ObsEvent } from '../obs/types.js';
+import type { UsageRecord } from '../meter/types.js';
+import type { Normalizer, NormalizeResult } from './normalizer.js';
+
+export interface IngestStat {
+	ok: boolean;
+	source: string;
+	events: number;
+	usage: number;
+	reason?: string;
+}
+
+function defaultSinks(): Sink[] {
+	const sinks: Sink[] = [];
+	try {
+		for (const sc of loadObservabilityConfig().observability.sinks) {
+			const s = sinkFromConfig(sc);
+			if (s) sinks.push(s);
+		}
+	} catch {
+		/* leave empty; writes become a safe no-op */
+	}
+	return sinks;
+}
+
+function warn(msg: string): void {
+	try {
+		process.stderr.write(`[collector] ${msg}\n`);
+	} catch {
+		/* best-effort */
+	}
+}
+
+export class Collector {
+	private readonly normalizers = new Map<string, Normalizer>();
+	private readonly sinks: Sink[];
+	private readonly usageWriter: (u: UsageRecord) => void;
+
+	/** `sinks` defaults to the configured obs sink-set (jsonl-file floor + any
+	 *  forward sink); `usageWriter` defaults to the durable meter ledger append. */
+	constructor(opts?: { sinks?: Sink[]; usageWriter?: (u: UsageRecord) => void }) {
+		this.sinks = opts?.sinks ?? defaultSinks();
+		this.usageWriter = opts?.usageWriter ?? writeLedger;
+	}
+
+	register(n: Normalizer): this {
+		if (this.normalizers.has(n.source)) warn(`source '${n.source}' re-registered, overwriting`);
+		this.normalizers.set(n.source, n);
+		return this;
+	}
+
+	sources(): string[] {
+		return [...this.normalizers.keys()];
+	}
+
+	/** Route a raw source payload to its normalizer and write the results. */
+	ingest(source: string, payload: unknown): IngestStat {
+		const n = this.normalizers.get(source);
+		if (!n) {
+			warn(`no normalizer registered for source '${source}'`);
+			return { ok: false, source, events: 0, usage: 0, reason: 'no normalizer for source' };
+		}
+		let res: NormalizeResult;
+		try {
+			res = n.normalize(payload, { node: nodeId(), receivedAt: Date.now() / 1000 });
+		} catch (e) {
+			warn(`normalizer '${source}' threw: ${(e as Error).message}`);
+			return { ok: false, source, events: 0, usage: 0, reason: 'normalize threw' };
+		}
+		this.accept(res);
+		return { ok: true, source, events: res.events.length, usage: res.usage.length };
+	}
+
+	/** Write ALREADY-normalized primitives — for an in-process emitter that maps
+	 *  locally but ships formed records here for durable storage + forwarding. */
+	accept(res: NormalizeResult): void {
+		for (const e of res.events) this.writeEvent(e);
+		for (const u of res.usage) {
+			try {
+				this.usageWriter(u);
+			} catch {
+				/* never throw out of the collector */
+			}
+		}
+	}
+
+	private writeEvent(e: ObsEvent): void {
+		for (const sink of this.sinks) {
+			try {
+				sink.write(e);
+			} catch {
+				/* one bad sink never blocks the others */
+			}
+		}
+	}
+}

--- a/src/kernel/collector/normalizer.ts
+++ b/src/kernel/collector/normalizer.ts
@@ -1,0 +1,74 @@
+/**
+ * Normalizer — turns ONE source's raw payload into the universal spine
+ * vocabulary (ObsEvent / UsageRecord).
+ *
+ * The collector is deliberately source-agnostic: every input TYPE (Claude Code
+ * hooks, the voice agent, the filewatcher, a bridge) is mapped by a registered
+ * `Normalizer` into the SAME schema and written through the SAME sink-set. That
+ * is what keeps heterogeneous sources consistent — Claude Code is just one of
+ * them. Adding a source = registering a Normalizer; the collector never changes.
+ *
+ * Source-specific knowledge (and any provider-isms — CC field names, etc.) lives
+ * in the adapter that owns the source, NOT in the kernel. The kernel only knows
+ * this interface.
+ *
+ * A normalizer MAY be stateful — e.g. accumulating streamed `delta` chunks into
+ * one event: a call can return zero primitives for a partial chunk and the full
+ * event on the terminal chunk. It MUST NOT throw; return EMPTY on garbage (the
+ * collector also guards, but a normalizer that swallows keeps the logs clean).
+ *
+ * Normalizers run inside the (TS) collector daemon. Python emitters don't need a
+ * Python normalizer — they POST their payload to `/ingest/<source>` and a TS
+ * normalizer maps it, OR they emit already-formed events to the generic
+ * `/ingest`. One collector, one place mapping happens.
+ */
+
+import type { ObsEvent } from '../obs/types.js';
+import type { UsageRecord } from '../meter/types.js';
+
+export interface NormalizeContext {
+	node: string; // which machine the collector runs on
+	receivedAt: number; // float unix seconds — when the payload reached the collector
+}
+
+export interface NormalizeResult {
+	events: ObsEvent[];
+	usage: UsageRecord[];
+}
+
+export interface Normalizer {
+	/** Route key — the `<source>` segment an emitter posts to
+	 *  (`POST /ingest/<source>`). e.g. "claude-code-hooks" | "voice-agent" |
+	 *  "filewatcher". Must be unique within a collector. */
+	readonly source: string;
+	normalize(payload: unknown, ctx: NormalizeContext): NormalizeResult;
+}
+
+export const EMPTY: NormalizeResult = { events: [], usage: [] };
+
+/**
+ * Composable normalizer: `normalize = map ∘ decode`.
+ *
+ * Splits ingestion into two single-responsibility halves so each source reads
+ * as "DETECT + strictly type, THEN map":
+ *
+ *   - `decode(payload)` — validate the raw `unknown` body and return it as a
+ *     strict, source-specific type `T` (or `null` to drop). This is where the
+ *     "if it's this source, type it into an interface" rule lives.
+ *   - `map(typed)` — transform the strictly-typed `T` into spine primitives,
+ *     with full type narrowing (no casts).
+ *
+ * Stateful sources (e.g. accumulating streamed chunks) keep their state on the
+ * subclass; `map` may return `EMPTY` for a partial input and the full result on
+ * the terminal one.
+ */
+export abstract class AbstractNormalizer<T> implements Normalizer {
+	abstract readonly source: string;
+	abstract decode(payload: unknown, ctx: NormalizeContext): T | null;
+	abstract map(typed: T, ctx: NormalizeContext): NormalizeResult;
+
+	normalize(payload: unknown, ctx: NormalizeContext): NormalizeResult {
+		const typed = this.decode(payload, ctx);
+		return typed == null ? EMPTY : this.map(typed, ctx);
+	}
+}

--- a/src/kernel/collector/server.ts
+++ b/src/kernel/collector/server.ts
@@ -1,0 +1,106 @@
+/**
+ * HTTP shell for the Collector — the long-running local daemon.
+ *
+ *   POST /ingest/<source>   raw payload for the normalizer registered under
+ *                           <source>. Body is a single payload or an array of
+ *                           them. (The CC shell hook posts here.)
+ *   POST /ingest            ALREADY-normalized ObsEvent | UsageRecord (or an
+ *                           array, or {events,usage}) — for in-process emitters
+ *                           that map locally but ship here for durable store +
+ *                           forward.
+ *   GET  /health            { ok, sources, ingested }
+ *
+ * Source-agnostic: it knows nothing about Claude Code. The composition root
+ * (`src/boot/collector.ts`) builds the Collector, registers the available
+ * normalizers, and calls `serveCollector()`. Never fails an emitter — a bad body
+ * or a normalizer miss is swallowed (204), because the emitter (a tool hook) must
+ * not block or error on the agent's hot path.
+ */
+
+import { createServer, type Server } from 'node:http';
+import type { Collector } from './collector.js';
+import type { ObsEvent } from '../obs/types.js';
+import type { UsageRecord } from '../meter/types.js';
+
+const MAX_BODY = 4_000_000;
+
+function looksLikeUsage(o: unknown): o is UsageRecord {
+	return (
+		!!o &&
+		typeof o === 'object' &&
+		typeof (o as Record<string, unknown>).usage_id === 'string' &&
+		typeof (o as Record<string, unknown>).meter === 'string'
+	);
+}
+
+/** Split a generic-ingest body into formed events vs usage records. Accepts a
+ *  single object, an array, or an `{events,usage}` envelope. */
+function splitFormed(parsed: unknown): { events: ObsEvent[]; usage: UsageRecord[] } {
+	const events: ObsEvent[] = [];
+	const usage: UsageRecord[] = [];
+	const env = parsed as { events?: unknown[]; usage?: unknown[] };
+	const items =
+		Array.isArray(env?.events) || Array.isArray(env?.usage)
+			? [...(env.events ?? []), ...(env.usage ?? [])]
+			: Array.isArray(parsed)
+				? parsed
+				: [parsed];
+	for (const o of items) (looksLikeUsage(o) ? usage : events).push(o as never);
+	return { events, usage };
+}
+
+export function serveCollector(collector: Collector, opts?: { port?: number }): Server {
+	let ingested = 0;
+	const port = opts?.port ?? (Number(process.env.SUTANDO_OBS_PORT) || 4000);
+
+	const server = createServer((req, res) => {
+		const url = req.url ?? '/';
+
+		if (req.method === 'POST' && url.startsWith('/ingest')) {
+			let body = '';
+			req.on('data', (c) => {
+				body += c;
+				if (body.length > MAX_BODY) req.destroy();
+			});
+			req.on('end', () => {
+				let parsed: unknown;
+				try {
+					parsed = JSON.parse(body);
+				} catch {
+					res.writeHead(400, { 'content-type': 'text/plain' }).end('bad json');
+					return;
+				}
+				try {
+					const m = url.match(/^\/ingest\/([^/?]+)/);
+					if (m) {
+						const source = decodeURIComponent(m[1]);
+						for (const p of Array.isArray(parsed) ? parsed : [parsed]) {
+							const stat = collector.ingest(source, p);
+							ingested += stat.events + stat.usage;
+						}
+					} else {
+						const { events, usage } = splitFormed(parsed);
+						collector.accept({ events, usage });
+						ingested += events.length + usage.length;
+					}
+				} catch {
+					/* never fail the emitter on a mapping/write error */
+				}
+				res.writeHead(204).end();
+			});
+			return;
+		}
+
+		if (url.startsWith('/health')) {
+			res
+				.writeHead(200, { 'content-type': 'application/json' })
+				.end(JSON.stringify({ ok: true, sources: collector.sources(), ingested }));
+			return;
+		}
+
+		res.writeHead(404).end();
+	});
+
+	server.listen(port);
+	return server;
+}

--- a/src/kernel/config/__init__.py
+++ b/src/kernel/config/__init__.py
@@ -1,0 +1,10 @@
+"""Narrow observability + metering config slice.
+
+    from kernel.config import load_observability_config
+"""
+
+from __future__ import annotations
+
+from .observability_config import OBSERVABILITY_DEFAULTS, load_observability_config
+
+__all__ = ["OBSERVABILITY_DEFAULTS", "load_observability_config"]

--- a/src/kernel/config/observability-config.ts
+++ b/src/kernel/config/observability-config.ts
@@ -1,0 +1,130 @@
+/**
+ * Narrow config slice for the observability + metering spine.
+ *
+ * This loader resolves ONLY the `observability`, `metering`, and `tenant`
+ * blocks — it is deliberately NOT the full Spine-C config loader (voice /
+ * telephony / stt / tts / send / services registry). Those are a separate,
+ * later concern; this slice ships the minimum the obs/meter seam needs.
+ *
+ * Resolution order (each layer overlays the previous, field by field):
+ *   1. shipped defaults — repo `config/sutando.config.defaults.json`
+ *      (falls back to OBSERVABILITY_DEFAULTS if the file is missing/unparseable)
+ *   2. environment knobs — SUTANDO_TENANT_ID / SUTANDO_TENANT_MODE /
+ *      SUTANDO_METERING_ENABLED / SUTANDO_METERING_ENDPOINT
+ *   3. workspace override — `<workspace>/config/observability.json` (machine-local; wins)
+ *
+ * Mirrors the `loadVoiceConfig` idiom (src/voice-config.ts): overlay over
+ * defaults, handle nested blocks explicitly, warn and fall back on a parse
+ * error. Twin of observability-config.py.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveWorkspace } from '../../workspace_default.js';
+
+export interface SinkConfig {
+	type: string;
+	path?: string;
+	endpoint?: string;
+	headers?: Record<string, string>;
+	[k: string]: unknown;
+}
+
+export interface ObservabilitySection {
+	sinks: SinkConfig[];
+	sampling: { trace: number };
+}
+
+export interface MeteringSection {
+	enabled: boolean;
+	endpoint: string | null;
+	batchMax: number;
+}
+
+export interface TenantSection {
+	id: string | null;
+	mode: 'byok' | 'managed';
+}
+
+export interface ObservabilityConfig {
+	observability: ObservabilitySection;
+	metering: MeteringSection;
+	tenant: TenantSection;
+}
+
+/** In-code defaults — kept byte-equivalent to config/sutando.config.defaults.json
+ *  (a test asserts they match, so they cannot drift). Used as the fallback when
+ *  the shipped file can't be read. */
+export const OBSERVABILITY_DEFAULTS: ObservabilityConfig = {
+	observability: { sinks: [{ type: 'jsonl-file' }], sampling: { trace: 1.0 } },
+	metering: { enabled: false, endpoint: null, batchMax: 100 },
+	tenant: { id: null, mode: 'byok' },
+};
+
+function defaultsFilePath(): string {
+	// src/kernel/config/observability-config.ts → repo root is three dirs up.
+	return join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'config', 'sutando.config.defaults.json');
+}
+
+function isTrueish(v: string): boolean {
+	return ['1', 'true', 'yes', 'on'].includes(v.trim().toLowerCase());
+}
+
+/** Overlay the three blocks of `raw` onto `base`, key by key. Keys absent from
+ *  `raw` keep their `base` value (so each layer is a true partial override).
+ *  The sinks array is taken verbatim when present. */
+function overlay(base: ObservabilityConfig, raw: Record<string, unknown>): ObservabilityConfig {
+	const obs = (raw.observability ?? {}) as Partial<ObservabilitySection>;
+	const meter = (raw.metering ?? {}) as Partial<MeteringSection>;
+	const tenant = (raw.tenant ?? {}) as Partial<TenantSection>;
+	return {
+		observability: {
+			sinks: Array.isArray(obs.sinks) ? (obs.sinks as SinkConfig[]) : base.observability.sinks,
+			sampling: { trace: obs.sampling?.trace ?? base.observability.sampling.trace },
+		},
+		metering: {
+			enabled: meter.enabled ?? base.metering.enabled,
+			endpoint: meter.endpoint ?? base.metering.endpoint,
+			batchMax: meter.batchMax ?? base.metering.batchMax,
+		},
+		tenant: {
+			id: tenant.id ?? base.tenant.id,
+			mode: tenant.mode === 'managed' ? 'managed' : tenant.mode === 'byok' ? 'byok' : base.tenant.mode,
+		},
+	};
+}
+
+function readJsonFile(path: string): Record<string, unknown> | null {
+	if (!existsSync(path)) return null;
+	try {
+		return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+	} catch (e) {
+		console.warn(`[observability-config] failed to parse ${path}, ignoring: ${(e as Error).message}`);
+		return null;
+	}
+}
+
+export function loadObservabilityConfig(opts?: { workspace?: string }): ObservabilityConfig {
+	// 1. shipped defaults (file overlays the in-code const; const is the floor)
+	let cfg = structuredClone(OBSERVABILITY_DEFAULTS);
+	const fileRaw = readJsonFile(defaultsFilePath());
+	if (fileRaw) cfg = overlay(cfg, fileRaw);
+
+	// 2. environment knobs
+	const tenantId = process.env.SUTANDO_TENANT_ID?.trim();
+	if (tenantId) cfg.tenant.id = tenantId;
+	const tenantMode = process.env.SUTANDO_TENANT_MODE?.trim();
+	if (tenantMode) cfg.tenant.mode = tenantMode === 'managed' ? 'managed' : 'byok';
+	const metEnabled = process.env.SUTANDO_METERING_ENABLED?.trim();
+	if (metEnabled !== undefined && metEnabled !== '') cfg.metering.enabled = isTrueish(metEnabled);
+	const metEndpoint = process.env.SUTANDO_METERING_ENDPOINT?.trim();
+	if (metEndpoint) cfg.metering.endpoint = metEndpoint;
+
+	// 3. workspace override (machine-local; wins, per the documented order)
+	const ws = opts?.workspace ?? resolveWorkspace();
+	const overrideRaw = readJsonFile(join(ws, 'config', 'observability.json'));
+	if (overrideRaw) cfg = overlay(cfg, overrideRaw);
+
+	return cfg;
+}

--- a/src/kernel/config/observability_config.py
+++ b/src/kernel/config/observability_config.py
@@ -1,0 +1,113 @@
+"""Narrow config slice for the observability + metering spine (Python twin).
+
+Resolves ONLY the ``observability`` / ``metering`` / ``tenant`` blocks -- NOT the
+full Spine-C config. Returns a plain ``dict`` mirroring the JSON structure
+(camelCase keys, e.g. ``batchMax``) so it stays byte-parallel with the TS twin
+``observability-config.ts`` and consistent with how obs/meter pass dicts.
+
+Resolution order (each layer overlays the previous, field by field):
+  1. shipped defaults -- repo ``config/sutando.config.defaults.json``
+     (falls back to OBSERVABILITY_DEFAULTS if missing/unparseable)
+  2. environment knobs -- SUTANDO_TENANT_ID / SUTANDO_TENANT_MODE /
+     SUTANDO_METERING_ENABLED / SUTANDO_METERING_ENDPOINT
+  3. workspace override -- ``<workspace>/config/observability.json`` (machine-local; wins)
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Flat src/ module; importable for the same reason the `kernel` package is.
+from workspace_default import resolve_workspace
+
+__all__ = ["OBSERVABILITY_DEFAULTS", "load_observability_config"]
+
+# In-code defaults -- kept equal to config/sutando.config.defaults.json's three
+# blocks (a test asserts this so they cannot drift). Fallback when the file
+# can't be read.
+OBSERVABILITY_DEFAULTS: dict[str, Any] = {
+    "observability": {"sinks": [{"type": "jsonl-file"}], "sampling": {"trace": 1.0}},
+    "metering": {"enabled": False, "endpoint": None, "batchMax": 100},
+    "tenant": {"id": None, "mode": "byok"},
+}
+
+_TRUEISH = {"1", "true", "yes", "on"}
+
+
+def _defaults_file_path() -> Path:
+    # src/kernel/config/observability_config.py -> repo root is three dirs up.
+    return Path(__file__).resolve().parents[3] / "config" / "sutando.config.defaults.json"
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        return data if isinstance(data, dict) else None
+    except (ValueError, OSError) as e:
+        print(f"[observability-config] failed to parse {path}, ignoring: {e}", file=sys.stderr)
+        return None
+
+
+def _overlay(base: dict[str, Any], raw: dict[str, Any]) -> dict[str, Any]:
+    """Overlay the three blocks of ``raw`` onto ``base``, key by key. Keys absent
+    from ``raw`` keep their ``base`` value. The sinks array is taken verbatim."""
+    obs = raw.get("observability") or {}
+    meter = raw.get("metering") or {}
+    tenant = raw.get("tenant") or {}
+    sinks = obs.get("sinks")
+    sampling = obs.get("sampling") or {}
+    mode = tenant.get("mode")
+    return {
+        "observability": {
+            "sinks": sinks if isinstance(sinks, list) else base["observability"]["sinks"],
+            "sampling": {
+                "trace": sampling.get("trace", base["observability"]["sampling"]["trace"]),
+            },
+        },
+        "metering": {
+            "enabled": meter.get("enabled", base["metering"]["enabled"]),
+            "endpoint": meter.get("endpoint", base["metering"]["endpoint"]),
+            "batchMax": meter.get("batchMax", base["metering"]["batchMax"]),
+        },
+        "tenant": {
+            "id": tenant.get("id", base["tenant"]["id"]),
+            "mode": mode if mode in ("byok", "managed") else base["tenant"]["mode"],
+        },
+    }
+
+
+def load_observability_config(workspace: Path | None = None) -> dict[str, Any]:
+    # 1. shipped defaults (file overlays the in-code const)
+    cfg = copy.deepcopy(OBSERVABILITY_DEFAULTS)
+    file_raw = _read_json(_defaults_file_path())
+    if file_raw:
+        cfg = _overlay(cfg, file_raw)
+
+    # 2. environment knobs
+    tenant_id = os.environ.get("SUTANDO_TENANT_ID", "").strip()
+    if tenant_id:
+        cfg["tenant"]["id"] = tenant_id
+    tenant_mode = os.environ.get("SUTANDO_TENANT_MODE", "").strip()
+    if tenant_mode:
+        cfg["tenant"]["mode"] = "managed" if tenant_mode == "managed" else "byok"
+    met_enabled = os.environ.get("SUTANDO_METERING_ENABLED", "").strip()
+    if met_enabled:
+        cfg["metering"]["enabled"] = met_enabled.lower() in _TRUEISH
+    met_endpoint = os.environ.get("SUTANDO_METERING_ENDPOINT", "").strip()
+    if met_endpoint:
+        cfg["metering"]["endpoint"] = met_endpoint
+
+    # 3. workspace override (machine-local; wins, per the documented order)
+    ws = workspace if workspace is not None else resolve_workspace(migrate=False)
+    override_raw = _read_json(Path(ws) / "config" / "observability.json")
+    if override_raw:
+        cfg = _overlay(cfg, override_raw)
+
+    return cfg

--- a/src/kernel/meter/__init__.py
+++ b/src/kernel/meter/__init__.py
@@ -1,0 +1,10 @@
+"""Durable usage metering.
+
+    from kernel.meter import record
+"""
+
+from __future__ import annotations
+
+from .meter import ledger_path, record
+
+__all__ = ["record", "ledger_path"]

--- a/src/kernel/meter/meter.py
+++ b/src/kernel/meter/meter.py
@@ -1,0 +1,129 @@
+"""``record(u)`` -- the durable usage primitive (Python twin of meter.ts).
+
+Guarantees: DURABLE synchronous append to
+``<workspace>/data/usage/usage-YYYY-MM-DD.jsonl`` (O_APPEND, single write per
+line; ``fsync`` when ``SUTANDO_METERING_FSYNC`` is truthy, default off);
+IDEMPOTENT on ``usage_id`` (append-only, at-least-once; downstream dedups);
+NEVER raises (returns the stamped record even on append failure). The durable
+append happens BEFORE the advisory ``usage.recorded`` obs event. The metering
+SHIPPER is intentionally NOT here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from workspace_default import resolve_workspace  # flat src/ module (see obs/sink.py note)
+
+from .._shared.ids import new_trace_id, new_usage_id
+from ..config.observability_config import load_observability_config
+from ..obs import emit
+
+__all__ = ["record", "ledger_path"]
+
+_TRUEISH = {"1", "true", "yes", "on"}
+
+
+def ledger_path(at_ms: float | None = None, workspace: Path | None = None) -> Path:
+    if at_ms is None:
+        at_ms = time.time() * 1000
+    date = time.strftime("%Y-%m-%d", time.localtime(at_ms / 1000))
+    ws = workspace if workspace is not None else resolve_workspace(migrate=False)
+    return Path(ws) / "data" / "usage" / f"usage-{date}.jsonl"
+
+
+def _fsync_enabled() -> bool:
+    return os.environ.get("SUTANDO_METERING_FSYNC", "").strip().lower() in _TRUEISH
+
+
+def record(usage_input: dict[str, Any]) -> dict[str, Any]:
+    # tenant_id defaults from config when the caller doesn't specify (BYOK -> None).
+    if "tenant_id" in usage_input:
+        tenant_id = usage_input["tenant_id"]
+    else:
+        try:
+            tenant_id = load_observability_config()["tenant"]["id"]
+        except Exception:
+            tenant_id = None
+
+    ts = usage_input["ts"] if usage_input.get("ts") is not None else round(time.time(), 3)
+    rec: dict[str, Any] = {
+        "schema": 1,
+        "usage_id": usage_input.get("usage_id") or new_usage_id(),
+        "ts": ts,
+        "tenant_id": tenant_id,
+        "trace_id": usage_input.get("trace_id") or new_trace_id(),
+        "actor": usage_input["actor"],
+        "source": usage_input["source"],
+        "meter": usage_input["meter"],
+        "quantity": usage_input["quantity"],
+        "unit": usage_input["unit"],
+        "provider": usage_input["provider"],
+        "provider_ref": usage_input.get("provider_ref"),
+        "attrs": usage_input.get("attrs") or {},
+    }
+    if usage_input.get("source_file") is not None:
+        rec["source_file"] = usage_input["source_file"]
+
+    # --- durability point: synchronous append BEFORE the advisory emit ---
+    try:
+        path = ledger_path(rec["ts"] * 1000)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = (json.dumps(rec, ensure_ascii=False, separators=(",", ":")) + "\n").encode("utf-8")
+        if _fsync_enabled():
+            fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+            try:
+                os.write(fd, data)
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        else:
+            with path.open("ab") as fh:
+                fh.write(data)
+    except Exception as e:  # noqa: BLE001 — never raise out of record()
+        try:
+            print(
+                f"[meter] FAILED to record usage {rec['usage_id']} ({rec['meter']}): {e}",
+                file=sys.stderr,
+            )
+        except Exception:
+            pass
+
+    # --- advisory obs event (the ledger bills; this just surfaces usage inline) ---
+    try:
+        attrs = rec["attrs"]
+        emit(
+            {
+                "source": rec["source"],
+                "source_file": rec.get("source_file"),
+                "trace_id": rec["trace_id"],
+                "actor": rec["actor"],
+                "kind": "usage.recorded",
+                "outcome": "ok",
+                "usage": {
+                    "provider": rec["provider"],
+                    "model": attrs.get("model"),
+                    "input_tokens": attrs.get("input_tokens"),
+                    "output_tokens": attrs.get("output_tokens"),
+                    "cache_read": attrs.get("cache_read"),
+                    "cache_creation": attrs.get("cache_creation"),
+                    "cost_usd": attrs.get("cost_usd"),
+                },
+                "data": {
+                    "meter": rec["meter"],
+                    "quantity": rec["quantity"],
+                    "unit": rec["unit"],
+                    "usage_id": rec["usage_id"],
+                    "provider_ref": rec["provider_ref"],
+                },
+            }
+        )
+    except Exception:
+        pass  # advisory is fire-and-forget
+
+    return rec

--- a/src/kernel/meter/meter.ts
+++ b/src/kernel/meter/meter.ts
@@ -42,6 +42,36 @@ function fsyncEnabled(): boolean {
 	return v === '1' || v === 'true' || v === 'yes' || v === 'on';
 }
 
+/** Durable append of a FULLY-FORMED usage record to the daily ledger — the
+ *  durability point (O_APPEND, single write per line; fsync behind
+ *  SUTANDO_METERING_FSYNC). Never throws. Used by `record()` and by the
+ *  collector, which receives already-stamped records from source normalizers
+ *  (CC-derived `usage_id`/`trace_id`) and must NOT re-stamp them. */
+export function writeLedger(rec: UsageRecord): void {
+	try {
+		const path = ledgerPath(rec.ts * 1000);
+		mkdirSync(dirname(path), { recursive: true });
+		const line = JSON.stringify(rec) + '\n';
+		if (fsyncEnabled()) {
+			const fd = openSync(path, 'a');
+			try {
+				writeSync(fd, line);
+				fsyncSync(fd);
+			} finally {
+				closeSync(fd);
+			}
+		} else {
+			appendFileSync(path, line, { flag: 'a' });
+		}
+	} catch (e) {
+		try {
+			process.stderr.write(`[meter] FAILED to record usage ${rec.usage_id} (${rec.meter}): ${(e as Error).message}\n`);
+		} catch {
+			/* best-effort */
+		}
+	}
+}
+
 export function record(input: UsageRecordInput): UsageRecord {
 	// tenant_id defaults from config when the caller doesn't specify (BYOK → null).
 	let tenantId = input.tenant_id;
@@ -71,28 +101,7 @@ export function record(input: UsageRecordInput): UsageRecord {
 	if (input.source_file !== undefined) rec.source_file = input.source_file;
 
 	// --- durability point: synchronous append BEFORE the advisory emit ---
-	try {
-		const path = ledgerPath(rec.ts * 1000);
-		mkdirSync(dirname(path), { recursive: true });
-		const line = JSON.stringify(rec) + '\n';
-		if (fsyncEnabled()) {
-			const fd = openSync(path, 'a');
-			try {
-				writeSync(fd, line);
-				fsyncSync(fd);
-			} finally {
-				closeSync(fd);
-			}
-		} else {
-			appendFileSync(path, line, { flag: 'a' });
-		}
-	} catch (e) {
-		try {
-			process.stderr.write(`[meter] FAILED to record usage ${rec.usage_id} (${rec.meter}): ${(e as Error).message}\n`);
-		} catch {
-			/* best-effort */
-		}
-	}
+	writeLedger(rec);
 
 	// --- advisory obs event so usage shows inline in traces (the ledger bills) ---
 	try {

--- a/src/kernel/meter/meter.ts
+++ b/src/kernel/meter/meter.ts
@@ -1,0 +1,128 @@
+/**
+ * `meter.record(u)` — the durable usage primitive. Twin of meter.py.
+ *
+ * Guarantees:
+ *  - DURABLE: synchronous append (O_APPEND, single write per line) to
+ *    `<workspace>/data/usage/usage-YYYY-MM-DD.jsonl`. This append is the
+ *    durability point — it survives crash/restart/offline. `fsync` is added
+ *    when `SUTANDO_METERING_FSYNC` is truthy (default off, matching event_log).
+ *  - IDEMPOTENT: `usage_id` is the dedup key. record() does NOT dedup on append
+ *    (append-only, at-least-once) — a crash-retry may legitimately re-append.
+ *    A caller may supply `usage_id` so the re-append carries the same key;
+ *    downstream (the deferred shipper / metering API) dedups on it →
+ *    exactly-once billing. Auto-minted when absent.
+ *  - NEVER THROWS: a thrown billing call is worse than a logged miss. On append
+ *    failure record() logs loudly and still RETURNS the stamped record.
+ *  - The durable append happens BEFORE the advisory `usage.recorded` obs event.
+ *
+ * The metering SHIPPER (cursor + batch POST + retry) is intentionally NOT here —
+ * that is post-parity. record() only writes the local source-of-truth ledger.
+ */
+
+import { appendFileSync, mkdirSync, openSync, writeSync, fsyncSync, closeSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { resolveWorkspace } from '../../workspace_default.js';
+import { newUsageId, newTraceId } from '../_shared/ids.js';
+import { loadObservabilityConfig } from '../config/observability-config.js';
+import { emit } from '../obs/obs.js';
+import type { UsageRecord, UsageRecordInput } from './types.js';
+
+function pad(n: number): string {
+	return String(n).padStart(2, '0');
+}
+
+export function ledgerPath(atMs: number = Date.now(), workspace?: string): string {
+	const d = new Date(atMs);
+	const date = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+	return join(workspace ?? resolveWorkspace(), 'data', 'usage', `usage-${date}.jsonl`);
+}
+
+function fsyncEnabled(): boolean {
+	const v = process.env.SUTANDO_METERING_FSYNC?.trim().toLowerCase();
+	return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
+export function record(input: UsageRecordInput): UsageRecord {
+	// tenant_id defaults from config when the caller doesn't specify (BYOK → null).
+	let tenantId = input.tenant_id;
+	if (tenantId === undefined) {
+		try {
+			tenantId = loadObservabilityConfig().tenant.id;
+		} catch {
+			tenantId = null;
+		}
+	}
+
+	const rec: UsageRecord = {
+		schema: 1,
+		usage_id: input.usage_id ?? newUsageId(),
+		ts: input.ts ?? Date.now() / 1000,
+		tenant_id: tenantId ?? null,
+		trace_id: input.trace_id ?? newTraceId(),
+		actor: input.actor,
+		source: input.source,
+		meter: input.meter,
+		quantity: input.quantity,
+		unit: input.unit,
+		provider: input.provider,
+		provider_ref: input.provider_ref ?? null,
+		attrs: input.attrs ?? {},
+	};
+	if (input.source_file !== undefined) rec.source_file = input.source_file;
+
+	// --- durability point: synchronous append BEFORE the advisory emit ---
+	try {
+		const path = ledgerPath(rec.ts * 1000);
+		mkdirSync(dirname(path), { recursive: true });
+		const line = JSON.stringify(rec) + '\n';
+		if (fsyncEnabled()) {
+			const fd = openSync(path, 'a');
+			try {
+				writeSync(fd, line);
+				fsyncSync(fd);
+			} finally {
+				closeSync(fd);
+			}
+		} else {
+			appendFileSync(path, line, { flag: 'a' });
+		}
+	} catch (e) {
+		try {
+			process.stderr.write(`[meter] FAILED to record usage ${rec.usage_id} (${rec.meter}): ${(e as Error).message}\n`);
+		} catch {
+			/* best-effort */
+		}
+	}
+
+	// --- advisory obs event so usage shows inline in traces (the ledger bills) ---
+	try {
+		emit({
+			source: rec.source,
+			source_file: rec.source_file,
+			trace_id: rec.trace_id,
+			actor: rec.actor,
+			kind: 'usage.recorded',
+			outcome: 'ok',
+			usage: {
+				provider: rec.provider,
+				model: rec.attrs.model,
+				input_tokens: rec.attrs.input_tokens,
+				output_tokens: rec.attrs.output_tokens,
+				cache_read: rec.attrs.cache_read,
+				cache_creation: rec.attrs.cache_creation,
+				cost_usd: rec.attrs.cost_usd,
+			},
+			data: {
+				meter: rec.meter,
+				quantity: rec.quantity,
+				unit: rec.unit,
+				usage_id: rec.usage_id,
+				provider_ref: rec.provider_ref,
+			},
+		});
+	} catch {
+		/* advisory is fire-and-forget; the ledger is the source of truth */
+	}
+
+	return rec;
+}

--- a/src/kernel/meter/types.py
+++ b/src/kernel/meter/types.py
@@ -1,0 +1,35 @@
+"""The usage record (Python twin of types.ts).
+
+Durable, billable/attributable primitive — distinct from an obs event. Emitted
+as a plain dict; TypedDicts here are for editor help only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class UsageAttrs(TypedDict, total=False):
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cache_read: int
+    cache_creation: int
+    cost_usd: float  # ADVISORY estimate only — never the billed figure
+
+
+class UsageRecord(TypedDict, total=False):
+    schema: int
+    usage_id: str
+    ts: float
+    tenant_id: str | None
+    trace_id: str
+    actor: dict[str, Any]
+    source: str
+    source_file: str
+    meter: str
+    quantity: float
+    unit: str
+    provider: str
+    provider_ref: str | None
+    attrs: dict[str, Any]

--- a/src/kernel/meter/types.ts
+++ b/src/kernel/meter/types.ts
@@ -1,0 +1,52 @@
+/**
+ * The usage record — the durable, billable/attributable primitive. Distinct
+ * from an obs event (§11.2: you cannot bill on a fire-and-forget log). Shares
+ * the obs vocabulary (`Actor`, `Source`, `trace_id`, dotted namespaces) but has
+ * its own delivery contract: append-only, at-least-once, idempotent on
+ * `usage_id`. Twin of types.py.
+ */
+
+import type { Actor, Source } from '../obs/types.js';
+
+/** Open payload bag. Field names align with Claude Code's gen_ai conventions so
+ *  the CC mappers populate them mechanically. */
+export interface UsageAttrs {
+	model?: string;
+	input_tokens?: number;
+	output_tokens?: number;
+	cache_read?: number;
+	cache_creation?: number;
+	cost_usd?: number; // ADVISORY estimate only — never the billed figure
+	[k: string]: unknown;
+}
+
+export interface UsageRecord {
+	schema: 1;
+	usage_id: string; // idempotency key — "ux_..."
+	ts: number;
+	tenant_id: string | null; // paying account (managed); null in BYOK
+	trace_id: string;
+	actor: Actor;
+	source: Source; // which process recorded the usage
+	source_file?: string;
+	meter: string; // open dotted: "claude.tokens" | "voice.seconds" | ...
+	quantity: number;
+	unit: string; // "tokens" | "seconds" | "minutes" | "characters" | "count" | "usd"
+	provider: string; // "anthropic" | "gemini-live" | "twilio" | ...
+	provider_ref: string | null; // request_id / Call SID — reconciliation hook
+	attrs: UsageAttrs;
+}
+
+/** Caller-supplied shape: the facade stamps schema/usage_id/ts/trace_id and
+ *  defaults tenant_id from config when absent. A caller MAY supply `usage_id`
+ *  so a crash-retry re-append carries the same idempotency key. */
+export type UsageRecordInput = Omit<
+	UsageRecord,
+	'schema' | 'usage_id' | 'ts' | 'trace_id' | 'tenant_id' | 'attrs'
+> & {
+	usage_id?: string;
+	ts?: number;
+	trace_id?: string;
+	tenant_id?: string | null;
+	attrs?: UsageAttrs;
+};

--- a/src/kernel/obs/__init__.py
+++ b/src/kernel/obs/__init__.py
@@ -1,0 +1,19 @@
+"""Observability facade.
+
+    from kernel.obs import emit
+"""
+
+from __future__ import annotations
+
+from .obs import emit, register_sink, reset_sinks, set_sampler
+from .sink import JsonlFileSink, Sink, sink_from_config
+
+__all__ = [
+    "emit",
+    "register_sink",
+    "reset_sinks",
+    "set_sampler",
+    "Sink",
+    "JsonlFileSink",
+    "sink_from_config",
+]

--- a/src/kernel/obs/obs.py
+++ b/src/kernel/obs/obs.py
@@ -1,0 +1,117 @@
+"""``emit(ev)`` -- the single, universal observability facade (Python twin of obs.ts).
+
+Best-effort, sampleable, structurally unable to raise into its caller. Every
+Sutando Python service calls this instead of ``print`` for anything that matters.
+
+Contract:
+  - stamps ``schema``, ``ts``, ``node``, and (if absent) ``trace_id``.
+  - sampling drops only ``ok`` events; ``error``/``denied`` and ``usage.recorded``
+    are ALWAYS kept.
+  - each sink write is isolated; nothing propagates out.
+  - on first emit with no registered sink, the configured default sinks
+    (jsonl-file) auto-register from ``load_observability_config()``.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable
+
+from .._shared.ids import new_trace_id
+from .._shared.node import node_id
+from ..config.observability_config import load_observability_config
+from .sink import Sink, sink_from_config
+
+__all__ = ["emit", "register_sink", "set_sampler", "reset_sinks"]
+
+_sinks: list[Sink] = []
+_auto_loaded = False
+_trace_sample = 1.0
+_trace_loaded = False
+_custom_sampler: Callable[[dict[str, Any]], bool] | None = None
+
+
+def register_sink(sink: Sink) -> None:
+    """Register an additional sink. Suppresses default-sink auto-loading."""
+    _sinks.append(sink)
+
+
+def set_sampler(fn: Callable[[dict[str, Any]], bool]) -> None:
+    """Override the sampler for ``ok`` events. Return True to keep."""
+    global _custom_sampler
+    _custom_sampler = fn
+
+
+def reset_sinks() -> None:
+    """Test hook: forget sinks + sampler + cached config."""
+    global _sinks, _auto_loaded, _trace_sample, _trace_loaded, _custom_sampler
+    _sinks = []
+    _auto_loaded = False
+    _trace_sample = 1.0
+    _trace_loaded = False
+    _custom_sampler = None
+
+
+def _load_sample_once() -> None:
+    global _trace_loaded, _trace_sample
+    if _trace_loaded:
+        return
+    _trace_loaded = True
+    try:
+        _trace_sample = load_observability_config()["observability"]["sampling"]["trace"]
+    except Exception:
+        pass  # keep 1.0
+
+
+def _ensure_default_sinks() -> None:
+    global _auto_loaded
+    if _auto_loaded or _sinks:
+        return
+    _auto_loaded = True
+    try:
+        for sc in load_observability_config()["observability"]["sinks"]:
+            s = sink_from_config(sc)
+            if s is not None:
+                _sinks.append(s)
+    except Exception:
+        pass  # leave empty; emit still no-ops safely
+
+
+def _should_keep(ev: dict[str, Any]) -> bool:
+    if ev.get("outcome") != "ok" or ev.get("kind") == "usage.recorded":
+        return True
+    if _custom_sampler is not None:
+        return _custom_sampler(ev)
+    import random
+
+    return random.random() < _trace_sample
+
+
+def emit(ev_input: dict[str, Any]) -> None:
+    try:
+        ev: dict[str, Any] = {
+            "schema": 1,
+            "ts": round(time.time(), 3),
+            "trace_id": ev_input.get("trace_id") or new_trace_id(),
+            "node": ev_input.get("node") or node_id(),
+            "source": ev_input["source"],
+            "actor": ev_input["actor"],
+            "kind": ev_input["kind"],
+            "outcome": ev_input["outcome"],
+        }
+        for opt in ("span_id", "parent_span_id", "source_file", "duration_ms", "usage", "data"):
+            if ev_input.get(opt) is not None:
+                ev[opt] = ev_input[opt]
+
+        _load_sample_once()
+        if not _should_keep(ev):
+            return
+
+        _ensure_default_sinks()
+        for sink in _sinks:
+            try:
+                sink.write(ev)
+            except Exception:
+                pass  # one bad sink never blocks the others
+    except Exception:
+        pass  # emit() is structurally incapable of raising into its caller

--- a/src/kernel/obs/obs.ts
+++ b/src/kernel/obs/obs.ts
@@ -1,0 +1,110 @@
+/**
+ * `obs.emit(ev)` — the single, universal observability facade. Best-effort,
+ * sampleable, and structurally unable to throw into its caller. Every service,
+ * bridge, adapter, and watcher calls this instead of `console.log` for anything
+ * that matters. Twin of obs.py.
+ *
+ * Contract:
+ *  - The facade stamps `schema`, `ts`, `node`, and (if absent) `trace_id`.
+ *  - Sampling drops only `ok` events; `error`/`denied` and `usage.recorded` are
+ *    ALWAYS kept (you never want to sample away a failure or a usage mirror).
+ *  - Each sink write is isolated — one failing sink never blocks another, and
+ *    nothing propagates out.
+ *  - On first emit, if no sink was registered, the configured default sinks
+ *    (jsonl-file) are auto-registered from `loadObservabilityConfig()`.
+ */
+
+import { nodeId } from '../_shared/node.js';
+import { newTraceId } from '../_shared/ids.js';
+import { loadObservabilityConfig } from '../config/observability-config.js';
+import { sinkFromConfig, type Sink } from './sink.js';
+import type { ObsEvent, ObsEventInput } from './types.js';
+
+let sinks: Sink[] = [];
+let autoLoaded = false;
+let traceSample = 1.0;
+let traceSampleLoaded = false;
+let customSampler: ((ev: ObsEvent) => boolean) | null = null;
+
+/** Register an additional sink. Suppresses default-sink auto-loading. */
+export function registerSink(sink: Sink): void {
+	sinks.push(sink);
+}
+
+/** Override the sampler for `ok` events. Return true to keep. */
+export function setSampler(fn: (ev: ObsEvent) => boolean): void {
+	customSampler = fn;
+}
+
+/** Test hook: forget sinks + sampler + cached config so the next emit re-inits. */
+export function resetSinks(): void {
+	sinks = [];
+	autoLoaded = false;
+	traceSample = 1.0;
+	traceSampleLoaded = false;
+	customSampler = null;
+}
+
+function loadSampleOnce(): void {
+	if (traceSampleLoaded) return;
+	traceSampleLoaded = true;
+	try {
+		traceSample = loadObservabilityConfig().observability.sampling.trace;
+	} catch {
+		/* keep 1.0 */
+	}
+}
+
+function ensureDefaultSinks(): void {
+	if (autoLoaded || sinks.length > 0) return;
+	autoLoaded = true;
+	try {
+		for (const sc of loadObservabilityConfig().observability.sinks) {
+			const s = sinkFromConfig(sc);
+			if (s) sinks.push(s);
+		}
+	} catch {
+		/* leave empty; emit still no-ops safely */
+	}
+}
+
+function shouldKeep(ev: ObsEvent): boolean {
+	if (ev.outcome !== 'ok' || ev.kind === 'usage.recorded') return true;
+	if (customSampler) return customSampler(ev);
+	return Math.random() < traceSample;
+}
+
+export function emit(input: ObsEventInput): void {
+	try {
+		const ev: ObsEvent = {
+			schema: 1,
+			ts: Date.now() / 1000,
+			trace_id: input.trace_id ?? newTraceId(),
+			node: input.node ?? nodeId(),
+			source: input.source,
+			actor: input.actor,
+			kind: input.kind,
+			outcome: input.outcome,
+		};
+		if (input.span_id !== undefined) ev.span_id = input.span_id;
+		if (input.parent_span_id !== undefined) ev.parent_span_id = input.parent_span_id;
+		if (input.source_file !== undefined) ev.source_file = input.source_file;
+		if (input.duration_ms !== undefined) ev.duration_ms = input.duration_ms;
+		if (input.usage !== undefined) ev.usage = input.usage;
+		if (input.data !== undefined) ev.data = input.data;
+
+		loadSampleOnce();
+		if (!shouldKeep(ev)) return;
+
+		ensureDefaultSinks();
+		for (const sink of sinks) {
+			try {
+				sink.write(ev);
+			} catch {
+				/* one bad sink never blocks the others */
+			}
+		}
+	} catch {
+		/* emit() is structurally incapable of throwing into its caller */
+	}
+}

--- a/src/kernel/obs/sink.py
+++ b/src/kernel/obs/sink.py
@@ -1,0 +1,63 @@
+"""Observability sinks (Python twin of sink.ts).
+
+The ``JsonlFileSink`` body is the crash-safe O_APPEND / single-write-per-line /
+daily-local-date pattern adapted directly from ``src/event_log.py``. A sink MUST
+be best-effort (never raise out). ``otlp-http`` is NOT built here -- only the
+``Sink`` protocol it will later implement.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Protocol
+
+# `workspace_default` is a flat module at src/; importable because the same src/
+# on sys.path that makes the `kernel` package importable also resolves it.
+from workspace_default import resolve_workspace
+
+__all__ = ["Sink", "JsonlFileSink", "sink_from_config"]
+
+
+class Sink(Protocol):
+    type: str
+
+    def write(self, ev: dict[str, Any]) -> None: ...
+
+
+class JsonlFileSink:
+    type = "jsonl-file"
+
+    def __init__(self, dir: Path | None = None) -> None:
+        self._dir = dir
+
+    def write(self, ev: dict[str, Any]) -> None:
+        try:
+            d = self._dir if self._dir is not None else (resolve_workspace(migrate=False) / "logs")
+            d.mkdir(parents=True, exist_ok=True)
+            ts = float(ev.get("ts", time.time()))
+            date = time.strftime("%Y-%m-%d", time.localtime(ts))
+            path = d / f"events-{date}.jsonl"
+            line = json.dumps(ev, ensure_ascii=False, separators=(",", ":")) + "\n"
+            # Single write() for atomicity on POSIX (event_log.py contract).
+            with path.open("ab") as fh:
+                fh.write(line.encode("utf-8"))
+        except Exception as e:  # noqa: BLE001 — never raise out of a sink
+            try:
+                print(f"[obs] jsonl-file sink failed: {e}", file=sys.stderr)
+            except Exception:
+                pass
+
+
+def sink_from_config(cfg: dict[str, Any]) -> Sink | None:
+    t = cfg.get("type")
+    if t == "jsonl-file":
+        p = cfg.get("path")
+        return JsonlFileSink(Path(p) if isinstance(p, str) else None)
+    try:
+        print(f"[obs] sink type {t!r} not supported yet, skipping", file=sys.stderr)
+    except Exception:
+        pass
+    return None

--- a/src/kernel/obs/sink.ts
+++ b/src/kernel/obs/sink.ts
@@ -1,0 +1,74 @@
+/**
+ * Observability sinks. A `Sink` accepts a finished `ObsEvent` and ships it
+ * somewhere; it MUST be best-effort (never throw out — `emit()` isolates each
+ * sink, but a sink that swallows its own errors keeps the others clean).
+ *
+ * The `Sink` interface stays in `kernel/obs` permanently. The concrete
+ * `JsonlFileSink` body is adapted from `src/event_log.py` (crash-safe O_APPEND,
+ * single write per line, daily local-date file). In a later phase the concrete
+ * sinks relocate to `adapters/obs-sinks/`; the interface does not move. The
+ * `otlp-http` sink is NOT built here — only the interface it will implement.
+ *
+ * Twin of sink.py.
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolveWorkspace } from '../../workspace_default.js';
+import type { ObsEvent } from './types.js';
+import type { SinkConfig } from '../config/observability-config.js';
+
+export interface Sink {
+	readonly type: string;
+	write(ev: ObsEvent): void; // best-effort; must not throw out
+}
+
+function dailyFilePath(dir: string, atMs: number): string {
+	const d = new Date(atMs);
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const day = String(d.getDate()).padStart(2, '0');
+	return join(dir, `events-${y}-${m}-${day}.jsonl`);
+}
+
+/** Append-only JSONL sink: `<dir>/events-YYYY-MM-DD.jsonl` (default dir
+ *  `<workspace>/logs`). One compact JSON object per line, atomic O_APPEND. */
+export class JsonlFileSink implements Sink {
+	readonly type = 'jsonl-file';
+	private readonly dir: string;
+
+	constructor(opts?: { dir?: string }) {
+		this.dir = opts?.dir ?? join(resolveWorkspace(), 'logs');
+	}
+
+	write(ev: ObsEvent): void {
+		try {
+			mkdirSync(this.dir, { recursive: true });
+			const line = JSON.stringify(ev) + '\n';
+			const path = dailyFilePath(this.dir, ev.ts * 1000);
+			appendFileSync(path, line, { flag: 'a' });
+		} catch (e) {
+			try {
+				process.stderr.write(`[obs] jsonl-file sink failed to write ${ev.kind}: ${(e as Error).message}\n`);
+			} catch {
+				/* even the warn is best-effort */
+			}
+		}
+	}
+}
+
+/** Build a concrete sink from a config entry. Returns null for an unsupported
+ *  type (e.g. otlp-http, not built yet) with a one-line warn. */
+export function sinkFromConfig(cfg: SinkConfig): Sink | null {
+	switch (cfg.type) {
+		case 'jsonl-file':
+			return new JsonlFileSink({ dir: typeof cfg.path === 'string' ? cfg.path : undefined });
+		default:
+			try {
+				process.stderr.write(`[obs] sink type '${cfg.type}' not supported yet, skipping\n`);
+			} catch {
+				/* best-effort */
+			}
+			return null;
+	}
+}

--- a/src/kernel/obs/types.py
+++ b/src/kernel/obs/types.py
@@ -1,0 +1,49 @@
+"""The universal observability event envelope (Python twin of types.ts).
+
+Defined as TypedDicts for editor help; ``obs.py`` builds and emits plain dicts
+(matching ``event_log.py``) so the JSONL bytes stay format-consistent with the
+TS twin. The envelope is thin and stable; kind-specific data lives in the open
+``data`` bag and the open dotted ``kind`` namespace.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+Outcome = Literal["ok", "error", "denied"]
+AccessTier = Literal["owner", "team", "public"]
+
+
+class Actor(TypedDict, total=False):
+    user_id: str
+    channel: str
+    access_tier: str
+    tenant_id: str | None
+
+
+class UsageAdvisory(TypedDict, total=False):
+    provider: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cache_read: int
+    cache_creation: int
+    audio_seconds: float
+    cost_usd: float
+
+
+class ObsEvent(TypedDict, total=False):
+    schema: int
+    ts: float
+    trace_id: str
+    span_id: str
+    parent_span_id: str
+    node: str
+    source: str
+    source_file: str
+    actor: Actor
+    kind: str
+    outcome: str
+    duration_ms: float
+    usage: UsageAdvisory
+    data: dict[str, Any]

--- a/src/kernel/obs/types.ts
+++ b/src/kernel/obs/types.ts
@@ -1,0 +1,78 @@
+/**
+ * The universal observability event envelope. EVERY service, bridge, adapter,
+ * watcher, and the core (via mappers) emits this same shape through `emit()`.
+ *
+ * Twin of types.py (which defines the same shape as a TypedDict). The envelope
+ * is thin and stable; everything kind-specific lives in the open `data` bag and
+ * the open dotted `kind` namespace, so new event shapes need no schema bump.
+ */
+
+export type Outcome = 'ok' | 'error' | 'denied';
+
+export type AccessTier = 'owner' | 'team' | 'public';
+
+/**
+ * The emitting process/service — WHICH PROCESS produced the event (distinct from
+ * `node` = which machine, and `actor.channel` = which ingress surface). Open
+ * string; the union lists the known emitters for autocomplete without closing it.
+ */
+export type Source =
+	| 'voice-agent'
+	| 'core-cli'
+	| 'phone'
+	| 'discord-voice'
+	| 'chat'
+	| 'discord-bridge'
+	| 'slack-bridge'
+	| 'telegram-bridge'
+	| 'agent-api'
+	| 'task-bridge'
+	| 'filewatcher'
+	| 'health-check'
+	| 'core-heartbeat'
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	| (string & {});
+
+/** WHO the request is from/for — the ingress surface + identity. */
+export interface Actor {
+	user_id: string;
+	channel: string;
+	access_tier: AccessTier;
+	tenant_id?: string | null;
+}
+
+/** Advisory usage mirror carried inline on an obs event. The BILLED copy is the
+ *  meter ledger — never bill off this. */
+export interface UsageAdvisory {
+	provider?: string;
+	model?: string;
+	input_tokens?: number;
+	output_tokens?: number;
+	cache_read?: number;
+	cache_creation?: number;
+	audio_seconds?: number;
+	cost_usd?: number;
+}
+
+export interface ObsEvent {
+	schema: 1;
+	ts: number; // float unix seconds, ms precision
+	trace_id: string;
+	span_id?: string;
+	parent_span_id?: string;
+	node: string; // which machine
+	source: Source; // which emitting process/service
+	source_file?: string; // the SUBJECT file the event is about (changed/read/consumed)
+	actor: Actor;
+	kind: string; // open dotted namespace: "tool.call" | "file.change" | "voice.session.end" | ...
+	outcome: Outcome;
+	duration_ms?: number;
+	usage?: UsageAdvisory;
+	data?: Record<string, unknown>; // open, kind-specific payload bag
+}
+
+/** Caller-supplied shape: the facade stamps schema/ts/node/trace_id. */
+export type ObsEventInput = Omit<ObsEvent, 'schema' | 'ts' | 'node' | 'trace_id'> & {
+	trace_id?: string;
+	node?: string;
+};

--- a/src/kernel/ports/executor-source.ts
+++ b/src/kernel/ports/executor-source.ts
@@ -1,0 +1,34 @@
+/**
+ * The `ExecutorSource` port — provider-agnostic. A live telemetry source for an
+ * executor (the interactive core) feeds already-mapped primitives into the
+ * spine through a `SourceSink`. The port has NO Claude-isms: the OTLP receiver,
+ * the .jsonl tailer, and the hook handler each implement this later (deferred);
+ * the Claude-specific mapping lives in `adapters/executor/claude-code/sources/`.
+ *
+ * Phase 0 ships ONLY this interface + the pure mappers. No live source exists
+ * yet. A future source: obtain CC telemetry → map it to ObsEvent/UsageRecord →
+ * push via the sink callbacks below.
+ */
+
+import type { ObsEvent } from '../obs/types.js';
+import type { UsageRecord } from '../meter/types.js';
+
+/** What the spine hands a source so it can push results in. `emit` is
+ *  best-effort (obs); `record` is durable (meter). Both take FULLY-FORMED
+ *  records — the interactive core's events already carry CC-derived ids, so they
+ *  are not re-stamped by `obs.emit`/`meter.record`. */
+export interface SourceSink {
+	emit(event: ObsEvent): void;
+	record(usage: UsageRecord): void;
+}
+
+export interface SourceStartOpts {
+	sink: SourceSink;
+	signal?: AbortSignal; // cooperative shutdown
+}
+
+export interface ExecutorSource {
+	readonly name: string; // "claude-code.otel" | "claude-code.jsonl" | "claude-code.hooks"
+	start(opts: SourceStartOpts): Promise<void> | void;
+	stop(): Promise<void> | void;
+}

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -228,6 +228,34 @@ else
   export ANTHROPIC_BASE_URL=http://localhost:7846
 fi
 
+# 0b. Obs collector (OPTIONAL — opt-in via SUTANDO_OBS_COLLECTOR=1).
+# The single, source-agnostic local collector: it receives Claude Code hooks
+# (and, later, voice / filewatcher / bridge events) on /ingest/<source>,
+# normalizes them into the one event schema, and writes the durable JSONL floor
+# at <workspace>/logs/events-*.jsonl (the visualizer tails that). Off by default
+# — it's an observability/dev tool, not required for the agent to run.
+#
+# When enabled we also point the core's hooks at it (SUTANDO_OBS_ENDPOINT) UNLESS
+# an endpoint is already set — e.g. a remote upstream collector — so the "always
+# set hooks, only export when told where" contract still holds.
+if [ "${SUTANDO_OBS_COLLECTOR:-}" = "1" ]; then
+  OBS_PORT="${SUTANDO_OBS_PORT:-4000}"
+  if ! lsof -i :"$OBS_PORT" > /dev/null 2>&1; then
+    echo "  Starting obs collector (port $OBS_PORT)..."
+    SUTANDO_WORKSPACE="$WORKSPACE" SUTANDO_OBS_PORT="$OBS_PORT" \
+      npx tsx "$REPO/src/boot/collector.ts" > "$LOGS_DIR/collector.log" 2>&1 &
+    echo "  ✓ obs collector"
+  else
+    echo "  ✓ obs collector (already running on $OBS_PORT)"
+  fi
+  # Wire the core's hooks to the local collector unless an endpoint is already set.
+  if [ -z "${SUTANDO_OBS_ENDPOINT:-}" ]; then
+    export SUTANDO_OBS_ENDPOINT="http://localhost:$OBS_PORT"
+  fi
+else
+  echo "  ~ obs collector (disabled — set SUTANDO_OBS_COLLECTOR=1 to enable)"
+fi
+
 # 1. Voice agent (Gemini Live on port 9900)
 if ! lsof -i :9900 > /dev/null 2>&1; then
   echo "  Starting voice agent (port 9900)..."
@@ -508,6 +536,9 @@ echo "Verifying services..."
 VERIFY_PORTS="9900:voice-agent 8080:web-client 7844:dashboard 7843:agent-api 7845:screen-capture"
 if [ "${SKIP_PHONE:-}" != "1" ] && grep -q "TWILIO_ACCOUNT_SID=" .env 2>/dev/null; then
   VERIFY_PORTS="$VERIFY_PORTS 3100:conversation-server"
+fi
+if [ "${SUTANDO_OBS_COLLECTOR:-}" = "1" ]; then
+  VERIFY_PORTS="$VERIFY_PORTS ${SUTANDO_OBS_PORT:-4000}:collector"
 fi
 for port_name in $VERIFY_PORTS; do
   port="${port_name%%:*}"

--- a/tests/adapters/executor/claude-code/sources/hook-map.test.ts
+++ b/tests/adapters/executor/claude-code/sources/hook-map.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { hookMap } from '../../../../../src/adapters/executor/claude-code/sources/hook-map.js';
+import type { MapContext } from '../../../../../src/adapters/executor/claude-code/sources/cc-records.js';
+
+const ctx: MapContext = { node: 'mac-studio', receivedAt: 1_717_900_000 };
+
+describe('hookMap — obs only, with file-op pairing', () => {
+	it('PostToolUse Read → tool.result AND a paired file.read carrying source_file', () => {
+		const out = hookMap({ hook_event_name: 'PostToolUse', session_id: 'sess-9', cwd: '/repo', tool_name: 'Read', tool_input: { file_path: 'tasks/task-1.txt' }, tool_output: 'contents' }, ctx);
+		assert.equal(out.usage.length, 0); // hooks NEVER produce usage
+		assert.equal(out.events.length, 2);
+		assert.equal(out.events[0].kind, 'tool.result');
+		assert.equal(out.events[1].kind, 'file.read');
+		assert.equal(out.events[1].source_file, 'tasks/task-1.txt');
+		assert.equal(out.events[1].outcome, 'ok');
+	});
+
+	it('PostToolUseFailure → outcome error (and Write pairs file.change)', () => {
+		const out = hookMap({ hook_event_name: 'PostToolUseFailure', session_id: 'sess-9', tool_name: 'Write', tool_input: { file_path: 'notes/x.md' }, error: 'EACCES' }, ctx);
+		assert.equal(out.events[0].kind, 'tool.result');
+		assert.equal(out.events[0].outcome, 'error');
+		const fe = out.events.find((e) => e.kind === 'file.change');
+		assert.ok(fe);
+		assert.equal(fe!.source_file, 'notes/x.md');
+		assert.equal((fe!.data as Record<string, unknown>).op, 'written');
+	});
+
+	it('SessionEnd → cc.hook.session_end with end_reason', () => {
+		const out = hookMap({ hook_event_name: 'SessionEnd', session_id: 'sess-9', end_reason: 'clear' }, ctx);
+		assert.equal(out.events[0].kind, 'cc.hook.session_end');
+		assert.equal((out.events[0].data as Record<string, unknown>).end_reason, 'clear');
+	});
+
+	it('unknown event → forward-compatible cc.hook.<snake> default branch', () => {
+		const out = hookMap({ hook_event_name: 'CwdChanged', session_id: 'sess-9', previous_cwd: '/old' }, ctx);
+		assert.equal(out.events[0].kind, 'cc.hook.cwd_changed');
+		assert.equal((out.events[0].data as Record<string, unknown>).previous_cwd, '/old');
+	});
+
+	it('non-file tool (Bash) PostToolUse → only tool.result, no file event', () => {
+		const out = hookMap({ hook_event_name: 'PostToolUse', session_id: 'sess-9', tool_name: 'Bash', tool_input: { command: 'ls' } }, ctx);
+		assert.equal(out.events.length, 1);
+		assert.equal(out.events[0].kind, 'tool.result');
+	});
+});

--- a/tests/adapters/executor/claude-code/sources/ids.test.ts
+++ b/tests/adapters/executor/claude-code/sources/ids.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	actorFromResourceAttrs,
+	spanIdFromCcSpan,
+	tenantFromResource,
+	traceIdFromSession,
+	usageIdFromRequest,
+} from '../../../../../src/adapters/executor/claude-code/sources/ids.js';
+
+describe('cc-source id adoption', () => {
+	it('one CC session = one trace', () => {
+		assert.equal(traceIdFromSession('sess-9'), 'cc-sess:sess-9');
+		assert.equal(traceIdFromSession(undefined), 'cc-sess:unknown');
+	});
+
+	it('span id pass-through, namespaced', () => {
+		assert.equal(spanIdFromCcSpan('abc'), 'sp_abc');
+		assert.equal(spanIdFromCcSpan(undefined), undefined);
+	});
+
+	it('usage_id keys on request_id, with type suffix and session fallback', () => {
+		assert.equal(usageIdFromRequest('req_1', {}), 'cc:tok:req_1');
+		assert.equal(usageIdFromRequest('req_1', {}, 'input'), 'cc:tok:req_1:input');
+		assert.equal(usageIdFromRequest(undefined, { sessionId: 'sess-9', tsBucket: 1717900000 }), 'cc:tok:sess-9:1717900000');
+	});
+
+	it('actor + tenant from resource, degrading gracefully', () => {
+		assert.deepEqual(actorFromResourceAttrs({ 'session.id': 's', 'user.id': 'u-42', 'organization.id': 'org-7' }), {
+			user_id: 'u-42',
+			channel: 'claude-code',
+			access_tier: 'owner',
+			tenant_id: 'org-7',
+		});
+		assert.deepEqual(actorFromResourceAttrs(undefined), { user_id: 'core', channel: 'claude-code', access_tier: 'owner', tenant_id: null });
+		assert.equal(tenantFromResource({}), null);
+	});
+});

--- a/tests/adapters/executor/claude-code/sources/otel-map.test.ts
+++ b/tests/adapters/executor/claude-code/sources/otel-map.test.ts
@@ -1,0 +1,133 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { otelMap } from '../../../../../src/adapters/executor/claude-code/sources/otel-map.js';
+import type { MapContext } from '../../../../../src/adapters/executor/claude-code/sources/cc-records.js';
+
+const ctx: MapContext = { node: 'mac-studio', receivedAt: 1_717_900_000 };
+const RES = { 'session.id': 'sess-9', 'user.id': 'u-42', 'organization.id': 'org-7' };
+const ACTOR = { user_id: 'u-42', channel: 'claude-code', access_tier: 'owner', tenant_id: 'org-7' };
+
+describe('otelMap — metrics', () => {
+	it('token.usage → one claude.tokens usage record, slotted by type, keyed by request', () => {
+		const out = otelMap(
+			{ signal: 'metric', metric: { name: 'claude_code.token.usage', value: 1500, ts: 1_717_900_001, attrs: { type: 'input', model: 'claude-opus-4-8', query_source: 'main', request_id: 'req_01H' }, resource: RES } },
+			ctx,
+		);
+		assert.deepEqual(out, {
+			events: [],
+			usage: [
+				{
+					schema: 1,
+					usage_id: 'cc:tok:req_01H:input',
+					ts: 1_717_900_001,
+					tenant_id: 'org-7',
+					trace_id: 'cc-sess:sess-9',
+					actor: ACTOR,
+					source: 'core-cli',
+					meter: 'claude.tokens',
+					quantity: 1500,
+					unit: 'tokens',
+					provider: 'anthropic',
+					provider_ref: 'req_01H',
+					attrs: { _cc_source: 'otel-metric', model: 'claude-opus-4-8', query_source: 'main', type: 'input', input_tokens: 1500 },
+				},
+			],
+		});
+	});
+
+	it('cost.usage → claude.cost usd record', () => {
+		const out = otelMap({ signal: 'metric', metric: { name: 'claude_code.cost.usage', value: 0.0061, ts: 1_717_900_001, attrs: { model: 'claude-opus-4-8', request_id: 'req_01H' }, resource: RES } }, ctx);
+		assert.equal(out.usage.length, 1);
+		assert.equal(out.usage[0].meter, 'claude.cost');
+		assert.equal(out.usage[0].unit, 'usd');
+		assert.equal(out.usage[0].quantity, 0.0061);
+		assert.equal(out.usage[0].attrs.cost_usd, 0.0061);
+		assert.equal(out.events.length, 0);
+	});
+
+	it('counters → obs events, never usage', () => {
+		const out = otelMap({ signal: 'metric', metric: { name: 'claude_code.lines_of_code.count', value: 42, ts: 1_717_900_001, attrs: { type: 'added' }, resource: RES } }, ctx);
+		assert.equal(out.usage.length, 0);
+		assert.equal(out.events.length, 1);
+		assert.equal(out.events[0].kind, 'cc.code.lines');
+		assert.deepEqual(out.events[0].data, { value: 42, type: 'added' });
+	});
+});
+
+describe('otelMap — logs (obs only)', () => {
+	it('user_prompt → cc.prompt', () => {
+		const out = otelMap({ signal: 'log', log: { event: 'claude_code.user_prompt', ts: 1_717_900_001, attrs: { 'prompt.id': 'p1', prompt_length: 12 }, resource: RES } }, ctx);
+		assert.equal(out.usage.length, 0);
+		assert.equal(out.events[0].kind, 'cc.prompt');
+		assert.deepEqual(out.events[0].data, { prompt_id: 'p1', prompt_length: 12 });
+	});
+
+	it('tool_result with reject → tool.result, outcome denied', () => {
+		const out = otelMap({ signal: 'log', log: { event: 'claude_code.tool_result', ts: 1_717_900_001, attrs: { tool_name: 'Bash', tool_decision: 'reject', decision_source: 'user_approval', tool_use_id: 'tu1' }, resource: RES } }, ctx);
+		assert.equal(out.events[0].kind, 'tool.result');
+		assert.equal(out.events[0].outcome, 'denied');
+		assert.equal((out.events[0].data as Record<string, unknown>).tool_name, 'Bash');
+	});
+});
+
+describe('otelMap — spans', () => {
+	it('llm_request → usage record (full breakdown) AND a cc.llm_request obs event', () => {
+		const out = otelMap(
+			{
+				signal: 'span',
+				span: {
+					name: 'claude_code.llm_request',
+					spanId: 'abc',
+					parentSpanId: 'par',
+					ts: 1_717_900_001.5,
+					durationMs: 1200,
+					attrs: { request_id: 'req_01H', model: 'claude-opus-4-8', input_tokens: 1500, output_tokens: 340, cache_read_tokens: 100, cache_creation_tokens: 0, ttft_ms: 230, stop_reason: 'end_turn', success: true, query_source: 'main' },
+					resource: RES,
+				},
+			},
+			ctx,
+		);
+		assert.deepEqual(out, {
+			events: [
+				{
+					schema: 1,
+					ts: 1_717_900_001.5,
+					trace_id: 'cc-sess:sess-9',
+					node: 'mac-studio',
+					source: 'core-cli',
+					actor: ACTOR,
+					kind: 'cc.llm_request',
+					outcome: 'ok',
+					span_id: 'sp_abc',
+					parent_span_id: 'sp_par',
+					duration_ms: 1200,
+					usage: { provider: 'anthropic', model: 'claude-opus-4-8', input_tokens: 1500, output_tokens: 340, cache_read: 100, cache_creation: 0 },
+					data: { request_id: 'req_01H', ttft_ms: 230, stop_reason: 'end_turn', query_source: 'main' },
+				},
+			],
+			usage: [
+				{
+					schema: 1,
+					usage_id: 'cc:tok:req_01H',
+					ts: 1_717_900_001.5,
+					tenant_id: 'org-7',
+					trace_id: 'cc-sess:sess-9',
+					actor: ACTOR,
+					source: 'core-cli',
+					meter: 'claude.tokens',
+					quantity: 1840,
+					unit: 'tokens',
+					provider: 'anthropic',
+					provider_ref: 'req_01H',
+					attrs: { _cc_source: 'otel-span', model: 'claude-opus-4-8', input_tokens: 1500, output_tokens: 340, cache_read: 100, cache_creation: 0 },
+				},
+			],
+		});
+	});
+
+	it('tool span → tool.call, lifting file_path into source_file', () => {
+		const out = otelMap({ signal: 'span', span: { name: 'claude_code.tool', spanId: 's1', ts: 1_717_900_001, attrs: { tool_name: 'Read', tool_use_id: 'tu9', file_path: 'tasks/task-1.txt' }, resource: RES } }, ctx);
+		assert.equal(out.events[0].kind, 'tool.call');
+		assert.equal(out.events[0].source_file, 'tasks/task-1.txt');
+	});
+});

--- a/tests/adapters/executor/claude-code/sources/routing.test.ts
+++ b/tests/adapters/executor/claude-code/sources/routing.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { otelMap } from '../../../../../src/adapters/executor/claude-code/sources/otel-map.js';
+import { hookMap } from '../../../../../src/adapters/executor/claude-code/sources/hook-map.js';
+import { transcriptMap } from '../../../../../src/adapters/executor/claude-code/sources/transcript-map.js';
+import type { MapContext, MapResult } from '../../../../../src/adapters/executor/claude-code/sources/cc-records.js';
+
+const ctx: MapContext = { node: 'n', receivedAt: 1 };
+const RES = { 'session.id': 's' };
+
+/**
+ * POLICY guard: every CC signal lands in meter XOR obs — except `llm_request`,
+ * which is deliberately BOTH (durable usage + operational span). Guards the
+ * routing table from drift.
+ */
+const cases: Array<{ name: string; out: MapResult; both?: boolean }> = [
+	{ name: 'token.usage', out: otelMap({ signal: 'metric', metric: { name: 'claude_code.token.usage', value: 5, attrs: { type: 'input', request_id: 'r' }, resource: RES } }, ctx) },
+	{ name: 'cost.usage', out: otelMap({ signal: 'metric', metric: { name: 'claude_code.cost.usage', value: 0.1, attrs: { request_id: 'r' }, resource: RES } }, ctx) },
+	{ name: 'lines_of_code', out: otelMap({ signal: 'metric', metric: { name: 'claude_code.lines_of_code.count', value: 1, resource: RES } }, ctx) },
+	{ name: 'user_prompt', out: otelMap({ signal: 'log', log: { event: 'claude_code.user_prompt', attrs: {}, resource: RES } }, ctx) },
+	{ name: 'tool_result(log)', out: otelMap({ signal: 'log', log: { event: 'claude_code.tool_result', attrs: { tool_name: 'Bash' }, resource: RES } }, ctx) },
+	{ name: 'llm_request', both: true, out: otelMap({ signal: 'span', span: { name: 'claude_code.llm_request', spanId: 'x', attrs: { request_id: 'r', input_tokens: 1, output_tokens: 1 }, resource: RES } }, ctx) },
+	{ name: 'tool(span)', out: otelMap({ signal: 'span', span: { name: 'claude_code.tool', spanId: 'x', attrs: { tool_name: 'Read' }, resource: RES } }, ctx) },
+	{ name: 'hook PostToolUse', out: hookMap({ hook_event_name: 'PostToolUse', session_id: 's', tool_name: 'Bash' }, ctx) },
+	{ name: 'transcript assistant', out: transcriptMap({ type: 'assistant', session_id: 's', request_id: 'r', usage: { input_tokens: 1, output_tokens: 1 } }, ctx) },
+	{ name: 'transcript tool_use', out: transcriptMap({ type: 'tool_use', session_id: 's', tool_name: 'Bash' }, ctx) },
+];
+
+describe('routing policy — meter xor obs (llm_request = both)', () => {
+	for (const c of cases) {
+		it(`${c.name}`, () => {
+			const hasUsage = c.out.usage.length > 0;
+			const hasObs = c.out.events.length > 0;
+			if (c.both) {
+				assert.ok(hasUsage && hasObs, `${c.name} must produce BOTH`);
+			} else {
+				assert.ok(hasUsage !== hasObs, `${c.name} must produce meter XOR obs (got usage=${hasUsage} obs=${hasObs})`);
+			}
+		});
+	}
+});

--- a/tests/adapters/executor/claude-code/sources/transcript-map.test.ts
+++ b/tests/adapters/executor/claude-code/sources/transcript-map.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { transcriptMap } from '../../../../../src/adapters/executor/claude-code/sources/transcript-map.js';
+import type { MapContext } from '../../../../../src/adapters/executor/claude-code/sources/cc-records.js';
+
+const ctx: MapContext = { node: 'mac-studio', receivedAt: 1_717_900_000 };
+
+describe('transcriptMap — enrichment/fallback', () => {
+	it('assistant.usage → claude.tokens record stamped _cc_source jsonl (lowest rank)', () => {
+		const out = transcriptMap(
+			{ type: 'assistant', ts: 1_717_900_002, model: 'claude-opus-4-8', request_id: 'req_01H', session_id: 'sess-9', usage: { input_tokens: 1500, output_tokens: 340, cache_read_tokens: 100, cache_creation_tokens: 0 } },
+			ctx,
+		);
+		assert.equal(out.events.length, 0);
+		assert.deepEqual(out.usage[0], {
+			schema: 1,
+			usage_id: 'cc:tok:req_01H',
+			ts: 1_717_900_002,
+			tenant_id: null,
+			trace_id: 'cc-sess:sess-9',
+			actor: { user_id: 'core', channel: 'claude-code', access_tier: 'owner', tenant_id: null },
+			source: 'core-cli',
+			meter: 'claude.tokens',
+			quantity: 1840,
+			unit: 'tokens',
+			provider: 'anthropic',
+			provider_ref: 'req_01H',
+			attrs: { _cc_source: 'jsonl', model: 'claude-opus-4-8', input_tokens: 1500, output_tokens: 340, cache_read: 100, cache_creation: 0 },
+		});
+	});
+
+	it('tool_use Write → tool.call AND paired file.change(written)', () => {
+		const out = transcriptMap({ type: 'tool_use', ts: 1_717_900_002, session_id: 'sess-9', tool_name: 'Write', tool_input: { file_path: 'notes/y.md' }, tool_use_id: 'tu5' }, ctx);
+		assert.equal(out.usage.length, 0);
+		assert.equal(out.events[0].kind, 'tool.call');
+		const fe = out.events.find((e) => e.kind === 'file.change');
+		assert.ok(fe);
+		assert.equal(fe!.source_file, 'notes/y.md');
+		assert.equal((fe!.data as Record<string, unknown>).op, 'written');
+	});
+
+	it('assistant line without usage → nothing', () => {
+		assert.deepEqual(transcriptMap({ type: 'assistant', ts: 1, session_id: 's' }, ctx), { events: [], usage: [] });
+	});
+
+	it('unrecognized line type → dropped (drift-safe), never throws', () => {
+		assert.deepEqual(transcriptMap({ type: 'totally_unknown_v2', blah: 1 }, ctx), { events: [], usage: [] });
+	});
+});

--- a/tests/adapters/executor/claude-code/sources/triangulate.test.ts
+++ b/tests/adapters/executor/claude-code/sources/triangulate.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { dedupUsage } from '../../../../../src/adapters/executor/claude-code/sources/triangulate.js';
+import type { UsageRecord } from '../../../../../src/kernel/meter/types.js';
+
+function tok(src: string, requestId: string | null, q: number, suffix = ''): UsageRecord {
+	return {
+		schema: 1,
+		usage_id: requestId ? `cc:tok:${requestId}${suffix}` : 'cc:tok:none',
+		ts: 1,
+		tenant_id: null,
+		trace_id: 't',
+		actor: { user_id: 'core', channel: 'claude-code', access_tier: 'owner' },
+		source: 'core-cli',
+		meter: 'claude.tokens',
+		quantity: q,
+		unit: 'tokens',
+		provider: 'anthropic',
+		provider_ref: requestId,
+		attrs: { _cc_source: src },
+	};
+}
+function cost(requestId: string, usd: number): UsageRecord {
+	return {
+		schema: 1,
+		usage_id: `cc:tok:${requestId}:cost`,
+		ts: 1,
+		tenant_id: null,
+		trace_id: 't',
+		actor: { user_id: 'core', channel: 'claude-code', access_tier: 'owner' },
+		source: 'core-cli',
+		meter: 'claude.cost',
+		quantity: usd,
+		unit: 'usd',
+		provider: 'anthropic',
+		provider_ref: requestId,
+		attrs: { _cc_source: 'otel-metric', cost_usd: usd },
+	};
+}
+
+const tokens = (rs: UsageRecord[]) => rs.filter((r) => r.meter === 'claude.tokens');
+
+describe('dedupUsage — triangulation', () => {
+	it('span beats jsonl for the same request (no single source load-bearing)', () => {
+		const out = tokens(dedupUsage([tok('jsonl', 'req_1', 1840), tok('otel-span', 'req_1', 1840)]));
+		assert.equal(out.length, 1);
+		assert.equal(out[0].attrs._cc_source, 'otel-span');
+	});
+
+	it('metrics-only: all per-type records survive (sole source)', () => {
+		const out = tokens(dedupUsage([tok('otel-metric', 'req_1', 1500, ':input'), tok('otel-metric', 'req_1', 340, ':output')]));
+		assert.equal(out.length, 2);
+	});
+
+	it('jsonl alone still yields a usable record (degraded fallback)', () => {
+		const out = tokens(dedupUsage([tok('jsonl', 'req_1', 1840)]));
+		assert.equal(out.length, 1);
+		assert.equal(out[0].attrs._cc_source, 'jsonl');
+	});
+
+	it('folds claude.cost into the surviving token record AND keeps the cost row', () => {
+		const out = dedupUsage([tok('otel-span', 'req_1', 1840), cost('req_1', 0.0061)]);
+		const t = out.find((r) => r.meter === 'claude.tokens')!;
+		const c = out.find((r) => r.meter === 'claude.cost');
+		assert.equal(t.attrs.cost_usd, 0.0061);
+		assert.ok(c, 'cost row preserved for the cost meter');
+	});
+
+	it('is order-independent', () => {
+		const a = [tok('jsonl', 'req_1', 1840), tok('otel-span', 'req_1', 1840), cost('req_1', 0.0061)];
+		const key = (r: UsageRecord) => r.meter + '|' + r.attrs._cc_source + '|' + r.quantity;
+		const norm = (rs: UsageRecord[]) => rs.map(key).sort();
+		assert.deepEqual(norm(dedupUsage(a)), norm(dedupUsage([...a].reverse())));
+	});
+
+	it('passes through token records with no provider_ref (coarse fallback)', () => {
+		const out = dedupUsage([tok('otel-metric', null, 5)]);
+		assert.equal(out.length, 1);
+	});
+});

--- a/tests/kernel/_shared/ids.test.py
+++ b/tests/kernel/_shared/ids.test.py
@@ -1,0 +1,44 @@
+"""Twin of ids.test.ts — same format guarantees on the Python side."""
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+
+from kernel._shared import ids  # noqa: E402
+
+ULID_BODY = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
+TRACE = re.compile(r"^tr_[0-9A-HJKMNP-TV-Z]{26}$")
+USAGE = re.compile(r"^ux_[0-9A-HJKMNP-TV-Z]{26}$")
+SPAN = re.compile(r"^sp_[0-9a-f]{16}$")
+
+
+class IdsTest(unittest.TestCase):
+    def test_prefixes_and_body(self) -> None:
+        self.assertRegex(ids.new_trace_id(), TRACE)
+        self.assertRegex(ids.new_usage_id(), USAGE)
+        self.assertRegex(ids.ulid(), ULID_BODY)
+
+    def test_span_id(self) -> None:
+        self.assertRegex(ids.new_span_id(), SPAN)
+
+    def test_time_sortable(self) -> None:
+        early = ids.new_trace_id(1_000_000_000_000)
+        late = ids.new_trace_id(1_700_000_000_000)
+        self.assertLess(early, late)
+
+    def test_collision_free(self) -> None:
+        seen = {ids.new_trace_id() for _ in range(10_000)}
+        self.assertEqual(len(seen), 10_000)
+
+    def test_no_ambiguous_chars(self) -> None:
+        for _ in range(200):
+            self.assertNotRegex(ids.ulid(), re.compile(r"[ILOU]"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/kernel/_shared/ids.test.ts
+++ b/tests/kernel/_shared/ids.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { newTraceId, newUsageId, newSpanId, ulid } from '../../../src/kernel/_shared/ids.js';
+
+const ULID_BODY = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const TRACE = /^tr_[0-9A-HJKMNP-TV-Z]{26}$/;
+const USAGE = /^ux_[0-9A-HJKMNP-TV-Z]{26}$/;
+const SPAN = /^sp_[0-9a-f]{16}$/;
+
+describe('kernel/_shared/ids', () => {
+	it('mints trace/usage ids with the right prefix + Crockford body', () => {
+		assert.match(newTraceId(), TRACE);
+		assert.match(newUsageId(), USAGE);
+		assert.match(ulid(), ULID_BODY);
+	});
+
+	it('mints span ids as sp_ + 16 hex', () => {
+		assert.match(newSpanId(), SPAN);
+	});
+
+	it('is lexicographically time-sortable (time is the high-order chars)', () => {
+		const early = newTraceId(1_000_000_000_000);
+		const late = newTraceId(1_700_000_000_000);
+		assert.ok(early < late, `${early} should sort before ${late}`);
+	});
+
+	it('is collision-free across 10k mints', () => {
+		const seen = new Set<string>();
+		for (let i = 0; i < 10_000; i++) seen.add(newTraceId());
+		assert.equal(seen.size, 10_000);
+	});
+
+	it('never emits the ambiguous Crockford chars I L O U', () => {
+		for (let i = 0; i < 200; i++) {
+			const body = ulid();
+			assert.doesNotMatch(body, /[ILOU]/);
+		}
+	});
+});

--- a/tests/kernel/_shared/node.test.py
+++ b/tests/kernel/_shared/node.test.py
@@ -1,0 +1,40 @@
+"""Twin of node.test.ts."""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+
+from kernel._shared import node  # noqa: E402
+
+
+class NodeTest(unittest.TestCase):
+    def tearDown(self) -> None:
+        os.environ.pop("SUTANDO_NODE_ID", None)
+        node.reset_node_id()
+
+    def test_override(self) -> None:
+        os.environ["SUTANDO_NODE_ID"] = "mac-studio-test"
+        node.reset_node_id()
+        self.assertEqual(node.node_id(), "mac-studio-test")
+
+    def test_hostname_fallback(self) -> None:
+        os.environ.pop("SUTANDO_NODE_ID", None)
+        node.reset_node_id()
+        self.assertEqual(node.node_id(), socket.gethostname().split(".")[0] or "unknown")
+
+    def test_caches_until_reset(self) -> None:
+        os.environ["SUTANDO_NODE_ID"] = "first"
+        node.reset_node_id()
+        self.assertEqual(node.node_id(), "first")
+        os.environ["SUTANDO_NODE_ID"] = "second"  # no reset -> cached value holds
+        self.assertEqual(node.node_id(), "first")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/kernel/_shared/node.test.ts
+++ b/tests/kernel/_shared/node.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { hostname } from 'node:os';
+import { nodeId, resetNodeId } from '../../../src/kernel/_shared/node.js';
+
+afterEach(() => {
+	delete process.env.SUTANDO_NODE_ID;
+	resetNodeId();
+});
+
+describe('kernel/_shared/node', () => {
+	it('honors the SUTANDO_NODE_ID override', () => {
+		process.env.SUTANDO_NODE_ID = 'mac-studio-test';
+		resetNodeId();
+		assert.equal(nodeId(), 'mac-studio-test');
+	});
+
+	it('falls back to the short hostname', () => {
+		delete process.env.SUTANDO_NODE_ID;
+		resetNodeId();
+		assert.equal(nodeId(), hostname().split('.')[0] || 'unknown');
+	});
+
+	it('caches within a process until reset', () => {
+		process.env.SUTANDO_NODE_ID = 'first';
+		resetNodeId();
+		assert.equal(nodeId(), 'first');
+		process.env.SUTANDO_NODE_ID = 'second'; // no reset → cached value holds
+		assert.equal(nodeId(), 'first');
+	});
+});

--- a/tests/kernel/config/observability-config.test.py
+++ b/tests/kernel/config/observability-config.test.py
@@ -1,0 +1,82 @@
+"""Twin of observability-config.test.ts.
+
+The loader reads already-populated ``os.environ`` (it does NOT re-parse .env --
+that's the bridges' job, PR #416), so this tests precedence, truthy parsing,
+malformed-override fallback, and defaults/const drift.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+
+from kernel.config import observability_config as cfgmod  # noqa: E402
+
+KNOBS = (
+    "SUTANDO_TENANT_ID",
+    "SUTANDO_TENANT_MODE",
+    "SUTANDO_METERING_ENABLED",
+    "SUTANDO_METERING_ENDPOINT",
+)
+
+
+class ObservabilityConfigTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = {k: os.environ.pop(k, None) for k in KNOBS}
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        self._tmp.cleanup()
+
+    def test_defaults_only(self) -> None:
+        self.assertEqual(cfgmod.load_observability_config(self.ws), cfgmod.OBSERVABILITY_DEFAULTS)
+
+    def test_env_beats_defaults_file(self) -> None:
+        os.environ["SUTANDO_TENANT_ID"] = "acct_123"
+        os.environ["SUTANDO_TENANT_MODE"] = "managed"
+        os.environ["SUTANDO_METERING_ENABLED"] = "true"
+        os.environ["SUTANDO_METERING_ENDPOINT"] = "https://meter.example"
+        cfg = cfgmod.load_observability_config(self.ws)
+        self.assertEqual(cfg["tenant"]["id"], "acct_123")
+        self.assertEqual(cfg["tenant"]["mode"], "managed")
+        self.assertTrue(cfg["metering"]["enabled"])
+        self.assertEqual(cfg["metering"]["endpoint"], "https://meter.example")
+
+    def test_metering_enabled_truthy_parse(self) -> None:
+        os.environ["SUTANDO_METERING_ENABLED"] = "no"
+        self.assertFalse(cfgmod.load_observability_config(self.ws)["metering"]["enabled"])
+        os.environ["SUTANDO_METERING_ENABLED"] = "on"
+        self.assertTrue(cfgmod.load_observability_config(self.ws)["metering"]["enabled"])
+
+    def test_workspace_override_wins(self) -> None:
+        os.environ["SUTANDO_TENANT_MODE"] = "managed"
+        (self.ws / "config").mkdir(parents=True, exist_ok=True)
+        (self.ws / "config" / "observability.json").write_text(
+            json.dumps({"tenant": {"mode": "byok"}, "observability": {"sampling": {"trace": 0.5}}})
+        )
+        cfg = cfgmod.load_observability_config(self.ws)
+        self.assertEqual(cfg["tenant"]["mode"], "byok")  # workspace overrides env
+        self.assertEqual(cfg["observability"]["sampling"]["trace"], 0.5)
+        self.assertEqual(cfg["metering"]["batchMax"], 100)  # untouched key kept
+
+    def test_malformed_override_falls_back(self) -> None:
+        (self.ws / "config").mkdir(parents=True, exist_ok=True)
+        (self.ws / "config" / "observability.json").write_text("{ not valid json")
+        cfg = cfgmod.load_observability_config(self.ws)
+        self.assertEqual(cfg, cfgmod.OBSERVABILITY_DEFAULTS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/kernel/config/observability-config.test.ts
+++ b/tests/kernel/config/observability-config.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	loadObservabilityConfig,
+	OBSERVABILITY_DEFAULTS,
+} from '../../../src/kernel/config/observability-config.js';
+
+const KNOBS = ['SUTANDO_TENANT_ID', 'SUTANDO_TENANT_MODE', 'SUTANDO_METERING_ENABLED', 'SUTANDO_METERING_ENDPOINT'];
+let saved: Record<string, string | undefined>;
+let ws: string;
+
+beforeEach(() => {
+	saved = {};
+	for (const k of KNOBS) {
+		saved[k] = process.env[k];
+		delete process.env[k];
+	}
+	ws = mkdtempSync(join(tmpdir(), 'obscfg-'));
+});
+
+afterEach(() => {
+	for (const k of KNOBS) {
+		if (saved[k] === undefined) delete process.env[k];
+		else process.env[k] = saved[k];
+	}
+	rmSync(ws, { recursive: true, force: true });
+});
+
+describe('kernel/config/observability-config', () => {
+	it('clean env + no override → equals OBSERVABILITY_DEFAULTS', () => {
+		assert.deepEqual(loadObservabilityConfig({ workspace: ws }), OBSERVABILITY_DEFAULTS);
+	});
+
+	it('env knobs beat the defaults file', () => {
+		process.env.SUTANDO_TENANT_ID = 'acct_123';
+		process.env.SUTANDO_TENANT_MODE = 'managed';
+		process.env.SUTANDO_METERING_ENABLED = 'true';
+		process.env.SUTANDO_METERING_ENDPOINT = 'https://meter.example';
+		const cfg = loadObservabilityConfig({ workspace: ws });
+		assert.equal(cfg.tenant.id, 'acct_123');
+		assert.equal(cfg.tenant.mode, 'managed');
+		assert.equal(cfg.metering.enabled, true);
+		assert.equal(cfg.metering.endpoint, 'https://meter.example');
+	});
+
+	it('SUTANDO_METERING_ENABLED parses only truthy tokens', () => {
+		process.env.SUTANDO_METERING_ENABLED = 'no';
+		assert.equal(loadObservabilityConfig({ workspace: ws }).metering.enabled, false);
+		process.env.SUTANDO_METERING_ENABLED = 'on';
+		assert.equal(loadObservabilityConfig({ workspace: ws }).metering.enabled, true);
+	});
+
+	it('workspace override wins over env (documented order)', () => {
+		process.env.SUTANDO_TENANT_MODE = 'managed';
+		mkdirSync(join(ws, 'config'), { recursive: true });
+		writeFileSync(
+			join(ws, 'config', 'observability.json'),
+			JSON.stringify({ tenant: { mode: 'byok' }, observability: { sampling: { trace: 0.5 } } }),
+		);
+		const cfg = loadObservabilityConfig({ workspace: ws });
+		assert.equal(cfg.tenant.mode, 'byok'); // workspace overrides the env knob
+		assert.equal(cfg.observability.sampling.trace, 0.5);
+		// untouched keys keep their resolved value (metering still defaulted)
+		assert.equal(cfg.metering.batchMax, 100);
+	});
+
+	it('malformed workspace override → warns and falls back, never throws', () => {
+		mkdirSync(join(ws, 'config'), { recursive: true });
+		writeFileSync(join(ws, 'config', 'observability.json'), '{ not valid json');
+		const cfg = loadObservabilityConfig({ workspace: ws });
+		assert.deepEqual(cfg, OBSERVABILITY_DEFAULTS);
+	});
+
+	it('the shipped defaults file matches the in-code const (no drift)', () => {
+		// defaults-only load reads the real config/sutando.config.defaults.json;
+		// equality to the const proves the file did not diverge.
+		assert.deepEqual(loadObservabilityConfig({ workspace: ws }), OBSERVABILITY_DEFAULTS);
+	});
+});

--- a/tests/kernel/meter/meter.test.py
+++ b/tests/kernel/meter/meter.test.py
@@ -1,0 +1,114 @@
+"""Twin of meter.test.ts."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+
+from kernel import meter, obs  # noqa: E402
+
+ENV = ("SUTANDO_WORKSPACE", "SUTANDO_TENANT_ID", "SUTANDO_TENANT_MODE", "SUTANDO_METERING_FSYNC")
+
+
+class Capture:
+    type = "capture"
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    def write(self, ev: dict) -> None:
+        self.events.append(ev)
+
+
+def base_usage() -> dict:
+    return {
+        "source": "core-cli",
+        "actor": {"user_id": "u1", "channel": "claude-code", "access_tier": "owner"},
+        "meter": "claude.tokens",
+        "quantity": 1840,
+        "unit": "tokens",
+        "provider": "anthropic",
+        "provider_ref": "req_01H",
+        "attrs": {"model": "claude-opus-4-8", "input_tokens": 1500, "output_tokens": 340},
+    }
+
+
+class RecordTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = {k: os.environ.pop(k, None) for k in ENV}
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+        os.environ["SUTANDO_WORKSPACE"] = str(self.ws)
+        obs.reset_sinks()
+        self.cap = Capture()
+        obs.register_sink(self.cap)
+
+    def tearDown(self) -> None:
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        obs.reset_sinks()
+        self._tmp.cleanup()
+
+    def _read_ledger(self, rec: dict) -> list[str]:
+        path = meter.ledger_path(rec["ts"] * 1000, self.ws)
+        if not path.exists():
+            return []
+        return [l for l in path.read_text().split("\n") if l]
+
+    def test_byte_exact_line(self) -> None:
+        rec = meter.record({**base_usage(), "usage_id": "ux_FIXED0000000000000000000", "ts": 1_717_900_000.12})
+        lines = self._read_ledger(rec)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0], json.dumps(rec, ensure_ascii=False, separators=(",", ":")))
+        self.assertEqual(json.loads(lines[0]), rec)
+        self.assertRegex(str(meter.ledger_path(rec["ts"] * 1000, self.ws)), r"/data/usage/usage-\d{4}-\d{2}-\d{2}\.jsonl$")
+
+    def test_stamps_and_defaults(self) -> None:
+        u = base_usage()
+        u.pop("provider_ref")
+        rec = meter.record(u)
+        self.assertEqual(rec["schema"], 1)
+        self.assertRegex(rec["usage_id"], r"^ux_")
+        self.assertRegex(rec["trace_id"], r"^tr_")
+        self.assertIsInstance(rec["ts"], float)
+        self.assertIsNone(rec["provider_ref"])
+
+    def test_supplied_usage_id_verbatim(self) -> None:
+        a = meter.record({**base_usage(), "usage_id": "ux_SAME0000000000000000000", "ts": 1_717_900_000})
+        meter.record({**base_usage(), "usage_id": "ux_SAME0000000000000000000", "ts": 1_717_900_000})
+        lines = self._read_ledger(a)
+        self.assertEqual(len(lines), 2)
+        for l in lines:
+            self.assertEqual(json.loads(l)["usage_id"], "ux_SAME0000000000000000000")
+
+    def test_auto_mint_distinct(self) -> None:
+        a = meter.record(base_usage())
+        b = meter.record(base_usage())
+        self.assertNotEqual(a["usage_id"], b["usage_id"])
+
+    def test_advisory_event_emitted(self) -> None:
+        rec = meter.record(base_usage())
+        adv = next((e for e in self.cap.events if e.get("kind") == "usage.recorded"), None)
+        self.assertIsNotNone(adv)
+        self.assertEqual(adv["source"], "core-cli")
+        self.assertEqual(adv["data"]["usage_id"], rec["usage_id"])
+        self.assertEqual(adv["usage"]["input_tokens"], 1500)
+
+    def test_tenant_default_and_override(self) -> None:
+        self.assertIsNone(meter.record(base_usage())["tenant_id"])
+        os.environ["SUTANDO_TENANT_ID"] = "acct_9"
+        self.assertEqual(meter.record(base_usage())["tenant_id"], "acct_9")
+        self.assertEqual(meter.record({**base_usage(), "tenant_id": "explicit"})["tenant_id"], "explicit")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/kernel/meter/meter.test.ts
+++ b/tests/kernel/meter/meter.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { record, ledgerPath } from '../../../src/kernel/meter/meter.js';
+import { resetSinks, registerSink } from '../../../src/kernel/obs/obs.js';
+import type { ObsEvent } from '../../../src/kernel/obs/types.js';
+import type { Sink } from '../../../src/kernel/obs/sink.js';
+import type { UsageRecordInput } from '../../../src/kernel/meter/types.js';
+
+const ENV = ['SUTANDO_WORKSPACE', 'SUTANDO_TENANT_ID', 'SUTANDO_TENANT_MODE', 'SUTANDO_METERING_FSYNC'];
+let saved: Record<string, string | undefined>;
+let ws: string;
+let cap: { type: string; events: ObsEvent[]; write(ev: ObsEvent): void };
+
+function baseUsage(): UsageRecordInput {
+	return {
+		source: 'core-cli',
+		actor: { user_id: 'u1', channel: 'claude-code', access_tier: 'owner' },
+		meter: 'claude.tokens',
+		quantity: 1840,
+		unit: 'tokens',
+		provider: 'anthropic',
+		provider_ref: 'req_01H',
+		attrs: { model: 'claude-opus-4-8', input_tokens: 1500, output_tokens: 340 },
+	};
+}
+
+beforeEach(() => {
+	saved = {};
+	for (const k of ENV) {
+		saved[k] = process.env[k];
+		delete process.env[k];
+	}
+	ws = mkdtempSync(join(tmpdir(), 'meter-'));
+	process.env.SUTANDO_WORKSPACE = ws;
+	resetSinks();
+	cap = { type: 'capture', events: [], write(ev) { this.events.push(ev); } };
+	registerSink(cap as Sink);
+});
+
+afterEach(() => {
+	for (const k of ENV) {
+		if (saved[k] === undefined) delete process.env[k];
+		else process.env[k] = saved[k];
+	}
+	rmSync(ws, { recursive: true, force: true });
+	resetSinks();
+});
+
+function readLedger(rec: { ts: number }): string[] {
+	const path = ledgerPath(rec.ts * 1000, ws);
+	if (!existsSync(path)) return [];
+	return readFileSync(path, 'utf-8').split('\n').filter((l) => l.length > 0);
+}
+
+describe('kernel/meter/record', () => {
+	it('writes a byte-exact compact ledger line at the dated path', () => {
+		const rec = record({ ...baseUsage(), usage_id: 'ux_FIXED0000000000000000000', ts: 1_717_900_000.12 });
+		const lines = readLedger(rec);
+		assert.equal(lines.length, 1);
+		assert.equal(lines[0], JSON.stringify(rec));
+		assert.deepEqual(JSON.parse(lines[0]), rec);
+		assert.match(ledgerPath(rec.ts * 1000, ws), /\/data\/usage\/usage-\d{4}-\d{2}-\d{2}\.jsonl$/);
+	});
+
+	it('stamps schema/usage_id/ts/trace_id and defaults provider_ref', () => {
+		const rec = record({ ...baseUsage(), provider_ref: undefined });
+		assert.equal(rec.schema, 1);
+		assert.match(rec.usage_id, /^ux_/);
+		assert.match(rec.trace_id, /^tr_/);
+		assert.equal(typeof rec.ts, 'number');
+		assert.equal(rec.provider_ref, null);
+	});
+
+	it('honors a supplied usage_id verbatim (idempotency key survives re-append)', () => {
+		const a = record({ ...baseUsage(), usage_id: 'ux_SAME0000000000000000000', ts: 1_717_900_000 });
+		const b = record({ ...baseUsage(), usage_id: 'ux_SAME0000000000000000000', ts: 1_717_900_000 });
+		const lines = readLedger(a);
+		assert.equal(lines.length, 2); // append-only, at-least-once
+		assert.equal(a.usage_id, b.usage_id);
+		for (const l of lines) assert.equal(JSON.parse(l).usage_id, 'ux_SAME0000000000000000000');
+	});
+
+	it('auto-mints distinct usage_ids when none supplied', () => {
+		const a = record(baseUsage());
+		const b = record(baseUsage());
+		assert.notEqual(a.usage_id, b.usage_id);
+	});
+
+	it('emits an advisory usage.recorded obs event AFTER the durable write', () => {
+		const rec = record(baseUsage());
+		const adv = cap.events.find((e) => e.kind === 'usage.recorded');
+		assert.ok(adv, 'expected a usage.recorded advisory event');
+		assert.equal(adv!.source, 'core-cli');
+		assert.equal((adv!.data as Record<string, unknown>).usage_id, rec.usage_id);
+		assert.equal(adv!.usage?.input_tokens, 1500);
+	});
+
+	it('defaults tenant_id from config, and honors an explicit value', () => {
+		assert.equal(record(baseUsage()).tenant_id, null); // BYOK default
+		process.env.SUTANDO_TENANT_ID = 'acct_9';
+		assert.equal(record(baseUsage()).tenant_id, 'acct_9');
+		assert.equal(record({ ...baseUsage(), tenant_id: 'explicit' }).tenant_id, 'explicit');
+	});
+});

--- a/tests/kernel/obs/obs.test.py
+++ b/tests/kernel/obs/obs.test.py
@@ -1,0 +1,90 @@
+"""Twin of obs.test.ts."""
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+
+from kernel import obs  # noqa: E402
+
+
+class Capture:
+    type = "capture"
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    def write(self, ev: dict) -> None:
+        self.events.append(ev)
+
+
+def base_input() -> dict:
+    return {
+        "source": "voice-agent",
+        "actor": {"user_id": "u1", "channel": "voice", "access_tier": "owner"},
+        "kind": "tool.call",
+        "outcome": "ok",
+    }
+
+
+class EmitTest(unittest.TestCase):
+    def setUp(self) -> None:
+        obs.reset_sinks()
+        self.cap = Capture()
+        obs.register_sink(self.cap)
+
+    def tearDown(self) -> None:
+        obs.reset_sinks()
+
+    def test_stamps_and_keeps_fields(self) -> None:
+        obs.emit({**base_input(), "source_file": "tasks/task-1.txt", "data": {"tool_name": "Read"}})
+        self.assertEqual(len(self.cap.events), 1)
+        ev = self.cap.events[0]
+        self.assertEqual(ev["schema"], 1)
+        self.assertIsInstance(ev["ts"], float)
+        self.assertRegex(ev["trace_id"], re.compile(r"^tr_"))
+        self.assertTrue(ev["node"])
+        self.assertEqual(ev["source"], "voice-agent")
+        self.assertEqual(ev["source_file"], "tasks/task-1.txt")
+        self.assertEqual(ev["data"], {"tool_name": "Read"})
+
+    def test_supplied_trace_id(self) -> None:
+        obs.emit({**base_input(), "trace_id": "tr_FIXED"})
+        self.assertEqual(self.cap.events[0]["trace_id"], "tr_FIXED")
+
+    def test_never_throws_other_sinks_receive(self) -> None:
+        class Bad:
+            type = "bad"
+
+            def write(self, ev: dict) -> None:
+                raise RuntimeError("boom")
+
+        obs.register_sink(Bad())
+        obs.emit(base_input())  # must not raise
+        self.assertEqual(len(self.cap.events), 1)
+
+    def test_sampling_drops_ok(self) -> None:
+        obs.set_sampler(lambda ev: False)
+        obs.emit(base_input())
+        self.assertEqual(len(self.cap.events), 0)
+
+    def test_never_samples_error_denied_usage(self) -> None:
+        obs.set_sampler(lambda ev: False)
+        obs.emit({**base_input(), "outcome": "error"})
+        obs.emit({**base_input(), "outcome": "denied"})
+        obs.emit({**base_input(), "kind": "usage.recorded"})
+        self.assertEqual(len(self.cap.events), 3)
+
+    def test_omits_unsupplied_optionals(self) -> None:
+        obs.emit(base_input())
+        ev = self.cap.events[0]
+        for k in ("span_id", "duration_ms", "usage", "source_file"):
+            self.assertNotIn(k, ev)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/kernel/obs/obs.test.ts
+++ b/tests/kernel/obs/obs.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { emit, registerSink, resetSinks, setSampler } from '../../../src/kernel/obs/obs.js';
+import type { ObsEvent, ObsEventInput } from '../../../src/kernel/obs/types.js';
+import type { Sink } from '../../../src/kernel/obs/sink.js';
+
+class Capture implements Sink {
+	readonly type = 'capture';
+	events: ObsEvent[] = [];
+	write(ev: ObsEvent): void {
+		this.events.push(ev);
+	}
+}
+
+function baseInput(): ObsEventInput {
+	return {
+		source: 'voice-agent',
+		actor: { user_id: 'u1', channel: 'voice', access_tier: 'owner' },
+		kind: 'tool.call',
+		outcome: 'ok',
+	};
+}
+
+let cap: Capture;
+
+beforeEach(() => {
+	resetSinks();
+	cap = new Capture();
+	registerSink(cap);
+});
+afterEach(() => resetSinks());
+
+describe('kernel/obs/emit', () => {
+	it('stamps schema/ts/node/trace_id and keeps caller fields', () => {
+		emit({ ...baseInput(), source_file: 'tasks/task-1.txt', data: { tool_name: 'Read' } });
+		assert.equal(cap.events.length, 1);
+		const ev = cap.events[0];
+		assert.equal(ev.schema, 1);
+		assert.equal(typeof ev.ts, 'number');
+		assert.match(ev.trace_id, /^tr_/);
+		assert.ok(ev.node.length > 0);
+		assert.equal(ev.source, 'voice-agent');
+		assert.equal(ev.source_file, 'tasks/task-1.txt');
+		assert.equal(ev.kind, 'tool.call');
+		assert.deepEqual(ev.data, { tool_name: 'Read' });
+	});
+
+	it('honors a supplied trace_id', () => {
+		emit({ ...baseInput(), trace_id: 'tr_FIXED' });
+		assert.equal(cap.events[0].trace_id, 'tr_FIXED');
+	});
+
+	it('never throws when a sink throws; other sinks still receive', () => {
+		const bad: Sink = {
+			type: 'bad',
+			write() {
+				throw new Error('boom');
+			},
+		};
+		registerSink(bad);
+		assert.doesNotThrow(() => emit(baseInput()));
+		assert.equal(cap.events.length, 1);
+	});
+
+	it('samples away ok events when the sampler returns false', () => {
+		setSampler(() => false);
+		emit(baseInput());
+		assert.equal(cap.events.length, 0);
+	});
+
+	it('never samples away error / denied / usage.recorded', () => {
+		setSampler(() => false);
+		emit({ ...baseInput(), outcome: 'error' });
+		emit({ ...baseInput(), outcome: 'denied' });
+		emit({ ...baseInput(), kind: 'usage.recorded' });
+		assert.equal(cap.events.length, 3);
+	});
+
+	it('omits optional fields that were not supplied', () => {
+		emit(baseInput());
+		const ev = cap.events[0];
+		assert.equal('span_id' in ev, false);
+		assert.equal('duration_ms' in ev, false);
+		assert.equal('usage' in ev, false);
+		assert.equal('source_file' in ev, false);
+	});
+});

--- a/tests/kernel/obs/sink-jsonl.test.py
+++ b/tests/kernel/obs/sink-jsonl.test.py
@@ -1,0 +1,64 @@
+"""Twin of sink-jsonl.test.ts."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+
+from kernel.obs import JsonlFileSink  # noqa: E402
+
+
+def sample_event() -> dict:
+    return {
+        "schema": 1,
+        "ts": round(time.time(), 3),
+        "trace_id": "tr_TEST00000000000000000000",
+        "node": "mac-studio",
+        "source": "filewatcher",
+        "source_file": "tasks/task-9.txt",
+        "actor": {"user_id": "u1", "channel": "discord", "access_tier": "owner"},
+        "kind": "file.change",
+        "outcome": "ok",
+        "data": {"op": "created"},
+    }
+
+
+class JsonlFileSinkTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_one_compact_line_at_daily_path(self) -> None:
+        ev = sample_event()
+        JsonlFileSink(self.dir).write(ev)
+
+        files = list(self.dir.iterdir())
+        self.assertEqual(len(files), 1)
+        self.assertRegex(files[0].name, re.compile(r"^events-\d{4}-\d{2}-\d{2}\.jsonl$"))
+
+        lines = [l for l in files[0].read_text().split("\n") if l]
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0], json.dumps(ev, ensure_ascii=False, separators=(",", ":")))
+        self.assertEqual(json.loads(lines[0]), ev)
+
+    def test_appends_without_clobber(self) -> None:
+        sink = JsonlFileSink(self.dir)
+        sink.write(sample_event())
+        sink.write(sample_event())
+        files = list(self.dir.iterdir())
+        lines = [l for l in files[0].read_text().split("\n") if l]
+        self.assertEqual(len(lines), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/kernel/obs/sink-jsonl.test.ts
+++ b/tests/kernel/obs/sink-jsonl.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { JsonlFileSink } from '../../../src/kernel/obs/sink.js';
+import type { ObsEvent } from '../../../src/kernel/obs/types.js';
+
+function sampleEvent(): ObsEvent {
+	return {
+		schema: 1,
+		ts: Date.now() / 1000,
+		trace_id: 'tr_TEST00000000000000000000',
+		node: 'mac-studio',
+		source: 'filewatcher',
+		source_file: 'tasks/task-9.txt',
+		actor: { user_id: 'u1', channel: 'discord', access_tier: 'owner' },
+		kind: 'file.change',
+		outcome: 'ok',
+		data: { op: 'created' },
+	};
+}
+
+let dir: string;
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), 'obssink-'));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe('kernel/obs/JsonlFileSink', () => {
+	it('writes exactly one compact JSON line at the daily-dated path', () => {
+		const ev = sampleEvent();
+		new JsonlFileSink({ dir }).write(ev);
+
+		const files = readdirSync(dir);
+		assert.equal(files.length, 1);
+		assert.match(files[0], /^events-\d{4}-\d{2}-\d{2}\.jsonl$/);
+
+		const body = readFileSync(join(dir, files[0]), 'utf-8');
+		const lines = body.split('\n').filter((l) => l.length > 0);
+		assert.equal(lines.length, 1);
+		// compact: no spaces, equals JSON.stringify, round-trips to the same object
+		assert.equal(lines[0], JSON.stringify(ev));
+		assert.deepEqual(JSON.parse(lines[0]), ev);
+	});
+
+	it('appends without clobbering across writes', () => {
+		const sink = new JsonlFileSink({ dir });
+		sink.write(sampleEvent());
+		sink.write(sampleEvent());
+		const files = readdirSync(dir);
+		const body = readFileSync(join(dir, files[0]), 'utf-8');
+		assert.equal(body.split('\n').filter((l) => l.length > 0).length, 2);
+	});
+});

--- a/tests/policy/runner-glob.test.py
+++ b/tests/policy/runner-glob.test.py
@@ -1,0 +1,69 @@
+"""Guard: the test runner globs must be RECURSIVE so relocated tests run.
+
+The migration moves tests out of the flat `tests/` dir into a tree that mirrors
+`src/` (`tests/kernel/...`, `tests/adapters/...`). A non-recursive glob
+(`tests/*.test.ts`) would silently skip every relocated test and still report
+green — the "green-but-blind" failure mode. This test fails loudly if the
+package.json scripts regress to a non-recursive pattern, and proves the
+recursive Python `find` actually discovers a nested test.
+
+POLICY test (test-inventory.md §5, Phase 0/4).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class RunnerGlobTest(unittest.TestCase):
+    def _scripts(self) -> dict[str, str]:
+        pkg = json.loads((REPO / "package.json").read_text())
+        return pkg.get("scripts", {})
+
+    def test_ts_glob_is_recursive(self) -> None:
+        test_script = self._scripts().get("test", "")
+        self.assertIn(
+            "tests/**/*.test.ts",
+            test_script,
+            "TS test glob must be recursive (tests/**/*.test.ts) so nested tests run",
+        )
+        self.assertNotIn(
+            "tests/*.test.ts",
+            test_script,
+            "non-recursive tests/*.test.ts would skip every relocated test",
+        )
+
+    def test_py_find_is_recursive(self) -> None:
+        py_script = self._scripts().get("test:py", "")
+        self.assertIn(
+            "find tests -name '*.test.py'",
+            py_script,
+            "Python runner must use a recursive `find`, not a flat glob",
+        )
+
+    def test_recursive_find_discovers_nested_tests(self) -> None:
+        """The recursive find must return at least one test under a SUBDIRECTORY
+        of tests/ (depth >= 2) — i.e. exactly what a flat glob would miss."""
+        out = subprocess.run(
+            ["find", "tests", "-name", "*.test.py"],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        paths = [p for p in out.splitlines() if p.strip()]
+        nested = [p for p in paths if Path(p).parent != Path("tests")]
+        self.assertTrue(
+            nested,
+            "expected at least one *.test.py under a tests/ subdirectory "
+            "(e.g. tests/kernel/...); recursion would be untested otherwise",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Builds the **observability + metering spine** (Phase 0 of the parity-first strangler-fig refactor) as **additive, zero-consumer libraries**, plus a **single source-agnostic local collector** and a **strict, composable Claude Code ingest path**.

Draft — the kernel seam commit (`c9c7d0f`) is WIP; the three commits here are review-ready.

## Why

Logging today is fragmented and retroactive (dormant `event_log.py`, three ad-hoc schemas, no `trace_id`, no token/cost ledger). The redesign's safety net for every later phase is trace-replay, which needs one event spine first. This is that spine — built so parity is trivially preserved (nothing calls it yet) — plus the local collector that normalizes heterogeneous sources into it.

## Scope (this branch)

| Commit | What |
|---|---|
| `c9c7d0f` | kernel `obs`/`meter`/`config` seam + CC OTel mappers (WIP, prior) |
| `4b6b835` | **source-agnostic local collector** — `kernel/collector/{collector,normalizer,server}` + `boot/collector.ts`; `Collector` routes `/ingest/<source>` → registered `Normalizer` → one sink-set + ledger; `AbstractNormalizer<T>` (`normalize = map ∘ decode`); `meter.writeLedger()` extracted |
| `4e031a6` | **strict Claude Code hook ingest** — `cc-hooks.ts` discriminated-union contract + `decodeClaudeCodeHook` (the detect→strictly-type boundary); `ClaudeCodeHookNormalizer`; `hook-map.ts` rewritten to narrow with no casts; thin `obs-hook.sh` + `start-cli.sh` per-session injection ("always set hooks, only export when told where") |
| `f31c8af` | **optional startup boot** — `SUTANDO_OBS_COLLECTOR=1` boots the collector + wires the core's `SUTANDO_OBS_ENDPOINT`; off by default |

**One collector, many sources.** Claude Code is just one registered normalizer; voice / filewatcher / bridges plug into the same collector. It's a *local* floor that later forwards upstream — adding a forward sink to `observability.sinks` fans every normalized event out with no code change.

## Design notes

- **Universal envelope:** thin stable `ObsEvent` + open `data` bag; `source` (emitter), `source_file` (subject file), `node` (machine), `actor.channel` (ingress) as distinct axes. `meter.record` is the durable append-only ledger (separate guarantees from best-effort `obs.emit`).
- **Strict CC typing:** `ClaudeCodeHook = KnownHook | UnknownHook`; the single boundary cast lives in `decode`, downstream is cast-free with full discriminated-union narrowing. Field names verified against **real** payloads (`tool_response`, `delta`+`final`, `prompt`) — the docs were wrong on several.
- **core-cli file consumption** is captured with no core instrumentation: a `Read`/`Write`/`Edit` tool hook emits a paired `file.*` event whose `source_file` is the touched path.

## Testing

- `npm test` (TS) — **64/64 green**, incl. the kernel + `adapters/executor/claude-code/sources` characterization tests (behavior byte-preserved through the strict-typing refactor); Python meter twin green.
- Type-clean: zero `tsc` errors in the new/changed files.
- Live end-to-end smoke through `boot/collector.ts`: `cc.prompt`, `tool.call`/`tool.result`, paired `file.read`, accumulated `cc.message`, `cc.hook.*` all normalize correctly; `decode` drops non-CC bodies.

## Deferred (not in this PR)

- The forward sink (otlp-http / batched POST) to an upstream collector.
- Live OTLP receiver / `.jsonl` tailer as `ExecutorSource`s; voice/filewatcher normalizers.
- Per-surface live `emit()` wiring (Phase 1).
- Design docs (`docs/migration/`) and the WIP transcript source (`jsonl-tail.ts`) intentionally excluded to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)