### PR TITLE
fix(session-handoff): drain relay notes into session-state.md on compaction (closes #1738)

### DIFF
--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: relay
-description: "Write a handoff/continuity note for the NEXT Sutando session. Captures what was just in flight, what to check first, what might go wrong, and implicit context the structured snapshot doesn't carry. Read first by /catchup-after-startup."
+description: "Write a handoff/continuity note for the NEXT Sutando session. Captures what was just in flight, what to check first, what might go wrong, and implicit context the structured snapshot doesn't carry. Drained by session-handoff.sh into session-state.md on context compaction (fixes #1738)."
 user-invocable: true
 ---
 
@@ -29,7 +29,7 @@ workspace/relay/
 
 - **File naming:** `relay-{epoch}.md` — sortable + greppable, matches the `task-{epoch}.txt` shape.
 - **Multiple files allowed:** `/relay` always creates a NEW file by default. `--append` appends to the LATEST unprocessed `relay-*.md` instead of creating a new one.
-- **Consumption:** catchup-after-startup reads ALL unprocessed `relay-*.md` files in mtime order (oldest first), prints them as section 0 of its briefing, then `mv`s each one to `processed/` (mirroring the result-watcher drain pattern).
+- **Consumption:** `src/session-handoff.sh` reads ALL unprocessed `relay-*.md` files (newest first) and includes them as a "## Relay Notes" section in `session-state.md` on context compaction, then `mv`s each one to `processed/` (mirroring the result-watcher drain pattern). Previously consumed by `catchup-after-startup`, which was removed by PR #1737 (orphaned by #1738; fixed here).
 - **Cleanup:** kept indefinitely on local disk. Tiny files (~200-500 bytes each); a year of relay notes is < 1 MB. Sync via the workspace-sync engine (`scripts/sync-workspace.sh`) for fleet visibility — the legacy `sync-memory.sh` flow is deprecated in v0.3.0 and removed in v0.4.0.
 
 ## What to write

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -124,6 +124,25 @@ print(f'5h: {d[\"utilization_5h\"]:.0%} (resets in {m5}min at {r5.strftime(\"%I:
   # Stars
   echo "## Repo Stats"
   gh api repos/sonichi/sutando --jq '.stargazers_count, .forks_count' 2>/dev/null | tr '\n' ' ' | awk '{print $1 " stars, " $2 " forks"}' || echo "(couldn't fetch)"
+  echo ""
+
+  # Relay notes — narrative continuity from prior passes (written by /relay +
+  # proactive-loop step 7). Drain on read: move to processed/ so the next
+  # compaction doesn't re-include them. Fixes #1738: catchup-after-startup
+  # was their only consumer and was removed by PR #1737.
+  RELAY_DIR="$WORKSPACE_DIR/relay"
+  RELAY_PROCESSED="$RELAY_DIR/processed"
+  RELAY_FILES=$(ls -t "$RELAY_DIR"/relay-*.md 2>/dev/null)
+  if [ -n "$RELAY_FILES" ]; then
+    mkdir -p "$RELAY_PROCESSED"
+    echo "## Relay Notes (from prior session)"
+    for rf in $RELAY_FILES; do
+      echo "### $(basename "$rf")"
+      cat "$rf"
+      echo ""
+      mv "$rf" "$RELAY_PROCESSED/" 2>/dev/null || true
+    done
+  fi
 
 } > "$STATE_FILE" 2>/dev/null
 


### PR DESCRIPTION
## What changed, and why?

PR #1737 removed `catchup-after-startup`, which was the **only consumer** of relay notes. Notes written by `/relay` and `proactive-loop` step 7 accumulated in `workspace/relay/` unread — cross-session narrative continuity silently broken.

**Fix:** wire `src/session-handoff.sh` as the new consumer. On context compaction (PreCompact hook), session-handoff now:
1. Reads all unprocessed `relay-*.md` files (newest-first order)
2. Appends them as a `## Relay Notes` section in `session-state.md`
3. Archives each to `relay/processed/` (consumed exactly once)

The next session reads `session-state.md` at startup (per CLAUDE.md), so relay narrative lands in the fresh context window automatically.

Also updates `skills/relay/SKILL.md` to remove the stale `catchup-after-startup` reference and document the new consumer.

## Files to review

- `src/session-handoff.sh` (+19 lines at end) — the new relay drain
- `skills/relay/SKILL.md` — updated consumer description

## Tests

- `bash -n src/session-handoff.sh` — syntax OK
- Placed a `relay-test.md` in `workspace/relay/`, ran `bash src/session-handoff.sh /dev/null`, verified it appeared in `session-state.md` under `## Relay Notes` and was moved to `relay/processed/`.

## Edge cases

- No relay notes: the `RELAY_FILES` variable is empty, section is skipped entirely — no change to existing output.
- Multiple notes: all drained in a single compaction run, newest first.
- Partially-written note (relay dir exists, file in progress): `cat` reads whatever's there; `mv` archives it. Acceptable — the incomplete note is at least surfaced.

## Known gaps

None. The relay folder + processed/ sub-dir are already gitignored via `workspace/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)