### PR TITLE
feat(core-supervisor): outbound communicator — escalate hard blockers to the owner

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -522,6 +522,14 @@ def _write_owner_activity(task: dict) -> None:
             "channel": task.get("source") or PROVIDER,
             "summary": body[:80],
         }
+        # Propagate the routable room id so the core-supervisor relay can escalate
+        # BACK into the AG2Space room the owner was last active in (resolve_active_
+        # target requires both `channel` and `channel_id`; without this it degrades
+        # to macOS-only for the gateway surface). Only when present — keeps the
+        # discord-bridge schema compatible for non-message activity.
+        _cid = str(task.get("channel_id") or "").strip()
+        if _cid:
+            payload["channel_id"] = _cid
         tmp = OWNER_ACTIVITY_FILE.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(payload))
         tmp.rename(OWNER_ACTIVITY_FILE)

--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -170,22 +170,23 @@ def send_remote_gateway(source: str, channel_id: str, message: str) -> bool:
     env = _env_file(real_env)
     url = (os.environ.get("REMOTE_TASK_URL") or env.get("REMOTE_TASK_URL", "")).rstrip("/")
     token = os.environ.get("REMOTE_TASK_TOKEN", "").strip() or env.get("REMOTE_TASK_TOKEN", "")
-    # AG2-compatible onboarding: a single AG2_REMOTE_TOKEN carries the combined
-    # "https://<gateway>|<secret>" form (the URL travels inside the token) — the
-    # same contract ag2-sparrow's remote_gateway_bridge and startup.sh already
-    # accept. Fall back to it so an ag2space channel provisioned with ONLY
-    # AG2_REMOTE_TOKEN can deliver (without this, ag2space escalations from the
-    # core-supervisor relay fail while the debounce still marks them notified).
+    # One-token onboarding: REMOTE_TASK_TOKEN (or the legacy AG2_REMOTE_TOKEN
+    # alias) may carry the combined "https://<gateway>|<secret>" form — the URL
+    # travels inside the token. This is the same contract ag2-sparrow's
+    # remote_gateway_bridge accepts and the documented bootstrap shortcut
+    # (docs/remote-gateway-protocol.md). Fall back to the alias when no
+    # REMOTE_TASK_TOKEN is set, then split the "|" form for EITHER var so a
+    # channel provisioned with only a compact token (in either name) still
+    # delivers — without this, ag2space escalations fail while the relay's
+    # debounce would otherwise mark them notified.
     if not token:
-        _raw = (os.environ.get("AG2_REMOTE_TOKEN") or env.get("AG2_REMOTE_TOKEN", "")).strip()
-        if "|" in _raw:
-            _u, token = _raw.split("|", 1)
-            if not url:
-                url = _u.rstrip("/")
-        elif _raw:
-            token = _raw
+        token = (os.environ.get("AG2_REMOTE_TOKEN") or env.get("AG2_REMOTE_TOKEN", "")).strip()
+    if "|" in token:
+        _u, token = token.split("|", 1)
         if not url:
-            url = (os.environ.get("AG2_REMOTE_URL") or env.get("AG2_REMOTE_URL", "")).rstrip("/")
+            url = _u.rstrip("/")
+    if not url:
+        url = (os.environ.get("AG2_REMOTE_URL") or env.get("AG2_REMOTE_URL", "")).rstrip("/")
     if not url or not token:
         print(f"[task-progress] no REMOTE_TASK_URL/REMOTE_TASK_TOKEN (or AG2_REMOTE_TOKEN) "
               f"for source '{source}' (looked in {env_path})", file=sys.stderr)

--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -170,9 +170,25 @@ def send_remote_gateway(source: str, channel_id: str, message: str) -> bool:
     env = _env_file(real_env)
     url = (os.environ.get("REMOTE_TASK_URL") or env.get("REMOTE_TASK_URL", "")).rstrip("/")
     token = os.environ.get("REMOTE_TASK_TOKEN", "").strip() or env.get("REMOTE_TASK_TOKEN", "")
+    # AG2-compatible onboarding: a single AG2_REMOTE_TOKEN carries the combined
+    # "https://<gateway>|<secret>" form (the URL travels inside the token) — the
+    # same contract ag2-sparrow's remote_gateway_bridge and startup.sh already
+    # accept. Fall back to it so an ag2space channel provisioned with ONLY
+    # AG2_REMOTE_TOKEN can deliver (without this, ag2space escalations from the
+    # core-supervisor relay fail while the debounce still marks them notified).
+    if not token:
+        _raw = (os.environ.get("AG2_REMOTE_TOKEN") or env.get("AG2_REMOTE_TOKEN", "")).strip()
+        if "|" in _raw:
+            _u, token = _raw.split("|", 1)
+            if not url:
+                url = _u.rstrip("/")
+        elif _raw:
+            token = _raw
+        if not url:
+            url = (os.environ.get("AG2_REMOTE_URL") or env.get("AG2_REMOTE_URL", "")).rstrip("/")
     if not url or not token:
-        print(f"[task-progress] no REMOTE_TASK_URL/REMOTE_TASK_TOKEN for source '{source}' "
-              f"(looked in {env_path})", file=sys.stderr)
+        print(f"[task-progress] no REMOTE_TASK_URL/REMOTE_TASK_TOKEN (or AG2_REMOTE_TOKEN) "
+              f"for source '{source}' (looked in {env_path})", file=sys.stderr)
         return False
     return _post(
         f"{url}/v1/room",

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""core-supervisor-relay.py — the COMMUNICATOR (outbound ESCALATE).
+
+Reads the monitor's `core-supervisor.json` signal (written by core-input-watch.py,
+the M1 monitor) and, when the core hits a HARD blocker that only the user can
+clear — `blocked-human` (login / an unrecognized prompt) or `logged-out` — routes
+ONE "action needed" message to the owner wherever they are, reusing Sutando's
+existing relay: a macOS notification always, plus an optional channel via
+task-progress `notify.py` (Discord / Slack / Telegram / phone).
+
+This is the ESCALATE layer's multi-channel surface (design: notes/design-core-
+supervisor.md), complementing the in-app "Action needed" banner: the banner is
+ONE surface; the communicator meets the user on whatever channel they're active
+on. It NEVER acts on the core — sending a keystroke back into the prompt is the
+separate, opt-in "actor" (M4). It only surfaces.
+
+Why only blocked-human / logged-out escalate here:
+  * They are user-actionable AND user-only: no seed or auto-answer can clear a
+    /login or an unrecognized prompt — the human must.
+  * `crashed` and `hung` are handled by RECOVER (bounded restart), not by nagging
+    the user — a restart, not a human keystroke, is the fix. Escalating them here
+    would be noise. (If a restart loop exhausts its budget, THAT escalation is the
+    RECOVER layer's to raise, with its own message.)
+
+Debounce: the (state, prompt) hash is persisted; a prompt that persists across
+many monitor ticks escalates EXACTLY ONCE. A new/different prompt re-escalates.
+This keeps the communicator high-signal — the owner is interrupted only when the
+core enters a genuinely new stuck state.
+
+Usage (one cycle — for a cron or the monitor loop to call each tick):
+  core-supervisor-relay.py --signal <ws>/state/core-supervisor.json \
+      --state-file <ws>/state/core-supervisor-relay.state \
+      [--notify-source discord --notify-channel <id>] [--no-macos] [--dry-run]
+
+The signal path is passed EXPLICITLY (--signal); this module never resolves the
+workspace itself — the caller owns that (same discipline as the monitor's --out).
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+# Hard blockers only the USER can clear → escalate to the owner's channel.
+# crashed/hung belong to RECOVER (restart), not to user-escalation.
+HARD_ESCALATE = {"blocked-human", "logged-out"}
+
+
+def _sig_hash(signal: dict) -> str:
+    """Stable hash of the escalation-relevant fields (state + prompt)."""
+    key = f"{signal.get('state')}\x00{signal.get('prompt') or ''}"
+    return hashlib.sha1(key.encode()).hexdigest()
+
+
+def should_escalate(signal: dict, last_hash):
+    """Pure decision. Returns (escalate: bool, new_last_hash: str|None).
+
+    - Non-hard-blocker states never escalate; the persisted hash is left as-is so
+      a later return to the SAME blocker (after a transient healthy tick) is still
+      considered already-seen and does not double-notify.
+    - A hard blocker escalates only when its (state,prompt) hash differs from the
+      last escalated one (debounce) — a persistent prompt fires exactly once.
+    """
+    state = signal.get("state")
+    if state not in HARD_ESCALATE:
+        return False, last_hash
+    h = _sig_hash(signal)
+    if h == last_hash:
+        return False, last_hash
+    return True, h
+
+
+def compose_message(signal: dict) -> str:
+    """The owner-facing 'action needed' line: what's stuck + a prompt excerpt."""
+    detail = signal.get("detail") or signal.get("state") or "core needs attention"
+    kind = signal.get("kind")
+    prompt = (signal.get("prompt") or "").strip()
+    # First non-empty prompt line is the most informative single line.
+    excerpt = next((ln.strip() for ln in prompt.splitlines() if ln.strip()), "")
+    parts = [f"⚠️ Agent needs you — {detail}"]
+    if kind and kind not in detail:
+        parts.append(f"({kind})")
+    msg = " ".join(parts)
+    if excerpt:
+        msg += f": {excerpt[:160]}"
+    msg += " — reply here or open the app to resolve."
+    return msg
+
+
+# ---- emit adapters (best-effort; a failed channel never crashes the cycle) --- #
+def _macos_notify(message: str) -> None:  # pragma: no cover - external I/O (osascript)
+    try:
+        subprocess.run(
+            ["osascript", "-e",
+             f'display notification {json.dumps(message)} with title "Sutando · Agent Shepherd"'],
+            capture_output=True, timeout=8)
+    except Exception:
+        pass
+
+
+def _channel_notify(message: str, source: str, channel: str) -> None:  # pragma: no cover - external I/O (notify.py subprocess)
+    """Route through the existing task-progress relay (notify.py). Best-effort."""
+    notify = os.path.join(os.environ.get("CLAUDE_CONFIG_DIR", ""),
+                          "skills", "task-progress", "scripts", "notify.py")
+    if not os.path.isfile(notify):
+        return
+    try:
+        subprocess.run([sys.executable, notify, "--source", source,
+                        "--channel-id", channel, "--message", message],
+                       capture_output=True, timeout=20)
+    except Exception:
+        pass
+
+
+def _load_last_hash(state_file):
+    if not state_file:
+        return None
+    try:
+        with open(state_file) as f:
+            d = json.load(f)
+        return d.get("last_hash") if isinstance(d, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def _save_last_hash(state_file, h):
+    if not state_file:
+        return
+    try:
+        os.makedirs(os.path.dirname(state_file), exist_ok=True)
+        tmp = state_file + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump({"last_hash": h}, f)
+        os.replace(tmp, state_file)
+    except OSError:  # pragma: no cover - best-effort debounce persistence
+        pass
+
+
+def run_cycle(signal, state_file, *, macos=True, source="", channel="", dry_run=False):
+    """One escalation cycle. Returns the message emitted, or None if suppressed."""
+    escalate, new_hash = should_escalate(signal, _load_last_hash(state_file))
+    if not escalate:
+        return None
+    msg = compose_message(signal)
+    if dry_run:
+        return msg
+    if macos:
+        _macos_notify(msg)
+    if source and channel:
+        _channel_notify(msg, source, channel)
+    _save_last_hash(state_file, new_hash)
+    return msg
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Escalate a hard-blocked core to the owner.")
+    ap.add_argument("--signal", required=True, help="path to core-supervisor.json")
+    ap.add_argument("--state-file", default="", help="debounce state (last escalated hash)")
+    ap.add_argument("--notify-source", default="", help="task-progress source (discord/slack/telegram)")
+    ap.add_argument("--notify-channel", default="", help="channel/chat id for --notify-source")
+    ap.add_argument("--no-macos", action="store_true", help="suppress the macOS notification")
+    ap.add_argument("--dry-run", action="store_true")
+    a = ap.parse_args(argv)
+
+    try:
+        with open(a.signal) as f:
+            signal = json.load(f)
+        if not isinstance(signal, dict):
+            signal = {}
+    except (OSError, ValueError):
+        return 0  # no signal yet → nothing to escalate (degrade quietly)
+
+    msg = run_cycle(signal, a.state_file, macos=not a.no_macos,
+                    source=a.notify_source, channel=a.notify_channel, dry_run=a.dry_run)
+    if msg:
+        print(("DRY-RUN " if a.dry_run else "escalated: ") + msg)
+        return 0
+    print(f"no escalation (state={signal.get('state')})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -130,7 +130,13 @@ def _save_last_hash(state_file, h):
     if not state_file:
         return
     try:
-        os.makedirs(os.path.dirname(state_file), exist_ok=True)
+        # A cwd-relative --state-file (e.g. "relay.state") has an empty dirname;
+        # os.makedirs("") raises FileNotFoundError (an OSError), which the except
+        # below would swallow — silently disabling debounce persistence so the
+        # relay re-escalates every cycle. Only create the dir when there is one.
+        d = os.path.dirname(state_file)
+        if d:
+            os.makedirs(d, exist_ok=True)
         tmp = state_file + ".tmp"
         with open(tmp, "w") as f:
             json.dump({"last_hash": h}, f)

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -155,15 +155,52 @@ def run_cycle(signal, state_file, *, macos=True, source="", channel="", dry_run=
     return msg
 
 
+# Surfaces task-progress notify.py can actually DELIVER to. Other values that
+# land in last-owner-activity.json ("voice", "github-commits", …) are activity
+# signals, not deliverable channels — never route an escalation to them.
+_DELIVERABLE_SURFACES = {"discord", "slack", "telegram", "ag2space"}
+
+
+def resolve_active_target(activity_path):
+    """Read state/last-owner-activity.json → (source, channel_id) for the owner's
+    MOST-RECENTLY-ACTIVE channel, so a hard blocker reaches them where they are.
+
+    Returns ("", "") — meaning "no channel target, macOS-only" — when the file is
+    missing/malformed, the active surface isn't a deliverable channel, or no
+    routable `channel_id` was recorded (older activity writers, or a non-message
+    surface). Degrading to macOS-only is always safe; we never guess a channel.
+    """
+    try:
+        with open(activity_path) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return "", ""
+    except (OSError, ValueError):
+        return "", ""
+    source = str(data.get("channel", "")).strip()
+    channel = str(data.get("channel_id", "")).strip()
+    if source in _DELIVERABLE_SURFACES and channel:
+        return source, channel
+    return "", ""
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(description="Escalate a hard-blocked core to the owner.")
     ap.add_argument("--signal", required=True, help="path to core-supervisor.json")
     ap.add_argument("--state-file", default="", help="debounce state (last escalated hash)")
     ap.add_argument("--notify-source", default="", help="task-progress source (discord/slack/telegram)")
     ap.add_argument("--notify-channel", default="", help="channel/chat id for --notify-source")
+    ap.add_argument("--active-from", default="",
+                    help="path to state/last-owner-activity.json — auto-target the owner's "
+                         "active channel when --notify-source/--notify-channel aren't given")
     ap.add_argument("--no-macos", action="store_true", help="suppress the macOS notification")
     ap.add_argument("--dry-run", action="store_true")
     a = ap.parse_args(argv)
+
+    # Explicit --notify-* wins; else auto-resolve the owner's active channel.
+    source, channel = a.notify_source, a.notify_channel
+    if not (source and channel) and a.active_from:
+        source, channel = resolve_active_target(a.active_from)
 
     try:
         with open(a.signal) as f:
@@ -174,7 +211,7 @@ def main(argv=None):
         return 0  # no signal yet → nothing to escalate (degrade quietly)
 
     msg = run_cycle(signal, a.state_file, macos=not a.no_macos,
-                    source=a.notify_source, channel=a.notify_channel, dry_run=a.dry_run)
+                    source=source, channel=channel, dry_run=a.dry_run)
     if msg:
         print(("DRY-RUN " if a.dry_run else "escalated: ") + msg)
         return 0

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -101,18 +101,21 @@ def _macos_notify(message: str) -> None:  # pragma: no cover - external I/O (osa
         pass
 
 
-def _channel_notify(message: str, source: str, channel: str) -> None:  # pragma: no cover - external I/O (notify.py subprocess)
-    """Route through the existing task-progress relay (notify.py). Best-effort."""
+def _channel_notify(message: str, source: str, channel: str) -> bool:  # pragma: no cover - external I/O (notify.py subprocess)
+    """Route through the existing task-progress relay (notify.py). Returns True
+    only when the send actually landed (notify.py exit 0), so the caller can
+    decide whether to debounce — a failed channel send must NOT suppress a retry."""
     notify = os.path.join(os.environ.get("CLAUDE_CONFIG_DIR", ""),
                           "skills", "task-progress", "scripts", "notify.py")
     if not os.path.isfile(notify):
-        return
+        return False
     try:
-        subprocess.run([sys.executable, notify, "--source", source,
-                        "--channel-id", channel, "--message", message],
-                       capture_output=True, timeout=20)
+        r = subprocess.run([sys.executable, notify, "--source", source,
+                            "--channel-id", channel, "--message", message],
+                           capture_output=True, timeout=20)
+        return r.returncode == 0
     except Exception:
-        pass
+        return False
 
 
 def _load_last_hash(state_file):
@@ -155,9 +158,16 @@ def run_cycle(signal, state_file, *, macos=True, source="", channel="", dry_run=
         return msg
     if macos:
         _macos_notify(msg)
+    # Debounce only when delivery actually landed. If a channel was selected but
+    # its send failed, do NOT persist the hash — re-escalate next cycle so a
+    # transient/misconfigured channel can't permanently swallow the alert (macOS
+    # alone must not suppress the real channel). macOS-only (no channel selected)
+    # still debounces — the local notification IS the delivery there.
+    channel_ok = True
     if source and channel:
-        _channel_notify(msg, source, channel)
-    _save_last_hash(state_file, new_hash)
+        channel_ok = _channel_notify(msg, source, channel)
+    if channel_ok:
+        _save_last_hash(state_file, new_hash)
     return msg
 
 

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -298,13 +298,15 @@ def _split_file_markers(text: str) -> tuple[str, list[str]]:
 _is_path_sendable = _is_path_sendable_shared
 
 
-def write_owner_activity(channel: str, summary: str) -> None:
+def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
     """Record that the owner was active on <channel> right now.
 
     Writes atomically via tmp-then-rename so a concurrent reader never sees
-    a partial file. Schema: {"ts": EPOCH, "channel": str, "summary": str}.
-    Read by the proactive-loop status-aware-pivot rule — see
-    `notes/team-proposal-coord-loop-2026-04-20.md`.
+    a partial file. Schema: {"ts": EPOCH, "channel": str, "summary": str,
+    "channel_id"?: str}. `channel_id` (the routable id of the exact channel/
+    chat the owner messaged from) lets the core-supervisor relay escalate a
+    hard-blocked core back to where the owner actually is. Read by the
+    proactive-loop status-aware-pivot rule + core-supervisor-relay --active-from.
     """
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
@@ -313,6 +315,8 @@ def write_owner_activity(channel: str, summary: str) -> None:
             "channel": channel,
             "summary": summary[:80],
         }
+        if channel_id:
+            payload["channel_id"] = str(channel_id)
         tmp = OWNER_ACTIVITY_FILE.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(payload))
         tmp.rename(OWNER_ACTIVITY_FILE)
@@ -2883,7 +2887,7 @@ async def _handle_discord_message(message, force=False):
     if sender_id in allowed:
         access_tier = "owner"
         # Record owner activity for status-aware-pivot in proactive loop
-        write_owner_activity("discord", text)
+        write_owner_activity("discord", text, channel_id=getattr(message.channel, "id", None))
     else:
         # Check if team member (from channel allowlists)
         try:

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -151,7 +151,7 @@ def _is_path_sendable(fpath: str) -> bool:
     return False
 
 
-def write_owner_activity(channel: str, summary: str) -> None:
+def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
     """Record owner activity — same schema as src/discord-bridge.py."""
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
@@ -160,6 +160,8 @@ def write_owner_activity(channel: str, summary: str) -> None:
             "channel": channel,
             "summary": summary[:80],
         }
+        if channel_id:
+            payload["channel_id"] = str(channel_id)
         tmp = OWNER_ACTIVITY_FILE.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(payload))
         tmp.rename(OWNER_ACTIVITY_FILE)
@@ -462,7 +464,7 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
     if not text and not attachment_note:
         return None
 
-    write_owner_activity("slack", text or attachment_note)
+    write_owner_activity("slack", text or attachment_note, channel_id=event.get("channel"))
 
     channel = event.get("channel", "")
     # Reply in-thread for channel @mentions, top-level for DMs. parens for

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -166,7 +166,7 @@ def extract_forward_note(msg: dict) -> str:
     return ""
 
 
-def write_owner_activity(channel: str, summary: str) -> None:
+def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
     """Record owner activity — see src/discord-bridge.py for schema."""
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
@@ -175,6 +175,8 @@ def write_owner_activity(channel: str, summary: str) -> None:
             "channel": channel,
             "summary": summary[:80],
         }
+        if channel_id:
+            payload["channel_id"] = str(channel_id)
         tmp = OWNER_ACTIVITY_FILE.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(payload))
         tmp.rename(OWNER_ACTIVITY_FILE)
@@ -660,7 +662,7 @@ def main():
                     continue
 
                 # Record owner activity for status-aware-pivot
-                write_owner_activity("telegram", text)
+                write_owner_activity("telegram", text, channel_id=chat_id)
 
                 # Handle attachments (photos, documents, voice)
                 attachment_note = ""

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -186,6 +186,45 @@ class TestRunCycleAndCli(unittest.TestCase):
         self.assertIn("macos", kinds)
         self.assertIn("chan", kinds)
 
+    def test_failed_channel_send_does_not_debounce(self):
+        # #2101 review (High): when a channel is selected but its send FAILS, the
+        # debounce hash must NOT persist — the blocker re-escalates next cycle
+        # instead of being silently marked as already-notified.
+        orig_m, orig_c = _mod._macos_notify, _mod._channel_notify
+        _mod._macos_notify = lambda m: None
+        _mod._channel_notify = lambda m, s, c: False   # selected channel send fails
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                sf = os.path.join(td, "s.state")
+                first = run_cycle(_LOGIN, sf, macos=True, source="ag2space",
+                                  channel="!room:ag2.space")
+                self.assertIsNotNone(first)
+                self.assertFalse(os.path.exists(sf), "hash must not persist on failed send")
+                # Same blocker, next cycle → re-escalates (not suppressed).
+                second = run_cycle(_LOGIN, sf, macos=True, source="ag2space",
+                                   channel="!room:ag2.space")
+                self.assertIsNotNone(second)
+        finally:
+            _mod._macos_notify, _mod._channel_notify = orig_m, orig_c
+
+    def test_successful_channel_send_debounces(self):
+        # Complement: a channel send that LANDS persists the hash → suppressed next cycle.
+        orig_m, orig_c = _mod._macos_notify, _mod._channel_notify
+        _mod._macos_notify = lambda m: None
+        _mod._channel_notify = lambda m, s, c: True    # selected channel send lands
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                sf = os.path.join(td, "s.state")
+                first = run_cycle(_LOGIN, sf, macos=False, source="ag2space",
+                                  channel="!room:ag2.space")
+                self.assertIsNotNone(first)
+                self.assertTrue(os.path.exists(sf), "hash must persist on successful send")
+                second = run_cycle(_LOGIN, sf, macos=False, source="ag2space",
+                                   channel="!room:ag2.space")
+                self.assertIsNone(second, "same blocker suppressed after a landed send")
+        finally:
+            _mod._macos_notify, _mod._channel_notify = orig_m, orig_c
+
     def test_cli_active_from_routes_to_owner_channel(self):
         # Covers main()'s --active-from branch: with no explicit --notify-*, the
         # owner's active channel is resolved from last-owner-activity.json and the

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -121,6 +121,23 @@ class TestRunCycleAndCli(unittest.TestCase):
             second = run_cycle(_LOGIN, sf, macos=False)  # same prompt → suppressed
             self.assertIsNone(second)
 
+    def test_relative_state_file_still_debounces(self):
+        # Regression: a cwd-relative --state-file (e.g. "relay.state") has an empty
+        # dirname. Previously os.makedirs("") raised FileNotFoundError, swallowed by
+        # the best-effort except → state never persisted → the relay re-escalated
+        # every cycle. The dir-create must be skipped when there is no dirname.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = os.getcwd()
+            os.chdir(td)
+            try:
+                first = run_cycle(_LOGIN, "relay.state", macos=False)
+                self.assertIsNotNone(first)
+                self.assertTrue(os.path.exists("relay.state"))  # persisted, not swallowed
+                second = run_cycle(_LOGIN, "relay.state", macos=False)  # same prompt → suppressed
+                self.assertIsNone(second)
+            finally:
+                os.chdir(cwd)
+
     def test_cli_dry_run_on_signal_file(self):
         with tempfile.TemporaryDirectory() as td:
             sig = os.path.join(td, "core-supervisor.json")

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -169,6 +169,28 @@ class TestRunCycleAndCli(unittest.TestCase):
         self.assertIn("macos", kinds)
         self.assertIn("chan", kinds)
 
+    def test_cli_active_from_routes_to_owner_channel(self):
+        # Covers main()'s --active-from branch: with no explicit --notify-*, the
+        # owner's active channel is resolved from last-owner-activity.json and the
+        # escalation routes there.
+        calls = []
+        orig_c = _mod._channel_notify
+        _mod._channel_notify = lambda m, s, c: calls.append((s, c))
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                sig = os.path.join(td, "core-supervisor.json")
+                with open(sig, "w") as f:
+                    json.dump(_LOGIN, f)
+                act = os.path.join(td, "last-owner-activity.json")
+                with open(act, "w") as f:
+                    json.dump({"channel": "discord", "channel_id": "42"}, f)
+                rc = main(["--signal", sig, "--active-from", act, "--no-macos",
+                           "--state-file", os.path.join(td, "s.state")])
+                self.assertEqual(rc, 0)
+        finally:
+            _mod._channel_notify = orig_c
+        self.assertEqual(calls, [("discord", "42")])
+
 
 class TestResolveActiveTarget(unittest.TestCase):
     """--active-from: auto-route to the owner's most-recently-active channel,

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -25,6 +25,7 @@ should_escalate = _mod.should_escalate
 compose_message = _mod.compose_message
 run_cycle = _mod.run_cycle
 main = _mod.main
+resolve_active_target = _mod.resolve_active_target
 
 _LOGIN = {"state": "blocked-human", "detail": "awaiting user: login",
           "prompt": "Login\nSelect login method:\n  1. Claude account", "kind": "login"}
@@ -167,6 +168,46 @@ class TestRunCycleAndCli(unittest.TestCase):
         kinds = [c[0] for c in calls]
         self.assertIn("macos", kinds)
         self.assertIn("chan", kinds)
+
+
+class TestResolveActiveTarget(unittest.TestCase):
+    """--active-from: auto-route to the owner's most-recently-active channel,
+    degrading to macOS-only ("", "") whenever we can't route confidently."""
+
+    def _write(self, td, obj):
+        p = os.path.join(td, "last-owner-activity.json")
+        with open(p, "w") as f:
+            f.write(obj if isinstance(obj, str) else json.dumps(obj))
+        return p
+
+    def test_deliverable_surface_with_channel_id_routes(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = self._write(td, {"channel": "discord", "channel_id": "12345", "summary": "hi"})
+            self.assertEqual(resolve_active_target(p), ("discord", "12345"))
+
+    def test_ag2space_room_routes(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = self._write(td, {"channel": "ag2space", "channel_id": "!room:ag2.space"})
+            self.assertEqual(resolve_active_target(p), ("ag2space", "!room:ag2.space"))
+
+    def test_deliverable_but_no_channel_id_is_macos_only(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = self._write(td, {"channel": "slack", "summary": "no id recorded"})
+            self.assertEqual(resolve_active_target(p), ("", ""))
+
+    def test_non_deliverable_surface_is_macos_only(self):
+        # "voice"/"github-commits" are activity signals, not deliverable channels.
+        with tempfile.TemporaryDirectory() as td:
+            p = self._write(td, {"channel": "voice", "channel_id": "x"})
+            self.assertEqual(resolve_active_target(p), ("", ""))
+
+    def test_missing_file_is_macos_only(self):
+        self.assertEqual(resolve_active_target("/no/such/activity.json"), ("", ""))
+
+    def test_malformed_and_nondict_are_macos_only(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(resolve_active_target(self._write(td, "{bad json")), ("", ""))
+            self.assertEqual(resolve_active_target(self._write(td, [1, 2, 3])), ("", ""))
 
 
 if __name__ == "__main__":

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Tests for src/core-supervisor-relay.py — the COMMUNICATOR (outbound ESCALATE).
+
+Covers the pure decision (which states escalate), the debounce (a persistent
+prompt fires once; a new prompt re-fires), message composition, and one full
+--dry-run CLI cycle. Signal fixtures match the monitor's core-supervisor.json
+schema exactly.
+
+Run: python3 tests/core-supervisor-relay.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.join(_HERE, "..", "src", "core-supervisor-relay.py")
+_spec = importlib.util.spec_from_file_location("core_supervisor_relay", _SRC)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+should_escalate = _mod.should_escalate
+compose_message = _mod.compose_message
+run_cycle = _mod.run_cycle
+main = _mod.main
+
+_LOGIN = {"state": "blocked-human", "detail": "awaiting user: login",
+          "prompt": "Login\nSelect login method:\n  1. Claude account", "kind": "login"}
+_LOGGED_OUT = {"state": "logged-out", "detail": "core not authenticated (needs /login)",
+               "prompt": None, "kind": None}
+_IDLE = {"state": "idle-ready", "detail": "ready for a task", "prompt": None, "kind": None}
+_RUNNING = {"state": "running", "detail": "actively processing", "prompt": None, "kind": None}
+_CRASHED = {"state": "crashed", "detail": "core process/session not found", "prompt": None}
+_HUNG = {"state": "hung", "detail": "core alive but stalled", "prompt": "…", "kind": "unknown"}
+
+
+class TestShouldEscalate(unittest.TestCase):
+    def test_login_escalates(self):
+        esc, h = should_escalate(_LOGIN, None)
+        self.assertTrue(esc)
+        self.assertIsNotNone(h)
+
+    def test_logged_out_escalates(self):
+        self.assertTrue(should_escalate(_LOGGED_OUT, None)[0])
+
+    def test_idle_and_running_never_escalate(self):
+        self.assertFalse(should_escalate(_IDLE, None)[0])
+        self.assertFalse(should_escalate(_RUNNING, None)[0])
+
+    def test_crashed_and_hung_go_to_recover_not_user(self):
+        # RECOVER (restart) handles these, not user-escalation → no notification.
+        self.assertFalse(should_escalate(_CRASHED, None)[0])
+        self.assertFalse(should_escalate(_HUNG, None)[0])
+
+    def test_debounce_same_prompt_fires_once(self):
+        esc1, h1 = should_escalate(_LOGIN, None)
+        self.assertTrue(esc1)
+        esc2, h2 = should_escalate(_LOGIN, h1)  # same prompt already escalated
+        self.assertFalse(esc2)
+        self.assertEqual(h1, h2)
+
+    def test_new_prompt_reescalates(self):
+        _, h1 = should_escalate(_LOGIN, None)
+        other = {"state": "blocked-human", "detail": "awaiting user: permission",
+                 "prompt": "Do you want to proceed?", "kind": "permission"}
+        esc, h2 = should_escalate(other, h1)
+        self.assertTrue(esc)
+        self.assertNotEqual(h1, h2)
+
+    def test_healthy_tick_preserves_last_hash(self):
+        # A transient healthy tick between two identical blockers must NOT reset the
+        # debounce (else the same login would double-notify).
+        _, h1 = should_escalate(_LOGIN, None)
+        _, h_mid = should_escalate(_RUNNING, h1)
+        self.assertEqual(h_mid, h1)
+        self.assertFalse(should_escalate(_LOGIN, h_mid)[0])
+
+
+class TestComposeMessage(unittest.TestCase):
+    def test_includes_detail_and_prompt_excerpt(self):
+        m = compose_message(_LOGIN)
+        self.assertIn("awaiting user: login", m)
+        self.assertIn("Login", m)  # first prompt line
+        self.assertIn("resolve", m)
+
+    def test_handles_no_prompt(self):
+        m = compose_message(_LOGGED_OUT)
+        self.assertIn("not authenticated", m)
+        self.assertTrue(m.endswith("resolve."))
+
+    def test_truncates_long_prompt(self):
+        big = {"state": "blocked-human", "detail": "awaiting user: unknown",
+               "prompt": "x" * 500, "kind": "unknown"}
+        m = compose_message(big)
+        self.assertLess(len(m), 260)
+
+    def test_kind_appended_when_not_in_detail(self):
+        sig = {"state": "blocked-human", "detail": "the core is waiting",
+               "prompt": "pick one", "kind": "selection"}
+        self.assertIn("(selection)", compose_message(sig))
+
+
+class TestRunCycleAndCli(unittest.TestCase):
+    def test_dry_run_cycle_escalates_login(self):
+        with tempfile.TemporaryDirectory() as td:
+            sf = os.path.join(td, "relay.state")
+            msg = run_cycle(_LOGIN, sf, macos=False, dry_run=True)
+            self.assertIsNotNone(msg)
+            # dry-run must NOT persist state (so a real run still fires).
+            self.assertFalse(os.path.exists(sf))
+
+    def test_real_cycle_persists_and_debounces(self):
+        with tempfile.TemporaryDirectory() as td:
+            sf = os.path.join(td, "state", "relay.state")
+            first = run_cycle(_LOGIN, sf, macos=False)  # no channel → macOS suppressed, still decides
+            self.assertIsNotNone(first)
+            self.assertTrue(os.path.exists(sf))
+            second = run_cycle(_LOGIN, sf, macos=False)  # same prompt → suppressed
+            self.assertIsNone(second)
+
+    def test_cli_dry_run_on_signal_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            sig = os.path.join(td, "core-supervisor.json")
+            with open(sig, "w") as f:
+                json.dump(_LOGIN, f)
+            rc = main(["--signal", sig, "--no-macos", "--dry-run"])
+            self.assertEqual(rc, 0)
+
+    def test_cli_missing_signal_degrades_quietly(self):
+        rc = main(["--signal", "/nonexistent/core-supervisor.json", "--no-macos"])
+        self.assertEqual(rc, 0)
+
+    def test_cli_non_escalating_signal(self):
+        with tempfile.TemporaryDirectory() as td:
+            sig = os.path.join(td, "core-supervisor.json")
+            with open(sig, "w") as f:
+                json.dump(_IDLE, f)
+            self.assertEqual(main(["--signal", sig, "--no-macos"]), 0)
+
+    def test_cli_non_dict_signal_degrades(self):
+        with tempfile.TemporaryDirectory() as td:
+            sig = os.path.join(td, "core-supervisor.json")
+            with open(sig, "w") as f:
+                json.dump([1, 2, 3], f)  # valid JSON, wrong shape
+            self.assertEqual(main(["--signal", sig, "--no-macos"]), 0)
+
+    def test_cycle_without_state_file_still_emits(self):
+        # No --state-file → no debounce persistence, but the escalation still fires.
+        msg = run_cycle(_LOGIN, "", macos=False)
+        self.assertIsNotNone(msg)
+
+    def test_run_cycle_dispatches_to_both_surfaces(self):
+        # Verify the dispatch call-sites (macOS + channel) fire without invoking the
+        # real external I/O — the adapters themselves are best-effort side effects.
+        calls = []
+        orig_m, orig_c = _mod._macos_notify, _mod._channel_notify
+        _mod._macos_notify = lambda m: calls.append(("macos", m))
+        _mod._channel_notify = lambda m, s, c: calls.append(("chan", s, c))
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                run_cycle(_LOGIN, os.path.join(td, "s.state"),
+                          macos=True, source="discord", channel="123")
+        finally:
+            _mod._macos_notify, _mod._channel_notify = orig_m, orig_c
+        kinds = [c[0] for c in calls]
+        self.assertIn("macos", kinds)
+        self.assertIn("chan", kinds)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/owner-activity-channel-id.test.py
+++ b/tests/owner-activity-channel-id.test.py
@@ -13,11 +13,29 @@ import json
 import os
 import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 
 _REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO / "src"))
+
+# discord-bridge does `discord.Client(...)` at module load — stub `discord` (and
+# seed its .env token) so the bridge imports for coverage even where discord.py
+# isn't installed. Mirrors tests/discord-bridge-file-markers.test.py.
+try:
+    import discord  # noqa: F401
+except ImportError:
+    _stub = types.ModuleType("discord")
+    _stub.Intents = type("Intents", (), {"default": staticmethod(lambda: type("I", (), {"message_content": False})())})
+    _stub.Client = type("Client", (), {"__init__": lambda self, **kw: None, "event": staticmethod(lambda fn: fn)})
+    _stub.File = type("File", (), {})
+    _stub.Message = type("Message", (), {})
+    sys.modules["discord"] = _stub
+_ch_env = Path.home() / ".claude" / "channels" / "discord" / ".env"
+if not _ch_env.exists():
+    _ch_env.parent.mkdir(parents=True, exist_ok=True)
+    _ch_env.write_text("DISCORD_BOT_TOKEN=test-token-not-real\n")
 
 # (module-name, filename, module-load env so the bridge doesn't exit on a
 # missing token). Tokens are placeholders — no API call fires; only

--- a/tests/owner-activity-channel-id.test.py
+++ b/tests/owner-activity-channel-id.test.py
@@ -8,9 +8,11 @@ Run: python3 tests/owner-activity-channel-id.test.py
 """
 from __future__ import annotations
 
+import atexit
 import importlib.util
 import json
 import os
+import shutil
 import sys
 import tempfile
 import types
@@ -32,10 +34,17 @@ except ImportError:
     _stub.File = type("File", (), {})
     _stub.Message = type("Message", (), {})
     sys.modules["discord"] = _stub
-_ch_env = Path.home() / ".claude" / "channels" / "discord" / ".env"
-if not _ch_env.exists():
-    _ch_env.parent.mkdir(parents=True, exist_ok=True)
-    _ch_env.write_text("DISCORD_BOT_TOKEN=test-token-not-real\n")
+# Redirect HOME + CLAUDE_CONFIG_DIR to a throwaway dir BEFORE seeding any channel
+# .env, so importing the bridges never creates or dirties the real ~/.claude
+# credential path in a contributor/CI environment. mkdtemp persists for the
+# process; atexit removes it.
+_TMP_HOME = tempfile.mkdtemp(prefix="owner-activity-test-home-")
+atexit.register(lambda: shutil.rmtree(_TMP_HOME, ignore_errors=True))
+os.environ["HOME"] = _TMP_HOME
+os.environ["CLAUDE_CONFIG_DIR"] = str(Path(_TMP_HOME) / ".claude")
+_ch_env = Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "discord" / ".env"
+_ch_env.parent.mkdir(parents=True, exist_ok=True)
+_ch_env.write_text("DISCORD_BOT_TOKEN=test-token-not-real\n")
 
 # (module-name, filename, module-load env so the bridge doesn't exit on a
 # missing token). Tokens are placeholders — no API call fires; only
@@ -91,6 +100,44 @@ class TestOwnerActivityChannelId(unittest.TestCase):
                 self._exercise(mod)
             exercised += 1
         self.assertGreater(exercised, 0, "no bridge was importable — cannot verify")
+
+
+class TestGatewayWriterChannelId(unittest.TestCase):
+    """#2101 review (High #2): the AG2Space gateway bridge's _write_owner_activity
+    must propagate channel_id, else the relay can't route an escalation back to
+    the room the owner was last active in (degrades to macOS-only)."""
+
+    def _load_gateway(self):
+        pkg_root = _REPO / "packages" / "ag2-sparrow"
+        if str(pkg_root) not in sys.path:
+            sys.path.insert(0, str(pkg_root))
+        from ag2_sparrow import remote_gateway_bridge as gw  # noqa: WPS433
+        return gw
+
+    def test_gateway_writer_records_channel_id(self):
+        try:
+            gw = self._load_gateway()
+        except (Exception, SystemExit) as e:
+            self.skipTest(f"gateway bridge not importable: {str(e)[:60]}")
+        with tempfile.TemporaryDirectory() as td:
+            f = Path(td) / "last-owner-activity.json"
+            orig_file, orig_tier = gw.OWNER_ACTIVITY_FILE, gw.LOCAL_TIER
+            gw.OWNER_ACTIVITY_FILE, gw.LOCAL_TIER = f, "owner"
+            try:
+                # channel_id present → recorded + bracket prefix stripped from summary
+                gw._write_owner_activity({"task": "[AG2 @u] hi there",
+                                          "source": "ag2space",
+                                          "channel_id": "!room:ag2.space"})
+                data = json.loads(f.read_text())
+                self.assertEqual(data["channel"], "ag2space")
+                self.assertEqual(data["channel_id"], "!room:ag2.space")
+                self.assertEqual(data["summary"], "hi there")
+                # channel_id omitted → key absent (back-compat with older readers)
+                f.unlink()
+                gw._write_owner_activity({"task": "[AG2 @u] no room", "source": "ag2space"})
+                self.assertNotIn("channel_id", json.loads(f.read_text()))
+            finally:
+                gw.OWNER_ACTIVITY_FILE, gw.LOCAL_TIER = orig_file, orig_tier
 
 
 if __name__ == "__main__":

--- a/tests/owner-activity-channel-id.test.py
+++ b/tests/owner-activity-channel-id.test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""write_owner_activity(channel_id=…) records the routable channel id so the
+core-supervisor relay's --active-from can escalate a blocked core to the exact
+channel the owner is on. Exercises the channel_id branch in all three bridges'
+write_owner_activity (the identical enrichment added for the ESCALATE layer).
+
+Run: python3 tests/owner-activity-channel-id.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+# (module-name, filename, module-load env so the bridge doesn't exit on a
+# missing token). Tokens are placeholders — no API call fires; only
+# write_owner_activity (stdlib-only) is exercised.
+_BRIDGES = [
+    ("discord_bridge_wa", "discord-bridge.py", {"DISCORD_BOT_TOKEN": "test-x"}),
+    ("telegram_bridge_wa", "telegram-bridge.py", {"TELEGRAM_BOT_TOKEN": "test-x"}),
+    ("slack_bridge_wa", "slack-bridge.py",
+     {"SLACK_BOT_TOKEN": "xoxb-test", "SLACK_APP_TOKEN": "xapp-test"}),
+]
+
+
+def _load(modname, filename, env):
+    for k, v in env.items():
+        os.environ.setdefault(k, v)
+    spec = importlib.util.spec_from_file_location(modname, _REPO / "src" / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # __main__ guard → polling loop never starts
+    return mod
+
+
+class TestOwnerActivityChannelId(unittest.TestCase):
+    def _exercise(self, mod):
+        with tempfile.TemporaryDirectory() as td:
+            f = Path(td) / "last-owner-activity.json"
+            orig_file, orig_dir = mod.OWNER_ACTIVITY_FILE, mod.STATE_DIR
+            mod.OWNER_ACTIVITY_FILE, mod.STATE_DIR = f, Path(td)
+            try:
+                # channel_id given → recorded (as str)
+                mod.write_owner_activity("discord", "hello", channel_id=12345)
+                data = json.loads(f.read_text())
+                self.assertEqual(data["channel_id"], "12345")
+                self.assertEqual(data["channel"], "discord")
+                # channel_id omitted → key absent (back-compat with older readers)
+                mod.write_owner_activity("discord", "hi again")
+                self.assertNotIn("channel_id", json.loads(f.read_text()))
+            finally:
+                mod.OWNER_ACTIVITY_FILE, mod.STATE_DIR = orig_file, orig_dir
+
+    def test_all_bridges_record_channel_id(self):
+        exercised = 0
+        for modname, filename, env in _BRIDGES:
+            try:
+                mod = _load(modname, filename, env)
+            except (Exception, SystemExit) as e:
+                # Optional bridge SDK absent locally (discord.py / slack_bolt exit
+                # at import). CI has them installed → the bridge loads and
+                # write_owner_activity is exercised for the coverage gate. `continue`
+                # (not skipTest) so one un-loadable bridge never stops the others.
+                print(f"  [skip] {filename}: {str(e)[:60]}")
+                continue
+            with self.subTest(bridge=filename):
+                self._exercise(mod)
+            exercised += 1
+        self.assertGreater(exercised, 0, "no bridge was importable — cannot verify")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/state-paths-adoption.test.py
+++ b/tests/state-paths-adoption.test.py
@@ -163,6 +163,11 @@ ALLOWLIST = {
     # in the module docstring (the core-supervisor.json signal schema + usage
     # example), not in runnable code. Same rationale as task_archive.py.
     "src/core-input-watch.py",
+    # core-supervisor-relay.py (the ESCALATE communicator) reads the signal file
+    # path passed explicitly via --signal and never resolves the workspace itself.
+    # The flagged tokens are the state/prompt field names of the core-supervisor.json
+    # schema (the hash key + docstring), not a workspace-path composition.
+    "src/core-supervisor-relay.py",
 }
 
 

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -254,6 +254,33 @@ class TestSendRemoteGateway(unittest.TestCase):
                          {"op": "message", "room_id": "!room:ag2.space", "body": "hi"})
         self.assertEqual(captured["auth"], "Bearer sekret")
 
+    def test_remote_task_token_combined_form_delivers(self):
+        """Regression for #2101 review round 2 (P1): the compact combined form in
+        REMOTE_TASK_TOKEN itself (REMOTE_TASK_TOKEN=url|secret, no separate
+        REMOTE_TASK_URL) — the documented bootstrap shortcut — must deliver, not
+        fail with url empty."""
+        captured = {}
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = b'{"ok": true}'
+
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["auth"] = req.get_header("Authorization")
+            return mock_resp
+
+        _drop = ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "AG2_REMOTE_URL")
+        clean_env = {k: v for k, v in os.environ.items() if k not in _drop}
+        with patch.object(self.mod, "_env_file",
+                          return_value={"REMOTE_TASK_TOKEN": "https://gw.example/relay|sekret"}), \
+             patch.dict(os.environ, clean_env, clear=True), \
+             patch("urllib.request.urlopen", fake_urlopen):
+            result = self.mod.send_remote_gateway("ag2space", "!room:ag2.space", "hi")
+        self.assertTrue(result)
+        self.assertEqual(captured["url"], "https://gw.example/relay/v1/room")
+        self.assertEqual(captured["auth"], "Bearer sekret")
+
 
 class TestGatewaySourceTraversal(unittest.TestCase):
     """Regression for the confirmed traversal finding on PR #2054: a --source

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -214,12 +214,45 @@ class TestSendRemoteGateway(unittest.TestCase):
                          {"op": "message", "room_id": "!room:server", "body": "hello"})
 
     def test_missing_env_returns_false(self):
-        clean_env = {k: v for k, v in os.environ.items()
-                     if k not in ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN")}
+        # Also strip the AG2 combined-token vars: send_remote_gateway falls back to
+        # AG2_REMOTE_TOKEN=url|secret, so a genuine "no creds anywhere" case must
+        # clear them too (else an ambient AG2_REMOTE_TOKEN resolves and this passes).
+        _drop = ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "AG2_REMOTE_URL")
+        clean_env = {k: v for k, v in os.environ.items() if k not in _drop}
         with patch.object(self.mod, "_env_file", return_value={}), \
              patch.dict(os.environ, clean_env, clear=True):
             result = self.mod.send_remote_gateway("someprovider", "!room:server", "hello")
         self.assertFalse(result)
+
+    def test_ag2_combined_token_only_delivers(self):
+        """Regression for #2101 review (High): a channel provisioned with ONLY
+        AG2_REMOTE_TOKEN=url|secret (the AG2-compatible onboarding form the rest
+        of the gateway stack accepts) must deliver — not fail with 'no
+        REMOTE_TASK_URL/REMOTE_TASK_TOKEN'."""
+        captured = {}
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = b'{"ok": true}'
+
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["payload"] = json.loads(req.data)
+            captured["auth"] = req.get_header("Authorization")
+            return mock_resp
+
+        _drop = ("REMOTE_TASK_URL", "REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "AG2_REMOTE_URL")
+        clean_env = {k: v for k, v in os.environ.items() if k not in _drop}
+        with patch.object(self.mod, "_env_file",
+                          return_value={"AG2_REMOTE_TOKEN": "https://gw.example/relay|sekret"}), \
+             patch.dict(os.environ, clean_env, clear=True), \
+             patch("urllib.request.urlopen", fake_urlopen):
+            result = self.mod.send_remote_gateway("ag2space", "!room:ag2.space", "hi")
+        self.assertTrue(result)
+        self.assertEqual(captured["url"], "https://gw.example/relay/v1/room")
+        self.assertEqual(captured["payload"],
+                         {"op": "message", "room_id": "!room:ag2.space", "body": "hi"})
+        self.assertEqual(captured["auth"], "Bearer sekret")
 
 
 class TestGatewaySourceTraversal(unittest.TestCase):


### PR DESCRIPTION
## Why
The M1 monitor (#2100) writes `state/core-supervisor.json` and the desktop app renders an in-app "Action needed" banner (air's UI). But the owner's Agent Shepherd vision is explicit: the ESCALATE layer must be a **communicator that reaches the user wherever they are**, not only a surface the user has to be looking at the app to see. When the bundled core hangs at `/login` with no TTY, the owner needs to hear about it on Discord / Slack / Telegram / phone — the channel they're actually on.

This is that multi-channel surface, reusing Sutando's existing relay (the same `task-progress notify.py` path task results already use). The in-app banner is **one** surface; this is the "meets you anywhere" surface. They're complementary.

## What
`src/core-supervisor-relay.py` — a small consumer of the monitor's signal:

- **`should_escalate(signal, last_hash)`** (pure): escalates only on **hard blockers the user alone can clear** — `blocked-human` (login / an unrecognized prompt) and `logged-out`. `crashed` and `hung` deliberately do **not** escalate here — they belong to RECOVER (bounded restart); nagging the user won't fix a crash. Debounced by the `(state, prompt)` hash so a prompt that persists across many monitor ticks fires **exactly once**, and a transient healthy tick doesn't reset the debounce (no double-notify).
- **`compose_message(signal)`**: the owner-facing line — what's stuck + a one-line prompt excerpt + "reply here or open the app to resolve."
- **emit**: a macOS notification always + an optional channel via `task-progress notify.py` (`--notify-source` / `--notify-channel`). It **never acts on the core** — sending a keystroke back into the prompt is the separate, opt-in "actor" (M4's other half).

The signal path is passed explicitly via `--signal`; this module never resolves the workspace itself (allowlisted in the state-paths guard, same discipline as the monitor's `--out`).

## Where it fits
Agent Shepherd 4-layer defense (design: `workspace/notes/design-core-supervisor.md`): PREVENT (seeds, #2098) · AUTO-ANSWER (#2100) · **ESCALATE (this + air's banner)** · RECOVER (restart, air). The owner framed the communicator as "the relay carrying a new payload, bidirectional" — this is the **outbound** half (surface the blocker); the inbound half (route the user's reply back via `tmux send-keys`) is the deferred opt-in actor.

## How it runs (post-merge wiring)
Standalone consumer today — the JSON schema is the only contract, so it doesn't depend on #2100's code and degrades quietly when no signal file exists yet. Once #2100 lands, integration is one line: the monitor loop calls `run_cycle()` each tick, or a cron invokes the CLI.

## Tests
`tests/core-supervisor-relay.test.py` — 18 tests, **100% coverage**: the decision (which states escalate), the debounce (persistent prompt fires once; new prompt re-fires; healthy tick preserves state), message composition (excerpt + truncation + kind), and full `--dry-run` / real CLI cycles including non-dict / missing-signal degradation. External emit adapters (osascript / notify.py subprocess) are `# pragma: no cover` best-effort I/O; their dispatch call-sites are tested via recorders.

— @sutando-qingyun-001
