### PR TITLE
fix(start-cli): replace fragile pgrep with tmux session_exists; make test hermetic

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -22,6 +22,11 @@ cd "$REPO"
 TMUX_SOCKET="/tmp/sutando-tmux.sock"
 SESSION="sutando-core"
 
+session_exists() {
+  command -v tmux > /dev/null 2>&1 || return 1
+  tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" > /dev/null 2>&1
+}
+
 # Optional working-directory override for the core `claude` process.
 #   - Unset (upstream default): no override — the core launches from $REPO (the
 #     script's cwd), exactly as before. Zero behavior change for OSS installs.
@@ -237,13 +242,13 @@ fi
 # emit-task. Unsafe: a future agent processing a "restart core" task by
 # exec'ing this script from within sutando-core. Per Mini's #608 review.
 if [ "$1" = "--restart" ]; then
-  if pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1; then
+  if session_exists; then
     echo "Killing existing $SESSION session..."
     tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION" 2>/dev/null || true
     # Poll for actual shutdown — robust on slow machines, faster on fast
     # ones (~1s ceiling) than a fixed sleep.
     for _ in 1 2 3 4 5; do
-      pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1 || break
+      session_exists || break
       sleep 0.2
     done
   fi
@@ -276,7 +281,7 @@ apply_tmux_defaults() {
 
 # Already running — attach if interactive, else exit cleanly. This branch
 # also catches the !--restart path so re-running the script is idempotent.
-if pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1; then
+if session_exists; then
   apply_tmux_defaults
   if [ -t 1 ] && command -v tmux > /dev/null 2>&1; then
     echo "Attaching to existing $SESSION (Ctrl-b d to detach)..."

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -24,7 +24,7 @@ SESSION="sutando-core"
 
 session_exists() {
   command -v tmux > /dev/null 2>&1 || return 1
-  tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" > /dev/null 2>&1
+  tmux -S "$TMUX_SOCKET" has-session -t "=$SESSION" > /dev/null 2>&1
 }
 
 # Optional working-directory override for the core `claude` process.
@@ -244,7 +244,7 @@ fi
 if [ "$1" = "--restart" ]; then
   if session_exists; then
     echo "Killing existing $SESSION session..."
-    tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION" 2>/dev/null || true
+    tmux -S "$TMUX_SOCKET" kill-session -t "=$SESSION" 2>/dev/null || true
     # Poll for actual shutdown — robust on slow machines, faster on fast
     # ones (~1s ceiling) than a fixed sleep.
     for _ in 1 2 3 4 5; do

--- a/tests/start-cli-claude-config-dir.test.sh
+++ b/tests/start-cli-claude-config-dir.test.sh
@@ -49,6 +49,9 @@ setup_sandbox() {
   BIN_STUB="$SANDBOX/bin"
   export HOME="$SANDBOX/home"
   export SUTANDO_WORKSPACE="$SANDBOX/workspace"
+  # Hermetic: parent session's CLAUDE_CONFIG_DIR must not bleed into start-cli's
+  # helper-absent test (it would appear in the env-dump and cause a false FAIL).
+  unset CLAUDE_CONFIG_DIR
 
   mkdir -p "$REPO_FAKE/scripts" "$REPO_FAKE/src" "$REPO_FAKE/src/agent/claude/cli" "$BIN_STUB" \
            "$HOME" "$SUTANDO_WORKSPACE/state"
@@ -61,10 +64,9 @@ exit 0
 EOF
   chmod +x "$BIN_STUB/claude"
 
-  # Stub `pgrep` — start-cli's L34/L48 use pgrep to detect an existing
-  # sutando-core session and short-circuit to "already running". The TEST
-  # runner itself IS a claude process, so real pgrep would match and the
-  # spawn path never runs. Stub returns exit 1 (no matches found).
+  # Stub `pgrep` — kept for forward-compat (some code paths may still call it),
+  # but session detection now goes through `tmux has-session` (see session_exists()
+  # in start-cli.sh). The stub here is a no-op safety net; exit 1 = no match.
   cat > "$BIN_STUB/pgrep" << 'EOF'
 #!/bin/bash
 exit 1
@@ -88,7 +90,10 @@ case "\$1" in
     while [ "\$#" -gt 0 ] && [ "\$1" != "claude" ]; do shift; done
     if [ "\$1" = "claude" ]; then exec "\$@"; fi
     ;;
-  has-session|kill-session|start-server|set-option|bind|attach)
+  has-session)
+    exit 1  # no session exists — lets tests exercise the fresh-spawn path
+    ;;
+  kill-session|start-server|set-option|bind|attach)
     :  # no-op
     ;;
 esac
@@ -108,9 +113,11 @@ EOF
   if [ "$helper_present" = "yes" ]; then
     cp "$REAL_REPO/scripts/sutando-config.sh" "$REPO_FAKE/scripts/"
     cp "$REAL_REPO/src/sutando_config.py" "$REPO_FAKE/src/"
+    # Use absolute path so workspace resolves to $SANDBOX/workspace (the same
+    # dir the mkdir above created), avoiding a mismatch with ${REPO_DIR}/workspace.
     cat > "$REPO_FAKE/sutando.config.json" << EOF
 {
-  "workspace": {"path": "\${REPO_DIR}/workspace"},
+  "workspace": {"path": "$SANDBOX/workspace"},
   "claude_sutando_config_dir": {"subdir": "$helper_subdir"}
 }
 EOF
@@ -173,8 +180,10 @@ test_valid_config_exports_env() {
     echo "  FAIL: CLAUDE_CONFIG_DIR not in claude's env"
     cleanup_sandbox; return 1
   fi
-  # Must point at SUTANDO_WORKSPACE/.claude-sutando.
-  expected="CLAUDE_CONFIG_DIR=$SUTANDO_WORKSPACE/.claude-sutando"
+  # Must point at SANDBOX/workspace/.claude-sutando. Normalize via realpath
+  # because sutando-config.sh resolves the path (macOS /var → /private/var).
+  ws_real="$(python3 -c "import os; print(os.path.realpath('$SANDBOX/workspace'))")"
+  expected="CLAUDE_CONFIG_DIR=${ws_real}/.claude-sutando"
   if [ "$ccd_in_env" != "$expected" ]; then
     echo "  FAIL: CLAUDE_CONFIG_DIR mismatch"
     echo "    expected : $expected"


### PR DESCRIPTION
## What

Replaces two uses of `pgrep -f "claude.*--name.*SESSION"` in `start-cli.sh` with a
`session_exists()` helper that calls `tmux -S SOCKET has-session -t =SESSION` — the
canonical tmux-native way to check whether a named session is alive.

Also fixes the unit test `tests/start-cli-claude-config-dir.test.sh` to be hermetic:
the tmux stub's `has-session` now correctly returns exit 1 (no session), and ambient
`CLAUDE_CONFIG_DIR` from the host is cleared before each test case.

## Why

`pgrep -f` matches against the full argv string of every running process. On a machine
where the test runner IS a `claude` process (typical in CI), the pgrep would hit the
test runner itself and the script would think a session is already running, skipping the
spawn path. Using `tmux has-session` is both correct and immune to this false positive.

## Changes

- `src/agent/claude/cli/start-cli.sh` — add `session_exists()`, replace 3 `pgrep` calls
- `tests/start-cli-claude-config-dir.test.sh`:
  - `has-session` stub returns exit 1 (no existing session — lets spawn path run)
  - `unset CLAUDE_CONFIG_DIR` hermetically clears ambient host env
  - `sutando.config.json` uses absolute `$SANDBOX/workspace` path (not `${REPO_DIR}/workspace`)
  - expected path normalized with `python3 os.path.realpath` (macOS `/var` → `/private/var`)

## Test

```
bash tests/start-cli-claude-config-dir.test.sh
```

```
PASSED: 4  FAILED: 0
```

Contributes to #1961 (burns `tests/start-cli-claude-config-dir.test.sh` from the allowlist).

**Note:** #1970 also modifies `tests/start-cli-claude-config-dir.test.sh` (overlapping
hermetic-env fixes). Whichever merges second will need a trivial rebase — changes touch
the same setup_sandbox block but are compatible. Recommend: merge this PR first (smaller
diff, source + one test), then #1970 rebases.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QB3qZQrwponfum2JFNvHeh