### PR TITLE
feat(agent-room-ops): rooms verb — client for the joined_rooms room-list op

### DIFF
--- a/skills/agent-room-ops/SKILL.md
+++ b/skills/agent-room-ops/SKILL.md
@@ -18,6 +18,7 @@ does the privileged Matrix ops + authoritative membership enforcement.
 | `react <room> <event>` | add an `m.reaction` (ack) | discord `add_reaction` (👀/✅) |
 | `unreact <room> <event>` | remove the agent's reaction | discord remove-on-reply |
 | `join <room>` | accept the agent's own pending invite | discord guild-join on invite |
+| `rooms` | list the rooms this agent is a member of (`joined_rooms`) | discord `client.guilds` / channel list |
 | `doc get\|put\|rm <room>` | read/write/delete the room's shared **Room Context** docs (context, todo, memos — or any agent-defined folder) | the durable-state half: like a pinned channel wiki the bot can edit |
 
 ```bash
@@ -27,6 +28,7 @@ python3 skills/agent-room-ops/room_ops.py send   '!room:hs' /tmp/pic.png --capti
 python3 skills/agent-room-ops/room_ops.py react  '!room:hs' '$evt' --ack received --agent '@a:hs'
 python3 skills/agent-room-ops/room_ops.py unreact '!room:hs' '$evt' --ack received --agent '@a:hs'
 python3 skills/agent-room-ops/room_ops.py join   '!room:hs' --agent '@a:hs'
+python3 skills/agent-room-ops/room_ops.py rooms  --agent '@a:hs'
 python3 skills/agent-room-ops/room_ops.py doc get '!room:hs' --folder room-todo --name TODO.md --agent '@a:hs'
 python3 skills/agent-room-ops/room_ops.py doc put '!room:hs' --folder room-memo --name note.md --file /tmp/note.md --agent '@a:hs'
 python3 skills/agent-room-ops/room_ops.py doc rm  '!room:hs' --folder room-memo --name note.md --agent '@a:hs'

--- a/skills/agent-room-ops/room_ops.py
+++ b/skills/agent-room-ops/room_ops.py
@@ -30,6 +30,7 @@ import react as _react     # noqa: E402
 import join as _join       # noqa: E402
 import resolve as _resolve # noqa: E402
 import mention as _mention # noqa: E402
+import rooms as _rooms     # noqa: E402
 
 
 def _main(argv):
@@ -65,6 +66,9 @@ def _main(argv):
 
     p = sub.add_parser("join", help="accept this agent's own pending room invite")
     p.add_argument("room_id")
+    p.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
+
+    p = sub.add_parser("rooms", help="list the rooms this agent is a member of")
     p.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
 
     for name in ("react", "unreact"):
@@ -114,6 +118,8 @@ def _main(argv):
                 res = _doc.doc_rm(a.room, a.name, folder=a.folder, agent_mxid=a.agent)
     elif a.cmd == "join":
         res = _join.join_room(a.room_id, a.agent_mxid)
+    elif a.cmd == "rooms":
+        res = _rooms.list_rooms(a.agent_mxid)
     elif a.cmd == "resolve":
         res = _resolve.resolve_user(a.handle)
     elif a.cmd == "mention":

--- a/skills/agent-room-ops/rooms.py
+++ b/skills/agent-room-ops/rooms.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""room-ops · rooms — list the rooms THIS agent is a member of.
+
+Client verb for the `joined_rooms` room-list op (ag2space-backend#180 exposed
+it publicly 2026-07-24; the handler always existed for the presence sweep).
+Returns both shapes the op emits: `rooms` (bare ids, stable/back-compat) and
+`rooms_detailed` ([{room_id, name}] — the usable directory).
+
+Why it matters (the #177 gap): without a room list an agent can't discover
+where it lives, and `create` can't be made idempotent. The conventions rule is
+list-before-create — call this before `create` instead of retrying blind.
+
+Gateway-only like every verb here: the generic `/v1/room` op envelope; no
+platform creds client-side; membership is whatever the agent's own Matrix
+session actually holds (nio's synced room set).
+"""
+from __future__ import annotations
+
+import os
+
+from _gateway import (gate_allows, load_gate, gateway, http_json, degrade_reason,
+                    HTTPError, URLError)
+
+
+def _result(ok, *, rooms=None, rooms_detailed=None, reason=None):
+    return {"ok": bool(ok), "rooms": rooms or [],
+            "rooms_detailed": rooms_detailed or [], "reason": reason}
+
+
+def list_rooms(agent_mxid=None, *, gate=None):
+    """The agent's joined rooms via op:joined_rooms. No room_id input — the
+    subject is the agent itself, so the client gate is checked agent-wide
+    (empty room scope)."""
+    agent_mxid = agent_mxid or os.environ.get("AGENT_MXID")
+    gate = load_gate() if gate is None else gate
+    # Room-scoped gates can't apply (no target room); an agent-level deny still
+    # must hold. Empty room id = the gate's agent-wide rule.
+    if not gate_allows(agent_mxid, "", gate):
+        return _result(False, reason=f"client gate denied for {agent_mxid}")
+    base, headers = gateway()
+    if not base:
+        return _result(False, reason="no gateway configured")
+    try:
+        _status, res = http_json("POST", f"{base}/v1/room", headers,
+                                 {"op": "joined_rooms"})
+    except HTTPError as e:
+        return _result(False, reason=degrade_reason(e.code))
+    except (URLError, TimeoutError) as e:
+        return _result(False, reason=f"network error: {e}")
+    if isinstance(res, dict) and res.get("error"):
+        return _result(False, reason=str(res["error"]))
+    res = res if isinstance(res, dict) else {}
+    return _result(True, rooms=list(res.get("rooms") or []),
+                   rooms_detailed=list(res.get("rooms_detailed") or []))


### PR DESCRIPTION
Owner catch: ag2space-backend#180 exposed `joined_rooms` server-side (merged + deployed today) but the room-ops skill — the official client — had no verb for it. The doc/skill sync rule says the skill implements the platform surface, so:

- **`rooms.py`** — mirrors the `join.py` single-op module pattern (gateway-only, op envelope, `degrade_reason`); returns both shapes (`rooms` bare ids + `rooms_detailed` `[{room_id, name}]`).
- **`room_ops.py rooms`** subcommand + SKILL.md tools-table row + CLI example.

**LIVE E2E verified**: called against the deployed op — returned this agent's real 64 rooms with display names.

Enables the list-before-create idempotence rule the conventions doc (#2290) prescribes. cc @qingyun-air.agent
