### PR TITLE
fix(ag2-sparrow): re-sync bundled local_task_protocol.py from src (#1974 drift → red main)

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -496,12 +496,28 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
 
 def iter_archived_tasks(tasks_dir: Path) -> Iterable[Path]:
     """Yield every archived task file (flat legacy + month-partitioned),
-    for corpus sweeps and golden tests."""
+    for corpus sweeps and golden tests. Skips non-task artefacts (files
+    without a `task:` line) that may accumulate in the archive directory
+    (e.g. `answer-Q*` files from the pending-questions flow)."""
     archive_root = tasks_dir / "archive"
     if not archive_root.is_dir():
         return
     for p in sorted(archive_root.glob("*.txt")):
-        yield p
+        if _has_task_line(p):
+            yield p
     for entry in sorted(archive_root.iterdir()):
         if entry.is_dir() and _MONTH_DIR_RE.match(entry.name):
-            yield from sorted(entry.glob("*.txt"))
+            for p in sorted(entry.glob("*.txt")):
+                if _has_task_line(p):
+                    yield p
+
+
+def _has_task_line(path: Path) -> bool:
+    """True iff `path` contains a `task:` header line — the structural marker
+    that distinguishes a real task file from a non-task artefact that has
+    accumulated in the archive directory."""
+    try:
+        return any(line.startswith("task:") for line in
+                   path.read_text(errors="replace").split("\n"))
+    except OSError:
+        return False


### PR DESCRIPTION
## What

`tests/ag2-sparrow-drift.test.py` (the **"tsc + tests (clean install)"** check) is **red on `main`**, which turns that check red on **every open PR** for an unrelated reason.

**Root cause:** #1974 (merged 2026-07-14) changed `src/local_task_protocol.py` (added `_has_task_line`, scoped `iter_archived_tasks` to files with a `task:` line) but didn't re-run the ag2-sparrow bundle sync, so `packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py` drifted. And because `test:py` runs `find tests -name '*.test.py' | sort | while read f; do … || exit 1`, the alphabetically-early `ag2-sparrow-drift` failure **halts the entire Python suite** before any later test runs — so the whole check goes red.

## Fix

`python3 packages/ag2-sparrow/tools/sync_from_src.py` — re-syncs the one drifted module (`task_archive` / `result_markers` were already in sync). **No src logic change**; the bundle now matches `src/` verbatim.

```
$ python3 tests/ag2-sparrow-drift.test.py
PASS — ag2-sparrow bundled utils in sync with src/
```

Single-file, mechanical. Unblocks the CI check for the whole open-PR queue.