### PR TITLE
feat(sync-memory): back up Claude Code settings.json to machine-<host>/

### DIFF
--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -361,6 +361,18 @@ for f in "${MACHINE_FILES[@]}"; do
     copy_if_newer "$src" "$MACHINE_DIR/$(basename "$f")"
 done
 
+# Claude Code per-host settings.json (enabled plugins, permission mode, hooks,
+# theme). Per-host + painful to recreate on a rebuild, and carries NO secrets
+# (tokens live in channels/<ch>/.env / Keychain, never here). Sibling to the
+# channel access.json backup — closes the second "unbacked per-host config"
+# gap so a rebuilt host restores its plugin/hook/permission config. Sourced
+# from the Claude Code config dir (CLAUDE_CONFIG_DIR canonical; CLAUDE_HOME
+# legacy; ~/.claude fallback) to work on both new and pre-migration hosts.
+SETTINGS_SRC="${CLAUDE_CONFIG_DIR:-${CLAUDE_HOME:-$HOME/.claude}}/settings.json"
+if [ -f "$SETTINGS_SRC" ]; then
+    copy_if_newer "$SETTINGS_SRC" "$MACHINE_DIR/settings.json"
+fi
+
 # Personal cron schedule (nested path)
 if [ -f "$REPO_DIR/skills/schedule-crons/crons.json" ]; then
     copy_if_newer "$REPO_DIR/skills/schedule-crons/crons.json" \


### PR DESCRIPTION
## What

Sibling to #1715. Adds `settings.json` to the per-host `machine-<host>/` backup in `sync-memory.sh`.

## Why

`settings.json` is the **second** currently-unbacked per-host config (alongside channel `access.json`, which #1715 covers). It holds enabled plugins, permission mode, SessionEnd hooks, theme — annoying to recreate on a rebuild — and carries **no secrets** (tokens live in `channels/<ch>/.env` / Keychain, never here). Closes the second "include everything" gap for the workspace-revamp import (owner directive 2026-06-20: "capture").

## What changed

```sh
SETTINGS_SRC="${CLAUDE_CONFIG_DIR:-${CLAUDE_HOME:-$HOME/.claude}}/settings.json"
[ -f "$SETTINGS_SRC" ] && copy_if_newer "$SETTINGS_SRC" "$MACHINE_DIR/settings.json"
```
- Source resolves CLAUDE_CONFIG_DIR (canonical) → CLAUDE_HOME (legacy) → `~/.claude` (fallback) so it works on post- and pre-migration hosts.
- Inserted **after the `MACHINE_FILES` loop** — a distinct location from #1715's after-crons `access.json` block, so the two land **without conflict** regardless of merge order.
- `bash -n` clean.

## Pairs with

- #1715 (access.json backup) — together they close both per-host config gaps.
- Both ride the `machine-<host>/` → `hosts/<host>/` relocation (#1721) during the import.

## Sequence to capture peers' config

Merge #1715 + this → Mini & Air `git pull` main + run `sync-memory` once → their `access.json` + `settings.json` land in `machine-<host>/` → Pro re-pulls + imports (relocating to `hosts/<host>/`).

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)