### PR TITLE
fix(pending-questions): host-aware DM text instead of hardcoded "the Mini"

### DIFF
--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -9,6 +9,7 @@ Use --force to bypass the 1-hour cooldown.
 import json
 import os
 import re
+import socket
 import subprocess
 import sys
 import time
@@ -167,7 +168,9 @@ def notify_discord_dm(questions):
     if len(questions) > 5:
         lines.append(f"…and {len(questions) - 5} more")
     lines.append("")
-    lines.append("Reply here or edit pending-questions.md on the Mini to resolve.")
+    lines.append(
+        f"Reply here or edit pending-questions.md on {socket.gethostname().split('.')[0]} to resolve."
+    )
     path.write_text("\n".join(lines))
 
 


### PR DESCRIPTION
Problem

The pending-question DM reminder (`src/check-pending-questions.py`) hardcoded
"Reply here or edit pending-questions.md on **the Mini** to resolve." That is
wrong on any non-Mini node — `pending-questions.md` is per-host, so the reminder
should name the node that actually holds the question.

Flagged by @sonichi in #bugs while triaging the "pending questions" report.

Fix

Use the actual short hostname (`socket.gethostname().split(".")[0]`), e.g.
"…edit pending-questions.md on Xueqings-MacBook-Pro-5 to resolve."

Scope

Single concern, host-text only. Does not touch the separate `[Voice]`
default-tag question (web-client) or the per-fire reminder file naming — those
are still under discussion in #bugs.