### PR TITLE
feat(runtime): advertise reachable direct call tiers in the descriptor (Track 9)

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -353,6 +353,26 @@ try:
         probe_voice_ws = vrec['voice_ws']
 except Exception:
     pass
+# call_tiers: the DIRECT call endpoints this core can advertise right now, the
+# runtime-authored half of the availability-driven call-tier menu (Track 9). The
+# emitter (src/emit-call-tiers.ts, from reachability-endpoints.ts) writes
+# state/call-tiers.json at startup; the client renders the tier picker from this
+# instead of the old static 'force tier' stub (greyed Direct even when live,
+# offered Local on a remote core). Only direct tiers are advertised — 'local' is
+# client-relative and cloud/relay are always-available + composed client-side.
+# The advertisement is a HINT: the client verifies reachability (first-reachable-
+# wins), so a stale entry degrades gracefully. Absent/malformed -> [] (client
+# falls back to cloud). A freshness window / re-emit-on-network-change is a
+# documented follow-up.
+probe_call_tiers = []
+try:
+    with open(os.path.join(ws, 'state', 'call-tiers.json')) as f:
+        crec = json.load(f)
+    ct = crec.get('call_tiers')
+    if isinstance(ct, list):
+        probe_call_tiers = ct
+except Exception:
+    pass
 env = dict(os.environ, SUTANDO_TMUX_SOCKET=probe_socket)
 h = {}
 try:
@@ -397,6 +417,11 @@ print(json.dumps({
     # state (probe_voice_ws above): voice-agent.ts records its actual bound PORT,
     # so a non-default-PORT install is reported correctly, not a hardcoded default.
     'voice_ws': probe_voice_ws,
+    # call_tiers: the direct call endpoints this core advertises (Track 9). The
+    # desktop 'Start Call' picker renders the tier menu from this — showing only
+    # reachable rows, un-greying Direct(Tailscale)/Direct(LAN) when their url is
+    # advertised. Runtime-authored via probe_call_tiers above (emit-call-tiers.ts).
+    'call_tiers': probe_call_tiers,
     'health': h.get('health', 'unknown'),
     'authenticated': h.get('authenticated'),
 }))

--- a/src/emit-call-tiers.ts
+++ b/src/emit-call-tiers.ts
@@ -1,0 +1,83 @@
+/**
+ * Emit the core's advertisable *direct* call tiers to `state/call-tiers.json` —
+ * the runtime-authored half of the availability-driven call-tier menu (Track 9).
+ *
+ * The desktop "Start Call" tier menu was a static "Developer — force tier"
+ * prototype: it greyed Direct(Tailscale) as "n/a" even when a tailnet endpoint
+ * was live, and offered Local even on a remote Pro core (owner live-test,
+ * 2026-07-10). The fix is availability-driven: the CORE advertises which direct
+ * endpoints it can actually offer, and the client renders the menu from that.
+ *
+ * This module is the core-advertise half. It composes the direct tiers from the
+ * existing `reachability-endpoints.ts` detection (tailnet + LAN, both gated by
+ * SUTANDO_LAN_SHARE) and writes them to a runtime-authored state file that
+ * `sutando-config.sh runtime` folds into the AgentRuntime descriptor's
+ * `call_tiers` field — the same runtime-authored-state pattern as `voice_ws`.
+ *
+ * Scope note: only the DIRECT tiers are advertised here. `local` and
+ * `cloud`/`relay` are NOT — `local` is a client-relative decision (only the
+ * client knows if it is co-located with this core), and cloud/relay are always
+ * available and composed client-side. The core advertises only what it uniquely
+ * knows: whether a directly-reachable endpoint exists right now.
+ *
+ * The advertisement is a HINT — the client resolver verifies reachability
+ * (first-reachable-wins, per reachability-endpoints.ts), so a slightly-stale
+ * entry degrades gracefully (client tries it, times out, falls back to cloud).
+ * Re-emitting on a network change / core heartbeat is a documented follow-up.
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { statusPath } from './workspace_default.js';
+import { directEndpoints } from './reachability-endpoints.js';
+
+export interface CallTier {
+	/** Stable machine id for the tier (client binds render logic to this). */
+	tier: string;
+	/** Human label for the menu row. */
+	label: string;
+	/** The reachable URL, or null when this tier can't be offered right now. */
+	url: string | null;
+	/** True iff `url` resolved — the client shows/un-greys the row only then. */
+	reachable: boolean;
+}
+
+/**
+ * Compose the direct call tiers from current reachability detection. Both are
+ * null (reachable:false) unless SUTANDO_LAN_SHARE is opted in AND the endpoint
+ * is actually detected (tailnet node online / private-LAN IPv4 present).
+ */
+export function composeCallTiers(): CallTier[] {
+	const { tailnet, lan } = directEndpoints();
+	return [
+		{ tier: 'direct-tailnet', label: 'Direct (Tailscale)', url: tailnet, reachable: tailnet !== null },
+		{ tier: 'direct-lan', label: 'Direct (LAN)', url: lan, reachable: lan !== null },
+	];
+}
+
+export interface CallTiersFile {
+	/** Unix seconds when this was written (for a freshness follow-up). */
+	ts: number;
+	/** Emitter pid (diagnostic; the client verifies reachability regardless). */
+	pid: number;
+	call_tiers: CallTier[];
+}
+
+/** Write `state/call-tiers.json` and return its path. */
+export function emitCallTiers(dest: string = statusPath('call-tiers.json')): string {
+	mkdirSync(dirname(dest), { recursive: true });
+	const payload: CallTiersFile = {
+		ts: Math.floor(Date.now() / 1000),
+		pid: process.pid,
+		call_tiers: composeCallTiers(),
+	};
+	writeFileSync(dest, JSON.stringify(payload));
+	return dest;
+}
+
+// Run directly (`node emit-call-tiers.js` / `tsx src/emit-call-tiers.ts`) —
+// startup wires this so the descriptor has a fresh advertisement each session.
+if (import.meta.url === `file://${process.argv[1]}`) {
+	const dest = emitCallTiers();
+	// eslint-disable-next-line no-console
+	console.log(`call-tiers written: ${dest}`);
+}

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -621,6 +621,14 @@ else
   echo "  ✓ voice agent (already running)"
 fi
 
+# 1b. Call-tier advertisement (one-shot): write state/call-tiers.json so the
+# runtime descriptor advertises which DIRECT call endpoints are reachable now
+# (Track 9 availability-driven call-tier menu). Backgrounded — it probes tailscale
+# with its own short timeout and never blocks the rest of startup; absent file
+# just means the descriptor advertises no direct tiers (client falls back to cloud).
+npx tsx src/emit-call-tiers.ts > "$LOGS_DIR/emit-call-tiers.log" 2>&1 &
+echo "  ✓ call-tiers advertisement"
+
 # 2. Web client (port 8080)
 reap_wedged_listener 8080 web-client
 if ! lsof -i :8080 > /dev/null 2>&1; then

--- a/tests/call-tiers-emit.test.ts
+++ b/tests/call-tiers-emit.test.ts
@@ -1,0 +1,60 @@
+/**
+ * emit-call-tiers.ts — the core-advertise half of the availability-driven
+ * call-tier menu (Track 9). Covers tier composition from reachability detection
+ * and the state-file write that `sutando-config.sh runtime` folds into the
+ * descriptor's `call_tiers`.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { composeCallTiers, emitCallTiers, type CallTiersFile } from '../src/emit-call-tiers.ts';
+
+// composeCallTiers reads process.env (SUTANDO_LAN_SHARE) via reachability-endpoints.
+// With LAN sharing OFF (default in CI), both direct tiers are unreachable — the
+// exact "nothing to offer -> client falls back to cloud" default.
+test('composeCallTiers: both direct tiers present, unreachable when LAN-share off', () => {
+	const prev = process.env.SUTANDO_LAN_SHARE;
+	delete process.env.SUTANDO_LAN_SHARE;
+	try {
+		const tiers = composeCallTiers();
+		assert.equal(tiers.length, 2);
+		const byTier = Object.fromEntries(tiers.map((t) => [t.tier, t]));
+		assert.deepEqual(Object.keys(byTier).sort(), ['direct-lan', 'direct-tailnet']);
+		for (const t of tiers) {
+			assert.equal(t.url, null, `${t.tier} url should be null when LAN-share off`);
+			assert.equal(t.reachable, false, `${t.tier} unreachable when url null`);
+			assert.equal(typeof t.label, 'string');
+			assert.ok(t.label.length > 0);
+		}
+	} finally {
+		if (prev !== undefined) process.env.SUTANDO_LAN_SHARE = prev;
+	}
+});
+
+test('reachable is exactly (url !== null) — the invariant the client binds to', () => {
+	for (const t of composeCallTiers()) {
+		assert.equal(t.reachable, t.url !== null);
+	}
+});
+
+test('emitCallTiers writes a parseable state file with the descriptor shape', () => {
+	const dir = mkdtempSync(join(tmpdir(), 'call-tiers-'));
+	const dest = join(dir, 'call-tiers.json');
+	try {
+		const written = emitCallTiers(dest);
+		assert.equal(written, dest);
+		const rec = JSON.parse(readFileSync(dest, 'utf8')) as CallTiersFile;
+		assert.equal(typeof rec.ts, 'number');
+		assert.equal(typeof rec.pid, 'number');
+		assert.ok(Array.isArray(rec.call_tiers));
+		assert.equal(rec.call_tiers.length, 2);
+		// Every entry carries the four keys the client renders from.
+		for (const t of rec.call_tiers) {
+			assert.deepEqual(Object.keys(t).sort(), ['label', 'reachable', 'tier', 'url']);
+		}
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
Core-advertise half of the **availability-driven call-tier menu** (Track 9). The desktop "Start Call" tier picker was a static *"Developer — force tier"* stub: it greyed **Direct (Tailscale)** as n/a even when a tailnet endpoint was live, and offered **Local** on a remote Pro core (owner live-test 2026-07-10). The fix is availability-driven — the **core advertises which direct endpoints it can actually offer**, and the client renders the menu from that.

## What (this PR — core half)
- **`src/emit-call-tiers.ts`** — composes the direct tiers from the existing `src/reachability-endpoints.ts` (`directEndpoints()` → tailnet + LAN, both gated by `SUTANDO_LAN_SHARE`, previously **zero consumers**) and writes `state/call-tiers.json`. Same runtime-authored-state pattern as `voice_ws`.
- **`scripts/sutando-config.sh runtime`** — folds `state/call-tiers.json` into the descriptor’s new **`call_tiers`** field. Absent/malformed → `[]` (client falls back to cloud). Only **direct** tiers are advertised — `local` is client-relative and cloud/relay are always-available + composed client-side.
- **`src/startup.sh`** — runs the emitter once at boot (backgrounded; own tailscale timeout; never blocks startup).

## Shape
```json
"call_tiers": [
  {"tier":"direct-tailnet","label":"Direct (Tailscale)","url":"https://host.ts.net","reachable":true},
  {"tier":"direct-lan","label":"Direct (LAN)","url":null,"reachable":false}
]
```
`reachable` is exactly `url !== null`. The advertisement is a **hint** — the client verifies reachability (first-reachable-wins per `reachability-endpoints.ts`), so a stale entry degrades gracefully. A freshness window / re-emit-on-network-change is a documented follow-up.

## Client half (sibling PR)
The cinny-desktop picker renders the menu from `call_tiers` (show only reachable rows, un-grey Direct when advertised, hide Local when not co-located). Contract handed to @qingyun-air.agent.

## Tests
- `tests/call-tiers-emit.test.ts` (3): tier composition, `reachable == (url !== null)` invariant, state-file shape.
- Descriptor round-trip verified locally: present → reachable tier surfaces; absent → `[]`. Reachability suite unchanged (20/20 TS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)