### PR TITLE
fix(discord-bridge): codex exec needs --skip-git-repo-check from the repo cwd

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -914,7 +914,7 @@ async def _run_codex_subprocess(prompt, model, timeout_s):
     except Exception:
         return ""
     try:
-        argv = ["codex", "exec", "--sandbox", "read-only", "-o", out_path]
+        argv = ["codex", "exec", "--sandbox", "read-only", "--skip-git-repo-check", "-o", out_path]
         if model:
             argv.extend(["-m", model])
         argv.extend(["--", prompt])
@@ -3196,7 +3196,7 @@ async def _handle_discord_message(message, force=False):
             "This task is from a TEAM tier sender. Choose ONE of three actions based on the content:\n\n"
             "1. RUN CODEX — for genuine requests (code review, bug report, technical question, analysis).\n"
             "   Two-stage execution to avoid racing the bridge's results-dir poller:\n"
-            f"   - Stage 1: bash skills/claude-codex/scripts/codex-bounded.sh --stall 45 --max 240 -- codex exec --sandbox read-only -o {RESULTS_DIR}/.codex-staging-{{id}}.txt -- {quoted_task} < /dev/null   (the bounded runner kills the codex tree if it goes SILENT for 45s — the 'never going to finish' signal, since a working codex streams output — with a hard 240s backstop; a slow-but-progressing run is NOT killed. `< /dev/null` avoids the stdin hang. Exit 125 = stalled, 124 = hit the max cap; EITHER → fire the Stage-2 fallback.)\n"
+            f"   - Stage 1: bash skills/claude-codex/scripts/codex-bounded.sh --stall 45 --max 240 -- codex exec --sandbox read-only --skip-git-repo-check -o {RESULTS_DIR}/.codex-staging-{{id}}.txt -- {quoted_task} < /dev/null   (the bounded runner kills the codex tree if it goes SILENT for 45s — the 'never going to finish' signal, since a working codex streams output — with a hard 240s backstop; a slow-but-progressing run is NOT killed. `< /dev/null` avoids the stdin hang. Exit 125 = stalled, 124 = hit the max cap; EITHER → fire the Stage-2 fallback.)\n"
             f"   - Stage 2: if codex exits 0 AND {RESULTS_DIR}/.codex-staging-{{id}}.txt is non-empty: mv {RESULTS_DIR}/.codex-staging-{{id}}.txt {RESULTS_DIR}/task-{{id}}.txt (atomic single move; bridge only ever sees a complete file).\n"
             f"   - Stage 2 fallback: if codex exits non-zero OR staging file is empty/missing: write 'Sandbox unavailable; refusing non-owner task.' directly to {RESULTS_DIR}/task-{{id}}.txt.\n"
             "   - The `-o` flag writes ONLY the agent's final message to the file (no exec sub-command dumps, no setup banner). Do NOT redirect stdout — codex's stdout includes verbose exec output from internal tool calls (e.g. github plugin reading PR diffs), which floods Discord. Do NOT add commentary.\n\n"

--- a/tests/discord-bridge-codex-subprocess-argv.test.py
+++ b/tests/discord-bridge-codex-subprocess-argv.test.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""_run_codex_subprocess builds a --skip-git-repo-check argv (PR #2155 coverage).
+
+The mod-judge codex wrapper spawns `codex exec` from the repo cwd, which codex
+refuses ("Not inside a trusted directory") without --skip-git-repo-check. This
+covers the argv-construction line by patching create_subprocess_exec and
+asserting the flag is present (and -m <model> is appended only when given).
+
+Run: python3 tests/discord-bridge-codex-subprocess-argv.test.py  (exit 0/1)
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+os.environ.setdefault("DISCORD_BOT_TOKEN", "faketoken")
+os.environ["CLAUDE_CONFIG_DIR"] = "/tmp/dc-codex-argv-ccd"
+
+try:
+    import discord  # noqa: F401
+except ImportError:
+    for _c in ("/opt/homebrew/bin/python3", "/usr/local/bin/python3"):
+        if os.path.exists(_c) and os.path.realpath(_c) != os.path.realpath(sys.executable):
+            import subprocess
+            if subprocess.run([_c, "-c", "import discord"], capture_output=True).returncode == 0:
+                os.execv(_c, [_c, os.path.abspath(__file__), *sys.argv[1:]])
+    print("SKIP — discord.py not importable")
+    sys.exit(0)
+
+spec = importlib.util.spec_from_file_location("dbridge_argv", REPO / "src" / "discord-bridge.py")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+failures: list[str] = []
+captured: dict = {}
+
+
+def check(name, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + name + ((" — " + detail) if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+class _FakeProc:
+    returncode = 0
+
+    async def communicate(self):
+        return (b"", b"")
+
+
+async def _fake_exec(*argv, **kwargs):
+    captured["argv"] = list(argv)
+    return _FakeProc()
+
+
+async def _run():
+    mod.asyncio.create_subprocess_exec = _fake_exec  # patch the spawn
+    # model=None path
+    await mod._run_codex_subprocess("hello prompt", None, 5)
+    argv1 = captured["argv"]
+    check("argv includes --skip-git-repo-check", "--skip-git-repo-check" in argv1, str(argv1))
+    check("argv starts with codex exec --sandbox read-only",
+          argv1[:4] == ["codex", "exec", "--sandbox", "read-only"], str(argv1[:4]))
+    check("no -m when model is None", "-m" not in argv1)
+    # model set path
+    await mod._run_codex_subprocess("hello", "gpt-x", 5)
+    argv2 = captured["argv"]
+    check("argv appends -m <model> when model given", "-m" in argv2 and "gpt-x" in argv2, str(argv2))
+
+
+asyncio.run(_run())
+
+print()
+if failures:
+    print(f"FAIL — {len(failures)}: {failures}")
+    sys.exit(1)
+print("PASS — codex subprocess argv (skip-git-repo-check)")


### PR DESCRIPTION
## Problem
Team-tier Discord tasks inject a RUN CODEX command that spawns `codex exec --sandbox read-only` from the canonical repo cwd. Codex refuses: `Not inside a trusted directory and --skip-git-repo-check was not specified` → exit 1 → Stage-2 fallback fires and the sender gets **"Sandbox unavailable; refusing non-owner task."** for every genuine request. Observed live 2026-07-17 on a technical question from @sonichi (task-1784306946648); re-running the identical command with the flag succeeded.

The mod-judge subprocess (`_run_codex_subprocess`) has the same trust-check exposure.

## Fix
Add `--skip-git-repo-check` to both invocation sites — parity with the other-tier template, which already passes it (and `-C /tmp`; team tier keeps repo-read cwd by design since reviews need repo context). Sandbox remains `read-only`.

## Live test
- Before: exact injected command exits 1 with the trust error (raw output above).
- After: same command + flag → codex completed, wrote the final answer to the staging file, exit 0 (delivered to the asking channel).
- `tests/discord-bridge-mod-judge-codex.test.py` and `tests/discord-bridge-access-tier.test.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)