### PR TITLE
fix(bridges): per-PID staging for last-owner-activity.json (concurrent writes)

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -716,7 +716,8 @@ def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
     unlisted sender `_tier_for` returns LOCAL_TIER, so the single-owner case is
     unchanged. Never trusts the gateway's own claim (it is outside the trust
     boundary) — only the broker-attested user_id keyed against the owner's LOCAL
-    tierMap. Atomic write via tmp+rename; same schema (`ts`, `channel`, `summary`)
+    tierMap. Atomic write via per-PID tmp + os.replace (this file has four
+    concurrent writers; #2222); same schema (`ts`, `channel`, `summary`)
     as discord-bridge.write_owner_activity so the proactive-loop reader is
     transport-agnostic. Best-effort — never blocks task intake."""
     if sender_tier is None:

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -45,6 +45,7 @@ import atexit
 import base64
 import json
 import os
+import uuid
 import re
 import signal
 import socket
@@ -749,7 +750,7 @@ def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
         # file, so the rename can publish torn JSON to the proactive loop's
         # presence check. A per-PID temp is never shared; os.replace is an atomic
         # overwrite — last writer wins, cleanly. (sonichi/sutando#2222)
-        tmp = OWNER_ACTIVITY_FILE.with_suffix(f".json.{os.getpid()}.tmp")
+        tmp = OWNER_ACTIVITY_FILE.with_suffix(f".json.{os.getpid()}.{uuid.uuid4().hex}.tmp")
         tmp.write_text(json.dumps(payload))
         os.replace(tmp, OWNER_ACTIVITY_FILE)
     except Exception as e:  # noqa: BLE001

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -328,9 +328,14 @@ def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
         }
         if channel_id:
             payload["channel_id"] = str(channel_id)
-        tmp = OWNER_ACTIVITY_FILE.with_suffix(".json.tmp")
+        # Per-PID staging name: this file is written by four processes (this
+        # bridge + slack/telegram/sparrow). A shared ".json.tmp" name lets two
+        # concurrent writers truncate and interleave the same temp file, so the
+        # rename can publish torn JSON. A per-PID temp is never shared, and
+        # os.replace is an atomic overwrite — last writer wins, cleanly. (#2222)
+        tmp = OWNER_ACTIVITY_FILE.with_suffix(f".json.{os.getpid()}.tmp")
         tmp.write_text(json.dumps(payload))
-        tmp.rename(OWNER_ACTIVITY_FILE)
+        os.replace(tmp, OWNER_ACTIVITY_FILE)
     except Exception as e:
         print(f"  [owner-activity] write failed: {e}", flush=True)
 

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import uuid
 import re
 import shlex
 import subprocess
@@ -333,7 +334,7 @@ def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
         # concurrent writers truncate and interleave the same temp file, so the
         # rename can publish torn JSON. A per-PID temp is never shared, and
         # os.replace is an atomic overwrite — last writer wins, cleanly. (#2222)
-        tmp = OWNER_ACTIVITY_FILE.with_suffix(f".json.{os.getpid()}.tmp")
+        tmp = OWNER_ACTIVITY_FILE.with_suffix(f".json.{os.getpid()}.{uuid.uuid4().hex}.tmp")
         tmp.write_text(json.dumps(payload))
         os.replace(tmp, OWNER_ACTIVITY_FILE)
     except Exception as e:

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -172,9 +172,14 @@ def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
         }
         if channel_id:
             payload["channel_id"] = str(channel_id)
-        tmp = OWNER_ACTIVITY_FILE.with_suffix(".json.tmp")
+        # Per-PID staging name: this file is written by four processes (this
+        # bridge + discord/telegram/sparrow). A shared ".json.tmp" name lets two
+        # concurrent writers truncate and interleave the same temp file, so the
+        # rename can publish torn JSON. A per-PID temp is never shared, and
+        # os.replace is an atomic overwrite — last writer wins, cleanly. (#2222)
+        tmp = OWNER_ACTIVITY_FILE.with_suffix(f".json.{os.getpid()}.tmp")
         tmp.write_text(json.dumps(payload))
-        tmp.rename(OWNER_ACTIVITY_FILE)
+        os.replace(tmp, OWNER_ACTIVITY_FILE)
     except Exception as e:
         print(f"  [owner-activity] write failed: {e}", flush=True)
 

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import json
 import mimetypes
 import os
+import uuid
 import re
 import secrets
 import sys
@@ -177,7 +178,7 @@ def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
         # concurrent writers truncate and interleave the same temp file, so the
         # rename can publish torn JSON. A per-PID temp is never shared, and
         # os.replace is an atomic overwrite — last writer wins, cleanly. (#2222)
-        tmp = OWNER_ACTIVITY_FILE.with_suffix(f".json.{os.getpid()}.tmp")
+        tmp = OWNER_ACTIVITY_FILE.with_suffix(f".json.{os.getpid()}.{uuid.uuid4().hex}.tmp")
         tmp.write_text(json.dumps(payload))
         os.replace(tmp, OWNER_ACTIVITY_FILE)
     except Exception as e:

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -35,7 +35,12 @@ function writeOwnerActivity(channel: string, summary: string): void {
 			channel,
 			summary: summary.slice(0, 80),
 		};
-		const tmp = OWNER_ACTIVITY_FILE + '.tmp';
+		// Per-PID staging: last-owner-activity.json is written by five processes
+		// (this task-bridge + the sparrow/discord/slack/telegram bridges). A shared
+		// '.tmp' name lets two concurrent writers truncate and interleave the same
+		// temp file, so the rename can publish torn JSON. A per-PID temp is never
+		// shared; renameSync maps to an atomic rename(2). (sonichi/sutando#2222)
+		const tmp = `${OWNER_ACTIVITY_FILE}.${process.pid}.tmp`;
 		writeFileSync(tmp, JSON.stringify(payload));
 		renameSync(tmp, OWNER_ACTIVITY_FILE);
 	} catch (e) {

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import uuid
 import re
 import secrets
 import sys
@@ -199,7 +200,7 @@ def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
         # concurrent writers truncate and interleave the same temp file, so the
         # rename can publish torn JSON. A per-PID temp is never shared, and
         # os.replace is an atomic overwrite — last writer wins, cleanly. (#2222)
-        tmp = OWNER_ACTIVITY_FILE.with_suffix(f".json.{os.getpid()}.tmp")
+        tmp = OWNER_ACTIVITY_FILE.with_suffix(f".json.{os.getpid()}.{uuid.uuid4().hex}.tmp")
         tmp.write_text(json.dumps(payload))
         os.replace(tmp, OWNER_ACTIVITY_FILE)
     except Exception as e:

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -194,9 +194,14 @@ def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
         }
         if channel_id:
             payload["channel_id"] = str(channel_id)
-        tmp = OWNER_ACTIVITY_FILE.with_suffix(".json.tmp")
+        # Per-PID staging name: this file is written by four processes (this
+        # bridge + slack/discord/sparrow). A shared ".json.tmp" name lets two
+        # concurrent writers truncate and interleave the same temp file, so the
+        # rename can publish torn JSON. A per-PID temp is never shared, and
+        # os.replace is an atomic overwrite — last writer wins, cleanly. (#2222)
+        tmp = OWNER_ACTIVITY_FILE.with_suffix(f".json.{os.getpid()}.tmp")
         tmp.write_text(json.dumps(payload))
-        tmp.rename(OWNER_ACTIVITY_FILE)
+        os.replace(tmp, OWNER_ACTIVITY_FILE)
     except Exception as e:
         print(f"  [owner-activity] write failed: {e}")
 

--- a/tests/owner-activity-atomic-write.test.py
+++ b/tests/owner-activity-atomic-write.test.py
@@ -25,8 +25,10 @@ import os
 import re
 import sys
 import tempfile
+import threading
 import time
 import unittest
+import uuid
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -42,7 +44,18 @@ def _write_shared(target: Path, payload: dict) -> None:
 
 
 def _write_perpid(target: Path, payload: dict) -> None:
-    tmp = target.with_suffix(f".json.{os.getpid()}.tmp")  # the fix
+    # PID-only staging: unique ACROSS processes but SHARED across threads in one
+    # process — insufficient for a multi-threaded writer (e.g. Slack Bolt's
+    # listener ThreadPoolExecutor). Two threads collide on this exact temp path.
+    tmp = target.with_suffix(f".json.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(payload))
+    os.replace(tmp, target)
+
+
+def _write_perinvocation(target: Path, payload: dict) -> None:
+    # Per-invocation staging (PID + uuid4): unique across BOTH processes and
+    # same-process threads. This is the fix the bridges use.
+    tmp = target.with_suffix(f".json.{os.getpid()}.{uuid.uuid4().hex}.tmp")
     tmp.write_text(json.dumps(payload))
     os.replace(tmp, target)
 
@@ -91,6 +104,60 @@ class TestOwnerActivityAtomicWrite(unittest.TestCase):
             f"per-PID staging produced {self._torn} torn reads — must be 0",
         )
 
+    def _run_threads(self, writer, n_threads=16, writes=400) -> int:
+        """Run `n_threads` writer threads IN ONE PROCESS (all sharing this PID),
+        sampling the target for torn JSON while they race. Returns torn count.
+        This is the case per-PID staging CANNOT cover — every thread has the same
+        os.getpid(), so a PID-only temp name is shared across them."""
+        tmpdir = Path(tempfile.mkdtemp(prefix="oa-2222-thr-"))
+        target = tmpdir / "last-owner-activity.json"
+        target.write_text(json.dumps({"ts": 0, "seed": True}))
+
+        def work():
+            for i in range(writes):
+                try:
+                    writer(target, {"ts": int(time.time()),
+                                    "tid": threading.get_ident(), "i": i})
+                except (FileNotFoundError, OSError):
+                    pass  # a shared-temp collision — the very race under test
+
+        ts = [threading.Thread(target=work) for _ in range(n_threads)]
+        for t in ts:
+            t.start()
+        torn = 0
+        while any(t.is_alive() for t in ts):
+            try:
+                json.loads(target.read_text())
+            except (ValueError, OSError):
+                torn += 1
+        for t in ts:
+            t.join(10)
+        json.loads(target.read_text())  # final state always valid (rename is atomic)
+        return torn
+
+    def test_perinvocation_never_tears_same_process_threads(self):
+        """The fix must be safe for MULTI-THREADED writers in a single process —
+        Slack Bolt runs listeners on a thread pool, so two owner-activity writes
+        can race inside one PID. Per-invocation (PID+uuid) staging → 0 torn."""
+        torn = self._run_threads(_write_perinvocation)
+        self.assertEqual(
+            torn, 0,
+            f"per-invocation staging tore {torn} times under same-process threads — must be 0",
+        )
+
+    def test_perpid_does_tear_same_process_threads(self):
+        """Regression witness: PID-only staging (the earlier, insufficient fix)
+        DOES tear when writers share a PID across threads — the exact collision
+        per-invocation staging removes. If this ever stops tearing, the test above
+        no longer proves anything, so it must fail loudly. High concurrency makes
+        it deterministic in practice (qingyun-001's repro: 8 threads → 1,216 torn)."""
+        torn = self._run_threads(_write_perpid)
+        self.assertGreater(
+            torn, 0,
+            "PID-only staging did not tear same-process — the per-invocation test "
+            "can then no longer demonstrate it fixes a real race",
+        )
+
     def test_source_sites_use_perpid_staging(self):
         """All FIVE owner-activity writers — the three bridges, the sparrow
         remote-gateway bridge (Python), and the task-bridge (TypeScript) — must
@@ -99,8 +166,11 @@ class TestOwnerActivityAtomicWrite(unittest.TestCase):
         bridges = ["src/slack-bridge.py", "src/discord-bridge.py",
                    "src/telegram-bridge.py",
                    "packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py"]
-        bad = re.compile(r'OWNER_ACTIVITY_FILE\.with_suffix\(\s*["\']\.json\.tmp["\']')
-        good = re.compile(r'OWNER_ACTIVITY_FILE\.with_suffix\(\s*f["\']\.json\.\{os\.getpid\(\)\}\.tmp["\']')
+        # bad = a SHARED '.json.tmp' OR a PID-only '.json.{os.getpid()}.tmp'
+        # (the latter still collides across threads in one process). good = the
+        # per-invocation PID+uuid name, unique across processes AND threads.
+        bad = re.compile(r'OWNER_ACTIVITY_FILE\.with_suffix\(\s*f?["\']\.json(\.\{os\.getpid\(\)\})?\.tmp["\']')
+        good = re.compile(r'OWNER_ACTIVITY_FILE\.with_suffix\(\s*f["\']\.json\.\{os\.getpid\(\)\}\.\{uuid\.uuid4\(\)\.hex\}\.tmp["\']')
         for rel in bridges:
             src = (REPO / rel).read_text()
             self.assertIsNone(

--- a/tests/owner-activity-atomic-write.test.py
+++ b/tests/owner-activity-atomic-write.test.py
@@ -92,9 +92,11 @@ class TestOwnerActivityAtomicWrite(unittest.TestCase):
         )
 
     def test_source_sites_use_perpid_staging(self):
-        """The three bridges must stage OWNER_ACTIVITY_FILE per-PID (#2222)."""
+        """All four owner-activity writers — the three bridges plus the sparrow
+        remote-gateway bridge — must stage OWNER_ACTIVITY_FILE per-PID (#2222)."""
         bridges = ["src/slack-bridge.py", "src/discord-bridge.py",
-                   "src/telegram-bridge.py"]
+                   "src/telegram-bridge.py",
+                   "packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py"]
         bad = re.compile(r'OWNER_ACTIVITY_FILE\.with_suffix\(\s*["\']\.json\.tmp["\']')
         good = re.compile(r'OWNER_ACTIVITY_FILE\.with_suffix\(\s*f["\']\.json\.\{os\.getpid\(\)\}\.tmp["\']')
         for rel in bridges:

--- a/tests/owner-activity-atomic-write.test.py
+++ b/tests/owner-activity-atomic-write.test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Regression tests for #2222: last-owner-activity.json torn/lost writes.
+
+`write_owner_activity()` in slack/discord/telegram bridges staged the temp file
+under a SHARED name (`.json.tmp`). That file is written by four processes (the
+three bridges + the sparrow remote-gateway bridge), so two concurrent writers
+could truncate and interleave the same temp file, and the rename could then
+publish torn JSON — a reader (the proactive loop's owner-presence check) would
+see a corrupt or partial timestamp. The fix stages under a per-PID name so no
+two processes ever share a temp file, and uses os.replace (atomic overwrite).
+
+Two tests:
+  1. Concurrency proof — many processes writing the target file with the fixed
+     (per-PID) pattern; the file is valid JSON at every sampled read and after.
+     This is designed to run long enough that the OLD shared-name pattern would
+     tear (demonstrated by the `--demo-old-pattern-tears` self-check below).
+  2. Source guard — the three bridge call sites use the per-PID form, not the
+     bare shared `.json.tmp`. Deterministic; mutation-checked (revert → fail).
+
+Run: python3 tests/owner-activity-atomic-write.test.py
+"""
+import json
+import multiprocessing
+import os
+import re
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+# ---- the two staging strategies, isolated so the test exercises the exact
+#      shape the bridges use (shared vs per-PID + os.replace) ----------------
+
+def _write_shared(target: Path, payload: dict) -> None:
+    tmp = target.with_suffix(".json.tmp")            # the #2222 bug
+    tmp.write_text(json.dumps(payload))
+    os.replace(tmp, target)
+
+
+def _write_perpid(target: Path, payload: dict) -> None:
+    tmp = target.with_suffix(f".json.{os.getpid()}.tmp")  # the fix
+    tmp.write_text(json.dumps(payload))
+    os.replace(tmp, target)
+
+
+def _hammer(target_str: str, strategy: str, n: int) -> int:
+    """Write `n` times; return the count of self-observed valid final states.
+    Runs in a child process (macOS spawn re-imports this module cleanly)."""
+    target = Path(target_str)
+    writer = _write_shared if strategy == "shared" else _write_perpid
+    for i in range(n):
+        writer(target, {"ts": int(time.time()), "pid": os.getpid(), "i": i})
+    return n
+
+
+class TestOwnerActivityAtomicWrite(unittest.TestCase):
+    def _run_fleet(self, strategy: str, procs: int = 12, writes: int = 120) -> Path:
+        tmpdir = Path(tempfile.mkdtemp(prefix="oa-2222-"))
+        target = tmpdir / "last-owner-activity.json"
+        target.write_text(json.dumps({"ts": 0, "seed": True}))
+        ctx = multiprocessing.get_context("spawn")
+        ps = [ctx.Process(target=_hammer, args=(str(target), strategy, writes))
+              for _ in range(procs)]
+        for p in ps:
+            p.start()
+        # Sample the file WHILE writers race; every observed state must parse.
+        torn = 0
+        deadline = time.time() + 5
+        while any(p.is_alive() for p in ps) and time.time() < deadline:
+            try:
+                json.loads(target.read_text())
+            except (ValueError, OSError):
+                torn += 1
+        for p in ps:
+            p.join(10)
+        # Final state must always be valid, regardless of strategy (rename is
+        # atomic); the interesting signal is torn reads observed mid-race.
+        json.loads(target.read_text())
+        self._torn = torn
+        return target
+
+    def test_perpid_never_tears_under_concurrency(self):
+        """With per-PID staging, no concurrent reader ever sees torn JSON."""
+        self._run_fleet("perpid")
+        self.assertEqual(
+            self._torn, 0,
+            f"per-PID staging produced {self._torn} torn reads — must be 0",
+        )
+
+    def test_source_sites_use_perpid_staging(self):
+        """The three bridges must stage OWNER_ACTIVITY_FILE per-PID (#2222)."""
+        bridges = ["src/slack-bridge.py", "src/discord-bridge.py",
+                   "src/telegram-bridge.py"]
+        bad = re.compile(r'OWNER_ACTIVITY_FILE\.with_suffix\(\s*["\']\.json\.tmp["\']')
+        good = re.compile(r'OWNER_ACTIVITY_FILE\.with_suffix\(\s*f["\']\.json\.\{os\.getpid\(\)\}\.tmp["\']')
+        for rel in bridges:
+            src = (REPO / rel).read_text()
+            self.assertIsNone(
+                bad.search(src),
+                f"{rel} still stages OWNER_ACTIVITY_FILE under a shared .json.tmp",
+            )
+            self.assertIsNotNone(
+                good.search(src),
+                f"{rel} does not use the per-PID staging name",
+            )
+
+
+# Self-check (not part of the suite): demonstrate the OLD pattern CAN tear, so
+# the concurrency test above is known to exercise a real race. Run manually:
+#   python3 tests/owner-activity-atomic-write.test.py --demo-old-pattern-tears
+def _demo_old_tears() -> None:
+    t = TestOwnerActivityAtomicWrite()
+    t._run_fleet("shared", procs=16, writes=400)
+    print(f"shared-name pattern: {t._torn} torn reads observed mid-race "
+          f"(>0 confirms the race is real)")
+
+
+if __name__ == "__main__":
+    if "--demo-old-pattern-tears" in sys.argv:
+        _demo_old_tears()
+    else:
+        unittest.main()

--- a/tests/owner-activity-atomic-write.test.py
+++ b/tests/owner-activity-atomic-write.test.py
@@ -92,8 +92,10 @@ class TestOwnerActivityAtomicWrite(unittest.TestCase):
         )
 
     def test_source_sites_use_perpid_staging(self):
-        """All four owner-activity writers — the three bridges plus the sparrow
-        remote-gateway bridge — must stage OWNER_ACTIVITY_FILE per-PID (#2222)."""
+        """All FIVE owner-activity writers — the three bridges, the sparrow
+        remote-gateway bridge (Python), and the task-bridge (TypeScript) — must
+        stage OWNER_ACTIVITY_FILE per-PID (#2222). The census is complete: any
+        new writer of the shared target must appear here or the guard is a lie."""
         bridges = ["src/slack-bridge.py", "src/discord-bridge.py",
                    "src/telegram-bridge.py",
                    "packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py"]
@@ -109,6 +111,22 @@ class TestOwnerActivityAtomicWrite(unittest.TestCase):
                 good.search(src),
                 f"{rel} does not use the per-PID staging name",
             )
+
+        # The 5th writer is TypeScript (src/task-bridge.ts) with different syntax:
+        # a shared `OWNER_ACTIVITY_FILE + '.tmp'` vs a per-PID template literal
+        # `${OWNER_ACTIVITY_FILE}.${process.pid}.tmp`.
+        ts_rel = "src/task-bridge.ts"
+        ts_src = (REPO / ts_rel).read_text()
+        ts_bad = re.compile(r"OWNER_ACTIVITY_FILE\s*\+\s*['\"]\.tmp['\"]")
+        ts_good = re.compile(r"\$\{OWNER_ACTIVITY_FILE\}\.\$\{process\.pid\}\.tmp")
+        self.assertIsNone(
+            ts_bad.search(ts_src),
+            f"{ts_rel} still stages OWNER_ACTIVITY_FILE under a shared .tmp",
+        )
+        self.assertIsNotNone(
+            ts_good.search(ts_src),
+            f"{ts_rel} does not use the per-PID staging name",
+        )
 
 
 # Self-check (not part of the suite): demonstrate the OLD pattern CAN tear, so

--- a/tests/sparrow-per-pid-staging.test.py
+++ b/tests/sparrow-per-pid-staging.test.py
@@ -43,13 +43,29 @@ class TestSparrowPerPidStaging(unittest.TestCase):
 
     def test_all_four_state_files_use_per_pid(self):
         code = SPARROW_PY.read_text()
-        for var in ("OWNER_ACTIVITY_FILE", "GATEWAY_STATUS_FILE",
-                    "TASK_ROOMS_FILE", "INFLIGHT_FILE"):
+        # The three single-writer state files (gateway-status / task-rooms /
+        # inflight) are written only by the single-threaded poll loop, so a
+        # per-PID temp name is sufficient.
+        for var in ("GATEWAY_STATUS_FILE", "TASK_ROOMS_FILE", "INFLIGHT_FILE"):
             pat = rf'{var}\.with_suffix\(\s*f["\']\.json\.\{{os\.getpid\(\)\}}\.tmp["\']'
             self.assertRegex(
                 code, pat,
                 f"{var} does not stage under a per-PID temp name",
             )
+        # OWNER_ACTIVITY_FILE is written by FIVE processes AND (for Slack Bolt)
+        # multiple threads within one process, so PID-only is NOT enough — it must
+        # stage per-INVOCATION (PID + uuid4), unique across processes and threads.
+        # See tests/owner-activity-atomic-write.test.py for the concurrency proof.
+        self.assertRegex(
+            code,
+            r'OWNER_ACTIVITY_FILE\.with_suffix\(\s*f["\']\.json\.\{os\.getpid\(\)\}\.\{uuid\.uuid4\(\)\.hex\}\.tmp["\']',
+            "OWNER_ACTIVITY_FILE must stage per-invocation (PID + uuid), not PID-only",
+        )
+        self.assertNotRegex(
+            code,
+            r'OWNER_ACTIVITY_FILE\.with_suffix\(\s*f["\']\.json\.\{os\.getpid\(\)\}\.tmp["\']',
+            "OWNER_ACTIVITY_FILE still uses the thread-unsafe PID-only staging",
+        )
 
     # -- behavioral: the live gateway-status write stages a pid-suffixed temp -- #
 


### PR DESCRIPTION
Closes #2222.

## The bug

`write_owner_activity()` in `slack-bridge.py`, `discord-bridge.py`, and `telegram-bridge.py` staged its atomic write under a **shared** temp name:

```python
tmp = OWNER_ACTIVITY_FILE.with_suffix(".json.tmp")
tmp.write_text(json.dumps(payload))
tmp.rename(OWNER_ACTIVITY_FILE)
```

`last-owner-activity.json` is written by **four** processes — these three bridges plus the sparrow remote-gateway bridge. When two fire within the same window, both open and truncate the *same* temp file; their writes interleave, and the `rename` can publish torn JSON. The reader is the proactive loop's owner-presence check, which then sees a corrupt or partial timestamp.

## The fix

```python
tmp = OWNER_ACTIVITY_FILE.with_suffix(f".json.{os.getpid()}.tmp")
tmp.write_text(json.dumps(payload))
os.replace(tmp, OWNER_ACTIVITY_FILE)
```

A per-PID temp is never shared, so no two writers touch the same staging file; `os.replace` is an atomic overwrite, so the final file is always one writer's complete payload — last writer wins, which is the correct semantics for a "latest activity" record.

## Scope

The three in-repo bridges. The **sparrow** package (`packages/ag2-sparrow/…/remote_gateway_bridge.py`) shares this exact pattern across several state files (`owner-activity`, `gateway-status`, `task-rooms`, `inflight`) — a separate package boundary, filed as a follow-up on #2222. Fixing these three already removes the realistic collision: they're the bridges that co-run on one host, and once each uses a distinct temp name, no two writers share a path.

Deliberately does **not** touch the other shared-`.json.tmp` sites (`WELCOMED_USERS_FILE`, `DM_CHECKPOINT_FILE`, `PENDING_REPLIES_FILE`) — those are single-writer per file, so they don't have the multi-process collision this fixes. Narrowed to the actual bug.

## Test — `tests/owner-activity-atomic-write.test.py`

- **Concurrency proof**: 12 spawned processes hammer the target with the per-PID pattern while a reader samples throughout; every read parses — **0 torn**. A self-check (`--demo-old-pattern-tears`) shows the shared-name pattern *does* produce torn mid-race reads, so the proof is exercising a real race, not a no-op.
- **Source guard**: asserts the three call sites use the per-PID form, not the bare `.json.tmp`. **Mutation-checked** — reverting any one to the shared name fails it.

`multiprocessing` uses the **spawn** context with module-level targets (macOS-safe; avoids the #2201 heredoc re-import trap that burned a CI timeout). Bounded by a 5s deadline + `join`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuRpcYxqsRQsoV44E5Gh1
