### PR TITLE
fix(dashboard): ThreadingHTTPServer + handler timeout; probe wedged listeners in health-check

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -386,6 +386,11 @@ def render_dashboard() -> str:
 
 
 class Handler(http.server.BaseHTTPRequestHandler):
+    # Drop connections that go silent (e.g. browser speculative preconnects
+    # that open TCP and never send a request line). Without this, readline()
+    # in handle_one_request blocks forever holding a server thread.
+    timeout = 30
+
     def log_message(self, fmt, *args): pass
 
     def end_headers(self):
@@ -556,7 +561,11 @@ if __name__ == "__main__":
     # know you want it. Same env-override shape as `AGENT_API_BIND` in
     # agent-api.py.
     bind = os.environ.get("DASHBOARD_BIND", "127.0.0.1")
-    server = http.server.HTTPServer((bind, PORT), Handler)
+    # ThreadingHTTPServer: the single-threaded HTTPServer wedged whenever one
+    # client held a connection without completing a request — every later
+    # request (and the dashboard UI) hung on a port that still looked open
+    # to startup.sh's lsof guard (2026-06-08/10 incidents).
+    server = http.server.ThreadingHTTPServer((bind, PORT), Handler)
     print(f"Sutando Dashboard → http://{bind}:{PORT}", flush=True)
     if bind != "127.0.0.1":
         print(

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -72,13 +72,41 @@ MEMORY_DIR = Path(os.environ.get("SUTANDO_MEMORY_DIR", _default_memory_dir()))
 # Checks
 # ---------------------------------------------------------------------------
 
-def check_port(port: int, name: str) -> dict:
-    """Check if a port is listening."""
+def check_port(port: int, name: str, probe: bool = False) -> dict:
+    """Check if a port is listening, optionally probing for a live response.
+
+    A wedged server can keep its listen socket open while never answering
+    (2026-06-10: voice-agent accepted TCP for 26h with a dead event loop, so
+    the dashboard's WS connect hung forever). With probe=True, send a minimal
+    HTTP GET and require *any* response bytes — a healthy HTTP server replies
+    with a status line and a healthy WS server replies 400/426 to a plain GET,
+    while a wedged one sends nothing.
+    """
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.settimeout(2)
             result = s.connect_ex(("127.0.0.1", port))
             up = result == 0
+            if up and probe:
+                try:
+                    # 10s: dashboard.py takes ~3.5s to first byte (collects
+                    # data via subprocesses before responding). Wedged servers
+                    # never send anything, so the verdict is still decisive.
+                    s.settimeout(10)
+                    # Probe an unknown path, NOT "/": dashboard's "/" collects
+                    # data including a health-check.py subprocess — probing it
+                    # from health-check recursed (probe → render → health-check
+                    # → probe …) and amplified into a request storm. A 404 is
+                    # still response bytes, which is all liveness needs.
+                    s.sendall(f"GET /__liveness_probe__ HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n".encode())
+                    if not s.recv(1):
+                        raise TimeoutError("no response bytes")
+                except Exception:
+                    return {
+                        "name": name,
+                        "status": "wedged",
+                        "detail": f"port {port} listening but unresponsive — restart needed",
+                    }
         return {"name": name, "status": "ok" if up else "down", "detail": f"port {port}"}
     except Exception as e:
         return {"name": name, "status": "error", "detail": str(e)}
@@ -973,7 +1001,7 @@ def run_all_checks() -> list[dict]:
     checks = []
 
     # Core services (required)
-    voice_check = check_port(9900, "voice-agent")
+    voice_check = check_port(9900, "voice-agent", probe=True)
     if voice_check["status"] == "ok":
         mark_stale_if_outdated(voice_check, REPO_DIR / "src" / "voice-agent.ts", "voice-agent.ts")
     checks.append(voice_check)
@@ -981,17 +1009,19 @@ def run_all_checks() -> list[dict]:
     checks.append(check_voice_transport(voice_check))
     checks.append(check_bodhi_dist())
 
-    web_check = check_port(8080, "web-client")
+    web_check = check_port(8080, "web-client", probe=True)
     if web_check["status"] == "ok":
         mark_stale_if_outdated(web_check, REPO_DIR / "src" / "web-client.ts", "web-client.ts")
     checks.append(web_check)
 
     # Optional services (downgrade missing to warning, not failure)
     for port, name in [(7843, "agent-api"), (7844, "dashboard"), (7845, "screen-capture")]:
-        c = check_port(port, name)
-        if c["status"] != "ok":
+        c = check_port(port, name, probe=True)
+        if c["status"] == "down":
             c["status"] = "warn"
             c["detail"] = "not running (optional)"
+        # "wedged" is NOT downgraded: listening-but-dead is worse than down —
+        # startup.sh's lsof guard sees the port as occupied and won't restart it.
         checks.append(c)
 
     # macOS TCC — must come before critical-file checks so if TCC is blocking


### PR DESCRIPTION
Two fixes from the 2026-06-08/10 dashboard outages:

- **dashboard.py**: was single-threaded `HTTPServer` — one client holding a connection without completing a request (e.g. browser speculative preconnect) blocked `readline()` forever and wedged every later request, while the port still looked open to `startup.sh`'s lsof guard. Switch to `ThreadingHTTPServer` + 30s handler timeout. Repro: a held silent connection no longer blocks concurrent requests.
- **health-check.py**: `check_port` only TCP-connected, so listening-but-dead services passed (voice-agent accepted TCP for 26h with a dead event loop). Add `probe=` option (minimal HTTP GET, require any response bytes); report `wedged` as an issue. Enabled for voice-agent, web-client, agent-api, dashboard, screen-capture.

Cherry-picked from `health-liveness-probe`; verified to apply cleanly onto current `staging-workspace-revamp`.

Stand: Echo Act IV Pro