### PR TITLE
fix(credential-proxy): add idle timeout so a hung upstream can't freeze the agent

### DIFF
--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -21,6 +21,14 @@ import { statusPath } from '../../../src/workspace_default.js';
 
 const PORT = 7846;
 const UPSTREAM = 'https://api.anthropic.com';
+// Idle (inactivity) timeout in ms for the upstream connection. The socket timer
+// resets on every byte sent or received, so a healthy long stream never trips it
+// (Anthropic's SSE ping cadence is ~25s); it only fires when the connection has
+// genuinely gone dead — sleep/wake, wifi drop, gateway unreachable mid-flight.
+// Node sets no default request timeout, so without this an in-flight request
+// hangs forever and freezes the agent until a full app restart. Override via
+// SUTANDO_PROXY_TIMEOUT_MS; default 120s.
+const UPSTREAM_IDLE_TIMEOUT_MS = Number(process.env.SUTANDO_PROXY_TIMEOUT_MS) || 120_000;
 // Quota state is per-user runtime state — canonical home is <workspace>/state/.
 // Historically written into the skill dir; readers (dashboard.py, read-quota.py)
 // keep the skill-dir path as a last-resort fallback for one release.
@@ -114,6 +122,8 @@ const server = createServer((req, res) => {
 			headers['authorization'] = `Bearer ${oauthToken}`;
 		}
 
+		let timedOut = false;
+
 		const upstream = httpsRequest(
 			{
 				hostname: upstreamUrl.hostname,
@@ -121,6 +131,7 @@ const server = createServer((req, res) => {
 				path: req.url,
 				method: req.method,
 				headers,
+				timeout: UPSTREAM_IDLE_TIMEOUT_MS,
 			} as RequestOptions,
 			(upRes) => {
 				// Extract rate limit headers
@@ -140,12 +151,31 @@ const server = createServer((req, res) => {
 			},
 		);
 
+		// 'timeout' fires on socket inactivity but does NOT auto-abort — destroy the
+		// request so it surfaces through the 'error' handler below as a clean failure
+		// (and Claude Code's own retry kicks in) instead of hanging indefinitely.
+		upstream.on('timeout', () => {
+			timedOut = true;
+			console.error(`${ts()} [Proxy] Upstream idle >${UPSTREAM_IDLE_TIMEOUT_MS}ms — aborting`);
+			upstream.destroy(new Error('upstream idle timeout'));
+		});
+
 		upstream.on('error', (err) => {
 			console.error(`${ts()} [Proxy] Upstream error:`, err.message);
 			if (!res.headersSent) {
-				res.writeHead(502);
-				res.end('Bad Gateway');
+				res.writeHead(timedOut ? 504 : 502);
+				res.end(timedOut ? 'Gateway Timeout' : 'Bad Gateway');
+			} else {
+				// Headers already streamed — can't change status. Tear down the client
+				// connection so the agent sees a broken stream and retries rather than
+				// waiting forever on a dead upstream.
+				res.destroy(err);
 			}
+		});
+
+		// If the agent hangs up first, don't leak the in-flight upstream request.
+		res.on('close', () => {
+			if (!res.writableEnded) upstream.destroy();
 		});
 
 		upstream.write(body);


### PR DESCRIPTION
## Summary

Every model call routes through the local credential proxy (`localhost:7846`), which forwards to `api.anthropic.com` via `https.request`. Node sets **no default timeout** on that request. When the network blips mid-flight (sleep/wake, wifi drop, gateway briefly unreachable), the upstream socket goes silent instead of erroring — the request never completes and never fails, so the proxy and the agent waiting on it **hang indefinitely**. Only a full app restart clears it.

## Fix

Add an **idle** timeout on the upstream request in `credential-proxy.ts`:

- `timeout` option (`SUTANDO_PROXY_TIMEOUT_MS`, default **120s**). Socket-idle based — it resets on every byte, so a healthy long SSE stream never trips it (Anthropic's ping cadence is ~25s); only a genuinely dead connection does.
- On `'timeout'`, `destroy()` the request so it surfaces as a clean **504** through the existing error handler, letting Claude Code's own retry logic take over instead of hanging.
- If response headers were already streamed, tear down the client connection (`res.destroy`) so the agent sees a broken stream rather than waiting on a dead upstream.
- Clean up the in-flight upstream request if the agent disconnects first.

## Why idle, not absolute

An absolute timeout would truncate long legitimate generations. The socket idle timer resets on every chunk, so it never interrupts a healthy stream — it only fires when bytes genuinely stop flowing.

## Test plan

- [x] `esbuild` transform of the edited file: clean
- [x] Simulated a hung upstream (a local server that accepts the TCP connection but never replies — the wifi-drop case): the `timeout` fired at the configured interval, `destroy()` routed through `'error'`, and the timeout flag produced a **504**. Healthy traffic is unaffected since the timer resets on activity.

## Prior art

#1669 (closed by its author as unsolicited, not for any technical reason) proposed the same idle-timeout fix with integration tests, but it was stacked on the now-closed #1668 and lives on a fork that can't be modified. This is a minimal, single-concern version based on current `main`. Happy to port #1669's integration test on top if reviewers want regression coverage in-tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
