### PR TITLE
fix(host-resolution): don't crash agent-api on unresolvable hostname; pin heartbeat label to _host_label

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -894,11 +894,22 @@ async function send(){
 </script></body></html>"""
 
 
+def _resolve_local_ip() -> str:
+    """Best-effort LAN IP for the startup log line. An unresolvable hostname
+    (e.g. a DHCP-assigned name not in DNS/hosts) must NOT crash startup —
+    `socket.gethostbyname(socket.gethostname())` raises gaierror in that case.
+    The value is informational only, so fall back to loopback."""
+    import socket
+    try:
+        return socket.gethostbyname(socket.gethostname())
+    except OSError:
+        return "127.0.0.1"
+
+
 if __name__ == "__main__":
     bind = os.environ.get("AGENT_API_BIND", "127.0.0.1")
     server = http.server.HTTPServer((bind, PORT), Handler)
-    import socket
-    local_ip = socket.gethostbyname(socket.gethostname())
+    local_ip = _resolve_local_ip()
     print(f"Sutando Agent API → http://{bind}:{PORT}")
     print(f"  POST /task  — submit a task")
     print(f"  GET  /status — health + capabilities")

--- a/src/core_heartbeat.py
+++ b/src/core_heartbeat.py
@@ -60,10 +60,18 @@ CORES_DIR = WORKSPACE / "state" / "cores"
 
 
 def _hostname() -> str:
-    """Short hostname without domain. Mirrors what sync-workspace.sh uses for
-    machine-<host>/ dirs, so the .alive file is recognizable across the
-    fleet's other state files."""
-    return socket.gethostname().split(".")[0]
+    """Per-host label for the `.alive` filename. Delegates to
+    `util_paths._host_label()` — the single source of truth (honors
+    `$SUTANDO_HOST_LABEL`, else short hostname) — so the heartbeat label stays
+    in lockstep with the `hosts/<host>/` per-host dir and survives DHCP
+    hostname drift (a node whose `hostname` is a DHCP/Comcast name that flaps
+    would otherwise write two divergent `<label>.alive` files). Falls back to
+    the raw short hostname if util_paths is unavailable."""
+    try:
+        from util_paths import _host_label
+        return _host_label()
+    except Exception:
+        return socket.gethostname().split(".")[0]
 
 
 def _alive_path() -> Path:

--- a/tests/hostname-resolution-resilience.test.py
+++ b/tests/hostname-resolution-resilience.test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Regression guards: hostname-resolution resilience (2026-06-22).
+
+Two related fragilities found when a node's `hostname` is a DHCP-assigned
+name (e.g. `Chis-MBP.hsd1.wa.comcast.net`) that is unstable and not
+DNS-resolvable:
+
+1. `agent-api.py` did `socket.gethostbyname(socket.gethostname())` at startup
+   for an informational log line. An unresolvable hostname raises `gaierror`
+   (an `OSError`) and CRASHED agent-api on boot. Fix: `_resolve_local_ip()`
+   catches `OSError` and falls back to loopback.
+
+2. `core_heartbeat._hostname()` used the raw `socket.gethostname()` for the
+   `<label>.alive` filename, diverging from `util_paths._host_label()` (which
+   honors `$SUTANDO_HOST_LABEL`). On a DHCP-drifting host that produced TWO
+   divergent `.alive` files and ignored the per-host label pin. Fix: delegate
+   to `_host_label()`.
+
+Run: python3 tests/hostname-resolution-resilience.test.py
+Exit: 0 = all pass, 1 = failure
+"""
+from __future__ import annotations
+import importlib.util
+import os
+import re
+import socket
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _load_core_heartbeat():
+    spec = importlib.util.spec_from_file_location(
+        "core_heartbeat", ROOT / "src" / "core_heartbeat.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class CoreHeartbeatHostnameTests(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("SUTANDO_HOST_LABEL", None)
+
+    def tearDown(self):
+        os.environ.pop("SUTANDO_HOST_LABEL", None)
+
+    def test_hostname_honors_label_pin(self):
+        os.environ["SUTANDO_HOST_LABEL"] = "Chis-MacBook-Pro"
+        ch = _load_core_heartbeat()
+        self.assertEqual(
+            ch._hostname(), "Chis-MacBook-Pro",
+            "_hostname() must honor $SUTANDO_HOST_LABEL (via _host_label), "
+            "so the .alive label survives DHCP hostname drift",
+        )
+
+    def test_hostname_fallback_matches_short_hostname(self):
+        # No label set → must equal the domain-stripped short hostname,
+        # i.e. byte-identical to the pre-fix behavior.
+        ch = _load_core_heartbeat()
+        self.assertEqual(ch._hostname(), socket.gethostname().split(".")[0])
+
+
+class AgentApiGethostbynameGuardTests(unittest.TestCase):
+    SRC = (ROOT / "src" / "agent-api.py").read_text()
+
+    def test_gethostbyname_is_wrapped(self):
+        self.assertIn("_resolve_local_ip", self.SRC,
+                      "the local-IP resolution must go through the guarded helper")
+        self.assertIn("except OSError", self.SRC,
+                      "gethostbyname must be wrapped so an unresolvable hostname "
+                      "can't crash startup")
+        self.assertIn('return "127.0.0.1"', self.SRC,
+                      "must fall back to loopback on resolution failure")
+
+    def test_no_bare_crashing_call_remains(self):
+        # The exact bare call that crashed must not be reintroduced at module top level.
+        self.assertNotRegex(
+            self.SRC,
+            r"\n    local_ip = socket\.gethostbyname\(socket\.gethostname\(\)\)",
+            "the bare unguarded gethostbyname call must not return",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem
On a node whose `hostname` is a DHCP-assigned name (e.g. `Chis-MBP.hsd1.wa.comcast.net`) that is unstable and not DNS-resolvable, two fragilities bite:

1. **agent-api crashes on boot.** `src/agent-api.py` ran `socket.gethostbyname(socket.gethostname())` for an informational startup log line; an unresolvable hostname raises `gaierror` (an `OSError`) → the server never starts.
2. **Heartbeat label drifts.** `core_heartbeat._hostname()` used the raw short hostname for `state/cores/<label>.alive`, diverging from `util_paths._host_label()` (which honors `$SUTANDO_HOST_LABEL`). On a DHCP-flapping host this writes two divergent `.alive` files and ignores the per-host label pin — peers see a phantom dead core.

Caught on a live node (Comcast DHCP hostname) where pinning `SUTANDO_HOST_LABEL` fixed the per-host *path* resolution (util_paths) but NOT these two raw-`gethostname` callers.

## Fix
- `_resolve_local_ip()` wraps `gethostbyname` → falls back to `127.0.0.1` on `OSError` (value is log-only).
- `core_heartbeat._hostname()` delegates to `_host_label()` (single source of truth; honors `$SUTANDO_HOST_LABEL`) with a safe fallback to the short hostname.
- Adds `tests/hostname-resolution-resilience.test.py` (4 cases, all green).

No behavior change on hosts with a resolvable/stable hostname. Single concern.

Stand: Echo Act IV Pro