### PR TITLE
fix(paths): two more silent failures on paths containing a space (+ regression tests)

### DIFF
--- a/.github/workflows/bundle-smoke.yml
+++ b/.github/workflows/bundle-smoke.yml
@@ -39,4 +39,4 @@ jobs:
           node-version: '22.17.0'
       - run: npm ci
       - name: bundle smoke (build + load each artifact under plain node)
-        run: bash scripts/smoke-bundle.sh
+        run: SMOKE_SPACED_ENTRYPOINT=1 bash scripts/smoke-bundle.sh

--- a/scripts/smoke-bundle.sh
+++ b/scripts/smoke-bundle.sh
@@ -99,6 +99,40 @@ if [ -f dist/web-client.js ]; then
   fi
 fi
 
+# ── entrypoint guard under a SPACED path ────────────────────────────────────
+# The bundled install lives under "~/Library/Application Support/…"; every dev
+# checkout does not. An entrypoint guard comparing `import.meta.url` (which
+# percent-encodes) against a raw argv path is therefore false ONLY in
+# production, and the process exits 0 with no output — it has shipped three
+# times that way. This runs the real artifact from a directory whose name
+# contains a space and asserts the OBSERVABLE effect, not the source text: a
+# source-shape assertion passes for any guard that merely looks plausible.
+#
+# CI-only, same reason as smoke-startup-gate.sh case 3: a passing guard means
+# the entrypoint actually runs, which for emit-call-tiers means writing into a
+# workspace. Gated so it never fires against a developer's live install.
+if [ "${SMOKE_SPACED_ENTRYPOINT:-0}" = "1" ] && [ -f dist/emit-call-tiers.js ]; then
+  echo "── entrypoint guard: spaced path (CI-only) ──"
+  _sp_root="$(mktemp -d)"
+  _sp_dir="$_sp_root/Application Support"
+  mkdir -p "$_sp_dir"
+  cp dist/emit-call-tiers.js "$_sp_dir/"
+  # Redirect the workspace so the run cannot touch anything real. The resolver
+  # honours SUTANDO_WORKSPACE only under SUTANDO_TEST_MODE=1.
+  _sp_ws="$_sp_root/ws"; mkdir -p "$_sp_ws/state"
+  ( cd "$_sp_dir" && SUTANDO_WORKSPACE="$_sp_ws" SUTANDO_TEST_MODE=1 node ./emit-call-tiers.js ) \
+    > "$_sp_root/out.log" 2>&1 || true
+  if [ -s "$_sp_root/out.log" ] && grep -q "call-tiers written" "$_sp_root/out.log"; then
+    echo "  ✓ entrypoint ran from a path containing a space"
+  else
+    echo "  ✗ SMOKE FAIL: entrypoint did NOT run from a spaced path (guard is false in production)"
+    echo "    expected 'call-tiers written' on stdout; got:"
+    sed 's/^/      /' "$_sp_root/out.log" | head -5
+    fail=1
+  fi
+  rm -rf "$_sp_root"
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "bundle smoke FAILED — an artifact breaks at load. A dependency or dynamic import likely can't be bundled."
   exit 1

--- a/src/emit-call-tiers.ts
+++ b/src/emit-call-tiers.ts
@@ -25,7 +25,8 @@
  * entry degrades gracefully (client tries it, times out, falls back to cloud).
  * Re-emitting on a network change / core heartbeat is a documented follow-up.
  */
-import { writeFileSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs';
+import { writeFileSync, mkdirSync, readFileSync, unlinkSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 import { dirname } from 'node:path';
 import { statusPath } from './workspace_default.js';
@@ -177,7 +178,24 @@ export function releaseSingleInstance(pidFile: string, myPid: number): void {
 // startup wires this so the descriptor has a fresh advertisement each session.
 // With `--interval <sec>` (or SUTANDO_CALL_TIERS_INTERVAL_S) it stays resident
 // and re-emits on that cadence so the advertisement tracks reachability changes.
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Compare REAL PATHS, not URL strings: `import.meta.url` percent-encodes, so a
+// `file://${process.argv[1]}` template never matches a path containing a space
+// — and the desktop-bundled install lives under "~/Library/Application
+// Support/…", which always does. This guard was silently false on every
+// packaged launch, so the resident emitter never started and
+// `state/call-tiers.json` was never written (the Direct/Tailscale call tier
+// simply never appeared). Node also resolves the specifier through symlinks
+// before setting import.meta.url while argv[1] keeps what the caller typed, so
+// realpath both sides. realpathSync throws on a missing path (bare import, or
+// `node -e`), and mapping that to false keeps import-without-run intact.
+const isEntrypoint = (a: string, b: string): boolean => {
+	try {
+		return realpathSync(a) === realpathSync(b);
+	} catch {
+		return false;
+	}
+};
+if (isEntrypoint(fileURLToPath(import.meta.url), process.argv[1] ?? '')) {
 	const intervalS = parseReemitInterval();
 	if (intervalS) {
 		// Resident mode: claim the single-instance slot BEFORE any write so a

--- a/src/voice-context.ts
+++ b/src/voice-context.ts
@@ -5,6 +5,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { resolveWorkspace } from './workspace_default.js';
 import { claudeHomePath } from './util_paths.js';
 
@@ -15,7 +16,12 @@ function defaultMemoryDir(): string {
 }
 
 const MEMORY_DIR = process.env.SUTANDO_MEMORY_DIR || defaultMemoryDir();
-const REPO_DIR = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+// fileURLToPath, never `.pathname`: URL.pathname stays percent-encoded, so on
+// the desktop-bundled install ("~/Library/Application Support/…") REPO_DIR
+// became ".../Application%20Support/..." and every join() below silently
+// pointed at a path that does not exist — no error, just an empty transcript
+// and missing CLAUDE.md context.
+const REPO_DIR = fileURLToPath(new URL('..', import.meta.url)).replace(/\/$/, '');
 const WORKSPACE_DIR = resolveWorkspace();
 
 function readMemory(filename: string): string | null {

--- a/tests/path-spaces-guards.test.ts
+++ b/tests/path-spaces-guards.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression guard for the "path with a space" bug class.
+ *
+ * The desktop-bundled install runs from `~/Library/Application Support/…`,
+ * which contains a space. Every dev checkout (`~/Documents/github/…`) does not.
+ * That asymmetry means this class passes review and CI, then silently fails
+ * only for real users. It has now bitten three times:
+ *
+ *   1. session-recap slug builder                       (#2200)
+ *   2. sidecar-supervisor entrypoint guard              (ag2space-cinny-desktop#182)
+ *   3. emit-call-tiers entrypoint guard + voice-context REPO_DIR  (this change)
+ *
+ * The failure signature is always the same and always looks harmless: the
+ * process exits 0 with no output, because a guard silently evaluated false.
+ *
+ * These tests encode the two safe idioms so a regression is caught here rather
+ * than by a user noticing a feature never ran.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { realpathSync, mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/** The guard idiom used by emit-call-tiers.ts and sidecar-supervisor.mjs. */
+const isEntrypoint = (a: string, b: string): boolean => {
+	try {
+		return realpathSync(a) === realpathSync(b);
+	} catch {
+		return false;
+	}
+};
+
+test('entrypoint guard matches when the path contains a space', () => {
+	const dir = mkdtempSync(join(tmpdir(), 'sutando-spaces-'));
+	const withSpace = join(dir, 'Application Support');
+	const script = join(withSpace, 'entry.mjs');
+	try {
+		mkdirSync(withSpace, { recursive: true });
+		writeFileSync(script, '// entry\n');
+
+		// What node would hand each side: an encoded URL, and a raw argv path.
+		const metaUrl = pathToFileURL(script).href;
+		assert.ok(metaUrl.includes('%20'), 'precondition: the URL is percent-encoded');
+
+		// The OLD idiom compares an encoded URL against a raw path — never equal.
+		assert.notEqual(metaUrl, `file://${script}`, 'the bug: encoded URL !== raw path template');
+
+		// The NEW idiom compares real paths and matches.
+		assert.equal(isEntrypoint(fileURLToPath(metaUrl), script), true);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('entrypoint guard matches through a symlink', () => {
+	const dir = mkdtempSync(join(tmpdir(), 'sutando-spaces-'));
+	const script = join(dir, 'entry.mjs');
+	const link = join(dir, 'link.mjs');
+	try {
+		writeFileSync(script, '// entry\n');
+		symlinkSync(script, link);
+		// node resolves the specifier through symlinks; argv[1] keeps what the
+		// caller typed. Only realpath-on-both-sides bridges that.
+		assert.equal(isEntrypoint(fileURLToPath(pathToFileURL(script).href), link), true);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('entrypoint guard refuses to run on a bare import (no argv script)', () => {
+	// realpathSync('') throws; mapping that to false is what keeps `import()`
+	// from booting a supervisor and spawning a real core.
+	assert.equal(isEntrypoint(fileURLToPath(import.meta.url), ''), false);
+});
+
+test('URL.pathname stays percent-encoded — use fileURLToPath for filesystem paths', () => {
+	const dir = mkdtempSync(join(tmpdir(), 'sutando-spaces-'));
+	const withSpace = join(dir, 'Application Support');
+	try {
+		mkdirSync(withSpace, { recursive: true });
+		const url = pathToFileURL(join(withSpace, 'x.ts'));
+
+		// The bug: .pathname keeps %20, so any join()/readFileSync on it misses.
+		assert.ok(url.pathname.includes('%20'));
+
+		// The fix: fileURLToPath decodes back to a real filesystem path.
+		assert.ok(!fileURLToPath(url).includes('%20'));
+		assert.ok(fileURLToPath(url).includes('Application Support'));
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/tests/phone-behavior-anchors.test.ts
+++ b/tests/phone-behavior-anchors.test.ts
@@ -13,13 +13,14 @@
  * Regenerate (deliberately): ANCHOR_UPDATE=1 npx tsx tests/phone-behavior-anchors.test.ts
  * Run: npx tsx --test tests/phone-behavior-anchors.test.ts
  */
+import { fileURLToPath } from 'node:url';
 import { test } from 'node:test';
 import assert from 'node:assert';
 import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-const REPO = join(new URL('.', import.meta.url).pathname, '..');
+const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..');
 const FIXTURE = join(REPO, 'tests', 'fixtures', 'phone-behavior-anchors.json');
 const UPDATE = process.env.ANCHOR_UPDATE === '1';
 

--- a/tests/task-bridge-skip-markers.test.ts
+++ b/tests/task-bridge-skip-markers.test.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
@@ -11,7 +12,7 @@ import { join } from 'node:path';
 // already honor these via parse_markers(). This test locks in parity for the
 // TypeScript voice surface.
 
-const SRC = readFileSync(join(import.meta.dirname ?? new URL('.', import.meta.url).pathname, '..', 'src', 'task-bridge.ts'), 'utf-8');
+const SRC = readFileSync(join(import.meta.dirname ?? fileURLToPath(new URL('.', import.meta.url)), '..', 'src', 'task-bridge.ts'), 'utf-8');
 
 // Helpers — find a block by its unique anchor text, return the source after it.
 function afterBlock(anchor: string): string {

--- a/tests/voice-behavior-anchors.test.ts
+++ b/tests/voice-behavior-anchors.test.ts
@@ -22,13 +22,14 @@
  * Regenerate (deliberately): ANCHOR_UPDATE=1 npx tsx tests/voice-behavior-anchors.test.ts
  * Run: npx tsx --test tests/voice-behavior-anchors.test.ts
  */
+import { fileURLToPath } from 'node:url';
 import { test } from 'node:test';
 import assert from 'node:assert';
 import { createHash } from 'node:crypto';
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-const REPO = join(new URL('.', import.meta.url).pathname, '..');
+const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..');
 const FIXTURE = join(REPO, 'tests', 'fixtures', 'voice-behavior-anchors.json');
 const UPDATE = process.env.ANCHOR_UPDATE === '1';
 


### PR DESCRIPTION
Found by generalizing ag2space-cinny-desktop#182 — I grepped for the same pattern and both hits turned out to be live, user-visible failures on this host.

## Why this class keeps landing

The desktop-bundled install runs from `~/Library/Application Support/…` — a path with a **space**. Every dev checkout (`~/Documents/github/…`) has none. So code that compares an encoded URL against a raw path, or treats `URL.pathname` as a filesystem path, **works perfectly in dev and review, then silently no-ops for every real user**. The failure signature is always the same and always looks fine: no crash, no error, just a feature that never runs.

Prior members of the family: #2200 (session-recap slug), ag2space-cinny-desktop#182 (sidecar supervisor entrypoint — the whole supervisor arc was inert in production).

## 1. `src/emit-call-tiers.ts` — the emitter never ran

The guard was the *identical* comparison:

```js
if (import.meta.url === `file://${process.argv[1]}`)   // never true when the path has a space
```

**Proof on this host:** `state/call-tiers.json` was **absent**, despite `startup.sh` spawning `emit-call-tiers` with `--interval 60` on every boot. After the fix, the same invocation from the same directory writes the file immediately:

```
call-tiers written: /Users/…/Application Support/…/workspace/state/call-tiers.json
```

User-visible effect of the bug: the availability-driven call menu never advertised a Direct/Tailscale tier, and nothing anywhere reported an error.

## 2. `src/voice-context.ts` — REPO_DIR pointed at a nonexistent path

```js
const REPO_DIR = new URL('..', import.meta.url).pathname   // ".../Application%20Support/..."
```

`URL.pathname` stays percent-encoded, so `join(REPO_DIR, 'results/calls/calls.jsonl')` and `join(REPO_DIR, 'CLAUDE.md')` read paths that do not exist. Also silent — an empty transcript is indistinguishable from "no calls yet".

Both now use `realpathSync` / `fileURLToPath`.

## Regression tests

`tests/path-spaces-guards.test.ts` (4 tests, passing) pins the safe idioms so the next instance is caught by CI rather than by someone noticing a feature never happened:

- entrypoint guard matches when the path contains a space (and asserts the old idiom would *not*)
- matches through a symlink (node resolves the specifier; `argv[1]` does not — this was the blocking review finding on #182)
- refuses to run on a bare `import()` — preserves the guarantee that importing a module never boots a supervisor
- `URL.pathname` stays encoded; `fileURLToPath` decodes

## Verification

- 4/4 new tests pass; `tsc --noEmit` clean for the changed files.
- Behavioral check at the real space-containing path, described above (absent → written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuRpcYxqsRQsoV44E5Gh1