### PR TITLE
feat(sync-workspace): snapshot $CLAUDE_CONFIG_DIR per-host config into hosts/<host>/

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -562,6 +562,42 @@ _refuse_staged_secrets() {
     return 0
 }
 
+# Snapshot the per-host config that LIVES at $CLAUDE_CONFIG_DIR into
+# <workspace>/hosts/<host>/ so it's carried by the hosts/*/ vault glob and
+# survives a rebuild. settings.json and channel access.json are owned by Claude
+# Code / the bridges at $CLAUDE_CONFIG_DIR — they can't be relocated, so they're
+# *backed up* here (the live readers keep reading $CLAUDE_CONFIG_DIR; hosts/<host>/
+# is a pure backup → no read/write skew).
+#
+# NOT snapshotted: PERSONAL_CLAUDE.md / stand-identity.json / tab-aliases.json —
+# those follow the RELOCATION model (migrator one-time move + personal_path /
+# CLAUDE.md readers that prefer hosts/<host>/). Snapshotting them would make the
+# reader prefer a stale snapshot over the live root file.
+#
+# Secret-safe: copies ONLY access.json, never the sibling .env (bot tokens).
+# Non-fatal by construction: every step tolerates failure and the function
+# returns 0, so a snapshot hiccup can never block the push.
+_snapshot_per_host_config() {
+    local _cfg="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+    local _host_dir="$WORKSPACE_DIR/hosts/$(_host)"
+    mkdir -p "$_host_dir" 2>/dev/null || return 0
+
+    if [ -f "$_cfg/settings.json" ]; then
+        cp -p "$_cfg/settings.json" "$_host_dir/settings.json" 2>/dev/null || true
+    fi
+
+    # Channel access.json only (allowlists / TOFU / tier-maps). Never the
+    # sibling .env — that's a hard-denied secret.
+    local _ch _svc
+    for _ch in "$_cfg"/channels/*/access.json; do
+        [ -f "$_ch" ] || continue
+        _svc="$(basename "$(dirname "$_ch")")"
+        mkdir -p "$_host_dir/channels/$_svc" 2>/dev/null || continue
+        cp -p "$_ch" "$_host_dir/channels/$_svc/access.json" 2>/dev/null || true
+    done
+    return 0
+}
+
 # Guard against running push/pull on a workspace that has a `.git` directory
 # but was never properly sync-initialized. Without this, a stray `.git` (from
 # a half-completed prior init, a backup restore, or operator-`git init` for
@@ -993,6 +1029,10 @@ _push_only_impl() {
     # rationale + the 2026-06-04 leak fix that motivated moving it there).
     # Heal rules + untrack newly-excluded BEFORE staging; sweep staged
     # credential-shaped paths AFTER (see the two functions' rationale).
+    # Back up per-host config ($CLAUDE_CONFIG_DIR settings.json + channel
+    # access.json) into hosts/<host>/ before staging, so it's carried + survives
+    # a rebuild. Non-fatal: never blocks the push.
+    _snapshot_per_host_config || color_warn "sync-workspace: per-host config snapshot failed (non-fatal); push continues"
     _enforce_carrier_set_pre
     git add -A
     _refuse_staged_secrets

--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -578,7 +578,8 @@ _refuse_staged_secrets() {
 # Non-fatal by construction: every step tolerates failure and the function
 # returns 0, so a snapshot hiccup can never block the push.
 _snapshot_per_host_config() {
-    local _cfg="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+    local _cfg
+    _cfg="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" claude-home-path)" || return 0
     local _host_dir="$WORKSPACE_DIR/hosts/$(_host)"
     mkdir -p "$_host_dir" 2>/dev/null || return 0
 


### PR DESCRIPTION
## What
Adds `_snapshot_per_host_config()` to `sync-workspace.sh`, called in `_push_only_impl` just before staging. It backs up the per-host config that **lives at `$CLAUDE_CONFIG_DIR`** — `settings.json` and `channels/*/access.json` — into `<workspace>/hosts/<host>/`, which the `hosts/*/` carrier already syncs.

## Why
The per-host coverage audit found these are **migrator one-time-copy only** — `--migrate-from-legacy` copies them once, but nothing re-backs them up after an edit, so a rebuild loses any change since migration. This closes that going-forward backup gap.

## Design — backup vs relocation (important)
- **settings.json + access.json** are owned by Claude Code / the bridges at `$CLAUDE_CONFIG_DIR` and can't be relocated → `hosts/<host>/` is a pure **backup**. Live readers keep reading `$CLAUDE_CONFIG_DIR`, so **no read/write skew**.
- **PERSONAL_CLAUDE.md / stand-identity.json / tab-aliases.json** are deliberately **NOT** snapshotted — they follow the **relocation** model (migrator + `personal_path`/`CLAUDE.md` readers that prefer `hosts/<host>/`, e.g. #1729). Snapshotting them would make the reader prefer a stale snapshot over the live file.

## Safety
- Copies **only** `access.json`, never the sibling `.env` (bot tokens). `.env*` is hard-denied by the carrier + `_refuse_staged_secrets` regardless.
- `settings.json`/`access.json` aren't credential-shaped, so `_refuse_staged_secrets` won't strip them (verified against its patterns).
- **Non-fatal by construction**: every step tolerates failure and the fn returns 0, so a snapshot hiccup can never block the push.

## Test
Standalone run of the function: copies `settings.json` + per-channel `access.json` into `hosts/<host>/`, leaves `.env` behind; `bash -n` clean.

## Follow-up
Restore-on-rebuild (`hosts/<host>/` → `$CLAUDE_CONFIG_DIR`) is a separate PR.

Stand: Echo Act IV Pro