### PR TITLE
fix(slack): dedupe recreated proactive results

### DIFF
--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -73,6 +73,8 @@ from workspace_default import resolve_workspace  # noqa: E402
 from task_archive import find_task_file  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
 from vault_intercept import intercept_vault_commands, redact_vault_commands  # noqa: E402
+from slack_proactive_receipts import mark_delivered as mark_proactive_delivered  # noqa: E402
+from slack_proactive_receipts import was_delivered as proactive_was_delivered  # noqa: E402
 
 try:
     from slack_bolt import App
@@ -1125,6 +1127,16 @@ def result_watcher():
                 for f in list(RESULTS_DIR.iterdir()):
                     if not (f.name.startswith("proactive-") and f.suffix == ".txt"):
                         continue
+                    delivery_id = f.name
+                    # A producer may recreate the same deterministic result
+                    # filename after the watcher successfully sends and removes
+                    # it. Keep a durable receipt so that file-existence checks or
+                    # retries cannot turn one schedule fire into duplicate DMs.
+                    if proactive_was_delivered(STATE_DIR, delivery_id):
+                        print(f"  [proactive] duplicate suppressed: {delivery_id}", flush=True)
+                        _record_skip_audit(delivery_id, "deduped")
+                        f.unlink(missing_ok=True)
+                        continue
                     # Peek before claiming: skip Discord-targeted proactive files.
                     # [channel: <17-20 digit snowflake>] is a Discord-only marker;
                     # claiming it here dumps the literal text to Slack DM instead.
@@ -1153,6 +1165,7 @@ def result_watcher():
                             resp = app.client.conversations_open(users=owner_id)
                             dm_channel = resp["channel"]["id"]
                             _send_reply(dm_channel, None, text, access_tier="owner")  # proactive → owner
+                            mark_proactive_delivered(STATE_DIR, delivery_id)
                             print(f"  [proactive] sent to {owner_id}: {text[:80]}", flush=True)
                         except Exception as e:
                             print(f"  [proactive] failed: {e}", flush=True)

--- a/src/slack_proactive_receipts.py
+++ b/src/slack_proactive_receipts.py
@@ -1,0 +1,30 @@
+"""Durable idempotency receipts for Slack proactive-result delivery."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+def _receipt_path(state_dir: Path, delivery_id: str) -> Path:
+    digest = hashlib.sha256(delivery_id.encode("utf-8")).hexdigest()
+    return state_dir / "slack-proactive-delivered" / f"{digest}.sentinel"
+
+
+def was_delivered(state_dir: Path, delivery_id: str) -> bool:
+    """Return whether this stable proactive filename was already delivered."""
+    try:
+        return _receipt_path(state_dir, delivery_id).exists()
+    except Exception:
+        return False
+
+
+def mark_delivered(state_dir: Path, delivery_id: str) -> None:
+    """Persist a delivery receipt immediately after Slack confirms the send."""
+    try:
+        receipt = _receipt_path(state_dir, delivery_id)
+        receipt.parent.mkdir(parents=True, exist_ok=True)
+        receipt.write_text(delivery_id + "\n")
+    except Exception:
+        # Receipt failure must not turn a successful Slack send into an error.
+        pass

--- a/src/slack_proactive_receipts.py
+++ b/src/slack_proactive_receipts.py
@@ -3,7 +3,15 @@
 from __future__ import annotations
 
 import hashlib
+import time
 from pathlib import Path
+
+
+# Long enough to cover the result-watcher/manual-recreation race, but shorter
+# than the hourly pending-question reminder cadence.  A permanent receipt would
+# suppress content-keyed reminders forever because they intentionally reuse the
+# same filename while a question remains unanswered.
+RECEIPT_TTL_SECONDS = 5 * 60
 
 
 def _receipt_path(state_dir: Path, delivery_id: str) -> Path:
@@ -12,11 +20,27 @@ def _receipt_path(state_dir: Path, delivery_id: str) -> Path:
 
 
 def was_delivered(state_dir: Path, delivery_id: str) -> bool:
-    """Return whether this stable proactive filename was already delivered."""
+    """Return whether this proactive filename was delivered very recently."""
     try:
-        return _receipt_path(state_dir, delivery_id).exists()
+        receipt = _receipt_path(state_dir, delivery_id)
+        if not receipt.exists():
+            return False
+        if time.time() - receipt.stat().st_mtime <= RECEIPT_TTL_SECONDS:
+            return True
+        receipt.unlink(missing_ok=True)
+        return False
     except Exception:
         return False
+
+
+def _prune_expired(receipt_dir: Path) -> None:
+    cutoff = time.time() - RECEIPT_TTL_SECONDS
+    for receipt in receipt_dir.glob("*.sentinel"):
+        try:
+            if receipt.stat().st_mtime < cutoff:
+                receipt.unlink(missing_ok=True)
+        except Exception:
+            continue
 
 
 def mark_delivered(state_dir: Path, delivery_id: str) -> None:
@@ -24,6 +48,7 @@ def mark_delivered(state_dir: Path, delivery_id: str) -> None:
     try:
         receipt = _receipt_path(state_dir, delivery_id)
         receipt.parent.mkdir(parents=True, exist_ok=True)
+        _prune_expired(receipt.parent)
         receipt.write_text(delivery_id + "\n")
     except Exception:
         # Receipt failure must not turn a successful Slack send into an error.

--- a/tests/slack-proactive-delivery-idempotency.test.py
+++ b/tests/slack-proactive-delivery-idempotency.test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Regression tests for recreated proactive-result delivery IDs."""
+
+import importlib.util
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location(
+    "slack_proactive_receipts",
+    REPO / "src" / "slack_proactive_receipts.py",
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def main():
+    state = Path(tempfile.mkdtemp(prefix="sutando-slack-proactive-receipt-"))
+    delivery_id = "proactive-daily-top-ai-news-1784638800.txt"
+
+    assert not module.was_delivered(state, delivery_id)
+    module.mark_delivered(state, delivery_id)
+    assert module.was_delivered(state, delivery_id)
+
+    # Recreating the same deterministic filename must remain a duplicate even
+    # if its content changes. A genuinely new schedule slot gets a new ID.
+    assert module.was_delivered(state, delivery_id)
+    assert not module.was_delivered(
+        state,
+        "proactive-daily-top-ai-news-1784725200.txt",
+    )
+
+    # Receipt paths are hashes, so a malformed filename cannot escape state/.
+    hostile = "../../outside.txt"
+    module.mark_delivered(state, hostile)
+    assert module.was_delivered(state, hostile)
+    assert not (state.parent / "outside.txt").exists()
+
+    bridge = (REPO / "src" / "slack-bridge.py").read_text()
+    check_pos = bridge.index("proactive_was_delivered(STATE_DIR, delivery_id)")
+    claim_pos = bridge.index("f.rename(claim)", check_pos)
+    send_pos = bridge.index("_send_reply(dm_channel", claim_pos)
+    mark_pos = bridge.index("mark_proactive_delivered(STATE_DIR, delivery_id)", send_pos)
+    assert check_pos < claim_pos < send_pos < mark_pos
+
+    print("PASS: recreated Slack proactive delivery IDs are suppressed durably")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/slack-proactive-delivery-idempotency.test.py
+++ b/tests/slack-proactive-delivery-idempotency.test.py
@@ -2,7 +2,13 @@
 """Regression tests for recreated proactive-result delivery IDs."""
 
 import importlib.util
+import json
+import os
+import sys
 import tempfile
+import threading
+import time
+import types
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -12,6 +18,50 @@ spec = importlib.util.spec_from_file_location(
 )
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
+
+
+class _RecordingClient:
+    def __init__(self):
+        self.calls = []
+
+    def conversations_open(self, **kwargs):
+        return {"channel": {"id": "D-OWNER"}}
+
+    def chat_postMessage(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"ok": True}
+
+
+class _FakeApp:
+    def __init__(self, token=None):
+        self.client = _RecordingClient()
+
+    def _decorator(self, *args, **kwargs):
+        return lambda fn: fn
+
+    event = message = command = action = shortcut = view = _decorator
+
+
+def _load_bridge():
+    bolt = types.ModuleType("slack_bolt")
+    bolt.App = _FakeApp
+    sys.modules["slack_bolt"] = bolt
+    sys.modules["slack_bolt.adapter"] = types.ModuleType("slack_bolt.adapter")
+    socket = types.ModuleType("slack_bolt.adapter.socket_mode")
+    socket.SocketModeHandler = type("SocketModeHandler", (), {})
+    sys.modules["slack_bolt.adapter.socket_mode"] = socket
+
+    os.environ["SUTANDO_WORKSPACE"] = tempfile.mkdtemp(prefix="sutando-slack-dedupe-bridge-")
+    os.environ["SUTANDO_TEST_MODE"] = "1"
+    os.environ["SLACK_BOT_TOKEN"] = "xoxb-test-not-real"
+    os.environ["SLACK_APP_TOKEN"] = "xapp-test-not-real"
+    bridge_spec = importlib.util.spec_from_file_location(
+        "slackbridge_dedupe_test",
+        REPO / "src" / "slack-bridge.py",
+    )
+    bridge = importlib.util.module_from_spec(bridge_spec)
+    bridge_spec.loader.exec_module(bridge)
+    return bridge
 
 
 def main():
@@ -35,6 +85,31 @@ def main():
     module.mark_delivered(state, hostile)
     assert module.was_delivered(state, hostile)
     assert not (state.parent / "outside.txt").exists()
+
+    # Receipt I/O is deliberately best-effort and must never break delivery.
+    original_receipt_path = module._receipt_path
+    module._receipt_path = lambda *_args: (_ for _ in ()).throw(OSError("read-only"))
+    assert module.was_delivered(state, "unreadable") is False
+    module.mark_delivered(state, "unwritable")
+    module._receipt_path = original_receipt_path
+
+    # Exercise the actual watcher twice with one deterministic filename.
+    bridge = _load_bridge()
+    access_file = Path(os.environ["SUTANDO_WORKSPACE"]) / "access.json"
+    bridge.ACCESS_FILE = access_file
+    access_file.write_text(json.dumps({"allowFrom": ["owner-id"]}))
+    proactive = bridge.RESULTS_DIR / "proactive-same-slot.txt"
+    proactive.write_text("first body")
+    watcher = threading.Thread(target=bridge.result_watcher, daemon=True)
+    watcher.start()
+    time.sleep(0.3)
+    assert len(bridge.app.client.calls) == 1
+    proactive.write_text("recreated body")
+    time.sleep(1.2)
+    assert len(bridge.app.client.calls) == 1
+    assert not proactive.exists()
+    audit = bridge.STATE_DIR / "result-audit.log"
+    assert "\tproactive-same-slot.txt\tdeduped\tslack" in audit.read_text()
 
     bridge = (REPO / "src" / "slack-bridge.py").read_text()
     check_pos = bridge.index("proactive_was_delivered(STATE_DIR, delivery_id)")

--- a/tests/slack-proactive-delivery-idempotency.test.py
+++ b/tests/slack-proactive-delivery-idempotency.test.py
@@ -80,6 +80,26 @@ def main():
         "proactive-daily-top-ai-news-1784725200.txt",
     )
 
+    # Content-keyed producers intentionally reuse a filename on a slower
+    # cadence (pending questions re-notify hourly). The short race receipt must
+    # expire so those later deliveries are not suppressed forever.
+    content_keyed = "proactive-pending-q-deadbeef.txt"
+    module.mark_delivered(state, content_keyed)
+    content_receipt = module._receipt_path(state, content_keyed)
+    expired = time.time() - module.RECEIPT_TTL_SECONDS - 1
+    os.utime(content_receipt, (expired, expired))
+    assert not module.was_delivered(state, content_keyed)
+    assert not content_receipt.exists()
+
+    # Marking a new delivery also prunes unrelated expired receipts, bounding
+    # the sentinel directory instead of accumulating one file per ID forever.
+    stale_id = "proactive-old-slot.txt"
+    module.mark_delivered(state, stale_id)
+    stale_receipt = module._receipt_path(state, stale_id)
+    os.utime(stale_receipt, (expired, expired))
+    module.mark_delivered(state, "proactive-current-slot.txt")
+    assert not stale_receipt.exists()
+
     # Receipt paths are hashes, so a malformed filename cannot escape state/.
     hostile = "../../outside.txt"
     module.mark_delivered(state, hostile)
@@ -118,7 +138,7 @@ def main():
     mark_pos = bridge.index("mark_proactive_delivered(STATE_DIR, delivery_id)", send_pos)
     assert check_pos < claim_pos < send_pos < mark_pos
 
-    print("PASS: recreated Slack proactive delivery IDs are suppressed durably")
+    print("PASS: recreated Slack proactive delivery IDs are suppressed within the race window")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed, and why?

Slack atomically claims a proactive result, sends it, and removes the file. If a producer then checks for file existence and recreates the same deterministic filename, the watcher treats it as new and sends the same scheduled output again.

This PR records a durable receipt keyed by the proactive filename immediately after Slack confirms delivery. A recreated file with the same delivery ID is removed without sending and recorded as `deduped` in the result audit. New schedule slots have new filenames and still deliver normally.

## Review first

- `src/slack_proactive_receipts.py` — safe hashed receipt paths
- `src/slack-bridge.py` — pre-claim duplicate check and post-send receipt
- `tests/slack-proactive-delivery-idempotency.test.py` — durable recreation regression

## User behavior / bug evidence

**Before (live, 2026-07-21):** the same daily-AI proactive result was delivered twice and the same competitor-watch result three times. In both cases the producer recreated the deterministic result filename after the watcher had successfully consumed it.

**After (live, patched branch, 2026-07-21 08:13 PT):** ran `src/slack-bridge.py` with an isolated workspace and live Slack credentials. Wrote `proactive-live-dedupe-1784646546.txt`, observed one successful owner-DM send, then recreated the exact filename with different content. The running watcher logged `duplicate suppressed`; the workspace contained exactly one outbox send and this audit sequence:

```
2026-07-21T15:13:47Z  unknown                                      delivered  slack
2026-07-21T15:13:53Z  proactive-live-dedupe-1784646546.txt        deduped    slack
```

## Tests run

- `python3 tests/slack-proactive-delivery-idempotency.test.py` — PASS
- `python3 tests/slack-bridge-chunking.test.py` — PASS
- `python3 -m py_compile src/slack_proactive_receipts.py src/slack-bridge.py` — PASS
- `git diff --check` — PASS
- Live Slack two-write test described above — PASS: one send, one dedupe audit

## Edge cases checked

- Same filename with changed content remains deduped (delivery ID is authoritative).
- A new schedule-slot filename remains deliverable.
- Hostile/path-like IDs cannot escape the state directory because receipt names are SHA-256 hashes.
- Receipt I/O failure never converts a successful Slack send into an exception.

## Migrations / permissions / rollback

No migration or new permission. Receipts are small files under `state/slack-proactive-delivered/`. Rollback is the single commit; old receipts are harmless if left behind.

## Known gaps / follow-up

The narrow process-crash window between Slack accepting the message and the receipt write remains, matching the documented limitation of the existing Discord delivery sentinel. This PR is intentionally scoped to Slack proactive results; owner-recipient selection is a separate PR.
