### PR TITLE
feat(health): read the desktop checklist's agent surface (onboarding-status.json)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -417,9 +417,13 @@ def check_onboarding_status() -> "dict | None":
         return None
     try:
         data = json.loads(path.read_text())
-        rows = data.get("rows", {})
+        # Shape-guard (Codex P1): a frontend bug could write [] or {"rows": []}
+        # — non-dict shapes must degrade to 'unreadable', never raise.
+        if not isinstance(data, dict) or not isinstance(data.get("rows"), dict):
+            return {"name": name, "status": "warn", "detail": "onboarding-status.json unreadable"}
+        rows = data["rows"]
         todo = sorted(k for k, v in rows.items() if isinstance(v, dict) and v.get("state") == "todo")
-        age_s = max(0, int(time.time()) - int(data.get("updated_at", 0)))
+        age_s = max(0, int(time.time()) - int(data.get("updated_at", 0) or 0))
     except (ValueError, OSError, TypeError):
         return {"name": name, "status": "warn", "detail": "onboarding-status.json unreadable"}
     if todo:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -396,6 +396,41 @@ def check_memory_sync() -> dict:
     return {"name": name, "status": "ok", "detail": "initialized, never fetched"}
 
 
+def check_onboarding_status() -> "dict | None":
+    """Read the desktop checklist's agent surface (onboarding v2 spec,
+    ag2space-cinny-desktop#165 S4).
+
+    The desktop Console mirrors its setup-checklist row states into
+    `<workspace>/state/onboarding-status.json` (written by console_status,
+    write-on-change). This check is the core-side half: surface rows the USER
+    still needs (or that regressed from green) so the proactive loop can run
+    the self-heal ladder and, failing that, tell the owner — instead of the
+    Console being the only place onboarding failures are visible.
+
+    Absent file → None (CLI installs and pre-S1 desktop builds have no
+    checklist; nothing to report). Rows in "todo" → warn with the row names.
+    Read-only; never raises.
+    """
+    name = "onboarding-status"
+    path = WORKSPACE_DIR / "state" / "onboarding-status.json"
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        rows = data.get("rows", {})
+        todo = sorted(k for k, v in rows.items() if isinstance(v, dict) and v.get("state") == "todo")
+        age_s = max(0, int(time.time()) - int(data.get("updated_at", 0)))
+    except (ValueError, OSError, TypeError):
+        return {"name": name, "status": "warn", "detail": "onboarding-status.json unreadable"}
+    if todo:
+        return {
+            "name": name,
+            "status": "warn",
+            "detail": f"user-facing setup incomplete: {', '.join(todo)} (as of {age_s}s ago)",
+        }
+    return {"name": name, "status": "ok", "detail": f"all checklist rows satisfied ({age_s}s ago)"}
+
+
 def check_host_subtrees() -> dict:
     """Surface per-host subtrees (hosts/<host>/) that have stopped syncing.
 
@@ -1790,6 +1825,9 @@ def run_all_checks() -> list[dict]:
 
     # Per-host subtree freshness (hosts/<host>/ stopped syncing?)
     checks.append(check_host_subtrees())
+    onboarding_check = check_onboarding_status()
+    if onboarding_check is not None:
+        checks.append(onboarding_check)
 
     # Migration/reader path-contract drift (#1543)
     checks.append(check_migrate_reader_contract())

--- a/tests/onboarding-status-check.test.py
+++ b/tests/onboarding-status-check.test.py
@@ -1,0 +1,74 @@
+"""check_onboarding_status: the core-side reader of the desktop checklist's
+agent surface (onboarding v2, ag2space-cinny-desktop#165 S4).
+
+Covers: absent file → None; todo rows → warn naming them; all-satisfied → ok;
+unreadable → warn (never raises).
+"""
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+sys.modules["health_check"] = hc
+spec.loader.exec_module(hc)
+
+
+class OnboardingStatusCheckTest(unittest.TestCase):
+    def _with_workspace(self, payload):
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        ws = Path(td.name)
+        if payload is not None:
+            (ws / "state").mkdir()
+            f = ws / "state" / "onboarding-status.json"
+            if isinstance(payload, str):
+                f.write_text(payload)
+            else:
+                f.write_text(json.dumps(payload))
+        orig = hc.WORKSPACE_DIR
+        hc.WORKSPACE_DIR = ws
+        self.addCleanup(lambda: setattr(hc, "WORKSPACE_DIR", orig))
+        return ws
+
+    def test_none_when_file_absent(self):
+        self._with_workspace(None)
+        self.assertIsNone(hc.check_onboarding_status())
+
+    def test_warn_names_todo_rows(self):
+        self._with_workspace(
+            {
+                "updated_at": 0,
+                "rows": {
+                    "core": {"state": "done"},
+                    "gateway": {"state": "todo"},
+                    "voice_creds": {"state": "optional"},
+                },
+            }
+        )
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("gateway", out["detail"])
+        self.assertNotIn("core,", out["detail"])
+
+    def test_ok_when_no_todo(self):
+        self._with_workspace(
+            {"updated_at": 0, "rows": {"core": {"state": "done"}, "accessibility": {"state": "optional"}}}
+        )
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "ok")
+
+    def test_warn_on_unreadable(self):
+        self._with_workspace("{not json")
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("unreadable", out["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/onboarding-status-check.test.py
+++ b/tests/onboarding-status-check.test.py
@@ -63,6 +63,25 @@ class OnboardingStatusCheckTest(unittest.TestCase):
         out = hc.check_onboarding_status()
         self.assertEqual(out["status"], "ok")
 
+    def test_warn_on_list_payload(self):
+        # Codex P1: a top-level list must degrade to 'unreadable', not raise.
+        self._with_workspace("[]")
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("unreadable", out["detail"])
+
+    def test_warn_on_list_rows(self):
+        # Codex P1: rows as a list (frontend bug) must also degrade cleanly.
+        self._with_workspace({"updated_at": 0, "rows": []})
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("unreadable", out["detail"])
+
+    def test_ok_with_null_updated_at(self):
+        self._with_workspace({"updated_at": None, "rows": {"core": {"state": "done"}}})
+        out = hc.check_onboarding_status()
+        self.assertEqual(out["status"], "ok")
+
     def test_warn_on_unreadable(self):
         self._with_workspace("{not json")
         out = hc.check_onboarding_status()


### PR DESCRIPTION
Core-side half of the desktop onboarding v2 spec (ag2-space/ag2space-cinny-desktop#165, slice S4 — owner-approved 2026-07-20).

The desktop Console mirrors its setup-checklist row states into `<workspace>/state/onboarding-status.json` (shipped desktop-side). This PR gives the core eyes on it:

- `check_onboarding_status()` in health-check: **todo rows → warn** naming them ("user-facing setup incomplete: gateway …"), all-satisfied → ok with freshness, unreadable → warn, **absent → check omitted** (CLI installs and pre-S1 desktop builds have no checklist — nothing to report, no noise).
- The proactive loop already reads health-check output each pass, so this is the hook that lets the agent notice a failed/regressed onboarding row and run the self-heal ladder (restart bridge, refresh creds) — escalating to the owner only when it genuinely can't fix it.
- 4 tests (`tests/onboarding-status-check.test.py`), green.

Read-only, additive, no behavior change for installs without the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)