### PR TITLE
fix(morning-briefing): don't count 'No reminders.' sentinel as a reminder

### DIFF
--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -190,9 +190,14 @@ def get_reminders() -> list[str]:
         if r.returncode != 0:
             return []
         items = []
+        # reminders.py prints the human-readable sentinel "No reminders."
+        # (exit 0) when the due-today list is empty — skip it so the empty
+        # state doesn't get counted as a single reminder and rendered as
+        # "Reminders due: No reminders.".
+        empty_sentinels = {"no reminders.", "no reminders"}
         for line in r.stdout.splitlines():
             line = line.strip()
-            if line and not line.startswith("#"):
+            if line and not line.startswith("#") and line.lower() not in empty_sentinels:
                 items.append(line)
         return items[:5]
     except (subprocess.TimeoutExpired, OSError):


### PR DESCRIPTION
The morning briefing counted the literal `No reminders.` sentinel string as if it were a real reminder, so a clear day reported one phantom reminder.

Fix: treat the `No reminders.` sentinel as zero reminders.

Cherry-picked from `health-liveness-probe`; verified to apply cleanly onto current `staging-workspace-revamp`.

Stand: Echo Act IV Pro