### PR TITLE
ci(coverage): enforce 95% unit-test coverage on changed Python lines

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,33 @@
+# Coverage.py config for the unit-test coverage gate (scripts/coverage-gate.sh).
+#
+# Scope: the Python code the standalone test suite (tests/**/*.test.py) can
+# meaningfully exercise. Tests themselves, vendored deps, and generated
+# trees are excluded.
+#
+# parallel + sigterm: each test file runs as its own `coverage run` process
+# (they are standalone scripts, not a pytest session); per-run .coverage.*
+# fragments are merged by `coverage combine` in the gate script.
+
+[run]
+parallel = True
+sigterm = True
+source =
+    src
+    scripts
+    skills
+
+omit =
+    tests/*
+    */node_modules/*
+    */.venv/*
+    */venv/*
+    workspace/*
+
+[report]
+# Pragmas for genuinely unreachable / interactive-only branches.
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:
+
+[xml]
+output = coverage.xml

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,65 @@
+name: Coverage Comment
+
+# Posts the Coverage Gate result as a sticky PR comment (created once,
+# updated on every subsequent run — no comment spam).
+#
+# Two-stage pattern: the gate itself runs on `pull_request`, where fork PRs
+# get a read-only GITHUB_TOKEN that cannot comment. This workflow fires on
+# workflow_run in the BASE-repo context with write permission, downloads the
+# summary artifact the gate uploaded, and posts it. It never checks out or
+# executes PR code — it only reads two small artifact files — which is what
+# keeps the write token safe (the reason pull_request_target is avoided).
+#
+# NOTE: workflow_run workflows execute from the default branch's copy of
+# this file, so the comment step activates once this file lands on main.
+
+on:
+  workflow_run:
+    workflows: ["Coverage Gate"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Download summary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-summary
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post / update sticky PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- coverage-gate-comment -->';
+            if (!fs.existsSync('coverage-summary.md') || !fs.existsSync('pr-number.txt')) {
+              core.info('No summary artifact content — nothing to post.');
+              return;
+            }
+            const prNumber = parseInt(fs.readFileSync('pr-number.txt', 'utf8').trim(), 10);
+            if (!Number.isInteger(prNumber)) {
+              core.setFailed(`pr-number.txt did not contain a PR number`);
+              return;
+            }
+            const body = marker + '\n' + fs.readFileSync('coverage-summary.md', 'utf8');
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              core.info(`Updated comment ${existing.id} on #${prNumber}`);
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+              core.info(`Created comment on #${prNumber}`);
+            }

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -1,0 +1,31 @@
+name: Coverage Gate
+
+# Enforce >= 95% unit-test coverage on changed Python lines (diff coverage).
+# The whole-tree number is printed informationally in the job log; the gate
+# itself only judges lines added/changed by the PR, so pre-existing legacy
+# coverage debt never reds an unrelated PR. See docs/testing-coverage.md.
+
+on:
+  pull_request:
+    branches: [main, staging-workspace-revamp]
+
+jobs:
+  coverage-gate:
+    name: diff coverage >= 95% (python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # diff-cover needs the base branch locally to compute changed lines.
+          fetch-depth: 0
+
+      - name: Install coverage tooling + test deps
+        run: python3 -m pip install coverage diff-cover 'detect-secrets>=1.5.0'
+
+      - name: Run coverage gate
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: bash scripts/coverage-gate.sh

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -4,6 +4,12 @@ name: Coverage Gate
 # The whole-tree number is printed informationally in the job log; the gate
 # itself only judges lines added/changed by the PR, so pre-existing legacy
 # coverage debt never reds an unrelated PR. See docs/testing-coverage.md.
+#
+# The gate writes coverage-summary.md and uploads it as an artifact; the
+# companion workflow_run job (.github/workflows/coverage-comment.yml) posts
+# it as a sticky PR comment. Two-stage on purpose: fork PRs run here with a
+# read-only GITHUB_TOKEN, so the comment must be posted by a workflow that
+# runs in the base-repo context WITHOUT checking out PR code.
 
 on:
   pull_request:
@@ -29,3 +35,18 @@ jobs:
         env:
           BASE_REF: origin/${{ github.base_ref }}
         run: bash scripts/coverage-gate.sh
+
+      - name: Stamp PR number for the comment workflow
+        if: always()
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload summary artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-summary
+          path: |
+            coverage-summary.md
+            pr-number.txt
+          if-no-files-found: ignore
+          retention-days: 3

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,10 @@ workspace/*
 !workspace/.gitkeep
 # AG2 onboarding summary — private (invite codes + ids)
 ag2-onboarding.txt
+
+# coverage-gate artifacts (scripts/coverage-gate.sh)
+.coverage
+.coverage.*
+coverage.xml
+diff-cover.md
+coverage-summary.md

--- a/docs/testing-coverage.md
+++ b/docs/testing-coverage.md
@@ -1,0 +1,59 @@
+# Unit-test coverage gate
+
+CI enforces **≥ 95% unit-test coverage on every changed Python line** in a PR
+(`.github/workflows/coverage-gate.yml` → `scripts/coverage-gate.sh`).
+
+## The rule
+
+If your PR adds or modifies executable Python lines, at least 95% of those
+lines must be exercised by the standalone test suite (`tests/**/*.test.py`).
+PRs that touch no Python pass trivially.
+
+Run it locally before pushing:
+
+```bash
+python3 -m pip install coverage diff-cover   # once (venv on Homebrew pythons)
+bash scripts/coverage-gate.sh                # gates your branch vs origin/main
+```
+
+The failure output lists exactly which changed lines are uncovered, per file.
+
+## Why diff coverage, not a global 95% floor
+
+The tree's historical global coverage is far below 95% — there is a large
+legacy surface (bridges with live APIs, GUI automation, launchd installers)
+that predates the test push. A global floor at 95% would red every PR
+immediately and block all merges, punishing whoever shows up next for debt
+they didn't create. The diff gate applies the full 95% bar to **new code
+only**: the number the gate protects can't get worse, every merged PR is
+held to the target, and the global number converges upward with each change
+to legacy files (touch a file → cover your changes).
+
+The whole-tree number is printed in every gate run (job log, "whole-tree
+coverage (informational)") so the trend is visible. Once it approaches the
+target, flip the gate to a global floor by adding a
+`python3 -m coverage report --fail-under=95` step.
+
+## What counts / doesn't count
+
+- **Scope**: `src/`, `scripts/`, `skills/` Python (see `.coveragerc`).
+- **Excluded lines**: `# pragma: no cover` and `if __name__ == "__main__":`
+  blocks. Use the pragma sparingly and only for genuinely untestable
+  branches (interactive prompts, macOS-only GUI calls) — a reviewer should
+  be able to agree at a glance.
+- **Subprocess boundaries**: code exercised only via `subprocess` calls in
+  tests is not traced. Prefer importing the module under test (importlib
+  pattern — see `tests/_helpers/`) so coverage sees it; this also makes
+  tests faster and failures more debuggable.
+- **Other languages**: TypeScript and bash are not yet gated. TS is the
+  natural next step (`c8` around the existing `tsx --test` run + diff-cover
+  on its lcov output); bash has no practical coverage tooling worth the
+  complexity. Tracked as a follow-up.
+
+## Escape hatch
+
+`COVERAGE_GATE_FAIL_UNDER=<n>` overrides the bar locally for
+experimentation. CI always runs the default (95). If a specific PR
+legitimately cannot meet the bar (rare — e.g. a pure launchd-installer
+change), the owner can merge over a red gate; the gate is a required
+conversation, not an unappealable veto.

--- a/docs/testing-coverage.md
+++ b/docs/testing-coverage.md
@@ -34,6 +34,22 @@ coverage (informational)") so the trend is visible. Once it approaches the
 target, flip the gate to a global floor by adding a
 `python3 -m coverage report --fail-under=95` step.
 
+## Where the numbers show up
+
+Every gate run posts a **sticky PR comment** (one comment, updated per push
+— marker `<!-- coverage-gate-comment -->`) with the diff-coverage verdict,
+the whole-tree percentage, and the per-file uncovered-lines table on
+failure. The same content lands in the Actions job summary.
+
+Mechanically this is two workflows: the gate (`coverage-gate.yml`) runs on
+`pull_request` — where fork PRs get a read-only token — and uploads
+`coverage-summary.md` as an artifact; `coverage-comment.yml` fires on
+`workflow_run` in the base-repo context with `pull-requests: write` and
+posts it. It never checks out PR code, which is what keeps the write token
+safe. Note `workflow_run` executes the default branch's copy of the file,
+so the comment half activates once merged to main; until then the numbers
+are in the job summary.
+
 ## What counts / doesn't count
 
 - **Scope**: `src/`, `scripts/`, `skills/` Python (see `.coveragerc`).

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -9,6 +9,9 @@
 #   3. Gates: `diff-cover` compares coverage.xml against the base branch and
 #      FAILS if less than 95% of the added/changed executable Python lines
 #      are exercised by the suite.
+#   4. Writes coverage-summary.md (the numbers + per-file misses) for the PR
+#      comment posted by .github/workflows/coverage-comment.yml, and appends
+#      it to $GITHUB_STEP_SUMMARY when running in Actions.
 #
 # Why diff coverage and not a global floor: the tree's historical global
 # coverage is far below 95% (large untested legacy surface: bridges, GUI
@@ -34,6 +37,24 @@ cd "$REPO_ROOT"
 
 BASE="${BASE_REF:-origin/main}"
 FAIL_UNDER="${COVERAGE_GATE_FAIL_UNDER:-95}"
+SUMMARY="coverage-summary.md"
+
+# publish_summary <verdict-line> [extra-markdown-file]
+# Writes the sticky-comment payload + mirrors it into the Actions job summary.
+publish_summary() {
+    {
+        echo "## Coverage Gate"
+        echo
+        echo "$1"
+        if [ -n "${2:-}" ] && [ -f "${2:-}" ]; then
+            echo
+            cat "$2"
+        fi
+    } > "$SUMMARY"
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        cat "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+    fi
+}
 
 if ! python3 -m coverage --version >/dev/null 2>&1; then
     echo "coverage-gate: coverage.py not importable by python3." >&2
@@ -50,11 +71,13 @@ fi
 # would report 100% anyway; skipping saves the full instrumented suite run.)
 if ! git diff --name-only "$BASE"...HEAD -- '*.py' | grep -q .; then
     echo "coverage-gate: no Python changes vs $BASE — nothing to gate. ✓"
+    publish_summary "✅ **No Python changes** — nothing to gate (bar: ${FAIL_UNDER}% on changed lines)."
     exit 0
 fi
 
 echo "coverage-gate: running Python suite under instrumentation..."
-rm -f .coverage .coverage.* coverage.xml
+rm -f .coverage coverage.xml diff-cover.md
+find . -maxdepth 1 -name '.coverage.*' -delete
 
 failed=0
 while IFS= read -r f; do
@@ -65,6 +88,7 @@ while IFS= read -r f; do
     fi
 done < <(find tests -name '*.test.py' -not -path '*/node_modules/*' | sort)
 if [ "$failed" -ne 0 ]; then
+    publish_summary "❌ **Test suite failed under instrumentation** — coverage not measurable. See the job log."
     echo "coverage-gate: suite must be green before coverage is meaningful." >&2
     exit 1
 fi
@@ -81,4 +105,18 @@ echo "────────────────────────�
 echo
 
 echo "coverage-gate: enforcing ${FAIL_UNDER}% on lines changed vs $BASE"
-diff-cover coverage.xml --compare-branch="$BASE" --fail-under="$FAIL_UNDER"
+gate_rc=0
+diff-cover coverage.xml --compare-branch="$BASE" --fail-under="$FAIL_UNDER" \
+    --markdown-report diff-cover.md || gate_rc=$?
+
+# diff-cover's markdown report carries the per-file table + missing lines;
+# prepend the verdict + tree number so the PR comment answers "what
+# percentage is it" at a glance.
+if [ "$gate_rc" -eq 0 ]; then
+    verdict="✅ **Diff coverage PASSES** the ${FAIL_UNDER}% bar. Whole-tree (informational): **${total}%**."
+else
+    verdict="❌ **Diff coverage BELOW the ${FAIL_UNDER}% bar** — uncovered changed lines listed below. Whole-tree (informational): **${total}%**."
+fi
+publish_summary "$verdict" diff-cover.md
+
+exit "$gate_rc"

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Unit-test coverage gate — enforce >= 95% coverage on CHANGED Python lines.
+#
+# What it does:
+#   1. Runs every standalone Python test (tests/**/*.test.py — same discovery
+#      as ci.yml) under coverage.py instrumentation.
+#   2. Prints the whole-tree coverage report (informational — the visibility
+#      that lets us ratchet the global floor up over time).
+#   3. Gates: `diff-cover` compares coverage.xml against the base branch and
+#      FAILS if less than 95% of the added/changed executable Python lines
+#      are exercised by the suite.
+#
+# Why diff coverage and not a global floor: the tree's historical global
+# coverage is far below 95% (large untested legacy surface: bridges, GUI
+# automation, installers). A global 95% floor would hard-red every PR on
+# day one and block all merges. The diff gate applies the full 95% bar to
+# every line of NEW code, which converges the tree toward the target
+# without freezing development. Flip GLOBAL_FLOOR on once the tree gets
+# there (see docs/testing-coverage.md).
+#
+# Usage:
+#   bash scripts/coverage-gate.sh                 # gate vs origin/main
+#   BASE_REF=<ref> bash scripts/coverage-gate.sh  # gate vs another base
+#   COVERAGE_GATE_FAIL_UNDER=90 bash scripts/coverage-gate.sh  # override bar
+#
+# Deps (dev-only, mirrors detect-secrets handling in ci.yml):
+#   python3 -m pip install coverage diff-cover
+# Locally on PEP-668 (Homebrew) pythons, use a venv and put it on PATH.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+BASE="${BASE_REF:-origin/main}"
+FAIL_UNDER="${COVERAGE_GATE_FAIL_UNDER:-95}"
+
+if ! python3 -m coverage --version >/dev/null 2>&1; then
+    echo "coverage-gate: coverage.py not importable by python3." >&2
+    echo "  Install dev deps: python3 -m pip install coverage diff-cover" >&2
+    exit 2
+fi
+if ! command -v diff-cover >/dev/null 2>&1; then
+    echo "coverage-gate: diff-cover not on PATH." >&2
+    echo "  Install dev deps: python3 -m pip install coverage diff-cover" >&2
+    exit 2
+fi
+
+# Fast path: PRs that touch no Python have no diff to gate. (diff-cover
+# would report 100% anyway; skipping saves the full instrumented suite run.)
+if ! git diff --name-only "$BASE"...HEAD -- '*.py' | grep -q .; then
+    echo "coverage-gate: no Python changes vs $BASE — nothing to gate. ✓"
+    exit 0
+fi
+
+echo "coverage-gate: running Python suite under instrumentation..."
+rm -f .coverage .coverage.* coverage.xml
+
+failed=0
+while IFS= read -r f; do
+    if ! output=$(python3 -m coverage run --rcfile=.coveragerc "$f" 2>&1); then
+        echo "✖ test failed under instrumentation: $f"
+        echo "$output"
+        failed=1
+    fi
+done < <(find tests -name '*.test.py' -not -path '*/node_modules/*' | sort)
+if [ "$failed" -ne 0 ]; then
+    echo "coverage-gate: suite must be green before coverage is meaningful." >&2
+    exit 1
+fi
+
+python3 -m coverage combine --quiet
+python3 -m coverage xml --quiet
+
+echo
+echo "── whole-tree coverage (informational) ─────────────────────────"
+python3 -m coverage report --skip-covered --sort=cover | tail -15
+total="$(python3 -m coverage report --format=total 2>/dev/null || echo '?')"
+echo "TOTAL: ${total}%"
+echo "─────────────────────────────────────────────────────────────────"
+echo
+
+echo "coverage-gate: enforcing ${FAIL_UNDER}% on lines changed vs $BASE"
+diff-cover coverage.xml --compare-branch="$BASE" --fail-under="$FAIL_UNDER"


### PR DESCRIPTION
## What

Owner-requested: enforce a 95% minimum unit-test coverage bar. New CI job **Coverage Gate**: every PR must cover **≥ 95% of the Python lines it adds or changes**, measured by running the full standalone suite (`tests/**/*.test.py`, same discovery as ci.yml) under coverage.py and judging the PR's diff with `diff-cover`. The whole-tree number is printed informationally in every run.

## Why diff coverage instead of a global 95% floor

Measured global coverage today is **31%** (10,570 statements, 7,323 missed) — the legacy surface (bridges with live APIs, GUI automation, launchd installers) predates the test push. A global floor at 95% would hard-red every open PR on day one and block all merges. The diff gate applies the full 95% bar to **all new code**: the protected number can't get worse, every merge converges the tree upward, and nobody gets punished for debt they didn't create. `docs/testing-coverage.md` documents the flip-to-global step for when the tree gets there. (If you want the hard global floor anyway, it's a one-line change — but I'd recommend against shipping that today.)

## Pieces

- `scripts/coverage-gate.sh` — instrumented suite run (parallel-mode per test file, combined), informational tree report, then `diff-cover --fail-under=95` vs base. Fast path: PRs touching no `.py` skip the instrumented run entirely. Runnable locally with the same command CI uses.
- `.coveragerc` — scope `src/ scripts/ skills/`; excludes tests, `__main__` blocks, `pragma: no cover`.
- `.github/workflows/coverage-gate.yml` — PR-triggered, `fetch-depth: 0` (diff-cover needs the base), dev-deps installed inline (same pattern as ci.yml's detect-secrets).
- `docs/testing-coverage.md` — the rule, local usage, pragma policy, the subprocess-boundary caveat (prefer importlib over subprocess in tests so coverage sees the module), TS follow-up note.

## Validation (local, full suite)

- 112-file Python suite runs green under instrumentation.
- Uncovered scratch module → gate **fails** (exit 1) naming the exact missing lines.
- Same module + test → gate **passes** (100% diff coverage).
- No-Python diff → fast-path skip.

## Follow-up (not in this PR)

TypeScript gating: `c8` around the existing `tsx --test` run + diff-cover on lcov output. Bash: no practical coverage tooling — excluded with rationale in docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4cEk3Nzp6kVVowwQaN1J1