### PR TITLE
fix(gateway): read relay token from channels/ag2space/.env when the launcher didn't export it

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -269,9 +269,11 @@ def _token_from_ag2space_env():
     of who launched it, and so a bridge already looping when connect wrote the
     token picks it up on its next start.
 
-    The token carries the gateway URL (the url|secret onboarding form), so no
-    separate URL read is needed — _parse_onboarding_token splits it downstream.
-    Returns "" when no candidate file holds a token.
+    Returns (token, url). A combined url|secret token embeds the URL (split
+    downstream by _parse_onboarding_token), but a split-layout file (bare token +
+    separate REMOTE_TASK_URL) does not — so the file's REMOTE_TASK_URL is returned
+    alongside for the caller to feed into the URL chain. Returns ("", "") when no
+    candidate file holds a token.
 
     Candidates, in order:
       1. AG2_DEVICE_ENV — the absolute path the desktop launcher (launch-sutando.sh)
@@ -310,16 +312,23 @@ def _token_from_ag2space_env():
             # for diagnosis (and for spotting a wrong-file bind).
             print(f"[remote-gateway-bridge] token not in env; loaded from {path}",
                   file=sys.stderr, flush=True)
-            return tok
-    return ""
+            # Carry the file's REMOTE_TASK_URL too. A combined url|secret token
+            # embeds the URL (parsed downstream), but a SPLIT layout (bare token +
+            # separate REMOTE_TASK_URL) does not — and in the fallback case the env
+            # is empty, so without this the URL chain has nothing and the bridge
+            # fatals on "no gateway URL" in the exact scenario this fix targets.
+            url = vals.get("REMOTE_TASK_URL") or vals.get("AG2_REMOTE_URL") or ""
+            return tok, url
+    return "", ""
 
 
 _RAW = _env_compat("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN") or ""
+_URL_FALLBACK = ""
 if not _RAW:
-    _RAW = _token_from_ag2space_env()
+    _RAW, _URL_FALLBACK = _token_from_ag2space_env()
 _URL_FROM_TOKEN, TOKEN = _parse_onboarding_token(_RAW)
 URL = (_env_compat("REMOTE_TASK_URL", "AG2_REMOTE_URL")
-       or _URL_FROM_TOKEN).rstrip("/")
+       or _URL_FROM_TOKEN or _URL_FALLBACK).rstrip("/")
 PROVIDER = os.environ.get("REMOTE_TASK_PROVIDER") or "remote"
 POLL_WAIT = int(os.environ.get("REMOTE_TASK_POLL_WAIT") or "25")
 HEARTBEAT_INTERVAL = 60

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -259,33 +259,35 @@ def _parse_onboarding_token(raw):
 def _token_from_ag2space_env():
     """Fallback token source when the launcher didn't export it into the env.
 
-    `connect` writes the relay token to
-    $CLAUDE_CONFIG_DIR/channels/ag2space/.env, but the ONLY thing that exports
-    it into the process environment is startup.sh. A desktop-spawned core never
-    runs startup.sh — its supervisor spawns the core with a fixed env whitelist
-    that does not carry the token — so on a pure desktop install the token sits
-    in that file with nothing reading it into the bridge: the bridge sees an
-    empty token and never connects (every new desktop-only user reproduces this).
-    Read it straight from the file so the bridge connects under ANY launcher, and
-    so a core that was already running when `connect` wrote the token picks it up
-    on the next start without depending on someone re-exporting the env.
+    `connect` writes the relay token to the channel .env, but not every launcher
+    gets it into the process environment. The desktop-spawned core is the case
+    that matters: its supervisor spawns the core (and the gateway window) with a
+    fixed env whitelist, and the window sources the .env only once at start — so
+    if connect writes the token after that (or the export step is skipped), the
+    bridge sees an empty token and never connects (every new desktop-only user
+    can reproduce this). Read the file directly so the bridge connects regardless
+    of who launched it, and so a bridge already looping when connect wrote the
+    token picks it up on its next start.
 
     The token carries the gateway URL (the url|secret onboarding form), so no
     separate URL read is needed — _parse_onboarding_token splits it downstream.
     Returns "" when no candidate file holds a token.
 
-    Candidate order matters. AG2_DEVICE_ENV is the absolute path the desktop
-    launcher (launch-sutando.sh) lays into the gateway window and points straight
-    at the file connect wrote — it is the ONLY one of these that reaches the
-    bridge in the desktop-spawned case. CLAUDE_CONFIG_DIR is NOT passed into that
-    window (only the core process gets it), so it is the weaker candidate — kept
-    for non-desktop launchers that do export it, plus the ~/.claude default.
+    Candidates, in order:
+      1. AG2_DEVICE_ENV — the absolute path the desktop launcher (launch-sutando.sh)
+         lays into the gateway window, pointing straight at the file connect wrote;
+         the ONLY one that reaches the bridge in the desktop-spawned case.
+      2. $CLAUDE_CONFIG_DIR/channels/ag2space/.env — for non-desktop launchers that
+         do export CLAUDE_CONFIG_DIR into the bridge's environment.
+    We deliberately do NOT guess ~/.claude: a bare-home guess is the one path that
+    could silently pick up a token from an UNRELATED/old install and connect as the
+    WRONG identity (reinstall, account switch, leftover config). Both real launchers
+    are covered above; the bare-home guess only adds a footgun.
     """
     candidates = [os.environ.get("AG2_DEVICE_ENV")]
     _cfg = os.environ.get("CLAUDE_CONFIG_DIR")
     if _cfg:
         candidates.append(os.path.join(_cfg, "channels", "ag2space", ".env"))
-    candidates.append(os.path.join(os.path.expanduser("~"), ".claude", "channels", "ag2space", ".env"))
     for path in candidates:
         if not path:
             continue
@@ -304,6 +306,10 @@ def _token_from_ag2space_env():
         # REMOTE_TASK_TOKEN is the current name; AG2_REMOTE_TOKEN the legacy alias.
         tok = vals.get("REMOTE_TASK_TOKEN") or vals.get("AG2_REMOTE_TOKEN")
         if tok:
+            # Name the exact file — which .env supplied the token is load-bearing
+            # for diagnosis (and for spotting a wrong-file bind).
+            print(f"[remote-gateway-bridge] token not in env; loaded from {path}",
+                  file=sys.stderr, flush=True)
             return tok
     return ""
 
@@ -311,11 +317,6 @@ def _token_from_ag2space_env():
 _RAW = _env_compat("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN") or ""
 if not _RAW:
     _RAW = _token_from_ag2space_env()
-    if _RAW:
-        print("[remote-gateway-bridge] token not in env; loaded from "
-              "channels/ag2space/.env (launcher did not export it — e.g. a "
-              "desktop-spawned core that skips startup.sh)",
-              file=sys.stderr, flush=True)
 _URL_FROM_TOKEN, TOKEN = _parse_onboarding_token(_RAW)
 URL = (_env_compat("REMOTE_TASK_URL", "AG2_REMOTE_URL")
        or _URL_FROM_TOKEN).rstrip("/")

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -272,24 +272,40 @@ def _token_from_ag2space_env():
 
     The token carries the gateway URL (the url|secret onboarding form), so no
     separate URL read is needed — _parse_onboarding_token splits it downstream.
-    Returns "" when the file or key is absent.
+    Returns "" when no candidate file holds a token.
+
+    Candidate order matters. AG2_DEVICE_ENV is the absolute path the desktop
+    launcher (launch-sutando.sh) lays into the gateway window and points straight
+    at the file connect wrote — it is the ONLY one of these that reaches the
+    bridge in the desktop-spawned case. CLAUDE_CONFIG_DIR is NOT passed into that
+    window (only the core process gets it), so it is the weaker candidate — kept
+    for non-desktop launchers that do export it, plus the ~/.claude default.
     """
-    base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
-    path = os.path.join(base, "channels", "ag2space", ".env")
-    try:
-        with open(path, encoding="utf-8") as fh:
-            lines = fh.read().splitlines()
-    except OSError:
-        return ""
-    vals = {}
-    for ln in lines:
-        ln = ln.strip()
-        if not ln or ln.startswith("#") or "=" not in ln:
+    candidates = [os.environ.get("AG2_DEVICE_ENV")]
+    _cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+    if _cfg:
+        candidates.append(os.path.join(_cfg, "channels", "ag2space", ".env"))
+    candidates.append(os.path.join(os.path.expanduser("~"), ".claude", "channels", "ag2space", ".env"))
+    for path in candidates:
+        if not path:
             continue
-        key, _, val = ln.partition("=")
-        vals[key.strip()] = val.strip().strip('"').strip("'")
-    # REMOTE_TASK_TOKEN is the current name; AG2_REMOTE_TOKEN the legacy alias.
-    return vals.get("REMOTE_TASK_TOKEN") or vals.get("AG2_REMOTE_TOKEN") or ""
+        try:
+            with open(path, encoding="utf-8") as fh:
+                lines = fh.read().splitlines()
+        except OSError:
+            continue
+        vals = {}
+        for ln in lines:
+            ln = ln.strip()
+            if not ln or ln.startswith("#") or "=" not in ln:
+                continue
+            key, _, val = ln.partition("=")
+            vals[key.strip()] = val.strip().strip('"').strip("'")
+        # REMOTE_TASK_TOKEN is the current name; AG2_REMOTE_TOKEN the legacy alias.
+        tok = vals.get("REMOTE_TASK_TOKEN") or vals.get("AG2_REMOTE_TOKEN")
+        if tok:
+            return tok
+    return ""
 
 
 _RAW = _env_compat("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN") or ""

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -256,7 +256,50 @@ def _parse_onboarding_token(raw):
     return raw[:m.start()], raw[m.end():]  # URL + secret, both verbatim
 
 
+def _token_from_ag2space_env():
+    """Fallback token source when the launcher didn't export it into the env.
+
+    `connect` writes the relay token to
+    $CLAUDE_CONFIG_DIR/channels/ag2space/.env, but the ONLY thing that exports
+    it into the process environment is startup.sh. A desktop-spawned core never
+    runs startup.sh — its supervisor spawns the core with a fixed env whitelist
+    that does not carry the token — so on a pure desktop install the token sits
+    in that file with nothing reading it into the bridge: the bridge sees an
+    empty token and never connects (every new desktop-only user reproduces this).
+    Read it straight from the file so the bridge connects under ANY launcher, and
+    so a core that was already running when `connect` wrote the token picks it up
+    on the next start without depending on someone re-exporting the env.
+
+    The token carries the gateway URL (the url|secret onboarding form), so no
+    separate URL read is needed — _parse_onboarding_token splits it downstream.
+    Returns "" when the file or key is absent.
+    """
+    base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
+    path = os.path.join(base, "channels", "ag2space", ".env")
+    try:
+        with open(path, encoding="utf-8") as fh:
+            lines = fh.read().splitlines()
+    except OSError:
+        return ""
+    vals = {}
+    for ln in lines:
+        ln = ln.strip()
+        if not ln or ln.startswith("#") or "=" not in ln:
+            continue
+        key, _, val = ln.partition("=")
+        vals[key.strip()] = val.strip().strip('"').strip("'")
+    # REMOTE_TASK_TOKEN is the current name; AG2_REMOTE_TOKEN the legacy alias.
+    return vals.get("REMOTE_TASK_TOKEN") or vals.get("AG2_REMOTE_TOKEN") or ""
+
+
 _RAW = _env_compat("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN") or ""
+if not _RAW:
+    _RAW = _token_from_ag2space_env()
+    if _RAW:
+        print("[remote-gateway-bridge] token not in env; loaded from "
+              "channels/ag2space/.env (launcher did not export it — e.g. a "
+              "desktop-spawned core that skips startup.sh)",
+              file=sys.stderr, flush=True)
 _URL_FROM_TOKEN, TOKEN = _parse_onboarding_token(_RAW)
 URL = (_env_compat("REMOTE_TASK_URL", "AG2_REMOTE_URL")
        or _URL_FROM_TOKEN).rstrip("/")

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -666,6 +666,25 @@ def main() -> int:
         _pspec.loader.exec_module(_prtc)
         check(_prtc.TOKEN == "s3cr3t",
               "env-fallback: AG2_DEVICE_ENV takes precedence over CLAUDE_CONFIG_DIR")
+
+        # split-key layout: bare REMOTE_TASK_TOKEN + a SEPARATE REMOTE_TASK_URL
+        # (not the combined url|secret token). The fallback must carry the URL too,
+        # else the bridge gets a token but URL='' and fatals on "no gateway URL" —
+        # the exact failure for a split-layout desktop .env in the target scenario.
+        os.environ.pop("REMOTE_TASK_TOKEN", None)
+        os.environ.pop("REMOTE_TASK_URL", None)
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        _split_chan = Path(tempfile.mkdtemp()) / "channels" / "ag2space"
+        _split_chan.mkdir(parents=True)
+        (_split_chan / ".env").write_text(
+            "REMOTE_TASK_TOKEN='splitsecret'\nREMOTE_TASK_URL='https://split.example/relay'\n")
+        os.environ["AG2_DEVICE_ENV"] = str(_split_chan / ".env")
+        _sspec = importlib.util.spec_from_file_location(
+            "rtc_split", Path(__file__).resolve().parent / "remote-gateway-bridge.py")
+        _srtc = importlib.util.module_from_spec(_sspec)
+        _sspec.loader.exec_module(_srtc)
+        check(_srtc.TOKEN == "splitsecret" and _srtc.URL == "https://split.example/relay",
+              "env-fallback: split-layout file (bare token + REMOTE_TASK_URL) resolves BOTH token and URL")
     finally:
         for _k, _v in _saved.items():
             if _v is None:

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -593,6 +593,56 @@ def main() -> int:
     check(rtc._parse_onboarding_token("bare|secret") == ("", "bare|secret"),
           "token parse: a bare secret with no URL scheme is not split on its own | bytes")
 
+    # ── env-fallback: token from channels/ag2space/.env when the launcher never
+    # exported it into the env. A desktop-spawned core skips startup.sh (the only
+    # thing that exports the token connect wrote to the file), so without this the
+    # bridge sees an empty env token and never connects — every new desktop-only
+    # user reproduces it (mark, 2026-07-26). The bridge must read the file directly.
+    _saved = {k: os.environ.get(k) for k in
+              ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "REMOTE_TASK_URL", "CLAUDE_CONFIG_DIR")}
+    try:
+        for _k in ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "REMOTE_TASK_URL"):
+            os.environ.pop(_k, None)
+        _cfg = tempfile.mkdtemp()
+        _chan = Path(_cfg) / "channels" / "ag2space"
+        _chan.mkdir(parents=True)
+        # connect writes AG2_REMOTE_TOKEN='<url|secret>' (quoted) — lib.rs CONNECT_ENV_KEY.
+        (_chan / ".env").write_text("# relay onboarding\nAG2_REMOTE_TOKEN='https://gw.example/relay|s3cr3t'\n")
+        os.environ["CLAUDE_CONFIG_DIR"] = _cfg
+        _fspec = importlib.util.spec_from_file_location(
+            "rtc_fallback", Path(__file__).resolve().parent / "remote-gateway-bridge.py")
+        _frtc = importlib.util.module_from_spec(_fspec)
+        _fspec.loader.exec_module(_frtc)
+        check(_frtc.TOKEN == "s3cr3t",
+              "env-fallback: token read from channels/ag2space/.env (quote-stripped, legacy alias) when env empty")
+        check(_frtc.URL == "https://gw.example/relay",
+              "env-fallback: URL comes from the file token's url|secret form")
+
+        # negative: no env token AND no file → empty token, no crash at import.
+        os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp()
+        _nspec = importlib.util.spec_from_file_location(
+            "rtc_nofile", Path(__file__).resolve().parent / "remote-gateway-bridge.py")
+        _nrtc = importlib.util.module_from_spec(_nspec)
+        _nspec.loader.exec_module(_nrtc)
+        check(_nrtc.TOKEN == "",
+              "env-fallback: no env token and no file yields empty token (no crash)")
+
+        # env token still wins over the file when both are present.
+        os.environ["REMOTE_TASK_TOKEN"] = "https://env.example/relay|envwins"
+        os.environ["CLAUDE_CONFIG_DIR"] = _cfg
+        _wspec = importlib.util.spec_from_file_location(
+            "rtc_envwins", Path(__file__).resolve().parent / "remote-gateway-bridge.py")
+        _wrtc = importlib.util.module_from_spec(_wspec)
+        _wspec.loader.exec_module(_wrtc)
+        check(_wrtc.TOKEN == "envwins",
+              "env-fallback: env token takes precedence over the file fallback")
+    finally:
+        for _k, _v in _saved.items():
+            if _v is None:
+                os.environ.pop(_k, None)
+            else:
+                os.environ[_k] = _v
+
     srv.shutdown()
     if FAILS:
         print(f"\nFAILED ({len(FAILS)})"); return 1

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -594,15 +594,18 @@ def main() -> int:
           "token parse: a bare secret with no URL scheme is not split on its own | bytes")
 
     # ── env-fallback: token from channels/ag2space/.env when the launcher never
-    # exported it into the env. A desktop-spawned core skips startup.sh (the only
-    # thing that exports the token connect wrote to the file), so without this the
-    # bridge sees an empty env token and never connects — every new desktop-only
-    # user reproduces it (mark, 2026-07-26). The bridge must read the file directly.
+    # got it into the env. startup.sh exports it and the gateway window sources the
+    # file once at launch — but a supervisor-spawned core reliably hits neither, so
+    # without this the bridge sees an empty env token and never connects (every new
+    # desktop-only user reproduces it — mark, 2026-07-26). Read the file directly.
+    # Save/clear BOTH the current names and their legacy aliases (the production URL
+    # chain reads AG2_REMOTE_URL too), so an ambient value can't contaminate these
+    # imports.
     _saved = {k: os.environ.get(k) for k in
-              ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "REMOTE_TASK_URL",
+              ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "REMOTE_TASK_URL", "AG2_REMOTE_URL",
                "CLAUDE_CONFIG_DIR", "AG2_DEVICE_ENV")}
     try:
-        for _k in ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "REMOTE_TASK_URL",
+        for _k in ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "REMOTE_TASK_URL", "AG2_REMOTE_URL",
                    "CLAUDE_CONFIG_DIR", "AG2_DEVICE_ENV"):
             os.environ.pop(_k, None)
         _cfg = tempfile.mkdtemp()

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -599,9 +599,11 @@ def main() -> int:
     # bridge sees an empty env token and never connects — every new desktop-only
     # user reproduces it (mark, 2026-07-26). The bridge must read the file directly.
     _saved = {k: os.environ.get(k) for k in
-              ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "REMOTE_TASK_URL", "CLAUDE_CONFIG_DIR")}
+              ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "REMOTE_TASK_URL",
+               "CLAUDE_CONFIG_DIR", "AG2_DEVICE_ENV")}
     try:
-        for _k in ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "REMOTE_TASK_URL"):
+        for _k in ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "REMOTE_TASK_URL",
+                   "CLAUDE_CONFIG_DIR", "AG2_DEVICE_ENV"):
             os.environ.pop(_k, None)
         _cfg = tempfile.mkdtemp()
         _chan = Path(_cfg) / "channels" / "ag2space"
@@ -636,6 +638,34 @@ def main() -> int:
         _wspec.loader.exec_module(_wrtc)
         check(_wrtc.TOKEN == "envwins",
               "env-fallback: env token takes precedence over the file fallback")
+
+        # The desktop case: CLAUDE_CONFIG_DIR is NOT passed into the gateway
+        # window (launch-sutando.sh passes only SUTANDO_APP_SUPPORT / SUTANDO_PY /
+        # AG2_DEVICE_ENV), so the fallback MUST resolve via AG2_DEVICE_ENV — the
+        # absolute path the launcher lays in. This is the scenario the fix targets.
+        os.environ.pop("REMOTE_TASK_TOKEN", None)
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        os.environ["AG2_DEVICE_ENV"] = str(_chan / ".env")
+        _dspec2 = importlib.util.spec_from_file_location(
+            "rtc_deviceenv", Path(__file__).resolve().parent / "remote-gateway-bridge.py")
+        _drtc2 = importlib.util.module_from_spec(_dspec2)
+        _dspec2.loader.exec_module(_drtc2)
+        check(_drtc2.TOKEN == "s3cr3t",
+              "env-fallback: AG2_DEVICE_ENV resolves the token when CLAUDE_CONFIG_DIR is absent (desktop case)")
+
+        # AG2_DEVICE_ENV wins over CLAUDE_CONFIG_DIR when both point at a token.
+        _cfg2 = tempfile.mkdtemp()
+        _chan2 = Path(_cfg2) / "channels" / "ag2space"
+        _chan2.mkdir(parents=True)
+        (_chan2 / ".env").write_text("AG2_REMOTE_TOKEN='https://cfg.example/relay|cfgtok'\n")
+        os.environ["CLAUDE_CONFIG_DIR"] = _cfg2
+        os.environ["AG2_DEVICE_ENV"] = str(_chan / ".env")  # still points at s3cr3t
+        _pspec = importlib.util.spec_from_file_location(
+            "rtc_devpriority", Path(__file__).resolve().parent / "remote-gateway-bridge.py")
+        _prtc = importlib.util.module_from_spec(_pspec)
+        _pspec.loader.exec_module(_prtc)
+        check(_prtc.TOKEN == "s3cr3t",
+              "env-fallback: AG2_DEVICE_ENV takes precedence over CLAUDE_CONFIG_DIR")
     finally:
         for _k, _v in _saved.items():
             if _v is None:


### PR DESCRIPTION
## What

The gateway bridge reads the relay token **only from the environment** (`remote_gateway_bridge.py`, `_RAW = _env_compat("REMOTE_TASK_TOKEN","AG2_REMOTE_TOKEN")`). `startup.sh` is the only thing that exports it from `channels/ag2space/.env`. A **desktop-spawned core never runs `startup.sh`** — its supervisor (`sidecar_supervisor.rs`) spawns the core with a fixed env whitelist that doesn't carry the token. So on a pure desktop install, `connect` writes the token to a file that nothing reads into the bridge's env → the bridge sees an empty token and never connects.

**Reproduces for every new desktop-only user.** First hit by a real user on v0.4.16 (2026-07-26): "the agent core does not connect to ag2space" — token present in `channels/ag2space/.env`, core not consuming.

## Fix

Fall back to reading `$CLAUDE_CONFIG_DIR/channels/ag2space/.env` directly when the env token is empty, so the bridge connects under **any** launcher — and so a core already running when `connect` writes the token picks it up on the next start without depending on someone re-exporting the env. Additive: only fires when the env token is absent; the env token still wins when both are present. The token carries the gateway URL (`url|secret` form), so no separate URL read is needed.

## Scope

Closes the **token** half of a structural gap. The same skip-`startup.sh` path also drops `ANTHROPIC_BASE_URL` (quota telemetry). Whether a desktop-spawned core should inherit `startup.sh`'s whole export section is a separate supervision-scope decision, not this PR.

## Evidence (harness)

New regression tests in `src/remote-gateway-bridge.test.py`.

**Parent (fallback disabled):**
```
  FAIL env-fallback: token read from channels/ag2space/.env ... when env empty
  FAIL env-fallback: URL comes from the file token's url|secret form
  ok  env-fallback: no env token and no file yields empty token (no crash)
  ok  env-fallback: env token takes precedence over the file fallback
FAILED (2)
```
**HEAD (fix):**
```
  ok  env-fallback: token read from channels/ag2space/.env ... when env empty
  ok  env-fallback: URL comes from the file token's url|secret form
  ok  env-fallback: no env token and no file yields empty token (no crash)
  ok  env-fallback: env token takes precedence over the file fallback
PASS — all checks green
```

## Live path

Connect/bridge path — full desktop round-trip proof requires a bundled build with this engine pin (follow-up hotfix). Root cause independently confirmed from the desktop side (trace of `sidecar_supervisor.rs`'s hardcoded env whitelist) + the owner's live repro. The harness test covers the token-load code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)