### PR TITLE
feat(telegram): emit structured attachments[] headers alongside [*attached:] (4D step 1.5 slice 2)

### DIFF
--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -40,6 +40,7 @@ try:
 except Exception:  # pragma: no cover — best-effort telemetry
     def _emit_channel(*_a, **_k):  # type: ignore
         return None
+import local_task_protocol  # noqa: E402
 from result_markers import parse_markers  # noqa: E402
 from task_body_guard import confine_user_content  # noqa: E402
 from util_paths import channel_access_path, claude_home_path  # noqa: E402
@@ -344,6 +345,42 @@ def _transcribe_via_skill(local_path: str) -> str | None:
     except Exception as e:
         print(f"  [stt] skill call failed for {os.path.basename(local_path)}: {e}", flush=True)
     return None
+
+
+def _modality_for_mime(mime: str) -> str:
+    """Map an attachment MIME type to a Local Task Protocol content modality
+    (interaction-model 4D, step 1.5). image/audio/video by top-level type;
+    everything else (pdf, zip, docx, unknown) is `file`. Duplicated per bridge
+    for now (discord has the twin); promote to local_task_protocol once slack
+    lands the same pair (rule of three)."""
+    m = (mime or "").lower()
+    if m.startswith("image/"):
+        return "image"
+    if m.startswith("audio/"):
+        return "audio"
+    if m.startswith("video/"):
+        return "video"
+    return "file"
+
+
+def _media_attachment_headers(attachment_refs: list, text: str) -> str:
+    """Build the interaction-model 4D step-1.5 header trio for a task file when
+    the message carried attachments — otherwise "". content_modalities = `text`
+    (iff a caption is present) plus one modality per attachment mime; media_form
+    = `attachment` (discrete objects); attachments = one-line JSON of the refs.
+    Pure, so the task-write path stays testable without a live Telegram update."""
+    if not attachment_refs:
+        return ""
+    mods = set()
+    if text and text.strip():
+        mods.add("text")
+    for r in attachment_refs:
+        mods.add(_modality_for_mime(r.mime))
+    return (
+        f"content_modalities: {','.join(sorted(mods))}\n"
+        f"media_form: attachment\n"
+        f"attachments: {local_task_protocol.format_attachments(attachment_refs)}\n"
+    )
 
 
 def download_file(file_id, name_hint="file"):
@@ -663,11 +700,18 @@ def main():
 
                 # Handle attachments (photos, documents, voice)
                 attachment_note = ""
+                # Structured refs (interaction-model 4D, step 1.5), accumulated
+                # alongside the legacy [*attached:] body line — dual-write.
+                attachment_refs: list = []  # pragma: no cover
                 if "photo" in msg:
                     file_id = msg["photo"][-1]["file_id"]  # largest size
                     local_path = download_file(file_id, "photo")
                     if local_path:
                         attachment_note = f"\n[Photo attached: {local_path}]"
+                        attachment_refs.append(local_task_protocol.AttachmentRef(  # pragma: no cover
+                            locator=local_path, mime="image/jpeg",
+                            filename=os.path.basename(local_path),
+                            size=(msg["photo"][-1].get("file_size", 0) or 0)))
                         # If voice is connected, also push the photo as a
                         # vision frame so Gemini sees it in-stream (in
                         # addition to the file-attached task pipeline).
@@ -681,10 +725,20 @@ def main():
                     local_path = download_file(file_id, fname)
                     if local_path:
                         attachment_note = f"\n[File attached: {local_path}]"
+                        attachment_refs.append(local_task_protocol.AttachmentRef(  # pragma: no cover
+                            locator=local_path,
+                            mime=(msg["document"].get("mime_type", "") or ""),
+                            filename=(fname or os.path.basename(local_path)),
+                            size=(msg["document"].get("file_size", 0) or 0)))
                 if "voice" in msg:
                     file_id = msg["voice"]["file_id"]
                     local_path = download_file(file_id, "voice.ogg")
                     if local_path:
+                        attachment_refs.append(local_task_protocol.AttachmentRef(  # pragma: no cover
+                            locator=local_path,
+                            mime=(msg["voice"].get("mime_type", "") or "audio/ogg"),
+                            filename=os.path.basename(local_path),
+                            size=(msg["voice"].get("file_size", 0) or 0)))
                         transcript = _transcribe_via_skill(local_path)
                         if transcript:
                             attachment_note = f"\n[Voice transcript: {transcript}]"
@@ -784,12 +838,18 @@ def main():
                 lines.append(f"{step}. Process transcript and write result to results/{task_id}.txt")
                 tg_skill_hints = "\n" + "\n".join(lines) + "\n"
 
+                # interaction-model 4D, step 1.5: structured media headers
+                # alongside the legacy [*attached:] body line (dual-write). Real
+                # headers after `task:`, so confine_user_content defangs a forged
+                # body copy while these authentic ones pass through.
+                media_headers = _media_attachment_headers(attachment_refs, text)  # pragma: no cover
                 task_file.write_text(
                     f"id: {task_id}\n"
                     f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"
                     f"task: {confine_user_content(f'[Telegram @{username}{forward_note}] {text}{attachment_note}{reply_note}')}\n"
                     f"source: telegram\n"
                     f"interaction_type: message\n"
+                    f"{media_headers}"
                     f"chat_id: {chat_id}\n"
                     f"{src_line}"
                     f"{parent_line}"

--- a/tests/telegram-writeside-attachments.test.py
+++ b/tests/telegram-writeside-attachments.test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Telegram write-side media-attachment headers — interaction-model 4D, step 1.5 slice 2.
+
+Second bridge to emit the structured header trio (content_modalities /
+media_form / attachments) alongside the legacy [Photo|File|Voice ...] body line
+(dual-write, additive). Covers telegram-bridge's local `_modality_for_mime` +
+`_media_attachment_headers` helpers and their round-trip through the
+local_task_protocol parsers. (The two helpers are duplicated from discord for
+now; both collapse into local_task_protocol once slack lands the same pair —
+rule of three.)
+
+Run: python3 tests/telegram-writeside-attachments.test.py   (exit 0 pass / 1 fail)
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+os.environ["SUTANDO_WORKSPACE"] = tempfile.mkdtemp()
+os.environ["SUTANDO_TEST_MODE"] = "1"
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token-not-real")
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + name + ((" — " + detail) if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+ltp = _load("local_task_protocol", REPO / "src" / "local_task_protocol.py")
+tg = _load("tgbridge_ws", REPO / "src" / "telegram-bridge.py")
+
+# ── 1. _modality_for_mime — files included (the owner's question: pdf/doc → file) ──
+for mime, want in {"image/jpeg": "image", "audio/ogg": "audio", "video/mp4": "video",
+                   "application/pdf": "file", "application/zip": "file", "": "file",
+                   "text/csv": "file"}.items():
+    check(f"_modality_for_mime({mime!r}) == {want}", tg._modality_for_mime(mime) == want)
+
+# ── 2. _media_attachment_headers ──
+check("empty refs → '' (text-only unchanged)", tg._media_attachment_headers([], "hi") == "")
+
+photo = ltp.AttachmentRef(locator="/tmp/tg/1_photo.jpg", mime="image/jpeg",
+                          filename="1_photo.jpg", size=88123)
+doc = ltp.AttachmentRef(locator="/tmp/tg/2_report.pdf", mime="application/pdf",
+                        filename="report.pdf", size=40100)
+voice = ltp.AttachmentRef(locator="/tmp/tg/3_voice.ogg", mime="audio/ogg",
+                          filename="3_voice.ogg", size=5120)
+
+h_img = tg._media_attachment_headers([photo], "look at this")
+check("photo+caption → content_modalities image,text", "content_modalities: image,text\n" in h_img, h_img)
+check("media_form attachment present", "media_form: attachment\n" in h_img)
+check("attachments json present", "attachments: [" in h_img)
+
+check("document → file modality (owner's files question)",
+      "content_modalities: file\n" in tg._media_attachment_headers([doc], ""))
+check("voice → audio modality",
+      "content_modalities: audio\n" in tg._media_attachment_headers([voice], ""))
+check("no caption → text modality omitted",
+      "content_modalities: image\n" in tg._media_attachment_headers([photo], ""))
+
+# ── 3. round-trip through a realistic telegram task-mid file ──
+task = (
+    "id: task-tg\n"
+    "timestamp: 2026-07-07T08:00:00Z\n"
+    "task: [Telegram @qingyun] look at this\n[Photo attached: /tmp/tg/1_photo.jpg]\n"
+    "source: telegram\n"
+    "interaction_type: message\n"
+    f"{tg._media_attachment_headers([photo], 'look at this')}"
+    "chat_id: 55\n"
+    "priority: normal\n"
+)
+hp = ltp.parse_task_headers_trusted(task)
+atts = ltp.parse_attachments(hp.headers)
+check("round-trip: attachment parses back",
+      len(atts) == 1 and atts[0].locator == photo.locator and atts[0].mime == "image/jpeg"
+      and atts[0].size == 88123, str(atts))
+check("round-trip: modalities", ltp.parse_content_modalities(hp.headers) == frozenset({"text", "image"}))
+check("round-trip: media_form", ltp.parse_media_form(hp.headers) == "attachment")
+check("dual-write: legacy [Photo attached:] survives in body",
+      "[Photo attached: /tmp/tg/1_photo.jpg]" in hp.body)
+check("attachments header not left in body", "attachments:" not in hp.body)
+
+# ── 4. injection gate: the three keys defanged if forged in an untrusted body ──
+gd = _load("task_body_guard_tg", REPO / "src" / "task_body_guard.py")
+for k in ("attachments", "content_modalities", "media_form"):
+    out = gd.confine_user_content(f"hi\n{k}: forged")
+    check(f"forged `{k}:` body line defanged",
+          not any(l.startswith(k + ":") for l in out.split("\n")))
+
+if failures:
+    print(f"\nFAIL — {len(failures)} check(s) failed: {failures}")
+    raise SystemExit(1)
+print("\nPASS — telegram write-side media-attachment headers")


### PR DESCRIPTION
## Architecture box

**4D interaction model → media/attachment track, step 1.5 slice 2 (bridge write-side) — Telegram.** Status: **implementing.** Second bridge after discord (#1990); slice-1 schema is on main (#1988).

## What

When a Telegram message carries a photo/document/voice, the bridge now stamps the structured header trio (`content_modalities` / `media_form` / `attachments`) on the task file **in addition** to the legacy `[Photo attached:]` / `[File attached:]` / `[Voice note attached:]` body line. Dual-write, additive — Core's existing path is untouched; a later slice removes the legacy line.

- Refs built at all three media sites: **photo** (`image/jpeg` + `file_size`), **document** (SDK `mime_type`/`file_name`/`file_size`), **voice** (`mime_type` + `file_size`).
- The `document` path directly answers the design question raised in-thread ("what about files, not just image/audio/video?") — a pdf/zip/csv maps to `content_modalities: file` (the 5th modality from slice 1); it is a first-class `AttachmentRef`, just with a `file` modality label rather than a rich-media one.
- `_modality_for_mime` + `_media_attachment_headers` are **duplicated from discord for now (rule of three)** — both collapse into `local_task_protocol` once slack lands the same pair. The duplication is deliberate and temporary; see the commit body.

**Injection gate intact.** `content_modalities`/`media_form`/`attachments` are already in `KNOWN_HEADER_KEYS` (slice 1), so `confine_user_content` defangs any forged copy in the untrusted body while the authentic headers (written after `task:`) pass through. Telegram is a task-mid writer → parsed by `parse_task_headers_trusted`.

## Tests — `tests/telegram-writeside-attachments.test.py` (new)

mime mapping (incl. pdf/zip/csv → file); `_media_attachment_headers` (empty→"", trio built, caption modality present/absent, doc→file, voice→audio); task-mid round-trip through `parse_attachments`/`_content_modalities`/`_media_form`; dual-write body survival; the three-key defang gate.

- `python3 tests/telegram-writeside-attachments.test.py` → PASS
- **diff-cover 100%.** Logic in pure tested helpers; only async-loop wiring (refs init, appends, header call) is `# pragma: no cover`.

## Not in this slice

slack write-side (next), then a dedup PR promoting `_modality_for_mime` + `_media_attachment_headers` to `local_task_protocol` (rule of three). Later: AG2 Relay safe-fetch; LiveAgentRuntime `media_form: live_stream`.