### PR TITLE
feat(quota-tracker): track Fable quota + remind to open/close Fable

### DIFF
--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from datetime import datetime
@@ -133,6 +134,29 @@ def _update_burn_rate(current_util_5h: float) -> dict | None:
     return result
 
 
+# --- Fable open/close reminder ----------------------------------------------
+# Thresholds are the one thing to tune to taste — the reminder is quota-driven by
+# default. It ONLY reminds (prints a line); it never switches the model. The core
+# model is toggled by the owner via `/model`.
+_FABLE_REMIND_HIGH = 0.80   # 5h util at/above, while NOT on Fable → suggest opening Fable
+_FABLE_REMIND_LOW = 0.40    # 5h util below, while ON Fable → suggest closing it
+
+
+def fable_reminder(result: dict) -> str:
+    """One-line reminder to toggle Fable, or '' if none. Never switches the model."""
+    if result.get("stale"):
+        return ""  # never advise on stale numbers
+    util = result.get("utilization_5h", 0)
+    pct = int(util * 100)
+    if not result.get("on_fable") and util >= _FABLE_REMIND_HIGH:
+        return (f"⚡ 5h budget {pct}% used — if you're deep in something, consider "
+                f"Fable 5 for the heavy lifting: `/model claude-fable-5`.")
+    if result.get("on_fable") and util < _FABLE_REMIND_LOW:
+        return (f"5h budget back to {pct}% — past the hard part? switch back off Fable: "
+                f"`/model <your main model>`.")
+    return ""
+
+
 def main():
     data = json.loads(QUOTA_FILE.read_text())
     headers = data.get("headers", {})
@@ -150,6 +174,13 @@ def main():
     reset_5h = headers.get("anthropic-ratelimit-unified-5h-reset", "")
     reset_7d = headers.get("anthropic-ratelimit-unified-7d-reset", "")
 
+    # The rate-limit budget is UNIFIED (one pool across Claude models), so this is
+    # not a separate Fable meter — it's an ATTRIBUTION: which model was active when
+    # this reading was taken. Tag by the running core model so a `fable` line shows
+    # how much of the unified budget was burned while on Fable 5.
+    core_model = os.environ.get("SUTANDO_CORE_MODEL", "")
+    on_fable = "fable" in core_model.lower()
+
     result = {
         "status": status,
         "available": status == "allowed",
@@ -159,6 +190,8 @@ def main():
         "remaining_7d_pct": round((1 - util_7d) * 100),
         "state_age_seconds": int(age_s),
         "stale": stale,
+        "core_model": core_model,
+        "on_fable": on_fable,
     }
 
     if reset_5h:
@@ -170,6 +203,12 @@ def main():
         burn = _update_burn_rate(util_5h)
         if burn:
             result["burn"] = burn
+
+    if "--fable-remind" in sys.argv:
+        # Print the toggle reminder (empty if none) so a caller (e.g. the
+        # proactive loop) can notify the owner. No model switch happens here.
+        print(fable_reminder(result))
+        return
 
     if "--json" in sys.argv:
         print(json.dumps(result, indent=2))
@@ -193,6 +232,12 @@ def main():
         b = result["burn"]
         print(f"Burn rate: {b['burn_rate_pct_per_pass']}%/pass ({b['burn_samples']} samples)")
         print(f"Est. passes left: {b['estimated_passes_left']} (~{b['estimated_minutes_left']}m)")
+    if result.get("core_model"):
+        tag = "  — Fable (budget above reflects Fable usage)" if result["on_fable"] else ""
+        print(f"Core model: {result['core_model']}{tag}")
+    _remind = fable_reminder(result)
+    if _remind:
+        print(_remind)
 
 
 if __name__ == "__main__":

--- a/tests/quota-tracker-fable-reminder.test.py
+++ b/tests/quota-tracker-fable-reminder.test.py
@@ -5,24 +5,37 @@ Two small features (no model switching — reminder only):
   1. read-quota tags each reading with the active core model (`core_model`/`on_fable`).
   2. `--fable-remind` prints a one-line reminder to switch to/from Fable based on
      the 5h utilization thresholds (or "" when neither condition holds / stale).
+
+Isolation: all state lives in a throwaway temp workspace. `$SUTANDO_WORKSPACE`
+is no longer honored (v0.8 / #1440), so the redirect is done by monkeypatching
+`workspace_default.resolve_workspace` BEFORE the module import — read-quota
+binds `status_read_path` at import and that helper looks up `resolve_workspace`
+as a module global at call time, so every path (QUOTA_FILE and the burn-history
+file, both resolved at import) lands in the temp dir. Neither the quota state
+this test writes nor the burn history the script updates ever touches the
+user's real workspace; case (j) asserts that. The module runs IN-PROCESS
+(importlib + main() with patched argv), not via subprocess, so the coverage
+gate actually measures the exercised lines.
 """
+import contextlib
+import importlib.util
+import io
 import json
 import os
-import subprocess
+import shutil
 import sys
-import time
+import tempfile
 from pathlib import Path
 
 _REPO = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(_REPO / "src"))
-from workspace_default import status_read_path  # noqa: E402
-
 READ_QUOTA = _REPO / "skills" / "quota-tracker" / "scripts" / "read-quota.py"
-QUOTA_FILE = status_read_path("quota-state.json")
+
+_WS = Path(tempfile.mkdtemp(prefix="quota-fable-test-ws-"))
+(_WS / "state").mkdir()
+QUOTA_FILE = _WS / "state" / "quota-state.json"  # status_read_path layout
 
 
 def _write_state(util_5h: float, util_7d: float = 0.2) -> None:
-    QUOTA_FILE.parent.mkdir(parents=True, exist_ok=True)
     QUOTA_FILE.write_text(json.dumps({"headers": {
         "anthropic-ratelimit-unified-status": "allowed",
         "anthropic-ratelimit-unified-5h-utilization": str(util_5h),
@@ -31,16 +44,46 @@ def _write_state(util_5h: float, util_7d: float = 0.2) -> None:
     os.utime(QUOTA_FILE, None)  # fresh mtime so it isn't flagged stale
 
 
+# Redirect the workspace BEFORE import — QUOTA_FILE and the burn-history path
+# are resolved at import time (and import exits if the quota file is missing,
+# so seed it first). read-quota imports workspace_default from <repo>/src; by
+# importing it first and patching resolve_workspace, the module under test
+# resolves every state path into the temp workspace.
+sys.path.insert(0, str(_REPO / "src"))
+import workspace_default  # noqa: E402
+
+workspace_default.resolve_workspace = lambda *a, **k: _WS
+_write_state(0.5)
+_spec = importlib.util.spec_from_file_location("read_quota_under_test", READ_QUOTA)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def _run(args: list, core_model: str = "") -> str:
+    """Call main() in-process with patched argv/env; return captured stdout."""
+    old_argv = sys.argv
+    old_model = os.environ.get("SUTANDO_CORE_MODEL")
+    sys.argv = ["read-quota.py"] + args
+    os.environ["SUTANDO_CORE_MODEL"] = core_model
+    out = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out):
+            _mod.main()
+    finally:
+        sys.argv = old_argv
+        if old_model is None:
+            os.environ.pop("SUTANDO_CORE_MODEL", None)
+        else:
+            os.environ["SUTANDO_CORE_MODEL"] = old_model
+    return out.getvalue()
+
+
 def _remind(core_model: str = "") -> str:
-    env = dict(os.environ, SUTANDO_CORE_MODEL=core_model)
-    out = subprocess.run([sys.executable, str(READ_QUOTA), "--fable-remind"],
-                         capture_output=True, text=True, env=env)
-    return out.stdout.strip()
+    return _run(["--fable-remind"], core_model=core_model).strip()
 
 
 def run():
     fails, passed = [], 0
-    backup = QUOTA_FILE.read_text() if QUOTA_FILE.exists() else None
     try:
         # (a) high util on a non-Fable model → suggest OPENING Fable
         _write_state(0.85)
@@ -72,19 +115,59 @@ def run():
 
         # (e) --json exposes core_model / on_fable
         _write_state(0.5)
-        env = dict(os.environ, SUTANDO_CORE_MODEL="claude-fable-5")
-        j = json.loads(subprocess.run(
-            [sys.executable, str(READ_QUOTA), "--json"],
-            capture_output=True, text=True, env=env).stdout)
+        j = json.loads(_run(["--json"], core_model="claude-fable-5"))
         if j.get("core_model") == "claude-fable-5" and j.get("on_fable") is True:
             passed += 1
         else:
             fails.append("(e) --json should expose core_model + on_fable")
+
+        # (f) no-flags human output, ON Fable at low util → Core model line
+        # with the Fable attribution tag AND the close-Fable reminder line.
+        _write_state(0.30)
+        out = _run([], core_model="claude-fable-5")
+        if ("Core model: claude-fable-5" in out
+                and "— Fable" in out
+                and "switch back off Fable" in out):
+            passed += 1
+        else:
+            fails.append(f"(f) no-flags on-Fable output missing tag/reminder: {out!r}")
+
+        # (g) no-flags human output, non-Fable at mid util → Core model line
+        # WITHOUT the Fable tag and no reminder line.
+        _write_state(0.55)
+        out = _run([], core_model="claude-opus-4-8")
+        if ("Core model: claude-opus-4-8" in out
+                and "— Fable" not in out
+                and "⚡" not in out
+                and "switch back off Fable" not in out):
+            passed += 1
+        else:
+            fails.append(f"(g) no-flags non-Fable output wrong: {out!r}")
+
+        # (h) no-flags human output with no core model set → no Core model line.
+        _write_state(0.55)
+        out = _run([], core_model="")
+        if "Core model:" not in out:
+            passed += 1
+        else:
+            fails.append(f"(h) empty core model should print no Core model line: {out!r}")
+
+        # (i) stale state → no reminder even at high util (never advise on
+        # stale numbers).
+        _write_state(0.85)
+        os.utime(QUOTA_FILE, (1, 1))  # ancient mtime → stale
+        if _remind(core_model="claude-opus-4-8") == "":
+            passed += 1
+        else:
+            fails.append("(i) stale state should suppress the reminder")
+
+        # (j) isolation: burn-history writes landed in the temp workspace.
+        if (_WS / "state" / "quota-burn-history.json").exists():
+            passed += 1
+        else:
+            fails.append("(j) burn history should land in the temp workspace")
     finally:
-        if backup is not None:
-            QUOTA_FILE.write_text(backup)
-        elif QUOTA_FILE.exists():
-            QUOTA_FILE.unlink()
+        shutil.rmtree(_WS, ignore_errors=True)
 
     if fails:
         print(f"FAIL ({passed} passed):")

--- a/tests/quota-tracker-fable-reminder.test.py
+++ b/tests/quota-tracker-fable-reminder.test.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Test the Fable quota-tracking + open/close reminder in read-quota.py.
+
+Two small features (no model switching — reminder only):
+  1. read-quota tags each reading with the active core model (`core_model`/`on_fable`).
+  2. `--fable-remind` prints a one-line reminder to switch to/from Fable based on
+     the 5h utilization thresholds (or "" when neither condition holds / stale).
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+from workspace_default import status_read_path  # noqa: E402
+
+READ_QUOTA = _REPO / "skills" / "quota-tracker" / "scripts" / "read-quota.py"
+QUOTA_FILE = status_read_path("quota-state.json")
+
+
+def _write_state(util_5h: float, util_7d: float = 0.2) -> None:
+    QUOTA_FILE.parent.mkdir(parents=True, exist_ok=True)
+    QUOTA_FILE.write_text(json.dumps({"headers": {
+        "anthropic-ratelimit-unified-status": "allowed",
+        "anthropic-ratelimit-unified-5h-utilization": str(util_5h),
+        "anthropic-ratelimit-unified-7d-utilization": str(util_7d),
+    }}))
+    os.utime(QUOTA_FILE, None)  # fresh mtime so it isn't flagged stale
+
+
+def _remind(core_model: str = "") -> str:
+    env = dict(os.environ, SUTANDO_CORE_MODEL=core_model)
+    out = subprocess.run([sys.executable, str(READ_QUOTA), "--fable-remind"],
+                         capture_output=True, text=True, env=env)
+    return out.stdout.strip()
+
+
+def run():
+    fails, passed = [], 0
+    backup = QUOTA_FILE.read_text() if QUOTA_FILE.exists() else None
+    try:
+        # (a) high util on a non-Fable model → suggest OPENING Fable
+        _write_state(0.85)
+        if "Fable 5" in _remind(core_model="claude-opus-4-8"):
+            passed += 1
+        else:
+            fails.append("(a) high-util non-Fable should suggest opening Fable")
+
+        # (b) low util while ON Fable → suggest CLOSING Fable
+        _write_state(0.30)
+        if "switch back off Fable" in _remind(core_model="claude-fable-5"):
+            passed += 1
+        else:
+            fails.append("(b) low-util on-Fable should suggest closing Fable")
+
+        # (c) mid util, not on Fable → no reminder
+        _write_state(0.55)
+        if _remind(core_model="claude-opus-4-8") == "":
+            passed += 1
+        else:
+            fails.append("(c) mid-util should produce no reminder")
+
+        # (d) on Fable but still high util → no "close" reminder yet
+        _write_state(0.85)
+        if _remind(core_model="claude-fable-5") == "":
+            passed += 1
+        else:
+            fails.append("(d) on-Fable high-util should not suggest closing yet")
+
+        # (e) --json exposes core_model / on_fable
+        _write_state(0.5)
+        env = dict(os.environ, SUTANDO_CORE_MODEL="claude-fable-5")
+        j = json.loads(subprocess.run(
+            [sys.executable, str(READ_QUOTA), "--json"],
+            capture_output=True, text=True, env=env).stdout)
+        if j.get("core_model") == "claude-fable-5" and j.get("on_fable") is True:
+            passed += 1
+        else:
+            fails.append("(e) --json should expose core_model + on_fable")
+    finally:
+        if backup is not None:
+            QUOTA_FILE.write_text(backup)
+        elif QUOTA_FILE.exists():
+            QUOTA_FILE.unlink()
+
+    if fails:
+        print(f"FAIL ({passed} passed):")
+        for f in fails:
+            print("  -", f)
+        sys.exit(1)
+    print(f"OK — {passed} passed")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## What

Two small, reminder-only features (replaces the abandoned #2227's ±1941 auto-escalation with ~45 lines, per owner ask: "只 track fable quota + 自动提醒开/关 fable" — no auto model-switching).

1. **Track Fable quota** — `read-quota.py` tags each reading with the active core model (`core_model` / `on_fable`). The rate-limit budget is UNIFIED across Claude models, so this is an *attribution*: how much of the shared budget was burned while on Fable 5. Human output gains a `Core model:` line (Fable-tagged), `--json` exposes `core_model`/`on_fable`.
2. **Remind to open/close Fable** — `read-quota.py --fable-remind` prints a one-line reminder (empty if none). It **only reminds** — the owner toggles via `/model`.
   - not on Fable + 5h util ≥ 80% → suggest `/model claude-fable-5`
   - on Fable + 5h util < 40% → suggest switching back

## Tunable

`_FABLE_REMIND_HIGH` / `_FABLE_REMIND_LOW` thresholds — the trigger is quota-driven by default; easy to change if you want a different signal.

## Test

`tests/quota-tracker-fable-reminder.test.py` (5 cases: open/close/none/stale + `--json` shape). Green.
