### PR TITLE
feat(config): sutando-config.sh runtime + tmux-socket — OSS-side AgentRuntime resolver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,13 +132,19 @@ unlinked so peers see a graceful shutdown immediately.
 
 Payload schema:
 ```json
-{"host": "...", "pid": ..., "started_at": ..., "last_beat_at": ..., "status": "...", "schema_version": 1}
+{"host": "...", "pid": ..., "started_at": ..., "last_beat_at": ..., "status": "...", "socket": "...", "schema_version": 1}
 ```
 
 This is foundation for the lease-based multi-core scheduler — workers consult
 the alive directory to know who's available before assigning a claim. For
 single-machine use today it also gives `health-check.py` and the dashboard a
 cleaner liveness probe than scanning `pgrep -f claude`.
+
+`socket` records the tmux socket the core launched on (its own
+`${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}`). It's the **runtime-authored**
+answer to "which socket?" — read by `sutando-config.sh runtime` so the
+AgentRuntime descriptor reports the real socket (custom sockets included)
+without trusting a foreign caller's ambient env.
 
 ## Durable per-host install state: `state/auth/`
 

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -264,8 +264,66 @@ print(_host_label(), end='')
     echo "workspace bootstrapped: $ws" >&2
     ;;
 
+  tmux-socket)
+    # Print the tmux socket the sutando-core session runs on. Mirrors the
+    # resolution in src/agent/claude/cli/start-cli.sh (`${SUTANDO_TMUX_SOCKET:-
+    # /tmp/sutando-tmux.sock}`) so a caller resolves the same socket the core
+    # actually launched on. Contract sibling of `workspace` — resolve via helper,
+    # never hardcode /tmp/sutando-tmux.sock. NOTE: for a FOREIGN caller (e.g. the
+    # desktop app, whose own env may point SUTANDO_TMUX_SOCKET at a private
+    # bundled socket) prefer the env-independent `runtime` subcommand below,
+    # which pins to the default OSS socket. This getter honors the ambient env
+    # and is meant for same-runtime callers.
+    printf '%s' "${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}"
+    ;;
+
+  runtime)
+    # Emit this install's AgentRuntime descriptor as one JSON object — the single
+    # OSS-side contract the desktop app reads to resolve which runtime to attach
+    # its Terminal to, route task-drops/gateway to, and decide port-vs-new
+    # (issue ag2-space/ag2space-cinny-desktop#98). Keyed on the repo; everything
+    # else derives:
+    #   {alive, repo, workspace, brain, socket, session, health, authenticated}
+    # FOREIGN-CALLER-SAFE: the liveness probe is pinned to the default OSS socket
+    # (/tmp/sutando-tmux.sock) so a caller whose OWN env points SUTANDO_TMUX_SOCKET
+    # at a different (e.g. bundled) socket still gets THIS OSS runtime's status,
+    # never the caller's socket (the re-split trap). Non-default OSS sockets are a
+    # documented fast-follow (record the real socket in the .alive heartbeat).
+    # Reuses src/runtime-health.py for alive/health/authenticated (single liveness
+    # source of truth) and adds the resolved repo / workspace / brain paths.
+    python3 -c "
+import sys, os, json, subprocess
+sys.path.insert(0, '$REPO_ROOT')
+from src.sutando_config import resolve_workspace
+repo = '$REPO_ROOT'
+ws = str(resolve_workspace())
+brain = os.path.join(ws, '.claude-sutando')
+# Pin the probe to the default OSS socket — env-independent, so a foreign
+# caller's SUTANDO_TMUX_SOCKET (bundled) can't misdirect it.
+env = dict(os.environ, SUTANDO_TMUX_SOCKET='/tmp/sutando-tmux.sock')
+h = {}
+try:
+    out = subprocess.run([sys.executable, os.path.join(repo, 'src', 'runtime-health.py')],
+                         capture_output=True, text=True, timeout=15, env=env, cwd=repo)
+    if out.stdout.strip():
+        h = json.loads(out.stdout)
+except Exception:
+    pass
+print(json.dumps({
+    'alive': bool(h.get('core_running', False)),
+    'repo': repo,
+    'workspace': ws,
+    'brain': brain,
+    'socket': h.get('tmux_socket') or '/tmp/sutando-tmux.sock',
+    'session': h.get('session', 'sutando-core'),
+    'health': h.get('health', 'unknown'),
+    'authenticated': h.get('authenticated'),
+}))
+"
+    ;;
+
   *)
-    echo "usage: $0 {workspace|vault-enabled|vault-url|vault-sync-include|vault-sync-exclude|claude-sutando-config-dir|claude-home-path <subpath>|core-config-dir-env-name [type|id]|core-config-dir-value [type|id]|core-config-dirs|host-label|dump|subdirs|bootstrap}" >&2
+    echo "usage: $0 {workspace|vault-enabled|vault-url|vault-sync-include|vault-sync-exclude|claude-sutando-config-dir|claude-home-path <subpath>|core-config-dir-env-name [type|id]|core-config-dir-value [type|id]|core-config-dirs|host-label|tmux-socket|runtime|dump|subdirs|bootstrap}" >&2
     exit 2
     ;;
 esac

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -309,9 +309,31 @@ try:
         h = json.loads(out.stdout)
 except Exception:
     pass
+# code: the source-version identity of the runtime — 'which Sutando is this,
+# behaviorally?' Prompts + skills + scripts in the repo determine behavior, so
+# the desktop app (and fleet tooling) wants this to reason about version-compat
+# and to spot a locally-modified core. All git-native + best-effort (None when
+# not a git checkout). tree_sha is the content hash of TRACKED files (version-
+# independent); dirty flags uncommitted edits. A stronger working-tree
+# 'source_sha' (hashes uncommitted + untracked behavior files) is a documented
+# follow-up alongside the identity block.
+def _git(*a):
+    try:
+        r = subprocess.run(['git', '-C', repo, *a], capture_output=True, text=True, timeout=5)
+        return (r.stdout.strip() or None) if r.returncode == 0 else None
+    except Exception:
+        return None
+code = {
+    'commit': _git('rev-parse', '--short', 'HEAD'),
+    'branch': _git('rev-parse', '--abbrev-ref', 'HEAD'),
+    'describe': _git('describe', '--tags', '--always', '--dirty'),
+    'tree_sha': _git('rev-parse', 'HEAD^{tree}'),
+    'dirty': bool(_git('status', '--porcelain')),
+}
 print(json.dumps({
     'alive': bool(h.get('core_running', False)),
     'repo': repo,
+    'code': code,
     'workspace': ws,
     'brain': brain,
     'socket': h.get('tmux_socket') or '/tmp/sutando-tmux.sock',

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -306,8 +306,14 @@ brain = str(resolve_claude_sutando_config_dir())
 # FRESH heartbeat (<90s, matching core-heartbeat's liveness window) is trusted;
 # stale/absent -> default OSS socket.
 def _host_label():
+    # Must match the WRITER's resolution exactly (core_heartbeat.py names the
+    # .alive file via util_paths._host_label, honoring \$SUTANDO_HOST_LABEL /
+    # \$SUTANDO_HOST_OVERRIDE). REPO_ROOT (not REPO_ROOT/src) is on sys.path here,
+    # so the import is 'src.util_paths' — matching 'from src.sutando_config'
+    # above; a bare 'from util_paths' silently fails to sys.path and would fall
+    # back to gethostname(), losing the label (review catch on c91a68c).
     try:
-        from util_paths import _host_label as hl
+        from src.util_paths import _host_label as hl
         return hl()
     except Exception:
         import socket as _s

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -284,23 +284,43 @@ print(_host_label(), end='')
     # (issue ag2-space/ag2space-cinny-desktop#98). Keyed on the repo; everything
     # else derives:
     #   {alive, repo, workspace, brain, socket, session, health, authenticated}
-    # FOREIGN-CALLER-SAFE: the liveness probe is pinned to the default OSS socket
-    # (/tmp/sutando-tmux.sock) so a caller whose OWN env points SUTANDO_TMUX_SOCKET
-    # at a different (e.g. bundled) socket still gets THIS OSS runtime's status,
-    # never the caller's socket (the re-split trap). Non-default OSS sockets are a
-    # documented fast-follow (record the real socket in the .alive heartbeat).
-    # Reuses src/runtime-health.py for alive/health/authenticated (single liveness
-    # source of truth) and adds the resolved repo / workspace / brain paths.
+    # FOREIGN-CALLER-SAFE *and* honors custom sockets: the tmux socket is read
+    # from a RUNTIME-AUTHORED source (the core's .alive heartbeat, which records
+    # the socket the core actually launched on — see core_heartbeat.py), NOT the
+    # caller's ambient SUTANDO_TMUX_SOCKET. So a foreign caller (the desktop app,
+    # whose env points at its bundled socket) still gets THIS OSS core's real
+    # socket, AND an install running on a custom socket is reported correctly
+    # (start-cli.sh honors SUTANDO_TMUX_SOCKET). No fresh heartbeat -> default OSS
+    # socket. Reuses src/runtime-health.py for alive/health/authenticated (single
+    # liveness source of truth) and the canonical resolve_claude_sutando_config_dir()
+    # for brain (honors core_config_dirs[type=claude] customization).
     python3 -c "
-import sys, os, json, subprocess
+import sys, os, json, time, subprocess
 sys.path.insert(0, '$REPO_ROOT')
-from src.sutando_config import resolve_workspace
+from src.sutando_config import resolve_workspace, resolve_claude_sutando_config_dir
 repo = '$REPO_ROOT'
 ws = str(resolve_workspace())
-brain = os.path.join(ws, '.claude-sutando')
-# Pin the probe to the default OSS socket — env-independent, so a foreign
-# caller's SUTANDO_TMUX_SOCKET (bundled) can't misdirect it.
-env = dict(os.environ, SUTANDO_TMUX_SOCKET='/tmp/sutando-tmux.sock')
+brain = str(resolve_claude_sutando_config_dir())
+# The socket this core runs on, from its own heartbeat: runtime-authored, so it
+# is correct for custom sockets AND immune to the caller's ambient env. Only a
+# FRESH heartbeat (<90s, matching core-heartbeat's liveness window) is trusted;
+# stale/absent -> default OSS socket.
+def _host_label():
+    try:
+        from util_paths import _host_label as hl
+        return hl()
+    except Exception:
+        import socket as _s
+        return _s.gethostname().split('.')[0]
+probe_socket = '/tmp/sutando-tmux.sock'
+try:
+    with open(os.path.join(ws, 'state', 'cores', _host_label() + '.alive')) as f:
+        rec = json.load(f)
+    if time.time() - float(rec.get('last_beat_at', 0)) < 90 and rec.get('socket'):
+        probe_socket = rec['socket']
+except Exception:
+    pass
+env = dict(os.environ, SUTANDO_TMUX_SOCKET=probe_socket)
 h = {}
 try:
     out = subprocess.run([sys.executable, os.path.join(repo, 'src', 'runtime-health.py')],
@@ -336,7 +356,7 @@ print(json.dumps({
     'code': code,
     'workspace': ws,
     'brain': brain,
-    'socket': h.get('tmux_socket') or '/tmp/sutando-tmux.sock',
+    'socket': h.get('tmux_socket') or probe_socket,
     'session': h.get('session', 'sutando-core'),
     'health': h.get('health', 'unknown'),
     'authenticated': h.get('authenticated'),

--- a/src/core_heartbeat.py
+++ b/src/core_heartbeat.py
@@ -89,6 +89,13 @@ def write_beat(status: str = "running") -> None:
         "started_at": _STARTED_AT,
         "last_beat_at": time.time(),
         "status": status,
+        # The tmux socket THIS core actually runs on. Recorded here — in the
+        # core's own environment — so it is the authoritative, runtime-authored
+        # answer to "which socket?" for readers that cannot reconstruct the
+        # launch env (e.g. `sutando-config.sh runtime` invoked by the desktop
+        # app, whose ambient SUTANDO_TMUX_SOCKET points at a *different* bundled
+        # socket). Mirrors start-cli.sh's resolution exactly.
+        "socket": os.environ.get("SUTANDO_TMUX_SOCKET", "/tmp/sutando-tmux.sock"),
         "schema_version": 1,
     }
     tmp = target.with_suffix(".alive.tmp")

--- a/tests/core-heartbeat.test.py
+++ b/tests/core-heartbeat.test.py
@@ -55,6 +55,13 @@ class TestHeartbeatWrite(unittest.TestCase):
         self.assertEqual(data["pid"], os.getpid())
         self.assertEqual(data["status"], "custom-status")
         self.assertEqual(data["schema_version"], 1)
+        # socket: the runtime-authored tmux socket the core runs on. Consumed by
+        # `sutando-config.sh runtime` so the AgentRuntime descriptor reports the
+        # real socket (incl. custom sockets) independent of a caller's env.
+        self.assertEqual(
+            data["socket"],
+            os.environ.get("SUTANDO_TMUX_SOCKET", "/tmp/sutando-tmux.sock"),
+        )
         self.assertIsInstance(data["started_at"], float)
         self.assertIsInstance(data["last_beat_at"], float)
         # last_beat_at advances after a sleep; just sanity-check it's recent.

--- a/tests/sutando-config-runtime.test.sh
+++ b/tests/sutando-config-runtime.test.sh
@@ -72,22 +72,22 @@ sock="$(SUTANDO_TMUX_SOCKET=/tmp/bundled-fake.sock bash "$SCRIPT" runtime \
 # .alive heartbeat (runtime-authored), so we plant a fresh heartbeat recording a
 # custom socket + a live sutando-core session there, point the resolver at that
 # workspace, and assert `runtime` reports it.
-echo "[5] runtime → honors a custom socket recorded in the .alive heartbeat"
+echo "[5] runtime → honors a custom socket via heartbeat, resolving the host label like the writer (SUTANDO_HOST_LABEL)"
 if command -v tmux >/dev/null 2>&1; then
   CFG="$REPO_DIR/sutando.config.local.json"; CFG_BAK=""
   [ -f "$CFG" ] && { CFG_BAK="$(mktemp)"; cp "$CFG" "$CFG_BAK"; }
-  T5WS="$(mktemp -d)"; CUSTOM="/tmp/pr2113-runtime-test-$$.sock"
-  HOST="$(python3 -c "import sys;sys.path.insert(0,'$REPO_DIR');
-try:
-    from util_paths import _host_label; print(_host_label())
-except Exception:
-    import socket; print(socket.gethostname().split('.')[0])")"
+  T5WS="$(mktemp -d)"; CUSTOM="/tmp/pr2113-runtime-test-$$.sock"; LBL="pr2113-review-host"
   mkdir -p "$T5WS/state/cores"
   tmux -S "$CUSTOM" new-session -d -s sutando-core 'sleep 120' 2>/dev/null
-  python3 -c "import json,time;json.dump({'host':'$HOST','last_beat_at':time.time(),'socket':'$CUSTOM','schema_version':1},open('$T5WS/state/cores/$HOST.alive','w'))"
+  # Heartbeat written under the LABEL — as core_heartbeat.py would when
+  # SUTANDO_HOST_LABEL is set (it names the file via util_paths._host_label).
+  python3 -c "import json,time;json.dump({'host':'$LBL','last_beat_at':time.time(),'socket':'$CUSTOM','schema_version':1},open('$T5WS/state/cores/$LBL.alive','w'))"
   printf '{\"workspace\":{\"path\":\"%s\"}}' "$T5WS" > "$CFG"
-  sock5="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["socket"])')"
-  [ "$sock5" = "$CUSTOM" ]; report "$?" "socket=$sock5 == custom $CUSTOM (heartbeat-authored, not default)"
+  # The reader must resolve the SAME label to find the heartbeat. Regression for
+  # the c91a68c review: a bare `from util_paths` fell back to gethostname(),
+  # missed the labelled file, and returned the default socket.
+  sock5="$(SUTANDO_HOST_LABEL="$LBL" bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["socket"])')"
+  [ "$sock5" = "$CUSTOM" ]; report "$?" "socket=$sock5 == custom $CUSTOM (heartbeat found via SUTANDO_HOST_LABEL, not default)"
   tmux -S "$CUSTOM" kill-server 2>/dev/null
   rm -rf "$T5WS"; rm -f "$CFG"; [ -n "$CFG_BAK" ] && mv "$CFG_BAK" "$CFG"
 else

--- a/tests/sutando-config-runtime.test.sh
+++ b/tests/sutando-config-runtime.test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# tests/sutando-config-runtime.test.sh — E2E smoke for the `tmux-socket` and
+# `runtime` subcommands on scripts/sutando-config.sh.
+#
+# These are the OSS-side AgentRuntime resolution contract consumed by the
+# desktop app (ag2-space/ag2space-cinny-desktop#98) to decide which runtime to
+# attach its Terminal to / route task-drops to / port-vs-new. The load-bearing
+# property under test is FOREIGN-CALLER SAFETY: a caller whose own env points
+# SUTANDO_TMUX_SOCKET at a different (bundled) socket must still get THIS OSS
+# runtime's socket from `runtime` — never the caller's — else the split-brain
+# the contract exists to prevent reappears.
+#
+# Run: bash tests/sutando-config-runtime.test.sh
+# Exit: 0 = all pass, 1 = failure
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_DIR/scripts/sutando-config.sh"
+DEFAULT_SOCK="/tmp/sutando-tmux.sock"
+
+pass=0; fail=0
+report() {
+  if [ "$1" = "0" ]; then
+    echo "  PASS: $2"; pass=$((pass+1))
+  else
+    echo "  FAIL: $2"; fail=$((fail+1))
+  fi
+}
+
+# -- Test 1: tmux-socket default -------------------------------------------
+echo "[1] tmux-socket → default OSS socket when env unset"
+out="$(env -u SUTANDO_TMUX_SOCKET bash "$SCRIPT" tmux-socket)"
+[ "$out" = "$DEFAULT_SOCK" ]; report "$?" "prints $DEFAULT_SOCK ($out)"
+
+# -- Test 2: tmux-socket honors ambient env (same-runtime caller) -----------
+echo "[2] tmux-socket → honors ambient SUTANDO_TMUX_SOCKET"
+out="$(SUTANDO_TMUX_SOCKET=/tmp/custom.sock bash "$SCRIPT" tmux-socket)"
+[ "$out" = "/tmp/custom.sock" ]; report "$?" "prints the ambient socket ($out)"
+
+# -- Test 3: runtime emits valid JSON with the full descriptor --------------
+echo "[3] runtime → valid JSON with all descriptor keys"
+json="$(bash "$SCRIPT" runtime)"
+echo "$json" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+need={'alive','repo','workspace','brain','socket','session','health','authenticated'}
+missing=need - set(d)
+assert not missing, f'missing keys: {missing}'
+assert d['repo']=='$REPO_DIR', f\"repo {d['repo']} != $REPO_DIR\"
+assert d['brain']==d['workspace']+'/.claude-sutando', f\"brain {d['brain']}\"
+assert d['session']=='sutando-core', d['session']
+assert isinstance(d['alive'], bool), d['alive']
+"
+report "$?" "JSON valid; repo/brain/session/alive correct"
+
+# -- Test 4: FOREIGN-CALLER SAFETY (the anti-split guarantee) ---------------
+# A caller whose env points at a bundled socket must NOT leak into runtime.socket.
+echo "[4] runtime → socket is env-independent (foreign-caller safe)"
+sock="$(SUTANDO_TMUX_SOCKET=/tmp/bundled-fake.sock bash "$SCRIPT" runtime \
+        | python3 -c 'import json,sys;print(json.load(sys.stdin)["socket"])')"
+[ "$sock" = "$DEFAULT_SOCK" ]; report "$?" "socket=$sock stays $DEFAULT_SOCK despite bundled env (no re-split)"
+
+echo
+echo "sutando-config-runtime: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/sutando-config-runtime.test.sh
+++ b/tests/sutando-config-runtime.test.sh
@@ -44,15 +44,20 @@ json="$(bash "$SCRIPT" runtime)"
 echo "$json" | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
-need={'alive','repo','workspace','brain','socket','session','health','authenticated'}
+need={'alive','repo','code','workspace','brain','socket','session','health','authenticated'}
 missing=need - set(d)
 assert not missing, f'missing keys: {missing}'
 assert d['repo']=='$REPO_DIR', f\"repo {d['repo']} != $REPO_DIR\"
 assert d['brain']==d['workspace']+'/.claude-sutando', f\"brain {d['brain']}\"
 assert d['session']=='sutando-core', d['session']
 assert isinstance(d['alive'], bool), d['alive']
+# code = source-version identity block (git-derived; keys always present, values may be null off-git)
+c=d['code']
+for k in ('commit','branch','describe','tree_sha','dirty'):
+    assert k in c, f'code missing {k}'
+assert isinstance(c['dirty'], bool), c['dirty']
 "
-report "$?" "JSON valid; repo/brain/session/alive correct"
+report "$?" "JSON valid; repo/brain/session/alive + code block correct"
 
 # -- Test 4: FOREIGN-CALLER SAFETY (the anti-split guarantee) ---------------
 # A caller whose env points at a bundled socket must NOT leak into runtime.socket.

--- a/tests/sutando-config-runtime.test.sh
+++ b/tests/sutando-config-runtime.test.sh
@@ -66,6 +66,52 @@ sock="$(SUTANDO_TMUX_SOCKET=/tmp/bundled-fake.sock bash "$SCRIPT" runtime \
         | python3 -c 'import json,sys;print(json.load(sys.stdin)["socket"])')"
 [ "$sock" = "$DEFAULT_SOCK" ]; report "$?" "socket=$sock stays $DEFAULT_SOCK despite bundled env (no re-split)"
 
+# -- Test 5: custom socket is honored via the runtime-authored heartbeat --------
+# Regression for the #2113 review (High): an OSS core on a NON-default socket must
+# still be reported alive on THAT socket. The socket is sourced from the core's
+# .alive heartbeat (runtime-authored), so we plant a fresh heartbeat recording a
+# custom socket + a live sutando-core session there, point the resolver at that
+# workspace, and assert `runtime` reports it.
+echo "[5] runtime → honors a custom socket recorded in the .alive heartbeat"
+if command -v tmux >/dev/null 2>&1; then
+  CFG="$REPO_DIR/sutando.config.local.json"; CFG_BAK=""
+  [ -f "$CFG" ] && { CFG_BAK="$(mktemp)"; cp "$CFG" "$CFG_BAK"; }
+  T5WS="$(mktemp -d)"; CUSTOM="/tmp/pr2113-runtime-test-$$.sock"
+  HOST="$(python3 -c "import sys;sys.path.insert(0,'$REPO_DIR');
+try:
+    from util_paths import _host_label; print(_host_label())
+except Exception:
+    import socket; print(socket.gethostname().split('.')[0])")"
+  mkdir -p "$T5WS/state/cores"
+  tmux -S "$CUSTOM" new-session -d -s sutando-core 'sleep 120' 2>/dev/null
+  python3 -c "import json,time;json.dump({'host':'$HOST','last_beat_at':time.time(),'socket':'$CUSTOM','schema_version':1},open('$T5WS/state/cores/$HOST.alive','w'))"
+  printf '{\"workspace\":{\"path\":\"%s\"}}' "$T5WS" > "$CFG"
+  sock5="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["socket"])')"
+  [ "$sock5" = "$CUSTOM" ]; report "$?" "socket=$sock5 == custom $CUSTOM (heartbeat-authored, not default)"
+  tmux -S "$CUSTOM" kill-server 2>/dev/null
+  rm -rf "$T5WS"; rm -f "$CFG"; [ -n "$CFG_BAK" ] && mv "$CFG_BAK" "$CFG"
+else
+  echo "  SKIP: tmux not available"
+fi
+
+# -- Test 6: brain follows the canonical claude-config resolver ------------------
+# Regression for the #2113 review (Medium): runtime.brain must match
+# resolve_claude_sutando_config_dir(), including a customized core_config_dirs.
+echo "[6] runtime.brain == canonical resolver under a custom core_config_dirs[type=claude]"
+CFG="$REPO_DIR/sutando.config.local.json"; CFG_BAK=""
+[ -f "$CFG" ] && { CFG_BAK="$(mktemp)"; cp "$CFG" "$CFG_BAK"; }
+T6WS="$(mktemp -d)"
+cat > "$CFG" <<JSON
+{
+  "workspace": {"path": "$T6WS"},
+  "core_config_dirs": [{"id":"claude-custom","type":"claude","env_name":"CLAUDE_CONFIG_DIR","value":"\${WORKSPACE_DIR}/custom-claude-state","synced":true}]
+}
+JSON
+canon="$(bash "$SCRIPT" claude-sutando-config-dir)"
+brain6="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["brain"])')"
+[ "$brain6" = "$canon" ]; report "$?" "brain=$brain6 == canonical $canon (not hardcoded .claude-sutando)"
+rm -rf "$T6WS"; rm -f "$CFG"; [ -n "$CFG_BAK" ] && mv "$CFG_BAK" "$CFG"
+
 echo
 echo "sutando-config-runtime: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

Two subcommands on `scripts/sutando-config.sh` that expose this install's runtime as a resolvable contract:

- **`tmux-socket`** → the socket the `sutando-core` session runs on (`${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}`), mirroring `src/agent/claude/cli/start-cli.sh`.
- **`runtime`** → the **AgentRuntime** descriptor as one JSON object, keyed on the repo; everything else derives:
  ```json
  {"alive": true, "repo": "...", "workspace": "...", "brain": "<ws>/.claude-sutando",
   "socket": "/tmp/sutando-tmux.sock", "session": "sutando-core",
   "health": "working", "authenticated": true}
  ```
  Reuses `src/runtime-health.py` for `alive`/`health`/`authenticated` (single liveness source of truth) and adds the resolved `repo` / `workspace` / `brain` paths.

## Why

The AG2 Space desktop app (ag2-space/ag2space-cinny-desktop#98) needs to resolve **which** Sutando runtime to attach its Terminal to, route task-drops/gateway to, and decide *port-vs-new* — through one contract, not hardcoded paths. When it hardcodes or guesses, you get **split-brain**: two `sutando-core` sessions on two sockets (the bundled core vs the user's OSS core), Terminal showing one while task-drop hits the other. This resolver is the OSS-side half of the fix; the desktop consumes it in that repo's #99 (Terminal-attach + spawn-decision).

## Foreign-caller safety (the load-bearing property)

`runtime` pins its liveness probe to the **default OSS socket**, independent of the caller's ambient `SUTANDO_TMUX_SOCKET`. A desktop app whose own env points that var at a private *bundled* socket still gets **this** OSS runtime's status — never the caller's socket. Without this, shelling the helper from the app process would re-introduce the exact split the contract prevents. Test 4 asserts it.

## Scope

Resolver + test only. Non-default OSS sockets (rare — nearly everyone runs the default `/tmp/sutando-tmux.sock`) are a documented fast-follow: record the real socket in the `.alive` heartbeat so `runtime` can report it authoritatively.

## Test

`bash tests/sutando-config-runtime.test.sh` — 4 cases: default socket, ambient-env honoring, full descriptor shape, and the foreign-caller anti-split guarantee.

— @sutando-qingyun-001
