### PR TITLE
fix(ag2space): resolve owner+connected for the desktop onboarding probe

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -494,22 +494,44 @@ probe_ag2space = {'connected': False, 'agent_id': None, 'owner': None}
 # file, but installs enrolled via the OSS path (onboard.sh -> startup.sh) and
 # the AG2 Space desktop launcher (AG2_DEVICE_ENV) write channels/ag2space/.env
 # instead. Try canonical first, then legacy, before concluding not-connected.
-for _envname in ('relay-client.env', '.env'):
-    try:
-        _kv = {}
-        with open(os.path.join(brain, 'channels', 'ag2space', _envname)) as f:
-            for _line in f:
-                _line = _line.strip()
-                if _line and not _line.startswith('#') and '=' in _line:
-                    _k, _, _v = _line.partition('=')
-                    _kv[_k.strip()] = _v.strip()
-        # AG2_REMOTE_TOKEN is the legacy alias for the same enrollment
-        # (startup.sh + health-check.py both recognize it) — either counts.
-        if _kv.get('REMOTE_TASK_TOKEN') or _kv.get('AG2_REMOTE_TOKEN'):
-            probe_ag2space['connected'] = True
-            break
-    except Exception:
-        pass
+#
+# Two BASE dirs, brain first then the desktop app-support dir: the desktop
+# connect-flow writes the token under app_data_dir()/channels/ag2space/ (Rust
+# lib.rs, for the AG2_DEVICE_ENV hand-off + gateway-keepalive) -- NOT under the
+# brain this probe defaults to. Without the app-support base, a genuinely
+# connected desktop core reads back connected=false (and, gated on it, owner
+# null) -- the desktop dialog then shows 'not paired yet' for a paired agent.
+# Prefer the exact file the desktop passes via AG2_DEVICE_ENV when present;
+# otherwise fall back to the canonical macOS app-support location for the
+# space.ag2.app bundle. HOME-relative so it stays correct per-user.
+_ag2_bases = [os.path.join(brain, 'channels', 'ag2space')]
+_device_env = os.environ.get('AG2_DEVICE_ENV')
+if _device_env:
+    _ag2_bases.append(os.path.dirname(_device_env))
+_ag2_bases.append(os.path.join(
+    os.path.expanduser('~'), 'Library', 'Application Support',
+    'space.ag2.app', 'channels', 'ag2space'))
+_found_token = False
+for _base in _ag2_bases:
+    if _found_token:
+        break
+    for _envname in ('relay-client.env', '.env'):
+        try:
+            _kv = {}
+            with open(os.path.join(_base, _envname)) as f:
+                for _line in f:
+                    _line = _line.strip()
+                    if _line and not _line.startswith('#') and '=' in _line:
+                        _k, _, _v = _line.partition('=')
+                        _kv[_k.strip()] = _v.strip()
+            # AG2_REMOTE_TOKEN is the legacy alias for the same enrollment
+            # (startup.sh + health-check.py both recognize it) -- either counts.
+            if _kv.get('REMOTE_TASK_TOKEN') or _kv.get('AG2_REMOTE_TOKEN'):
+                probe_ag2space['connected'] = True
+                _found_token = True
+                break
+        except Exception:
+            pass
 try:
     with open(os.path.join(ws, 'state', 'auth', 'ag2space.json')) as f:
         _aid = json.load(f).get('agent_id') or ''
@@ -529,6 +551,16 @@ try:
         probe_ag2space['owner'] = _own
 except Exception:
     pass
+# NOTE: earlier this fell back to agent_id when tofuOwner was empty. That was
+# wrong: the dialog compares owner to the signed-in HUMAN, so an agent-id owner
+# read as owned-by-someone-else (agent != human) -> the other branch, which hides
+# the pair-as-owner button entirely. Owner must be the HUMAN mxid, which only the
+# webview knows; it records it via the write_ag2space_owner Tauri command on
+# pairing, and the tofuOwner read above picks it up. When no human owner is
+# recorded yet, owner stays null -> the dialog correctly shows unpaired and offers
+# to pair. (connected still resolves independently, above.)
+# Keep this comment free of double-quotes, backticks and dollar signs -- the whole
+# probe is inside a double-quoted python3 -c shell string.
 env = dict(os.environ, SUTANDO_TMUX_SOCKET=probe_socket)
 h = {}
 try:


### PR DESCRIPTION
## What & why

`scripts/sutando-config.sh runtime` emits the AgentRuntime descriptor's `ag2space` block, which the AG2 Space desktop shell reads to render the **"This agent is already connected"** dialog (Agent / Owner / Gateway). Two ag2space false-negatives made a genuinely-paired desktop agent read as unpaired:

### 1. `connected` was false for a connected desktop core
The probe read the relay token only from `<brain>/channels/ag2space/`. But the desktop connect-flow writes it under `app_data_dir()/channels/ag2space/` (the file it hands the bridge via `AG2_DEVICE_ENV`, and what `gateway-keepalive.sh` sources). So a real, connected core reported `connected: false`.

**Fix:** scan the app-support base too — preferring the exact file `AG2_DEVICE_ENV` points at when set, otherwise the canonical `~/Library/Application Support/space.ag2.app/channels/ag2space/` (HOME-relative, per-user). The existing `<brain>` location is still tried first, so OSS/CLI installs are unaffected.

### 2. `owner` resolution hid the "Pair as owner" button
ag2space is broker/token-attested and never writes a `tofuOwner`, so `owner` was always `null` → a false *"not paired yet"*. An interim `agent_id` fallback made it worse: the agent mxid ≠ the signed-in human, so the dialog took its *"this core is owned by someone else"* branch, which **hides** the "Pair as owner" button entirely — the user could never pair.

**Fix:** remove the `agent_id` fallback. `owner` stays `null` until the **human** is recorded, so the dialog correctly offers "Pair as owner". The human mxid is written by the desktop's `write_ag2space_owner` command (webview-side, on pairing) into the ag2space `access.json`; the existing `tofuOwner` read here then surfaces it. `connected` resolves independently of `owner`.

## Before / after evidence

`bash scripts/sutando-config.sh runtime | jq .ag2space`, on a connected desktop core:

**Before** (parent `qingyun-dev`):
```json
{"connected": false, "agent_id": "@vidhu-desktop.agent:ag2.space", "owner": "@vidhu:ag2.space"}
```
→ `connected: false` despite the gateway being Up and the relay token present (in app-support). The dialog shows a paired agent as disconnected.

**After** (this branch):
```json
{"connected": true, "agent_id": "@vidhu-desktop.agent:ag2.space", "owner": "@vidhu:ag2.space"}
```
→ `connected: true`. (Here `owner` is already populated because the sibling desktop write had persisted `access.json`; on a fresh core it is `null` until "Pair as owner" writes the human mxid — which then reads back through the unchanged `tofuOwner` path.)

## Scope / notes

- Single file, single concern: `scripts/sutando-config.sh` (the `ag2space` probe block), +48/−16.
- No hardcoded token/host values added; the only new path is the documented per-user app-support location (HOME-relative) plus the `AG2_DEVICE_ENV`-provided path.
- Targets **`qingyun-dev`** deliberately: the `ag2space` probe block this patches exists on `qingyun-dev`, not `main` (`grep -c probe_ag2space` on `main` = 0). This is a fix to that integration line, not a `main` change.
- The `write_ag2space_owner` writer referenced above is the desktop (Tauri) half and lives in the desktop repo; this PR is only the engine-side read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
