### PR TITLE
fix(startup,discord-bridge): health-aware bridge guard via liveness heartbeat

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2273,6 +2273,29 @@ def _recover_orphan_sending_files() -> int:
     return recovered
 
 
+HEARTBEAT_FILE = STATE_DIR / "discord-bridge.heartbeat"
+HEARTBEAT_INTERVAL_S = 30
+
+
+async def _heartbeat_loop():
+    """Liveness heartbeat: rewrite state/discord-bridge.heartbeat every 30s
+    while the asyncio event loop is alive. startup.sh's bridge guard reads
+    this file's mtime to distinguish a HUNG bridge (process present but event
+    loop stalled → heartbeat goes stale) from a healthy-but-idle one (no
+    Discord traffic, loop still ticking → heartbeat stays fresh). A bare
+    `pgrep` can't make that distinction, so a hung bridge was treated as
+    "already running" and blocked its own restart — the 2026-06-23 bridge-down
+    incident. Writes once immediately so a freshly-(re)started bridge is
+    visible within seconds, not after the first interval."""
+    while True:
+        try:
+            STATE_DIR.mkdir(parents=True, exist_ok=True)
+            HEARTBEAT_FILE.write_text(str(int(time.time())))
+        except Exception as exc:
+            print(f"  [heartbeat] write failed (non-fatal): {exc}", flush=True)
+        await asyncio.sleep(HEARTBEAT_INTERVAL_S)
+
+
 @client.event
 async def on_ready():
     print(f"Discord bridge ready: {client.user}")
@@ -2305,6 +2328,10 @@ async def on_ready():
     client.loop.create_task(poll_dm_fallback())
     # Auto-mod LLM-judge flush timer (per-guild gate enforced inside flush)
     client.loop.create_task(_mod_flush_timer_loop())
+    # Liveness heartbeat — lets startup.sh's guard tell a hung bridge from a
+    # healthy-idle one (see _heartbeat_loop). Started last so it reflects a
+    # fully-initialized bridge.
+    client.loop.create_task(_heartbeat_loop())
 
 
 def _message_mentions_bot(message):

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -808,12 +808,33 @@ if _DC_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels/d
   fi
   if [ -z "$PYTHON_WITH_DISCORD" ]; then
     echo "  ~ discord bridge (no python with discord.py — run: /opt/homebrew/bin/pip3 install discord.py)"
-  elif ! pgrep -f "discord-bridge" > /dev/null 2>&1; then
-    echo "  Starting Discord bridge with $PYTHON_WITH_DISCORD..."
-    "$PYTHON_WITH_DISCORD" src/discord-bridge.py > "$LOGS_DIR/discord-bridge.log" 2>&1 &
-    echo "  ✓ discord bridge"
   else
-    echo "  ✓ discord bridge (already running)"
+    # Health-aware guard (2026-06-23 bridge-down incident): a bare `pgrep`
+    # treats a HUNG bridge (process alive, event loop stalled) as "already
+    # running" and never replaces it — exactly what stranded owner DMs that
+    # day. Gate on the bridge liveness heartbeat instead
+    # (state/discord-bridge.heartbeat, rewritten every 30s by _heartbeat_loop):
+    # present + heartbeat <90s old = healthy; present + stale-or-missing =
+    # hung (or a pre-heartbeat build) → reap + restart; absent = start.
+    _dc_hb="$WORKSPACE/state/discord-bridge.heartbeat"
+    if pgrep -f "discord-bridge\.py$" > /dev/null 2>&1; then _dc_running=1; else _dc_running=0; fi
+    _dc_fresh=0
+    if [ "$_dc_running" = 1 ] && [ -f "$_dc_hb" ]; then
+      _dc_mtime="$(stat -f %m "$_dc_hb" 2>/dev/null || stat -c %Y "$_dc_hb" 2>/dev/null || echo 0)"
+      if [ "$(( $(date +%s) - _dc_mtime ))" -lt 90 ]; then _dc_fresh=1; fi
+    fi
+    if [ "$_dc_running" = 1 ] && [ "$_dc_fresh" = 1 ]; then
+      echo "  ✓ discord bridge (already running, heartbeat fresh)"
+    else
+      if [ "$_dc_running" = 1 ]; then
+        echo "  ⚠ discord bridge present but heartbeat stale/missing (hung or pre-heartbeat build) — reaping + restarting"
+        pkill -f "discord-bridge\.py$" 2>/dev/null || true
+        sleep 1
+      fi
+      echo "  Starting Discord bridge with $PYTHON_WITH_DISCORD..."
+      "$PYTHON_WITH_DISCORD" src/discord-bridge.py > "$LOGS_DIR/discord-bridge.log" 2>&1 &
+      echo "  ✓ discord bridge"
+    fi
   fi
 else
   echo "  ~ discord bridge (no token — optional)"


### PR DESCRIPTION
## Root cause (2026-06-23 bridge-down incident)

`startup.sh`'s Discord-bridge guard used a bare `pgrep -f discord-bridge`. A **hung** bridge (process alive, asyncio event loop stalled) reads as "already running", so a plain `startup.sh` run never replaces it. That morning a bridge hung at 07:46, two later plain startups saw it and skipped, then it died — leaving **no bridge and no startup willing to start one** (`restart.sh` pkills first, but plain startups don't).

## Fix

A liveness **heartbeat** distinguishes *hung* from *healthy-idle* — which log-mtime can't (a quiet bridge writes no logs):

- **discord-bridge.py** — `_heartbeat_loop()` rewrites `state/discord-bridge.heartbeat` every 30s while the event loop is alive (started in `on_ready`, writes once immediately). A stalled loop stops touching it; an idle-but-healthy bridge keeps it fresh with zero Discord traffic.
- **startup.sh** — gate on heartbeat freshness:
  - present + heartbeat **<90s** → healthy, skip
  - present + **stale/missing** → hung (or a pre-heartbeat build) → `pkill` + restart
  - absent → start

## Limitation (documented, not hidden)

Catches a **stalled event loop / dead process** — the common "alive but doing nothing" case, which is what the incident was. A *partial* hang where the loop still services other tasks would keep the heartbeat fresh and slip past. Follow-up could add a deeper liveness probe (e.g. gateway-connected check) if that mode is ever observed.

## Verification

- `python3 -m py_compile src/discord-bridge.py` ✓
- `bash -n src/startup.sh` ✓
- Freshness arithmetic dry-tested: 0s → healthy, 200s → stale.
- Live bridge untouched; takes effect on next bridge (re)start. First startup after this lands will reap the current heartbeat-less bridge and relaunch with the new code (one-time, intended).

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)