### PR TITLE
feat(hooks): gmail-write-guard — deny broken Gmail-connector write tools (report 05cb849a)

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -60,3 +60,37 @@ Test: `python3 tests/skip-ask-user-question.test.py` (hook) and
 
 Config paths are env-overridable for testing: `SUTANDO_DISCORD_ACCESS_FILE`,
 `SUTANDO_DISCORD_ENV_FILE`, `SUTANDO_WORKSPACE`. Test: `python3 tests/context-source-guard.test.py`.
+
+## `gmail-write-guard.py`
+
+Denies the **claude.ai Gmail MCP connector's WRITE-scoped tools** (create_draft,
+label_thread, unlabel_thread, create_label, apply_sensitive_*_label, archive,
+trash, send, …) and routes the model to the app-password IMAP/SMTP path
+(docs/built-in-tools.md → Email). Field report 05cb849a: the connector's OAuth
+flow doesn't actually grant Gmail write scopes (label/archive fail with a raw
+"insufficient authentication scopes" error) and `create_draft` caused 7
+documented incidents incl. a wrong-recipient send — while READ tools work fine
+and remain allowed. The guard matches only `mcp__…` tools whose name mentions
+gmail AND carries a write verb (`list_labels` stays allowed; `label_thread` is
+denied); non-Gmail tools are a no-op, so it is safe under a broad matcher.
+
+Escape hatch: `SUTANDO_ALLOW_GMAIL_CONNECTOR_WRITES=1` lifts the guard (for
+if/when the connector's scopes are fixed upstream). Fail-OPEN on hook errors.
+
+### Deploy (per node)
+
+```bash
+cp hooks/gmail-write-guard.py ~/.claude/hooks/
+python3 - <<'PY'
+import json, os
+sp = os.path.expanduser("~/.claude/settings.json"); s = json.load(open(sp))
+cmd = "python3 ~/.claude/hooks/gmail-write-guard.py"
+pre = s.setdefault("hooks", {}).setdefault("PreToolUse", [])
+blk = next((b for b in pre if b.get("matcher") == "mcp__.*gmail.*"), None)
+if blk is None: pre.append({"matcher": "mcp__.*gmail.*", "hooks": [{"type": "command", "command": cmd}]})
+elif cmd not in [h.get("command") for h in blk["hooks"]]: blk["hooks"].append({"type": "command", "command": cmd})
+json.dump(s, open(sp, "w"), indent=2)
+PY
+```
+
+Test: `python3 tests/gmail-write-guard.test.py`.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -86,8 +86,8 @@ import json, os
 sp = os.path.expanduser("~/.claude/settings.json"); s = json.load(open(sp))
 cmd = "python3 ~/.claude/hooks/gmail-write-guard.py"
 pre = s.setdefault("hooks", {}).setdefault("PreToolUse", [])
-blk = next((b for b in pre if b.get("matcher") == "mcp__.*gmail.*"), None)
-if blk is None: pre.append({"matcher": "mcp__.*gmail.*", "hooks": [{"type": "command", "command": cmd}]})
+blk = next((b for b in pre if b.get("matcher") == "mcp__.*[Gg][Mm][Aa][Ii][Ll].*"), None)
+if blk is None: pre.append({"matcher": "mcp__.*[Gg][Mm][Aa][Ii][Ll].*", "hooks": [{"type": "command", "command": cmd}]})
 elif cmd not in [h.get("command") for h in blk["hooks"]]: blk["hooks"].append({"type": "command", "command": cmd})
 json.dump(s, open(sp, "w"), indent=2)
 PY

--- a/hooks/gmail-write-guard.py
+++ b/hooks/gmail-write-guard.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""gmail-write-guard — PreToolUse hook that denies the claude.ai Gmail MCP
+connector's WRITE-scoped tools and routes writes to the IMAP/SMTP path.
+
+Why (field report 05cb849a, michael@actoneventures.com, 2026-07-13): every
+Gmail WRITE operation through the claude.ai connector is unreliable or broken
+while reads work fine —
+
+  * ``create_draft`` caused 7 documented incidents over ~5 weeks on one
+    install (drafts not reflecting what actually gets sent — one
+    wrong-recipient send), and the connector exposes no delete-draft tool, so
+    each cleanup needed raw IMAP ``UID SEARCH`` + ``STORE \\Deleted`` +
+    ``EXPUNGE``.
+  * ``label_thread`` (and the other label/unlabel tools) fail outright with
+    "Request had insufficient authentication scopes" — the connector's OAuth
+    flow doesn't actually grant the Gmail write scopes it needs, even when
+    read tools (search_threads / get_thread / list_labels) work.
+
+Nothing in the tools' own descriptions warns about this; an install can only
+discover it by getting burned. This hook is the generalized version of the
+per-install block Michael built: deny the connector's Gmail write tools BEFORE
+they run, with a reason that points the model at the app-password IMAP/SMTP
+path (see docs/built-in-tools.md → Email) that actually works.
+
+Scope — deliberately narrow:
+  * Only MCP tools (``mcp__…``) whose server/tool name mentions gmail.
+  * Only WRITE verbs (create/send/label/unlabel/delete/trash/archive/modify/
+    update/move/apply/remove/mark). Read tools — search_threads, get_thread,
+    list_labels, get_message, … — pass through untouched (they work fine).
+  * Non-Gmail tools: no-op (exit 0), safe to register under a broad matcher.
+
+Escape hatch: set ``SUTANDO_ALLOW_GMAIL_CONNECTOR_WRITES=1`` to disable the
+guard (e.g. if/when the connector's OAuth scopes are fixed upstream).
+
+Fail-OPEN on any error — a crashing hook must never wedge the core (same
+contract as skip-ask-user-question.py).
+
+Registration: manual per-node deploy like context-source-guard.py — see
+hooks/README.md.
+"""
+import json
+import os
+import sys
+
+# Write-verb tokens. Matched against the '_'-split tokens of the MCP tool's
+# trailing tool-name segment, so `list_labels` (token "labels") stays allowed
+# while `label_thread` / `create_label` / `unlabel_thread` are denied.
+WRITE_TOKENS = {
+    "create", "send", "delete", "trash", "archive", "modify", "update",
+    "move", "apply", "remove", "mark", "label", "unlabel", "insert",
+    "batchmodify", "batchdelete", "untrash",
+}
+
+REASON = (
+    "Gmail writes through the claude.ai MCP connector are blocked on this install: "
+    "the connector's write scopes are broken/unreliable (label/archive fail with "
+    "'insufficient authentication scopes'; create_draft has a documented history of "
+    "drafts not matching what gets sent, incl. a wrong-recipient send — field report "
+    "05cb849a). Gmail READS through the connector are fine and remain allowed. "
+    "For this write, use the app-password IMAP/SMTP path instead (docs/built-in-tools.md "
+    "-> Email: scripts using imaplib/smtplib with the vaulted app password). "
+    "If the connector's OAuth scopes get fixed upstream, set "
+    "SUTANDO_ALLOW_GMAIL_CONNECTOR_WRITES=1 to lift this guard. [gmail-write-guard]"
+)
+
+
+def is_gmail_connector_write(tool_name: str) -> bool:
+    """True only for MCP Gmail tools whose name carries a write verb."""
+    if not tool_name.startswith("mcp__"):
+        return False
+    lowered = tool_name.lower()
+    if "gmail" not in lowered:
+        return False
+    # Trailing segment = the tool itself (server names also split on __).
+    tool_part = lowered.rsplit("__", 1)[-1]
+    tokens = set(tool_part.split("_"))
+    return bool(tokens & WRITE_TOKENS)
+
+
+def main() -> None:
+    if os.environ.get("SUTANDO_ALLOW_GMAIL_CONNECTOR_WRITES", "").strip() == "1":
+        sys.exit(0)
+    data = json.loads(sys.stdin.read())
+    tool_name = str(data.get("tool_name") or "")
+    if is_gmail_connector_write(tool_name):
+        print(json.dumps({"hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": REASON,
+        }}))
+    # Everything else (and the deny above) exits 0; PreToolUse only blocks
+    # when a deny decision is present in the JSON payload.
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:  # fail-open: never wedge the core on a hook error
+        print(f"[gmail-write-guard] non-fatal error, allowing: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/tests/gmail-write-guard.test.py
+++ b/tests/gmail-write-guard.test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""PreToolUse gmail-write-guard: Gmail MCP connector WRITE tools must be denied
+with an actionable reason; reads and non-Gmail tools pass (hooks/gmail-write-guard.py).
+
+Behavioral: drives the real hook via stdin exactly the way Claude Code invokes
+it, asserting on the emitted decision JSON + exit code.
+
+Run:  python3 tests/gmail-write-guard.test.py
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK = str(Path(__file__).resolve().parent.parent / "hooks" / "gmail-write-guard.py")
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + name + ((" — " + detail) if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def run(payload, env_extra=None):
+    stdin = json.dumps(payload) if not isinstance(payload, str) else payload
+    env = dict(os.environ)
+    env.pop("SUTANDO_ALLOW_GMAIL_CONNECTOR_WRITES", None)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run([sys.executable, HOOK], input=stdin,
+                          capture_output=True, text=True, timeout=20, env=env)
+
+
+def decision(r):
+    try:
+        return json.loads(r.stdout).get("hookSpecificOutput", {}).get("permissionDecision")
+    except Exception:
+        return None
+
+
+# ── The 8 write tools from field report 05cb849a are all denied ───────────────
+WRITE_TOOLS = [
+    "mcp__claude_ai_Gmail__create_draft",
+    "mcp__claude_ai_Gmail__label_thread",
+    "mcp__claude_ai_Gmail__unlabel_thread",
+    "mcp__claude_ai_Gmail__create_label",
+    "mcp__claude_ai_Gmail__apply_sensitive_content_label",
+    "mcp__claude_ai_Gmail__apply_sensitive_topics_label",
+    "mcp__claude_ai_Gmail__archive_thread",
+    "mcp__claude_ai_Gmail__trash_message",
+]
+for t in WRITE_TOOLS:
+    r = run({"tool_name": t, "tool_input": {}})
+    check(f"deny: {t.rsplit('__', 1)[-1]}",
+          r.returncode == 0 and decision(r) == "deny", r.stdout[:120])
+
+# Reason must be actionable: name the IMAP/SMTP path + the escape hatch.
+r = run({"tool_name": "mcp__claude_ai_Gmail__create_draft", "tool_input": {}})
+reason = json.loads(r.stdout)["hookSpecificOutput"]["permissionDecisionReason"]
+check("reason points at the IMAP/SMTP path", "imaplib/smtplib" in reason)
+check("reason names the escape hatch", "SUTANDO_ALLOW_GMAIL_CONNECTOR_WRITES" in reason)
+
+# ── Read tools pass through (they work fine and must keep working) ────────────
+READ_TOOLS = [
+    "mcp__claude_ai_Gmail__search_threads",
+    "mcp__claude_ai_Gmail__get_thread",
+    "mcp__claude_ai_Gmail__list_labels",      # token "labels" != write token "label"
+    "mcp__claude_ai_Gmail__get_message",
+]
+for t in READ_TOOLS:
+    r = run({"tool_name": t, "tool_input": {}})
+    check(f"allow: {t.rsplit('__', 1)[-1]}",
+          r.returncode == 0 and decision(r) is None and not r.stdout.strip(), r.stdout[:120])
+
+# ── Naming variants: other server spellings still match ──────────────────────
+for t in ["mcp__gmail__send_message", "mcp__composio__GMAIL_CREATE_DRAFT"]:
+    r = run({"tool_name": t, "tool_input": {}})
+    check(f"deny variant spelling: {t}", decision(r) == "deny")
+
+# ── Non-Gmail tools are untouched (safe under a broad matcher) ────────────────
+for t in ["Bash", "Read", "mcp__claude_ai_Google_Drive__create_file",
+          "mcp__sutando-station__composio_exec"]:
+    r = run({"tool_name": t, "tool_input": {}})
+    check(f"allow non-gmail: {t}",
+          r.returncode == 0 and decision(r) is None and not r.stdout.strip())
+
+# ── Escape hatch: env var lifts the guard ─────────────────────────────────────
+r = run({"tool_name": "mcp__claude_ai_Gmail__create_draft", "tool_input": {}},
+        env_extra={"SUTANDO_ALLOW_GMAIL_CONNECTOR_WRITES": "1"})
+check("SUTANDO_ALLOW_GMAIL_CONNECTOR_WRITES=1 lifts the guard",
+      r.returncode == 0 and not r.stdout.strip())
+
+# ── Malformed stdin: fail-OPEN (exit 0, no deny) — never wedge the core ───────
+r = run("this is not json")
+check("malformed stdin fails open", r.returncode == 0 and decision(r) is None)
+
+if failures:
+    print(f"\nFAIL — {len(failures)}: {failures}")
+    sys.exit(1)
+print("\nPASS — gmail-write-guard tests")


### PR DESCRIPTION
## Summary

Field report **05cb849a** (michael@actoneventures.com, 2026-07-13, assigned rui@): every Gmail **write** through the claude.ai MCP connector is unreliable or broken while reads work fine:

- `label_thread` / other label tools fail outright with `"Request had insufficient authentication scopes"` — the connector's OAuth flow doesn't grant the Gmail write scopes it needs (read tools on the same account work).
- `create_draft` caused **7 documented incidents over ~5 weeks** on the reporter's install (drafts not reflecting what gets sent — one wrong-recipient send), and the connector exposes no delete-draft tool, so each cleanup needed raw IMAP `UID SEARCH` + `STORE \Deleted` + `EXPUNGE`.

Nothing in the tools' descriptions warns about this — an install discovers it by getting burned. The reporter fixed it locally with a per-install PreToolUse block; this PR **generalizes that guard** so other installs don't have to rediscover it:

- `hooks/gmail-write-guard.py` — PreToolUse **deny** for `mcp__*` Gmail tools carrying a write verb; the deny reason is actionable (points at the app-password IMAP/SMTP path in `docs/built-in-tools.md → Email` instead of a raw scope-error string). Reads (`search_threads`/`get_thread`/`list_labels`/`get_message`) pass untouched.
- Token-wise verb matching: `list_labels` (token `labels`) stays **allowed** while `label_thread`/`create_label`/`unlabel_thread` are denied.
- Escape hatch: `SUTANDO_ALLOW_GMAIL_CONNECTOR_WRITES=1` lifts the guard for if/when the connector scopes are fixed upstream. Fail-**open** on hook errors (same contract as `skip-ask-user-question.py`).
- `hooks/README.md` deploy section — manual per-node registration, same pattern as `context-source-guard.py`. Deliberately **not** auto-registered in `build-core-settings.mjs`; default-on protection can be a follow-up if maintainers want it.

## Live test results

`python3 tests/gmail-write-guard.test.py` — behavioral (drives the real hook via stdin, the way Claude Code invokes it):

```
  ok  deny: create_draft / label_thread / unlabel_thread / create_label
  ok  deny: apply_sensitive_content_label / apply_sensitive_topics_label / archive_thread / trash_message
  ok  reason points at the IMAP/SMTP path
  ok  reason names the escape hatch
  ok  allow: search_threads / get_thread / list_labels / get_message
  ok  deny variant spelling: mcp__gmail__send_message, mcp__composio__GMAIL_CREATE_DRAFT
  ok  allow non-gmail: Bash, Read, mcp__claude_ai_Google_Drive__create_file, mcp__sutando-station__composio_exec
  ok  SUTANDO_ALLOW_GMAIL_CONNECTOR_WRITES=1 lifts the guard
  ok  malformed stdin fails open
PASS — gmail-write-guard tests
```

Closes the Sutando-side action for report 05cb849a (the connector's OAuth scopes themselves are Anthropic-side; this makes the failure mode safe + self-explanatory for every install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWvssgDGkNzjMPVG9xaMdj
