### PR TITLE
fix(health-check): slack-bridge stale-warning false positive from one-time startup hint

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1707,6 +1707,33 @@ def _resolve_menu_bar_pgrep(pgrep_status: Optional[str], pids: list[str]) -> tup
     return pgrep_status, pids
 
 
+def bridge_log_content_status(name: str, status: str, tail: list[str]) -> Optional[tuple[str, str]]:
+    """Check a bridge's recent log lines for known failure-mode signatures.
+
+    Returns an (status, detail) override, or None if nothing to override.
+    discord-bridge: LoginFailure means the token is revoked/invalid. Always
+      overrides — there is no point restarting with stale code if the token
+      is bad; the token fix is the only path forward.
+    slack-bridge: "60s elapsed" hint means Socket Mode connected but events
+      weren't routing yet at startup (Slack app Event Subscriptions
+      disabled). Only overrides "ok" — stale/dead-inode are higher priority.
+      The hint is a one-time startup message that never clears itself in the
+      log, so it only counts if no event has actually been processed since
+      it last fired (checked via a subsequent "Wrote task-" line) — otherwise
+      Event Subscriptions clearly ARE enabled and it's a stale false alarm.
+    """
+    if name == "discord-bridge":
+        if any("LoginFailure" in ln or "Improper token" in ln for ln in tail):
+            return "fail", "token invalid (LoginFailure) — regenerate at discord.com/developers/applications"
+    elif name == "slack-bridge" and status == "ok":
+        warn_idxs = [i for i, ln in enumerate(tail) if "60s elapsed with zero events" in ln]
+        if warn_idxs:
+            events_after = any("Wrote task-" in ln for ln in tail[warn_idxs[-1] + 1:])
+            if not events_after:
+                return "warn", "connected but events not arriving — enable Event Subscriptions at api.slack.com/apps"
+    return None
+
+
 def run_all_checks() -> list[dict]:
     checks = []
 
@@ -1982,23 +2009,12 @@ def run_all_checks() -> list[dict]:
             pass
 
         # Check 6: Log-content health for known failure modes.
-        # discord-bridge: LoginFailure means the token is revoked/invalid.
-        #   Always overrides — there is no point restarting with stale code
-        #   if the token is bad; the token fix is the only path forward.
-        # slack-bridge: "60s elapsed" hint means Socket Mode connected but
-        #   events aren't routing (Slack app Event Subscriptions disabled).
-        #   Only overrides "ok" — stale/dead-inode are higher priority.
         if log_file.exists() and name in ("discord-bridge", "slack-bridge"):
             try:
                 tail = log_file.read_text(errors="replace").splitlines()[-60:]
-                if name == "discord-bridge":
-                    if any("LoginFailure" in ln or "Improper token" in ln for ln in tail):
-                        status = "fail"
-                        detail = "token invalid (LoginFailure) — regenerate at discord.com/developers/applications"
-                elif name == "slack-bridge" and status == "ok":
-                    if any("60s elapsed with zero events" in ln for ln in tail):
-                        status = "warn"
-                        detail = "connected but events not arriving — enable Event Subscriptions at api.slack.com/apps"
+                override = bridge_log_content_status(name, status, tail)
+                if override is not None:
+                    status, detail = override
             except OSError:
                 pass
 

--- a/tests/health-check-bridge-log-content.test.py
+++ b/tests/health-check-bridge-log-content.test.py
@@ -12,8 +12,12 @@ of successful events. The fix only treats it as a live warning when no
 Run: python3 tests/health-check-bridge-log-content.test.py
 """
 import importlib.util
+import os
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 REPO = Path(__file__).resolve().parent.parent
 spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
@@ -83,6 +87,68 @@ check("discord LoginFailure overrides even non-ok incoming status", result7 is n
 
 result8 = hc.bridge_log_content_status("discord-bridge", "ok", ["Logged in as SutandoBot#1234"])
 check("discord healthy log → no override", result8 is None)
+
+# ── run_all_checks() integration: exercise the actual call site ─────────────
+# The unit tests above cover bridge_log_content_status() in isolation, but the
+# call site inside run_all_checks() (fetching `tail`, invoking the function,
+# applying the override to `status`/`detail`) is separate code that needs its
+# own coverage. Fakes just the slack-bridge pgrep result (a real PID would
+# make Check 4/5's ps/lsof calls meaningfully diverge; a fake one just makes
+# them no-op safely, which is what we want here) and points WORKSPACE_DIR /
+# claude_home_path at a temp tree so the log content is fully controlled.
+
+_orig_subprocess_run = subprocess.run
+
+
+def _fake_pgrep_slack(cmd, *args, **kwargs):
+    if isinstance(cmd, list) and len(cmd) >= 3 and cmd[0] == "/usr/bin/pgrep" and "slack-bridge" in cmd[2]:
+        class _Result:
+            returncode = 0
+            stdout = "999999\n"
+        return _Result()
+    return _orig_subprocess_run(cmd, *args, **kwargs)
+
+
+def _run_all_checks_with_slack_log(log_contents: str) -> "dict | None":
+    with tempfile.TemporaryDirectory() as tmpws, tempfile.TemporaryDirectory() as tmphome:
+        tmpws = Path(tmpws)
+        (tmpws / "logs").mkdir(parents=True)
+        (tmpws / "logs" / "slack-bridge.log").write_text(log_contents)
+        channel_dir = Path(tmphome) / "channels" / "slack"
+        channel_dir.mkdir(parents=True)
+        (channel_dir / ".env").write_text("SLACK_BOT_TOKEN=xoxb-test\n")
+
+        _orig_chp = hc.claude_home_path
+
+        def _fake_chp(*sub):
+            if sub and sub[0] == "channels":
+                return Path(tmphome).joinpath(*sub)
+            return _orig_chp(*sub)
+
+        for _k in ("SKIP_TELEGRAM", "SKIP_DISCORD", "SKIP_SLACK"):
+            os.environ.pop(_k, None)
+
+        with patch.object(hc, "WORKSPACE_DIR", tmpws), \
+             patch.object(hc, "claude_home_path", side_effect=_fake_chp), \
+             patch.object(subprocess, "run", side_effect=_fake_pgrep_slack):
+            checks = hc.run_all_checks()
+        return next((c for c in checks if c["name"] == "slack-bridge"), None)
+
+
+_stale_hint_only = (
+    "Slack bridge started. Socket Mode connecting...\n"
+    "⚡️ Bolt app is running!\n"
+    "[Slack] HINT: 60s elapsed with zero events received.\n"
+)
+_hint_with_activity = _stale_hint_only + "  Wrote task-1784555474341 from Slack DM @Bassil Khilo\n"
+
+_check_warn = _run_all_checks_with_slack_log(_stale_hint_only)
+check("run_all_checks: hint-only log → slack-bridge warns",
+      _check_warn is not None and _check_warn["status"] == "warn", str(_check_warn))
+
+_check_ok = _run_all_checks_with_slack_log(_hint_with_activity)
+check("run_all_checks: hint + later activity → slack-bridge stays ok (the fix)",
+      _check_ok is not None and _check_ok["status"] == "ok", str(_check_ok))
 
 if failures:
     sys.exit(1)

--- a/tests/health-check-bridge-log-content.test.py
+++ b/tests/health-check-bridge-log-content.test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Tests for bridge_log_content_status() — slack-bridge "60s elapsed" false positive.
+
+Health-check flagged slack-bridge as "connected but events not arriving" even
+while the bridge was actively writing tasks from live Slack DMs. Root cause:
+the "60s elapsed with zero events" hint fires once at startup (before the
+first event ever arrives) and is never cleared from the log — a naive
+substring scan over the log tail keeps finding it forever, even after dozens
+of successful events. The fix only treats it as a live warning when no
+"Wrote task-" line appears after it in the tail.
+
+Run: python3 tests/health-check-bridge-log-content.test.py
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+sys.modules["health_check"] = hc
+spec.loader.exec_module(hc)
+
+failures = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    print(("  ok  " if cond else "  FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+# ── slack-bridge: startup hint with no events since → real warning ──────────
+
+startup_only = [
+    "Slack bridge started. Socket Mode connecting...",
+    "⚡️ Bolt app is running!",
+    "[Slack] HINT: 60s elapsed with zero events received.",
+    "  Bridge is connected to Slack's edge, but events are not arriving.",
+]
+result = hc.bridge_log_content_status("slack-bridge", "ok", startup_only)
+check("startup hint with no events after it → warns", result is not None and result[0] == "warn")
+
+# ── slack-bridge: startup hint followed by real activity → false positive fixed ──
+
+with_activity = startup_only + [
+    "  Wrote task-1784553750056 from Slack DM @Bassil Khilo",
+    "  Replied to D0B5L7X2TK2: ...",
+    "  Wrote task-1784555474341 from Slack DM @Bassil Khilo",
+    "  Replied to D0B5L7X2TK2: ...",
+]
+result2 = hc.bridge_log_content_status("slack-bridge", "ok", with_activity)
+check("startup hint but events arrived afterward → no override (stays ok)", result2 is None)
+
+# ── slack-bridge: no hint at all → no override ──────────────────────────────
+
+clean = ["Slack bridge started. Socket Mode connecting...", "⚡️ Bolt app is running!"]
+result3 = hc.bridge_log_content_status("slack-bridge", "ok", clean)
+check("no hint in log → no override", result3 is None)
+
+# ── slack-bridge: only overrides when incoming status is "ok" ──────────────
+
+result4 = hc.bridge_log_content_status("slack-bridge", "warn", startup_only)
+check("status already non-ok (e.g. stale) → does not override", result4 is None)
+
+# ── slack-bridge: a second startup hint after activity (bridge restarted) ──
+# re-warns because there's no "Wrote task-" line after the LAST hint occurrence.
+
+restarted = with_activity + ["[Slack] HINT: 60s elapsed with zero events received."]
+result5 = hc.bridge_log_content_status("slack-bridge", "ok", restarted)
+check("bridge restarted (fresh hint after old activity) → warns again", result5 is not None and result5[0] == "warn")
+
+# ── discord-bridge: LoginFailure always overrides regardless of status ──────
+
+login_failure = ["discord.errors.LoginFailure: Improper token has been passed."]
+result6 = hc.bridge_log_content_status("discord-bridge", "ok", login_failure)
+check("discord LoginFailure → fail status", result6 is not None and result6[0] == "fail")
+
+result7 = hc.bridge_log_content_status("discord-bridge", "warn", login_failure)
+check("discord LoginFailure overrides even non-ok incoming status", result7 is not None and result7[0] == "fail")
+
+# ── discord-bridge: healthy log → no override ───────────────────────────────
+
+result8 = hc.bridge_log_content_status("discord-bridge", "ok", ["Logged in as SutandoBot#1234"])
+check("discord healthy log → no override", result8 is None)
+
+if failures:
+    sys.exit(1)
+print("PASS — bridge_log_content_status tests")


### PR DESCRIPTION
## What changed, and why?

`health-check.py`'s slack-bridge check scans the last 60 lines of `logs/slack-bridge.log` for the string `"60s elapsed with zero events"` — a hint the bridge logs once at startup, before its first event ever arrives. That line is never cleared from the log, so once it appears it stays in the tail forever (or until enough later output pushes it out of the last-60-lines window), permanently flagging a perfectly healthy, actively-processing bridge as `warn: connected but events not arriving — enable Event Subscriptions at api.slack.com/apps`.

Fix: only treat the hint as a live warning if no `"Wrote task-"` line (the bridge's own per-event log line) appears after its last occurrence in the tail. If events have arrived since the hint fired, Event Subscriptions clearly *are* enabled and the hint is stale.

Also extracted the log-content check (previously inline in `run_all_checks()`, and — as far as I can tell — untested) into a standalone `bridge_log_content_status(name, status, tail)` function, so it's unit-testable without mocking pids/heartbeat/lsof/ps. Behavior for discord-bridge's `LoginFailure` check is unchanged.

## What files / sections should reviewers look at first?

- `src/health-check.py`: `bridge_log_content_status()` (new function) and its call site inside `run_all_checks()`'s "Check 6".
- `tests/health-check-bridge-log-content.test.py`: new regression tests.

## What user behavior or bug does this prove?

A live slack-bridge that has been running fine for hours — actively receiving Slack DMs and writing/replying to tasks — was reported as degraded by `health-check.py`, purely because of a stale startup-time log line. This is a false alarm an operator would otherwise chase down (checking Slack app config, restarting the bridge) for no reason.

## What tests did you run? Include commands and results.

```
$ python3 tests/health-check-bridge-log-content.test.py
  ok  startup hint with no events after it → warns
  ok  startup hint but events arrived afterward → no override (stays ok)
  ok  no hint in log → no override
  ok  status already non-ok (e.g. stale) → does not override
  ok  bridge restarted (fresh hint after old activity) → warns again
  ok  discord LoginFailure → fail status
  ok  discord LoginFailure overrides even non-ok incoming status
  ok  discord healthy log → no override
PASS — bridge_log_content_status tests

$ python3 tests/health-check-bridge-skip.test.py
... (18/18 pass, no regression)
```

Before/after evidence: reproduced against a real `slack-bridge.log` (startup hint + 8 successfully-processed Slack DM tasks logged after it) — `health-check.py` reported `slack-bridge: warn` before this fix, `slack-bridge: ok` after.

## What edge cases or non-happy paths did you check?

- Bridge restarted mid-session (a fresh hint appears after prior activity) → correctly re-warns, since there's no activity *after* the newest hint yet.
- Incoming status already non-`ok` (e.g. `stale` from the code-staleness check) → check doesn't override, matching existing precedence (only fires on top of `status == "ok"`).
- discord-bridge's separate `LoginFailure` branch is unchanged and still covered.

## Any migrations, config, permissions, rollback, or deployment risks?

None — pure detection-logic change, no schema/config/behavior change to the bridge itself.

## Any known gaps or follow-up work?

None identified. This is a monitoring-accuracy fix only.