### PR TITLE
feat(call-tiers): python emitter for node-less installs (Track 9 desktop gap)

### DIFF
--- a/src/emit_call_tiers.py
+++ b/src/emit_call_tiers.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""emit_call_tiers — python port of src/emit-call-tiers.ts for node-less installs.
+
+The TS emitter is invoked by startup.sh via `npx tsx`, which DESKTOP-LAUNCHED
+cores never run: launch-sutando.sh (ag2space-cinny-desktop) wraps core+gateway
+only, and the bundled engine ships python+tmux with NO node toolchain (R1's
+bundled node ships pre-built service dists, not a tsx runner). Result observed
+live 2026-07-16: the runtime descriptor folds `call_tiers: []` on a desktop
+install, so the availability-driven Start-Call menu (Track 9) never sees the
+core's direct routes. This port lets the desktop launcher emit the SAME
+`state/call-tiers.json` with the python the engine already bundles.
+
+Behavior parity with emit-call-tiers.ts + reachability-endpoints.ts:
+  - only DIRECT tiers advertised (local is client-relative; cloud/relay are
+    client-composed) — the advertisement is a HINT, the client still verifies;
+  - both tiers gated by SUTANDO_LAN_SHARE;
+  - tailnet: `tailscale status --json` (1.5s timeout), Online gate, MagicDNS
+    name preferred over the 100.x IPv4; SUTANDO_TAILNET_SERVE flips the URL to
+    https://<host> (tailscale serve fronts :443), else http://<host>:CLIENT_PORT;
+  - lan: lowest-named interface's RFC1918 IPv4 (tailnet 100.64/10, loopback and
+    link-local excluded), http://<ip>:CLIENT_PORT;
+  - payload {ts, pid, call_tiers} written to status_path('call-tiers.json').
+
+Keep the two emitters in sync: a tier/label/shape change here must land in
+emit-call-tiers.ts too (and vice versa) — `sutando-config.sh runtime` and the
+desktop `console_status` passthrough read whichever ran last.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+_SRC = os.path.dirname(os.path.abspath(__file__))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from workspace_default import status_path  # noqa: E402
+
+
+def _client_port() -> int:
+    try:
+        return int(os.environ.get("CLIENT_PORT", "") or 8080)
+    except ValueError:
+        return 8080
+
+
+def _flag(name: str) -> bool:
+    return bool(re.match(r"^(1|true|yes|on)$", os.environ.get(name, ""), re.IGNORECASE))
+
+
+def lan_share_enabled() -> bool:
+    """True when sharing the core off-localhost is opted in (mirrors web-client.ts)."""
+    return _flag("SUTANDO_LAN_SHARE")
+
+
+def tailnet_serve_enabled() -> bool:
+    """True when `tailscale serve` fronts the webUI (HTTPS on the MagicDNS name)."""
+    return _flag("SUTANDO_TAILNET_SERVE")
+
+
+def is_private_lan_ipv4(ip: str) -> bool:
+    """RFC1918 private-LAN IPv4 (10/8, 172.16/12, 192.168/16) — excludes
+    loopback, link-local, and CGNAT/tailnet (100.64/10) like the TS original."""
+    parts = ip.split(".")
+    if len(parts) != 4:
+        return False
+    try:
+        m = [int(p) for p in parts]
+    except ValueError:
+        return False
+    if any(n < 0 or n > 255 for n in m):
+        return False
+    if m[0] == 10:
+        return True
+    if m[0] == 172 and 16 <= m[1] <= 31:
+        return True
+    if m[0] == 192 and m[1] == 168:
+        return True
+    return False
+
+
+def parse_ifconfig_lan_ipv4(text: str) -> str | None:
+    """First private-LAN IPv4 from `ifconfig -a` output, interfaces in listed
+    order (macOS lists them name-sorted enough for the TS parity goal: a
+    deterministic pick). Pure for unit tests."""
+    current: list[tuple[str, str]] = []
+    iface = ""
+    for line in text.splitlines():
+        m = re.match(r"^(\S+?):", line)
+        if m:
+            iface = m.group(1)
+            continue
+        m = re.search(r"^\s+inet\s+(\d+\.\d+\.\d+\.\d+)", line)
+        if m and is_private_lan_ipv4(m.group(1)):
+            current.append((iface, m.group(1)))
+    if not current:
+        return None
+    return sorted(current, key=lambda t: t[0])[0][1]
+
+
+def detect_lan_ipv4(run=None) -> str | None:
+    """The machine's primary private-LAN IPv4 via ifconfig, or None. Injectable
+    runner keeps it testable; any failure is a benign None."""
+    if run is None:
+        def run():  # pragma: no cover - thin subprocess shim
+            try:
+                r = subprocess.run(["ifconfig", "-a"], capture_output=True,
+                                   timeout=1.5, text=True)
+                return r.stdout if r.returncode == 0 and r.stdout else None
+            except Exception:
+                return None
+    out = run()
+    return parse_ifconfig_lan_ipv4(out) if out else None
+
+
+def parse_tailnet_host(status) -> str | None:
+    """Tailnet host from parsed `tailscale status --json`, or None. Prefers the
+    MagicDNS name (trailing dot stripped) and falls back to the 100.x IPv4;
+    nothing is advertised when the node reports Online: false."""
+    if not isinstance(status, dict):
+        return None
+    self_ = status.get("Self")
+    if not isinstance(self_, dict):
+        return None
+    if self_.get("Online") is False:
+        return None
+    dns = self_.get("DNSName")
+    if isinstance(dns, str) and dns:
+        return dns.rstrip(".")
+    ips = self_.get("TailscaleIPs")
+    if isinstance(ips, list):
+        for ip in ips:
+            if isinstance(ip, str) and ip.startswith("100."):
+                return ip
+    return None
+
+
+def detect_tailnet_host(run=None) -> str | None:
+    """Tailnet host via the local `tailscale` CLI, or None when tailscale is
+    absent/down. Short timeout so a hung binary never blocks the launcher."""
+    if run is None:
+        def run():  # pragma: no cover - thin subprocess shim
+            try:
+                r = subprocess.run(["tailscale", "status", "--json"],
+                                   capture_output=True, timeout=1.5, text=True)
+                return r.stdout if r.returncode == 0 and r.stdout else None
+            except Exception:
+                return None
+    out = run()
+    if not out:
+        return None
+    try:
+        return parse_tailnet_host(json.loads(out))
+    except (ValueError, TypeError):
+        return None
+
+
+def compose_tailnet_url(host: str, serve: bool | None = None) -> str:
+    """serve on → HTTPS on the MagicDNS name (tailscale serve fronts :443);
+    off → plain HTTP on CLIENT_PORT."""
+    if serve is None:
+        serve = tailnet_serve_enabled()
+    return f"https://{host}" if serve else f"http://{host}:{_client_port()}"
+
+
+def tailnet_endpoint_url() -> str | None:
+    if not lan_share_enabled():
+        return None
+    host = detect_tailnet_host()
+    return compose_tailnet_url(host) if host else None
+
+
+def lan_endpoint_url() -> str | None:
+    if not lan_share_enabled():
+        return None
+    ip = detect_lan_ipv4()
+    return f"http://{ip}:{_client_port()}" if ip else None
+
+
+def compose_call_tiers() -> list[dict]:
+    """Direct tiers in resolver-preferred order — identical shape + labels to
+    composeCallTiers() in emit-call-tiers.ts."""
+    tailnet = tailnet_endpoint_url()
+    lan = lan_endpoint_url()
+    return [
+        {"tier": "direct-tailnet", "label": "Direct (Tailscale)",
+         "url": tailnet, "reachable": tailnet is not None},
+        {"tier": "direct-lan", "label": "Direct (LAN)",
+         "url": lan, "reachable": lan is not None},
+    ]
+
+
+def emit_call_tiers(dest: str | None = None) -> str:
+    """Write state/call-tiers.json ({ts, pid, call_tiers}) and return its path."""
+    import time
+    path = dest or str(status_path("call-tiers.json"))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    payload = {"ts": int(time.time()), "pid": os.getpid(),
+               "call_tiers": compose_call_tiers()}
+    with open(path, "w") as f:
+        json.dump(payload, f)
+    return path
+
+
+if __name__ == "__main__":
+    print(f"call-tiers written: {emit_call_tiers()}")

--- a/tests/emit-call-tiers-py.test.py
+++ b/tests/emit-call-tiers-py.test.py
@@ -1,0 +1,101 @@
+"""Tests for src/emit_call_tiers.py — parity with tests/call-tiers-emit.test.ts."""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import emit_call_tiers as ect
+
+
+class TestPrivateLanIpv4(unittest.TestCase):
+    def test_rfc1918_ranges(self):
+        for ip in ("10.0.0.1", "172.16.0.1", "172.31.255.255", "192.168.1.5"):
+            self.assertTrue(ect.is_private_lan_ipv4(ip), ip)
+
+    def test_excluded_ranges(self):
+        for ip in ("127.0.0.1", "169.254.1.1", "100.101.1.2", "8.8.8.8",
+                   "172.32.0.1", "172.15.0.1", "192.169.0.1"):
+            self.assertFalse(ect.is_private_lan_ipv4(ip), ip)
+
+    def test_malformed(self):
+        for ip in ("", "1.2.3", "a.b.c.d", "10.0.0.999", "10.0.0.-1"):
+            self.assertFalse(ect.is_private_lan_ipv4(ip), ip)
+
+
+class TestParseIfconfig(unittest.TestCase):
+    IFCONFIG = """lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+\tinet 127.0.0.1 netmask 0xff000000
+utun3: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1280
+\tinet 100.76.47.3 --> 100.76.47.3 netmask 0xffffffff
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+\tinet 192.168.1.23 netmask 0xffffff00 broadcast 192.168.1.255
+"""
+
+    def test_picks_private_lan_only(self):
+        self.assertEqual(ect.parse_ifconfig_lan_ipv4(self.IFCONFIG), "192.168.1.23")
+
+    def test_none_when_no_private(self):
+        self.assertIsNone(ect.parse_ifconfig_lan_ipv4("lo0:\n\tinet 127.0.0.1\n"))
+
+    def test_lowest_named_interface_wins(self):
+        text = ("en5:\n\tinet 10.0.0.5 netmask 0xff000000\n"
+                "en0:\n\tinet 192.168.1.9 netmask 0xffffff00\n")
+        self.assertEqual(ect.parse_ifconfig_lan_ipv4(text), "192.168.1.9")
+
+
+class TestParseTailnetHost(unittest.TestCase):
+    def test_prefers_magicdns_and_strips_dot(self):
+        s = {"Self": {"Online": True, "DNSName": "mbp.taila1a7c4.ts.net.",
+                      "TailscaleIPs": ["100.1.2.3"]}}
+        self.assertEqual(ect.parse_tailnet_host(s), "mbp.taila1a7c4.ts.net")
+
+    def test_falls_back_to_100x_ip(self):
+        s = {"Self": {"Online": True, "DNSName": "", "TailscaleIPs": ["fd7a::1", "100.1.2.3"]}}
+        self.assertEqual(ect.parse_tailnet_host(s), "100.1.2.3")
+
+    def test_offline_node_advertises_nothing(self):
+        s = {"Self": {"Online": False, "DNSName": "mbp.ts.net."}}
+        self.assertIsNone(ect.parse_tailnet_host(s))
+
+    def test_malformed(self):
+        for s in (None, [], {}, {"Self": None}, {"Self": {"DNSName": 3}}):
+            self.assertIsNone(ect.parse_tailnet_host(s), repr(s))
+
+
+class TestComposeTailnetUrl(unittest.TestCase):
+    def test_serve_https_no_port(self):
+        self.assertEqual(ect.compose_tailnet_url("h.ts.net", True), "https://h.ts.net")
+
+    def test_no_serve_http_client_port(self):
+        with patch.dict(os.environ, {"CLIENT_PORT": "9999"}):
+            self.assertEqual(ect.compose_tailnet_url("h.ts.net", False), "http://h.ts.net:9999")
+
+
+class TestComposeAndEmit(unittest.TestCase):
+    def test_gated_off_both_unreachable(self):
+        with patch.dict(os.environ, {"SUTANDO_LAN_SHARE": ""}):
+            tiers = ect.compose_call_tiers()
+        self.assertEqual([t["tier"] for t in tiers], ["direct-tailnet", "direct-lan"])
+        self.assertTrue(all(t["url"] is None and t["reachable"] is False for t in tiers))
+
+    def test_emit_payload_shape(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+             patch.dict(os.environ, {"SUTANDO_LAN_SHARE": ""}):
+            dest = os.path.join(tmp, "state", "call-tiers.json")
+            out = ect.emit_call_tiers(dest)
+            self.assertEqual(out, dest)
+            with open(dest) as f:
+                payload = json.load(f)
+        self.assertIn("ts", payload)
+        self.assertIn("pid", payload)
+        self.assertEqual(len(payload["call_tiers"]), 2)
+        # shape identical to the TS emitter: {tier,label,url,reachable}
+        self.assertEqual(sorted(payload["call_tiers"][0]), ["label", "reachable", "tier", "url"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the desktop half of the Track-9 emit gap found by live probe (see roadmap/STATUS-2026-07-16.md): **desktop-launched cores never emit `call_tiers`** — `launch-sutando.sh` skips `startup.sh` (the `npx tsx` emitter's only home), and bundled installs ship python+tmux with **no node toolchain** (R1 bundles node as service dists only). Observed live: descriptor folds `call_tiers: []`, so the availability-driven Start-Call menu (#2122 → cinny-desktop#116 → cinny-webclient#159) can never see direct routes on the v0.4.0 desktop target.

`src/emit_call_tiers.py` is a behavior-parity port of `emit-call-tiers.ts` + `reachability-endpoints.ts`: SUTANDO_LAN_SHARE gating, tailnet detection (`tailscale status --json`, Online gate, MagicDNS preferred, 1.5s timeout), SUTANDO_TAILNET_SERVE https switch, RFC1918 LAN pick (injectable ifconfig parse), identical `{ts, pid, call_tiers}` payload to `status_path('call-tiers.json')`. Both module docs carry a keep-in-sync note.

## Verification
- 14 unit tests (RFC1918 edges, ifconfig parse, tailnet parse incl. Online:false + MagicDNS-dot-strip, serve URL switch, gating, payload shape) — all green.
- **Live E2E on a real node-less desktop install** (this host): `python3 src/emit_call_tiers.py` → `state/call-tiers.json` written → `sutando-config.sh runtime` folds the tier objects into the descriptor. Both tiers correctly `reachable:false` (LAN share off here).

Follow-up PR (ag2space-cinny-desktop): `launch-sutando.sh` invokes this via the bundled python once the engine pin includes it — then the owner-MBP Track-9 E2E works on desktop-native cores too.

cc @sutando-qingyun-001 — this is the fix-option-1 lean from my 11:47 driver post; grab the review when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwMjjL4xVu4qUnAoCzdbTH