### PR TITLE
fix(protocol): relax valid_task_id to match gateway _valid_tid charset (#1960)

### DIFF
--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -121,22 +121,23 @@ KNOWN_HEADER_KEYS = (
 )
 _KNOWN_KEY_SET = frozenset(KNOWN_HEADER_KEYS)
 
-# Task-id shape: `task-<slug>` where slug is dash-separated [a-z0-9] segments
-# (task-1783..., task-chat-1783..., task-phone-..., task-summary-...,
-# task-gh-..., task-health-...). Mirrors the gateway bridge's `_valid_tid`
-# defense: ids become filenames, so the charset is the path-traversal guard.
-TASK_ID_RE = re.compile(r"^task-[A-Za-z0-9][A-Za-z0-9-]{0,120}$")
+# Task-id charset matches the gateway bridge's `_valid_tid` exactly:
+# [A-Za-z0-9._-]{1,64}, with "." and ".." blocked explicitly.
+# Live producers use task-*, ask-*, sc-ask-*, reco-skill-* prefixes;
+# the charset (not the prefix) is the path-traversal guard (#2007).
+TASK_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
 
 def valid_task_id(tid: str) -> bool:
     """True iff `tid` is a well-formed task id, safe to embed in a filename.
 
-    Rejects path separators, dots, whitespace, and empty/oversized ids — the
-    id is used as `tasks/<tid>.txt` and `results/<tid>.txt`, so this is the
-    single traversal gate for readers that accept ids from message content
-    (e.g. `[deduped: <tid>]` holders).
+    Rejects path separators, whitespace, empty/oversized ids, and the dot
+    aliases "." / ".." — the id is used as `tasks/<tid>.txt` and
+    `results/<tid>.txt`, so this is the traversal gate for readers that
+    accept ids from message content (e.g. `[deduped: <tid>]` holders).
+    Charset mirrors `remote-gateway-bridge._valid_tid` (issue #1960).
     """
-    return bool(TASK_ID_RE.match(tid or ""))
+    return bool(TASK_ID_RE.match(tid or "")) and tid not in (".", "..")
 
 
 # ── Header parsing ───────────────────────────────────────────────────────────

--- a/tests/local-task-protocol.test.py
+++ b/tests/local-task-protocol.test.py
@@ -213,11 +213,14 @@ check("task_body on file with no task: line is empty",
       ltp.task_body("id: t\ntimestamp: ts\n") == "")
 
 # 7. Task-id validation (traversal gate).
+# Charset matches gateway _valid_tid: [A-Za-z0-9._-]{1,64}, "."/"..") blocked (#1960).
+# Live producers use task-*, ask-*, sc-ask-*, reco-skill-* — all must pass.
 for good in ("task-1783377232367", "task-chat-1783379117", "task-phone-1", "task-gh-5",
-             "task-health-1700", "task-summary-1"):
+             "task-health-1700", "task-summary-1",
+             "ask-1783377232367", "sc-ask-1783379117", "reco-skill-9012"):
     check(f"id ok: {good}", ltp.valid_task_id(good))
-for bad in ("", "task-", "task-../../etc", "task-a b", "task-a/b", "result-1",
-            "task-" + "x" * 200, "task-.hidden"):
+for bad in ("", "task-../../etc", "task-a b", "task-a/b",
+            "x" * 65, ".", ".."):
     check(f"id rejected: {bad[:24]!r}", not ltp.valid_task_id(bad))
 
 # 8. Archive rules.


### PR DESCRIPTION
## Summary

- `local_task_protocol.valid_task_id` required a `task-` prefix and forbade `.`/`_`, while the gateway's `_valid_tid` (the function it's documented to mirror) accepts `[A-Za-z0-9._-]{1,64}` with no prefix requirement
- 79 archived task files use `ask-*`, `sc-ask-*`, `reco-skill-*` prefixes — valid tasks from live producers, silently rejected by `valid_task_id`
- When readers adopt `find_archived_task()` in the reader-consolidation follow-up, those files would be invisibly missed

## Change

New `TASK_ID_RE = ^[A-Za-z0-9._-]{1,64}$` matches the gateway charset exactly; `"."` and `".."` are blocked explicitly (as the gateway does with `tid not in (".", "..")`)

## Test plan

- [ ] All existing tests pass (`python3 tests/local-task-protocol.test.py`)
- [ ] `ask-*`, `sc-ask-*`, `reco-skill-*` IDs now accepted (added as good cases)
- [ ] `"."`, `".."`, empty string, `>64` length, paths-with-`/` still rejected

Closes #1960

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB3qZQrwponfum2JFNvHeh