### PR TITLE
fix(task-progress): prevent duplicate Discord final replies

### DIFF
--- a/skills/task-progress/SKILL.md
+++ b/skills/task-progress/SKILL.md
@@ -2,11 +2,26 @@
 
 Sends mid-task progress updates to the channel a task came from (Slack, Discord, or Telegram).
 
-## Critical rule — notify BEFORE any work begins
+## Critical rule — if you notify, notify BEFORE any work begins
 
-**Call notify.py as the FIRST action after reading a task — before transcription, web searches,
-code reads, or any other tool call.** The user's first signal that you received their message
-must be the notification, not silence followed by a result minutes later.
+For tasks that need a progress update, **call notify.py as the FIRST action after reading
+the task — before transcription, web searches, code reads, or any other tool call.**
+The user's first signal that you received a long-running task must be the notification,
+not silence followed by a result minutes later.
+
+## Critical rule — progress only, never final answers
+
+`notify.py` is only for short progress/status updates. Do **not** use it to send the
+answer, findings, recommendations, completed list, PR summary, or any other final result.
+Final task delivery must go through the authoritative task result file
+(`results/task-<id>.txt`, or the channel-specific result path named in the task).
+
+Keep notify bodies short: at most 280 characters and 4 non-empty lines. The script
+rejects longer messages so a final answer cannot accidentally be sent directly and
+then duplicated by the bridge when it delivers the result file.
+
+If you already sent the final answer through another approved path, write `[REPLIED]`
+to the task result file so the bridge archives the task without sending a duplicate.
 
 ### Voice message tasks (most common failure case)
 
@@ -26,7 +41,7 @@ Correct order:
 4. Process — if research needed, notify again before starting
 5. Return result
 
-### All other tasks
+### All other long-running tasks
 
 Wrong order:
 1. Read task

--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -20,6 +20,27 @@ import urllib.request
 from pathlib import Path
 
 
+MAX_PROGRESS_CHARS = 280
+MAX_PROGRESS_LINES = 4
+
+
+def _progress_message_error(message: str) -> str | None:
+    """Return a validation error when a notify body looks like a final answer."""
+    stripped = message.strip()
+    if len(stripped) > MAX_PROGRESS_CHARS:
+        return (
+            f"progress update is too long ({len(stripped)} chars; "
+            f"max {MAX_PROGRESS_CHARS})"
+        )
+    line_count = len([line for line in stripped.splitlines() if line.strip()])
+    if line_count > MAX_PROGRESS_LINES:
+        return (
+            f"progress update has too many lines ({line_count}; "
+            f"max {MAX_PROGRESS_LINES})"
+        )
+    return None
+
+
 def _env_file(path: str) -> dict[str, str]:
     """Parse key=value pairs from an .env file. Returns {} on any error."""
     result: dict[str, str] = {}
@@ -126,6 +147,16 @@ def main() -> int:
 
     if not channel:
         print("[task-progress] --channel-id (or --chat-id) is required", file=sys.stderr)
+        return 1
+
+    validation_error = _progress_message_error(message)
+    if validation_error:
+        print(
+            "[task-progress] refusing message: "
+            f"{validation_error}. notify.py is only for short progress updates; "
+            "write final answers to the task result file.",
+            file=sys.stderr,
+        )
         return 1
 
     if source == "slack":

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -42,6 +42,41 @@ class TestTokenResolution(unittest.TestCase):
             self.assertIsInstance(result, str)
 
 
+class TestProgressMessageGuard(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+
+    def test_short_progress_message_allowed(self):
+        self.assertIsNone(
+            self.mod._progress_message_error("On it — checking the PR now.")
+        )
+
+    def test_long_final_answer_rejected(self):
+        message = (
+            "Top options for a personal landing page: Framer for speed, Carrd for "
+            "cost, Astro plus Vercel for full control, and GitHub Pages for zero "
+            "hosting cost. Recommendation: use Framer if you want polish today, "
+            "or Astro plus Vercel if you want a blog and source-controlled content. "
+            "That gives you the best tradeoff between design quality, cost, and "
+            "future flexibility."
+        )
+        error = self.mod._progress_message_error(message)
+        self.assertIsNotNone(error)
+        self.assertIn("too long", error)
+
+    def test_multiline_answer_rejected(self):
+        message = "\n".join([
+            "Options:",
+            "1. Framer",
+            "2. Carrd",
+            "3. Astro",
+            "4. GitHub Pages",
+        ])
+        error = self.mod._progress_message_error(message)
+        self.assertIsNotNone(error)
+        self.assertIn("too many lines", error)
+
+
 class TestSendSlack(unittest.TestCase):
     def setUp(self):
         self.mod = _load()
@@ -152,6 +187,16 @@ class TestCLI(unittest.TestCase):
             capture_output=True, text=True,
         )
         self.assertNotEqual(r.returncode, 0)
+
+    def test_long_message_rejected_before_token_lookup(self):
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT), "--source", "slack",
+             "--channel-id", "D123", "--message", "x" * 281],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("progress update is too long", r.stderr)
+        self.assertNotIn("SLACK_BOT_TOKEN", r.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -76,6 +76,23 @@ class TestProgressMessageGuard(unittest.TestCase):
         self.assertIsNotNone(error)
         self.assertIn("too many lines", error)
 
+    def test_main_rejects_long_message(self):
+        with patch("sys.argv", [
+            "notify.py", "--source", "discord", "--channel-id", "C123",
+            "--message", "x" * 281,
+        ]):
+            rc = self.mod.main()
+        self.assertEqual(rc, 1)
+
+    def test_main_rejects_multiline_message(self):
+        msg = "\n".join(["line1", "line2", "line3", "line4", "line5"])
+        with patch("sys.argv", [
+            "notify.py", "--source", "discord", "--channel-id", "C123",
+            "--message", msg,
+        ]):
+            rc = self.mod.main()
+        self.assertEqual(rc, 1)
+
 
 class TestSendSlack(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## What changed

`task-progress` is now progress-only in both code and instructions:

- `skills/task-progress/scripts/notify.py` rejects notify bodies over 280 chars or over 4 non-empty lines before any token lookup / network send.
- `skills/task-progress/SKILL.md` explicitly says final answers must go through the task result file, and `[REPLIED]` is the escape hatch if a final answer was already delivered elsewhere.
- `tests/task-progress-skill.test.py` covers short progress messages, long final-answer-shaped messages, multi-line answer-shaped messages, and CLI rejection before token lookup.

## Why

Live Discord DMs showed the same owner task being delivered through two outbound paths:

1. The core called `workspace/.claude-sutando/skills/task-progress/scripts/notify.py` with a full answer.
2. The Discord bridge then delivered `results/task-*.txt` for the same task.

Example from live DM history on 2026-07-07:

- `01:04:18` owner asked: "If I want to create a good quality low cost personal landing site..."
- `01:04:42` Rui Bot sent a full answer via `notify.py`.
- `01:04:50` Rui Bot sent the bridge result for `task-1783386258401`.

Same pattern repeated at `01:06:13` / `01:06:35` / `01:06:42` for the Astro vs Vercel question.

This is not a duplicate Discord bridge instance and not duplicate result polling. The bug is that the progress tool could be used as a second final-answer channel.

Related but separate: #1889 handles thread routing / duplicate acknowledgments. This PR handles final-answer misuse of `notify.py`.

## Review first

- `skills/task-progress/scripts/notify.py`
- `skills/task-progress/SKILL.md`
- `tests/task-progress-skill.test.py`

## Verification

Focused tests:

```bash
python3 tests/task-progress-skill.test.py
# Ran 18 tests in 0.200s
# OK
```

Compile check:

```bash
python3 -m py_compile skills/task-progress/scripts/notify.py tests/task-progress-skill.test.py
# OK
```

Live guard check, using the same symlinked skill path the running core uses:

```bash
python3 skills/task-progress/scripts/notify.py --source discord --channel-id 1512996282140987452 --message "$(printf 'x%.0s' {1..281})"
# [task-progress] refusing message: progress update is too long (281 chars; max 280). notify.py is only for short progress updates; write final answers to the task result file.
```

No migration. Rollback is removing the guard and doc clarification.
