### PR TITLE
feat(voice): transparent tier-resolution module (happy-path pt1)

### DIFF
--- a/src/voice-connect-resolver.ts
+++ b/src/voice-connect-resolver.ts
@@ -9,9 +9,9 @@
  * picks a tier" behaviour: the app resolves the best available path invisibly
  * and only the latency/capability differs — never the agent's behaviour.
  *
- * Framework-agnostic (no DOM/React deps): the reachability probe is INJECTED
- * (`opts.probe`), so the SAME resolver is used by the Sutando webUI and the
- * AG2Space (Cinny) wrapper — one shared source, no drift. In the browser the
+ * Framework-agnostic (no DOM/framework deps): the reachability probe is INJECTED
+ * (`opts.probe`), so the SAME resolver can back multiple embedding surfaces
+ * (the webUI and any host-app wrapper) — one shared source, no drift. In the browser the
  * probe opens a short-lived WebSocket; opening `ws://localhost` from a public
  * HTTPS page triggers the one-time Local Network Access permission (Chrome
  * 147+), and a denied/failed probe is simply treated as "not reachable" so the
@@ -54,7 +54,14 @@ export async function resolveVoiceEndpoint(
 		} catch {
 			ok = false;
 		}
-		opts.onAttempt?.(ep, ok);
+		// onAttempt is a status-UI/telemetry hook — keep it strictly best-effort.
+		// A throwing callback must NOT abort resolution, or a harmless progress
+		// handler could prevent fall-through to relay/cloud.
+		try {
+			opts.onAttempt?.(ep, ok);
+		} catch {
+			/* telemetry failure is non-fatal — continue the ladder */
+		}
 		if (ok) return ep;
 	}
 	return null;

--- a/src/voice-connect-resolver.ts
+++ b/src/voice-connect-resolver.ts
@@ -1,0 +1,92 @@
+/**
+ * Transparent voice-connection tier resolution — picks the best reachable
+ * endpoint for "call your agent" so the user never chooses a tier.
+ *
+ * The candidate order encodes the tier ladder, best/fastest first:
+ *   local core on this machine (Tier 0) → same-LAN core (Tier 0-LAN) →
+ *   relay to the core (Tier 2b) → cloud daemon (Tier 1, always-available).
+ * Each is PROBED in order; the first reachable wins. This is the "user never
+ * picks a tier" behaviour: the app resolves the best available path invisibly
+ * and only the latency/capability differs — never the agent's behaviour.
+ *
+ * Framework-agnostic (no DOM/React deps): the reachability probe is INJECTED
+ * (`opts.probe`), so the SAME resolver is used by the Sutando webUI and the
+ * AG2Space (Cinny) wrapper — one shared source, no drift. In the browser the
+ * probe opens a short-lived WebSocket; opening `ws://localhost` from a public
+ * HTTPS page triggers the one-time Local Network Access permission (Chrome
+ * 147+), and a denied/failed probe is simply treated as "not reachable" so the
+ * resolver falls through to the next tier.
+ */
+
+export type VoiceTier = 'local' | 'lan' | 'relay' | 'cloud';
+
+export interface VoiceEndpoint {
+	tier: VoiceTier;
+	/** WebSocket URL to connect the bodhi voice client to. */
+	url: string;
+	/** Human label for status/telemetry (e.g. "this machine (Tier 0)"). */
+	label: string;
+}
+
+export interface ResolveOptions {
+	/** Probe an endpoint: resolve true if reachable, false/throw otherwise.
+	 *  Injected so the resolver stays DOM-free — the browser passes a WS probe. */
+	probe: (url: string) => Promise<boolean>;
+	/** Per-probe timeout in ms (default 2500). A slow probe counts as unreachable. */
+	timeoutMs?: number;
+	/** Optional per-attempt callback for status UI / telemetry. */
+	onAttempt?: (ep: VoiceEndpoint, ok: boolean) => void;
+}
+
+/**
+ * Probe candidates in ladder order; return the first reachable, or null if none
+ * are. A probe that throws or times out counts as unreachable (fall through).
+ */
+export async function resolveVoiceEndpoint(
+	candidates: VoiceEndpoint[],
+	opts: ResolveOptions,
+): Promise<VoiceEndpoint | null> {
+	const timeoutMs = opts.timeoutMs ?? 2500;
+	for (const ep of candidates) {
+		let ok = false;
+		try {
+			ok = await withTimeout(opts.probe(ep.url), timeoutMs);
+		} catch {
+			ok = false;
+		}
+		opts.onAttempt?.(ep, ok);
+		if (ok) return ep;
+	}
+	return null;
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const t = setTimeout(() => reject(new Error('probe timeout')), ms);
+		p.then(
+			(v) => { clearTimeout(t); resolve(v); },
+			(e) => { clearTimeout(t); reject(e); },
+		);
+	});
+}
+
+/**
+ * Build the default candidate ladder for a user's own core. Any field omitted
+ * is skipped (e.g. no LAN host known → no LAN candidate). `local` is always
+ * first (best) and `cloud` last (the always-available fallback).
+ */
+export function defaultCandidates(opts: {
+	localPort?: number;     // default 9900 (the local voice-agent WS port)
+	lanHost?: string;       // e.g. "192.168.1.20" — same-wifi core
+	relayWsUrl?: string;    // wss://relay/.../<agent> — Tier 2b bridge to the core
+	cloudUrl?: string;      // the Tier-1 cloud fallback
+}): VoiceEndpoint[] {
+	const port = opts.localPort ?? 9900;
+	const out: VoiceEndpoint[] = [
+		{ tier: 'local', url: `ws://localhost:${port}`, label: 'this machine (Tier 0)' },
+	];
+	if (opts.lanHost) out.push({ tier: 'lan', url: `ws://${opts.lanHost}:${port}`, label: 'same network (Tier 0-LAN)' });
+	if (opts.relayWsUrl) out.push({ tier: 'relay', url: opts.relayWsUrl, label: 'relay to your core (Tier 2b)' });
+	if (opts.cloudUrl) out.push({ tier: 'cloud', url: opts.cloudUrl, label: 'cloud agent (Tier 1)' });
+	return out;
+}

--- a/tests/voice-connect-resolver.test.ts
+++ b/tests/voice-connect-resolver.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveVoiceEndpoint, defaultCandidates } from '../src/voice-connect-resolver.js';
+
+describe('voice-connect-resolver', () => {
+	it('defaultCandidates: local first, cloud last, omits unknowns', () => {
+		const full = defaultCandidates({ lanHost: '192.168.1.5', relayWsUrl: 'wss://r', cloudUrl: 'wss://c' });
+		assert.deepEqual(full.map((x) => x.tier), ['local', 'lan', 'relay', 'cloud']);
+		assert.ok(full[0].url.includes('localhost:9900'));
+		const minimal = defaultCandidates({});
+		assert.deepEqual(minimal.map((x) => x.tier), ['local']); // only local when nothing else known
+	});
+
+	it('returns the first reachable in ladder order (local down → relay up)', async () => {
+		const cands = defaultCandidates({ relayWsUrl: 'wss://relay/x', cloudUrl: 'wss://cloud/x' });
+		const seen: string[] = [];
+		const ep = await resolveVoiceEndpoint(cands, {
+			probe: async (url) => { seen.push(url); return url.includes('relay'); },
+		});
+		assert.equal(ep?.tier, 'relay');
+		assert.ok(seen[0].includes('localhost'), 'probes local first (order preserved)');
+	});
+
+	it('picks local (Tier 0) when reachable — best wins', async () => {
+		const ep = await resolveVoiceEndpoint(defaultCandidates({ cloudUrl: 'wss://c' }), {
+			probe: async () => true, // everything reachable → first (local) wins
+		});
+		assert.equal(ep?.tier, 'local');
+	});
+
+	it('null when nothing is reachable', async () => {
+		const ep = await resolveVoiceEndpoint(defaultCandidates({ cloudUrl: 'wss://c' }), { probe: async () => false });
+		assert.equal(ep, null);
+	});
+
+	it('a throwing probe (e.g. LNA denied) counts as unreachable → falls through', async () => {
+		const cands = defaultCandidates({ cloudUrl: 'wss://cloud/x' });
+		const ep = await resolveVoiceEndpoint(cands, {
+			probe: async (url) => { if (url.includes('localhost')) throw new Error('LNA denied'); return true; },
+		});
+		assert.equal(ep?.tier, 'cloud'); // local threw → fell through to cloud
+	});
+
+	it('a slow probe times out → unreachable → falls through', async () => {
+		const cands = defaultCandidates({ cloudUrl: 'wss://cloud/x' });
+		const ep = await resolveVoiceEndpoint(cands, {
+			timeoutMs: 30,
+			probe: async (url) => {
+				if (url.includes('localhost')) { await new Promise((r) => setTimeout(r, 200)); return true; }
+				return true;
+			},
+		});
+		assert.equal(ep?.tier, 'cloud'); // local exceeded 30ms → treated unreachable
+	});
+
+	it('onAttempt fires per candidate with the outcome', async () => {
+		const attempts: Array<[string, boolean]> = [];
+		await resolveVoiceEndpoint(defaultCandidates({ cloudUrl: 'wss://cloud/x' }), {
+			probe: async (url) => url.includes('cloud'),
+			onAttempt: (ep, ok) => attempts.push([ep.tier, ok]),
+		});
+		assert.deepEqual(attempts, [['local', false], ['cloud', true]]);
+	});
+});

--- a/tests/voice-connect-resolver.test.ts
+++ b/tests/voice-connect-resolver.test.ts
@@ -61,4 +61,16 @@ describe('voice-connect-resolver', () => {
 		});
 		assert.deepEqual(attempts, [['local', false], ['cloud', true]]);
 	});
+
+	it('a throwing onAttempt is best-effort — resolution still falls through', async () => {
+		// local down, cloud reachable. A telemetry hook that throws on the first
+		// (failed) attempt must NOT abort the ladder — we still reach cloud.
+		const ep = await resolveVoiceEndpoint(defaultCandidates({ cloudUrl: 'wss://cloud/x' }), {
+			probe: async (url) => url.includes('cloud'),
+			onAttempt: () => {
+				throw new Error('telemetry failed');
+			},
+		});
+		assert.equal(ep?.tier, 'cloud', 'throwing onAttempt did not prevent fall-through');
+	});
 });


### PR DESCRIPTION
## Box (north-star): VoiceStack — transport happy-path (Tier 2b), piece 1

The transparent **tier-resolution** logic — the "user never picks a tier" behaviour. On "call your agent," the app probes candidate endpoints in ladder order and connects to the first reachable:

`local core on this machine (Tier 0)` → `same-LAN core (Tier 0-LAN)` → `relay to the core (Tier 2b)` → `cloud daemon (Tier 1, always-available)`

Only latency/capability differs across tiers — never the agent's behaviour (the invariant).

### Why a standalone module
Framework-agnostic (no DOM/framework deps): the reachability probe is **injected**, so the SAME resolver can back multiple embedding surfaces — one shared source, no per-surface drift (mirroring the runtime invariant). In the browser the probe opens a short-lived WebSocket; opening `ws://localhost` from a public HTTPS page triggers the Chrome 147+ Local Network Access permission — a denied/failed/timed-out probe simply counts as unreachable and the resolver falls through.

### Scope
Just the resolver + 7 unit tests (ladder order, first-reachable, none-reachable, throw/timeout fall-through, onAttempt). The shared client-module extraction (voice transport core) and the host-app wrapper come next. Spike already confirmed in-app Tier 0 is feasible (one-time LNA permission).

— @sutando-qingyun-001
