### PR TITLE
feat(task-progress): route unknown --source through the remote gateway

### DIFF
--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import urllib.request
 from pathlib import Path
@@ -137,16 +138,38 @@ def send_telegram(chat_id: str, message: str) -> bool:
     )
 
 
+# Gateway provider names come from task files, i.e. from OUTSIDE the trust
+# boundary — a `source` like `../evil` must never become a path segment
+# (traversal reads an arbitrary .env-shaped file and posts its bearer to the
+# URL named in that same file). Safe slug only.
+_SOURCE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
 def send_remote_gateway(source: str, channel_id: str, message: str) -> bool:
     """Generic sender for gateway-bridged channels (any --source with a
     channels/<source>/.env carrying REMOTE_TASK_URL + REMOTE_TASK_TOKEN)."""
+    if not _SOURCE_SLUG_RE.match(source or ""):
+        print(f"[task-progress] invalid gateway source {source!r} — "
+              "provider names must match ^[a-z0-9][a-z0-9_-]*$", file=sys.stderr)
+        return False
     # Mirrors util_paths.claude_home_path ($CLAUDE_CONFIG_DIR -> $CLAUDE_HOME -> ~/.claude).
     _base = os.environ.get("CLAUDE_CONFIG_DIR") or os.environ.get("CLAUDE_HOME")
     _claude_config = Path(_base) if _base else Path.home() / ".claude"
-    env_path = _claude_config / "channels" / source / ".env"
-    env = _env_file(str(env_path))
+    channels_dir = _claude_config / "channels"
+    env_path = channels_dir / source / ".env"
+    # Belt and suspenders: even a slug-valid name must RESOLVE inside the
+    # channels directory. The containment root is the realpath of channels/
+    # itself (so a symlinked channels dir works), but a channel entry that
+    # symlinks OUT of the directory is refused by design.
+    real_env = os.path.realpath(env_path)
+    real_root = os.path.realpath(channels_dir)
+    if not real_env.startswith(real_root + os.sep):
+        print(f"[task-progress] refusing env path outside channels dir: {env_path}",
+              file=sys.stderr)
+        return False
+    env = _env_file(real_env)
     url = (os.environ.get("REMOTE_TASK_URL") or env.get("REMOTE_TASK_URL", "")).rstrip("/")
-    token = _token(source, "REMOTE_TASK_TOKEN")
+    token = os.environ.get("REMOTE_TASK_TOKEN", "").strip() or env.get("REMOTE_TASK_TOKEN", "")
     if not url or not token:
         print(f"[task-progress] no REMOTE_TASK_URL/REMOTE_TASK_TOKEN for source '{source}' "
               f"(looked in {env_path})", file=sys.stderr)

--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -6,6 +6,13 @@ Usage:
     python3 notify.py --source slack --channel-id D0B5L7X2TK2 --thread-ts 1780586204.198 --message "Still working..."
     python3 notify.py --source discord --channel-id 1234567890 --message "Working on it..."
     python3 notify.py --source telegram --chat-id 123456789 --message "On it..."
+    python3 notify.py --source <provider> --channel-id '!roomid:server' --message "On it..."
+
+Any --source other than slack/discord/telegram is treated as a remote-gateway
+channel: the sender reads channels/<source>/.env (under $CLAUDE_CONFIG_DIR) for
+REMOTE_TASK_URL + REMOTE_TASK_TOKEN and posts the message through the gateway's
+POST /v1/room {op: "message"} endpoint — the same transport the task bridge for
+that provider uses, so progress updates land in the originating room.
 
 Exits 0 on success, 1 on failure. Fail-open by design — a failed send must never
 block the task itself. The caller should always continue working regardless of exit code.
@@ -130,10 +137,34 @@ def send_telegram(chat_id: str, message: str) -> bool:
     )
 
 
+def send_remote_gateway(source: str, channel_id: str, message: str) -> bool:
+    """Generic sender for gateway-bridged channels (any --source with a
+    channels/<source>/.env carrying REMOTE_TASK_URL + REMOTE_TASK_TOKEN)."""
+    # Mirrors util_paths.claude_home_path ($CLAUDE_CONFIG_DIR -> $CLAUDE_HOME -> ~/.claude).
+    _base = os.environ.get("CLAUDE_CONFIG_DIR") or os.environ.get("CLAUDE_HOME")
+    _claude_config = Path(_base) if _base else Path.home() / ".claude"
+    env_path = _claude_config / "channels" / source / ".env"
+    env = _env_file(str(env_path))
+    url = (os.environ.get("REMOTE_TASK_URL") or env.get("REMOTE_TASK_URL", "")).rstrip("/")
+    token = _token(source, "REMOTE_TASK_TOKEN")
+    if not url or not token:
+        print(f"[task-progress] no REMOTE_TASK_URL/REMOTE_TASK_TOKEN for source '{source}' "
+              f"(looked in {env_path})", file=sys.stderr)
+        return False
+    return _post(
+        f"{url}/v1/room",
+        {"op": "message", "room_id": channel_id, "body": message},
+        {"Authorization": f"Bearer {token}",
+         # some gateway edges (CDN/WAF) reject the default Python-urllib UA
+         "User-Agent": "sutando-task-progress/1.0"},
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Send a task-progress update to a channel.")
-    parser.add_argument("--source", required=True, choices=["slack", "discord", "telegram"],
-                        help="Channel source (slack / discord / telegram)")
+    parser.add_argument("--source", required=True,
+                        help="Channel source: slack / discord / telegram, or any "
+                             "gateway-bridged provider with a channels/<source>/.env")
     parser.add_argument("--channel-id", help="Slack / Discord channel ID")
     parser.add_argument("--chat-id", help="Telegram chat ID (alias for --channel-id on telegram)")
     parser.add_argument("--thread-ts", default=None,
@@ -166,8 +197,7 @@ def main() -> int:
     elif source == "telegram":
         ok = send_telegram(channel, message)
     else:
-        print(f"[task-progress] unknown source: {source}", file=sys.stderr)
-        return 1
+        ok = send_remote_gateway(source, channel, message)
 
     return 0 if ok else 1
 

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
+import tempfile
 import sys
 import types
 import unittest
@@ -198,9 +200,12 @@ class TestSendRemoteGateway(unittest.TestCase):
             captured["payload"] = json.loads(req.data)
             return mock_resp
 
-        with patch.object(self.mod, "_token", return_value="bearer-fake"), \
-             patch.object(self.mod, "_env_file",
-                          return_value={"REMOTE_TASK_URL": "https://gw.example/relay"}), \
+        clean_env = {k: v for k, v in os.environ.items()
+                     if k not in ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN")}
+        with patch.object(self.mod, "_env_file",
+                          return_value={"REMOTE_TASK_URL": "https://gw.example/relay",
+                                        "REMOTE_TASK_TOKEN": "bearer-fake"}), \
+             patch.dict(os.environ, clean_env, clear=True), \
              patch("urllib.request.urlopen", fake_urlopen):
             result = self.mod.send_remote_gateway("someprovider", "!room:server", "hello")
         self.assertTrue(result)
@@ -209,10 +214,69 @@ class TestSendRemoteGateway(unittest.TestCase):
                          {"op": "message", "room_id": "!room:server", "body": "hello"})
 
     def test_missing_env_returns_false(self):
-        with patch.object(self.mod, "_token", return_value=""), \
-             patch.object(self.mod, "_env_file", return_value={}):
+        clean_env = {k: v for k, v in os.environ.items()
+                     if k not in ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN")}
+        with patch.object(self.mod, "_env_file", return_value={}), \
+             patch.dict(os.environ, clean_env, clear=True):
             result = self.mod.send_remote_gateway("someprovider", "!room:server", "hello")
         self.assertFalse(result)
+
+
+class TestGatewaySourceTraversal(unittest.TestCase):
+    """Regression for the confirmed traversal finding on PR #2054: a --source
+    like `../evil` must never escape $CLAUDE_CONFIG_DIR/channels — neither
+    reading the escaped .env nor posting its bearer anywhere."""
+
+    def setUp(self):
+        self.mod = _load()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.cfg = Path(self.tmp.name)
+        (self.cfg / "channels").mkdir(parents=True)
+        # The file an attacker wants us to read: OUTSIDE channels/, .env-shaped,
+        # with an attacker-controlled URL alongside the secret.
+        (self.cfg / "evil").mkdir()
+        (self.cfg / "evil" / ".env").write_text(
+            "REMOTE_TASK_URL=https://escaped.example\nREMOTE_TASK_TOKEN=escaped-token\n")
+        self.env_patch = patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(self.cfg)}, clear=False)
+        self.env_patch.start()
+        # env vars must not mask the file-read path under test
+        for var in ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN"):
+            os.environ.pop(var, None)
+
+    def tearDown(self):
+        self.env_patch.stop()
+        self.tmp.cleanup()
+
+    def test_dotdot_source_refused_before_any_read(self):
+        posts = []
+        with patch.object(self.mod, "_post", side_effect=lambda *a, **k: posts.append(a) or True):
+            ok = self.mod.send_remote_gateway("../evil", "!room:server", "hi")
+        self.assertFalse(ok)
+        self.assertEqual(posts, [])
+
+    def test_dotdot_source_refused_via_cli(self):
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT), "--source", "../evil",
+             "--channel-id", "!room:server", "--message", "hi"],
+            capture_output=True, text=True,
+            env={**os.environ, "CLAUDE_CONFIG_DIR": str(self.cfg)},
+        )
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("invalid gateway source", r.stderr)
+        self.assertNotIn("escaped-token", r.stderr)
+
+    def test_symlink_escape_refused(self):
+        # Slug-valid name whose directory symlinks out of channels/.
+        os.symlink(self.cfg / "evil", self.cfg / "channels" / "sneaky")
+        posts = []
+        with patch.object(self.mod, "_post", side_effect=lambda *a, **k: posts.append(a) or True):
+            ok = self.mod.send_remote_gateway("sneaky", "!room:server", "hi")
+        self.assertFalse(ok)
+        self.assertEqual(posts, [])
+
+    def test_uppercase_and_weird_slugs_refused(self):
+        for bad in ("EVIL", "a b", "a/b", ".hidden", "", "-lead"):
+            self.assertFalse(self.mod.send_remote_gateway(bad, "!r:s", "hi"), bad)
 
 
 class TestCLI(unittest.TestCase):

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -182,6 +182,39 @@ class TestSendTelegram(unittest.TestCase):
         self.assertFalse(result)
 
 
+class TestSendRemoteGateway(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+
+    def test_success_posts_room_message_op(self):
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = b'{"ok": true}'
+        captured = {}
+
+        def fake_urlopen(req, timeout=10):
+            captured["url"] = req.full_url
+            captured["payload"] = json.loads(req.data)
+            return mock_resp
+
+        with patch.object(self.mod, "_token", return_value="bearer-fake"), \
+             patch.object(self.mod, "_env_file",
+                          return_value={"REMOTE_TASK_URL": "https://gw.example/relay"}), \
+             patch("urllib.request.urlopen", fake_urlopen):
+            result = self.mod.send_remote_gateway("someprovider", "!room:server", "hello")
+        self.assertTrue(result)
+        self.assertEqual(captured["url"], "https://gw.example/relay/v1/room")
+        self.assertEqual(captured["payload"],
+                         {"op": "message", "room_id": "!room:server", "body": "hello"})
+
+    def test_missing_env_returns_false(self):
+        with patch.object(self.mod, "_token", return_value=""), \
+             patch.object(self.mod, "_env_file", return_value={}):
+            result = self.mod.send_remote_gateway("someprovider", "!room:server", "hello")
+        self.assertFalse(result)
+
+
 class TestCLI(unittest.TestCase):
     def test_missing_channel_id_exits_1(self):
         r = subprocess.run(
@@ -197,13 +230,18 @@ class TestCLI(unittest.TestCase):
         )
         self.assertNotEqual(r.returncode, 0)
 
-    def test_unknown_source_rejected_by_argparse(self):
+    def test_unconfigured_gateway_source_fails_open(self):
+        # A source outside the built-ins routes to the remote-gateway sender;
+        # with no channels/<source>/.env it must fail (exit 1) with a hint —
+        # never traceback, never block.
         r = subprocess.run(
             [sys.executable, str(SCRIPT), "--source", "whatsapp",
              "--channel-id", "D123", "--message", "hi"],
             capture_output=True, text=True,
+            env={"PATH": "/usr/bin:/bin", "CLAUDE_CONFIG_DIR": "/nonexistent"},
         )
-        self.assertNotEqual(r.returncode, 0)
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("REMOTE_TASK_URL", r.stderr)
 
     def test_long_message_rejected_before_token_lookup(self):
         r = subprocess.run(


### PR DESCRIPTION
## Problem

`notify.py` hardcodes `--source` choices to slack/discord/telegram. Tasks arriving through a remote-gateway bridge (`src/remote-gateway-bridge.py` providers) have no progress-notify path — the owner waits in silence while the task runs, violating the skill's own notify-before-work rule.

## Fix

Any `--source` outside the three built-ins is treated as a gateway-bridged channel: resolve `$CLAUDE_CONFIG_DIR/channels/<source>/.env` for `REMOTE_TASK_URL` + `REMOTE_TASK_TOKEN` and post `{op: "message", room_id, body}` to the gateway's `POST /v1/room` — the same transport that provider's task bridge already uses. No provider-specific code.

Fail-open contract unchanged: missing env → stderr hint + exit 1, never blocks the task.

## Verify

- `--source nonexistent` → clean exit 1 with the env-path hint, no traceback.
- Real send through a configured gateway channel → HTTP 2xx, message rendered in the originating room.
- slack/discord/telegram paths untouched (dispatch falls through to the new branch only for unknown sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)