### PR TITLE
fix(task-progress): validate Discord mentions before posting

### DIFF
--- a/skills/task-progress/SKILL.md
+++ b/skills/task-progress/SKILL.md
@@ -116,6 +116,16 @@ Optional for Slack @mentions: `reply_thread_ts:` → `--thread-ts`
 - **Discord** — REST v10 messages, token from `$CLAUDE_CONFIG_DIR/channels/discord/.env` (`DISCORD_BOT_TOKEN`)
 - **Telegram** — `sendMessage`, token from `$CLAUDE_CONFIG_DIR/channels/telegram/.env` (`TELEGRAM_BOT_TOKEN`)
 
+### Discord mentions
+
+Discord mention validation is on by default. Use a resolved user snowflake
+(`<@USER_ID>`), not a GitHub-style `@handle`. Before posting, `notify.py`
+checks each user ID through Discord; after posting, it verifies the response's
+`mentions` array. An unresolved mention exits 1 with an agent-visible error.
+
+For intentional plain-text handles that should not ping anyone, pass
+`--no-validate-mentions`.
+
 ## Fail-open
 
 A failed send (missing token, network error) prints a warning to stderr and exits 1.

--- a/skills/task-progress/manifest.json
+++ b/skills/task-progress/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "task-progress",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "owner": "github:sonichi/sutando",
   "license": "MIT",
   "stability": "experimental",

--- a/skills/task-progress/scripts/notify.py
+++ b/skills/task-progress/scripts/notify.py
@@ -26,10 +26,13 @@ import re
 import sys
 import urllib.request
 from pathlib import Path
+from typing import Optional
 
 
 MAX_PROGRESS_CHARS = 280
 MAX_PROGRESS_LINES = 4
+_DISCORD_USER_MENTION_RE = re.compile(r"<@!?([0-9]{17,20})>")
+_PLAIN_AT_MENTION_RE = re.compile(r"(?<![\w@])@([A-Za-z0-9_.-]{2,64})")
 
 
 def _progress_message_error(message: str) -> str | None:
@@ -95,6 +98,32 @@ def _post(url: str, payload: dict, headers: dict) -> bool:
         return False
 
 
+def _discord_request(url: str, token: str, payload: Optional[dict] = None):
+    """Make a Discord JSON request and return its response body, or None."""
+    try:
+        data = json.dumps(payload).encode() if payload is not None else None
+        headers = {
+            "Authorization": f"Bot {token}",
+            "User-Agent": "DiscordBot (https://github.com/sonichi/sutando, 1.0)",
+        }
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(url, data=data, headers=headers)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read())
+    except Exception as e:
+        print(f"[task-progress] Discord request failed: {e}", file=sys.stderr)
+        return None
+
+
+def _discord_mentions(message: str):
+    """Return (structured user ids, unresolved plain @handles), preserving order."""
+    user_ids = list(dict.fromkeys(_DISCORD_USER_MENTION_RE.findall(message)))
+    without_structured = _DISCORD_USER_MENTION_RE.sub("", message)
+    plain_handles = list(dict.fromkeys(_PLAIN_AT_MENTION_RE.findall(without_structured)))
+    return user_ids, plain_handles
+
+
 def send_slack(channel_id: str, message: str, thread_ts: str | None = None) -> bool:
     token = _token("slack", "SLACK_BOT_TOKEN")
     if not token:
@@ -110,20 +139,67 @@ def send_slack(channel_id: str, message: str, thread_ts: str | None = None) -> b
     )
 
 
-def send_discord(channel_id: str, message: str) -> bool:
+def send_discord(channel_id: str, message: str, validate_mentions: bool = True) -> bool:
     token = _token("discord", "DISCORD_BOT_TOKEN")
     if not token:
         print("[task-progress] DISCORD_BOT_TOKEN not found", file=sys.stderr)
         return False
-    return _post(
+    user_ids, plain_handles = _discord_mentions(message)
+    if validate_mentions and plain_handles:
+        rendered = ", ".join(f"@{handle}" for handle in plain_handles)
+        print(
+            "[task-progress] unresolved Discord mention(s): "
+            f"{rendered}. Use <@USER_ID>, or --no-validate-mentions for "
+            "intentional plain-text handles.",
+            file=sys.stderr,
+        )
+        return False
+
+    if validate_mentions:
+        for user_id in user_ids:
+            resolved = _discord_request(
+                f"https://discord.com/api/v10/users/{user_id}", token
+            )
+            if not isinstance(resolved, dict) or str(resolved.get("id")) != user_id:
+                print(
+                    f"[task-progress] Discord mention <@{user_id}> did not resolve; "
+                    "message was not sent.",
+                    file=sys.stderr,
+                )
+                return False
+
+    payload = {
+        "content": message,
+        "allowed_mentions": {
+            "parse": [],
+            "users": user_ids,
+            "replied_user": False,
+        },
+    }
+    posted = _discord_request(
         f"https://discord.com/api/v10/channels/{channel_id}/messages",
-        {"content": message},
-        # Discord's API (behind Cloudflare) 403s the default `Python-urllib/x`
-        # User-Agent with Cloudflare error 1010. Discord requires the
-        # `DiscordBot ($url, $version)` UA format — send it or every POST fails.
-        {"Authorization": f"Bot {token}",
-         "User-Agent": "DiscordBot (https://github.com/sonichi/sutando, 1.0)"},
+        token,
+        payload,
     )
+    if not isinstance(posted, dict):
+        return False
+
+    if validate_mentions:
+        resolved_ids = {
+            str(mention.get("id"))
+            for mention in posted.get("mentions", [])
+            if isinstance(mention, dict)
+        }
+        missing = [user_id for user_id in user_ids if user_id not in resolved_ids]
+        if missing:
+            rendered = ", ".join(f"<@{user_id}>" for user_id in missing)
+            print(
+                "[task-progress] Discord posted the message but did not resolve "
+                f"expected mention(s): {rendered}.",
+                file=sys.stderr,
+            )
+            return False
+    return True
 
 
 def send_telegram(chat_id: str, message: str) -> bool:
@@ -209,6 +285,11 @@ def main() -> int:
     parser.add_argument("--chat-id", help="Telegram chat ID (alias for --channel-id on telegram)")
     parser.add_argument("--thread-ts", default=None,
                         help="Slack thread timestamp for threaded replies")
+    parser.add_argument(
+        "--no-validate-mentions",
+        action="store_true",
+        help="Discord only: allow intentional plain-text @handles and skip mention checks",
+    )
     parser.add_argument("--message", required=True, help="Text to send")
     args = parser.parse_args()
 
@@ -233,7 +314,11 @@ def main() -> int:
     if source == "slack":
         ok = send_slack(channel, message, thread_ts=args.thread_ts)
     elif source == "discord":
-        ok = send_discord(channel, message)
+        ok = send_discord(
+            channel,
+            message,
+            validate_mentions=not args.no_validate_mentions,
+        )
     elif source == "telegram":
         ok = send_telegram(channel, message)
     else:

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -169,6 +169,22 @@ class TestSendDiscord(unittest.TestCase):
             result = self.mod.send_discord("111", "hello")
         self.assertFalse(result)
 
+    def test_discord_request_api_error_returns_none(self):
+        with patch("urllib.request.urlopen", side_effect=Exception("timeout")), \
+             patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            result = self.mod._discord_request(
+                "https://discord.com/api/v10/users/123",
+                "Bot-fake",
+            )
+        self.assertIsNone(result)
+        self.assertIn("Discord request failed: timeout", stderr.getvalue())
+
+    def test_post_failure_returns_false(self):
+        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
+             patch.object(self.mod, "_discord_request", return_value=None):
+            result = self.mod.send_discord("111", "hello")
+        self.assertFalse(result)
+
     def test_plain_at_handle_is_rejected_before_post(self):
         with patch.object(self.mod, "_token", return_value="Bot-fake"), \
              patch.object(self.mod, "_discord_request") as request, \

--- a/tests/task-progress-skill.test.py
+++ b/tests/task-progress-skill.test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
 import subprocess
@@ -148,11 +149,16 @@ class TestSendDiscord(unittest.TestCase):
     def setUp(self):
         self.mod = _load()
 
+    @staticmethod
+    def _response(body):
+        response = MagicMock()
+        response.__enter__ = lambda s: s
+        response.__exit__ = MagicMock(return_value=False)
+        response.read.return_value = json.dumps(body).encode()
+        return response
+
     def test_success(self):
-        mock_resp = MagicMock()
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_resp.read.return_value = b'{"id": "msg123"}'
+        mock_resp = self._response({"id": "msg123", "mentions": []})
         with patch.object(self.mod, "_token", return_value="Bot-fake"), \
              patch("urllib.request.urlopen", return_value=mock_resp):
             result = self.mod.send_discord("111222333", "hello")
@@ -162,6 +168,114 @@ class TestSendDiscord(unittest.TestCase):
         with patch.object(self.mod, "_token", return_value=""):
             result = self.mod.send_discord("111", "hello")
         self.assertFalse(result)
+
+    def test_plain_at_handle_is_rejected_before_post(self):
+        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
+             patch.object(self.mod, "_discord_request") as request, \
+             patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            result = self.mod.send_discord("111", "Please review, @qingyun-wu")
+        self.assertFalse(result)
+        request.assert_not_called()
+        self.assertIn("unresolved Discord mention(s): @qingyun-wu", stderr.getvalue())
+
+    def test_email_address_is_not_treated_as_a_mention(self):
+        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
+             patch.object(
+                 self.mod,
+                 "_discord_request",
+                 return_value={"id": "msg123", "mentions": []},
+             ) as request:
+            result = self.mod.send_discord("111", "Email dev@example.com")
+        self.assertTrue(result)
+        self.assertEqual(request.call_count, 1)
+
+    def test_structured_mention_is_preflighted_and_verified(self):
+        user_id = "1025828152183885925"
+        posted = {
+            "id": "msg123",
+            "mentions": [{"id": user_id, "username": "qingyunwu"}],
+        }
+        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
+             patch.object(
+                 self.mod,
+                 "_discord_request",
+                 side_effect=[{"id": user_id}, posted],
+             ) as request:
+            result = self.mod.send_discord("111", f"Please review, <@{user_id}>")
+        self.assertTrue(result)
+        self.assertEqual(request.call_count, 2)
+        payload = request.call_args_list[1].args[2]
+        self.assertEqual(payload["allowed_mentions"]["parse"], [])
+        self.assertEqual(payload["allowed_mentions"]["users"], [user_id])
+
+    def test_unresolvable_structured_mention_is_not_posted(self):
+        user_id = "999999999999999999"
+        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
+             patch.object(
+                 self.mod,
+                 "_discord_request",
+                 return_value=None,
+             ) as request, \
+             patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            result = self.mod.send_discord("111", f"Please review, <@{user_id}>")
+        self.assertFalse(result)
+        self.assertEqual(request.call_count, 1)
+        self.assertIn("message was not sent", stderr.getvalue())
+
+    def test_missing_mention_in_post_response_returns_error(self):
+        user_id = "1025828152183885925"
+        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
+             patch.object(
+                 self.mod,
+                 "_discord_request",
+                 side_effect=[{"id": user_id}, {"id": "msg123", "mentions": []}],
+             ), \
+             patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            result = self.mod.send_discord("111", f"Please review, <@{user_id}>")
+        self.assertFalse(result)
+        self.assertIn("did not resolve expected mention", stderr.getvalue())
+
+    def test_validation_can_be_disabled_for_plain_text_handle(self):
+        with patch.object(self.mod, "_token", return_value="Bot-fake"), \
+             patch.object(
+                 self.mod,
+                 "_discord_request",
+                 return_value={"id": "msg123", "mentions": []},
+             ) as request:
+            result = self.mod.send_discord(
+                "111",
+                "GitHub author @qingyun-wu",
+                validate_mentions=False,
+            )
+        self.assertTrue(result)
+        self.assertEqual(request.call_count, 1)
+
+    def test_cli_defaults_to_validation_and_returns_agent_visible_error(self):
+        with patch("sys.argv", [
+            "notify.py", "--source", "discord", "--channel-id", "111",
+            "--message", "Please review, @qingyun-wu",
+        ]), patch.object(self.mod, "_token", return_value="Bot-fake"), \
+             patch.object(self.mod, "_discord_request") as request, \
+             patch("sys.stderr", new_callable=io.StringIO) as stderr:
+            result = self.mod.main()
+        self.assertEqual(result, 1)
+        request.assert_not_called()
+        self.assertIn("Use <@USER_ID>", stderr.getvalue())
+
+    def test_cli_opt_out_allows_intentional_plain_text_handle(self):
+        with patch("sys.argv", [
+            "notify.py", "--source", "discord", "--channel-id", "111",
+            "--message", "GitHub author @qingyun-wu",
+            "--no-validate-mentions",
+        ]), patch.object(self.mod, "_token", return_value="Bot-fake"), \
+             patch.object(
+                 self.mod,
+                 "_discord_request",
+                 return_value={"id": "msg123", "mentions": []},
+             ) as request:
+            result = self.mod.main()
+        self.assertEqual(result, 0)
+        self.assertEqual(request.call_count, 1)
 
 
 class TestSendTelegram(unittest.TestCase):


### PR DESCRIPTION
## What changed and why

Discord progress notifications now validate intended user mentions by default. Plain `@handles` fail before POST with an agent-visible correction, structured `<@USER_ID>` mentions are resolved through Discord before POST, `allowed_mentions` is restricted to those users, and the returned message is checked to confirm every intended mention resolved. `--no-validate-mentions` preserves intentional plain-text handles.

The owner requested this after two #dev author-action messages posted successfully but pinged nobody.

## Review first

- `skills/task-progress/scripts/notify.py`: parsing, preflight, restricted POST, response verification
- `tests/task-progress-skill.test.py`: default-on, failure, opt-out, email, and response checks
- `skills/task-progress/SKILL.md`: caller contract

## User-visible proof

### Failing before (`origin/main`, live Discord)

Two real #dev messages were accepted by Discord with unresolved GitHub-style handles:

- message `1529912452144169153`: content contained `@qingyun-wu`; API `mentions: []`
- message `1529912454803488901`: content contained `@liususan091219` and `@qingyun-wu`; API `mentions: []`

The old sender returned success because it discarded the Discord message response.

### Passing after (`da8cd78`, live Discord DM)

Using the branch script against the live API:

```text
plain @handle preflight        -> exit 1; clear unresolved-mention error; 0 messages posted
unknown <@999999999999999999> -> exit 1 after Discord 404; 0 messages posted
valid <@1358841611580080168>  -> exit 0; message 1529916915961692292 posted
Discord API response           -> mentions: [1358841611580080168]
```

The successful live test targeted the requesting owner in the originating DM, avoiding an unrelated-user ping.

## Automated tests

- `python3 tests/task-progress-skill.test.py` — 36/36 passed
- `python3 -m py_compile skills/task-progress/scripts/notify.py tests/task-progress-skill.test.py` — passed
- `git diff --check` — passed

Local Ruff could not run because the installed binary predates this repository’s `[lint]` config schema; CI will run the repository-supported Ruff version.

## Edge cases

- Email addresses such as `dev@example.com` are not classified as mentions.
- Duplicate mentions are deduplicated while retaining order.
- `@everyone` / `@here` and GitHub-style handles fail by default.
- The opt-out posts intentional plain-text handles without pinging them.
- `allowed_mentions.parse` is empty, so Discord cannot expand unrequested mention classes.

## Migrations, permissions, rollback, risks

No migration or new permission is required. Structured mentions add one Discord `GET /users/{id}` preflight per unique user. Rollback is the single commit. The behavior change is intentionally fail-closed for ambiguous plain handles; callers can explicitly opt out.

## Known gaps / follow-up

This focused PR covers the task-progress Discord writer that produced the incident. Other Discord delivery paths should adopt the same helper in a separate consolidation PR rather than expanding this change.