### PR TITLE
test(shell-ci): fix three ubuntu-portability failures from shell-ci-known-failures

### DIFF
--- a/tests/start-cli-claude-config-dir.test.sh
+++ b/tests/start-cli-claude-config-dir.test.sh
@@ -44,11 +44,17 @@ setup_sandbox() {
   local helper_subdir="$2"    # subdir to put in fake config; e.g. ".claude-sutando" (valid) or "/etc/claude" (invalid)
 
   SANDBOX="$(mktemp -d -t start-cli-test.XXXXXX)"
+  # Resolve symlinks so path comparisons match the helper's resolved output
+  # (macOS mktemp returns /var/folders/... which is a symlink to /private/var/...).
+  SANDBOX="$(cd "$SANDBOX" && pwd -P)"
   REPO_FAKE="$SANDBOX/repo"
   ENV_DUMP="$SANDBOX/env-dump"
   BIN_STUB="$SANDBOX/bin"
   export HOME="$SANDBOX/home"
   export SUTANDO_WORKSPACE="$SANDBOX/workspace"
+  # Prevent ambient CLAUDE_CONFIG_DIR (from the test runner's own session) from
+  # leaking into the spawned process and breaking the "not set" assertion.
+  unset CLAUDE_CONFIG_DIR
 
   mkdir -p "$REPO_FAKE/scripts" "$REPO_FAKE/src" "$REPO_FAKE/src/agent/claude/cli" "$BIN_STUB" \
            "$HOME" "$SUTANDO_WORKSPACE/state"
@@ -173,8 +179,11 @@ test_valid_config_exports_env() {
     echo "  FAIL: CLAUDE_CONFIG_DIR not in claude's env"
     cleanup_sandbox; return 1
   fi
-  # Must point at SUTANDO_WORKSPACE/.claude-sutando.
-  expected="CLAUDE_CONFIG_DIR=$SUTANDO_WORKSPACE/.claude-sutando"
+  # Must point at <workspace>/.claude-sutando where <workspace> is resolved
+  # from sutando.config.json (= "${REPO_DIR}/workspace" = $REPO_FAKE/workspace).
+  # $SUTANDO_WORKSPACE is the deprecated v0.8 env-var and is no longer read by
+  # the resolver — using it here would give a stale path on a clean CI runner.
+  expected="CLAUDE_CONFIG_DIR=$REPO_FAKE/workspace/.claude-sutando"
   if [ "$ccd_in_env" != "$expected" ]; then
     echo "  FAIL: CLAUDE_CONFIG_DIR mismatch"
     echo "    expected : $expected"

--- a/tests/startup-env-token-persist.test.sh
+++ b/tests/startup-env-token-persist.test.sh
@@ -63,7 +63,8 @@ CLAUDE_CODE_OAUTH_TOKEN="test-token-001" run_persist_block "$T" >/dev/null 2>&1
 report "$?" "persist fires + writes correct token from CLAUDE_CODE_OAUTH_TOKEN"
 
 # Test 2: mode 600 enforced
-[ "$(stat -f '%Lp' "$T/.credentials.json")" = "600" ]
+# Use Python for portable mode check (stat -f '%Lp' is BSD-only; GNU stat uses -c '%a').
+[ "$(python3 -c "import stat,os; print('%o' % stat.S_IMODE(os.stat('$T/.credentials.json').st_mode))")" = "600" ]
 report "$?" "persisted .credentials.json is mode 600"
 
 # Test 3: schema is the expected claudeAiOauth shape
@@ -71,10 +72,11 @@ jq -e '.claudeAiOauth.accessToken' "$T/.credentials.json" >/dev/null 2>&1
 report "$?" "persisted file has claudeAiOauth.accessToken structure"
 
 # Test 4: idempotent — re-run with file present should NOT overwrite
-old_mtime="$(stat -f '%m' "$T/.credentials.json")"
+# Use Python for portable mtime (stat -f '%m' is BSD-only; GNU stat uses -c '%Y').
+old_mtime="$(python3 -c "import os; print(int(os.stat('$T/.credentials.json').st_mtime))")"
 sleep 1
 CLAUDE_CODE_OAUTH_TOKEN="test-token-002" run_persist_block "$T" >/dev/null 2>&1
-new_mtime="$(stat -f '%m' "$T/.credentials.json")"
+new_mtime="$(python3 -c "import os; print(int(os.stat('$T/.credentials.json').st_mtime))")"
 [ "$old_mtime" = "$new_mtime" ] && [ "$(jq -r .claudeAiOauth.accessToken "$T/.credentials.json")" = "test-token-001" ]
 report "$?" "idempotent — re-run preserves original token, no overwrite"
 

--- a/tests/sutando-migrate.test.sh
+++ b/tests/sutando-migrate.test.sh
@@ -59,8 +59,10 @@ RUN_MIGRATE() {
     SUTANDO_MIGRATE_SRC_A="$A" \
     SUTANDO_MIGRATE_SRC_B="$B" \
     SUTANDO_MIGRATE_SRC_C="$C" \
-    SUTANDO_WORKSPACE="$DEST" \
-        bash "$MIGRATE" --respect-env "$@"
+    SUTANDO_MIGRATE_DEST="$DEST" \
+        bash "$MIGRATE" "$@"
+    # Note: SUTANDO_MIGRATE_DEST is the proper test hook (workspace resolver
+    # ignores $SUTANDO_WORKSPACE since #1440). --respect-env is not needed.
 }
 
 # Also add a stale task to source B for archive-routing assertion
@@ -87,7 +89,7 @@ echo
 echo "==== TEST: commit ===="
 COMMIT_OUT="$(RUN_MIGRATE commit --source A,B,C 2>&1)"
 echo "$COMMIT_OUT" | grep -E "Committing source|copied:|identical:|kept-dest:|sidecar:|skipped:|sentinel:|backup|COMMIT" | head -40
-INITIAL_BACKUP_ID="$(echo "$COMMIT_OUT" | grep -E "^sutando-migrate: backup" | head -1 | sed -E 's@.*migration-backup-(.+)\.tar\.gz.*@\1@')"
+INITIAL_BACKUP_ID="$(echo "$COMMIT_OUT" | grep -E "migration-backup-.*\.tar\.gz" | head -1 | sed -E 's@.*migration-backup-(.+)\.tar\.gz.*@\1@' || true)"
 
 echo
 echo "==== ASSERTIONS ===="
@@ -106,9 +108,9 @@ done
 if [ ! -f "$DEST/notes/shared.md" ]; then
     echo "  FAIL: $DEST/notes/shared.md missing"; fail=1
 else
-    # mtime should match source
-    src_mt="$(stat -f %m "$C/notes/shared.md")"
-    dst_mt="$(stat -f %m "$DEST/notes/shared.md")"
+    # mtime should match source (Python for portability — stat -f %m is BSD-only)
+    src_mt="$(python3 -c "import os; print(int(os.stat('$C/notes/shared.md').st_mtime))")"
+    dst_mt="$(python3 -c "import os; print(int(os.stat('$DEST/notes/shared.md').st_mtime))")"
     if [ "$src_mt" != "$dst_mt" ]; then
         echo "  FAIL: shared.md mtime not preserved (src=$src_mt dst=$dst_mt)"; fail=1
     else


### PR DESCRIPTION
## Summary

Fixes three test suites that fail on ubuntu-latest CI (wired in by #1948) due to macOS-specific tooling or test bugs. All three are in \`tests/shell-ci-known-failures.txt\` as non-gating entries; these fixes promote them to gating.

**tests/start-cli-claude-config-dir.test.sh** (2 of 4 tests failed):
- Ambient `CLAUDE_CONFIG_DIR` from the runner's live Claude session leaked into the subprocess — fix: `unset CLAUDE_CONFIG_DIR` in `setup_sandbox()`
- macOS `mktemp` returns `/var/folders/…` (symlink) but the helper resolves to `/private/var/…`; test also expected deprecated `$SUTANDO_WORKSPACE` as the value — fix: `pwd -P` to normalize, use `$REPO_FAKE/workspace` (via workspace config, not the deprecated env var)

**tests/startup-env-token-persist.test.sh** (2 of 7 tests failed):
- `stat -f '%Lp'` (BSD) and `stat -f '%m'` (BSD) are not available on Ubuntu — fix: Python `os.stat()` one-liners (portable)

**tests/sutando-migrate.test.sh** (7 of 14 assertions failed, with early exit):
- Wrong DEST: test used `SUTANDO_WORKSPACE="$DEST" --respect-env` but the workspace resolver ignores `$SUTANDO_WORKSPACE` since #1440 — fix: use `SUTANDO_MIGRATE_DEST` (the documented E2E test hook)
- Early script exit via `set -eo pipefail`: `grep -E "^sutando-migrate: backup"` exits 1 when dest is empty (line reads "placeholder backup →") — fix: broaden grep pattern + add `|| true`
- `stat -f %m` (BSD) for mtime comparison — fix: Python `os.stat().st_mtime` (same pattern as above)

## Test plan
- [ ] `bash tests/start-cli-claude-config-dir.test.sh` → 4/4 pass
- [ ] `bash tests/startup-env-token-persist.test.sh` → 7/7 pass
- [ ] `bash tests/sutando-migrate.test.sh` → 14/14 assertions pass
- [ ] CI tsc+tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EL2XBcV3RsWhevzTPtW4jw