### PR TITLE
chore(lint): add shellcheck gate for shell scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,50 @@
+name: shellcheck
+
+# CI lint: the shell baseline, completing the set alongside eslint.yml (TS/JS)
+# and ruff.yml (Python).
+#
+# 124 .sh files across src/, scripts/, skills/, tests/ and hooks/ — startup,
+# migration, health-check and the shell test suites. Shell has no compiler and
+# no type checker, so an unquoted expansion or a typo'd variable fails only at
+# runtime, on a user's machine, mid-migration.
+#
+# GATED AT `error` SEVERITY ONLY, deliberately. Current counts:
+#
+#     error    5    <- gated (fixed in this PR, so the gate starts green)
+#     warning  87   \
+#     info     211   >  real signal, but too large to fix in a lint-introduction PR
+#     style    219  /
+#
+# Gating at `warning` today would mean either 87 shell edits bundled into this
+# change, or a permanently-red check. `error` is the subset that is nearly
+# always a genuine defect, so it can gate immediately and the bar can be raised
+# in follow-ups as the warning backlog comes down.
+#
+# ubuntu-latest ships shellcheck preinstalled, so there is no install step to
+# pin or cache.
+
+on:
+  pull_request:
+    branches: [main, staging-interaction-planes]
+  push:
+    branches: [main, staging-interaction-planes]
+
+jobs:
+  shellcheck:
+    name: shellcheck over shell scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show shellcheck version
+        run: shellcheck --version
+
+      - name: Run shellcheck (error severity)
+        run: |
+          # -print0/-0 so paths with spaces cannot split into bogus arguments.
+          # `-S error` sets the gate; see the header for why not `warning` yet.
+          find src scripts skills tests hooks -name '*.sh' -not -path '*/node_modules/*' -print0 \
+            | xargs -0 shellcheck -S error -f gcc

--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1581,7 +1581,7 @@ commit_main() {
         echo "  If you want to commit + delete in one step on a fresh state, run --commit first (no-delete)," >&2
         echo "  observe ~7d for straggler writers, then re-run with --commit --delete-source --backup-id <id-from-step-1>." >&2
         echo "  Available backups:" >&2
-        ls -1 "$DEST_REAL/state/migration-backup-"*.tar 2>/dev/null "$DEST_REAL/state/migration-backup-"*.tar.gz 2>/dev/null \
+        ls -1 "$DEST_REAL/state/migration-backup-"*.tar "$DEST_REAL/state/migration-backup-"*.tar.gz 2>/dev/null \
             | sed -E 's@.*migration-backup-(.+)\.tar(\.gz)?$@    \1@' >&2 || echo "    (none)" >&2
         exit 2
     fi
@@ -1949,7 +1949,7 @@ rollback_main() {
         echo "rollback: --backup-id <id> required. Available backups:" >&2
         # Bug #3 (2026-06-06): backups can be .tar.gz OR .tar (uncompressed
         # for media-heavy workspaces). List both shapes.
-        ls -1 "$DEST_REAL/state/migration-backup-"*.tar 2>/dev/null "$DEST_REAL/state/migration-backup-"*.tar.gz 2>/dev/null \
+        ls -1 "$DEST_REAL/state/migration-backup-"*.tar "$DEST_REAL/state/migration-backup-"*.tar.gz 2>/dev/null \
             | sed -E 's@.*migration-backup-(.+)\.tar(\.gz)?$@  \1@' >&2
         exit 2
     }

--- a/src/migration_safety_helpers.sh
+++ b/src/migration_safety_helpers.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # PR #1440 — auto-migration safety helpers (Mini review).
 #
 # Sourced by src/startup.sh's v0.8 SUTANDO_WORKSPACE auto-migration block and


### PR DESCRIPTION
Stacked on #2187 → #2186 → #2185 → #2184 — review those first.

Completes the linter set alongside `eslint.yml` (TS/JS) and `ruff.yml` (Python).

**124 `.sh` files** across `src/`, `scripts/`, `skills/`, `tests/` and `hooks/` — startup, migration, health-check and the shell test suites — had no static analysis. Shell has no compiler and no type checker, so an unquoted expansion or a typo'd variable fails only at runtime, on a user's machine, mid-migration.

## Gated at `error` severity only — deliberately

| Severity | Count | Gated |
|---|---|---|
| `error` | 5 | ✅ fixed here, so the gate starts green |
| `warning` | 87 | ❌ deferred |
| `info` | 211 | ❌ deferred |
| `style` | 219 | ❌ deferred |

Gating at `warning` today would mean either 87 shell edits bundled into this change, or a permanently-red check. `error` is the subset that is nearly always a genuine defect, so it can gate immediately and the bar can be raised in follow-ups as the backlog comes down.

`ubuntu-latest` ships shellcheck preinstalled, so there is no install step to pin or cache.

## The 5 errors fixed

**`scripts/sutando-migrate.sh` (×2, SC2261)** — the backup-listing had a duplicated stderr redirect mid-command:

```bash
ls -1 "$D"*.tar 2>/dev/null "$D"*.tar.gz 2>/dev/null
```

Both redirects target stderr so the last one wins and the behaviour was already correct — this is a copy-paste artefact from when the second glob was added for "Bug #3 (2026-06-06): backups can be .tar.gz OR .tar". Collapsed to a single trailing redirect. Verified the glob still lists both shapes:

```
  aaa      <- migration-backup-aaa.tar
  bbb      <- migration-backup-bbb.tar.gz
```

**`src/migration_safety_helpers.sh` (SC2148)** — no shebang, so shellcheck could not infer the dialect. This file is **sourced** (by `src/startup.sh` and `tests/startup-migration.integration.test.sh`), never executed, so a shebang would wrongly imply it is runnable. Added `# shellcheck shell=bash` instead — tells the linter the dialect, changes nothing at runtime.

## Verification

- The exact CI command exits **0**
- All 124 files pass `bash -n`
- **7/7** shell tests pass
- Negative-tested with a planted SC2261 — the gate correctly exits non-zero, so the green result is not vacuous:

```
src/_negtest.sh:2:17: error: Multiple redirections compete for stderr. [SC2261]
(exit 1)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Before/after: the exact CI command

`find src scripts skills tests hooks -name '*.sh' -not -path '*/node_modules/*' -print0 | xargs -0 shellcheck -S error -f gcc`

**Before** (parent commit):

```
src/migration_safety_helpers.sh:1:1: error: Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]
scripts/sutando-migrate.sh:1584:58: error: Multiple redirections compete for stderr. Use cat, tee, or pass filenames instead. [SC2261]
scripts/sutando-migrate.sh:1584:115: error: Multiple redirections compete for stderr. [SC2261]
scripts/sutando-migrate.sh:1952:58: error: Multiple redirections compete for stderr. [SC2261]
scripts/sutando-migrate.sh:1952:115: error: Multiple redirections compete for stderr. [SC2261]
(exit 1)
```

**After** (this branch): no output, **exit 0**.

## Re: "remove pull_request branch filters so stacked PR gates run"

Not needed — `on.pull_request.branches` filters on the PR's **base** branch, not its head, and every PR in this stack targets `main`, so the filter matches. Empirically: the `shellcheck` run is registered on this PR's head SHA (it sat at `action_required` pending maintainer approval of fork workflow runs, like every other gate here — an approval queue, not a trigger miss). The filter also matches the convention of every existing workflow in the repo (`ci.yml`, `eslint.yml`, `ruff.yml`, the five `lint-*.yml`), so removing it would be a deviation with no effect.
