### PR TITLE
fix(watch-tasks): stop calling the tmux wake poke (keep the helper)

### DIFF
--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -75,9 +75,21 @@ trap 'rm -f "$PID_FILE"' EXIT
 TMUX_SOCK="${SUTANDO_TMUX_SOCK:-/tmp/sutando-tmux.sock}"
 TMUX_SESSION="${SUTANDO_TMUX_SESSION:-sutando-core}"
 
+# Wake helper, kept but NOT called on the task paths below. Under the only
+# launch path that exists — Claude Code's `Monitor` tool (CLAUDE.md, the
+# schedule-crons / proactive-loop / startup skills, and the menu-app restart) —
+# Monitor re-invokes the session on each stdout line, which wakes an IDLE
+# session on its own (controlled test 2026-06-13: synthetic task processed in
+# ~30s with no poke — see reference_monitor_notification_wakes_idle_session).
+# So calling this per task only duplicated the wake and spammed the CLI input
+# line on a restart sweep (Chi saw 7-in-a-row, 2026-06-13). The calls were
+# removed in #1679. The helper stays for a future setup that runs this watcher
+# WITHOUT a Monitor consuming stdout (a bare background process in a tmux
+# session) — wire it back into the loops below if you build that path.
+# shellcheck disable=SC2317  # defined-but-unreferenced is intentional
 _tmux_wake() {
   # Poke the idle CLI session so it processes the new task without waiting
-  # for the next 5-min proactive-loop cron tick (sutando-skills#27).
+  # for the next 5-min proactive-loop cron tick (sutando-skills#27 / #1289).
   tmux -S "$TMUX_SOCK" send-keys -t "$TMUX_SESSION" '[watcher-ping]' Enter 2>/dev/null || true
 }
 
@@ -86,7 +98,6 @@ _tmux_wake() {
 shopt -s nullglob
 for f in "$TASKS_DIR"/*.txt; do
   printf 'TASK_FILE: %s\n' "$(basename "$f")" || exit 0
-  _tmux_wake
 done
 shopt -u nullglob
 
@@ -131,7 +142,6 @@ fswatch \
       parent="$(dirname "$path")"
       if [ "$parent" = "$TASKS_DIR_ABS" ] && [ -f "$path" ]; then
         printf 'TASK_FILE: %s\n' "$(basename "$path")" || exit 0
-        _tmux_wake
       fi
       ;;
   esac


### PR DESCRIPTION
## Problem

`_tmux_wake()` in `src/watch-tasks-stream.sh` fired one `[watcher-ping]` `send-keys` into the `sutando-core` pane **per surfaced task** — the initial sweep loops over every backlog file, the fswatch loop pokes per event. On a restart with queued tasks that's a burst of identical input lines in the CLI (Chi saw **7-in-a-row**, 2026-06-13).

It's also redundant. The watcher only ever runs under Claude Code's **Monitor** tool (CLAUDE.md + the schedule-crons / proactive-loop / startup skills + the menu-app restart all launch it that way; `startup.sh` only *reaps* a stale one). Monitor re-invokes the session on each stdout line.

## What the test showed

Controlled test, 2026-06-13 (Chi authorized): isolated temp workspace, poke **neutered** (tmux socket → nowhere), synthetic task dropped by a **detached** process (so no harness completion-notification confound) while the main session was **idle**. The Monitor `<task-notification>` alone re-invoked the idle session in **~30s** — no `[watcher-ping]`. So Monitor wakes an idle session on its own; the poke added nothing but the visible input line.

## Fix

**Remove both call sites** so no poke fires — no env var, no debounce. **Keep the `_tmux_wake()` helper defined**, with a comment marking it intentionally uncalled, so a future setup that runs this watcher **standalone** (no Monitor consuming stdout) can wire it back into the loops.

```
 _tmux_wake()  → defined: 1, called: 0
```

`sutando-skills#27` / `#1289` added the calls before Monitor's idle-wake was verified.

## Verification

- `bash -n` clean; helper defined, zero call sites.
- No behavioral test depended on the poke (`grep tests/` for `watcher-ping` / `_tmux_wake` / `WAKE_` → empty).
- Live: takes effect on the watcher's next restart; the currently-running watcher has the old code in memory (no disruption).

Stand: Echo Act IV (Mini)