### PR TITLE
fix(task-priority): demote non-owner Slack tasks like discord/telegram

### DIFF
--- a/src/task_priority.py
+++ b/src/task_priority.py
@@ -8,8 +8,8 @@ lease-based scheduler; today this is just machine-readable metadata.
 Defaults by source (writers emit these; consumers can override per call):
   voice, phone            -> "urgent"   (sub-second response expected)
   chat, context-drop      -> "normal"   (owner foreground)
-  discord, telegram (owner-tier)        -> "normal"
-  discord, telegram (team/other-tier)   -> "low"
+  discord, telegram, slack (owner-tier)        -> "normal"
+  discord, telegram, slack (team/other-tier)   -> "low"
   health-check, sync-memory, sync-workspace, cron -> "low"
 
 Anything not recognized parses as "normal" (fail-open). Order on disk:
@@ -43,9 +43,12 @@ def default_priority_for_source(source: str, access_tier: str | None = None) -> 
         return "urgent"
     if s in ("chat", "context-drop"):
         return "normal"
-    if s in ("discord", "telegram"):
+    if s in ("discord", "telegram", "slack"):
         # Owner-tier traffic stays at normal; team/other gets demoted so a
-        # public-channel ping never preempts an owner-DM follow-up.
+        # public-channel ping never preempts an owner-DM follow-up. Slack was
+        # omitted originally (Air's finding 2026-07-24) — it carries the exact
+        # same owner/team/other tier model as discord, so its non-owner tasks
+        # must demote identically or a team-tier Slack ping outranks owner work.
         return "normal" if (access_tier or "owner").lower() == "owner" else "low"
     if s in ("health-check", "sync-memory", "sync-workspace", "cron"):
         return "low"

--- a/tests/task-priority.test.py
+++ b/tests/task-priority.test.py
@@ -53,6 +53,15 @@ class TestEnumAndDefaults(unittest.TestCase):
         self.assertEqual(default_priority_for_source("telegram", "owner"), "normal")
         self.assertEqual(default_priority_for_source("telegram", "team"), "low")
 
+    def test_slack_owner_tier_normal_other_tier_low(self):
+        # Slack carries the same owner/team/other tier model as discord — its
+        # non-owner tasks must demote identically (Air's finding 2026-07-24;
+        # slack was omitted from the tier branch originally).
+        self.assertEqual(default_priority_for_source("slack", "owner"), "normal")
+        self.assertEqual(default_priority_for_source("slack", "team"), "low")
+        self.assertEqual(default_priority_for_source("slack", "other"), "low")
+        self.assertEqual(default_priority_for_source("slack", None), "normal")
+
     def test_health_check_and_cron_default_low(self):
         self.assertEqual(default_priority_for_source("health-check"), "low")
         self.assertEqual(default_priority_for_source("sync-memory"), "low")


### PR DESCRIPTION
## Bug (found by @qingyun-air.agent, 2026-07-24)
`default_priority_for_source()` demotes team/other-tier **discord** + **telegram** tasks to `low` — so a public-channel ping never preempts an owner-DM follow-up — but the branch **omitted `slack`**. Since Slack carries the same owner/team/other tier model (per the Slack access-control block in CLAUDE.md), a team-tier Slack task stayed at `normal` and could outrank genuine owner work in the pending queue.

## Fix
- Add `slack` to the tier-demotion branch (+ docstring).
- +4 test assertions: owner→normal, team/other→low, None→owner-default.

`tests/task-priority.test.py`: 16/16 green.

One-line behavior fix; scope limited to Slack (didn't touch `ag2space`, whose tiering is resolved differently — separate question if it needs the same).