### PR TITLE
feat(config): add vision_control to runtime descriptor (v0.3.0 Watch)

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -353,6 +353,33 @@ try:
         probe_voice_ws = vrec['voice_ws']
 except Exception:
     pass
+# vision_control: the HTTP control endpoint the running vision-control server
+# actually bound (:7847 default, or VISION_CONTROL_PORT). Runtime-authored the
+# same way as voice_ws — vision-tools.ts writes state/vision-control.json at
+# listen with its real port, pid-validated (written once at startup, so liveness
+# is the pid not a time window). Consumed by the desktop 'Watch' toggle (v0.3.0
+# Slice-2) to drive /vision/start|stop|state. Absent / dead-pid / unreadable ->
+# default OSS endpoint.
+probe_vision_control = 'http://127.0.0.1:7847'
+try:
+    with open(os.path.join(ws, 'state', 'vision-control.json')) as f:
+        crec = json.load(f)
+    cpid = int(crec.get('pid', 0) or 0)
+    calive = False
+    if cpid > 0:
+        try:
+            os.kill(cpid, 0)
+            calive = True
+        except ProcessLookupError:
+            calive = False
+        except PermissionError:
+            calive = True  # exists but not ours — still a live process
+        except Exception:
+            calive = False
+    if calive and crec.get('vision_control'):
+        probe_vision_control = crec['vision_control']
+except Exception:
+    pass
 env = dict(os.environ, SUTANDO_TMUX_SOCKET=probe_socket)
 h = {}
 try:
@@ -397,6 +424,12 @@ print(json.dumps({
     # state (probe_voice_ws above): voice-agent.ts records its actual bound PORT,
     # so a non-default-PORT install is reported correctly, not a hardcoded default.
     'voice_ws': probe_voice_ws,
+    # vision_control: the HTTP control endpoint the runtime's vision-control server
+    # listens on — where the desktop 'Watch' toggle POSTs /vision/start|stop and
+    # polls /vision/state (ag2-space/ag2space-cinny-desktop v0.3.0 Slice-2).
+    # Sourced from runtime-authored state (probe_vision_control above), so a
+    # VISION_CONTROL_PORT override is reported correctly, not a hardcoded default.
+    'vision_control': probe_vision_control,
     'health': h.get('health', 'unknown'),
     'authenticated': h.get('authenticated'),
 }))

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -376,8 +376,12 @@ try:
             calive = True  # exists but not ours — still a live process
         except Exception:
             calive = False
-    if calive and crec.get('vision_control'):
-        probe_vision_control = crec['vision_control']
+    # Only trust a loopback endpoint — the control server binds 127.0.0.1, so a
+    # non-loopback scheme/host in the state file is stale or crafted; fall back to
+    # the default rather than hand the desktop client a URL it should never call.
+    _cv = crec.get('vision_control')
+    if calive and isinstance(_cv, str) and _cv.startswith('http://127.0.0.1:'):
+        probe_vision_control = _cv
 except Exception:
     pass
 env = dict(os.environ, SUTANDO_TMUX_SOCKET=probe_socket)

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -709,7 +709,13 @@ export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): S
 		console.error(`${ts()} [Vision] control server error: ${err.message}`);
 	});
 	srv.listen(port, '127.0.0.1', () => {
-		console.log(`${ts()} [Vision] control server listening on 127.0.0.1:${port}`);
+		// Record the port the OS ACTUALLY bound, read from srv.address() — not the
+		// `port` parameter, which would echo `0` when the caller requested an
+		// ephemeral port instead of the real assigned one (the whole point of the
+		// runtime-authored state is correctness under a non-default port).
+		const addr = srv.address();
+		const boundPort = (addr && typeof addr === 'object') ? addr.port : port;
+		console.log(`${ts()} [Vision] control server listening on 127.0.0.1:${boundPort}`);
 		// vision-control.json is runtime-authored state recording the ACTUAL bound
 		// control port. `sutando-config.sh runtime` reads it (validated by pid
 		// liveness) so the AgentRuntime descriptor's `vision_control` reports the
@@ -720,7 +726,7 @@ export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): S
 		try {
 			writeFileSync(
 				statusPath('vision-control.json', resolveWorkspace()),
-				JSON.stringify({ vision_control: `http://127.0.0.1:${port}`, port, pid: process.pid, ts: Math.floor(Date.now() / 1000) })
+				JSON.stringify({ vision_control: `http://127.0.0.1:${boundPort}`, port: boundPort, pid: process.pid, ts: Math.floor(Date.now() / 1000) })
 			);
 		} catch (err) {
 			console.error(`${ts()} [Vision] runtime state write failed:`, err);

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -16,7 +16,7 @@
  * realtime_input.video slot accepts single-frame images.
  */
 
-import { readFileSync, unlinkSync, mkdtempSync } from 'node:fs';
+import { readFileSync, writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFile } from 'node:child_process';
@@ -24,6 +24,7 @@ import { promisify } from 'node:util';
 import { createServer, type Server } from 'node:http';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
+import { resolveWorkspace, statusPath } from './workspace_default.js';
 
 const execFileAsync = promisify(execFile);
 const ts = () => new Date().toLocaleTimeString('en-US', { hour12: false });
@@ -709,6 +710,21 @@ export function startVisionControlServer(port: number = DEFAULT_CONTROL_PORT): S
 	});
 	srv.listen(port, '127.0.0.1', () => {
 		console.log(`${ts()} [Vision] control server listening on 127.0.0.1:${port}`);
+		// vision-control.json is runtime-authored state recording the ACTUAL bound
+		// control port. `sutando-config.sh runtime` reads it (validated by pid
+		// liveness) so the AgentRuntime descriptor's `vision_control` reports the
+		// port this process really bound — correct for a VISION_CONTROL_PORT
+		// override, not a hardcoded default. Same pattern as voice-agent.ts's
+		// writeVoiceRuntimeState() for voice_ws (#2115); consumed by the desktop
+		// 'Watch' toggle (ag2-space/ag2space-cinny-desktop v0.3.0 Slice-2).
+		try {
+			writeFileSync(
+				statusPath('vision-control.json', resolveWorkspace()),
+				JSON.stringify({ vision_control: `http://127.0.0.1:${port}`, port, pid: process.pid, ts: Math.floor(Date.now() / 1000) })
+			);
+		} catch (err) {
+			console.error(`${ts()} [Vision] runtime state write failed:`, err);
+		}
 	});
 	controlServer = srv;
 	return srv;

--- a/tests/sutando-config-runtime.test.sh
+++ b/tests/sutando-config-runtime.test.sh
@@ -163,6 +163,15 @@ os.waitpid(p,0);print(p)")
 python3 -c "import json;json.dump({'vision_control':'http://127.0.0.1:17847','port':17847,'pid':$DEADPID2,'ts':0},open('$T9WS/state/vision-control.json','w'))"
 vc10="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["vision_control"])')"
 [ "$vc10" = "http://127.0.0.1:7847" ]; report "$?" "vision_control=$vc10 == default (dead pid $DEADPID2 ignored)"
+
+# -- Test 11: vision_control rejects a non-loopback URL even with a live pid ------
+# Hardening (#2118 review): the control server binds 127.0.0.1, so a state file
+# recording a non-loopback host is stale/crafted — must fall back to the default,
+# never hand the desktop client a URL it should not call.
+echo "[11] runtime.vision_control → rejects a non-loopback recorded URL (live pid)"
+python3 -c "import json;json.dump({'vision_control':'http://10.0.0.5:7847','port':7847,'pid':$$,'ts':0},open('$T9WS/state/vision-control.json','w'))"
+vc11="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["vision_control"])')"
+[ "$vc11" = "http://127.0.0.1:7847" ]; report "$?" "vision_control=$vc11 == default (non-loopback 10.0.0.5 rejected)"
 rm -rf "$T9WS"; rm -f "$CFG"; [ -n "$CFG_BAK" ] && mv "$CFG_BAK" "$CFG"
 
 echo

--- a/tests/sutando-config-runtime.test.sh
+++ b/tests/sutando-config-runtime.test.sh
@@ -44,11 +44,13 @@ json="$(bash "$SCRIPT" runtime)"
 echo "$json" | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
-need={'alive','repo','code','workspace','brain','socket','session','voice_ws','health','authenticated'}
+need={'alive','repo','code','workspace','brain','socket','session','voice_ws','vision_control','health','authenticated'}
 missing=need - set(d)
 assert not missing, f'missing keys: {missing}'
 # voice_ws = the runtime's voice-agent WS endpoint (v0.3.0 Live page consumes it)
 assert d['voice_ws'].startswith('ws://'), f\"voice_ws {d['voice_ws']!r} not a ws:// url\"
+# vision_control = the runtime's vision-control HTTP endpoint (v0.3.0 Watch consumes it)
+assert d['vision_control'].startswith('http://'), f\"vision_control {d['vision_control']!r} not an http:// url\"
 assert d['repo']=='$REPO_DIR', f\"repo {d['repo']} != $REPO_DIR\"
 assert d['brain']==d['workspace']+'/.claude-sutando', f\"brain {d['brain']}\"
 assert d['session']=='sutando-core', d['session']
@@ -139,6 +141,29 @@ python3 -c "import json;json.dump({'voice_ws':'ws://127.0.0.1:19900','port':1990
 vws8="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["voice_ws"])')"
 [ "$vws8" = "ws://127.0.0.1:9900" ]; report "$?" "voice_ws=$vws8 == default (dead pid $DEADPID ignored)"
 rm -rf "$T7WS"; rm -f "$CFG"; [ -n "$CFG_BAK" ] && mv "$CFG_BAK" "$CFG"
+
+# -- Test 9: vision_control honors a custom PORT via runtime-authored state -------
+# Same guarantee as voice_ws (#2115) for the Watch endpoint: vision-tools.ts writes
+# state/vision-control.json at listen with its real port (:7847 or VISION_CONTROL_PORT);
+# the descriptor must report that, pid-validated, not a hardcoded default.
+echo "[9] runtime.vision_control → reports a custom vision port from runtime-authored state (pid-validated)"
+CFG="$REPO_DIR/sutando.config.local.json"; CFG_BAK=""
+[ -f "$CFG" ] && { CFG_BAK="$(mktemp)"; cp "$CFG" "$CFG_BAK"; }
+T9WS="$(mktemp -d)"; mkdir -p "$T9WS/state"
+python3 -c "import json;json.dump({'vision_control':'http://127.0.0.1:17847','port':17847,'pid':$$,'ts':0},open('$T9WS/state/vision-control.json','w'))"
+printf '{"workspace":{"path":"%s"}}' "$T9WS" > "$CFG"
+vc="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["vision_control"])')"
+[ "$vc" = "http://127.0.0.1:17847" ]; report "$?" "vision_control=$vc == custom :17847 (from state, pid alive)"
+
+# -- Test 10: vision_control falls back to default when the recorded pid is dead --
+echo "[10] runtime.vision_control → falls back to default when the state pid is dead"
+DEADPID2=$(python3 -c "import os;p=os.fork()
+if p==0: os._exit(0)
+os.waitpid(p,0);print(p)")
+python3 -c "import json;json.dump({'vision_control':'http://127.0.0.1:17847','port':17847,'pid':$DEADPID2,'ts':0},open('$T9WS/state/vision-control.json','w'))"
+vc10="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["vision_control"])')"
+[ "$vc10" = "http://127.0.0.1:7847" ]; report "$?" "vision_control=$vc10 == default (dead pid $DEADPID2 ignored)"
+rm -rf "$T9WS"; rm -f "$CFG"; [ -n "$CFG_BAK" ] && mv "$CFG_BAK" "$CFG"
 
 echo
 echo "sutando-config-runtime: $pass passed, $fail failed"


### PR DESCRIPTION
## What

Adds a `vision_control` field to the `sutando-config.sh runtime` descriptor — the HTTP control endpoint the vision-control server listens on (`:7847` default, or `VISION_CONTROL_PORT`). A desktop client's "Watch" (screen-share) control POSTs `/vision/start` + `/vision/stop` and polls `/vision/state` against this endpoint.

## How — mirrors voice_ws (#2115)

Same "the running process is the authority on its own resource" pattern already used for `voice_ws`:
- `vision-tools.ts` writes `state/vision-control.json` at `listen()` with its real bound port + pid.
- The resolver reads it **pid-validated** (`os.kill(pid, 0)`; the file is written once at startup, so liveness is the recorded pid, not a time window).
- Absent / dead-pid / unreadable → default OSS endpoint `http://127.0.0.1:7847`.

This means a non-default `VISION_CONTROL_PORT` is reported correctly instead of a hardcoded default — the exact review point that hardened `voice_ws` in #2115.

## Tests

`tests/sutando-config-runtime.test.sh`:
- `vision_control` added to the descriptor key-set assertion (Test 3) + an `http://` shape check.
- **Test 9** — custom port via runtime-authored state (live pid) is reported.
- **Test 10** — falls back to default when the recorded pid is dead.

**10/10 green** locally.

Fully additive — new descriptor field + a state write in the vision-control server's `listen` callback; no existing behavior changes.

— @sutando-qingyun-001
