### PR TITLE
feat(hooks): activity-emitter — durable activity journal (Activity outbox Phase 2, step 1)

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -61,6 +61,24 @@ Test: `python3 tests/skip-ask-user-question.test.py` (hook) and
 Config paths are env-overridable for testing: `SUTANDO_DISCORD_ACCESS_FILE`,
 `SUTANDO_DISCORD_ENV_FILE`, `SUTANDO_WORKSPACE`. Test: `python3 tests/context-source-guard.test.py`.
 
+## `activity-emitter.py`
+
+Journals the core's activity as AWP activity objects (Activity outbox Phase 2,
+step 1). Async command hook for SessionStart / UserPromptSubmit / PreToolUse /
+PostToolUse / PostToolUseFailure / Notification / Stop / SessionEnd — each fires
+this emitter, which normalizes the hook JSON to an activity object and appends
+it to `<workspace>/state/activity-journal/YYYY-MM-DD.jsonl`. Attribution rides
+in from the Execution Binding Registry when present. Secret hygiene: tool input
+reduces to a display hint (description/file_path/pattern/url — deliberately
+never the raw `command`). Fail-OPEN + fast; register every entry with
+`"async": true`. Upstream HTTP delivery is a later step (broker `/v1/activities`);
+until then the journal is the local activity feed.
+
+Not yet auto-registered. Manual registration: async command-hook entries for the
+events above, argv[1] = hook name as a stdin fallback. Test:
+`python3 tests/activity-emitter.test.py`. Test-only env override:
+`SUTANDO_ACTIVITY_DIR`.
+
 ## `gmail-write-guard.py`
 
 Denies the **claude.ai Gmail MCP connector's WRITE-scoped tools** (create_draft,

--- a/hooks/activity-emitter.py
+++ b/hooks/activity-emitter.py
@@ -109,11 +109,16 @@ def _tool_summary(data: dict) -> dict:
     hint = (ti.get("description") or ti.get("file_path") or ti.get("path")
             or ti.get("pattern") or "")
     if not hint and ti.get("url"):
-        # URLs carry tokens in query strings/fragments (presigned sigs, OAuth
-        # codes — Codex review, reproduced) — journal scheme+host+path ONLY.
+        # URLs carry secrets in query strings/fragments (presigned sigs, OAuth
+        # codes) AND in userinfo (https://user:token@host — netloc includes it,
+        # so reusing netloc leaked credentials; second review). Journal
+        # scheme + hostname[:port] + path ONLY, authority REBUILT from parts.
         try:
             u = urllib.parse.urlsplit(str(ti["url"]))
-            hint = urllib.parse.urlunsplit((u.scheme, u.netloc, u.path, "", ""))
+            host = u.hostname or ""
+            authority = host + (f":{u.port}" if u.port else "")
+            hint = urllib.parse.urlunsplit(
+                (u.scheme, authority, u.path, "", "")) if host else ""
         except ValueError:
             hint = ""
     hint = str(hint).splitlines()[0][:_SUMMARY_LIMIT] if hint else ""

--- a/hooks/activity-emitter.py
+++ b/hooks/activity-emitter.py
@@ -52,6 +52,7 @@ import json
 import os
 import sys
 import time
+import urllib.parse
 import uuid
 from pathlib import Path
 
@@ -106,7 +107,15 @@ def _tool_summary(data: dict) -> dict:
     # NOTE: deliberately NOT ti["command"] — raw command lines are the
     # likeliest secret carriers; Bash calls surface via their description.
     hint = (ti.get("description") or ti.get("file_path") or ti.get("path")
-            or ti.get("pattern") or ti.get("url") or "")
+            or ti.get("pattern") or "")
+    if not hint and ti.get("url"):
+        # URLs carry tokens in query strings/fragments (presigned sigs, OAuth
+        # codes — Codex review, reproduced) — journal scheme+host+path ONLY.
+        try:
+            u = urllib.parse.urlsplit(str(ti["url"]))
+            hint = urllib.parse.urlunsplit((u.scheme, u.netloc, u.path, "", ""))
+        except ValueError:
+            hint = ""
     hint = str(hint).splitlines()[0][:_SUMMARY_LIMIT] if hint else ""
     return {"tool": {"kind": name, **({"display": hint} if hint else {})}}
 

--- a/hooks/activity-emitter.py
+++ b/hooks/activity-emitter.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""activity-emitter — async Claude Code hook that journals the core's activity
+as AWP activity objects (Activity outbox Phase 2, step 1 — owner's pick
+2026-07-24, delivered via the human-action bridge's first live card).
+
+The AWP roadmap's Phase 2 is a durable Agent Activity outbox: the owner (and
+later the Workspace) should be able to see WHAT the agent is doing — session
+lifecycle, tool activity, turn completions — without attaching to tmux. Claude
+Code hooks are the structured source (NOT tmux scraping): each hook fires with
+JSON on stdin; this emitter normalizes it to an AWP activity object and appends
+it to a durable local journal. Upstream HTTP delivery is a later step (needs a
+broker /v1/activities endpoint); the journal means nothing is lost meanwhile,
+and the dashboard gets a local activity feed for free.
+
+Design (workspace notes/tasks-events/human_action_bridge_design.md §2.6):
+  hook JSON → normalize → append JSONL line to
+  <workspace>/state/activity-journal/YYYY-MM-DD.jsonl
+
+Hook → activity mapping (first ring, per the usecase doc):
+  SessionStart        → agent.session.started
+  UserPromptSubmit    → task.execution.started
+  PreToolUse          → agent.tool.started
+  PostToolUse         → agent.tool.completed
+  PostToolUseFailure  → agent.tool.failed
+  Notification        → agent.attention.required
+  Stop                → task.turn.completed
+  SessionEnd          → agent.session.ended
+  (unknown hook)      → agent.activity (generic — forward-compatible)
+
+Attribution: if the Execution Binding Registry file exists
+(<workspace>/state/bindings/active-execution.json, written by the Core at task
+pickup), its task_id/room_id ride on every activity so downstream consumers can
+group by task. Absent registry → activities still journal, unattributed.
+
+Invariants:
+  - FAIL-OPEN and FAST: any error → exit 0 silently. An emitter crash or slow
+    path must never wedge or lag the core (register with "async": true).
+  - Append-only JSONL, one line per activity, day-rotated by filename. No
+    fsync — activities are telemetry, not decisions (the human-action store is
+    the durable-by-contract one); a crash losing the tail of a telemetry
+    journal is acceptable, wedging the core is not.
+  - No secrets: tool_input is reduced to a short display summary, never the
+    full payload (commands can carry tokens).
+
+Registration (NOT auto-registered yet — see hooks/README.md): add async
+command-hook entries for the events above pointing at this file, argv[1] =
+the hook name (SessionStart etc.) as a fallback when stdin lacks
+hook_event_name. Test: tests/activity-emitter.test.py.
+Test-only env override: SUTANDO_ACTIVITY_DIR (journal dir).
+"""
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+HOOK_TO_TYPE = {
+    "SessionStart": "agent.session.started",
+    "UserPromptSubmit": "task.execution.started",
+    "PreToolUse": "agent.tool.started",
+    "PostToolUse": "agent.tool.completed",
+    "PostToolUseFailure": "agent.tool.failed",
+    "Notification": "agent.attention.required",
+    "Stop": "task.turn.completed",
+    "SessionEnd": "agent.session.ended",
+}
+
+_SUMMARY_LIMIT = 160
+
+
+def _workspace() -> Path:
+    """CLAUDE_CONFIG_DIR walk — same derivation as context-source-guard /
+    human-action-bridge (no subprocess, no __file__ walk, deploy-safe)."""
+    p = os.path.normpath(os.environ.get("CLAUDE_CONFIG_DIR")
+                         or os.path.expanduser("~/.claude"))
+    while True:
+        if os.path.basename(p) == ".claude-sutando":
+            return Path(os.path.dirname(p))
+        parent = os.path.dirname(p)
+        if parent == p:
+            return Path(os.path.expanduser("~/sutando-workspace"))
+        p = parent
+
+
+def _journal_dir(ws: Path) -> Path:
+    override = os.environ.get("SUTANDO_ACTIVITY_DIR")
+    return Path(override) if override else ws / "state" / "activity-journal"
+
+
+def _binding(ws: Path) -> dict:
+    try:
+        with open(ws / "state" / "bindings" / "active-execution.json") as f:
+            b = json.load(f)
+        return {k: b[k] for k in ("task_id", "room_id", "generation") if k in b}
+    except (OSError, ValueError):
+        return {}
+
+
+def _tool_summary(data: dict) -> dict:
+    """Reduce tool info to display-safe fields — never the raw input payload."""
+    name = data.get("tool_name")
+    if not name:
+        return {}
+    ti = data.get("tool_input") or {}
+    # NOTE: deliberately NOT ti["command"] — raw command lines are the
+    # likeliest secret carriers; Bash calls surface via their description.
+    hint = (ti.get("description") or ti.get("file_path") or ti.get("path")
+            or ti.get("pattern") or ti.get("url") or "")
+    hint = str(hint).splitlines()[0][:_SUMMARY_LIMIT] if hint else ""
+    return {"tool": {"kind": name, **({"display": hint} if hint else {})}}
+
+
+def build_activity(data: dict, argv_hook: "str | None" = None,
+                   ws: "Path | None" = None) -> dict:
+    ws = ws or _workspace()
+    hook = data.get("hook_event_name") or argv_hook or "unknown"
+    activity = {
+        "activity_id": f"act_{uuid.uuid4().hex[:12]}",
+        "type": HOOK_TO_TYPE.get(hook, "agent.activity"),
+        "hook": hook,
+        "occurred_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "execution": {"runtime": "claude-code",
+                      "session_id": data.get("session_id")},
+        **_binding(ws),
+        **_tool_summary(data),
+    }
+    if hook == "Notification" and data.get("message"):
+        activity["summary"] = str(data["message"])[:_SUMMARY_LIMIT]
+    return activity
+
+
+def append(activity: dict, ws: "Path | None" = None) -> Path:
+    ws = ws or _workspace()
+    d = _journal_dir(ws)
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / (time.strftime("%Y-%m-%d", time.gmtime()) + ".jsonl")
+    with open(path, "a") as f:
+        f.write(json.dumps(activity, ensure_ascii=False) + "\n")
+    return path
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    data = json.loads(raw) if raw.strip() else {}
+    argv_hook = sys.argv[1] if len(sys.argv) > 1 else None
+    append(build_activity(data, argv_hook))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:  # noqa: BLE001 — telemetry must NEVER wedge the core
+        sys.exit(0)

--- a/tests/activity-emitter.test.py
+++ b/tests/activity-emitter.test.py
@@ -94,6 +94,32 @@ def test_url_hints_strip_query_and_fragment():
           "URL hint keeps scheme+host+path (still useful display)")
 
 
+def test_url_hints_strip_userinfo_credentials():
+    # Second-review P1: netloc INCLUDES userinfo, so scheme+netloc+path still
+    # leaked `user:password@`. The authority must be rebuilt from
+    # hostname[:port] — username, password, query, fragment ALL absent.
+    d = tempfile.mkdtemp()
+    _run({"hook_event_name": "PreToolUse", "session_id": "s",
+          "tool_name": "WebFetch",
+          "tool_input": {"url":
+              "https://alice:sk-SECRET@files.example:8443/download?tok=q#f"}}, d)
+    rows = _journal(d)
+    dumped = json.dumps(rows)
+    check("sk-SECRET" not in dumped and "alice" not in dumped
+          and "tok=q" not in dumped and "#f" not in dumped,
+          "URL SECRET HYGIENE — userinfo (user:password@) never reaches the journal")
+    check(rows[0]["tool"]["display"] == "https://files.example:8443/download",
+          "URL hint authority rebuilt as hostname:port only")
+    # an unparseable-port URL degrades to no hint, never a crash or a leak
+    d2 = tempfile.mkdtemp()
+    _run({"hook_event_name": "PreToolUse", "session_id": "s",
+          "tool_name": "WebFetch",
+          "tool_input": {"url": "https://bob:pw@files.example:not-a-port/x"}}, d2)
+    dumped2 = json.dumps(_journal(d2))
+    check("pw" not in dumped2 and "bob" not in dumped2,
+          "URL SECRET HYGIENE — invalid-port URL drops the hint, no leak")
+
+
 def test_binding_attribution():
     ws = Path(tempfile.mkdtemp())
     (ws / "state" / "bindings").mkdir(parents=True)

--- a/tests/activity-emitter.test.py
+++ b/tests/activity-emitter.test.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Tests for hooks/activity-emitter.py — the Activity-outbox journal source.
+Covers: hook→type mapping, JSONL journaling, binding attribution, secret
+hygiene (no raw command payloads), fail-open on garbage, unknown-hook
+forward-compat. Runs the hook as a subprocess exactly as Claude Code would
+(async command hook). Exit 0/1."""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK = REPO / "hooks" / "activity-emitter.py"
+
+FAILS: list = []
+
+
+def check(cond, msg):
+    print(("  ok  " if cond else "  FAIL ") + msg)
+    if not cond:
+        FAILS.append(msg)
+
+
+def _run(payload, journal_dir, argv=None, raw=None):
+    env = {**os.environ, "SUTANDO_ACTIVITY_DIR": str(journal_dir)}
+    p = subprocess.run(
+        [sys.executable, str(HOOK)] + (argv or []),
+        input=raw if raw is not None else json.dumps(payload),
+        capture_output=True, text=True, env=env, timeout=15)
+    return p
+
+
+def _journal(journal_dir):
+    files = sorted(Path(journal_dir).glob("*.jsonl"))
+    if not files:
+        return []
+    return [json.loads(ln) for ln in files[-1].read_text().splitlines() if ln]
+
+
+def test_mapping_and_journal():
+    d = tempfile.mkdtemp()
+    cases = [
+        ({"hook_event_name": "SessionStart", "session_id": "s1"},
+         "agent.session.started"),
+        ({"hook_event_name": "PreToolUse", "session_id": "s1",
+          "tool_name": "Bash", "tool_input": {"description": "Run tests"}},
+         "agent.tool.started"),
+        ({"hook_event_name": "PostToolUseFailure", "session_id": "s1",
+          "tool_name": "Read", "tool_input": {"file_path": "/x/y.py"}},
+         "agent.tool.failed"),
+        ({"hook_event_name": "Stop", "session_id": "s1"},
+         "task.turn.completed"),
+    ]
+    for payload, _ in cases:
+        p = _run(payload, d)
+        check(p.returncode == 0, f"emitter exits 0 for {payload['hook_event_name']}")
+    rows = _journal(d)
+    check([r["type"] for r in rows] == [c[1] for c in cases],
+          "hook→activity type mapping journals in order")
+    check(all(r["activity_id"].startswith("act_") and r["occurred_at"].endswith("Z")
+              for r in rows), "every activity carries id + UTC timestamp")
+    tool_row = rows[1]
+    check(tool_row["tool"] == {"kind": "Bash", "display": "Run tests"},
+          "tool activities carry kind + display hint")
+
+
+def test_no_raw_command_leaks():
+    d = tempfile.mkdtemp()
+    _run({"hook_event_name": "PreToolUse", "session_id": "s1",
+          "tool_name": "Bash",
+          "tool_input": {"command": "curl -H 'Authorization: Bearer sk-SECRET' x"}}, d)
+    rows = _journal(d)
+    dumped = json.dumps(rows)
+    check("SECRET" not in dumped and "curl" not in dumped,
+          "SECRET HYGIENE — raw command payloads never reach the journal")
+    check(rows[0]["tool"] == {"kind": "Bash"},
+          "command-only Bash input reduces to kind alone (no display)")
+
+
+def test_binding_attribution():
+    ws = Path(tempfile.mkdtemp())
+    (ws / "state" / "bindings").mkdir(parents=True)
+    (ws / "state" / "bindings" / "active-execution.json").write_text(json.dumps(
+        {"task_id": "task-123", "room_id": "!r:hs", "generation": 7, "extra": "x"}))
+    d = ws / "state" / "activity-journal"
+    # point CLAUDE_CONFIG_DIR at <ws>/.claude-sutando so _workspace() → ws,
+    # exercising the real binding-read path (no SUTANDO_ACTIVITY_DIR override).
+    env = {**os.environ, "CLAUDE_CONFIG_DIR": str(ws / ".claude-sutando")}
+    env.pop("SUTANDO_ACTIVITY_DIR", None)
+    subprocess.run([sys.executable, str(HOOK)],
+                   input=json.dumps({"hook_event_name": "Stop", "session_id": "s"}),
+                   capture_output=True, text=True, env=env, timeout=15)
+    rows = _journal(d)
+    check(rows and rows[0]["task_id"] == "task-123" and rows[0]["room_id"] == "!r:hs"
+          and rows[0]["generation"] == 7,
+          "binding registry attribution rides on activities (task/room/generation)")
+    check("extra" not in rows[0], "only the attribution keys are copied")
+
+
+def test_unknown_hook_and_argv_fallback():
+    d = tempfile.mkdtemp()
+    _run({"hook_event_name": "SomeFutureHook", "session_id": "s"}, d)
+    _run({"session_id": "s"}, d, argv=["SessionEnd"])
+    rows = _journal(d)
+    check(rows[0]["type"] == "agent.activity" and rows[0]["hook"] == "SomeFutureHook",
+          "unknown hooks journal as generic agent.activity (forward-compatible)")
+    check(rows[1]["type"] == "agent.session.ended",
+          "argv hook-name fallback works when stdin lacks hook_event_name")
+
+
+def test_fail_open():
+    d = tempfile.mkdtemp()
+    p = _run(None, d, raw="{not json")
+    check(p.returncode == 0, "garbage stdin → exit 0 (NEVER wedge the core)")
+    p2 = _run(None, d, raw="")
+    check(p2.returncode == 0, "empty stdin → exit 0")
+    rows = _journal(d)
+    check(len(rows) == 1 and rows[0]["hook"] == "unknown",
+          "empty input still journals a generic activity; garbage journals nothing")
+
+
+def main():
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            print(f"# {name}")
+            fn()
+    if FAILS:
+        print(f"\nFAILED ({len(FAILS)})")
+        return 1
+    print("\nPASS — activity-emitter (journal source)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/activity-emitter.test.py
+++ b/tests/activity-emitter.test.py
@@ -79,6 +79,21 @@ def test_no_raw_command_leaks():
           "command-only Bash input reduces to kind alone (no display)")
 
 
+def test_url_hints_strip_query_and_fragment():
+    # Codex P1: URLs routinely carry bearer tokens / presigned sigs / OAuth
+    # codes in query or fragment — only scheme+host+path may reach the journal.
+    d = tempfile.mkdtemp()
+    _run({"hook_event_name": "PreToolUse", "session_id": "s",
+          "tool_name": "WebFetch",
+          "tool_input": {"url": "https://files.example/download?token=sk-SECRET&sig=abc#frag"}}, d)
+    rows = _journal(d)
+    dumped = json.dumps(rows)
+    check("sk-SECRET" not in dumped and "sig=abc" not in dumped and "#frag" not in dumped,
+          "URL SECRET HYGIENE — query + fragment never reach the journal")
+    check(rows[0]["tool"]["display"] == "https://files.example/download",
+          "URL hint keeps scheme+host+path (still useful display)")
+
+
 def test_binding_attribution():
     ws = Path(tempfile.mkdtemp())
     (ws / "state" / "bindings").mkdir(parents=True)


### PR DESCRIPTION
## What

Step 1 of the **Activity outbox** (AWP roadmap Phase 2 — the owner's pick, decided via the human-action bridge's first live card): a fail-open async hook that journals the core's activity as AWP activity objects.

```
Claude Code hooks (SessionStart/PreToolUse/PostToolUse/…, async)
  → hooks/activity-emitter.py (normalize; attribution from Execution Binding Registry)
  → <workspace>/state/activity-journal/YYYY-MM-DD.jsonl
```

- **First hook ring:** session lifecycle, tool start/complete/fail, attention, turn completion; unknown hooks → generic `agent.activity` (forward-compatible).
- **Secret hygiene:** tool input reduces to a display hint (`description`/`file_path`/`pattern`/`url`) — deliberately never the raw `command` (likeliest token carrier). Regression-tested with a synthetic bearer token.
- **Invariants:** fail-open + fast (exit 0 on any error — telemetry must never wedge the core); append-only JSONL, day-rotated, no fsync (telemetry ≠ decisions; the human-action store is the durable-by-contract one).
- **Not yet auto-registered** — registration instructions in hooks/README.md; the `build-core-settings.mjs` flip is a follow-up, same staging as the human-action hook (#2295).

## What this does NOT do (later steps per design)

Upstream HTTP delivery (needs broker `/v1/activities`); sparrow durable-outbox POSTing; WS preferred transport. The journal is the local activity feed until then.

## Test

`python3 tests/activity-emitter.test.py` — 13 assertions: mapping/journal order, secret hygiene, binding attribution via the real CLAUDE_CONFIG_DIR derivation, unknown-hook + argv fallback, fail-open. Auto-discovered (tests/*.test.py). ruff clean.

Cross-review: @001 per tonight's mutual-verification protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)