### PR TITLE
refactor(bridges): dedup _modality_for_mime/_media_attachment_headers → LTP

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -425,22 +425,6 @@ def _safe_attachment_basename(filename: str) -> str:
     return f"{safe_base}.{safe_ext}" if safe_ext else safe_base
 
 
-def _modality_for_mime(mime: str) -> str:
-    """Map an attachment MIME type to a Local Task Protocol content modality
-    (interaction-model 4D, step 1.5). image/audio/video by top-level type;
-    everything else (pdf, zip, docx, unknown) is `file`. Kept local to the
-    bridge until all three bridges converge on an identical mapping worth
-    promoting to local_task_protocol."""
-    m = (mime or "").lower()
-    if m.startswith("image/"):
-        return "image"
-    if m.startswith("audio/"):
-        return "audio"
-    if m.startswith("video/"):
-        return "video"
-    return "file"
-
-
 def _ref_from_attachment(att, local_path) -> "local_task_protocol.AttachmentRef":
     """Build an AttachmentRef from a discord Attachment + its saved local path
     (interaction-model 4D, step 1.5). Reads the SDK's `content_type`/`size`
@@ -452,29 +436,6 @@ def _ref_from_attachment(att, local_path) -> "local_task_protocol.AttachmentRef"
         mime=(getattr(att, "content_type", "") or ""),
         filename=_safe_attachment_basename(getattr(att, "filename", "") or ""),
         size=(getattr(att, "size", 0) or 0),
-    )
-
-
-def _media_attachment_headers(attachment_refs: list, text: str) -> str:
-    """Build the interaction-model 4D step-1.5 header trio for a task file when
-    the message carried attachments — otherwise "".
-
-    `content_modalities` = `text` (iff a caption is present) plus one modality
-    per attachment mime; `media_form` = `attachment` (these are discrete objects
-    — live audio/video never arrives on this path); `attachments` = one-line
-    JSON of the refs. Pure (no I/O) so the task-write path stays testable
-    without constructing a full discord Message."""
-    if not attachment_refs:
-        return ""
-    mods = set()
-    if text and text.strip():
-        mods.add("text")
-    for r in attachment_refs:
-        mods.add(_modality_for_mime(r.mime))
-    return (
-        f"content_modalities: {','.join(sorted(mods))}\n"
-        f"media_form: attachment\n"
-        f"attachments: {local_task_protocol.format_attachments(attachment_refs)}\n"
     )
 
 
@@ -3231,7 +3192,9 @@ async def _handle_discord_message(message, force=False):
     # Additive dual-write — Core's existing path is untouched; these are real
     # headers (after `task:`), so confine_user_content defangs any forged copy a
     # user tries to smuggle in the body but leaves these authentic ones intact.
-    media_headers = _media_attachment_headers(attachment_refs, text)  # pragma: no cover
+    media_headers = local_task_protocol.media_attachment_headers(  # pragma: no cover
+        attachment_refs, bool(text and text.strip())
+    )
 
     # Instrumentation (2026-06-23): make a silent "message received but no task
     # written" drop diagnosable. The owner saw several messages vanish with no

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -347,42 +347,6 @@ def _transcribe_via_skill(local_path: str) -> str | None:
     return None
 
 
-def _modality_for_mime(mime: str) -> str:
-    """Map an attachment MIME type to a Local Task Protocol content modality
-    (interaction-model 4D, step 1.5). image/audio/video by top-level type;
-    everything else (pdf, zip, docx, unknown) is `file`. Duplicated per bridge
-    for now (discord has the twin); promote to local_task_protocol once slack
-    lands the same pair (rule of three)."""
-    m = (mime or "").lower()
-    if m.startswith("image/"):
-        return "image"
-    if m.startswith("audio/"):
-        return "audio"
-    if m.startswith("video/"):
-        return "video"
-    return "file"
-
-
-def _media_attachment_headers(attachment_refs: list, text: str) -> str:
-    """Build the interaction-model 4D step-1.5 header trio for a task file when
-    the message carried attachments — otherwise "". content_modalities = `text`
-    (iff a caption is present) plus one modality per attachment mime; media_form
-    = `attachment` (discrete objects); attachments = one-line JSON of the refs.
-    Pure, so the task-write path stays testable without a live Telegram update."""
-    if not attachment_refs:
-        return ""
-    mods = set()
-    if text and text.strip():
-        mods.add("text")
-    for r in attachment_refs:
-        mods.add(_modality_for_mime(r.mime))
-    return (
-        f"content_modalities: {','.join(sorted(mods))}\n"
-        f"media_form: attachment\n"
-        f"attachments: {local_task_protocol.format_attachments(attachment_refs)}\n"
-    )
-
-
 def download_file(file_id, name_hint="file"):
     """Download a file from Telegram and save locally."""
     result = api("getFile", file_id=file_id)
@@ -842,7 +806,9 @@ def main():
                 # alongside the legacy [*attached:] body line (dual-write). Real
                 # headers after `task:`, so confine_user_content defangs a forged
                 # body copy while these authentic ones pass through.
-                media_headers = _media_attachment_headers(attachment_refs, text)  # pragma: no cover
+                media_headers = local_task_protocol.media_attachment_headers(  # pragma: no cover
+                    attachment_refs, bool(text and text.strip())
+                )
                 task_file.write_text(
                     f"id: {task_id}\n"
                     f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"

--- a/tests/discord-writeside-attachments.test.py
+++ b/tests/discord-writeside-attachments.test.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """Discord write-side media-attachment headers — interaction-model 4D, step 1.5 slice 2.
 
-The bridge now emits the structured header trio (`content_modalities` /
-`media_form` / `attachments`) ALONGSIDE the legacy `[File attached:]` body line
-(dual-write, additive). This covers the two pure helpers that build those
-headers — `_modality_for_mime` and `_media_attachment_headers` — and asserts the
-emitted headers round-trip back through the local_task_protocol parsers in a
-realistic task-mid file.
+The bridge emits the structured header trio (`content_modalities` / `media_form` /
+`attachments`) ALONGSIDE the legacy `[File attached:]` body line (dual-write,
+additive). After the rule-of-three promotion in #1992 the two bridge-local helpers
+were removed; this test now exercises `local_task_protocol.modality_for_mime` and
+`local_task_protocol.media_attachment_headers` directly, plus discord-specific
+`_ref_from_attachment`, and asserts the headers round-trip through the LTP parsers.
 
 discord-bridge's module load has side effects (discord SDK import, token read),
 so we stub them and run hermetically. Mirrors tests/bridge-audit-wiring.test.py.
@@ -60,12 +60,12 @@ except ImportError:
 ltp = _load("local_task_protocol", REPO / "src" / "local_task_protocol.py")
 db = _load("dbridge_ws", REPO / "src" / "discord-bridge.py")
 
-# ── 1. _modality_for_mime mapping ──
+# ── 1. modality_for_mime mapping (now in LTP, promoted from discord-bridge) ──
 cases = {"image/png": "image", "image/jpeg": "image", "audio/ogg": "audio",
          "video/mp4": "video", "application/pdf": "file", "text/plain": "file",
          "": "file", "IMAGE/PNG": "image"}
 for mime, want in cases.items():
-    check(f"_modality_for_mime({mime!r}) == {want}", db._modality_for_mime(mime) == want)
+    check(f"modality_for_mime({mime!r}) == {want}", ltp.modality_for_mime(mime) == want)
 
 # ── 1b. _ref_from_attachment reads discord SDK attributes defensively ──
 class _FakeAtt:
@@ -86,14 +86,14 @@ r2 = db._ref_from_attachment(_FakeAtt(content_type=None, size=None, filename="x.
 check("missing content_type → empty mime", r2.mime == "")
 check("missing size → 0", r2.size == 0)
 
-# ── 2. _media_attachment_headers: empty refs → "" (text-only path untouched) ──
+# ── 2. media_attachment_headers: empty refs → "" (text-only path untouched) ──
 check("no attachments → no headers (text-only unchanged)",
-      db._media_attachment_headers([], "hello") == "")
+      ltp.media_attachment_headers([], True) == "")
 
 # ── 3. header trio built for an image with a caption ──
 ref = ltp.AttachmentRef(locator="/tmp/discord-inbox/1_s.png", mime="image/png",
                         filename="s.png", size=438707)
-hdrs = db._media_attachment_headers([ref], "describe this")
+hdrs = ltp.media_attachment_headers([ref], True)
 check("emits content_modalities", "content_modalities: image,text\n" in hdrs, hdrs)
 check("emits media_form attachment", "media_form: attachment\n" in hdrs, hdrs)
 check("emits attachments json header", "attachments: [" in hdrs, hdrs)
@@ -101,14 +101,14 @@ check("header block is newline-terminated (composes into the write f-string)", h
 check("no stray embedded blank line breaks the header run", "\n\n" not in hdrs)
 
 # caption absent → no `text` modality
-hdrs_nocap = db._media_attachment_headers([ref], "")
+hdrs_nocap = ltp.media_attachment_headers([ref], False)
 check("no caption → text modality omitted",
       "content_modalities: image\n" in hdrs_nocap, hdrs_nocap)
 
 # a non-image attachment → file modality
 pdf = ltp.AttachmentRef(locator="/tmp/x.pdf", mime="application/pdf", size=10)
 check("pdf → file modality",
-      "content_modalities: file\n" in db._media_attachment_headers([pdf], ""))
+      "content_modalities: file\n" in ltp.media_attachment_headers([pdf], False))
 
 # ── 4. round-trip through a realistic task-mid file (discord is a task-mid writer) ──
 # Assemble exactly as the write block does, including the legacy body line.
@@ -119,7 +119,7 @@ task_file = (
     f"task: {body}\n"
     "source: discord\n"
     "interaction_type: message\n"
-    f"{db._media_attachment_headers([ref], 'describe this')}"
+    f"{ltp.media_attachment_headers([ref], True)}"
     "channel_id: 123\n"
     "access_tier: owner\n"
 )
@@ -145,4 +145,4 @@ for k in ("attachments", "content_modalities", "media_form"):
 if failures:
     print(f"\nFAIL — {len(failures)} check(s) failed: {failures}")
     raise SystemExit(1)
-print("\nPASS — discord write-side media-attachment headers")
+print("\nPASS — discord write-side media-attachment headers (LTP helpers)")

--- a/tests/telegram-writeside-attachments.test.py
+++ b/tests/telegram-writeside-attachments.test.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 """Telegram write-side media-attachment headers — interaction-model 4D, step 1.5 slice 2.
 
-Second bridge to emit the structured header trio (content_modalities /
-media_form / attachments) alongside the legacy [Photo|File|Voice ...] body line
-(dual-write, additive). Covers telegram-bridge's local `_modality_for_mime` +
-`_media_attachment_headers` helpers and their round-trip through the
-local_task_protocol parsers. (The two helpers are duplicated from discord for
-now; both collapse into local_task_protocol once slack lands the same pair —
-rule of three.)
+Telegram emits the structured header trio (content_modalities / media_form /
+attachments) alongside the legacy [Photo|File|Voice ...] body line (dual-write,
+additive). After the rule-of-three promotion in #1992 the two bridge-local helpers
+were removed; this test now exercises `local_task_protocol.modality_for_mime` and
+`local_task_protocol.media_attachment_headers` directly and asserts the headers
+round-trip through the LTP parsers.
 
 Run: python3 tests/telegram-writeside-attachments.test.py   (exit 0 pass / 1 fail)
 """
@@ -45,14 +44,14 @@ def _load(name: str, path: Path):
 ltp = _load("local_task_protocol", REPO / "src" / "local_task_protocol.py")
 tg = _load("tgbridge_ws", REPO / "src" / "telegram-bridge.py")
 
-# ── 1. _modality_for_mime — files included (the owner's question: pdf/doc → file) ──
+# ── 1. modality_for_mime — files included (the owner's question: pdf/doc → file) ──
 for mime, want in {"image/jpeg": "image", "audio/ogg": "audio", "video/mp4": "video",
                    "application/pdf": "file", "application/zip": "file", "": "file",
                    "text/csv": "file"}.items():
-    check(f"_modality_for_mime({mime!r}) == {want}", tg._modality_for_mime(mime) == want)
+    check(f"modality_for_mime({mime!r}) == {want}", ltp.modality_for_mime(mime) == want)
 
-# ── 2. _media_attachment_headers ──
-check("empty refs → '' (text-only unchanged)", tg._media_attachment_headers([], "hi") == "")
+# ── 2. media_attachment_headers (LTP) ──
+check("empty refs → '' (text-only unchanged)", ltp.media_attachment_headers([], True) == "")
 
 photo = ltp.AttachmentRef(locator="/tmp/tg/1_photo.jpg", mime="image/jpeg",
                           filename="1_photo.jpg", size=88123)
@@ -61,17 +60,17 @@ doc = ltp.AttachmentRef(locator="/tmp/tg/2_report.pdf", mime="application/pdf",
 voice = ltp.AttachmentRef(locator="/tmp/tg/3_voice.ogg", mime="audio/ogg",
                           filename="3_voice.ogg", size=5120)
 
-h_img = tg._media_attachment_headers([photo], "look at this")
+h_img = ltp.media_attachment_headers([photo], True)
 check("photo+caption → content_modalities image,text", "content_modalities: image,text\n" in h_img, h_img)
 check("media_form attachment present", "media_form: attachment\n" in h_img)
 check("attachments json present", "attachments: [" in h_img)
 
 check("document → file modality (owner's files question)",
-      "content_modalities: file\n" in tg._media_attachment_headers([doc], ""))
+      "content_modalities: file\n" in ltp.media_attachment_headers([doc], False))
 check("voice → audio modality",
-      "content_modalities: audio\n" in tg._media_attachment_headers([voice], ""))
+      "content_modalities: audio\n" in ltp.media_attachment_headers([voice], False))
 check("no caption → text modality omitted",
-      "content_modalities: image\n" in tg._media_attachment_headers([photo], ""))
+      "content_modalities: image\n" in ltp.media_attachment_headers([photo], False))
 
 # ── 3. round-trip through a realistic telegram task-mid file ──
 task = (
@@ -80,7 +79,7 @@ task = (
     "task: [Telegram @qingyun] look at this\n[Photo attached: /tmp/tg/1_photo.jpg]\n"
     "source: telegram\n"
     "interaction_type: message\n"
-    f"{tg._media_attachment_headers([photo], 'look at this')}"
+    f"{ltp.media_attachment_headers([photo], True)}"
     "chat_id: 55\n"
     "priority: normal\n"
 )
@@ -105,4 +104,4 @@ for k in ("attachments", "content_modalities", "media_form"):
 if failures:
     print(f"\nFAIL — {len(failures)} check(s) failed: {failures}")
     raise SystemExit(1)
-print("\nPASS — telegram write-side media-attachment headers")
+print("\nPASS — telegram write-side media-attachment headers (LTP helpers)")


### PR DESCRIPTION
## Summary

- Delete the bridge-local `_modality_for_mime` and `_media_attachment_headers` from `discord-bridge.py` and `telegram-bridge.py` — both were promoted to `local_task_protocol` in #1992 (rule-of-three)
- Update call sites: `_media_attachment_headers(refs, text)` → `local_task_protocol.media_attachment_headers(refs, bool(text and text.strip()))`, adapting `text: str` to the LTP `has_text: bool` signature
- Update both writeside attachment tests to use `ltp.modality_for_mime()` / `ltp.media_attachment_headers()` directly (sections 1–3 in each test file); discord-specific `_ref_from_attachment` unchanged

Net: -72 lines of duplicated logic. No behavior change — logic is identical and both bridge tests still pass.

## Test plan

- [ ] `python3 tests/discord-writeside-attachments.test.py` — 30/30 PASS
- [ ] `python3 tests/telegram-writeside-attachments.test.py` — 23/23 PASS
- [ ] `python3 tests/local-task-protocol-attachments.test.py` — all PASS
- [ ] CI tsc + diff-coverage gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB3qZQrwponfum2JFNvHeh