### PR TITLE
fix(sync-workspace): snapshot canonical Claude config

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -585,12 +585,12 @@ _refuse_staged_secrets() {
     return 0
 }
 
-# Snapshot the per-host config that LIVES at $CLAUDE_CONFIG_DIR into
+# Snapshot the per-host config from the canonical Claude config dir into
 # <workspace>/hosts/<host>/ so it's carried by the hosts/*/ vault glob and
-# survives a rebuild. settings.json and channel access.json are owned by Claude
-# Code / the bridges at $CLAUDE_CONFIG_DIR — they can't be relocated, so they're
-# *backed up* here (the live readers keep reading $CLAUDE_CONFIG_DIR; hosts/<host>/
-# is a pure backup → no read/write skew).
+# survives a rebuild. Startup exports this same path as CLAUDE_CONFIG_DIR for
+# Claude Code / the bridges. Resolve it from config here because launchd/cron
+# does not reliably inherit that export; falling back to ~/.claude would copy
+# stale pre-migration access state over the live backup.
 #
 # NOT snapshotted: PERSONAL_CLAUDE.md / stand-identity.json / tab-aliases.json —
 # those follow the RELOCATION model (migrator one-time move + personal_path /
@@ -602,7 +602,7 @@ _refuse_staged_secrets() {
 # returns 0, so a snapshot hiccup can never block the push.
 _snapshot_per_host_config() {
     local _cfg
-    _cfg="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" claude-home-path)" || return 0
+    _cfg="$(bash "$SCRIPT_PARENT/scripts/sutando-config.sh" claude-sutando-config-dir)" || return 0
     local _host_dir="$WORKSPACE_DIR/hosts/$(_host)"
     mkdir -p "$_host_dir" 2>/dev/null || return 0
 

--- a/tests/sync-workspace.test.sh
+++ b/tests/sync-workspace.test.sh
@@ -236,6 +236,31 @@ else
   echo "  FAIL: host/${HOST}/${WS_ID} branch NOT in vault"; fail=$((fail+1))
 fi
 
+# Regression: launchd/cron does not inherit CLAUDE_CONFIG_DIR. The snapshot
+# must still read the workspace-scoped Claude config used by startup, not a
+# stale legacy ~/.claude tree.
+echo
+echo "==== Test 2b: per-host config snapshot resolves canonical Claude config without env ===="
+SNAPSHOT_HOME="$TEST_ROOT/snapshot-home"
+LIVE_CCD="$FIXTURE_WS/.claude-sutando"
+mkdir -p "$SNAPSHOT_HOME/.claude/channels/discord" "$LIVE_CCD/channels/discord"
+printf '%s\n' '{"allowFrom":["owner-live"],"tierMap":{"owner-live":"owner"}}' \
+  > "$LIVE_CCD/channels/discord/access.json"
+printf '%s\n' '{"allowFrom":["member-stale"],"tierMap":{"member-stale":"team"}}' \
+  > "$SNAPSHOT_HOME/.claude/channels/discord/access.json"
+snapshot_out=$(env -u CLAUDE_CONFIG_DIR -u CLAUDE_HOME \
+  HOME="$SNAPSHOT_HOME" "${COMMON_ENV[@]}" \
+  bash "$SYNC" --vault-url "$FIXTURE_VAULT" --push-only 2>&1)
+SNAPSHOT_BACKUP="$FIXTURE_WS/hosts/$HOST/channels/discord/access.json"
+if cmp -s "$LIVE_CCD/channels/discord/access.json" "$SNAPSHOT_BACKUP"; then
+  echo "  OK: snapshot preserved live owner tierMap without CLAUDE_CONFIG_DIR"; pass=$((pass+1))
+else
+  echo "  FAIL: snapshot used legacy HOME instead of canonical Claude config"
+  [ -f "$SNAPSHOT_BACKUP" ] && sed -n '1p' "$SNAPSHOT_BACKUP"
+  echo "  INFO: push-only output: $snapshot_out"
+  fail=$((fail+1))
+fi
+
 # ============================================================================
 echo
 echo "==== Test 3: idempotent re-init ===="


### PR DESCRIPTION
## What changed

`sync-workspace` now resolves the per-host settings/access snapshot source with `claude-sutando-config-dir`, the same canonical config path that startup exports to the Claude core and channel bridges.

Previously `_snapshot_per_host_config` used `claude-home-path`. In launchd/cron environments without `CLAUDE_CONFIG_DIR`, that helper falls back to legacy `~/.claude`, so a stale Discord `access.json` could overwrite the vault backup and later restore an owner without their `owner` tier.

This is the focused corrective follow-up to the drift detector in #2277.

## Before / after evidence

Parent `649af1f` with the regression added but before the implementation change:

```text
$ bash tests/sync-workspace.test.sh
==== Test 2b: per-host config snapshot resolves canonical Claude config without env ====
  FAIL: snapshot used legacy HOME instead of canonical Claude config
{"allowFrom":["member-stale"],"tierMap":{"member-stale":"team"}}
  INFO: push-only output: claude-home-path: $CLAUDE_CONFIG_DIR not set — falling back to ~/.claude/.
```

HEAD `23f2867`:

```text
$ bash tests/sync-workspace.test.sh
==== Test 2b: per-host config snapshot resolves canonical Claude config without env ====
  OK: snapshot preserved live owner tierMap without CLAUDE_CONFIG_DIR
...
Total: 89 — pass: 89, fail: 0
```

Additional checks:

```text
$ bash -n scripts/sync-workspace.sh tests/sync-workspace.test.sh
# exit 0

$ git diff --check
# exit 0
```

## Live post-restart round trip

Tested on the affected host after restarting the Discord bridge:

```text
Discord bridge ready: Rui Bot#5744
[msg] #DM @immaculate_possum_27099: sutando access test
[task-write] wrote task-1785161360808.txt (@immaculate_possum_27099, #DM, tier=owner)
Replied: Live test passed ✅ After the bridge restart, your DM was received as `access_tier: owner` and the reply path is working.
```

The live access file retained owner ID `1358841611580080168` as `owner` through the restart.

## Scope / risk

Single concern: snapshot source resolution plus its regression. No bridge behavior, prompts, restore semantics, or unrelated sync logic changed. The added lines contain no host-specific paths or inline path fallbacks.
