### PR TITLE
fix(local-task-protocol): scope iter_archived_tasks to files with a task: line

### DIFF
--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -496,12 +496,28 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
 
 def iter_archived_tasks(tasks_dir: Path) -> Iterable[Path]:
     """Yield every archived task file (flat legacy + month-partitioned),
-    for corpus sweeps and golden tests."""
+    for corpus sweeps and golden tests. Skips non-task artefacts (files
+    without a `task:` line) that may accumulate in the archive directory
+    (e.g. `answer-Q*` files from the pending-questions flow)."""
     archive_root = tasks_dir / "archive"
     if not archive_root.is_dir():
         return
     for p in sorted(archive_root.glob("*.txt")):
-        yield p
+        if _has_task_line(p):
+            yield p
     for entry in sorted(archive_root.iterdir()):
         if entry.is_dir() and _MONTH_DIR_RE.match(entry.name):
-            yield from sorted(entry.glob("*.txt"))
+            for p in sorted(entry.glob("*.txt")):
+                if _has_task_line(p):
+                    yield p
+
+
+def _has_task_line(path: Path) -> bool:
+    """True iff `path` contains a `task:` header line — the structural marker
+    that distinguishes a real task file from a non-task artefact that has
+    accumulated in the archive directory."""
+    try:
+        return any(line.startswith("task:") for line in
+                   path.read_text(errors="replace").split("\n"))
+    except OSError:
+        return False

--- a/tests/local-task-protocol.test.py
+++ b/tests/local-task-protocol.test.py
@@ -303,6 +303,11 @@ _tasks = _tmp / "tasks"
 (_tasks / "archive" / "2026-07" / "ask-123.txt").write_text("id: ask-123\ntask: x\n")
 (_tasks / "archive" / "2026-07" / "sc-ask-456.txt").write_text("id: sc-ask-456\ntask: x\n")
 (_tasks / "archive" / "stray-dir" / "task-stray.txt").write_text("id: task-stray\ntask: x\n")
+# Non-task artefact: no `task:` line — iter should skip it.
+(_tasks / "archive" / "answer-Q1-1783000000.txt").write_text("User answered Q1: Yes\n")
+(_tasks / "archive" / "2026-07" / "answer-Q2-1783000001.txt").write_text("User answered Q2: No\n")
+# Non-task-prefixed id but with proper task structure (ask-*, sc-ask-*) — iter must include it.
+(_tasks / "archive" / "ask-1783000002.txt").write_text("id: ask-1783000002\ntask: y\n")
 
 check("find: live dir", ltp.find_archived_task(_tasks, "task-live") == _tasks / "task-live.txt")
 check("find: processed", ltp.find_archived_task(_tasks, "task-proc") == _tasks / "processed" / "task-proc.txt")
@@ -314,10 +319,25 @@ check("find: non-month dirs skipped", ltp.find_archived_task(_tasks, "task-stray
 check("find: missing id", ltp.find_archived_task(_tasks, "task-nope") is None)
 check("find: malformed id gated", ltp.find_archived_task(_tasks, "task-../etc") is None)
 swept = [p.name for p in ltp.iter_archived_tasks(_tasks)]
-check("iter: flat + months, stray-dir skipped, live/processed excluded",
-      swept == ["task-flat.txt", "task-old.txt", "ask-123.txt", "sc-ask-456.txt", "task-new.txt"], str(swept))
+check("iter: flat + months, stray-dir skipped, live/processed excluded, artefacts skipped",
+      swept == ["ask-1783000002.txt", "task-flat.txt", "task-old.txt", "ask-123.txt", "sc-ask-456.txt", "task-new.txt"], str(swept))
+check("iter: non-task artefacts without task: line are excluded",
+      "answer-Q1-1783000000.txt" not in swept and "answer-Q2-1783000001.txt" not in swept)
+check("iter: non-task-prefixed files WITH task: line are included",
+      "ask-1783000002.txt" in swept and "ask-123.txt" in swept and "sc-ask-456.txt" in swept)
 check("iter: no archive dir yields nothing",
       list(ltp.iter_archived_tasks(_tmp / "nonexistent")) == [])
+
+# _has_task_line: OSError branch (unreadable file returns False, not an exception).
+# Skip when running as root — root can read 0o000 files.
+import os as _os
+if _os.getuid() != 0:
+    _unreadable = _tasks / "archive" / "unreadable.txt"
+    _unreadable.write_text("task: unreachable\n")
+    _unreadable.chmod(0o000)
+    check("_has_task_line: OSError returns False (not an exception)",
+          not ltp._has_task_line(_unreadable))
+    _unreadable.chmod(0o644)  # restore for tempdir cleanup
 
 if failures:
     sys.exit(1)


### PR DESCRIPTION
## Problem

`archive/` can accumulate non-task artefacts (e.g. `answer-Q*` files from the pending-questions flow) that lack a `task:` header line. The prior `glob("*.txt")` yielded them, causing the live corpus id-recovery check to fail on 4 legacy `answer-Q*` files.

## Fix

Add a `_has_task_line()` content check so only files with a `task:` line are yielded. This is the correct semantic gate — any valid task file has a `task:` line regardless of its filename prefix (`task-*`, `ask-*`, `sc-ask-*`, `reco-skill-*`, etc. per issue #1960), so non-task artefacts are excluded without over-narrowing by filename pattern.

A prior iteration used `glob("task-*.txt")` which would have incorrectly excluded `ask-*` / `sc-ask-*` / `reco-skill-*` task files (issue #1960 / PR #1968 documents 79 such files). Content-based filtering is correct for all producer shapes.

## Test plan

- [ ] `python3 tests/local-task-protocol.test.py` — all checks including live corpus sweep pass (id recoverable for all 172 real task files; 4 `answer-Q*` artefacts excluded)
- [ ] Fixture tests unchanged: archive helpers only create files with `task:` lines so the content filter produces identical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB3qZQrwponfum2JFNvHeh