### PR TITLE
fix(health-check): flag when a channel access.json vault backup drifts from live

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -913,6 +913,13 @@ def check_per_host_config_backup() -> dict:
         try:
             live_bytes = live.read_bytes()
         except OSError:
+            # An unreadable LIVE access.json is the exact failure this probe
+            # exists to surface — never silently skip it. Skipping let a lone
+            # unreadable live file fall through to checked==0 → a false
+            # "no channel access.json to back up" all-clear (qingyun, #2277
+            # review). Count + flag it; the probe stays non-fatal (warn).
+            drift.append(f"{svc} (live unreadable)")
+            checked += 1
             continue
         checked += 1
         carrier = carrier_base / svc / "access.json"

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -861,6 +861,29 @@ def check_host_subtrees() -> dict:
     return {"name": name, "status": "ok", "detail": f"{fresh} host subtree(s), all synced <{stale_days:.0f}d"}
 
 
+def _durable_access_bytes(raw: bytes) -> "bytes | None":
+    """Normalized, comparable view of an access.json for backup-drift detection.
+
+    Drops the volatile ``pending`` block — short-lived pairing codes created on
+    any non-owner DM that expire ~1h later (see #2260). Live grows and ages
+    these out constantly, so a byte-for-byte compare would flag a perfectly
+    healthy backup as "stale" on nearly every run. Comparing only the durable
+    keys (``allowFrom`` / ``tierMap`` / …) makes the probe fire on real
+    allowlist/tier drift, not pairing-code churn.
+
+    Returns stable-sorted JSON bytes of the durable keys, or ``None`` when the
+    payload is not parseable JSON — the caller then falls back to a raw byte
+    compare (can't normalize, so stay conservative and flag any difference).
+    """
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if isinstance(data, dict):
+        data = {k: v for k, v in data.items() if k != "pending"}
+    return json.dumps(data, sort_keys=True).encode()
+
+
 def check_per_host_config_backup() -> dict:
     """Warn when a channel's access.json vault backup has drifted from live.
 
@@ -897,10 +920,21 @@ def check_per_host_config_backup() -> dict:
             drift.append(f"{svc} (no backup)")
             continue
         try:
-            if carrier.read_bytes() != live_bytes:
-                drift.append(f"{svc} (stale)")
+            carrier_bytes = carrier.read_bytes()
         except OSError:
             drift.append(f"{svc} (unreadable backup)")
+            continue
+        # Compare only the durable config — the volatile `pending` pairing-code
+        # block churns ~hourly and would otherwise flag every healthy backup
+        # (john, #2277 review). Raw-byte fallback when either side is malformed.
+        live_norm = _durable_access_bytes(live_bytes)
+        carrier_norm = _durable_access_bytes(carrier_bytes)
+        if live_norm is None or carrier_norm is None:
+            if carrier_bytes != live_bytes:
+                drift.append(f"{svc} (stale)")
+        elif live_norm != carrier_norm:
+            drift.append(f"{svc} (stale)")
+        # else: durable config matches — any pending-only diff is healthy churn.
     if checked == 0:
         return {"name": name, "status": "ok", "detail": "no channel access.json to back up"}
     if drift:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -861,6 +861,56 @@ def check_host_subtrees() -> dict:
     return {"name": name, "status": "ok", "detail": f"{fresh} host subtree(s), all synced <{stale_days:.0f}d"}
 
 
+def check_per_host_config_backup() -> dict:
+    """Warn when a channel's access.json vault backup has drifted from live.
+
+    sync-workspace's `_snapshot_per_host_config` copies each live
+    <claude-home>/channels/<svc>/access.json into
+    hosts/<host>/channels/<svc>/access.json — a pure backup carried by the vault
+    (nothing reads the carrier live, so there's no read/write skew). If that
+    snapshot silently stops refreshing, the vault copy drifts stale: the owner's
+    allowlist LOOKS synced but recent changes never reach the vault. Observed
+    2026-07-22 — a discord access.json backup 6 weeks stale while live had
+    changed, so the owner asking "is my access.json synced?" got a misleading
+    "there's a committed copy" when that copy was long out of date. This probe
+    makes the drift a first-class, glanceable signal. Read-only: content compare,
+    warn on divergence; never mutates either file.
+    """
+    name = "per-host-config-backup"
+    try:
+        channels_dir = Path(claude_home_path("channels"))
+    except Exception:
+        return {"name": name, "status": "ok", "detail": "no channels dir resolvable"}
+    if not channels_dir.is_dir():
+        return {"name": name, "status": "ok", "detail": "no channels configured"}
+    carrier_base = WORKSPACE_DIR / "hosts" / _host_label() / "channels"
+    drift, checked = [], 0
+    for live in sorted(channels_dir.glob("*/access.json")):
+        svc = live.parent.name
+        try:
+            live_bytes = live.read_bytes()
+        except OSError:
+            continue
+        checked += 1
+        carrier = carrier_base / svc / "access.json"
+        if not carrier.exists():
+            drift.append(f"{svc} (no backup)")
+            continue
+        try:
+            if carrier.read_bytes() != live_bytes:
+                drift.append(f"{svc} (stale)")
+        except OSError:
+            drift.append(f"{svc} (unreadable backup)")
+    if checked == 0:
+        return {"name": name, "status": "ok", "detail": "no channel access.json to back up"}
+    if drift:
+        return {"name": name, "status": "warn",
+                "detail": f"{len(drift)} channel access.json backup(s) drifted from live: "
+                          f"{', '.join(drift)} — vault copy stale; a full sync-workspace "
+                          f"(_snapshot_per_host_config) should refresh it"}
+    return {"name": name, "status": "ok", "detail": f"{checked} channel access.json backup(s) current"}
+
+
 def check_migrate_reader_contract() -> dict:
     """Verify migration CLASS_RULES are compatible with reader resolution chains (issue #1543).
 
@@ -3010,6 +3060,8 @@ def run_all_checks() -> list[dict]:
 
     # Per-host subtree freshness (hosts/<host>/ stopped syncing?)
     checks.append(check_host_subtrees())
+    # Per-host channel access.json backup drift (live vs vault-carried copy)
+    checks.append(check_per_host_config_backup())
     onboarding_check = check_onboarding_status()
     if onboarding_check is not None:
         checks.append(onboarding_check)

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -901,7 +901,18 @@ def check_per_host_config_backup() -> dict:
     """
     name = "per-host-config-backup"
     try:
-        channels_dir = Path(claude_home_path("channels"))
+        # Resolve the live channels source from the SAME canonical resolver the
+        # snapshot WRITER uses — sync-workspace's `_snapshot_per_host_config`
+        # reads `sutando-config.sh claude-sutando-config-dir`, i.e.
+        # resolve_claude_sutando_config_dir(). The old claude_home_path() fell
+        # back to ~/.claude whenever CLAUDE_CONFIG_DIR was unset, but Sutando.app's
+        # runHealthCheck() subprocess and the fallback launchd plist don't inject
+        # it — so the probe read a DIFFERENT tree than the writer and false-greened
+        # "no channels" on exactly the app/launchd paths this check exists to
+        # cover (qingyun, #2277 review). The canonical resolver honors deliberate
+        # config-based overrides (core_config_dirs) that the writer also respects.
+        from sutando_config import resolve_claude_sutando_config_dir  # noqa: PLC0415
+        channels_dir = resolve_claude_sutando_config_dir() / "channels"
     except Exception:
         return {"name": name, "status": "ok", "detail": "no channels dir resolvable"}
     if not channels_dir.is_dir():

--- a/tests/health-check-per-host-config-backup.test.py
+++ b/tests/health-check-per-host-config-backup.test.py
@@ -14,10 +14,14 @@ Root cause it was built for (observed 2026-07-22): a discord access.json backup
 copied a stale ~/.claude copy instead of the live workspace one.
 
 Covers:
-  a) backup byte-identical to live  → ok
-  b) backup content differs         → warn (stale)
-  c) backup file missing            → warn (no backup)
-  d) no channels dir at all         → ok (nothing to back up)
+  a) backup byte-identical to live      → ok
+  b) durable backup content differs     → warn (stale)
+  c) backup file missing                → warn (no backup)
+  d) no channels dir at all             → ok (nothing to back up)
+  i) only volatile `pending` differs    → ok (durable config matches; #2277 review)
+  j) durable drift + pending differs    → warn (pending doesn't mask real drift)
+  k) malformed JSON, bytes differ       → warn (raw-byte fallback)
+  l) malformed JSON, bytes identical    → ok (raw-byte fallback)
 
 Run: python3 tests/health-check-per-host-config-backup.test.py
 Exit code: 0 on pass, 1 on fail.
@@ -173,6 +177,62 @@ def case_h_unreadable_live_skipped_ok() -> list[str]:
     return []
 
 
+def case_i_pending_only_diff_ok() -> list[str]:
+    """Volatile `pending` pairing codes differ but durable config matches → ok.
+
+    Regression for the #2277 review: pending codes churn ~hourly, so a raw byte
+    compare flagged healthy backups. Normalizing out `pending` must treat this
+    as current, not drift.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            h.write_live("discord", b'{"allowFrom":["123"],"pending":{"s6288g":1784600000}}')
+            h.write_carrier("discord", b'{"allowFrom":["123"],"pending":{"eo0355":1784500000}}')
+            r = hc.check_per_host_config_backup()
+    if r["status"] != "ok":
+        return [f"i) pending-only difference should be ok (durable config matches), got {r}"]
+    return []
+
+
+def case_j_durable_drift_despite_pending_warn() -> list[str]:
+    """Durable allowlist drift must still warn even when pending also differs —
+    normalizing pending must not mask a real allowlist/tier change."""
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            h.write_live("discord", b'{"allowFrom":["123","789"],"pending":{"s6288g":1784600000}}')
+            h.write_carrier("discord", b'{"allowFrom":["123"],"pending":{"eo0355":1784500000}}')
+            r = hc.check_per_host_config_backup()
+    if r["status"] != "warn" or "stale" not in r["detail"]:
+        return [f"j) durable allowlist drift should warn 'stale' despite pending diff, got {r}"]
+    return []
+
+
+def case_k_malformed_json_raw_fallback_warn() -> list[str]:
+    """When a side isn't parseable JSON, fall back to a raw byte compare and
+    flag any difference (can't isolate durable config → stay conservative)."""
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            h.write_live("discord", b'{"allowFrom":["123"]}')
+            h.write_carrier("discord", b'{not valid json')  # malformed → raw compare
+            r = hc.check_per_host_config_backup()
+    if r["status"] != "warn" or "stale" not in r["detail"]:
+        return [f"k) malformed backup should warn 'stale' via raw fallback, got {r}"]
+    return []
+
+
+def case_l_malformed_but_byte_identical_ok() -> list[str]:
+    """Malformed JSON on both sides but byte-identical → raw fallback sees no
+    diff → ok (a garbled-but-matching backup isn't drift)."""
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            h.write_live("discord", b'{not valid json')
+            h.write_carrier("discord", b'{not valid json')
+            r = hc.check_per_host_config_backup()
+    if r["status"] != "ok":
+        return [f"l) byte-identical malformed pair should be ok via raw fallback, got {r}"]
+    return []
+
+
 def main() -> int:
     cases = [
         ("a", case_a_identical_ok),
@@ -183,6 +243,10 @@ def main() -> int:
         ("f", case_f_channels_dir_but_no_access_ok),
         ("g", case_g_unreadable_carrier_warn),
         ("h", case_h_unreadable_live_skipped_ok),
+        ("i", case_i_pending_only_diff_ok),
+        ("j", case_j_durable_drift_despite_pending_warn),
+        ("k", case_k_malformed_json_raw_fallback_warn),
+        ("l", case_l_malformed_but_byte_identical_ok),
     ]
     failures = []
     for label, fn in cases:

--- a/tests/health-check-per-host-config-backup.test.py
+++ b/tests/health-check-per-host-config-backup.test.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Tests for `check_per_host_config_backup` in src/health-check.py.
+
+sync-workspace snapshots each live <claude-home>/channels/<svc>/access.json into
+hosts/<host>/channels/<svc>/access.json as a vault-carried backup. When that
+snapshot silently stops refreshing (or reads the wrong claude-home), the backup
+drifts stale while the live allowlist keeps changing — the owner's access config
+LOOKS synced but the vault copy is out of date. This probe makes that drift a
+first-class health signal.
+
+Root cause it was built for (observed 2026-07-22): a discord access.json backup
+6 weeks stale because the snapshot lost CLAUDE_CONFIG_DIR in the cron context and
+copied a stale ~/.claude copy instead of the live workspace one.
+
+Covers:
+  a) backup byte-identical to live  → ok
+  b) backup content differs         → warn (stale)
+  c) backup file missing            → warn (no backup)
+  d) no channels dir at all         → ok (nothing to back up)
+
+Run: python3 tests/health-check-per-host-config-backup.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+
+class _Harness:
+    """Point the probe at a temp claude-home + workspace hosts/ tree.
+
+    Overrides the three collaborators the probe reads:
+      - hc.claude_home_path (live channels source)
+      - hc.WORKSPACE_DIR    (carrier base is WORKSPACE_DIR/hosts/<host>/channels)
+      - hc._host_label      (which host subtree is the carrier)
+    """
+
+    def __init__(self, tmp: Path):
+        self.tmp = tmp
+        self.home = tmp / "claude-home"
+        self.ws = tmp / "workspace"
+        self._saved = {}
+
+    def __enter__(self):
+        self._saved = {
+            "claude_home_path": hc.claude_home_path,
+            "WORKSPACE_DIR": hc.WORKSPACE_DIR,
+            "_host_label": hc._host_label,
+        }
+
+        def _chp(*parts):
+            return self.home.joinpath(*parts)
+
+        hc.claude_home_path = _chp
+        hc.WORKSPACE_DIR = self.ws
+        hc._host_label = lambda: "TestHost"
+        return self
+
+    def __exit__(self, *a):
+        for k, v in self._saved.items():
+            setattr(hc, k, v)
+
+    def write_live(self, svc: str, content: bytes):
+        d = self.home / "channels" / svc
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "access.json").write_bytes(content)
+
+    def write_carrier(self, svc: str, content: bytes):
+        d = self.ws / "hosts" / "TestHost" / "channels" / svc
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "access.json").write_bytes(content)
+
+
+def case_a_identical_ok() -> list[str]:
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            h.write_live("discord", b'{"allowFrom":["123"]}')
+            h.write_carrier("discord", b'{"allowFrom":["123"]}')
+            r = hc.check_per_host_config_backup()
+    if r["status"] != "ok":
+        return [f"a) identical backup should be ok, got {r}"]
+    return []
+
+
+def case_b_diff_warn() -> list[str]:
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            h.write_live("discord", b'{"allowFrom":["123","456"]}')
+            h.write_carrier("discord", b'{"allowFrom":["123"]}')  # stale
+            r = hc.check_per_host_config_backup()
+    if r["status"] != "warn" or "stale" not in r["detail"]:
+        return [f"b) drifted backup should warn 'stale', got {r}"]
+    return []
+
+
+def case_c_missing_warn() -> list[str]:
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            h.write_live("discord", b'{"allowFrom":["123"]}')
+            # no carrier written
+            r = hc.check_per_host_config_backup()
+    if r["status"] != "warn" or "no backup" not in r["detail"]:
+        return [f"c) missing backup should warn 'no backup', got {r}"]
+    return []
+
+
+def case_d_no_channels_ok() -> list[str]:
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            # neither live nor carrier exists
+            r = hc.check_per_host_config_backup()
+    if r["status"] != "ok":
+        return [f"d) no channels dir should be ok, got {r}"]
+    return []
+
+
+def main() -> int:
+    cases = [
+        ("a", case_a_identical_ok),
+        ("b", case_b_diff_warn),
+        ("c", case_c_missing_warn),
+        ("d", case_d_no_channels_ok),
+    ]
+    failures = []
+    for label, fn in cases:
+        try:
+            fails = fn()
+        except Exception as e:  # noqa: BLE001
+            fails = [f"{label}) raised {type(e).__name__}: {e}"]
+        if fails:
+            failures.extend(fails)
+            print(f"  ✗ case {label}")
+            for f in fails:
+                print(f"      {f}")
+        else:
+            print(f"  ✓ case {label}")
+    if failures:
+        print(f"\n{len(failures)} failure(s)")
+        return 1
+    print("\nper-host-config-backup drift probe invariants hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/health-check-per-host-config-backup.test.py
+++ b/tests/health-check-per-host-config-backup.test.py
@@ -123,12 +123,66 @@ def case_d_no_channels_ok() -> list[str]:
     return []
 
 
+def case_e_unresolvable_home_ok() -> list[str]:
+    """claude_home_path raising must degrade to ok, never crash the run."""
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            def _boom(*_a):
+                raise RuntimeError("no home")
+            hc.claude_home_path = _boom
+            r = hc.check_per_host_config_backup()
+    if r["status"] != "ok" or "resolvable" not in r["detail"]:
+        return [f"e) unresolvable claude-home should be ok, got {r}"]
+    return []
+
+
+def case_f_channels_dir_but_no_access_ok() -> list[str]:
+    """channels/ exists but holds no access.json → nothing to back up → ok."""
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            (h.home / "channels" / "discord").mkdir(parents=True)  # no access.json
+            r = hc.check_per_host_config_backup()
+    if r["status"] != "ok" or "no channel access.json" not in r["detail"]:
+        return [f"f) channels dir with no access.json should be ok, got {r}"]
+    return []
+
+
+def case_g_unreadable_carrier_warn() -> list[str]:
+    """A carrier that can't be read (here: a directory in its place) → warn."""
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            h.write_live("discord", b'{"allowFrom":["123"]}')
+            # carrier path exists but is a directory → read_bytes raises OSError
+            (h.ws / "hosts" / "TestHost" / "channels" / "discord" / "access.json").mkdir(parents=True)
+            r = hc.check_per_host_config_backup()
+    if r["status"] != "warn" or "unreadable backup" not in r["detail"]:
+        return [f"g) unreadable carrier should warn 'unreadable backup', got {r}"]
+    return []
+
+
+def case_h_unreadable_live_skipped_ok() -> list[str]:
+    """A live access.json that can't be read (a directory) is skipped, not fatal."""
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            # live path is a directory → read_bytes raises → that entry is skipped
+            (h.home / "channels" / "discord" / "access.json").mkdir(parents=True)
+            r = hc.check_per_host_config_backup()
+    # skipped → nothing checked → ok (no channel access.json to back up)
+    if r["status"] != "ok":
+        return [f"h) unreadable live entry should be skipped (ok), got {r}"]
+    return []
+
+
 def main() -> int:
     cases = [
         ("a", case_a_identical_ok),
         ("b", case_b_diff_warn),
         ("c", case_c_missing_warn),
         ("d", case_d_no_channels_ok),
+        ("e", case_e_unresolvable_home_ok),
+        ("f", case_f_channels_dir_but_no_access_ok),
+        ("g", case_g_unreadable_carrier_warn),
+        ("h", case_h_unreadable_live_skipped_ok),
     ]
     failures = []
     for label, fn in cases:

--- a/tests/health-check-per-host-config-backup.test.py
+++ b/tests/health-check-per-host-config-backup.test.py
@@ -18,6 +18,7 @@ Covers:
   b) durable backup content differs     → warn (stale)
   c) backup file missing                → warn (no backup)
   d) no channels dir at all             → ok (nothing to back up)
+  h) unreadable LIVE access.json        → warn (never a false all-clear; #2277 review)
   i) only volatile `pending` differs    → ok (durable config matches; #2277 review)
   j) durable drift + pending differs    → warn (pending doesn't mask real drift)
   k) malformed JSON, bytes differ       → warn (raw-byte fallback)
@@ -164,16 +165,19 @@ def case_g_unreadable_carrier_warn() -> list[str]:
     return []
 
 
-def case_h_unreadable_live_skipped_ok() -> list[str]:
-    """A live access.json that can't be read (a directory) is skipped, not fatal."""
+def case_h_unreadable_live_warn() -> list[str]:
+    """A live access.json that can't be read (here: a directory in its place) must
+    WARN, not be silently skipped. This is the lone-unreadable-live entry: skipping
+    it let checked fall to 0 → a false 'no channel access.json to back up' all-clear,
+    masking the exact failure this probe exists to surface (qingyun, #2277 review).
+    Non-fatal: it flags as drift, never crashes the run."""
     with tempfile.TemporaryDirectory() as td:
         with _Harness(Path(td)) as h:
-            # live path is a directory → read_bytes raises → that entry is skipped
+            # live path is a directory → read_bytes raises OSError
             (h.home / "channels" / "discord" / "access.json").mkdir(parents=True)
             r = hc.check_per_host_config_backup()
-    # skipped → nothing checked → ok (no channel access.json to back up)
-    if r["status"] != "ok":
-        return [f"h) unreadable live entry should be skipped (ok), got {r}"]
+    if r["status"] != "warn" or "live unreadable" not in r["detail"]:
+        return [f"h) unreadable live entry should warn 'live unreadable', got {r}"]
     return []
 
 
@@ -242,7 +246,7 @@ def main() -> int:
         ("e", case_e_unresolvable_home_ok),
         ("f", case_f_channels_dir_but_no_access_ok),
         ("g", case_g_unreadable_carrier_warn),
-        ("h", case_h_unreadable_live_skipped_ok),
+        ("h", case_h_unreadable_live_warn),
         ("i", case_i_pending_only_diff_ok),
         ("j", case_j_durable_drift_despite_pending_warn),
         ("k", case_k_malformed_json_raw_fallback_warn),

--- a/tests/health-check-per-host-config-backup.test.py
+++ b/tests/health-check-per-host-config-backup.test.py
@@ -23,6 +23,7 @@ Covers:
   j) durable drift + pending differs    → warn (pending doesn't mask real drift)
   k) malformed JSON, bytes differ       → warn (raw-byte fallback)
   l) malformed JSON, bytes identical    → ok (raw-byte fallback)
+  m) resolves canonical tree, not env ~/.claude → ok (no false all-clear; #2277 review)
 
 Run: python3 tests/health-check-per-host-config-backup.test.py
 Exit code: 0 on pass, 1 on fail.
@@ -35,44 +36,54 @@ import tempfile
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
 spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
 hc = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(hc)
+import sutando_config  # noqa: E402 — patched by _Harness so the probe's local import resolves to the temp tree
 
 
 class _Harness:
-    """Point the probe at a temp claude-home + workspace hosts/ tree.
+    """Point the probe at a temp canonical config dir + workspace hosts/ tree.
 
-    Overrides the three collaborators the probe reads:
-      - hc.claude_home_path (live channels source)
+    The probe resolves the LIVE channels source via
+    `sutando_config.resolve_claude_sutando_config_dir()` — the SAME canonical
+    resolver the snapshot writer uses (#2277 review) — so we patch that, not the
+    env-based `claude_home_path`. Overrides:
+      - sutando_config.resolve_claude_sutando_config_dir (canonical live source)
+      - hc.claude_home_path (kept patched so a regression to the old env-based
+        resolver would read `home_divergent` — an EMPTY tree — and fail loudly)
       - hc.WORKSPACE_DIR    (carrier base is WORKSPACE_DIR/hosts/<host>/channels)
       - hc._host_label      (which host subtree is the carrier)
     """
 
     def __init__(self, tmp: Path):
         self.tmp = tmp
-        self.home = tmp / "claude-home"
+        self.home = tmp / "canonical-config"        # resolve_claude_sutando_config_dir() target
+        self.home_divergent = tmp / "legacy-home"   # what the old claude_home_path fallback would hit
         self.ws = tmp / "workspace"
         self._saved = {}
 
     def __enter__(self):
         self._saved = {
-            "claude_home_path": hc.claude_home_path,
-            "WORKSPACE_DIR": hc.WORKSPACE_DIR,
-            "_host_label": hc._host_label,
+            "hc.claude_home_path": hc.claude_home_path,
+            "hc.WORKSPACE_DIR": hc.WORKSPACE_DIR,
+            "hc._host_label": hc._host_label,
+            "sc.resolve_claude_sutando_config_dir": sutando_config.resolve_claude_sutando_config_dir,
         }
-
-        def _chp(*parts):
-            return self.home.joinpath(*parts)
-
-        hc.claude_home_path = _chp
+        # canonical resolver → temp config dir (this is where write_live seeds)
+        sutando_config.resolve_claude_sutando_config_dir = lambda *a, **k: self.home
+        # old env-based path → a SEPARATE empty tree, so a regression to it reads nothing
+        hc.claude_home_path = lambda *parts: self.home_divergent.joinpath(*parts)
         hc.WORKSPACE_DIR = self.ws
         hc._host_label = lambda: "TestHost"
         return self
 
     def __exit__(self, *a):
-        for k, v in self._saved.items():
-            setattr(hc, k, v)
+        hc.claude_home_path = self._saved["hc.claude_home_path"]
+        hc.WORKSPACE_DIR = self._saved["hc.WORKSPACE_DIR"]
+        hc._host_label = self._saved["hc._host_label"]
+        sutando_config.resolve_claude_sutando_config_dir = self._saved["sc.resolve_claude_sutando_config_dir"]
 
     def write_live(self, svc: str, content: bytes):
         d = self.home / "channels" / svc
@@ -128,16 +139,18 @@ def case_d_no_channels_ok() -> list[str]:
     return []
 
 
-def case_e_unresolvable_home_ok() -> list[str]:
-    """claude_home_path raising must degrade to ok, never crash the run."""
+def case_e_unresolvable_config_ok() -> list[str]:
+    """The canonical config resolver raising must degrade to ok, never crash the
+    run. (Now patches resolve_claude_sutando_config_dir — the resolver the probe
+    actually uses post-#2277 — not the old env-based claude_home_path.)"""
     with tempfile.TemporaryDirectory() as td:
         with _Harness(Path(td)) as h:
-            def _boom(*_a):
-                raise RuntimeError("no home")
-            hc.claude_home_path = _boom
+            def _boom(*_a, **_k):
+                raise RuntimeError("no config dir")
+            sutando_config.resolve_claude_sutando_config_dir = _boom
             r = hc.check_per_host_config_backup()
     if r["status"] != "ok" or "resolvable" not in r["detail"]:
-        return [f"e) unresolvable claude-home should be ok, got {r}"]
+        return [f"e) unresolvable config dir should degrade to ok, got {r}"]
     return []
 
 
@@ -237,13 +250,36 @@ def case_l_malformed_but_byte_identical_ok() -> list[str]:
     return []
 
 
+def case_m_reads_canonical_tree_not_env_home() -> list[str]:
+    """The probe must resolve live channels from the canonical resolver
+    (`resolve_claude_sutando_config_dir`, what the snapshot writer uses), NOT the
+    env-based `claude_home_path` that falls back to ~/.claude when
+    CLAUDE_CONFIG_DIR is unset. Regression for the #2277 false-green: under
+    Sutando.app's runHealthCheck() / the fallback launchd plist (neither injects
+    CLAUDE_CONFIG_DIR), the old probe read ~/.claude, found nothing, and reported
+    a false "no channels" all-clear — hiding the very stale-backup failure this
+    check exists to detect. Here the channel is seeded ONLY in the canonical tree
+    while the harness points claude_home_path at a SEPARATE empty tree; a
+    regression to the env-based resolver would read empty → "no channels"."""
+    with tempfile.TemporaryDirectory() as td:
+        with _Harness(Path(td)) as h:
+            h.write_live("discord", b'{"allowFrom":["123"]}')      # canonical tree only
+            h.write_carrier("discord", b'{"allowFrom":["123"]}')
+            # sanity: the env-based fallback tree is genuinely empty
+            assert not (h.home_divergent / "channels").exists()
+            r = hc.check_per_host_config_backup()
+    if r["status"] != "ok" or "backup(s) current" not in r["detail"]:
+        return [f"m) probe must read the canonical tree (not env ~/.claude); got {r}"]
+    return []
+
+
 def main() -> int:
     cases = [
         ("a", case_a_identical_ok),
         ("b", case_b_diff_warn),
         ("c", case_c_missing_warn),
         ("d", case_d_no_channels_ok),
-        ("e", case_e_unresolvable_home_ok),
+        ("e", case_e_unresolvable_config_ok),
         ("f", case_f_channels_dir_but_no_access_ok),
         ("g", case_g_unreadable_carrier_warn),
         ("h", case_h_unreadable_live_warn),
@@ -251,6 +287,7 @@ def main() -> int:
         ("j", case_j_durable_drift_despite_pending_warn),
         ("k", case_k_malformed_json_raw_fallback_warn),
         ("l", case_l_malformed_but_byte_identical_ok),
+        ("m", case_m_reads_canonical_tree_not_env_home),
     ]
     failures = []
     for label, fn in cases:


### PR DESCRIPTION
## The gap

`sync-workspace`'s `_snapshot_per_host_config` copies each live `<claude-home>/channels/<svc>/access.json` into `hosts/<host>/channels/<svc>/access.json` as a vault-carried backup. If that snapshot silently stops refreshing — or reads the *wrong* claude-home — the backup drifts stale while the live allowlist keeps changing. The owner's access config **looks** synced but the vault copy is out of date, and "is my access.json synced?" gets a misleading yes.

## How it showed up (2026-07-22)

A discord `access.json` vault backup was **6 weeks stale** (Jun 8 / 2339 bytes) while live had changed (Jul 21 / 7731 bytes). Confirmed root cause: the snapshot **loses `CLAUDE_CONFIG_DIR`** in the cron/sync context and falls back to `~/.claude` (a stale pre-revamp copy) instead of the live workspace `.claude-sutando` — so every sync overwrote a fresh carrier with the stale file. (The classic launchd/cron "env lacks CLAUDE_CONFIG_DIR" trap.)

That deeper fix — making the snapshot resolve the same claude-home the running bridges use — is a focused **follow-up PR**. This PR adds the **detection** so the drift can never again silently rot for weeks; it's the safety net that would have caught this on day one.

## The change

`check_per_host_config_backup()` — for each live `channels/<svc>/access.json`, compare bytes against the `hosts/<host>/` carrier copy; **warn** on divergence or a missing backup. Read-only — never mutates either file. Registered next to `check_host_subtrees` (same per-host-drift family).

On the affected machine it now surfaces:
```
⚠ per-host-config-backup   warn   1 channel access.json backup(s) drifted from live: discord (stale) — vault copy stale; a full sync-workspace (_snapshot_per_host_config) should refresh it
```

## Tests

`tests/health-check-per-host-config-backup.test.py` — 4/4 green: identical→ok, differ→warn(stale), missing→warn(no backup), no-channels→ok.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)