### PR TITLE
fix(agent-api): make listed pending questions answerable (POST /answer 404s on every id)

### DIFF
--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -16,7 +16,7 @@ Format: `- Brief description of what changed. ([#NNN])`
 
 <!-- fix() PRs go here -->
 
-- Pending questions listed in the web UI can be answered again. `POST /answer` skipped every free-form section, so answering any question returned "not found or already answered"; question ids are now derived from the title (stable across rewrites of the file) instead of the section's position, and archived entries below the `# Resolved` divider are no longer offered as open. ([#2103])
+- Pending questions listed in the web UI can be answered again. `POST /answer` skipped every free-form section, so answering any question returned "not found or already answered"; question ids are now derived from each section's own content (stable across rewrites of the file, and distinct + non-renumbering when two open questions share a title) instead of the section's position, and archived entries below the `# Resolved` divider are no longer offered as open. ([#2103])
 
 ## Changed
 

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -16,6 +16,8 @@ Format: `- Brief description of what changed. ([#NNN])`
 
 <!-- fix() PRs go here -->
 
+- Pending questions listed in the web UI can be answered again. `POST /answer` skipped every free-form section, so answering any question returned "not found or already answered"; question ids are now derived from the title (stable across rewrites of the file) instead of the section's position, and archived entries below the `# Resolved` divider are no longer offered as open. ([#2103])
+
 ## Changed
 
 <!-- refactor(), perf(), docs() changes visible to operators go here -->

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -141,11 +141,22 @@ PQ_OPTIONS_RE = re.compile(r'\*\*Options:\*\*\s*(.+)')
 def parse_pending_questions(content: str) -> list[dict]:
     """Open questions in pending-questions.md, in file order.
 
-    Ids are derived from the title, not the section's position. The agent
-    rewrites this file continuously, so a positional id minted by one GET
-    points at a different — or already-archived — section by the time the owner
-    clicks answer on it. Each dict carries the section's `start`/`end` offsets
-    into `content` so the writer can splice it back in place.
+    Ids are derived from the section's own content, not its title or its
+    position. The agent rewrites this file continuously, so a positional id
+    minted by one GET points at a different — or already-archived — section by
+    the time the owner clicks answer on it. Each dict carries the section's
+    `start`/`end` offsets into `content` so the writer can splice it in place.
+
+    Hashing the *whole section* (not just the title) is what makes an id stable
+    when two open sections share a title. A title-hash plus an occurrence-count
+    suffix (`-2`, `-3`) renumbers the survivors as soon as an earlier duplicate
+    is answered or reordered, so a stale id the UI still holds would silently
+    resolve to a *neighbour* (#2103 review). A content hash is tied to that one
+    section: siblings appearing, being answered, or moving around it don't
+    change it, so a stale id resolves to its original section — or, if that
+    section's own text has since changed, cleanly 404s — but never a neighbour.
+    Two sections with an identical title *and* body are the same question and
+    share an id by design.
 
     Sections below the `# Resolved` divider are the audit trail, not open
     questions (same cut as check-pending-questions.py:95).
@@ -154,19 +165,17 @@ def parse_pending_questions(content: str) -> list[dict]:
     active = content[:archive.start()] if archive else content
     starts = [m.start() for m in PQ_SECTION_RE.finditer(active)]
     questions: list[dict] = []
-    seen: dict[str, int] = {}
     for n, start in enumerate(starts):
         end = starts[n + 1] if n + 1 < len(starts) else len(active)
-        head, _, body = active[start:end].partition('\n')
+        section = active[start:end]
+        head, _, body = section.partition('\n')
         title = head[3:].strip()  # drop the '## '
         if not title or title.startswith('RESOLVED') or title.startswith('[RESOLVED'):
             continue
         if PQ_ANSWERED_RE.search(body):
             continue
-        qid = "Q" + hashlib.sha1(" ".join(title.split()).encode()).hexdigest()[:8]
-        seen[qid] = seen.get(qid, 0) + 1
-        if seen[qid] > 1:  # two sections sharing a title — keep the ids distinct
-            qid = f"{qid}-{seen[qid]}"
+        # Whitespace-normalised so a reflow of the same prose keeps the id.
+        qid = "Q" + hashlib.sha1(" ".join(section.split()).encode()).hexdigest()[:12]
         q = {
             "id": qid,
             "text": title,

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -31,6 +31,7 @@ Security: Set SUTANDO_API_TOKEN in .env for token auth (Authorization: Bearer <t
 For remote access: use ngrok or SSH tunnel.
 """
 
+import hashlib
 import http.server
 import ipaddress
 import json
@@ -120,6 +121,82 @@ task_history = {}
 # Web client polls /voice/state and connects/disconnects accordingly.
 voice_desired_state = "disconnected"
 
+
+
+# --- pending-questions.md ---------------------------------------------------
+# ONE parser, shared by GET /status (lists the questions, mints their ids) and
+# POST /answer (resolves an id back to a section). They used to walk the file
+# separately, and drifted: the reader took the free-form format (post-#1265, no
+# **Status:** markers) while the writer still required a **Status:**/**Options:**
+# line, so every free-form question was listed but unanswerable — POST /answer
+# 404'd on every id. Both paths stay on this function.
+PQ_ARCHIVE_RE = re.compile(r'^#\s+Resolved\b', re.MULTILINE)
+PQ_SECTION_RE = re.compile(r'^## ', re.MULTILINE)
+PQ_ANSWERED_RE = re.compile(r'\*\*Status:\*\*\s*(resolved|answered|done|complete)', re.IGNORECASE)
+PQ_STATUS_RE = re.compile(r'\*\*Status:\*\*.*')
+PQ_FIELD_RE = re.compile(r'\*\*(?:Status|Options|Asked|Question):\*\*')
+PQ_OPTIONS_RE = re.compile(r'\*\*Options:\*\*\s*(.+)')
+
+
+def parse_pending_questions(content: str) -> list[dict]:
+    """Open questions in pending-questions.md, in file order.
+
+    Ids are derived from the title, not the section's position. The agent
+    rewrites this file continuously, so a positional id minted by one GET
+    points at a different — or already-archived — section by the time the owner
+    clicks answer on it. Each dict carries the section's `start`/`end` offsets
+    into `content` so the writer can splice it back in place.
+
+    Sections below the `# Resolved` divider are the audit trail, not open
+    questions (same cut as check-pending-questions.py:95).
+    """
+    archive = PQ_ARCHIVE_RE.search(content)
+    active = content[:archive.start()] if archive else content
+    starts = [m.start() for m in PQ_SECTION_RE.finditer(active)]
+    questions: list[dict] = []
+    seen: dict[str, int] = {}
+    for n, start in enumerate(starts):
+        end = starts[n + 1] if n + 1 < len(starts) else len(active)
+        head, _, body = active[start:end].partition('\n')
+        title = head[3:].strip()  # drop the '## '
+        if not title or title.startswith('RESOLVED') or title.startswith('[RESOLVED'):
+            continue
+        if PQ_ANSWERED_RE.search(body):
+            continue
+        qid = "Q" + hashlib.sha1(" ".join(title.split()).encode()).hexdigest()[:8]
+        seen[qid] = seen.get(qid, 0) + 1
+        if seen[qid] > 1:  # two sections sharing a title — keep the ids distinct
+            qid = f"{qid}-{seen[qid]}"
+        q = {
+            "id": qid,
+            "text": title,
+            "detail": PQ_FIELD_RE.split(body)[0].strip() or title,
+            "start": start,
+            "end": end,
+        }
+        opts = PQ_OPTIONS_RE.search(body)
+        if opts:
+            q["options"] = [o.strip() for o in opts.group(1).split("|")]
+        questions.append(q)
+    return questions
+
+
+def answer_pending_question(content: str, question: dict, answer: str) -> str:
+    """Return `content` with `question`'s section marked answered.
+
+    The resolution has to land on a **Status:** line: check-pending-questions.py
+    treats a status-less section as unanswered (its free-form convention), so a
+    [RESOLVED] title prefix alone would silence this API's own reader while the
+    notifier kept re-asking the owner hourly.
+    """
+    section = content[question["start"]:question["end"]]
+    status = f"**Status:** Answered {datetime.now().strftime('%Y-%m-%d')} — {' '.join(answer.split())}"
+    if PQ_STATUS_RE.search(section):
+        # A function repl, not a string: a raw answer may contain \1-style escapes.
+        new_section = PQ_STATUS_RE.sub(lambda _m: status, section, count=1)
+    else:
+        new_section = section.rstrip("\n") + f"\n{status}\n\n"
+    return content[:question["start"]] + new_section + content[question["end"]:]
 
 
 def get_status() -> dict:
@@ -473,39 +550,15 @@ class Handler(http.server.BaseHTTPRequestHandler):
             # Return most recent 10 from history
             sorted_tasks = sorted(task_history.items(), key=lambda x: x[1].get("time", 0), reverse=True)[:10]
             tasks = [{"id": tid, **tdata} for tid, tdata in sorted_tasks]
-            # Parse pending questions
+            # Parse pending questions. `start`/`end` are the writer's splice
+            # offsets — internal, not part of the wire format.
             questions = []
             pq_file = Path(personal_path("pending-questions.md", WORKSPACE_DIR))
             if pq_file.exists():
-                import re
-                content = pq_file.read_text()
-                # Split into sections by ## headers
-                sections = re.split(r'^## ', content, flags=re.MULTILINE)
-                for i, section in enumerate(sections):
-                    if not section.strip():
-                        continue
-                    lines = section.strip().split('\n')
-                    title = lines[0].strip()
-                    body = '\n'.join(lines[1:])
-                    # Skip preamble before first ## header (contains the file title).
-                    if i == 0 or title.startswith('#'):
-                        continue
-                    # Skip sections already marked resolved in title — free-form format
-                    # (post-#1265: no **Status:** markers; [RESOLVED ...] prefix instead).
-                    if title.startswith('[RESOLVED') or title.startswith('RESOLVED'):
-                        continue
-                    # Skip resolved/answered questions (structured format — optional marker)
-                    if re.search(r'\*\*Status:\*\*\s*(resolved|answered|done|complete)', body, re.IGNORECASE):
-                        continue
-                    # Extract question text — use body before first metadata field (if any)
-                    q_text = re.split(r'\*\*(?:Status|Options|Asked|Question):\*\*', body)[0].strip()
-                    q_text = q_text if q_text else title
-                    q = {"id": f"Q{i}", "text": title, "detail": q_text}
-                    # Parse custom options if present
-                    opts_match = re.search(r'\*\*Options:\*\*\s*(.+)', body)
-                    if opts_match:
-                        q["options"] = [o.strip() for o in opts_match.group(1).split("|")]
-                    questions.append(q)
+                questions = [
+                    {k: v for k, v in q.items() if k not in ("start", "end")}
+                    for q in parse_pending_questions(pq_file.read_text())
+                ]
             self.send_json(200, {"tasks": tasks, "watcher": watcher_ok, "claude": claude_ok, "questions": questions})
         elif path == "/delegation/results":
             # TaskDelegationService relay backend (#1947): list results/ for
@@ -869,39 +922,13 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 pq_file = Path(personal_path("pending-questions.md", WORKSPACE_DIR))
                 if pq_file.exists():
                     content = pq_file.read_text()
-                    # Update status from unanswered to answered
-                    import re
-                    safe_answer = answer.replace('\n', ' ')
-                    # Try new format: - **Status:** unanswered
-                    pattern = rf'(## [^\n]*\n(?:.*?\n)*?- \*\*Status:\*\* )unanswered'
-                    # Find the right section by matching the question ID
-                    sections = re.split(r'(^## )', content, flags=re.MULTILINE)
-                    new_content = content
-                    # Reconstruct and find the section matching this qid
-                    idx = 0
-                    for si, section in enumerate(re.split(r'^## ', content, flags=re.MULTILINE)):
-                        if not section.strip():
-                            continue
-                        lines = section.strip().split('\n')
-                        title = lines[0].strip()
-                        body = '\n'.join(lines[1:])
-                        if '**Status:**' not in body and '**Options:**' not in body:
-                            continue
-                        if re.search(r'\*\*Status:\*\*\s*(resolved|answered|done|complete)', body, re.IGNORECASE):
-                            continue
-                        idx += 1
-                        if f"Q{si}" == qid:
-                            # Match any waiting/unanswered status line
-                            new_body = re.sub(
-                                r'\*\*Status:\*\*\s*(?:Waiting|unanswered).*',
-                                f'**Status:** Answered — {safe_answer}',
-                                body
-                            )
-                            if new_body != body:
-                                new_content = content.replace(body, new_body)
-                            break
-                    if new_content != content:
-                        pq_file.write_text(new_content)
+                    # Same parser the ids were minted by — see parse_pending_questions.
+                    match = next(
+                        (q for q in parse_pending_questions(content) if q["id"] == qid),
+                        None,
+                    )
+                    if match:
+                        pq_file.write_text(answer_pending_question(content, match, answer))
                         ts = int(datetime.now().timestamp() * 1000)
                         safe_qid = re.sub(r'[^a-zA-Z0-9_\-.]', '', qid)
                         if safe_qid:

--- a/tests/agent-api-answer-e2e.test.py
+++ b/tests/agent-api-answer-e2e.test.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""E2E for the pending-questions round trip: GET /tasks/active → POST /answer.
+
+The bug this covers end-to-end: the web UI listed a free-form question and then
+POST /answer 404'd on its id ("question Q1 not found or already answered"), because
+the writer required **Status:**/**Options:** markers the reader never needed. Unit
+tests over the parser live in agent-api-pending-questions.test.py; this drives the
+two HTTP handlers against a real server so the id a client is *given* is provably
+the id it can *answer* with.
+
+Run: python3 tests/agent-api-answer-e2e.test.py
+Exit: 0 = all pass, 1 = failure
+"""
+import http.server
+import importlib.util
+import json
+import sys
+import tempfile
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+api = _load("agent_api", REPO / "src" / "agent-api.py")
+
+# The format the agent writes today: prose sections, no metadata markers,
+# resolved items parked below a `# Resolved` divider.
+PQ = """# Pending Questions
+
+_Open decisions awaiting owner input._
+
+## ❓ Re-auth the Station Gmail connector?
+Returns HTTP 410. Reconnect, or say "drop it" and I'll rely on the MCP.
+
+## ❓ Rebuild the Swift menu-bar app?
+Dead since Jul 6 — it owns the watcher auto-restart safety net.
+
+# Resolved & archived detail
+
+## ❓ Something already dealt with
+Archive. Must never be offered as open.
+"""
+
+tmp = Path(tempfile.mkdtemp(prefix="pq-answer-e2e-"))
+(tmp / "tasks").mkdir()
+api.WORKSPACE_DIR = tmp
+api.TASK_DIR = tmp / "tasks"
+api.API_TOKEN = "test-token-123"
+
+# personal_path() puts the file under hosts/<hostname>/ — ask the module where,
+# rather than recomputing the host convention here.
+PQ_FILE = Path(api.personal_path("pending-questions.md", tmp))
+PQ_FILE.parent.mkdir(parents=True, exist_ok=True)
+PQ_FILE.write_text(PQ)
+
+# Handler runs on the MAIN thread (plain HTTPServer + handle_request loop);
+# requests are issued from a worker thread. Inverted on purpose: the coverage
+# gate's tracer misses handler-THREAD execution, so serving on the main
+# thread is what makes the handler lines measurable.
+server = http.server.HTTPServer(("127.0.0.1", 0), api.Handler)
+server.timeout = 0.5
+BASE = f"http://127.0.0.1:{server.server_address[1]}"
+
+failures = []
+ran = 0
+
+
+def check(name, cond, detail=""):
+    global ran
+    ran += 1
+    print(("  ok  " if cond else "  FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def _raw_req(method, path, body=None):
+    r = urllib.request.Request(f"{BASE}{path}", method=method,
+                               data=None if body is None else json.dumps(body).encode())
+    r.add_header("Authorization", "Bearer test-token-123")
+    r.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(r, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode() or "{}")
+    except urllib.error.HTTPError as e:
+        try:
+            payload = json.loads(e.read().decode() or "{}")
+        except Exception:
+            payload = {}
+        return e.code, payload
+    except Exception as e:
+        return -1, {"error": repr(e)}
+
+
+def req(method, path, body=None):
+    """Issue the request from a worker thread while the MAIN thread serves it."""
+    out = {}
+    t = threading.Thread(target=lambda: out.update(
+        zip(("code", "data"), _raw_req(method, path, body))), daemon=True)
+    t.start()
+    while t.is_alive():
+        server.handle_request()   # serve on the main thread (traced)
+    t.join()
+    return out["code"], out["data"]
+
+
+print("agent-api answer e2e")
+
+# 1. The listing: free-form questions are offered, the archive is not.
+code, data = req("GET", "/tasks/active")
+questions = data.get("questions", [])
+check("GET /tasks/active → 200", code == 200, f"got {code}")
+check("free-form questions listed", [q["text"] for q in questions] == [
+    "❓ Re-auth the Station Gmail connector?",
+    "❓ Rebuild the Swift menu-bar app?",
+], f"got {[q.get('text') for q in questions]}")
+check("archive below the `# Resolved` divider is not offered",
+      all("already dealt with" not in q["text"] for q in questions))
+check("splice offsets stay server-side",
+      all("start" not in q and "end" not in q for q in questions))
+
+target = questions[0] if questions else {"id": "Q1"}
+
+# 2. The round trip: the id a client was GIVEN is the id it can ANSWER with.
+#    Pre-fix this 404'd for every free-form question — the whole bug.
+code, data = req("POST", "/answer", {"id": target["id"], "answer": "drop it"})
+check("POST /answer with a listed id → 200", code == 200, f"got {code} {data}")
+check("response echoes the id", data.get("id") == target["id"])
+
+body = PQ_FILE.read_text()
+check("answer recorded on a **Status:** line (the notifier reads this)",
+      "**Status:** Answered" in body and "drop it" in body)
+check("the other question is untouched", "## ❓ Rebuild the Swift menu-bar app?" in body)
+check("the archive is untouched", "## ❓ Something already dealt with" in body)
+
+tasks = list((tmp / "tasks").glob("answer-*.txt"))
+check("agent task file written", len(tasks) == 1, f"got {[t.name for t in tasks]}")
+if tasks:
+    check("task file carries the answer", "drop it" in tasks[0].read_text())
+
+# 3. The answered question drops out of the next listing.
+code, data = req("GET", "/tasks/active")
+still_open = [q["id"] for q in data.get("questions", [])]
+check("answered question no longer listed", target["id"] not in still_open)
+check("unanswered question still listed", len(still_open) == 1, f"got {still_open}")
+
+# 4. Genuine 404s — the message now only fires when it's true.
+code, data = req("POST", "/answer", {"id": target["id"], "answer": "again"})
+check("re-answering the same id → 404 (already answered)", code == 404, f"got {code}")
+code, data = req("POST", "/answer", {"id": "Q1", "answer": "stale"})
+check("unknown/stale positional id → 404", code == 404, f"got {code}")
+code, data = req("POST", "/answer", {"id": target["id"]})
+check("missing answer → 400", code == 400, f"got {code}")
+
+server.server_close()
+print(f"\nagent-api-answer-e2e: {ran - len(failures)}/{ran} passed")
+if failures:
+    print("failed: " + ", ".join(failures))
+sys.exit(1 if failures else 0)

--- a/tests/agent-api-answer-e2e.test.py
+++ b/tests/agent-api-answer-e2e.test.py
@@ -163,6 +163,39 @@ check("unknown/stale positional id → 404", code == 404, f"got {code}")
 code, data = req("POST", "/answer", {"id": target["id"]})
 check("missing answer → 400", code == 400, f"got {code}")
 
+# 5. Duplicate-title stale id must never migrate to a neighbour (#2103 review).
+#    Three open sections share a title; the UI is handed an id for the SECOND.
+#    The agent answers the FIRST (rewriting the file). The id the UI still holds
+#    must still resolve the SECOND section over HTTP — not the third.
+PQ_FILE.write_text(
+    "# Pending Questions\n\n"
+    "## Same title\nFirst — ALPHA.\n\n"
+    "## Same title\nSecond — BRAVO.\n\n"
+    "## Same title\nThird — CHARLIE.\n"
+)
+code, data = req("GET", "/tasks/active")
+dupes = data.get("questions", [])
+check("three duplicate-title questions listed", len(dupes) == 3, f"got {len(dupes)}")
+id_second = dupes[1]["id"] if len(dupes) > 1 else None
+id_third = dupes[2]["id"] if len(dupes) > 2 else None
+check("duplicate ids are distinct", len({q["id"] for q in dupes}) == 3)
+
+# Answer the FIRST duplicate, then reuse the stale id for the SECOND.
+req("POST", "/answer", {"id": dupes[0]["id"], "answer": "resolved first"})
+code, data = req("POST", "/answer", {"id": id_second, "answer": "picked BRAVO"})
+check("stale duplicate id still answers → 200", code == 200, f"got {code} {data}")
+
+# The answer must sit in the BRAVO section, never in CHARLIE's.
+sections = [s for s in PQ_FILE.read_text().split("## Same title\n") if s.strip()]
+answered = [s for s in sections if "picked BRAVO" in s]
+check("the owner's answer landed on exactly one section", len(answered) == 1)
+check("...and it was BRAVO, not the neighbour",
+      bool(answered) and "BRAVO" in answered[0] and "CHARLIE" not in answered[0],
+      f"landed on: {answered}")
+code, data = req("GET", "/tasks/active")
+left = [q["id"] for q in data.get("questions", [])]
+check("the third (CHARLIE) question is still open", id_third in left, f"got {left}")
+
 server.server_close()
 print(f"\nagent-api-answer-e2e: {ran - len(failures)}/{ran} passed")
 if failures:

--- a/tests/agent-api-pending-questions.test.py
+++ b/tests/agent-api-pending-questions.test.py
@@ -1,78 +1,177 @@
 #!/usr/bin/env python3
-"""Structural regression test for agent-api.py GET /status pending-questions fix (2026-06-07).
+"""Behavioural tests for agent-api.py's pending-questions parser + answer path.
 
-The /status endpoint's questions parser used to require **Status:** or **Options:**
-markers to recognise a pending-questions.md entry (post-#1265 free-form format).
-This caused the web UI "Asks" panel to always show 0 questions when there were 12+.
+History of the bug these guard:
 
-Guards: the fix must survive future refactors that re-introduce the old gate.
+  #1265 moved pending-questions.md to a free-form format (prose sections, no
+  **Status:** markers). A 2026-06-07 fix taught GET /status to read it, but left
+  the *writer* (POST /answer) requiring a **Status:**/**Options:** line to
+  recognise a section — so every free-form question was listed in the UI and
+  then 404'd with "question Q1 not found or already answered" when answered.
+  The two paths also minted/consumed ids positionally, so any rewrite of the
+  file between the poll and the click re-pointed an id at another section.
+
+  The earlier version of this file asserted on the *source text* of agent-api.py
+  and explicitly permitted the writer-side gate to remain ("intentional"). It
+  passed for the entire time POST /answer was 100% broken. These tests drive the
+  parser instead.
 
 Run: python3 tests/agent-api-pending-questions.test.py
 Exit: 0 = all pass, 1 = failure
 """
 from __future__ import annotations
+
+import importlib.util
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
-SRC = (Path(__file__).resolve().parent.parent / "src" / "agent-api.py").read_text()
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
 
 
-class TestAgentApiPendingQuestionsParser(unittest.TestCase):
-    """GET /status questions parser must handle free-form pending-questions.md.
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
 
-    post-#1265 format: no **Status:** markers; sections use [RESOLVED ...] prefix.
-    pre-fix: **Status:** not in body → skip ALL free-form sections → 0 questions.
-    """
 
-    def test_preamble_skip_present(self):
-        """Parser must skip the preamble chunk (before first ## header) via i==0 check."""
-        self.assertIn(
-            "i == 0",
-            SRC,
-            "GET /status questions parser must skip preamble chunk via i==0 guard",
+api = _load("agent_api", REPO / "src" / "agent-api.py")
+cpq = _load("check_pending_questions", REPO / "src" / "check-pending-questions.py")
+
+# The format the agent actually writes today: prose under a `## ` heading, no
+# metadata fields, resolved items parked below a `# Resolved` divider.
+FREE_FORM = """# Pending Questions
+
+_Open decisions awaiting owner input._
+
+## ❓ Re-auth the Station Gmail connector?
+The connector returns HTTP 410. Reconnect, or say "drop it" and I'll use the MCP.
+
+## ❓ Rebuild the Swift menu-bar app?
+Dead since Jul 6. It owns the watcher auto-restart safety net.
+
+## [RESOLVED 2026-07-01] ❓ Enable cross-machine sync?
+Closed in place with the title-prefix convention, above the divider.
+
+# Resolved & archived detail
+
+## ❓ An old question that was already dealt with
+Archived — must never be offered as open.
+"""
+
+STRUCTURED = """# Pending Questions
+
+## Ship the timer tool?
+- **Status:** unanswered
+- **Options:** Yes | No | Later
+"""
+
+
+class TestParse(unittest.TestCase):
+    def test_free_form_questions_are_listed(self):
+        """No **Status:**/**Options:** markers — still open questions."""
+        qs = api.parse_pending_questions(FREE_FORM)
+        self.assertEqual([q["text"] for q in qs], [
+            "❓ Re-auth the Station Gmail connector?",
+            "❓ Rebuild the Swift menu-bar app?",
+        ])
+
+    def test_archive_below_resolved_divider_is_excluded(self):
+        """Sections under `# Resolved` are audit trail, not open questions."""
+        titles = [q["text"] for q in api.parse_pending_questions(FREE_FORM)]
+        self.assertNotIn("❓ An old question that was already dealt with", titles)
+
+    def test_resolved_title_prefix_is_excluded(self):
+        """The free-form format closes a question in place with a [RESOLVED] prefix."""
+        titles = [q["text"] for q in api.parse_pending_questions(FREE_FORM)]
+        self.assertFalse([t for t in titles if "Enable cross-machine sync" in t])
+
+    def test_ids_are_stable_when_the_file_is_rewritten(self):
+        """The agent rewrites this file constantly. An id minted by one GET must
+        still name the same question after unrelated sections move around it —
+        a positional id silently re-points at its neighbour."""
+        before = {q["text"]: q["id"] for q in api.parse_pending_questions(FREE_FORM)}
+        shifted = FREE_FORM.replace(
+            "## ❓ Re-auth",
+            "## ❓ A brand-new question jumped the queue\nBody.\n\n## ❓ Re-auth",
+            1,
         )
+        after = {q["text"]: q["id"] for q in api.parse_pending_questions(shifted)}
+        self.assertEqual(before["❓ Rebuild the Swift menu-bar app?"],
+                         after["❓ Rebuild the Swift menu-bar app?"])
 
-    def test_resolved_prefix_check_present(self):
-        """Parser must skip [RESOLVED ...] sections via title prefix check."""
-        self.assertIn(
-            "startswith('[RESOLVED')",
-            SRC,
-            "Parser must check title.startswith('[RESOLVED') to skip resolved sections",
-        )
+    def test_duplicate_titles_get_distinct_ids(self):
+        dupes = "# Q\n\n## Same title\nOne.\n\n## Same title\nTwo.\n"
+        ids = [q["id"] for q in api.parse_pending_questions(dupes)]
+        self.assertEqual(len(set(ids)), 2, f"ids collided: {ids}")
 
-    def test_status_gate_count_reduced(self):
-        """The **Status:** not in body gate should appear at most once (POST /answer path only).
+    def test_structured_format_still_parses(self):
+        qs = api.parse_pending_questions(STRUCTURED)
+        self.assertEqual(len(qs), 1)
+        self.assertEqual(qs[0]["options"], ["Yes", "No", "Later"])
 
-        The GET /status path should NOT have this gate — it would exclude all free-form
-        questions (which don't have **Status:** markers per post-#1265 convention).
-        """
-        import re
-        # Count occurrences of the status-gate pattern
-        matches = re.findall(r"Status.*not in body|not in body.*Status", SRC)
-        self.assertLessEqual(
-            len(matches), 1,
-            f"Status gate found {len(matches)} times — GET /status path should not "
-            "have this gate (only POST /answer path should use it for finding "
-            "structured questions to update). More than 1 occurrence means the "
-            "GET /status fix was reverted.",
-        )
+    def test_explicitly_answered_section_is_not_open(self):
+        answered = STRUCTURED.replace("**Status:** unanswered", "**Status:** Answered — yes")
+        self.assertEqual(api.parse_pending_questions(answered), [])
 
-    def test_resolved_text_check_not_removed(self):
-        """The **Status:** resolved check in POST /answer must still be present.
 
-        This gate is intentional — when ANSWERING a question, we need to find
-        sections with **Status:** to update. Don't accidentally remove it.
-        """
-        self.assertIn(
-            "resolved|answered|done|complete",
-            SRC,
-            "The **Status:** resolved skip in POST /answer must remain — "
-            "needed to avoid re-answering already-resolved questions",
-        )
+class TestAnswer(unittest.TestCase):
+    def test_free_form_question_is_answerable(self):
+        """The regression: listed by GET /status, then 404 on POST /answer."""
+        qs = api.parse_pending_questions(FREE_FORM)
+        updated = api.answer_pending_question(FREE_FORM, qs[0], "drop it")
+        self.assertIn("drop it", updated)
+        still_open = [q["text"] for q in api.parse_pending_questions(updated)]
+        self.assertNotIn(qs[0]["text"], still_open)
+        # The other question, and the archive, are untouched.
+        self.assertEqual(still_open, ["❓ Rebuild the Swift menu-bar app?"])
+        self.assertIn("## ❓ An old question that was already dealt with", updated)
+
+    def test_answer_silences_the_notifier_too(self):
+        """check-pending-questions.py treats a status-less section as unanswered.
+        If the answer doesn't land on a **Status:** line it keeps DMing the owner
+        hourly about a question they already answered."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pq = Path(tmp) / "pending-questions.md"
+            qs = api.parse_pending_questions(FREE_FORM)
+            pq.write_text(api.answer_pending_question(FREE_FORM, qs[0], "drop it"))
+            cpq.PQ_FILE = pq
+            waiting = [q["title"] for q in cpq.get_waiting_questions()]
+            self.assertNotIn(qs[0]["text"], waiting)
+            self.assertIn("❓ Rebuild the Swift menu-bar app?", waiting)
+
+    def test_structured_status_line_is_updated_in_place(self):
+        qs = api.parse_pending_questions(STRUCTURED)
+        updated = api.answer_pending_question(STRUCTURED, qs[0], "Later")
+        self.assertIn("- **Status:** Answered", updated)  # bullet preserved
+        self.assertNotIn("unanswered", updated)
+        self.assertIn("- **Options:** Yes | No | Later", updated)  # options preserved
+        self.assertEqual(api.parse_pending_questions(updated), [])
+
+    def test_answer_with_regex_escapes_is_written_literally(self):
+        """A raw answer goes into an re.sub replacement — \\1 must not expand."""
+        qs = api.parse_pending_questions(STRUCTURED)
+        updated = api.answer_pending_question(STRUCTURED, qs[0], r"use \1 and \g<0>")
+        self.assertIn(r"use \1 and \g<0>", updated)
+
+    def test_multiline_answer_cannot_forge_a_heading(self):
+        """Answers are collapsed to one line — otherwise '## ' in an answer would
+        inject a new question section."""
+        qs = api.parse_pending_questions(FREE_FORM)
+        updated = api.answer_pending_question(FREE_FORM, qs[0], "yes\n## ❓ injected?\nbody")
+        titles = [q["text"] for q in api.parse_pending_questions(updated)]
+        self.assertNotIn("❓ injected?", titles)
 
 
 if __name__ == "__main__":
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestAgentApiPendingQuestionsParser)
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite([
+        loader.loadTestsFromTestCase(TestParse),
+        loader.loadTestsFromTestCase(TestAnswer),
+    ])
     result = unittest.TextTestRunner(verbosity=2).run(suite)
     sys.exit(0 if result.wasSuccessful() else 1)

--- a/tests/agent-api-pending-questions.test.py
+++ b/tests/agent-api-pending-questions.test.py
@@ -109,6 +109,67 @@ class TestParse(unittest.TestCase):
         ids = [q["id"] for q in api.parse_pending_questions(dupes)]
         self.assertEqual(len(set(ids)), 2, f"ids collided: {ids}")
 
+    def test_duplicate_id_survives_resolving_an_earlier_duplicate(self):
+        """The #2103 review's blocking case: a stale duplicate-title id must
+        never migrate to a neighbour.
+
+        Three open sections share a title. The UI is handed an id for the
+        *second* section; the agent then answers the *first*, rewriting the
+        file. The id the UI still holds must resolve the same (second) section
+        — never the third — or, at worst, 404. It must not silently record the
+        owner's answer against a different question.
+
+        This is the guarantee an occurrence-count suffix (`-2`/`-3`) breaks:
+        answering the first section renumbers the survivors, so `...-2` slides
+        from the second section onto the third.
+        """
+        dupes = (
+            "# Pending Questions\n\n"
+            "## Same title\nFirst — ALPHA.\n\n"
+            "## Same title\nSecond — BRAVO.\n\n"
+            "## Same title\nThird — CHARLIE.\n"
+        )
+        before = api.parse_pending_questions(dupes)
+        self.assertEqual(len(before), 3)
+        id_for_second = before[1]["id"]
+        id_for_third = before[2]["id"]
+
+        # The agent resolves the first duplicate and rewrites the file.
+        rewritten = api.answer_pending_question(dupes, before[0], "done with the first")
+        after = api.parse_pending_questions(rewritten)
+
+        # The originally-issued ids still name their own sections, unchanged.
+        second = next((q for q in after if q["id"] == id_for_second), None)
+        self.assertIsNotNone(second, "the second section's id stopped resolving")
+        self.assertIn("BRAVO", second["detail"])
+        self.assertNotIn("CHARLIE", second["detail"])  # never the neighbour
+
+        third = next((q for q in after if q["id"] == id_for_third), None)
+        self.assertIsNotNone(third)
+        self.assertIn("CHARLIE", third["detail"])
+
+        # And answering through the stale id lands on BRAVO, leaving CHARLIE open.
+        final = api.answer_pending_question(rewritten, second, "picked BRAVO")
+        still_open = api.parse_pending_questions(final)
+        self.assertEqual([q["detail"] for q in still_open], ["Third — CHARLIE."])
+
+    def test_ids_are_independent_of_sibling_count(self):
+        """A section's id must not depend on how many same-title siblings are
+        currently open. Removing an earlier duplicate must leave every survivor's
+        id byte-for-byte identical (no renumbering)."""
+        dupes = (
+            "# Q\n\n"
+            "## Same title\nAlpha body.\n\n"
+            "## Same title\nBravo body.\n\n"
+            "## Same title\nCharlie body.\n"
+        )
+        by_detail = {q["detail"]: q["id"] for q in api.parse_pending_questions(dupes)}
+        # Drop the first duplicate entirely (not just answer it).
+        pruned = dupes.replace("## Same title\nAlpha body.\n\n", "", 1)
+        after = {q["detail"]: q["id"] for q in api.parse_pending_questions(pruned)}
+        self.assertEqual(after["Bravo body."], by_detail["Bravo body."])
+        self.assertEqual(after["Charlie body."], by_detail["Charlie body."])
+
     def test_structured_format_still_parses(self):
         qs = api.parse_pending_questions(STRUCTURED)
         self.assertEqual(len(qs), 1)


### PR DESCRIPTION
## Summary

Answering any question in the web UI's Asks panel fails with `question Q1 not found or already answered`. On a real `pending-questions.md` this reproduces on **every** question — `POST /answer` cannot resolve a single id the UI was given.

`GET /tasks/active` and `POST /answer` each walked the file with their own parser, and the two drifted:

- **The writer's marker gate.** #1265 moved the file to the free-form format (prose sections, no `**Status:**` markers) and the reader was updated for it. The writer still required a `**Status:**`/`**Options:**` line to *recognise* a section (`agent-api.py:888`), so it skipped every free-form question before it ever compared the id → no match → 404 on all of them. The reader lists them; the writer structurally cannot see them.
- **Positional ids.** Ids were `Q<split-index>`, minted fresh on each `GET`. The agent rewrites this file continuously, so an id could name a *different* section by the time the owner clicked answer — a 404, or worse, silently resolving the neighbouring question.
- **No `# Resolved` cut.** The reader never truncated at the divider (`check-pending-questions.py:95` does), so archived entries were listed as open and offered for answering. On my file that was 9 of the 22 sections.

## Fix

Both paths now share `parse_pending_questions()` — one filter, one id scheme. Ids are derived from **each section's own content** (`Q` + sha1[:12] of the whitespace-normalised section), so an id stays valid across rewrites of the file — siblings appearing, being answered, or moving around a section don't change it; each section carries its offsets so the writer splices in place rather than doing a global body-substring `.replace()`.

The answer is recorded as a `**Status:** Answered <date> — <text>` line, **not** a `[RESOLVED]` title prefix: `check-pending-questions.py` treats a status-less section as unanswered, so a title-only marker would drop the question from the dashboard while the notifier kept DMing the owner about it hourly. There's a test pinning that both readers agree.

## Follow-up: duplicate-title id stability (#2103 review)

@qingyun-wu and @liususan091219 caught that the first cut still disambiguated two open sections sharing a title with a live occurrence-count suffix (`-2`, `-3`). That suffix is minted from *how many same-title siblings are open at parse time*, so answering an earlier duplicate renumbers the survivors and a stale id the UI still holds slides onto a **neighbour** — silently recording the owner's answer against the wrong question. Fixed by hashing the whole section (above) instead of `title-hash + count`, so each id is tied to its own section and never renumbers. Identical title *and* body ⇒ same question ⇒ same id, by design.

Before/after, three open sections all titled `Same title` (ALPHA/BRAVO/CHARLIE bodies); the UI is handed the id for the **second** (BRAVO), the agent answers the first, then the UI re-uses its stored id:

```
=== BEFORE (head eb25c4f5) ===
initial ids: [('Qd74bc42c', 'ALPHA'), ('Qd74bc42c-2', 'BRAVO'), ('Qd74bc42c-3', 'CHARLIE')]
UI holds id 'Qd74bc42c-2' for the SECOND (BRAVO) section
RESULT: id 'Qd74bc42c-2' now resolves the 'CHARLIE' section -> *** WRONG: neighbour ***

=== AFTER ===
initial ids: [('Qa29a8af65192', 'ALPHA'), ('Q3f1cccd39e10', 'BRAVO'), ('Q359063a3581f', 'CHARLIE')]
UI holds id 'Q3f1cccd39e10' for the SECOND (BRAVO) section
RESULT: id 'Q3f1cccd39e10' now resolves the 'BRAVO' section -> CORRECT
```

## Relationship to #1855

#1855 fixes the same marker gate and is still open with red CI. This PR is a superset of it and additionally fixes the positional-id drift (#1855 keeps `Q<split-index>` — "Q-numbering already aligned" holds only within a single snapshot of the file) and the missing `# Resolved` cut. #1855's second fix (`ThreadingHTTPServer`) is already on `main`. Happy to close whichever the maintainers prefer — flagged on that thread.

## Test plan

- [x] `tests/agent-api-answer-e2e.test.py` — **new**, now 22 checks. Drives both handlers against a real HTTP server: the id a client is *given* is the id it can *answer* with, the answer lands in the markdown, the agent task file is written, the question drops out of the next listing, and the 404 now only fires when it's actually true (re-answer / unknown id). Serves on the main thread, per the delegation test's note about the coverage tracer. **New block:** three same-title questions over HTTP — answer the first, then reuse the stale id for the second and prove the owner's answer lands on that section (never the neighbour) and the third stays open.
- [x] `tests/agent-api-pending-questions.test.py` — rewritten. It used to assert on agent-api.py's *source text* and explicitly permitted the writer-side gate to remain ("intentional"), so it stayed green for the entire time `/answer` was unusable. Now 14 behavioural tests over the parser: free-form listing, archive cut, `[RESOLVED]` prefix, id stability under file rewrites, duplicate titles, legacy `**Status:**`/`**Options:**` format, notifier agreement, regex-escape-safe answers (`\1` in an answer must not expand through `re.sub`), and heading-injection via a multi-line answer. **New:** `test_duplicate_id_survives_resolving_an_earlier_duplicate` (the review's exact case — resolve an earlier duplicate, prove the originally-issued id still answers its own section, never the neighbour) and `test_ids_are_independent_of_sibling_count`.
- [x] Diff coverage of the follow-up change: **100%** (`diff-cover` on the changed lines; the change is 3 source lines inside the already-covered parser).
- [x] Full related suite green: agent-api ×4, check-pending-questions ×2, friction-detector, morning-briefing, dashboard ×4.
- [x] Reproduced against a real 22-section `pending-questions.md`: before → 404 on every id; after → 13 open questions listed (archive excluded), answering returns 200 and records to the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
