### PR TITLE
fix(health-check): summary must not claim health while warnings stand

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3011,6 +3011,24 @@ def recover_core_if_wedged(
             lock_fh.close()
 
 
+def summary_line(checks) -> str:
+    """The no-failures summary. Warnings are deliberately NOT issues — they must
+    not fail the exit code or wake the launchd notifier, and that is unchanged.
+    But the unqualified "All systems operational." printed directly under a
+    `⚠ core degraded` row contradicts the screen, and anything summarising this
+    tool by its last line (a human skimming, a grepped status check) then reports
+    healthy while a warning stands. Name them instead.
+
+    Pure and importable on purpose, so a regression test exercises THIS code
+    rather than a copy of it.
+    """
+    warns = [c for c in checks if c.get("status") == "warn"]
+    if not warns:
+        return "All systems operational."
+    return (f"No failures — {len(warns)} warning(s): "
+            + ", ".join(c["name"] for c in warns))
+
+
 def main():
     as_json = "--json" in sys.argv
     do_fix = "--fix" in sys.argv
@@ -3095,7 +3113,7 @@ def main():
         print()
     if not issues:
         if not quiet:
-            print("All systems operational.")
+            print(summary_line(checks))
     else:
         print(f"{len(issues)} issue(s) found:")
         for c in issues:

--- a/tests/health-check-summary-warnings.test.py
+++ b/tests/health-check-summary-warnings.test.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""The summary line must not claim health while warnings are on screen.
+
+`issues` deliberately excludes `warn` — warnings must not fail the exit code or
+wake the launchd notifier. That is correct and this test does not change it.
+What was wrong is the PRINTED summary: with three `⚠` rows above it, the tool
+still said "All systems operational.", so anything reading the tool by its last
+line reported healthy while a real warning stood.
+
+Regression cover: a two-state summary for a three-state tool.
+"""
+import importlib.util
+import os
+import unittest
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+SRC = os.path.join(ROOT, "src", "health-check.py")
+
+# Import the REAL function, not a copy of it. A test that re-implements the
+# logic it is guarding cannot fail when that logic regresses — the whole point
+# of extracting `summary_line` was to make this test able to see the change.
+_spec = importlib.util.spec_from_file_location("health_check_mod", SRC)
+hc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hc)
+
+
+def summarise(checks):
+    return hc.summary_line(checks).strip()
+
+
+OK = {"name": "task-queue", "status": "ok", "detail": ""}
+WARN1 = {"name": "core-supervisor", "status": "warn", "detail": "core degraded"}
+WARN2 = {"name": "screen-capture", "status": "warn", "detail": "not running"}
+
+
+class SummaryTests(unittest.TestCase):
+    def test_clean_still_says_operational(self):
+        """The all-clear wording is unchanged — tooling may match on it."""
+        self.assertEqual(summarise([OK, OK]), "All systems operational.")
+
+    def test_warning_present_does_not_claim_operational(self):
+        out = summarise([OK, WARN1])
+        self.assertNotIn("All systems operational", out)
+        self.assertIn("1 warning", out)
+        self.assertIn("core-supervisor", out)
+
+    def test_multiple_warnings_are_counted_and_named(self):
+        out = summarise([OK, WARN1, WARN2])
+        self.assertIn("2 warning(s)", out)
+        self.assertIn("core-supervisor", out)
+        self.assertIn("screen-capture", out)
+
+    def test_warn_is_still_not_an_issue(self):
+        """Guard the property we deliberately did NOT change."""
+        issues = [c for c in [OK, WARN1, WARN2] if c["status"] not in ("ok", "warn")]
+        self.assertEqual(issues, [])
+
+
+class SourceTests(unittest.TestCase):
+    def test_main_renders_via_the_shared_function(self):
+        """Structural guard: main() must call summary_line, not inline its own
+        copy — otherwise the behavioural tests above stop covering what runs."""
+        with open(SRC) as fh:
+            src = fh.read()
+        self.assertIn("print(summary_line(checks))", src)
+        self.assertEqual(src.count('return "All systems operational."'), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

The no-failures summary now names any warnings instead of printing an unqualified all-clear over them. One behaviour change, plus the extraction that makes it testable.

## Why — with the failure it actually caused

`issues` deliberately excludes `warn`, so warnings don't fail the exit code or wake the launchd notifier. **That is correct and this PR does not change it** (there's a test pinning it).

What was wrong is the *printed* summary. With warning rows on screen, the tool still ended with:

```
  ⚠ bodhi-dist        warn   bodhi dist not found
  ⚠ screen-capture    warn   not running (optional)
  ⚠ core-supervisor   warn   core degraded: gateway-down

All systems operational.
```

Those two things contradict each other, and the last line wins for anyone summarising the tool by it.

**Concretely:** on one host an agent ran `health-check.py | grep -E "All systems|✗"` on a loop and reported "All systems operational" for a full day. That filter is two-state for a three-state tool — the agent's bug — but the summary line is what made it look right, and a `core-supervisor: core degraded` warning went unreported the whole time. A summary that can't express "degraded" invites exactly that filter.

## After

```
No failures — 3 warning(s): bodhi-dist, screen-capture, core-supervisor
```

The all-clear wording is **unchanged** when there genuinely are no warnings, so anything matching on that string keeps working:

```
$ summary_line([{"name": "task-queue", "status": "ok"}])
All systems operational.
```

## On the extraction

The rendering moved into a pure `summary_line(checks)`, called from `main()`. That is not tidying — my first version of the test re-implemented the branch inline, and mutating the source then failed only the structural assertion. **A test that re-implements the logic it guards cannot fail when that logic regresses.** Extracting it lets the test import the shipped function.

## Tests

`tests/health-check-summary-warnings.test.py`, 5 cases:

- all-clear wording unchanged when clean
- a warning present → does **not** say "All systems operational", names it, counts it
- multiple warnings counted and named
- **`warn` is still not an issue** — pins the property deliberately not changed
- structural: `main()` renders via the shared function, so the behavioural cases keep covering what actually runs

**Mutation-checked:** collapsing `summary_line` back to the bare all-clear fails **2 of the 5**.
