### PR TITLE
fix(sparrow): self-healing retry for task /ack when the gateway gains the endpoint

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -386,6 +386,15 @@ def _req(method: str, path: str, payload: dict | None = None, timeout: int = 35)
         return json.loads(raw) if raw else {}
 
 
+def _http_error_body(e) -> str:
+    """Best-effort read of an HTTPError's response body, for content-sniffing a
+    per-task answer vs an endpoint-unsupported one. Never raises."""
+    try:
+        return (e.read() or b"").decode("utf-8", "replace")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 def _post_task_ack(tid: str) -> bool:
     """Tell the gateway a task made it safely into the local queue."""
     global _ack_disabled_until
@@ -400,8 +409,18 @@ def _post_task_ack(tid: str) -> bool:
         return True
     except urllib.error.HTTPError as e:
         if e.code in (404, 405):
-            # Not permanent: a broker that later deploys /ack should be picked up
-            # without a worker restart, so back off for a cooldown and retry.
+            # A 404/405 is ambiguous. The pre-/ack broker returns a bare no-route
+            # 404/405 → the endpoint is UNSUPPORTED: back off (cooldown) and retry
+            # later, so a broker that deploys /ack afterward is picked up without a
+            # restart. But the DEPLOYED broker returns a PER-TASK
+            # 404 {"error":"not leased to you"} when THIS task's lease expired /
+            # was re-served / isn't ours — routine under churn. That must NOT
+            # disable acking for every OTHER task (one stale lease would blind the
+            # whole host's `received` state), so treat it as a single-task negative
+            # ack: skip this one, leave global acking enabled. (Per qingyun-001,
+            # broker-half author — the deployed 404 is per-task, not "no route".)
+            if e.code == 404 and "not leased" in _http_error_body(e).lower():
+                return False   # per-task lease gone — keep acking the rest
             _ack_disabled_until = time.time() + ACK_UNSUPPORTED_COOLDOWN
             _log(f"gateway does not support task ack — retrying in "
                  f"{ACK_UNSUPPORTED_COOLDOWN}s")

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -117,7 +117,12 @@ URL = (_env_compat("REMOTE_TASK_URL", "AG2_REMOTE_URL")
 PROVIDER = os.environ.get("REMOTE_TASK_PROVIDER") or "remote"
 POLL_WAIT = int(os.environ.get("REMOTE_TASK_POLL_WAIT") or "25")
 HEARTBEAT_INTERVAL = 60
-_ack_disabled = False
+# When the gateway lacks /v1/tasks/<id>/ack it returns 404/405; we back off
+# instead of hammering it — but only for this cooldown, then retry. A permanent
+# latch would mean a broker that GAINS the endpoint (e.g. a deploy) is never
+# picked up until the worker restarts; time-gating makes it self-healing.
+ACK_UNSUPPORTED_COOLDOWN = int(os.environ.get("REMOTE_ACK_RETRY_COOLDOWN") or "300")
+_ack_disabled_until = 0.0   # 0 = enabled; else epoch until which acks are skipped
 _heartbeat_disabled = False
 _last_heartbeat_at = 0.0
 
@@ -383,17 +388,23 @@ def _req(method: str, path: str, payload: dict | None = None, timeout: int = 35)
 
 def _post_task_ack(tid: str) -> bool:
     """Tell the gateway a task made it safely into the local queue."""
-    global _ack_disabled
-    if _ack_disabled or not _valid_tid(tid):
+    global _ack_disabled_until
+    if not _valid_tid(tid):
         return False
+    if _ack_disabled_until and time.time() < _ack_disabled_until:
+        return False  # gateway recently 404'd /ack — retry after the cooldown
     try:
         safe_tid = urllib.parse.quote(tid, safe="")
         _req("POST", f"/v1/tasks/{safe_tid}/ack", {"id": tid}, timeout=10)
+        _ack_disabled_until = 0.0  # success (or re-enablement) → clear any backoff
         return True
     except urllib.error.HTTPError as e:
         if e.code in (404, 405):
-            _ack_disabled = True
-            _log("gateway does not support task ack — continuing without")
+            # Not permanent: a broker that later deploys /ack should be picked up
+            # without a worker restart, so back off for a cooldown and retry.
+            _ack_disabled_until = time.time() + ACK_UNSUPPORTED_COOLDOWN
+            _log(f"gateway does not support task ack — retrying in "
+                 f"{ACK_UNSUPPORTED_COOLDOWN}s")
             return False
         if e.code in (401, 403):
             raise

--- a/packages/ag2-sparrow/tests/test_ack_retry.py
+++ b/packages/ag2-sparrow/tests/test_ack_retry.py
@@ -5,7 +5,7 @@ When the broker lacks the endpoint it 404s; the worker must back off — but NOT
 permanently, or a broker that later *deploys* the endpoint is never picked up
 until the worker restarts. This pins the time-gated retry (self-heal on deploy).
 """
-import os, importlib, sys, pathlib, tempfile
+import os, io, importlib, sys, pathlib, tempfile
 import urllib.error
 
 
@@ -23,6 +23,13 @@ def _load(base, cooldown="300"):
 
 def _http404():
     return urllib.error.HTTPError("https://gw/relay", 404, "no route", {}, None)
+
+
+def _http404_not_leased():
+    # The DEPLOYED broker's per-task 404: this lease expired / was re-served /
+    # isn't ours. Body carries the documented marker.
+    fp = io.BytesIO(b'{"error":"not leased to you"}')
+    return urllib.error.HTTPError("https://gw/relay", 404, "not leased", {}, fp)
 
 
 def test_ack_success_no_backoff():
@@ -88,9 +95,48 @@ def test_ack_self_heals_after_cooldown():
         print("PASS test_ack_self_heals_after_cooldown")
 
 
+def test_ack_per_task_404_not_leased_keeps_acking_others():
+    """A DEPLOYED-broker per-task `404 {"error":"not leased to you"}` (this lease
+    expired / re-served / foreign) must NOT arm the global cooldown — else one
+    stale lease silences /ack for EVERY other task on the host, blinding the
+    `received` state during churn. It's a single-task negative ack: skip this one,
+    leave global acking enabled. (Blocking finding from qingyun-001, broker author.)"""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d), cooldown="300")
+        calls = []
+
+        def not_leased(*a, **k):
+            calls.append(a)
+            raise _http404_not_leased()
+
+        m._req = not_leased
+        assert m._post_task_ack("task-stale") is False
+        assert len(calls) == 1
+        assert m._ack_disabled_until == 0.0, "per-task 404 must NOT arm the global cooldown"
+        # An unrelated task's ack still hits the network — acking stays enabled.
+        ok = []
+        m._req = lambda *a, **k: ok.append(a) or {"ok": True}
+        assert m._post_task_ack("task-other") is True
+        assert len(ok) == 1, "acking must stay enabled after a per-task not-leased 404"
+        print("PASS test_ack_per_task_404_not_leased_keeps_acking_others")
+
+
+def test_ack_bare_404_still_arms_cooldown():
+    """A bare no-route 404 (pre-/ack broker, no body) is still 'endpoint
+    unsupported' → arms the cooldown (self-heal path unchanged)."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d), cooldown="300")
+        m._req = lambda *a, **k: (_ for _ in ()).throw(_http404())
+        assert m._post_task_ack("task-x") is False
+        assert m._ack_disabled_until > 0, "bare no-route 404 must arm the cooldown"
+        print("PASS test_ack_bare_404_still_arms_cooldown")
+
+
 if __name__ == "__main__":
     test_ack_success_no_backoff()
     test_ack_invalid_tid_never_hits_network()
     test_ack_404_backs_off_within_cooldown()
     test_ack_self_heals_after_cooldown()
+    test_ack_per_task_404_not_leased_keeps_acking_others()
+    test_ack_bare_404_still_arms_cooldown()
     print("ALL PASS test_ack_retry")

--- a/packages/ag2-sparrow/tests/test_ack_retry.py
+++ b/packages/ag2-sparrow/tests/test_ack_retry.py
@@ -1,0 +1,96 @@
+"""_post_task_ack — self-healing retry when the gateway lacks /v1/tasks/<id>/ack.
+
+The worker acks each pulled task so the broker can surface a "received" state.
+When the broker lacks the endpoint it 404s; the worker must back off — but NOT
+permanently, or a broker that later *deploys* the endpoint is never picked up
+until the worker restarts. This pins the time-gated retry (self-heal on deploy).
+"""
+import os, importlib, sys, pathlib, tempfile
+import urllib.error
+
+
+def _load(base, cooldown="300"):
+    os.environ["AGENT_CONNECT_TASK_DIR"] = str(base / "tasks")
+    os.environ["AGENT_CONNECT_RESULT_DIR"] = str(base / "results")
+    os.environ["AGENT_CONNECT_STATE_DIR"] = str(base / "state")
+    os.environ["REMOTE_ACK_RETRY_COOLDOWN"] = cooldown
+    os.environ.setdefault("REMOTE_TASK_URL", "https://gw.example/relay")
+    os.environ.setdefault("REMOTE_TASK_TOKEN", "dummy-secret")
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+    mod = importlib.import_module("ag2_sparrow.remote_gateway_bridge")
+    return importlib.reload(mod)
+
+
+def _http404():
+    return urllib.error.HTTPError("https://gw/relay", 404, "no route", {}, None)
+
+
+def test_ack_success_no_backoff():
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = []
+        m._req = lambda *a, **k: calls.append(a) or {"ok": True}
+        assert m._post_task_ack("task-1") is True
+        assert len(calls) == 1
+        assert m._ack_disabled_until == 0.0
+        print("PASS test_ack_success_no_backoff")
+
+
+def test_ack_invalid_tid_never_hits_network():
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = []
+        m._req = lambda *a, **k: calls.append(a)
+        assert m._post_task_ack("../evil") is False
+        assert calls == []
+        print("PASS test_ack_invalid_tid_never_hits_network")
+
+
+def test_ack_404_backs_off_within_cooldown():
+    """A 404 arms a cooldown; a second ack *within* it is skipped (no network)."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d), cooldown="300")
+        calls = []
+
+        def boom(*a, **k):
+            calls.append(a)
+            raise _http404()
+
+        m._req = boom
+        assert m._post_task_ack("task-1") is False
+        assert len(calls) == 1
+        assert m._ack_disabled_until > 0, "404 must arm a cooldown"
+        # Second ack within the cooldown: skipped entirely, no network call.
+        assert m._post_task_ack("task-2") is False
+        assert len(calls) == 1, "within cooldown the worker must NOT hit /ack"
+        print("PASS test_ack_404_backs_off_within_cooldown")
+
+
+def test_ack_self_heals_after_cooldown():
+    """The cooldown the 404 sets must be FINITE — after it lapses the ack retries
+    and a now-deployed endpoint succeeds, with no worker restart. Uses cooldown=0
+    so the retry is driven by the handler's own value, NOT a manual timer reset:
+    a permanent latch (∞) fails this; a finite cooldown passes it."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d), cooldown="0")
+        # First ack 404s → handler arms _ack_disabled_until = now + 0 (already lapsed).
+        def boom(*a, **k):
+            raise _http404()
+        m._req = boom
+        assert m._post_task_ack("task-1") is False
+        # Endpoint has since deployed; next ack must retry (cooldown already lapsed),
+        # driven purely by the finite value the 404 handler set — no manual reset.
+        ok = []
+        m._req = lambda *a, **k: ok.append(a) or {"ok": True}
+        assert m._post_task_ack("task-2") is True, "finite cooldown must let the ack retry"
+        assert len(ok) == 1, "self-heal: a deployed endpoint is picked up without a restart"
+        assert m._ack_disabled_until == 0.0, "success clears the backoff"
+        print("PASS test_ack_self_heals_after_cooldown")
+
+
+if __name__ == "__main__":
+    test_ack_success_no_backoff()
+    test_ack_invalid_tid_never_hits_network()
+    test_ack_404_backs_off_within_cooldown()
+    test_ack_self_heals_after_cooldown()
+    print("ALL PASS test_ack_retry")

--- a/src/remote-gateway-bridge.py
+++ b/src/remote-gateway-bridge.py
@@ -73,7 +73,7 @@ for _root in (
 # module-level config (tier fail-closed parsing, URL/TOKEN, dirs) must
 # re-evaluate on EVERY load of this file — the mock-gateway test harness loads
 # it repeatedly under different env — and attribute reads/writes
-# (``rtc._ack_disabled = False``) must hit the same namespace the running code
+# (``rtc._ack_disabled_until = 0.0``) must hit the same namespace the running code
 # uses. A cached ``import ag2_sparrow.remote_gateway_bridge`` gives neither.
 _IMPL = _REPO / "packages" / "ag2-sparrow" / "ag2_sparrow" / "remote_gateway_bridge.py"
 __package__ = "ag2_sparrow"  # PEP 328: makes the source's relative imports resolve

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -242,11 +242,13 @@ def main() -> int:
           "malformed core-status → heartbeat omits status/step (liveness-only)")
 
     # Backwards compatibility: old gateways that only implement pull/results can
-    # 404 optional protocol extensions; the client disables them and continues.
+    # 404 optional protocol extensions; the client backs off (time-gated, so a
+    # gateway that later deploys /ack is picked up without a restart) and continues.
     STATE["force_ack_404"] = True
-    rtc._ack_disabled = False
-    check(not rtc._post_task_ack("task-OLD") and rtc._ack_disabled,
-          "task ack 404 disables ack support")
+    rtc._ack_disabled_until = 0.0
+    check(not rtc._post_task_ack("task-OLD") and rtc._ack_disabled_until > 0,
+          "task ack 404 backs off ack support (retryable)")
+    rtc._ack_disabled_until = 0.0   # clear so later calls aren't skipped
     STATE["force_ack_404"] = False
     STATE["force_heartbeat_404"] = True
     rtc._heartbeat_disabled = False


### PR DESCRIPTION
## What
Makes the worker's **optional** task-ack self-healing so a gateway that later *gains* the `POST /v1/tasks/<id>/ack` endpoint is picked up automatically, without a client restart.

## Why
`_post_task_ack` acks each pulled task (optional protocol extension). When the gateway lacks the endpoint it returns 404/405 — and the client latched `_ack_disabled = True` **permanently**. Since a client that has been polling a gateway without the endpoint already hit a 404, it stays latched off even after the endpoint becomes available — so the ack silently never resumes until the client restarts, with no error to explain it.

## Fix
Replace the permanent bool latch with a **time-gated backoff** (`_ack_disabled_until`): a 404/405 backs off for `REMOTE_ACK_RETRY_COOLDOWN` (default 300s), then retries; a successful ack clears it. A newly-available endpoint is picked up on the next cooldown boundary — no restart. Heartbeat keeps its own latch (separate concern).

## Test — `tests/test_ack_retry.py`
success-no-backoff, invalid-tid-no-network, 404-backs-off-within-cooldown, self-heal-after-cooldown. **Mutation-checked**: a permanent latch (cooldown → ∞) fails the self-heal test; the finite cooldown passes it.

```
cd packages/ag2-sparrow && python3 tests/test_ack_retry.py   # ALL PASS
```

Note: a client already running against a gateway that lacks the endpoint needs one restart to clear its in-memory latch; after this ships, later additions are picked up automatically.
