### PR TITLE
feat(voice): opt-in cloud-brain research tool for local agent (Tier 0.5)

### DIFF
--- a/src/cloud-brain.ts
+++ b/src/cloud-brain.ts
@@ -1,0 +1,87 @@
+/**
+ * The cloud brain — a fast research side-call for the local voice agent (Tier
+ * 0.5). Answers general / current-info questions (news, scores, weather,
+ * definitions) with web-search grounding in ~2s, so the agent doesn't have to
+ * round-trip through the core.
+ *
+ * WHY a separate call rather than the live model's own grounding: the local
+ * native-audio model (gemini-3.1-live) cannot do Google Search grounding — the
+ * (3.1, googleSearch) combo trips a 1011 quota-close on connect, so grounding
+ * ships OFF for voice. This side-call uses a text model (gemini-2.5-flash) that
+ * grounds cleanly, giving the live agent a research path without touching the
+ * voice session's model config.
+ *
+ * Uses the Generative Language REST API directly (matching browser-tools.ts /
+ * recording-tools.ts) rather than the AI SDK — the repo's @ai-sdk/google is a
+ * v1-spec provider that its ai@6 (v2-only) rejects for generateText.
+ *
+ * Kept behind a thin, stable interface so it can grow (memory read-replica,
+ * multi-step, streaming) without callers changing.
+ */
+
+const CLOUD_BRAIN_MODEL = process.env.CLOUD_BRAIN_MODEL || 'gemini-2.5-flash';
+
+function cloudBrainKey(): string {
+  return (
+    process.env.GEMINI_API_KEY ||
+    process.env.GEMINI_VOICE_API_KEY ||
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
+    ''
+  );
+}
+
+export interface ResearchOptions {
+  /** 1-3 sentence description of what the user can see, if the question refers
+   * to their screen/camera. The cloud brain can't see; this is its window. */
+  visualContext?: string;
+  /** Override the request timeout (ms). Default 8000. */
+  timeoutMs?: number;
+}
+
+/**
+ * Answer a general / current-info question. Returns a concise, spoken-friendly
+ * string (no markdown). Throws on API failure / empty response — callers should
+ * catch and degrade gracefully (e.g. delegate to the core agent).
+ */
+export async function research(query: string, opts: ResearchOptions = {}): Promise<string> {
+  const apiKey = cloudBrainKey();
+  if (!apiKey) throw new Error('cloud-brain: no GEMINI_API_KEY');
+
+  const visual = opts.visualContext?.trim()
+    ? `\n\n[What the user can see right now: ${opts.visualContext.trim()}]`
+    : '';
+  const prompt =
+    'You are a voice assistant answering OUT LOUD in a live call. Answer the question ' +
+    'concisely and conversationally in 1-3 sentences — spoken prose, no markdown, no bullet ' +
+    'lists, no headings. If it needs current information, use search. If you are unsure, say ' +
+    `so briefly rather than guessing.\n\nQuestion: ${query}${visual}`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 8000);
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${CLOUD_BRAIN_MODEL}:generateContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: prompt }] }],
+          tools: [{ google_search: {} }], // web-search grounding
+        }),
+        signal: controller.signal,
+      },
+    );
+    if (!res.ok) {
+      throw new Error(`cloud-brain: HTTP ${res.status} ${(await res.text()).slice(0, 200)}`);
+    }
+    const data: any = await res.json();
+    const parts = data?.candidates?.[0]?.content?.parts;
+    const text = Array.isArray(parts)
+      ? parts.map((p: any) => p?.text || '').join('').trim()
+      : '';
+    if (!text) throw new Error('cloud-brain: empty response');
+    return text;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/inline-tools.ts
+++ b/src/inline-tools.ts
@@ -44,6 +44,7 @@ export { setActiveArtifactTool, queryActiveArtifactTool, clearActiveArtifactTool
 export { switchVoiceConfigTool } from './voice-config-switch.js';
 import { switchVoiceConfigTool } from './voice-config-switch.js';
 import { setActiveArtifactTool, queryActiveArtifactTool, clearActiveArtifactTool } from './artifact-cache-tools.js';
+import { research as cloudResearch } from './cloud-brain.js';
 
 // --- File-open tool (moved out of recording-tools — generic file open, optionally fullscreen) ---
 
@@ -1140,6 +1141,37 @@ function loadCoreDocumentedSkills(): { name: string; description: string }[] {
 	return Array.from(byName.values());
 }
 export const coreDocumentedSkills = loadCoreDocumentedSkills();
+
+// Tier 0.5 — fast cloud-brain research. The local live-audio model can't do
+// Google Search grounding (the 3.1 + search combo 1011s), so a current-info
+// question otherwise falls back to opening a browser + reading the screen —
+// slow and clunky. This gives the agent a direct, spoken, ~2s answer instead.
+// NOT in the default `inlineTools` array (vanilla Tier 0 stays untouched);
+// voice-agent.ts adds it only when SUTANDO_TIER05 is enabled. The routing hint
+// lives in the description (no tuned-prompt change needed).
+export const researchTool: ToolDefinition = {
+	name: 'research',
+	description:
+		'Answer a general or current-information question — news, sports scores, weather, stocks, ' +
+		'definitions, recent events, "who/what/when is X". Returns a short spoken answer in ~2s via ' +
+		'web-search-grounded lookup. ALWAYS PREFER THIS over opening a browser or screen-searching ' +
+		'for current-info questions — do NOT open a browser for these. Only for questions that do ' +
+		"NOT need the user's own machine, files, or accounts (those go to work/delegation).",
+	parameters: z.object({
+		query: z.string().describe('The question to research, phrased naturally as the user asked it.'),
+	}),
+	execution: 'inline',
+	async execute(args) {
+		const { query } = args as { query: string };
+		try {
+			const answer = await cloudResearch(query);
+			console.log(`${ts()} [Research] "${query.slice(0, 50)}" -> ${answer.slice(0, 60)}`);
+			return { answer };
+		} catch (err) {
+			return { error: `research failed: ${err instanceof Error ? err.message : err}` };
+		}
+	},
+};
 
 export const inlineTools = assertUniqueToolNames([
 	pressKeyTool, scrollTool, switchTabTool, closeTabTool, openUrlTool,

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -30,7 +30,7 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { z } from 'zod';
 import { existsSync, readFileSync, readdirSync, statSync, unlinkSync, mkdirSync, copyFileSync, appendFileSync, writeFileSync, openSync, writeSync, closeSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
-import { inlineTools, coreDocumentedSkills } from './inline-tools.js';
+import { inlineTools, coreDocumentedSkills, researchTool } from './inline-tools.js';
 import { setVisionSession, startVisionControlServer, stopVisionControlServer, setSessionToolUpdater } from './vision-tools.js';
 import { clearActiveArtifact } from './artifact-cache-tools.js';
 import { injectText } from './browser-tools.js';
@@ -541,7 +541,21 @@ function resolveCurrentMode(): ModeState {
 	return resolveCurrentModeImpl({ meetingActive, presenterActive });
 }
 
-const mainAgentTools: ToolDefinition[] = [workTool, getTaskStatus, switchModeTool, saveMeetingNoteTool, ...inlineTools];
+// Tier 0.5 — opt-in cloud optimizations for the local voice route. Off by
+// default: vanilla Tier 0 keeps exactly today's tool table. When enabled, add
+// the cloud-brain `research` tool so current-info questions get a fast spoken
+// answer instead of falling back to opening a browser (the live model can't
+// ground natively). The routing hint rides in the tool description, so the
+// tuned system prompt is untouched.
+const TIER05 = /^(1|true|yes|on)$/i.test(process.env.SUTANDO_TIER05 || '');
+const mainAgentTools: ToolDefinition[] = [
+	workTool,
+	getTaskStatus,
+	switchModeTool,
+	saveMeetingNoteTool,
+	...inlineTools,
+	...(TIER05 ? [researchTool] : []),
+];
 
 // Injection seam for the tuned factories in voice-agent-config.ts: this
 // module owns the session-gate + mode state; the config module owns the

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -548,14 +548,7 @@ function resolveCurrentMode(): ModeState {
 // ground natively). The routing hint rides in the tool description, so the
 // tuned system prompt is untouched.
 const TIER05 = /^(1|true|yes|on)$/i.test(process.env.SUTANDO_TIER05 || '');
-const mainAgentTools: ToolDefinition[] = [
-	workTool,
-	getTaskStatus,
-	switchModeTool,
-	saveMeetingNoteTool,
-	...inlineTools,
-	...(TIER05 ? [researchTool] : []),
-];
+const mainAgentTools: ToolDefinition[] = [workTool, getTaskStatus, switchModeTool, saveMeetingNoteTool, ...inlineTools, ...(TIER05 ? [researchTool] : [])];
 
 // Injection seam for the tuned factories in voice-agent-config.ts: this
 // module owns the session-gate + mode state; the config module owns the

--- a/tests/cloud-brain-tool.test.ts
+++ b/tests/cloud-brain-tool.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { inlineTools, researchTool } from '../src/inline-tools.js';
+
+// Tier 0.5 gating invariant: the research tool must NOT be part of the default
+// inline tool table. Vanilla Tier 0 stays byte-identical; voice-agent.ts adds
+// research only when SUTANDO_TIER05 is enabled. If someone accidentally drops
+// researchTool into `inlineTools`, this fails and catches the vanilla regression.
+describe('cloud-brain research tool (Tier 0.5 gating)', () => {
+	it('research tool is well-formed', () => {
+		assert.equal(researchTool.name, 'research');
+		assert.ok(researchTool.parameters, 'has a parameters schema');
+		assert.equal(typeof researchTool.execute, 'function');
+	});
+
+	it('is NOT in the default inline tool table (vanilla Tier 0 untouched)', () => {
+		assert.ok(
+			inlineTools.every((t) => t.name !== 'research'),
+			'research must be added only via the SUTANDO_TIER05 gate, never in the default table',
+		);
+	});
+});

--- a/tests/fixtures/voice-behavior-anchors.json
+++ b/tests/fixtures/voice-behavior-anchors.json
@@ -647,6 +647,6 @@
  "instructions_hash_fixed_env": "4bfd0db86de348a3cd2be8b1acf85952a50d63f1a06c157f001ddc6cb83eb7f5",
  "meeting_greeting": "[System: MEETING MODE — LISTEN AND TAKE NOTES. A Zoom meeting is active. Listen to everything and mentally track the discussion: who said what, key decisions, action items, topics covered. But do NOT produce any audio output UNLESS someone says \"Sutando\" or \"hey Sutando\" — then respond to their request using your accumulated notes and context. When not addressed, produce absolutely zero words — no acknowledgments, no \"silent\", no sounds. You are an invisible note-taker until called upon.]\n\n[MODE-MARKER-MEETING]",
  "regions": {
-  "tool_table": "e6d53e7a98b6c0f052148b6bae6096eab4e5768fb8187be8d03deee179023e78"
+  "tool_table": "3c39114fec04c014317694e6e5da63feaf3cafbc863c7b8c65216983c2978683"
  }
 }


### PR DESCRIPTION
## Box (north-star): VoiceStack — shared runtime, Tier 0.5 (local + cloud research)

Gives the **local** voice agent a fast research path so it stops falling back to opening a browser for current-info questions.

### Why
The local native-audio model can't do Google Search grounding — the `(live-audio model, googleSearch)` combo trips a `1011` quota-close on connect, so grounding ships **off** for voice. Result: a "what's the score / latest news" question makes the agent open a browser and read the screen — slow and clunky. This adds a **side-channel research tool** (a text model with grounding) so the answer comes back spoken in ~2s without touching the live voice session.

### What
- `src/cloud-brain.ts` — standalone `research()` over the Generative Language REST API (matching the repo's existing Gemini calls; sidesteps the `ai@6` / `@ai-sdk/google` v1 spec-version mismatch that blocks `generateText`). Thin, stable interface with room to grow (memory replica, multi-step, streaming).
- `researchTool` — the wrapper. Its **description** carries the routing hint ("prefer this over opening a browser"), so the **tuned system prompt is unchanged**.
- **Gated:** OFF by default — the vanilla tool table is byte-identical. The agent adds `research` only when `SUTANDO_TIER05` is set.

### Shared-runtime intent
This is the same research brain the cloud daemon uses — defined once, so the local optimized route (Tier 0.5) and the cloud route answer the same class of question the same way. Near-term the two repos share the module with a drift-guard; the runtime convergence (Phase C) folds them onto one runtime so even that copy disappears.

### Verification
- `research()` returns a fresh grounded answer in ~2s (inline). ✓
- Gating test asserts `research` never leaks into the default table (vanilla stays clean). ✓
- `tsc --noEmit` clean.

Enable + test: `SUTANDO_TIER05=1` on the core, ask a current-info question — it should answer directly instead of opening a browser.

— @sutando-qingyun-001
