### PR TITLE
fix(credential-proxy): fall back off a doomed scoped token instead of 401-looping

### DIFF
--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -109,6 +109,31 @@ export function keychainServiceCandidates(configDir = process.env.CLAUDE_CONFIG_
 	return [...new Set(services)];
 }
 
+// A keychain OAuth entry is "hard-expired" once its access token's expiry is at
+// or before now — serving it guarantees an upstream 401. No `expiresAt` → we
+// can't tell, so treat as usable (matches the rest of this file's lenient reads).
+export function tokenHardExpired(oauth: ClaudeOAuth, now: number): boolean {
+	return typeof oauth.expiresAt === 'number' && oauth.expiresAt <= now;
+}
+
+// Pure candidate selection for the doomed-token fallback. Given the ordered
+// keychain candidates already read (scoped first, then default), return the
+// first that is NOT hard-expired, optionally skipping one service. This is the
+// automatic equivalent of the manual "delete the scoped entry" workaround: when
+// a scoped token is expired and unrefreshable, a still-valid default entry (kept
+// fresh by interactive `/login`) is preferred over serving a guaranteed-401 token.
+export function firstUsableCandidate(
+	candidates: StoredClaudeOAuth[],
+	now: number,
+	excludeService?: string,
+): StoredClaudeOAuth | null {
+	for (const c of candidates) {
+		if (excludeService && c.service === excludeService) continue;
+		if (!tokenHardExpired(c.oauth, now)) return c;
+	}
+	return null;
+}
+
 // Read the full cred object from one keychain service (not just accessToken).
 function readCredFromService(service: string): StoredClaudeOAuth | null {
 	try {
@@ -130,6 +155,17 @@ function readCred(): StoredClaudeOAuth | null {
 		if (stored) return stored;
 	}
 	return null;
+}
+
+// Read every candidate keychain entry that currently holds a cred (scoped first,
+// then default), so the serve path can fall back off a doomed token to a sibling.
+function readAllCandidates(): StoredClaudeOAuth[] {
+	const out: StoredClaudeOAuth[] = [];
+	for (const service of keychainServiceCandidates()) {
+		const stored = readCredFromService(service);
+		if (stored) out.push(stored);
+	}
+	return out;
 }
 
 // Atomically write the cred back to the keychain. Returns true ONLY after a
@@ -269,9 +305,10 @@ async function getFreshOAuthToken(): Promise<string | null> {
 	const stored = readCred();
 	if (!stored) return null;
 	const { service, oauth: cred } = stored;
+	const now = Date.now();
 	const needsRefresh =
 		typeof cred.expiresAt === 'number' &&
-		cred.expiresAt - Date.now() <= REFRESH_SKEW_MS &&
+		cred.expiresAt - now <= REFRESH_SKEW_MS &&
 		!!cred.refreshToken;
 	if (shouldAttemptRefresh(needsRefresh, Date.now(), nextRefreshAllowedAt)) {
 		if (!refreshInFlight) {
@@ -290,7 +327,29 @@ async function getFreshOAuthToken(): Promise<string | null> {
 			})().finally(() => { refreshInFlight = null; });
 		}
 		await refreshInFlight;
-		return readCredFromService(service)?.oauth.accessToken ?? cred.accessToken;
+		const after = readCredFromService(service)?.oauth;
+		if (after && !tokenHardExpired(after, Date.now())) return after.accessToken;
+		// Refresh failed and the chosen (typically scoped) token is still expired.
+		// Rather than serve a doomed token and 401-loop until someone deletes the
+		// scoped keychain entry by hand, fall back to any other candidate that
+		// still holds a valid token (the default item interactive `/login` keeps
+		// fresh). This automates the manual "delete the scoped entry" workaround.
+		const fallback = firstUsableCandidate(readAllCandidates(), Date.now(), service);
+		if (fallback) {
+			console.error(`${ts()} [Proxy] '${service}' token unrefreshable — serving valid '${fallback.service}' instead`);
+			return fallback.oauth.accessToken;
+		}
+		return after?.accessToken ?? cred.accessToken;
+	}
+	// Not within the refresh-skew window, but if the chosen token is already
+	// hard-expired (e.g. no refreshToken to trigger the refresh path above), still
+	// prefer a fresher sibling over serving a guaranteed-401 token.
+	if (tokenHardExpired(cred, now)) {
+		const fallback = firstUsableCandidate(readAllCandidates(), now, service);
+		if (fallback) {
+			console.error(`${ts()} [Proxy] '${service}' token hard-expired with no usable refresh — serving valid '${fallback.service}' instead`);
+			return fallback.oauth.accessToken;
+		}
 	}
 	return cred.accessToken;
 }

--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -316,44 +316,80 @@ let refreshInFlight: Promise<void> | null = null;
 let refreshFailCount = 0;
 let nextRefreshAllowedAt = 0;
 
+// Injectable seam for the serve decision. Production binds the real keychain
+// readers / refresh / clock / backoff state (`defaultServeDeps` below); the
+// offline test binds fakes so the ACTUAL getFreshOAuthToken composition — not
+// just the pure helpers — is exercised end-to-end (CR #2106, qingyun): the
+// refresh-attempted-but-failed fallback and the cooldown-skipped fallback both
+// run through the real branch structure with controlled dependencies.
+export interface ServeTokenDeps {
+	readCred(): StoredClaudeOAuth | null;
+	readCredFromService(service: string): StoredClaudeOAuth | null;
+	readAllCandidates(): StoredClaudeOAuth[];
+	refreshAccessToken(cred: ClaudeOAuth): Promise<ClaudeOAuth | null>;
+	writeCred(service: string, oauth: ClaudeOAuth): boolean;
+	now(): number;
+	// Failure-backoff state — module-level singletons in production, test-owned
+	// in tests. Read as one snapshot, written as one replacement, so the branch
+	// logic never depends on the storage being module globals.
+	getBackoff(): { failCount: number; nextAllowedAt: number };
+	setBackoff(next: { failCount: number; nextAllowedAt: number }): void;
+	log(msg: string): void;
+	logError(msg: string): void;
+}
+
+const defaultServeDeps: ServeTokenDeps = {
+	readCred,
+	readCredFromService,
+	readAllCandidates,
+	refreshAccessToken,
+	writeCred,
+	now: () => Date.now(),
+	getBackoff: () => ({ failCount: refreshFailCount, nextAllowedAt: nextRefreshAllowedAt }),
+	setBackoff: (n) => { refreshFailCount = n.failCount; nextRefreshAllowedAt = n.nextAllowedAt; },
+	log: (m) => console.log(`${ts()} [Proxy] ${m}`),
+	logError: (m) => console.error(`${ts()} [Proxy] ${m}`),
+};
+
 // Return a usable accessToken, refreshing first if the stored one is at/near
 // expiry. Fail-safe at every step: any problem → return the existing token.
-async function getFreshOAuthToken(): Promise<string | null> {
-	const stored = readCred();
+// `deps` defaults to the real production dependencies; the offline test injects
+// fakes. Behavior with the default deps is identical to the pre-seam version.
+export async function getFreshOAuthToken(deps: ServeTokenDeps = defaultServeDeps): Promise<string | null> {
+	const stored = deps.readCred();
 	if (!stored) return null;
 	const { service, oauth: cred } = stored;
-	const now = Date.now();
+	const now = deps.now();
 	const needsRefresh =
 		typeof cred.expiresAt === 'number' &&
 		cred.expiresAt - now <= REFRESH_SKEW_MS &&
 		!!cred.refreshToken;
-	if (shouldAttemptRefresh(needsRefresh, Date.now(), nextRefreshAllowedAt)) {
+	if (shouldAttemptRefresh(needsRefresh, deps.now(), deps.getBackoff().nextAllowedAt)) {
 		if (!refreshInFlight) {
 			refreshInFlight = (async () => {
-				const fresh = await refreshAccessToken(cred);
-				if (fresh && writeCred(service, fresh)) {
-					refreshFailCount = 0;
-					nextRefreshAllowedAt = 0;
-					console.log(`${ts()} [Proxy] OAuth token refreshed (new expiry ${new Date(fresh.expiresAt ?? 0).toISOString()})`);
+				const fresh = await deps.refreshAccessToken(cred);
+				if (fresh && deps.writeCred(service, fresh)) {
+					deps.setBackoff({ failCount: 0, nextAllowedAt: 0 });
+					deps.log(`OAuth token refreshed (new expiry ${new Date(fresh.expiresAt ?? 0).toISOString()})`);
 				} else {
-					refreshFailCount += 1;
-					const backoff = nextRefreshBackoffMs(refreshFailCount);
-					nextRefreshAllowedAt = Date.now() + backoff;
-					console.error(`${ts()} [Proxy] refresh did not persist — keeping existing token (failure ${refreshFailCount}, backing off ${Math.round(backoff / 1000)}s)`);
+					const failCount = deps.getBackoff().failCount + 1;
+					const backoff = nextRefreshBackoffMs(failCount);
+					deps.setBackoff({ failCount, nextAllowedAt: deps.now() + backoff });
+					deps.logError(`refresh did not persist — keeping existing token (failure ${failCount}, backing off ${Math.round(backoff / 1000)}s)`);
 				}
 			})().finally(() => { refreshInFlight = null; });
 		}
 		await refreshInFlight;
-		const after = readCredFromService(service)?.oauth;
-		if (after && !tokenHardExpired(after, Date.now())) return after.accessToken;
+		const after = deps.readCredFromService(service)?.oauth;
+		if (after && !tokenHardExpired(after, deps.now())) return after.accessToken;
 		// Refresh failed and the chosen (typically scoped) token is still expired.
 		// Rather than serve a doomed token and 401-loop until someone deletes the
 		// scoped keychain entry by hand, fall back to any other candidate that
 		// still holds a valid token (the default item interactive `/login` keeps
 		// fresh). This automates the manual "delete the scoped entry" workaround.
-		const fallback = firstUsableCandidate(readAllCandidates(), Date.now(), service);
+		const fallback = firstUsableCandidate(deps.readAllCandidates(), deps.now(), service);
 		if (fallback) {
-			console.error(`${ts()} [Proxy] '${service}' token unrefreshable — serving valid '${fallback.service}' instead`);
+			deps.logError(`'${service}' token unrefreshable — serving valid '${fallback.service}' instead`);
 			return fallback.oauth.accessToken;
 		}
 		return after?.accessToken ?? cred.accessToken;
@@ -362,9 +398,9 @@ async function getFreshOAuthToken(): Promise<string | null> {
 	// OR the failure-backoff cooldown skipped it (shouldAttemptRefresh false).
 	// In every one of those cases a hard-expired chosen token must still fall
 	// back to a valid sibling rather than serve a guaranteed 401.
-	const served = serveWithoutRefresh(stored, readAllCandidates(), now);
+	const served = serveWithoutRefresh(stored, deps.readAllCandidates(), now);
 	if (served.fellBack) {
-		console.error(`${ts()} [Proxy] '${service}' token hard-expired and refresh unavailable this call — serving valid '${served.via}' instead`);
+		deps.logError(`'${service}' token hard-expired and refresh unavailable this call — serving valid '${served.via}' instead`);
 	}
 	return served.token;
 }

--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -134,6 +134,23 @@ export function firstUsableCandidate(
 	return null;
 }
 
+// Pure serve decision for calls where NO refresh attempt happens this request —
+// outside the skew window, no refreshToken, or (the CR #2106 case) a
+// failure-backoff cooldown skipping the attempt. The doomed-token fallback must
+// hold here exactly as it does post-attempt: a hard-expired chosen token is
+// never served while a valid sibling exists.
+export function serveWithoutRefresh(
+	stored: StoredClaudeOAuth,
+	candidates: StoredClaudeOAuth[],
+	now: number,
+): { token: string; via: string; fellBack: boolean } {
+	if (tokenHardExpired(stored.oauth, now)) {
+		const fb = firstUsableCandidate(candidates, now, stored.service);
+		if (fb) return { token: fb.oauth.accessToken, via: fb.service, fellBack: true };
+	}
+	return { token: stored.oauth.accessToken, via: stored.service, fellBack: false };
+}
+
 // Read the full cred object from one keychain service (not just accessToken).
 function readCredFromService(service: string): StoredClaudeOAuth | null {
 	try {
@@ -341,17 +358,15 @@ async function getFreshOAuthToken(): Promise<string | null> {
 		}
 		return after?.accessToken ?? cred.accessToken;
 	}
-	// Not within the refresh-skew window, but if the chosen token is already
-	// hard-expired (e.g. no refreshToken to trigger the refresh path above), still
-	// prefer a fresher sibling over serving a guaranteed-401 token.
-	if (tokenHardExpired(cred, now)) {
-		const fallback = firstUsableCandidate(readAllCandidates(), now, service);
-		if (fallback) {
-			console.error(`${ts()} [Proxy] '${service}' token hard-expired with no usable refresh — serving valid '${fallback.service}' instead`);
-			return fallback.oauth.accessToken;
-		}
+	// No refresh attempt this call — outside the skew window, no refreshToken,
+	// OR the failure-backoff cooldown skipped it (shouldAttemptRefresh false).
+	// In every one of those cases a hard-expired chosen token must still fall
+	// back to a valid sibling rather than serve a guaranteed 401.
+	const served = serveWithoutRefresh(stored, readAllCandidates(), now);
+	if (served.fellBack) {
+		console.error(`${ts()} [Proxy] '${service}' token hard-expired and refresh unavailable this call — serving valid '${served.via}' instead`);
 	}
-	return cred.accessToken;
+	return served.token;
 }
 
 // Back-compat sync reader (startup probe only — does not refresh).

--- a/tests/credential-proxy-refresh.test.ts
+++ b/tests/credential-proxy-refresh.test.ts
@@ -240,3 +240,83 @@ test('cooldown path: no usable sibling → original token served (fail-safe, nev
 	assert.equal(served.fellBack, false);
 	assert.equal(served.token, 'doomed-scoped-token-aaaaaaaaaa');
 });
+
+// ── CR #2106: exercise the PRODUCTION getFreshOAuthToken composition ──────────
+// The helpers above are covered in isolation, but qingyun's CR asks that the
+// actual serve path — not just the helpers — prove it returns the sibling token
+// at both changed call sites. getFreshOAuthToken now accepts an injectable deps
+// seam, so these tests drive the REAL function with controlled keychain / refresh
+// / clock / backoff and assert the token the production path returns.
+
+import { getFreshOAuthToken, type ServeTokenDeps } from '../skills/quota-tracker/scripts/credential-proxy.ts';
+
+// Build deps that default to {expired scoped chosen, valid default sibling};
+// `over` replaces any leaf; returns the mutable backoff `state` for assertions.
+function makeServeDeps(
+	over: Partial<ServeTokenDeps> = {},
+	initialBackoff: { failCount: number; nextAllowedAt: number } = { failCount: 0, nextAllowedAt: 0 },
+): { deps: ServeTokenDeps; state: { failCount: number; nextAllowedAt: number } } {
+	const state = { ...initialBackoff };
+	const deps: ServeTokenDeps = {
+		readCred: () => scopedDoomed,
+		readCredFromService: (svc) =>
+			svc === scopedDoomed.service ? scopedDoomed
+				: svc === defaultValid.service ? defaultValid : null,
+		readAllCandidates: () => [scopedDoomed, defaultValid],
+		refreshAccessToken: async () => null,
+		writeCred: () => false,
+		now: () => NOW,
+		getBackoff: () => state,
+		setBackoff: (n) => { state.failCount = n.failCount; state.nextAllowedAt = n.nextAllowedAt; },
+		log: () => {},
+		logError: () => {},
+		...over,
+	};
+	return { deps, state };
+}
+
+test('getFreshOAuthToken (prod path): failed refresh with expired scoped + valid default → serves the sibling', async () => {
+	let refreshCalls = 0;
+	const { deps, state } = makeServeDeps({
+		refreshAccessToken: async () => { refreshCalls += 1; return null; },
+	});
+	const tok = await getFreshOAuthToken(deps);
+	assert.equal(tok, 'valid-default-token-bbbbbbbbbb'); // production return, not just a helper
+	assert.equal(refreshCalls, 1);                       // the refresh was actually attempted
+	assert.equal(state.failCount, 1);                    // and the failure armed the backoff
+	assert.ok(state.nextAllowedAt > NOW);
+});
+
+test('getFreshOAuthToken (prod path): cooldown-skipped refresh still falls back off the doomed scoped token', async () => {
+	let refreshCalls = 0;
+	const { deps } = makeServeDeps(
+		{ refreshAccessToken: async () => { refreshCalls += 1; return null; } },
+		{ failCount: 1, nextAllowedAt: NOW + 60_000 }, // active cooldown → shouldAttemptRefresh false
+	);
+	const tok = await getFreshOAuthToken(deps);
+	assert.equal(tok, 'valid-default-token-bbbbbbbbbb'); // serveWithoutRefresh branch, prod path
+	assert.equal(refreshCalls, 0);                       // cooldown genuinely suppressed the attempt
+});
+
+test('getFreshOAuthToken (prod path): successful refresh serves the freshly minted scoped token (no spurious fallback)', async () => {
+	const refreshed = { accessToken: 'freshly-refreshed-token-cccccccc', refreshToken: 'r2', expiresAt: NOW + 3_600_000 };
+	const { deps, state } = makeServeDeps(
+		{
+			refreshAccessToken: async () => refreshed,
+			writeCred: () => true,
+			readCredFromService: (svc) =>
+				svc === scopedDoomed.service ? { service: scopedDoomed.service, oauth: refreshed }
+					: svc === defaultValid.service ? defaultValid : null,
+		},
+		{ failCount: 2, nextAllowedAt: 0 },
+	);
+	const tok = await getFreshOAuthToken(deps);
+	assert.equal(tok, 'freshly-refreshed-token-cccccccc'); // scoped token, refreshed — not a sibling
+	assert.equal(state.failCount, 0);                       // success resets the backoff
+	assert.equal(state.nextAllowedAt, 0);
+});
+
+test('getFreshOAuthToken (prod path): no stored credential → null (unchanged fail-safe)', async () => {
+	const { deps } = makeServeDeps({ readCred: () => null });
+	assert.equal(await getFreshOAuthToken(deps), null);
+});

--- a/tests/credential-proxy-refresh.test.ts
+++ b/tests/credential-proxy-refresh.test.ts
@@ -200,3 +200,43 @@ test('firstUsableCandidate: all hard-expired → null (caller keeps existing beh
 	assert.equal(firstUsableCandidate([cand(scopedSvc, 10), cand(defaultSvc, 20)], 100), null);
 	assert.equal(firstUsableCandidate([], 100), null);
 });
+
+// ── CR #2106: the doomed-token fallback must hold when refresh is SKIPPED ──
+// (failure-backoff cooldown / no refreshToken), not only after a failed attempt.
+
+import { serveWithoutRefresh } from '../skills/quota-tracker/scripts/credential-proxy.ts';
+
+const NOW = 1_000_000;
+const scopedDoomed = {
+	service: 'Claude Code-credentials-scoped01',
+	oauth: { accessToken: 'doomed-scoped-token-aaaaaaaaaa', refreshToken: 'dead', expiresAt: NOW - 60_000 },
+};
+const defaultValid = {
+	service: 'Claude Code-credentials',
+	oauth: { accessToken: 'valid-default-token-bbbbbbbbbb', expiresAt: NOW + 3_600_000 },
+};
+
+test('cooldown skips the refresh attempt (shouldAttemptRefresh false during backoff)', () => {
+	assert.equal(shouldAttemptRefresh(true, NOW, NOW + 60_000), false);
+});
+
+test('cooldown path: hard-expired scoped token falls back to the valid sibling', () => {
+	// This is the exact branch a cooldown-skipped call takes in getFreshOAuthToken.
+	const served = serveWithoutRefresh(scopedDoomed, [scopedDoomed, defaultValid], NOW);
+	assert.equal(served.fellBack, true);
+	assert.equal(served.via, 'Claude Code-credentials');
+	assert.equal(served.token, 'valid-default-token-bbbbbbbbbb');
+});
+
+test('cooldown path: still-valid token is served as-is (no spurious fallback)', () => {
+	const scopedValid = { ...scopedDoomed, oauth: { ...scopedDoomed.oauth, expiresAt: NOW + 120_000 } };
+	const served = serveWithoutRefresh(scopedValid, [scopedValid, defaultValid], NOW);
+	assert.equal(served.fellBack, false);
+	assert.equal(served.token, 'doomed-scoped-token-aaaaaaaaaa');
+});
+
+test('cooldown path: no usable sibling → original token served (fail-safe, never null)', () => {
+	const served = serveWithoutRefresh(scopedDoomed, [scopedDoomed], NOW);
+	assert.equal(served.fellBack, false);
+	assert.equal(served.token, 'doomed-scoped-token-aaaaaaaaaa');
+});

--- a/tests/credential-proxy-refresh.test.ts
+++ b/tests/credential-proxy-refresh.test.ts
@@ -10,12 +10,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import {
+	firstUsableCandidate,
 	keychainServiceCandidates,
 	nextRefreshBackoffMs,
 	parseRefreshResponse,
 	redactForLog,
 	scopedKeychainService,
 	shouldAttemptRefresh,
+	tokenHardExpired,
 } from '../skills/quota-tracker/scripts/credential-proxy.ts';
 
 const base = { accessToken: 'old-access', refreshToken: 'old-refresh', expiresAt: 1000 };
@@ -162,4 +164,39 @@ test('redactForLog: truncates an over-long body', () => {
 	const out = redactForLog(longBody, 300);
 	assert.ok(out.length <= 300 + '…(truncated)'.length, String(out.length));
 	assert.ok(out.endsWith('…(truncated)'));
+});
+
+// --- doomed-token fallback (candidate selection when a scoped token is
+// expired-and-unrefreshable, e.g. the recurring 401 loop cured manually by
+// deleting the scoped keychain entry) ---
+
+test('tokenHardExpired: at/before now → true; future or missing expiresAt → false', () => {
+	assert.equal(tokenHardExpired({ accessToken: A, expiresAt: 100 }, 100), true);  // == now
+	assert.equal(tokenHardExpired({ accessToken: A, expiresAt: 99 }, 100), true);   // before now
+	assert.equal(tokenHardExpired({ accessToken: A, expiresAt: 101 }, 100), false); // future
+	assert.equal(tokenHardExpired({ accessToken: A }, 100), false);                 // unknown → usable
+});
+
+const scopedSvc = 'Claude Code-credentials-c365fc51';
+const defaultSvc = 'Claude Code-credentials';
+const cand = (service: string, expiresAt?: number) => ({ service, oauth: { accessToken: A, refreshToken: 'r', expiresAt } });
+
+test('firstUsableCandidate: expired scoped + valid default → picks default (the auto delete-scoped workaround)', () => {
+	const picked = firstUsableCandidate([cand(scopedSvc, 50), cand(defaultSvc, 999)], 100);
+	assert.equal(picked?.service, defaultSvc);
+});
+
+test('firstUsableCandidate: healthy scoped is preferred (first non-expired wins)', () => {
+	const picked = firstUsableCandidate([cand(scopedSvc, 999), cand(defaultSvc, 999)], 100);
+	assert.equal(picked?.service, scopedSvc);
+});
+
+test('firstUsableCandidate: excludeService skips the just-failed scoped item', () => {
+	const picked = firstUsableCandidate([cand(scopedSvc, 999), cand(defaultSvc, 999)], 100, scopedSvc);
+	assert.equal(picked?.service, defaultSvc);
+});
+
+test('firstUsableCandidate: all hard-expired → null (caller keeps existing behavior)', () => {
+	assert.equal(firstUsableCandidate([cand(scopedSvc, 10), cand(defaultSvc, 20)], 100), null);
+	assert.equal(firstUsableCandidate([], 100), null);
 });


### PR DESCRIPTION
## What

Cures the recurring **credential-proxy 401 crash-loop** whose only known workaround has been to *manually delete the scoped Keychain entry*.

### Root cause
`readCred()` iterates the keychain candidates `[scoped, default]` and returns the **first that holds any cred — regardless of token expiry**:

```ts
for (const service of keychainServiceCandidates()) {
  const stored = readCredFromService(service);
  if (stored) return stored;   // <-- first-present wins, even if expired
}
```

So when a namespaced core's scoped `Claude Code-credentials-<sha256(CLAUDE_CONFIG_DIR)[:8]>` token is expired **and** its refresh 400s (dead/rotated refresh token), `getFreshOAuthToken()` keeps injecting that doomed token → every upstream request 401s → the loop starves the core heartbeat → watchdog kill. Deleting the scoped entry makes `readCredFromService(scoped)` return null, so the proxy falls through to the **default** item (which interactive `/login` keeps fresh) and the 401s clear. That hand-delete has been the standing workaround.

### Fix
In `getFreshOAuthToken()`, when the chosen token is still **hard-expired** after a failed/absent refresh, fall back to any *other* candidate that currently holds a valid token before serving a guaranteed-401 token — i.e. automate the delete-scoped workaround.

**Fail-safe / backward-compatible:** every new branch only *adds* a path to a usable token; if none is found it returns exactly what it returned before (no regression). Healthy scoped nodes are unaffected — their refresh succeeds and the fresh scoped token is returned as today.

## Relationship to sibling PRs
- **#2048** (merged) added the scoped-keychain *read*. This PR adds the missing *fallback* off a scoped token that's expired-and-unrefreshable.
- **#2102** (open) adds refresh-error logging + backoff — damage control, but it does **not** add candidate fallback, so a doomed scoped token still 401-loops without this.

## Tests
Pure selection extracted to `firstUsableCandidate()` / `tokenHardExpired()` and unit-tested offline (no network/keychain): 5 new cases incl. "expired scoped + valid default → picks default", "healthy scoped preferred", exclude-service, all-expired → null. **16/16 pass** (`tsx --test tests/credential-proxy-refresh.test.ts`). `typecheck:skills` clean.

## Evidence
Reproduced by Michael Silton's node ~5× across Jul 14–15 (each cleared by deleting the scoped entry). His question — *"if the proxy reads the default entry, why does deleting the scoped one reliably fix it?"* — is exactly this candidate-fallback gap.

## Note for reviewers
This is the highest-risk auth path, so the change is deliberately additive + fail-safe. Would appreciate @sonichi's eyes on the fallback semantics before merge.