### PR TITLE
fix(health-check): bodhi probe scanned a path bundled installs don't have

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1117,12 +1117,37 @@ def check_bodhi_dist() -> dict:
 
     Fix when this check fails: `npm install github:sonichi/bodhi_realtime_agent`
     then `launchctl kickstart -k gui/$(id -u)/com.sutando.voice-agent`.
+
+    Scans whichever artifact the voice-agent ACTUALLY loads, because that
+    differs by deployment and the node_modules copy is not always the one
+    running:
+
+      - dev checkout  -> node_modules/bodhi-realtime-agent/dist/index.js
+      - bundled app   -> dist/voice-agent.js, an esbuild bundle with bodhi
+                         inlined and NO node_modules on disk at all
+
+    Checking only the node_modules path made this probe useless in exactly
+    the deployment where it matters: a bundled install has an empty
+    node_modules, so the check warned "run `npm install`" on every tick
+    (noise that reads as benign) while giving ZERO coverage of the running
+    bundle. The 1007 regression this was written to catch would have
+    shipped undetected. The body scan below needs no change — it matches
+    the bundled output as-is.
     """
     check = {"name": "bodhi-dist", "status": "ok", "detail": "Gemini 3.1 wire-format fixes present"}
-    dist = REPO_DIR / "node_modules" / "bodhi-realtime-agent" / "dist" / "index.js"
-    if not dist.exists():
+    # Order matters: node_modules first so a dev checkout reports on the
+    # package it actually resolves, bundle second for bundled installs.
+    candidates = [
+        REPO_DIR / "node_modules" / "bodhi-realtime-agent" / "dist" / "index.js",
+        REPO_DIR / "dist" / "voice-agent.js",
+    ]
+    dist = next((c for c in candidates if c.exists()), None)
+    if dist is None:
         check["status"] = "warn"
-        check["detail"] = "bodhi dist not found — run `npm install`"
+        check["detail"] = (
+            "no bodhi artifact found (checked node_modules and dist/voice-agent.js) — "
+            "run `npm install`, or `npm run build` for a bundled install"
+        )
         return check
     try:
         text = dist.read_text(errors="replace")
@@ -1130,13 +1155,14 @@ def check_bodhi_dist() -> dict:
         check["status"] = "warn"
         check["detail"] = f"dist read failed: {e}"
         return check
+    check["detail"] = f"Gemini 3.1 wire-format fixes present ({dist.name})"
     # Isolate the Gemini transport's sendAudio body. The OpenAI realtime
     # transport also defines sendAudio but uses `audio: base64Data` as a
     # flat string — a naive grep would false-positive.
     idx = text.find("sendAudio(base64Data) {")
     if idx < 0:
         check["status"] = "warn"
-        check["detail"] = "could not locate sendAudio in bodhi dist"
+        check["detail"] = f"could not locate sendAudio in {dist.name}"
         return check
     # Find the first two sendAudio definitions; the Gemini one wraps its
     # arg in `this.session.sendRealtimeInput(...)`.

--- a/tests/health-check-bodhi-dist.test.py
+++ b/tests/health-check-bodhi-dist.test.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Regression test: check_bodhi_dist must scan whichever bodhi artifact the
+voice-agent ACTUALLY loads, which differs by deployment.
+
+  dev checkout  -> node_modules/bodhi-realtime-agent/dist/index.js
+  bundled app   -> dist/voice-agent.js (esbuild bundle, bodhi inlined,
+                   NO node_modules on disk at all)
+
+The original implementation only checked the node_modules path. On a bundled
+install that path cannot exist, so the probe warned "run `npm install`" on
+every tick — noise that reads as benign — while giving ZERO coverage of the
+bundle actually running. Per check_bodhi_dist's own docstring it is the only
+probe for a stale bodhi (voice-agent boots fine and fails at 1007 only once a
+client connects), so the regression it exists to catch would have shipped
+undetected in exactly the deployment where it matters.
+
+The two cases that matter most here are `bundled_ok` (proves the bundled
+layout is scanned at all) and `stale_*` (proves the probe still FAILS on the
+regression — a check that passes everywhere is worthless).
+
+Run: python3 tests/health-check-bodhi-dist.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Minimal stand-ins for the two transports. The Gemini one is identified by
+# its sendRealtimeInput call; `media:` is the deprecated pre-fix key that
+# Gemini 3.1 rejects with a 1007.
+GEMINI_OK = """
+class GeminiTransport {
+  sendAudio(base64Data) {
+    if (!this.session) return;
+    this.session.sendRealtimeInput({ audio: { data: base64Data, mimeType: "audio/pcm;rate=16000" } });
+  }
+  sendFile(base64Data, mimeType) {
+    if (!this.session) return;
+    this.session.sendRealtimeInput({ video: { data: base64Data, mimeType } });
+  }
+}
+"""
+
+GEMINI_STALE_AUDIO = GEMINI_OK.replace(
+    "sendRealtimeInput({ audio: { data", "sendRealtimeInput({ media: { data"
+)
+GEMINI_STALE_FILE = GEMINI_OK.replace(
+    "sendRealtimeInput({ video: { data", "sendRealtimeInput({ media: { data"
+)
+
+
+def _load_health_check():
+    spec = importlib.util.spec_from_file_location(
+        "health_check_bodhi_test", REPO / "src" / "health-check.py"
+    )
+    hc = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(hc)
+    return hc
+
+
+class TestBodhiDistArtifactSelection(unittest.TestCase):
+    def setUp(self):
+        self.hc = _load_health_check()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.hc.REPO_DIR = self.root
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write_bundle(self, text: str) -> Path:
+        d = self.root / "dist"
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / "voice-agent.js"
+        p.write_text(text)
+        return p
+
+    def _write_node_modules(self, text: str) -> Path:
+        d = self.root / "node_modules" / "bodhi-realtime-agent" / "dist"
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / "index.js"
+        p.write_text(text)
+        return p
+
+    def test_bundled_install_is_scanned(self):
+        """The regression: a bundled install has no node_modules, and the
+        bundle must be scanned rather than reported as 'not found'."""
+        self._write_bundle(GEMINI_OK)
+        r = self.hc.check_bodhi_dist()
+        self.assertEqual(r["status"], "ok", r["detail"])
+        self.assertIn("voice-agent.js", r["detail"])
+
+    def test_dev_layout_preferred_when_present(self):
+        """A dev checkout must report on the package it actually resolves."""
+        self._write_node_modules(GEMINI_OK)
+        self._write_bundle(GEMINI_OK)
+        r = self.hc.check_bodhi_dist()
+        self.assertEqual(r["status"], "ok", r["detail"])
+        self.assertIn("index.js", r["detail"])
+
+    def test_neither_artifact_present_warns(self):
+        r = self.hc.check_bodhi_dist()
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("no bodhi artifact found", r["detail"])
+
+    def test_stale_audio_in_bundle_still_fails(self):
+        """A check that passes everywhere is worthless — the whole point of
+        this probe is catching the deprecated `media` key."""
+        self._write_bundle(GEMINI_STALE_AUDIO)
+        r = self.hc.check_bodhi_dist()
+        self.assertEqual(r["status"], "fail", r["detail"])
+        self.assertIn("sendAudio", r["detail"])
+
+    def test_stale_file_in_bundle_still_fails(self):
+        self._write_bundle(GEMINI_STALE_FILE)
+        r = self.hc.check_bodhi_dist()
+        self.assertEqual(r["status"], "fail", r["detail"])
+        self.assertIn("sendFile", r["detail"])
+
+    def test_unrecognizable_artifact_names_the_file(self):
+        """No sendAudio at all (e.g. a truncated or wrong bundle) must warn
+        and say WHICH file was scanned, so the two layouts stay
+        distinguishable in the health output."""
+        self._write_bundle("export const nothingUseful = 1;\n")
+        r = self.hc.check_bodhi_dist()
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("could not locate sendAudio", r["detail"])
+        self.assertIn("voice-agent.js", r["detail"])
+
+    def test_unreadable_artifact_warns(self):
+        """A directory where the file is expected makes read_text raise
+        OSError; the probe must degrade to a warn, not crash the tick."""
+        d = self.root / "dist" / "voice-agent.js"
+        d.mkdir(parents=True, exist_ok=True)
+        r = self.hc.check_bodhi_dist()
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("dist read failed", r["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Found while chasing a `bodhi-dist` warn that appeared on a routine health tick.

## The bug

`check_bodhi_dist` only ever looked at `node_modules/bodhi-realtime-agent/dist/index.js`. A **bundled install has no `node_modules` at all** — on this host it has exactly zero entries — and the voice-agent runs `dist/voice-agent.js`, an esbuild bundle with bodhi inlined.

Two consequences, and the second is the serious one:

1. Every health tick warned `bodhi dist not found — run npm install`. That reads as a benign setup nit, so it trains you to ignore the line.
2. **The probe gave zero coverage of the bundle that actually runs.**

Per this function's own docstring, it exists precisely because voice-agent boots fine with a stale bodhi and only fails with a 1007 once a client connects — no other probe catches that. So in the deployment where it matters most, it was scanning a file that cannot exist, while looking green-ish enough to be ignored.

## Fix

Scan whichever artifact is actually loaded: `node_modules` first so a dev checkout still reports on the package it resolves, `dist/voice-agent.js` otherwise. The scanned filename now appears in the detail so the two cases are distinguishable. Warn only when neither exists.

**The body scan is unchanged** — it already matches the bundled output, so this is purely about which file gets read.

## Verification

Exercised the patched function against four layouts:

| case | result |
| --- | --- |
| real bundled install on this host | `ok — ...present (voice-agent.js)` |
| neither artifact present | `warn — no bodhi artifact found (checked both)` |
| deliberately staled bundle | `fail — bodhi dist stale: sendFile still uses deprecated media key` |
| dev layout (both present) | `ok — ...present (index.js)` |

The third row is the one that matters: a check that passes everywhere is worthless, so I introduced a `media:`-key regression into a copy of the real bundle and confirmed the probe still fails and names the right method. (It flagged `sendFile` rather than `sendAudio` because my splice matched the indentation inside `sendFile`'s audio branch — the probe correctly reported the method I actually mutated.)

## Not addressed here

The `screen-capture not running (optional)` warn on the same tick is unrelated and genuinely pending a Screen Recording grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuRpcYxqsRQsoV44E5Gh1
