### PR TITLE
fix(health-check): remove --recover-core from launchd template default (#2246)

### DIFF
--- a/src/install-health-check-launchd.sh
+++ b/src/install-health-check-launchd.sh
@@ -13,16 +13,17 @@
 #     ~/Library/LaunchAgents/com.sutando.health-check-fallback.plist
 #   - Loads it via `launchctl bootstrap gui/$UID` (the modern Sequoia idiom).
 #   - Result: macOS runs `python3 src/health-check.py --emit-task
-#     --notify-on-fail --notify-slack --recover-core --quiet` every 5min,
+#     --notify-on-fail --notify-slack --quiet` every 5min,
 #     independent of any other Sutando process. Failures surface as tasks (for
 #     the agent to act on), macOS notifications (so the human sees them even if
 #     all of Sutando is dead), AND a direct Slack DM to the owner (remote-visible
 #     self-report for outages — fires even when the core loop is wedged). The
 #     Slack DM no-ops if no token / owner is configured.
-#   - --recover-core additionally self-heals an alive-but-wedged core (the
-#     2026-06-02 1M usage-credit-gate loop) by restarting it via start-cli.sh,
-#     guarded by a confirm window + cooldown + 3/hr give-up cap. No-op when
-#     healthy; keeps 1M on the first restart, degrades to 200K only if it recurs.
+#   - NOTE (#2246): the --recover-core destructive auto-restart was REMOVED from
+#     the default args. It decided "wedged" from core-status.json ts freshness
+#     alone and false-positived on a busy-but-healthy core, restart-looping and
+#     killing in-flight tasks. Alerting is kept; auto-restart stays off until a
+#     durable 2-independent-signal fix lands (#2246).
 #
 # What the user sees first time they install:
 #   - One macOS "Background Item Added" notification banner (Apple's own UX,

--- a/src/launchd/com.sutando.health-check-fallback.plist
+++ b/src/launchd/com.sutando.health-check-fallback.plist
@@ -22,19 +22,22 @@
   Behavior:
     - Fires every 300s (StartInterval).
     - Runs `python3 src/health-check.py --emit-task --notify-on-fail
-      --notify-slack --recover-core --quiet`.
+      --notify-slack --quiet`.
     - Surfaces failures as tasks/task-health-*.txt, macOS notifications, AND
       a direct Slack DM to the owner (remote-visible; fires even when the core
       session is wedged but its heartbeat process still ticks). The Slack DM
       no-ops cleanly if SLACK_BOT_TOKEN (channel .env / $REPO/.env / env) or the
       owner id in ~/.claude/channels/slack/access.json is missing.
-    - --recover-core: when the core is alive-but-wedged (heartbeat ticking but
-      the task queue isn't draining — the 2026-06-02 1M usage-credit-gate loop
-      signature), auto-restarts it via src/agent/start-cli.sh --restart. Heavily
-      guarded (sustained-wedge confirm window, 30min cooldown, 3/hr give-up cap)
-      and a clean no-op when the core is healthy. Keeps 1M on the first restart;
-      degrades to standard 200K only if the wedge recurs. Runs here, in launchd's
-      own process — never from inside the core session it would kill.
+    - NOTE (#2246): --recover-core was REMOVED from the default args. It decided
+      "core wedged" almost entirely from core-status.json ts freshness — a
+      best-effort *voluntary* signal — and false-positived when the core was
+      legitimately busy on a long task, restart-looping: each restart killed the
+      tmux session (dropping the attached Core CLI) AND the in-flight task, which
+      then never drained, so it re-fired every cooldown. Alerting is kept; the
+      destructive auto-restart is not re-enabled until #2246 lands a durable fix
+      (require a 2nd independent *involuntary* signal — heartbeat process
+      alive/dead + transcript/obs-hook tool activity — and restart only when BOTH
+      say wedged; default destructive restart to opt-in/alert-only).
     - ThrottleInterval=60 prevents crash-loop thrash.
     - Exit-only job (KeepAlive omitted) — launchd waits StartInterval, fires
       again, no zombie process between runs.
@@ -53,7 +56,6 @@
         <string>--emit-task</string>
         <string>--notify-on-fail</string>
         <string>--notify-slack</string>
-        <string>--recover-core</string>
         <string>--quiet</string>
     </array>
 


### PR DESCRIPTION
## Summary
Immediate mitigation for #2246: `--recover-core` was shipping **on-by-default** in the committed `com.sutando.health-check-fallback.plist` template, so every host that ran `install-health-check-launchd.sh` had the destructive auto-restart watchdog enabled.

## The bug (#2246)
`recover_core_if_wedged()` decides "core wedged" almost entirely from `core-status.json` `ts` freshness — a best-effort **voluntary** signal. When that ts goes stale while the core is legitimately busy on a long task (or a real task is queued), it false-positives and **restart-loops**: each restart kills the tmux session (dropping the attached Core CLI) **and** the in-flight task, which then never drains, so it re-fires every cooldown.

Observed on @sonichi's host (11 `wedge-restart` log entries); lightly on other Claude-based hosts; Codex-based hosts unaffected.

## This PR
- Removes `--recover-core` from the default `ProgramArguments` in the template plist.
- Updates the plist + install-script comments to document why (references #2246).
- **Keeps alerting** (`--emit-task` / `--notify-on-fail` / `--notify-slack`) — failures are still surfaced; only the destructive auto-restart is off.

Config/docs only — no code paths changed.

## Durable follow-up (#2246)
Restore *safe* auto-recovery by requiring a **2nd independent involuntary signal** (heartbeat process alive/dead + transcript/obs-hook tool activity) and restarting only when **both** say wedged; default destructive restart to opt-in / alert-only. A core busy on a long task always fails the "no activity" key → the false positive is eliminated.

Refs #2246
