### PR TITLE
fix(health-check): probe the credential proxy (:7846) so the dashboard lists it

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1031,6 +1031,19 @@ def run_all_checks() -> list[dict]:
         # startup.sh's lsof guard sees the port as occupied and won't restart it.
         checks.append(c)
 
+    # Credential proxy (port 7846) — the OAuth-injection + quota-header path
+    # (skills/quota-tracker/scripts/credential-proxy.ts). It was previously
+    # unmonitored, so a dead proxy (= broken auth/quota for proxy-routed cores)
+    # never surfaced on the dashboard. Plain TCP-listening check (probe=False):
+    # it's a forwarding proxy with no liveness endpoint, so an HTTP probe would
+    # be forwarded upstream and misread as "wedged". Optional (not every node
+    # routes through it) → down is a warning, not a failure.
+    proxy_check = check_port(7846, "credential-proxy", probe=False)
+    if proxy_check["status"] == "down":
+        proxy_check["status"] = "warn"
+        proxy_check["detail"] = "not running (optional)"
+    checks.append(proxy_check)
+
     # macOS TCC — must come before critical-file checks so if TCC is blocking
     # everything, the operator sees the root cause before the downstream failures.
     checks.append(check_tcc_documents_access())


### PR DESCRIPTION
The credential-proxy is the OAuth-injection + quota path but was never health-checked, so the dashboard Services panel never showed it — a dead proxy (broken auth/quota) gave no signal. Adds a TCP-listening `check_port(7846, 'credential-proxy', probe=False)` (no HTTP probe — it's a forwarding proxy with no liveness endpoint; an HTTP probe would be forwarded upstream and misread as wedged). Optional → down=warn. Verified: `credential-proxy  ok  port 7846` now appears and passes the dashboard Services filter. py_compile clean.

Answers the owner's 'why isn't the proxy in dashboard services?'.