### PR TITLE
fix(core-supervisor): read the gateway's own liveness, not its interpreter path

### DIFF
--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -250,7 +250,54 @@ def _pgrep(pattern):
         return False
 
 
-def gateway_alive(app_data):
+# A healthy bridge rewrites gateway-status.json after every successful poll
+# round-trip, and its long-poll is REMOTE_TASK_POLL_WAIT (default 25s) with a
+# +10s request timeout — so ~35s is the worst-case gap between writes on a
+# working connection. 90s leaves room for a slow round-trip without letting a
+# genuinely stalled bridge read as alive.
+GATEWAY_STATUS_MAX_AGE_S = 90.0
+
+
+def _gateway_status(state_dir):
+    """Read the bridge's own liveness sidecar. Returns True/False if the file
+    is present and fresh, else None (meaning: no opinion, fall back to pgrep).
+    """
+    if not state_dir:
+        return None
+    try:
+        p = os.path.join(state_dir, "gateway-status.json")
+        with open(p) as fh:
+            data = json.load(fh)
+        ts = data.get("ts")
+        if not isinstance(ts, (int, float)):
+            return None
+        if time.time() - ts > GATEWAY_STATUS_MAX_AGE_S:
+            return None      # stale — the bridge may be wedged; let pgrep answer
+        return bool(data.get("connected"))
+    except Exception:
+        return None
+
+
+def gateway_alive(app_data, state_dir=None):
+    """Whether the relay gateway is up.
+
+    Prefer the bridge's OWN status sidecar (state/gateway-status.json), which
+    remote_gateway_bridge rewrites on every poll outcome. It reports whether the
+    connection is *serving*; the pgrep paths below only ever answered "is there a
+    process whose argv looks right", which is a proxy for the wrong thing.
+
+    That proxy was also wrong in practice: on a bundled install the pattern is the
+    app-data interpreter, so a bridge started under system python (as startup.sh
+    does with a bare `python3`) matched nothing. Observed 2026-07-21 — the bridge
+    was connected and writing a 3s-old status file while the supervisor pinned the
+    core at `gateway-down`, which surfaces as a standing health-check warning.
+
+    Falls back to the pgrep probes when the sidecar is missing or stale, so hosts
+    running a bridge too old to emit it keep their previous behavior.
+    """
+    verdict = _gateway_status(state_dir)
+    if verdict is not None:
+        return verdict
     # The bundled gateway runs from the app-data interpreter (see console_status:
     # keepalive cd's into $ENGINE so the argv is relative — match the app-unique
     # runtime-python dir, which uniquely scopes to THIS app's gateway). Gateway
@@ -308,7 +355,8 @@ def main():
         pane = capture(a.socket, a.session)
         base = rh.derive()  # shared: offline|needs_login|working|idle|unknown
         state, detail, prompt, kind = compose_state(
-            pane or "", base.get("health", "unknown"), gateway_alive(a.app_data))
+            pane or "", base.get("health", "unknown"),
+            gateway_alive(a.app_data, os.path.dirname(os.path.abspath(a.out))))
 
         # Debounce prompt escalation: only surface once the SAME prompt persists
         # (not a menu the core is actively navigating through).

--- a/tests/core-input-watch-gateway-probe.test.py
+++ b/tests/core-input-watch-gateway-probe.test.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Tests for `gateway_alive` / `_gateway_status` in src/core-input-watch.py.
+
+Motivated by 2026-07-21: the supervisor pinned the core at `gateway-down` —
+surfacing as a standing health-check warning — while the bridge was connected
+and rewriting state/gateway-status.json every few seconds.
+
+Mechanism: on a bundled install the probe was
+`pgrep -f <app_data>/engine/runtime/python`, i.e. "is a process running under
+the app-bundle interpreter". The bridge on this host runs under system python
+(startup.sh invokes a bare `python3`), so the pattern matched nothing. The
+probe answered a question about argv when the question was whether the gateway
+is serving.
+
+Covers:
+  a) fresh + connected  → True, without consulting pgrep
+  b) fresh + disconnected → False, without consulting pgrep (info the pgrep
+     path never had — a live-but-unauthenticated bridge)
+  c) stale ts → fall back to pgrep (a wedged bridge must not read as alive)
+  d) missing file → fall back (bridge too old to emit the sidecar)
+  e) malformed JSON → fall back
+  f) non-numeric ts → fall back
+  g) state_dir None → fall back (preserves the old call signature)
+  h) the 90s threshold clears the bridge's worst-case write gap
+     (REMOTE_TASK_POLL_WAIT 25s + 10s request timeout)
+
+Run: python3 tests/core-input-watch-gateway-probe.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import json
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+spec = importlib.util.spec_from_file_location(
+    "core_input_watch", REPO / "src" / "core-input-watch.py")
+ciw = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ciw)
+
+
+def with_status(payload, *, pgrep_returns=False, app_data="", write=True):
+    """Run gateway_alive against a temp state dir holding `payload`.
+
+    Returns (verdict, pgrep_was_called). `payload=None` with write=True writes
+    invalid JSON; write=False skips the file entirely.
+    """
+    calls = []
+
+    def fake_pgrep(pattern):
+        calls.append(pattern)
+        return pgrep_returns
+
+    with tempfile.TemporaryDirectory() as td:
+        state_dir = Path(td)
+        if write:
+            body = json.dumps(payload) if payload is not None else "{ not json"
+            (state_dir / "gateway-status.json").write_text(body)
+        orig = ciw._pgrep
+        try:
+            ciw._pgrep = fake_pgrep
+            verdict = ciw.gateway_alive(app_data, str(state_dir))
+        finally:
+            ciw._pgrep = orig
+    return verdict, bool(calls)
+
+
+def case_a_fresh_connected() -> list[str]:
+    v, pgrepped = with_status({"connected": True, "ts": time.time()}, pgrep_returns=False)
+    fails = []
+    if v is not True:
+        fails.append(f"a) fresh+connected should be True, got {v!r}")
+    if pgrepped:
+        fails.append("a) should not consult pgrep when the sidecar answers")
+    return fails
+
+
+def case_b_fresh_disconnected() -> list[str]:
+    # pgrep_returns=True: if the fallback ran, the verdict would wrongly be True.
+    v, pgrepped = with_status({"connected": False, "ts": time.time()}, pgrep_returns=True)
+    fails = []
+    if v is not False:
+        fails.append(f"b) fresh+disconnected should be False, got {v!r}")
+    if pgrepped:
+        fails.append("b) a fresh sidecar saying 'not connected' must not be second-guessed by pgrep")
+    return fails
+
+
+def case_c_stale_falls_back() -> list[str]:
+    old = time.time() - (ciw.GATEWAY_STATUS_MAX_AGE_S + 30)
+    v, pgrepped = with_status({"connected": True, "ts": old}, pgrep_returns=False)
+    fails = []
+    if not pgrepped:
+        fails.append("c) a stale sidecar must fall back to pgrep, not be trusted")
+    if v is not False:
+        fails.append(f"c) stale + no process should be False, got {v!r}")
+    return fails
+
+
+def case_d_missing_falls_back() -> list[str]:
+    v, pgrepped = with_status(None, write=False, pgrep_returns=True)
+    fails = []
+    if not pgrepped:
+        fails.append("d) missing sidecar must fall back to pgrep")
+    if v is not True:
+        fails.append(f"d) fallback should return the pgrep verdict, got {v!r}")
+    return fails
+
+
+def case_e_malformed_falls_back() -> list[str]:
+    v, pgrepped = with_status(None, write=True, pgrep_returns=True)
+    if not pgrepped:
+        return ["e) malformed JSON must fall back to pgrep"]
+    return []
+
+
+def case_f_non_numeric_ts_falls_back() -> list[str]:
+    v, pgrepped = with_status({"connected": True, "ts": "just now"}, pgrep_returns=True)
+    if not pgrepped:
+        return ["f) non-numeric ts must fall back to pgrep"]
+    return []
+
+
+def case_g_no_state_dir_falls_back() -> list[str]:
+    """The old signature was gateway_alive(app_data); callers passing one arg
+    must still get the pgrep behavior."""
+    calls = []
+    orig = ciw._pgrep
+    try:
+        ciw._pgrep = lambda p: (calls.append(p), True)[1]
+        v = ciw.gateway_alive("")
+    finally:
+        ciw._pgrep = orig
+    fails = []
+    if not calls:
+        fails.append("g) no state_dir must fall back to pgrep")
+    if v is not True:
+        fails.append(f"g) should return pgrep's verdict, got {v!r}")
+    return fails
+
+
+def case_h_threshold_clears_poll_gap() -> list[str]:
+    """The bridge long-polls REMOTE_TASK_POLL_WAIT (default 25s) with a +10s
+    request timeout, so ~35s is the worst-case gap between writes on a HEALTHY
+    connection. The threshold must sit above that or healthy bridges flap."""
+    if ciw.GATEWAY_STATUS_MAX_AGE_S <= 35:
+        return [f"h) threshold {ciw.GATEWAY_STATUS_MAX_AGE_S}s does not clear the "
+                "35s worst-case healthy write gap"]
+    # And a write inside that gap must still read fresh.
+    v, pgrepped = with_status({"connected": True, "ts": time.time() - 35})
+    if v is not True or pgrepped:
+        return ["h) a 35s-old sidecar (healthy long-poll gap) must still be trusted"]
+    return []
+
+
+def main() -> int:
+    cases = [
+        ("a", case_a_fresh_connected),
+        ("b", case_b_fresh_disconnected),
+        ("c", case_c_stale_falls_back),
+        ("d", case_d_missing_falls_back),
+        ("e", case_e_malformed_falls_back),
+        ("f", case_f_non_numeric_ts_falls_back),
+        ("g", case_g_no_state_dir_falls_back),
+        ("h", case_h_threshold_clears_poll_gap),
+    ]
+    all_failures = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            all_failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if all_failures:
+        print(f"\n{len(all_failures)} failure(s)")
+        return 1
+    print("\nGateway-probe invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The false alarm

The supervisor has been pinning the core at `gateway-down` — which `health-check.py` surfaces as a standing `core degraded: gateway-down` warning — while the bridge is connected and healthy:

```
core-supervisor.json : gateway-down | core up but relay gateway not running
gateway-status.json  : connected=True  ts age 3s
ps                   : 92530 …/Python src/remote-gateway-bridge.py
```

## Mechanism

`gateway_alive()` asked `pgrep` whether a process matching a pattern existed. On a bundled install that pattern is `<app_data>/engine/runtime/python` — "is something running under the app-bundle interpreter". The bridge on this host runs under **system** python, because `startup.sh` invokes a bare `python3`. Nothing matched, so a healthy gateway read as down.

Note the shape: `pgrep -f remote-gateway-bridge` *does* find it (92530). The bundled branch is the one that misses, and it misses permanently — nothing about that mismatch resolves on its own, so the warning is load-bearing noise that trains us to ignore `core-supervisor` warns.

The deeper issue is that argv was never the question. "A process whose path looks right exists" and "the gateway is serving" are different claims, and only the second matters to the state being derived.

## The fix

The bridge already publishes the right signal. `remote_gateway_bridge` rewrites `state/gateway-status.json` on **every poll outcome** — `connected` after a healthy round-trip, `reconnecting` with the error in each backoff branch. `gateway_alive` now prefers it.

That also gives the supervisor something the pgrep path structurally could not have: a **live-but-unauthenticated** bridge (process up, auth rejected) is now visible as down instead of up.

**Freshness threshold is 90s**, and the number is derived rather than picked: the long-poll is `REMOTE_TASK_POLL_WAIT` (default 25s) with a `+10s` request timeout, so ~35s is the worst-case gap between writes on a *working* connection. 90s clears that comfortably without letting a wedged bridge read as alive. Case (h) pins this — it fails if the threshold drops below the healthy write gap.

**Missing or stale sidecar falls back to the existing pgrep probes**, unchanged. Hosts running a bridge too old to emit one keep their current behavior; this is strictly additive.

## Verification

A `--once` run against the live core, before and after:

```
BEFORE : gateway-down | core up but relay gateway not running
AFTER  : hung         | core alive but stalled (status stale, no recognized prompt)
```

Worth being precise about that: the fix does **not** turn the state green. The false `gateway-down` was *masking* the base health verdict — `compose_state` checks the gateway before the base mapping — so removing it unmasks whatever runtime-health actually thinks. That `hung` reading is a separate pre-existing question (#2112 territory: an idle core writes `core-status` rarely and goes `unknown` → `hung`), and deliberately not touched here. One concern per PR.

Eight cases, each verified by mutation — the three invariants that matter (prefer the sidecar, don't trust a stale one, keep the threshold above the healthy poll gap) were each broken in turn and the corresponding case failed.

One local-only gotcha worth recording, since it briefly made a restored file look broken: macOS system python 3.9 caches bytecode under `~/Library/Caches/com.apple.python/`, not a repo-local `__pycache__`. A size-preserving mutation (`90.0` → `20.0`) survived the restore in that cache, so the suite kept failing against a file that was already correct on disk. Doesn't affect CI (fresh checkout, different interpreter), but it does mean mutation runs here need an explicit cache clear to be trustworthy.
