### PR TITLE
feat(review-pr): scan PR diff for hardcoded paths every review

### DIFF
--- a/skills/claude-codex/scripts/review-pr.sh
+++ b/skills/claude-codex/scripts/review-pr.sh
@@ -38,6 +38,45 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DIFF="$(gh pr diff "$PR" 2>/dev/null)" || { echo "review-pr: \`gh pr diff $PR\` failed (bad PR number, or no gh auth/remote)" >&2; exit 2; }
 [[ -n "$DIFF" ]] || { echo "review-pr: empty diff for #$PR (already merged with no changes, or not found)" >&2; exit 2; }
 
+# --- hardcoded-path pre-scan (owner directive: run on every review) -----------
+# Deterministic bash/awk pass over the diff's ADDED lines. Flags absolute-path
+# literals (/Users/, /home/<user>, ~/.claude, ~/.sutando, quoted
+# /(Users|home|opt|usr|private)/ ...) while excluding test-fixture/system noise
+# (/nonexistent, /usr/fake, /tmp/, example.com) and comment lines. Tracks the
+# new-file line number from @@ hunk headers so hits report as file:line. No deps.
+scan_hardcoded_paths() {
+    awk '
+    /^\+\+\+ / { f=$2; sub(/^b\//,"",f); next }
+    /^@@ / { m=$0; sub(/^@@ [^+]*\+/,"",m); sub(/[, ].*$/,"",m); ln=m-1; next }
+    /^-/    { next }                 # removed line: no new-file line number
+    /^[^+]/ { ln++; next }           # context line advances the new-file counter
+    /^\+/ {
+        ln++
+        line=substr($0,2)            # strip the leading +
+        t=line; sub(/^[ \t]*/,"",t)  # left-trimmed copy for comment detection
+        if (t ~ /^(#|\/\/|\*)/) next
+        if (line ~ /\/nonexistent|\/usr\/fake|\/tmp\/|example\.com/) next
+        if (line ~ /\/Users\/|\/home\/[A-Za-z]|~\/\.claude|~\/\.sutando|["'"'"']\/(Users|home|opt|usr|private)\//) {
+            s=t; if (length(s) > 160) s=substr(s,1,160) "…"
+            print f ":" ln ": " s
+        }
+    }
+    '
+}
+PATH_HITS="$(printf '%s\n' "$DIFF" | scan_hardcoded_paths)"
+if [[ -n "$PATH_HITS" ]]; then
+    PATH_COUNT="$(printf '%s\n' "$PATH_HITS" | grep -c '')"
+    PATH_LINE="paths: ${PATH_COUNT} flagged"
+else
+    PATH_LINE="paths: clean"
+fi
+emit_path_scan() {
+    echo "$PATH_LINE"
+    [[ -n "$PATH_HITS" ]] && printf '%s\n' "$PATH_HITS"
+    echo
+}
+# -----------------------------------------------------------------------------
+
 OUT="$(mktemp -t review-pr.XXXXXX)"
 trap 'rm -f "$OUT"' EXIT   # clean up even on interrupt / non-zero exit, not just the happy path
 bash "$HERE/codex-bounded.sh" --stall "$STALL" --max "$MAX" -- \
@@ -46,6 +85,7 @@ bash "$HERE/codex-bounded.sh" --stall "$STALL" --max "$MAX" -- \
 $DIFF" < /dev/null
 rc=$?
 
+emit_path_scan   # deterministic path verdict prepended to every review, pass or fail
 if [[ $rc -eq 0 && -s "$OUT" ]]; then
     cat "$OUT"
 else

--- a/skills/claude-codex/scripts/review-pr.sh
+++ b/skills/claude-codex/scripts/review-pr.sh
@@ -45,8 +45,13 @@ DIFF="$(gh pr diff "$PR" 2>/dev/null)" || { echo "review-pr: \`gh pr diff $PR\` 
 # (/nonexistent, /usr/fake, /tmp/, example.com) and comment lines. Tracks the
 # new-file line number from @@ hunk headers so hits report as file:line. No deps.
 scan_hardcoded_paths() {
-    awk '
-    /^\+\+\+ / { f=$2; sub(/^b\//,"",f); next }
+    # awk program lives in a temp file written by a quoted-heredoc REDIRECT (not a
+    # $(...) command substitution — that mis-balances the ' and " inside the regex
+    # and breaks the whole script). Keeps the regexes readable and unescaped.
+    local awkf
+    awkf="$(mktemp -t scanpaths.XXXXXX)"
+    cat > "$awkf" <<'AWK'
+    /^\+\+\+ / { f=$0; sub(/^\+\+\+ [ab]\//,"",f); next }   # whole path — filenames with spaces survive ($2 truncated them)
     /^@@ / { m=$0; sub(/^@@ [^+]*\+/,"",m); sub(/[, ].*$/,"",m); ln=m-1; next }
     /^-/    { next }                 # removed line: no new-file line number
     /^[^+]/ { ln++; next }           # context line advances the new-file counter
@@ -54,14 +59,27 @@ scan_hardcoded_paths() {
         ln++
         line=substr($0,2)            # strip the leading +
         t=line; sub(/^[ \t]*/,"",t)  # left-trimmed copy for comment detection
-        if (t ~ /^(#|\/\/|\*)/) next
-        if (line ~ /\/nonexistent|\/usr\/fake|\/tmp\/|example\.com/) next
-        if (line ~ /\/Users\/|\/home\/[A-Za-z]|~\/\.claude|~\/\.sutando|["'"'"']\/(Users|home|opt|usr|private)\//) {
+        if (t ~ /^(#|\/\/)/) next    # skip # and // comments; NOT bare * (it swallowed real paths in C-pointer / markdown-bullet lines)
+        # Walk each matched path token; exclude a token only if the token ITSELF is
+        # a fixture/system path — a whole-line exclusion hid a real /Users/ path that
+        # merely shared a line with example.com or /tmp/.
+        rest=line
+        hit=0
+        while (match(rest, /["']\/(Users|home|opt|usr|private)\/[^ "']*|\/Users\/[^ "']*|\/home\/[A-Za-z][^ "']*|~\/\.claude[^ "']*|~\/\.sutando[^ "']*/)) {
+            tok=substr(rest, RSTART, RLENGTH)
+            rest=substr(rest, RSTART + RLENGTH)
+            cand=tok; sub(/^["']/,"",cand)   # drop a leading quote from the quoted variant
+            if (cand ~ /^\/nonexistent/ || cand ~ /^\/usr\/fake/ || cand ~ /^\/tmp\// || cand ~ /example\.com/) continue
+            hit=1
+        }
+        if (hit) {
             s=t; if (length(s) > 160) s=substr(s,1,160) "…"
             print f ":" ln ": " s
         }
     }
-    '
+AWK
+    awk -f "$awkf"
+    rm -f "$awkf"
 }
 PATH_HITS="$(printf '%s\n' "$DIFF" | scan_hardcoded_paths)"
 if [[ -n "$PATH_HITS" ]]; then

--- a/tests/review-pr.test.sh
+++ b/tests/review-pr.test.sh
@@ -54,5 +54,54 @@ check "happy path prints codex verdict" ok "$v"
 # 5. --max is accepted (and forwarded; happy path still works)
 bash "$HELPER" 1754 --max 300 >/dev/null 2>&1; check "--max accepted → exit 0" 0 "$?"
 
+# --- scanner fixtures: scan_hardcoded_paths, the mandatory hardcoded-path signal ---
+# Source just the function (extracted from the helper) so we can drive it with
+# crafted diffs. Deterministic — no gh/codex. Covers the review findings on the
+# first cut: whole-line exclusion masking, bare-`*` over-match, and $2 truncation.
+awk '/^scan_hardcoded_paths\(\) \{/,/^\}/' "$HELPER" > "$STUB/scanfn.sh"
+# shellcheck disable=SC1090
+source "$STUB/scanfn.sh"
+scan(){ printf '%s\n' "$1" | scan_hardcoded_paths; }
+
+# a) a positive absolute path is flagged, reported as file:line off the +++/@@ headers
+D=$'+++ b/app.js\n@@ -1,0 +1,1 @@\n+const home = "/Users/alice/app";'
+case "$(scan "$D")" in "app.js:1: const home"*) v=ok;; *) v=miss;; esac
+check "positive /Users/ path flagged as file:line" ok "$v"
+
+# b) # and // comment lines are NOT flagged
+D=$'+++ b/c.js\n@@ -1,0 +1,2 @@\n+# note /Users/bob/x\n+// note /Users/bob/x'
+check "# and // comment lines not flagged" "" "$(scan "$D")"
+
+# c) allowed fixture / system-noise paths are NOT flagged
+D=$'+++ b/f.js\n@@ -1,0 +1,3 @@\n+a = "/usr/fake/p"\n+b = "/nonexistent/p"\n+c = "/tmp/scratch"'
+check "fixture paths (/usr/fake,/nonexistent,/tmp) not flagged" "" "$(scan "$D")"
+
+# d) FIX (john-the-dev): a real /Users/ path sharing a line with example.com / a
+#    fixture token still flags — the exclusion is per-token, not whole-line.
+D=$'+++ b/m.js\n@@ -1,0 +1,1 @@\n+x = "/Users/alice/app"; y = "https://example.com";'
+case "$(scan "$D")" in *"/Users/alice/app"*) v=ok;; *) v=miss;; esac
+check "mixed forbidden+allowed line still flags the real path" ok "$v"
+#    ...and the anchored /tmp/ exclusion does NOT swallow a real /Users/tmp/ path
+D=$'+++ b/t.js\n@@ -1,0 +1,1 @@\n+p = "/Users/tmp/keep"'
+case "$(scan "$D")" in *"/Users/tmp/keep"*) v=ok;; *) v=miss;; esac
+check "real /Users/tmp/ path not masked by the /tmp/ fixture rule" ok "$v"
+
+# e) hunk line numbers are tracked (path on the 3rd added line of a hunk starting at +10 → 12)
+D=$'+++ b/h.js\n@@ -1,0 +10,3 @@\n+ok1\n+ok2\n+p = "/Users/x/y"'
+case "$(scan "$D")" in "h.js:12: "*) v=ok;; *) v=miss;; esac
+check "hunk line number reported (start +10, 3rd added line = 12)" ok "$v"
+
+# f) FIX (qingyun-wu): *-prefixed real paths flag — a C-pointer deref and a markdown
+#    bullet were silently skipped by the bare-`*` comment rule.
+D=$'+++ b/p.c\n@@ -1,0 +1,2 @@\n+*cfg = "/Users/bob/.ssh/id_rsa";\n+* see /Users/bob/notes'
+n="$(scan "$D" | grep -c '/Users/bob')"
+check "*-prefixed real paths flagged (not skipped as comments)" 2 "$n"
+
+# g) FIX (qingyun-wu): a filename containing a space keeps the correct file:line
+#    label — $2 split it at the space and reported the wrong file.
+D=$'+++ b/my file.py\n@@ -1,0 +1,1 @@\n+home = "/Users/alice/app"'
+case "$(scan "$D")" in "my file.py:1: "*) v=ok;; *) v=miss;; esac
+check "spaced filename preserved in file:line label" ok "$v"
+
 [ "$fail" -eq 0 ] && echo PASS || echo FAILED
 exit $fail


### PR DESCRIPTION
Owner asked that every cold-review check for hardcoded paths ("do it every time you review"). This adds a deterministic path-scan of the PR's added lines to `skills/claude-codex/scripts/review-pr.sh` so each verdict carries a `paths: clean` / `paths: N flagged` line (with `file:line` snippets).

- Runs on the already-fetched `gh pr diff` output, before/alongside the codex call — pure bash/awk, no new deps.
- Flags absolute-path literals: `/Users/`, `/home/<user>`, `~/.claude`, `~/.sutando`, and quoted `/(Users|home|opt|usr|private)/` literals.
- Excludes test-fixture/system noise (`/nonexistent`, `/usr/fake`, `/tmp/`, `example.com`) and comment lines.
- Tracks the new-file line number from `@@` hunk headers so hits report as `file:line`.
- Codex behavior unchanged; the path line is prepended to the verdict on every run (pass or fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)