### PR TITLE
feat(workspace): per-host carried-path safety — hostname-qualify crons.json + lint + doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ jobs:
       - name: UTC timestamp check
         run: python3 scripts/check-utc-z-strftime.py
 
+      # Fails if vault.sync.include carries a per-host-prone path without a
+      # hostname qualifier (would collapse across hosts on pull-merge).
+      # See docs/workspace-per-host-paths.md.
+      - name: Per-host carried-path lint
+        run: bash scripts/lint-vault-sync-paths.sh
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/docs/workspace-per-host-paths.md
+++ b/docs/workspace-per-host-paths.md
@@ -38,9 +38,12 @@ include them.
    ignores everything not listed). This is how channel configs stay per-host
    today.
 2. **Hostname-qualify it.** If it should be synced/backed-up per host, give it a
-   path that expands to one file per host — `crons/<hostname>.json`,
-   `build_log/<hostname>.md`. Each host owns its file; pulls bring peers' files
-   in side-by-side, never merging.
+   path that expands to one file per host. The canonical home is the
+   `hosts/<hostname>/` per-host subtree (see
+   [`workspace-hosts-convention.md`](workspace-hosts-convention.md)) — e.g.
+   `hosts/<hostname>/crons.json`, carried by the `hosts/*/` glob — but any
+   qualified pattern works (`build_log/<hostname>.md`). Each host owns its file;
+   pulls bring peers' files in side-by-side, never merging.
 
 Use the host slug the sync layer uses: `hostname | sed 's/\..*//'`.
 
@@ -56,7 +59,7 @@ carrier addition from silently reintroducing the collapse.
 
 | Path in `vault.sync.include` | Verdict |
 | --- | --- |
-| `crons/<hostname>.json` | ✅ hostname-qualified |
+| `hosts/*/` (carries `hosts/<hostname>/crons.json`) | ✅ glob expands per host |
 | `build_log/<hostname>.md` | ✅ hostname-qualified |
 | `.claude-sutando/projects/*/memory/` | ✅ glob expands per slug |
 | `crons.json` | ❌ bare per-host file → collapses on pull-merge |

--- a/docs/workspace-per-host-paths.md
+++ b/docs/workspace-per-host-paths.md
@@ -1,0 +1,64 @@
+# Per-host carried paths must be hostname-qualified
+
+**Rule:** any file synced through the workspace vault (`vault.sync.include`) that
+holds **per-host** data MUST live at a **hostname-qualified path** —
+`<dir>/<hostname>.json`, `build_log/<hostname>.md`, etc. A bare, non-qualified
+path that carries per-host data will silently cross-contaminate hosts.
+
+## Why
+
+`scripts/sync-workspace.sh` uses a **branch-per-host** topology: each host
+pushes only to its own branch `host/<hostname>/<wsId>`, and pulls peers via
+`fetch` + **3-way merge** into its local branch.
+
+That merge isolates by branch on **push**, but on **pull** it re-collides
+**same-path** files: if host A and host B both have `crons.json` at the same
+path with different content, the pull-merge tries to merge the two — conflict or
+blended content. So branch-per-host does **not**, by itself, keep per-host data
+separate. The separation only holds when the path differs per host:
+
+- **distinct by construction** — `build_log/<hostname>.md` (each host writes its
+  own file; peers' files coexist after pull, never merge), or
+- **distinct by accident** — `.claude-sutando/projects/<local_slug>/memory/`,
+  where `<local_slug>` is the repo path with `/`→`-`. Safe only while hosts use
+  *different* repo paths; if two hosts share a path the slug "collapses" and the
+  memory dirs merge. (That's luck, not design.)
+
+The sharpest failure is a path with **no per-host component at all** —
+`channels/<svc>/access.json` (allowlists / TOFU / tier-maps), `state/auth/device.json`
+and `cloud-auth.json` (per-host identity/credentials). If any of these were ever
+added to the carrier set, *every* host's copy would collide at the identical
+path on the first pull — blending allowlists or device identities across
+machines. Today they are safe **only** because the carrier whitelist does not
+include them.
+
+## The two safe options for per-host data
+
+1. **Don't carry it.** Leave it out of `vault.sync.include` (whitelist mode
+   ignores everything not listed). This is how channel configs stay per-host
+   today.
+2. **Hostname-qualify it.** If it should be synced/backed-up per host, give it a
+   path that expands to one file per host — `crons/<hostname>.json`,
+   `build_log/<hostname>.md`. Each host owns its file; pulls bring peers' files
+   in side-by-side, never merging.
+
+Use the host slug the sync layer uses: `hostname | sed 's/\..*//'`.
+
+## Enforcement
+
+`scripts/lint-vault-sync-paths.sh` fails CI if `vault.sync.include` carries a
+known per-host-prone path (`channels/`, `state/auth`, `device.json`,
+`cloud-auth.json`, `state/cores`) without a hostname qualifier (an explicit
+`<hostname>`/`$(hostname)` token or a `*` glob segment). This stops a future
+carrier addition from silently reintroducing the collapse.
+
+## Examples
+
+| Path in `vault.sync.include` | Verdict |
+| --- | --- |
+| `crons/<hostname>.json` | ✅ hostname-qualified |
+| `build_log/<hostname>.md` | ✅ hostname-qualified |
+| `.claude-sutando/projects/*/memory/` | ✅ glob expands per slug |
+| `crons.json` | ❌ bare per-host file → collapses on pull-merge |
+| `channels/discord/access.json` | ❌ per-host, zero qualifier |
+| `state/auth/` | ❌ per-host identity, must not propagate |

--- a/scripts/lint-vault-sync-paths.sh
+++ b/scripts/lint-vault-sync-paths.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Sutando lint: per-host carried paths must be hostname-qualified.
+#
+# The workspace sync (scripts/sync-workspace.sh) is branch-per-host: a host
+# pushes to host/<hostname>/<wsId> and PULLS peers via 3-way merge. That merge
+# isolates by branch on push, but RE-COLLIDES same-path files on pull — so any
+# carried file at a path with no per-host qualifier gets cross-host merged.
+# For genuinely per-host data (channel allowlists/tokens, device identity, a
+# host's cron set) that is data loss: e.g. every host's
+# `channels/<svc>/access.json` would merge into one. See
+# docs/workspace-per-host-paths.md for the full rationale.
+#
+# Rule enforced here: a `vault.sync.include` entry that matches a known
+# per-host-prone path MUST be hostname-qualified (carry a `<hostname>` /
+# `$(hostname)` token, or a `*` glob segment that expands to per-host files).
+# Bare per-host paths in the carrier set fail the lint.
+#
+# Usage:
+#   bash scripts/lint-vault-sync-paths.sh            # lint sutando.config*.json
+#   bash scripts/lint-vault-sync-paths.sh <file>...  # lint specific config files
+#
+# Exit 0 = clean, 1 = a bare per-host path is carried.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Paths that hold per-host data and therefore collapse if carried without a
+# hostname qualifier. Matched as substrings against each include entry.
+PER_HOST_PRONE=(
+  "channels/"          # access.json (allowlists/TOFU/tiers), .env (tokens)
+  "state/auth"         # device.json, cloud-auth.json — per-host identity
+  "device.json"
+  "cloud-auth.json"
+  "state/cores"        # <hostname>.alive liveness
+  "crons.json"         # a bare crons.json is per-host config; carry crons/<hostname>.json
+)
+
+# A carried entry is "hostname-qualified" if it contains an explicit host token
+# or a glob segment (so each host expands to its own file, like
+# build_log/<hostname>.md or crons/<hostname>.json written per host).
+_is_host_qualified() {
+  local p="$1"
+  case "$p" in
+    *'<hostname>'*|*'$(hostname)'*|*'${hostname}'*|*'*'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+_config_files() {
+  if [ "$#" -gt 0 ]; then
+    printf '%s\n' "$@"
+  else
+    for f in "$SCRIPT_DIR/sutando.config.json" "$SCRIPT_DIR/sutando.config.local.json"; do
+      [ -f "$f" ] && printf '%s\n' "$f"
+    done
+  fi
+}
+
+fail=0
+while IFS= read -r cfg; do
+  [ -z "$cfg" ] && continue
+  # Extract vault.sync.include entries (one per line) without a JSON dep.
+  includes="$(python3 - "$cfg" <<'PY'
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(0)
+for p in (d.get("vault", {}).get("sync", {}).get("include", []) or []):
+    print(p)
+PY
+)"
+  while IFS= read -r entry; do
+    [ -z "$entry" ] && continue
+    for prone in "${PER_HOST_PRONE[@]}"; do
+      case "$entry" in
+        *"$prone"*)
+          if ! _is_host_qualified "$entry"; then
+            echo "FAIL: $cfg → vault.sync.include carries per-host-prone path '$entry' without a hostname qualifier."
+            echo "      Per-host data collapses on cross-host pull-merge. Use a hostname-qualified path"
+            echo "      (e.g. '<dir>/<hostname>.json') or drop it from the carrier set. See docs/workspace-per-host-paths.md."
+            fail=1
+          fi
+          ;;
+      esac
+    done
+  done <<<"$includes"
+done < <(_config_files "$@")
+
+if [ "$fail" -eq 0 ]; then
+  echo "lint-vault-sync-paths: OK — no bare per-host paths in any vault.sync.include."
+fi
+exit "$fail"

--- a/scripts/lint-vault-sync-paths.sh
+++ b/scripts/lint-vault-sync-paths.sh
@@ -33,7 +33,7 @@ PER_HOST_PRONE=(
   "device.json"
   "cloud-auth.json"
   "state/cores"        # <hostname>.alive liveness
-  "crons.json"         # a bare crons.json is per-host config; carry crons/<hostname>.json
+  "crons.json"         # a bare crons.json is per-host config; carry it under hosts/<hostname>/crons.json
 )
 
 # A carried entry is "hostname-qualified" if it contains an explicit host token

--- a/skills/schedule-crons/SKILL.md
+++ b/skills/schedule-crons/SKILL.md
@@ -6,10 +6,10 @@ Re-create all session cron jobs for Sutando. Run this on startup or after a sess
 
 ## How It Works
 
-Jobs are defined per host in `<workspace>/crons/<hostname>.json` — **per-host, synced + backed up via the vault** (carried as `crons/*.json`, which is hostname-qualified so it never collapses across hosts; see [`docs/workspace-per-host-paths.md`](../../docs/workspace-per-host-paths.md)). `<hostname>` is `hostname | sed 's/\..*//'`, matching the sync layer's host slug. A template is in `crons.example.json` (in this skill dir, version-controlled). Copy it on first setup:
+Jobs are defined per host in `<workspace>/hosts/<hostname>/crons.json` — **per-host, synced + backed up via the vault** (carried as part of the `hosts/*/` per-host subtree (#1717), which is hostname-qualified so it never collapses across hosts; see [`docs/workspace-hosts-convention.md`](../../docs/workspace-hosts-convention.md) and [`docs/workspace-per-host-paths.md`](../../docs/workspace-per-host-paths.md)). `<hostname>` is `hostname | sed 's/\..*//'`, matching the sync layer's host slug. A template is in `crons.example.json` (in this skill dir, version-controlled). Copy it on first setup:
 ```bash
-WS="$(bash scripts/sutando-config.sh workspace)"; mkdir -p "$WS/crons"
-cp skills/schedule-crons/crons.example.json "$WS/crons/$(hostname | sed 's/\..*//').json"
+WS="$(bash scripts/sutando-config.sh workspace)"; H="$(hostname | sed 's/\..*//')"; mkdir -p "$WS/hosts/$H"
+cp skills/schedule-crons/crons.example.json "$WS/hosts/$H/crons.json"
 ```
 (Migrated from the old `skills/schedule-crons/crons.json`, which lived in the code checkout — misfiled per the workspace contract, and per-host-but-unsynced. The new path is proper per-user state: backed up + visible across hosts, each host keeping its own cron set.)
 
@@ -25,7 +25,7 @@ Each entry has:
 
    Rationale: post-#954, the CLI boots with `-- "/schedule-crons"` (not `/proactive-loop`), so this skill IS the actual startup entry — wiring catchup here means it runs synchronously at session start instead of waiting until the first `main-loop` cron fire (~5 min later) to reach `/proactive-loop`'s catchup step (which `822e630` of #1056 added). Identical PID-stamp guard semantics across both paths, so they cooperate idempotently — whichever runs first stamps the sentinel with `$PPID`; the other reads it, finds the PID alive (same session), and skips.
 
-1. Read `<workspace>/crons/<hostname>.json` (resolve `<workspace>` via `bash scripts/sutando-config.sh workspace`; `<hostname>` = `hostname | sed 's/\..*//'`). **Transition / self-heal:** if that file is missing, seed it once — from the legacy `skills/schedule-crons/crons.json` if it still exists (one-time migration), else from `skills/schedule-crons/crons.example.json` — then read it: `WS="$(bash scripts/sutando-config.sh workspace)"; CF="$WS/crons/$(hostname | sed 's/\..*//').json"; if [ ! -f "$CF" ]; then mkdir -p "$WS/crons"; cp "$(ls skills/schedule-crons/crons.json 2>/dev/null || echo skills/schedule-crons/crons.example.json)" "$CF"; fi`
+1. Read `<workspace>/hosts/<hostname>/crons.json` (resolve `<workspace>` via `bash scripts/sutando-config.sh workspace`; `<hostname>` = `hostname | sed 's/\..*//'`). **Transition / self-heal:** if that file is missing, seed it once — from the interim `<workspace>/crons/<hostname>.json` if it still exists (folded-in from the pre-#1717 layout), else the legacy `skills/schedule-crons/crons.json` (one-time migration), else `skills/schedule-crons/crons.example.json` — then read it: `WS="$(bash scripts/sutando-config.sh workspace)"; H="$(hostname | sed 's/\..*//')"; CF="$WS/hosts/$H/crons.json"; if [ ! -f "$CF" ]; then mkdir -p "$WS/hosts/$H"; SRC="$(ls "$WS/crons/$H.json" 2>/dev/null || ls skills/schedule-crons/crons.json 2>/dev/null || echo skills/schedule-crons/crons.example.json)"; cp "$SRC" "$CF"; fi`
 2. Check existing cron jobs with CronList
 3. For each job in the config:
    - Skip if a job with matching prompt/name already exists
@@ -39,7 +39,7 @@ Each entry has:
 
 ## Adding New Crons
 
-Edit `<workspace>/crons/<hostname>.json` (this host's cron set) to add/remove jobs. No need to change this skill file. The proactive-loop fallback (step 4 above) auto-armed if your `crons.json` is missing the loop entry; add an explicit `proactive-loop` entry to suppress the fallback message and pick your own cadence.
+Edit `<workspace>/hosts/<hostname>/crons.json` (this host's cron set) to add/remove jobs. No need to change this skill file. The proactive-loop fallback (step 4 above) auto-armed if your `crons.json` is missing the loop entry; add an explicit `proactive-loop` entry to suppress the fallback message and pick your own cadence.
 
 ### Defer non-loop crons when owner tasks are queued
 

--- a/skills/schedule-crons/SKILL.md
+++ b/skills/schedule-crons/SKILL.md
@@ -6,10 +6,12 @@ Re-create all session cron jobs for Sutando. Run this on startup or after a sess
 
 ## How It Works
 
-Jobs are defined in `skills/schedule-crons/crons.json` (gitignored — personal). A template is in `crons.example.json` — copy it on first setup:
+Jobs are defined per host in `<workspace>/crons/<hostname>.json` — **per-host, synced + backed up via the vault** (carried as `crons/*.json`, which is hostname-qualified so it never collapses across hosts; see [`docs/workspace-per-host-paths.md`](../../docs/workspace-per-host-paths.md)). `<hostname>` is `hostname | sed 's/\..*//'`, matching the sync layer's host slug. A template is in `crons.example.json` (in this skill dir, version-controlled). Copy it on first setup:
 ```bash
-cp skills/schedule-crons/crons.example.json skills/schedule-crons/crons.json
+WS="$(bash scripts/sutando-config.sh workspace)"; mkdir -p "$WS/crons"
+cp skills/schedule-crons/crons.example.json "$WS/crons/$(hostname | sed 's/\..*//').json"
 ```
+(Migrated from the old `skills/schedule-crons/crons.json`, which lived in the code checkout — misfiled per the workspace contract, and per-host-but-unsynced. The new path is proper per-user state: backed up + visible across hosts, each host keeping its own cron set.)
 
 Each entry has:
 - `name` — unique identifier (used to avoid duplicates)
@@ -23,7 +25,7 @@ Each entry has:
 
    Rationale: post-#954, the CLI boots with `-- "/schedule-crons"` (not `/proactive-loop`), so this skill IS the actual startup entry — wiring catchup here means it runs synchronously at session start instead of waiting until the first `main-loop` cron fire (~5 min later) to reach `/proactive-loop`'s catchup step (which `822e630` of #1056 added). Identical PID-stamp guard semantics across both paths, so they cooperate idempotently — whichever runs first stamps the sentinel with `$PPID`; the other reads it, finds the PID alive (same session), and skips.
 
-1. Read `skills/schedule-crons/crons.json`
+1. Read `<workspace>/crons/<hostname>.json` (resolve `<workspace>` via `bash scripts/sutando-config.sh workspace`; `<hostname>` = `hostname | sed 's/\..*//'`). **Transition / self-heal:** if that file is missing, seed it once — from the legacy `skills/schedule-crons/crons.json` if it still exists (one-time migration), else from `skills/schedule-crons/crons.example.json` — then read it: `WS="$(bash scripts/sutando-config.sh workspace)"; CF="$WS/crons/$(hostname | sed 's/\..*//').json"; if [ ! -f "$CF" ]; then mkdir -p "$WS/crons"; cp "$(ls skills/schedule-crons/crons.json 2>/dev/null || echo skills/schedule-crons/crons.example.json)" "$CF"; fi`
 2. Check existing cron jobs with CronList
 3. For each job in the config:
    - Skip if a job with matching prompt/name already exists
@@ -37,7 +39,7 @@ Each entry has:
 
 ## Adding New Crons
 
-Edit `crons.json` to add/remove jobs. No need to change this skill file. The proactive-loop fallback (step 4 above) auto-armed if your `crons.json` is missing the loop entry; add an explicit `proactive-loop` entry to suppress the fallback message and pick your own cadence.
+Edit `<workspace>/crons/<hostname>.json` (this host's cron set) to add/remove jobs. No need to change this skill file. The proactive-loop fallback (step 4 above) auto-armed if your `crons.json` is missing the loop entry; add an explicit `proactive-loop` entry to suppress the fallback message and pick your own cadence.
 
 ### Defer non-loop crons when owner tasks are queued
 

--- a/sutando.config.json
+++ b/sutando.config.json
@@ -19,7 +19,6 @@
         "notes/",
         "pending-questions.md",
         "build_log.md",
-        "crons/*.json",
         ".claude-sutando/projects/*/memory/"
       ],
       "exclude": [

--- a/sutando.config.json
+++ b/sutando.config.json
@@ -19,6 +19,7 @@
         "notes/",
         "pending-questions.md",
         "build_log.md",
+        "crons/*.json",
         ".claude-sutando/projects/*/memory/"
       ],
       "exclude": [


### PR DESCRIPTION
Per Chi's design thread in #echo-act-iv-pro: per-host data synced through the vault must be **hostname-qualified**, or it cross-contaminates hosts. Branch-per-host isolates on *push* but 3-way-merges same-path files on *pull*, so a bare per-host file blends across machines (e.g. every host's `channels/<svc>/access.json` or `crons.json` would collide).

**Changes**
- **crons.json → `<workspace>/crons/<hostname>.json`.** It was misfiled in the code repo (`skills/schedule-crons/crons.json`) — per the workspace contract it's per-user mutable state, and it was per-host-but-unsynced. Now carried as `crons/*.json` in `vault.sync.include` (hostname-qualified → syncs + backs up per host, no collapse). `SKILL.md` updated with the new read path + a one-time self-heal seed (from legacy crons.json, else crons.example.json). `crons.example.json` stays in the skill dir as the template.
- **`scripts/lint-vault-sync-paths.sh` + CI step.** Fails if `vault.sync.include` carries a per-host-prone path (`channels/`, `state/auth`, `device.json`, `cloud-auth.json`, `state/cores`, `crons.json`) without a hostname qualifier — stops a future carrier addition from reintroducing the collapse.
- **`docs/workspace-per-host-paths.md`** — documents the rule + rationale + the two safe options (don't carry, or hostname-qualify).

**Evidence**
- Lint on the updated `sutando.config.json`: `OK — no bare per-host paths` (rc 0).
- Negative test: a config carrying `channels/discord/access.json`, `state/auth/`, bare `crons.json` → all flagged (rc 1); `crons/<hostname>.json` correctly passes.
- `sutando.config.json` re-parses; `crons/*.json` present in include.
- Migration verified on this host: `workspace/crons/<hostname>.json` seeded identical to the prior crons.json.

Note: SKILL.md's self-heal makes the path switch zero-downtime — first `/schedule-crons` after merge seeds the per-host file from the legacy one if needed.

Stand: Echo Act IV Pro