### PR TITLE
feat(room-react): agent reactions add/remove (parity slice 3)

### DIFF
--- a/skills/room-react/SKILL.md
+++ b/skills/room-react/SKILL.md
@@ -1,0 +1,59 @@
+# room-react — add / remove an agent's reaction on a room event
+
+Closes the **reaction parity gap** vs a chat bot-client (`src/discord-bridge.py`
+auto-reacts 👀 on receipt and removes it when the reply posts — an instant-ack
+UX). Adds native Matrix `m.reaction` add + remove for an agent. Slice 3 of the
+agent-capability parity epic (slices 1–2 = `room-read`, `room-media`).
+
+**Usage:**
+```bash
+# ack receipt on the message that triggered the task (event_id = source_message_id)
+python3 skills/room-react/react.py react '!room:hs' '$evt' --ack received --agent '@a:hs'
+# flip to done, removing the receipt ack
+python3 skills/room-react/react.py react   '!room:hs' '$evt' --ack done --agent '@a:hs'
+python3 skills/room-react/react.py unreact '!room:hs' '$evt' --ack received --agent '@a:hs'
+# or an arbitrary emoji
+python3 skills/room-react/react.py react '!room:hs' '$evt' --key '🎉' --agent '@a:hs'
+```
+
+Named acks (`--ack`): `received` 👀 · `working` ⏳ · `done` ✅ · `fail` ⚠️ (any
+emoji via `--key`). The event to react to is typically the task's
+`source_message_id`. Returns JSON `{ok, room_id, event_id, key, reason}`;
+`ok:false` + reason on any expected failure, never raises. CLI exits 0 for any
+structured result; usage errors exit 2.
+
+## Design — same boundary + pattern as room-read / room-media
+
+- **Orthogonal to the task file bridge**; a separate synchronous call.
+- **Relay-only client** — speaks only the `/v1` relay protocol, holds no
+  platform/AppService token. The relay/broker (box-side) does the actual
+  `m.reaction` send (`react`) and redact (`unreact`) + membership enforcement.
+  - `POST {RELAY_URL}/v1/rooms/{room}/react`   `{event_id, key}`
+  - `POST {RELAY_URL}/v1/rooms/{room}/unreact` `{event_id, key}`
+- **Membership enforced relay-side** (`403` for a non-member); optional local
+  `ROOM_REACT_GATE` is defense-in-depth, not the boundary.
+- **Graceful degrade** — missing relay / gate-deny / `404` (verb unimplemented) /
+  `403` / network → structured `ok:false`, never raises. Additive + versioned.
+- **No platform literals**; relay coords from env/vault.
+
+## Configuration
+
+| env | meaning |
+| --- | --- |
+| `RELAY_URL` / `REMOTE_TASK_URL` | relay base |
+| `RELAY_TOKEN` / `REMOTE_TASK_TOKEN` | relay bearer (optional) |
+| `AGENT_MXID` | the agent identity (relay resolves membership) |
+| `ROOM_REACT_GATE` | optional client gate JSON (defense-in-depth) |
+
+## Tests
+
+`python3 skills/room-react/test_react.py` — 16 unit tests: gate, react/unreact
+endpoints, graceful degrade (404/403/network), arg validation, ack mapping, CLI
+exit-0. No network.
+
+## Status
+
+- Client tool (react + unreact) + gate + tests: done (this skill).
+- Relay-side `POST /v1/rooms/{room}/react|unreact` (membership-enforced,
+  `m.reaction` send/redact) + live e2e: the paired box-side half, tracked in the
+  epic. Remaining slice: delivery/routing markers (then Matrix-surpass).

--- a/skills/room-react/react.py
+++ b/skills/room-react/react.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""room-react — add / remove an agent's reaction on a room event, via the relay.
+
+Closes the **reaction parity gap** vs a chat bot-client (discord-bridge auto-reacts
+👀 on receipt and removes it when the reply posts — an instant-ack UX). This adds
+native Matrix `m.reaction` add + remove for an agent.
+
+The event to react to is typically the task's `source_message_id` (the message
+that triggered the agent), so the agent can ack receipt (👀 / ⏳) immediately and
+flip to done (✅) / fail (❌) when finished.
+
+Two operations, orthogonal to the task file bridge (tasks/ -> results/):
+
+  - react(room, event_id, key)    add an m.reaction (key = emoji) as the agent
+  - unreact(room, event_id, key)  remove (redact) the agent's own reaction
+
+## Architecture boundary (same as room-read / room-media)
+
+The local client speaks ONLY the stable relay `/v1` protocol; it holds no
+platform/AppService token and never talks to a homeserver directly. The
+relay/broker (box-side) owns the creds and does the actual `m.reaction` send +
+redact + membership enforcement. Membership is enforced relay-side (a non-member
+reaction is denied 403); the optional local gate (`ROOM_REACT_GATE`) is
+defense-in-depth, not the boundary.
+
+Graceful degrade: missing relay config, gate-deny, 404 (verb unimplemented), 403
+(not a member), network → structured `ok:false`, never raises. The CLI exits 0
+for any structured result; usage errors exit 2. No platform literals here.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+HTTP_TIMEOUT = 15
+
+# Convenience ack keys (the function still accepts any emoji/key).
+ACK = {"received": "👀", "working": "⏳", "done": "✅", "fail": "⚠️"}
+
+
+def _result(ok, *, room_id=None, event_id=None, key=None, reason=None):
+    return {"ok": bool(ok), "room_id": room_id, "event_id": event_id, "key": key, "reason": reason}
+
+
+# --------------------------------------------------------------------------- #
+# Optional client gate (defense-in-depth; relay is the real enforcer)
+# --------------------------------------------------------------------------- #
+def _gate_path():
+    return os.environ.get("ROOM_REACT_GATE") or os.path.join(os.getcwd(), "room-react-gate.json")
+
+
+def load_gate(path=None):
+    """Missing file -> None (defer to relay). Present -> dict (default-deny)."""
+    path = path or _gate_path()
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return None
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def gate_allows(agent_mxid, room_id, gate):
+    if gate is None:
+        return True  # no client gate -> relay enforces membership
+    entry = gate.get(agent_mxid)
+    if not isinstance(entry, dict):
+        return False
+    if room_id and room_id in (entry.get("rooms") or []):
+        return True
+    return bool(entry.get("all_member_rooms"))
+
+
+# --------------------------------------------------------------------------- #
+# Relay
+# --------------------------------------------------------------------------- #
+def _relay():
+    base = (os.environ.get("RELAY_URL") or os.environ.get("REMOTE_TASK_URL") or "").rstrip("/")
+    token = os.environ.get("RELAY_TOKEN") or os.environ.get("REMOTE_TASK_TOKEN")
+    headers = {"User-Agent": "sutando-room-react/1", "Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return base, headers
+
+
+def _http_post(url, headers, payload):
+    req = urllib.request.Request(url, data=json.dumps(payload).encode(), headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+        return resp.status, resp.read()
+
+
+def _degrade(code):
+    if code == 404:
+        return "verb unimplemented (404)"
+    if code in (401, 403):
+        return f"denied — agent not a joined member ({code})"
+    return f"HTTP {code}"
+
+
+def _op(verb, room_id, event_id, key, agent_mxid, gate):
+    agent_mxid = agent_mxid or os.environ.get("AGENT_MXID")
+    if not room_id or not event_id or not key:
+        return _result(False, room_id=room_id, event_id=event_id, key=key,
+                       reason="room_id, event_id and key are all required")
+    gate = load_gate() if gate is None else gate
+    if not gate_allows(agent_mxid, room_id, gate):
+        return _result(False, room_id=room_id, event_id=event_id, key=key,
+                       reason=f"client gate denied for {agent_mxid}")
+    base, headers = _relay()
+    if not base:
+        return _result(False, room_id=room_id, event_id=event_id, key=key,
+                       reason="no RELAY_URL configured")
+    url = f"{base}/v1/rooms/{urllib.parse.quote(room_id, safe='')}/{verb}"
+    try:
+        _http_post(url, headers, {"event_id": event_id, "key": key})
+    except urllib.error.HTTPError as e:
+        return _result(False, room_id=room_id, event_id=event_id, key=key, reason=_degrade(e.code))
+    except (urllib.error.URLError, TimeoutError) as e:
+        return _result(False, room_id=room_id, event_id=event_id, key=key, reason=f"network error: {e}")
+    return _result(True, room_id=room_id, event_id=event_id, key=key)
+
+
+def react(room_id, event_id, key, agent_mxid=None, *, gate=None):
+    """Add an m.reaction (key = emoji) on `event_id` as the agent."""
+    return _op("react", room_id, event_id, key, agent_mxid, gate)
+
+
+def unreact(room_id, event_id, key, agent_mxid=None, *, gate=None):
+    """Remove (redact) the agent's own `key` reaction on `event_id`."""
+    return _op("unreact", room_id, event_id, key, agent_mxid, gate)
+
+
+def _main(argv):
+    import argparse
+    ap = argparse.ArgumentParser(description="Add/remove an agent reaction on a room event via the relay (gated).")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    for name in ("react", "unreact"):
+        p = sub.add_parser(name)
+        p.add_argument("room_id")
+        p.add_argument("event_id")
+        g = p.add_mutually_exclusive_group(required=True)
+        g.add_argument("--key", help="emoji / reaction key")
+        g.add_argument("--ack", choices=sorted(ACK), help="named ack key (received/working/done/fail)")
+        p.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
+    args = ap.parse_args(argv)
+    key = args.key or ACK[args.ack]
+    fn = react if args.cmd == "react" else unreact
+    res = fn(args.room_id, args.event_id, key, args.agent_mxid)
+    print(json.dumps(res, indent=2))
+    return 0  # structured result -> exit 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv[1:]))

--- a/skills/room-react/room-react-gate.json.example
+++ b/skills/room-react/room-react-gate.json.example
@@ -1,0 +1,5 @@
+{
+  "_comment": "Optional defense-in-depth gate for room-react (same shape as room-read/room-media). DEFAULT-DENY when present; ABSENT file -> defer entirely to relay-side membership enforcement. The relay is the authoritative enforcer regardless.",
+  "@example.agent:your-homeserver": { "rooms": ["!exampleRoomId:your-homeserver"] },
+  "@trusted.agent:your-homeserver": { "all_member_rooms": true }
+}

--- a/skills/room-react/test_react.py
+++ b/skills/room-react/test_react.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Unit tests for react — gate, react/unreact relay verbs, graceful degrade
+(404/403/network), arg validation, ack mapping, CLI exit-0. No network."""
+import json
+import os
+import sys
+import unittest
+import urllib.error
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+import react as r  # noqa: E402
+
+HS = "@agent.a:hs"
+ROOM = "!roomA:hs"
+EV = "$event1"
+KEYS = ["RELAY_URL", "REMOTE_TASK_URL", "RELAY_TOKEN", "REMOTE_TASK_TOKEN"]
+
+
+def _clear(keys):
+    for k in keys:
+        os.environ.pop(k, None)
+
+
+class GateTests(unittest.TestCase):
+    def test_no_gate_defers(self):
+        self.assertTrue(r.gate_allows(HS, ROOM, None))
+
+    def test_empty_denies(self):
+        self.assertFalse(r.gate_allows(HS, ROOM, {}))
+
+    def test_explicit_room(self):
+        self.assertTrue(r.gate_allows(HS, ROOM, {HS: {"rooms": [ROOM]}}))
+
+    def test_all_member(self):
+        self.assertTrue(r.gate_allows(HS, ROOM, {HS: {"all_member_rooms": True}}))
+
+    def test_malformed(self):
+        self.assertFalse(r.gate_allows(HS, ROOM, {HS: 1}))
+
+    def test_load_missing_none(self):
+        self.assertIsNone(r.load_gate("/nonexistent/gate.json"))
+
+
+class OpTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in KEYS}
+        _clear(KEYS)
+
+    def tearDown(self):
+        _clear(KEYS)
+        for k, v in self._saved.items():
+            if v is not None:
+                os.environ[k] = v
+
+    def test_missing_args(self):
+        self.assertFalse(r.react("", EV, "👀", HS)["ok"])
+        self.assertFalse(r.react(ROOM, "", "👀", HS)["ok"])
+        self.assertFalse(r.react(ROOM, EV, "", HS)["ok"])
+
+    def test_gate_deny(self):
+        os.environ["RELAY_URL"] = "https://relay"
+        res = r.react(ROOM, EV, "👀", HS, gate={})
+        self.assertIn("gate denied", res["reason"])
+
+    def test_no_relay(self):
+        res = r.react(ROOM, EV, "👀", HS, gate=None)
+        self.assertEqual(res["reason"], "no RELAY_URL configured")
+
+    def test_404_degrades(self):
+        os.environ["RELAY_URL"] = "https://relay"
+        err = urllib.error.HTTPError("u", 404, "nf", {}, None)
+        with mock.patch.object(r, "_http_post", side_effect=err):
+            res = r.react(ROOM, EV, "👀", HS, gate=None)
+        self.assertIn("unimplemented", res["reason"])
+
+    def test_403_degrades(self):
+        os.environ["RELAY_URL"] = "https://relay"
+        err = urllib.error.HTTPError("u", 403, "no", {}, None)
+        with mock.patch.object(r, "_http_post", side_effect=err):
+            res = r.react(ROOM, EV, "👀", HS, gate=None)
+        self.assertIn("not a joined member", res["reason"])
+
+    def test_network_degrades(self):
+        os.environ["RELAY_URL"] = "https://relay"
+        with mock.patch.object(r, "_http_post", side_effect=urllib.error.URLError("down")):
+            res = r.react(ROOM, EV, "👀", HS, gate=None)
+        self.assertIn("network", res["reason"])
+
+    def test_react_success_hits_react_endpoint(self):
+        os.environ["RELAY_URL"] = "https://relay"
+        captured = {}
+
+        def fake(url, headers, payload):
+            captured["url"] = url
+            captured["payload"] = payload
+            return 200, b"{}"
+
+        with mock.patch.object(r, "_http_post", side_effect=fake):
+            res = r.react(ROOM, EV, "✅", HS, gate=None)
+        self.assertTrue(res["ok"])
+        self.assertTrue(captured["url"].endswith("/react"))
+        self.assertEqual(captured["payload"], {"event_id": EV, "key": "✅"})
+
+    def test_unreact_hits_unreact_endpoint(self):
+        os.environ["RELAY_URL"] = "https://relay"
+        captured = {}
+        with mock.patch.object(r, "_http_post", side_effect=lambda u, h, p: (captured.setdefault("url", u), (200, b"{}"))[1]):
+            res = r.unreact(ROOM, EV, "👀", HS, gate=None)
+        self.assertTrue(res["ok"])
+        self.assertTrue(captured["url"].endswith("/unreact"))
+
+
+class CliTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in KEYS}
+        _clear(KEYS)
+
+    def tearDown(self):
+        _clear(KEYS)
+        for k, v in self._saved.items():
+            if v is not None:
+                os.environ[k] = v
+
+    def test_ack_maps_to_emoji(self):
+        os.environ["RELAY_URL"] = "https://relay"
+        captured = {}
+        with mock.patch.object(r, "_http_post", side_effect=lambda u, h, p: (captured.update(p), (200, b"{}"))[1]):
+            rc = r._main(["react", ROOM, EV, "--ack", "done", "--agent", HS])
+        self.assertEqual(rc, 0)
+        self.assertEqual(captured["key"], r.ACK["done"])
+
+    def test_exit_zero_on_no_context(self):
+        # no relay -> ok:false, but CLI exits 0
+        rc = r._main(["react", ROOM, EV, "--key", "👀", "--agent", HS])
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What — parity slice 3: reactions

Adds `skills/room-react` — native `m.reaction` add/remove for an agent, closing the gap vs a chat bot-client (`src/discord-bridge.py` auto-reacts 👀 on receipt and removes it when the reply posts — the instant-ack UX).

- `react(room, event_id, key)` — `POST /v1/rooms/{room}/react` `{event_id, key}`
- `unreact(room, event_id, key)` — `POST /v1/rooms/{room}/unreact` (redact the agent's own reaction)

Named acks: `received` 👀 · `working` ⏳ · `done` ✅ · `fail` ⚠️ (or any emoji via `--key`). The event is typically the task's `source_message_id`, so an agent can ack receipt immediately and flip to done/fail when finished.

## Built to the same bar as #1869 / #1876

- **Relay-only client** — speaks only the `/v1` relay protocol, holds **no platform/AppService token**; the relay/broker (box-side) does the actual `m.reaction` send + redact + membership enforcement.
- **Membership enforced relay-side** (`403` for a non-member); optional local `ROOM_REACT_GATE` is defense-in-depth, not the boundary.
- **Graceful degrade** — missing relay / gate-deny / `404` (verb unimplemented) / `403` / network → structured `ok:false`, never raises. CLI exits 0 on any structured result.
- **No platform literals**; relay coords from env/vault.

## Tests

`python3 skills/room-react/test_react.py` — **16 unit tests**: gate, react/unreact endpoints, graceful degrade (404/403/network), arg validation, ack mapping, CLI exit-0. No network.

## Not in this PR

- Relay-side `POST /v1/rooms/{room}/react|unreact` (membership-enforced, `m.reaction` send/redact) + live e2e — the paired box-side half, tracked in the parity epic.

Slice 3 of the agent-capability parity epic (slice 1 = room-read #1869 merged; slice 2 = room-media #1876 in review). Remaining: delivery/routing markers, then Matrix-surpass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
