### PR TITLE
feat(core): safe-restart-core.sh — switch model / config from inside the session

### DIFF
--- a/scripts/safe-restart-core.sh
+++ b/scripts/safe-restart-core.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# scripts/safe-restart-core.sh — restart the sutando-core CLI from INSIDE the
+# running core session, to apply config changes (e.g. switch model).
+#
+# Why this exists
+# ---------------
+# scripts/start-cli.sh --restart does `tmux kill-session` then relaunch. Its own
+# header warns: --restart MUST NOT be invoked from inside sutando-core, because
+# kill-session terminates the running agent mid-task — so the relaunch never
+# runs and the core just dies. That makes "agent, restart yourself with a new
+# model" impossible through start-cli.sh alone.
+#
+# This script closes that gap with a DETACHED hand-off: it (1) persists the
+# requested config into .env so the change survives, then (2) spawns a
+# background helper that is immune to the SIGHUP tmux sends on kill-session
+# (via nohup + disown) and reparents to launchd. The helper waits a short delay
+# — long enough for the calling agent to finish writing its reply so the bridge
+# delivers it — then calls `start-cli.sh --restart` with the new config in its
+# environment. Because the helper lives outside the tmux pane's process tree,
+# killing the current agent does NOT kill the helper; it relaunches the core
+# cleanly on the new model.
+#
+# Usage:
+#   bash scripts/safe-restart-core.sh --model <model>       # switch model + restart
+#   bash scripts/safe-restart-core.sh --set KEY=VALUE ...   # set arbitrary .env config + restart
+#   bash scripts/safe-restart-core.sh --model opus --set SUTANDO_OBS_ENDPOINT=...
+#   bash scripts/safe-restart-core.sh --delay 8 --model sonnet
+#   bash scripts/safe-restart-core.sh --dry-run --model opus   # print plan, don't restart
+#
+# Flags:
+#   --model <m>     sugar for --set SUTANDO_CORE_MODEL=<m> (the value start-cli.sh
+#                   passes to `claude --model`). Empty/"default"/"inherit" CLEARS
+#                   the pin so the core inherits the global model.
+#   --set KEY=VAL   upsert an env var into .env (repeatable). KEY must match
+#                   [A-Z_][A-Z0-9_]*; VAL must be single-line.
+#   --delay N       seconds the detached helper waits before restarting (default 5).
+#   --dry-run       persist nothing, spawn nothing; just print what would happen.
+#   --stop-only     don't relaunch after killing (passes through to start-cli.sh).
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$REPO/.env"
+DELAY=5
+DRY_RUN=0
+STOP_ONLY=0
+declare -a SETS=()
+
+die() { echo "safe-restart-core: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --model)
+      [ $# -ge 2 ] || die "--model needs a value"
+      SETS+=("SUTANDO_CORE_MODEL=$2"); shift 2 ;;
+    --set)
+      [ $# -ge 2 ] || die "--set needs KEY=VALUE"
+      SETS+=("$2"); shift 2 ;;
+    --delay)
+      [ $# -ge 2 ] || die "--delay needs a value"
+      case "$2" in ''|*[!0-9]*) die "--delay must be a non-negative integer" ;; esac
+      DELAY="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --stop-only) STOP_ONLY=1; shift ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ "${#SETS[@]}" -gt 0 ] || die "nothing to do — pass --model or --set (or --stop-only with a config)"
+
+# Validate every KEY=VALUE up front so we never partially write .env.
+for kv in "${SETS[@]}"; do
+  key="${kv%%=*}"
+  val="${kv#*=}"
+  [ "$key" != "$kv" ] || die "malformed --set (need KEY=VALUE): $kv"
+  [[ "$key" =~ ^[A-Z_][A-Z0-9_]*$ ]] || die "invalid env key '$key' (must match [A-Z_][A-Z0-9_]*)"
+  case "$val" in
+    *$'\n'*) die "value for $key must be single-line" ;;
+  esac
+done
+
+# Model normalization: treat empty/default/inherit as "clear the pin".
+model_for_env=""
+model_pin_present=0
+for kv in "${SETS[@]}"; do
+  if [ "${kv%%=*}" = "SUTANDO_CORE_MODEL" ]; then
+    model_pin_present=1
+    v="${kv#*=}"
+    case "$v" in default|inherit|"") model_for_env="" ;; *) model_for_env="$v" ;; esac
+  fi
+done
+
+echo "safe-restart-core: repo=$REPO"
+echo "  config changes to persist in .env:"
+for kv in "${SETS[@]}"; do
+  key="${kv%%=*}"; val="${kv#*=}"
+  if [ "$key" = "SUTANDO_CORE_MODEL" ] && [ -z "$model_for_env" ]; then
+    echo "    - $key: (cleared → inherit global model)"
+  else
+    echo "    - $key=$val"
+  fi
+done
+echo "  restart: start-cli.sh --restart$([ $STOP_ONLY -eq 1 ] && echo ' (stop-only)') after ${DELAY}s (detached)"
+
+# ---- persist config into .env (atomic, idempotent upsert) -------------------
+upsert_env() {
+  ENV_FILE="$ENV_FILE" python3 - "$@" <<'PY'
+import os, sys, tempfile
+env = os.environ["ENV_FILE"]
+pairs = []
+for a in sys.argv[1:]:
+    k, _, v = a.partition("=")
+    pairs.append((k, v))
+lines = []
+if os.path.exists(env):
+    with open(env) as f:
+        lines = f.read().splitlines()
+seen = set()
+out = []
+keys = {k for k, _ in pairs}
+def render(k, v):
+    return f"{k}={v}"
+for ln in lines:
+    stripped = ln.lstrip()
+    key = None
+    if stripped and not stripped.startswith("#") and "=" in stripped:
+        key = stripped.split("=", 1)[0].strip()
+    if key in keys:
+        if key not in seen:
+            v = dict(pairs)[key]
+            out.append(render(key, v)); seen.add(key)
+        # drop later duplicate assignments of the same key
+        continue
+    out.append(ln)
+for k, v in pairs:
+    if k not in seen:
+        out.append(render(k, v)); seen.add(k)
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(env) or ".", prefix=".env.")
+with os.fdopen(fd, "w") as f:
+    f.write("\n".join(out) + "\n")
+os.replace(tmp, env)
+PY
+}
+
+if [ $DRY_RUN -eq 1 ]; then
+  echo "  [dry-run] no .env write, no restart spawned."
+  exit 0
+fi
+
+# Persist. For a cleared model pin, write the empty value (start-cli.sh treats
+# empty SUTANDO_CORE_MODEL as "no --model flag").
+declare -a persist=()
+for kv in "${SETS[@]}"; do
+  key="${kv%%=*}"
+  if [ "$key" = "SUTANDO_CORE_MODEL" ]; then
+    persist+=("SUTANDO_CORE_MODEL=$model_for_env")
+  else
+    persist+=("$kv")
+  fi
+done
+upsert_env "${persist[@]}"
+echo "  ✓ .env updated"
+
+# ---- detached restart hand-off ----------------------------------------------
+# nohup + disown → immune to the SIGHUP tmux delivers on kill-session, and
+# reparented to launchd once this shell exits. The model is passed through the
+# helper's ENV directly (not relying on .env being sourced by start-cli.sh),
+# so the immediate relaunch honors it even though start-cli.sh reads only the
+# environment. The .env write above makes it durable for future full startups.
+LOG="$REPO/logs/safe-restart-core.log"
+mkdir -p "$REPO/logs"
+restart_arg="--restart"
+[ $STOP_ONLY -eq 1 ] && restart_arg="--stop-only"
+
+# Build the env-prefix for the helper: only SUTANDO_CORE_MODEL matters to
+# start-cli.sh's launch flags; other --set keys are already in .env for the
+# next startup.sh. Pass model explicitly when pinned.
+if [ $model_pin_present -eq 1 ] && [ -n "$model_for_env" ]; then
+  nohup bash -c "sleep $DELAY; exec env SUTANDO_CORE_MODEL='$model_for_env' bash '$REPO/scripts/start-cli.sh' $restart_arg" \
+    >>"$LOG" 2>&1 &
+else
+  nohup bash -c "sleep $DELAY; exec bash '$REPO/scripts/start-cli.sh' $restart_arg" \
+    >>"$LOG" 2>&1 &
+fi
+disown || true
+
+echo "  ✓ restart scheduled (detached, pid $!) — core will bounce in ~${DELAY}s"
+echo "  log: $LOG"

--- a/src/restart.sh
+++ b/src/restart.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Sutando restart — stops all background services, then restarts via startup.sh.
 # Does NOT touch the Claude Code CLI (core agent) — that's managed separately.
+# To restart the CORE (e.g. to switch model / apply .env config) from inside the
+# running session, use scripts/safe-restart-core.sh (detached, survives its own
+# kill-session). Calling scripts/start-cli.sh --restart from within sutando-core
+# kills the agent before relaunch — see that script's header.
 # Usage: bash src/restart.sh
 #   --stop-only    Stop without restarting
 

--- a/tests/safe-restart-core.test.sh
+++ b/tests/safe-restart-core.test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# tests/safe-restart-core.test.sh — behavioral tests for scripts/safe-restart-core.sh
+#
+# Verifies the two things the script is responsible for WITHOUT ever restarting
+# a real core:
+#   1. .env config upsert is atomic + idempotent (append new key, replace in
+#      place, no duplicate lines, clear-a-pin).
+#   2. the detached restart hand-off fires start-cli.sh with the right arg —
+#      exercised against a harmless stub start-cli.sh in a temp REPO.
+#
+# The script derives REPO from its own location ($(dirname $0)/..), so we run it
+# from a temp REPO layout (tmp/scripts/{safe-restart-core.sh,start-cli.sh}) whose
+# start-cli.sh is a stub that records its args instead of touching tmux.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REAL_SCRIPT="$HERE/../scripts/safe-restart-core.sh"
+[ -f "$REAL_SCRIPT" ] || { echo "FAIL: cannot find $REAL_SCRIPT"; exit 1; }
+
+TMP="$(mktemp -d -t safe-restart-test.XXXXXX)"
+cleanup() { pkill -f "$TMP" 2>/dev/null; rm -rf "$TMP"; }
+trap cleanup EXIT
+
+mkdir -p "$TMP/scripts" "$TMP/logs"
+cp "$REAL_SCRIPT" "$TMP/scripts/safe-restart-core.sh"
+chmod +x "$TMP/scripts/safe-restart-core.sh"
+# Stub start-cli.sh: record args + the model env it was launched with, then exit.
+cat > "$TMP/scripts/start-cli.sh" <<'STUB'
+#!/bin/bash
+echo "args=$*" >> "$(dirname "$0")/../restart-invoked"
+echo "model=${SUTANDO_CORE_MODEL:-<unset>}" >> "$(dirname "$0")/../restart-invoked"
+STUB
+chmod +x "$TMP/scripts/start-cli.sh"
+
+SR="$TMP/scripts/safe-restart-core.sh"
+ENV="$TMP/.env"
+MARK="$TMP/restart-invoked"
+
+pass=0; fail=0
+ok() { echo "  ok: $1"; pass=$((pass+1)); }
+no() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+reset() { rm -f "$ENV" "$MARK"; pkill -f "$TMP" 2>/dev/null; sleep 0.05; }
+
+# --- Case A: --dry-run persists nothing, spawns nothing ----------------------
+reset
+printf 'FOO=bar\n' > "$ENV"
+out="$(bash "$SR" --dry-run --model opus 2>&1)"; rc=$?
+[ $rc -eq 0 ] && grep -q "dry-run" <<<"$out" && ok "dry-run exits 0 and says dry-run" || no "dry-run exit/msg (rc=$rc)"
+grep -q "^FOO=bar$" "$ENV" && ! grep -q "SUTANDO_CORE_MODEL" "$ENV" && ok "dry-run left .env untouched" || no "dry-run mutated .env"
+[ ! -f "$MARK" ] && ok "dry-run spawned no restart" || no "dry-run spawned a restart"
+
+# --- Case B: append a new key, preserve existing --------------------------------
+reset
+printf 'FOO=bar\n' > "$ENV"
+bash "$SR" --model opus --delay 30 >/dev/null 2>&1
+grep -q "^FOO=bar$" "$ENV" && ok "existing key preserved" || no "existing key lost"
+grep -q "^SUTANDO_CORE_MODEL=opus$" "$ENV" && ok "new model key appended" || no "model key not appended"
+
+# --- Case C: replace in place, no duplicate line -----------------------------
+reset
+printf 'SUTANDO_CORE_MODEL=old\nOTHER=1\n' > "$ENV"
+bash "$SR" --model new --delay 30 >/dev/null 2>&1
+n="$(grep -c '^SUTANDO_CORE_MODEL=' "$ENV")"
+[ "$n" -eq 1 ] && ok "exactly one model line after update" || no "duplicate model lines ($n)"
+grep -q "^SUTANDO_CORE_MODEL=new$" "$ENV" && ok "model updated in place" || no "model not updated in place"
+grep -q "^OTHER=1$" "$ENV" && ok "unrelated key preserved on in-place update" || no "unrelated key lost"
+
+# --- Case D: restart actually fires with --restart + model env ---------------
+reset
+: > "$ENV"
+bash "$SR" --model opus --delay 1 >/dev/null 2>&1
+sleep 2
+if [ -f "$MARK" ] && grep -q -- "--restart" "$MARK"; then ok "detached helper invoked start-cli.sh --restart"; else no "restart did not fire"; fi
+grep -q "model=opus" "$MARK" 2>/dev/null && ok "restart carried SUTANDO_CORE_MODEL=opus in env" || no "restart missing model env"
+
+# --- Case E: clear the pin (default) writes empty value ----------------------
+reset
+printf 'SUTANDO_CORE_MODEL=opus\n' > "$ENV"
+bash "$SR" --model default --delay 30 >/dev/null 2>&1
+grep -q "^SUTANDO_CORE_MODEL=$" "$ENV" && ok "model pin cleared to empty" || no "pin not cleared ($(grep SUTANDO_CORE_MODEL "$ENV"))"
+
+# --- Case F: reject invalid env key ------------------------------------------
+reset
+bash "$SR" --set "bad key=1" --delay 30 >/dev/null 2>&1; rc=$?
+[ $rc -ne 0 ] && ok "invalid key rejected (rc=$rc)" || no "invalid key accepted"
+[ ! -f "$MARK" ] && ok "invalid key spawned no restart" || no "invalid key spawned restart"
+
+# --- Case G: --stop-only passes through ---------------------------------------
+reset
+: > "$ENV"
+bash "$SR" --stop-only --set "X=1" --delay 1 >/dev/null 2>&1
+sleep 2
+grep -q -- "--stop-only" "$MARK" 2>/dev/null && ok "stop-only passed through to start-cli.sh" || no "stop-only not passed"
+
+# --- Case H: no-op args error out --------------------------------------------
+reset
+bash "$SR" --delay 5 >/dev/null 2>&1; rc=$?
+[ $rc -ne 0 ] && ok "no config args rejected" || no "no-op accepted"
+
+echo
+echo "safe-restart-core: $pass passed, $fail failed"
+[ $fail -eq 0 ]


### PR DESCRIPTION
## Problem

The running core **can't restart itself** to change its model. `scripts/start-cli.sh --restart` does `tmux kill-session` then relaunch, and its own header warns it MUST NOT be called from inside `sutando-core` — kill-session terminates the agent *before* the relaunch runs, so the core just dies. `start-cli.sh` already accepts `--model` (via `SUTANDO_CORE_MODEL`), but there was no safe way to trigger a bounce from the session that's being replaced. (Owner asked directly: "a safe restart so you can easily change configs including switch model.")

## Approach

`scripts/safe-restart-core.sh`:
1. **Persists** the requested config into `.env` with an atomic, idempotent upsert (replace-in-place, no duplicate lines) — so the change survives future full `startup.sh` runs.
2. **Detaches** the actual restart: spawns a `nohup`+`disown` helper that is immune to the SIGHUP tmux sends on kill-session and reparents to launchd. It waits a short `--delay` (default 5s — long enough for the calling agent to write its reply so the bridge delivers it) then runs `start-cli.sh --restart` with the model in its environment. Because the helper lives outside the tmux pane's process tree, killing the current agent doesn't kill it.

```
bash scripts/safe-restart-core.sh --model opus            # switch model + bounce
bash scripts/safe-restart-core.sh --set KEY=VALUE ...      # arbitrary .env config + bounce
bash scripts/safe-restart-core.sh --model default         # clear the pin (inherit global)
bash scripts/safe-restart-core.sh --dry-run --model opus   # print plan, change nothing
```

`--model` is sugar for `SUTANDO_CORE_MODEL`; `--set KEY=VALUE` (repeatable) handles any other `.env` config; `--delay`, `--dry-run`, `--stop-only` supported. Keys are validated (`[A-Z_][A-Z0-9_]*`), values must be single-line — so a bad `--set` can't corrupt `.env`.

## Tests

`tests/safe-restart-core.test.sh` — 15 cases against a stub `start-cli.sh` in a temp REPO, **never restarts a real core**: dry-run isolation, append-new / replace-in-place / no-duplicate-line / clear-pin upsert, key validation, and the detached helper actually firing `start-cli.sh --restart` with the right arg + model env. All pass.

## Notes / open questions for the reviewer

- **Persistence target is `.env`** — consistent with how `SUTANDO_CORE_MODEL` is already consumed (env-only, set by health-check's `--recover-core`). A follow-up could teach `start-cli.sh` to source `SUTANDO_CORE_MODEL` from `.env` so a bare Sutando.app "Restart Core" (no env) also honors the persisted pin; left out here to keep this PR to one concern and off the launch-critical path.
- **Scope**: kept minimal (model + generic `.env` upsert). Happy to widen to `sutando.config.local.json` if that's the preferred config home.
- Detached hand-off relies on `nohup`+`disown` surviving `tmux kill-session` (standard "survive pane death" behavior on macOS); the test's Case D exercises the real spawn path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)