### PR TITLE
fix(discord-bridge): discord-voice task results become DM-fallback eligible

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -4291,7 +4291,14 @@ async def poll_proactive():
 # owns its own delivery path and must never be echoed here. This is an
 # allowlist, not a denylist: a newly-added source is non-eligible by default
 # and can never leak into DM unless deliberately added.
-DM_FALLBACK_SOURCES = {"voice", "phone"}
+#
+# "discord-voice" added 2026-07-03 (sutando-meeting#54, owner-hit): a voice-
+# delegated task's ONLY primary consumer is the live discord-voice session,
+# and when the bot leaves the VC before the result lands, nothing else ever
+# delivers it — the completed work silently rots until the retention sweep.
+# The session keeps first dibs via the 90s grace window; this fallback fires
+# only when the result is still sitting there after that.
+DM_FALLBACK_SOURCES = {"voice", "phone", "discord-voice"}
 
 
 def _task_source(task_id: str):

--- a/tests/discord-bridge-dm-fallback-source-guard.test.py
+++ b/tests/discord-bridge-dm-fallback-source-guard.test.py
@@ -93,8 +93,13 @@ def _build_helper_namespace_with_archive(tmpdir: Path, active: dict, archived: d
 def test_allowlist_is_positive_voice_phone_only():
     const_src = _extract(r"DM_FALLBACK_SOURCES = \{[^}]*\}")
     assert "voice" in const_src and "phone" in const_src, const_src
+    # sutando-meeting#54: discord-voice results' only primary consumer is the
+    # live session; when it dies first, this fallback is the ONLY delivery.
+    assert "discord-voice" in const_src, (
+        f"discord-voice must be DM-fallback eligible (sutando-meeting#54): {const_src}"
+    )
     # Must NOT be the old denylist of local sources.
-    assert "api" not in const_src and "chat" not in const_src, (
+    assert '"api"' not in const_src and '"chat"' not in const_src, (
         "DM_FALLBACK_SOURCES must be a positive allowlist of channel-less "
         f"sources, not a denylist: {const_src}"
     )


### PR DESCRIPTION
Closes sonichi/sutando-meeting#54.

## Problem (owner-hit 2026-07-03)
A voice-delegated task's only primary consumer is the live discord-voice session. When the bot leaves the VC before the result lands, nothing else ever delivers it: `poll_dm_fallback` skipped these results because `DM_FALLBACK_SOURCES` was `{voice, phone}` while discord-voice tasks declare `source: discord-voice`. The completed work silently rotted until the retention sweep and the task read as dropped (the owner's session bug-summary, board task #93).

## Fix
Add `"discord-voice"` to `DM_FALLBACK_SOURCES`. The live session keeps first dibs via the existing 90s grace window; the fallback fires only when the result is still sitting there after that — exactly the dead-session case. Archive-on-delivery (existing dm-result path) prevents double sends.

## Tests
`tests/discord-bridge-dm-fallback-source-guard.test.py` extended: `discord-voice` must be eligible; denylist assertions tightened to quoted forms. 9/9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)