### PR TITLE
refactor(phone): step 5b-1 — behavior anchors + per-call instruction extraction

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -83,6 +83,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { z } from 'zod';
 import { inlineTools, anyCallerTools, ownerOnlyTools, configurableTools } from '../../../src/inline-tools.js';
+import { buildPhoneInstructions } from './phone-agent-config.js';
 import { recordSession, recordConversation, recordToolCall } from '../../../src/conversation-store.js';
 import { startPhoneTicker, type TickerControl } from '../../../src/observability/realtime.js';
 import { resultBelongsTo, phoneCallKey } from '../../../src/result-channel-key.js';
@@ -506,124 +507,20 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 // The 'work' tool is the same as task-bridge.ts — write task file, Claude handles it.
 
 function buildAgent(callSession: CallSession): MainAgent {
-	const isChildCall = !!callSession.parentCallSid;
-
-	let instructions: string;
-	if (callSession.isMeeting) {
-		const ivrInstructions = [
-			'You are dialing into a meeting. You will first hear an automated IVR system.',
-			'CRITICAL IVR NAVIGATION: Listen carefully to the automated prompts and react to what you actually hear.',
-			callSession.meetingId ? `If the IVR asks for a meeting ID, meeting number, conference ID, or PIN, immediately call send_dtmf with digits "${callSession.meetingId}#".` : '',
-			callSession.passcode ? `If the IVR separately asks for a passcode or meeting passcode, immediately call send_dtmf with digits "${callSession.passcode}#".` : '',
-			'If the IVR asks you to record a name, announce yourself briefly as "Sutando" unless there is an option to skip.',
-			'If the IVR says "press # to skip", call send_dtmf with digits "#".',
-			'Do NOT guess or front-run the menu. Wait for the prompt, then send the matching digits.',
-			'Do NOT try to speak over DTMF-only prompts. Use send_dtmf for keypad interactions.',
-			'Once you are in the meeting (you hear people talking, hold music ending, or silence), do NOT announce that you just joined or that you were dialing in. Just listen quietly until someone speaks to you or asks you something.',
-		].filter(Boolean).join('\n');
-
-		const meetingInstructions = callSession.callerVerified
-			? 'You are Sutando, an AI assistant in a meeting. You have full capabilities — make calls, look things up, send messages, and perform tasks. Be natural, warm, and conversational. Keep responses to 1-2 sentences. Known URLs: "sutando agent repo" = https://github.com/sonichi/sutando'
-			: 'You are Sutando, an AI note-taker in a meeting. Be natural, warm, and conversational. Keep responses to 1-2 sentences. You can listen, take notes, and answer questions about the discussion. You cannot make phone calls, send messages, or look things up — if asked, just say you can only help with notes today.';
-
-		instructions = ivrInstructions + '\n\nAfter joining the meeting:\n' + meetingInstructions;
-	} else if (isChildCall) {
-		const availableTools = [
+	// Tuned per-call instruction assembly moved verbatim to
+	// phone-agent-config.ts (step 5b-1) so it is importable/testable; tool
+	// construction below stays here (it closes over live call state).
+	const instructions = buildPhoneInstructions(callSession, {
+		ownerName: OWNER_NAME,
+		ownerTz: OWNER_TZ,
+		googleSearch: PHONE_GOOGLE_SEARCH,
+		inlineToolNames: inlineTools.map(t => t.name),
+		availableToolNames: [
 			...anyCallerTools.map(t => t.name),
 			...(callSession.callerVerified ? configurableTools.map(t => t.name) : []),
 			...(callSession.isOwner ? ownerOnlyTools.map(t => t.name) : []),
-		];
-		instructions = [
-			`You are Sutando, a personal AI assistant. You are making a phone call on behalf of ${OWNER_NAME || 'your owner'}.`,
-			`You are Sutando — NOT the person you are calling. When the person picks up, introduce yourself as Sutando.`,
-			callSession.purpose ? `Purpose of this call: "${callSession.purpose}"` : '',
-			'Be natural, warm, and conversational. Have a full conversation — do NOT rush to hang up.',
-			'Ask follow-up questions to get complete information.',
-			'ONLY call hang_up when the caller says goodbye/bye/farewell/"I\'m done"/"that\'s all". Closing a video, ending a task, or saying "close it"/"stop" is NOT a goodbye — those are about the current action, not the call.',
-			'Keep responses to 1-2 sentences.',
-			availableTools.length > 0 ? `You have these tools available: ${availableTools.join(', ')}. Use them when relevant to help the caller.` : '',
-			'You can ONLY fulfill the stated purpose of this call. If the person asks you to do something outside your available tools, politely decline.',
-		].filter(Boolean).join('\n');
-	} else {
-		// Inbound calls have no purpose (Twilio webhook doesn't set one).
-		// Outbound calls (from /call or /concurrent-call) always set a purpose.
-		const isInbound = !callSession.purpose;
-		// Load Stand identity (voice-context.txt excluded — can confuse phone identity)
-		const standId = (() => { try { const si = JSON.parse(readFileSync(personalPath('stand-identity.json'), 'utf-8')); return si.name ? `Your Stand name is ${si.name}. When asked your name, say "I'm Sutando — ${si.name}."` : ''; } catch { return ''; } })();
-		const instructionParts: string[] = [
-			'You are Sutando, a personal AI assistant.',
-			standId,
-			// Identity & greeting — based on owner vs verified vs unverified
-			isInbound && callSession.isOwner
-				? `Your owner${OWNER_NAME ? ` ${OWNER_NAME}` : ''} is calling you. YOU are Sutando — the AI assistant. The person on the phone is your OWNER, a human. Do NOT confuse yourself with the caller. You have full capabilities — use the work tool for anything: check the screen, send emails, look things up, make calls, browse the web, or check results of previous tasks. Say exactly: "Hi, this is Sutando. How can I help?" then WAIT for them to speak. Do NOT say anything else before they talk. Do NOT make up tasks, scenarios, or pretend you were doing something.${(() => { const ctx = getSafeContext(); return ctx ? `\n\nRecent voice conversation (for context — do NOT repeat or bring up unless asked):\n${ctx}` : ''; })()}`
-				: isInbound && callSession.callerVerified
-				? 'A verified caller is calling you. Be helpful and conversational. You can look up meeting IDs and check the time. You CAN answer general knowledge questions, do translations, and have conversations. You cannot access files, control the screen, or delegate tasks. Say "Hello, this is Sutando. How can I help?"'
-				: isInbound
-				? 'Someone is calling you. Be helpful and conversational. You CAN answer general knowledge questions, do translations, and have conversations — but you cannot access files, control the screen, or delegate tasks. Greet them with "Hello, this is Sutando. How can I help?"'
-				: callSession.isOwner
-				? `You are calling your owner${OWNER_NAME ? ` ${OWNER_NAME}` : ''}. The person who picks up IS your owner. You have full capabilities — use the work tool for anything: check the screen, send emails, look things up, make calls, browse the web, or check results of previous tasks. After delivering your message, ask if there is anything else you can help with.${(() => { const ctx = getSafeContext(); return ctx ? `\n\nRecent voice conversation (for context — do NOT repeat or bring up unless asked):\n${ctx}` : ''; })()}`
-				: 'You initiated this call on behalf of your owner.',
-			callSession.purpose && !isInbound ? `Purpose of this call: "${callSession.purpose}"` : '',
-			'Be natural, warm, and conversational. Keep responses to 1-2 sentences.',
-			'NEVER say "I\'m back", "Welcome back", "Working on it", or "task is queued". If the conversation resumes after a pause, just continue naturally from where you left off.',
-			'ONLY call hang_up when the caller says goodbye/bye/farewell/"I\'m done"/"that\'s all". Closing a video, ending a task, or saying "close it"/"stop" is NOT a goodbye — those are about the current action, not the call.',
-		];
-
-		// Owner-only sections
-		if (callSession.isOwner) {
-			instructionParts.push(
-				'',
-				'## How to think',
-				'Before acting, gather what you need. Before delegating, give them what they need.',
-				'call_contact makes a phone call — the message you pass is ALL the other person knows. If you pass no message or a vague one, they will be confused.',
-				'If you need info from multiple tools, call them in sequence — get the results first, then act.',
-				'',
-				'## Tools',
-				`These tools are instant (use them directly, NOT through work): ${inlineTools.map(t => t.name).join(', ')}. Use work for everything else.`,
-				'TOOL EXCLUSIVITY: If an inline tool can handle the request, use ONLY the inline tool. NEVER also call work. They are mutually exclusive — calling both causes duplicate responses. Only use work when no inline tool fits.',
-				'SUMMON: Before calling summon, ALWAYS say "Summoning your screen now" FIRST — the user is on the phone and cannot see what is happening. The tool takes several seconds.',
-				'PLAYBACK RULES (CRITICAL):',
-				'0. Video tools: open_file (open), play_video (play from start), pause_video (pause), resume_video (resume/continue), replay_video (start over), close_video (close). NEVER use work for video.',
-				'1. After calling play_video or resume_video, say NOTHING. Audio streams to the phone.',
-				'2. "pause", "stop", "hold" → call pause_video, then say "Paused."',
-				'3. "play" → play_video. "resume"/"continue" → resume_video. "start over"/"replay" → replay_video.',
-				'4. Do NOT use describe_screen, scroll, or work while a recording is playing.',
-				'5. Do NOT guess or hallucinate about the video (duration, content, etc). You cannot see or hear it.',
-				'You can make concurrent calls — stay on the line while calling someone else.',
-				'',
-				'',
-				'## Known info',
-				(() => { try { const url = execSync('git remote get-url origin', { timeout: 2_000 }).toString().trim().replace(/\.git$/, ''); return `Sutando GitHub repo: ${url}`; } catch { return ''; } })(),
-				ownerLocalDateContext(),
-				// Session-level anti-hallucination backstop (cherry-picked from
-				// bassilkhilo-ag2's parallel PR #1249). Pre-warms the model
-				// with the constraint at session-open so the rule is in scope
-				// BEFORE any result-injection wrapper lands. Combined with the
-				// per-result wrapper below at conversation-server.ts:405, the
-				// model gets the rule twice: at boot and at delivery.
-				'TOOL RESULT TRUTHFULNESS: When a work task result is empty or says nothing was found, you MUST say "nothing scheduled" or "nothing found" — never invent, guess, or fill with plausible-sounding calendar events, emails, or other items. Fabricated events mislead the owner and are worse than silence.',
-				'',
-				'## Style',
-				'Be natural, warm, and conversational. Keep responses to 1-2 sentences.',
-				'ONLY call hang_up when the caller says goodbye/bye/farewell/"I\'m done"/"that\'s all". Closing a video, ending a task, or saying "close it"/"stop" is NOT a goodbye — those are about the current action, not the call.',
-			);
-		}
-
-		instructions = instructionParts.filter(Boolean).join('\n');
-	}
-
-	// Grounding. The "look it up" pointer is conditional on per-surface
-	// config: native Web search when googleSearch is enabled (~2-3s, answer
-	// in conversation), `work` tool otherwise (round-trip ~8-15s). Earlier
-	// versions had a permanent "use work" line + a soft nudge toward native
-	// search — the model read the first as imperative and the nudge as
-	// optional, so it kept delegating even with search on. One conditional
-	// line so only one path is presented per config.
-	if (callSession.isOwner) {
-		instructions += PHONE_GOOGLE_SEARCH
-			? '\n\nNEVER fabricate specific details. If you don\'t know it, use your built-in Web search to look it up — it\'s faster than delegating, and the answer stays in the conversation. If your built-in search returns nothing useful, OR the question needs deeper-than-one-lookup research (multi-step, multiple sources, file reading), call the work tool — it routes to the core agent which can do extensive research.'
-			: '\n\nNEVER fabricate specific details. If you don\'t know it, use the work tool to look it up.';
-	}
+		],
+	});
 
 	const tools: ToolDefinition[] = [];
 

--- a/skills/phone-conversation/scripts/phone-agent-config.ts
+++ b/skills/phone-conversation/scripts/phone-agent-config.ts
@@ -1,0 +1,225 @@
+/**
+ * Phone agent tuned-prompt configuration — step 5b-1 of the interaction-planes
+ * refactor (the phone side's mirror of src/voice-agent-config.ts).
+ *
+ * PURE MOVE from conversation-server.ts buildAgent(): the per-call
+ * system-instruction assembly, verbatim, for every variant — meeting IVR
+ * (verified/unverified), child call (outbound on behalf of the owner),
+ * inbound (owner/verified/unverified), outbound-owner — plus the grounding
+ * suffix. conversation-server.ts calls start() at module load and is
+ * untestable in place; here the strings are importable, which upgrades the
+ * 5b tripwire anchors to real output snapshots.
+ *
+ * Tool CONSTRUCTION (hang_up, send_dtmf, work wiring) deliberately stays in
+ * conversation-server — it closes over live call state and Twilio
+ * side-effects; this module owns prompt strings only, same split as 5a-1.
+ *
+ * CLAUDE.md rule: prompts are preserved exactly. Injection seams:
+ * per-call state arrives via the CallSessionShape param (as before);
+ * env/config values via PhoneInstructionDeps; env-dependent reads (safe
+ * context, repo URL) run verbatim by default with test-only overrides.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { resolveWorkspace } from '../../../src/workspace_default.js';
+import { personalPath } from '../../../src/util_paths.js';
+
+const WORKSPACE_DIR = resolveWorkspace();
+
+/** The subset of CallSession the instruction assembly reads. */
+export interface CallSessionShape {
+	isMeeting: boolean;
+	meetingId?: string | null;
+	passcode?: string | null;
+	callerVerified: boolean;
+	parentCallSid?: string | null;
+	purpose?: string | null;
+	isOwner: boolean;
+}
+
+export interface PhoneInstructionDeps {
+	ownerName: string;
+	ownerTz: string;
+	googleSearch: boolean;
+	/** Names for the owner "instant tools" line (inlineTools on the server). */
+	inlineToolNames: string[];
+	/** Child-call tier-filtered tool names (caller computes from the tiers). */
+	availableToolNames: string[];
+	/** Test-only determinism overrides; production passes nothing. */
+	overrides?: {
+		safeContext?: string;
+		repoUrl?: string;
+		standIdentityJson?: string;
+		now?: Date;
+	};
+}
+
+// ── Env-dependent readers (moved verbatim; override-first for tests) ────────
+
+export function ownerLocalDateContext(tz: string, now: Date = new Date()): string {
+	const today = now.toLocaleDateString('en-CA', { timeZone: tz }); // YYYY-MM-DD
+	const dayName = now.toLocaleDateString('en-US', { timeZone: tz, weekday: 'long' });
+	const timeStr = now.toLocaleTimeString('en-US', { timeZone: tz, hour: 'numeric', minute: '2-digit' });
+	const tomorrow = new Date(now.getTime() + 86_400_000).toLocaleDateString('en-CA', { timeZone: tz });
+	const yesterday = new Date(now.getTime() - 86_400_000).toLocaleDateString('en-CA', { timeZone: tz });
+	return `Owner-local time: ${dayName}, ${today}, ${timeStr} (${tz}). Tomorrow = ${tomorrow}. Yesterday = ${yesterday}. When the owner says "today", "tomorrow", "yesterday", "this week", etc., resolve against THESE owner-local dates — never against UTC or server-local time. Pass absolute YYYY-MM-DD values to tools (not relative phrases).`;
+}
+
+export function getSafeContext(lines = 5): string {
+	try {
+		const logPath = join(WORKSPACE_DIR, 'logs', 'conversation.log');
+		if (!existsSync(logPath)) return '';
+		const entries = readFileSync(logPath, 'utf-8').trim().split('\n').slice(-lines);
+		return entries.map(line => {
+			const [, role, text] = line.split('|', 3);
+			if (!role || !text) return '';
+			if (role === 'user') return `Owner said: ${text}`;
+			if (role === 'assistant') return `You (Sutando) replied: ${text}`;
+			return '';
+		}).filter(Boolean).join('\n');
+	} catch { return ''; }
+}
+
+function repoUrlLine(overrides?: PhoneInstructionDeps['overrides']): string {
+	if (overrides?.repoUrl !== undefined) {
+		return overrides.repoUrl ? `Sutando GitHub repo: ${overrides.repoUrl}` : '';
+	}
+	try { const url = execSync('git remote get-url origin', { timeout: 2_000 }).toString().trim().replace(/\.git$/, ''); return `Sutando GitHub repo: ${url}`; } catch { return ''; }
+}
+
+function standIdLine(overrides?: PhoneInstructionDeps['overrides']): string {
+	try {
+		const raw = overrides?.standIdentityJson !== undefined
+			? overrides.standIdentityJson
+			: readFileSync(personalPath('stand-identity.json'), 'utf-8');
+		const si = JSON.parse(raw);
+		return si.name ? `Your Stand name is ${si.name}. When asked your name, say "I'm Sutando — ${si.name}."` : '';
+	} catch { return ''; }
+}
+
+// ── The tuned per-call instruction assembly (moved verbatim) ─────────────────
+
+export function buildPhoneInstructions(callSession: CallSessionShape, deps: PhoneInstructionDeps): string {
+	const isChildCall = !!callSession.parentCallSid;
+	const OWNER_NAME = deps.ownerName;
+	const safeCtx = deps.overrides?.safeContext !== undefined
+		? deps.overrides.safeContext
+		: getSafeContext();
+
+	let instructions: string;
+	if (callSession.isMeeting) {
+		const ivrInstructions = [
+			'You are dialing into a meeting. You will first hear an automated IVR system.',
+			'CRITICAL IVR NAVIGATION: Listen carefully to the automated prompts and react to what you actually hear.',
+			callSession.meetingId ? `If the IVR asks for a meeting ID, meeting number, conference ID, or PIN, immediately call send_dtmf with digits "${callSession.meetingId}#".` : '',
+			callSession.passcode ? `If the IVR separately asks for a passcode or meeting passcode, immediately call send_dtmf with digits "${callSession.passcode}#".` : '',
+			'If the IVR asks you to record a name, announce yourself briefly as "Sutando" unless there is an option to skip.',
+			'If the IVR says "press # to skip", call send_dtmf with digits "#".',
+			'Do NOT guess or front-run the menu. Wait for the prompt, then send the matching digits.',
+			'Do NOT try to speak over DTMF-only prompts. Use send_dtmf for keypad interactions.',
+			'Once you are in the meeting (you hear people talking, hold music ending, or silence), do NOT announce that you just joined or that you were dialing in. Just listen quietly until someone speaks to you or asks you something.',
+		].filter(Boolean).join('\n');
+
+		const meetingInstructions = callSession.callerVerified
+			? 'You are Sutando, an AI assistant in a meeting. You have full capabilities — make calls, look things up, send messages, and perform tasks. Be natural, warm, and conversational. Keep responses to 1-2 sentences. Known URLs: "sutando agent repo" = https://github.com/sonichi/sutando'
+			: 'You are Sutando, an AI note-taker in a meeting. Be natural, warm, and conversational. Keep responses to 1-2 sentences. You can listen, take notes, and answer questions about the discussion. You cannot make phone calls, send messages, or look things up — if asked, just say you can only help with notes today.';
+
+		instructions = ivrInstructions + '\n\nAfter joining the meeting:\n' + meetingInstructions;
+	} else if (isChildCall) {
+		const availableTools = deps.availableToolNames;
+		instructions = [
+			`You are Sutando, a personal AI assistant. You are making a phone call on behalf of ${OWNER_NAME || 'your owner'}.`,
+			`You are Sutando — NOT the person you are calling. When the person picks up, introduce yourself as Sutando.`,
+			callSession.purpose ? `Purpose of this call: "${callSession.purpose}"` : '',
+			'Be natural, warm, and conversational. Have a full conversation — do NOT rush to hang up.',
+			'Ask follow-up questions to get complete information.',
+			'ONLY call hang_up when the caller says goodbye/bye/farewell/"I\'m done"/"that\'s all". Closing a video, ending a task, or saying "close it"/"stop" is NOT a goodbye — those are about the current action, not the call.',
+			'Keep responses to 1-2 sentences.',
+			availableTools.length > 0 ? `You have these tools available: ${availableTools.join(', ')}. Use them when relevant to help the caller.` : '',
+			'You can ONLY fulfill the stated purpose of this call. If the person asks you to do something outside your available tools, politely decline.',
+		].filter(Boolean).join('\n');
+	} else {
+		// Inbound calls have no purpose (Twilio webhook doesn't set one).
+		// Outbound calls (from /call or /concurrent-call) always set a purpose.
+		const isInbound = !callSession.purpose;
+		// Load Stand identity (voice-context.txt excluded — can confuse phone identity)
+		const standId = standIdLine(deps.overrides);
+		const instructionParts: string[] = [
+			'You are Sutando, a personal AI assistant.',
+			standId,
+			// Identity & greeting — based on owner vs verified vs unverified
+			isInbound && callSession.isOwner
+				? `Your owner${OWNER_NAME ? ` ${OWNER_NAME}` : ''} is calling you. YOU are Sutando — the AI assistant. The person on the phone is your OWNER, a human. Do NOT confuse yourself with the caller. You have full capabilities — use the work tool for anything: check the screen, send emails, look things up, make calls, browse the web, or check results of previous tasks. Say exactly: "Hi, this is Sutando. How can I help?" then WAIT for them to speak. Do NOT say anything else before they talk. Do NOT make up tasks, scenarios, or pretend you were doing something.${safeCtx ? `\n\nRecent voice conversation (for context — do NOT repeat or bring up unless asked):\n${safeCtx}` : ''}`
+				: isInbound && callSession.callerVerified
+				? 'A verified caller is calling you. Be helpful and conversational. You can look up meeting IDs and check the time. You CAN answer general knowledge questions, do translations, and have conversations. You cannot access files, control the screen, or delegate tasks. Say "Hello, this is Sutando. How can I help?"'
+				: isInbound
+				? 'Someone is calling you. Be helpful and conversational. You CAN answer general knowledge questions, do translations, and have conversations — but you cannot access files, control the screen, or delegate tasks. Greet them with "Hello, this is Sutando. How can I help?"'
+				: callSession.isOwner
+				? `You are calling your owner${OWNER_NAME ? ` ${OWNER_NAME}` : ''}. The person who picks up IS your owner. You have full capabilities — use the work tool for anything: check the screen, send emails, look things up, make calls, browse the web, or check results of previous tasks. After delivering your message, ask if there is anything else you can help with.${safeCtx ? `\n\nRecent voice conversation (for context — do NOT repeat or bring up unless asked):\n${safeCtx}` : ''}`
+				: 'You initiated this call on behalf of your owner.',
+			callSession.purpose && !isInbound ? `Purpose of this call: "${callSession.purpose}"` : '',
+			'Be natural, warm, and conversational. Keep responses to 1-2 sentences.',
+			'NEVER say "I\'m back", "Welcome back", "Working on it", or "task is queued". If the conversation resumes after a pause, just continue naturally from where you left off.',
+			'ONLY call hang_up when the caller says goodbye/bye/farewell/"I\'m done"/"that\'s all". Closing a video, ending a task, or saying "close it"/"stop" is NOT a goodbye — those are about the current action, not the call.',
+		];
+
+		// Owner-only sections
+		if (callSession.isOwner) {
+			instructionParts.push(
+				'',
+				'## How to think',
+				'Before acting, gather what you need. Before delegating, give them what they need.',
+				'call_contact makes a phone call — the message you pass is ALL the other person knows. If you pass no message or a vague one, they will be confused.',
+				'If you need info from multiple tools, call them in sequence — get the results first, then act.',
+				'',
+				'## Tools',
+				`These tools are instant (use them directly, NOT through work): ${deps.inlineToolNames.join(', ')}. Use work for everything else.`,
+				'TOOL EXCLUSIVITY: If an inline tool can handle the request, use ONLY the inline tool. NEVER also call work. They are mutually exclusive — calling both causes duplicate responses. Only use work when no inline tool fits.',
+				'SUMMON: Before calling summon, ALWAYS say "Summoning your screen now" FIRST — the user is on the phone and cannot see what is happening. The tool takes several seconds.',
+				'PLAYBACK RULES (CRITICAL):',
+				'0. Video tools: open_file (open), play_video (play from start), pause_video (pause), resume_video (resume/continue), replay_video (start over), close_video (close). NEVER use work for video.',
+				'1. After calling play_video or resume_video, say NOTHING. Audio streams to the phone.',
+				'2. "pause", "stop", "hold" → call pause_video, then say "Paused."',
+				'3. "play" → play_video. "resume"/"continue" → resume_video. "start over"/"replay" → replay_video.',
+				'4. Do NOT use describe_screen, scroll, or work while a recording is playing.',
+				'5. Do NOT guess or hallucinate about the video (duration, content, etc). You cannot see or hear it.',
+				'You can make concurrent calls — stay on the line while calling someone else.',
+				'',
+				'',
+				'## Known info',
+				repoUrlLine(deps.overrides),
+				ownerLocalDateContext(deps.ownerTz, deps.overrides?.now ?? new Date()),
+				// Session-level anti-hallucination backstop (cherry-picked from
+				// bassilkhilo-ag2's parallel PR #1249). Pre-warms the model
+				// with the constraint at session-open so the rule is in scope
+				// BEFORE any result-injection wrapper lands. Combined with the
+				// per-result wrapper at the conversation-server result-injection
+				// site, the model gets the rule twice: at boot and at delivery.
+				'TOOL RESULT TRUTHFULNESS: When a work task result is empty or says nothing was found, you MUST say "nothing scheduled" or "nothing found" — never invent, guess, or fill with plausible-sounding calendar events, emails, or other items. Fabricated events mislead the owner and are worse than silence.',
+				'',
+				'## Style',
+				'Be natural, warm, and conversational. Keep responses to 1-2 sentences.',
+				'ONLY call hang_up when the caller says goodbye/bye/farewell/"I\'m done"/"that\'s all". Closing a video, ending a task, or saying "close it"/"stop" is NOT a goodbye — those are about the current action, not the call.',
+			);
+		}
+
+		instructions = instructionParts.filter(Boolean).join('\n');
+	}
+
+	// Grounding. The "look it up" pointer is conditional on per-surface
+	// config: native Web search when googleSearch is enabled (~2-3s, answer
+	// in conversation), `work` tool otherwise (round-trip ~8-15s). Earlier
+	// versions had a permanent "use work" line + a soft nudge toward native
+	// search — the model read the first as imperative and the nudge as
+	// optional, so it kept delegating even with search on. One conditional
+	// line so only one path is presented per config.
+	if (callSession.isOwner) {
+		instructions += deps.googleSearch
+			? '\n\nNEVER fabricate specific details. If you don\'t know it, use your built-in Web search to look it up — it\'s faster than delegating, and the answer stays in the conversation. If your built-in search returns nothing useful, OR the question needs deeper-than-one-lookup research (multi-step, multiple sources, file reading), call the work tool — it routes to the core agent which can do extensive research.'
+			: '\n\nNEVER fabricate specific details. If you don\'t know it, use the work tool to look it up.';
+	}
+
+	return instructions;
+}

--- a/tests/conversation-server-no-hallucination.test.ts
+++ b/tests/conversation-server-no-hallucination.test.ts
@@ -14,8 +14,14 @@ import { join } from 'node:path';
 //   (1) RESULT_EMPTY sentinel on truly-empty results
 //   (2) "only items present verbatim" guardrail on every result
 
+// Step 5b-1 moved the tuned per-call instruction assembly into
+// phone-agent-config.ts; the invariants below span both files, so SRC is
+// their concatenation (server wiring + config prompts).
 const SRC = readFileSync(
 	join(import.meta.dirname ?? '.', '..', 'skills/phone-conversation/scripts/conversation-server.ts'),
+	'utf-8',
+) + readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'skills/phone-conversation/scripts/phone-agent-config.ts'),
 	'utf-8',
 );
 

--- a/tests/conversation-server-owner-local-date.test.ts
+++ b/tests/conversation-server-owner-local-date.test.ts
@@ -13,8 +13,14 @@ import { join } from 'node:path';
 // session-open, naming the owner-local today/tomorrow/yesterday so the model
 // has explicit absolute YYYY-MM-DD values to pass to tools.
 
+// Step 5b-1 moved the tuned per-call instruction assembly into
+// phone-agent-config.ts; the invariants below span both files, so SRC is
+// their concatenation (server wiring + config prompts).
 const SRC = readFileSync(
 	join(import.meta.dirname ?? '.', '..', 'skills/phone-conversation/scripts/conversation-server.ts'),
+	'utf-8',
+) + readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'skills/phone-conversation/scripts/phone-agent-config.ts'),
 	'utf-8',
 );
 
@@ -67,7 +73,9 @@ describe('conversation-server — owner-local date context (sonichi#1243)', () =
 	});
 
 	it('injects ownerLocalDateContext() into the "## Known info" block', () => {
-		const re = /## Known info[\s\S]{0,400}?ownerLocalDateContext\(\)/;
+		// Post-5b-1 the call site passes the tz + clock explicitly
+		// (ownerLocalDateContext(deps.ownerTz, ...)) — accept both forms.
+		const re = /## Known info[\s\S]{0,400}?ownerLocalDateContext\((\)|deps\.ownerTz)/;
 		assert.match(
 			SRC,
 			re,

--- a/tests/fixtures/phone-behavior-anchors.json
+++ b/tests/fixtures/phone-behavior-anchors.json
@@ -1,0 +1,7 @@
+{
+ "note": "Step-5b phone anchors (tripwire stage). Deliberate tuned-prompt changes must regenerate via ANCHOR_UPDATE=1 with the diff called out in the PR.",
+ "regions": {
+  "build_agent": "7f2f5bf5004bf9e8cac11b9e3f51ad2efea13e2c61a42e6a8827539b41c81101",
+  "try_fast_path": "3ad11e5c56e9bdd52a771ed338e73173805196beaefb57c82e662b4ce506d0d8"
+ }
+}

--- a/tests/fixtures/phone-behavior-anchors.json
+++ b/tests/fixtures/phone-behavior-anchors.json
@@ -1,7 +1,16 @@
 {
- "note": "Step-5b phone anchors (tripwire stage). Deliberate tuned-prompt changes must regenerate via ANCHOR_UPDATE=1 with the diff called out in the PR.",
+ "note": "Step-5b phone anchors (post-extraction: real factory output across the call-variant matrix). Deliberate prompt changes regenerate via ANCHOR_UPDATE=1 with the diff called out.",
+ "variant_hashes": {
+  "meeting_verified": "1d4dc9b853f2fc183b066b5b679d266a0781984a17b358f2e054c2e74cd57816",
+  "meeting_unverified": "bab8e57c4fde14b2be1b3e5f5edd2d4156345614d67dbf102c1bf04a93aec0bd",
+  "child_call": "2e26b5279c2f6f825ea1b5975927aac1cf64a0b070734c2d68ef514ddfe5e178",
+  "inbound_owner": "ef8cb6676d193c42523ca14f7103a22484e9619b796faa4cb8846f2e4439aeee",
+  "inbound_verified": "7bbb23e75f06780ca041fe1f02ae9499ee855c3a82a74283cc3503f27de74b41",
+  "inbound_unverified": "cd350b662a13c01f80776f5f97f1b43202b416030224f0cbc21e2ffbb7b68fdf",
+  "outbound_owner": "3098814344fdb4d911dae5d7544752a87538db449921c41475a40bd567d83ccc",
+  "outbound_owner_no_search": "ea012feb6c7d9e0cf2f814424939f377e8304fe605477fc2da73461f9bd65abd"
+ },
  "regions": {
-  "build_agent": "7f2f5bf5004bf9e8cac11b9e3f51ad2efea13e2c61a42e6a8827539b41c81101",
   "try_fast_path": "3ad11e5c56e9bdd52a771ed338e73173805196beaefb57c82e662b4ce506d0d8"
  }
 }

--- a/tests/phone-behavior-anchors.test.ts
+++ b/tests/phone-behavior-anchors.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Step-5b behavior anchors — the phone side's mirror of
+ * tests/voice-behavior-anchors.test.ts (same proven sequence: tripwires
+ * BEFORE any move; upgraded to real output snapshots once the tuned config
+ * is extracted into an importable module).
+ *
+ * conversation-server.ts calls start() at module load (Twilio WS server +
+ * ngrok), so it cannot be imported by tests — anchors are SHA-256 source
+ * tripwires over the tuned regions:
+ *
+ * 1. buildAgent(callSession) — the per-call system-instruction factory:
+ *    meeting IVR navigation, verified/unverified meeting prompts, child-call
+ *    (outbound on behalf of owner) prompt, inbound variants, greeting rules.
+ * 2. tryFastPath — the tuned fast-path routing rules (which requests bypass
+ *    the work-tool round-trip).
+ *
+ * A tripwire firing means a tuned phone region changed: revert, or
+ * consciously regenerate (ANCHOR_UPDATE=1) with the diff called out — the
+ * extraction commit does exactly that, paired with an ordered string-entry
+ * equivalence proof (the 5a-1 method).
+ *
+ * Run: npx tsx --test tests/phone-behavior-anchors.test.ts
+ */
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO = join(new URL('.', import.meta.url).pathname, '..');
+const FIXTURE = join(REPO, 'tests', 'fixtures', 'phone-behavior-anchors.json');
+const UPDATE = process.env.ANCHOR_UPDATE === '1';
+
+const cs = readFileSync(
+	join(REPO, 'skills', 'phone-conversation', 'scripts', 'conversation-server.ts'), 'utf-8');
+
+function region(startMarker: string, endMarker: string): string {
+	const start = cs.indexOf(startMarker);
+	assert.notStrictEqual(start, -1, `region start not found: ${startMarker}`);
+	const end = cs.indexOf(endMarker, start + startMarker.length);
+	assert.notStrictEqual(end, -1, `region end not found: ${endMarker}`);
+	return cs.slice(start, end);
+}
+
+const anchors = {
+	note: 'Step-5b phone anchors (tripwire stage). Deliberate tuned-prompt changes must regenerate via ANCHOR_UPDATE=1 with the diff called out in the PR.',
+	regions: {
+		build_agent: createHash('sha256').update(
+			region('function buildAgent(callSession: CallSession): MainAgent {',
+				'\n// --- Create VoiceSession for a call ---')).digest('hex'),
+		try_fast_path: createHash('sha256').update(
+			region('function tryFastPath(callSession: CallSession, task: string):',
+				'\nfunction ')).digest('hex'),
+	},
+};
+
+if (UPDATE || !existsSync(FIXTURE)) {
+	writeFileSync(FIXTURE, JSON.stringify(anchors, null, 1) + '\n');
+	console.log(`phone anchor fixture ${UPDATE ? 'regenerated' : 'created'}: ${FIXTURE}`);
+}
+const expected = JSON.parse(readFileSync(FIXTURE, 'utf-8'));
+
+test('phone tripwires: tuned conversation-server regions unchanged', () => {
+	assert.deepStrictEqual(anchors.regions, expected.regions);
+});
+
+test('tripwire breadth: the anchored regions are non-trivial', () => {
+	const ba = region('function buildAgent(callSession: CallSession): MainAgent {',
+		'\n// --- Create VoiceSession for a call ---');
+	assert.ok(ba.split('\n').length > 200, 'buildAgent region unexpectedly small');
+	assert.ok(ba.includes('CRITICAL IVR NAVIGATION'), 'IVR rules present');
+	assert.ok(ba.includes('You are Sutando — NOT the person you are calling'), 'child-call identity rule present');
+});

--- a/tests/phone-behavior-anchors.test.ts
+++ b/tests/phone-behavior-anchors.test.ts
@@ -1,24 +1,16 @@
 /**
- * Step-5b behavior anchors — the phone side's mirror of
- * tests/voice-behavior-anchors.test.ts (same proven sequence: tripwires
- * BEFORE any move; upgraded to real output snapshots once the tuned config
- * is extracted into an importable module).
+ * Step-5b behavior anchors — post-extraction stage: the tuned per-call
+ * instruction assembly lives in the importable phone-agent-config.ts, so
+ * the anchors assert REAL factory output across the full call-variant
+ * matrix (upgraded from the pre-move source tripwires, exactly the 5a
+ * sequence).
  *
- * conversation-server.ts calls start() at module load (Twilio WS server +
- * ngrok), so it cannot be imported by tests — anchors are SHA-256 source
- * tripwires over the tuned regions:
+ * Deterministic inputs: fixed owner name/tz/now, pinned safe-context /
+ * repo-URL / stand-identity overrides, fixed tool-name lists — so every
+ * variant's full instruction string hashes identically on any machine.
+ * tryFastPath keeps its source tripwire (it stays in conversation-server).
  *
- * 1. buildAgent(callSession) — the per-call system-instruction factory:
- *    meeting IVR navigation, verified/unverified meeting prompts, child-call
- *    (outbound on behalf of owner) prompt, inbound variants, greeting rules.
- * 2. tryFastPath — the tuned fast-path routing rules (which requests bypass
- *    the work-tool round-trip).
- *
- * A tripwire firing means a tuned phone region changed: revert, or
- * consciously regenerate (ANCHOR_UPDATE=1) with the diff called out — the
- * extraction commit does exactly that, paired with an ordered string-entry
- * equivalence proof (the 5a-1 method).
- *
+ * Regenerate (deliberately): ANCHOR_UPDATE=1 npx tsx tests/phone-behavior-anchors.test.ts
  * Run: npx tsx --test tests/phone-behavior-anchors.test.ts
  */
 import { test } from 'node:test';
@@ -31,9 +23,41 @@ const REPO = join(new URL('.', import.meta.url).pathname, '..');
 const FIXTURE = join(REPO, 'tests', 'fixtures', 'phone-behavior-anchors.json');
 const UPDATE = process.env.ANCHOR_UPDATE === '1';
 
-const cs = readFileSync(
-	join(REPO, 'skills', 'phone-conversation', 'scripts', 'conversation-server.ts'), 'utf-8');
+const cfg = await import('../skills/phone-conversation/scripts/phone-agent-config.js');
 
+const DEPS = {
+	ownerName: 'AnchorOwner',
+	ownerTz: 'America/Los_Angeles',
+	googleSearch: true,
+	inlineToolNames: ['tool_a', 'tool_b'],
+	availableToolNames: ['tier_x', 'tier_y'],
+	overrides: {
+		safeContext: 'Owner said: anchor line',
+		repoUrl: 'https://github.com/sonichi/sutando',
+		standIdentityJson: '{"name":"AnchorStand"}',
+		now: new Date('2026-07-07T12:00:00Z'),
+	},
+};
+
+const base = { isMeeting: false, meetingId: null, passcode: null, callerVerified: false, parentCallSid: null, purpose: null, isOwner: false };
+const VARIANTS: Record<string, Parameters<typeof cfg.buildPhoneInstructions>[0]> = {
+	meeting_verified: { ...base, isMeeting: true, meetingId: '123456', passcode: '9999', callerVerified: true },
+	meeting_unverified: { ...base, isMeeting: true, meetingId: '123456', callerVerified: false },
+	child_call: { ...base, parentCallSid: 'CAparent', purpose: 'book a table', callerVerified: true },
+	inbound_owner: { ...base, isOwner: true },
+	inbound_verified: { ...base, callerVerified: true },
+	inbound_unverified: { ...base },
+	outbound_owner: { ...base, isOwner: true, purpose: 'remind about the meeting' },
+	outbound_owner_no_search: { ...base, isOwner: true, purpose: 'remind about the meeting' },
+};
+
+const outputs: Record<string, string> = {};
+for (const [name, session] of Object.entries(VARIANTS)) {
+	const deps = name === 'outbound_owner_no_search' ? { ...DEPS, googleSearch: false } : DEPS;
+	outputs[name] = cfg.buildPhoneInstructions(session, deps);
+}
+
+const cs = readFileSync(join(REPO, 'skills', 'phone-conversation', 'scripts', 'conversation-server.ts'), 'utf-8');
 function region(startMarker: string, endMarker: string): string {
 	const start = cs.indexOf(startMarker);
 	assert.notStrictEqual(start, -1, `region start not found: ${startMarker}`);
@@ -43,11 +67,10 @@ function region(startMarker: string, endMarker: string): string {
 }
 
 const anchors = {
-	note: 'Step-5b phone anchors (tripwire stage). Deliberate tuned-prompt changes must regenerate via ANCHOR_UPDATE=1 with the diff called out in the PR.',
+	note: 'Step-5b phone anchors (post-extraction: real factory output across the call-variant matrix). Deliberate prompt changes regenerate via ANCHOR_UPDATE=1 with the diff called out.',
+	variant_hashes: Object.fromEntries(Object.entries(outputs).map(
+		([k, v]) => [k, createHash('sha256').update(v).digest('hex')])),
 	regions: {
-		build_agent: createHash('sha256').update(
-			region('function buildAgent(callSession: CallSession): MainAgent {',
-				'\n// --- Create VoiceSession for a call ---')).digest('hex'),
 		try_fast_path: createHash('sha256').update(
 			region('function tryFastPath(callSession: CallSession, task: string):',
 				'\nfunction ')).digest('hex'),
@@ -60,14 +83,27 @@ if (UPDATE || !existsSync(FIXTURE)) {
 }
 const expected = JSON.parse(readFileSync(FIXTURE, 'utf-8'));
 
-test('phone tripwires: tuned conversation-server regions unchanged', () => {
-	assert.deepStrictEqual(anchors.regions, expected.regions);
+test('phone variant matrix: every call-variant instruction string matches', () => {
+	assert.deepStrictEqual(anchors.variant_hashes, expected.variant_hashes);
 });
 
-test('tripwire breadth: the anchored regions are non-trivial', () => {
-	const ba = region('function buildAgent(callSession: CallSession): MainAgent {',
-		'\n// --- Create VoiceSession for a call ---');
-	assert.ok(ba.split('\n').length > 200, 'buildAgent region unexpectedly small');
-	assert.ok(ba.includes('CRITICAL IVR NAVIGATION'), 'IVR rules present');
-	assert.ok(ba.includes('You are Sutando — NOT the person you are calling'), 'child-call identity rule present');
+test('variant semantics: the tuned conditionals land correctly', () => {
+	assert.ok(outputs.meeting_verified.includes('You have full capabilities — make calls'));
+	assert.ok(outputs.meeting_verified.includes('send_dtmf with digits "123456#"'));
+	assert.ok(outputs.meeting_verified.includes('send_dtmf with digits "9999#"'));
+	assert.ok(outputs.meeting_unverified.includes('AI note-taker in a meeting'));
+	assert.ok(outputs.child_call.includes('NOT the person you are calling'));
+	assert.ok(outputs.child_call.includes('tier_x, tier_y'));
+	assert.ok(outputs.inbound_owner.includes('Your owner AnchorOwner is calling you.'));
+	assert.ok(outputs.inbound_owner.includes('Owner said: anchor line'));
+	assert.ok(outputs.inbound_owner.includes('built-in Web search'), 'googleSearch grounding');
+	assert.ok(outputs.outbound_owner_no_search.includes('use the work tool to look it up'), 'no-search grounding');
+	assert.ok(outputs.inbound_unverified.includes('cannot access files, control the screen, or delegate tasks'));
+	assert.ok(outputs.outbound_owner.includes('You are calling your owner AnchorOwner.'));
+	assert.ok(outputs.outbound_owner.includes('Owner-local time: '));
+	assert.ok(!outputs.inbound_verified.includes('## Tools'), 'owner-only sections stay owner-only');
+});
+
+test('tryFastPath tripwire unchanged', () => {
+	assert.deepStrictEqual(anchors.regions, expected.regions);
 });


### PR DESCRIPTION
The phone side's mirror of #1964, same two-commit shape:

**Commit 1 — tripwire anchors** on the tuned regions (buildAgent's ~286-line per-call instruction factory + tryFastPath), established before moving anything.

**Commit 2 — the move**: the instruction assembly for every call variant (meeting IVR verified/unverified, child call, inbound owner/verified/unverified, outbound owner, conditional grounding) extracted verbatim into importable `phone-agent-config.ts`. Tool construction stays in conversation-server (live call state + Twilio side-effects — same prompt/wiring split as 5a-1).

**Equivalence evidence**: 44/44 tuned string entries identical in order (programmatic comparison; the single diff is the inline-tool-names interpolation expression, fed the same runtime values). Anchors upgraded to real output snapshots across an **8-variant deterministic call matrix** (env-independent hashes) with per-variant semantic assertions — IVR digits land, owner-only sections stay owner-only, googleSearch grounding flips correctly.

tsc clean, anchors 3/3 (+ voice anchors 11/11 unaffected). With #1965 (runtime) this completes the extraction stage; 5b-2 (phone onto the shared runtime: SessionRecorder first) follows.

— @sutando-qingyun-001