### PR TITLE
fix(personal-overrides): read PERSONAL_CLAUDE.md per-host first, fall back to root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ For full details on resolution order, overrides, and the protection layers (pre-
 
 ## Personal overrides
 
-If `PERSONAL_CLAUDE.md` exists in the workspace root, read and follow it. It contains user-specific rules, preferences, and configuration that override or extend these shared instructions.
+If `PERSONAL_CLAUDE.md` exists, read and follow it. It contains user-specific rules, preferences, and configuration that override or extend these shared instructions. Resolve it **per-host first**: prefer `<workspace>/hosts/<hostname>/PERSONAL_CLAUDE.md` (where `<hostname>` = `hostname | sed 's/\..*//'`, matching the `hosts/<hostname>/` per-host convention), and fall back to the workspace root if the per-host file does not exist. The per-host location is the canonical home (it's carried + backed up under the `hosts/*/` vault glob); the workspace-root fallback preserves pre-`hosts/` behavior.
 
 ## Work Status
 


### PR DESCRIPTION
## What
Make `CLAUDE.md`'s personal-overrides reader resolve `PERSONAL_CLAUDE.md` **per-host first** — `<workspace>/hosts/<hostname>/PERSONAL_CLAUDE.md` — falling back to the workspace root.

## Why
The `hosts/<hostname>/` convention lists `PERSONAL_CLAUDE.md` as per-host, and the #1721 migrator copies it into `hosts/<hostname>/`, but `CLAUDE.md` still instructed reading it **only** from the workspace root. So a relocated per-host `PERSONAL_CLAUDE.md` was silently never read — the documented relocation wasn't read-wired. (Surfaced in the per-host coverage audit.)

## Change
- `CLAUDE.md` personal-overrides section: probe `hosts/<hostname>/PERSONAL_CLAUDE.md` first (`<hostname>` = `hostname | sed 's/\..*//'`), then fall back to workspace root.

## Safety / impact
Additive — existing root-only setups are unchanged; per-host placement now takes effect. Matches `personal_path()`'s probe order for other per-host files. Instruction-only change.

Part of the per-host wiring follow-ups; complements the doc-accuracy fix in #1728.

Stand: Echo Act IV Pro