### PR TITLE
fix(obs): remove MessageDisplay from hook events (closes #1755)

### DIFF
--- a/src/observability/claude/hooks/build-hook-settings.mjs
+++ b/src/observability/claude/hooks/build-hook-settings.mjs
@@ -14,9 +14,10 @@
 // Usage:  node build-hook-settings.mjs <abs-path-to-obs-hook.sh>
 // Prints the settings JSON to stdout (exit 2 on missing arg).
 //
-// The 10 event keys are all valid Claude Code hook events, verified against
-// https://code.claude.com/docs/en/hooks.md (incl. UserPromptExpansion and
-// MessageDisplay). Unknown keys would be silently ignored by the CLI.
+// The 9 event keys are all valid Claude Code hook events, verified against
+// https://code.claude.com/docs/en/hooks.md (incl. UserPromptExpansion).
+// MessageDisplay was removed from the valid event set; include it would cause
+// /doctor to warn on every session.
 
 const hookScript = process.argv[2];
 if (!hookScript) {
@@ -39,7 +40,6 @@ process.stdout.write(
 		hooks: {
 			UserPromptSubmit: life,
 			UserPromptExpansion: life,
-			MessageDisplay: life,
 			PreToolUse: tool,
 			PostToolUse: tool,
 			Stop: life,

--- a/tests/observability/claude/hooks/build-hook-settings.test.ts
+++ b/tests/observability/claude/hooks/build-hook-settings.test.ts
@@ -33,7 +33,6 @@ const ADVERSARIAL = [
 const EXPECTED_EVENTS = [
 	'UserPromptSubmit',
 	'UserPromptExpansion',
-	'MessageDisplay',
 	'PreToolUse',
 	'PostToolUse',
 	'Stop',


### PR DESCRIPTION
## What changed, and why?

`build-hook-settings.mjs` was registering `MessageDisplay` as a Claude Code hook event, but `MessageDisplay` is no longer in the valid event set. This caused `/doctor` to warn:

> Settings › hooks.MessageDisplay: Unknown hook event "MessageDisplay" was ignored.

on every session for any user with `SUTANDO_OBS_ENDPOINT` set — adding noise and eroding trust in `/doctor` output.

**Fix:** remove the `MessageDisplay: life,` entry from the hooks object and update the count in the comment (10 → 9).

No behavioral change — Claude Code was already silently ignoring the key. The fix just stops the warning.

Closes #1755.

## Test plan
- `node src/observability/claude/hooks/build-hook-settings.mjs /tmp/any-script.sh` produces valid JSON with 9 event keys — no `MessageDisplay` key present.
- `/doctor` no longer warns about `MessageDisplay` for users with obs hooks configured.