### PR TITLE
fix(pending-questions): stop claiming delivery that did not happen

### DIFF
--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -148,11 +148,13 @@ def should_notify():
 
 
 def notify_macos(count, titles):
+    """Returns True only if osascript actually accepted the notification."""
     msg = f"{count} pending question{'s' if count > 1 else ''}: {', '.join(titles[:3])}"
-    subprocess.run([
+    r = subprocess.run([
         "osascript", "-e",
         f'display notification "{msg}" with title "Sutando"'
     ], capture_output=True)
+    return r.returncode == 0
 
 
 def questions_key(questions):
@@ -195,6 +197,31 @@ def notify_discord_dm(questions):
     path.write_text("\n".join(lines))
 
 
+# A proactive-*.txt is only a DELIVERY if some bridge drains it. On a host where
+# none is running the file just accumulates, while this script still printed
+# "Notified" -- claiming an outcome it never achieved. Rather than sniff for
+# consumer processes (pgrep -f self-matches; see the watcher notes), use the
+# evidence already on disk: files we wrote earlier that nobody took.
+UNDRAINED_AGE_S = 600
+
+
+def undrained_proactive_files():
+    """Previously-written proactive-*.txt older than UNDRAINED_AGE_S -- i.e. old
+    enough that a live consumer would have drained them."""
+    now = time.time()
+    out = []
+    try:
+        for f in RESULTS_DIR.glob("proactive-*.txt"):
+            try:
+                if now - f.stat().st_mtime > UNDRAINED_AGE_S:
+                    out.append(f.name)
+            except OSError:
+                continue
+    except OSError:
+        return []
+    return sorted(out)
+
+
 def main():
     force = "--force" in sys.argv
     questions = get_waiting_questions()
@@ -213,13 +240,16 @@ def main():
     titles = [q["title"] for q in questions]
 
     # macOS notification
-    notify_macos(count, titles)
+    stale_before = undrained_proactive_files()
+    macos_ok = notify_macos(count, titles)
 
     # Voice result — only when voice is actually connected. When offline, the
     # discord-bridge dm-fallback would deliver question-*.txt as a duplicate
     # of notify_discord_dm below. Skipping cuts the spam in half.
+    voice_ok = False
     if voice_client_connected():
         notify_voice(questions)
+        voice_ok = True
 
     # Discord DM to owner (via discord-bridge poll_proactive)
     notify_discord_dm(questions)
@@ -227,7 +257,21 @@ def main():
     # Update last notify time
     LAST_NOTIFY_FILE.write_text(str(int(time.time())))
 
-    print(f"Notified: {count} pending questions")
+    paths = []
+    paths.append("macos=ok" if macos_ok else "macos=FAILED")
+    paths.append("voice=ok" if voice_ok else "voice=skipped(not connected)")
+    if stale_before:
+        paths.append(f"proactive-file=written but {len(stale_before)} earlier one(s) UNDRAINED")
+    else:
+        paths.append("proactive-file=written")
+    print(f"Notified: {count} pending questions [{', '.join(paths)}]")
+    if stale_before:
+        print(
+            "  WARNING: no consumer is draining results/proactive-*.txt on this host "
+            f"(oldest undrained: {stale_before[0]}). The DM path is NOT reaching the owner; "
+            "only the macOS notification is real here.",
+            file=sys.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -246,6 +246,23 @@ def notify_summary(count, macos_ok, voice_ok, stale):
     return summary, warning
 
 
+def deliver(questions, count, titles):
+    """Fire every notification path and report what actually happened.
+
+    Separated from main() so the delivery decisions are testable; main() is left
+    as argument parsing plus printing. Voice is skipped when disconnected because
+    the DM fallback would otherwise deliver question-*.txt as a duplicate.
+    """
+    stale = undrained_proactive_files()
+    macos_ok = notify_macos(count, titles)
+    voice_ok = False
+    if voice_client_connected():
+        notify_voice(questions)
+        voice_ok = True
+    notify_discord_dm(questions)
+    return notify_summary(count, macos_ok, voice_ok, stale)
+
+
 def main():
     force = "--force" in sys.argv
     questions = get_waiting_questions()
@@ -263,25 +280,8 @@ def main():
     count = len(questions)
     titles = [q["title"] for q in questions]
 
-    # macOS notification
-    stale_before = undrained_proactive_files()
-    macos_ok = notify_macos(count, titles)
-
-    # Voice result — only when voice is actually connected. When offline, the
-    # discord-bridge dm-fallback would deliver question-*.txt as a duplicate
-    # of notify_discord_dm below. Skipping cuts the spam in half.
-    voice_ok = False
-    if voice_client_connected():
-        notify_voice(questions)
-        voice_ok = True
-
-    # Discord DM to owner (via discord-bridge poll_proactive)
-    notify_discord_dm(questions)
-
-    # Update last notify time
+    summary, warning = deliver(questions, count, titles)
     LAST_NOTIFY_FILE.write_text(str(int(time.time())))
-
-    summary, warning = notify_summary(count, macos_ok, voice_ok, stale_before)
     print(summary)
     if warning:
         print(warning, file=sys.stderr)

--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -260,7 +260,10 @@ def deliver(questions, count, titles):
         notify_voice(questions)
         voice_ok = True
     notify_discord_dm(questions)
-    return notify_summary(count, macos_ok, voice_ok, stale)
+    summary, warning = notify_summary(count, macos_ok, voice_ok, stale)
+    if warning:
+        print(warning, file=sys.stderr)
+    return summary
 
 
 def main():
@@ -280,11 +283,8 @@ def main():
     count = len(questions)
     titles = [q["title"] for q in questions]
 
-    summary, warning = deliver(questions, count, titles)
     LAST_NOTIFY_FILE.write_text(str(int(time.time())))
-    print(summary)
-    if warning:
-        print(warning, file=sys.stderr)
+    print(deliver(questions, count, titles))
 
 
 if __name__ == "__main__":

--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -222,6 +222,30 @@ def undrained_proactive_files():
     return sorted(out)
 
 
+def notify_summary(count, macos_ok, voice_ok, stale):
+    """Build the per-path summary line, plus a warning when the DM path is dead.
+
+    Pure so the claim itself is testable — the whole point of this change is that
+    the summary must not assert delivery that did not occur."""
+    paths = [
+        "macos=ok" if macos_ok else "macos=FAILED",
+        "voice=ok" if voice_ok else "voice=skipped(not connected)",
+    ]
+    if stale:
+        paths.append(f"proactive-file=written but {len(stale)} earlier one(s) UNDRAINED")
+    else:
+        paths.append("proactive-file=written")
+    summary = f"Notified: {count} pending questions [{', '.join(paths)}]"
+    warning = None
+    if stale:
+        warning = (
+            "  WARNING: no consumer is draining results/proactive-*.txt on this host "
+            f"(oldest undrained: {stale[0]}). The DM path is NOT reaching the owner; "
+            "only the macOS notification is real here."
+        )
+    return summary, warning
+
+
 def main():
     force = "--force" in sys.argv
     questions = get_waiting_questions()
@@ -257,21 +281,10 @@ def main():
     # Update last notify time
     LAST_NOTIFY_FILE.write_text(str(int(time.time())))
 
-    paths = []
-    paths.append("macos=ok" if macos_ok else "macos=FAILED")
-    paths.append("voice=ok" if voice_ok else "voice=skipped(not connected)")
-    if stale_before:
-        paths.append(f"proactive-file=written but {len(stale_before)} earlier one(s) UNDRAINED")
-    else:
-        paths.append("proactive-file=written")
-    print(f"Notified: {count} pending questions [{', '.join(paths)}]")
-    if stale_before:
-        print(
-            "  WARNING: no consumer is draining results/proactive-*.txt on this host "
-            f"(oldest undrained: {stale_before[0]}). The DM path is NOT reaching the owner; "
-            "only the macOS notification is real here.",
-            file=sys.stderr,
-        )
+    summary, warning = notify_summary(count, macos_ok, voice_ok, stale_before)
+    print(summary)
+    if warning:
+        print(warning, file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/src/check-pending-questions.py
+++ b/src/check-pending-questions.py
@@ -179,7 +179,7 @@ def notify_discord_dm(questions):
     """Write a proactive-*.txt file so discord-bridge DMs the owner.
     Owner asked (2026-04-09, while traveling) to receive pending-question
     pings as DMs instead of just macOS notifications."""
-    path = RESULTS_DIR / f"proactive-pending-q-{questions_key(questions)}.txt"
+    path = RESULTS_DIR / f"{PROACTIVE_PREFIX}{questions_key(questions)}.txt"
     lines = [
         f"⚠️ {len(questions)} pending question{'s' if len(questions) > 1 else ''} waiting:",
         "",
@@ -203,6 +203,11 @@ def notify_discord_dm(questions):
 # consumer processes (pgrep -f self-matches; see the watcher notes), use the
 # evidence already on disk: files we wrote earlier that nobody took.
 UNDRAINED_AGE_S = 600
+# Only OUR files are evidence about OUR delivery path. results/proactive-*.txt is
+# a shared namespace — morning-briefing and the durable scheduler write there too
+# (see notes/proactive-delivery-void-inventory.md). One unrelated stale file would
+# otherwise produce a confident, wrong "the DM path is not reaching the owner".
+PROACTIVE_PREFIX = "proactive-pending-q-"
 
 
 def undrained_proactive_files():
@@ -211,7 +216,7 @@ def undrained_proactive_files():
     now = time.time()
     out = []
     try:
-        for f in RESULTS_DIR.glob("proactive-*.txt"):
+        for f in RESULTS_DIR.glob(f"{PROACTIVE_PREFIX}*.txt"):
             try:
                 if now - f.stat().st_mtime > UNDRAINED_AGE_S:
                     out.append(f.name)
@@ -283,8 +288,13 @@ def main():
     count = len(questions)
     titles = [q["title"] for q in questions]
 
+    # Cooldown is stamped only AFTER delivery returns. Stamping first meant a
+    # raising delivery path still suppressed the next hour's notification — the
+    # exact "claimed an outcome it never achieved" failure this script exists to
+    # remove, reproduced in its own control flow.
+    summary = deliver(questions, count, titles)
     LAST_NOTIFY_FILE.write_text(str(int(time.time())))
-    print(deliver(questions, count, titles))
+    print(summary)
 
 
 if __name__ == "__main__":

--- a/tests/pending-questions-honest-notify.test.py
+++ b/tests/pending-questions-honest-notify.test.py
@@ -49,9 +49,30 @@ class TestUndrainedDetection(unittest.TestCase):
         self.assertEqual(self.m.undrained_proactive_files(), [],
                          "a stale task result is a different thing entirely")
 
-    def test_d_missing_dir_does_not_raise(self):
-        self.m.RESULTS_DIR = Path("/nonexistent/definitely/not/here")
+    def test_d_glob_raising_oserror_is_swallowed(self):
+        """The outer handler. A missing dir does NOT raise from glob() — it
+        yields nothing — so the earlier version of this test passed without ever
+        reaching the except it was named for."""
+        class Boom:
+            def glob(self, _pat):
+                raise OSError("boom")
+        self.m.RESULTS_DIR = Boom()
         self.assertEqual(self.m.undrained_proactive_files(), [])
+
+    def test_d2_stat_raising_oserror_skips_that_file(self):
+        """The inner handler: one unstattable entry must not lose the others."""
+        good = self._write("proactive-good.txt", self.m.UNDRAINED_AGE_S + 60)
+
+        class Bad:
+            name = "proactive-bad.txt"
+            def stat(self):
+                raise OSError("nope")
+
+        class Dir:
+            def glob(self, _pat):
+                return [Bad(), good]
+        self.m.RESULTS_DIR = Dir()
+        self.assertEqual(self.m.undrained_proactive_files(), ["proactive-good.txt"])
 
     def test_e_notify_macos_reports_failure(self):
         import subprocess
@@ -99,6 +120,43 @@ class TestNotifySummary(unittest.TestCase):
     def test_e_count_is_carried(self):
         s, _ = self.m.notify_summary(16, True, True, [])
         self.assertIn("16 pending questions", s)
+
+
+class TestDeliver(unittest.TestCase):
+    """deliver() must report per-path truth, not a blanket success."""
+
+    def setUp(self):
+        import tempfile
+        self.m = _load(tempfile.mkdtemp(prefix="cpq-del-"))
+        self.m.notify_discord_dm = lambda q: None
+        self.m.notify_voice = lambda q: None
+
+    def test_a_voice_connected_reports_ok(self):
+        self.m.notify_macos = lambda c, t: True
+        self.m.voice_client_connected = lambda: True
+        s, w = self.m.deliver([{"title": "q"}], 1, ["q"])
+        self.assertIn("voice=ok", s)
+        self.assertIsNone(w)
+
+    def test_b_voice_offline_reports_skipped(self):
+        self.m.notify_macos = lambda c, t: True
+        self.m.voice_client_connected = lambda: False
+        s, _ = self.m.deliver([{"title": "q"}], 1, ["q"])
+        self.assertIn("voice=skipped", s)
+
+    def test_c_macos_failure_surfaces(self):
+        self.m.notify_macos = lambda c, t: False
+        self.m.voice_client_connected = lambda: False
+        s, _ = self.m.deliver([{"title": "q"}], 1, ["q"])
+        self.assertIn("macos=FAILED", s)
+
+    def test_d_undrained_backlog_produces_warning(self):
+        self.m.notify_macos = lambda c, t: True
+        self.m.voice_client_connected = lambda: False
+        self.m.undrained_proactive_files = lambda: ["proactive-old.txt"]
+        s, w = self.m.deliver([{"title": "q"}], 1, ["q"])
+        self.assertIn("UNDRAINED", s)
+        self.assertIn("NOT reaching the owner", w)
 
 
 if __name__ == "__main__":

--- a/tests/pending-questions-honest-notify.test.py
+++ b/tests/pending-questions-honest-notify.test.py
@@ -191,6 +191,20 @@ class TestReviewFindings(unittest.TestCase):
         self.assertFalse(stamp.exists(),
                          "a failed delivery must NOT put the next hour on cooldown")
 
+    def test_a2_cooldown_IS_stamped_when_delivery_succeeds(self):
+        """The positive half. Testing only the failure case let the stamp be
+        deleted outright without any test failing — which would notify on every
+        run forever. A guard needs both directions or it pins nothing."""
+        import tempfile, pathlib
+        stamp = pathlib.Path(tempfile.mkdtemp()) / "last-notify"
+        self.m.LAST_NOTIFY_FILE = stamp
+        self.m.deliver = lambda *a, **k: "Notified: 1 pending questions [ok]"
+        self.m.get_waiting_questions = lambda: [{"title": "q"}]
+        self.m.should_notify = lambda *a, **k: True
+        self.m.main()
+        self.assertTrue(stamp.exists(), "a successful delivery MUST set the cooldown")
+        self.assertGreater(int(stamp.read_text()), 0)
+
     # --- finding 2: only THIS notifier's files are evidence ---
     def test_b_unrelated_stale_proactive_file_is_ignored(self):
         self._age("proactive-schedule-alert-cron.txt", self.m.UNDRAINED_AGE_S + 60)

--- a/tests/pending-questions-honest-notify.test.py
+++ b/tests/pending-questions-honest-notify.test.py
@@ -65,5 +65,41 @@ class TestUndrainedDetection(unittest.TestCase):
             subprocess.run = real
 
 
+
+class TestNotifySummary(unittest.TestCase):
+    """The summary line is the claim. It must not assert delivery that failed."""
+
+    def setUp(self):
+        import tempfile
+        self.m = _load(tempfile.mkdtemp(prefix="cpq-sum-"))
+
+    def test_a_all_paths_healthy(self):
+        s, w = self.m.notify_summary(3, True, True, [])
+        self.assertIn("macos=ok", s)
+        self.assertIn("voice=ok", s)
+        self.assertIn("proactive-file=written", s)
+        self.assertIsNone(w, "no warning when nothing is undrained")
+
+    def test_b_macos_failure_is_not_reported_as_ok(self):
+        s, _ = self.m.notify_summary(3, False, True, [])
+        self.assertIn("macos=FAILED", s)
+        self.assertNotIn("macos=ok", s)
+
+    def test_c_voice_offline_says_skipped_not_ok(self):
+        s, _ = self.m.notify_summary(3, True, False, [])
+        self.assertIn("voice=skipped(not connected)", s)
+
+    def test_d_undrained_produces_an_explicit_warning(self):
+        s, w = self.m.notify_summary(16, True, False, ["proactive-pending-q-old.txt"])
+        self.assertIn("UNDRAINED", s)
+        self.assertIsNotNone(w)
+        self.assertIn("NOT reaching the owner", w)
+        self.assertIn("proactive-pending-q-old.txt", w)
+
+    def test_e_count_is_carried(self):
+        s, _ = self.m.notify_summary(16, True, True, [])
+        self.assertIn("16 pending questions", s)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/pending-questions-honest-notify.test.py
+++ b/tests/pending-questions-honest-notify.test.py
@@ -134,29 +134,32 @@ class TestDeliver(unittest.TestCase):
     def test_a_voice_connected_reports_ok(self):
         self.m.notify_macos = lambda c, t: True
         self.m.voice_client_connected = lambda: True
-        s, w = self.m.deliver([{"title": "q"}], 1, ["q"])
+        s = self.m.deliver([{"title": "q"}], 1, ["q"])
         self.assertIn("voice=ok", s)
-        self.assertIsNone(w)
 
     def test_b_voice_offline_reports_skipped(self):
         self.m.notify_macos = lambda c, t: True
         self.m.voice_client_connected = lambda: False
-        s, _ = self.m.deliver([{"title": "q"}], 1, ["q"])
+        s = self.m.deliver([{"title": "q"}], 1, ["q"])
         self.assertIn("voice=skipped", s)
 
     def test_c_macos_failure_surfaces(self):
         self.m.notify_macos = lambda c, t: False
         self.m.voice_client_connected = lambda: False
-        s, _ = self.m.deliver([{"title": "q"}], 1, ["q"])
+        s = self.m.deliver([{"title": "q"}], 1, ["q"])
         self.assertIn("macos=FAILED", s)
 
     def test_d_undrained_backlog_produces_warning(self):
         self.m.notify_macos = lambda c, t: True
         self.m.voice_client_connected = lambda: False
         self.m.undrained_proactive_files = lambda: ["proactive-old.txt"]
-        s, w = self.m.deliver([{"title": "q"}], 1, ["q"])
+        import io, contextlib
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            s = self.m.deliver([{"title": "q"}], 1, ["q"])
         self.assertIn("UNDRAINED", s)
-        self.assertIn("NOT reaching the owner", w)
+        self.assertIn("NOT reaching the owner", err.getvalue(),
+                      "the warning must reach stderr, not just be returned")
 
 
 if __name__ == "__main__":

--- a/tests/pending-questions-honest-notify.test.py
+++ b/tests/pending-questions-honest-notify.test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""check-pending-questions must not claim delivery it did not achieve.
+
+2026-07-21: the cron printed "Notified: 16 pending questions" on a host where no
+bridge was draining results/proactive-*.txt. The DM never reached the owner; only
+a local macOS notification did. A notifier that reports success regardless of
+outcome is how a blocked decision sits unseen for a day.
+"""
+import importlib.util
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load(results_dir):
+    spec = importlib.util.spec_from_file_location("cpq", REPO / "src" / "check-pending-questions.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    m.RESULTS_DIR = Path(results_dir)
+    return m
+
+
+class TestUndrainedDetection(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+        self.d = Path(tempfile.mkdtemp(prefix="cpq-"))
+        self.m = _load(self.d)
+
+    def _write(self, name, age_s):
+        p = self.d / name
+        p.write_text("x")
+        t = time.time() - age_s
+        import os
+        os.utime(p, (t, t))
+        return p
+
+    def test_a_fresh_file_is_not_undrained(self):
+        self._write("proactive-pending-q-abc.txt", 5)
+        self.assertEqual(self.m.undrained_proactive_files(), [])
+
+    def test_b_old_file_is_undrained(self):
+        self._write("proactive-pending-q-abc.txt", self.m.UNDRAINED_AGE_S + 60)
+        self.assertEqual(self.m.undrained_proactive_files(), ["proactive-pending-q-abc.txt"])
+
+    def test_c_only_proactive_files_count(self):
+        self._write("task-123.txt", self.m.UNDRAINED_AGE_S + 60)
+        self.assertEqual(self.m.undrained_proactive_files(), [],
+                         "a stale task result is a different thing entirely")
+
+    def test_d_missing_dir_does_not_raise(self):
+        self.m.RESULTS_DIR = Path("/nonexistent/definitely/not/here")
+        self.assertEqual(self.m.undrained_proactive_files(), [])
+
+    def test_e_notify_macos_reports_failure(self):
+        import subprocess
+        real = subprocess.run
+        try:
+            subprocess.run = lambda *a, **k: type("R", (), {"returncode": 1})()
+            self.assertFalse(self.m.notify_macos(1, ["t"]), "a failed osascript must not read as delivered")
+            subprocess.run = lambda *a, **k: type("R", (), {"returncode": 0})()
+            self.assertTrue(self.m.notify_macos(1, ["t"]))
+        finally:
+            subprocess.run = real
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/pending-questions-honest-notify.test.py
+++ b/tests/pending-questions-honest-notify.test.py
@@ -162,5 +162,53 @@ class TestDeliver(unittest.TestCase):
                       "the warning must reach stderr, not just be returned")
 
 
+class TestReviewFindings(unittest.TestCase):
+    """Both cases john-the-dev flagged: the suite passed without exercising either."""
+
+    def setUp(self):
+        import tempfile
+        self.d = __import__("pathlib").Path(tempfile.mkdtemp(prefix="cpq-rev-"))
+        self.m = _load(self.d)
+
+    def _age(self, name, secs):
+        import os
+        p = self.d / name
+        p.write_text("x")
+        t = __import__("time").time() - secs
+        os.utime(p, (t, t))
+        return p
+
+    # --- finding 1: cooldown must not be stamped when delivery raises ---
+    def test_a_cooldown_not_stamped_when_delivery_raises(self):
+        import tempfile, pathlib
+        stamp = pathlib.Path(tempfile.mkdtemp()) / "last-notify"
+        self.m.LAST_NOTIFY_FILE = stamp
+        self.m.deliver = lambda *a, **k: (_ for _ in ()).throw(OSError("delivery blew up"))
+        self.m.get_waiting_questions = lambda: [{"title": "q"}]
+        self.m.should_notify = lambda *a, **k: True
+        with self.assertRaises(OSError):
+            self.m.main()
+        self.assertFalse(stamp.exists(),
+                         "a failed delivery must NOT put the next hour on cooldown")
+
+    # --- finding 2: only THIS notifier's files are evidence ---
+    def test_b_unrelated_stale_proactive_file_is_ignored(self):
+        self._age("proactive-schedule-alert-cron.txt", self.m.UNDRAINED_AGE_S + 60)
+        self._age("proactive-morning-brief.txt", self.m.UNDRAINED_AGE_S + 60)
+        self.assertEqual(self.m.undrained_proactive_files(), [],
+                         "another producer's stale file must not diagnose OUR path as dead")
+
+    def test_c_our_own_stale_file_is_still_detected(self):
+        self._age(f"{self.m.PROACTIVE_PREFIX}abc.txt", self.m.UNDRAINED_AGE_S + 60)
+        self.assertEqual(self.m.undrained_proactive_files(),
+                         [f"{self.m.PROACTIVE_PREFIX}abc.txt"])
+
+    def test_d_written_name_matches_the_scanned_prefix(self):
+        """Writer and detector must agree, or the check silently never fires."""
+        src = (REPO / "src" / "check-pending-questions.py").read_text()
+        self.assertIn('RESULTS_DIR / f"{PROACTIVE_PREFIX}', src)
+        self.assertIn('RESULTS_DIR.glob(f"{PROACTIVE_PREFIX}', src)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`check-pending-questions.py` printed `Notified: N pending questions` unconditionally, whether or not anything was delivered.

## Why it matters

Observed twice today: the cron reported `Notified: 16 pending questions` on a host where **no bridge was running to drain `results/proactive-*.txt`**. The DM was written into a directory nobody reads. The only real delivery was a local macOS notification — visible solely if you happen to be at that Mac.

So the mechanism whose entire job is *"tell the owner they have blocked decisions"* reported success while telling them nothing, for a full day, with sixteen questions open.

## How

Three small pieces, all about the **claim** rather than the delivery mechanism:

- `notify_macos()` returns whether `osascript` accepted the notification.
- `undrained_proactive_files()` — proactive files written earlier and not drained within 10 minutes. **Evidence-based rather than consumer-detection**: undrained files are already on disk, whereas `pgrep -f` self-matches (a trap this repo documents for the task watcher).
- `notify_summary(count, macos_ok, voice_ok, stale)` → `(line, warning)`, pure. The summary now reads `macos=ok` / `macos=FAILED`, `voice=ok` / `voice=skipped(not connected)`, and says plainly when the DM path is not reaching the owner.

`deliver()` wraps the three notification paths and owns the stderr warning, so `main()` contributes one statement. **Ordering is load-bearing**: `stale` is computed *before* the proactive file is rewritten — the filename is content-keyed, so writing first would reset the very mtime the check depends on and the warning would never fire.

## Tests — 15 cases

Fresh vs. old files, a stale `task-*.txt` not miscounted, `osascript` failure surfacing as failure, both threshold boundaries, the worse-of-two rule, and the summary's per-path truth.

**Mutation-checked** — each breaks the suite: stub the detector to `[]`, ignore the age threshold, force `notify_macos` to return `True`, widen the glob, suppress the warning, report an offline voice client as ok. Every mutation asserts its anchor exists first, so a no-op edit cannot masquerade as a passing test.

One test in an earlier revision was **vacuous** and the coverage gate caught it: `test_d_missing_dir_does_not_raise` pointed at a nonexistent path, but `Path.glob()` on a missing directory yields nothing rather than raising — so it never entered the `except` it was named for. Replaced with two that genuinely raise (a throwing `glob`, and one unstattable entry among good ones). That was the same defect class this PR exists to fix, inside this PR's own test.
