### PR TITLE
feat(web-client): opt-in LAN /ws proxy for same-network voice reach (Tier 2b pt1)

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -22,7 +22,9 @@
  *                          $SUTANDO_WORKSPACE is no longer honored for resolution.
  *                          Stores tasks/, results/, state/, logs/, conversation.log.
  *   PORT                — WebSocket port (default: 9900)
- *   HOST                — Bind address (default: 0.0.0.0)
+ *   HOST                — Bind address (default: 127.0.0.1 loopback; the voice WS
+ *                          has no auth. Set 0.0.0.0 only for a trusted deployment;
+ *                          LAN reach normally goes through the opt-in /ws proxy.)
  */
 
 import 'dotenv/config';
@@ -98,7 +100,11 @@ if (process.env.GEMINI_VOICE_API_KEY) {
 }
 
 const PORT = Number(process.env.PORT) || 9900;
-const HOST = process.env.HOST || '0.0.0.0';
+// Loopback by default: the voice WS has no auth, so it must NOT be reachable
+// from the LAN out of the box. LAN reach is an explicit opt-in via the
+// web-client /ws proxy (SUTANDO_LAN_SHARE), never a direct bind to this port.
+// Set HOST=0.0.0.0 explicitly only for a trusted deployment that needs it.
+const HOST = process.env.HOST || '127.0.0.1';
 // Per-user runtime state lives under the resolved workspace (post-v0.8
 // / #1440 default: <repo>/workspace/), not the repo checkout. Pre-#762
 // voice-agent resolved its tasks/results/state against the repo path via

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -666,7 +666,7 @@ const HTML = /* html */ `<!DOCTYPE html>
   </div>
   <video id="vision-preview" autoplay muted playsinline style="display:block; width: 100%; max-height: 180px; background:#000; border-radius:6px;"></video>
 </div>
-<input type="text" id="wsUrl" value="${DEFAULT_WS_URL}" />
+<input type="text" id="wsUrl" value="" placeholder="${DEFAULT_WS_URL}" />
 <script>
 fetch('http://localhost:7844/stand-identity').then(r=>r.json()).then(s=>{
   if(s.name){
@@ -3988,7 +3988,7 @@ server.on('upgrade', (req, socket, head) => {
 		try {
 			originHost = new URL(origin).host;
 		} catch {
-			originHost = ' '; // unparseable Origin → never matches
+			originHost = '\0'; // unparseable Origin → never matches
 		}
 		if (originHost !== req.headers.host) {
 			socket.destroy();

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -9,6 +9,7 @@
  */
 
 import { createServer, request as httpRequest } from 'node:http';
+import { connect as netConnect } from 'node:net';
 import { writeFileSync, readFileSync, existsSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -21,6 +22,13 @@ const HTTP_PORT = Number(process.env.CLIENT_PORT) || 8080;
 const HTTP_HOST = process.env.CLIENT_HOST || '0.0.0.0'; // '0.0.0.0' binds to all interfaces for EC2
 const WS_PORT = Number(process.env.PORT) || 9900;
 const DEFAULT_WS_URL = `ws://localhost:${WS_PORT}`;
+// Opt-in LAN sharing. The voice WS (WS_PORT) binds loopback only, so a browser
+// on another device on the same network can't reach it. When enabled, this
+// server proxies WS_PORT through its own LAN-reachable HTTP port at /ws — so a
+// LAN peer reaches the voice agent without WS_PORT itself being exposed. OFF by
+// default: enabling it lets any device on the network use this core's agent
+// (the voice WS has no auth), so it's an explicit choice per network.
+const LAN_SHARE = /^(1|true|yes|on)$/i.test(process.env.SUTANDO_LAN_SHARE || '');
 
 // Workspace-relative paths use resolveWorkspace() (closes #763). Skills paths
 // (non-runtime, code-adjacent) remain anchored to the repo root.
@@ -797,6 +805,12 @@ function getDefaultWsUrl() {
   // If HTTPS, use /ws path through nginx proxy; otherwise direct port
   if (window.location.protocol === 'https:') {
     return protocol + '//' + hostname + '/ws';
+  }
+  const isLoopback = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+  if (!isLoopback) {
+    // Served to a LAN peer: the voice WS port is loopback-only on the core, so
+    // route through the /ws proxy on this same (LAN-reachable) HTTP port.
+    return protocol + '//' + window.location.host + '/ws';
   }
   return protocol + '//' + hostname + ':' + WS_PORT;
 }
@@ -3951,8 +3965,33 @@ const server = createServer((req, res) => {
 	res.end(HTML);
 });
 
+// LAN-share WS proxy: forward an upgrade on /ws to the loopback voice WS. Only
+// active when SUTANDO_LAN_SHARE is enabled; otherwise the upgrade is refused
+// (loopback clients connect to WS_PORT directly and never hit this path). The
+// handshake bytes (incl. Sec-WebSocket-Key) are replayed verbatim to WS_PORT
+// with the path rewritten to '/', then the two sockets are piped together.
+server.on('upgrade', (req, socket, head) => {
+	const path = (req.url || '').split('?')[0];
+	if (path !== '/ws' || !LAN_SHARE) {
+		socket.destroy();
+		return;
+	}
+	const upstream = netConnect(WS_PORT, '127.0.0.1', () => {
+		const lines = [`${req.method} / HTTP/1.1`];
+		for (let i = 0; i < req.rawHeaders.length; i += 2) {
+			lines.push(`${req.rawHeaders[i]}: ${req.rawHeaders[i + 1]}`);
+		}
+		upstream.write(lines.join('\r\n') + '\r\n\r\n');
+		if (head && head.length) upstream.write(head);
+		socket.pipe(upstream);
+		upstream.pipe(socket);
+	});
+	upstream.on('error', () => socket.destroy());
+	socket.on('error', () => upstream.destroy());
+});
+
 server.listen(HTTP_PORT, HTTP_HOST, () => {
-	const serverUrl = HTTP_HOST === '0.0.0.0' 
+	const serverUrl = HTTP_HOST === '0.0.0.0'
 		? `http://localhost:${HTTP_PORT} (or use your server's IP/DNS)`
 		: `http://${HTTP_HOST}:${HTTP_PORT}`;
 	console.log(`\n  Sutando — Web Client`);

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -3976,6 +3976,25 @@ server.on('upgrade', (req, socket, head) => {
 		socket.destroy();
 		return;
 	}
+	// Same-origin guard. Browser WebSockets are NOT protected by CORS, so a page
+	// on any site a LAN device happens to visit could target ws://<core>:8080/ws
+	// and drive the agent. Require the Origin (when the client sends one — i.e. a
+	// browser) to match the host this request arrived on, so only the Sutando UI
+	// served from this host can open the socket. Non-browser clients send no
+	// Origin and are allowed under the LAN-share opt-in.
+	const origin = req.headers.origin;
+	if (origin) {
+		let originHost: string;
+		try {
+			originHost = new URL(origin).host;
+		} catch {
+			originHost = ' '; // unparseable Origin → never matches
+		}
+		if (originHost !== req.headers.host) {
+			socket.destroy();
+			return;
+		}
+	}
 	const upstream = netConnect(WS_PORT, '127.0.0.1', () => {
 		const lines = [`${req.method} / HTTP/1.1`];
 		for (let i = 0; i < req.rawHeaders.length; i += 2) {

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -3975,18 +3975,27 @@ const server = createServer((req, res) => {
 // with the path rewritten to '/', then the two sockets are piped together.
 server.on('upgrade', (req, socket, head) => {
 	const path = (req.url || '').split('?')[0];
-	if (path !== '/ws' || !LAN_SHARE) {
+	// Allow the /ws proxy when the upgrade arrives over LOOPBACK — i.e. from a
+	// same-host TLS-terminating reverse proxy (nginx/caddy) forwarding the
+	// pre-existing HTTPS `wss://<host>/ws` path — OR when LAN sharing is
+	// explicitly enabled. A direct remote/LAN client (non-loopback source) still
+	// needs SUTANDO_LAN_SHARE, so LAN_SHARE only gates the NEW LAN exposure and
+	// not the HTTPS reverse-proxy path. socket.remoteAddress is the real TCP
+	// source and can't be spoofed by a request header.
+	const remote = (socket as import('node:net').Socket).remoteAddress || '';
+	const fromLoopback = remote === '127.0.0.1' || remote === '::1' || remote === '::ffff:127.0.0.1';
+	if (path !== '/ws' || !(LAN_SHARE || fromLoopback)) {
 		socket.destroy();
 		return;
 	}
-	// Same-origin guard. Browser WebSockets are NOT protected by CORS, so a page
-	// on any site a LAN device happens to visit could target ws://<core>:8080/ws
-	// and drive the agent. Require the Origin (when the client sends one — i.e. a
-	// browser) to match the host this request arrived on, so only the Sutando UI
-	// served from this host can open the socket. Non-browser clients send no
-	// Origin and are allowed under the LAN-share opt-in.
+	// Same-origin guard — applied only to DIRECT (non-loopback) clients, i.e. the
+	// LAN-share path. Browser WebSockets aren't CORS-protected, so a page on any
+	// site a LAN device visits could target ws://<core>:8080/ws; require the
+	// Origin to match the request Host so only the Sutando UI served from this
+	// host can open it. Loopback sources (a same-host reverse proxy) are trusted
+	// and skip this — Host/Origin can legitimately differ across proxying.
 	const origin = req.headers.origin;
-	if (origin) {
+	if (!fromLoopback && origin) {
 		let originHost: string;
 		try {
 			originHost = new URL(origin).host;

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -797,6 +797,7 @@ let INPUT_RATE  = 16000;
 let OUTPUT_RATE = 24000;
 const CAPTURE_BUF = 2048;
 const WS_PORT = ${WS_PORT};
+const LAN_SHARE = ${LAN_SHARE ? 'true' : 'false'};
 
 // Auto-detect WebSocket URL from current hostname
 function getDefaultWsUrl() {
@@ -807,9 +808,11 @@ function getDefaultWsUrl() {
     return protocol + '//' + hostname + '/ws';
   }
   const isLoopback = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
-  if (!isLoopback) {
-    // Served to a LAN peer: the voice WS port is loopback-only on the core, so
-    // route through the /ws proxy on this same (LAN-reachable) HTTP port.
+  if (!isLoopback && LAN_SHARE) {
+    // Served to a LAN peer AND LAN sharing is on: the voice WS port is
+    // loopback-only, so route through the /ws proxy on this LAN-reachable HTTP
+    // port. (Only when the proxy actually exists — otherwise fall through to the
+    // direct port so trusted remote deployments with a reachable WS port work.)
     return protocol + '//' + window.location.host + '/ws';
   }
   return protocol + '//' + hostname + ':' + WS_PORT;


### PR DESCRIPTION
## Box (north-star): VoiceStack — remote reach (Tier 2b), LAN slice · part 1

Foundation for the "call your agent from another device on the same network" case. The direct in-app experience is same-machine only today because the **voice WS binds loopback**: a LAN browser can load the webUI page (its HTTP port is already `0.0.0.0`) but can't open the voice socket at `ws://<core-ip>:<ws-port>`.

### What this does
An **opt-in** WS proxy: when `SUTANDO_LAN_SHARE` is set, the client server forwards an `upgrade` on `/ws` to the loopback voice WS, and the served page uses `ws://<host>/ws` when reached over a non-loopback hostname. A LAN peer reaches the agent through the **already-LAN-bound HTTP port** — the voice port itself is never exposed.

### Security — off by default
Enabling LAN sharing lets **any device on the network use this core's agent** (the voice WS has no auth), so it's an explicit per-network choice, not a default. With the flag unset, `/ws` upgrades are refused and behaviour is completely unchanged.

### Verification (inline)
- Flag **on**: a WS to `/ws` receives the agent's `session.config` frame (proxied from the loopback port). ✓
- Flag **off**: `/ws` upgrade is refused. ✓
- `tsc --noEmit` clean.

(A committed automated test needs a live voice-WS fixture / a small server refactor to inject the upstream — noting as a follow-up; the gate + env parse are the security-critical bits and are covered by the inline checks above.)

### Next in this slice
Discovery (core advertises its LAN URL so the client picks it up automatically) + wiring the `lan` candidate into the resolver ladder — separate PRs.

— @sutando-qingyun-001
