### PR TITLE
fix(vault): intercept `vault set KEY=VALUE` (= separator) — close plaintext-leak gap

### DIFF
--- a/src/vault_intercept.py
+++ b/src/vault_intercept.py
@@ -57,8 +57,15 @@ _MANIFEST_PATH = os.path.expanduser("~/.sutando-secret-vault/keys.json")
 # pattern-based validation, eliminating both:
 #   - FP: "the vault set command works fine" → "works" is not a secret → skip
 #   - FN: "hey vault set APOLLO_KEY sk-..." mid-prose → "sk-..." is OpenAI → store
+# Key/value separator is whitespace OR `=` (with optional surrounding spaces),
+# so `vault set KEY VALUE`, `vault set KEY=VALUE`, and `vault set KEY = VALUE`
+# all intercept. The KEY group stops at the first space or `=` (`[^\s=]+`) so
+# the `=` form isn't swallowed whole — that swallowing is what let an owner's
+# `vault set X_BEARER_TOKEN=…` slip past uncaught and land in plaintext on disk
+# (2026-06-22 incident). Group numbering preserved: key=group(1), value
+# alternatives=groups 2-5 (separator is non-capturing).
 _VAULT_SET_RE = re.compile(
-    r'\bvault\s+set\s+(\S+)\s+(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+))(?=\s|$|[.,!?;])',
+    r'\bvault\s+set\s+([^\s=]+)(?:\s*=\s*|\s+)(?:"([^"]*)"|\'([^\']*)\'|`([^`]*)`|(\S+))(?=\s|$|[.,!?;])',
     re.IGNORECASE,
 )
 

--- a/tests/vault-intercept.test.py
+++ b/tests/vault-intercept.test.py
@@ -99,6 +99,46 @@ class TestSingleVaultSet(unittest.TestCase):
         self.assertEqual(result.text, "vault set FOO [STORED-IN-KEYCHAIN]")
         self.assertEqual(result.stored, ["FOO"])
 
+    # --- `=` separator (2026-06-22 leak: `vault set KEY=VALUE` was uncaught) ---
+    def test_equals_separator_bare(self):
+        with _mock_store():
+            value = "sk-" + "a"*20 + "T3BlbkFJ" + "b"*20
+            result = intercept_vault_commands(f"vault set MY_KEY={value}")
+        self.assertEqual(result.text, "vault set MY_KEY [STORED-IN-KEYCHAIN]")
+        self.assertEqual(result.stored, ["MY_KEY"])
+
+    def test_equals_separator_with_spaces(self):
+        with _mock_store():
+            value = "sk-" + "a"*20 + "T3BlbkFJ" + "b"*20
+            result = intercept_vault_commands(f"vault set MY_KEY = {value}")
+        self.assertEqual(result.text, "vault set MY_KEY [STORED-IN-KEYCHAIN]")
+        self.assertEqual(result.stored, ["MY_KEY"])
+
+    def test_equals_separator_quoted_value(self):
+        with _mock_store():
+            result = intercept_vault_commands('vault set API_KEY="secret value here"')
+        self.assertEqual(result.text, "vault set API_KEY [STORED-IN-KEYCHAIN]")
+        self.assertEqual(result.stored, ["API_KEY"])
+
+    def test_equals_first_only_value_keeps_rest(self):
+        # Only the FIRST `=` is the separator; `=` inside the value is kept.
+        stored_value = []
+        def _capture_run(cmd, **kw):
+            if "add-generic-password" in cmd:
+                stored_value.append(cmd[cmd.index("-w") + 1])
+            return MagicMock(returncode=0)
+        with patch("vault_intercept.subprocess.run", side_effect=_capture_run), \
+             patch.object(vault_intercept, "_register_key"):
+            intercept_vault_commands('vault set TOK="ab=cd=="')
+        self.assertEqual(stored_value, ["ab=cd=="])
+
+    def test_space_form_still_intercepts(self):
+        # Regression: the original space-separated form is unaffected.
+        with _mock_store():
+            value = "sk-" + "a"*20 + "T3BlbkFJ" + "b"*20
+            result = intercept_vault_commands(f"vault set MY_KEY {value}")
+        self.assertEqual(result.stored, ["MY_KEY"])
+
     def test_surrounded_by_prose(self):
         with _mock_store():
             value = "sk-" + "a"*20 + "T3BlbkFJ" + "b"*20


### PR DESCRIPTION
## Problem (security)
The vault interceptor regex required `vault set KEY VALUE` (whitespace separator). With `vault set KEY=VALUE` the `(\S+)` key group swallowed `KEY=VALUE` whole, the required `\s+value` never matched → **no interception → the raw secret was written to the task file in plaintext**.

Live incident 2026-06-22: an owner `vault set X_BEARER_TOKEN=<token>` landed unredacted on disk (and in `discord-bridge.log`); it had to be manually stored in Keychain + scrubbed.

## Fix
KEY group stops at the first space or `=` (`[^\s=]+`); the separator accepts `=` (with optional surrounding spaces) **or** whitespace. So `vault set KEY VALUE`, `KEY=VALUE`, and `KEY = VALUE` all intercept. Only the first `=` is the separator — `=` inside the value is preserved. Group numbering unchanged (key=1, value alternatives=2–5; separator non-capturing).

Raw-regex check of all forms incl. the exact leak string:
```
KEY VALUE                      → key='KEY'            value='VALUE'
KEY=VALUE                      → key='KEY'            value='VALUE'
KEY = VALUE                    → key='KEY'            value='VALUE'
X_BEARER_TOKEN=AAAA%3DmWhO     → key='X_BEARER_TOKEN' value='AAAA%3DmWhO'
K="a=b=c"                      → key='K'              value='a=b=c'
```

## Tests
`tests/vault-intercept.test.py` +5: bare `=`, `=` with spaces, quoted `=` value, first-`=`-only (value keeps the rest), and a space-form regression. NOTE: the bare-value cases exercise the detect-secrets FP guard so they need the `detect_secrets` dep (present in CI); the quoted-path cases + the raw-regex check above verify the fix without it.

Companion to #1743 (task-body field/fence confinement) — both close "secret/forge reaches disk unredacted" gaps.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)