### PR TITLE
fix(core): stop headless core hanging on AskUserQuestion

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -36,5 +36,27 @@ PY
 file itself is executed fresh on every tool call, so updating `context-source-guard.py`
 takes effect immediately. Adding a *new* registration requires the core session to restart.
 
+## `skip-ask-user-question.py`
+
+Blocks the built-in interactive **AskUserQuestion** tool in the headless core.
+The core runs non-interactively (`start-cli.sh` launches `claude` with
+`--dangerously-skip-permissions` inside tmux, driven over `--remote-control`, no
+human at the terminal), so an `AskUserQuestion` tool call has no UI to answer it
+and **blocks the session indefinitely**. This hook returns a PreToolUse `deny`
+for `AskUserQuestion` — Claude Code short-circuits the call before it can render
+and feeds the reason back to the model, which then proceeds autonomously. It is a
+no-op (exit 0) for every other tool, and fails **open** on any error.
+
+Unlike `context-source-guard.py`, this hook is **auto-registered** for every core
+session — no per-node deploy step. `src/agent/claude/cli/start-cli.sh` always
+composes it into the core's `--settings` JSON (via
+`src/agent/claude/cli/build-core-settings.mjs`, which also merges in the obs
+collector hooks when capture is enabled), under a `PreToolUse` matcher scoped to
+`AskUserQuestion`. To register it manually elsewhere, add a `PreToolUse` entry
+with matcher `"AskUserQuestion"` and command `python3 <path>/skip-ask-user-question.py`.
+
+Test: `python3 tests/skip-ask-user-question.test.py` (hook) and
+`tsx --test tests/agent/claude/cli/build-core-settings.test.ts` (registration/merge).
+
 Config paths are env-overridable for testing: `SUTANDO_DISCORD_ACCESS_FILE`,
 `SUTANDO_DISCORD_ENV_FILE`, `SUTANDO_WORKSPACE`. Test: `python3 tests/context-source-guard.test.py`.

--- a/hooks/skip-ask-user-question.py
+++ b/hooks/skip-ask-user-question.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""skip-ask-user-question — PreToolUse hook that blocks the interactive
+`AskUserQuestion` tool in Sutando's headless core session.
+
+Why: the core agent runs NON-INTERACTIVELY — src/agent/claude/cli/start-cli.sh
+launches it with `--dangerously-skip-permissions` inside a tmux pane, driven
+over `--remote-control`, with no human watching the terminal. When the model
+calls the built-in `AskUserQuestion` tool there, no UI ever renders to answer
+it, so the tool BLOCKS THE SESSION INDEFINITELY (observed in the obs collector:
+a `tool.call` with tool_name=AskUserQuestion, permission_mode=bypassPermissions,
+that never returns).
+
+Denying the call in a PreToolUse hook short-circuits it BEFORE it can render:
+Claude Code skips the tool and feeds `permissionDecisionReason` back to the
+model, which then continues on its own judgement instead of hanging. Confirmed
+against the hooks contract — a PreToolUse `deny` does not render an
+AskUserQuestion prompt, it blocks the call outright.
+
+The hook is a NO-OP (exit 0 = allow) for every other tool, so it is safe to
+register under any matcher; the `permissionDecision: deny` output is only ever
+emitted for AskUserQuestion. Fail-OPEN on any error — a crashing hook must never
+wedge the core.
+
+Registration: Sutando's core launcher wires this automatically for every core
+session via `--settings` (see src/agent/claude/cli/build-core-settings.mjs,
+invoked from start-cli.sh). For manual/other deployments, register it under
+PreToolUse with matcher "AskUserQuestion" — see hooks/README.md.
+"""
+import sys
+import json
+
+TOOL = "AskUserQuestion"
+
+REASON = (
+    "AskUserQuestion is disabled in this session: Sutando's core agent runs headless "
+    "(no interactive user to answer), so the tool would block the session forever. "
+    "Do NOT ask — decide autonomously: pick the option you judge best, or state a clear "
+    "assumption and proceed. If a choice is genuinely blocking AND irreversible, surface "
+    "the question through a normal channel instead (write it to the per-host "
+    "pending-questions.md or send an owner notification) and keep working on other things. "
+    "[skip-ask-user-question]"
+)
+
+
+def main() -> None:
+    data = json.loads(sys.stdin.read())
+    if data.get("tool_name") == TOOL:
+        print(json.dumps({"hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": REASON,
+        }}))
+    # Every other tool (and the deny above) exits 0: PreToolUse only blocks when
+    # a deny decision is present in the JSON payload.
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:  # fail-open: never wedge the core on a hook error
+        print(f"[skip-ask-user-question] non-fatal error, allowing: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/src/agent/claude/cli/build-core-settings.mjs
+++ b/src/agent/claude/cli/build-core-settings.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Build the Claude Code `--settings` JSON for the Sutando core session.
+//
+// Always registers the AskUserQuestion safety guard (a PreToolUse `deny` hook —
+// the headless core has no interactive user, so an AskUserQuestion tool call
+// would block the session forever; see hooks/skip-ask-user-question.py). When
+// obs capture is enabled, the collector's hook settings are MERGED into the same
+// JSON so a single `--settings` flag carries both (multiple `--settings` flags
+// are undocumented / last-wins, so we never rely on passing more than one).
+//
+// Composition — not obs internals — lives here on purpose: the obs event map is
+// owned solely by src/observability/claude/hooks/build-hook-settings.mjs; this
+// builder treats the obs settings as an opaque JSON blob and array-concats it
+// with the guard, so the two concerns never drift.
+//
+// Usage:  node build-core-settings.mjs <abs-path-to-guard-hook.py> [<obs-settings-json>]
+//   arg1 (required): path to the guard hook script (skip-ask-user-question.py).
+//   arg2 (optional): the obs `--settings` JSON string from build-hook-settings.mjs;
+//                    empty / omitted → obs hooks are not included.
+// Prints the merged settings JSON to stdout (exit 2 on a missing guard path,
+// exit 3 on an unparseable obs-settings blob).
+
+const guardHook = process.argv[2];
+if (!guardHook) {
+	process.stderr.write('usage: build-core-settings.mjs <guard-hook-path> [<obs-settings-json>]\n');
+	process.exit(2);
+}
+const obsJson = process.argv[3] || '';
+
+// POSIX single-quote a string so it survives as one shell word regardless of
+// spaces, $, backticks, or quotes: wrap in '…' and replace each embedded ' with
+// the '\'' idiom. (Same guarantee as build-hook-settings.mjs — the checkout path
+// can contain any of these.)
+const shq = (s) => "'" + s.replace(/'/g, "'\\''") + "'";
+
+// The guard is a PreToolUse hook scoped to the single `AskUserQuestion` tool
+// (exact-string matcher). Defense-in-depth: the script itself re-checks the tool
+// name and no-ops for anything else, so the matcher is belt-and-suspenders.
+const guardCommand = `python3 ${shq(guardHook)}`;
+const guardSettings = {
+	hooks: {
+		PreToolUse: [{ matcher: 'AskUserQuestion', hooks: [{ type: 'command', command: guardCommand }] }],
+	},
+};
+
+// Deep-merge hook settings by CONCATENATING the per-event arrays (Claude Code
+// runs every registered hook for an event). Plain object spread / `*`-style
+// merges would REPLACE one PreToolUse array with the other — dropping either the
+// guard or the obs collector. Order: guard first so its deny is evaluated, then
+// obs (which still records the tool.call for AskUserQuestion — both hooks fire).
+function mergeHookSettings(...sources) {
+	const out = { hooks: {} };
+	for (const src of sources) {
+		const hooks = (src && src.hooks) || {};
+		for (const [event, entries] of Object.entries(hooks)) {
+			out.hooks[event] = (out.hooks[event] || []).concat(entries);
+		}
+	}
+	return out;
+}
+
+let obsSettings = null;
+if (obsJson.trim()) {
+	try {
+		obsSettings = JSON.parse(obsJson);
+	} catch (e) {
+		process.stderr.write(`build-core-settings: obs settings JSON is unparseable: ${e.message}\n`);
+		process.exit(3);
+	}
+}
+
+process.stdout.write(JSON.stringify(mergeHookSettings(guardSettings, obsSettings)));

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -176,36 +176,50 @@ if [ -n "${SUTANDO_CORE_MODEL:-}" ]; then
   MODEL_ARGS=(--model "$SUTANDO_CORE_MODEL")
 fi
 
-# ---- obs hooks (registered ONLY when an export endpoint is set) -------------
-# Register Claude Code hooks via `--settings` (merges with the user's settings
-# at highest precedence, per-session — no persistent file edit) ONLY when an
-# endpoint is configured. With no endpoint we inject no --settings at all, so
-# PreToolUse/PostToolUse never fork obs-hook.sh on the tool-call hot path —
-# capture is truly zero-cost (not just a no-op fork) when off. The endpoint comes
-# from $SUTANDO_OBS_ENDPOINT (exported so the hook — which runs in the session's
-# inherited env — resolves it at hook-time).
+# ---- core --settings hooks (AskUserQuestion guard always; obs when enabled) --
+# One `--settings` flag carries every hook the core needs (multiple --settings
+# flags are undocumented / last-wins, so we compose into a single JSON):
+#
+#   * AskUserQuestion guard — ALWAYS registered. The core runs headless (no
+#     interactive user), so an AskUserQuestion tool call would block the session
+#     forever; a PreToolUse `deny` short-circuits it (hooks/skip-ask-user-question.py).
+#   * obs collector hooks — added to the SAME JSON only when an export endpoint
+#     is set, so PreToolUse/PostToolUse only fork obs-hook.sh on the tool-call
+#     hot path when capture is actually on. Endpoint comes from
+#     $SUTANDO_OBS_ENDPOINT (exported so the hook resolves it at hook-time).
+#
+# The JSON is built by node helpers, NOT shell string interpolation: hand-rolled
+# interpolation broke when $REPO held a space (split the command) or a `"` (broke
+# the JSON). The helpers POSIX single-quote the path inside the command and
+# JSON-escape the payload. The ${arr[@]+...} guard keeps the empty array safe on
+# bash 3.2 under `set -u` (same pattern as MODEL_ARGS above).
 OBS_ENDPOINT="${SUTANDO_OBS_ENDPOINT:-}"
 export SUTANDO_OBS_ENDPOINT="$OBS_ENDPOINT"
 
-# Inject --settings (and thus the per-event hooks) only when an endpoint exists.
-# The ${arr[@]+...} guard keeps the empty array safe on bash 3.2 under `set -u`
-# (same pattern as MODEL_ARGS above). The settings JSON is built by a node helper,
-# NOT shell string interpolation: hand-rolled interpolation broke when $REPO held
-# a space (split the command) or a `"` (broke the JSON). The helper POSIX
-# single-quotes the path inside the command and JSON-escapes the payload. Its 10
-# event keys are all valid CC hook events (code.claude.com/docs/en/hooks.md).
 SETTINGS_ARGS=()
-if [ -z "$OBS_ENDPOINT" ]; then
-  echo "obs hooks: not registered (no export endpoint — set SUTANDO_OBS_ENDPOINT to enable capture)"
-elif ! command -v node > /dev/null 2>&1; then
-  echo "obs hooks: node unavailable — cannot safely build --settings JSON; capture disabled this session" >&2
+if ! command -v node > /dev/null 2>&1; then
+  echo "core hooks: node unavailable — cannot safely build --settings JSON; AskUserQuestion guard + obs disabled this session" >&2
 else
-  HOOKS_JSON="$(node "$REPO/src/observability/claude/hooks/build-hook-settings.mjs" "$REPO/src/observability/claude/hooks/obs-hook.sh")"
-  if [ -n "$HOOKS_JSON" ]; then
-    SETTINGS_ARGS=(--settings "$HOOKS_JSON")
-    echo "obs hooks: → $OBS_ENDPOINT/ingest/claude-code-hooks (collector)"
+  # Obs hooks are optional; the guard is not. Build the obs blob first (empty
+  # string when capture is off) and let the composer array-concat it with the
+  # always-on guard.
+  OBS_JSON=""
+  if [ -z "$OBS_ENDPOINT" ]; then
+    echo "obs hooks: not registered (no export endpoint — set SUTANDO_OBS_ENDPOINT to enable capture)"
   else
-    echo "obs hooks: settings build failed — capture disabled this session" >&2
+    OBS_JSON="$(node "$REPO/src/observability/claude/hooks/build-hook-settings.mjs" "$REPO/src/observability/claude/hooks/obs-hook.sh")"
+    if [ -n "$OBS_JSON" ]; then
+      echo "obs hooks: → $OBS_ENDPOINT/ingest/claude-code-hooks (collector)"
+    else
+      echo "obs hooks: settings build failed — capture disabled this session" >&2
+    fi
+  fi
+  CORE_SETTINGS_JSON="$(node "$REPO/src/agent/claude/cli/build-core-settings.mjs" "$REPO/hooks/skip-ask-user-question.py" "$OBS_JSON")"
+  if [ -n "$CORE_SETTINGS_JSON" ]; then
+    SETTINGS_ARGS=(--settings "$CORE_SETTINGS_JSON")
+    echo "core hooks: AskUserQuestion guard registered (PreToolUse deny — headless core can't answer it)"
+  else
+    echo "core hooks: settings build failed — AskUserQuestion guard NOT registered this session" >&2
   fi
 fi
 

--- a/tests/agent/claude/cli/build-core-settings.test.ts
+++ b/tests/agent/claude/cli/build-core-settings.test.ts
@@ -1,0 +1,91 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// Builders are plain .mjs (run by start-cli.sh via `node <builder> <args>`), so
+// we exercise them exactly as the shell does: exec and parse stdout.
+const CORE_BUILDER = fileURLToPath(
+	new URL('../../../../src/agent/claude/cli/build-core-settings.mjs', import.meta.url),
+);
+const OBS_BUILDER = fileURLToPath(
+	new URL('../../../../src/observability/claude/hooks/build-hook-settings.mjs', import.meta.url),
+);
+
+function buildCore(guardPath: string, obsJson?: string): any {
+	const args = obsJson === undefined ? [CORE_BUILDER, guardPath] : [CORE_BUILDER, guardPath, obsJson];
+	return JSON.parse(execFileSync('node', args, { encoding: 'utf8' }));
+}
+
+function buildObs(hookPath: string): string {
+	return execFileSync('node', [OBS_BUILDER, hookPath], { encoding: 'utf8' });
+}
+
+/** Strip a `python3 `/`bash ` prefix and let a real shell re-parse the quoted
+ *  remainder — i.e. the path the shell would actually pass to the interpreter. */
+function shellParsedPath(command: string): string {
+	const arg = command.replace(/^(python3|bash) /, '');
+	return execFileSync('/bin/bash', ['-c', `printf %s ${arg}`], { encoding: 'utf8' });
+}
+
+const GUARD = '/x/hooks/skip-ask-user-question.py';
+
+describe('build-core-settings.mjs', () => {
+	it('always registers the AskUserQuestion guard (guard-only, obs off)', () => {
+		const o = buildCore(GUARD, ''); // empty obs blob == capture off
+		assert.deepEqual(Object.keys(o.hooks), ['PreToolUse']);
+		const pre = o.hooks.PreToolUse;
+		assert.equal(pre.length, 1);
+		assert.equal(pre[0].matcher, 'AskUserQuestion');
+		assert.match(pre[0].hooks[0].command as string, /^python3 '/);
+		assert.equal(shellParsedPath(pre[0].hooks[0].command), GUARD);
+	});
+
+	it('omitting the obs arg entirely is equivalent to obs off', () => {
+		const o = buildCore(GUARD);
+		assert.deepEqual(Object.keys(o.hooks), ['PreToolUse']);
+		assert.equal(o.hooks.PreToolUse.length, 1);
+		assert.equal(o.hooks.PreToolUse[0].matcher, 'AskUserQuestion');
+	});
+
+	it('merges the guard with obs hooks (concat, guard first) when obs is on', () => {
+		const obs = JSON.parse(buildObs('/x/obs-hook.sh'));
+		const o = buildCore(GUARD, buildObs('/x/obs-hook.sh'));
+		// Guard survives, obs survives: PreToolUse holds BOTH matchers, guard first.
+		const pre = o.hooks.PreToolUse;
+		assert.equal(pre.length, 2, 'guard entry must not replace the obs entry (or vice-versa)');
+		assert.equal(pre[0].matcher, 'AskUserQuestion');
+		assert.equal(pre[1].matcher, '*');
+		// Every obs event key is preserved.
+		for (const ev of Object.keys(obs.hooks)) {
+			assert.ok(o.hooks[ev], `merged settings dropped obs event ${ev}`);
+		}
+		// obs-only lifecycle events pass through untouched.
+		assert.deepEqual(o.hooks.SessionStart, obs.hooks.SessionStart);
+	});
+
+	const ADVERSARIAL = [
+		'/Users/o brien/hooks/skip-ask-user-question.py', // spaces
+		'/Users/o"brien/hooks/skip-ask-user-question.py', // double quote
+		"/Users/o'brien/hooks/skip-ask-user-question.py", // single quote (POSIX '\'' escape)
+		'/path/with$dollar/and`tick`/skip-ask-user-question.py', // $ + backtick must not expand
+	];
+	for (const p of ADVERSARIAL) {
+		it(`round-trips a guard path through valid JSON + shell quoting: ${p}`, () => {
+			const o = buildCore(p, '');
+			const cmd = o.hooks.PreToolUse[0].hooks[0].command as string;
+			assert.match(cmd, /^python3 '/); // POSIX single-quoted
+			assert.equal(shellParsedPath(cmd), p); // shell sees the EXACT original path
+		});
+	}
+
+	it('exits non-zero when no guard path is given', () => {
+		assert.throws(() => execFileSync('node', [CORE_BUILDER], { encoding: 'utf8', stdio: 'pipe' }));
+	});
+
+	it('exits non-zero on an unparseable obs-settings blob', () => {
+		assert.throws(() =>
+			execFileSync('node', [CORE_BUILDER, GUARD, '{not json'], { encoding: 'utf8', stdio: 'pipe' }),
+		);
+	});
+});

--- a/tests/skip-ask-user-question.test.py
+++ b/tests/skip-ask-user-question.test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""PreToolUse skip-ask-user-question: the headless core must never block on the
+interactive AskUserQuestion tool (hooks/skip-ask-user-question.py).
+
+Drives the real hook via stdin (the way Claude Code invokes it) and asserts:
+  * AskUserQuestion  -> emits a PreToolUse `deny` decision (tool short-circuited).
+  * any other tool   -> no output, exit 0 (allowed).
+  * malformed stdin  -> fail-OPEN (exit 0, no deny) so a crash never wedges core.
+Run:  python3 tests/skip-ask-user-question.test.py
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK = str(Path(__file__).resolve().parent.parent / "hooks" / "skip-ask-user-question.py")
+
+
+def run(payload):
+    # payload may be a dict (JSON-encoded) or a raw string (malformed-input case).
+    stdin = json.dumps(payload) if not isinstance(payload, str) else payload
+    return subprocess.run([sys.executable, HOOK], input=stdin,
+                          capture_output=True, text=True, timeout=20)
+
+
+def decision(out):
+    try:
+        return json.loads(out).get("hookSpecificOutput", {}).get("permissionDecision")
+    except Exception:
+        return None
+
+
+# 1) AskUserQuestion is denied — the whole point of the hook.
+r = run({"tool_name": "AskUserQuestion", "tool_input": {"questions": [{"question": "?"}]}})
+assert r.returncode == 0, f"AskUserQuestion: expected exit 0, got {r.returncode} / {r.stderr}"
+out = json.loads(r.stdout)
+hso = out["hookSpecificOutput"]
+assert hso["hookEventName"] == "PreToolUse", f"wrong hookEventName: {hso}"
+assert hso["permissionDecision"] == "deny", f"expected deny, got {hso}"
+assert hso.get("permissionDecisionReason"), "deny must carry a reason so the model can proceed"
+
+# 2) Every other tool is allowed (no output, exit 0). A stray deny here would
+#    break normal operation for unrelated tools.
+for tool in ("Bash", "Read", "Edit", "Task", "WebFetch", "AskUserQuestionX", "askuserquestion"):
+    r = run({"tool_name": tool, "tool_input": {}})
+    assert r.returncode == 0, f"{tool}: expected exit 0, got {r.returncode}"
+    assert r.stdout.strip() == "", f"{tool}: expected no output, got {r.stdout!r}"
+    assert decision(r.stdout) is None, f"{tool}: must not emit a permission decision"
+
+# 3) Missing tool_name key -> treated as any-other-tool (allow), not a crash.
+r = run({"tool_input": {}})
+assert r.returncode == 0 and r.stdout.strip() == "", f"missing tool_name should allow: {r.stdout!r}"
+
+# 4) Malformed stdin -> fail-OPEN: exit 0, no deny (a crashing hook must never
+#    wedge the core by blocking every tool call).
+r = run("this is not json")
+assert r.returncode == 0, f"malformed stdin must fail-open (exit 0), got {r.returncode}"
+assert decision(r.stdout) is None, "malformed stdin must not produce a deny"
+
+print("PASS: skip-ask-user-question — denies AskUserQuestion, allows all else, fails open")


### PR DESCRIPTION
## Problem

The core agent runs **non-interactively** — `src/agent/claude/cli/start-cli.sh` launches `claude` with `--dangerously-skip-permissions` inside a tmux pane, driven over `--remote-control`, with no human at the terminal. When the model calls the built-in **`AskUserQuestion`** tool there, no UI ever renders to answer it, so the tool **blocks the session indefinitely**.

Observed in the obs collector:

```json
{ "kind": "tool.call", "outcome": "ok",
  "data": { "permission_mode": "bypassPermissions", "tool_name": "AskUserQuestion", ... } }
```

…a `tool.call` that never returns — the core wedges until it's killed.

## Fix

Add a `PreToolUse` hook that **denies** `AskUserQuestion`. A PreToolUse `deny` short-circuits the call *before it can render* and feeds the reason back to the model, which then proceeds on its own judgement instead of hanging. The hook is a no-op (exit 0) for every other tool and **fails open** on any error, so it can never wedge the core.

- **`hooks/skip-ask-user-question.py`** *(new)* — the standalone PreToolUse deny hook.
- **`src/agent/claude/cli/build-core-settings.mjs`** *(new)* — composes the core `--settings` JSON: always includes the guard, and array-concat-merges the obs collector hooks in when capture is enabled (a single `--settings` flag carries both — multiple flags are undocumented / last-wins). The obs event map stays owned solely by `build-hook-settings.mjs`; this composer treats it as an opaque blob so the two never drift.
- **`src/agent/claude/cli/start-cli.sh`** — the old obs-only `--settings` block now **always** registers the guard (obs remains gated on `$SUTANDO_OBS_ENDPOINT`).
- **`hooks/README.md`** — documents the hook.

It's **auto-registered on every core launch** — no per-node deploy step (unlike `context-source-guard.py`).

## Tests

- `tests/skip-ask-user-question.test.py` — drives the real hook via stdin: `AskUserQuestion`→deny, all other tools→allow, malformed input→fail-open.
- `tests/agent/claude/cli/build-core-settings.test.ts` — guard-always, obs-merge (concat, no drop), adversarial path quoting, error exits.
- The untouched `build-hook-settings.test.ts` still passes (obs builder unchanged).

```
# tests 17  # pass 17  # fail 0   (+ the python hook test: PASS)
```

## Notes / limitations

- Registration requires `node` (already true for the obs path). If `node` is absent the launcher warns loudly and the guard is skipped — no python fallback was added to avoid over-engineering.
- Single concern: the headless-core `AskUserQuestion` hang. No unrelated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
