### PR TITLE
fix(session-recap): transcript dir resolution fails on repo paths with spaces/dots

### DIFF
--- a/skills/session-recap/scripts/extract.py
+++ b/skills/session-recap/scripts/extract.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -26,7 +27,12 @@ def transcripts_dir() -> Path:
     ws = subprocess.run(
         ["bash", str(REPO / "scripts" / "sutando-config.sh"), "workspace"],
         capture_output=True, text=True, check=True).stdout.strip()
-    slug = str(REPO).replace("/", "-")
+    # Claude Code slugs the project path by dashing every non-alphanumeric
+    # character, not just "/" — e.g. ".../Application Support/space.ag2.app/..."
+    # becomes "...-Application-Support-space-ag2-app-...". Matching only "/"
+    # resolves to a nonexistent dir on any checkout path containing spaces
+    # or dots (observed 2026-07-20 on a desktop-bundled engine checkout).
+    slug = re.sub(r"[^A-Za-z0-9]", "-", str(REPO))
     return Path(ws) / ".claude-sutando" / "projects" / slug
 
 

--- a/tests/session-recap-extract.test.py
+++ b/tests/session-recap-extract.test.py
@@ -87,7 +87,21 @@ class TestTranscriptsDir(unittest.TestCase):
         with patch.object(self.m.subprocess, "run", return_value=fake):
             got = self.m.transcripts_dir()
         self.assertTrue(str(got).startswith("/tmp/ws/.claude-sutando/projects/"))
-        self.assertIn(str(self.m.REPO).replace("/", "-"), str(got))
+        import re as _re
+        self.assertIn(_re.sub(r"[^A-Za-z0-9]", "-", str(self.m.REPO)), str(got))
+
+    def test_slug_dashes_all_non_alphanumerics(self):
+        # Claude Code's project slug dashes spaces and dots too, not just "/".
+        # A repo path like the desktop-bundled engine checkout must resolve to
+        # the dir Claude Code actually writes.
+        fake = subprocess.CompletedProcess(args=[], returncode=0, stdout="/tmp/ws\n")
+        bundled = Path("/Users/u/Library/Application Support/space.ag2.app/engine/sutando")
+        with patch.object(self.m, "REPO", bundled), \
+                patch.object(self.m.subprocess, "run", return_value=fake):
+            got = self.m.transcripts_dir()
+        self.assertEqual(
+            got.name,
+            "-Users-u-Library-Application-Support-space-ag2-app-engine-sutando")
 
 
 class TestMainDumpAndList(unittest.TestCase):


### PR DESCRIPTION
## Problem

`skills/session-recap/scripts/extract.py` builds the Claude Code project-dir slug with `str(REPO).replace("/", "-")`, but Claude Code dashes **every** non-alphanumeric character. On any checkout whose path contains spaces or dots — e.g. the desktop-bundled engine at `.../Library/Application Support/space.ag2.app/engine/sutando` — the computed dir doesn't exist, so `list`/`dump` exit "no transcripts found" and the **boot recap silently breaks** on such hosts (observed live 2026-07-20; the session worked around it with a symlink).

## Fix

`slug = re.sub(r"[^A-Za-z0-9]", "-", str(REPO))` — matches the dir Claude Code actually writes (verified against the real projects dir on the affected host). Updated the existing slug assertion and added a bundled-path regression test.

`python3 tests/session-recap-extract.test.py` → 13 tests OK.

Single concern; sibling of #2199 (both are CLI-boot-path breakages surfaced by tonight's desktop restart test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VYfRhotcsNxF1LCbk7gPV