### PR TITLE
feat(result-router): §7 audit ledger sink + Slack delivery wiring (Router v1 S5)

### DIFF
--- a/src/result_audit.py
+++ b/src/result_audit.py
@@ -1,0 +1,56 @@
+"""Result-delivery audit ledger (Result Router spec §7) — the append-only sink.
+
+Answers "did the user ever actually see this result?" without grepping four
+bridge logs. Each outbound result gets exactly one line:
+
+    <iso_ts>\t<task_id>\t<disposition>\t<surface>
+
+written to `<workspace>/state/result-audit.log`. The *line format* is the pure
+`result_router.audit_line` (no I/O, no clock); this module is the thin I/O
+wrapper that stamps the time and appends — the same separation `outbox_log`
+uses for outbound-message visibility.
+
+**Never raises.** Auditing must not block or break delivery: every failure
+(unresolvable workspace, unwritable file, bad input) silently no-ops. Bridges
+call `record(...)` immediately AFTER a delivery attempt resolves — logging what
+actually happened, not what was attempted.
+
+`disposition` should be one of `result_router.Disposition`
+(delivered / redirected / deduped / no_send / late_result / failed).
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from workspace_default import resolve_workspace  # noqa: E402
+import result_router  # noqa: E402
+
+
+def _audit_path() -> Path:
+    return resolve_workspace() / "state" / "result-audit.log"
+
+
+def record(task_id: str, disposition: str, surface: str, ts: str | None = None) -> None:
+    """Append one §7 audit line for a resolved delivery. Never raises.
+
+    `ts` defaults to now (ISO-8601 UTC); callers may pass an explicit stamp for
+    determinism (tests) or to match the delivery's own timestamp.
+    """
+    try:
+        if ts is None:
+            ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        line = result_router.audit_line(task_id or "unknown", disposition, surface, ts)
+        path = _audit_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except Exception:
+        # Observability must never block or crash delivery.
+        pass

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -694,10 +694,12 @@ def _send_reply(channel: str, thread_ts: str | None, text: str, task_id: str | N
     # [channel:] redirect — for cross-channel posting (e.g., reply to a DM
     # task by sending into a public channel instead). Drop thread_ts since
     # we're moving to a new channel.
+    redirected = False
     for action in parsed.actions:
         if action.kind == "redirect":
             channel = action.value
             thread_ts = None
+            redirected = True
             break
 
     file_paths = [a.value for a in parsed.actions if a.kind == "attach"]
@@ -787,6 +789,20 @@ def _send_reply(channel: str, thread_ts: str | None, text: str, task_id: str | N
                 "file_count": sent_files,
             },
         )
+
+    # §7 audit ledger (Result Router S5): one line per resolved delivery so
+    # "did the user ever see this?" is answerable without grepping bridge logs.
+    # Guarded + never-raising — auditing must not block or crash delivery.
+    if clean_text or file_paths:
+        try:
+            import result_audit
+            result_audit.record(
+                task_id or "",
+                "failed" if not delivered_ok else ("redirected" if redirected else "delivered"),
+                "slack",
+            )
+        except Exception:  # pragma: no cover  (defensive: result_audit import is safe + record() never raises)
+            pass
 
 
 def _check_task_timeouts() -> None:

--- a/tests/result-audit.test.py
+++ b/tests/result-audit.test.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Tests for src/result_audit.py — the Result Router §7 audit ledger sink.
+
+`record()` appends one `<iso_ts>\\t<task_id>\\t<disposition>\\t<surface>` line to
+`<workspace>/state/result-audit.log`, and must NEVER raise (observability can't
+block delivery). Runs against a hermetic temp workspace (SUTANDO_TEST_MODE=1).
+
+Run: python3 tests/result-audit.test.py   (exit 0 pass / 1 fail)
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Hermetic workspace before importing the module (it resolves the path lazily,
+# but set it up front so _audit_path() lands in the temp dir).
+_WS = tempfile.mkdtemp()
+os.environ["SUTANDO_WORKSPACE"] = _WS
+os.environ["SUTANDO_TEST_MODE"] = "1"
+
+spec = importlib.util.spec_from_file_location("result_audit", REPO / "src" / "result_audit.py")
+ra = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ra)
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + name + ((" — " + detail) if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+AUDIT = Path(_WS) / "state" / "result-audit.log"
+
+# 1. A basic record writes exactly one tab-separated §7 line.
+ra.record("task-abc-1", "delivered", "discord", ts="2026-07-07T06:00:00Z")
+lines = AUDIT.read_text().splitlines()
+check("writes one line", len(lines) == 1, str(lines))
+check("line is the §7 tab format",
+      lines[0] == "2026-07-07T06:00:00Z\ttask-abc-1\tdelivered\tdiscord", repr(lines[0]))
+
+# 2. Appends (does not truncate).
+ra.record("task-def-2", "redirected", "slack", ts="2026-07-07T06:01:00Z")
+ra.record("task-ghi-3", "failed", "telegram", ts="2026-07-07T06:02:00Z")
+lines = AUDIT.read_text().splitlines()
+check("appends across calls", len(lines) == 3)
+check("fields cut cleanly on tab",
+      [l.split("\t")[2] for l in lines] == ["delivered", "redirected", "failed"],
+      str([l.split("\t")[2] for l in lines]))
+
+# 3. ts defaults to an ISO-8601 UTC stamp when omitted.
+ra.record("task-jkl-4", "no_send", "voice")
+last = AUDIT.read_text().splitlines()[-1]
+ts0 = last.split("\t")[0]
+check("default ts is ISO-8601 UTC", ts0.endswith("Z") and "T" in ts0 and len(ts0) == 20, repr(ts0))
+
+# 4. Never raises — empty task_id falls back, weird disposition/surface still logged.
+try:
+    ra.record("", "delivered", "discord", ts="2026-07-07T06:03:00Z")
+    ra.record("task-x", "some-unknown-disposition", "", ts="2026-07-07T06:04:00Z")
+    check("empty task_id falls back to 'unknown'",
+          "\tunknown\t" in AUDIT.read_text())
+    check("does not raise on odd inputs", True)
+except Exception as e:
+    check("does not raise on odd inputs", False, str(e))
+
+# 5. Never raises even when the sink path can't be written (unresolvable ws).
+#    Point resolve at a file-as-directory so mkdir/open fail; record must no-op.
+_saved = ra._audit_path
+try:
+    bad = Path(_WS) / "not-a-dir-file"
+    bad.write_text("x")  # a file where a dir would need to be
+    ra._audit_path = lambda: bad / "state" / "result-audit.log"  # parent is a file → mkdir raises
+    try:
+        ra.record("task-boom", "delivered", "discord")
+        check("never raises when path unwritable", True)
+    except Exception as e:
+        check("never raises when path unwritable", False, str(e))
+finally:
+    ra._audit_path = _saved
+
+if failures:
+    print(f"\nFAIL — {len(failures)} check(s) failed: {failures}")
+    raise SystemExit(1)
+print("\nPASS — result_audit sink tests")

--- a/tests/slack-bridge-chunking.test.py
+++ b/tests/slack-bridge-chunking.test.py
@@ -127,6 +127,21 @@ mod._send_reply("C0FAKECHAN", "1699999999.000100", "line\n" * 2000)  # long, for
 check("slack: threaded reply keeps thread_ts on every chunk",
       len(client.calls) > 1 and all(c.get("thread_ts") == "1699999999.000100" for c in client.calls))
 
+# S5 wiring — _send_reply records a §7 audit line to the temp workspace ledger.
+_audit = Path(os.environ["SUTANDO_WORKSPACE"]) / "state" / "result-audit.log"
+check("slack wiring: _send_reply wrote a result-audit line", _audit.exists())
+_atext = _audit.read_text() if _audit.exists() else ""
+check("slack wiring: audit line records surface=slack", "\tslack" in _atext)
+check("slack wiring: successful sends recorded 'delivered'", "\tdelivered\tslack" in _atext)
+
+# redirect disposition: a [channel:] marker routes to a target → 'redirected'.
+client.calls.clear()
+mod._send_reply("C0ORIG", None, "[channel: C0TARGET]\nrerouted body", task_id="task-r")
+check("slack wiring: [channel:] redirect records 'redirected'",
+      "\tredirected\tslack" in _audit.read_text())
+check("slack wiring: redirect actually posts to the target channel",
+      any(c["channel"] == "C0TARGET" for c in client.calls))
+
 if failures:
     print(f"\nFAIL — {len(failures)} check(s) failed: {failures}")
     raise SystemExit(1)


### PR DESCRIPTION
## North-star box

**Result Router (Delegation — result route-back): S5, the §7 audit ledger + delivery wiring.** Follows S4 (#1972, the policy) and S3 (#1982, the shared chunker), both merged.

## What this lands

1. **`src/result_audit.py`** — the never-raise §7 sink over the pure `result_router.audit_line`. `record(task_id, disposition, surface, ts=None)` stamps the time and appends one `<iso_ts>\t<task_id>\t<disposition>\t<surface>` line to `<workspace>/state/result-audit.log` — the "**did the user ever actually see this result?**" ledger. Mirrors `outbox_log`'s never-block-delivery contract (every failure silently no-ops).

2. **Slack delivery wired** — `slack-bridge._send_reply` now records one audit line per resolved delivery: `delivered` / `redirected` (a `[channel:]` reroute) / `failed`, via a guarded, never-blocking call.

## Scope note — Discord/Telegram deferred to an immediate follow-up

Slack's `_send_reply` is a clean, unit-testable delivery choke point, so its wiring is fully covered end-to-end. **Discord and Telegram deliver inside long async pollers** (`poll_results` / the Telegram poll loop) with no small testable entry point — wiring them cleanly (so the added lines are actually covered, not just added) needs a delivery-path extraction first. Rather than red the coverage gate or ship untested edits to the live delivery path, that lands as the next PR. The §9.3 delivery-failure owner-DM (via `DeliveryFailure`/`delivery_failure_notice`) rides with it.

## Tests / eval

- `tests/result-audit.test.py` — sink format, append, default+explicit ts, empty-id fallback, never-raises-on-unwritable-path.
- `tests/slack-bridge-chunking.test.py` — extended to drive `_send_reply` (stubbed `slack_bolt`, temp workspace) and assert the audit line is written for both the `delivered` and `[channel:]`-`redirected` cases.
- `result_audit.py` + the Slack changes: **diff-cover 100%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
