### PR TITLE
fix(start-cli): seed skipDangerousModePermissionPrompt for detached cores

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -117,16 +117,20 @@ if [ -x "$REPO/scripts/sutando-config.sh" ]; then
     # --dangerously-skip-permissions does NOT bypass, and the core hangs with no
     # TTY to answer it. Gated on the opt-in env var so we only ever trust the dir
     # the operator explicitly chose, never arbitrary paths. We still do NOT touch
-    # the dangerous-mode acknowledgement gate for INTERACTIVE callers — that's the
-# user's to accept. But when SUTANDO_CLAUDE_WORKING_DIR IS set (a deliberately
-# detached, no-TTY core — the bundled desktop app), we ALSO seed
-# skipDangerousModePermissionPrompt below, because there is no TTY to answer that
-# prompt and the core would otherwise hang forever (owner-hit 2026-07-14).
+    # the dangerous-mode acknowledgement gate on a normal start — that's the
+    # user's to accept. EXCEPTION: when SUTANDO_ACCEPT_BYPASS_PERMISSIONS=1 is set
+    # (a deliberately detached, no-TTY core that explicitly opted in — the bundled
+    # desktop's launch-sutando.sh sets it), we ALSO seed
+    # skipDangerousModePermissionPrompt below, because there is no TTY to answer
+    # that prompt and the core hangs forever otherwise (owner-hit 2026-07-14).
+    # Dedicated opt-in (NOT the broader SUTANDO_CLAUDE_WORKING_DIR trust gate) so
+    # only the truly-headless bundled core auto-accepts — the interactive
+    # terminal-server pane still prompts the user to accept it themselves.
     # This is the single launch chokepoint (Sutando.app's launchCore, the
     # terminal-server Core CLI pane, and src/startup.sh all exec this script),
     # so seeding here covers every path.
     if command -v python3 > /dev/null 2>&1; then
-      _ccd="$_ccd" _cwd="${SUTANDO_CLAUDE_WORKING_DIR:-}" python3 - <<'PY' || echo "  ⚠ onboarding-seed skipped (non-fatal)"
+      _ccd="$_ccd" _cwd="${SUTANDO_CLAUDE_WORKING_DIR:-}" _accept_bypass="${SUTANDO_ACCEPT_BYPASS_PERMISSIONS:-}" python3 - <<'PY' || echo "  ⚠ onboarding-seed skipped (non-fatal)"
 import json, os
 ccd = os.environ["_ccd"]
 target = os.path.join(ccd, ".claude.json")
@@ -175,12 +179,14 @@ if cwd:
 # no-TTY core (the bundled desktop app) hangs on it forever — process alive but
 # never reaching /schedule-crons (owner-hit 2026-07-14 on the mini; distinct from
 # the folder-trust dialog above). Pre-accept it by seeding
-# skipDangerousModePermissionPrompt in <ccd>/settings.json. Gated on the SAME
-# opt-in env (SUTANDO_CLAUDE_WORKING_DIR / cwd) as the trust-seed: only the
-# operator's explicitly-chosen detached core is affected; interactive callers
-# still get the prompt and accept it themselves. Merge — never clobber existing
-# settings. Idempotent + atomic.
-if cwd:
+# skipDangerousModePermissionPrompt in <ccd>/settings.json. Gated on the DEDICATED
+# SUTANDO_ACCEPT_BYPASS_PERMISSIONS opt-in (set only by the bundled desktop's
+# launch-sutando.sh) — NOT the broader SUTANDO_CLAUDE_WORKING_DIR trust gate — so
+# only the truly-headless bundled core auto-accepts; the interactive terminal-server
+# pane (also a working-dir launch) still prompts the user. Merge — never clobber
+# existing settings. Idempotent + atomic. Empirically verified on claude v2.1.209
+# (the bundled version): accepting the prompt writes exactly this settings.json key.
+if os.environ.get("_accept_bypass"):
     settings_path = os.path.join(ccd, "settings.json")
     try:
         st = json.load(open(settings_path)) if os.path.exists(settings_path) else {}

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -117,7 +117,11 @@ if [ -x "$REPO/scripts/sutando-config.sh" ]; then
     # --dangerously-skip-permissions does NOT bypass, and the core hangs with no
     # TTY to answer it. Gated on the opt-in env var so we only ever trust the dir
     # the operator explicitly chose, never arbitrary paths. We still do NOT touch
-    # the global bypassPermissionsModeAccepted gate — that's the user's to accept.
+    # the dangerous-mode acknowledgement gate for INTERACTIVE callers — that's the
+# user's to accept. But when SUTANDO_CLAUDE_WORKING_DIR IS set (a deliberately
+# detached, no-TTY core — the bundled desktop app), we ALSO seed
+# skipDangerousModePermissionPrompt below, because there is no TTY to answer that
+# prompt and the core would otherwise hang forever (owner-hit 2026-07-14).
     # This is the single launch chokepoint (Sutando.app's launchCore, the
     # terminal-server Core CLI pane, and src/startup.sh all exec this script),
     # so seeding here covers every path.
@@ -164,6 +168,33 @@ if cwd:
         entry["hasTrustDialogAccepted"] = True
         changed = True
         trusted_dir = cwd
+# Dangerous-mode seed (env-gated, detached-core only). The core launches with
+# --dangerously-skip-permissions; on first run in a fresh scoped config Claude
+# Code shows a "Bypass Permissions mode / Yes, I accept" acknowledgement prompt.
+# --dangerously-skip-permissions does NOT bypass THAT prompt, so a detached
+# no-TTY core (the bundled desktop app) hangs on it forever — process alive but
+# never reaching /schedule-crons (owner-hit 2026-07-14 on the mini; distinct from
+# the folder-trust dialog above). Pre-accept it by seeding
+# skipDangerousModePermissionPrompt in <ccd>/settings.json. Gated on the SAME
+# opt-in env (SUTANDO_CLAUDE_WORKING_DIR / cwd) as the trust-seed: only the
+# operator's explicitly-chosen detached core is affected; interactive callers
+# still get the prompt and accept it themselves. Merge — never clobber existing
+# settings. Idempotent + atomic.
+if cwd:
+    settings_path = os.path.join(ccd, "settings.json")
+    try:
+        st = json.load(open(settings_path)) if os.path.exists(settings_path) else {}
+        if not isinstance(st, dict):
+            st = {}
+    except Exception:
+        st = {}
+    if st.get("skipDangerousModePermissionPrompt") is not True:
+        st["skipDangerousModePermissionPrompt"] = True
+        s_tmp = settings_path + ".tmp"
+        with open(s_tmp, "w") as f:
+            json.dump(st, f, indent=2)
+        os.replace(s_tmp, settings_path)
+        print("  ✓ dangerous-mode-seed: skipDangerousModePermissionPrompt set in settings.json")
 if changed:
     tmp = target + ".tmp"
     with open(tmp, "w") as f:

--- a/tests/health-check-bridge-skip.test.py
+++ b/tests/health-check-bridge-skip.test.py
@@ -133,8 +133,13 @@ with tempfile.TemporaryDirectory() as _home:
     (_ch / ".env").write_text("SLACK_BOT_TOKEN=xoxb-test\n")
     _orig_chp = hc.claude_home_path
 
-    def _fake_chp(sub):
-        return Path(_home) / sub if sub == "channels" else _orig_chp(sub)
+    def _fake_chp(*sub):
+        # mirror claude_home_path(*subpath): redirect the whole channels/ tree
+        # (any depth, e.g. channels/ag2space/.env) into the temp home; delegate
+        # everything else to the real resolver.
+        if sub and sub[0] == "channels":
+            return Path(_home).joinpath(*sub)
+        return _orig_chp(*sub)
 
     with patch.object(hc, "check_port", side_effect=_stub_port), \
          patch.object(hc, "claude_home_path", side_effect=_fake_chp), \

--- a/tests/start-cli-dangerous-mode-seed.test.py
+++ b/tests/start-cli-dangerous-mode-seed.test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Hermetic test for the dangerous-mode seed in start-cli.sh (#2098).
+
+On a working-dir launch, start-cli.sh seeds `skipDangerousModePermissionPrompt`
+into `<ccd>/settings.json` ONLY when `SUTANDO_ACCEPT_BYPASS_PERMISSIONS` is set —
+the dedicated opt-in the bundled desktop's launch-sutando.sh exports for the
+detached, no-TTY core. `--dangerously-skip-permissions` does NOT bypass Claude
+Code's "Bypass Permissions mode / Yes, I accept" acknowledgement, so a headless
+core hangs on it forever unless the flag is pre-seeded (owner-hit 2026-07-14).
+
+This extracts the ACTUAL embedded seed program from start-cli.sh (source-tied —
+fails if the block is renamed/removed) and drives it with controlled env,
+asserting the four behaviors the review asked for:
+  - env set   ⇒ settings.json gains exactly `skipDangerousModePermissionPrompt: true`
+  - env unset ⇒ settings.json is never created / untouched
+  - an existing settings.json is MERGED, not clobbered
+  - a second run is idempotent (stays true, no error)
+
+Run: python3 tests/start-cli-dangerous-mode-seed.test.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "agent" / "claude" / "cli" / "start-cli.sh"
+
+
+def _seed_program() -> str:
+    """Extract the embedded `python3 - <<'PY' … PY` seed program verbatim."""
+    txt = SCRIPT.read_text()
+    m = re.search(r"<<'PY'.*?\n(.*?)\nPY\b", txt, re.S)
+    assert m, "seed PY heredoc not found in start-cli.sh — did the seed block move?"
+    prog = m.group(1)
+    assert "skipDangerousModePermissionPrompt" in prog, \
+        "extracted seed program no longer references skipDangerousModePermissionPrompt"
+    return prog
+
+
+def _run(program: str, ccd: Path, accept_bypass: bool, home: Path):
+    """Run the seed program with controlled env; return the parsed settings.json or None."""
+    env = dict(os.environ)
+    env["_ccd"] = str(ccd)
+    env["_cwd"] = ""  # no trust-seed dir — isolate the dangerous-mode path
+    env["_accept_bypass"] = "1" if accept_bypass else ""
+    env["HOME"] = str(home)  # so the ~/.claude.json read is hermetic (absent)
+    r = subprocess.run([sys.executable, "-c", program],
+                       env=env, capture_output=True, text=True, timeout=30)
+    assert r.returncode == 0, f"seed program errored: {r.stderr}"
+    sp = ccd / "settings.json"
+    return json.loads(sp.read_text()) if sp.exists() else None
+
+
+class TestDangerousModeSeed(unittest.TestCase):
+    def setUp(self):
+        self.prog = _seed_program()
+
+    def test_env_set_seeds_the_key(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            ccd = td / "cfg"
+            ccd.mkdir()
+            st = _run(self.prog, ccd, accept_bypass=True, home=td)
+            self.assertIsNotNone(st, "settings.json should be created when opted in")
+            self.assertIs(st.get("skipDangerousModePermissionPrompt"), True)
+
+    def test_env_unset_leaves_settings_untouched(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            ccd = td / "cfg"
+            ccd.mkdir()
+            st = _run(self.prog, ccd, accept_bypass=False, home=td)
+            # No opt-in → the seed must not create settings.json at all.
+            self.assertIsNone(st, "settings.json must not be created without the opt-in")
+
+    def test_existing_settings_merged_not_clobbered(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            ccd = td / "cfg"
+            ccd.mkdir()
+            (ccd / "settings.json").write_text(json.dumps(
+                {"env": {"FOO": "bar"}, "permissions": {"allow": ["x"]}}))
+            st = _run(self.prog, ccd, accept_bypass=True, home=td)
+            self.assertIs(st.get("skipDangerousModePermissionPrompt"), True)
+            # Pre-existing keys survive.
+            self.assertEqual(st.get("env"), {"FOO": "bar"})
+            self.assertEqual(st.get("permissions"), {"allow": ["x"]})
+
+    def test_idempotent_second_run(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            ccd = td / "cfg"
+            ccd.mkdir()
+            _run(self.prog, ccd, accept_bypass=True, home=td)
+            st = _run(self.prog, ccd, accept_bypass=True, home=td)
+            self.assertEqual(st, {"skipDangerousModePermissionPrompt": True})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The hang
The bundled desktop core launches with `--dangerously-skip-permissions` in a fully **detached, no-TTY** tmux window. On first run in a fresh scoped `CLAUDE_CONFIG_DIR`, Claude Code shows a **"Bypass Permissions mode / Yes, I accept"** acknowledgement prompt that `--dangerously-skip-permissions` does **not** bypass. With no TTY to answer it, the core hangs forever — process alive (so the app shows "core up") but never reaching `/schedule-crons`.

Owner-hit 2026-07-14 (Mac mini desktop test): app showed core+gateway up while the claude core sat stuck at this prompt. Distinct from the folder-trust dialog already seeded in this same block.

## Fix
Seed `skipDangerousModePermissionPrompt: true` in `<ccd>/settings.json`, gated on a **dedicated `SUTANDO_ACCEPT_BYPASS_PERMISSIONS=1` opt-in** — deliberately **NOT** the broader `SUTANDO_CLAUDE_WORKING_DIR` trust gate. That separation is the point: the working-dir gate is also set by the *interactive* terminal-server Core CLI pane (a working-dir launch too), which has a TTY and should keep prompting the user to accept dangerous mode themselves. Only the truly-headless bundled core — which sets the dedicated opt-in — auto-accepts. Merge (never clobbers existing settings), idempotent, atomic.

## Who sets the opt-in (the pairing)
`SUTANDO_ACCEPT_BYPASS_PERMISSIONS=1` is exported by the **bundled desktop's `launch-sutando.sh`** in **ag2space-cinny-desktop** (the detached, no-TTY launch path) — that repo owns the setter; this PR owns the seed that consumes it. The two are intentionally split across repos: sutando must never auto-accept dangerous mode for an ordinary checkout, so nothing in this repo sets the flag. `start-cli.sh` is the single launch chokepoint every path execs (Sutando.app's launchCore, the terminal-server Core CLI pane, `src/startup.sh`), so seeding here covers every launch once the desktop bundle opts in. (Part of the "Agent Shepherd" PREVENT layer — `workspace/notes/design-core-supervisor.md`.)

## Tests
`tests/start-cli-dangerous-mode-seed.test.py` (new) — hermetic, source-tied: it extracts the actual embedded seed program from `start-cli.sh` (fails if the block is renamed/removed) and drives it with controlled env, asserting:
- env set ⇒ `settings.json` gains exactly `skipDangerousModePermissionPrompt: true`
- env unset ⇒ `settings.json` is never created / untouched
- an existing `settings.json` is **merged**, not clobbered
- a second run is idempotent

4/4 pass. Empirically verified on the mini (claude v2.1.209): accepting the prompt writes exactly this key to `settings.json`.

— @sutando-qingyun-001
