### PR TITLE
feat(scripts): sutando-whoami — instance-identity primitive

### DIFF
--- a/scripts/sutando-whoami.sh
+++ b/scripts/sutando-whoami.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# sutando-whoami.sh — print this Sutando instance's identity as one JSON object.
+#
+# The stable, machine-readable handle for "which Sutando is this?" — the thing
+# a user pastes (or a tool reads) when another system needs to find or attach
+# to this instance. First consumer: agent-connect's `--sutando-workspace`
+# connect path (the AG2 Space Connect modal pre-fills from this output).
+# Owner-designed primitive, 2026-07-13.
+#
+#   bash scripts/sutando-whoami.sh
+#
+# Output (single JSON object on stdout):
+#   instance_id  stable per-host install id (state/auth/device.json machineId;
+#                falls back to "unprovisioned-<host>" before provisioning)
+#   host         short hostname (matches the hosts/<hostname>/ convention)
+#   workspace    absolute workspace path (the M0 resolver's answer)
+#   repo         absolute path of this checkout
+#
+# Agent identity (the @...:ag2.space mxid) is deliberately absent: it is not
+# stored locally today — the gateway resolves token → identity server-side.
+# When a gateway whoami op exists, it belongs here too.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WS="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+
+python3 - "$REPO" "$WS" <<'PY'
+import json
+import os
+import socket
+import sys
+
+repo, ws = sys.argv[1], sys.argv[2]
+host = socket.gethostname().split(".")[0]
+
+machine_id = None
+try:
+    with open(os.path.join(ws, "state", "auth", "device.json")) as f:
+        machine_id = json.load(f).get("machineId")
+except (OSError, ValueError):
+    pass
+
+print(
+    json.dumps(
+        {
+            "instance_id": machine_id or f"unprovisioned-{host}",
+            "host": host,
+            "workspace": ws,
+            "repo": repo,
+        },
+        indent=2,
+    )
+)
+PY

--- a/tests/sutando-whoami.test.sh
+++ b/tests/sutando-whoami.test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Tests for scripts/sutando-whoami.sh — the instance-identity primitive.
+#
+#   bash tests/sutando-whoami.test.sh
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fails=0
+ok()  { printf '  ok   %s\n' "$1"; }
+bad() { printf '  FAIL %s\n' "$1"; fails=$((fails + 1)); }
+
+out="$(bash "$REPO/scripts/sutando-whoami.sh")"
+
+# 1) output is a single valid JSON object with the contract fields
+if WHOAMI_OUT="$out" REPO_EXPECT="$REPO" python3 - <<'PY'
+import json, os
+d = json.loads(os.environ["WHOAMI_OUT"])
+assert set(d) == {"instance_id", "host", "workspace", "repo"}, d.keys()
+assert d["repo"] == os.environ["REPO_EXPECT"], d["repo"]
+assert d["workspace"].startswith("/"), d["workspace"]
+assert d["instance_id"] and d["host"]
+PY
+then ok "valid JSON with contract fields"; else bad "JSON contract"; fi
+
+# 2) workspace matches the M0 resolver's answer (no parallel resolution logic)
+ws_json="$(WHOAMI_OUT="$out" python3 -c 'import json,os; print(json.loads(os.environ["WHOAMI_OUT"])["workspace"])')"
+ws_helper="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
+if [ "$ws_json" = "$ws_helper" ]; then ok "workspace == sutando-config.sh workspace"; else bad "workspace mismatch: $ws_json vs $ws_helper"; fi
+
+# 3) instance_id falls back to unprovisioned-<host> when device.json is absent.
+#    Point the resolver at an empty temp workspace via the sanctioned test-mode
+#    env override (SUTANDO_WORKSPACE is only honored under SUTANDO_TEST_MODE=1).
+T="$(mktemp -d)"
+mkdir -p "$T/ws"
+out2="$(SUTANDO_TEST_MODE=1 SUTANDO_WORKSPACE="$T/ws" bash "$REPO/scripts/sutando-whoami.sh")"
+if WHOAMI_OUT="$out2" python3 - <<'PY'
+import json, os
+d = json.loads(os.environ["WHOAMI_OUT"])
+assert d["instance_id"].startswith("unprovisioned-"), d["instance_id"]
+assert d["workspace"].endswith("/ws"), d["workspace"]
+PY
+then ok "unprovisioned fallback when device.json absent"; else bad "unprovisioned fallback"; fi
+rm -rf "$T"
+
+printf '\n%s\n' "$([ "$fails" -eq 0 ] && echo 'PASS — sutando-whoami green' || echo "FAIL — $fails failing")"
+exit "$fails"


### PR DESCRIPTION
Owner-designed primitive (2026-07-13, owner room): a running Sutando should hand out one identifier that other tools use to find/attach to it. `bash scripts/sutando-whoami.sh` prints a single JSON object: `instance_id` (device.json machineId; `unprovisioned-<host>` fallback), `host`, `workspace` (resolved via the M0 helper — no parallel resolution), `repo`.

First consumer: agent-connect#5's `--sutando-workspace` (the Connect modal pre-fill reads this verbatim). Agent mxid intentionally omitted — not stored locally; add when a gateway whoami op exists.

Verified: 3 tests green (JSON contract, resolver parity, unprovisioned fallback via SUTANDO_TEST_MODE override); live output on this host correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)