### PR TITLE
fix(auth): mirror default OAuth credential into CLAUDE_CONFIG_DIR-namespaced keychain item (fixes daily re-login on migrated nodes)

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -136,6 +136,21 @@ json.dump({'source':'env','env_var':v,'carried_at':datetime.datetime.now(datetim
       fi
     fi
     export CLAUDE_CONFIG_DIR="$_ccd"
+    # [CRED-MIRROR 20260622] Claude Code keys its keychain credential by
+    # config-dir namespace, so an isolated CLAUDE_CONFIG_DIR isolates AUTH too:
+    # the user's /login (default namespace) never reaches the namespaced item
+    # the core reads -> daily re-login. Mirror the default credential into the
+    # namespaced item so the isolated core finds the login. Runs in the GUI
+    # login session (keychain-writable); no-op if the default item is absent.
+    _ccd_ns="Claude Code-credentials-$(printf %s "$_ccd" | shasum -a 256 | cut -c1-8)"
+    _ccd_cred="$(security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null || true)"
+    if [ -n "$_ccd_cred" ]; then
+      if security add-generic-password -U -s "$_ccd_ns" -a "$USER" -w "$_ccd_cred" 2>/dev/null; then
+        echo "  \u2713 mirrored default Claude credential -> $_ccd_ns"
+      else
+        echo "  \u26a0 credential mirror failed (keychain not writable here)"
+      fi
+    fi
   else
     echo "startup: claude_sutando_config_dir invalid — refusing to start" >&2
     cat "$_ccd_err" >&2


### PR DESCRIPTION
## Repurposed — the real fix (proven on a migrated node)

The original patch here (proxy reads the namespaced keychain item) addressed the wrong end. This is the actual fix.

## Bug: daily re-login on migrated nodes
Workspace-revamp (#1454) sets `CLAUDE_CONFIG_DIR=<workspace>/.claude-sutando`. Claude Code keys its OAuth credential in the keychain by config-dir namespace, so isolating the config also isolates **auth**:
- The user's `/login` writes the **default** item `Claude Code-credentials`.
- The isolated core reads the **namespaced** item `Claude Code-credentials-<sha256(CLAUDE_CONFIG_DIR)[:8]>`.
- The core never sees the credential the login produced → fails → re-login → **every day**.

Evidence (migrated node): keychain `mdat` showed default = fresh (today's login), namespaced = days stale.

## Fix
At startup (which runs in the user's GUI login session, where keychain is writable), **mirror the default credential into the namespaced item** the core reads — keeping `CLAUDE_CONFIG_DIR` intact (config isolation preserved) and requiring **no new login**. The core then reads a valid credential and auto-refreshes the namespaced item going forward.

`src/startup.sh`, right after the `CLAUDE_CONFIG_DIR` export:
```sh
_ccd_ns="Claude Code-credentials-$(printf %s "$_ccd" | shasum -a 256 | cut -c1-8)"
_ccd_cred="$(security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null || true)"
if [ -n "$_ccd_cred" ]; then
  security add-generic-password -U -s "$_ccd_ns" -a "$USER" -w "$_ccd_cred" 2>/dev/null \
    && echo "  ✓ mirrored default Claude credential -> $_ccd_ns" \
    || echo "  ⚠ credential mirror failed (keychain not writable here)"
fi
```

## Proven
On a real migrated node: applied the mirror (namespaced `mdat` updated; `MIRROR_OK`), then `claude -p` with `CLAUDE_CONFIG_DIR` set (same as the core) read the mirrored credential and authenticated → `AUTHOK`, exit 0, no login. Satisfies both constraints: config isolation kept, no login.

Closes the daily-re-login class. (Supersedes the proxy-namespace approach.)
