### PR TITLE
feat(hooks): human-action-bridge — remote-ask upgrade for AskUserQuestion (v1 step 1)

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -61,6 +61,30 @@ Test: `python3 tests/skip-ask-user-question.test.py` (hook) and
 Config paths are env-overridable for testing: `SUTANDO_DISCORD_ACCESS_FILE`,
 `SUTANDO_DISCORD_ENV_FILE`, `SUTANDO_WORKSPACE`. Test: `python3 tests/context-source-guard.test.py`.
 
+## `human-action-bridge.py`
+
+Upgrades the `AskUserQuestion` hard-deny into a **remote ask** (human-action
+bridge v1 step 1 — design: `workspace notes/tasks-events/human_action_bridge_design.md`).
+On an `AskUserQuestion` call it writes a durable pending-action file
+(`<workspace>/state/human-actions/ha_*.json`), drops a question card for the
+owner (`results/proactive-ha-*.txt` — the sanctioned proactive path), and
+polls the action file for a bounded window. A resolved decision returns
+PreToolUse `allow` with `updatedInput.answers` (Claude continues as if answered
+locally); **timeout or cancellation denies** with the same decide-autonomously
+guidance `skip-ask-user-question.py` ships — so with no resolver present the
+behavior is exactly today's. Timeout NEVER approves; fail-**open** for the
+session, fail-**closed** for the decision. Decisions are written by the sparrow
+`DecisionHandler` (bridge v1 step 3) or by the core when the owner's answer
+arrives as a normal task.
+
+Register under `PreToolUse` matcher `"AskUserQuestion"` **instead of**
+`skip-ask-user-question.py` (the timeout branch subsumes it). Not yet
+auto-registered — flipping `build-core-settings.mjs` over is a follow-up once
+the decision path is live end-to-end.
+
+Test: `python3 tests/human-action-bridge.test.py`. Test-only env overrides:
+`SUTANDO_HA_DIR`, `SUTANDO_HA_CARD_DIR`, `SUTANDO_HA_TIMEOUT`, `SUTANDO_HA_POLL`.
+
 ## `gmail-write-guard.py`
 
 Denies the **claude.ai Gmail MCP connector's WRITE-scoped tools** (create_draft,

--- a/hooks/human-action-bridge.py
+++ b/hooks/human-action-bridge.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""human-action-bridge — PreToolUse hook that turns `AskUserQuestion` into a
+REMOTE question instead of a hard deny (human-action bridge v1, step 1).
+
+Today `hooks/skip-ask-user-question.py` denies AskUserQuestion outright because
+the core runs headless — a rendered prompt would hang the session forever. That
+protects the session but lobotomizes the interaction: every question the model
+judged worth asking is silently skipped.
+
+This hook upgrades deny → remote-ask:
+
+    AskUserQuestion fires
+      → durable pending-action file      (<workspace>/state/human-actions/)
+      → card file for the owner         (results/proactive-ha-<id>.txt — the
+                                          sanctioned proactive path; the channel
+                                          bridge delivers it to the owner)
+      → bounded wait, polling the action file for a decision
+      → decision arrives  → allow + updatedInput carrying the owner's answers
+                            (Claude continues as if answered locally)
+      → timeout / no path → deny with the same decide-autonomously guidance as
+                            skip-ask-user-question (EXACTLY today's behavior)
+
+Decisions are written into the action file by whoever holds the return path:
+the sparrow DecisionHandler (v1 step 3) when SPARROW_EVENTS is live, or the
+core itself when the owner's reply arrives as a normal task (works today).
+A decision is only honored while `status` is "pending"; terminal states are
+immutable and late answers are ignored by the hook (the writer may still record
+them for audit).
+
+Safety invariants (design: notes/tasks-events/human_action_bridge_design.md):
+  - timeout NEVER approves — no response ⇒ deny-with-reason, never consent
+  - fail-OPEN for the session (any hook error ⇒ exit 0 allow-passthrough;
+    a crashing hook must never wedge the core) but fail-CLOSED for the
+    decision (only an explicit resolved decision produces an allow)
+  - every state transition is stamped in the action file for audit
+
+Registration: PreToolUse with matcher "AskUserQuestion", INSTEAD OF
+skip-ask-user-question.py (it subsumes it — the timeout branch IS that hook).
+See hooks/README.md. Test-only env overrides (documented here, used by
+tests/human-action-bridge.test.py): SUTANDO_HA_DIR (action-store dir),
+SUTANDO_HA_CARD_DIR (card dir), SUTANDO_HA_TIMEOUT (seconds, default 120),
+SUTANDO_HA_POLL (seconds, default 2).
+"""
+import hashlib
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+TOOL = "AskUserQuestion"
+
+# Timeout branch = the exact guidance skip-ask-user-question ships today, so the
+# fallback behavior is indistinguishable from the current hook.
+TIMEOUT_REASON = (
+    "AskUserQuestion could not be answered remotely in time: Sutando's core agent "
+    "runs headless and the owner did not respond to the question card within the "
+    "window. Do NOT ask again — decide autonomously: pick the option you judge "
+    "best, or state a clear assumption and proceed. If a choice is genuinely "
+    "blocking AND irreversible, surface the question through a normal channel "
+    "(per-host pending-questions.md or an owner notification) and keep working "
+    "on other things. [human-action-bridge:{action_id}]"
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _workspace() -> Path:
+    """Resolve the workspace via the M0 helper (never hardcode)."""
+    sys.path.insert(0, str(_repo_root() / "src"))
+    from workspace_default import resolve_workspace  # noqa: PLC0415
+    return Path(resolve_workspace())
+
+
+def _store_dir() -> Path:
+    override = os.environ.get("SUTANDO_HA_DIR")
+    return Path(override) if override else _workspace() / "state" / "human-actions"
+
+
+def _card_dir() -> Path:
+    override = os.environ.get("SUTANDO_HA_CARD_DIR")
+    return Path(override) if override else _workspace() / "results"
+
+
+def _atomic_write(path: Path, payload: dict) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=1))
+    os.replace(tmp, path)
+
+
+def _new_action(data: dict) -> dict:
+    tool_input = data.get("tool_input") or {}
+    questions = tool_input.get("questions") or []
+    now = time.time()
+    digest = hashlib.sha1(
+        (json.dumps(questions, sort_keys=True, ensure_ascii=False)
+         + str(data.get("session_id")) + str(now)).encode()
+    ).hexdigest()[:12]
+    timeout = float(os.environ.get("SUTANDO_HA_TIMEOUT", "120"))
+    return {
+        "action_id": f"ha_{digest}",
+        "kind": "clarification",
+        "status": "pending",
+        "claude_session_id": data.get("session_id"),
+        "tool_input": tool_input,
+        "questions": questions,
+        "decision": None,
+        "resolved_by": None,
+        "created_at": now,
+        "expires_at": now + timeout,
+        "audit": [{"at": now, "event": "created"}],
+    }
+
+
+def _render_card(action: dict) -> str:
+    lines = [
+        "**Claude is asking you a question** (reply within "
+        f"{int(action['expires_at'] - action['created_at'])}s or it decides on its own)",
+        "",
+    ]
+    for qi, q in enumerate(action["questions"], 1):
+        lines.append(f"Q{qi}. {q.get('question', '?')}")
+        for oi, opt in enumerate(q.get("options") or [], 1):
+            label = opt.get("label", "?")
+            desc = opt.get("description") or ""
+            lines.append(f"  {oi}. {label}" + (f" — {desc}" if desc else ""))
+        lines.append("")
+    lines.append(f"Reply: `answer {action['action_id']} <option number per question, "
+                 "comma-separated>` — or answer in your own words naming the option.")
+    return "\n".join(lines)
+
+
+def _poll_for_decision(path: Path, action: dict) -> "dict | None":
+    poll = float(os.environ.get("SUTANDO_HA_POLL", "2"))
+    while time.time() < action["expires_at"]:
+        try:
+            current = json.loads(path.read_text())
+        except (OSError, ValueError):
+            current = None
+        if current:
+            if current.get("status") == "resolved" and current.get("decision"):
+                return current
+            if current.get("status") in ("cancelled", "expired"):
+                return None
+        time.sleep(poll)
+    # Timeout: stamp expired IF still pending (a racing resolver keeps its win —
+    # re-read inside the same best-effort write).
+    try:
+        current = json.loads(path.read_text())
+        if current.get("status") == "pending":
+            current["status"] = "expired"
+            current.setdefault("audit", []).append({"at": time.time(), "event": "expired"})
+            _atomic_write(path, current)
+            return None
+        if current.get("status") == "resolved" and current.get("decision"):
+            return current  # resolved in the final poll gap — honor it
+    except (OSError, ValueError):
+        pass
+    return None
+
+
+def _emit(decision_obj: dict) -> None:
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse", **decision_obj}}))
+
+
+def main() -> None:
+    data = json.loads(sys.stdin.read())
+    if data.get("tool_name") != TOOL:
+        sys.exit(0)  # not ours — allow-passthrough
+
+    action = _new_action(data)
+    store = _store_dir()
+    store.mkdir(parents=True, exist_ok=True)
+    path = store / (action["action_id"] + ".json")
+    _atomic_write(path, action)
+
+    # Card: best-effort. The proactive results path is the sanctioned way to
+    # speak to the owner; if it fails we still wait (a decision can arrive via
+    # any writer that knows the store), then fall back to deny-on-timeout.
+    try:
+        card = _card_dir() / f"proactive-ha-{action['action_id']}.txt"
+        card.parent.mkdir(parents=True, exist_ok=True)
+        card.write_text(_render_card(action))
+    except OSError as e:
+        print(f"[human-action-bridge] card write failed (still waiting): {e}",
+              file=sys.stderr)
+
+    resolved = _poll_for_decision(path, action)
+    if resolved:
+        answers = resolved["decision"].get("answers") or {}
+        _emit({
+            "permissionDecision": "allow",
+            "updatedInput": {**(data.get("tool_input") or {}), "answers": answers},
+        })
+        sys.exit(0)
+
+    _emit({
+        "permissionDecision": "deny",
+        "permissionDecisionReason":
+            TIMEOUT_REASON.format(action_id=action["action_id"]),
+    })
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:  # fail-open: never wedge the core on a hook error
+        print(f"[human-action-bridge] non-fatal error, allowing: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/hooks/human-action-bridge.py
+++ b/hooks/human-action-bridge.py
@@ -63,15 +63,23 @@ TIMEOUT_REASON = (
 )
 
 
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parent.parent
-
-
 def _workspace() -> Path:
-    """Resolve the workspace via the M0 helper (never hardcode)."""
-    sys.path.insert(0, str(_repo_root() / "src"))
-    from workspace_default import resolve_workspace  # noqa: PLC0415
-    return Path(resolve_workspace())
+    """Derive the workspace from CLAUDE_CONFIG_DIR — the Claude Code project
+    tree lives at `<workspace>/.claude-sutando` per the workspace contract, so
+    the nearest `.claude-sutando` ancestor's parent IS the workspace. Same
+    pattern as context-source-guard.py: no subprocess (hooks are hot-path) and
+    no __file__ walk (the bundled-symlink anti-pattern; also keeps this hook
+    standalone-deployable). Falls back to the system's canonical last-ditch
+    default, ~/sutando-workspace."""
+    p = os.path.normpath(os.environ.get("CLAUDE_CONFIG_DIR")
+                         or os.path.expanduser("~/.claude"))
+    while True:
+        if os.path.basename(p) == ".claude-sutando":
+            return Path(os.path.dirname(p))
+        parent = os.path.dirname(p)
+        if parent == p:  # filesystem root — no `.claude-sutando` ancestor
+            return Path(os.path.expanduser("~/sutando-workspace"))
+        p = parent
 
 
 def _store_dir() -> Path:

--- a/hooks/human-action-bridge.py
+++ b/hooks/human-action-bridge.py
@@ -41,11 +41,13 @@ tests/human-action-bridge.test.py): SUTANDO_HA_DIR (action-store dir),
 SUTANDO_HA_CARD_DIR (card dir), SUTANDO_HA_TIMEOUT (seconds, default 120),
 SUTANDO_HA_POLL (seconds, default 2).
 """
+import fcntl
 import hashlib
 import json
 import os
 import sys
 import time
+import uuid
 from pathlib import Path
 
 TOOL = "AskUserQuestion"
@@ -93,9 +95,32 @@ def _card_dir() -> Path:
 
 
 def _atomic_write(path: Path, payload: dict) -> None:
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=1))
+    """Durable atomic write: unique per-writer temp (the resolver may write the
+    same action concurrently — a fixed name could be clobbered mid-write),
+    fsync the data before rename and the directory entry after, so a crash can
+    never lose pending-action state (review blocker)."""
+    tmp = path.parent / f"{path.name}.{os.getpid()}.{uuid.uuid4().hex[:8]}.tmp"
+    with open(tmp, "w") as f:
+        f.write(json.dumps(payload, ensure_ascii=False, indent=1))
+        f.flush()
+        os.fsync(f.fileno())
     os.replace(tmp, path)
+    dfd = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(dfd)
+    finally:
+        os.close(dfd)
+
+
+def _transition_lock(path: Path):
+    """flock shared by EVERY writer of an action file — this hook's expiry path
+    AND the sparrow resolver (ActionStore.transition_lock uses the same
+    `<action_id>.lock` file). Serializes read→check→write so exactly one
+    terminal transition wins (review blocker: the timeout could overwrite a
+    decision that landed between its read and its write)."""
+    lock_file = open(path.parent / (path.stem + ".lock"), "a+")
+    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+    return lock_file
 
 
 def _new_action(data: dict) -> dict:
@@ -153,17 +178,23 @@ def _poll_for_decision(path: Path, action: dict) -> "dict | None":
             if current.get("status") in ("cancelled", "expired"):
                 return None
         time.sleep(poll)
-    # Timeout: stamp expired IF still pending (a racing resolver keeps its win —
-    # re-read inside the same best-effort write).
+    # Timeout: expire ONLY if still pending, with read→check→write under the
+    # shared transition lock — a resolver landing in the gap keeps its win, and
+    # a late resolver can never overwrite `expired` (terminal immutability).
     try:
-        current = json.loads(path.read_text())
-        if current.get("status") == "pending":
-            current["status"] = "expired"
-            current.setdefault("audit", []).append({"at": time.time(), "event": "expired"})
-            _atomic_write(path, current)
-            return None
-        if current.get("status") == "resolved" and current.get("decision"):
-            return current  # resolved in the final poll gap — honor it
+        lk = _transition_lock(path)
+        try:
+            current = json.loads(path.read_text())
+            if current.get("status") == "pending":
+                current["status"] = "expired"
+                current.setdefault("audit", []).append({"at": time.time(), "event": "expired"})
+                _atomic_write(path, current)
+                return None
+            if current.get("status") == "resolved" and current.get("decision"):
+                return current  # resolved in the final poll gap — honor it
+        finally:
+            fcntl.flock(lk.fileno(), fcntl.LOCK_UN)
+            lk.close()
     except (OSError, ValueError):
         pass
     return None
@@ -191,7 +222,11 @@ def main() -> None:
     try:
         card = _card_dir() / f"proactive-ha-{action['action_id']}.txt"
         card.parent.mkdir(parents=True, exist_ok=True)
-        card.write_text(_render_card(action))
+        # the proactive path is consumed by a bridge poller — write via temp +
+        # rename so it can never observe a half-written card (review P2)
+        card_tmp = card.parent / f"{card.name}.{os.getpid()}.tmp"
+        card_tmp.write_text(_render_card(action))
+        os.replace(card_tmp, card)
     except OSError as e:
         print(f"[human-action-bridge] card write failed (still waiting): {e}",
               file=sys.stderr)

--- a/tests/human-action-bridge.test.py
+++ b/tests/human-action-bridge.test.py
@@ -173,6 +173,88 @@ def test_card_failure_still_waits_then_denies():
           "action file exists even when the card could not be written")
 
 
+def test_timeout_cannot_overwrite_a_racing_resolution():
+    # Review blocker (CAS): a resolution landing between the hook's last poll
+    # and its expiry write must WIN. Deterministic version of the race: hold
+    # the shared transition lock (the same flock the resolver uses), let the
+    # hook hit its timeout and block on the lock, resolve while holding, then
+    # release — the expiry path must re-read, see `resolved`, and HONOR it
+    # (allow + answers), never stamp `expired` over the decision.
+    import fcntl
+    env, store, _ = _dirs()
+    store.mkdir(parents=True, exist_ok=True)
+
+    holder = {}
+
+    def hold_lock_then_resolve():
+        deadline = time.time() + 5
+        while time.time() < deadline and not list(store.glob("ha_*.json")):
+            time.sleep(0.05)
+        files = list(store.glob("ha_*.json"))
+        if not files:
+            return
+        lock = open(store / (files[0].stem + ".lock"), "a+")
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        holder["locked"] = True
+        time.sleep(1.5)  # hook's 1s timeout passes while we hold the lock
+        rec = json.loads(files[0].read_text())
+        rec["status"] = "resolved"
+        rec["decision"] = {"answers": {"Ship v1 or wait?": "Ship v1"}}
+        rec["resolved_by"] = "@qingyun:ag2.space"
+        files[0].write_text(json.dumps(rec))
+        fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+        lock.close()
+
+    t = threading.Thread(target=hold_lock_then_resolve)
+    t.start()
+    p, out = _run(_hook_input(), {**env, "SUTANDO_HA_TIMEOUT": "1"}, timeout=30)
+    t.join()
+    d = out["hookSpecificOutput"]
+    check(holder.get("locked") and d["permissionDecision"] == "allow",
+          "CAS: a resolution racing the expiry write WINS (allow, not expired)")
+    rec = json.loads(list(store.glob("ha_*.json"))[0].read_text())
+    check(rec["status"] == "resolved",
+          "CAS: the action file keeps the decision — expiry never overwrote it")
+
+
+def test_action_writes_are_durable_and_uniquely_named():
+    # Review blocker: pending-action state must be fsync-durable (file + dir)
+    # with per-writer-unique temp names. Verify via the module's own writer.
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("hab", str(HOOK))
+    hab = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(hab)
+    d = Path(tempfile.mkdtemp())
+    fsynced, replaced = [], []
+    orig_fsync, orig_replace = os.fsync, os.replace
+    os.fsync = lambda fd: fsynced.append(fd)
+    os.replace = lambda a, b: (replaced.append(str(a)), orig_replace(a, b))[1]
+    try:
+        hab._atomic_write(d / "ha_x.json", {"status": "pending"})
+    finally:
+        os.fsync, os.replace = orig_fsync, orig_replace
+    check(len(fsynced) >= 2, "durable write: fsyncs the file AND the directory")
+    check(str(os.getpid()) in replaced[0] and not replaced[0].endswith("json.tmp"),
+          "durable write: per-writer-unique temp name (no fixed .tmp collision)")
+
+
+def test_card_is_written_atomically():
+    # Review P2: the card lands on a bridge-consumed path — a poller must never
+    # see a half-written file, so it must arrive via temp + os.replace.
+    env, _, cards = _dirs()
+    replaced = []
+    # run the hook and observe the card path appears fully-formed with no
+    # lingering temp (the rename target is the final name).
+    p, out = _run(_hook_input(), {**env, "SUTANDO_HA_TIMEOUT": "1"})
+    card_files = list(cards.glob("proactive-ha-*.txt"))
+    tmp_files = list(cards.glob("*.tmp"))
+    check(len(card_files) == 1 and not tmp_files,
+          "card: final file present, no temp residue (temp+rename path)")
+    check("Reply:" in card_files[0].read_text(),
+          "card: content complete (rendered before the rename)")
+    _ = replaced
+
+
 def main():
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):

--- a/tests/human-action-bridge.test.py
+++ b/tests/human-action-bridge.test.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Tests for hooks/human-action-bridge.py — the remote-ask upgrade of the
+AskUserQuestion hard-deny (human-action bridge v1 step 1).
+
+Covers the safety invariants from notes/tasks-events/human_action_bridge_design.md:
+timeout NEVER approves; only an explicit resolved decision produces an allow;
+fail-open for the session; terminal states immutable; card is best-effort.
+Runs the hook as a subprocess exactly as Claude Code would. Exit 0/1."""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK = REPO / "hooks" / "human-action-bridge.py"
+
+FAILS: list = []
+
+
+def check(cond, msg):
+    print(("  ok  " if cond else "  FAIL ") + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+def _hook_input(tool="AskUserQuestion"):
+    return {
+        "tool_name": tool,
+        "session_id": "sess_test",
+        "hook_event_name": "PreToolUse",
+        "tool_input": {
+            "questions": [{
+                "question": "Ship v1 or wait?",
+                "header": "Scope",
+                "multiSelect": False,
+                "options": [
+                    {"label": "Ship v1", "description": "smallest useful slice"},
+                    {"label": "Wait", "description": "bundle with v2"},
+                ],
+            }],
+        },
+    }
+
+
+def _run(payload, env_extra, timeout=30):
+    env = {**os.environ, **env_extra}
+    p = subprocess.run(
+        [sys.executable, str(HOOK)], input=json.dumps(payload),
+        capture_output=True, text=True, env=env, timeout=timeout,
+    )
+    out = None
+    for line in p.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            out = json.loads(line)
+            break
+    return p, out
+
+
+def _dirs():
+    base = Path(tempfile.mkdtemp())
+    store, cards = base / "actions", base / "cards"
+    return {
+        "SUTANDO_HA_DIR": str(store),
+        "SUTANDO_HA_CARD_DIR": str(cards),
+        "SUTANDO_HA_POLL": "0.1",
+    }, store, cards
+
+
+def test_other_tools_pass_through():
+    env, store, _ = _dirs()
+    p, out = _run(_hook_input(tool="Bash"), {**env, "SUTANDO_HA_TIMEOUT": "1"})
+    check(p.returncode == 0 and out is None,
+          "non-AskUserQuestion tools pass through untouched (no decision JSON)")
+    check(not store.exists() or not list(store.glob("*.json")),
+          "no action file is created for other tools")
+
+
+def test_timeout_denies_and_expires():
+    env, store, cards = _dirs()
+    p, out = _run(_hook_input(), {**env, "SUTANDO_HA_TIMEOUT": "1"})
+    d = out["hookSpecificOutput"]
+    check(d["permissionDecision"] == "deny",
+          "TIMEOUT NEVER APPROVES — no response ⇒ deny")
+    check("decide autonomously" in d["permissionDecisionReason"],
+          "timeout deny carries the decide-autonomously guidance (today's behavior)")
+    actions = list(store.glob("ha_*.json"))
+    check(len(actions) == 1, "one durable action file created")
+    rec = json.loads(actions[0].read_text())
+    check(rec["status"] == "expired", "unanswered action is stamped expired")
+    check(rec["audit"][-1]["event"] == "expired", "expiry is audited")
+    card = list(cards.glob("proactive-ha-*.txt"))
+    check(len(card) == 1 and "Ship v1" in card[0].read_text(),
+          "owner card written with the options rendered")
+
+
+def test_decision_allows_with_answers():
+    env, store, _ = _dirs()
+
+    def resolve_soon():
+        # act like the DecisionHandler: wait for the pending file, write decision
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            files = list(store.glob("ha_*.json"))
+            if files:
+                rec = json.loads(files[0].read_text())
+                if rec["status"] == "pending":
+                    rec["status"] = "resolved"
+                    rec["decision"] = {"answers": {"Ship v1 or wait?": "Ship v1"}}
+                    rec["resolved_by"] = "@qingyun:ag2.space"
+                    files[0].write_text(json.dumps(rec))
+                    return
+            time.sleep(0.05)
+
+    t = threading.Thread(target=resolve_soon)
+    t.start()
+    p, out = _run(_hook_input(), {**env, "SUTANDO_HA_TIMEOUT": "6"})
+    t.join()
+    d = out["hookSpecificOutput"]
+    check(d["permissionDecision"] == "allow",
+          "an explicit resolved decision produces allow")
+    check(d["updatedInput"]["answers"] == {"Ship v1 or wait?": "Ship v1"},
+          "owner's answers ride back via updatedInput")
+    check(d["updatedInput"]["questions"],
+          "updatedInput preserves the original questions (answers-injection contract)")
+
+
+def test_cancelled_action_denies():
+    env, store, _ = _dirs()
+
+    def cancel_soon():
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            files = list(store.glob("ha_*.json"))
+            if files:
+                rec = json.loads(files[0].read_text())
+                rec["status"] = "cancelled"
+                files[0].write_text(json.dumps(rec))
+                return
+            time.sleep(0.05)
+
+    t = threading.Thread(target=cancel_soon)
+    t.start()
+    p, out = _run(_hook_input(), {**env, "SUTANDO_HA_TIMEOUT": "6"})
+    t.join()
+    check(out["hookSpecificOutput"]["permissionDecision"] == "deny",
+          "a cancelled action denies — fail-closed for the decision")
+
+
+def test_garbage_stdin_fails_open():
+    env, _, _ = _dirs()
+    p = subprocess.run([sys.executable, str(HOOK)], input="{not json",
+                       capture_output=True, text=True,
+                       env={**os.environ, **env}, timeout=10)
+    check(p.returncode == 0 and not p.stdout.strip().startswith("{"),
+          "garbage stdin fails OPEN (exit 0, no decision) — never wedge the core")
+
+
+def test_card_failure_still_waits_then_denies():
+    env, store, _ = _dirs()
+    # point the card dir at an uncreatable path (child of a FILE)
+    blocker = Path(tempfile.mkdtemp()) / "file"
+    blocker.write_text("x")
+    env["SUTANDO_HA_CARD_DIR"] = str(blocker / "sub")
+    p, out = _run(_hook_input(), {**env, "SUTANDO_HA_TIMEOUT": "1"})
+    check(out["hookSpecificOutput"]["permissionDecision"] == "deny",
+          "card-write failure is non-fatal: hook still waits then denies (best-effort card)")
+    check(list(store.glob("ha_*.json")),
+          "action file exists even when the card could not be written")
+
+
+def main():
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            print(f"# {name}")
+            fn()
+    if FAILS:
+        print(f"\nFAILED ({len(FAILS)})")
+        return 1
+    print("\nPASS — human-action-bridge hook (v1 step 1)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Step 1 of the **control plane + human-action bridge** (owner-confirmed direction, 2026-07-24; design: `workspace notes/tasks-events/human_action_bridge_design.md`).

Upgrades the `AskUserQuestion` hard-deny (`skip-ask-user-question.py`) into a **remote ask**:

- `AskUserQuestion` fires → durable pending-action file (`<workspace>/state/human-actions/ha_*.json`) + question card for the owner (`results/proactive-ha-*.txt`, the sanctioned proactive path) → bounded poll.
- Decision resolved → PreToolUse `allow` + `updatedInput.answers` — Claude continues as if answered locally.
- Timeout / cancelled → `deny` with the same decide-autonomously guidance as today. **With no resolver present, behavior is exactly the current hook's** — strictly additive.

## Safety invariants

- **Timeout NEVER approves** — no response ⇒ deny, never consent.
- Fail-**open** for the session (hook error ⇒ passthrough; never wedge the core), fail-**closed** for the decision (only an explicit resolved decision allows).
- Terminal action states immutable + audited; racing resolver keeps its win.

## What this does NOT do (follow-ups per design)

- No auto-registration flip yet (`build-core-settings.mjs` still registers skip-ask) — flipped once the decision path is proven end-to-end.
- Decision return path: sparrow `DecisionHandler` in the #2294 EventConsumer (step 3, separate PR — depends on #2294); until then the core writes decisions when the owner's reply arrives as a task.

## Test

`python3 tests/human-action-bridge.test.py` — 15 assertions: passthrough, timeout-deny+expiry+audit, decision→allow+updatedInput, cancelled→deny, garbage-stdin fail-open, card-failure best-effort. Auto-discovered (tests/*.test.py). ruff + orphan-guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)