### PR TITLE
ci: install discord.py so discord-bridge behavioral tests run + count coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       # was pure indirection. Must run BEFORE `npm test`: the `test` script chains
       # `npm run test:py`, so Python tests execute inside the "Run tests" step.
       - name: Install Python test deps
-        run: python3 -m pip install 'detect-secrets>=1.5.0'
+        run: python3 -m pip install 'detect-secrets>=1.5.0' 'discord.py>=2.3'
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install coverage tooling + test deps
-        run: python3 -m pip install coverage diff-cover 'detect-secrets>=1.5.0'
+        run: python3 -m pip install coverage diff-cover 'detect-secrets>=1.5.0' 'discord.py>=2.3'
 
       - name: Run coverage gate
         env:


### PR DESCRIPTION
## Problem
The coverage gate and the main test job install only `coverage diff-cover detect-secrets` — **not discord.py**. Every discord-bridge *behavioral* test imports the module, so in CI those tests skip/fail-to-import and contribute **zero** coverage. Net effect: diff-coverage on any `discord-bridge.py` change is structurally unwinnable — the changed lines are covered locally (discord.py present) but always flagged uncovered in CI. Multiple open PRs (#2155, #2158, #2159, #2161) are red on the coverage gate solely because of this.

## Fix
Add `discord.py>=2.3` to the Python deps of both `.github/workflows/ci.yml` and `.github/workflows/coverage-gate.yml`. It's pure-python and installs in a second; the runtime still soft-imports discord (the bridge's rescue/guard path is unchanged). Now discord-bridge behavioral tests execute and their coverage counts, and the four PRs above can pass the gate with their existing behavioral tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)