### PR TITLE
fix(health-check): sutando-app probe no longer counts the Electron desktop app as the menu-bar app

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1034,6 +1034,61 @@ def check_notes_split_brain() -> "dict | None":
     }
 
 
+def _outermost_bundle(comm: str) -> Optional[Path]:
+    """Map an executable path to its OUTERMOST .app bundle, or None.
+
+    Electron helper processes live at
+    …/Sutando.app/Contents/Frameworks/Sutando Helper*.app/Contents/MacOS/…,
+    so split on the FIRST `.app/` to resolve them to the top-level bundle
+    rather than the nested helper bundle.
+    """
+    if ".app/" not in comm:
+        return None
+    return Path(comm.split(".app/", 1)[0] + ".app")
+
+
+def _is_electron_impostor(comm: str) -> bool:
+    """True if `comm` belongs to an Electron bundle squatting the Sutando name.
+
+    The desktop UI also installs as "Sutando.app", and its main binary lives
+    at the same …/Contents/MacOS/Sutando suffix the sutando-app pgrep pattern
+    matches — so the probe reported "running" while the actual Swift menu-bar
+    app (the contextual-chips writer + watcher-auto-restart owner) was dead
+    (#2038, 2026-07-09). Electron bundles are distinguishable on disk: they
+    ship Contents/Frameworks/Sutando Helper.app; the Swift app has no helper
+    frameworks.
+    """
+    bundle = _outermost_bundle(comm)
+    if bundle is None:
+        return False  # bare dev binary (src/Sutando/Sutando) — not a bundle
+    return (bundle / "Contents" / "Frameworks" / "Sutando Helper.app").exists()
+
+
+def _ps_comm(pid: str) -> str:
+    """Executable path (macOS) / name (linux) for a PID via ps; "" on error."""
+    return subprocess.run(
+        ["/bin/ps", "-o", "comm=", "-p", pid],
+        capture_output=True, text=True, timeout=5,
+    ).stdout.strip()
+
+
+def _filter_electron_impostor_pids(pids: list[str]) -> list[str]:
+    """Drop PIDs that belong to the Electron desktop app, keep the rest.
+
+    Fail-open per PID: if the ps lookup errors, keep the PID (pre-fix
+    behavior) rather than false-alarm "stopped".
+    """
+    kept = []
+    for pid in pids:
+        try:
+            if _is_electron_impostor(_ps_comm(pid)):
+                continue
+        except Exception:
+            pass
+        kept.append(pid)
+    return kept
+
+
 def run_all_checks() -> list[dict]:
     checks = []
 
@@ -1354,36 +1409,9 @@ def run_all_checks() -> list[dict]:
             pgrep_status = "error"
             pgrep_err = f"{type(e).__name__}: {e}"[:120]
 
-        # Disqualify Electron impostors. The desktop UI also installs as
-        # "Sutando.app", and its main binary lives at the same
-        # …/Contents/MacOS/Sutando suffix the pgrep pattern matches — so the
-        # probe reported "running" while the actual Swift menu-bar app (the
-        # contextual-chips writer + watcher-auto-restart owner) was dead
-        # (#2038, 2026-07-09). Electron bundles are distinguishable on disk:
-        # they ship Contents/Frameworks/Sutando Helper.app; the Swift app has
-        # no helper frameworks. Fail-open per PID: if the ps lookup errors,
-        # keep the PID (pre-fix behavior) rather than false-alarm "stopped".
+        # Disqualify Electron impostors (see _filter_electron_impostor_pids).
         if pgrep_status == "ok-running" and pids:
-            kept = []
-            for pid in pids:
-                try:
-                    comm = subprocess.run(
-                        ["/bin/ps", "-o", "comm=", "-p", pid],
-                        capture_output=True, text=True, timeout=5,
-                    ).stdout.strip()
-                    if ".app/" in comm:
-                        # Outermost bundle: Electron helper processes live at
-                        # …/Sutando.app/Contents/Frameworks/Sutando Helper*.app/…,
-                        # so split on the FIRST .app/ to map them back to the
-                        # top-level bundle before checking the marker.
-                        bundle = comm.split(".app/", 1)[0] + ".app"
-                        helper = Path(bundle) / "Contents" / "Frameworks" / "Sutando Helper.app"
-                        if helper.exists():
-                            continue  # Electron desktop app, not the menu-bar app
-                    kept.append(pid)
-                except Exception:
-                    kept.append(pid)
-            pids = kept
+            pids = _filter_electron_impostor_pids(pids)
             if not pids:
                 pgrep_status = "ok-stopped"
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1354,6 +1354,39 @@ def run_all_checks() -> list[dict]:
             pgrep_status = "error"
             pgrep_err = f"{type(e).__name__}: {e}"[:120]
 
+        # Disqualify Electron impostors. The desktop UI also installs as
+        # "Sutando.app", and its main binary lives at the same
+        # …/Contents/MacOS/Sutando suffix the pgrep pattern matches — so the
+        # probe reported "running" while the actual Swift menu-bar app (the
+        # contextual-chips writer + watcher-auto-restart owner) was dead
+        # (#2038, 2026-07-09). Electron bundles are distinguishable on disk:
+        # they ship Contents/Frameworks/Sutando Helper.app; the Swift app has
+        # no helper frameworks. Fail-open per PID: if the ps lookup errors,
+        # keep the PID (pre-fix behavior) rather than false-alarm "stopped".
+        if pgrep_status == "ok-running" and pids:
+            kept = []
+            for pid in pids:
+                try:
+                    comm = subprocess.run(
+                        ["/bin/ps", "-o", "comm=", "-p", pid],
+                        capture_output=True, text=True, timeout=5,
+                    ).stdout.strip()
+                    if ".app/" in comm:
+                        # Outermost bundle: Electron helper processes live at
+                        # …/Sutando.app/Contents/Frameworks/Sutando Helper*.app/…,
+                        # so split on the FIRST .app/ to map them back to the
+                        # top-level bundle before checking the marker.
+                        bundle = comm.split(".app/", 1)[0] + ".app"
+                        helper = Path(bundle) / "Contents" / "Frameworks" / "Sutando Helper.app"
+                        if helper.exists():
+                            continue  # Electron desktop app, not the menu-bar app
+                    kept.append(pid)
+                except Exception:
+                    kept.append(pid)
+            pids = kept
+            if not pids:
+                pgrep_status = "ok-stopped"
+
         if pgrep_status == "ok-running" and pids:
             check = {"name": "sutando-app", "status": "ok", "detail": f"running (⌃C/⌃V/⌃M)"}
             # Staleness check is meaningful only in the dev workflow — the

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1089,6 +1089,16 @@ def _filter_electron_impostor_pids(pids: list[str]) -> list[str]:
     return kept
 
 
+def _resolve_menu_bar_pgrep(pgrep_status: Optional[str], pids: list[str]) -> tuple[Optional[str], list[str]]:
+    """Post-process the sutando-app pgrep result: drop Electron impostor
+    PIDs, and demote "ok-running" to "ok-stopped" when nothing real remains."""
+    if pgrep_status == "ok-running" and pids:
+        pids = _filter_electron_impostor_pids(pids)
+        if not pids:
+            pgrep_status = "ok-stopped"
+    return pgrep_status, pids
+
+
 def run_all_checks() -> list[dict]:
     checks = []
 
@@ -1409,11 +1419,8 @@ def run_all_checks() -> list[dict]:
             pgrep_status = "error"
             pgrep_err = f"{type(e).__name__}: {e}"[:120]
 
-        # Disqualify Electron impostors (see _filter_electron_impostor_pids).
-        if pgrep_status == "ok-running" and pids:
-            pids = _filter_electron_impostor_pids(pids)
-            if not pids:
-                pgrep_status = "ok-stopped"
+        # Disqualify Electron impostors (see _resolve_menu_bar_pgrep).
+        pgrep_status, pids = _resolve_menu_bar_pgrep(pgrep_status, pids)
 
         if pgrep_status == "ok-running" and pids:
             check = {"name": "sutando-app", "status": "ok", "detail": f"running (⌃C/⌃V/⌃M)"}

--- a/tests/health-check-sutando-app-electron.test.py
+++ b/tests/health-check-sutando-app-electron.test.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Tests for the sutando-app probe's Electron-impostor filter in
+src/health-check.py (#2038).
+
+The desktop UI also installs as "Sutando.app"; its main binary and Helper
+processes match the probe's pgrep pattern, so pre-fix the probe reported
+"running" while the actual Swift menu-bar app was dead. The filter drops
+PIDs whose OUTERMOST .app bundle ships Contents/Frameworks/Sutando Helper.app
+(an Electron marker the Swift app never has).
+
+Covers:
+  a) Electron main binary            → impostor (dropped)
+  b) Electron Helper process         → resolves to outermost bundle → dropped
+  c) Swift-style bundle (no helper)  → kept
+  d) bare dev binary (no .app)       → kept
+  e) _filter_electron_impostor_pids → drops impostors, keeps real, and
+     fail-opens (keeps PID) when the ps lookup raises
+  f) _ps_comm on a live PID          → returns a non-empty string
+
+Run: python3 tests/health-check-sutando-app-electron.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+failures = []
+
+
+def check(name: str, cond: bool):
+    if cond:
+        print(f"  ok  {name}")
+    else:
+        print(f"  FAIL {name}")
+        failures.append(name)
+
+
+with tempfile.TemporaryDirectory() as td:
+    # Fake Electron bundle: Sutando.app WITH Contents/Frameworks/Sutando Helper.app
+    electron = Path(td) / "Applications" / "Sutando.app"
+    (electron / "Contents" / "Frameworks" / "Sutando Helper.app").mkdir(parents=True)
+    (electron / "Contents" / "MacOS").mkdir(parents=True)
+    electron_main = str(electron / "Contents" / "MacOS" / "Sutando")
+    electron_helper = str(
+        electron / "Contents" / "Frameworks" / "Sutando Helper (GPU).app"
+        / "Contents" / "MacOS" / "Sutando Helper (GPU)"
+    )
+
+    # Fake Swift menu-bar bundle: Sutando.app WITHOUT helper frameworks
+    swift = Path(td) / "src" / "Sutando" / "Sutando.app"
+    (swift / "Contents" / "MacOS").mkdir(parents=True)
+    swift_main = str(swift / "Contents" / "MacOS" / "Sutando")
+
+    # Bare dev binary — no .app anywhere in the path
+    dev_bin = str(Path(td) / "src" / "Sutando" / "Sutando")
+
+    # a) Electron main binary is an impostor
+    check("electron main → impostor", hc._is_electron_impostor(electron_main) is True)
+
+    # b) Helper resolves to the OUTERMOST bundle (Sutando.app, not the
+    #    nested helper bundle) and is therefore also an impostor
+    check("electron helper → impostor via outermost bundle",
+          hc._is_electron_impostor(electron_helper) is True)
+    check("outermost bundle of helper is top-level Sutando.app",
+          hc._outermost_bundle(electron_helper) == electron)
+
+    # c) Swift-style bundle (no Sutando Helper.app) is kept
+    check("swift bundle → not impostor", hc._is_electron_impostor(swift_main) is False)
+
+    # d) Bare dev binary is kept (no bundle at all)
+    check("dev binary → not impostor", hc._is_electron_impostor(dev_bin) is False)
+    check("dev binary has no bundle", hc._outermost_bundle(dev_bin) is None)
+
+    # e) _filter_electron_impostor_pids: drop impostors, keep real ones,
+    #    fail-open on ps errors. Patch _ps_comm with a recording fake.
+    comm_by_pid = {"1": electron_main, "2": swift_main, "3": dev_bin}
+
+    def fake_ps_comm(pid):
+        if pid == "4":
+            raise RuntimeError("ps blew up")
+        return comm_by_pid[pid]
+
+    orig = hc._ps_comm
+    hc._ps_comm = fake_ps_comm
+    try:
+        kept = hc._filter_electron_impostor_pids(["1", "2", "3", "4"])
+    finally:
+        hc._ps_comm = orig
+    check("filter drops electron, keeps swift + dev + errored",
+          kept == ["2", "3", "4"])
+
+    # f) _ps_comm works against a real live PID (this test process)
+    check("_ps_comm returns non-empty for live pid",
+          bool(hc._ps_comm(str(os.getpid()))))
+
+if failures:
+    print(f"\n{len(failures)} failure(s): {failures}")
+    sys.exit(1)
+print("\nall tests passed")
+sys.exit(0)

--- a/tests/health-check-sutando-app-electron.test.py
+++ b/tests/health-check-sutando-app-electron.test.py
@@ -104,6 +104,29 @@ with tempfile.TemporaryDirectory() as td:
     check("_ps_comm returns non-empty for live pid",
           bool(hc._ps_comm(str(os.getpid()))))
 
+    # g) _resolve_menu_bar_pgrep — the probe's post-processing step.
+    comm_by_pid = {"1": electron_main, "2": swift_main}
+
+    def fake_ps_comm2(pid):
+        return comm_by_pid[pid]
+
+    orig = hc._ps_comm
+    hc._ps_comm = fake_ps_comm2
+    try:
+        # All matches are impostors → demoted to ok-stopped, no pids left.
+        check("resolve: all impostors → ok-stopped",
+              hc._resolve_menu_bar_pgrep("ok-running", ["1"]) == ("ok-stopped", []))
+        # A real menu-bar PID survives → stays ok-running.
+        check("resolve: real pid survives → ok-running",
+              hc._resolve_menu_bar_pgrep("ok-running", ["1", "2"]) == ("ok-running", ["2"]))
+    finally:
+        hc._ps_comm = orig
+    # Non-running statuses pass through untouched (no ps calls at all).
+    check("resolve: ok-stopped passthrough",
+          hc._resolve_menu_bar_pgrep("ok-stopped", []) == ("ok-stopped", []))
+    check("resolve: error passthrough",
+          hc._resolve_menu_bar_pgrep("error", ["9"]) == ("error", ["9"]))
+
 if failures:
     print(f"\n{len(failures)} failure(s): {failures}")
     sys.exit(1)


### PR DESCRIPTION
## Problem

The `sutando-app` probe's pgrep pattern `(Sutando|MacOS)/Sutando` matches the **Electron desktop app** (`/Applications/Sutando.app/Contents/MacOS/Sutando`) and all of its Helper processes — not just the Swift menu-bar app it's meant to check. On a host where the menu-bar app is dead but the desktop app is open, the probe false-reports `running (⌃C/⌃V/⌃M)`.

That false assurance hid the root cause of #2038 for two days: the menu-bar app (sole `contextual-chips.json` writer + owner of the 300s watcher-auto-restart timer) had been down since Jul 6 while health-check kept saying it was fine.

## Fix

After pgrep, resolve each PID's executable via `ps -o comm=` and map it to its **outermost** `.app` bundle (first `.app/` split, so Electron Helper processes resolve to the top-level bundle). Drop PIDs whose bundle ships `Contents/Frameworks/Sutando Helper.app` — an Electron marker the Swift app never has. If no PIDs survive, report `ok-stopped`. Per-PID fail-open on ps errors preserves pre-fix behavior.

## Verification

- On this host (Electron app running, menu-bar app dead): probe went from `ok — running` to `warn — not running, hotkeys disabled` ✓
- Dev-binary path (`src/Sutando/Sutando`, no `.app` in path) is untouched by the filter ✓
- `tests/health-check-*.test.py`: all pass except `notify-slack`, which fails identically on clean main (pre-existing; #1817 territory)

Refs #2038.

🤖 Generated with [Claude Code](https://claude.com/claude-code)