### PR TITLE
feat(voice): in-room context association — calls carry their originating room

### DIFF
--- a/src/voice-agent-config.ts
+++ b/src/voice-agent-config.ts
@@ -23,6 +23,7 @@ import { join } from 'node:path';
 import { resolveWorkspace } from './workspace_default.js';
 import { personalPath, memoryDirEnv } from './util_paths.js';
 import { buildVoiceAgentContext } from './voice-context.js';
+import { roomContextBlock } from './voice-room-context.js';
 import { inlineTools, coreDocumentedSkills } from './inline-tools.js';
 import type { ModeState } from './voice-mode-resolver.js';
 
@@ -226,6 +227,11 @@ export function buildInstructions(ctx: VoiceConfigContext, overrides?: ConfigOve
 		'All of your code was written by your own autonomous build loop.',
 		'',
 		overrides?.voiceAgentContext !== undefined ? overrides.voiceAgentContext : buildVoiceAgentContext(),
+		'',
+		// In-room context layer (2026-07-09): when the call originates from a
+		// room, inject "you're called in room X" + (slice 2) the room's prep
+		// artifact. Empty string when no fresh room is set (safe no-op).
+		roomContextBlock(WORKSPACE_DIR),
 		'',
 		'DEFAULT BEHAVIOR: Call work for almost everything.',
 		'You are the voice interface. The Claude Code session is the brain.',

--- a/src/voice-room-context.ts
+++ b/src/voice-room-context.ts
@@ -1,0 +1,60 @@
+// In-room context layer — room association (US: in-room context, 2026-07-09;
+// design of record: notes/voicestack-in-room-context-layer-2026-07-09.md).
+//
+// A voice call can originate from a room/channel in an embedding chat client.
+// The client reports which room via web-client's `/room-context`
+// route → this JSON state file. buildInstructions() (system prompt) reads it
+// so the agent knows "I'm being called in room X"; search_knowledge + the
+// prep-artifact fetch (slice 2) will read the same state to scope to the room.
+//
+// Mirrors the voice-state.json / mute-state pattern: the client POSTs, the
+// agent reads a small JSON state file — no bodhi/transport changes needed.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface VoiceSessionRoom {
+	room_id: string;
+	room_name?: string;
+	prep?: string; // optional pre-fetched prep/context artifact body (slice 2)
+	ts: number; // epoch SECONDS when set (matches voice-state.json convention)
+}
+
+export function roomStatePath(workspaceDir: string): string {
+	return join(workspaceDir, 'state', 'voice-session-room.json');
+}
+
+// Max age for a room association to still apply. A stale file must NOT leak an
+// old room's context into an unrelated later call — room_id is set right before
+// connect, so 15 min is ample headroom without cross-session bleed.
+const ROOM_TTL_MS = 15 * 60 * 1000;
+
+export function readVoiceSessionRoom(workspaceDir: string, now: number = Date.now()): VoiceSessionRoom | null {
+	const p = roomStatePath(workspaceDir);
+	if (!existsSync(p)) return null;
+	try {
+		const raw = JSON.parse(readFileSync(p, 'utf-8')) as Partial<VoiceSessionRoom>;
+		if (!raw || typeof raw.room_id !== 'string' || !raw.room_id) return null;
+		const tsMs = typeof raw.ts === 'number' ? raw.ts * 1000 : 0;
+		if (tsMs && now - tsMs > ROOM_TTL_MS) return null; // stale → treat as no active room
+		return { room_id: raw.room_id, room_name: raw.room_name, prep: raw.prep, ts: raw.ts ?? 0 };
+	} catch {
+		return null;
+	}
+}
+
+// The system-prompt block injected when a call originates in a room. Empty
+// string when no (fresh) room is set — safe to always include in the prompt
+// array (joins to a no-op blank line, same as the other conditional blocks).
+export function roomContextBlock(workspaceDir: string, now: number = Date.now()): string {
+	const room = readVoiceSessionRoom(workspaceDir, now);
+	if (!room) return '';
+	const label = room.room_name ? `"${room.room_name}" (${room.room_id})` : room.room_id;
+	const lines = [
+		`IN-ROOM CONTEXT: You are being called from room ${label}. Scope your focus to this room — its topic, artifacts, and events. When the user says "this", "here", "my notes", or "search", prefer this room's context first.`,
+	];
+	if (room.prep && room.prep.trim()) {
+		lines.push(`Room prep/context:\n${room.prep.trim().slice(0, 1500)}`);
+	}
+	return lines.join('\n');
+}

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -836,11 +836,40 @@ function renderHotkeyHints() {
   }).catch(function () {});
 }
 
+// In-room context (2026-07-09, slice 1b): when this web UI is embedded in a
+// room's call iframe, the embedding client appends ?room_id=&room_name= to the
+// src. Self-report that room to the agent via /room-context so buildInstructions
+// scopes to it. No room in the URL (e.g. the plain local UI) → clear, so a stale
+// association never bleeds into a later non-room call (belt-and-suspenders over
+// the 15m TTL).
+function reportRoomFromUrl() {
+  try {
+    var q = new URLSearchParams(window.location.search);
+    var roomId = q.get('room_id');
+    if (roomId) {
+      var qs = 'room_id=' + encodeURIComponent(roomId);
+      var rn = q.get('room_name'); if (rn) qs += '&room_name=' + encodeURIComponent(rn);
+      fetch('/room-context?' + qs).catch(function () {});
+    } else {
+      fetch('/room-context?clear=true').catch(function () {});
+    }
+  } catch (e) {}
+}
+// Clear the room association when the call iframe is closed/navigated away, so
+// the next call starts clean. sendBeacon survives page teardown; fetch fallback.
+window.addEventListener('pagehide', function () {
+  try {
+    if (navigator.sendBeacon) navigator.sendBeacon('/room-context?clear=true');
+    else fetch('/room-context?clear=true', { keepalive: true }).catch(function () {});
+  } catch (e) {}
+});
+
 window.addEventListener('DOMContentLoaded', () => {
   const wsUrlInput = $('wsUrl');
   if (wsUrlInput && !wsUrlInput.value) {
     wsUrlInput.value = getDefaultWsUrl();
   }
+  reportRoomFromUrl();
   renderHotkeyHints();
   initChromeStt();
   // Auto-reconnect voice if it was connected before refresh
@@ -3670,6 +3699,31 @@ const server = createServer((req, res) => {
 		} catch {}
 		res.writeHead(200, { 'Content-Type': 'application/json' });
 		res.end(JSON.stringify({ active }));
+		return;
+	}
+
+	// In-room context layer (2026-07-09): the client reports which room a voice
+	// call originates from → state/voice-session-room.json. buildInstructions
+	// reads it so the agent knows "I'm called in room X" (search_knowledge + the
+	// prep-artifact fetch read the same state, slice 2). Mirrors /mute-state:
+	// client POSTs, agent reads a small JSON state file. `clear=true` (or empty
+	// room_id) on call end resets it so no room bleeds into a later local call.
+	if (url.pathname === '/room-context') {
+		const roomId = (url.searchParams.get('room_id') || '').trim();
+		const roomName = url.searchParams.get('room_name') || undefined;
+		const clear = url.searchParams.get('clear') === 'true';
+		try {
+			const p = join(STATE_DIR, 'voice-session-room.json');
+			const nowSec = Math.floor(Date.now() / 1000);
+			const payload = (clear || !roomId)
+				? { room_id: '', ts: nowSec }
+				: { room_id: roomId, room_name: roomName, ts: nowSec };
+			writeFileSync(p, JSON.stringify(payload));
+		} catch (e) {
+			console.error('[web-client] /room-context write failed:', e);
+		}
+		res.writeHead(200, { 'Content-Type': 'application/json' });
+		res.end(JSON.stringify({ ok: true, room_id: clear ? '' : roomId }));
 		return;
 	}
 


### PR DESCRIPTION
## What

When a voice call originates from a room/channel in an embedding chat client, the agent now knows *which room it's being called in* and scopes its focus to it. Three pieces:

- **`src/voice-room-context.ts` (new)** — reader + prompt block over `state/voice-session-room.json`. 15-min TTL so a stale association never bleeds into a later unrelated call; cleared/empty `room_id` → no injection.
- **web-client `/room-context` route** — the client reports the call's room → the state file (mirrors the `/mute-state` client-POSTs/agent-reads pattern). Plus `reportRoomFromUrl()`: when the page is embedded with `?room_id=&room_name=`, it self-reports on load and clears on `pagehide` (sendBeacon).
- **`buildInstructions` injects `roomContextBlock()`** — "you are being called from room X — scope your focus to this room", with an optional `prep` field reserved for the next slice (room prep/context artifacts).

## Why

The room a user calls from *is* their intent signal: calling in a project room means "this project's context". This lands the association seam — identity now, content (prep artifacts + room-scoped `search_knowledge`) as the follow-up slice. Any embedding client that appends `?room_id=` to the web UI URL gets it; without the param, behavior is unchanged (clear-on-load keeps plain local calls clean).

## Box

`built→` Live-Media plane / LiveAgentRuntime — session context seam.

## Testing

- esbuild clean (all three files).
- Unit: fresh room read / 20-min-stale → null / cleared → null / prep-included — 4/4.
- Live route: set writes `{room_id, room_name, ts}`; `clear=true` empties.
- Prompt: `buildInstructions` injects the block when a room is set, omits when cleared (mock-ctx test).
- Validated end-to-end on a live embedded call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
