### PR TITLE
fix(config): tsx-bin resolution dies under pipefail on hosts without nvm

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -261,7 +261,11 @@ print(_host_label(), end='')
     # pins, and the ONLY tsx on a host with no homebrew/nvm/volta node at all),
     # then the usual global locations. Prints the resolved path, or nothing —
     # the caller falls back to `npx tsx` on empty output.
-    _nvm_tsx="$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin/tsx"
+    # `|| true` inside the substitution: on a host with no ~/.nvm the `ls`
+    # fails, and under `set -euo pipefail` that pipeline status would kill the
+    # whole script BEFORE the candidate loop — startup.sh then dies silently at
+    # its `_TSX_BIN=$(...)` line even though node_modules/.bin/tsx exists.
+    _nvm_tsx="$HOME/.nvm/versions/node/$( (ls "$HOME/.nvm/versions/node/" 2>/dev/null || true) | sort -V | tail -1)/bin/tsx"
     for _p in \
       "$REPO_ROOT/node_modules/.bin/tsx" \
       /opt/homebrew/bin/tsx \
@@ -270,6 +274,10 @@ print(_host_label(), end='')
       "$HOME/.volta/bin/tsx"; do
       [ -x "$_p" ] && { printf '%s' "$_p"; break; }
     done
+    # The contract is "print the path, or nothing" — exit 0 either way. Without
+    # this, a no-match run exits with the last [ -x ] test's failure status and
+    # set -e callers die instead of falling back to `npx tsx`.
+    true
     ;;
 
   dump)

--- a/tests/sutando-config-tsx-resolution.test.sh
+++ b/tests/sutando-config-tsx-resolution.test.sh
@@ -38,4 +38,16 @@ else
 fi
 grep -q 'sutando-config.sh" app-node-dir' "$WRAP" && say "PASS wrapper config-resolves app-node-dir" || { say "FAIL wrapper missing app-node-dir call"; fail=1; }
 
+# --- tsx-bin on a host with NO ~/.nvm (regression: pipefail killed the script) ---
+# The _nvm_tsx candidate assignment pipes `ls ~/.nvm/versions/node/` into
+# sort|tail; under set -euo pipefail a missing ~/.nvm made that pipeline's
+# status fatal BEFORE the candidate loop, so tsx-bin exited 1 with no output
+# and startup.sh died silently at its `_TSX_BIN=$(...)` line. The old
+# assertions above never caught this: empty output landed in the SKIP branch.
+_fake_home="$(mktemp -d)"
+out="$(HOME="$_fake_home" bash "$CFG" tsx-bin)"; rc=$?
+rmdir "$_fake_home"
+[ "$rc" -eq 0 ] && say "PASS tsx-bin exits 0 with no ~/.nvm" || { say "FAIL tsx-bin exit $rc with no ~/.nvm (pipefail regression)"; fail=1; }
+case "$out" in */node_modules/.bin/tsx) say "PASS repo tsx still resolved with no ~/.nvm";; *) say "FAIL no-nvm resolution: '$out'"; fail=1;; esac
+
 [ "$fail" -eq 0 ] && echo "PASS — tsx/app-node resolution centralized + config-resolved (startup + launchd)" || { echo "FAIL"; exit 1; }


### PR DESCRIPTION
## Problem

`bash src/startup.sh` dies **silently** at its `_TSX_BIN=$(...)` line (line 44) on any host without `~/.nvm` — full from-source startup is broken there. Found tonight attempting exactly that on a clean macOS host.

Root cause in `scripts/sutando-config.sh` (`set -euo pipefail`):

```bash
_nvm_tsx="$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node/" 2>/dev/null | sort -V | tail -1)/bin/tsx"
```

With no `~/.nvm`, `ls` fails (stderr hidden by `2>/dev/null`), `pipefail` propagates its status through the pipeline, and `set -e` kills the script **before the candidate loop runs** — `tsx-bin` exits 1 with no output even when `node_modules/.bin/tsx` exists right there. The caller's `set -e` then kills startup.sh with nothing printed past the log-path banner.

## Fix

1. Guard the `ls` inside the substitution (`(ls … || true) | sort | tail`) so a missing nvm dir is a non-event.
2. `true` after the candidate loop: the documented contract is "prints the path, **or nothing** — caller falls back to `npx tsx`", but a no-match run leaked the last `[ -x ]` test's failure status, killing `set -e` callers instead of letting them fall back.

## Why the existing test missed it

`tests/sutando-config-tsx-resolution.test.sh` routed empty output into its SKIP branch ("no tsx installed"). New regression case: with `HOME` pointed at an empty dir, `tsx-bin` must exit 0 and still resolve the repo-pinned tsx. **Fails on the pre-fix script, passes post-fix** (verified both directions).

## Verification

- `bash scripts/sutando-config.sh tsx-bin` → prints `node_modules/.bin/tsx`, exit 0 (was: silent exit 1)
- `bash src/startup.sh` → full stack boots (voice agent, web client, dashboard, agent API, bridges, core CLI in tmux)
- All 8 sutando-config test suites pass; `shellcheck -S error` clean on both touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)