### PR TITLE
fix(credential-proxy): self-refresh OAuth token to end the daily 401 (namespaced-CCD nodes)

### DIFF
--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -107,6 +107,30 @@ function writeCred(oauth: ClaudeOAuth): boolean {
 // (== current behavior, no regression). Request shape is standard OAuth2
 // public-client refresh (JSON body); response field names tolerated in both
 // snake_case (spec) and camelCase. NOT live-validated — see PR notes.
+// Pure: map an OAuth token-endpoint response into a fresh cred, or null if the
+// response isn't usable. Tolerates snake_case (spec) and camelCase, keeps the
+// existing refresh token when the response doesn't rotate it, and refuses any
+// access token that isn't a plausible non-empty string (never write garbage).
+// Exported so this — the highest-risk logic (field names + the guard) — is
+// unit-tested offline: no network, no keychain, no token rotation.
+export function parseRefreshResponse(
+	statusCode: number,
+	bodyText: string,
+	oauth: ClaudeOAuth,
+	now: number = Date.now(),
+): ClaudeOAuth | null {
+	if (statusCode >= 400) return null;
+	let j: Record<string, unknown>;
+	try { j = JSON.parse(bodyText); } catch { return null; }
+	const access = j.access_token ?? j.accessToken;
+	const refresh = (j.refresh_token ?? j.refreshToken ?? oauth.refreshToken) as string | undefined;
+	const expiresIn = j.expires_in ?? j.expiresIn;
+	const expiresAt = (j.expires_at ?? j.expiresAt ??
+		(typeof expiresIn === 'number' ? now + expiresIn * 1000 : undefined)) as number | undefined;
+	if (typeof access !== 'string' || access.length < 20) return null;
+	return { ...oauth, accessToken: access, refreshToken: refresh, expiresAt };
+}
+
 function refreshAccessToken(oauth: ClaudeOAuth): Promise<ClaudeOAuth | null> {
 	return new Promise((resolve) => {
 		if (!oauth.refreshToken) { resolve(null); return; }
@@ -131,29 +155,9 @@ function refreshAccessToken(oauth: ClaudeOAuth): Promise<ClaudeOAuth | null> {
 			const cs: Buffer[] = [];
 			resp.on('data', (c) => cs.push(c));
 			resp.on('end', () => {
-				if ((resp.statusCode ?? 0) >= 400) {
-					console.error(`${ts()} [Proxy] refresh HTTP ${resp.statusCode}`);
-					resolve(null);
-					return;
-				}
-				try {
-					const j = JSON.parse(Buffer.concat(cs).toString('utf-8'));
-					const access = j.access_token ?? j.accessToken;
-					const refresh = j.refresh_token ?? j.refreshToken ?? oauth.refreshToken;
-					const expiresIn = j.expires_in ?? j.expiresIn;
-					const expiresAt = j.expires_at ?? j.expiresAt ??
-						(typeof expiresIn === 'number' ? Date.now() + expiresIn * 1000 : undefined);
-					// Guard: only accept a plausible, non-empty access token.
-					if (typeof access !== 'string' || access.length < 20) {
-						console.error(`${ts()} [Proxy] refresh response lacked a usable access_token`);
-						resolve(null);
-						return;
-					}
-					resolve({ ...oauth, accessToken: access, refreshToken: refresh, expiresAt });
-				} catch (e) {
-					console.error(`${ts()} [Proxy] refresh parse error:`, (e as Error).message);
-					resolve(null);
-				}
+				const fresh = parseRefreshResponse(resp.statusCode ?? 0, Buffer.concat(cs).toString('utf-8'), oauth);
+				if (!fresh) console.error(`${ts()} [Proxy] refresh unusable (HTTP ${resp.statusCode} or bad/empty response)`);
+				resolve(fresh);
 			});
 		});
 		r.on('error', (e) => { console.error(`${ts()} [Proxy] refresh request error:`, e.message); resolve(null); });
@@ -229,13 +233,22 @@ function updateQuotaState(headers: Record<string, string>): void {
 	} catch { /* best effort */ }
 }
 
-// Verify token exists at startup
-const initToken = getOAuthToken();
-if (!initToken) {
-	console.error('No OAuth token found in macOS keychain. Is Claude Code logged in?');
-	process.exit(1);
+// Only start the server when run directly. Importing this module (e.g. from the
+// offline parse test) must NOT bind the port, touch the keychain, or exit.
+// Match the exact script name, NOT a substring — the offline test file is named
+// `credential-proxy-refresh.test.ts`, which contains "credential-proxy" but must
+// NOT be treated as the entry point (else importing it tries to bind the port).
+const isMain = (process.argv[1] ?? '').endsWith('credential-proxy.ts');
+
+if (isMain) {
+	// Verify token exists at startup
+	const initToken = getOAuthToken();
+	if (!initToken) {
+		console.error('No OAuth token found in macOS keychain. Is Claude Code logged in?');
+		process.exit(1);
+	}
+	console.log(`${ts()} [Proxy] OAuth token loaded from keychain (will re-read on each request)`);
 }
-console.log(`${ts()} [Proxy] OAuth token loaded from keychain (will re-read on each request)`);
 
 const upstreamUrl = new URL(UPSTREAM);
 
@@ -311,8 +324,10 @@ const server = createServer((req, res) => {
 	});
 });
 
-server.listen(PORT, '127.0.0.1', () => {
-	console.log(`${ts()} [Proxy] Credential proxy → http://localhost:${PORT}`);
-	console.log(`${ts()} [Proxy] Upstream: ${UPSTREAM}`);
-	console.log(`${ts()} [Proxy] Set ANTHROPIC_BASE_URL=http://localhost:${PORT} to route through proxy`);
-});
+if (isMain) {
+	server.listen(PORT, '127.0.0.1', () => {
+		console.log(`${ts()} [Proxy] Credential proxy → http://localhost:${PORT}`);
+		console.log(`${ts()} [Proxy] Upstream: ${UPSTREAM}`);
+		console.log(`${ts()} [Proxy] Set ANTHROPIC_BASE_URL=http://localhost:${PORT} to route through proxy`);
+	});
+}

--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -14,7 +14,7 @@
 
 import { createServer, request as httpRequest, type RequestOptions } from 'node:http';
 import { request as httpsRequest } from 'node:https';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { writeFileSync, readFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { statusPath } from '../../../src/workspace_default.js';
@@ -26,20 +26,176 @@ const UPSTREAM = 'https://api.anthropic.com';
 // keep the skill-dir path as a last-resort fallback for one release.
 const QUOTA_FILE = statusPath('quota-state.json');
 
+// OAuth self-refresh. The proxy reads the DEFAULT `Claude Code-credentials`
+// keychain item, but nothing refreshes that item's accessToken on a headless
+// node (interactive `/login` refreshes it; a namespaced-CLAUDE_CONFIG_DIR core
+// refreshes its OWN `Claude Code-credentials-<hash>` item). So once `expiresAt`
+// passes the proxy injects an EXPIRED token → upstream 401 ("401 after a while").
+// Fix: when the stored token is at/near expiry, use the stored refreshToken to
+// mint a fresh one and write it back — making every proxy-routed node self-heal.
+// Endpoint + client_id verified from the Claude Code binary (v2.1.170 strings).
+const TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
+const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const KEYCHAIN_SERVICE = 'Claude Code-credentials';
+// Refresh when the token expires within this window (ms). Tokens are ~8h-lived;
+// 5 min of slack avoids racing the expiry on a long-running upstream request.
+const REFRESH_SKEW_MS = 5 * 60 * 1000;
+
+interface ClaudeOAuth {
+	accessToken: string;
+	refreshToken?: string;
+	expiresAt?: number; // epoch ms
+	[k: string]: unknown;
+}
+
 function ts(): string { return new Date().toISOString().slice(11, 23); }
 
-// Read OAuth token from macOS keychain
-function getOAuthToken(): string | null {
+// Read the full cred object from the keychain (not just the accessToken).
+function readCred(): ClaudeOAuth | null {
 	try {
-		const cred = execSync('security find-generic-password -s "Claude Code-credentials" -w', {
+		const raw = execSync(`security find-generic-password -s "${KEYCHAIN_SERVICE}" -w`, {
 			encoding: 'utf-8',
 			timeout: 5000,
 		}).trim();
-		const parsed = JSON.parse(cred);
-		return parsed?.claudeAiOauth?.accessToken ?? null;
+		const parsed = JSON.parse(raw);
+		const oauth = parsed?.claudeAiOauth;
+		return oauth && typeof oauth.accessToken === 'string' ? (oauth as ClaudeOAuth) : null;
 	} catch {
 		return null;
 	}
+}
+
+// Atomically write the cred back to the keychain. Returns true ONLY after a
+// read-back confirms the new accessToken landed — the rotation-lockout guard:
+// if we consumed a (rotating) refresh token we MUST be sure its replacement
+// persisted, else the node can never refresh again.
+function keychainAccount(): string | null {
+	try {
+		const meta = execFileSync('security', ['find-generic-password', '-s', KEYCHAIN_SERVICE], {
+			encoding: 'utf-8', timeout: 5000,
+		});
+		const m = meta.match(/"acct"<blob>="([^"]*)"/);
+		return m ? m[1] : null;
+	} catch {
+		return null;
+	}
+}
+
+function writeCred(oauth: ClaudeOAuth): boolean {
+	try {
+		const acct = keychainAccount();
+		if (!acct) { console.error(`${ts()} [Proxy] keychain write: account not found`); return false; }
+		const payload = JSON.stringify({ claudeAiOauth: oauth });
+		// execFileSync (args array, no shell) — value passed as a single argv
+		// element, so no quoting/injection surface. -U updates the item in place.
+		// (Value is briefly visible in `ps` to the same user — acceptable on a
+		// single-user Mac, same as the rest of the vault path.)
+		execFileSync('security', [
+			'add-generic-password', '-U',
+			'-s', KEYCHAIN_SERVICE, '-a', acct, '-w', payload,
+		], { timeout: 5000 });
+		const back = readCred();
+		return back?.accessToken === oauth.accessToken; // rotation-lockout read-back guard
+	} catch (e) {
+		console.error(`${ts()} [Proxy] keychain write FAILED:`, (e as Error).message);
+		return false;
+	}
+}
+
+// POST the stored refresh token to the OAuth token endpoint → fresh cred.
+// Fail-safe: any error returns null and the caller keeps the existing token
+// (== current behavior, no regression). Request shape is standard OAuth2
+// public-client refresh (JSON body); response field names tolerated in both
+// snake_case (spec) and camelCase. NOT live-validated — see PR notes.
+function refreshAccessToken(oauth: ClaudeOAuth): Promise<ClaudeOAuth | null> {
+	return new Promise((resolve) => {
+		if (!oauth.refreshToken) { resolve(null); return; }
+		const bodyStr = JSON.stringify({
+			grant_type: 'refresh_token',
+			refresh_token: oauth.refreshToken,
+			client_id: OAUTH_CLIENT_ID,
+		});
+		const u = new URL(TOKEN_ENDPOINT);
+		const reqOpts: RequestOptions = {
+			hostname: u.hostname,
+			port: 443,
+			path: u.pathname,
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				'content-length': Buffer.byteLength(bodyStr),
+				accept: 'application/json',
+			},
+		};
+		const r = httpsRequest(reqOpts, (resp) => {
+			const cs: Buffer[] = [];
+			resp.on('data', (c) => cs.push(c));
+			resp.on('end', () => {
+				if ((resp.statusCode ?? 0) >= 400) {
+					console.error(`${ts()} [Proxy] refresh HTTP ${resp.statusCode}`);
+					resolve(null);
+					return;
+				}
+				try {
+					const j = JSON.parse(Buffer.concat(cs).toString('utf-8'));
+					const access = j.access_token ?? j.accessToken;
+					const refresh = j.refresh_token ?? j.refreshToken ?? oauth.refreshToken;
+					const expiresIn = j.expires_in ?? j.expiresIn;
+					const expiresAt = j.expires_at ?? j.expiresAt ??
+						(typeof expiresIn === 'number' ? Date.now() + expiresIn * 1000 : undefined);
+					// Guard: only accept a plausible, non-empty access token.
+					if (typeof access !== 'string' || access.length < 20) {
+						console.error(`${ts()} [Proxy] refresh response lacked a usable access_token`);
+						resolve(null);
+						return;
+					}
+					resolve({ ...oauth, accessToken: access, refreshToken: refresh, expiresAt });
+				} catch (e) {
+					console.error(`${ts()} [Proxy] refresh parse error:`, (e as Error).message);
+					resolve(null);
+				}
+			});
+		});
+		r.on('error', (e) => { console.error(`${ts()} [Proxy] refresh request error:`, e.message); resolve(null); });
+		r.setTimeout(10000, () => { r.destroy(); resolve(null); });
+		r.write(bodyStr);
+		r.end();
+	});
+}
+
+// Single-flight guard: at most one refresh in progress, so concurrent requests
+// never race to consume/rotate the refresh token twice.
+let refreshInFlight: Promise<void> | null = null;
+
+// Return a usable accessToken, refreshing first if the stored one is at/near
+// expiry. Fail-safe at every step: any problem → return the existing token.
+async function getFreshOAuthToken(): Promise<string | null> {
+	const cred = readCred();
+	if (!cred) return null;
+	const needsRefresh =
+		typeof cred.expiresAt === 'number' &&
+		cred.expiresAt - Date.now() <= REFRESH_SKEW_MS &&
+		!!cred.refreshToken;
+	if (needsRefresh) {
+		if (!refreshInFlight) {
+			refreshInFlight = (async () => {
+				const fresh = await refreshAccessToken(cred);
+				if (fresh && writeCred(fresh)) {
+					console.log(`${ts()} [Proxy] OAuth token refreshed (new expiry ${new Date(fresh.expiresAt ?? 0).toISOString()})`);
+				} else {
+					console.error(`${ts()} [Proxy] refresh did not persist — keeping existing token`);
+				}
+			})().finally(() => { refreshInFlight = null; });
+		}
+		await refreshInFlight;
+		return readCred()?.accessToken ?? cred.accessToken;
+	}
+	return cred.accessToken;
+}
+
+// Back-compat sync reader (startup probe only — does not refresh).
+function getOAuthToken(): string | null {
+	return readCred()?.accessToken ?? null;
 }
 
 function updateQuotaState(headers: Record<string, string>): void {
@@ -86,11 +242,13 @@ const upstreamUrl = new URL(UPSTREAM);
 const server = createServer((req, res) => {
 	const chunks: Buffer[] = [];
 	req.on('data', (c) => chunks.push(c));
-	req.on('end', () => {
+	req.on('end', async () => {
 		const body = Buffer.concat(chunks);
 
-		// Read token fresh from keychain each request (tokens get refreshed by active sessions)
-		const oauthToken = getOAuthToken();
+		// Read token fresh from keychain each request, refreshing it first if it
+		// is at/near expiry (tokens are also refreshed by active interactive
+		// sessions; this self-refresh covers headless nodes where they aren't).
+		const oauthToken = await getFreshOAuthToken();
 		if (!oauthToken) {
 			res.writeHead(502);
 			res.end('No OAuth token in keychain');

--- a/tests/credential-proxy-refresh.test.ts
+++ b/tests/credential-proxy-refresh.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Offline unit test for #1767's OAuth-refresh response handling.
+ *
+ * Validates the highest-risk logic — field-name handling + the access-token
+ * guard in parseRefreshResponse — WITHOUT any network, keychain, or token
+ * rotation. The live round-trip (real endpoint behavior) is validated
+ * separately on a proxy-routed node; this catches the parse/guard bugs that
+ * would otherwise only surface in production.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { parseRefreshResponse } from '../skills/quota-tracker/scripts/credential-proxy.ts';
+
+const base = { accessToken: 'old-access', refreshToken: 'old-refresh', expiresAt: 1000 };
+const A = 'a'.repeat(40); // a plausible (>=20 char) access token
+
+test('snake_case response → fresh cred, expiresAt from expires_in', () => {
+	const r = parseRefreshResponse(200, JSON.stringify({ access_token: A, refresh_token: 'new-refresh', expires_in: 3600 }), base, 0);
+	assert.equal(r?.accessToken, A);
+	assert.equal(r?.refreshToken, 'new-refresh');
+	assert.equal(r?.expiresAt, 3600 * 1000);
+});
+
+test('camelCase response is tolerated', () => {
+	const r = parseRefreshResponse(200, JSON.stringify({ accessToken: A, refreshToken: 'r2', expiresAt: 9999 }), base, 0);
+	assert.equal(r?.accessToken, A);
+	assert.equal(r?.refreshToken, 'r2');
+	assert.equal(r?.expiresAt, 9999);
+});
+
+test('no rotation in response → keeps the existing refresh token', () => {
+	const r = parseRefreshResponse(200, JSON.stringify({ access_token: A, expires_in: 60 }), base, 0);
+	assert.equal(r?.refreshToken, 'old-refresh');
+});
+
+test('HTTP >=400 → null (no write)', () => {
+	assert.equal(parseRefreshResponse(401, JSON.stringify({ access_token: A }), base), null);
+	assert.equal(parseRefreshResponse(500, JSON.stringify({ access_token: A }), base), null);
+});
+
+test('garbage / non-JSON body → null', () => {
+	assert.equal(parseRefreshResponse(200, 'not-json', base), null);
+	assert.equal(parseRefreshResponse(200, '', base), null);
+});
+
+test('missing access token → null', () => {
+	assert.equal(parseRefreshResponse(200, JSON.stringify({ refresh_token: 'x' }), base), null);
+});
+
+test('short access token (<20 chars) → null (the anti-garbage guard)', () => {
+	assert.equal(parseRefreshResponse(200, JSON.stringify({ access_token: 'short' }), base), null);
+});
+
+test('non-string access token → null', () => {
+	assert.equal(parseRefreshResponse(200, JSON.stringify({ access_token: 12345 }), base), null);
+});
+
+test('preserves unrelated existing fields (scopes etc.)', () => {
+	const withScopes = { ...base, scopes: ['a', 'b'], subscriptionType: 'max' };
+	const r = parseRefreshResponse(200, JSON.stringify({ access_token: A, expires_in: 10 }), withScopes, 0);
+	assert.deepEqual(r?.scopes, ['a', 'b']);
+	assert.equal(r?.subscriptionType, 'max');
+});


### PR DESCRIPTION
## Root cause (confirmed 3 machines)

The recurring daily 401 on CLAUDE_CONFIG_DIR-namespaced nodes. Pro, Maddy, and Susan all have a `Claude Code-credentials-<hash>` keychain item (hash = `sha256(CLAUDE_CONFIG_DIR)[:8]`) alongside the default — so macOS Claude Code **does** namespace credentials by config-dir (the pasted "shared Keychain" doc answer is outdated for our version).

The credential-proxy reads the **default** `Claude Code-credentials` item fresh per request — but nothing refreshes *that item's* accessToken on a headless node:
- interactive `/login` refreshes the default item,
- a namespaced-CCD core refreshes its **own** `-<hash>` item,
- neither fires automatically.

So once `expiresAt` passes, the proxy injects an **expired** token → upstream 401 ("after a while, not upfront"). Verified on Pro: the item carries `accessToken` + `refreshToken` + `expiresAt`; the access token simply ages out (Pro's expires 08:30Z today).

## Fix

The proxy **self-refreshes**: when the stored token is at/near expiry (5-min skew), it POSTs the stored `refreshToken` to the OAuth token endpoint, writes the fresh token back to the keychain, and uses it. The proxy is the single auth-path chokepoint that already reads this item → the natural owner of refresh. Every proxy-routed node self-heals (no `/login`, no `#1741` mirror).

## Safety (auth path — designed defensively)

- **Fail-safe**: any refresh failure → returns the EXISTING token (== today, no regression).
- **Single-flight guard**: ≤1 refresh in flight; concurrent requests never double-rotate.
- **Rotation-lockout guard**: keychain write does a read-back verify; if the rotated refresh token can't persist, it logs and keeps the old cred.
- Parser tolerates snake_case + camelCase; only accepts a ≥20-char access token before writing. Keychain write via `execFileSync` (args array, no shell).

Endpoint + client_id verified from the Claude Code binary (v2.1.170): `https://platform.claude.com/v1/oauth/token`, client_id `9d1c250a-…-d1962f5e`.

## ⚠️ NOT live-validated

The actual refresh round-trip is unverified — firing it consumes/rotates Pro's **production** refresh token, and a casual test could lock the node out if write-back were wrong. The fail-safe design means a wrong request format degrades to "no refresh / token unchanged", not a regression. **Recommend a deliberate first test on a node where re-login is cheap before fleet rollout.**

typecheck:skills passes (0 errors); loads at runtime (keychain read OK, reaches `server.listen`).
