### PR TITLE
chore(lint): plain JavaScript (.mjs / .js)

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,6 +1,8 @@
 name: eslint
 
-# CI lint: the general-purpose ESLint baseline over src/ TypeScript.
+# CI lint: the general-purpose ESLint baseline over all first-party sources —
+# TypeScript (src/, skills/, tests/) and plain JavaScript (.js/.mjs build
+# scripts + the Electron overlay app, which tsc never sees).
 #
 # Distinct from the five lint-*.yml workflows, which are targeted greps for
 # architectural rules (workspace resolution, host labels, home-path literals).
@@ -24,7 +26,7 @@ on:
 
 jobs:
   eslint:
-    name: eslint over src/
+    name: eslint over first-party TS + JS
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@
 // double-escaping, optional-dependency @ts-ignore) appear in all three trees.
 
 import js from '@eslint/js';
+import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
@@ -74,5 +75,47 @@ export default tseslint.config(
         { 'ts-ignore': 'allow-with-description', minimumDescriptionLength: 10 },
       ],
     },
+  },
+
+  // --- Plain JavaScript ------------------------------------------------------
+  // Build/utility scripts and the Electron overlay app. These are NOT compiled
+  // by tsc (the tsconfigs are .ts-only), so before this block they had no static
+  // checking of any kind — not even the unused-import and undefined-variable
+  // checks the TypeScript tree gets for free.
+  //
+  // typescript-eslint is deliberately not applied here: these are real .js/.mjs
+  // files, so the base ESLint rules are the correct tool. That means the base
+  // `no-unused-vars` (not the @typescript-eslint/ variant) and, crucially,
+  // `no-undef` — which is off for TS (tsc owns it) but is the main value here.
+  {
+    files: ['**/*.mjs', '**/*.js'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'module',
+      globals: { ...globals.node },
+    },
+    rules: {
+      'no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      'no-useless-escape': 'off',
+    },
+  },
+
+  // Electron main process + preload are CommonJS (`require`, `module.exports`),
+  // not ESM — parsing them as modules makes `require` an undefined global.
+  {
+    files: ['skills/overlay-apps/app/main.js', 'skills/overlay-apps/app/preload.js', 'skills/overlay-apps/app/control-server.js'],
+    languageOptions: { sourceType: 'commonjs', globals: { ...globals.node } },
+  },
+
+  // Renderer-process scripts run in a browser context: `document`, `window`,
+  // and the `overlay` bridge that preload.js exposes via contextBridge.
+  {
+    files: ['skills/overlay-apps/app/stats-renderer.js', 'skills/overlay-apps/app/stats.js'],
+    languageOptions: { sourceType: 'script', globals: { ...globals.browser } },
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/node": "^22.0.0",
         "esbuild": "^0.28.1",
         "eslint": "^10.7.0",
+        "globals": "^17.7.0",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.64.0"
@@ -2235,6 +2236,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/google-auth-library": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sutando",
   "version": "0.1.0",
-  "description": "Sutando \u2014 a personal AI agent with a voice interface and selectable Claude Code or Codex CLI core.",
+  "description": "Sutando — a personal AI agent with a voice interface and selectable Claude Code or Codex CLI core.",
   "type": "module",
   "scripts": {
     "start": "tsx src/voice-agent.ts",
@@ -34,6 +34,7 @@
     "@types/node": "^22.0.0",
     "esbuild": "^0.28.1",
     "eslint": "^10.7.0",
+    "globals": "^17.7.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.64.0"


### PR DESCRIPTION
Stacked on #2185 (which stacks on #2184) — review those first. This PR shows their commits until they merge; the diff unique to this branch is `eslint.config.mjs` + the `globals` devDependency.

## The gap

The 11 first-party `.js`/`.mjs` files had **no static checking of any kind**. They are not compiled by `tsc` — both tsconfigs are `.ts`-only — so unused imports and undefined variables in them were invisible to every existing gate:

```
scripts/build-bundle.mjs, scripts/poc-voice-metrics-reset.js
src/browser.mjs, src/agent/claude/cli/build-core-settings.mjs
src/observability/claude/hooks/build-hook-settings.mjs
skills/overlay-apps/app/{main,preload,control-server,stats,stats-renderer}.js
eslint.config.mjs
```

## Why base ESLint, not typescript-eslint

typescript-eslint is deliberately **not** applied here — these are real JavaScript, so the base rules are the right tool. That brings in **`no-undef`**, which is off for TypeScript (tsc owns it) and is the main value here: a typo'd global in a build script or an Electron renderer previously failed only at runtime.

## Three runtimes, three sets of globals

| Files | Runtime | Why |
|---|---|---|
| default | Node ESM | build scripts, hook generators |
| `main.js`, `preload.js`, `control-server.js` | Electron main, **CommonJS** | parsing as ESM makes `require` an undefined global |
| `stats.js`, `stats-renderer.js` | Electron renderer, **browser** | `document`, `window`, the contextBridge-exposed `overlay` |

Adds `globals` as a devDependency to supply those sets.

## Result: 0 findings — and why that is not vacuous

All 11 files were already clean. The value is the **guard**, not a cleanup.

A zero-finding result can also mean the config silently matched nothing, so I verified it is actually effective with a negative test — a deliberate unused variable plus an undefined call in each block:

```
ESM/node block:   'unusedVar' is assigned a value but never used   no-unused-vars
                  'undefinedFunctionCall' is not defined            no-undef
renderer block:   correctly scoped globals per filename
```

Both caught. The files are clean because they are clean, not because the linter is asleep.

## Verification

- `npm run lint` → **0 errors**, 11 JS/MJS files confirmed in the lint target set
- `npm run typecheck` → pass
- 619/619 TS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review follow-ups

**"Lint the .js/.mjs files this PR targets" / "actual TypeScript-only lint scope"** — the JS files *are* in the lint target set on this branch. `npx eslint . --format json` reports 161 files linted, of which these 11 are `.js`/`.mjs`:

```
eslint.config.mjs
scripts/build-bundle.mjs
scripts/poc-voice-metrics-reset.js
skills/overlay-apps/app/control-server.js
skills/overlay-apps/app/main.js
skills/overlay-apps/app/preload.js
skills/overlay-apps/app/stats-renderer.js
skills/overlay-apps/app/stats.js
src/agent/claude/cli/build-core-settings.mjs
src/browser.mjs
src/observability/claude/hooks/build-hook-settings.mjs
```

The kernel of truth in the comment: the **CI workflow's own name and header** still said "eslint over src/ TypeScript" — stale wording from the #2184 baseline that underclaimed the real scope. Fixed here (`eslint.yml` retitled to "eslint over first-party TS + JS"; not a required-checks context, so the rename is safe).

## Before/after: forced JS defect

Same deliberate defect appended to `scripts/build-bundle.mjs`:

```js
const unusedVar = 1;
undefinedFunctionCall();
```

**Before (on the #2185 config, no JS block):** zero output, exit 0 — even a full `eslint .` passes with the defect present. The file simply isn't in any lint scope.

**After (this branch):** exit 1:

```
/…/scripts/build-bundle.mjs
  84:7  error  'unusedVar' is assigned a value but never used. Allowed unused vars must match /^_/u  no-unused-vars
  85:1  error  'undefinedFunctionCall' is not defined                                                no-undef

✖ 2 problems (2 errors, 0 warnings)
```
