### PR TITLE
fix(start-cli): forward $SUTANDO_APP_SUPPORT into the core tmux session (companion to #2094)

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -35,14 +35,14 @@ SESSION="sutando-core"
 # server's environment, not necessarily this shell's.
 export SUTANDO_CORE_SESSION=1
 CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1)
-# Forward the bundled-app workspace signal into the core session for the SAME
-# reason as above (tmux takes the server env, not this shell's). Without this
-# the core's own resolve_workspace() (proactive-loop, task scripts) misses
-# $SUTANDO_APP_SUPPORT and falls back to {repo}/workspace — while the gateway
-# window (which gets it explicitly) resolves to $SUTANDO_APP_SUPPORT/workspace:
-# a split-brain where the two watch different tasks/ dirs. Companion to the
-# resolver change (#2094); conditional so non-bundled/OSS installs are untouched.
-[ -n "${SUTANDO_APP_SUPPORT:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_APP_SUPPORT=$SUTANDO_APP_SUPPORT")
+# Forward the embedder-provided default workspace into the core session for the
+# SAME reason as above (tmux takes the server env, not this shell's). Without
+# this the core's own resolve_workspace() (proactive-loop, task scripts) misses
+# $SUTANDO_DEFAULT_WORKSPACE and falls back to {repo}/workspace — while the
+# gateway window (which gets it explicitly) resolves to that path: a split-brain
+# where the two watch different tasks/ dirs. Companion to the resolver change
+# (#2094); conditional so non-bundled/OSS installs are untouched.
+[ -n "${SUTANDO_DEFAULT_WORKSPACE:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_DEFAULT_WORKSPACE=$SUTANDO_DEFAULT_WORKSPACE")
 
 # Optional working-directory override for the core `claude` process.
 #   - Unset (upstream default): no override — the core launches from $REPO (the

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -35,6 +35,14 @@ SESSION="sutando-core"
 # server's environment, not necessarily this shell's.
 export SUTANDO_CORE_SESSION=1
 CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1)
+# Forward the bundled-app workspace signal into the core session for the SAME
+# reason as above (tmux takes the server env, not this shell's). Without this
+# the core's own resolve_workspace() (proactive-loop, task scripts) misses
+# $SUTANDO_APP_SUPPORT and falls back to {repo}/workspace — while the gateway
+# window (which gets it explicitly) resolves to $SUTANDO_APP_SUPPORT/workspace:
+# a split-brain where the two watch different tasks/ dirs. Companion to the
+# resolver change (#2094); conditional so non-bundled/OSS installs are untouched.
+[ -n "${SUTANDO_APP_SUPPORT:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_APP_SUPPORT=$SUTANDO_APP_SUPPORT")
 
 # Optional working-directory override for the core `claude` process.
 #   - Unset (upstream default): no override — the core launches from $REPO (the


### PR DESCRIPTION
## Companion to #2094 — without this, #2094 is a split-brain
#2094 makes `resolve_workspace()` honor `$SUTANDO_APP_SUPPORT`. But the bundled desktop **core** is launched via `tmux new-session -e SUTANDO_CORE_SESSION=1 …`, and tmux runs the command under the **server's** environment, not the launcher shell's (the file's own comment says exactly this). So `SUTANDO_APP_SUPPORT` never reaches the core process → the core's internal `resolve_workspace()` (proactive-loop, task-file scripts, `sutando-config.sh workspace`) falls back to `{repo}/workspace` = the read-only app bundle.

Meanwhile the **gateway** window gets `SUTANDO_APP_SUPPORT` explicitly in the desktop launcher. Result post-#2094: gateway writes incoming tasks to `$APP_SUPPORT/workspace/tasks`, core watches `{repo}/workspace/tasks` → **tasks never flow** even with both the resolver change AND the desktop lib.rs env set. Found co-reviewing #2094 against the desktop bundled-spawn (owner test-5, 2026-07-14).

## Fix
Append `-e SUTANDO_APP_SUPPORT=$SUTANDO_APP_SUPPORT` to `CORE_ENV_ARGS`, **conditional on the var being set** — identical mechanism to the existing `SUTANDO_CORE_SESSION` injection. Non-bundled / OSS installs (var unset) are byte-for-byte unchanged.

## Verify
- `bash -n` clean.
- var set → `CORE_ENV_ARGS = -e SUTANDO_CORE_SESSION=1 -e SUTANDO_APP_SUPPORT=…`; var unset → `-e SUTANDO_CORE_SESSION=1` (unchanged).

Land alongside #2094 (or fold in) + the desktop engine-pin bump; then the bundled core + gateway resolve the SAME writable workspace. @sonichi / owner authz to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)