### PR TITLE
feat(web-client): SSE gui-command endpoint for server-triggered localStorage cleanup

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -856,6 +856,27 @@ function initRemoteToggle() {
       });
     } catch {}
   });
+  _sseSource.addEventListener('gui-command', (e) => {
+    try {
+      var cmd = JSON.parse(String(e.data || '{}'));
+      if (cmd.command === 'clear_tasks_history') {
+        var keepN = typeof cmd.keep === 'number' ? cmd.keep : 0;
+        try {
+          var raw = localStorage.getItem('sutando-taskmap-v1');
+          if (raw) {
+            var m = JSON.parse(raw);
+            var entries = Object.entries(m).sort(function(a, b) {
+              return new Date(a[1].time).getTime() - new Date(b[1].time).getTime();
+            });
+            var toRemove = Math.max(0, entries.length - keepN);
+            entries.slice(0, toRemove).forEach(function(pair) { delete m[pair[0]]; });
+            localStorage.setItem('sutando-taskmap-v1', JSON.stringify(m));
+          }
+        } catch {}
+        renderTasks();
+      }
+    } catch {}
+  });
   _sseSource.onerror = () => setTimeout(() => initRemoteToggle(), 5000);
 }
 initRemoteToggle();
@@ -3878,6 +3899,29 @@ const server = createServer((req, res) => {
 			res.writeHead(500, { 'Content-Type': 'application/json' });
 			res.end(JSON.stringify({ ok: false, error: 'failed to enqueue scan' }));
 		}
+		return;
+	}
+
+	// Broadcast a gui-command SSE event to all connected browser tabs.
+	// POST /gui/command  body: { "command": "clear_tasks_history", "keep": 50 }
+	if (url.pathname === '/gui/command' && req.method === 'POST') {
+		const chunks: Buffer[] = [];
+		req.on('data', (c: Buffer) => chunks.push(c));
+		req.on('end', () => {
+			try {
+				const body = JSON.parse(Buffer.concat(chunks).toString() || '{}');
+				const event = `event: gui-command\ndata: ${JSON.stringify(body)}\n\n`;
+				let sent = 0;
+				for (const client of sseClients) {
+					try { client.write(event); sent++; } catch {}
+				}
+				res.writeHead(200, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify({ ok: true, clients: sent }));
+			} catch (e: any) {
+				res.writeHead(400, { 'Content-Type': 'application/json' });
+				res.end(JSON.stringify({ ok: false, error: String(e?.message) }));
+			}
+		});
 		return;
 	}
 

--- a/tests/web-client-gui-command.test.py
+++ b/tests/web-client-gui-command.test.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Structural regression test for web-client.ts POST /gui/command endpoint.
+
+Guards the clear_tasks_history feature (added 2026-06-22):
+  POST /gui/command {"command":"clear_tasks_history","keep":N}
+  → SSE broadcast of gui-command event to all connected browser tabs
+  → browser handler clears localStorage sutando-taskmap-v1 keeping N newest
+
+Run: python3 tests/web-client-gui-command.test.py
+Exit: 0 = all pass, 1 = failure
+"""
+from __future__ import annotations
+import sys
+import unittest
+from pathlib import Path
+
+SRC = (Path(__file__).resolve().parent.parent / "src" / "web-client.ts").read_text()
+
+
+class TestGuiCommandEndpoint(unittest.TestCase):
+    """POST /gui/command must exist as a server-side handler."""
+
+    def test_endpoint_path_present(self):
+        self.assertIn("/gui/command", SRC, "POST /gui/command route must be present")
+
+    def test_sse_broadcast(self):
+        self.assertIn("gui-command", SRC, "endpoint must broadcast 'gui-command' SSE event")
+
+    def test_sseClients_write(self):
+        self.assertIn("sseClients", SRC, "endpoint must iterate sseClients to broadcast")
+
+
+class TestGuiCommandBrowserHandler(unittest.TestCase):
+    """Browser-side EventSource must handle gui-command events."""
+
+    def test_listener_registered(self):
+        self.assertIn(
+            "addEventListener('gui-command'",
+            SRC,
+            "browser must register 'gui-command' SSE event listener",
+        )
+
+    def test_clear_tasks_history_command(self):
+        self.assertIn(
+            "clear_tasks_history",
+            SRC,
+            "browser handler must handle clear_tasks_history command",
+        )
+
+    def test_localstorage_key(self):
+        self.assertIn(
+            "sutando-taskmap-v1",
+            SRC,
+            "handler must reference the localStorage key sutando-taskmap-v1",
+        )
+
+    def test_keep_param(self):
+        self.assertIn(
+            "keepN",
+            SRC,
+            "handler must support keep=N param to retain N most recent tasks",
+        )
+
+
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(sys.modules[__name__])
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)


### PR DESCRIPTION
## Summary

- Adds `POST /gui/command` endpoint to `src/web-client.ts` that broadcasts an SSE `gui-command` event to all connected browser tabs
- Adds a browser-side `gui-command` SSE listener inside `initRemoteToggle()` that handles `clear_tasks_history` — deletes the oldest `N` entries from `localStorage['sutando-taskmap-v1']` keeping the `keep` most recent, then re-renders the Tasks tab
- Adds 7 structural regression tests in `tests/web-client-gui-command.test.py` (3 server-side, 4 browser-side; all pass)
- **Housekeeping**: also adds `xingyu_xiang_2026.{aux,out,pdf}` to `.gitignore` (personal LaTeX build artifacts; happy to split to a separate PR if preferred)

## Motivation

The Tasks tab badge (`_drTaskCount`) counts every entry in `sutando-taskmap-v1` since it accumulates indefinitely, causing the count to balloon (e.g. 361 tasks from months of use). Chrome's JS-from-AppleEvents is disabled, so browser automation cannot clear localStorage directly. The SSE broadcast path is the clean server-triggered solution.

## Usage

```bash
# keep the 50 most recent tasks, delete the rest
curl -X POST http://localhost:8080/gui/command \
  -H 'Content-Type: application/json' \
  -d '{"command":"clear_tasks_history","keep":50}'
```

The voice agent can trigger this after a user says "clean up the task history". Browser tab must be open (and page refreshed once after deployment) to receive the event.

## Files changed

- `src/web-client.ts` — server-side POST handler (~20 lines before `res.end(HTML)`) + browser-side SSE listener (~18 lines after `_sseSource.onerror`)
- `tests/web-client-gui-command.test.py` — 7 structural regression tests
- `.gitignore` — exclude personal LaTeX build artifacts (5 lines)

## Tests

```
python3 tests/web-client-gui-command.test.py
Ran 7 tests in 0.000s — OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yLYcCwmnnJWWB7962jBhv
