### PR TITLE
fix(agent-api): guard voice_desired_state toggle with a Lock (closes #1922)

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -39,6 +39,7 @@ import re
 import socket
 import subprocess
 import sys
+import threading
 from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlparse, unquote
@@ -118,6 +119,7 @@ task_history = {}
 # Voice state: "connected" or "disconnected". Toggled via /voice/toggle.
 # Web client polls /voice/state and connects/disconnects accordingly.
 voice_desired_state = "disconnected"
+_voice_state_lock = threading.Lock()
 
 
 
@@ -763,7 +765,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
         if path == "/voice/toggle":
             if not self.check_auth():
                 return
-            voice_desired_state = "connected" if voice_desired_state == "disconnected" else "disconnected"
+            with _voice_state_lock:
+                voice_desired_state = "connected" if voice_desired_state == "disconnected" else "disconnected"
             self.send_json(200, {"state": voice_desired_state})
             return
 


### PR DESCRIPTION
## Summary

- `/voice/toggle` had a read-modify-write on `voice_desired_state`: read current value, compute toggle, assign back — all unprotected.
- With `ThreadingHTTPServer` (PR #1921), two simultaneous POSTs can interleave and double-toggle, landing the UI on the wrong state.
- Fix: add `_voice_state_lock = threading.Lock()` (module-level, near the `voice_desired_state` declaration) and acquire it around the toggle's read-then-assign.
- Harmless with the current single-threaded `HTTPServer`; necessary when #1921 lands.
- `/voice/set` plain assignment stays unlocked — single assignment is atomic under the GIL and has no read-modify cycle.

## Test plan
- [ ] `python3 tests/agent-api-delegation.test.py` — PASS (no regression in the endpoint test suite)
- [ ] `python3 tests/agent-api-task-field-injection.test.py` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB3qZQrwponfum2JFNvHeh