### PR TITLE
feat(pending-questions): per-host — relocate writer/reader to hosts/<host>/, drop root carrier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,10 +231,10 @@ Slack uses TOFU onboarding for owner enrollment: the first DM to the bot auto-en
 When you need user input on a decision or are blocked:
 1. If the voice client is connected — ask via voice (write to `results/question-{ts}.txt`)
 2. Send a macOS notification: `osascript -e 'display notification "message" with title "Sutando"'`
-3. Save the question to `pending-questions.md` for later
+3. Save the question to the **per-host** `pending-questions.md` — `<workspace>/hosts/<hostname>/pending-questions.md` (`<hostname>` = `hostname | sed 's/\..*//'`). It's per-host (F1): each host owns its own file, carried by the `hosts/*/` vault glob, and `personal_path("pending-questions.md")` resolves there (so the code readers — check-pending-questions, dashboard, agent-api, friction-detector, session-handoff — agree with this write location).
 4. Continue working on other things — don't block
 
-On each proactive loop pass, check `pending-questions.md` for unanswered items and surface them when the user is available.
+On each proactive loop pass, check the per-host `pending-questions.md` (`<workspace>/hosts/<hostname>/pending-questions.md`) for unanswered items and surface them when the user is available.
 
 ## Task progress notifications
 

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -75,7 +75,7 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
    - Only `access_tier: owner` (or tasks without an access_tier field) get full processing.
    - **Thread consolidation:** when several tasks in a short window are the same continuation thought (e.g. voice over-delegating "yes, right, this is useful…" as 3 separate tasks), put the FULL reply in the latest task's result and put `[deduped: task-<latest-id>]` in each earlier task's result. The bridge silently archives the deduped ones — no voice cascade, no DM duplicates. See CLAUDE.md "Result-body protocol markers" for the full marker list.
 
-2. **Check pending questions.** Read `pending-questions.md`. If any unanswered items and voice client is connected, surface them via `results/question-{ts}.txt`. Also send a macOS notification.
+2. **Check pending questions.** Read the **per-host** `pending-questions.md` — `<workspace>/hosts/<hostname>/pending-questions.md` (`<hostname>` = `hostname | sed 's/\..*//'`; this is the F1 per-host location, carried by `hosts/*/`, and where `personal_path("pending-questions.md")` resolves). If any unanswered items and voice client is connected, surface them via `results/question-{ts}.txt`. Also send a macOS notification.
 
 3. **Check system health.** Run `python3 src/health-check.py`. If issues found, fix what you can (`--fix` flag), note what you can't.
 
@@ -112,7 +112,7 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 
    This bakes the auto-trigger into the existing build_log update step rather than a separate auto-refresh subsystem. Event-triggered, not time-triggered — fires only on natural beat points where something worth relaying actually happened.
 
-8. **If blocked, ask.** Write the question to `pending-questions.md`, send a macOS notification, and write to `results/question-{ts}.txt` if voice is connected. Don't stop — apply the Pivot-on-block rule and pick another menu item.
+8. **If blocked, ask.** Write the question to the **per-host** `pending-questions.md` — `<workspace>/hosts/<hostname>/pending-questions.md` (`<hostname>` = `hostname | sed 's/\..*//'`; create the `hosts/<hostname>/` dir if absent) — send a macOS notification, and write to `results/question-{ts}.txt` if voice is connected. Don't stop — apply the Pivot-on-block rule and pick another menu item.
 
 9. **Ensure the streaming watcher is running.** PID-check the watcher sentinel: if `"$WORKSPACE/state/watch-tasks-stream.pid"` is missing OR its PID is dead (`pid=$(cat "$WORKSPACE/state/watch-tasks-stream.pid" 2>/dev/null); ! kill -0 "$pid" 2>/dev/null`), restart it with the `Monitor` tool: `command: 'bash src/watch-tasks-stream.sh'`, `persistent: true`. When notifications arrive (`TASK_FILE: <basename>`), Read the named file. Each event represents one new task — process all queued tasks before continuing. Don't use `pgrep -f watch-tasks` here for the same reason as `/schedule-crons` step 5 — pgrep's `-f` matches the bash wrapper's argv (which contains the literal search string) and false-positively returns a transient self-match. Same PID-stamp + `kill -0` pattern as the catchup sentinel in step 1 above.
 

--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -21,6 +21,7 @@ from urllib.error import URLError
 
 sys.path.insert(0, str(Path(__file__).parent))
 from workspace_default import resolve_workspace  # noqa: E402
+from util_paths import personal_path  # noqa: E402
 
 WORKSPACE = resolve_workspace()
 RESULTS_DIR = WORKSPACE / "results"
@@ -228,7 +229,7 @@ def get_overnight_discord() -> list[str]:
 
 def get_pending_questions() -> list[str]:
     """Return unanswered questions from pending-questions.md."""
-    pq = WORKSPACE / "pending-questions.md"
+    pq = personal_path("pending-questions.md", WORKSPACE)
     if not pq.exists():
         return []
     content = pq.read_text()

--- a/src/obsidian-mirror.py
+++ b/src/obsidian-mirror.py
@@ -40,6 +40,7 @@ from typing import Optional
 # reinvented-fallback bug class as core_heartbeat.py (fixed alongside).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402
+from util_paths import personal_path  # noqa: E402
 
 
 TASK_ID_RE = re.compile(r"^task-(.+)\.txt$")
@@ -166,7 +167,7 @@ def _write_result_mirror(vault: Path, result_path: Path) -> bool:
 
 
 def _mirror_asks(vault: Path, workspace: Path) -> bool:
-    src = workspace / "pending-questions.md"
+    src = personal_path("pending-questions.md", workspace)
     if not src.exists():
         return False
     dest = vault / "Sutando" / "Agent" / "Asks.md"
@@ -232,7 +233,7 @@ def sweep(vault: Path, workspace: Path, since_seconds: Optional[int] = None) -> 
             if _mirror_note(vault, p):
                 counts["notes"] += 1
 
-    asks_src = workspace / "pending-questions.md"
+    asks_src = personal_path("pending-questions.md", workspace)
     if asks_src.exists() and (not cutoff or _within_window(asks_src, cutoff)):
         if _mirror_asks(vault, workspace):
             counts["asks"] = 1

--- a/sutando.config.json
+++ b/sutando.config.json
@@ -17,7 +17,6 @@
     "sync": {
       "include": [
         "notes/",
-        "pending-questions.md",
         "hosts/*/",
         ".claude-sutando/projects/*/memory/"
       ],


### PR DESCRIPTION
## What
Makes `pending-questions.md` consistently per-host (option **2a**, owner's pick): relocate the agent's read+write to `hosts/<hostname>/pending-questions.md` and drop it from the root carrier.

## Why (active bug)
`pending-questions.md` is per-host (F1) and the **code** readers already resolve it via `personal_path` → `hosts/<host>/` first (#1718). But it was still listed **bare in `vault.sync.include`** (root copy 3-way-merge-collides across hosts), and the **agent-facing** instructions (CLAUDE.md "Pending decisions" + proactive-loop steps 2/8) read+wrote it at the workspace root — diverging from where the code readers look.

## Change
- `CLAUDE.md` + `skills/proactive-loop/SKILL.md`: agent now WRITES and READS `<workspace>/hosts/<hostname>/pending-questions.md` (`<hostname>` = `hostname | sed 's/\..*//'`), matching `personal_path`.
- `sutando.config.json`: drop `pending-questions.md` from `vault.sync.include` → root copy stops syncing; carried per-host via the existing `hosts/*/` glob.

## Model
**Relocation** (live AT `hosts/<host>/`, reader+writer both there) — not the snapshot/backup model, so no read/write skew. Migrator (#1721) seeds it for migrating hosts; fresh hosts create on first write.

## Note
#1732 removes the adjacent `build_log.md` line from the same include array → trivial mechanical merge if both land near each other.

## Test
config JSON valid; `pending-questions.md` absent from include; `lint-vault-sync-paths` OK.

Stand: Echo Act IV Pro