### PR TITLE
chore(lint): add ruff baseline for Python with CI gate

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,6 +1,8 @@
 name: eslint
 
-# CI lint: the general-purpose ESLint baseline over src/ TypeScript.
+# CI lint: the general-purpose ESLint baseline over all first-party sources —
+# TypeScript (src/, skills/, tests/) and plain JavaScript (.js/.mjs build
+# scripts + the Electron overlay app, which tsc never sees).
 #
 # Distinct from the five lint-*.yml workflows, which are targeted greps for
 # architectural rules (workspace resolution, host labels, home-path literals).
@@ -24,7 +26,7 @@ on:
 
 jobs:
   eslint:
-    name: eslint over src/
+    name: eslint over first-party TS + JS
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,41 @@
+name: ruff
+
+# CI lint: the Python baseline, mirroring what eslint.yml does for TypeScript.
+#
+# Python is the largest untyped surface in the repo — 341 files across src/,
+# skills/, tests/, scripts/, hooks/ and packages/ — and before this it had no
+# linter at all. There is no `tsc` equivalent here, so a syntax error, a broken
+# .format() call, or an undefined name in a rarely-exercised branch could reach
+# main with nothing to catch it.
+#
+# Rule selection and every deliberate exclusion are documented in ruff.toml.
+#
+# Ruff is PINNED. Linters gain rules between releases, so an unpinned install
+# turns an unrelated PR red when a new check ships. Bump deliberately.
+
+on:
+  pull_request:
+    branches: [main, staging-interaction-planes]
+  push:
+    branches: [main, staging-interaction-planes]
+
+jobs:
+  ruff:
+    name: ruff over Python sources
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install ruff (pinned)
+        run: python3 -m pip install 'ruff==0.15.22'
+
+      - name: Run ruff
+        run: ruff check --output-format=github .

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@
 // double-escaping, optional-dependency @ts-ignore) appear in all three trees.
 
 import js from '@eslint/js';
+import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
@@ -74,5 +75,47 @@ export default tseslint.config(
         { 'ts-ignore': 'allow-with-description', minimumDescriptionLength: 10 },
       ],
     },
+  },
+
+  // --- Plain JavaScript ------------------------------------------------------
+  // Build/utility scripts and the Electron overlay app. These are NOT compiled
+  // by tsc (the tsconfigs are .ts-only), so before this block they had no static
+  // checking of any kind — not even the unused-import and undefined-variable
+  // checks the TypeScript tree gets for free.
+  //
+  // typescript-eslint is deliberately not applied here: these are real .js/.mjs
+  // files, so the base ESLint rules are the correct tool. That means the base
+  // `no-unused-vars` (not the @typescript-eslint/ variant) and, crucially,
+  // `no-undef` — which is off for TS (tsc owns it) but is the main value here.
+  {
+    files: ['**/*.mjs', '**/*.js'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'module',
+      globals: { ...globals.node },
+    },
+    rules: {
+      'no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
+      ],
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      'no-useless-escape': 'off',
+    },
+  },
+
+  // Electron main process + preload are CommonJS (`require`, `module.exports`),
+  // not ESM — parsing them as modules makes `require` an undefined global.
+  {
+    files: ['skills/overlay-apps/app/main.js', 'skills/overlay-apps/app/preload.js', 'skills/overlay-apps/app/control-server.js'],
+    languageOptions: { sourceType: 'commonjs', globals: { ...globals.node } },
+  },
+
+  // Renderer-process scripts run in a browser context: `document`, `window`,
+  // and the `overlay` bridge that preload.js exposes via contextBridge.
+  {
+    files: ['skills/overlay-apps/app/stats-renderer.js', 'skills/overlay-apps/app/stats.js'],
+    languageOptions: { sourceType: 'script', globals: { ...globals.browser } },
   },
 );

--- a/hooks/context-source-guard.py
+++ b/hooks/context-source-guard.py
@@ -26,7 +26,12 @@ Deploy: copy to ~/.claude/hooks/ and register under PreToolUse for BOTH the "Bas
 and "Read" matchers in ~/.claude/settings.json. See hooks/README.md. Config paths are
 env-overridable (SUTANDO_DISCORD_ACCESS_FILE / SUTANDO_DISCORD_ENV_FILE) for testing.
 """
-import sys, json, os, re, time, urllib.request
+import sys
+import json
+import os
+import re
+import time
+import urllib.request
 
 # Resolve the Claude config dir via $CLAUDE_CONFIG_DIR (set by Claude Code),
 # matching read_discord_channel.py/discord-bridge's claude_home_path — NOT a

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/node": "^22.0.0",
         "esbuild": "^0.28.1",
         "eslint": "^10.7.0",
+        "globals": "^17.7.0",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.64.0"
@@ -2235,6 +2236,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/google-auth-library": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sutando",
   "version": "0.1.0",
-  "description": "Sutando \u2014 a personal AI agent with a voice interface and selectable Claude Code or Codex CLI core.",
+  "description": "Sutando — a personal AI agent with a voice interface and selectable Claude Code or Codex CLI core.",
   "type": "module",
   "scripts": {
     "start": "tsx src/voice-agent.ts",
@@ -34,6 +34,7 @@
     "@types/node": "^22.0.0",
     "esbuild": "^0.28.1",
     "eslint": "^10.7.0",
+    "globals": "^17.7.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.64.0"

--- a/packages/ag2-sparrow/tests/test_ack_retry.py
+++ b/packages/ag2-sparrow/tests/test_ack_retry.py
@@ -5,7 +5,12 @@ When the broker lacks the endpoint it 404s; the worker must back off — but NOT
 permanently, or a broker that later *deploys* the endpoint is never picked up
 until the worker restarts. This pins the time-gated retry (self-heal on deploy).
 """
-import os, io, importlib, sys, pathlib, tempfile
+import os
+import io
+import importlib
+import sys
+import pathlib
+import tempfile
 import urllib.error
 
 

--- a/packages/ag2-sparrow/tests/test_gateway_status.py
+++ b/packages/ag2-sparrow/tests/test_gateway_status.py
@@ -2,7 +2,12 @@
 Covers the shape a local supervisor reads and the last_ok_ts preservation that
 lets it show "last connected N s ago" while reconnecting.
 """
-import json, os, tempfile, importlib, sys, pathlib
+import json
+import os
+import tempfile
+import importlib
+import sys
+import pathlib
 
 def _load(tmp):
     os.environ["AGENT_CONNECT_STATE_DIR"] = str(tmp)

--- a/packages/ag2-sparrow/tests/test_inflight_recovery.py
+++ b/packages/ag2-sparrow/tests/test_inflight_recovery.py
@@ -7,7 +7,12 @@ the set must survive so the result drain re-acks it — otherwise the reply is l
 must be atomic (no partial JSON) and the read must fail open (a corrupt ledger
 starts empty, never crashes the loop).
 """
-import os, json, importlib, sys, pathlib, tempfile
+import os
+import json
+import importlib
+import sys
+import pathlib
+import tempfile
 
 
 def _load(base):

--- a/packages/ag2-sparrow/tests/test_write_task_atomic.py
+++ b/packages/ag2-sparrow/tests/test_write_task_atomic.py
@@ -5,7 +5,11 @@ partial file, and must be idempotent under gateway redelivery (the relay replays
 its un-acked pool on reconnect — the 2026-06-30/07-01 500-task floods). These are
 the two properties the at-least-once broker contract leans on at the worker edge.
 """
-import os, importlib, sys, pathlib, tempfile
+import os
+import importlib
+import sys
+import pathlib
+import tempfile
 
 
 def _load(base):

--- a/packages/ag2-sparrow/tools/test_no_drift.py
+++ b/packages/ag2-sparrow/tools/test_no_drift.py
@@ -1,5 +1,6 @@
 """CI guard: the packaged modules must match sonichi/sutando src/ verbatim."""
-import subprocess, sys
+import subprocess
+import sys
 from pathlib import Path
 
 def test_package_in_sync_with_src():

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,106 @@
+# Ruff baseline for the Python sources (341 files across src/, skills/, tests/,
+# scripts/, hooks/, packages/).
+#
+# Same philosophy as eslint.config.mjs: enable the rules that catch real
+# defects, and turn off the ones that only flag this codebase's deliberate
+# house style. A linter that reports 346 findings on day one gates nothing,
+# because nobody can land it.
+#
+# Formatting is explicitly out of scope — `ruff format` is not wired up, for
+# the same reason Prettier is not: it would rewrite every file and collide with
+# the repo's single-concern-per-PR rule.
+
+# Python 3.9, NOT the interpreter this repo is developed on. CONTRIBUTING.md
+# requires 3.9+ compatibility ("avoid `str | None` — use `Optional[str]`") and
+# tests/python39-union-annotations.test.py enforces it, because 3.9 is still the
+# stock macOS interpreter. Declaring py310 here would tell ruff that 3.10-only
+# syntax is fine and silently undercut that policy.
+target-version = "py39"
+
+exclude = [
+    "workspace",       # per-user runtime state, not source
+    "node_modules",
+    ".git",
+]
+
+[lint]
+# E4 = imports, E7 = statement style, E9 = syntax/IO errors, F = pyflakes.
+# F is the real prize: undefined names, unused imports, broken .format() calls.
+select = ["E4", "E7", "E9", "F"]
+
+ignore = [
+    # Module-level import not at top of file. This is STRUCTURAL here, not
+    # sloppiness: scripts insert src/ into sys.path before importing from it
+    #     _SRC = os.path.join(os.path.dirname(__file__), "..", "..", "src")
+    #     sys.path.insert(0, _SRC)
+    #     from vault_intercept import get_vault_key
+    # and others gate on an env var before importing an optional dependency.
+    # The import CANNOT move above the code that makes it resolvable.
+    "E402",
+
+    # Multiple statements on one line (colon / semicolon). 81 hits, and the
+    # dense one-liner is a deliberate idiom throughout — `if not line: continue`
+    # in parse loops, `run(...); print("PASS ...")` in the standalone tests.
+    # Splitting them is churn with no defect caught.
+    "E701",
+    "E702",
+
+    # Ambiguous variable name (`l`, `I`, `O`). 47 hits, all in comprehensions
+    # and short loops where the scope is two lines. Renaming them is a
+    # whole-tree diff that changes no behaviour.
+    "E741",
+
+    # Lambda assignment. One hit, and the lambda is clearer than a def there.
+    "E731",
+
+    # ── Deferred, NOT dismissed ──────────────────────────────────────────────
+    # F401 unused-import (87 hits) and F841 unused-variable (17).
+    #
+    # These are real findings and should be cleaned up — but NOT by autofix, and
+    # not in the same PR that introduces the linter. `ruff check --fix` on F401
+    # breaks this codebase: several modules import a name purely to RE-EXPORT it
+    # for tests that reach in via `module.NAME`. Ruff sees no local use and
+    # deletes it. Confirmed breakage on the first attempt:
+    #
+    #   src/discord-bridge.py
+    #     - from message_chunking import chunk_message, _is_fence_open_line
+    #     + from message_chunking import chunk_message
+    #   → tests/discord-chunker.test.py:
+    #     AttributeError: module 'dbridge' has no attribute '_is_fence_open_line'
+    #
+    # The import line's own comment says "_is_fence_open_line re-exported for
+    # existing tests" — ruff removed it anyway. Same shape for
+    # SEND_ALLOWED_PREFIXES / SEND_ALLOWED_ROOTS (src/discord-bridge.py, read by
+    # tests/remote-gateway-file-attach.test.py) and chunk_message in
+    # src/dm-result.py.
+    #
+    # Clearing these needs a per-site judgement — delete the genuinely dead ones,
+    # mark the deliberate re-exports `# noqa: F401` (or list them in __all__).
+    # That is a focused follow-up, not a side effect of turning on a linter.
+    "F401",
+    "F841",
+]
+
+[lint.per-file-ignores]
+# ── Deferred like F401/F841 above, but per-file: the coverage gate ───────────
+# These four files carry F541/E401 hits on lines in legacy branches with no
+# test coverage. The fixes are byte-identical mechanical edits, but the
+# diff-coverage gate (95% on changed lines) cannot distinguish an edited-in-
+# place line from new code — fixing them here reds the gate over unrelated
+# legacy coverage debt. Defer until those paths gain tests (or fix alongside
+# a PR that covers them); everything already covered was fixed in this PR.
+"src/discord-bridge.py" = ["F541", "E401"]
+"src/github-webhook.py" = ["F541"]
+"src/health-check.py" = ["F541"]
+"src/scan-call-logs.py" = ["E401"]
+
+# F821 false positive. `judge_pair(client: anthropic.Anthropic, ...)` annotates
+# a lazily-imported optional dependency — `anthropic` is imported inside run(),
+# not at module level, on purpose: importing it at the top makes the script
+# raise ModuleNotFoundError on hosts without the package even when the
+# SUTANDO_OBSIDIAN_MIRROR gate is off and it should be a clean no-op.
+#
+# `from __future__ import annotations` (line 33) defers the annotation to a
+# string, so this is correct and the module imports fine — verified. Ruff still
+# flags the name as undefined at module scope.
+"skills/obsidian-vault/scripts/dream.py" = ["F821"]

--- a/skills/call-diagnostics/scripts/diagnose.py
+++ b/skills/call-diagnostics/scripts/diagnose.py
@@ -863,9 +863,9 @@ def generate_tracker_html(calls, output_path, source_type="phone"):
 
     last_cd = call_data[-1] if call_data else {}
     parts = [
-        f'<!DOCTYPE html><html><head><meta charset="utf-8"><title>TRACKER_TITLE_PLACEHOLDER</title>',
+        '<!DOCTYPE html><html><head><meta charset="utf-8"><title>TRACKER_TITLE_PLACEHOLDER</title>',
         f'<style>{_CSS}</style></head><body>',
-        f'<h1>TRACKER_TITLE_PLACEHOLDER</h1>',
+        '<h1>TRACKER_TITLE_PLACEHOLDER</h1>',
         f'<div class="summary"><strong>{len(calls)} calls total</strong> | Showing last 5 | '
         f'Issues in view: {len(table_cats)} | Last call: {last_cd.get("date","")} {last_cd.get("time","")}</div>',
     ]

--- a/skills/image-generation/scripts/generate.py
+++ b/skills/image-generation/scripts/generate.py
@@ -90,7 +90,7 @@ def generate_image(client, args):
     model = args.model or os.environ.get("IMAGE_MODEL", "gemini-3.1-flash-image-preview")
     print(f"  Model: {model}", file=sys.stderr)
     print(f"  Prompt: {args.prompt[:100]}{'...' if len(args.prompt) > 100 else ''}", file=sys.stderr)
-    print(f"  Generating image...", file=sys.stderr)
+    print("  Generating image...", file=sys.stderr)
 
     try:
         response = client.models.generate_content(
@@ -127,7 +127,7 @@ def generate_image(client, args):
                 text_response += part.text
 
     if not image_saved:
-        print(f"Error: No image in response.", file=sys.stderr)
+        print("Error: No image in response.", file=sys.stderr)
         if text_response:
             print(f"  Model said: {text_response}", file=sys.stderr)
         sys.exit(1)
@@ -178,7 +178,7 @@ def generate_video(client, args):
         img.save(buf, format="PNG")
         image = types.Image(image_bytes=buf.getvalue(), mime_type="image/png")
 
-    print(f"  Generating video (this may take 1-3 minutes)...", file=sys.stderr)
+    print("  Generating video (this may take 1-3 minutes)...", file=sys.stderr)
 
     try:
         if image:

--- a/skills/macos-tools/scripts/contacts.py
+++ b/skills/macos-tools/scripts/contacts.py
@@ -150,9 +150,9 @@ def main():
         lines.append('set p to item 1 of results')
         if phone:
             lines.append('-- Remove existing phones and add new one')
-            lines.append(f'repeat while (count of phones of p) > 0')
-            lines.append(f'    delete (item 1 of phones of p)')
-            lines.append(f'end repeat')
+            lines.append('repeat while (count of phones of p) > 0')
+            lines.append('    delete (item 1 of phones of p)')
+            lines.append('end repeat')
             lines.append(f'make new phone at end of phones of p with properties {{label:"mobile", value:"{phone}"}}')
         if email:
             lines.append('repeat while (count of emails of p) > 0')

--- a/skills/macos-tools/scripts/email-sender.py
+++ b/skills/macos-tools/scripts/email-sender.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Send email via macOS Mail.app. Usage: python3 email-sender.py "to" "subject" "body" [--draft] [--cc "cc"]"""
-import subprocess, sys
+import subprocess
+import sys
 
 def escape(s): return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
 

--- a/skills/make-viral-video/scripts/render.py
+++ b/skills/make-viral-video/scripts/render.py
@@ -469,12 +469,12 @@ def kenburns_clip(frame_path: Path, duration_s: float, clip_idx: int, clip_path:
     even = clip_idx % 2 == 0
 
     if even:
-        zoom_expr = f"min(zoom+0.0008,1.08)"
+        zoom_expr = "min(zoom+0.0008,1.08)"
         x_expr = "iw/2-(iw/zoom/2)"
         y_expr = "ih/2-(ih/zoom/2)"
     else:
         # zoom-out: start zoomed at 1.08, end at 1.00
-        zoom_expr = f"if(eq(on,0),1.08,max(zoom-0.0008,1.00))"
+        zoom_expr = "if(eq(on,0),1.08,max(zoom-0.0008,1.00))"
         x_expr = "iw/2-(iw/zoom/2)"
         y_expr = "ih/2-(ih/zoom/2)"
 
@@ -738,7 +738,7 @@ def main():
     if narrated_words_total > 0 and narration_dur > 0:
         for i in range(narration_frame_count):
             durations[i] = narration_dur * (frame_words[i] / narrated_words_total)
-        print(f"[render] word-share durations: " +
+        print("[render] word-share durations: " +
               " ".join(f"{frame_words[i]}w→{durations[i]:.1f}s" for i in range(narration_frame_count)),
               file=sys.stderr)
     else:

--- a/skills/make-viral-video/scripts/verify_video.py
+++ b/skills/make-viral-video/scripts/verify_video.py
@@ -49,7 +49,7 @@ def verify(video_path: Path, expected_duration_s: float = None):
     try:
         probe = ffprobe(video_path)
     except subprocess.CalledProcessError as e:
-        return {"valid": False, "reason": f"ffprobe_failed", "stderr": e.stderr}
+        return {"valid": False, "reason": "ffprobe_failed", "stderr": e.stderr}
     except Exception as e:
         return {"valid": False, "reason": f"ffprobe_exception: {type(e).__name__}: {e}"}
 

--- a/skills/pointer-teacher-tracer/resolver.py
+++ b/skills/pointer-teacher-tracer/resolver.py
@@ -10,7 +10,15 @@ is the path the POC actually proved.
 Usage: resolver.py "where do I commit here?"
 Emits  /tmp/pointer-cmd.json : {"nx","ny","label","say","ts"}
 """
-import base64, json, os, re, subprocess, sys, time, urllib.request, urllib.error
+import base64
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.request
+import urllib.error
 
 CMD = "/tmp/pointer-cmd.json"
 MODEL = "gemini-3-flash-preview"

--- a/skills/regression-search/scripts/diagnose-call.py
+++ b/skills/regression-search/scripts/diagnose-call.py
@@ -358,7 +358,7 @@ def main() -> int:
 
     if metrics:
         print()
-        print(f"Metrics (data/conversation.sqlite):")
+        print("Metrics (data/conversation.sqlite):")
         print(f"  duration: {metrics.get('durationMs', 0) // 1000}s")
         print(f"  isOwner: {metrics.get('isOwner')}, isMeeting: {metrics.get('isMeeting')}")
         print(f"  tool calls: {metrics.get('toolCount', 0)}")

--- a/skills/schedule-crons/ensure-cron-room.py
+++ b/skills/schedule-crons/ensure-cron-room.py
@@ -30,7 +30,13 @@ Token: resolved from $GATEWAY_TOKEN / $REMOTE_TASK_TOKEN / $AG2_REMOTE_TOKEN
 Owner mxid: --owner, else $AG2_OWNER_MXID, else the token's own account is not
 discoverable here so we require one of those when creating.
 """
-import argparse, json, os, sys, time, urllib.request, urllib.error
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.request
+import urllib.error
 
 
 def resolve_token(repo):

--- a/skills/screen-record/scripts/subtitle.py
+++ b/skills/screen-record/scripts/subtitle.py
@@ -85,7 +85,7 @@ def main():
         print(json.dumps({"error": "Transcription failed — no speech detected or Whisper error"}))
         return
 
-    print(f"Burning subtitles...", file=sys.stderr)
+    print("Burning subtitles...", file=sys.stderr)
     out_path, size_mb = burn_subtitles(video_path, srt_path)
     if not out_path:
         print(json.dumps({"error": "ffmpeg subtitle burn failed"}))

--- a/skills/submit-use-case/scripts/submit_use_case.py
+++ b/skills/submit-use-case/scripts/submit_use_case.py
@@ -19,7 +19,14 @@ Usage:
 """
 from __future__ import annotations
 
-import argparse, datetime, json, re, shutil, subprocess, sys, time
+import argparse
+import datetime
+import json
+import re
+import shutil
+import subprocess
+import sys
+import time
 from pathlib import Path
 
 REPO = "sonichi/sutando"
@@ -306,7 +313,7 @@ def main():
         print("--- END PR FILE ---")
         _nm, _em = committer_identity()
         print(f"identity: would commit as {_nm or '(unset)'} <{_em or '(unset)'}> — your existing git config, never overridden. Ensure it's the identity you want on the CLA.")
-        print(f"DRY RUN — staged in memory only, no clone/issue/PR")
+        print("DRY RUN — staged in memory only, no clone/issue/PR")
         return
 
     # Idempotency probes (live only).

--- a/skills/x-twitter/x-post.py
+++ b/skills/x-twitter/x-post.py
@@ -92,7 +92,8 @@ def _bearer_get(url):
     read_tweet() when X_BEARER_TOKEN is set, so a bearer-only environment
     doesn't need `requests` / `requests_oauthlib`.
     """
-    import urllib.request, urllib.error
+    import urllib.request
+    import urllib.error
     req = urllib.request.Request(url, headers={"Authorization": f"Bearer {BEARER_TOKEN}"})
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -60,7 +60,9 @@ def validate_twilio_signature(handler, body: str) -> bool:
     auth_token = os.environ.get("TWILIO_AUTH_TOKEN", "")
     if not auth_token:
         return False
-    import hmac, hashlib, base64
+    import hmac
+    import hashlib
+    import base64
     from urllib.parse import parse_qs
 
     signature = handler.headers.get("X-Twilio-Signature", "")
@@ -826,7 +828,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             '<Say voice="alice">Hello, you\'ve reached Sutando. '
             "Please leave a message after the tone and I will get back to you.</Say>"
             '<Record maxLength="120" transcribe="true" '
-            f'transcribeCallback="/twilio/transcription"/>'
+            'transcribeCallback="/twilio/transcription"/>'
             '<Say voice="alice">Thank you. Goodbye.</Say>'
             "</Response>"
         )
@@ -1187,11 +1189,11 @@ if __name__ == "__main__":
     server = http.server.ThreadingHTTPServer((bind, PORT), Handler)
     local_ip = _resolve_local_ip()
     print(f"Sutando Agent API → http://{bind}:{PORT}")
-    print(f"  POST /task  — submit a task")
-    print(f"  GET  /status — health + capabilities")
-    print(f"  GET  /ping   — alive check")
+    print("  POST /task  — submit a task")
+    print("  GET  /status — health + capabilities")
+    print("  GET  /ping   — alive check")
     if bind == "127.0.0.1":
-        print(f"  (localhost only — set AGENT_API_BIND=0.0.0.0 for LAN access)")
+        print("  (localhost only — set AGENT_API_BIND=0.0.0.0 for LAN access)")
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -532,7 +532,7 @@ def render_dashboard() -> str:
         )
 
     # Quick links
-    cards.append(f"""<div class="card full">
+    cards.append("""<div class="card full">
 <h2>Quick Links</h2>
 <div class="quick-links">
 <a href="http://localhost:8080" target="_blank" rel="noopener noreferrer" onclick="openQuickLink(event,this)">Voice UI :8080</a>

--- a/src/read_discord_channel.py
+++ b/src/read_discord_channel.py
@@ -32,7 +32,12 @@ Usage:
 Exit codes: 0 = content printed; 2 = BLOCKED by contextNotFrom (nothing fetched);
 1 = operational error (no token / fetch failed). Fetches NOTHING on a block.
 """
-import argparse, json, os, sys, urllib.request, urllib.error
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -442,7 +442,7 @@ def main() -> int:
     # 6e. malformed media URLs never crash task intake (drop-in-safe)
     #     (re-review 2026-07-03: `.port` raises ValueError at ACCESS time)
     rtc._download_bytes = lambda url, headers, cap: b"X"
-    for bad in (f"https://127.0.0.1:bad/media/p", "https://hs.example:bad/_matrix/media/v3/download/hs/id",
+    for bad in ("https://127.0.0.1:bad/media/p", "https://hs.example:bad/_matrix/media/v3/download/hs/id",
                 "https://[broken/media/p"):
         try:
             out = rtc._maybe_fetch_media(f"[{rtc.MEDIA_MARKER_TAG}: {bad} name=x.bin]")

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -776,7 +776,7 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
                 attached_path = ap.replace("[File attached: ", "").rstrip("]")
                 if _notify_py.exists():
                     hints_lines.append(
-                        f'   Update notify message to: --message "Got your voice message, give me a moment."'
+                        '   Update notify message to: --message "Got your voice message, give me a moment."'
                     )
                 hints_lines.append(
                     f"{step}. TRANSCRIBE: python3 {_transcribe_py} '{attached_path}'"
@@ -1325,10 +1325,10 @@ def main():  # pragma: no cover
     if not ACCESS_FILE.exists():
         _TOFU_ENROLLMENT_CODE = secrets.token_hex(3)  # 6-char hex, 16M combinations
         print("", flush=True)
-        print(f"  *** TOFU enrollment required ***", flush=True)
+        print("  *** TOFU enrollment required ***", flush=True)
         print(f"  Enrollment code: {_TOFU_ENROLLMENT_CODE}", flush=True)
-        print(f"  Send this code in your first DM to register as owner.", flush=True)
-        print(f"  Anyone who sends this code first becomes owner — keep it private.", flush=True)
+        print("  Send this code in your first DM to register as owner.", flush=True)
+        print("  Anyone who sends this code first becomes owner — keep it private.", flush=True)
         print("", flush=True)
 
     threading.Thread(target=result_watcher, name="slack-result-watcher", daemon=True).start()

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -624,7 +624,7 @@ def poll_progress(pending_replies: dict) -> None:
 def main():  # pragma: no cover
     global _TOFU_ENROLLMENT_CODE
     _single_instance_acquire("telegram-bridge")
-    print(f"Telegram bridge started. Polling for messages...", flush=True)
+    print("Telegram bridge started. Polling for messages...", flush=True)
     # Restart-safety: sweep orphan `.sending` files before the poll
     # loop starts. See _recover_orphan_sending_files for rationale.
     _recover_orphan_sending_files()
@@ -639,10 +639,10 @@ def main():  # pragma: no cover
     if not ACCESS_FILE.exists():
         _TOFU_ENROLLMENT_CODE = secrets.token_hex(3)  # 6-char hex, 16M combinations
         print("", flush=True)
-        print(f"  *** TOFU enrollment required ***", flush=True)
+        print("  *** TOFU enrollment required ***", flush=True)
         print(f"  Enrollment code: {_TOFU_ENROLLMENT_CODE}", flush=True)
-        print(f"  Send this code in your first DM to register as owner.", flush=True)
-        print(f"  Anyone who sends this code first becomes owner — keep it private.", flush=True)
+        print("  Send this code in your first DM to register as owner.", flush=True)
+        print("  Anyone who sends this code first becomes owner — keep it private.", flush=True)
         print("", flush=True)
 
     offset = None

--- a/tests/agent-api-task-done-id-guard.test.py
+++ b/tests/agent-api-task-done-id-guard.test.py
@@ -93,4 +93,4 @@ if errors:
     print(f"\nFAILED: {errors} check(s) failed", file=sys.stderr)
     sys.exit(1)
 else:
-    print(f"\nPASSED: /task-done id guard present and correctly ordered")
+    print("\nPASSED: /task-done id guard present and correctly ordered")

--- a/tests/bridge-not-allowlisted-ack.test.py
+++ b/tests/bridge-not-allowlisted-ack.test.py
@@ -12,7 +12,13 @@ ack and writes no task.
 Run: python3 tests/bridge-not-allowlisted-ack.test.py   (exit 0 pass / 1 fail)
 """
 from __future__ import annotations
-import asyncio, importlib.util, json, os, sys, tempfile, types
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent

--- a/tests/ci-covers-every-python-test.test.py
+++ b/tests/ci-covers-every-python-test.test.py
@@ -75,7 +75,7 @@ class TestCICoversEveryPythonTest(unittest.TestCase):
             orphans, [],
             "these test files are never executed by CI — either move them to "
             "tests/<name>.test.py (auto-discovered) or name them explicitly in "
-            f"a workflow:\n  " + "\n  ".join(orphans),
+            "a workflow:\n  " + "\n  ".join(orphans),
         )
 
     def test_the_guard_can_actually_fail(self):

--- a/tests/context-resume.test.py
+++ b/tests/context-resume.test.py
@@ -142,7 +142,8 @@ class LatestTranscriptTests(unittest.TestCase):
             old.write_text(json.dumps(_user("old")) + "\n")
             new = d / "new.jsonl"
             new.write_text(json.dumps(_user("new")) + "\n")
-            import os, time
+            import os
+            import time
             past = time.time() - 1000
             os.utime(old, (past, past))
         return tmp

--- a/tests/context-source-guard.test.py
+++ b/tests/context-source-guard.test.py
@@ -8,7 +8,11 @@ contained: a fixture access.json + a temp workspace are pointed at via env
 so no live Discord is touched. All ids are FICTITIOUS. Run:
   python3 tests/context-source-guard.test.py
 """
-import json, os, subprocess, tempfile, sys
+import json
+import os
+import subprocess
+import tempfile
+import sys
 from pathlib import Path
 
 HOOK = str(Path(__file__).resolve().parent.parent / "hooks" / "context-source-guard.py")

--- a/tests/dedup-cross-channel.test.py
+++ b/tests/dedup-cross-channel.test.py
@@ -8,7 +8,8 @@ returns the holder's channel when it differs (→ bridge posts a pointer), else
 None (→ keep silent archive). All ids are FICTITIOUS. Run:
   python3 tests/dedup-cross-channel.test.py
 """
-import sys, unittest
+import sys
+import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))

--- a/tests/discord-bridge-access-tier.test.py
+++ b/tests/discord-bridge-access-tier.test.py
@@ -89,10 +89,10 @@ def main() -> int:
         return 1
 
     print("PASS: discord-bridge.py access_tier classification looks correct.")
-    print(f"  - defaults to 'other'")
-    print(f"  - global allowFrom → owner")
-    print(f"  - channel-level allowFrom union → team (fallback)")
-    print(f"  - ordering enforced (owner check before team check)")
+    print("  - defaults to 'other'")
+    print("  - global allowFrom → owner")
+    print("  - channel-level allowFrom union → team (fallback)")
+    print("  - ordering enforced (owner check before team check)")
     return 0
 
 

--- a/tests/discord-bridge-mod-judge-integration.test.py
+++ b/tests/discord-bridge-mod-judge-integration.test.py
@@ -177,7 +177,7 @@ def case_b_batch_retained_on_empty_verdicts():
     try:
         asyncio.run(bridge._flush_mod_buffer())
         if len(bridge._mod_buffer) != 1:
-            fails.append(f"b) batch should remain in buffer when codex returns []")
+            fails.append("b) batch should remain in buffer when codex returns []")
     finally:
         bridge._codex_judge_batch = orig
         bridge._mod_buffer.clear()

--- a/tests/discord-bridge-mod-server-config.test.py
+++ b/tests/discord-bridge-mod-server-config.test.py
@@ -173,9 +173,9 @@ def case_h_partial_config():
     if cfg["escalation_channel"] != 555:
         fails.append(f"h) partial config: escalation_channel should be 555, got {cfg['escalation_channel']}")
     if cfg["escalation_ccs"] != ():
-        fails.append(f"h) partial config: missing ccs should default to ()")
+        fails.append("h) partial config: missing ccs should default to ()")
     if cfg["redirect_channel_jobs"] is not None:
-        fails.append(f"h) partial config: missing redirect should default to None")
+        fails.append("h) partial config: missing redirect should default to None")
     return fails
 
 

--- a/tests/discord-bridge-reply-directive.test.py
+++ b/tests/discord-bridge-reply-directive.test.py
@@ -150,7 +150,7 @@ def case_a_directive_present_constructs_reference():
         return fails
     first = sent[0]
     if first["reference"] is None:
-        fails.append(f"a) first send should have reference set (got None)")
+        fails.append("a) first send should have reference set (got None)")
         return fails
     ref = first["reference"]
     if not hasattr(ref, "message_id") or str(ref.message_id) != parent_msg_id:

--- a/tests/discord-bridge-state-prefetch.test.py
+++ b/tests/discord-bridge-state-prefetch.test.py
@@ -327,10 +327,10 @@ def case_i_no_refs_returns_none():
         fails.append(f"i) no-refs body should return None, got {type(enriched).__name__}")
     enriched_empty = asyncio.run(bridge._prefetch_discord_state_refs(""))
     if enriched_empty is not None:
-        fails.append(f"i2) empty body should return None")
+        fails.append("i2) empty body should return None")
     enriched_none = asyncio.run(bridge._prefetch_discord_state_refs(None))
     if enriched_none is not None:
-        fails.append(f"i3) None body should return None")
+        fails.append("i3) None body should return None")
     return fails
 
 
@@ -347,7 +347,7 @@ def case_j_unexpected_exception_silent_fail():
         fails.append(f"j) unexpected exception leaked out of prefetch: {type(e).__name__}: {e}")
         return fails
     if enriched is not None:
-        fails.append(f"j) unexpected exception should return None, got enriched body")
+        fails.append("j) unexpected exception should return None, got enriched body")
     return fails
 
 

--- a/tests/health-check-emit-task.test.py
+++ b/tests/health-check-emit-task.test.py
@@ -320,7 +320,7 @@ def case_l_task_field_is_last() -> list[str]:
             if sentinel not in keys:
                 continue
             if "task" not in keys:
-                fails.append(f"l) task: key missing from task file")
+                fails.append("l) task: key missing from task file")
                 break
             if keys.index(sentinel) > keys.index("task"):
                 fails.append(

--- a/tests/health-check-memory-sync.test.py
+++ b/tests/health-check-memory-sync.test.py
@@ -50,7 +50,8 @@ def main() -> int:
     # branch routes the SAME behavior through the canonical Python resolver
     # (_resolved_vault → sutando_config.resolve_vault). These tests now assert
     # the resolver-backed behavior, which is the point of the extraction.
-    import os, time as _time
+    import os
+    import time as _time
 
     def _vault(enabled=None, remote_url="", explicit_disable=False):
         return {"enabled": enabled, "remote_url": remote_url,

--- a/tests/host-label-scutil.test.py
+++ b/tests/host-label-scutil.test.py
@@ -5,7 +5,9 @@ Guards the DHCP-hostname-drift fix: a drifting `hostname` must not override the
 stable Bonjour LocalHostName on macOS. Run:
   python3 tests/host-label-scutil.test.py
 """
-import os, sys, unittest
+import os
+import sys
+import unittest
 from unittest.mock import patch, MagicMock
 from pathlib import Path
 

--- a/tests/local-task-protocol.test.py
+++ b/tests/local-task-protocol.test.py
@@ -280,8 +280,8 @@ if (corpus / "archive").is_dir():
         except Exception:
             bad += 1
     check(f"live corpus: {n} files parse without throwing", bad == 0, f"{bad} threw")
-    check(f"live corpus: id recoverable everywhere", no_id == 0, f"{no_id} lacked ids")
-    check(f"live corpus: trusted-body fidelity (no non-header line lost)",
+    check("live corpus: id recoverable everywhere", no_id == 0, f"{no_id} lacked ids")
+    check("live corpus: trusted-body fidelity (no non-header line lost)",
           infidel == 0, f"{infidel} files lost lines")
 else:
     print("  (live corpus sweep skipped — no workspace archive)")
@@ -341,4 +341,4 @@ if _os.getuid() != 0:
 
 if failures:
     sys.exit(1)
-print(f"PASS — local_task_protocol read-side golden tests")
+print("PASS — local_task_protocol read-side golden tests")

--- a/tests/morning-briefing-completion-line.test.py
+++ b/tests/morning-briefing-completion-line.test.py
@@ -79,7 +79,9 @@ def _drive_main(*, sentinel_present: bool) -> str:
     """Run main() against stubbed collaborators and a temp workspace, returning
     stdout. Exercises the two print sites themselves — asserting on
     `completion_line` alone would leave main() free to print anything."""
-    import io, tempfile, contextlib
+    import io
+    import tempfile
+    import contextlib
     from datetime import datetime
     with tempfile.TemporaryDirectory() as td:
         td = Path(td)

--- a/tests/pending-questions-honest-notify.test.py
+++ b/tests/pending-questions-honest-notify.test.py
@@ -153,7 +153,8 @@ class TestDeliver(unittest.TestCase):
         self.m.notify_macos = lambda c, t: True
         self.m.voice_client_connected = lambda: False
         self.m.undrained_proactive_files = lambda: ["proactive-old.txt"]
-        import io, contextlib
+        import io
+        import contextlib
         err = io.StringIO()
         with contextlib.redirect_stderr(err):
             s = self.m.deliver([{"title": "q"}], 1, ["q"])
@@ -180,7 +181,8 @@ class TestReviewFindings(unittest.TestCase):
 
     # --- finding 1: cooldown must not be stamped when delivery raises ---
     def test_a_cooldown_not_stamped_when_delivery_raises(self):
-        import tempfile, pathlib
+        import tempfile
+        import pathlib
         stamp = pathlib.Path(tempfile.mkdtemp()) / "last-notify"
         self.m.LAST_NOTIFY_FILE = stamp
         self.m.deliver = lambda *a, **k: (_ for _ in ()).throw(OSError("delivery blew up"))
@@ -195,7 +197,8 @@ class TestReviewFindings(unittest.TestCase):
         """The positive half. Testing only the failure case let the stamp be
         deleted outright without any test failing — which would notify on every
         run forever. A guard needs both directions or it pins nothing."""
-        import tempfile, pathlib
+        import tempfile
+        import pathlib
         stamp = pathlib.Path(tempfile.mkdtemp()) / "last-notify"
         self.m.LAST_NOTIFY_FILE = stamp
         self.m.deliver = lambda *a, **k: "Notified: 1 pending questions [ok]"

--- a/tests/python39-union-annotations.test.py
+++ b/tests/python39-union-annotations.test.py
@@ -157,7 +157,8 @@ def test_negative_cases() -> None:
         )
     # Guarded file: has __future__, so check_file returns None
     src = "from __future__ import annotations\ndef f(x: str | None): pass"
-    import tempfile, os
+    import tempfile
+    import os
     with tempfile.NamedTemporaryFile(suffix=".py", delete=False, mode="w") as f:
         f.write(src)
         fname = f.name

--- a/tests/read-discord-channel-gate.test.py
+++ b/tests/read-discord-channel-gate.test.py
@@ -8,7 +8,10 @@ All ids below are FICTITIOUS placeholders (no real channels/guilds). The guild
 resolver is stubbed, so no live Discord is needed. Run:
   python3 tests/read-discord-channel-gate.test.py
 """
-import json, tempfile, os, importlib.util
+import json
+import tempfile
+import os
+import importlib.util
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent

--- a/tests/task-body-injection-guard.test.py
+++ b/tests/task-body-injection-guard.test.py
@@ -5,7 +5,8 @@ fences (instruction injection) once embedded in a `key: value` task file.
 
 Run: python3 tests/task-body-injection-guard.test.py
 """
-import sys, unittest
+import sys
+import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))


### PR DESCRIPTION
Stacked on #2186 → #2185 → #2184 — review those first. It also carries the #2183 fix as a dependency (ruff flags the same `F524` bugs, so the branch needs it to be green); if #2183 merges first this becomes a no-op.

Python was the **largest unlinted surface in the repo** — 341 files across `src/`, `skills/`, `tests/`, `scripts/`, `hooks/` and `packages/` — with no linter at all. Unlike TypeScript there is no `tsc` backstop, so a broken `.format()` call or an undefined name in a rarely-exercised branch could reach main uncaught. The `KeyError` bug in #2183 was found exactly that way.

Adds `ruff.toml` + `.github/workflows/ruff.yml`. **Ruff is pinned to 0.15.22** — linters gain rules between releases, and an unpinned install turns unrelated PRs red.

## 346 findings → 0, in three moves

### 1. Turned off what is deliberate house style, not sloppiness

| Rule | Hits | Why off |
|---|---|---|
| `E402` | 33 | **Structural.** Scripts insert `src/` into `sys.path` *before* importing from it. The import cannot move above the code that makes it resolvable. |
| `E701`/`E702` | 81 | The dense one-liner is an idiom here — `if not line: continue` in parse loops, `run(...); print("PASS ...")` in tests. |
| `E741`, `E731` | 48 | Renaming `l` across the tree changes no behaviour. |

### 2. Applied 76 semantically-safe fixes

`F541` f-string-missing-placeholders (55) and `E401` multiple-imports-on-one-line (21). The `F541` fixes only drop an `f` prefix from strings with no placeholders — a no-op.

### 3. Deferred `F401` (87) and `F841` (17) — reason recorded in `ruff.toml`

**This is the important part.** `ruff check --fix` for `F401` *breaks this codebase*.

Several modules import a name purely to **re-export** it for tests that reach in via `module.NAME`. Ruff sees no local use and deletes it. My first attempt produced:

```diff
  src/discord-bridge.py
- from message_chunking import chunk_message, _is_fence_open_line
+ from message_chunking import chunk_message
```
```
tests/discord-chunker.test.py
AttributeError: module 'dbridge' has no attribute '_is_fence_open_line'
```

That import line's own comment reads *"`_is_fence_open_line` re-exported for existing tests"* — ruff removed it regardless. `SEND_ALLOWED_PREFIXES` (read by `tests/remote-gateway-file-attach.test.py`) and `chunk_message` in `src/dm-result.py` have the same shape.

I reverted all 87 import deletions. Clearing them needs a per-site judgement — delete the genuinely dead, mark deliberate re-exports `# noqa: F401` or list them in `__all__` — which is a focused follow-up, not a side effect of enabling a linter.

## Verification

- `ruff check .` → **All checks passed**
- **201/203** Python tests pass; every touched file compiles (`py_compile`)
- The two non-passes are **pre-existing and confirmed identical on `main`**: `vault-intercept.test.py` (14 failures) and `secret-scanner.test.py` (missing `detect_secrets`, which CI installs)

Negative-tested so a green result is not vacuous — a planted `.format()` bug and undefined name are both still caught:

```
F524 `.format` call is missing argument(s) for placeholder(s): 'a','b'
F821 Undefined name `x`
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Before/after: `ruff check .` (ruff 0.15.22, this PR's `ruff.toml`)

**Before** — tree at the parent of the baseline commit (current main + the carried #2183 fix), with this PR's config:

```
55  F541  [*] f-string-missing-placeholders
22  E401  [*] multiple-imports-on-one-line
Found 77 errors.
```

(Raw, before the config's documented exclusions: **368 findings** — 86 F401, 77 E702, 55 F541, 49 E741, 34 E402, 26 E701, 22 E401, 17 F841, 1 E731, and 1 F821 which is the documented `dream.py` lazy-import false positive.)

**After** — this branch:

```
All checks passed!
```

## Re: "ensure ruff workflow runs on this stacked PR base"

It does — `ruff.yml` triggers on `pull_request: branches: [main]` and this PR's base is `main`. The run is registered on the head SHA but sits at `action_required` alongside every other workflow on these fork PRs, pending maintainer approval to execute. Not a config issue; nothing on the contributor side can release it.

## Post-rebase note

After rebasing onto current main, one new finding existed that the baseline commit predates: an E401 in `tests/bridge-not-allowlisted-ack.test.py` (landed via #2109). Fixed with the same mechanical split in 37df5d2; the test still passes and `ruff check .` is clean again — an early live demonstration of exactly the drift this gate exists to catch.


## Coverage-gate follow-up (faddbc2)

The diff-coverage gate redded this PR at 46%: it judges every changed executable line against the 95% bar, and it cannot distinguish an edited-in-place line from new code. The F541/E401 fixes in `discord-bridge.py`, `github-webhook.py`, `health-check.py` and `scan-call-logs.py` sat on legacy branches no test exercises, so byte-identical mechanical edits were counted as uncovered "new" code.

Rather than bolting tests for unrelated legacy branches onto a lint PR (or scattering `# pragma: no cover`, which the coverage docs reserve for genuinely untestable lines), those four files are reverted to main and their hits deferred via documented `per-file-ignores` — the same deferred-not-dismissed treatment as F401/F841. They should be fixed alongside whatever PR gives those paths coverage.

Local `scripts/coverage-gate.sh` vs `origin/main` now reports **100% (11/11 changed lines covered)**, and `ruff check .` remains clean.
