### PR TITLE
fix(restart): cycle slack-bridge, gateway-bridge, and obs collector on restart

### DIFF
--- a/src/restart.sh
+++ b/src/restart.sh
@@ -14,6 +14,9 @@ pkill -f "agent-api.py" 2>/dev/null
 pkill -f "screen-capture-server" 2>/dev/null
 pkill -f "telegram-bridge" 2>/dev/null
 pkill -f "discord-bridge" 2>/dev/null
+pkill -f "slack-bridge" 2>/dev/null
+pkill -f "remote-gateway-bridge" 2>/dev/null
+pkill -f "observability/boot" 2>/dev/null
 pkill -f "watch-tasks" 2>/dev/null
 pkill -f "conversation-server" 2>/dev/null
 pkill -f "ngrok" 2>/dev/null
@@ -55,7 +58,8 @@ fi
 # startup.sh's recompile-replace path.
 STOP_PATTERNS=(
     "voice-agent" "web-client.ts" "dashboard.py" "agent-api.py"
-    "screen-capture-server" "telegram-bridge" "discord-bridge" "watch-tasks"
+    "screen-capture-server" "telegram-bridge" "discord-bridge" "slack-bridge"
+    "remote-gateway-bridge" "observability/boot" "watch-tasks"
     "conversation-server" "ngrok" "src/Sutando/Sutando"
 )
 for _ in $(seq 1 30); do


### PR DESCRIPTION
## What

Add three background services to `restart.sh`'s stop list so a restart actually cycles them:

- `slack-bridge`
- `remote-gateway-bridge`
- `observability/boot` (the opt-in obs collector)

Each is added to both the `pkill` block and the `STOP_PATTERNS` drain-wait array.

## Why

`restart.sh` keeps a hand-maintained list of services to kill, parallel to the list `startup.sh` launches. The two drifted: these three services were each added to `startup.sh` in later feature PRs, but `restart.sh`'s list was never updated to match.

- `slack-bridge` → added to `startup.sh` in #867
- `remote-gateway-bridge` → added in #1911
- obs collector → added in #1671

`restart.sh`'s service list was last synced well before those landed. Neither slack nor the gateway was ever present in `restart.sh`, so this is drift/oversight, not a deliberate exclusion.

The bug was masked because `startup.sh` guards each launch with an idempotency check (`pgrep` for the gateway, `lsof` on the port for slack/collector). On restart the old process was never killed, so startup saw "already running" and skipped relaunch — the service kept running and nothing looked broken. The only symptom: **code changes to these three never take effect on `restart.sh`**; you had to `pkill` them by hand. (Observed live: the gateway bridge had been up 1d+ across restarts.)

## Deliberately NOT added

`core_heartbeat.py` is intentionally left out. It's the per-host core liveness signal, and `restart.sh` explicitly does not touch the core agent. It also unlinks its `.alive` file on SIGTERM, so killing it during a services-only restart would briefly signal "core down" to peers. Leaving it running is correct.

## Verification

- `bash -n src/restart.sh` — passes.
- Confirmed `startup.sh` relaunches each after it's killed: slack (`src/startup.sh:910`), gateway (`:845`, `pgrep` guard), collector (`:574`, `lsof` guard) — so nothing is killed that startup won't bring back.

## Follow-up (not in this PR)

The underlying issue is two independently hand-maintained lists (startup launches vs restart kills) with no enforcement keeping them in sync. A structural fix — a single shared service table both scripts read — would prevent recurrence. Happy to open a tracking issue if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
