### PR TITLE
fix(health-check): resolve .env from workspace root when absent at repo root

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1079,10 +1079,12 @@ def run_all_checks() -> list[dict]:
     checks.append(check_tcc_documents_access())
 
     # Critical files
+    # .env may live at repo root (startup.sh default) or workspace root (workspace contract).
+    _env_path = REPO_DIR / ".env" if (REPO_DIR / ".env").exists() else WORKSPACE_DIR / ".env"
     for name, path in [
         ("CLAUDE.md", REPO_DIR / "CLAUDE.md"),
         ("build_log.md", WORKSPACE_DIR / "build_log.md"),
-        (".env", REPO_DIR / ".env"),
+        (".env", _env_path),
     ]:
         checks.append(check_file(path, name))
 
@@ -1111,7 +1113,7 @@ def run_all_checks() -> list[dict]:
     checks.append(check_host_subtrees())
 
     # Phone conversation server (optional — only check if Twilio configured and not skipped)
-    env_path = REPO_DIR / ".env"
+    env_path = _env_path
     if env_path.exists():
         env_content = env_path.read_text()
         has_twilio = "TWILIO_ACCOUNT_SID=" in env_content and not env_content.split("TWILIO_ACCOUNT_SID=")[1].startswith("\n")


### PR DESCRIPTION
## Bug

`health-check.py` always probed `REPO_DIR/.env` for the critical-files check. Per the workspace contract, `.env` may legitimately live at `WORKSPACE_DIR/.env` instead — for example when Sutando is installed from a tarball or when the repo and workspace are separate directories (Sutando.app bundles them separately).

Result: every Sutando install where `.env` is in the workspace (not the repo root) gets a permanent false-positive `✗ .env  missing` in every health check run.

## Fix

```python
_env_path = REPO_DIR / ".env" if (REPO_DIR / ".env").exists() else WORKSPACE_DIR / ".env"
```

Tries repo root first (startup.sh default), falls back to workspace root. The same resolved `_env_path` is reused for the Twilio phone probe so both locations are consistent.

## Verified

On a setup where `REPO_DIR/.env` is absent but `WORKSPACE_DIR/.env` exists:
```
Before: ✗ .env   missing   /Users/.../repo/.env
After:  ✓ .env   ok        /Users/.../repo/workspace/.env
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXQJogmVSdYrKtYX1LwzwT