### PR TITLE
feat(review): repo-scoped REVIEW_GUIDE drives a generic checks runner + CI gate

### DIFF
--- a/.github/REVIEW_GUIDE.md
+++ b/.github/REVIEW_GUIDE.md
@@ -1,0 +1,56 @@
+# Review guide — sonichi/sutando
+
+Canonical, in-repo review criteria for this repository. Two audiences in one file:
+
+- **Humans + the codex reviewer** read the prose lessons below as review criteria.
+- **Automated scanners** (`scripts/review-checks.sh`, run in CI on every PR) parse the
+  fenced `checks:` block at the bottom — the *only* machine-read section.
+
+This file is the single source of truth: adding a lesson or a check is a PR to this
+file, **not** a code change to the review tooling. Another repo ships its own
+`.github/REVIEW_GUIDE.md`; the tooling is generic and loads whichever repo it reviews.
+
+## Lessons (criteria for reviewers)
+
+1. **Confirm the bug exists on `main` before endorsing a fix.** A patch for a bug that
+   isn't there is noise.
+2. **Review the whole activated path, not just the diff.** Bugs hide in the unchanged
+   code the diff now reaches. A parity change means reading both branches end-to-end.
+3. **Prove the fix by exercising the failure mode.** Happy-path green ≠ proof — a test
+   must actually reproduce the original failure, or the fix is unverified.
+4. **Destructive / auto-remediating actions: check default state and blast radius.** For
+   anything that deletes, restarts, recovers, or prunes, ask *is it on by default, and
+   how many hosts/files does it touch?* Prefer fail-closed (raise rather than proceed on
+   an ambiguous result) over silently reporting success.
+5. **Disruption to existing users is part of correctness.** "No bugs" is not a
+   sufficient verdict. Check: opt-in vs always-on; on-disk state-format/migration
+   compatibility across the rolling-upgrade window; new hard-required config that breaks
+   current installs; process-global patches with wide blast radius.
+6. **No hardcoded absolute paths.** Machine- or user-specific path literals
+   (`/Users/…`, `/home/<user>/…`, `~/.claude`, `~/.sutando`, …) break on other hosts;
+   resolve via the workspace/config helpers instead. Enforced by the `checks:` block.
+7. **A verdict must state merge-readiness explicitly** — "ready to merge" /
+   "changes requested: …" / "LGTM, non-blocking". And it is only honest if you actually
+   ran these criteria on *this* PR — a readiness claim with no evidence attached
+   (no test run, no failure-mode named, no blast-radius call) is an over-claim.
+
+## Checks (machine-readable — consumed by scripts/review-checks.sh)
+
+```yaml
+checks:
+  hardcoded-paths:
+    # Added lines containing any of these substrings are flagged as errors...
+    flag:
+      - '/Users/'
+      - '/home/'
+      - '/opt/'
+      - '/private/'
+      - '~/.claude'
+      - '~/.sutando'
+    # ...unless the path token also matches one of these (fixtures / system noise).
+    allow:
+      - '/nonexistent'
+      - '/usr/fake'
+      - '/tmp/'
+      - 'example.com'
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,17 @@ jobs:
       - name: CLASS_RULES vs reader-chain symmetry lint
         run: python3 scripts/lint-class-rules.py
 
+      # Repo-scoped review checks: runs the machine-readable `checks:` block from
+      # .github/REVIEW_GUIDE.md (today: hardcoded-path scan) over the PR diff, so
+      # the guide's lessons gate EVERY PR — not just reviews that use the codex
+      # tool. `gh pr diff` needs no history/fetch-depth. PR events only (a push to
+      # main has no PR diff). See docs + scripts/review-checks.sh.
+      - name: Review checks (REVIEW_GUIDE)
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr diff ${{ github.event.pull_request.number }} | bash scripts/review-checks.sh
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,11 @@ jobs:
         run: python3 scripts/lint-class-rules.py
 
       # Repo-scoped review checks: runs the machine-readable `checks:` block from
-      # .github/REVIEW_GUIDE.md (today: hardcoded-path scan) over the PR diff, so
+      # REVIEW.md (today: hardcoded-path scan) over the PR diff, so
       # the guide's lessons gate EVERY PR — not just reviews that use the codex
       # tool. `gh pr diff` needs no history/fetch-depth. PR events only (a push to
       # main has no PR diff). See docs + scripts/review-checks.sh.
-      - name: Review checks (REVIEW_GUIDE)
+      - name: Review checks (REVIEW.md)
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,16 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr diff ${{ github.event.pull_request.number }} | bash scripts/review-checks.sh
+        # Materialize the diff BEFORE scanning and fail closed if `gh pr diff`
+        # errors (#2281, Qingyun review). The old `gh pr diff … | review-checks.sh`
+        # pipe reported the pipeline's LAST exit status, so a failed `gh pr diff`
+        # (auth/rate-limit/network) sent an empty diff to the scanner, which
+        # printed "empty diff — nothing to check" and exited 0 → the gate passed
+        # WITHOUT scanning the PR. `set -euo pipefail` + `--diff` closes that.
+        run: |
+          set -euo pipefail
+          gh pr diff ${{ github.event.pull_request.number }} > /tmp/review-pr.diff
+          bash scripts/review-checks.sh --diff /tmp/review-pr.diff
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,15 +68,7 @@ When you review a PR (including another agent's), you MUST follow `CONTRIBUTING.
 - Once a requested change is verified fixed, dismiss or replace the stale REQUEST_CHANGES state. If it remains, cite the exact unresolved behavior.
 - Merge only when the current head is mergeable, required CI + CLA are green, and two maintainers have recorded formal approvals. Never substitute a comment, bot recommendation, stale approval, or admin bypass.
 
-**Canonical review criteria (mirror of `REVIEW.md`).** These are the repo's review lessons. The root `REVIEW.md` carries the same list for Codex's managed GitHub-App PR reviews (which read `REVIEW.md`); the local in-session `/code-review` reads *this* file (`AGENTS.md`), **not** `REVIEW.md` — so the lessons live in both. Keep the two prose copies in sync. The machine-readable `checks:` block (hardcoded-path scan, run in CI via `scripts/review-checks.sh`) lives only in `REVIEW.md`.
-
-1. **Confirm the bug exists on `main` before endorsing a fix.** A patch for a bug that isn't there is noise.
-2. **Review the whole activated path, not just the diff.** Bugs hide in the unchanged code the diff now reaches; a parity change means reading both branches end-to-end.
-3. **Prove the fix by exercising the failure mode.** Happy-path green ≠ proof — a test must actually reproduce the original failure, or the fix is unverified.
-4. **Destructive / auto-remediating actions: check default state and blast radius.** For anything that deletes, restarts, recovers, or prunes, ask *is it on by default, and how many hosts/files does it touch?* Prefer fail-closed over silently reporting success.
-5. **Disruption to existing users is part of correctness.** Check opt-in vs always-on, on-disk state-format/migration compatibility across the rolling-upgrade window, new hard-required config that breaks current installs, and process-global patches with wide blast radius.
-6. **No hardcoded absolute paths.** Machine/user-specific literals (`/Users/…`, `/home/<user>/…`, `~/.claude`, `~/.sutando`) break on other hosts; resolve via the workspace/config helpers. Enforced by the `checks:` block in `REVIEW.md`.
-7. **A verdict must state merge-readiness explicitly** ("ready to merge" / "changes requested: …" / "LGTM, non-blocking") — and only honestly if you actually ran these criteria on *this* PR; a readiness claim with no evidence attached is an over-claim.
+**Review criteria live in `REVIEW.md` (single source of truth).** Don't duplicate the 7 lessons here — read them from `REVIEW.md`. When you review, `review-preflight.py` reads `REVIEW.md` and prints the criteria inline so you see them on every preflight run; `scripts/review-checks.sh` runs the machine-readable `checks:` block (hardcoded-path scan) in CI; and Codex's managed GitHub-App reviewer reads `REVIEW.md` directly. Adding or editing a lesson is a PR to `REVIEW.md` only.
 
 Skill-PR destination: a skill is **coupled** (PR to `sonichi/sutando`) if it imports from `src/` or another skill, modifies main-repo files, or is tightly bound to a feature there (e.g. `skills/phone-conversation/`). A skill is **standalone** (PR to `sonichi/sutando-skills-community`) if it ships its own scripts/binaries, reads files but doesn't import main-repo modules, and works against any checkout. If unsure, ask in #design.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,16 @@ When you review a PR (including another agent's), you MUST follow `CONTRIBUTING.
 - Once a requested change is verified fixed, dismiss or replace the stale REQUEST_CHANGES state. If it remains, cite the exact unresolved behavior.
 - Merge only when the current head is mergeable, required CI + CLA are green, and two maintainers have recorded formal approvals. Never substitute a comment, bot recommendation, stale approval, or admin bypass.
 
+**Canonical review criteria (mirror of `REVIEW.md`).** These are the repo's review lessons. The root `REVIEW.md` carries the same list for Codex's managed GitHub-App PR reviews (which read `REVIEW.md`); the local in-session `/code-review` reads *this* file (`AGENTS.md`), **not** `REVIEW.md` — so the lessons live in both. Keep the two prose copies in sync. The machine-readable `checks:` block (hardcoded-path scan, run in CI via `scripts/review-checks.sh`) lives only in `REVIEW.md`.
+
+1. **Confirm the bug exists on `main` before endorsing a fix.** A patch for a bug that isn't there is noise.
+2. **Review the whole activated path, not just the diff.** Bugs hide in the unchanged code the diff now reaches; a parity change means reading both branches end-to-end.
+3. **Prove the fix by exercising the failure mode.** Happy-path green ≠ proof — a test must actually reproduce the original failure, or the fix is unverified.
+4. **Destructive / auto-remediating actions: check default state and blast radius.** For anything that deletes, restarts, recovers, or prunes, ask *is it on by default, and how many hosts/files does it touch?* Prefer fail-closed over silently reporting success.
+5. **Disruption to existing users is part of correctness.** Check opt-in vs always-on, on-disk state-format/migration compatibility across the rolling-upgrade window, new hard-required config that breaks current installs, and process-global patches with wide blast radius.
+6. **No hardcoded absolute paths.** Machine/user-specific literals (`/Users/…`, `/home/<user>/…`, `~/.claude`, `~/.sutando`) break on other hosts; resolve via the workspace/config helpers. Enforced by the `checks:` block in `REVIEW.md`.
+7. **A verdict must state merge-readiness explicitly** ("ready to merge" / "changes requested: …" / "LGTM, non-blocking") — and only honestly if you actually ran these criteria on *this* PR; a readiness claim with no evidence attached is an over-claim.
+
 Skill-PR destination: a skill is **coupled** (PR to `sonichi/sutando`) if it imports from `src/` or another skill, modifies main-repo files, or is tightly bound to a feature there (e.g. `skills/phone-conversation/`). A skill is **standalone** (PR to `sonichi/sutando-skills-community`) if it ships its own scripts/binaries, reads files but doesn't import main-repo modules, and works against any checkout. If unsure, ask in #design.
 
 ## Workspace contract

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,15 +68,7 @@ When you review a PR (including another agent's), you MUST follow `CONTRIBUTING.
 - Once a requested change is verified fixed, dismiss or replace the stale REQUEST_CHANGES state. If it remains, cite the exact unresolved behavior.
 - Merge only when the current head is mergeable, required CI + CLA are green, and two maintainers have recorded formal approvals. Never substitute a comment, bot recommendation, stale approval, or admin bypass.
 
-**Canonical review criteria (mirror of `REVIEW.md`).** These are the repo's review lessons. The root `REVIEW.md` carries the same list for Claude Code's managed GitHub-App PR reviews (which read `REVIEW.md`); the local in-session `/code-review` reads *this* file (`CLAUDE.md`), **not** `REVIEW.md` — so the lessons live in both. Keep the two prose copies in sync. The machine-readable `checks:` block (hardcoded-path scan, run in CI via `scripts/review-checks.sh`) lives only in `REVIEW.md`.
-
-1. **Confirm the bug exists on `main` before endorsing a fix.** A patch for a bug that isn't there is noise.
-2. **Review the whole activated path, not just the diff.** Bugs hide in the unchanged code the diff now reaches; a parity change means reading both branches end-to-end.
-3. **Prove the fix by exercising the failure mode.** Happy-path green ≠ proof — a test must actually reproduce the original failure, or the fix is unverified.
-4. **Destructive / auto-remediating actions: check default state and blast radius.** For anything that deletes, restarts, recovers, or prunes, ask *is it on by default, and how many hosts/files does it touch?* Prefer fail-closed over silently reporting success.
-5. **Disruption to existing users is part of correctness.** Check opt-in vs always-on, on-disk state-format/migration compatibility across the rolling-upgrade window, new hard-required config that breaks current installs, and process-global patches with wide blast radius.
-6. **No hardcoded absolute paths.** Machine/user-specific literals (`/Users/…`, `/home/<user>/…`, `~/.claude`, `~/.sutando`) break on other hosts; resolve via the workspace/config helpers. Enforced by the `checks:` block in `REVIEW.md`.
-7. **A verdict must state merge-readiness explicitly** ("ready to merge" / "changes requested: …" / "LGTM, non-blocking") — and only honestly if you actually ran these criteria on *this* PR; a readiness claim with no evidence attached is an over-claim.
+**Review criteria live in `REVIEW.md` (single source of truth).** Don't duplicate the 7 lessons here — read them from `REVIEW.md`. When you review, `review-preflight.py` reads `REVIEW.md` and prints the criteria inline so you see them on every preflight run; `scripts/review-checks.sh` runs the machine-readable `checks:` block (hardcoded-path scan) in CI; and Claude Code's managed GitHub-App reviewer reads `REVIEW.md` directly. Adding or editing a lesson is a PR to `REVIEW.md` only.
 
 Skill-PR destination: a skill is **coupled** (PR to `sonichi/sutando`) if it imports from `src/` or another skill, modifies main-repo files, or is tightly bound to a feature there (e.g. `skills/phone-conversation/`). A skill is **standalone** (PR to `sonichi/sutando-skills-community`) if it ships its own scripts/binaries, reads files but doesn't import main-repo modules, and works against any checkout. If unsure, ask in #design.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,16 @@ When you review a PR (including another agent's), you MUST follow `CONTRIBUTING.
 - Once a requested change is verified fixed, dismiss or replace the stale REQUEST_CHANGES state. If it remains, cite the exact unresolved behavior.
 - Merge only when the current head is mergeable, required CI + CLA are green, and two maintainers have recorded formal approvals. Never substitute a comment, bot recommendation, stale approval, or admin bypass.
 
+**Canonical review criteria (mirror of `REVIEW.md`).** These are the repo's review lessons. The root `REVIEW.md` carries the same list for Claude Code's managed GitHub-App PR reviews (which read `REVIEW.md`); the local in-session `/code-review` reads *this* file (`CLAUDE.md`), **not** `REVIEW.md` — so the lessons live in both. Keep the two prose copies in sync. The machine-readable `checks:` block (hardcoded-path scan, run in CI via `scripts/review-checks.sh`) lives only in `REVIEW.md`.
+
+1. **Confirm the bug exists on `main` before endorsing a fix.** A patch for a bug that isn't there is noise.
+2. **Review the whole activated path, not just the diff.** Bugs hide in the unchanged code the diff now reaches; a parity change means reading both branches end-to-end.
+3. **Prove the fix by exercising the failure mode.** Happy-path green ≠ proof — a test must actually reproduce the original failure, or the fix is unverified.
+4. **Destructive / auto-remediating actions: check default state and blast radius.** For anything that deletes, restarts, recovers, or prunes, ask *is it on by default, and how many hosts/files does it touch?* Prefer fail-closed over silently reporting success.
+5. **Disruption to existing users is part of correctness.** Check opt-in vs always-on, on-disk state-format/migration compatibility across the rolling-upgrade window, new hard-required config that breaks current installs, and process-global patches with wide blast radius.
+6. **No hardcoded absolute paths.** Machine/user-specific literals (`/Users/…`, `/home/<user>/…`, `~/.claude`, `~/.sutando`) break on other hosts; resolve via the workspace/config helpers. Enforced by the `checks:` block in `REVIEW.md`.
+7. **A verdict must state merge-readiness explicitly** ("ready to merge" / "changes requested: …" / "LGTM, non-blocking") — and only honestly if you actually ran these criteria on *this* PR; a readiness claim with no evidence attached is an over-claim.
+
 Skill-PR destination: a skill is **coupled** (PR to `sonichi/sutando`) if it imports from `src/` or another skill, modifies main-repo files, or is tightly bound to a feature there (e.g. `skills/phone-conversation/`). A skill is **standalone** (PR to `sonichi/sutando-skills-community`) if it ships its own scripts/binaries, reads files but doesn't import main-repo modules, and works against any checkout. If unsure, ask in #design.
 
 ## Workspace contract

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,14 +1,24 @@
-# Review guide — sonichi/sutando
+# Review guide — sonichi/sutando (`REVIEW.md`)
 
-Canonical, in-repo review criteria for this repository. Two audiences in one file:
+Canonical, in-repo review criteria for this repository. This is Claude Code's
+conventional `REVIEW.md` at the repo root, so it is consumed by **three** audiences:
 
+- **Claude Code's managed GitHub App PR reviews** inject this file's prose directly
+  into every review agent's system prompt (that service reads a root `REVIEW.md`).
 - **Humans + the codex reviewer** read the prose lessons below as review criteria.
 - **Automated scanners** (`scripts/review-checks.sh`, run in CI on every PR) parse the
   fenced `checks:` block at the bottom — the *only* machine-read section.
 
-This file is the single source of truth: adding a lesson or a check is a PR to this
-file, **not** a code change to the review tooling. Another repo ships its own
-`.github/REVIEW_GUIDE.md`; the tooling is generic and loads whichever repo it reviews.
+This file is the single source of truth for the machine checks and the GitHub-App
+criteria: adding a lesson or a check is a PR to *this* file, **not** a code change to
+the review tooling. Another repo ships its own root `REVIEW.md`; the tooling is generic
+and loads whichever repo it reviews.
+
+> **Note on the local `/code-review` command:** the in-session `/code-review` reads
+> `CLAUDE.md` but **not** `REVIEW.md` (only the managed GitHub App reads this file).
+> So the same lessons are mirrored into `CLAUDE.md` ("Reviewing a PR") to cover
+> in-session reviews. Keep the two prose copies in sync; the `checks:` block below
+> lives here only.
 
 ## Lessons (criteria for reviewers)
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -14,11 +14,13 @@ criteria: adding a lesson or a check is a PR to *this* file, **not** a code chan
 the review tooling. Another repo ships its own root `REVIEW.md`; the tooling is generic
 and loads whichever repo it reviews.
 
-> **Note on the local `/code-review` command:** the in-session `/code-review` reads
-> `CLAUDE.md` but **not** `REVIEW.md` (only the managed GitHub App reads this file).
-> So the same lessons are mirrored into `CLAUDE.md` ("Reviewing a PR") to cover
-> in-session reviews. Keep the two prose copies in sync; the `checks:` block below
-> lives here only.
+> **Single source of truth.** These lessons live here in `REVIEW.md` only — they are
+> **not** duplicated in `CLAUDE.md`. They reach reviewers three ways: `review-preflight.py`
+> reads this file and prints the criteria on every pre-review run (for the core agent);
+> `scripts/review-checks.sh` runs the machine `checks:` block below in CI; and Claude Code's
+> managed GitHub-App reviewer reads this file directly. (The in-session `/code-review` reads
+> only `CLAUDE.md`, not this file — but it is not part of our review flow.) Add or edit a
+> lesson in one place: here.
 
 ## Lessons (criteria for reviewers)
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -28,12 +28,23 @@ and loads whichever repo it reviews.
    isn't there is noise.
 2. **Review the whole activated path, not just the diff.** Bugs hide in the unchanged
    code the diff now reaches. A parity change means reading both branches end-to-end.
+   *Grounded by:* the #1600 M-fix — the watchdog's new forced-full-reset path reached
+   unchanged wake-state code the diff never touched, leaving the bot permanently muted
+   despite owner summons (#1663). Also #1403: the migration script's `rehome-state`
+   classification was never traced against the reader's `personal_path()` resolution
+   order, so post-migration bots lost their Stand names (fixed in #1540).
 3. **Prove the fix by exercising the failure mode.** Happy-path green ≠ proof — a test
    must actually reproduce the original failure, or the fix is unverified.
 4. **Destructive / auto-remediating actions: check default state and blast radius.** For
    anything that deletes, restarts, recovers, or prunes, ask *is it on by default, and
    how many hosts/files does it touch?* Prefer fail-closed (raise rather than proceed on
    an ambiguous result) over silently reporting success.
+   *Grounded by:* #1428 — the `--recover-core` watchdog shipped **on by default** in the
+   committed launchd template (every host that ran the installer), and its false-positive
+   restarts killed the in-flight task and re-fired in a loop, leaving Chi's Sutando
+   "not responsive or not functioning at many times, nearly unusable" for weeks
+   (reported #dev 2026-07-21); Rui's host was bitten too (11 wedge-restarts) without
+   anyone noticing.
 5. **Disruption to existing users is part of correctness — ask the worst-case question.**
    "No bugs" is not a sufficient verdict. The explicit question every reviewer **and the
    maintainer (before merging)** must answer: **"What is the worst-case disruption to
@@ -43,6 +54,11 @@ and loads whichever repo it reviews.
    process-global patches with wide blast radius; and — per #1898 — for any auto-action,
    *what code or state does it act on* (does it verify the target is canonical, or run
    whatever's there?). A PR is not merge-ready until that worst case is named and mitigated.
+   *Grounded by:* #1898 itself — the live test verified the claimed behavior, but the
+   latent bug sat in exactly this un-asked worst-case question and surfaced 2026-07-25.
+   The full reported-breakage corpus grounding these lessons lives in
+   sutando-pr-triage `kb/breakage/breakages.csv` (reporter, verbatim quote, breaking
+   merge, previously-working evidence per row).
 6. **No hardcoded absolute paths.** Machine- or user-specific path literals
    (`/Users/…`, `/home/<user>/…`, `~/.claude`, `~/.sutando`, …) break on other hosts;
    resolve via the workspace/config helpers instead. Enforced by the `checks:` block.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -34,10 +34,15 @@ and loads whichever repo it reviews.
    anything that deletes, restarts, recovers, or prunes, ask *is it on by default, and
    how many hosts/files does it touch?* Prefer fail-closed (raise rather than proceed on
    an ambiguous result) over silently reporting success.
-5. **Disruption to existing users is part of correctness.** "No bugs" is not a
-   sufficient verdict. Check: opt-in vs always-on; on-disk state-format/migration
-   compatibility across the rolling-upgrade window; new hard-required config that breaks
-   current installs; process-global patches with wide blast radius.
+5. **Disruption to existing users is part of correctness — ask the worst-case question.**
+   "No bugs" is not a sufficient verdict. The explicit question every reviewer **and the
+   maintainer (before merging)** must answer: **"What is the worst-case disruption to
+   Sutando's users from this PR, and how do we mitigate it?"** (Chi 2026-07-25.) Concretely
+   check: opt-in vs always-on; on-disk state-format/migration compatibility across the
+   rolling-upgrade window; new hard-required config that breaks current installs;
+   process-global patches with wide blast radius; and — per #1898 — for any auto-action,
+   *what code or state does it act on* (does it verify the target is canonical, or run
+   whatever's there?). A PR is not merge-ready until that worst case is named and mitigated.
 6. **No hardcoded absolute paths.** Machine- or user-specific path literals
    (`/Users/…`, `/home/<user>/…`, `~/.claude`, `~/.sutando`, …) break on other hosts;
    resolve via the workspace/config helpers instead. Enforced by the `checks:` block.

--- a/scripts/review-checks.py
+++ b/scripts/review-checks.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Hardcoded-path scanner for review-checks.sh (kept as a sibling file so the
+shell runner never embeds a heredoc inside $(), which macOS's bash 3.2
+mis-parses). Inputs via env: RC_FLAGS / RC_ALLOWS (newline-separated pattern
+lists from the guide's checks: block) and RC_DIFF (the unified diff). Prints one
+`file:line: hardcoded path (tok): text` per violation to stdout; exit is always
+0 — the caller decides pass/fail from whether anything was printed."""
+import os
+import re
+import sys
+
+flags = [p for p in os.environ.get("RC_FLAGS", "").split("\n") if p]
+allows = [a for a in os.environ.get("RC_ALLOWS", "").split("\n") if a]
+DELIMS = set("\"'()" + ", ;=" + chr(96) + chr(9))   # quotes, brackets, backtick, tab, etc.
+SKIP = re.compile(r"\.md$|(^|/)tests/|\.test\.|review-checks\.(sh|py)$")
+
+
+def token_at(s, pos):
+    """The path-ish token containing index `pos` — expand to nearest delimiters."""
+    left = pos
+    while left > 0 and s[left - 1] not in DELIMS:
+        left -= 1
+    right = pos
+    while right < len(s) - 1 and s[right + 1] not in DELIMS:
+        right += 1
+    return s[left:right + 1]
+
+
+def allowed(tok):
+    """A path-like allow (starts with / or ~) must match at the token START, so
+    a fixture like `/tmp/` cannot mask a real `/Users/tmp/...`; a non-path allow
+    (e.g. a domain) matches anywhere in the token."""
+    for a in allows:
+        if a[:1] in ("/", "~"):
+            if tok.startswith(a):
+                return True
+        elif a in tok:
+            return True
+    return False
+
+
+def main():
+    skip = False
+    ln = 0
+    cur_file = ""
+    hits = 0
+    for raw in os.environ.get("RC_DIFF", "").split("\n"):
+        if raw.startswith("+++ "):
+            f = raw[4:].split("\t")[0]
+            if f.startswith("b/"):
+                f = f[2:]
+            cur_file = f
+            ln = 0
+            skip = bool(SKIP.search(f))
+            continue
+        if raw.startswith("@@ "):
+            m = re.search(r"\+(\d+)", raw)
+            if m:
+                ln = int(m.group(1))
+            continue
+        if raw.startswith("-"):
+            continue
+        if raw.startswith("+"):
+            if skip:
+                continue
+            line = raw[1:]
+            cur = ln
+            ln += 1
+            stripped = line.lstrip()
+            if stripped.startswith("#") or stripped.startswith("//"):
+                continue
+            for p in flags:
+                pos = line.find(p)
+                if pos < 0:
+                    continue
+                tok = token_at(line, pos)
+                if not allowed(tok):
+                    print("%s:%d: hardcoded path (%s): %s" % (cur_file, cur, tok, stripped))
+                    hits += 1
+                    break
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/review-checks.py
+++ b/scripts/review-checks.py
@@ -60,6 +60,11 @@ def main():
             continue
         if raw.startswith("-"):
             continue
+        if raw.startswith(" "):
+            # Context lines exist in both old and new files, so they advance the
+            # new-file line counter just like additions do.
+            ln += 1
+            continue
         if raw.startswith("+"):
             if skip:
                 continue

--- a/scripts/review-checks.py
+++ b/scripts/review-checks.py
@@ -43,12 +43,30 @@ def allowed(tok):
     return False
 
 
-def _toggles_docstring(line):
-    """A line flips triple-quote (docstring) state when it holds an ODD number of
-    ``\"\"\"``/``'''`` delimiters (one opens or closes; two on a line open+close and
-    leave state unchanged). Approximate — good enough to keep the scanner off
-    docstring PROSE, which is where a path is documentation, not a code path."""
-    return (line.count('"""') + line.count("'''")) % 2 == 1
+# Opens an exempt span ONLY for a bare string-expression (the shape of a real
+# docstring): optional string prefix (r/b/u/f, up to 2) then a triple-quote at
+# the very start of the stripped line. An assignment/call that merely carries a
+# triple-quoted literal (`COMMAND = """`) does NOT match, so it stays executable
+# code and a hardcoded path inside it is still flagged (#2281, Qingyun review —
+# the old count-only toggle suppressed ANY multi-line string, a scanner bypass).
+_DOCSTRING_OPEN = re.compile(r"^[rbuf]{0,2}('''|" + '"' * 3 + ")", re.IGNORECASE)
+
+
+def _doc_transition(line, in_doc):
+    """Triple-quote (docstring) state AFTER `line`, given the state before it.
+
+    - Inside a docstring: an ODD number of triple-quote delimiters closes it
+      (the closing delimiter may sit anywhere on the line).
+    - Not inside one: open only for a bona-fide docstring line whose stripped
+      content STARTS with a triple-quote (per _DOCSTRING_OPEN) AND has an odd
+      delimiter count (even = a same-line open+close one-liner, stay out). This
+      is the assignment-string bypass fix: a triple-quoted literal assigned to a
+      name no longer exempts a hardcoded path inside it (#2281, Qingyun review).
+    """
+    quotes = line.count('"""') + line.count("'''")
+    if in_doc:
+        return quotes % 2 == 0                       # odd → closed
+    return bool(_DOCSTRING_OPEN.match(line.lstrip())) and quotes % 2 == 1
 
 
 def main():
@@ -83,8 +101,7 @@ def main():
             # Context lines exist in both old and new files, so they advance the
             # new-file line counter just like additions do — and they move the
             # docstring state (a docstring may open on unchanged context).
-            if _toggles_docstring(raw[1:]):
-                in_doc = not in_doc
+            in_doc = _doc_transition(raw[1:], in_doc)
             ln += 1
             continue
         if raw.startswith("+"):
@@ -98,8 +115,7 @@ def main():
             # describing a legacy path a PR is REMOVING) is not flagged, while
             # the opening `"""` line itself is still checked.
             was_in_doc = in_doc
-            if _toggles_docstring(line):
-                in_doc = not in_doc
+            in_doc = _doc_transition(line, in_doc)
             stripped = line.lstrip()
             if was_in_doc or stripped.startswith("#") or stripped.startswith("//"):
                 continue

--- a/scripts/review-checks.py
+++ b/scripts/review-checks.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 """Hardcoded-path scanner for review-checks.sh (kept as a sibling file so the
 shell runner never embeds a heredoc inside $(), which macOS's bash 3.2
-mis-parses). Inputs via env: RC_FLAGS / RC_ALLOWS (newline-separated pattern
-lists from the guide's checks: block) and RC_DIFF (the unified diff). Prints one
-`file:line: hardcoded path (tok): text` per violation to stdout; exit is always
-0 — the caller decides pass/fail from whether anything was printed."""
+mis-parses). The pattern lists come via env (RC_FLAGS / RC_ALLOWS — small,
+newline-separated lists from the guide's checks: block); the unified diff is
+read from STDIN, never argv/env, so an ~8MB PR diff can't blow the OS
+'Argument list too long' limit and make the scan silently skip (#2281). Prints
+one `file:line: hardcoded path (tok): text` per violation to stdout; exit is 0
+when the scan runs (with or without hits — the caller decides pass/fail from
+whether anything was printed) and non-zero only if the scanner itself crashes,
+so the runner can fail closed."""
 import os
 import re
 import sys
@@ -40,11 +44,12 @@ def allowed(tok):
 
 
 def main():
+    diff = sys.stdin.read()  # streamed by the runner — see module docstring (#2281)
     skip = False
     ln = 0
     cur_file = ""
     hits = 0
-    for raw in os.environ.get("RC_DIFF", "").split("\n"):
+    for raw in diff.split("\n"):
         if raw.startswith("+++ "):
             f = raw[4:].split("\t")[0]
             if f.startswith("b/"):

--- a/scripts/review-checks.py
+++ b/scripts/review-checks.py
@@ -43,12 +43,21 @@ def allowed(tok):
     return False
 
 
+def _toggles_docstring(line):
+    """A line flips triple-quote (docstring) state when it holds an ODD number of
+    ``\"\"\"``/``'''`` delimiters (one opens or closes; two on a line open+close and
+    leave state unchanged). Approximate — good enough to keep the scanner off
+    docstring PROSE, which is where a path is documentation, not a code path."""
+    return (line.count('"""') + line.count("'''")) % 2 == 1
+
+
 def main():
     diff = sys.stdin.read()  # streamed by the runner — see module docstring (#2281)
     skip = False
     ln = 0
     cur_file = ""
     hits = 0
+    in_doc = False   # inside a triple-quoted docstring/string block (reset per hunk)
     for raw in diff.split("\n"):
         if raw.startswith("+++ "):
             f = raw[4:].split("\t")[0]
@@ -57,17 +66,25 @@ def main():
             cur_file = f
             ln = 0
             skip = bool(SKIP.search(f))
+            in_doc = False
             continue
         if raw.startswith("@@ "):
             m = re.search(r"\+(\d+)", raw)
             if m:
                 ln = int(m.group(1))
+            # A hunk can't be trusted to continue a prior hunk's string state
+            # (gaps between hunks); reset so a docstring opened + closed within
+            # this hunk is tracked, without carrying stale state across a gap.
+            in_doc = False
             continue
         if raw.startswith("-"):
             continue
         if raw.startswith(" "):
             # Context lines exist in both old and new files, so they advance the
-            # new-file line counter just like additions do.
+            # new-file line counter just like additions do — and they move the
+            # docstring state (a docstring may open on unchanged context).
+            if _toggles_docstring(raw[1:]):
+                in_doc = not in_doc
             ln += 1
             continue
         if raw.startswith("+"):
@@ -76,8 +93,15 @@ def main():
             line = raw[1:]
             cur = ln
             ln += 1
+            # Decide skip from the state at the line's START, then advance it —
+            # so a path sitting inside a docstring (documentation, e.g. a comment
+            # describing a legacy path a PR is REMOVING) is not flagged, while
+            # the opening `"""` line itself is still checked.
+            was_in_doc = in_doc
+            if _toggles_docstring(line):
+                in_doc = not in_doc
             stripped = line.lstrip()
-            if stripped.startswith("#") or stripped.startswith("//"):
+            if was_in_doc or stripped.startswith("#") or stripped.startswith("//"):
                 continue
             for p in flags:
                 pos = line.find(p)

--- a/scripts/review-checks.py
+++ b/scripts/review-checks.py
@@ -81,5 +81,5 @@ def main():
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())

--- a/scripts/review-checks.sh
+++ b/scripts/review-checks.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # review-checks.sh — run a repo's machine-readable review checks over a unified diff.
 #
-# Reads the `checks:` block from the repo's .github/REVIEW_GUIDE.md (the single
+# Reads the `checks:` block from the repo's REVIEW.md (the single
 # source of truth — lessons + checks live there, NOT baked into this runner) and
 # runs each check over the ADDED lines of a diff. Today the only check is
 # `hardcoded-paths` (folds the per-review scanner from #2229 into one place that
@@ -10,9 +10,9 @@
 # Usage:
 #   git diff | bash scripts/review-checks.sh                 # scan a diff on stdin
 #   bash scripts/review-checks.sh --diff pr.diff             # scan a diff file
-#   bash scripts/review-checks.sh --guide path/to/REVIEW_GUIDE.md --diff pr.diff
+#   bash scripts/review-checks.sh --guide path/to/REVIEW.md --diff pr.diff
 #
-# Guide resolution: --guide wins; else <repo>/.github/REVIEW_GUIDE.md. Missing
+# Guide resolution: --guide wins; else <repo>/REVIEW.md. Missing
 # guide -> generic fallback patterns + a stderr note (degrades safely).
 #
 # Exit: 0 = clean; 1 = a check flagged something; 2 = usage error.
@@ -42,7 +42,7 @@ fi
 # O(pathological) on a large string under macOS bash 3.2 and effectively hangs).
 [[ "$DIFF" =~ [^[:space:]] ]] || { echo "review-checks: empty diff — nothing to check." >&2; exit 0; }
 
-[[ -n "$GUIDE" ]] || GUIDE="$REPO/.github/REVIEW_GUIDE.md"
+[[ -n "$GUIDE" ]] || GUIDE="$REPO/REVIEW.md"
 
 # --- parse the guide's checks: hardcoded-paths {flag,allow} lists -------------
 parse_list() {  # $1 = flag|allow ; reads $GUIDE
@@ -82,7 +82,7 @@ HITS="$(RC_FLAGS="$FLAGS" RC_ALLOWS="$ALLOWS" RC_DIFF="$DIFF" python3 "$HERE/rev
 if [[ "$HITS" =~ [^[:space:]] ]]; then
     echo "review-checks: FAIL — hardcoded-paths:" >&2
     printf '%s\n' "$HITS" >&2
-    echo "review-checks: $(printf '%s\n' "$HITS" | grep -c '') violation(s). Resolve via workspace/config helpers, or add a scoped allow to .github/REVIEW_GUIDE.md if it's a genuine fixture." >&2
+    echo "review-checks: $(printf '%s\n' "$HITS" | grep -c '') violation(s). Resolve via workspace/config helpers, or add a scoped allow to REVIEW.md if it's a genuine fixture." >&2
     exit 1
 fi
 echo "review-checks: PASS (hardcoded-paths clean)"

--- a/scripts/review-checks.sh
+++ b/scripts/review-checks.sh
@@ -15,7 +15,8 @@
 # Guide resolution: --guide wins; else <repo>/REVIEW.md. Missing
 # guide -> generic fallback patterns + a stderr note (degrades safely).
 #
-# Exit: 0 = clean; 1 = a check flagged something; 2 = usage error.
+# Exit: 0 = clean; 1 = a check flagged something; 2 = usage error OR the scanner
+#       failed to launch/run (fail-closed — NEVER print PASS in that case).
 set -u
 
 DIFF_FILE=""
@@ -74,8 +75,18 @@ fi
 # --- scan ADDED diff lines for flagged hardcoded paths -----------------------
 # The scan itself is a sibling Python file (robust string handling; and keeping
 # it out of a $() heredoc dodges macOS bash 3.2's heredoc-in-$() mis-parse).
-# Patterns + diff are passed via env.
-HITS="$(RC_FLAGS="$FLAGS" RC_ALLOWS="$ALLOWS" RC_DIFF="$DIFF" python3 "$HERE/review-checks.py")"
+# Patterns pass via env (small); the diff is STREAMED via stdin — never argv/env
+# — so a large PR diff (~8MB) can't hit 'Argument list too long' and make the
+# scanner fail to launch while we blindly print PASS (#2281). `printf` is a bash
+# builtin, so piping the whole diff carries no exec-size limit.
+HITS="$(printf '%s' "$DIFF" | RC_FLAGS="$FLAGS" RC_ALLOWS="$ALLOWS" python3 "$HERE/review-checks.py")"
+SCAN_RC=$?
+# Fail closed: if the scanner didn't run to completion (exec failure, crash),
+# its exit is non-zero. Do NOT interpret an empty stdout as "clean" — error out.
+if [[ $SCAN_RC -ne 0 ]]; then
+    echo "review-checks: ERROR — hardcoded-paths scanner failed to run (exit $SCAN_RC); failing closed (NOT a pass)." >&2
+    exit 2
+fi
 
 [[ -n "$NOTE" ]] && echo "review-checks: $NOTE" >&2
 

--- a/scripts/review-checks.sh
+++ b/scripts/review-checks.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# review-checks.sh — run a repo's machine-readable review checks over a unified diff.
+#
+# Reads the `checks:` block from the repo's .github/REVIEW_GUIDE.md (the single
+# source of truth — lessons + checks live there, NOT baked into this runner) and
+# runs each check over the ADDED lines of a diff. Today the only check is
+# `hardcoded-paths` (folds the per-review scanner from #2229 into one place that
+# CI, review-pr.sh, and any agent all call).
+#
+# Usage:
+#   git diff | bash scripts/review-checks.sh                 # scan a diff on stdin
+#   bash scripts/review-checks.sh --diff pr.diff             # scan a diff file
+#   bash scripts/review-checks.sh --guide path/to/REVIEW_GUIDE.md --diff pr.diff
+#
+# Guide resolution: --guide wins; else <repo>/.github/REVIEW_GUIDE.md. Missing
+# guide -> generic fallback patterns + a stderr note (degrades safely).
+#
+# Exit: 0 = clean; 1 = a check flagged something; 2 = usage error.
+set -u
+
+DIFF_FILE=""
+GUIDE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --diff)  DIFF_FILE="${2:?--diff needs a path}"; shift 2;;
+        --guide) GUIDE="${2:?--guide needs a path}";    shift 2;;
+        -h|--help) sed -n '2,16p' "$0"; exit 0;;
+        *) echo "review-checks: unknown arg '$1'" >&2; exit 2;;
+    esac
+done
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+
+if [[ -n "$DIFF_FILE" ]]; then
+    [[ -r "$DIFF_FILE" ]] || { echo "review-checks: cannot read diff '$DIFF_FILE'" >&2; exit 2; }
+    DIFF="$(cat "$DIFF_FILE")"
+else
+    DIFF="$(cat)"
+fi
+# Non-empty test via regex (NOT ${DIFF//…/} — that global substitution is
+# O(pathological) on a large string under macOS bash 3.2 and effectively hangs).
+[[ "$DIFF" =~ [^[:space:]] ]] || { echo "review-checks: empty diff — nothing to check." >&2; exit 0; }
+
+[[ -n "$GUIDE" ]] || GUIDE="$REPO/.github/REVIEW_GUIDE.md"
+
+# --- parse the guide's checks: hardcoded-paths {flag,allow} lists -------------
+parse_list() {  # $1 = flag|allow ; reads $GUIDE
+    [[ -r "$GUIDE" ]] || return 0
+    awk -v want="$1" '
+        /^```yaml/ {y=1; next}
+        /^```/     {y=0}
+        !y {next}
+        /^[[:space:]]*flag:[[:space:]]*$/  {s="flag";  next}
+        /^[[:space:]]*allow:[[:space:]]*$/ {s="allow"; next}
+        /^[[:space:]]*[A-Za-z_-]+:[[:space:]]*$/ {s=""}
+        s==want && /^[[:space:]]*-[[:space:]]/ {
+            v=$0; sub(/^[[:space:]]*-[[:space:]]*/,"",v)
+            sub(/[[:space:]]+#.*$/,"",v)
+            gsub(/^["'\'']|["'\'']$/,"",v)
+            if (v!="") print v
+        }
+    ' "$GUIDE"
+}
+FLAGS="$(parse_list flag)"
+ALLOWS="$(parse_list allow)"
+NOTE=""
+if [[ -z "${FLAGS//[$' \t\r\n']/}" ]]; then
+    FLAGS=$'/Users/\n/home/'
+    ALLOWS=$'/nonexistent\n/usr/fake\n/tmp/\nexample.com'
+    NOTE="no repo review guide (or no checks: block) at ${GUIDE#$REPO/}; used generic defaults"
+fi
+
+# --- scan ADDED diff lines for flagged hardcoded paths -----------------------
+# The scan itself is a sibling Python file (robust string handling; and keeping
+# it out of a $() heredoc dodges macOS bash 3.2's heredoc-in-$() mis-parse).
+# Patterns + diff are passed via env.
+HITS="$(RC_FLAGS="$FLAGS" RC_ALLOWS="$ALLOWS" RC_DIFF="$DIFF" python3 "$HERE/review-checks.py")"
+
+[[ -n "$NOTE" ]] && echo "review-checks: $NOTE" >&2
+
+if [[ "$HITS" =~ [^[:space:]] ]]; then
+    echo "review-checks: FAIL — hardcoded-paths:" >&2
+    printf '%s\n' "$HITS" >&2
+    echo "review-checks: $(printf '%s\n' "$HITS" | grep -c '') violation(s). Resolve via workspace/config helpers, or add a scoped allow to .github/REVIEW_GUIDE.md if it's a genuine fixture." >&2
+    exit 1
+fi
+echo "review-checks: PASS (hardcoded-paths clean)"
+exit 0

--- a/skills/claude-codex/scripts/review-pr.sh
+++ b/skills/claude-codex/scripts/review-pr.sh
@@ -43,7 +43,7 @@ trap 'rm -f "$OUT"' EXIT   # clean up even on interrupt / non-zero exit, not jus
 
 # Mechanical checks first — the deterministic, guide-driven scanners (today:
 # hardcoded paths) via the shared runner (supersedes the baked-in scanner from
-# #2229; the patterns live in .github/REVIEW_GUIDE.md, not here). Surfaced ahead
+# #2229; the patterns live in REVIEW.md, not here). Surfaced ahead
 # of the codex verdict so the mechanical findings are never buried. Best-effort:
 # the runner's own exit code doesn't fail the review.
 CHECKS_SH="$(cd "$HERE/../../.." && pwd)/scripts/review-checks.sh"

--- a/skills/claude-codex/scripts/review-pr.sh
+++ b/skills/claude-codex/scripts/review-pr.sh
@@ -40,6 +40,18 @@ DIFF="$(gh pr diff "$PR" 2>/dev/null)" || { echo "review-pr: \`gh pr diff $PR\` 
 
 OUT="$(mktemp -t review-pr.XXXXXX)"
 trap 'rm -f "$OUT"' EXIT   # clean up even on interrupt / non-zero exit, not just the happy path
+
+# Mechanical checks first — the deterministic, guide-driven scanners (today:
+# hardcoded paths) via the shared runner (supersedes the baked-in scanner from
+# #2229; the patterns live in .github/REVIEW_GUIDE.md, not here). Surfaced ahead
+# of the codex verdict so the mechanical findings are never buried. Best-effort:
+# the runner's own exit code doesn't fail the review.
+CHECKS_SH="$(cd "$HERE/../../.." && pwd)/scripts/review-checks.sh"
+MECH=""
+if [[ -x "$CHECKS_SH" ]]; then
+    MECH="$(printf '%s' "$DIFF" | bash "$CHECKS_SH" 2>&1 || true)"
+fi
+[[ -n "$MECH" ]] && printf 'Mechanical checks (review-checks.sh):\n%s\n\n' "$MECH"
 bash "$HERE/codex-bounded.sh" --stall "$STALL" --max "$MAX" -- \
     codex exec --sandbox read-only -o "$OUT" -- "Concisely review this PR diff. List only real bugs, correctness issues, or security problems as bullets; if there are none, say 'no blocking issues'. Be specific (file + what's wrong).
 

--- a/tests/review-checks-py.test.py
+++ b/tests/review-checks-py.test.py
@@ -115,6 +115,39 @@ code, out = scan(big_diff)
 ok("oversized diff (>ARG_MAX) still flags hardcoded path",
    code == 0 and "big.js:200001:" in out and "/Users/alice/secret" in out)
 
+# --- docstring prose is not a hardcoded path (#2313 false-positive) ---------
+# A PR that ADDS a docstring describing a legacy path it's removing must not be
+# flagged for the path sitting in that prose.
+code, out = scan(
+    '+++ b/src/health-check.py\n'
+    '@@ -1,0 +1,3 @@\n'
+    '+    """Detect unlinked skills.\n'
+    '+    On a migrated install this scanned a stale ~/.claude/skills/ path.\n'
+    '+    """'
+)
+ok("path inside a multi-line docstring is NOT flagged (#2313)", out.strip() == "")
+
+# But real code AFTER the docstring closes is still scanned.
+code, out = scan(
+    '+++ b/src/x.py\n'
+    '@@ -1,0 +1,3 @@\n'
+    '+    """doc line one\n'
+    '+    doc line two."""\n'
+    '+    skills = "/Users/real/path"'
+)
+ok("code after a docstring still flags a hardcoded path",
+   "/Users/real/path" in out)
+
+# A single-line pair of triple-quotes (open+close) leaves state unchanged, so a
+# real path on the NEXT line is still caught (parity not corrupted).
+code, out = scan(
+    '+++ b/src/y.py\n'
+    '@@ -1,0 +1,2 @@\n'
+    '+    doc = """inline"""\n'
+    '+    p = "/Users/z"'
+)
+ok("even triple-quote count doesn't corrupt state; next line flags", "/Users/z" in out)
+
 print("---")
 if failed:
     print("FAILED — %d of %d" % (failed, passed + failed))

--- a/tests/review-checks-py.test.py
+++ b/tests/review-checks-py.test.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/review-checks.py (the hardcoded-path scanner behind
+review-checks.sh). Imports the module under coverage and exercises token_at /
+allowed / main across the diff-parsing branches. The shell-level behaviour is
+covered by tests/review-checks.test.sh; this pins the Python internals + gives
+the diff-coverage gate real coverage of the new file."""
+import contextlib
+import importlib.util
+import io
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+MODPATH = REPO / "scripts" / "review-checks.py"
+
+# Module reads RC_FLAGS / RC_ALLOWS at import time — set them first.
+os.environ["RC_FLAGS"] = "\n".join(["/Users/", "/home/", "~/.claude"])
+os.environ["RC_ALLOWS"] = "\n".join(["/tmp/", "/nonexistent", "example.com"])
+
+spec = importlib.util.spec_from_file_location("review_checks", MODPATH)
+rc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(rc)
+
+passed = 0
+failed = 0
+
+
+def ok(name, cond):
+    global passed, failed
+    if cond:
+        print("ok   " + name)
+        passed += 1
+    else:
+        print("FAIL " + name)
+        failed += 1
+
+
+def scan(diff):
+    """Run main() with RC_DIFF=diff, return (exit, stdout)."""
+    os.environ["RC_DIFF"] = diff
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        code = rc.main()
+    return code, buf.getvalue()
+
+
+# --- token_at ---------------------------------------------------------------
+ok("token_at extracts a quoted path token",
+   rc.token_at('x = "/Users/alice/app";', 5) == "/Users/alice/app")
+ok("token_at stops at a space delimiter",
+   rc.token_at("p /home/bob end", 2) == "/home/bob")
+ok("token_at expands left AND right from a mid-token position",
+   rc.token_at("a=/Users/alice/app b", 10) == "/Users/alice/app")
+
+# --- allowed: both branches -------------------------------------------------
+ok("allowed: path-allow matches at token start", rc.allowed("/tmp/scratch") is True)
+ok("allowed: path-allow anchored (no substring mask)", rc.allowed("/Users/tmp/keep") is False)
+ok("allowed: domain-allow matches as substring", rc.allowed("https://example.com/x") is True)
+ok("allowed: unrelated token not allowed", rc.allowed("/Users/alice") is False)
+
+# --- main(): diff-parsing branches ------------------------------------------
+code, out = scan('+++ b/src/app.ts\n@@ -1,0 +5,1 @@\n+const p = "/Users/a/b";')
+ok("positive: /Users flagged with file:line", code == 0 and "src/app.ts:5:" in out and "/Users/a/b" in out)
+
+code, out = scan('+++ b/src/c.py\n@@ -1,0 +1,2 @@\n+# note /Users/x\n+  // note /home/y')
+ok("comment lines (# and //) skipped", out.strip() == "")
+
+code, out = scan('+++ b/docs/x.md\n@@ -1,0 +1,1 @@\n+see /Users/x')
+ok("docs (.md) file skipped", out.strip() == "")
+
+code, out = scan('+++ b/tests/x.test.sh\n@@ -1,0 +1,1 @@\n+D="/Users/x"')
+ok("tests/ file skipped", out.strip() == "")
+
+code, out = scan('+++ b/scripts/review-checks.py\n@@ -1,0 +1,1 @@\n+x = "/Users/self"')
+ok("self (review-checks.py) skipped", out.strip() == "")
+
+code, out = scan('+++ b/src/x.ts\n@@ -1,0 +1,1 @@\n-const gone = "/home/removed"\n+const stay = ok()')
+ok("removed (-) lines ignored; clean add passes", out.strip() == "")
+
+code, out = scan('+++ b/g.sh\n@@ -1,0 +1,1 @@\n+cfg=~/.claude/settings.json')
+ok("~/.claude flagged", "~/.claude" in out)
+
+code, out = scan('+++ b/m.js\n@@ -1,0 +1,1 @@\n+x="/Users/a"; y="https://example.com"')
+ok("mixed forbidden+allowed still flags real path", "/Users/a" in out)
+
+code, out = scan("")
+ok("empty diff -> no output, exit 0", code == 0 and out == "")
+
+print("---")
+if failed:
+    print("FAILED — %d of %d" % (failed, passed + failed))
+    sys.exit(1)
+print("PASS — review-checks.py internals (%d checks)" % passed)
+sys.exit(0)

--- a/tests/review-checks-py.test.py
+++ b/tests/review-checks-py.test.py
@@ -148,6 +148,30 @@ code, out = scan(
 )
 ok("even triple-quote count doesn't corrupt state; next line flags", "/Users/z" in out)
 
+# A multi-line ASSIGNED string (not a docstring) must NOT be exempted — a
+# hardcoded path inside it is still flagged (#2281, Qingyun review). The old
+# count-only toggle opened the exempt span on `COMMAND = """`, letting host
+# config slip past this required gate under a false-green check.
+code, out = scan(
+    '+++ b/src/deploy.py\n'
+    '@@ -1,0 +1,3 @@\n'
+    '+COMMAND = """\n'
+    '+rsync /Users/alice/data /backup\n'
+    '+"""'
+)
+ok("multi-line assigned string does NOT exempt a hardcoded path (#2281 bypass)",
+   "/Users/alice/data" in out)
+
+# ...and a prefixed real docstring (r\"\"\") still exempts its prose.
+code, out = scan(
+    '+++ b/src/z.py\n'
+    '@@ -1,0 +1,3 @@\n'
+    '+    r"""Legacy note.\n'
+    '+    Old path was /Users/legacy/thing.\n'
+    '+    """'
+)
+ok("prefixed (r) docstring prose is still NOT flagged", out.strip() == "")
+
 print("---")
 if failed:
     print("FAILED — %d of %d" % (failed, passed + failed))

--- a/tests/review-checks-py.test.py
+++ b/tests/review-checks-py.test.py
@@ -37,11 +37,16 @@ def ok(name, cond):
 
 
 def scan(diff):
-    """Run main() with RC_DIFF=diff, return (exit, stdout)."""
-    os.environ["RC_DIFF"] = diff
+    """Run main() with `diff` fed on STDIN (the runner streams it there — #2281),
+    return (exit, stdout)."""
+    old_stdin = sys.stdin
+    sys.stdin = io.StringIO(diff)
     buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        code = rc.main()
+    try:
+        with contextlib.redirect_stdout(buf):
+            code = rc.main()
+    finally:
+        sys.stdin = old_stdin
     return code, buf.getvalue()
 
 
@@ -96,6 +101,19 @@ ok("mixed forbidden+allowed still flags real path", "/Users/a" in out)
 
 code, out = scan("")
 ok("empty diff -> no output, exit 0", code == 0 and out == "")
+
+# --- oversized input can't bypass the scan (#2281) --------------------------
+# A diff far larger than the OS argv/env limit (~1MB on macOS) used to be passed
+# via the RC_DIFF env var and blew 'Argument list too long', silently skipping
+# the scan. Streamed on stdin it must still flag the embedded hardcoded path.
+big = ["+++ b/big.js", "@@ -1,0 +1,200001 @@"]
+big += ["+const filler = resolveWorkspace();"] * 200000
+big += ['+const home = "/Users/alice/secret";']
+big_diff = "\n".join(big)
+assert len(big_diff) > 1048576, "regression fixture must exceed ARG_MAX"
+code, out = scan(big_diff)
+ok("oversized diff (>ARG_MAX) still flags hardcoded path",
+   code == 0 and "big.js:200001:" in out and "/Users/alice/secret" in out)
 
 print("---")
 if failed:

--- a/tests/review-checks-py.test.py
+++ b/tests/review-checks-py.test.py
@@ -63,6 +63,16 @@ ok("allowed: unrelated token not allowed", rc.allowed("/Users/alice") is False)
 code, out = scan('+++ b/src/app.ts\n@@ -1,0 +5,1 @@\n+const p = "/Users/a/b";')
 ok("positive: /Users flagged with file:line", code == 0 and "src/app.ts:5:" in out and "/Users/a/b" in out)
 
+code, out = scan(
+    '+++ b/src/app.ts\n'
+    '@@ -10,2 +10,3 @@\n'
+    ' existing_line_one = 1\n'
+    ' existing_line_two = 2\n'
+    '+path = "/Users/a/b"'
+)
+ok("context lines advance the reported new-file line",
+   code == 0 and "src/app.ts:12:" in out and "/Users/a/b" in out)
+
 code, out = scan('+++ b/src/c.py\n@@ -1,0 +1,2 @@\n+# note /Users/x\n+  // note /home/y')
 ok("comment lines (# and //) skipped", out.strip() == "")
 

--- a/tests/review-checks.test.sh
+++ b/tests/review-checks.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Tests for scripts/review-checks.sh — the guide-driven review-checks runner.
+# Folds the hardcoded-path scanner fixtures from #2229 (which this supersedes)
+# and adds coverage for: guide-supplied patterns, no-guide fallback, per-token
+# allow anchoring, and the file-skip (docs/tests/runner carry pattern literals
+# as data, not shipping code).
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="$HERE/../scripts/review-checks.sh"
+GUIDE="$HERE/../.github/REVIEW_GUIDE.md"
+
+pass=0; fail=0
+# check <name> <expect: flag|clean> <diff> [extra-args...]
+check() {
+    local name="$1" expect="$2" diff="$3"; shift 3
+    local out rc
+    out="$(printf '%s' "$diff" | bash "$RUNNER" "$@" 2>/dev/null)"; rc=$?
+    if { [ "$expect" = flag ] && [ "$rc" = 1 ]; } || { [ "$expect" = clean ] && [ "$rc" = 0 ]; }; then
+        echo "ok   $name"; pass=$((pass+1))
+    else
+        echo "FAIL $name (rc=$rc, want=$expect)"; fail=$((fail+1))
+    fi
+}
+
+# --- hardcoded-paths scanner (fixtures carried from #2229) ---------------------
+check "positive /Users/ path flagged"                 flag  $'+++ b/app.js\n@@ -1,0 +1,1 @@\n+const home = "/Users/alice/app";'
+check "# and // comment lines not flagged"            clean $'+++ b/c.js\n@@ -1,0 +1,2 @@\n+# note /Users/bob/x\n+// note /Users/bob/x'
+check "fixture paths (/usr/fake,/nonexistent,/tmp)"   clean $'+++ b/f.js\n@@ -1,0 +1,3 @@\n+a = "/usr/fake/p"\n+b = "/nonexistent/p"\n+c = "/tmp/scratch"'
+check "mixed forbidden+allowed line still flags real" flag  $'+++ b/m.js\n@@ -1,0 +1,1 @@\n+x = "/Users/alice/app"; y = "https://example.com";'
+check "real /Users/tmp/ not masked by /tmp/ allow"    flag  $'+++ b/t.js\n@@ -1,0 +1,1 @@\n+p = "/Users/tmp/keep"'
+check "~/.claude flagged"                             flag  $'+++ b/g.sh\n@@ -1,0 +1,1 @@\n+cfg=~/.claude/settings.json'
+check "/home/ flagged"                                flag  $'+++ b/i.py\n@@ -1,0 +1,1 @@\n+p = "/home/bob/.config"'
+check "clean diff passes"                             clean $'+++ b/h.js\n@@ -1,0 +1,1 @@\n+const x = resolveWorkspace();'
+
+# --- file-skip: path literals are legit DATA in docs/tests/runner -------------
+check "docs (.md) not scanned"                        clean $'+++ b/docs/x.md\n@@ -1,0 +1,1 @@\n+example path: /Users/a/b'
+check "tests/ not scanned"                            clean $'+++ b/tests/x.test.sh\n@@ -1,0 +1,1 @@\n+D="/Users/alice/app"'
+check "code still flagged alongside skipped file"     flag  $'+++ b/docs/a.md\n@@ -1,0 +1,1 @@\n+see /Users/x\n+++ b/src/a.ts\n@@ -1,0 +1,1 @@\n+const p="/home/y";'
+
+# --- guide resolution + fallback ---------------------------------------------
+check "explicit --guide is honored"                   flag  $'+++ b/z.ts\n@@ -1,0 +1,1 @@\n+const p="/opt/thing";' --guide "$GUIDE"
+check "missing guide falls back, still flags /Users/" flag  $'+++ b/z.ts\n@@ -1,0 +1,1 @@\n+const p="/Users/a/b";' --guide /does/not/exist
+check "empty diff exits 0 (nothing to check)"         clean $''
+
+# --- guide's own checks: block is parseable ----------------------------------
+if grep -q "hardcoded-paths:" "$GUIDE" && grep -qE "^\s*flag:" "$GUIDE"; then
+    echo "ok   REVIEW_GUIDE.md carries a hardcoded-paths checks: block"; pass=$((pass+1))
+else
+    echo "FAIL REVIEW_GUIDE.md missing checks: block"; fail=$((fail+1))
+fi
+
+echo "---"
+if [ "$fail" -eq 0 ]; then
+    echo "PASS — review-checks runner ($pass checks)"
+    exit 0
+else
+    echo "FAILED — $fail of $((pass+fail)) checks"
+    exit 1
+fi

--- a/tests/review-checks.test.sh
+++ b/tests/review-checks.test.sh
@@ -7,7 +7,7 @@
 set -u
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER="$HERE/../scripts/review-checks.sh"
-GUIDE="$HERE/../.github/REVIEW_GUIDE.md"
+GUIDE="$HERE/../REVIEW.md"
 
 pass=0; fail=0
 # check <name> <expect: flag|clean> <diff> [extra-args...]
@@ -44,9 +44,9 @@ check "empty diff exits 0 (nothing to check)"         clean $''
 
 # --- guide's own checks: block is parseable ----------------------------------
 if grep -q "hardcoded-paths:" "$GUIDE" && grep -qE "^\s*flag:" "$GUIDE"; then
-    echo "ok   REVIEW_GUIDE.md carries a hardcoded-paths checks: block"; pass=$((pass+1))
+    echo "ok   REVIEW.md carries a hardcoded-paths checks: block"; pass=$((pass+1))
 else
-    echo "FAIL REVIEW_GUIDE.md missing checks: block"; fail=$((fail+1))
+    echo "FAIL REVIEW.md missing checks: block"; fail=$((fail+1))
 fi
 
 echo "---"

--- a/tests/review-checks.test.sh
+++ b/tests/review-checks.test.sh
@@ -42,6 +42,22 @@ check "explicit --guide is honored"                   flag  $'+++ b/z.ts\n@@ -1,
 check "missing guide falls back, still flags /Users/" flag  $'+++ b/z.ts\n@@ -1,0 +1,1 @@\n+const p="/Users/a/b";' --guide /does/not/exist
 check "empty diff exits 0 (nothing to check)"         clean $''
 
+# --- oversized input can't silently bypass the scan (#2281) -------------------
+# A diff far larger than the OS argv/env limit (~1MB on macOS) used to be handed
+# to the Python scanner via the RC_DIFF env var, which blew 'Argument list too
+# long' — the scanner never launched, yet the runner still printed PASS/exit 0.
+# Streamed via stdin the embedded hardcoded path must still be flagged (exit 1),
+# and it must never silently PASS.
+big_out="$( { printf '+++ b/big.js\n@@ -1,0 +1,200001 @@\n'; \
+              yes '+const filler = resolveWorkspace();' | head -n 200000; \
+              printf '+const home = "/Users/alice/secret";\n'; } \
+            | bash "$RUNNER" 2>/dev/null )"; big_rc=$?
+if [ "$big_rc" = 1 ] && [ -z "$big_out" ]; then
+    echo "ok   oversized diff still flags (no silent PASS)"; pass=$((pass+1))
+else
+    echo "FAIL oversized diff bypassed scan (rc=$big_rc, stdout='$big_out')"; fail=$((fail+1))
+fi
+
 # --- guide's own checks: block is parseable ----------------------------------
 if grep -q "hardcoded-paths:" "$GUIDE" && grep -qE "^\s*flag:" "$GUIDE"; then
     echo "ok   REVIEW.md carries a hardcoded-paths checks: block"; pass=$((pass+1))


### PR DESCRIPTION
## What & why

Chi asked (2026-07-22, and gave the go today) for the review-guide's lessons to live *in the repo* and drive a *generic* review tool — so following the guide is **structurally enforced**, not dependent on an agent remembering to. This implements design v3 (`workspace/notes/design-repo-scoped-reviewer-guide.md`).

Splits **generic mechanics** from **repo-specific criteria**:

- **`.github/REVIEW_GUIDE.md`** — single source of truth. Prose lessons (fed to the codex reviewer as criteria) + a machine-readable ```yaml `checks:` ``` block (hardcoded-path `flag`/`allow` patterns). Adding a lesson or a check is a PR to *this file*, not a code change to the tooling.
- **`scripts/review-checks.sh`** (+ `review-checks.py`) — standalone, codex-free runner. Reads the guide's `checks:` block and scans a diff's added lines. Generic-default fallback when a repo has no guide (degrades safely). Skips docs/tests/self (path literals are legitimate *data* there, not shipping code).
- **`.github/workflows/ci.yml`** — runs the runner on **every PR diff** (`gh pr diff | review-checks.sh`), so the guide gates **all** PRs unconditionally — the big win over v1 (which only reached the team-tier codex path).
- **`review-pr.sh`** — now calls the shared runner (**supersedes the baked-in scanner**), surfacing the same mechanical findings ahead of the codex verdict.
- **`tests/review-checks.test.sh`** — 15 checks: folds the #2229 hardcoded-path fixtures (comment-skip, per-token allow anchoring so `/tmp/` can't mask `/Users/tmp/…`, mixed forbidden+allowed lines) + guide-driven patterns, fallback, and file-skip.

## Closes #2229
Its hardcoded-path scan now lives in the shared, guide-driven runner (patterns moved out of the tool and into `REVIEW_GUIDE.md`).

## Verification
- `bash tests/review-checks.test.sh` → 15/15.
- Self-check: this PR's own diff passes the new gate (`git diff | review-checks.sh` → clean).
- Robust on macOS bash 3.2 (avoids heredoc-in-`$()` and the O(pathological) `${var//…/}` whitespace-strip on large diffs — both silently hang there; the Python scanner + regex non-empty checks fix it).

## Note for reviewers
The CI gate flags **new** hardcoded paths in a PR's added lines only — it never scans existing/merged code, so it can't retroactively break anything. A genuine fixture path can be allow-listed by editing `REVIEW_GUIDE.md`.

Stand: Echo Act IV Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rq18tfPmFcgzHQFgoSpsUN