### PR TITLE
fix(slack-bridge): self-load channel .env so supervisor-spawned bridge gets tokens

### DIFF
--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -75,6 +75,19 @@ INBOX_DIR.mkdir(parents=True, exist_ok=True)
 
 BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN", "")
 APP_TOKEN = os.environ.get("SLACK_APP_TOKEN", "")
+# Fall back to the channel .env when the tokens aren't already in our env. The
+# Electron backend-supervisor gates the bridge on this file's presence but builds
+# the child env from process.env + workspace .env only — it relies on each bridge
+# self-loading its channel .env (discord/telegram already do). Without this, the
+# supervisor-spawned bridge crash-loops on "not set". Mirrors discord-bridge.py.
+if not BOT_TOKEN or not APP_TOKEN:
+    channels_env = claude_home_path("channels", "slack", ".env")
+    if channels_env.exists():
+        for line in channels_env.read_text().splitlines():
+            if line.startswith("SLACK_BOT_TOKEN=") and not BOT_TOKEN:
+                BOT_TOKEN = line.split("=", 1)[1].strip().strip('"').strip("'")
+            elif line.startswith("SLACK_APP_TOKEN=") and not APP_TOKEN:
+                APP_TOKEN = line.split("=", 1)[1].strip().strip('"').strip("'")
 if not BOT_TOKEN or not APP_TOKEN:
     print("SLACK_BOT_TOKEN and/or SLACK_APP_TOKEN not set", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
## Problem

The Slack bridge crash-loops when launched by the Electron backend-supervisor, even when a valid token is configured.

Root cause is a launch-path asymmetry:

- The app **Settings page** persists the Slack tokens to `~/.claude/channels/slack/.env` (`electron/ipc.cjs` `channelEnv:write`).
- The **backend-supervisor** *gates* the Slack daemon on that file's presence (`channelTokenPresent`) but builds the child env from `process.env` + the **workspace** `.env` only — it never injects the **channel** `.env` into the spawned process.
- `discord-bridge.py` and `telegram-bridge.py` **self-load** their channel `.env`, so they survive this. `slack-bridge.py` did **not** — it only read `os.environ`.

Net effect: the token never reaches the bridge, it exits immediately with `SLACK_BOT_TOKEN and/or SLACK_APP_TOKEN not set`, and the supervisor's restart/backoff loop produces a crash-loop (observed as 19+ identical lines in `slack-bridge.log`).

`startup.sh` is unaffected because it `source`s the channel `.env` itself before spawning — which is also why a manual "source then run" restart worked.

## Fix

Fall back to reading `~/.claude/channels/slack/.env` when the tokens aren't already in the environment, mirroring `discord-bridge.py` (with telegram's quote-stripping). `claude_home_path` was already imported, so this is self-contained.

This makes the Slack bridge robust under **every** launch path: Electron supervisor, `startup.sh`, manual, and launchd.

## Test

- `python3 -m py_compile src/slack-bridge.py` — clean
- Verified against a real `channels/slack/.env`: both `SLACK_BOT_TOKEN` (xoxb-) and `SLACK_APP_TOKEN` (xapp-) load via the new fallback.

## Follow-up (not in this PR)

The Settings write + supervisor gate hardcode `~/.claude/...`, while the bridge self-loads via `claude_home_path` (honors `CLAUDE_CONFIG_DIR`). They can diverge if `CLAUDE_CONFIG_DIR` is workspace-scoped (#1454). Affects all three bridges identically; better fixed centrally in the supervisor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)