### PR TITLE
docs(workspace-contract): update relay consumer from catchup-after-startup → session-handoff.sh

### DIFF
--- a/docs/workspace-contract.md
+++ b/docs/workspace-contract.md
@@ -56,7 +56,7 @@ Resolved by `bash scripts/sutando-config.sh workspace` (the M0 helper). Helpers 
 ├── logs/                   ← append-only chrono streams (bridges, watchers, sync)
 ├── notes/                  ← long-form human-readable content
 ├── data/                   ← durable input data (datasets, fetched feeds)
-├── relay/                  ← inter-session continuity notes (consumed by catchup)
+├── relay/                  ← inter-session continuity notes (drained by session-handoff.sh)
 ├── skills/                 ← user's personal/custom skills (local-only)
 ├── build_log.md            ← single-file done/in-flight/next snapshot (append-only)
 └── pending-questions.md    ← unanswered questions awaiting owner input
@@ -77,7 +77,7 @@ When the agent writes a new file under `<repo>/workspace/`, walk this list top-t
 7. **Done/in-flight/next snapshot?** → append to `build_log.md`.
 8. **Blocked question for the owner?** → append to `pending-questions.md`.
 9. **Durable input data?** → `data/<topic>/`.
-10. **Continuity note for the next session?** → `relay/relay-<ts>.md` (consumed by `/catchup-after-startup`).
+10. **Continuity note for the next session?** → `relay/relay-<ts>.md` (drained by `session-handoff.sh` into `session-state.md` on context compaction).
 11. **Personal skill the user adds for their own use?** → `skills/<skill-name>/` (local-only, not contributed to `skills/` at the repo root).
 
 If two layers seem to fit, prefer the more specific one (state JSON beats logs beats notes).


### PR DESCRIPTION
## What changed, and why?

PR #1737 removed `catchup-after-startup`. PR #1793 fixes `skills/relay/SKILL.md` to reflect the new consumer (`session-handoff.sh`), but two stale references remain in `docs/workspace-contract.md`:

1. **Line 59** — directory tree comment: `relay/ ← ... (consumed by catchup)` → `(drained by session-handoff.sh)`
2. **Line 80** — "Continuity note" decision guide: `(consumed by /catchup-after-startup)` → `(drained by session-handoff.sh into session-state.md on context compaction)`

The changelog entry at line 246 (`catchup PID-stamp sentinel`) is intentionally preserved as historical context.

## Relation to other PRs

- #1737: removed `catchup-after-startup` (root cause)
- #1793: fixes `skills/relay/SKILL.md` (companion PR, still open)
- This PR: cleans up the two remaining doc references in `workspace-contract.md`

## Test plan

- [ ] `grep -n "catchup-after-startup" docs/workspace-contract.md` — only the historical changelog entry (line 246) should remain