### PR TITLE
feat(relay-channel): remote-task-client — one-token onboarding to a hosted relay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -163,3 +163,7 @@ PORT=9900
 # WhatsApp → Linked Devices on the user's phone.
 # WACLI_DEVICE_LABEL=Sutando
 # WACLI_DEVICE_PLATFORM=CHROME
+
+# AG2 remote relay. Paste the onboarding string you received; startup.sh
+# auto-starts the relay client when set.
+# AG2_REMOTE_TOKEN=paste-your-onboarding-string-here

--- a/src/remote-task-client.py
+++ b/src/remote-task-client.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+remote-task-client.py — generic client that bridges a REMOTE task relay to the
+local Sutando file queue, so the local core processes remote tasks unchanged.
+
+This is the OPEN, provider-agnostic half of the "agent as a service" design: a
+relay service holds the platform connection and
+exposes a tiny HTTP protocol; this client pulls *your* tasks down into the local
+`tasks/` queue and pushes results back up. No provider-specific logic lives here
+— that's the relay's job.
+
+Protocol (versioned, Bearer-auth):
+  GET  {REMOTE_TASK_URL}/v1/tasks?wait=<sec>
+       → 200 {"tasks": [ {<task fields...>}, ... ]}   (long-poll; [] on timeout)
+  POST {REMOTE_TASK_URL}/v1/results
+       → body {"id": "<task-id>", "body": "<result text>"}  → 200 on accepted
+
+Each task object uses the same schema Sutando's other bridges write, so this
+client just serializes it to `tasks/task-<id>.txt` and the core handles it like
+any Discord/Telegram/Slack task. When `results/task-<id>.txt` appears, its body
+is POSTed back and the result file is archived.
+
+Config (env / .env):
+  AG2_REMOTE_TOKEN      the onboarding string — the ONLY required setting
+                        (combined "https://<relay>|<secret>" or a bare secret)
+  AG2_REMOTE_URL        relay base URL (only needed with a bare secret)
+  REMOTE_TASK_URL/_TOKEN  legacy aliases
+  REMOTE_TASK_PROVIDER  label used for the task `source:` field (default "remote")
+  REMOTE_TASK_POLL_WAIT long-poll seconds (default 25)
+
+Stdlib only (urllib) — no new dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# resolve_workspace lives alongside this file in src/.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_default import resolve_workspace  # noqa: E402
+
+WS = resolve_workspace()
+TASKS_DIR = WS / "tasks"
+RESULTS_DIR = WS / "results"
+ARCHIVE_RESULTS_DIR = RESULTS_DIR / "archive"
+# Persist the in-flight set (tasks pulled from the relay, awaiting result-POST)
+# so a client restart between pull and POST doesn't strand the result. Scoped to
+# relay-pulled tasks only — we must NOT blindly POST every results/ file, or we'd
+# cross-send other channels' (Discord/Telegram) results to the relay.
+INFLIGHT_FILE = WS / "state" / "remote-task-inflight.json"
+
+# One-token onboarding: AG2_REMOTE_TOKEN alone is enough. The onboarding
+# string may be the combined "https://<relay>|<secret>" form (the URL travels
+# inside the token — nothing service-specific lives in this repo); a bare
+# secret needs AG2_REMOTE_URL/REMOTE_TASK_URL alongside it.
+_RAW = os.environ.get("AG2_REMOTE_TOKEN") or os.environ.get("REMOTE_TASK_TOKEN") or ""
+if "|" in _RAW:
+    _URL_FROM_TOKEN, TOKEN = _RAW.split("|", 1)
+else:
+    _URL_FROM_TOKEN, TOKEN = "", _RAW
+URL = (os.environ.get("AG2_REMOTE_URL") or os.environ.get("REMOTE_TASK_URL")
+       or _URL_FROM_TOKEN).rstrip("/")
+PROVIDER = os.environ.get("REMOTE_TASK_PROVIDER") or "remote"
+POLL_WAIT = int(os.environ.get("REMOTE_TASK_POLL_WAIT") or "25")
+
+_TASK_FIELDS = ("id", "timestamp", "task", "source", "channel_id",
+                "source_message_id", "user_id", "access_tier", "priority")
+
+
+def _log(msg: str) -> None:
+    print(f"[remote-task-client] {msg}", flush=True)
+
+
+def _req(method: str, path: str, payload: dict | None = None, timeout: int = 35):
+    """One authenticated HTTP request. Returns parsed JSON (or {} for empty)."""
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(f"{URL}{path}", data=data, method=method)
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    req.add_header("Accept", "application/json")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode().strip()
+        return json.loads(raw) if raw else {}
+
+
+def _write_task(task: dict) -> str | None:
+    """Serialize a relay task into tasks/task-<id>.txt (same schema as bridges).
+    Returns the task id, or None if it has no id / already present."""
+    tid = str(task.get("id") or "").strip()
+    if not tid:
+        _log("dropping task with no id")
+        return None
+    dest = TASKS_DIR / f"{tid}.txt"
+    # Idempotent: don't re-write a task already queued, claimed, or archived.
+    if dest.exists() or any(TASKS_DIR.glob(f"{tid}.claimed-*")):
+        return tid
+    TASKS_DIR.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for f in _TASK_FIELDS:
+        if f == "source":
+            lines.append(f"source: {task.get('source') or PROVIDER}")
+        elif f in task and task[f] not in (None, ""):
+            lines.append(f"{f}: {task[f]}")
+    tmp = dest.with_suffix(".txt.tmp")
+    tmp.write_text("\n".join(lines) + "\n")
+    tmp.rename(dest)  # atomic publish so the watcher never sees a partial file
+    _log(f"queued {tid}")
+    return tid
+
+
+def _archive_result(path: Path, tid: str) -> None:
+    ARCHIVE_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        path.rename(ARCHIVE_RESULTS_DIR / f"{tid}-{int(time.time())}.txt")
+    except OSError:
+        path.unlink(missing_ok=True)
+
+
+def _load_inflight() -> set[str]:
+    """Restore the in-flight set from disk (fail-open to empty)."""
+    try:
+        data = json.loads(INFLIGHT_FILE.read_text())
+        return {str(t) for t in data} if isinstance(data, list) else set()
+    except FileNotFoundError:
+        return set()
+    except Exception as e:  # noqa: BLE001
+        _log(f"inflight file unreadable ({e}) — starting empty")
+        return set()
+
+
+def _save_inflight(inflight: set[str]) -> None:
+    """Atomically persist the in-flight set. Best-effort (never blocks the loop)."""
+    try:
+        INFLIGHT_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = INFLIGHT_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(sorted(inflight)))
+        tmp.rename(INFLIGHT_FILE)
+    except Exception as e:  # noqa: BLE001
+        _log(f"inflight persist failed ({e}) — continuing")
+
+
+def _post_ready_results(inflight: set[str]) -> None:
+    """For each in-flight task, if its result file exists, POST it + archive."""
+    changed = False
+    for tid in list(inflight):
+        rfile = RESULTS_DIR / f"{tid}.txt"
+        if not rfile.exists():
+            continue
+        body = rfile.read_text().strip()
+        try:
+            _req("POST", "/v1/results", {"id": tid, "body": body})
+        except urllib.error.HTTPError as e:
+            _log(f"result POST failed for {tid}: HTTP {e.code} — will retry")
+            continue
+        except (urllib.error.URLError, TimeoutError) as e:
+            _log(f"result POST network error for {tid}: {e} — will retry")
+            continue
+        _archive_result(rfile, tid)
+        inflight.discard(tid)
+        changed = True
+        _log(f"delivered result for {tid}")
+    if changed:
+        _save_inflight(inflight)
+
+
+def main() -> None:
+    if not URL or not TOKEN:
+        sys.exit("FATAL: set AG2_REMOTE_TOKEN (and AG2_REMOTE_URL if your token is a bare secret).")
+    inflight: set[str] = _load_inflight()
+    _log(f"starting — relay={URL} provider={PROVIDER} workspace={WS} "
+         f"(restored {len(inflight)} in-flight)")
+    backoff = 1
+    while True:
+        try:
+            resp = _req("GET", f"/v1/tasks?wait={POLL_WAIT}", timeout=POLL_WAIT + 10)
+            added = False
+            for task in resp.get("tasks", []):
+                tid = _write_task(task)
+                if tid and tid not in inflight:
+                    inflight.add(tid)
+                    added = True
+            if added:
+                _save_inflight(inflight)
+            _post_ready_results(inflight)
+            backoff = 1  # healthy round-trip → reset backoff
+        except urllib.error.HTTPError as e:
+            if e.code in (401, 403):
+                sys.exit(f"FATAL: relay auth rejected (HTTP {e.code}) — check AG2_REMOTE_TOKEN.")
+            _log(f"poll HTTP {e.code} — backing off {backoff}s")
+            time.sleep(backoff); backoff = min(backoff * 2, 60)
+        except (urllib.error.URLError, TimeoutError) as e:
+            _log(f"poll network error: {e} — backing off {backoff}s")
+            time.sleep(backoff); backoff = min(backoff * 2, 60)
+        except Exception as e:  # noqa: BLE001 — keep the loop alive
+            _log(f"unexpected: {e} — backing off {backoff}s")
+            time.sleep(backoff); backoff = min(backoff * 2, 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -394,6 +394,20 @@ else
   echo "  ~ telegram bridge (no token — optional)"
 fi
 
+# AG2 remote relay client. One env var is the whole config:
+# AG2_REMOTE_TOKEN (the onboarding string carries the relay URL).
+if [ -n "${AG2_REMOTE_TOKEN:-}" ]; then
+  if ! pgrep -f "remote-task-client" > /dev/null 2>&1; then
+    echo "  Starting AG2 relay client..."
+    python3 src/remote-task-client.py > "$LOGS_DIR/remote-task-client.log" 2>&1 &
+    echo "  ✓ ag2 relay client"
+  else
+    echo "  ✓ ag2 relay client (already running)"
+  fi
+else
+  echo "  ~ ag2 relay client (no AG2_REMOTE_TOKEN — optional)"
+fi
+
 # 7. Discord bridge (optional — needs DISCORD_BOT_TOKEN + discord.py)
 #
 # `python3` on $PATH is unpredictable across installs (miniconda, system,

--- a/tests/remote-task-client.test.py
+++ b/tests/remote-task-client.test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Unit test for src/remote-task-client.py against an in-process mock relay.
+
+CI-safe: spins up a localhost HTTP stub, no external network/deps. Exits 0 on
+pass, 1 on fail.
+
+Covers: task pull → local file write (correct schema + atomic), result file →
+POST back (correct payload + auth header), idempotent re-write, auth rejection.
+
+Run: python3 tests/remote-task-client.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+FAILS: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    print(("  ok  " if cond else "  FAIL ") + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+# ── mock relay ────────────────────────────────────────────────────────────
+STATE = {"tasks_served": 0, "results": [], "auth_seen": [], "force_401": False}
+TASK = {"id": "task-MOCK1", "timestamp": "2026-05-23T00:00:00Z",
+        "task": "hello from relay", "source": "remote-relay",
+        "channel_id": "!room:example.org", "user_id": "@qingyun:example.org",
+        "access_tier": "owner", "priority": "normal"}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):  # silence
+        pass
+
+    def _auth_ok(self):
+        STATE["auth_seen"].append(self.headers.get("Authorization"))
+        if STATE["force_401"]:
+            self.send_response(401); self.end_headers(); return False
+        return True
+
+    def do_GET(self):
+        if not self._auth_ok():
+            return
+        # first poll returns the task; later polls return empty
+        if self.path.startswith("/v1/tasks"):
+            tasks = [TASK] if STATE["tasks_served"] == 0 else []
+            STATE["tasks_served"] += 1
+            body = json.dumps({"tasks": tasks}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers(); self.wfile.write(body)
+        else:
+            self.send_response(404); self.end_headers()
+
+    def do_POST(self):
+        if not self._auth_ok():
+            return
+        if self.path == "/v1/results":
+            n = int(self.headers.get("Content-Length") or 0)
+            STATE["results"].append(json.loads(self.rfile.read(n).decode()))
+            self.send_response(200); self.end_headers()
+        else:
+            self.send_response(404); self.end_headers()
+
+
+def main() -> int:
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+
+    tmp = tempfile.mkdtemp(prefix="rtc-test-")
+    os.environ["SUTANDO_WORKSPACE"] = tmp
+    # Pre-satisfy the in-repo migrators (notes + build_log) so importing the
+    # client — which calls resolve_workspace() at import — does NOT relocate
+    # this repo's notes/ and build_log.md into the throwaway temp workspace.
+    # Both migrators short-circuit when their sentinel exists.
+    Path(tmp, ".notes-migrated").touch()
+    Path(tmp, ".build_log-migrated").touch()
+    os.environ["REMOTE_TASK_URL"] = f"http://127.0.0.1:{port}"
+    os.environ["REMOTE_TASK_TOKEN"] = "testtoken"
+    os.environ["REMOTE_TASK_PROVIDER"] = "remote-relay"
+
+    # import the hyphenated module by path (env must be set first — module reads
+    # config + resolves workspace at import time)
+    spec = importlib.util.spec_from_file_location("rtc", REPO / "src" / "remote-task-client.py")
+    rtc = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(rtc)
+
+    # 1. pull a task and write it locally
+    resp = rtc._req("GET", "/v1/tasks?wait=0")
+    tid = rtc._write_task(resp["tasks"][0])
+    check(tid == "task-MOCK1", "pull → task id parsed")
+    tfile = rtc.TASKS_DIR / "task-MOCK1.txt"
+    check(tfile.exists(), "task file written")
+    content = tfile.read_text() if tfile.exists() else ""
+    check("task: hello from relay" in content, "task body serialized")
+    check("source: remote-relay" in content, "source field carried")
+    check("access_tier: owner" in content, "access_tier carried")
+
+    # 2. idempotent: re-writing the same task doesn't duplicate / error
+    before = content
+    rtc._write_task(TASK)
+    check(tfile.read_text() == before, "idempotent re-write (unchanged)")
+
+    # 3. result file → POST back + archive
+    (rtc.RESULTS_DIR).mkdir(parents=True, exist_ok=True)
+    (rtc.RESULTS_DIR / "task-MOCK1.txt").write_text("the reply\n")
+    rtc._post_ready_results({"task-MOCK1"})
+    check(len(STATE["results"]) == 1, "result POSTed")
+    if STATE["results"]:
+        r = STATE["results"][0]
+        check(r.get("id") == "task-MOCK1" and r.get("body") == "the reply",
+              "result payload correct (id + body)")
+    check(not (rtc.RESULTS_DIR / "task-MOCK1.txt").exists(), "result file archived after POST")
+
+    # 3b. inflight persistence (restart-safety): a pulled task's id survives a
+    # restart so its result still gets POSTed, and is cleared after delivery.
+    rtc._save_inflight({"task-RESTART"})
+    check("task-RESTART" in rtc._load_inflight(), "inflight persisted + restored across restart")
+    rtc._save_inflight(set())
+    check(rtc._load_inflight() == set(), "inflight cleared once empty")
+    # and _post_ready_results persists the removal after a successful POST
+    (rtc.RESULTS_DIR / "task-MOCK2.txt").write_text("reply2\n")
+    rtc._save_inflight({"task-MOCK2"})
+    rtc._post_ready_results({"task-MOCK2"})
+    check("task-MOCK2" not in rtc._load_inflight(), "delivered task removed from persisted inflight")
+
+    # 4. auth header was sent on every call
+    check(all(a == "Bearer testtoken" for a in STATE["auth_seen"] if a is not None)
+          and STATE["auth_seen"], "Bearer token sent on requests")
+
+    # 5. auth rejection surfaces as HTTPError 401
+    STATE["force_401"] = True
+    import urllib.error
+    try:
+        rtc._req("GET", "/v1/tasks?wait=0")
+        check(False, "401 raises HTTPError")
+    except urllib.error.HTTPError as e:
+        check(e.code == 401, "401 raises HTTPError")
+
+    srv.shutdown()
+    if FAILS:
+        print(f"\nFAILED ({len(FAILS)})"); return 1
+    print("\nPASS — all checks green"); return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Optional relay channel: connect this Sutando to a hosted AG2 relay with a single setting.

```
# .env
AG2_REMOTE_TOKEN=<the onboarding string you received>
```

then normal `bash src/startup.sh` — the client auto-starts (same pattern as the Telegram/Discord bridges; skipped silently when unset).

**What's in here**
- `src/remote-task-client.py` — stdlib-only single-file long-poll client (pulls tasks into `tasks/`, posts `results/` back). The onboarding string carries the relay URL (`https://<relay>|<secret>`); a bare secret works with `AG2_REMOTE_URL`. Legacy `REMOTE_TASK_*` vars honored.
- `src/startup.sh` — auto-start block gated on `AG2_REMOTE_TOKEN` (idempotent; re-running startup.sh is also the restart path).
- `.env.example` — placeholder.
- `tests/remote-task-client.test.py` — in-process mock-relay suite, all green.

Where to get an onboarding string: ask your relay operator.

Core boots unchanged without the token — fully optional channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)