### PR TITLE
fix(util_paths): probe hosts/<host>/ first in personal_path/personalPath (H4)

### DIFF
--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -81,29 +81,53 @@ def _workspace_root() -> Path:
         return Path.home() / ".sutando" / "workspace"
 
 
+def _host_label() -> str:
+    r"""Per-host directory label: `$SUTANDO_HOST_LABEL` or short hostname.
+
+    Single source of truth for the per-host segment so the legacy
+    `machine-<host>/` (memory-dir) and new `hosts/<host>/` (workspace)
+    conventions stay in lockstep. Matches `_host()` in sync-workspace.sh
+    and the crons-path host derivation (`hostname | sed 's/\..*//'`)."""
+    return os.environ.get("SUTANDO_HOST_LABEL") or socket.gethostname().split(".")[0]
+
+
 def _private_machine_dir() -> Path | None:
     root = _memory_dir_env()
     if not root:
         return None
     expanded = os.path.expanduser(root)
-    host = os.environ.get("SUTANDO_HOST_LABEL") or socket.gethostname().split(".")[0]
-    return Path(expanded) / f"machine-{host}"
+    return Path(expanded) / f"machine-{_host_label()}"
 
 
 def personal_path(filename: str, workspace: Path | None = None) -> Path:
     """Resolve a personal-asset path.
 
-    Order: `$SUTANDO_MEMORY_DIR/machine-<host>/<filename>` → `<workspace>/<filename>`.
+    Order: `<workspace>/hosts/<host>/<filename>` (new per-host home, #1717)
+    → `$SUTANDO_MEMORY_DIR/machine-<host>/<filename>` (legacy memory-dir
+    per-host) → `<workspace>/<filename>`.
     (Legacy `$SUTANDO_PRIVATE_DIR` is honored as a fallback with a
     deprecation warning — see `_memory_dir_env()`.)
     For files known to live under `assets/` in the public workspace
     (currently `stand-avatar.png`), also tries `<workspace>/assets/<filename>`
     before falling back to `<workspace>/<filename>`.
 
+    The `hosts/<host>/` probe is read-side only and purely additive: when no
+    such file exists, resolution is identical to the pre-#1717 behavior. This
+    is the reader half of the per-host relocation — without it, moving a
+    per-host file into `hosts/<host>/` would silently strand readers on the
+    workspace-root fallback (the H4 regression).
+
     Returns the FIRST existing path. If none exist, returns the preferred
     private-dir path so the caller's `.exists()` check fails gracefully.
     """
     ws = workspace if workspace is not None else _workspace_root()
+
+    # New per-host canonical home (workspace-as-git-repo, #1717). Probed first
+    # so relocated files are found; absent → falls through to legacy order.
+    host_dir = ws / "hosts" / _host_label()
+    p = host_dir / filename
+    if p.exists():
+        return p
 
     private = _private_machine_dir()
     if private is not None:

--- a/src/util_paths.ts
+++ b/src/util_paths.ts
@@ -62,14 +62,31 @@ export function memoryDirEnv(): string | undefined {
 	return undefined;
 }
 
+/**
+ * Per-host directory label: `$SUTANDO_HOST_LABEL` or short hostname.
+ *
+ * Single source of truth for the per-host segment so the legacy
+ * `machine-<host>/` (memory-dir) and new `hosts/<host>/` (workspace)
+ * conventions stay in lockstep. Matches `_host()` in sync-workspace.sh.
+ */
+function hostLabel(): string {
+	return (process.env.SUTANDO_HOST_LABEL || hostname()).split('.')[0];
+}
+
 /** Per-machine resolver. */
 export function personalPath(filename: string, workspace?: string): string {
 	const ws = workspace ?? resolveWorkspace();
+	// New per-host canonical home (workspace-as-git-repo, #1717). Probed first
+	// so relocated files are found; absent → falls through to the legacy order
+	// (identical to pre-#1717 behavior). Reader half of the per-host
+	// relocation — without it, moving a per-host file into `hosts/<host>/`
+	// would silently strand readers on the workspace-root fallback (H4).
+	const hostCandidate = join(ws, 'hosts', hostLabel(), filename);
+	if (existsSync(hostCandidate)) return hostCandidate;
 	const privateRoot = memoryDirEnv();
 	if (privateRoot) {
 		const root = expandHome(privateRoot);
-		const host = (process.env.SUTANDO_HOST_LABEL || hostname()).split('.')[0];
-		const candidate = join(root, `machine-${host}`, filename);
+		const candidate = join(root, `machine-${hostLabel()}`, filename);
 		if (existsSync(candidate)) return candidate;
 	}
 	// stand-avatar.png lives under assets/ in the public workspace.
@@ -83,8 +100,7 @@ export function personalPath(filename: string, workspace?: string): string {
 	// check fails gracefully.
 	if (privateRoot) {
 		const root = expandHome(privateRoot);
-		const host = (process.env.SUTANDO_HOST_LABEL || hostname()).split('.')[0];
-		return join(root, `machine-${host}`, filename);
+		return join(root, `machine-${hostLabel()}`, filename);
 	}
 	if (filename === 'stand-avatar.png') return join(ws, 'assets', filename);
 	return wsPath;

--- a/src/util_paths.ts
+++ b/src/util_paths.ts
@@ -67,10 +67,16 @@ export function memoryDirEnv(): string | undefined {
  *
  * Single source of truth for the per-host segment so the legacy
  * `machine-<host>/` (memory-dir) and new `hosts/<host>/` (workspace)
- * conventions stay in lockstep. Matches `_host()` in sync-workspace.sh.
+ * conventions stay in lockstep. Matches `_host()` in sync-workspace.sh:
+ * an explicit label is an override and is used RAW; only the auto-detected
+ * hostname has its mDNS/domain suffix stripped. (A dotted label like
+ * "a.b" must NOT be split — splitting it would strand the reader, the very
+ * class this PR fixes. Mirrors `_host_label()` in util_paths.py.)
  */
 function hostLabel(): string {
-	return (process.env.SUTANDO_HOST_LABEL || hostname()).split('.')[0];
+	const label = process.env.SUTANDO_HOST_LABEL;
+	if (label) return label;
+	return hostname().split('.')[0];
 }
 
 /** Per-machine resolver. */

--- a/tests/util-paths-hosts-resolution.test.py
+++ b/tests/util-paths-hosts-resolution.test.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Tests for the `hosts/<host>/` per-host read probe in personal_path (H4 fix).
+
+The per-host relocation (#1717) moves per-host files into
+`<workspace>/hosts/<hostname>/`. personal_path() must probe that location
+FIRST so relocated files are found; when absent, resolution must be
+byte-for-byte identical to the pre-#1717 order (purely additive, no regression).
+
+Run: python3 tests/util-paths-hosts-resolution.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from util_paths import _host_label, personal_path  # noqa: E402
+
+
+def clear_env():
+    for k in ("SUTANDO_MEMORY_DIR", "SUTANDO_PRIVATE_DIR", "SUTANDO_HOST_LABEL"):
+        os.environ.pop(k, None)
+
+
+class HostsResolutionTests(unittest.TestCase):
+    def setUp(self):
+        clear_env()
+        os.environ["SUTANDO_HOST_LABEL"] = "test-host"
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        clear_env()
+
+    def test_hosts_file_found_first(self):
+        # A file relocated to hosts/<host>/ is returned, not the root copy.
+        host_dir = self.ws / "hosts" / "test-host"
+        host_dir.mkdir(parents=True)
+        (host_dir / "stand-identity.json").write_text("{}")
+        (self.ws / "stand-identity.json").write_text("{}")  # stale root copy
+        with redirect_stderr(io.StringIO()):
+            p = personal_path("stand-identity.json", workspace=self.ws)
+        self.assertEqual(p, host_dir / "stand-identity.json")
+
+    def test_absent_hosts_falls_back_to_workspace_root(self):
+        # No hosts/ file → identical to pre-#1717 behavior (root fallback).
+        (self.ws / "pending-questions.md").write_text("q")
+        with redirect_stderr(io.StringIO()):
+            p = personal_path("pending-questions.md", workspace=self.ws)
+        self.assertEqual(p, self.ws / "pending-questions.md")
+
+    def test_nothing_exists_preferred_return_unchanged(self):
+        # No memory dir, nothing on disk → preferred return is workspace root
+        # (NOT hosts/) — the fix is read-side only; write target is untouched.
+        with redirect_stderr(io.StringIO()):
+            p = personal_path("never-created.json", workspace=self.ws)
+        self.assertEqual(p, self.ws / "never-created.json")
+
+    def test_hosts_beats_legacy_machine_dir(self):
+        # Both hosts/ (new) and machine-<host>/ (legacy memory-dir) have the
+        # file → hosts/ wins (it is probed first).
+        mem = Path(self._tmp.name) / "memrepo"
+        (mem / "machine-test-host").mkdir(parents=True)
+        (mem / "machine-test-host" / "f.json").write_text("legacy")
+        host_dir = self.ws / "hosts" / "test-host"
+        host_dir.mkdir(parents=True)
+        (host_dir / "f.json").write_text("new")
+        os.environ["SUTANDO_MEMORY_DIR"] = str(mem)
+        with redirect_stderr(io.StringIO()):
+            p = personal_path("f.json", workspace=self.ws)
+        self.assertEqual(p, host_dir / "f.json")
+
+    def test_legacy_machine_dir_still_found_when_no_hosts(self):
+        # hosts/ absent but legacy machine-<host>/ has it → legacy still works.
+        mem = Path(self._tmp.name) / "memrepo2"
+        (mem / "machine-test-host").mkdir(parents=True)
+        (mem / "machine-test-host" / "g.json").write_text("legacy")
+        os.environ["SUTANDO_MEMORY_DIR"] = str(mem)
+        with redirect_stderr(io.StringIO()):
+            p = personal_path("g.json", workspace=self.ws)
+        self.assertEqual(p, mem / "machine-test-host" / "g.json")
+
+    def test_host_label_drives_hosts_segment(self):
+        self.assertEqual(_host_label(), "test-host")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/util-paths-hosts-resolution.test.py
+++ b/tests/util-paths-hosts-resolution.test.py
@@ -90,6 +90,12 @@ class HostsResolutionTests(unittest.TestCase):
     def test_host_label_drives_hosts_segment(self):
         self.assertEqual(_host_label(), "test-host")
 
+    def test_dotted_host_label_used_raw(self):
+        # An explicit label is an override → used verbatim, NOT split on '.'.
+        # Parity guard with TS hostLabel() (Mini #1718 review note 1).
+        os.environ["SUTANDO_HOST_LABEL"] = "a.b"
+        self.assertEqual(_host_label(), "a.b")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/util-paths-hosts-resolution.test.ts
+++ b/tests/util-paths-hosts-resolution.test.ts
@@ -107,4 +107,22 @@ describe('personalPath hosts/<host>/ resolution (#1717 / H4)', () => {
 			clearEnv();
 		}
 	});
+
+	it('uses a dotted SUTANDO_HOST_LABEL raw (not split) — parity with PY', () => {
+		// Mini #1718 review note 1: an explicit label is an override, used
+		// verbatim. A dotted label must resolve hosts/a.b/, not hosts/a/.
+		clearEnv();
+		process.env.SUTANDO_HOST_LABEL = 'a.b';
+		const ws = mkdtempSync(join(tmpdir(), 'sut-hosts-'));
+		try {
+			const hostDir = join(ws, 'hosts', 'a.b');
+			mkdirSync(hostDir, { recursive: true });
+			writeFileSync(join(hostDir, 'f.json'), 'x');
+			const p = personalPath('f.json', ws);
+			assert.equal(p, join(hostDir, 'f.json'));
+		} finally {
+			rmSync(ws, { recursive: true, force: true });
+			clearEnv();
+		}
+	});
 });

--- a/tests/util-paths-hosts-resolution.test.ts
+++ b/tests/util-paths-hosts-resolution.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Tests for the `hosts/<host>/` per-host read probe in personalPath (H4 fix).
+ * Mirrors tests/util-paths-hosts-resolution.test.py.
+ *
+ * The per-host relocation (#1717) moves per-host files into
+ * `<workspace>/hosts/<hostname>/`. personalPath() must probe that location
+ * FIRST so relocated files are found; when absent, resolution must be
+ * identical to the pre-#1717 order (purely additive, no regression).
+ */
+
+import { personalPath } from '../src/util_paths.js';
+
+function clearEnv() {
+	delete process.env.SUTANDO_MEMORY_DIR;
+	delete process.env.SUTANDO_PRIVATE_DIR;
+	delete process.env.SUTANDO_HOST_LABEL;
+}
+
+describe('personalPath hosts/<host>/ resolution (#1717 / H4)', () => {
+	it('returns hosts/<host>/ copy ahead of the workspace-root copy', () => {
+		clearEnv();
+		process.env.SUTANDO_HOST_LABEL = 'test-host';
+		const ws = mkdtempSync(join(tmpdir(), 'sut-hosts-'));
+		try {
+			const hostDir = join(ws, 'hosts', 'test-host');
+			mkdirSync(hostDir, { recursive: true });
+			writeFileSync(join(hostDir, 'stand-identity.json'), '{}');
+			writeFileSync(join(ws, 'stand-identity.json'), '{}'); // stale root copy
+			const p = personalPath('stand-identity.json', ws);
+			assert.equal(p, join(hostDir, 'stand-identity.json'));
+		} finally {
+			rmSync(ws, { recursive: true, force: true });
+			clearEnv();
+		}
+	});
+
+	it('falls back to workspace root when no hosts/ file exists', () => {
+		clearEnv();
+		process.env.SUTANDO_HOST_LABEL = 'test-host';
+		const ws = mkdtempSync(join(tmpdir(), 'sut-hosts-'));
+		try {
+			writeFileSync(join(ws, 'pending-questions.md'), 'q');
+			const p = personalPath('pending-questions.md', ws);
+			assert.equal(p, join(ws, 'pending-questions.md'));
+		} finally {
+			rmSync(ws, { recursive: true, force: true });
+			clearEnv();
+		}
+	});
+
+	it('nothing-exists preferred return is workspace root (write target untouched)', () => {
+		clearEnv();
+		process.env.SUTANDO_HOST_LABEL = 'test-host';
+		const ws = mkdtempSync(join(tmpdir(), 'sut-hosts-'));
+		try {
+			const p = personalPath('never-created.json', ws);
+			assert.equal(p, join(ws, 'never-created.json'));
+		} finally {
+			rmSync(ws, { recursive: true, force: true });
+			clearEnv();
+		}
+	});
+
+	it('hosts/<host>/ wins over legacy machine-<host>/', () => {
+		clearEnv();
+		process.env.SUTANDO_HOST_LABEL = 'test-host';
+		const ws = mkdtempSync(join(tmpdir(), 'sut-hosts-'));
+		const mem = mkdtempSync(join(tmpdir(), 'sut-mem-'));
+		try {
+			const machineDir = join(mem, 'machine-test-host');
+			mkdirSync(machineDir, { recursive: true });
+			writeFileSync(join(machineDir, 'f.json'), 'legacy');
+			const hostDir = join(ws, 'hosts', 'test-host');
+			mkdirSync(hostDir, { recursive: true });
+			writeFileSync(join(hostDir, 'f.json'), 'new');
+			process.env.SUTANDO_MEMORY_DIR = mem;
+			const p = personalPath('f.json', ws);
+			assert.equal(p, join(hostDir, 'f.json'));
+		} finally {
+			rmSync(ws, { recursive: true, force: true });
+			rmSync(mem, { recursive: true, force: true });
+			clearEnv();
+		}
+	});
+
+	it('legacy machine-<host>/ still found when hosts/ absent', () => {
+		clearEnv();
+		process.env.SUTANDO_HOST_LABEL = 'test-host';
+		const ws = mkdtempSync(join(tmpdir(), 'sut-hosts-'));
+		const mem = mkdtempSync(join(tmpdir(), 'sut-mem-'));
+		try {
+			const machineDir = join(mem, 'machine-test-host');
+			mkdirSync(machineDir, { recursive: true });
+			writeFileSync(join(machineDir, 'g.json'), 'legacy');
+			process.env.SUTANDO_MEMORY_DIR = mem;
+			const p = personalPath('g.json', ws);
+			assert.equal(p, join(machineDir, 'g.json'));
+		} finally {
+			rmSync(ws, { recursive: true, force: true });
+			rmSync(mem, { recursive: true, force: true });
+			clearEnv();
+		}
+	});
+});


### PR DESCRIPTION
## What

Makes the per-host path resolvers (`personal_path` in `src/util_paths.py`, `personalPath` in `src/util_paths.ts`) aware of the new `<workspace>/hosts/<hostname>/` per-host home that #1717 establishes.

## Why (the H4 reader-trap)

The per-component relocation plan moves per-host files (stand-identity.json, channel access.json, crons.json, …) into `hosts/<hostname>/`. But the resolvers only knew about the legacy `$SUTANDO_MEMORY_DIR/machine-<host>/` location and the workspace-root fallback. **Relocating a file into `hosts/<host>/` would silently strand every reader on the root fallback** — a #1540-class regression that gates the whole relocation. This is the reader half that must land *with or before* any relocation PR.

Flagged in the overnight issue-hunt (#design, round 3, "H4 — the big one") and confirmed there is no other open PR updating these resolvers.

## What changed

- Add `<workspace>/hosts/<host>/<filename>` as the **first** existence-check candidate in both resolvers, ahead of `machine-<host>/` and the workspace-root fallback.
- Factor the per-host segment into one helper (`_host_label` / `hostLabel`) so `machine-<host>/` and `hosts/<host>/` stay in lockstep and match `_host()` in `sync-workspace.sh`.

## Scope / safety

- **Read-side only, purely additive.** When no `hosts/` file exists, resolution is byte-for-byte identical to pre-#1717. Zero risk to existing installs.
- **"Nothing-exists" preferred return (write target) deliberately unchanged.** Different per-host files want different homes (per-host → `hosts/`, shared like `pending-questions.md` → root), so blanket write-target convergence is a separate follow-up once `SUTANDO_MEMORY_DIR` retires. Out of scope here.

## Tests

New `tests/util-paths-hosts-resolution.test.{py,ts}` — hosts-first precedence, legacy fallthrough, hosts-beats-machine, legacy-still-works-when-hosts-absent, and the unchanged nothing-exists return.

```
PY  util-paths-hosts-resolution      6/6 OK
PY  util-paths-memory-dir (regress) 13/13 OK
PY  util-paths-ccd-banner (regress) 13/13 OK
TS  util-paths-hosts-resolution      5/5 pass
TS  util-paths-memory-dir (regress)  8/8 pass
tsc --noEmit                          clean
```

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)