### PR TITLE
fix(bridges): line-buffer stdout/stderr in discord + slack bridges

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -18,6 +18,16 @@ import sys
 import time
 from pathlib import Path
 
+# startup.sh redirects stdout to a log file, which makes CPython block-buffer
+# it — diagnostic prints without flush=True (e.g. the tier-ownership warnings
+# below) sit invisible in the buffer, and SIGTERM kills the process without
+# flushing, losing them entirely. startup.sh launches this bridge with
+# PYTHONUNBUFFERED=1, but other launchers (health-check --fix restarts, ad-hoc
+# respawns) don't — line-buffer structurally so every print lands in the log
+# as it happens, regardless of launcher. Same fix as telegram-bridge (#1926).
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
+
 # Self-rescue: this bridge HAS to keep running — Discord is the primary channel
 # the owner uses to reach Sutando. If `python3` on $PATH happens to resolve to
 # an interpreter that lacks `discord.py` (e.g. miniconda's python on a Mac that

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -44,6 +44,15 @@ import time
 import urllib.request
 from pathlib import Path
 
+# startup.sh redirects stdout to a log file, which makes CPython block-buffer
+# it — diagnostic prints without flush=True sit invisible in the buffer, and
+# SIGTERM kills the process without flushing, losing them entirely. Unlike
+# discord-bridge, this bridge isn't even launched with PYTHONUNBUFFERED=1 —
+# line-buffer structurally so every print lands in the log as it happens.
+# Same fix as telegram-bridge (#1926).
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from task_priority import default_priority_for_source  # noqa: E402
 


### PR DESCRIPTION
Sibling of #1926, applying the same structural fix to the two remaining bridges launched with `> log 2>&1 &`.

## Why

CPython block-buffers stdout when it's redirected to a file. Any `print()` without `flush=True` sits invisible in the buffer, and SIGTERM kills the process without flushing — the exact mechanism behind the empty logs in both telegram silent-wedge incidents (2026-06-15 TLS, 2026-07-05 stale heartbeat). #1926 fixed telegram-bridge; this PR covers the same shape in the other two bridges:

- **discord-bridge.py** — 40+ prints lack `flush=True`, including the load-bearing tier-ownership warnings (`[tier-ownership] ⚠ …`, discord-bridge.py:607-617) and the token-missing fatal. `startup.sh:861` launches it with `PYTHONUNBUFFERED=1`, but that covers only the startup.sh path — a health-check `--fix` restart (`subprocess.Popen` in #1898) or any ad-hoc respawn doesn't set it. The reconfigure makes log delivery launcher-independent.
- **slack-bridge.py** — 7 unflushed prints and no env guard on any launch path (`startup.sh:887` has no `PYTHONUNBUFFERED`).

Same two-line `sys.stdout/stderr.reconfigure(line_buffering=True)` at import, placed immediately after the stdlib imports, before any code that can print.

## Verification

- `py_compile` clean on both files.
- Existing suites pass against this head (the reconfigure runs at import in every one of these, so the change is exercised): slack-bridge access / allowlist / tier-map (14/14) / task-timeout / orphan-recovery / channel-redirect-guard, discord-bridge access-tier / allowlist / file-markers / prose-marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9E832S1QZiwRdujtdKPs7