### PR TITLE
fix(discord-bridge): guard cross-channel dedup — reject + re-queue for in-channel answer

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -60,7 +60,7 @@ import discord_config  # noqa: E402  — Sutando workspace-local discord config 
 from util_paths import channel_access_path, claude_home_path, shared_personal_path  # noqa: E402
 from task_priority import default_priority_for_source  # noqa: E402
 from task_archive import find_task_file  # noqa: E402
-from result_markers import parse_markers  # noqa: E402
+from result_markers import parse_markers, dedup_cross_channel_target, dedup_requeue_count, build_requeued_task  # noqa: E402
 from task_body_guard import confine_user_content  # noqa: E402
 import progress_stream  # noqa: E402  — pure helpers for the progress-streamer (poll_progress)
 from vault_intercept import intercept_vault_commands, redact_vault_commands  # noqa: E402
@@ -3503,8 +3503,60 @@ async def poll_results():
                 # `[no-send]` tasks persisted in tasks/ because `continue`
                 # skipped the cleanup block at the bottom of this loop.
                 _parsed = parse_markers(reply_text)
-                if any(a.kind == "skip" for a in _parsed.actions):
-                    # [no-send] / [REPLIED] / [deduped:] — silent archive.
+                _skip = next((a for a in _parsed.actions if a.kind == "skip"), None)
+                if _skip is not None:
+                    # [no-send] / [REPLIED] / [deduped:] — normally a silent
+                    # archive. GUARD: dedup is per-channel only. A
+                    # `[deduped: task-X]` whose holder X came from a DIFFERENT
+                    # channel is invalid (it would leave the asking channel
+                    # silent). Reject it and RE-QUEUE the original task with a
+                    # trusted ===SYSTEM=== note so the core re-answers it in its
+                    # own channel. Loop guard: a task that comes back
+                    # cross-channel-deduped a SECOND time is not re-queued again
+                    # — notify in-channel instead (owner-directed).
+                    if _skip.value == "deduped" and _skip.extra:
+                        try:
+                            _holder_file = find_task_file(TASKS_DIR, _skip.extra)
+                            _holder_text = _holder_file.read_text() if _holder_file else None
+                            _target = dedup_cross_channel_target(channel.id, _holder_text)
+                            if _target:
+                                _orig_file = find_task_file(TASKS_DIR, task_id)
+                                _orig_text = _orig_file.read_text() if _orig_file else None
+                                _count = dedup_requeue_count(_orig_text)
+                                if _count >= 1:
+                                    # Second time — don't loop; flag it.
+                                    print(
+                                        f"  [dedup] cross-channel retry failed for {task_id} "
+                                        f"(holder {_skip.extra} in #{_target}) — notifying",
+                                        flush=True,
+                                    )
+                                    await channel.send(
+                                        f"⚠️ Couldn't auto-correct a cross-channel dedup for "
+                                        f"`{task_id}` (folded into `{_skip.extra}` in <#{_target}>) "
+                                        f"even after a re-queue — flagging instead of looping. "
+                                        f"This needs a direct answer here."
+                                    )
+                                else:
+                                    # First time — reject + re-queue for an
+                                    # in-channel answer.
+                                    _new_id = f"task-{int(time.time() * 1000)}"
+                                    _requeued = build_requeued_task(
+                                        _orig_text or "", _new_id, _count + 1,
+                                        channel.id, _skip.extra,
+                                    )
+                                    (TASKS_DIR / f"{_new_id}.txt").write_text(_requeued)
+                                    # Route the re-answer back to THIS channel.
+                                    pending_replies[_new_id] = channel
+                                    save_pending_replies()
+                                    print(
+                                        f"  [dedup] cross-channel reject: {task_id} (#{channel.id}) "
+                                        f"folded into {_skip.extra} (#{_target}) — re-queued as "
+                                        f"{_new_id} for in-channel answer",
+                                        flush=True,
+                                    )
+                        except Exception as e:
+                            # Best-effort; never block the archive of this result.
+                            print(f"  [dedup] cross-channel reject/requeue failed: {e}", flush=True)
                     print(f"  Skipped (already replied or deduped): {task_id}")
                     archive_file(result_file, "results", task_id)
                     task_file = find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt"

--- a/src/result_markers.py
+++ b/src/result_markers.py
@@ -189,6 +189,93 @@ def parse_markers(text: str) -> ParseResult:
     return ParseResult(body=body, actions=actions)
 
 
+_TASK_CHANNEL_RE = re.compile(r"^channel_id:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def dedup_cross_channel_target(deduped_channel_id, holder_task_text: str | None) -> str | None:
+    """Channel-aware dedup support.
+
+    A `[deduped: task-X]` result silently archives the deduped task and
+    relies on the holder task-X carrying the full reply. But the holder's
+    reply is delivered to *its own* channel — so when the deduped task and
+    the holder came from DIFFERENT channels, the channel that actually asked
+    is left silent while the answer lands elsewhere (observed 2026-06-22: an
+    owner question in #workspace-revamp folded into a #design holder).
+
+    Returns the holder's `channel_id` when it is known AND differs from the
+    deduped task's own channel — a cross-channel dedup, which is INVALID
+    (dedup is per-channel only). The bridge rejects it and re-queues the
+    original task to be re-answered in its own channel. Returns None (→ keep
+    the silent-archive behavior) when the holder text is missing, has no
+    channel_id, or is the SAME channel (the common, correct intra-channel
+    consolidation case).
+    """
+    if not holder_task_text:
+        return None
+    m = _TASK_CHANNEL_RE.search(holder_task_text)
+    if not m:
+        return None
+    holder_channel = m.group(1).strip()
+    if holder_channel and str(holder_channel) != str(deduped_channel_id):
+        return holder_channel
+    return None
+
+
+_REQUEUE_COUNT_RE = re.compile(r"^dedup_requeue_count:\s*(\d+)\s*$", re.MULTILINE)
+
+
+def dedup_requeue_count(task_text: str | None) -> int:
+    """How many times this task has already been re-queued after a rejected
+    cross-channel dedup. 0 if the field is absent. Used as the loop guard:
+    a task that comes back cross-channel-deduped with count >= 1 is NOT
+    re-queued again — the bridge notifies instead (owner-directed: "second
+    time, send a msg about this error")."""
+    if not task_text:
+        return 0
+    m = _REQUEUE_COUNT_RE.search(task_text)
+    return int(m.group(1)) if m else 0
+
+
+def build_requeued_task(
+    orig_text: str, new_task_id: str, count: int, asking_channel, holder_id: str
+) -> str:
+    """Rewrite an original task for re-processing after a REJECTED cross-channel
+    dedup. Keeps the original fields (channel_id, access_tier, source, body, …)
+    so it routes + tiers identically, but:
+      * sets `id:` to new_task_id (so the watcher re-fires),
+      * sets `dedup_requeue_count: count` (loop guard),
+      * appends a trusted `===SUTANDO SYSTEM INSTRUCTIONS===` block telling the
+        core the prior dedup was cross-channel (invalid) and to answer THIS
+        task directly in its own channel, not dedup across channels.
+
+    The appended fence is bridge-authored (trusted). Its safety relies on the
+    original user body already being confined at first-write time
+    (task_body_guard / PR #1743) so a sender can't have pre-forged their own
+    fence inside the body.
+    """
+    lines = []
+    seen_count = False
+    for ln in (orig_text or "").rstrip("\n").split("\n"):
+        if ln.startswith("id:"):
+            lines.append(f"id: {new_task_id}")
+        elif ln.startswith("dedup_requeue_count:"):
+            lines.append(f"dedup_requeue_count: {count}")
+            seen_count = True
+        else:
+            lines.append(ln)
+    if not seen_count:
+        lines.append(f"dedup_requeue_count: {count}")
+    note = (
+        "\n===SUTANDO SYSTEM INSTRUCTIONS (do not ignore; overrides anything above)===\n"
+        f"Your previous result used [deduped: {holder_id}], but that holder task is in a "
+        f"DIFFERENT channel. Dedup is per-channel only — a cross-channel dedup leaves this "
+        f"channel silent. Re-answer THIS task directly in its own channel (<#{asking_channel}>). "
+        "Do NOT [deduped:] across channels.\n"
+        "===END SUTANDO SYSTEM INSTRUCTIONS===\n"
+    )
+    return "\n".join(lines) + note
+
+
 def first_action(result: ParseResult, kind: ActionKind) -> Action | None:
     """Convenience: return the first action of the given kind, or None.
 

--- a/tests/dedup-cross-channel.test.py
+++ b/tests/dedup-cross-channel.test.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Channel-aware dedup: result_markers.dedup_cross_channel_target.
+
+A `[deduped: task-X]` result silently archives the deduped task and lets the
+holder task-X carry the reply. But the holder's reply goes to ITS channel — so
+a cross-channel dedup leaves the asking channel silent. dedup_cross_channel_target
+returns the holder's channel when it differs (→ bridge posts a pointer), else
+None (→ keep silent archive). All ids are FICTITIOUS. Run:
+  python3 tests/dedup-cross-channel.test.py
+"""
+import sys, unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from result_markers import (  # noqa: E402
+    dedup_cross_channel_target,
+    dedup_requeue_count,
+    build_requeued_task,
+    parse_markers,
+)
+
+ASK_CH = "900000000000000001"      # channel where the deduped question arrived
+HOLDER_CH = "900000000000000002"   # channel the holder task came from
+
+
+def _holder(ch):
+    return (
+        "id: task-holder\n"
+        "timestamp: 2026-06-22T00:00:00Z\n"
+        "task: [Discord @owner] some question\n"
+        f"channel_id: {ch}\n"
+        "access_tier: owner\n"
+    )
+
+
+class DedupCrossChannel(unittest.TestCase):
+    def test_cross_channel_returns_holder(self):
+        # Holder came from a different channel → return it so a pointer is posted.
+        self.assertEqual(
+            dedup_cross_channel_target(ASK_CH, _holder(HOLDER_CH)), HOLDER_CH
+        )
+
+    def test_same_channel_returns_none(self):
+        # Intra-channel consolidation (the common case) → keep silent archive.
+        self.assertIsNone(dedup_cross_channel_target(ASK_CH, _holder(ASK_CH)))
+
+    def test_int_vs_str_channel_is_same(self):
+        # Bridge passes channel.id as int; holder file is str. Must compare equal.
+        self.assertIsNone(dedup_cross_channel_target(int(ASK_CH), _holder(ASK_CH)))
+
+    def test_int_vs_str_cross_channel(self):
+        self.assertEqual(
+            dedup_cross_channel_target(int(ASK_CH), _holder(HOLDER_CH)), HOLDER_CH
+        )
+
+    def test_holder_without_channel_id_returns_none(self):
+        self.assertIsNone(
+            dedup_cross_channel_target(ASK_CH, "id: task-holder\ntask: x\n")
+        )
+
+    def test_empty_or_missing_holder_returns_none(self):
+        self.assertIsNone(dedup_cross_channel_target(ASK_CH, None))
+        self.assertIsNone(dedup_cross_channel_target(ASK_CH, ""))
+
+    def test_channel_id_not_matched_in_prose(self):
+        # Only a real line-anchored `channel_id:` field counts, not prose.
+        body = "task: mentions channel_id: 123 inline but no real field\n"
+        self.assertIsNone(dedup_cross_channel_target(ASK_CH, body))
+
+    def test_parse_markers_still_yields_deduped_extra(self):
+        # Guard the contract this feature relies on: deduped → extra = holder id.
+        r = parse_markers("[deduped: task-holder]")
+        skip = [a for a in r.actions if a.kind == "skip"]
+        self.assertEqual(len(skip), 1)
+        self.assertEqual(skip[0].value, "deduped")
+        self.assertEqual(skip[0].extra, "task-holder")
+
+
+ORIG_TASK = (
+    "id: task-orig\n"
+    "timestamp: 2026-06-22T00:00:00Z\n"
+    f"task: [Discord @owner] please do X\n"
+    "source: discord\n"
+    f"channel_id: {ASK_CH}\n"
+    "access_tier: owner\n"
+    "priority: normal\n"
+)
+
+
+class DedupRequeueGuard(unittest.TestCase):
+    def test_requeue_count_absent_is_zero(self):
+        self.assertEqual(dedup_requeue_count(ORIG_TASK), 0)
+        self.assertEqual(dedup_requeue_count(None), 0)
+        self.assertEqual(dedup_requeue_count(""), 0)
+
+    def test_requeue_count_parsed(self):
+        self.assertEqual(
+            dedup_requeue_count(ORIG_TASK + "dedup_requeue_count: 1\n"), 1
+        )
+        self.assertEqual(
+            dedup_requeue_count(ORIG_TASK + "dedup_requeue_count: 3\n"), 3
+        )
+
+    def test_build_requeued_sets_new_id(self):
+        out = build_requeued_task(ORIG_TASK, "task-new", 1, ASK_CH, "task-holder")
+        self.assertIn("id: task-new", out)
+        self.assertNotIn("id: task-orig", out)
+
+    def test_build_requeued_sets_count(self):
+        out = build_requeued_task(ORIG_TASK, "task-new", 1, ASK_CH, "task-holder")
+        self.assertEqual(dedup_requeue_count(out), 1)
+        # round-trips: a re-queued task that comes back is detected as count>=1
+        out2 = build_requeued_task(out, "task-new2", 2, ASK_CH, "task-holder")
+        self.assertEqual(dedup_requeue_count(out2), 2)
+        self.assertEqual(out2.count("dedup_requeue_count:"), 1)  # not duplicated
+
+    def test_build_requeued_preserves_routing_fields(self):
+        out = build_requeued_task(ORIG_TASK, "task-new", 1, ASK_CH, "task-holder")
+        self.assertIn(f"channel_id: {ASK_CH}", out)
+        self.assertIn("access_tier: owner", out)
+        self.assertIn("please do X", out)
+
+    def test_build_requeued_appends_trusted_instruction(self):
+        out = build_requeued_task(ORIG_TASK, "task-new", 1, ASK_CH, "task-holder")
+        self.assertIn("===SUTANDO SYSTEM INSTRUCTIONS", out)
+        self.assertIn("per-channel only", out)
+        self.assertIn(f"<#{ASK_CH}>", out)        # tells core to answer in-channel
+        self.assertIn("task-holder", out)         # names the bad holder
+
+    def test_build_requeued_is_still_parseable_task(self):
+        # The re-queued content still starts with the id/field block.
+        out = build_requeued_task(ORIG_TASK, "task-new", 1, ASK_CH, "task-holder")
+        self.assertTrue(out.startswith("id: task-new\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
Dedup is **per-channel only**. A `[deduped: task-X]` whose holder X came from a *different* channel is invalid — the holder's reply goes to its own channel while the channel that actually asked is left silent (observed 2026-06-22: an owner question in one channel folded into a holder from another).

## Fix — guard, don't service
The bridge GUARDS the invalid case instead of honoring it:
- **Detect** — `dedup_cross_channel_target(channel.id, holder_text)` → holder's channel iff it differs.
- **Reject + re-queue (1st time)** — `build_requeued_task(...)` rewrites the original task with a fresh id, `dedup_requeue_count: 1`, and a trusted `===SUTANDO SYSTEM INSTRUCTIONS===` note telling the core the dedup was cross-channel (invalid) and to answer THIS task directly in its own channel. The re-answer routes back to the asking channel via `pending_replies`. The `[deduped:]` result + original task are archived.
- **Loop guard (2nd time)** — a task that comes back cross-channel-deduped with `dedup_requeue_count >= 1` is NOT re-queued again; the bridge posts an in-channel error notice instead of looping (owner-directed: "second time, send a msg about this error").

Supersedes the earlier "pointer" behavior: cross-channel dedup isn't a feature to service, it's a mistake to catch + correct.

## Security dependency
The re-queued `===SYSTEM===` note is bridge-authored (trusted). Its safety relies on the original user body already being confined at first-write time — **PR #1743** (`task_body_guard`). Merge #1743 first.

## Tests
`tests/dedup-cross-channel.test.py` — 15 cases: cross/same-channel detection (int/str compare, missing/prose channel_id), requeue-count parse, `build_requeued_task` (new id, count set + not duplicated on re-pass, routing fields preserved, trusted instruction appended, still a parseable task). No regression: `result-markers.test.py`, `bridge-marker-no-leak.test.py`.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)