### PR TITLE
feat(live): stamp media_form: live_stream on live-plane tasks (4D step 1.5, scope A)

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -433,7 +433,10 @@ function delegateTask(callSession: CallSession, taskDescription: string): Promis
 	// task_priority's phone→urgent mapping, and discord-bridge's
 	// DM_FALLBACK_SOURCES — a result landing after the call ended now reaches
 	// the owner as a DM instead of rotting unclaimed in results/.
-	const content = `id: ${taskId}\ntimestamp: ${new Date().toISOString()}\nsource: phone\ninteraction_type: realtime_audio\ncallSid: ${callSession.callSid}\ncaller: ${callSession.callerNumber || 'unknown'}\naccess_tier: ${callSession.isOwner ? 'owner' : 'other'}\ntask: ${taskDescription}\nhint: Check ${skillsHint} for a matching skill before using raw commands.\ntranscript:\n${fullTranscript}\n`;
+	// `media_form: live_stream` — interaction-model 4D step 1.5 (scope A): the
+	// phone plane is a live real-time session, same as web voice. Additive
+	// provenance/observability stamp; media frames stay out-of-band.
+	const content = `id: ${taskId}\ntimestamp: ${new Date().toISOString()}\nsource: phone\ninteraction_type: realtime_audio\nmedia_form: live_stream\ncallSid: ${callSession.callSid}\ncaller: ${callSession.callerNumber || 'unknown'}\naccess_tier: ${callSession.isOwner ? 'owner' : 'other'}\ntask: ${taskDescription}\nhint: Check ${skillsHint} for a matching skill before using raw commands.\ntranscript:\n${fullTranscript}\n`;
 	writeFileSync(taskPath, content);
 
 	// Poll for result in background, inject when ready — don't block Gemini

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -357,6 +357,13 @@ export const workTool: ToolDefinition = {
 			`timestamp: ${timestamp}\n` +
 			`source: voice\n` +
 			`interaction_type: realtime_audio\n` +
+			// interaction-model 4D, step 1.5 (scope A): stamp the media-form axis
+			// on live-plane tasks. Additive/observability — routing still keys on
+			// _isVoiceTask (source/channel_id); scope B makes this the canonical
+			// plane-routing signal. `live_stream` = the payload originates from a
+			// continuous real-time session (media frames stay out-of-band per the
+			// three-channel rule; this is provenance, not stream bytes).
+			`media_form: live_stream\n` +
 			`channel_id: local-voice\n` +
 			`user_id: ${ownerId}\n` +
 			`access_tier: owner\n` +

--- a/tests/task-bridge-isvoice.test.ts
+++ b/tests/task-bridge-isvoice.test.ts
@@ -37,6 +37,17 @@ source: discord
 channel_id: 1490906927675474030
 task: hello world
 `;
+// interaction-model 4D step 1.5 (scope A): voice tasks now carry a
+// `media_form: live_stream` header BEFORE `task:`. The stamp is additive —
+// _isVoiceTask keys on source/channel_id, so the verdict must stay true.
+const VOICE_BODY_LIVESTREAM = `id: task-isvoice-test-ls-aaa
+timestamp: 2026-07-07T00:00:00Z
+source: voice
+interaction_type: realtime_audio
+media_form: live_stream
+channel_id: local-voice
+task: hello world
+`;
 
 const created: string[] = [];
 function writeTask(path: string, body: string) {
@@ -55,6 +66,12 @@ describe('_isVoiceTask — archive-path coverage', () => {
 	it('returns true for a voice task in the live tasks/ dir', () => {
 		const id = 'task-isvoice-test-live-aaa';
 		writeTask(join(TASK_DIR, `${id}.txt`), VOICE_BODY);
+		assert.equal(_isVoiceTask(id), true);
+	});
+
+	it('returns true for a scope-A voice task carrying media_form: live_stream (stamp is additive)', () => {
+		const id = 'task-isvoice-test-ls-aaa';
+		writeTask(join(TASK_DIR, `${id}.txt`), VOICE_BODY_LIVESTREAM);
 		assert.equal(_isVoiceTask(id), true);
 	});
 


### PR DESCRIPTION
## Architecture box

**4D interaction model → media_form axis, `live_stream` — scope A (stamp).** Status: **implementing.** Owner-approved A→B split from the design proposal (`notes/design-media-form-live-stream.md`).

## What

Stamp `media_form: live_stream` on live-plane tasks so the 4D media-form axis is complete and observable end-to-end (the attachment side landed across all 4 producers; this is the live side). **Additive only** — routing still keys on `_isVoiceTask`; **scope B** (make `media_form` the canonical plane-routing signal, gated by a shadow-replay eval) is the fast-follow.

Both live-task producers get the stamp, placed **before** the `task:` line:
- `src/task-bridge.ts` — web-voice delegation, after `interaction_type: realtime_audio`.
- `skills/phone-conversation/scripts/conversation-server.ts` — phone, same.

`live_stream` = the payload originates from a continuous real-time session; media frames stay **out-of-band** per the three-channel rule (LiveAgentRuntime owns them), so this is provenance, not stream bytes. `parse_media_form` already recognizes it (`local_task_protocol`, #1988).

## Why it's safe (no routing change)

The stamp lands **before** `task:`, and `_isVoiceTask` stops scanning at `task:` and keys on `source`/`channel_id` — so its verdict is unaffected. Locked by a new regression case: a voice task carrying `media_form: live_stream` still classifies as voice.

## Tests

- New `_isVoiceTask` regression fixture in `tests/task-bridge-isvoice.test.ts` (scope-A shape → still voice).
- `tsc --noEmit` clean.
- Green: isvoice (9) + phone-archive + delegation + delimiter (26 total). Pure-TS change, so the Python diff-cover gate is N/A.

## Next (scope B — separate PR)

Make `media_form` the canonical plane-routing signal (`_isVoiceTask` / result-router consult it, source/channel_id as transition fallback), gated by a **shadow-replay eval**: replay archived `realtime_audio` tasks through the media_form-keyed router and assert the verdict matches the current `_isVoiceTask` verdict for 100% of the corpus before cutover. Never change the voice-critical result path without it.