### PR TITLE
fix(vault): move key-name manifest into <workspace>/state (non-synced) + legacy read-fallback

### DIFF
--- a/src/vault_intercept.py
+++ b/src/vault_intercept.py
@@ -38,11 +38,57 @@ import json
 import os
 import re
 import subprocess
+import sys
 from datetime import datetime, timezone
 from typing import NamedTuple
 
 _ACCOUNT = "sutando"
-_MANIFEST_PATH = os.path.expanduser("~/.sutando-secret-vault/keys.json")
+
+# The manifest is the NON-SECRET index of key NAMES (values live in macOS
+# Keychain, per-host, never synced). Canonical location is
+# `<workspace>/state/secret-vault/keys.json` — under the workspace contract
+# rather than a home dotdir. It indexes the per-host Keychain, so it stays
+# PER-HOST and must NOT sync: `state/` is outside the sync carrier set
+# (whitelist mode un-ignores only notes/ + hosts/<host>/ + memory/), so this
+# path is non-synced by construction. Were it synced, every node would inherit
+# key names its local Keychain can't resolve — a lying index.
+_LEGACY_MANIFEST_PATH = os.path.expanduser("~/.sutando-secret-vault/keys.json")
+
+
+def _manifest_path() -> str:
+    """Canonical manifest path under the resolved workspace. Falls back to the
+    legacy home-dir path if the workspace can't be resolved (preserves behavior
+    in import contexts where workspace_default isn't importable)."""
+    try:
+        from workspace_default import resolve_workspace
+        return os.path.join(str(resolve_workspace()), "state", "secret-vault", "keys.json")
+    except Exception:
+        return _LEGACY_MANIFEST_PATH
+
+
+def _read_manifest() -> dict:
+    """Load the manifest, preferring the canonical path and falling back to the
+    legacy home-dir path for existing installs. The fallback makes the first
+    write self-migrate: `_register_key` reads via this helper (inheriting any
+    legacy keys), then writes the merged set to the canonical path."""
+    canonical = _manifest_path()
+    candidates = [canonical]
+    if _LEGACY_MANIFEST_PATH != canonical:
+        candidates.append(_LEGACY_MANIFEST_PATH)
+    for path in candidates:
+        try:
+            with open(path) as f:
+                data = json.load(f)
+            if path == _LEGACY_MANIFEST_PATH and path != canonical:
+                print(
+                    "vault: read legacy manifest (~/.sutando-secret-vault/keys.json); "
+                    "migrating to <workspace>/state/secret-vault/ on next write.",
+                    file=sys.stderr, flush=True,
+                )
+            return data
+        except (FileNotFoundError, json.JSONDecodeError):
+            continue
+    return {}
 
 # Matches: vault set KEY <value>  where value is:
 #   - double-quoted string   "foo bar"
@@ -98,27 +144,22 @@ def _store_in_keychain(key: str, value: str) -> None:
 
 
 def _register_key(key: str) -> None:
-    os.makedirs(os.path.dirname(_MANIFEST_PATH), exist_ok=True)
-    try:
-        with open(_MANIFEST_PATH) as f:
-            manifest = json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError):
-        manifest = {}
+    path = _manifest_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    # Read via _read_manifest so the first write after the move inherits any
+    # legacy keys (self-migration) rather than starting an empty index.
+    manifest = _read_manifest()
     manifest[key] = {"stored_at": datetime.now(timezone.utc).isoformat()}
     # Atomic write — concurrent bridge processes won't corrupt keys.json.
-    tmp = _MANIFEST_PATH + ".tmp"
+    tmp = path + ".tmp"
     with open(tmp, "w") as f:
         json.dump(manifest, f, indent=2)
-    os.replace(tmp, _MANIFEST_PATH)
+    os.replace(tmp, path)
 
 
 def list_vault_keys() -> list[str]:
     """Return all key names stored in the vault manifest (no values)."""
-    try:
-        with open(_MANIFEST_PATH) as f:
-            return sorted(json.load(f).keys())
-    except (FileNotFoundError, json.JSONDecodeError):
-        return []
+    return sorted(_read_manifest().keys())
 
 
 def get_vault_key(key: str) -> str:

--- a/tests/vault-skill.test.py
+++ b/tests/vault-skill.test.py
@@ -33,19 +33,61 @@ _spec.loader.exec_module(vault_cli)
 class TestListVaultKeys(unittest.TestCase):
     def test_returns_sorted_keys(self):
         manifest = {"ZEBRA": {"stored_at": "x"}, "ALPHA": {"stored_at": "y"}}
-        with patch("builtins.open", mock_open(read_data=json.dumps(manifest))):
+        with patch.object(vault_intercept, "_read_manifest", return_value=manifest):
             result = vault_intercept.list_vault_keys()
         self.assertEqual(result, ["ALPHA", "ZEBRA"])
 
-    def test_empty_when_no_manifest(self):
-        with patch("builtins.open", side_effect=FileNotFoundError):
+    def test_empty_when_manifest_empty(self):
+        with patch.object(vault_intercept, "_read_manifest", return_value={}):
             result = vault_intercept.list_vault_keys()
         self.assertEqual(result, [])
 
-    def test_empty_on_corrupt_json(self):
-        with patch("builtins.open", mock_open(read_data="not-json")):
-            result = vault_intercept.list_vault_keys()
-        self.assertEqual(result, [])
+
+class TestReadManifest(unittest.TestCase):
+    """Read-error handling + canonical-preferred / legacy-fallback resolution."""
+
+    def _patch_paths(self, canonical, legacy):
+        return (
+            patch.object(vault_intercept, "_manifest_path", return_value=canonical),
+            patch.object(vault_intercept, "_LEGACY_MANIFEST_PATH", legacy),
+        )
+
+    def test_missing_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p1, p2 = self._patch_paths(os.path.join(tmp, "c.json"), os.path.join(tmp, "l.json"))
+            with p1, p2:
+                self.assertEqual(vault_intercept._read_manifest(), {})
+
+    def test_corrupt_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            canonical = os.path.join(tmp, "c.json")
+            with open(canonical, "w") as f:
+                f.write("not-json")
+            p1, p2 = self._patch_paths(canonical, os.path.join(tmp, "l.json"))
+            with p1, p2:
+                self.assertEqual(vault_intercept._read_manifest(), {})
+
+    def test_prefers_canonical_over_legacy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            canonical = os.path.join(tmp, "c.json")
+            legacy = os.path.join(tmp, "l.json")
+            with open(canonical, "w") as f:
+                json.dump({"NEW": {"stored_at": "t"}}, f)
+            with open(legacy, "w") as f:
+                json.dump({"OLD": {"stored_at": "t"}}, f)
+            p1, p2 = self._patch_paths(canonical, legacy)
+            with p1, p2:
+                self.assertEqual(sorted(vault_intercept._read_manifest()), ["NEW"])
+
+    def test_falls_back_to_legacy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            canonical = os.path.join(tmp, "c.json")  # absent
+            legacy = os.path.join(tmp, "l.json")
+            with open(legacy, "w") as f:
+                json.dump({"OLD": {"stored_at": "t"}}, f)
+            p1, p2 = self._patch_paths(canonical, legacy)
+            with p1, p2:
+                self.assertEqual(sorted(vault_intercept._read_manifest()), ["OLD"])
 
 
 class TestGetVaultKey(unittest.TestCase):
@@ -63,10 +105,17 @@ class TestGetVaultKey(unittest.TestCase):
 
 
 class TestRegisterKey(unittest.TestCase):
+    def _patch_paths(self, canonical, legacy):
+        return (
+            patch.object(vault_intercept, "_manifest_path", return_value=canonical),
+            patch.object(vault_intercept, "_LEGACY_MANIFEST_PATH", legacy),
+        )
+
     def test_new_key_written_to_manifest(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_path = os.path.join(tmpdir, "keys.json")
-            with patch.object(vault_intercept, "_MANIFEST_PATH", manifest_path):
+            p1, p2 = self._patch_paths(manifest_path, os.path.join(tmpdir, "legacy.json"))
+            with p1, p2:
                 vault_intercept._register_key("NEW_KEY")
             with open(manifest_path) as f:
                 data = json.load(f)
@@ -78,12 +127,28 @@ class TestRegisterKey(unittest.TestCase):
             manifest_path = os.path.join(tmpdir, "keys.json")
             with open(manifest_path, "w") as f:
                 json.dump({"OLD": {"stored_at": "2020"}}, f)
-            with patch.object(vault_intercept, "_MANIFEST_PATH", manifest_path):
+            p1, p2 = self._patch_paths(manifest_path, os.path.join(tmpdir, "legacy.json"))
+            with p1, p2:
                 vault_intercept._register_key("OLD")
             with open(manifest_path) as f:
                 data = json.load(f)
             self.assertIn("OLD", data)
             self.assertNotEqual(data["OLD"]["stored_at"], "2020")
+
+    def test_first_write_migrates_legacy_keys(self):
+        """Canonical absent + legacy present → first write inherits legacy keys
+        (and creates the nested canonical dir)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            canonical = os.path.join(tmpdir, "state", "secret-vault", "keys.json")  # nested, absent
+            legacy = os.path.join(tmpdir, "legacy.json")
+            with open(legacy, "w") as f:
+                json.dump({"A": {"stored_at": "t"}, "B": {"stored_at": "t"}}, f)
+            p1, p2 = self._patch_paths(canonical, legacy)
+            with p1, p2:
+                vault_intercept._register_key("C")
+            with open(canonical) as f:
+                data = json.load(f)
+            self.assertEqual(sorted(data), ["A", "B", "C"])
 
 
 class TestStoreRegistersKey(unittest.TestCase):


### PR DESCRIPTION
## Problem

The vault manifest — the **non-secret** index of key *names* (the secret *values* live in macOS Keychain) — lived at `~/.sutando-secret-vault/keys.json`, a home dotdir. That's the anti-pattern the workspace contract exists to eliminate (all per-user state should live under the workspace). Surfaced in the owner's "is the vault per-host or shared / should it be in the workspace?" thread.

## Fix

Move the manifest to `<workspace>/state/secret-vault/keys.json`.

**It must stay per-host and non-synced** because it indexes the per-host Keychain. If it synced, every node would inherit key names its local Keychain can't resolve — a *lying index*. `state/` is outside the sync carrier set (sync-workspace.sh uses whitelist mode, un-ignoring only `notes/` + `hosts/<host>/` + `memory/`), so the new path is non-synced **by construction** — verified against the live carrier set.

- `_manifest_path()` resolves the canonical path via `resolve_workspace()`, falling back to the legacy home-dir path if the workspace can't be resolved (robust in odd import contexts).
- `_read_manifest()` prefers canonical, falls back to legacy for existing installs (one-line stderr deprecation note).
- **First write self-migrates**: `_register_key` reads via `_read_manifest` (inheriting legacy keys) then writes the merged set to canonical — no key-name loss, no manual migration. Legacy file left in place (harmless).

Secrets are unaffected — they stay in Keychain, found by `security find-generic-password` regardless of where the index lives.

## Verification

```
canonical path: <workspace>/state/secret-vault/keys.json          ✓ under workspace/state
list (pre-write, canonical absent): reads legacy {A,B}            ✓
register C: canonical self-migrates → {A,B,C}                     ✓ no key-name loss
list (post-write): reads canonical                               ✓
real install (no canonical yet): list_vault_keys() → existing 4 keys via legacy fallback, no write  ✓
```
`python3 -m py_compile src/vault_intercept.py` → OK.
