### PR TITLE
feat(webui): TLS-aware tailnet endpoint + tailscale-serve helper (browser wss reach)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,18 @@ PORT=9900
 # OPTIONAL — add these when you need specific features
 # ============================================================
 
+# Call your agent from another device (Tier 2b — same Wi-Fi or your tailnet).
+# The voice WS (PORT above) binds loopback only, so another device can't reach
+# it directly. These opt you into a LAN-reachable /ws proxy on the webUI port.
+# Off by default: enabling exposes this core's agent (the voice WS has no auth),
+# so it's a per-network choice.
+#   SUTANDO_LAN_SHARE=1        # serve the /ws voice proxy off-localhost
+#   CLIENT_PORT=8080           # webUI + /ws proxy port (default 8080)
+# For a browser on an HTTPS page to reach the tailnet path it needs wss:// — run
+# `bash scripts/tailscale-serve-voice.sh` (fronts the webUI with a Tailscale TLS
+# cert), then set this so the advertised endpoint is https:// (browser-ready):
+#   SUTANDO_TAILNET_SERVE=1
+
 # Optional: Twilio for phone calls and SMS
 # Get started: https://www.twilio.com (free trial available, ~$1/month for a number)
 # Enables: crisis phone alerts, meeting dial-in, incoming call handling

--- a/scripts/tailscale-serve-voice.sh
+++ b/scripts/tailscale-serve-voice.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Front the Sutando webUI with Tailscale-terminated HTTPS, so a browser on
+# another device on your tailnet can open a voice call straight to this core.
+#
+# Why this exists: a browser on an HTTPS page blocks insecure ws:// to a
+# non-localhost host (mixed content), so the tailnet voice path only works over
+# wss://. `tailscale serve` terminates TLS with an auto-provisioned, auto-renewed
+# cert on this machine's MagicDNS name and reverse-proxies to loopback — where
+# the webUI's existing /ws proxy accepts the (now loopback-sourced) upgrade. No
+# cert management, no extra serving code.
+#
+# Prerequisites:
+#   - `tailscale up` (this node on the tailnet)
+#   - HTTPS enabled for the tailnet (admin console → DNS → "Enable HTTPS")
+#   - the webUI running with SUTANDO_LAN_SHARE=1 on CLIENT_PORT (so /ws is live)
+#
+# After running this, also export SUTANDO_TAILNET_SERVE=1 for the core so the
+# advertised tailnet endpoint becomes https:// (browser-ready) instead of
+# http://host:CLIENT_PORT (native-only). Then restart the core.
+#
+# Undo:  tailscale serve reset
+set -euo pipefail
+
+PORT="${CLIENT_PORT:-8080}"
+
+if ! command -v tailscale >/dev/null 2>&1; then
+	echo "error: tailscale CLI not found. Install Tailscale and run 'tailscale up' first." >&2
+	exit 1
+fi
+
+# Fail early with a clear message if the node isn't up / has no tailnet name.
+DNSNAME="$(tailscale status --json 2>/dev/null | python3 -c 'import json,sys; s=json.load(sys.stdin).get("Self",{}); print((s.get("DNSName") or "").rstrip("."))' 2>/dev/null || true)"
+if [ -z "$DNSNAME" ]; then
+	echo "error: this node has no tailnet DNS name (is 'tailscale up' done?)." >&2
+	exit 1
+fi
+
+echo "Serving the webUI (127.0.0.1:${PORT}) over HTTPS on your tailnet…"
+# --bg = run in the background (persists). Exposes https://<magicdns>/ on :443,
+# forwarding to the local webUI. Idempotent-ish: re-running updates the mapping.
+tailscale serve --bg "${PORT}"
+
+echo
+echo "  ✓ webUI now reachable at:  https://${DNSNAME}/"
+echo "    voice WS for clients:     wss://${DNSNAME}/ws"
+echo
+echo "  Next, so the core advertises the https endpoint:"
+echo "    export SUTANDO_TAILNET_SERVE=1   # (and SUTANDO_LAN_SHARE=1) then restart the core"
+echo
+echo "  To undo:  tailscale serve reset"

--- a/src/reachability-endpoints.ts
+++ b/src/reachability-endpoints.ts
@@ -119,11 +119,43 @@ export function detectTailnetHost(
 	}
 }
 
-/** Tailnet webUI endpoint (e.g. `http://host.tailnet.ts.net:8080`), or null. */
+/**
+ * True when the operator has fronted the webUI with `tailscale serve` (TLS
+ * termination on the MagicDNS name, auto-provisioned cert, default :443). This
+ * is the mode that lets a BROWSER on an HTTPS page reach the core: a browser
+ * blocks insecure `ws://` to a non-localhost host as mixed content, so the
+ * tailnet voice path only works over `wss://` — which `tailscale serve` provides
+ * without any cert management here (it forwards to loopback:CLIENT_PORT, where
+ * the existing /ws proxy accepts the loopback-sourced upgrade).
+ *
+ * Set after running `scripts/tailscale-serve-voice.sh` (or `tailscale serve
+ * --bg <CLIENT_PORT>`).
+ */
+export function tailnetServeEnabled(): boolean {
+	return /^(1|true|yes|on)$/i.test(process.env.SUTANDO_TAILNET_SERVE || '');
+}
+
+/**
+ * Compose the tailnet endpoint URL for a host. Pure (serve flag injectable) so
+ * the scheme switch is unit-tested. With serve on → HTTPS on the MagicDNS name,
+ * no explicit port (`tailscale serve` fronts :443); off → plain HTTP on
+ * CLIENT_PORT.
+ */
+export function composeTailnetUrl(host: string, serve: boolean = tailnetServeEnabled()): string {
+	return serve ? `https://${host}` : `http://${host}:${CLIENT_PORT}`;
+}
+
+/**
+ * Tailnet webUI endpoint, or null. With `tailscale serve` on (SUTANDO_TAILNET_SERVE)
+ * it's HTTPS on the MagicDNS name with no explicit port (`https://host.ts.net`)
+ * — browser-ready, the client derives `wss://host.ts.net/ws`. Otherwise it's
+ * plain HTTP on CLIENT_PORT (`http://host:8080`), usable by native/non-browser
+ * clients only (a browser on an HTTPS page can't open ws:// to it).
+ */
 export function tailnetEndpointUrl(): string | null {
 	if (!lanShareEnabled()) return null;
 	const host = detectTailnetHost();
-	return host ? `http://${host}:${CLIENT_PORT}` : null;
+	return host ? composeTailnetUrl(host) : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -625,6 +625,23 @@ else
   echo "  ✓ web client (already running)"
 fi
 
+# 2b. Tailnet HTTPS front for browser wss:// voice reach (opt-in).
+# When SUTANDO_TAILNET_SERVE is on, front the webUI with `tailscale serve` so a
+# browser on another device on your tailnet can open wss:// to the /ws proxy
+# (plain ws:// to a non-localhost host is blocked as mixed content from an HTTPS
+# page). Best-effort: a missing prerequisite (tailscale down, HTTPS not enabled
+# for the tailnet) must NOT fail startup — the helper prints its own diagnostics
+# to the log. `tailscale serve --bg` is idempotent, so re-running each boot is
+# safe. Pairs with SUTANDO_LAN_SHARE=1 (which the helper reminds you to set).
+if [[ "${SUTANDO_TAILNET_SERVE:-}" =~ ^(1|true|yes|on)$ ]]; then
+  echo "  Fronting webUI with tailscale serve (SUTANDO_TAILNET_SERVE on)..."
+  if bash "$REPO/scripts/tailscale-serve-voice.sh" >> "$LOGS_DIR/tailscale-serve.log" 2>&1; then
+    echo "  ✓ tailscale serve (browser wss:// tailnet reach)"
+  else
+    echo "  ⚠ tailscale serve skipped — see $LOGS_DIR/tailscale-serve.log"
+  fi
+fi
+
 # 3. Dashboard (port 7844)
 reap_wedged_listener 7844 dashboard
 if ! lsof -i :7844 > /dev/null 2>&1; then

--- a/tests/reachability-endpoints.test.ts
+++ b/tests/reachability-endpoints.test.ts
@@ -9,6 +9,8 @@ import {
 	tailnetEndpointUrl,
 	directEndpoints,
 	lanShareEnabled,
+	tailnetServeEnabled,
+	composeTailnetUrl,
 } from '../src/reachability-endpoints.js';
 
 // US-10 / Tier 2b: the core detects the direct endpoints it can advertise
@@ -18,15 +20,19 @@ import {
 
 const origShare = process.env.SUTANDO_LAN_SHARE;
 const origPort = process.env.CLIENT_PORT;
+const origServe = process.env.SUTANDO_TAILNET_SERVE;
 beforeEach(() => {
 	delete process.env.SUTANDO_LAN_SHARE;
 	delete process.env.CLIENT_PORT;
+	delete process.env.SUTANDO_TAILNET_SERVE;
 });
 afterEach(() => {
 	if (origShare === undefined) delete process.env.SUTANDO_LAN_SHARE;
 	else process.env.SUTANDO_LAN_SHARE = origShare;
 	if (origPort === undefined) delete process.env.CLIENT_PORT;
 	else process.env.CLIENT_PORT = origPort;
+	if (origServe === undefined) delete process.env.SUTANDO_TAILNET_SERVE;
+	else process.env.SUTANDO_TAILNET_SERVE = origServe;
 });
 
 describe('isPrivateLanIpv4', () => {
@@ -112,6 +118,25 @@ describe('detectTailnetHost (injected runner)', () => {
 	});
 	it('returns null on unparseable output rather than throwing', () => {
 		assert.equal(detectTailnetHost(() => 'not json'), null);
+	});
+});
+
+describe('composeTailnetUrl — TLS scheme switch (wss:// enablement)', () => {
+	const host = 'qingyuns-macbook-pro.taila1a7c4.ts.net';
+	it('serve OFF → plain http on CLIENT_PORT (native-only path)', () => {
+		assert.equal(composeTailnetUrl(host, false), `http://${host}:8080`);
+	});
+	it('serve ON → https on the MagicDNS name, no explicit port (browser wss-ready)', () => {
+		// tailscale serve fronts :443, so the client derives wss://host/ws — which
+		// a browser on an HTTPS page can open (plain ws:// would be blocked).
+		assert.equal(composeTailnetUrl(host, true), `https://${host}`);
+	});
+	it('reads the SUTANDO_TAILNET_SERVE env when serve arg omitted', () => {
+		assert.equal(tailnetServeEnabled(), false);
+		assert.equal(composeTailnetUrl(host), `http://${host}:8080`);
+		process.env.SUTANDO_TAILNET_SERVE = '1';
+		assert.equal(tailnetServeEnabled(), true);
+		assert.equal(composeTailnetUrl(host), `https://${host}`);
 	});
 });
 


### PR DESCRIPTION
## What

Makes the tailnet voice path actually connect **from a browser**. A browser on an HTTPS page blocks insecure `ws://` to a non-localhost host (mixed content), so reaching a self-hosted core over the tailnet needs `wss://`. This wires that up without adding any TLS/cert code to the core.

## How

Lean on **`tailscale serve`**, which terminates TLS with an auto-provisioned, auto-renewed cert on the node's MagicDNS name and reverse-proxies to loopback. The `/ws` upgrade then arrives from `127.0.0.1`, where the existing opt-in proxy (#2021) already accepts a loopback-sourced upgrade — so there's nothing new to serve and no cert to manage.

- **`reachability-endpoints.ts`** — `tailnetEndpointUrl()` is now TLS-aware via `SUTANDO_TAILNET_SERVE`:
  - **on** → `https://<magicdns>` (no explicit port; serve fronts `:443`) → the client derives `wss://<magicdns>/ws`, browser-ready.
  - **off** → `http://<host>:CLIENT_PORT` as before (native / non-browser clients only).
  - Extracted a pure `composeTailnetUrl(host, serve)` so the scheme switch is unit-tested deterministically.
- **`scripts/tailscale-serve-voice.sh`** — one command (`tailscale serve --bg CLIENT_PORT`) with prerequisite checks (tailscale present, node has a MagicDNS name) and clear next-steps; `tailscale serve reset` undoes it.

## Why this shape

The alternative — serving HTTPS directly from the webUI — means loading/rotating certs and a new failure surface. `tailscale serve` is purpose-built for exactly this (secure intra-tailnet exposure with managed certs), and #2021 already left the loopback reverse-proxy door open for it. Lower friction, less code, less to break.

## Scope / follow-ups

Core-side only. The client resolver consuming an `https://` tailnet endpoint as a `wss://` candidate is a client-repo change (separate). This PR is inert by default — `SUTANDO_TAILNET_SERVE` unset → behavior unchanged.

## Tests

- `tests/reachability-endpoints.test.ts` — **17/17** (adds the scheme-switch cases: serve on→https-no-port, off→http:port, env-read path).
- `tsc --noEmit` clean; `bash -n` clean. Live-verified on a tailnet (serve-off → `http://host:8080`, serve-on → `https://host`).
