### PR TITLE
fix(gateway-bridge): reconcile abandoned in-flight ids so the heartbeat count stays honest

### DIFF
--- a/src/remote-gateway-bridge.py
+++ b/src/remote-gateway-bridge.py
@@ -686,6 +686,7 @@ def _reconcile_abandoned(inflight: set[str], suspects: set[str]) -> set[str]:
     gone = {tid for tid in inflight
             if _valid_tid(tid)
             and not (TASKS_DIR / f"{tid}.txt").exists()
+            and not any(TASKS_DIR.glob(f"{tid}.claimed-*"))
             and not (RESULTS_DIR / f"{tid}.txt").exists()}
     confirmed = gone & suspects
     if confirmed:

--- a/src/remote-gateway-bridge.py
+++ b/src/remote-gateway-bridge.py
@@ -668,10 +668,39 @@ def _post_ready_results(inflight: set[str]) -> None:
         _save_inflight(inflight)
 
 
+def _reconcile_abandoned(inflight: set[str], suspects: set[str]) -> set[str]:
+    """Drop in-flight ids that can never complete through this loop: the task
+    file is no longer pending in tasks/ AND no result file is waiting. That
+    combination means the task was completed elsewhere (a concurrent core
+    racing the same workspace, a manual sweep to tasks/processed/, or history
+    from before a restart) — this client will never see a result to POST, so
+    the id would otherwise strand in the ledger forever. Stranded ids inflate
+    the heartbeat's `inflight` count monotonically until the broker's presence
+    sweep marks the agent unassignable (observed 2026-07-09: 175 stranded ids,
+    0 with any pending work).
+
+    Two consecutive sightings are required before dropping (`suspects` carries
+    the previous pass's candidates): a result landing between the task-file
+    check and the discard is then picked up by the next `_post_ready_results`
+    instead of being raced. Returns the new suspects set for the next pass."""
+    gone = {tid for tid in inflight
+            if _valid_tid(tid)
+            and not (TASKS_DIR / f"{tid}.txt").exists()
+            and not (RESULTS_DIR / f"{tid}.txt").exists()}
+    confirmed = gone & suspects
+    if confirmed:
+        for tid in sorted(confirmed):
+            inflight.discard(tid)
+            _log(f"dropped abandoned in-flight id {tid} (no task/result file — completed elsewhere)")
+        _save_inflight(inflight)
+    return gone - confirmed
+
+
 def main() -> None:
     if not URL or not TOKEN:
         sys.exit("FATAL: set REMOTE_TASK_TOKEN (and REMOTE_TASK_URL if your token is a bare secret).")
     inflight: set[str] = _load_inflight()
+    abandoned_suspects: set[str] = set()
     _log(f"starting — gateway={URL} provider={PROVIDER} workspace={WS} "
          f"(restored {len(inflight)} in-flight)")
     backoff = 1
@@ -695,6 +724,7 @@ def main() -> None:
             for tid in pending_ack:
                 _post_task_ack(tid)
             _post_ready_results(inflight)
+            abandoned_suspects = _reconcile_abandoned(inflight, abandoned_suspects)
             _post_heartbeat(inflight)
             backoff = 1  # healthy round-trip → reset backoff
         except urllib.error.HTTPError as e:

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -474,6 +474,15 @@ def main() -> int:
           "reconcile: first sighting only suspects (no drop yet)")
     check("task-PEND" not in s1 and "task-RDY" not in s1,
           "reconcile: pending task file / waiting result exempt from suspicion")
+    # a task claimed by a core (multi-core rename, claim_task.py #884) is
+    # ACTIVE, not abandoned — must never be suspected while the claim exists
+    (rtc.TASKS_DIR / "task-CLAIMED.claimed-core-2.txt").write_text("being worked")
+    inflight.add("task-CLAIMED")
+    s_c = rtc._reconcile_abandoned(inflight, {"task-CLAIMED"})
+    check("task-CLAIMED" in inflight and "task-CLAIMED" not in s_c,
+          "reconcile: claimed task exempt (long-running work not dropped)")
+    (rtc.TASKS_DIR / "task-CLAIMED.claimed-core-2.txt").unlink()
+    inflight.discard("task-CLAIMED")
     s2 = rtc._reconcile_abandoned(inflight, s1)
     check("task-GONE" not in inflight and s2 == set(),
           "reconcile: second sighting drops the id and clears suspects")

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -463,6 +463,53 @@ def main() -> int:
           "LOCAL_TIER=owner → owner-activity written with stripped summary")
     rtc.LOCAL_TIER = "team"
 
+    # 8. _reconcile_abandoned — two-sighting drop of stranded in-flight ids
+    rtc.TASKS_DIR.mkdir(parents=True, exist_ok=True)
+    rtc.RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    (rtc.TASKS_DIR / "task-PEND.txt").write_text("still pending")
+    (rtc.RESULTS_DIR / "task-RDY.txt").write_text("result waiting")
+    inflight = {"task-GONE", "task-PEND", "task-RDY", "not!a!tid"}
+    s1 = rtc._reconcile_abandoned(inflight, set())
+    check(s1 == {"task-GONE"} and "task-GONE" in inflight,
+          "reconcile: first sighting only suspects (no drop yet)")
+    check("task-PEND" not in s1 and "task-RDY" not in s1,
+          "reconcile: pending task file / waiting result exempt from suspicion")
+    s2 = rtc._reconcile_abandoned(inflight, s1)
+    check("task-GONE" not in inflight and s2 == set(),
+          "reconcile: second sighting drops the id and clears suspects")
+    saved = set(json.loads(rtc.INFLIGHT_FILE.read_text()))
+    check("task-GONE" not in saved and "task-PEND" in saved,
+          "reconcile: ledger persisted on drop")
+    # a result landing between sightings rescues the id
+    inflight2 = {"task-LATE"}
+    s = rtc._reconcile_abandoned(inflight2, set())
+    (rtc.RESULTS_DIR / "task-LATE.txt").write_text("landed late")
+    s = rtc._reconcile_abandoned(inflight2, s)
+    check("task-LATE" in inflight2, "reconcile: late-landing result rescues the id")
+    (rtc.RESULTS_DIR / "task-LATE.txt").unlink()
+
+    # 9. main() one-iteration smoke — exercises the reconcile wiring in the
+    # poll loop (heartbeat → poll → results → reconcile → heartbeat), bounded
+    # by raising KeyboardInterrupt on the 3rd heartbeat (= start of round 2).
+    STATE["force_401"] = False
+    STATE["force_ack_404"] = False
+    STATE["force_heartbeat_404"] = False
+    real_hb = rtc._post_heartbeat
+    hb_calls = {"n": 0}
+    def _hb_bounded(inflight_arg):
+        hb_calls["n"] += 1
+        if hb_calls["n"] >= 3:
+            raise KeyboardInterrupt
+        return real_hb(inflight_arg)
+    rtc._post_heartbeat = _hb_bounded
+    try:
+        rtc.main()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        rtc._post_heartbeat = real_hb
+    check(hb_calls["n"] == 3, "main: one full loop iteration ran (reconcile wired)")
+
     srv.shutdown()
     if FAILS:
         print(f"\nFAILED ({len(FAILS)})"); return 1

--- a/tests/remote-gateway-bridge.test.py
+++ b/tests/remote-gateway-bridge.test.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Delegator: run src/remote-gateway-bridge.test.py under the tests/ discovery
+root.
+
+The coverage gate (scripts/coverage-gate.sh) only discovers tests/**/*.test.py,
+so the bridge's own suite — which lives next to the module in src/ — never ran
+under coverage and its lines counted as uncovered in diff-cover. Running it
+in-process (runpy, not a subprocess) keeps execution inside the same coverage
+recorder.
+
+Run: python3 tests/remote-gateway-bridge.test.py
+Exit code: propagated from the src suite (0 pass, 1 fail).
+"""
+from __future__ import annotations
+
+import runpy
+import sys
+from pathlib import Path
+
+TARGET = Path(__file__).resolve().parent.parent / "src" / "remote-gateway-bridge.test.py"
+
+try:
+    runpy.run_path(str(TARGET), run_name="__main__")
+except SystemExit as e:
+    sys.exit(e.code)
+sys.exit(0)


### PR DESCRIPTION
## Priority

P2 — correctness of the agent's advertised load; no crash, but degrades task routing to affected agents over time.

## Problem

In-flight ids only leave `state/remote-task-inflight.json` when their result file flows through this client (`_post_ready_results`). Ids resolved anywhere else — a concurrent core racing the same workspace, a manual sweep to `tasks/processed/`, pre-restart history — strand **forever**. The heartbeat sends `inflight: len(inflight)`, so the count inflates monotonically and the broker's presence sweep eventually reports the agent as overloaded/unassignable.

Observed on a live node (2026-07-09): **175 stranded ids, 0 with any pending work** (167 already archived/processed locally, 8 consumed by a concurrent core); room presence showed `load.inflight` in the hundreds with `assignable: false`.

## Fix

`_reconcile_abandoned()`, called once per poll loop after `_post_ready_results`: an id with **no pending task file AND no waiting result file** can never complete through this loop → drop it and persist the ledger.

Race guard: **two consecutive sightings** required before dropping (the `suspects` set carries the previous pass's candidates) — a result that lands between the task-file check and the discard is picked up by the next `_post_ready_results` instead of being raced.

## Verify

- `python3 -m py_compile` clean
- Sandboxed functional test (temp dirs, monkeypatched module paths) asserts: keep-pending, keep-result-waiting, race-spare (late result between passes → id retained), 2-pass drop, ledger persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)