### PR TITLE
fix(host-label): route sync-memory + dashboard per-host paths through the scutil-first shim (#1771 stragglers)

### DIFF
--- a/scripts/sync-memory.sh
+++ b/scripts/sync-memory.sh
@@ -393,7 +393,25 @@ fi
 # `git clone sutando-memory && cp -r machine-<hostname>/* ~/Desktop/sutando/`.
 # Other machines' machine-<other>/ dirs are read-only from this machine's
 # POV — NO pull-back in the sync → local section below.
-HOST="$(hostname | sed 's/\..*//')"
+# Per-host label MUST match the reader — src/util_paths.py `_private_machine_dir()`
+# → `_host_label()` resolves `machine-<host>/` scutil-LocalHostName-FIRST. A bare
+# `hostname` can drift under DHCP (e.g. a Comcast lease → `Chis-MBP` while the
+# stable Bonjour name is `Chis-MacBook-Pro`), which would back up the WRONG
+# `machine-<host>/` dir — split from where personal_path() actually reads it
+# (#1745). Use the canonical `sutando-config.sh host-label` shim (#1771; single
+# source of truth, precedence $SUTANDO_HOST_LABEL > scutil > short hostname);
+# fall back to that same precedence inline if the shim is unavailable so backup
+# never hard-depends on python being importable.
+HOST="$(bash "$SCRIPT_DIR/sutando-config.sh" host-label 2>/dev/null || true)"
+if [ -z "$HOST" ]; then
+    HOST="${SUTANDO_HOST_LABEL:-${SUTANDO_HOST_OVERRIDE:-}}"
+    if [ -z "$HOST" ]; then
+        if command -v scutil >/dev/null 2>&1; then
+            HOST="$(scutil --get LocalHostName 2>/dev/null)"
+        fi
+        [ -z "$HOST" ] && HOST="$(hostname | sed 's/\..*//')"
+    fi
+fi
 MACHINE_DIR="machine-$HOST"
 mkdir -p "$MACHINE_DIR/skills" "$MACHINE_DIR/data"
 

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -18,7 +18,6 @@ import http.server
 import json
 import os
 import re
-import socket
 import subprocess
 import sys
 from datetime import datetime

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -32,7 +32,7 @@ from urllib.parse import urlparse
 REPO_DIR = Path(__file__).parent.parent
 sys.path.insert(0, str(Path(__file__).parent))
 from workspace_default import resolve_workspace, status_read_path  # noqa: E402
-from util_paths import personal_path, shared_personal_path  # noqa: E402
+from util_paths import personal_path, shared_personal_path, _host_label  # noqa: E402
 WORKSPACE_DIR = resolve_workspace()
 PORT = 7844
 
@@ -343,7 +343,12 @@ def get_schedules() -> list[dict]:
     Source: <workspace>/hosts/<hostname>/crons.json (see skills/schedule-crons).
     Status is 'active' + next run; last-run history isn't tracked on disk.
     """
-    host = socket.gethostname().split(".")[0]
+    # scutil-first canonical label (NOT bare hostname) — must match the WRITER,
+    # schedule-crons, which keys hosts/<host>/crons.json off
+    # `sutando-config.sh host-label` (= util_paths._host_label()). A bare
+    # `hostname` can drift under DHCP and read the wrong hosts/<host>/ dir, so
+    # this panel would show no schedules on a drift machine (#1745).
+    host = _host_label()
     cfg = WORKSPACE_DIR / "hosts" / host / "crons.json"
     if not cfg.exists():
         return []

--- a/tests/dashboard-schedules.test.py
+++ b/tests/dashboard-schedules.test.py
@@ -81,7 +81,7 @@ def test_cron_next_run_no_match_in_horizon():
 # --------------------------------------------------------------------------- #
 def _with_crons(tmp: Path, jobs):
     host = "test-host"
-    dashboard.socket.gethostname = lambda: f"{host}.local"  # → split(".")[0]
+    dashboard._host_label = lambda: host  # production keys hosts/<host>/ off _host_label()
     dashboard.WORKSPACE_DIR = tmp
     d = tmp / "hosts" / host
     d.mkdir(parents=True, exist_ok=True)
@@ -91,7 +91,7 @@ def _with_crons(tmp: Path, jobs):
 
 def test_get_schedules_missing_file_returns_empty():
     with tempfile.TemporaryDirectory() as td:
-        dashboard.socket.gethostname = lambda: "nohost"
+        dashboard._host_label = lambda: "nohost"
         dashboard.WORKSPACE_DIR = Path(td)
         assert dashboard.get_schedules() == []
 
@@ -100,7 +100,7 @@ def test_get_schedules_bad_json_returns_empty():
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
         host = "test-host"
-        dashboard.socket.gethostname = lambda: host
+        dashboard._host_label = lambda: host
         dashboard.WORKSPACE_DIR = tmp
         d = tmp / "hosts" / host
         d.mkdir(parents=True)


### PR DESCRIPTION
## Problem

Two per-host path resolvers still compute the host label with a **bare `hostname`** while the code they must agree with resolves it **scutil-`LocalHostName`-first** (`sutando-config.sh host-label` = `util_paths._host_label()`). On a DHCP-drift machine these split (a Comcast lease → `hostname` `Chis-MBP.hsd1.wa.comcast.net` → `Chis-MBP`, while the stable Bonjour name is `Chis-MacBook-Pro`) — the #1745 split-brain class the whole host-label convention exists to prevent.

1. **`scripts/sync-memory.sh`** (writer) backed up per-machine memory to `machine-$(hostname | sed …)/`, but the reader `util_paths._private_machine_dir()` → `_host_label()` reads `machine-<scutil-label>/` — the disaster-recovery backup silently targets a dir nobody reads.
2. **`src/dashboard.py` `get_schedules()`** (reader) read `hosts/<host>/crons.json` keyed off `socket.gethostname()`, but the **writer** (schedule-crons) keys that same path off `sutando-config.sh host-label`. `skills/schedule-crons/SKILL.md` explicitly forbids the bare-hostname recipe here. On a drift machine the dashboard's schedules panel reads a `hosts/<hostname>/` dir that doesn't exist → shows **no schedules**.

#1771 introduced the canonical `sutando-config.sh host-label` shim and wired schedule-crons + self-diagnose to it, but **missed these two**. This completes that rollout.

## Fix

- `sync-memory.sh`: resolve `machine-<host>/` via the `sutando-config.sh host-label` shim, with the same inline scutil-first fallback `self-diagnose/gather.sh` uses (never hard-depends on python).
- `dashboard.py`: resolve `hosts/<host>/crons.json` via `util_paths._host_label()` (already imported). Updated `tests/dashboard-schedules.test.py` to stub the production resolver (`dashboard._host_label`) instead of `socket.gethostname` — so the test controls what the code actually reads.

## Impact

- **No-op** where `scutil LocalHostName == short hostname` (the common single-machine case — verified locally: both resolve `Ruis-MacBook-Pro-2`, matching `_host_label()`).
- Corrects the target only on drift machines.

## Verified

- Only the two flagged writers/readers were genuine: `sync-workspace.sh`, `core_heartbeat.py`, `workspace_lock.py` all already delegate to the scutil-first resolver (bare `hostname` is only their fallback); health-check readers `glob('*.alive')` (hostname-agnostic); `event_log.py`/`observability/node.py` are self-consistent display tags. Grep discriminator: bare-hostname is a bug only when NOT preceded by a scutil attempt AND the path's counterpart is scutil-first.
- `bash -n scripts/sync-memory.sh` clean; `python3 tests/dashboard-schedules.test.py` → 7/7 pass (the updated test requires the dashboard fix — old gethostname path reads the wrong dir under the new stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)