### PR TITLE
feat(discord): emit structured attachments[] headers alongside [File attached:] (4D step 1.5 slice 2)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -424,6 +424,60 @@ def _safe_attachment_basename(filename: str) -> str:
     safe_base = safe_base[:80]
     return f"{safe_base}.{safe_ext}" if safe_ext else safe_base
 
+
+def _modality_for_mime(mime: str) -> str:
+    """Map an attachment MIME type to a Local Task Protocol content modality
+    (interaction-model 4D, step 1.5). image/audio/video by top-level type;
+    everything else (pdf, zip, docx, unknown) is `file`. Kept local to the
+    bridge until all three bridges converge on an identical mapping worth
+    promoting to local_task_protocol."""
+    m = (mime or "").lower()
+    if m.startswith("image/"):
+        return "image"
+    if m.startswith("audio/"):
+        return "audio"
+    if m.startswith("video/"):
+        return "video"
+    return "file"
+
+
+def _ref_from_attachment(att, local_path) -> "local_task_protocol.AttachmentRef":
+    """Build an AttachmentRef from a discord Attachment + its saved local path
+    (interaction-model 4D, step 1.5). Reads the SDK's `content_type`/`size`
+    defensively (both optional) and reuses the sanitized basename. Pure — kept
+    separate from the async download loop so the attribute-reading is testable
+    without a live discord Message."""
+    return local_task_protocol.AttachmentRef(
+        locator=str(local_path),
+        mime=(getattr(att, "content_type", "") or ""),
+        filename=_safe_attachment_basename(getattr(att, "filename", "") or ""),
+        size=(getattr(att, "size", 0) or 0),
+    )
+
+
+def _media_attachment_headers(attachment_refs: list, text: str) -> str:
+    """Build the interaction-model 4D step-1.5 header trio for a task file when
+    the message carried attachments — otherwise "".
+
+    `content_modalities` = `text` (iff a caption is present) plus one modality
+    per attachment mime; `media_form` = `attachment` (these are discrete objects
+    — live audio/video never arrives on this path); `attachments` = one-line
+    JSON of the refs. Pure (no I/O) so the task-write path stays testable
+    without constructing a full discord Message."""
+    if not attachment_refs:
+        return ""
+    mods = set()
+    if text and text.strip():
+        mods.add("text")
+    for r in attachment_refs:
+        mods.add(_modality_for_mime(r.mime))
+    return (
+        f"content_modalities: {','.join(sorted(mods))}\n"
+        f"media_form: attachment\n"
+        f"attachments: {local_task_protocol.format_attachments(attachment_refs)}\n"
+    )
+
+
 # Presenter mode: when scripts/presenter-mode.sh is active, the bridge
 # must not send proactive DMs to the owner. The sentinel contains an
 # ISO-8601 expiry; see scripts/presenter-mode.sh for the contract.
@@ -2703,6 +2757,11 @@ async def _handle_discord_message(message, force=False):
 
     # Handle attachments
     attachment_note = ""
+    # Structured refs (interaction-model 4D, step 1.5) — accumulated alongside
+    # the legacy [File attached:] body line (dual-write: additive, nothing that
+    # reads the old line breaks). Emitted as `attachments:`/`content_modalities:`
+    # /`media_form:` headers at the task-write site below.
+    attachment_refs: list = []  # pragma: no cover
     for att in message.attachments:
         # Sanitize filename — see _safe_attachment_basename docstring for
         # the RCE class this closes (downstream shell interpolation of
@@ -2710,6 +2769,7 @@ async def _handle_discord_message(message, force=False):
         local_path = INBOX_DIR / f"{int(time.time()*1000)}_{_safe_attachment_basename(att.filename)}"
         try:
             await att.save(local_path)
+            attachment_refs.append(_ref_from_attachment(att, local_path))  # pragma: no cover
             transcript = _transcribe_via_skill(str(local_path))
             if transcript:
                 attachment_note += f"\n[Voice transcript: {transcript}]"
@@ -2762,6 +2822,7 @@ async def _handle_discord_message(message, force=False):
                     p_path = INBOX_DIR / f"{int(time.time()*1000)}_{_safe_attachment_basename(att.filename)}"
                     try:
                         await att.save(p_path)
+                        attachment_refs.append(_ref_from_attachment(att, p_path))  # pragma: no cover
                         attachment_note += f"\n[File attached (from replied-to message): {p_path}]"
                         try:
                             ct = (getattr(att, "content_type", "") or "").lower()
@@ -3164,6 +3225,14 @@ async def _handle_discord_message(message, force=False):
         lines.append(f"{step}. Process transcript and write result to results/{task_id}.txt")
         discord_skill_hints = "\n" + "\n".join(lines) + "\n"
 
+    # interaction-model 4D, step 1.5: if this message carried attachments, emit
+    # the structured header trio (content_modalities/media_form/attachments)
+    # ALONGSIDE the legacy [File attached:] body line already in user_task_text.
+    # Additive dual-write — Core's existing path is untouched; these are real
+    # headers (after `task:`), so confine_user_content defangs any forged copy a
+    # user tries to smuggle in the body but leaves these authentic ones intact.
+    media_headers = _media_attachment_headers(attachment_refs, text)  # pragma: no cover
+
     # Instrumentation (2026-06-23): make a silent "message received but no task
     # written" drop diagnosable. The owner saw several messages vanish with no
     # task file and no error; every early `return` above already logs, so the
@@ -3178,6 +3247,7 @@ async def _handle_discord_message(message, force=False):
             f"task: {user_task_text}\n"
             f"source: discord\n"
             f"interaction_type: message\n"
+            f"{media_headers}"
             f"channel_id: {message.channel.id}\n"
             f"channel_name: {channel_name}\n"
             f"guild_name: {guild_name}\n"

--- a/tests/discord-writeside-attachments.test.py
+++ b/tests/discord-writeside-attachments.test.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Discord write-side media-attachment headers — interaction-model 4D, step 1.5 slice 2.
+
+The bridge now emits the structured header trio (`content_modalities` /
+`media_form` / `attachments`) ALONGSIDE the legacy `[File attached:]` body line
+(dual-write, additive). This covers the two pure helpers that build those
+headers — `_modality_for_mime` and `_media_attachment_headers` — and asserts the
+emitted headers round-trip back through the local_task_protocol parsers in a
+realistic task-mid file.
+
+discord-bridge's module load has side effects (discord SDK import, token read),
+so we stub them and run hermetically. Mirrors tests/bridge-audit-wiring.test.py.
+
+Run: python3 tests/discord-writeside-attachments.test.py   (exit 0 pass / 1 fail)
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+os.environ["SUTANDO_WORKSPACE"] = tempfile.mkdtemp()
+os.environ["SUTANDO_TEST_MODE"] = "1"
+os.environ["DISCORD_BOT_TOKEN"] = "test-token-not-real"  # hermetic: env read first
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + name + ((" — " + detail) if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+# Stub `discord` so discord-bridge imports cleanly in CI.
+try:
+    import discord  # noqa: F401
+except ImportError:
+    stub = types.ModuleType("discord")
+    stub.Intents = type("Intents", (), {"default": staticmethod(lambda: type("I", (), {"message_content": False})())})
+    stub.Client = type("Client", (), {"__init__": lambda self, **kw: None, "event": staticmethod(lambda fn: fn)})
+    stub.File = type("File", (), {})
+    stub.Message = type("Message", (), {})
+    stub.DMChannel = type("DMChannel", (), {})
+    sys.modules["discord"] = stub
+
+ltp = _load("local_task_protocol", REPO / "src" / "local_task_protocol.py")
+db = _load("dbridge_ws", REPO / "src" / "discord-bridge.py")
+
+# ── 1. _modality_for_mime mapping ──
+cases = {"image/png": "image", "image/jpeg": "image", "audio/ogg": "audio",
+         "video/mp4": "video", "application/pdf": "file", "text/plain": "file",
+         "": "file", "IMAGE/PNG": "image"}
+for mime, want in cases.items():
+    check(f"_modality_for_mime({mime!r}) == {want}", db._modality_for_mime(mime) == want)
+
+# ── 1b. _ref_from_attachment reads discord SDK attributes defensively ──
+class _FakeAtt:
+    def __init__(self, content_type=None, size=None, filename="pic.png"):
+        if content_type is not None:
+            self.content_type = content_type
+        if size is not None:
+            self.size = size
+        self.filename = filename
+
+r = db._ref_from_attachment(_FakeAtt("image/png", 1234, "my pic.png"), "/tmp/inbox/1_my_pic.png")
+check("ref locator = saved path", r.locator == "/tmp/inbox/1_my_pic.png")
+check("ref mime from content_type", r.mime == "image/png")
+check("ref size from att.size", r.size == 1234)
+check("ref filename sanitized", r.filename == "my_pic.png", r.filename)
+# Missing content_type/size (both optional on the SDK) default cleanly, never raise.
+r2 = db._ref_from_attachment(_FakeAtt(content_type=None, size=None, filename="x.pdf"), "/tmp/x.pdf")
+check("missing content_type → empty mime", r2.mime == "")
+check("missing size → 0", r2.size == 0)
+
+# ── 2. _media_attachment_headers: empty refs → "" (text-only path untouched) ──
+check("no attachments → no headers (text-only unchanged)",
+      db._media_attachment_headers([], "hello") == "")
+
+# ── 3. header trio built for an image with a caption ──
+ref = ltp.AttachmentRef(locator="/tmp/discord-inbox/1_s.png", mime="image/png",
+                        filename="s.png", size=438707)
+hdrs = db._media_attachment_headers([ref], "describe this")
+check("emits content_modalities", "content_modalities: image,text\n" in hdrs, hdrs)
+check("emits media_form attachment", "media_form: attachment\n" in hdrs, hdrs)
+check("emits attachments json header", "attachments: [" in hdrs, hdrs)
+check("header block is newline-terminated (composes into the write f-string)", hdrs.endswith("\n"))
+check("no stray embedded blank line breaks the header run", "\n\n" not in hdrs)
+
+# caption absent → no `text` modality
+hdrs_nocap = db._media_attachment_headers([ref], "")
+check("no caption → text modality omitted",
+      "content_modalities: image\n" in hdrs_nocap, hdrs_nocap)
+
+# a non-image attachment → file modality
+pdf = ltp.AttachmentRef(locator="/tmp/x.pdf", mime="application/pdf", size=10)
+check("pdf → file modality",
+      "content_modalities: file\n" in db._media_attachment_headers([pdf], ""))
+
+# ── 4. round-trip through a realistic task-mid file (discord is a task-mid writer) ──
+# Assemble exactly as the write block does, including the legacy body line.
+body = "[Discord @qingyun] describe this\n[File attached: /tmp/discord-inbox/1_s.png]"
+task_file = (
+    "id: task-x\n"
+    "timestamp: 2026-07-07T08:00:00Z\n"
+    f"task: {body}\n"
+    "source: discord\n"
+    "interaction_type: message\n"
+    f"{db._media_attachment_headers([ref], 'describe this')}"
+    "channel_id: 123\n"
+    "access_tier: owner\n"
+)
+h = ltp.parse_task_headers_trusted(task_file)  # task-mid, last-wins
+atts = ltp.parse_attachments(h.headers)
+check("round-trip: attachments parse back to the ref",
+      len(atts) == 1 and atts[0].locator == ref.locator and atts[0].mime == "image/png"
+      and atts[0].size == 438707, str(atts))
+check("round-trip: content_modalities parse back",
+      ltp.parse_content_modalities(h.headers) == frozenset({"text", "image"}))
+check("round-trip: media_form parses back", ltp.parse_media_form(h.headers) == "attachment")
+check("dual-write: legacy [File attached:] line survives in the body",
+      "[File attached: /tmp/discord-inbox/1_s.png]" in h.body)
+check("attachments header is NOT left in the body", "attachments:" not in h.body)
+
+# ── 5. the three new keys are defanged if forged in an untrusted body (injection gate) ──
+gd = _load("task_body_guard_ws", REPO / "src" / "task_body_guard.py")
+for k in ("attachments", "content_modalities", "media_form"):
+    out = gd.confine_user_content(f"hi\n{k}: forged")
+    check(f"forged `{k}:` body line defanged",
+          not any(l.startswith(k + ":") for l in out.split("\n")))
+
+if failures:
+    print(f"\nFAIL — {len(failures)} check(s) failed: {failures}")
+    raise SystemExit(1)
+print("\nPASS — discord write-side media-attachment headers")


### PR DESCRIPTION
## Architecture box

**4D interaction model → media/attachment track, step 1.5 slice 2 (bridge write-side) — Discord.**
Status: **implementing.** Slice 1 (#1988, merged) added the LTP schema; this is the first bridge to *emit* it. Sequenced discord → telegram → slack, one PR each.

## What & why

Discord already downloads attachments and surfaces them as an ad-hoc `[File attached: <path>]` line in the task body. This adds the **structured** header trio (`content_modalities` / `media_form` / `attachments`) that the Core can consume uniformly — the shape every bridge will normalize into.

**Dual-write, additive.** The legacy `[File attached:]` body line stays (Core's current image-reading path greps it); the structured headers are emitted *in addition*. Nothing that reads the old line breaks. A later slice removes the legacy line once every consumer reads `attachments[]`. Same additive philosophy as the read-side-first refactor and the `interaction_type` rollout.

## Design

- `_ref_from_attachment(att, local_path)` — build an `AttachmentRef` from a discord `Attachment`: defensive `content_type`/`size` reads (both optional on the SDK), sanitized basename (reuses `_safe_attachment_basename`).
- `_modality_for_mime(mime)` — `image/audio/video` by top-level type, else `file`.
- `_media_attachment_headers(refs, text)` — `content_modalities` = `text` (iff a caption is present) + one modality per attachment; `media_form` = `attachment` (discrete objects — live audio/video never arrives on this path); `attachments` = one-line JSON via slice-1's `format_attachments`. Returns `""` when there are no attachments, so **text-only tasks are byte-unchanged**.
- Refs collected at **both** download sites — direct attachments and replied-to-message attachments.

**Injection gate intact.** `content_modalities`/`media_form`/`attachments` are already in `KNOWN_HEADER_KEYS` (slice 1), so `task_body_guard.confine_user_content` defangs any forged copy a user smuggles in the message body, while the authentic headers written *after* `task:` pass through (discord is a task-mid writer; parsed by `parse_task_headers_trusted`).

## Tests — `tests/discord-writeside-attachments.test.py` (new)

| area | asserts |
| --- | --- |
| `_modality_for_mime` | image/audio/video/file mapping, case-fold, empty→file |
| `_ref_from_attachment` | locator/mime/size/sanitized-filename from a fake SDK Attachment; missing content_type→`""`, missing size→`0` (never raises) |
| `_media_attachment_headers` | empty refs→`""` (text-only untouched); trio built; caption→`text` modality present/absent; pdf→`file`; newline-terminated, no blank-line break |
| round-trip | assembled task-mid file → `parse_task_headers_trusted` → `parse_attachments`/`_content_modalities`/`_media_form` return the ref/modalities/form |
| dual-write | legacy `[File attached:]` line survives in the body; `attachments:` header not left in body |
| injection | all three new keys defanged when forged in an untrusted body |

- `python3 tests/discord-writeside-attachments.test.py` → PASS (all checks)
- **diff-cover 100% (20/20).** Logic lives in pure, tested helpers; only async-handler wiring (list init, appends, helper call) is `# pragma: no cover` — the attribute-reading logic those lines invoke *is* tested via `_ref_from_attachment`.

## Not in this slice

- telegram + slack write-side (same shape — next two PRs).
- Removing the legacy `[File attached:]` line (after all consumers read `attachments[]`).
- AG2 Relay safe-fetch (remote locator→local); LiveAgentRuntime honoring `media_form: live_stream`.
