### PR TITLE
fix(tests): honor $CLAUDE_CONFIG_DIR in collaborator-tier test env seed

### DIFF
--- a/tests/discord-bridge-collaborator-tier.test.py
+++ b/tests/discord-bridge-collaborator-tier.test.py
@@ -33,6 +33,7 @@ Exit code: 0 on pass, 1 on fail.
 """
 
 import importlib.util
+import os
 import re
 import sys
 import types
@@ -85,7 +86,7 @@ def _install_discord_stub():
 def load_bridge():
     _install_discord_stub()
     # The bridge reads a DISCORD_BOT_TOKEN .env at import — seed a stub if absent.
-    env_dir = Path.home() / ".claude" / "channels" / "discord"
+    env_dir = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude")) / "channels" / "discord"
     env = env_dir / ".env"
     if not env.exists():
         env_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Follow-up to #2080 (test-only, low severity).

## What
`load_bridge()` in `tests/discord-bridge-collaborator-tier.test.py` seeded the `DISCORD_BOT_TOKEN` stub `.env` at a hardcoded `Path.home()/.claude/channels/discord`, ignoring `$CLAUDE_CONFIG_DIR`.

## Why it matters
On a node with an overridden config dir, the test seeded the **wrong** directory and — via `mkdir(parents=True)` + a stub `.env` write — brushed the PathState empty-`.env`-template trap under `~/.claude`. CI passed only because it leaves `CLAUDE_CONFIG_DIR` unset (defaults to `~/.claude`). Production `src/discord-bridge.py` already honors the override; this aligns the test with it.

Guarded by `if not env.exists()` so a real token is never clobbered — hence low severity, test-only.

## Proof
- Default (`CLAUDE_CONFIG_DIR` unset): PASS, unchanged.
- Overridden (`CLAUDE_CONFIG_DIR=$TMP`): PASS, and the stub `.env` now lands in `$TMP/channels/discord/.env` instead of `~/.claude` — the failure mode is closed.

Stand: Echo Act IV Pro