### PR TITLE
feat(runtime): expose AG2 Space enrollment (connected + agent_id) in the AgentRuntime descriptor

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -450,18 +450,24 @@ except Exception:
 # enrolled before it existed -> null, and consumers should treat null as
 # 'enrolled, identity unknown', not 'not enrolled'.
 probe_ag2space = {'connected': False, 'agent_id': None, 'owner': None}
-try:
-    _kv = {}
-    with open(os.path.join(brain, 'channels', 'ag2space', 'relay-client.env')) as f:
-        for _line in f:
-            _line = _line.strip()
-            if _line and not _line.startswith('#') and '=' in _line:
-                _k, _, _v = _line.partition('=')
-                _kv[_k.strip()] = _v.strip()
-    if _kv.get('REMOTE_TASK_TOKEN'):
-        probe_ag2space['connected'] = True
-except Exception:
-    pass
+# Reader fallback (repo convention): relay-client.env is the canonical creds
+# file, but installs enrolled via the OSS path (onboard.sh -> startup.sh) and
+# the AG2 Space desktop launcher (AG2_DEVICE_ENV) write channels/ag2space/.env
+# instead. Try canonical first, then legacy, before concluding not-connected.
+for _envname in ('relay-client.env', '.env'):
+    try:
+        _kv = {}
+        with open(os.path.join(brain, 'channels', 'ag2space', _envname)) as f:
+            for _line in f:
+                _line = _line.strip()
+                if _line and not _line.startswith('#') and '=' in _line:
+                    _k, _, _v = _line.partition('=')
+                    _kv[_k.strip()] = _v.strip()
+        if _kv.get('REMOTE_TASK_TOKEN'):
+            probe_ag2space['connected'] = True
+            break
+    except Exception:
+        pass
 try:
     with open(os.path.join(ws, 'state', 'auth', 'ag2space.json')) as f:
         _aid = json.load(f).get('agent_id') or ''

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -449,7 +449,7 @@ except Exception:
 # clobbers foreign keys). Written by the connect flow; absent on installs
 # enrolled before it existed -> null, and consumers should treat null as
 # 'enrolled, identity unknown', not 'not enrolled'.
-probe_ag2space = {'connected': False, 'agent_id': None}
+probe_ag2space = {'connected': False, 'agent_id': None, 'owner': None}
 try:
     _kv = {}
     with open(os.path.join(brain, 'channels', 'ag2space', 'relay-client.env')) as f:
@@ -468,6 +468,17 @@ try:
     # only trust a well-formed mxid (@localpart:server)
     if isinstance(_aid, str) and _aid.startswith('@') and ':' in _aid[1:]:
         probe_ag2space['agent_id'] = _aid
+except Exception:
+    pass
+# owner: the mxid the core obeys as owner (TOFU enrollment in the gateway
+# bridge's access.json). Lets the dialog render 'you are its owner' vs 'this
+# core belongs to <owner>' when the signed-in user differs — authority itself
+# is enforced at message-processing time (allowFrom/tierMap), this is display.
+try:
+    with open(os.path.join(brain, 'channels', 'ag2space', 'access.json')) as f:
+        _own = json.load(f).get('tofuOwner') or ''
+    if isinstance(_own, str) and _own.startswith('@') and ':' in _own[1:]:
+        probe_ag2space['owner'] = _own
 except Exception:
     pass
 env = dict(os.environ, SUTANDO_TMUX_SOCKET=probe_socket)

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -463,7 +463,9 @@ for _envname in ('relay-client.env', '.env'):
                 if _line and not _line.startswith('#') and '=' in _line:
                     _k, _, _v = _line.partition('=')
                     _kv[_k.strip()] = _v.strip()
-        if _kv.get('REMOTE_TASK_TOKEN'):
+        # AG2_REMOTE_TOKEN is the legacy alias for the same enrollment
+        # (startup.sh + health-check.py both recognize it) — either counts.
+        if _kv.get('REMOTE_TASK_TOKEN') or _kv.get('AG2_REMOTE_TOKEN'):
             probe_ag2space['connected'] = True
             break
     except Exception:

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -438,6 +438,38 @@ try:
         probe_call_tiers = ct
 except Exception:
     pass
+# ag2space: is this install already enrolled on AG2 Space, and as whom?
+# 'connected' = ENROLLED (the gateway bridge has a task token configured in
+# channels/ag2space/relay-client.env under the brain dir) — deliberately not
+# process-liveness: the consumer is the desktop onboarding dialog, and a
+# momentarily-down bridge must not push the user into re-minting an identity.
+# agent_id comes from state/auth/ag2space.json — the durable per-host identity
+# home (state/auth/ is exempt from transient-state cleanup; relay-client.env is
+# the WRONG home for identity because the bridge regenerates that file and
+# clobbers foreign keys). Written by the connect flow; absent on installs
+# enrolled before it existed -> null, and consumers should treat null as
+# 'enrolled, identity unknown', not 'not enrolled'.
+probe_ag2space = {'connected': False, 'agent_id': None}
+try:
+    _kv = {}
+    with open(os.path.join(brain, 'channels', 'ag2space', 'relay-client.env')) as f:
+        for _line in f:
+            _line = _line.strip()
+            if _line and not _line.startswith('#') and '=' in _line:
+                _k, _, _v = _line.partition('=')
+                _kv[_k.strip()] = _v.strip()
+    if _kv.get('REMOTE_TASK_TOKEN'):
+        probe_ag2space['connected'] = True
+except Exception:
+    pass
+try:
+    with open(os.path.join(ws, 'state', 'auth', 'ag2space.json')) as f:
+        _aid = json.load(f).get('agent_id') or ''
+    # only trust a well-formed mxid (@localpart:server)
+    if isinstance(_aid, str) and _aid.startswith('@') and ':' in _aid[1:]:
+        probe_ag2space['agent_id'] = _aid
+except Exception:
+    pass
 env = dict(os.environ, SUTANDO_TMUX_SOCKET=probe_socket)
 h = {}
 try:
@@ -493,6 +525,13 @@ print(json.dumps({
     # reachable rows, un-greying Direct(Tailscale)/Direct(LAN) when their url is
     # advertised. Runtime-authored via probe_call_tiers above (emit-call-tiers.ts).
     'call_tiers': probe_call_tiers,
+    # ag2space: AG2 Space enrollment of THIS install (probe_ag2space above).
+    # {connected: bool, agent_id: '@…:server'|null}. 'connected' = enrolled
+    # (relay token configured), NOT bridge liveness — consumed by the desktop
+    # onboarding dialog to stop offering identity-minting to an already-
+    # connected core (owner report 2026-07-19). agent_id null on pre-
+    # AG2_AGENT_ID installs: treat as 'enrolled, identity unknown'.
+    'ag2space': probe_ag2space,
     'health': h.get('health', 'unknown'),
     'authenticated': h.get('authenticated'),
 }))

--- a/tests/sutando-config-runtime.test.sh
+++ b/tests/sutando-config-runtime.test.sh
@@ -174,6 +174,29 @@ vc11="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys
 [ "$vc11" = "http://127.0.0.1:7847" ]; report "$?" "vision_control=$vc11 == default (non-loopback 10.0.0.5 rejected)"
 rm -rf "$T9WS"; rm -f "$CFG"; [ -n "$CFG_BAK" ] && mv "$CFG_BAK" "$CFG"
 
+# -- Test 12: ag2space.connected — legacy .env + AG2_REMOTE_TOKEN alias (#2178 P1) --
+# OSS-path enrollments write channels/ag2space/.env (not relay-client.env), and
+# older ones carry AG2_REMOTE_TOKEN (the alias startup.sh + health-check.py
+# recognize). The probe must report connected for BOTH filenames and BOTH keys —
+# else an enrolled legacy install is offered a fresh identity by the desktop
+# onboarding dialog (the bug #2178 exists to fix).
+echo "[12] runtime.ag2space → connected for legacy .env + AG2_REMOTE_TOKEN (and both canonical shapes)"
+CFG="$REPO_DIR/sutando.config.local.json"; CFG_BAK=""
+[ -f "$CFG" ] && { CFG_BAK="$(mktemp)"; cp "$CFG" "$CFG_BAK"; }
+T12WS="$(mktemp -d)"; mkdir -p "$T12WS/state" "$T12WS/.claude-sutando/channels/ag2space"
+printf '{"workspace":{"path":"%s"}}' "$T12WS" > "$CFG"
+printf 'AG2_REMOTE_TOKEN=tok\n' > "$T12WS/.claude-sutando/channels/ag2space/.env"
+c12a="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["ag2space"]["connected"])')"
+[ "$c12a" = "True" ]; report "$?" "ag2space.connected=$c12a for legacy .env + AG2_REMOTE_TOKEN"
+printf 'REMOTE_TASK_TOKEN=tok\n' > "$T12WS/.claude-sutando/channels/ag2space/.env"
+c12b="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["ag2space"]["connected"])')"
+[ "$c12b" = "True" ]; report "$?" "ag2space.connected=$c12b for legacy .env + REMOTE_TASK_TOKEN"
+rm -f "$T12WS/.claude-sutando/channels/ag2space/.env"
+printf 'REMOTE_TASK_TOKEN=tok\n' > "$T12WS/.claude-sutando/channels/ag2space/relay-client.env"
+c12c="$(bash "$SCRIPT" runtime | python3 -c 'import json,sys;print(json.load(sys.stdin)["ag2space"]["connected"])')"
+[ "$c12c" = "True" ]; report "$?" "ag2space.connected=$c12c for canonical relay-client.env"
+rm -rf "$T12WS"; rm -f "$CFG"; [ -n "$CFG_BAK" ] && mv "$CFG_BAK" "$CFG"
+
 echo
 echo "sutando-config-runtime: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

The desktop onboarding dialog offers to mint a **new** agent identity even when the detected core is already connected to AG2 Space (owner report 2026-07-19 — the dialog proposed `@qingyun-desktop.agent` while the core runs as `@sutando-qingyun-001`). Root cause: enrollment identity existed only server-side; nothing local exposed it, so the dialog had nothing to read.

Adds an `ag2space: {connected, agent_id}` block to the `runtime` descriptor:

- **connected** = a gateway task token is configured in `channels/ag2space/relay-client.env` (brain dir). Enrollment, deliberately **not** bridge process-liveness — a momentarily-down bridge must not push the user back into onboarding.
- **agent_id** = read from `state/auth/ag2space.json`, the durable per-host identity home (`state/auth/` is exempt from transient-state cleanup). **Not** `relay-client.env`: the bridge regenerates that file — verified live, an appended `AG2_AGENT_ID` line was clobbered within minutes.
- `agent_id: null` = "enrolled, identity unknown" (installs enrolled before this file existed) — consumers must treat this as enrolled.

## Test

- Probe verified against this live install: `{"connected": true, "agent_id": "@sutando-qingyun-001:ag2.space"}`.
- 5 parse cases (missing/empty/malformed token + mxid) pass; malformed mxid → null.
- `bash -n` clean; foreign-caller-safe (same read-only sources pattern as socket/voice_ws probes).

## Consumer

ag2space-cinny-desktop onboarding (air's paired slice, spec'd in the focus room): render ✓ core running / ✓ already connected as `<mxid>` instead of the identity-mint form when `agent_id` is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)