### PR TITLE
chore(ag2-sparrow): single-source the package version

### DIFF
--- a/packages/ag2-sparrow/pyproject.toml
+++ b/packages/ag2-sparrow/pyproject.toml
@@ -4,7 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ag2-sparrow"
-version = "0.2.0"
+# Single-sourced from ag2_sparrow.__version__ (see [tool.setuptools.dynamic]) so the
+# packaged dist version and the importable __version__ can never drift.
+dynamic = ["version"]
 description = "Transport client that connects a local agent to AG2 Space: long-polls the task gateway for your agent's tasks and posts results back."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -29,3 +31,6 @@ ag2-sparrow = "ag2_sparrow.remote_gateway_bridge:main"
 
 [tool.setuptools]
 packages = ["ag2_sparrow"]
+
+[tool.setuptools.dynamic]
+version = { attr = "ag2_sparrow.__version__" }


### PR DESCRIPTION
## Why
`packages/ag2-sparrow` keeps its version in **two** static places:
- `pyproject.toml` → `version = "0.2.0"`
- `ag2_sparrow/__init__.py` → `__version__ = "0.2.0"`

They match today, but two hand-maintained copies drift the first time one is bumped without the other. That exact skew already shipped in the sibling `ag2-agent-connect` package (dist `0.2.0` / `__version__` `0.1.0`, fixed in ag2-space/agent-connect#9). `ag2-sparrow` is **PyPI-published**, so a drifted `__version__` would make `import ag2_sparrow; ag2_sparrow.__version__` misreport the installed release.

## What
Give the version one source of truth:
- `pyproject [project]` now declares `dynamic = ["version"]`.
- `[tool.setuptools.dynamic]` reads it from `ag2_sparrow.__version__`.

A future bump touches only `__init__.py` and propagates to the built dist; re-hardcoding a static `version` in `[project]` can't reintroduce the skew. Value unchanged (0.2.0), no behavior change — packaging-metadata only.

## Verified
`python -m build --sdist` resolves the dynamic version and produces `ag2_sparrow-0.2.0.tar.gz`. Single 1-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)