### PR TITLE
fix(credential-proxy): log the real refresh-failure body + back off the retry storm

### DIFF
--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -180,6 +180,18 @@ function writeCred(service: string, oauth: ClaudeOAuth): boolean {
 // access token that isn't a plausible non-empty string (never write garbage).
 // Exported so this — the highest-risk logic (field names + the guard) — is
 // unit-tested offline: no network, no keychain, no token rotation.
+// Redact + truncate an upstream response body before it goes to the log.
+// The OAuth token-endpoint ERROR body (e.g. `{"error":"invalid_grant",...}`)
+// is what we want to see when a refresh 400s — but never risk emitting a
+// token if one ever appears: mask any long token-like run (20+ base64url/JWT
+// chars, incl. dotted JWTs) and cap the length. Exported for offline testing.
+export function redactForLog(bodyText: string, max: number = 300): string {
+	const trimmed = (bodyText ?? '').trim();
+	if (!trimmed) return '(empty body)';
+	const redacted = trimmed.replace(/[A-Za-z0-9_-]{20,}(?:\.[A-Za-z0-9_-]{10,}){0,2}/g, '[redacted]');
+	return redacted.length > max ? redacted.slice(0, max) + '…(truncated)' : redacted;
+}
+
 export function parseRefreshResponse(
 	statusCode: number,
 	bodyText: string,
@@ -222,8 +234,15 @@ function refreshAccessToken(oauth: ClaudeOAuth): Promise<ClaudeOAuth | null> {
 			const cs: Buffer[] = [];
 			resp.on('data', (c) => cs.push(c));
 			resp.on('end', () => {
-				const fresh = parseRefreshResponse(resp.statusCode ?? 0, Buffer.concat(cs).toString('utf-8'), oauth);
-				if (!fresh) console.error(`${ts()} [Proxy] refresh unusable (HTTP ${resp.statusCode} or bad/empty response)`);
+				const rawBody = Buffer.concat(cs).toString('utf-8');
+				const fresh = parseRefreshResponse(resp.statusCode ?? 0, rawBody, oauth);
+				// Instrument the ACTUAL upstream failure. Previously this masked
+				// every failure as "HTTP N or bad/empty response", so a recurring
+				// refresh 400 (the fb556dd6 crash-loop root cause) was undiagnosable
+				// — "bad/empty response" hid the real token-endpoint error. Log the
+				// redacted+truncated body so the actual `error`/`error_description`
+				// is visible in credential-proxy.log.
+				if (!fresh) console.error(`${ts()} [Proxy] refresh unusable (HTTP ${resp.statusCode}): ${redactForLog(rawBody)}`);
 				resolve(fresh);
 			});
 		});

--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -50,6 +50,40 @@ const DEFAULT_KEYCHAIN_SERVICE = 'Claude Code-credentials';
 // 5 min of slack avoids racing the expiry on a long-running upstream request.
 const REFRESH_SKEW_MS = 5 * 60 * 1000;
 
+// Failure backoff. Once the stored token is at/near expiry, `needsRefresh` stays
+// true on EVERY subsequent request — so if the refresh itself keeps failing
+// (e.g. the stored refresh token was revoked/rotated out-of-band → HTTP 400),
+// the naive code re-attempts on each request and hammers the OAuth endpoint in
+// a tight loop. After a failure we hold off re-attempting until a backoff window
+// elapses, growing exponentially from BASE to MAX and resetting on the next
+// success. Overridable via env for tests / tuning.
+const REFRESH_FAIL_BACKOFF_BASE_MS =
+	Number(process.env.SUTANDO_PROXY_REFRESH_BACKOFF_BASE_MS) || 30 * 1000; // 30s
+const REFRESH_FAIL_BACKOFF_MAX_MS =
+	Number(process.env.SUTANDO_PROXY_REFRESH_BACKOFF_MAX_MS) || 15 * 60 * 1000; // 15 min
+
+// Pure: how long to wait before the next refresh attempt after `failCount`
+// consecutive failures. 0 failures → 0 (attempt immediately). Exponential
+// (BASE·2^(n-1)) capped at MAX.
+export function nextRefreshBackoffMs(failCount: number): number {
+	if (failCount <= 0) return 0;
+	return Math.min(
+		REFRESH_FAIL_BACKOFF_BASE_MS * 2 ** (failCount - 1),
+		REFRESH_FAIL_BACKOFF_MAX_MS,
+	);
+}
+
+// Pure: should we attempt a refresh right now? Only when the token needs it AND
+// we're past any active failure-backoff window. This is the guard that turns the
+// per-request retry storm into at most one attempt per backoff window.
+export function shouldAttemptRefresh(
+	needsRefresh: boolean,
+	now: number,
+	nextAllowedAt: number,
+): boolean {
+	return needsRefresh && now >= nextAllowedAt;
+}
+
 interface ClaudeOAuth {
 	accessToken: string;
 	refreshToken?: string;
@@ -204,6 +238,12 @@ function refreshAccessToken(oauth: ClaudeOAuth): Promise<ClaudeOAuth | null> {
 // never race to consume/rotate the refresh token twice.
 let refreshInFlight: Promise<void> | null = null;
 
+// Failure-backoff state (see nextRefreshBackoffMs / shouldAttemptRefresh).
+// `nextRefreshAllowedAt` is an epoch-ms gate: while now < it, we skip the
+// refresh and fall through to the existing (stale) token instead of hammering.
+let refreshFailCount = 0;
+let nextRefreshAllowedAt = 0;
+
 // Return a usable accessToken, refreshing first if the stored one is at/near
 // expiry. Fail-safe at every step: any problem → return the existing token.
 async function getFreshOAuthToken(): Promise<string | null> {
@@ -214,14 +254,19 @@ async function getFreshOAuthToken(): Promise<string | null> {
 		typeof cred.expiresAt === 'number' &&
 		cred.expiresAt - Date.now() <= REFRESH_SKEW_MS &&
 		!!cred.refreshToken;
-	if (needsRefresh) {
+	if (shouldAttemptRefresh(needsRefresh, Date.now(), nextRefreshAllowedAt)) {
 		if (!refreshInFlight) {
 			refreshInFlight = (async () => {
 				const fresh = await refreshAccessToken(cred);
 				if (fresh && writeCred(service, fresh)) {
+					refreshFailCount = 0;
+					nextRefreshAllowedAt = 0;
 					console.log(`${ts()} [Proxy] OAuth token refreshed (new expiry ${new Date(fresh.expiresAt ?? 0).toISOString()})`);
 				} else {
-					console.error(`${ts()} [Proxy] refresh did not persist — keeping existing token`);
+					refreshFailCount += 1;
+					const backoff = nextRefreshBackoffMs(refreshFailCount);
+					nextRefreshAllowedAt = Date.now() + backoff;
+					console.error(`${ts()} [Proxy] refresh did not persist — keeping existing token (failure ${refreshFailCount}, backing off ${Math.round(backoff / 1000)}s)`);
 				}
 			})().finally(() => { refreshInFlight = null; });
 		}

--- a/tests/credential-proxy-refresh.test.ts
+++ b/tests/credential-proxy-refresh.test.ts
@@ -13,6 +13,7 @@ import {
 	keychainServiceCandidates,
 	nextRefreshBackoffMs,
 	parseRefreshResponse,
+	redactForLog,
 	scopedKeychainService,
 	shouldAttemptRefresh,
 } from '../skills/quota-tracker/scripts/credential-proxy.ts';
@@ -133,4 +134,32 @@ test('shouldAttemptRefresh: suppress the retry storm while inside the cooldown w
 	assert.equal(shouldAttemptRefresh(true, now + 29_999, nextAllowed), false);
 	// ...until the window elapses.
 	assert.equal(shouldAttemptRefresh(true, nextAllowed, nextAllowed), true);
+});
+
+test('redactForLog: surfaces the real token-endpoint error (invalid_grant)', () => {
+	const out = redactForLog(JSON.stringify({ error: 'invalid_grant', error_description: 'refresh token expired' }));
+	assert.ok(out.includes('invalid_grant'), out);
+	assert.ok(out.includes('refresh token expired'), out);
+});
+
+test('redactForLog: masks any long token-like string (never log a secret)', () => {
+	const jwt = 'eyJhbGciOiJIUzI1NiJ9.' + 'a'.repeat(60) + '.' + 'b'.repeat(40);
+	const out = redactForLog(`{"error":"x","access_token":"${jwt}"}`);
+	assert.ok(!out.includes(jwt), out);
+	assert.ok(out.includes('[redacted]'), out);
+	assert.ok(out.includes('error'), out); // non-secret error field still visible
+});
+
+test('redactForLog: empty/whitespace body → explicit marker (not blank)', () => {
+	assert.equal(redactForLog(''), '(empty body)');
+	assert.equal(redactForLog('   '), '(empty body)');
+});
+
+test('redactForLog: truncates an over-long body', () => {
+	// Many short words (each < 20 chars, so none get redacted away) → the body
+	// stays long and must be truncated to the cap.
+	const longBody = ('err bad grant no ').repeat(40); // ~680 chars, all short tokens
+	const out = redactForLog(longBody, 300);
+	assert.ok(out.length <= 300 + '…(truncated)'.length, String(out.length));
+	assert.ok(out.endsWith('…(truncated)'));
 });

--- a/tests/credential-proxy-refresh.test.ts
+++ b/tests/credential-proxy-refresh.test.ts
@@ -11,8 +11,10 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import {
 	keychainServiceCandidates,
+	nextRefreshBackoffMs,
 	parseRefreshResponse,
 	scopedKeychainService,
+	shouldAttemptRefresh,
 } from '../skills/quota-tracker/scripts/credential-proxy.ts';
 
 const base = { accessToken: 'old-access', refreshToken: 'old-refresh', expiresAt: 1000 };
@@ -78,4 +80,57 @@ test('CLAUDE_CONFIG_DIR maps to Claude Code scoped keychain service', () => {
 test('keychain candidates fall back to the default service when no config dir is set', () => {
 	assert.equal(scopedKeychainService(''), null);
 	assert.deepEqual(keychainServiceCandidates(''), ['Claude Code-credentials']);
+});
+
+// --- Refresh-failure backoff (regression for the tight retry loop) ---------
+// Before this guard, a refresh that returned HTTP 400 (revoked/rotated refresh
+// token) was re-attempted on EVERY subsequent request because `needsRefresh`
+// stays true while the token is near expiry — hammering the OAuth endpoint.
+// nextRefreshBackoffMs + shouldAttemptRefresh cap that to one attempt per
+// (growing) backoff window. Defaults: 30s base, 15min cap.
+
+test('no failures → attempt immediately (zero backoff)', () => {
+	assert.equal(nextRefreshBackoffMs(0), 0);
+	assert.equal(nextRefreshBackoffMs(-1), 0);
+});
+
+test('backoff grows exponentially from the 30s base', () => {
+	assert.equal(nextRefreshBackoffMs(1), 30_000);
+	assert.equal(nextRefreshBackoffMs(2), 60_000);
+	assert.equal(nextRefreshBackoffMs(3), 120_000);
+	assert.equal(nextRefreshBackoffMs(4), 240_000);
+});
+
+test('backoff is capped at the 15min max and never exceeds it', () => {
+	assert.equal(nextRefreshBackoffMs(6), 15 * 60 * 1000);
+	assert.equal(nextRefreshBackoffMs(100), 15 * 60 * 1000);
+	// monotonic non-decreasing, always positive after a failure, always <= cap
+	let prev = 0;
+	for (let n = 1; n <= 50; n++) {
+		const b = nextRefreshBackoffMs(n);
+		assert.ok(b > 0, `failure ${n} must impose a positive cooldown`);
+		assert.ok(b >= prev, `backoff must not shrink at failure ${n}`);
+		assert.ok(b <= 15 * 60 * 1000, `backoff must stay within cap at failure ${n}`);
+		prev = b;
+	}
+});
+
+test('shouldAttemptRefresh: skip entirely when the token does not need refresh', () => {
+	assert.equal(shouldAttemptRefresh(false, 1_000_000, 0), false);
+});
+
+test('shouldAttemptRefresh: attempt when needed and no active cooldown', () => {
+	assert.equal(shouldAttemptRefresh(true, 1_000_000, 0), true);
+	assert.equal(shouldAttemptRefresh(true, 1_000_000, 1_000_000), true); // exactly at the boundary
+});
+
+test('shouldAttemptRefresh: suppress the retry storm while inside the cooldown window', () => {
+	const now = 1_000_000;
+	const nextAllowed = now + nextRefreshBackoffMs(1); // one failure → 30s cooldown
+	// Every request that lands during the window is refused a fresh attempt...
+	assert.equal(shouldAttemptRefresh(true, now, nextAllowed), false);
+	assert.equal(shouldAttemptRefresh(true, now + 1, nextAllowed), false);
+	assert.equal(shouldAttemptRefresh(true, now + 29_999, nextAllowed), false);
+	// ...until the window elapses.
+	assert.equal(shouldAttemptRefresh(true, nextAllowed, nextAllowed), true);
 });


### PR DESCRIPTION
## What

Root-causes the **fb556dd6** credential-proxy crash-loop class reported in #product-feedback (Michael Silton's node: ~85 restarts Jul 10–12). The local credential-proxy (`localhost:7846`) intermittently fails to refresh the OAuth token with `refresh unusable (HTTP 400 or bad/empty response)`; it's silent until the access token actually expires, then every request 401s in a retry loop that starves the core heartbeat and gets it watchdog-killed.

Two **owner-approved** fixes (Michael's priority list), one PR:

**1. Instrumentation (the primary ask).** `refreshAccessToken` previously logged only `HTTP N or bad/empty response`, masking the real token-endpoint error — so a recurring 400 was undiagnosable. It now logs the **redacted + truncated** response body, surfacing the actual `error` / `error_description` (e.g. `invalid_grant`) in `credential-proxy.log`. A new `redactForLog()` masks any long token-like run (base64url / JWT) and caps length, so a secret can never leak into the log even if the endpoint ever echoes one.

**2. Backoff.** After a failed refresh, hold off re-attempting until a backoff window elapses instead of hammering the endpoint every 30–60s — turning the per-request retry storm into at most one attempt per window.

## Tests

`tests/credential-proxy-refresh.test.ts` — **21/21 pass** (offline; no network/keychain). Adds 4 behavioral `redactForLog` cases: surfaces `invalid_grant`, masks a JWT, empty-body marker, truncation.

## Notes

Instrumentation is the load-bearing change here — it makes the *next* recurrence diagnosable (we'll finally see the real 400 body). The refresh round-trip itself isn't live-validated from CI; the parse/guard/redact logic is fully unit-tested offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)