### PR TITLE
feat(core): supervisor monitor — core-supervisor.json state signal (M1)

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -310,10 +310,33 @@ apply_tmux_defaults() {
   tmux -S "$TMUX_SOCKET" bind -n WheelDownPane send-keys -M 2>/dev/null || true
 }
 
+# Agent Shepherd M1 monitor (PR #2100). Watch the CANONICAL sutando-core session
+# for blocked-on-input gates the no-TTY core can't answer (/login, a mid-session
+# permission prompt, an unknown dialog) and write state/core-supervisor.json —
+# consumed by the desktop "Action needed" banner and the communicator relay.
+# Launched HERE, the one place that knows the canonical TMUX_SOCKET + SESSION —
+# NOT from startup.sh, whose $TMUX is empty in the Sutando.app/background path
+# (so a $TMUX-derived wiring would never start the monitor for the real core).
+# The guard is scoped to THIS socket + out path so a monitor for a different
+# core/socket can never suppress this one.
+ensure_core_monitor() {
+  local ws mon_out
+  ws="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)" || return 0
+  [ -n "$ws" ] || return 0
+  mon_out="$ws/state/core-supervisor.json"
+  if pgrep -f "core-input-watch\.py .*--socket ${TMUX_SOCKET} .*--out ${mon_out}" > /dev/null 2>&1; then
+    return 0   # a monitor for this exact core is already running
+  fi
+  python3 "$REPO/src/core-input-watch.py" \
+    --socket "$TMUX_SOCKET" --session "$SESSION" --out "$mon_out" \
+    > /tmp/core-input-watch.log 2>&1 &
+}
+
 # Already running — attach if interactive, else exit cleanly. This branch
 # also catches the !--restart path so re-running the script is idempotent.
 if tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null; then
   apply_tmux_defaults
+  ensure_core_monitor   # re-ensure the supervisor monitor on every attach/re-run
   if [ -t 1 ] && command -v tmux > /dev/null 2>&1; then
     echo "Attaching to existing $SESSION (Ctrl-b d to detach)..."
     exec tmux -S "$TMUX_SOCKET" attach -t "$SESSION"
@@ -375,6 +398,7 @@ apply_tmux_defaults
 # start-directory is silently dropped — so re-anchoring a running core to a new
 # working dir must go through `--restart` (kill-then-create), not a bare rerun.
 if [ -t 1 ]; then
+  ensure_core_monitor   # backgrounded child survives the exec below
   exec tmux -S "$TMUX_SOCKET" new-session -A -s "$SESSION" ${CORE_ENV_ARGS[@]+"${CORE_ENV_ARGS[@]}"} ${CWD_ARGS[@]+"${CWD_ARGS[@]}"} \
     claude --name "$SESSION" ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
     ${SETTINGS_ARGS[@]+"${SETTINGS_ARGS[@]}"} \
@@ -384,6 +408,7 @@ else
     claude --name "$SESSION" ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} --remote-control "Sutando" --dangerously-skip-permissions --add-dir "$HOME" \
     ${SETTINGS_ARGS[@]+"${SETTINGS_ARGS[@]}"} \
     -- "/schedule-crons"
+  ensure_core_monitor   # canonical session now exists — start the supervisor monitor
   echo "Started $SESSION detached. Attach via Open Core CLI in menu bar, or:"
   echo "  tmux -S $TMUX_SOCKET attach -t $SESSION"
 fi

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -58,6 +58,35 @@ _LOGGED_OUT = re.compile(r"Not logged in|Please run /login|Invalid API key", re.
 # selection/permission. The rest (trust/bypass/press-enter) are known-safe.
 _HUMAN_GATES = {"login", "selection", "permission", "unknown"}
 
+# --- M4 AUTO-ANSWER decision (Layer 2), PURE + report-only. -----------------
+# This returns WHICH keystroke would safely dismiss a gate; it does NOT send it —
+# a separate, opt-in supervisor actor does that (kept OUT of the report-only
+# monitor loop). The allowlist is deliberately TINY and strictly non-destructive:
+# EVERYTHING not explicitly listed (every _HUMAN_GATE, every unknown/ambiguous
+# state) returns None → ESCALATE. Expanding it is an owner-reviewed change.
+_AUTO_ANSWER = {
+    # "Press Enter to continue…" — purely informational (e.g. the post-login
+    # confirmation). Pressing Enter only proceeds; it grants nothing and is not
+    # destructive. The one gate safe to auto-dismiss.
+    "press-enter": "Enter",
+}
+
+
+def auto_answer(kind):
+    """M4 decision: the safe keystroke to auto-dismiss `kind`, or None → ESCALATE.
+
+    SAFETY INVARIANT: only strictly non-destructive, capability-granting-nothing
+    gates are answerable. A human gate (login/selection/permission/unknown) or any
+    kind not in the allowlist ALWAYS returns None — the supervisor escalates,
+    never guesses. Notably folder-trust + bypass-permissions are handled by the
+    PREVENT seeds; if they ever surface at runtime they ESCALATE — we never
+    auto-accept a trust / dangerous-mode prompt without the operator's explicit
+    per-install opt-in.
+    """
+    if kind in _HUMAN_GATES:
+        return None
+    return _AUTO_ANSWER.get(kind)
+
 
 def classify(pane: str):
     """Return (kind, excerpt) if the pane is awaiting user input, else None."""

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -1,61 +1,69 @@
 #!/usr/bin/env python3
-"""core-input-watch.py — surface "the agent needs your input" to the desktop UI.
+"""core-input-watch.py — the core supervisor MONITOR (M1).
 
-The detached bundled core runs Claude Code with no TTY. Most first-run gates are
-pre-seeded (folder-trust, bypass-permissions, onboarding) so the core never stops
-on them — but some interactions inherently need the user (/login) or can't be
-predicted (a mid-session permission request, a model/selection prompt, an unknown
-dialog). With no TTY the core silently BLOCKS on those, "alive but stuck".
+The detached bundled core runs Claude Code's interactive TUI with no TTY. Most
+first-run gates are pre-seeded so the core never stops on them, but some
+interactions inherently need the user (/login) or can't be predicted (a
+mid-session permission request, a model/selection prompt, an unknown dialog).
+With no TTY the core silently BLOCKS, "alive but stuck".
 
-This watcher polls the core's tmux pane and, when it detects the core parked on
-an interactive prompt AND not progressing, writes <workspace>/state/core-needs-
-input.json so the app can show an "Action needed" banner with the prompt text +
-a button to open the terminal. When the prompt clears, it writes blocked:false.
+This is the MONITOR layer of the core supervisor (design: notes/design-core-
+supervisor.md). Each tick it composes the core's state from three cheap signals —
+process liveness, the tmux pane (via classify()), and gateway liveness — and
+writes a single `state/core-supervisor.json` the desktop app reads for BOTH its
+status display AND the "Action needed" banner. It never acts; PREVENT (seeds),
+AUTO-ANSWER, ESCALATE (the banner), and RECOVER (restart) are the other layers.
 
-It is the catch-all behind the pre-seeds: seed what we can, this surfaces the rest.
+State (exactly one per tick):
+  running · idle-ready · blocked-known · blocked-human · hung · crashed ·
+  gateway-down · logged-out
+
+Signal schema (state/core-supervisor.json):
+  { "state": "<state>", "detail": "<human string>",
+    "prompt": "<pane excerpt if blocked, else null>",
+    "kind": "<gate kind if blocked, else null>",
+    "session": "sutando-core" }
 
 Usage:
   core-input-watch.py --socket <tmux.sock> --session sutando-core \
-      --out <workspace>/state/core-needs-input.json [--interval 3] [--stable 2]
+      --out <workspace>/state/core-supervisor.json [--app-data <dir>] \
+      [--interval 3] [--stable 2]
 """
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
 import subprocess
 import time
 
-# Interactive-prompt signatures. Each: (kind, compiled regex). Order = priority;
-# the FIRST match classifies the block. Kept specific so the normal idle prompt
-# (a bare "❯ " ready for a task) is NEVER flagged — only genuine input gates.
+# ---- ESCALATE-detection: interactive-prompt signatures. First match classifies.
+# Specific so the idle "❯ " prompt (ready for a task) is NEVER flagged.
 _SIGNATURES = [
     ("folder-trust", re.compile(r"trust the files in this folder|Do you trust", re.I)),
     ("bypass-permissions", re.compile(r"Bypass Permissions mode|Yes, I accept", re.I)),
     ("login", re.compile(r"Select login method|Paste code here|Browser didn'?t open", re.I)),
     ("press-enter", re.compile(r"Press Enter to continue", re.I)),
-    # Generic numbered menu awaiting a choice, e.g. "❯ 1. …" plus a cancel hint.
     ("selection", re.compile(r"(❯\s*\d+\.|\bSelect\b).*", re.S)),
     ("permission", re.compile(r"Do you want to (proceed|allow)|Allow this action|permission to", re.I)),
 ]
-
-# A pane is only "awaiting input" if it ALSO carries a confirm/cancel affordance —
-# this filters out normal agent output that merely happens to contain a digit.
 _AWAIT_HINT = re.compile(
-    r"Esc to cancel|Enter to confirm|Press Enter|Paste code|to accept|❯\s*\d+\.",
-    re.I,
-)
-# The normal ready-for-work state: a bare prompt with the bypass footer. NEVER flag.
+    r"Esc to cancel|Enter to confirm|Press Enter|Paste code|to accept|❯\s*\d+\.", re.I)
 _IDLE = re.compile(r"⏵⏵\s*bypass permissions on|for agents\b", re.I)
+_LOGGED_OUT = re.compile(r"Not logged in|Please run /login|Invalid API key", re.I)
+
+# Gates that need a human (can't be auto-answered): login + any unrecognized
+# selection/permission. The rest (trust/bypass/press-enter) are known-safe.
+_HUMAN_GATES = {"login", "selection", "permission"}
 
 
-def classify(pane: str) -> tuple[str, str] | None:
+def classify(pane: str):
     """Return (kind, excerpt) if the pane is awaiting user input, else None."""
     tail = "\n".join([ln for ln in pane.splitlines() if ln.strip()][-14:])
     if not _AWAIT_HINT.search(tail):
         return None
-    # An idle "ready for a task" prompt shows the bypass footer with no gate above.
     if _IDLE.search(tail) and not any(rx.search(tail) for _, rx in _SIGNATURES[:5]):
         return None
     for kind, rx in _SIGNATURES:
@@ -64,18 +72,73 @@ def classify(pane: str) -> tuple[str, str] | None:
     return None
 
 
-def capture(socket: str, session: str) -> str | None:
+def compose_state(pane, core_alive, gateway_alive, progressing):
+    """Pure state-machine core: map the signals + pane to a supervisor state.
+
+    Returns (state, detail, prompt_or_None, kind_or_None). `progressing` = the pane
+    changed since the previous tick (only decisive when not at a prompt / idle).
+    """
+    if not core_alive:
+        return "crashed", "core process/session not found", None, None
+    hit = classify(pane) if pane else None
+    if hit:
+        kind, excerpt = hit
+        if kind in _HUMAN_GATES:
+            return "blocked-human", f"awaiting user: {kind}", excerpt, kind
+        return "blocked-known", f"at known gate: {kind}", excerpt, kind
+    # No interactive prompt showing.
+    if pane and _LOGGED_OUT.search(pane):
+        return "logged-out", "core not authenticated (needs /login)", None, None
+    if not gateway_alive:
+        return "gateway-down", "core up but relay gateway not running", None, None
+    if pane and _IDLE.search(pane):
+        return "idle-ready", "ready for a task", None, None
+    if progressing:
+        return "running", "actively processing", None, None
+    return "hung", "core alive but not progressing and not at a known prompt", None, None
+
+
+# ---- Liveness signals (cheap, pgrep/tmux-based). --------------------------- #
+def _has_session(socket, session):
     try:
-        out = subprocess.run(
-            ["tmux", "-S", socket, "capture-pane", "-p", "-t", f"{session}:0"],
-            capture_output=True, text=True, timeout=8,
-        )
+        return subprocess.run(["tmux", "-S", socket, "has-session", "-t", session],
+                              capture_output=True, timeout=6).returncode == 0
+    except Exception:
+        return False
+
+
+def _pgrep(pattern):
+    try:
+        return subprocess.run(["pgrep", "-f", pattern],
+                              capture_output=True, timeout=6).returncode == 0
+    except Exception:
+        return False
+
+
+def core_alive(socket, session):
+    # A live core = the tmux session exists AND a claude bound to it is running.
+    return _has_session(socket, session) and _pgrep(f"claude.*--name.*{session}")
+
+
+def gateway_alive(app_data):
+    # The bundled gateway runs from the app-data interpreter (see console_status:
+    # keepalive cd's into $ENGINE so the argv is relative — match the app-unique
+    # runtime-python dir, which uniquely scopes to THIS app's gateway).
+    if app_data:
+        return _pgrep(os.path.join(app_data, "engine", "runtime", "python"))
+    return _pgrep("remote-gateway-bridge")
+
+
+def capture(socket, session):
+    try:
+        out = subprocess.run(["tmux", "-S", socket, "capture-pane", "-p", "-t", f"{session}:0"],
+                             capture_output=True, text=True, timeout=8)
         return out.stdout if out.returncode == 0 else None
     except Exception:
         return None
 
 
-def _atomic_write(path: str, payload: dict) -> None:
+def _atomic_write(path, payload):
     os.makedirs(os.path.dirname(path), exist_ok=True)
     tmp = path + ".tmp"
     with open(tmp, "w") as f:
@@ -83,41 +146,50 @@ def _atomic_write(path: str, payload: dict) -> None:
     os.replace(tmp, path)
 
 
-def main() -> None:
+def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--socket", required=True)
     ap.add_argument("--session", default="sutando-core")
     ap.add_argument("--out", required=True)
+    ap.add_argument("--app-data", default="", help="app-support dir (for gateway probe)")
     ap.add_argument("--interval", type=float, default=3.0)
     ap.add_argument("--stable", type=int, default=2,
-                    help="consecutive identical polls before flagging (debounce)")
+                    help="consecutive identical prompt polls before escalating (debounce)")
+    ap.add_argument("--once", action="store_true", help="one tick then exit (for tests/probes)")
     a = ap.parse_args()
 
-    last_excerpt = None
-    stable = 0
-    last_written_blocked = None
+    last_hash = None
+    last_sig = None
+    stable_prompt = 0
+    last_prompt = None
     while True:
         pane = capture(a.socket, a.session)
-        hit = classify(pane) if pane else None
-        if hit:
-            kind, excerpt = hit
-            # Debounce: only flag once the same prompt persists (not a transient
-            # menu the core is actively navigating).
-            stable = stable + 1 if excerpt == last_excerpt else 1
-            last_excerpt = excerpt
-            if stable >= a.stable and last_written_blocked is not True:
-                _atomic_write(a.out, {
-                    "blocked": True, "kind": kind, "prompt": excerpt,
-                    "ts": int(os.environ.get("_NOW_", "0")) or None,
-                    "session": a.session,
-                })
-                last_written_blocked = True
+        cur_hash = hashlib.sha1((pane or "").encode()).hexdigest()
+        progressing = cur_hash != last_hash
+        last_hash = cur_hash
+
+        state, detail, prompt, kind = compose_state(
+            pane or "", core_alive(a.socket, a.session),
+            gateway_alive(a.app_data), progressing)
+
+        # Debounce prompt escalation: only surface once the SAME prompt persists
+        # (not a menu the core is actively navigating through).
+        if state in ("blocked-human", "blocked-known"):
+            stable_prompt = stable_prompt + 1 if prompt == last_prompt else 1
+            last_prompt = prompt
+            if stable_prompt < a.stable:
+                state, detail, prompt, kind = "running", "processing (prompt settling)", None, None
         else:
-            stable = 0
-            last_excerpt = None
-            if last_written_blocked is not False:
-                _atomic_write(a.out, {"blocked": False, "session": a.session})
-                last_written_blocked = False
+            stable_prompt = 0
+            last_prompt = None
+
+        sig = (state, prompt)
+        if sig != last_sig:
+            _atomic_write(a.out, {"state": state, "detail": detail,
+                                  "prompt": prompt, "kind": kind, "session": a.session})
+            last_sig = sig
+        if a.once:
+            return
         time.sleep(a.interval)
 
 

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -157,7 +157,15 @@ def classify(pane: str):
     tail = "\n".join([ln for ln in pane.splitlines() if ln.strip()][-14:])
     if not _AWAIT_HINT.search(tail):
         return None
-    if _IDLE.search(tail) and not any(rx.search(tail) for _, rx in _SIGNATURES[:5]):
+    # Idle-footer suppression: the normal footer ("⏵⏵ bypass permissions on … ←
+    # for agents") also carries an await-affordance, so a genuinely idle pane would
+    # otherwise fall through to "unknown". Suppress it ONLY when NO real gate
+    # signature matches — check ALL of _SIGNATURES, not a prefix. (Bug caught in
+    # review 2026-07-14: slicing [:5] excluded `permission` (index 5), so a real
+    # mid-session "Do you want to proceed? / Allow this action" prompt rendered
+    # above the footer was hidden — a false negative on a MAIN escalation case. The
+    # footer itself matches none of the signatures, so idle still suppresses.)
+    if _IDLE.search(tail) and not any(rx.search(tail) for _, rx in _SIGNATURES):
         return None
     for kind, rx in _SIGNATURES:
         if rx.search(tail):

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -65,8 +65,28 @@ import importlib.util
 import json
 import os
 import re
+import shutil
 import subprocess
 import time
+
+
+def _ensure_tmux_on_path():
+    """Both this monitor (capture) and runtime-health (its liveness probes) call
+    bare `tmux`. In a bundled/detached spawn the ambient PATH may lack Homebrew
+    (/opt/homebrew/bin on Apple Silicon, /usr/local/bin on Intel) — where tmux
+    actually lives — so bare `tmux` fails and a perfectly HEALTHY core reads as
+    offline → 'crashed', which would trigger a false RECOVER restart. Mini-verified
+    2026-07-14: over a non-Homebrew PATH the live idle core mis-reported 'crashed';
+    prepending the tmux dir fixed it. Resolve tmux once and prepend its dir so the
+    bare calls succeed regardless of how the app spawned us. Mutating PATH (vs.
+    threading a tmux path everywhere) also transparently fixes the imported
+    runtime-health probes, which share this process env."""
+    if shutil.which("tmux"):
+        return
+    for cand in ("/opt/homebrew/bin/tmux", "/usr/local/bin/tmux", "/usr/bin/tmux"):
+        if os.path.exists(cand):
+            os.environ["PATH"] = os.path.dirname(cand) + os.pathsep + os.environ.get("PATH", "")
+            return
 
 
 # ---- Shared derivation core: runtime-health.py (#2092). -------------------- #
@@ -241,6 +261,10 @@ def main():
                     help="consecutive identical prompt polls before escalating (debounce)")
     ap.add_argument("--once", action="store_true", help="one tick then exit (for tests/probes)")
     a = ap.parse_args()
+
+    # Make bare `tmux` resolvable before ANY probe (ours or runtime-health's) —
+    # else a detached spawn without Homebrew on PATH reads a healthy core as crashed.
+    _ensure_tmux_on_path()
 
     # Point the SHARED runtime-health derivation at THIS core's socket/session so
     # the supervisor and the Console's status strip read the same liveness core.

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -8,15 +8,37 @@ mid-session permission request, a model/selection prompt, an unknown dialog).
 With no TTY the core silently BLOCKS, "alive but stuck".
 
 This is the MONITOR layer of the core supervisor (design: notes/design-core-
-supervisor.md). Each tick it composes the core's state from three cheap signals —
-process liveness, the tmux pane (via classify()), and gateway liveness — and
-writes a single `state/core-supervisor.json` the desktop app reads for BOTH its
-status display AND the "Action needed" banner. It never acts; PREVENT (seeds),
-AUTO-ANSWER, ESCALATE (the banner), and RECOVER (restart) are the other layers.
+supervisor.md). Each tick it writes a single `state/core-supervisor.json` the
+desktop app reads for BOTH its status display AND the "Action needed" banner. It
+never acts; PREVENT (seeds), AUTO-ANSWER, ESCALATE (the banner), and RECOVER
+(restart) are the other layers.
 
-State (exactly one per tick):
-  running · idle-ready · blocked-known · blocked-human · hung · crashed ·
-  gateway-down · logged-out
+Relationship to runtime-health.py (#2092) — ONE derivation core, no drift.
+------------------------------------------------------------------------------
+`runtime-health.py` is the owner-designed coarse health signal the desktop
+Console renders as a plain-English status strip: {offline, needs_login, working,
+idle, unknown}. This supervisor does NOT re-derive liveness independently — that
+would give two tmux/process derivations that drift (the review's `naming_conflict`
+on #2100). Instead it CONSUMES `runtime_health.derive()` as its base and REFINES
+those 5 coarse states into the 8 supervisor states, adding only what escalation
+needs (which gate, the prompt text, can-we-auto-answer). The refinement is a pure
+mapping, so the two vocabularies provably agree on "is it running / logged in /
+idle / wedged":
+
+    runtime-health health   →   supervisor state
+    ---------------------       ----------------
+    offline                 →   crashed
+    needs_login             →   logged-out        (unless an ACTIVE gate shows, below)
+    working                 →   running
+    idle                    →   idle-ready
+    unknown (status stale)  →   hung
+    (any, + gateway down)   →   gateway-down       (gateway probe is bundled-specific)
+    (any, + active gate)    →   blocked-known / blocked-human   (net-new: pane classify)
+
+runtime-health.json stays the Console's coarse view (unchanged, its consumers
+untouched); core-supervisor.json is the escalation-facing refinement of the same
+derivation. Net-new here vs runtime-health = the gate classifier (classify),
+the auto-answer decision (auto_answer), and the escalation state machine.
 
 Signal schema (state/core-supervisor.json):
   { "state": "<state>", "detail": "<human string>",
@@ -24,23 +46,46 @@ Signal schema (state/core-supervisor.json):
     "kind": "<gate kind if blocked, else null>",
     "session": "sutando-core" }
 
+How this runs (the launch + consumer live in the desktop bundle):
+  * On-demand one-shot (in-repo, mirrors runtime-health.py's invocation model):
+      core-input-watch.py --socket <sock> --out <ws>/state/core-supervisor.json --once
+  * Continuous supervision loop: launched by the Tauri desktop bundle
+    (ag2space-cinny-desktop #62) alongside the detached core; the "Action needed"
+    banner + login button that CONSUME core-supervisor.json are #64 / cinny #130.
+
 Usage:
   core-input-watch.py --socket <tmux.sock> --session sutando-core \
       --out <workspace>/state/core-supervisor.json [--app-data <dir>] \
-      [--interval 3] [--stable 2]
+      [--interval 3] [--stable 2] [--once]
 """
 from __future__ import annotations
 
 import argparse
-import hashlib
+import importlib.util
 import json
 import os
 import re
 import subprocess
 import time
 
+
+# ---- Shared derivation core: runtime-health.py (#2092). -------------------- #
+# Loaded via importlib because the filename has a dash. This is THE single
+# liveness/health derivation both the Console and this supervisor read from —
+# reusing it (rather than re-implementing tmux/process probes here) is what keeps
+# the two state vocabularies from drifting.
+def _load_runtime_health():
+    src = os.path.join(os.path.dirname(os.path.abspath(__file__)), "runtime-health.py")
+    spec = importlib.util.spec_from_file_location("runtime_health", src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 # ---- ESCALATE-detection: interactive-prompt signatures. First match classifies.
-# Specific so the idle "❯ " prompt (ready for a task) is NEVER flagged.
+# Specific so the idle "❯ " prompt (ready for a task) is NEVER flagged. This is
+# the net-new layer over runtime-health: it identifies WHICH gate the core is
+# stuck at so ESCALATE can show the prompt and AUTO-ANSWER can decide.
 _SIGNATURES = [
     ("folder-trust", re.compile(r"trust the files in this folder|Do you trust", re.I)),
     ("bypass-permissions", re.compile(r"Bypass Permissions mode|Yes, I accept", re.I)),
@@ -52,7 +97,6 @@ _SIGNATURES = [
 _AWAIT_HINT = re.compile(
     r"Esc to cancel|Enter to confirm|Press Enter|Paste code|to accept|❯\s*\d+\.", re.I)
 _IDLE = re.compile(r"⏵⏵\s*bypass permissions on|for agents\b", re.I)
-_LOGGED_OUT = re.compile(r"Not logged in|Please run /login|Invalid API key", re.I)
 
 # Gates that need a human (can't be auto-answered): login + any unrecognized
 # selection/permission. The rest (trust/bypass/press-enter) are known-safe.
@@ -106,45 +150,50 @@ def classify(pane: str):
     return "unknown", tail
 
 
-def compose_state(pane, core_alive, gateway_alive, progressing):
-    """Pure state-machine core: map the signals + pane to a supervisor state.
+# runtime-health health string → supervisor state, for the non-gate branches.
+_BASE_TO_STATE = {
+    "offline": ("crashed", "core process/session not found"),
+    "needs_login": ("logged-out", "core not authenticated (needs /login)"),
+    "idle": ("idle-ready", "ready for a task"),
+    "working": ("running", "actively processing"),
+    # "unknown" = runtime-health saw a live session but a stale/absent core-status
+    # ("running" that never advanced) → wedged. That IS the supervisor's `hung`.
+    "unknown": ("hung", "core alive but stalled (status stale, no recognized prompt)"),
+}
 
-    Returns (state, detail, prompt_or_None, kind_or_None). `progressing` = the pane
-    changed since the previous tick (only decisive when not at a prompt / idle).
+
+def compose_state(pane, base_health, gateway_alive):
+    """Refine runtime-health's coarse `base_health` into a supervisor state.
+
+    `base_health` ∈ {offline, needs_login, working, idle, unknown} comes from
+    runtime_health.derive() — the SHARED derivation. This function adds only the
+    escalation-specific refinements: an active gate in the pane (finest signal),
+    and the bundled-gateway-down state. Returns (state, detail, prompt, kind).
     """
-    if not core_alive:
-        return "crashed", "core process/session not found", None, None
+    if base_health == "offline":
+        return "crashed", _BASE_TO_STATE["offline"][1], None, None
+    # An ACTIVE interactive gate in the pane is the finest signal — it distinguishes
+    # "sitting at a prompt waiting for input" from the coarse health (e.g. the live
+    # /login MENU, which runtime-health's needs_login markers don't match). Check it
+    # first so we carry the prompt text + kind for ESCALATE / AUTO-ANSWER.
     hit = classify(pane) if pane else None
     if hit:
         kind, excerpt = hit
         if kind in _HUMAN_GATES:
             return "blocked-human", f"awaiting user: {kind}", excerpt, kind
         return "blocked-known", f"at known gate: {kind}", excerpt, kind
-    # No interactive prompt showing.
-    if pane and _LOGGED_OUT.search(pane):
-        return "logged-out", "core not authenticated (needs /login)", None, None
+    if base_health == "needs_login":
+        return "logged-out", _BASE_TO_STATE["needs_login"][1], None, None
     if not gateway_alive:
         return "gateway-down", "core up but relay gateway not running", None, None
-    if pane and _IDLE.search(pane):
-        return "idle-ready", "ready for a task", None, None
-    if progressing:
-        return "running", "actively processing", None, None
-    # Stalled: alive, not idle, no recognized affordance, not progressing. Could be
-    # an unforeseen prompt with no await-hint we matched. Carry the pane so the UI
-    # shows WHAT it's stuck on — never a silent dead-end.
-    tail = "\n".join([ln for ln in (pane or "").splitlines() if ln.strip()][-14:])
-    return "hung", "core alive but stalled (no progress, no recognized prompt)", tail or None, "unknown"
+    state, detail = _BASE_TO_STATE.get(base_health, _BASE_TO_STATE["unknown"])
+    if state == "hung":
+        tail = "\n".join([ln for ln in (pane or "").splitlines() if ln.strip()][-14:])
+        return "hung", detail, tail or None, "unknown"
+    return state, detail, None, None
 
 
-# ---- Liveness signals (cheap, pgrep/tmux-based). --------------------------- #
-def _has_session(socket, session):
-    try:
-        return subprocess.run(["tmux", "-S", socket, "has-session", "-t", session],
-                              capture_output=True, timeout=6).returncode == 0
-    except Exception:
-        return False
-
-
+# ---- Bundled-context probes (NOT part of runtime-health's coarse health). --- #
 def _pgrep(pattern):
     try:
         return subprocess.run(["pgrep", "-f", pattern],
@@ -153,15 +202,12 @@ def _pgrep(pattern):
         return False
 
 
-def core_alive(socket, session):
-    # A live core = the tmux session exists AND a claude bound to it is running.
-    return _has_session(socket, session) and _pgrep(f"claude.*--name.*{session}")
-
-
 def gateway_alive(app_data):
     # The bundled gateway runs from the app-data interpreter (see console_status:
     # keepalive cd's into $ENGINE so the argv is relative — match the app-unique
-    # runtime-python dir, which uniquely scopes to THIS app's gateway).
+    # runtime-python dir, which uniquely scopes to THIS app's gateway). Gateway
+    # liveness is a supervisor concern the Console's coarse health folds into a
+    # detail string; here it is elevated to its own state, so it stays local.
     if app_data:
         return _pgrep(os.path.join(app_data, "engine", "runtime", "python"))
     return _pgrep("remote-gateway-bridge")
@@ -196,19 +242,21 @@ def main():
     ap.add_argument("--once", action="store_true", help="one tick then exit (for tests/probes)")
     a = ap.parse_args()
 
-    last_hash = None
+    # Point the SHARED runtime-health derivation at THIS core's socket/session so
+    # the supervisor and the Console's status strip read the same liveness core.
+    os.environ["SUTANDO_TMUX_SOCKET"] = a.socket
+    rh = _load_runtime_health()
+    rh.TMUX_SOCKET = a.socket
+    rh.SESSION = a.session
+
     last_sig = None
     stable_prompt = 0
     last_prompt = None
     while True:
         pane = capture(a.socket, a.session)
-        cur_hash = hashlib.sha1((pane or "").encode()).hexdigest()
-        progressing = cur_hash != last_hash
-        last_hash = cur_hash
-
+        base = rh.derive()  # shared: offline|needs_login|working|idle|unknown
         state, detail, prompt, kind = compose_state(
-            pane or "", core_alive(a.socket, a.session),
-            gateway_alive(a.app_data), progressing)
+            pane or "", base.get("health", "unknown"), gateway_alive(a.app_data))
 
         # Debounce prompt escalation: only surface once the SAME prompt persists
         # (not a menu the core is actively navigating through).

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -276,7 +276,7 @@ def main():
             last_sig = sig
         if a.once:
             return
-        time.sleep(a.interval)
+        time.sleep(a.interval)  # pragma: no cover - daemon heartbeat (tests use --once)
 
 
 if __name__ == "__main__":

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""core-input-watch.py — surface "the agent needs your input" to the desktop UI.
+
+The detached bundled core runs Claude Code with no TTY. Most first-run gates are
+pre-seeded (folder-trust, bypass-permissions, onboarding) so the core never stops
+on them — but some interactions inherently need the user (/login) or can't be
+predicted (a mid-session permission request, a model/selection prompt, an unknown
+dialog). With no TTY the core silently BLOCKS on those, "alive but stuck".
+
+This watcher polls the core's tmux pane and, when it detects the core parked on
+an interactive prompt AND not progressing, writes <workspace>/state/core-needs-
+input.json so the app can show an "Action needed" banner with the prompt text +
+a button to open the terminal. When the prompt clears, it writes blocked:false.
+
+It is the catch-all behind the pre-seeds: seed what we can, this surfaces the rest.
+
+Usage:
+  core-input-watch.py --socket <tmux.sock> --session sutando-core \
+      --out <workspace>/state/core-needs-input.json [--interval 3] [--stable 2]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import time
+
+# Interactive-prompt signatures. Each: (kind, compiled regex). Order = priority;
+# the FIRST match classifies the block. Kept specific so the normal idle prompt
+# (a bare "❯ " ready for a task) is NEVER flagged — only genuine input gates.
+_SIGNATURES = [
+    ("folder-trust", re.compile(r"trust the files in this folder|Do you trust", re.I)),
+    ("bypass-permissions", re.compile(r"Bypass Permissions mode|Yes, I accept", re.I)),
+    ("login", re.compile(r"Select login method|Paste code here|Browser didn'?t open", re.I)),
+    ("press-enter", re.compile(r"Press Enter to continue", re.I)),
+    # Generic numbered menu awaiting a choice, e.g. "❯ 1. …" plus a cancel hint.
+    ("selection", re.compile(r"(❯\s*\d+\.|\bSelect\b).*", re.S)),
+    ("permission", re.compile(r"Do you want to (proceed|allow)|Allow this action|permission to", re.I)),
+]
+
+# A pane is only "awaiting input" if it ALSO carries a confirm/cancel affordance —
+# this filters out normal agent output that merely happens to contain a digit.
+_AWAIT_HINT = re.compile(
+    r"Esc to cancel|Enter to confirm|Press Enter|Paste code|to accept|❯\s*\d+\.",
+    re.I,
+)
+# The normal ready-for-work state: a bare prompt with the bypass footer. NEVER flag.
+_IDLE = re.compile(r"⏵⏵\s*bypass permissions on|for agents\b", re.I)
+
+
+def classify(pane: str) -> tuple[str, str] | None:
+    """Return (kind, excerpt) if the pane is awaiting user input, else None."""
+    tail = "\n".join([ln for ln in pane.splitlines() if ln.strip()][-14:])
+    if not _AWAIT_HINT.search(tail):
+        return None
+    # An idle "ready for a task" prompt shows the bypass footer with no gate above.
+    if _IDLE.search(tail) and not any(rx.search(tail) for _, rx in _SIGNATURES[:5]):
+        return None
+    for kind, rx in _SIGNATURES:
+        if rx.search(tail):
+            return kind, tail
+    return None
+
+
+def capture(socket: str, session: str) -> str | None:
+    try:
+        out = subprocess.run(
+            ["tmux", "-S", socket, "capture-pane", "-p", "-t", f"{session}:0"],
+            capture_output=True, text=True, timeout=8,
+        )
+        return out.stdout if out.returncode == 0 else None
+    except Exception:
+        return None
+
+
+def _atomic_write(path: str, payload: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(payload, f, indent=2)
+    os.replace(tmp, path)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--socket", required=True)
+    ap.add_argument("--session", default="sutando-core")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--interval", type=float, default=3.0)
+    ap.add_argument("--stable", type=int, default=2,
+                    help="consecutive identical polls before flagging (debounce)")
+    a = ap.parse_args()
+
+    last_excerpt = None
+    stable = 0
+    last_written_blocked = None
+    while True:
+        pane = capture(a.socket, a.session)
+        hit = classify(pane) if pane else None
+        if hit:
+            kind, excerpt = hit
+            # Debounce: only flag once the same prompt persists (not a transient
+            # menu the core is actively navigating).
+            stable = stable + 1 if excerpt == last_excerpt else 1
+            last_excerpt = excerpt
+            if stable >= a.stable and last_written_blocked is not True:
+                _atomic_write(a.out, {
+                    "blocked": True, "kind": kind, "prompt": excerpt,
+                    "ts": int(os.environ.get("_NOW_", "0")) or None,
+                    "session": a.session,
+                })
+                last_written_blocked = True
+        else:
+            stable = 0
+            last_excerpt = None
+            if last_written_blocked is not False:
+                _atomic_write(a.out, {"blocked": False, "session": a.session})
+                last_written_blocked = False
+        time.sleep(a.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -56,7 +56,7 @@ _LOGGED_OUT = re.compile(r"Not logged in|Please run /login|Invalid API key", re.
 
 # Gates that need a human (can't be auto-answered): login + any unrecognized
 # selection/permission. The rest (trust/bypass/press-enter) are known-safe.
-_HUMAN_GATES = {"login", "selection", "permission"}
+_HUMAN_GATES = {"login", "selection", "permission", "unknown"}
 
 
 def classify(pane: str):
@@ -69,7 +69,12 @@ def classify(pane: str):
     for kind, rx in _SIGNATURES:
         if rx.search(tail):
             return kind, tail
-    return None
+    # No specific signature — but an input affordance IS present and this is NOT
+    # the idle prompt. That means an UNFORESEEN prompt. Surface it rather than
+    # leave a silent dead-end (owner's no-dead-end requirement 2026-07-14): we
+    # cannot enumerate every possible TUI question, so ANY await-affordance that
+    # isn't the known idle-ready state is treated as needing the user.
+    return "unknown", tail
 
 
 def compose_state(pane, core_alive, gateway_alive, progressing):
@@ -95,7 +100,11 @@ def compose_state(pane, core_alive, gateway_alive, progressing):
         return "idle-ready", "ready for a task", None, None
     if progressing:
         return "running", "actively processing", None, None
-    return "hung", "core alive but not progressing and not at a known prompt", None, None
+    # Stalled: alive, not idle, no recognized affordance, not progressing. Could be
+    # an unforeseen prompt with no await-hint we matched. Carry the pane so the UI
+    # shows WHAT it's stuck on — never a silent dead-end.
+    tail = "\n".join([ln for ln in (pane or "").splitlines() if ln.strip()][-14:])
+    return "hung", "core alive but stalled (no progress, no recognized prompt)", tail or None, "unknown"
 
 
 # ---- Liveness signals (cheap, pgrep/tmux-based). --------------------------- #

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1017,6 +1017,43 @@ def check_core_proactive_loop(threshold_sec: int = 600) -> dict:
     return {"name": name, "status": "ok", "detail": f"running ({age}s ago)"}
 
 
+def check_core_supervisor() -> dict:
+    """Surface the core-supervisor (Agent Shepherd M1) state for OSS users.
+
+    The monitor (core-input-watch.py) writes state/core-supervisor.json with
+    the core's supervised state. The desktop app renders this as an "Action
+    needed" banner, but OSS users running bare Sutando have no such UI — so
+    surface it here, in the canonical OSS status tool, as the simple in-repo
+    consumer of the signal.
+
+    States needing the user (login / an unrecognized prompt) → warn with a
+    "needs you" line + the prompt excerpt; degraded states (crashed / hung /
+    gateway-down) → warn; healthy (running / idle-ready / blocked-known, the
+    last being pre-seeded/auto-answered) → ok. File missing → ok (monitor not
+    running, or a pre-supervisor install).
+    """
+    name = "core-supervisor"
+    sig_path = status_read_path("core-supervisor.json", WORKSPACE_DIR)
+    if not sig_path.exists():
+        return {"name": name, "status": "ok", "detail": "core-supervisor.json not yet written"}
+    try:
+        data = json.loads(sig_path.read_text())
+    except Exception as e:
+        return {"name": name, "status": "ok", "detail": f"core-supervisor.json unreadable: {str(e)[:60]}"}
+    state = data.get("state", "unknown")
+    detail = state
+    prompt = data.get("prompt")
+    if prompt:
+        detail = f"{state} — {str(prompt).splitlines()[0][:60]}"
+    needs_user = {"blocked-human", "logged-out"}
+    degraded = {"crashed", "hung", "gateway-down"}
+    if state in needs_user:
+        return {"name": name, "status": "warn", "detail": f"core needs you: {detail}"}
+    if state in degraded:
+        return {"name": name, "status": "warn", "detail": f"core degraded: {detail}"}
+    return {"name": name, "status": "ok", "detail": detail}
+
+
 def check_gateway_bridge() -> "dict | None":
     """Health of the ag2.space gateway bridge (remote-gateway-bridge.py) — the
     process that carries MOBILE-app messages from the cloud gateway down to the
@@ -1598,6 +1635,7 @@ def run_all_checks() -> list[dict]:
     checks.append(check_battery())
     checks.append(check_memory())
     checks.append(check_core_proactive_loop(threshold_sec=loop_stale_sec))
+    checks.append(check_core_supervisor())
     checks.append(check_task_queue(threshold_count=queue_count, threshold_age_sec=queue_age_sec))
 
     return checks

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -524,25 +524,6 @@ else
   echo "  ✓ core heartbeat (already running)"
 fi
 
-# Core input monitor (Agent Shepherd M1) — watches THIS core's tmux pane for
-# blocked-on-input gates the no-TTY core can't answer (/login, a mid-session
-# permission prompt, an unknown dialog) and writes state/core-supervisor.json,
-# which the desktop app's "Action needed" banner and the communicator relay
-# (core-supervisor-relay.py) consume. Self-wires to the current tmux socket +
-# session ($TMUX is "socket,pid,session" inside tmux); no-op when not in tmux.
-if [ -n "${TMUX:-}" ] && ! pgrep -f "src/core-input-watch.py" > /dev/null 2>&1; then
-  echo "  Starting core input monitor..."
-  MON_SOCK="${TMUX%%,*}"
-  MON_SESS="$(tmux display-message -p '#S' 2>/dev/null || echo sutando-core)"
-  MON_OUT="$(bash "$REPO/scripts/sutando-config.sh" workspace)/state/core-supervisor.json"
-  python3 "$REPO/src/core-input-watch.py" \
-    --socket "$MON_SOCK" --session "$MON_SESS" --out "$MON_OUT" \
-    > /tmp/core-input-watch.log 2>&1 &
-  echo "  ✓ core input monitor ($MON_SESS)"
-elif [ -n "${TMUX:-}" ]; then
-  echo "  ✓ core input monitor (already running)"
-fi
-
 # 0. Credential proxy for quota tracking (port 7846).
 # Prefer the launchd-supervised job (KeepAlive + ThrottleInterval=10s) so the
 # proxy restarts on crash instead of leaving a proxy-routed core stranded on a

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -524,6 +524,25 @@ else
   echo "  ✓ core heartbeat (already running)"
 fi
 
+# Core input monitor (Agent Shepherd M1) — watches THIS core's tmux pane for
+# blocked-on-input gates the no-TTY core can't answer (/login, a mid-session
+# permission prompt, an unknown dialog) and writes state/core-supervisor.json,
+# which the desktop app's "Action needed" banner and the communicator relay
+# (core-supervisor-relay.py) consume. Self-wires to the current tmux socket +
+# session ($TMUX is "socket,pid,session" inside tmux); no-op when not in tmux.
+if [ -n "${TMUX:-}" ] && ! pgrep -f "src/core-input-watch.py" > /dev/null 2>&1; then
+  echo "  Starting core input monitor..."
+  MON_SOCK="${TMUX%%,*}"
+  MON_SESS="$(tmux display-message -p '#S' 2>/dev/null || echo sutando-core)"
+  MON_OUT="$(bash "$REPO/scripts/sutando-config.sh" workspace)/state/core-supervisor.json"
+  python3 "$REPO/src/core-input-watch.py" \
+    --socket "$MON_SOCK" --session "$MON_SESS" --out "$MON_OUT" \
+    > /tmp/core-input-watch.log 2>&1 &
+  echo "  ✓ core input monitor ($MON_SESS)"
+elif [ -n "${TMUX:-}" ]; then
+  echo "  ✓ core input monitor (already running)"
+fi
+
 # 0. Credential proxy for quota tracking (port 7846).
 # Prefer the launchd-supervised job (KeepAlive + ThrottleInterval=10s) so the
 # proxy restarts on crash instead of leaving a proxy-routed core stranded on a

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-"""Tests for src/core-input-watch.py classify() — the core-needs-input detector.
+"""Tests for src/core-input-watch.py — the core supervisor MONITOR (M1).
 
-Fixtures are the ACTUAL tmux panes captured from the bundled core on the Mac mini
-2026-07-14 while driving the first-run gates by hand (bypass-permissions, /login,
-paste-code, login-success) plus the two states that must NEVER flag: the idle
-"ready for a task" prompt and normal agent output.
+classify() fixtures are the ACTUAL tmux panes captured from the bundled core on
+the Mac mini 2026-07-14 while driving the first-run gates by hand
+(bypass-permissions, /login, paste-code, login-success) plus the two states that
+must NEVER flag: the idle "ready for a task" prompt and normal agent output.
+
+compose_state() tests exercise the full state machine (crashed / blocked-human /
+blocked-known / logged-out / gateway-down / idle-ready / running / hung).
 
 Run: python3 tests/core-input-watch.test.py
 """
@@ -20,61 +23,81 @@ _spec = importlib.util.spec_from_file_location("core_input_watch", _SRC)
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 classify = _mod.classify
+compose_state = _mod.compose_state
+
+_BYPASS = ("  in Bypass Permissions mode.\n  https://code.claude.com/docs/en/security\n"
+           "  ❯ 1. No, exit\n    2. Yes, I accept\n  Enter to confirm · Esc to cancel")
+_LOGIN_MENU = ("  Login\n  Select login method:\n  ❯ 1. Claude account with subscription\n"
+               "    2. Anthropic Console account\n  Esc to cancel")
+_PASTE = ("  Login\n  Browser didn't open? Use the url below to sign in\n"
+          "https://claude.com/cai/oauth/authorize?code=true\n"
+          "  Paste code here if prompted >\n  Esc to cancel")
+_PRESS_ENTER = ("  Login\n  Logged in as x@example.com\n  Login successful. Press Enter to continue…")
+_IDLE = ("──────── sutando-core ──\n❯ \n────────\n"
+         "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents")
+_IDLE_LOGGEDOUT = _IDLE + "\n     Not logged in · Run /login"
+_WORKING = ("⏺ Bash(WS=... echo WORKSPACE=...)\n  ⎿  WORKSPACE=/Users/x\n     HOST=mini\n     … +39 lines")
 
 
 class TestClassify(unittest.TestCase):
-    def test_bypass_permissions_prompt_flags(self) -> None:
-        pane = (
-            "  in Bypass Permissions mode.\n"
-            "  https://code.claude.com/docs/en/security\n"
-            "  ❯ 1. No, exit\n    2. Yes, I accept\n"
-            "  Enter to confirm · Esc to cancel"
-        )
-        self.assertEqual(classify(pane)[0], "bypass-permissions")
+    def test_bypass_flags(self):
+        self.assertEqual(classify(_BYPASS)[0], "bypass-permissions")
 
-    def test_login_method_menu_flags(self) -> None:
-        pane = (
-            "  Login\n  Select login method:\n"
-            "  ❯ 1. Claude account with subscription\n"
-            "    2. Anthropic Console account\n  Esc to cancel"
-        )
-        self.assertEqual(classify(pane)[0], "login")
+    def test_login_menu_flags(self):
+        self.assertEqual(classify(_LOGIN_MENU)[0], "login")
 
-    def test_paste_code_prompt_flags(self) -> None:
-        pane = (
-            "  Login\n  Browser didn't open? Use the url below to sign in\n"
-            "https://claude.com/cai/oauth/authorize?code=true\n"
-            "  Paste code here if prompted >\n  Esc to cancel"
-        )
-        self.assertEqual(classify(pane)[0], "login")
+    def test_paste_flags(self):
+        self.assertEqual(classify(_PASTE)[0], "login")
 
-    def test_press_enter_prompt_flags(self) -> None:
-        pane = (
-            "  Login\n  Logged in as qingyun0327@gmail.com\n"
-            "  Login successful. Press Enter to continue…"
-        )
-        self.assertEqual(classify(pane)[0], "press-enter")
+    def test_press_enter_flags(self):
+        self.assertEqual(classify(_PRESS_ENTER)[0], "press-enter")
 
-    def test_idle_ready_prompt_does_not_flag(self) -> None:
-        # The normal "ready for a task" state — a bare prompt with the bypass
-        # footer. Must NOT be surfaced as needing input (would false-alarm forever).
-        pane = (
-            "──────── sutando-core ──\n❯ \n────────\n"
-            "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
-            "     Not logged in · Run /login"
-        )
-        self.assertIsNone(classify(pane))
+    def test_idle_does_not_flag(self):
+        self.assertIsNone(classify(_IDLE))
 
-    def test_normal_agent_output_does_not_flag(self) -> None:
-        pane = (
-            "⏺ Bash(WS=... echo WORKSPACE=...)\n"
-            "  ⎿  WORKSPACE=/Users/qingyun-mini/Library/Application Support\n"
-            "     HOST=qingyun-mac-mini\n     … +39 lines"
-        )
-        self.assertIsNone(classify(pane))
+    def test_working_does_not_flag(self):
+        self.assertIsNone(classify(_WORKING))
 
-    def test_empty_pane_does_not_flag(self) -> None:
+    def test_empty_does_not_flag(self):
         self.assertIsNone(classify(""))
+
+
+class TestComposeState(unittest.TestCase):
+    def test_crashed_when_core_dead(self):
+        # core_alive=False dominates everything.
+        st, *_ = compose_state(_WORKING, core_alive=False, gateway_alive=True, progressing=True)
+        self.assertEqual(st, "crashed")
+
+    def test_blocked_human_on_login(self):
+        st, detail, prompt, kind = compose_state(_LOGIN_MENU, True, True, False)
+        self.assertEqual(st, "blocked-human")
+        self.assertEqual(kind, "login")
+        self.assertIsNotNone(prompt)
+
+    def test_blocked_known_on_bypass(self):
+        st, _d, _p, kind = compose_state(_BYPASS, True, True, False)
+        self.assertEqual(st, "blocked-known")
+        self.assertEqual(kind, "bypass-permissions")
+
+    def test_logged_out_when_idle_but_not_authed(self):
+        st, *_ = compose_state(_IDLE_LOGGEDOUT, True, True, False)
+        self.assertEqual(st, "logged-out")
+
+    def test_gateway_down_when_core_ok_gateway_dead(self):
+        st, *_ = compose_state(_IDLE, True, gateway_alive=False, progressing=False)
+        self.assertEqual(st, "gateway-down")
+
+    def test_idle_ready_when_healthy(self):
+        st, *_ = compose_state(_IDLE, True, True, False)
+        self.assertEqual(st, "idle-ready")
+
+    def test_running_when_progressing(self):
+        st, *_ = compose_state(_WORKING, True, True, progressing=True)
+        self.assertEqual(st, "running")
+
+    def test_hung_when_stalled_not_prompt_not_idle(self):
+        st, *_ = compose_state(_WORKING, True, True, progressing=False)
+        self.assertEqual(st, "hung")
 
 
 if __name__ == "__main__":

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -155,6 +155,39 @@ class TestAutoAnswer(unittest.TestCase):
         self.assertIsNone(auto_answer("bypass-permissions"))
 
 
+class TestEnsureTmuxOnPath(unittest.TestCase):
+    """Mini-verified 2026-07-14: a detached spawn without Homebrew on PATH made bare
+    `tmux` fail → healthy core mis-read as crashed. The monitor must self-heal PATH."""
+
+    def test_prepends_tmux_dir_when_not_on_path(self):
+        import sys
+        orig_path = os.environ.get("PATH", "")
+        orig_which = _mod.shutil.which
+        orig_exists = _mod.os.path.exists
+        try:
+            _mod.shutil.which = lambda _n: None            # tmux not on PATH
+            _mod.os.path.exists = lambda p: p == "/opt/homebrew/bin/tmux"
+            os.environ["PATH"] = "/usr/bin"
+            _mod._ensure_tmux_on_path()
+            self.assertIn("/opt/homebrew/bin", os.environ["PATH"].split(os.pathsep))
+        finally:
+            _mod.shutil.which = orig_which
+            _mod.os.path.exists = orig_exists
+            os.environ["PATH"] = orig_path
+
+    def test_noop_when_tmux_already_resolvable(self):
+        orig_path = os.environ.get("PATH", "")
+        orig_which = _mod.shutil.which
+        try:
+            _mod.shutil.which = lambda _n: "/usr/bin/tmux"  # already found
+            os.environ["PATH"] = "/usr/bin"
+            _mod._ensure_tmux_on_path()
+            self.assertEqual(os.environ["PATH"], "/usr/bin")  # untouched
+        finally:
+            _mod.shutil.which = orig_which
+            os.environ["PATH"] = orig_path
+
+
 class TestMainOnce(unittest.TestCase):
     """End-to-end --once through the SHARED runtime-health derivation: with no
     live sutando-core, runtime_health.derive() → 'offline' → the supervisor

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -14,6 +14,7 @@ Run: python3 tests/core-input-watch.test.py
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import unittest
 
@@ -25,6 +26,7 @@ _spec.loader.exec_module(_mod)
 classify = _mod.classify
 compose_state = _mod.compose_state
 auto_answer = _mod.auto_answer
+main = _mod.main
 
 _BYPASS = ("  in Bypass Permissions mode.\n  https://code.claude.com/docs/en/security\n"
            "  ❯ 1. No, exit\n    2. Yes, I accept\n  Enter to confirm · Esc to cancel")
@@ -143,6 +145,31 @@ class TestAutoAnswer(unittest.TestCase):
         # auto-accept a trust / dangerous-mode prompt without explicit opt-in.
         self.assertIsNone(auto_answer("folder-trust"))
         self.assertIsNone(auto_answer("bypass-permissions"))
+
+
+class TestMainOnce(unittest.TestCase):
+    """End-to-end --once through the SHARED runtime-health derivation: with no
+    live sutando-core, runtime_health.derive() → 'offline' → the supervisor
+    writes state 'crashed'. Exercises main()/_load_runtime_health()/capture()/
+    gateway_alive()/_atomic_write() in-process (not just classify/compose)."""
+
+    def test_once_writes_crashed_with_no_core(self):
+        import sys
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            out = os.path.join(td, "state", "core-supervisor.json")
+            argv = ["core-input-watch.py", "--socket",
+                    os.path.join(td, "nope.sock"), "--out", out, "--once"]
+            old = sys.argv
+            sys.argv = argv
+            try:
+                main()
+            finally:
+                sys.argv = old
+            with open(out) as f:
+                sig = json.load(f)
+        self.assertEqual(sig["state"], "crashed")
+        self.assertEqual(sig["session"], "sutando-core")
 
 
 if __name__ == "__main__":

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -40,6 +40,11 @@ _IDLE = ("──────── sutando-core ──\n❯ \n──────
          "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents")
 _IDLE_LOGGEDOUT = _IDLE + "\n     Not logged in · Run /login"
 _WORKING = ("⏺ Bash(WS=... echo WORKSPACE=...)\n  ⎿  WORKSPACE=/Users/x\n     HOST=mini\n     … +39 lines")
+# A real mid-session permission prompt rendered ABOVE the persistent idle footer
+# (review repro 2026-07-14). The footer's await-affordance must NOT suppress it.
+_PERMISSION_WITH_FOOTER = (
+    "  Do you want to proceed?\n  Allow this action\n  Esc to cancel\n"
+    "  ────────\n  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents")
 
 
 class TestClassify(unittest.TestCase):
@@ -63,6 +68,19 @@ class TestClassify(unittest.TestCase):
 
     def test_empty_does_not_flag(self):
         self.assertIsNone(classify(""))
+
+    def test_permission_prompt_above_footer_is_not_suppressed(self):
+        # Regression (review 2026-07-14): the idle-footer suppression must not hide a
+        # real permission prompt just because the persistent footer is also present.
+        hit = classify(_PERMISSION_WITH_FOOTER)
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit[0], "permission")
+
+    def test_permission_with_footer_composes_blocked_human(self):
+        st, _d, prompt, kind = compose_state(_PERMISSION_WITH_FOOTER, "working", True)
+        self.assertEqual(st, "blocked-human")
+        self.assertEqual(kind, "permission")
+        self.assertIsNotNone(prompt)
 
     def test_idle_with_await_token_still_does_not_flag(self):
         # The idle prompt can carry an await-hint-like token ("to accept") without

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -24,6 +24,7 @@ _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 classify = _mod.classify
 compose_state = _mod.compose_state
+auto_answer = _mod.auto_answer
 
 _BYPASS = ("  in Bypass Permissions mode.\n  https://code.claude.com/docs/en/security\n"
            "  ❯ 1. No, exit\n    2. Yes, I accept\n  Enter to confirm · Esc to cancel")
@@ -107,6 +108,30 @@ class TestComposeState(unittest.TestCase):
     def test_hung_when_stalled_not_prompt_not_idle(self):
         st, *_ = compose_state(_WORKING, True, True, progressing=False)
         self.assertEqual(st, "hung")
+
+
+class TestAutoAnswer(unittest.TestCase):
+    """M4 decision safety: only strictly-safe gates auto-answer; all else escalates."""
+
+    def test_press_enter_is_the_only_auto_answer(self):
+        self.assertEqual(auto_answer("press-enter"), "Enter")
+
+    def test_login_never_auto_answered(self):
+        self.assertIsNone(auto_answer("login"))
+
+    def test_unknown_never_auto_answered(self):
+        # The no-dead-end catch-all must escalate, never guess a keystroke.
+        self.assertIsNone(auto_answer("unknown"))
+
+    def test_selection_and_permission_never_auto_answered(self):
+        self.assertIsNone(auto_answer("selection"))
+        self.assertIsNone(auto_answer("permission"))
+
+    def test_trust_and_bypass_escalate_not_auto_accepted(self):
+        # Handled by PREVENT seeds; if they surface at runtime we ESCALATE — never
+        # auto-accept a trust / dangerous-mode prompt without explicit opt-in.
+        self.assertIsNone(auto_answer("folder-trust"))
+        self.assertIsNone(auto_answer("bypass-permissions"))
 
 
 if __name__ == "__main__":

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Tests for src/core-input-watch.py classify() — the core-needs-input detector.
+
+Fixtures are the ACTUAL tmux panes captured from the bundled core on the Mac mini
+2026-07-14 while driving the first-run gates by hand (bypass-permissions, /login,
+paste-code, login-success) plus the two states that must NEVER flag: the idle
+"ready for a task" prompt and normal agent output.
+
+Run: python3 tests/core-input-watch.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.join(_HERE, "..", "src", "core-input-watch.py")
+_spec = importlib.util.spec_from_file_location("core_input_watch", _SRC)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+classify = _mod.classify
+
+
+class TestClassify(unittest.TestCase):
+    def test_bypass_permissions_prompt_flags(self) -> None:
+        pane = (
+            "  in Bypass Permissions mode.\n"
+            "  https://code.claude.com/docs/en/security\n"
+            "  ❯ 1. No, exit\n    2. Yes, I accept\n"
+            "  Enter to confirm · Esc to cancel"
+        )
+        self.assertEqual(classify(pane)[0], "bypass-permissions")
+
+    def test_login_method_menu_flags(self) -> None:
+        pane = (
+            "  Login\n  Select login method:\n"
+            "  ❯ 1. Claude account with subscription\n"
+            "    2. Anthropic Console account\n  Esc to cancel"
+        )
+        self.assertEqual(classify(pane)[0], "login")
+
+    def test_paste_code_prompt_flags(self) -> None:
+        pane = (
+            "  Login\n  Browser didn't open? Use the url below to sign in\n"
+            "https://claude.com/cai/oauth/authorize?code=true\n"
+            "  Paste code here if prompted >\n  Esc to cancel"
+        )
+        self.assertEqual(classify(pane)[0], "login")
+
+    def test_press_enter_prompt_flags(self) -> None:
+        pane = (
+            "  Login\n  Logged in as qingyun0327@gmail.com\n"
+            "  Login successful. Press Enter to continue…"
+        )
+        self.assertEqual(classify(pane)[0], "press-enter")
+
+    def test_idle_ready_prompt_does_not_flag(self) -> None:
+        # The normal "ready for a task" state — a bare prompt with the bypass
+        # footer. Must NOT be surfaced as needing input (would false-alarm forever).
+        pane = (
+            "──────── sutando-core ──\n❯ \n────────\n"
+            "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\n"
+            "     Not logged in · Run /login"
+        )
+        self.assertIsNone(classify(pane))
+
+    def test_normal_agent_output_does_not_flag(self) -> None:
+        pane = (
+            "⏺ Bash(WS=... echo WORKSPACE=...)\n"
+            "  ⎿  WORKSPACE=/Users/qingyun-mini/Library/Application Support\n"
+            "     HOST=qingyun-mac-mini\n     … +39 lines"
+        )
+        self.assertIsNone(classify(pane))
+
+    def test_empty_pane_does_not_flag(self) -> None:
+        self.assertIsNone(classify(""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -61,6 +61,15 @@ class TestClassify(unittest.TestCase):
     def test_empty_does_not_flag(self):
         self.assertIsNone(classify(""))
 
+    def test_unforeseen_prompt_surfaces_as_unknown(self):
+        # No matching signature, but an input affordance is present and it is NOT
+        # the idle prompt → must surface as "unknown" (owner's no-dead-end rule),
+        # never fall through silently.
+        novel = "  Overwrite the existing config file?\n  (Enter to confirm · Esc to cancel)"
+        hit = classify(novel)
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit[0], "unknown")
+
 
 class TestComposeState(unittest.TestCase):
     def test_crashed_when_core_dead(self):

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -73,41 +73,52 @@ class TestClassify(unittest.TestCase):
 
 
 class TestComposeState(unittest.TestCase):
-    def test_crashed_when_core_dead(self):
-        # core_alive=False dominates everything.
-        st, *_ = compose_state(_WORKING, core_alive=False, gateway_alive=True, progressing=True)
+    """compose_state REFINES runtime-health's coarse `base_health` (one shared
+    derivation, #2092) into the 8 supervisor states — signature is
+    (pane, base_health, gateway_alive). base_health ∈
+    {offline, needs_login, working, idle, unknown}."""
+
+    def test_crashed_when_base_offline(self):
+        # runtime-health "offline" (no session) dominates everything.
+        st, *_ = compose_state(_WORKING, "offline", gateway_alive=True)
         self.assertEqual(st, "crashed")
 
     def test_blocked_human_on_login(self):
-        st, detail, prompt, kind = compose_state(_LOGIN_MENU, True, True, False)
+        # An ACTIVE /login menu is finer than the coarse health → carry the prompt.
+        st, detail, prompt, kind = compose_state(_LOGIN_MENU, "working", True)
         self.assertEqual(st, "blocked-human")
         self.assertEqual(kind, "login")
         self.assertIsNotNone(prompt)
 
     def test_blocked_known_on_bypass(self):
-        st, _d, _p, kind = compose_state(_BYPASS, True, True, False)
+        st, _d, _p, kind = compose_state(_BYPASS, "working", True)
         self.assertEqual(st, "blocked-known")
         self.assertEqual(kind, "bypass-permissions")
 
-    def test_logged_out_when_idle_but_not_authed(self):
-        st, *_ = compose_state(_IDLE_LOGGEDOUT, True, True, False)
+    def test_logged_out_when_base_needs_login_no_active_gate(self):
+        # Passive "Not logged in · Run /login" banner (no active menu) → the
+        # base needs_login maps straight to logged-out.
+        st, *_ = compose_state(_IDLE_LOGGEDOUT, "needs_login", True)
         self.assertEqual(st, "logged-out")
 
-    def test_gateway_down_when_core_ok_gateway_dead(self):
-        st, *_ = compose_state(_IDLE, True, gateway_alive=False, progressing=False)
+    def test_gateway_down_when_base_ok_gateway_dead(self):
+        st, *_ = compose_state(_IDLE, "idle", gateway_alive=False)
         self.assertEqual(st, "gateway-down")
 
-    def test_idle_ready_when_healthy(self):
-        st, *_ = compose_state(_IDLE, True, True, False)
+    def test_idle_ready_when_base_idle(self):
+        st, *_ = compose_state(_IDLE, "idle", True)
         self.assertEqual(st, "idle-ready")
 
-    def test_running_when_progressing(self):
-        st, *_ = compose_state(_WORKING, True, True, progressing=True)
+    def test_running_when_base_working(self):
+        st, *_ = compose_state(_WORKING, "working", True)
         self.assertEqual(st, "running")
 
-    def test_hung_when_stalled_not_prompt_not_idle(self):
-        st, *_ = compose_state(_WORKING, True, True, progressing=False)
+    def test_hung_when_base_unknown(self):
+        # runtime-health "unknown" = live session but stale/absent core-status
+        # (wedged loop) → the supervisor's hung, carrying the pane tail.
+        st, _d, prompt, _k = compose_state(_WORKING, "unknown", True)
         self.assertEqual(st, "hung")
+        self.assertIsNotNone(prompt)
 
 
 class TestAutoAnswer(unittest.TestCase):

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -64,6 +64,14 @@ class TestClassify(unittest.TestCase):
     def test_empty_does_not_flag(self):
         self.assertIsNone(classify(""))
 
+    def test_idle_with_await_token_still_does_not_flag(self):
+        # The idle prompt can carry an await-hint-like token ("to accept") without
+        # being a real gate — the _IDLE guard must still suppress it (never nag the
+        # user on the ready-for-a-task prompt).
+        idle_hint = ("  ⏵⏵ bypass permissions on (shift+tab to cycle) · "
+                     "press tab to accept · ← for agents")
+        self.assertIsNone(classify(idle_hint))
+
     def test_unforeseen_prompt_surfaces_as_unknown(self):
         # No matching signature, but an input affordance is present and it is NOT
         # the idle prompt → must surface as "unknown" (owner's no-dead-end rule),
@@ -170,6 +178,41 @@ class TestMainOnce(unittest.TestCase):
                 sig = json.load(f)
         self.assertEqual(sig["state"], "crashed")
         self.assertEqual(sig["session"], "sutando-core")
+
+    def test_once_blocked_prompt_debounces_on_first_tick(self):
+        """A fresh gate with --stable 2 must NOT escalate on the first tick — the
+        debounce holds it as 'running (settling)' until the prompt persists. Drives
+        the settling branch + the --app-data gateway probe in-process."""
+        import sys
+        import tempfile
+
+        class _FakeRH:  # stand in for runtime-health: session alive + working
+            TMUX_SOCKET = None
+            SESSION = None
+
+            def derive(self):
+                return {"health": "working"}
+
+        orig_cap, orig_load = _mod.capture, _mod._load_runtime_health
+        _mod.capture = lambda sock, sess: _BYPASS          # a recognized gate
+        _mod._load_runtime_health = lambda: _FakeRH()
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                out = os.path.join(td, "state", "core-supervisor.json")
+                argv = ["core-input-watch.py", "--socket", "/x", "--out", out,
+                        "--app-data", td, "--stable", "2", "--once"]
+                old = sys.argv
+                sys.argv = argv
+                try:
+                    main()
+                finally:
+                    sys.argv = old
+                with open(out) as f:
+                    sig = json.load(f)
+        finally:
+            _mod.capture, _mod._load_runtime_health = orig_cap, orig_load
+        # stable=2, first tick → prompt seen once (< 2) → debounced to running.
+        self.assertEqual(sig["state"], "running")
 
 
 if __name__ == "__main__":

--- a/tests/health-check-bridge-skip.test.py
+++ b/tests/health-check-bridge-skip.test.py
@@ -133,8 +133,13 @@ with tempfile.TemporaryDirectory() as _home:
     (_ch / ".env").write_text("SLACK_BOT_TOKEN=xoxb-test\n")
     _orig_chp = hc.claude_home_path
 
-    def _fake_chp(sub):
-        return Path(_home) / sub if sub == "channels" else _orig_chp(sub)
+    def _fake_chp(*sub):
+        # mirror claude_home_path(*subpath): redirect the whole channels/ tree
+        # (any depth, e.g. channels/ag2space/.env) into the temp home; delegate
+        # everything else to the real resolver.
+        if sub and sub[0] == "channels":
+            return Path(_home).joinpath(*sub)
+        return _orig_chp(*sub)
 
     with patch.object(hc, "check_port", side_effect=_stub_port), \
          patch.object(hc, "claude_home_path", side_effect=_fake_chp), \

--- a/tests/health-check-core-supervisor.test.py
+++ b/tests/health-check-core-supervisor.test.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Tests for health-check.py's check_core_supervisor — the OSS surface for the
+core-supervisor (Agent Shepherd M1) signal. The desktop app renders the signal
+as a banner; OSS users see it here in `python3 src/health-check.py`.
+
+Covers: file missing → ok · malformed → ok · blocked-human/logged-out → warn
+(needs you) · crashed/hung/gateway-down → warn (degraded) · running/idle-ready/
+blocked-known → ok.
+
+Run: python3 tests/health-check-core-supervisor.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.join(_HERE, "..", "src", "health-check.py")
+_spec = importlib.util.spec_from_file_location("health_check", _SRC)
+hc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hc)
+
+
+class TestCheckCoreSupervisor(unittest.TestCase):
+    def _run(self, td, payload):
+        sig = os.path.join(td, "state", "core-supervisor.json")
+        os.makedirs(os.path.dirname(sig), exist_ok=True)
+        if payload is not None:
+            with open(sig, "w") as f:
+                f.write(payload)
+
+        def _rp(name, ws):
+            if name == "core-supervisor.json":
+                return pathlib.Path(sig)
+            return pathlib.Path(td) / name
+
+        with mock.patch.object(hc, "status_read_path", side_effect=_rp):
+            return hc.check_core_supervisor()
+
+    def test_missing_file_is_ok(self):
+        with tempfile.TemporaryDirectory() as td:
+            r = self._run(td, None)
+            self.assertEqual(r["status"], "ok")
+            self.assertEqual(r["name"], "core-supervisor")
+
+    def test_malformed_is_ok(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(self._run(td, "{not json")["status"], "ok")
+
+    def test_blocked_human_warns_needs_you_with_prompt(self):
+        with tempfile.TemporaryDirectory() as td:
+            r = self._run(td, json.dumps({"state": "blocked-human",
+                                          "prompt": "Login\nSelect login method"}))
+            self.assertEqual(r["status"], "warn")
+            self.assertIn("needs you", r["detail"])
+            self.assertIn("Login", r["detail"])          # first prompt line only
+            self.assertNotIn("Select", r["detail"])
+
+    def test_logged_out_warns_needs_you(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(self._run(td, json.dumps({"state": "logged-out"}))["status"], "warn")
+
+    def test_degraded_states_warn(self):
+        with tempfile.TemporaryDirectory() as td:
+            for st in ("crashed", "hung", "gateway-down"):
+                r = self._run(td, json.dumps({"state": st}))
+                self.assertEqual(r["status"], "warn", st)
+                self.assertIn("degraded", r["detail"])
+
+    def test_healthy_states_ok(self):
+        with tempfile.TemporaryDirectory() as td:
+            for st in ("running", "idle-ready", "blocked-known"):
+                self.assertEqual(self._run(td, json.dumps({"state": st}))["status"], "ok", st)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/state-paths-adoption.test.py
+++ b/tests/state-paths-adoption.test.py
@@ -157,6 +157,12 @@ ALLOWLIST = {
     # flagged token is the `kind: 'tasks' | 'results'` TYPE UNION on the
     # injected archive callback, mirroring archiveFile's own signature.
     "src/task-delegation.ts",
+    # core-input-watch.py (the core-supervisor monitor) never resolves the
+    # workspace itself — the output path is passed explicitly via --out (the
+    # launcher resolves it env-independently). The flagged tokens appear only
+    # in the module docstring (the core-supervisor.json signal schema + usage
+    # example), not in runnable code. Same rationale as task_archive.py.
+    "src/core-input-watch.py",
 }
 
 


### PR DESCRIPTION
## Why
The detached bundled desktop core runs Claude Code's **interactive TUI** with no TTY. We pre-seed the predictable first-run gates (folder-trust, onboarding, bypass-permissions) so the core never stops on them — but some interactions **inherently need the user** (`/login`) or **can't be predicted** (a mid-session permission request, a model/selection prompt, an unknown dialog). With no TTY the core silently **blocks, alive-but-stuck** — the exact failure mode hit repeatedly on the Mac mini 2026-07-14, where the app showed the core 'up' while it sat frozen on a prompt.

This is the **MONITOR (M1)** milestone of the core-supervisor / "Agent Shepherd" design (`workspace/notes/design-core-supervisor.md`): PREVENT (seeds) / AUTO-ANSWER / ESCALATE / RECOVER. This PR is the monitor + the escalation signal + the (pure, report-only) auto-answer decision.

## What
`src/core-input-watch.py` composes the core's state each tick and writes one signal file `<workspace>/state/core-supervisor.json`:
```json
{ "state": "blocked-human", "detail": "awaiting user: login",
  "prompt": "…pane excerpt…", "kind": "login", "session": "sutando-core" }
```
State ∈ `running · idle-ready · blocked-known · blocked-human · hung · crashed · gateway-down · logged-out`. The desktop app reads this for both its status display and an **"Action needed"** banner (prompt text + open-terminal / login button).

## Reconciliation with `runtime-health.py` (#2092) — addresses `naming_conflict`
`runtime-health.py` is the owner-designed **coarse** health signal the Console renders (`offline / needs_login / working / idle / unknown`). To avoid two tmux/process derivations that drift, this supervisor no longer re-derives liveness — it **consumes `runtime_health.derive()` as its base** and refines those 5 coarse states into the 8 supervisor states via a **pure mapping**:

| runtime-health `health` | supervisor `state` |
|---|---|
| offline | crashed |
| needs_login | logged-out *(unless an active gate shows)* |
| working | running |
| idle | idle-ready |
| unknown (status stale) | hung |
| *(any) + gateway down* | gateway-down |
| *(any) + active pane gate* | blocked-known / blocked-human |

So there is **one derivation core**. `runtime-health.json` stays the Console's coarse view (its file + consumers untouched); `core-supervisor.json` is the escalation-facing refinement of the **same** derivation. Net-new here vs runtime-health = the gate classifier (`classify`), the auto-answer decision (`auto_answer`), and the escalation state machine. The prior duplicated liveness probes + pane-hash progress heuristic are **removed** — working/idle/hung now ride runtime-health's core-status + staleness signal (which handles the wedged-loop case explicitly).

## How this runs / who consumes it — addresses `incomplete_fix`
- **In-repo, on-demand one-shot** (mirrors `runtime-health.py`'s own invocation model — it too is an on-demand observer, not a daemon in `startup.sh`):
  `core-input-watch.py --socket <sock> --out <ws>/state/core-supervisor.json --once`
  A `--once` end-to-end smoke through the shared `derive()` is exercised in this PR.
- **Continuous supervision loop** (the daemon that runs it every N seconds): launched by the Tauri desktop bundle alongside the detached core — **ag2space-cinny-desktop#62**.
- **Consumer** of `core-supervisor.json` (status + "Action needed" banner + login button): **ag2space-cinny-desktop#64** + **cinny#130**.

## AUTO-ANSWER (M4) — pure, report-only
`auto_answer(kind)` returns the safe keystroke to dismiss a gate, or `None` → escalate. Allowlist is deliberately **tiny + strictly non-destructive**: only `press-enter`. Every human gate (login/selection/permission/unknown) and every trust/bypass prompt returns `None` — the supervisor **escalates, never guesses**. This is the *decision*; the send-keys *actor* is a separate, opt-in follow-up kept out of the report-only monitor.

## Correctness
`classify()` and `compose_state()` are pure and tested against the **actual mini panes** for every gate hit this session (bypass-permissions, login menu, paste-code, press-enter) AND — critically — against the idle 'ready for a task' prompt and normal agent output, which must **never** false-flag. The escalate-by-default invariant (unknown/human gates never auto-answer) is asserted. **21/21 tests pass**; `runtime-health.py`'s suite stays green (file untouched).

— @sutando-qingyun-001
