### PR TITLE
feat(slack): emit structured attachments[] headers + promote shared helpers to LTP (4D step 1.5 slice 2)

### DIFF
--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -398,6 +398,49 @@ def format_attachments(refs: Iterable["AttachmentRef"]) -> str:
     return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
 
 
+def modality_for_mime(mime: str) -> str:
+    """Map an attachment MIME type to a content modality (CONTENT_MODALITIES):
+    image/audio/video by top-level type, everything else (pdf, zip, docx,
+    unknown) → `file`. The shared home for the mapping each bridge needs when it
+    stamps `content_modalities` — promoted here once a third bridge required it
+    (discord/telegram carried private copies first)."""
+    m = (mime or "").lower()
+    if m.startswith("image/"):
+        return "image"
+    if m.startswith("audio/"):
+        return "audio"
+    if m.startswith("video/"):
+        return "video"
+    return "file"
+
+
+def media_attachment_headers(attachment_refs: Iterable["AttachmentRef"], has_text: bool) -> str:
+    """Build the `content_modalities`/`media_form`/`attachments` header block a
+    bridge stamps on a task file when a message carried attachments (step 1.5).
+    Returns "" when there are no refs — so a text-only task's headers are
+    unchanged.
+
+    `content_modalities` = `text` (iff `has_text`) plus one modality per ref
+    mime; `media_form` = `attachment` (these are discrete objects — a live
+    stream is never emitted through the messaging task path); `attachments` =
+    the one-line JSON from `format_attachments`. The block is newline-terminated
+    so it composes directly into a writer's header f-string. Pure — a bridge can
+    unit-test its write path without a live message object."""
+    refs = [r for r in attachment_refs if r.locator]
+    if not refs:
+        return ""
+    mods = set()
+    if has_text:
+        mods.add("text")
+    for r in refs:
+        mods.add(modality_for_mime(r.mime))
+    return (
+        f"content_modalities: {','.join(sorted(mods))}\n"
+        f"media_form: attachment\n"
+        f"attachments: {format_attachments(refs)}\n"
+    )
+
+
 # ── Archive rules ────────────────────────────────────────────────────────────
 
 _MONTH_DIR_RE = re.compile(r"^\d{4}-\d{2}$")

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -56,6 +56,7 @@ except Exception:  # pragma: no cover — best-effort telemetry
         return None
 from result_markers import parse_markers  # noqa: E402
 from message_chunking import chunk_message  # noqa: E402  (Result Router S3 — shared fence-aware chunker)
+import local_task_protocol  # noqa: E402
 from task_body_guard import confine_user_content  # noqa: E402
 from util_paths import channel_access_path, claude_home_path  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
@@ -366,6 +367,19 @@ def _download_slack_file(file_dict: dict) -> str | None:
         return None
 
 
+def _ref_from_slack_file(file_dict: dict, local_path: str) -> "local_task_protocol.AttachmentRef":
+    """Build an AttachmentRef from a Slack file object + its saved local path
+    (interaction-model 4D, step 1.5). Reads Slack's `mimetype`/`name`/`size`
+    defensively; falls back to the saved basename when `name` is absent. Pure —
+    kept separate from the async handler so the field-reading is testable."""
+    return local_task_protocol.AttachmentRef(
+        locator=local_path,
+        mime=(file_dict.get("mimetype", "") or ""),
+        filename=(file_dict.get("name", "") or os.path.basename(local_path)),
+        size=(file_dict.get("size", 0) or 0),
+    )
+
+
 def _transcribe_via_skill(local_path: str) -> str | None:
     """Call skills/audio-transcribe/scripts/transcribe.py. Returns transcript or None.
 
@@ -422,9 +436,13 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
     # carries the local paths. Skips silently on failure — task still goes
     # through with whatever files did download.
     attachment_lines = []
+    # Structured refs (interaction-model 4D, step 1.5) — accumulated alongside
+    # the legacy [File attached:] body line (dual-write, additive).
+    attachment_refs: list = []  # pragma: no cover
     for file_dict in event.get("files") or []:
         local_path = _download_slack_file(file_dict)
         if local_path:
+            attachment_refs.append(_ref_from_slack_file(file_dict, local_path))  # pragma: no cover
             transcript = _transcribe_via_skill(local_path)
             if transcript:
                 attachment_lines.append(f"[Voice transcript: {transcript}]")
@@ -550,12 +568,20 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
         hints_lines.append(f"{step}. Then process and write result to results/{task_id}.txt")
         skill_hints = "\n" + "\n".join(hints_lines) + "\n"
 
+    # interaction-model 4D, step 1.5: structured media headers alongside the
+    # legacy [File attached:] body line (dual-write). Real headers after `task:`,
+    # so confine_user_content defangs a forged body copy while these authentic
+    # ones pass through. Uses the shared local_task_protocol helper (slack is the
+    # third bridge; discord/telegram fold onto it in a follow-up dedup).
+    media_headers = local_task_protocol.media_attachment_headers(  # pragma: no cover
+        attachment_refs, bool(text and text.strip()))
     task_file.write_text(
         f"id: {task_id}\n"
         f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"
         f"task: {user_task_text}\n"
         f"source: slack\n"
         f"interaction_type: message\n"
+        f"{media_headers}"
         f"channel_id: {channel}\n"
         f"user_id: {user_id}\n"
         f"access_tier: {access_tier}\n"

--- a/tests/local-task-protocol-attachments.test.py
+++ b/tests/local-task-protocol-attachments.test.py
@@ -150,6 +150,34 @@ check("plain task → no attachments", ltp.parse_attachments(plain.headers) == [
 check("plain task → attachment default form", ltp.parse_media_form(plain.headers) == "attachment")
 check("plain task → empty modalities", ltp.parse_content_modalities(plain.headers) == frozenset())
 
+# ── 8. shared header builders (promoted for the 3rd bridge — slack) ──
+check("modality_for_mime: image", ltp.modality_for_mime("image/png") == "image")
+check("modality_for_mime: audio", ltp.modality_for_mime("audio/ogg") == "audio")
+check("modality_for_mime: video", ltp.modality_for_mime("video/mp4") == "video")
+check("modality_for_mime: file default", ltp.modality_for_mime("application/pdf") == "file")
+check("modality_for_mime: empty → file", ltp.modality_for_mime("") == "file")
+check("modality_for_mime: case-fold", ltp.modality_for_mime("IMAGE/PNG") == "image")
+
+check("media_attachment_headers: no refs → ''", ltp.media_attachment_headers([], True) == "")
+_r = ltp.AttachmentRef(locator="/tmp/a.png", mime="image/png", size=10)
+_hdrs = ltp.media_attachment_headers([_r], True)
+check("media_attachment_headers: has_text → text modality present",
+      "content_modalities: image,text\n" in _hdrs, _hdrs)
+check("media_attachment_headers: media_form attachment", "media_form: attachment\n" in _hdrs)
+check("media_attachment_headers: attachments json", "attachments: [" in _hdrs)
+check("media_attachment_headers: no has_text → text omitted",
+      "content_modalities: image\n" in ltp.media_attachment_headers([_r], False))
+check("media_attachment_headers: locator-less ref dropped → ''",
+      ltp.media_attachment_headers([ltp.AttachmentRef(locator="")], True) == "")
+# The promoted builder round-trips through the parsers just like a bridge emits it.
+_task = ("task: hi\nsource: slack\ninteraction_type: message\n"
+         + ltp.media_attachment_headers([_r], True) + "channel_id: C1\n")
+_h = ltp.parse_task_headers_trusted(_task)
+check("promoted builder round-trips: attachments",
+      len(ltp.parse_attachments(_h.headers)) == 1)
+check("promoted builder round-trips: media_form",
+      ltp.parse_media_form(_h.headers) == "attachment")
+
 if failures:
     print(f"\nFAIL — {len(failures)} check(s) failed: {failures}")
     raise SystemExit(1)

--- a/tests/slack-writeside-attachments.test.py
+++ b/tests/slack-writeside-attachments.test.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Slack write-side media-attachment headers — interaction-model 4D, step 1.5 slice 2.
+
+Third and last bridge to emit the structured header trio (content_modalities /
+media_form / attachments) alongside the legacy [File attached:] body line
+(dual-write, additive). Because slack is the third consumer, the header-building
+helpers now live in local_task_protocol (media_attachment_headers /
+modality_for_mime) — this covers slack's own `_ref_from_slack_file` (Slack
+file-object field reading) plus a round-trip through the parsers.
+
+slack-bridge imports slack_bolt + exits without tokens, so we stub the SDK and
+set fake tokens for a hermetic load. Mirrors the discord/telegram write-side tests.
+
+Run: python3 tests/slack-writeside-attachments.test.py   (exit 0 pass / 1 fail)
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+os.environ["SUTANDO_WORKSPACE"] = tempfile.mkdtemp()
+os.environ["SUTANDO_TEST_MODE"] = "1"
+os.environ.setdefault("SLACK_BOT_TOKEN", "xoxb-test-not-real")
+os.environ.setdefault("SLACK_APP_TOKEN", "xapp-test-not-real")
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + name + ((" — " + detail) if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+# Stub slack_bolt so slack-bridge imports without the real SDK.
+if "slack_bolt" not in sys.modules:
+    bolt = types.ModuleType("slack_bolt")
+    bolt.App = type("App", (), {"__init__": lambda self, **kw: None,
+                                "event": staticmethod(lambda *a, **k: (lambda fn: fn)),
+                                "message": staticmethod(lambda *a, **k: (lambda fn: fn))})
+    sys.modules["slack_bolt"] = bolt
+    adapter = types.ModuleType("slack_bolt.adapter")
+    socket_mode = types.ModuleType("slack_bolt.adapter.socket_mode")
+    socket_mode.SocketModeHandler = type("SocketModeHandler", (), {"__init__": lambda self, *a, **k: None})
+    sys.modules["slack_bolt.adapter"] = adapter
+    sys.modules["slack_bolt.adapter.socket_mode"] = socket_mode
+
+ltp = _load("local_task_protocol", REPO / "src" / "local_task_protocol.py")
+sb = _load("slackbridge_ws", REPO / "src" / "slack-bridge.py")
+
+# ── 1. _ref_from_slack_file reads Slack file fields defensively ──
+r = sb._ref_from_slack_file(
+    {"mimetype": "application/pdf", "name": "report.pdf", "size": 40100}, "/tmp/slack/1-report.pdf")
+check("ref locator = saved path", r.locator == "/tmp/slack/1-report.pdf")
+check("ref mime from mimetype", r.mime == "application/pdf")
+check("ref filename from name", r.filename == "report.pdf")
+check("ref size from size", r.size == 40100)
+# Missing name → basename fallback; missing mimetype/size → empty/0, never raises.
+r2 = sb._ref_from_slack_file({}, "/tmp/slack/2-photo.jpg")
+check("missing name → basename fallback", r2.filename == "2-photo.jpg")
+check("missing mimetype → empty mime", r2.mime == "")
+check("missing size → 0", r2.size == 0)
+
+# ── 2. slack builds the header block via the shared LTP helper ──
+img = ltp.AttachmentRef(locator="/tmp/slack/3-pic.png", mime="image/png", filename="pic.png", size=88)
+hdrs = ltp.media_attachment_headers([img], True)  # slack calls this directly
+check("shared builder: content_modalities image,text", "content_modalities: image,text\n" in hdrs, hdrs)
+check("shared builder: media_form attachment", "media_form: attachment\n" in hdrs)
+check("shared builder: attachments json", "attachments: [" in hdrs)
+check("shared builder: file modality for pdf",
+      "content_modalities: file\n" in ltp.media_attachment_headers([r], False))
+
+# ── 3. round-trip through a realistic slack task-mid file ──
+task = (
+    "id: task-sl\n"
+    "timestamp: 2026-07-07T08:40:00Z\n"
+    "task: [Slack @qingyun] look\n[File attached: /tmp/slack/3-pic.png]\n"
+    "source: slack\n"
+    "interaction_type: message\n"
+    f"{ltp.media_attachment_headers([img], True)}"
+    "channel_id: C123\n"
+    "access_tier: owner\n"
+)
+h = ltp.parse_task_headers_trusted(task)
+atts = ltp.parse_attachments(h.headers)
+check("round-trip: attachment parses back",
+      len(atts) == 1 and atts[0].locator == img.locator and atts[0].mime == "image/png", str(atts))
+check("round-trip: modalities", ltp.parse_content_modalities(h.headers) == frozenset({"text", "image"}))
+check("round-trip: media_form", ltp.parse_media_form(h.headers) == "attachment")
+check("dual-write: legacy [File attached:] survives in body",
+      "[File attached: /tmp/slack/3-pic.png]" in h.body)
+check("attachments header not left in body", "attachments:" not in h.body)
+
+# ── 4. injection gate: three keys defanged if forged in an untrusted body ──
+gd = _load("task_body_guard_sl", REPO / "src" / "task_body_guard.py")
+for k in ("attachments", "content_modalities", "media_form"):
+    out = gd.confine_user_content(f"hi\n{k}: forged")
+    check(f"forged `{k}:` body line defanged",
+          not any(l.startswith(k + ":") for l in out.split("\n")))
+
+if failures:
+    print(f"\nFAIL — {len(failures)} check(s) failed: {failures}")
+    raise SystemExit(1)
+print("\nPASS — slack write-side media-attachment headers")


### PR DESCRIPTION
## Architecture box

**4D interaction model → media/attachment track, step 1.5 slice 2 (bridge write-side) — Slack (3rd/last bridge).** Status: **implementing.** discord = #1990 (merged), telegram = #1991 (open).

## What

When a Slack message carries files, the bridge now stamps the structured header trio (`content_modalities` / `media_form` / `attachments`) on the task file **alongside** the legacy `[File attached:]` body line. Dual-write, additive — Core's existing path is untouched.

**Rule of three → shared helper.** Slack is the third consumer of the header-building helpers, so they graduate to their canonical home in `local_task_protocol`:
- `modality_for_mime(mime)` — image/audio/video by top-level type, else `file`.
- `media_attachment_headers(refs, has_text)` — the `content_modalities`/`media_form`/`attachments` block (returns `""` when no refs, so text-only tasks are unchanged).

Slack uses the shared version directly. A **follow-up dedup PR** folds discord's + telegram's private `_modality_for_mime`/`_media_attachment_headers` copies onto these (they were deliberately duplicated for the first two — refactor at the third).

- `_ref_from_slack_file(file_dict, local_path)` — AttachmentRef from a Slack file object (defensive `mimetype`/`name`/`size`, basename fallback).
- Keys already in `KNOWN_HEADER_KEYS` (slice 1) → `confine_user_content` defangs forged body copies; authentic post-`task:` headers pass through (slack is a task-mid writer → `parse_task_headers_trusted`).

## Tests

- `tests/local-task-protocol-attachments.test.py` (extended) — the promoted `modality_for_mime` + `media_attachment_headers` (mapping, text/no-text, locator-less drop, parser round-trip).
- `tests/slack-writeside-attachments.test.py` (new) — `_ref_from_slack_file` field reading (incl. missing-field fallbacks), shared-builder use, task-mid round-trip through `parse_attachments`/`_content_modalities`/`_media_form`, dual-write body survival, defang gate. Stubs `slack_bolt` for a hermetic load.
- **diff-cover 100%** on both `local_task_protocol.py` and `slack-bridge.py`. Only async-handler wiring (refs init, append, header call) is `# pragma: no cover`.

## Sequence

This completes all three message bridges. **Next:** dedup PR (discord + telegram → the LTP helpers), then AG2 Relay safe-fetch (remote locator→local) and LiveAgentRuntime honoring `media_form: live_stream`.