### PR TITLE
fix(bridges): make CONTEXT-FIRST reconstruction unconditional (discord + telegram)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -3166,17 +3166,22 @@ async def _handle_discord_message(message, force=False):
         step = 1
         # Context-first: a terse or threaded reply ("no", "continue", a pronoun)
         # loses its referent when interpreted against a stale/compacted session
-        # context. Reconstruct from the durable channel BEFORE interpreting —
-        # keyed on the message not being self-contained (the agent's own judgment,
-        # not a parent_message_id gate), following the reply chain back, no
-        # arbitrary message count. Root-cause fix 2026-06-25.
+        # context. UNCONDITIONAL as of 2026-07-13 (owner-approved): the prior form
+        # gated reconstruction on the agent judging the message "not self-contained"
+        # — but that judgment ("I already understand this") is the exact signal that
+        # fails, so the agent kept walking past the read on questions it only *felt*
+        # confident about. Removing the gate trades a few cheap reads for never
+        # skipping it; only a pure greeting/ack is exempt. Supersedes the
+        # self-contained-judgment form (root-cause 2026-06-25).
         lines.append(
-            f'{step}. CONTEXT-FIRST: if this message is not self-contained (terse, a reply, '
-            f'or refers to something not stated here), reconstruct the relevant context '
-            f'BEFORE interpreting — `python3 src/discord-read.py {channel_id_str}` — and '
-            f'read the thread (everyone\'s messages including your own prior replies) back '
-            f'until it stands on its own, then answer from the reconstructed thread, not '
-            f'from memory.'
+            f'{step}. CONTEXT-FIRST (unconditional): before interpreting this message, '
+            f'reconstruct the thread — `python3 src/discord-read.py {channel_id_str}` — '
+            f'and read it back (everyone\'s messages including your own prior replies) '
+            f'until this message stands on its own, then answer from the reconstructed '
+            f'thread, NOT from memory. Do this every time; do NOT skip it because the '
+            f'message looks self-contained or you feel you already understand it — felt '
+            f'confidence is exactly the signal that fails. The only exception is a pure '
+            f'greeting or acknowledgement with no referent (e.g. "hi", "thanks").'
         )
         step += 1
         if _notify_py.exists():

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -773,16 +773,26 @@ def main():
                 )
                 lines = ["===SKILL INSTRUCTIONS (follow before any other action)==="]
                 step = 1
-                # CONTEXT-FIRST: reconstruct before interpreting a message that isn't
-                # self-contained. Unlike Discord, Telegram's Bot API has NO message-history
-                # fetch — so the reconstruct substrate is the embedded [Replying to …] quote
-                # (above) + the session transcript, NOT a channel pull-back. Always emitted.
+                # CONTEXT-FIRST: reconstruct before interpreting. UNCONDITIONAL as of
+                # 2026-07-13 (owner-approved): the prior form gated reconstruction on the
+                # agent judging the message "not self-contained" — but that judgment ("I
+                # already understand this") is the exact signal that fails, so the agent
+                # kept walking past the read on questions it only *felt* confident about.
+                # Removing the gate trades a little cheap re-reading for never skipping it;
+                # only a pure greeting/ack is exempt. Unlike Discord, Telegram's Bot API has
+                # NO message-history fetch — so the reconstruct substrate is the embedded
+                # [Replying to …] quote (above) + the session transcript, NOT a channel
+                # pull-back. Supersedes the self-contained-judgment form.
                 lines.append(
-                    f'{step}. CONTEXT-FIRST: if this message is not self-contained '
-                    f'(terse — "y", "no", a pronoun — a reply, or refers to something not '
-                    f'stated here), reconstruct context BEFORE interpreting. Telegram has no '
-                    f'message-history fetch, so use the embedded [Replying to …] quote above '
-                    f'plus the session transcript, and answer from that, not from memory.'
+                    f'{step}. CONTEXT-FIRST (unconditional): before interpreting this '
+                    f'message, reconstruct context and answer from it, NOT from memory. '
+                    f'Telegram has no message-history fetch, so the substrate is the '
+                    f'embedded [Replying to …] quote above plus the session transcript — '
+                    f'read them back until this message stands on its own. Do this every '
+                    f'time; do NOT skip it because the message looks self-contained or you '
+                    f'feel you already understand it — felt confidence is exactly the '
+                    f'signal that fails. The only exception is a pure greeting or '
+                    f'acknowledgement with no referent (e.g. "hi", "thanks").'
                 )
                 step += 1
                 if _notify_py.exists():


### PR DESCRIPTION
## What

The owner-task skill-instruction **step 1 (CONTEXT-FIRST)** injected by the Discord and Telegram bridges gated reconstruction on the agent judging the message *"not self-contained."* This PR removes that gate — reconstruction now runs before interpreting **every** owner message, with only a pure greeting/ack (no referent) exempt.

## Why

The self-contained judgment is the exact signal that fails. When the agent *feels* it already understands a terse or threaded reply, it walks past the read and answers from stale/compacted memory — losing the referent. "Do I feel confident?" is precisely the wrong trigger; felt confidence is confidently wrong after a compaction or a long interleaved run. Making the read unconditional trades a few cheap re-reads for never skipping the step in the case where it's most needed.

## Change

- `src/discord-bridge.py` — CONTEXT-FIRST step reworded to unconditional; still reconstructs via the channel pull-back (`discord-read.py`).
- `src/telegram-bridge.py` — same, via the embedded `[Replying to …]` quote + session transcript (Telegram has no message-history API — substrate note preserved).

Prompt-instruction text only. No code-path or tool-behavior change; both files `py_compile` clean.

## Scope

Single concern (the CONTEXT-FIRST instruction in the two bridges that pull-back). Slack's CONTEXT-FIRST step is being handled separately in #1839/#1840.

Stand: Echo Act IV Pro