### PR TITLE
fix(morning-briefing): skip organizer headers in pending-questions extract

### DIFF
--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -238,13 +238,25 @@ def get_pending_questions() -> list[str]:
     # this cut the briefing speaks every resolved entry as still-pending.
     # No-op when there is no such divider.
     content = re.split(r'^#\s+Resolved\b', content, maxsplit=1, flags=re.MULTILINE)[0]
+    # Organizer/section-shell headers (e.g. "## FRESH — 2026-07-05 [wu-air]",
+    # "## ACTIVE — ...", "## SURFACED — ...") group questions but are not
+    # themselves questions — skip them so the briefing's "top item" is a real
+    # question, not a date-label. Also skip anything already marked resolved
+    # inline (the "# Resolved" divider above is a no-op for files that use
+    # per-item "[RESOLVED]" markers instead).
+    org_header = re.compile(
+        r'^(FRESH|ACTIVE|HELD|TRIAGE|SURFACED|RESOLVED|ANSWERED)\b', re.IGNORECASE
+    )
     questions = []
     for section in re.split(r'^## ', content, flags=re.MULTILINE)[1:]:
         title = section.partition('\n')[0].strip()
         # Strip leading date prefix like "[2026-05-27] "
         title = re.sub(r'^\[\d{4}-\d{2}-\d{2}\]\s*', '', title)
-        if title:
-            questions.append(title[:60])
+        if not title:
+            continue
+        if 'RESOLVED' in title.upper() or org_header.match(title):
+            continue
+        questions.append(title[:60])
     return questions
 
 

--- a/tests/morning-briefing-pending-extract.test.py
+++ b/tests/morning-briefing-pending-extract.test.py
@@ -84,6 +84,16 @@ class TestGetPendingQuestions(unittest.TestCase):
         qs = self._run(text)
         self.assertEqual(qs, ["1. Open question?"])
 
+    def test_skips_empty_title_header(self):
+        # A header that is only a date prefix strips to an empty title and
+        # must be skipped (not emitted as a blank question).
+        text = (
+            "## [2026-07-10]\n"
+            "## 1. Real question?\n"
+        )
+        qs = self._run(text)
+        self.assertEqual(qs, ["1. Real question?"])
+
     def test_missing_file_returns_empty(self):
         with patch.object(
             self.mod, "personal_path", return_value=Path("/nonexistent/pq.md")

--- a/tests/morning-briefing-pending-extract.test.py
+++ b/tests/morning-briefing-pending-extract.test.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for morning-briefing.py get_pending_questions() filtering.
+
+Before this fix, every `## ` section title in pending-questions.md was
+treated as a pending question — including organizer/section-shell headers
+(`## FRESH — …`, `## ACTIVE — …`, `## SURFACED — …`) and already-resolved
+items. That made the briefing's "Top item" a section label and inflated the
+count.
+
+After the fix, section-shell headers and inline-[RESOLVED] titles are skipped,
+so only real open questions are returned (order preserved).
+"""
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "morning-briefing.py"
+
+
+def _load():
+    # src/ is on the path so the module's `from util_paths import …` resolves.
+    sys.path.insert(0, str(REPO / "src"))
+    spec = importlib.util.spec_from_file_location("morning_briefing", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestGetPendingQuestions(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+
+    def _run(self, text: str):
+        """Write `text` to a temp file and run get_pending_questions against it."""
+        with tempfile.TemporaryDirectory() as d:
+            pq = Path(d) / "pending-questions.md"
+            pq.write_text(text)
+            with patch.object(self.mod, "personal_path", return_value=pq):
+                return self.mod.get_pending_questions()
+
+    def test_skips_organizer_section_headers(self):
+        text = (
+            "# Pending questions\n"
+            "## FRESH — 2026-07-05 [name]\n"
+            "## ACTIVE — 2026-07-04 session\n"
+            "## SURFACED — 2026-07-10 [name]\n"
+            "## 1. Build the widget? (yes/no)\n"
+        )
+        qs = self._run(text)
+        self.assertEqual(qs, ["1. Build the widget? (yes/no)"])
+
+    def test_skips_inline_resolved(self):
+        text = (
+            "## 2. [RESOLVED 2026-07-03] shipped already\n"
+            "## 3. Force, hand-merge, or leave?\n"
+        )
+        qs = self._run(text)
+        self.assertEqual(qs, ["3. Force, hand-merge, or leave?"])
+
+    def test_preserves_order_of_real_questions(self):
+        text = (
+            "## FRESH — 2026-07-05 [name]\n"
+            "## 1. First question?\n"
+            "## 2. Second question?\n"
+        )
+        qs = self._run(text)
+        self.assertEqual(qs, ["1. First question?", "2. Second question?"])
+
+    def test_strips_leading_date_prefix(self):
+        text = "## [2026-05-27] Real dated question?\n"
+        qs = self._run(text)
+        self.assertEqual(qs, ["Real dated question?"])
+
+    def test_resolved_divider_still_cuts(self):
+        text = (
+            "## 1. Open question?\n"
+            "# Resolved\n"
+            "## 9. Old answered thing\n"
+        )
+        qs = self._run(text)
+        self.assertEqual(qs, ["1. Open question?"])
+
+    def test_missing_file_returns_empty(self):
+        with patch.object(
+            self.mod, "personal_path", return_value=Path("/nonexistent/pq.md")
+        ):
+            self.assertEqual(self.mod.get_pending_questions(), [])
+
+    def test_truncates_long_titles_to_60(self):
+        long_q = "## " + ("x" * 100) + "\n"
+        qs = self._run(long_q)
+        self.assertEqual(len(qs), 1)
+        self.assertEqual(len(qs[0]), 60)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`get_pending_questions()` in `src/morning-briefing.py` treats every `## ` section title in `pending-questions.md` as a pending question. But that file also uses `## ` for **organizer/section-shell headers** (`## FRESH — <date> [name]`, `## ACTIVE — …`, `## SURFACED — …`), which group questions rather than being questions themselves.

Result: the briefing's spoken "Top item: …" surfaces a section label (e.g. a date-stamped header) instead of an actual question, and the pending-question **count is inflated** by the header rows + already-resolved items.

## Fix

Skip section-shell headers (`FRESH/ACTIVE/HELD/TRIAGE/SURFACED/RESOLVED/ANSWERED` prefixes) and any title carrying an inline `[RESOLVED]` marker. Additive, single-function change.

- The pre-existing `# Resolved` divider cut (#1402) is preserved — it stays a no-op for files that use per-item `[RESOLVED]` markers instead of a top-level divider.

## Verification

Ran the updated extractor against a real `pending-questions.md`:
- **Before:** count included section headers; top item was a date-label header.
- **After:** count reflects only open questions; top item is a real question.

`python3 -m py_compile src/morning-briefing.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)