### PR TITLE
fix(util-paths): claude_home_path falls back to legacy ~/.claude/ for un-migrated config

### DIFF
--- a/src/util_paths.py
+++ b/src/util_paths.py
@@ -275,7 +275,25 @@ def claude_home_path(*subpath: str) -> Path:
         base = Path.home() / ".claude"
     if not subpath:
         return base
-    return base.joinpath(*subpath)
+    primary = base.joinpath(*subpath)
+    # Legacy reader-fallback (M1 30-day transition policy — see CLAUDE.md
+    # "Migration transition window"). When CLAUDE_CONFIG_DIR / CLAUDE_HOME points
+    # somewhere other than ~/.claude and the requested file is ABSENT there but
+    # PRESENT under the legacy ~/.claude/ home, resolve to the legacy copy and
+    # warn once. This bridges config that predates the config-home migration and
+    # was never copied forward (channels/, hooks/, skills/) — without it a
+    # stranded bot token is silently invisible and the bridge exits "no token"
+    # (the exact Telegram + Discord outage seen 2026-07-24). Pure fallback: it
+    # only fires when primary is MISSING and legacy EXISTS, so an already-migrated
+    # install is unaffected, and a brand-new write (neither exists) still lands at
+    # primary. Suppress with SUTANDO_SUPPRESS_CLAUDE_HOME_LEGACY_FALLBACK=1.
+    legacy_home = Path.home() / ".claude"
+    if base != legacy_home and not primary.exists():
+        legacy = legacy_home.joinpath(*subpath)
+        if legacy.exists():
+            _emit_claude_home_legacy_fallback_warning_once(subpath)
+            return legacy
+    return primary
 
 
 def channel_access_path(source: str) -> Path:
@@ -340,5 +358,29 @@ def _emit_claude_home_fallback_banner_once() -> None:
         "shell function and src/startup.sh set it; ad-hoc launches must too) so "
         "channels/skills/hooks/sessions resolve to the workspace-scoped per-runtime "
         "location post-#1454. Suppress with SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1.",
+        file=sys.stderr,
+    )
+
+
+# Deduped per (subpath) so a bridge that resolves the same stranded file every
+# poll doesn't spam stderr. Distinct from the CCD-unset banner above: this fires
+# when CCD *is* set correctly but a specific file was never migrated forward from
+# ~/.claude/, so it names the file and the copy-forward remedy.
+_CLAUDE_HOME_LEGACY_FALLBACK_WARNED: set = set()
+
+
+def _emit_claude_home_legacy_fallback_warning_once(subpath: tuple) -> None:
+    if os.environ.get("SUTANDO_SUPPRESS_CLAUDE_HOME_LEGACY_FALLBACK") == "1":
+        return
+    if subpath in _CLAUDE_HOME_LEGACY_FALLBACK_WARNED:
+        return
+    _CLAUDE_HOME_LEGACY_FALLBACK_WARNED.add(subpath)
+    rel = "/".join(subpath)
+    print(
+        f"claude_home_path: '{rel}' not found under $CLAUDE_CONFIG_DIR — using the "
+        f"legacy ~/.claude/{rel} copy. This config predates the config-home migration "
+        f"and was never copied forward; copy it into $CLAUDE_CONFIG_DIR to silence "
+        f"this (e.g. `cp -p ~/.claude/{rel} \"$CLAUDE_CONFIG_DIR/{rel}\"`). "
+        f"Suppress with SUTANDO_SUPPRESS_CLAUDE_HOME_LEGACY_FALLBACK=1.",
         file=sys.stderr,
     )

--- a/tests/util-paths-ccd-banner.test.py
+++ b/tests/util-paths-ccd-banner.test.py
@@ -19,7 +19,7 @@ REPO = Path(__file__).resolve().parent.parent
 SRC = REPO / "src"
 
 
-def _run_probe(env_overrides: dict[str, str | None]) -> tuple[str, str, int]:
+def _run_probe(env_overrides: dict[str, str | None], home: str | None = None) -> tuple[str, str, int]:
     """Run a minimal Python probe that imports util_paths and calls
     claude_home_path() three times, then prints the resolved base.
     Return (stdout, stderr, returncode). env_overrides=None unsets the key.
@@ -28,6 +28,12 @@ def _run_probe(env_overrides: dict[str, str | None]) -> tuple[str, str, int]:
     # Always start from a clean slate for these vars.
     for k in ("CLAUDE_CONFIG_DIR", "CLAUDE_HOME", "SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER"):
         env.pop(k, None)
+    # Isolate HOME so the legacy reader-fallback added in claude_home_path()
+    # (resolve to ~/.claude/<file> when the file is absent under CCD but present
+    # in the legacy home) can't leak the dev machine's real ~/.claude/channels/
+    # into these assertions. Callers pass a fresh empty temp dir as `home`.
+    if home is not None:
+        env["HOME"] = home
     for k, v in env_overrides.items():
         if v is None:
             env.pop(k, None)
@@ -83,8 +89,8 @@ def main() -> int:
 
     # Test 1: CCD set → no banner, resolved path uses CCD.
     print("\n[1] CLAUDE_CONFIG_DIR set → no banner, resolves under CCD")
-    with tempfile.TemporaryDirectory() as ccd:
-        out, err, rc = _run_probe({"CLAUDE_CONFIG_DIR": ccd})
+    with tempfile.TemporaryDirectory() as ccd, tempfile.TemporaryDirectory() as home:
+        out, err, rc = _run_probe({"CLAUDE_CONFIG_DIR": ccd}, home=home)
         passed.append(assert_eq(rc, 0, "exit 0"))
         passed.append(assert_not_in(
             "CLAUDE_CONFIG_DIR not set", err,
@@ -95,45 +101,47 @@ def main() -> int:
 
     # Test 2: CLAUDE_HOME set (legacy test override) → no banner.
     print("\n[2] CLAUDE_HOME set (CCD unset) → no banner, resolves under CLAUDE_HOME")
-    with tempfile.TemporaryDirectory() as home:
-        out, err, rc = _run_probe({"CLAUDE_HOME": home})
+    with tempfile.TemporaryDirectory() as claude_home, tempfile.TemporaryDirectory() as home:
+        out, err, rc = _run_probe({"CLAUDE_HOME": claude_home}, home=home)
         passed.append(assert_eq(rc, 0, "exit 0"))
         passed.append(assert_not_in(
             "CLAUDE_CONFIG_DIR not set", err,
             "no fallback banner on stderr (CLAUDE_HOME is a test override, not the deprecated path)"))
         passed.append(assert_in(
-            f"RESOLVED: {home}/channels/discord/access.json", out,
+            f"RESOLVED: {claude_home}/channels/discord/access.json", out,
             "resolved path uses CLAUDE_HOME"))
 
     # Test 3: Both unset → banner fires ONCE.
     print("\n[3] CCD + CLAUDE_HOME unset → banner fires ONCE, falls back to ~/.claude/")
-    out, err, rc = _run_probe({})
-    passed.append(assert_eq(rc, 0, "exit 0"))
-    passed.append(assert_in(
-        "CLAUDE_CONFIG_DIR not set", err,
-        "fallback banner present on stderr"))
-    # Count banner occurrences — should be exactly 1 even though we called the
-    # helper three times in the probe.
-    occurrences = err.count("CLAUDE_CONFIG_DIR not set")
-    passed.append(assert_eq(
-        occurrences, 1,
-        f"banner fires exactly once across 3 helper calls (got {occurrences})"))
-    home_default = str(Path.home() / ".claude")
-    passed.append(assert_in(
-        f"RESOLVED: {home_default}/channels/discord/access.json", out,
-        "resolved path uses ~/.claude/ default"))
+    with tempfile.TemporaryDirectory() as home:
+        out, err, rc = _run_probe({}, home=home)
+        passed.append(assert_eq(rc, 0, "exit 0"))
+        passed.append(assert_in(
+            "CLAUDE_CONFIG_DIR not set", err,
+            "fallback banner present on stderr"))
+        # Count banner occurrences — should be exactly 1 even though we called the
+        # helper three times in the probe.
+        occurrences = err.count("CLAUDE_CONFIG_DIR not set")
+        passed.append(assert_eq(
+            occurrences, 1,
+            f"banner fires exactly once across 3 helper calls (got {occurrences})"))
+        home_default = str(Path(home) / ".claude")
+        passed.append(assert_in(
+            f"RESOLVED: {home_default}/channels/discord/access.json", out,
+            "resolved path uses ~/.claude/ default"))
 
     # Test 4: Suppression env var set → no banner even when both unset.
     print("\n[4] SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER=1 → no banner, still falls back")
-    out, err, rc = _run_probe({"SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER": "1"})
-    passed.append(assert_eq(rc, 0, "exit 0"))
-    passed.append(assert_not_in(
-        "CLAUDE_CONFIG_DIR not set", err,
-        "no banner with suppression env var set"))
-    home_default = str(Path.home() / ".claude")
-    passed.append(assert_in(
-        f"RESOLVED: {home_default}/channels/discord/access.json", out,
-        "resolved path still uses ~/.claude/ default (suppression only silences banner)"))
+    with tempfile.TemporaryDirectory() as home:
+        out, err, rc = _run_probe({"SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER": "1"}, home=home)
+        passed.append(assert_eq(rc, 0, "exit 0"))
+        passed.append(assert_not_in(
+            "CLAUDE_CONFIG_DIR not set", err,
+            "no banner with suppression env var set"))
+        home_default = str(Path(home) / ".claude")
+        passed.append(assert_in(
+            f"RESOLVED: {home_default}/channels/discord/access.json", out,
+            "resolved path still uses ~/.claude/ default (suppression only silences banner)"))
 
     print("\n" + "=" * 50)
     failed = passed.count(False)

--- a/tests/util-paths-legacy-fallback.test.py
+++ b/tests/util-paths-legacy-fallback.test.py
@@ -107,9 +107,66 @@ def main() -> int:
         results.append(check(_resolved(out) == legacy_path, "case4 still resolves to legacy when suppressed"))
         results.append(check("not found under" not in err, "case4 warning suppressed"))
 
+    results.extend(_in_process_coverage())
+
     passed = sum(1 for r in results if r)
     print(f"\n{passed}/{len(results)} checks passed")
     return 0 if passed == len(results) else 1
+
+
+def _in_process_coverage():
+    """Exercise claude_home_path()'s fallback branches IN-PROCESS so the
+    coverage gate (scripts/coverage-gate.sh runs each test under `coverage run`)
+    counts the added src/util_paths.py lines. The subprocess probes above are
+    the behavioral contract; these direct calls are what the coverage tool can
+    see (a child `python3 -c` is not instrumented)."""
+    print("\n[in-process coverage]")
+    sys.path.insert(0, str(SRC))
+    import util_paths as up
+    out = []
+    saved = {k: os.environ.get(k) for k in
+             ("HOME", "CLAUDE_CONFIG_DIR", "CLAUDE_HOME",
+              "SUTANDO_SUPPRESS_CLAUDE_HOME_LEGACY_FALLBACK")}
+    with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as ccd:
+        try:
+            os.environ["HOME"] = home
+            os.environ["CLAUDE_CONFIG_DIR"] = ccd
+            os.environ.pop("CLAUDE_HOME", None)
+            os.environ.pop("SUTANDO_SUPPRESS_CLAUDE_HOME_LEGACY_FALLBACK", None)
+            up._CLAUDE_HOME_LEGACY_FALLBACK_WARNED.clear()
+
+            legacy = Path(home) / ".claude" / Path(*SUB)
+            legacy.parent.mkdir(parents=True, exist_ok=True)
+            legacy.write_text("legacy\n")
+
+            # (a) primary missing + legacy present -> warn + return legacy
+            out.append(check(str(up.claude_home_path(*SUB)) == str(legacy),
+                             "in-proc: fallback resolves to legacy + warns"))
+            # (b) same subpath again -> dedup branch of the warning helper
+            out.append(check(str(up.claude_home_path(*SUB)) == str(legacy),
+                             "in-proc: dedup branch (no re-warn)"))
+            # (c) suppressed -> suppression branch of the warning helper
+            up._CLAUDE_HOME_LEGACY_FALLBACK_WARNED.clear()
+            os.environ["SUTANDO_SUPPRESS_CLAUDE_HOME_LEGACY_FALLBACK"] = "1"
+            out.append(check(str(up.claude_home_path(*SUB)) == str(legacy),
+                             "in-proc: suppressed fallback still resolves"))
+            os.environ.pop("SUTANDO_SUPPRESS_CLAUDE_HOME_LEGACY_FALLBACK", None)
+            # (d) primary present -> return primary (no fallback)
+            prim = Path(ccd) / Path(*SUB)
+            prim.parent.mkdir(parents=True, exist_ok=True)
+            prim.write_text("primary\n")
+            out.append(check(str(up.claude_home_path(*SUB)) == str(prim),
+                             "in-proc: primary present -> primary"))
+            # (e) no subpath -> base returned directly
+            out.append(check(str(up.claude_home_path()) == ccd,
+                             "in-proc: base returned when no subpath"))
+        finally:
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+    return out
 
 
 if __name__ == "__main__":

--- a/tests/util-paths-legacy-fallback.test.py
+++ b/tests/util-paths-legacy-fallback.test.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Tests for src/util_paths.py claude_home_path() legacy reader-fallback.
+
+Regression guard for the 2026-07-24 Telegram + Discord outage: bot tokens +
+allowlists lived at the legacy ~/.claude/channels/ home, but the active
+CLAUDE_CONFIG_DIR had no channels/ dir. claude_home_path() resolved straight to
+the (empty) active dir with no fallback, so the stranded config was invisible
+and both bridges exited "no token".
+
+Policy (CLAUDE.md "Migration transition window"): when CLAUDE_CONFIG_DIR points
+somewhere other than ~/.claude and the requested file is ABSENT there but
+PRESENT under legacy ~/.claude/, resolve to the legacy copy and warn once.
+
+Run: python3 tests/util-paths-legacy-fallback.test.py
+"""
+from __future__ import annotations
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "src"
+
+SUB = ("channels", "discord", "access.json")
+
+
+def _run_probe(*, home: str, ccd: str | None, seed_legacy: bool, seed_primary: bool,
+               suppress: bool = False) -> tuple[str, str, int]:
+    """Set up isolated HOME (+ optional CCD) dirs, optionally seed the file in
+    the legacy ~/.claude/ tree and/or the CCD tree, then resolve SUB and print
+    the result. Returns (stdout, stderr, returncode).
+    """
+    home_p = Path(home)
+    if seed_legacy:
+        legacy = home_p / ".claude" / Path(*SUB)
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text("legacy-token\n")
+    if seed_primary and ccd:
+        prim = Path(ccd) / Path(*SUB)
+        prim.parent.mkdir(parents=True, exist_ok=True)
+        prim.write_text("primary-token\n")
+
+    env = os.environ.copy()
+    for k in ("CLAUDE_CONFIG_DIR", "CLAUDE_HOME",
+              "SUTANDO_SUPPRESS_CLAUDE_HOME_LEGACY_FALLBACK"):
+        env.pop(k, None)
+    env["HOME"] = home
+    if ccd is not None:
+        env["CLAUDE_CONFIG_DIR"] = ccd
+    if suppress:
+        env["SUTANDO_SUPPRESS_CLAUDE_HOME_LEGACY_FALLBACK"] = "1"
+
+    probe = f"""
+import sys
+sys.path.insert(0, {str(SRC)!r})
+from util_paths import claude_home_path
+p = claude_home_path(*{SUB!r})
+print('RESOLVED:', p, flush=True)
+"""
+    r = subprocess.run([sys.executable, "-c", probe], env=env,
+                       capture_output=True, text=True, timeout=10)
+    return r.stdout, r.stderr, r.returncode
+
+
+def _resolved(stdout: str) -> str:
+    for line in stdout.splitlines():
+        if line.startswith("RESOLVED:"):
+            return line[len("RESOLVED:"):].strip()
+    return ""
+
+
+def check(cond, label):
+    print(f"  {'PASS' if cond else 'FAIL'}: {label}")
+    return cond
+
+
+def main() -> int:
+    results = []
+    with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as ccd:
+        # 1. Primary missing, legacy present → fall back to legacy + warn once.
+        out, err, rc = _run_probe(home=home, ccd=ccd, seed_legacy=True, seed_primary=False)
+        legacy_path = str(Path(home) / ".claude" / Path(*SUB))
+        results.append(check(rc == 0, "case1 exit 0"))
+        results.append(check(_resolved(out) == legacy_path, "case1 resolves to legacy copy"))
+        results.append(check("not found under $CLAUDE_CONFIG_DIR" in err, "case1 emits warning"))
+
+    with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as ccd:
+        # 2. Primary present → use primary, never fall back, no warning.
+        out, err, rc = _run_probe(home=home, ccd=ccd, seed_legacy=True, seed_primary=True)
+        primary_path = str(Path(ccd) / Path(*SUB))
+        results.append(check(_resolved(out) == primary_path, "case2 resolves to primary when it exists"))
+        results.append(check("not found under" not in err, "case2 no warning when primary exists"))
+
+    with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as ccd:
+        # 3. Neither present (fresh write target) → return primary, no warning.
+        out, err, rc = _run_probe(home=home, ccd=ccd, seed_legacy=False, seed_primary=False)
+        primary_path = str(Path(ccd) / Path(*SUB))
+        results.append(check(_resolved(out) == primary_path, "case3 returns primary when legacy absent"))
+        results.append(check("not found under" not in err, "case3 no warning when nothing to fall back to"))
+
+    with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as ccd:
+        # 4. Suppression env silences the warning but STILL resolves to legacy.
+        out, err, rc = _run_probe(home=home, ccd=ccd, seed_legacy=True, seed_primary=False, suppress=True)
+        legacy_path = str(Path(home) / ".claude" / Path(*SUB))
+        results.append(check(_resolved(out) == legacy_path, "case4 still resolves to legacy when suppressed"))
+        results.append(check("not found under" not in err, "case4 warning suppressed"))
+
+    passed = sum(1 for r in results if r)
+    print(f"\n{passed}/{len(results)} checks passed")
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

When `CLAUDE_CONFIG_DIR` is set (every claude-sutando install), `claude_home_path()` resolves straight to the workspace-scoped `.claude-sutando/` with **no fallback**. Config that predates the config-home migration and was never copied forward — bot tokens + allowlists under `~/.claude/channels/` — becomes invisible: the resolver returns a non-existent path under `CLAUDE_CONFIG_DIR`, and the Telegram/Discord bridges exit `"no token"`.

This is the root cause of a **dual-bridge outage on 2026-07-24**: a supervisor-launched core (which skips `src/startup.sh`) had its `channels/` config stranded at `~/.claude/channels/`, so neither Telegram nor Discord ever came up, and owner DMs went unanswered.

CLAUDE.md's own **"Migration transition window"** policy already prescribes the fix: readers should prefer the canonical location but **fall back to the legacy one for ~30 days with a one-line stderr deprecation warning**. That fallback was simply never implemented.

## Fix

Add the documented reader-fallback at the single choke point every config reader goes through (`channels/`, `hooks/`, `skills/`, `sessions/`). It is a **pure reader-fallback**: it only fires when the requested file is **absent under `CLAUDE_CONFIG_DIR` and present under legacy `~/.claude/`**.

- Already-migrated install → unaffected (primary exists, used directly).
- Brand-new write target (neither exists) → still resolves to primary.
- Warning is deduped per subpath and suppressible via `SUTANDO_SUPPRESS_CLAUDE_HOME_LEGACY_FALLBACK=1`.

## Before / after evidence

Scenario: `CLAUDE_CONFIG_DIR` set to an empty dir, the file present only under `~/.claude/`.

**Before (`origin/main`):**
```
resolved: <CCD>/channels/discord/access.json
exists: False        # ← bridge sees no token, exits
```

**After (this branch):**
```
claude_home_path: 'channels/discord/access.json' not found under $CLAUDE_CONFIG_DIR — using the legacy ~/.claude/channels/discord/access.json copy. This config predates the config-home migration and was never copied forward; copy it into $CLAUDE_CONFIG_DIR to silence this (e.g. `cp -p ...`). Suppress with SUTANDO_SUPPRESS_CLAUDE_HOME_LEGACY_FALLBACK=1.
resolved: <HOME>/.claude/channels/discord/access.json
exists: True         # ← real config found, bridge boots
```

Real-world confirmation: after migrating the stranded config forward on the affected host, both bridges booted and replied to the queued owner messages end-to-end.

## Tests

- `tests/util-paths-legacy-fallback.test.py` (new, 9 checks): fallback fires when primary missing + legacy present; primary wins when it exists; no fallback when legacy absent; suppression silences the warning but still resolves to legacy.
- `tests/util-paths-ccd-banner.test.py` made **hermetic** — it never isolated `HOME`, so the new fallback would read the dev machine's real `~/.claude/channels/`. Each case now runs under a temp `HOME`. 13/13 pass.

```
$ python3 tests/util-paths-legacy-fallback.test.py   # 9/9 checks passed
$ python3 tests/util-paths-ccd-banner.test.py        # Pass: 13 / 13
```

## Scope

Single concern: the resolver fallback. Bridge auto-restart/supervision (the second amplifier of the same outage) is intentionally **out of scope** — it is already covered by open PR #2068.

🤖 Generated with [Claude Code](https://claude.com/claude-code)