### PR TITLE
feat(webui): detect direct-reachability endpoints (tailnet + LAN) for off-localhost voice calling

### DIFF
--- a/src/reachability-endpoints.ts
+++ b/src/reachability-endpoints.ts
@@ -1,0 +1,147 @@
+/**
+ * Direct-reachability endpoint detection (US-10, Tier 2b) — "call your agent
+ * from another device and still reach YOUR core, directly, without routing
+ * through the cloud."
+ *
+ * A remote client can't reach the core's `localhost`, so the core advertises a
+ * directly-reachable URL. This module is the CORE-side detection half: compose
+ * the webUI endpoint (the HTTP port, which fronts the opt-in /ws voice proxy
+ * from PR #2021) on each direct path the core can offer. The advertise TRANSPORT
+ * (how the endpoint reaches the remote client) is a separate piece.
+ *
+ * Two direct candidates, in the resolver's preferred order:
+ *   1. tailnet — a mesh-VPN address (e.g. Tailscale). Superset of LAN: reaches
+ *      the core from the same Wi-Fi AND from a different network entirely, with a
+ *      STABLE address (doesn't change per-Wi-Fi) and NAT-traversal + encryption
+ *      handled by the mesh. Preferred when present.
+ *   2. lan — a same-subnet private IPv4 (RFC1918). Works only when both devices
+ *      share the LAN, but needs nothing installed on the client.
+ *
+ * Both are gated by SUTANDO_LAN_SHARE — nothing is advertised unless the operator
+ * opted into the /ws proxy that makes the core reachable off-localhost.
+ */
+import { networkInterfaces } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const CLIENT_PORT = Number(process.env.CLIENT_PORT) || 8080;
+
+/** True when sharing the core off-localhost is opted in (mirrors web-client.ts). */
+export function lanShareEnabled(): boolean {
+	return /^(1|true|yes|on)$/i.test(process.env.SUTANDO_LAN_SHARE || '');
+}
+
+// ---------------------------------------------------------------------------
+// LAN (same-subnet private IPv4)
+// ---------------------------------------------------------------------------
+
+/** Is this an RFC1918 private-LAN IPv4 (10/8, 172.16/12, 192.168/16)? */
+export function isPrivateLanIpv4(ip: string): boolean {
+	const m = ip.split('.').map(Number);
+	if (m.length !== 4 || m.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return false;
+	if (m[0] === 10) return true;
+	if (m[0] === 172 && m[1] >= 16 && m[1] <= 31) return true;
+	if (m[0] === 192 && m[1] === 168) return true;
+	return false; // excludes loopback (127), link-local (169.254), CGNAT/tailnet (100.64/10), public
+}
+
+/**
+ * The machine's primary private-LAN IPv4, or null if none. Deterministic:
+ * lowest-named interface first. Tailnet (100.64/10) and link-local are excluded
+ * here — the tailnet path is its own candidate below.
+ */
+export function detectLanIpv4(ifaces = networkInterfaces()): string | null {
+	const candidates: string[] = [];
+	for (const name of Object.keys(ifaces).sort()) {
+		for (const addr of ifaces[name] || []) {
+			if (addr.family === 'IPv4' && !addr.internal && isPrivateLanIpv4(addr.address)) {
+				candidates.push(addr.address);
+			}
+		}
+	}
+	return candidates[0] ?? null;
+}
+
+/** LAN webUI endpoint (e.g. `http://192.168.1.5:8080`), or null. */
+export function lanEndpointUrl(): string | null {
+	if (!lanShareEnabled()) return null;
+	const ip = detectLanIpv4();
+	return ip ? `http://${ip}:${CLIENT_PORT}` : null;
+}
+
+// ---------------------------------------------------------------------------
+// Tailnet (mesh VPN — Tailscale)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `tailscale status --json` output into the core's tailnet host, or null
+ * when the node isn't up / has no tailnet address. Pure (no subprocess) so it's
+ * unit-testable. Prefers the MagicDNS name (stable, human-readable, survives IP
+ * churn) and falls back to the 100.x IPv4 when MagicDNS is unavailable.
+ */
+export function parseTailnetHost(status: unknown): string | null {
+	if (!status || typeof status !== 'object') return null;
+	const self = (status as Record<string, unknown>).Self;
+	if (!self || typeof self !== 'object') return null;
+	const s = self as Record<string, unknown>;
+	// Only advertise when the node is actually online on the tailnet.
+	if (s.Online === false) return null;
+	const dns = typeof s.DNSName === 'string' ? s.DNSName.replace(/\.$/, '') : '';
+	if (dns) return dns;
+	const ips = Array.isArray(s.TailscaleIPs) ? (s.TailscaleIPs as unknown[]) : [];
+	const v4 = ips.find((ip) => typeof ip === 'string' && /^100\./.test(ip));
+	return typeof v4 === 'string' ? v4 : null;
+}
+
+/**
+ * The core's tailnet host via the local `tailscale` CLI, or null when tailscale
+ * is absent/down. Short timeout so a hung/absent binary never blocks startup.
+ * Injectable runner keeps it testable.
+ */
+export function detectTailnetHost(
+	run: () => string | null = () => {
+		try {
+			const r = spawnSync('tailscale', ['status', '--json'], {
+				timeout: 1500,
+				encoding: 'utf8',
+			});
+			return r.status === 0 && r.stdout ? r.stdout : null;
+		} catch {
+			return null;
+		}
+	},
+): string | null {
+	const out = run();
+	if (!out) return null;
+	try {
+		return parseTailnetHost(JSON.parse(out));
+	} catch {
+		return null;
+	}
+}
+
+/** Tailnet webUI endpoint (e.g. `http://host.tailnet.ts.net:8080`), or null. */
+export function tailnetEndpointUrl(): string | null {
+	if (!lanShareEnabled()) return null;
+	const host = detectTailnetHost();
+	return host ? `http://${host}:${CLIENT_PORT}` : null;
+}
+
+// ---------------------------------------------------------------------------
+// Combined advertisement
+// ---------------------------------------------------------------------------
+
+export interface DirectEndpoints {
+	/** Mesh-VPN endpoint (Tailscale). Preferred — reaches the core off-LAN too. */
+	tailnet: string | null;
+	/** Same-subnet LAN endpoint. Fallback when both devices share the Wi-Fi. */
+	lan: string | null;
+}
+
+/**
+ * All direct endpoints the core can advertise right now, in resolver-preferred
+ * order (tailnet before lan). Empty object-values when LAN sharing is off. The
+ * client resolver tries these ahead of relay/cloud; first reachable wins.
+ */
+export function directEndpoints(): DirectEndpoints {
+	return { tailnet: tailnetEndpointUrl(), lan: lanEndpointUrl() };
+}

--- a/tests/reachability-endpoints.test.ts
+++ b/tests/reachability-endpoints.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	isPrivateLanIpv4,
+	detectLanIpv4,
+	lanEndpointUrl,
+	parseTailnetHost,
+	detectTailnetHost,
+	tailnetEndpointUrl,
+	directEndpoints,
+	lanShareEnabled,
+} from '../src/reachability-endpoints.js';
+
+// US-10 / Tier 2b: the core detects the direct endpoints it can advertise
+// (tailnet preferred, LAN fallback). These are the CORE-side halves; both are
+// gated behind SUTANDO_LAN_SHARE so nothing is advertised unless the /ws proxy
+// (PR #2021) is opted in.
+
+const origShare = process.env.SUTANDO_LAN_SHARE;
+const origPort = process.env.CLIENT_PORT;
+beforeEach(() => {
+	delete process.env.SUTANDO_LAN_SHARE;
+	delete process.env.CLIENT_PORT;
+});
+afterEach(() => {
+	if (origShare === undefined) delete process.env.SUTANDO_LAN_SHARE;
+	else process.env.SUTANDO_LAN_SHARE = origShare;
+	if (origPort === undefined) delete process.env.CLIENT_PORT;
+	else process.env.CLIENT_PORT = origPort;
+});
+
+describe('isPrivateLanIpv4', () => {
+	it('accepts RFC1918 ranges', () => {
+		for (const ip of ['10.0.0.4', '172.16.5.9', '172.31.255.1', '192.168.1.5']) {
+			assert.equal(isPrivateLanIpv4(ip), true, ip);
+		}
+	});
+	it('rejects loopback, link-local, tailnet/CGNAT, and public', () => {
+		for (const ip of ['127.0.0.1', '169.254.1.1', '100.115.82.19', '8.8.8.8', '172.32.0.1']) {
+			assert.equal(isPrivateLanIpv4(ip), false, ip);
+		}
+	});
+	it('rejects malformed input', () => {
+		for (const ip of ['', 'not.an.ip', '10.0.0', '999.1.1.1', '1.2.3.4.5']) {
+			assert.equal(isPrivateLanIpv4(ip), false, ip);
+		}
+	});
+});
+
+describe('detectLanIpv4', () => {
+	it('picks the private IPv4, skipping internal/tailnet/ipv6', () => {
+		const ifaces = {
+			lo0: [{ address: '127.0.0.1', family: 'IPv4', internal: true } as any],
+			en0: [
+				{ address: 'fe80::1', family: 'IPv6', internal: false } as any,
+				{ address: '192.168.1.42', family: 'IPv4', internal: false } as any,
+			],
+			utun3: [{ address: '100.115.82.19', family: 'IPv4', internal: false } as any],
+		};
+		assert.equal(detectLanIpv4(ifaces), '192.168.1.42');
+	});
+	it('returns null when only loopback/tailnet present', () => {
+		const ifaces = {
+			lo0: [{ address: '127.0.0.1', family: 'IPv4', internal: true } as any],
+			utun3: [{ address: '100.115.82.19', family: 'IPv4', internal: false } as any],
+		};
+		assert.equal(detectLanIpv4(ifaces), null);
+	});
+	it('is deterministic across interface ordering (lowest name wins)', () => {
+		const ifaces = {
+			en5: [{ address: '10.0.0.9', family: 'IPv4', internal: false } as any],
+			en0: [{ address: '192.168.1.7', family: 'IPv4', internal: false } as any],
+		};
+		assert.equal(detectLanIpv4(ifaces), '192.168.1.7');
+	});
+});
+
+describe('parseTailnetHost', () => {
+	it('prefers the MagicDNS name (trailing dot stripped)', () => {
+		const status = {
+			Self: {
+				DNSName: 'qingyuns-macbook-pro.taila1a7c4.ts.net.',
+				TailscaleIPs: ['100.115.82.19', 'fd7a:115c:a1e0::b73b:5214'],
+				Online: true,
+			},
+		};
+		assert.equal(parseTailnetHost(status), 'qingyuns-macbook-pro.taila1a7c4.ts.net');
+	});
+	it('falls back to the 100.x IPv4 when MagicDNS is absent', () => {
+		const status = { Self: { DNSName: '', TailscaleIPs: ['100.115.82.19', 'fd7a::1'] } };
+		assert.equal(parseTailnetHost(status), '100.115.82.19');
+	});
+	it('returns null when the node is offline', () => {
+		const status = { Self: { DNSName: 'x.ts.net.', TailscaleIPs: ['100.1.1.1'], Online: false } };
+		assert.equal(parseTailnetHost(status), null);
+	});
+	it('returns null for missing/garbage self', () => {
+		assert.equal(parseTailnetHost(null), null);
+		assert.equal(parseTailnetHost({}), null);
+		assert.equal(parseTailnetHost({ Self: { TailscaleIPs: [] } }), null);
+		assert.equal(parseTailnetHost({ Self: { TailscaleIPs: ['fd7a::1'] } }), null); // no v4
+	});
+});
+
+describe('detectTailnetHost (injected runner)', () => {
+	it('parses a good status blob', () => {
+		const run = () => JSON.stringify({ Self: { DNSName: 'host.ts.net.', Online: true } });
+		assert.equal(detectTailnetHost(run), 'host.ts.net');
+	});
+	it('returns null when tailscale is absent (runner yields null)', () => {
+		assert.equal(detectTailnetHost(() => null), null);
+	});
+	it('returns null on unparseable output rather than throwing', () => {
+		assert.equal(detectTailnetHost(() => 'not json'), null);
+	});
+});
+
+describe('endpoint URLs are gated by SUTANDO_LAN_SHARE', () => {
+	it('lanEndpointUrl/tailnetEndpointUrl/directEndpoints are null/empty when unshared', () => {
+		assert.equal(lanShareEnabled(), false);
+		assert.equal(lanEndpointUrl(), null);
+		assert.equal(tailnetEndpointUrl(), null);
+		assert.deepEqual(directEndpoints(), { tailnet: null, lan: null });
+	});
+});


### PR DESCRIPTION
## What

Detect the directly-reachable URLs the core can advertise, so a device **other than the one running the core** can open a web voice call straight to it — without routing audio through the cloud.

A remote client can't reach the core's `localhost`, so it needs a reachable address. This is the core-side detection half; it returns two candidates in preferred order:

- **`tailnet`** — a mesh-VPN address (e.g. Tailscale). A superset of LAN: reachable both on the same network and remotely, with a stable address and NAT-traversal handled by the mesh. Parsed from `tailscale status --json` — MagicDNS name preferred, `100.x` IPv4 fallback.
- **`lan`** — a same-subnet RFC1918 IPv4; needs nothing installed on the client, but only works when both devices share the network.

## Design notes

- **Opt-in gated.** Both endpoints are `null` unless `SUTANDO_LAN_SHARE` is set — the same gate that enables the off-localhost `/ws` voice proxy (#2021). Nothing is advertised unless that proxy is on.
- **Non-blocking + testable.** The `tailscale` call has a short subprocess timeout so an absent/hung binary never stalls startup, and the runner is injectable so the parse path is unit-tested without the binary.
- **Correct exclusions.** LAN detection excludes loopback, link-local, and CGNAT/tailnet ranges (the tailnet path is its own candidate), so the LAN address is genuinely same-subnet.

## Scope

This PR is the detection primitive only. The **advertise transport** (how the endpoint reaches a remote client) and the **client-side resolver wiring** (probe the candidate, fall back to cloud when unreachable) are separate follow-ups. Kept small and side-effect-free on purpose.

## Tests

- `tests/reachability-endpoints.test.ts` — 14 cases: RFC1918 classification, interface selection determinism, tailnet status parsing (MagicDNS vs IPv4 fallback, offline node, garbage input), injected-runner paths, and the share-gate. All pass.
- `tsc --noEmit` clean.
