### PR TITLE
fix(tests): skip secret-scanner suite locally when detect-secrets is absent (still runs in CI)

### DIFF
--- a/tests/secret-scanner.test.py
+++ b/tests/secret-scanner.test.py
@@ -9,7 +9,37 @@ import sys
 import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-from secret_scanner import scan_secrets, redact_secrets, scan_and_redact
+
+# src/secret_scanner.py imports detect-secrets at module scope, so without the
+# package this file dies with ModuleNotFoundError before a single test runs —
+# an import-time crash that reads like a broken suite rather than a missing
+# dev dependency. detect-secrets is a TEST-only dep (the runtime soft-imports
+# it and degrades gracefully), installed in CI by the "Install Python test
+# deps" step, so a local checkout without it is expected and fine.
+#
+# Skip with an actionable message locally; still FAIL under CI, so a silently
+# broken install step can never be mistaken for a clean run.
+try:
+    from secret_scanner import scan_secrets, redact_secrets, scan_and_redact
+
+    _IMPORT_ERROR = None
+except ModuleNotFoundError as exc:  # pragma: no cover — depends on local env
+    if os.environ.get("CI"):
+        raise
+    _IMPORT_ERROR = exc
+    scan_secrets = redact_secrets = scan_and_redact = None
+
+
+if _IMPORT_ERROR is not None:  # pragma: no cover — depends on local env
+    print(
+        f"SKIP tests/secret-scanner.test.py — {_IMPORT_ERROR}.\n"
+        "      Install the test dep to run this suite:\n"
+        f"          {sys.executable} -m pip install 'detect-secrets>=1.5.0'\n"
+        "      (if that fails with 'externally-managed-environment' (PEP 668),\n"
+        "       retry the same command with --break-system-packages)",
+        file=sys.stderr,
+    )
+    raise SystemExit(0)
 
 
 class TestDetection(unittest.TestCase):


### PR DESCRIPTION
Independent of the lint stack — branches off `main`, no dependencies.

`src/secret_scanner.py` imports detect-secrets at module scope, so on a checkout without the package `tests/secret-scanner.test.py` dies with `ModuleNotFoundError` **before a single test runs**. Locally that reads like a broken test file rather than a missing dev dependency.

## Not a defect — a legibility problem

detect-secrets is **test-only**: the runtime soft-imports it and vault degrades gracefully when it is absent (per the comment on `ci.yml`'s install step). CI installs it in *Install Python test deps*, so the suite is green there and always has been. A local checkout without it is expected.

Verified in a clean venv: with the package installed the suite is **24 tests, OK**. Nothing is actually broken.

## The fix

Guard the import — print an actionable skip and `exit 0` locally:

```
SKIP tests/secret-scanner.test.py — No module named 'detect_secrets'.
      Install the test dep to run this suite:
          python3 -m pip install 'detect-secrets>=1.5.0'
```

**Critically, the guard does not apply under CI.** If `$CI` is set the `ModuleNotFoundError` is re-raised, so a silently broken install step still fails the build. A skip that can hide a real regression would be worse than the confusing failure it replaces.

## Verification

| Condition | Expected | Result |
|---|---|---|
| no dep, no CI | skip, exit 0 | ✅ |
| no dep, `CI=1` | `ModuleNotFoundError`, exit 1 | ✅ |
| dep, no CI | 24 tests | ✅ OK |
| dep, `CI=1` | 24 tests | ✅ OK |

No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Correction (updated after further investigation)

An earlier revision of this description called a checkout without detect-secrets *"expected, not a defect."* **That was wrong**, and worth correcting rather than quietly editing away.

Nothing installs detect-secrets outside CI — no requirements file, no setup step, no mention in README or CONTRIBUTING. It is not an edge case; it is the default state of **every** fresh clone. And it is not a dev dep at all: `vault_intercept` fails closed without it and refuses every unquoted `vault set KEY VALUE`, the form CLAUDE.md documents. That root cause is addressed separately in **#2192**.

This PR is still worth having, and is independent of #2192: #2192 makes the missing dep visible to an **operator** at startup, while this makes the test suite legible to a **contributor** who has cloned the repo and never runs `startup.sh`. Neither installs the package, so the skip is still needed.

The install hint in the skip message has also been corrected. It previously read `python3 -m pip install 'detect-secrets>=1.5.0'` — which **cannot succeed** on a stock Homebrew/macOS host (PEP 668 rejects it, and rejects `--user` too). It now names `sys.executable` and the `--break-system-packages` fallback, matching #2192. Handing out an install command that fails on the most common host would have made this PR part of the problem it set out to fix.
