### PR TITLE
fix(util-paths): #1826 follow-up — last-ditch fallback still returned dotted ~/.sutando/workspace

### DIFF
--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -86,7 +86,10 @@ def _workspace_root() -> Path:
                     return Path(result.stdout.strip())
         except Exception:
             pass
-        return Path.home() / ".sutando" / "workspace"
+        # Last-ditch default: the canonical post-v0.8 home-dir location
+        # (~/sutando-workspace, matching sutando_config.py resolve_workspace) —
+        # NOT the pre-v0.8 dotted ~/.sutando/workspace, which no longer exists.
+        return Path.home() / "sutando-workspace"
 
 
 def _host_label() -> str:


### PR DESCRIPTION
Post-merge codex audit of #1826 found its ImportError branch still returns the pre-v0.8 dotted ~/.sutando/workspace as the FINAL fallback — inconsistent with the canonical undotted ~/sutando-workspace that sutando_config.py resolve_workspace defaults to (line 351). One line + explanatory comment; the git rev-parse + sutando-config.sh resolution that #1826 added is unchanged and still runs first.

Verified: py_compile clean; workspace-resolution lint passes (util_paths.py is on its allowlist per #1826, and the new value is the canonical form the lint exists to enforce).

Closes the reopened util_paths item in #1906.