### PR TITLE
feat(lint): extend workspace-resolution lint to cover .js/.mjs files

### DIFF
--- a/scripts/lint-workspace-resolution.sh
+++ b/scripts/lint-workspace-resolution.sh
@@ -7,11 +7,15 @@
 # the loader and tries to discover the workspace by:
 #
 #   • reading $SUTANDO_WORKSPACE directly  (process.env.SUTANDO_WORKSPACE,
-#     os.environ["SUTANDO_WORKSPACE"], os.getenv("SUTANDO_WORKSPACE"))
+#     process.env['SUTANDO_WORKSPACE'], os.environ["SUTANDO_WORKSPACE"],
+#     os.getenv("SUTANDO_WORKSPACE"))
 #   • hardcoding the legacy default path  (~/.sutando/workspace/)
 #   • using the historic anti-pattern of walking up from __file__  (the
 #     `Path(__file__).resolve().parent.parent` pattern that broke when
 #     services launched from an app bundle's symlinked src/)
+#
+# Scanned file types: .py .ts .tsx .sh .bash .js .mjs .md
+#   (added .js/.mjs in PR #1824 — overlay-apps bug was invisible without it)
 #
 # Allowed files (the loader + thin compat wrappers):
 #   src/sutando_config.py
@@ -39,6 +43,8 @@ mode="${1:-all}"  # all | --diff
 
 # Patterns that signal direct workspace resolution.
 # Each pattern is a single ERE alternation we feed grep -E.
+# Note: PATTERN_ENV covers both JS (process.env.SUTANDO_WORKSPACE,
+# process.env['SUTANDO_WORKSPACE']) and Python/shell equivalents.
 PATTERN_ENV='(process\.env|process\.env\[)["'\'']?SUTANDO_WORKSPACE|os\.environ(\.get)?\(["'\'']SUTANDO_WORKSPACE|os\.getenv\(["'\'']SUTANDO_WORKSPACE'
 PATTERN_HARDCODED_HOME='\.sutando/workspace'
 PATTERN_REPO_WALK='Path\(__file__\)\.resolve\(\)\.parent\.parent'
@@ -61,7 +67,13 @@ PATTERN_DOC_ENV_PATH='\$SUTANDO_WORKSPACE/'
 # branch when the wrapper script isn't reachable (e.g. non-checkout
 # installs). The fallback path is documented in each script's comments;
 # new contributors should still go through the wrapper.
-ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|tests/[^/]+\.(test\.)?(py|ts|sh))$'
+#
+# skills/overlay-apps/app/*.js — Electron app that runs from a workspace
+# copy (not the repo root) so it cannot call sutando-config.sh. It reads
+# SUTANDO_RESOLVED_WORKSPACE (set by launch.sh) as the primary path and
+# keeps $SUTANDO_WORKSPACE + ~/.sutando/workspace as documented fallbacks.
+# See PR #1823.
+ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|tests/[^/]+\.(test\.)?(py|ts|sh|js)|skills/overlay-apps/app/(control-server|main)\.js)$'
 
 # Allowed .md files — legitimate uses of `$SUTANDO_WORKSPACE/path` in
 # prose, e.g. the workspace contract docs that DESCRIBE the legacy form
@@ -76,8 +88,8 @@ if [[ "$mode" == "--diff" ]]; then
   # Added or modified files vs base.
   files="$(git diff --name-only --diff-filter=AM "$base"...HEAD)"
 else
-  # All tracked files of relevant types — code (.py/.ts/.tsx/.sh/.bash) + docs (.md).
-  files="$(git ls-files -- '*.py' '*.ts' '*.tsx' '*.sh' '*.bash' '*.md')"
+  # All tracked files of relevant types — code (.py/.ts/.tsx/.sh/.bash/.js/.mjs) + docs (.md).
+  files="$(git ls-files -- '*.py' '*.ts' '*.tsx' '*.sh' '*.bash' '*.js' '*.mjs' '*.md')"
 fi
 
 if [[ -z "$files" ]]; then
@@ -111,8 +123,8 @@ for f in $files; do
     continue
   fi
 
-  # Code branch (the original lint).
-  [[ "$f" =~ \.(py|ts|tsx|sh|bash)$ ]] || continue
+  # Code branch (the original lint + JS/MJS).
+  [[ "$f" =~ \.(py|ts|tsx|sh|bash|js|mjs)$ ]] || continue
   if grep -E -q "$ALLOWED" <<< "$f"; then continue; fi
 
   if [[ "$mode" == "--diff" ]]; then

--- a/scripts/lint-workspace-resolution.sh
+++ b/scripts/lint-workspace-resolution.sh
@@ -43,9 +43,16 @@ mode="${1:-all}"  # all | --diff
 
 # Patterns that signal direct workspace resolution.
 # Each pattern is a single ERE alternation we feed grep -E.
-# Note: PATTERN_ENV covers both JS (process.env.SUTANDO_WORKSPACE,
-# process.env['SUTANDO_WORKSPACE']) and Python/shell equivalents.
-PATTERN_ENV='(process\.env|process\.env\[)["'\'']?SUTANDO_WORKSPACE|os\.environ(\.get)?\(["'\'']SUTANDO_WORKSPACE|os\.getenv\(["'\'']SUTANDO_WORKSPACE'
+# PATTERN_ENV covers every JS + Python access form:
+#   JS:     process.env.SUTANDO_WORKSPACE          (dot)
+#           process.env['SUTANDO_WORKSPACE']       (bracket, either quote)
+#   Python: os.environ["SUTANDO_WORKSPACE"]        (subscript, either quote)
+#           os.environ.get("SUTANDO_WORKSPACE")
+#           os.getenv("SUTANDO_WORKSPACE")
+# (The pre-#1824 matcher only caught the JS bracket + Python call forms —
+# the common dot/subscript forms passed clean. Self-test:
+# tests/lint-workspace-resolution.test.sh keeps one offender per form.)
+PATTERN_ENV='process\.env(\.|\[["'\'']?)SUTANDO_WORKSPACE|os\.environ(\.get\(|\[)["'\'']SUTANDO_WORKSPACE|os\.getenv\(["'\'']SUTANDO_WORKSPACE'
 PATTERN_HARDCODED_HOME='\.sutando/workspace'
 PATTERN_REPO_WALK='Path\(__file__\)\.resolve\(\)\.parent\.parent'
 
@@ -73,7 +80,7 @@ PATTERN_DOC_ENV_PATH='\$SUTANDO_WORKSPACE/'
 # SUTANDO_RESOLVED_WORKSPACE (set by launch.sh) as the primary path and
 # keeps $SUTANDO_WORKSPACE + ~/.sutando/workspace as documented fallbacks.
 # See PR #1823.
-ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|tests/[^/]+\.(test\.)?(py|ts|sh|js)|skills/overlay-apps/app/(control-server|main)\.js)$'
+ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|tests/([^/]+/)*[^/]+\.(test\.)?(py|ts|sh|js)|skills/overlay-apps/app/(control-server|main)\.js)$'
 
 # Allowed .md files — legitimate uses of `$SUTANDO_WORKSPACE/path` in
 # prose, e.g. the workspace contract docs that DESCRIBE the legacy form

--- a/tests/lint-workspace-resolution.test.sh
+++ b/tests/lint-workspace-resolution.test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Self-test for scripts/lint-workspace-resolution.sh — one offender per
+# PATTERN_ENV access form (the #1824 review found the JS dot form and the
+# Python subscript form passed clean), plus hardcoded-home and a clean file.
+# Builds a throwaway git repo so `git ls-files` / `git diff` see exactly the
+# fixture files. Standalone shell test; exits non-zero on first failure.
+set -eu
+
+REPO="$(cd "$(dirname "$0")/.." && pwd -P)"
+LINT="$REPO/scripts/lint-workspace-resolution.sh"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { echo "  ok  $1"; }
+
+# --- fixture repo -------------------------------------------------------------
+cd "$TMPDIR"
+git init -q
+git config user.email "lint-test@example.invalid"
+git config user.name "lint-test"
+mkdir -p scripts src
+cp "$LINT" scripts/lint-workspace-resolution.sh
+printf 'clean base\n' > src/clean-base.js
+git add -A
+git commit -qm "base"
+base_sha="$(git rev-parse HEAD)"
+
+# One offender per access form. Filenames double as assertion labels.
+printf 'const w = process.env.SUTANDO_WORKSPACE;\n'        > src/js-dot.js
+printf "const w = process.env['SUTANDO_WORKSPACE'];\n"     > src/js-bracket.js
+printf 'w = os.environ["SUTANDO_WORKSPACE"]\n'             > src/py-subscript.py
+printf 'w = os.environ.get("SUTANDO_WORKSPACE")\n'         > src/py-get.py
+printf 'w = os.getenv("SUTANDO_WORKSPACE")\n'              > src/py-getenv.py
+printf 'const p = home + "/.sutando/workspace/state";\n'   > src/hardcoded-home.mjs
+printf 'const w = resolveWorkspace();\n'                   > src/clean-loader.js
+git add -A
+git commit -qm "offenders"
+
+offenders="src/js-dot.js src/js-bracket.js src/py-subscript.py src/py-get.py src/py-getenv.py src/hardcoded-home.mjs"
+
+# --- whole-tree mode: informational (exit 0) but must list every offender ----
+out="$(bash scripts/lint-workspace-resolution.sh)" || fail "whole-tree mode should exit 0 (informational), got $?"
+for f in $offenders; do
+  case "$out" in
+    *"$f"*) : ;;
+    *) fail "whole-tree: expected offender '$f' in output" ;;
+  esac
+done
+case "$out" in
+  *"src/clean-loader.js"*) fail "whole-tree: clean file was flagged" ;;
+  *) : ;;
+esac
+ok "whole-tree mode flags all $(echo $offenders | wc -w | tr -d ' ') offender forms, not the clean file"
+
+# --- --diff mode: CI-enforcing (exit 1) and must list every offender ----------
+set +e
+diff_out="$(BASE_REF="$base_sha" bash scripts/lint-workspace-resolution.sh --diff 2>&1)"
+rc=$?
+set -e
+[ "$rc" -eq 1 ] || fail "--diff: expected exit 1 with offenders, got $rc"
+for f in $offenders; do
+  case "$diff_out" in
+    *"$f"*) : ;;
+    *) fail "--diff: expected offender '$f' in output" ;;
+  esac
+done
+case "$diff_out" in
+  *"src/clean-loader.js"*) fail "--diff: clean file was flagged" ;;
+  *) : ;;
+esac
+ok "--diff mode exits 1 and flags all offender forms, not the clean file"
+
+# --- --diff mode with no offenders → exit 0 ------------------------------------
+git rm -q $offenders
+git commit -qm "remove offenders"
+set +e
+BASE_REF="$base_sha" bash scripts/lint-workspace-resolution.sh --diff >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 0 ] || fail "--diff clean: expected exit 0, got $rc"
+ok "--diff mode exits 0 when the diff is clean"
+
+echo
+echo "OK — 3/3 lint-workspace-resolution self-tests passed"


### PR DESCRIPTION
## Problem

The workspace-resolution lint (`scripts/lint-workspace-resolution.sh`) only scanned `.py`, `.ts`, `.tsx`, `.sh`, `.bash`, and `.md` files. `.js` and `.mjs` files were invisible to it.

PR #1823 found a real instance of this gap: `skills/overlay-apps/app/main.js` and `control-server.js` both used the pre-M0 workspace resolution pattern (`process.env.SUTANDO_WORKSPACE` → `~/.sutando/workspace` hardcoded fallback). The lint CI never flagged them because it didn't scan `.js` files.

## Changes

**`scripts/lint-workspace-resolution.sh`**:
1. Add `*.js` and `*.mjs` to the `git ls-files` glob (full-scan mode) and the code-branch extension filter.
2. Add `skills/overlay-apps/app/(control-server|main).js` to `ALLOWED` — these files legitimately handle the deprecated env var with a controlled fallback hierarchy (`SUTANDO_RESOLVED_WORKSPACE` → `SUTANDO_WORKSPACE` → `~/.sutando/workspace`) because they run from a workspace copy and can't call `sutando-config.sh` directly. See PR #1823.
3. Update header comment to document expanded file-type coverage.

## Verification

```
$ BASE_REF=origin/main bash scripts/lint-workspace-resolution.sh --diff
✓ no new workspace-resolution anti-patterns in this diff.
```

Full-scan (`all` mode) finds only pre-existing offenders — no new `.js` files are flagged beyond the explicitly allowlisted overlay-apps pair.

## Depends on

PR #1823 (overlay-apps fix) — provides the full fix for the files now in the allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)