### PR TITLE
feat(gateway): per-sender access_tier from owner tierMap

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -558,21 +558,25 @@ def _maybe_fetch_media(body: str, _refs_out: "list | None" = None) -> str:
     return MEDIA_MARKER_RE.sub(lambda _m: f"[{label}: {path}]", body, count=1)
 
 
-def _write_owner_activity(task: dict) -> None:
+def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
     """Record that the owner was active on this transport right now — but only
-    when THIS node resolves the SENDER to owner tier. Gated on
-    `_tier_for(user_id)`, NOT the gateway-wide LOCAL_TIER: in a shared room a
+    when THIS node resolves the SENDER to owner tier. Gated on the sender's
+    resolved tier, NOT the gateway-wide LOCAL_TIER: in a shared room a
     down-tiered teammate (tierMap[...] = "team"/"other") must not overwrite
     `state/last-owner-activity.json`, or their message would poison owner-presence
     routing (the proactive-loop's "owner active N min ago" signal + the core-
-    supervisor escalation target). For an unlisted sender `_tier_for` returns
-    LOCAL_TIER, so the single-owner case is unchanged. Never trusts the gateway's
-    own claim (it is outside the trust boundary) — only the broker-attested
-    user_id keyed against the owner's LOCAL tierMap. Atomic write via tmp+rename;
-    same schema (`ts`, `channel`, `summary`) as discord-bridge.write_owner_activity
-    so the proactive-loop reader is transport-agnostic. Best-effort — never blocks
-    task intake."""
-    if _tier_for(task.get("user_id")) != "owner":
+    supervisor escalation target). `sender_tier` is passed in by `_write_task` so
+    the task tier and this gate share a SINGLE resolution (no divergence, no
+    double tierMap read); a direct caller can omit it and we resolve here. For an
+    unlisted sender `_tier_for` returns LOCAL_TIER, so the single-owner case is
+    unchanged. Never trusts the gateway's own claim (it is outside the trust
+    boundary) — only the broker-attested user_id keyed against the owner's LOCAL
+    tierMap. Atomic write via tmp+rename; same schema (`ts`, `channel`, `summary`)
+    as discord-bridge.write_owner_activity so the proactive-loop reader is
+    transport-agnostic. Best-effort — never blocks task intake."""
+    if sender_tier is None:
+        sender_tier = _tier_for(task.get("user_id"))
+    if sender_tier != "owner":
         return
     try:
         OWNER_ACTIVITY_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -689,14 +693,19 @@ def _write_task(task: dict) -> str | None:
     # forge an earlier one either. Resolved per broker-attested sender via the
     # owner's tierMap (LOCAL file), falling back to LOCAL_TIER for unlisted
     # senders — so a named teammate can be down-tiered without trusting the task.
-    lines.append(f"access_tier: {_tier_for(task.get('user_id'))}")
+    # Resolve ONCE and reuse for both the task tier AND the owner-activity gate
+    # below, so the two decisions can never diverge (a single source of truth,
+    # no double read of the tierMap).
+    sender_tier = _tier_for(task.get("user_id"))
+    lines.append(f"access_tier: {sender_tier}")
     tmp = dest.with_suffix(".txt.tmp")
     tmp.write_text("\n".join(lines) + "\n")
     tmp.rename(dest)  # atomic publish so the watcher never sees a partial file
     _log(f"queued {tid}")
     _record_task_room(tid, str(task.get("channel_id") or ""))
-    # Bridges-as-siblings: feed the proactive-loop's active-engagement gate.
-    _write_owner_activity(task)
+    # Bridges-as-siblings: feed the proactive-loop's active-engagement gate — but
+    # only for owner-tier senders (same resolved tier as the task above).
+    _write_owner_activity(task, sender_tier)
     return tid
 
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -181,37 +181,61 @@ _TIER_MAP_CACHE = {"mtime": None, "map": {}}
 
 
 def _load_tier_map():
-    """Return the owner's {sender_mxid: tier} map, mtime-cached. Fail-soft to {}."""
+    """Return the owner's {sender_mxid: tier} map, mtime-cached.
+
+    Preserves the last-known-good map on a READ error (stat/open/parse failure)
+    rather than clearing to {}. Clearing would silently up-tier every previously
+    down-tiered sender back to LOCAL_TIER the moment access.json is mid-write,
+    corrupt, or transiently unreadable — a fail-OPEN that is especially bad on a
+    LOCAL_TIER=owner node (a teammate momentarily regains owner). Only a
+    SUCCESSFUL read of a changed file replaces the cache; a fixed file (new mtime)
+    is picked up on the next call. A genuine deletion keeps the last map until the
+    owner writes an empty tierMap or the process restarts (the safe, non-surprising
+    tradeoff — the map floor never drops on a transient fault)."""
     path = _ag2space_access_path()
     try:
         mt = os.path.getmtime(path)
     except OSError:
-        _TIER_MAP_CACHE["mtime"], _TIER_MAP_CACHE["map"] = None, {}
-        return {}
+        # Absent/unstattable → keep last-known-good (initially {} before any load).
+        return _TIER_MAP_CACHE["map"]
     if mt == _TIER_MAP_CACHE["mtime"]:
         return _TIER_MAP_CACHE["map"]
-    tm = {}
     try:
         with open(path) as f:
             raw = (json.load(f) or {}).get("tierMap") or {}
+        tm = {}
         for who, tier in raw.items():
             t = str(tier).strip().lower()
             if isinstance(who, str) and t in ("owner", "team", "other"):
                 tm[who.strip()] = t
     except Exception:
-        tm = {}  # malformed file → no re-tiering, keep LOCAL_TIER for everyone
+        # Malformed / mid-write → keep last-known-good; don't advance mtime so a
+        # later successful read of the fixed file is still picked up.
+        return _TIER_MAP_CACHE["map"]
     _TIER_MAP_CACHE["mtime"], _TIER_MAP_CACHE["map"] = mt, tm
     return tm
 
 
+# Privilege ordering — a higher rank is MORE privileged. Used to clamp a mapped
+# tier so the owner file can only ever DOWN-tier (never escalate above the node's
+# own default), keeping the "map only down-tiers named senders" safety invariant
+# true in code rather than only in the comment.
+_TIER_RANK = {"other": 0, "team": 1, "owner": 2}
+
+
 def _tier_for(user_id):
     """Resolve the access_tier for a task's broker-attested sender.
-    Listed senders get their mapped tier; everyone else gets LOCAL_TIER."""
+
+    A listed sender gets their mapped tier, CLAMPED to <= LOCAL_TIER: the map can
+    down-tier a sender below this node's default but never raise them above it, so
+    a compromised/misconfigured access.json can never ESCALATE. Everyone else
+    (unlisted / no user_id) gets LOCAL_TIER."""
     uid = (user_id or "").strip()
     if uid:
         mapped = _load_tier_map().get(uid)
-        if mapped in ("owner", "team", "other"):
-            return mapped
+        if mapped in _TIER_RANK:
+            local_rank = _TIER_RANK.get(LOCAL_TIER, _TIER_RANK["owner"])
+            return mapped if _TIER_RANK[mapped] <= local_rank else LOCAL_TIER
     return LOCAL_TIER
 
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -560,12 +560,19 @@ def _maybe_fetch_media(body: str, _refs_out: "list | None" = None) -> str:
 
 def _write_owner_activity(task: dict) -> None:
     """Record that the owner was active on this transport right now — but only
-    when THIS node grants gateway traffic owner tier (LOCAL_TIER, never the
-    gateway's own claim; the gateway is outside the trust boundary). Atomic write
-    via tmp+rename; same schema (`ts`, `channel`, `summary`) as
-    discord-bridge.write_owner_activity so the proactive-loop reader is
-    transport-agnostic. Best-effort — never blocks task intake."""
-    if LOCAL_TIER != "owner":
+    when THIS node resolves the SENDER to owner tier. Gated on
+    `_tier_for(user_id)`, NOT the gateway-wide LOCAL_TIER: in a shared room a
+    down-tiered teammate (tierMap[...] = "team"/"other") must not overwrite
+    `state/last-owner-activity.json`, or their message would poison owner-presence
+    routing (the proactive-loop's "owner active N min ago" signal + the core-
+    supervisor escalation target). For an unlisted sender `_tier_for` returns
+    LOCAL_TIER, so the single-owner case is unchanged. Never trusts the gateway's
+    own claim (it is outside the trust boundary) — only the broker-attested
+    user_id keyed against the owner's LOCAL tierMap. Atomic write via tmp+rename;
+    same schema (`ts`, `channel`, `summary`) as discord-bridge.write_owner_activity
+    so the proactive-loop reader is transport-agnostic. Best-effort — never blocks
+    task intake."""
+    if _tier_for(task.get("user_id")) != "owner":
         return
     try:
         OWNER_ACTIVITY_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -159,6 +159,62 @@ if LOCAL_TIER not in ("owner", "team", "other"):
     # "owner" (the `or "owner"` above — the explicit personal-agent model).
     LOCAL_TIER = "team"
 
+
+# ── per-sender tier map (owner-controlled, LOCAL) ────────────────────────────
+# LOCAL_TIER above is the gateway-wide default. A SHARED room can carry messages
+# from senders who are NOT the owner (e.g. a teammate invited into a project
+# room). To tier those correctly WITHOUT trusting the task's self-claimed tier,
+# the OWNER declares a per-sender map in a LOCAL, owner-owned file:
+#   $CLAUDE_CONFIG_DIR/channels/ag2space/access.json → {"tierMap": {"@user:hs": "team"}}
+# We key the lookup on the BROKER-attested `user_id` (Matrix sender the broker
+# writes into the task, not a task-body self-claim), so this stays a LOCAL trust
+# decision — same principle as LOCAL_TIER. Only listed senders are re-tiered;
+# everyone else keeps LOCAL_TIER, so an unknown sender can never ESCALATE (the
+# map only DOWN-tiers named senders; owner stays owner by being absent from it).
+# Hot: re-read on mtime change so the owner can add teammates without a restart.
+def _ag2space_access_path():
+    base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
+    return os.path.join(base, "channels", "ag2space", "access.json")
+
+
+_TIER_MAP_CACHE = {"mtime": None, "map": {}}
+
+
+def _load_tier_map():
+    """Return the owner's {sender_mxid: tier} map, mtime-cached. Fail-soft to {}."""
+    path = _ag2space_access_path()
+    try:
+        mt = os.path.getmtime(path)
+    except OSError:
+        _TIER_MAP_CACHE["mtime"], _TIER_MAP_CACHE["map"] = None, {}
+        return {}
+    if mt == _TIER_MAP_CACHE["mtime"]:
+        return _TIER_MAP_CACHE["map"]
+    tm = {}
+    try:
+        with open(path) as f:
+            raw = (json.load(f) or {}).get("tierMap") or {}
+        for who, tier in raw.items():
+            t = str(tier).strip().lower()
+            if isinstance(who, str) and t in ("owner", "team", "other"):
+                tm[who.strip()] = t
+    except Exception:
+        tm = {}  # malformed file → no re-tiering, keep LOCAL_TIER for everyone
+    _TIER_MAP_CACHE["mtime"], _TIER_MAP_CACHE["map"] = mt, tm
+    return tm
+
+
+def _tier_for(user_id):
+    """Resolve the access_tier for a task's broker-attested sender.
+    Listed senders get their mapped tier; everyone else gets LOCAL_TIER."""
+    uid = (user_id or "").strip()
+    if uid:
+        mapped = _load_tier_map().get(uid)
+        if mapped in ("owner", "team", "other"):
+            return mapped
+    return LOCAL_TIER
+
+
 # ── inbound media fetch (owner screenshots, file uploads) ────────────────────
 # A gateway can hand the task body a media MARKER instead of raw bytes:
 #   [<tag>: <url> mime=<m> name=<f> size=<n> kind=<msgtype>] <caption>
@@ -623,8 +679,10 @@ def _write_task(task: dict) -> str | None:
     # consumer in skills/agent-room-ops/verify_platform_card.py.)
     # access_tier is a LOCAL decision and written LAST so it wins even under a
     # last-occurrence parser; every other field is newline-stripped so none can
-    # forge an earlier one either.
-    lines.append(f"access_tier: {LOCAL_TIER}")
+    # forge an earlier one either. Resolved per broker-attested sender via the
+    # owner's tierMap (LOCAL file), falling back to LOCAL_TIER for unlisted
+    # senders — so a named teammate can be down-tiered without trusting the task.
+    lines.append(f"access_tier: {_tier_for(task.get('user_id'))}")
     tmp = dest.with_suffix(".txt.tmp")
     tmp.write_text("\n".join(lines) + "\n")
     tmp.rename(dest)  # atomic publish so the watcher never sees a partial file

--- a/tests/gateway-per-sender-tier.test.py
+++ b/tests/gateway-per-sender-tier.test.py
@@ -79,5 +79,31 @@ check("malformed access.json → LOCAL_TIER", rgb._tier_for("@rick:ag2.space") =
 _write_map({"@rick:ag2.space": "team", "@sam:ag2.space": "team"})
 check("live-added teammate → team", rgb._tier_for("@sam:ag2.space") == "team")
 
-print(f"\nResults: {8 - len(failures)}/8 passed" if not failures else f"\nResults: FAILED {failures}")
+# --- owner-activity gate (same tier map must gate presence, not just task tier) ---
+# Regression for the blocking finding on a3e24dd: _write_owner_activity() gated on
+# the blanket LOCAL_TIER, so a down-tiered teammate still overwrote
+# state/last-owner-activity.json and poisoned owner-presence routing. It must gate
+# on the SENDER's resolved tier, exactly like the task access_tier write.
+OWNER_ACT = tmp / "last-owner-activity.json"
+rgb.OWNER_ACTIVITY_FILE = OWNER_ACT
+_write_map({"@rick:ag2.space": "team"})
+
+# 9. owner sender → owner-activity IS written
+OWNER_ACT.unlink(missing_ok=True)
+rgb._write_owner_activity({"task": "hi", "source": "ag2space", "user_id": "@qingyun:ag2.space", "channel_id": "!r:hs"})
+check("owner sender writes owner-activity", OWNER_ACT.exists())
+
+# 10. team-tier teammate → owner-activity NOT written (the fix)
+OWNER_ACT.unlink(missing_ok=True)
+rgb._write_owner_activity({"task": "hi", "source": "ag2space", "user_id": "@rick:ag2.space", "channel_id": "!r:hs"})
+check("team teammate does NOT write owner-activity", not OWNER_ACT.exists())
+
+# 11. team teammate cannot OVERWRITE a prior genuine owner-activity record
+rgb._write_owner_activity({"task": "owner here", "source": "ag2space", "user_id": "@qingyun:ag2.space", "channel_id": "!r:hs"})
+before = OWNER_ACT.read_text()
+rgb._write_owner_activity({"task": "rick here", "source": "ag2space", "user_id": "@rick:ag2.space", "channel_id": "!r:hs"})
+check("teammate does not clobber owner's activity record", OWNER_ACT.read_text() == before)
+
+_total = 11
+print(f"\nResults: {_total - len(failures)}/{_total} passed" if not failures else f"\nResults: FAILED {failures}")
 sys.exit(1 if failures else 0)

--- a/tests/gateway-per-sender-tier.test.py
+++ b/tests/gateway-per-sender-tier.test.py
@@ -6,7 +6,6 @@ self-claim). This test covers the owner-controlled per-sender tierMap layered on
 top of LOCAL_TIER: a named teammate is down-tiered by user_id, everyone else
 keeps LOCAL_TIER, and a malformed/missing map never re-tiers (fail-soft).
 """
-import importlib.util
 import json
 import sys
 import tempfile
@@ -14,16 +13,14 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 
-
-def _load(name, path):
-    spec = importlib.util.spec_from_file_location(name, path)
-    m = importlib.util.module_from_spec(spec)
-    sys.modules[name] = m
-    spec.loader.exec_module(m)
-    return m
-
-
-rgb = _load("remote_gateway_bridge", REPO / "src" / "remote-gateway-bridge.py")
+# Load the EXACT module this PR modifies — packages/ag2-sparrow/ag2_sparrow/
+# remote_gateway_bridge.py — as a proper package import so its relative imports
+# resolve. (An earlier version loaded src/remote-gateway-bridge.py, a shim that
+# EXECS this file; that shim contains none of these functions textually, so the
+# indirection made it non-obvious the test exercised the new code — review catch.
+# Importing the packages module directly removes all doubt.)
+sys.path.insert(0, str(REPO / "packages" / "ag2-sparrow"))
+import ag2_sparrow.remote_gateway_bridge as rgb  # noqa: E402
 
 failures = []
 
@@ -104,6 +101,27 @@ before = OWNER_ACT.read_text()
 rgb._write_owner_activity({"task": "rick here", "source": "ag2space", "user_id": "@rick:ag2.space", "channel_id": "!r:hs"})
 check("teammate does not clobber owner's activity record", OWNER_ACT.read_text() == before)
 
-_total = 11
+# --- clamp: the map can only DOWN-tier, never escalate above LOCAL_TIER ---
+# 12. on a LOCAL_TIER=team node, a map entry of "owner" is clamped to team, while
+# a "other" entry still down-tiers. Guards against a misconfigured/compromised
+# access.json escalating a sender above the node's own default.
+_prev_local = rgb.LOCAL_TIER
+rgb.LOCAL_TIER = "team"
+_write_map({"@rick:ag2.space": "owner", "@stranger:ag2.space": "other"})
+check("map cannot escalate above LOCAL_TIER (owner clamped to team)", rgb._tier_for("@rick:ag2.space") == "team")
+check("map still down-tiers below LOCAL_TIER (team node, 'other' honored)", rgb._tier_for("@stranger:ag2.space") == "other")
+rgb.LOCAL_TIER = _prev_local
+
+# --- fail-safe: a transient read error preserves the last-known-good map ---
+# 13. once a teammate is down-tiered, a malformed/mid-write access.json must NOT
+# silently fail-open them back to LOCAL_TIER (owner). Preserve last-known-good.
+_write_map({"@rick:ag2.space": "team"})
+assert rgb._tier_for("@rick:ag2.space") == "team"  # prime the cache with a good read
+ACCESS.write_text("{ corrupt not json ]")           # file now unparseable
+rgb._TIER_MAP_CACHE["mtime"] = -1                    # force a re-read attempt (hits except)
+check("malformed re-read keeps the down-tier (fail-safe, not fail-open to owner)",
+      rgb._tier_for("@rick:ag2.space") == "team")
+
+_total = 13
 print(f"\nResults: {_total - len(failures)}/{_total} passed" if not failures else f"\nResults: FAILED {failures}")
 sys.exit(1 if failures else 0)

--- a/tests/gateway-per-sender-tier.test.py
+++ b/tests/gateway-per-sender-tier.test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Per-sender access_tier resolution in the ag2-sparrow gateway.
+
+The gateway writes access_tier as a LOCAL decision (never trusting the task's
+self-claim). This test covers the owner-controlled per-sender tierMap layered on
+top of LOCAL_TIER: a named teammate is down-tiered by user_id, everyone else
+keeps LOCAL_TIER, and a malformed/missing map never re-tiers (fail-soft).
+"""
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+rgb = _load("remote_gateway_bridge", REPO / "src" / "remote-gateway-bridge.py")
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("ok   " if cond else "FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+tmp = Path(tempfile.mkdtemp(prefix="rgb-tier-test-"))
+ACCESS = tmp / "access.json"
+# point the resolver at our temp file, and make sure LOCAL_TIER is a known value
+rgb._ag2space_access_path = lambda: str(ACCESS)
+rgb.LOCAL_TIER = "owner"
+
+
+def _write_map(m):
+    ACCESS.write_text(json.dumps({"allowFrom": ["@qingyun:ag2.space"], "tierMap": m}))
+    rgb._TIER_MAP_CACHE["mtime"] = None  # force re-read (mtime granularity is coarse)
+
+
+# 1. named teammate is down-tiered by user_id
+_write_map({"@rick:ag2.space": "team"})
+check("mapped sender → team", rgb._tier_for("@rick:ag2.space") == "team")
+
+# 2. unlisted sender keeps LOCAL_TIER (owner) — no escalation, no accidental downgrade
+check("unlisted sender → LOCAL_TIER", rgb._tier_for("@qingyun:ag2.space") == "owner")
+
+# 3. empty / missing user_id → LOCAL_TIER
+check("empty user_id → LOCAL_TIER", rgb._tier_for("") == "owner")
+check("None user_id → LOCAL_TIER", rgb._tier_for(None) == "owner")
+
+# 4. invalid tier value in the map is ignored → LOCAL_TIER (never a bogus tier)
+_write_map({"@rick:ag2.space": "boss"})
+check("invalid tier value ignored → LOCAL_TIER", rgb._tier_for("@rick:ag2.space") == "owner")
+
+# 5. 'other' tier is honored
+_write_map({"@stranger:ag2.space": "other"})
+check("'other' tier honored", rgb._tier_for("@stranger:ag2.space") == "other")
+
+# 6. missing file → LOCAL_TIER (fail-soft, no crash)
+ACCESS.unlink()
+rgb._TIER_MAP_CACHE["mtime"] = None
+check("missing access.json → LOCAL_TIER", rgb._tier_for("@rick:ag2.space") == "owner")
+
+# 7. malformed JSON → LOCAL_TIER (fail-soft)
+ACCESS.write_text("{ not json ]")
+rgb._TIER_MAP_CACHE["mtime"] = None
+check("malformed access.json → LOCAL_TIER", rgb._tier_for("@rick:ag2.space") == "owner")
+
+# 8. live update: adding a teammate is picked up without reload (mtime cache)
+_write_map({"@rick:ag2.space": "team", "@sam:ag2.space": "team"})
+check("live-added teammate → team", rgb._tier_for("@sam:ag2.space") == "team")
+
+print(f"\nResults: {8 - len(failures)}/8 passed" if not failures else f"\nResults: FAILED {failures}")
+sys.exit(1 if failures else 0)


### PR DESCRIPTION
## What

Lets the ag2-sparrow gateway tier **individual senders** in a shared room, instead of stamping one blanket `LOCAL_TIER` on every task. Motivating case: a teammate (e.g. `@rick:ag2.space`) invited into a project room should be **team**-tier (sandboxed, read-only), but the gateway was tagging their messages **owner**.

## How

- New per-sender map, read from the owner's LOCAL file `$CLAUDE_CONFIG_DIR/channels/ag2space/access.json`:
  ```json
  { "tierMap": { "@rick:ag2.space": "team" } }
  ```
- At the write site, `access_tier` is resolved via `_tier_for(task["user_id"])` — the **broker-attested** Matrix sender (not the task's self-claimed tier) — mapped through the tierMap, falling back to `LOCAL_TIER`.

## Trust model — unchanged

- `access_tier` remains a **LOCAL decision**: the map is owner-owned; the task's self-claimed tier is still ignored.
- The map only **DOWN-tiers named senders**. An unknown sender is absent from the map ⇒ gets `LOCAL_TIER`; the owner stays owner by being absent. **No path to escalate.**
- `mtime`-cached → the owner can add teammates live (no gateway restart). Fail-soft to `LOCAL_TIER` on a missing/malformed file (never a bogus tier).

## Tests

`tests/gateway-per-sender-tier.test.py` — **8/8**: mapped→team · unlisted→LOCAL_TIER · empty/None user_id → LOCAL_TIER · invalid tier value ignored · `other` honored · missing file fail-soft · malformed file fail-soft · live-add via mtime cache.

`remote_gateway_bridge.py` is package-canonical (per `tools/sync_from_src.py`), so this is edited in place — no drift.

— @sutando-qingyun-001
