### PR TITLE
feat(heartbeat): double-start self-guard — deterministic single writer for .alive

### DIFF
--- a/src/core_heartbeat.py
+++ b/src/core_heartbeat.py
@@ -36,6 +36,7 @@ Runs forever until killed. Exit codes:
 """
 from __future__ import annotations
 import argparse
+import fcntl
 import json
 import os
 import signal
@@ -124,9 +125,16 @@ def write_beat(status: str = "running") -> None:
         "locality": _locality(),
         "schema_version": 2,
     }
-    tmp = target.with_suffix(".alive.tmp")
-    tmp.write_text(json.dumps(payload, indent=2))
-    tmp.replace(target)
+    # Per-PROCESS staging file: with a shared name, two concurrent first beats
+    # destroy each other mid-`replace` (one writer's rename removes the other's
+    # staging file → FileNotFoundError, and interleaved writes can leave the
+    # final .alive as invalid JSON — both reproduced in the #2201 review).
+    tmp = target.parent / f"{target.name}.tmp.{os.getpid()}"
+    try:
+        tmp.write_text(json.dumps(payload, indent=2))
+        tmp.replace(target)
+    finally:
+        tmp.unlink(missing_ok=True)  # no-op after a successful replace
 
 
 _STARTED_AT: float = time.time()
@@ -174,6 +182,48 @@ def another_heartbeat_alive(staleness_s: float = 90.0) -> "int | None":
     return pid
 
 
+_LOCK_FD: "int | None" = None
+
+
+def try_acquire_ownership() -> "int | None":
+    """Atomically claim single-writer ownership for this host, or name who to
+    yield to. Returns None on success; a pid (or -1 when the holder is not yet
+    identifiable) when another starter/beater owns the host.
+
+    Check-then-act on the .alive file alone is NOT enough: on a true
+    simultaneous start every process can observe "no fresh owner" before any
+    first beat lands (reproduced with a 5-way forked barrier in the #2201
+    review — all five proceeded as owners). The claim must be atomic, so it
+    rides an flock(LOCK_EX | LOCK_NB) on `<host>.lock`, held open for the
+    process lifetime and released by the kernel on ANY death — no stale-lock
+    recovery needed, which is why it beats O_EXCL lock files here.
+
+    The freshness/pid guard still runs AFTER the flock: a beater from a
+    pre-flock build (or a foreign writer) doesn't hold the lock but is still
+    a legitimate owner — yield to it rather than fight over the file.
+    """
+    global _LOCK_FD
+    CORES_DIR.mkdir(parents=True, exist_ok=True)
+    lock_path = CORES_DIR / f"{_hostname()}.lock"
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        os.close(fd)
+        # The holder's pid is only knowable once it has beaten.
+        try:
+            return int(json.loads(_alive_path().read_text())["pid"])
+        except Exception:
+            return -1
+    other = another_heartbeat_alive()
+    if other is not None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+        return other
+    _LOCK_FD = fd  # deliberately held (and leaked) for the process lifetime
+    return None
+
+
 def _handle_signal(signum: int, frame) -> None:
     """Mark shutdown so the loop exits at the top of the next sleep; also
     unlink the .alive file so peers see this core leave immediately rather
@@ -191,6 +241,15 @@ def run_forever(interval: float = 30.0, status: str = "running") -> int:
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)
     while not _SHUTDOWN_REQUESTED:
+        # Re-check ownership before every beat: if a DIFFERENT live pid now
+        # owns the file (e.g. this process wedged long enough to be declared
+        # stale and something else legitimately took over), exit instead of
+        # flapping the file back (#2201 review hardening).
+        usurper = another_heartbeat_alive()
+        if usurper is not None:
+            print(f"core_heartbeat: pid {usurper} took over the host heartbeat — "
+                  "exiting (yield instead of pid-flapping)", flush=True)
+            return 0
         try:
             write_beat(status=status)
         except Exception as e:
@@ -222,9 +281,10 @@ def main(argv: list[str] | None = None) -> int:
         # the self-guard on purpose.
         write_beat(status=args.status)
         return 0
-    other = another_heartbeat_alive()
+    other = try_acquire_ownership()
     if other is not None:
-        print(f"core_heartbeat: pid {other} is already beating for this host — "
+        who = f"pid {other}" if other > 0 else "another starter (lock held, no beat yet)"
+        print(f"core_heartbeat: {who} already owns this host's heartbeat — "
               "exiting (self-guard; the desired single-writer state already holds)",
               flush=True)
         return 0

--- a/src/core_heartbeat.py
+++ b/src/core_heartbeat.py
@@ -133,6 +133,41 @@ _STARTED_AT: float = time.time()
 _SHUTDOWN_REQUESTED = False
 
 
+def another_heartbeat_alive(staleness_s: float = 90.0) -> "int | None":
+    """Self-guard: return the pid of an ALREADY-BEATING heartbeat for this
+    host, or None if this process should take over.
+
+    "Already beating" requires ALL of: the .alive file exists, its mtime is
+    younger than `staleness_s` (the documented cross-host liveness threshold),
+    its payload names a pid, that pid is a live process, and it isn't us.
+    Anything else — missing/stale file, malformed payload, dead pid — means
+    the previous owner is gone and we take over (same recoverability stance
+    as the mtime-staleness readers).
+
+    Why: two concurrent heartbeats write the same .alive and flap it between
+    pids — harmless for mtime-liveness, but ambiguous for consumers that use
+    the pid as a control target (the pause/stop-core path, #2198). With this
+    guard a double-start (e.g. startup.sh + the schedule-crons step-5.5
+    backstop landing in the same window, #2199) resolves to exactly one
+    writer, deterministically.
+    """
+    target = _alive_path()
+    try:
+        st = target.stat()
+        if time.time() - st.st_mtime > staleness_s:
+            return None
+        pid = int(json.loads(target.read_text())["pid"])
+    except Exception:
+        return None
+    if pid == os.getpid():
+        return None
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return None
+    return pid
+
+
 def _handle_signal(signum: int, frame) -> None:
     """Mark shutdown so the loop exits at the top of the next sleep; also
     unlink the .alive file so peers see this core leave immediately rather
@@ -177,7 +212,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     if args.once:
+        # Debug/test escape hatch: --once is a forced single beat, exempt from
+        # the self-guard on purpose.
         write_beat(status=args.status)
+        return 0
+    other = another_heartbeat_alive()
+    if other is not None:
+        print(f"core_heartbeat: pid {other} is already beating for this host — "
+              "exiting (self-guard; the desired single-writer state already holds)",
+              flush=True)
         return 0
     # Anonymous, opt-out product telemetry: one event per real core boot so
     # maintainers can count active installs (OSS + desktop). No-op when opted

--- a/src/core_heartbeat.py
+++ b/src/core_heartbeat.py
@@ -163,8 +163,14 @@ def another_heartbeat_alive(staleness_s: float = 90.0) -> "int | None":
         return None
     try:
         os.kill(pid, 0)
+    except ProcessLookupError:
+        return None  # ESRCH — no such process; take over.
+    except PermissionError:
+        # EPERM — the process EXISTS but we may not signal it (sandboxed or
+        # privilege-separated launcher). That is a live heartbeat: yield.
+        return pid
     except OSError:
-        return None
+        return None  # anything else — treat as dead; staleness readers recover.
     return pid
 
 

--- a/tests/core-heartbeat-selfguard.test.py
+++ b/tests/core-heartbeat-selfguard.test.py
@@ -71,6 +71,15 @@ class SelfGuardTest(unittest.TestCase):
         self._write_alive(os.getppid(), age_s=120.0)
         self.assertIsNone(hb.another_heartbeat_alive())
 
+    def test_eperm_pid_counts_as_live(self):
+        # pid 1 (launchd/init) exists but os.kill(1, 0) raises EPERM for
+        # non-root — the Codex-found case: EXISTS-but-unsignalable must yield,
+        # not take over (a second writer would reintroduce the pid flap).
+        if os.geteuid() == 0:
+            self.skipTest("running as root: kill(1,0) would succeed, fixture invalid")
+        self._write_alive(1)
+        self.assertEqual(hb.another_heartbeat_alive(), 1)
+
     def test_malformed_payload_takes_over(self):
         target = hb._alive_path()
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/core-heartbeat-selfguard.test.py
+++ b/tests/core-heartbeat-selfguard.test.py
@@ -9,6 +9,7 @@ double-start source it defuses.
 Run: python3 tests/core-heartbeat-selfguard.test.py
 """
 
+import fcntl
 import importlib.util
 import json
 import os
@@ -115,6 +116,91 @@ class SelfGuardTest(unittest.TestCase):
         self.assertEqual(hb.main(["--once"]), 0)
         # --once overwrote the file with OUR beat (forced single write)
         self.assertEqual(json.loads(hb._alive_path().read_text())["pid"], os.getpid())
+
+    def test_flock_makes_acquisition_atomic_within_process_pair(self):
+        # Sequential sanity: first acquire wins, and after the winner beats,
+        # a second acquire attempt in ANOTHER process yields to the winner.
+        self.assertIsNone(hb.try_acquire_ownership())
+        hb.write_beat()
+        code = (
+            "import importlib.util, sys, json, os\n"
+            f"spec = importlib.util.spec_from_file_location('hb', {str(REPO / 'src' / 'core_heartbeat.py')!r})\n"
+            "m = importlib.util.module_from_spec(spec); sys.modules['hb'] = m\n"
+            "spec.loader.exec_module(m)\n"
+            f"m.CORES_DIR = __import__('pathlib').Path({str(hb.CORES_DIR)!r})\n"
+            "print(m.try_acquire_ownership())\n"
+        )
+        out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+        self.assertEqual(out.stdout.strip(), str(os.getpid()), out.stderr)
+        self._release_lock()
+
+    def test_concurrent_start_exactly_one_owner(self):
+        """The #2201 review repro, inverted into a regression test: N processes
+        pass a barrier and race try_acquire_ownership + first beat. Exactly one
+        must win; the final .alive must be valid JSON naming the winner."""
+        import multiprocessing as mp
+        ctx = mp.get_context("fork")  # fork so the CORES_DIR monkeypatch propagates
+        n = 5
+        barrier = ctx.Barrier(n)
+        q = ctx.Queue()
+
+        cores_dir = str(hb.CORES_DIR)
+
+        def racer(barrier, q, cores_dir):
+            import importlib.util as ilu
+            from pathlib import Path
+            spec = ilu.spec_from_file_location("hb_child", str(REPO / "src" / "core_heartbeat.py"))
+            m = ilu.module_from_spec(spec)
+            sys.modules["hb_child"] = m
+            spec.loader.exec_module(m)
+            m.CORES_DIR = Path(cores_dir)
+            barrier.wait()  # two-phase: everyone checks at the same instant
+            got = m.try_acquire_ownership()
+            err = ""
+            if got is None:
+                try:
+                    m.write_beat()
+                except Exception as e:  # the shared-tmp collision class
+                    err = f"{type(e).__name__}: {e}"
+            q.put((os.getpid(), got is None, err))
+            if got is None:
+                time.sleep(0.5)  # hold the flock while siblings finish checking
+
+        procs = [ctx.Process(target=racer, args=(barrier, q, cores_dir)) for _ in range(n)]
+        for p in procs:
+            p.start()
+        results = [q.get(timeout=15) for _ in range(n)]
+        for p in procs:
+            p.join(timeout=15)
+
+        owners = [pid for (pid, won, _err) in results if won]
+        errors = [err for (_pid, _won, err) in results if err]
+        self.assertEqual(len(owners), 1, f"expected exactly one owner, got {owners}; results={results}")
+        self.assertEqual(errors, [], f"owner's first beat must not collide: {errors}")
+        payload = json.loads(hb._alive_path().read_text())  # valid JSON or this raises
+        self.assertEqual(payload["pid"], owners[0])
+        # no stray shared-name staging file left behind
+        leftovers = [p.name for p in hb.CORES_DIR.iterdir() if ".tmp" in p.name]
+        self.assertEqual(leftovers, [], f"staging files left behind: {leftovers}")
+
+    def test_usurped_writer_exits_instead_of_flapping(self):
+        # A different live pid legitimately owns the file → run_forever must
+        # exit 0 before writing a single beat (the pre-beat recheck).
+        self._write_alive(os.getppid())
+        target = hb._alive_path()
+        before = target.read_text()
+        self.assertEqual(hb.run_forever(interval=0.05), 0)
+        self.assertEqual(target.read_text(), before, "usurped writer flapped the file")
+
+    def _release_lock(self):
+        # tests share one process; drop the module-held flock between cases
+        if hb._LOCK_FD is not None:
+            try:
+                fcntl.flock(hb._LOCK_FD, fcntl.LOCK_UN)
+                os.close(hb._LOCK_FD)
+            except OSError:
+                pass
+            hb._LOCK_FD = None
 
 
 if __name__ == "__main__":

--- a/tests/core-heartbeat-selfguard.test.py
+++ b/tests/core-heartbeat-selfguard.test.py
@@ -183,6 +183,33 @@ class SelfGuardTest(unittest.TestCase):
         leftovers = [p.name for p in hb.CORES_DIR.iterdir() if ".tmp" in p.name]
         self.assertEqual(leftovers, [], f"staging files left behind: {leftovers}")
 
+    def test_lock_contention_returns_holder_pid_in_process(self):
+        # flock conflicts even between two fds of the SAME process, so the
+        # contention branch is coverable in-process: first acquire holds the
+        # lock, second attempt must hit the OSError arm. With a beat on disk
+        # the holder's pid is readable; without one it's the -1 sentinel.
+        self.assertIsNone(hb.try_acquire_ownership())
+        try:
+            # no beat yet → holder unknown
+            self.assertEqual(hb.try_acquire_ownership(), -1)
+            hb.write_beat()
+            # after a beat → holder pid comes from the .alive payload
+            self.assertEqual(hb.try_acquire_ownership(), os.getpid())
+        finally:
+            self._release_lock()
+
+    def test_flock_free_but_live_prebeat_owner_yields(self):
+        # A pre-flock-build beater doesn't hold the lock but IS a live owner:
+        # flock succeeds, the freshness/pid guard still yields — and the lock
+        # must be RELEASED on that path (a second acquire attempt after the
+        # yield must not hit the contention arm).
+        self._write_alive(os.getppid())
+        self.assertEqual(hb.try_acquire_ownership(), os.getppid())
+        self.assertIsNone(hb._LOCK_FD, "yield path must not retain the lock fd")
+        # lock was released → the next acquisition conflict-checks cleanly
+        self._write_alive(os.getppid())
+        self.assertEqual(hb.try_acquire_ownership(), os.getppid())
+
     def test_usurped_writer_exits_instead_of_flapping(self):
         # A different live pid legitimately owns the file → run_forever must
         # exit 0 before writing a single beat (the pre-beat recheck).

--- a/tests/core-heartbeat-selfguard.test.py
+++ b/tests/core-heartbeat-selfguard.test.py
@@ -80,6 +80,19 @@ class SelfGuardTest(unittest.TestCase):
         self._write_alive(1)
         self.assertEqual(hb.another_heartbeat_alive(), 1)
 
+    def test_unknown_oserror_takes_over(self):
+        # non-ESRCH/EPERM OSError (e.g. EINVAL) — conservative take-over path;
+        # covers the final except arm the real-pid fixtures can't reach.
+        self._write_alive(os.getppid())
+        orig = hb.os.kill
+
+        def fake_kill(pid, sig):
+            raise OSError(22, "Invalid argument")
+
+        hb.os.kill = fake_kill
+        self.addCleanup(lambda: setattr(hb.os, "kill", orig))
+        self.assertIsNone(hb.another_heartbeat_alive())
+
     def test_malformed_payload_takes_over(self):
         target = hb._alive_path()
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/core-heartbeat-selfguard.test.py
+++ b/tests/core-heartbeat-selfguard.test.py
@@ -1,0 +1,99 @@
+"""core_heartbeat self-guard: double-starts resolve to exactly one writer.
+
+The guard yields ONLY to a fresh .alive naming a live pid that isn't us;
+missing/stale/malformed files and dead pids all mean take over. Consumers
+that use the .alive pid as a control target (pause/stop-core, #2198) depend
+on this determinism; the schedule-crons step-5.5 backstop (#2199) is the
+double-start source it defuses.
+
+Run: python3 tests/core-heartbeat-selfguard.test.py
+"""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("core_heartbeat", REPO / "src" / "core_heartbeat.py")
+hb = importlib.util.module_from_spec(spec)
+sys.modules["core_heartbeat"] = hb
+spec.loader.exec_module(hb)
+
+
+def dead_pid() -> int:
+    """A pid guaranteed dead: spawn a child that exits immediately, reap it."""
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    return proc.pid
+
+
+class SelfGuardTest(unittest.TestCase):
+    def setUp(self):
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        self._orig = hb.CORES_DIR
+        hb.CORES_DIR = Path(td.name)
+        self.addCleanup(lambda: setattr(hb, "CORES_DIR", self._orig))
+
+    def _write_alive(self, pid, age_s=0.0):
+        target = hb._alive_path()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps({"pid": pid, "host": "t", "schema_version": 2}))
+        if age_s:
+            past = time.time() - age_s
+            os.utime(target, (past, past))
+        return target
+
+    def test_no_alive_file_takes_over(self):
+        self.assertIsNone(hb.another_heartbeat_alive())
+
+    def test_fresh_alive_with_live_other_pid_yields(self):
+        # our parent is a live process that isn't us
+        self._write_alive(os.getppid())
+        self.assertEqual(hb.another_heartbeat_alive(), os.getppid())
+
+    def test_own_pid_takes_over(self):
+        # restart racing its own leftover file must not deadlock against itself
+        self._write_alive(os.getpid())
+        self.assertIsNone(hb.another_heartbeat_alive())
+
+    def test_dead_pid_takes_over(self):
+        self._write_alive(dead_pid())
+        self.assertIsNone(hb.another_heartbeat_alive())
+
+    def test_stale_file_takes_over_even_with_live_pid(self):
+        self._write_alive(os.getppid(), age_s=120.0)
+        self.assertIsNone(hb.another_heartbeat_alive())
+
+    def test_malformed_payload_takes_over(self):
+        target = hb._alive_path()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{not json")
+        self.assertIsNone(hb.another_heartbeat_alive())
+
+    def test_missing_pid_field_takes_over(self):
+        target = hb._alive_path()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps({"host": "t"}))
+        self.assertIsNone(hb.another_heartbeat_alive())
+
+    def test_main_exits_zero_without_looping_when_guarded(self):
+        self._write_alive(os.getppid())
+        # would loop forever if the guard failed; guard-hit returns 0 instantly
+        self.assertEqual(hb.main([]), 0)
+
+    def test_once_bypasses_guard(self):
+        self._write_alive(os.getppid())
+        self.assertEqual(hb.main(["--once"]), 0)
+        # --once overwrote the file with OUR beat (forced single write)
+        self.assertEqual(json.loads(hb._alive_path().read_text())["pid"], os.getpid())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

`core_heartbeat.py` has no double-start protection: two concurrent heartbeats write the same `.alive` and flap it between pids. Harmless for mtime-liveness — but ambiguous for consumers that use the **pid as a control target**, which the pause/stop-core design (#2198) is about to do. And #2199's schedule-crons step-5.5 backstop legitimately creates a second start source, so a same-window double start (supervisor restart storm, startup.sh + backstop racing the 90s mtime check) is now a real scenario. Raised as the non-blocking follow-up in #2199's review; this is that PR.

## Fix

`another_heartbeat_alive()` + a guard at the top of `main()`: yield (exit 0 — the desired single-writer state already holds) **only** when `.alive` is fresh (<90s, the documented threshold) AND names a live pid that isn't us. Missing/stale/malformed files and dead pids all mean take over — the same recoverability stance as the existing staleness readers. `--once` stays exempt (it's the forced-single-beat debug hatch).

Independent of #2199 (that PR touches only `skills/schedule-crons/SKILL.md`); no ordering constraint between them.

## Tests

New `tests/core-heartbeat-selfguard.test.py` (9): take-over on missing/stale/malformed/dead-pid/own-pid; yield on fresh live other-pid; `main()` returns 0 instantly when guarded (would hang if not); `--once` bypass writes our pid. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
