### PR TITLE
fix(recording): probe the bundled-runtime ffmpeg for subtitles

### DIFF
--- a/src/recording-tools.ts
+++ b/src/recording-tools.ts
@@ -5,6 +5,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { writeFileSync, unlinkSync, readFileSync, readlinkSync, existsSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { demoStateRef, narrationSpeakingRef, lastSpokenRef, nextDescRef, scrollPausedRef } from './recording-state.js';
@@ -14,14 +15,39 @@ const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
 /**
  * Auto-detect an ffmpeg binary that has the `subtitles` filter (requires libass).
  * Cached after first call so the probe only runs once per process lifetime.
- * Probe order: $FFMPEG_SUBTITLE_BIN env → system ffmpeg → homebrew narrow → homebrew full.
+ * Probe order: $FFMPEG_SUBTITLE_BIN env → system ffmpeg → homebrew narrow →
+ * homebrew full → bundled runtime.
+ *
+ * The bundled-runtime candidate is the fix for a real failure mode: when the
+ * voice-agent runs inside Sutando.app it executes under the bundled node at
+ * `…/Contents/Resources/runtime/bin/node`, and a libass-capable ffmpeg ships
+ * as its sibling (`…/runtime/bin/ffmpeg`). On an install with no ffmpeg on PATH
+ * and no Homebrew, all the earlier candidates miss and subtitles silently fail
+ * even though a perfectly capable ffmpeg sits right next to the running node.
+ * Deriving the path from `process.execPath` means we find it without any env
+ * wiring; in dev (system node) the sibling simply doesn't exist and the probe
+ * falls through harmlessly. Kept LAST so working installs are unaffected.
  */
+/**
+ * Ordered ffmpeg probe candidates for a given node exec path. Exported for
+ * testing. The final entry is the bundled runtime ffmpeg (sibling of the
+ * running node) — see findFfmpegWithSubtitles for why it's last.
+ */
+export function ffmpegSubtitleCandidates(execPath: string): string[] {
+	return [
+		'ffmpeg',
+		'/opt/homebrew/bin/ffmpeg',
+		'/opt/homebrew/opt/ffmpeg-full/bin/ffmpeg',
+		join(dirname(execPath), 'ffmpeg'),
+	];
+}
+
 let _cachedSubtitleFfmpeg: string | null | undefined;
 function findFfmpegWithSubtitles(): string | null {
 	if (_cachedSubtitleFfmpeg !== undefined) return _cachedSubtitleFfmpeg;
 	const envBin = process.env.FFMPEG_SUBTITLE_BIN?.trim();
 	if (envBin) { _cachedSubtitleFfmpeg = envBin; console.log(`${ts()} [ffmpeg] using $FFMPEG_SUBTITLE_BIN: ${envBin}`); return envBin; }
-	const candidates = ['ffmpeg', '/opt/homebrew/bin/ffmpeg', '/opt/homebrew/opt/ffmpeg-full/bin/ffmpeg'];
+	const candidates = ffmpegSubtitleCandidates(process.execPath);
 	for (const bin of candidates) {
 		try {
 			// execFileSync argv array — bin is from env or hardcoded candidates, not user input (fixes #1451)

--- a/tests/recording-tools-ffmpeg.test.ts
+++ b/tests/recording-tools-ffmpeg.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { dirname, join } from 'node:path';
+import { ffmpegSubtitleCandidates } from '../src/recording-tools.js';
+
+/**
+ * Regression guard for the ffmpeg subtitle-probe bundled-runtime fix.
+ *
+ * When the voice-agent runs inside Sutando.app it executes under the bundled
+ * node at `…/Contents/Resources/runtime/bin/node`, and a libass-capable ffmpeg
+ * ships as its sibling `…/runtime/bin/ffmpeg`. Before this fix the probe only
+ * checked PATH + Homebrew, so on an install with neither, subtitles silently
+ * failed even though a capable ffmpeg sat right next to the running node.
+ */
+describe('ffmpegSubtitleCandidates', () => {
+	it('includes the bundled ffmpeg as a sibling of the node exec path', () => {
+		const execPath = '/Applications/Sutando.app/Contents/Resources/runtime/bin/node';
+		const cands = ffmpegSubtitleCandidates(execPath);
+		const expected = join(dirname(execPath), 'ffmpeg');
+		assert.equal(expected, '/Applications/Sutando.app/Contents/Resources/runtime/bin/ffmpeg');
+		assert.ok(cands.includes(expected), 'bundled-runtime sibling ffmpeg must be a candidate');
+	});
+
+	it('keeps the bundled candidate LAST so working installs are unaffected', () => {
+		const cands = ffmpegSubtitleCandidates('/opt/homebrew/bin/node');
+		assert.equal(cands[0], 'ffmpeg', 'PATH ffmpeg stays first');
+		assert.equal(cands[cands.length - 1], '/opt/homebrew/bin/ffmpeg', 'bundled sibling is last');
+	});
+
+	it('still probes PATH and both Homebrew locations', () => {
+		const cands = ffmpegSubtitleCandidates('/usr/bin/node');
+		assert.ok(cands.includes('ffmpeg'));
+		assert.ok(cands.includes('/opt/homebrew/bin/ffmpeg'));
+		assert.ok(cands.includes('/opt/homebrew/opt/ffmpeg-full/bin/ffmpeg'));
+	});
+});


### PR DESCRIPTION
## Problem

The subtitle-burn probe (`findFfmpegWithSubtitles`) only checked `$FFMPEG_SUBTITLE_BIN`, PATH `ffmpeg`, and two Homebrew locations. But inside Sutando.app the voice-agent runs under the **bundled node** at `…/Contents/Resources/runtime/bin/node`, and a libass-capable ffmpeg ships as its **sibling** `…/runtime/bin/ffmpeg`. On an install with no ffmpeg on PATH and no Homebrew, every candidate missed → screen-recording-with-subtitles silently failed, even though a perfectly capable ffmpeg (verified: `--enable-libass`, has the `subtitles` filter) sat right next to the running node.

Reported from an install exhibiting exactly this (no PATH ffmpeg, no Homebrew).

## Fix

Add the bundled binary as a probe candidate, derived from `process.execPath` so it needs no env wiring:
```ts
join(dirname(process.execPath), 'ffmpeg')
```
Kept **last** so installs that already resolve a system/Homebrew ffmpeg are unaffected; in dev (system node) the sibling doesn't exist and the probe falls through harmlessly.

Extracted `ffmpegSubtitleCandidates(execPath)` as a pure exported helper and added a regression test: bundled sibling present, ordered last, PATH + both Homebrew paths still probed. Verified the test fails when the bundled candidate is dropped.

## Test

- `npx tsc --noEmit` clean.
- `tsx --test tests/recording-tools-ffmpeg.test.ts` — 3/3 pass.
- Empirically confirmed on a bundled install: `…/runtime/bin/ffmpeg` exists, is a sibling of `…/runtime/bin/node`, and reports the `subtitles` filter.

## Scope

`src/recording-tools.ts` + a new focused test. Single concern; additive probe candidate only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)