### PR TITLE
feat(runtime): G1.5 node-bundle engine half — SUTANDO_NODE-first launch + dist-first services + health probe

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -256,16 +256,26 @@ print(_host_label(), end='')
 
   node-bin)
     # SINGLE SOURCE OF TRUTH for the Node executable (G1.5 node-bundle,
-    # owner-adopted design 2026-07-19). Precedence:
-    #   1. $SUTANDO_NODE — the EXACT executable, exported by the desktop app
-    #      when it manages the launch (its pinned bundled runtime always wins).
-    #   2. app-node-dir/node — the bundled runtime found at its default home
-    #      (covers launchd jobs whose plist doesn't export SUTANDO_NODE).
+    # owner-adopted design + owner review 2026-07-19). Precedence:
+    #   1. $SUTANDO_NODE — the EXACT executable, exported by the desktop app.
+    #      AUTHORITATIVE ONCE SET: if it is set but not executable, that is a
+    #      desktop packaging error — FAIL CLOSED (stderr + exit 1) instead of
+    #      silently rescuing via whatever node the host happens to have, which
+    #      would mask the packaging bug and void the deterministic-runtime
+    #      guarantee (owner review P1-1).
+    #   2. app-node-dir/node — the bundled runtime at its canonical home
+    #      <engine-root>/runtime/node/bin (covers launchd jobs whose plist
+    #      doesn't export SUTANDO_NODE).
     #   3. first `node` on PATH — dev/OSS hosts, unchanged behavior.
-    # Prints the resolved path, or nothing — the caller decides how to fail
-    # (same contract as tsx-bin).
-    if [ -n "${SUTANDO_NODE:-}" ] && [ -x "${SUTANDO_NODE}" ]; then
-      printf '%s' "$SUTANDO_NODE"
+    # Prints the resolved path; empty output + exit 0 when nothing resolves
+    # (caller decides), exit 1 ONLY for the invalid-explicit case.
+    if [ -n "${SUTANDO_NODE:-}" ]; then
+      if [ -x "${SUTANDO_NODE}" ]; then
+        printf '%s' "$SUTANDO_NODE"
+      else
+        echo "sutando-config: SUTANDO_NODE is set but not an executable: $SUTANDO_NODE (desktop packaging error — refusing PATH fallback)" >&2
+        exit 1
+      fi
     else
       _app_node="${SUTANDO_APP_NODE_DIR:-$HOME/Library/Application Support/space.ag2.app/engine/runtime/node/bin}/node"
       if [ -x "$_app_node" ]; then

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -254,6 +254,28 @@ print(_host_label(), end='')
     printf '%s' "${SUTANDO_APP_NODE_DIR:-$HOME/Library/Application Support/space.ag2.app/engine/runtime/node/bin}"
     ;;
 
+  node-bin)
+    # SINGLE SOURCE OF TRUTH for the Node executable (G1.5 node-bundle,
+    # owner-adopted design 2026-07-19). Precedence:
+    #   1. $SUTANDO_NODE — the EXACT executable, exported by the desktop app
+    #      when it manages the launch (its pinned bundled runtime always wins).
+    #   2. app-node-dir/node — the bundled runtime found at its default home
+    #      (covers launchd jobs whose plist doesn't export SUTANDO_NODE).
+    #   3. first `node` on PATH — dev/OSS hosts, unchanged behavior.
+    # Prints the resolved path, or nothing — the caller decides how to fail
+    # (same contract as tsx-bin).
+    if [ -n "${SUTANDO_NODE:-}" ] && [ -x "${SUTANDO_NODE}" ]; then
+      printf '%s' "$SUTANDO_NODE"
+    else
+      _app_node="${SUTANDO_APP_NODE_DIR:-$HOME/Library/Application Support/space.ag2.app/engine/runtime/node/bin}/node"
+      if [ -x "$_app_node" ]; then
+        printf '%s' "$_app_node"
+      else
+        command -v node 2>/dev/null || true
+      fi
+    fi
+    ;;
+
   tsx-bin)
     # SINGLE SOURCE OF TRUTH for tsx resolution — the launchd wrapper and
     # src/startup.sh both call this instead of each duplicating the candidate

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -147,6 +147,63 @@ def twilio_configured(env_content: str) -> bool:
     return False
 
 
+def resolve_node_runtime(env: Optional[dict] = None, which=shutil.which) -> dict:
+    """G1.5 node-bundle: resolve the Node executable the engine's JS services
+    would use, in the same precedence as `sutando-config.sh node-bin`:
+
+      1. $SUTANDO_NODE — exact executable exported by the desktop app.
+      2. $SUTANDO_APP_NODE_DIR/node (or its default app-support home) — the
+         bundled runtime found at rest (launchd jobs without the env var).
+      3. `node` on PATH — dev/OSS hosts.
+
+    Returns {"source": "bundled"|"app-bundle"|"system"|"none", "path": str|None}.
+    Pure over (env, which) for testability.
+    """
+    env = os.environ if env is None else env
+    explicit = env.get("SUTANDO_NODE", "")
+    if explicit and os.path.isfile(explicit) and os.access(explicit, os.X_OK):
+        return {"source": "bundled", "path": explicit}
+    app_dir = env.get("SUTANDO_APP_NODE_DIR", "") or os.path.expanduser(
+        "~/Library/Application Support/space.ag2.app/engine/runtime/node/bin"
+    )
+    app_node = os.path.join(app_dir, "node")
+    if os.path.isfile(app_node) and os.access(app_node, os.X_OK):
+        return {"source": "app-bundle", "path": app_node}
+    on_path = which("node")
+    if on_path:
+        return {"source": "system", "path": on_path}
+    return {"source": "none", "path": None}
+
+
+def check_node_runtime() -> dict:
+    """Surface WHICH node the JS services resolve to — or a loud red line when
+    none exists. The 2026-07-13 outage class: an interactive terminal finding
+    node does NOT mean launchd-/app-spawned services can (credential-proxy sat
+    dead for days on this failure). "none" is a real issue, not a warn: every
+    JS service (voice, phone, proxy, web-client) silently fails to start.
+    """
+    resolved = resolve_node_runtime()
+    if resolved["source"] == "none":
+        return {
+            "name": "node-runtime",
+            "status": "down",
+            "detail": "no node found (no SUTANDO_NODE, no app bundle, none on PATH) — JS services cannot start",
+        }
+    version = ""
+    try:
+        out = subprocess.run(
+            [resolved["path"], "--version"], capture_output=True, text=True, timeout=5
+        )
+        version = out.stdout.strip()
+    except Exception:
+        version = "version probe failed"
+    return {
+        "name": "node-runtime",
+        "status": "ok",
+        "detail": f"{version} via {resolved['source']} ({resolved['path']})",
+    }
+
+
 def check_port(port: int, name: str, probe: bool = False) -> dict:
     """Check if a port is listening, optionally probing for a live response.
 
@@ -1746,6 +1803,10 @@ def run_all_checks() -> list[dict]:
         proxy_check["status"] = "warn"
         proxy_check["detail"] = "not running (optional)"
     checks.append(proxy_check)
+
+    # G1.5: which Node would JS services resolve to (bundled/app-bundle/
+    # system), red when none — the silent-dead-services failure class.
+    checks.append(check_node_runtime())
 
     # macOS TCC — must come before critical-file checks so if TCC is blocking
     # everything, the operator sees the root cause before the downstream failures.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -211,14 +211,26 @@ def check_node_runtime() -> dict:
             "status": "warn",
             "detail": f"bundled runtime dir present but its node is unusable — running on system node {resolved['path']} (pinned-runtime guarantee NOT in effect)",
         }
-    version = ""
+    # Executable permission alone doesn't prove the runtime can launch the
+    # bundled services (Codex re-review F3): a --version that errors or fails
+    # to run means every JS service dies at spawn — that is DOWN, not ok.
     try:
         out = subprocess.run(
             [resolved["path"], "--version"], capture_output=True, text=True, timeout=5
         )
+        if out.returncode != 0:
+            return {
+                "name": "node-runtime",
+                "status": "down",
+                "detail": f"node at {resolved['path']} failed --version (rc={out.returncode}) — runtime not runnable",
+            }
         version = out.stdout.strip()
-    except Exception:
-        version = "version probe failed"
+    except Exception as exc:
+        return {
+            "name": "node-runtime",
+            "status": "down",
+            "detail": f"node at {resolved['path']} could not be executed ({exc}) — runtime not runnable",
+        }
     return {
         "name": "node-runtime",
         "status": "ok",

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -22,6 +22,7 @@ Checks:
 import hashlib
 import json
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -230,6 +231,24 @@ def check_node_runtime() -> dict:
             "name": "node-runtime",
             "status": "down",
             "detail": f"node at {resolved['path']} could not be executed ({exc}) — runtime not runnable",
+        }
+    # Version floor (external review on #2182): bundled services use node:sqlite,
+    # which needs Node >= 22.5 — an older node passes every other probe here but
+    # crashes those services at import. Unparseable versions degrade to warn
+    # (never block on a formatting surprise), too-old is DOWN with the fix named.
+    floor = (22, 5)
+    parsed = re.match(r"v?(\d+)\.(\d+)", version or "")
+    if parsed is None:
+        return {
+            "name": "node-runtime",
+            "status": "warn",
+            "detail": f"node at {resolved['path']} reported unparseable version {version!r} — cannot verify the >=22.5 floor (node:sqlite)",
+        }
+    if (int(parsed.group(1)), int(parsed.group(2))) < floor:
+        return {
+            "name": "node-runtime",
+            "status": "down",
+            "detail": f"{version} via {resolved['source']} is below the 22.5 floor (node:sqlite) — bundled services will crash; upgrade the runtime",
         }
     return {
         "name": "node-runtime",

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -161,8 +161,13 @@ def resolve_node_runtime(env: Optional[dict] = None, which=shutil.which) -> dict
     """
     env = os.environ if env is None else env
     explicit = env.get("SUTANDO_NODE", "")
-    if explicit and os.path.isfile(explicit) and os.access(explicit, os.X_OK):
-        return {"source": "bundled", "path": explicit}
+    if explicit:
+        if os.path.isfile(explicit) and os.access(explicit, os.X_OK):
+            return {"source": "bundled", "path": explicit}
+        # Owner review P1-1: SUTANDO_NODE is the desktop's explicit
+        # declaration — set-but-invalid is a packaging error, NOT a case to
+        # silently rescue via PATH. Surface it as its own failure source.
+        return {"source": "invalid-explicit", "path": explicit}
     app_dir = env.get("SUTANDO_APP_NODE_DIR", "") or os.path.expanduser(
         "~/Library/Application Support/space.ag2.app/engine/runtime/node/bin"
     )
@@ -171,6 +176,11 @@ def resolve_node_runtime(env: Optional[dict] = None, which=shutil.which) -> dict
         return {"source": "app-bundle", "path": app_node}
     on_path = which("node")
     if on_path:
+        # Desktop-managed installs should never end up here (bundled runtime
+        # dir exists but its node is broken/missing) — flag it so the probe
+        # can degrade instead of reporting a false green (owner review).
+        if os.path.isdir(app_dir):
+            return {"source": "system-degraded", "path": on_path}
         return {"source": "system", "path": on_path}
     return {"source": "none", "path": None}
 
@@ -188,6 +198,18 @@ def check_node_runtime() -> dict:
             "name": "node-runtime",
             "status": "down",
             "detail": "no node found (no SUTANDO_NODE, no app bundle, none on PATH) — JS services cannot start",
+        }
+    if resolved["source"] == "invalid-explicit":
+        return {
+            "name": "node-runtime",
+            "status": "down",
+            "detail": f"SUTANDO_NODE set but not executable: {resolved['path']} — desktop packaging error (fail-closed, no PATH fallback)",
+        }
+    if resolved["source"] == "system-degraded":
+        return {
+            "name": "node-runtime",
+            "status": "warn",
+            "detail": f"bundled runtime dir present but its node is unusable — running on system node {resolved['path']} (pinned-runtime guarantee NOT in effect)",
         }
     version = ""
     try:

--- a/src/install-credential-proxy-launchd.sh
+++ b/src/install-credential-proxy-launchd.sh
@@ -81,11 +81,17 @@ case "$cmd" in
         echo "  brew bin:  $BREW_BIN"
         mkdir -p "$HOME/Library/LaunchAgents"
         mkdir -p "$WORKSPACE/logs"
+        # SUTANDO_NODE is caller-controlled and lands inside plist XML via sed
+        # (external review on #2182): XML-encode &<> then escape sed's \ & and
+        # the | delimiter so hostile-looking paths can't corrupt the plist.
+        _node_xml="$(printf '%s' "${SUTANDO_NODE:-}" \
+            | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')"
+        _node_sed="$(printf '%s' "$_node_xml" | sed -e 's/[\\&|]/\\&/g')"
         sed \
             -e "s|__REPO__|$REPO|g" \
             -e "s|__WORKSPACE__|$WORKSPACE|g" \
             -e "s|__BREW_BIN__|$BREW_BIN|g" \
-            -e "s|__SUTANDO_NODE__|${SUTANDO_NODE:-}|g" \
+            -e "s|__SUTANDO_NODE__|${_node_sed}|g" \
             -e "s|__HOME__|$HOME|g" \
             "$TEMPLATE" > "$DEST"
         bootout_if_loaded

--- a/src/install-credential-proxy-launchd.sh
+++ b/src/install-credential-proxy-launchd.sh
@@ -85,6 +85,7 @@ case "$cmd" in
             -e "s|__REPO__|$REPO|g" \
             -e "s|__WORKSPACE__|$WORKSPACE|g" \
             -e "s|__BREW_BIN__|$BREW_BIN|g" \
+            -e "s|__SUTANDO_NODE__|${SUTANDO_NODE:-}|g" \
             -e "s|__HOME__|$HOME|g" \
             "$TEMPLATE" > "$DEST"
         bootout_if_loaded

--- a/src/launchd/com.sutando.credential-proxy.plist
+++ b/src/launchd/com.sutando.credential-proxy.plist
@@ -54,6 +54,14 @@
         <string>__HOME__</string>
         <key>SUTANDO_WORKSPACE</key>
         <string>__WORKSPACE__</string>
+        <!-- G1.5 P3: the pinned bundled Node, passed through from the
+             installing environment (desktop launcher exports it; startup.sh
+             inherits and runs this installer). Empty when not desktop-managed
+             — the wrapper's [ -n ... ] guards treat empty as unset, so
+             dev/OSS behavior is unchanged. This is what keeps launchd
+             RESTARTS on the pinned runtime (env-loss trap, owner review). -->
+        <key>SUTANDO_NODE</key>
+        <string>__SUTANDO_NODE__</string>
     </dict>
 
     <key>StandardOutPath</key>

--- a/src/launchd/credential-proxy-wrapper.sh
+++ b/src/launchd/credential-proxy-wrapper.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 # on the supervised launchd path too — not just src/startup.sh (Codex #2154).
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 for _node_cand in \
+    "${SUTANDO_NODE:-}" \
     /opt/homebrew/bin/node \
     /usr/local/bin/node \
     "$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin/node" \
@@ -94,6 +95,15 @@ kill_stale_holder() {
 }
 
 kill_stale_holder
+
+# G1.5 node-bundle: when the plist exports SUTANDO_NODE (desktop-managed
+# install), run the pre-built dist artifact directly under the pinned
+# runtime — no tsx, no node_modules. Falls through to the tsx path when
+# unset (dev/OSS) or when the artifact is absent (pre-bundle checkout).
+DIST_PROXY="$REPO_ROOT/dist/credential-proxy.js"
+if [ -n "${SUTANDO_NODE:-}" ] && [ -x "${SUTANDO_NODE}" ] && [ -f "$DIST_PROXY" ]; then
+    exec "$SUTANDO_NODE" "$DIST_PROXY"
+fi
 
 # Resolve and run.
 TSX_BIN=$(resolve_tsx 2>/dev/null) || true

--- a/src/launchd/credential-proxy-wrapper.sh
+++ b/src/launchd/credential-proxy-wrapper.sh
@@ -96,13 +96,33 @@ kill_stale_holder() {
 
 kill_stale_holder
 
-# G1.5 node-bundle: when the plist exports SUTANDO_NODE (desktop-managed
-# install), run the pre-built dist artifact directly under the pinned
-# runtime — no tsx, no node_modules. Falls through to the tsx path when
-# unset (dev/OSS) or when the artifact is absent (pre-bundle checkout).
+# G1.5 node-bundle (Codex re-review F1b): the wrapper enforces the SAME
+# resolver + fail-closed + mode contract as startup.sh. node-bin exits 1 on a
+# set-but-invalid SUTANDO_NODE — that is a desktop packaging error and the
+# job must FAIL (KeepAlive backs off on ThrottleInterval), never silently
+# slide to tsx/npx on whatever node the host has. Bundled context = explicit
+# env OR this wrapper running from the packaged engine copy (repo inside the
+# engine root that owns the at-rest runtime); in that context the dist
+# artifact is REQUIRED.
+NODE_BIN="$(bash "$REPO_ROOT/scripts/sutando-config.sh" node-bin)" || {
+    echo "credential-proxy-wrapper: SUTANDO_NODE set but invalid — desktop packaging error; fail-closed (no PATH/tsx fallback)" >&2
+    exit 78
+}
+_W_APP_NODE_DIR="$(bash "$REPO_ROOT/scripts/sutando-config.sh" app-node-dir)"
+_W_ENGINE_ROOT="${_W_APP_NODE_DIR%/node/bin}"; _W_ENGINE_ROOT="${_W_ENGINE_ROOT%/runtime}"
+_W_BUNDLED=0
+if [ -n "${SUTANDO_NODE:-}" ]; then
+    _W_BUNDLED=1
+elif [ -x "$_W_APP_NODE_DIR/node" ] && [ "${REPO_ROOT#"$_W_ENGINE_ROOT"/}" != "$REPO_ROOT" ]; then
+    _W_BUNDLED=1
+fi
 DIST_PROXY="$REPO_ROOT/dist/credential-proxy.js"
-if [ -n "${SUTANDO_NODE:-}" ] && [ -x "${SUTANDO_NODE}" ] && [ -f "$DIST_PROXY" ]; then
-    exec "$SUTANDO_NODE" "$DIST_PROXY"
+if [ "$_W_BUNDLED" = "1" ]; then
+    if [ ! -f "$DIST_PROXY" ]; then
+        echo "credential-proxy-wrapper: bundled mode but $DIST_PROXY missing — desktop packaging error; fail-closed" >&2
+        exit 78
+    fi
+    exec "$NODE_BIN" "$DIST_PROXY"
 fi
 
 # Resolve and run.

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -86,9 +86,18 @@ if [ -n "${SUTANDO_NODE:-}" ]; then
 elif [ -x "$_APP_NODE_DIR/node" ] && [ "${REPO#"$_APP_ENGINE_ROOT"/}" != "$REPO" ]; then
   BUNDLED_MODE=1
 fi
-if [ "$BUNDLED_MODE" = "1" ] && [ ! -f "$REPO/dist/web-client.js" ]; then
-  echo "✗ bundled mode: required dist artifacts missing ($REPO/dist/web-client.js) — desktop packaging error; refusing dev fallback (G1.5 fail-closed)"
-  exit 1
+if [ "$BUNDLED_MODE" = "1" ]; then
+  # Validate EVERY artifact of the build:bundle contract, not a representative
+  # one (external review on #2182): a missing voice/proxy/etc artifact would
+  # otherwise fail inside a background job while boot still prints ✓.
+  _MISSING_DIST=""
+  for _artifact in web-client voice-agent conversation-server credential-proxy boot emit-call-tiers; do
+    [ -f "$REPO/dist/$_artifact.js" ] || _MISSING_DIST="$_MISSING_DIST $_artifact.js"
+  done
+  if [ -n "$_MISSING_DIST" ]; then
+    echo "✗ bundled mode: required dist artifacts missing ($REPO/dist:$_MISSING_DIST) — desktop packaging error; refusing dev fallback (G1.5 fail-closed)"
+    exit 1
+  fi
 fi
 if [ -n "${SUTANDO_NODE:-}" ]; then
   _SUTANDO_NODE_DIR="$(dirname "$SUTANDO_NODE")"

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -50,6 +50,30 @@ run_tsx() {
   fi
 }
 
+# G1.5 node-bundle (owner-adopted design 2026-07-19): when the desktop app
+# manages the launch it exports SUTANDO_NODE=<exact bundled node executable>.
+# That runtime's dir wins PATH (covers every `#!/usr/bin/env node` re-exec),
+# and services prefer the pre-built dist/<name>.js artifact under it — no npm
+# install, no tsx, no node_modules at runtime. Dev/OSS hosts (SUTANDO_NODE
+# unset) keep tsx-over-src EXACTLY as before, so a stale dist/ can never
+# shadow live src edits.
+if [ -n "${SUTANDO_NODE:-}" ] && [ -x "${SUTANDO_NODE}" ]; then
+  _SUTANDO_NODE_DIR="$(dirname "$SUTANDO_NODE")"
+  case ":$PATH:" in *":$_SUTANDO_NODE_DIR:"*) ;; *) PATH="$_SUTANDO_NODE_DIR:$PATH"; export PATH ;; esac
+fi
+run_node_service() {
+  # $1 = dist basename (build-bundle artifact), $2 = ts entry (as run_tsx
+  # expects it today — relative or absolute), rest = service args.
+  _rns_dist="$REPO/dist/$1.js"
+  _rns_entry="$2"
+  shift 2
+  if [ -n "${SUTANDO_NODE:-}" ] && [ -x "${SUTANDO_NODE}" ] && [ -f "$_rns_dist" ]; then
+    "$SUTANDO_NODE" "$_rns_dist" "$@"
+  else
+    run_tsx "$_rns_entry" "$@"
+  fi
+}
+
 # Export workspace-scoped CLAUDE_CONFIG_DIR before services launch. Without it,
 # init.sh + the bridge-launcher blocks below (L~262 proxy, L~429 telegram,
 # L~449 discord, L~473 slack) probe `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` and
@@ -580,7 +604,7 @@ fi
 if ! lsof -i :7846 > /dev/null 2>&1; then
   echo "  Starting credential proxy (port 7846)..."
   _PROXY_SCRIPT="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/credential-proxy.ts)"
-  run_tsx "$_PROXY_SCRIPT" > /tmp/credential-proxy.log 2>&1 &
+  run_node_service credential-proxy "$_PROXY_SCRIPT" > /tmp/credential-proxy.log 2>&1 &
   sleep 1
   if lsof -i :7846 > /dev/null 2>&1; then
     echo "  ✓ credential proxy"
@@ -608,7 +632,7 @@ if [ "${SUTANDO_OBS_COLLECTOR:-}" = "1" ]; then
   if ! lsof -i :"$OBS_PORT" > /dev/null 2>&1; then
     echo "  Starting obs collector (port $OBS_PORT)..."
     SUTANDO_WORKSPACE="$WORKSPACE" SUTANDO_OBS_PORT="$OBS_PORT" \
-      run_tsx "$REPO/src/observability/boot.ts" > "$LOGS_DIR/collector.log" 2>&1 &
+      run_node_service boot "$REPO/src/observability/boot.ts" > "$LOGS_DIR/collector.log" 2>&1 &
     echo "  ✓ obs collector"
   else
     echo "  ✓ obs collector (already running on $OBS_PORT)"
@@ -673,7 +697,7 @@ else
     fi
   elif ! lsof -i :9900 > /dev/null 2>&1; then
     echo "  Starting voice agent (port 9900)..."
-    run_tsx src/voice-agent.ts > "$LOGS_DIR/voice-agent.log" 2>&1 &
+    run_node_service voice-agent src/voice-agent.ts > "$LOGS_DIR/voice-agent.log" 2>&1 &
     echo "  ✓ voice agent"
   else
     echo "  ✓ voice agent (already running)"
@@ -688,7 +712,7 @@ fi
 # back to cloud). `--interval 60` keeps it resident and re-emits every 60s so the
 # advertisement tracks reachability changes AFTER boot (tailnet/VPN coming up
 # post-startup would otherwise leave Direct(Tailscale) greyed until a restart).
-run_tsx src/emit-call-tiers.ts --interval 60 > "$LOGS_DIR/emit-call-tiers.log" 2>&1 &
+run_node_service emit-call-tiers src/emit-call-tiers.ts --interval 60 > "$LOGS_DIR/emit-call-tiers.log" 2>&1 &
 echo "  ✓ call-tiers advertisement (re-emit 60s)"
 
 # 2. Web client (port 8080 by default; CLIENT_PORT may avoid a local conflict)
@@ -713,7 +737,7 @@ if [ "$WEB_CLIENT_PORT" = "8080" ] && launchctl print "gui/$(id -u)/com.sutando.
   fi
 elif ! lsof -i :"$WEB_CLIENT_PORT" > /dev/null 2>&1; then
   echo "  Starting web client (port $WEB_CLIENT_PORT)..."
-  run_tsx src/web-client.ts > "$LOGS_DIR/web-client.log" 2>&1 &
+  run_node_service web-client src/web-client.ts > "$LOGS_DIR/web-client.log" 2>&1 &
   echo "  ✓ web client"
 else
   echo "  ✓ web client (already running on $WEB_CLIENT_PORT)"
@@ -1026,7 +1050,7 @@ elif ! phone_stack_enabled; then
 elif grep -qE '^[[:space:]]*TWILIO_ACCOUNT_SID=[^[:space:]]' .env 2>/dev/null; then
   if ! pgrep -f "conversation-server" > /dev/null 2>&1; then
     echo "  Starting conversation server..."
-    run_tsx skills/phone-conversation/scripts/conversation-server.ts > /tmp/conversation-server.log 2>&1 &
+    run_node_service conversation-server skills/phone-conversation/scripts/conversation-server.ts > /tmp/conversation-server.log 2>&1 &
     echo "  ✓ conversation server (port 3100)"
   else
     echo "  ✓ conversation server (already running)"

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -387,8 +387,22 @@ echo ""
 # things piece by piece.
 bash "$REPO/src/init.sh" --preflight | tail -1
 
-# Install dependencies if needed
-if [ ! -d node_modules ]; then
+# Bundled mode (G1.5 node-bundle, Codex review finding on #2182): when the
+# desktop app manages the launch it exports SUTANDO_NODE and ships pre-built
+# dist artifacts — there is deliberately NO npm/npx/node_modules in that
+# runtime, so the dependency bootstrap and the npx prerequisite below would
+# kill startup before run_node_service ever runs. Gate them off. Sentinel =
+# a valid SUTANDO_NODE plus the web-client dist artifact (built by
+# build:bundle; the one service every install runs).
+BUNDLED_MODE=0
+if [ -n "${SUTANDO_NODE:-}" ] && [ -x "${SUTANDO_NODE}" ] && [ -f "$REPO/dist/web-client.js" ]; then
+  BUNDLED_MODE=1
+  echo "  ✓ bundled mode (SUTANDO_NODE + dist artifacts) — skipping dependency bootstrap"
+fi
+
+# Install dependencies if needed (dev/source mode only — bundled installs
+# run dist artifacts under the pinned node and need no node_modules).
+if [ "$BUNDLED_MODE" != "1" ] && [ ! -d node_modules ]; then
   if command -v npm > /dev/null 2>&1 && npm install 2>/dev/null; then
     echo "  ✓ Dependencies installed (npm)"
   elif command -v pnpm > /dev/null 2>&1 && pnpm install 2>/dev/null; then
@@ -405,9 +419,13 @@ fi
 
 # Check CLI prerequisites. node/npx/python3, the selected core runtime, and
 # fswatch are checked here because they are not needed for init.sh bootstrap.
+# Bundled mode: node is $SUTANDO_NODE (its dir already heads PATH) and npx is
+# intentionally absent (bare-node runtime, dist-first services) — skip both.
 missing=0
-if ! command -v node > /dev/null 2>&1; then echo "  ✗ node not found — brew install node"; missing=1; fi
-if ! command -v npx > /dev/null 2>&1; then echo "  ✗ npx not found — comes with node"; missing=1; fi
+if [ "$BUNDLED_MODE" != "1" ]; then
+  if ! command -v node > /dev/null 2>&1; then echo "  ✗ node not found — brew install node"; missing=1; fi
+  if ! command -v npx > /dev/null 2>&1; then echo "  ✗ npx not found — comes with node"; missing=1; fi
+fi
 if ! command -v python3 > /dev/null 2>&1; then echo "  ✗ python3 not found"; missing=1; fi
 core_runtime="$(bash "$REPO/scripts/sutando-config.sh" core-runtime)"
 if ! command -v "$core_runtime" > /dev/null 2>&1; then

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -67,9 +67,21 @@ _NODE_BIN="$(bash "$REPO/scripts/sutando-config.sh" node-bin)" || {
   echo "✗ SUTANDO_NODE is set but invalid — desktop packaging error; refusing PATH fallback (G1.5 fail-closed)"
   exit 1
 }
+# At-rest discovery is scoped to the PACKAGED ENGINE COPY ONLY: the checkout
+# must itself live inside the engine root that owns the runtime
+# (<engine-root>/runtime/node/bin + <engine-root>/.../this repo). A dev
+# checkout on a machine that merely HAS the app installed must stay dev even
+# after `npm run build:bundle` — stale dist can never shadow live src
+# (Codex finding #3).
+_APP_ENGINE_ROOT="${_APP_NODE_DIR%/node/bin}"
+_APP_ENGINE_ROOT="${_APP_ENGINE_ROOT%/runtime}"
 BUNDLED_MODE=0
-if { [ -n "${SUTANDO_NODE:-}" ] || [ -x "$_APP_NODE_DIR/node" ]; } && [ -f "$REPO/dist/web-client.js" ]; then
-  BUNDLED_MODE=1
+if [ -f "$REPO/dist/web-client.js" ]; then
+  if [ -n "${SUTANDO_NODE:-}" ]; then
+    BUNDLED_MODE=1
+  elif [ -x "$_APP_NODE_DIR/node" ] && [ "${REPO#"$_APP_ENGINE_ROOT"/}" != "$REPO" ]; then
+    BUNDLED_MODE=1
+  fi
 fi
 if [ -n "${SUTANDO_NODE:-}" ]; then
   _SUTANDO_NODE_DIR="$(dirname "$SUTANDO_NODE")"

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -41,7 +41,10 @@ export SUTANDO_ROOT="$REPO"
 # such hosts (web-client outage 2026-07-17).
 _APP_NODE_DIR="$(bash "$REPO/scripts/sutando-config.sh" app-node-dir)"
 [ -d "$_APP_NODE_DIR" ] && case ":$PATH:" in *":$_APP_NODE_DIR:"*) ;; *) PATH="$_APP_NODE_DIR:$PATH"; export PATH ;; esac
-_TSX_BIN="$(bash "$REPO/scripts/sutando-config.sh" tsx-bin)"
+# `|| true`: tsx-bin prints nothing AND returns nonzero on a bare bundled
+# runtime (no tsx anywhere) — under set -e that exited startup at this line
+# before the bundled-mode gate could run (Codex blocking finding #2).
+_TSX_BIN="$(bash "$REPO/scripts/sutando-config.sh" tsx-bin || true)"
 run_tsx() {
   if [ -n "$_TSX_BIN" ]; then
     "$_TSX_BIN" "$@"
@@ -50,14 +53,25 @@ run_tsx() {
   fi
 }
 
-# G1.5 node-bundle (owner-adopted design 2026-07-19): when the desktop app
-# manages the launch it exports SUTANDO_NODE=<exact bundled node executable>.
-# That runtime's dir wins PATH (covers every `#!/usr/bin/env node` re-exec),
-# and services prefer the pre-built dist/<name>.js artifact under it — no npm
-# install, no tsx, no node_modules at runtime. Dev/OSS hosts (SUTANDO_NODE
-# unset) keep tsx-over-src EXACTLY as before, so a stale dist/ can never
-# shadow live src edits.
-if [ -n "${SUTANDO_NODE:-}" ] && [ -x "${SUTANDO_NODE}" ]; then
+# G1.5 node-bundle (owner-adopted design + owner review 2026-07-19).
+# Bundled and dev are MUTUALLY EXCLUSIVE modes, not a preference (P1-2):
+#   BUNDLED = the desktop-managed runtime is present — SUTANDO_NODE exported
+#   (fail-closed if invalid, see node-bin) OR the bundled runtime discovered
+#   at its canonical home (app-node-dir; covers launchd jobs without the env
+#   var) — AND dist artifacts are shipped. Services run dist/<name>.js under
+#   the pinned node; a missing artifact is an explicit PACKAGING ERROR, never
+#   a tsx fallback (tsx/npm/node_modules deliberately don't exist here).
+#   DEV = everything else; tsx-over-src exactly as before, so a stale dist/
+#   can never shadow live src edits.
+_NODE_BIN="$(bash "$REPO/scripts/sutando-config.sh" node-bin)" || {
+  echo "✗ SUTANDO_NODE is set but invalid — desktop packaging error; refusing PATH fallback (G1.5 fail-closed)"
+  exit 1
+}
+BUNDLED_MODE=0
+if { [ -n "${SUTANDO_NODE:-}" ] || [ -x "$_APP_NODE_DIR/node" ]; } && [ -f "$REPO/dist/web-client.js" ]; then
+  BUNDLED_MODE=1
+fi
+if [ -n "${SUTANDO_NODE:-}" ]; then
   _SUTANDO_NODE_DIR="$(dirname "$SUTANDO_NODE")"
   case ":$PATH:" in *":$_SUTANDO_NODE_DIR:"*) ;; *) PATH="$_SUTANDO_NODE_DIR:$PATH"; export PATH ;; esac
 fi
@@ -67,8 +81,12 @@ run_node_service() {
   _rns_dist="$REPO/dist/$1.js"
   _rns_entry="$2"
   shift 2
-  if [ -n "${SUTANDO_NODE:-}" ] && [ -x "${SUTANDO_NODE}" ] && [ -f "$_rns_dist" ]; then
-    "$SUTANDO_NODE" "$_rns_dist" "$@"
+  if [ "$BUNDLED_MODE" = "1" ]; then
+    if [ ! -f "$_rns_dist" ]; then
+      echo "  ✗ bundled mode: dist artifact missing: $_rns_dist (packaging error — refusing tsx fallback)"
+      return 1
+    fi
+    "$_NODE_BIN" "$_rns_dist" "$@"
   else
     run_tsx "$_rns_entry" "$@"
   fi
@@ -387,17 +405,13 @@ echo ""
 # things piece by piece.
 bash "$REPO/src/init.sh" --preflight | tail -1
 
-# Bundled mode (G1.5 node-bundle, Codex review finding on #2182): when the
-# desktop app manages the launch it exports SUTANDO_NODE and ships pre-built
-# dist artifacts — there is deliberately NO npm/npx/node_modules in that
-# runtime, so the dependency bootstrap and the npx prerequisite below would
-# kill startup before run_node_service ever runs. Gate them off. Sentinel =
-# a valid SUTANDO_NODE plus the web-client dist artifact (built by
-# build:bundle; the one service every install runs).
-BUNDLED_MODE=0
-if [ -n "${SUTANDO_NODE:-}" ] && [ -x "${SUTANDO_NODE}" ] && [ -f "$REPO/dist/web-client.js" ]; then
-  BUNDLED_MODE=1
-  echo "  ✓ bundled mode (SUTANDO_NODE + dist artifacts) — skipping dependency bootstrap"
+# Bundled mode (G1.5): BUNDLED_MODE is computed ONCE next to
+# run_node_service (single source of truth — owner review P1-2: app-node-dir
+# discovery counts as bundled too, not just the env var). The npm bootstrap
+# + node/npx prereq blocks below are gated on it because a bundled runtime
+# deliberately has NO npm/npx/node_modules (Codex finding #1).
+if [ "$BUNDLED_MODE" = "1" ]; then
+  echo "  ✓ bundled mode (pinned runtime + dist artifacts) — skipping dependency bootstrap"
 fi
 
 # Install dependencies if needed (dev/source mode only — bundled installs

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -75,13 +75,20 @@ _NODE_BIN="$(bash "$REPO/scripts/sutando-config.sh" node-bin)" || {
 # (Codex finding #3).
 _APP_ENGINE_ROOT="${_APP_NODE_DIR%/node/bin}"
 _APP_ENGINE_ROOT="${_APP_ENGINE_ROOT%/runtime}"
+# Mode comes from the MANAGED-RUNTIME SIGNAL ALONE (Codex re-review F2):
+# explicit SUTANDO_NODE, or the at-rest runtime discovered while running AS
+# the packaged engine copy. Artifact presence is then VALIDATED separately —
+# a managed runtime with missing dist is a packaging error that fails closed,
+# never a silent slide into dev/npm/tsx.
 BUNDLED_MODE=0
-if [ -f "$REPO/dist/web-client.js" ]; then
-  if [ -n "${SUTANDO_NODE:-}" ]; then
-    BUNDLED_MODE=1
-  elif [ -x "$_APP_NODE_DIR/node" ] && [ "${REPO#"$_APP_ENGINE_ROOT"/}" != "$REPO" ]; then
-    BUNDLED_MODE=1
-  fi
+if [ -n "${SUTANDO_NODE:-}" ]; then
+  BUNDLED_MODE=1
+elif [ -x "$_APP_NODE_DIR/node" ] && [ "${REPO#"$_APP_ENGINE_ROOT"/}" != "$REPO" ]; then
+  BUNDLED_MODE=1
+fi
+if [ "$BUNDLED_MODE" = "1" ] && [ ! -f "$REPO/dist/web-client.js" ]; then
+  echo "✗ bundled mode: required dist artifacts missing ($REPO/dist/web-client.js) — desktop packaging error; refusing dev fallback (G1.5 fail-closed)"
+  exit 1
 fi
 if [ -n "${SUTANDO_NODE:-}" ]; then
   _SUTANDO_NODE_DIR="$(dirname "$SUTANDO_NODE")"
@@ -632,10 +639,18 @@ fi
 _PROXY_LABEL="com.sutando.credential-proxy"
 _PROXY_INSTALLER="$REPO/src/install-credential-proxy-launchd.sh"
 if [ -f "$_PROXY_INSTALLER" ] && [ -f "$REPO/src/launchd/$_PROXY_LABEL.plist" ]; then
-  if launchctl print "gui/$(id -u)/$_PROXY_LABEL" > /dev/null 2>&1; then
-    echo "  ✓ credential proxy (launchd-supervised, already loaded)"
+  # Upgrade path (Codex re-review F1): an already-loaded job may carry a plist
+  # generated BEFORE SUTANDO_NODE existed (or with a different runtime) — a
+  # KeepAlive restart would then lose the pinned runtime. Compare the loaded
+  # plist's managed runtime to the current one and reinstall on drift (the
+  # installer bootout_if_loaded+bootstraps, so re-running over a live job is
+  # safe).
+  _PROXY_PLIST_DEST="$HOME/Library/LaunchAgents/$_PROXY_LABEL.plist"
+  _PROXY_PLIST_NODE="$(/usr/libexec/PlistBuddy -c "Print :EnvironmentVariables:SUTANDO_NODE" "$_PROXY_PLIST_DEST" 2>/dev/null || true)"
+  if launchctl print "gui/$(id -u)/$_PROXY_LABEL" > /dev/null 2>&1 && [ "$_PROXY_PLIST_NODE" = "${SUTANDO_NODE:-}" ]; then
+    echo "  ✓ credential proxy (launchd-supervised, already loaded, runtime current)"
   else
-    echo "  Installing launchd-supervised credential proxy..."
+    echo "  Installing launchd-supervised credential proxy (fresh or runtime drift)..."
     if bash "$_PROXY_INSTALLER" install > /dev/null 2>&1; then
       # Wait for the supervised proxy to bind before the legacy-launch guard.
       for _ in $(seq 1 10); do lsof -i :7846 > /dev/null 2>&1 && break; sleep 0.5; done

--- a/tests/node-runtime-resolve.test.py
+++ b/tests/node-runtime-resolve.test.py
@@ -1,0 +1,102 @@
+"""G1.5 node-bundle: resolve_node_runtime precedence + check_node_runtime shape.
+
+Covers the resolver's four outcomes (bundled / app-bundle / system / none) and
+the check's ok/down mapping, using temp executables so no host state leaks in.
+"""
+
+import importlib.util
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+sys.modules["health_check"] = hc
+spec.loader.exec_module(hc)
+
+
+def _make_exec(path: Path) -> str:
+    path.write_text("#!/bin/sh\necho v99.0.0\n")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return str(path)
+
+
+class ResolveNodeRuntimeTest(unittest.TestCase):
+    def test_sutando_node_wins_when_executable(self):
+        with tempfile.TemporaryDirectory() as td:
+            node = _make_exec(Path(td) / "node")
+            out = hc.resolve_node_runtime(
+                env={"SUTANDO_NODE": node}, which=lambda _: "/usr/fake/node"
+            )
+            self.assertEqual(out, {"source": "bundled", "path": node})
+
+    def test_sutando_node_ignored_when_missing(self):
+        # A dangling SUTANDO_NODE must not mask the PATH fallback.
+        out = hc.resolve_node_runtime(
+            env={"SUTANDO_NODE": "/nonexistent/node", "SUTANDO_APP_NODE_DIR": "/nonexistent"},
+            which=lambda _: "/usr/fake/node",
+        )
+        self.assertEqual(out, {"source": "system", "path": "/usr/fake/node"})
+
+    def test_app_bundle_beats_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            node = _make_exec(Path(td) / "node")
+            out = hc.resolve_node_runtime(
+                env={"SUTANDO_APP_NODE_DIR": td}, which=lambda _: "/usr/fake/node"
+            )
+            self.assertEqual(out, {"source": "app-bundle", "path": node})
+
+    def test_none_when_nothing_resolves(self):
+        out = hc.resolve_node_runtime(
+            env={"SUTANDO_APP_NODE_DIR": "/nonexistent"}, which=lambda _: None
+        )
+        self.assertEqual(out, {"source": "none", "path": None})
+
+
+class CheckNodeRuntimeTest(unittest.TestCase):
+    def test_down_when_none(self):
+        orig = hc.resolve_node_runtime
+        hc.resolve_node_runtime = lambda: {"source": "none", "path": None}
+        try:
+            out = hc.check_node_runtime()
+        finally:
+            hc.resolve_node_runtime = orig
+        self.assertEqual(out["name"], "node-runtime")
+        self.assertEqual(out["status"], "down")
+        self.assertIn("JS services cannot start", out["detail"])
+
+    def test_ok_reports_version_and_source(self):
+        with tempfile.TemporaryDirectory() as td:
+            node = _make_exec(Path(td) / "node")
+            orig = hc.resolve_node_runtime
+            hc.resolve_node_runtime = lambda: {"source": "bundled", "path": node}
+            try:
+                out = hc.check_node_runtime()
+            finally:
+                hc.resolve_node_runtime = orig
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("v99.0.0", out["detail"])
+        self.assertIn("bundled", out["detail"])
+
+    def test_ok_survives_version_probe_failure(self):
+        # A resolvable-but-broken binary still reports ok with a probe note —
+        # existence is the check's job; runnability shows in the detail.
+        with tempfile.TemporaryDirectory() as td:
+            broken = Path(td) / "node"
+            broken.write_text("not a script")
+            broken.chmod(0o755)
+            orig = hc.resolve_node_runtime
+            hc.resolve_node_runtime = lambda: {"source": "system", "path": str(broken)}
+            try:
+                out = hc.check_node_runtime()
+            finally:
+                hc.resolve_node_runtime = orig
+        self.assertEqual(out["status"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/node-runtime-resolve.test.py
+++ b/tests/node-runtime-resolve.test.py
@@ -112,9 +112,9 @@ class CheckNodeRuntimeTest(unittest.TestCase):
         self.assertIn("v99.0.0", out["detail"])
         self.assertIn("bundled", out["detail"])
 
-    def test_ok_survives_version_probe_failure(self):
-        # A resolvable-but-broken binary still reports ok with a probe note —
-        # existence is the check's job; runnability shows in the detail.
+    def test_down_when_version_probe_fails(self):
+        # Codex re-review F3: a resolvable-but-broken binary means every JS
+        # service dies at spawn — that is DOWN, not ok-with-a-note.
         with tempfile.TemporaryDirectory() as td:
             broken = Path(td) / "node"
             broken.write_text("not a script")
@@ -125,7 +125,8 @@ class CheckNodeRuntimeTest(unittest.TestCase):
                 out = hc.check_node_runtime()
             finally:
                 hc.resolve_node_runtime = orig
-        self.assertEqual(out["status"], "ok")
+        self.assertEqual(out["status"], "down")
+        self.assertIn("not runnable", out["detail"])
 
 
 if __name__ == "__main__":

--- a/tests/node-runtime-resolve.test.py
+++ b/tests/node-runtime-resolve.test.py
@@ -34,13 +34,23 @@ class ResolveNodeRuntimeTest(unittest.TestCase):
             )
             self.assertEqual(out, {"source": "bundled", "path": node})
 
-    def test_sutando_node_ignored_when_missing(self):
-        # A dangling SUTANDO_NODE must not mask the PATH fallback.
+    def test_sutando_node_invalid_fails_closed(self):
+        # Owner review P1-1: set-but-invalid is a packaging error — it must
+        # NOT be silently rescued by PATH; it surfaces as its own source.
         out = hc.resolve_node_runtime(
             env={"SUTANDO_NODE": "/nonexistent/node", "SUTANDO_APP_NODE_DIR": "/nonexistent"},
             which=lambda _: "/usr/fake/node",
         )
-        self.assertEqual(out, {"source": "system", "path": "/usr/fake/node"})
+        self.assertEqual(out, {"source": "invalid-explicit", "path": "/nonexistent/node"})
+
+    def test_system_degraded_when_app_dir_present_but_node_unusable(self):
+        # Bundled runtime dir exists but its node is broken -> desktop-managed
+        # install running on system node = degraded, not a clean "system".
+        with tempfile.TemporaryDirectory() as td:
+            out = hc.resolve_node_runtime(
+                env={"SUTANDO_APP_NODE_DIR": td}, which=lambda _: "/usr/fake/node"
+            )
+        self.assertEqual(out, {"source": "system-degraded", "path": "/usr/fake/node"})
 
     def test_app_bundle_beats_path(self):
         with tempfile.TemporaryDirectory() as td:
@@ -58,6 +68,26 @@ class ResolveNodeRuntimeTest(unittest.TestCase):
 
 
 class CheckNodeRuntimeTest(unittest.TestCase):
+    def test_down_when_invalid_explicit(self):
+        orig = hc.resolve_node_runtime
+        hc.resolve_node_runtime = lambda: {"source": "invalid-explicit", "path": "/x/node"}
+        try:
+            out = hc.check_node_runtime()
+        finally:
+            hc.resolve_node_runtime = orig
+        self.assertEqual(out["status"], "down")
+        self.assertIn("packaging error", out["detail"])
+
+    def test_warn_when_system_degraded(self):
+        orig = hc.resolve_node_runtime
+        hc.resolve_node_runtime = lambda: {"source": "system-degraded", "path": "/usr/bin/node"}
+        try:
+            out = hc.check_node_runtime()
+        finally:
+            hc.resolve_node_runtime = orig
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("NOT in effect", out["detail"])
+
     def test_down_when_none(self):
         orig = hc.resolve_node_runtime
         hc.resolve_node_runtime = lambda: {"source": "none", "path": None}

--- a/tests/node-runtime-resolve.test.py
+++ b/tests/node-runtime-resolve.test.py
@@ -112,6 +112,36 @@ class CheckNodeRuntimeTest(unittest.TestCase):
         self.assertIn("v99.0.0", out["detail"])
         self.assertIn("bundled", out["detail"])
 
+    def test_down_when_version_below_floor(self):
+        # External review on #2182: node < 22.5 lacks node:sqlite — every other
+        # probe passes but bundled services crash at import. Must be DOWN.
+        with tempfile.TemporaryDirectory() as td:
+            node = Path(td) / "node"
+            node.write_text("#!/bin/sh\necho v20.11.0\n")
+            node.chmod(node.stat().st_mode | stat.S_IXUSR)
+            orig = hc.resolve_node_runtime
+            hc.resolve_node_runtime = lambda: {"source": "system", "path": str(node)}
+            try:
+                out = hc.check_node_runtime()
+            finally:
+                hc.resolve_node_runtime = orig
+        self.assertEqual(out["status"], "down")
+        self.assertIn("22.5 floor", out["detail"])
+
+    def test_warn_when_version_unparseable(self):
+        with tempfile.TemporaryDirectory() as td:
+            node = Path(td) / "node"
+            node.write_text("#!/bin/sh\necho weird-build\n")
+            node.chmod(node.stat().st_mode | stat.S_IXUSR)
+            orig = hc.resolve_node_runtime
+            hc.resolve_node_runtime = lambda: {"source": "system", "path": str(node)}
+            try:
+                out = hc.check_node_runtime()
+            finally:
+                hc.resolve_node_runtime = orig
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("unparseable", out["detail"])
+
     def test_down_when_version_probe_fails(self):
         # Codex re-review F3: a resolvable-but-broken binary means every JS
         # service dies at spawn — that is DOWN, not ok-with-a-note.


### PR DESCRIPTION
## What

The **engine half of G1.5 node-bundle** (owner-adopted design 2026-07-19): the desktop app ships a pinned node executable and exports `SUTANDO_NODE=<exact path>`; the engine then needs **no system node, no npm install, no tsx** at runtime. Builds on #2154's `app-node-dir`/`tsx-bin` and the `build:bundle` dist artifacts.

## Semantics (post-review, authoritative)

- **`node-bin`** (single source of truth): `$SUTANDO_NODE` → `app-node-dir/node` → PATH → empty. **Set-but-invalid `SUTANDO_NODE` FAILS CLOSED** (exit 1, startup aborts, wrapper exits 78, health = down) — the desktop's explicit declaration is authoritative; no silent PATH rescue.
- **Bundled vs dev are mutually exclusive modes.** Bundled = explicit env OR at-rest runtime discovered while running as the packaged engine copy (dev clones on machines that merely have the app installed stay dev). Missing required dist under a managed runtime = explicit packaging error, never a tsx/npm fallback.
- **All launch paths enforce the same contract**: startup services (`run_node_service`), the launchd wrapper (node-bin + fail-closed + dist-required), and the plist (carries `SUTANDO_NODE`; upgrade drift detected via PlistBuddy → reinstall over live job so KeepAlive restarts keep the pinned runtime).
- **Health**: `bundled`/`app-bundle` ok · `system-degraded` warn · `none`/`invalid-explicit`/**not-runnable (failed `--version`)** down.

Dev/OSS hosts with `SUTANDO_NODE` unset and no packaged runtime: behavior unchanged.

## Verification

10/10 resolver/health tests; bash -n + py_compile + plutil clean; four Codex review rounds addressed (reachability ×2, dev-contamination scoping, upgrade-drift/wrapper/artifact/runnability).

Companion: desktop half in ag2-space/ag2space-cinny-desktop#159 (SUTANDO_NODE export + R1 audit fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194Kffr9WaeHAu19TZ8rjhK