### PR TITLE
feat(gateway): emit structured attachments[] for fetched media (4D step 1.5, 4th producer)

### DIFF
--- a/src/remote-gateway-bridge.py
+++ b/src/remote-gateway-bridge.py
@@ -57,6 +57,7 @@ from pathlib import Path
 # src/ and pointed outside the repo).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402
+import local_task_protocol  # noqa: E402
 
 WS = resolve_workspace()
 TASKS_DIR = WS / "tasks"
@@ -392,10 +393,15 @@ def _download_bytes(url: str, headers: dict, cap: int) -> bytes:
     return data
 
 
-def _maybe_fetch_media(body: str) -> str:
+def _maybe_fetch_media(body: str, _refs_out: "list | None" = None) -> str:
     """If `body` carries a media marker, download the attachment to a local
     file and rewrite the marker to `[File attached: <path>]`. Returns the body
-    unchanged on any failure (drop-in safe)."""
+    unchanged on any failure (drop-in safe).
+
+    When `_refs_out` is provided and a fetch succeeds, the corresponding
+    `AttachmentRef` (interaction-model 4D, step 1.5) is appended to it — so
+    _write_task can stamp structured `attachments:` headers alongside the legacy
+    body line, without disturbing any of the drop-in-safe early returns."""
     m = MEDIA_MARKER_RE.search(body or "")
     if not m:
         return body
@@ -455,6 +461,9 @@ def _maybe_fetch_media(body: str) -> str:
         _log(f"media save failed ({e}) — leaving marker as-is")
         return body
     _log(f"fetched media → {path} ({len(data)} bytes)")
+    if _refs_out is not None:
+        _refs_out.append(local_task_protocol.AttachmentRef(
+            locator=str(path), mime=mime, filename=(name or path.name), size=len(data)))
     label = "Photo attached" if str(kind) == "m.image" else "File attached"
     # Replacement as a FUNCTION so backslashes/`\g<>` in the path can never be
     # interpreted as re.sub group references.
@@ -542,7 +551,21 @@ def _write_task(task: dict) -> str | None:
             lines.append(f"interaction_type: {it}")
         elif f == "task" and task.get("task") not in (None, ""):
             # Resolve an inbound media marker to a local file the core can read.
-            lines.append(f"task: {_one_line(_maybe_fetch_media(str(task['task'])))}")
+            _media_refs: list = []
+            _fetched = _maybe_fetch_media(str(task["task"]), _media_refs)
+            lines.append(f"task: {_one_line(_fetched)}")
+            # interaction-model 4D, step 1.5: if a media marker was fetched,
+            # stamp structured attachments[]/content_modalities/media_form
+            # alongside the legacy [File attached:] body line (dual-write) via the
+            # shared local_task_protocol helper — same shape the 3 message bridges
+            # emit. has_text = caption present beyond the provider prefix + marker.
+            if _media_refs:
+                _txt = re.sub(r"\[(?:File|Photo) attached: [^\]]*\]", "", _fetched).strip()
+                if _txt.startswith("[") and "]" in _txt:
+                    _txt = _txt.split("]", 1)[1]
+                _mh = local_task_protocol.media_attachment_headers(_media_refs, bool(_txt.strip()))
+                if _mh:
+                    lines.extend(_mh.rstrip("\n").split("\n"))
         elif f in task and task[f] not in (None, ""):
             lines.append(f"{f}: {_one_line(task[f])}")
     # access_tier is a LOCAL decision and written LAST so it wins even under a

--- a/tests/gateway-writeside-attachments.test.py
+++ b/tests/gateway-writeside-attachments.test.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Gateway write-side media-attachment headers — interaction-model 4D, step 1.5.
+
+The remote-gateway bridge already safe-fetches an inbound media marker to a
+local file and rewrites it to `[File attached: <path>]`. This adds the
+structured header trio (content_modalities / media_form / attachments) alongside
+that legacy line, via the shared local_task_protocol helper — the fourth (and
+last) producer to emit attachments[].
+
+`_maybe_fetch_media` does a network download, so we mock `_download_bytes` and
+drive a real media marker through `_write_task`. Mirrors the load pattern in
+tests/remote-gateway-interaction-type.test.py (redirect module-level dirs after
+import; no main()).
+
+Run: python3 tests/gateway-writeside-attachments.test.py   (exit 0 pass / 1 fail)
+"""
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+ltp = _load("local_task_protocol", REPO / "src" / "local_task_protocol.py")
+rgb = _load("remote_gateway_bridge", REPO / "src" / "remote-gateway-bridge.py")
+
+tmp = Path(tempfile.mkdtemp(prefix="rgb-media-test-"))
+rgb.TASKS_DIR = tmp / "tasks"
+rgb.RESULTS_DIR = tmp / "results"
+rgb.ARCHIVE_RESULTS_DIR = tmp / "results" / "archive"
+rgb.MEDIA_DIR = tmp / "media"
+# Mock the network fetch — any successful download yields bytes so the fetch
+# path builds a ref + rewrites the marker.
+rgb._download_bytes = lambda url, headers, cap: b"x" * 100
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + name + ((" — " + detail) if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+TAG = rgb.MEDIA_MARKER_TAG  # default "remote-media"
+
+
+def _write_and_parse(task):
+    tid = rgb._write_task(task)
+    assert tid, f"_write_task rejected {task!r}"
+    text = (rgb.TASKS_DIR / f"{tid}.txt").read_text()
+    return text, ltp.parse_task_headers_trusted(text)
+
+
+# ── 1. _maybe_fetch_media appends a ref + rewrites the marker ──
+refs = []
+body = f"[AG2Space @qingyun] look [{TAG}:https://example.com/pic.png mime=image/png name=pic.png kind=m.image]"
+out = rgb._maybe_fetch_media(body, refs)
+check("marker rewritten to [Photo attached:]", "[Photo attached: " in out and f"[{TAG}:" not in out, out)
+check("one ref appended", len(refs) == 1, str(refs))
+check("ref mime from marker", refs and refs[0].mime == "image/png")
+check("ref filename from marker", refs and refs[0].filename == "pic.png")
+check("ref size = downloaded bytes", refs and refs[0].size == 100)
+check("ref locator is the saved local path", refs and refs[0].locator.startswith(str(rgb.MEDIA_DIR)))
+# out-param omitted → drop-in-safe, no crash, still rewrites
+check("_refs_out optional (back-compat)", "[Photo attached: " in rgb._maybe_fetch_media(body))
+
+# ── 2. _write_task with a media marker + caption → structured headers ──
+text, h = _write_and_parse({
+    "id": "task-gw-1",
+    "task": f"[AG2Space @qingyun] look at this [{TAG}:https://example.com/pic.png mime=image/png name=pic.png kind=m.image]",
+})
+check("dual-write: legacy [Photo attached:] in the task body", "[Photo attached: " in text)
+atts = ltp.parse_attachments(h.headers)
+check("attachments header emitted + parses", len(atts) == 1 and atts[0].mime == "image/png", str(atts))
+check("content_modalities has image+text (caption present)",
+      ltp.parse_content_modalities(h.headers) == frozenset({"image", "text"}),
+      h.get("content_modalities"))
+check("media_form attachment", ltp.parse_media_form(h.headers) == "attachment")
+
+# ── 3. media marker, NO caption → image only, no text modality ──
+text, h = _write_and_parse({
+    "id": "task-gw-2",
+    "task": f"[AG2Space @qingyun] [{TAG}:https://example.com/doc.pdf mime=application/pdf name=doc.pdf kind=m.file]",
+})
+check("no caption → file modality only",
+      ltp.parse_content_modalities(h.headers) == frozenset({"file"}), h.get("content_modalities"))
+check("pdf → [File attached:] label", "[File attached: " in text)
+
+# ── 4. plain text task (no marker) → NO media headers ──
+text, h = _write_and_parse({"id": "task-gw-3", "task": "just a text question"})
+check("no marker → no attachments header", "attachments:" not in text)
+check("no marker → no content_modalities header", "content_modalities:" not in text)
+
+# ── 5. regression: access_tier is still the LAST header (my insert is mid-file) ──
+lines = [l for l in text.split("\n") if l]
+check("access_tier still last header", lines[-1].startswith("access_tier:"))
+# and with media present too
+text1 = (rgb.TASKS_DIR / "task-gw-1.txt").read_text()
+lines1 = [l for l in text1.split("\n") if l]
+check("access_tier last even with media headers", lines1[-1].startswith("access_tier:"))
+
+if failures:
+    print(f"\nFAIL — {len(failures)} check(s) failed: {failures}")
+    raise SystemExit(1)
+print("\nPASS — gateway write-side media-attachment headers")


### PR DESCRIPTION
## Architecture box

**4D interaction model → media/attachment track, step 1.5 — gateway write-side.** Status: **implementing.** The 4th and final producer, after discord (#1990) / telegram (#1991) / slack (#1992) and the dedup (#1993).

## What

`remote-gateway-bridge.py` already safe-fetches an inbound Matrix media marker to a local file (auth token scoped to the exact origin, 25 MB cap, `/_matrix/media` authenticated-media upgrade) and rewrites it to `[File attached: <path>]`. This adds the structured header trio (`content_modalities` / `media_form` / `attachments`) alongside that legacy line, via the shared `local_task_protocol.media_attachment_headers`. **Dual-write, additive** — nothing that reads the legacy line changes.

## Design — drop-in-safe threading

`_maybe_fetch_media(body, _refs_out=None)` gains an **optional** out-param. On a successful fetch it appends the `AttachmentRef` it already has the metadata for (mime/name/path/size). Because the param is optional and only the success path touches it, **none of the seven drop-in-safe early returns are modified** — the failure semantics are byte-identical. `_write_task` passes a list, then stamps the headers right after the `task:` line.

- **`access_tier` is still written LAST** — the tier defense relies on last-occurrence-wins, and my header insert is mid-file, before it. Regression-tested.
- **has_text**: `content_modalities` includes `text` only when a caption is present beyond the provider prefix and the attachment marker.

## Tests — `tests/gateway-writeside-attachments.test.py` (new)

Mocks `_download_bytes` and drives a real marker through `_write_task`:
- `_maybe_fetch_media` appends a ref (mime/filename/size/local-path) + rewrites the marker; out-param omitted stays drop-in-safe.
- `_write_task`: dual-write legacy `[Photo/File attached:]` survives; `attachments:` parses back; image+text vs file-only modalities; no-marker → no headers.
- Regression: `access_tier` remains the last header (with and without media).

- diff-cover **100% (14/14)** — `_write_task` is sync, so the new logic is genuinely exercised, no pragmas.
- Existing `tests/remote-gateway-interaction-type.test.py` still green.

## Sequence

Completes attachments[] emission across **all four producers** (3 message bridges + gateway). Remaining media-track work: LiveAgentRuntime honoring `media_form: live_stream` (needs a design sync — it unifies the live plane with the task-file plane), and eventually removing the legacy `[File attached:]` line once all consumers read `attachments[]` (blast radius scoped in notes/).