### PR TITLE
fix(startup): add relay drain step to restore cross-session narrative continuity (closes #1738)

### DIFF
--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -29,7 +29,7 @@ workspace/relay/
 
 - **File naming:** `relay-{epoch}.md` — sortable + greppable, matches the `task-{epoch}.txt` shape.
 - **Multiple files allowed:** `/relay` always creates a NEW file by default. `--append` appends to the LATEST unprocessed `relay-*.md` instead of creating a new one.
-- **Consumption:** catchup-after-startup reads ALL unprocessed `relay-*.md` files in mtime order (oldest first), prints them as section 0 of its briefing, then `mv`s each one to `processed/` (mirroring the result-watcher drain pattern).
+- **Consumption:** `/startup` step 1.5 reads ALL unprocessed `relay-*.md` files in mtime order (oldest first), prints them at session start, then `mv`s each one to `processed/` (mirroring the result-watcher drain pattern). Prior consumer was `/catchup-after-startup` (removed in #1737; relay drain moved to `/startup` in #1738 fix).
 - **Cleanup:** kept indefinitely on local disk. Tiny files (~200-500 bytes each); a year of relay notes is < 1 MB. Sync via the workspace-sync engine (`scripts/sync-workspace.sh`) for fleet visibility — the legacy `sync-memory.sh` flow is deprecated in v0.3.0 and removed in v0.4.0.
 
 ## What to write
@@ -67,7 +67,7 @@ If the session was genuinely uneventful (read-only, no decisions, no in-flight w
 
 - **Manual-invocation only.** Auto-refresh (writing/updating from `/proactive-loop`) deferred to Phase 2 once we see how owners actually use the manual path.
 - **No quality-gate (refuse-on-thin-note).** Always write whatever the LLM produces. Quality-gate deferred to Phase 2 pending observation.
-- **Read-side** lives in `/catchup-after-startup` — see that skill for the read-then-archive flow.
+- **Read-side** lives in `/startup` step 1.5 — drain runs at session start, prints notes, archives to `processed/`.
 
 ## Phase 2 ideas (NOT in scope)
 

--- a/skills/startup/SKILL.md
+++ b/skills/startup/SKILL.md
@@ -42,6 +42,28 @@ If the skill is not installed, skip silently. `/startup` works without it — ev
 
 Note: this step runs BEFORE step 2 so that the watcher (started by step 2's downstream) doesn't pick up an orphan task before recovery has classified it.
 
+### Step 1.5 — Relay drain (optional)
+
+Drain any pending relay notes left by the prior session so the current session starts with full narrative continuity.
+
+```bash
+WORKSPACE="$(bash scripts/sutando-config.sh workspace)"
+relay_dir="$WORKSPACE/relay"
+processed_dir="$relay_dir/processed"
+```
+
+1. Skip silently if `$relay_dir/relay-*.md` has no matches — no notes to drain.
+2. `mkdir -p "$processed_dir"` (idempotent).
+3. For each file matching `$relay_dir/relay-*.md` in mtime order (oldest first):
+   - Print a header: `📡 Relay note from prior session (<filename>):`
+   - Print the file contents.
+   - `mv` the file to `$processed_dir/` (claim-by-mv mirrors the task/result drain pattern).
+4. Emit a one-line summary: `relay-drain: consumed N note(s) → processed/`.
+
+**Idempotency**: after the drain, `relay-*.md` is empty — re-running is a no-op.
+
+**Why here**: `/catchup-after-startup` (the prior consumer) was removed in PR #1737. The relay write-side (`/relay` skill + `/proactive-loop` step 7) was left intact — see issue #1738. Folding the drain into `/startup` restores the read→archive loop at the earliest point in the session where context is needed, without resurrecting the full catchup machinery. (Closes #1738, option 2.)
+
 ### Step 2 — Register schedules + start watcher
 
 Invoke `/schedule-crons`. This handles:
@@ -68,12 +90,14 @@ session start
     ▼
 /startup
     │
-    ├─► step 1:  /task-orphan-check (optional) ──► classifies + archives orphan tasks
+    ├─► step 1:   /task-orphan-check (optional) ──► classifies + archives orphan tasks
     │
-    ├─► step 2:  /schedule-crons ──┬─► step 1-3 (register crons.json entries)
-    │                               ├─► step 4 (proactive-loop fallback if missing)
-    │                               ├─► step 5 (start watch-tasks-stream.sh via Monitor)
-    │                               └─► step 6 (confirm what was scheduled)
+    ├─► step 1.5: relay drain ──────────────────► prints + mv's relay-*.md → processed/
+    │
+    ├─► step 2:   /schedule-crons ──┬─► step 1-3 (register crons.json entries)
+    │                                ├─► step 4 (proactive-loop fallback if missing)
+    │                                ├─► step 5 (start watch-tasks-stream.sh via Monitor)
+    │                                └─► step 6 (confirm what was scheduled)
     │
     └─► step 3: emit summary
 ```
@@ -95,3 +119,4 @@ If you find yourself wanting to put logic IN `/startup`, ask whether it belongs 
 
 - v0.1.0 — 2026-05-23 — initial draft. Per Chi 2026-05-23 Discord exchange about #1049 redesign ("make a new skill and include everything we need at start"). `/startup` becomes the canonical CLI entry; `/schedule-crons` remains callable for manual cron re-registration. Migration: launchd plists + CLI scripts switch to `/startup`.
 - v0.2.0 — 2026-06-21 — removed the fresh-session briefing step and its session sentinel (that sub-skill was deleted). `/startup` now runs orphan-check → schedules + watcher → confirm; sub-skill idempotency replaces the former sentinel guard.
+- v0.3.0 — 2026-06-27 — added step 1.5 relay drain (closes #1738). `/catchup-after-startup` (removed in #1737) was the sole consumer of `workspace/relay/relay-*.md`; folding the drain into `/startup` restores read→archive continuity at session start without the full catchup machinery.


### PR DESCRIPTION
## Summary

- Closes #1738 (relay skill orphaned after #1737 removed its only consumer)
- Adds **step 1.5 — relay drain** to `/startup` between orphan-check and cron registration
- Updates `relay/SKILL.md` to point the consumer reference to `/startup` step 1.5 instead of the deleted `/catchup-after-startup`

## Problem

PR #1737 removed `/catchup-after-startup` — the only consumer that read `workspace/relay/relay-*.md`, printed it as context, and archived it to `processed/`. The relay write-side (`/relay` skill + `/proactive-loop` step 7) was untouched, so relay notes accumulate unread. Cross-session narrative continuity (intent, in-flight decisions, "what to check first") is silently lost on every restart.

## Fix

Step 1.5 in `/startup`:
1. Skip silently if `relay/` has no `relay-*.md` files (no-op on fresh installs)
2. `mkdir -p relay/processed/`
3. For each file oldest-first: print header + contents → `mv` to `processed/`
4. Emit one-line summary

No new scripts — the agent executes the bash inline, same as the other startup steps. Idempotent: re-running after drain is a no-op.

## Why option 2 (fold into /startup) over option 1 (new lightweight skill)

The drain is three bash lines and a loop. A separate skill would be another file to maintain and another optional-install check in `/startup`. Inline is the right scope for something this small.

## Test plan

- [ ] Boot a fresh session with pending `relay-*.md` files in `workspace/relay/` — notes appear in session context and are moved to `processed/`
- [ ] Boot with no relay files — step 1.5 emits nothing, no errors
- [ ] Re-run `/startup` mid-session after drain — no-op (files already in `processed/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)