### PR TITLE
feat(sync): make build_log.md per-host — drop root carrier + snapshot to hosts/

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -596,6 +596,16 @@ _snapshot_per_host_config() {
         mkdir -p "$_host_dir/channels/$_svc" 2>/dev/null || continue
         cp -p "$_ch" "$_host_dir/channels/$_svc/access.json" 2>/dev/null || true
     done
+
+    # build_log.md is per-host (F1 decision) but its loop-writer keeps it at the
+    # workspace root and reads it from there — so it's snapshot-model like the
+    # files above (live at root, backup here; nothing reads the hosts/ copy live,
+    # so no read/write skew). Its root entry is dropped from vault.sync.include
+    # in tandem with this (it was colliding across hosts as a bare carried path);
+    # this snapshot is what carries it per-host instead.
+    if [ -f "$WORKSPACE_DIR/build_log.md" ]; then
+        cp -p "$WORKSPACE_DIR/build_log.md" "$_host_dir/build_log.md" 2>/dev/null || true
+    fi
     return 0
 }
 

--- a/sutando.config.json
+++ b/sutando.config.json
@@ -18,7 +18,6 @@
       "include": [
         "notes/",
         "pending-questions.md",
-        "build_log.md",
         "hosts/*/",
         ".claude-sutando/projects/*/memory/"
       ],


### PR DESCRIPTION
## What
Stops `build_log.md` colliding across hosts: drop it from `vault.sync.include` (root) and back it up per-host via the snapshot instead.

## Why (active bug)
`build_log.md` is per-host (F1 decision; #1718 reader + #1721 migrator already treat it so) — but it was **still listed bare in `vault.sync.include`**, so every host's root `build_log.md` synced and 3-way-merged across the fleet. That's the exact collision the per-host model exists to prevent, live today.

## Fix — snapshot/backup model
build_log's loop-writer keeps it at the workspace **root** and reads it from there (nothing reads it via `personal_path`), so `hosts/<host>/` is a pure backup → **no read/write skew**.
- Drop `build_log.md` from `vault.sync.include` → root copy stops syncing (collision gone).
- Extend `_snapshot_per_host_config()` to copy `<workspace>/build_log.md` → `hosts/<host>/build_log.md`, carried by the existing `hosts/*/` glob.

## Stacked
On #1730 (base = `feat/per-host-config-snapshot`) — uses its `_snapshot_per_host_config`. Retarget to staging once #1730 lands.

## ⚠️ Same-class follow-up (not in this PR)
`pending-questions.md` has the **identical** problem — bare in `vault.sync.include` despite being per-host (F1) + read via `personal_path`. It should also be dropped from the root carrier (relocation-model, hosts-native via the #1718 reader → carrier removal only, no snapshot). Left separate to keep this single-concern.

## Test
config JSON valid + `build_log.md` absent from include; `bash -n` clean; snapshot fn run copies `build_log.md` (+ settings.json) into `hosts/<host>/`.

Stand: Echo Act IV Pro