### PR TITLE
fix(workspace): extend lint to .js/.mjs; align sync-memory fallback (closes #1906 remaining)

### DIFF
--- a/scripts/lint-workspace-resolution.sh
+++ b/scripts/lint-workspace-resolution.sh
@@ -61,7 +61,7 @@ PATTERN_DOC_ENV_PATH='\$SUTANDO_WORKSPACE/'
 # branch when the wrapper script isn't reachable (e.g. non-checkout
 # installs). The fallback path is documented in each script's comments;
 # new contributors should still go through the wrapper.
-ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|tests/[^/]+\.(test\.)?(py|ts|sh))$'
+ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|tests/[^/]+\.(test\.)?(py|ts|sh)|skills/overlay-apps/app/(control-server|main)\.js)$'
 
 # Allowed .md files — legitimate uses of `$SUTANDO_WORKSPACE/path` in
 # prose, e.g. the workspace contract docs that DESCRIBE the legacy form
@@ -76,8 +76,8 @@ if [[ "$mode" == "--diff" ]]; then
   # Added or modified files vs base.
   files="$(git diff --name-only --diff-filter=AM "$base"...HEAD)"
 else
-  # All tracked files of relevant types — code (.py/.ts/.tsx/.sh/.bash) + docs (.md).
-  files="$(git ls-files -- '*.py' '*.ts' '*.tsx' '*.sh' '*.bash' '*.md')"
+  # All tracked files of relevant types — code (.py/.ts/.tsx/.js/.mjs/.sh/.bash) + docs (.md).
+  files="$(git ls-files -- '*.py' '*.ts' '*.tsx' '*.js' '*.mjs' '*.sh' '*.bash' '*.md')"
 fi
 
 if [[ -z "$files" ]]; then
@@ -112,7 +112,7 @@ for f in $files; do
   fi
 
   # Code branch (the original lint).
-  [[ "$f" =~ \.(py|ts|tsx|sh|bash)$ ]] || continue
+  [[ "$f" =~ \.(py|ts|tsx|js|mjs|sh|bash)$ ]] || continue
   if grep -E -q "$ALLOWED" <<< "$f"; then continue; fi
 
   if [[ "$mode" == "--diff" ]]; then

--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -240,13 +240,17 @@ fi
 # Anchoring the lookup to SCRIPT_PARENT means it works regardless of
 # REPO_DIR drift — the helper and this script ship in the same commit.
 #
-# Fallback retains the legacy inline default for the rare case where the
-# wrapper isn't present (e.g. extracted-archive install where SCRIPT_PARENT
-# itself lost the helper).
+# Fallback for the rare case where the wrapper isn't present (e.g.
+# extracted-archive install where SCRIPT_PARENT itself lost the helper):
+# mirror the M0 canonical default — <repo>/workspace/ anchored to
+# SCRIPT_PARENT — rather than any home-dir literal. ($SUTANDO_WORKSPACE is
+# deprecated post-#1440: the resolver ignores its value, so honoring it
+# only here would make the fallback DISAGREE with the helper it stands in
+# for.)
 if [ -f "$SCRIPT_PARENT/scripts/sutando-config.sh" ]; then
     WS_DIR="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" workspace)"
 else
-    WS_DIR="${SUTANDO_WORKSPACE:-$HOME/sutando-workspace}"
+    WS_DIR="$SCRIPT_PARENT/workspace"
 fi
 # Disambiguation guard: if WS_DIR points at a public-repo checkout (a
 # legacy-shaped SUTANDO_WORKSPACE value, or — on truly broken installs —

--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -246,7 +246,7 @@ fi
 if [ -f "$SCRIPT_PARENT/scripts/sutando-config.sh" ]; then
     WS_DIR="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" workspace)"
 else
-    WS_DIR="${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}"
+    WS_DIR="${SUTANDO_WORKSPACE:-$HOME/sutando-workspace}"
 fi
 # Disambiguation guard: if WS_DIR points at a public-repo checkout (a
 # legacy-shaped SUTANDO_WORKSPACE value, or — on truly broken installs —


### PR DESCRIPTION
## Summary

Two remaining items from issue #1906 (post-M0 workspace path cleanup) not covered by #1977 (which handled the TS sites):

- **`scripts/lint-workspace-resolution.sh`**: extend file scan to `*.js` and `*.mjs` so future hand-rolled resolution in JS code is caught by CI. Adds `skills/overlay-apps/app/control-server.js` and `main.js` to the ALLOWED list — they legitimately read `process.env.SUTANDO_WORKSPACE` as a one-step deprecated fallback (same rationale as `sync-memory.sh` already being allowlisted). Extension check updated to match `.js`/`.mjs` in the code branch.
- **`scripts/sync-memory.sh:249`**: last-ditch fallback was still pointing at the deprecated dotted `$HOME/.sutando/workspace`; aligned to the post-v0.8 canonical `$HOME/sutando-workspace`.

## Verification

- `bash scripts/lint-workspace-resolution.sh --diff` → `✓ no new workspace-resolution anti-patterns`
- Full scan (`bash scripts/lint-workspace-resolution.sh`) now picks up `.js` files; overlay-apps files are in ALLOWED and not flagged
- `bash -n scripts/sync-memory.sh` passes (syntax check)

## Test plan

- [ ] CI: `refuse new direct workspace-path resolution` check should pass (diff-mode lint scan)
- [ ] CI: `tsc + tests (clean install)` — shell-only changes, TS compilation unaffected
- [ ] No existing JS files newly flagged (overlay-apps are in ALLOWED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB3qZQrwponfum2JFNvHeh