### PR TITLE
fix(discord-bridge): vault-set intercept can't crash the handler or leak secrets

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2863,7 +2863,11 @@ async def _handle_discord_message(message, force=False):
         else:
             return
 
-    print(f"  @{username}: {text}{attachment_note}")
+    # Redact any `vault set KEY VALUE` secret before logging. Without this, the
+    # raw print lands the secret in discord-bridge.log even though the intercept
+    # below (L~2939) would store/redact it — a plaintext-secret leak to the log.
+    # (2026-06-23 incident: an owner's telegram bot token leaked here.)
+    print(f"  @{username}: {redact_vault_commands(text)}{attachment_note}")
 
     # Determine access tier
     access_tier = "other"
@@ -2936,12 +2940,21 @@ async def _handle_discord_message(message, force=False):
     # untrusted senders — the actual secret never reaches the task file either way.
     if text:
         if access_tier == "owner":
-            vault_result = intercept_vault_commands(text)
-            text = vault_result.text
-            if vault_result.stored:
-                print(f"  [vault] stored keys: {vault_result.stored}", flush=True)
-            if vault_result.failed:
-                print(f"  [vault] store failed (still redacted): {vault_result.failed}", flush=True)
+            # Defensive: a failure inside intercept_vault_commands (e.g. a missing
+            # optional dep like detect_secrets — 2026-06-23 incident) must NOT
+            # crash the message handler AND must NOT leak the secret. On any
+            # exception, fall back to redaction so the raw `vault set` value never
+            # reaches the task file / downstream — it just isn't stored to Keychain.
+            try:
+                vault_result = intercept_vault_commands(text)
+                text = vault_result.text
+                if vault_result.stored:
+                    print(f"  [vault] stored keys: {vault_result.stored}", flush=True)
+                if vault_result.failed:
+                    print(f"  [vault] store failed (still redacted): {vault_result.failed}", flush=True)
+            except Exception as _vault_exc:
+                text = redact_vault_commands(text)
+                print(f"  [vault] intercept errored ({type(_vault_exc).__name__}: {_vault_exc}) — redacted, NOT stored", flush=True)
         else:
             text = redact_vault_commands(text)
 


### PR DESCRIPTION
## Incident (2026-06-23)

An owner `vault set TELEGRAM_BOT_TOKEN <token>` in Discord **crashed the message handler and leaked the token**:
- `intercept_vault_commands` → `secret_scanner` → imports `detect_secrets`, which **wasn't installed on that node** → uncaught `ModuleNotFoundError` at discord-bridge.py:2939. Token not stored.
- Separately, the raw message text was logged at :2866 **before** the intercept ran → the `vault set … <secret>` landed in `discord-bridge.log` in plaintext.

## Fix (defense-in-depth; the secret path must fail safe)

1. **Wrap the intercept in try/except** — on ANY failure (missing optional dep, or any intercept bug), fall back to `redact_vault_commands` so the raw value never reaches the task file / downstream, and the handler keeps running. The secret simply isn't stored to Keychain — it is **never** leaked or allowed to crash processing.
2. **Redact the `@user` message log print** (:2866) so a `vault set` secret never lands in the log in plaintext, regardless of the intercept outcome (mirrors the already-redacted log at :2396).

## Not in this PR (separate provisioning fix)

The root missing dep — `detect-secrets` — **is** declared in `requirements.txt`; it just wasn't `pip install`ed on that node. That's a node-provisioning fix (`pip install -r requirements.txt`), not a code change. This PR makes the vault path safe **even when** a declared dep is missing, so a provisioning gap can't turn into a secret leak again.

## Verify

`python3 -m py_compile src/discord-bridge.py` ✓. Single file, +20/-7. `redact_vault_commands` already imported (:66).

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)