### PR TITLE
fix(health-check): stop nagging when cross-machine sync is off by design

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -164,6 +164,19 @@ def _vault_sync_disabled() -> bool:
         return False
 
 
+def _vault_remote_url() -> str:
+    """The canonical vault remote (sutando.config.{local.,}json → vault.remote_url)
+    via the same config-helper contract as _vault_sync_disabled. Empty string when
+    unset or on any error (callers then try the legacy .env alias)."""
+    try:
+        return subprocess.run(
+            ["bash", str(REPO_DIR / "scripts" / "sutando-config.sh"), "vault-url"],
+            capture_output=True, text=True, timeout=5,
+        ).stdout.strip()
+    except Exception:
+        return ""
+
+
 def check_memory_sync() -> dict:
     """Verify memory sync is configured and has run recently.
 
@@ -177,13 +190,18 @@ def check_memory_sync() -> dict:
     # Deliberate config opt-out → informational, never a nag.
     if _vault_sync_disabled():
         return {"name": name, "status": "ok", "detail": "cross-machine sync disabled (config opt-out)"}
-    env_path = REPO_DIR / ".env"
-    repo_url = ""
-    if env_path.exists():
-        for line in env_path.read_text().splitlines():
-            if line.startswith("SUTANDO_MEMORY_REPO="):
-                repo_url = line.split("=", 1)[1].strip().strip('"').strip("'")
-                break
+    # "Configured?" must consult the CANONICAL config first (vault.remote_url
+    # via sutando-config.sh — the documented setup path), not just the legacy
+    # .env alias; otherwise a config-file host with sync enabled+stale would
+    # false-"ok" as single-machine mode and stop alerting entirely (qingyun P1).
+    repo_url = _vault_remote_url()
+    if not repo_url:
+        env_path = REPO_DIR / ".env"
+        if env_path.exists():
+            for line in env_path.read_text().splitlines():
+                if line.startswith("SUTANDO_MEMORY_REPO="):
+                    repo_url = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    break
     if not repo_url:
         return {"name": name, "status": "ok", "detail": "cross-machine sync not configured (single-machine mode)"}
     # Current model (sync-workspace.sh): the workspace ITSELF is a git repo with

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -150,9 +150,33 @@ def check_directory(path: Path, name: str) -> dict:
     return {"name": name, "status": "ok", "detail": f"{count} .md files"}
 
 
+def _vault_sync_disabled() -> bool:
+    """True when cross-machine sync is deliberately turned OFF in config
+    (vault.enabled=false via sutando.config). Best-effort — false on any error so
+    a config-helper hiccup never masks a real stale-sync warning."""
+    try:
+        out = subprocess.run(
+            ["bash", str(REPO_DIR / "scripts" / "sutando-config.sh"), "vault-enabled"],
+            capture_output=True, text=True, timeout=5,
+        ).stdout.strip()
+        return out == "false"
+    except Exception:
+        return False
+
+
 def check_memory_sync() -> dict:
-    """Verify memory sync is configured and has run recently."""
+    """Verify memory sync is configured and has run recently.
+
+    Cross-machine sync is OPT-IN. When it's deliberately disabled (vault.enabled=
+    false) or simply not configured, that's a valid single-machine choice — report
+    it as informational (ok), NOT a recurring warn. Otherwise the health check
+    nags "not configured" on every tick forever even though the operator opted out
+    on purpose (owner ask 2026-07-10 — the confusing memory-var warning). A
+    configured-but-stale sync still warns; that's a real problem."""
     name = "memory-sync"
+    # Deliberate config opt-out → informational, never a nag.
+    if _vault_sync_disabled():
+        return {"name": name, "status": "ok", "detail": "cross-machine sync disabled (config opt-out)"}
     env_path = REPO_DIR / ".env"
     repo_url = ""
     if env_path.exists():
@@ -161,7 +185,7 @@ def check_memory_sync() -> dict:
                 repo_url = line.split("=", 1)[1].strip().strip('"').strip("'")
                 break
     if not repo_url:
-        return {"name": name, "status": "warn", "detail": "SUTANDO_MEMORY_REPO not set — cross-machine sync disabled"}
+        return {"name": name, "status": "ok", "detail": "cross-machine sync not configured (single-machine mode)"}
     # Current model (sync-workspace.sh): the workspace ITSELF is a git repo with
     # the vault as a remote — sync = git fetch/merge/push on the workspace, no
     # separate clone dir. So the freshness signal is the workspace's own

--- a/tests/health-check-memory-sync.test.py
+++ b/tests/health-check-memory-sync.test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Tests for health-check.py's check_memory_sync() opt-out behavior.
+
+Context (owner ask 2026-07-10): cross-machine memory sync is OPT-IN, but the
+health check warned "SUTANDO_MEMORY_REPO not set — cross-machine sync disabled"
+on every tick — a permanent nag on any single-machine install, and it ignored a
+deliberate config opt-out (vault.enabled=false). This surfaced as "noise" after
+the 0.61 migration. Fix: report the disabled / not-configured cases as
+informational (ok), not warn; a configured-but-stale sync still warns.
+
+Covers: _vault_sync_disabled() (true/false/error) and the two early-return
+branches of check_memory_sync (opt-out → ok, not-configured → ok).
+
+Run: python3 tests/health-check-memory-sync.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest.mock
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+FAILURES = []
+
+
+def check(name, cond, detail=""):
+    print(f"{'  ok  ' if cond else '  FAIL '}{name}" + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        FAILURES.append(f"{name}: {detail}")
+
+
+def _run_mock(stdout):
+    r = unittest.mock.MagicMock()
+    r.stdout = stdout
+    return r
+
+
+def main() -> int:
+    # _vault_sync_disabled(): "false" → True, "true" → False, error → False.
+    with unittest.mock.patch.object(hc.subprocess, "run", return_value=_run_mock("false")):
+        check("_vault_sync_disabled: 'false' → True", hc._vault_sync_disabled() is True)
+    with unittest.mock.patch.object(hc.subprocess, "run", return_value=_run_mock("true")):
+        check("_vault_sync_disabled: 'true' → False", hc._vault_sync_disabled() is False)
+    with unittest.mock.patch.object(hc.subprocess, "run", side_effect=OSError("boom")):
+        check("_vault_sync_disabled: error → False (fail-open)", hc._vault_sync_disabled() is False)
+
+    # check_memory_sync: deliberate opt-out → ok (no nag).
+    with unittest.mock.patch.object(hc, "_vault_sync_disabled", return_value=True):
+        r = hc.check_memory_sync()
+    check("opt-out → ok", r["status"] == "ok", f"got {r!r}")
+    check("opt-out detail mentions opt-out", "opt-out" in r["detail"], f"got {r!r}")
+
+    # check_memory_sync: not opted out, no SUTANDO_MEMORY_REPO configured → ok
+    # (single-machine), NOT warn.
+    empty_repo = Path(tempfile.mkdtemp(prefix="sutando-hc-nosync-"))  # no .env inside
+    with unittest.mock.patch.object(hc, "_vault_sync_disabled", return_value=False), \
+         unittest.mock.patch.object(hc, "REPO_DIR", empty_repo):
+        r = hc.check_memory_sync()
+    check("not configured → ok (not warn)", r["status"] == "ok", f"got {r!r}")
+    check("not-configured detail is non-scary", "not configured" in r["detail"], f"got {r!r}")
+
+    if FAILURES:
+        print(f"\n{len(FAILURES)} failure(s)")
+        return 1
+    print("\nall check_memory_sync opt-out cases passed")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/tests/health-check-memory-sync.test.py
+++ b/tests/health-check-memory-sync.test.py
@@ -108,6 +108,23 @@ def main() -> int:
     check("config-file configured + never fetched → 'never fetched' state (not 'not configured')",
           "never fetched" in r["detail"] and "not configured" not in r["detail"], f"got {r!r}")
 
+    # Legacy .env fallback path (covers the env-read loop, lines ~199-204):
+    # config has NO vault URL but REPO_DIR/.env carries the deprecated
+    # SUTANDO_MEMORY_REPO alias → repo_url resolves from .env, and (with a
+    # never-fetched workspace git repo) we get the initialized state, NOT the
+    # 'not configured' false-ok.
+    legacy_repo = Path(tempfile.mkdtemp(prefix="sutando-hc-legacy-"))
+    (legacy_repo / ".env").write_text('SUTANDO_MEMORY_REPO="https://vault.example/legacy.git"\n')
+    ws2 = Path(tempfile.mkdtemp(prefix="sutando-hc-ws2-"))
+    (ws2 / ".git").mkdir()
+    with unittest.mock.patch.object(hc, "_vault_sync_disabled", return_value=False), \
+         unittest.mock.patch.object(hc, "_vault_remote_url", return_value=""), \
+         unittest.mock.patch.object(hc, "REPO_DIR", legacy_repo), \
+         unittest.mock.patch.object(hc, "WORKSPACE_DIR", ws2):
+        r = hc.check_memory_sync()
+    check("legacy .env SUTANDO_MEMORY_REPO → configured (not 'not configured')",
+          "not configured" not in r["detail"], f"got {r!r}")
+
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1

--- a/tests/health-check-memory-sync.test.py
+++ b/tests/health-check-memory-sync.test.py
@@ -68,6 +68,46 @@ def main() -> int:
     check("not configured → ok (not warn)", r["status"] == "ok", f"got {r!r}")
     check("not-configured detail is non-scary", "not configured" in r["detail"], f"got {r!r}")
 
+    # ── qingyun P1 regression (config-file hosts) ────────────────────────────
+    # A host with vault.remote_url set in sutando.config (the CANONICAL setup)
+    # and NO legacy .env alias must NOT be reported as "not configured" — that
+    # false "ok" silences real stale-sync alerts. _vault_remote_url() is the
+    # config-loader contract; stub it to the configured URL.
+
+    # _vault_remote_url unit behavior
+    with unittest.mock.patch.object(hc.subprocess, "run", return_value=_run_mock("https://vault.example/repo.git\n")):
+        check("_vault_remote_url: returns stripped URL",
+              hc._vault_remote_url() == "https://vault.example/repo.git")
+    with unittest.mock.patch.object(hc.subprocess, "run", side_effect=OSError("boom")):
+        check("_vault_remote_url: error → '' (falls to legacy alias)", hc._vault_remote_url() == "")
+
+    import os, time as _time
+    # config-configured + workspace git repo + STALE fetch → warn (NOT the false ok)
+    ws = Path(tempfile.mkdtemp(prefix="sutando-hc-ws-"))
+    (ws / ".git").mkdir()
+    fetch = ws / ".git" / "FETCH_HEAD"
+    fetch.write_text("x")
+    os.utime(fetch, (_time.time() - 96 * 3600, _time.time() - 96 * 3600))  # 96h old
+    empty_repo2 = Path(tempfile.mkdtemp(prefix="sutando-hc-noenv-"))  # no .env
+    with unittest.mock.patch.object(hc, "_vault_sync_disabled", return_value=False), \
+         unittest.mock.patch.object(hc, "_vault_remote_url", return_value="https://vault.example/repo.git"), \
+         unittest.mock.patch.object(hc, "REPO_DIR", empty_repo2), \
+         unittest.mock.patch.object(hc, "WORKSPACE_DIR", ws):
+        r = hc.check_memory_sync()
+    check("config-file configured + stale fetch → warn (qingyun P1)",
+          r["status"] == "warn" and "stale" in r["detail"], f"got {r!r}")
+
+    # config-configured + workspace git repo + never fetched → ok 'never fetched',
+    # NOT the 'not configured (single-machine mode)' false-positive.
+    fetch.unlink()
+    with unittest.mock.patch.object(hc, "_vault_sync_disabled", return_value=False), \
+         unittest.mock.patch.object(hc, "_vault_remote_url", return_value="https://vault.example/repo.git"), \
+         unittest.mock.patch.object(hc, "REPO_DIR", empty_repo2), \
+         unittest.mock.patch.object(hc, "WORKSPACE_DIR", ws):
+        r = hc.check_memory_sync()
+    check("config-file configured + never fetched → 'never fetched' state (not 'not configured')",
+          "never fetched" in r["detail"] and "not configured" not in r["detail"], f"got {r!r}")
+
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1


### PR DESCRIPTION
## Problem

`check_memory_sync()` warned **"SUTANDO_MEMORY_REPO not set — cross-machine sync disabled"** on *every* health-check tick whenever no memory repo was configured, and it ignored a deliberate config opt-out (`vault.enabled=false`). On a single-machine install — or one where the operator turned sync off on purpose — that's a permanent, confusing nag, not a signal.

Reported as post-0.61 noise (local config that didn't carry forward cleanly after the migration). Owner: *"we should not show the warning about memory var which is confusing."*

## Fix

Treat both cases as **informational (`ok`)** rather than `warn`:
- **Deliberate opt-out** (`vault.enabled=false`) → `ok` "cross-machine sync disabled (config opt-out)".
- **Not configured** (no `SUTANDO_MEMORY_REPO`) → `ok` "cross-machine sync not configured (single-machine mode)".

A **configured-but-stale** sync still `warn`s — that remains a real problem worth surfacing.

Adds `_vault_sync_disabled()` (reads `vault.enabled` via `sutando-config.sh`, fail-open so a helper hiccup never masks a real stale warning) and `tests/health-check-memory-sync.test.py` covering the helper (true / false / error) and both early-return branches.

## Verify

- New test: 7/7 assertions pass. Full health-check suite: no regressions.
- On a host with sync opted out, the dashboard line flips from `⚠ warn` to:
  `✓ memory-sync  ok  cross-machine sync disabled (config opt-out)`

## Scope

`src/health-check.py` + new test. Single concern. (Companion note: the sibling "false `.env` missing" alert from the same report is already covered by #1973 + #2002.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)