### PR TITLE
fix(obsidian-mirror): resolve workspace via shared helper, not inlined pre-v0.8 fallback

### DIFF
--- a/src/obsidian-mirror.py
+++ b/src/obsidian-mirror.py
@@ -33,12 +33,13 @@ from typing import Optional
 
 
 # ---- Path resolution ----
-
-def resolve_workspace() -> Path:
-    ws = os.environ.get("SUTANDO_WORKSPACE")
-    if ws:
-        return Path(ws).expanduser()
-    return Path.home() / ".sutando" / "workspace"
+# Use the shared helper (same precedence as the rest of Sutando:
+# sutando.config.local.json override, else <repo>/workspace/). This used to
+# inline the pre-v0.8 fallback ($SUTANDO_WORKSPACE else ~/.sutando/workspace),
+# which would mirror tasks/notes from the legacy root post-M0 — same
+# reinvented-fallback bug class as core_heartbeat.py (fixed alongside).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_default import resolve_workspace  # noqa: E402
 
 
 TASK_ID_RE = re.compile(r"^task-(.+)\.txt$")

--- a/src/obsidian-mirror.py
+++ b/src/obsidian-mirror.py
@@ -35,8 +35,8 @@ from typing import Optional
 # ---- Path resolution ----
 # Use the shared helper (same precedence as the rest of Sutando:
 # sutando.config.local.json override, else <repo>/workspace/). This used to
-# inline the pre-v0.8 fallback ($SUTANDO_WORKSPACE else ~/.sutando/workspace),
-# which would mirror tasks/notes from the legacy root post-M0 — same
+# inline the pre-v0.8 env-var-else-home-default fallback the resolver no
+# longer honors, which would mirror tasks/notes from the legacy root post-M0 — same
 # reinvented-fallback bug class as core_heartbeat.py (fixed alongside).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402


### PR DESCRIPTION
`obsidian-mirror.py` still carried an inlined `def resolve_workspace()` with a pre-v0.8 fallback, diverging from the canonical `workspace_default.resolve_workspace()` helper every other service uses. Switch it to import the shared helper.

**Context / supersedes #1684:** #1684 bundled this obsidian-mirror fix with a core-heartbeat fix and went CONFLICTING. On current `staging-workspace-revamp`, `core_heartbeat.py` **already** resolves via the shared helper (landed independently), so that half of #1684 is now redundant — and is the source of its conflict. This PR carries only the still-needed obsidian-mirror half, cherry-picked clean onto current staging (single concern). Recommend closing #1684 once this lands.

Stand: Echo Act IV Pro