### PR TITLE
refactor(agent): move Claude core-agent launchers into src/agent/claude/cli/

### DIFF
--- a/docs/host-cli-bindings.md
+++ b/docs/host-cli-bindings.md
@@ -28,7 +28,7 @@ The point of the helper is *grep-counting*: one canonical resolver means a futur
 
 ### Read-side companion: `$SOURCE_CLAUDE_CONFIG_DIR`
 
-Migration code (`scripts/sutando-shell-setup.sh --migrate`, `src/migrate.sh`) reads FROM a historically-vanilla state location and writes TO `$CLAUDE_CONFIG_DIR`. To keep that direction visible, migration scripts honor `${SOURCE_CLAUDE_CONFIG_DIR:-$HOME/.claude}` for their source path. The default matches the canonical vanilla-claude location; override for CI fixtures, custom installs, or staging tests that need a different source. `claude_home_path()` does NOT consult this — it's a migration-script convention, not a runtime resolver.
+Migration code (`src/agent/claude/cli/sutando-shell-setup.sh --migrate`, `src/migrate.sh`) reads FROM a historically-vanilla state location and writes TO `$CLAUDE_CONFIG_DIR`. To keep that direction visible, migration scripts honor `${SOURCE_CLAUDE_CONFIG_DIR:-$HOME/.claude}` for their source path. The default matches the canonical vanilla-claude location; override for CI fixtures, custom installs, or staging tests that need a different source. `claude_home_path()` does NOT consult this — it's a migration-script convention, not a runtime resolver.
 
 If you're adding code that touches a new surface (not currently in the table above), update this doc with the new surface + its re-bind cost. The taxonomy is the value here, not the row count.
 

--- a/scripts/start-cli.sh
+++ b/scripts/start-cli.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# COMPAT SHIM — DO NOT ADD LOGIC HERE.
+#
+# The canonical launcher moved to src/agent/claude/cli/start-cli.sh (PR #1891).
+# This wrapper preserves the old path for ONE RELEASE so callers that still
+# reference scripts/start-cli.sh keep working until they pick up the new path —
+# notably a not-yet-rebuilt Sutando.app binary (the path is compiled in, so it
+# lags a `git pull`) or an in-flight health-check --recover-core. Remove after
+# one release once all callers reference src/agent/claude/cli/start-cli.sh.
+_repo="$(cd "$(dirname "$0")/.." && pwd)"
+echo "scripts/start-cli.sh is a compat shim — moved to src/agent/claude/cli/start-cli.sh (update your caller)." >&2
+exec bash "$_repo/src/agent/claude/cli/start-cli.sh" "$@"

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1641,7 +1641,9 @@ commit_main() {
     # Skipped on phase-2 delete-only runs (DELETE_SOURCE=1 with $ROLLBACK_ID
     # set means the copy walk was already done in an earlier pass).
     if [ "$NO_CLAUDE_IMPORT" = "0" ] && [ "$DELETE_SOURCE" = "0" ]; then
-        local _import_script="$(dirname "$0")/sutando-shell-setup.sh"
+        # sutando-shell-setup.sh moved to src/agent/claude/ — anchor off
+        # SCRIPT_DIR (= scripts/) rather than as a sibling of this migrate script.
+        local _import_script="$SCRIPT_DIR/../src/agent/claude/cli/sutando-shell-setup.sh"
         if [ -x "$_import_script" ] || [ -f "$_import_script" ]; then
             echo
             echo "sutando-migrate: invoking sutando-shell-setup.sh --import to copy Claude memory ..."
@@ -1653,10 +1655,10 @@ commit_main() {
                 # workspace migration completed successfully; the user can
                 # re-run `--import` manually. Surface the failure so they know
                 # to address it.
-                echo "  Claude memory import: FAILED (rc=$_rc) — re-run manually: bash scripts/sutando-shell-setup.sh --import" >&2
+                echo "  Claude memory import: FAILED (rc=$_rc) — re-run manually: bash src/agent/claude/cli/sutando-shell-setup.sh --import" >&2
             fi
         else
-            echo "  Claude memory import: skipped (scripts/sutando-shell-setup.sh not found at expected path; run --import manually after migrate)"
+            echo "  Claude memory import: skipped (src/agent/claude/cli/sutando-shell-setup.sh not found at expected path; run --import manually after migrate)"
         fi
     fi
 

--- a/scripts/sutando-shell-setup.sh
+++ b/scripts/sutando-shell-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# COMPAT SHIM — DO NOT ADD LOGIC HERE.
+#
+# The canonical onboarding script moved to
+# src/agent/claude/cli/sutando-shell-setup.sh (PR #1891). This wrapper preserves
+# the old path for ONE RELEASE so old callers (docs, muscle-memory, an older
+# migrate.sh, a not-yet-rebuilt Sutando.app) keep working until they pick up the
+# new path. It is only ever RUN (never sourced) — `bash …/sutando-shell-setup.sh
+# --auto|--import` — so exec-forwarding preserves behavior. Remove after one
+# release.
+_repo="$(cd "$(dirname "$0")/.." && pwd)"
+echo "scripts/sutando-shell-setup.sh is a compat shim — moved to src/agent/claude/cli/sutando-shell-setup.sh (update your caller)." >&2
+exec bash "$_repo/src/agent/claude/cli/sutando-shell-setup.sh" "$@"

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -526,7 +526,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // the watcherKeystrokesQueued() check above + the Timer interval.)
 
         // If Claude Code is running inside the `sutando-core` tmux session
-        // (launch via scripts/start-cli.sh), send the word `watcher` to
+        // (launch via src/agent/claude/cli/start-cli.sh), send the word `watcher` to
         // its pane as if Chi typed it. The CLI parses that as a restart
         // prompt and starts the watcher via its own run_in_background Bash
         // — so the watcher's stdout routes through the task-notification
@@ -540,7 +540,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Fallback: Claude Code isn't in the expected tmux session.
         // Notify so Chi can restart manually.
-        notify("Sutando", "Task watcher is down — prompt the CLI to restart it (or start CLI via scripts/start-cli.sh)")
+        notify("Sutando", "Task watcher is down — prompt the CLI to restart it (or start CLI via src/agent/claude/cli/start-cli.sh)")
         logToFile("watcher dead; notification fired (tmux session not found)")
     }
 
@@ -2248,7 +2248,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Restart the Claude Code core session (sutando-core tmux session).
-    /// Invokes scripts/start-cli.sh --restart which kills any existing
+    /// Invokes src/agent/claude/cli/start-cli.sh --restart which kills any existing
     /// session and starts fresh detached. User can re-attach via
     /// "Open Core CLI" in the menu (or `tmux -S /tmp/sutando-tmux.sock
     /// attach -t sutando-core` from a terminal).
@@ -2265,7 +2265,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// this only restarts the Claude Code CLI session.
     @objc func restartCore() {
         notify("Sutando", "Restarting Core CLI…")
-        let script = repoRoot + "/scripts/start-cli.sh"
+        let script = repoRoot + "/src/agent/claude/cli/start-cli.sh"
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/bash")
         proc.arguments = [script, "--restart"]

--- a/src/agent/claude/README.md
+++ b/src/agent/claude/README.md
@@ -1,0 +1,48 @@
+# `src/agent/claude/` — the Claude core-agent
+
+Sutando's **core agent** is Claude Code (`claude`). This directory is the home for the code that
+**initializes** that core agent and **onboards** its auth — pulled out of the general `scripts/`
+pile so the launch/onboarding logic lives in one place, and so a second initialization flow
+(e.g. a headless / alternate-provider launcher) can grow alongside the current one without
+scattering launch code across the repo.
+
+## Layout
+
+```
+src/agent/claude/
+  cli/                       # launchers that drive the `claude` BINARY
+    start-cli.sh             #   the canonical persistent tmux core (sutando-core)
+    sutando-shell-setup.sh   #   the `claude-sutando` config-dir alias onboarding
+  README.md
+```
+
+> The launchers self-locate the repo root **four levels up** (`dirname/../../../..`) because they
+> live in `cli/`. Everything else inside them is repo-root-relative (`$REPO/scripts/...`). Keep
+> this in mind if you move them again.
+
+## Contents
+
+- **`cli/start-cli.sh`** — the single canonical launcher/restarter for the `sutando-core` tmux
+  session. Every core launch funnels through it: `src/startup.sh` execs it at the end of boot,
+  `src/health-check.py` (`_default_core_restart`) runs it with `--restart` for wedge recovery, and
+  Sutando.app's "Restart Core CLI" menu invokes it. It assembles the `claude` command line
+  (model/settings/cwd/obs args), resolves the workspace-scoped `CLAUDE_CONFIG_DIR`, and seeds
+  onboarding/trust state so a detached, no-TTY core doesn't dead-end at the welcome or
+  folder-trust prompt.
+- **`cli/sutando-shell-setup.sh`** — configures the interactive `claude-sutando` shell function
+  (the per-invocation analogue of start-cli.sh's config-dir resolution: it runs `claude` with
+  `CLAUDE_CONFIG_DIR` pointed at `<workspace>/.claude-sutando`). Also provides `--import` /
+  `--repair-paths` used by `scripts/sutando-migrate.sh`. Invoked once-per-host (`--auto`) from
+  `src/startup.sh`.
+
+## Auth / onboarding that lives *elsewhere* (by design)
+
+- **Credential seeding at boot** — the auth-carry / env-token-persist block in `src/startup.sh`
+  (copies `.credentials.json` + `.claude.json` from `~/.claude/`, or writes a token from
+  `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN`). Stays inline because it must run in
+  startup's own environment and export `CLAUDE_CONFIG_DIR` for the bridges that launch after — it
+  is not a separately-execed step.
+- **Credential proxy + quota** — `skills/quota-tracker/` (local proxy that injects/refreshes the
+  OAuth token and routes the core via `ANTHROPIC_BASE_URL=http://localhost:7846`, plus
+  `read-quota.py`). An optional, self-contained **skill** per `CLAUDE.md`'s architecture rules; the
+  core boots fine without it.

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# scripts/start-cli.sh — canonical launch script for the sutando-core tmux
-# session. Single source of truth for the "how to start Claude Code" command,
+# src/agent/claude/cli/start-cli.sh — canonical launch script for the sutando-core
+# tmux session. Single source of truth for the "how to start Claude Code" command,
 # so startup.sh + Sutando.app's Restart Core menu can both invoke it without
 # duplicating the launch arguments.
 #
 # Usage:
-#   bash scripts/start-cli.sh           # start (or attach if running)
-#   bash scripts/start-cli.sh --restart # kill existing session then start fresh
+#   bash src/agent/claude/cli/start-cli.sh           # start (or attach if running)
+#   bash src/agent/claude/cli/start-cli.sh --restart # kill existing session then start fresh
 #
 # Per Chi's prompt 2026-05-05 ("shall we add core CLI-related commands in
 # sutando app"): extracting the launch command from startup.sh's inline tmux
@@ -15,7 +15,8 @@
 
 set -e
 
-REPO="$(cd "$(dirname "$0")/.." && pwd)"
+# This script lives at src/agent/claude/cli/ — four levels under the repo root.
+REPO="$(cd "$(dirname "$0")/../../../.." && pwd)"
 cd "$REPO"
 
 TMUX_SOCKET="/tmp/sutando-tmux.sock"

--- a/src/agent/claude/cli/sutando-shell-setup.sh
+++ b/src/agent/claude/cli/sutando-shell-setup.sh
@@ -17,12 +17,12 @@
 # load-bearing for sync coherence.
 #
 # Usage:
-#   bash scripts/sutando-shell-setup.sh                # dry-run: print proposed line + target rc
-#   bash scripts/sutando-shell-setup.sh --commit       # append to rc file (idempotent)
-#   bash scripts/sutando-shell-setup.sh --auto         # one-shot prompt path used by startup.sh
-#   bash scripts/sutando-shell-setup.sh --check        # exit 0 if alias present + path matches; 1 otherwise
-#   bash scripts/sutando-shell-setup.sh --import       # rsync ~/.claude → <workspace>/.claude-sutando (idempotent, non-destructive)
-#   bash scripts/sutando-shell-setup.sh --repair-paths # re-pin hardcoded SOURCE_DIR paths in runtime files to CLAUDE_DIR (idempotent)
+#   bash src/agent/claude/cli/sutando-shell-setup.sh                # dry-run: print proposed line + target rc
+#   bash src/agent/claude/cli/sutando-shell-setup.sh --commit       # append to rc file (idempotent)
+#   bash src/agent/claude/cli/sutando-shell-setup.sh --auto         # one-shot prompt path used by startup.sh
+#   bash src/agent/claude/cli/sutando-shell-setup.sh --check        # exit 0 if alias present + path matches; 1 otherwise
+#   bash src/agent/claude/cli/sutando-shell-setup.sh --import       # rsync ~/.claude → <workspace>/.claude-sutando (idempotent, non-destructive)
+#   bash src/agent/claude/cli/sutando-shell-setup.sh --repair-paths # re-pin hardcoded SOURCE_DIR paths in runtime files to CLAUDE_DIR (idempotent)
 #
 # Deprecated aliases (kept for one release):
 #   --migrate      # alias for --import; emits a stderr deprecation warning. Per
@@ -51,7 +51,8 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# This script lives at src/agent/claude/cli/ — four levels under the repo root.
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
 MODE="dry-run"
 FORCE=0
 FROM_DIR=""

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1762,7 +1762,7 @@ def notify_slack_for_failures(
 # makes it SELF-HEALING.
 #
 # Recovery action is the one mechanism we already own and trust:
-# `scripts/start-cli.sh --restart`. A restarted session starts fresh under the
+# `src/agent/claude/cli/start-cli.sh --restart`. A restarted session starts fresh under the
 # standard context boundary; because the /usage-credits enable persists
 # ACCOUNT-WIDE once a human sets it (and on Max/Team plans 1M is included with
 # no gate at all), the restarted core keeps 1M and re-clears the gate by
@@ -1883,11 +1883,11 @@ def _core_started_within(seconds: float, workspace: Optional[Path] = None, now: 
 
 
 def _default_core_restart(standard_context: bool) -> bool:
-    """Run scripts/start-cli.sh --restart out-of-process. When standard_context
-    is True, pin SUTANDO_CORE_MODEL=opus so the restarted core runs in the
-    standard 200K window (graceful degradation). Returns True if the restart
-    command exited 0."""
-    script = REPO_DIR / "scripts" / "start-cli.sh"
+    """Run src/agent/claude/cli/start-cli.sh --restart out-of-process. When
+    standard_context is True, pin SUTANDO_CORE_MODEL=opus so the restarted core
+    runs in the standard 200K window (graceful degradation). Returns True if the
+    restart command exited 0."""
+    script = REPO_DIR / "src" / "agent" / "claude" / "cli" / "start-cli.sh"
     if not script.exists():
         return False
     env = dict(os.environ)

--- a/src/launchd/com.sutando.health-check-fallback.plist
+++ b/src/launchd/com.sutando.health-check-fallback.plist
@@ -30,7 +30,7 @@
       owner id in ~/.claude/channels/slack/access.json is missing.
     - --recover-core: when the core is alive-but-wedged (heartbeat ticking but
       the task queue isn't draining — the 2026-06-02 1M usage-credit-gate loop
-      signature), auto-restarts it via scripts/start-cli.sh --restart. Heavily
+      signature), auto-restarts it via src/agent/claude/cli/start-cli.sh --restart. Heavily
       guarded (sustained-wedge confirm window, 30min cooldown, 3/hr give-up cap)
       and a clean no-op when the core is healthy. Keeps 1M on the first restart;
       degrades to standard 200K only if the wedge recurs. Runs here, in launchd's

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -37,7 +37,7 @@ export SUTANDO_ROOT="$REPO"
 # L~449 discord, L~473 slack) probe `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` and
 # fall back to legacy `~/.claude/` when the env var is unset — meaning bridges
 # read tokens / access lists from the pre-migration location even after a
-# successful `claude-sutando --migrate`. Mirrors scripts/start-cli.sh:38-51
+# successful `claude-sutando --migrate`. Mirrors src/agent/claude/cli/start-cli.sh
 # (Sutando.app's tmux-wrapped CLI launcher) — same machine-spawn pattern.
 #
 # Defense in depth (matches start-cli):
@@ -48,6 +48,12 @@ if [ -x "$REPO/scripts/sutando-config.sh" ]; then
   _ccd_err="$(mktemp -t startup-ccd.XXXXXX)"
   if _ccd="$(bash "$REPO/scripts/sutando-config.sh" claude-sutando-config-dir 2>"$_ccd_err")"; then
     mkdir -p "$_ccd"
+    # NOTE: the claude core-agent launcher + the `claude-sutando` config-dir
+    # onboarding alias now live under src/agent/claude/ (start-cli.sh /
+    # sutando-shell-setup.sh). This credentials seed stays INLINE here by design:
+    # it must run in the same startup env (exports CLAUDE_CONFIG_DIR for the
+    # bridges below), not in a separately-execed launcher. See
+    # src/agent/claude/README.md for the full auth/onboarding map.
     # Auth-carry (v0.8 cold-start fix). Seed credentials + onboarding state from
     # $HOME/.claude/ so a cold `claude` core doesn't dead-end at the login wall
     # (.credentials.json) or trust-folder prompt (.claude.json) before reaching
@@ -463,8 +469,8 @@ fi
 # per-host sentinel at $WORKSPACE/state/.shell-setup-prompted-<hostname> so
 # this never re-pesters after the user's initial yes/no.
 # Failures are non-fatal — startup.sh continues regardless.
-if [ -x "$REPO/scripts/sutando-shell-setup.sh" ]; then
-  bash "$REPO/scripts/sutando-shell-setup.sh" --auto || true
+if [ -x "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" ]; then
+  bash "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" --auto || true
 fi
 
 # Reap any stale watch-tasks-stream watcher from a prior session. The
@@ -962,9 +968,9 @@ done
 echo ""
 open "http://localhost:8080"
 
-# Delegate to scripts/start-cli.sh — canonical sutando-core launch command.
-# Single source of truth so Sutando.app's Restart Core menu can invoke the
-# same launch path without duplicating the tmux + claude flags.
+# Delegate to src/agent/claude/cli/start-cli.sh — canonical sutando-core launch
+# command. Single source of truth so Sutando.app's Restart Core menu can invoke
+# the same launch path without duplicating the tmux + claude flags.
 #
 # Restore stdout/stderr to the terminal first when the operator is
 # interactive: the tee-redirect at the top of this script makes fd 1 a PIPE,
@@ -977,4 +983,4 @@ open "http://localhost:8080"
 if [ -t 0 ]; then
     exec >/dev/tty 2>&1
 fi
-exec bash "$REPO/scripts/start-cli.sh"
+exec bash "$REPO/src/agent/claude/cli/start-cli.sh"

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -426,7 +426,7 @@ def resolve_claude_sutando_config_dir(repo_root: Optional[Path] = None) -> Path:
     `/tmp/...` doesn't become `/private/tmp/...` from a stray `.resolve()`).
 
     Does NOT create the directory; callers (e.g.
-    `scripts/sutando-shell-setup.sh`) are responsible for mkdir as part of the
+    `src/agent/claude/cli/sutando-shell-setup.sh`) are responsible for mkdir as part of the
     alias-setup flow.
     """
     global _LEGACY_CLAUDE_SUBDIR_WARN_PRINTED

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -373,7 +373,7 @@ const DEFAULT_CLAUDE_SUTANDO_SUBDIR = '.claude-sutando';
  * are rejected at load (schema pattern) AND asserted again here (defense in
  * depth, catches symlink escapes the regex misses).
  *
- * Does NOT create the directory — callers (e.g. `scripts/sutando-shell-setup.sh`)
+ * Does NOT create the directory — callers (e.g. `src/agent/claude/cli/sutando-shell-setup.sh`)
  * are responsible for mkdir as part of the alias-setup flow.
  *
  * @throws if the subdir violates the workspace-sub-folder invariant.

--- a/src/util_paths.ts
+++ b/src/util_paths.ts
@@ -144,7 +144,7 @@ export function sharedPersonalPath(filename: string, workspace?: string): string
 // Resolution (3-tier, prefer most specific):
 //   1. $CLAUDE_CONFIG_DIR  — Claude Code's canonical env var (string present
 //      in the `claude` binary). Set by `claude-sutando` shell function +
-//      scripts/start-cli.sh + src/startup.sh so every workspace gets its own
+//      src/agent/claude/cli/start-cli.sh + src/startup.sh so every workspace gets its own
 //      .claude-sutando/ tree instead of sharing global ~/.claude/.
 //   2. $CLAUDE_HOME        — deprecated legacy override (kept for one release
 //      so pre-M0 callers / test fixtures don't break instantly). Emits a

--- a/tests/health-check-recover-core.test.py
+++ b/tests/health-check-recover-core.test.py
@@ -7,7 +7,7 @@ Motivated by the 2026-06-02 incident: the core crossed into 1M extended
 context, hit the interactive `/usage-credits` gate (which cannot be
 pre-authorized for an unattended agent), and looped silently — alive (heartbeat
 ticking) but draining nothing. --notify-slack makes that visible; this makes it
-self-healing by restarting the core via scripts/start-cli.sh --restart, with
+self-healing by restarting the core via src/agent/claude/cli/start-cli.sh --restart, with
 1M preserved on the first attempt and a graceful 200K fallback if it recurs.
 
 Because auto-restarting a 24/7 agent is consequential, the guards are the whole

--- a/tests/start-cli-claude-config-dir.test.sh
+++ b/tests/start-cli-claude-config-dir.test.sh
@@ -99,8 +99,9 @@ EOF
   export PATH="$BIN_STUB:$PATH"
 
   # Copy the real start-cli.sh into the fake repo (mirroring its real
-  # src/agent/claude/ location, since the script self-locates the repo root
-  # three levels up) plus the bits it needs to resolve claude_sutando_config_dir
+  # src/agent/claude/cli/ location, since the script self-locates the repo root
+  # four levels up: cli → claude → agent → src → repo) plus the bits it needs to
+  # resolve claude_sutando_config_dir
   # (sutando-config.sh stays under scripts/ — start-cli calls $REPO/scripts/...).
   cp "$REAL_REPO/src/agent/claude/cli/start-cli.sh" "$REPO_FAKE/src/agent/claude/cli/"
 

--- a/tests/start-cli-claude-config-dir.test.sh
+++ b/tests/start-cli-claude-config-dir.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Integration test for scripts/start-cli.sh's CLAUDE_CONFIG_DIR export.
+# Integration test for src/agent/claude/cli/start-cli.sh's CLAUDE_CONFIG_DIR export.
 #
 # Covers the 3 states the design doc enumerated:
 #   1. M0 helper missing                              → silent fallback, claude spawns w/o env
@@ -50,7 +50,7 @@ setup_sandbox() {
   export HOME="$SANDBOX/home"
   export SUTANDO_WORKSPACE="$SANDBOX/workspace"
 
-  mkdir -p "$REPO_FAKE/scripts" "$REPO_FAKE/src" "$BIN_STUB" \
+  mkdir -p "$REPO_FAKE/scripts" "$REPO_FAKE/src" "$REPO_FAKE/src/agent/claude/cli" "$BIN_STUB" \
            "$HOME" "$SUTANDO_WORKSPACE/state"
 
   # Stub `claude` binary — records its env to ENV_DUMP, exits 0.
@@ -98,9 +98,11 @@ EOF
 
   export PATH="$BIN_STUB:$PATH"
 
-  # Copy the real start-cli.sh into the fake repo and the bits it needs to
-  # actually resolve claude_sutando_config_dir.
-  cp "$REAL_REPO/scripts/start-cli.sh" "$REPO_FAKE/scripts/"
+  # Copy the real start-cli.sh into the fake repo (mirroring its real
+  # src/agent/claude/ location, since the script self-locates the repo root
+  # three levels up) plus the bits it needs to resolve claude_sutando_config_dir
+  # (sutando-config.sh stays under scripts/ — start-cli calls $REPO/scripts/...).
+  cp "$REAL_REPO/src/agent/claude/cli/start-cli.sh" "$REPO_FAKE/src/agent/claude/cli/"
 
   if [ "$helper_present" = "yes" ]; then
     cp "$REAL_REPO/scripts/sutando-config.sh" "$REPO_FAKE/scripts/"
@@ -128,7 +130,7 @@ REAL_REPO="$(cd "$(dirname "$0")/.." && pwd)"
 test_helper_missing_silent_fallback() {
   setup_sandbox "no" "(unused)"
   # Run start-cli; should reach claude stub without erroring on missing helper.
-  bash "$REPO_FAKE/scripts/start-cli.sh" </dev/null >/dev/null 2>&1
+  bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null >/dev/null 2>&1
   rc=$?
   if [ "$rc" != "0" ]; then
     echo "  FAIL: start-cli exit $rc (expected 0 — helper-missing should be silent fallback)"
@@ -155,7 +157,7 @@ test_helper_missing_silent_fallback() {
 # ----------------------------------------------------------------------
 test_valid_config_exports_env() {
   setup_sandbox "yes" ".claude-sutando"
-  bash "$REPO_FAKE/scripts/start-cli.sh" </dev/null >/dev/null 2>&1
+  bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null >/dev/null 2>&1
   rc=$?
   if [ "$rc" != "0" ]; then
     echo "  FAIL: start-cli exit $rc (expected 0 for valid config)"
@@ -188,7 +190,7 @@ test_valid_config_exports_env() {
 # ----------------------------------------------------------------------
 test_invalid_config_refuses_to_start() {
   setup_sandbox "yes" "/etc/claude-state"  # absolute path, invariant violation
-  bash "$REPO_FAKE/scripts/start-cli.sh" </dev/null >/dev/null 2>&1
+  bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null >/dev/null 2>&1
   rc=$?
   if [ "$rc" = "0" ]; then
     echo "  FAIL: start-cli exit 0 (expected non-zero — config violates invariant)"
@@ -208,16 +210,16 @@ test_invalid_config_refuses_to_start() {
 #    tests above stay green but this one catches the regression.
 # ----------------------------------------------------------------------
 test_block_present_in_start_cli() {
-  if ! grep -qF 'CLAUDE_CONFIG_DIR' "$REAL_REPO/scripts/start-cli.sh"; then
-    echo "  FAIL: scripts/start-cli.sh no longer references CLAUDE_CONFIG_DIR"
+  if ! grep -qF 'CLAUDE_CONFIG_DIR' "$REAL_REPO/src/agent/claude/cli/start-cli.sh"; then
+    echo "  FAIL: src/agent/claude/cli/start-cli.sh no longer references CLAUDE_CONFIG_DIR"
     return 1
   fi
-  if ! grep -qF 'claude-sutando-config-dir' "$REAL_REPO/scripts/start-cli.sh"; then
-    echo "  FAIL: scripts/start-cli.sh no longer calls the M0 helper subcommand"
+  if ! grep -qF 'claude-sutando-config-dir' "$REAL_REPO/src/agent/claude/cli/start-cli.sh"; then
+    echo "  FAIL: src/agent/claude/cli/start-cli.sh no longer calls the M0 helper subcommand"
     return 1
   fi
-  if ! grep -qF 'refusing to start core' "$REAL_REPO/scripts/start-cli.sh"; then
-    echo "  FAIL: scripts/start-cli.sh dropped the fail-loud branch on invariant violation"
+  if ! grep -qF 'refusing to start core' "$REAL_REPO/src/agent/claude/cli/start-cli.sh"; then
+    echo "  FAIL: src/agent/claude/cli/start-cli.sh dropped the fail-loud branch on invariant violation"
     return 1
   fi
   return 0

--- a/tests/start-cli-compat-shim.test.sh
+++ b/tests/start-cli-compat-shim.test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Smoke test for the one-release compat shims added when the Claude core-agent
+# launchers moved to src/agent/claude/cli/ (PR #1891).
+#
+# Guards against the "moved with no shim" regression: an already-installed /
+# not-yet-rebuilt Sutando.app (and health-check --recover-core) still invoke the
+# OLD scripts/{start-cli,sutando-shell-setup}.sh paths, and would hard-fail after
+# a `git pull` if those paths vanished. This asserts the shims exist, are
+# executable, parse, and exec-forward to their new src/agent/claude/cli/ homes.
+# It does NOT run the shims (that would launch the live core) — structural only.
+set -u
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+fail=0
+
+for name in start-cli sutando-shell-setup; do
+    shim="$REPO/scripts/$name.sh"
+    target="src/agent/claude/cli/$name.sh"
+
+    [ -f "$shim" ] || { echo "  FAIL: compat shim $shim is missing"; fail=1; continue; }
+    [ -x "$shim" ] || { echo "  FAIL: compat shim $shim is not executable"; fail=1; }
+    bash -n "$shim" 2>/dev/null || { echo "  FAIL: $shim has a syntax error"; fail=1; }
+    grep -q "exec bash .*$target" "$shim" \
+        || { echo "  FAIL: $shim does not exec-forward to $target"; fail=1; }
+    [ -f "$REPO/$target" ] || { echo "  FAIL: forward target $REPO/$target is missing"; fail=1; }
+done
+
+if [ "$fail" -eq 0 ]; then
+    echo "PASS: scripts/{start-cli,sutando-shell-setup}.sh shims forward to src/agent/claude/cli/"
+else
+    echo "compat-shim test FAILED"
+    exit 1
+fi

--- a/tests/start-cli-model-pin.test.py
+++ b/tests/start-cli-model-pin.test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests that scripts/start-cli.sh honors $SUTANDO_CORE_MODEL (PR #1428).
+"""Tests that src/agent/claude/cli/start-cli.sh honors $SUTANDO_CORE_MODEL (PR #1428).
 
 The recovery escalation in src/health-check.py restarts a re-wedging core with
 SUTANDO_CORE_MODEL=opus so it falls back to standard 200K context. This verifies
@@ -22,7 +22,7 @@ import tempfile
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
-SCRIPT = REPO / "scripts" / "start-cli.sh"
+SCRIPT = REPO / "src" / "agent" / "claude" / "cli" / "start-cli.sh"
 
 
 def _launch_argv(model_env: "str | None") -> list[str]:

--- a/tests/startup-shell-setup-wireup.test.sh
+++ b/tests/startup-shell-setup-wireup.test.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Tests for the src/startup.sh wire-up of scripts/sutando-shell-setup.sh
+# Tests for the src/startup.sh wire-up of src/agent/claude/cli/sutando-shell-setup.sh
 #
-# The wire-up is intentionally minimal (3 lines, src/startup.sh:210-212):
+# The wire-up is intentionally minimal (3 lines in src/startup.sh):
 #
-#   if [ -x "$REPO/scripts/sutando-shell-setup.sh" ]; then
-#     bash "$REPO/scripts/sutando-shell-setup.sh" --auto || true
+#   if [ -x "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" ]; then
+#     bash "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" --auto || true
 #   fi
 #
 # These tests cover three branches:
@@ -43,25 +43,25 @@ run_test() {
 make_driver_with_stub_helper() {
   local exit_code="$1"      # exit code the stub helper should return ('absent' to skip creating it)
   TEST_TMP="$(mktemp -d -t startup-shell-setup-wireup.XXXXXX)"
-  mkdir -p "$TEST_TMP/scripts"
+  mkdir -p "$TEST_TMP/src/agent/claude/cli"
 
   if [ "$exit_code" != "absent" ]; then
-    cat > "$TEST_TMP/scripts/sutando-shell-setup.sh" << EOF
+    cat > "$TEST_TMP/src/agent/claude/cli/sutando-shell-setup.sh" << EOF
 #!/usr/bin/env bash
 exit $exit_code
 EOF
-    chmod +x "$TEST_TMP/scripts/sutando-shell-setup.sh"
+    chmod +x "$TEST_TMP/src/agent/claude/cli/sutando-shell-setup.sh"
   fi
 
   cat > "$TEST_TMP/driver.sh" << 'EOF'
 #!/usr/bin/env bash
-# Mirror of src/startup.sh:210-212 wire-up block.
+# Mirror of src/startup.sh's sutando-shell-setup wire-up block.
 REPO="$1"
 SENTINEL="$2"
 
 # This is the exact block from startup.sh — keep these 3 lines in sync.
-if [ -x "$REPO/scripts/sutando-shell-setup.sh" ]; then
-  bash "$REPO/scripts/sutando-shell-setup.sh" --auto || true
+if [ -x "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" ]; then
+  bash "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" --auto || true
 fi
 
 # If startup.sh continues past the wire-up, we'd reach here.

--- a/tests/sutando-migrate-claude-import.test.sh
+++ b/tests/sutando-migrate-claude-import.test.sh
@@ -3,9 +3,10 @@
 # Addresses Lucy's Maddy v0.8 migration report (2026-06-06 #design):
 # sutando-migrate previously set up M2 directories but did NOT copy Claude
 # memory from `~/.claude/projects/<slug>/*` to `<workspace>/.claude-sutando/
-# projects/<slug>/*`. Owner's workaround was to run `bash scripts/
-# sutando-shell-setup.sh --import` manually; now `commit_main` wires that
-# automatically as the final step.
+# projects/<slug>/*`. Owner's workaround was to run the shell-setup script's
+# `--import` manually (now at src/agent/claude/cli/sutando-shell-setup.sh — moved
+# from scripts/ in PR #1891); now `commit_main` wires that automatically as the
+# final step.
 #
 # This test verifies the wiring (flag parsing + call site shape) without
 # requiring a full live --import run (which depends on rsync + actual

--- a/tests/sutando-shell-setup-argparse.test.sh
+++ b/tests/sutando-shell-setup-argparse.test.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
-SETUP="$REPO/scripts/sutando-shell-setup.sh"
+SETUP="$REPO/src/agent/claude/cli/sutando-shell-setup.sh"
 
 pass=0
 fail=0
@@ -274,7 +274,7 @@ for excl in "shell-snapshots/" "history.jsonl" "file-history/"; do
   if printf '%s' "$filters_block" | grep -qF -- "--exclude='$excl'"; then
     assert_pass "exclude '$excl' present in RSYNC_FILTERS"
   else
-    assert_fail "exclude '$excl' missing from RSYNC_FILTERS" "see scripts/sutando-shell-setup.sh"
+    assert_fail "exclude '$excl' missing from RSYNC_FILTERS" "see src/agent/claude/cli/sutando-shell-setup.sh"
   fi
 done
 

--- a/tests/sutando-shell-setup.test.sh
+++ b/tests/sutando-shell-setup.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tests for scripts/sutando-shell-setup.sh
+# Tests for src/agent/claude/cli/sutando-shell-setup.sh
 #
 # Covers: --check (4 states), --commit (4 states), --migrate (2 states),
 # dry-run (default mode). Isolation strategy: each test runs with a fresh
@@ -18,7 +18,7 @@
 set -uo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-HELPER="$REPO/scripts/sutando-shell-setup.sh"
+HELPER="$REPO/src/agent/claude/cli/sutando-shell-setup.sh"
 
 if [ ! -x "$HELPER" ]; then
   echo "FATAL: $HELPER not found or not executable" >&2


### PR DESCRIPTION
## What

Moves the two scripts that **initialize + onboard the Claude Code core agent** out of `scripts/` into a dedicated **`src/agent/claude/cli/`**:

- `scripts/start-cli.sh` → `src/agent/claude/cli/start-cli.sh` — the canonical `sutando-core` tmux launcher/restarter
- `scripts/sutando-shell-setup.sh` → `src/agent/claude/cli/sutando-shell-setup.sh` — the `claude-sutando` config-dir alias onboarding

## Why

The core-agent launch/onboarding logic was scattered in `scripts/`. Consolidating it under `src/agent/claude/` gives it a clear home — and room for a second initialization flow (a headless / alternate-provider launcher) to grow alongside it without more `scripts/` sprawl. `git mv` preserves history.

## Changes

- **Re-points every caller**: `src/startup.sh`, `src/health-check.py` (`_default_core_restart`), `src/Sutando/main.swift`, `scripts/sutando-migrate.sh`, the health-check-fallback launchd plist, `docs/host-cli-bindings.md`, and comment refs in `sutando_config.py` / `sutando_config.ts` / `util_paths.ts`.
- **Fixes repo-root self-location** in both scripts: `dirname/..` → `dirname/../../../..` (they're four levels deep now). This caught two path-built-from-parts references (`health-check.py`'s restart call and a test) that a string-only sweep would miss.
- **Updates the affected tests** — path constants + the fake-repo integration-test layouts that copy the real script and rely on its self-location.
- Adds `src/agent/claude/README.md`.

**Pure move + reference update — no behavior change.**

## Tests

`start-cli-model-pin`, `sutando-shell-setup` (+ argparse), `startup-shell-setup-wireup`, and `health-check-recover-core` all pass. `start-cli-claude-config-dir` is 3/4 — the single failure is **pre-existing on `main`** (its expectation assumes `$SUTANDO_WORKSPACE` is honored for workspace resolution, which was removed in v0.8 / #1440); it's unrelated to this move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)