### PR TITLE
Enforce 0600 on discord access.json after writes

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2745,6 +2745,7 @@ async def _handle_discord_message(message, force=False):
         }
         access["pending"] = pending
         ACCESS_FILE.write_text(json.dumps(access, indent=2))
+        os.chmod(ACCESS_FILE, 0o600)  # don't inherit umask 644 — file holds owner's Discord user IDs
         await message.channel.send(f"Pairing required. Ask the owner to run:\n`/discord:access pair {code}`")
         print(f"  Pairing requested: @{username} ({sender_id}) code={code}")
         return
@@ -3343,6 +3344,7 @@ def save_to_allowlist(sender_id):
         data.setdefault("allowFrom", []).append(sender_id)
         ACCESS_FILE.parent.mkdir(parents=True, exist_ok=True)
         ACCESS_FILE.write_text(json.dumps(data, indent=2))
+        os.chmod(ACCESS_FILE, 0o600)  # don't inherit umask 644 — file holds owner's Discord user IDs
 
 
 async def poll_approved():


### PR DESCRIPTION
## What

`discord-bridge.py` writes `channels/discord/access.json` in two places — the pairing-code write in `_handle_discord_message` and `save_to_allowlist` — but never chmods it. So on a fresh onboarding (or any rewrite) the file, which holds the owner's Discord user IDs, inherits a world-readable `0644` from umask.

`telegram-bridge.py:305` and `slack-bridge.py:228,297` already `os.chmod(ACCESS_FILE, 0o600)` after every write for exactly this reason. This brings discord in line.

## Change

Add `os.chmod(ACCESS_FILE, 0o600)` after both `ACCESS_FILE.write_text(...)` calls. Two lines, no behavior change beyond the permission bits.

## Verification

- `python3 -m py_compile src/discord-bridge.py` passes.
- Confirmed the gap exists on `upstream/main` (neither write site chmods).
- Matches the exact pattern + comment style used by the telegram/slack bridges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)