### PR TITLE
fix(slack): preserve pending reply routing across restarts

### DIFF
--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -335,11 +335,91 @@ def tofu_onboard(user_id: str, username: str | None) -> set:
 
 
 # Track which Slack channel/thread to reply into for each task we wrote.
-# Keyed by task_id; value is {channel, thread_ts, submitted_at, timed_out}
-# so we can reply in-thread for @mentions and at top-level for DMs, and so
-# the result_watcher can detect tasks the core never answered.
-pending_replies: dict[str, dict] = {}
+# This map must survive bridge restarts: task/result files are durable, and a
+# restarted bridge still needs the original channel + thread timestamp to route
+# a late result. Discord already persists the equivalent map for this reason.
+PENDING_REPLIES_FILE = STATE_DIR / "slack-pending-replies.json"
+
+
+def _atomic_write_pending_replies(data: dict) -> None:
+    """Persist reply routing without exposing a truncated JSON file on crash."""
+    try:
+        PENDING_REPLIES_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = PENDING_REPLIES_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(data))
+        tmp.replace(PENDING_REPLIES_FILE)
+    except Exception as e:
+        print(f"  [recovery] could not persist Slack pending replies: {e}", flush=True)
+
+
+def load_pending_replies_from_disk() -> dict:
+    """Restore reply routing on startup, aging out entries older than 7 days."""
+    try:
+        if not PENDING_REPLIES_FILE.exists():
+            return {}
+        data = json.loads(PENDING_REPLIES_FILE.read_text())
+        if not isinstance(data, dict):
+            return {}
+        now_ms = int(time.time() * 1000)
+        max_age_ms = 7 * 86400 * 1000
+        aged_out = []
+        for task_id, info in list(data.items()):
+            if not isinstance(info, dict) or not info.get("channel"):
+                del data[task_id]
+                continue
+            try:
+                ts_ms = int(task_id.split("-")[1])
+                if now_ms - ts_ms > max_age_ms:
+                    aged_out.append(task_id)
+                    del data[task_id]
+            except (ValueError, IndexError):
+                pass
+        if aged_out:
+            print(f"  [recovery] aged out {len(aged_out)} Slack pending replies > 7d", flush=True)
+        _atomic_write_pending_replies(data)
+        return data
+    except Exception as e:
+        print(f"  [recovery] could not load Slack pending replies: {e}", flush=True)
+        return {}
+
+
+# Keyed by task_id; value is {channel, thread_ts, submitted_at, timed_out,
+# access_tier}. Loading happens before the watcher starts, so any result that
+# landed while the bridge was down is delivered on its first poll.
+pending_replies: dict[str, dict] = load_pending_replies_from_disk()
 pending_replies_lock = threading.Lock()
+
+
+def _set_pending_reply(task_id: str, info: dict) -> None:
+    with pending_replies_lock:
+        pending_replies[task_id] = info
+        _atomic_write_pending_replies(dict(pending_replies))
+
+
+def _pop_pending_reply(task_id: str):
+    with pending_replies_lock:
+        target = pending_replies.pop(task_id, None)
+        _atomic_write_pending_replies(dict(pending_replies))
+    return target
+
+
+def _mark_pending_timed_out(task_id: str) -> None:
+    with pending_replies_lock:
+        entry = pending_replies.get(task_id)
+        if entry is None:
+            return
+        entry["timed_out"] = True
+        _atomic_write_pending_replies(dict(pending_replies))
+
+
+def _write_routed_task(task_file: Path, content: str, task_id: str, info: dict) -> None:
+    """Persist the Slack route before exposing its task file to the core."""
+    _set_pending_reply(task_id, info)
+    try:
+        task_file.write_text(content)
+    except Exception:
+        _pop_pending_reply(task_id)
+        raise
 
 # Per-task timeout. Mirrors task-bridge.ts's DEFAULT_TASK_TIMEOUT_MS (10 min):
 # if the core session wedges (e.g. hits the 1M-context usage-credit gate and
@@ -664,7 +744,14 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
     # third bridge; discord/telegram fold onto it in a follow-up dedup).
     media_headers = local_task_protocol.media_attachment_headers(  # pragma: no cover
         attachment_refs, bool(text and text.strip()))
-    task_file.write_text(
+    pending_info = {
+        "channel": channel,
+        "thread_ts": thread_ts,
+        "access_tier": access_tier,  # threaded to the outbound obs event
+        "submitted_at": time.time(),
+        "timed_out": False,
+    }
+    task_content = (
         f"id: {task_id}\n"
         f"timestamp: {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}\n"
         f"source: slack\n"
@@ -677,14 +764,9 @@ def _write_task(event: dict, prefix: str, text: str, username: str | None) -> st
         f"task: {user_task_text}\n"
         f"{skill_hints}"
     )
-    with pending_replies_lock:
-        pending_replies[task_id] = {
-            "channel": channel,
-            "thread_ts": thread_ts,
-            "access_tier": access_tier,  # threaded to the outbound obs event
-            "submitted_at": time.time(),
-            "timed_out": False,
-        }
+    # If the bridge dies immediately after creation, the next process can still
+    # route the result. The helper rolls the route back if task writing fails.
+    _write_routed_task(task_file, task_content, task_id, pending_info)
 
     global _event_count
     with _event_count_lock:
@@ -985,10 +1067,7 @@ def _check_task_timeouts() -> None:
         # Notified once, successfully. Mark so we don't repeat. The entry may
         # have been popped by result_watcher if a real result landed meanwhile
         # — guard with get() so we don't resurrect a delivered task.
-        with pending_replies_lock:
-            entry = pending_replies.get(task_id)
-            if entry is not None:
-                entry["timed_out"] = True
+        _mark_pending_timed_out(task_id)
         print(f"  [timeout] notified Slack for {task_id} after {TASK_TIMEOUT_SEC}s", flush=True)
 
 
@@ -1012,7 +1091,7 @@ def result_watcher():
                 if not reply_text:
                     continue
                 with pending_replies_lock:
-                    target = pending_replies.pop(task_id, None)
+                    target = pending_replies.get(task_id)
                 if not target:
                     continue
 
@@ -1033,7 +1112,11 @@ def result_watcher():
                         print(f"  Replied to {target['channel']}: {reply_text[:80]}...", flush=True)
                     except Exception as e:
                         print(f"[Slack] reply error: {e}", flush=True)
+                        # Keep both the durable route and result file so the
+                        # next poll (or restarted bridge) can retry delivery.
+                        continue  # pragma: no cover - watcher loop retry; helper state is unit-tested
 
+                _pop_pending_reply(task_id)
                 archive_file(result_file, "results", task_id)
                 archive_file(find_task_file(TASKS_DIR, task_id) or TASKS_DIR / f"{task_id}.txt", "tasks", task_id)
 
@@ -1191,4 +1274,3 @@ def main():  # pragma: no cover
 
 if __name__ == "__main__":
     main()
-

--- a/tests/slack-bridge-pending-recovery.test.py
+++ b/tests/slack-bridge-pending-recovery.test.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Crash-recovery tests for Slack pending reply routing."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load_bridge(workspace: Path):
+    os.environ["SLACK_BOT_TOKEN"] = "xoxb-test-token"
+    os.environ["SLACK_APP_TOKEN"] = "xapp-test-token"
+    os.environ["SUTANDO_WORKSPACE"] = str(workspace)
+    os.environ["SUTANDO_TEST_MODE"] = "1"
+
+    class _StubApp:
+        def __init__(self, *args, **kwargs):
+            self.client = types.SimpleNamespace()
+
+        def event(self, _name):
+            return lambda fn: fn
+
+    slack_bolt = types.ModuleType("slack_bolt")
+    slack_bolt.App = _StubApp
+    sys.modules["slack_bolt"] = slack_bolt
+    sys.modules["slack_bolt.adapter"] = types.ModuleType("slack_bolt.adapter")
+    socket_mode = types.ModuleType("slack_bolt.adapter.socket_mode")
+    socket_mode.SocketModeHandler = object
+    sys.modules["slack_bolt.adapter.socket_mode"] = socket_mode
+    sys.path.insert(0, str(REPO / "src"))
+
+    name = f"slack_bridge_pending_{time.time_ns()}"
+    spec = importlib.util.spec_from_file_location(name, REPO / "src" / "slack-bridge.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestSlackPendingRecovery(unittest.TestCase):
+    def test_pending_route_survives_restart_and_is_removed_after_delivery(self):
+        with tempfile.TemporaryDirectory(prefix="slack-pending-") as raw:
+            workspace = Path(raw)
+            first = _load_bridge(workspace)
+            task_id = f"task-{int(time.time() * 1000)}"
+            route = {
+                "channel": "C123",
+                "thread_ts": "1784559002.847939",
+                "access_tier": "owner",
+                "submitted_at": time.time(),
+                "timed_out": False,
+            }
+            first._set_pending_reply(task_id, route)
+
+            state_file = workspace / "state" / "slack-pending-replies.json"
+            self.assertEqual(json.loads(state_file.read_text())[task_id], route)
+
+            restarted = _load_bridge(workspace)
+            self.assertEqual(restarted.pending_replies[task_id], route)
+            self.assertEqual(restarted._pop_pending_reply(task_id), route)
+            self.assertNotIn(task_id, json.loads(state_file.read_text()))
+
+    def test_route_is_written_before_task_and_rolled_back_on_write_failure(self):
+        with tempfile.TemporaryDirectory(prefix="slack-pending-write-") as raw:
+            workspace = Path(raw)
+            bridge = _load_bridge(workspace)
+            task_id = f"task-{int(time.time() * 1000)}"
+            route = {"channel": "D123", "thread_ts": None}
+            task_file = workspace / "tasks" / f"{task_id}.txt"
+            task_file.parent.mkdir(exist_ok=True)
+
+            bridge._write_routed_task(task_file, "task body", task_id, route)
+            self.assertEqual(task_file.read_text(), "task body")
+            self.assertIn(task_id, bridge.pending_replies)
+
+            failing_id = f"task-{int(time.time() * 1000) + 1}"
+            with self.assertRaises(IsADirectoryError):
+                bridge._write_routed_task(workspace, "cannot write", failing_id, route)
+            self.assertNotIn(failing_id, bridge.pending_replies)
+
+    def test_entries_older_than_seven_days_are_aged_out(self):
+        with tempfile.TemporaryDirectory(prefix="slack-pending-old-") as raw:
+            workspace = Path(raw)
+            state_dir = workspace / "state"
+            state_dir.mkdir()
+            old_ms = int((time.time() - 8 * 86400) * 1000)
+            state_file = state_dir / "slack-pending-replies.json"
+            state_file.write_text(json.dumps({
+                f"task-{old_ms}": {
+                    "channel": "D123",
+                    "thread_ts": None,
+                    "submitted_at": old_ms / 1000,
+                    "timed_out": False,
+                }
+            }))
+
+            restarted = _load_bridge(workspace)
+            self.assertEqual(restarted.pending_replies, {})
+            self.assertEqual(json.loads(state_file.read_text()), {})
+
+    def test_invalid_state_is_sanitized_without_crashing(self):
+        with tempfile.TemporaryDirectory(prefix="slack-pending-invalid-") as raw:
+            workspace = Path(raw)
+            state_dir = workspace / "state"
+            state_dir.mkdir()
+            state_file = state_dir / "slack-pending-replies.json"
+
+            state_file.write_text("[]")
+            self.assertEqual(_load_bridge(workspace).pending_replies, {})
+
+            malformed_id = "task-not-a-timestamp"
+            state_file.write_text(json.dumps({
+                "task-123": "not-a-route",
+                malformed_id: {"channel": "D123", "thread_ts": None},
+            }))
+            loaded = _load_bridge(workspace).pending_replies
+            self.assertNotIn("task-123", loaded)
+            self.assertIn(malformed_id, loaded)
+
+            state_file.write_text("{broken json")
+            self.assertEqual(_load_bridge(workspace).pending_replies, {})
+
+    def test_defensive_write_and_missing_timeout_entry_do_not_raise(self):
+        with tempfile.TemporaryDirectory(prefix="slack-pending-defensive-") as raw:
+            workspace = Path(raw)
+            bridge = _load_bridge(workspace)
+            bridge.PENDING_REPLIES_FILE = workspace  # replace(directory) must fail
+            bridge._atomic_write_pending_replies({"task-1": {"channel": "D1"}})
+            bridge._mark_pending_timed_out("task-missing")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What changed and why?

Slack task and result files are durable, but the bridge kept the task → Slack channel/thread routing map only in process memory. If the bridge restarted after receiving a message, the task still reached the core and the result could be written, but the new bridge process had no destination for it. The result remained in `results/` and the Slack user saw silence.

This happened live in `#product-critical-bug`: `task-1784559004277` was received and persisted, the Slack bridge later exited, and after restart its result could not be claimed because `pending_replies` was empty.

The bridge now:

- atomically persists pending Slack reply routes to `state/slack-pending-replies.json`;
- reloads them before the result watcher starts;
- records routing before exposing a task file to the core, closing the task-write/crash window;
- retains the durable route and result when delivery raises, so a later poll/restart can retry;
- removes routing only after successful delivery or an intentional skip marker;
- ages out unresolved routes older than seven days.

This is intentionally separate from #2068, which supervises and auto-restarts dead channel bridge processes. #2068 restores the process; this PR lets a restarted Slack process finish replies accepted by its predecessor.

## Review first

- `src/slack-bridge.py` — persistence helpers and task/result lifecycle changes
- `tests/slack-bridge-pending-recovery.test.py` — simulated process restart and age-out coverage

## Failing-before / passing-after evidence

Before this change, importing a fresh Slack bridge process always initialized `pending_replies = {}` even when durable task/result files from the previous process remained. The live result file stayed unclaimed after the bridge was restarted.

The new regression test writes a channel/thread route with one bridge instance, imports a fresh instance against the same workspace, verifies the exact route is restored, and verifies it is removed from disk only after resolution.

## Tests

```text
python3 tests/slack-bridge-pending-recovery.test.py  PASS (5 tests)
python3 tests/slack-bridge-task-timeout.test.py      PASS (5 tests)
python3 tests/slack-bridge-orphan-recovery.test.py   PASS (7 tests)
python3 -m py_compile src/slack-bridge.py             PASS
git diff --check                                    PASS
```

## Edge cases / risk

- Atomic tmp + rename avoids truncated state after a crash.
- Mutations and persistence share the existing pending-reply lock, preventing stale concurrent snapshots.
- Invalid/missing state fails open to an empty routing map without crashing the bridge.
- Entries without a channel are discarded; valid entries older than seven days are removed.
- No config, permission, or data migration is required. The new state file is ordinary transient bridge routing state.