### PR TITLE
fix(query-conversation): resolve DB from workspace, not repo root

### DIFF
--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -134,6 +134,15 @@ npx tsx -e "import 'dotenv/config'; import { summonTool } from './skills/zoom/to
 - Look up contacts and calendar for numbers/PINs before calling
 - The voice agent delegates "call X" and "join my meeting" requests to core via `work`
 
+**Conversation history** — search voice, phone, and Discord voice transcripts stored in `data/conversation.sqlite`:
+```bash
+bash scripts/query-conversation.sh "search term"              # search anywhere in text
+bash scripts/query-conversation.sh "term" --since "1 hour"   # time-bounded
+bash scripts/query-conversation.sh "term" --role user         # filter by role
+bash scripts/query-conversation.sh --last 20                  # latest N turns, no filter
+```
+Output: tab-separated `timestamp | role | text (truncated 200 chars)`. Searches across `voice`, `phone`, and `discord_voice` tables. DB path auto-resolved via M0 workspace helper; override with `$SUTANDO_CONVERSATION_DB`.
+
 **Local skills** — check `$CLAUDE_CONFIG_DIR/skills/` for user-installed skills (video processing, etc.). Always prefer a local skill over raw commands when one exists for the task.
 
 **App launcher** — open any macOS app:

--- a/scripts/query-conversation.sh
+++ b/scripts/query-conversation.sh
@@ -10,8 +10,8 @@
 # Output: tab-separated ts (ISO) | role | text (truncated to 200 chars)
 set -euo pipefail
 
-REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-DB="${SUTANDO_CONVERSATION_DB:-$REPO_DIR/data/conversation.sqlite}"
+_WS="$(bash "$(dirname "$0")/sutando-config.sh" workspace)"
+DB="${SUTANDO_CONVERSATION_DB:-${_WS}/data/conversation.sqlite}"
 
 if [[ ! -f "$DB" ]]; then
 	echo "error: $DB does not exist yet — no conversations recorded" >&2


### PR DESCRIPTION
## Problem

`scripts/query-conversation.sh` defaulted to `<repo>/data/conversation.sqlite`, but the workspace contract places all per-user data under `<workspace>/data/`. On any install where workspace ≠ repo root, the tool either threw "file not found" or silently queried a stale DB while the live one was written elsewhere.

## Fix

- Resolve the DB path via the M0 workspace helper (`sutando-config.sh workspace`), consistent with every other script that reads workspace-resident files.
- `$SUTANDO_CONVERSATION_DB` override still works for tests and non-standard install paths.
- Added `query-conversation.sh` to `docs/built-in-tools.md` so the agent knows to reach for it when searching conversation history.

## Bot review — no merge; owner merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)