### PR TITLE
test(sparrow): atomic publish + in-flight recovery regression tests (v1 freeze gate)

### DIFF
--- a/packages/ag2-sparrow/tests/test_inflight_recovery.py
+++ b/packages/ag2-sparrow/tests/test_inflight_recovery.py
@@ -1,0 +1,96 @@
+"""in-flight ledger — crash-before-ack recovery (v1 freeze gate #142 item 6).
+
+A task pulled from the broker but not yet completed (`POST /v1/results`) lives in
+the persisted in-flight set. If the worker restarts between pull and result-POST,
+the set must survive so the result drain re-acks it — otherwise the reply is lost
+(the exact restart-safety gap called out in the broker README). The ledger write
+must be atomic (no partial JSON) and the read must fail open (a corrupt ledger
+starts empty, never crashes the loop).
+"""
+import os, json, importlib, sys, pathlib, tempfile
+
+
+def _load(base):
+    os.environ["AGENT_CONNECT_TASK_DIR"] = str(base / "tasks")
+    os.environ["AGENT_CONNECT_RESULT_DIR"] = str(base / "results")
+    os.environ["AGENT_CONNECT_STATE_DIR"] = str(base / "state")
+    os.environ.setdefault("REMOTE_TASK_URL", "https://gw.example/relay")
+    os.environ.setdefault("REMOTE_TASK_TOKEN", "dummy-secret")
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+    mod = importlib.import_module("ag2_sparrow.remote_gateway_bridge")
+    return importlib.reload(mod)
+
+
+def test_inflight_survives_restart():
+    """save → simulated restart (reload) → load returns the same set."""
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        m = _load(base)
+        pulled = {"task-1", "task-2", "task-3"}
+        m._save_inflight(pulled)
+        assert m.INFLIGHT_FILE.exists()
+        # Atomic write — no temp sidecar left behind.
+        assert not (m.INFLIGHT_FILE.with_suffix(".json.tmp")).exists()
+        # Persisted as a sorted JSON list (deterministic on disk).
+        assert json.loads(m.INFLIGHT_FILE.read_text()) == ["task-1", "task-2", "task-3"]
+        # Restart: reload the module (same state dir) and read back.
+        m2 = _load(base)
+        assert m2._load_inflight() == pulled, "in-flight set must survive a restart"
+        print("PASS test_inflight_survives_restart")
+
+
+def test_inflight_load_fails_open_on_corruption():
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        m = _load(base)
+        m.INFLIGHT_FILE.parent.mkdir(parents=True, exist_ok=True)
+        m.INFLIGHT_FILE.write_text("{ not json at all ")
+        assert m._load_inflight() == set(), "corrupt ledger must load empty, not raise"
+        # A JSON object (not a list) is also treated as empty, not crashed on.
+        m.INFLIGHT_FILE.write_text('{"task-1": true}')
+        assert m._load_inflight() == set()
+        print("PASS test_inflight_load_fails_open_on_corruption")
+
+
+def test_inflight_load_missing_file_is_empty():
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        m = _load(base)
+        if m.INFLIGHT_FILE.exists():
+            m.INFLIGHT_FILE.unlink()
+        assert m._load_inflight() == set()
+        print("PASS test_inflight_load_missing_file_is_empty")
+
+
+def test_inflight_save_never_raises_on_unwritable():
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        m = _load(base)
+        m.INFLIGHT_FILE = pathlib.Path("/proc/nonexistent/dir/inflight.json")
+        m._save_inflight({"task-1"})  # must swallow, not raise
+        print("PASS test_inflight_save_never_raises_on_unwritable")
+
+
+def test_inflight_round_trip_after_add_and_discard():
+    """The real loop mutates the set as tasks are pulled and acked — verify the
+    ledger reflects an add-then-discard across a persist boundary."""
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        m = _load(base)
+        s = m._load_inflight()          # empty
+        s.add("task-a")                 # pulled
+        s.add("task-b")                 # pulled
+        m._save_inflight(s)
+        s.discard("task-a")             # acked via /v1/results
+        m._save_inflight(s)
+        assert _load(base)._load_inflight() == {"task-b"}
+        print("PASS test_inflight_round_trip_after_add_and_discard")
+
+
+if __name__ == "__main__":
+    test_inflight_survives_restart()
+    test_inflight_load_fails_open_on_corruption()
+    test_inflight_load_missing_file_is_empty()
+    test_inflight_save_never_raises_on_unwritable()
+    test_inflight_round_trip_after_add_and_discard()
+    print("ALL PASS test_inflight_recovery")

--- a/packages/ag2-sparrow/tests/test_write_task_atomic.py
+++ b/packages/ag2-sparrow/tests/test_write_task_atomic.py
@@ -103,6 +103,38 @@ def test_write_task_is_idempotent_under_redelivery():
         print("PASS test_write_task_is_idempotent_under_redelivery")
 
 
+def test_write_task_does_not_reexecute_a_completed_task():
+    """v1 freeze gate item 3: same task_id never starts two local executions.
+    The broker re-serves a task on lease expiry; if the worker already handled it,
+    `_write_task` must NOT re-queue it (no second run for the watcher to pick up) —
+    it drops a `[no-send]` result so the drain re-acks it upstream instead."""
+    # (a) the task was already processed + archived
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        tid = "task-1784500000010"
+        arch = m.TASKS_DIR / "archive"
+        arch.mkdir(parents=True, exist_ok=True)
+        (arch / f"{tid}.txt").write_text(f"id: {tid}\ntask: handled earlier\n")
+        assert m._write_task(_task(tid)) == tid
+        # NOT re-queued — nothing live for the watcher to execute a second time.
+        assert list(m.TASKS_DIR.glob("task-*.txt")) == []
+        rfile = m.RESULTS_DIR / f"{tid}.txt"
+        assert rfile.exists() and rfile.read_text().startswith("[no-send]")
+        print("PASS test_write_task_does_not_reexecute_a_completed_task (archived task)")
+
+    # (b) the reply was already delivered + archived (result archive, ts-suffixed)
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        tid = "task-1784500000011"
+        m.ARCHIVE_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        (m.ARCHIVE_RESULTS_DIR / f"{tid}-1784500000999.txt").write_text("earlier reply\n")
+        assert m._write_task(_task(tid)) == tid
+        assert list(m.TASKS_DIR.glob("task-*.txt")) == []
+        rfile = m.RESULTS_DIR / f"{tid}.txt"
+        assert rfile.exists() and rfile.read_text().startswith("[no-send]")
+        print("PASS test_write_task_does_not_reexecute_a_completed_task (archived result)")
+
+
 def test_write_task_drops_unsafe_and_idless():
     with tempfile.TemporaryDirectory() as d:
         base = pathlib.Path(d)
@@ -117,5 +149,6 @@ if __name__ == "__main__":
     test_write_task_publishes_atomically_and_completely()
     test_write_task_never_leaves_partial_file_on_publish_crash()
     test_write_task_is_idempotent_under_redelivery()
+    test_write_task_does_not_reexecute_a_completed_task()
     test_write_task_drops_unsafe_and_idless()
     print("ALL PASS test_write_task_atomic")

--- a/packages/ag2-sparrow/tests/test_write_task_atomic.py
+++ b/packages/ag2-sparrow/tests/test_write_task_atomic.py
@@ -1,0 +1,121 @@
+"""_write_task — atomic publish + idempotency (v1 freeze gate #142 item 5).
+
+The transport writer must publish a task file so the core's watcher never sees a
+partial file, and must be idempotent under gateway redelivery (the relay replays
+its un-acked pool on reconnect — the 2026-06-30/07-01 500-task floods). These are
+the two properties the at-least-once broker contract leans on at the worker edge.
+"""
+import os, importlib, sys, pathlib, tempfile
+
+
+def _load(base):
+    """Reload the bridge with task/result/state dirs pointed under `base`."""
+    os.environ["AGENT_CONNECT_TASK_DIR"] = str(base / "tasks")
+    os.environ["AGENT_CONNECT_RESULT_DIR"] = str(base / "results")
+    os.environ["AGENT_CONNECT_STATE_DIR"] = str(base / "state")
+    os.environ.setdefault("REMOTE_TASK_URL", "https://gw.example/relay")
+    os.environ.setdefault("REMOTE_TASK_TOKEN", "dummy-secret")
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+    mod = importlib.import_module("ag2_sparrow.remote_gateway_bridge")
+    return importlib.reload(mod)
+
+
+def _task(tid="task-1784500000000"):
+    return {
+        "id": tid,
+        "task": "[AG2Space qingyun] hello there",
+        "source": "ag2space",
+        "channel_id": "!room:ag2.space",
+        "user_id": "@qingyun:ag2.space",
+        "timestamp": "2026-07-20T00:00:00Z",
+    }
+
+
+def test_write_task_publishes_atomically_and_completely():
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        m = _load(base)
+        tid = m._write_task(_task())
+        dest = m.TASKS_DIR / f"{tid}.txt"
+        assert tid == "task-1784500000000"
+        assert dest.exists(), "task file must be published"
+        # No temp sidecar left behind — the tmp+rename must have completed.
+        assert not (dest.with_suffix(".txt.tmp")).exists()
+        # The watcher globs task-*.txt; the tmp name (…​.txt.tmp) must not match it.
+        assert list(m.TASKS_DIR.glob("task-*.txt")) == [dest]
+        body = dest.read_text()
+        assert body.endswith("\n")
+        # access_tier is written LAST so a last-occurrence parser can't be tricked.
+        assert body.rstrip().splitlines()[-1].startswith("access_tier:")
+        assert "id: task-1784500000000" in body
+        assert "source: ag2space" in body
+        print("PASS test_write_task_publishes_atomically_and_completely")
+
+
+def test_write_task_never_leaves_partial_file_on_publish_crash():
+    """If the process dies at the rename, the watcher-visible .txt must not exist —
+    the reader only ever sees the fully-formed file or nothing (atomic publish)."""
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        m = _load(base)
+        tid = "task-1784500000001"
+        dest = m.TASKS_DIR / f"{tid}.txt"
+        orig_rename = pathlib.Path.rename
+
+        def boom(self, target):
+            raise OSError("simulated crash at publish")
+
+        pathlib.Path.rename = boom
+        try:
+            raised = False
+            try:
+                m._write_task(_task(tid))
+            except OSError:
+                raised = True
+            assert raised, "a failed publish must surface, not silently succeed"
+        finally:
+            pathlib.Path.rename = orig_rename
+        # The watcher-visible .txt must NOT exist — only nothing or a .tmp sidecar.
+        assert not dest.exists(), "partial task must never be visible to the watcher"
+        print("PASS test_write_task_never_leaves_partial_file_on_publish_crash")
+
+
+def test_write_task_is_idempotent_under_redelivery():
+    """Re-writing an already-queued task returns its id without duplicating the
+    file — the guard that survives the relay replaying its un-acked pool."""
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        m = _load(base)
+        t = _task("task-1784500000002")
+        tid1 = m._write_task(t)
+        first = (m.TASKS_DIR / f"{tid1}.txt").read_text()
+        # Redeliver the SAME id with a DIFFERENT body: the guard must skip the
+        # rewrite entirely (return the id, leave the queued file byte-for-byte).
+        # A modified body proves the guard fired — an identical body could pass
+        # even with no guard at all.
+        redelivered = dict(t, task="[AG2Space qingyun] TAMPERED redelivery body")
+        tid2 = m._write_task(redelivered)
+        assert tid1 == tid2
+        assert list(m.TASKS_DIR.glob("task-*.txt")) == [m.TASKS_DIR / f"{tid1}.txt"]
+        # Untouched — the original queued content wins, not the redelivery.
+        assert (m.TASKS_DIR / f"{tid1}.txt").read_text() == first
+        assert "TAMPERED" not in (m.TASKS_DIR / f"{tid1}.txt").read_text()
+        print("PASS test_write_task_is_idempotent_under_redelivery")
+
+
+def test_write_task_drops_unsafe_and_idless():
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        m = _load(base)
+        assert m._write_task({"task": "no id"}) is None
+        assert m._write_task({"id": "../etc/passwd", "task": "x"}) is None
+        assert list(m.TASKS_DIR.glob("*")) == []
+        print("PASS test_write_task_drops_unsafe_and_idless")
+
+
+if __name__ == "__main__":
+    test_write_task_publishes_atomically_and_completely()
+    test_write_task_never_leaves_partial_file_on_publish_crash()
+    test_write_task_is_idempotent_under_redelivery()
+    test_write_task_drops_unsafe_and_idless()
+    print("ALL PASS test_write_task_atomic")


### PR DESCRIPTION
## What
Regression tests for the **ag2-sparrow** transport client. No product code — tests only.

They pin the worker-edge correctness properties the client's at-least-once task protocol depends on:

**`test_write_task_atomic.py`**
- **Atomic publish** — `_write_task` writes complete-or-nothing (tmp+rename); the watcher never sees a partial file, and a crash at publish leaves no partial `.txt`. `access_tier` is written last (last-occurrence-parser defense).
- **Idempotent under redelivery** — a re-delivered task id is not re-queued (mutation-verified: a modified-body redelivery must not overwrite the queued file).
- **No double execution on re-serve** — if the client already handled a task (archived task, or already-delivered result), a re-served copy is **not** re-queued for a second run; it drops a `[no-send]` result so the drain re-acks it. Mutation-checked against removing the dedup guard.
- Drops id-less / unsafe-id tasks.

**`test_inflight_recovery.py`**
- The persisted in-flight ledger **survives a restart** (save → reload → load round-trips), so a task pulled but not yet result-posted isn't lost across a crash. Atomic write; read fails open (corrupt/missing ledger → empty, never raises).

```
cd packages/ag2-sparrow
python3 tests/test_write_task_atomic.py     # ALL PASS
python3 tests/test_inflight_recovery.py     # ALL PASS
```
