### PR TITLE
ci(sparrow): tag-triggered PyPI publish workflow (Trusted Publishing) + 0.3.0 bump

### DIFF
--- a/.github/workflows/publish-sparrow.yml
+++ b/.github/workflows/publish-sparrow.yml
@@ -1,0 +1,86 @@
+# Publish ag2-sparrow to PyPI — tag-triggered, Trusted Publishing (OIDC).
+#
+# Release flow:
+#   1. bump packages/ag2-sparrow/ag2_sparrow/__init__.py __version__ (PR, merge)
+#   2. tag the merge commit:  git tag sparrow-v<version> && git push origin sparrow-v<version>
+#   3. this workflow builds sdist+wheel from packages/ag2-sparrow and publishes.
+#
+# Guards:
+#   - the tag MUST equal the packaged __version__ (fail loudly on mismatch);
+#   - the version MUST NOT already exist on PyPI (no silent re-upload);
+#   - the package test suites + src-drift guard run before any upload.
+#
+# One-time PyPI setup (owner): project ag2-sparrow → Publishing → add GitHub
+# Trusted Publisher (owner: sonichi, repo: sutando, workflow:
+# publish-sparrow.yml, environment: pypi). No API token is stored anywhere.
+#
+# The version-drift job below is PR-time advisory: it warns (never fails) when
+# a PR changes packages/ag2-sparrow/** without moving __version__ past the
+# published PyPI release — the "main is silently ahead of PyPI" signal.
+name: publish-sparrow
+
+on:
+  push:
+    tags: ["sparrow-v*"]
+  pull_request:
+    paths: ["packages/ag2-sparrow/**"]
+
+permissions:
+  contents: read
+
+jobs:
+  version-drift:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with: {python-version: "3.11"}
+      - name: Warn when package changes ride an already-published version
+        run: |
+          set -e
+          LOCAL=$(python3 -c "import sys; sys.path.insert(0, 'packages/ag2-sparrow'); import ag2_sparrow; print(ag2_sparrow.__version__)")
+          PYPI=$(python3 -c "import json,urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/ag2-sparrow/json'))['info']['version'])" || echo unknown)
+          echo "local __version__=$LOCAL  pypi latest=$PYPI"
+          if [ "$LOCAL" = "$PYPI" ]; then
+            echo "::warning title=ag2-sparrow version not bumped::This PR changes packages/ag2-sparrow/** but __version__ ($LOCAL) equals the published PyPI release — after merge, main will be ahead of PyPI with no release signal. Bump __version__ (and tag sparrow-v<version> after merge) when this change should ship."
+          fi
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/sparrow-v')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # OIDC for PyPI Trusted Publishing
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with: {python-version: "3.11"}
+      - name: Tag must match the packaged version
+        run: |
+          set -e
+          TAG="${GITHUB_REF#refs/tags/sparrow-v}"
+          VER=$(python3 -c "import sys; sys.path.insert(0, 'packages/ag2-sparrow'); import ag2_sparrow; print(ag2_sparrow.__version__)")
+          echo "tag=$TAG  __version__=$VER"
+          [ "$TAG" = "$VER" ] || { echo "::error::tag sparrow-v$TAG != __version__ $VER"; exit 1; }
+      - name: Refuse re-publishing an existing PyPI version
+        run: |
+          set -e
+          VER=$(python3 -c "import sys; sys.path.insert(0, 'packages/ag2-sparrow'); import ag2_sparrow; print(ag2_sparrow.__version__)")
+          if python3 -c "import json,sys,urllib.request; d=json.load(urllib.request.urlopen('https://pypi.org/pypi/ag2-sparrow/json')); sys.exit(0 if '$VER' in d['releases'] else 1)"; then
+            echo "::error::version $VER already on PyPI — bump __version__"; exit 1
+          fi
+      - name: Test before publish (package suites + src-drift guard)
+        run: |
+          set -e
+          for t in packages/ag2-sparrow/tests/test_*.py; do python3 "$t"; done
+          python3 packages/ag2-sparrow/tools/test_no_drift.py
+      - name: Build sdist + wheel
+        run: |
+          python3 -m pip install --quiet build
+          python3 -m build packages/ag2-sparrow --outdir dist/
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/packages/ag2-sparrow/README.md
+++ b/packages/ag2-sparrow/README.md
@@ -26,6 +26,21 @@ ag2-sparrow
 The token is your AG2 Space **identity** — not a model API key. Your agent runs
 locally with its own credentials; only tasks and results flow through AG2 Space.
 
+## Optional: room-event subscription (0.3.0)
+
+Off by default. With `SPARROW_EVENTS=1` the client also maintains a persistent
+SSE channel to the events plane: room events land in a durable local inbox
+(SQLite, crash-safe, exactly-once) and batches of meaningful events are
+promoted into ambient task files a worker can pick up. Fully isolated from
+task delivery — a channel failure never affects the task loop.
+
+| Env | Meaning |
+|---|---|
+| `SPARROW_EVENTS` | `1` enables the event channel + consumer (default off) |
+| `SPARROW_HA_OWNER` | owner mxid; enables human-action decision routing — the owner's typed/reacted answers to pending question cards resolve them |
+| `SPARROW_HA_ROOM` | room id where question cards are posted (with `SPARROW_HA_OWNER`) |
+| `SPARROW_HA_A2UI` | `1` attaches interactive A2UI blocks to cards (default off; requires a client that renders them) |
+
 ## Directories & single source
 
 The client's filesystem contract is three dirs — set them (or take the defaults):
@@ -38,7 +53,7 @@ The client's filesystem contract is three dirs — set them (or take the default
 
 Point these at the same queue your worker (e.g. agent-connect) watches. Zero third-party runtime dependencies.
 
-The transport modules (`remote_gateway_bridge`, `_dirs`, `send_allowlist`) are canonical here; the pure shared utilities (`task_archive`, `local_task_protocol`, `result_markers`) are bundled verbatim from [`sonichi/sutando`](https://github.com/sonichi/sutando) `src/` via `tools/sync_from_src.py`.
+The transport modules (`remote_gateway_bridge`, `event_channel`, `event_inbox`, `event_consumer`, `human_action`, `_dirs`, `send_allowlist`) are canonical here; the pure shared utilities (`task_archive`, `local_task_protocol`, `result_markers`, `workspace_lock`) are bundled verbatim from [`sonichi/sutando`](https://github.com/sonichi/sutando) `src/` via `tools/sync_from_src.py`.
 
 ## License
 

--- a/packages/ag2-sparrow/ag2_sparrow/__init__.py
+++ b/packages/ag2-sparrow/ag2_sparrow/__init__.py
@@ -9,4 +9,4 @@ The modules here are the canonical AG2 Space relay client, kept in lockstep with
 sonichi/sutando `src/` via tools/sync_from_src.py (a drift-check test fails CI if
 they diverge — single source of truth, no hand-maintained fork).
 """
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
## Why

`ag2-sparrow` 0.1.0/0.2.0 were published to PyPI manually, and main has since shipped a generation of features (event channel, human-action decision handling, secret redaction) still labeled 0.2.0 — pip users silently trail the repo with no release signal.

## What

**`.github/workflows/publish-sparrow.yml`** — the standard tag-driven release path:

- **Trigger**: push tag `sparrow-v<version>` (release), or PR touching `packages/ag2-sparrow/**` (advisory job only).
- **Guards before any upload**: tag must equal `ag2_sparrow.__version__`; that version must not already exist on PyPI (no silent re-upload); all package test suites + the src-drift guard must pass.
- **Publish**: `python -m build` → `pypa/gh-action-pypi-publish` with **Trusted Publishing** (OIDC, `environment: pypi`) — no API token stored anywhere.
- **PR-time advisory**: when a PR changes `packages/ag2-sparrow/**` while `__version__` equals the published PyPI release, the job emits a warning (never fails) — the "main is ahead of PyPI" signal that was missing.

**Version bump to 0.3.0** so the first tagged release carries this week's work.

## One-time owner setup

PyPI → project `ag2-sparrow` → Publishing → add GitHub Trusted Publisher (owner `sonichi`, repo `sutando`, workflow `publish-sparrow.yml`, environment `pypi`). Until that's configured the publish job simply fails at the upload step — merging this is safe at any time.

## Release flow after merge

```
git tag sparrow-v0.3.0 <merge-commit> && git push origin sparrow-v0.3.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)