### PR TITLE
fix(quota-tracker): resolve tsx/node on hosts without homebrew/nvm + warn on stale state

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -238,6 +238,31 @@ print(_host_label(), end='')
 "
     ;;
 
+  app-node-dir)
+    # The bundled app runtime's node bin dir (Sutando.app ships a private node
+    # for hosts with no homebrew/nvm/volta). CONFIG-RESOLVED, not hardcoded:
+    # override via $SUTANDO_APP_NODE_DIR; default = the app-support engine path.
+    printf '%s' "${SUTANDO_APP_NODE_DIR:-$HOME/Library/Application Support/space.ag2.app/engine/runtime/node/bin}"
+    ;;
+
+  tsx-bin)
+    # SINGLE SOURCE OF TRUTH for tsx resolution — the launchd wrapper and
+    # src/startup.sh both call this instead of each duplicating the candidate
+    # list. Prefers the repo-pinned node_modules/.bin/tsx (the version the repo
+    # pins, and the ONLY tsx on a host with no homebrew/nvm/volta node at all),
+    # then the usual global locations. Prints the resolved path, or nothing —
+    # the caller falls back to `npx tsx` on empty output.
+    _nvm_tsx="$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin/tsx"
+    for _p in \
+      "$REPO_ROOT/node_modules/.bin/tsx" \
+      /opt/homebrew/bin/tsx \
+      /usr/local/bin/tsx \
+      "$_nvm_tsx" \
+      "$HOME/.volta/bin/tsx"; do
+      [ -x "$_p" ] && { printf '%s' "$_p"; break; }
+    done
+    ;;
+
   dump)
     python3 -m src.sutando_config
     ;;

--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -137,6 +137,13 @@ def main():
     data = json.loads(QUOTA_FILE.read_text())
     headers = data.get("headers", {})
 
+    # Staleness guard: the proxy rewrites this file on every API response, so
+    # an old mtime means quota data is NOT current (proxy dead, or the session
+    # isn't routed through it). Report it loudly — a confident 4-day-old
+    # reading once drove a full day of budget decisions (2026-07-17).
+    age_s = time.time() - QUOTA_FILE.stat().st_mtime
+    stale = age_s > 30 * 60
+
     status = headers.get("anthropic-ratelimit-unified-status", "unknown")
     util_5h = float(headers.get("anthropic-ratelimit-unified-5h-utilization", 0))
     util_7d = float(headers.get("anthropic-ratelimit-unified-7d-utilization", 0))
@@ -150,6 +157,8 @@ def main():
         "utilization_7d": util_7d,
         "remaining_5h_pct": round((1 - util_5h) * 100),
         "remaining_7d_pct": round((1 - util_7d) * 100),
+        "state_age_seconds": int(age_s),
+        "stale": stale,
     }
 
     if reset_5h:
@@ -170,6 +179,9 @@ def main():
         sys.exit(0 if result["available"] else 1)
 
     # Human readable
+    if stale:
+        hrs = age_s / 3600
+        print(f"⚠ STALE: quota state is {hrs:.1f}h old — proxy not feeding it; numbers below are historical, not current")
     print(f"Status: {status}")
     print(f"5h window: {int(util_5h * 100)}% used, {result['remaining_5h_pct']}% remaining")
     if reset_5h:

--- a/src/launchd/credential-proxy-wrapper.sh
+++ b/src/launchd/credential-proxy-wrapper.sh
@@ -22,12 +22,16 @@ set -euo pipefail
 # candidate MUST use `sort -V | tail -1`, NOT a `*/bin` glob: glob order is
 # lexicographic, so with prepend-then-continue a box with v9 + v10 would pick v9
 # (`'1' < '9'` sorts v10 first, v9 last-wins) — an older node, not the latest.
+# REPO_ROOT is resolved HERE (before the loop) so the app-bundle node dir is
+# CONFIG-RESOLVED via sutando-config.sh app-node-dir (honors $SUTANDO_APP_NODE_DIR)
+# on the supervised launchd path too — not just src/startup.sh (Codex #2154).
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 for _node_cand in \
     /opt/homebrew/bin/node \
     /usr/local/bin/node \
     "$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin/node" \
     "$HOME/.volta/bin/node" \
-    "$HOME/Library/Application Support/space.ag2.app/engine/runtime/node/bin/node"
+    "$(bash "$REPO_ROOT/scripts/sutando-config.sh" app-node-dir)/node"
 do
     [ -x "$_node_cand" ] || continue
     _node_dir="$(dirname "$_node_cand")"
@@ -39,7 +43,7 @@ done
 # launchd plist exports it (claude-sutando installs); otherwise falls back to
 # ~/.claude. launchd itself doesn't inherit shell env, so this fallback is the
 # vanilla-claude default unless the plist's EnvironmentVariables sets it.
-REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# (REPO_ROOT is resolved above, before the node-candidate loop.)
 PROXY_SCRIPT="$(bash "$REPO_ROOT/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/credential-proxy.ts)"
 
 # Resolve npx — launchd doesn't inherit the user's shell PATH.

--- a/src/launchd/credential-proxy-wrapper.sh
+++ b/src/launchd/credential-proxy-wrapper.sh
@@ -26,7 +26,8 @@ for _node_cand in \
     /opt/homebrew/bin/node \
     /usr/local/bin/node \
     "$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin/node" \
-    "$HOME/.volta/bin/node"
+    "$HOME/.volta/bin/node" \
+    "$HOME/Library/Application Support/space.ag2.app/engine/runtime/node/bin/node"
 do
     [ -x "$_node_cand" ] || continue
     _node_dir="$(dirname "$_node_cand")"
@@ -38,7 +39,8 @@ done
 # launchd plist exports it (claude-sutando installs); otherwise falls back to
 # ~/.claude. launchd itself doesn't inherit shell env, so this fallback is the
 # vanilla-claude default unless the plist's EnvironmentVariables sets it.
-PROXY_SCRIPT="$(bash "$(cd "$(dirname "$0")/../.." && pwd)/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/credential-proxy.ts)"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PROXY_SCRIPT="$(bash "$REPO_ROOT/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/credential-proxy.ts)"
 
 # Resolve npx — launchd doesn't inherit the user's shell PATH.
 resolve_npx() {
@@ -54,8 +56,13 @@ resolve_npx() {
 }
 
 # Resolve tsx — prefer direct binary to avoid npx overhead on restart paths.
+# The repo's own node_modules/.bin/tsx comes FIRST: it's the version the repo
+# pins, and it's the only tsx on a host with no homebrew/nvm/volta node at all
+# (the app-bundle runtime ships bare `node` — the PATH heal above covers the
+# `#!/usr/bin/env node` re-exec).
 resolve_tsx() {
     for p in \
+        "$REPO_ROOT/node_modules/.bin/tsx" \
         /opt/homebrew/bin/tsx \
         /usr/local/bin/tsx \
         "$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin/tsx" \

--- a/src/launchd/credential-proxy-wrapper.sh
+++ b/src/launchd/credential-proxy-wrapper.sh
@@ -61,15 +61,11 @@ resolve_npx() {
 # (the app-bundle runtime ships bare `node` — the PATH heal above covers the
 # `#!/usr/bin/env node` re-exec).
 resolve_tsx() {
-    for p in \
-        "$REPO_ROOT/node_modules/.bin/tsx" \
-        /opt/homebrew/bin/tsx \
-        /usr/local/bin/tsx \
-        "$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin/tsx" \
-        "$HOME/.volta/bin/tsx"
-    do
-        [ -x "$p" ] && { echo "$p"; return; }
-    done
+    # Single source of truth: scripts/sutando-config.sh tsx-bin (repo-pinned
+    # node_modules/.bin/tsx first, then global locations). Prints the path or
+    # nothing; return 1 on empty lets the caller fall through to `npx tsx`.
+    _tsx="$(bash "$REPO_ROOT/scripts/sutando-config.sh" tsx-bin 2>/dev/null)"
+    [ -n "$_tsx" ] && { echo "$_tsx"; return 0; }
     return 1  # fall through to npx tsx
 }
 

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -32,6 +32,24 @@ fi
 # $SUTANDO_ROOT.
 export SUTANDO_ROOT="$REPO"
 
+# tsx runner for every TS service start below — resolution is config-resolved
+# via sutando-config.sh (`tsx-bin` / `app-node-dir` are the single source of
+# truth, shared with the launchd wrapper); `npx tsx` only as a last resort. A
+# host may have no homebrew/nvm node/npx at all (the app-bundle runtime ships
+# bare `node` only, no npx — the PATH prepend covers tsx's `#!/usr/bin/env node`
+# re-exec). A raw `npx tsx` call site silently fails to start its service on
+# such hosts (web-client outage 2026-07-17).
+_APP_NODE_DIR="$(bash "$REPO/scripts/sutando-config.sh" app-node-dir)"
+[ -d "$_APP_NODE_DIR" ] && case ":$PATH:" in *":$_APP_NODE_DIR:"*) ;; *) PATH="$_APP_NODE_DIR:$PATH"; export PATH ;; esac
+_TSX_BIN="$(bash "$REPO/scripts/sutando-config.sh" tsx-bin)"
+run_tsx() {
+  if [ -n "$_TSX_BIN" ]; then
+    "$_TSX_BIN" "$@"
+  else
+    npx tsx "$@"
+  fi
+}
+
 # Export workspace-scoped CLAUDE_CONFIG_DIR before services launch. Without it,
 # init.sh + the bridge-launcher blocks below (L~262 proxy, L~429 telegram,
 # L~449 discord, L~473 slack) probe `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` and
@@ -556,21 +574,8 @@ if [ -f "$_PROXY_INSTALLER" ] && [ -f "$REPO/src/launchd/$_PROXY_LABEL.plist" ];
 fi
 if ! lsof -i :7846 > /dev/null 2>&1; then
   echo "  Starting credential proxy (port 7846)..."
-  # Repo-pinned tsx first; `npx tsx` only as a last resort (a host may have no
-  # homebrew/nvm node at all — the app-bundle runtime ships bare `node`, which
-  # the PATH prepend covers for tsx's `#!/usr/bin/env node` re-exec).
-  # App-bundle node dir + tsx resolution are BOTH resolved via sutando-config.sh
-  # (single source of truth — the launchd wrapper uses the same tsx-bin resolver;
-  # the path is config-resolved, not hardcoded here).
-  _APP_NODE_DIR="$(bash "$REPO/scripts/sutando-config.sh" app-node-dir)"
-  [ -d "$_APP_NODE_DIR" ] && case ":$PATH:" in *":$_APP_NODE_DIR:"*) ;; *) PATH="$_APP_NODE_DIR:$PATH"; export PATH ;; esac
   _PROXY_SCRIPT="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/credential-proxy.ts)"
-  _TSX="$(bash "$REPO/scripts/sutando-config.sh" tsx-bin)"
-  if [ -n "$_TSX" ]; then
-    "$_TSX" "$_PROXY_SCRIPT" > /tmp/credential-proxy.log 2>&1 &
-  else
-    npx tsx "$_PROXY_SCRIPT" > /tmp/credential-proxy.log 2>&1 &
-  fi
+  run_tsx "$_PROXY_SCRIPT" > /tmp/credential-proxy.log 2>&1 &
   sleep 1
   if lsof -i :7846 > /dev/null 2>&1; then
     echo "  ✓ credential proxy"
@@ -598,7 +603,7 @@ if [ "${SUTANDO_OBS_COLLECTOR:-}" = "1" ]; then
   if ! lsof -i :"$OBS_PORT" > /dev/null 2>&1; then
     echo "  Starting obs collector (port $OBS_PORT)..."
     SUTANDO_WORKSPACE="$WORKSPACE" SUTANDO_OBS_PORT="$OBS_PORT" \
-      npx tsx "$REPO/src/observability/boot.ts" > "$LOGS_DIR/collector.log" 2>&1 &
+      run_tsx "$REPO/src/observability/boot.ts" > "$LOGS_DIR/collector.log" 2>&1 &
     echo "  ✓ obs collector"
   else
     echo "  ✓ obs collector (already running on $OBS_PORT)"
@@ -636,7 +641,7 @@ reap_wedged_listener() {
 reap_wedged_listener 9900 voice-agent
 if ! lsof -i :9900 > /dev/null 2>&1; then
   echo "  Starting voice agent (port 9900)..."
-  npx tsx src/voice-agent.ts > "$LOGS_DIR/voice-agent.log" 2>&1 &
+  run_tsx src/voice-agent.ts > "$LOGS_DIR/voice-agent.log" 2>&1 &
   echo "  ✓ voice agent"
 else
   echo "  ✓ voice agent (already running)"
@@ -650,14 +655,14 @@ fi
 # back to cloud). `--interval 60` keeps it resident and re-emits every 60s so the
 # advertisement tracks reachability changes AFTER boot (tailnet/VPN coming up
 # post-startup would otherwise leave Direct(Tailscale) greyed until a restart).
-npx tsx src/emit-call-tiers.ts --interval 60 > "$LOGS_DIR/emit-call-tiers.log" 2>&1 &
+run_tsx src/emit-call-tiers.ts --interval 60 > "$LOGS_DIR/emit-call-tiers.log" 2>&1 &
 echo "  ✓ call-tiers advertisement (re-emit 60s)"
 
 # 2. Web client (port 8080)
 reap_wedged_listener 8080 web-client
 if ! lsof -i :8080 > /dev/null 2>&1; then
   echo "  Starting web client (port 8080)..."
-  npx tsx src/web-client.ts > "$LOGS_DIR/web-client.log" 2>&1 &
+  run_tsx src/web-client.ts > "$LOGS_DIR/web-client.log" 2>&1 &
   echo "  ✓ web client"
 else
   echo "  ✓ web client (already running)"
@@ -968,7 +973,7 @@ if [ "${SKIP_PHONE:-}" = "1" ]; then
 elif grep -qE '^[[:space:]]*TWILIO_ACCOUNT_SID=[^[:space:]]' .env 2>/dev/null; then
   if ! pgrep -f "conversation-server" > /dev/null 2>&1; then
     echo "  Starting conversation server..."
-    npx tsx skills/phone-conversation/scripts/conversation-server.ts > /tmp/conversation-server.log 2>&1 &
+    run_tsx skills/phone-conversation/scripts/conversation-server.ts > /tmp/conversation-server.log 2>&1 &
     echo "  ✓ conversation server (port 3100)"
   else
     echo "  ✓ conversation server (already running)"

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -556,7 +556,17 @@ if [ -f "$_PROXY_INSTALLER" ] && [ -f "$REPO/src/launchd/$_PROXY_LABEL.plist" ];
 fi
 if ! lsof -i :7846 > /dev/null 2>&1; then
   echo "  Starting credential proxy (port 7846)..."
-  npx tsx "$(bash "$REPO/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/credential-proxy.ts)" > /tmp/credential-proxy.log 2>&1 &
+  # Repo-pinned tsx first; `npx tsx` only as a last resort (a host may have no
+  # homebrew/nvm node at all — the app-bundle runtime ships bare `node`, which
+  # the PATH prepend covers for tsx's `#!/usr/bin/env node` re-exec).
+  _APP_NODE_DIR="$HOME/Library/Application Support/space.ag2.app/engine/runtime/node/bin"
+  [ -d "$_APP_NODE_DIR" ] && case ":$PATH:" in *":$_APP_NODE_DIR:"*) ;; *) PATH="$_APP_NODE_DIR:$PATH"; export PATH ;; esac
+  _PROXY_SCRIPT="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/credential-proxy.ts)"
+  if [ -x "$REPO/node_modules/.bin/tsx" ]; then
+    "$REPO/node_modules/.bin/tsx" "$_PROXY_SCRIPT" > /tmp/credential-proxy.log 2>&1 &
+  else
+    npx tsx "$_PROXY_SCRIPT" > /tmp/credential-proxy.log 2>&1 &
+  fi
   sleep 1
   if lsof -i :7846 > /dev/null 2>&1; then
     echo "  ✓ credential proxy"

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -559,11 +559,15 @@ if ! lsof -i :7846 > /dev/null 2>&1; then
   # Repo-pinned tsx first; `npx tsx` only as a last resort (a host may have no
   # homebrew/nvm node at all — the app-bundle runtime ships bare `node`, which
   # the PATH prepend covers for tsx's `#!/usr/bin/env node` re-exec).
-  _APP_NODE_DIR="$HOME/Library/Application Support/space.ag2.app/engine/runtime/node/bin"
+  # App-bundle node dir + tsx resolution are BOTH resolved via sutando-config.sh
+  # (single source of truth — the launchd wrapper uses the same tsx-bin resolver;
+  # the path is config-resolved, not hardcoded here).
+  _APP_NODE_DIR="$(bash "$REPO/scripts/sutando-config.sh" app-node-dir)"
   [ -d "$_APP_NODE_DIR" ] && case ":$PATH:" in *":$_APP_NODE_DIR:"*) ;; *) PATH="$_APP_NODE_DIR:$PATH"; export PATH ;; esac
   _PROXY_SCRIPT="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/credential-proxy.ts)"
-  if [ -x "$REPO/node_modules/.bin/tsx" ]; then
-    "$REPO/node_modules/.bin/tsx" "$_PROXY_SCRIPT" > /tmp/credential-proxy.log 2>&1 &
+  _TSX="$(bash "$REPO/scripts/sutando-config.sh" tsx-bin)"
+  if [ -n "$_TSX" ]; then
+    "$_TSX" "$_PROXY_SCRIPT" > /tmp/credential-proxy.log 2>&1 &
   else
     npx tsx "$_PROXY_SCRIPT" > /tmp/credential-proxy.log 2>&1 &
   fi

--- a/tests/quota-burn-rate.test.py
+++ b/tests/quota-burn-rate.test.py
@@ -7,7 +7,9 @@ Run: python3 tests/quota-burn-rate.test.py
 Exit: 0 on pass, 1 on fail.
 """
 from __future__ import annotations
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import shutil
@@ -157,6 +159,56 @@ class TestUpdateBurnRate(unittest.TestCase):
             round(result["estimated_passes_left"] * 5),
             delta=1,
         )
+
+
+class TestStalenessGuard(unittest.TestCase):
+    """PR #2154: read-quota.py flags quota-state.json older than 30 min as stale
+    (the proxy rewrites it on every response, so an old mtime = not current — a
+    confident 4-day-old reading once drove a full day of budget calls)."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="quota-stale-test-"))
+        self.mod = _load_module(self.tmp)
+        self.quota_file = self.tmp / "state" / "quota-state.json"
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _set_age(self, seconds: float):
+        t = time.time() - seconds
+        os.utime(self.quota_file, (t, t))
+
+    def _run(self, argv):
+        buf = io.StringIO()
+        with patch.object(sys, "argv", argv), contextlib.redirect_stdout(buf):
+            try:
+                self.mod.main()
+            except SystemExit:
+                pass
+        return buf.getvalue()
+
+    def test_stale_file_flagged_in_json(self):
+        self._set_age(2 * 3600)  # 2h old → stale
+        out = json.loads(self._run(["read-quota.py", "--json"]))
+        self.assertTrue(out["stale"])
+        self.assertGreaterEqual(out["state_age_seconds"], 3600)
+
+    def test_fresh_file_not_stale(self):
+        self._set_age(60)  # 1 min old → fresh
+        out = json.loads(self._run(["read-quota.py", "--json"]))
+        self.assertFalse(out["stale"])
+        self.assertLess(out["state_age_seconds"], 30 * 60)
+
+    def test_stale_warning_in_human_output(self):
+        self._set_age(3 * 3600)  # 3h old
+        out = self._run(["read-quota.py"])
+        self.assertIn("STALE", out)
+        self.assertIn("historical", out)
+
+    def test_fresh_no_warning(self):
+        self._set_age(10)
+        out = self._run(["read-quota.py"])
+        self.assertNotIn("STALE", out)
 
 
 if __name__ == "__main__":

--- a/tests/sutando-config-tsx-resolution.test.sh
+++ b/tests/sutando-config-tsx-resolution.test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Evidence for PR #2154: the tsx/node resolution for a host with no
+# homebrew/nvm/volta. Both the launchd wrapper and startup.sh resolve tsx +
+# the app-node dir via the SINGLE sutando-config.sh source of truth.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+CFG="scripts/sutando-config.sh"
+fail=0
+say() { echo "  $1"; }
+
+# --- app-node-dir: config-resolved, not hardcoded (ask: config-resolve path) ---
+out="$(SUTANDO_APP_NODE_DIR=/custom/node/bin bash "$CFG" app-node-dir)"
+[ "$out" = "/custom/node/bin" ] && say "PASS app-node-dir honors override" || { say "FAIL override: $out"; fail=1; }
+out="$(unset SUTANDO_APP_NODE_DIR; bash "$CFG" app-node-dir)"
+case "$out" in *space.ag2.app*node*bin) say "PASS app-node-dir default = app-support engine";; *) say "FAIL default: $out"; fail=1;; esac
+
+# --- tsx-bin: centralized resolver; repo-pinned tsx preferred (the no-homebrew case) ---
+out="$(bash "$CFG" tsx-bin)"
+if [ -n "$out" ]; then
+  [ -x "$out" ] && say "PASS tsx-bin returns an executable ($out)" || { say "FAIL not executable: $out"; fail=1; }
+  # BEFORE/AFTER evidence: on a host with no global tsx, the repo-pinned
+  # node_modules/.bin/tsx is what makes the proxy start. When present it MUST win.
+  if [ -x "node_modules/.bin/tsx" ]; then
+    case "$out" in */node_modules/.bin/tsx) say "PASS repo-pinned tsx preferred (no-homebrew fallback works)";; *) say "FAIL repo tsx not preferred: $out"; fail=1;; esac
+  fi
+else
+  say "SKIP tsx-bin empty (no tsx installed) — caller falls back to npx tsx"
+fi
+
+[ "$fail" -eq 0 ] && echo "PASS — tsx/app-node resolution centralized + config-resolved" || { echo "FAIL"; exit 1; }

--- a/tests/sutando-config-tsx-resolution.test.sh
+++ b/tests/sutando-config-tsx-resolution.test.sh
@@ -27,4 +27,15 @@ else
   say "SKIP tsx-bin empty (no tsx installed) — caller falls back to npx tsx"
 fi
 
-[ "$fail" -eq 0 ] && echo "PASS — tsx/app-node resolution centralized + config-resolved" || { echo "FAIL"; exit 1; }
+# --- wrapper (supervised launchd path) also config-resolves the app node dir ---
+# Codex #2154: the launchd wrapper is the preferred proxy path on installed
+# systems; it must honor app-node-dir too, not hardcode the bundle path.
+WRAP="src/launchd/credential-proxy-wrapper.sh"
+if grep -q 'space.ag2.app/engine/runtime/node/bin/node' "$WRAP"; then
+  say "FAIL wrapper still hardcodes the app-bundle node path"; fail=1
+else
+  say "PASS wrapper does not hardcode the app-bundle node path"
+fi
+grep -q 'sutando-config.sh" app-node-dir' "$WRAP" && say "PASS wrapper config-resolves app-node-dir" || { say "FAIL wrapper missing app-node-dir call"; fail=1; }
+
+[ "$fail" -eq 0 ] && echo "PASS — tsx/app-node resolution centralized + config-resolved (startup + launchd)" || { echo "FAIL"; exit 1; }


### PR DESCRIPTION
## The incident
On a host whose only node is the app-bundle runtime (bare `node`, no npm/npx/tsx anywhere in homebrew//usr/local/nvm/volta), the credential proxy can never start: the launchd wrapper exits 78 and `startup.sh`'s `npx tsx` fallback dies on a missing npx. Nothing marks the failure — `read-quota.py` kept reporting a **4-day-old** `quota-state.json` as current (with an absurd burn-rate estimate), and a full day of per-pass budget decisions ran on frozen numbers before it was caught (2026-07-17).

## The fix (two halves, one incident)
1. **Runtime resolution**: the repo's own `node_modules/.bin/tsx` becomes the *first* tsx candidate in both the launchd wrapper and the `startup.sh` fallback — it's the version the repo pins and it exists in every dev checkout. The app-bundle runtime node dir (`~/Library/Application Support/space.ag2.app/engine/runtime/node/bin`) joins the node candidate list / PATH heal, covering tsx's `#!/usr/bin/env node` re-exec.
2. **Staleness made visible**: `read-quota.py` prints a loud `⚠ STALE` banner when `quota-state.json` is >30 min old, and exposes `state_age_seconds` / `stale` in `--json` so budget logic can distrust historical numbers.

## Relationship to #1887
Sibling, not duplicate: #1887 fixes **which checkout's script** the proxy runs (workspace mismatch on multi-checkout hosts); this fixes **which runtime binary** runs it at all, plus the missing staleness signal. Same three files touched; textual overlap is minimal (candidate lists + a new banner). Happy to rebase whichever lands second.

## Verification (on the affected host)
- `repo/node_modules/.bin/tsx` + app-bundle node: proxy binds `127.0.0.1:7846`, loads the OAuth token, serves.
- `read-quota.py` on the 86h-old state file: banner fires, `--json` carries `stale: true`.
- Note: launchd on this host *additionally* fails from TCC (repo under `~/Documents`, spawn denied EX_CONFIG before the wrapper runs) — that needs an owner Full-Disk-Access grant and is out of scope here; the startup.sh path works without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)