### PR TITLE
fix(startup): resolve AG2 Space inbound images (default REMOTE_MEDIA_MARKER=ag2space-media)

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -962,7 +962,15 @@ if _RELAY_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channel
   # would export a value and the bridge's default never fires. A shared /
   # multi-user gateway sets REMOTE_TASK_TIER=team explicitly.
   REMOTE_TASK_TIER="${REMOTE_TASK_TIER:-${AG2_REMOTE_TIER:-owner}}"
-  export REMOTE_TASK_TOKEN REMOTE_TASK_TIER
+  # AG2 Space's gateway tags inbound image/file markers `ag2space-media` (its
+  # media-proxy at {gateway}/v1/media/...). The provider-neutral bridge defaults
+  # its marker tag to `remote-media`, so without this the marker never matches and
+  # the media URL lands in the task body unresolved — the core can't see the image
+  # (owner-reported 2026-07-25). Default it to the AG2 tag here, in the AG2-specific
+  # launch block, so the generic package carries no provider string. Explicit
+  # REMOTE_MEDIA_MARKER (e.g. from the channel .env) still wins.
+  REMOTE_MEDIA_MARKER="${REMOTE_MEDIA_MARKER:-ag2space-media}"
+  export REMOTE_TASK_TOKEN REMOTE_TASK_TIER REMOTE_MEDIA_MARKER
   if ! pgrep -f "remote-gateway-bridge" > /dev/null 2>&1; then
     python3 "$REPO/src/remote-gateway-bridge.py" > "$LOGS_DIR/remote-gateway-bridge.log" 2>&1 &
     echo "  ✓ gateway bridge"

--- a/tests/startup-media-marker.test.py
+++ b/tests/startup-media-marker.test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Pin both sides of the AG2 launch block's REMOTE_MEDIA_MARKER contract.
+
+The provider-neutral bridge tests never execute startup.sh's launcher mapping,
+which is how a marker mismatch shipped (inbound images rendered as plain text).
+This test executes the REAL defaulting line extracted from src/startup.sh in a
+bash subshell — not a re-implementation of it — so it fails if the line is
+removed, renamed, or its semantics change:
+
+  1. unset REMOTE_MEDIA_MARKER  -> defaults to "ag2space-media"
+  2. explicitly set             -> the explicit value survives untouched
+"""
+import pathlib
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+STARTUP = REPO / "src" / "startup.sh"
+
+
+def _marker_line() -> str:
+    lines = [
+        ln.strip()
+        for ln in STARTUP.read_text().splitlines()
+        if 'REMOTE_MEDIA_MARKER="${REMOTE_MEDIA_MARKER:-' in ln
+    ]
+    assert len(lines) == 1, (
+        f"expected exactly one REMOTE_MEDIA_MARKER defaulting line in "
+        f"src/startup.sh, found {len(lines)} — the AG2 launch-block contract "
+        f"this test pins has moved or been duplicated"
+    )
+    return lines[0]
+
+
+def _run(prelude: str) -> str:
+    line = _marker_line()
+    out = subprocess.run(
+        ["bash", "-c", f'{prelude}; {line}; printf %s "$REMOTE_MEDIA_MARKER"'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout
+
+
+def test_default_when_unset():
+    got = _run("unset REMOTE_MEDIA_MARKER")
+    assert got == "ag2space-media", f"unset -> {got!r}, want 'ag2space-media'"
+    print("PASS test_default_when_unset")
+
+
+def test_explicit_value_wins():
+    got = _run("REMOTE_MEDIA_MARKER=custom-tag")
+    assert got == "custom-tag", f"explicit -> {got!r}, want 'custom-tag'"
+    print("PASS test_explicit_value_wins")
+
+
+def test_empty_string_gets_default():
+    # ${VAR:-default} (colon form) treats empty as unset — an empty marker from
+    # a half-written channel .env must not disable media resolution.
+    got = _run('REMOTE_MEDIA_MARKER=""')
+    assert got == "ag2space-media", f"empty -> {got!r}, want 'ag2space-media'"
+    print("PASS test_empty_string_gets_default")
+
+
+if __name__ == "__main__":
+    test_default_when_unset()
+    test_explicit_value_wins()
+    test_empty_string_gets_default()
+    print("ALL PASS")
+    sys.exit(0)


### PR DESCRIPTION
## What

AG2 Space inbound images/files never reached the core. A screenshot pasted into a room arrived in the task file as an unresolved marker —

```
[ag2space-media: https://chat.ag2.space/relay/v1/media/ag2.space/<id> mime=image/png name=Screenshot.png size=... kind=m.image]
```

— instead of a downloaded local file, so the agent literally could not see the picture. Owner-reported 2026-07-25.

## Root cause

The gateway tags its media-proxy markers `ag2space-media`, but the provider-neutral bridge defaults `MEDIA_MARKER_TAG` to `remote-media` (`remote_gateway_bridge.py:305`). `MEDIA_MARKER_RE` therefore never matched, `_maybe_fetch_media()` returned the body unchanged, and the raw URL persisted to `tasks/*.txt`.

The **download path was already correct**: `_maybe_fetch_media` → `_under_gateway(url)` already routes the gateway bearer to `{REMOTE_TASK_URL}/v1/media/...` URLs (`:695-696`). Only the marker *tag* was mismatched.

## How

`src/startup.sh` already maps the AG2-specific `AG2_REMOTE_*` env → the bridge's generic `REMOTE_TASK_*` in its AG2 launch block. This adds one line there:

```sh
REMOTE_MEDIA_MARKER="${REMOTE_MEDIA_MARKER:-ag2space-media}"
```

The default lives in the **AG2-specific launcher**, not the package, so `ag2-sparrow` carries no provider string (its default stays `remote-media`). An explicit `REMOTE_MEDIA_MARKER` (e.g. from the channel `.env`) still wins.

## Testing

Live before/after through the real bridge code against a real gateway media URL (same image both runs):

```
BEFORE (REMOTE_MEDIA_MARKER=remote-media — the bug):
  resolved? False
  [ag2space-media: https://chat.ag2.space/relay/v1/media/ag2.space/... mime=image/png ...   ← raw, unresolved

AFTER (REMOTE_MEDIA_MARKER=ag2space-media — this fix):
  [remote-gateway-bridge] fetched media → .../state/remote-media/verify-7dnur9te.png (502296 bytes)
  resolved? True
  [Photo attached: .../state/remote-media/verify-7dnur9te.png] test caption   ← downloaded + rewritten
```

Post-restart round trip on the live host: bridge relaunched with the marker set, reacquired the singleton poller lock, reconnected to `chat.ag2.space/relay`, and a subsequently-pasted room image now arrives as `[Photo attached: <local path>]` with no manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
