### PR TITLE
feat(health-check): surface a credential proxy that produces no quota state

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1102,6 +1102,53 @@ def check_voice_transport(voice_check: dict) -> dict:
     return check
 
 
+def check_quota_telemetry(proxy_status: str) -> dict:
+    """Warn when the credential proxy is up but producing no quota state.
+
+    quota-state.json is written by the proxy from the quota headers on
+    upstream responses, so it only appears if a core actually ROUTES through
+    the proxy. `src/startup.sh` is the only thing that exports
+    ANTHROPIC_BASE_URL=http://localhost:7846 — and a core launched by the
+    desktop supervisor never runs startup.sh. Result on such a host: the
+    proxy is healthy and listening, every check is green, and quota
+    telemetry is silently absent forever. The proactive loop's per-pass
+    budget check reads "unknown" on every pass and nobody is told why.
+
+    The existing credential-proxy check can't catch this: it is a plain
+    TCP-listening probe (correctly so — a forwarding proxy has no liveness
+    endpoint), so "listening" is all it can ever assert.
+
+    Deliberately narrow to stay quiet in the legitimate cases:
+      - proxy not up          -> silent. Not every host routes through it,
+                                 and its own check already says so.
+      - file present          -> ok, with its age. NOT stale-checked: a quiet
+                                 core legitimately writes nothing for a long
+                                 time, so an age threshold would fire on
+                                 healthy idle hosts. Absence is the signal
+                                 that actually distinguishes broken wiring.
+    """
+    check = {"name": "quota-telemetry", "status": "ok"}
+    if proxy_status != "ok":
+        check["detail"] = "credential proxy not running — quota telemetry not expected"
+        return check
+    path = status_read_path("quota-state.json", WORKSPACE_DIR)
+    if path.exists():
+        try:
+            age_min = int((time.time() - path.stat().st_mtime) / 60)
+            check["detail"] = f"quota state present (updated {age_min}m ago)"
+        except OSError:
+            check["detail"] = "quota state present"
+        return check
+    check["status"] = "warn"
+    check["detail"] = (
+        "credential proxy is up but has never written quota-state.json — "
+        "nothing is routing through it (ANTHROPIC_BASE_URL unset; set by "
+        "src/startup.sh, which a supervisor-launched core never runs). "
+        "Quota-based budgeting is blind on this host."
+    )
+    return check
+
+
 def check_bodhi_dist() -> dict:
     """Verify the installed bodhi-realtime-agent dist has the Gemini 3.1
     wire-format fixes applied. Greps the Gemini sendAudio/sendFile bodies
@@ -1746,6 +1793,9 @@ def run_all_checks() -> list[dict]:
         proxy_check["status"] = "warn"
         proxy_check["detail"] = "not running (optional)"
     checks.append(proxy_check)
+
+    # Quota telemetry — only meaningful when the proxy is actually up.
+    checks.append(check_quota_telemetry(proxy_check["status"]))
 
     # macOS TCC — must come before critical-file checks so if TCC is blocking
     # everything, the operator sees the root cause before the downstream failures.

--- a/tests/health-check-quota-telemetry.test.py
+++ b/tests/health-check-quota-telemetry.test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Regression test: check_quota_telemetry must surface a proxy that is up but
+producing no quota state.
+
+The gap it covers: quota-state.json is written by the credential proxy from
+upstream response headers, so it only appears if a core actually ROUTES
+through the proxy. src/startup.sh is the only thing exporting
+ANTHROPIC_BASE_URL=http://localhost:7846, and a supervisor-launched core
+never runs startup.sh. On such a host the proxy is healthy and listening,
+every check is green, and quota telemetry is silently absent forever — the
+proactive loop's budget check reads "unknown" every pass with no explanation.
+
+The pre-existing credential-proxy check cannot catch this: it is a plain
+TCP-listening probe (correct for a forwarding proxy with no liveness
+endpoint), so "listening" is the most it can ever assert.
+
+Run: python3 tests/health-check-quota-telemetry.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+import importlib.util
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load_health_check():
+    spec = importlib.util.spec_from_file_location(
+        "health_check_quota_test", REPO / "src" / "health-check.py"
+    )
+    hc = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(hc)
+    return hc
+
+
+class TestQuotaTelemetryCheck(unittest.TestCase):
+    def setUp(self):
+        self.hc = _load_health_check()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+        (self.ws / "state").mkdir(parents=True, exist_ok=True)
+        self.hc.WORKSPACE_DIR = self.ws
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write_quota(self, mtime_age_sec: float = 0.0) -> Path:
+        p = self.ws / "state" / "quota-state.json"
+        p.write_text('{"remaining_pct": 42}')
+        if mtime_age_sec:
+            past = time.time() - mtime_age_sec
+            os.utime(p, (past, past))
+        return p
+
+    def test_proxy_up_but_no_quota_state_warns(self):
+        """The actual bug: green everywhere, telemetry silently dead."""
+        r = self.hc.check_quota_telemetry("ok")
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("never written quota-state.json", r["detail"])
+        # The detail must name the cause, not just the symptom — otherwise the
+        # reader has no idea why an up proxy produces nothing.
+        self.assertIn("ANTHROPIC_BASE_URL", r["detail"])
+
+    def test_proxy_down_stays_silent(self):
+        """Not every host routes through the proxy, and its own check already
+        reports it as down. Warning twice would be noise."""
+        for status in ("warn", "down"):
+            r = self.hc.check_quota_telemetry(status)
+            self.assertEqual(r["status"], "ok", f"status={status}")
+            self.assertIn("not expected", r["detail"])
+
+    def test_quota_state_present_is_ok_with_age(self):
+        self._write_quota()
+        r = self.hc.check_quota_telemetry("ok")
+        self.assertEqual(r["status"], "ok")
+        self.assertIn("present", r["detail"])
+
+    def test_old_quota_state_does_not_warn(self):
+        """Deliberate: a quiet core legitimately writes nothing for a long
+        time. An age threshold would fire on healthy idle hosts, so absence —
+        not staleness — is the signal. Pin it so nobody 'improves' this into
+        a flaky check later."""
+        self._write_quota(mtime_age_sec=60 * 60 * 24 * 3)
+        r = self.hc.check_quota_telemetry("ok")
+        self.assertEqual(r["status"], "ok")
+        self.assertIn("4320m ago", r["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-quota-telemetry.test.py
+++ b/tests/health-check-quota-telemetry.test.py
@@ -23,6 +23,7 @@ import os
 import tempfile
 import time
 import unittest
+from unittest import mock
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -88,6 +89,22 @@ class TestQuotaTelemetryCheck(unittest.TestCase):
         r = self.hc.check_quota_telemetry("ok")
         self.assertEqual(r["status"], "ok")
         self.assertIn("4320m ago", r["detail"])
+
+    def test_stat_failure_still_reports_present(self):
+        """`exists()` true but `stat()` raising is rare (file removed mid-check,
+        permissions changed) — but a health tick must degrade to a less precise
+        detail, never raise. Without this guard one unlucky race takes down the
+        whole check run, which is strictly worse than losing the age string."""
+        self._write_quota()
+        # `exists()` calls stat() internally and swallows OSError by returning
+        # False — patching stat alone would silently exercise the ABSENT branch
+        # instead, so exists() is pinned True to isolate the one being tested.
+        with mock.patch.object(Path, "exists", return_value=True), mock.patch.object(
+            Path, "stat", side_effect=OSError("boom")
+        ):
+            r = self.hc.check_quota_telemetry("ok")
+        self.assertEqual(r["status"], "ok")
+        self.assertEqual(r["detail"], "quota state present")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Found while running the proactive loop's own budget check, which has been reading "unknown" on every pass on this machine.

## The gap

`quota-state.json` is written by the credential proxy from quota headers on upstream responses. It therefore only appears if a core actually **routes through** the proxy. `src/startup.sh` is the only thing that exports `ANTHROPIC_BASE_URL=http://localhost:7846` — and **a core launched by the desktop supervisor never runs startup.sh**.

So on this host: proxy alive on 7846 for hours, every health check green, and quota telemetry silently absent forever. Nothing tells you why.

The existing `credential-proxy` check can't catch it, and shouldn't be changed to: it's a plain TCP-listening probe, correct for a forwarding proxy with no liveness endpoint. "Listening" is the most it can assert. This is the same alive-is-not-working gap one layer up — the proxy is genuinely fine; it just has no traffic.

## Deliberately narrow

| condition | result |
| --- | --- |
| proxy not up | **silent** — not every host routes through it, and the proxy's own check already says so |
| quota-state present | ok, with age |
| quota-state absent | warn, naming the **cause** (unset `ANTHROPIC_BASE_URL`), not just the symptom |

It explicitly does **not** stale-check the file. A quiet core legitimately writes nothing for a long time, so an age threshold would fire on healthy idle hosts. Absence is what actually separates broken wiring from an idle one. There's a test pinning that specifically so it doesn't get "improved" into a flaky check later.

## What this does not do

It does **not** change routing. Exporting `ANTHROPIC_BASE_URL` into a running core changes its auth path — that's a deployment decision, not something a health check should do as a side effect. This just makes the situation visible so it can be decided deliberately.

## Verification

Four tests. Verified by mutation rather than by coverage percentage — flipping the warn branch to `ok` fails the relevant test. Also ran the check against this live host, where it correctly warns:

```
warn: credential proxy is up but has never written quota-state.json —
nothing is routing through it (ANTHROPIC_BASE_URL unset; set by
src/startup.sh, which a supervisor-launched core never runs).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuRpcYxqsRQsoV44E5Gh1
