### PR TITLE
fix(bridges): read .env from repo root, not workspace

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -54,7 +54,7 @@ except ModuleNotFoundError:
     raise
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from workspace_default import resolve_workspace  # noqa: E402
+from workspace_default import resolve_workspace, resolve_repo_root  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
 import discord_config  # noqa: E402  — Sutando workspace-local discord config (#1147)
 from util_paths import channel_access_path, claude_home_path, personal_path, shared_personal_path  # noqa: E402
@@ -579,7 +579,7 @@ def presenter_mode_active():
 TEAM_TIER_OWNER = ""
 LOCAL_MACHINE = ""
 try:
-    env_file = REPO / ".env"
+    env_file = resolve_repo_root() / ".env"
     if env_file.exists():
         for line in env_file.read_text().splitlines():
             if line.startswith("SUTANDO_TEAM_TIER_OWNER="):

--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -34,7 +34,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from util_paths import claude_home_path  # noqa: E402
-from workspace_default import resolve_workspace  # noqa: E402
+from workspace_default import resolve_workspace, resolve_repo_root  # noqa: E402
 import discord_config  # noqa: E402  — workspace-local Sutando discord config (#1147)
 REPO = resolve_workspace()
 ACCESS_JSON = claude_home_path("channels", "discord", "access.json")
@@ -185,7 +185,7 @@ def _load_token() -> str:
     """Read DISCORD_BOT_TOKEN from the first env file that has it."""
     for env_path in [
         claude_home_path("channels", "discord", ".env"),
-        REPO / ".env",
+        resolve_repo_root() / ".env",
     ]:
         if not env_path.exists():
             continue

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -44,7 +44,7 @@ from result_markers import parse_markers  # noqa: E402
 from task_body_guard import confine_user_content  # noqa: E402
 from util_paths import channel_access_path, claude_home_path  # noqa: E402
 
-from workspace_default import resolve_workspace  # noqa: E402
+from workspace_default import resolve_workspace, resolve_repo_root  # noqa: E402
 from task_archive import find_task_file  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
 import progress_stream  # noqa: E402  (opt-in owner progress streaming, SUTANDO_PROGRESS_STREAM=1)
@@ -90,7 +90,7 @@ def _is_path_sendable(fpath: str) -> bool:
 
 try:
     from dotenv import load_dotenv
-    load_dotenv(REPO / ".env")
+    load_dotenv(resolve_repo_root() / ".env")
 except ImportError:
     pass  # python-dotenv not installed — token loaded from channels config below
 

--- a/src/workspace_default.py
+++ b/src/workspace_default.py
@@ -71,6 +71,17 @@ def _legacy_repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def resolve_repo_root() -> Path:
+    """Return the sutando repo root (the directory that contains `src/`).
+
+    Use this instead of bare `Path(__file__).resolve().parent.parent` in
+    `src/` scripts that need the repo root (e.g. to read `<repo>/.env`).
+    Centralised here so the lint-workspace-resolution CI check has a single
+    allowed location for the pattern.
+    """
+    return _legacy_repo_root()
+
+
 def _migrate_from_legacy(target: Path) -> bool:
     """Move runtime-state dirs from the legacy repo-root fallback into `target`
     on first run after the workspace-default change.

--- a/tests/telegram-bridge-access.test.py
+++ b/tests/telegram-bridge-access.test.py
@@ -47,6 +47,7 @@ sys.modules["task_priority"] = _tp
 # Stub workspace_default
 _wd = types.ModuleType("workspace_default")
 _wd.resolve_workspace = lambda: REPO
+_wd.resolve_repo_root = lambda: REPO
 sys.modules["workspace_default"] = _wd
 
 # Stub vision_push

--- a/tests/workspace-default.test.py
+++ b/tests/workspace-default.test.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(ROOT / "src"))
 import workspace_default  # noqa: E402
 from workspace_default import (  # noqa: E402
     default_workspace_dir,
+    resolve_repo_root,
     resolve_workspace,
     status_path,
     status_read_path,
@@ -745,6 +746,27 @@ class TestPostMigrationDisableBehavior(unittest.TestCase):
             with patch.object(sys, "stderr", buf):
                 resolve_workspace(migrate=True)
             self.assertEqual("", buf.getvalue())
+
+
+class TestResolveRepoRoot(unittest.TestCase):
+    """resolve_repo_root() returns the repo root (parent of src/)."""
+
+    def test_returns_path(self):
+        result = resolve_repo_root()
+        self.assertIsInstance(result, Path)
+
+    def test_contains_src_dir(self):
+        """The returned path must have a src/ subdirectory — it's the repo root."""
+        self.assertTrue((resolve_repo_root() / "src").is_dir())
+
+    def test_distinct_from_workspace(self):
+        """resolve_repo_root() != resolve_workspace() on a default install."""
+        # workspace defaults to <repo>/workspace/, repo root is <repo>/ — not equal.
+        self.assertNotEqual(resolve_repo_root(), resolve_workspace(migrate=False))
+
+    def test_matches_legacy_repo_root(self):
+        """resolve_repo_root() is a stable alias for _legacy_repo_root()."""
+        self.assertEqual(resolve_repo_root(), workspace_default._legacy_repo_root())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Scripts using `REPO = resolve_workspace()` were loading `<workspace>/.env` via `REPO / ".env"` — that path does not exist. The canonical `.env` (holds `SUTANDO_TEAM_TIER_OWNER`, bot tokens, etc.) lives at `<repo>/.env`.
- Adds `resolve_repo_root()` to `workspace_default.py` so callers get the repo root without a raw `parent.parent` (blocked by `lint-workspace-resolution` CI outside of `workspace_default.py`).
- Fixes three callers: `discord-bridge.py` (TEAM_TIER_OWNER loader), `telegram-bridge.py` (initial dotenv load), `dm-result.py` (DISCORD_BOT_TOKEN fallback).

## Affected files

| File | Line | Old | New |
|------|------|-----|-----|
| `src/workspace_default.py` | new | — | `resolve_repo_root()` public helper |
| `src/discord-bridge.py` | 582 | `REPO / ".env"` | `resolve_repo_root() / ".env"` |
| `src/telegram-bridge.py` | 93 | `REPO / ".env"` | `resolve_repo_root() / ".env"` |
| `src/dm-result.py` | 188 | `REPO / ".env"` | `resolve_repo_root() / ".env"` |

## Test plan

- [ ] `discord-bridge.py`: set `SUTANDO_TEAM_TIER_OWNER=test-host` in `<repo>/.env` and confirm the bridge reads it correctly on startup (not from `<workspace>/.env`)
- [ ] `telegram-bridge.py`: set `TELEGRAM_BOT_TOKEN=...` in `<repo>/.env` and confirm the bridge picks it up via `load_dotenv`
- [ ] `dm-result.py`: set `DISCORD_BOT_TOKEN=...` in `<repo>/.env` (without channel .env) and confirm `_load_token()` returns it
- [ ] CI lint: `lint-workspace-resolution` must pass (no bare `parent.parent` outside the allowed list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)