### PR TITLE
fix(health-check): read vault.remote_url from config, not SUTANDO_MEMORY_REPO (#1450)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -151,17 +151,25 @@ def check_directory(path: Path, name: str) -> dict:
 
 
 def check_memory_sync() -> dict:
-    """Verify memory sync is configured and has run recently."""
+    """Verify workspace sync is configured and has run recently."""
     name = "memory-sync"
-    env_path = REPO_DIR / ".env"
+    # Canonical: vault.remote_url in sutando.config.local.json (M2+ / sync-workspace.sh).
+    # Backward-compat fallback: SUTANDO_MEMORY_REPO in .env (deprecated, #1446 window).
     repo_url = ""
-    if env_path.exists():
-        for line in env_path.read_text().splitlines():
-            if line.startswith("SUTANDO_MEMORY_REPO="):
-                repo_url = line.split("=", 1)[1].strip().strip('"').strip("'")
-                break
+    try:
+        from sutando_config import resolve_vault  # noqa: PLC0415
+        repo_url = resolve_vault(repo_root=REPO_DIR)["remote_url"]
+    except Exception:
+        pass
     if not repo_url:
-        return {"name": name, "status": "warn", "detail": "SUTANDO_MEMORY_REPO not set — cross-machine sync disabled"}
+        env_path = REPO_DIR / ".env"
+        if env_path.exists():
+            for line in env_path.read_text().splitlines():
+                if line.startswith("SUTANDO_MEMORY_REPO="):
+                    repo_url = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    break
+    if not repo_url:
+        return {"name": name, "status": "warn", "detail": "vault.remote_url not configured — cross-machine sync disabled (set via sutando.config.local.json or run bash scripts/sync-workspace.sh --init)"}
     # Current model (sync-workspace.sh): the workspace ITSELF is a git repo with
     # the vault as a remote — sync = git fetch/merge/push on the workspace, no
     # separate clone dir. So the freshness signal is the workspace's own
@@ -187,7 +195,7 @@ def check_memory_sync() -> dict:
     elif sync_dir_legacy.exists():
         sync_dir = sync_dir_legacy
     else:
-        return {"name": name, "status": "warn", "detail": "repo configured but never synced — run bash scripts/sync-memory.sh"}
+        return {"name": name, "status": "warn", "detail": "repo configured but never synced — run bash scripts/sync-workspace.sh"}
     git_dir = sync_dir / ".git" / "FETCH_HEAD"
     if git_dir.exists():
         age_h = (time.time() - git_dir.stat().st_mtime) / 3600

--- a/tests/health-check-memory-sync-vault.test.py
+++ b/tests/health-check-memory-sync-vault.test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for check_memory_sync() vault.remote_url lookup in src/health-check.py.
+
+Regression coverage for PR #1862 / issue #1450: the health check now reads
+vault.remote_url from sutando.config.local.json (canonical) before falling
+back to SUTANDO_MEMORY_REPO in .env (deprecated). The "never synced" message
+points at sync-workspace.sh instead of sync-memory.sh.
+
+Run: python3 tests/health-check-memory-sync-vault.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+spec = importlib.util.spec_from_file_location(
+    "health_check", REPO / "src" / "health-check.py"
+)
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+
+class TestMemorySyncVaultLookup(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="hc-sync-vault-"))
+        self._saved_repo = hc.REPO_DIR
+        self._saved_ws = hc.WORKSPACE_DIR
+
+    def tearDown(self):
+        hc.REPO_DIR = self._saved_repo
+        hc.WORKSPACE_DIR = self._saved_ws
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _set_repo(self, env_content=""):
+        repo = self.tmp / "repo"
+        repo.mkdir(parents=True, exist_ok=True)
+        if env_content:
+            (repo / ".env").write_text(env_content)
+        hc.REPO_DIR = repo
+        ws = self.tmp / "workspace"
+        ws.mkdir(parents=True, exist_ok=True)
+        hc.WORKSPACE_DIR = ws
+        return repo, ws
+
+    def test_vault_remote_url_read_from_config(self):
+        """vault.remote_url in sutando.config.local.json → no warn about not-configured."""
+        repo, ws = self._set_repo()
+        (repo / "sutando.config.local.json").write_text(
+            json.dumps({"vault": {"enabled": True, "remote_url": "git@github.com:user/vault.git"}})
+        )
+        # Workspace is a git repo so freshness check runs.
+        (ws / ".git").mkdir()
+        with patch("sys.path", [str(REPO / "src")] + sys.path):
+            result = hc.check_memory_sync()
+        # Should not warn about missing config.
+        self.assertNotIn("not configured", result.get("detail", ""))
+        self.assertNotIn("SUTANDO_MEMORY_REPO", result.get("detail", ""))
+
+    def test_env_fallback_when_vault_url_empty(self):
+        """vault.remote_url empty → falls back to SUTANDO_MEMORY_REPO in .env."""
+        repo, ws = self._set_repo(env_content='SUTANDO_MEMORY_REPO=git@github.com:user/vault.git\n')
+        (repo / "sutando.config.local.json").write_text(json.dumps({"vault": {"remote_url": ""}}))
+        (ws / ".git").mkdir()
+        with patch("sys.path", [str(REPO / "src")] + sys.path):
+            result = hc.check_memory_sync()
+        self.assertNotIn("not configured", result.get("detail", ""))
+
+    def test_no_config_no_env_warns_vault_remote_url(self):
+        """Neither vault.remote_url nor SUTANDO_MEMORY_REPO set → warn mentions vault.remote_url."""
+        repo, ws = self._set_repo()
+        with patch("sys.path", [str(REPO / "src")] + sys.path):
+            result = hc.check_memory_sync()
+        self.assertEqual(result["status"], "warn")
+        self.assertIn("vault.remote_url", result["detail"])
+        self.assertNotIn("SUTANDO_MEMORY_REPO", result["detail"])
+
+    def test_never_synced_message_points_at_sync_workspace(self):
+        """'Never synced' hint says sync-workspace.sh, not sync-memory.sh."""
+        repo, ws = self._set_repo()
+        (repo / "sutando.config.local.json").write_text(
+            json.dumps({"vault": {"remote_url": "git@github.com:user/vault.git"}})
+        )
+        # No .git in workspace → falls through to legacy clone path checks
+        # which both fail → "never synced" message.
+        with patch("sys.path", [str(REPO / "src")] + sys.path):
+            result = hc.check_memory_sync()
+        detail = result.get("detail", "")
+        self.assertNotIn("sync-memory.sh", detail)
+        if "never synced" in detail:
+            self.assertIn("sync-workspace.sh", detail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`check_memory_sync()` in `src/health-check.py` read `SUTANDO_MEMORY_REPO` from `.env` — the env var retired in #1446. Users who correctly configured `vault.remote_url` in `sutando.config.local.json` (M2+ / `sync-workspace.sh`) saw a false-positive:

```
[WARN] memory-sync: SUTANDO_MEMORY_REPO not set — cross-machine sync disabled
```

…on every health-check run, even with sync working correctly via `sync-workspace.sh`.

Additionally, the "never synced" fallback message said `sync-memory.sh` (deprecated), not `sync-workspace.sh`.

## Fix

- **Canonical path**: call `resolve_vault(repo_root=REPO_DIR)["remote_url"]` from `sutando_config.py` — reads `vault.remote_url` from `sutando.config.local.json`.
- **Backward-compat fallback**: if `vault.remote_url` is empty, fall back to `SUTANDO_MEMORY_REPO` in `.env` for installs that haven't migrated yet (the #1446 deprecation window).
- **Updated warning**: names `vault.remote_url` (the config key to set) and points at `sync-workspace.sh --init`.
- **Never-synced message**: updated to `sync-workspace.sh` (supersedes PR #1847's string-only change; both files differ here so there's no conflict).

## Tests

4 new cases in `tests/health-check-memory-sync-vault.test.py`:
1. `vault.remote_url` set in config → no "not configured" warning
2. `vault.remote_url` empty + `SUTANDO_MEMORY_REPO` in `.env` → .env fallback works
3. Neither configured → warn message names `vault.remote_url`, not `SUTANDO_MEMORY_REPO`
4. "Never synced" message contains `sync-workspace.sh`, not `sync-memory.sh`

All 4 pass. Existing health-check tests unaffected.

## Closes

- Closes the health-check portion of #1450 (the `SUTANDO_MEMORY_REPO`/`sync-memory.sh` references in `health-check.py`)
- Note to PR #1847 author: this supersedes the string-only change in #1847 on `health-check.py` (line 190 now says `sync-workspace.sh` here too). #1847 may close or rebase out that line if it lands after this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXQJogmVSdYrKtYX1LwzwT