### PR TITLE
fix(relay): wire relay notes into session-handoff.sh (closes #1738)

### DIFF
--- a/docs/workspace-contract.md
+++ b/docs/workspace-contract.md
@@ -56,7 +56,7 @@ Resolved by `bash scripts/sutando-config.sh workspace` (the M0 helper). Helpers 
 ├── logs/                   ← append-only chrono streams (bridges, watchers, sync)
 ├── notes/                  ← long-form human-readable content
 ├── data/                   ← durable input data (datasets, fetched feeds)
-├── relay/                  ← inter-session continuity notes (consumed by catchup)
+├── relay/                  ← inter-session continuity notes (consumed by session-handoff.sh)
 ├── skills/                 ← user's personal/custom skills (local-only)
 ├── build_log.md            ← single-file done/in-flight/next snapshot (append-only)
 └── pending-questions.md    ← unanswered questions awaiting owner input
@@ -77,7 +77,7 @@ When the agent writes a new file under `<repo>/workspace/`, walk this list top-t
 7. **Done/in-flight/next snapshot?** → append to `build_log.md`.
 8. **Blocked question for the owner?** → append to `pending-questions.md`.
 9. **Durable input data?** → `data/<topic>/`.
-10. **Continuity note for the next session?** → `relay/relay-<ts>.md` (consumed by `/catchup-after-startup`).
+10. **Continuity note for the next session?** → `relay/relay-<ts>.md` (consumed by `session-handoff.sh` on context compaction → appears in `session-state.md` as "## Relay Notes"; archived to `relay/processed/`).
 11. **Personal skill the user adds for their own use?** → `skills/<skill-name>/` (local-only, not contributed to `skills/` at the repo root).
 
 If two layers seem to fit, prefer the more specific one (state JSON beats logs beats notes).

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: relay
-description: "Write a handoff/continuity note for the NEXT Sutando session. Captures what was just in flight, what to check first, what might go wrong, and implicit context the structured snapshot doesn't carry. Read first by /catchup-after-startup."
+description: "Write a handoff/continuity note for the NEXT Sutando session. Captures what was just in flight, what to check first, what might go wrong, and implicit context the structured snapshot doesn't carry. Consumed by session-handoff.sh on context compaction."
 user-invocable: true
 ---
 
@@ -29,7 +29,7 @@ workspace/relay/
 
 - **File naming:** `relay-{epoch}.md` — sortable + greppable, matches the `task-{epoch}.txt` shape.
 - **Multiple files allowed:** `/relay` always creates a NEW file by default. `--append` appends to the LATEST unprocessed `relay-*.md` instead of creating a new one.
-- **Consumption:** catchup-after-startup reads ALL unprocessed `relay-*.md` files in mtime order (oldest first), prints them as section 0 of its briefing, then `mv`s each one to `processed/` (mirroring the result-watcher drain pattern).
+- **Consumption:** `session-handoff.sh` (fired on context compaction by the PreCompact hook) reads ALL unprocessed `relay-*.md` files in mtime order (oldest first), appends them as a "## Relay Notes" section in `session-state.md`, then `mv`s each one to `processed/` (mirroring the result-watcher drain pattern).
 - **Cleanup:** kept indefinitely on local disk. Tiny files (~200-500 bytes each); a year of relay notes is < 1 MB. Sync via the workspace-sync engine (`scripts/sync-workspace.sh`) for fleet visibility — the legacy `sync-memory.sh` flow is deprecated in v0.3.0 and removed in v0.4.0.
 
 ## What to write
@@ -67,7 +67,7 @@ If the session was genuinely uneventful (read-only, no decisions, no in-flight w
 
 - **Manual-invocation only.** Auto-refresh (writing/updating from `/proactive-loop`) deferred to Phase 2 once we see how owners actually use the manual path.
 - **No quality-gate (refuse-on-thin-note).** Always write whatever the LLM produces. Quality-gate deferred to Phase 2 pending observation.
-- **Read-side** lives in `/catchup-after-startup` — see that skill for the read-then-archive flow.
+- **Read-side** lives in `src/session-handoff.sh` — the PreCompact hook fires it on every context compaction; it drains relay notes into `session-state.md` and archives them to `processed/`.
 
 ## Phase 2 ideas (NOT in scope)
 

--- a/skills/relay/manifest.json
+++ b/skills/relay/manifest.json
@@ -4,7 +4,7 @@
   "owner": "github:sonichi/sutando",
   "license": "MIT",
   "stability": "experimental",
-  "description": "Write a handoff/continuity note for the NEXT Sutando session. Captures what was just in flight, what to check first, what might go wrong, and implicit context the structured snapshot doesn't carry. Read first by /catchup-after-startup.",
+  "description": "Write a handoff/continuity note for the NEXT Sutando session. Captures what was just in flight, what to check first, what might go wrong, and implicit context the structured snapshot doesn't carry. Consumed by session-handoff.sh on context compaction.",
   "provenance": {
     "source_repo": "https://github.com/sonichi/sutando"
   }

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -122,6 +122,32 @@ print(f'5h: {d[\"utilization_5h\"]:.0%} (resets in {m5}min at {r5.strftime(\"%I:
   fi
   echo ""
 
+  # Relay notes — cross-session narrative continuity (#1738)
+  # Written by /relay skill and /proactive-loop step 7; consumed here so
+  # the next session sees intent/judgment the structured snapshot can't carry.
+  # Each file is moved to relay/processed/ after being read (drain-on-read).
+  echo "## Relay Notes"
+  RELAY_DIR="$WORKSPACE_DIR/relay"
+  if [ -d "$RELAY_DIR" ]; then
+    # ls -1t = newest-first; awk reversal = oldest-first (chronological order)
+    relay_files=$(ls -1t "$RELAY_DIR"/relay-*.md 2>/dev/null | awk '{a[i++]=$0} END{for(j=i-1;j>=0;j--) print a[j]}')
+    if [ -z "$relay_files" ]; then
+      echo "(none)"
+    else
+      mkdir -p "$RELAY_DIR/processed"
+      while IFS= read -r rfile; do
+        [ -f "$rfile" ] || continue
+        echo "### $(basename "$rfile")"
+        cat "$rfile"
+        echo ""
+        mv "$rfile" "$RELAY_DIR/processed/$(basename "$rfile")"
+      done <<< "$relay_files"
+    fi
+  else
+    echo "(relay dir not yet created)"
+  fi
+  echo ""
+
   # Stars
   echo "## Repo Stats"
   gh api repos/sonichi/sutando --jq '.stargazers_count, .forks_count' 2>/dev/null | tr '\n' ' ' | awk '{print $1 " stars, " $2 " forks"}' || echo "(couldn't fetch)"

--- a/src/session-handoff.sh
+++ b/src/session-handoff.sh
@@ -138,9 +138,12 @@ print(f'5h: {d[\"utilization_5h\"]:.0%} (resets in {m5}min at {r5.strftime(\"%I:
       while IFS= read -r rfile; do
         [ -f "$rfile" ] || continue
         echo "### $(basename "$rfile")"
-        cat "$rfile"
-        echo ""
-        mv "$rfile" "$RELAY_DIR/processed/$(basename "$rfile")"
+        if cat "$rfile"; then
+          echo ""
+          mv "$rfile" "$RELAY_DIR/processed/$(basename "$rfile")"
+        else
+          echo "(read error — file left in place for retry)"
+        fi
       done <<< "$relay_files"
     fi
   else


### PR DESCRIPTION
## Summary

- `catchup-after-startup` (the only relay consumer) was removed in #1737, leaving relay notes accumulating unread in `workspace/relay/` (41 files stacked up).
- Wires the drain into `src/session-handoff.sh` (fired by the PreCompact hook on every context compaction): reads all unprocessed `relay-*.md` files oldest-first, appends them as `## Relay Notes` in `session-state.md`, archives each to `relay/processed/`.
- No new infrastructure — reuses the existing drain pattern (claim-by-mv) from result-watcher and tasks/.
- Updates stale `/catchup-after-startup` references: `skills/relay/SKILL.md`, `skills/relay/manifest.json`, `docs/workspace-contract.md`.

Closes #1738.

## Test plan

- [ ] Add a relay file to `workspace/relay/relay-<ts>.md`, run `bash src/session-handoff.sh`, verify `session-state.md` contains `## Relay Notes` section with the file content, and the source file moved to `workspace/relay/processed/`
- [ ] No relay files: `session-state.md` contains `## Relay Notes\n(none)`
- [ ] CI checks (no Python diff, shell-only change — diff-cover gate does not apply)
- [ ] `lint-workspace-resolution.sh` clean (uses `$WORKSPACE_DIR` which is the resolved variable, not a hardcoded path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB3qZQrwponfum2JFNvHeh