### PR TITLE
feat(whoami): add agent identity + config-dir + live runtime status

### DIFF
--- a/scripts/sutando-whoami.sh
+++ b/scripts/sutando-whoami.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# sutando-whoami.sh — print this Sutando instance's identity as one JSON object.
+# sutando-whoami.sh — print this Sutando instance's identity + runtime as one JSON object.
 #
-# The stable, machine-readable handle for "which Sutando is this?" — the thing
-# a user pastes (or a tool reads) when another system needs to find or attach
-# to this instance. First consumer: agent-connect's `--sutando-workspace`
-# connect path (the AG2 Space Connect modal pre-fills from this output).
-# Owner-designed primitive, 2026-07-13.
+# The stable, machine-readable handle for "which Sutando is this, and is it
+# running?" — the thing a user pastes (or a tool reads) when another system
+# needs to find, attach to, or pre-fill a form about this instance. First
+# consumer: agent-connect's `--sutando-workspace` connect path (the AG2 Space
+# Connect modal pre-fills from this output). Owner-designed primitive, 2026-07-13.
 #
 #   bash scripts/sutando-whoami.sh
 #
@@ -13,24 +13,48 @@
 #   instance_id  stable per-host install id (state/auth/device.json machineId;
 #                falls back to "unprovisioned-<host>" before provisioning)
 #   host         short hostname (matches the hosts/<hostname>/ convention)
-#   workspace    absolute workspace path (the M0 resolver's answer)
-#   repo         absolute path of this checkout
+#   agent_id     the @…:ag2.space mxid, read LOCALLY from the device-auth env
+#                (<config_dir>/channels/ag2space/.env AGENT_ID) that the connect
+#                flow writes; null before a device is connected
+#   workspace    absolute workspace path — the USER DATA folder (M0 resolver)
+#   repo         absolute path of this checkout (the CODE)
+#   config_dir   absolute .claude-sutando config dir (sessions/memory/channels)
+#   runtime      { core_running, gateway_running, tmux_socket, session } — is a
+#                sutando-core actually up on this host, and where (the "where are
+#                the instances" signal). Best-effort; never fails the whoami.
 #
-# Agent identity (the @...:ag2.space mxid) is deliberately absent: it is not
-# stored locally today — the gateway resolves token → identity server-side.
-# When a gateway whoami op exists, it belongs here too.
+# Identity note: agent_id is read LOCALLY from the device-auth env — that is where
+# the connect flow persists it. If it is absent the device is unprovisioned; a
+# future gateway whoami op can additionally cross-check token → identity server-side.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WS="$(bash "$REPO/scripts/sutando-config.sh" workspace)"
 
-python3 - "$REPO" "$WS" <<'PY'
+# Config dir (the .claude-sutando data dir). Best-effort — the resolver refuses
+# on an invalid config, and whoami must still answer the rest, so swallow errors.
+CONFIG_DIR="$(bash "$REPO/scripts/sutando-config.sh" claude-sutando-config-dir 2>/dev/null || true)"
+
+# Runtime detection (best-effort — a whoami that crashes because tmux is missing
+# is useless; each probe degrades to false). Mirrors start-cli.sh's socket env.
+TMUX_SOCKET="${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}"
+SESSION="sutando-core"
+CORE_RUNNING=false
+if command -v tmux >/dev/null 2>&1 && tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null; then
+  CORE_RUNNING=true
+fi
+GATEWAY_RUNNING=false
+if pgrep -f "remote-gateway-bridge" >/dev/null 2>&1; then
+  GATEWAY_RUNNING=true
+fi
+
+python3 - "$REPO" "$WS" "$CONFIG_DIR" "$TMUX_SOCKET" "$SESSION" "$CORE_RUNNING" "$GATEWAY_RUNNING" <<'PY'
 import json
 import os
 import socket
 import sys
 
-repo, ws = sys.argv[1], sys.argv[2]
+repo, ws, config_dir, tmux_socket, session, core_running, gateway_running = sys.argv[1:8]
 host = socket.gethostname().split(".")[0]
 
 machine_id = None
@@ -40,13 +64,36 @@ try:
 except (OSError, ValueError):
     pass
 
+# Agent identity: read AGENT_ID from the device-auth env — the file the connect
+# flow writes (channels/ag2space/.env). Absent before a device is connected.
+agent_id = None
+if config_dir:
+    env_path = os.path.join(config_dir, "channels", "ag2space", ".env")
+    try:
+        with open(env_path) as f:
+            for raw in f:
+                line = raw.strip()
+                if line.startswith("AGENT_ID="):
+                    agent_id = line.split("=", 1)[1].strip().strip('"').strip("'") or None
+                    break
+    except OSError:
+        pass
+
 print(
     json.dumps(
         {
             "instance_id": machine_id or f"unprovisioned-{host}",
             "host": host,
+            "agent_id": agent_id,
             "workspace": ws,
             "repo": repo,
+            "config_dir": config_dir or None,
+            "runtime": {
+                "core_running": core_running == "true",
+                "gateway_running": gateway_running == "true",
+                "tmux_socket": tmux_socket,
+                "session": session,
+            },
         },
         indent=2,
     )

--- a/tests/sutando-whoami.test.sh
+++ b/tests/sutando-whoami.test.sh
@@ -52,5 +52,28 @@ PY
 then ok "unprovisioned fallback when device.json absent"; else bad "unprovisioned fallback"; fi
 rm -rf "$T"
 
+# 4) agent_id is actually READ from <config_dir>/channels/ag2space/.env AGENT_ID.
+#    Guards the identity path the desktop Connect UI depends on: a schema-only
+#    check would stay green even if the parser silently stopped reading the file
+#    (always emitting null). Write a real device-env fixture and assert the value.
+T2="$(mktemp -d)"
+mkdir -p "$T2/ws"
+ccd="$(SUTANDO_TEST_MODE=1 SUTANDO_WORKSPACE="$T2/ws" bash "$REPO/scripts/sutando-config.sh" claude-sutando-config-dir 2>/dev/null || true)"
+if [ -n "$ccd" ]; then
+  mkdir -p "$ccd/channels/ag2space"
+  printf 'AGENT_ID="@agent:ag2.space"\nREMOTE_TASK_TOKEN=x\n' > "$ccd/channels/ag2space/.env"
+  out3="$(SUTANDO_TEST_MODE=1 SUTANDO_WORKSPACE="$T2/ws" bash "$REPO/scripts/sutando-whoami.sh")"
+  if WHOAMI_OUT="$out3" python3 - <<'PY'
+import json, os
+d = json.loads(os.environ["WHOAMI_OUT"])
+assert d["agent_id"] == "@agent:ag2.space", d["agent_id"]
+assert d["config_dir"] and d["config_dir"].endswith(".claude-sutando"), d["config_dir"]
+PY
+  then ok "agent_id read from device-auth env"; else bad "agent_id extraction (parser did not read AGENT_ID)"; fi
+else
+  bad "config-dir resolver returned empty under test mode"
+fi
+rm -rf "$T2"
+
 printf '\n%s\n' "$([ "$fails" -eq 0 ] && echo 'PASS — sutando-whoami green' || echo "FAIL — $fails failing")"
 exit "$fails"

--- a/tests/sutando-whoami.test.sh
+++ b/tests/sutando-whoami.test.sh
@@ -14,10 +14,21 @@ out="$(bash "$REPO/scripts/sutando-whoami.sh")"
 if WHOAMI_OUT="$out" REPO_EXPECT="$REPO" python3 - <<'PY'
 import json, os
 d = json.loads(os.environ["WHOAMI_OUT"])
-assert set(d) == {"instance_id", "host", "workspace", "repo"}, d.keys()
+assert set(d) == {
+    "instance_id", "host", "agent_id", "workspace", "repo", "config_dir", "runtime"
+}, d.keys()
 assert d["repo"] == os.environ["REPO_EXPECT"], d["repo"]
 assert d["workspace"].startswith("/"), d["workspace"]
 assert d["instance_id"] and d["host"]
+# agent_id / config_dir are optional (null before a device is connected / an
+# unresolvable config), but must be str-or-None when present.
+assert d["agent_id"] is None or isinstance(d["agent_id"], str), d["agent_id"]
+assert d["config_dir"] is None or isinstance(d["config_dir"], str), d["config_dir"]
+# runtime is always an object with the four liveness fields.
+rt = d["runtime"]
+assert set(rt) == {"core_running", "gateway_running", "tmux_socket", "session"}, rt.keys()
+assert isinstance(rt["core_running"], bool) and isinstance(rt["gateway_running"], bool)
+assert rt["tmux_socket"].startswith("/") and rt["session"]
 PY
 then ok "valid JSON with contract fields"; else bad "JSON contract"; fi
 


### PR DESCRIPTION
## What

Extends the `sutando-whoami` primitive (owner-requested 2026-07-13) so the desktop **Connect UI** and a human can answer *"which Sutando is this, is it running, and where is my data"* from one command. Purely **additive** — existing fields (`instance_id`/`host`/`workspace`/`repo`) unchanged.

New fields:
- **`agent_id`** — the `@…:ag2.space` mxid, read **locally** from the device-auth env (`<config_dir>/channels/ag2space/.env` `AGENT_ID`) the connect flow writes. The script previously punted this to a future gateway op, but it's already on disk once a device is connected. `null` before provisioning.
- **`config_dir`** — the resolved `.claude-sutando` (sessions/memory/channels).
- **`runtime`** — `{ core_running, gateway_running, tmux_socket, session }` — *"where are the instances"*: is a `sutando-core` actually up on this host. Best-effort probes (`tmux has-session` on `SUTANDO_TMUX_SOCKET`; `pgrep` for the gateway bridge); each degrades to `false` so whoami never crashes on a missing tool.

## Why

Owner (2026-07-13): the desktop setup UX needs a command that tells the user their identity + data-folder + whether the runtime is live, to pre-fill the Connect modal and to answer "is my agent running + where." This session's air-restore made the gap concrete — hunting for the config/workspace by hand is exactly what `whoami` should surface.

## Test

```
$ bash scripts/sutando-whoami.sh
{ "instance_id": …, "host": …, "agent_id": "@…:ag2.space"|null,
  "workspace": …, "repo": …, "config_dir": …,
  "runtime": { "core_running": true, "gateway_running": true,
               "tmux_socket": "/tmp/sutando-tmux.sock", "session": "sutando-core" } }
```
`bash -n` clean; runs on a live host (core/gateway detected true) and an unprovisioned checkout (`agent_id: null`, runtime false).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
