### PR TITLE
docs: define the Sutando core boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ We're looking for contributors to help test and harden these capabilities. If yo
 
 ## How it works
 
+See [Sutando architecture boundaries](docs/architecture-boundaries.md) for the
+normative definitions of core, adapters, apps, skills, tooling, and workspace
+state.
+
 ```
     You ──voice (browser)──► Voice agent ─────────┐
      │                       (Gemini Live,        │

--- a/docs/architecture-boundaries.md
+++ b/docs/architecture-boundaries.md
@@ -1,0 +1,208 @@
+# Sutando architecture boundaries
+
+**Status:** Proposed boundary for incremental adoption. This document classifies
+the current repository; it does not imply that every existing dependency already
+follows the target rules.
+
+Sutando's open-source core is intended to be the common execution foundation for
+the community product and future distributions, including Sutando Enterprise.
+Product surfaces and optional capabilities may differ, but they should consume
+the same versioned core rather than fork it.
+
+## Definitions
+
+### Core
+
+Core is the smallest surface-independent runtime that can accept an authorized
+task, execute registered capabilities, and route a result while maintaining its
+workspace and lifecycle.
+
+Core owns:
+
+- task and result envelopes, validation, queueing, and routing;
+- identity, access-tier, capability, and policy decisions;
+- workspace/config resolution and shared state-path contracts;
+- agent lifecycle, task-watcher, health, and liveness primitives;
+- public tool/plugin registration interfaces;
+- provider-neutral conversation/session contracts;
+- provider-neutral audit and observability event contracts.
+
+Core must not depend on:
+
+- a messaging or telephony provider;
+- a model vendor;
+- a UI application;
+- a particular skill or business workflow;
+- enterprise-only policy, identity, or deployment code.
+
+Removing every adapter, app, and skill should still leave an independently
+buildable and testable core.
+
+### Adapter
+
+An adapter translates an external system into or out of a core contract. Examples
+include Discord, Slack, Telegram, Twilio, remote gateways, model providers, and
+OS-specific integrations.
+
+Adapters may depend on the public core API. Core must not import an adapter.
+
+### App
+
+An app is a user-facing process or UI assembled from core plus adapters. The
+desktop app, web client, browser voice surface, and phone service are apps or app
+components. Apps choose configuration and presentation; they do not define core
+policy.
+
+### Skill
+
+A skill is an optional capability or workflow under `skills/<name>/`. Installing
+or removing a skill must not change whether core can boot. Skills may use the
+public SDK and declared capability interfaces. They should not import arbitrary
+core internals or another skill's implementation.
+
+### Tooling
+
+Build, migration, release, test, and repository-maintenance scripts are tooling.
+Tooling may inspect multiple layers but is not part of the runtime dependency
+graph.
+
+### Workspace
+
+The resolved `workspace/` is mutable user state, not product code. Its layout and
+confidentiality rules are defined by the
+[Workspace Contract](workspace-contract.md).
+
+## Dependency direction
+
+The intended runtime dependency flow is:
+
+```text
+schemas / public contracts
+            ↓
+           core
+            ↓
+    adapters and skills
+            ↓
+           apps
+```
+
+Allowed:
+
+- core → schemas/public contracts;
+- adapters → public core API;
+- skills → public SDK and declared capability interfaces;
+- apps → core, adapters, and skills;
+- tooling/tests → any layer needed to build or verify it.
+
+Disallowed:
+
+- core → adapters, apps, or skills;
+- adapter → another adapter's private implementation;
+- skill → another skill's private implementation;
+- skill/adapter → private core modules when a public contract exists;
+- enterprise code → unpublished core internals.
+
+Shared behavior needed by multiple adapters belongs in core only when it is
+provider-neutral. Otherwise it belongs in an adapter library.
+
+## Current repository classification
+
+This is the ownership intent for today's paths. Several rows contain known
+boundary debt; the physical moves and dependency cleanup will happen separately.
+For a generated file-by-file inventory of `src/`, see the
+[source module map](src-map.md).
+
+| Current path | Classification | Notes |
+|---|---|---|
+| `schemas/` | Contracts | Canonical wire/config schemas; should remain dependency-light. |
+| `src/agent/`, task watcher/bridge, local task protocol, result routing | Core | Execution lifecycle and provider-neutral task/result plumbing. |
+| Workspace/config/path, access-tier, health, heartbeat primitives in `src/` | Core | Shared infrastructure used across surfaces. |
+| `src/discord-bridge.py`, `src/slack-bridge.py`, `src/telegram-bridge.py`, remote-gateway bridges | Adapters | Currently stored under `src/`; target ownership is adapter, not core. |
+| `src/voice-agent.ts` | App/runtime composition | Wires a voice provider and browser session to core contracts. |
+| `src/web-client.ts`, `src/Sutando/` | Apps | Web and macOS presentation/application code. |
+| `src/inline-tools.ts` | Mixed boundary debt | Registration framework is core-facing; concrete feature/provider tools should live in skills/adapters. |
+| `src/recording-tools.ts` and other feature-specific tool implementations | Skills/adapters | Existing core-to-feature coupling to remove through registration interfaces. |
+| `skills/phone-conversation/` | Phone app/adapter | Deliberate historical exception: call transport/lifecycle is physically skill-shaped but is not generic core. |
+| Other `skills/<name>/` | Skills | Optional capabilities and workflows. Coupled skills are migration candidates for the public SDK. |
+| `packages/ag2-sparrow/` | Independent package/adapter | Separately packaged gateway support, not core. |
+| `scripts/`, `hooks/`, `.github/` | Tooling/governance | Build, migration, repository policy, and CI. |
+| `tests/` | Verification | Tests should be tagged or grouped by the layer they protect. |
+| resolved `workspace/` | User state | Never product source and never part of a distributable core artifact. |
+
+## Known boundary debt
+
+The current tree has two forms of coupling that must be removed before a physical
+core extraction:
+
+1. Some `src/` modules locate or import concrete skill implementations.
+2. Some skills import internal modules directly from `src/`.
+
+Both should move toward dependency inversion:
+
+- core exposes a narrow contract or registration hook;
+- adapters/skills implement and register it;
+- apps select which implementations to assemble;
+- compatibility shims preserve current prompts, tool names, and behavior during
+  migration.
+
+Moving files without first removing these dependencies would make the boundary
+look cleaner without making it real.
+
+## Decision guide for new code
+
+Walk this list top to bottom:
+
+1. Is it a provider-neutral task, policy, workspace, lifecycle, or plugin
+   contract required with all optional components removed? **Core.**
+2. Does it translate a third-party API, model provider, OS API, or transport?
+   **Adapter.**
+3. Is it a user-facing process that assembles core and adapters? **App.**
+4. Is it an optional capability or business workflow? **Skill.**
+5. Is it used only to build, migrate, test, release, or maintain the repository?
+   **Tooling.**
+6. Is it mutable per-user data? **Workspace, not code.**
+
+If a module appears to fit two layers, split the provider-neutral contract from
+the provider/feature implementation. Prefer the more specific outer layer for
+the implementation.
+
+## Core change governance
+
+Until the core is independently packaged, a "core change" means a change to the
+paths classified as core or contracts above, or any change that alters their
+public behavior.
+
+Core changes should eventually require:
+
+- dedicated core code owners;
+- two current-head approvals from core maintainers;
+- stale approval dismissal after new commits;
+- approval from someone other than the last pusher;
+- no direct pushes or routine admin bypass to the protected branch;
+- full unit, contract, integration, compatibility, and security checks;
+- an ADR and threat-model update for public API or security-boundary changes.
+
+Repository rules and CI enforcement are follow-up work. This document defines
+the boundary they will protect.
+
+## Enterprise relationship
+
+Sutando Enterprise should consume released, immutable OSS core artifacts and run
+the same core contract suite against the exact artifact digest it ships.
+Enterprise-only SSO/SCIM, tenant administration, audit exporters, deployment
+controls, proprietary connectors, and policy packs stay outside the OSS core.
+
+The enterprise product may extend public interfaces; it must not patch private
+core internals or maintain a long-lived core fork.
+
+## Migration principles
+
+- Classify and test before moving files.
+- One concern per PR; no big-bang directory rewrite.
+- Preserve prompts, tool names, and behavior exactly while changing boundaries.
+- Add dependency-direction checks with a temporary allowlist for known debt.
+- Reduce the allowlist monotonically.
+- Extract independently buildable core packages only after forbidden imports are
+  gone.
+- Consider a separate public core repository only after the package boundary is
+  proven inside this repository.

--- a/docs/architecture-boundaries.md
+++ b/docs/architecture-boundaries.md
@@ -150,6 +150,11 @@ look cleaner without making it real.
 
 ## Decision guide for new code
 
+This section explains the architectural categories. The repository-specific
+placement checklist in `AGENTS.md` / `CLAUDE.md` remains authoritative for
+current file locations; update both documents together if the placement rules
+change.
+
 Walk this list top to bottom:
 
 1. Is it a provider-neutral task, policy, workspace, lifecycle, or plugin


### PR DESCRIPTION
## What changed and why

Adds a normative architecture-boundary guide so contributors can distinguish the shared OSS core from adapters, apps, skills, tooling, and mutable workspace state. This is the documentation-first step requested before any enterprise-readiness refactor.

The guide defines:

- what core owns and must not depend on;
- allowed dependency directions;
- an initial classification of current repository paths;
- known core/skill coupling debt;
- a decision guide for new code;
- intended governance for protected core changes;
- how a future Sutando Enterprise distribution consumes the same OSS core without forking it;
- incremental migration principles that preserve prompts and tool behavior.

README now links the guide from “How it works.”

## Review first

- `docs/architecture-boundaries.md`: definitions, current-path classification, and dependency rules.
- `README.md`: discoverability link only.

## User behavior or bug proved

Documentation-only. It resolves the current ambiguity where `src/` contains both shared infrastructure and peripheral adapters/apps, while the phone adapter is physically under `skills/`.

## Tests

- Checked every local link in `docs/architecture-boundaries.md`; zero missing.
- Confirmed the README architecture link targets the new file.
- `git diff --check` passes.

## Edge cases

The guide explicitly labels itself as a proposed boundary for incremental adoption, distinguishes ownership intent from current dependency reality, documents mixed-boundary files, and avoids claiming that file moves have already happened.

## Migrations, config, permissions, rollback, deployment risk

N/A. Documentation only; no runtime, prompt, tool, config, or permission changes. Rollback is the single commit.

## Known gaps / follow-up

Enforcement is deliberately out of scope. Follow-ups may add a machine-readable component map, dependency-direction CI, core CODEOWNERS/review gates, public SDK contracts, and finally physical moves after coupling is removed.