### PR TITLE
fix(vision): lazy-start the screen-capture-server so Watch works in the bundled app

### DIFF
--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -89,7 +89,21 @@ export async function ensureScreenCaptureServer(): Promise<void> {
 	const start = (async () => {
 		// screen-capture-server.py sits next to this module in src/.
 		const script = join(dirname(fileURLToPath(import.meta.url)), 'screen-capture-server.py');
-		const child = spawn('python3', [script], { detached: true, stdio: 'ignore' });
+		// The bundled .app's voice-agent runs under a MINIMAL launchd PATH (no
+		// /opt/homebrew/bin etc. — same class as the claude-on-PATH gotcha, desktop
+		// PR #50). A bare `python3` would ENOENT there — Watch would still silently
+		// fail, one layer deeper. And screen-capture-server.py itself shells out to
+		// `screencapture` (/usr/sbin). Prepend the standard macOS bin dirs so BOTH
+		// the interpreter and the server's own subprocess resolve regardless of how
+		// the app launched the runtime. (Review: air, bundled-spawn-PATH risk.)
+		const augmentedPath = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/usr/sbin', '/bin', process.env.PATH]
+			.filter(Boolean)
+			.join(':');
+		const child = spawn('python3', [script], {
+			detached: true,
+			stdio: 'ignore',
+			env: { ...process.env, PATH: augmentedPath },
+		});
 		child.unref();
 		for (let i = 0; i < 40; i++) {
 			if (await _portListening(SCREEN_CAPTURE_PORT)) return;

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -84,9 +84,9 @@ function _portListening(port: number): Promise<boolean> {
  *  Reuses a running server (startup.sh's, or a prior lazy spawn); memoizes the
  *  in-flight spawn so concurrent captures don't double-start it. */
 export async function ensureScreenCaptureServer(): Promise<void> {
-	if (await _portListening(SCREEN_CAPTURE_PORT)) return;
-	if (_screenCaptureStarting) return _screenCaptureStarting;
-	_screenCaptureStarting = (async () => {
+	if (await _portListening(SCREEN_CAPTURE_PORT)) return; // reuse a running server
+	if (_screenCaptureStarting) return _screenCaptureStarting; // join an in-flight spawn
+	const start = (async () => {
 		// screen-capture-server.py sits next to this module in src/.
 		const script = join(dirname(fileURLToPath(import.meta.url)), 'screen-capture-server.py');
 		const child = spawn('python3', [script], { detached: true, stdio: 'ignore' });
@@ -96,11 +96,21 @@ export async function ensureScreenCaptureServer(): Promise<void> {
 			await new Promise((r) => setTimeout(r, 200));
 		}
 		throw new Error('screen-capture-server did not come up on :7845 within 8s');
-	})().catch((err) => {
-		_screenCaptureStarting = null; // reset so a later capture retries the spawn
-		throw err;
-	});
-	return _screenCaptureStarting;
+	})();
+	_screenCaptureStarting = start;
+	try {
+		await start;
+	} finally {
+		// Clear on BOTH success and failure: _screenCaptureStarting exists only to
+		// dedupe a CONCURRENT spawn, not to cache a completed one. Memoizing the
+		// resolved promise would make a later call short-circuit past the spawn even
+		// after the detached server has died/crashed — the port check above would
+		// see :7845 down but this guard would return the stale "up" promise, leaving
+		// Watch connection-refused until the whole voice-agent restarts (review P1 on
+		// 0589a18). Clearing here means the next capture re-checks the port and
+		// re-spawns if the server is gone — true self-healing.
+		_screenCaptureStarting = null;
+	}
 }
 
 const screenSource: VisionSource = {

--- a/src/vision-tools.ts
+++ b/src/vision-tools.ts
@@ -18,10 +18,12 @@
 
 import { readFileSync, writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { execFile } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { createServer, type Server } from 'node:http';
+import { connect } from 'node:net';
+import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import type { ToolDefinition } from 'bodhi-realtime-agent';
 import { resolveWorkspace, statusPath } from './workspace_default.js';
@@ -51,9 +53,62 @@ export interface VisionSource {
 	capture(): Promise<VisionFrame>;
 }
 
+// --- screen-capture-server (:7845) lazy start ----------------------------
+// The screen source grabs frames from the screen-capture-server on :7845. That
+// server is launched by startup.sh (the OSS menu-bar path) — but NOT by
+// start-cli.sh, which is how the bundled desktop app (ag2-space/ag2space-cinny-
+// desktop) launches the core. So in the bundled app the Watch toggle hit a dead
+// :7845 (connection refused) and silently did nothing, even with Screen Recording
+// granted. Rather than depend on every launch path remembering to start :7845,
+// the vision pipeline starts it ON DEMAND here: self-healing, works identically
+// in the OSS app and the bundled Tauri app. (First-run macOS Screen Recording
+// prompting via CGRequestScreenCaptureAccess is a documented follow-up — this
+// change unblocks the already-granted case and stops the silent failure.)
+const SCREEN_CAPTURE_PORT = 7845;
+let _screenCaptureStarting: Promise<void> | null = null;
+
+function _portListening(port: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		const sock = connect({ host: '127.0.0.1', port });
+		const done = (up: boolean) => {
+			sock.destroy();
+			resolve(up);
+		};
+		sock.once('connect', () => done(true));
+		sock.once('error', () => done(false));
+		sock.setTimeout(600, () => done(false));
+	});
+}
+
+/** Ensure the screen-capture-server is up on :7845, spawning it if absent.
+ *  Reuses a running server (startup.sh's, or a prior lazy spawn); memoizes the
+ *  in-flight spawn so concurrent captures don't double-start it. */
+export async function ensureScreenCaptureServer(): Promise<void> {
+	if (await _portListening(SCREEN_CAPTURE_PORT)) return;
+	if (_screenCaptureStarting) return _screenCaptureStarting;
+	_screenCaptureStarting = (async () => {
+		// screen-capture-server.py sits next to this module in src/.
+		const script = join(dirname(fileURLToPath(import.meta.url)), 'screen-capture-server.py');
+		const child = spawn('python3', [script], { detached: true, stdio: 'ignore' });
+		child.unref();
+		for (let i = 0; i < 40; i++) {
+			if (await _portListening(SCREEN_CAPTURE_PORT)) return;
+			await new Promise((r) => setTimeout(r, 200));
+		}
+		throw new Error('screen-capture-server did not come up on :7845 within 8s');
+	})().catch((err) => {
+		_screenCaptureStarting = null; // reset so a later capture retries the spawn
+		throw err;
+	});
+	return _screenCaptureStarting;
+}
+
 const screenSource: VisionSource = {
 	name: 'screen',
 	async capture() {
+		// Self-healing: bring up the screen-capture-server if the current launch
+		// path (e.g. the bundled desktop app's start-cli.sh) didn't start it.
+		await ensureScreenCaptureServer();
 		// silent=true skips the menu-bar flash + macOS notification, which would
 		// otherwise fire on every frame during a stream. format=jpeg keeps
 		// frames small (~50–150KB).


### PR DESCRIPTION
The v0.3.0 **Watch** bug (owner-caught on live E2E): the "Watch my screen" toggle did nothing — no screen-share prompt, no frames — even with macOS Screen Recording granted.

## Root cause
The Watch chain is: button → `/vision/start` on :7847 (voice-agent) → `screenSource.capture()` → **screen-capture-server on :7845** → screen grab. That server is launched by `startup.sh` (the OSS menu-bar path) but **NOT** by `start-cli.sh`, which is how the bundled desktop app (ag2-space/ag2space-cinny-desktop) launches the core. So in the bundled app, voice works (voice-agent + :7847 are up) but `:7845` is dead → the fetch gets connection-refused and the Watch silently fails. Screen Recording being ON is irrelevant because `screencapture` is never reached.

## Fix
Rather than depend on every launch path remembering to start `:7845`, the vision pipeline brings it up **on demand**: `screenSource.capture()` calls `ensureScreenCaptureServer()`, which
- spawns `python3 src/screen-capture-server.py` if `:7845` isn’t listening,
- reuses a running server otherwise (startup.sh’s, or a prior lazy spawn),
- memoizes the in-flight spawn so concurrent captures don’t double-start it.

Self-healing → works identically in the OSS app and the bundled Tauri app.

## Verification
Local: with `:7845` down, `ensureScreenCaptureServer()` spawns it and the port comes up within ~200ms; a second call reuses it. Real E2E = the owner clicking Watch on the next cinny-desktop build.

## Follow-up
Trigger the macOS Screen Recording prompt via `CGRequestScreenCaptureAccess()` on first use (coordinating python-vs-Rust-layer with the desktop lane), so first-run users get the permission dialog instead of `screencapture` silently returning black frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)