### PR TITLE
feat(agent): Agent-SDK session core with live UI + full runtime (claude_sdk)

### DIFF
--- a/docs/host-cli-bindings.md
+++ b/docs/host-cli-bindings.md
@@ -28,7 +28,7 @@ The point of the helper is *grep-counting*: one canonical resolver means a futur
 
 ### Read-side companion: `$SOURCE_CLAUDE_CONFIG_DIR`
 
-Migration code (`scripts/sutando-shell-setup.sh --migrate`, `src/migrate.sh`) reads FROM a historically-vanilla state location and writes TO `$CLAUDE_CONFIG_DIR`. To keep that direction visible, migration scripts honor `${SOURCE_CLAUDE_CONFIG_DIR:-$HOME/.claude}` for their source path. The default matches the canonical vanilla-claude location; override for CI fixtures, custom installs, or staging tests that need a different source. `claude_home_path()` does NOT consult this — it's a migration-script convention, not a runtime resolver.
+Migration code (`src/agent/claude/cli/sutando-shell-setup.sh --migrate`, `src/migrate.sh`) reads FROM a historically-vanilla state location and writes TO `$CLAUDE_CONFIG_DIR`. To keep that direction visible, migration scripts honor `${SOURCE_CLAUDE_CONFIG_DIR:-$HOME/.claude}` for their source path. The default matches the canonical vanilla-claude location; override for CI fixtures, custom installs, or staging tests that need a different source. `claude_home_path()` does NOT consult this — it's a migration-script convention, not a runtime resolver.
 
 If you're adding code that touches a new surface (not currently in the table above), update this doc with the new surface + its re-bind cost. The taxonomy is the value here, not the row count.
 

--- a/scripts/start-cli.sh
+++ b/scripts/start-cli.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# COMPAT SHIM — DO NOT ADD LOGIC HERE.
+#
+# The canonical launcher moved to src/agent/claude/cli/start-cli.sh (PR #1891).
+# This wrapper preserves the old path for ONE RELEASE so callers that still
+# reference scripts/start-cli.sh keep working until they pick up the new path —
+# notably a not-yet-rebuilt Sutando.app binary (the path is compiled in, so it
+# lags a `git pull`) or an in-flight health-check --recover-core. Remove after
+# one release once all callers reference src/agent/claude/cli/start-cli.sh.
+_repo="$(cd "$(dirname "$0")/.." && pwd)"
+echo "scripts/start-cli.sh is a compat shim — moved to src/agent/claude/cli/start-cli.sh (update your caller)." >&2
+exec bash "$_repo/src/agent/claude/cli/start-cli.sh" "$@"

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -10,6 +10,7 @@
 #   bash scripts/sutando-config.sh workspace     # print resolved workspace path
 #   bash scripts/sutando-config.sh vault-enabled # print "true" or "false"
 #   bash scripts/sutando-config.sh vault-url     # print vault remote_url (may be empty)
+#   bash scripts/sutando-config.sh core-config   # print core_config as CFG_*=… lines
 #   bash scripts/sutando-config.sh dump          # print full merged config as JSON
 #   bash scripts/sutando-config.sh subdirs       # print canonical workspace subdir list (one per line)
 #   bash scripts/sutando-config.sh bootstrap     # mkdir -p the canonical subdirs in the resolved workspace
@@ -216,6 +217,30 @@ sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import resolve_core_config_dirs
 for entry in resolve_core_config_dirs():
     print(json.dumps(entry))
+"
+    ;;
+
+  core-config)
+    # Print the resolved core_config block as shell `CFG_<KEY>=<value>` lines.
+    # Safe to read via `while IFS='=' read` — values are simple scalars (type
+    # word, URL, env-var name, model id). Consumed by src/agent/claude/
+    # (provider-env.sh, start-cli.sh). Schema + defaults:
+    # src/sutando_config.py::resolve_core_config.
+    python3 -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT')
+from src.sutando_config import resolve_core_config
+d = resolve_core_config()
+def emit(name, v):
+    print(f'{name}={v}')
+emit('CFG_CORE_TYPE', d['core_type'])
+emit('CFG_PROVIDER', d['provider'])
+emit('CFG_AUTH_ENV', d['auth_env'])
+emit('CFG_MODEL', d['model'])
+m = d.get('models') or {}
+emit('CFG_MODEL_OPUS', m.get('opus', ''))
+emit('CFG_MODEL_SONNET', m.get('sonnet', ''))
+emit('CFG_MODEL_HAIKU', m.get('haiku', ''))
 "
     ;;
 

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1641,7 +1641,9 @@ commit_main() {
     # Skipped on phase-2 delete-only runs (DELETE_SOURCE=1 with $ROLLBACK_ID
     # set means the copy walk was already done in an earlier pass).
     if [ "$NO_CLAUDE_IMPORT" = "0" ] && [ "$DELETE_SOURCE" = "0" ]; then
-        local _import_script="$(dirname "$0")/sutando-shell-setup.sh"
+        # sutando-shell-setup.sh moved to src/agent/claude/ — anchor off
+        # SCRIPT_DIR (= scripts/) rather than as a sibling of this migrate script.
+        local _import_script="$SCRIPT_DIR/../src/agent/claude/cli/sutando-shell-setup.sh"
         if [ -x "$_import_script" ] || [ -f "$_import_script" ]; then
             echo
             echo "sutando-migrate: invoking sutando-shell-setup.sh --import to copy Claude memory ..."
@@ -1653,10 +1655,10 @@ commit_main() {
                 # workspace migration completed successfully; the user can
                 # re-run `--import` manually. Surface the failure so they know
                 # to address it.
-                echo "  Claude memory import: FAILED (rc=$_rc) — re-run manually: bash scripts/sutando-shell-setup.sh --import" >&2
+                echo "  Claude memory import: FAILED (rc=$_rc) — re-run manually: bash src/agent/claude/cli/sutando-shell-setup.sh --import" >&2
             fi
         else
-            echo "  Claude memory import: skipped (scripts/sutando-shell-setup.sh not found at expected path; run --import manually after migrate)"
+            echo "  Claude memory import: skipped (src/agent/claude/cli/sutando-shell-setup.sh not found at expected path; run --import manually after migrate)"
         fi
     fi
 

--- a/scripts/sutando-shell-setup.sh
+++ b/scripts/sutando-shell-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# COMPAT SHIM — DO NOT ADD LOGIC HERE.
+#
+# The canonical onboarding script moved to
+# src/agent/claude/cli/sutando-shell-setup.sh (PR #1891). This wrapper preserves
+# the old path for ONE RELEASE so old callers (docs, muscle-memory, an older
+# migrate.sh, a not-yet-rebuilt Sutando.app) keep working until they pick up the
+# new path. It is only ever RUN (never sourced) — `bash …/sutando-shell-setup.sh
+# --auto|--import` — so exec-forwarding preserves behavior. Remove after one
+# release.
+_repo="$(cd "$(dirname "$0")/.." && pwd)"
+echo "scripts/sutando-shell-setup.sh is a compat shim — moved to src/agent/claude/cli/sutando-shell-setup.sh (update your caller)." >&2
+exec bash "$_repo/src/agent/claude/cli/sutando-shell-setup.sh" "$@"

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -526,7 +526,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // the watcherKeystrokesQueued() check above + the Timer interval.)
 
         // If Claude Code is running inside the `sutando-core` tmux session
-        // (launch via scripts/start-cli.sh), send the word `watcher` to
+        // (launch via src/agent/claude/cli/start-cli.sh), send the word `watcher` to
         // its pane as if Chi typed it. The CLI parses that as a restart
         // prompt and starts the watcher via its own run_in_background Bash
         // — so the watcher's stdout routes through the task-notification
@@ -540,7 +540,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Fallback: Claude Code isn't in the expected tmux session.
         // Notify so Chi can restart manually.
-        notify("Sutando", "Task watcher is down — prompt the CLI to restart it (or start CLI via scripts/start-cli.sh)")
+        notify("Sutando", "Task watcher is down — prompt the CLI to restart it (or start CLI via src/agent/claude/cli/start-cli.sh)")
         logToFile("watcher dead; notification fired (tmux session not found)")
     }
 
@@ -2248,7 +2248,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Restart the Claude Code core session (sutando-core tmux session).
-    /// Invokes scripts/start-cli.sh --restart which kills any existing
+    /// Invokes src/agent/claude/cli/start-cli.sh --restart which kills any existing
     /// session and starts fresh detached. User can re-attach via
     /// "Open Core CLI" in the menu (or `tmux -S /tmp/sutando-tmux.sock
     /// attach -t sutando-core` from a terminal).
@@ -2265,7 +2265,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// this only restarts the Claude Code CLI session.
     @objc func restartCore() {
         notify("Sutando", "Restarting Core CLI…")
-        let script = repoRoot + "/scripts/start-cli.sh"
+        let script = repoRoot + "/src/agent/claude/cli/start-cli.sh"
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/bash")
         proc.arguments = [script, "--restart"]

--- a/src/agent/claude/README.md
+++ b/src/agent/claude/README.md
@@ -1,0 +1,48 @@
+# `src/agent/claude/` — the Claude core-agent
+
+Sutando's **core agent** is Claude Code (`claude`). This directory is the home for the code that
+**initializes** that core agent and **onboards** its auth — pulled out of the general `scripts/`
+pile so the launch/onboarding logic lives in one place, and so a second initialization flow
+(e.g. a headless / alternate-provider launcher) can grow alongside the current one without
+scattering launch code across the repo.
+
+## Layout
+
+```
+src/agent/claude/
+  cli/                       # launchers that drive the `claude` BINARY
+    start-cli.sh             #   the canonical persistent tmux core (sutando-core)
+    sutando-shell-setup.sh   #   the `claude-sutando` config-dir alias onboarding
+  README.md
+```
+
+> The launchers self-locate the repo root **four levels up** (`dirname/../../../..`) because they
+> live in `cli/`. Everything else inside them is repo-root-relative (`$REPO/scripts/...`). Keep
+> this in mind if you move them again.
+
+## Contents
+
+- **`cli/start-cli.sh`** — the single canonical launcher/restarter for the `sutando-core` tmux
+  session. Every core launch funnels through it: `src/startup.sh` execs it at the end of boot,
+  `src/health-check.py` (`_default_core_restart`) runs it with `--restart` for wedge recovery, and
+  Sutando.app's "Restart Core CLI" menu invokes it. It assembles the `claude` command line
+  (model/settings/cwd/obs args), resolves the workspace-scoped `CLAUDE_CONFIG_DIR`, and seeds
+  onboarding/trust state so a detached, no-TTY core doesn't dead-end at the welcome or
+  folder-trust prompt.
+- **`cli/sutando-shell-setup.sh`** — configures the interactive `claude-sutando` shell function
+  (the per-invocation analogue of start-cli.sh's config-dir resolution: it runs `claude` with
+  `CLAUDE_CONFIG_DIR` pointed at `<workspace>/.claude-sutando`). Also provides `--import` /
+  `--repair-paths` used by `scripts/sutando-migrate.sh`. Invoked once-per-host (`--auto`) from
+  `src/startup.sh`.
+
+## Auth / onboarding that lives *elsewhere* (by design)
+
+- **Credential seeding at boot** — the auth-carry / env-token-persist block in `src/startup.sh`
+  (copies `.credentials.json` + `.claude.json` from `~/.claude/`, or writes a token from
+  `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN`). Stays inline because it must run in
+  startup's own environment and export `CLAUDE_CONFIG_DIR` for the bridges that launch after — it
+  is not a separately-execed step.
+- **Credential proxy + quota** — `skills/quota-tracker/` (local proxy that injects/refreshes the
+  OAuth token and routes the core via `ANTHROPIC_BASE_URL=http://localhost:7846`, plus
+  `read-quota.py`). An optional, self-contained **skill** per `CLAUDE.md`'s architecture rules; the
+  core boots fine without it.

--- a/src/agent/claude/README.md
+++ b/src/agent/claude/README.md
@@ -1,8 +1,9 @@
 # `src/agent/claude/` — the Claude core-agent
 
 Sutando's **core agent** is Claude Code (`claude`). This directory owns how that core is
-**initialized** and how its auth is **onboarded** — kept out of the general `scripts/` pile so
-the different launch flows live in one place.
+**initialized** (subscription CLI, provider-backed CLI, headless one-shot, or an Agent-SDK
+session) and how its auth is **onboarded** — kept out of the general `scripts/` pile so the
+different launch flows live in one place.
 
 ## Layout
 
@@ -12,13 +13,17 @@ src/agent/claude/
     start-cli.sh             #   the canonical persistent tmux core (sutando-core)
     sutando-shell-setup.sh   #   the `claude-sutando` config-dir alias onboarding
     dashp.sh                 #   headless one-shot `claude -p`
-  provider-env.sh            # SHARED: resolves the provider connection for the launchers
+  sdk/                       # the Agent SDK (@anthropic-ai/claude-agent-sdk)
+    session-server.ts        #   persistent, observable session + SSE event stream
+    session-server.sh        #   its launcher (provider via provider-env.sh)
+    ui.html                  #   minimal live browser UI over the event stream
+  provider-env.sh            # SHARED: resolves the provider connection for all of the above
   README.md
 ```
 
 > The launchers self-locate the repo root **four levels up** (`dirname/../../../..`) because
-> they live in `cli/`. `provider-env.sh` stays at the `claude/` root (shared) and is sourced by
-> the launchers via an absolute `$REPO/...` path.
+> they live in `cli/` or `sdk/`. `provider-env.sh` stays at the `claude/` root (shared) and is
+> sourced by both via an absolute `$REPO/...` path. Keep this in mind if you move things again.
 
 ## Initialization flows
 
@@ -27,20 +32,19 @@ src/agent/claude/
 | **Subscription core** (default) | `cli/start-cli.sh` | interactive, tmux `sutando-core` | Claude.ai OAuth |
 | **Provider core** | `cli/start-cli.sh` (when `core_config.provider` is set) | same interactive core, pointed at a custom endpoint | API token + `provider` |
 | **Headless** | `cli/dashp.sh` | one-shot `claude -p` | API token + `provider` |
+| **SDK session** | `sdk/session-server.sh` | persistent Agent-SDK session (streaming) | API token + `provider` |
 
 `src/startup.sh` boots the persistent core via `cli/start-cli.sh`. With no provider set that's
-the subscription; set `core_config.provider` and the **same** persistent core boots against your
-provider instead — a drop-in that survives restarts, health-check `--recover-core`, and
-Sutando.app's Restart Core. `dashp.sh` is a separate, opt-in one-shot path that shares the same
-provider-connection resolution (`provider-env.sh`).
-
-> A fourth flow — an Agent-SDK **session core** (`core_config.core_type: claude_sdk`) with a live
-> browser UI + the full runtime — builds on this and lands in a follow-up PR.
+the subscription; set `core_config.provider` and the **same** persistent core (tmux session,
+watcher loop, `/schedule-crons`) boots against your provider instead — a drop-in that survives
+restarts, health-check `--recover-core`, and Sutando.app's Restart Core (all re-exec that one
+script). `dashp.sh` and the SDK session are separate, opt-in paths that share the same provider
+connection resolution (`provider-env.sh`).
 
 ## Configuration — the `core_config` block
 
-The high-level "which core, and how it connects" contract lives in the **`core_config`** block of
-`sutando.config(.local).json` (schema + defaults: `src/sutando_config.py::resolve_core_config`,
+The high-level "which core, and how it connects" contract lives in the **`core_config`** block
+of `sutando.config(.local).json` (schema + defaults: `src/sutando_config.py::resolve_core_config`,
 read via `scripts/sutando-config.sh core-config`):
 
 ```json
@@ -57,23 +61,26 @@ read via `scripts/sutando-config.sh core-config`):
 ```
 
 - **`core_type`** — `claude_cli` (the interactive tmux core, `cli/start-cli.sh`) or `claude_sdk`
-  (the Agent-SDK session core — follow-up PR).
+  (the Agent-SDK session, `sdk/session-server.sh`).
 - **`provider`** — custom Anthropic-compatible endpoint URL. **Empty = stock Anthropic /
-  subscription** (no provider needed). Set it to run on a gateway.
+  subscription** (no provider needed). Set it to run on a gateway; required for `claude_sdk`.
 - **`auth_env`** — **defaults to the sentinel `ANTHROPIC_SUBSCRIPTION`** = use the Claude.ai
-  subscription OAuth, no provider token. For a provider, set the env var (and vault key) holding
-  the token: `ANTHROPIC_AUTH_TOKEN` → `Authorization: Bearer`, or `ANTHROPIC_API_KEY` → `x-api-key`.
-- **`model`** — the **primary** session model (the core's own, opus-class) → `ANTHROPIC_MODEL`.
-- **`models`** — per-**class** model IDs for **subtasks/subagents** (so lighter work runs cheaper
-  models), each mapping to a Claude Code alias (empty = inherit): `models.opus` →
-  `ANTHROPIC_DEFAULT_OPUS_MODEL`, `models.sonnet` → `ANTHROPIC_DEFAULT_SONNET_MODEL` (subagents
-  default here), `models.haiku` → `ANTHROPIC_DEFAULT_HAIKU_MODEL` (quick/background). An
-  already-set `ANTHROPIC_DEFAULT_*_MODEL` env var wins.
+  subscription OAuth, no provider token (correct for the default `claude_cli` core). For a
+  provider, set the env var (and vault key) holding the token: `ANTHROPIC_AUTH_TOKEN` →
+  `Authorization: Bearer`, or `ANTHROPIC_API_KEY` → `x-api-key`.
+- **`model`** — the **primary** session model (the core's own, opus-class) →
+  `ANTHROPIC_MODEL`. Empty = provider/account default.
+- **`models`** — per-**class** model IDs for **subtasks/subagents** (so lighter work
+  runs cheaper models), each mapping to a Claude Code alias (empty = inherit):
+  `models.opus` → `ANTHROPIC_DEFAULT_OPUS_MODEL`, `models.sonnet` →
+  `ANTHROPIC_DEFAULT_SONNET_MODEL` (subagents default here), `models.haiku` →
+  `ANTHROPIC_DEFAULT_HAIKU_MODEL` (quick/background). An already-set
+  `ANTHROPIC_DEFAULT_*_MODEL` env var takes precedence.
 
-The token named by `auth_env` is read from the env, else the **vault** (`vault set <auth_env>
-<token>` — never in the config file). `dashp.sh`'s launch knobs (permission mode, `--bare`, output
-format) are env/CLI overrides only, keeping the config high-level. Precedence everywhere:
-**CLI flag > env var > config > default**.
+The token is read from the env var named by `auth_env`, else the **vault** (`vault set <auth_env>
+<token>` — never in the config file). `dashp.sh`'s launch knobs (permission mode, `--bare`,
+output format) are intentionally **not** in `core_config` — they're env/CLI overrides only, so
+the config stays high-level. Precedence everywhere: **CLI flag > env var > config > default**.
 
 ### Run the persistent core on the provider (drop-in replacement)
 
@@ -92,17 +99,85 @@ format) are env/CLI overrides only, keeping the config high-level. Precedence ev
 
 When `core_config.provider` is set, `start-cli.sh` sheds any inherited credential-proxy
 `ANTHROPIC_BASE_URL`, sources `provider-env.sh` to export `ANTHROPIC_BASE_URL` / the token /
-`ANTHROPIC_MODEL`, and launches the same interactive core (env token overrides any OAuth
-`.credentials.json` — Claude Code precedence: env > keychain). **If a provider is set but no token
+`ANTHROPIC_MODEL` (env token overrides any OAuth `.credentials.json` — Claude Code precedence:
+env > keychain), and launches the same interactive core. **If a provider is set but no token
 resolves, `start-cli.sh` refuses to start** rather than silently using the subscription. Clear
 `core_config.provider` to return to the subscription core.
 
+## Live UI over the session (Agent SDK)
+
+`sdk/session-server.ts` runs a **persistent, fully-observable** Claude Code session and streams
+every event to a browser. It uses `@anthropic-ai/claude-agent-sdk`'s `query()` with an
+**async-iterable prompt** — one long-lived process that keeps context across turns (the stable,
+SDK-wrapped form of the CLI's `--input-format stream-json` / `--output-format stream-json`). No
+hooks / OTel / JSONL-tail glue: the SDK message stream *is* the event feed.
+
+```
+browser ──GET /events (SSE)──►  session-server.ts  ──query({prompt: stream})──►  Agent SDK ⇄ claude
+        ◄─POST /input {text}──                       (assistant · tool_use · tool_result · result)
+```
+
+```bash
+bash src/agent/claude/sdk/session-server.sh                        # → http://localhost:4100
+SUTANDO_SESSION_FAKE=1 bash src/agent/claude/sdk/session-server.sh # offline echo mode (UI dev)
+```
+
+Endpoints: `GET /` (UI), `GET /events` (SSE — every SDK message), `POST /input` (`{"text"}` — a
+user turn), `GET /health`. Env: `SUTANDO_SESSION_PORT` (4100), `SUTANDO_SESSION_BIND` (127.0.0.1
+— no auth; relays full prompts + tool I/O, keep it loopback), `SUTANDO_SESSION_FAKE=1`.
+
+Tools **auto-approve** (`permissionMode: 'bypassPermissions'`). To surface approvals in the UI
+later, pass a `canUseTool` callback to `query()` that emits a `permission_request` event and
+awaits a `POST /permission` decision.
+
+### It runs the full Sutando runtime (hybrid)
+
+`session-server.ts` is not a bare Q&A session — it's the `claude_sdk` **core**, running the same
+runtime as the interactive core. The SDK session is the **brain** (it loads `CLAUDE.md` + skills
+via `settingSources: ['user','project','local']` + the `claude_code` `systemPrompt` preset —
+without these the SDK runs in *isolation mode* with no runtime), and this Node **host** is the
+**nervous system** — it watches for work and injects it as turns:
+
+- **Task ingestion** — watches `<workspace>/tasks/` and injects each task as a turn. On pickup a
+  task is atomically moved to `tasks/.sdk-inflight/` *before* injection (so the proactive loop's
+  own `tasks/` scan can't double-process it), then archived to `tasks/archive/YYYY-MM/` when its
+  result appears; staged leftovers are recovered on restart. Sets **`SUTANDO_HOST_OWNS_WATCHER=1`**
+  so the agent's own `Monitor` watcher (`src/watch-tasks-stream.sh`) no-ops (holds its PID so the
+  proactive loop's watcher check passes, but emits nothing).
+- **Cron + proactive scheduling** — reads the same `hosts/<host>/crons.json`, matches each 5-field
+  schedule against the clock, and injects the cron's prompt (`prompt_skill` → `/skill`, e.g.
+  `/proactive-loop` on `*/5`; `prompt` → the literal text, which self-gates via `cron-gate.sh`).
+  **This is host-driven because `CronCreate`/`CronList` are NOT available in an SDK session**
+  (verified live) — so the bootstrap orients the agent to *not* run `/schedule-crons` or manage
+  the watcher (override with `SUTANDO_SESSION_BOOTSTRAP` / `SUTANDO_SESSION_NO_BOOTSTRAP=1`).
+- **Liveness** — the per-host `state/cores/<host>.alive` heartbeat (30s, atomic, schema-v1, matching
+  `src/core_heartbeat.py`) and `state/core-status.json` (running/idle). Skipped with
+  `SUTANDO_SESSION_NO_HEARTBEAT=1` when `startup.sh` already runs `core_heartbeat.py`.
+
+Extra SSE server events: `bootstrap`, `task_injected {id}`, `task_done {id}`, `cron_fired {name}`,
+`user_turn`. In `SUTANDO_SESSION_FAKE=1` mode the SDK isn't spawned but the **host runtime still
+runs** (heartbeat, task lifecycle, cron ticks) — so you can develop/verify ingestion offline.
+
+### Starting it — `src/startup.sh` routes by `core_type`
+
+`bash src/startup.sh` starts every service, then launches the core based on
+`core_config.core_type`:
+
+- **`claude_cli`** (default) → the interactive tmux core (`cli/start-cli.sh`), as always.
+- **`claude_sdk`** → the SDK core: `startup.sh` starts `sdk/session-server.sh` in the background
+  (with `SUTANDO_SESSION_NO_HEARTBEAT=1`, since `core_heartbeat.py` already runs) and opens the UI.
+
+So to run everything on the SDK core, set `"core_type": "claude_sdk"` in `sutando.config.local.json`
+and run `bash src/startup.sh`. Run `sdk/session-server.sh` directly for a standalone core (it then
+owns its own heartbeat).
+
 ## Auth / onboarding that lives *elsewhere* (by design)
 
-- **Credential seeding at boot** — the auth-carry / env-token-persist block in `src/startup.sh`.
-  Stays inline because it must run in startup's own environment and export `CLAUDE_CONFIG_DIR` for
-  the bridges that launch after.
+- **Credential seeding at boot** — the auth-carry / env-token-persist block in `src/startup.sh`
+  (copies `.credentials.json` + `.claude.json` from `~/.claude/`, or writes a token from
+  `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN`). Stays inline because it must run in
+  startup's own environment and export `CLAUDE_CONFIG_DIR` for the bridges that launch after.
 - **Credential proxy + quota** — `skills/quota-tracker/` (local proxy that injects/refreshes the
-  OAuth token and routes the subscription core via `ANTHROPIC_BASE_URL=http://localhost:7846`). An
-  optional, self-contained **skill** per `CLAUDE.md`; the core boots fine without it. (Provider
-  mode overrides this `ANTHROPIC_BASE_URL`.)
+  OAuth token and routes the subscription core via `ANTHROPIC_BASE_URL=http://localhost:7846`,
+  plus `read-quota.py`). An optional, self-contained **skill** per `CLAUDE.md`'s architecture
+  rules; the core boots fine without it. (Provider mode overrides this `ANTHROPIC_BASE_URL`.)

--- a/src/agent/claude/README.md
+++ b/src/agent/claude/README.md
@@ -1,10 +1,8 @@
 # `src/agent/claude/` — the Claude core-agent
 
-Sutando's **core agent** is Claude Code (`claude`). This directory is the home for the code that
-**initializes** that core agent and **onboards** its auth — pulled out of the general `scripts/`
-pile so the launch/onboarding logic lives in one place, and so a second initialization flow
-(e.g. a headless / alternate-provider launcher) can grow alongside the current one without
-scattering launch code across the repo.
+Sutando's **core agent** is Claude Code (`claude`). This directory owns how that core is
+**initialized** and how its auth is **onboarded** — kept out of the general `scripts/` pile so
+the different launch flows live in one place.
 
 ## Layout
 
@@ -13,36 +11,98 @@ src/agent/claude/
   cli/                       # launchers that drive the `claude` BINARY
     start-cli.sh             #   the canonical persistent tmux core (sutando-core)
     sutando-shell-setup.sh   #   the `claude-sutando` config-dir alias onboarding
+    dashp.sh                 #   headless one-shot `claude -p`
+  provider-env.sh            # SHARED: resolves the provider connection for the launchers
   README.md
 ```
 
-> The launchers self-locate the repo root **four levels up** (`dirname/../../../..`) because they
-> live in `cli/`. Everything else inside them is repo-root-relative (`$REPO/scripts/...`). Keep
-> this in mind if you move them again.
+> The launchers self-locate the repo root **four levels up** (`dirname/../../../..`) because
+> they live in `cli/`. `provider-env.sh` stays at the `claude/` root (shared) and is sourced by
+> the launchers via an absolute `$REPO/...` path.
 
-## Contents
+## Initialization flows
 
-- **`cli/start-cli.sh`** — the single canonical launcher/restarter for the `sutando-core` tmux
-  session. Every core launch funnels through it: `src/startup.sh` execs it at the end of boot,
-  `src/health-check.py` (`_default_core_restart`) runs it with `--restart` for wedge recovery, and
-  Sutando.app's "Restart Core CLI" menu invokes it. It assembles the `claude` command line
-  (model/settings/cwd/obs args), resolves the workspace-scoped `CLAUDE_CONFIG_DIR`, and seeds
-  onboarding/trust state so a detached, no-TTY core doesn't dead-end at the welcome or
-  folder-trust prompt.
-- **`cli/sutando-shell-setup.sh`** — configures the interactive `claude-sutando` shell function
-  (the per-invocation analogue of start-cli.sh's config-dir resolution: it runs `claude` with
-  `CLAUDE_CONFIG_DIR` pointed at `<workspace>/.claude-sutando`). Also provides `--import` /
-  `--repair-paths` used by `scripts/sutando-migrate.sh`. Invoked once-per-host (`--auto`) from
-  `src/startup.sh`.
+| Flow | Launcher | How `claude` runs | Auth |
+|------|----------|-------------------|------|
+| **Subscription core** (default) | `cli/start-cli.sh` | interactive, tmux `sutando-core` | Claude.ai OAuth |
+| **Provider core** | `cli/start-cli.sh` (when `core_config.provider` is set) | same interactive core, pointed at a custom endpoint | API token + `provider` |
+| **Headless** | `cli/dashp.sh` | one-shot `claude -p` | API token + `provider` |
+
+`src/startup.sh` boots the persistent core via `cli/start-cli.sh`. With no provider set that's
+the subscription; set `core_config.provider` and the **same** persistent core boots against your
+provider instead — a drop-in that survives restarts, health-check `--recover-core`, and
+Sutando.app's Restart Core. `dashp.sh` is a separate, opt-in one-shot path that shares the same
+provider-connection resolution (`provider-env.sh`).
+
+> A fourth flow — an Agent-SDK **session core** (`core_config.core_type: claude_sdk`) with a live
+> browser UI + the full runtime — builds on this and lands in a follow-up PR.
+
+## Configuration — the `core_config` block
+
+The high-level "which core, and how it connects" contract lives in the **`core_config`** block of
+`sutando.config(.local).json` (schema + defaults: `src/sutando_config.py::resolve_core_config`,
+read via `scripts/sutando-config.sh core-config`):
+
+```json
+"core_config": {
+  "core_type": "claude_cli",
+  "provider": "https://your-gateway.example.com",
+  "auth_env": "ANTHROPIC_AUTH_TOKEN",
+  "model": "your-opus-class-model-id",
+  "models": {
+    "sonnet": "your-sonnet-model-id",
+    "haiku": "your-haiku-model-id"
+  }
+}
+```
+
+- **`core_type`** — `claude_cli` (the interactive tmux core, `cli/start-cli.sh`) or `claude_sdk`
+  (the Agent-SDK session core — follow-up PR).
+- **`provider`** — custom Anthropic-compatible endpoint URL. **Empty = stock Anthropic /
+  subscription** (no provider needed). Set it to run on a gateway.
+- **`auth_env`** — **defaults to the sentinel `ANTHROPIC_SUBSCRIPTION`** = use the Claude.ai
+  subscription OAuth, no provider token. For a provider, set the env var (and vault key) holding
+  the token: `ANTHROPIC_AUTH_TOKEN` → `Authorization: Bearer`, or `ANTHROPIC_API_KEY` → `x-api-key`.
+- **`model`** — the **primary** session model (the core's own, opus-class) → `ANTHROPIC_MODEL`.
+- **`models`** — per-**class** model IDs for **subtasks/subagents** (so lighter work runs cheaper
+  models), each mapping to a Claude Code alias (empty = inherit): `models.opus` →
+  `ANTHROPIC_DEFAULT_OPUS_MODEL`, `models.sonnet` → `ANTHROPIC_DEFAULT_SONNET_MODEL` (subagents
+  default here), `models.haiku` → `ANTHROPIC_DEFAULT_HAIKU_MODEL` (quick/background). An
+  already-set `ANTHROPIC_DEFAULT_*_MODEL` env var wins.
+
+The token named by `auth_env` is read from the env, else the **vault** (`vault set <auth_env>
+<token>` — never in the config file). `dashp.sh`'s launch knobs (permission mode, `--bare`, output
+format) are env/CLI overrides only, keeping the config high-level. Precedence everywhere:
+**CLI flag > env var > config > default**.
+
+### Run the persistent core on the provider (drop-in replacement)
+
+```jsonc
+// sutando.config.local.json
+"core_config": {
+  "core_type": "claude_cli",
+  "provider": "https://your-gateway.example.com",
+  "auth_env": "ANTHROPIC_AUTH_TOKEN",
+  "model": "your-model-id"
+}
+```
+
+1. Store the token: `vault set ANTHROPIC_AUTH_TOKEN <token>` (via Slack/Discord), or export it.
+2. Restart the core: `bash src/agent/claude/cli/start-cli.sh --restart` — or `bash src/startup.sh`.
+
+When `core_config.provider` is set, `start-cli.sh` sheds any inherited credential-proxy
+`ANTHROPIC_BASE_URL`, sources `provider-env.sh` to export `ANTHROPIC_BASE_URL` / the token /
+`ANTHROPIC_MODEL`, and launches the same interactive core (env token overrides any OAuth
+`.credentials.json` — Claude Code precedence: env > keychain). **If a provider is set but no token
+resolves, `start-cli.sh` refuses to start** rather than silently using the subscription. Clear
+`core_config.provider` to return to the subscription core.
 
 ## Auth / onboarding that lives *elsewhere* (by design)
 
-- **Credential seeding at boot** — the auth-carry / env-token-persist block in `src/startup.sh`
-  (copies `.credentials.json` + `.claude.json` from `~/.claude/`, or writes a token from
-  `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN`). Stays inline because it must run in
-  startup's own environment and export `CLAUDE_CONFIG_DIR` for the bridges that launch after — it
-  is not a separately-execed step.
+- **Credential seeding at boot** — the auth-carry / env-token-persist block in `src/startup.sh`.
+  Stays inline because it must run in startup's own environment and export `CLAUDE_CONFIG_DIR` for
+  the bridges that launch after.
 - **Credential proxy + quota** — `skills/quota-tracker/` (local proxy that injects/refreshes the
-  OAuth token and routes the core via `ANTHROPIC_BASE_URL=http://localhost:7846`, plus
-  `read-quota.py`). An optional, self-contained **skill** per `CLAUDE.md`'s architecture rules; the
-  core boots fine without it.
+  OAuth token and routes the subscription core via `ANTHROPIC_BASE_URL=http://localhost:7846`). An
+  optional, self-contained **skill** per `CLAUDE.md`; the core boots fine without it. (Provider
+  mode overrides this `ANTHROPIC_BASE_URL`.)

--- a/src/agent/claude/cli/dashp.sh
+++ b/src/agent/claude/cli/dashp.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# src/agent/claude/cli/dashp.sh — headless (`claude -p`) launcher for the claude
+# core agent, against a custom Anthropic-compatible provider + API token.
+#
+# Sibling of start-cli.sh. Where start-cli.sh runs an INTERACTIVE `claude` in a
+# tmux `sutando-core` session, dashp.sh runs a ONE-SHOT, NON-INTERACTIVE
+# `claude -p "<prompt>"`. The assistant's final message is printed to stdout;
+# exit 0 on success, non-zero on error.
+#
+# (To run the PERSISTENT core on the provider instead — a drop-in for the
+# subscription core — set `core_config.provider` in sutando config; start-cli.sh
+# then boots the interactive core against it. dashp.sh is the one-shot path.)
+#
+# Usage:
+#   bash src/agent/claude/cli/dashp.sh "Summarize today's open PRs"
+#   echo "Summarize today's open PRs" | bash src/agent/claude/cli/dashp.sh
+#   bash src/agent/claude/cli/dashp.sh --json --model my-model "Find bugs in app.js"
+#
+# Options (consumed from the front; the rest is the prompt):
+#   --json / --text   → claude --output-format json|text
+#   --bare            → claude --bare  (skip hooks/skills/MCP/CLAUDE.md)
+#   --model NAME      → provider model (same as ANTHROPIC_MODEL / core_config.model)
+#   --                → end option parsing; everything after is the prompt
+# If no prompt args are given, the prompt is read from stdin.
+#
+# ── Configuration ────────────────────────────────────────────────────────────
+# The provider connection (provider + auth_env + model) comes from the
+# `core_config` block of sutando.config(.local).json, resolved by the shared
+# helper provider-env.sh (schema: src/sutando_config.py::resolve_core_config):
+#
+#   "core_config": {
+#     "provider": "https://your-gateway.example.com",
+#     "auth_env": "ANTHROPIC_AUTH_TOKEN",   // or ANTHROPIC_API_KEY (x-api-key)
+#     "model": "your-model-id"
+#   }
+#
+# dashp.sh's own launch knobs are env/CLI only (NOT in core_config), keeping the
+# config high-level. Precedence: CLI flag > env var > default.
+#   SUTANDO_DASHP_OUTPUT_FORMAT   text|json   (or --json/--text)
+#   SUTANDO_DASHP_BARE            1            (or --bare)
+#   SUTANDO_DASHP_PERMISSION_MODE <mode>       (empty = --dangerously-skip-permissions)
+# Provider-connection env overrides (shared, honored by provider-env.sh):
+#   SUTANDO_PROVIDER_URL / SUTANDO_PROVIDER_MODEL / SUTANDO_PROVIDER_AUTH_ENV
+#
+# ── Auth ─────────────────────────────────────────────────────────────────────
+# The token is read from the env var named by `auth_env` if set, else from the
+# vault key of the same name (skills/secret-vault). Never logged. It takes
+# precedence over any OAuth .credentials.json in CLAUDE_CONFIG_DIR (Claude Code:
+# env > settings > keychain), so the subscription token is never used here.
+#
+# ── Permissions ──────────────────────────────────────────────────────────────
+# `claude -p` denies all tools unless told otherwise. Empty permission_mode →
+# --dangerously-skip-permissions (parity with the subscription core). Tool
+# execution is always LOCAL regardless of provider — set a restrictive
+# permission_mode (e.g. dontAsk) when the provider isn't trusted.
+
+set -euo pipefail
+
+# This script lives at src/agent/claude/cli/ — four levels under the repo root.
+REPO="$(cd "$(dirname "$0")/../../../.." && pwd)"
+cd "$REPO"
+
+# ---- CLI options (highest precedence) --------------------------------------
+cli_output_format=""   # "json" | "text" when a CLI flag set it
+cli_bare=0
+PROMPT_ARGS=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json)  cli_output_format="json"; shift ;;
+    --text)  cli_output_format="text"; shift ;;
+    --bare)  cli_bare=1; shift ;;
+    # Inject --model into the env var the provider helper reads, so CLI beats
+    # both env and config for the model (CLI > env > config).
+    --model|-m) export SUTANDO_PROVIDER_MODEL="${2:-}"; shift 2 ;;
+    --)      shift; while [ "$#" -gt 0 ]; do PROMPT_ARGS+=("$1"); shift; done ;;
+    *)       PROMPT_ARGS+=("$1"); shift ;;
+  esac
+done
+
+# ---- dashp-only launch knobs (env/CLI only — NOT in core_config) ------------
+# These are dashp.sh-specific and intentionally kept out of core_config to keep
+# it high-level. Precedence: CLI flag > env var > default.
+
+# output format: CLI > env > default(text)
+if [ -n "$cli_output_format" ]; then
+  OUTPUT_FORMAT="$cli_output_format"
+elif [ -n "${SUTANDO_DASHP_OUTPUT_FORMAT:-}" ]; then
+  OUTPUT_FORMAT="$SUTANDO_DASHP_OUTPUT_FORMAT"
+else
+  OUTPUT_FORMAT="text"
+fi
+
+# bare: CLI > env > default(off)
+BARE=0
+if [ "$cli_bare" -eq 1 ]; then
+  BARE=1
+elif [ -n "${SUTANDO_DASHP_BARE:-}" ]; then
+  case "$SUTANDO_DASHP_BARE" in 1|true|TRUE|yes) BARE=1 ;; esac
+fi
+
+# permission posture: env > default(--dangerously-skip-permissions)
+PERMISSION_MODE="${SUTANDO_DASHP_PERMISSION_MODE:-}"
+
+# ---- prompt: args win; else stdin ------------------------------------------
+# `claude -p -` reads the prompt from stdin. Refuse the ambiguous
+# "no args AND a TTY stdin" case rather than hang on an interactive terminal.
+PROMPT=""
+READ_STDIN=0
+if [ "${#PROMPT_ARGS[@]}" -gt 0 ]; then
+  PROMPT="${PROMPT_ARGS[*]}"
+elif [ ! -t 0 ]; then
+  READ_STDIN=1
+else
+  echo "dashp: no prompt given (pass it as args or pipe it on stdin)" >&2
+  echo "  e.g. bash src/agent/claude/cli/dashp.sh \"your prompt\"" >&2
+  exit 2
+fi
+
+# ---- workspace-scoped CLAUDE_CONFIG_DIR (mirror start-cli.sh) ---------------
+# Resolve the same per-runtime config dir so settings/skills/CLAUDE.md and
+# channel state resolve to the workspace tree (not global ~/.claude/). The env
+# token resolved below takes precedence over any OAuth .credentials.json here.
+if [ -x "$REPO/scripts/sutando-config.sh" ]; then
+  if _ccd="$(bash "$REPO/scripts/sutando-config.sh" claude-sutando-config-dir 2>/dev/null)"; then
+    mkdir -p "$_ccd"
+    export CLAUDE_CONFIG_DIR="$_ccd"
+  fi
+  # Helper-missing / invalid → silent fallback (claude resolves its own dir).
+fi
+
+# ---- provider connection (shared with start-cli.sh) ------------------------
+# shellcheck source=src/agent/claude/provider-env.sh
+. "$REPO/src/agent/claude/provider-env.sh"
+_prc=0; claude_provider_export_env || _prc=$?
+if [ "$_prc" = "0" ]; then
+  echo "dashp: provider → ${ANTHROPIC_BASE_URL:-(stock Anthropic endpoint)}${ANTHROPIC_MODEL:+ · model=$ANTHROPIC_MODEL} (auth via ${CLAUDE_PROVIDER_AUTH_ENV})" >&2
+elif [ "$_prc" = "2" ]; then
+  # ANTHROPIC_SUBSCRIPTION sentinel — run `claude -p` on the Claude.ai subscription
+  # (no provider token). Set core_config.provider + a token auth_env for a provider.
+  echo "dashp: subscription auth (auth_env=ANTHROPIC_SUBSCRIPTION) — running claude -p on the Claude.ai subscription." >&2
+else
+  echo "dashp: no API token found via ${CLAUDE_PROVIDER_AUTH_ENV:-ANTHROPIC_AUTH_TOKEN}. Set it in the env," >&2
+  echo "  or store it in the vault ('vault set ${CLAUDE_PROVIDER_AUTH_ENV:-ANTHROPIC_AUTH_TOKEN} <token>' via Slack/Discord)," >&2
+  echo "  or set core_config.auth_env=ANTHROPIC_API_KEY for x-api-key style. See src/agent/claude/README.md." >&2
+  exit 3
+fi
+[ -n "${ANTHROPIC_BASE_URL:-}" ] || echo "dashp: no provider set — using the stock Anthropic endpoint (set core_config.provider for a custom provider)." >&2
+
+# ---- assemble claude args ---------------------------------------------------
+# Model comes from ANTHROPIC_MODEL (exported by the helper), so no --model here.
+OUTPUT_ARGS=(--output-format "$OUTPUT_FORMAT")
+BARE_ARGS=()
+[ "$BARE" -eq 1 ] && BARE_ARGS=(--bare)
+PERM_ARGS=(--dangerously-skip-permissions)
+[ -n "$PERMISSION_MODE" ] && PERM_ARGS=(--permission-mode "$PERMISSION_MODE")
+
+# ---- launch -----------------------------------------------------------------
+# --add-dir "$HOME" mirrors start-cli.sh so the headless core has the same file
+# reach as the interactive one. The ${arr[@]+...} guards keep empty arrays safe
+# on bash 3.2 under `set -u` (same pattern as start-cli.sh).
+if [ "$READ_STDIN" -eq 1 ]; then
+  exec claude -p - \
+    ${OUTPUT_ARGS[@]+"${OUTPUT_ARGS[@]}"} \
+    ${BARE_ARGS[@]+"${BARE_ARGS[@]}"} \
+    ${PERM_ARGS[@]+"${PERM_ARGS[@]}"} \
+    --add-dir "$HOME"
+else
+  exec claude -p "$PROMPT" \
+    ${OUTPUT_ARGS[@]+"${OUTPUT_ARGS[@]}"} \
+    ${BARE_ARGS[@]+"${BARE_ARGS[@]}"} \
+    ${PERM_ARGS[@]+"${PERM_ARGS[@]}"} \
+    --add-dir "$HOME"
+fi

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# src/agent/claude/cli/start-cli.sh — canonical launch script for the sutando-core
-# tmux session. Single source of truth for the "how to start Claude Code" command,
+# src/agent/claude/cli/start-cli.sh — canonical launch script for the sutando-core tmux
+# session. Single source of truth for the "how to start Claude Code" command,
 # so startup.sh + Sutando.app's Restart Core menu can both invoke it without
 # duplicating the launch arguments.
 #
@@ -161,6 +161,59 @@ PY
   rm -f "$_ccd_err"
 fi
 
+# ---- provider-backed core (core_config.provider) ---------------------------
+# When core_config.provider is set, boot the SAME interactive core (tmux session,
+# watcher loop, /schedule-crons — everything below is unchanged) but pointed at a
+# custom Anthropic-compatible provider + API token instead of the Claude.ai
+# subscription. A drop-in replacement: config-driven, so it persists across
+# restarts, health-check --recover-core, and Sutando.app's Restart Core (all of
+# which re-exec this one script). With no provider set, this block is skipped and
+# the core runs on the subscription exactly as before.
+#
+# We source the SHARED provider-env helper (also used by dashp.sh / session-server)
+# to export ANTHROPIC_BASE_URL / <auth_env> token / ANTHROPIC_MODEL. Those env
+# exports are inherited by the tmux-launched `claude` below the same way
+# startup.sh's ANTHROPIC_BASE_URL=<credential-proxy> already reaches it — and the
+# env token takes precedence over any OAuth .credentials.json (Claude Code: env >
+# keychain), so the subscription creds are ignored.
+#
+# Read core_config first so we only touch the provider path when one is
+# configured (otherwise a stray token in the env must NOT override subscription
+# auth). Fail loud if a provider is set but no token resolves.
+CLAUDE_AS_CORE_PROVIDER=0
+if [ -x "$REPO/scripts/sutando-config.sh" ]; then
+  _cc_provider="" _cc_core_type=""
+  while IFS='=' read -r _k _v; do
+    case "$_k" in CFG_PROVIDER) _cc_provider="$_v" ;; CFG_CORE_TYPE) _cc_core_type="$_v" ;; esac
+  done < <(bash "$REPO/scripts/sutando-config.sh" core-config 2>/dev/null) || true
+  # A provider counts as configured via config OR the env override.
+  if [ -n "$_cc_provider" ] || [ -n "${SUTANDO_PROVIDER_URL:-}" ]; then
+    CLAUDE_AS_CORE_PROVIDER=1
+    [ "$_cc_core_type" = "claude_sdk" ] && echo "  ~ note: core_config.core_type=claude_sdk — this is the CLI core; run src/agent/claude/sdk/session-server.sh for the SDK core." >&2
+    # Shed any inherited ANTHROPIC_BASE_URL before resolving the provider. When
+    # launched via src/startup.sh this is pre-set to the credential proxy
+    # (http://localhost:7846), which injects the SUBSCRIPTION token — the exact
+    # thing provider mode must NOT use. Unsetting it lets provider-env.sh set the
+    # provider endpoint from core_config.provider (or SUTANDO_PROVIDER_URL).
+    unset ANTHROPIC_BASE_URL
+    # shellcheck source=src/agent/claude/provider-env.sh
+    . "$REPO/src/agent/claude/provider-env.sh"
+    _prc=0; claude_provider_export_env || _prc=$?
+    if [ "$_prc" = "0" ]; then
+      echo "  ✓ core provider: ${ANTHROPIC_BASE_URL:-(stock Anthropic endpoint)}${ANTHROPIC_MODEL:+ · model=$ANTHROPIC_MODEL} (auth via ${CLAUDE_PROVIDER_AUTH_ENV})"
+    elif [ "$_prc" = "2" ]; then
+      # Subscription auth_env but a provider IS set — contradictory: a provider
+      # endpoint won't authenticate against the subscription OAuth.
+      echo "start-cli: core_config.provider is set but core_config.auth_env=ANTHROPIC_SUBSCRIPTION (no token) — a provider needs a token. Set auth_env to ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY, or clear core_config.provider. Refusing to start core." >&2
+      exit 1
+    else
+      echo "start-cli: core_config.provider is set but no API token resolved via ${CLAUDE_PROVIDER_AUTH_ENV:-ANTHROPIC_AUTH_TOKEN} (env or vault) — refusing to start core." >&2
+      echo "  Set the token in the env or vault, or clear core_config.provider to use the subscription core. See src/agent/claude/README.md." >&2
+      exit 1
+    fi
+  fi
+fi
+
 # Optional context-window pin (graceful-degradation hook for the 1M
 # usage-credit-gate wedge — see src/health-check.py recover_core_if_wedged).
 # When SUTANDO_CORE_MODEL is set we pass it through as `--model`; otherwise we
@@ -171,8 +224,13 @@ fi
 # 200K context (no gate) and keeps working instead of looping. The
 # ${arr[@]+...} guard keeps an empty array safe on bash 3.2 even under `set -u`
 # (mirrors the empty-array care in PR #1391).
+# In alternate-provider mode the model comes from ANTHROPIC_MODEL (exported by
+# the provider-env helper above); we do NOT translate SUTANDO_CORE_MODEL into a
+# --model flag there, because that pin (opus / 1M degradation) is a
+# subscription-specific concept and its model names don't exist on a custom
+# provider — a --model flag would also override ANTHROPIC_MODEL.
 MODEL_ARGS=()
-if [ -n "${SUTANDO_CORE_MODEL:-}" ]; then
+if [ "$CLAUDE_AS_CORE_PROVIDER" != "1" ] && [ -n "${SUTANDO_CORE_MODEL:-}" ]; then
   MODEL_ARGS=(--model "$SUTANDO_CORE_MODEL")
 fi
 

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -182,9 +182,13 @@ fi
 # auth). Fail loud if a provider is set but no token resolves.
 CLAUDE_AS_CORE_PROVIDER=0
 if [ -x "$REPO/scripts/sutando-config.sh" ]; then
-  _cc_provider="" _cc_core_type=""
+  _cc_provider="" _cc_core_type="" _cc_auth_env=""
   while IFS='=' read -r _k _v; do
-    case "$_k" in CFG_PROVIDER) _cc_provider="$_v" ;; CFG_CORE_TYPE) _cc_core_type="$_v" ;; esac
+    case "$_k" in
+      CFG_PROVIDER)  _cc_provider="$_v" ;;
+      CFG_CORE_TYPE) _cc_core_type="$_v" ;;
+      CFG_AUTH_ENV)  _cc_auth_env="$_v" ;;
+    esac
   done < <(bash "$REPO/scripts/sutando-config.sh" core-config 2>/dev/null) || true
   # A provider counts as configured via config OR the env override.
   if [ -n "$_cc_provider" ] || [ -n "${SUTANDO_PROVIDER_URL:-}" ]; then
@@ -210,6 +214,18 @@ if [ -x "$REPO/scripts/sutando-config.sh" ]; then
       echo "start-cli: core_config.provider is set but no API token resolved via ${CLAUDE_PROVIDER_AUTH_ENV:-ANTHROPIC_AUTH_TOKEN} (env or vault) — refusing to start core." >&2
       echo "  Set the token in the env or vault, or clear core_config.provider to use the subscription core. See src/agent/claude/README.md." >&2
       exit 1
+    fi
+  elif [ "${_cc_auth_env:-ANTHROPIC_SUBSCRIPTION}" = "ANTHROPIC_SUBSCRIPTION" ]; then
+    # Subscription core (the default): clear any stray API token so a shell-set
+    # ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN (e.g. exported in ~/.zshrc) cannot
+    # override the Claude.ai subscription OAuth. Claude Code precedence is
+    # env token > keychain/.credentials.json, so a lingering key silently bills
+    # the API (or 401s on an invalid one) instead of using the subscription the
+    # operator asked for. auth_env=ANTHROPIC_SUBSCRIPTION means "subscription,
+    # period" — so we enforce it here rather than trust a clean env.
+    if [ -n "${ANTHROPIC_API_KEY:-}" ] || [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+      unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+      echo "  ~ subscription core: cleared a stray ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN from the env (using the Claude.ai subscription)"
     fi
   fi
 fi

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# scripts/start-cli.sh — canonical launch script for the sutando-core tmux
-# session. Single source of truth for the "how to start Claude Code" command,
+# src/agent/claude/cli/start-cli.sh — canonical launch script for the sutando-core
+# tmux session. Single source of truth for the "how to start Claude Code" command,
 # so startup.sh + Sutando.app's Restart Core menu can both invoke it without
 # duplicating the launch arguments.
 #
 # Usage:
-#   bash scripts/start-cli.sh           # start (or attach if running)
-#   bash scripts/start-cli.sh --restart # kill existing session then start fresh
+#   bash src/agent/claude/cli/start-cli.sh           # start (or attach if running)
+#   bash src/agent/claude/cli/start-cli.sh --restart # kill existing session then start fresh
 #
 # Per Chi's prompt 2026-05-05 ("shall we add core CLI-related commands in
 # sutando app"): extracting the launch command from startup.sh's inline tmux
@@ -15,7 +15,8 @@
 
 set -e
 
-REPO="$(cd "$(dirname "$0")/.." && pwd)"
+# This script lives at src/agent/claude/cli/ — four levels under the repo root.
+REPO="$(cd "$(dirname "$0")/../../../.." && pwd)"
 cd "$REPO"
 
 TMUX_SOCKET="/tmp/sutando-tmux.sock"

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -183,13 +183,24 @@ fi
 CLAUDE_AS_CORE_PROVIDER=0
 if [ -x "$REPO/scripts/sutando-config.sh" ]; then
   _cc_provider="" _cc_core_type="" _cc_auth_env=""
-  while IFS='=' read -r _k _v; do
-    case "$_k" in
-      CFG_PROVIDER)  _cc_provider="$_v" ;;
-      CFG_CORE_TYPE) _cc_core_type="$_v" ;;
-      CFG_AUTH_ENV)  _cc_auth_env="$_v" ;;
-    esac
-  done < <(bash "$REPO/scripts/sutando-config.sh" core-config 2>/dev/null) || true
+  # Read core_config LOUD: this decides provider-vs-subscription routing, so a
+  # malformed sutando.config (getter exits nonzero) must not be swallowed into a
+  # silent subscription fallback. Capture the rc and warn; `|| _cc_rc=$?` keeps
+  # this `set -euo pipefail` script alive.
+  _cc_raw="" _cc_rc=0
+  _cc_raw="$(bash "$REPO/scripts/sutando-config.sh" core-config 2>&1)" || _cc_rc=$?
+  if [ "$_cc_rc" -ne 0 ]; then
+    echo "start-cli: WARNING — reading core_config failed (rc=$_cc_rc); using defaults (subscription). Fix sutando.config, then: bash scripts/sutando-config.sh core-config" >&2
+    printf '%s\n' "$_cc_raw" | sed 's/^/  /' >&2
+  else
+    while IFS='=' read -r _k _v; do
+      case "$_k" in
+        CFG_PROVIDER)  _cc_provider="$_v" ;;
+        CFG_CORE_TYPE) _cc_core_type="$_v" ;;
+        CFG_AUTH_ENV)  _cc_auth_env="$_v" ;;
+      esac
+    done <<< "$_cc_raw"
+  fi
   # A provider counts as configured via config OR the env override.
   if [ -n "$_cc_provider" ] || [ -n "${SUTANDO_PROVIDER_URL:-}" ]; then
     CLAUDE_AS_CORE_PROVIDER=1

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -227,16 +227,18 @@ if [ -x "$REPO/scripts/sutando-config.sh" ]; then
       exit 1
     fi
   elif [ "${_cc_auth_env:-ANTHROPIC_SUBSCRIPTION}" = "ANTHROPIC_SUBSCRIPTION" ]; then
-    # Subscription core (the default): clear any stray API token so a shell-set
-    # ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN (e.g. exported in ~/.zshrc) cannot
-    # override the Claude.ai subscription OAuth. Claude Code precedence is
-    # env token > keychain/.credentials.json, so a lingering key silently bills
-    # the API (or 401s on an invalid one) instead of using the subscription the
-    # operator asked for. auth_env=ANTHROPIC_SUBSCRIPTION means "subscription,
-    # period" — so we enforce it here rather than trust a clean env.
-    if [ -n "${ANTHROPIC_API_KEY:-}" ] || [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
-      unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
-      echo "  ~ subscription core: cleared a stray ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN from the env (using the Claude.ai subscription)"
+    # Subscription core (the default): clear a stray ANTHROPIC_API_KEY so a
+    # shell-set x-api-key (e.g. exported in ~/.zshrc) can't shadow the Claude.ai
+    # subscription OAuth. Claude Code precedence is env token > keychain/
+    # .credentials.json, so a lingering key silently bills the raw API (or 401s
+    # on an invalid one) instead of using the subscription the operator asked for.
+    # Clear ONLY ANTHROPIC_API_KEY — NOT ANTHROPIC_AUTH_TOKEN, which can itself be
+    # the subscription/OAuth bearer (and may be the only credential present before
+    # .credentials.json is written); the credential-proxy rewrites the
+    # Authorization header anyway, so a stray bearer is harmless there.
+    if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+      unset ANTHROPIC_API_KEY
+      echo "  ~ subscription core: cleared a stray ANTHROPIC_API_KEY from the env (using the Claude.ai subscription)"
     fi
   fi
 fi

--- a/src/agent/claude/cli/sutando-shell-setup.sh
+++ b/src/agent/claude/cli/sutando-shell-setup.sh
@@ -17,12 +17,12 @@
 # load-bearing for sync coherence.
 #
 # Usage:
-#   bash scripts/sutando-shell-setup.sh                # dry-run: print proposed line + target rc
-#   bash scripts/sutando-shell-setup.sh --commit       # append to rc file (idempotent)
-#   bash scripts/sutando-shell-setup.sh --auto         # one-shot prompt path used by startup.sh
-#   bash scripts/sutando-shell-setup.sh --check        # exit 0 if alias present + path matches; 1 otherwise
-#   bash scripts/sutando-shell-setup.sh --import       # rsync ~/.claude → <workspace>/.claude-sutando (idempotent, non-destructive)
-#   bash scripts/sutando-shell-setup.sh --repair-paths # re-pin hardcoded SOURCE_DIR paths in runtime files to CLAUDE_DIR (idempotent)
+#   bash src/agent/claude/cli/sutando-shell-setup.sh                # dry-run: print proposed line + target rc
+#   bash src/agent/claude/cli/sutando-shell-setup.sh --commit       # append to rc file (idempotent)
+#   bash src/agent/claude/cli/sutando-shell-setup.sh --auto         # one-shot prompt path used by startup.sh
+#   bash src/agent/claude/cli/sutando-shell-setup.sh --check        # exit 0 if alias present + path matches; 1 otherwise
+#   bash src/agent/claude/cli/sutando-shell-setup.sh --import       # rsync ~/.claude → <workspace>/.claude-sutando (idempotent, non-destructive)
+#   bash src/agent/claude/cli/sutando-shell-setup.sh --repair-paths # re-pin hardcoded SOURCE_DIR paths in runtime files to CLAUDE_DIR (idempotent)
 #
 # Deprecated aliases (kept for one release):
 #   --migrate      # alias for --import; emits a stderr deprecation warning. Per
@@ -51,7 +51,8 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# This script lives at src/agent/claude/cli/ — four levels under the repo root.
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
 MODE="dry-run"
 FORCE=0
 FROM_DIR=""

--- a/src/agent/claude/provider-env.sh
+++ b/src/agent/claude/provider-env.sh
@@ -45,17 +45,28 @@ CLAUDE_SUBSCRIPTION_AUTH="ANTHROPIC_SUBSCRIPTION"
 claude_provider_export_env() {
   local cfg_provider="" cfg_model="" cfg_auth_env="" cfg_opus="" cfg_sonnet="" cfg_haiku=""
   if [ -x "$REPO/scripts/sutando-config.sh" ]; then
-    local _k _v
-    while IFS='=' read -r _k _v; do
-      case "$_k" in
-        CFG_PROVIDER)     cfg_provider="$_v" ;;
-        CFG_MODEL)        cfg_model="$_v" ;;
-        CFG_AUTH_ENV)     cfg_auth_env="$_v" ;;
-        CFG_MODEL_OPUS)   cfg_opus="$_v" ;;
-        CFG_MODEL_SONNET) cfg_sonnet="$_v" ;;
-        CFG_MODEL_HAIKU)  cfg_haiku="$_v" ;;
-      esac
-    done < <(bash "$REPO/scripts/sutando-config.sh" core-config 2>/dev/null) || true
+    # Read core_config LOUD. A malformed sutando.config makes the getter exit
+    # nonzero (resolve_core_config → _load_json raises on bad JSON). Capture the
+    # rc so we can surface that instead of silently swallowing it and falling
+    # back to the subscription default — a provider you configured must not
+    # vanish quietly. `|| _cc_rc=$?` keeps a `set -e` caller alive.
+    local _k _v _cc_raw="" _cc_rc=0
+    _cc_raw="$(bash "$REPO/scripts/sutando-config.sh" core-config 2>&1)" || _cc_rc=$?
+    if [ "$_cc_rc" -ne 0 ]; then
+      echo "provider-env: WARNING — reading core_config failed (rc=$_cc_rc); using defaults (subscription). Fix sutando.config, then: bash scripts/sutando-config.sh core-config" >&2
+      printf '%s\n' "$_cc_raw" | sed 's/^/  /' >&2
+    else
+      while IFS='=' read -r _k _v; do
+        case "$_k" in
+          CFG_PROVIDER)     cfg_provider="$_v" ;;
+          CFG_MODEL)        cfg_model="$_v" ;;
+          CFG_AUTH_ENV)     cfg_auth_env="$_v" ;;
+          CFG_MODEL_OPUS)   cfg_opus="$_v" ;;
+          CFG_MODEL_SONNET) cfg_sonnet="$_v" ;;
+          CFG_MODEL_HAIKU)  cfg_haiku="$_v" ;;
+        esac
+      done <<< "$_cc_raw"
+    fi
   fi
 
   # Which env var / vault key holds the token (picks Bearer vs x-api-key style),
@@ -64,21 +75,60 @@ claude_provider_export_env() {
   [ -n "$auth_env" ] || auth_env="${cfg_auth_env:-$CLAUDE_SUBSCRIPTION_AUTH}"
   CLAUDE_PROVIDER_AUTH_ENV="$auth_env"
 
-  # Endpoint: honor a pre-set ANTHROPIC_BASE_URL, else env override, else config.
-  if [ -z "${ANTHROPIC_BASE_URL:-}" ]; then
-    if [ -n "${SUTANDO_PROVIDER_URL:-}" ]; then
-      export ANTHROPIC_BASE_URL="$SUTANDO_PROVIDER_URL"
-    elif [ -n "$cfg_provider" ]; then
-      export ANTHROPIC_BASE_URL="$cfg_provider"
-    fi
+  # $auth_env drives indirect expansion and `export` below, so it MUST be a plain
+  # env-var identifier — never anything the shell could interpret as code. It
+  # comes from config / SUTANDO_PROVIDER_AUTH_ENV (which may be synced), so reject
+  # anything that isn't [A-Za-z_][A-Za-z0-9_]* before we use it. (The
+  # ANTHROPIC_SUBSCRIPTION sentinel is itself a valid identifier and passes.)
+  case "$auth_env" in
+    ""|[0-9]*|*[!A-Za-z0-9_]*)
+      echo "provider-env: invalid auth_env '$auth_env' — must be an env-var name (e.g. ANTHROPIC_AUTH_TOKEN, or the ANTHROPIC_SUBSCRIPTION sentinel)." >&2
+      return 1 ;;
+  esac
+
+  # Endpoint (CLI > env > config): an explicit SUTANDO_PROVIDER_URL (the channel
+  # dashp.sh's flags inject through) WINS over an inherited ANTHROPIC_BASE_URL;
+  # otherwise a pre-set ANTHROPIC_BASE_URL stands; otherwise fall back to
+  # core_config.provider.
+  if [ -n "${SUTANDO_PROVIDER_URL:-}" ]; then
+    export ANTHROPIC_BASE_URL="$SUTANDO_PROVIDER_URL"
+  elif [ -z "${ANTHROPIC_BASE_URL:-}" ] && [ -n "$cfg_provider" ]; then
+    export ANTHROPIC_BASE_URL="$cfg_provider"
   fi
   CLAUDE_PROVIDER_ENDPOINT="${ANTHROPIC_BASE_URL:-}"
 
-  # Model: SUTANDO_PROVIDER_MODEL (or caller-injected CLI) > config. Only set
-  # ANTHROPIC_MODEL if not already pinned in the env.
-  local model="${SUTANDO_PROVIDER_MODEL:-$cfg_model}"
-  if [ -n "$model" ] && [ -z "${ANTHROPIC_MODEL:-}" ]; then
-    export ANTHROPIC_MODEL="$model"
+  # Don't leak the token over this endpoint. When a provider TOKEN will be sent
+  # (i.e. NOT the subscription sentinel), refuse credentials embedded in the URL
+  # (userinfo leaks via logs/proxies) and refuse a plaintext http:// URL to
+  # anywhere but loopback (the token would travel unencrypted). Loopback http is
+  # allowed — it's how the subscription credential-proxy is addressed.
+  if [ -n "$CLAUDE_PROVIDER_ENDPOINT" ] && [ "$auth_env" != "$CLAUDE_SUBSCRIPTION_AUTH" ]; then
+    local _authority="${CLAUDE_PROVIDER_ENDPOINT#*://}"; _authority="${_authority%%/*}"
+    case "$_authority" in
+      *@*)
+        echo "provider-env: refusing provider URL with embedded credentials (user@host) — store the token in auth_env/vault, not the URL." >&2
+        return 1 ;;
+    esac
+    case "$CLAUDE_PROVIDER_ENDPOINT" in
+      https://*) : ;;
+      http://localhost|http://localhost:*|http://localhost/*) : ;;
+      http://127.0.0.1|http://127.0.0.1:*|http://127.0.0.1/*) : ;;
+      'http://[::1]'|'http://[::1]:'*|'http://[::1]/'*) : ;;
+      *)
+        echo "provider-env: refusing non-https provider URL '$CLAUDE_PROVIDER_ENDPOINT' — the $auth_env token would be sent in plaintext. Use https:// (loopback http is allowed)." >&2
+        return 1 ;;
+    esac
+  fi
+
+  # Model (CLI > env > config): an explicit SUTANDO_PROVIDER_MODEL (the channel
+  # dashp.sh's --model injects through) WINS over an inherited ANTHROPIC_MODEL;
+  # otherwise fall back to core_config.model, but only when ANTHROPIC_MODEL isn't
+  # already pinned. (Previously an inherited ANTHROPIC_MODEL silently no-op'd
+  # --model, breaking the documented precedence.)
+  if [ -n "${SUTANDO_PROVIDER_MODEL:-}" ]; then
+    export ANTHROPIC_MODEL="$SUTANDO_PROVIDER_MODEL"
+  elif [ -n "$cfg_model" ] && [ -z "${ANTHROPIC_MODEL:-}" ]; then
+    export ANTHROPIC_MODEL="$cfg_model"
   fi
 
   # Per-class model overrides for subtasks/subagents (core_config.models.*). Each
@@ -105,8 +155,9 @@ claude_provider_export_env() {
   fi
 
   # Token: env value of $auth_env first, else the vault key of the same name.
-  local have=""
-  eval "have=\${$auth_env:-}"
+  # Bash indirect expansion (${!name}) — NOT eval — so a hostile auth_env cannot
+  # be executed. (auth_env is also identifier-validated near the top.)
+  local have="${!auth_env:-}"
   if [ -z "${have:-}" ]; then
     local vault="$REPO/skills/secret-vault/secret-vault.py"
     if [ -f "$vault" ] && command -v python3 > /dev/null 2>&1; then

--- a/src/agent/claude/provider-env.sh
+++ b/src/agent/claude/provider-env.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# src/agent/claude/provider-env.sh — SOURCEABLE helper. Resolves the alternate
+# Anthropic-compatible provider connection from the `core_config` block (+ env
+# overrides + vault) and EXPORTS the ANTHROPIC_* vars that Claude Code reads:
+#
+#   ANTHROPIC_BASE_URL   — provider endpoint (from core_config.provider)
+#   <auth_env>           — the API token (ANTHROPIC_AUTH_TOKEN → Bearer, or
+#                          ANTHROPIC_API_KEY → x-api-key), read from the env or,
+#                          failing that, the macOS-keychain vault. Never logged.
+#   ANTHROPIC_MODEL      — primary session model (core_config.model)
+#   ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL — per-class subtask/subagent model
+#                          IDs (core_config.models.{opus,sonnet,haiku})
+#
+# Single source of truth for "connect the claude agent to the provider", shared
+# by every launcher that runs against a provider:
+#   - src/agent/claude/cli/dashp.sh          (one-shot `claude -p`)
+#   - src/agent/claude/cli/start-cli.sh      (interactive core, when a provider is set)
+#   - src/agent/claude/sdk/session-server.sh (Agent-SDK session)
+#
+# CONTRACT: this file only DEFINES a function — no top-level side effects, no
+# `set`, no `exit`, no `exec` — so it is safe to `.`/`source` from a caller that
+# is mid-flight under `set -euo pipefail`. The caller must have $REPO set to the
+# repo root before sourcing.
+#
+# Per-setting precedence: env override > core_config > default. CLI flags are
+# injected by the caller as the matching SUTANDO_PROVIDER_* env var before
+# calling, so "CLI > env > config" holds end-to-end. Env overrides:
+#   SUTANDO_PROVIDER_URL       → endpoint      (core_config.provider)
+#   SUTANDO_PROVIDER_MODEL     → model         (core_config.model)
+#   SUTANDO_PROVIDER_AUTH_ENV  → token env/key (core_config.auth_env)
+
+# The sentinel `auth_env` value meaning "use the Claude.ai SUBSCRIPTION OAuth —
+# there is NO provider API token to inject." It is NOT a real env var to read.
+CLAUDE_SUBSCRIPTION_AUTH="ANTHROPIC_SUBSCRIPTION"
+
+# Resolve + export the provider env. Returns:
+#   0 — a token was found and exported (provider connection is ready)
+#   1 — a token env was named but NO token found (caller decides fatal vs skip)
+#   2 — auth_env is the ANTHROPIC_SUBSCRIPTION sentinel: subscription OAuth, no
+#       token injected (endpoint/model still exported if a provider is configured)
+# On return:
+#   $CLAUDE_PROVIDER_AUTH_ENV  — the resolved auth_env (messaging)
+#   $CLAUDE_PROVIDER_ENDPOINT  — the resolved endpoint ("" if none configured;
+#                                callers use this to tell provider vs subscription)
+claude_provider_export_env() {
+  local cfg_provider="" cfg_model="" cfg_auth_env="" cfg_opus="" cfg_sonnet="" cfg_haiku=""
+  if [ -x "$REPO/scripts/sutando-config.sh" ]; then
+    local _k _v
+    while IFS='=' read -r _k _v; do
+      case "$_k" in
+        CFG_PROVIDER)     cfg_provider="$_v" ;;
+        CFG_MODEL)        cfg_model="$_v" ;;
+        CFG_AUTH_ENV)     cfg_auth_env="$_v" ;;
+        CFG_MODEL_OPUS)   cfg_opus="$_v" ;;
+        CFG_MODEL_SONNET) cfg_sonnet="$_v" ;;
+        CFG_MODEL_HAIKU)  cfg_haiku="$_v" ;;
+      esac
+    done < <(bash "$REPO/scripts/sutando-config.sh" core-config 2>/dev/null) || true
+  fi
+
+  # Which env var / vault key holds the token (picks Bearer vs x-api-key style),
+  # or the ANTHROPIC_SUBSCRIPTION sentinel (default — subscription, no token).
+  local auth_env="${SUTANDO_PROVIDER_AUTH_ENV:-}"
+  [ -n "$auth_env" ] || auth_env="${cfg_auth_env:-$CLAUDE_SUBSCRIPTION_AUTH}"
+  CLAUDE_PROVIDER_AUTH_ENV="$auth_env"
+
+  # Endpoint: honor a pre-set ANTHROPIC_BASE_URL, else env override, else config.
+  if [ -z "${ANTHROPIC_BASE_URL:-}" ]; then
+    if [ -n "${SUTANDO_PROVIDER_URL:-}" ]; then
+      export ANTHROPIC_BASE_URL="$SUTANDO_PROVIDER_URL"
+    elif [ -n "$cfg_provider" ]; then
+      export ANTHROPIC_BASE_URL="$cfg_provider"
+    fi
+  fi
+  CLAUDE_PROVIDER_ENDPOINT="${ANTHROPIC_BASE_URL:-}"
+
+  # Model: SUTANDO_PROVIDER_MODEL (or caller-injected CLI) > config. Only set
+  # ANTHROPIC_MODEL if not already pinned in the env.
+  local model="${SUTANDO_PROVIDER_MODEL:-$cfg_model}"
+  if [ -n "$model" ] && [ -z "${ANTHROPIC_MODEL:-}" ]; then
+    export ANTHROPIC_MODEL="$model"
+  fi
+
+  # Per-class model overrides for subtasks/subagents (core_config.models.*). Each
+  # maps to a Claude Code alias env var; sonnet is what subagents default to,
+  # haiku is used for quick/background work. Only set when configured AND not
+  # already pinned in the env (so an explicit ANTHROPIC_DEFAULT_*_MODEL wins).
+  [ -n "$cfg_opus" ]   && [ -z "${ANTHROPIC_DEFAULT_OPUS_MODEL:-}" ]   && export ANTHROPIC_DEFAULT_OPUS_MODEL="$cfg_opus"
+  [ -n "$cfg_sonnet" ] && [ -z "${ANTHROPIC_DEFAULT_SONNET_MODEL:-}" ] && export ANTHROPIC_DEFAULT_SONNET_MODEL="$cfg_sonnet"
+  [ -n "$cfg_haiku" ]  && [ -z "${ANTHROPIC_DEFAULT_HAIKU_MODEL:-}" ]  && export ANTHROPIC_DEFAULT_HAIKU_MODEL="$cfg_haiku"
+
+  # Subscription sentinel → no token to resolve/inject; Claude Code uses its
+  # OAuth (.credentials.json). The env token would otherwise OVERRIDE that.
+  if [ "$auth_env" = "$CLAUDE_SUBSCRIPTION_AUTH" ]; then
+    return 2
+  fi
+
+  # Clear the OTHER Anthropic auth var so Claude Code doesn't send two credential
+  # headers at once. A provider like z.ai wants ONLY its Bearer token — a stale
+  # ANTHROPIC_API_KEY lingering in the shell would conflict and get rejected.
+  if [ "$auth_env" = "ANTHROPIC_AUTH_TOKEN" ]; then
+    unset ANTHROPIC_API_KEY 2>/dev/null || true
+  elif [ "$auth_env" = "ANTHROPIC_API_KEY" ]; then
+    unset ANTHROPIC_AUTH_TOKEN 2>/dev/null || true
+  fi
+
+  # Token: env value of $auth_env first, else the vault key of the same name.
+  local have=""
+  eval "have=\${$auth_env:-}"
+  if [ -z "${have:-}" ]; then
+    local vault="$REPO/skills/secret-vault/secret-vault.py"
+    if [ -f "$vault" ] && command -v python3 > /dev/null 2>&1; then
+      local tok=""
+      if tok="$(python3 "$vault" get "$auth_env" 2>/dev/null)" && [ -n "$tok" ]; then
+        export "$auth_env=$tok"
+        have="$tok"
+      fi
+    fi
+  fi
+
+  [ -n "${have:-}" ] || return 1
+  return 0
+}

--- a/src/agent/claude/sdk/session-server.sh
+++ b/src/agent/claude/sdk/session-server.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# src/agent/claude/sdk/session-server.sh — launch the SDK session server against the
+# provider (core_config), reusing the shared provider-env.sh helper.
+#
+# Boots src/agent/claude/sdk/session-server.ts with ANTHROPIC_BASE_URL / <token> /
+# ANTHROPIC_MODEL exported, so the persistent SDK session runs on the configured
+# provider. Open http://localhost:${SUTANDO_SESSION_PORT:-4100} for the UI.
+#
+# Usage:
+#   bash src/agent/claude/sdk/session-server.sh
+#   SUTANDO_SESSION_FAKE=1 bash src/agent/claude/sdk/session-server.sh   # offline UI dev
+#
+# Requires a token (env or vault) for the provider. Set
+# SUTANDO_SESSION_ALLOW_SUBSCRIPTION=1 to fall back to the subscription auth
+# instead (e.g. local dev without a provider configured).
+
+set -euo pipefail
+
+# This script lives at src/agent/claude/sdk/ — four levels under the repo root.
+REPO="$(cd "$(dirname "$0")/../../../.." && pwd)"
+cd "$REPO"
+
+# Workspace-scoped CLAUDE_CONFIG_DIR (same resolution as start-cli.sh / dashp.sh).
+if [ -x "$REPO/scripts/sutando-config.sh" ]; then
+  if _ccd="$(bash "$REPO/scripts/sutando-config.sh" claude-sutando-config-dir 2>/dev/null)"; then
+    mkdir -p "$_ccd"
+    export CLAUDE_CONFIG_DIR="$_ccd"
+  fi
+fi
+
+# FAKE mode needs no provider/token — it never spawns claude.
+if [ "${SUTANDO_SESSION_FAKE:-0}" = "1" ]; then
+  echo "session-server: FAKE echo mode (no provider needed)" >&2
+  exec npx tsx "$REPO/src/agent/claude/sdk/session-server.ts" "$@"
+fi
+
+# Shed any inherited ANTHROPIC_BASE_URL before resolving auth. When launched from
+# src/startup.sh this is pre-set to the credential proxy (http://localhost:7846),
+# which injects the SUBSCRIPTION OAuth token — routing an API-key/provider request
+# through it fails ("API Error: Connection error", the exact hang we hit). We
+# restore it ONLY for the subscription path (rc=2), where the proxy is the point.
+_inherited_base_url="${ANTHROPIC_BASE_URL:-}"
+unset ANTHROPIC_BASE_URL
+
+# Provider connection (endpoint + token + model) via the shared helper.
+# shellcheck source=src/agent/claude/provider-env.sh
+. "$REPO/src/agent/claude/provider-env.sh"
+_prc=0; claude_provider_export_env || _prc=$?
+if [ "$_prc" = "0" ]; then
+  echo "session-server: provider → ${ANTHROPIC_BASE_URL:-(stock Anthropic endpoint)}${ANTHROPIC_MODEL:+ · model=$ANTHROPIC_MODEL} (auth via ${CLAUDE_PROVIDER_AUTH_ENV})" >&2
+elif [ "$_prc" = "2" ]; then
+  # ANTHROPIC_SUBSCRIPTION sentinel — run on the subscription. Route back through
+  # the credential proxy if startup.sh set one (OAuth injection + quota tracking);
+  # otherwise the SDK uses the OAuth creds in CLAUDE_CONFIG_DIR directly.
+  [ -n "$_inherited_base_url" ] && export ANTHROPIC_BASE_URL="$_inherited_base_url"
+  echo "session-server: subscription auth — running the SDK session on the Claude.ai subscription${ANTHROPIC_BASE_URL:+ via $ANTHROPIC_BASE_URL}." >&2
+elif [ "${SUTANDO_SESSION_ALLOW_SUBSCRIPTION:-0}" = "1" ]; then
+  [ -n "$_inherited_base_url" ] && export ANTHROPIC_BASE_URL="$_inherited_base_url"
+  echo "session-server: no provider token — falling back to subscription auth (SUTANDO_SESSION_ALLOW_SUBSCRIPTION=1)" >&2
+else
+  echo "session-server: no API token via ${CLAUDE_PROVIDER_AUTH_ENV:-ANTHROPIC_AUTH_TOKEN} (env or vault) — refusing to start." >&2
+  echo "  Set core_config.provider + the token ('vault set ${CLAUDE_PROVIDER_AUTH_ENV:-ANTHROPIC_AUTH_TOKEN} <token>' or export it)," >&2
+  echo "  or set SUTANDO_SESSION_ALLOW_SUBSCRIPTION=1 to use the subscription. See src/agent/claude/README.md." >&2
+  exit 1
+fi
+
+exec npx tsx "$REPO/src/agent/claude/sdk/session-server.ts" "$@"

--- a/src/agent/claude/sdk/session-server.ts
+++ b/src/agent/claude/sdk/session-server.ts
@@ -1,0 +1,538 @@
+/**
+ * src/agent/claude/sdk/session-server.ts — a PERSISTENT, observable Sutando
+ * core over the Agent SDK (`@anthropic-ai/claude-agent-sdk`), with a browser UI.
+ *
+ * This is the `claude_sdk` core: one long-lived `query()` session (async-iterable
+ * prompt = multi-turn, context preserved) that runs the FULL Sutando runtime.
+ *
+ * RUNTIME SPLIT (hybrid):
+ *  - AGENT-driven (via the `/startup` bootstrap turn): registers crons
+ *    (CronCreate), runs proactive-loop passes, and everything else the
+ *    interactive core does — because we load CLAUDE.md + skills (settingSources)
+ *    and use Claude Code's system prompt (systemPrompt preset).
+ *  - HOST-driven (this Node process): watches <workspace>/tasks/ and injects each
+ *    task as a turn, and emits the per-host liveness heartbeat + core-status. We
+ *    set SUTANDO_HOST_OWNS_WATCHER=1 so the agent's own Monitor task-watcher
+ *    (src/watch-tasks-stream.sh) no-ops — otherwise every task double-processes.
+ *    On pickup a task is atomically moved to an in-flight staging dir BEFORE
+ *    injection, so the proactive loop's own tasks/ scan never races it.
+ *
+ * Endpoints (localhost only): GET / (UI) · GET /events (SSE, every SDK message) ·
+ * POST /input {text} (a user turn) · GET /health.
+ *
+ * Env: SUTANDO_SESSION_PORT (4100) · SUTANDO_SESSION_BIND (127.0.0.1) ·
+ * SUTANDO_SESSION_FAKE=1 (offline echo mode; host runtime still runs) ·
+ * SUTANDO_SESSION_BOOTSTRAP (default "/startup") · SUTANDO_SESSION_NO_BOOTSTRAP=1.
+ * Provider/auth come from the env (session-server.sh sources provider-env.sh).
+ */
+
+import { createServer, type ServerResponse, type IncomingMessage } from 'node:http';
+import { readFileSync, writeFileSync, renameSync, mkdirSync, readdirSync, existsSync, unlinkSync, watch } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { execSync } from 'node:child_process';
+import os from 'node:os';
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = process.cwd(); // session-server.sh cd's to the repo before exec
+const PORT = Number(process.env.SUTANDO_SESSION_PORT) || 4100;
+const HOST = process.env.SUTANDO_SESSION_BIND || '127.0.0.1';
+const FAKE = process.env.SUTANDO_SESSION_FAKE === '1';
+const NO_BOOTSTRAP = process.env.SUTANDO_SESSION_NO_BOOTSTRAP === '1';
+// The host owns task-watching, the heartbeat, and cron/proactive SCHEDULING.
+// CronCreate/CronList are NOT available in an SDK session (verified live), so the
+// bootstrap must NOT ask the agent to run /schedule-crons or manage the watcher —
+// it would fail and improvise (e.g. shelling out to `claude`, spawning nested
+// sessions). Instead we orient it: process what the host injects, nothing more.
+// Override with SUTANDO_SESSION_BOOTSTRAP (e.g. '/startup') or disable entirely
+// with SUTANDO_SESSION_NO_BOOTSTRAP=1.
+const DEFAULT_BOOTSTRAP =
+	'You are running as the Sutando SDK core (core_type claude_sdk); your CLAUDE.md instructions apply. ' +
+	'This HOST process owns task-watching, the liveness heartbeat, and cron/proactive SCHEDULING — it injects ' +
+	'each task and each scheduled prompt (e.g. /proactive-loop) directly into this session. Do NOT run ' +
+	'/schedule-crons, do NOT try to register crons (the CronCreate tool is unavailable here), and do NOT start ' +
+	'the task watcher — the host handles all of that. Just process each injected task/prompt per your ' +
+	'instructions and write replies to the results/ dir. Acknowledge readiness in one short line.';
+const BOOTSTRAP = process.env.SUTANDO_SESSION_BOOTSTRAP || DEFAULT_BOOTSTRAP;
+
+// ── workspace + canonical dirs ───────────────────────────────────────────────
+function resolveWorkspace(): string {
+	try {
+		return execSync('bash scripts/sutando-config.sh workspace', { cwd: REPO, encoding: 'utf8' }).trim();
+	} catch {
+		return join(REPO, 'workspace');
+	}
+}
+const WORKSPACE = resolveWorkspace();
+const TASKS_DIR = join(WORKSPACE, 'tasks');
+const RESULTS_DIR = join(WORKSPACE, 'results');
+const STATE_DIR = join(WORKSPACE, 'state');
+const CORES_DIR = join(STATE_DIR, 'cores');
+const INFLIGHT_DIR = join(TASKS_DIR, '.sdk-inflight'); // staged tasks the host has picked up
+for (const d of [TASKS_DIR, RESULTS_DIR, STATE_DIR, CORES_DIR, INFLIGHT_DIR]) mkdirSync(d, { recursive: true });
+
+// Make the agent's Monitor watcher a no-op — the host owns task watching.
+process.env.SUTANDO_HOST_OWNS_WATCHER = '1';
+
+const HOST_LABEL = process.env.SUTANDO_HOST_LABEL || os.hostname().split('.')[0];
+
+function atomicWrite(path: string, data: string): void {
+	const tmp = `${path}.tmp`;
+	writeFileSync(tmp, data);
+	renameSync(tmp, path);
+}
+
+// ── SSE fan-out (+ replay history) ───────────────────────────────────────────
+// There is only ONE live session, so every viewer sees the same event log. We
+// keep an in-memory history and replay it to each new SSE client, so a browser
+// refresh shows the full session (input, output, tool calls) — not a blank page.
+const clients = new Set<ServerResponse>();
+const history: string[] = [];
+const HISTORY_CAP = 20_000;
+let lastSessionId = '';
+function broadcast(evt: unknown): void {
+	const payload = JSON.stringify(evt);
+	history.push(payload);
+	if (history.length > HISTORY_CAP) history.shift();
+	const line = `data: ${payload}\n\n`;
+	for (const res of clients) {
+		try {
+			res.write(line);
+		} catch {
+			/* evicted on close */
+		}
+	}
+}
+
+// ── core-status (host-written, reflects session busy/idle) ───────────────────
+function writeStatus(status: 'running' | 'idle', step?: string): void {
+	try {
+		const payload: Record<string, unknown> = { status, ts: Math.floor(Date.now() / 1000) };
+		if (step) payload.step = step;
+		atomicWrite(join(STATE_DIR, 'core-status.json'), JSON.stringify(payload));
+	} catch {
+		/* non-fatal */
+	}
+}
+
+// ── per-host liveness heartbeat (schema-v1, matches src/core_heartbeat.py) ───
+const STARTED_AT = Date.now() / 1000;
+const ALIVE_FILE = join(CORES_DIR, `${HOST_LABEL}.alive`);
+let hbTimer: ReturnType<typeof setInterval> | undefined;
+function writeBeat(status = 'running'): void {
+	try {
+		atomicWrite(
+			ALIVE_FILE,
+			JSON.stringify({
+				host: HOST_LABEL,
+				pid: process.pid,
+				started_at: STARTED_AT,
+				last_beat_at: Date.now() / 1000,
+				status,
+				schema_version: 1,
+			}),
+		);
+	} catch {
+		/* non-fatal */
+	}
+}
+// When launched via src/startup.sh, core_heartbeat.py already emits this host's
+// beat — set SUTANDO_SESSION_NO_HEARTBEAT=1 so we don't fight it for the .alive
+// file. Standalone runs keep their own heartbeat.
+const OWN_HEARTBEAT = process.env.SUTANDO_SESSION_NO_HEARTBEAT !== '1';
+function startHeartbeat(): void {
+	if (!OWN_HEARTBEAT) return;
+	writeBeat();
+	hbTimer = setInterval(() => writeBeat(), 30_000);
+}
+function shutdown(): void {
+	if (hbTimer) clearInterval(hbTimer);
+	if (OWN_HEARTBEAT) {
+		try {
+			unlinkSync(ALIVE_FILE); // signal graceful shutdown to peers immediately
+		} catch {
+			/* already gone */
+		}
+	}
+	writeStatus('idle');
+	process.exit(0);
+}
+
+// ── streaming input: the async-iterable the SDK consumes as turns arrive ─────
+type UserMsg = {
+	type: 'user';
+	message: { role: 'user'; content: string };
+	parent_tool_use_id: null;
+	session_id: string;
+};
+class InputStream {
+	private buf: UserMsg[] = [];
+	private waiters: Array<(r: IteratorResult<UserMsg>) => void> = [];
+	private closed = false;
+	push(text: string): void {
+		const msg: UserMsg = { type: 'user', message: { role: 'user', content: text }, parent_tool_use_id: null, session_id: lastSessionId };
+		const w = this.waiters.shift();
+		if (w) w({ value: msg, done: false });
+		else this.buf.push(msg);
+	}
+	close(): void {
+		this.closed = true;
+		const w = this.waiters.shift();
+		if (w) w({ value: undefined as unknown as UserMsg, done: true });
+	}
+	[Symbol.asyncIterator](): AsyncIterator<UserMsg> {
+		return {
+			next: (): Promise<IteratorResult<UserMsg>> => {
+				if (this.buf.length) return Promise.resolve({ value: this.buf.shift()!, done: false });
+				if (this.closed) return Promise.resolve({ value: undefined as unknown as UserMsg, done: true });
+				return new Promise((resolve) => this.waiters.push(resolve));
+			},
+		};
+	}
+}
+const input = new InputStream();
+
+// ── host task watcher (stage-on-pickup → inject → archive-on-result) ─────────
+const inflight = new Map<string, string>(); // task id → staged path (awaiting result)
+
+function taskIdFromName(name: string): string | null {
+	const m = name.match(/^(task-[^./]+)\.txt$/);
+	return m ? m[1] : null;
+}
+
+function injectTask(id: string, stagedPath: string): void {
+	inflight.set(id, stagedPath);
+	writeStatus('running', `task ${id}`);
+	input.push(
+		`A new Sutando task has arrived. Read the task file at ${stagedPath} and process it EXACTLY per your task-handling instructions in CLAUDE.md — notify first if warranted, honor its access_tier, and write the reply to ${join(RESULTS_DIR, `${id}.txt`)} using the result protocol (markers like [no-send]/[channel:]/[file:] as needed). Task id: ${id}.`,
+	);
+	broadcast({ type: 'server', subtype: 'task_injected', id, path: stagedPath });
+}
+
+function pickupTask(name: string): void {
+	const id = taskIdFromName(name);
+	if (!id || inflight.has(id)) return;
+	const src = join(TASKS_DIR, name);
+	const dst = join(INFLIGHT_DIR, name);
+	try {
+		renameSync(src, dst); // move OUT of tasks/ before injecting (no race with the proactive scan)
+	} catch {
+		return; // already picked up / gone
+	}
+	injectTask(id, dst);
+}
+
+function sweepTasks(): void {
+	// Recover any staged tasks from a prior crash (mid-process) → re-inject.
+	try {
+		for (const f of readdirSync(INFLIGHT_DIR)) {
+			const id = taskIdFromName(f);
+			if (id && !inflight.has(id)) injectTask(id, join(INFLIGHT_DIR, f));
+		}
+	} catch {
+		/* dir may be empty */
+	}
+	// Pick up any tasks already sitting in tasks/ at boot.
+	try {
+		for (const f of readdirSync(TASKS_DIR)) if (f.endsWith('.txt')) pickupTask(f);
+	} catch {
+		/* empty */
+	}
+}
+
+function archiveInflight(id: string): void {
+	const staged = inflight.get(id);
+	inflight.delete(id);
+	if (!staged) return;
+	try {
+		const d = new Date();
+		const ym = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+		const archDir = join(TASKS_DIR, 'archive', ym);
+		mkdirSync(archDir, { recursive: true });
+		renameSync(staged, join(archDir, `${id}.txt`));
+	} catch {
+		/* best effort */
+	}
+}
+
+// A result file is `task-{id}.txt` or `<channel-key>.task-{id}.txt`.
+function onResultFile(name: string): void {
+	for (const id of inflight.keys()) {
+		if (name === `${id}.txt` || name.endsWith(`.${id}.txt`)) {
+			archiveInflight(id);
+			writeStatus('idle');
+			broadcast({ type: 'server', subtype: 'task_done', id });
+			return;
+		}
+	}
+}
+
+function startTaskWatcher(): void {
+	sweepTasks();
+	try {
+		watch(TASKS_DIR, (_ev, name) => {
+			if (!name || !String(name).endsWith('.txt')) return;
+			// small debounce so the writer finishes; existence check ignores our own move-outs
+			setTimeout(() => {
+				if (existsSync(join(TASKS_DIR, String(name)))) pickupTask(String(name));
+			}, 200);
+		});
+	} catch (e) {
+		broadcast({ type: 'server', subtype: 'error', error: `tasks watch failed: ${String(e)}` });
+	}
+	try {
+		watch(RESULTS_DIR, (_ev, name) => {
+			if (name && String(name).endsWith('.txt')) onResultFile(String(name));
+		});
+	} catch {
+		/* results archiving is best-effort */
+	}
+}
+
+// ── host-driven cron scheduler (CronCreate is NOT available in SDK sessions) ─
+// Reads the same hosts/<host>/crons.json the interactive core registers, matches
+// each 5-field schedule against the clock, and injects the cron's prompt as a
+// turn (prompt_skill → "/skill"; prompt → the literal text, which self-gates via
+// scripts/cron-gate.sh for sub-daily entries). This is what makes /proactive-loop
+// fire on `*/5`.
+type Cron = { name: string; cron: string; prompt?: string; prompt_skill?: string };
+
+function cronsPath(): string {
+	const perHost = join(WORKSPACE, 'hosts', HOST_LABEL, 'crons.json');
+	if (existsSync(perHost)) return perHost;
+	const legacy = join(REPO, 'skills', 'schedule-crons', 'crons.json');
+	if (existsSync(legacy)) return legacy;
+	return join(REPO, 'skills', 'schedule-crons', 'crons.example.json');
+}
+function readCrons(): Cron[] {
+	try {
+		const raw = JSON.parse(readFileSync(cronsPath(), 'utf8'));
+		return Array.isArray(raw) ? (raw.filter((c) => c && c.name && c.cron) as Cron[]) : [];
+	} catch {
+		return [];
+	}
+}
+// Match one cron field (supports "*", "*/n", "n", "a-b", "a-b/n", and comma lists).
+function fieldMatch(field: string, val: number): boolean {
+	return field.split(',').some((part) => {
+		let range = part;
+		let step = 1;
+		const slash = part.split('/');
+		if (slash.length === 2) {
+			range = slash[0];
+			step = parseInt(slash[1], 10) || 1;
+		}
+		let lo: number;
+		let hi: number;
+		if (range === '*') {
+			return step === 1 ? true : val % step === 0;
+		}
+		const dash = range.split('-');
+		lo = parseInt(dash[0], 10);
+		hi = dash.length === 2 ? parseInt(dash[1], 10) : lo;
+		if (Number.isNaN(lo) || val < lo || val > hi) return false;
+		return (val - lo) % step === 0;
+	});
+}
+function cronMatches(expr: string, d: Date): boolean {
+	const f = expr.trim().split(/\s+/);
+	if (f.length !== 5) return false;
+	const dow = d.getDay(); // 0=Sun..6=Sat; cron also allows 7=Sun
+	return (
+		fieldMatch(f[0], d.getMinutes()) &&
+		fieldMatch(f[1], d.getHours()) &&
+		fieldMatch(f[2], d.getDate()) &&
+		fieldMatch(f[3], d.getMonth() + 1) &&
+		(fieldMatch(f[4], dow) || (dow === 0 && fieldMatch(f[4], 7)))
+	);
+}
+const cronLastFired = new Map<string, number>(); // name → minute-epoch (double-fire guard)
+function cronTick(): void {
+	const now = new Date();
+	const minuteKey = Math.floor(now.getTime() / 60_000);
+	for (const c of readCrons()) {
+		if (!cronMatches(c.cron, now)) continue;
+		if (cronLastFired.get(c.name) === minuteKey) continue;
+		cronLastFired.set(c.name, minuteKey);
+		const prompt = c.prompt_skill ? `/${c.prompt_skill}` : c.prompt || '';
+		if (!prompt) continue;
+		writeStatus('running', `cron ${c.name}`);
+		input.push(prompt);
+		broadcast({ type: 'server', subtype: 'cron_fired', name: c.name, prompt: c.prompt_skill ? `/${c.prompt_skill}` : prompt.slice(0, 60) });
+	}
+}
+function startCrons(): void {
+	// Seed the boot minute as already-fired for every cron, so a restart doesn't
+	// immediately fire crons matching the current minute (mimics the interactive
+	// core: crons fire at their scheduled time, not on registration). Firing
+	// begins at the next matching minute.
+	const crons = readCrons();
+	const bootMinute = Math.floor(Date.now() / 60_000);
+	for (const c of crons) cronLastFired.set(c.name, bootMinute);
+	// Announce the loaded schedule up front (there is no CronCreate registration —
+	// the host fires each cron's prompt at its time). This is the "crons are set
+	// up" confirmation; each firing later shows as a `cron_fired` event.
+	broadcast({
+		type: 'server',
+		subtype: 'cron_schedule',
+		source: cronsPath(),
+		crons: crons.map((c) => ({
+			name: c.name,
+			cron: c.cron,
+			target: c.prompt_skill ? `/${c.prompt_skill}` : (c.prompt || '').slice(0, 70),
+		})),
+	});
+	console.error(`session-server: ${crons.length} host-driven crons scheduled from ${cronsPath()}`);
+	setInterval(cronTick, 30_000); // 30s tick; minute-dedup prevents double-fire
+}
+
+// ── the real SDK session (full Sutando runtime) ──────────────────────────────
+async function runRealSession(): Promise<void> {
+	broadcast({
+		type: 'server',
+		subtype: 'starting',
+		provider: process.env.ANTHROPIC_BASE_URL || '(subscription / stock endpoint)',
+		model: process.env.ANTHROPIC_MODEL || '(default)',
+		workspace: WORKSPACE,
+	});
+	const q = query({
+		prompt: input as unknown as AsyncIterable<never>,
+		options: {
+			// Exit SDK isolation mode: load CLAUDE.md + skills + settings so the
+			// runtime (slash commands, /startup, proactive-loop, crons) exists.
+			settingSources: ['user', 'project', 'local'],
+			systemPrompt: { type: 'preset', preset: 'claude_code' },
+			permissionMode: 'bypassPermissions',
+			allowDangerouslySkipPermissions: true,
+			additionalDirectories: [os.homedir()],
+			// Surface the spawned claude's stderr into the event stream so auth /
+			// connection failures are visible in the UI instead of a silent hang.
+			stderr: (d: string) => {
+				const t = String(d).trim();
+				if (t) broadcast({ type: 'server', subtype: 'stderr', text: t.slice(0, 2000) });
+			},
+		} as Record<string, unknown>,
+	});
+	try {
+		for await (const msg of q as AsyncIterable<Record<string, unknown>>) {
+			if (msg?.type === 'system' && typeof msg?.session_id === 'string') lastSessionId = msg.session_id as string;
+			if (msg?.type === 'result') writeStatus('idle');
+			broadcast(msg);
+		}
+		broadcast({ type: 'server', subtype: 'session_ended' });
+	} catch (err) {
+		broadcast({ type: 'server', subtype: 'error', error: String((err as Error)?.message ?? err) });
+	}
+}
+
+// ── deterministic FAKE session (UI/runtime-host dev + tests; no claude spawn) ─
+async function runFakeSession(): Promise<void> {
+	lastSessionId = 'fake-session';
+	broadcast({ type: 'system', subtype: 'init', session_id: lastSessionId, model: 'fake-model', tools: [] });
+	for await (const m of input) {
+		writeStatus('running', 'fake turn');
+		broadcast({
+			type: 'assistant',
+			message: { role: 'assistant', content: [{ type: 'text', text: `echo: ${m.message.content.slice(0, 120)}` }] },
+			session_id: lastSessionId,
+		});
+		broadcast({ type: 'result', subtype: 'success', result: 'echo', usage: { input_tokens: 1, output_tokens: 1 }, total_cost_usd: 0, session_id: lastSessionId });
+		writeStatus('idle');
+	}
+}
+
+// ── HTTP ─────────────────────────────────────────────────────────────────────
+function readBody(req: IncomingMessage, done: (s: string) => void): void {
+	let body = '';
+	req.on('data', (c) => {
+		body += c;
+		if (body.length > 1_000_000) req.destroy();
+	});
+	req.on('end', () => done(body));
+}
+
+const server = createServer((req, res) => {
+	const url = req.url ?? '/';
+	if (req.method === 'GET' && (url === '/' || url === '/index.html')) {
+		try {
+			res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' }).end(readFileSync(join(HERE, 'ui.html')));
+		} catch {
+			res.writeHead(500).end('ui.html not found');
+		}
+		return;
+	}
+	if (req.method === 'GET' && url === '/events') {
+		res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', connection: 'keep-alive' });
+		// Replay the session log so a refresh shows the full history (single session).
+		for (const p of history) {
+			try {
+				res.write(`data: ${p}\n\n`);
+			} catch {
+				/* client gone mid-replay */
+			}
+		}
+		res.write(`data: ${JSON.stringify({ type: 'server', subtype: 'connected', session_id: lastSessionId, workspace: WORKSPACE, replayed: history.length })}\n\n`);
+		clients.add(res);
+		const hb = setInterval(() => {
+			try {
+				res.write(': hb\n\n');
+			} catch {
+				/* evicted */
+			}
+		}, 15000);
+		req.on('close', () => {
+			clearInterval(hb);
+			clients.delete(res);
+		});
+		return;
+	}
+	if (req.method === 'POST' && url === '/input') {
+		readBody(req, (body) => {
+			try {
+				const { text } = JSON.parse(body || '{}') as { text?: unknown };
+				if (typeof text === 'string' && text.trim()) {
+					writeStatus('running', 'user turn');
+					input.push(text);
+					broadcast({ type: 'server', subtype: 'user_turn', text });
+				}
+				res.writeHead(204).end();
+			} catch {
+				res.writeHead(400).end('bad json');
+			}
+		});
+		return;
+	}
+	if (req.method === 'GET' && url === '/health') {
+		res.writeHead(200, { 'content-type': 'application/json' }).end(
+			JSON.stringify({ ok: true, clients: clients.size, session_id: lastSessionId, fake: FAKE, workspace: WORKSPACE, inflight: inflight.size }),
+		);
+		return;
+	}
+	res.writeHead(404).end();
+});
+
+// ── boot ─────────────────────────────────────────────────────────────────────
+process.once('SIGTERM', shutdown);
+process.once('SIGINT', shutdown);
+
+server.listen(PORT, HOST, () => {
+	console.error(`session-server: http://${HOST}:${PORT}  (${FAKE ? 'FAKE echo mode' : 'SDK mode'})  workspace=${WORKSPACE}`);
+	if (HOST !== '127.0.0.1' && HOST !== 'localhost') {
+		console.error('session-server: WARNING — non-loopback bind with NO auth; it relays full prompts + tool I/O.');
+	}
+});
+
+startHeartbeat();
+writeStatus('running', 'booting');
+if (!NO_BOOTSTRAP) {
+	// Orient the agent FIRST (host owns tasks/crons/watcher; don't self-manage them).
+	broadcast({ type: 'server', subtype: 'bootstrap', command: BOOTSTRAP.slice(0, 80) });
+	input.push(BOOTSTRAP);
+}
+startTaskWatcher(); // host task ingestion (fs.watch → inject)
+startCrons(); // host cron/proactive scheduling (reads crons.json → inject prompts)
+
+void (FAKE ? runFakeSession() : runRealSession()).catch((e) => {
+	broadcast({ type: 'server', subtype: 'error', error: String(e?.message ?? e) });
+});

--- a/src/agent/claude/sdk/ui.html
+++ b/src/agent/claude/sdk/ui.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Claude Code — live session</title>
+<style>
+  :root { --bg:#0d1117; --panel:#161b22; --line:#30363d; --fg:#e6edf3; --dim:#8b949e;
+          --user:#1f6feb; --asst:#3fb950; --tool:#d29922; --result:#a371f7; --err:#f85149; }
+  * { box-sizing:border-box; }
+  body { margin:0; height:100vh; display:flex; flex-direction:column; background:var(--bg);
+         color:var(--fg); font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; }
+  header { padding:8px 14px; border-bottom:1px solid var(--line); display:flex; gap:12px;
+           align-items:center; background:var(--panel); }
+  header .dot { width:9px; height:9px; border-radius:50%; background:var(--err); }
+  header .dot.on { background:var(--asst); }
+  header .meta { color:var(--dim); font-size:12px; }
+  #log { flex:1; overflow:auto; padding:10px 14px; }
+  .row { padding:6px 10px; margin:6px 0; border-left:3px solid var(--line);
+         background:var(--panel); border-radius:0 6px 6px 0; white-space:pre-wrap; word-break:break-word; }
+  .row .kind { font-size:11px; text-transform:uppercase; letter-spacing:.5px; color:var(--dim); margin-bottom:2px; }
+  .row.user    { border-left-color:var(--user); }
+  .row.assistant { border-left-color:var(--asst); }
+  .row.tool    { border-left-color:var(--tool); }
+  .row.result  { border-left-color:var(--result); color:var(--dim); }
+  .row.server  { border-left-color:var(--dim); color:var(--dim); font-size:12px; }
+  .row.error   { border-left-color:var(--err); color:var(--err); }
+  details { margin-top:4px; } summary { cursor:pointer; color:var(--dim); font-size:12px; }
+  pre { margin:4px 0 0; font-size:12px; color:var(--dim); overflow:auto; }
+  form { display:flex; gap:8px; padding:10px 14px; border-top:1px solid var(--line); background:var(--panel); }
+  #box { flex:1; background:var(--bg); color:var(--fg); border:1px solid var(--line);
+         border-radius:6px; padding:8px 10px; font:inherit; resize:none; }
+  button { background:var(--user); color:#fff; border:0; border-radius:6px; padding:0 16px;
+           font:inherit; cursor:pointer; } button:disabled { opacity:.5; cursor:default; }
+</style>
+</head>
+<body>
+  <header>
+    <span class="dot" id="dot"></span>
+    <strong>Claude Code — live session</strong>
+    <span class="meta" id="meta">connecting…</span>
+  </header>
+  <div id="log"></div>
+  <form id="form">
+    <textarea id="box" rows="2" placeholder="Type a turn, Enter to send (Shift+Enter = newline)…"></textarea>
+    <button id="send" type="submit">Send</button>
+  </form>
+
+<script>
+const log = document.getElementById('log');
+const dot = document.getElementById('dot');
+const meta = document.getElementById('meta');
+const box = document.getElementById('box');
+const form = document.getElementById('form');
+
+function el(cls, kind, body, raw) {
+  const row = document.createElement('div');
+  row.className = 'row ' + cls;
+  row.innerHTML = '<div class="kind"></div>';
+  row.querySelector('.kind').textContent = kind;
+  const b = document.createElement('div');
+  b.textContent = body;
+  row.appendChild(b);
+  if (raw !== undefined) {
+    const d = document.createElement('details');
+    d.innerHTML = '<summary>raw</summary>';
+    const pre = document.createElement('pre');
+    pre.textContent = typeof raw === 'string' ? raw : JSON.stringify(raw, null, 2);
+    d.appendChild(pre);
+    row.appendChild(d);
+  }
+  log.appendChild(row);
+  log.scrollTop = log.scrollHeight;
+}
+
+// Render one SDK (or server) message into a friendly row.
+function render(m) {
+  const t = m.type;
+  if (t === 'server') {
+    if (m.subtype === 'connected' || m.subtype === 'starting') {
+      dot.classList.add('on');
+      meta.textContent = (m.provider ? m.provider + '  ·  ' : '') + (m.model || '') + (m.session_id ? '  ·  ' + m.session_id : '');
+    }
+    if (m.subtype === 'user_turn') return el('user', 'you', m.text);
+    if (m.subtype === 'error' || m.subtype === 'stderr') return el('error', m.subtype, m.error || m.text, m);
+    if (m.subtype === 'task_injected') return el('tool', 'task ← ' + m.id, m.path || '', m);
+    if (m.subtype === 'task_done') return el('server', 'task ✓ ' + m.id, '', m);
+    if (m.subtype === 'cron_fired') return el('tool', 'cron ⏱ ' + m.name, m.prompt || '', m);
+    if (m.subtype === 'cron_schedule')
+      return el('server', 'crons scheduled (' + (m.crons || []).length + ')',
+        (m.crons || []).map(c => c.cron + '  ' + c.name + ' → ' + c.target).join('\n'), m);
+    return el('server', 'server', m.subtype + (m.session_id ? ' · ' + m.session_id : ''), m);
+  }
+  if (t === 'system') {
+    meta.textContent = [m.model, m.session_id].filter(Boolean).join('  ·  ');
+    return el('server', 'system/' + (m.subtype || ''), 'tools: ' + ((m.tools || []).length), m);
+  }
+  if (t === 'assistant') {
+    const blocks = (m.message && m.message.content) || [];
+    for (const b of Array.isArray(blocks) ? blocks : [{ type: 'text', text: String(blocks) }]) {
+      if (b.type === 'text') el('assistant', 'assistant', b.text);
+      else if (b.type === 'thinking') el('assistant', 'thinking', b.thinking || '', b);
+      else if (b.type === 'tool_use') el('tool', 'tool → ' + b.name, JSON.stringify(b.input), b);
+      else el('assistant', b.type || 'assistant', '', b);
+    }
+    return;
+  }
+  if (t === 'user') { // tool results coming back from tool execution
+    const blocks = (m.message && m.message.content) || [];
+    for (const b of Array.isArray(blocks) ? blocks : []) {
+      if (b.type === 'tool_result') el('tool', 'tool result', typeof b.content === 'string' ? b.content : JSON.stringify(b.content), b);
+    }
+    return;
+  }
+  if (t === 'result') {
+    const u = m.usage || {};
+    const cls = m.is_error ? 'error' : 'result';
+    el(cls, 'result/' + (m.is_error ? 'error' : (m.subtype || '')),
+       `${m.result ?? ''}  ·  in ${u.input_tokens ?? '?'} / out ${u.output_tokens ?? '?'} tok` +
+       (m.total_cost_usd != null ? `  ·  $${m.total_cost_usd}` : ''), m);
+    return;
+  }
+  el('server', t || 'event', '', m); // stream_event + anything else → raw
+}
+
+const es = new EventSource('/events');
+es.onmessage = (e) => { try { render(JSON.parse(e.data)); } catch {} };
+es.onerror = () => { dot.classList.remove('on'); meta.textContent = 'disconnected — retrying…'; };
+
+async function send(text) {
+  await fetch('/input', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ text }) });
+}
+form.addEventListener('submit', (e) => { e.preventDefault(); const t = box.value.trim(); if (t) { send(t); box.value = ''; } });
+box.addEventListener('keydown', (e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); form.requestSubmit(); } });
+</script>
+</body>
+</html>

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1762,7 +1762,7 @@ def notify_slack_for_failures(
 # makes it SELF-HEALING.
 #
 # Recovery action is the one mechanism we already own and trust:
-# `scripts/start-cli.sh --restart`. A restarted session starts fresh under the
+# `src/agent/claude/cli/start-cli.sh --restart`. A restarted session starts fresh under the
 # standard context boundary; because the /usage-credits enable persists
 # ACCOUNT-WIDE once a human sets it (and on Max/Team plans 1M is included with
 # no gate at all), the restarted core keeps 1M and re-clears the gate by
@@ -1883,11 +1883,11 @@ def _core_started_within(seconds: float, workspace: Optional[Path] = None, now: 
 
 
 def _default_core_restart(standard_context: bool) -> bool:
-    """Run scripts/start-cli.sh --restart out-of-process. When standard_context
-    is True, pin SUTANDO_CORE_MODEL=opus so the restarted core runs in the
-    standard 200K window (graceful degradation). Returns True if the restart
-    command exited 0."""
-    script = REPO_DIR / "scripts" / "start-cli.sh"
+    """Run src/agent/claude/cli/start-cli.sh --restart out-of-process. When
+    standard_context is True, pin SUTANDO_CORE_MODEL=opus so the restarted core
+    runs in the standard 200K window (graceful degradation). Returns True if the
+    restart command exited 0."""
+    script = REPO_DIR / "src" / "agent" / "claude" / "cli" / "start-cli.sh"
     if not script.exists():
         return False
     env = dict(os.environ)

--- a/src/launchd/com.sutando.health-check-fallback.plist
+++ b/src/launchd/com.sutando.health-check-fallback.plist
@@ -30,7 +30,7 @@
       owner id in ~/.claude/channels/slack/access.json is missing.
     - --recover-core: when the core is alive-but-wedged (heartbeat ticking but
       the task queue isn't draining — the 2026-06-02 1M usage-credit-gate loop
-      signature), auto-restarts it via scripts/start-cli.sh --restart. Heavily
+      signature), auto-restarts it via src/agent/claude/cli/start-cli.sh --restart. Heavily
       guarded (sustained-wedge confirm window, 30min cooldown, 3/hr give-up cap)
       and a clean no-op when the core is healthy. Keeps 1M on the first restart;
       degrades to standard 200K only if the wedge recurs. Runs here, in launchd's

--- a/src/restart.sh
+++ b/src/restart.sh
@@ -16,6 +16,10 @@ pkill -f "telegram-bridge" 2>/dev/null
 pkill -f "discord-bridge" 2>/dev/null
 pkill -f "watch-tasks" 2>/dev/null
 pkill -f "conversation-server" 2>/dev/null
+# SDK core (session-server.ts) — the claude_sdk core is a background node service,
+# so restart.sh owns its lifecycle (unlike the interactive tmux core). Matches the
+# node/tsx/npm variants by their shared script path.
+pkill -f "src/agent/claude/sdk/session-server" 2>/dev/null
 pkill -f "ngrok" 2>/dev/null
 # Credential proxy: handle the launchd-supervised job explicitly. pkill alone
 # only bounces the worker — launchd's KeepAlive respawns it on its own throttle,
@@ -56,7 +60,7 @@ fi
 STOP_PATTERNS=(
     "voice-agent" "web-client.ts" "dashboard.py" "agent-api.py"
     "screen-capture-server" "telegram-bridge" "discord-bridge" "watch-tasks"
-    "conversation-server" "ngrok" "src/Sutando/Sutando"
+    "conversation-server" "src/agent/claude/sdk/session-server" "ngrok" "src/Sutando/Sutando"
 )
 for _ in $(seq 1 30); do
     still=0

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -37,7 +37,7 @@ export SUTANDO_ROOT="$REPO"
 # L~449 discord, L~473 slack) probe `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` and
 # fall back to legacy `~/.claude/` when the env var is unset — meaning bridges
 # read tokens / access lists from the pre-migration location even after a
-# successful `claude-sutando --migrate`. Mirrors scripts/start-cli.sh:38-51
+# successful `claude-sutando --migrate`. Mirrors src/agent/claude/cli/start-cli.sh
 # (Sutando.app's tmux-wrapped CLI launcher) — same machine-spawn pattern.
 #
 # Defense in depth (matches start-cli):
@@ -48,6 +48,12 @@ if [ -x "$REPO/scripts/sutando-config.sh" ]; then
   _ccd_err="$(mktemp -t startup-ccd.XXXXXX)"
   if _ccd="$(bash "$REPO/scripts/sutando-config.sh" claude-sutando-config-dir 2>"$_ccd_err")"; then
     mkdir -p "$_ccd"
+    # NOTE: the claude core-agent launcher + the `claude-sutando` config-dir
+    # onboarding alias now live under src/agent/claude/ (start-cli.sh /
+    # sutando-shell-setup.sh). This credentials seed stays INLINE here by design:
+    # it must run in the same startup env (exports CLAUDE_CONFIG_DIR for the
+    # bridges below), not in a separately-execed launcher. See
+    # src/agent/claude/README.md for the full auth/onboarding map.
     # Auth-carry (v0.8 cold-start fix). Seed credentials + onboarding state from
     # $HOME/.claude/ so a cold `claude` core doesn't dead-end at the login wall
     # (.credentials.json) or trust-folder prompt (.claude.json) before reaching
@@ -463,8 +469,8 @@ fi
 # per-host sentinel at $WORKSPACE/state/.shell-setup-prompted-<hostname> so
 # this never re-pesters after the user's initial yes/no.
 # Failures are non-fatal — startup.sh continues regardless.
-if [ -x "$REPO/scripts/sutando-shell-setup.sh" ]; then
-  bash "$REPO/scripts/sutando-shell-setup.sh" --auto || true
+if [ -x "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" ]; then
+  bash "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" --auto || true
 fi
 
 # Reap any stale watch-tasks-stream watcher from a prior session. The
@@ -962,9 +968,9 @@ done
 echo ""
 open "http://localhost:8080"
 
-# Delegate to scripts/start-cli.sh — canonical sutando-core launch command.
-# Single source of truth so Sutando.app's Restart Core menu can invoke the
-# same launch path without duplicating the tmux + claude flags.
+# Delegate to src/agent/claude/cli/start-cli.sh — canonical sutando-core launch
+# command. Single source of truth so Sutando.app's Restart Core menu can invoke
+# the same launch path without duplicating the tmux + claude flags.
 #
 # Restore stdout/stderr to the terminal first when the operator is
 # interactive: the tee-redirect at the top of this script makes fd 1 a PIPE,
@@ -977,4 +983,4 @@ open "http://localhost:8080"
 if [ -t 0 ]; then
     exec >/dev/tty 2>&1
 fi
-exec bash "$REPO/scripts/start-cli.sh"
+exec bash "$REPO/src/agent/claude/cli/start-cli.sh"

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -968,9 +968,45 @@ done
 echo ""
 open "http://localhost:8080"
 
-# Delegate to src/agent/claude/cli/start-cli.sh — canonical sutando-core launch
-# command. Single source of truth so Sutando.app's Restart Core menu can invoke
-# the same launch path without duplicating the tmux + claude flags.
+# Launch the CORE — routed by core_config.core_type:
+#   claude_sdk → the Agent-SDK session core (src/agent/claude/sdk/session-server.sh),
+#                a background HTTP server + browser UI on :${SUTANDO_SESSION_PORT:-4100}.
+#                Everything above (heartbeat, proxy, bridges, services) has already
+#                started; the SDK core owns task-watching + cron/proactive scheduling
+#                itself, and defers the heartbeat to the core_heartbeat.py started above.
+#   claude_cli → (default) the interactive tmux core via cli/start-cli.sh.
+# Lowercase-normalize so claude_SDK / CLAUDE_SDK / claude_sdk all route the same.
+_CORE_TYPE="$(bash "$REPO/scripts/sutando-config.sh" core-config 2>/dev/null | sed -n 's/^CFG_CORE_TYPE=//p' | tr '[:upper:]' '[:lower:]')"
+if [ "$_CORE_TYPE" = "claude_sdk" ]; then
+  _SDK_PORT="${SUTANDO_SESSION_PORT:-4100}"
+  if lsof -i :"$_SDK_PORT" > /dev/null 2>&1; then
+    echo "  ✓ SDK core (session-server) already running on :$_SDK_PORT"
+  else
+    echo "  Starting SDK core (session-server) on :$_SDK_PORT..."
+    # core_heartbeat.py (started above) owns this host's liveness beat → skip the
+    # session-server's own heartbeat so they don't fight over state/cores/*.alive.
+    SUTANDO_SESSION_NO_HEARTBEAT=1 nohup bash "$REPO/src/agent/claude/sdk/session-server.sh" \
+      > "$LOGS_DIR/session-server.log" 2>&1 &
+    # Wait for the HTTP server to bind (it does so before the SDK session connects),
+    # so a refusal (e.g. missing provider token) surfaces here, not as a dead URL.
+    for _ in $(seq 1 20); do lsof -i :"$_SDK_PORT" > /dev/null 2>&1 && break; sleep 0.5; done
+    if lsof -i :"$_SDK_PORT" > /dev/null 2>&1; then
+      echo "  ✓ SDK core → http://localhost:$_SDK_PORT  (logs: $LOGS_DIR/session-server.log)"
+    else
+      echo "  ✗ SDK core failed to bind :$_SDK_PORT — check $LOGS_DIR/session-server.log (often a missing provider token)" >&2
+    fi
+  fi
+  if lsof -i :"$_SDK_PORT" > /dev/null 2>&1; then
+    open "http://localhost:$_SDK_PORT" 2>/dev/null || true
+    echo ""
+    echo "Startup complete (SDK core). Open http://localhost:$_SDK_PORT for the live session UI."
+  fi
+  exit 0
+fi
+
+# Default: delegate to src/agent/claude/cli/start-cli.sh — canonical sutando-core
+# launch command. Single source of truth so Sutando.app's Restart Core menu can
+# invoke the same launch path without duplicating the tmux + claude flags.
 #
 # Restore stdout/stderr to the terminal first when the operator is
 # interactive: the tee-redirect at the top of this script makes fd 1 a PIPE,

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -54,6 +54,7 @@ _KNOWN_TOP_LEVEL_KEYS = {
     "workspace",
     "claude_sutando_config_dir",
     "core_config_dirs",
+    "core_config",
     "vault",
     "migrate",
 }
@@ -401,6 +402,76 @@ def resolve_vault(repo_root: Optional[Path] = None) -> Dict[str, Any]:
     vault["sync"] = sync
     vault.setdefault("interval_seconds", 1800)
     return vault
+
+
+# --------------------------------------------------------------------------- #
+#  Core agent config — `core_config` (which core, and its provider connection) #
+# --------------------------------------------------------------------------- #
+
+# Baked-in defaults for the `core_config` block — the high-level "which core
+# agent, and how does it connect" contract, consumed by src/agent/claude/.
+#   core_type — which core implementation runs:
+#                 "claude_cli" (default) — the interactive tmux core
+#                   (src/agent/claude/cli/start-cli.sh). Uses the Claude.ai
+#                   SUBSCRIPTION when `provider` is empty; runs on `provider`
+#                   when it is set. provider/auth_env are NOT required for the
+#                   subscription case.
+#                 "claude_sdk" — the Agent-SDK session core
+#                   (src/agent/claude/sdk/session-server.sh). Requires a
+#                   provider + auth_env.
+#   provider  — custom Anthropic-compatible endpoint URL (""=stock Anthropic /
+#               subscription). Required for claude_sdk and for a provider-backed
+#               claude_cli.
+#   auth_env  — env var (and vault key) holding the API token, OR the sentinel
+#               "ANTHROPIC_SUBSCRIPTION" (default) meaning "use the Claude.ai
+#               subscription OAuth — no provider token". A real token env picks
+#               the credential style: ANTHROPIC_AUTH_TOKEN (Bearer) or
+#               ANTHROPIC_API_KEY (x-api-key). A provider needs a real token env.
+#   model     — the PRIMARY session model (the core's own model, opus-class for
+#               the interactive core). ""=provider/account default. → ANTHROPIC_MODEL.
+#   models    — per-CLASS model IDs used for SUBTASKS/subagents, so a provider (or
+#               a quota-conscious subscription) can run cheaper models for lighter
+#               work. Each maps to the Claude Code alias env var (empty = inherit):
+#                 models.opus   → ANTHROPIC_DEFAULT_OPUS_MODEL
+#                 models.sonnet → ANTHROPIC_DEFAULT_SONNET_MODEL  (subagents default here)
+#                 models.haiku  → ANTHROPIC_DEFAULT_HAIKU_MODEL   (quick/background work)
+# dashp.sh's launch knobs (permission_mode / bare / output_format) are NOT config
+# — they're env/CLI overrides only, keeping this block high-level.
+_CORE_CONFIG_MODEL_TIERS = ("opus", "sonnet", "haiku")
+_CORE_CONFIG_DEFAULTS: Dict[str, Any] = {
+    "core_type": "claude_cli",
+    "provider": "",
+    "auth_env": "ANTHROPIC_SUBSCRIPTION",
+    "model": "",
+    "models": {tier: "" for tier in _CORE_CONFIG_MODEL_TIERS},
+}
+
+
+def resolve_core_config(repo_root: Optional[Path] = None) -> Dict[str, Any]:
+    """Return the resolved `core_config` subtree (defaults merged with config).
+
+    Missing/partial config falls through to `_CORE_CONFIG_DEFAULTS` per-field
+    (and per-tier for the nested `models` block), so callers always get a
+    fully-populated dict. Consumed by `scripts/sutando-config.sh core-config` →
+    src/agent/claude/ (provider-env.sh, start-cli.sh, dashp.sh, session-server.sh).
+    """
+    cfg = load_config(repo_root)
+    block = dict(cfg.get("core_config") or {})
+    out = dict(_CORE_CONFIG_DEFAULTS)
+    out["models"] = dict(_CORE_CONFIG_DEFAULTS["models"])  # copy nested defaults
+    for key in ("core_type", "provider", "auth_env", "model"):
+        if block.get(key) is not None:
+            out[key] = block[key]
+    sub = block.get("models")
+    if isinstance(sub, dict):
+        for tier in _CORE_CONFIG_MODEL_TIERS:
+            if sub.get(tier) is not None:
+                out["models"][tier] = sub[tier]
+    # Canonicalize core_type to lowercase so claude_SDK / CLAUDE_SDK all resolve
+    # the same for the routing consumers (startup.sh, start-cli.sh).
+    if isinstance(out.get("core_type"), str):
+        out["core_type"] = out["core_type"].lower()
+    return out
 
 
 _DEFAULT_CLAUDE_SUTANDO_SUBDIR = ".claude-sutando"

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -426,7 +426,7 @@ def resolve_claude_sutando_config_dir(repo_root: Optional[Path] = None) -> Path:
     `/tmp/...` doesn't become `/private/tmp/...` from a stray `.resolve()`).
 
     Does NOT create the directory; callers (e.g.
-    `scripts/sutando-shell-setup.sh`) are responsible for mkdir as part of the
+    `src/agent/claude/cli/sutando-shell-setup.sh`) are responsible for mkdir as part of the
     alias-setup flow.
     """
     global _LEGACY_CLAUDE_SUBDIR_WARN_PRINTED

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -37,7 +37,14 @@ const LOCAL_FILENAME = 'sutando.config.local.json';
  * stays lenient (warn-only) so experimental/scratch keys don't break.
  * Per Mini's review #8 on PR #1395.
  */
-const KNOWN_TOP_LEVEL_KEYS = new Set(['workspace', 'claude_sutando_config_dir', 'vault']);
+const KNOWN_TOP_LEVEL_KEYS = new Set([
+	'workspace',
+	'claude_sutando_config_dir',
+	'core_config_dirs',
+	'core_config',
+	'vault',
+	'migrate',
+]);
 
 /**
  * Walk upward from `start` until we find a directory containing

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -373,7 +373,7 @@ const DEFAULT_CLAUDE_SUTANDO_SUBDIR = '.claude-sutando';
  * are rejected at load (schema pattern) AND asserted again here (defense in
  * depth, catches symlink escapes the regex misses).
  *
- * Does NOT create the directory — callers (e.g. `scripts/sutando-shell-setup.sh`)
+ * Does NOT create the directory — callers (e.g. `src/agent/claude/cli/sutando-shell-setup.sh`)
  * are responsible for mkdir as part of the alias-setup flow.
  *
  * @throws if the subdir violates the workspace-sub-folder invariant.

--- a/src/util_paths.ts
+++ b/src/util_paths.ts
@@ -144,7 +144,7 @@ export function sharedPersonalPath(filename: string, workspace?: string): string
 // Resolution (3-tier, prefer most specific):
 //   1. $CLAUDE_CONFIG_DIR  — Claude Code's canonical env var (string present
 //      in the `claude` binary). Set by `claude-sutando` shell function +
-//      scripts/start-cli.sh + src/startup.sh so every workspace gets its own
+//      src/agent/claude/cli/start-cli.sh + src/startup.sh so every workspace gets its own
 //      .claude-sutando/ tree instead of sharing global ~/.claude/.
 //   2. $CLAUDE_HOME        — deprecated legacy override (kept for one release
 //      so pre-M0 callers / test fixtures don't break instantly). Emits a

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -63,6 +63,25 @@ STATE_DIR="$(bash "$__REPO_ROOT/scripts/sutando-config.sh" workspace)/state"
 mkdir -p "$STATE_DIR"
 PID_FILE="$STATE_DIR/watch-tasks-stream.pid"
 echo "$$" > "$PID_FILE"
+
+# Host-owned-watcher mode (SDK core). src/agent/claude/sdk/session-server.ts sets
+# SUTANDO_HOST_OWNS_WATCHER=1 and watches tasks/ itself, injecting each task into
+# the SDK session directly. When set, this script must NOT also emit TASK_FILE
+# events — that would double-process every task. We still hold the PID (so the
+# agent's /schedule-crons + /proactive-loop "ensure watcher running" PID checks
+# pass) and stay alive under the Monitor tool, but emit nothing and never fswatch.
+if [ "${SUTANDO_HOST_OWNS_WATCHER:-0}" = "1" ]; then
+  # The signal handler must EXIT (not just clean up), and the hold below must be
+  # `sleep & wait` — a bare `sleep` blocks the trap until it returns, so TERM
+  # would be ignored. `wait` is interruptible, so the trap fires immediately.
+  trap 'rm -f "$PID_FILE"; [ -n "${_sl:-}" ] && kill "$_sl" 2>/dev/null; exit 0' HUP INT TERM
+  trap 'rm -f "$PID_FILE"' EXIT
+  echo "watch-tasks-stream: SUTANDO_HOST_OWNS_WATCHER=1 — host owns task watching; this watcher is a no-op (PID held, no events)." >&2
+  while :; do
+    sleep 3600 & _sl=$!
+    wait "$_sl" 2>/dev/null || true
+  done
+fi
 # PID-file cleanup is folded into the unified `cleanup` function below so a
 # single trap covers both responsibilities (rm + kill children). An earlier
 # version set `trap 'rm -f "$PID_FILE"' EXIT` here AND `trap cleanup EXIT...`

--- a/sutando.config.json
+++ b/sutando.config.json
@@ -11,6 +11,17 @@
       "value": "${WORKSPACE_DIR}/.claude-sutando"
     }
   ],
+  "core_config": {
+    "core_type": "claude_cli",
+    "provider": "",
+    "auth_env": "ANTHROPIC_SUBSCRIPTION",
+    "model": "",
+    "models": {
+      "opus": "",
+      "sonnet": "",
+      "haiku": ""
+    }
+  },
   "vault": {
     "enabled": false,
     "remote_url": "",

--- a/sutando.config.local.json.example
+++ b/sutando.config.local.json.example
@@ -6,6 +6,24 @@
     "path": "/absolute/path/to/your/workspace"
   },
 
+  "core_config": {
+    "_comment": "High-level 'which core agent + how it connects'. Consumed by src/agent/claude/. Defaults keep the Claude.ai-subscription CLI core; set a provider to run on a custom Anthropic-compatible endpoint.",
+    "_comment_core_type": "claude_cli = the interactive tmux core (cli/start-cli.sh) — subscription when `provider` is empty, or on `provider` when set. claude_sdk = the Agent-SDK session core (sdk/session-server.sh; requires provider + auth_env).",
+    "core_type": "claude_cli",
+    "_comment_provider": "Custom Anthropic-compatible endpoint URL. Empty = stock Anthropic / subscription (no provider). Required for claude_sdk and for a provider-backed claude_cli.",
+    "provider": "https://your-gateway.example.com",
+    "_comment_auth_env": "Default is the sentinel ANTHROPIC_SUBSCRIPTION = use the Claude.ai subscription OAuth (no token) — correct for a subscription claude_cli core. For a PROVIDER (as below), set a real token env var: ANTHROPIC_AUTH_TOKEN → Authorization: Bearer, or ANTHROPIC_API_KEY → x-api-key. Store the secret with `vault set <auth_env> <token>` (never put the token in this file).",
+    "auth_env": "ANTHROPIC_AUTH_TOKEN",
+    "_comment_model": "The PRIMARY session model (the core's own model) → ANTHROPIC_MODEL. Empty = provider/account default.",
+    "model": "",
+    "_comment_models": "Per-class model IDs for SUBTASKS/subagents, so lighter work can run cheaper models. Each empty value inherits. opus → ANTHROPIC_DEFAULT_OPUS_MODEL; sonnet → ANTHROPIC_DEFAULT_SONNET_MODEL (subagents default here); haiku → ANTHROPIC_DEFAULT_HAIKU_MODEL (quick/background). An already-set ANTHROPIC_DEFAULT_*_MODEL env var wins.",
+    "models": {
+      "opus": "",
+      "sonnet": "",
+      "haiku": ""
+    }
+  },
+
   "vault": {
     "_comment": "Enable + point at your private remote git repo to sync notes/memory/archives off-host.",
     "enabled": true,

--- a/tests/health-check-recover-core.test.py
+++ b/tests/health-check-recover-core.test.py
@@ -7,7 +7,7 @@ Motivated by the 2026-06-02 incident: the core crossed into 1M extended
 context, hit the interactive `/usage-credits` gate (which cannot be
 pre-authorized for an unattended agent), and looped silently — alive (heartbeat
 ticking) but draining nothing. --notify-slack makes that visible; this makes it
-self-healing by restarting the core via scripts/start-cli.sh --restart, with
+self-healing by restarting the core via src/agent/claude/cli/start-cli.sh --restart, with
 1M preserved on the first attempt and a graceful 200K fallback if it recurs.
 
 Because auto-restarting a 24/7 agent is consequential, the guards are the whole

--- a/tests/provider-env-guards.test.sh
+++ b/tests/provider-env-guards.test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Guards in src/agent/claude/provider-env.sh::claude_provider_export_env:
+#   - auth_env is validated as an env-var identifier (no shell injection via the
+#     indirect expansion / export), replacing an earlier `eval`.
+#   - a provider token is never sent over a leaky endpoint: non-https to a
+#     non-loopback host is refused, and userinfo (user:pass@host) is refused.
+#   - precedence is CLI(SUTANDO_PROVIDER_*) > inherited ANTHROPIC_* > config, so
+#     an explicit override wins over an inherited ANTHROPIC_MODEL/_BASE_URL.
+#
+# Each case sources the helper in a subshell and sets SUTANDO_PROVIDER_* so the
+# result is independent of the caller's sutando.config (env override > config).
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+export REPO
+PE="$REPO/src/agent/claude/provider-env.sh"
+fail=0
+
+# call <extra-env-eval> → prints "rc=<n> base=<url> model=<m> stderr=<text>"
+call() {
+  ( set +e
+    . "$PE"
+    eval "$1"
+    local err; err="$(claude_provider_export_env 2>&1 1>/dev/null)"
+    # re-run to capture rc + exports on stdout (stderr already captured above)
+    claude_provider_export_env >/dev/null 2>&1; local rc=$?
+    echo "rc=$rc base=${ANTHROPIC_BASE_URL:-} model=${ANTHROPIC_MODEL:-} stderr=$err"
+  )
+}
+
+check() { # <name> <expect-substr> <actual>
+  if printf '%s' "$3" | grep -qF "$2"; then echo "  ok   $1"; else echo "  FAIL $1"; echo "        want ~ '$2'"; echo "        got    '$3'"; fail=1; fi
+}
+
+marker="$REPO/../.pe-guard-injection-marker.$$"
+rm -f "$marker" 2>/dev/null
+
+check "auth_env injection is rejected (not executed)" "invalid auth_env" \
+  "$(call 'export SUTANDO_PROVIDER_AUTH_ENV="X:-\$(touch '"$marker"')"')"
+if [ -e "$marker" ]; then echo "  FAIL injection EXECUTED (marker created)"; fail=1; rm -f "$marker"; else echo "  ok   injection did not execute"; fi
+
+check "non-https to non-loopback refused" "refusing non-https" \
+  "$(call 'export SUTANDO_PROVIDER_URL=http://evil.example.com SUTANDO_PROVIDER_AUTH_ENV=ANTHROPIC_AUTH_TOKEN ANTHROPIC_AUTH_TOKEN=t')"
+
+check "embedded userinfo refused" "embedded credentials" \
+  "$(call 'export SUTANDO_PROVIDER_URL=https://user:pass@host.example.com SUTANDO_PROVIDER_AUTH_ENV=ANTHROPIC_AUTH_TOKEN ANTHROPIC_AUTH_TOKEN=t')"
+
+check "loopback http allowed (rc=0)" "rc=0" \
+  "$(call 'export SUTANDO_PROVIDER_URL=http://localhost:7846 SUTANDO_PROVIDER_AUTH_ENV=ANTHROPIC_AUTH_TOKEN ANTHROPIC_AUTH_TOKEN=t')"
+
+check "https + token ok (rc=0)" "rc=0" \
+  "$(call 'export SUTANDO_PROVIDER_URL=https://api.example.com SUTANDO_PROVIDER_AUTH_ENV=ANTHROPIC_AUTH_TOKEN ANTHROPIC_AUTH_TOKEN=t')"
+
+check "SUTANDO_PROVIDER_MODEL beats inherited ANTHROPIC_MODEL" "model=FLAGMODEL" \
+  "$(call 'export ANTHROPIC_MODEL=INHERITED SUTANDO_PROVIDER_MODEL=FLAGMODEL SUTANDO_PROVIDER_URL=https://api.example.com SUTANDO_PROVIDER_AUTH_ENV=ANTHROPIC_AUTH_TOKEN ANTHROPIC_AUTH_TOKEN=t')"
+
+check "SUTANDO_PROVIDER_URL beats inherited ANTHROPIC_BASE_URL" "base=https://flagurl.example.com" \
+  "$(call 'export ANTHROPIC_BASE_URL=https://inherited.example.com SUTANDO_PROVIDER_URL=https://flagurl.example.com SUTANDO_PROVIDER_AUTH_ENV=ANTHROPIC_AUTH_TOKEN ANTHROPIC_AUTH_TOKEN=t')"
+
+check "subscription sentinel → rc=2 (no token, endpoint exempt from https guard)" "rc=2" \
+  "$(call 'export SUTANDO_PROVIDER_AUTH_ENV=ANTHROPIC_SUBSCRIPTION')"
+
+echo "----------------------------------------"
+if [ "$fail" -eq 0 ]; then echo "PASS: provider-env guards"; else echo "provider-env guards FAILED"; exit 1; fi

--- a/tests/start-cli-claude-config-dir.test.sh
+++ b/tests/start-cli-claude-config-dir.test.sh
@@ -99,8 +99,9 @@ EOF
   export PATH="$BIN_STUB:$PATH"
 
   # Copy the real start-cli.sh into the fake repo (mirroring its real
-  # src/agent/claude/ location, since the script self-locates the repo root
-  # three levels up) plus the bits it needs to resolve claude_sutando_config_dir
+  # src/agent/claude/cli/ location, since the script self-locates the repo root
+  # four levels up: cli → claude → agent → src → repo) plus the bits it needs to
+  # resolve claude_sutando_config_dir
   # (sutando-config.sh stays under scripts/ — start-cli calls $REPO/scripts/...).
   cp "$REAL_REPO/src/agent/claude/cli/start-cli.sh" "$REPO_FAKE/src/agent/claude/cli/"
 

--- a/tests/start-cli-claude-config-dir.test.sh
+++ b/tests/start-cli-claude-config-dir.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Integration test for scripts/start-cli.sh's CLAUDE_CONFIG_DIR export.
+# Integration test for src/agent/claude/cli/start-cli.sh's CLAUDE_CONFIG_DIR export.
 #
 # Covers the 3 states the design doc enumerated:
 #   1. M0 helper missing                              → silent fallback, claude spawns w/o env
@@ -50,7 +50,7 @@ setup_sandbox() {
   export HOME="$SANDBOX/home"
   export SUTANDO_WORKSPACE="$SANDBOX/workspace"
 
-  mkdir -p "$REPO_FAKE/scripts" "$REPO_FAKE/src" "$BIN_STUB" \
+  mkdir -p "$REPO_FAKE/scripts" "$REPO_FAKE/src" "$REPO_FAKE/src/agent/claude/cli" "$BIN_STUB" \
            "$HOME" "$SUTANDO_WORKSPACE/state"
 
   # Stub `claude` binary — records its env to ENV_DUMP, exits 0.
@@ -98,9 +98,11 @@ EOF
 
   export PATH="$BIN_STUB:$PATH"
 
-  # Copy the real start-cli.sh into the fake repo and the bits it needs to
-  # actually resolve claude_sutando_config_dir.
-  cp "$REAL_REPO/scripts/start-cli.sh" "$REPO_FAKE/scripts/"
+  # Copy the real start-cli.sh into the fake repo (mirroring its real
+  # src/agent/claude/ location, since the script self-locates the repo root
+  # three levels up) plus the bits it needs to resolve claude_sutando_config_dir
+  # (sutando-config.sh stays under scripts/ — start-cli calls $REPO/scripts/...).
+  cp "$REAL_REPO/src/agent/claude/cli/start-cli.sh" "$REPO_FAKE/src/agent/claude/cli/"
 
   if [ "$helper_present" = "yes" ]; then
     cp "$REAL_REPO/scripts/sutando-config.sh" "$REPO_FAKE/scripts/"
@@ -128,7 +130,7 @@ REAL_REPO="$(cd "$(dirname "$0")/.." && pwd)"
 test_helper_missing_silent_fallback() {
   setup_sandbox "no" "(unused)"
   # Run start-cli; should reach claude stub without erroring on missing helper.
-  bash "$REPO_FAKE/scripts/start-cli.sh" </dev/null >/dev/null 2>&1
+  bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null >/dev/null 2>&1
   rc=$?
   if [ "$rc" != "0" ]; then
     echo "  FAIL: start-cli exit $rc (expected 0 — helper-missing should be silent fallback)"
@@ -155,7 +157,7 @@ test_helper_missing_silent_fallback() {
 # ----------------------------------------------------------------------
 test_valid_config_exports_env() {
   setup_sandbox "yes" ".claude-sutando"
-  bash "$REPO_FAKE/scripts/start-cli.sh" </dev/null >/dev/null 2>&1
+  bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null >/dev/null 2>&1
   rc=$?
   if [ "$rc" != "0" ]; then
     echo "  FAIL: start-cli exit $rc (expected 0 for valid config)"
@@ -188,7 +190,7 @@ test_valid_config_exports_env() {
 # ----------------------------------------------------------------------
 test_invalid_config_refuses_to_start() {
   setup_sandbox "yes" "/etc/claude-state"  # absolute path, invariant violation
-  bash "$REPO_FAKE/scripts/start-cli.sh" </dev/null >/dev/null 2>&1
+  bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null >/dev/null 2>&1
   rc=$?
   if [ "$rc" = "0" ]; then
     echo "  FAIL: start-cli exit 0 (expected non-zero — config violates invariant)"
@@ -208,16 +210,16 @@ test_invalid_config_refuses_to_start() {
 #    tests above stay green but this one catches the regression.
 # ----------------------------------------------------------------------
 test_block_present_in_start_cli() {
-  if ! grep -qF 'CLAUDE_CONFIG_DIR' "$REAL_REPO/scripts/start-cli.sh"; then
-    echo "  FAIL: scripts/start-cli.sh no longer references CLAUDE_CONFIG_DIR"
+  if ! grep -qF 'CLAUDE_CONFIG_DIR' "$REAL_REPO/src/agent/claude/cli/start-cli.sh"; then
+    echo "  FAIL: src/agent/claude/cli/start-cli.sh no longer references CLAUDE_CONFIG_DIR"
     return 1
   fi
-  if ! grep -qF 'claude-sutando-config-dir' "$REAL_REPO/scripts/start-cli.sh"; then
-    echo "  FAIL: scripts/start-cli.sh no longer calls the M0 helper subcommand"
+  if ! grep -qF 'claude-sutando-config-dir' "$REAL_REPO/src/agent/claude/cli/start-cli.sh"; then
+    echo "  FAIL: src/agent/claude/cli/start-cli.sh no longer calls the M0 helper subcommand"
     return 1
   fi
-  if ! grep -qF 'refusing to start core' "$REAL_REPO/scripts/start-cli.sh"; then
-    echo "  FAIL: scripts/start-cli.sh dropped the fail-loud branch on invariant violation"
+  if ! grep -qF 'refusing to start core' "$REAL_REPO/src/agent/claude/cli/start-cli.sh"; then
+    echo "  FAIL: src/agent/claude/cli/start-cli.sh dropped the fail-loud branch on invariant violation"
     return 1
   fi
   return 0

--- a/tests/start-cli-compat-shim.test.sh
+++ b/tests/start-cli-compat-shim.test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Smoke test for the one-release compat shims added when the Claude core-agent
+# launchers moved to src/agent/claude/cli/ (PR #1891).
+#
+# Guards against the "moved with no shim" regression: an already-installed /
+# not-yet-rebuilt Sutando.app (and health-check --recover-core) still invoke the
+# OLD scripts/{start-cli,sutando-shell-setup}.sh paths, and would hard-fail after
+# a `git pull` if those paths vanished. This asserts the shims exist, are
+# executable, parse, and exec-forward to their new src/agent/claude/cli/ homes.
+# It does NOT run the shims (that would launch the live core) — structural only.
+set -u
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+fail=0
+
+for name in start-cli sutando-shell-setup; do
+    shim="$REPO/scripts/$name.sh"
+    target="src/agent/claude/cli/$name.sh"
+
+    [ -f "$shim" ] || { echo "  FAIL: compat shim $shim is missing"; fail=1; continue; }
+    [ -x "$shim" ] || { echo "  FAIL: compat shim $shim is not executable"; fail=1; }
+    bash -n "$shim" 2>/dev/null || { echo "  FAIL: $shim has a syntax error"; fail=1; }
+    grep -q "exec bash .*$target" "$shim" \
+        || { echo "  FAIL: $shim does not exec-forward to $target"; fail=1; }
+    [ -f "$REPO/$target" ] || { echo "  FAIL: forward target $REPO/$target is missing"; fail=1; }
+done
+
+if [ "$fail" -eq 0 ]; then
+    echo "PASS: scripts/{start-cli,sutando-shell-setup}.sh shims forward to src/agent/claude/cli/"
+else
+    echo "compat-shim test FAILED"
+    exit 1
+fi

--- a/tests/start-cli-model-pin.test.py
+++ b/tests/start-cli-model-pin.test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests that scripts/start-cli.sh honors $SUTANDO_CORE_MODEL (PR #1428).
+"""Tests that src/agent/claude/cli/start-cli.sh honors $SUTANDO_CORE_MODEL (PR #1428).
 
 The recovery escalation in src/health-check.py restarts a re-wedging core with
 SUTANDO_CORE_MODEL=opus so it falls back to standard 200K context. This verifies
@@ -22,7 +22,7 @@ import tempfile
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
-SCRIPT = REPO / "scripts" / "start-cli.sh"
+SCRIPT = REPO / "src" / "agent" / "claude" / "cli" / "start-cli.sh"
 
 
 def _launch_argv(model_env: "str | None") -> list[str]:

--- a/tests/start-cli-provider-as-core.test.sh
+++ b/tests/start-cli-provider-as-core.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Tests for src/agent/claude/cli/start-cli.sh's provider-backed core mode
+# (core_config.provider) + the shared src/agent/claude/provider-env.sh helper.
+#
+# When core_config.provider is set, start-cli.sh boots the SAME interactive core
+# but pointed at a custom Anthropic-compatible provider: it sources provider-env.sh
+# to export ANTHROPIC_BASE_URL / <auth_env> token / ANTHROPIC_MODEL, and suppresses
+# the subscription-only SUTANDO_CORE_MODEL → --model pin. With no provider set it
+# runs on the Claude.ai subscription exactly as before.
+#
+# Strategy (same as start-cli-claude-config-dir.test.sh): build a fake repo with
+# the real start-cli.sh + provider-env.sh + sutando-config.sh + sutando_config.py,
+# stub claude/tmux/pgrep on PATH, run start-cli, inspect the env the claude stub saw.
+#
+# Run:    bash tests/start-cli-provider-as-core.test.sh
+# Exit:   0 on pass, 1 on first failure.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+run_test() {
+  local name="$1"; shift
+  printf '%-58s' "$name"
+  if "$@"; then echo "ok"; PASS=$((PASS + 1)); else echo "FAIL"; FAIL=$((FAIL + 1)); fi
+}
+
+REAL_REPO="$(cd "$(dirname "$0")/.." && pwd)"
+
+# $1 = provider URL (empty string = subscription core)
+# $2 = auth_env (optional; default ANTHROPIC_AUTH_TOKEN)
+setup_sandbox() {
+  local provider="$1"
+  local auth_env="${2:-ANTHROPIC_AUTH_TOKEN}"
+  SANDBOX="$(mktemp -d -t start-cli-provider.XXXXXX)"
+  REPO_FAKE="$SANDBOX/repo"
+  ENV_DUMP="$SANDBOX/env-dump"
+  BIN_STUB="$SANDBOX/bin"
+  export HOME="$SANDBOX/home"
+
+  mkdir -p "$REPO_FAKE/src/agent/claude/cli" "$REPO_FAKE/scripts" "$REPO_FAKE/src" \
+           "$BIN_STUB" "$HOME" "$REPO_FAKE/workspace/state"
+
+  # start-cli.sh lives in cli/ (self-locates 4 levels up); provider-env.sh is
+  # shared and stays at the claude/ root (start-cli sources it via $REPO/...).
+  cp "$REAL_REPO/src/agent/claude/cli/start-cli.sh"   "$REPO_FAKE/src/agent/claude/cli/"
+  cp "$REAL_REPO/src/agent/claude/provider-env.sh"    "$REPO_FAKE/src/agent/claude/"
+  cp "$REAL_REPO/scripts/sutando-config.sh"           "$REPO_FAKE/scripts/"
+  cp "$REAL_REPO/src/sutando_config.py"               "$REPO_FAKE/src/"
+
+  cat > "$REPO_FAKE/sutando.config.json" << EOF
+{
+  "workspace": { "path": "\${REPO_DIR}/workspace" },
+  "core_config": {
+    "core_type": "claude_cli",
+    "provider": "$provider",
+    "auth_env": "$auth_env",
+    "model": "prov-model-7"
+  }
+}
+EOF
+
+  # claude stub — dumps the provider-relevant env + argv, exits 0.
+  cat > "$BIN_STUB/claude" << EOF
+#!/bin/bash
+{
+  echo "ARGV=\$*"
+  echo "BASE_URL=\${ANTHROPIC_BASE_URL:-}"
+  echo "MODEL=\${ANTHROPIC_MODEL:-}"
+  echo "TOKEN=\${ANTHROPIC_AUTH_TOKEN:-}"
+} > "$ENV_DUMP"
+exit 0
+EOF
+  chmod +x "$BIN_STUB/claude"
+
+  # tmux stub — run the trailing claude command, no-op everything else.
+  cat > "$BIN_STUB/tmux" << 'EOF'
+#!/bin/bash
+case "$1" in -S) shift 2 ;; esac
+case "$1" in
+  new-session) while [ "$#" -gt 0 ] && [ "$1" != "claude" ]; do shift; done; [ "$1" = "claude" ] && exec "$@" ;;
+  *) : ;;
+esac
+exit 0
+EOF
+  chmod +x "$BIN_STUB/tmux"
+  printf '#!/bin/bash\nexit 1\n' > "$BIN_STUB/pgrep"; chmod +x "$BIN_STUB/pgrep"
+
+  export PATH="$BIN_STUB:$PATH"
+}
+
+cleanup() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX" || true; unset SANDBOX REPO_FAKE ENV_DUMP BIN_STUB HOME; }
+
+PROVIDER="https://prov.example.com"
+
+# 1. provider set + token in env → provider env reaches claude; the
+#    SUTANDO_CORE_MODEL pin does NOT become a --model flag (provider owns the model).
+test_provider_with_token() {
+  setup_sandbox "$PROVIDER"
+  ANTHROPIC_AUTH_TOKEN="prov-tok" SUTANDO_CORE_MODEL="opus" \
+    bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null >/dev/null 2>&1
+  local rc=$?
+  [ "$rc" = "0" ] || { echo "  FAIL: start-cli exit $rc (expected 0)"; cleanup; return 1; }
+  [ -f "$ENV_DUMP" ] || { echo "  FAIL: claude stub never ran"; cleanup; return 1; }
+  grep -q "^BASE_URL=$PROVIDER$" "$ENV_DUMP" || { echo "  FAIL: ANTHROPIC_BASE_URL not exported"; cat "$ENV_DUMP"; cleanup; return 1; }
+  grep -q "^MODEL=prov-model-7$" "$ENV_DUMP" || { echo "  FAIL: ANTHROPIC_MODEL not exported"; cat "$ENV_DUMP"; cleanup; return 1; }
+  grep -q "^TOKEN=prov-tok$" "$ENV_DUMP" || { echo "  FAIL: token not exported"; cleanup; return 1; }
+  if grep -q "^ARGV=.*--model opus" "$ENV_DUMP"; then
+    echo "  FAIL: --model opus leaked into provider-mode launch"; cat "$ENV_DUMP"; cleanup; return 1
+  fi
+  # sanity: it really is the interactive core launch
+  grep -q "^ARGV=.*--name sutando-core" "$ENV_DUMP" || { echo "  FAIL: not the interactive core launch"; cleanup; return 1; }
+  cleanup; return 0
+}
+
+# 1b. provider set + ANTHROPIC_BASE_URL pre-set to the credential proxy (as
+#     src/startup.sh does) → the config provider MUST win, not the proxy.
+test_provider_sheds_proxy_base_url() {
+  setup_sandbox "$PROVIDER"
+  ANTHROPIC_AUTH_TOKEN="prov-tok" ANTHROPIC_BASE_URL="http://localhost:7846" \
+    bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null >/dev/null 2>&1
+  [ -f "$ENV_DUMP" ] || { echo "  FAIL: claude stub never ran"; cleanup; return 1; }
+  grep -q "^BASE_URL=$PROVIDER$" "$ENV_DUMP" || { echo "  FAIL: proxy base_url leaked (expected provider url)"; cat "$ENV_DUMP"; cleanup; return 1; }
+  cleanup; return 0
+}
+
+# 2. provider set + NO token → refuse to start (exit 1), claude never runs.
+test_provider_no_token_refuses() {
+  setup_sandbox "$PROVIDER"
+  # scrub any inherited token
+  unset ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY
+  bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null >"$SANDBOX/log" 2>&1
+  local rc=$?
+  [ "$rc" != "0" ] || { echo "  FAIL: start-cli exit 0 (expected non-zero refusal)"; cleanup; return 1; }
+  [ ! -f "$ENV_DUMP" ] || { echo "  FAIL: claude ran despite missing token"; cleanup; return 1; }
+  grep -qi "refusing to start core" "$SANDBOX/log" || { echo "  FAIL: no refusal message"; cat "$SANDBOX/log"; cleanup; return 1; }
+  cleanup; return 0
+}
+
+# 2b. provider set + auth_env=ANTHROPIC_SUBSCRIPTION → contradictory (a provider
+#     needs a token) → refuse to start, even if a token is present in the env.
+test_provider_subscription_auth_refuses() {
+  setup_sandbox "$PROVIDER" "ANTHROPIC_SUBSCRIPTION"
+  ANTHROPIC_AUTH_TOKEN="prov-tok" \
+    bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null >"$SANDBOX/log" 2>&1
+  local rc=$?
+  [ "$rc" != "0" ] || { echo "  FAIL: start-cli exit 0 (expected refusal for provider+subscription auth)"; cleanup; return 1; }
+  [ ! -f "$ENV_DUMP" ] || { echo "  FAIL: claude ran despite provider+subscription misconfig"; cleanup; return 1; }
+  grep -qi "ANTHROPIC_SUBSCRIPTION" "$SANDBOX/log" || { echo "  FAIL: refusal didn't mention the subscription-auth misconfig"; cat "$SANDBOX/log"; cleanup; return 1; }
+  cleanup; return 0
+}
+
+# 3. no provider → subscription path unchanged: no provider env, and the
+#    SUTANDO_CORE_MODEL pin IS honored as --model. A stray token in the env must
+#    NOT be exported into the subscription launch.
+test_no_provider_subscription_unchanged() {
+  setup_sandbox ""
+  ANTHROPIC_AUTH_TOKEN="stray-tok" SUTANDO_CORE_MODEL="opus" \
+    bash "$REPO_FAKE/src/agent/claude/cli/start-cli.sh" </dev/null >/dev/null 2>&1
+  local rc=$?
+  [ "$rc" = "0" ] || { echo "  FAIL: start-cli exit $rc (expected 0)"; cleanup; return 1; }
+  [ -f "$ENV_DUMP" ] || { echo "  FAIL: claude stub never ran"; cleanup; return 1; }
+  grep -q "^BASE_URL=$" "$ENV_DUMP" || { echo "  FAIL: ANTHROPIC_BASE_URL set when no provider"; cat "$ENV_DUMP"; cleanup; return 1; }
+  grep -q "^ARGV=.*--model opus" "$ENV_DUMP" || { echo "  FAIL: --model opus missing on subscription path"; cat "$ENV_DUMP"; cleanup; return 1; }
+  cleanup; return 0
+}
+
+# 4. Source-tied guard — start-cli.sh actually wires the provider branch + helper.
+test_source_guard() {
+  local s="$REAL_REPO/src/agent/claude/cli/start-cli.sh"
+  grep -qF 'core-config' "$s" || { echo "  FAIL: start-cli.sh no longer reads the core-config getter"; return 1; }
+  grep -qF 'provider-env.sh' "$s" || { echo "  FAIL: start-cli.sh no longer sources provider-env.sh"; return 1; }
+  grep -qF 'claude_provider_export_env' "$s" || { echo "  FAIL: start-cli.sh no longer calls claude_provider_export_env"; return 1; }
+  [ -f "$REAL_REPO/src/agent/claude/provider-env.sh" ] || { echo "  FAIL: provider-env.sh missing"; return 1; }
+  return 0
+}
+
+echo "tests/start-cli-provider-as-core.test.sh — running"
+echo
+run_test "1. provider + token → provider env, no model pin" test_provider_with_token
+run_test "1b. provider set sheds inherited proxy base_url"  test_provider_sheds_proxy_base_url
+run_test "2. provider + no token → refuse to start"         test_provider_no_token_refuses
+run_test "2b. provider + subscription auth → refuse"        test_provider_subscription_auth_refuses
+run_test "3. no provider → subscription path unchanged"     test_no_provider_subscription_unchanged
+run_test "4. source-tied guard: provider branch present"    test_source_guard
+echo
+echo "----------------------------------------"
+echo "PASSED: $PASS"
+echo "FAILED: $FAIL"
+[ "$FAIL" -gt 0 ] && exit 1
+exit 0

--- a/tests/startup-shell-setup-wireup.test.sh
+++ b/tests/startup-shell-setup-wireup.test.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Tests for the src/startup.sh wire-up of scripts/sutando-shell-setup.sh
+# Tests for the src/startup.sh wire-up of src/agent/claude/cli/sutando-shell-setup.sh
 #
-# The wire-up is intentionally minimal (3 lines, src/startup.sh:210-212):
+# The wire-up is intentionally minimal (3 lines in src/startup.sh):
 #
-#   if [ -x "$REPO/scripts/sutando-shell-setup.sh" ]; then
-#     bash "$REPO/scripts/sutando-shell-setup.sh" --auto || true
+#   if [ -x "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" ]; then
+#     bash "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" --auto || true
 #   fi
 #
 # These tests cover three branches:
@@ -43,25 +43,25 @@ run_test() {
 make_driver_with_stub_helper() {
   local exit_code="$1"      # exit code the stub helper should return ('absent' to skip creating it)
   TEST_TMP="$(mktemp -d -t startup-shell-setup-wireup.XXXXXX)"
-  mkdir -p "$TEST_TMP/scripts"
+  mkdir -p "$TEST_TMP/src/agent/claude/cli"
 
   if [ "$exit_code" != "absent" ]; then
-    cat > "$TEST_TMP/scripts/sutando-shell-setup.sh" << EOF
+    cat > "$TEST_TMP/src/agent/claude/cli/sutando-shell-setup.sh" << EOF
 #!/usr/bin/env bash
 exit $exit_code
 EOF
-    chmod +x "$TEST_TMP/scripts/sutando-shell-setup.sh"
+    chmod +x "$TEST_TMP/src/agent/claude/cli/sutando-shell-setup.sh"
   fi
 
   cat > "$TEST_TMP/driver.sh" << 'EOF'
 #!/usr/bin/env bash
-# Mirror of src/startup.sh:210-212 wire-up block.
+# Mirror of src/startup.sh's sutando-shell-setup wire-up block.
 REPO="$1"
 SENTINEL="$2"
 
 # This is the exact block from startup.sh — keep these 3 lines in sync.
-if [ -x "$REPO/scripts/sutando-shell-setup.sh" ]; then
-  bash "$REPO/scripts/sutando-shell-setup.sh" --auto || true
+if [ -x "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" ]; then
+  bash "$REPO/src/agent/claude/cli/sutando-shell-setup.sh" --auto || true
 fi
 
 # If startup.sh continues past the wire-up, we'd reach here.

--- a/tests/sutando-migrate-claude-import.test.sh
+++ b/tests/sutando-migrate-claude-import.test.sh
@@ -3,9 +3,10 @@
 # Addresses Lucy's Maddy v0.8 migration report (2026-06-06 #design):
 # sutando-migrate previously set up M2 directories but did NOT copy Claude
 # memory from `~/.claude/projects/<slug>/*` to `<workspace>/.claude-sutando/
-# projects/<slug>/*`. Owner's workaround was to run `bash scripts/
-# sutando-shell-setup.sh --import` manually; now `commit_main` wires that
-# automatically as the final step.
+# projects/<slug>/*`. Owner's workaround was to run the shell-setup script's
+# `--import` manually (now at src/agent/claude/cli/sutando-shell-setup.sh — moved
+# from scripts/ in PR #1891); now `commit_main` wires that automatically as the
+# final step.
 #
 # This test verifies the wiring (flag parsing + call site shape) without
 # requiring a full live --import run (which depends on rsync + actual

--- a/tests/sutando-shell-setup-argparse.test.sh
+++ b/tests/sutando-shell-setup-argparse.test.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
-SETUP="$REPO/scripts/sutando-shell-setup.sh"
+SETUP="$REPO/src/agent/claude/cli/sutando-shell-setup.sh"
 
 pass=0
 fail=0
@@ -274,7 +274,7 @@ for excl in "shell-snapshots/" "history.jsonl" "file-history/"; do
   if printf '%s' "$filters_block" | grep -qF -- "--exclude='$excl'"; then
     assert_pass "exclude '$excl' present in RSYNC_FILTERS"
   else
-    assert_fail "exclude '$excl' missing from RSYNC_FILTERS" "see scripts/sutando-shell-setup.sh"
+    assert_fail "exclude '$excl' missing from RSYNC_FILTERS" "see src/agent/claude/cli/sutando-shell-setup.sh"
   fi
 done
 

--- a/tests/sutando-shell-setup.test.sh
+++ b/tests/sutando-shell-setup.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tests for scripts/sutando-shell-setup.sh
+# Tests for src/agent/claude/cli/sutando-shell-setup.sh
 #
 # Covers: --check (4 states), --commit (4 states), --migrate (2 states),
 # dry-run (default mode). Isolation strategy: each test runs with a fresh
@@ -18,7 +18,7 @@
 set -uo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-HELPER="$REPO/scripts/sutando-shell-setup.sh"
+HELPER="$REPO/src/agent/claude/cli/sutando-shell-setup.sh"
 
 if [ ! -x "$HELPER" ]; then
   echo "FATAL: $HELPER not found or not executable" >&2


### PR DESCRIPTION
> **Stacked on #1891 + #1892.** Until those merge, their commits appear in this diff too — review the **top commit** here. Rebased onto `main` after they land.

## What

Adds a second core implementation — **`core_config.core_type: claude_sdk`** — built on `@anthropic-ai/claude-agent-sdk`: a persistent, fully-observable Claude Code session behind a live browser UI, carrying the **full Sutando runtime** (tasks, crons, proactive loop, heartbeat).

## The session

`sdk/session-server.ts` runs one long-lived `query()` with an **async-iterable prompt** (persistent multi-turn — the stable SDK form of the CLI's `--input/--output-format stream-json`). It loads `CLAUDE.md` + skills (`settingSources` + the `claude_code` `systemPrompt` preset — without these the SDK runs in *isolation mode* with no runtime). Every SDK message streams to the browser over **SSE**; `POST /input` feeds a turn. It **replays event history** to each new SSE client, so a refresh shows the whole session. `ui.html` is a minimal single-file client.

## Hybrid runtime (host + agent)

`CronCreate` / `Monitor` are **not usable in an SDK session** (verified live), so scheduling/watching live in the Node **host**:

- **Task ingestion** — watches `<workspace>/tasks/`; on pickup a task is atomically moved to an in-flight staging dir *before* injection (so the proactive loop's own `tasks/` scan can't double-process it), then archived to `tasks/archive/YYYY-MM/` on result; staged leftovers recovered on restart.
- **`SUTANDO_HOST_OWNS_WATCHER=1`** — `watch-tasks-stream.sh` gains a no-op guard so the agent's own `Monitor` watcher holds its PID but emits nothing (only the host injects).
- **Cron/proactive scheduling** — reads the same `hosts/<host>/crons.json`, matches each 5-field schedule, and injects the cron's prompt (`/proactive-loop` on `*/5`, etc.).
- **Liveness** — per-host `state/cores/<host>.alive` heartbeat + `state/core-status.json`.

## Wiring

- **`src/startup.sh`** routes the core by `core_config.core_type`: `claude_cli` → the tmux core (unchanged default); `claude_sdk` → `session-server.sh` backgrounded (heartbeat deferred to `core_heartbeat.py`), UI opened.
- **`restart.sh` / `stop.sh`** now stop the SDK core too.

## Notes / status

- Auto-approves tools (`permissionMode: 'bypassPermissions'`) — a `canUseTool` UI-approval flow is the natural follow-up.
- Bound to loopback only (no auth; relays full prompts + tool I/O).
- Verified: FAKE-mode host runtime (heartbeat, task lifecycle, cron scheduling), the SDK session spawning + emitting events, and event replay across reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)