### PR TITLE
fix(launchd): credential-proxy exits 127 when node isn't on the plist PATH

### DIFF
--- a/src/launchd/credential-proxy-wrapper.sh
+++ b/src/launchd/credential-proxy-wrapper.sh
@@ -10,6 +10,30 @@
 
 set -euo pipefail
 
+# Ensure `node` is on PATH. npx/tsx are launched by absolute path below, but
+# they re-exec `node` via `#!/usr/bin/env node`, so the node install dir must be
+# on PATH or the job dies with exit 127 ("env: node: No such file or directory").
+# launchd's plist PATH is a fixed guess (often /opt/homebrew/bin on Apple Silicon)
+# and won't match an Intel-Homebrew (/usr/local/bin) or version-manager install —
+# so heal it here rather than depend on the plist being right for every machine.
+#
+# Resolve exactly ONE node dir, first match wins, in the same priority order (and
+# with the same NEWEST-nvm selection) as resolve_npx/resolve_tsx below. The nvm
+# candidate MUST use `sort -V | tail -1`, NOT a `*/bin` glob: glob order is
+# lexicographic, so with prepend-then-continue a box with v9 + v10 would pick v9
+# (`'1' < '9'` sorts v10 first, v9 last-wins) — an older node, not the latest.
+for _node_cand in \
+    /opt/homebrew/bin/node \
+    /usr/local/bin/node \
+    "$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin/node" \
+    "$HOME/.volta/bin/node"
+do
+    [ -x "$_node_cand" ] || continue
+    _node_dir="$(dirname "$_node_cand")"
+    case ":$PATH:" in *":$_node_dir:"*) ;; *) PATH="$_node_dir:$PATH"; export PATH ;; esac
+    break   # first (highest-priority) node wins — don't stack multiple node dirs
+done
+
 # Resolve the credential-proxy script path. Honors $CLAUDE_CONFIG_DIR if the
 # launchd plist exports it (claude-sutando installs); otherwise falls back to
 # ~/.claude. launchd itself doesn't inherit shell env, so this fallback is the


### PR DESCRIPTION
## Closes

Standalone fix — no tracking issue. (Related: #1767 credential-proxy OAuth self-refresh; #1291 / #1086 launchd supervision.)

## Summary

The launchd-supervised credential proxy (`com.sutando.credential-proxy`) exits **127** and never binds `:7846` on machines where `node` isn't in the plist's hardcoded `PATH`.

`credential-proxy-wrapper.sh` resolves `npx`/`tsx` by absolute path, but those re-exec `node` via `#!/usr/bin/env node`, and launchd runs with only the plist's `EnvironmentVariables.PATH` (a fixed `/opt/homebrew/bin:…` guess). On an Intel-Homebrew (`/usr/local/bin`) / nvm / volta install, `env node` → `No such file or directory` → exit **127** → the proxy never binds `:7846` (and KeepAlive's stale-holder eviction also kills any manually-started proxy).

Because the subscription core routes through this proxy (`ANTHROPIC_BASE_URL=http://localhost:7846`) for OAuth injection + token self-refresh (#1767), a dead proxy means every request hits **ConnectionRefused** — the core can't authenticate at all.

Fix: the wrapper prepends the real `node` install dir it finds (checks `/usr/local/bin`, `/opt/homebrew/bin`, nvm, volta) to `PATH` before exec, so the proxy starts regardless of the plist's guess and existing installs self-heal without re-running the installer.

## Test plan

- **Repro:** node at `/usr/local/bin`; `logs/credential-proxy.log` showed repeated `env: node: No such file or directory`, `launchctl list` showed last-exit **127**, nothing listening on `:7846`, core showed `API Error: Unable to connect to API (ConnectionRefused)`.
- **After fix:** `launchctl kickstart -k gui/$(id -u)/com.sutando.credential-proxy` → proxy binds `:7846` (`[Proxy] OAuth token loaded from keychain`), core reconnects, `[Quota]` lines resume (subscription `anthropic-ratelimit-unified-*` headers present), no more ConnectionRefused.
- `bash -n src/launchd/credential-proxy-wrapper.sh` clean; the PATH-resolution loop verified to locate `node` starting from a stripped `PATH=/usr/bin:/bin`.

## Checklist notes

- **Single concern** ✅ — credential-proxy wrapper PATH only. (The subscription-clear that was originally bundled here lives in #1892, where its `core-config` / `provider-env.sh` dependencies also land.)
- Bug confirmed on the running install (exit-127 loop) ✅
- Author email GH-mapped ✅
- **Test: N/A** — launchd/env-shell wiring, verified by the live repro above. Optional follow-up: teach `install-credential-proxy-launchd.sh` to write the correct node dir into the plist so fresh installs don't rely on the wrapper heal.
