### PR TITLE
feat(vision): inject selected text alongside auto-streamed frames (closes #1425)

### DIFF
--- a/skills/screen-companion/tools.ts
+++ b/skills/screen-companion/tools.ts
@@ -19,7 +19,7 @@ import { join } from 'node:path';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { loadConfig, discoverConfigs, renderGoal } from './scripts/load-config.js';
 import { readSelection as defaultReadSelection, type SelectionResult } from './scripts/read-selection.js';
-import { registerVisionOnContributor, callUpdateTools, callRestoreTools, captureSendFrame, getFullToolSurface } from '../../src/vision-tools.js';
+import { registerVisionOnContributor, registerFrameContextProvider, callUpdateTools, callRestoreTools, captureSendFrame, getFullToolSurface } from '../../src/vision-tools.js';
 
 function resolveWorkspace(): string {
 	const env = process.env.SUTANDO_WORKSPACE;
@@ -45,6 +45,17 @@ registerVisionOnContributor(() => {
 		`call the \`activate_screen_companion\` tool with the matching mode + their goal. ` +
 		`If the goal doesn't match a configured mode, operate normally with screen awareness.`
 	);
+});
+
+// Frame-context provider: injects the user's current AX/Chrome text selection
+// alongside every auto-streamed frame (push and pull paths) — issue #1425.
+// Mirrors the pull-path selection-first behavior from PR #1409 so guided-setup
+// and other push-mode sessions also get exact selected text without the model
+// having to call vision_query explicitly.
+registerFrameContextProvider(() => {
+	const sel = _readSelection();
+	if (!sel || !sel.text) return null;
+	return `[Selected text on screen: ${sel.text}]`;
 });
 
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -174,6 +174,30 @@ export function _getVisionOnContributorCount(): number {
 	return visionOnContributors.length;
 }
 
+// ── Frame context providers (issue #1425) ───────────────────────────────────
+// Skills register a sync-or-async callback that may return extra text context
+// to inject alongside each captured frame. If a provider returns non-empty
+// text it is sent as a turnComplete=false user turn immediately before the
+// frame, so the model sees both the exact context and the visual.
+// Returning null/undefined means "nothing to add" — no extra message is sent.
+export type FrameContextProvider = () => string | null | undefined | Promise<string | null | undefined>;
+const frameContextProviders: FrameContextProvider[] = [];
+
+/** Register a frame-context provider called before each captured frame send.
+ *  Returns an unregister function (useful for tests). */
+export function registerFrameContextProvider(fn: FrameContextProvider): () => void {
+	frameContextProviders.push(fn);
+	return () => {
+		const i = frameContextProviders.indexOf(fn);
+		if (i >= 0) frameContextProviders.splice(i, 1);
+	};
+}
+
+/** Visible for tests. */
+export function _getFrameContextProviderCount(): number {
+	return frameContextProviders.length;
+}
+
 // TODO(roadmap §5 Now: "Define DeviceSession"): Replace this single-session
 // global with a DeviceSession map keyed by device ID. Today push-mode senders
 // (browser, Mentra glasses, Discord/Telegram photo helper, phone agent) all
@@ -452,6 +476,22 @@ async function captureAndSend(source: VisionSource): Promise<{ ok: boolean; erro
 	const sendFile = getSendFile();
 	if (!sendFile) return { ok: false, error: 'no active voice session' };
 	const frame = await source.capture();
+	// Call registered frame-context providers (issue #1425: selection-first for push path).
+	// Each provider may return extra text context (e.g. the user's current AX text
+	// selection). Non-empty results are injected as a turnComplete=false user turn
+	// immediately before the frame so the model sees both exact text and the visual.
+	if (frameContextProviders.length > 0) {
+		const results = await Promise.all(frameContextProviders.map(fn => {
+			try { return Promise.resolve(fn()); } catch { return Promise.resolve(null); }
+		}));
+		const text = results.filter((r): r is string => typeof r === 'string' && r.length > 0).join('\n');
+		if (text) {
+			const transport = sessionRef?.transport;
+			if (transport && typeof transport.sendContent === 'function') {
+				try { transport.sendContent([{ role: 'user', text }], false); } catch { /* best-effort */ }
+			}
+		}
+	}
 	sendFile(frame.data.toString('base64'), frame.mimeType);
 	return { ok: true };
 }


### PR DESCRIPTION
## Summary

- PR #1409 added selection-first to `vision_query` (interactive pull-path tool) but push-mode auto-streaming (`tick()` → `captureAndSend()`) still sent raw frames with no selection context.
- In `guided-setup` or any `vision_mode: push` session, text the user had highlighted was invisible to the model unless it explicitly called `vision_query`.

## Fix

**`src/vision-tools.ts`**: add a `FrameContextProvider` hook (mirrors the existing `VisionOnContributor` pattern). `captureAndSend()` now calls every registered provider before sending each frame. If any returns non-empty text, a `turnComplete=false` user turn is injected with that text so the model receives both the visual frame AND the exact selection.

**`skills/screen-companion/tools.ts`**: register a `FrameContextProvider` at module-load time (same lifecycle as the existing `VisionOnContributor`). The provider calls `_readSelection()` and returns `[Selected text on screen: <text>]` when text is selected via AX or Chrome JS.

Result: selection context now works on **both** pull (`vision_query`) and push (`guided-setup` auto-stream / `tick()`) paths. No duplicate probe logic.

## Test plan

- [ ] `tsc --noEmit` passes (TypeScript clean)
- [ ] Start a guided-setup session with `vision_mode: push`; highlight text in a native app → model should mention the exact selected text alongside the frame
- [ ] No selection active → no extra text message injected (provider returns null)
- [ ] Unit: `_getFrameContextProviderCount()` returns 1 after screen-companion skill loads

Closes #1425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB3qZQrwponfum2JFNvHeh