### PR TITLE
feat(cli): record core session start times (session-starts.log)

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -319,6 +319,17 @@ if ! command -v tmux > /dev/null 2>&1 && command -v brew > /dev/null 2>&1; then
   brew install tmux 2>&1 | tail -3
 fi
 
+# Stamp the core session start into an append-only per-boot log. One JSONL
+# line per launch; consecutive entries bound each session's lifetime, which
+# is what session-recap tooling needs to pick the right transcript (owner
+# ask 2026-07-13). Best-effort: never block the launch on it.
+if _ws="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)" && [ -n "$_ws" ]; then
+  mkdir -p "$_ws/state" 2>/dev/null || true
+  printf '{"host":"%s","session_started_at":%s,"iso":"%s","source":"start-cli"}\n' \
+    "$(hostname | sed 's/\..*//')" "$(date +%s)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    >> "$_ws/state/session-starts.log" 2>/dev/null || true
+fi
+
 # Fall back to a bare `exec claude` if tmux is still missing.
 if ! command -v tmux > /dev/null 2>&1; then
   echo "  ⚠ tmux not found — running without tmux wrapper"


### PR DESCRIPTION
Owner ask 2026-07-13 (Sutando-001-Pro-Main): record the exact restart time so any session's period is knowable and session-recap tooling can bound "the last session".

**What:** `start-cli.sh` appends one JSONL line (`host`, `session_started_at`, `iso`, `source`) to `<workspace>/state/session-starts.log` before launching the core — all three launch paths (bare exec, tmux attach, tmux detached) flow through the stamp. Best-effort with `|| true` throughout: a missing workspace or unwritable state dir never blocks the launch.

**Why JSONL + append-only:** consecutive entries bound each session's lifetime; crash-restarts (no graceful shutdown) still get their start recorded, which is the case relay/handoff notes can't cover.

**Verify:** `bash -n` clean; stamp pattern mirrors the existing sutando-config.sh usage at the top of the file. This session's start was backfilled manually to the same log (2026-07-13T01:08:39Z) so the log is already seeded.

**Box:** Track 14 continuity/observability — session-recap groundwork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)