### PR TITLE
fix(desktop): skip [RESOLVED] headings in pending-question chip scan (#2005)

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -647,9 +647,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // first so the chip reflects THIS host's questions, not a stale flat-root copy.
         let pqPath = perHostPath("pending-questions.md")
         if let pq = try? String(contentsOfFile: pqPath, encoding: .utf8) {
-            // Skip the leading "# Memory" or similar h1, find first h2.
+            // Skip h1 and [RESOLVED] h2s; latch onto the first open h2.
             for line in pq.split(separator: "\n") {
-                if line.hasPrefix("## ") {
+                if line.hasPrefix("## ") && !line.hasPrefix("## [RESOLVED]") {
                     let title = String(line.dropFirst(3))
                     let preview = title.count > 60 ? String(title.prefix(57)) + "..." : title
                     chips.append(["label": "Pending: \(preview)", "desc": "Resolve in pending-questions.md"])


### PR DESCRIPTION
## Summary

- `refreshContextualChips()` in `src/Sutando/main.swift` was picking the **first `## ` heading** in `pending-questions.md` regardless of whether it was marked `[RESOLVED]`
- Answered questions remained visible as "Pending:" chips in the menu-bar until the file was restructured
- One-character guard: `&& !line.hasPrefix("## [RESOLVED]")` makes the loop walk past resolved headings and latch onto the first open one (or add no chip if all are resolved)

## Test plan

- [x] Seed `pending-questions.md` with all `[RESOLVED]` entries — verify no "Pending:" chip appears after next 120s tick
- [x] Seed with one `[RESOLVED]` above one open question — verify chip shows the open question, not the resolved one
- [x] No open questions at all — verify no chip

Closes #2005

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB3qZQrwponfum2JFNvHeh

## Manual verification

Ran locally on 2026-07-07 against `fix/pending-question-chip-resolved-skip`.

- Confirmed `origin/main` still has the unguarded first-`## ` scan, and the pre-test chip output from the older running app showed `Pending: [RESOLVED] Q7 ...`.
- Built the patched menu-bar binary with `swiftc -O -o Sutando main.swift SutandoConfig.swift -framework Cocoa -framework Carbon -framework ApplicationServices -framework AVFoundation`.
- Seeded all `[RESOLVED]` h2 entries: after startup refresh, `contextual-chips.json` had no `Pending:` chip.
- Seeded `[RESOLVED]` h2 above `## Q2 - Manual test open question`: after the real 120s timer tick, the chip was `Pending: Q2 - Manual test open question`.
- Seeded no h2/open question: after the real 120s timer tick, `contextual-chips.json` had no `Pending:` chip.
- Restored the original host `pending-questions.md` after the test.
