### PR TITLE
fix(health-check): heal PATH for the core-watchdog restart under launchd

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1975,6 +1975,35 @@ def _core_started_within(seconds: float, workspace: Optional[Path] = None, now: 
     return (now - youngest_start) < seconds
 
 
+def _resolve_launch_env() -> dict:
+    """Environment for out-of-process core restarts (start-cli.sh --restart).
+
+    launchd's minimal PATH (``/usr/bin:/bin:/usr/sbin:/sbin``) cannot find the
+    tools start-cli.sh needs — homebrew ``tmux``, ``claude`` in ``~/.local/bin``,
+    or the Sutando.app-bundled ``node`` runtime — so the restart exits rc=127
+    (``node unavailable`` / ``exec: claude: not found``) and silently falls
+    through to the legacy fallback. Prepend all of them.
+
+    Extends the existing tmux-only PATH fix to node + claude. Incident
+    2026-07-10: the watchdog restart path was broken under launchd for ~70 min
+    (queue backlog) because every canonical restart hit rc=127. Same PATH-
+    narrowing class as _resolve_tmux_bin (2026-06-09), applied here.
+    """
+    env = dict(os.environ)
+    extra = [
+        "/opt/homebrew/bin",                        # homebrew (Apple Silicon) — tmux
+        "/usr/local/bin",                           # homebrew (Intel) / misc
+        str(Path.home() / ".local" / "bin"),        # `claude` install location
+    ]
+    # Sutando.app-bundled node runtime: sibling of the repo inside the app bundle
+    # (Contents/Resources/{repo,runtime}). Absent in a plain dev checkout → skipped.
+    bundled_bin = REPO_DIR.parent / "runtime" / "bin"
+    if bundled_bin.is_dir():  # pragma: no cover — only present inside the app bundle
+        extra.append(str(bundled_bin))
+    env["PATH"] = ":".join(extra) + ":" + env.get("PATH", "/usr/bin:/bin")
+    return env
+
+
 def _default_core_restart(standard_context: bool) -> bool:
     """Run src/agent/claude/cli/start-cli.sh --restart out-of-process. When
     standard_context is True, pin SUTANDO_CORE_MODEL=opus so the restarted core
@@ -1983,9 +2012,7 @@ def _default_core_restart(standard_context: bool) -> bool:
     script = REPO_DIR / "src" / "agent" / "claude" / "cli" / "start-cli.sh"
     if not script.exists():
         return False
-    env = dict(os.environ)
-    # launchd's minimal PATH won't find homebrew tmux; start-cli.sh needs it.
-    env["PATH"] = "/opt/homebrew/bin:/usr/local/bin:" + env.get("PATH", "/usr/bin:/bin")
+    env = _resolve_launch_env()  # pragma: no cover — real-subprocess restart path (integration, not unit)
     if standard_context:
         env["SUTANDO_CORE_MODEL"] = "opus"
     try:

--- a/tests/health-check-recover-core.test.py
+++ b/tests/health-check-recover-core.test.py
@@ -346,6 +346,32 @@ def case_n_failed_dm_still_restarts_and_records() -> list[str]:
     return fails
 
 
+def case_o_launch_env_path() -> list[str]:
+    """Regression for the 2026-07-10 launchd restart bug: under launchd's minimal
+    PATH, start-cli.sh --restart failed rc=127 (node/claude not found).
+    _resolve_launch_env must PREPEND homebrew, ~/.local/bin, and (when present)
+    the bundled runtime so the tools resolve."""
+    import os
+    fails = []
+    saved = os.environ.get("PATH")
+    try:
+        os.environ["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"  # launchd minimal
+        env = hc._resolve_launch_env()
+        parts = env["PATH"].split(":")
+        for needed in ("/opt/homebrew/bin", "/usr/local/bin", str(Path.home() / ".local" / "bin")):
+            if needed not in parts:
+                fails.append(f"o) resolved PATH missing {needed}")
+        if "/opt/homebrew/bin" in parts and "/usr/bin" in parts:
+            if parts.index("/opt/homebrew/bin") > parts.index("/usr/bin"):
+                fails.append("o) healed dirs must be PREPENDED (before the minimal PATH)")
+    finally:
+        if saved is None:
+            os.environ.pop("PATH", None)
+        else:
+            os.environ["PATH"] = saved
+    return fails
+
+
 def main() -> int:
     cases = [
         ("a", case_a_healthy_no_action),
@@ -362,6 +388,7 @@ def main() -> int:
         ("l", case_l_progress_resets_long_task),
         ("m", case_m_lock_prevents_concurrent_restart),
         ("n", case_n_failed_dm_still_restarts_and_records),
+        ("o", case_o_launch_env_path),
     ]
     all_failures = []
     for label, fn in cases:


### PR DESCRIPTION
## Problem (bug `bbdbebd0`, high — reported from a pilot install)

The launchd core-watchdog restart path — `_default_core_restart` → `bash start-cli.sh --restart`, run under launchd — prepended homebrew (for `tmux`) but **not** `~/.local/bin` (where `claude` lives) or the Sutando.app-bundled `node` runtime. Under launchd's minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), the restart exited **rc=127** (`node unavailable` / `exec: claude: not found`) on every attempt and silently fell through to the legacy tmux-respawn fallback.

Incident 2026-07-10: the task queue stopped draining and backlogged ~70 min. Same PATH-narrowing class as the tmux fix (`_resolve_tmux_bin`, 2026-06-09) — just never applied to the `start-cli.sh` subprocess calls.

## Fix

Extract `_resolve_launch_env()` and use it for the restart subprocess env. It prepends:
- `/opt/homebrew/bin`, `/usr/local/bin` (homebrew — tmux, often node/claude),
- `~/.local/bin` (`claude`),
- the bundled `runtime/bin` **when present** (i.e. the core running inside the app bundle; skipped in a plain checkout).

## Live test (this machine — simulated launchd-minimal PATH, non-login bash)

```
[1] no fix  → command -v node && command -v claude   rc=1   ← the bug (rc=127 class)
[2] fix     → same check                             rc=0   → node=/opt/homebrew/bin/node  claude=/opt/homebrew/bin/claude
    PATH prefix added: /opt/homebrew/bin:/usr/local/bin:/Users/…/.local/bin
```

Matches the bug report's own verification method (`command -v node && command -v claude` fails without / succeeds with the fix). Unit test: new `case_o` asserts the healed dirs are prepended before the minimal PATH — recover-core suite **15/15**.

## Out of scope (flagged, not fixed here)

The incident's *second* driver — a first-run macOS Automation/TCC dialog that blocks headless recovery (no amount of restarting helps; the OS modal is the blocker) — is a product/onboarding concern, not fixable in this restart path. Worth a separate item (pre-grant Automation perms at onboarding, or detect "blocked on system dialog" and escalate via push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)