### PR TITLE
feat(agent-room-ops): resolve_user + mention — @-mention a peer by handle

### DIFF
--- a/skills/agent-room-ops/mention.py
+++ b/skills/agent-room-ops/mention.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""room-ops · mention — @-mention another agent reliably, by friendly handle.
+
+The whole point: an agent should never hand-craft a peer's mxid (and get it wrong,
+or forget it — the single most-repeated delivery failure). Give `mention` a handle
+("qingyun-001") and a message; it resolves the one canonical mxid from the live
+/v1/agents directory and posts an op:message with that mxid leading the body — the
+form the broker's `is_mention` matches (localpart as a whole token), so the peer is
+actually triggered.
+
+`build_body` (pure) is separated from the network post so the mention-construction
+is unit-tested without a gateway.
+"""
+from __future__ import annotations
+
+import os
+
+from _gateway import gate_allows, load_gate, gateway, http_json, degrade_reason, HTTPError, URLError
+from resolve import resolve_user
+
+
+def _result(ok, *, room_id=None, mxid=None, event_id=None, candidates=None, reason=None):
+    return {"ok": bool(ok), "room_id": room_id, "mxid": mxid, "event_id": event_id,
+            "candidates": candidates or [], "reason": reason}
+
+
+def build_body(mxid: str, message: str) -> str:
+    """Compose the room message so the mention actually triggers the peer.
+
+    The mxid LEADS the body: `is_mention` matches the peer's localpart as a
+    whole token, and a leading mxid is unambiguous + reads as a directed ask.
+    An em dash separates it from the message when there is one.
+    """
+    message = (message or "").strip()
+    return f"{mxid} — {message}" if message else mxid
+
+
+def mention(handle: str, message: str, room_id: str, agent_mxid: str | None = None,
+            *, gate=None, agents: list | None = None) -> dict:
+    """Resolve `handle` → mxid and post a triggering @-mention into `room_id`.
+
+    Returns {ok, room_id, mxid, event_id, candidates, reason}. On an ambiguous
+    handle it does NOT post — it returns ok:false + the candidate mxids so the
+    caller disambiguates rather than mentioning the wrong agent.
+    """
+    agent_mxid = agent_mxid or os.environ.get("AGENT_MXID")
+    if not room_id:
+        return _result(False, room_id=room_id, reason="room_id required")
+    if not handle:
+        return _result(False, room_id=room_id, reason="handle required")
+
+    res = resolve_user(handle, agents=agents)
+    if not res.get("ok"):
+        return _result(False, room_id=room_id, candidates=res.get("candidates"),
+                       reason=res.get("reason") or "could not resolve handle")
+    mxid = res["mxid"]
+
+    gate = load_gate() if gate is None else gate
+    if not gate_allows(agent_mxid, room_id, gate):
+        return _result(False, room_id=room_id, mxid=mxid,
+                       reason=f"client gate denied for {agent_mxid}")
+
+    base, headers = gateway()
+    if not base:
+        return _result(False, room_id=room_id, mxid=mxid, reason="no gateway configured")
+
+    body = build_body(mxid, message)
+    try:
+        _status, parsed = http_json(
+            "POST", f"{base}/v1/room", headers,
+            {"op": "message", "room_id": room_id, "body": body},
+        )
+    except HTTPError as e:
+        return _result(False, room_id=room_id, mxid=mxid, reason=degrade_reason(e.code))
+    except (URLError, TimeoutError) as e:
+        return _result(False, room_id=room_id, mxid=mxid, reason=f"network error: {e}")
+    event_id = parsed.get("event_id") if isinstance(parsed, dict) else None
+    return _result(True, room_id=room_id, mxid=mxid, event_id=event_id)

--- a/skills/agent-room-ops/mention.py
+++ b/skills/agent-room-ops/mention.py
@@ -66,9 +66,13 @@ def mention(handle: str, message: str, room_id: str, agent_mxid: str | None = No
 
     body = build_body(mxid, message)
     try:
+        # `mentions` is forward-compat: the leading mxid in `body` already
+        # triggers via the broker's localpart text-match, so this is harmlessly
+        # ignored today — but it auto-activates structured push-notifications the
+        # moment the broker honors it (a peer-review ask, ties to broker #151).
         _status, parsed = http_json(
             "POST", f"{base}/v1/room", headers,
-            {"op": "message", "room_id": room_id, "body": body},
+            {"op": "message", "room_id": room_id, "body": body, "mentions": [mxid]},
         )
     except HTTPError as e:
         return _result(False, room_id=room_id, mxid=mxid, reason=degrade_reason(e.code))

--- a/skills/agent-room-ops/resolve.py
+++ b/skills/agent-room-ops/resolve.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""room-ops · resolve — map a friendly handle to an agent's mxid via GET /v1/agents.
+
+The recurring failure mode for an agent that wants to @-mention a peer is not the
+trigger (the broker's `is_mention` matches the peer's localpart as a whole token,
+so a plain-text mxid in the body already fires) — it's *hand-crafting the mxid*
+and getting it wrong or forgetting it. This module removes the hand-craft: give it
+a friendly handle ("qingyun-001", a label, or a full mxid) and it returns the one
+canonical mxid from the live directory, or the candidate set when ambiguous.
+
+Pure matching (`match_agent`) is separated from the network fetch so it is unit-
+testable without a gateway.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from _gateway import gateway, http_request, degrade_reason, HTTPError, URLError
+
+
+def _localpart(mxid: str) -> str:
+    """@sutando-qingyun-001:ag2.space -> sutando-qingyun-001."""
+    return (mxid or "").split(":", 1)[0].lstrip("@")
+
+
+def _is_mxid(q: str) -> bool:
+    return q.startswith("@") and ":" in q
+
+
+def match_agent(query: str, agents: list) -> dict:
+    """Resolve `query` to a single agent mxid from `agents` (list of {id, label,…}).
+
+    Ranking, best first: exact localpart → exact label → substring localpart →
+    substring label. A single winner at the best populated tier resolves; a tie at
+    that tier is reported as `candidates` (ambiguous, caller disambiguates). Pure —
+    no I/O — so the ranking is unit-tested directly.
+    """
+    q = (query or "").strip()
+    if not q:
+        return {"ok": False, "mxid": None, "candidates": [], "reason": "empty query"}
+    # A full mxid is already resolved — trust it (still normalise via the directory
+    # if present, but never fail just because the directory is stale/unreachable).
+    if _is_mxid(q):
+        return {"ok": True, "mxid": q, "candidates": [], "reason": "already an mxid"}
+
+    ql = q.lstrip("@").lower()
+    exact_local, exact_label, sub_local, sub_label = [], [], [], []
+    for a in agents or []:
+        mxid = a.get("id") or ""
+        if not mxid:
+            continue
+        lp = _localpart(mxid).lower()
+        label = (a.get("label") or "").lower()
+        if lp == ql:
+            exact_local.append(mxid)
+        elif label and label == ql:
+            exact_label.append(mxid)
+        elif ql in lp:
+            sub_local.append(mxid)
+        elif label and ql in label:
+            sub_label.append(mxid)
+
+    for tier in (exact_local, exact_label, sub_local, sub_label):
+        # De-dup while preserving order (an agent can't match two tiers, but a
+        # directory could list a dup id).
+        uniq = list(dict.fromkeys(tier))
+        if len(uniq) == 1:
+            return {"ok": True, "mxid": uniq[0], "candidates": [], "reason": None}
+        if len(uniq) > 1:
+            return {"ok": False, "mxid": None, "candidates": uniq,
+                    "reason": f"ambiguous — {len(uniq)} agents match {query!r}"}
+    return {"ok": False, "mxid": None, "candidates": [], "reason": f"no agent matches {query!r}"}
+
+
+def list_agents() -> dict:
+    """GET /v1/agents → {"ok", "agents": [...], "reason"}. Graceful on any failure."""
+    base, headers = gateway()
+    if not base:
+        return {"ok": False, "agents": [], "reason": "no gateway configured"}
+    try:
+        _, body, _h = http_request("GET", f"{base}/v1/agents", headers)
+    except HTTPError as e:
+        return {"ok": False, "agents": [], "reason": degrade_reason(e.code)}
+    except (URLError, TimeoutError) as e:
+        return {"ok": False, "agents": [], "reason": f"network error: {e}"}
+    try:
+        parsed = json.loads(body.decode("utf-8") or "{}")
+    except ValueError as e:
+        return {"ok": False, "agents": [], "reason": f"parse error: {e}"}
+    agents = parsed.get("agents") if isinstance(parsed, dict) else parsed
+    return {"ok": True, "agents": agents or [], "reason": None}
+
+
+def resolve_user(query: str, *, agents: list | None = None) -> dict:
+    """Resolve a friendly handle to a single agent mxid.
+
+    Returns {"ok", "mxid", "candidates", "reason"}. Pass `agents` to skip the
+    network fetch (tests / batch). A full mxid short-circuits without a fetch.
+    """
+    if _is_mxid((query or "").strip()):
+        return match_agent(query, agents or [])
+    if agents is None:
+        got = list_agents()
+        if not got["ok"]:
+            return {"ok": False, "mxid": None, "candidates": [], "reason": got["reason"]}
+        agents = got["agents"]
+    return match_agent(query, agents)

--- a/skills/agent-room-ops/room_ops.py
+++ b/skills/agent-room-ops/room_ops.py
@@ -28,6 +28,8 @@ import read as _read       # noqa: E402
 import media as _media     # noqa: E402
 import react as _react     # noqa: E402
 import join as _join       # noqa: E402
+import resolve as _resolve # noqa: E402
+import mention as _mention # noqa: E402
 
 
 def _main(argv):
@@ -74,6 +76,15 @@ def _main(argv):
         g.add_argument("--ack", choices=sorted(_react.ACK))
         p.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
 
+    p = sub.add_parser("resolve", help="resolve a friendly handle -> agent mxid (via /v1/agents)")
+    p.add_argument("handle")
+
+    p = sub.add_parser("mention", help="@-mention an agent by handle (resolve + post a triggering message)")
+    p.add_argument("handle")
+    p.add_argument("message")
+    p.add_argument("room_id")
+    p.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
+
     a = ap.parse_args(argv)
     if a.cmd == "read":
         res = _read.read_room(a.room_id, a.agent_mxid, a.limit, before=a.before)
@@ -103,6 +114,10 @@ def _main(argv):
                 res = _doc.doc_rm(a.room, a.name, folder=a.folder, agent_mxid=a.agent)
     elif a.cmd == "join":
         res = _join.join_room(a.room_id, a.agent_mxid)
+    elif a.cmd == "resolve":
+        res = _resolve.resolve_user(a.handle)
+    elif a.cmd == "mention":
+        res = _mention.mention(a.handle, a.message, a.room_id, a.agent_mxid)
     else:  # react / unreact
         key = a.key or _react.ACK[a.ack]
         fn = _react.react if a.cmd == "react" else _react.unreact

--- a/skills/agent-room-ops/test_room_ops.py
+++ b/skills/agent-room-ops/test_room_ops.py
@@ -526,6 +526,27 @@ class MentionBodyTests(unittest.TestCase):
         self.assertFalse(res["ok"])
         self.assertEqual(len(res["candidates"]), 2)
 
+    def test_post_payload_leads_with_mxid_and_carries_mentions(self):
+        # A resolved mention posts op:message to /v1/room with the mxid LEADING
+        # the body (text trigger) AND a forward-compat `mentions:[mxid]` (activates
+        # structured push once the broker honors it). Both pinned so neither regresses.
+        cap = {}
+
+        def _fake_http_json(method, url, headers, payload):
+            cap["url"], cap["payload"] = url, payload
+            return 200, {"event_id": "$posted"}
+
+        with mock.patch.object(mn, "gateway", return_value=("https://gw/relay", {})), \
+             mock.patch.object(mn, "http_json", side_effect=_fake_http_json):
+            res = mn.mention("qingyun-001", "review #149", ROOM, HS, gate=None, agents=_AGENTS)
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["event_id"], "$posted")
+        self.assertTrue(cap["url"].endswith("/v1/room"))
+        p = cap["payload"]
+        self.assertEqual(p["op"], "message")
+        self.assertEqual(p["mentions"], ["@sutando-qingyun-001:ag2.space"])
+        self.assertTrue(p["body"].startswith("@sutando-qingyun-001:ag2.space"))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/skills/agent-room-ops/test_room_ops.py
+++ b/skills/agent-room-ops/test_room_ops.py
@@ -458,5 +458,74 @@ class NormalizeReactionsTests(unittest.TestCase):
         self.assertEqual(out[0]["reactions"], [])
 
 
+import resolve as rs  # noqa: E402
+import mention as mn  # noqa: E402
+
+_AGENTS = [
+    {"id": "@sutando-qingyun-001:ag2.space", "label": "Air MBP"},
+    {"id": "@sutando-qingyun-mini:ag2.space", "label": "Mini"},
+    {"id": "@qingyun-air.agent:ag2.space", "label": "core"},
+]
+
+
+class ResolveTests(unittest.TestCase):
+    def test_exact_localpart(self):
+        r = rs.match_agent("sutando-qingyun-001", _AGENTS)
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["mxid"], "@sutando-qingyun-001:ag2.space")
+
+    def test_substring_unique(self):
+        r = rs.match_agent("001", _AGENTS)  # only qingyun-001's localpart contains it
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["mxid"], "@sutando-qingyun-001:ag2.space")
+
+    def test_full_mxid_passthrough(self):
+        r = rs.match_agent("@whoever:ag2.space", _AGENTS)  # already an mxid → trust it
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["mxid"], "@whoever:ag2.space")
+
+    def test_ambiguous_reports_candidates_and_does_not_resolve(self):
+        r = rs.match_agent("sutando-qingyun", _AGENTS)  # substring of BOTH 001 and mini
+        self.assertFalse(r["ok"])
+        self.assertEqual(len(r["candidates"]), 2)
+        self.assertIsNone(r["mxid"])
+
+    def test_no_match(self):
+        r = rs.match_agent("nobody", _AGENTS)
+        self.assertFalse(r["ok"])
+        self.assertEqual(r["candidates"], [])
+
+    def test_exact_beats_substring(self):
+        agents = [{"id": "@mini:hs", "label": ""}, {"id": "@mini-helper:hs", "label": ""}]
+        r = rs.match_agent("mini", agents)  # exact localpart wins over the substring one
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["mxid"], "@mini:hs")
+
+    def test_label_exact_match(self):
+        r = rs.match_agent("Mini", _AGENTS)  # case-insensitive label hit
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["mxid"], "@sutando-qingyun-mini:ag2.space")
+
+    def test_empty_query(self):
+        self.assertFalse(rs.match_agent("", _AGENTS)["ok"])
+
+
+class MentionBodyTests(unittest.TestCase):
+    def test_leads_with_mxid(self):
+        b = mn.build_body("@sutando-qingyun-001:ag2.space", "review #149")
+        self.assertTrue(b.startswith("@sutando-qingyun-001:ag2.space"))
+        self.assertIn("review #149", b)
+
+    def test_empty_message_is_bare_mxid(self):
+        self.assertEqual(mn.build_body("@x:hs", ""), "@x:hs")
+
+    def test_ambiguous_handle_does_not_post(self):
+        # mention() must refuse to post on an ambiguous handle (never mention the
+        # wrong agent) — returns ok:false + candidates, no network touched.
+        res = mn.mention("sutando-qingyun", "hi", ROOM, HS, gate=None, agents=_AGENTS)
+        self.assertFalse(res["ok"])
+        self.assertEqual(len(res["candidates"]), 2)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What

First slice of the AG2 Space **capability service**: reliable agent-to-agent `@`-mention by friendly handle, as two new `agent-room-ops` verbs.

- **`resolve_user(handle)` → mxid** via the `GET /v1/agents` directory. Ranking: exact-localpart > exact-label > substring; an ambiguous handle returns the candidate set (never a wrong guess); a full mxid short-circuits.
- **`mention(handle, msg, room)`** → resolve + post an `op:message` with the mxid **leading** the body — the form the broker's `is_mention` matches (localpart as a whole token), so the peer is actually triggered. Refuses to post on an ambiguous handle.

CLI: `python3 room_ops.py resolve <handle>` and `python3 room_ops.py mention <handle> <message> <room>`.

## Why

The most-repeated agent-to-agent delivery failure is hand-crafting a peer's mxid and getting it wrong — or forgetting it entirely, so the mention silently never triggers. This removes the hand-craft: give a handle, get the one canonical mxid.

## How

Client-side only — **no broker change**. `GET /v1/agents` already provides the directory, and the localpart text-match already triggers a mention. Pure matching (`match_agent`) and body-construction (`build_body`) are separated from I/O so they're unit-tested without a gateway.

## Testing

- 11 new unit tests (ranking, ambiguity→candidates, exact-beats-substring, label match, mxid passthrough, body leads-with-mxid, ambiguous-does-not-post). **67 total pass**, no regressions.
- `resolve` verified live against the directory: `qingyun-001` and `001` both → `@sutando-qingyun-001:ag2.space`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
