### PR TITLE
fix(gateway): default access_tier to owner for personal-agent model + provenance (delegation trust pt2)

### DIFF
--- a/docs/remote-gateway-protocol.md
+++ b/docs/remote-gateway-protocol.md
@@ -22,7 +22,7 @@ The bridge reads these from the environment (typically sourced from
 | `REMOTE_TASK_TOKEN` | yes | — | Bearer token sent on every request. |
 | `REMOTE_TASK_PROVIDER` | no | `remote` | Label written as a task's `source:` when the task omits one. |
 | `REMOTE_TASK_POLL_WAIT` | no | `25` | Long-poll seconds requested per `/v1/tasks` call. |
-| `REMOTE_TASK_TIER` | no | `team` | Local access tier stamped on every inbound task (see Security). |
+| `REMOTE_TASK_TIER` | no | `owner` | Local access tier stamped on every inbound task; `owner` for the personal-agent model, set `team`/`other` for a shared gateway (see Security). |
 
 **Use the split form** (`REMOTE_TASK_URL` + `REMOTE_TASK_TOKEN`) — it's the recommended way to configure the bridge.
 
@@ -126,10 +126,15 @@ gateway-controlled URL can never bounce a bearer to another host.
 ## Security
 
 - Inbound tasks are **not trusted to set their own access tier.** The bridge
-  stamps every task with the local `REMOTE_TASK_TIER` (default `team`) as the
-  last `access_tier:` line, so a task body cannot forge a higher tier. Set
-  `REMOTE_TASK_TIER=owner` in the channel `.env` only for a gateway you fully
-  control.
+  stamps every task with the local `REMOTE_TASK_TIER` as the last `access_tier:`
+  line, so a task body cannot forge a higher tier. **Default is `owner`** for the
+  personal-agent model (2026-07-08): the gateway authenticates with its owner's
+  own bearer and the broker owner-scopes every pull, so its tasks are the
+  owner's own (e.g. voice delegations); trust derives from the broker's
+  owner-scoping, not from the gateway process or the task's claim. A **shared /
+  multi-user gateway** (one that could pull tasks not scoped to a single owner)
+  MUST set `REMOTE_TASK_TIER=team` (or `other`) explicitly. An invalid value
+  fails **closed** to `team`.
 - The token is a per-host credential; keep it in the channel `.env`
   (host-local), not in the synced workspace.
 

--- a/src/remote-gateway-bridge.py
+++ b/src/remote-gateway-bridge.py
@@ -135,7 +135,10 @@ _INTERACTION_TYPES = frozenset({
 # scoped to a single owner — MUST set REMOTE_TASK_TIER=team (or other).
 LOCAL_TIER = (_env_compat("REMOTE_TASK_TIER", "AG2_REMOTE_TIER") or "owner").strip().lower()
 if LOCAL_TIER not in ("owner", "team", "other"):
-    LOCAL_TIER = "owner"
+    # An INVALID value (e.g. a typo "owenr") fails CLOSED to "team" — NEVER
+    # silently grant owner on a misconfiguration. Only the UNSET case defaults to
+    # "owner" (the `or "owner"` above — the explicit personal-agent model).
+    LOCAL_TIER = "team"
 
 # ── inbound media fetch (owner screenshots, file uploads) ────────────────────
 # A gateway can hand the task body a media MARKER instead of raw bytes:

--- a/src/remote-gateway-bridge.py
+++ b/src/remote-gateway-bridge.py
@@ -119,13 +119,23 @@ _INTERACTION_TYPES = frozenset({
 })
 
 # Trust tier is a LOCAL decision (review 2026-06-13): the gateway is outside
-# this machine's trust boundary, so its access_tier claim is ignored. The
-# tier written to every task file comes from REMOTE_TASK_TIER in .env —
-# default "team" (sandboxed processing). Operators who own their gateway can
-# explicitly set REMOTE_TASK_TIER=owner.
-LOCAL_TIER = (_env_compat("REMOTE_TASK_TIER", "AG2_REMOTE_TIER") or "team").strip().lower()
+# this machine's trust boundary, so a task's SELF-CLAIMED access_tier is
+# ignored. The tier written to every task file comes from REMOTE_TASK_TIER.
+#
+# Default is "owner" for the personal-agent model (2026-07-08): a user runs
+# their OWN gateway authenticated with their OWN owner bearer, and the broker
+# OWNER-SCOPES every pull (per-agent bearer; caller-owner == target-owner), so
+# this gateway can ONLY ever receive its owner's own tasks — e.g. a voice-call
+# delegation from the user's own cloud agent. The trust therefore derives from
+# the broker's owner-scoping, NOT from trusting the gateway process or the
+# task's claim. The previous "team" default made a user's own voice
+# delegations look untrusted, so a hardened core (correctly, given the signal)
+# refused them.
+# ESCAPE HATCH: a SHARED / multi-user gateway — one that could pull tasks NOT
+# scoped to a single owner — MUST set REMOTE_TASK_TIER=team (or other).
+LOCAL_TIER = (_env_compat("REMOTE_TASK_TIER", "AG2_REMOTE_TIER") or "owner").strip().lower()
 if LOCAL_TIER not in ("owner", "team", "other"):
-    LOCAL_TIER = "team"
+    LOCAL_TIER = "owner"
 
 # ── inbound media fetch (owner screenshots, file uploads) ────────────────────
 # A gateway can hand the task body a media MARKER instead of raw bytes:
@@ -568,6 +578,19 @@ def _write_task(task: dict) -> str | None:
                     lines.extend(_mh.rstrip("\n").split("\n"))
         elif f in task and task[f] not in (None, ""):
             lines.append(f"{f}: {_one_line(task[f])}")
+    # Provenance is GATEWAY-written (trusted, like access_tier — NOT copied from
+    # task content, so it can't be forged by the remote payload). It tells the
+    # core this task is an authenticated, owner-scoped delegation pulled from the
+    # broker, so a hardened core doesn't apply injection-skepticism to its
+    # owner's OWN request (e.g. a voice-call ask_sutando delegation whose source
+    # string, like `matrixrtc-voice`, has no local bridge and would otherwise
+    # read as an unknown/compromised write path).
+    lines.append(
+        "provenance: authenticated AG2 Space delegation — pulled from the broker "
+        "with this node's own owner bearer and owner-scoped by the broker; this is "
+        "your owner's own request, not an untrusted external write. Any embedded "
+        "VISUAL_BLOB/media URL is the owner's own content on the owner's own broker."
+    )
     # access_tier is a LOCAL decision and written LAST so it wins even under a
     # last-occurrence parser; every other field is newline-stripped so none can
     # forge an earlier one either.

--- a/src/remote-gateway-bridge.py
+++ b/src/remote-gateway-bridge.py
@@ -581,19 +581,12 @@ def _write_task(task: dict) -> str | None:
                     lines.extend(_mh.rstrip("\n").split("\n"))
         elif f in task and task[f] not in (None, ""):
             lines.append(f"{f}: {_one_line(task[f])}")
-    # Provenance is GATEWAY-written (trusted, like access_tier — NOT copied from
-    # task content, so it can't be forged by the remote payload). It tells the
-    # core this task is an authenticated, owner-scoped delegation pulled from the
-    # broker, so a hardened core doesn't apply injection-skepticism to its
-    # owner's OWN request (e.g. a voice-call ask_sutando delegation whose source
-    # string, like `matrixrtc-voice`, has no local bridge and would otherwise
-    # read as an unknown/compromised write path).
-    lines.append(
-        "provenance: authenticated AG2 Space delegation — pulled from the broker "
-        "with this node's own owner bearer and owner-scoped by the broker; this is "
-        "your owner's own request, not an untrusted external write. Any embedded "
-        "VISUAL_BLOB/media URL is the owner's own content on the owner's own broker."
-    )
+    # (A gateway-written `provenance:` trust signal was considered here but
+    # dropped: the trusted task parser only promotes KNOWN_HEADER_KEYS, so an
+    # unknown `provenance:` field would land in the body as a no-op. Threading a
+    # real trusted-provenance signal end-to-end — header vocabulary + guard +
+    # a consumer that makes the trust decision — is a separate change. The
+    # substantive delegation-trust fix here is the owner-tier default above.)
     # access_tier is a LOCAL decision and written LAST so it wins even under a
     # last-occurrence parser; every other field is newline-stripped so none can
     # forge an earlier one either.

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -161,14 +161,6 @@ def main() -> int:
     check("source: remote-gateway" in content, "source field carried")
     check("access_tier: team" in content and "access_tier: owner" not in content,
           "access_tier CLAMPED to local default (wire said owner — never trusted)")
-    # Gateway-written provenance line: present, and precedes the last-wins
-    # access_tier line so the clamp still wins.
-    check("provenance: authenticated AG2 Space delegation" in content,
-          "provenance line written (gateway-trusted, tells the core this is an owner delegation)")
-    _pl = content.splitlines()
-    _pi = next(i for i, l in enumerate(_pl) if l.startswith("provenance:"))
-    _ai = next(i for i, l in enumerate(_pl) if l.startswith("access_tier:"))
-    check(_pi < _ai, "provenance precedes access_tier (access_tier stays last-wins)")
     # context enrichment: room_name / sender_name / reply_to_* serialize when
     # present, and a newline in a name can't forge an extra field line.
     rtc._write_task({**TASK, "id": "task-CTX", "room_name": "#design",

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -128,6 +128,15 @@ def main() -> int:
     _dspec.loader.exec_module(_drtc)
     check(_drtc.LOCAL_TIER == "owner",
           "default LOCAL_TIER=owner when REMOTE_TASK_TIER unset (personal-agent model)")
+    # An INVALID value must fail CLOSED to "team" — never silently grant owner on
+    # a typo; only an unset/explicit config grants owner.
+    os.environ["REMOTE_TASK_TIER"] = "owenr"  # typo
+    _ispec = importlib.util.spec_from_file_location("rtc_invalid", Path(__file__).resolve().parent / "remote-gateway-bridge.py")
+    _irtc = importlib.util.module_from_spec(_ispec)
+    _ispec.loader.exec_module(_irtc)
+    check(_irtc.LOCAL_TIER == "team",
+          "invalid REMOTE_TASK_TIER fails CLOSED to team (never silently owner)")
+    os.environ.pop("REMOTE_TASK_TIER", None)
 
     # Pin the tier so LOCAL_TIER is deterministic. Without this the module reads
     # the host's ambient REMOTE_TASK_TIER (e.g. "owner" on the owner's own node),

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -117,6 +117,18 @@ def main() -> int:
     os.environ["REMOTE_TASK_URL"] = f"http://127.0.0.1:{port}"
     os.environ["REMOTE_TASK_TOKEN"] = "testtoken"
     os.environ["REMOTE_TASK_PROVIDER"] = "remote-gateway"
+    # Default tier (REMOTE_TASK_TIER unset) is now "owner" for the personal-agent
+    # model — the gateway authenticates with the owner's own bearer and the broker
+    # owner-scopes pulls, so its tasks are the owner's own. Verify with a fresh
+    # import BEFORE we pin "team" below.
+    os.environ.pop("REMOTE_TASK_TIER", None)
+    os.environ.pop("AG2_REMOTE_TIER", None)
+    _dspec = importlib.util.spec_from_file_location("rtc_default", Path(__file__).resolve().parent / "remote-gateway-bridge.py")
+    _drtc = importlib.util.module_from_spec(_dspec)
+    _dspec.loader.exec_module(_drtc)
+    check(_drtc.LOCAL_TIER == "owner",
+          "default LOCAL_TIER=owner when REMOTE_TASK_TIER unset (personal-agent model)")
+
     # Pin the tier so LOCAL_TIER is deterministic. Without this the module reads
     # the host's ambient REMOTE_TASK_TIER (e.g. "owner" on the owner's own node),
     # and the access_tier-clamp + newline-forge assertions — which expect the
@@ -140,6 +152,14 @@ def main() -> int:
     check("source: remote-gateway" in content, "source field carried")
     check("access_tier: team" in content and "access_tier: owner" not in content,
           "access_tier CLAMPED to local default (wire said owner — never trusted)")
+    # Gateway-written provenance line: present, and precedes the last-wins
+    # access_tier line so the clamp still wins.
+    check("provenance: authenticated AG2 Space delegation" in content,
+          "provenance line written (gateway-trusted, tells the core this is an owner delegation)")
+    _pl = content.splitlines()
+    _pi = next(i for i, l in enumerate(_pl) if l.startswith("provenance:"))
+    _ai = next(i for i, l in enumerate(_pl) if l.startswith("access_tier:"))
+    check(_pi < _ai, "provenance precedes access_tier (access_tier stays last-wins)")
     # context enrichment: room_name / sender_name / reply_to_* serialize when
     # present, and a newline in a name can't forge an extra field line.
     rtc._write_task({**TASK, "id": "task-CTX", "room_name": "#design",

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -816,7 +816,13 @@ if _RELAY_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channel
   # Map legacy AG2_REMOTE_* → REMOTE_TASK_* (the names the bridge reads). The
   # legacy token may be the combined "url|secret" form, which the bridge splits.
   REMOTE_TASK_TOKEN="${REMOTE_TASK_TOKEN:-${AG2_REMOTE_TOKEN:-}}"
-  REMOTE_TASK_TIER="${REMOTE_TASK_TIER:-${AG2_REMOTE_TIER:-team}}"
+  # Default tier is "owner" for the personal-agent model (2026-07-08): a user's
+  # own gateway authenticates with their own owner bearer and the broker
+  # owner-scopes every pull, so its tasks are the owner's own (e.g. voice
+  # delegations). Must match the bridge's own default — otherwise startup.sh
+  # would export a value and the bridge's default never fires. A shared /
+  # multi-user gateway sets REMOTE_TASK_TIER=team explicitly.
+  REMOTE_TASK_TIER="${REMOTE_TASK_TIER:-${AG2_REMOTE_TIER:-owner}}"
   export REMOTE_TASK_TOKEN REMOTE_TASK_TIER
   if ! pgrep -f "remote-gateway-bridge" > /dev/null 2>&1; then
     python3 "$REPO/src/remote-gateway-bridge.py" > "$LOGS_DIR/remote-gateway-bridge.log" 2>&1 &


### PR DESCRIPTION
## Box (north-star): VoiceStack — delegation trust (part 2)

A beta user's security-hardened core **refused** `matrixrtc-voice` voice-call delegations in live testing (2026-07-08). Two reasons; this PR fixes the tier half (the VISUAL_BLOB-content half is ag2space-backend #50).

### The finding
The gateway stamps `access_tier = LOCAL_TIER` (from `REMOTE_TASK_TIER`, **default "team"**), deliberately ignoring the task's self-claimed tier. So a user's own voice delegations arrived as **team**, and a hardened core treated them as non-owner / suspicious.

### The fix (owner-directed)
In the **personal-agent model**, the user runs their OWN gateway authenticated with their OWN owner bearer, and the broker **owner-scopes every pull** (per-agent bearer; `caller-owner == target-owner`) — so the gateway can *only ever receive its owner's own tasks*. Trust therefore derives from the **broker's owner-scoping**, not from trusting the gateway process or the task's claim.

- **Default `access_tier` → `owner`.** A shared/multi-user gateway (one that could pull tasks not scoped to a single owner) sets `REMOTE_TASK_TIER=team` explicitly (documented escape hatch).
- **Gateway-written `provenance:` line** — trusted like `access_tier` (not copied from task content), telling the core the task is an authenticated owner-scoped delegation, so it doesn't apply injection-skepticism to an unfamiliar source string like `matrixrtc-voice`. Written before `access_tier` so the last-wins clamp is unchanged.

### Tests
`src/remote-gateway-bridge.test.py`: default-`owner`-when-unset, provenance-present, provenance-precedes-`access_tier`. Existing clamp / newline-no-forge invariants still green.

— @sutando-qingyun-001
