### PR TITLE
feat(start-cli): honor SUTANDO_TMUX_SOCKET for a caller-provided tmux socket

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -90,7 +90,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// different TMPDIR due to sandboxing) must target the same socket
     /// to find the same server. Without this, tmux has-session fails
     /// app-side even when the session is alive shell-side.
-    let sutandoTmuxSocket = "/tmp/sutando-tmux.sock"
+    /// Honors SUTANDO_TMUX_SOCKET (the env var start-cli.sh + the desktop
+    /// private-socket runtime set) so the app's state-detection / wakeup /
+    /// pane-capture target the SAME tmux server as a private-socket core;
+    /// falls back to the /tmp default when unset. Without this, a private-
+    /// socket core is invisible to all four control paths below.
+    let sutandoTmuxSocket = ProcessInfo.processInfo.environment["SUTANDO_TMUX_SOCKET"] ?? "/tmp/sutando-tmux.sock"
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Self-preventive single-instance: if another Sutando.app is already

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -265,13 +265,13 @@ fi
 # emit-task. Unsafe: a future agent processing a "restart core" task by
 # exec'ing this script from within sutando-core. Per Mini's #608 review.
 if [ "$1" = "--restart" ]; then
-  if pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1; then
+  if tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null; then
     echo "Killing existing $SESSION session..."
     tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION" 2>/dev/null || true
     # Poll for actual shutdown — robust on slow machines, faster on fast
     # ones (~1s ceiling) than a fixed sleep.
     for _ in 1 2 3 4 5; do
-      pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1 || break
+      tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null || break
       sleep 0.2
     done
   fi
@@ -304,7 +304,7 @@ apply_tmux_defaults() {
 
 # Already running — attach if interactive, else exit cleanly. This branch
 # also catches the !--restart path so re-running the script is idempotent.
-if pgrep -f "claude.*--name.*$SESSION" > /dev/null 2>&1; then
+if tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null; then
   apply_tmux_defaults
   if [ -t 1 ] && command -v tmux > /dev/null 2>&1; then
     echo "Attaching to existing $SESSION (Ctrl-b d to detach)..."

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -19,7 +19,10 @@ set -e
 REPO="$(cd "$(dirname "$0")/../../../.." && pwd)"
 cd "$REPO"
 
-TMUX_SOCKET="/tmp/sutando-tmux.sock"
+# Honor a caller-provided socket (e.g. a desktop app that runs a user-private tmux
+# runtime under its app-support dir); default to the shared /tmp socket for dev/CLI.
+# Backward-compatible: unset → identical to the previous hardcoded value.
+TMUX_SOCKET="${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}"
 SESSION="sutando-core"
 
 # Marker identifying THIS process as the long-lived sutando-core session (as

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -76,7 +76,11 @@ echo "$$" > "$PID_FILE"
 # tmux socket for the wakeup signal. Sutando.app creates the CLI session via
 # this socket. If the socket doesn't exist (different setup), wakeup is a
 # silent no-op thanks to 2>/dev/null || true.
-TMUX_SOCK="${SUTANDO_TMUX_SOCK:-/tmp/sutando-tmux.sock}"
+# Honors SUTANDO_TMUX_SOCKET (the name start-cli.sh + the desktop private-socket
+# runtime use) so the wakeup ping targets the SAME tmux server as the core when
+# a caller overrides the default socket; the legacy SUTANDO_TMUX_SOCK is kept as
+# a one-release fallback so any straggler setter still works.
+TMUX_SOCK="${SUTANDO_TMUX_SOCKET:-${SUTANDO_TMUX_SOCK:-/tmp/sutando-tmux.sock}}"
 TMUX_SESSION="${SUTANDO_TMUX_SESSION:-sutando-core}"
 
 # Wake helper, kept but NOT called on the task paths below. Under the only


### PR DESCRIPTION
## What

The core's tmux control socket was hardcoded at `/tmp/sutando-tmux.sock` across **three** independent control surfaces. An embedder that runs the core on an isolated, **user-private** socket — a bundled desktop runtime under its app-support dir, so it can't collide with a developer's own `/tmp` tmux session or have lifecycle commands act on the wrong server — had no way to point all three at the same socket.

## Change — one env var, all three surfaces

`SUTANDO_TMUX_SOCKET` overrides the socket; unset → the previous `/tmp` default (byte-identical).

| File | Line | Before | After |
|---|---|---|---|
| `start-cli.sh` | 25 | `TMUX_SOCKET="/tmp/sutando-tmux.sock"` | `TMUX_SOCKET="${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}"` |
| `main.swift` | 93 | `let sutandoTmuxSocket = "/tmp/sutando-tmux.sock"` | `… = ProcessInfo.processInfo.environment["SUTANDO_TMUX_SOCKET"] ?? "/tmp/sutando-tmux.sock"` |
| `watch-tasks-stream.sh` | 79 | `TMUX_SOCK="${SUTANDO_TMUX_SOCK:-/tmp/sutando-tmux.sock}"` | `TMUX_SOCK="${SUTANDO_TMUX_SOCKET:-${SUTANDO_TMUX_SOCK:-/tmp/sutando-tmux.sock}}"` |

`start-cli.sh` also swaps three socket-blind `pgrep -f "claude.*--name.*$SESSION"` liveness probes (restart-guard, kill-poll, running→attach) for socket-scoped `tmux -S "$TMUX_SOCKET" has-session` — without that, the anti-dup-core check reads the *default* tmux server even when the core is on a private socket, so a private-socket core is both invisible (never attached) and unprotected (a second core can spawn).

## Naming (CR pt. 1 — naming_conflict)

`SUTANDO_TMUX_SOCKET` is canonical because it is the name the desktop private-socket runtime **sets** — an external contract this PR *consumes*, not one it is free to rename. The pre-existing `SUTANDO_TMUX_SOCK` (no `T`) appeared in exactly one caller (`watch-tasks-stream.sh:79`) and is kept as a one-release migration alias, resolved in that **single place** (SOCKET preferred → legacy SOCK → default). That is the "migrate both deliberately in one place" path, not two live names for one socket.

## Coverage (CR pt. 2 + 3 — bandaid_generalize / false_claim)

Every **functional** `tmux -S` caller now resolves through the honored variable — verified by `grep -rn "tmux -S"`:
- `start-cli.sh` — all 10 `tmux -S` sites use `$TMUX_SOCKET` (restart / kill / attach / new-session — the lifecycle paths).
- `main.swift` — the single `sutandoTmuxSocket` constant feeds all four control paths (list-panes, has-session, send-keys, capture-pane).
- `watch-tasks-stream.sh` — the wake `send-keys` uses `$TMUX_SOCK` (→ SOCKET).
- `startup.sh` **delegates** to `start-cli.sh` (no independent socket); `restart.sh` constructs none.

**Scoped claim:** coverage is exactly these three files. One literal remains — `main.swift:2367`, a `///` docstring showing the *default* attach command (`tmux -S /tmp/sutando-tmux.sock attach …`) to a developer. It is illustrative help text for the unset case, not a functional caller; left as-is deliberately (editing help text to satisfy a grep would be the bandaid this sweep guards against).

## Proof (CR pt. 4 — missing_before_after)

Deterministic resolution, no fork required:

```
start-cli.sh:25    SUTANDO_TMUX_SOCKET unset      -> /tmp/sutando-tmux.sock   (byte-identical to old hardcode)
                   SUTANDO_TMUX_SOCKET=<app-dir>  -> <app-dir>
watch-…:79         both env unset                 -> /tmp/sutando-tmux.sock
                   only legacy SUTANDO_TMUX_SOCK  -> <legacy>                 (back-compat honored)
                   both set                       -> SUTANDO_TMUX_SOCKET wins
```

The live socket-isolation half (a session created on a custom socket is invisible to the default socket's `has-session` and visible only through the override) is standard `tmux -S` per-server isolation. Its fork-based capture is deferred: this box is currently swap-exhausted (18.4 G / 19.4 G, `fork failed: Device not configured` host-wide), so `tmux new-session` can't spawn. Before/after transcript will be appended once the box recovers.

## Compatibility

Unset `SUTANDO_TMUX_SOCKET` → byte-identical to prior behavior on all three surfaces. `bash -n` clean on both shell files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
