### PR TITLE
fix(start-cli): trust tmux session state

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -22,6 +22,11 @@ cd "$REPO"
 TMUX_SOCKET="/tmp/sutando-tmux.sock"
 SESSION="sutando-core"
 
+session_exists() {
+  command -v tmux > /dev/null 2>&1 || return 1
+  tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" > /dev/null 2>&1
+}
+
 # Optional working-directory override for the core `claude` process.
 #   - Unset (upstream default): no override — the core launches from $REPO (the
 #     script's cwd), exactly as before. Zero behavior change for OSS installs.
@@ -237,13 +242,13 @@ fi
 # emit-task. Unsafe: a future agent processing a "restart core" task by
 # exec'ing this script from within sutando-core. Per Mini's #608 review.
 if [ "$1" = "--restart" ]; then
-  if pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1; then
+  if session_exists; then
     echo "Killing existing $SESSION session..."
     tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION" 2>/dev/null || true
     # Poll for actual shutdown — robust on slow machines, faster on fast
     # ones (~1s ceiling) than a fixed sleep.
     for _ in 1 2 3 4 5; do
-      pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1 || break
+      session_exists || break
       sleep 0.2
     done
   fi
@@ -276,7 +281,7 @@ apply_tmux_defaults() {
 
 # Already running — attach if interactive, else exit cleanly. This branch
 # also catches the !--restart path so re-running the script is idempotent.
-if pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1; then
+if session_exists; then
   apply_tmux_defaults
   if [ -t 1 ] && command -v tmux > /dev/null 2>&1; then
     echo "Attaching to existing $SESSION (Ctrl-b d to detach)..."

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -24,7 +24,7 @@ SESSION="sutando-core"
 
 session_exists() {
   command -v tmux > /dev/null 2>&1 || return 1
-  tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" > /dev/null 2>&1
+  tmux -S "$TMUX_SOCKET" has-session -t "=$SESSION" > /dev/null 2>&1
 }
 
 # Optional working-directory override for the core `claude` process.
@@ -244,7 +244,7 @@ fi
 if [ "$1" = "--restart" ]; then
   if session_exists; then
     echo "Killing existing $SESSION session..."
-    tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION" 2>/dev/null || true
+    tmux -S "$TMUX_SOCKET" kill-session -t "=$SESSION" 2>/dev/null || true
     # Poll for actual shutdown — robust on slow machines, faster on fast
     # ones (~1s ceiling) than a fixed sleep.
     for _ in 1 2 3 4 5; do

--- a/tests/start-cli-claude-config-dir.test.sh
+++ b/tests/start-cli-claude-config-dir.test.sh
@@ -49,6 +49,9 @@ setup_sandbox() {
   BIN_STUB="$SANDBOX/bin"
   export HOME="$SANDBOX/home"
   export SUTANDO_WORKSPACE="$SANDBOX/workspace"
+  # Hermetic: parent session's CLAUDE_CONFIG_DIR must not bleed into start-cli's
+  # helper-absent test (it would appear in the env-dump and cause a false FAIL).
+  unset CLAUDE_CONFIG_DIR
 
   mkdir -p "$REPO_FAKE/scripts" "$REPO_FAKE/src" "$REPO_FAKE/src/agent/claude/cli" "$BIN_STUB" \
            "$HOME" "$SUTANDO_WORKSPACE/state"
@@ -61,10 +64,9 @@ exit 0
 EOF
   chmod +x "$BIN_STUB/claude"
 
-  # Stub `pgrep` — start-cli's L34/L48 use pgrep to detect an existing
-  # sutando-core session and short-circuit to "already running". The TEST
-  # runner itself IS a claude process, so real pgrep would match and the
-  # spawn path never runs. Stub returns exit 1 (no matches found).
+  # Stub `pgrep` — kept for forward-compat (some code paths may still call it),
+  # but session detection now goes through `tmux has-session` (see session_exists()
+  # in start-cli.sh). The stub here is a no-op safety net; exit 1 = no match.
   cat > "$BIN_STUB/pgrep" << 'EOF'
 #!/bin/bash
 exit 1
@@ -88,7 +90,10 @@ case "\$1" in
     while [ "\$#" -gt 0 ] && [ "\$1" != "claude" ]; do shift; done
     if [ "\$1" = "claude" ]; then exec "\$@"; fi
     ;;
-  has-session|kill-session|start-server|set-option|bind|attach)
+  has-session)
+    exit 1  # no session exists — lets tests exercise the fresh-spawn path
+    ;;
+  kill-session|start-server|set-option|bind|attach)
     :  # no-op
     ;;
 esac
@@ -108,9 +113,11 @@ EOF
   if [ "$helper_present" = "yes" ]; then
     cp "$REAL_REPO/scripts/sutando-config.sh" "$REPO_FAKE/scripts/"
     cp "$REAL_REPO/src/sutando_config.py" "$REPO_FAKE/src/"
+    # Use absolute path so workspace resolves to $SANDBOX/workspace (the same
+    # dir the mkdir above created), avoiding a mismatch with ${REPO_DIR}/workspace.
     cat > "$REPO_FAKE/sutando.config.json" << EOF
 {
-  "workspace": {"path": "\${REPO_DIR}/workspace"},
+  "workspace": {"path": "$SANDBOX/workspace"},
   "claude_sutando_config_dir": {"subdir": "$helper_subdir"}
 }
 EOF
@@ -173,8 +180,10 @@ test_valid_config_exports_env() {
     echo "  FAIL: CLAUDE_CONFIG_DIR not in claude's env"
     cleanup_sandbox; return 1
   fi
-  # Must point at SUTANDO_WORKSPACE/.claude-sutando.
-  expected="CLAUDE_CONFIG_DIR=$SUTANDO_WORKSPACE/.claude-sutando"
+  # Must point at SANDBOX/workspace/.claude-sutando. Normalize via realpath
+  # because sutando-config.sh resolves the path (macOS /var → /private/var).
+  ws_real="$(python3 -c "import os; print(os.path.realpath('$SANDBOX/workspace'))")"
+  expected="CLAUDE_CONFIG_DIR=${ws_real}/.claude-sutando"
   if [ "$ccd_in_env" != "$expected" ]; then
     echo "  FAIL: CLAUDE_CONFIG_DIR mismatch"
     echo "    expected : $expected"


### PR DESCRIPTION
## Summary
- replace `pgrep -f "claude.*--name.*sutando-core"` with `tmux has-session` for start/restart idempotence
- prevents a stale tmux server command line from making `start-cli.sh` think `sutando-core` is running when there is no attachable tmux session
- **new commit (2026-07-07):** make `tests/start-cli-claude-config-dir.test.sh` hermetic:
  - `has-session` stub now returns exit 1 (no session) so test exercises the fresh-spawn path with the new `session_exists()`
  - `unset CLAUDE_CONFIG_DIR` in `setup_sandbox` to prevent ambient host env leakage
  - absolute `$SANDBOX/workspace` path in `sutando.config.json` instead of `${REPO_DIR}/workspace`
  - expected path normalized via `python3 os.path.realpath` (macOS `/var` → `/private/var`)
  - All 4 test cases pass after patch

## Why
During live debugging, `start-cli.sh` printed `sutando-core already running`, but `tmux -S /tmp/sutando-tmux.sock has-session -t sutando-core` failed. The only match was the tmux server process command line, which still contained the original `new-session ... claude --name sutando-core ...` argv even though the `sutando-core` session was gone.

That state made the desktop Core CLI pane unable to attach or recreate the core cleanly.

## Verification
- `bash -n src/agent/claude/cli/start-cli.sh`
- `git diff --check`
- live repro before patch:
  - `tmux -S /tmp/sutando-tmux.sock has-session -t sutando-core` → `can't find session: sutando-core`
  - `pgrep -af 'claude.*--name.*sutando-core'` matched the tmux server argv
  - `bash src/agent/claude/cli/start-cli.sh` incorrectly reported `sutando-core already running`
- live after patch:
  - `SUTANDO_CLAUDE_WORKING_DIR="$(bash scripts/sutando-config.sh workspace)" bash src/agent/claude/cli/start-cli.sh`
  - output: `Started sutando-core detached`
- test suite: `bash tests/start-cli-claude-config-dir.test.sh` → PASSED: 4, FAILED: 0

Contributes to #1961 (burns `tests/start-cli-claude-config-dir.test.sh` from the allowlist).

**Merge order note:** `tests/start-cli-claude-config-dir.test.sh` is also modified by #1970.
Recommend merging this PR first — the 4 test fixes here are a superset of #1970's 3 fixes
for the same file. After this merges, #1970 rebases cleanly (its test hunks land as no-ops).