### PR TITLE
fix(cron-gate): don't defer on cron-runner's own task-cron-*.txt emissions

### DIFF
--- a/scripts/cron-gate.sh
+++ b/scripts/cron-gate.sh
@@ -34,9 +34,19 @@ WORKSPACE="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" workspace)"
 reason="$1"
 shift
 
-# Defer if any task-*.txt is queued (top-level only; archive/processed subdirs
-# don't count). find is safer than ls + glob for empty-dir / non-existent-dir.
-if [ -d "$WORKSPACE/tasks" ] && [ -n "$(find "$WORKSPACE/tasks" -maxdepth 1 -name 'task-*.txt' -print -quit 2>/dev/null)" ]; then
+# Defer if any OWNER task-*.txt is queued (top-level only; archive/processed
+# subdirs don't count). find is safer than ls + glob for empty-dir /
+# non-existent-dir.
+#
+# Exclude task-cron-*.txt: those are emitted by src/cron-runner.py (the launchd
+# cron owner) as its delivery vehicle for `launchd: true` entries, carrying
+# user_id: cron-runner / priority: low — machine work, never the human-owner
+# DMs/voice this gate exists to yield to. Without the exclusion a cron-gate-
+# wrapped entry that has been migrated to launchd defers on its own emitted
+# file every fire, silently and permanently. This is the gate-side (root) half
+# of the fix; the eligibility-side half (don't migrate gated entries) landed in
+# reconcile_launchd.py.
+if [ -d "$WORKSPACE/tasks" ] && [ -n "$(find "$WORKSPACE/tasks" -maxdepth 1 -name 'task-*.txt' ! -name 'task-cron-*.txt' -print -quit 2>/dev/null)" ]; then
   echo "cron-gate: owner tasks queued — deferring $reason (will retry next fire)"
   exit 0
 fi

--- a/tests/cron-gate.test.sh
+++ b/tests/cron-gate.test.sh
@@ -55,6 +55,29 @@ out="$(SUTANDO_WORKSPACE="$TMPDIR" SUTANDO_TEST_MODE=1 bash "$GATE" test-non-tas
 [ "$out" = "ran-non-task-ok" ] || fail "non-task file: expected 'ran-non-task-ok', got '$out'"
 ok "non-task-*.txt files do not trigger deferral"
 
+# --- task-cron-*.txt (cron-runner emission) does NOT count -------------------
+# Regression: a cron-gate-wrapped entry migrated to launchd is delivered as its
+# own task-cron-<name>-<ms>.txt file; that file must not make the gate defer, or
+# the entry defers on its own delivery vehicle forever.
+touch "$TMPDIR/tasks/task-cron-sync-workspace-1785114482357.txt"
+out="$(SUTANDO_WORKSPACE="$TMPDIR" SUTANDO_TEST_MODE=1 bash "$GATE" test-cron-emit echo 'ran-despite-cron-file' 2>&1)"
+[ "$out" = "ran-despite-cron-file" ] || fail "task-cron-* file: expected 'ran-despite-cron-file', got '$out'"
+ok "task-cron-*.txt (cron-runner emission) does not trigger deferral"
+
+# --- but a genuine owner task-*.txt alongside it STILL defers -----------------
+touch "$TMPDIR/tasks/task-9876543210987.txt"
+out="$(SUTANDO_WORKSPACE="$TMPDIR" SUTANDO_TEST_MODE=1 bash "$GATE" test-owner-plus-cron echo 'should-not-run' 2>&1)"
+case "$out" in
+  *"deferring test-owner-plus-cron"*) : ;;
+  *) fail "owner+cron: expected deferral, got '$out'" ;;
+esac
+case "$out" in
+  *"should-not-run"*) fail "owner+cron: wrapped command ran" ;;
+  *) : ;;
+esac
+ok "genuine owner task still defers even when a task-cron-* file is present"
+rm -f "$TMPDIR/tasks/task-cron-sync-workspace-1785114482357.txt" "$TMPDIR/tasks/task-9876543210987.txt"
+
 # --- usage error: no command → exit 2 -----------------------------------------
 set +e
 SUTANDO_WORKSPACE="$TMPDIR" SUTANDO_TEST_MODE=1 bash "$GATE" test-usage >/dev/null 2>&1
@@ -72,4 +95,4 @@ set -e
 ok "wrapped command exit code propagates via exec"
 
 echo
-echo "OK — 7/7 cron-gate tests passed"
+echo "OK — 9/9 cron-gate tests passed"


### PR DESCRIPTION
## Problem

`scripts/cron-gate.sh` defers a wrapped cron when **any** `task-*.txt` is queued in `<workspace>/tasks/`, so cron noise yields to owner DMs/voice. But `src/cron-runner.py` — the launchd cron owner — delivers each `launchd: true` entry by writing `task-cron-<name>-<ms>.txt` into that same dir (`src/cron-runner.py:238`), and `task-cron-*.txt` matches `task-*.txt`.

So a `cron-gate.sh`-wrapped entry that has been migrated to launchd **defers on its own delivery vehicle every fire, silently and permanently** — e.g. `pending-questions` / `sync-workspace`. The deferral message ("will retry next fire") makes it quiet rather than loud: the next fire emits another `task-cron-*` file and defers again.

This was surfaced by @bassilkhilo-ag2's review of #2330.

## Fix

`task-cron-*.txt` files carry `user_id: cron-runner` / `priority: low` — machine work, never the human-owner work this gate exists to yield to. Exclude them from the defer predicate:

```diff
- -name 'task-*.txt' -print -quit
+ -name 'task-*.txt' ! -name 'task-cron-*.txt' -print -quit
```

A genuine owner `task-*.txt` still defers, even when a `task-cron-*` file is also present.

## Evidence

Only a cron-runner-emitted file queued (no owner work):

```
--- parent (origin/main) ---
cron-gate: owner tasks queued — deferring sync-workspace (will retry next fire)   ← BUG
--- HEAD ---
COMMAND RAN
```

Control — a genuine owner `task-*.txt` queued (must still defer):

```
--- parent ---   cron-gate: owner tasks queued — deferring sync-workspace
--- HEAD ---     cron-gate: owner tasks queued — deferring sync-workspace
```

`tests/cron-gate.test.sh`: **9/9** (2 new — the exclusion, and owner-still-defers-alongside-a-cron-file).

## Relationship to #2330

This is the **gate-side (root) half** of the fix. The **eligibility-side half** — `reconcile_launchd.py` should not migrate `cron-gate.sh`-wrapped entries to launchd in the first place — is in #2330.

- Either alone prevents the trap for *new* migrations.
- Only this gate-side fix also heals the **already-migrated live case**: `reconcile` only *adds* `launchd:true`, never un-stamps, so hosts that already ran reconcile (with a gated entry present) have the trap sprung today. Narrowing the gate fixes them without touching `crons.json` ownership.

Independent of #2330 on the merge order — they touch disjoint files (`scripts/cron-gate.sh` here, `skills/schedule-crons/scripts/reconcile_launchd.py` there).

## Out of scope (noted, not changed)

`src/health-check.py --emit-task` writes `task-health-*.txt`, which also matches `task-*.txt`. A health-failure alert arguably *should* surface, so its gate semantics are a separate judgment call — deliberately not touched here to keep this single-concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)