### PR TITLE
feat(result-router): fallback & audit policy + parse_markers golden net (Router v1 S4)

### DIFF
--- a/src/result_router.py
+++ b/src/result_router.py
@@ -1,0 +1,137 @@
+"""
+Result Router — fallback & audit policy (Result Router v1, slice S4).
+
+Companion to `result_markers.py` (#873, which owns marker parsing:
+skip/redirect/attach). This module owns the OTHER half of delivery policy from
+the Result Router spec (`notes/design-result-router-spec-2026-07-06.md`):
+**what happens when the normal delivery can't or didn't land**, and the audit
+trail. It is a set of PURE functions — no I/O, no network, no bridge state — so
+it is trivially testable and safe to adopt bridge-by-bridge (the wiring is a
+separate slice; this PR only lands the policy + tests).
+
+Spec decisions encoded here (§9, owner 2026-07-07):
+
+  §9.1  A live-session (voice/phone) result that outlives its session is NOT
+        silently dropped — it is delivered to the owner DM as a *late result*.
+  §9.2  Late-result presentation is a PLAIN TEXT prefix, `[late result —
+        session ended]`, followed by the original body. No per-surface cards;
+        every surface renders the prefix as-is.
+  §9.3  A delivery failure of ANY tier produces BOTH a structured audit line
+        AND an owner DM naming the task id, tier, surface, and error. (Owner
+        chose stronger visibility over audit-only.)
+
+And §4 (fallback trigger conditions) + §7 (audit) as predicates/formatters.
+
+Normative rule zero (spec §1): *exactly one user-visible delivery per user
+intent* — every function here exists to enforce **no silent drops** while never
+manufacturing a duplicate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+# ── §9.2 late-result prefix ──────────────────────────────────────────────────
+
+# Exact, surface-agnostic. Kept as a module constant so bridges and tests share
+# one string — a drift here would fragment how a late result reads per surface.
+LATE_RESULT_PREFIX = "[late result — session ended]"
+
+
+def late_result_body(body: str) -> str:
+    """Prepend the §9.2 late-result prefix to a result body.
+
+    Plain text, rendered as-is on every surface. Idempotent: a body that
+    already leads with the prefix is returned unchanged (guards against a
+    double-prefix if two fallback paths both fire for the same result).
+    """
+    text = body or ""
+    if text.lstrip().startswith(LATE_RESULT_PREFIX):
+        return text
+    # One blank line between prefix and body when the body is non-empty, so the
+    # prefix reads as its own line on chat surfaces; bare prefix if body empty
+    # (an empty late result is still surfaced — an empty result is a producer
+    # bug per §4 and must stay visible, not be swallowed).
+    return f"{LATE_RESULT_PREFIX}\n\n{text}" if text.strip() else LATE_RESULT_PREFIX
+
+
+# ── §4 fallback trigger conditions ───────────────────────────────────────────
+
+# Triggers that MUST route a result to the fallback (owner DM) instead of, or
+# in addition to, the primary channel. Exhaustive per spec §4.
+FallbackTrigger = Literal[
+    "session_closed",   # hang-up / voice disconnect / Matrix session ended
+    "delivery_error",   # surface API error after the adapter's own retry
+    "over_limit",       # exceeds a hard surface limit even after chunking
+    "channel_gated",    # serving channel gated (e.g. contextNotFrom) — don't drop
+]
+
+# NON-triggers (spec §4): these must NOT cause a fallback. Slow delivery, an
+# idle user, or an empty-looking result are delivered as-is (an empty result is
+# a producer bug and must stay visible, not be rerouted or dropped).
+_NON_TRIGGERS = frozenset({"slow_delivery", "user_idle", "empty_result"})
+
+_FALLBACK_TRIGGERS = frozenset({
+    "session_closed", "delivery_error", "over_limit", "channel_gated",
+})
+
+
+def is_fallback_trigger(reason: str) -> bool:
+    """True iff `reason` is a spec-§4 fallback trigger.
+
+    Unknown reasons return False (fail-safe: an unrecognized reason does not
+    manufacture an owner DM). Explicit non-triggers also return False.
+    """
+    return reason in _FALLBACK_TRIGGERS
+
+
+# ── §9.3 delivery-failure owner notice + §7 audit ────────────────────────────
+
+@dataclass(frozen=True)
+class DeliveryFailure:
+    """The facts of one failed (or fell-back) delivery, for owner-DM + audit."""
+
+    task_id: str
+    tier: str            # "owner" | "team" | "other" (or "" if unknown)
+    surface: str         # "discord" | "slack" | "telegram" | "voice" | "phone" | ...
+    error: str           # short human-readable cause (API error / "session ended" / ...)
+
+
+def delivery_failure_notice(f: DeliveryFailure) -> str:
+    """The owner-DM text for a §9.3 delivery failure (any tier).
+
+    Names task id, tier, surface, and error so the owner can act without
+    grepping bridge logs. One compact multi-line block; safe on every surface.
+    """
+    tier = f.tier or "unknown"
+    return (
+        f"⚠️ Result delivery failed — you did not see this.\n"
+        f"• task: {f.task_id}\n"
+        f"• tier: {tier}\n"
+        f"• surface: {f.surface}\n"
+        f"• error: {f.error}"
+    )
+
+
+# Dispositions an audited result can end in (spec §3/§6/§7).
+Disposition = Literal[
+    "delivered",      # landed on the primary channel
+    "redirected",     # delivered to a [channel:] target
+    "deduped",        # [deduped:] — silently archived
+    "no_send",        # [no-send] / [REPLIED] — silently archived
+    "late_result",    # session ended → owner DM fallback
+    "failed",         # delivery error → owner DM + this audit line
+]
+
+
+def audit_line(task_id: str, disposition: str, surface: str, ts: str) -> str:
+    """One structured audit line per result (spec §7).
+
+    Makes "did the user ever see this?" answerable without grepping four bridge
+    logs. Tab-separated so it greps/cuts cleanly; fields are positional:
+    `ts \\t task_id \\t disposition \\t surface`. `ts` is caller-supplied (an
+    ISO-8601 UTC string) — this module stays pure and does no clock reads.
+    """
+    return f"{ts}\t{task_id}\t{disposition}\t{surface}"

--- a/tests/result-markers-golden.test.py
+++ b/tests/result-markers-golden.test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Golden net over src/result_markers.py (#873) — the Result Router v1 "S0"
+regression baseline. Pins the disposition `parse_markers()` produces for a
+corpus that exercises EVERY marker path, so any later Router slice that touches
+marker handling must reproduce these byte-for-byte.
+
+Bodies are synthetic but mirror real archived `results/*.txt` shapes (no PII in
+the repo). Each case declares the expected (actions, body) the current module
+produces; a drift breaks the test loudly.
+
+Run: python3 tests/result-markers-golden.test.py
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("result_markers", _ROOT / "src" / "result_markers.py")
+rm = importlib.util.module_from_spec(spec)
+sys.modules["result_markers"] = rm
+spec.loader.exec_module(rm)
+
+_failures = []
+def check(cond, msg):
+    if not cond:
+        _failures.append(msg)
+
+def kinds(pr):
+    return [a.kind for a in pr.actions]
+
+# ── the corpus: (label, body, expected_kinds, expected_body_or_None) ─────────
+# expected_body None = don't assert body (only disposition)
+
+# 1. plain deliver — no markers
+pr = rm.parse_markers("Here is your answer: 42.")
+check(kinds(pr) == [], "plain: no actions")
+check(pr.body == "Here is your answer: 42.", "plain: body untouched")
+
+# 2. [no-send] — skip, terminal, body emptied
+pr = rm.parse_markers("[no-send]\nInternal note, do not deliver.")
+check(kinds(pr) == ["skip"], "no-send: single skip action")
+check(pr.actions[0].value == "no-send", "no-send: reason")
+check(pr.body == "", "no-send: body emptied (invisible to user)")
+
+# 3. [REPLIED] — skip
+pr = rm.parse_markers("[REPLIED]")
+check(kinds(pr) == ["skip"] and pr.actions[0].value == "REPLIED", "REPLIED: skip")
+
+# 4. [deduped: task-X] — skip with the holder id in .extra
+pr = rm.parse_markers("[deduped: task-1783000000000]\nfull reply lives in holder")
+check(kinds(pr) == ["skip"], "deduped: skip")
+check(pr.actions[0].value == "deduped", "deduped: reason")
+check(pr.actions[0].extra == "task-1783000000000", "deduped: holder id captured in extra")
+
+# 5. [channel: <id>] — redirect, body is text AFTER the marker line
+pr = rm.parse_markers("[channel: 1509576272920182874]\nPosting this to #design instead.")
+check(kinds(pr) == ["redirect"], "channel: redirect action")
+check(pr.actions[0].value == "1509576272920182874", "channel: target id")
+check(pr.body == "Posting this to #design instead.", "channel: body is text after marker")
+
+# 6. [file:/path] — attach, marker stripped from body
+pr = rm.parse_markers("Here's the screenshot.\n[file: /tmp/shot.png]")
+check(kinds(pr) == ["attach"], "file: attach action")
+check(pr.actions[0].value == "/tmp/shot.png", "file: path extracted")
+check("[file:" not in pr.body, "file: marker stripped from body")
+check("screenshot" in pr.body, "file: prose preserved")
+
+# 7. send/attach aliases + multiple attachments in document order
+pr = rm.parse_markers("two files [send: /a.pdf] and [attach: /b.png] done")
+check(kinds(pr) == ["attach", "attach"], "send/attach: two attach actions")
+check([a.value for a in pr.actions] == ["/a.pdf", "/b.png"], "attach: document order")
+
+# 8. skip precedence — a skip marker wins over any redirect/attach in the body
+pr = rm.parse_markers("[no-send]\n[channel: 123] [file: /x] should NOT be parsed")
+check(kinds(pr) == ["skip"], "skip precedence: only skip, no redirect/attach")
+
+# 9. D7 reply-header preserved on a normal deliver
+pr = rm.parse_markers("**[core: 3]**\n_(switched)_\nActual answer here.")
+check(kinds(pr) == [], "D7: no actions on plain body")
+check(pr.body.startswith("**[core: 3]**"), "D7: header restored onto user-facing body")
+check("Actual answer here." in pr.body, "D7: body preserved")
+
+# 10. D7 header + [channel:] — header must not shadow the redirect
+pr = rm.parse_markers("**[core: 2]**\n[channel: 999]\nrerouted body")
+check(kinds(pr) == ["redirect"], "D7+redirect: redirect still recognized under header")
+check(pr.actions[0].value == "999", "D7+redirect: target id")
+
+# 11. D7 header + skip — still invisible (header discarded with body)
+pr = rm.parse_markers("**[core: 1]**\n[no-send]\nx")
+check(kinds(pr) == ["skip"], "D7+skip: skip terminal")
+check(pr.body == "", "D7+skip: body emptied despite header")
+
+# 12. empty input
+pr = rm.parse_markers("")
+check(kinds(pr) == [] and pr.body == "", "empty input → empty result")
+
+# 13. redirect + attach combined (non-skip): both actions, correct order
+pr = rm.parse_markers("[channel: 555]\nsee file [file: /r.txt]")
+check(kinds(pr) == ["redirect", "attach"], "redirect+attach: both, redirect first")
+check("[file:" not in pr.body, "redirect+attach: attach marker stripped")
+
+if _failures:
+    print(f"FAIL ({len(_failures)}):")
+    for m in _failures:
+        print("  -", m)
+    raise SystemExit(1)
+print(f"result-markers-golden: all {13} corpus cases passed")

--- a/tests/result-router-fallback.test.py
+++ b/tests/result-router-fallback.test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Unit coverage for src/result_router.py — the Result Router fallback & audit
+policy (spec §4/§7/§9). Pure functions, no I/O, so no fixtures/stubs needed.
+
+Run: python3 tests/result-router-fallback.test.py
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("result_router", _ROOT / "src" / "result_router.py")
+rr = importlib.util.module_from_spec(spec)
+# Register before exec so @dataclass can resolve string annotations (the module
+# uses `from __future__ import annotations`); mirrors a normal `import`.
+sys.modules["result_router"] = rr
+spec.loader.exec_module(rr)
+
+_failures = []
+def check(cond, msg):
+    if not cond:
+        _failures.append(msg)
+
+# ── §9.2 late_result_body ────────────────────────────────────────────────────
+PFX = rr.LATE_RESULT_PREFIX
+check(PFX == "[late result — session ended]", "prefix string is the exact §9.2 wording")
+
+# non-empty body → prefix on its own line + blank line + body
+out = rr.late_result_body("Report is ready: 3 items.")
+check(out.startswith(PFX + "\n\n"), "non-empty body: prefix then blank line")
+check(out.endswith("Report is ready: 3 items."), "non-empty body: original body preserved")
+
+# empty / whitespace body → bare prefix (still surfaced, not swallowed)
+check(rr.late_result_body("") == PFX, "empty body → bare prefix")
+check(rr.late_result_body("   \n ") == PFX, "whitespace-only body → bare prefix")
+
+# idempotent: already-prefixed body is unchanged (guards double-prefix)
+once = rr.late_result_body("hello")
+twice = rr.late_result_body(once)
+check(once == twice, "late_result_body is idempotent")
+# leading-whitespace before an existing prefix is still recognized as prefixed
+check(rr.late_result_body("  " + PFX + "\n\nx") == "  " + PFX + "\n\nx", "leading ws + existing prefix unchanged")
+# None-safe
+check(rr.late_result_body(None) == PFX, "None body → bare prefix (no crash)")
+
+# ── §4 is_fallback_trigger ───────────────────────────────────────────────────
+for t in ("session_closed", "delivery_error", "over_limit", "channel_gated"):
+    check(rr.is_fallback_trigger(t) is True, f"{t} IS a fallback trigger")
+for n in ("slow_delivery", "user_idle", "empty_result"):
+    check(rr.is_fallback_trigger(n) is False, f"{n} is NOT a fallback trigger (§4)")
+check(rr.is_fallback_trigger("some_unknown_reason") is False, "unknown reason → False (fail-safe)")
+check(rr.is_fallback_trigger("") is False, "empty reason → False")
+
+# ── §9.3 delivery_failure_notice ─────────────────────────────────────────────
+f = rr.DeliveryFailure(task_id="task-abc", tier="owner", surface="discord", error="403 Forbidden")
+note = rr.delivery_failure_notice(f)
+for token in ("task-abc", "owner", "discord", "403 Forbidden"):
+    check(token in note, f"failure notice names {token!r}")
+check("did not see this" in note, "failure notice is loud (names the miss)")
+
+# unknown tier renders as 'unknown', not empty
+f2 = rr.DeliveryFailure(task_id="task-x", tier="", surface="slack", error="timeout")
+check("unknown" in rr.delivery_failure_notice(f2), "empty tier → 'unknown'")
+
+# frozen dataclass (facts are immutable once captured)
+try:
+    f.error = "mutated"  # type: ignore[misc]
+    check(False, "DeliveryFailure must be frozen")
+except Exception:
+    check(True, "DeliveryFailure is frozen")
+
+# ── §7 audit_line ────────────────────────────────────────────────────────────
+line = rr.audit_line("task-9", "delivered", "telegram", "2026-07-07T02:40:00Z")
+parts = line.split("\t")
+check(parts == ["2026-07-07T02:40:00Z", "task-9", "delivered", "telegram"],
+      "audit line is tab-separated ts/task/disposition/surface")
+check("\n" not in line, "audit line is single-line (grep-friendly)")
+
+if _failures:
+    print(f"FAIL ({len(_failures)}):")
+    for m in _failures:
+        print("  -", m)
+    raise SystemExit(1)
+print("result-router-fallback: all checks passed")


### PR DESCRIPTION
## North-star box

**Result Router (Delegation layer — result route-back): `spec-only → implementing`.**

Result Router v1, slice **S4** — the first genuinely-missing piece of the outbound delivery policy. A code check before starting found the marker core (`parse_markers`, #873) already exists and is consumed by discord/telegram/slack + task-bridge, so the originally-planned S1 (marker core) and S2 (bridge cutover) are effectively already done. This slice skips that redundant work and lands only what the spec (§4/§7/§9) still owes, plus a golden net over the existing behavior.

## What this lands

`src/result_router.py` — **pure functions** (no I/O, no bridge state), safe to adopt bridge-by-bridge in a later wiring slice. This PR is **policy + tests only; no live-delivery behavior change yet**:

- `late_result_body()` — §9.2 plain-text `[late result — session ended]` prefix. Idempotent and empty-safe (an empty late result is still surfaced, never silently dropped).
- `is_fallback_trigger()` — §4 triggers (`session_closed` / `delivery_error` / `over_limit` / `channel_gated`) vs explicit non-triggers (`slow` / `idle` / `empty`). Unknown reasons **fail safe** — no manufactured owner DM.
- `delivery_failure_notice()` + `DeliveryFailure` — §9.3 owner-DM naming task / tier / surface / error (loud, any tier).
- `audit_line()` — §7 one tab-separated line (ts / task / disposition / surface) so "did the user ever actually see this?" is answerable without grepping four bridge logs.

## Tests / eval

- `tests/result-router-fallback.test.py` — 100% line coverage of the module (prefix idempotency, empty-safe, every trigger/non-trigger, notice fields, frozen dataclass, audit format). **Passing locally.**
- `tests/result-markers-golden.test.py` — S0 golden net over the **existing** `parse_markers` (#873): 13 cases pinning every disposition (skip precedence, redirect, attach aliases + order, D7-header interplay) as the regression baseline for any later Router slice. **Passing locally (all 13 cases).**

**Eval plan for the follow-up wiring slices** (not this PR — this one changes no delivery path):
- *synthetic*: the S0 golden corpus above, byte-exact per disposition.
- *real-user*: before the S4 fallback flag is flipped live, run it in shadow mode over N days of archived results and diff against what the bridge logs show was actually delivered — **zero diff** required before any real fallback DM fires.

## Scope / follow-ups (deliberately out)

- Wiring `result_router` into the Python bridges' delivery path — separate slice.
- The TS session-ended late-result path (voice/phone) — separate slice.
- Chunking as a shared pure module (S3) and the structured audit line at call sites (S5) — separate slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
