### PR TITLE
fix(gateway): peer fleet agent must not set owner-presence (presence-only gate)

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -675,6 +675,37 @@ def _maybe_fetch_media(body: str, _refs_out: "list | None" = None) -> str:
     return MEDIA_MARKER_RE.sub(lambda _m: f"[{label}: {path}]", body, count=1)
 
 
+# Fleet-agent directory cache — peer agents (in the broker's /v1/agents) are
+# NEVER the human owner, so their messages must not set owner-presence. Only the
+# PRESENCE gate consults this; task authority (_tier_for) is deliberately left
+# untouched, so peer-to-peer delegation keeps its access_tier (a peer agent still
+# resolves to owner tier on a tierMap-less node and can still act — the two
+# consumers of _tier_for are decoupled here on purpose).
+_FLEET_AGENTS_TTL_S = 300.0
+_fleet_agents_cache: dict = {"ts": 0.0, "ids": set()}
+
+
+def _fleet_agent_ids() -> set[str]:
+    """Broker-attested set of fleet agent mxids (from GET /v1/agents), cached
+    ~5 min. FAIL-OPEN: on any fetch/parse error keep (and return) the last good
+    set — never an empty set that would mistake a real peer for the owner. Before
+    the first successful fetch the set is empty, so behavior is exactly today's
+    (record) until the directory is known — presence must never SWALLOW genuine
+    owner activity, only decline to record a KNOWN peer."""
+    now = time.time()
+    if now - _fleet_agents_cache["ts"] < _FLEET_AGENTS_TTL_S and _fleet_agents_cache["ids"]:
+        return _fleet_agents_cache["ids"]
+    try:
+        resp = _req("GET", "/v1/agents")
+        ids = {a.get("id") for a in (resp.get("agents") or []) if isinstance(a, dict) and a.get("id")}
+        if ids:
+            _fleet_agents_cache["ts"] = now
+            _fleet_agents_cache["ids"] = ids
+    except Exception:
+        pass  # keep the prior good set (fail-open)
+    return _fleet_agents_cache["ids"]
+
+
 def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
     """Record that the owner was active on this transport right now — but only
     when THIS node resolves the SENDER to owner tier. Gated on the sender's
@@ -694,6 +725,16 @@ def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
     if sender_tier is None:
         sender_tier = _tier_for(task.get("user_id"))
     if sender_tier != "owner":
+        return
+    # A peer FLEET agent resolves to owner tier on a tierMap-less node (LOCAL_TIER
+    # fallthrough), but it is never the HUMAN owner — recording its post as
+    # owner-presence poisons the proactive-loop's engagement signal and the
+    # core-supervisor escalation target. Gate PRESENCE ONLY here; the task's
+    # access_tier (the other _tier_for consumer) stays owner so peer delegation
+    # is unaffected. Broker-attested user_id only — the /v1/agents directory is
+    # the authoritative peer set (the human owner is not in it).
+    _uid = (task.get("user_id") or "").strip()
+    if _uid and _uid in _fleet_agent_ids():
         return
     try:
         OWNER_ACTIVITY_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/ag2-sparrow/tests/test_owner_presence_peer_gate.py
+++ b/packages/ag2-sparrow/tests/test_owner_presence_peer_gate.py
@@ -1,0 +1,120 @@
+"""Presence gate: a peer FLEET agent must not set owner-presence, while its
+task authority (access_tier) stays exactly as today.
+
+Regression: `_tier_for()` falls through to LOCAL_TIER="owner" for any unlisted
+sender on a tierMap-less node, so a peer agent's room post (a) read as owner-tier
+AND (b) overwrote `last-owner-activity.json`, poisoning the proactive-loop's
+"owner active N min ago" signal (and the core-supervisor escalation target).
+
+The fix gates PRESENCE ONLY (`_write_owner_activity` consults the /v1/agents
+fleet directory and returns early for peers) and deliberately leaves `_tier_for`
+untouched — because `_tier_for` also feeds the task's access_tier, and
+down-tiering peers there would sandbox all peer-to-peer delegation. So this test
+covers BOTH consumers of `_tier_for` (per the review requirement): after the
+change a peer task still resolves access_tier=owner, but no owner-activity is
+written for it.
+"""
+import importlib
+import json
+import os
+import tempfile
+import pathlib
+
+
+OWNER = "@qingyun:ag2.space"          # the human owner — NOT in /v1/agents
+PEER = "@qingyun-air.agent:ag2.space"  # a fleet agent — IN /v1/agents
+
+
+def _load():
+    os.environ.setdefault("REMOTE_TASK_URL", "https://gw.example/relay")
+    os.environ.setdefault("REMOTE_TASK_TOKEN", "dummy-secret")
+    os.environ["REMOTE_TASK_TIER"] = "owner"   # tierMap-less node → LOCAL_TIER=owner
+    m = importlib.import_module("ag2_sparrow.remote_gateway_bridge")
+    m = importlib.reload(m)
+    # deterministic fleet directory
+    m._req = lambda method, path, *a, **k: (
+        {"agents": [{"id": PEER}, {"id": "@sutando-bassil:ag2.space"}]}
+        if path == "/v1/agents" else {}
+    )
+    m._fleet_agents_cache["ts"] = 0.0
+    m._fleet_agents_cache["ids"] = set()
+    return m
+
+
+def _task(uid):
+    return {"user_id": uid, "task": "[AG2Space @x] coordinate on the pin", "source": "ag2space"}
+
+
+def _tmp_owner_file(m):
+    d = tempfile.mkdtemp()
+    m.OWNER_ACTIVITY_FILE = pathlib.Path(d) / "last-owner-activity.json"
+    return m.OWNER_ACTIVITY_FILE
+
+
+def test_fleet_agent_ids_fetches_and_caches():
+    m = _load()
+    ids = m._fleet_agent_ids()
+    assert PEER in ids and "@sutando-bassil:ag2.space" in ids
+    assert OWNER not in ids
+    # cached: a later _req that raises must not disturb the cached set
+    m._req = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("down"))
+    assert m._fleet_agent_ids() == ids  # served from cache
+
+
+def test_fleet_agent_ids_fail_open_empty_on_error_before_first_fetch():
+    m = _load()
+    m._req = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("down"))
+    m._fleet_agents_cache["ts"] = 0.0
+    m._fleet_agents_cache["ids"] = set()
+    assert m._fleet_agent_ids() == set()  # never invents ids → never mistakes owner for peer
+
+
+def test_peer_sender_does_not_write_owner_activity():
+    m = _load()
+    f = _tmp_owner_file(m)
+    # consumer 1 (presence): peer resolves to owner tier, but must NOT record
+    m._write_owner_activity(_task(PEER), sender_tier="owner")
+    assert not f.exists(), "peer agent poisoned owner-presence"
+
+
+def test_owner_sender_still_writes_owner_activity():
+    m = _load()
+    f = _tmp_owner_file(m)
+    m._write_owner_activity(_task(OWNER), sender_tier="owner")
+    assert f.exists(), "genuine owner activity was swallowed"
+    assert json.loads(f.read_text())["channel"] == "ag2space"
+
+
+def test_peer_task_authority_unchanged_access_tier_still_owner():
+    m = _load()
+    # consumer 2 (task authority): _tier_for is UNTOUCHED — a peer still resolves
+    # to owner tier on this tierMap-less node, so peer-to-peer delegation keeps
+    # working. If this flips to team/other, the fix wrongly sandboxed peers.
+    assert m._tier_for(PEER) == "owner"
+    assert m._tier_for(OWNER) == "owner"
+
+
+def test_fail_open_records_peer_when_directory_unknown():
+    m = _load()
+    f = _tmp_owner_file(m)
+    # directory fetch fails and cache empty → fail-open: record (never swallow).
+    m._req = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("down"))
+    m._fleet_agents_cache["ts"] = 0.0
+    m._fleet_agents_cache["ids"] = set()
+    m._write_owner_activity(_task(PEER), sender_tier="owner")
+    assert f.exists(), "fail-open must record rather than risk swallowing owner activity"
+
+
+if __name__ == "__main__":
+    import sys
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    fails = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"  ok   {fn.__name__}")
+        except Exception as e:
+            fails += 1
+            print(f"  FAIL {fn.__name__}: {e}")
+    print(f"\n{'PASS' if not fails else 'FAILED'} ({len(fns)-fails}/{len(fns)})")
+    sys.exit(1 if fails else 0)

--- a/tests/gateway-owner-presence-peer-gate.test.py
+++ b/tests/gateway-owner-presence-peer-gate.test.py
@@ -29,6 +29,9 @@ def _load():
     os.environ.setdefault("REMOTE_TASK_URL", "https://gw.example/relay")
     os.environ.setdefault("REMOTE_TASK_TOKEN", "dummy-secret")
     os.environ["REMOTE_TASK_TIER"] = "owner"   # tierMap-less node → LOCAL_TIER=owner
+    # Repo root is parents[1] from tests/; the package lives under packages/.
+    import sys
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "packages" / "ag2-sparrow"))
     m = importlib.import_module("ag2_sparrow.remote_gateway_bridge")
     m = importlib.reload(m)
     # deterministic fleet directory


### PR DESCRIPTION
## The bug

On a node with no `tierMap`, `_tier_for()` falls through to `LOCAL_TIER="owner"` for any unlisted sender. In a **shared room**, that means a *peer fleet agent's* post:
1. reads as owner-tier, and
2. passes `_write_owner_activity`'s owner-gate → overwrites `state/last-owner-activity.json`.

That poisons owner-presence: the proactive-loop's "owner active N min ago" active-engagement signal, step-6.5's away/present discriminator, and core-supervisor-relay's `--active-from` escalation target all read that file. Observed live — a peer agent's Master-Room coordination posts registered as recent *owner* activity.

## The fix (presence only)

`_tier_for` is **left untouched** — it also produces the task's `access_tier` (`access_tier: {sender_tier}`), and down-tiering peers there would rewrite every peer-sent task to `team` → sandboxed read-only, breaking all peer-to-peer delegation.

Instead `_write_owner_activity` grows its **own** discriminator: consult the broker's `/v1/agents` fleet directory (the human owner is not in it), cached ~5 min, and return early for a sender in that set. **Fail-open**: on fetch error / before the first successful fetch the set is empty, so it records as today — presence must never *swallow* genuine owner activity, only decline to record a *known* peer.

## Tested — both consumers

Per review, both `_tier_for` consumers are asserted (else the untouched one is untested):
- **presence**: a peer sender → `last-owner-activity.json` NOT written; owner sender → written.
- **authority**: `_tier_for(peer)` still returns `owner` (peer delegation unaffected).
- plus fail-open (records when directory unknown) and fetch/cache.

6/6 green; existing `remote-gateway-bridge.test.py` still passes.

Credit: **@qingyun-air.agent** caught the two-consumer blast radius before this shipped as a `_tier_for` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
