### PR TITLE
feat(gateway-bridge): honor [file:] result markers via the room media endpoint

### DIFF
--- a/src/remote-gateway-bridge.py
+++ b/src/remote-gateway-bridge.py
@@ -41,6 +41,7 @@ Stdlib only (urllib) — no new dependencies.
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import re
@@ -58,6 +59,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from workspace_default import resolve_workspace  # noqa: E402
 import local_task_protocol  # noqa: E402
+from result_markers import parse_markers  # noqa: E402
+from send_allowlist import is_path_sendable  # noqa: E402
 
 WS = resolve_workspace()
 TASKS_DIR = WS / "tasks"
@@ -68,6 +71,12 @@ ARCHIVE_RESULTS_DIR = RESULTS_DIR / "archive"
 # gateway-pulled tasks only — we must NOT blindly POST every results/ file, or we'd
 # cross-send other channels' (Discord/Telegram) results to the gateway.
 INFLIGHT_FILE = WS / "state" / "remote-task-inflight.json"
+# Sidecar map {task id → origin room id}, recorded at queue time. Outbound
+# file-attach needs the room because media uploads go to the room-scoped
+# endpoint (POST /v1/rooms/{room}/media) while text results go to /v1/results
+# (which resolves the room server-side). Separate file — the inflight ledger's
+# list-of-ids format stays untouched for compat.
+TASK_ROOMS_FILE = WS / "state" / "remote-task-rooms.json"
 
 # Back-compat: instances onboarded before the AG2_REMOTE_* → REMOTE_TASK_*
 # rename still export the legacy names in their .env. Honor them as DEPRECATED
@@ -595,9 +604,78 @@ def _write_task(task: dict) -> str | None:
     tmp.write_text("\n".join(lines) + "\n")
     tmp.rename(dest)  # atomic publish so the watcher never sees a partial file
     _log(f"queued {tid}")
+    _record_task_room(tid, str(task.get("channel_id") or ""))
     # Bridges-as-siblings: feed the proactive-loop's active-engagement gate.
     _write_owner_activity(task)
     return tid
+
+
+def _load_task_rooms() -> dict[str, str]:
+    """Restore the {task id → room id} sidecar map (fail-open to empty)."""
+    try:
+        data = json.loads(TASK_ROOMS_FILE.read_text())
+        return {str(k): str(v) for k, v in data.items()} if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return {}
+    except Exception as e:  # noqa: BLE001
+        _log(f"task-rooms file unreadable ({e}) — starting empty")
+        return {}
+
+
+def _save_task_rooms(rooms: dict[str, str]) -> None:
+    """Atomically persist the task→room map. Best-effort (never blocks the loop)."""
+    try:
+        TASK_ROOMS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = TASK_ROOMS_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(rooms, sort_keys=True))
+        tmp.rename(TASK_ROOMS_FILE)
+    except Exception as e:  # noqa: BLE001
+        _log(f"task-rooms persist failed ({e}) — continuing")
+
+
+def _record_task_room(tid: str, room: str) -> None:
+    if not room:
+        return
+    rooms = _load_task_rooms()
+    if rooms.get(tid) != room:
+        rooms[tid] = room
+        _save_task_rooms(rooms)
+
+
+def _forget_task_room(tid: str) -> None:
+    rooms = _load_task_rooms()
+    if tid in rooms:
+        rooms.pop(tid)
+        _save_task_rooms(rooms)
+
+
+def _upload_attachment(room: str, path_str: str) -> tuple[bool, str]:
+    """Upload one allowlisted local file to the task's room via the gateway
+    media endpoint. Returns (ok, reason)."""
+    fpath = os.path.realpath(os.path.expanduser(path_str.strip()))
+    if not is_path_sendable(fpath):
+        return False, "path not allowlisted"
+    try:
+        size = os.path.getsize(fpath)
+    except OSError as e:
+        return False, f"stat failed: {e}"
+    if size > MAX_MEDIA_BYTES:
+        return False, f"file exceeds {MAX_MEDIA_BYTES} bytes"
+    try:
+        with open(fpath, "rb") as f:
+            content_b64 = base64.b64encode(f.read()).decode("ascii")
+    except OSError as e:
+        return False, f"read failed: {e}"
+    safe_room = urllib.parse.quote(room, safe="")
+    try:
+        _req("POST", f"/v1/rooms/{safe_room}/media",
+             {"filename": os.path.basename(fpath), "content_b64": content_b64},
+             timeout=60)
+    except urllib.error.HTTPError as e:
+        return False, f"HTTP {e.code}"
+    except (urllib.error.URLError, TimeoutError) as e:
+        return False, f"network error: {e}"
+    return True, ""
 
 
 def _archive_result(path: Path, tid: str) -> None:
@@ -631,6 +709,10 @@ def _save_inflight(inflight: set[str]) -> None:
         _log(f"inflight persist failed ({e}) — continuing")
 
 
+# (tid, path) pairs already uploaded this process — result-POST retry guard.
+_uploaded_attachments: set[tuple[str, str]] = set()
+
+
 def _post_ready_results(inflight: set[str]) -> None:
     """For each in-flight task, if its result file exists, POST it + archive."""
     changed = False
@@ -642,18 +724,52 @@ def _post_ready_results(inflight: set[str]) -> None:
         if not rfile.exists():
             continue
         body = rfile.read_text().strip()
-        # Result-body protocol markers are a local bridge concern — never ship
-        # them to the gateway. [no-send]/[deduped:] mean "no user-facing reply":
-        # archive without POSTing (match the other bridges' semantics).
-        low = body.lower()
-        if low.startswith("[no-send]") or low.startswith("[deduped:"):
+        # Route marker decisions through the unified parser (#873) like the
+        # other bridges — no hand-rolled startswith checks.
+        parsed = parse_markers(body)
+        skip = next((a for a in parsed.actions if a.kind == "skip"), None)
+        if skip:
+            # [no-send]/[REPLIED]/[deduped:] mean "no user-facing reply":
+            # archive without POSTing (match the other bridges' semantics).
             _archive_result(rfile, tid)
             inflight.discard(tid)
+            _forget_task_room(tid)
             changed = True
-            _log(f"archived {tid} (marker, not sent)")
+            _log(f"archived {tid} (marker {skip.value}, not sent)")
             continue
+        out_body = parsed.body
+        redirect = next((a for a in parsed.actions if a.kind == "redirect"), None)
+        if redirect:
+            # Cross-room redirect is handled GATEWAY-side for this transport —
+            # re-stitch the marker the parser stripped so the server still
+            # sees it as the first line.
+            out_body = f"[channel: {redirect.value}]\n{out_body}"
+        attaches = [a.value for a in parsed.actions if a.kind == "attach"]
+        if attaches:
+            room = _load_task_rooms().get(tid, "")
+            sent = 0
+            for fp in attaches:
+                # Uploads happen before the result POST (so failures can be
+                # annotated in-band); if that POST then fails and this loop
+                # retries, don't re-upload the same file into the room.
+                if (tid, fp) in _uploaded_attachments:
+                    sent += 1
+                    continue
+                ok, reason = (_upload_attachment(room, fp) if room
+                              else (False, "origin room unknown"))
+                if ok:
+                    sent += 1
+                    _uploaded_attachments.add((tid, fp))
+                    _log(f"attached {fp} to {room} for {tid}")
+                else:
+                    # Keep the information in-band rather than dropping the
+                    # file silently — mirrors the other bridges' rejection UX.
+                    out_body += f"\n[attachment not sent: {fp} ({reason})]"
+                    _log(f"attachment skipped for {tid}: {fp} ({reason})")
+            if not out_body.strip() and sent:
+                out_body = "(file attached)"
         try:
-            _req("POST", "/v1/results", {"id": tid, "body": body})
+            _req("POST", "/v1/results", {"id": tid, "body": out_body})
         except urllib.error.HTTPError as e:
             _log(f"result POST failed for {tid}: HTTP {e.code} — will retry")
             continue
@@ -662,6 +778,7 @@ def _post_ready_results(inflight: set[str]) -> None:
             continue
         _archive_result(rfile, tid)
         inflight.discard(tid)
+        _forget_task_room(tid)
         changed = True
         _log(f"delivered result for {tid}")
     if changed:

--- a/tests/bridge-marker-no-leak.test.py
+++ b/tests/bridge-marker-no-leak.test.py
@@ -17,6 +17,7 @@ Guards:
   1. src/slack-bridge.py imports parse_markers from result_markers
   2. src/telegram-bridge.py imports parse_markers from result_markers
   3. src/discord-bridge.py imports parse_markers from result_markers (#896)
+  3c. src/remote-gateway-bridge.py imports parse_markers (file-attach change)
   4. Each bridge's marker-handling block calls parse_markers(...)
   5. result_markers.py exposes the public surface parse_markers + Action
 
@@ -92,6 +93,20 @@ def main() -> int:
             return fail(
                 f"src/discord-bridge.py still has hand-rolled skip check {hand_rolled!r} — "
                 "must route through parse_markers() per #896"
+            )
+
+    # 3c. Remote-gateway bridge wires the parser (outbound file-attach change)
+    gb = REPO / "src" / "remote-gateway-bridge.py"
+    gb_src = gb.read_text()
+    if "from result_markers import parse_markers" not in gb_src:
+        return fail("src/remote-gateway-bridge.py must import parse_markers from result_markers")
+    if "parse_markers(" not in gb_src:
+        return fail("src/remote-gateway-bridge.py must call parse_markers(...) somewhere")
+    for hand_rolled in ('startswith("[no-send]")', 'startswith("[deduped:")'):
+        if hand_rolled in gb_src:
+            return fail(
+                f"src/remote-gateway-bridge.py still has hand-rolled skip check {hand_rolled!r} — "
+                "must route through parse_markers() per #873"
             )
 
     # 4. Behavior smoke test of the parser itself

--- a/tests/remote-gateway-file-attach.test.py
+++ b/tests/remote-gateway-file-attach.test.py
@@ -133,6 +133,65 @@ class FileAttachTests(unittest.TestCase):
         self.assertTrue(results[0][2]["body"].startswith("[channel: !dev:server]"))
         self.assertIn("the reply", results[0][2]["body"])
 
+    # failure branches (coverage bar: every degrade path observable)
+    def test_upload_stat_and_read_failures_noted(self):
+        fd, fpath = tempfile.mkstemp(prefix="sutando-attach-test-", suffix=".txt", dir="/tmp")
+        os.write(fd, b"x"); os.close(fd)
+        self.addCleanup(lambda: os.path.exists(fpath) and os.unlink(fpath))
+        with patch.object(self.mod.os.path, "getsize", side_effect=OSError("boom")):
+            ok, reason = self.mod._upload_attachment("!r:s", fpath)
+        self.assertFalse(ok); self.assertIn("stat failed", reason)
+        with patch("builtins.open", side_effect=OSError("denied")):
+            ok, reason = self.mod._upload_attachment("!r:s", fpath)
+        self.assertFalse(ok); self.assertIn("read failed", reason)
+
+    def test_upload_oversize_refused(self):
+        fd, fpath = tempfile.mkstemp(prefix="sutando-attach-test-", suffix=".bin", dir="/tmp")
+        os.write(fd, b"x"); os.close(fd)
+        self.addCleanup(lambda: os.path.exists(fpath) and os.unlink(fpath))
+        with patch.object(self.mod, "MAX_MEDIA_BYTES", 0):
+            ok, reason = self.mod._upload_attachment("!r:s", fpath)
+        self.assertFalse(ok); self.assertIn("exceeds", reason)
+
+    def test_upload_http_and_network_errors(self):
+        import urllib.error
+        fd, fpath = tempfile.mkstemp(prefix="sutando-attach-test-", suffix=".txt", dir="/tmp")
+        os.write(fd, b"x"); os.close(fd)
+        self.addCleanup(lambda: os.path.exists(fpath) and os.unlink(fpath))
+        self._req_patch.stop()
+        try:
+            with patch.object(self.mod, "_req",
+                              side_effect=urllib.error.HTTPError("u", 500, "boom", {}, None)):
+                ok, reason = self.mod._upload_attachment("!r:s", fpath)
+            self.assertFalse(ok); self.assertIn("HTTP 500", reason)
+            with patch.object(self.mod, "_req",
+                              side_effect=urllib.error.URLError("down")):
+                ok, reason = self.mod._upload_attachment("!r:s", fpath)
+            self.assertFalse(ok); self.assertIn("network error", reason)
+        finally:
+            self._req_patch.start()
+
+    def test_result_post_errors_leave_result_for_retry(self):
+        import urllib.error
+        self._req_patch.stop()
+        try:
+            for exc in (urllib.error.HTTPError("u", 502, "bad", {}, None),
+                        urllib.error.URLError("down")):
+                self._result("t9", "plain reply")
+                with patch.object(self.mod, "_req", side_effect=exc):
+                    inflight = {"t9"}
+                    self.mod._post_ready_results(inflight)
+                # not archived, still inflight — the next loop retries
+                self.assertIn("t9", inflight)
+                self.assertTrue((self.mod.RESULTS_DIR / "t9.txt").exists())
+                (self.mod.RESULTS_DIR / "t9.txt").unlink()
+        finally:
+            self._req_patch.start()
+
+    def test_save_rooms_persist_failure_never_raises(self):
+        with patch.object(self.mod.json, "dumps", side_effect=RuntimeError("boom")):
+            self.mod._save_task_rooms({"a": "!x:s"})  # must not raise
+
     # 5 — sidecar map round-trip
     def test_rooms_map_roundtrip(self):
         self.mod._record_task_room("a", "!x:s")

--- a/tests/remote-gateway-file-attach.test.py
+++ b/tests/remote-gateway-file-attach.test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Tests for the remote-gateway-bridge outbound file-attach path.
+
+Covers:
+  1. `_post_ready_results` routes marker decisions through the unified
+     parser (parse_markers, #873): skip markers archive without POSTing.
+  2. `[file:]` markers upload via POST /v1/rooms/{room}/media, the marker
+     is stripped from the delivered body, and the room comes from the
+     task→room sidecar map recorded at queue time.
+  3. Disallowed / missing-room attachments degrade to an in-band
+     `[attachment not sent: …]` note — never a silent drop, never a crash.
+  4. `[channel:]` redirect is re-stitched (gateway handles redirect
+     server-side for this transport).
+  5. The task→room sidecar map round-trips and is pruned on delivery.
+
+Run: python3 tests/remote-gateway-file-attach.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "remote-gateway-bridge.py"
+
+
+def _load(ws: Path):
+    """Load the hyphenated bridge module against a scratch workspace."""
+    os.environ["SUTANDO_TEST_WORKSPACE"] = str(ws)
+    os.environ.setdefault("REMOTE_TASK_TOKEN", "test-token-0123456789abcdef")
+    os.environ.setdefault("REMOTE_TASK_URL", "https://gw.invalid/relay")
+    sys.path.insert(0, str(REPO / "src"))
+    spec = importlib.util.spec_from_file_location("rgb_under_test", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    with patch("workspace_default.resolve_workspace", return_value=ws):
+        spec.loader.exec_module(mod)
+    # Re-point the module's derived paths at the scratch workspace regardless
+    # of what resolve_workspace did during import (belt + braces for CI envs).
+    mod.WS = ws
+    mod.TASKS_DIR = ws / "tasks"
+    mod.RESULTS_DIR = ws / "results"
+    mod.ARCHIVE_RESULTS_DIR = ws / "results" / "archive"
+    mod.INFLIGHT_FILE = ws / "state" / "remote-task-inflight.json"
+    mod.TASK_ROOMS_FILE = ws / "state" / "remote-task-rooms.json"
+    for d in (mod.TASKS_DIR, mod.RESULTS_DIR, ws / "state"):
+        d.mkdir(parents=True, exist_ok=True)
+    return mod
+
+
+class FileAttachTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+        self.mod = _load(self.ws)
+        self.calls: list[tuple[str, str, dict | None]] = []
+
+        def fake_req(method, path, payload=None, timeout=35):
+            self.calls.append((method, path, payload))
+            return {}
+
+        self._req_patch = patch.object(self.mod, "_req", side_effect=fake_req)
+        self._req_patch.start()
+
+    def tearDown(self):
+        self._req_patch.stop()
+        self._tmp.cleanup()
+
+    def _result(self, tid: str, body: str) -> None:
+        (self.mod.RESULTS_DIR / f"{tid}.txt").write_text(body)
+
+    # 1 — unified-parser skip semantics
+    def test_skip_marker_archives_without_posting(self):
+        self._result("t1", "[no-send] internal only")
+        self.mod._post_ready_results({"t1"})
+        self.assertEqual(self.calls, [])
+        self.assertTrue(list((self.mod.ARCHIVE_RESULTS_DIR).glob("t1-*.txt")))
+
+    # 2 — happy path: allowlisted file uploads, marker stripped, room from map
+    def test_attach_uploads_and_strips_marker(self):
+        # `/tmp/sutando-*` is an allowlisted prefix on every machine
+        # (send_allowlist.SEND_ALLOWED_PREFIXES) — use it so the happy path
+        # actually runs everywhere instead of skipping.
+        fd, fpath = tempfile.mkstemp(prefix="sutando-attach-test-", suffix=".txt", dir="/tmp")
+        os.write(fd, b"payload")
+        os.close(fd)
+        self.addCleanup(lambda: os.path.exists(fpath) and os.unlink(fpath))
+        self.assertTrue(self.mod.is_path_sendable(fpath),
+                        f"expected allowlisted prefix for {fpath}")
+        self.mod._record_task_room("t2", "!room:server")
+        self._result("t2", f"here you go [file: {fpath}]")
+        self.mod._post_ready_results({"t2"})
+        media = [c for c in self.calls if "/media" in c[1]]
+        results = [c for c in self.calls if c[1] == "/v1/results"]
+        self.assertEqual(len(media), 1)
+        self.assertIn("/v1/rooms/%21room%3Aserver/media", media[0][1])
+        self.assertEqual(media[0][2]["filename"], os.path.basename(fpath))
+        self.assertEqual(len(results), 1)
+        self.assertNotIn("[file:", results[0][2]["body"])
+        self.assertIn("here you go", results[0][2]["body"])
+        # map pruned on delivery
+        self.assertNotIn("t2", self.mod._load_task_rooms())
+
+    # 3 — disallowed path degrades to an in-band note
+    def test_disallowed_attachment_noted_in_band(self):
+        self.mod._record_task_room("t3", "!room:server")
+        self._result("t3", "sensitive [file: /etc/passwd]")
+        self.mod._post_ready_results({"t3"})
+        media = [c for c in self.calls if "/media" in c[1]]
+        results = [c for c in self.calls if c[1] == "/v1/results"]
+        self.assertEqual(media, [])
+        self.assertEqual(len(results), 1)
+        self.assertIn("[attachment not sent: /etc/passwd", results[0][2]["body"])
+
+    def test_unknown_room_noted_in_band(self):
+        self._result("t4", "report [file: /tmp/whatever.txt]")
+        self.mod._post_ready_results({"t4"})
+        results = [c for c in self.calls if c[1] == "/v1/results"]
+        self.assertEqual(len(results), 1)
+        self.assertIn("origin room unknown", results[0][2]["body"])
+
+    # 4 — redirect is re-stitched for the gateway to handle
+    def test_redirect_restitched_first_line(self):
+        self._result("t5", "[channel: !dev:server]\nthe reply")
+        self.mod._post_ready_results({"t5"})
+        results = [c for c in self.calls if c[1] == "/v1/results"]
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0][2]["body"].startswith("[channel: !dev:server]"))
+        self.assertIn("the reply", results[0][2]["body"])
+
+    # 5 — sidecar map round-trip
+    def test_rooms_map_roundtrip(self):
+        self.mod._record_task_room("a", "!x:s")
+        self.mod._record_task_room("b", "!y:s")
+        self.assertEqual(self.mod._load_task_rooms(), {"a": "!x:s", "b": "!y:s"})
+        self.mod._forget_task_room("a")
+        self.assertEqual(self.mod._load_task_rooms(), {"b": "!y:s"})
+        # corrupt file fails open
+        self.mod.TASK_ROOMS_FILE.write_text("{not json")
+        self.assertEqual(self.mod._load_task_rooms(), {})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
TODO open item "gateway outbound file-attach — docs/files as real attachments" (claimed in Master Room). Client half — the server media endpoint already shipped.

## Problem
Relay results drop `[file:|send:|attach:]` markers as literal text: the gateway transport has no outbound file path, so an agent replying with an attachment on Discord delivers it, but the same result over the gateway shows the raw marker.

## Fix
- **Unified parser adoption**: all marker decisions now route through `result_markers.parse_markers` (#873), replacing this bridge's hand-rolled `startswith` block. The no-leak structural guard (`tests/bridge-marker-no-leak.test.py`) now covers this bridge too.
- **Attach**: each allowlisted file (shared `send_allowlist` policy + `MAX_MEDIA_BYTES` cap) uploads to the task's origin room via `POST /v1/rooms/{room}/media`; failures degrade to an in-band `[attachment not sent: …]` note — never a silent drop.
- **Origin room** comes from a new `{task id → room}` sidecar map recorded at queue time (`state/remote-task-rooms.json`); the inflight ledger's list format is untouched. Entries pruned on delivery/archive.
- **Redirect** (`[channel:]`) is re-stitched onto the body — redirect is handled gateway-side for this transport, so stripping it client-side would regress.
- **Retry safety**: in-process `(tid, path)` guard prevents duplicate uploads when a result POST fails and the loop retries.

## Verify
- `tests/remote-gateway-file-attach.test.py`: 6 cases — skip archives without POST, happy-path upload (endpoint + payload shape + marker stripped + map pruned), disallowed-path note, unknown-room note, redirect re-stitch, map round-trip + corrupt-file fail-open. All pass.
- `tests/bridge-marker-no-leak.test.py` PASS with the new 3c guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)