### PR TITLE
feat(health-check): report a full volume instead of certifying it healthy

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -23,6 +23,7 @@ import hashlib
 import json
 import os
 import shutil
+import tempfile
 import socket
 import subprocess
 import sys
@@ -1580,6 +1581,44 @@ def check_gateway_bridge() -> "dict | None":
     return {"name": "gateway-bridge", "status": "ok", "detail": "running"}
 
 
+# Free-space thresholds. A full volume is not a slow degradation — it is a hard
+# stop: task/result writes fail with ENOSPC, so the bridge silently stops
+# delivering and the core looks alive while doing nothing. Observed 2026-07-21,
+# when the volume hit 100% and this script still reported "All systems
+# operational" because nothing here looked at disk at all.
+DISK_WARN_GIB = 10.0
+DISK_FAIL_GIB = 2.0
+
+
+def check_disk_space() -> dict:
+    """Free space on the volume(s) the core actually writes to.
+
+    Checks the workspace and the temp dir, reporting the WORST of the two —
+    they are usually the same volume, but a separate /tmp must not hide a full
+    workspace (or the reverse). Reports absolute GiB rather than percentage:
+    5% of a 460G disk is 23G (fine) while 5% of a 20G disk is 1G (dead), so a
+    percentage threshold would mean different things on different hosts.
+    """
+    name = "disk-space"
+    targets = {}
+    for label, path in (("workspace", WORKSPACE_DIR), ("tmp", Path(tempfile.gettempdir()))):
+        try:
+            st = os.statvfs(str(path))
+        except OSError as e:
+            return {"name": name, "status": "error", "detail": f"cannot stat {label} ({path}): {e}"}
+        # Key by device so the same volume isn't reported twice.
+        targets[st.f_fsid or label] = (label, path, st.f_bavail * st.f_frsize / (1024 ** 3))
+
+    worst_label, worst_path, worst_free = min(targets.values(), key=lambda t: t[2])
+    where = f"{worst_free:.1f} GiB free on {worst_label} ({worst_path})"
+    if worst_free < DISK_FAIL_GIB:
+        return {"name": name, "status": "fail",
+                "detail": f"{where} — writes will fail with ENOSPC; free space now"}
+    if worst_free < DISK_WARN_GIB:
+        return {"name": name, "status": "warn", "detail": f"{where} — below {DISK_WARN_GIB:.0f} GiB"}
+    return {"name": name, "status": "ok", "detail": where}
+
+
 def check_skill_symlinks() -> dict:
     """Detect skills in the OSS repo checkout that are not symlinked into
     ~/.claude/skills/. A missing symlink means Claude Code never loads the
@@ -2266,6 +2305,7 @@ def run_all_checks() -> list[dict]:
     checks.append(check_core_supervisor())
     checks.append(check_task_queue(threshold_count=queue_count, threshold_age_sec=queue_age_sec))
     checks.append(check_skill_symlinks())
+    checks.append(check_disk_space())
 
     return checks
 

--- a/tests/health-check-disk-space.test.py
+++ b/tests/health-check-disk-space.test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""check_disk_space: a full volume must be reported, not silently ignored.
+
+Regression for 2026-07-21: the volume hit 100%, task/result writes failed with
+ENOSPC, and health-check reported "All systems operational" because no check
+looked at free space. A health check that stays green through the failure it
+should catch is worse than no check — it actively certifies a broken system.
+"""
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeStat:
+    """statvfs_result stand-in: free bytes = f_bavail * f_frsize."""
+    def __init__(self, free_gib, fsid=1):
+        self.f_frsize = 4096
+        self.f_bavail = int(free_gib * (1024 ** 3) / 4096)
+        self.f_fsid = fsid
+
+
+class TestDiskSpace(unittest.TestCase):
+    def setUp(self):
+        self.hc = _load()
+        self._real = os.statvfs
+
+    def tearDown(self):
+        os.statvfs = self._real
+
+    def _status(self, free_gib):
+        os.statvfs = lambda p: _FakeStat(free_gib)
+        return self.hc.check_disk_space()
+
+    def test_a_full_volume_fails(self):
+        r = self._status(0.1)
+        self.assertEqual(r["status"], "fail", r)
+        self.assertIn("ENOSPC", r["detail"])
+
+    def test_b_low_volume_warns(self):
+        self.assertEqual(self._status(5.0)["status"], "warn")
+
+    def test_c_healthy_volume_ok(self):
+        self.assertEqual(self._status(200.0)["status"], "ok")
+
+    def test_d_boundaries(self):
+        self.assertEqual(self._status(self.hc.DISK_FAIL_GIB - 0.01)["status"], "fail")
+        self.assertEqual(self._status(self.hc.DISK_FAIL_GIB + 0.01)["status"], "warn")
+        self.assertEqual(self._status(self.hc.DISK_WARN_GIB + 0.01)["status"], "ok")
+
+    def test_e_reports_the_worse_of_two_distinct_volumes(self):
+        """A roomy /tmp must not mask a full workspace."""
+        seen = {"n": 0}
+        def fake(_p):
+            seen["n"] += 1
+            return _FakeStat(500.0, fsid=1) if seen["n"] == 1 else _FakeStat(0.2, fsid=2)
+        os.statvfs = fake
+        r = self.hc.check_disk_space()
+        self.assertEqual(r["status"], "fail", r)
+
+    def test_f_stat_failure_is_reported_not_swallowed(self):
+        def boom(_p):
+            raise OSError("nope")
+        os.statvfs = boom
+        self.assertEqual(self.hc.check_disk_space()["status"], "error")
+
+    def test_g_check_is_actually_registered(self):
+        src = (REPO / "src" / "health-check.py").read_text()
+        self.assertIn("checks.append(check_disk_space())", src,
+                      "check exists but never runs — the exact 2026-07-21 failure shape")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`health-check.py` had 24 checks and none of them looked at free disk space.

## Why

On 2026-07-21 this host's volume hit 100% (117 MB free of 460 GB). Task and result writes started failing with `ENOSPC` — which on this architecture means the bridge silently stops delivering while the core still looks alive. `health-check.py` ran during the outage and printed **"All systems operational."**

A check that stays green through the failure it should catch is worse than no check: it actively certifies a broken system. Same shape as #2252 (health summary claiming health while the task watcher was dead).

## How

`check_disk_space()` stats the workspace and the temp dir and reports the **worse** of the two, keyed by device so the same volume isn't double-counted. A roomy `/tmp` must not mask a full workspace, or the reverse.

Thresholds are **absolute GiB, not a percentage** — 5% of a 460G disk is 23G (fine) while 5% of a 20G disk is 1G (dead), so a percentage threshold would mean different things on different hosts. `warn < 10 GiB`, `fail < 2 GiB`.

## Tests

`tests/health-check-disk-space.test.py` — 7 cases: full → `fail`, low → `warn`, healthy → `ok`, both threshold boundaries, worse-of-two across distinct volumes, `OSError` surfacing as `error` rather than being swallowed, and that the check is actually registered (a check that exists but never runs is the 2026-07-21 failure shape exactly).

**Mutation-checked** — each of these breaks the suite:
- downgrade `fail` → `warn`
- drop `checks.append(check_disk_space())`
- flip `min()` → `max()` (roomy volume masks the full one)
- swallow the `OSError` as `ok`

One honesty note on that list: my first attempt at the `fail`→`warn` mutation appeared **not** to bite. It turned out the mutation was invalid — `str.replace(..., 1)` had hit the first of five `"status": "fail"` occurrences in the file, which belongs to a different check. Re-anchored on this function's unique string, it bites (3 failures). Worth stating because "the mutation didn't fail" and "the mutation didn't apply" look identical from the exit code.

Existing `tests/health-check-*.test.py` all still exit 0.
