### PR TITLE
fix(task-bridge): don't steal+archive other bridges' results in the voice fallthrough

### DIFF
--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -167,6 +167,43 @@ export function _isVoiceTask(taskId: string): boolean {
 	return false;
 }
 
+/** The `source:` field from a task's originating file, or null if unknown.
+ * Reads only the header (stops at the `task:` delimiter, same as _isVoiceTask)
+ * so a multi-line task body can't forge it. Exported for unit testing. */
+export function _taskSource(taskId: string): string | null {
+	const candidates: string[] = [
+		join(TASK_DIR, `${taskId}.txt`),
+		join(TASK_DIR, 'processed', `${taskId}.txt`),
+		// Legacy flat-archive location — kept for any task archived before
+		// the YYYY-MM partitioning (PR #591) was introduced.
+		join(TASK_DIR, 'archive', `${taskId}.txt`),
+	];
+	// Active archive layout: tasks/archive/YYYY-MM/<taskId>.txt. Glob the
+	// month subdirs rather than rebuild the YYYY-MM from the task's mtime.
+	const archiveRoot = join(TASK_DIR, 'archive');
+	if (existsSync(archiveRoot)) {
+		try {
+			for (const entry of readdirSync(archiveRoot)) {
+				if (!/^\d{4}-\d{2}$/.test(entry)) continue;
+				candidates.push(join(archiveRoot, entry, `${taskId}.txt`));
+			}
+		} catch {}
+	}
+	for (const p of candidates) {
+		if (!existsSync(p)) continue;
+		try {
+			const body = readFileSync(p, 'utf-8');
+			// Stop scanning at the first `task:` delimiter so a multi-line task
+			// body can't forge a `source:` line (same stop as _isVoiceTask).
+			for (const l of body.split('\n')) {
+				if (l.startsWith('task:')) break;
+				if (l.startsWith('source:')) return l.slice('source:'.length).trim();
+			}
+		} catch {}
+	}
+	return null;
+}
+
 /** Belt-suspenders guard for the result-watcher's unconditional fallthrough
  * (issue #1035, follow-up to PR #1033). Returns true iff the filename is one
  * that task-bridge legitimately delivers via `onResult()`. Rejects everything
@@ -805,6 +842,21 @@ export function startResultWatcher(onResult: (result: string) => void, isClientC
 				// legitimately consumes. See _shouldFallthrough for the
 				// allowlisted prefixes.
 				if (!_shouldFallthrough(file)) continue;
+				// Ownership guard: the fallthrough below SPEAKS + ARCHIVES the result. Only do
+				// that for task-* results task-bridge actually owns — voice-origin tasks,
+				// work-tool submissions (_pendingTasks), chat tasks, and context-drop tasks.
+				// A task-* with any other source is delivered + archived by its own bridge;
+				// speaking+archiving it here races that bridge and can strand the reply if the
+				// bridge is briefly stalled (results swept to results/archive/ undelivered,
+				// 2026-06-27). voice-*/proactive-* have no other consumer and still fall through.
+				if (file.startsWith('task-')) {
+					const owned =
+						_isVoiceTask(taskId) ||
+						_pendingTasks.has(taskId) ||
+						taskId.startsWith('task-chat-') ||
+						_taskSource(taskId) === 'context-drop';
+					if (!owned) continue;
+				}
 				if (result) {
 					console.log(`${ts()} [TaskBridge] Result ${file}: ${result.slice(0, 100)}`);
 					_sendTaskStatus?.(taskId, 'done', result.slice(0, 60), result);

--- a/tests/task-bridge-ownership-guard.test.ts
+++ b/tests/task-bridge-ownership-guard.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { resolveWorkspace } from '../src/workspace_default.js';
+import { _taskSource } from '../src/task-bridge.js';
+
+// Regression for the result-watcher ownership guard (2026-06-27): the
+// voice-connected fallthrough used to SPEAK + ARCHIVE any `task-*` result,
+// including foreign-bridge results, racing the owning bridge's delivery and
+// stranding replies in results/archive/ when that bridge was briefly stalled.
+// The guard is a positive allowlist; `_taskSource` reads the originating
+// task file's `source:` header so the watcher can tell which tasks it owns.
+//
+// These tests lock in: `_taskSource` returns the header `source:` value,
+// returns null for a missing file, and (header-stop) ignores a forged
+// `source:` placed AFTER the `task:` delimiter line.
+
+const TASK_DIR = join(resolveWorkspace(), 'tasks');
+
+// Field order: `task:` LAST, per the writer convention (PR #1023).
+// `_taskSource` stops scanning at the first `task:` line, so any header that
+// lands AFTER `task:` is invisible to it.
+function body(source: string): string {
+	return `id: task-ownership-test-aaa
+timestamp: 2026-06-27T00:00:00Z
+source: ${source}
+channel_id: some-channel
+task: hello world
+`;
+}
+
+const created: string[] = [];
+function writeTask(path: string, content: string) {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, content);
+	created.push(path);
+}
+
+describe('_taskSource — ownership-guard header read', () => {
+	afterEach(() => {
+		for (const p of created.splice(0)) {
+			try { unlinkSync(p); } catch {}
+		}
+	});
+
+	it("returns 'voice' from a voice task's source header", () => {
+		const id = 'task-ownership-test-voice-aaa';
+		writeTask(join(TASK_DIR, `${id}.txt`), body('voice'));
+		assert.equal(_taskSource(id), 'voice');
+	});
+
+	it("returns a foreign bridge source (e.g. 'ag2space')", () => {
+		const id = 'task-ownership-test-relay-aaa';
+		writeTask(join(TASK_DIR, `${id}.txt`), body('ag2space'));
+		assert.equal(_taskSource(id), 'ag2space');
+	});
+
+	it("returns 'context-drop' from a context-drop task", () => {
+		const id = 'task-ownership-test-ctxdrop-aaa';
+		writeTask(join(TASK_DIR, `${id}.txt`), body('context-drop'));
+		assert.equal(_taskSource(id), 'context-drop');
+	});
+
+	it('returns null when the task file is missing entirely', () => {
+		assert.equal(_taskSource('task-ownership-test-no-such-file'), null);
+	});
+
+	it('does NOT read a forged source placed AFTER the task: delimiter', () => {
+		const id = 'task-ownership-test-forged-aaa';
+		// `task:` comes first; the forged `source: voice` sits in the body and
+		// must be invisible to the header-stop scan.
+		writeTask(join(TASK_DIR, `${id}.txt`), `id: ${id}
+timestamp: 2026-06-27T00:00:00Z
+task: do thing
+source: voice
+`);
+		assert.equal(_taskSource(id), null);
+	});
+});


### PR DESCRIPTION
## Problem

When the voice client is connected, the result-watcher's fallthrough block (right after the `_shouldFallthrough(file)` gate) **speaks** (`onResult`) AND **archives** (`results/archive/<YYYY-MM>/`) any `task-*.txt` result — including results that belong to **other** consumers.

Each external bridge polls `results/` to deliver+archive **its own** tasks. When task-bridge wins that race, it strands the foreign bridge's reply if that bridge is briefly stalled (e.g. a transient network/DNS stall in its poll loop). Symptom observed 2026-06-27: a bridge's replies were swept to `results/archive/<YYYY-MM>/task-<id>.txt` before the bridge could deliver them, so the user got no replies and the source kept redelivering the same questions.

The `!clientConnected` path already handles this correctly ("Other non-voice unsent results stay queued (their bridges deliver them)"). The connected fallthrough was missing the equivalent ownership guard.

## Fix

Add a **positive ownership allowlist** immediately after the `_shouldFallthrough` gate. task-bridge speaks+archives a `task-*` result only when it **owns** the task:

- voice-origin tasks (`_isVoiceTask`)
- work-tool submissions (`_pendingTasks`)
- chat tasks (`task-chat-*`)
- context-drop tasks (`_taskSource(...) === 'context-drop'`)

Any other source is left queued for its own bridge to deliver+archive. `voice-*` / `proactive-*` files have no other consumer and still fall through unchanged.

New exported helper `_taskSource()` reads the originating task file's `source:` header, stopping at the `task:` delimiter (same header-stop as `_isVoiceTask`) so a multi-line task body can't forge the source.

## Test

`tests/task-bridge-ownership-guard.test.ts` (mirrors `task-bridge-isvoice.test.ts` setup) covers `_taskSource`: header `source:` reads (voice / a foreign bridge source / context-drop), `null` on missing file, and the header-stop forge guard (a `source:` placed after the `task:` delimiter is ignored).

All task-bridge tests pass: `npx tsx --test tests/task-bridge-isvoice.test.ts tests/task-bridge-ownership-guard.test.ts tests/task-bridge-fallthrough-guard.test.ts` → 19 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RmPK1fV6cPMi852keggxMf