### PR TITLE
fix(health-check): a dangling skill symlink counted as linked (closes #2213)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1486,23 +1486,58 @@ def check_skill_symlinks() -> dict:
     if not skills_dst.exists():
         return {"name": name, "status": "ok", "detail": "~/.claude/skills/ not found — skipped"}
 
-    unlinked: list[str] = []
+    # A DANGLING symlink (entry present, target gone) is the case the original
+    # condition let through: `exists()` follows the link and is False, but
+    # `is_symlink()` is True, so `not exists and not is_symlink` is False and the
+    # skill counted as linked. Claude Code cannot load it either way, so it was
+    # invisible AND reported healthy. Tracked as #2213.
+    unlinked: list[str] = []   # no entry at all -> symlink_to() works
+    broken: list[str] = []     # dangling link  -> must be unlinked first
     for skill_dir in sorted(skills_src.iterdir()):
         if not skill_dir.is_dir():
             continue
         skill_name = skill_dir.name
         dst = skills_dst / skill_name
-        if not dst.exists() and not dst.is_symlink():
+        if dst.is_symlink() and not dst.exists():
+            broken.append(skill_name)
+        elif not dst.exists() and not dst.is_symlink():
             unlinked.append(skill_name)
 
-    if not unlinked:
+    # Dangling links whose skill is NOT in this repo are missed by the loop
+    # above, which only walks repo skills. They are still dead entries that make
+    # a skill silently unloadable, so sweep the destination too. Reported, never
+    # auto-removed: the target may belong to another checkout that is simply
+    # not mounted right now, and deleting someone else's link is not this
+    # check's call.
+    orphaned: list[str] = []
+    try:
+        repo_names = {d.name for d in skills_src.iterdir() if d.is_dir()}
+        for entry in sorted(skills_dst.iterdir()):
+            if entry.name in repo_names:
+                continue
+            if entry.is_symlink() and not entry.exists():
+                orphaned.append(entry.name)
+    except OSError:
+        pass
+
+    if not unlinked and not broken and not orphaned:
         return {"name": name, "status": "ok", "detail": f"all {sum(1 for d in skills_src.iterdir() if d.is_dir())} skills linked"}
+
+    parts = []
+    if broken:
+        parts.append(f"{len(broken)} dangling: {', '.join(broken[:4])}{'...' if len(broken) > 4 else ''}")
+    if unlinked:
+        parts.append(f"{len(unlinked)} unlinked: {', '.join(unlinked[:4])}{'...' if len(unlinked) > 4 else ''}")
+    if orphaned:
+        parts.append(f"{len(orphaned)} dangling not in this repo: {', '.join(orphaned[:4])}{'...' if len(orphaned) > 4 else ''}")
 
     return {
         "name": name,
         "status": "warn",
-        "detail": f"{len(unlinked)} unlinked skill(s): {', '.join(unlinked[:5])}{'...' if len(unlinked) > 5 else ''}",
+        "detail": "; ".join(parts),
         "_unlinked": unlinked,
+        "_broken": broken,
+        "_orphaned": orphaned,
         "_skills_src": str(skills_src),
         "_skills_dst": str(skills_dst),
     }
@@ -1511,14 +1546,21 @@ def check_skill_symlinks() -> dict:
 def fix_skill_symlinks(check: dict) -> dict:
     """Create missing symlinks for unlinked skills (--fix handler)."""
     unlinked = check.get("_unlinked", [])
+    broken = check.get("_broken", [])
     skills_src = Path(check.get("_skills_src", ""))
     skills_dst = Path(check.get("_skills_dst", ""))
     created: list[str] = []
     errors: list[str] = []
-    for skill_name in unlinked:
+    for skill_name in list(broken) + list(unlinked):
         src = skills_src / skill_name
         dst = skills_dst / skill_name
         try:
+            # A dangling link occupies the name: symlink_to() would raise
+            # FileExistsError, so --fix could not repair the very case it was
+            # meant to. Guard on is_symlink() so a real directory is never
+            # removed by a health check.
+            if dst.is_symlink() and not dst.exists():
+                dst.unlink()
             dst.symlink_to(src)
             created.append(skill_name)
         except Exception as e:
@@ -1535,7 +1577,7 @@ def apply_skill_symlink_fixes(checks: list) -> None:
     """--fix dispatch for skill-symlinks: warn-level (excluded from the issues
     loop) but auto-fixable, so it is handled by its own pass over checks."""
     for c in checks:
-        if c["name"] == "skill-symlinks" and c.get("_unlinked"):
+        if c["name"] == "skill-symlinks" and (c.get("_unlinked") or c.get("_broken")):
             result = fix_skill_symlinks(c)
             print(f"  {c['name']}: {result['detail']}")
 

--- a/tests/health-check-dangling-symlinks.test.py
+++ b/tests/health-check-dangling-symlinks.test.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import importlib.util
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -119,6 +120,29 @@ class TestDanglingSkillSymlinks(unittest.TestCase):
         check = self.hc.check_skill_symlinks()
         self.hc.fix_skill_symlinks(check)
         self.assertTrue((real / "keep.txt").exists(), "real dir must survive --fix")
+
+
+    def test_unreadable_destination_dir_does_not_crash_the_tick(self):
+        """The destination sweep walks a directory that can disappear or become
+        unreadable between the earlier exists() check and iteration (races,
+        permissions, an unmounted volume). A health check must degrade to
+        "no orphans found" rather than raise — one bad tick would take down
+        every check after it, which is strictly worse than under-reporting."""
+        self._skill("alpha")
+        (self.dst / "alpha").symlink_to(self.src / "alpha")
+        real_iterdir = Path.iterdir
+
+        def boom(self_path):
+            # Only the destination sweep should blow up; the repo scan above it
+            # must still run, otherwise this proves nothing about the guard.
+            if self_path == self.dst:
+                raise OSError("permission denied")
+            return real_iterdir(self_path)
+
+        with mock.patch.object(Path, "iterdir", boom):
+            r = self.hc.check_skill_symlinks()
+        self.assertEqual(r["status"], "ok", r["detail"])
+        self.assertEqual(r.get("_orphaned", []), [])
 
 
 if __name__ == "__main__":

--- a/tests/health-check-dangling-symlinks.test.py
+++ b/tests/health-check-dangling-symlinks.test.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Regression test: a DANGLING skill symlink must not count as linked (#2213).
+
+The original condition was:
+
+    if not dst.exists() and not dst.is_symlink():
+
+`exists()` follows the link, so it is False for a dangling one — but
+`is_symlink()` is True, making the whole condition False. A dangling entry was
+therefore reported as linked. Claude Code cannot load such a skill, so it was
+simultaneously invisible and green: the exact "reports healthy while doing
+nothing" shape.
+
+Measured on a live host before the fix: 14 dangling links out of 67 entries,
+health-check reporting "all 51 skills linked".
+
+Second layer: even once detected, `--fix` could not repair it. The dangling
+link occupies the name, so `symlink_to()` raises FileExistsError. Verified
+empirically before writing this.
+
+Run: python3 tests/health-check-dangling-symlinks.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "health_check_symlink_test", REPO / "src" / "health-check.py"
+    )
+    hc = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(hc)
+    return hc
+
+
+class TestDanglingSkillSymlinks(unittest.TestCase):
+    def setUp(self):
+        self.hc = _load()
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.repo = root / "repo"
+        self.src = self.repo / "skills"
+        self.dst = root / "home" / ".claude" / "skills"
+        self.src.mkdir(parents=True)
+        self.dst.mkdir(parents=True)
+        self.hc.REPO_DIR = self.repo
+        # check_skill_symlinks hardcodes Path.home(); redirect it.
+        self._home = root / "home"
+        self.hc.Path.home = staticmethod(lambda: self._home)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _skill(self, name: str) -> Path:
+        d = self.src / name
+        d.mkdir()
+        (d / "SKILL.md").write_text("# x\n")
+        return d
+
+    def test_dangling_link_is_not_reported_as_linked(self):
+        """The bug. Before the fix this returned ok/'all 1 skills linked'."""
+        self._skill("alpha")
+        (self.dst / "alpha").symlink_to(self.src / "gone-elsewhere")
+        r = self.hc.check_skill_symlinks()
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("dangling", r["detail"])
+        self.assertEqual(r["_broken"], ["alpha"])
+
+    def test_healthy_link_still_ok(self):
+        self._skill("alpha")
+        (self.dst / "alpha").symlink_to(self.src / "alpha")
+        r = self.hc.check_skill_symlinks()
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    def test_missing_and_dangling_are_reported_separately(self):
+        """They need different remediation — one needs unlinking first — so
+        collapsing them into one bucket would make --fix wrong for half."""
+        self._skill("alpha")
+        self._skill("beta")
+        (self.dst / "alpha").symlink_to(self.src / "gone")
+        r = self.hc.check_skill_symlinks()
+        self.assertEqual(r["_broken"], ["alpha"])
+        self.assertEqual(r["_unlinked"], ["beta"])
+
+    def test_dangling_link_for_a_skill_not_in_this_repo_is_still_flagged(self):
+        """The repo-driven loop only walks repo skills, so a dead entry from
+        another checkout would be missed entirely."""
+        self._skill("alpha")
+        (self.dst / "alpha").symlink_to(self.src / "alpha")
+        (self.dst / "from-another-clone").symlink_to(self.src / "nowhere")
+        r = self.hc.check_skill_symlinks()
+        self.assertEqual(r["status"], "warn")
+        self.assertEqual(r["_orphaned"], ["from-another-clone"])
+
+    def test_fix_repairs_a_dangling_link(self):
+        """--fix must unlink first; symlink_to() alone raises FileExistsError,
+        so before this the fix could not repair the case it existed for."""
+        self._skill("alpha")
+        (self.dst / "alpha").symlink_to(self.src / "gone")
+        check = self.hc.check_skill_symlinks()
+        res = self.hc.fix_skill_symlinks(check)
+        self.assertEqual(res["status"], "ok", res["detail"])
+        self.assertTrue((self.dst / "alpha").exists())
+        self.assertEqual((self.dst / "alpha").resolve(), (self.src / "alpha").resolve())
+
+    def test_fix_never_removes_a_real_directory(self):
+        """The unlink guard must be is_symlink()-gated — a health check must
+        not delete real content under any circumstances."""
+        self._skill("alpha")
+        real = self.dst / "alpha"
+        real.mkdir()
+        (real / "keep.txt").write_text("important")
+        check = self.hc.check_skill_symlinks()
+        self.hc.fix_skill_symlinks(check)
+        self.assertTrue((real / "keep.txt").exists(), "real dir must survive --fix")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #2213.

## The bug

```python
if not dst.exists() and not dst.is_symlink():
```

`exists()` follows the link, so it's False for a dangling entry — but `is_symlink()` is True, so the whole condition is False and the skill **counted as linked**. Claude Code can't load it either way, so the skill was invisible *and* green.

On this host: **14 dangling entries out of 67**, while health-check printed `all 51 skills linked`.

## Both layers were blind

Before writing anything I checked whether `--fix` could repair it once detected. It couldn't — the dangling link occupies the name, so `symlink_to()` raises `FileExistsError`. So flipping the condition alone would have produced a warning nobody could action.

## Why the minimal fix would have found nothing here

The scan walks **repo** skills and checks each for a link. But on this host **all 14 dead entries are for skills not in this repo** — left behind by another checkout. The repo-driven loop never visits those names, so simply correcting the condition would still report zero on the machine that has the problem.

Hence the destination sweep. It's reported but **never auto-removed**: the target may belong to a checkout that just isn't mounted right now, and deleting another tool's symlink isn't a health check's call.

## Changes

1. Dangling classified separately from missing — different remediation, so one bucket makes `--fix` wrong for half.
2. Destination sweep for dead entries outside this repo.
3. `--fix` unlinks before relinking, guarded on `is_symlink()` so a real directory is never removed.

## Verification

Six tests, **verified by mutation** — restoring the original condition fails three of them — and against the live host, where it now warns with the same 14 an independent manual count found:

```
warn: 14 dangling not in this repo: calendar-prep, catchup-after-startup, code-reviewer, commute-and-weather...
```

One test specifically pins that `--fix` never deletes a real directory.

## Honest note

#2213 says 15 dangling; I measure 14. Same substance, presumably counted at a different moment.

I also found this bug in my own verification code first — I'd reported "0 dangling" earlier today using `for n in */`, which matches directories only and so could never see a dangling link. Same blind spot, different language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuRpcYxqsRQsoV44E5Gh1
