### PR TITLE
fix(local-task-protocol): separate archive lookup ids from live task ids

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -128,22 +128,34 @@ KNOWN_HEADER_KEYS = (
 )
 _KNOWN_KEY_SET = frozenset(KNOWN_HEADER_KEYS)
 
-# Task-id shape: `task-<slug>` where slug is dash-separated [a-z0-9] segments
-# (task-1783..., task-chat-1783..., task-phone-..., task-summary-...,
-# task-gh-..., task-health-...). Mirrors the gateway bridge's `_valid_tid`
-# defense: ids become filenames, so the charset is the path-traversal guard.
+# Canonical live task-id shape: `task-<slug>` where slug is dash-separated
+# [a-z0-9] segments (task-1783..., task-chat-1783..., task-phone-...,
+# task-summary-..., task-gh-..., task-health-...). This stays narrower than
+# the archive lookup gate below: live API/task-result routes still key off
+# the canonical `task-*` namespace even though historic archives contain
+# additional gateway-safe producer ids like `ask-*`.
 TASK_ID_RE = re.compile(r"^task-[A-Za-z0-9][A-Za-z0-9-]{0,120}$")
+ARCHIVE_LOOKUP_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
 
 def valid_task_id(tid: str) -> bool:
-    """True iff `tid` is a well-formed task id, safe to embed in a filename.
+    """True iff `tid` is a canonical live task id.
 
-    Rejects path separators, dots, whitespace, and empty/oversized ids — the
-    id is used as `tasks/<tid>.txt` and `results/<tid>.txt`, so this is the
-    single traversal gate for readers that accept ids from message content
-    (e.g. `[deduped: <tid>]` holders).
+    Live task/result routes still expect the `task-*` namespace, so this is
+    intentionally stricter than the archive lookup gate.
     """
     return bool(TASK_ID_RE.match(tid or ""))
+
+
+def valid_archive_lookup_id(tid: str) -> bool:
+    """True iff `tid` is safe to look up as an archived filename stem.
+
+    Archive corpora include historic non-`task-*` producer ids (`ask-*`,
+    `sc-ask-*`, `reco-skill-*`). The lookup gate therefore mirrors the
+    gateway bridge's filename-safe charset while still rejecting traversal
+    sentinels and path separators.
+    """
+    return bool(ARCHIVE_LOOKUP_ID_RE.match(tid or "")) and tid not in (".", "..")
 
 
 # ── Header parsing ───────────────────────────────────────────────────────────
@@ -466,7 +478,7 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
     the month-partitioned archive — the same candidate set task-bridge's
     `_isVoiceTask` walks. Returns the first existing path or None. Rejects
     malformed ids rather than globbing with them (traversal gate)."""
-    if not valid_task_id(task_id):
+    if not valid_archive_lookup_id(task_id):
         return None
     fname = f"{task_id}.txt"
     candidates = [tasks_dir / fname, tasks_dir / "processed" / fname,

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -128,22 +128,34 @@ KNOWN_HEADER_KEYS = (
 )
 _KNOWN_KEY_SET = frozenset(KNOWN_HEADER_KEYS)
 
-# Task-id shape: `task-<slug>` where slug is dash-separated [a-z0-9] segments
-# (task-1783..., task-chat-1783..., task-phone-..., task-summary-...,
-# task-gh-..., task-health-...). Mirrors the gateway bridge's `_valid_tid`
-# defense: ids become filenames, so the charset is the path-traversal guard.
+# Canonical live task-id shape: `task-<slug>` where slug is dash-separated
+# [a-z0-9] segments (task-1783..., task-chat-1783..., task-phone-...,
+# task-summary-..., task-gh-..., task-health-...). This stays narrower than
+# the archive lookup gate below: live API/task-result routes still key off
+# the canonical `task-*` namespace even though historic archives contain
+# additional gateway-safe producer ids like `ask-*`.
 TASK_ID_RE = re.compile(r"^task-[A-Za-z0-9][A-Za-z0-9-]{0,120}$")
+ARCHIVE_LOOKUP_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
 
 def valid_task_id(tid: str) -> bool:
-    """True iff `tid` is a well-formed task id, safe to embed in a filename.
+    """True iff `tid` is a canonical live task id.
 
-    Rejects path separators, dots, whitespace, and empty/oversized ids — the
-    id is used as `tasks/<tid>.txt` and `results/<tid>.txt`, so this is the
-    single traversal gate for readers that accept ids from message content
-    (e.g. `[deduped: <tid>]` holders).
+    Live task/result routes still expect the `task-*` namespace, so this is
+    intentionally stricter than the archive lookup gate.
     """
     return bool(TASK_ID_RE.match(tid or ""))
+
+
+def valid_archive_lookup_id(tid: str) -> bool:
+    """True iff `tid` is safe to look up as an archived filename stem.
+
+    Archive corpora include historic non-`task-*` producer ids (`ask-*`,
+    `sc-ask-*`, `reco-skill-*`). The lookup gate therefore mirrors the
+    gateway bridge's filename-safe charset while still rejecting traversal
+    sentinels and path separators.
+    """
+    return bool(ARCHIVE_LOOKUP_ID_RE.match(tid or "")) and tid not in (".", "..")
 
 
 # ── Header parsing ───────────────────────────────────────────────────────────
@@ -466,7 +478,7 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
     the month-partitioned archive — the same candidate set task-bridge's
     `_isVoiceTask` walks. Returns the first existing path or None. Rejects
     malformed ids rather than globbing with them (traversal gate)."""
-    if not valid_task_id(task_id):
+    if not valid_archive_lookup_id(task_id):
         return None
     fname = f"{task_id}.txt"
     candidates = [tasks_dir / fname, tasks_dir / "processed" / fname,

--- a/tests/local-task-protocol.test.py
+++ b/tests/local-task-protocol.test.py
@@ -219,6 +219,11 @@ for good in ("task-1783377232367", "task-chat-1783379117", "task-phone-1", "task
 for bad in ("", "task-", "task-../../etc", "task-a b", "task-a/b", "result-1",
             "task-" + "x" * 200, "task-.hidden"):
     check(f"id rejected: {bad[:24]!r}", not ltp.valid_task_id(bad))
+for good in ("task-1783377232367", "ask-1783379117", "sc-ask-1234",
+             "reco-skill-9999", "result-1"):
+    check(f"archive id ok: {good}", ltp.valid_archive_lookup_id(good))
+for bad in ("", ".", "..", "task-../../etc", "task-a b", "task-a/b", "x" * 65):
+    check(f"archive id rejected: {bad[:24]!r}", not ltp.valid_archive_lookup_id(bad))
 
 # 8. Archive rules.
 base = Path("/tmp/x")
@@ -252,7 +257,8 @@ if (corpus / "archive").is_dir():
         try:
             text = p.read_text(errors="replace")
             h = ltp.parse_task_headers(text)
-            if not (h.get("id") or ltp.valid_task_id(p.stem.split(".")[-1] if "." in p.stem else p.stem)):
+            stem = p.stem.split(".")[-1] if "." in p.stem else p.stem
+            if not (h.get("id") or ltp.valid_archive_lookup_id(stem)):
                 no_id += 1
             # Body fidelity (Codex P2): every post-task: line that is NOT a
             # vocabulary header line must survive into the trusted body.
@@ -294,18 +300,22 @@ _tasks = _tmp / "tasks"
 (_tasks / "archive" / "task-flat.txt").write_text("id: task-flat\ntask: x\n")
 (_tasks / "archive" / "2026-05" / "task-old.txt").write_text("id: task-old\ntask: x\n")
 (_tasks / "archive" / "2026-07" / "task-new.txt").write_text("id: task-new\ntask: x\n")
+(_tasks / "archive" / "2026-07" / "ask-123.txt").write_text("id: ask-123\ntask: x\n")
+(_tasks / "archive" / "2026-07" / "sc-ask-456.txt").write_text("id: sc-ask-456\ntask: x\n")
 (_tasks / "archive" / "stray-dir" / "task-stray.txt").write_text("id: task-stray\ntask: x\n")
 
 check("find: live dir", ltp.find_archived_task(_tasks, "task-live") == _tasks / "task-live.txt")
 check("find: processed", ltp.find_archived_task(_tasks, "task-proc") == _tasks / "processed" / "task-proc.txt")
 check("find: legacy flat archive", ltp.find_archived_task(_tasks, "task-flat") == _tasks / "archive" / "task-flat.txt")
 check("find: month partition", ltp.find_archived_task(_tasks, "task-old") == _tasks / "archive" / "2026-05" / "task-old.txt")
+check("find: ask-* archive id", ltp.find_archived_task(_tasks, "ask-123") == _tasks / "archive" / "2026-07" / "ask-123.txt")
+check("find: sc-ask-* archive id", ltp.find_archived_task(_tasks, "sc-ask-456") == _tasks / "archive" / "2026-07" / "sc-ask-456.txt")
 check("find: non-month dirs skipped", ltp.find_archived_task(_tasks, "task-stray") is None)
 check("find: missing id", ltp.find_archived_task(_tasks, "task-nope") is None)
 check("find: malformed id gated", ltp.find_archived_task(_tasks, "task-../etc") is None)
 swept = [p.name for p in ltp.iter_archived_tasks(_tasks)]
 check("iter: flat + months, stray-dir skipped, live/processed excluded",
-      swept == ["task-flat.txt", "task-old.txt", "task-new.txt"], str(swept))
+      swept == ["task-flat.txt", "task-old.txt", "ask-123.txt", "sc-ask-456.txt", "task-new.txt"], str(swept))
 check("iter: no archive dir yields nothing",
       list(ltp.iter_archived_tasks(_tmp / "nonexistent")) == [])
 


### PR DESCRIPTION
## Summary

Closes #1960.

`local_task_protocol.find_archived_task()` was using `valid_task_id()` as its traversal gate, but `valid_task_id()` intentionally enforces the canonical live `task-*` namespace. That meant archive lookup would silently reject historic gateway-safe ids like `ask-*`, `sc-ask-*`, and `reco-skill-*` even though those ids are valid archived task stems.

This PR separates the two concerns:

- keep `valid_task_id()` strict for live task/result routes that still key off `task-*`
- add a dedicated archive-lookup gate that mirrors the gateway's filename-safe charset and use it only in `find_archived_task()` and the archive corpus assertions

That fixes the archive-reader gap without widening the live API gate to every `[A-Za-z0-9._-]{1,64}` slug.

## Root cause

The original code treated "safe filename stem" and "canonical live task id" as the same concept. They are not: the archive contains valid non-`task-*` producer ids, while the live submit/archive APIs still rely on the narrower `task-*` contract.

## Files to review first

- `src/local_task_protocol.py`
- `tests/local-task-protocol.test.py`

## Verification

- `python3 tests/local-task-protocol.test.py`
  - PASS

## Behavior proved

- `find_archived_task()` now resolves archived `ask-*` / `sc-ask-*` ids instead of rejecting them up front
- malformed lookup ids (`.`, `..`, slashes, spaces, >64 chars) are still rejected
- live `valid_task_id()` behavior stays strict for the existing `task-*` namespace

## Risks / follow-up

- This is intentionally narrower than the earlier closed regex-relaxation PRs: it does not change the live agent-api/task-result gate.
- `#1974` is adjacent but separate: it filters non-task artefacts out of archive iteration; this PR fixes the lookup gate for real archived task ids.
