### PR TITLE
fix(gateway-bridge): prefer IPv4 for the relay (v6-blackhole ~26s delay)

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -47,6 +47,7 @@ import json
 import os
 import re
 import signal
+import socket
 import sys
 import tempfile
 import time
@@ -54,6 +55,30 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
+
+# Prefer IPv4 for gateway/relay connections. The relay host (e.g. chat.ag2.space)
+# publishes AAAA records, but some hosts have IPv6 black-holed at the network
+# (the SYN is silently dropped, not refused). Python's getaddrinfo returns v6
+# first, so each fresh urllib connection — this bridge opens one per long-poll
+# AND one per outbound send, with no keep-alive — hangs on the dead v6 address
+# for the full TCP connect timeout (~26s observed) before falling back to v4,
+# which connects in <1s. That timeout is added to EVERY inbound message and
+# EVERY reply, so the owner sees ~26s each way and messages look dropped. We
+# filter getaddrinfo to A (v4) records for the gateway host so the dead v6 path
+# is never tried; we keep the original result when there is no v4 address, so a
+# genuinely v6-only destination still resolves. Opt out with
+# REMOTE_GATEWAY_ALLOW_IPV6=1 (hosts with working v6 lose nothing either way).
+if os.environ.get("REMOTE_GATEWAY_ALLOW_IPV6") != "1":
+    _orig_getaddrinfo = socket.getaddrinfo
+
+    def _getaddrinfo_prefer_v4(host, *args, **kwargs):
+        infos = _orig_getaddrinfo(host, *args, **kwargs)
+        if host and "ag2.space" in str(host):
+            v4 = [i for i in infos if i[0] == socket.AF_INET]
+            return v4 or infos
+        return infos
+
+    socket.getaddrinfo = _getaddrinfo_prefer_v4
 
 # resolve_workspace lives alongside this file in src/ — put THIS directory on
 # the path (no repo-walking; the old triple-parent form predated the move into


### PR DESCRIPTION
## Symptom

The owner saw a **~26s delay each way** on gateway messages (enough to double-send, and some replies appeared dropped). Measured live 2026-07-20 on this host: stuck `tcp6 SYN_SENT` sockets to the relay's IPv6 address (`chat.ag2.space` → `2606:4700:20::…`), while IPv4 connects in **0.25s**.

## Root cause

The host has **IPv6 black-holed** (SYN silently dropped, not refused). The relay publishes AAAA records, so `getaddrinfo` returns v6 first. `remote_gateway_bridge.py` uses stdlib `urllib` with **no keep-alive** — it opens a fresh connection per long-poll (`GET /v1/tasks?wait=25`) *and* per outbound send. Each fresh connect hangs on the dead v6 address for the full TCP timeout (~26s) before falling back to v4. That timeout lands on every inbound message and every reply. (`POLL_WAIT=25` looks like the culprit but isn't — a long-poll returns immediately on a message; the delay is the v6 **connect**, not the poll wait.)

## Fix

Filter `getaddrinfo` to A (v4) records **for the gateway host only** (`ag2.space`), at import:
- Dead v6 path is never tried → no ~26s timeout, both directions.
- Keeps the original result when there's no v4 address → a genuinely v6-only destination still resolves.
- Scoped to the relay host → nothing else on the process is affected.
- Opt out with `REMOTE_GATEWAY_ALLOW_IPV6=1`.

## Verification

- `python3` check: `getaddrinfo("chat.ag2.space", 443)` families `[AF_INET, AF_INET6]` → **`[AF_INET]`** after the filter; a non-`ag2.space` host passes through unchanged; fallback path preserved.
- `py_compile` clean.

Filed from live owner-facing impact. Memory: `reference_ipv6_blackhole_relay_delay`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
