### PR TITLE
fix(tmux-status): pass -S custom socket so pane capture finds sutando-core

### DIFF
--- a/src/tmux-status.ts
+++ b/src/tmux-status.ts
@@ -4,7 +4,16 @@
 // and categorizes the rendered state.
 //
 // Disabled by setting `SUTANDO_TMUX_SCRAPE=0`. Tmux session name override via
-// `SUTANDO_TMUX_SESSION` (default `sutando-core`).
+// `SUTANDO_TMUX_SESSION` (default `sutando-core`), socket override via
+// `SUTANDO_TMUX_SOCK` (default `/tmp/sutando-tmux.sock`).
+//
+// The socket flag is load-bearing: Sutando.app / start-cli.sh run their tmux
+// server on the custom socket `/tmp/sutando-tmux.sock` (via `tmux -S`), NOT the
+// default socket. A bare `tmux capture-pane` therefore talks to the default
+// server, never finds the `sutando-core` session, throws, and this scraper
+// falls back to `idle` on EVERY call — so the status widget reads "idle" even
+// while the core is actively working. The Swift path (main.swift) and the
+// watcher (watch-tasks-stream.sh) both already pass `-S`; this scraper must too.
 //
 // All failure modes (tmux missing, timeout, parse error) return `idle` — this
 // is a best-effort hint, never ground-truth, never throws.
@@ -20,6 +29,9 @@ export type TmuxParseResult = {
 };
 
 const DEFAULT_SESSION = 'sutando-core';
+// Must match start-cli.sh (TMUX_SOCKET), main.swift (sutandoTmuxSocket), and
+// watch-tasks-stream.sh (SUTANDO_TMUX_SOCK default). Single canonical socket.
+const DEFAULT_SOCKET = '/tmp/sutando-tmux.sock';
 const CACHE_TTL_MS = 3_000;
 const CAPTURE_TIMEOUT_MS = 500;
 const LINES_BACK = 30;
@@ -35,14 +47,28 @@ function logOnce(msg: string): void {
 	console.error(`[tmux-status] ${msg}`);
 }
 
+/**
+ * Build the `tmux` argv for capturing the core pane. Exported for testing.
+ *
+ * The `-S <socket>` server flag MUST precede the `capture-pane` command — tmux
+ * parses server options before the command word. Sutando.app / start-cli.sh run
+ * the tmux server on this custom socket, so omitting `-S` targets the default
+ * server (where `sutando-core` does not exist), the capture throws, and the
+ * scraper silently reports `idle` forever. See the header note.
+ */
+export function buildCaptureArgs(socket: string, session: string): string[] {
+	return ['-S', socket, 'capture-pane', '-t', session, '-pS', `-${LINES_BACK}`];
+}
+
 async function _refreshCache(): Promise<void> {
 	if (_refreshInFlight) return;
 	_refreshInFlight = true;
 	const session = process.env.SUTANDO_TMUX_SESSION || DEFAULT_SESSION;
+	const socket = process.env.SUTANDO_TMUX_SOCK || DEFAULT_SOCKET;
 	try {
 		const { stdout } = await execFileAsync(
 			'tmux',
-			['capture-pane', '-t', session, '-pS', `-${LINES_BACK}`],
+			buildCaptureArgs(socket, session),
 			{ encoding: 'utf-8', timeout: CAPTURE_TIMEOUT_MS },
 		);
 		_cache = { ts: Date.now(), result: parseTmuxPane(stdout) };

--- a/tests/tmux-status.test.ts
+++ b/tests/tmux-status.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseTmuxPane, readTmuxStatus, _resetTmuxCacheForTests } from '../src/tmux-status.js';
+import { parseTmuxPane, readTmuxStatus, buildCaptureArgs, _resetTmuxCacheForTests } from '../src/tmux-status.js';
 
 /**
  * Tests for `parseTmuxPane` — the pane-capture parser used as a fallback
@@ -162,6 +162,31 @@ describe('parseTmuxPane', () => {
 		const r = parseTmuxPane(42);
 		assert.equal(r.state, 'idle');
 		assert.equal(r.label, '');
+	});
+});
+
+describe('buildCaptureArgs', () => {
+	// Regression guard: Sutando.app / start-cli.sh run tmux on a custom socket
+	// (`tmux -S /tmp/sutando-tmux.sock`). A bare `tmux capture-pane` hits the
+	// DEFAULT server, never finds `sutando-core`, throws, and the scraper falls
+	// back to `idle` on every call — so the status widget reads "idle" even
+	// while the core is working. The `-S <socket>` server flag must be present
+	// AND precede the `capture-pane` command word.
+
+	it('includes -S <socket> and it precedes capture-pane', () => {
+		const args = buildCaptureArgs('/tmp/sutando-tmux.sock', 'sutando-core');
+		const sIdx = args.indexOf('-S');
+		const capIdx = args.indexOf('capture-pane');
+		assert.notEqual(sIdx, -1, '-S socket flag must be present');
+		assert.equal(args[sIdx + 1], '/tmp/sutando-tmux.sock', '-S must be followed by the socket path');
+		assert.ok(sIdx < capIdx, '-S (server flag) must come before the capture-pane command');
+	});
+
+	it('targets the given session with -t', () => {
+		const args = buildCaptureArgs('/sock', 'my-session');
+		const tIdx = args.indexOf('-t');
+		assert.notEqual(tIdx, -1);
+		assert.equal(args[tIdx + 1], 'my-session');
 	});
 });
 


### PR DESCRIPTION
## Problem

Sutando.app and `start-cli.sh` run their tmux server on the **custom socket** `/tmp/sutando-tmux.sock` (`tmux -S …`), not the default socket. But the status scraper in `src/tmux-status.ts` called `tmux capture-pane` with **no `-S` flag**:

```ts
['capture-pane', '-t', session, '-pS', `-${LINES_BACK}`]
```

So it talked to the *default* tmux server, never found the `sutando-core` session, threw, and fell into the `idle` fallback on **every** call. Net effect: the live-status widget reported **"idle" even while the core was actively working** — a silent, always-on failure.

The Swift path (`main.swift:877`) and the watcher (`watch-tasks-stream.sh`) both already pass `-S`; this scraper was the lone omission.

## Fix

Pass `-S <socket>` (a server flag — must precede the command word) sourced from `SUTANDO_TMUX_SOCK`, defaulting to the canonical `/tmp/sutando-tmux.sock` — matching `start-cli.sh` (`TMUX_SOCKET`), `main.swift` (`sutandoTmuxSocket`), and `watch-tasks-stream.sh`.

Extracted `buildCaptureArgs(socket, session)` so the argv is unit-testable, and added a regression test asserting `-S <socket>` is present and precedes `capture-pane`. Verified the test **fails** when the flag is removed.

## Test

- `npx tsc --noEmit` clean.
- `tsx --test tests/tmux-status.test.ts` — 18/18 pass (2 new).
- Regression confirmed: neutering `-S` makes the new test fail.

## Scope

`src/tmux-status.ts` + its test. Single concern. Behavior unchanged where callers already set `SUTANDO_TMUX_SOCK`; default now matches the rest of the codebase instead of the wrong (default) socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)