### PR TITLE
fix(gateway): decode a %7C-encoded url|secret separator + fail loud on a URL-less token

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -138,28 +138,34 @@ def _env_compat(new, old):
 # string may be the combined "https://<gateway>|<secret>" form (the URL travels
 # inside the token — nothing service-specific lives in this repo); a bare
 # secret needs REMOTE_TASK_URL alongside it.
+# The combined onboarding form is "<url>|<secret>" — the URL travels inside the
+# token. The separator is a literal "|", OR a "%7C"/"%7c" when the desktop connect
+# flow URL-encodes it (ag2space-cinny-desktop#231): "https://<gateway>/relay%7C<secret>".
+# A %7C-separated token carries no literal "|", so a naive split leaves it a bare
+# secret with an empty URL and the bridge FATALs at startup — the core looks
+# "connected" (device-connect completed) but never responds, the Vidhu-onboarding
+# failure 2026-07-24.
+_SEPARATOR_RE = re.compile(r"\||%7[Cc]")
+
+
 def _parse_onboarding_token(raw):
     """Split the onboarding string into (url_from_token, secret).
 
-    The combined form is "https://<gateway>|<secret>" — the URL travels inside
-    the token. Returns ("", raw) for a bare secret (URL then comes from
-    REMOTE_TASK_URL alongside it).
+    NEVER mutates the token bytes — it only *splits* at the separator, so the
+    secret is returned verbatim (a bearer that itself contains "%7C" or "|" is
+    preserved intact; #2307 review). Disambiguation: only the combined form —
+    which begins with an http(s):// scheme — carries a separator to split on; a
+    bare secret is opaque and returned untouched even if it contains "%7C".
 
-    Defensive: the desktop connect flow has been observed to URL-encode the
-    separator as %7C — "https://<gateway>/relay%7C<secret>"
-    (ag2space-cinny-desktop#231). A %7C token carries no literal "|", so without
-    this it parses as a bare secret with an empty URL and FATALs at startup —
-    the core looks "connected" (device-connect completed) but never responds,
-    the Vidhu-onboarding failure 2026-07-24. Decoding here, at the single parse
-    point, covers every caller (startup.sh, direct env, legacy alias) regardless
-    of which onboarding writer produced the token.
+    Handled at the single parse point, so every caller (startup.sh, direct env,
+    legacy AG2_REMOTE_TOKEN alias) is covered regardless of the onboarding writer.
     """
-    if "%7c" in raw.lower():
-        raw = raw.replace("%7C", "|").replace("%7c", "|")
-    if "|" in raw:
-        url, secret = raw.split("|", 1)
-        return url, secret
-    return "", raw
+    if not raw.lower().startswith(("http://", "https://")):
+        return "", raw  # bare secret — opaque, never touched
+    m = _SEPARATOR_RE.search(raw)
+    if m is None:
+        return "", raw  # scheme but no separator; the URL-less guard in main() speaks
+    return raw[:m.start()], raw[m.end():]  # URL + secret, both verbatim
 
 
 _RAW = _env_compat("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN") or ""

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -138,11 +138,32 @@ def _env_compat(new, old):
 # string may be the combined "https://<gateway>|<secret>" form (the URL travels
 # inside the token — nothing service-specific lives in this repo); a bare
 # secret needs REMOTE_TASK_URL alongside it.
+def _parse_onboarding_token(raw):
+    """Split the onboarding string into (url_from_token, secret).
+
+    The combined form is "https://<gateway>|<secret>" — the URL travels inside
+    the token. Returns ("", raw) for a bare secret (URL then comes from
+    REMOTE_TASK_URL alongside it).
+
+    Defensive: the desktop connect flow has been observed to URL-encode the
+    separator as %7C — "https://<gateway>/relay%7C<secret>"
+    (ag2space-cinny-desktop#231). A %7C token carries no literal "|", so without
+    this it parses as a bare secret with an empty URL and FATALs at startup —
+    the core looks "connected" (device-connect completed) but never responds,
+    the Vidhu-onboarding failure 2026-07-24. Decoding here, at the single parse
+    point, covers every caller (startup.sh, direct env, legacy alias) regardless
+    of which onboarding writer produced the token.
+    """
+    if "%7c" in raw.lower():
+        raw = raw.replace("%7C", "|").replace("%7c", "|")
+    if "|" in raw:
+        url, secret = raw.split("|", 1)
+        return url, secret
+    return "", raw
+
+
 _RAW = _env_compat("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN") or ""
-if "|" in _RAW:
-    _URL_FROM_TOKEN, TOKEN = _RAW.split("|", 1)
-else:
-    _URL_FROM_TOKEN, TOKEN = "", _RAW
+_URL_FROM_TOKEN, TOKEN = _parse_onboarding_token(_RAW)
 URL = (_env_compat("REMOTE_TASK_URL", "AG2_REMOTE_URL")
        or _URL_FROM_TOKEN).rstrip("/")
 PROVIDER = os.environ.get("REMOTE_TASK_PROVIDER") or "remote"
@@ -1301,8 +1322,17 @@ def _maybe_start_event_channel() -> None:
 
 
 def main() -> None:
-    if not URL or not TOKEN:
-        sys.exit("FATAL: set REMOTE_TASK_TOKEN (and REMOTE_TASK_URL if your token is a bare secret).")
+    if not TOKEN:
+        sys.exit("FATAL: set REMOTE_TASK_TOKEN (the onboarding string, or a bare secret with REMOTE_TASK_URL).")
+    if not URL:
+        # A token that starts with a URL scheme but yielded no URL means the
+        # url|secret separator was swallowed (e.g. a %7C survived decoding, or a
+        # new encoding we don't handle) — say so, instead of the misleading
+        # "set REMOTE_TASK_TOKEN" when the token is present but malformed.
+        _hint = (" — the token carries a gateway URL but the url|secret separator "
+                 "looks missing/corrupted" if TOKEN[:4].lower() == "http" else "")
+        sys.exit("FATAL: no gateway URL — set REMOTE_TASK_URL, or use the combined "
+                 f"'https://<gateway>|<secret>' onboarding token{_hint}.")
     if not _acquire_singleton():
         return  # a live bridge already polls this workspace — exit cleanly (no dual-poll)
     inflight: set[str] = _load_inflight()

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -567,6 +567,25 @@ def main() -> int:
     check("AGENTS.md" not in _ro_only and "room-ops metadata" not in _ro_only.lower(),
           "metadata-only task file carries no injected block (empty task body)")
 
+    # Onboarding-token parse: the combined "url|secret" form, and the %7C-encoded
+    # separator the desktop connect flow emits (ag2space-cinny-desktop#231). A
+    # %7C token must decode so URL is populated — otherwise it parses as a bare
+    # secret with empty URL and FATALs at startup (the Vidhu "connected but not
+    # responding" failure, 2026-07-24).
+    check(rtc._parse_onboarding_token("https://chat.ag2.space/relay|deadbeef")
+          == ("https://chat.ag2.space/relay", "deadbeef"),
+          "token parse: literal | splits into (url, secret)")
+    check(rtc._parse_onboarding_token("https://chat.ag2.space/relay%7Cdeadbeef")
+          == ("https://chat.ag2.space/relay", "deadbeef"),
+          "token parse: %7C-encoded separator decodes to (url, secret)")
+    check(rtc._parse_onboarding_token("https://chat.ag2.space/relay%7cdeadbeef")
+          == ("https://chat.ag2.space/relay", "deadbeef"),
+          "token parse: lowercase %7c also decodes")
+    check(rtc._parse_onboarding_token("baresecret") == ("", "baresecret"),
+          "token parse: bare secret yields empty url (REMOTE_TASK_URL supplies it)")
+    check(rtc._parse_onboarding_token("https://gw|a|b") == ("https://gw", "a|b"),
+          "token parse: splits on the FIRST separator only (secret may contain |)")
+
     srv.shutdown()
     if FAILS:
         print(f"\nFAILED ({len(FAILS)})"); return 1

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -585,6 +585,13 @@ def main() -> int:
           "token parse: bare secret yields empty url (REMOTE_TASK_URL supplies it)")
     check(rtc._parse_onboarding_token("https://gw|a|b") == ("https://gw", "a|b"),
           "token parse: splits on the FIRST separator only (secret may contain |)")
+    # #2307 review: never mutate token bytes — the secret is returned verbatim.
+    check(rtc._parse_onboarding_token("https://gw|AB%7CCD") == ("https://gw", "AB%7CCD"),
+          "token parse: %7C INSIDE the secret is preserved, not decoded (split on the literal |)")
+    check(rtc._parse_onboarding_token("AB%7CCD") == ("", "AB%7CCD"),
+          "token parse: a bare secret containing %7C is opaque — returned untouched")
+    check(rtc._parse_onboarding_token("bare|secret") == ("", "bare|secret"),
+          "token parse: a bare secret with no URL scheme is not split on its own | bytes")
 
     srv.shutdown()
     if FAILS:


### PR DESCRIPTION
## What & why

The desktop connect flow (**ag2space-cinny-desktop#231**) has been observed to URL-encode the onboarding token's `url|secret` separator as `%7C`, producing e.g. `https://<gateway>/relay%7C<secret>`. A `%7C` token carries no literal `|`, so the bridge parsed it as a *bare secret with an empty URL* and **FATAL-exited at startup** (`main()`'s `if not URL or not TOKEN`). The core then looked **"connected"** (device-connect completed, other services up) but **never responded** — the gateway bridge was dead.

This was the **Vidhu onboarding failure (2026-07-24)**: token was valid (verified against the live relay: `op:joined_rooms` → ok, 4 rooms), but the `%7C` corruption bricked it silently.

## Change

- **Decode `%7C` → `|` at the single parse point** (new `_parse_onboarding_token`), so every caller — `startup.sh`, direct env, the legacy `AG2_REMOTE_TOKEN` alias — is covered regardless of which onboarding writer produced the token.
- **Fail loud, legibly.** Split the `main()` guard so a token-present-but-URL-less case gets an actionable message ("no gateway URL — the separator looks missing/corrupted") instead of the misleading "set REMOTE_TASK_TOKEN" (the token *is* set).

The cinny-side fix (stop emitting `%7C`) rides in ag2space-cinny-desktop#231; this is the **core-side defense** so a malformed token self-heals rather than silently bricking the agent.

## Before / after (actual output)

**BEFORE** (`origin/main`), parsing `https://gw.example%7Csekret` with no `REMOTE_TASK_URL`:
```
  URL = ''
  TOKEN = 'https://gw.example%7Csekret'
  main() guard "if not URL or not TOKEN" -> FATAL (URL empty)
```

**AFTER** (this branch), same input:
```
decoded URL= 'https://gw.example'  TOKEN= 'sekret'
OK: %7C decoded, URL populated -> no FATAL
```

## Tests

Added 5 checks to `src/remote-gateway-bridge.test.py` (combined `|`, `%7C`, lowercase `%7c`, bare-secret, first-separator-only). Full suite green:
```
  ok  token parse: literal | splits into (url, secret)
  ok  token parse: %7C-encoded separator decodes to (url, secret)
  ok  token parse: lowercase %7c also decodes
  ok  token parse: bare secret yields empty url (REMOTE_TASK_URL supplies it)
  ok  token parse: splits on the FIRST separator only (secret may contain |)
PASS — all checks green
```

## Scope

Single concern: token-parse robustness in the gateway bridge. No prompt/behavior changes. The path-alignment follow-up (desktop should write to `$CLAUDE_CONFIG_DIR/channels/` — the OSS-canonical location startup.sh reads — instead of a bundle-only `app_data/channels/`) is tracked separately as a cinny-side change.

— *qingyun-001 (Sutando core agent; contribution authored on behalf of @qingyun)*
