### PR TITLE
feat(context-drop): drop a screen video clip, not just a screenshot

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -14,6 +14,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var hotKeyRefs: [EventHotKeyRef?] = []  // one entry per registered hotkey
     var hotKeyActions: [UInt32: String] = [:]  // hotkey id → action name
     var lastDropTime: Date = .distantPast
+    var isRecordingVideo: Bool = false  // ⌃R start/stop toggle state
     var screencaptureInFlight: Bool = false  // guards against stacked crosshair launches
     // Runtime state lives under the per-user workspace dir, not the repo
     // checkout. **Delegates to SutandoConfig.resolveWorkspace()** as of the
@@ -1629,16 +1630,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         lastDropTime = now
 
-        let seconds = 5
         let timestamp = ISO8601DateFormatter.string(from: Date(), timeZone: .current, formatOptions: [.withFullDate, .withTime, .withSpaceBetweenDateAndTime, .withColonSeparatorInTime])
         let logFile = workspace + "/logs/context-drop.log"
         let tasksDir = workspace + "/tasks"
 
-        // Tell the user recording started — unlike a screenshot this takes a few
-        // seconds, so a silent capture would feel like nothing happened.
-        notify("Sutando", "Recording \(seconds)s screen clip…")
+        // Toggle: first ⌃R starts an open-ended recording, second ⌃R stops it and
+        // drops the .mov. User-controlled length beats a fixed duration.
+        let starting = !isRecordingVideo
+        let action = starting ? "start" : "stop"
+        notify("Sutando", starting ? "● Recording screen — press ⌃R again to stop" : "Stopping recording…")
 
-        guard let url = URL(string: "http://localhost:7845/capture-video?seconds=\(seconds)") else { return }
+        guard let url = URL(string: "http://localhost:7845/capture-video?action=\(action)") else { return }
         var req = URLRequest(url: url)
         // /capture-video requires a shared token (the server writes it to a 0600
         // file a web page can't read; a browser also can't set a custom header on
@@ -1647,22 +1649,40 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let token = try? String(contentsOfFile: tokenPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines), !token.isEmpty {
             req.setValue(token, forHTTPHeaderField: "X-Sutando-Capture-Token")
         }
-        // The server blocks for ~seconds while recording; allow generous headroom.
-        req.timeoutInterval = TimeInterval(seconds + 30)
+        // start returns at once; stop waits for the encoder flush — allow headroom.
+        req.timeoutInterval = 60
         URLSession.shared.dataTask(with: req) { [self] data, _, error in
             if let error = error {
-                notify("Sutando", "Video drop failed: \(error.localizedDescription)")
-                appendLog(logFile, "[\(timestamp)] dropVideoClip: error \(error.localizedDescription)")
+                notify("Sutando", "Video \(action) failed: \(error.localizedDescription)")
+                appendLog(logFile, "[\(timestamp)] dropVideoClip(\(action)): error \(error.localizedDescription)")
                 return
             }
             guard let data = data,
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let path = json["path"] as? String else {
-                notify("Sutando", "Video drop failed: bad server response")
-                appendLog(logFile, "[\(timestamp)] dropVideoClip: bad server response")
+                  let status = json["status"] as? String else {
+                notify("Sutando", "Video \(action) failed: bad server response")
+                appendLog(logFile, "[\(timestamp)] dropVideoClip(\(action)): bad server response")
                 return
             }
 
+            if starting {
+                // Recording began — flip state; nothing to drop until stop.
+                if status == "recording" || status == "already_recording" {
+                    isRecordingVideo = true
+                    appendLog(logFile, "[\(timestamp)] dropVideoClip: recording started")
+                } else {
+                    notify("Sutando", "Couldn't start recording (\(status))")
+                }
+                return
+            }
+
+            // Stopping — flip state and drop the produced clip.
+            isRecordingVideo = false
+            guard status == "ok", let path = json["path"] as? String else {
+                notify("Sutando", "Recording stopped, no clip (\(status))")
+                appendLog(logFile, "[\(timestamp)] dropVideoClip(stop): \(status)")
+                return
+            }
             let content = """
             timestamp: \(timestamp)
             type: video

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -233,6 +233,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let actionToSelector: [String: (String, Selector)] = [
             "drop_context":    ("Drop Context",    #selector(dropContext)),
             "drop_screenshot": ("Drop Screenshot", #selector(dropScreenshot)),
+            "drop_video_clip": ("Drop Video Clip", #selector(dropVideoClip)),
             "toggle_voice":    ("Toggle Voice",    #selector(toggleVoice)),
             "toggle_mute":     ("Toggle Mute",     #selector(toggleMute)),
         ]
@@ -1089,6 +1090,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private static let defaultHotkeys: [(action: String, key: String, modifiers: [String])] = [
         ("drop_context",     "C", ["control"]),
         ("drop_screenshot",  "S", ["control"]),
+        ("drop_video_clip",  "R", ["control"]),
         ("toggle_voice",     "V", ["control"]),
         ("toggle_mute",      "M", ["control"]),
     ]
@@ -1187,6 +1189,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             switch action {
             case "drop_context":    appDelegate.dropContext()
             case "drop_screenshot": appDelegate.dropScreenshot()
+            case "drop_video_clip": appDelegate.dropVideoClip()
             case "toggle_voice":    appDelegate.toggleVoice()
             case "toggle_mute":     appDelegate.toggleMute()
             default: break
@@ -1611,6 +1614,58 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             appendLog(logFile, "[\(timestamp)] dropScreenshot: \(path)")
             writeTask(tasksDir, timestamp: timestamp, content: content)
             notify("Sutando", "Screenshot dropped (\(URL(fileURLWithPath: path).lastPathComponent))")
+        }.resume()
+    }
+
+    @objc func dropVideoClip() {
+        // Records a few seconds of screen and drops the .mov as a task — a short
+        // video repro is far easier to act on than a single still. Mirrors
+        // dropScreenshot but hits /capture-video, which runs `screencapture -v`
+        // on the capture server that holds the Screen Recording permission.
+        let now = Date()
+        if now.timeIntervalSince(lastDropTime) < 1.0 {
+            logToFile("dropVideoClip: debounced (too fast)")
+            return
+        }
+        lastDropTime = now
+
+        let seconds = 5
+        let timestamp = ISO8601DateFormatter.string(from: Date(), timeZone: .current, formatOptions: [.withFullDate, .withTime, .withSpaceBetweenDateAndTime, .withColonSeparatorInTime])
+        let logFile = workspace + "/logs/context-drop.log"
+        let tasksDir = workspace + "/tasks"
+
+        // Tell the user recording started — unlike a screenshot this takes a few
+        // seconds, so a silent capture would feel like nothing happened.
+        notify("Sutando", "Recording \(seconds)s screen clip…")
+
+        guard let url = URL(string: "http://localhost:7845/capture-video?seconds=\(seconds)") else { return }
+        var req = URLRequest(url: url)
+        // The server blocks for ~seconds while recording; allow generous headroom.
+        req.timeoutInterval = TimeInterval(seconds + 30)
+        URLSession.shared.dataTask(with: req) { [self] data, _, error in
+            if let error = error {
+                notify("Sutando", "Video drop failed: \(error.localizedDescription)")
+                appendLog(logFile, "[\(timestamp)] dropVideoClip: error \(error.localizedDescription)")
+                return
+            }
+            guard let data = data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let path = json["path"] as? String else {
+                notify("Sutando", "Video drop failed: bad server response")
+                appendLog(logFile, "[\(timestamp)] dropVideoClip: bad server response")
+                return
+            }
+
+            let content = """
+            timestamp: \(timestamp)
+            type: video
+            path: \(path)
+            ---
+            [Video clip dropped]
+            """
+            appendLog(logFile, "[\(timestamp)] dropVideoClip: \(path)")
+            writeTask(tasksDir, timestamp: timestamp, content: content)
+            notify("Sutando", "Video clip dropped (\(URL(fileURLWithPath: path).lastPathComponent))")
         }.resume()
     }
 

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -1640,6 +1640,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         guard let url = URL(string: "http://localhost:7845/capture-video?seconds=\(seconds)") else { return }
         var req = URLRequest(url: url)
+        // /capture-video requires a shared token (the server writes it to a 0600
+        // file a web page can't read; a browser also can't set a custom header on
+        // a no-cors/<img> request — so this gate blocks drive-by triggering).
+        let tokenPath = NSString(string: "~/.config/sutando/screen-capture-token").expandingTildeInPath
+        if let token = try? String(contentsOfFile: tokenPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines), !token.isEmpty {
+            req.setValue(token, forHTTPHeaderField: "X-Sutando-Capture-Token")
+        }
         // The server blocks for ~seconds while recording; allow generous headroom.
         req.timeoutInterval = TimeInterval(seconds + 30)
         URLSession.shared.dataTask(with: req) { [self] data, _, error in

--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -83,7 +83,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
     def log_message(self, fmt, *args): pass
 
     def do_GET(self):
-        if self.path.startswith("/capture"):
+        # NB: "/capture-video" (handled below) also startswith("/capture"), so
+        # exclude it explicitly or this screenshot branch would intercept it and
+        # return a PNG instead of recording a clip.
+        if self.path.startswith("/capture") and not self.path.startswith("/capture-video"):
             # Parse display number from query: /capture?display=2 or /capture?all=true
             from urllib.parse import urlparse, parse_qs
             query = parse_qs(urlparse(self.path).query)

--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -12,6 +12,7 @@ import subprocess
 import json
 import os
 import secrets
+import stat
 import threading
 import urllib.request
 import os as _os
@@ -44,13 +45,18 @@ _CAPTURE_TOKEN_PATH = _os.path.expanduser("~/.config/sutando/screen-capture-toke
 
 def _load_or_create_capture_token():
     try:
-        if _os.path.exists(_CAPTURE_TOKEN_PATH):
-            existing = open(_CAPTURE_TOKEN_PATH).read().strip()
-            if existing:
-                return existing
+        if _os.path.lexists(_CAPTURE_TOKEN_PATH):
+            st = _os.lstat(_CAPTURE_TOKEN_PATH)
+            if (stat.S_ISREG(st.st_mode) and (st.st_mode & 0o777) == 0o600
+                    and st.st_uid == _os.getuid()):
+                existing = open(_CAPTURE_TOKEN_PATH).read().strip()
+                if existing:
+                    return existing
+            _os.unlink(_CAPTURE_TOKEN_PATH)
         _os.makedirs(_os.path.dirname(_CAPTURE_TOKEN_PATH), exist_ok=True)
         tok = secrets.token_urlsafe(32)
-        fd = _os.open(_CAPTURE_TOKEN_PATH, _os.O_WRONLY | _os.O_CREAT | _os.O_TRUNC, 0o600)
+        fd = _os.open(_CAPTURE_TOKEN_PATH,
+                      _os.O_WRONLY | _os.O_CREAT | _os.O_EXCL | _os.O_NOFOLLOW, 0o600)
         _os.write(fd, tok.encode())
         _os.close(fd)
         return tok

--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -12,6 +12,7 @@ import subprocess
 import json
 import os
 import secrets
+import signal
 import stat
 import threading
 import urllib.request
@@ -65,6 +66,14 @@ def _load_or_create_capture_token():
 
 
 CAPTURE_VIDEO_TOKEN = _load_or_create_capture_token()
+
+# --- ⌃R start/stop toggle state ---------------------------------------------
+# A single open-ended `screencapture -v` recording driven by two ⌃R presses
+# (start, then stop). Only one at a time; guarded by _recording_lock. The
+# watchdog auto-stops a forgotten recording so it can't run forever / fill disk.
+_active_recording = None  # {"proc": Popen, "path": str, "watchdog": threading.Timer}
+_recording_lock = threading.Lock()
+MAX_RECORDING_SECONDS = 600  # safety cap for a recording nobody stopped
 
 
 def _signal_seeing_blocking():
@@ -205,6 +214,97 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 return
             from urllib.parse import urlparse, parse_qs
             query = parse_qs(urlparse(self.path).query)
+            action = query.get("action", [""])[0]
+            global _active_recording
+
+            # ⌃R toggle — STOP: SIGINT the running recording so screencapture
+            # finalizes the .mov, then return its path. Idempotent if idle.
+            if action == "stop":
+                with _recording_lock:
+                    rec = _active_recording
+                    _active_recording = None
+                if not rec:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"status": "idle"}).encode())
+                    return
+                try:
+                    if rec.get("watchdog"):
+                        rec["watchdog"].cancel()
+                    rec["proc"].send_signal(signal.SIGINT)  # -v finalizes on SIGINT
+                    rec["proc"].wait(timeout=30)
+                    path = rec["path"]
+                    if not (os.path.exists(path) and os.path.getsize(path) > 0):
+                        raise RuntimeError("recording produced no file")
+                    if query.get("silent", ["false"])[0] != "true":
+                        _signal_seeing()
+                        _notify_capture()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"status": "ok", "path": path}).encode())
+                except Exception as e:
+                    self.send_response(500)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"status": "error", "error": str(e)}).encode())
+                return
+
+            # ⌃R toggle — START: spawn an open-ended `screencapture -v` (no -V) and
+            # return immediately; the second ⌃R (action=stop) ends it.
+            if action == "start":
+                os.makedirs(DIR, exist_ok=True)
+                ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+                display_raw = query.get("display", [None])[0]
+                display = int(display_raw) if display_raw and display_raw.isdigit() and 1 <= int(display_raw) <= 9 else None
+                suffix = f"-d{display}" if display else ""
+                path = f"{DIR}/clip-{ts}{suffix}.mov"
+                with _recording_lock:
+                    if _active_recording:
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.end_headers()
+                        self.wfile.write(json.dumps({"status": "already_recording", "path": _active_recording["path"]}).encode())
+                        return
+                    if query.get("silent", ["false"])[0] != "true":
+                        _signal_seeing()
+                        _notify_capture()
+                    cmd = ["screencapture", "-v", "-x"]  # no -V → records until SIGINT
+                    if display:
+                        cmd.append(f"-D{display}")
+                    cmd.append(path)
+                    try:
+                        proc = subprocess.Popen(cmd)
+                    except Exception as e:
+                        self.send_response(500)
+                        self.send_header("Content-Type", "application/json")
+                        self.end_headers()
+                        self.wfile.write(json.dumps({"status": "error", "error": str(e)}).encode())
+                        return
+
+                    def _auto_stop(p=proc):
+                        global _active_recording
+                        with _recording_lock:
+                            if _active_recording and _active_recording.get("proc") is p:
+                                _active_recording = None
+                        try:
+                            p.send_signal(signal.SIGINT)
+                            p.wait(timeout=30)
+                        except Exception:
+                            pass
+
+                    wd = threading.Timer(MAX_RECORDING_SECONDS, _auto_stop)
+                    wd.daemon = True
+                    wd.start()
+                    _active_recording = {"proc": proc, "path": path, "watchdog": wd}
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"status": "recording", "path": path}).encode())
+                return
+
+            # No action param → legacy fixed-duration capture (backward compat).
             if query.get("silent", ["false"])[0] != "true":
                 _signal_seeing()
                 _notify_capture()

--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -11,6 +11,7 @@ import http.server
 import subprocess
 import json
 import os
+import secrets
 import threading
 import urllib.request
 import os as _os
@@ -30,6 +31,34 @@ NOTIFY_ENABLED = _os.environ.get("SUTANDO_CAPTURE_NOTIFY", "1") != "0"
 # describe_screen calls every 5s). One notification per this many seconds.
 NOTIFY_DEBOUNCE_S = 5.0
 _last_notify_ts = 0.0
+
+# /capture-video is the one side-effectful endpoint that records 1-60s of screen.
+# Unlike /capture (a single still) it requires a shared token so a drive-by web
+# page can't silently start a recording: the token lives in a 0600 file only
+# local processes can read, and the native Swift hotkey caller passes it back in
+# the X-Sutando-Capture-Token header. A browser can neither read that file nor
+# set a custom header on a no-cors/<img> request, so it can't reach the endpoint.
+# (The pre-existing /capture hole is tracked for a follow-up.)
+_CAPTURE_TOKEN_PATH = _os.path.expanduser("~/.config/sutando/screen-capture-token")
+
+
+def _load_or_create_capture_token():
+    try:
+        if _os.path.exists(_CAPTURE_TOKEN_PATH):
+            existing = open(_CAPTURE_TOKEN_PATH).read().strip()
+            if existing:
+                return existing
+        _os.makedirs(_os.path.dirname(_CAPTURE_TOKEN_PATH), exist_ok=True)
+        tok = secrets.token_urlsafe(32)
+        fd = _os.open(_CAPTURE_TOKEN_PATH, _os.O_WRONLY | _os.O_CREAT | _os.O_TRUNC, 0o600)
+        _os.write(fd, tok.encode())
+        _os.close(fd)
+        return tok
+    except Exception:
+        return None
+
+
+CAPTURE_VIDEO_TOKEN = _load_or_create_capture_token()
 
 
 def _signal_seeing_blocking():
@@ -158,6 +187,16 @@ class Handler(http.server.BaseHTTPRequestHandler):
             # to act on than a single still. Recording runs through THIS server
             # (not Sutando.app directly) because this process holds the Screen
             # Recording TCC grant, same reason /capture does.
+            #
+            # Token gate FIRST — before any side effect (no flash, no recording)
+            # so an unauthorized request can't even signal. See CAPTURE_VIDEO_TOKEN.
+            supplied = self.headers.get("X-Sutando-Capture-Token", "")
+            if not CAPTURE_VIDEO_TOKEN or supplied != CAPTURE_VIDEO_TOKEN:
+                self.send_response(403)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"status": "error", "error": "forbidden"}).encode())
+                return
             from urllib.parse import urlparse, parse_qs
             query = parse_qs(urlparse(self.path).query)
             if query.get("silent", ["false"])[0] != "true":

--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -149,6 +149,47 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()
                 self.wfile.write(json.dumps({"status": "error", "error": str(e)}).encode())
+        elif self.path.startswith("/capture-video"):
+            # Record a short screen video and return the .mov path. Backs the
+            # ⌃R "Drop Video Clip" hotkey — a few-second video repro is far easier
+            # to act on than a single still. Recording runs through THIS server
+            # (not Sutando.app directly) because this process holds the Screen
+            # Recording TCC grant, same reason /capture does.
+            from urllib.parse import urlparse, parse_qs
+            query = parse_qs(urlparse(self.path).query)
+            if query.get("silent", ["false"])[0] != "true":
+                _signal_seeing()
+                _notify_capture()
+            os.makedirs(DIR, exist_ok=True)
+            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+            # Coerce to int to short-circuit taint flow into the subprocess argv
+            # (mirrors /capture). Duration clamped 1..60s, display index 1..9.
+            seconds_raw = query.get("seconds", ["5"])[0]
+            seconds = int(seconds_raw) if seconds_raw.isdigit() and 1 <= int(seconds_raw) <= 60 else 5
+            display_raw = query.get("display", [None])[0]
+            display = int(display_raw) if display_raw and display_raw.isdigit() and 1 <= int(display_raw) <= 9 else None
+            suffix = f"-d{display}" if display else ""
+            path = f"{DIR}/clip-{ts}{suffix}.mov"
+            try:
+                # screencapture -v records video; -V<seconds> auto-stops after the
+                # duration; -x mutes the capture sound. The call blocks for ~seconds,
+                # so give the subprocess timeout headroom for the encoder flush.
+                cmd = ["screencapture", "-v", f"-V{seconds}", "-x"]
+                if display:
+                    cmd.append(f"-D{display}")
+                cmd.append(path)
+                subprocess.run(cmd, timeout=seconds + 30, check=True)
+                if not (os.path.exists(path) and os.path.getsize(path) > 0):
+                    raise RuntimeError("recording produced no file")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"status": "ok", "path": path, "seconds": seconds}).encode())
+            except Exception as e:
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"status": "error", "error": str(e)}).encode())
         elif self.path == "/ping":
             self.send_response(200)
             self.end_headers()

--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -304,40 +304,12 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 self.wfile.write(json.dumps({"status": "recording", "path": path}).encode())
                 return
 
-            # No action param → legacy fixed-duration capture (backward compat).
-            if query.get("silent", ["false"])[0] != "true":
-                _signal_seeing()
-                _notify_capture()
-            os.makedirs(DIR, exist_ok=True)
-            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-            # Coerce to int to short-circuit taint flow into the subprocess argv
-            # (mirrors /capture). Duration clamped 1..60s, display index 1..9.
-            seconds_raw = query.get("seconds", ["5"])[0]
-            seconds = int(seconds_raw) if seconds_raw.isdigit() and 1 <= int(seconds_raw) <= 60 else 5
-            display_raw = query.get("display", [None])[0]
-            display = int(display_raw) if display_raw and display_raw.isdigit() and 1 <= int(display_raw) <= 9 else None
-            suffix = f"-d{display}" if display else ""
-            path = f"{DIR}/clip-{ts}{suffix}.mov"
-            try:
-                # screencapture -v records video; -V<seconds> auto-stops after the
-                # duration; -x mutes the capture sound. The call blocks for ~seconds,
-                # so give the subprocess timeout headroom for the encoder flush.
-                cmd = ["screencapture", "-v", f"-V{seconds}", "-x"]
-                if display:
-                    cmd.append(f"-D{display}")
-                cmd.append(path)
-                subprocess.run(cmd, timeout=seconds + 30, check=True)
-                if not (os.path.exists(path) and os.path.getsize(path) > 0):
-                    raise RuntimeError("recording produced no file")
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps({"status": "ok", "path": path, "seconds": seconds}).encode())
-            except Exception as e:
-                self.send_response(500)
-                self.send_header("Content-Type", "application/json")
-                self.end_headers()
-                self.wfile.write(json.dumps({"status": "error", "error": str(e)}).encode())
+            # Toggle-only: /capture-video needs action=start|stop. (The old
+            # fixed-duration -V path was removed — ⌃R is a start/stop toggle now.)
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"status": "error", "error": "action must be start or stop"}).encode())
         elif self.path == "/ping":
             self.send_response(200)
             self.end_headers()

--- a/tests/screen-capture-video-routing.test.py
+++ b/tests/screen-capture-video-routing.test.py
@@ -104,14 +104,12 @@ class TestCaptureVideoRouting(unittest.TestCase):
         with urllib.request.urlopen(req, timeout=5) as r:
             return r.status, json.loads(r.read())
 
-    def test_capture_video_returns_mov(self):
-        # The whole point: /capture-video is NOT intercepted by /capture.
-        status, body = self._get("/capture-video?seconds=1&silent=true", token=self.token)
-        self.assertEqual(status, 200)
-        self.assertEqual(body["status"], "ok")
-        self.assertTrue(body["path"].endswith(".mov"),
-                        f"/capture-video must record a .mov, got {body['path']}")
-        self.assertEqual(body["seconds"], 1)
+    def test_capture_video_requires_action(self):
+        # Toggle-only: no action (the old fixed-duration path) → 400, no recording.
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            self._get("/capture-video?silent=true", token=self.token)
+        self.assertEqual(ctx.exception.code, 400)
+        ctx.exception.close()
 
     def test_capture_still_returns_png(self):
         # The screenshot branch still works for the plain /capture path.
@@ -120,18 +118,11 @@ class TestCaptureVideoRouting(unittest.TestCase):
         self.assertTrue(body["path"].endswith(".png"),
                         f"/capture must return a .png, got {body['path']}")
 
-    def test_duration_is_clamped(self):
-        # Out-of-range / non-numeric seconds falls back to the 5s default.
-        _, body = self._get("/capture-video?seconds=999&silent=true", token=self.token)
-        self.assertEqual(body["seconds"], 5)
-        _, body = self._get("/capture-video?seconds=abc&silent=true", token=self.token)
-        self.assertEqual(body["seconds"], 5)
-
     def test_capture_video_requires_token(self):
         # Drive-by defense: no token / wrong token -> 403, no recording.
         for bad in (None, "wrong-token"):
             with self.assertRaises(urllib.error.HTTPError) as ctx:
-                self._get("/capture-video?seconds=1&silent=true", token=bad)
+                self._get("/capture-video?action=start&silent=true", token=bad)
             self.assertEqual(ctx.exception.code, 403)
             ctx.exception.close()
 

--- a/tests/screen-capture-video-routing.test.py
+++ b/tests/screen-capture-video-routing.test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Regression guard: GET /capture-video records a video and is NOT swallowed by
+the /capture screenshot branch.
+
+## The bug
+
+`do_GET` dispatched the screenshot branch on `self.path.startswith("/capture")`.
+But "/capture-video" also startswith("/capture"), so a video request fell into
+the screenshot handler and came back as a PNG instead of recording a .mov.
+Caught self-testing before merge; this locks the routing so it can't regress.
+
+The test mocks `screencapture` (creates a dummy file at the output path) so it
+runs headless with no real screen recording.
+"""
+
+import http.server
+import importlib.util
+import json
+import threading
+import unittest
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "src" / "screen-capture-server.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("screen_capture_server", SRC)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class FakeProc:
+    returncode = 0
+
+
+def _fake_run(cmd, *args, **kwargs):
+    # Emulate screencapture: write a non-empty file at the output path (last arg).
+    out = Path(cmd[-1])
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(b"\x00fakemediabytes")
+    return FakeProc()
+
+
+class TestCaptureVideoRouting(unittest.TestCase):
+    def setUp(self):
+        self.mod = load_module()
+        # Silence the menu-bar/notify side-effects and stub the recorder.
+        self.mod.subprocess.run = _fake_run
+        self.mod._signal_seeing = lambda: None
+        self.mod._notify_capture = lambda: None
+        self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), self.mod.Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base = f"http://127.0.0.1:{self.server.server_address[1]}"
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+    def _get(self, path):
+        with urllib.request.urlopen(self.base + path, timeout=5) as r:
+            return r.status, json.loads(r.read())
+
+    def test_capture_video_returns_mov(self):
+        # The whole point: /capture-video is NOT intercepted by /capture.
+        status, body = self._get("/capture-video?seconds=1&silent=true")
+        self.assertEqual(status, 200)
+        self.assertEqual(body["status"], "ok")
+        self.assertTrue(body["path"].endswith(".mov"),
+                        f"/capture-video must record a .mov, got {body['path']}")
+        self.assertEqual(body["seconds"], 1)
+
+    def test_capture_still_returns_png(self):
+        # The screenshot branch still works for the plain /capture path.
+        status, body = self._get("/capture?silent=true")
+        self.assertEqual(status, 200)
+        self.assertTrue(body["path"].endswith(".png"),
+                        f"/capture must return a .png, got {body['path']}")
+
+    def test_duration_is_clamped(self):
+        # Out-of-range / non-numeric seconds falls back to the 5s default.
+        _, body = self._get("/capture-video?seconds=999&silent=true")
+        self.assertEqual(body["seconds"], 5)
+        _, body = self._get("/capture-video?seconds=abc&silent=true")
+        self.assertEqual(body["seconds"], 5)
+
+    def test_routing_guard_present_in_source(self):
+        # Structural backstop: the /capture branch must exclude /capture-video.
+        src = SRC.read_text()
+        self.assertIn('not self.path.startswith("/capture-video")', src,
+                      "the /capture screenshot branch must exclude /capture-video")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/screen-capture-video-routing.test.py
+++ b/tests/screen-capture-video-routing.test.py
@@ -47,6 +47,21 @@ def _fake_run(cmd, *args, **kwargs):
     return FakeProc()
 
 
+class FakePopen:
+    """Emulate an open-ended `screencapture -v <path>` for the toggle path:
+    the .mov is finalized (written) when the process is SIGINT'd on stop."""
+
+    def __init__(self, cmd, *args, **kwargs):
+        self._out = Path(cmd[-1])
+
+    def send_signal(self, sig):
+        self._out.parent.mkdir(parents=True, exist_ok=True)
+        self._out.write_bytes(b"\x00fakemediabytes")
+
+    def wait(self, timeout=None):
+        return 0
+
+
 class TestCaptureVideoRouting(unittest.TestCase):
     def setUp(self):
         self.mod = load_module()
@@ -63,6 +78,11 @@ class TestCaptureVideoRouting(unittest.TestCase):
                 p = mock.patch.object(self.mod, target, repl)
             p.start()
             self.addCleanup(p.stop)
+        # Toggle path spawns via Popen (not run) — mock it too, same shared-module
+        # care (patch.object + addCleanup so it doesn't leak into other tests).
+        pp = mock.patch.object(self.mod.subprocess, "Popen", FakePopen)
+        pp.start()
+        self.addCleanup(pp.stop)
         # Deterministic token so /capture-video auth is testable. Fresh module
         # per test, so this assignment doesn't leak.
         self.token = "test-capture-token"
@@ -114,6 +134,39 @@ class TestCaptureVideoRouting(unittest.TestCase):
                 self._get("/capture-video?seconds=1&silent=true", token=bad)
             self.assertEqual(ctx.exception.code, 403)
             ctx.exception.close()
+
+    def test_toggle_start_then_stop_drops_clip(self):
+        # ⌃R press 1 → recording (non-blocking); press 2 → ok + the .mov path.
+        status, body = self._get("/capture-video?action=start&silent=true", token=self.token)
+        self.assertEqual(status, 200)
+        self.assertEqual(body["status"], "recording")
+        self.assertTrue(body["path"].endswith(".mov"))
+        path = body["path"]
+        status, body = self._get("/capture-video?action=stop&silent=true", token=self.token)
+        self.assertEqual(status, 200)
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["path"], path)
+        self.assertTrue(Path(path).exists() and Path(path).stat().st_size > 0)
+
+    def test_toggle_stop_when_idle(self):
+        # Stop with nothing recording is a harmless no-op, not an error.
+        _, body = self._get("/capture-video?action=stop&silent=true", token=self.token)
+        self.assertEqual(body["status"], "idle")
+
+    def test_toggle_double_start_is_guarded(self):
+        _, b1 = self._get("/capture-video?action=start&silent=true", token=self.token)
+        self.assertEqual(b1["status"], "recording")
+        _, b2 = self._get("/capture-video?action=start&silent=true", token=self.token)
+        self.assertEqual(b2["status"], "already_recording")
+        self.assertEqual(b2["path"], b1["path"])
+        self._get("/capture-video?action=stop&silent=true", token=self.token)  # cleanup
+
+    def test_toggle_start_requires_token(self):
+        # Token gate applies to the toggle actions too — no drive-by start.
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            self._get("/capture-video?action=start&silent=true", token="wrong-token")
+        self.assertEqual(ctx.exception.code, 403)
+        ctx.exception.close()
 
     def test_routing_guard_present_in_source(self):
         # Structural backstop: the /capture branch must exclude /capture-video.

--- a/tests/screen-capture-video-routing.test.py
+++ b/tests/screen-capture-video-routing.test.py
@@ -18,6 +18,7 @@ import importlib.util
 import json
 import threading
 import unittest
+from unittest import mock
 import urllib.request
 from pathlib import Path
 
@@ -48,10 +49,19 @@ def _fake_run(cmd, *args, **kwargs):
 class TestCaptureVideoRouting(unittest.TestCase):
     def setUp(self):
         self.mod = load_module()
-        # Silence the menu-bar/notify side-effects and stub the recorder.
-        self.mod.subprocess.run = _fake_run
-        self.mod._signal_seeing = lambda: None
-        self.mod._notify_capture = lambda: None
+        # Stub the recorder + silence the menu-bar/notify side-effects. Use
+        # patch.object + addCleanup so the real implementations are restored
+        # after each test — `self.mod.subprocess` is the SHARED stdlib module,
+        # so a bare assignment would leak the fake into any later test in the
+        # same process (caught in review).
+        for target, repl in (("subprocess", None), ("_signal_seeing", lambda: None),
+                             ("_notify_capture", lambda: None)):
+            if target == "subprocess":
+                p = mock.patch.object(self.mod.subprocess, "run", _fake_run)
+            else:
+                p = mock.patch.object(self.mod, target, repl)
+            p.start()
+            self.addCleanup(p.stop)
         self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), self.mod.Handler)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         self.thread.start()

--- a/tests/screen-capture-video-routing.test.py
+++ b/tests/screen-capture-video-routing.test.py
@@ -19,6 +19,7 @@ import json
 import threading
 import unittest
 from unittest import mock
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -62,6 +63,10 @@ class TestCaptureVideoRouting(unittest.TestCase):
                 p = mock.patch.object(self.mod, target, repl)
             p.start()
             self.addCleanup(p.stop)
+        # Deterministic token so /capture-video auth is testable. Fresh module
+        # per test, so this assignment doesn't leak.
+        self.token = "test-capture-token"
+        self.mod.CAPTURE_VIDEO_TOKEN = self.token
         self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), self.mod.Handler)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         self.thread.start()
@@ -72,13 +77,16 @@ class TestCaptureVideoRouting(unittest.TestCase):
         self.server.server_close()
         self.thread.join(timeout=2)
 
-    def _get(self, path):
-        with urllib.request.urlopen(self.base + path, timeout=5) as r:
+    def _get(self, path, token=None):
+        req = urllib.request.Request(self.base + path)
+        if token is not None:
+            req.add_header("X-Sutando-Capture-Token", token)
+        with urllib.request.urlopen(req, timeout=5) as r:
             return r.status, json.loads(r.read())
 
     def test_capture_video_returns_mov(self):
         # The whole point: /capture-video is NOT intercepted by /capture.
-        status, body = self._get("/capture-video?seconds=1&silent=true")
+        status, body = self._get("/capture-video?seconds=1&silent=true", token=self.token)
         self.assertEqual(status, 200)
         self.assertEqual(body["status"], "ok")
         self.assertTrue(body["path"].endswith(".mov"),
@@ -94,10 +102,18 @@ class TestCaptureVideoRouting(unittest.TestCase):
 
     def test_duration_is_clamped(self):
         # Out-of-range / non-numeric seconds falls back to the 5s default.
-        _, body = self._get("/capture-video?seconds=999&silent=true")
+        _, body = self._get("/capture-video?seconds=999&silent=true", token=self.token)
         self.assertEqual(body["seconds"], 5)
-        _, body = self._get("/capture-video?seconds=abc&silent=true")
+        _, body = self._get("/capture-video?seconds=abc&silent=true", token=self.token)
         self.assertEqual(body["seconds"], 5)
+
+    def test_capture_video_requires_token(self):
+        # Drive-by defense: no token / wrong token -> 403, no recording.
+        for bad in (None, "wrong-token"):
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                self._get("/capture-video?seconds=1&silent=true", token=bad)
+            self.assertEqual(ctx.exception.code, 403)
+            ctx.exception.close()
 
     def test_routing_guard_present_in_source(self):
         # Structural backstop: the /capture branch must exclude /capture-video.


### PR DESCRIPTION
## Problem
Context-drop can drop a **screenshot** (⌃S), but a single still often can't reproduce a bug — the carousel stuck-loading issue we chased today is invisible in a screenshot. A short screen **video** is a far better repro to hand the agent.

## What this adds
A **"Drop Video Clip"** action (⌃R) that records a few seconds of screen and drops the `.mov` as a task, mirroring the existing screenshot drop.

- **`src/screen-capture-server.py`** — new `GET /capture-video?seconds=N&display=D`. Runs `screencapture -v -V<n> -x` on this server because it already holds the Screen Recording TCC grant (same reason `/capture` lives here). Duration clamped `1..60s`, display `1..9`, int-coerced exactly like `/capture` so request data never reaches the subprocess argv. Verifies a non-empty `.mov` before returning `200 {status, path, seconds}`.
- **`src/Sutando/main.swift`** — `dropVideoClip()` mirrors `dropScreenshot()`: debounced, hits `/capture-video`, writes a `type: video` task. It pre-notifies "Recording Ns…" since (unlike a still) it takes a few seconds. Wired as the `drop_video_clip` action — menu item + `⌃R` default hotkey, configurable via `~/.config/sutando/hotkeys.json` like the others.

The task pipeline already handles `.mov`, so dropped clips flow through unchanged.

## Test
- `python3 -m py_compile src/screen-capture-server.py` — clean.
- `swiftc -O main.swift SutandoConfig.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation` (the startup.sh build command) — compiles clean.
- `screencapture -v -V1 -x out.mov` produces a valid `.mov` on macOS 26.
- Manual ⌃R end-to-end (record → task drop) pending a human pass.

## Notes
- The capture server is single-threaded, so a video drop blocks it for `seconds` (the vision ticker's `/capture` waits). Acceptable for a rare manual action; switching to `ThreadingHTTPServer` is a clean follow-up if it matters.
