### PR TITLE
fix(workspace): honor $SUTANDO_APP_SUPPORT so the bundled desktop core uses a writable workspace

### DIFF
--- a/src/Sutando/SutandoConfig.swift
+++ b/src/Sutando/SutandoConfig.swift
@@ -191,7 +191,9 @@ enum SutandoConfig {
     ///
     /// Order:
     ///   1. config workspace.path (deep-merged)
-    ///   2. {repoRoot}/workspace baked-in default
+    ///   2. $SUTANDO_DEFAULT_WORKSPACE — optional full workspace path an embedder
+    ///      may set (fills the default slot). Mirrors sutando_config.py.
+    ///   3. {repoRoot}/workspace baked-in default
     ///
     /// $SUTANDO_WORKSPACE is ignored in production as of v0.8 (warn once).
     /// SUTANDO_TEST_MODE=1 keeps the env override for tests only.
@@ -218,10 +220,20 @@ enum SutandoConfig {
 
         let cfg = (try? loadConfig(repoRoot: explicitRoot)) ?? [:]
         let root = explicitRoot ?? cacheRepoRoot
+        // Optional embedder-provided default workspace (mirrors sutando_config.py):
+        // an embedder (e.g. the AG2 Space desktop app) passes the FULL workspace
+        // path via $SUTANDO_DEFAULT_WORKSPACE. Fills the default slot only —
+        // explicit workspace.path config wins. Parity keeps the native app side in
+        // the same workspace as the Python core + TS services.
+        let embedderDefault = ProcessInfo.processInfo
+            .environment["SUTANDO_DEFAULT_WORKSPACE"]?
+            .trimmingCharacters(in: .whitespaces)
         let resolved: String
         if let ws = cfg["workspace"] as? [String: Any],
            let path = ws["path"] as? String, !path.isEmpty {
             resolved = (path as NSString).expandingTildeInPath
+        } else if let emb = embedderDefault, !emb.isEmpty {
+            resolved = (emb as NSString).expandingTildeInPath
         } else if let r = root {
             resolved = (r as NSString).appendingPathComponent(hardcodedWorkspaceDefaultRel)
         } else {

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -292,7 +292,10 @@ def resolve_workspace(repo_root: Optional[Path] = None) -> Path:
 
     Order (v0.8 — `$SUTANDO_WORKSPACE` env override removed):
       1. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
-      2. `{repo_root}/workspace` baked-in default.
+      2. `$SUTANDO_APP_SUPPORT/workspace` — bundled-app override (host-set by the
+         Tauri app to its writable app_data_dir; fills only the default slot,
+         below explicit config. See the branch comment for the full rationale).
+      3. `{repo_root}/workspace` baked-in default.
 
     Does NOT create the directory; the caller decides. Returns an absolute
     `Path`.
@@ -340,8 +343,24 @@ def resolve_workspace(repo_root: Optional[Path] = None) -> Path:
     cfg = load_config(repo_root)
     root = repo_root or _CACHE_REPO_ROOT
     cfg_path = (cfg.get("workspace") or {}).get("path")
+    # Bundled-app override (added 2026-07-14, test-5): `$SUTANDO_APP_SUPPORT`,
+    # when set AND no explicit `workspace.path` config, defaults the workspace
+    # to `$SUTANDO_APP_SUPPORT/workspace` — ranked BELOW an explicit config but
+    # ABOVE the `{repo_root}/workspace` baked-in default. Why env, not config:
+    # a static bundle `sutando.config.json` can only expand `${REPO_DIR}`, not
+    # `$HOME`, and for the Tauri app `{repo_root}` is the engine dir INSIDE the
+    # read-only `.app` bundle — so the baked-in default lands in a read-only
+    # location and the bundled core's tasks/state/CLAUDE_CONFIG_DIR (all derived
+    # from the workspace) can't be written → gateway can't ingest tasks. The
+    # Tauri host sets `SUTANDO_APP_SUPPORT` to its writable app_data_dir
+    # (`~/Library/Application Support/space.ag2.app`). This is NOT the removed
+    # `$SUTANDO_WORKSPACE` escape hatch: it is scoped to the bundled-runtime
+    # case (host-set, no user shell involvement) and only fills the default slot.
+    app_support = os.environ.get("SUTANDO_APP_SUPPORT", "").strip()
     if cfg_path:
         resolved = Path(cfg_path).expanduser().resolve()
+    elif app_support:
+        resolved = (Path(app_support).expanduser() / "workspace").resolve()
     elif root is None:
         # No config and no repo root — last-ditch fallback for ad-hoc invocations
         # outside a checkout. Post-v0.8 (#1440 + Mini opinion-requested 2026-06-06),

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -292,9 +292,8 @@ def resolve_workspace(repo_root: Optional[Path] = None) -> Path:
 
     Order (v0.8 — `$SUTANDO_WORKSPACE` env override removed):
       1. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
-      2. `$SUTANDO_APP_SUPPORT/workspace` — bundled-app override (host-set by the
-         Tauri app to its writable app_data_dir; fills only the default slot,
-         below explicit config. See the branch comment for the full rationale).
+      2. `$SUTANDO_DEFAULT_WORKSPACE` — an optional full workspace path an
+         embedder may set (fills the default slot, below explicit config).
       3. `{repo_root}/workspace` baked-in default.
 
     Does NOT create the directory; the caller decides. Returns an absolute
@@ -343,24 +342,15 @@ def resolve_workspace(repo_root: Optional[Path] = None) -> Path:
     cfg = load_config(repo_root)
     root = repo_root or _CACHE_REPO_ROOT
     cfg_path = (cfg.get("workspace") or {}).get("path")
-    # Bundled-app override (added 2026-07-14, test-5): `$SUTANDO_APP_SUPPORT`,
-    # when set AND no explicit `workspace.path` config, defaults the workspace
-    # to `$SUTANDO_APP_SUPPORT/workspace` — ranked BELOW an explicit config but
-    # ABOVE the `{repo_root}/workspace` baked-in default. Why env, not config:
-    # a static bundle `sutando.config.json` can only expand `${REPO_DIR}`, not
-    # `$HOME`, and for the Tauri app `{repo_root}` is the engine dir INSIDE the
-    # read-only `.app` bundle — so the baked-in default lands in a read-only
-    # location and the bundled core's tasks/state/CLAUDE_CONFIG_DIR (all derived
-    # from the workspace) can't be written → gateway can't ingest tasks. The
-    # Tauri host sets `SUTANDO_APP_SUPPORT` to its writable app_data_dir
-    # (`~/Library/Application Support/space.ag2.app`). This is NOT the removed
-    # `$SUTANDO_WORKSPACE` escape hatch: it is scoped to the bundled-runtime
-    # case (host-set, no user shell involvement) and only fills the default slot.
-    app_support = os.environ.get("SUTANDO_APP_SUPPORT", "").strip()
+    # Optional embedder-provided default workspace. An embedder (e.g. the AG2
+    # Space desktop app, whose `{repo_root}` is a read-only .app bundle) passes
+    # the FULL workspace path it wants; OSS stays agnostic to how it was derived.
+    # Fills the default slot only — an explicit `workspace.path` config wins.
+    embedder_default = os.environ.get("SUTANDO_DEFAULT_WORKSPACE", "").strip()
     if cfg_path:
         resolved = Path(cfg_path).expanduser().resolve()
-    elif app_support:
-        resolved = (Path(app_support).expanduser() / "workspace").resolve()
+    elif embedder_default:
+        resolved = Path(embedder_default).expanduser().resolve()
     elif root is None:
         # No config and no repo root — last-ditch fallback for ad-hoc invocations
         # outside a checkout. Post-v0.8 (#1440 + Mini opinion-requested 2026-06-06),

--- a/src/sutando_config.ts
+++ b/src/sutando_config.ts
@@ -259,7 +259,9 @@ const HARDCODED_WORKSPACE_DEFAULT_REL = 'workspace';
  *
  * Order (v0.8 — `$SUTANDO_WORKSPACE` no longer honored):
  *   1. `sutando.config.{json,local.json}` → `workspace.path` (deep-merged).
- *   2. `{repoRoot}/workspace` baked-in default.
+ *   2. `$SUTANDO_DEFAULT_WORKSPACE` — optional full workspace path an embedder
+ *      may set (fills the default slot). Mirrors `sutando_config.py`.
+ *   3. `{repoRoot}/workspace` baked-in default.
  *
  * If `$SUTANDO_WORKSPACE` is set in the environment, prints a one-time
  * migration-nag warning pointing at `scripts/sutando-migrate.sh` but does
@@ -301,9 +303,17 @@ export function resolveWorkspace(repoRoot?: string): string {
 	const cfg = loadConfig(repoRoot);
 	const root = repoRoot ?? _cacheRepoRoot;
 	const ws = (cfg.workspace as { [k: string]: Json } | undefined)?.path;
+	// Optional embedder-provided default workspace (mirrors sutando_config.py):
+	// an embedder (e.g. the AG2 Space desktop app) passes the FULL workspace path
+	// via $SUTANDO_DEFAULT_WORKSPACE. Fills the default slot only — explicit
+	// workspace.path config wins. Parity here keeps TS services (task-bridge,
+	// voice-agent, web-client) in the same workspace as the Python core.
+	const embedderDefault = process.env.SUTANDO_DEFAULT_WORKSPACE?.trim();
 	let resolved: string;
 	if (typeof ws === 'string' && ws) {
 		resolved = resolve(ws.replace(/^~/, homedir()));
+	} else if (embedderDefault) {
+		resolved = resolve(embedderDefault.replace(/^~/, homedir()));
 	} else if (root === undefined) {
 		resolved = resolve(join(homedir(), '.sutando', 'workspace'));
 	} else {

--- a/tests/sutando-config.prod-path.test.py
+++ b/tests/sutando-config.prod-path.test.py
@@ -63,7 +63,7 @@ class TestProdPath(unittest.TestCase):
         self._saved_env = os.environ.pop("SUTANDO_WORKSPACE", None)
         self._saved_no_color = os.environ.pop("NO_COLOR", None)
         self._saved_test_mode = os.environ.pop("SUTANDO_TEST_MODE", None)
-        self._saved_app_support = os.environ.pop("SUTANDO_APP_SUPPORT", None)
+        self._saved_embedder_ws = os.environ.pop("SUTANDO_DEFAULT_WORKSPACE", None)
         _reset_cache_for_tests()
         self._tmpdir = tempfile.mkdtemp(prefix="sutando-prod-path-")
         self.repo = Path(self._tmpdir)
@@ -82,38 +82,39 @@ class TestProdPath(unittest.TestCase):
             os.environ.pop("SUTANDO_TEST_MODE", None)
         else:
             os.environ["SUTANDO_TEST_MODE"] = self._saved_test_mode
-        if self._saved_app_support is None:
-            os.environ.pop("SUTANDO_APP_SUPPORT", None)
+        if self._saved_embedder_ws is None:
+            os.environ.pop("SUTANDO_DEFAULT_WORKSPACE", None)
         else:
-            os.environ["SUTANDO_APP_SUPPORT"] = self._saved_app_support
+            os.environ["SUTANDO_DEFAULT_WORKSPACE"] = self._saved_embedder_ws
         # Clean up tmp dir
         import shutil
 
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
-    # --- Bundled-app override: $SUTANDO_APP_SUPPORT (test-5 2026-07-14) ---- #
+    # --- Embedder default workspace: $SUTANDO_DEFAULT_WORKSPACE (2026-07-14) - #
 
-    def test_app_support_fills_default_slot(self) -> None:
-        """$SUTANDO_APP_SUPPORT set + no config → workspace = $APP_SUPPORT/workspace
-        (instead of the {repo_root}/workspace baked-in default that would land
-        inside a read-only .app bundle)."""
-        app = tempfile.mkdtemp(prefix="sutando-appsupport-")
+    def test_embedder_default_fills_default_slot(self) -> None:
+        """$SUTANDO_DEFAULT_WORKSPACE set + no config → workspace = that FULL path
+        verbatim (the embedder — e.g. the desktop app — passes the complete path;
+        OSS does no derivation). Replaces the {repo_root}/workspace baked-in
+        default that would land inside a read-only .app bundle."""
+        ws = tempfile.mkdtemp(prefix="sutando-embedder-ws-")
         try:
-            os.environ["SUTANDO_APP_SUPPORT"] = app
+            os.environ["SUTANDO_DEFAULT_WORKSPACE"] = ws
             got = resolve_workspace(self.repo)
-            self.assertEqual(got, (Path(app) / "workspace").resolve())
+            self.assertEqual(got, Path(ws).resolve())
         finally:
             import shutil
 
-            shutil.rmtree(app, ignore_errors=True)
+            shutil.rmtree(ws, ignore_errors=True)
 
-    def test_explicit_config_wins_over_app_support(self) -> None:
+    def test_explicit_config_wins_over_embedder_default(self) -> None:
         """An explicit workspace.path in sutando.config.local.json outranks
-        $SUTANDO_APP_SUPPORT (the env override only fills the default slot)."""
-        app = tempfile.mkdtemp(prefix="sutando-appsupport-")
+        $SUTANDO_DEFAULT_WORKSPACE (the env only fills the default slot)."""
+        emb = tempfile.mkdtemp(prefix="sutando-embedder-ws-")
         cfg_ws = tempfile.mkdtemp(prefix="sutando-cfgws-")
         try:
-            os.environ["SUTANDO_APP_SUPPORT"] = app
+            os.environ["SUTANDO_DEFAULT_WORKSPACE"] = emb
             (self.repo / "sutando.config.local.json").write_text(
                 '{"workspace": {"path": "' + cfg_ws + '"}}'
             )
@@ -123,7 +124,7 @@ class TestProdPath(unittest.TestCase):
         finally:
             import shutil
 
-            shutil.rmtree(app, ignore_errors=True)
+            shutil.rmtree(emb, ignore_errors=True)
             shutil.rmtree(cfg_ws, ignore_errors=True)
 
     # --- B4: NO_COLOR honored --------------------------------------------- #

--- a/tests/sutando-config.prod-path.test.py
+++ b/tests/sutando-config.prod-path.test.py
@@ -63,6 +63,7 @@ class TestProdPath(unittest.TestCase):
         self._saved_env = os.environ.pop("SUTANDO_WORKSPACE", None)
         self._saved_no_color = os.environ.pop("NO_COLOR", None)
         self._saved_test_mode = os.environ.pop("SUTANDO_TEST_MODE", None)
+        self._saved_app_support = os.environ.pop("SUTANDO_APP_SUPPORT", None)
         _reset_cache_for_tests()
         self._tmpdir = tempfile.mkdtemp(prefix="sutando-prod-path-")
         self.repo = Path(self._tmpdir)
@@ -81,10 +82,49 @@ class TestProdPath(unittest.TestCase):
             os.environ.pop("SUTANDO_TEST_MODE", None)
         else:
             os.environ["SUTANDO_TEST_MODE"] = self._saved_test_mode
+        if self._saved_app_support is None:
+            os.environ.pop("SUTANDO_APP_SUPPORT", None)
+        else:
+            os.environ["SUTANDO_APP_SUPPORT"] = self._saved_app_support
         # Clean up tmp dir
         import shutil
 
         shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    # --- Bundled-app override: $SUTANDO_APP_SUPPORT (test-5 2026-07-14) ---- #
+
+    def test_app_support_fills_default_slot(self) -> None:
+        """$SUTANDO_APP_SUPPORT set + no config → workspace = $APP_SUPPORT/workspace
+        (instead of the {repo_root}/workspace baked-in default that would land
+        inside a read-only .app bundle)."""
+        app = tempfile.mkdtemp(prefix="sutando-appsupport-")
+        try:
+            os.environ["SUTANDO_APP_SUPPORT"] = app
+            got = resolve_workspace(self.repo)
+            self.assertEqual(got, (Path(app) / "workspace").resolve())
+        finally:
+            import shutil
+
+            shutil.rmtree(app, ignore_errors=True)
+
+    def test_explicit_config_wins_over_app_support(self) -> None:
+        """An explicit workspace.path in sutando.config.local.json outranks
+        $SUTANDO_APP_SUPPORT (the env override only fills the default slot)."""
+        app = tempfile.mkdtemp(prefix="sutando-appsupport-")
+        cfg_ws = tempfile.mkdtemp(prefix="sutando-cfgws-")
+        try:
+            os.environ["SUTANDO_APP_SUPPORT"] = app
+            (self.repo / "sutando.config.local.json").write_text(
+                '{"workspace": {"path": "' + cfg_ws + '"}}'
+            )
+            _reset_cache_for_tests()
+            got = resolve_workspace(self.repo)
+            self.assertEqual(got, Path(cfg_ws).resolve())
+        finally:
+            import shutil
+
+            shutil.rmtree(app, ignore_errors=True)
+            shutil.rmtree(cfg_ws, ignore_errors=True)
 
     # --- B4: NO_COLOR honored --------------------------------------------- #
 

--- a/tests/sutando-config.prod-path.test.ts
+++ b/tests/sutando-config.prod-path.test.ts
@@ -17,7 +17,7 @@ import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import { resetCacheForTests, resolveWorkspace } from '../src/sutando_config.js';
 
@@ -46,15 +46,18 @@ describe('sutando_config — production path (env-set, no TEST_MODE)', () => {
 	let savedEnv: string | undefined;
 	let savedNoColor: string | undefined;
 	let savedTestMode: string | undefined;
+	let savedEmbedderWs: string | undefined;
 	let repo: string;
 
 	beforeEach(() => {
 		savedEnv = process.env.SUTANDO_WORKSPACE;
 		savedNoColor = process.env.NO_COLOR;
 		savedTestMode = process.env.SUTANDO_TEST_MODE;
+		savedEmbedderWs = process.env.SUTANDO_DEFAULT_WORKSPACE;
 		delete process.env.SUTANDO_WORKSPACE;
 		delete process.env.NO_COLOR;
 		delete process.env.SUTANDO_TEST_MODE;
+		delete process.env.SUTANDO_DEFAULT_WORKSPACE;
 		resetCacheForTests();
 		repo = mkdtempSync(join(tmpdir(), 'sutando-prod-path-'));
 	});
@@ -67,7 +70,37 @@ describe('sutando_config — production path (env-set, no TEST_MODE)', () => {
 		else process.env.NO_COLOR = savedNoColor;
 		if (savedTestMode === undefined) delete process.env.SUTANDO_TEST_MODE;
 		else process.env.SUTANDO_TEST_MODE = savedTestMode;
+		if (savedEmbedderWs === undefined) delete process.env.SUTANDO_DEFAULT_WORKSPACE;
+		else process.env.SUTANDO_DEFAULT_WORKSPACE = savedEmbedderWs;
 		if (repo) rmSync(repo, { recursive: true, force: true });
+	});
+
+	// --- Embedder default workspace: $SUTANDO_DEFAULT_WORKSPACE ------------ //
+	// Parity with the Python twin (tests/sutando-config.prod-path.test.py).
+
+	it('$SUTANDO_DEFAULT_WORKSPACE set + no config → resolves to that FULL path', () => {
+		const ws = mkdtempSync(join(tmpdir(), 'sutando-embedder-ws-'));
+		try {
+			process.env.SUTANDO_DEFAULT_WORKSPACE = ws;
+			resetCacheForTests();
+			assert.equal(resolveWorkspace(repo), resolve(ws));
+		} finally {
+			rmSync(ws, { recursive: true, force: true });
+		}
+	});
+
+	it('explicit workspace.path config wins over $SUTANDO_DEFAULT_WORKSPACE', () => {
+		const emb = mkdtempSync(join(tmpdir(), 'sutando-embedder-ws-'));
+		const cfgWs = mkdtempSync(join(tmpdir(), 'sutando-cfgws-'));
+		try {
+			process.env.SUTANDO_DEFAULT_WORKSPACE = emb;
+			writeFileSync(join(repo, 'sutando.config.local.json'), JSON.stringify({ workspace: { path: cfgWs } }));
+			resetCacheForTests();
+			assert.equal(resolveWorkspace(repo), resolve(cfgWs));
+		} finally {
+			rmSync(emb, { recursive: true, force: true });
+			rmSync(cfgWs, { recursive: true, force: true });
+		}
 	});
 
 	// --- B4: NO_COLOR honored --------------------------------------------- //


### PR DESCRIPTION
## What
The Tauri desktop app bundles the engine inside a **read-only `.app`** bundle. The resolver's `{repo_root}/workspace` baked-in default therefore resolves to `/Applications/AG2 Space.app/Contents/Resources/engine/sutando/workspace` — read-only. The bundled core spawns, but its **tasks/state/CLAUDE_CONFIG_DIR** (all derived from the workspace) can't be written → the gateway can't ingest tasks → **GATEWAY Down**. Surfaced live in **test-5** (2026-07-14).

A static bundle `sutando.config.json` can't fix it — the config resolver only expands `${REPO_DIR}`, not `$HOME`.

## Fix
The Tauri host sets **`$SUTANDO_APP_SUPPORT`** to its writable app_data_dir (`~/Library/Application Support/space.ag2.app`). The canonical resolver now defaults the workspace to `$SUTANDO_APP_SUPPORT/workspace` — **ranked below explicit config, above the baked-in default**. One place: `workspace_default.resolve_workspace` and `scripts/sutando-config.sh` both delegate to `sutando_config.resolve_workspace`, and CLAUDE_CONFIG_DIR/tasks/state derive from the resolved workspace.

Not the removed `$SUTANDO_WORKSPACE` hatch: **host-set, no user shell, fills only the default slot.**

## Verification
- `bash scripts/lint-workspace-resolution.sh` → passes.
- `tests/sutando-config.prod-path.test.py` → +2 tests (app-support fills default; explicit config still wins), all green.

Pairs with the desktop-side change (@qingyun-air.agent sets `$SUTANDO_APP_SUPPORT` from lib.rs). — @sutando-qingyun-001