### PR TITLE
chore(lint): skills/ and tests/

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,9 @@
 // so those are NOT covered here. No formatter either — tsc already covers
 // types, and formatting is out of scope for this baseline.
 //
-// Scope is src/ for now. Widen to skills/ and tests/ once src/ is clean.
+// Scope is all first-party TypeScript: src/, skills/, tests/. The rule set is
+// shared — the idioms the relaxations exist for (fail-open catch, deliberate
+// double-escaping, optional-dependency @ts-ignore) appear in all three trees.
 
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
@@ -17,10 +19,10 @@ export default tseslint.config(
     ignores: ['node_modules/**', 'packages/**', 'workspace/**', 'dist/**'],
   },
   {
-    files: ['src/**/*.ts'],
+    files: ['src/**/*.ts', 'skills/**/*.ts', 'tests/**/*.ts'],
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     linterOptions: {
-      // src/ already carries hand-written eslint-disable comments (no-console,
+      // The tree already carries hand-written eslint-disable comments (no-console,
       // ban-types) for rules this baseline doesn't enable. Don't report them as
       // unused — `--fix` would strip comments that encode author intent.
       reportUnusedDisableDirectives: 'off',

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -52,30 +52,8 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { voiceApiKey } from '../../../src/voice-key.js';
 import { loadVoiceConfig } from '../../../src/voice-config.js';
-import { hostname } from 'node:os';
 import { resolveWorkspace } from '../../../src/workspace_default.js';
 
-// Personal-asset path resolver — twin of util_paths.py / voice-agent.ts:personalPath.
-// Reads $SUTANDO_MEMORY_DIR (canonical post-#870), honors legacy $SUTANDO_PRIVATE_DIR
-// as a fallback with a one-release deprecation warning on every read.
-function personalPath(filename: string): string {
-	let privateRoot = process.env.SUTANDO_MEMORY_DIR;
-	if (!privateRoot && process.env.SUTANDO_PRIVATE_DIR) {
-		console.warn(
-			'[conversation-server] DEPRECATION: SUTANDO_PRIVATE_DIR is the old name ' +
-				'for the memory dir; set SUTANDO_MEMORY_DIR instead (this alias will ' +
-				'be removed in the next release). See #870.',
-		);
-		privateRoot = process.env.SUTANDO_PRIVATE_DIR;
-	}
-	if (privateRoot) {
-		const root = privateRoot.replace(/^~/, process.env.HOME || '');
-		const host = hostname().split('.')[0];
-		const candidate = join(root, `machine-${host}`, filename);
-		if (existsSync(candidate)) return candidate;
-	}
-	return filename;
-}
 import { execSync, execFileSync, spawn, type ChildProcess } from 'node:child_process';
 import { isAllowedAudioPath } from './audio_path_guard.js';
 import { VoiceSession, type ToolDefinition, type MainAgent } from 'bodhi-realtime-agent';
@@ -148,26 +126,10 @@ function archivePhoneFile(srcPath: string, kind: 'tasks' | 'results', taskId: st
 }
 
 const TASK_POLL_INTERVAL_MS = 500;
-const TASK_TIMEOUT_MS = 120_000;
 const OWNER_NAME = process.env.owner ?? '';
 const OWNER_NUMBER = process.env.OWNER_NUMBER ?? '';
 const OWNER_TZ = process.env.OWNER_TZ ?? 'America/Los_Angeles';
 
-// Build a date-context string injected into the system prompt at session-open
-// so Gemini resolves date-relative phrases ("tomorrow", "this Friday") against
-// the owner's local clock, not UTC or server-local. Without this, US-Pacific
-// owners get an off-by-one whenever a call lands after ~5pm PT (UTC midnight
-// rollover): the model says "tomorrow = May 28" when owner-local says May 27.
-// See sonichi/sutando#1243.
-function ownerLocalDateContext(now: Date = new Date()): string {
-	const tz = OWNER_TZ;
-	const today = now.toLocaleDateString('en-CA', { timeZone: tz }); // YYYY-MM-DD
-	const dayName = now.toLocaleDateString('en-US', { timeZone: tz, weekday: 'long' });
-	const timeStr = now.toLocaleTimeString('en-US', { timeZone: tz, hour: 'numeric', minute: '2-digit' });
-	const tomorrow = new Date(now.getTime() + 86_400_000).toLocaleDateString('en-CA', { timeZone: tz });
-	const yesterday = new Date(now.getTime() - 86_400_000).toLocaleDateString('en-CA', { timeZone: tz });
-	return `Owner-local time: ${dayName}, ${today}, ${timeStr} (${tz}). Tomorrow = ${tomorrow}. Yesterday = ${yesterday}. When the owner says "today", "tomorrow", "yesterday", "this week", etc., resolve against THESE owner-local dates — never against UTC or server-local time. Pass absolute YYYY-MM-DD values to tools (not relative phrases).`;
-}
 
 // Model configuration — text/STT model still env-driven; the native-audio
 // model + googleSearch grounding are per-user config: data, not code, so they
@@ -205,24 +167,6 @@ function normalizePhone(num: string): string {
 	return digits.length === 10 ? '1' + digits : digits;
 }
 
-/** Read recent conversation context, relabeled to avoid identity confusion.
- *  Reads the text conversation.log directly — it is the primary truth for
- *  per-turn content. The sqlite mirror is a best-effort parallel write and
- *  may lag, so it must not be authoritative here. */
-function getSafeContext(lines = 5): string {
-	try {
-		const logPath = join(WORKSPACE_DIR, 'logs', 'conversation.log');
-		if (!existsSync(logPath)) return '';
-		const entries = readFileSync(logPath, 'utf-8').trim().split('\n').slice(-lines);
-		return entries.map(line => {
-			const [, role, text] = line.split('|', 3);
-			if (!role || !text) return '';
-			if (role === 'user') return `Owner said: ${text}`;
-			if (role === 'assistant') return `You (Sutando) replied: ${text}`;
-			return '';
-		}).filter(Boolean).join('\n');
-	} catch { return ''; }
-}
 
 
 const VERIFIED_CALLERS_RAW = (process.env.VERIFIED_CALLERS ?? '').split(',').map(s => s.trim()).filter(Boolean);
@@ -995,7 +939,7 @@ async function createCallSession(params: {
 					sessionAny.handleClientConnected();
 					// Fallback: unmute after max(10s, 2s per turn) in case turn detection fails
 					const fallbackMs = Math.max(10000, turnCountBeforeDisconnect * 2000);
-					const fallbackTimer = setTimeout(() => {
+					setTimeout(() => {
 						if (isReplaying) {
 							console.log(`${ts()} [Phone] replay suppression fallback (${fallbackMs}ms)`);
 							isReplaying = false;

--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -12,10 +12,10 @@
  *   ANTHROPIC_BASE_URL=http://localhost:7846 claude ...  # route Claude through proxy
  */
 
-import { createServer, request as httpRequest, type RequestOptions } from 'node:http';
+import { createServer, type RequestOptions } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import { execFileSync } from 'node:child_process';
-import { writeFileSync, readFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { createHash } from 'node:crypto';
 import { statusPath } from '../../../src/workspace_default.js';

--- a/skills/screen-companion/scripts/activate.ts
+++ b/skills/screen-companion/scripts/activate.ts
@@ -19,7 +19,7 @@
  * same pattern as src/oc-profile-catalog.ts).
  */
 
-import { discoverConfigs, loadConfig, parseYaml, validateConfig, renderGoal, type ScreenCompanionConfig } from './load-config.js';
+import { discoverConfigs, loadConfig, parseYaml, validateConfig, type ScreenCompanionConfig } from './load-config.js';
 
 function cliArg(name: string): string | undefined {
 	const i = process.argv.indexOf(`--${name}`);

--- a/skills/zoom/tools.ts
+++ b/skills/zoom/tools.ts
@@ -43,7 +43,7 @@ export const summonTool: ToolDefinition = {
 	// readiness/Join-retry loop + share script 15s + mute/cleanup 10s + dial-in
 	// host wait 20s). 120s gives meaningful margin without being absurd.
 	timeout: 120_000,
-	async execute(args, ctx) {
+	async execute(args, _ctx) {
 		const { meetingId, passcode, shareScreen = getShareScreen(), dialIn = false } = args as { meetingId?: string; passcode?: string; shareScreen?: boolean; dialIn?: boolean };
 		const pwd = passcode ?? getZoomPasscode();
 		const cleanId = (meetingId ?? getZoomPMI()).replace(/\D/g, '');

--- a/tests/get-core-status-tool.test.ts
+++ b/tests/get-core-status-tool.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, before, after, beforeEach } from 'node:test';
+import { describe, it, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdirSync } from 'node:fs';
+import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { setupTempWorkspace } from './_helpers/temp-workspace.js';
 

--- a/tests/memory-bootstrap.test.ts
+++ b/tests/memory-bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, writeFileSync, existsSync, readFileSync, mkdtempSync, rmSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';

--- a/tests/observability/realtime.test.ts
+++ b/tests/observability/realtime.test.ts
@@ -152,7 +152,7 @@ describe('client → collector POST', () => {
 	beforeEach(() => {
 		calls = [];
 		process.env.SUTANDO_OBS_ENDPOINT = 'http://localhost:4000';
-		// @ts-expect-error test stub
+		// @ts-expect-error - minimal fetch stub, not the full DOM fetch signature
 		globalThis.fetch = (url: string, init?: { body?: string }) => {
 			calls.push({ url, body: init?.body ? JSON.parse(init.body) : undefined });
 			return Promise.resolve({ ok: true });

--- a/tests/session-boundary.test.ts
+++ b/tests/session-boundary.test.ts
@@ -1,8 +1,5 @@
-import { describe, it, beforeEach, afterEach } from 'node:test';
+import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 
 /**
  * Tests for the session-boundary trimming logic added in PR #257
@@ -17,8 +14,6 @@ import { join } from 'node:path';
  * tests avoid the same way (see twilio-signature.test.ts,
  * end-session-gate.test.ts).
  */
-
-type ReadFile = (path: string) => string;
 
 function parseRecentConversation(content: string, count: number): string {
 	const allLines = content.trim().split('\n');

--- a/tests/sutando-config-shell.test.ts
+++ b/tests/sutando-config-shell.test.ts
@@ -31,22 +31,6 @@ function runShell(subcmd: string, ws: string): string {
 	return proc.stdout;
 }
 
-function runPyResolve(ws: string): string {
-	const proc = spawnSync(
-		'python3',
-		['-c', 'import sys; sys.path.insert(0, ".."); from importlib import import_module; m = import_module("src.sutando_config"); print(m.resolve_workspace(), end="")'],
-		{
-			cwd: REPO_ROOT,
-			env: { ...process.env, SUTANDO_WORKSPACE: ws, SUTANDO_TEST_MODE: '1' },
-			encoding: 'utf-8',
-		},
-	);
-	if (proc.status !== 0) {
-		throw new Error(`py resolve_workspace exit ${proc.status}: stderr=${proc.stderr}`);
-	}
-	return proc.stdout;
-}
-
 let scratch: string;
 
 beforeEach(() => {

--- a/tests/sutando-config.prod-path.test.ts
+++ b/tests/sutando-config.prod-path.test.ts
@@ -15,7 +15,7 @@
  */
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 

--- a/tests/task-bridge-confine.test.ts
+++ b/tests/task-bridge-confine.test.ts
@@ -17,7 +17,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 
 const SRC_PATH = resolve('src/task-bridge.ts');
 const SRC = readFileSync(SRC_PATH, 'utf8');

--- a/tests/task-bridge-isvoice.test.ts
+++ b/tests/task-bridge-isvoice.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, before, after, afterEach } from 'node:test';
+import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { writeFileSync, existsSync, unlinkSync, mkdirSync, rmSync } from 'node:fs';
+import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { resolveWorkspace } from '../src/workspace_default.js';
 import { _isVoiceTask } from '../src/task-bridge.js';

--- a/tests/task-bridge-skip-markers.test.ts
+++ b/tests/task-bridge-skip-markers.test.ts
@@ -90,7 +90,6 @@ describe('task-bridge.ts — [no-send]/[REPLIED] skip-marker handling (#1381)', 
 		// other result files that could have marker-like content. Without this guard
 		// a proactive-result file beginning with [no-send] would be swallowed here
 		// instead of reaching discord-bridge's poll_proactive delivery path.
-		const afterSkip = afterBlock('has skip marker');
 		// Look backward from the log line to find the enclosing if-condition.
 		const beforeSkip = SRC.slice(0, SRC.indexOf('has skip marker'));
 		const lastIfBeforeSkip = beforeSkip.lastIndexOf('if (');

--- a/tests/task-bridge-stop-at-task-delimiter.test.ts
+++ b/tests/task-bridge-stop-at-task-delimiter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from 'node:test';
+import { describe, it, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tests/tmux-status.test.ts
+++ b/tests/tmux-status.test.ts
@@ -151,14 +151,14 @@ describe('parseTmuxPane', () => {
 	});
 
 	it('undefined input → idle (defensive)', () => {
-		// @ts-expect-error
+		// @ts-expect-error - deliberately passing undefined to test the defensive guard
 		const r = parseTmuxPane(undefined);
 		assert.equal(r.state, 'idle');
 		assert.equal(r.label, '');
 	});
 
 	it('non-string input → idle (defensive)', () => {
-		// @ts-expect-error
+		// @ts-expect-error - deliberately passing a non-string to test the defensive guard
 		const r = parseTmuxPane(42);
 		assert.equal(r.state, 'idle');
 		assert.equal(r.label, '');


### PR DESCRIPTION
Stacked on #2184 — review that one first. This PR shows its commits until it merges; the diff unique to this branch is the 16 files below.

Widens the ESLint glob from `src/` to all first-party TypeScript: `skills/` (13 files) and `tests/` (75).

The rule set is **shared, not duplicated**. The idioms the relaxations exist for — fail-open `catch {}`, deliberate double-escaping, optional-dependency `@ts-ignore` — appear in all three trees, so no per-tree overrides were needed. The `eslint.yml` workflow from #2184 already covers this: it runs `npm run lint`, which follows whatever the config globs.

## 35 errors fixed — all dead code

**23 unused named imports**, mostly test helpers pulled in and never used (`before`, `beforeEach`, `afterEach`, assorted fs/path helpers).

**Three stale duplicate functions** in `skills/phone-conversation/scripts/conversation-server.ts` — `personalPath`, `ownerLocalDateContext`, `getSafeContext`. The live versions live in `phone-agent-config.ts` (and `src/util_paths.ts` for `personalPath`); these copies were left behind when the functions were extracted.

They had **already drifted**:

```
dead copy:  ownerLocalDateContext(now)          // conversation-server.ts
real one:   ownerLocalDateContext(tz, now)      // phone-agent-config.ts
```

The dead copy silently lost the `tz` parameter — precisely the divergence stale duplicates cause. Nothing called it, so nothing broke, but it was a trap for anyone reading that file for the timezone logic.

**Smaller items:**
- Dead `TASK_TIMEOUT_MS` constant; dead `runPyResolve` test helper
- `const fallbackTimer = setTimeout(...)` → `setTimeout(...)`. The binding was never read and the callback self-guards on `isReplaying`, so this is behaviour-identical — the timer is still scheduled. (Checked specifically that it was not a missing `clearTimeout`.)
- Removing `personalPath` left its `hostname` import unused — dropped too
- One unused handler arg → `_ctx`, matching the config `^_` convention
- Three bare `@ts-expect-error` directives given the justification `ban-ts-comment` requires

## Verification

- `npm run lint` → **0 errors** (117 warnings, all pre-existing `no-explicit-any`, non-blocking by design)
- `npm run typecheck` + `npm run typecheck:skills` → pass
- 619/619 TS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)