### PR TITLE
fix(phone): load .env via fileURLToPath, not URL.pathname (spaced installs)

### DIFF
--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -45,7 +45,10 @@
 // Load .env from the project root (3 levels up from this script), not cwd —
 // override: true ensures .env values win over stale shell env vars
 import { config as _dotenvConfig } from 'dotenv';
-_dotenvConfig({ path: new URL('../../../.env', import.meta.url).pathname, override: true });
+// fileURLToPath (as used below at _phoneSkillDir) instead of .pathname: URL.pathname
+// stays percent-encoded, so a spaced install path (".../Application Support/...")
+// yields a literal "%20" that points at no file and the .env silently never loads. (#2228)
+_dotenvConfig({ path: fileURLToPath(new URL('../../../.env', import.meta.url)), override: true });
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { mkdirSync, writeFileSync, copyFileSync, appendFileSync, unlinkSync, existsSync, readFileSync, readdirSync, renameSync, symlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';

--- a/tests/conversation-server-env-path-spaced.test.ts
+++ b/tests/conversation-server-env-path-spaced.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression guard for #2228 (conversation-server half): the phone
+ * conversation-server loaded its `.env` from
+ * `new URL('../../../.env', import.meta.url).pathname`. `URL.pathname` stays
+ * percent-encoded, so on the desktop-bundled install
+ * (".../Application Support/…") the path became ".../Application%20Support/.env"
+ * — a file that does not exist — and dotenv silently loaded nothing, with no
+ * error. The fix uses fileURLToPath (as the same file already does for
+ * `_phoneSkillDir`).
+ *
+ * The sibling site src/voice-context.ts is fixed separately in PR #2206; this
+ * test covers only the conversation-server site, which #2206 does not touch.
+ *
+ * The module lives at a fixed, unspaced repo path, so importing it here cannot
+ * reproduce the spaced-path condition. Test 1 exercises the resolution
+ * technique in a real spaced temp dir via subprocess; test 2 source-guards the
+ * actual call site so a revert to `.pathname` fails here (mutation-checked).
+ *
+ * Runs under `tsx --test` (npm test); needs no build.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const CONVERSATION_SERVER = 'skills/phone-conversation/scripts/conversation-server.ts';
+
+test('fileURLToPath resolves an import.meta.url .env path on a spaced install; .pathname does not', () => {
+  const base = mkdtempSync(join(tmpdir(), 'sutando-2228-'));
+  // Mirror the ../../../.env climb from scripts/ up to a repo root, with a
+  // space in an ancestor segment (the crux of the bug).
+  const scriptDir = join(base, 'Application Support', 'repo', 'skills', 'phone', 'scripts');
+  mkdirSync(scriptDir, { recursive: true });
+  const repoRoot = join(base, 'Application Support', 'repo');
+  writeFileSync(join(repoRoot, '.env'), 'PROBE=1\n');
+  try {
+    const probe = join(scriptDir, 'probe.mjs');
+    writeFileSync(probe, `import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+const bad = new URL('../../../.env', import.meta.url).pathname;
+const good = fileURLToPath(new URL('../../../.env', import.meta.url));
+process.stdout.write(JSON.stringify({
+  badEncoded: bad.includes('%20'), badExists: existsSync(bad),
+  goodExists: existsSync(good),
+}));\n`);
+    const out = JSON.parse(execFileSync(process.execPath, [probe], { encoding: 'utf8' }));
+    assert.equal(out.badEncoded, true, '.pathname must stay percent-encoded');
+    assert.equal(out.badExists, false, 'the encoded .env path must not exist');
+    assert.equal(out.goodExists, true, 'the fileURLToPath .env path must exist');
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test(`${CONVERSATION_SERVER} loads .env via fileURLToPath, never new URL(import.meta.url).pathname (#2228)`, () => {
+  const src = readFileSync(join(REPO_ROOT, CONVERSATION_SERVER), 'utf8');
+  // Drop line comments so the explanatory comment naming the pattern can't self-trip.
+  const code = src.split('\n').filter((l) => !l.trimStart().startsWith('//')).join('\n');
+  // Narrow by design: only `.pathname` on a URL built from import.meta.url — never
+  // the legitimate `url.pathname === '/route'` HTTP-routing uses elsewhere.
+  const hit = /new URL\([^)]*import\.meta\.url[^)]*\)\.pathname/.exec(code);
+  assert.equal(hit, null, hit ? `forbidden pattern present: ${hit[0]}` : '');
+});


### PR DESCRIPTION
## The bug

The phone conversation-server loaded its `.env` with:

```ts
_dotenvConfig({ path: new URL('../../../.env', import.meta.url).pathname, override: true });
```

`URL.pathname` stays **percent-encoded**. On the desktop-bundled install — which lives under `~/Library/Application Support/…`, a path containing a space — this resolves to `.../Application%20Support/.env`, a file that does not exist. dotenv then silently loads nothing (no throw, no warning), and every value expected from `.env` is simply absent at runtime.

## The fix

```ts
_dotenvConfig({ path: fileURLToPath(new URL('../../../.env', import.meta.url)), override: true });
```

Same URL resolution, decoded properly. `fileURLToPath` is already imported and used a few lines down in the same file (`_phoneSkillDir`), so this makes the file internally consistent — no new import, minimal diff.

## Scope — this is the conversation-server half of #2228

#2228 lists two sites. The other, `src/voice-context.ts`, is **already fixed in #2206** (same bug class). This PR is scoped to the one remaining site #2206 does not touch — **zero file overlap** with #2206, so it isn't a duplicate. Together they close #2228.

## Test

`tests/conversation-server-env-path-spaced.test.ts` (runs under `npm test`):

1. **Technique proof** — builds a real temp dir with a space in an ancestor segment, climbs `../../../.env` the same way the source does, and asserts `.pathname` stays `%20`-encoded (file missing) while `fileURLToPath` decodes (file present). Run with the bundled node.
2. **Source guard** — asserts the call site doesn't regress to `.pathname` on an `import.meta.url` URL. Narrow by construction: the regex only matches `.pathname` on a URL built from `import.meta.url`, so it never touches the ~30 legitimate `url.pathname === '/route'` HTTP-routing uses elsewhere in the tree. **Mutation-checked**: reverting the source line to `.pathname` fails this test.

## Verification honesty

I could not run the full existing `tsx --test` suite locally — the scratch checkout has no `node_modules`. The change is **value-identical on unspaced paths** (same resolved path, only decoded), so the existing conversation-server tests can't regress from it; CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuRpcYxqsRQsoV44E5Gh1
