### PR TITLE
fix(ag2-sparrow): re-sync bundled local_task_protocol.py after #1974 (unbreak main CI)

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -496,12 +496,28 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
 
 def iter_archived_tasks(tasks_dir: Path) -> Iterable[Path]:
     """Yield every archived task file (flat legacy + month-partitioned),
-    for corpus sweeps and golden tests."""
+    for corpus sweeps and golden tests. Skips non-task artefacts (files
+    without a `task:` line) that may accumulate in the archive directory
+    (e.g. `answer-Q*` files from the pending-questions flow)."""
     archive_root = tasks_dir / "archive"
     if not archive_root.is_dir():
         return
     for p in sorted(archive_root.glob("*.txt")):
-        yield p
+        if _has_task_line(p):
+            yield p
     for entry in sorted(archive_root.iterdir()):
         if entry.is_dir() and _MONTH_DIR_RE.match(entry.name):
-            yield from sorted(entry.glob("*.txt"))
+            for p in sorted(entry.glob("*.txt")):
+                if _has_task_line(p):
+                    yield p
+
+
+def _has_task_line(path: Path) -> bool:
+    """True iff `path` contains a `task:` header line — the structural marker
+    that distinguishes a real task file from a non-task artefact that has
+    accumulated in the archive directory."""
+    try:
+        return any(line.startswith("task:") for line in
+                   path.read_text(errors="replace").split("\n"))
+    except OSError:
+        return False


### PR DESCRIPTION
#1974 changed `src/local_task_protocol.py` (added `_has_task_line()`) without running the ag2-sparrow bundle sync, so `tests/ag2-sparrow-drift.test.py` now fails on main — and on every open PR's `tsc + tests` job (e.g. surfaced #2071's CI as red). Re-synced the bundled copy via `packages/ag2-sparrow/tools/sync_from_src.py`; drift test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)