### PR TITLE
fix(config): drop workspace.path so it stops overriding $SUTANDO_DEFAULT_WORKSPACE

### DIFF
--- a/sutando.config.json
+++ b/sutando.config.json
@@ -1,7 +1,5 @@
 {
-  "workspace": {
-    "path": "${REPO_DIR}/workspace"
-  },
+  "_workspace_note": "workspace.path is INTENTIONALLY not set here. Setting it would OUTRANK the $SUTANDO_DEFAULT_WORKSPACE embedder hook (precedence: config.workspace.path > embedder env > baked default) and pin the workspace to {repoRoot}/workspace. For a normal checkout that equals the baked-in default anyway (no change); but for an embedder (the AG2 Space desktop) it would trap the workspace inside the read-only .app bundle and silently defeat $SUTANDO_DEFAULT_WORKSPACE. Leave unset: resolve_workspace() uses the env hook when set, else {repoRoot}/workspace. (Regression guard: tests/sutando-config.prod-path.test.py::test_shipped_config_does_not_override_embedder_default.)",
   "core_config_dirs": [
     {
       "id": "claude-default",

--- a/tests/sutando-config.prod-path.test.py
+++ b/tests/sutando-config.prod-path.test.py
@@ -127,6 +127,32 @@ class TestProdPath(unittest.TestCase):
             shutil.rmtree(emb, ignore_errors=True)
             shutil.rmtree(cfg_ws, ignore_errors=True)
 
+    def test_shipped_config_does_not_override_embedder_default(self) -> None:
+        """Regression guard (read-only-bundle root cause, 2026-07-14): the
+        SHIPPED `sutando.config.json` must NOT set `workspace.path`. If it does,
+        it OUTRANKS $SUTANDO_DEFAULT_WORKSPACE (config > embedder) and pins the
+        workspace to {repoRoot}/workspace — which, for the AG2 Space desktop,
+        traps it inside the read-only .app bundle and silently defeats the
+        embedder hook. With the REAL repo config loaded + the env set,
+        resolve_workspace must honor the env, not a shipped workspace.path."""
+        emb = tempfile.mkdtemp(prefix="sutando-shipped-cfg-")
+        try:
+            os.environ["SUTANDO_DEFAULT_WORKSPACE"] = emb
+            _reset_cache_for_tests()
+            # ROOT = the real repo root, holding the shipped sutando.config.json.
+            got = resolve_workspace(ROOT)
+            self.assertEqual(
+                got,
+                Path(emb).resolve(),
+                "shipped sutando.config.json sets workspace.path — it overrides "
+                "$SUTANDO_DEFAULT_WORKSPACE and breaks embedders (read-only-bundle "
+                "bug). Remove workspace.path from sutando.config.json.",
+            )
+        finally:
+            import shutil
+
+            shutil.rmtree(emb, ignore_errors=True)
+
     # --- B4: NO_COLOR honored --------------------------------------------- #
 
     def test_no_color_one_strips_ansi(self) -> None:


### PR DESCRIPTION
## The bug
The shipped `sutando.config.json` sets `workspace.path: "${REPO_DIR}/workspace"`. For a normal checkout that's identical to the baked-in default — but because `config.workspace.path` **outranks** the embedder env hook (precedence: config > `SUTANDO_DEFAULT_WORKSPACE` > baked default), this one line **silently defeated the entire `SUTANDO_DEFAULT_WORKSPACE` mechanism** (#2094/#2095) for embedders.

## Impact (root-caused live on the AG2 Space desktop, 2026-07-14)
The bundled core resolved its workspace to the **read-only `.app` engine dir** despite the Tauri host setting `SUTANDO_DEFAULT_WORKSPACE` — because this config line overrode it. Cascade: no workspace created → `CLAUDE_CONFIG_DIR` read-only → Claude Code folder-trust hang → gateway never comes up.

## Fix
Remove `workspace.path` (replaced with a documenting `_`-comment key, which the loader strips). 
- **OSS users:** no behavior change — `resolve_workspace()` falls to the identical `{repoRoot}/workspace` baked default.
- **Embedders:** `SUTANDO_DEFAULT_WORKSPACE` is now honored.

Adds a regression test (`test_shipped_config_does_not_override_embedder_default`) that loads the real shipped config + asserts the env hook wins.

— @sutando-qingyun-001