### PR TITLE
fix(security): resolve 3 CodeQL alerts — ReDoS ×2 + incomplete sanitization

### DIFF
--- a/skills/obsidian-vault/tools.ts
+++ b/skills/obsidian-vault/tools.ts
@@ -77,7 +77,10 @@ async function writeNote(root: string, title: string | undefined, body: string):
     const file = join(root, 'Sutando', 'Notes', `${slugify(baseTitle)}-${isoCompact(now)}.md`);
     const frontmatter = [
         '---',
-        `title: ${baseTitle.replace(/"/g, '\\"')}`,
+        // double-quoted YAML scalar: escape backslash FIRST, then quote, so
+        // titles with `\`, `"`, or `:` can't break/inject the frontmatter
+        // (CodeQL js/incomplete-sanitization — backslash was unescaped).
+        `title: "${baseTitle.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`,
         `created: ${now.toISOString()}`,
         'source: sutando',
         '---',

--- a/src/browser-tools.ts
+++ b/src/browser-tools.ts
@@ -269,7 +269,12 @@ export const closeTabTool: ToolDefinition = {
 // URL so callers/users still see exactly what they tried to open. Per
 // Susan's PR #919 review: regex strip is safer than `new URL()`-based
 // redaction since the failure path is often an unparseable URL.
-const redactQuery = (u: string): string => JSON.stringify(u.replace(/\?.*$/, '?…'));
+const redactQuery = (u: string): string => {
+	// split on the first '?' instead of /\?.*$/ — linear, no polynomial
+	// backtracking on inputs with many '?' (CodeQL js/polynomial-redos).
+	const i = u.indexOf('?');
+	return JSON.stringify(i === -1 ? u : u.slice(0, i + 1) + '…');
+};
 
 export const openUrlTool: ToolDefinition = {
 	name: 'open_url',

--- a/src/meeting-tools.ts
+++ b/src/meeting-tools.ts
@@ -24,7 +24,9 @@ export const joinGmeetTool: ToolDefinition = {
 	async execute(args) {
 		const { meetingCode } = args as { meetingCode: string };
 		// Extract code from URL or use as-is
-		const code = meetingCode.replace(/^https?:\/\/meet\.google\.com\//, '').replace(/\?.*$/, '').trim();
+		// strip the query string by splitting on '?' (linear; avoids the
+		// polynomial-backtracking /\?.*$/ regex — CodeQL js/polynomial-redos)
+		const code = meetingCode.replace(/^https?:\/\/meet\.google\.com\//, '').split('?')[0].trim();
 		if (!code) return { error: 'Invalid meeting code' };
 
 		const meetUrl = `https://meet.google.com/${code}`;


### PR DESCRIPTION
Fixes the 3 open CodeQL code-scanning alerts (all **high**).

| Alert | Rule | File | Fix |
|---|---|---|---|
| #54 | `js/polynomial-redos` | `src/meeting-tools.ts:27` | `/\?.*$/` query-strip → `.split('?')[0]` (linear) |
| #53 | `js/polynomial-redos` | `src/browser-tools.ts:272` | `/\?.*$/` query-redact → `indexOf('?')` slice, keeps the `?…` marker |
| #52 | `js/incomplete-sanitization` | `skills/obsidian-vault/tools.ts:80` | escape `\` before `"` + wrap title in a double-quoted YAML scalar |

**Why:** the two ReDoS regexes backtrack polynomially on inputs with many `?`; the obsidian title-escaper escaped `"` but not backslash (and the value was unquoted, so a title with `:` could break the frontmatter).

**Behavior preserved:** query stripping/redaction identical for normal URLs; obsidian titles now correctly escaped + quoted.

`tsc --noEmit` clean. No new deps. Single concern (the 3 scanning alerts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)