### PR TITLE
fix(human-action): answer grammar accepts the bare ha_<hex> N form

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/human_action.py
+++ b/packages/ag2-sparrow/ag2_sparrow/human_action.py
@@ -41,11 +41,25 @@ import uuid
 _KEYCAP = {f"{i}️⃣": i for i in range(1, 10)}  # 1️⃣..9️⃣ → 1..9
 # The `answer` keyword is OPTIONAL: live human acceptance (2026-07-26) showed
 # a real owner naturally types the bare `ha_<hex> 1` — a grammar humans fail
-# on the first try is a UX defect, not a user error. A bare id+number can in
-# principle appear in prose, but resolution still requires: the sender is the
-# configured owner, the id names a PENDING action, and the numbers are valid
-# options — so the loosening is bounded by the same gates as before.
-_ANSWER_RE = re.compile(r"\b(?:answer\s+)?(ha_[0-9a-f]{6,})\s+([0-9][0-9,\s]*)", re.IGNORECASE)
+# on the first try is a UX defect, not a user error. Intent boundary (review):
+# the EXPLICIT `answer ha_<hex> N` form may appear inside prose (the keyword
+# is the intent signal), but the bare `ha_<hex> N` form must BE the entire
+# trimmed message — an owner message that merely QUOTES a pending token in
+# prose must never resolve the action. Both forms remain bounded by the same
+# gates: owner-only sender, PENDING id, valid option numbers.
+_ANSWER_EXPLICIT_RE = re.compile(
+    r"\banswer\s+(ha_[0-9a-f]{6,})\s+([0-9][0-9,\s]*)", re.IGNORECASE)
+_ANSWER_BARE_RE = re.compile(
+    r"(ha_[0-9a-f]{6,})\s+([0-9][0-9,\s]*)", re.IGNORECASE)
+
+
+def _parse_answer(text: str) -> "tuple[str, str] | None":
+    """(action_id, numbers) from an owner message, or None. Explicit form is
+    searched anywhere; bare form must fullmatch the trimmed message."""
+    m = _ANSWER_EXPLICIT_RE.search(text)
+    if m is None:
+        m = _ANSWER_BARE_RE.fullmatch(text.strip())
+    return (m.group(1), m.group(2)) if m else None
 
 
 def _relates_to(event: dict) -> "str | None":
@@ -315,10 +329,10 @@ class DecisionHandler:
             if rec and num:
                 choice_nums = [num]
         elif etype == "message.created":
-            m = _ANSWER_RE.search(text)
-            if m:
-                rec = next((r for r in pending if r["action_id"] == m.group(1)), None)
-                choice_nums = [int(n) for n in re.findall(r"\d+", m.group(2))]
+            parsed = _parse_answer(text)
+            if parsed:
+                rec = next((r for r in pending if r["action_id"] == parsed[0]), None)
+                choice_nums = [int(n) for n in re.findall(r"\d+", parsed[1])]
             else:
                 rec = by_card.get(_relates_to(event))
                 if rec and text.strip().isdigit():

--- a/packages/ag2-sparrow/ag2_sparrow/human_action.py
+++ b/packages/ag2-sparrow/ag2_sparrow/human_action.py
@@ -39,7 +39,13 @@ import urllib.request
 import uuid
 
 _KEYCAP = {f"{i}️⃣": i for i in range(1, 10)}  # 1️⃣..9️⃣ → 1..9
-_ANSWER_RE = re.compile(r"\banswer\s+(ha_[0-9a-f]{6,})\s+([0-9][0-9,\s]*)", re.IGNORECASE)
+# The `answer` keyword is OPTIONAL: live human acceptance (2026-07-26) showed
+# a real owner naturally types the bare `ha_<hex> 1` — a grammar humans fail
+# on the first try is a UX defect, not a user error. A bare id+number can in
+# principle appear in prose, but resolution still requires: the sender is the
+# configured owner, the id names a PENDING action, and the numbers are valid
+# options — so the loosening is bounded by the same gates as before.
+_ANSWER_RE = re.compile(r"\b(?:answer\s+)?(ha_[0-9a-f]{6,})\s+([0-9][0-9,\s]*)", re.IGNORECASE)
 
 
 def _relates_to(event: dict) -> "str | None":

--- a/packages/ag2-sparrow/tests/test_human_action.py
+++ b/packages/ag2-sparrow/tests/test_human_action.py
@@ -115,6 +115,26 @@ def test_answer_command_and_reply_forms():
     check(got3b["decision"]["answers"] == {"Ship v1 or wait?": "Wait"},
           "late bare-id answer cannot overwrite the resolution")
 
+    # Intent boundary (review blocker): the BARE form must be the ENTIRE
+    # trimmed message. Prose that merely QUOTES a pending token must not
+    # resolve; the explicit `answer` keyword remains usable inside prose.
+    store4, rec4 = _store_with_action()
+    h4 = ha.DecisionHandler(store4, OWNER, log=lambda *_: None)
+    h4.offer(_message("fyi the pending card ha_abc123def456 2 is still open"))
+    got4 = json.loads(Path(store4.dir, rec4["action_id"] + ".json").read_text())
+    check(got4.get("decision") is None and got4["status"] == "pending",
+          "prose quoting `ha_x 2` does NOT resolve (bare form must fullmatch)")
+    h4.offer(_message("  ha_abc123def456 2  "))
+    got4b = json.loads(Path(store4.dir, rec4["action_id"] + ".json").read_text())
+    check(got4b["decision"]["answers"] == {"Ship v1 or wait?": "Wait"},
+          "whitespace-padded bare form still resolves (trimmed fullmatch)")
+    store5, rec5 = _store_with_action()
+    h5 = ha.DecisionHandler(store5, OWNER, log=lambda *_: None)
+    h5.offer(_message("ok let me answer ha_abc123def456 1 then"))
+    got5 = json.loads(Path(store5.dir, rec5["action_id"] + ".json").read_text())
+    check(got5["decision"]["answers"] == {"Ship v1 or wait?": "Ship v1"},
+          "explicit `answer ha_x N` inside prose still resolves")
+
 
 def test_a2ui_button_click_resolves():
     # A2UI-CONTRACT.md: a button click arrives as a NORMAL m.room.message with a

--- a/packages/ag2-sparrow/tests/test_human_action.py
+++ b/packages/ag2-sparrow/tests/test_human_action.py
@@ -101,6 +101,20 @@ def test_answer_command_and_reply_forms():
     check(got2["decision"]["answers"] == {"Ship v1 or wait?": "Ship v1"},
           "bare option number replying to the card resolves")
 
+    # Keyword-optional grammar (live-acceptance finding 2026-07-26): a real
+    # owner naturally types the bare `ha_<hex> N` without `answer`.
+    store3, rec3 = _store_with_action()
+    h3 = ha.DecisionHandler(store3, OWNER, log=lambda *_: None)
+    h3.offer(_message("ha_abc123def456 2"))
+    got3 = json.loads(Path(store3.dir, rec3["action_id"] + ".json").read_text())
+    check(got3["decision"]["answers"] == {"Ship v1 or wait?": "Wait"},
+          "bare `ha_x 2` (no answer keyword) resolves")
+    # a NON-pending id mentioned with a number stays inert (terminal immutable)
+    h3.offer(_message("ha_abc123def456 1"))
+    got3b = json.loads(Path(store3.dir, rec3["action_id"] + ".json").read_text())
+    check(got3b["decision"]["answers"] == {"Ship v1 or wait?": "Wait"},
+          "late bare-id answer cannot overwrite the resolution")
+
 
 def test_a2ui_button_click_resolves():
     # A2UI-CONTRACT.md: a button click arrives as a NORMAL m.room.message with a


### PR DESCRIPTION
Live-acceptance finding #2 (2026-07-26): the runtime-api approval loop's real owner naturally typed `ha_446eb4f5ed37 1` — no `answer` keyword — and the reply silently failed to match `_ANSWER_RE`. A grammar a real human fails on the first try is a UX defect, not a user error.

## What
The `answer` keyword becomes optional: `\b(?:answer\s+)?(ha_[0-9a-f]{6,})\s+([0-9][0-9,\s]*)`.

**Bounding** (why the loosening is safe): resolution still requires (a) the sender is the configured `SPARROW_HA_OWNER`, (b) the id names a PENDING action in the store, (c) the numbers are valid options for that action's shape, and (d) terminal states are immutable — so a bare id+digit mentioned in prose (e.g. status messages quoting an action id) can at most target a pending action the owner owns, which is the same power the explicit form already grants them. Regression pins that a late bare-form answer cannot overwrite a resolution.

Buttons cards (fluffy#57 / cinny#318) remain the real fix — this is the text fallback catching up to how humans actually type.

## Evidence
- Before (main): `_ANSWER_RE` requires the literal keyword; the live owner's bare reply produced no match (observed: ha stayed pending through two correct-content replies).
- After (HEAD): `test_human_action.py` → PASS incl. 2 new checks (bare form resolves; late bare form immutable); `src/remote-gateway-bridge.test.py` → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjCFofrj7FTrFnhjMidJ2Y