### PR TITLE
fix(sync-workspace): hard-deny SSH keys + cert/key material (M3)

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -392,6 +392,22 @@ _compose_exclude_content() {
     echo "*.alive"
     echo "*.sentinel"
     echo "*.pid"
+    # Secret material — name-pattern deny (M3). The deny list above caught
+    # transient state + .env*; it did NOT cover SSH private keys or
+    # cert/key material, which would be carried if they ever landed in a
+    # synced path. These are gitignore-style globs composed into
+    # .git/info/exclude. Public keys (*.pub) are intentionally NOT denied.
+    echo "id_rsa"
+    echo "id_dsa"
+    echo "id_ecdsa"
+    echo "id_ed25519"
+    echo "*.pem"
+    echo "*.key"
+    echo "*.p12"
+    echo "*.pfx"
+    echo "*.ppk"
+    echo "*.keystore"
+    echo "*.jks"
 }
 
 # Write `<workspace>/.git/info/exclude` from the composed content. Also

--- a/tests/sync-workspace.test.sh
+++ b/tests/sync-workspace.test.sh
@@ -189,6 +189,21 @@ else
   echo "  FAIL: .git/info/exclude missing carrier-set un-ignore rules"; fail=$((fail+1))
 fi
 
+# M3: secret material hard-deny (SSH private keys + cert/key extensions).
+for _deny in "id_rsa" "id_ed25519" "*.pem" "*.key" "*.p12"; do
+  if grep -qxF "$_deny" "$EXCLUDE_FILE"; then
+    echo "  OK: .git/info/exclude hard-denies secret pattern '$_deny' (M3)"; pass=$((pass+1))
+  else
+    echo "  FAIL: .git/info/exclude missing secret deny '$_deny' (M3)"; fail=$((fail+1))
+  fi
+done
+# Public keys must remain syncable — *.pub is NOT denied.
+if grep -qxF '*.pub' "$EXCLUDE_FILE"; then
+  echo "  FAIL: .git/info/exclude wrongly denies *.pub (public keys should sync)"; fail=$((fail+1))
+else
+  echo "  OK: .git/info/exclude does not deny *.pub (public keys still sync)"; pass=$((pass+1))
+fi
+
 # Verify the OLD canonical-specific pattern is GONE
 if grep -qE 'projects/[a-f0-9]{8}/memory' "$EXCLUDE_FILE"; then
   echo "  FAIL: .git/info/exclude still has canonical-id-specific pattern"; fail=$((fail+1))


### PR DESCRIPTION
## What

Extends the `_compose_exclude_content` hard-deny block in `sync-workspace.sh` to cover secret key material.

## Why (M3)

The deny block caught transient state (`.env*`, `*.alive/sentinel/pid/heartbeat`) but **not** SSH private keys or cert/keystore files. If one ever landed in a synced carrier path, it would be pushed to the vault. Flagged as M3 in the overnight sync issue-hunt; worth closing before the workspace import starts carrying files.

## What changed

Added name-pattern denies:
- SSH private-key family: `id_rsa`, `id_dsa`, `id_ecdsa`, `id_ed25519`
- Cert/key extensions: `*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.ppk`, `*.keystore`, `*.jks`

Public keys (`*.pub`) are intentionally **not** denied.

## Tests

`sync-workspace.test.sh` Test 2 now asserts the secret patterns land in `.git/info/exclude` after `--init`, plus a negative assertion that `*.pub` is not denied.

```
sync-workspace.test.sh:  77 OK / 0 FAIL  (baseline staging: 71 OK / 0 FAIL — +6 new)
bash -n                  clean
```

Note: a pre-existing Test-27 abort under `set -e` (git D/F-branch-migration, environment-specific) reproduces on unmodified staging too — unrelated to this change, left out of scope.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)