### PR TITLE
fix(app): read pending-questions.md from hosts/<host>/ first (per-host #1717)

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -544,6 +544,34 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         logToFile("watcher dead; notification fired (tmux session not found)")
     }
 
+    /// Per-host label for `hosts/<host>/` paths. Lockstep with `_host_label()`
+    /// (src/util_paths.py) and `_host()` (scripts/sync-workspace.sh):
+    /// $SUTANDO_HOST_LABEL > scutil LocalHostName (stable) > short hostname
+    /// (a raw hostname can DHCP-drift, e.g. Comcast → Chis-MBP, splitting
+    /// per-host paths from the scutil-named Chis-MacBook-Pro subtree; #1745).
+    func perHostLabel() -> String {
+        let env = ProcessInfo.processInfo.environment
+        if let v = env["SUTANDO_HOST_LABEL"] ?? env["SUTANDO_HOST_OVERRIDE"], !v.isEmpty {
+            return v
+        }
+        if let lhn = runShell("/usr/sbin/scutil", ["--get", "LocalHostName"])?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !lhn.isEmpty {
+            return lhn
+        }
+        let host = ProcessInfo.processInfo.hostName
+        return host.split(separator: ".").first.map(String.init) ?? host
+    }
+
+    /// Resolve a per-host workspace file: prefer `<workspace>/hosts/<host>/<name>`
+    /// (the #1717 per-host home the writers target), fall back to the flat
+    /// `<workspace>/<name>` for un-migrated layouts. Mirrors personal_path()'s
+    /// read-side probe order (#1718).
+    func perHostPath(_ name: String) -> String {
+        let perHost = workspace + "/hosts/" + perHostLabel() + "/" + name
+        if FileManager.default.fileExists(atPath: perHost) { return perHost }
+        return workspace + "/" + name
+    }
+
     /// Refresh `contextual-chips.json` from cheap mechanical sources. No LLM
     /// round-trip — just shell-out to `gh pr list`, read top `## Title` line
     /// of `pending-questions.md`, scan `results/` for unread items. Atomic
@@ -587,7 +615,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // 2. Top pending question (read first `## Title` line of pending-questions.md).
-        let pqPath = workspace + "/pending-questions.md"
+        // pending-questions.md is per-host (hosts/<host>/, #1717 F1) — probe there
+        // first so the chip reflects THIS host's questions, not a stale flat-root copy.
+        let pqPath = perHostPath("pending-questions.md")
         if let pq = try? String(contentsOfFile: pqPath, encoding: .utf8) {
             // Skip the leading "# Memory" or similar h1, find first h2.
             for line in pq.split(separator: "\n") {


### PR DESCRIPTION
## What

Sutando.app's contextual-chips refresher (`main.swift` `refreshContextualChips`) read `pending-questions.md` from the **flat workspace root**, missing the per-host `hosts/<host>/` location the workspace-revamp (#1717, F1) writes to. So the "Pending:" chip showed a **stale/empty** question on the new layout — observed live: it was surfacing the already-resolved "21 commits behind origin/main" entry.

## Fix

- `perHostLabel()` — `$SUTANDO_HOST_LABEL` > `scutil --get LocalHostName` > short `hostname`, **lockstep with `_host_label()` (util_paths.py) / `_host()` (sync-workspace.sh)**. A raw `hostname` can DHCP-drift to `Chis-MBP` and miss the scutil-named `Chis-MacBook-Pro` subtree where the writers put the file (#1745).
- `perHostPath(_:)` — probe `hosts/<host>/<name>` first, fall back to flat `<workspace>/<name>` for un-migrated layouts. Mirrors `personal_path()`'s read-side probe (#1718).
- Point the pending-questions read at `perHostPath("pending-questions.md")`.

The **Swift counterpart of #1757** (gather.sh) — closes the last of the two leftover per-host readers flagged in the workspace-revamp validation.

## Verification

`swiftc -O -o /tmp/... main.swift SutandoConfig.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation` → **builds clean** (live binary untouched). On this node `scutil LocalHostName` = `Chis-MacBook-Pro` and the per-host file exists at `hosts/Chis-MacBook-Pro/pending-questions.md`, which the new probe now resolves.

## Note

Compiled app — takes effect on the **next app rebuild + re-sign**, after which Accessibility/TCC must be re-granted (codesign change orphans the grant). Code-only change here; the rebuild is owner-timed.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)