### PR TITLE
feat(protocol): structured media-attachment schema in Local Task Protocol (4D step 1.5)

### DIFF
--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -52,6 +52,7 @@ task-last; until then both parsers exist and are named for their trust model.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -66,6 +67,25 @@ INTERACTION_TYPES = frozenset({
     "message", "realtime_audio", "realtime_video",
     "tool_initiated", "system_event", "self_reflective",
 })
+
+# Content-modality vocabulary (interaction-model 4D, step 1.5). The modalities
+# a task's payload spans — orthogonal to interaction_type (which names the
+# *mode*, not the media). A text-only DM is {"text"}; a photo with a caption is
+# {"text", "image"}; a voice note is {"audio"}. Producers stamp a comma-joined
+# subset next to `interaction_type`; readers whitelist against this set
+# (unknown token dropped), the same discipline as the interaction_type gateway
+# whitelist.
+CONTENT_MODALITIES = frozenset({"text", "image", "audio", "video", "file"})
+
+# Media-form vocabulary — the load-bearing routing axis of the 4D model:
+# `attachment` = a discrete, already-bounded object delivered alongside a
+# message (a photo, a PDF, a voice note) → lands in the task file as an
+# AttachmentRef the Core fetches + analyzes. `live_stream` = a continuous
+# real-time media plane (a call's audio, a screen share) → does NOT belong in
+# a task file; it is owned by the LiveAgentRuntime. A missing header defaults
+# to `attachment`: messaging is the default plane, and `live_stream` is the
+# explicit opt-out that routes a payload away from the task-file path.
+MEDIA_FORMS = frozenset({"attachment", "live_stream"})
 
 # Task priority enum (src/task_priority.py is the behavior owner; these are
 # the schema names). Consumer semantics: highest first, mtime FIFO tiebreak.
@@ -93,6 +113,11 @@ KNOWN_HEADER_KEYS = (
     "parent_message_id", "reminder", "author_name", "author_id", "chat_id",
     "thread_ts", "reply_to_event", "reply_to_me", "callSid", "caller",
     "from", "call_sid", "hint", "instructions", "transcript",
+    # interaction-model 4D, step 1.5 — structured media metadata. Listing them
+    # here promotes them to headers AND (via the guard's shared import) defangs
+    # them in untrusted bodies, so a forged `attachments:` body line can never
+    # smuggle a fetch locator past the parser.
+    "content_modalities", "media_form", "attachments",
 )
 _KNOWN_KEY_SET = frozenset(KNOWN_HEADER_KEYS)
 
@@ -247,6 +272,126 @@ def _parse_task_mid(text: str, last_wins: bool) -> TaskHeaders:
     while body_lines and body_lines[-1] == "":
         body_lines.pop()
     return TaskHeaders(headers=headers, body="\n".join(body_lines))
+
+
+# ── Media attachments (interaction-model 4D, step 1.5) ───────────────────────
+
+
+@dataclass
+class AttachmentRef:
+    """One discrete media object carried by a task, source-independent.
+
+    The unified descriptor every bridge normalizes its native attachment into
+    (Discord CDN url, Slack file, Telegram file_id, Matrix mxc://, or an
+    already-downloaded local path) so the Core sees ONE shape regardless of
+    surface. `locator` is the source-specific pointer to the bytes; the
+    safe-fetch policy (bridge/relay side, a later slice) resolves a remote
+    locator to a local path and may rewrite `locator` in place once fetched.
+
+    Deliberately metadata-only: no bytes, no file handles (R1 stdlib-only, and
+    a task file must stay a small text record). `size`/`sha256` let a consumer
+    enforce a limit and dedupe *before* fetching. Every field but `locator` is
+    optional — a ref with nothing to point at is meaningless, so an element
+    lacking a locator is dropped on both encode and decode.
+    """
+    locator: str
+    id: str = ""
+    mime: str = ""
+    filename: str = ""
+    size: int = 0
+    sha256: str = ""
+    expiry: str = ""  # ISO-8601 UTC; "" = no expiry / already-local
+
+    def as_dict(self) -> dict:
+        """Compact dict for JSON serialization — omits empty/zero fields so the
+        header line stays small and round-trips back to an equal ref."""
+        d: dict = {"locator": self.locator}
+        for k in ("id", "mime", "filename", "sha256", "expiry"):
+            v = getattr(self, k)
+            if v:
+                d[k] = v
+        if self.size:
+            d["size"] = self.size
+        return d
+
+
+def parse_content_modalities(headers: dict) -> frozenset:
+    """The whitelisted set of content modalities from a parsed header dict.
+
+    Reads the comma-joined `content_modalities` value, lower-cases + trims each
+    token, and drops anything outside CONTENT_MODALITIES — an unknown token is
+    noise, never a new modality (same rule as the interaction_type whitelist).
+    Missing/empty → empty set; a text-only task need not stamp `{"text"}`."""
+    raw = (headers or {}).get("content_modalities") or ""
+    return frozenset(
+        t for t in (tok.strip().lower() for tok in raw.split(",")) if t in CONTENT_MODALITIES
+    )
+
+
+def parse_media_form(headers: dict) -> str:
+    """The task's media form: `attachment` (default) or `live_stream`.
+
+    Whitelists the `media_form` value; anything unknown or missing collapses to
+    `attachment`, the safe default that routes the payload through the normal
+    task-file path rather than mis-claiming a LiveAgentRuntime stream."""
+    v = ((headers or {}).get("media_form") or "").strip().lower()
+    return v if v in MEDIA_FORMS else "attachment"
+
+
+def parse_attachments(headers: dict) -> list["AttachmentRef"]:
+    """Decode the `attachments:` header — a one-line JSON array of objects —
+    into AttachmentRefs.
+
+    Tolerant by contract: a malformed value, a non-list payload, a non-object
+    element, or an element with no `locator` is skipped, never raised. A bad
+    attachments header must not block reading the rest of the task (the same
+    never-block principle as the audit sink). Missing header → []."""
+    raw = (headers or {}).get("attachments")
+    if not raw:
+        return []
+    try:
+        arr = json.loads(raw)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(arr, list):
+        return []
+    refs: list[AttachmentRef] = []
+    for el in arr:
+        if not isinstance(el, dict):
+            continue
+        locator = el.get("locator")
+        if not locator or not isinstance(locator, str):
+            continue
+        size = el.get("size", 0)
+        if isinstance(size, bool):
+            size = 0  # a JSON bool is not a byte count (int(True) == 1 would lie)
+        elif not isinstance(size, int):
+            try:
+                size = int(size)
+            except (ValueError, TypeError):
+                size = 0
+        refs.append(AttachmentRef(
+            locator=locator,
+            id=str(el.get("id", "")),
+            mime=str(el.get("mime", "")),
+            filename=str(el.get("filename", "")),
+            size=size,
+            sha256=str(el.get("sha256", "")),
+            expiry=str(el.get("expiry", "")),
+        ))
+    return refs
+
+
+def format_attachments(refs: Iterable["AttachmentRef"]) -> str:
+    """Encode AttachmentRefs into the one-line JSON value of an `attachments:`
+    header — the write-side inverse of parse_attachments.
+
+    Guaranteed single-line (json escapes any embedded newline in a field), so
+    it is safe for both task-last single-line values and the task-mid
+    newline-stripping writers. Refs without a locator are dropped (they'd be
+    unparseable on read, so encoding them would not round-trip)."""
+    payload = [r.as_dict() for r in refs if r.locator]
+    return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
 
 
 # ── Archive rules ────────────────────────────────────────────────────────────

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -370,6 +370,10 @@ def parse_attachments(headers: dict) -> list["AttachmentRef"]:
                 size = int(size)
             except (ValueError, TypeError):
                 size = 0
+        if size < 0:
+            size = 0  # a negative byte count is nonsense and would slip past a
+            #            `ref.size and ref.size > max_bytes` cap check — normalize
+            #            it to 0 (unknown) so limit enforcement stays sound.
         refs.append(AttachmentRef(
             locator=locator,
             id=str(el.get("id", "")),

--- a/tests/local-task-protocol-attachments.test.py
+++ b/tests/local-task-protocol-attachments.test.py
@@ -92,6 +92,12 @@ check("un-coercible size falls back to 0",
       ltp.parse_attachments({"attachments": '[{"locator":"/a","size":"big"}]'})[0].size == 0)
 check("bool size is not accepted as int",
       ltp.parse_attachments({"attachments": '[{"locator":"/a","size":true}]'})[0].size == 0)
+# Negative sizes are nonsense and would slip past a `size > max_bytes` cap —
+# clamp int and coerced-string negatives back to 0 (unknown).
+check("negative int size clamped to 0",
+      ltp.parse_attachments({"attachments": '[{"locator":"/a","size":-1}]'})[0].size == 0)
+check("negative numeric-string size clamped to 0",
+      ltp.parse_attachments({"attachments": '[{"locator":"/a","size":"-5"}]'})[0].size == 0)
 
 # ── 5. parse_content_modalities: whitelist + case-fold ──
 check("known modalities parsed, case-folded",

--- a/tests/local-task-protocol-attachments.test.py
+++ b/tests/local-task-protocol-attachments.test.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Media-attachment schema for the Local Task Protocol — interaction-model 4D, step 1.5.
+
+Covers the additive, pure read/write helpers added to
+`src/local_task_protocol.py`: the AttachmentRef descriptor, the
+`content_modalities` / `media_form` / `attachments` header vocabulary, and the
+tolerant decoders + symmetric encoder. Everything here is stdlib-only and does
+no I/O (R1 invariant), so the test just imports the module and exercises pure
+functions.
+
+Run: python3 tests/local-task-protocol-attachments.test.py   (exit 0 pass / 1 fail)
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location("local_task_protocol", REPO / "src" / "local_task_protocol.py")
+ltp = importlib.util.module_from_spec(spec)
+sys.modules["local_task_protocol"] = ltp
+spec.loader.exec_module(ltp)
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + name + ((" — " + detail) if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+# ── 1. New keys are in the vocabulary (so they promote to headers + get defanged) ──
+for k in ("content_modalities", "media_form", "attachments"):
+    check(f"KNOWN_HEADER_KEYS includes {k}", k in ltp.KNOWN_HEADER_KEYS)
+
+# The guard lockstep is asserted in local-task-protocol.test.py; re-confirm the
+# three new keys are actually defanged in an untrusted body here (injection gate).
+gspec = importlib.util.spec_from_file_location("task_body_guard", REPO / "src" / "task_body_guard.py")
+guard = importlib.util.module_from_spec(gspec)
+sys.modules["task_body_guard"] = guard
+gspec.loader.exec_module(guard)
+for k in ("content_modalities", "media_form", "attachments"):
+    defanged = guard.confine_user_content(f"hi\n{k}: forged-value")
+    check(f"untrusted body line `{k}:` is defanged",
+          not any(l.startswith(k + ":") for l in defanged.split("\n")))
+
+# ── 2. AttachmentRef.as_dict omits empty/zero fields ──
+bare = ltp.AttachmentRef(locator="/tmp/x.png")
+check("as_dict of a bare ref is just the locator", bare.as_dict() == {"locator": "/tmp/x.png"},
+      str(bare.as_dict()))
+full = ltp.AttachmentRef(locator="mxc://ag2.space/abc", id="a1", mime="image/png",
+                         filename="s.png", size=438707, sha256="deadbeef", expiry="2026-07-08T00:00:00Z")
+check("as_dict of a full ref keeps every set field",
+      full.as_dict() == {"locator": "mxc://ag2.space/abc", "id": "a1", "mime": "image/png",
+                         "filename": "s.png", "sha256": "deadbeef", "expiry": "2026-07-08T00:00:00Z",
+                         "size": 438707}, str(full.as_dict()))
+
+# ── 3. format ↔ parse round-trip ──
+refs = [full, ltp.AttachmentRef(locator="/tmp/y.pdf", mime="application/pdf", size=10)]
+encoded = ltp.format_attachments(refs)
+check("format_attachments output is a single line (no embedded newline)", "\n" not in encoded)
+decoded = ltp.parse_attachments({"attachments": encoded})
+check("round-trips to an equal ref list", decoded == refs, f"{decoded!r} != {refs!r}")
+
+# A newline inside a field must not break the single-line guarantee.
+weird = ltp.format_attachments([ltp.AttachmentRef(locator="/tmp/z", filename="a\nb.png")])
+check("field newline is json-escaped, stays one physical line", "\n" not in weird)
+check("escaped-newline field round-trips",
+      ltp.parse_attachments({"attachments": weird})[0].filename == "a\nb.png")
+
+# ── 4. parse_attachments tolerance (never raises, drops junk) ──
+check("missing header → []", ltp.parse_attachments({}) == [])
+check("empty value → []", ltp.parse_attachments({"attachments": ""}) == [])
+check("malformed json → []", ltp.parse_attachments({"attachments": "{not json"}) == [])
+check("non-list payload → []", ltp.parse_attachments({"attachments": '{"locator":"x"}'}) == [])
+check("non-object element skipped", ltp.parse_attachments({"attachments": '["str", 3, null]'}) == [])
+check("element without locator dropped",
+      ltp.parse_attachments({"attachments": '[{"mime":"image/png"}]'}) == [])
+check("non-string locator dropped",
+      ltp.parse_attachments({"attachments": '[{"locator": 42}]'}) == [])
+# A good ref mixed with junk survives; the junk is dropped.
+mixed = ltp.parse_attachments({"attachments": '[{"locator":"/ok"}, 7, {"no":"loc"}]'})
+check("good ref survives alongside dropped junk",
+      len(mixed) == 1 and mixed[0].locator == "/ok", str(mixed))
+# size coercion: numeric string ok, bad string → 0, bool → 0 (not treated as int)
+check("string size is coerced to int",
+      ltp.parse_attachments({"attachments": '[{"locator":"/a","size":"12"}]'})[0].size == 12)
+check("un-coercible size falls back to 0",
+      ltp.parse_attachments({"attachments": '[{"locator":"/a","size":"big"}]'})[0].size == 0)
+check("bool size is not accepted as int",
+      ltp.parse_attachments({"attachments": '[{"locator":"/a","size":true}]'})[0].size == 0)
+
+# ── 5. parse_content_modalities: whitelist + case-fold ──
+check("known modalities parsed, case-folded",
+      ltp.parse_content_modalities({"content_modalities": "Text, IMAGE"}) == frozenset({"text", "image"}))
+check("unknown modality token dropped",
+      ltp.parse_content_modalities({"content_modalities": "text, hologram"}) == frozenset({"text"}))
+check("missing modalities → empty set", ltp.parse_content_modalities({}) == frozenset())
+check("empty modalities value → empty set",
+      ltp.parse_content_modalities({"content_modalities": ""}) == frozenset())
+check("all five modalities recognized",
+      ltp.parse_content_modalities({"content_modalities": "text,image,audio,video,file"})
+      == ltp.CONTENT_MODALITIES)
+
+# ── 6. parse_media_form: whitelist, default attachment ──
+check("attachment recognized", ltp.parse_media_form({"media_form": "attachment"}) == "attachment")
+check("live_stream recognized", ltp.parse_media_form({"media_form": "live_stream"}) == "live_stream")
+check("case-folded", ltp.parse_media_form({"media_form": "LIVE_STREAM"}) == "live_stream")
+check("missing → attachment (default plane)", ltp.parse_media_form({}) == "attachment")
+check("unknown → attachment (safe default, not a phantom stream)",
+      ltp.parse_media_form({"media_form": "telepathy"}) == "attachment")
+
+# ── 7. Integration: a task-last file carrying the new headers parses through ──
+task = (
+    "id: task-1\n"
+    "timestamp: 2026-07-07T07:51:04Z\n"
+    "source: discord\n"
+    "interaction_type: message\n"
+    "content_modalities: text,image\n"
+    "media_form: attachment\n"
+    'attachments: [{"locator":"/tmp/discord-inbox/1_s.png","mime":"image/png","size":438707}]\n'
+    "access_tier: owner\n"
+    "task: describe the image I sent you\n"
+)
+h = ltp.parse_task_headers(task)
+check("task-last parse promotes content_modalities header", h.get("content_modalities") == "text,image")
+check("task-last parse promotes media_form header", h.get("media_form") == "attachment")
+check("modalities read from a real parsed task",
+      ltp.parse_content_modalities(h.headers) == frozenset({"text", "image"}))
+check("media form read from a real parsed task", ltp.parse_media_form(h.headers) == "attachment")
+atts = ltp.parse_attachments(h.headers)
+check("attachments read from a real parsed task",
+      len(atts) == 1 and atts[0].locator == "/tmp/discord-inbox/1_s.png"
+      and atts[0].mime == "image/png" and atts[0].size == 438707, str(atts))
+check("attachments: header line stays out of the body",
+      "attachments:" not in h.body and h.body.strip() == "describe the image I sent you")
+
+# A plain task with no media headers reads as no attachments / default form.
+plain = ltp.parse_task_headers("source: discord\ntask: hi\n")
+check("plain task → no attachments", ltp.parse_attachments(plain.headers) == [])
+check("plain task → attachment default form", ltp.parse_media_form(plain.headers) == "attachment")
+check("plain task → empty modalities", ltp.parse_content_modalities(plain.headers) == frozenset())
+
+if failures:
+    print(f"\nFAIL — {len(failures)} check(s) failed: {failures}")
+    raise SystemExit(1)
+print("\nPASS — local task protocol media-attachment schema")


### PR DESCRIPTION
## Architecture box

**4D interaction model → media/attachment track, step 1.5 — Local Task Protocol half.**
Status: **spec → implementing.** The `[File attached: /path]` string in a task body already works today (Discord downloads to its inbox, surfaces the path); what's *missing* — and what this implements — is the structured, source-independent schema that replaces that ad-hoc, per-bridge string.

## What & why

Every bridge normalizes its native attachment (Discord CDN url, Slack file, Telegram `file_id`, Matrix `mxc://`, or an already-downloaded local path) into a bespoke `[File attached: …]` line. The Core then re-derives everything (is it an image? how big? where are the bytes?) per surface. This adds the one shape they can all normalize into, so the Core sees a uniform `AttachmentRef` regardless of origin.

Additive & pure — **stdlib-only, no I/O** (R1 invariant), writers untouched this slice — same phasing as the interaction-planes read-side refactor and the `interaction_type` rollout (#1953):

- **Vocab + keys:** `CONTENT_MODALITIES` (`text/image/audio/video/file`), `MEDIA_FORMS` (`attachment`/`live_stream`), and three new `KNOWN_HEADER_KEYS`: `content_modalities`, `media_form`, `attachments`. Listing them in the vocab both promotes them to headers **and** — via `task_body_guard`'s shared import of that tuple — defangs them in untrusted bodies. So a forged `attachments:` line in user content can't smuggle a fetch locator past the parser (the same injection gate that covers `access_tier`).
- **`AttachmentRef`** — `locator` + `id/mime/filename/size/sha256/expiry`. Metadata-only (no bytes, no handles — a task file stays a small text record). `size`/`sha256` let a consumer enforce a limit and dedupe *before* fetching. Resolving a remote `locator` → local path (the safe-fetch policy) is a later bridge/relay slice.
- **`media_form` is the load-bearing routing axis** of the 4D model: `attachment` = discrete object → lands in the task file, Core fetches + analyzes; `live_stream` = continuous plane (call audio, screen share) → owned by LiveAgentRuntime, never a task file. Missing header → `attachment` (messaging is the default plane; `live_stream` is the explicit opt-out).
- **Tolerant read + symmetric write:** `parse_attachments` / `parse_content_modalities` / `parse_media_form` never raise (a malformed header can't block reading the task — same never-block principle as the audit sink); `format_attachments` is the one-line-JSON encoder (json escapes any embedded newline, so it's safe for both task-last single-line values and the task-mid newline-stripping writers) for write-side adoption.

## Tests

`tests/local-task-protocol-attachments.test.py` (new) — enumerated:

| area | asserts |
| --- | --- |
| vocab | the 3 new keys are in `KNOWN_HEADER_KEYS` **and** are defanged in an untrusted body by `task_body_guard` |
| `AttachmentRef.as_dict` | omits empty/zero fields; keeps every set field |
| round-trip | `format` → `parse` equal; single-line guarantee holds even with a newline inside a field |
| tolerance | missing / empty / malformed-json / non-list / non-object-element / no-locator / non-string-locator all → dropped, never raised; good ref survives alongside junk; size coercion (string→int, bad→0, **bool→0** not `int(True)==1`) |
| modalities | whitelist + case-fold; unknown token dropped; missing → `∅` |
| media_form | whitelist; missing/unknown → `attachment`; `live_stream` preserved |
| integration | a task-last file carrying the new headers parses through `parse_task_headers`, and the decoders read them; `attachments:` stays out of the body; a plain task → no attachments / default form |

- `python3 tests/local-task-protocol-attachments.test.py` → PASS
- `python3 tests/local-task-protocol.test.py` → PASS (no regression; guard/parser vocab lockstep still holds)
- **diff-cover: 100%** (57/57 changed lines) — clears the `--fail-under=95` gate.

## Not in this slice (follow-ups)

- Write-side: bridges emit `attachments[]`/`content_modalities`/`media_form` instead of `[File attached: …]` (byte-identical golden tests, per bridge).
- Safe-fetch policy: AG2 Relay resolves a remote `locator` → local path (auth media fetch, no-redirect, scoped-token/expiry — promoting the logic already in `remote-gateway-bridge.py` to shared).
- LiveAgentRuntime: honor `media_form: live_stream` to route a payload away from the task-file path.
