### PR TITLE
test(slack-bridge): isolate ACCESS_FILE so tier-map test can't delete the real access.json

### DIFF
--- a/tests/slack-bridge-tier-map.test.py
+++ b/tests/slack-bridge-tier-map.test.py
@@ -68,6 +68,13 @@ def _load_module():
     sys.path.insert(0, str(repo / "src"))
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
+    # Isolate ACCESS_FILE from the REAL slack access.json — this test writes to
+    # it (invalid-JSON case) and unlinks it. ACCESS_FILE resolves via
+    # CLAUDE_CONFIG_DIR (the SUTANDO_WORKSPACE temp above does NOT cover it), so
+    # without this a local run with CLAUDE_CONFIG_DIR set would clobber + DELETE
+    # the owner's real allowlist. Same guard the tofu-enroll / mod-judge-buffer
+    # tests already use.
+    mod.ACCESS_FILE = Path(tempfile.mkdtemp(prefix="sutando-tier-access-")) / "access.json"
     return mod
 
 


### PR DESCRIPTION
## What

`tests/slack-bridge-tier-map.test.py` writes test payloads (including an invalid-JSON case) to `mod.ACCESS_FILE` and then `unlink()`s it — but it **never redirects `ACCESS_FILE` to a temp path**. `ACCESS_FILE` resolves via `CLAUDE_CONFIG_DIR` (the `SUTANDO_WORKSPACE` temp the test sets does **not** cover it), so a **local** run with `CLAUDE_CONFIG_DIR` set **clobbers and then DELETES the owner's real Slack allowlist** — after which the bridge drops the owner as non-allowlisted.

CI is unaffected (there `CLAUDE_CONFIG_DIR` is unset → clean `~/.claude`), which is why it's gone unnoticed — but there's **no conftest** isolating `CLAUDE_CONFIG_DIR` (tests run standalone via `find tests | python3`), so each test must isolate `ACCESS_FILE` itself.

## Fix

Redirect `mod.ACCESS_FILE` to a `tempfile.mkdtemp()` path right after the module loads — the **same guard** `slack-bridge-tofu-enroll.test.py`, `telegram-bridge-tofu.test.py`, and `discord-bridge-mod-judge-buffer.test.py` already use.

## Verified
```
$ CLAUDE_CONFIG_DIR=<live dir> python3 tests/slack-bridge-tier-map.test.py
Results: 14 passed, 0 failed
```
Real `access.json` md5 is **identical before/after** the run (owner allowlist intact) — the temp redirect fully isolates it.

## Context
Found while auditing the test suite after a sibling test hit this exact class of bug and took the owner's Discord + Slack access down live. This is the only other unisolated `ACCESS_FILE`-writing test.