### PR TITLE
docs(agent-room-ops): rename room 'vault' → 'Room Context' (agent-facing prose, track 7)

### DIFF
--- a/skills/agent-room-ops/SKILL.md
+++ b/skills/agent-room-ops/SKILL.md
@@ -18,7 +18,7 @@ does the privileged Matrix ops + authoritative membership enforcement.
 | `react <room> <event>` | add an `m.reaction` (ack) | discord `add_reaction` (👀/✅) |
 | `unreact <room> <event>` | remove the agent's reaction | discord remove-on-reply |
 | `join <room>` | accept the agent's own pending invite | discord guild-join on invite |
-| `doc get\|put\|rm <room>` | read/write/delete the room's shared vault docs (context, todo, memos — or any agent-defined folder) | the durable-state half: like a pinned channel wiki the bot can edit |
+| `doc get\|put\|rm <room>` | read/write/delete the room's shared **Room Context** docs (context, todo, memos — or any agent-defined folder) | the durable-state half: like a pinned channel wiki the bot can edit |
 
 ```bash
 python3 skills/agent-room-ops/room_ops.py read   '!room:hs' --limit 20 --agent '@a:hs'

--- a/skills/agent-room-ops/doc.py
+++ b/skills/agent-room-ops/doc.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""room-ops · doc — read/write/delete a room's shared vault documents.
+"""room-ops · doc — read/write/delete a room's shared Room Context documents.
 
 The missing half of room participation: `read`/`send`/`react` cover the room
-TIMELINE; `doc` covers the room's durable SHARED STATE — the per-room vault
+TIMELINE; `doc` covers the room's durable SHARED STATE — the per-room Room Context store
 folders (`room-live-context/`, `room-todo/`, `room-memo/`,
 `room-live-transcript/` by convention, or any agent-defined folder the gateway
 accepts). With these three verbs an agent can maintain a room's context,
@@ -56,7 +56,7 @@ def _call(op, room_id, agent_mxid, gate, extra):
 
 
 def doc_get(room_id, folder=DEFAULT_FOLDER, name=None, agent_mxid=None, *, gate=None):
-    """Fetch one vault doc (or the folder's default doc when `name` is None)."""
+    """Fetch one Room Context doc (or the folder's default doc when `name` is None)."""
     extra = {"folder": folder}
     if name:
         extra["filename"] = name
@@ -70,7 +70,7 @@ def doc_get(room_id, folder=DEFAULT_FOLDER, name=None, agent_mxid=None, *, gate=
 
 def doc_put(room_id, content, folder=DEFAULT_FOLDER, name="CONTEXT.md",
             message=None, agent_mxid=None, *, gate=None):
-    """Create or update one vault doc (full-content write, gateway commits)."""
+    """Create or update one Room Context doc (full-content write, gateway commits)."""
     extra = {
         "folder": folder, "filename": name,
         "content_b64": base64.b64encode((content or "").encode()).decode(),
@@ -85,7 +85,7 @@ def doc_put(room_id, content, folder=DEFAULT_FOLDER, name="CONTEXT.md",
 
 
 def doc_rm(room_id, name, folder=DEFAULT_FOLDER, agent_mxid=None, *, gate=None):
-    """Delete one vault doc (404 at the gateway degrades to a graceful ok:false)."""
+    """Delete one Room Context doc (404 at the gateway degrades to a graceful ok:false)."""
     res = _call("prep_delete", room_id, agent_mxid, gate,
                 {"folder": folder, "filename": name})
     if not isinstance(res, dict) or res.get("ok") is False:

--- a/skills/agent-room-ops/room_ops.py
+++ b/skills/agent-room-ops/room_ops.py
@@ -52,7 +52,7 @@ def _main(argv):
     p.add_argument("--caption", default=None)
     p.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
 
-    p = sub.add_parser("doc", help="read/write/delete a room vault document")
+    p = sub.add_parser("doc", help="read/write/delete a room Context document")
     p.add_argument("action", choices=["get", "put", "rm"])
     p.add_argument("room")
     p.add_argument("--folder", default="room-live-context")


### PR DESCRIPTION
## What

Renames the room shared-state noun from "vault" to **Room Context** in agent-facing prose only:
- `SKILL.md` — the `doc get|put|rm` verb description.
- `doc.py` — module docstring + the get/put/rm docstrings.
- `room_ops.py` — the `doc` subcommand help text.

## What is deliberately NOT changed

- **Wire protocol**: folder names (`room-memo`/`room-todo`), `--folder` args, the `doc get/put/rm` verbs, and the gateway `prep_*` ops — all untouched. The naming changes, the protocol doesn't.
- **The secret vault**: `GATEWAY_TOKEN … from env/vault` (the Keychain credential store) stays "vault" — only the room-shared-state sense is renamed.

## Why

"Vault" collides with the secret/credential vault and reads as locked storage; "Room Context" says what the docs actually hold.

## Tests

56 agent-room-ops tests pass; `py_compile` clean. Docs/copy only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
