### PR TITLE
fix(hooks): correct-method-guard — deny wrong Google integrations (Drive MCP / Gmail connector), redirect to service-account / IMAP

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -94,3 +94,40 @@ PY
 ```
 
 Test: `python3 tests/gmail-write-guard.test.py`.
+
+## `correct-method-guard.py`
+
+Denies the **wrong Google integrations** and redirects to the documented paths
+(recurring field report 64340119 / 14015ea1, michael@actoneventures.com,
+team-wide): **Google Drive MCP** → the Drive **service account**; the **Gmail MCP
+connector** (which exposes no attachment-download method) → **IMAP** via
+`X-GM-MSGID` + the vaulted `GMAIL_APP_PASSWORD`. Written rules kept failing
+because they depend on the model recalling them at tool-selection time — one such
+memory was even stranded in a backup tree and never loaded — so this removes the
+wrong tool from the menu the same way `gmail-write-guard.py` does for writes.
+Matches Google Drive MCP tools by name (`google_drive`/`gdrive`) and Gmail via
+the Composio bridge (`composio_exec`/`composio_find` with `toolkit=gmail`); other
+toolkits (googlecalendar, slack, …) and non-Google tools are a no-op, so it is
+safe under a broad `mcp__.*` matcher.
+
+Escape hatch: `SUTANDO_ALLOW_GOOGLE_CONNECTORS=1` lifts the guard (installs where
+the connectors work, or where the service-account / IMAP creds aren't
+provisioned). Fail-OPEN on hook errors.
+
+### Deploy (per node)
+
+```bash
+cp hooks/correct-method-guard.py ~/.claude/hooks/
+python3 - <<'PY'
+import json, os
+sp = os.path.expanduser("~/.claude/settings.json"); s = json.load(open(sp))
+cmd = "python3 ~/.claude/hooks/correct-method-guard.py"
+pre = s.setdefault("hooks", {}).setdefault("PreToolUse", [])
+blk = next((b for b in pre if b.get("matcher") == "mcp__.*"), None)
+if blk is None: pre.append({"matcher": "mcp__.*", "hooks": [{"type": "command", "command": cmd}]})
+elif cmd not in [h.get("command") for h in blk["hooks"]]: blk["hooks"].append({"type": "command", "command": cmd})
+json.dump(s, open(sp, "w"), indent=2)
+PY
+```
+
+Test: `python3 tests/correct-method-guard.test.py`.

--- a/hooks/correct-method-guard.py
+++ b/hooks/correct-method-guard.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""correct-method-guard — PreToolUse hook that denies the wrong Google
+integrations and redirects to the documented, working paths.
+
+Why (recurring field report 64340119 / 14015ea1, michael@actoneventures.com,
+team-wide, latest 2026-07-15): the core keeps reaching for the **Google Drive
+MCP** and the **Gmail MCP connector** even though those paths are broken for the
+real jobs, and re-learns the lesson only after being told. The two correct paths
+(established repeatedly by Michael) are:
+
+  1. Google Drive  -> the **service account** (docs/built-in-tools.md), NOT the
+     Google Drive MCP (search is hook-blocked / unreliable on these installs).
+  2. Email + attachments -> **IMAP** via ``X-GM-MSGID`` + the vaulted
+     ``GMAIL_APP_PASSWORD``, NOT the Gmail MCP connector (which exposes no
+     attachment-download method, so attachment jobs dead-end and the core
+     reports itself stuck).
+
+Written rules (capability memories, feedback memories, CLAUDE.md guidance) have
+failed many times because they depend on the model *recalling* them at
+tool-selection time — and on one occasion the very memory that carried the IMAP
+technique was stranded in a backup tree and never loaded into the live index.
+The durable fix is the same one that already works for Gmail writes
+(gmail-write-guard.py): remove the wrong tool from the menu. This hook denies the
+wrong calls **before they run** and hands back the correct path in the reason.
+
+Scope — deliberately narrow, so it never blocks a correct call:
+  * **Google Drive MCP**: any ``mcp__…`` tool whose server segment names Google
+    Drive (``google_drive`` / ``gdrive``). Non-Google "drive" tools pass through.
+  * **Gmail connector**: the Composio bridge (``mcp__sutando-station__composio_exec``
+    / ``…composio_find``) invoked with ``toolkit == "gmail"`` — the Gmail-MCP
+    surface on these installs. Other toolkits (googlecalendar, slack, …) pass
+    through untouched. (Name-based claude.ai Gmail *write* tools are already
+    handled by the sibling gmail-write-guard.py.)
+  * Everything else: no-op (exit 0), safe under a broad matcher.
+
+Escape hatch: set ``SUTANDO_ALLOW_GOOGLE_CONNECTORS=1`` to disable the guard
+(e.g. on an install where the connector paths actually work, or the service
+account / IMAP creds are not provisioned).
+
+Fail-OPEN on any error — a crashing hook must never wedge the core (same
+contract as gmail-write-guard.py / skip-ask-user-question.py).
+
+Registration: manual per-node deploy like context-source-guard.py — see
+hooks/README.md.
+"""
+import json
+import os
+import sys
+
+DRIVE_REASON = (
+    "Google Drive MCP is blocked on this install: the Drive connector is "
+    "unreliable / search-hook-blocked here and repeatedly dead-ends real jobs. "
+    "Use the Drive **service account** instead (docs/built-in-tools.md -> Google "
+    "Drive: the gdrive service-account script with the vaulted key). If a task "
+    "needs an email ATTACHMENT, that is not a Drive job either — fetch it over "
+    "**IMAP** (see below). Set SUTANDO_ALLOW_GOOGLE_CONNECTORS=1 to lift this "
+    "guard. [correct-method-guard]"
+)
+
+GMAIL_REASON = (
+    "The Gmail MCP connector is blocked on this install: it exposes no "
+    "attachment-download method, so email/attachment jobs dead-end here. Use "
+    "**IMAP** instead: connect with imaplib + the vaulted GMAIL_APP_PASSWORD, "
+    "locate the message by its X-GM-MSGID, and fetch the body/attachment "
+    "(docs/built-in-tools.md -> Email). This is the path that has worked every "
+    "time. Set SUTANDO_ALLOW_GOOGLE_CONNECTORS=1 to lift this guard. "
+    "[correct-method-guard]"
+)
+
+
+def _is_google_drive_mcp(tool_name: str) -> bool:
+    """True for an MCP tool whose server segment is the Google Drive connector."""
+    if not tool_name.startswith("mcp__"):
+        return False
+    lowered = tool_name.lower()
+    # Match the Google Drive connector specifically (e.g.
+    # mcp__claude_ai_Google_Drive__search_files) — not an unrelated "drive".
+    return "google_drive" in lowered or "gdrive" in lowered or "googledrive" in lowered
+
+
+def _is_gmail_connector(tool_name: str, tool_input: dict) -> bool:
+    """True for a Gmail call routed through the Composio bridge (toolkit=gmail),
+    or any other MCP tool whose name carries 'gmail'."""
+    lowered = tool_name.lower()
+    if lowered.startswith("mcp__") and "gmail" in lowered:
+        return True
+    # Composio bridge: the tool name is composio_exec/composio_find; the Gmail-ness
+    # lives in the arguments (toolkit=gmail). Other toolkits pass through.
+    if lowered.startswith("mcp__") and "composio" in lowered:
+        toolkit = tool_input.get("toolkit")
+        if isinstance(toolkit, str) and toolkit.strip().lower() == "gmail":
+            return True
+    return False
+
+
+def _deny(reason: str) -> None:
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }}))
+
+
+def main() -> None:
+    if os.environ.get("SUTANDO_ALLOW_GOOGLE_CONNECTORS", "").strip() == "1":
+        sys.exit(0)
+    data = json.loads(sys.stdin.read())
+    tool_name = str(data.get("tool_name") or "")
+    tool_input = data.get("tool_input")
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+    if _is_google_drive_mcp(tool_name):
+        _deny(DRIVE_REASON)
+    elif _is_gmail_connector(tool_name, tool_input):
+        _deny(GMAIL_REASON)
+    # Everything else (and the deny above) exits 0; PreToolUse only blocks when a
+    # deny decision is present in the emitted JSON payload.
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as e:  # fail-open: never wedge the core on a hook error
+        print(f"[correct-method-guard] non-fatal error, allowing: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/tests/correct-method-guard.test.py
+++ b/tests/correct-method-guard.test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Behavioral test for hooks/correct-method-guard.py — feeds real PreToolUse
+payloads through the hook and asserts deny/allow + the correct redirect.
+
+Run: python3 tests/correct-method-guard.test.py   (exit 0 pass / 1 fail)
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK = Path(__file__).resolve().parent.parent / "hooks" / "correct-method-guard.py"
+
+_failed = 0
+
+
+def run(payload: dict, env_extra: dict | None = None):
+    """Invoke the hook with a PreToolUse payload; return (decision, reason)."""
+    env = dict(os.environ)
+    if env_extra:
+        env.update(env_extra)
+    p = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True, text=True, env=env, timeout=15,
+    )
+    assert p.returncode == 0, f"hook must always exit 0 (got {p.returncode}); stderr={p.stderr}"
+    out = (p.stdout or "").strip()
+    if not out:
+        return (None, None)
+    try:
+        j = json.loads(out)
+        hso = j.get("hookSpecificOutput", {})
+        return (hso.get("permissionDecision"), hso.get("permissionDecisionReason", ""))
+    except Exception:
+        return (None, out)
+
+
+def check(name: str, cond: bool, detail: str = ""):
+    global _failed
+    print(("  ok  " if cond else "  FAIL ") + name + (("" if cond else " — " + detail)))
+    if not cond:
+        _failed += 1
+
+
+# 1) Google Drive MCP → denied, points at the service account.
+d, r = run({"tool_name": "mcp__claude_ai_Google_Drive__search_files", "tool_input": {"query": "deck"}})
+check("Google Drive MCP is denied", d == "deny", f"got {d}")
+check("Drive deny mentions the service account", "service account" in (r or "").lower())
+
+d, r = run({"tool_name": "mcp__claude_ai_Google_Drive__download_file_content", "tool_input": {"fileId": "x"}})
+check("Google Drive MCP download is denied", d == "deny", f"got {d}")
+
+# 2) Composio Gmail (toolkit=gmail) → denied, points at IMAP.
+d, r = run({"tool_name": "mcp__sutando-station__composio_exec",
+            "tool_input": {"toolkit": "gmail", "action": "GMAIL_FETCH_EMAILS", "arguments": {}}})
+check("Composio Gmail is denied", d == "deny", f"got {d}")
+check("Gmail deny mentions IMAP + X-GM-MSGID", "imap" in (r or "").lower() and "x-gm-msgid" in (r or "").lower())
+
+d, r = run({"tool_name": "mcp__sutando-station__composio_find", "tool_input": {"toolkit": "gmail", "query": "attachment"}})
+check("Composio Gmail find is denied", d == "deny", f"got {d}")
+
+# 3) Name-based Gmail MCP tool → denied (defense in depth).
+d, r = run({"tool_name": "mcp__some_server__gmail_get_message", "tool_input": {}})
+check("Name-based Gmail MCP tool is denied", d == "deny", f"got {d}")
+
+# 4) Composio NON-gmail toolkits pass through (calendar, slack).
+d, _ = run({"tool_name": "mcp__sutando-station__composio_exec",
+            "tool_input": {"toolkit": "googlecalendar", "action": "GOOGLECALENDAR_EVENTS_LIST"}})
+check("Composio Calendar passes through", d is None, f"got {d}")
+d, _ = run({"tool_name": "mcp__sutando-station__composio_exec", "tool_input": {"toolkit": "slack"}})
+check("Composio Slack passes through", d is None, f"got {d}")
+
+# 5) Unrelated tools pass through.
+d, _ = run({"tool_name": "Bash", "tool_input": {"command": "ls"}})
+check("Bash passes through", d is None, f"got {d}")
+d, _ = run({"tool_name": "mcp__claude_ai_Slack__slack_send_message", "tool_input": {}})
+check("Slack MCP passes through", d is None, f"got {d}")
+# An unrelated 'drive' that is not Google Drive must not be caught.
+d, _ = run({"tool_name": "mcp__some_server__usb_drive_list", "tool_input": {}})
+check("Non-Google 'drive' tool passes through", d is None, f"got {d}")
+
+# 6) Escape hatch disables the guard.
+d, _ = run({"tool_name": "mcp__claude_ai_Google_Drive__search_files", "tool_input": {}},
+           env_extra={"SUTANDO_ALLOW_GOOGLE_CONNECTORS": "1"})
+check("Escape hatch lifts the Drive guard", d is None, f"got {d}")
+
+# 7) Fail-open on malformed input (never wedge the core).
+p = subprocess.run([sys.executable, str(HOOK)], input="not-json{", capture_output=True, text=True, timeout=15)
+check("Malformed input fails open (exit 0)", p.returncode == 0, f"rc={p.returncode}")
+
+print()
+if _failed:
+    print(f"FAIL — {_failed} check(s) failed")
+    sys.exit(1)
+print("PASS — correct-method-guard behavioral tests")


### PR DESCRIPTION
## Problem

Recurring field report **64340119 / 14015ea1** (michael@actoneventures.com, team-wide, latest 2026-07-15): the core keeps reaching for the **Google Drive MCP** and the **Gmail MCP connector** instead of the documented working paths, and re-learns the lesson only after a human says "why didn't you use IMAP."

The two correct paths (established repeatedly by Michael):
1. **Google Drive → the service account**, not the Drive MCP (search hook-blocked / unreliable on these installs).
2. **Email + attachments → IMAP** via `X-GM-MSGID` + the vaulted `GMAIL_APP_PASSWORD`, not the Gmail MCP connector (which exposes **no attachment-download method**, so attachment jobs dead-end and the core reports itself stuck).

Today's failure: a time-sensitive board pre-read from a PDF **attached to an email** — the core tried the Gmail connector (no attachment method), then the Drive MCP (hook-blocked), and gave up with a CRM-only pre-read; the correct IMAP path worked first try, but only after being told.

**Root cause is persistence/enforcement, not a missing rule.** Written rules (capability/feedback memories, CLAUDE.md guidance) have failed many times because they depend on the model *recalling* them at tool-selection time — and one memory carrying the IMAP technique was stranded in a backup tree and never loaded into the live index.

## Fix (enforcement over exhortation)

Same approach that already works for Gmail writes (`gmail-write-guard.py`): a **PreToolUse hook** that denies the wrong calls *before they run* and hands back the correct path in the reason. This was the approved plan ("`hooks/correct-method-guard.py`, PreToolUse deny+redirect" — Rui: "do as recommended").

Scope is deliberately narrow so it never blocks a correct call:
- **Google Drive MCP**: `mcp__…` tools whose server names Google Drive (`google_drive`/`gdrive`) → redirect to the service account.
- **Gmail connector**: the Composio bridge (`composio_exec`/`composio_find`) with `toolkit == "gmail"` → redirect to IMAP + `X-GM-MSGID`. Also catches any `mcp__…gmail…` name (defense in depth).
- Other toolkits (googlecalendar, slack, …), non-Google tools, and a non-Google "drive" → **no-op**, safe under a broad `mcp__.*` matcher.

Escape hatch `SUTANDO_ALLOW_GOOGLE_CONNECTORS=1`; **fail-open** on any hook error (never wedge the core).

## Tests

`tests/correct-method-guard.test.py` — behavioral, feeds real PreToolUse payloads through the hook: **14/14 pass** — denies Drive MCP + Composio/name-based Gmail with the right redirect; allows Composio calendar/slack, Bash, Slack MCP, non-Google "drive"; escape hatch lifts the guard; malformed input fails open.

Deploy is per-node (like the sibling guards) — see `hooks/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)