### PR TITLE
feat(agent-room-ops): join verb — agent accepts its own pending room invite

### DIFF
--- a/skills/agent-room-ops/SKILL.md
+++ b/skills/agent-room-ops/SKILL.md
@@ -17,6 +17,7 @@ does the privileged Matrix ops + authoritative membership enforcement.
 | `send <room> <path>` | outbound file/image upload | discord outbound `[file:]` |
 | `react <room> <event>` | add an `m.reaction` (ack) | discord `add_reaction` (👀/✅) |
 | `unreact <room> <event>` | remove the agent's reaction | discord remove-on-reply |
+| `join <room>` | accept the agent's own pending invite | discord guild-join on invite |
 
 ```bash
 python3 skills/agent-room-ops/room_ops.py read   '!room:hs' --limit 20 --agent '@a:hs'
@@ -24,7 +25,14 @@ python3 skills/agent-room-ops/room_ops.py fetch  'mxc://hs/abc' --room '!room:hs
 python3 skills/agent-room-ops/room_ops.py send   '!room:hs' /tmp/pic.png --caption 'fig 1' --agent '@a:hs'
 python3 skills/agent-room-ops/room_ops.py react  '!room:hs' '$evt' --ack received --agent '@a:hs'
 python3 skills/agent-room-ops/room_ops.py unreact '!room:hs' '$evt' --ack received --agent '@a:hs'
+python3 skills/agent-room-ops/room_ops.py join   '!room:hs' --agent '@a:hs'
 ```
+
+`join` accepts the agent's **own** pending invite (owner-directed self-accept —
+the counterpart to the box-side invite-supervision auto-join, which only fires
+when the owner joins). Matrix rejects a join without a standing invite for
+invite-only rooms; on success the gateway clears the supervision's pending_join
+record for that agent+room.
 
 Every tool prints a structured JSON result and **exits 0** for any structured
 result (a graceful `ok:false` "no context / no-op" is not a failed task); usage

--- a/skills/agent-room-ops/join.py
+++ b/skills/agent-room-ops/join.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""room-ops · join — accept THIS agent's own pending room invite.
+
+Explicit, owner-directed invite acceptance (`join`) — the self-serve counterpart
+to the box-side invite-supervision auto-join (which only fires when the owner
+joins the room). Until this verb, agents held invites they could never accept:
+room_ops was read/send/react only, so a pending invite 403'd every other op.
+Gateway-only; Matrix itself enforces that a join without a standing invite is
+rejected for invite-only rooms, and the gateway cleans up the supervision's
+pending_join record on success.
+"""
+from __future__ import annotations
+
+import os
+
+from _gateway import (gate_allows, load_gate, gateway, http_json, degrade_reason,
+                    quote, HTTPError, URLError)
+
+
+def _result(ok, *, room_id=None, reason=None):
+    return {"ok": bool(ok), "room_id": room_id, "reason": reason}
+
+
+def join_room(room_id, agent_mxid=None, *, gate=None):
+    agent_mxid = agent_mxid or os.environ.get("AGENT_MXID")
+    if not room_id:
+        return _result(False, room_id=room_id, reason="room_id is required")
+    gate = load_gate() if gate is None else gate
+    if not gate_allows(agent_mxid, room_id, gate):
+        return _result(False, room_id=room_id,
+                       reason=f"client gate denied for {agent_mxid}")
+    base, headers = gateway()
+    if not base:
+        return _result(False, room_id=room_id, reason="no gateway configured")
+    url = f"{base}/v1/rooms/{quote(room_id)}/join"
+    try:
+        http_json("POST", url, headers, {})
+    except HTTPError as e:
+        return _result(False, room_id=room_id, reason=degrade_reason(e.code))
+    except (URLError, TimeoutError) as e:
+        return _result(False, room_id=room_id, reason=f"network error: {e}")
+    return _result(True, room_id=room_id)

--- a/skills/agent-room-ops/room_ops.py
+++ b/skills/agent-room-ops/room_ops.py
@@ -11,6 +11,7 @@ graceful-degrade); this file is the unified CLI that dispatches to them.
     python3 room_ops.py send   <room> <path> [--caption c] [--agent mxid]  # media out
     python3 room_ops.py react  <room> <event_id> (--ack received|working|done|fail | --key 🎉) [--agent mxid]
     python3 room_ops.py unreact <room> <event_id> (--ack … | --key …) [--agent mxid]
+    python3 room_ops.py join   <room> [--agent mxid]                 # accept own invite
 
 Every subcommand prints a structured JSON result and **exits 0** for any
 structured result (a graceful `ok:false` "no context / no-op" is not a failed
@@ -26,6 +27,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 import read as _read       # noqa: E402
 import media as _media     # noqa: E402
 import react as _react     # noqa: E402
+import join as _join       # noqa: E402
 
 
 def _main(argv):
@@ -50,6 +52,10 @@ def _main(argv):
     p.add_argument("--caption", default=None)
     p.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
 
+    p = sub.add_parser("join", help="accept this agent's own pending room invite")
+    p.add_argument("room_id")
+    p.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
+
     for name in ("react", "unreact"):
         p = sub.add_parser(name, help=f"{name} on a room event")
         p.add_argument("room_id")
@@ -66,6 +72,8 @@ def _main(argv):
         res = _media.fetch_media(a.ref, a.agent_mxid, a.room_id)
     elif a.cmd == "send":
         res = _media.send_media(a.room_id, a.path, a.agent_mxid, caption=a.caption)
+    elif a.cmd == "join":
+        res = _join.join_room(a.room_id, a.agent_mxid)
     else:  # react / unreact
         key = a.key or _react.ACK[a.ack]
         fn = _react.react if a.cmd == "react" else _react.unreact

--- a/skills/agent-room-ops/test_room_ops.py
+++ b/skills/agent-room-ops/test_room_ops.py
@@ -15,6 +15,7 @@ import _gateway  # noqa: E402
 import read as rd  # noqa: E402
 import media as md  # noqa: E402
 import react as rc  # noqa: E402
+import join as jn  # noqa: E402
 import room_ops  # noqa: E402
 
 HS = "@agent.a:hs"
@@ -210,6 +211,36 @@ class ReactTests(EnvCase):
             self.assertIn("not a joined member", rc.react(ROOM, EV, "👀", HS, gate=None)["reason"])
 
 
+# ----- join ----- #
+class JoinTests(EnvCase):
+    def test_missing_room(self):
+        self.assertFalse(jn.join_room("", HS)["ok"])
+
+    def test_gate_deny(self):
+        os.environ["RELAY_URL"] = "https://r"
+        self.assertIn("gate denied", jn.join_room(ROOM, HS, gate={})["reason"])
+
+    def test_no_relay(self):
+        self.assertIn("no gateway", jn.join_room(ROOM, HS, gate=None)["reason"])
+
+    def test_join_endpoint(self):
+        os.environ["RELAY_URL"] = "https://r"
+        cap = {}
+        with mock.patch.object(jn, "http_json",
+                               side_effect=lambda m, u, h, p: (cap.update(url=u, payload=p), (200, {}))[1]):
+            res = jn.join_room(ROOM, HS, gate=None)
+        self.assertTrue(res["ok"] and cap["url"].endswith("/join"))
+        self.assertEqual(cap["payload"], {})
+
+    def test_403_degrades(self):
+        # No standing invite for an invite-only room → the gateway 403 degrades
+        # to the structured membership reason, not an exception.
+        os.environ["RELAY_URL"] = "https://r"
+        err = urllib.error.HTTPError("u", 403, "no", {}, None)
+        with mock.patch.object(jn, "http_json", side_effect=err):
+            self.assertIn("not a joined member", jn.join_room(ROOM, HS, gate=None)["reason"])
+
+
 # ----- unified CLI ----- #
 class CliTests(EnvCase):
     def test_read_exits_zero(self):
@@ -229,6 +260,9 @@ class CliTests(EnvCase):
 
     def test_fetch_exits_zero(self):
         self.assertEqual(room_ops._main(["fetch", "mxc://x/y", "--room", ROOM, "--agent", HS]), 0)
+
+    def test_join_exits_zero_on_no_gateway(self):
+        self.assertEqual(room_ops._main(["join", ROOM, "--agent", HS]), 0)
 
 
 class GatewayTokenOnboardingTests(EnvCase):


### PR DESCRIPTION
## Why

An agent holding a room invite had no way to accept it: `room_ops` was read/send/react only, so every op against the invited room returned 403 ("agent not a joined member") until the owner happened to join the room and the invite-supervision auto-join fired. Owner picked the self-serve option: an explicit `join` verb.

## What

- **`join.py`** — new gateway-only client module, mirroring `react.py`: client gate → gateway coords → `POST /v1/rooms/{room}/join` → structured degrade on HTTP error.
- **`room_ops.py`** — `join <room> [--agent mxid]` subcommand in the unified CLI.
- **`SKILL.md`** — tool table row, usage example, and the invite-supervision interaction note (explicit owner-directed accept vs. passive auto-join; gateway clears the `pending_join` record on success).
- **`test_room_ops.py`** — `JoinTests` (missing-room, gate-deny, no-gateway, endpoint shape, 403-degrade) + CLI exit-zero test. Full suite green.

## Server side

The gateway route (`POST /v1/rooms/{room}/join` → `op=join`), AppService masquerade join + `pending_join` cleanup, and broker nio `client.join` branch are deployed gateway-side (live). Matrix itself rejects joins without a standing invite for invite-only rooms — the verb can only accept invites the agent already holds.

## Single concern

Client-skill addition only; no bundled refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)