### PR TITLE
fix(health-check): don't report never-configured vaults as deliberate opt-outs

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -106,24 +106,46 @@ def _resolved_vault() -> dict:
     (`sutando_config.resolve_vault`) — the SINGLE source of truth for
     `vault.enabled` and `vault.remote_url`.
 
-    Augments the resolver's dict with `_explicit_disable`: True only when the
-    config file actually carries `vault.enabled=false` (a deliberate opt-out),
-    as opposed to the resolver's default-False for a host with no vault block
-    at all. This lets check_memory_sync distinguish "opted out on purpose" from
+    Augments the resolver's dict with `_explicit_disable`: True only when THIS
+    HOST actually authored `vault.enabled=false` (a deliberate opt-out), as
+    opposed to the resolver's default-False for a host with no vault block at
+    all. This lets check_memory_sync distinguish "opted out on purpose" from
     "never configured" without re-reading config.
+
+    That signal MUST come from the per-clone override file alone. It cannot come
+    from `load_config()`, which deep-merges the repo-shipped `sutando.config.json`
+    — and that file ships `vault.enabled: false` to every clone, so a merged read
+    reports *every* unconfigured host as a deliberate opt-out and leaves
+    check_memory_sync's "not configured" branch unreachable (#2231).
 
     Best-effort: on any error (resolver import failure, malformed config) return
     safe defaults ({"enabled": False, "remote_url": ""}) so a config-helper
     hiccup never masks a real check. Mirrors resolve_vault's own defaults.
     """
     try:
-        from sutando_config import resolve_vault, load_config  # noqa: PLC0415
+        from sutando_config import resolve_vault  # noqa: PLC0415
         vault = dict(resolve_vault(repo_root=REPO_DIR))
-        raw_vault = load_config(repo_root=REPO_DIR).get("vault") or {}
-        vault["_explicit_disable"] = raw_vault.get("enabled") is False
+        vault["_explicit_disable"] = _local_vault_enabled_is_false()
         return vault
     except Exception:
         return {"enabled": False, "remote_url": "", "_explicit_disable": False}
+
+
+def _local_vault_enabled_is_false() -> bool:
+    """True only if `sutando.config.local.json` itself sets vault.enabled=false.
+
+    Reads the per-clone override directly — no defaults merge — so the repo's
+    shipped `vault.enabled: false` can never masquerade as a host's choice.
+    A missing or malformed override file means "this host chose nothing".
+    """
+    local_path = REPO_DIR / "sutando.config.local.json"
+    if not local_path.is_file():
+        return False
+    try:
+        local_cfg = json.loads(local_path.read_text()) or {}
+    except (OSError, ValueError):
+        return False
+    return (local_cfg.get("vault") or {}).get("enabled") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/health-check-memory-sync-optout.test.py
+++ b/tests/health-check-memory-sync-optout.test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Tests for check_memory_sync()'s opt-out vs never-configured distinction (#2231).
+
+`_resolved_vault()` used to derive `_explicit_disable` from `load_config()`,
+which deep-merges the repo-shipped `sutando.config.json`. That file ships
+`vault.enabled: false` to every clone, so the flag was True on every host that
+had simply never configured a vault — making check_memory_sync always report
+"config opt-out" and leaving its "not configured (single-machine mode)" branch
+unreachable.
+
+CRITICAL FIXTURE NOTE: every test here writes the shipped `sutando.config.json`
+into the temp repo. Without it, `load_config()` finds no repo root, returns {},
+and `_explicit_disable` is False for the *wrong* reason — the fixture would pass
+against the buggy code and prove nothing. The sibling
+`health-check-memory-sync-vault.test.py` omits that file, which is exactly why
+this bug survived.
+
+Run: python3 tests/health-check-memory-sync-optout.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+import importlib.util
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+spec = importlib.util.spec_from_file_location(
+    "health_check", REPO / "src" / "health-check.py"
+)
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+# Mirrors the real repo-shipped defaults: sync is opt-in, so the committed file
+# carries enabled=false for everyone.
+SHIPPED_DEFAULTS = {"vault": {"enabled": False, "remote_url": ""}}
+
+
+class TestOptOutVsNeverConfigured(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="hc-optout-"))
+        self._saved_repo = hc.REPO_DIR
+        self._saved_ws = hc.WORKSPACE_DIR
+        self.repo = self.tmp / "repo"
+        self.repo.mkdir(parents=True, exist_ok=True)
+        # The shipped defaults — present on every real clone.
+        (self.repo / "sutando.config.json").write_text(json.dumps(SHIPPED_DEFAULTS))
+        hc.REPO_DIR = self.repo
+        ws = self.tmp / "workspace"
+        ws.mkdir(parents=True, exist_ok=True)
+        hc.WORKSPACE_DIR = ws
+        self._clear_config_cache()
+
+    def tearDown(self):
+        hc.REPO_DIR = self._saved_repo
+        hc.WORKSPACE_DIR = self._saved_ws
+        self._clear_config_cache()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    @staticmethod
+    def _clear_config_cache():
+        """sutando_config memoizes load_config; stale cache would cross tests."""
+        try:
+            import sutando_config
+            sutando_config._CACHE = None
+            sutando_config._CACHE_REPO_ROOT = None
+        except Exception:
+            pass
+
+    def _write_local(self, cfg):
+        (self.repo / "sutando.config.local.json").write_text(json.dumps(cfg))
+        self._clear_config_cache()
+
+    # -- the regression ----------------------------------------------------- #
+
+    def test_no_local_config_is_not_an_opt_out(self):
+        """No override file: the host chose nothing, despite shipped enabled=false.
+
+        This is the #2231 regression. Pre-fix, _explicit_disable was True here.
+        """
+        vault = hc._resolved_vault()
+        self.assertFalse(
+            vault["_explicit_disable"],
+            "a host with no sutando.config.local.json never opted out",
+        )
+        result = hc.check_memory_sync()
+        self.assertIn("not configured", result["detail"])
+        self.assertNotIn("opt-out", result["detail"])
+
+    def test_local_config_without_vault_block_is_not_an_opt_out(self):
+        """An override file that says nothing about vault is not a choice either."""
+        self._write_local({"workspace": {"path": "/tmp/ws"}})
+        self.assertFalse(hc._resolved_vault()["_explicit_disable"])
+        self.assertIn("not configured", hc.check_memory_sync()["detail"])
+
+    # -- the branch that must still work ------------------------------------ #
+
+    def test_local_enabled_false_is_a_real_opt_out(self):
+        """Explicit vault.enabled=false in the override IS a deliberate opt-out."""
+        self._write_local({"vault": {"enabled": False}})
+        self.assertTrue(hc._resolved_vault()["_explicit_disable"])
+        self.assertIn("opt-out", hc.check_memory_sync()["detail"])
+
+    def test_local_enabled_true_is_not_an_opt_out(self):
+        self._write_local({"vault": {"enabled": True, "remote_url": "git@x:y/z.git"}})
+        self.assertFalse(hc._resolved_vault()["_explicit_disable"])
+
+    # -- defensive branches (written with the guard, per the coverage gate) -- #
+
+    def test_malformed_local_config_is_not_an_opt_out(self):
+        """Unparseable override must not be read as a deliberate choice."""
+        (self.repo / "sutando.config.local.json").write_text("{not json")
+        self._clear_config_cache()
+        self.assertFalse(hc._resolved_vault()["_explicit_disable"])
+
+    def test_vault_key_present_but_null(self):
+        """`"vault": null` must not raise and must not read as opt-out."""
+        self._write_local({"vault": None})
+        self.assertFalse(hc._resolved_vault()["_explicit_disable"])
+
+    def test_enabled_absent_from_vault_block(self):
+        """A vault block without `enabled` is not an opt-out (is-False, not falsy)."""
+        self._write_local({"vault": {"remote_url": ""}})
+        self.assertFalse(hc._resolved_vault()["_explicit_disable"])
+
+    def test_enabled_zero_is_not_false(self):
+        """`0` is falsy but is not an explicit disable — `is False` matters."""
+        self._write_local({"vault": {"enabled": 0}})
+        self.assertFalse(
+            hc._resolved_vault()["_explicit_disable"],
+            "0 is not the boolean False; only an authored `false` counts",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-memory-sync-optout.test.py
+++ b/tests/health-check-memory-sync-optout.test.py
@@ -110,13 +110,33 @@ class TestOptOutVsNeverConfigured(unittest.TestCase):
         self._write_local({"vault": {"enabled": True, "remote_url": "git@x:y/z.git"}})
         self.assertFalse(hc._resolved_vault()["_explicit_disable"])
 
-    # -- defensive branches (written with the guard, per the coverage gate) -- #
+    # -- defensive branches of the helper itself --------------------------- #
+    #
+    # These call _local_vault_enabled_is_false() DIRECTLY, not through
+    # _resolved_vault(). That is deliberate and load-bearing: _resolved_vault()
+    # runs resolve_vault()/load_config() FIRST, and load_config() raises on a
+    # malformed config — so a malformed-file test routed through _resolved_vault
+    # is caught by its OUTER except and never reaches the helper's own
+    # `except (OSError, ValueError)`. The assertion (returns False) passes
+    # either way; only line-coverage reveals the branch was never run. The
+    # coverage gate caught exactly that on the first push (missing 146-147).
 
-    def test_malformed_local_config_is_not_an_opt_out(self):
-        """Unparseable override must not be read as a deliberate choice."""
+    def test_malformed_local_config_returns_false(self):
+        """Unparseable override → helper's own except branch → False."""
         (self.repo / "sutando.config.local.json").write_text("{not json")
-        self._clear_config_cache()
-        self.assertFalse(hc._resolved_vault()["_explicit_disable"])
+        self.assertFalse(hc._local_vault_enabled_is_false())
+
+    def test_no_local_file_returns_false(self):
+        """Absent override → early `not is_file()` return, no read attempted."""
+        self.assertFalse((self.repo / "sutando.config.local.json").exists())
+        self.assertFalse(hc._local_vault_enabled_is_false())
+
+    def test_helper_reads_authored_false_directly(self):
+        """Authored enabled=false → True, without going through _resolved_vault."""
+        self._write_local({"vault": {"enabled": False}})
+        self.assertTrue(hc._local_vault_enabled_is_false())
+
+    # -- value semantics (via the public path) ----------------------------- #
 
     def test_vault_key_present_but_null(self):
         """`"vault": null` must not raise and must not read as opt-out."""


### PR DESCRIPTION
Closes #2231.

## The bug

`_resolved_vault()` computed the "did this host deliberately opt out?" signal from a **merged** config read:

```python
raw_vault = load_config(repo_root=REPO_DIR).get("vault") or {}
vault["_explicit_disable"] = raw_vault.get("enabled") is False
```

`load_config()` deep-merges the repo-shipped `sutando.config.json`, which carries:

```json
"vault": { "enabled": false, "remote_url": "" }
```

That file ships to **every** clone. So `_explicit_disable` was `True` for every host that had never configured a vault — precisely the population the flag exists to exclude. `raw_vault` was never raw.

Consequence: `check_memory_sync()` always took the first branch, making the second unreachable:

```python
if vault.get("_explicit_disable"):     # always True when unconfigured
    return {... "cross-machine sync disabled (config opt-out)"}
if not repo_url:
    return {... "cross-machine sync not configured (single-machine mode)"}   # dead code
```

An operator who never set up backup was told they had *chosen* not to have it.

## The fix

Read the per-clone override file directly — no defaults merge — so only a value the host actually authored counts as a choice.

## Before / after

On a real clone with no `sutando.config.local.json`:

```
before:  ✓ memory-sync   ok   cross-machine sync disabled (config opt-out)
after:   ✓ memory-sync   ok   cross-machine sync not configured (single-machine mode)
```

`sync-workspace.sh` has been describing this state correctly all along — the two agree now:

```
sync-workspace: cross-machine sync disabled (no vault URL configured) — skipping.
```

## Scope

Both states remain `ok`. This is a **message-accuracy** fix, not a severity change — #2069 established that unconfigured sync must not nag, and that is untouched. The ask is only that the stated *reason* be true, since the two states warrant different operator responses.

## Tests

`tests/health-check-memory-sync-optout.test.py`, 8 cases: the regression, the real-opt-out path that must keep working, and the defensive branches added with the guard (malformed JSON, `"vault": null`, absent `enabled`, and `0` — which is falsy but is not an authored `false`).

**Fixture note, which is the reason this bug survived:** every test here writes the shipped `sutando.config.json` into the temp repo. Without it, `load_config()` finds no repo root, returns `{}`, and the flag is `False` for the *wrong* reason — the fixture would pass against the buggy code and prove nothing. The sibling `health-check-memory-sync-vault.test.py` omits that file, which is exactly why it never caught this.

**Verified by mutation:** reverting the one-line change fails 3 of the 8 new tests. Sibling suites (`health-check-memory-sync`, `-vault`, `memory-dir-override`) all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuRpcYxqsRQsoV44E5Gh1
