### PR TITLE
fix(security): close current CodeQL high alerts

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -381,7 +381,7 @@ def delegation_submit_task(data: dict):
     # private temporary entry through an already-open directory descriptor,
     # then atomically replace the final directory entry.  os.replace replaces
     # a raced symlink itself instead of following it to an outside target.
-    task_name = os.path.basename(task_file_str)
+    task_name = f"{tid}.txt"
     dir_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0)
     task_dir_fd = os.open(task_dir_real, dir_flags)
     temp_name = f".{task_name}.{secrets.token_hex(8)}.tmp"

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -37,8 +37,10 @@ import ipaddress
 import json
 import os
 import re
+import secrets
 import shutil
 import socket
+import stat
 import subprocess
 import sys
 import threading
@@ -374,7 +376,46 @@ def delegation_submit_task(data: dict):
     )
     if not task_file_str.startswith(task_dir_real + os.sep):
         return 400, {"error": "task path escapes task directory"}
-    Path(task_file_str).write_text(content)
+    # Do not reopen the validated pathname: a local process could swap in a
+    # symlink between the realpath check above and write_text().  Write a
+    # private temporary entry through an already-open directory descriptor,
+    # then atomically replace the final directory entry.  os.replace replaces
+    # a raced symlink itself instead of following it to an outside target.
+    task_name = os.path.basename(task_file_str)
+    dir_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0)
+    task_dir_fd = os.open(task_dir_real, dir_flags)
+    temp_name = f".{task_name}.{secrets.token_hex(8)}.tmp"
+    try:
+        try:
+            existing = os.stat(task_name, dir_fd=task_dir_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            existing = None
+        if existing is not None and stat.S_ISLNK(existing.st_mode):
+            return 400, {"error": "task path escapes task directory"}
+
+        open_flags = (os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                      | getattr(os, "O_NOFOLLOW", 0)
+                      | getattr(os, "O_CLOEXEC", 0))
+        temp_fd = os.open(temp_name, open_flags, 0o600, dir_fd=task_dir_fd)
+        try:
+            with os.fdopen(temp_fd, "w", encoding="utf-8") as handle:
+                handle.write(content)
+        except Exception:
+            try:
+                os.close(temp_fd)
+            except OSError:
+                pass
+            raise
+        os.replace(temp_name, task_name,
+                   src_dir_fd=task_dir_fd, dst_dir_fd=task_dir_fd)
+        temp_name = ""
+    finally:
+        if temp_name:
+            try:
+                os.unlink(temp_name, dir_fd=task_dir_fd)
+            except FileNotFoundError:
+                pass
+        os.close(task_dir_fd)
     return 200, {"ok": True, "task_id": tid}
 
 

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -364,7 +364,17 @@ def delegation_submit_task(data: dict):
     if embedded != tid:
         return 400, {"error": f"body id header ({embedded!r}) does not match request id"}
     TASK_DIR.mkdir(parents=True, exist_ok=True)
-    (TASK_DIR / f"{tid}.txt").write_text(content)
+    # Keep the containment check in this function so CodeQL can follow the
+    # tainted HTTP value through normalization to the filesystem sink.  The
+    # task-id regex alone prevents lexical traversal, but not an existing
+    # `<task-id>.txt` symlink that points outside TASK_DIR.
+    task_dir_real = os.path.realpath(TASK_DIR)
+    task_file_str = os.path.realpath(
+        os.path.join(task_dir_real, f"{tid}.txt")
+    )
+    if not task_file_str.startswith(task_dir_real + os.sep):
+        return 400, {"error": "task path escapes task directory"}
+    Path(task_file_str).write_text(content)
     return 200, {"ok": True, "task_id": tid}
 
 
@@ -372,13 +382,22 @@ def delegation_archive_result(data: dict):
     name = str(data.get("name", ""))
     tid = str(data.get("task_id", ""))
     stem = name[:-4] if name.endswith(".txt") else name
-    src = _safe_path(RESULT_DIR, stem)
     # Identity coherence (Codex P1 on #1956): a relay client may only archive
     # ITS OWN result — the source name must be exactly <task_id>.txt. Without
     # this, any safe name could be filed under any valid id, hijacking other
     # consumers' results into a foreign archive slot.
-    if src is None or not local_task_protocol.valid_task_id(tid) or stem != tid:
+    if not local_task_protocol.valid_task_id(tid) or stem != tid:
         return 400, {"error": "invalid name/task id, or name does not match task id"}
+    # Inline the CodeQL-modeled normalization + prefix guard at both the
+    # source and destination sinks.  `_safe_path` enforces the same policy,
+    # but CodeQL does not propagate that sanitizer through the helper return.
+    result_dir_real = os.path.realpath(RESULT_DIR)
+    src_str = os.path.realpath(
+        os.path.join(result_dir_real, f"{stem}.txt")
+    )
+    if not src_str.startswith(result_dir_real + os.sep):
+        return 400, {"error": "result path escapes result directory"}
+    src = Path(src_str)
     if not os.path.exists(src):
         return 200, {"ok": True, "note": "already gone"}
     # Same destination scheme as task-bridge's archiveFile():
@@ -388,9 +407,20 @@ def delegation_archive_result(data: dict):
     dest_dir = local_task_protocol.archive_month_dir(
         RESULT_DIR, datetime.now().isoformat())
     dest_dir.mkdir(parents=True, exist_ok=True)
-    dest = dest_dir / f"{tid}.txt"
+    dest_dir_real = os.path.realpath(dest_dir)
+    dest_str = os.path.realpath(
+        os.path.join(dest_dir_real, f"{tid}.txt")
+    )
+    if not dest_str.startswith(dest_dir_real + os.sep):
+        return 400, {"error": "archive path escapes archive directory"}
+    dest = Path(dest_str)
     if dest.exists():
-        dest = dest_dir / f"{tid}-{int(datetime.now().timestamp())}.txt"
+        dest_str = os.path.realpath(os.path.join(
+            dest_dir_real, f"{tid}-{int(datetime.now().timestamp())}.txt"
+        ))
+        if not dest_str.startswith(dest_dir_real + os.sep):
+            return 400, {"error": "archive path escapes archive directory"}
+        dest = Path(dest_str)
     os.replace(src, dest)
     return 200, {"ok": True}
 

--- a/tests/agent-api-delegation.test.py
+++ b/tests/agent-api-delegation.test.py
@@ -186,6 +186,24 @@ check("submit rejects id/body divergence",
       api.delegation_submit_task({"id": "task-direct-9", "content": DIRECT_CONTENT})[0] == 400)
 check("direct submit rejects bad id", api.delegation_submit_task({"id": "../x", "content": "y"})[0] == 400)
 check("direct submit rejects empty content", api.delegation_submit_task({"id": "task-d2", "content": ""})[0] == 400)
+# A filename-safe task id can still escape through a pre-positioned symlink.
+# The HTTP-controlled submit path must reject it rather than overwrite the
+# symlink target outside tasks/.
+outside = tmp / "outside-task.txt"
+outside.write_text("do not overwrite\n")
+escape_link = api.TASK_DIR / "task-symlink-escape.txt"
+try:
+    escape_link.symlink_to(outside)
+except OSError:
+    # Windows/non-privileged environments may not permit symlink creation.
+    pass
+else:
+    escape_content = DIRECT_CONTENT.replace("task-direct-1", "task-symlink-escape")
+    code, _ = api.delegation_submit_task({
+        "id": "task-symlink-escape", "content": escape_content,
+    })
+    check("direct submit rejects symlink escape",
+          code == 400 and outside.read_text() == "do not overwrite\n")
 (api.RESULT_DIR / "task-direct-1.txt").write_text("direct answer\n")
 code, data = api.delegation_list_results()
 check("direct list", code == 200 and "task-direct-1.txt" in data["files"])
@@ -212,6 +230,39 @@ check("direct archive bad tid", api.delegation_archive_result(
 (api.RESULT_DIR / "task-foreign.txt").write_text("someone else's\n")
 check("archive rejects name/tid mismatch", api.delegation_archive_result(
     {"name": "task-foreign.txt", "task_id": "task-direct-1"})[0] == 400)
+# Both archive paths are confined after resolving symlinks. A relay client
+# cannot make the archive endpoint inspect or move a result outside results/,
+# or replace a destination outside the month archive directory.
+outside_result = tmp / "outside-result.txt"
+outside_result.write_text("outside result\n")
+source_escape = api.RESULT_DIR / "task-source-escape.txt"
+try:
+    source_escape.symlink_to(outside_result)
+except OSError:
+    pass
+else:
+    code, _ = api.delegation_archive_result({
+        "name": "task-source-escape.txt", "task_id": "task-source-escape",
+    })
+    check("archive rejects source symlink escape",
+          code == 400 and outside_result.read_text() == "outside result\n")
+
+(api.RESULT_DIR / "task-dest-escape.txt").write_text("inside result\n")
+archive_month = api.local_task_protocol.archive_month_dir(
+    api.RESULT_DIR, api.datetime.now().isoformat())
+archive_month.mkdir(parents=True, exist_ok=True)
+dest_escape = archive_month / "task-dest-escape.txt"
+try:
+    dest_escape.symlink_to(outside_result)
+except OSError:
+    pass
+else:
+    code, _ = api.delegation_archive_result({
+        "name": "task-dest-escape.txt", "task_id": "task-dest-escape",
+    })
+    check("archive rejects destination symlink escape",
+          code == 400 and outside_result.read_text() == "outside result\n"
+          and (api.RESULT_DIR / "task-dest-escape.txt").exists())
 # No-clobber (Codex P1): an occupied archive slot gets an epoch-suffixed name.
 (api.RESULT_DIR / "task-direct-1.txt").write_text("second result\n")
 code, _ = api.delegation_archive_result({"name": "task-direct-1.txt", "task_id": "task-direct-1"})

--- a/tests/agent-api-delegation.test.py
+++ b/tests/agent-api-delegation.test.py
@@ -235,6 +235,76 @@ check("direct submit is safe against symlink swap race",
       code == 200 and race_outside.read_text() == "race sentinel\n"
       and (api.TASK_DIR / race_name).read_text() == race_content
       and not (api.TASK_DIR / race_name).is_symlink())
+
+# A pre-positioned symlink whose target stays inside TASK_DIR passes the
+# realpath containment gate, so the descriptor-level no-symlink check must
+# still reject it.
+inside_target = api.TASK_DIR / "inside-target.txt"
+inside_target.write_text("inside sentinel\n")
+inside_link = api.TASK_DIR / "task-inside-symlink.txt"
+try:
+    inside_link.symlink_to(inside_target)
+except OSError:
+    pass
+else:
+    inside_content = DIRECT_CONTENT.replace("task-direct-1", "task-inside-symlink")
+    code, _ = api.delegation_submit_task({
+        "id": "task-inside-symlink", "content": inside_content,
+    })
+    check("direct submit rejects in-directory symlink",
+          code == 400 and inside_target.read_text() == "inside sentinel\n")
+
+# If wrapping/writing the private descriptor fails, the descriptor and hidden
+# temporary entry are both cleaned up before the error propagates.
+real_fdopen = api.os.fdopen
+
+
+def _failing_fdopen(fd, *args, **kwargs):
+    api.os.close(fd)
+    raise OSError("injected fdopen failure")
+
+
+api.os.fdopen = _failing_fdopen
+try:
+    try:
+        api.delegation_submit_task({
+            "id": "task-write-failure",
+            "content": DIRECT_CONTENT.replace("task-direct-1", "task-write-failure"),
+        })
+    except OSError as exc:
+        write_failed = "injected fdopen failure" in str(exc)
+    else:
+        write_failed = False
+finally:
+    api.os.fdopen = real_fdopen
+check("failed task write removes private temp entry",
+      write_failed and not list(api.TASK_DIR.glob(".task-write-failure.txt.*.tmp")))
+
+# If publication fails after another process has already removed the temp
+# entry, the cleanup path tolerates the missing name while preserving the
+# original publish error.
+real_replace = api.os.replace
+
+
+def _remove_temp_then_fail(src, dst, *args, **kwargs):
+    api.os.unlink(src, dir_fd=kwargs["src_dir_fd"])
+    raise OSError("injected publish failure")
+
+
+api.os.replace = _remove_temp_then_fail
+try:
+    try:
+        api.delegation_submit_task({
+            "id": "task-publish-failure",
+            "content": DIRECT_CONTENT.replace("task-direct-1", "task-publish-failure"),
+        })
+    except OSError as exc:
+        publish_failed = "injected publish failure" in str(exc)
+    else:
+        publish_failed = False
+finally:
+    api.os.replace = real_replace
+check("missing temp during failed publish cleanup is harmless", publish_failed)
 (api.RESULT_DIR / "task-direct-1.txt").write_text("direct answer\n")
 code, data = api.delegation_list_results()
 check("direct list", code == 200 and "task-direct-1.txt" in data["files"])

--- a/tests/agent-api-delegation.test.py
+++ b/tests/agent-api-delegation.test.py
@@ -204,6 +204,37 @@ else:
     })
     check("direct submit rejects symlink escape",
           code == 400 and outside.read_text() == "do not overwrite\n")
+
+# Race the final task entry into a symlink after validation but immediately
+# before the atomic publish.  The submit must replace the directory entry,
+# never follow it and overwrite the outside target.
+race_outside = tmp / "outside-task-race.txt"
+race_outside.write_text("race sentinel\n")
+race_name = "task-symlink-race.txt"
+race_content = DIRECT_CONTENT.replace("task-direct-1", "task-symlink-race")
+real_replace = api.os.replace
+
+
+def _race_replace(src, dst, *args, **kwargs):
+    raced = api.TASK_DIR / dst
+    try:
+        raced.symlink_to(race_outside)
+    except OSError:
+        pass
+    return real_replace(src, dst, *args, **kwargs)
+
+
+api.os.replace = _race_replace
+try:
+    code, _ = api.delegation_submit_task({
+        "id": "task-symlink-race", "content": race_content,
+    })
+finally:
+    api.os.replace = real_replace
+check("direct submit is safe against symlink swap race",
+      code == 200 and race_outside.read_text() == "race sentinel\n"
+      and (api.TASK_DIR / race_name).read_text() == race_content
+      and not (api.TASK_DIR / race_name).is_symlink())
 (api.RESULT_DIR / "task-direct-1.txt").write_text("direct answer\n")
 code, data = api.delegation_list_results()
 check("direct list", code == 200 and "task-direct-1.txt" in data["files"])

--- a/tests/lint-class-rules.test.py
+++ b/tests/lint-class-rules.test.py
@@ -90,9 +90,11 @@ CLASS_RULES=(
 {body}
 )
 """
-        p = Path(tempfile.mktemp(suffix=".sh"))
-        p.write_text(content)
-        return p
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".sh", delete=False
+        ) as tmp:
+            tmp.write(content)
+            return Path(tmp.name)
 
     def test_parses_simple_rules(self):
         f = self._make_migrate_sh([


### PR DESCRIPTION
## What changed, and why?

Closes the four open high-severity CodeQL findings on `main` (alerts 55–58): three `py/path-injection` flows in the authenticated TaskDelegationService endpoints and one `py/insecure-temporary-file` finding in the class-rule test.

The submit route now normalizes the final task path and proves it remains inside `TASK_DIR` immediately before writing. The archive route applies the same CodeQL-modeled `realpath` + prefix check locally at its source and destination sinks. The test fixture now uses `NamedTemporaryFile` instead of deprecated `mktemp`.

## Review first

1. `src/agent-api.py` — containment checks in `delegation_submit_task` and `delegation_archive_result`.
2. `tests/agent-api-delegation.test.py` — task-write, archive-source, and archive-destination symlink regressions.
3. `tests/lint-class-rules.test.py` — atomic temporary-file creation.

## Failing-before / passing-after evidence

On `origin/main` (`b6ec180`), a pre-positioned `tasks/task-symlink-escape.txt` symlink caused a valid authenticated delegation submit to return 200 and overwrite the target outside `tasks/`. The reproduced target changed from `sentinel` to the HTTP-controlled task body.

On this head (`ead4ada`), the same case returns 400 and the external target remains unchanged. The regression is part of the delegation E2E suite.

## Tests run

- `python3 tests/agent-api-delegation.test.py` — PASS, including all three symlink-containment cases.
- `python3 tests/lint-class-rules.test.py` — PASS (31 tests).
- `python3 tests/agent-api-task-display-text.test.py` — PASS.
- `python3 -m py_compile src/agent-api.py tests/agent-api-delegation.test.py tests/lint-class-rules.test.py` — PASS.
- `git diff --check` — PASS.

GitHub CodeQL is the authoritative verification that alerts 55–58 close; its PR workflow is expected to run on this branch.

## Edge cases checked

- Lexically valid task ID with an existing symlink outside `tasks/`.
- Archive source symlink resolving outside `results/`.
- Archive destination symlink resolving outside the month directory.
- Existing archive destination still uses the timestamp-suffixed no-clobber path.
- Traversal, mismatched IDs, malformed IDs, and already-gone results retain their existing responses.

## Migration, config, permissions, rollback, and deployment risks

No migration, config, or permission changes. Existing regular files behave unchanged. A request that resolves through a symlink outside its permitted root now fails with HTTP 400. Rollback is a normal revert.

## Known gaps / follow-up

None for the current open CodeQL alert set.