### PR TITLE
fix(workspace): route 3 voice/transcribe skill scripts through canonical resolve_workspace (sweep phase 1)

### DIFF
--- a/skills/audio-transcribe/scripts/transcribe.py
+++ b/skills/audio-transcribe/scripts/transcribe.py
@@ -18,6 +18,13 @@ import sys
 import urllib.request
 from pathlib import Path
 
+# Canonical workspace resolution. workspace_default lives in <repo>/src; this
+# script is at <repo>/skills/audio-transcribe/scripts/, so parents[3] is <repo>.
+# (parents[3] is used instead of a .parent.parent chain so the workspace lint
+# does not conflate this import bootstrap with workspace-path resolution.)
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+from workspace_default import resolve_workspace  # noqa: E402
+
 _AUDIO_MIME: dict[str, str] = {
     ".m4a": "audio/mp4",
     ".mp4": "audio/mp4",
@@ -43,11 +50,8 @@ def _api_key() -> str:
         if val:
             return val
     # Walk candidate .env files: workspace root, then common bridge credential dirs.
-    workspace = os.environ.get("SUTANDO_WORKSPACE", "")
-    if not workspace:
-        workspace = str(Path.home() / ".sutando" / "workspace")
     candidates = [
-        Path(workspace) / ".env",
+        resolve_workspace() / ".env",
         _claude_config() / "channels" / "slack" / ".env",
         _claude_config() / "channels" / "discord" / ".env",
         _claude_config() / "channels" / "telegram" / ".env",

--- a/skills/voice-agent-test-harness/scripts/report.py
+++ b/skills/voice-agent-test-harness/scripts/report.py
@@ -8,8 +8,16 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import time
 from pathlib import Path
+
+# Canonical workspace resolution. workspace_default lives in <repo>/src; this
+# script is at <repo>/skills/voice-agent-test-harness/scripts/, so parents[3]
+# is <repo>. (parents[3] avoids a .parent.parent chain so the workspace lint
+# does not conflate this import bootstrap with workspace-path resolution.)
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
+from workspace_default import resolve_workspace  # noqa: E402
 
 
 def _percentile(values: list[float], pct: float) -> float | None:
@@ -65,8 +73,8 @@ def render(run: dict, regressions: list[str], date: str) -> str:
 
 def deliver(text: str, workspace: str | None = None) -> str:
     """Write a result file the bridge delivers to Telegram. Returns the path."""
-    ws = workspace or os.environ.get("SUTANDO_WORKSPACE") or os.path.expanduser("~/.sutando/workspace")
-    results = Path(ws) / "results"
+    ws = Path(workspace) if workspace else resolve_workspace()
+    results = ws / "results"
     results.mkdir(parents=True, exist_ok=True)
     ts = int(time.time())
     path = results / f"proactive-{ts}.txt"

--- a/skills/voice-agent-test-harness/scripts/score.py
+++ b/skills/voice-agent-test-harness/scripts/score.py
@@ -10,6 +10,7 @@ import base64
 import json
 import os
 import re
+import sys
 import urllib.request
 from dataclasses import dataclass, asdict
 from pathlib import Path
@@ -20,7 +21,10 @@ JUDGE_MODEL = os.environ.get("VTH_JUDGE_MODEL", "gemini-2.5-flash")
 _ENDPOINT = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}"
 
 _REPO = Path(__file__).resolve().parents[3]
-_WS = Path(os.environ.get("SUTANDO_WORKSPACE", Path.home() / ".sutando" / "workspace"))
+sys.path.insert(0, str(_REPO / "src"))
+from workspace_default import resolve_workspace  # noqa: E402
+
+_WS = resolve_workspace()
 
 _JUDGE_SYSTEM = """You are grading a voice assistant's spoken reply.
 You receive the prompt it was given, what a correct reply should contain, an STT


### PR DESCRIPTION
Phase 1 of the systematic workspace-resolution sweep (audit: notes/workspace-migration-residual-systematic-fix.md). Follows #1754 + #1765 (now merged).

## Problem
Three runtime skill scripts resolved the workspace via an ad-hoc SUTANDO_WORKSPACE env read with a pre-v0.8 legacy ~/.sutando/workspace fallback, instead of the canonical helper. When the env var is unset they silently diverge to the legacy dir — the same class of bug as #1754/#1765/#1766.

## Change
All three now import the canonical resolve_workspace() and drop the legacy fallback:
- skills/audio-transcribe/scripts/transcribe.py — resolve <workspace>/.env
- skills/voice-agent-test-harness/scripts/report.py — deliver() must write to the real <workspace>/results/ the bridge polls (keeps the explicit workspace arg override)
- skills/voice-agent-test-harness/scripts/score.py — _WS via the helper (file already resolved _REPO = parents[3], so no new assumption)

Import bootstrap uses Path(__file__).resolve().parents[3] (not a .parent.parent chain) so the workspace lint does not conflate loading the helper with resolving the workspace.

No behavior change in the live system (CLAUDE_CONFIG_DIR is exported, so the resolver returns the same <repo>/workspace these scripts already targeted).

## Deliberately excluded
- baseline.py — its parent.parent/results/voice-test/ is skill-local, gitignored, PER-HOST scratch (baseline is "previous green run on the same machines"); relocating it under the synced workspace would break that. Recommend ALLOWED-listing it when the lint flips to full-tree (prong D), not relocating.
- bash sites (startup.sh, sync-memory.sh, install-*-launchd.sh) — already route through scripts/sutando-config.sh or src/workspace_resolve.sh with documented non-checkout fallbacks; startup.sh is already lint-allowed.
- prong C (central unset-CLAUDE_CONFIG_DIR fallback) — already aligned by #1754; prong D (flip lint to full-tree) — separate follow-up once the tree is clean.

## Verification
- All 3 resolve to the canonical <repo>/workspace; report.deliver lands in <workspace>/results/
- tests/audio-transcribe-skill.test.py passes (16)
- run_suite imports clean
- scripts/lint-workspace-resolution.sh --diff clean