### PR TITLE
fix(vault): surface missing detect-secrets at startup, make recovery work

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -885,6 +885,33 @@ fi
 
 echo ""
 
+# Vault scanner preflight, shared by the three bridges that intercept secrets
+# (telegram, discord, slack — all import src/vault_intercept.py).
+#
+# detect-secrets has been treated as a CI-only test dep, but it is a RUNTIME dep
+# of a shipping feature: without it vault_intercept fails closed and REFUSES
+# every unquoted `vault set KEY VALUE` — which is the form CLAUDE.md documents
+# as the way to store a secret. Quoted values still work, so the degradation is
+# safe but silent: nothing surfaced it until an owner tried to store a secret
+# and got a refusal.
+#
+# This mirrors how discord.py / slack_bolt are handled below — name the missing
+# dep and the exact fix at the startup console, don't auto-install.
+#
+# Checked PER INTERPRETER because each bridge is launched with whichever python
+# had ITS client library, and those are frequently not the same binary.
+_vault_scanner_check() {
+  _vsc_py="$1"; _vsc_who="$2"
+  [ -n "$_vsc_py" ] || return 0
+  if ! "$_vsc_py" -c "import detect_secrets" >/dev/null 2>&1; then
+    echo "  ~ $_vsc_who: detect-secrets missing in $_vsc_py — unquoted \`vault set\` will be REFUSED"
+    # Both plain and --user installs are blocked by PEP 668 on stock
+    # Homebrew/macOS python, so the fallback is named up front rather than
+    # leaving the operator to rediscover it.
+    echo "      fix: $_vsc_py -m pip install detect-secrets   (add --break-system-packages if PEP 668 blocks it)"
+  fi
+}
+
 # 6. Telegram bridge (optional — needs TELEGRAM_BOT_TOKEN, skip with SKIP_TELEGRAM=1)
 if [ "${SKIP_TELEGRAM:-}" = "1" ]; then
   echo "  ~ telegram bridge (skipped via SKIP_TELEGRAM)"
@@ -905,6 +932,7 @@ elif _TG_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels
     fi
     "$TGPY" src/telegram-bridge.py > "$LOGS_DIR/telegram-bridge.log" 2>&1 &
     echo "  ✓ telegram bridge ($TGPY)"
+    _vault_scanner_check "$TGPY" "telegram bridge"
   else
     echo "  ✓ telegram bridge (already running)"
   fi
@@ -979,6 +1007,7 @@ elif _DC_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels
     echo "  Starting Discord bridge with $PYTHON_WITH_DISCORD..."
     PYTHONUNBUFFERED=1 "$PYTHON_WITH_DISCORD" src/discord-bridge.py > "$LOGS_DIR/discord-bridge.log" 2>&1 &
     echo "  ✓ discord bridge"
+    _vault_scanner_check "$PYTHON_WITH_DISCORD" "discord bridge"
   else
     echo "  ✓ discord bridge (already running)"
   fi
@@ -1007,6 +1036,7 @@ elif _SL_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels
     set -a; . "$_SL_ENV"; set +a
     "$PYTHON_WITH_SLACK" src/slack-bridge.py > "$LOGS_DIR/slack-bridge.log" 2>&1 &
     echo "  ✓ slack bridge"
+    _vault_scanner_check "$PYTHON_WITH_SLACK" "slack bridge"
   else
     echo "  ✓ slack bridge (already running)"
   fi

--- a/src/vault_intercept.py
+++ b/src/vault_intercept.py
@@ -279,16 +279,30 @@ def intercept_vault_commands(text: str) -> InterceptResult:
                 # pip-install (env mutation in a message handler) and no separate task:
                 # the refusal rides the normal task to core, channel context intact.
                 print(
-                    f"vault: detect-secrets not installed — refused unquoted "
-                    f"`vault set {key}` (can't validate). Core will install the dep; "
-                    f"quote the value to store immediately.",
+                    f"vault: detect-secrets not installed in {sys.executable} — refused "
+                    f"unquoted `vault set {key}` (can't validate). Quote the value to "
+                    f"store immediately; see the task text for the install command.",
                     flush=True,
                 )
                 failed.append(key)
+                # The install hint must name THIS interpreter (sys.executable),
+                # not a bare `python3`: the bridges are launched with whichever
+                # interpreter had their client library (see the probes in
+                # src/startup.sh), which is frequently NOT the `python3` first on
+                # PATH. Installing into the wrong one leaves the refusal in place
+                # and looks like the fix silently failed.
+                #
+                # The --break-system-packages fallback is required, not optional
+                # noise: on a stock Homebrew/macOS python both `pip install` AND
+                # `pip install --user` are refused by PEP 668, so the previous
+                # bare `python3 -m pip install detect-secrets` could not succeed
+                # on the most common Sutando host. Verified 2026-07-20.
                 return (
                     f"vault set {key} [vault: REFUSED — detect-secrets not installed, "
                     f"can't validate an unquoted value. AGENT: run "
-                    f"'python3 -m pip install detect-secrets', then tell the owner to "
+                    f"'{sys.executable} -m pip install detect-secrets' — if that fails "
+                    f"with 'externally-managed-environment' (PEP 668), retry the same "
+                    f"command with --break-system-packages. Then tell the owner to "
                     f"re-send this vault set (or quote the value next time). Never echo "
                     f"or ask for the value.]"
                 )


### PR DESCRIPTION
Independent — branches off `main`.

## The mislabel

`ci.yml:51` calls detect-secrets *"a TEST/dev dep — the runtime soft-imports it (vault degrades gracefully when it's absent)."*

It is in fact a **runtime dependency of a shipping feature**. Without it `vault_intercept` fails closed and **refuses every unquoted `vault set KEY VALUE`** — the exact form `CLAUDE.md` documents as the way to store a secret:

> Secrets passed via Slack/Discord (`vault set KEY VALUE`) are intercepted by the bridge…

Quoted values still work, so the degradation is safe — but silent. And **nothing installs it outside CI**: no requirements file, no setup step, no mention in README or CONTRIBUTING. Verified on my machine, where the feature is degraded right now:

```
vault set DEMO_KEY [vault: REFUSED — detect-secrets not installed …]
stored: []
```

Two changes, one concern: make the missing dep **visible**, and make the stated recovery **actually run**.

## 1. Startup visibility — `src/startup.sh`

Adds `_vault_scanner_check()`, called after each of the three bridges that import `vault_intercept` (telegram, discord, slack). This mirrors how `discord.py` and `slack_bolt` are already handled — name the dep and the exact fix at the startup console, don't auto-install:

```
~ discord bridge: detect-secrets missing in /opt/homebrew/…/python3 — unquoted `vault set` will be REFUSED
      fix: /opt/homebrew/…/python3 -m pip install detect-secrets   (add --break-system-packages if PEP 668 blocks it)
```

Checked **per interpreter**, not once globally: each bridge launches with whichever python had *its* client library, and those are frequently not the same binary.

## 2. Recovery that works — `src/vault_intercept.py`

The refusal told the agent to run `python3 -m pip install detect-secrets`. **That command cannot succeed on a stock Homebrew/macOS host.** Verified 2026-07-20 by dry-run:

| Command | Result |
|---|---|
| `pip install detect-secrets` | ❌ PEP 668 externally-managed-environment |
| `pip install --user detect-secrets` | ❌ PEP 668 (the obvious workaround also fails) |
| `pip install --break-system-packages detect-secrets` | ✅ `Would install detect-secrets-1.5.0` |

So the built-in self-heal was a **no-op on the most common Sutando host**. The hint now:

- names **`sys.executable`** rather than a bare `python3` — installing into the wrong interpreter leaves the refusal in place and looks like the fix silently failed
- names the **`--break-system-packages`** fallback up front

The console line also loses its *"Core will install the dep"* claim. Nothing installs it automatically — that text sent operators looking for a mechanism that does not exist (it is only ever an instruction to the agent).

## Verification

- `startup.sh` parses (`bash -n`) and is shellcheck-clean at error severity
- Helper correct in all four states: dep present (silent) / absent (warns) / empty arg (silent, rc=0) / nonexistent binary (warns, no crash)
- Emitted install command confirmed to resolve
- **203/203** Python tests, **35/35** shell tests
- No test asserted the old wording

## Not included

Declaring a `requirements-dev.txt` — that would dedupe the package list now duplicated across `ci.yml` and `coverage-gate.yml`, but it reverses the documented decision at `ci.yml:53` ("pure indirection"), so it belongs in its own PR with maintainer input. Worth noting that comment's "single dev-only package" premise is now four packages out of date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
