### PR TITLE
fix(screen-companion): resolve workspace via canonical helper (sweep phase 2, closes #1786)

### DIFF
--- a/skills/screen-companion/tools.ts
+++ b/skills/screen-companion/tools.ts
@@ -20,12 +20,7 @@ import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { loadConfig, discoverConfigs, renderGoal } from './scripts/load-config.js';
 import { readSelection as defaultReadSelection, type SelectionResult } from './scripts/read-selection.js';
 import { registerVisionOnContributor, callUpdateTools, callRestoreTools, captureSendFrame, getFullToolSurface } from '../../src/vision-tools.js';
-
-function resolveWorkspace(): string {
-	const env = process.env.SUTANDO_WORKSPACE;
-	if (env) return env.replace(/^~/, process.env.HOME ?? '');
-	return join(process.env.HOME ?? '', '.sutando', 'workspace');
-}
+import { resolveWorkspace } from '../../src/workspace_default.js';
 
 // Contributor for the screen-share-started system note. Tells Gemini the
 // screen-companion catalog is available AND names the configs the user can


### PR DESCRIPTION
## What changed, and why?

`skills/screen-companion/tools.ts` had a local `resolveWorkspace()` that read `$SUTANDO_WORKSPACE` (honored for one release per #1440, no longer honored post-v0.8) and fell back to the hardcoded `~/.sutando/workspace` path. Users with a workspace configured via `sutando.config.local.json` landed in the legacy home-dir location instead.

**Fix:** drop the local function and import `resolveWorkspace()` from `../../src/workspace_default.js` — the same pattern `obsidian-vault/tools.ts` used in [de1cf5c](https://github.com/sonichi/sutando/commit/de1cf5c) (merged in #1790).

## Relation to #1790 (sweep phase 1)

PR #1790 patched `voice/`, `transcribe/` skill scripts + `context-source-guard.py` + `obsidian-vault/tools.ts`. `screen-companion/tools.ts` was missed in that sweep — this is the remaining file.

## Changes

- `skills/screen-companion/tools.ts` — removes local `resolveWorkspace()` (6 lines), adds canonical import (1 line). Net: -5 lines.

## Test plan

```
npx tsc --noEmit   # passes
```

No existing test coverage for this function (workspace path is env-dependent); the pattern matches what obsidian-vault did in de1cf5c which was accepted in #1790.

🤖 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>