### PR TITLE
fix(agent-room-ops): don't mislabel a 401 auth failure as "not a joined member"

### DIFF
--- a/skills/agent-room-ops/_gateway.py
+++ b/skills/agent-room-ops/_gateway.py
@@ -81,12 +81,16 @@ def gateway():
     explicit_token = os.environ.get("GATEWAY_TOKEN") or os.environ.get("RELAY_TOKEN")
     raw = explicit_token or os.environ.get("REMOTE_TASK_TOKEN") or ""
     url_from_token = ""
-    if explicit_token:
-        token = explicit_token  # explicit bearer — never split
-    elif "|" in raw:
-        url_from_token, token = raw.split("|", 1)  # combined onboarding string
+    # The combined onboarding string is "https://<gateway>|<secret>" — the URL
+    # travels inside the token. Detect it by the leading URL scheme (NOT a bare
+    # "|"), so this splits even an EXPLICIT combined token while leaving an
+    # explicit bearer that merely contains "|" intact. Without the split, a
+    # `GATEWAY_TOKEN=https://…|secret` was sent whole as the bearer → auth
+    # failure → a 401 the client used to mis-report as "not a joined member".
+    if "|" in raw and raw.split("|", 1)[0].startswith(("http://", "https://")):
+        url_from_token, token = raw.split("|", 1)
     else:
-        token = raw  # bare secret
+        token = raw  # bare secret, or an explicit bearer that isn't combined
     base = (os.environ.get("GATEWAY_URL") or os.environ.get("RELAY_URL")
             or os.environ.get("REMOTE_TASK_URL") or url_from_token or "").rstrip("/")
     headers = {"User-Agent": "sutando-room-ops/1"}
@@ -133,8 +137,13 @@ def degrade_reason(code):
     """Uniform reason for a non-2xx the caller should degrade on (never raise)."""
     if code == 404:
         return "verb unimplemented (404)"
-    if code in (401, 403):
-        return f"denied — agent not a joined member ({code})"
+    if code == 401:
+        # 401 = the gateway could not authenticate the bearer at all (missing /
+        # wrong / un-split combined token) — NOT a membership verdict. Keep this
+        # distinct from 403 so a token problem isn't misread as "not a member".
+        return "auth failed — check the gateway bearer token (401)"
+    if code == 403:
+        return "denied — agent not a joined member (403)"
     return f"HTTP {code}"
 
 

--- a/skills/agent-room-ops/test_room_ops.py
+++ b/skills/agent-room-ops/test_room_ops.py
@@ -264,17 +264,35 @@ class GatewayTokenOnboardingTests(EnvCase):
         self.assertEqual(headers["Authorization"], "Bearer s3cret")
 
     def test_explicit_relay_token_not_split(self):
-        # An explicit RELAY_TOKEN is a bearer, never split on '|'.
+        # An explicit token whose part before '|' is NOT a URL scheme is a real
+        # bearer and kept whole (only the "https://<url>|<secret>" onboarding
+        # form is split).
         os.environ["RELAY_TOKEN"] = "weird|bearer|value"
         os.environ["RELAY_URL"] = "https://r"
         base, headers = _gateway.gateway()
         self.assertEqual(headers["Authorization"], "Bearer weird|bearer|value")
+
+    def test_explicit_combined_gateway_token_is_split(self):
+        # The combined onboarding form is split even when passed EXPLICITLY as
+        # GATEWAY_TOKEN, so `GATEWAY_TOKEN=https://g|secret` authenticates with
+        # just the secret (regression: it used to send the whole string → 401).
+        os.environ["GATEWAY_TOKEN"] = "https://chat.example/relay|s3cr3t"
+        base, headers = _gateway.gateway()
+        self.assertEqual(headers["Authorization"], "Bearer s3cr3t")
+        self.assertEqual(base, "https://chat.example/relay")
 
     def test_bare_secret_needs_url(self):
         os.environ["REMOTE_TASK_TOKEN"] = "baresecret"
         base, headers = _gateway.gateway()
         self.assertEqual(base, "")  # no url anywhere -> empty (op will degrade)
         self.assertEqual(headers["Authorization"], "Bearer baresecret")
+
+    def test_degrade_reason_distinguishes_401_from_403(self):
+        # 401 = auth failure (bad bearer), 403 = real non-member. Keeping them
+        # distinct is what stops a token bug being misread as "not a member".
+        self.assertIn("auth", _gateway.degrade_reason(401).lower())
+        self.assertNotIn("member", _gateway.degrade_reason(401).lower())
+        self.assertIn("member", _gateway.degrade_reason(403).lower())
 
 
 class OutboxAllowlistTests(EnvCase):


### PR DESCRIPTION
## Problem

The agent-room-ops gateway client turned a simple token mistake into a misleading "you're not a room member" error, costing real debugging time (hit live this session, and previously by another operator).

Two compounding issues in `skills/agent-room-ops/_gateway.py`:

1. **Combined token not split when explicit.** The onboarding token is the combined form `https://<gateway>|<secret>`. When passed via `REMOTE_TASK_TOKEN` it was split, but when passed explicitly as `GATEWAY_TOKEN` the code kept it whole (`# explicit bearer — never split`) and sent the entire `url|secret` string as the bearer → the gateway can't authenticate it → **401**.

2. **401 and 403 collapsed into one message.** `degrade_reason()` reported *any* 401/403 as `"denied — agent not a joined member"`. But a gateway **401 = auth failure** (bad/un-split bearer), while **403 = a real non-member**. So the token failure above surfaced as a membership problem, sending debugging down the wrong path entirely.

## Fix

- Split the combined onboarding token **even when passed explicitly**, detected by a **leading URL scheme** (`http://`/`https://`) rather than a bare `|`. This fixes `GATEWAY_TOKEN=https://…|secret` while leaving an explicit bearer that merely contains `|` intact (preserves `test_explicit_relay_token_not_split`).
- `degrade_reason()` now distinguishes **401** (`auth failed — check the gateway bearer token`) from **403** (`not a joined member`).

## Tests

- `test_explicit_combined_gateway_token_is_split` — combined explicit `GATEWAY_TOKEN` → bearer is just the secret, URL extracted.
- `test_degrade_reason_distinguishes_401_from_403`.
- Full suite: **41/41 pass**.

Verified live against the relay: `GATEWAY_TOKEN=<combined>` room read now returns 200 (was 401).

Single concern; no behavior change beyond the two points above.
