### PR TITLE
ci(lint): guard against new inline ~/.sutando/ install-path literals

### DIFF
--- a/.github/workflows/lint-sutando-home-path.yml
+++ b/.github/workflows/lint-sutando-home-path.yml
@@ -1,0 +1,37 @@
+name: lint-sutando-home-path
+
+# CI lint: refuse PRs that introduce NEW inline `~/.sutando/<...>` install-path
+# literals. Hardcoded `~/.sutando/*` paths copied into new call sites have
+# stranded config across packaging/rename changes before (#762 workspace,
+# #1785 repo). New code must resolve through the helper / import the constant
+# from the one file that owns the install location.
+#
+# Runs `scripts/lint-sutando-home-path.sh --diff`, which scans only ADDED lines
+# in the PR — existing offenders are left for deliberate migration, not flagged.
+#
+# Companion to `lint-workspace-resolution.yml` (workspace resolver) and
+# `lint-claude-home-path.yml` (~/.claude home). Together they keep all
+# per-user path resolution behind the documented helpers.
+
+on:
+  pull_request:
+    branches: [main, staging-workspace-revamp]
+  push:
+    branches: [main, staging-workspace-revamp]
+
+jobs:
+  lint-sutando-home-path:
+    name: refuse new inline ~/.sutando/ install-path literal
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Checkout (with full history for base-ref diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run lint in --diff mode
+        env:
+          BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || 'HEAD~1' }}
+        run: bash scripts/lint-sutando-home-path.sh --diff

--- a/scripts/lint-sutando-home-path.sh
+++ b/scripts/lint-sutando-home-path.sh
@@ -47,10 +47,15 @@ cd "$REPO_ROOT"
 
 mode="${1:-all}"
 
-# Match the inline install-path literal in shell + python:
-#   shell    : $HOME/.sutando/…   or   ~/.sutando/…   (also covers os.path.expanduser("~/.sutando/…"))
-#   python   : Path.home() / ".sutando"   (home() followed by a ".sutando" string)
-PATTERN='(\$HOME|~)/\.sutando/|home\(\)[[:space:]]*/[[:space:]]*["'\'']\.sutando'
+# Match the inline install-path literal in shell + python + TS/JS:
+#   shell/env : $HOME/.sutando/…   or   ~/.sutando/…   (also os.path.expanduser("~/.sutando/…"))
+#   ABSOLUTE  : /Users/<name>/.sutando/…  or  /home/<name>/.sutando/…  — the form
+#               that caused #2048 (an absolute home path, no $HOME/~ prefix). This
+#               is the one the first cut MISSED; it's the whole point of the guard.
+#   python    : Path.home() / ".sutando"   (home() followed by a ".sutando" string)
+# Applies to any scanned language — a quoted TS/JS literal like "~/.sutando/x" or
+# "/Users/x/.sutando/y" contains one of these substrings and is caught.
+PATTERN='(\$HOME|~|/Users/[^/]+|/home/[^/]+)/\.sutando/|home\(\)[[:space:]]*/[[:space:]]*["'\'']\.sutando'
 
 # Allowed files — may legitimately reference the install-home literal because
 # they OWN the resolution/install-location, or are migration/legacy scripts
@@ -61,7 +66,7 @@ PATTERN='(\$HOME|~)/\.sutando/|home\(\)[[:space:]]*/[[:space:]]*["'\'']\.sutando
 # fallback after resolve_workspace() / a doc comment). They're allowed because
 # the reference is intentional and reviewed; a brand-new file copying the
 # literal is what this lint is for.
-ALLOWED='^(scripts/sutando-config\.sh|src/util_paths\.py|src/workspace_default\.(py|ts)|src/startup\.sh|scripts/install-git-hooks\.sh|scripts/install-session-start-hook\.sh|src/agent/claude/cli/start-cli\.sh|src/health-check\.py|scripts/sync-memory\.sh|scripts/sync-workspace\.sh|scripts/sutando-migrate\.sh|src/migrate\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/probe-team-sandbox\.sh|skills/report-feedback/report-feedback\.py|src/telemetry\.py|src/inline-tools\.ts|tests/[^/]+\.(test\.)?(py|ts|sh))$'
+ALLOWED='^(scripts/sutando-config\.sh|src/util_paths\.py|src/workspace_default\.(py|ts)|src/startup\.sh|scripts/install-git-hooks\.sh|scripts/install-session-start-hook\.sh|src/agent/claude/cli/start-cli\.sh|src/health-check\.py|scripts/sync-memory\.sh|scripts/sync-workspace\.sh|scripts/sutando-migrate\.sh|src/migrate\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/probe-team-sandbox\.sh|skills/report-feedback/report-feedback\.py|src/telemetry\.py|src/inline-tools\.ts|tests/lint-sutando-home-path\.test\.sh|tests/credential-proxy-refresh\.test\.ts|tests/migration-safety-helpers\.test\.sh|tests/state-paths-adoption\.test\.py|tests/sync-memory-migration\.test\.sh|tests/sync-workspace\.test\.sh|tests/workspace-default\.test\.py)$'
 
 if [[ "$mode" == "--diff" ]]; then
   base="${BASE_REF:-origin/main}"

--- a/scripts/lint-sutando-home-path.sh
+++ b/scripts/lint-sutando-home-path.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Sutando lint: forbid NEW inline `~/.sutando/<...>` install-path literals.
+#
+# `~/.sutando/` is Sutando's per-user home for install/runtime state
+# (`~/.sutando/repo` = the app-bundle clone, `~/.sutando/workspace` = the
+# legacy workspace default, `~/.sutando/bin` = staged wrappers, etc.). New
+# code MUST NOT hardcode a `~/.sutando/<segment>` path inline — it should
+# resolve through the documented helper for whatever it needs:
+#
+#   • workspace     → scripts/sutando-config.sh workspace   (src/sutando_config.*)
+#   • claude home   → scripts/sutando-config.sh claude-home-path
+#   • other install → import the constant from the one file that owns it,
+#                     don't re-hardcode the literal in a new call site.
+#
+# WHY (this is the part that stops recurrence, not the red X):
+#   Hardcoded `~/.sutando/*` literals have bitten this repo more than once
+#   (workspace default #762, later removed in #1440; app-bundle repo path
+#   #1785). When the same install-path literal is copied into a new file,
+#   a later move/rename/packaging change silently strands whichever copy
+#   wasn't updated — an expensive, hard-to-see class of bug. Centralizing
+#   the path behind a helper/constant means there's ONE place to change.
+#
+# Companion to `lint-workspace-resolution.sh` (which specifically guards the
+# WORKSPACE resolver) and `lint-claude-home-path.sh` (the ~/.claude home).
+# This one is the general `~/.sutando/*` install-home backstop.
+#
+# The lint flags only lines ADDED in the PR diff (--diff), so existing
+# offenders stay un-flagged until deliberately migrated; new ones fail CI.
+#
+# Allowed files — the resolver/helpers, the one owner of each install
+# location, migration/legacy scripts that must reference pre-M0 paths, and
+# this lint + its tests:
+#   scripts/sutando-config.sh · src/util_paths.py · src/workspace_default.{py,ts}
+#   src/startup.sh · scripts/install-git-hooks.sh · scripts/install-session-start-hook.sh
+#   src/agent/claude/cli/start-cli.sh · src/health-check.py
+#   scripts/sync-memory.sh · scripts/sync-workspace.sh · scripts/sutando-migrate.sh
+#   src/migration_safety_helpers.sh · scripts/lint-sutando-home-path.sh
+#
+# Usage:
+#   bash scripts/lint-sutando-home-path.sh          # scan whole tree (show legacy debt)
+#   bash scripts/lint-sutando-home-path.sh --diff   # scan only added lines vs BASE_REF (CI)
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+mode="${1:-all}"
+
+# Match the inline install-path literal in shell + python:
+#   shell    : $HOME/.sutando/…   or   ~/.sutando/…   (also covers os.path.expanduser("~/.sutando/…"))
+#   python   : Path.home() / ".sutando"   (home() followed by a ".sutando" string)
+PATTERN='(\$HOME|~)/\.sutando/|home\(\)[[:space:]]*/[[:space:]]*["'\'']\.sutando'
+
+# Allowed files — may legitimately reference the install-home literal because
+# they OWN the resolution/install-location, or are migration/legacy scripts
+# that must name the pre-M0 paths they migrate from.
+# NOTE on the "consumer" entries (report-feedback, telemetry, inline-tools):
+# these are NOT resolver-owners — they carry a *deliberate* reference to the
+# packaged-app install path (a cross-checkout token probe / a defensive
+# fallback after resolve_workspace() / a doc comment). They're allowed because
+# the reference is intentional and reviewed; a brand-new file copying the
+# literal is what this lint is for.
+ALLOWED='^(scripts/sutando-config\.sh|src/util_paths\.py|src/workspace_default\.(py|ts)|src/startup\.sh|scripts/install-git-hooks\.sh|scripts/install-session-start-hook\.sh|src/agent/claude/cli/start-cli\.sh|src/health-check\.py|scripts/sync-memory\.sh|scripts/sync-workspace\.sh|scripts/sutando-migrate\.sh|src/migrate\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/probe-team-sandbox\.sh|skills/report-feedback/report-feedback\.py|src/telemetry\.py|src/inline-tools\.ts|tests/[^/]+\.(test\.)?(py|ts|sh))$'
+
+if [[ "$mode" == "--diff" ]]; then
+  base="${BASE_REF:-origin/main}"
+  files="$(git diff --name-only --diff-filter=AM "$base"...HEAD -- '*.py' '*.ts' '*.tsx' '*.sh' '*.bash')"
+else
+  files="$(git ls-files -- '*.py' '*.ts' '*.tsx' '*.sh' '*.bash')"
+fi
+
+if [[ -z "$files" ]]; then
+  echo "lint-sutando-home-path: nothing to scan (mode=$mode)"
+  exit 0
+fi
+
+found=0
+while IFS= read -r f; do
+  [[ -f "$f" ]] || continue
+  if [[ "$f" =~ $ALLOWED ]]; then
+    continue
+  fi
+  if [[ "$mode" == "--diff" ]]; then
+    added="$(git diff "$base"...HEAD -- "$f" | awk '/^\+[^+]/ {print substr($0, 2)}')"
+    matches="$(echo "$added" | grep -E "$PATTERN" || true)"
+  else
+    matches="$(grep -E "$PATTERN" "$f" || true)"
+  fi
+  if [[ -n "$matches" ]]; then
+    found=1
+    echo "lint-sutando-home-path: forbidden inline ~/.sutando/ literal in $f"
+    while IFS= read -r line; do
+      echo "  $line"
+    done <<< "$matches"
+  fi
+done <<< "$files"
+
+if [[ "$found" -eq 1 ]]; then
+  cat >&2 <<'EOF'
+
+ERROR: One or more files hardcode an inline `~/.sutando/<...>` install-path
+literal. Copying this literal into a new call site is the class of bug that
+stranded config across packaging changes before (#762 workspace, #1785 repo).
+
+Fix: resolve through the helper / import the constant, don't re-hardcode:
+
+  Workspace:
+    Before:  WS="$HOME/.sutando/workspace"
+    After:   WS="$(bash "$REPO_DIR/scripts/sutando-config.sh" workspace)"
+
+  Claude home:
+    Before:  D="$HOME/.sutando/repo/.claude"      # (illustrative)
+    After:   D="$(bash "$REPO_DIR/scripts/sutando-config.sh" claude-home-path)"
+
+  Other install paths (e.g. ~/.sutando/repo, ~/.sutando/bin): import the
+  constant from the single file that already owns it rather than writing a
+  fresh literal — so there's ONE place to change when packaging moves.
+
+If your file legitimately OWNS an install location (a new resolver/installer),
+add it to the ALLOWED list in scripts/lint-sutando-home-path.sh with a comment
+explaining why. See that script's header for the full rationale.
+EOF
+  exit 1
+fi
+
+echo "lint-sutando-home-path: clean (mode=$mode, scanned $(wc -l <<< "$files" | tr -d ' ') files)"
+exit 0

--- a/scripts/lint-workspace-resolution.sh
+++ b/scripts/lint-workspace-resolution.sh
@@ -61,7 +61,7 @@ PATTERN_DOC_ENV_PATH='\$SUTANDO_WORKSPACE/'
 # branch when the wrapper script isn't reachable (e.g. non-checkout
 # installs). The fallback path is documented in each script's comments;
 # new contributors should still go through the wrapper.
-ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|tests/[^/]+\.(test\.)?(py|ts|sh))$'
+ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|tests/[^/]+\.(test\.)?(py|ts|sh))$'
 
 # Allowed .md files — legitimate uses of `$SUTANDO_WORKSPACE/path` in
 # prose, e.g. the workspace contract docs that DESCRIBE the legacy form

--- a/tests/lint-sutando-home-path.test.sh
+++ b/tests/lint-sutando-home-path.test.sh
@@ -10,7 +10,7 @@ ok()   { echo "ok   - $1"; }
 bad()  { echo "FAIL - $1"; fail=1; }
 
 # The pattern the lint uses (kept in sync with the script).
-PATTERN='(\$HOME|~)/\.sutando/|home\(\)[[:space:]]*/[[:space:]]*["'\'']\.sutando'
+PATTERN='(\$HOME|~|/Users/[^/]+|/home/[^/]+)/\.sutando/|home\(\)[[:space:]]*/[[:space:]]*["'\'']\.sutando'
 
 matches() { printf '%s\n' "$1" | grep -Eq "$PATTERN"; }
 
@@ -22,6 +22,11 @@ if bash "$LINT" >/dev/null 2>&1; then ok "all-mode passes on the current tree"; 
 if matches 'WS="$HOME/.sutando/newthing"';           then ok "catches shell \$HOME/.sutando/ literal"; else bad "catches shell \$HOME/.sutando/ literal"; fi
 if matches 'x=~/.sutando/repo/x';                      then ok "catches shell ~/.sutando/ literal";      else bad "catches shell ~/.sutando/ literal"; fi
 if matches 'p = Path.home() / ".sutando" / "repo"';    then ok "catches python Path.home() / .sutando";  else bad "catches python Path.home() / .sutando"; fi
+# ABSOLUTE home paths — the #2048 form the first cut missed (no $HOME/~ prefix).
+if matches 'x = "/Users/ruiwang/.sutando/repo/.env"';  then ok "catches absolute macOS /Users/*/.sutando"; else bad "catches absolute macOS /Users/*/.sutando"; fi
+if matches 'D=/home/ubuntu/.sutando/repo/x';           then ok "catches absolute linux /home/*/.sutando"; else bad "catches absolute linux /home/*/.sutando"; fi
+# TS/JS quoted literal (the scanner covers .ts/.tsx; the literal contains a matched substring).
+if matches 'const repo = "~/.sutando/repo";';          then ok "catches TS quoted ~/.sutando literal";    else bad "catches TS quoted ~/.sutando literal"; fi
 
 # 3. The pattern does NOT catch unrelated / bare mentions.
 if matches 'd=~/.claude/skills';                       then bad "ignores a bare ~/.claude path";          else ok "ignores a bare ~/.claude path"; fi

--- a/tests/lint-sutando-home-path.test.sh
+++ b/tests/lint-sutando-home-path.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Tests for scripts/lint-sutando-home-path.sh — the ~/.sutando/ install-path guard.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+LINT="scripts/lint-sutando-home-path.sh"
+fail=0
+ok()   { echo "ok   - $1"; }
+bad()  { echo "FAIL - $1"; fail=1; }
+
+# The pattern the lint uses (kept in sync with the script).
+PATTERN='(\$HOME|~)/\.sutando/|home\(\)[[:space:]]*/[[:space:]]*["'\'']\.sutando'
+
+matches() { printf '%s\n' "$1" | grep -Eq "$PATTERN"; }
+
+# 1. The current tree is clean in all-mode (every existing ~/.sutando use is a
+#    resolver-owner / intentional fallback in the ALLOWED list).
+if bash "$LINT" >/dev/null 2>&1; then ok "all-mode passes on the current tree"; else bad "all-mode passes on the current tree"; fi
+
+# 2. The pattern CATCHES the real offending forms.
+if matches 'WS="$HOME/.sutando/newthing"';           then ok "catches shell \$HOME/.sutando/ literal"; else bad "catches shell \$HOME/.sutando/ literal"; fi
+if matches 'x=~/.sutando/repo/x';                      then ok "catches shell ~/.sutando/ literal";      else bad "catches shell ~/.sutando/ literal"; fi
+if matches 'p = Path.home() / ".sutando" / "repo"';    then ok "catches python Path.home() / .sutando";  else bad "catches python Path.home() / .sutando"; fi
+
+# 3. The pattern does NOT catch unrelated / bare mentions.
+if matches 'd=~/.claude/skills';                       then bad "ignores a bare ~/.claude path";          else ok "ignores a bare ~/.claude path"; fi
+if matches 'echo .sutando-memory-sync';                then bad "ignores .sutando-memory-sync dir name";  else ok "ignores .sutando-memory-sync dir name"; fi
+
+# 4. The lint self-whitelists (its own file carries the literal in examples).
+if grep -q 'lint-sutando-home-path\\.sh' "$LINT";      then ok "lint file itself is in the ALLOWED list"; else bad "lint file itself is in the ALLOWED list"; fi
+
+if [[ "$fail" -eq 0 ]]; then echo "PASS"; else echo "SOME TESTS FAILED"; exit 1; fi


### PR DESCRIPTION
## What
A dedicated CI lint that refuses **new** inline `~/.sutando/<...>` install-path literals — the general `~/.sutando/*` install-home backstop, alongside the existing workspace-resolver and `~/.claude`-home lints.

## Why
Hardcoded `~/.sutando/*` literals copied into a new call site are a costly, hard-to-see bug class: a later move/rename/packaging change silently strands whichever copy wasn't updated. It's bitten us more than once — the workspace default (#762, later removed in #1440) and the app-bundle repo path (#1785). A lint alone doesn't prevent recurrence; **understanding the why does** — so the error message explains the resolver-vs-install-location distinction and shows a before/after fix, and this description documents the pattern for the team.

## How
- `scripts/lint-sutando-home-path.sh` flags `$HOME/.sutando/`, `~/.sutando/`, and `Path.home() / ".sutando"` in shell + python. Runs `--diff` in CI (`.github/workflows/lint-sutando-home-path.yml`), so **existing** offenders aren't flagged — only new ones.
- Whitelist = the resolver/helpers, the one owner of each install location, migration/legacy scripts, and a few files with a reviewed intentional reference (packaged-app token probe, defensive fallback). All-mode is clean on the current tree (509 files).
- `tests/lint-sutando-home-path.test.sh` — 7 tests (catches shell/python forms, ignores `~/.claude` + the `.sutando-memory-sync` dir name, self-whitelist).

## Note
This applies to everyone — my own #762 is one of the two root cases. cc @jsun-m: #1785 (the `~/.sutando/repo` path) is the other case that surfaced the gap — flagging so the pattern + the helper are on your radar, not as a callout. The fix everywhere is the same: resolve through `scripts/sutando-config.sh` / import the constant from the file that owns the install location, rather than re-writing the literal.
