### PR TITLE
fix(tests): isolate notify-slack case i from the host's CLAUDE_CONFIG_DIR

### DIFF
--- a/tests/health-check-notify-slack.test.py
+++ b/tests/health-check-notify-slack.test.py
@@ -198,12 +198,19 @@ def case_i_token_read_prefers_channel_env() -> list[str]:
     first, then fall back to $REPO/.env.
 
     Redirects HOME (Path.home() honors $HOME on POSIX) and hc.REPO_DIR so the
-    real path-resolution code runs against temp files."""
+    real path-resolution code runs against temp files. CLAUDE_CONFIG_DIR and
+    CLAUDE_HOME must be cleared too: claude_home_path() prefers them over
+    ~/.claude, and CLAUDE_CONFIG_DIR is set on every claude-sutando install —
+    with it live, the HOME redirect is bypassed and the host's REAL channel
+    .env leaks into the assertions (3 failures on any slack-enrolled host,
+    printing the real token into test output)."""
     import os
     fails = []
     saved_home = os.environ.get("HOME")
     saved_repo = hc.REPO_DIR
     saved_env_token = os.environ.pop("SLACK_BOT_TOKEN", None)  # force the file path
+    saved_ccd = os.environ.pop("CLAUDE_CONFIG_DIR", None)
+    saved_chome = os.environ.pop("CLAUDE_HOME", None)
     try:
         with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as repo:
             os.environ["HOME"] = home
@@ -213,26 +220,36 @@ def case_i_token_read_prefers_channel_env() -> list[str]:
             (Path(repo) / ".env").write_text("SLACK_BOT_TOKEN=xoxb-from-repo\n")
             (chan / ".env").write_text('SLACK_BOT_TOKEN="xoxb-from-channel"\n')
 
+            # Never print a non-fixture value: if isolation regresses, the
+            # leaked value is the host's live bot token.
+            def masked(v):
+                fixtures = ("xoxb-from-channel", "xoxb-from-repo", "")
+                return repr(v) if v in fixtures else f"<non-fixture {len(v)}-char value, masked>"
+
             tok = hc._slack_token_from_env_file()
             if tok != "xoxb-from-channel":
-                fails.append(f"i) channel .env should win, got {tok!r}")
+                fails.append(f"i) channel .env should win, got {masked(tok)}")
 
             # Remove the channel token → must fall back to $REPO/.env.
             (chan / ".env").write_text("OTHER=1\n")
             tok2 = hc._slack_token_from_env_file()
             if tok2 != "xoxb-from-repo":
-                fails.append(f"i) fallback to $REPO/.env failed, got {tok2!r}")
+                fails.append(f"i) fallback to $REPO/.env failed, got {masked(tok2)}")
 
             # Neither present → empty string (no crash).
             (Path(repo) / ".env").write_text("OTHER=2\n")
             tok3 = hc._slack_token_from_env_file()
             if tok3 != "":
-                fails.append(f"i) absent token should be '', got {tok3!r}")
+                fails.append(f"i) absent token should be '', got {masked(tok3)}")
     finally:
         if saved_home is not None:
             os.environ["HOME"] = saved_home
         if saved_env_token is not None:
             os.environ["SLACK_BOT_TOKEN"] = saved_env_token
+        if saved_ccd is not None:
+            os.environ["CLAUDE_CONFIG_DIR"] = saved_ccd
+        if saved_chome is not None:
+            os.environ["CLAUDE_HOME"] = saved_chome
         hc.REPO_DIR = saved_repo
     return fails
 


### PR DESCRIPTION
closes #2203

## Problem

`tests/health-check-notify-slack.test.py` case i redirects `$HOME` to a temp dir to test token-path resolution — but `claude_home_path()` prefers **`$CLAUDE_CONFIG_DIR`**, which is set on every claude-sutando install. The HOME redirect is silently bypassed and the host's **real** `channels/slack/.env` resolves into the assertions.

Effect on any slack-enrolled host: 3 deterministic failures — and the failure messages print the **live bot token verbatim** into test output/CI logs/agent transcripts (see #2203; this bit us 2026-07-20 during integration-branch suite verification). Vanilla env passes, which is why CI never saw it.

## Fix (test-only, but issue-linked per queue policy)

- save/pop `CLAUDE_CONFIG_DIR` + `CLAUDE_HOME` alongside `HOME` in case i, restored in `finally` — resolution falls to the redirected `~/.claude` exactly as the fixture intends.
- mask non-fixture values in the three failure messages so a future isolation regression fails loudly **without** printing a live secret.

Supersedes #1903 (same diagnosis; auto-closed for missing issue linkage, branch since stale).

## Verification

- `CLAUDE_CONFIG_DIR` → real enrolled config dir: was 3 failures → now 10/10 pass.
- Unset (CI-like): 10/10 pass, unchanged.
- Env restoration asserted in-process after the case runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)