### PR TITLE
fix(local-task-protocol): iter_archived_tasks skips non-task-id files

### DIFF
--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -285,12 +285,19 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
 
 def iter_archived_tasks(tasks_dir: Path) -> Iterable[Path]:
     """Yield every archived task file (flat legacy + month-partitioned),
-    for corpus sweeps and golden tests."""
+    for corpus sweeps and golden tests.
+
+    Only yields files whose stem is a valid task id — skips non-task files
+    (e.g. answer-Q* response records) that may share the archive directory.
+    """
     archive_root = tasks_dir / "archive"
     if not archive_root.is_dir():
         return
     for p in sorted(archive_root.glob("*.txt")):
-        yield p
+        if valid_task_id(p.stem):
+            yield p
     for entry in sorted(archive_root.iterdir()):
         if entry.is_dir() and _MONTH_DIR_RE.match(entry.name):
-            yield from sorted(entry.glob("*.txt"))
+            for p in sorted(entry.glob("*.txt")):
+                if valid_task_id(p.stem):
+                    yield p


### PR DESCRIPTION
## Summary
- `iter_archived_tasks` now filters out files whose stem is not a valid task id
- `answer-Q*` response records (from the question-answering mechanism) land in the archive directory but have stems like `answer-Q1-1782828485030` which fail `valid_task_id` (must start with `task-`)
- The live corpus sweep in `tests/local-task-protocol.test.py` was counting them as "lacked ids" and failing with "4 lacked ids"

## Test plan
- [ ] `python3 tests/local-task-protocol.test.py` — "live corpus: id recoverable everywhere" now passes
- [ ] `python3 tests/discord-task-source-invariance.test.py` — still passes (172 files, same count)
- [ ] `python3 tests/task-priority-invariance.test.py` — still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB3qZQrwponfum2JFNvHeh