### PR TITLE
feat(health-check): comm-sweep staleness probe — make dead comm-handling loud (P1)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2120,6 +2120,39 @@ def bridge_log_content_status(name: str, status: str, tail: list[str]) -> Option
     return None
 
 
+def check_comm_sweep_freshness() -> dict:
+    """Comm-handling liveness (P1 of the comm-handling overhaul).
+
+    The comm-sweep driver stamps state/last-comm-sweep.json every run. A stale
+    stamp means comm handling has silently STOPPED — the exact failure that let
+    the inbox-score loop die 2026-07-21 and owner-comm sweeps lapse for days
+    with nobody alerted (comm handling was a *discipline*, not a *mechanism*).
+    This probe makes that loud instead of silent: warn past ~2h, down past ~6h,
+    warn (not down) when the stamp is absent — a host that never wired the
+    driver isn't "broken", it just hasn't adopted P1 yet.
+
+    Age-checked (unlike quota-telemetry, which is absence-only): comm handling
+    is expected to run on a fixed cadence, so a lengthening age IS the signal.
+    """
+    path = status_read_path("last-comm-sweep.json", WORKSPACE_DIR)
+    name = "comm-sweep"
+    if not path.exists():
+        return {"name": name, "status": "warn",
+                "detail": "no last-comm-sweep.json — comm-sweep driver not wired on this host yet (P1)"}
+    try:
+        age_h = (time.time() - path.stat().st_mtime) / 3600
+    except OSError as exc:
+        return {"name": name, "status": "warn",
+                "detail": f"last-comm-sweep.json stat failed ({exc})"}
+    if age_h > 6:
+        return {"name": name, "status": "down",
+                "detail": f"last comm sweep {age_h:.1f}h ago (>6h) — comm handling has silently stopped"}
+    if age_h > 2:
+        return {"name": name, "status": "warn",
+                "detail": f"last comm sweep {age_h:.1f}h ago (>2h) — comm handling lagging"}
+    return {"name": name, "status": "ok", "detail": f"last comm sweep {age_h:.1f}h ago"}
+
+
 def run_all_checks() -> list[dict]:
     checks = []
 
@@ -2162,6 +2195,9 @@ def run_all_checks() -> list[dict]:
 
     # Quota telemetry — only meaningful when the proxy is actually up.
     checks.append(check_quota_telemetry(proxy_check["status"]))
+
+    # Comm-handling liveness (P1): loud when the owner-comm sweep goes stale.
+    checks.append(check_comm_sweep_freshness())
 
     # macOS TCC — must come before critical-file checks so if TCC is blocking
     # everything, the operator sees the root cause before the downstream failures.

--- a/tests/health-check-comm-sweep-freshness.test.py
+++ b/tests/health-check-comm-sweep-freshness.test.py
@@ -18,6 +18,7 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -71,6 +72,35 @@ class TestCommSweepFreshness(unittest.TestCase):
         out = self.hc.check_comm_sweep_freshness()
         self.assertEqual(out["status"], "down")
         self.assertIn("silently stopped", out["detail"])
+
+    def test_stat_failure_warns_not_crashes(self):
+        # A stamp that exists() but whose stat() raises (races, permission, a
+        # broken mount) must degrade to warn, never propagate an OSError that
+        # would crash the whole health check.
+        class _StatFails:
+            def exists(self):
+                return True
+
+            def stat(self):
+                raise OSError("simulated stat failure")
+
+        with mock.patch.object(self.hc, "status_read_path", return_value=_StatFails()):
+            out = self.hc.check_comm_sweep_freshness()
+        self.assertEqual(out["name"], "comm-sweep")
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("stat failed", out["detail"])
+
+    def test_run_all_checks_emits_comm_sweep(self):
+        # Reachability guard (mirrors PR #1898): the probe is useless if it's
+        # defined but never wired into run_all_checks(). Exercise the actual
+        # call site and assert a "comm-sweep" check is emitted.
+        try:
+            checks = self.hc.run_all_checks()
+        except Exception as e:  # pragma: no cover - failure path
+            self.fail(f"run_all_checks() raised: {e!r}")
+        names = [c.get("name") for c in checks if isinstance(c, dict)]
+        self.assertIn("comm-sweep", names,
+                      "run_all_checks() emitted no comm-sweep check (branch unreachable)")
 
 
 if __name__ == "__main__":

--- a/tests/health-check-comm-sweep-freshness.test.py
+++ b/tests/health-check-comm-sweep-freshness.test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Regression test: check_comm_sweep_freshness must make a stalled owner-comm
+sweep LOUD instead of silent (P1 of the comm-handling overhaul).
+
+The gap it covers: comm handling ran as a discipline ("remember to sweep"),
+so when its driver died (inbox-score loop, 2026-07-21) the owner-comm sweeps
+lapsed for days and NOTHING alerted. The fix is a mechanism: the comm-sweep
+driver stamps state/last-comm-sweep.json every run, and this probe pages when
+that stamp goes stale (warn >2h, down >6h) or is absent (warn — not wired yet).
+
+Run: python3 tests/health-check-comm-sweep-freshness.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+import importlib.util
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load_health_check():
+    spec = importlib.util.spec_from_file_location(
+        "health_check_commsweep_test", REPO / "src" / "health-check.py"
+    )
+    hc = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(hc)
+    return hc
+
+
+class TestCommSweepFreshness(unittest.TestCase):
+    def setUp(self):
+        self.hc = _load_health_check()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+        (self.ws / "state").mkdir(parents=True, exist_ok=True)
+        self.hc.WORKSPACE_DIR = self.ws
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _stamp(self, age_hours: float) -> Path:
+        p = self.ws / "state" / "last-comm-sweep.json"
+        p.write_text('{"last_sweep_ts": 0}')
+        if age_hours:
+            t = time.time() - age_hours * 3600
+            os.utime(p, (t, t))
+        return p
+
+    def test_missing_stamp_warns_not_down(self):
+        out = self.hc.check_comm_sweep_freshness()
+        self.assertEqual(out["name"], "comm-sweep")
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("not wired", out["detail"])
+
+    def test_fresh_is_ok(self):
+        self._stamp(0.1)
+        self.assertEqual(self.hc.check_comm_sweep_freshness()["status"], "ok")
+
+    def test_lagging_warns(self):
+        self._stamp(3.0)
+        out = self.hc.check_comm_sweep_freshness()
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("lagging", out["detail"])
+
+    def test_stalled_is_down(self):
+        self._stamp(7.0)
+        out = self.hc.check_comm_sweep_freshness()
+        self.assertEqual(out["status"], "down")
+        self.assertIn("silently stopped", out["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**P1 of the comm-handling overhaul** (`notes/comm-handling-overhaul.md`), per Chi's "find your way to work on them but don't drop the ball."

## Why
Comm handling ran as a *discipline* ("sweep every quiet pass"), so when its driver died (inbox-score loop, 2026-07-21) the owner-comm sweeps lapsed for days and **nothing alerted** — the recurring "you dropped comm handling" failure. [[feedback_guarantee_is_structural_not_disciplinary]]: the fix is a monitored mechanism, not more discipline.

## What
`check_comm_sweep_freshness()`: the comm-sweep driver stamps `state/last-comm-sweep.json` each run; this probe pages when that stamp goes stale — **warn >2h, down >6h, warn (not down) when absent** (a host that hasn't wired the driver isn't broken, just un-adopted). Unlike `check_quota_telemetry` (absence-only, because a quiet core legitimately writes nothing), this **is** age-checked — comm handling runs on a fixed cadence, so a lengthening age is the signal. Wired into `run_all_checks` after quota-telemetry.

4 regression tests (missing / fresh / lagging / stalled). On this host it currently reports **down** (last sweep ~2 days ago) — correctly surfacing that comm handling did silently stop.

## Follow-ons (build order in the `comm-sweep` skill)
1. This probe ✅
2. `comm-sweep.sh` — the executable sweep that writes the stamp
3. Owner-task-gated cron (~45-60 min) that drives it, independent of inbox-score

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rq18tfPmFcgzHQFgoSpsUN