### PR TITLE
refactor(phone): step 5b-2 — adopt shared SessionRecorder (LiveAgentRuntime unification complete)

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -84,8 +84,9 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { z } from 'zod';
 import { inlineTools, anyCallerTools, ownerOnlyTools, configurableTools } from '../../../src/inline-tools.js';
 import { buildPhoneInstructions } from './phone-agent-config.js';
-import { recordSession, recordConversation, recordToolCall } from '../../../src/conversation-store.js';
-import { startPhoneTicker, type TickerControl } from '../../../src/observability/realtime.js';
+import { recordConversation, recordToolCall } from '../../../src/conversation-store.js';
+import { startPhoneTicker } from '../../../src/observability/realtime.js';
+import { createSessionRecorder, type SessionRecorder } from '../../../src/live-agent-runtime.js';
 import { resultBelongsTo, phoneCallKey } from '../../../src/result-channel-key.js';
 // Lazy vision-session handle. Only loaded if a call ever needs it — keeps the
 // phone-agent boot path free of the vision-tools.ts side-effects on cold start.
@@ -338,11 +339,12 @@ interface CallSession {
 	// provides toolCallId, not toolName. Without this, the play_recording context
 	// reminder (line ~621) checks e.toolName which is undefined and never matches.
 	_toolIdMap?: Map<string, string>;
-	// Observability: per-call metrics (startTime already on CallSession from #209)
-	toolCalls: { name: string; durationMs: number; timestamp: string }[];
-	events: { event: string; timestamp: string }[];
-	// Realtime usage ticker — emits voice+phone seconds incrementally while live.
-	usageTicker?: TickerControl;
+	// Observability: per-call metrics recorder (step 5b-2). Owns the events +
+	// toolCalls arrays and the realtime usage ticker (startPhoneTicker via the
+	// injected factory), and does the idempotent recordSession flush at finalize.
+	// transcript/startTime/pendingTasks stay on the CallSession — they're call
+	// artifacts/lifecycle, not recorder-owned. (startTime already here from #209.)
+	recorder: SessionRecorder;
 	// Per-call channel-scan state (results/<callSid>.task-*.txt pull path).
 	channelScanHandle?: NodeJS.Timeout;
 	// Safety-net against silent unlinkSync failures — `name -> first-seen ms`,
@@ -418,7 +420,7 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 
 	callSession.pendingTasks++;
 	console.log(`${ts()} [Task] delegated: ${taskId} — "${taskDescription}" (pending: ${callSession.pendingTasks})`);
-	callSession.events.push({ event: `task_delegated:${taskDescription.slice(0, 60)}`, timestamp: new Date().toISOString() });
+	callSession.recorder.events.push({ event: `task_delegated:${taskDescription.slice(0, 60)}`, timestamp: new Date().toISOString() });
 
 	const fullTranscript = callSession.transcript.slice(-20)
 		.map(t => `${t.role === 'sutando' ? 'Sutando' : 'Caller'}: ${t.text}`)
@@ -456,7 +458,7 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 			callSession.pendingTasks = Math.max(0, callSession.pendingTasks - 1);
 			const result = readFileSync(resultPath, 'utf-8').trim();
 			console.log(`${ts()} [Task] result for ${taskId} (${Date.now() - startTime}ms): ${result.slice(0, 200)}`);
-			callSession.events.push({ event: `task_result:${taskId}:${Date.now() - startTime}ms`, timestamp: new Date().toISOString() });
+			callSession.recorder.events.push({ event: `task_result:${taskId}:${Date.now() - startTime}ms`, timestamp: new Date().toISOString() });
 			// Archive both the result + task files so phone surfaces match the
 			// task-bridge.ts archiveFile() audit-trail pattern (#1235).
 			archivePhoneFile(resultPath, 'results', taskId);
@@ -710,6 +712,22 @@ async function createCallSession(params: {
 }): Promise<CallSession> {
 	const bodhiPort = nextBodhiPort++;
 
+	// Per-call observability recorder (step 5b-2). The injected factory keeps the
+	// phone usage kind (`phone.call`, with callSid/isOwner/isMeeting) — the
+	// recorder's default would be the voice ticker, which would mis-bill phone
+	// seconds as `voice.session`. toolCallsGetter reads recorder.toolCalls so the
+	// per-tick count matches what finalize records.
+	const recorder = createSessionRecorder('phone', params.callSid, {
+		tickerFactory: (model) => startPhoneTicker({
+			callSid: params.callSid,
+			model,
+			isOwner: params.isOwner,
+			isMeeting: params.isMeeting,
+			toolCallsGetter: () => recorder.toolCalls.length,
+		}),
+	});
+	recorder.events.push({ event: 'call_started', timestamp: new Date().toISOString() });
+
 	const callSession: CallSession = {
 		...params,
 		voiceSession: null as unknown as VoiceSession,
@@ -720,16 +738,11 @@ async function createCallSession(params: {
 		startTime: Date.now(),
 		transcript: [],
 		resultQueue: [],
-		toolCalls: [],
-		events: [{ event: 'call_started', timestamp: new Date().toISOString() }],
-		usageTicker: startPhoneTicker({
-			callSid: params.callSid,
-			model: VOICE_MODEL,
-			isOwner: params.isOwner,
-			isMeeting: params.isMeeting,
-			toolCallsGetter: () => callSession.toolCalls.length,
-		}),
+		recorder,
 	};
+	// Start the usage ticker now (call is live). Matches the pre-5b-2 inline
+	// startPhoneTicker at CallSession creation; recorder.flush() stops it.
+	recorder.startTicker(VOICE_MODEL);
 
 	// Start live transcript file
 	const liveTranscriptPath = `/tmp/sutando-live-transcript-${params.callSid}.txt`;
@@ -770,7 +783,7 @@ async function createCallSession(params: {
 				// Resolve tool name from the map since e.toolName is undefined in onToolResult
 				const toolName = callSession._toolIdMap?.get(e.toolCallId) || 'unknown';
 				console.log(`${ts()} [Tool] result: ${toolName} (${e.status}, ${e.durationMs}ms)`);
-				callSession.toolCalls.push({ name: toolName, durationMs: e.durationMs, timestamp: new Date().toISOString() });
+				callSession.recorder.toolCalls.push({ name: toolName, durationMs: e.durationMs, timestamp: new Date().toISOString() });
 				// tool_result event push removed per #1052 — recordToolCall
 				// below is the canonical write (phone table, kind='tool_call').
 				// Phone tool_call rows must key on callSid (same as recordConversation
@@ -781,7 +794,7 @@ async function createCallSession(params: {
 				// Log REC indicator status for recording tools
 				if (toolName === 'record_screen_with_narration' || toolName === 'screen_record' || toolName === 'open_file') {
 					const hasIndicator = existsSync('/tmp/sutando-rec-indicator.pid');
-					callSession.events.push({ event: `rec_indicator:${hasIndicator ? 'on' : 'off'}`, timestamp: new Date().toISOString() });
+					callSession.recorder.events.push({ event: `rec_indicator:${hasIndicator ? 'on' : 'off'}`, timestamp: new Date().toISOString() });
 				}
 				// After video play/pause, inject context reminder
 				if (['play_video', 'pause_video', 'resume_video', 'replay_video'].includes(toolName)) {
@@ -1012,7 +1025,7 @@ async function createCallSession(params: {
 				continue;
 			}
 			console.log(`${ts()} [ChannelScan] picked up ${name} for ${callSession.callSid} (${body.length}B)`);
-			callSession.events.push({ event: `channel_result:${name}`, timestamp: new Date().toISOString() });
+			callSession.recorder.events.push({ event: `channel_result:${name}`, timestamp: new Date().toISOString() });
 			try {
 				(callSession.voiceSession as any).transport.sendContent(
 					[{ role: 'user', text: `[Channel result]\n${body}\n\nReport this result to the caller now.` }],
@@ -1094,27 +1107,25 @@ function cleanupCall(callSid: string): void {
 	}
 	console.log(`${ts()} [Phone] call finalized: ${callSid}`);
 
-	// Observability: per-call metrics → sqlite (data/conversation.sqlite, #603)
-	session.events.push({ event: 'call_ended', timestamp: new Date().toISOString() });
+	// Observability: per-call metrics → sqlite (data/conversation.sqlite, #603).
+	// recorder.flush() stops the usage ticker (final Twilio+Gemini-Live bucket)
+	// FIRST, then records once (idempotent). Surface-specific columns go via the
+	// extra arg: callSid/caller/isOwner/isMeeting/pendingTasks, plus durationMs and
+	// transcriptLines (from session.startTime/transcript, which live on the
+	// CallSession, not the recorder) and sessionId:null (phone keys rows by callSid,
+	// so session_id stays null as it was pre-5b-2).
+	session.recorder.events.push({ event: 'call_ended', timestamp: new Date().toISOString() });
 	const durationMs = Date.now() - session.startTime;
-	recordSession({
-		source: 'phone',
+	session.recorder.flush({
+		sessionId: null,
 		callSid,
 		caller: session.callerNumber,
 		isOwner: session.isOwner,
 		isMeeting: session.isMeeting,
 		durationMs,
 		transcriptLines: session.transcript.length,
-		toolCount: session.toolCalls.length,
 		pendingTasks: session.pendingTasks,
-		toolCalls: session.toolCalls,
-		events: session.events,
 	});
-
-	// Spine usage: flush the final partial bucket for both Twilio + Gemini-Live
-	// axes. The ticker has been emitting increments every USAGE_TICK_MS while the
-	// call ran; stop() emits the remainder and clears the interval.
-	try { session.usageTicker?.stop(); } catch {}
 
 	// Auto-scan the latest call for issues (async, best effort)
 	try {

--- a/src/live-agent-runtime.ts
+++ b/src/live-agent-runtime.ts
@@ -171,8 +171,12 @@ export interface SessionRecorder {
 	/** Reset per-logical-session state (fresh arrays + start time). */
 	reset(): void;
 	/** Flush metrics once (idempotent) and stop the usage ticker FIRST — a
-	 * leaked ticker must never fire past a flush. */
-	flush(): void;
+	 * leaked ticker must never fire past a flush. `extra` merges surface-specific
+	 * columns into the recordSession payload (phone carries callSid, caller,
+	 * isOwner, isMeeting, pendingTasks and overrides transcriptLines/durationMs/
+	 * sessionId — see conversation-server finalize). Voice calls flush() with no
+	 * args, so its payload is unchanged. */
+	flush(extra?: Record<string, unknown>): void;
 	/** Start (or restart) the realtime usage ticker for a fresh logical
 	 * session. Stops any lingering ticker first. */
 	startTicker(model: string): void;
@@ -181,13 +185,36 @@ export interface SessionRecorder {
 	readonly wasFlushed: boolean;
 }
 
-export function createSessionRecorder(source: string, sessionId: string): SessionRecorder {
+/**
+ * Options for {@link createSessionRecorder}.
+ * `tickerFactory` lets a surface inject its own usage ticker so the recorder
+ * stays surface-agnostic: voice defaults to `startVoiceTicker` (kind
+ * `voice.session`), phone injects `startPhoneTicker` (kind `phone.call`, carries
+ * callSid/isOwner/isMeeting). The recorder owns the ticker's lifecycle either
+ * way (start on startTicker, stop-before-guard on flush).
+ */
+export interface SessionRecorderOptions {
+	tickerFactory?: (model: string) => TickerControl;
+}
+
+export function createSessionRecorder(
+	source: string,
+	sessionId: string,
+	opts: SessionRecorderOptions = {},
+): SessionRecorder {
 	const events: Array<{ event: string; timestamp: string }> = [];
 	const toolCalls: Array<{ name: string; durationMs: number; timestamp: string }> = [];
 	const transcript: Array<{ role: string; text: string }> = [];
 	let sessionStart = Date.now();
 	let metricsWritten = false;
 	let ticker: TickerControl | null = null;
+	// Default (voice) ticker: verbatim to the pre-extraction startVoiceTicker
+	// call. Phone overrides this with a startPhoneTicker factory.
+	const makeTicker = opts.tickerFactory ?? ((model: string) => startVoiceTicker({
+		sessionId,
+		model,
+		toolCallsGetter: () => toolCalls.length,
+	}));
 
 	return {
 		events, toolCalls, transcript,
@@ -197,7 +224,7 @@ export function createSessionRecorder(source: string, sessionId: string): Sessio
 			sessionStart = Date.now();
 			metricsWritten = false;
 		},
-		flush() {
+		flush(extra?: Record<string, unknown>) {
 			// Spine usage: flush the final partial bucket and clear the interval FIRST,
 			// before the metricsWritten guard. stop() is idempotent (ticker→null),
 			// so a double-flush never double-emits — but doing it before the guard means
@@ -207,6 +234,10 @@ export function createSessionRecorder(source: string, sessionId: string): Sessio
 			if (metricsWritten) return;
 			metricsWritten = true;
 			try {
+				// Surface-specific columns (extra) win over the recorder's defaults:
+				// phone overrides sessionId (→null; it keys rows by callSid), plus
+				// transcriptLines/durationMs (its transcript + startTime live on the
+				// CallSession, not this recorder). Voice passes no extra → unchanged.
 				recordSession({
 					source,
 					sessionId,
@@ -215,19 +246,17 @@ export function createSessionRecorder(source: string, sessionId: string): Sessio
 					toolCount: toolCalls.length,
 					toolCalls,
 					events,
+					...extra,
 				});
-				console.log(`${ts()} [Observability] Recorded ${source} session: ${toolCalls.length} tools, ${events.length} events, ${transcript.length} transcript lines (sqlite, #603)`);
+				const loggedTranscriptLines = (extra?.transcriptLines as number | undefined) ?? transcript.length;
+				console.log(`${ts()} [Observability] Recorded ${source} session: ${toolCalls.length} tools, ${events.length} events, ${loggedTranscriptLines} transcript lines (sqlite, #603)`);
 			} catch (err) {
 				console.log(`${ts()} [Observability] Failed to write metrics: ${err}`);
 			}
 		},
 		startTicker(model: string) {
 			ticker?.stop();
-			ticker = startVoiceTicker({
-				sessionId,
-				model,
-				toolCallsGetter: () => toolCalls.length,
-			});
+			ticker = makeTicker(model);
 		},
 	};
 }

--- a/tests/session-recorder.test.ts
+++ b/tests/session-recorder.test.ts
@@ -1,0 +1,127 @@
+// Unit coverage for the generalized SessionRecorder (step 5b-2): the injected
+// ticker factory and the flush(extra) payload merge that let phone share the
+// voice recorder without changing its stored observability shape.
+//
+// Seam: conversation-store honors SUTANDO_CONVERSATION_DB, so we point the
+// recorder at a throwaway sqlite file and read the `sessions` row back. No
+// collector endpoint is set, so the real usage tickers no-op on emit and their
+// 30s interval never fires (flush clears it either way).
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+const DBP = join(mkdtempSync(join(tmpdir(), 'sutando-recorder-')), 'test.sqlite');
+
+type Recorder = import('../src/live-agent-runtime.js').SessionRecorder;
+let createSessionRecorder: (
+	source: string,
+	sessionId: string,
+	opts?: { tickerFactory?: (model: string) => { stop: () => void } },
+) => Recorder;
+
+before(async () => {
+	process.env.SUTANDO_CONVERSATION_DB = DBP;
+	// Import AFTER the env is set — conversation-store reads DB_PATH at module init.
+	({ createSessionRecorder } = await import('../src/live-agent-runtime.js'));
+});
+
+function fakeTicker() {
+	const calls = { started: 0, stopped: 0, models: [] as string[] };
+	const factory = (model: string) => {
+		calls.started++;
+		calls.models.push(model);
+		return { stop: () => { calls.stopped++; } };
+	};
+	return { factory, calls };
+}
+
+function lastRow(where: string) {
+	const db = new DatabaseSync(DBP);
+	const row = db.prepare(`SELECT * FROM sessions WHERE ${where} ORDER BY rowid DESC LIMIT 1`).get() as Record<string, unknown>;
+	db.close();
+	return row;
+}
+
+test('phone flush: injected ticker is used, extra overrides base, row is phone-shaped', () => {
+	const { factory, calls } = fakeTicker();
+	// A real sessionId is passed to the constructor, but phone overrides it to
+	// null in flush() — the row must keep session_id null (phone keys by call_sid).
+	const rec = createSessionRecorder('phone', 'recorder-constructor-sid', { tickerFactory: factory });
+	rec.startTicker('gemini-2.5-flash');
+	assert.equal(calls.started, 1, 'injected factory drove startTicker');
+	assert.deepEqual(calls.models, ['gemini-2.5-flash']);
+
+	rec.events.push({ event: 'call_started', timestamp: new Date().toISOString() });
+	rec.toolCalls.push({ name: 'hang_up', durationMs: 5, timestamp: new Date().toISOString() });
+
+	rec.flush({
+		sessionId: null,
+		callSid: 'CA123',
+		caller: '+15551234567',
+		isOwner: true,
+		isMeeting: false,
+		durationMs: 4200,
+		transcriptLines: 9,
+		pendingTasks: 0,
+	});
+	assert.equal(calls.stopped, 1, 'flush stopped the injected ticker');
+
+	const row = lastRow("call_sid='CA123'");
+	assert.equal(row.source, 'phone');
+	assert.equal(row.session_id, null, 'extra sessionId:null wins over constructor sessionId');
+	assert.equal(row.call_sid, 'CA123');
+	assert.equal(row.caller, '+15551234567');
+	assert.equal(row.is_owner, 1);
+	assert.equal(row.is_meeting, 0);
+	assert.equal(row.duration_ms, 4200);
+	assert.equal(row.transcript_lines, 9, 'transcriptLines from extra, not recorder.transcript (len 0)');
+	assert.equal(row.tool_count, 1, 'tool_count from recorder.toolCalls');
+	assert.equal(row.pending_tasks, 0);
+});
+
+test('flush is idempotent and stops the ticker before the write guard', () => {
+	const { factory, calls } = fakeTicker();
+	const rec = createSessionRecorder('phone', 'sid', { tickerFactory: factory });
+	rec.startTicker('m');
+	rec.flush({ sessionId: null, callSid: 'CAdup', durationMs: 1 });
+	rec.flush({ sessionId: null, callSid: 'CAdup', durationMs: 1 });
+	assert.equal(calls.stopped, 1, 'second flush neither re-stops nor re-emits');
+	assert.equal(rec.wasFlushed, true);
+
+	const db = new DatabaseSync(DBP);
+	const n = db.prepare("SELECT COUNT(*) c FROM sessions WHERE call_sid='CAdup'").get() as { c: number };
+	db.close();
+	assert.equal(n.c, 1, 'exactly one row despite double flush');
+});
+
+test('voice flush(): no extra → base payload unchanged (session_id set, call_sid null)', () => {
+	const { factory } = fakeTicker();
+	const rec = createSessionRecorder('voice', 'voice-sess-1', { tickerFactory: factory });
+	rec.startTicker('m');
+	rec.transcript.push({ role: 'user', text: 'hi' });
+	rec.transcript.push({ role: 'assistant', text: 'hello' });
+	rec.toolCalls.push({ name: 'x', durationMs: 1, timestamp: new Date().toISOString() });
+	rec.flush();
+
+	const row = lastRow("source='voice' AND session_id='voice-sess-1'");
+	assert.equal(row.session_id, 'voice-sess-1');
+	assert.equal(row.call_sid, null, 'voice has no callSid');
+	assert.equal(row.transcript_lines, 2, 'from recorder.transcript.length');
+	assert.equal(row.tool_count, 1);
+	assert.equal(row.pending_tasks, null, 'no pendingTasks for voice');
+});
+
+test('default ticker factory (no opts) is selected and flushes cleanly', () => {
+	// Exercises the `opts.tickerFactory ?? <voice default>` branch. The default
+	// wraps the real startVoiceTicker; with no collector endpoint it no-ops on
+	// emit, and flush() clears the interval so the process does not hang.
+	const rec = createSessionRecorder('voice', 'voice-default');
+	rec.startTicker('m');
+	rec.flush();
+	assert.equal(rec.wasFlushed, true);
+	const row = lastRow("session_id='voice-default'");
+	assert.equal(row.source, 'voice');
+});


### PR DESCRIPTION
## What

Completes **step 5b** of the LiveAgentRuntime extraction: phone's per-call observability now runs on the same `SessionRecorder` extracted for voice in 5a-3. This closes the loop — both live surfaces (voice + phone) share one durable-runtime spine.

**Step 5 map:** 5a-1 tuned-prompt factory (#1964 ✅) · 5a-2/5a-3 durable channels + SessionRecorder (#1965 ✅) · 5b-1 phone instruction extraction (#1967 ✅) · **5b-2 phone SessionRecorder adoption (this PR).**

## How — two behavior-preserving generalizations

Phone's session shape genuinely diverges from voice's, so rather than force-fit, `createSessionRecorder` grows two small seams:

1. **Injected ticker factory.** Phone bills realtime usage as kind `phone.call` (carrying `callSid`/`isOwner`/`isMeeting`) via `startPhoneTicker`; voice bills `voice.session` via `startVoiceTicker`. The recorder now accepts an optional `tickerFactory` and **defaults to the voice ticker verbatim**. Voice is untouched; phone keeps its own usage kind — no mis-billing.

2. **`flush(extra?)`.** Phone's `recordSession` row carries columns voice doesn't (`callSid`, `caller`, `isOwner`, `isMeeting`, `pendingTasks`) and sources `transcript`/`duration` from the `CallSession` — `transcript` stays on `CallSession` because it's a call artifact (drives summary-task generation + `conversation.log`), not recorder-owned. `flush` merges an `extra` object over the recorder's defaults. **Voice calls `flush()` with no args, so its payload is byte-identical.**

## Equivalence, deliberately

- Phone rows keep `session_id` **NULL** (phone keys by `call_sid`) via an explicit `sessionId: null` override. Populating it would change stored observability data — left for a separate follow-up, not smuggled into a move-only refactor.
- The leaked-ticker invariant is preserved (flush stops the ticker *before* the write guard). Order of ticker-stop vs. record flips (stop-then-record), but the two side effects are independent — no ordering dependency.
- `transcript`/`startTime`/`pendingTasks` remain `CallSession` lifecycle fields; only `events`/`toolCalls`/ticker move to the recorder.

## Tests

- **New** `tests/session-recorder.test.ts` (4 cases): injected-factory path, `extra` merge + override (incl. `sessionId:null`, `transcriptLines`), flush idempotency + leaked-ticker stop, and the default (voice) payload — all asserted against a temp sqlite via the `SUTANDO_CONVERSATION_DB` seam.
- Phone behavior anchors (8-variant matrix) + voice anchors (10) **unchanged**.
- All `conversation-server-*` suites green; `tsc --noEmit` clean.

Not behavior-effective until a service restart — will pair with a live voice+phone smoke check before that.

— @sutando-qingyun-001

**North-star box:** LiveAgentRuntime (Control/Runtime layer) — *built, extending*: this slice brings the phone surface onto the shared runtime's SessionRecorder, completing the voice+phone unification of that box.
