### PR TITLE
fix(context-drop): audio for drop-video-clip + move Ctrl-C/Ctrl-R hotkeys off terminal keys

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -1642,7 +1642,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // drops the .mov. User-controlled length beats a fixed duration.
         let starting = !isRecordingVideo
         let action = starting ? "start" : "stop"
-        notify("Sutando", starting ? "● Recording screen — press ⌃R again to stop" : "Stopping recording…")
+        notify("Sutando", starting ? "● Recording screen + mic — press ⌃⇧R again to stop" : "Stopping recording…")
 
         guard let url = URL(string: "http://localhost:7845/capture-video?action=\(action)") else { return }
         var req = URLRequest(url: url)

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -1089,9 +1089,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// Default hotkey config used when ~/.config/sutando/hotkeys.json is missing.
     /// Keys: action name → (key letter, modifier names).
     private static let defaultHotkeys: [(action: String, key: String, modifiers: [String])] = [
-        ("drop_context",     "C", ["control"]),
+        // ⌃C / ⌃R avoided: they shadow terminal SIGINT and reverse-i-search.
+        // Use ⌃⇧C / ⌃⇧R so plain ⌃C/⌃R still reach the terminal (global
+        // hotkeys match the exact modifier mask, so the shifted variants
+        // never swallow the unshifted keys).
+        ("drop_context",     "C", ["control", "shift"]),
         ("drop_screenshot",  "S", ["control"]),
-        ("drop_video_clip",  "R", ["control"]),
+        ("drop_video_clip",  "R", ["control", "shift"]),
         ("toggle_voice",     "V", ["control"]),
         ("toggle_mute",      "M", ["control"]),
     ]

--- a/src/screen-capture-server.py
+++ b/src/screen-capture-server.py
@@ -270,7 +270,16 @@ class Handler(http.server.BaseHTTPRequestHandler):
                     if query.get("silent", ["false"])[0] != "true":
                         _signal_seeing()
                         _notify_capture()
+                    # Audio: -g records the *default input device*, so the clip's
+                    # sound source follows System Settings > Sound > Input:
+                    #   mic (MacBook Pro Microphone) → narration / room audio
+                    #   BlackHole 2ch (with output routed there) → system/app audio
+                    # ?audio=off disables sound; ?device=<id> pins a specific input via -G<id>.
+                    audio = query.get("audio", ["on"])[0]
+                    device = query.get("device", [None])[0]
                     cmd = ["screencapture", "-v", "-x"]  # no -V → records until SIGINT
+                    if audio != "off":
+                        cmd.append(f"-G{device}" if device else "-g")
                     if display:
                         cmd.append(f"-D{display}")
                     cmd.append(path)


### PR DESCRIPTION
## What & why

Two small UX fixes to the drop-video-clip feature added in #1859.

### 1. Audio in the recorded clip
The capture server ran `screencapture -v -x` with no audio flag, so dropped clips were silent. Add `-g`, which records the **default audio input** — the source follows System Settings > Sound > Input:
- mic → narration / room audio
- BlackHole (with output routed there) → system/app audio

New query params on `/capture-video?action=start`:
- `?audio=off` — record without sound (previous behavior)
- `?device=<id>` — pin a specific input via `-G<id>`

Default (no params) now captures the default input, so the Swift caller needs no change.

### 2. Hotkeys off terminal-reserved keys
Two global hotkeys shadowed terminal keys and were intercepting them system-wide:
- `drop_context`: `Ctrl-C` → `Ctrl-Shift-C` (was eating SIGINT / cancel)
- `drop_video_clip`: `Ctrl-R` → `Ctrl-Shift-R` (was eating reverse-i-search)

Global hotkeys match the exact modifier mask, so plain `Ctrl-C` / `Ctrl-R` reach the terminal again; only the shifted variants trigger Sutando. `Ctrl-S`/`Ctrl-V`/`Ctrl-M` unchanged.

## Test
Verified end-to-end on macOS: recorded a 2s clip through `/capture-video`; `ffprobe` confirms both an h264 video stream and an aac stereo audio track. Screen Recording permission unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
