### PR TITLE
feat(workspace): add SUTANDO_WORKSPACE_DIR override

### DIFF
--- a/docs/workspace-config.md
+++ b/docs/workspace-config.md
@@ -8,15 +8,16 @@ Sutando keeps **per-user runtime state** (tasks, results, notes, state, logs, et
 <repo>/workspace/
 ```
 
-That's it for a fresh clone — no setup, no env var, no config file. The directory is gitignored except for `.gitkeep`, so user data never sneaks into commits.
+That's it for a fresh clone — no setup, no config file. The directory is gitignored except for `.gitkeep`, so user data never sneaks into commits.
 
 ## Resolution order (highest wins)
 
-1. **`sutando.config.local.json`** → `workspace.path` — per-clone override. Gitignored.
-2. **`sutando.config.json`** → `workspace.path` — tracked default. The repo ships `${REPO_DIR}/workspace`.
-3. **Baked-in fallback** — `${REPO_DIR}/workspace`, used if neither config file exists.
+1. **`SUTANDO_WORKSPACE_DIR`** — launch-time operator override. Use this for desktop/dev sessions that must force one workspace across every child process.
+2. **`sutando.config.local.json`** → `workspace.path` — per-clone override. Gitignored.
+3. **`sutando.config.json`** → `workspace.path` — tracked default. The repo ships `${REPO_DIR}/workspace`.
+4. **Baked-in fallback** — `${REPO_DIR}/workspace`, used if neither config file exists.
 
-**Note:** `$SUTANDO_WORKSPACE` is **no longer honored** by the resolver as of PR #1440 (workspace contract v0.3.0). If set, startup emits a one-time stderr deprecation warning + invokes auto-migration via `src/startup.sh`. Migrate to `sutando.config.local.json` to silence the warning.
+**Note:** `$SUTANDO_WORKSPACE` is **no longer honored** by the resolver as of PR #1440 (workspace contract v0.3.0). If set without `SUTANDO_WORKSPACE_DIR`, startup emits a one-time stderr deprecation warning + invokes auto-migration via `src/startup.sh`. Use `SUTANDO_WORKSPACE_DIR` for a process-tree override, or migrate to `sutando.config.local.json` for a durable per-clone override.
 
 `${REPO_DIR}` in any config string expands to the directory containing the config file (== git toplevel for a sane checkout).
 
@@ -49,14 +50,19 @@ Keys whose name starts with `_` (e.g. `_comment`) are stripped before validation
 
 ## Three common overrides
 
+```bash
+# 1. Force one workspace for a dev session / process tree
+SUTANDO_WORKSPACE_DIR=/Users/you/.sutando/repo/workspace bash src/startup.sh
+```
+
 ```json
-// 1. Move workspace outside the repo (e.g. shared between clones)
+// 2. Move workspace outside the repo (e.g. shared between clones)
 { "workspace": { "path": "/Users/you/.sutando/workspace" } }
 
-// 2. Enable vault sync to a private remote
+// 3. Enable vault sync to a private remote
 { "vault": { "enabled": true, "remote_url": "https://vault.example.com/you/workspace.git" } }
 
-// 3. Both
+// 4. Both
 {
   "workspace": { "path": "/Users/you/.sutando/workspace" },
   "vault": { "enabled": true, "remote_url": "https://vault.example.com/you/workspace.git" }
@@ -92,7 +98,7 @@ Escape hatch for the rare legitimate case (updating `.gitkeep` itself): `git com
 
 Older installs used `~/.sutando/workspace/` as the default. If you have one:
 
-- **Path-only override:** add `{"workspace":{"path":"/Users/you/.sutando/workspace"}}` to `sutando.config.local.json`. Done.
+- **Path-only override:** set `SUTANDO_WORKSPACE_DIR=/Users/you/.sutando/workspace` for a launch-only override, or add `{"workspace":{"path":"/Users/you/.sutando/workspace"}}` to `sutando.config.local.json` for a durable per-clone override.
 - **Move into the in-repo default:** copy your old workspace contents into `<repo>/workspace/`. The loader will emit a `.env` drift warning if your `.env` still declares `SUTANDO_WORKSPACE=` — remove that line once you've migrated.
 
 The M1 milestone will ship a dedicated recovery skill (`bash scripts/sutando-migrate.sh`) for users who want a guided audit + move.

--- a/docs/workspace-config.md
+++ b/docs/workspace-config.md
@@ -13,6 +13,15 @@ That's it for a fresh clone — no setup, no config file. The directory is gitig
 ## Resolution order (highest wins)
 
 1. **`SUTANDO_WORKSPACE_DIR`** — launch-time operator override. Use this for desktop/dev sessions that must force one workspace across every child process.
+
+   > **Not the same variable as the deprecated `SUTANDO_WORKSPACE`.** The two differ by more than the `_DIR` suffix:
+   >
+   > | Variable | Status | Effect |
+   > |---|---|---|
+   > | `SUTANDO_WORKSPACE_DIR` | **current** | highest-precedence launch-time override; honored by all three resolver twins (py/ts/swift) |
+   > | `SUTANDO_WORKSPACE` | **deprecated (#1440)** | value **ignored** by the resolver; presence only triggers a one-time warning + auto-migration |
+   >
+   > If both are set, `SUTANDO_WORKSPACE_DIR` wins and the deprecated variable is still ignored. New scripts and docs must reference only `SUTANDO_WORKSPACE_DIR`.
 2. **`sutando.config.local.json`** → `workspace.path` — per-clone override. Gitignored.
 3. **`sutando.config.json`** → `workspace.path` — tracked default. The repo ships `${REPO_DIR}/workspace`.
 4. **Baked-in fallback** — `${REPO_DIR}/workspace`, used if neither config file exists.
@@ -52,19 +61,19 @@ Keys whose name starts with `_` (e.g. `_comment`) are stripped before validation
 
 ```bash
 # 1. Force one workspace for a dev session / process tree
-SUTANDO_WORKSPACE_DIR=/Users/you/.sutando/repo/workspace bash src/startup.sh
+SUTANDO_WORKSPACE_DIR="<absolute-path-to-workspace>" bash src/startup.sh
 ```
 
 ```json
 // 2. Move workspace outside the repo (e.g. shared between clones)
-{ "workspace": { "path": "/Users/you/.sutando/workspace" } }
+{ "workspace": { "path": "<absolute-path-to-workspace>" } }
 
 // 3. Enable vault sync to a private remote
 { "vault": { "enabled": true, "remote_url": "https://vault.example.com/you/workspace.git" } }
 
 // 4. Both
 {
-  "workspace": { "path": "/Users/you/.sutando/workspace" },
+  "workspace": { "path": "<absolute-path-to-workspace>" },
   "vault": { "enabled": true, "remote_url": "https://vault.example.com/you/workspace.git" }
 }
 ```
@@ -98,7 +107,7 @@ Escape hatch for the rare legitimate case (updating `.gitkeep` itself): `git com
 
 Older installs used `~/.sutando/workspace/` as the default. If you have one:
 
-- **Path-only override:** set `SUTANDO_WORKSPACE_DIR=/Users/you/.sutando/workspace` for a launch-only override, or add `{"workspace":{"path":"/Users/you/.sutando/workspace"}}` to `sutando.config.local.json` for a durable per-clone override.
+- **Path-only override:** set `SUTANDO_WORKSPACE_DIR=<absolute-path-to-workspace>` for a launch-only override, or add `{"workspace":{"path":"<absolute-path-to-workspace>"}}` to `sutando.config.local.json` for a durable per-clone override.
 - **Move into the in-repo default:** copy your old workspace contents into `<repo>/workspace/`. The loader will emit a `.env` drift warning if your `.env` still declares `SUTANDO_WORKSPACE=` — remove that line once you've migrated.
 
 The M1 milestone will ship a dedicated recovery skill (`bash scripts/sutando-migrate.sh`) for users who want a guided audit + move.

--- a/docs/workspace-contract.md
+++ b/docs/workspace-contract.md
@@ -2,9 +2,9 @@
 
 **Version:** v0.3.0 (current). Predecessors: pre-M0 (env-honored, scattered defaults), M0 (in-repo default + config-driven resolver, env still legacy-honored).
 
-**Status:** **Ratified as of PR #1440 merge (2026-06-04).** The contract below describes the operational shape. M0 (in-repo default, config-driven resolver) shipped via PRs #1395 + #1397 + #1399 + #1403; M1 (workspace migration script + skill) via #1403 + #1406; M2 (`claude_sutando_config_dir`) via #1415 + #1424 + #1429; workspace-as-git-repo sync (`sync-workspace.sh`) via #1445 + #1446 + #1447 + #1458 + #1459 + #1460 + #1461 + #1463. The "no env override" strip landed in #1440: `$SUTANDO_WORKSPACE` is no longer honored by the resolver; setting it triggers a one-time stderr deprecation warning + bootstrap auto-migration in `src/startup.sh`. This file is the operational source of truth.
+**Status:** **Ratified as of PR #1440 merge (2026-06-04), amended by the `SUTANDO_WORKSPACE_DIR` override.** The contract below describes the operational shape. M0 (in-repo default, config-driven resolver) shipped via PRs #1395 + #1397 + #1399 + #1403; M1 (workspace migration script + skill) via #1403 + #1406; M2 (`claude_sutando_config_dir`) via #1415 + #1424 + #1429; workspace-as-git-repo sync (`sync-workspace.sh`) via #1445 + #1446 + #1447 + #1458 + #1459 + #1460 + #1461 + #1463. The legacy `$SUTANDO_WORKSPACE` strip landed in #1440: `$SUTANDO_WORKSPACE` is no longer honored by the resolver; setting it without `SUTANDO_WORKSPACE_DIR` triggers a one-time stderr deprecation warning + bootstrap auto-migration in `src/startup.sh`. This file is the operational source of truth.
 
-**One-sentence summary**: The workspace is `<repo>/workspace/`, period. It is gitignored, computed (no env override), and ephemeral; durability is a separate concern handled by the vault.
+**One-sentence summary**: The workspace defaults to `<repo>/workspace/`, is gitignored, can be forced for a process tree with `SUTANDO_WORKSPACE_DIR`, and is otherwise config-driven; durability is a separate concern handled by the vault.
 
 ---
 
@@ -16,15 +16,15 @@
 <repo>/workspace/    ← workspace root (gitignored)
 ```
 
-Resolved by `bash scripts/sutando-config.sh workspace` (the M0 helper). Helpers in Python (`from workspace_default import resolve_workspace`), TypeScript (`import { resolveWorkspace } from './workspace_default.js'`), and Swift (`AppDelegate.workspace`) read from `sutando.config.{json,local.json}` with `<repo>/workspace/` as the baked-in default.
+Resolved by `bash scripts/sutando-config.sh workspace` (the M0 helper). Helpers in Python (`from workspace_default import resolve_workspace`), TypeScript (`import { resolveWorkspace } from './workspace_default.js'`), and Swift (`AppDelegate.workspace`) honor `SUTANDO_WORKSPACE_DIR`, then read from `sutando.config.{json,local.json}` with `<repo>/workspace/` as the baked-in default.
 
 **Hard rules (after #1440):**
-- The workspace is **always** at `<repo>/workspace/` by default. The location is specified via the config file (`sutando.config.{json,local.json}` → `workspace.path`); the per-clone `sutando.config.local.json` (gitignored) is where users override, if they choose to.
-- **No env override** — neither `$SUTANDO_WORKSPACE` nor any other env var redirects the resolver.
+- The workspace is **always** at `<repo>/workspace/` by default. The location is specified via `SUTANDO_WORKSPACE_DIR` for a launch-time process-tree override, or via the config file (`sutando.config.{json,local.json}` → `workspace.path`) for durable per-clone overrides.
+- `$SUTANDO_WORKSPACE` remains legacy/deprecated and does not redirect the resolver.
 - The whole `/workspace/` tree is gitignored (single entry in repo `.gitignore`).
 - Workspace is computed by the helpers — never by a per-script fallback.
 
-> ⚠️ **Cost of overriding `workspace.path` outside `<repo>/workspace/`.** The in-repo default is what unlocks Claude Code's cwd-anchored features:
+> ⚠️ **Cost of overriding the workspace outside `<repo>/workspace/`.** The in-repo default is what unlocks Claude Code's cwd-anchored features:
 >
 > - **CLAUDE.md auto-load** — Claude Code reads the project's `CLAUDE.md` automatically when cwd is inside the repo. Move workspace outside and the workspace-rooted `PERSONAL_CLAUDE.md` stops being auto-loaded.
 > - **Skills auto-discovery** — workspace-rooted `skills/` is auto-discovered when workspace is under cwd. Outside the repo, sessions need an explicit `--add-dir <workspace>` to see them.
@@ -34,7 +34,7 @@ Resolved by `bash scripts/sutando-config.sh workspace` (the M0 helper). Helpers 
 >
 > Only override if you have a clear reason (shared workspace across multiple checkouts; custom storage for size / encryption / quota). Otherwise, accept the default.
 
-**Today's deprecation path:** `$SUTANDO_WORKSPACE` set in the environment fires a one-time bold-red stderr warning pointing at `scripts/sutando-migrate.sh`. After #1440 merges, the value is not honored even with the warning. Hosts with the env var set are auto-migrated by `src/startup.sh` on first run post-merge (run `sutando-migrate.sh --commit`, then compress the original folder in place + unset the env).
+**Today's deprecation path:** `$SUTANDO_WORKSPACE` set in the environment without `SUTANDO_WORKSPACE_DIR` fires a one-time bold-red stderr warning pointing at `scripts/sutando-migrate.sh`. The value is not honored even with the warning. Hosts with the legacy env var set are auto-migrated by `src/startup.sh` on first run post-merge (run `sutando-migrate.sh --commit`, then compress the original folder in place + unset the env).
 
 **Why in-repo:** the workspace inherits Claude Code's cwd privileges — CLAUDE.md auto-load, skills auto-discovery, project-slug for session transcripts, hook scope, no `--add-dir` needed. Putting it anywhere else forfeits these.
 
@@ -125,11 +125,12 @@ Path computation is centralized; do NOT reinvent the fallback per-script.
 - **Shell:** `WORKSPACE="$(bash scripts/sutando-config.sh workspace)"` then `"$WORKSPACE/..."`. The shared `src/workspace_resolve.sh` helper wraps this for scripts that source it.
 
 **Resolution order (post-#1440):**
-1. `sutando.config.local.json` → `workspace.path` (per-clone override, gitignored).
-2. `sutando.config.json` → `workspace.path` (tracked defaults at repo root).
-3. `<repo>/workspace/` baked-in default.
+1. `SUTANDO_WORKSPACE_DIR` → explicit launch-time operator override.
+2. `sutando.config.local.json` → `workspace.path` (per-clone override, gitignored).
+3. `sutando.config.json` → `workspace.path` (tracked defaults at repo root).
+4. `<repo>/workspace/` baked-in default.
 
-**Today (pre-#1440):** `$SUTANDO_WORKSPACE` env var is honored as a legacy escape hatch ahead of step 1, with a one-time deprecation warning. PR #1440 removes that step.
+`$SUTANDO_WORKSPACE` is not in the resolution order. It is only detected for deprecation/migration warnings.
 
 ## 3. Migration from earlier versions
 
@@ -155,7 +156,7 @@ The workspace is intentionally ephemeral: delete the repo and the workspace dies
 
 | # | Decision | Rationale |
 |---|---|---|
-| 1 | Workspace = `<repo>/workspace/`, **computed**, no env override (post-#1440) | Claude Code cwd-privilege capture; structural simplicity |
+| 1 | Workspace = `<repo>/workspace/` by default, **computed**, with `SUTANDO_WORKSPACE_DIR` as the explicit launch override | Claude Code cwd-privilege capture by default; one simple operator control for dev/runtime launches |
 | 2 | Whole `/workspace/` tree gitignored | Prevents tracked-pollution anti-pattern (the historic `Path(__file__).parent.parent` regression) |
 | 3 | Top-level dirs (tasks/results/state/logs/notes/data/relay/skills) + 2 .md files | Matches the decision guide; agent has a single answer for each write |
 | 4 | Confidentiality default-deny | Workspace = owner-private; bots paraphrase, never quote |
@@ -183,7 +184,13 @@ This is intentional. This doc (the workspace contract) defines location + struct
 
 **Q: Can I use a workspace dir other than `<repo>/workspace/`?**
 
-A: Yes. Override `workspace.path` in your gitignored `sutando.config.local.json`:
+A: Yes. For a one-process-tree override, set `SUTANDO_WORKSPACE_DIR` before launching Sutando:
+
+```bash
+SUTANDO_WORKSPACE_DIR=/some/other/absolute/path bash src/startup.sh
+```
+
+For a durable per-clone override, set `workspace.path` in your gitignored `sutando.config.local.json`:
 
 ```json
 {
@@ -204,7 +211,7 @@ A: It was the legacy escape hatch (pre-M0). Two problems with env-based override
 1. Two processes inheriting the env at different times read different values (cron jobs, launchd jobs, ad-hoc shells) — silent split-brain.
 2. The env var doesn't survive a fresh `git clone`. New machines / checkouts don't see your override; the default applies inconsistently.
 
-`sutando.config.local.json` solves both: it lives at a known path (gitignored), every process reads it the same way, and a new clone gets a clean state with the default.
+`sutando.config.local.json` solves the durable per-clone case. `SUTANDO_WORKSPACE_DIR` exists for the operational case where a launcher needs to force every child process onto the same workspace without editing files. `$SUTANDO_WORKSPACE` stays ignored because it is coupled to old migration behavior.
 
 **Q: How do I migrate an existing workspace from a pre-v0.8 layout?**
 

--- a/src/Sutando/SutandoConfig.swift
+++ b/src/Sutando/SutandoConfig.swift
@@ -199,11 +199,26 @@ enum SutandoConfig {
     /// $SUTANDO_WORKSPACE is ignored in production as of v0.8 (warn once when
     /// SUTANDO_WORKSPACE_DIR is not set).
     /// SUTANDO_TEST_MODE=1 keeps the env override for tests only.
+    /// Expand a leading `~` and normalize to an absolute, standardized path.
+    /// Mirrors the Python (`Path(...).expanduser().resolve()`) and TS
+    /// (`path.resolve(value.replace(/^~/, homedir()))`) twins so a relative
+    /// override like `SUTANDO_WORKSPACE_DIR=tmp/ws` resolves against the current
+    /// working directory instead of staying relative — otherwise Sutando.app
+    /// would split onto a different workspace than the Python/TS services.
+    private static func absolutize(_ path: String) -> String {
+        let expanded = (path as NSString).expandingTildeInPath
+        let absolute = (expanded as NSString).isAbsolutePath
+            ? expanded
+            : (FileManager.default.currentDirectoryPath as NSString)
+                .appendingPathComponent(expanded)
+        return (absolute as NSString).standardizingPath
+    }
+
     static func resolveWorkspace(repoRoot explicitRoot: String? = nil) -> String {
         if let explicitEnv = ProcessInfo.processInfo.environment["SUTANDO_WORKSPACE_DIR"]?
             .trimmingCharacters(in: .whitespaces),
            !explicitEnv.isEmpty {
-            return (explicitEnv as NSString).expandingTildeInPath
+            return absolutize(explicitEnv)
         }
 
         let env = ProcessInfo.processInfo.environment["SUTANDO_WORKSPACE"]?

--- a/src/Sutando/SutandoConfig.swift
+++ b/src/Sutando/SutandoConfig.swift
@@ -7,14 +7,16 @@
 // resolved workspace so menubar app + bridges + voice agent all land in
 // the same directory.
 //
-// Resolution order (v0.8):
-//   1. sutando.config.local.json (per-clone override, gitignored)
-//   2. sutando.config.json (tracked defaults at repo root)
-//   3. Baked-in default ({repoRoot}/workspace)
+// Resolution order:
+//   1. SUTANDO_WORKSPACE_DIR (explicit operator override)
+//   2. sutando.config.local.json (per-clone override, gitignored)
+//   3. sutando.config.json (tracked defaults at repo root)
+//   4. Baked-in default ({repoRoot}/workspace)
 //
-// $SUTANDO_WORKSPACE is no longer honored in production. If set, a one-time
-// warning points at scripts/sutando-migrate.sh. SUTANDO_TEST_MODE=1 preserves
-// the env override only for test fixtures, matching the Python/TS twins.
+// $SUTANDO_WORKSPACE is no longer honored in production. If set without
+// SUTANDO_WORKSPACE_DIR, a one-time warning points at scripts/sutando-migrate.sh.
+// SUTANDO_TEST_MODE=1 preserves the env override only for test fixtures,
+// matching the Python/TS twins.
 //
 // Foundation-only — no extra deps. Swift 5+.
 
@@ -190,12 +192,20 @@ enum SutandoConfig {
     /// Returns an absolute path. Does NOT create the directory.
     ///
     /// Order:
-    ///   1. config workspace.path (deep-merged)
-    ///   2. {repoRoot}/workspace baked-in default
+    ///   1. SUTANDO_WORKSPACE_DIR explicit operator override
+    ///   2. config workspace.path (deep-merged)
+    ///   3. {repoRoot}/workspace baked-in default
     ///
-    /// $SUTANDO_WORKSPACE is ignored in production as of v0.8 (warn once).
+    /// $SUTANDO_WORKSPACE is ignored in production as of v0.8 (warn once when
+    /// SUTANDO_WORKSPACE_DIR is not set).
     /// SUTANDO_TEST_MODE=1 keeps the env override for tests only.
     static func resolveWorkspace(repoRoot explicitRoot: String? = nil) -> String {
+        if let explicitEnv = ProcessInfo.processInfo.environment["SUTANDO_WORKSPACE_DIR"]?
+            .trimmingCharacters(in: .whitespaces),
+           !explicitEnv.isEmpty {
+            return (explicitEnv as NSString).expandingTildeInPath
+        }
+
         let env = ProcessInfo.processInfo.environment["SUTANDO_WORKSPACE"]?
             .trimmingCharacters(in: .whitespaces)
         if let env = env, !env.isEmpty {

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -88,8 +88,8 @@ def validate_twilio_signature(handler, body: str) -> bool:
 #               checkout, loading .env, etc. Stays anchored to the checkout.
 # - WORKSPACE_DIR = runtime state (resolve_workspace()) — for tasks/, results/,
 #               core-status.json, pending-questions.md, contextual-chips.json,
-#               etc. Honors SUTANDO_WORKSPACE when set so watcher + bridges
-#               stay aligned with these writes.
+#               etc. Uses the canonical resolver so watcher + bridges stay
+#               aligned with these writes.
 REPO_DIR = Path(__file__).parent.parent
 sys.path.insert(0, str(Path(__file__).parent))
 from workspace_default import resolve_workspace, status_read_path  # noqa: E402

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -7,13 +7,16 @@ go through `load_config()` so that the contract is enforced in one place
 rather than re-implemented per-service.
 
 Resolution order (highest layer wins):
-  1. `sutando.config.local.json` (per-clone override, gitignored)
-  2. `sutando.config.json` (tracked defaults at repo root)
-  3. Baked-in default (`{repo_root}/workspace`)
+  1. `$SUTANDO_WORKSPACE_DIR` (explicit operator override)
+  2. `sutando.config.local.json` (per-clone override, gitignored)
+  3. `sutando.config.json` (tracked defaults at repo root)
+  4. Baked-in default (`{repo_root}/workspace`)
 
-`$SUTANDO_WORKSPACE` is no longer honored (removed in v0.8). If set, a
-one-time stderr warning fires pointing at `scripts/sutando-migrate.sh`
-for relocation of any data still living at the env-pointed path.
+`$SUTANDO_WORKSPACE_DIR` is an explicit operator override and wins over config.
+`$SUTANDO_WORKSPACE` is no longer honored (removed in v0.8). If set without
+`$SUTANDO_WORKSPACE_DIR`, a one-time stderr warning fires pointing at
+`scripts/sutando-migrate.sh` for relocation of any data still living at the
+env-pointed path.
 
 Deep-merge semantics: `.local.json` is merged over the tracked defaults.
 Dicts deep-merge; arrays REPLACE wholesale (not unioned). This matches the
@@ -290,25 +293,31 @@ _HARDCODED_WORKSPACE_DEFAULT_REL = "workspace"  # relative to repo root
 def resolve_workspace(repo_root: Optional[Path] = None) -> Path:
     """Resolve the workspace directory per the canonical contract.
 
-    Order (v0.8 — `$SUTANDO_WORKSPACE` env override removed):
-      1. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
-      2. `{repo_root}/workspace` baked-in default.
+    Order:
+      1. `$SUTANDO_WORKSPACE_DIR` explicit operator override.
+      2. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
+      3. `{repo_root}/workspace` baked-in default.
 
     Does NOT create the directory; the caller decides. Returns an absolute
     `Path`.
 
-    If `$SUTANDO_WORKSPACE` is set in the environment, fires a one-time
-    stderr migration-nag warning pointing at `scripts/sutando-migrate.sh`
-    but does NOT honor the env value (the legacy escape hatch was removed
-    in v0.8 per `docs/workspace-contract-v0.8.md`).
+    If `$SUTANDO_WORKSPACE` is set in the environment without
+    `$SUTANDO_WORKSPACE_DIR`, fires a one-time stderr migration-nag warning
+    pointing at `scripts/sutando-migrate.sh` but does NOT honor the env value
+    (the legacy escape hatch was removed in v0.8 per
+    `docs/workspace-contract-v0.8.md`).
     """
     global _LEGACY_ENV_WARN_PRINTED, _DOTENV_DRIFT_WARN_PRINTED
+
+    explicit_env_val = os.environ.get("SUTANDO_WORKSPACE_DIR", "").strip()
+    if explicit_env_val:
+        return Path(explicit_env_val).expanduser().resolve()
 
     env_val = os.environ.get("SUTANDO_WORKSPACE", "").strip()
 
     # Test-only escape hatch: when `SUTANDO_TEST_MODE=1` is set, honor
     # `$SUTANDO_WORKSPACE` silently. This preserves the v0.8 contract for
-    # end users (no env override; warning + ignore) while letting the test
+    # end users (no legacy env override; warning + ignore) while letting the test
     # suite redirect workspace to per-test tmp dirs without rewriting every
     # test fixture. Production code MUST NOT set `SUTANDO_TEST_MODE`.
     if env_val and os.environ.get("SUTANDO_TEST_MODE") == "1":

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -313,7 +313,12 @@ export function resolveWorkspace(repoRoot?: string): string {
 	if (typeof ws === 'string' && ws) {
 		resolved = resolve(ws.replace(/^~/, homedir()));
 	} else if (root === undefined) {
-		resolved = resolve(join(homedir(), '.sutando', 'workspace'));
+		// Last-ditch fallback for ad-hoc invocations outside a checkout.
+		// Post-v0.8 (#1440) the legacy `.sutando/workspace/` namespace is gone;
+		// use the unhidden `~/sutando-workspace/` default so the deprecated
+		// `.sutando/` alias doesn't live on. Mirrors the Python + Swift twins'
+		// no-config-no-repo-root branch.
+		resolved = resolve(join(homedir(), 'sutando-workspace'));
 	} else {
 		resolved = resolve(join(root, HARDCODED_WORKSPACE_DEFAULT_REL));
 	}

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -7,14 +7,16 @@
  * Python services (bridges, health-check) and TS services (voice-agent,
  * task-bridge) land in the same workspace.
  *
- * Resolution order (highest layer wins, v0.8 — env override removed):
- *   1. `sutando.config.local.json` (per-clone override, gitignored)
- *   2. `sutando.config.json` (tracked defaults at repo root)
- *   3. Baked-in default (`{repo_root}/workspace`)
+ * Resolution order (highest layer wins):
+ *   1. `$SUTANDO_WORKSPACE_DIR` (explicit operator override)
+ *   2. `sutando.config.local.json` (per-clone override, gitignored)
+ *   3. `sutando.config.json` (tracked defaults at repo root)
+ *   4. Baked-in default (`{repo_root}/workspace`)
  *
- * `$SUTANDO_WORKSPACE` is no longer honored. If set in the environment,
- * a one-time stderr warning fires pointing at `scripts/sutando-migrate.sh`
- * for relocation of any data still living at the env-pointed path.
+ * `$SUTANDO_WORKSPACE` is no longer honored. If set in the environment
+ * without `$SUTANDO_WORKSPACE_DIR`, a one-time stderr warning fires pointing
+ * at `scripts/sutando-migrate.sh` for relocation of any data still living at
+ * the env-pointed path.
  *
  * No external deps — stdlib only.
  */
@@ -257,23 +259,29 @@ const HARDCODED_WORKSPACE_DEFAULT_REL = 'workspace';
 /**
  * Resolve the workspace directory per the canonical contract.
  *
- * Order (v0.8 — `$SUTANDO_WORKSPACE` no longer honored):
- *   1. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
- *   2. `{repoRoot}/workspace` baked-in default.
+ * Order:
+ *   1. `$SUTANDO_WORKSPACE_DIR` explicit operator override.
+ *   2. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
+ *   3. `{repoRoot}/workspace` baked-in default.
  *
- * If `$SUTANDO_WORKSPACE` is set in the environment, prints a one-time
- * migration-nag warning pointing at `scripts/sutando-migrate.sh` but does
- * NOT honor the env value (the legacy escape hatch was removed in v0.8
- * per `docs/workspace-contract-v0.8.md`).
+ * If `$SUTANDO_WORKSPACE` is set in the environment without
+ * `$SUTANDO_WORKSPACE_DIR`, prints a one-time migration-nag warning pointing
+ * at `scripts/sutando-migrate.sh` but does NOT honor the env value (the
+ * legacy escape hatch was removed in v0.8 per `docs/workspace-contract-v0.8.md`).
  *
  * Returns an absolute path. Does NOT create the directory.
  */
 export function resolveWorkspace(repoRoot?: string): string {
+	const explicitEnvVal = process.env.SUTANDO_WORKSPACE_DIR?.trim();
+	if (explicitEnvVal) {
+		return resolve(explicitEnvVal.replace(/^~(?=$|\/)/, homedir()));
+	}
+
 	const envVal = process.env.SUTANDO_WORKSPACE?.trim();
 
 	// Test-only escape hatch: when `SUTANDO_TEST_MODE=1` is set, honor
 	// `$SUTANDO_WORKSPACE` silently. This preserves the v0.8 contract for
-	// end users (no env override; warning + ignore) while letting the test
+	// end users (no legacy env override; warning + ignore) while letting the test
 	// suite redirect workspace to per-test tmp dirs without rewriting every
 	// test fixture. Production code MUST NOT set `SUTANDO_TEST_MODE`.
 	if (envVal && process.env.SUTANDO_TEST_MODE === '1') {

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -18,7 +18,8 @@
  *   ANTHROPIC_API_KEY   — Optional: only needed if not using claude CLI subscription auth
  *   (workspace)         — Per-user workspace dir resolved via `resolveWorkspace()`
  *                          from src/workspace_default.ts. Post-v0.8 (#1440) default is
- *                          `<repo>/workspace/`; configurable via `sutando.config.local.json`.
+ *                          `<repo>/workspace/`; override with SUTANDO_WORKSPACE_DIR
+ *                          for a launch, or `sutando.config.local.json` for a clone.
  *                          $SUTANDO_WORKSPACE is no longer honored for resolution.
  *                          Stores tasks/, results/, state/, logs/, conversation.log.
  *   PORT                — WebSocket port (default: 9900)

--- a/src/workspace_default.py
+++ b/src/workspace_default.py
@@ -1,16 +1,16 @@
 """Canonical workspace-directory resolution for Sutando services.
 
 All runtime artifacts (tasks/, results/, state/, data/, build_log.md, ...) live
-under the workspace dir. Post-v0.8 (#1440), components MUST resolve via the M0
+under the workspace dir. Components MUST resolve via the M0
 helper (`scripts/sutando-config.sh workspace` from shell, or
-`from src.sutando_config import resolve_workspace` from Python) which reads
-`sutando.config.local.json` (per-clone, gitignored) and defaults to
-`<repo>/workspace/`.
+`from src.sutando_config import resolve_workspace` from Python), which honors
+`$SUTANDO_WORKSPACE_DIR`, then reads `sutando.config.local.json` (per-clone,
+gitignored), and defaults to `<repo>/workspace/`.
 
 `$SUTANDO_WORKSPACE` is no longer honored for workspace resolution as of v0.8;
-if set, it is still detected to fire a one-time deprecation warning and trigger
-one-time auto-migration via per-source sentinels (PR #1478), but the resolver
-ignores its value. The ad-hoc no-config-no-repo-root last-ditch fallback is
+if set without `$SUTANDO_WORKSPACE_DIR`, it is still detected to fire a one-time
+deprecation warning and trigger one-time auto-migration via per-source sentinels
+(PR #1478), but the resolver ignores its value. The ad-hoc no-config-no-repo-root last-ditch fallback is
 `~/sutando-workspace/` (was `~/.sutando/workspace/` pre-v0.8 — namespace
 retired per Mini opinion-requested 2026-06-06).
 

--- a/src/workspace_default.ts
+++ b/src/workspace_default.ts
@@ -11,15 +11,16 @@
  * services run first (via startup.sh) and handle the one-time dir-move from
  * any legacy repo-root install. TS callers rely on that having already run.
  *
- * Resolution order (post-v0.8 / #1440, via src/sutando_config.ts):
- *   1. sutando.config.local.json -> workspace.path (per-clone override)
- *   2. sutando.config.json -> workspace.path (tracked defaults)
- *   3. ${REPO_DIR}/workspace baked-in default
+ * Resolution order (via src/sutando_config.ts):
+ *   1. SUTANDO_WORKSPACE_DIR explicit operator override
+ *   2. sutando.config.local.json -> workspace.path (per-clone override)
+ *   3. sutando.config.json -> workspace.path (tracked defaults)
+ *   4. ${REPO_DIR}/workspace baked-in default
  *
  * $SUTANDO_WORKSPACE is no longer honored for resolution (removed in v0.8);
- * if set, the loader fires a one-time deprecation warning + triggers one-time
- * auto-migration via per-source sentinels (PR #1478), but the resolver
- * ignores its value. The ad-hoc no-config-no-repo-root last-ditch fallback
+ * if set without SUTANDO_WORKSPACE_DIR, the loader fires a one-time deprecation
+ * warning + triggers one-time auto-migration via per-source sentinels (PR #1478),
+ * but the resolver ignores its value. The ad-hoc no-config-no-repo-root last-ditch fallback
  * is `~/sutando-workspace/` (was `~/.sutando/workspace/` pre-v0.8 — namespace
  * retired per Mini opinion-requested 2026-06-06).
  */
@@ -35,16 +36,17 @@ import { resolveWorkspace as _resolveWorkspaceFromConfig } from './sutando_confi
  * **Delegates to `src/sutando_config.ts::resolveWorkspace`** as of the
  * M0 cutover. The new loader implements the resolution order:
  *
- *   1. sutando.config.local.json -> workspace.path (per-clone override)
- *   2. sutando.config.json -> workspace.path (tracked defaults)
- *   3. ${REPO_DIR}/workspace baked-in default
+ *   1. SUTANDO_WORKSPACE_DIR explicit operator override
+ *   2. sutando.config.local.json -> workspace.path (per-clone override)
+ *   3. sutando.config.json -> workspace.path (tracked defaults)
+ *   4. ${REPO_DIR}/workspace baked-in default
  *
  * This wrapper is preserved so existing callers don't need code changes
  * — the export name + signature + return type are unchanged. Post-v0.8
  * (#1440), $SUTANDO_WORKSPACE is no longer honored for workspace
- * resolution; if set, the loader fires a one-time deprecation warning
- * and triggers one-time auto-migration via per-source sentinels
- * (PR #1478), but the resolver ignores its value.
+ * resolution; if set without SUTANDO_WORKSPACE_DIR, the loader fires a
+ * one-time deprecation warning and triggers one-time auto-migration via
+ * per-source sentinels (PR #1478), but the resolver ignores its value.
  *
  * Default location is ${REPO_DIR}/workspace (in-repo). .env declarations
  * of SUTANDO_WORKSPACE are also detected and warned about; they do not

--- a/tests/sutando-config-swift.test.py
+++ b/tests/sutando-config-swift.test.py
@@ -50,7 +50,12 @@ class TestSutandoConfigSwift(unittest.TestCase):
     def tearDown(self) -> None:
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def run_probe(self, repo: Path, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    def run_probe(
+        self,
+        repo: Path,
+        extra_env: dict[str, str] | None = None,
+        cwd: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.pop("SUTANDO_WORKSPACE_DIR", None)
         env.pop("SUTANDO_TEST_MODE", None)
@@ -58,6 +63,7 @@ class TestSutandoConfigSwift(unittest.TestCase):
         return subprocess.run(
             [str(self.probe), str(repo)],
             env=env,
+            cwd=str(cwd) if cwd is not None else None,
             text=True,
             capture_output=True,
             check=False,
@@ -81,6 +87,28 @@ class TestSutandoConfigSwift(unittest.TestCase):
 
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertEqual(proc.stdout.strip(), "/from/swift/explicit-env")
+        self.assertEqual(proc.stderr, "")
+
+    def test_relative_workspace_dir_env_is_absolutized_against_cwd(self) -> None:
+        # Parity with the Python (`Path(...).resolve()`) and TS
+        # (`path.resolve(...)`) twins: a relative SUTANDO_WORKSPACE_DIR must
+        # come back absolute (resolved against cwd), never as a bare relative
+        # string — otherwise Sutando.app splits onto a different workspace.
+        repo = self.tmp / "repo-relative-env"
+        repo.mkdir()
+        run_cwd = self.tmp / "run-cwd"
+        run_cwd.mkdir()
+
+        proc = self.run_probe(
+            repo,
+            {"SUTANDO_WORKSPACE_DIR": "tmp/ws"},
+            cwd=run_cwd,
+        )
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        out = proc.stdout.strip()
+        self.assertTrue(out.startswith("/"), f"expected absolute path, got {out!r}")
+        self.assertEqual(out, os.path.realpath(run_cwd / "tmp" / "ws"))
         self.assertEqual(proc.stderr, "")
 
     def test_env_set_returns_config_path_not_env_path(self) -> None:

--- a/tests/sutando-config-swift.test.py
+++ b/tests/sutando-config-swift.test.py
@@ -52,6 +52,7 @@ class TestSutandoConfigSwift(unittest.TestCase):
 
     def run_probe(self, repo: Path, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
+        env.pop("SUTANDO_WORKSPACE_DIR", None)
         env.pop("SUTANDO_TEST_MODE", None)
         env.update(extra_env or {})
         return subprocess.run(
@@ -61,6 +62,26 @@ class TestSutandoConfigSwift(unittest.TestCase):
             capture_output=True,
             check=False,
         )
+
+    def test_workspace_dir_env_overrides_config_and_legacy_env(self) -> None:
+        repo = self.tmp / "repo-explicit-env"
+        repo.mkdir()
+        (repo / "sutando.config.local.json").write_text(
+            json.dumps({"workspace": {"path": "/from/swift/config"}}),
+            encoding="utf-8",
+        )
+
+        proc = self.run_probe(
+            repo,
+            {
+                "SUTANDO_WORKSPACE_DIR": "/from/swift/explicit-env",
+                "SUTANDO_WORKSPACE": "/from/swift/legacy-env",
+            },
+        )
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "/from/swift/explicit-env")
+        self.assertEqual(proc.stderr, "")
 
     def test_env_set_returns_config_path_not_env_path(self) -> None:
         repo = self.tmp / "repo-config"

--- a/tests/sutando-config.prod-path.test.py
+++ b/tests/sutando-config.prod-path.test.py
@@ -60,6 +60,7 @@ class TestProdPath(unittest.TestCase):
 
     def setUp(self) -> None:
         # Snapshot + clear env; reset per-process cache for warning state.
+        self._saved_workspace_dir = os.environ.pop("SUTANDO_WORKSPACE_DIR", None)
         self._saved_env = os.environ.pop("SUTANDO_WORKSPACE", None)
         self._saved_no_color = os.environ.pop("NO_COLOR", None)
         self._saved_test_mode = os.environ.pop("SUTANDO_TEST_MODE", None)
@@ -69,6 +70,10 @@ class TestProdPath(unittest.TestCase):
 
     def tearDown(self) -> None:
         _reset_cache_for_tests()
+        if self._saved_workspace_dir is None:
+            os.environ.pop("SUTANDO_WORKSPACE_DIR", None)
+        else:
+            os.environ["SUTANDO_WORKSPACE_DIR"] = self._saved_workspace_dir
         if self._saved_env is None:
             os.environ.pop("SUTANDO_WORKSPACE", None)
         else:

--- a/tests/sutando-config.prod-path.test.ts
+++ b/tests/sutando-config.prod-path.test.ts
@@ -43,15 +43,18 @@ function captureStderr(): CapturedStderr {
 }
 
 describe('sutando_config — production path (env-set, no TEST_MODE)', () => {
+	let savedWorkspaceDir: string | undefined;
 	let savedEnv: string | undefined;
 	let savedNoColor: string | undefined;
 	let savedTestMode: string | undefined;
 	let repo: string;
 
 	beforeEach(() => {
+		savedWorkspaceDir = process.env.SUTANDO_WORKSPACE_DIR;
 		savedEnv = process.env.SUTANDO_WORKSPACE;
 		savedNoColor = process.env.NO_COLOR;
 		savedTestMode = process.env.SUTANDO_TEST_MODE;
+		delete process.env.SUTANDO_WORKSPACE_DIR;
 		delete process.env.SUTANDO_WORKSPACE;
 		delete process.env.NO_COLOR;
 		delete process.env.SUTANDO_TEST_MODE;
@@ -61,6 +64,8 @@ describe('sutando_config — production path (env-set, no TEST_MODE)', () => {
 
 	afterEach(() => {
 		resetCacheForTests();
+		if (savedWorkspaceDir === undefined) delete process.env.SUTANDO_WORKSPACE_DIR;
+		else process.env.SUTANDO_WORKSPACE_DIR = savedWorkspaceDir;
 		if (savedEnv === undefined) delete process.env.SUTANDO_WORKSPACE;
 		else process.env.SUTANDO_WORKSPACE = savedEnv;
 		if (savedNoColor === undefined) delete process.env.NO_COLOR;

--- a/tests/sutando-config.test.py
+++ b/tests/sutando-config.test.py
@@ -2,7 +2,7 @@
 """Tests for src/sutando_config.py — the canonical workspace + vault loader.
 
 Covers the eight invariants Mini called out in the cold review of #1395:
-  1. $SUTANDO_WORKSPACE env var precedence over .local.json
+  1. $SUTANDO_WORKSPACE_DIR precedence over .local.json
   2. .local.json deep-merge over tracked sutando.config.json
      (dicts merge, arrays REPLACE wholesale)
   3. ${REPO_DIR} expansion in string values, NOT in keys
@@ -62,6 +62,7 @@ class TestSutandoConfig(unittest.TestCase):
 
     def setUp(self):
         # Stash any env var that could leak resolution between tests.
+        self._saved_workspace_dir = os.environ.pop("SUTANDO_WORKSPACE_DIR", None)
         self._saved_env = os.environ.pop("SUTANDO_WORKSPACE", None)
         _reset_cache_for_tests()
         # Each test gets its own tmp dir simulating a Sutando checkout.
@@ -70,14 +71,28 @@ class TestSutandoConfig(unittest.TestCase):
 
     def tearDown(self):
         _reset_cache_for_tests()
+        os.environ.pop("SUTANDO_WORKSPACE_DIR", None)
+        if self._saved_workspace_dir is not None:
+            os.environ["SUTANDO_WORKSPACE_DIR"] = self._saved_workspace_dir
         os.environ.pop("SUTANDO_WORKSPACE", None)
         if self._saved_env is not None:
             os.environ["SUTANDO_WORKSPACE"] = self._saved_env
         self._tmp.cleanup()
 
     # ------------------------------------------------------------------ #
-    #  1. v0.8: env var IGNORED; .local.json wins                         #
+    #  1. explicit env override wins; legacy env remains ignored          #
     # ------------------------------------------------------------------ #
+
+    def test_workspace_dir_env_var_overrides_local_json(self):
+        _write_config(self.repo, "sutando.config.json",
+                      {"workspace": {"path": "${REPO_DIR}/workspace"}})
+        _write_config(self.repo, "sutando.config.local.json",
+                      {"workspace": {"path": "/from/local"}})
+        os.environ["SUTANDO_WORKSPACE_DIR"] = "/from/explicit-env"
+        os.environ["SUTANDO_WORKSPACE"] = "/from/legacy-env"
+        os.environ.pop("SUTANDO_TEST_MODE", None)
+        resolved = resolve_workspace(repo_root=self.repo)
+        self.assertEqual(str(resolved), str(Path("/from/explicit-env").resolve()))
 
     def test_env_var_ignored_in_favor_of_local_json(self):
         # v0.8 contract: `$SUTANDO_WORKSPACE` is no longer honored.

--- a/tests/sutando-config.test.ts
+++ b/tests/sutando-config.test.ts
@@ -42,12 +42,15 @@ function writeConfig(repo: string, name: string, body: ConfigBody | string): str
 }
 
 describe('sutando_config loader', () => {
+	let savedWorkspaceDir: string | undefined;
 	let savedEnv: string | undefined;
 	let repo: string;
 
 	beforeEach(() => {
 		// Snapshot + clear env; reset per-process cache.
+		savedWorkspaceDir = process.env.SUTANDO_WORKSPACE_DIR;
 		savedEnv = process.env.SUTANDO_WORKSPACE;
+		delete process.env.SUTANDO_WORKSPACE_DIR;
 		delete process.env.SUTANDO_WORKSPACE;
 		resetCacheForTests();
 		repo = makeRepo();
@@ -55,14 +58,30 @@ describe('sutando_config loader', () => {
 
 	const restoreEnvAndRepo = () => {
 		resetCacheForTests();
+		delete process.env.SUTANDO_WORKSPACE_DIR;
+		if (savedWorkspaceDir !== undefined) process.env.SUTANDO_WORKSPACE_DIR = savedWorkspaceDir;
 		delete process.env.SUTANDO_WORKSPACE;
 		if (savedEnv !== undefined) process.env.SUTANDO_WORKSPACE = savedEnv;
 		if (repo) rmSync(repo, { recursive: true, force: true });
 	};
 
 	// ------------------------------------------------------------------ //
-	//  1. v0.8: env var IGNORED; .local.json wins                         //
+	//  1. explicit env override wins; legacy env remains ignored          //
 	// ------------------------------------------------------------------ //
+
+	it('SUTANDO_WORKSPACE_DIR overrides .local.json and legacy SUTANDO_WORKSPACE', () => {
+		writeConfig(repo, 'sutando.config.json', { workspace: { path: '${REPO_DIR}/workspace' } });
+		writeConfig(repo, 'sutando.config.local.json', { workspace: { path: '/from/local' } });
+		process.env.SUTANDO_WORKSPACE_DIR = '/from/explicit-env';
+		process.env.SUTANDO_WORKSPACE = '/from/legacy-env';
+		delete process.env.SUTANDO_TEST_MODE;
+		try {
+			const resolved = resolveWorkspace(repo);
+			assert.equal(resolved, resolve('/from/explicit-env'));
+		} finally {
+			restoreEnvAndRepo();
+		}
+	});
 
 	it('env var is ignored in favor of .local.json (v0.8)', () => {
 		// v0.8 contract: `$SUTANDO_WORKSPACE` is no longer honored.


### PR DESCRIPTION
## What changed
- Add `SUTANDO_WORKSPACE_DIR` as the highest-precedence workspace override in the Python, TypeScript, and Swift resolver twins.
- Keep legacy `SUTANDO_WORKSPACE` deprecated/ignored in production, with the existing test-mode escape hatch intact.
- Update workspace docs/comments so operators have one clear launch-time knob and durable per-clone config remains `sutando.config.local.json`.

## Why
Desktop/dev launches can currently split across workspaces when one process reads baked config and another core/session runs from a different checkout. A single explicit process-tree override gives launchers a simple way to force every service onto the same workspace without editing config files.

## Review first
- `src/sutando_config.py`
- `src/sutando_config.ts`
- `src/Sutando/SutandoConfig.swift`
- `tests/sutando-config.*`
- `docs/workspace-config.md`

## Duplicate check
Checked exact and broader searches for `SUTANDO_WORKSPACE_DIR workspace override` and `workspace path config` across open/recent PRs/issues. Related cleanup exists, but I did not find an existing PR adding this explicit override.

## Verification
- `python3 tests/sutando-config.test.py` — pass
- `python3 tests/sutando-config.prod-path.test.py` — pass
- `npx tsx --test tests/sutando-config.test.ts` — pass
- `npx tsx --test tests/sutando-config.prod-path.test.ts` — pass
- `python3 tests/sutando-config-swift.test.py` — pass
- `python3 -m py_compile src/sutando_config.py src/workspace_default.py src/agent-api.py` — pass
- `SUTANDO_WORKSPACE_DIR=/tmp/sutando-core-explicit-workspace bash scripts/sutando-config.sh workspace` — printed `/private/tmp/sutando-core-explicit-workspace`

## Risks
`SUTANDO_WORKSPACE_DIR` is intentionally process-local. Durable installs should still use `sutando.config.local.json` when they want the setting to survive launcher/env changes.
