### PR TITLE
fix(telemetry): flush feature events before script exit

### DIFF
--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -210,10 +210,10 @@ def main():
 
     # Anonymous, opt-out product telemetry: one bucketed event when this feature
     # actually runs (not on the cached early return). Never content/PII.
-    try:  # pragma: no cover — fire-and-forget; logic tested in tests/telemetry.test.py
+    try:  # pragma: no cover — bounded flush; logic tested in tests/telemetry.test.py
         from telemetry import feature_used  # sibling module (src/ on sys.path)
 
-        feature_used("daily_insight")
+        feature_used("daily_insight", flush=True)
     except Exception:  # pragma: no cover — telemetry must never break the feature
         pass
 

--- a/src/morning-briefing.py
+++ b/src/morning-briefing.py
@@ -424,10 +424,10 @@ def main():
 
     # Anonymous, opt-out product telemetry: one bucketed event when this feature
     # actually runs (not on the already-delivered early return). No content/PII.
-    try:  # pragma: no cover — fire-and-forget; logic tested in tests/telemetry.test.py
+    try:  # pragma: no cover — bounded flush; logic tested in tests/telemetry.test.py
         from telemetry import feature_used  # sibling module (src/ on sys.path)
 
-        feature_used("morning_briefing")
+        feature_used("morning_briefing", flush=True)
     except Exception:  # pragma: no cover — telemetry must never break the feature
         pass
 

--- a/src/telemetry.py
+++ b/src/telemetry.py
@@ -149,24 +149,28 @@ def enabled() -> bool:
     return bool(_KEY) and not opted_out()
 
 
-def _post(payload: dict) -> None:  # pragma: no cover — real network I/O; mocked in tests
+def _post(payload: dict, timeout: float = 5) -> None:  # pragma: no cover — real network I/O; mocked in tests
     try:
         req = urllib.request.Request(
             f"{_HOST}/capture/",
             data=json.dumps(payload).encode("utf-8"),
             headers={"Content-Type": "application/json"},
         )
-        urllib.request.urlopen(req, timeout=5).read()
+        urllib.request.urlopen(req, timeout=timeout).read()
     except Exception:
         pass  # best-effort: telemetry must never affect the app
 
 
-def capture(event: str, properties: dict | None = None) -> None:
+def capture(event: str, properties: dict | None = None, *, flush: bool = False) -> None:
     """Record one anonymous product event. No-op if opted out or no key.
 
     ``properties`` must be bucketed/categorical only — never task content,
     message text, paths, or PII. The caller owns that discipline; this module
     does not inspect payloads beyond attaching the anonymous distinct id.
+
+    ``flush=True`` uses a bounded synchronous send for short-lived commands
+    that are about to exit. Long-running services should keep the default
+    daemon-thread path so telemetry never delays their work.
     """
     if os.environ.get("SUTANDO_DEBUG_TELEMETRY", "").strip().lower() in _TRUTHY:
         sys.stderr.write(
@@ -175,7 +179,7 @@ def capture(event: str, properties: dict | None = None) -> None:
         )
     if not enabled():
         return
-    _dispatch(event, properties)
+    _dispatch(event, properties, flush=flush)
 
 
 def task_processed(source: str) -> None:
@@ -189,15 +193,15 @@ def task_processed(source: str) -> None:
     capture("task_processed", {"source": str(source)})
 
 
-def feature_used(feature: str) -> None:
+def feature_used(feature: str, *, flush: bool = False) -> None:
     """One anonymous event when a named product feature runs, tagged only with
     the feature's short categorical name (e.g. ``morning_briefing``). Never any
     task content, arguments, or PII.
     """
-    capture("feature_used", {"feature": str(feature)})
+    capture("feature_used", {"feature": str(feature)}, flush=flush)
 
 
-def _dispatch(event: str, properties: dict | None) -> None:
+def _dispatch(event: str, properties: dict | None, *, flush: bool = False) -> None:
     props = {
         "$ip": "",
         "$geoip_disable": True,
@@ -221,4 +225,10 @@ def _dispatch(event: str, properties: dict | None) -> None:
         # inherent to any HTTPS request; the vendor is told not to keep it).
         "properties": props,
     }
-    threading.Thread(target=_post, args=(payload,), daemon=True).start()
+    if flush:
+        # One-shot feature scripts exit immediately after this call. A daemon
+        # sender is terminated with the interpreter, so give the request a
+        # short bounded window to complete before returning.
+        _post(payload, timeout=1)
+    else:
+        threading.Thread(target=_post, args=(payload,), daemon=True).start()

--- a/tests/telemetry.test.py
+++ b/tests/telemetry.test.py
@@ -18,10 +18,13 @@ Run: python3 tests/telemetry.test.py
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
+import subprocess
 import sys
 import tempfile
 import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 SRC = Path(__file__).resolve().parent.parent / "src"
@@ -206,7 +209,21 @@ def run():
         passed += 1
         print("ok   task_processed/feature_used send correct bucketed events")
 
-    # 7) The typed helpers ALSO honor opt-out (no path around capture()).
+    # 7) Short-lived callers can select the bounded synchronous path.
+    with tempfile.TemporaryDirectory() as td:
+        mod = _load(Path(td), key="phc_live")
+        calls = []
+        mod._post = lambda payload, timeout=5: calls.append((payload, timeout))  # type: ignore
+        mod.feature_used("morning_briefing", flush=True)
+        assert len(calls) == 1, f"flush path must send exactly once, got {len(calls)}"
+        payload, timeout = calls[0]
+        assert payload["event"] == "feature_used"
+        assert payload["properties"]["feature"] == "morning_briefing"
+        assert timeout == 1, f"flush path must stay bounded to 1s, got {timeout}"
+        passed += 1
+        print("ok   feature_used flush path sends synchronously with 1s bound")
+
+    # 8) The typed helpers ALSO honor opt-out (no path around capture()).
     with tempfile.TemporaryDirectory() as td:
         mod = _load(Path(td), key="phc_live", env={"DO_NOT_TRACK": "1"})
         calls = []
@@ -219,6 +236,62 @@ def run():
         assert calls == [], f"opt-out MUST silence phase-2 helpers too, got {calls}"
         passed += 1
         print("ok   phase-2 helpers honor opt-out (zero sends)")
+
+    # 9) A short-lived subprocess can flush feature telemetry before exit.
+    # This is the production lifecycle of morning-briefing.py/daily-insight.py;
+    # their old daemon sender was terminated with the interpreter.
+    with tempfile.TemporaryDirectory() as td:
+        received = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", "0"))
+                received.append(json.loads(self.rfile.read(length)))
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"ok")
+
+            def log_message(self, *_args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        server_thread = threading.Thread(target=server.serve_forever)
+        server_thread.start()
+        try:
+            env = {
+                **os.environ,
+                "POSTHOG_API_KEY": "phc_subprocess_test",
+                "POSTHOG_HOST": f"http://127.0.0.1:{server.server_port}",
+                "SUTANDO_STATE_DIR": td,
+                "SUTANDO_SURFACE": "oss",
+                "PYTHONPATH": str(SRC),
+            }
+            env.pop("DO_NOT_TRACK", None)
+            env.pop("SUTANDO_TELEMETRY", None)
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "from telemetry import feature_used; "
+                    "feature_used('subprocess_probe', flush=True)",
+                ],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join(timeout=2)
+
+        assert proc.returncode == 0, proc.stderr
+        assert len(received) == 1, \
+            f"short-lived process must deliver before exit, got {len(received)}"
+        assert received[0]["event"] == "feature_used"
+        assert received[0]["properties"]["feature"] == "subprocess_probe"
+        passed += 1
+        print("ok   short-lived subprocess flushes feature_used before exit")
 
     print(f"\nALL PASS ({passed} checks)")
     return 0


### PR DESCRIPTION
## What changed, and why?

`morning-briefing.py` and `daily-insight.py` emitted `feature_used` as their final action, but `telemetry.capture()` always sent on a daemon thread. Python terminates daemon threads when these one-shot commands exit, so most feature events never reached PostHog.

This adds an opt-in `flush=True` path with a bounded 1-second synchronous request for commands that are about to exit. The two one-shot feature scripts use it; long-running core/bridge telemetry keeps the existing non-blocking daemon-thread behavior.

## Review first

- `src/telemetry.py`: bounded flush path; async remains the default
- `tests/telemetry.test.py`: subprocess-lifecycle regression test with a real local HTTP server
- `src/morning-briefing.py` / `src/daily-insight.py`: opt into the flush path

## What bug does this prove?

The production-shaped immediate-exit probe on `origin/main` (`e4de7c32`) delivered **0/20** events. The same probe at this PR's HEAD delivered **20/20**.

The existing unit tests masked the bug because their helper explicitly joined newly spawned telemetry threads before asserting.

## Tests

### Automated

```text
$ python3.9 tests/telemetry.test.py
...
ok   short-lived subprocess flushes feature_used before exit
ALL PASS (15 checks)

$ python3.13 tests/telemetry.test.py
...
ok   short-lived subprocess flushes feature_used before exit
ALL PASS (15 checks)

$ python3 -m py_compile src/telemetry.py src/morning-briefing.py src/daily-insight.py tests/telemetry.test.py
# exit 0

$ git diff --check
# exit 0
```

A direct in-process assertion also exercises the bounded `_post(..., timeout=1)` branch; local diff coverage is **100% (8/8 changed lines)**.
The new regression test launches a short-lived Python subprocess, sends to an actual local `HTTPServer`, exits, and asserts that exactly one correctly-shaped `feature_used` payload arrived.

### Failing-before / passing-after lifecycle probe

```text
origin/main: immediate_exit_deliveries=0/20
PR HEAD:     immediate_exit_deliveries=20/20
```

Each sender used a 200ms delayed sink, matching the failure mode where the process exits before its daemon sender runs.

### Live PostHog test

Ran the patched synchronous path against Sutando's real PostHog project:

```text
[telemetry] feature_used {'feature': 'telemetry_flush_pr_live_test'} (enabled=True)
live_send_elapsed_seconds=0.344
```

A second capture with the same payload shape returned:

```text
HTTP 200
{"status":"Ok"}
elapsed_seconds=0.265
distinct_id=8364970a533049bc8b53aa877b176f94
```

The matching `feature_used` event appeared in the project's raw Activity stream under that exact distinct ID. [Open the PostHog raw event stream](https://us.posthog.com/project/504955/activity/explore) (project access required).

## Edge cases checked

- All three opt-out mechanisms still send zero events.
- No configured key still sends zero events.
- Long-running callers remain asynchronous by default.
- Network errors remain swallowed and cannot break the feature.
- The synchronous path is bounded to 1 second.
- Python 3.9 baseline compatibility is preserved.

## Migrations / config / permissions / rollback risk

N/A. No schema, config, permission, or dependency changes. Reverting the commit restores the old asynchronous-only behavior.

## Known gaps / follow-up

This fixes delivery reliability only. `feature_used` is still intentionally wired to just `morning_briefing` and `daily_insight`; expanding feature coverage should be separate work.


