### PR TITLE
refactor(bridges): fold discord+telegram media-header helpers into local_task_protocol

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -425,22 +425,6 @@ def _safe_attachment_basename(filename: str) -> str:
     return f"{safe_base}.{safe_ext}" if safe_ext else safe_base
 
 
-def _modality_for_mime(mime: str) -> str:
-    """Map an attachment MIME type to a Local Task Protocol content modality
-    (interaction-model 4D, step 1.5). image/audio/video by top-level type;
-    everything else (pdf, zip, docx, unknown) is `file`. Kept local to the
-    bridge until all three bridges converge on an identical mapping worth
-    promoting to local_task_protocol."""
-    m = (mime or "").lower()
-    if m.startswith("image/"):
-        return "image"
-    if m.startswith("audio/"):
-        return "audio"
-    if m.startswith("video/"):
-        return "video"
-    return "file"
-
-
 def _ref_from_attachment(att, local_path) -> "local_task_protocol.AttachmentRef":
     """Build an AttachmentRef from a discord Attachment + its saved local path
     (interaction-model 4D, step 1.5). Reads the SDK's `content_type`/`size`
@@ -452,29 +436,6 @@ def _ref_from_attachment(att, local_path) -> "local_task_protocol.AttachmentRef"
         mime=(getattr(att, "content_type", "") or ""),
         filename=_safe_attachment_basename(getattr(att, "filename", "") or ""),
         size=(getattr(att, "size", 0) or 0),
-    )
-
-
-def _media_attachment_headers(attachment_refs: list, text: str) -> str:
-    """Build the interaction-model 4D step-1.5 header trio for a task file when
-    the message carried attachments — otherwise "".
-
-    `content_modalities` = `text` (iff a caption is present) plus one modality
-    per attachment mime; `media_form` = `attachment` (these are discrete objects
-    — live audio/video never arrives on this path); `attachments` = one-line
-    JSON of the refs. Pure (no I/O) so the task-write path stays testable
-    without constructing a full discord Message."""
-    if not attachment_refs:
-        return ""
-    mods = set()
-    if text and text.strip():
-        mods.add("text")
-    for r in attachment_refs:
-        mods.add(_modality_for_mime(r.mime))
-    return (
-        f"content_modalities: {','.join(sorted(mods))}\n"
-        f"media_form: attachment\n"
-        f"attachments: {local_task_protocol.format_attachments(attachment_refs)}\n"
     )
 
 
@@ -3231,7 +3192,8 @@ async def _handle_discord_message(message, force=False):
     # Additive dual-write — Core's existing path is untouched; these are real
     # headers (after `task:`), so confine_user_content defangs any forged copy a
     # user tries to smuggle in the body but leaves these authentic ones intact.
-    media_headers = _media_attachment_headers(attachment_refs, text)  # pragma: no cover
+    media_headers = local_task_protocol.media_attachment_headers(  # pragma: no cover
+        attachment_refs, bool(text and text.strip()))
 
     # Instrumentation (2026-06-23): make a silent "message received but no task
     # written" drop diagnosable. The owner saw several messages vanish with no

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -347,42 +347,6 @@ def _transcribe_via_skill(local_path: str) -> str | None:
     return None
 
 
-def _modality_for_mime(mime: str) -> str:
-    """Map an attachment MIME type to a Local Task Protocol content modality
-    (interaction-model 4D, step 1.5). image/audio/video by top-level type;
-    everything else (pdf, zip, docx, unknown) is `file`. Duplicated per bridge
-    for now (discord has the twin); promote to local_task_protocol once slack
-    lands the same pair (rule of three)."""
-    m = (mime or "").lower()
-    if m.startswith("image/"):
-        return "image"
-    if m.startswith("audio/"):
-        return "audio"
-    if m.startswith("video/"):
-        return "video"
-    return "file"
-
-
-def _media_attachment_headers(attachment_refs: list, text: str) -> str:
-    """Build the interaction-model 4D step-1.5 header trio for a task file when
-    the message carried attachments — otherwise "". content_modalities = `text`
-    (iff a caption is present) plus one modality per attachment mime; media_form
-    = `attachment` (discrete objects); attachments = one-line JSON of the refs.
-    Pure, so the task-write path stays testable without a live Telegram update."""
-    if not attachment_refs:
-        return ""
-    mods = set()
-    if text and text.strip():
-        mods.add("text")
-    for r in attachment_refs:
-        mods.add(_modality_for_mime(r.mime))
-    return (
-        f"content_modalities: {','.join(sorted(mods))}\n"
-        f"media_form: attachment\n"
-        f"attachments: {local_task_protocol.format_attachments(attachment_refs)}\n"
-    )
-
-
 def download_file(file_id, name_hint="file"):
     """Download a file from Telegram and save locally."""
     result = api("getFile", file_id=file_id)
@@ -842,7 +806,8 @@ def main():
                 # alongside the legacy [*attached:] body line (dual-write). Real
                 # headers after `task:`, so confine_user_content defangs a forged
                 # body copy while these authentic ones pass through.
-                media_headers = _media_attachment_headers(attachment_refs, text)  # pragma: no cover
+                media_headers = local_task_protocol.media_attachment_headers(  # pragma: no cover
+                    attachment_refs, bool(text and text.strip()))
                 task_file.write_text(
                     f"id: {task_id}\n"
                     f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"

--- a/tests/discord-writeside-attachments.test.py
+++ b/tests/discord-writeside-attachments.test.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Discord write-side media-attachment headers — interaction-model 4D, step 1.5 slice 2.
+"""Discord write-side media-attachment integration — interaction-model 4D, step 1.5.
 
-The bridge now emits the structured header trio (`content_modalities` /
-`media_form` / `attachments`) ALONGSIDE the legacy `[File attached:]` body line
-(dual-write, additive). This covers the two pure helpers that build those
-headers — `_modality_for_mime` and `_media_attachment_headers` — and asserts the
-emitted headers round-trip back through the local_task_protocol parsers in a
-realistic task-mid file.
+After the rule-of-three dedup, the header-building helpers live in
+local_task_protocol (media_attachment_headers / modality_for_mime), tested in
+tests/local-task-protocol-attachments.test.py. This covers what stays
+discord-specific: `_ref_from_attachment` (Attachment field reading) plus an
+end-to-end round-trip of a discord task-mid file assembled with the shared
+helper — including dual-write body survival and the injection-defang gate.
 
 discord-bridge's module load has side effects (discord SDK import, token read),
 so we stub them and run hermetically. Mirrors tests/bridge-audit-wiring.test.py.
@@ -45,7 +45,6 @@ def _load(name: str, path: Path):
     return m
 
 
-# Stub `discord` so discord-bridge imports cleanly in CI.
 try:
     import discord  # noqa: F401
 except ImportError:
@@ -60,14 +59,7 @@ except ImportError:
 ltp = _load("local_task_protocol", REPO / "src" / "local_task_protocol.py")
 db = _load("dbridge_ws", REPO / "src" / "discord-bridge.py")
 
-# ── 1. _modality_for_mime mapping ──
-cases = {"image/png": "image", "image/jpeg": "image", "audio/ogg": "audio",
-         "video/mp4": "video", "application/pdf": "file", "text/plain": "file",
-         "": "file", "IMAGE/PNG": "image"}
-for mime, want in cases.items():
-    check(f"_modality_for_mime({mime!r}) == {want}", db._modality_for_mime(mime) == want)
-
-# ── 1b. _ref_from_attachment reads discord SDK attributes defensively ──
+# ── 1. _ref_from_attachment reads discord SDK attributes defensively ──
 class _FakeAtt:
     def __init__(self, content_type=None, size=None, filename="pic.png"):
         if content_type is not None:
@@ -81,49 +73,28 @@ check("ref locator = saved path", r.locator == "/tmp/inbox/1_my_pic.png")
 check("ref mime from content_type", r.mime == "image/png")
 check("ref size from att.size", r.size == 1234)
 check("ref filename sanitized", r.filename == "my_pic.png", r.filename)
-# Missing content_type/size (both optional on the SDK) default cleanly, never raise.
 r2 = db._ref_from_attachment(_FakeAtt(content_type=None, size=None, filename="x.pdf"), "/tmp/x.pdf")
 check("missing content_type → empty mime", r2.mime == "")
 check("missing size → 0", r2.size == 0)
 
-# ── 2. _media_attachment_headers: empty refs → "" (text-only path untouched) ──
-check("no attachments → no headers (text-only unchanged)",
-      db._media_attachment_headers([], "hello") == "")
+# ── 2. discord no longer carries local header helpers (folded into LTP) ──
+check("local _media_attachment_headers removed", not hasattr(db, "_media_attachment_headers"))
+check("local _modality_for_mime removed", not hasattr(db, "_modality_for_mime"))
 
-# ── 3. header trio built for an image with a caption ──
+# ── 3. round-trip: a discord task-mid file assembled with the shared helper ──
 ref = ltp.AttachmentRef(locator="/tmp/discord-inbox/1_s.png", mime="image/png",
                         filename="s.png", size=438707)
-hdrs = db._media_attachment_headers([ref], "describe this")
-check("emits content_modalities", "content_modalities: image,text\n" in hdrs, hdrs)
-check("emits media_form attachment", "media_form: attachment\n" in hdrs, hdrs)
-check("emits attachments json header", "attachments: [" in hdrs, hdrs)
-check("header block is newline-terminated (composes into the write f-string)", hdrs.endswith("\n"))
-check("no stray embedded blank line breaks the header run", "\n\n" not in hdrs)
-
-# caption absent → no `text` modality
-hdrs_nocap = db._media_attachment_headers([ref], "")
-check("no caption → text modality omitted",
-      "content_modalities: image\n" in hdrs_nocap, hdrs_nocap)
-
-# a non-image attachment → file modality
-pdf = ltp.AttachmentRef(locator="/tmp/x.pdf", mime="application/pdf", size=10)
-check("pdf → file modality",
-      "content_modalities: file\n" in db._media_attachment_headers([pdf], ""))
-
-# ── 4. round-trip through a realistic task-mid file (discord is a task-mid writer) ──
-# Assemble exactly as the write block does, including the legacy body line.
-body = "[Discord @qingyun] describe this\n[File attached: /tmp/discord-inbox/1_s.png]"
 task_file = (
     "id: task-x\n"
     "timestamp: 2026-07-07T08:00:00Z\n"
-    f"task: {body}\n"
+    "task: [Discord @qingyun] describe this\n[File attached: /tmp/discord-inbox/1_s.png]\n"
     "source: discord\n"
     "interaction_type: message\n"
-    f"{db._media_attachment_headers([ref], 'describe this')}"
+    f"{ltp.media_attachment_headers([ref], True)}"
     "channel_id: 123\n"
     "access_tier: owner\n"
 )
-h = ltp.parse_task_headers_trusted(task_file)  # task-mid, last-wins
+h = ltp.parse_task_headers_trusted(task_file)
 atts = ltp.parse_attachments(h.headers)
 check("round-trip: attachments parse back to the ref",
       len(atts) == 1 and atts[0].locator == ref.locator and atts[0].mime == "image/png"
@@ -135,7 +106,7 @@ check("dual-write: legacy [File attached:] line survives in the body",
       "[File attached: /tmp/discord-inbox/1_s.png]" in h.body)
 check("attachments header is NOT left in the body", "attachments:" not in h.body)
 
-# ── 5. the three new keys are defanged if forged in an untrusted body (injection gate) ──
+# ── 4. injection gate: the three keys defanged if forged in an untrusted body ──
 gd = _load("task_body_guard_ws", REPO / "src" / "task_body_guard.py")
 for k in ("attachments", "content_modalities", "media_form"):
     out = gd.confine_user_content(f"hi\n{k}: forged")
@@ -145,4 +116,4 @@ for k in ("attachments", "content_modalities", "media_form"):
 if failures:
     print(f"\nFAIL — {len(failures)} check(s) failed: {failures}")
     raise SystemExit(1)
-print("\nPASS — discord write-side media-attachment headers")
+print("\nPASS — discord write-side media-attachment integration")

--- a/tests/telegram-writeside-attachments.test.py
+++ b/tests/telegram-writeside-attachments.test.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-"""Telegram write-side media-attachment headers — interaction-model 4D, step 1.5 slice 2.
+"""Telegram write-side media-attachment integration — interaction-model 4D, step 1.5.
 
-Second bridge to emit the structured header trio (content_modalities /
-media_form / attachments) alongside the legacy [Photo|File|Voice ...] body line
-(dual-write, additive). Covers telegram-bridge's local `_modality_for_mime` +
-`_media_attachment_headers` helpers and their round-trip through the
-local_task_protocol parsers. (The two helpers are duplicated from discord for
-now; both collapse into local_task_protocol once slack lands the same pair —
-rule of three.)
+After the rule-of-three dedup, telegram builds its refs inline and uses the
+shared local_task_protocol.media_attachment_headers (the header logic + mime
+mapping are tested in tests/local-task-protocol-attachments.test.py). Telegram
+has no remaining bridge-specific pure helper, so this asserts the module loads
+cleanly after the dedup (import + shared-helper use) and that a telegram-shaped
+task-mid file round-trips through the parsers with the legacy body line intact.
+
+telegram-bridge only warns (doesn't exit) without a token, so the load is easy.
 
 Run: python3 tests/telegram-writeside-attachments.test.py   (exit 0 pass / 1 fail)
 """
@@ -45,42 +46,23 @@ def _load(name: str, path: Path):
 ltp = _load("local_task_protocol", REPO / "src" / "local_task_protocol.py")
 tg = _load("tgbridge_ws", REPO / "src" / "telegram-bridge.py")
 
-# ── 1. _modality_for_mime — files included (the owner's question: pdf/doc → file) ──
-for mime, want in {"image/jpeg": "image", "audio/ogg": "audio", "video/mp4": "video",
-                   "application/pdf": "file", "application/zip": "file", "": "file",
-                   "text/csv": "file"}.items():
-    check(f"_modality_for_mime({mime!r}) == {want}", tg._modality_for_mime(mime) == want)
+# ── 1. telegram no longer carries local header helpers (folded into LTP) ──
+check("telegram module loads after dedup", tg is not None)
+check("local _media_attachment_headers removed", not hasattr(tg, "_media_attachment_headers"))
+check("local _modality_for_mime removed", not hasattr(tg, "_modality_for_mime"))
 
-# ── 2. _media_attachment_headers ──
-check("empty refs → '' (text-only unchanged)", tg._media_attachment_headers([], "hi") == "")
-
+# ── 2. round-trip through a realistic telegram task-mid file (shared helper) ──
 photo = ltp.AttachmentRef(locator="/tmp/tg/1_photo.jpg", mime="image/jpeg",
                           filename="1_photo.jpg", size=88123)
 doc = ltp.AttachmentRef(locator="/tmp/tg/2_report.pdf", mime="application/pdf",
                         filename="report.pdf", size=40100)
-voice = ltp.AttachmentRef(locator="/tmp/tg/3_voice.ogg", mime="audio/ogg",
-                          filename="3_voice.ogg", size=5120)
-
-h_img = tg._media_attachment_headers([photo], "look at this")
-check("photo+caption → content_modalities image,text", "content_modalities: image,text\n" in h_img, h_img)
-check("media_form attachment present", "media_form: attachment\n" in h_img)
-check("attachments json present", "attachments: [" in h_img)
-
-check("document → file modality (owner's files question)",
-      "content_modalities: file\n" in tg._media_attachment_headers([doc], ""))
-check("voice → audio modality",
-      "content_modalities: audio\n" in tg._media_attachment_headers([voice], ""))
-check("no caption → text modality omitted",
-      "content_modalities: image\n" in tg._media_attachment_headers([photo], ""))
-
-# ── 3. round-trip through a realistic telegram task-mid file ──
 task = (
     "id: task-tg\n"
     "timestamp: 2026-07-07T08:00:00Z\n"
     "task: [Telegram @qingyun] look at this\n[Photo attached: /tmp/tg/1_photo.jpg]\n"
     "source: telegram\n"
     "interaction_type: message\n"
-    f"{tg._media_attachment_headers([photo], 'look at this')}"
+    f"{ltp.media_attachment_headers([photo], True)}"
     "chat_id: 55\n"
     "priority: normal\n"
 )
@@ -94,8 +76,11 @@ check("round-trip: media_form", ltp.parse_media_form(hp.headers) == "attachment"
 check("dual-write: legacy [Photo attached:] survives in body",
       "[Photo attached: /tmp/tg/1_photo.jpg]" in hp.body)
 check("attachments header not left in body", "attachments:" not in hp.body)
+# document → file modality (the owner's "what about files?" case) via the shared helper
+check("document → file modality",
+      "content_modalities: file\n" in ltp.media_attachment_headers([doc], False))
 
-# ── 4. injection gate: the three keys defanged if forged in an untrusted body ──
+# ── 3. injection gate: the three keys defanged if forged in an untrusted body ──
 gd = _load("task_body_guard_tg", REPO / "src" / "task_body_guard.py")
 for k in ("attachments", "content_modalities", "media_form"):
     out = gd.confine_user_content(f"hi\n{k}: forged")
@@ -105,4 +90,4 @@ for k in ("attachments", "content_modalities", "media_form"):
 if failures:
     print(f"\nFAIL — {len(failures)} check(s) failed: {failures}")
     raise SystemExit(1)
-print("\nPASS — telegram write-side media-attachment headers")
+print("\nPASS — telegram write-side media-attachment integration")


### PR DESCRIPTION
## Architecture box

**4D interaction model → media/attachment track, step 1.5 cleanup.** Status: **implementing** (rule-of-three dedup, closing out the bridge write-side series).

## What

Slack (#1992) promoted `modality_for_mime` + `media_attachment_headers` into `local_task_protocol` when it became the third consumer. Discord (#1990) and telegram (#1991) still carried **verbatim private copies** of both. This deletes those copies and points each bridge's write site at the shared helpers — one implementation across all three message bridges.

**Pure refactor, behavior-identical.** The shared `media_attachment_headers(refs, has_text)` produces the exact header block the local `_media_attachment_headers(refs, text)` did; the two call sites now pass `bool(text and text.strip())`. `_ref_from_attachment` (discord SDK field reading) stays local — it's discord-specific, not shared.

## Tests

The write-side tests fold to match: the helper logic is covered by `tests/local-task-protocol-attachments.test.py`, so the bridge tests keep only what's bridge-specific:
- **discord** — `_ref_from_attachment` field reading + a task-mid round-trip through the shared helper (dual-write body survival, injection-defang gate), and asserts the local helpers are gone.
- **telegram** — post-dedup module load (catches a bad import from the refactor) + a round-trip through the shared helper, and asserts the local helpers are gone.

- All three tests PASS; no dangling references to the deleted helpers.
- diff-cover: **no coverage lines to gate** — the change is deletions + `# pragma: no cover` call-site swaps.
- **Net −117 lines.**

## Sequence

Closes the rule-of-three loop for the message bridges. **Next:** gateway structured emission (`remote-gateway-bridge.py` already safe-fetches Matrix media — just needs to emit `attachments[]` via the same shared helper), then LiveAgentRuntime honoring `media_form: live_stream`.