### PR TITLE
fix(result-channel-key): match Python code-point semantics in TS sanitizeKey (astral chars)

### DIFF
--- a/src/result-channel-key.ts
+++ b/src/result-channel-key.ts
@@ -22,7 +22,11 @@
 
 // Filename-safe alphabet. Any char outside it is collapsed to `-` so a
 // stray channel id can never inject a path separator or a regex special.
-const KEY_SAFE_RE = /[^A-Za-z0-9_-]/g;
+// The `u` flag makes the class match by code point, not UTF-16 code unit —
+// so an astral char (e.g. an emoji, a surrogate pair) collapses to a SINGLE
+// `-`, matching the Python twin's code-point `re.sub` (src/result_channel_key.py).
+// Without it, JS matched each surrogate half → two dashes → silent TS/PY drift.
+const KEY_SAFE_RE = /[^A-Za-z0-9_-]/gu;
 
 // Scoped filename shape: `<channel-key>.task-{id}` (with or without .txt).
 // The key must NOT contain `.` (so `task-foo.txt` itself never matches).

--- a/tests/fixtures/result-channel-key.parity.json
+++ b/tests/fixtures/result-channel-key.parity.json
@@ -12,6 +12,7 @@
     {"in": "../etc/passwd",       "out": "---etc-passwd"},
     {"in": "  trim-me  ",         "out": "trim-me"},
     {"in": "café",                "out": "caf-"},
+    {"in": "a😀b",                "out": "a-b"},
     {"in": "",                    "out": "unknown"},
     {"in": null,                  "out": "unknown"}
   ],


### PR DESCRIPTION
## Problem

The `result-channel-key` twins (`src/result-channel-key.ts` / `src/result_channel_key.py`) silently diverge on **astral / surrogate-pair** input:

- TS `sanitizeKey("a😀b")` → `a--b` — the `/[^A-Za-z0-9_-]/g` regex matched each UTF-16 surrogate half, so one emoji became **two** dashes.
- PY `sanitize_key("a😀b")` → `a-b` — Python's `re.sub` operates on code points, so one emoji → **one** dash.

Flagged by @Maddy-MBP-Susan while reviewing #1703 (the parity-fixture PR) as "the one spot they could still silently diverge"; confirmed divergent before this fix.

## Fix

Add the `u` flag to `KEY_SAFE_RE` (`/[^A-Za-z0-9_-]/gu`) so the JS class matches by code point, collapsing an astral char to a single `-` — matching the Python twin. Pinned with an `a😀b → a-b` row in the shared parity fixture so the twins can't re-drift here.

## Testing

- `tests/result-channel-key.test.ts` 27/27, `tests/result-channel-key.test.py` 27/27.
- Direct check: both impls now return `a-b` for `a😀b` (was TS `a--b`).

Latent in practice — real channel keys (snowflake ids, call-sids) are ASCII — but this closes the last known TS/PY gap the parity fixture is meant to guard.

Stand: Echo Act IV Pro