### PR TITLE
fix(workspace): align TS no-repo-root fallbacks to canonical undotted ~/sutando-workspace

### DIFF
--- a/skills/screen-companion/tools.ts
+++ b/skills/screen-companion/tools.ts
@@ -20,12 +20,7 @@ import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { loadConfig, discoverConfigs, renderGoal } from './scripts/load-config.js';
 import { readSelection as defaultReadSelection, type SelectionResult } from './scripts/read-selection.js';
 import { registerVisionOnContributor, callUpdateTools, callRestoreTools, captureSendFrame, getFullToolSurface } from '../../src/vision-tools.js';
-
-function resolveWorkspace(): string {
-	const env = process.env.SUTANDO_WORKSPACE;
-	if (env) return env.replace(/^~/, process.env.HOME ?? '');
-	return join(process.env.HOME ?? '', 'sutando-workspace');
-}
+import { resolveWorkspace } from '../../src/workspace_default.js';
 
 // Contributor for the screen-share-started system note. Tells Gemini the
 // screen-companion catalog is available AND names the configs the user can

--- a/skills/screen-companion/tools.ts
+++ b/skills/screen-companion/tools.ts
@@ -24,7 +24,7 @@ import { registerVisionOnContributor, callUpdateTools, callRestoreTools, capture
 function resolveWorkspace(): string {
 	const env = process.env.SUTANDO_WORKSPACE;
 	if (env) return env.replace(/^~/, process.env.HOME ?? '');
-	return join(process.env.HOME ?? '', '.sutando', 'workspace');
+	return join(process.env.HOME ?? '', 'sutando-workspace');
 }
 
 // Contributor for the screen-share-started system note. Tells Gemini the

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -305,7 +305,7 @@ export function resolveWorkspace(repoRoot?: string): string {
 	if (typeof ws === 'string' && ws) {
 		resolved = resolve(ws.replace(/^~/, homedir()));
 	} else if (root === undefined) {
-		resolved = resolve(join(homedir(), '.sutando', 'workspace'));
+		resolved = resolve(join(homedir(), 'sutando-workspace'));
 	} else {
 		resolved = resolve(join(root, HARDCODED_WORKSPACE_DEFAULT_REL));
 	}


### PR DESCRIPTION
## Summary

- `src/sutando_config.ts:308`: last-ditch `resolveWorkspace()` fallback was returning `~/.sutando/workspace` (pre-v0.8 path). Changed to canonical `~/sutando-workspace`.
- `skills/screen-companion/tools.ts:27`: `resolveWorkspace()` env-var fallback had the same stale dotted path. Changed to `~/sutando-workspace`.

Both are TS-only changes, no Python touched — diff-cover gate does not apply.

Closes #1906 (partial — two of the remaining TS sites; Python site in `util_paths.py` was already fixed by a prior PR; overlay-apps sites use `SUTANDO_RESOLVED_WORKSPACE` as primary so they are lower priority).

## Test plan

- [ ] `tsc --noEmit` passes (type-safe, no logic change — just a string literal)
- [ ] `scripts/lint-workspace-resolution.sh` passes (both sites previously matched the `\.sutando/workspace` pattern; now they don't)
- [ ] Cold-boot smoke test: remove `sutando.config.local.json`, start core, verify workspace resolves to `~/sutando-workspace` not `~/.sutando/workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB3qZQrwponfum2JFNvHeh