### PR TITLE
fix(test): flush coverage before os._exit in slack-bridge tofu test

### DIFF
--- a/tests/slack-bridge-tofu-enroll.test.py
+++ b/tests/slack-bridge-tofu-enroll.test.py
@@ -363,4 +363,16 @@ if __name__ == "__main__":
     # the finalization that crashes; the test result (_rc) is unaffected.
     sys.stdout.flush()
     sys.stderr.flush()
+    # os._exit() below skips atexit handlers — including coverage.py's data
+    # writer — so under `coverage run` this file would record 0% and its
+    # exercised src/slack-bridge.py lines show as uncovered in the diff gate
+    # (spurious failures on any slack-bridge PR). Flush the active coverage
+    # session explicitly before the hard exit.
+    try:
+        import coverage
+        _cov = coverage.Coverage.current()
+        if _cov is not None:
+            _cov.save()
+    except Exception:
+        pass
     os._exit(_rc)


### PR DESCRIPTION
## Problem

`tests/slack-bridge-tofu-enroll.test.py` ends with `os._exit(_rc)` to dodge an intermittent interpreter-teardown SIGSEGV (#2118/#2124). But `os._exit` skips atexit handlers — including **coverage.py's data writer** — so under `coverage run` this file records `src/slack-bridge.py` at **0%** (all 539 lines "missing") even though it exercises ~184 of them via the TOFU-enrollment path.

Effect: the `diff coverage >= 95%` gate spuriously flags **any** slack-bridge change as uncovered, because the one test that covers those lines throws its coverage away. (Same footgun class as `os.execv` in tests; it just bit the telemetry-usage + morning-briefing tests too.)

## Fix

Flush the active coverage session explicitly before the hard exit — the same pattern the morning-briefing calendar test uses:

```python
try:
    import coverage
    _cov = coverage.Coverage.current()
    if _cov is not None:
        _cov.save()
except Exception:
    pass
os._exit(_rc)
```

The SIGSEGV-dodge is preserved (still `os._exit`); coverage is just saved first.

## Verified

- `coverage run tests/slack-bridge-tofu-enroll.test.py` → slack-bridge.py **0% → 34%** recorded.
- Plain run: **7/7 TOFU tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
