### PR TITLE
fix(web-client): sticky header keeps End Voice button visible on scroll

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -49,6 +49,7 @@ const HTML = /* html */ `<!DOCTYPE html>
     width: 100%; padding: 16px 20px;
     display: flex; align-items: center; gap: 14px;
     background: #0e0e18; border-bottom: 1px solid #1a1a2e;
+    position: sticky; top: 0; z-index: 10;
   }
   .header .avatar-wrap {
     position: relative; width: 60px; height: 60px; flex-shrink: 0;


### PR DESCRIPTION
## Summary

- When `#dynamic-region` content (tasks list, DR tabs) is tall, the page body exceeds the viewport and becomes scrollable
- `.header` had no `position` set, so it scrolled off the top — taking the End Voice, Mute, and Watch buttons with it
- Fix: `position: sticky; top: 0; z-index: 10` on `.header` — one line, keeps the header pinned at the viewport top

## Root cause

The `#dynamic-region` has no `max-height` constraint. With many expanded tasks, it can easily be 400–600px tall. Combined with a 768px viewport, the body overflows and becomes scrollable. The header (a flex child of `<body>`) is `position: static` by default and scrolls with the page.

Same `z-index: 10` as the fixed `#bottom-panel` to prevent z-fighting.

## Test plan

- [ ] Start voice session, expand several tasks in the DR panel, scroll down — header stays pinned at the top
- [ ] End Voice / Mute buttons remain clickable while scrolled
- [ ] No visual regression on page load or when voice is inactive

Fixes #2013

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUA5TZgDa7VmFcNtPka38t