### PR TITLE
feat(dashboard): add Schedules card (cron jobs + next run)

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -352,7 +352,16 @@ def get_schedules() -> list[dict]:
             next_str = f'{nxt.strftime("%a %H:%M")} ({rel})'
         else:
             next_str = ">7d" if expr else "invalid"
-        out.append({"name": job.get("name", "?"), "cron": expr, "kind": kind, "next": next_str})
+        if job.get("description"):
+            desc = job["description"]
+        elif job.get("prompt_skill"):
+            desc = f'Runs the /{job["prompt_skill"]} skill'
+        else:
+            _p = re.sub(r"^Run:?\s*", "", (job.get("prompt") or "").strip())
+            desc = (_p[:100] + "…") if len(_p) > 100 else _p
+        desc = desc.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        out.append({"name": job.get("name", "?"), "cron": expr, "kind": kind,
+                    "next": next_str, "desc": desc})
     return out
 
 
@@ -474,7 +483,8 @@ def render_dashboard() -> str:
         for s in schedules:
             sched_rows += (
                 f'<tr>'
-                f'<td style="color:#8ab">{s["name"]}</td>'
+                f'<td style="color:#8ab">{s["name"]}'
+                f'<div style="font-size:9px;color:#555">{s.get("desc","")}</div></td>'
                 f'<td style="color:#666;font-family:monospace;font-size:10px">{s["cron"]}</td>'
                 f'<td style="color:#555;font-size:10px">{s["kind"]}</td>'
                 f'<td style="color:#4a8aaa">{s["next"]}</td>'

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -18,6 +18,7 @@ import http.server
 import json
 import os
 import re
+import socket
 import subprocess
 import sys
 from datetime import datetime
@@ -272,6 +273,89 @@ def get_use_case_matrix() -> str:
     return '<table style="width:100%;font-size:11px;border-collapse:collapse"><tr style="color:#555;text-align:left"><th></th><th>Use Case</th><th>Details</th></tr>' + ''.join(rows) + '</table>'
 
 
+def _cron_field_match(spec: str, value: int) -> bool:
+    """Match one cron field value against a spec supporting *, */N, A-B, A,B, N."""
+    for token in spec.split(","):
+        if token == "*":
+            return True
+        if token.startswith("*/"):
+            try:
+                step = int(token[2:])
+            except ValueError:
+                continue
+            if step and value % step == 0:
+                return True
+        elif "-" in token:
+            try:
+                a, b = (int(x) for x in token.split("-", 1))
+            except ValueError:
+                continue
+            if a <= value <= b:
+                return True
+        elif token.isdigit() and int(token) == value:
+            return True
+    return False
+
+
+def _cron_next_run(expr: str, now: datetime, horizon_days: int = 8):
+    """Next datetime matching a 5-field cron expr (minute hour dom month dow),
+    scanning minute-by-minute up to horizon_days. Returns datetime or None.
+
+    dom/dow are AND-combined (sufficient for our crons, which restrict only one
+    of them); the rare cron OR-semantics edge case is not modeled.
+    """
+    from datetime import timedelta
+    parts = expr.split()
+    if len(parts) != 5:
+        return None
+    mnt, hr, dom, mon, dow = parts
+    t = now.replace(second=0, microsecond=0) + timedelta(minutes=1)
+    end = now + timedelta(days=horizon_days)
+    while t <= end:
+        cron_dow = (t.weekday() + 1) % 7  # python Mon=0..Sun=6 -> cron Sun=0..Sat=6
+        if (_cron_field_match(mnt, t.minute) and _cron_field_match(hr, t.hour)
+                and _cron_field_match(dom, t.day) and _cron_field_match(mon, t.month)
+                and _cron_field_match(dow, cron_dow)):
+            return t
+        t += timedelta(minutes=1)
+    return None
+
+
+def get_schedules() -> list[dict]:
+    """This host's cron schedules + computed next-run time.
+
+    Source: <workspace>/hosts/<hostname>/crons.json (see skills/schedule-crons).
+    Status is 'active' + next run; last-run history isn't tracked on disk.
+    """
+    host = socket.gethostname().split(".")[0]
+    cfg = WORKSPACE_DIR / "hosts" / host / "crons.json"
+    if not cfg.exists():
+        return []
+    try:
+        jobs = json.loads(cfg.read_text())
+    except (OSError, ValueError):
+        return []
+    now = datetime.now()
+    out = []
+    for job in jobs:
+        expr = job.get("cron", "")
+        kind = f'skill:{job["prompt_skill"]}' if job.get("prompt_skill") else "prompt"
+        nxt = _cron_next_run(expr, now) if expr else None
+        if nxt:
+            mins = int((nxt - now).total_seconds() // 60)
+            if mins < 60:
+                rel = f"in {mins}m"
+            elif mins < 1440:
+                rel = f"in {mins // 60}h{mins % 60:02d}m"
+            else:
+                rel = f"in {mins // 1440}d{(mins % 1440) // 60}h"
+            next_str = f'{nxt.strftime("%a %H:%M")} ({rel})'
+        else:
+            next_str = ">7d" if expr else "invalid"
+        out.append({"name": job.get("name", "?"), "cron": expr, "kind": kind, "next": next_str})
+    return out
+
+
 def render_dashboard() -> str:
     health = get_health()
     activity = get_activity(5)
@@ -382,6 +466,31 @@ def render_dashboard() -> str:
 <div style="margin-top:8px;font-size:12px;color:#555">
 {_hk_rows}
 </div></div>""")
+
+    # Schedules (cron jobs from this host's crons.json)
+    schedules = get_schedules()
+    if schedules:
+        sched_rows = ""
+        for s in schedules:
+            sched_rows += (
+                f'<tr>'
+                f'<td style="color:#8ab">{s["name"]}</td>'
+                f'<td style="color:#666;font-family:monospace;font-size:10px">{s["cron"]}</td>'
+                f'<td style="color:#555;font-size:10px">{s["kind"]}</td>'
+                f'<td style="color:#4a8aaa">{s["next"]}</td>'
+                f'</tr>\n'
+            )
+        cards.append(
+            '<div class="card full"><h2>Schedules</h2>'
+            '<table style="width:100%;font-size:11px;border-collapse:collapse">'
+            '<tr style="color:#555;text-align:left"><th>Name</th><th>Cron</th>'
+            '<th>Type</th><th>Next run</th></tr>'
+            + sched_rows +
+            '</table>'
+            '<div style="font-size:9px;color:#444;margin-top:4px">'
+            f'{len(schedules)} active. Next-run computed from cron expression '
+            '(local time); last-run history not tracked.</div></div>'
+        )
 
     # Quick links
     cards.append(f"""<div class="card full">

--- a/tests/dashboard-schedules.test.py
+++ b/tests/dashboard-schedules.test.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Unit tests for the dashboard Schedules card (PR #2008).
+
+Covers the cron-schedule surface added to ``src/dashboard.py``:
+  - ``_cron_field_match`` — one cron field vs a spec (``*``, ``*/N``, ``A-B``,
+    ``A,B``, ``N``, and the malformed-token skip paths).
+  - ``_cron_next_run`` — next matching datetime (a match, a wrong-arity expr,
+    and an expr with no match inside the horizon).
+  - ``get_schedules`` — reads ``<workspace>/hosts/<host>/crons.json`` and formats
+    each job (all four ``next``-string buckets + the three ``desc`` sources +
+    the missing-file / bad-json guards).
+  - the Schedules block inside ``render_dashboard`` — driven with the heavy
+    ``get_*`` helpers stubbed so it runs identically on any host/CI.
+
+Standalone script (``python3 tests/dashboard-schedules.test.py``), matching the
+repo's ``tests/**/*.test.py`` convention.
+"""
+
+import json
+import sys
+import tempfile
+import types
+from datetime import datetime, timedelta
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+import dashboard  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# _cron_field_match
+# --------------------------------------------------------------------------- #
+def test_cron_field_match_wildcard():
+    assert dashboard._cron_field_match("*", 0) is True
+    assert dashboard._cron_field_match("*", 59) is True
+
+
+def test_cron_field_match_step():
+    assert dashboard._cron_field_match("*/5", 10) is True   # 10 % 5 == 0
+    assert dashboard._cron_field_match("*/5", 3) is False   # 3 % 5 != 0
+    assert dashboard._cron_field_match("*/0", 4) is False   # step 0 → no match
+    assert dashboard._cron_field_match("*/x", 4) is False   # non-int step → skip
+
+
+def test_cron_field_match_range():
+    assert dashboard._cron_field_match("1-5", 3) is True
+    assert dashboard._cron_field_match("1-5", 9) is False
+    assert dashboard._cron_field_match("a-b", 3) is False   # non-int range → skip
+
+
+def test_cron_field_match_list_and_single():
+    assert dashboard._cron_field_match("1,2,3", 2) is True
+    assert dashboard._cron_field_match("7", 7) is True
+    assert dashboard._cron_field_match("7", 8) is False
+    assert dashboard._cron_field_match("9,10-12", 11) is True  # list + range mix
+
+
+# --------------------------------------------------------------------------- #
+# _cron_next_run
+# --------------------------------------------------------------------------- #
+def test_cron_next_run_matches():
+    now = datetime(2026, 7, 7, 12, 0, 0)
+    nxt = dashboard._cron_next_run("* * * * *", now)
+    assert nxt == now + timedelta(minutes=1)
+
+
+def test_cron_next_run_wrong_arity():
+    assert dashboard._cron_next_run("* * * *", datetime.now()) is None
+    assert dashboard._cron_next_run("", datetime.now()) is None
+
+
+def test_cron_next_run_no_match_in_horizon():
+    # Feb 30 never exists → scans the whole horizon and returns None.
+    assert dashboard._cron_next_run("0 0 30 2 *", datetime(2026, 7, 7, 12, 0)) is None
+
+
+# --------------------------------------------------------------------------- #
+# get_schedules
+# --------------------------------------------------------------------------- #
+def _with_crons(tmp: Path, jobs):
+    host = "test-host"
+    dashboard.socket.gethostname = lambda: f"{host}.local"  # → split(".")[0]
+    dashboard.WORKSPACE_DIR = tmp
+    d = tmp / "hosts" / host
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "crons.json").write_text(json.dumps(jobs))
+    return dashboard.get_schedules()
+
+
+def test_get_schedules_missing_file_returns_empty():
+    with tempfile.TemporaryDirectory() as td:
+        dashboard.socket.gethostname = lambda: "nohost"
+        dashboard.WORKSPACE_DIR = Path(td)
+        assert dashboard.get_schedules() == []
+
+
+def test_get_schedules_bad_json_returns_empty():
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        host = "test-host"
+        dashboard.socket.gethostname = lambda: host
+        dashboard.WORKSPACE_DIR = tmp
+        d = tmp / "hosts" / host
+        d.mkdir(parents=True)
+        (d / "crons.json").write_text("{not valid json")
+        assert dashboard.get_schedules() == []
+
+
+def test_get_schedules_formats_all_branches():
+    now = datetime.now()
+    soon = now + timedelta(minutes=30)          # < 60m  → "in Xm"
+    hours = now + timedelta(hours=3)            # < 1440m → "in HhMMm"
+    days = now + timedelta(days=2)              # >= 1440m → "in DdHh"
+    jobs = [
+        # prompt_skill → kind "skill:...", desc "Runs the /... skill"
+        {"name": "loop", "cron": "* * * * *", "prompt_skill": "proactive-loop"},
+        # explicit description wins; hour-bucket next-run
+        {"name": "brief", "cron": f"{hours.minute} {hours.hour} * * *",
+         "description": "Daily briefing"},
+        # day-bucket next-run
+        {"name": "weekly", "cron": f"{days.minute} {days.hour} {days.day} * *",
+         "prompt": "do weekly things"},
+        # minute-bucket + prompt-derived desc with Run: prefix, HTML chars, truncation
+        {"name": "sync", "cron": f"{soon.minute} {soon.hour} * * *",
+         "prompt": "Run: sync & flush <everything> " + "x" * 120},
+        # valid expr but no match in horizon → ">7d"
+        {"name": "leap", "cron": "0 0 30 2 *"},
+        # no cron → "invalid"; no name → "?"
+        {"prompt": "no schedule"},
+    ]
+    with tempfile.TemporaryDirectory() as td:
+        out = _with_crons(Path(td), jobs)
+
+    by_name = {r["name"]: r for r in out}
+    assert by_name["loop"]["kind"] == "skill:proactive-loop"
+    assert by_name["loop"]["desc"] == "Runs the /proactive-loop skill"
+    assert by_name["brief"]["desc"] == "Daily briefing"
+    assert by_name["brief"]["kind"] == "prompt"
+
+    # next-string buckets
+    assert by_name["loop"]["next"].endswith("(in 0m)") or "in " in by_name["loop"]["next"]
+    assert "h" in by_name["brief"]["next"]        # HhMMm bucket
+    assert "d" in by_name["weekly"]["next"]       # DdHh bucket
+    assert by_name["leap"]["next"] == ">7d"
+    assert by_name["?"]["next"] == "invalid"
+
+    # prompt-derived desc: "Run:" stripped, &/< escaped, truncated with ellipsis
+    sync_desc = by_name["sync"]["desc"]
+    assert not sync_desc.startswith("Run:")
+    assert "&amp;" in sync_desc and "&lt;" in sync_desc
+    assert sync_desc.endswith("…")
+
+
+# --------------------------------------------------------------------------- #
+# render_dashboard — Schedules block
+# --------------------------------------------------------------------------- #
+def _stub_render_deps():
+    """Stub the heavy get_* helpers so render_dashboard runs deterministically."""
+    dashboard.get_health = lambda *a, **k: []
+    dashboard.get_activity = lambda *a, **k: []
+    dashboard.get_pending_count = lambda *a, **k: {"open": 0}
+    dashboard.get_score = lambda *a, **k: 50
+    dashboard.get_system_stats = lambda *a, **k: {
+        "charging": False, "disk_free": "10G", "battery": "100%",
+        "quota": {"available": True, "utilization_5h": 0, "utilization_7d": 0,
+                  "reset_5h": "?", "reset_7d": "?", "headers": {}},
+    }
+    dashboard.get_use_case_matrix = lambda *a, **k: ""
+    dashboard.get_outbox = lambda *a, **k: []
+    # Avoid depending on a real `pgrep` binary in the render path.
+    dashboard.subprocess = types.SimpleNamespace(
+        run=lambda *a, **k: types.SimpleNamespace(returncode=1),
+        PIPE=-1,
+    )
+
+
+def test_render_dashboard_includes_schedules_block():
+    _stub_render_deps()
+    dashboard.get_schedules = lambda: [
+        {"name": "job1", "desc": "does a thing", "cron": "* * * * *",
+         "kind": "skill:proactive-loop", "next": "Mon 09:00 (in 5m)"},
+    ]
+    html = dashboard.render_dashboard()
+    assert "<h2>Schedules</h2>" in html
+    assert "job1" in html and "does a thing" in html
+    assert "1 active." in html
+
+
+def test_render_dashboard_omits_schedules_when_none():
+    _stub_render_deps()
+    dashboard.get_schedules = lambda: []
+    html = dashboard.render_dashboard()
+    assert "<h2>Schedules</h2>" not in html
+
+
+def main():
+    tests = [
+        test_cron_field_match_wildcard,
+        test_cron_field_match_step,
+        test_cron_field_match_range,
+        test_cron_field_match_list_and_single,
+        test_cron_next_run_matches,
+        test_cron_next_run_wrong_arity,
+        test_cron_next_run_no_match_in_horizon,
+        test_get_schedules_missing_file_returns_empty,
+        test_get_schedules_bad_json_returns_empty,
+        test_get_schedules_formats_all_branches,
+        test_render_dashboard_includes_schedules_block,
+        test_render_dashboard_omits_schedules_when_none,
+    ]
+    failures = []
+    for fn in tests:
+        try:
+            fn()
+            print(f"  ✓ {fn.__name__}")
+        except AssertionError as e:
+            failures.append(f"{fn.__name__}: {e}")
+            print(f"  ✗ {fn.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failures.append(f"{fn.__name__}: {type(e).__name__}: {e}")
+            print(f"  ✗ {fn.__name__}: {type(e).__name__}: {e}")
+    if failures:
+        print("\nFailures:")
+        for f in failures:
+            print(f"  {f}")
+        sys.exit(1)
+    print("All dashboard-schedules tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a **Schedules** card to the local dashboard so you can see all your cron schedules and their status at a glance.

For each job in `<workspace>/hosts/<hostname>/crons.json` it shows:
- **Name** (e.g. `main-loop`, `morning-briefing`)
- **Cron** expression
- **Type** — `skill:<name>` or `prompt`
- **Next run** — computed local time + relative (e.g. `Wed 06:57 (in 19h14m)`)

## How

- `get_schedules()` reads the per-host `crons.json` and computes next-run per job.
- `_cron_next_run()` / `_cron_field_match()` — a small, dependency-free 5-field cron evaluator (`*`, `*/N`, `A-B`, `A,B`, `N`; dom/dow AND-combined), scanning up to 8 days ahead. **No `croniter` dependency.**
- Last-run history isn't tracked on disk, so status is "active" + next run.

## Testing

Rendered against the real `crons.json` (7 jobs) — next-run values verified: `*/5`→`in ~2m`, `*/30`→next `:00`, `57 6 * * *`→`Wed 06:57`. Full `render_dashboard()` smoke test passes and produces well-formed HTML with all 7 rows.

Note: the dashboard reads schedules from the workspace it resolves to; on a split-checkout host the live dashboard and `crons.json` must share a workspace for the card to populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)