### PR TITLE
fix(core): require tmux session for launcher health

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -36,6 +36,38 @@ SESSION="sutando-core"
 export SUTANDO_CORE_SESSION=1
 CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1)
 
+tmux_available() {
+  command -v tmux > /dev/null 2>&1
+}
+
+tmux_session_exists() {
+  tmux_available || return 1
+  tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null
+}
+
+tmux_session_command() {
+  tmux_available || return 1
+  tmux -S "$TMUX_SOCKET" display-message -p -t "$SESSION" '#{pane_current_command}' 2>/dev/null
+}
+
+tmux_core_session_running() {
+  tmux_session_exists || return 1
+  [ "$(tmux_session_command)" = "claude" ]
+}
+
+core_claude_pids() {
+  pgrep -x claude 2>/dev/null | while read -r pid; do
+    args="$(ps -p "$pid" -o args= 2>/dev/null || true)"
+    case "$args" in
+      *"--name $SESSION"*|*"--name=$SESSION"*) echo "$pid" ;;
+    esac
+  done
+}
+
+core_claude_running() {
+  [ -n "$(core_claude_pids)" ]
+}
+
 # Optional working-directory override for the core `claude` process.
 #   - Unset (upstream default): no override — the core launches from $REPO (the
 #     script's cwd), exactly as before. Zero behavior change for OSS installs.
@@ -264,14 +296,17 @@ fi
 # Safe callers: Sutando.app menu, terminal one-off, future health-check
 # emit-task. Unsafe: a future agent processing a "restart core" task by
 # exec'ing this script from within sutando-core. Per Mini's #608 review.
-if [ "$1" = "--restart" ]; then
-  if tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null; then
+if [ "${1:-}" = "--restart" ]; then
+  if tmux_session_exists || core_claude_running; then
     echo "Killing existing $SESSION session..."
     tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION" 2>/dev/null || true
+    core_claude_pids | while read -r pid; do
+      [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+    done
     # Poll for actual shutdown — robust on slow machines, faster on fast
     # ones (~1s ceiling) than a fixed sleep.
     for _ in 1 2 3 4 5; do
-      tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null || break
+      tmux_session_exists || core_claude_running || break
       sleep 0.2
     done
   fi
@@ -302,9 +337,12 @@ apply_tmux_defaults() {
   tmux -S "$TMUX_SOCKET" bind -n WheelDownPane send-keys -M 2>/dev/null || true
 }
 
-# Already running — attach if interactive, else exit cleanly. This branch
-# also catches the !--restart path so re-running the script is idempotent.
-if tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null; then
+# Already running — attach if interactive, else exit cleanly. A healthy managed
+# core is the tmux session itself, not a fuzzy process-name match. `pgrep -f
+# "claude.*--name.*sutando-core"` also matches orphaned `tmux new-session ...`
+# launcher processes because their argv contains the embedded claude command;
+# those stale launchers used to make startup exit while no tmux session existed.
+if tmux_core_session_running; then
   apply_tmux_defaults
   if [ -t 1 ] && command -v tmux > /dev/null 2>&1; then
     echo "Attaching to existing $SESSION (Ctrl-b d to detach)..."
@@ -313,6 +351,11 @@ if tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null; then
   echo "$SESSION already running."
   echo "To attach: tmux -S $TMUX_SOCKET attach -t $SESSION"
   exit 0
+fi
+
+if tmux_session_exists; then
+  echo "  ⚠ $SESSION tmux session exists but pane is not Claude Code — restarting it" >&2
+  tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION" 2>/dev/null || true
 fi
 
 # Auto-install tmux via Homebrew if missing. Sutando.app's

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -45,11 +45,6 @@ tmux_session_exists() {
   tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null
 }
 
-tmux_session_command() {
-  tmux_available || return 1
-  tmux -S "$TMUX_SOCKET" display-message -p -t "$SESSION" '#{pane_current_command}' 2>/dev/null
-}
-
 # A managed core is alive when the tmux session EXISTS and a `claude --name
 # sutando-core` process is running under it. Do NOT gate on the pane's current
 # foreground command: a healthy core that is mid-tool shows the pane cmd as

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -50,9 +50,15 @@ tmux_session_command() {
   tmux -S "$TMUX_SOCKET" display-message -p -t "$SESSION" '#{pane_current_command}' 2>/dev/null
 }
 
+# A managed core is alive when the tmux session EXISTS and a `claude --name
+# sutando-core` process is running under it. Do NOT gate on the pane's current
+# foreground command: a healthy core that is mid-tool shows the pane cmd as
+# bash/python3/node/etc, so a pane-command match would falsely report it dead
+# and (on --restart) tear down a live core mid-task. Existence + the core claude
+# process is the correct liveness signal.
 tmux_core_session_running() {
   tmux_session_exists || return 1
-  [ "$(tmux_session_command)" = "claude" ]
+  core_claude_running
 }
 
 core_claude_pids() {
@@ -337,11 +343,10 @@ apply_tmux_defaults() {
   tmux -S "$TMUX_SOCKET" bind -n WheelDownPane send-keys -M 2>/dev/null || true
 }
 
-# Already running — attach if interactive, else exit cleanly. A healthy managed
-# core is the tmux session itself, not a fuzzy process-name match. `pgrep -f
-# "claude.*--name.*sutando-core"` also matches orphaned `tmux new-session ...`
-# launcher processes because their argv contains the embedded claude command;
-# those stale launchers used to make startup exit while no tmux session existed.
+# Already running — attach if interactive, else exit cleanly. A managed core is
+# live when the tmux session exists AND a `claude --name sutando-core` process
+# runs under it (tmux_core_session_running). Re-running the script is idempotent:
+# we attach/no-op instead of spawning a second core (→ duplicate task consumers).
 if tmux_core_session_running; then
   apply_tmux_defaults
   if [ -t 1 ] && command -v tmux > /dev/null 2>&1; then
@@ -353,8 +358,19 @@ if tmux_core_session_running; then
   exit 0
 fi
 
+# Orphaned core process, no tmux session — a `claude --name sutando-core` is
+# running detached from any managed session (e.g. its tmux server died but the
+# child claude survived). Adopt it: do NOT start a second core, which would
+# double the task-consumer count. On a non-restart start we reuse the existing
+# process; the operator can `--restart` to cleanly recycle it.
+if core_claude_running; then
+  echo "$SESSION claude process already running (no tmux session) — reusing it." >&2
+  echo "To recycle it cleanly: bash $0 --restart"
+  exit 0
+fi
+
 if tmux_session_exists; then
-  echo "  ⚠ $SESSION tmux session exists but pane is not Claude Code — restarting it" >&2
+  echo "  ⚠ $SESSION tmux session exists but no core Claude process — restarting it" >&2
   tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION" 2>/dev/null || true
 fi
 


### PR DESCRIPTION
## Summary
- Make `src/agent/claude/cli/start-cli.sh` treat the tmux `sutando-core` session as the source of truth for a managed core.
- Stop using fuzzy `pgrep -f "claude.*--name.*sutando-core"` as the already-running check; tmux server argv can contain the embedded `claude --name sutando-core` command even when no session exists.
- On `--restart`, kill the tmux session plus exact `claude` processes only.
- If a `sutando-core` tmux session exists but **no `claude --name sutando-core` process is running under it**, kill and recreate it. (Deliberately NOT gated on the pane's current command — a healthy core that is mid-tool shows `bash`/`python3`/`node` as the pane command, so a pane-command match would falsely report it dead and tear down a live core. Process existence is the liveness signal.)
- Conversely, an orphaned core process with no tmux session is adopted (reuse, don't double the task consumers); `--restart` recycles it cleanly.

## Live test results
- Syntax:
  - `bash -n src/agent/claude/cli/start-cli.sh`
- Reproduced the bad condition live:
  - Killed the live `sutando-core` tmux session.
  - Left/created stale process matches whose argv contained `claude --name sutando-core` while `tmux -S /tmp/sutando-tmux.sock has-session -t sutando-core` returned false.
  - `pgrep -fl 'claude.*--name.*sutando-core'` still matched stale tmux/fake launcher processes.
- Verified patched launcher behavior:
  - Ran `SUTANDO_CLAUDE_WORKING_DIR=/Users/ruiwang/.sutando/repo/workspace bash src/agent/claude/cli/start-cli.sh`.
  - It ignored the stale `pgrep` matches and started a real detached `sutando-core` session.
  - `tmux -S /tmp/sutando-tmux.sock display-message -p -t sutando-core '#{pane_current_command} #{pane_current_path}'` returned:
    `claude /Users/ruiwang/.sutando/repo/workspace`.
  - Task queue remained empty.
- Final live health:
  - `sutando-core` running.
  - `agent-api` restored on `:7843`.
  - Health check reports task queue ok/empty; remaining issues are pre-existing/systemic memory pressure and optional bridge warnings.

