### PR TITLE
feat(relay-client): forward core-status in heartbeat for AG2 presence

### DIFF
--- a/src/remote-relay-bridge.py
+++ b/src/remote-relay-bridge.py
@@ -176,20 +176,42 @@ def _post_task_ack(tid: str) -> bool:
         return False
 
 
+_CORE_STEP_MAX = 500
+
+
+def _core_str(v) -> str | None:
+    """A core-status field → bounded non-empty str, or None. core-status.json is
+    written by another process and may be malformed; a non-string field must not
+    be forwarded (the broker calls .lower() on it)."""
+    if not isinstance(v, str):
+        return None
+    v = v.strip()
+    return v[:_CORE_STEP_MAX] if v else None
+
+
 def _read_core_status() -> tuple[str | None, str | None]:
     """Read this node's core-status.json → (status, step) for the presence layer.
     core-status is written by the proactive loop / task handlers (status =
     running|idle, step = human 'what it's doing'). The broker derives the agent's
-    presence badge from it. Best-effort: any error → (None, None) so the
+    presence badge from it.
+
+    MUST NOT raise: this runs in the main loop BEFORE the /v1/tasks poll, so an
+    exception here would back the loop off and stall task delivery — a malformed
+    presence side-channel must never become a delivery blocker. So we guard the
+    JSON shape (a valid-JSON non-object would AttributeError on .get) and coerce
+    every field to a bounded str-or-None; any surprise → (None, None) and the
     heartbeat still fires as a plain liveness ping."""
     try:
         with open(WS / "state" / "core-status.json") as f:
             cs = json.load(f)
-        step = cs.get("step")
+        if not isinstance(cs, dict):
+            return (None, None)
+        status = _core_str(cs.get("status"))
+        step = _core_str(cs.get("step"))
         # An idle status carries no meaningful step — send status only so the
         # sweep reads 'available' rather than stale 'what it was last doing'.
-        return (cs.get("status"), step if cs.get("status") != "idle" else None)
-    except (OSError, ValueError):
+        return (status, None if status == "idle" else step)
+    except Exception:  # noqa: BLE001 — best-effort; never stall the main loop
         return (None, None)
 
 

--- a/src/remote-relay-bridge.py
+++ b/src/remote-relay-bridge.py
@@ -176,8 +176,26 @@ def _post_task_ack(tid: str) -> bool:
         return False
 
 
+def _read_core_status() -> tuple[str | None, str | None]:
+    """Read this node's core-status.json → (status, step) for the presence layer.
+    core-status is written by the proactive loop / task handlers (status =
+    running|idle, step = human 'what it's doing'). The broker derives the agent's
+    presence badge from it. Best-effort: any error → (None, None) so the
+    heartbeat still fires as a plain liveness ping."""
+    try:
+        with open(WS / "state" / "core-status.json") as f:
+            cs = json.load(f)
+        step = cs.get("step")
+        # An idle status carries no meaningful step — send status only so the
+        # sweep reads 'available' rather than stale 'what it was last doing'.
+        return (cs.get("status"), step if cs.get("status") != "idle" else None)
+    except (OSError, ValueError):
+        return (None, None)
+
+
 def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
-    """Best-effort liveness ping for hosted relay dashboards."""
+    """Best-effort liveness + core-status ping. Liveness feeds hosted dashboards;
+    the status/step feed the broker's presence sweep (agent working/available/…)."""
     global _heartbeat_disabled, _last_heartbeat_at
     if _heartbeat_disabled:
         return False
@@ -185,15 +203,24 @@ def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
     if not force and now - _last_heartbeat_at < HEARTBEAT_INTERVAL:
         return False
     _last_heartbeat_at = now
+    _status, _step = _read_core_status()
     try:
-        _req("POST", "/v1/heartbeat", {
+        payload = {
             "client": "sutando-relay-client",
             "protocol_version": 1,
             "provider": PROVIDER,
             "tier": LOCAL_TIER,
             "inflight": len(inflight),
-            "capabilities": ["task-ack", "heartbeat", "result-skip-markers"],
-        }, timeout=10)
+            "capabilities": ["task-ack", "heartbeat", "result-skip-markers",
+                             "core-status"],
+        }
+        # Only include when present so a status-less node never clobbers the
+        # broker's last-known core-status (the broker only records on presence).
+        if _status is not None:
+            payload["status"] = _status
+        if _step is not None:
+            payload["step"] = _step
+        _req("POST", "/v1/heartbeat", payload, timeout=10)
         return True
     except urllib.error.HTTPError as e:
         if e.code in (404, 405):

--- a/src/remote-relay-bridge.test.py
+++ b/src/remote-relay-bridge.test.py
@@ -177,6 +177,31 @@ def main() -> int:
     check(hb2.get("status") == "idle" and "step" not in hb2,
           "idle status sends no step (avoids stale 'what it was doing')")
 
+    # SECURITY / robustness: core-status.json is written by another process and
+    # may be malformed. _read_core_status runs in the main loop BEFORE the poll,
+    # so it MUST NOT raise (else it stalls task delivery). Regression for the
+    # #1884 blocking finding.
+    csf = rtc.WS / "state" / "core-status.json"
+    csf.write_text(json.dumps(["not", "an", "object"]))   # valid JSON, not a dict
+    check(rtc._read_core_status() == (None, None),
+          "valid-JSON non-object core-status → (None, None), no crash")
+    csf.write_text(json.dumps({"status": {"x": 1}, "step": ["y"]}))  # non-string fields
+    check(rtc._read_core_status() == (None, None),
+          "non-string status/step → (None, None), never forwarded")
+    csf.write_text("{ this is not json")                   # malformed JSON
+    check(rtc._read_core_status() == (None, None), "malformed JSON → (None, None)")
+    csf.write_text(json.dumps({"status": "running", "step": "x" * 5000}))  # oversized
+    st, sp = rtc._read_core_status()
+    check(st == "running" and sp is not None and len(sp) == rtc._CORE_STEP_MAX,
+          "oversized step is bounded, not forwarded whole")
+    # a malformed file must not break the heartbeat POST either (best-effort)
+    csf.write_text(json.dumps([1, 2, 3]))
+    STATE["heartbeats"].clear(); rtc._last_heartbeat_at = 0.0
+    check(rtc._post_heartbeat(set(), force=True), "heartbeat still fires despite malformed core-status")
+    hb3 = STATE["heartbeats"][-1] if STATE["heartbeats"] else {}
+    check("status" not in hb3 and "step" not in hb3,
+          "malformed core-status → heartbeat omits status/step (liveness-only)")
+
     # Backwards compatibility: old relays that only implement pull/results can
     # 404 optional protocol extensions; the client disables them and continues.
     STATE["force_ack_404"] = True

--- a/src/remote-relay-bridge.test.py
+++ b/src/remote-relay-bridge.test.py
@@ -110,6 +110,11 @@ def main() -> int:
     os.environ["REMOTE_TASK_URL"] = f"http://127.0.0.1:{port}"
     os.environ["REMOTE_TASK_TOKEN"] = "testtoken"
     os.environ["REMOTE_TASK_PROVIDER"] = "remote-relay"
+    # Pin the tier so LOCAL_TIER is deterministic. Without this the module reads
+    # the host's ambient REMOTE_TASK_TIER (e.g. "owner" on the owner's own node),
+    # and the access_tier-clamp + newline-forge assertions — which expect the
+    # "team" default — fail non-hermetically depending on where the suite runs.
+    os.environ["REMOTE_TASK_TIER"] = "team"
 
     # import the hyphenated module by path (env must be set first — module reads
     # config + resolves workspace at import time)
@@ -147,6 +152,30 @@ def main() -> int:
         check("result-skip-markers" in h.get("capabilities", [])
               and "result-markers" not in h.get("capabilities", []),
               "heartbeat advertises only local skip-marker handling")
+        check("core-status" in h.get("capabilities", [])
+              and "status" not in h and "step" not in h,
+              "no core-status.json → capability advertised, status/step omitted (no-clobber)")
+
+    # Presence: with a core-status.json, the heartbeat carries status+step so the
+    # broker's presence sweep can derive the agent's activity + human text.
+    (rtc.WS / "state").mkdir(parents=True, exist_ok=True)
+    (rtc.WS / "state" / "core-status.json").write_text(
+        json.dumps({"status": "running", "step": "opening PR #20", "ts": 1}))
+    STATE["heartbeats"].clear()
+    rtc._last_heartbeat_at = 0.0
+    rtc._post_heartbeat({"task-MOCK1"}, force=True)
+    hb = STATE["heartbeats"][-1] if STATE["heartbeats"] else {}
+    check(hb.get("status") == "running" and hb.get("step") == "opening PR #20",
+          "heartbeat carries core-status status+step when core-status.json present")
+    # An idle status drops the (stale) step so the sweep reads 'available'.
+    (rtc.WS / "state" / "core-status.json").write_text(
+        json.dumps({"status": "idle", "ts": 2}))
+    STATE["heartbeats"].clear()
+    rtc._last_heartbeat_at = 0.0
+    rtc._post_heartbeat(set(), force=True)
+    hb2 = STATE["heartbeats"][-1] if STATE["heartbeats"] else {}
+    check(hb2.get("status") == "idle" and "step" not in hb2,
+          "idle status sends no step (avoids stale 'what it was doing')")
 
     # Backwards compatibility: old relays that only implement pull/results can
     # 404 optional protocol extensions; the client disables them and continues.


### PR DESCRIPTION
## Relay client: forward `core-status` in heartbeat (AG2 presence, client half)

The AG2 Space broker now has a presence sweep + a `/v1/heartbeat` endpoint (ag2-space/ag2space-backend #18, #20). This is the client half: the relay client already POSTs `/v1/heartbeat` every interval — now it includes this node's **`core-status.json`** (`{status, step}`) so the broker can derive the agent's presence badge (working / available / needs-attention) and the human "what it's doing" text.

Same `core-status` signal the Discord bridge already streams locally (`progress_stream.read_core_status`) — reused, not reinvented, so an agent "opening PR #20" reads the same in Discord and in AG2.

### Change
- `_read_core_status()` reads `<workspace>/state/core-status.json`, **best-effort** — any error → omitted, heartbeat still fires as a plain liveness ping.
- **Idle** status sends **no step**, so the sweep reads `available` rather than a stale "what it was last doing".
- `status`/`step` included **only when present** → never clobbers the broker's last-known status. Advertises a `core-status` capability.
- **Backward compatible**: brokers without `/v1/heartbeat` still 404 + self-disable, exactly as today.

### Tests
`remote-relay-bridge.test.py` extended: status+step carried when `core-status.json` present · omitted (capability-only) when absent · idle drops step. **Suite fully green.**

Also pins `REMOTE_TASK_TIER=team` in the test setup: it was **non-hermetic** — it read the host's ambient `REMOTE_TASK_TIER` (e.g. `owner` on the owner's own node), so the `access_tier`-clamp + newline-forge assertions failed depending on where the suite ran. The sanitization itself was always correct (the forge was blocked); only the test's env isolation was missing.

### Pairs with
ag2-space/ag2space-backend **#20** (adds `/v1/heartbeat` → `HUB.set_core_status`). Either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
