### PR TITLE
fix(core-supervisor): idle core no longer false-flagged 'hung' (#2112)

### DIFF
--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -178,6 +178,16 @@ def classify(pane: str):
     return "unknown", tail
 
 
+def _is_idle_ready(pane: str) -> bool:
+    """True when the pane POSITIVELY shows the idle-ready prompt (the bypass /
+    for-agents footer) and no gate signature — the core is sitting ready for a
+    task. Distinct from `classify(pane) is None`, which is ALSO None for a
+    no-affordance pane (mid-processing / blank / frozen); that must NOT be read as
+    idle. Mirrors classify()'s idle-footer suppression."""
+    tail = "\n".join([ln for ln in pane.splitlines() if ln.strip()][-14:])
+    return bool(_IDLE.search(tail)) and not any(rx.search(tail) for _, rx in _SIGNATURES)
+
+
 # runtime-health health string → supervisor state, for the non-gate branches.
 _BASE_TO_STATE = {
     "offline": ("crashed", "core process/session not found"),
@@ -216,6 +226,16 @@ def compose_state(pane, base_health, gateway_alive):
         return "gateway-down", "core up but relay gateway not running", None, None
     state, detail = _BASE_TO_STATE.get(base_health, _BASE_TO_STATE["unknown"])
     if state == "hung":
+        # #2112: base_health "unknown" (live session, stale/absent core-status)
+        # maps to "hung" — but an idle core writes core-status rarely, so a
+        # perfectly healthy core sitting at its idle prompt routinely goes
+        # "unknown" and would be FALSELY flagged hung (→ spurious ESCALATE /
+        # RECOVER). If the pane POSITIVELY shows the idle-ready prompt, trust that
+        # direct evidence over the stale status file: it's idle, not wedged. Only
+        # a positive idle match overrides — a no-affordance pane (mid-work or truly
+        # frozen) still reads hung, preserving genuine wedge detection.
+        if pane and _is_idle_ready(pane):
+            return "idle-ready", _BASE_TO_STATE["idle"][1], None, None
         tail = "\n".join([ln for ln in (pane or "").splitlines() if ln.strip()][-14:])
         return "hung", detail, tail or None, "unknown"
     return state, detail, None, None

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -143,10 +143,26 @@ class TestComposeState(unittest.TestCase):
 
     def test_hung_when_base_unknown(self):
         # runtime-health "unknown" = live session but stale/absent core-status
-        # (wedged loop) → the supervisor's hung, carrying the pane tail.
+        # (wedged loop) → the supervisor's hung, carrying the pane tail. Uses a
+        # WORKING (no-affordance) pane: no idle footer → genuinely wedged.
         st, _d, prompt, _k = compose_state(_WORKING, "unknown", True)
         self.assertEqual(st, "hung")
         self.assertIsNotNone(prompt)
+
+    def test_idle_ready_overrides_stale_status_when_pane_is_idle(self):
+        # #2112: a healthy core sitting at its idle prompt writes core-status
+        # rarely, so runtime-health goes "unknown" (stale status) and WOULD be
+        # falsely flagged hung (→ spurious ESCALATE / RECOVER). When the pane
+        # POSITIVELY shows the idle-ready footer, trust it: idle, not wedged.
+        idle_footer = ("prior output\n\n"
+                       "⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents")
+        st, _d, _p, _k = compose_state(idle_footer, "unknown", True)
+        self.assertEqual(st, "idle-ready")
+        # A no-affordance pane (mid-work / frozen) with the same stale status must
+        # STILL read hung — the override is positive-idle-only, so genuine wedge
+        # detection is preserved.
+        st2, *_ = compose_state("Running step 3...\n(no prompt, no footer)", "unknown", True)
+        self.assertEqual(st2, "hung")
 
 
 class TestAutoAnswer(unittest.TestCase):


### PR DESCRIPTION
## Bug (#2112)

The M1 supervisor monitor (`core-input-watch.py`) false-flags a **healthy idle core as `hung`**.

runtime-health returns `base_health='unknown'` for a live session whose `core-status.json` is stale/absent. `compose_state` maps `unknown → hung` ("wedged"). But an **idle core writes core-status rarely**, so a perfectly healthy core sitting at its idle prompt routinely goes `unknown` — and gets flagged `hung`, triggering spurious ESCALATE / RECOVER (restart) of a fine core.

## Fix

When `base_health='unknown'` would resolve to `hung`, first check whether the pane **positively** shows the idle-ready footer (new `_is_idle_ready`). If so, trust that direct pane evidence over the stale status file → report `idle-ready`.

The override is **positive-idle-only**: a no-affordance pane (mid-work or truly frozen) still reads `hung`, so genuine wedge detection is preserved. `_is_idle_ready` is deliberately distinct from `classify()==None` — which is *also* None for a no-affordance pane, so it can't be used to infer "idle".

## Verify
`python3 tests/core-input-watch.test.py` — 29/29, incl. the new `test_idle_ready_overrides_stale_status_when_pane_is_idle` (idle-footer pane → idle-ready; frozen pane → still hung). Behavioral check: base=unknown + {idle-footer → idle-ready, frozen → hung, empty → hung}.

Filed as #2112. Owner merges.

— @sutando-qingyun-001