### PR TITLE
fix(discord-bridge): #1854 follow-up — DM-fallback source gate fails CLOSED on missing source

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -4281,19 +4281,9 @@ def _task_source(task_id: str):
 
 
 def _dm_fallback_eligible(task_id: str) -> bool:
-    """True iff a `task-` result may be DMed by poll_dm_fallback.
-
-    FAIL-CLOSED (#1854 follow-up, post-merge audit): a missing/unreadable
-    task file or absent `source:` field is NOT eligible. The original
-    fail-open posture ("missing source -> DM it, never silently lose a
-    result") left a leak path: any result whose task file was already
-    swept/unreadable would DM regardless of its true origin. Every current
-    task writer sets `source:`, task files outlive results (processed/ +
-    archive/ are both searched), and a wrongly-skipped result still
-    surfaces via the retention sweep — so closed is the safe default.
-    """
-    src = _task_source(task_id)
-    return src in DM_FALLBACK_SOURCES
+    """FAIL-CLOSED (#1854 follow-up): missing/unreadable source -> NOT
+    DM-eligible; a wrongly-skipped result still surfaces via retention."""
+    return _task_source(task_id) in DM_FALLBACK_SOURCES
 
 
 async def poll_dm_fallback():

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -4280,6 +4280,22 @@ def _task_source(task_id: str):
     return None
 
 
+def _dm_fallback_eligible(task_id: str) -> bool:
+    """True iff a `task-` result may be DMed by poll_dm_fallback.
+
+    FAIL-CLOSED (#1854 follow-up, post-merge audit): a missing/unreadable
+    task file or absent `source:` field is NOT eligible. The original
+    fail-open posture ("missing source -> DM it, never silently lose a
+    result") left a leak path: any result whose task file was already
+    swept/unreadable would DM regardless of its true origin. Every current
+    task writer sets `source:`, task files outlive results (processed/ +
+    archive/ are both searched), and a wrongly-skipped result still
+    surfaces via the retention sweep — so closed is the safe default.
+    """
+    src = _task_source(task_id)
+    return src in DM_FALLBACK_SOURCES
+
+
 async def poll_dm_fallback():
     """Fallback path for task/question/briefing results that no other
     consumer is going to handle.
@@ -4317,14 +4333,10 @@ async def poll_dm_fallback():
                 # it for its own consumer (+ the retention sweep) to drain. The
                 # other FALLBACK_PREFIXES (question-/briefing-/insight-/friction-)
                 # are cron/proactive artifacts with no channel, so they bypass
-                # this gate and stay eligible. A missing source field is treated
-                # as eligible to preserve the original never-silently-lose-a-
-                # result posture; every current task writer sets the field, so
-                # in practice only voice/phone reach the DM path.
-                if task_id.startswith("task-"):
-                    _src = _task_source(task_id)
-                    if _src is not None and _src not in DM_FALLBACK_SOURCES:
-                        continue
+                # this gate and stay eligible. FAIL-CLOSED: a missing/unreadable
+                # source is NOT eligible (see _dm_fallback_eligible).
+                if task_id.startswith("task-") and not _dm_fallback_eligible(task_id):
+                    continue
                 # Grace window so voice-agent / telegram-bridge get first dibs.
                 try:
                     st = f.stat()

--- a/tests/discord-bridge-dm-fallback-source-guard.test.py
+++ b/tests/discord-bridge-dm-fallback-source-guard.test.py
@@ -59,8 +59,9 @@ def _build_helper_namespace(tmpdir: Path, task_files: dict):
 
     const_src = _extract(r"DM_FALLBACK_SOURCES = \{[^}]*\}")
     func_src = _extract(r"def _task_source\(task_id: str\):.*?(?=^\n\n|\Z)")
+    elig_src = _extract(r"def _dm_fallback_eligible\(task_id: str\).*?(?=^\n\n|\Z)")
     ns = {"find_task_file": stub_find_task_file, "TASKS_DIR": tmpdir, "Path": Path}
-    exec(const_src + "\n\n" + func_src, ns)
+    exec(const_src + "\n\n" + func_src + "\n\n" + elig_src, ns)
     return ns
 
 
@@ -80,8 +81,9 @@ def _build_helper_namespace_with_archive(tmpdir: Path, active: dict, archived: d
 
     const_src = _extract(r"DM_FALLBACK_SOURCES = \{[^}]*\}")
     func_src = _extract(r"def _task_source\(task_id: str\):.*?(?=^\n\n|\Z)")
+    elig_src = _extract(r"def _dm_fallback_eligible\(task_id: str\).*?(?=^\n\n|\Z)")
     ns = {"find_task_file": stub_find_task_file, "TASKS_DIR": tmpdir, "Path": Path, "sorted": sorted}
-    exec(const_src + "\n\n" + func_src, ns)
+    exec(const_src + "\n\n" + func_src + "\n\n" + elig_src, ns)
     return ns
 
 
@@ -102,8 +104,9 @@ def test_allowlist_is_positive_voice_phone_only():
 
 def test_gate_is_wired_into_poll_dm_fallback():
     body = _poll_dm_fallback_body()
-    assert "DM_FALLBACK_SOURCES" in body, "fallback must consult the allowlist"
-    assert "_task_source" in body, "fallback must look up the task source"
+    assert "_dm_fallback_eligible" in body, (
+        "fallback must consult the shared eligibility decision"
+    )
     assert 'task_id.startswith("task-")' in body, (
         "gate must scope to task- results so question-/briefing-/insight-/"
         "friction- cron artifacts stay eligible"
@@ -122,10 +125,10 @@ def test_gate_precedes_grace_window():
 # ---------------------------------------------------------------------------
 
 def _eligible(ns, task_id) -> bool:
-    """Replicate the fallback's decision: a task- result is DM-eligible iff
-    its source is None (missing) or in the allowlist."""
-    src = ns["_task_source"](task_id)
-    return src is None or src in ns["DM_FALLBACK_SOURCES"]
+    """Execute the REAL production decision (_dm_fallback_eligible, extracted
+    and exec'd from discord-bridge.py in the namespace) — not a replica, so a
+    regression in the production function fails this test."""
+    return ns["_dm_fallback_eligible"](task_id)
 
 
 def test_voice_result_is_eligible():
@@ -171,18 +174,20 @@ def test_discord_and_telegram_results_are_not_eligible():
         assert _eligible(ns, "task-t") is False
 
 
-def test_missing_source_fails_open_to_eligible():
-    """No source field, or no task file at all → eligible, preserving the
-    original never-silently-lose-a-result posture."""
+def test_missing_source_fails_closed_to_not_eligible():
+    """FAIL-CLOSED (#1854 follow-up): no source field, or no task file at
+    all → NOT eligible. The earlier fail-open posture let a result whose
+    task file was swept/unreadable DM regardless of its true origin —
+    that's the residual leak path the post-merge audit flagged."""
     with tempfile.TemporaryDirectory() as d:
         ns = _build_helper_namespace(Path(d), {
             "task-nosrc": "id: task-nosrc\ntask: legacy\n",
         })
         assert ns["_task_source"]("task-nosrc") is None
-        assert _eligible(ns, "task-nosrc") is True
+        assert _eligible(ns, "task-nosrc") is False
         # missing file entirely
         assert ns["_task_source"]("task-ghost") is None
-        assert _eligible(ns, "task-ghost") is True
+        assert _eligible(ns, "task-ghost") is False
 
 
 def test_source_match_is_case_insensitive():


### PR DESCRIPTION
Why this must change — the residual leak path in #1854:

#1854 gates DM delivery by reading the task file's source: field (only DM-origin tasks may DM). But when the task file is GONE, the source is unreadable, and the old code treated unknown-source as DM-eligible (fail-open). The task file goes missing in real, common timings: (a) the bridge restarts and re-scans results/ after the task file was archived; (b) a long-running task's result lands after the task file was swept. In exactly those messy windows, a web-chat (or any non-DM) result would leak into the owner's Discord DM again — the very bug #1854 fixed, re-entering through the back door.

The fix is one decision flip: unreadable/missing source -> NOT DM-eligible (fail-closed), factored into _dm_fallback_eligible() and wired through poll_dm_fallback. The cost asymmetry justifies closed-by-default: a wrongly-skipped result merely doesn't ping (it still surfaces via the retention sweep and stays in results/); a wrongly-sent one actively pushes wrong content at the owner. Every current task writer sets source:, so the closed default changes nothing on the happy path.

Test updated per the new test standard (pr-triage skill 3.3): the regression test now extracts and EXECUTES the real production function (previously it asserted against an inline replica — a production regression would not have failed it), and the missing-source case asserts fail-closed. 9/9 pass.

Post-merge codex audit finding on #1854; tracked in #1906.
