### PR TITLE
ci: run the five Python tests that live outside tests/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
         run: |
           python3 src/remote-gateway-bridge.test.py
           python3 packages/ag2-sparrow/tests/test_gateway_status.py
+          python3 packages/ag2-sparrow/tests/test_ack_retry.py
+          python3 packages/ag2-sparrow/tests/test_inflight_recovery.py
+          python3 packages/ag2-sparrow/tests/test_write_task_atomic.py
           python3 packages/ag2-sparrow/tools/test_no_drift.py
           python3 skills/agent-room-ops/test_room_ops.py
           python3 skills/make-viral-video/scripts/test_source_tag.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,21 @@ jobs:
           python3 scripts/lint-skill.test.py
           python3 scripts/lint-skill.py --all --strict
 
+      # Python tests that live OUTSIDE tests/ and so are invisible to the
+      # `find tests -name '*.test.py'` step below. Same reason the skill-manifest
+      # test above is wired by hand. Without this they run only when someone
+      # remembers to run them locally, which is indistinguishable from passing.
+      # Notably src/remote-gateway-bridge.test.py — the suite the transport
+      # change process requires for ANY package change — and tools/test_no_drift.py,
+      # which is the guard against src/ and the package silently diverging.
+      - name: Run out-of-tree Python tests
+        run: |
+          python3 src/remote-gateway-bridge.test.py
+          python3 packages/ag2-sparrow/tests/test_gateway_status.py
+          python3 packages/ag2-sparrow/tools/test_no_drift.py
+          python3 skills/agent-room-ops/test_room_ops.py
+          python3 skills/make-viral-video/scripts/test_source_tag.py
+
       - name: Run tests
         run: npm test
         if: hashFiles('tests/**/*.test.ts') != ''

--- a/tests/ci-covers-every-python-test.test.py
+++ b/tests/ci-covers-every-python-test.test.py
@@ -57,11 +57,20 @@ def test_looking_files():
     return keep
 
 
+def orphans_in(all_files, discovered, named):
+    """The actual rule, extracted so a synthetic case can pin it.
+
+    Inlined, this was un-pinnable: gutting it to `orphans = []` passed the whole
+    suite, because the only other test exercised set arithmetic in isolation
+    rather than the code path the real assertion uses."""
+    return sorted(set(all_files) - set(discovered) - set(named))
+
+
 class TestCICoversEveryPythonTest(unittest.TestCase):
     def test_no_python_test_is_invisible_to_ci(self):
         import os
         os.chdir(REPO)
-        orphans = sorted(test_looking_files() - discovered_by_find() - named_in_workflows())
+        orphans = orphans_in(test_looking_files(), discovered_by_find(), named_in_workflows())
         self.assertEqual(
             orphans, [],
             "these test files are never executed by CI — either move them to "
@@ -70,10 +79,21 @@ class TestCICoversEveryPythonTest(unittest.TestCase):
         )
 
     def test_the_guard_can_actually_fail(self):
-        """A guard that cannot fire is the bug it exists to catch."""
-        fake = {"packages/somewhere/tests/test_invented.py"}
-        self.assertTrue(fake - discovered_by_find() - named_in_workflows(),
-                        "an out-of-tree file must register as an orphan")
+        """A guard that cannot fire is the bug it exists to catch.
+
+        Exercises orphans_in() — the same function the real assertion calls — so
+        stubbing that computation breaks this case too. Testing the set algebra
+        inline instead left the real check gutted-and-green."""
+        self.assertEqual(
+            orphans_in({"packages/somewhere/tests/test_invented.py"}, set(), set()),
+            ["packages/somewhere/tests/test_invented.py"],
+            "an out-of-tree file must register as an orphan")
+
+    def test_a_discovered_file_is_not_an_orphan(self):
+        self.assertEqual(orphans_in({"tests/x.test.py"}, {"tests/x.test.py"}, set()), [])
+
+    def test_a_workflow_named_file_is_not_an_orphan(self):
+        self.assertEqual(orphans_in({"scripts/y.py"}, set(), {"scripts/y.py"}), [])
 
 
 if __name__ == "__main__":

--- a/tests/ci-covers-every-python-test.test.py
+++ b/tests/ci-covers-every-python-test.test.py
@@ -34,13 +34,27 @@ def named_in_workflows():
 
 
 def test_looking_files():
-    out = set()
-    for pat in ("**/*.test.py", "**/test_*.py", "**/*_test.py"):
-        for p in glob.glob(pat, recursive=True):
-            if "node_modules" in p or p.startswith(".git/"):
-                continue
-            out.add(str(Path(p)))
-    return out
+    """Git-TRACKED test-looking files only.
+
+    A bare glob also sees transient files that other suites create while running
+    (temp fixtures written inside the tree), which made this guard fail in one CI
+    step and pass in another within the same job — order-dependent, and a flaky
+    guard is worse than none. Only committed files are part of the repo's test
+    surface, so ask git rather than the filesystem."""
+    import subprocess
+    out = subprocess.run(["git", "ls-files", "-z"], capture_output=True)
+    if out.returncode != 0:
+        raise unittest.SkipTest("not a git checkout — this guard is about committed files")
+    files = [f for f in out.stdout.decode().split("\0") if f]
+    keep = set()
+    for f in files:
+        base = Path(f).name
+        if "node_modules" in f:
+            continue
+        if base.endswith(".test.py") or base.startswith("test_") and base.endswith(".py") \
+           or base.endswith("_test.py"):
+            keep.add(str(Path(f)))
+    return keep
 
 
 class TestCICoversEveryPythonTest(unittest.TestCase):

--- a/tests/ci-covers-every-python-test.test.py
+++ b/tests/ci-covers-every-python-test.test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Every test-looking Python file must actually be executed by CI.
+
+CI discovers Python tests with `find tests -name '*.test.py'`. Anything outside
+that root or suffix runs only if ci.yml names it explicitly. A fixed list is
+maintenance the next author will not know they owe: a test added under
+packages/*/tests/ is silently never run, and reads as coverage anyway.
+
+This guard makes that gap self-detecting instead of silent. It failed to exist
+when five suites -- including the transport gate and the src/-vs-package drift
+guard -- had never run in CI.
+"""
+import glob
+import re
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CI = REPO / ".github" / "workflows" / "ci.yml"
+
+
+def discovered_by_find():
+    """What `find tests -name '*.test.py'` reaches."""
+    return {str(Path(p)) for p in glob.glob("tests/**/*.test.py", recursive=True)}
+
+
+def named_in_workflows():
+    """Files any workflow invokes explicitly, e.g. `python3 path/to/x.py`."""
+    named = set()
+    for wf in (REPO / ".github" / "workflows").glob("*.yml"):
+        for m in re.finditer(r"python3?\s+(\S+\.py)", wf.read_text()):
+            named.add(m.group(1))
+    return named
+
+
+def test_looking_files():
+    out = set()
+    for pat in ("**/*.test.py", "**/test_*.py", "**/*_test.py"):
+        for p in glob.glob(pat, recursive=True):
+            if "node_modules" in p or p.startswith(".git/"):
+                continue
+            out.add(str(Path(p)))
+    return out
+
+
+class TestCICoversEveryPythonTest(unittest.TestCase):
+    def test_no_python_test_is_invisible_to_ci(self):
+        import os
+        os.chdir(REPO)
+        orphans = sorted(test_looking_files() - discovered_by_find() - named_in_workflows())
+        self.assertEqual(
+            orphans, [],
+            "these test files are never executed by CI — either move them to "
+            "tests/<name>.test.py (auto-discovered) or name them explicitly in "
+            f"a workflow:\n  " + "\n  ".join(orphans),
+        )
+
+    def test_the_guard_can_actually_fail(self):
+        """A guard that cannot fire is the bug it exists to catch."""
+        fake = {"packages/somewhere/tests/test_invented.py"}
+        self.assertTrue(fake - discovered_by_find() - named_in_workflows(),
+                        "an out-of-tree file must register as an orphan")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Two things, the second added in response to review:

1. **Runs the five Python suites that live outside `tests/`** and are therefore never executed by CI.
2. **Adds a guard so this class of gap reports itself** instead of needing a reviewer to notice.

## Why

`ci.yml` discovers Python tests with `find tests -name '*.test.py'` — rooted at `tests/`, suffix-gated. That reaches 214 suites. Five fall outside it and have never run in CI:

| file | why it matters |
| --- | --- |
| `src/remote-gateway-bridge.test.py` | the suite our transport-change process *requires* for any package change |
| `packages/ag2-sparrow/tools/test_no_drift.py` | the guard against `src/` and the package copy diverging |
| `packages/ag2-sparrow/tests/test_gateway_status.py` | gateway status emission |
| `skills/agent-room-ops/test_room_ops.py` | ~105 lines of tests shipped recently; none ran |
| `skills/make-viral-video/scripts/test_source_tag.py` | — |

The first two are the point. One was treated as a required gate while nothing enforced it; the other exists to catch two copies of a module diverging, which is exactly what it cannot catch while unexecuted. A suite that is *relied upon* and never runs is worse than no suite — it is counted as coverage.

## The guard (added after review)

Review raised that a **fixed list is maintenance the next author doesn't know they owe** — demonstrated the same day, when a test added in another PR was already absent from it.

So `tests/ci-covers-every-python-test.test.py` now enumerates every **git-tracked** test-looking file and fails if any is neither reachable by the CI glob nor named explicitly in a workflow, printing the offending path.

It asks `git ls-files` rather than globbing the filesystem: an earlier revision globbed, saw transient fixtures other suites write mid-run, and failed in one CI step while passing in another — order-dependent. A flaky guard is worse than none, because it trains people to rerun instead of read.

## Verification

- All five suites exit 0 on `main` — this lands green, it does not turn CI red.
- **The step gates:** with one suite forced to fail, the combined step exits non-zero.
- **The guard gates, both directions:** removing a wired entry from `ci.yml` fails it and names the file; adding a new out-of-tree test fails it too. An untracked transient file does not.
- The suite includes an explicit *can-this-guard-fire* case, since a guard that cannot fire is the bug it exists to catch.
- Confirmed in CI at step level: `Run out-of-tree Python tests -> completed/success`.
