### PR TITLE
fix(tests): skip vault-intercept suite locally when detect-secrets is absent (still runs in CI)

### DIFF
--- a/tests/vault-intercept.test.py
+++ b/tests/vault-intercept.test.py
@@ -5,6 +5,8 @@ All Keychain writes are mocked: no real 'security' subprocess is spawned,
 secrets never touch the test runner's Keychain.
 """
 
+import importlib.util
+import os
 import sys
 import unittest
 from pathlib import Path
@@ -12,6 +14,35 @@ from unittest.mock import MagicMock, call, patch
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "src"))
+
+# vault_intercept imports cleanly without detect-secrets — but it FAILS CLOSED
+# at runtime: with no scanner available it refuses every unquoted `vault set`
+# rather than storing a value it cannot validate (see vault_intercept.py:266).
+#
+# That is correct production behaviour, but it means 15 of these 47 tests
+# assert outcomes that only hold when scanning actually works. Without the
+# package they report as ordinary failures, which reads like broken vault
+# logic instead of a missing dev dependency.
+#
+# Skipping the whole suite (rather than the 15) is deliberate: with no scanner
+# this file exercises a degraded configuration that never occurs in
+# production — CI and every real deployment have detect-secrets — so a partial
+# local pass would assert against a shape that does not ship.
+#
+# The guard does NOT apply under CI: if $CI is set the suite runs regardless,
+# so a silently broken install step fails the build instead of being papered
+# over as a skip.
+if importlib.util.find_spec("detect_secrets") is None and not os.environ.get("CI"):
+    print(
+        "SKIP tests/vault-intercept.test.py — detect-secrets not installed, so\n"
+        "      vault_intercept fails closed and 15 of 47 assertions cannot hold.\n"
+        "      Install the test dep to run this suite:\n"
+        f"          {sys.executable} -m pip install 'detect-secrets>=1.5.0'\n"
+        "      (if that fails with 'externally-managed-environment' (PEP 668),\n"
+        "       retry the same command with --break-system-packages)",
+        file=sys.stderr,
+    )
+    raise SystemExit(0)
 
 import vault_intercept
 from vault_intercept import InterceptResult, intercept_vault_commands, redact_vault_commands


### PR DESCRIPTION
Independent of the lint stack — branches off `main`. Sibling of #2190 (same root cause, different failure mode).

`vault_intercept` imports cleanly without detect-secrets, but **fails closed** at runtime: with no scanner available it refuses every unquoted `vault set` rather than storing a value it cannot validate (`vault_intercept.py:266`).

That is correct production behaviour. The side effect is that **15 of these 47 tests** assert outcomes which only hold when scanning works, so on a checkout without the package they report as 14 failures + 1 error — the noisiest thing in the Python suite, and it reads like broken vault logic.

## Not a defect

detect-secrets is **test-only** (the runtime soft-imports it and vault degrades gracefully) and CI installs it in *Install Python test deps*. Verified in a clean venv: with the package installed the suite is **47 tests, OK**.

## Why skip the whole suite, not the 15

Deliberate. With no scanner this file exercises a **degraded configuration that never occurs in production** — CI and every real deployment have detect-secrets — so a partial local pass would assert against a shape that does not ship.

The cost is real and worth naming: 32 tests that would pass locally are also skipped. That seemed better than reporting green on a configuration nobody runs. Happy to switch to per-test `skipUnless` on the 15 if you would rather keep the partial local signal.

## The CI escape hatch

The guard does **not** apply under CI. With `$CI` set the suite runs regardless, so a silently broken install step still fails the build instead of being papered over as a skip.

## Verification

| Condition | Expected | Result |
|---|---|---|
| no dep, no CI | skip, exit 0 | ✅ |
| no dep, `CI=1` | suite runs, exit 1 | ✅ |
| dep, no CI | 47 tests | ✅ OK |
| dep, `CI=1` | exit 0 | ✅ |

No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Correction (updated after further investigation)

An earlier revision of this description called a checkout without detect-secrets *"expected, not a defect."* **That was wrong**, and worth correcting rather than quietly editing away.

Nothing installs detect-secrets outside CI — no requirements file, no setup step, no mention in README or CONTRIBUTING. It is not an edge case; it is the default state of **every** fresh clone. And it is not a dev dep at all: `vault_intercept` fails closed without it and refuses every unquoted `vault set KEY VALUE`, the form CLAUDE.md documents. That root cause is addressed separately in **#2192**.

This PR is still worth having, and is independent of #2192: #2192 makes the missing dep visible to an **operator** at startup, while this makes the test suite legible to a **contributor** who has cloned the repo and never runs `startup.sh`. Neither installs the package, so the skip is still needed.

The install hint in the skip message has also been corrected. It previously read `python3 -m pip install 'detect-secrets>=1.5.0'` — which **cannot succeed** on a stock Homebrew/macOS host (PEP 668 rejects it, and rejects `--user` too). It now names `sys.executable` and the `--break-system-packages` fallback, matching #2192. Handing out an install command that fails on the most common host would have made this PR part of the problem it set out to fix.
