### PR TITLE
fix(obs): remove MessageDisplay hook — not a valid Claude Code event (#1755)

### DIFF
--- a/src/observability/claude/hooks/build-hook-settings.mjs
+++ b/src/observability/claude/hooks/build-hook-settings.mjs
@@ -14,9 +14,8 @@
 // Usage:  node build-hook-settings.mjs <abs-path-to-obs-hook.sh>
 // Prints the settings JSON to stdout (exit 2 on missing arg).
 //
-// The 10 event keys are all valid Claude Code hook events, verified against
-// https://code.claude.com/docs/en/hooks.md (incl. UserPromptExpansion and
-// MessageDisplay). Unknown keys would be silently ignored by the CLI.
+// The event keys are all valid Claude Code hook events. MessageDisplay was
+// removed from the valid set; keeping it causes /doctor to warn every session.
 
 const hookScript = process.argv[2];
 if (!hookScript) {
@@ -39,7 +38,6 @@ process.stdout.write(
 		hooks: {
 			UserPromptSubmit: life,
 			UserPromptExpansion: life,
-			MessageDisplay: life,
 			PreToolUse: tool,
 			PostToolUse: tool,
 			Stop: life,

--- a/tests/observability/claude/hooks/build-hook-settings.test.ts
+++ b/tests/observability/claude/hooks/build-hook-settings.test.ts
@@ -33,7 +33,6 @@ const ADVERSARIAL = [
 const EXPECTED_EVENTS = [
 	'UserPromptSubmit',
 	'UserPromptExpansion',
-	'MessageDisplay',
 	'PreToolUse',
 	'PostToolUse',
 	'Stop',


### PR DESCRIPTION
## Summary

- `MessageDisplay` is not a valid Claude Code hook event and was removed from the set some time ago
- Keeping it caused `/doctor` to warn every session for users with obs hooks enabled (SUTANDO_OBS_ENDPOINT set)
- Remove the key from `build-hook-settings.mjs` and update the stale comment

## Test plan

- [ ] Run `node src/observability/claude/hooks/build-hook-settings.mjs /path/to/obs-hook.sh` — output should not include `MessageDisplay`
- [ ] Launch a session with obs hooks enabled; `/doctor` should show no `Unknown hook event` warning

Closes #1755

🤖 Generated with [Claude Code](https://claude.com/claude-code)