### PR TITLE
feat(secret-vault): add 'delete' verb — remove a key from Keychain + manifest

### DIFF
--- a/skills/secret-vault/secret-vault.py
+++ b/skills/secret-vault/secret-vault.py
@@ -6,6 +6,7 @@ Subcommands:
   get KEY                 Print the value for KEY
   set KEY                 Store a value for KEY, read from stdin (not argv —
                           keeps the secret out of `ps`/shell history)
+  delete KEY              Remove KEY from the Keychain and the manifest
   env KEY [KEY...] -- CMD Run CMD with vault keys injected as environment variables
 
 Examples:
@@ -24,7 +25,7 @@ _SRC = os.path.join(os.path.dirname(__file__), "..", "..", "src")
 if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 
-from vault_intercept import get_vault_key, list_vault_keys, set_vault_key
+from vault_intercept import delete_vault_key, get_vault_key, list_vault_keys, set_vault_key
 
 
 def cmd_list() -> None:
@@ -58,6 +59,15 @@ def cmd_set(key: str) -> None:
         print(str(e), file=sys.stderr)
         sys.exit(1)
     print(f"stored '{key}'")
+
+
+def cmd_delete(key: str) -> None:
+    try:
+        delete_vault_key(key)
+    except (ValueError, KeyError) as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+    print(f"deleted '{key}'")
 
 
 def cmd_env(keys: list[str], cmd: list[str]) -> None:
@@ -103,6 +113,12 @@ def main() -> None:
             sys.exit(1)
         cmd_set(args[1])
 
+    elif sub == "delete":
+        if len(args) < 2:
+            print("vault delete: missing KEY", file=sys.stderr)
+            sys.exit(1)
+        cmd_delete(args[1])
+
     elif sub == "env":
         rest = args[1:]
         try:
@@ -114,7 +130,7 @@ def main() -> None:
 
     else:
         print(f"vault: unknown subcommand '{sub}'", file=sys.stderr)
-        print("Usage: vault.py list | get KEY | set KEY | env KEY... -- CMD", file=sys.stderr)
+        print("Usage: vault.py list | get KEY | set KEY | delete KEY | env KEY... -- CMD", file=sys.stderr)
         sys.exit(1)
 
 

--- a/src/vault_intercept.py
+++ b/src/vault_intercept.py
@@ -192,6 +192,44 @@ def _register_key(key: str) -> None:
     os.replace(tmp, path)
 
 
+def _deregister_key(key: str) -> None:
+    manifest = _read_manifest()
+    if key not in manifest:
+        return
+    del manifest[key]
+    path = _manifest_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    # Atomic write — same pattern as _register_key so concurrent bridge
+    # processes won't corrupt keys.json.
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(manifest, f, indent=2)
+    os.replace(tmp, path)
+
+
+def delete_vault_key(key: str) -> None:
+    """Remove a secret from Keychain + manifest — the public delete path.
+
+    Counterpart to set_vault_key for callers that need to forget a stored
+    secret (CLI `delete` verb; the desktop's cloud_logout forgetting the
+    `sutk_` bearer). Removes the Keychain item AND deregisters the manifest
+    entry; tolerates the two drifting (a manifest entry with no Keychain item,
+    or vice versa, is cleaned up rather than erroring). Raises ValueError on
+    an invalid key name; KeyError when the key exists in neither place.
+    """
+    if not _ENV_KEY_RE.match(key or ""):
+        raise ValueError(f"vault: invalid key name '{key}' (want [A-Za-z_][A-Za-z0-9_]*)")
+    result = subprocess.run(
+        ["security", "delete-generic-password", "-a", _ACCOUNT, "-s", key],
+        capture_output=True,
+    )
+    keychain_had_it = result.returncode == 0
+    manifest_had_it = key in _read_manifest()
+    if not keychain_had_it and not manifest_had_it:
+        raise KeyError(f"vault: key '{key}' not found")
+    _deregister_key(key)
+
+
 def list_vault_keys() -> list[str]:
     """Return all key names stored in the vault manifest (no values)."""
     return sorted(_read_manifest().keys())

--- a/src/vault_intercept.py
+++ b/src/vault_intercept.py
@@ -224,6 +224,16 @@ def delete_vault_key(key: str) -> None:
         capture_output=True,
     )
     keychain_had_it = result.returncode == 0
+    # Only NOT-FOUND (errSecItemNotFound, rc 44) is tolerable drift. Any other
+    # nonzero result (locked Keychain, user denial, other OSStatus) means the
+    # secret may STILL be in the Keychain — deregistering the manifest then
+    # would hide a live credential from `list`. Fail loudly and leave the
+    # manifest intact so the entry stays findable.
+    if not keychain_had_it and result.returncode != 44:
+        raise RuntimeError(
+            f"vault: Keychain delete failed for '{key}' "
+            f"(rc={result.returncode}): {result.stderr.decode(errors='replace').strip()}"
+        )
     manifest_had_it = key in _read_manifest()
     if not keychain_had_it and not manifest_had_it:
         raise KeyError(f"vault: key '{key}' not found")

--- a/tests/vault-skill.test.py
+++ b/tests/vault-skill.test.py
@@ -124,6 +124,67 @@ class TestSetVaultKey(unittest.TestCase):
         mock_store.assert_not_called()
 
 
+class TestDeleteVaultKey(unittest.TestCase):
+    def test_deletes_from_keychain_and_manifest(self):
+        mock_result = MagicMock(returncode=0, stdout=b"", stderr=b"")
+        with patch("subprocess.run", return_value=mock_result) as mock_run, \
+             patch.object(vault_intercept, "_read_manifest", return_value={"MY_KEY": {}}), \
+             patch.object(vault_intercept, "_deregister_key") as mock_dereg:
+            vault_intercept.delete_vault_key("MY_KEY")
+        self.assertIn("delete-generic-password", mock_run.call_args[0][0])
+        mock_dereg.assert_called_once_with("MY_KEY")
+
+    def test_manifest_only_entry_still_deregisters(self):
+        # Keychain item already gone (drift) — the manifest entry is cleaned up
+        # rather than erroring.
+        mock_result = MagicMock(returncode=44, stdout=b"", stderr=b"not found")
+        with patch("subprocess.run", return_value=mock_result), \
+             patch.object(vault_intercept, "_read_manifest", return_value={"MY_KEY": {}}), \
+             patch.object(vault_intercept, "_deregister_key") as mock_dereg:
+            vault_intercept.delete_vault_key("MY_KEY")
+        mock_dereg.assert_called_once_with("MY_KEY")
+
+    def test_raises_key_error_when_nowhere(self):
+        mock_result = MagicMock(returncode=44, stdout=b"", stderr=b"not found")
+        with patch("subprocess.run", return_value=mock_result), \
+             patch.object(vault_intercept, "_read_manifest", return_value={}), \
+             patch.object(vault_intercept, "_deregister_key") as mock_dereg:
+            with self.assertRaises(KeyError):
+                vault_intercept.delete_vault_key("MISSING")
+        mock_dereg.assert_not_called()
+
+    def test_rejects_invalid_key_names(self):
+        for bad in ("", "has space", "has-dash", "a=b"):
+            with patch("subprocess.run") as mock_run:
+                with self.assertRaises(ValueError):
+                    vault_intercept.delete_vault_key(bad)
+            mock_run.assert_not_called()
+
+
+class TestDeregisterKey(unittest.TestCase):
+    def test_removes_key_and_rewrites_manifest(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "keys.json")
+            with open(path, "w") as f:
+                json.dump({"KEEP": {"stored_at": "x"}, "DROP": {"stored_at": "y"}}, f)
+            with patch.object(vault_intercept, "_manifest_path", return_value=path), \
+                 patch.object(vault_intercept, "_read_manifest",
+                              return_value={"KEEP": {"stored_at": "x"}, "DROP": {"stored_at": "y"}}):
+                vault_intercept._deregister_key("DROP")
+            with open(path) as f:
+                manifest = json.load(f)
+        self.assertEqual(list(manifest.keys()), ["KEEP"])
+
+    def test_absent_key_is_a_noop_write(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "keys.json")
+            with patch.object(vault_intercept, "_manifest_path", return_value=path), \
+                 patch.object(vault_intercept, "_read_manifest", return_value={"KEEP": {}}):
+                vault_intercept._deregister_key("NOT_THERE")
+            # No manifest file written for a no-op deregister.
+            self.assertFalse(os.path.exists(path))
+
+
 class TestRegisterKey(unittest.TestCase):
     def _patch_paths(self, canonical, legacy):
         return (
@@ -226,6 +287,22 @@ class TestVaultCliGet(unittest.TestCase):
         with patch("vault.get_vault_key", side_effect=KeyError("not found")):
             with self.assertRaises(SystemExit) as cm:
                 vault_cli.cmd_get("MISSING")
+        self.assertEqual(cm.exception.code, 1)
+
+
+class TestVaultCliDelete(unittest.TestCase):
+    def test_prints_confirmation(self):
+        with patch("vault.delete_vault_key") as mock_del:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                vault_cli.cmd_delete("MY_KEY")
+        mock_del.assert_called_once_with("MY_KEY")
+        self.assertIn("deleted 'MY_KEY'", buf.getvalue())
+
+    def test_exits_1_on_missing_key(self):
+        with patch("vault.delete_vault_key", side_effect=KeyError("not found")):
+            with self.assertRaises(SystemExit) as cm:
+                vault_cli.cmd_delete("MISSING")
         self.assertEqual(cm.exception.code, 1)
 
 

--- a/tests/vault-skill.test.py
+++ b/tests/vault-skill.test.py
@@ -387,5 +387,75 @@ class TestVaultCliEnv(unittest.TestCase):
         self.assertEqual(cm.exception.code, 1)
 
 
+class TestVaultCliDelete(unittest.TestCase):
+    """Error/exit branches of the delete verb (coverage-gate follow-up,
+    john-the-dev peer note 2026-07-20): the happy path is covered above;
+    these pin the failure contract — exit 1 + the error on stderr."""
+
+    def _main(self, argv):
+        with patch.object(sys, "argv", ["secret-vault.py", *argv]):
+            vault_cli.main()
+
+    def test_delete_missing_key_exits_1_with_stderr(self):
+        import io
+        from contextlib import redirect_stderr
+        buf = io.StringIO()
+        with patch("vault.delete_vault_key", side_effect=KeyError("vault: key 'NOPE' not found")):
+            with self.assertRaises(SystemExit) as cm, redirect_stderr(buf):
+                self._main(["delete", "NOPE"])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("NOPE", buf.getvalue())
+
+    def test_delete_invalid_name_exits_1(self):
+        with patch("vault.delete_vault_key", side_effect=ValueError("vault: invalid key name")):
+            with self.assertRaises(SystemExit) as cm:
+                self._main(["delete", "bad-name"])
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_delete_without_key_exits_1_with_usage(self):
+        import io
+        from contextlib import redirect_stderr
+        buf = io.StringIO()
+        with self.assertRaises(SystemExit) as cm, redirect_stderr(buf):
+            self._main(["delete"])
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn("missing KEY", buf.getvalue())
+
+
+class TestDeleteVaultKeyErrorBranches(unittest.TestCase):
+    """vault_intercept.delete_vault_key / _deregister_key error + no-op paths."""
+
+    def test_not_found_anywhere_raises_keyerror(self):
+        # Keychain says no (rc!=0) AND manifest doesn't have it -> KeyError.
+        with patch.object(vault_intercept.subprocess, "run",
+                          return_value=MagicMock(returncode=44)), \
+             patch.object(vault_intercept, "_read_manifest", return_value={}):
+            with self.assertRaises(KeyError):
+                vault_intercept.delete_vault_key("GHOST_KEY")
+
+    def test_invalid_key_name_raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            vault_intercept.delete_vault_key("not a valid name!")
+
+    def test_manifest_only_drift_still_deletes(self):
+        # Keychain item already gone but manifest has the entry: tolerated,
+        # deregisters instead of erroring (the drift-cleanup contract).
+        with patch.object(vault_intercept.subprocess, "run",
+                          return_value=MagicMock(returncode=44)), \
+             patch.object(vault_intercept, "_read_manifest",
+                          return_value={"DRIFTED": {"stored_at": "x"}}), \
+             patch.object(vault_intercept, "_deregister_key") as mock_dereg:
+            vault_intercept.delete_vault_key("DRIFTED")
+        mock_dereg.assert_called_once_with("DRIFTED")
+
+    def test_deregister_missing_key_is_noop(self):
+        # _deregister_key early-returns when the key isn't in the manifest —
+        # no write attempted.
+        with patch.object(vault_intercept, "_read_manifest", return_value={}), \
+             patch.object(vault_intercept, "_manifest_path") as mock_path:
+            vault_intercept._deregister_key("ABSENT")
+        mock_path.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/vault-skill.test.py
+++ b/tests/vault-skill.test.py
@@ -387,7 +387,7 @@ class TestVaultCliEnv(unittest.TestCase):
         self.assertEqual(cm.exception.code, 1)
 
 
-class TestVaultCliDelete(unittest.TestCase):
+class TestVaultCliDeleteErrorBranches(unittest.TestCase):
     """Error/exit branches of the delete verb (coverage-gate follow-up,
     john-the-dev peer note 2026-07-20): the happy path is covered above;
     these pin the failure contract — exit 1 + the error on stderr."""
@@ -447,6 +447,20 @@ class TestDeleteVaultKeyErrorBranches(unittest.TestCase):
              patch.object(vault_intercept, "_deregister_key") as mock_dereg:
             vault_intercept.delete_vault_key("DRIFTED")
         mock_dereg.assert_called_once_with("DRIFTED")
+
+    def test_real_security_failure_raises_and_keeps_manifest(self):
+        # P1 regression (Codex 2026-07-20): a NON-not-found `security` failure
+        # (locked Keychain, user denial — rc != 44) while the manifest still
+        # holds the key must RAISE and leave the manifest untouched. Anything
+        # else silently hides a live credential from `list`.
+        with patch.object(vault_intercept.subprocess, "run",
+                          return_value=MagicMock(returncode=51, stderr=b"User interaction is not allowed.")), \
+             patch.object(vault_intercept, "_read_manifest",
+                          return_value={"LOCKED": {"stored_at": "x"}}), \
+             patch.object(vault_intercept, "_deregister_key") as mock_dereg:
+            with self.assertRaises(RuntimeError):
+                vault_intercept.delete_vault_key("LOCKED")
+        mock_dereg.assert_not_called()
 
     def test_deregister_missing_key_is_noop(self):
         # _deregister_key early-returns when the key isn't in the manifest —


### PR DESCRIPTION
## What

The missing counterpart to #2132's `set` verb: a public delete path for the secret vault.

- **`vault_intercept.delete_vault_key(key)`** — removes the Keychain item (`security delete-generic-password -a sutando -s KEY`) AND deregisters the manifest entry (atomic rewrite, mirroring `_register_key`). **Drift-tolerant**: a manifest entry whose Keychain item is already gone — or a Keychain item missing from the manifest — is cleaned up rather than erroring; `KeyError` only when the key exists in neither place. `ValueError` on invalid names (same `_ENV_KEY_RE` gate as `set`).
- **CLI**: `secret-vault.py delete KEY` → `deleted 'KEY'`; exit 1 + stderr on missing/invalid. Docstring + usage updated.

## Why now

Consumers need to *forget* stored secrets and currently can't — the vault surface is set/list/get-only. First user: the ag2space desktop's `cloud_logout` (forgetting the `sutk_` cloud bearer stored by its Rust cloud-session; ag2space-cinny-desktop#136 ships login/fetch and had to leave Disconnect web-only pending this verb).

## Test

- 8 new unit tests (delete: keychain+manifest / drift cases / KeyError / key validation; `_deregister_key`: rewrite + no-op-no-write; CLI: confirmation + exit-1) — `tests/vault-skill.test.py` now 38 pass.
- `tests/vault-intercept.test.py` — 47 pass (module touched, suite unaffected).
- Live smoke on a throwaway key: set → listed → **deleted** → get fails → manifest clean → second delete = clean `KeyError`.

Single concern; no refactors. Bug-free base confirmed against `upstream/main` (the verb simply doesn't exist there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194Kffr9WaeHAu19TZ8rjhK