### PR TITLE
fix(core-supervisor): actually run the communicator relay on a cadence

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -414,13 +414,17 @@ ensure_core_monitor() {
   relay_pid_file="$ws/state/core-supervisor-relay-loop.pid"
   relay_state="$ws/state/core-supervisor-relay.state"
   if ! { [ -f "$relay_pid_file" ] && kill -0 "$(cat "$relay_pid_file" 2>/dev/null)" 2>/dev/null; }; then
+    # Redirect the WHOLE subshell (not just the inner python) to the log, so the
+    # backgrounded loop does not inherit/hold this script's stdout/stderr — else a
+    # caller that captures start-cli.sh's output (e.g. tests/start-cli-*.test.py)
+    # blocks on the pipe until this infinite loop closes it (never) and times out.
+    # Mirrors the monitor launch above, which redirects to /tmp/core-input-watch.log.
     ( while true; do
         python3 "$REPO/src/core-supervisor-relay.py" \
           --signal "$mon_out" --state-file "$relay_state" \
-          --active-from "$ws/state/last-owner-activity.json" \
-          >> /tmp/core-supervisor-relay.log 2>&1
+          --active-from "$ws/state/last-owner-activity.json"
         sleep 30
-      done ) &
+      done ) >> /tmp/core-supervisor-relay.log 2>&1 &
     echo $! > "$relay_pid_file"
   fi
 }

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -393,16 +393,36 @@ apply_tmux_defaults() {
 # The guard is scoped to THIS socket + out path so a monitor for a different
 # core/socket can never suppress this one.
 ensure_core_monitor() {
-  local ws mon_out
+  local ws mon_out relay_pid_file relay_state
   ws="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)" || return 0
   [ -n "$ws" ] || return 0
   mon_out="$ws/state/core-supervisor.json"
-  if pgrep -f "core-input-watch\.py .*--socket ${TMUX_SOCKET} .*--out ${mon_out}" > /dev/null 2>&1; then
-    return 0   # a monitor for this exact core is already running
+  # Monitor (PR #2100): launch unless one for this exact socket+out is running.
+  if ! pgrep -f "core-input-watch\.py .*--socket ${TMUX_SOCKET} .*--out ${mon_out}" > /dev/null 2>&1; then
+    python3 "$REPO/src/core-input-watch.py" \
+      --socket "$TMUX_SOCKET" --session "$SESSION" --out "$mon_out" \
+      > /tmp/core-input-watch.log 2>&1 &
   fi
-  python3 "$REPO/src/core-input-watch.py" \
-    --socket "$TMUX_SOCKET" --session "$SESSION" --out "$mon_out" \
-    > /tmp/core-input-watch.log 2>&1 &
+  # Communicator relay (PR #2101): the monitor only WRITES core-supervisor.json;
+  # nothing escalated it, so a hard-blocker (blocked-human / logged-out) on a
+  # no-TTY core never reached an away owner. Run the one-shot relay on a cadence
+  # so those states escalate to the owner's most-recently-active channel
+  # (--active-from). The relay debounces internally (--state-file), so re-running
+  # every 30s escalates a given stuck episode exactly once. Pidfile + kill -0
+  # guard so an attach/re-run never double-starts the loop. Only blocked-human /
+  # logged-out escalate (relay's HARD_ESCALATE); hung/crashed are RECOVER's job.
+  relay_pid_file="$ws/state/core-supervisor-relay-loop.pid"
+  relay_state="$ws/state/core-supervisor-relay.state"
+  if ! { [ -f "$relay_pid_file" ] && kill -0 "$(cat "$relay_pid_file" 2>/dev/null)" 2>/dev/null; }; then
+    ( while true; do
+        python3 "$REPO/src/core-supervisor-relay.py" \
+          --signal "$mon_out" --state-file "$relay_state" \
+          --active-from "$ws/state/last-owner-activity.json" \
+          >> /tmp/core-supervisor-relay.log 2>&1
+        sleep 30
+      done ) &
+    echo $! > "$relay_pid_file"
+  fi
 }
 
 # Already running — attach if interactive, else exit cleanly. A managed core is


### PR DESCRIPTION
The never-STUCK escalation chain was built end-to-end but **not wired**.

## The gap
- The M1 monitor (`core-input-watch.py`, #2100) writes `state/core-supervisor.json` each tick.
- The communicator relay (`core-supervisor-relay.py`, #2101) reads that signal and escalates a **hard-blocker** (`blocked-human` / `logged-out`) to the owner’s most-recently-active channel.
- **But nothing invoked the relay.** `start-cli.sh` launched only the monitor. A `git grep` for the relay CLI finds zero real callers (only a comment). So when a no-TTY core hit a `/login` or an unrecognized permission prompt, the signal was written and the in-app banner could show it — but the multi-channel escalation to an **away** owner never fired.

## The fix
Wire the relay in `ensure_core_monitor()` (the one place that knows the canonical `TMUX_SOCKET` + workspace):
- After the monitor, run the **one-shot relay every 30s** against the signal the monitor writes, with `--active-from state/last-owner-activity.json` so it targets wherever the owner was last active.
- The relay **debounces internally** (`--state-file`) → a given stuck episode escalates exactly once; a genuinely new prompt re-escalates.
- **Pidfile + `kill -0` guard** so an attach/re-run never double-starts the loop (same idempotency the monitor block already has).
- Only `blocked-human` / `logged-out` escalate here (relay’s `HARD_ESCALATE`); `hung`/`crashed` stay RECOVER’s job, so the relay never fights the restart thread.

The monitor guard changes from early-return to conditional-launch so both the monitor **and** the relay are reached + independently guarded. Monitor behavior is otherwise identical (launch iff not already running).

## Verification
- `bash -n` clean.
- Relay **escalates** a `blocked-human` signal → **debounces** the repeat → **re-escalates** a new prompt → **never** escalates `idle-ready`.
- Existing `tests/core-supervisor-relay.test.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)