### PR TITLE
feat(config): add voice_ws to runtime descriptor (v0.3.0 Live page)

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -326,6 +326,33 @@ try:
         probe_socket = rec['socket']
 except Exception:
     pass
+# voice_ws: the WS the running voice-agent actually bound. Runtime-authored —
+# voice-agent.ts writes state/voice-agent.json at listen with its real PORT — so
+# a non-default PORT is reported correctly instead of a hardcoded default (same
+# 'running process is the authority' principle as the socket above). Liveness is
+# validated by the recorded pid, NOT a time window: the file is written once at
+# startup (not refreshed like the heartbeat), so a window would wrongly expire a
+# long-running agent. Absent / dead-pid / unreadable -> default OSS endpoint.
+probe_voice_ws = 'ws://127.0.0.1:9900'
+try:
+    with open(os.path.join(ws, 'state', 'voice-agent.json')) as f:
+        vrec = json.load(f)
+    vpid = int(vrec.get('pid', 0) or 0)
+    alive = False
+    if vpid > 0:
+        try:
+            os.kill(vpid, 0)
+            alive = True
+        except ProcessLookupError:
+            alive = False
+        except PermissionError:
+            alive = True  # exists but not ours — still a live process
+        except Exception:
+            alive = False
+    if alive and vrec.get('voice_ws'):
+        probe_voice_ws = vrec['voice_ws']
+except Exception:
+    pass
 env = dict(os.environ, SUTANDO_TMUX_SOCKET=probe_socket)
 h = {}
 try:
@@ -366,12 +393,10 @@ print(json.dumps({
     'session': h.get('session', 'sutando-core'),
     # voice_ws: the WebSocket the runtime's voice-agent listens on — the endpoint
     # the desktop 'Live' page's browser VoiceTransport.connect(url) opens
-    # (ag2-space/ag2space-cinny-desktop v0.3.0). voice-agent.ts binds
-    # 'process.env.PORT || 9900'; the default is by far the common case (a custom
-    # PORT is rare, like a custom tmux socket) so we report the default here.
-    # Reporting a PORT-custom voice-agent authoritatively (record it in the
-    # .alive heartbeat, same pattern as socket) is a documented follow-up.
-    'voice_ws': 'ws://127.0.0.1:9900',
+    # (ag2-space/ag2space-cinny-desktop v0.3.0). Sourced from runtime-authored
+    # state (probe_voice_ws above): voice-agent.ts records its actual bound PORT,
+    # so a non-default-PORT install is reported correctly, not a hardcoded default.
+    'voice_ws': probe_voice_ws,
     'health': h.get('health', 'unknown'),
     'authenticated': h.get('authenticated'),
 }))

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -364,6 +364,14 @@ print(json.dumps({
     'brain': brain,
     'socket': h.get('tmux_socket') or probe_socket,
     'session': h.get('session', 'sutando-core'),
+    # voice_ws: the WebSocket the runtime's voice-agent listens on — the endpoint
+    # the desktop 'Live' page's browser VoiceTransport.connect(url) opens
+    # (ag2-space/ag2space-cinny-desktop v0.3.0). voice-agent.ts binds
+    # 'process.env.PORT || 9900'; the default is by far the common case (a custom
+    # PORT is rare, like a custom tmux socket) so we report the default here.
+    # Reporting a PORT-custom voice-agent authoritatively (record it in the
+    # .alive heartbeat, same pattern as socket) is a documented follow-up.
+    'voice_ws': 'ws://127.0.0.1:9900',
     'health': h.get('health', 'unknown'),
     'authenticated': h.get('authenticated'),
 }))

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -729,6 +729,23 @@ async function main() {
 	// the file is always present + always reflects the latest known state.
 	writeVoiceState(false);
 
+	// voice-agent.json is runtime-authored state recording the ACTUAL bound WS
+	// endpoint. `sutando-config.sh runtime` reads it (validated by pid liveness)
+	// so the AgentRuntime descriptor's `voice_ws` reports the port this process
+	// really bound — correct for installs on a non-default PORT, not a hardcoded
+	// default. Same "the running process is the authority on its own resource"
+	// principle by which the tmux socket is sourced from the core's heartbeat.
+	function writeVoiceRuntimeState() {
+		try {
+			writeFileSync(
+				statusPath('voice-agent.json', WORKSPACE_DIR),
+				JSON.stringify({ voice_ws: `ws://127.0.0.1:${PORT}`, port: PORT, pid: process.pid, ts: Math.floor(Date.now() / 1000) })
+			);
+		} catch (err) {
+			console.error(`${ts()} [VoiceRuntime] state write failed:`, err);
+		}
+	}
+
 
 	const session = new VoiceSession({
 		sessionId: SESSION_ID,
@@ -1187,6 +1204,10 @@ async function main() {
 			}
 		}
 	}, 30_000);
+
+	// The server bound successfully (EADDRINUSE would have exited via main().catch
+	// before here) — record the actual bound endpoint for the runtime descriptor.
+	writeVoiceRuntimeState();
 
 	console.log('============================================================');
 	console.log('Sutando — Voice Interface');

--- a/tests/sutando-config-runtime.test.sh
+++ b/tests/sutando-config-runtime.test.sh
@@ -114,6 +114,32 @@ brain6="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(s
 [ "$brain6" = "$canon" ]; report "$?" "brain=$brain6 == canonical $canon (not hardcoded .claude-sutando)"
 rm -rf "$T6WS"; rm -f "$CFG"; [ -n "$CFG_BAK" ] && mv "$CFG_BAK" "$CFG"
 
+# -- Test 7: voice_ws honors a custom PORT via runtime-authored state ------------
+# Regression for the #2115 review (Medium): voice_ws hardcoded ws://127.0.0.1:9900
+# is wrong for a voice-agent on a non-default PORT. It must be sourced from the
+# runtime-authored state voice-agent.ts writes (state/voice-agent.json), validated
+# by the recorded pid. Plant a state file recording a NON-default port + THIS
+# shell's pid (alive), point the resolver at that workspace, assert it's reported.
+echo "[7] runtime.voice_ws → reports a custom voice port from runtime-authored state (pid-validated)"
+CFG="$REPO_DIR/sutando.config.local.json"; CFG_BAK=""
+[ -f "$CFG" ] && { CFG_BAK="$(mktemp)"; cp "$CFG" "$CFG_BAK"; }
+T7WS="$(mktemp -d)"; mkdir -p "$T7WS/state"
+python3 -c "import json;json.dump({'voice_ws':'ws://127.0.0.1:19900','port':19900,'pid':$$,'ts':0},open('$T7WS/state/voice-agent.json','w'))"
+printf '{"workspace":{"path":"%s"}}' "$T7WS" > "$CFG"
+vws="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["voice_ws"])')"
+[ "$vws" = "ws://127.0.0.1:19900" ]; report "$?" "voice_ws=$vws == custom :19900 (from state, pid alive)"
+
+# -- Test 8: voice_ws falls back to default when the recorded pid is dead --------
+# A stale state file (voice-agent exited) must NOT report a port nothing is on.
+echo "[8] runtime.voice_ws → falls back to default when the state pid is dead"
+DEADPID=$(python3 -c "import os;p=os.fork()
+if p==0: os._exit(0)
+os.waitpid(p,0);print(p)")
+python3 -c "import json;json.dump({'voice_ws':'ws://127.0.0.1:19900','port':19900,'pid':$DEADPID,'ts':0},open('$T7WS/state/voice-agent.json','w'))"
+vws8="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["voice_ws"])')"
+[ "$vws8" = "ws://127.0.0.1:9900" ]; report "$?" "voice_ws=$vws8 == default (dead pid $DEADPID ignored)"
+rm -rf "$T7WS"; rm -f "$CFG"; [ -n "$CFG_BAK" ] && mv "$CFG_BAK" "$CFG"
+
 echo
 echo "sutando-config-runtime: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/tests/sutando-config-runtime.test.sh
+++ b/tests/sutando-config-runtime.test.sh
@@ -44,9 +44,11 @@ json="$(bash "$SCRIPT" runtime)"
 echo "$json" | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
-need={'alive','repo','code','workspace','brain','socket','session','health','authenticated'}
+need={'alive','repo','code','workspace','brain','socket','session','voice_ws','health','authenticated'}
 missing=need - set(d)
 assert not missing, f'missing keys: {missing}'
+# voice_ws = the runtime's voice-agent WS endpoint (v0.3.0 Live page consumes it)
+assert d['voice_ws'].startswith('ws://'), f\"voice_ws {d['voice_ws']!r} not a ws:// url\"
 assert d['repo']=='$REPO_DIR', f\"repo {d['repo']} != $REPO_DIR\"
 assert d['brain']==d['workspace']+'/.claude-sutando', f\"brain {d['brain']}\"
 assert d['session']=='sutando-core', d['session']


### PR DESCRIPTION
## What
The AgentRuntime descriptor (`sutando-config.sh runtime`, #2113) now reports **`voice_ws`** — the WebSocket the runtime's voice-agent listens on.

## Why
v0.3.0's desktop **Live page** (realtime voice + Watch) reuses the existing voice stack instead of rebuilding: the browser `VoiceTransport.connect(url)` (`src/web-voice-transport.ts`) opens this WS, backed by `live-agent-runtime.ts` + bodhi `VoiceSession`. `voice-agent.ts` binds `process.env.PORT || 9900`; the descriptor reports the 9900 default (a custom PORT is rare, like a custom tmux socket — a `.alive`-heartbeat-recorded voice port is a documented follow-up, same pattern as the socket).

## Verified live
`sutando-config.sh runtime | jq .voice_ws` → `ws://127.0.0.1:9900`, and that endpoint is **TCP-reachable on this core** (voice-agent listening on :9900). So the Live page's connect target is real.

## Test
`bash tests/sutando-config-runtime.test.sh` — 6/6; asserts voice_ws present + ws:// scheme.

Owner merges. Not urgent (v0.3.0 hasn't kicked off — this is the OSS-side prep so the Live page has a runtime-resolved endpoint).

— @sutando-qingyun-001