### PR TITLE
fix(local-task-protocol): relax valid_task_id to match gateway corpus (closes #1960)

### DIFF
--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -96,22 +96,24 @@ KNOWN_HEADER_KEYS = (
 )
 _KNOWN_KEY_SET = frozenset(KNOWN_HEADER_KEYS)
 
-# Task-id shape: `task-<slug>` where slug is dash-separated [a-z0-9] segments
-# (task-1783..., task-chat-1783..., task-phone-..., task-summary-...,
-# task-gh-..., task-health-...). Mirrors the gateway bridge's `_valid_tid`
-# defense: ids become filenames, so the charset is the path-traversal guard.
-TASK_ID_RE = re.compile(r"^task-[A-Za-z0-9][A-Za-z0-9-]{0,120}$")
+# Task-id shape mirrors the gateway bridge's `_valid_tid` exactly:
+# letters, digits, dots, and dashes; max 64 chars; `.` and `..` rejected
+# explicitly. The charset is the path-traversal guard — ids become filenames
+# (`tasks/<id>.txt`, `results/<id>.txt`). NOT restricted to `task-` prefix:
+# real producers also emit `ask-*`, `sc-ask-*`, and `reco-skill-*` ids
+# that `find_archived_task` must be able to look up (issue #1960).
+TASK_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
 
 def valid_task_id(tid: str) -> bool:
     """True iff `tid` is a well-formed task id, safe to embed in a filename.
 
-    Rejects path separators, dots, whitespace, and empty/oversized ids — the
-    id is used as `tasks/<tid>.txt` and `results/<tid>.txt`, so this is the
-    single traversal gate for readers that accept ids from message content
-    (e.g. `[deduped: <tid>]` holders).
+    Rejects path separators, whitespace, empty/oversized ids, and the special
+    dot-names `.` / `..`. Matches the gateway bridge's `_valid_tid` charset
+    exactly so `find_archived_task` accepts every id shape any live producer
+    can emit (`task-*`, `ask-*`, `sc-ask-*`, `reco-skill-*`, …).
     """
-    return bool(TASK_ID_RE.match(tid or ""))
+    return bool(TASK_ID_RE.match(tid or "")) and tid not in (".", "..")
 
 
 # ── Header parsing ───────────────────────────────────────────────────────────

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -102,6 +102,9 @@ _KNOWN_KEY_SET = frozenset(KNOWN_HEADER_KEYS)
 # (`tasks/<id>.txt`, `results/<id>.txt`). NOT restricted to `task-` prefix:
 # real producers also emit `ask-*`, `sc-ask-*`, and `reco-skill-*` ids
 # that `find_archived_task` must be able to look up (issue #1960).
+# Leading `-` is accepted intentionally — mirrors `_valid_tid` and is safe
+# because ids are only used in Path-based operations, never interpolated raw
+# into shell args.
 TASK_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
 

--- a/tests/local-task-protocol.test.py
+++ b/tests/local-task-protocol.test.py
@@ -213,11 +213,14 @@ check("task_body on file with no task: line is empty",
       ltp.task_body("id: t\ntimestamp: ts\n") == "")
 
 # 7. Task-id validation (traversal gate).
+# Accepts any producer prefix — real archive has task-*, ask-*, sc-ask-*,
+# reco-skill-* all coexisting (issue #1960). Charset mirrors gateway _valid_tid.
 for good in ("task-1783377232367", "task-chat-1783379117", "task-phone-1", "task-gh-5",
-             "task-health-1700", "task-summary-1"):
+             "task-health-1700", "task-summary-1",
+             "ask-1783379117", "sc-ask-1234", "reco-skill-9999", "result-1"):
     check(f"id ok: {good}", ltp.valid_task_id(good))
-for bad in ("", "task-", "task-../../etc", "task-a b", "task-a/b", "result-1",
-            "task-" + "x" * 200, "task-.hidden"):
+for bad in ("", ".", "..", "task-../../etc", "task-a b", "task-a/b",
+            "task-" + "x" * 200, "x" * 65, "has/slash", "has\x00null"):
     check(f"id rejected: {bad[:24]!r}", not ltp.valid_task_id(bad))
 
 # 8. Archive rules.
@@ -247,13 +250,18 @@ except Exception:
 if (corpus / "archive").is_dir():
     n = bad = no_id = 0
     infidel = 0
+    vid_rejected = 0  # ids that exist but valid_task_id rejects (#1960)
     for p in ltp.iter_archived_tasks(corpus):
         n += 1
         try:
             text = p.read_text(errors="replace")
             h = ltp.parse_task_headers(text)
-            if not (h.get("id") or ltp.valid_task_id(p.stem.split(".")[-1] if "." in p.stem else p.stem)):
+            stem = p.stem.split(".")[-1] if "." in p.stem else p.stem
+            tid = h.get("id") or stem
+            if not tid:
                 no_id += 1
+            elif not ltp.valid_task_id(tid):
+                vid_rejected += 1
             # Body fidelity (Codex P2): every post-task: line that is NOT a
             # vocabulary header line must survive into the trusted body.
             ht = ltp.parse_task_headers_trusted(text)
@@ -275,6 +283,8 @@ if (corpus / "archive").is_dir():
             bad += 1
     check(f"live corpus: {n} files parse without throwing", bad == 0, f"{bad} threw")
     check(f"live corpus: id recoverable everywhere", no_id == 0, f"{no_id} lacked ids")
+    check(f"live corpus: all archive ids accepted by valid_task_id",
+          vid_rejected == 0, f"{vid_rejected} rejected (ask-*, sc-ask-*, reco-skill-* etc. must pass)")
     check(f"live corpus: trusted-body fidelity (no non-header line lost)",
           infidel == 0, f"{infidel} files lost lines")
 else:


### PR DESCRIPTION
## Problem

`valid_task_id` required a `task-` prefix (`^task-[A-Za-z0-9][A-Za-z0-9-]{0,120}$`), but the live archive contains 79+ task files with ids outside that shape — `ask-*` (voice asks), `sc-ask-*` (screen-companion), `reco-skill-*` (recommender). All are real producers, all accepted by the gateway's `_valid_tid`.

`find_archived_task` calls `valid_task_id` as a gate and returns `None` for anything that fails. Once reader-consolidation switches consumers to `find_archived_task`, those 79+ task ids would start being silently missed.

The `valid_task_id` docstring claimed to "mirror the gateway bridge's `_valid_tid` defense" but the two diverged materially on prefix and length.

Fixes #1960.

## Change

**`src/local_task_protocol.py`** — relax `TASK_ID_RE` from `^task-[A-Za-z0-9][A-Za-z0-9-]{0,120}$` to `^[A-Za-z0-9._-]{1,64}$`, matching the gateway's `_TID_RE` exactly. Add explicit rejection of `.` and `..` (same as gateway). Update comment and docstring.

**`tests/local-task-protocol.test.py`**:
- Add `ask-1783379117`, `sc-ask-1234`, `reco-skill-9999`, `result-1` to the valid-id good list.
- Replace the now-accepted `result-1` / `task-.hidden` bad cases with length-overflow (65 chars) and null-byte cases that remain rejected.
- Add corpus assertion: **"all archive ids accepted by valid_task_id"** — this assertion would have caught the pre-fix divergence automatically, covering the gap flagged in the issue.

## Test results

```
ok  id ok: ask-1783379117
ok  id ok: sc-ask-1234
ok  id ok: reco-skill-9999
ok  id ok: result-1
ok  id rejected: 'xxxxxxxxxxxxxxxxxxxxxxxx'  (65 chars)
ok  id rejected: 'has/slash'
ok  id rejected: 'has\x00null'
ok  live corpus: all archive ids accepted by valid_task_id
PASS — local_task_protocol read-side golden tests
```