### PR TITLE
feat(proactive-loop): re-anchor step + context-reconstruct skill

### DIFF
--- a/skills/context-reconstruct/SKILL.md
+++ b/skills/context-reconstruct/SKILL.md
@@ -1,0 +1,45 @@
+# context-reconstruct
+
+**Goal:** never act on lost/eroded memory of the ongoing work. The agent can be interrupted, compacted, or run dozens of interleaved cron passes and still pick up exactly where the thread left off — *without the owner re-reminding it*.
+
+**Why a skill, not a script:** a hardcoded bundler (fixed N reads, one channel, fixed depth) is rigid — and easy to *skip* (narrate "re-anchor" then assert from memory anyway). The fix isn't a rigid script; it's flexible judgment + practice. This file is living — improve it whenever a reconstruction misses.
+
+## The one rule
+
+**Before interpreting or acting on anything that depends on earlier context, READ the durable record. Don't recall — read.** A "re-anchor" you claim but don't actually read is the failure.
+
+## What to read — judgment, fit to the moment (not a checklist to run blindly)
+
+**Read the current-track record FIRST** — `<workspace>/state/current-track.md` (this skill owns it; see "Maintain" below). It's the fast anchor: the **current main-track goal**, the active sub-task, and the live open decisions. This is what's missing when "continue your main track" gets guessed — the goal must be a pinned record, not inferred from luck.
+
+Then, as the situation needs (pick what's *relevant*; skip what isn't):
+
+- **The live thread** — the channel(s) the owner is actually active on: `python3 src/discord-read.py <channel_id>` (Discord), telegram task `[Replying to…]` quotes (Telegram has no history fetch). Go **as deep as the thread needs** with `--until <id|iso>` — not a fixed message count. If unsure which channel is live, check the most recent task's `channel_id` / `state/last-owner-activity.json`.
+- **Open decisions** — per-host `pending-questions.md`.
+- **Recent judgment/decisions** — latest `relay/relay-*.md`.
+- **What's built / next** — `build_log.md` tail.
+- **Deep history** (older than the channel can cheaply reach) — the session transcript JSONL.
+
+Effective > exhaustive: read enough to make *this* message/decision stand on its own, then stop.
+
+## Maintain the current-track record (the skill owns it)
+
+The skill both **uses** and **maintains** `state/current-track.md` — the owner doesn't dictate its content and the agent doesn't invent it from memory; it's **derived from the reconstruction**:
+
+- **Create it if absent** (first run): write the current main-track goal + active sub-task + key open decisions, derived from what the durable record (thread / build_log / pending-questions / relevant project memory) actually shows.
+- **Update it when the track moves** — after a reconstruction reveals the goal/sub-task/decisions changed (owner redirected, a thing shipped, a decision resolved), rewrite it. Keep it short (a pinned summary, not a log).
+- Next reconstruction reads it first → "what's the main track" is never a guess again.
+
+## Then
+
+Compare what you read against what you *think* is true. **Where they differ, trust the record.** If the current track is a still-open owner thread, continue THAT.
+
+## When to reconstruct
+
+When the thing in front of you isn't self-contained — terse ("y", "no", "?", a pronoun), a reply, refers to something not stated, or you're resuming after a gap/compaction. Keyed on the *message/situation*, not on felt confidence (felt confidence is what fails — the agent is confidently wrong).
+
+## Practice log (improve this skill here)
+
+- v0: created after a hardcoded `reanchor.sh` was rejected for being rigid + skippable. Open problem: making "actually read" reliable (it's a habit, not a one-liner). Iterate as misses happen.
+- invocation test PASSED: wired into proactive-loop step 0.7 as an actual Skill-tool **invocation** (not a "see X" reference — references don't load). Verified: invoking loads this body, then following it (read the live thread) confirms the current track. Invocation is the reliable-load half; doing the read is still the habit half.
+- added current-track ownership: the skill now READS `state/current-track.md` first and MAINTAINS it (derive from the record, don't dictate/invent). Seeded the file from the durable record. Closes the "reconstructs context but not the persistent goal" gap.

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -55,6 +55,16 @@ Each pass, in order:
 
    Budget informs the **depth** of step 6 — not whether to do it. "Ran out of ideas" is never a valid skip; the work menu is infinite by design. See **Skip conditions** below for the only legitimate reasons step 6 may be skipped.
 
+0.7. **RE-ANCHOR — reconstruct the current track before acting (every pass).**
+
+   **GOAL (Chi 2026-06-25):** Never act on lost or eroded memory of the ongoing work. My in-session memory is NOT the record — it erodes *continuously* (interleaving with cron passes, attention drift over a long context, and compaction), and I can't reliably tell when it has. Success = I can be interrupted, compacted, or run dozens of interleaved cron passes and still pick up exactly where the thread left off **without the owner having to re-remind me**. ("you're supposed to keep working when I go to sleep and remind me of things when I wake up" — the loop is what makes that true.) See [[feedback_retrieve_thread_dont_guess]].
+
+   **How (flexible, not a hardcoded recipe — Chi 2026-06-25):** before acting, actually READ the durable record to re-establish the current track — don't assert it from memory. *Which* sources and *how far* are judgment, fit to the situation, not a fixed script: the channel(s) the owner is actually active on (`python3 src/discord-read.py <channel_id>`, `--until <id|iso>` to go as deep as the thread needs), the per-host `pending-questions.md`, the latest `relay/relay-*.md`, the `build_log.md` tail, and the session transcript for deep history. Read what's relevant to *this* moment; skip what isn't.
+
+   Then **compare what you read against your in-context belief; where they differ, trust the record.** If the current track is a still-open owner thread, continue THAT — don't start something tangential.
+
+   **Invoke** the **`context-reconstruct` skill** (Skill tool — `context-reconstruct`) at the start of the pass; don't merely reference it — invoking is what loads the living how-to into context (kept flexible + improved with practice, per Chi 2026-06-25; no hardcoded bundler script). The hard part is *doing it*, not knowing it: an unread re-anchor asserted "from memory" is the failure — read, don't recall.
+
 ## Skip conditions for step 6 (the ONLY legitimate reasons)
 
 Skip step 6 (end the pass early after step 3) if and only if one of these applies:
@@ -70,6 +80,7 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 ## The numbered loop
 
 1. **Check for tasks.** Look in `tasks/` for voice / Discord / Telegram / phone tasks. Look at `context-drop.txt` for context drops. Process anything found — execute the task, write results to `results/`.
+   - **RECONSTRUCT before interpreting (don't recall — read).** My session context compacts and is interleaved with cron passes, so my memory of "what we said / what I committed to" is unreliable — it is NOT the record; the channel/transcript is. So when a task isn't self-contained (terse — "no", "continue", "y", a pronoun — a reply, or refers to something not stated), reconstruct the relevant context FIRST, before forming any interpretation: `python3 src/discord-read.py <channel_id>`, reading the thread (everyone's messages **including my own prior replies**, since I forget those too) back until it stands on its own, then answer from the reconstructed thread, not from memory. Keyed on the message not being self-contained (not "always", not my felt-confidence). This also re-anchors after a compaction. See [[feedback_retrieve_thread_dont_guess]].
    - **Access control:** If the task has `access_tier: other` or `access_tier: team`, delegate to a sandboxed agent. Do NOT process non-owner tasks with your full capabilities. Write the sandboxed output to results.
    - Only `access_tier: owner` (or tasks without an access_tier field) get full processing.
    - **Thread consolidation:** when several tasks in a short window are the same continuation thought (e.g. voice over-delegating "yes, right, this is useful…" as 3 separate tasks), put the FULL reply in the latest task's result and put `[deduped: task-<latest-id>]` in each earlier task's result. The bridge silently archives the deduped ones — no voice cascade, no DM duplicates. See CLAUDE.md "Result-body protocol markers" for the full marker list.


### PR DESCRIPTION
## What

Adds a per-pass **RE-ANCHOR** step (0.7) to the proactive loop and a new **`context-reconstruct`** skill it invokes.

- **proactive-loop step 0.7** — before acting each pass, read the durable record (current-track, the live channel thread, pending-questions, build_log tail, transcript) to re-establish the current track, instead of asserting it from eroded in-session memory (which drifts under compaction + interleaved cron passes). Plus a RECONSTRUCT bullet in step 1 for non-self-contained messages (terse replies, pronouns).
- **`context-reconstruct` skill** — flexible judgment + practice, **not** a hardcoded bundler (a rigid script was easy to *skip*: narrate "re-anchor", assert from memory anyway). The skill reads and maintains a per-node `state/current-track.md` — the pinned main-track goal — so "what's the current track" is never guessed after a compaction.

## Why

Recurring failure mode: over a long async thread the agent loses track of what was said (its own replies included) and **guesses from degraded memory instead of retrieving**. In-session memory is not the record; the channel/transcript is. This makes "keep working while the owner is away, pick up exactly where the thread left off" reliable.

## Verified working

- This mechanism, run live: invoking the skill loads the how-to, then reading `current-track.md` + the live thread correctly re-confirmed the track (no drift) and detected owner re-engagement → conversation mode.
- Backward thread reconstruction (the `discord-read --before/--until` half, in #1782) recovered real lost context across a sleep/wake boundary.

Reliability of *always doing the read* (vs narrating it) is a habit still being built — the skill's practice log tracks misses and is meant to improve over time.

## Scope notes

- Companion to #1782 (bridge-side CONTEXT-FIRST reconstruct). This is the **loop-side + the skill it invokes**; kept separate (different files, separable concern).
- The skill moved from workspace-only into the repo so the fleet-shared proactive-loop step 0.7 doesn't dangle. Generic logic in the repo; `state/current-track.md` stays per-node workspace state (same pattern as proactive-loop's other state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)