### PR TITLE
feat(runtime-health): derive live core health (working/idle/needs_login/offline)

### DIFF
--- a/src/runtime-health.py
+++ b/src/runtime-health.py
@@ -86,12 +86,19 @@ def needs_login(pane_text):
 
 
 def _core_status(workspace):
-    """Read the agent's own status ('running'|'idle') from core-status.json."""
+    """Read the agent's own status ('running'|'idle') from core-status.json.
+
+    This is a shared state file written by other processes, so treat it as
+    untrusted: a missing/corrupt file (OSError/ValueError) OR a valid-but-non-object
+    JSON value (e.g. a stray `[]` — `.get` would AttributeError) degrades to None,
+    never a crash — keeping the script's "unknown, not exception" contract.
+    """
     try:
         with open(os.path.join(workspace, "state", "core-status.json")) as f:
-            return json.load(f).get("status")
+            data = json.load(f)
     except (OSError, ValueError):
         return None
+    return data.get("status") if isinstance(data, dict) else None
 
 
 def _resolve_workspace(repo):

--- a/src/runtime-health.py
+++ b/src/runtime-health.py
@@ -26,12 +26,21 @@ observer; it starts nothing and kills nothing.
 """
 import json
 import os
-import re
 import subprocess
 import sys
+import time
 
 SESSION = "sutando-core"
 TMUX_SOCKET = os.environ.get("SUTANDO_TMUX_SOCKET", "/tmp/sutando-tmux.sock")
+
+# A `core-status.json` claiming "running" is only trustworthy if its `ts` is
+# recent — a crashed/wedged loop can leave it stuck on "running" indefinitely.
+# Beyond this window a "running" record degrades to "unknown" rather than
+# falsely reporting "working" (the exact incident this signal exists to catch).
+# Aligned with the freshness gates other readers already apply (web-client 60s,
+# core-heartbeat ~90s); 90s tolerates a normal long step between status writes
+# while still catching a genuinely wedged loop (stale for far longer).
+STALE_STATUS_SECONDS = 90
 
 # Markers that mean the bundled claude CLI is sitting at its auth prompt and the
 # core therefore cannot act. Kept broad on purpose — the failure mode is a user
@@ -97,8 +106,15 @@ def _core_status(workspace):
         with open(os.path.join(workspace, "state", "core-status.json")) as f:
             data = json.load(f)
     except (OSError, ValueError):
-        return None
-    return data.get("status") if isinstance(data, dict) else None
+        return None, None
+    if not isinstance(data, dict):
+        return None, None
+    ts = data.get("ts")
+    try:
+        ts = float(ts) if ts is not None else None
+    except (TypeError, ValueError):
+        ts = None
+    return data.get("status"), ts
 
 
 def _resolve_workspace(repo):
@@ -119,10 +135,15 @@ def derive():
         if needs_login(_pane_text()):
             health, authed, detail = "needs_login", False, "Agent needs to sign in"
         else:
-            status = _core_status(workspace)
+            status, ts = _core_status(workspace)
             authed = True
-            if status == "running":
+            stale = ts is not None and (time.time() - ts) > STALE_STATUS_SECONDS
+            if status == "running" and not stale:
                 health, detail = "working", "Agent is working"
+            elif status == "running" and stale:
+                # Session alive but status hasn't advanced — likely a wedged/
+                # crashed loop; don't claim "working" off a stale record.
+                health, detail = "unknown", "Status stale (still 'running', not updated recently) — possibly wedged"
             elif status == "idle":
                 health, detail = "idle", "Agent is online and idle"
             else:

--- a/src/runtime-health.py
+++ b/src/runtime-health.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""runtime-health.py — derive this Sutando core's live health as one JSON object.
+
+The machine-readable "is my agent working, idle, stuck-at-login, or offline?"
+signal. The desktop app's Console renders it as a plain-English status strip +
+one-click action cards (regular users) instead of making them read a raw
+terminal; `sutando-whoami` can embed it too. Owner-designed 2026-07-13 — the
+"when she's not responding, I can't tell if she's thinking or stuck" painpoint,
+made concrete when a core sat unresponsive at claude's `/login` (locked keychain).
+
+    python3 src/runtime-health.py           # prints JSON; also writes state/runtime-health.json
+
+Output (single JSON object on stdout):
+    health           working | idle | needs_login | offline | unknown
+    authenticated    bool | null  (false when the core is sitting at claude's login prompt;
+                     null when we can't tell, e.g. the core is offline)
+    core_running     bool   (a `sutando-core` tmux session exists on the socket)
+    gateway_running  bool   (the relay gateway bridge process is up)
+    tmux_socket      the SUTANDO_TMUX_SOCKET this probed (private-socket aware)
+    session          the tmux session name
+    detail           short human string for the status strip
+
+Design: every probe is best-effort and degrades — a missing tmux or an
+unreadable status file yields `unknown`, never a crash. This is a read-only
+observer; it starts nothing and kills nothing.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+
+SESSION = "sutando-core"
+TMUX_SOCKET = os.environ.get("SUTANDO_TMUX_SOCKET", "/tmp/sutando-tmux.sock")
+
+# Markers that mean the bundled claude CLI is sitting at its auth prompt and the
+# core therefore cannot act. Kept broad on purpose — the failure mode is a user
+# staring at an unresponsive agent, so a false "needs_login" (rare) is far less
+# costly than missing a real one.
+_LOGIN_MARKERS = (
+    "not logged in",
+    "please run /login",
+    "run `claude login`",
+    "run 'claude login'",
+    "unlock-keychain",
+    "invalid api key",
+    "authentication_error",
+)
+
+
+def _run(cmd):
+    """Run a command, returning (rc, stdout). Never raises."""
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=8)
+        return p.returncode, p.stdout
+    except (OSError, subprocess.SubprocessError):
+        return 127, ""
+
+
+def _core_running():
+    # has-session returns non-zero (and _run yields 127 if tmux is absent), so a
+    # missing tmux or socket degrades cleanly to "not running".
+    rc, _ = _run(["tmux", "-S", TMUX_SOCKET, "has-session", "-t", SESSION])
+    return rc == 0
+
+
+def _gateway_running():
+    rc, _ = _run(["pgrep", "-f", "remote-gateway-bridge"])
+    if rc == 0:
+        return True
+    # Fallback: a window named "gateway" in the core session.
+    rc, out = _run(["tmux", "-S", TMUX_SOCKET, "list-windows", "-t", SESSION, "-F", "#{window_name}"])
+    return rc == 0 and any(w.strip() == "gateway" for w in out.splitlines())
+
+
+def _pane_text():
+    rc, out = _run(["tmux", "-S", TMUX_SOCKET, "capture-pane", "-p", "-t", SESSION])
+    return out if rc == 0 else ""
+
+
+def needs_login(pane_text):
+    """Pure predicate: does the core pane show claude's auth prompt? Testable
+    without a live tmux — this is the load-bearing 'stuck vs thinking' decision."""
+    low = pane_text.lower()
+    return any(m in low for m in _LOGIN_MARKERS)
+
+
+def _core_status(workspace):
+    """Read the agent's own status ('running'|'idle') from core-status.json."""
+    try:
+        with open(os.path.join(workspace, "state", "core-status.json")) as f:
+            return json.load(f).get("status")
+    except (OSError, ValueError):
+        return None
+
+
+def _resolve_workspace(repo):
+    rc, out = _run(["bash", os.path.join(repo, "scripts", "sutando-config.sh"), "workspace"])
+    return out.strip() if rc == 0 and out.strip() else os.path.join(repo, "workspace")
+
+
+def derive():
+    repo = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    workspace = _resolve_workspace(repo)
+
+    core = _core_running()
+    gateway = _gateway_running()
+
+    if not core:
+        health, authed, detail = "offline", None, "Agent is not running"
+    else:
+        if needs_login(_pane_text()):
+            health, authed, detail = "needs_login", False, "Agent needs to sign in"
+        else:
+            status = _core_status(workspace)
+            authed = True
+            if status == "running":
+                health, detail = "working", "Agent is working"
+            elif status == "idle":
+                health, detail = "idle", "Agent is online and idle"
+            else:
+                health, detail = "unknown", "Agent is running (status unknown)"
+
+    return {
+        "health": health,
+        "authenticated": authed,
+        "core_running": core,
+        "gateway_running": gateway,
+        "tmux_socket": TMUX_SOCKET,
+        "session": SESSION,
+        "detail": detail,
+    }
+
+
+def main():
+    result = derive()
+    # Best-effort persist so anything (app, dashboard) can read the latest without
+    # re-probing; failure to write must not fail the read.
+    try:
+        repo = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        ws = _resolve_workspace(repo)
+        state_dir = os.path.join(ws, "state")
+        os.makedirs(state_dir, exist_ok=True)
+        with open(os.path.join(state_dir, "runtime-health.json"), "w") as f:
+            json.dump(result, f, indent=2)
+    except OSError:
+        pass
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/runtime-health.test.py
+++ b/tests/runtime-health.test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Tests for src/runtime-health.py — the core health-state derivation.
+
+Covers the load-bearing 'stuck-at-login vs thinking' predicate against the REAL
+pane text a stuck core shows, and the offline path end-to-end. tmux-dependent
+paths (working/idle) are covered by the pure predicate + the offline e2e; a full
+working-state e2e would need a live core, which CI doesn't have.
+
+    python3 tests/runtime-health.test.py
+"""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "runtime_health", os.path.join(REPO, "src", "runtime-health.py")
+)
+rh = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rh)
+
+fails = 0
+
+
+def check(name, cond):
+    global fails
+    print(("  ok   " if cond else "  FAIL ") + name)
+    if not cond:
+        fails += 1
+
+
+# 1) needs_login() fires on the REAL text a keychain-locked core shows.
+#    (Captured verbatim 2026-07-13 from a core stuck after an SSH-launched start.)
+STUCK_PANE = """\
+  ⎿  Not logged in · Please run /login
+     · Run in another terminal: security unlock-keychain
+✻ Worked for 0s
+                                                     Not logged in · Run /login
+"""
+check("needs_login: true on a stuck-at-login pane", rh.needs_login(STUCK_PANE) is True)
+
+# 2) It does NOT fire on a normal working pane (no false 'needs sign-in').
+WORKING_PANE = """\
+  connect-flow → recommended path (b), #8 merged, memory maintenance. Then it
+  Running 1 shell command…
+✢ Perambulating… (1m 46s · ↓ 5.9k tokens)
+"""
+check("needs_login: false on a working pane", rh.needs_login(WORKING_PANE) is False)
+check("needs_login: false on empty pane", rh.needs_login("") is False)
+
+# 3) offline end-to-end: a socket with no session → health=offline, authed=null.
+env = dict(os.environ)
+env["SUTANDO_TMUX_SOCKET"] = "/tmp/rh-test-nonexistent-%d.sock" % os.getpid()
+p = subprocess.run(
+    [sys.executable, os.path.join(REPO, "src", "runtime-health.py")],
+    capture_output=True, text=True, timeout=30, env=env,
+)
+try:
+    out = json.loads(p.stdout)
+except (ValueError, json.JSONDecodeError):
+    out = {}
+check("offline: valid JSON emitted", bool(out))
+check("offline: health == offline", out.get("health") == "offline")
+check("offline: authenticated is null", out.get("authenticated") is None)
+check("offline: core_running is false", out.get("core_running") is False)
+check(
+    "contract keys present",
+    set(out) == {"health", "authenticated", "core_running", "gateway_running",
+                 "tmux_socket", "session", "detail"},
+)
+
+print("\n" + ("PASS — runtime-health green" if fails == 0 else "FAIL — %d failing" % fails))
+sys.exit(fails)

--- a/tests/runtime-health.test.py
+++ b/tests/runtime-health.test.py
@@ -114,6 +114,16 @@ with open(os.path.join(T, "state", "core-status.json"), "w") as f:
 check("_core_status: reads status from file", rh._core_status(T) == "running")
 check("_core_status: missing file -> None", rh._core_status(tempfile.mkdtemp()) is None)
 
+# core-status.json written by another process could be corrupt OR a valid but
+# non-object JSON value (e.g. a stray '[]'); must degrade to None, not crash.
+for bad in ("[]", '"idle"', "42", "not json {"):
+    Tb = tempfile.mkdtemp()
+    os.makedirs(os.path.join(Tb, "state"))
+    with open(os.path.join(Tb, "state", "core-status.json"), "w") as f:
+        f.write(bad)
+    ok_ = rh._core_status(Tb) is None
+    check("_core_status: non-object/corrupt JSON %r -> None (no crash)" % bad, ok_)
+
 # 6) Exercise the REAL probe implementations in-process (offline path) so the
 #    subprocess-only e2e above doesn't leave _run/_core_running/_gateway_running/
 #    _pane_text/main uncovered. Point at a socket with no session → offline, and

--- a/tests/runtime-health.test.py
+++ b/tests/runtime-health.test.py
@@ -13,6 +13,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _spec = importlib.util.spec_from_file_location(
@@ -74,12 +75,17 @@ check(
 # 4) derive() maps every state correctly — drive it by patching the probes so we
 #    exercise the working/idle/needs_login/offline/unknown branches without a live
 #    tmux (the branches a schema-only test would leave uncovered).
-def _derive_with(core, pane, status, gateway=False):
+def _derive_with(core, pane, status, gateway=False, ts="fresh"):
+    # ts: "fresh" -> now; "stale" -> older than the gate; or an explicit epoch/None.
+    if ts == "fresh":
+        ts = time.time()
+    elif ts == "stale":
+        ts = time.time() - (rh.STALE_STATUS_SECONDS + 60)
     orig = (rh._core_running, rh._pane_text, rh._core_status,
             rh._gateway_running, rh._resolve_workspace)
     rh._core_running = lambda: core
     rh._pane_text = lambda: pane
-    rh._core_status = lambda ws: status
+    rh._core_status = lambda ws: (status, ts)
     rh._gateway_running = lambda: gateway
     rh._resolve_workspace = lambda repo: "/tmp/ignored-ws"
     try:
@@ -89,9 +95,15 @@ def _derive_with(core, pane, status, gateway=False):
          rh._gateway_running, rh._resolve_workspace) = orig
 
 
-d = _derive_with(core=True, pane="", status="running", gateway=True)
-check("derive: running status -> working", d["health"] == "working" and d["authenticated"] is True)
+d = _derive_with(core=True, pane="", status="running", gateway=True, ts="fresh")
+check("derive: fresh running -> working", d["health"] == "working" and d["authenticated"] is True)
 check("derive: gateway_running surfaced", d["gateway_running"] is True)
+
+d = _derive_with(core=True, pane="", status="running", ts="stale")
+check("derive: STALE running -> unknown (not working)", d["health"] == "unknown")
+
+d = _derive_with(core=True, pane="", status="running", ts=None)
+check("derive: running with no ts -> working (can't prove stale)", d["health"] == "working")
 
 d = _derive_with(core=True, pane="", status="idle")
 check("derive: idle status -> idle", d["health"] == "idle" and d["authenticated"] is True)
@@ -111,18 +123,25 @@ T = tempfile.mkdtemp()
 os.makedirs(os.path.join(T, "state"))
 with open(os.path.join(T, "state", "core-status.json"), "w") as f:
     f.write('{"status":"running","ts":1}')
-check("_core_status: reads status from file", rh._core_status(T) == "running")
-check("_core_status: missing file -> None", rh._core_status(tempfile.mkdtemp()) is None)
+check("_core_status: reads (status, ts) from file", rh._core_status(T) == ("running", 1.0))
+check("_core_status: missing file -> (None, None)", rh._core_status(tempfile.mkdtemp()) == (None, None))
 
 # core-status.json written by another process could be corrupt OR a valid but
-# non-object JSON value (e.g. a stray '[]'); must degrade to None, not crash.
+# non-object JSON value (e.g. a stray '[]'); must degrade to (None, None), not crash.
 for bad in ("[]", '"idle"', "42", "not json {"):
     Tb = tempfile.mkdtemp()
     os.makedirs(os.path.join(Tb, "state"))
     with open(os.path.join(Tb, "state", "core-status.json"), "w") as f:
         f.write(bad)
-    ok_ = rh._core_status(Tb) is None
-    check("_core_status: non-object/corrupt JSON %r -> None (no crash)" % bad, ok_)
+    ok_ = rh._core_status(Tb) == (None, None)
+    check("_core_status: non-object/corrupt JSON %r -> (None, None) (no crash)" % bad, ok_)
+
+# A non-numeric ts must not crash the float() coercion -> ts None.
+Tt = tempfile.mkdtemp()
+os.makedirs(os.path.join(Tt, "state"))
+with open(os.path.join(Tt, "state", "core-status.json"), "w") as f:
+    f.write('{"status":"running","ts":"garbage"}')
+check("_core_status: non-numeric ts -> (status, None)", rh._core_status(Tt) == ("running", None))
 
 # 6) Exercise the REAL probe implementations in-process (offline path) so the
 #    subprocess-only e2e above doesn't leave _run/_core_running/_gateway_running/

--- a/tests/runtime-health.test.py
+++ b/tests/runtime-health.test.py
@@ -71,5 +71,95 @@ check(
                  "tmux_socket", "session", "detail"},
 )
 
+# 4) derive() maps every state correctly — drive it by patching the probes so we
+#    exercise the working/idle/needs_login/offline/unknown branches without a live
+#    tmux (the branches a schema-only test would leave uncovered).
+def _derive_with(core, pane, status, gateway=False):
+    orig = (rh._core_running, rh._pane_text, rh._core_status,
+            rh._gateway_running, rh._resolve_workspace)
+    rh._core_running = lambda: core
+    rh._pane_text = lambda: pane
+    rh._core_status = lambda ws: status
+    rh._gateway_running = lambda: gateway
+    rh._resolve_workspace = lambda repo: "/tmp/ignored-ws"
+    try:
+        return rh.derive()
+    finally:
+        (rh._core_running, rh._pane_text, rh._core_status,
+         rh._gateway_running, rh._resolve_workspace) = orig
+
+
+d = _derive_with(core=True, pane="", status="running", gateway=True)
+check("derive: running status -> working", d["health"] == "working" and d["authenticated"] is True)
+check("derive: gateway_running surfaced", d["gateway_running"] is True)
+
+d = _derive_with(core=True, pane="", status="idle")
+check("derive: idle status -> idle", d["health"] == "idle" and d["authenticated"] is True)
+
+d = _derive_with(core=True, pane=STUCK_PANE, status="running")
+check("derive: login pane wins over status -> needs_login", d["health"] == "needs_login" and d["authenticated"] is False)
+
+d = _derive_with(core=True, pane="", status=None)
+check("derive: running but no status -> unknown", d["health"] == "unknown")
+
+d = _derive_with(core=False, pane="", status="running")
+check("derive: no core -> offline", d["health"] == "offline" and d["authenticated"] is None)
+
+# 5) _core_status reads the status field from a fixture core-status.json.
+import tempfile
+T = tempfile.mkdtemp()
+os.makedirs(os.path.join(T, "state"))
+with open(os.path.join(T, "state", "core-status.json"), "w") as f:
+    f.write('{"status":"running","ts":1}')
+check("_core_status: reads status from file", rh._core_status(T) == "running")
+check("_core_status: missing file -> None", rh._core_status(tempfile.mkdtemp()) is None)
+
+# 6) Exercise the REAL probe implementations in-process (offline path) so the
+#    subprocess-only e2e above doesn't leave _run/_core_running/_gateway_running/
+#    _pane_text/main uncovered. Point at a socket with no session → offline, and
+#    call each real helper directly (they degrade to empty/false, never crash).
+_orig_socket = rh.TMUX_SOCKET
+rh.TMUX_SOCKET = "/tmp/rh-inproc-nonexistent-%d.sock" % os.getpid()
+try:
+    check("real _core_running: false on bogus socket", rh._core_running() is False)
+    check("real _gateway_running returns a bool", isinstance(rh._gateway_running(), bool))
+    check("real _pane_text returns a str", isinstance(rh._pane_text(), str))
+    check("real _resolve_workspace returns a path", rh._resolve_workspace(REPO).startswith("/"))
+    d = rh.derive()
+    check("real derive: offline on bogus socket", d["health"] == "offline")
+    # main() derives + best-effort persists + prints; must not raise.
+    rh.main()
+    check("real main() ran without error", True)
+finally:
+    rh.TMUX_SOCKET = _orig_socket
+
+# 7) Defensive branches (the degrade-not-crash paths).
+rc, out = rh._run(["/nonexistent-rh-binary-xyz"])
+check("_run: missing binary -> (127, '')", rc == 127 and out == "")
+
+
+def _fake_run_gw(cmd):
+    if cmd[:1] == ["pgrep"]:
+        return 1, ""                      # no gateway process
+    if "list-windows" in cmd:
+        return 0, "core\ngateway\n"       # ...but a 'gateway' window exists
+    return 1, ""
+
+
+_o = rh._run
+rh._run = _fake_run_gw
+try:
+    check("_gateway_running: window-scan fallback", rh._gateway_running() is True)
+finally:
+    rh._run = _o
+
+_ow = rh._resolve_workspace
+rh._resolve_workspace = lambda repo: "/dev/null/cannot-mkdir-here"
+try:
+    rh.main()  # unwritable state dir -> write swallowed, still prints
+    check("main(): survives an unwritable state dir", True)
+finally:
+    rh._resolve_workspace = _ow
+
 print("\n" + ("PASS — runtime-health green" if fails == 0 else "FAIL — %d failing" % fails))
 sys.exit(fails)


### PR DESCRIPTION
## What

`src/runtime-health.py` — derives this core's **live health** as one JSON object: the machine-readable *"is my agent working, idle, stuck-at-login, or offline?"* signal.

```
health           working | idle | needs_login | offline | unknown
authenticated    bool | null   (false when the core sits at claude's /login)
core_running     bool
gateway_running  bool
tmux_socket, session, detail
```

## Why

The runtime side of the desktop app's **Console** (owner-designed 2026-07-13, the *"when she's not responding I can't tell if she's thinking or stuck"* painpoint). The Console's **regular-user Actions view** renders this as a plain status strip + one-click cards (Sign in / Restart) instead of making the user read a raw terminal; `sutando-whoami` (#2091) can embed it. Grounded in a real incident: an SSH-launched core sat unresponsive at claude's `/login` (locked keychain) with no legible signal — `health="needs_login"` is exactly that signal.

Read-only observer — starts/kills nothing; every probe degrades to `unknown`/`offline` rather than crashing (missing tmux, unreadable status). Private-socket aware (`SUTANDO_TMUX_SOCKET`). Writes `state/runtime-health.json` best-effort.

## Test

`python3 tests/runtime-health.test.py` — covers the load-bearing `needs_login` predicate against the **verbatim stuck-core pane text**, the offline path e2e, and the JSON contract. Green; also validated against a live working core.

## Coordinate

@qingyun-air — this is the data source for the Console **Actions view** (your app-side UI + the `core_terminal_*` capability powers the Terminal view). If you want a different `health` enum or field names for the UI, say so and I'll match — the schema is meant to be what your Console renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
