### PR TITLE
fix(startup): set NODE_OPTIONS=--experimental-sqlite for voice-agent

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -603,7 +603,7 @@ reap_wedged_listener() {
 reap_wedged_listener 9900 voice-agent
 if ! lsof -i :9900 > /dev/null 2>&1; then
   echo "  Starting voice agent (port 9900)..."
-  npx tsx src/voice-agent.ts > "$LOGS_DIR/voice-agent.log" 2>&1 &
+  NODE_OPTIONS="--experimental-sqlite" npx tsx src/voice-agent.ts > "$LOGS_DIR/voice-agent.log" 2>&1 &
   echo "  ✓ voice agent"
 else
   echo "  ✓ voice agent (already running)"


### PR DESCRIPTION
## What

Prepend `NODE_OPTIONS="--experimental-sqlite"` to the `npx tsx` invocation that starts the voice agent in `src/startup.sh`.

## Why

`node:sqlite` (used by `conversation-store.ts`) requires the `--experimental-sqlite` flag on Node v22.x. Without it the voice-agent crashes immediately on startup with `ERR_UNKNOWN_BUILTIN_MODULE`.

This regression is **environment-dependent**: a process that inherits the flag from Sutando.app's launch environment starts fine, but a bare `npx` invocation (e.g. manual restart from the terminal, or health-check `--fix` restart) does not inherit it and fails immediately.

## Change

One line in `src/startup.sh`:
```sh
# Before
npx tsx src/voice-agent.ts > "$LOGS_DIR/voice-agent.log" 2>&1 &
# After
NODE_OPTIONS="--experimental-sqlite" npx tsx src/voice-agent.ts > "$LOGS_DIR/voice-agent.log" 2>&1 &
```

## Test plan

- [ ] `bash src/startup.sh` from a clean terminal (no existing voice-agent) starts voice-agent and port 9900 responds within ~3s
- [ ] Manually kill voice-agent (`lsof -i :9900 | grep LISTEN | awk '{print $2}' | xargs kill`) then re-run `bash src/startup.sh` — restarts cleanly without ERR_UNKNOWN_BUILTIN_MODULE
- [ ] `health-check.py --fix` restart path (if it kills + restarts voice-agent) starts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KXQJogmVSdYrKtYX1LwzwT