### PR TITLE
fix(startup): let a minted managed Gemini credential enable voice

### DIFF
--- a/src/startup-runtime.sh
+++ b/src/startup-runtime.sh
@@ -8,12 +8,40 @@ configure_startup_runtime() {
     echo "  ~ .env not found — continuing with credential-free services"
   fi
 
-  if [ -z "${GEMINI_VOICE_API_KEY:-${GEMINI_API_KEY:-}}" ]; then
+  if [ -n "${GEMINI_VOICE_API_KEY:-${GEMINI_API_KEY:-}}" ]; then
+    unset SKIP_VOICE
+  elif managed_gemini_credential_present; then
+    unset SKIP_VOICE
+    echo "  ✓ voice credential: managed (state/auth/managed-credentials.json)"
+  else
     export SKIP_VOICE=1
     echo "  ~ voice agent disabled (set GEMINI_VOICE_API_KEY or GEMINI_API_KEY to enable)"
-  else
-    unset SKIP_VOICE
   fi
+}
+
+# G8 managed tier (see src/credential-resolver.ts): the desktop app mints
+# <workspace>/state/auth/managed-credentials.json instead of exporting BYO env
+# keys, and voice-key.ts resolves it at runtime. A minted gemini capability must
+# therefore enable voice the same way an env key does — the env-only check above
+# left a managed-only install booting with SKIP_VOICE=1 while the voice-agent
+# itself would have connected fine (observed live 2026-07-23). Mirrors the
+# resolver's presence semantics: gemini-voice falls back to gemini-text, any
+# non-empty key counts; expiry/refresh stay the resolver's concern.
+managed_gemini_credential_present() {
+  local ws file
+  ws="$(bash scripts/sutando-config.sh workspace 2>/dev/null)"
+  [ -n "$ws" ] || ws="workspace"
+  file="$ws/state/auth/managed-credentials.json"
+  [ -f "$file" ] || return 1
+  python3 -c '
+import json, sys
+try:
+    caps = json.load(open(sys.argv[1])).get("capabilities") or {}
+except Exception:
+    sys.exit(1)
+slots = ("gemini-voice", "gemini-text")
+sys.exit(0 if any(isinstance(caps.get(s), dict) and caps[s].get("key") for s in slots) else 1)
+' "$file" 2>/dev/null
 }
 
 phone_stack_enabled() {

--- a/tests/startup-voice-optional.test.sh
+++ b/tests/startup-voice-optional.test.sh
@@ -32,6 +32,30 @@ if grep -q 'voice agent disabled' <<<"$with_voice_key"; then
   exit 1
 fi
 
+# G8 managed tier: a minted managed-credentials.json (desktop-provisioned, no
+# env keys) must enable voice too — the resolver reads it at runtime, so the
+# startup gate may not skip the service. Fixture uses the default in-repo
+# workspace location the helper falls back to.
+MANAGED_DIR="$TMP/managed"
+mkdir -p "$MANAGED_DIR/workspace/state/auth"
+printf '{"version":1,"capabilities":{"gemini-voice":{"key":"managed-test-token"}}}\n' \
+  > "$MANAGED_DIR/workspace/state/auth/managed-credentials.json"
+with_managed="$(env -i PATH="/usr/bin:/bin" \
+  bash -c 'cd "$1"; source "$2/src/startup-runtime.sh"; configure_startup_runtime; printf "SKIP_VOICE=%s\n" "${SKIP_VOICE:-0}"' \
+  _ "$MANAGED_DIR" "$REPO")"
+grep -q 'SKIP_VOICE=0' <<<"$with_managed"
+grep -q 'voice credential: managed' <<<"$with_managed"
+
+# A managed file whose capabilities carry no usable key must NOT enable voice —
+# presence of the file alone is not a credential.
+printf '{"version":1,"capabilities":{"gemini-voice":{"key":""}}}\n' \
+  > "$MANAGED_DIR/workspace/state/auth/managed-credentials.json"
+managed_keyless="$(env -i PATH="/usr/bin:/bin" \
+  bash -c 'cd "$1"; source "$2/src/startup-runtime.sh"; configure_startup_runtime; printf "SKIP_VOICE=%s\n" "${SKIP_VOICE:-0}"' \
+  _ "$MANAGED_DIR" "$REPO")"
+grep -q 'SKIP_VOICE=1' <<<"$managed_keyless"
+grep -q 'voice agent disabled' <<<"$managed_keyless"
+
 # The phone stack shares the Gemini voice session and must stay down when
 # credential-free startup sets SKIP_VOICE, even if Twilio is configured.
 phone_gate="$(env -i PATH="/usr/bin:/bin" bash -c '


### PR DESCRIPTION
## Problem

`configure_startup_runtime` (src/startup-runtime.sh) decides `SKIP_VOICE` from the BYO env keys alone (`GEMINI_VOICE_API_KEY` / `GEMINI_API_KEY`). On a managed-mode install there are no env keys — the desktop app mints `<workspace>/state/auth/managed-credentials.json` (G8 contract, `src/credential-resolver.ts`) and `voice-key.ts` resolves it at runtime. Result: startup sets `SKIP_VOICE=1` and the voice-agent never launches, even though it would connect fine.

Observed live 2026-07-23 on a managed-only install: credential minted and valid, voice-agent down; launching `dist/voice-agent.js` manually connected to Gemini Live immediately (`[VoiceSession] LLM transport connected`).

## Fix

If no env key is present, check the managed file for a `gemini-voice` (fallback `gemini-text`) capability with a non-empty key — the same presence semantics the resolver uses. Expiry/refresh remain the resolver's concern. When the managed tier is what enabled voice, print `✓ voice credential: managed (…)` per G8's source-observability goal.

**Compatibility:** with no managed file the gate behaves byte-identically to today, so this is inert on plain/BYOK installs and on main until the G8 writer lands (#2131 / #2262 / #2197 — none of which touch this gate).

## Tests

Extended `tests/startup-voice-optional.test.sh`: a minted managed file enables voice (SKIP_VOICE=0 + managed message); a keyless managed file does not (SKIP_VOICE=1). All pre-existing cases pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)