### PR TITLE
fix(ci): --test-force-exit to kill the flaky esbuild-teardown segfault

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/voice-agent.ts",
     "typecheck": "tsc --noEmit",
     "typecheck:skills": "tsc -p tsconfig.skills.json",
-    "test": "tsx --test 'tests/**/*.test.ts' && npm run test:py",
+    "test": "tsx --test --test-force-exit 'tests/**/*.test.ts' && npm run test:py",
     "test:py": "find tests -name '*.test.py' | sort | while read f; do echo \"--- $f ---\" && python3 \"$f\" || exit 1; done",
     "build:bundle": "node scripts/build-bundle.mjs"
   },


### PR DESCRIPTION
## Problem
The `tsc + tests (clean install)` job **intermittently** fails with `Segmentation fault (core dumped)` — but only **after every test has passed** (the log shows repeated `Ran N tests … OK`, then the segfault, then `Terminate orphan process: … (esbuild)`). It's not a test failure; it's a `tsx --test` / esbuild-service **teardown race on process exit**. It's been flaking PRs red (e.g. feat/gateway-status-emit twice) while main mostly passes by luck.

## Fix
Add Node 22's **`--test-force-exit`** to the `test` script. It exits the test runner once all known tests have finished, instead of waiting on the event loop (where the esbuild native teardown segfaults). The tests have already reported pass/fail before exit, so **this changes nothing about correctness** — it only removes the crash-on-exit flake.

```
- "test": "tsx --test 'tests/**/*.test.ts' && npm run test:py",
+ "test": "tsx --test --test-force-exit 'tests/**/*.test.ts' && npm run test:py",
```

Verified `tsx --test --test-force-exit` runs + exits cleanly locally. One-line, CI-hygiene only — unblocks the PR queue (incl. G11 gateway-status #2130).