### PR TITLE
fix(self-diagnose): read pending-questions.md from hosts/<host>/ first (per-host #1717)

### DIFF
--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -57,6 +57,27 @@ else
 	NOTES_DIR="$REPO/notes"
 fi
 
+# Per-host label for hosts/<host>/ paths. Lockstep with `_host()`
+# (scripts/sync-workspace.sh) and `_host_label()` (src/util_paths.py):
+# $SUTANDO_HOST_LABEL > scutil LocalHostName (stable) > short hostname (which
+# can DHCP-drift, e.g. Comcast → Chis-MBP, splitting per-host paths; #1745).
+_sd_host() {
+	local env="${SUTANDO_HOST_LABEL:-${SUTANDO_HOST_OVERRIDE:-}}"
+	if [ -n "$env" ]; then
+		printf '%s\n' "$env"
+		return
+	fi
+	local lhn=""
+	if command -v scutil >/dev/null 2>&1; then
+		lhn="$(scutil --get LocalHostName 2>/dev/null)"
+	fi
+	if [ -n "$lhn" ]; then
+		printf '%s\n' "$lhn"
+	else
+		hostname | sed 's/\..*//'
+	fi
+}
+
 # Convert window to seconds for log filtering
 case "$WINDOW" in
 	*h) SECONDS_AGO=$((${WINDOW%h} * 3600)) ;;
@@ -103,7 +124,13 @@ fi
 # 3) Build log tail + pending questions + cold-review log (small files, copy whole)
 _bl="${WS}/build_log.md"; [ -f "$_bl" ] || _bl="${REPO}/build_log.md"
 tail -150 "$_bl" > "$OUT/build_log-tail.md" 2>/dev/null || true
-_pq="${WS}/pending-questions.md"; [ -f "$_pq" ] || _pq="${REPO}/pending-questions.md"
+# pending-questions.md is per-host (hosts/<host>/, #1717 F1 convention); probe
+# there FIRST, then the flat workspace root and repo root (back-compat for
+# pre-revamp / un-migrated layouts). Mirrors personal_path()'s read-side probe
+# order (#1718) so self-diagnose reads the same file the writers target.
+_pq="${WS}/hosts/$(_sd_host)/pending-questions.md"
+[ -f "$_pq" ] || _pq="${WS}/pending-questions.md"
+[ -f "$_pq" ] || _pq="${REPO}/pending-questions.md"
 cp "$_pq" "$OUT/pending-questions.md" 2>/dev/null || true
 cp "$NOTES_DIR/cold-review-log.md" "$OUT/cold-review-log.md" 2>/dev/null || true
 


### PR DESCRIPTION
## What

`skills/self-diagnose/scripts/gather.sh` read `pending-questions.md` only from the **flat workspace root** (`$WS/pending-questions.md`, then `$REPO/...`). The workspace-revamp moved per-host files to `hosts/<host>/` (#1717, F1 owner decision), so on the new layout `/self-diagnose` copied a **stale or empty** pending-questions into its bundle.

## Fix

Probe `hosts/<host>/pending-questions.md` **first**, then fall back to the flat workspace root and repo root (back-compat for un-migrated installs). Host label is resolved with the **same precedence as `_host()` (sync-workspace.sh) / `_host_label()` (util_paths.py)**: `$SUTANDO_HOST_LABEL` > `scutil --get LocalHostName` > short `hostname`. This matters: a raw `hostname` can DHCP-drift (e.g. `Chis-MBP`) and miss the scutil-stable `Chis-MacBook-Pro` subtree where the writer actually put the file (#1745). Mirrors `personal_path()`'s read-side probe order (#1718).

## Verification

On this node (Echo Act IV Pro), `scutil LocalHostName` = `Chis-MacBook-Pro`; the per-host file **exists** at `hosts/Chis-MacBook-Pro/pending-questions.md` and was being missed by raw-`hostname` readers (which resolve `Chis-MBP`). After the fix the probe resolves to the correct per-host file. `bash -n` clean.

## Scope

- Single file, read-side only, additive (no writer change).
- `build_log.md` intentionally left reading from workspace root — it's dual-location (live at root, mirrored to hosts/) by design, not per-host-only.
- One of two leftover per-host readers; the sibling is the Swift app (`main.swift`), which needs an app rebuild and is tracked separately.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)