### PR TITLE
fix(health-check): memory-index integrity probe — surface memories that will never load

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -269,6 +269,64 @@ def check_memory_dir_override() -> "dict | None":
     }
 
 
+def check_memory_index_integrity() -> "dict | None":
+    """Catch memories that exist on disk but will never load into a session.
+
+    A memory only loads if it is (a) present in the LIVE memory dir and (b)
+    referenced in that dir's MEMORY.md index. Two silent-loss modes have bitten
+    us (recurring field report 64340119): a memory file written to the live dir
+    but never added to MEMORY.md, and a hard-won capability memory stranded in a
+    ``*-BACKUP`` tree (created by scripts/sutando-migrate.sh) that never made it
+    into the live index — so the rule it carried was written yet never recalled.
+
+    Warn (never fail) listing the orphaned/stranded files so the divergence is
+    visible instead of silently dropping the memory. Returns None on a clean
+    index or when the memory dir does not exist yet.
+    """
+    if not MEMORY_DIR.exists():
+        return None
+    index = MEMORY_DIR / "MEMORY.md"
+    index_text = index.read_text(errors="ignore") if index.exists() else ""
+
+    # (a) live memory files not referenced anywhere in MEMORY.md → won't load.
+    unindexed = [
+        p.name for p in sorted(MEMORY_DIR.glob("*.md"))
+        if p.name != "MEMORY.md"
+        and p.name not in index_text and p.name[:-3] not in index_text
+    ]
+
+    # (b) memories stranded in a sibling *-BACKUP tree, absent from the live dir.
+    stranded: list[str] = []
+    try:
+        claude_home = MEMORY_DIR.parent.parent.parent  # memory -> <slug> -> projects -> claude-home
+        slug = MEMORY_DIR.parent.name
+        for backup in claude_home.parent.glob(claude_home.name + "*BACKUP*"):
+            bmem = backup / "projects" / slug / "memory"
+            if bmem.is_dir():
+                stranded += [
+                    mp.name for mp in bmem.glob("*.md")
+                    if mp.name != "MEMORY.md" and not (MEMORY_DIR / mp.name).exists()
+                ]
+    except Exception:
+        pass
+
+    if not unindexed and not stranded:
+        return {"name": "memory-index", "status": "ok",
+                "detail": "all memory files present in the MEMORY.md index"}
+    parts = []
+    if unindexed:
+        parts.append(
+            f"{len(unindexed)} memory file(s) not in MEMORY.md (won't load): "
+            + ", ".join(unindexed[:6]) + ("…" if len(unindexed) > 6 else "")
+        )
+    if stranded:
+        parts.append(
+            f"{len(stranded)} memory file(s) stranded in a *-BACKUP tree, absent from the live dir: "
+            + ", ".join(sorted(set(stranded))[:6]) + ("…" if len(set(stranded)) > 6 else "")
+        )
+    return {"name": "memory-index", "status": "warn", "detail": "; ".join(parts)}
+
+
 def check_memory_sync() -> dict:
     """Verify memory sync is configured and has run recently.
 
@@ -1572,6 +1630,10 @@ def run_all_checks() -> list[dict]:
     _mem_override = check_memory_dir_override()
     if _mem_override:
         checks.append(_mem_override)
+
+    _mem_index = check_memory_index_integrity()
+    if _mem_index:
+        checks.append(_mem_index)
 
     # Notes — canonical home is the resolved workspace post-migration.
     # Pass WORKSPACE_DIR (not REPO_DIR) so the check resolves to

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -307,7 +307,7 @@ def check_memory_index_integrity() -> "dict | None":
                     mp.name for mp in bmem.glob("*.md")
                     if mp.name != "MEMORY.md" and not (MEMORY_DIR / mp.name).exists()
                 ]
-    except Exception:
+    except Exception:  # pragma: no cover — best-effort backup scan; never break the health check
         pass
 
     if not unindexed and not stranded:

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Test check_memory_index_integrity() — the health probe that catches memories
+which exist on disk but will never load (not in MEMORY.md, or stranded in a
+*-BACKUP tree). Run: python3 tests/memory-index-integrity.test.py"""
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import sys
+from pathlib import Path
+
+HC = Path(__file__).resolve().parent.parent / "src" / "health-check.py"
+spec = importlib.util.spec_from_file_location("health_check", HC)
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+_failed = 0
+
+
+def check(name: str, cond: bool, detail: str = ""):
+    global _failed
+    print(("  ok  " if cond else "  FAIL ") + name + (("" if cond else " — " + detail)))
+    if not cond:
+        _failed += 1
+
+
+def make_tree(tmp: Path) -> Path:
+    """<tmp>/home/projects/<slug>/memory — return the memory dir."""
+    mem = tmp / "home" / "projects" / "slug" / "memory"
+    mem.mkdir(parents=True)
+    return mem
+
+
+# 1) All indexed → ok.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    (mem / "MEMORY.md").write_text("# Index\n- [Good](good-memory.md) — hook\n")
+    (mem / "good-memory.md").write_text("body")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("all-indexed → ok", r and r["status"] == "ok", str(r))
+
+# 2) An unindexed live memory → warn naming it.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    (mem / "MEMORY.md").write_text("# Index\n- [Good](good-memory.md)\n")
+    (mem / "good-memory.md").write_text("body")
+    (mem / "orphan-memory.md").write_text("stranded rule that never loads")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("unindexed live memory → warn", r and r["status"] == "warn", str(r))
+    check("warn names the orphan file", r and "orphan-memory.md" in r["detail"], str(r))
+
+# 3) A memory stranded in a sibling *-BACKUP tree, absent from live → warn.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    (mem / "MEMORY.md").write_text("# Index\n")
+    backup_mem = Path(t) / "home-BACKUP-20260714" / "projects" / "slug" / "memory"
+    backup_mem.mkdir(parents=True)
+    (backup_mem / "gmail-imap-capability.md").write_text("the IMAP technique")
+    (backup_mem / "MEMORY.md").write_text("# Index\n")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("backup-stranded memory → warn", r and r["status"] == "warn", str(r))
+    check("warn names the stranded file", r and "gmail-imap-capability.md" in r["detail"], str(r))
+
+# 4) Missing memory dir → None (no false alarm on fresh installs).
+with tempfile.TemporaryDirectory() as t:
+    hc.MEMORY_DIR = Path(t) / "does-not-exist" / "memory"
+    check("missing dir → None", hc.check_memory_index_integrity() is None)
+
+print()
+if _failed:
+    print(f"FAIL — {_failed} check(s) failed"); sys.exit(1)
+print("PASS — memory-index-integrity tests")

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -69,6 +69,15 @@ with tempfile.TemporaryDirectory() as t:
     hc.MEMORY_DIR = Path(t) / "does-not-exist" / "memory"
     check("missing dir → None", hc.check_memory_index_integrity() is None)
 
+# 5) The probe is wired into run_all_checks() — a memory-index entry appears.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    (mem / "MEMORY.md").write_text("# Index\n- [Orphan check](orphan.md)\n")
+    (mem / "orphan.md").write_text("x")
+    hc.MEMORY_DIR = mem
+    names = [c.get("name") for c in hc.run_all_checks()]
+    check("run_all_checks() includes memory-index", "memory-index" in names, str(names))
+
 print()
 if _failed:
     print(f"FAIL — {_failed} check(s) failed"); sys.exit(1)


### PR DESCRIPTION
## Problem

Recurring field report **64340119**: the Gmail IMAP-attachment technique was learned and memory-filed on 2026-07-14, but the file was **stranded in the `.claude-sutando-BACKUP` tree** (created by `scripts/sutando-migrate.sh`) and never made it into the live `MEMORY.md` index — so it was never loaded and never recalled at tool-selection time, and the core kept defaulting to the wrong Google integration.

This is the **persistence/loading half** of that bug. The enforcement half (deny the wrong tool regardless of recall) is the `correct-method-guard` hook, #2117. A memory only loads if it is (a) in the live memory dir **and** (b) referenced in that dir's `MEMORY.md`; both failure modes were silent.

## Fix

`check_memory_index_integrity()` in `health-check.py` — a **warn-only** probe (never fails the check) that surfaces memories which won't load:
- live `*.md` files not referenced anywhere in `MEMORY.md` (present but won't load), and
- memory files stranded in a sibling `*-BACKUP` tree that are absent from the live dir.

It lists the offending filenames so the divergence is visible and fixable instead of silently dropping a hard-won memory. Returns `None` on a clean index / fresh install (no false alarms).

## Tests

`tests/memory-index-integrity.test.py` — **6/6**: all-indexed → ok; unindexed live memory → warn (names it); backup-stranded memory → warn (names it); missing dir → None.

Verified against the real memory dir: `memory-index: ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)