### PR TITLE
fix(task-progress): send DiscordBot User-Agent on notify POSTs — dodge Cloudflare 1010

### DIFF
--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -87,7 +87,11 @@ def send_discord(channel_id: str, message: str) -> bool:
     return _post(
         f"https://discord.com/api/v10/channels/{channel_id}/messages",
         {"content": message},
-        {"Authorization": f"Bot {token}"},
+        # Discord's API (behind Cloudflare) 403s the default `Python-urllib/x`
+        # User-Agent with Cloudflare error 1010. Discord requires the
+        # `DiscordBot ($url, $version)` UA format — send it or every POST fails.
+        {"Authorization": f"Bot {token}",
+         "User-Agent": "DiscordBot (https://github.com/sonichi/sutando, 1.0)"},
     )
 
 


### PR DESCRIPTION
## What

`send_discord()` in the task-progress notify helper (`skills/task-progress/scripts/notify.py`) POSTs to the Discord API with the default `Python-urllib/x` User-Agent. Discord sits behind Cloudflare, which **403s that UA with error 1010** — so every notify POST failed silently.

That breaks the "**notify BEFORE doing any work**" step CLAUDE.md mandates for Discord-sourced tasks: the user got silence instead of the "On it — back in a moment" ack.

## Fix

Send Discord's required `DiscordBot ($url, $version)` User-Agent format. Header-only; no behavior change beyond the added header.

```python
{"Authorization": f"Bot {token}",
 "User-Agent": "DiscordBot (https://github.com/sonichi/sutando, 1.0)"}
```

## Notes
- Bug confirmed present on `main` (no User-Agent header in `send_discord`).
- Single-concern, one-line header addition. Slack/Telegram paths untouched.
- Unrelated to the stalled DRAFT #968 (a larger declarative-ping skill rewrite); this is a targeted bugfix to the existing live helper.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)