### PR TITLE
fix(agent-room-ops): carry reactions through read._normalize

### DIFF
--- a/skills/agent-room-ops/read.py
+++ b/skills/agent-room-ops/read.py
@@ -28,6 +28,11 @@ def _normalize(items):
             "ts": m.get("ts") or m.get("timestamp"),
             "body": m.get("body") or m.get("text") or m.get("message"),
             "event_id": m.get("event_id") or m.get("id"),
+            # The gateway annotates each message with its reactions (key + sender);
+            # without carrying it through, a worker can't see the 👀 delivery-ack on
+            # its own messages (reactions are never pushed as tasks — read is the
+            # only surface). Always a list so consumers need no None-check.
+            "reactions": m.get("reactions") or [],
         })
     return out
 

--- a/skills/agent-room-ops/test_room_ops.py
+++ b/skills/agent-room-ops/test_room_ops.py
@@ -443,5 +443,20 @@ class ContentLengthTests(EnvCase):
         self.assertIn("exceeds", res["reason"])
 
 
+class NormalizeReactionsTests(unittest.TestCase):
+    """_normalize must carry the gateway's per-message `reactions` annotation —
+    it's the ONLY surface for the 👀 delivery-ack (reactions never arrive as tasks).
+    Regression: the field was silently dropped, so a worker saw zero reactions."""
+
+    def test_reactions_preserved(self):
+        out = rd._normalize([{"event_id": "$e", "sender": "@a:hs", "body": "hi",
+                              "reactions": [{"key": "\U0001F440", "sender": "@b:hs"}]}])
+        self.assertEqual(out[0]["reactions"], [{"key": "\U0001F440", "sender": "@b:hs"}])
+
+    def test_reactions_default_empty_list(self):
+        out = rd._normalize([{"event_id": "$e", "sender": "@a:hs", "body": "hi"}])
+        self.assertEqual(out[0]["reactions"], [])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`read._normalize` rebuilt each message with only `sender`/`ts`/`body`/`event_id`, silently dropping the gateway's per-message **`reactions`** annotation. This carries it through (always a list).

## Why

Reactions are never delivered as tasks — room read is the **only** surface for them. So a worker could never see the 👀 delivery-ack a peer put on its own message: a read of the room surfaced **0 reactions** despite them being present. This is the client-side half of the "can I tell my message was delivered?" gap.

## Impact

Unblocks **on-demand delivery confirmation** — a worker can now read the 👀 ack on its message (verified live: 8 messages now surface reactions, including the ack a peer put on this agent's own message; before: 0).

## Testing

2 regression tests (`reactions_preserved`, `reactions_default_empty_list`); 58 total pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
