### PR TITLE
fix(host-label): prefer scutil LocalHostName over DHCP hostname; unify py+bash precedence

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -205,8 +205,17 @@ _host() {
     local env="${SUTANDO_HOST_LABEL:-${SUTANDO_HOST_OVERRIDE:-}}"
     if [ -n "$env" ]; then
         printf '%s\n' "$env"
-    elif command -v scutil >/dev/null 2>&1 && scutil --get LocalHostName >/dev/null 2>&1; then
-        scutil --get LocalHostName
+        return
+    fi
+    # Capture scutil ONCE and guard exit-0-but-empty output (parity with the
+    # py side's non-empty `.strip()` check) — an empty LocalHostName must not
+    # win over the hostname fallback.
+    local lhn=""
+    if command -v scutil >/dev/null 2>&1; then
+        lhn="$(scutil --get LocalHostName 2>/dev/null)"
+    fi
+    if [ -n "$lhn" ]; then
+        printf '%s\n' "$lhn"
     else
         hostname | sed 's/\..*//'
     fi

--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -195,8 +195,18 @@ die() {
 # (sutando-workspace.test.sh Test 23, Codex P1.3 reproducer). Not for
 # production use.
 _host() {
-    if [ -n "${SUTANDO_HOST_OVERRIDE:-}" ]; then
-        printf '%s\n' "$SUTANDO_HOST_OVERRIDE"
+    # Lockstep with `_host_label()` in src/util_paths.py. Precedence:
+    #   1. $SUTANDO_HOST_LABEL (or legacy $SUTANDO_HOST_OVERRIDE)
+    #   2. macOS `scutil --get LocalHostName` (stable Bonjour name)
+    #   3. short `hostname`
+    # scutil before hostname because a DHCP-assigned hostname can drift (e.g.
+    # Comcast → Chis-MBP) and split per-host paths/branches from the stable
+    # LocalHostName (Chis-MacBook-Pro). 2026-06-22 incident.
+    local env="${SUTANDO_HOST_LABEL:-${SUTANDO_HOST_OVERRIDE:-}}"
+    if [ -n "$env" ]; then
+        printf '%s\n' "$env"
+    elif command -v scutil >/dev/null 2>&1 && scutil --get LocalHostName >/dev/null 2>&1; then
+        scutil --get LocalHostName
     else
         hostname | sed 's/\..*//'
     fi

--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -20,6 +20,7 @@ Usage:
 from __future__ import annotations
 import os
 import socket
+import subprocess
 import sys
 from pathlib import Path
 
@@ -82,13 +83,36 @@ def _workspace_root() -> Path:
 
 
 def _host_label() -> str:
-    r"""Per-host directory label: `$SUTANDO_HOST_LABEL` or short hostname.
+    r"""Per-host directory label. Precedence:
+      1. `$SUTANDO_HOST_LABEL` (or legacy `$SUTANDO_HOST_OVERRIDE`)
+      2. macOS `scutil --get LocalHostName` (the stable Bonjour name)
+      3. short `hostname`
+
+    Why scutil before hostname: on DHCP networks `hostname` can drift (e.g. a
+    Comcast residential lease returns `Chis-MBP.hsd1.wa.comcast.net` →
+    `Chis-MBP`), while the Bonjour LocalHostName (`Chis-MacBook-Pro`) is stable.
+    A drifting `hostname` splits per-host paths — two `hosts/<label>/` dirs,
+    phantom `state/cores/<label>.alive`, and `personal_path()` falling back to
+    the workspace root (2026-06-22 incident). `scutil` is macOS-only; on Linux
+    it's absent and we fall through to `hostname`.
 
     Single source of truth for the per-host segment so the legacy
     `machine-<host>/` (memory-dir) and new `hosts/<host>/` (workspace)
-    conventions stay in lockstep. Matches `_host()` in sync-workspace.sh
-    and the crons-path host derivation (`hostname | sed 's/\..*//'`)."""
-    return os.environ.get("SUTANDO_HOST_LABEL") or socket.gethostname().split(".")[0]
+    conventions stay in lockstep. Kept in lockstep with `_host()` in
+    sync-workspace.sh (same precedence)."""
+    env = os.environ.get("SUTANDO_HOST_LABEL") or os.environ.get("SUTANDO_HOST_OVERRIDE")
+    if env:
+        return env
+    try:
+        out = subprocess.run(
+            ["scutil", "--get", "LocalHostName"],
+            capture_output=True, text=True, timeout=2,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return socket.gethostname().split(".")[0]
 
 
 def _private_machine_dir() -> Path | None:

--- a/tests/host-label-scutil-bash.test.sh
+++ b/tests/host-label-scutil-bash.test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Bash _host() precedence test — the bash-side mirror of
+# tests/host-label-scutil.test.py. Guards: env wins (scutil not consulted),
+# scutil LocalHostName over a drifting hostname, and — the py/bash parity fix —
+# an exit-0-but-EMPTY scutil output falls back to hostname rather than winning.
+#
+#   bash tests/host-label-scutil-bash.test.sh
+set -u
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts/sync-workspace.sh"
+# Source ONLY the _host() definition — avoids running the script's main body.
+eval "$(sed -n '/^_host()/,/^}/p' "$SCRIPT")"
+
+fail=0
+check() { # desc expected actual
+    if [ "$2" = "$3" ]; then printf 'ok   - %s\n' "$1"
+    else printf 'FAIL - %s (want=%q got=%q)\n' "$1" "$2" "$3"; fail=1; fi
+}
+
+# Stub bin: scutil reads $FAKE_LHN / $FAKE_RC; hostname reads $FAKE_HOSTNAME.
+BIN="$(mktemp -d)"
+cat > "$BIN/scutil" <<'EOF'
+#!/usr/bin/env bash
+[ "${FAKE_RC:-0}" -ne 0 ] && exit "$FAKE_RC"
+printf '%s\n' "${FAKE_LHN-}"
+EOF
+cat > "$BIN/hostname" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_HOSTNAME:-box.local}"
+EOF
+chmod +x "$BIN/scutil" "$BIN/hostname"
+export PATH="$BIN:$PATH"
+
+out="$(SUTANDO_HOST_LABEL=Pinned FAKE_LHN=ShouldNotWin _host)"
+check "env SUTANDO_HOST_LABEL wins (scutil not consulted)" "Pinned" "$out"
+
+out="$(unset SUTANDO_HOST_LABEL; SUTANDO_HOST_OVERRIDE=Legacy _host)"
+check "legacy SUTANDO_HOST_OVERRIDE honored" "Legacy" "$out"
+
+out="$(unset SUTANDO_HOST_LABEL SUTANDO_HOST_OVERRIDE; FAKE_LHN=Chis-MacBook-Pro FAKE_HOSTNAME=Chis-MBP.hsd1.wa.comcast.net _host)"
+check "scutil LocalHostName over drifting hostname" "Chis-MacBook-Pro" "$out"
+
+out="$(unset SUTANDO_HOST_LABEL SUTANDO_HOST_OVERRIDE; FAKE_LHN= FAKE_HOSTNAME=fallback.local _host)"
+check "scutil exit-0 EMPTY falls back to hostname" "fallback" "$out"
+
+out="$(unset SUTANDO_HOST_LABEL SUTANDO_HOST_OVERRIDE; FAKE_RC=1 FAKE_HOSTNAME=slow.local _host)"
+check "scutil nonzero falls back to hostname" "slow" "$out"
+
+rm -rf "$BIN"
+[ "$fail" -eq 0 ] && echo "PASS (5 cases)" || echo "FAILED"
+exit $fail

--- a/tests/host-label-scutil.test.py
+++ b/tests/host-label-scutil.test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""util_paths._host_label precedence: env → scutil LocalHostName → hostname.
+
+Guards the DHCP-hostname-drift fix: a drifting `hostname` must not override the
+stable Bonjour LocalHostName on macOS. Run:
+  python3 tests/host-label-scutil.test.py
+"""
+import os, sys, unittest
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+import util_paths  # noqa: E402
+
+
+def _scutil(rc=0, out="Chis-MacBook-Pro"):
+    return MagicMock(returncode=rc, stdout=out)
+
+
+class HostLabelPrecedence(unittest.TestCase):
+    def setUp(self):
+        # Clear both env vars by default; tests opt in.
+        self._patcher = patch.dict(os.environ, {}, clear=False)
+        for k in ("SUTANDO_HOST_LABEL", "SUTANDO_HOST_OVERRIDE"):
+            os.environ.pop(k, None)
+
+    def test_env_label_wins(self):
+        with patch.dict(os.environ, {"SUTANDO_HOST_LABEL": "Pinned"}), \
+             patch.object(util_paths.subprocess, "run") as run:
+            self.assertEqual(util_paths._host_label(), "Pinned")
+            run.assert_not_called()  # env short-circuits before scutil
+
+    def test_legacy_override_env_honored(self):
+        with patch.dict(os.environ, {"SUTANDO_HOST_OVERRIDE": "Legacy"}), \
+             patch.object(util_paths.subprocess, "run") as run:
+            self.assertEqual(util_paths._host_label(), "Legacy")
+            run.assert_not_called()
+
+    def test_scutil_localhostname_over_hostname(self):
+        with patch.object(util_paths.subprocess, "run", return_value=_scutil(0, "Chis-MacBook-Pro\n")), \
+             patch.object(util_paths.socket, "gethostname", return_value="Chis-MBP.hsd1.wa.comcast.net"):
+            self.assertEqual(util_paths._host_label(), "Chis-MacBook-Pro")
+
+    def test_scutil_nonzero_falls_back_to_hostname(self):
+        with patch.object(util_paths.subprocess, "run", return_value=_scutil(1, "")), \
+             patch.object(util_paths.socket, "gethostname", return_value="box.local"):
+            self.assertEqual(util_paths._host_label(), "box")
+
+    def test_scutil_missing_falls_back_to_hostname(self):
+        # Linux / scutil absent → OSError → hostname.
+        with patch.object(util_paths.subprocess, "run", side_effect=FileNotFoundError), \
+             patch.object(util_paths.socket, "gethostname", return_value="linuxhost"):
+            self.assertEqual(util_paths._host_label(), "linuxhost")
+
+    def test_scutil_empty_output_falls_back(self):
+        with patch.object(util_paths.subprocess, "run", return_value=_scutil(0, "  \n")), \
+             patch.object(util_paths.socket, "gethostname", return_value="fallback.local"):
+            self.assertEqual(util_paths._host_label(), "fallback")
+
+    def test_scutil_timeout_falls_back(self):
+        import subprocess as _sp
+        with patch.object(util_paths.subprocess, "run", side_effect=_sp.TimeoutExpired("scutil", 2)), \
+             patch.object(util_paths.socket, "gethostname", return_value="slow.local"):
+            self.assertEqual(util_paths._host_label(), "slow")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
The per-host label is derived from `hostname`, which on DHCP networks can drift — a Comcast residential lease returns `Chis-MBP.hsd1.wa.comcast.net` → `Chis-MBP`, while the machine's stable Bonjour name (`scutil --get LocalHostName` = `Chis-MacBook-Pro`) does not. A drifting label splits per-host state: two `hosts/<label>/` dirs, a phantom `state/cores/<label>.alive`, and `personal_path()` falling back to the workspace root — the symptom this session was the pending-questions cron reading a stale root file and false-notifying.

Two resolvers had also diverged: `_host_label()` (py) honored `$SUTANDO_HOST_LABEL` while `sync-workspace.sh _host()` honored a *different* var (`$SUTANDO_HOST_OVERRIDE`) — so the documented `.env` pin never reached the bash sync, and both fell back to `hostname`.

## Fix
One shared precedence in both `src/util_paths.py:_host_label()` and `scripts/sync-workspace.sh:_host()`:
```
env ($SUTANDO_HOST_LABEL → legacy $SUTANDO_HOST_OVERRIDE) → scutil --get LocalHostName (macOS) → short hostname
```
`scutil` is macOS-only; on Linux it's absent and we fall through to `hostname`. Only nodes on the revamped code run this; pinned pre-revamp nodes are unaffected until migration. On this host, `hostname` and `scutil` currently both return `Chis-MacBook-Pro` — the fix makes the resolution robust to the next DHCP flap.

This lets the per-cron `SUTANDO_HOST_LABEL=` band-aids (check-pending-questions, morning-briefing) be retired once it lands.

## Tests
`tests/host-label-scutil.test.py` — 7 cases: env wins (+ no scutil call), legacy override env, scutil-over-hostname, and scutil nonzero / missing (Linux) / empty / timeout → hostname fallback. bash `_host()` branches verified live. No regression: `util-paths-hosts-resolution`, `hostname-resolution-resilience`, `host-cli-dependency-snapshot` (0 new CLI-dep violations), `workspace-default` all pass.

Completes the hostname-resilience work started in #1739.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)