### PR TITLE
fix(tests): sync-workspace.test.sh's HOST used the naive hostname recipe, not the scutil-first precedence

### DIFF
--- a/tests/sync-workspace.test.sh
+++ b/tests/sync-workspace.test.sh
@@ -115,7 +115,13 @@ COMMON_ENV=(
 )
 
 SYNC="$FIXTURE_REPO/scripts/sync-workspace.sh"
-HOST=$(hostname | sed 's/\..*//')
+# Must match sync-workspace.sh's own _host() precedence (scutil LocalHostName
+# before raw `hostname`, #1745) — not the naive `hostname | sed` recipe, which
+# can diverge from it on this exact machine and make this assertion fail
+# against a script that's actually behaving correctly. Resolved via the real
+# repo (not $FIXTURE_REPO, which doesn't carry src/util_paths.py) since this
+# is a fact about the machine, not the fixture.
+HOST=$(bash "$REPO/scripts/sutando-config.sh" host-label)
 # Post-wsId branch shape (`host/<hostname>/<wsId>`). WS_ID matches the override
 # set in COMMON_ENV above, so test assertions know the exact ref.
 WS_ID=t01ws1


### PR DESCRIPTION
## What changed, and why?

`tests/sync-workspace.test.sh` computed its expected `HOST` value via `hostname | sed 's/\..*//'`, but `sync-workspace.sh`'s own `_host()` function correctly prefers `scutil --get LocalHostName` first (per #1745 — a DHCP-assigned hostname can drift, e.g. a Comcast lease returning `Chis-MBP.hsd1.wa.comcast.net`, while the Bonjour `LocalHostName` is stable). On any macOS machine where these two values diverge, the test's assertions check for a branch name the script never actually creates — a false failure against genuinely-correct behavior.

Reproduced live on this machine: `hostname` → `Bassils-MBP.lan`, `scutil --get LocalHostName` → `Bassils-MacBook-Pro`. Running the test as-is: 2 of 88 assertions failed (`host/Bassils-MBP/t01ws1 branch NOT in vault`, and a matching vault-path miss in test 5), even though `sync-workspace.sh` correctly pushed to `host/Bassils-MacBook-Pro/t01ws1`.

This is invisible in CI: GitHub Actions runs on Linux, where `scutil` doesn't exist, so `_host()`'s fallback-to-`hostname` path and the test's naive computation happen to agree there. The divergence only bites real macOS dev machines with a hostname/LocalHostName mismatch — exactly the scenario #1745 was written to protect against, so it's a bit ironic the regression test for the surrounding sync system itself carried the anti-pattern.

## What files / sections should reviewers look at first?

`tests/sync-workspace.test.sh` — the `HOST=` assignment near the top (was line 118).

## What user behavior or bug does this prove?

Nothing user-facing changes — `sync-workspace.sh` itself was already correct. This fixes the *test* so it actually verifies the real behavior on any machine, rather than silently depending on an environment where `hostname` and `scutil --get LocalHostName` happen to agree.

## What tests did you run? Include commands and results.

```
$ bash tests/sync-workspace.test.sh
Total: 88 — pass: 88, fail: 0
```

Before this fix, the same run on this machine: 86/88 pass, 2 fail (the branch-name and vault-path assertions built from the wrong `HOST` value).

## What edge cases or non-happy paths did you check?

- Confirmed via direct commands that `hostname` and `scutil --get LocalHostName` genuinely differ on this machine (not a hypothetical) — that's what made the pre-existing bug reproducible rather than theoretical.
- Confirmed the fix resolves `HOST` against the real repo (`$REPO/scripts/sutando-config.sh`), not `$FIXTURE_REPO` (the test's stripped-down fixture, which only copies `sync-workspace.sh`, `sutando-config.sh`, and `sutando_config.py` — not `src/util_paths.py`, which `host-label` needs). This is a fact about the machine running the test, not about the fixture under test, so resolving it against the real repo is correct either way.
- Confirmed `scripts/sutando-config.sh host-label` is the same canonical shim already used elsewhere (per #1745/#1771) — not a new, parallel hostname-resolution implementation that could itself drift from `sync-workspace.sh`'s `_host()` in the future.

## Any migrations, config, permissions, rollback, or deployment risks?

None — test-only change, no production code touched.

## Any known gaps or follow-up work?

Separately (not in this PR — flagged to the owner, awaiting go-ahead): the same naive `hostname | sed` recipe still appears in `CLAUDE.md` (2 spots) and the `schedule-crons`/`proactive-loop` SKILL.md files, which is what actually caused an agent session to write real content (a populated `pending-questions.md`) to the wrong `hosts/Bassils-MBP/` directory this week, invisible to the canonical reader. That's a docs/instructions change with broader blast radius, intentionally scoped out of this narrow test fix.