### PR TITLE
fix(bot2bot-post): recipient-first channel routing so a ping can't dead-letter

### DIFF
--- a/skills/bot2bot-post/post.py
+++ b/skills/bot2bot-post/post.py
@@ -16,14 +16,18 @@ entries tagged with `{"role": "bot2bot", ...}` in `groups` are candidates. We
 pick the first such channel. If none is tagged, we fall back to the first
 group whose value is just `true` (legacy convention), or error out.
 
-Recipient targeting: pass `--to <peer|id>` to @-mention a specific peer. This
-is the correct way when more than one peer exists — the old auto-resolve below
-assumes a SINGLE other bot and silently mis-fires otherwise (it mentioned Mini
-for a post addressed to Pro, 2026-06-06). Without `--to`, the other bot's user
-ID is read from the bot2bot CHANNEL's `allowFrom`, excluding this bot
-(identified via Discord GET /users/@me) — fine only while exactly one peer is
-allowlisted there. The resulting `<@id>` mention is prepended so the receiving
-bot's bridge will process it as a task (discord-bridge.py line 244 exception).
+Recipient targeting: pass `--to <peer|id>` to @-mention a specific peer. With
+`--to`, the target channel is derived FROM the recipient — we post to a channel
+whose `allowFrom` contains them (recipient-first routing), and REFUSE rather
+than dead-letter if they are in no accessible channel. This fixes the 2026-07-27
+mis-route where contributor pings (qingyun/Rui/john) were sent to the fleet-only
+#bot2bot they aren't members of, so they silently went nowhere; and it guards
+the bot-vs-human-owner id confusion (different ids → different channels). Without
+`--to`, this is a fleet broadcast to the `role:bot2bot` channel, and the other
+bot's id is read from that channel's `allowFrom` (fine only while exactly one
+peer is allowlisted there — mis-fires with 3+, so prefer `--to`). The resulting
+`<@id>` mention is prepended so the receiving bot's bridge processes it as a
+task (discord-bridge.py line 244 exception).
 
 Requires DISCORD_BOT_TOKEN in $CLAUDE_CONFIG_DIR/channels/discord/.env.
 """
@@ -138,6 +142,33 @@ def resolve_other_bot(access: dict, self_id: str, channel_id: str):
     return others[0]
 
 
+def resolve_channel_for_recipient(access: dict, recipient_id: str):
+    """Return a channel whose allowFrom contains `recipient_id`, or None.
+
+    RECIPIENT-FIRST routing (the dead-letter fix, 2026-07-27). Instead of always
+    posting to the fixed `role:bot2bot` channel and *hoping* the recipient reads
+    it, resolve the channel FROM the recipient: post only to a channel they are
+    actually a member of. If the recipient is in NO channel's allowFrom, the
+    caller MUST refuse rather than dead-letter.
+
+    Why: `--to <contributor>` used to post to the fleet-only #bot2bot, whose
+    allowFrom is Air/Mini/Pro only — so pings to qingyun/Rui/john silently went
+    nowhere. Deriving the channel from `allowFrom` membership makes that
+    mis-route impossible by construction.
+
+    A recipient may be in several channels (any of them reaches them, so the
+    no-dead-letter guarantee holds); pick deterministically (lowest channel id).
+    """
+    rid = str(recipient_id)
+    matches = [
+        cid
+        for cid, cfg in access.get("groups", {}).items()
+        if isinstance(cfg, dict)
+        and rid in {str(x) for x in cfg.get("allowFrom", [])}
+    ]
+    return sorted(matches)[0] if matches else None
+
+
 def post(channel_id: str, text: str, token: str):
     url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
     body = json.dumps({"content": text}).encode()
@@ -214,14 +245,27 @@ def main():
 
     token = load_token()
     access = load_access()
-    channel_id = resolve_bot2bot_channel(access)
     self_id = get_self_id(token)
 
     if to_target is not None:
         other_id = resolve_to_target(to_target)
         if other_id == self_id:
             sys.exit("ERROR: --to resolves to this bot itself; pick a peer")
+        # RECIPIENT-FIRST routing: post to a channel the recipient is actually
+        # in, NOT the fixed bot2bot channel. Refuse rather than dead-letter — the
+        # 2026-07-27 mis-route where contributor pings went to the fleet-only
+        # #bot2bot they aren't members of.
+        channel_id = resolve_channel_for_recipient(access, other_id)
+        if channel_id is None:
+            sys.exit(
+                f"ERROR: recipient {other_id} is in no channel's allowFrom in "
+                f"{ACCESS_JSON} — refusing to post (it would be a dead letter). "
+                "Add them to the target channel's allowFrom, or check the id "
+                "(a bot vs its human owner are different ids)."
+            )
     else:
+        # No explicit recipient → fleet broadcast to the bot2bot channel.
+        channel_id = resolve_bot2bot_channel(access)
         other_id = resolve_other_bot(access, self_id, channel_id)
 
     prefix = f"<@{other_id}> " if other_id else ""

--- a/tests/bot2bot-post.test.py
+++ b/tests/bot2bot-post.test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Tests for skills/bot2bot-post/post.py — recipient-first channel routing.
+
+Regression for the 2026-07-27 dead-letter mis-route: contributor pings were
+sent to the fleet-only #bot2bot (whose allowFrom is Air/Mini/Pro only), so they
+silently went nowhere. `resolve_channel_for_recipient` derives the channel FROM
+the recipient's allowFrom membership so that mis-route is impossible by
+construction, and refuses (None → caller exits) when the recipient is in no
+channel.
+
+Run: python3 tests/bot2bot-post.test.py   (exit 0 pass / non-zero on failure)
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_POST = Path(__file__).resolve().parents[1] / "skills" / "bot2bot-post" / "post.py"
+_spec = importlib.util.spec_from_file_location("b2b_post", _POST)
+b2b = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(b2b)
+
+_fails = []
+
+
+def check(name, cond):
+    print(f"{'PASS' if cond else 'FAIL'}  {name}")
+    if not cond:
+        _fails.append(name)
+
+
+# Two channels: a fleet #bot2bot (Air/Mini/Pro) and a contributor #dev.
+ACCESS = {
+    "allowFrom": ["owner1"],
+    "groups": {
+        "1490_fleet": {"role": "bot2bot", "allowFrom": ["air", "mini", "pro"]},
+        "1485_dev": {"requireMention": True, "allowFrom": ["owner1", "qingyun", "rui", "pro"]},
+        "1494_susan": {"allowFrom": ["susan", "pro"]},
+    },
+}
+
+# --- recipient-first routing: post where the recipient actually is ---
+check("contributor rui → #dev (not fleet)", b2b.resolve_channel_for_recipient(ACCESS, "rui") == "1485_dev")
+check("qingyun → #dev", b2b.resolve_channel_for_recipient(ACCESS, "qingyun") == "1485_dev")
+check("fleet-only air → fleet channel", b2b.resolve_channel_for_recipient(ACCESS, "air") == "1490_fleet")
+
+# --- the dead-letter guarantee: unknown recipient → None (caller must refuse) ---
+check("john (in NO channel) → None (no dead-letter)", b2b.resolve_channel_for_recipient(ACCESS, "john") is None)
+check("empty/garbage recipient → None", b2b.resolve_channel_for_recipient(ACCESS, "nobody") is None)
+
+# --- multi-channel recipient: deterministic pick (any reaches them) ---
+# 'pro' is in all three; lowest channel id wins deterministically.
+check("multi-channel recipient → deterministic lowest id",
+      b2b.resolve_channel_for_recipient(ACCESS, "pro") == "1485_dev")
+
+# --- id type coercion: int allowFrom entry still matches a str recipient ---
+ACCESS_INT = {"groups": {"c1": {"allowFrom": [12345, 67890]}}}
+check("int allowFrom matches str recipient", b2b.resolve_channel_for_recipient(ACCESS_INT, "12345") == "c1")
+
+# --- legacy fleet-broadcast path still resolves the tagged channel ---
+check("resolve_bot2bot_channel still finds role:bot2bot", b2b.resolve_bot2bot_channel(ACCESS) == "1490_fleet")
+
+print()
+if _fails:
+    print(f"{len(_fails)} test(s) FAILED: {_fails}")
+    sys.exit(1)
+print("all tests passed — recipient-first routing")


### PR DESCRIPTION
## Root cause

`bot2bot-post` always posted to the fixed `role:bot2bot` channel — the **fleet-only #bot2bot** (allowFrom = Air/Mini/Pro). So `--to <contributor>` pings to **qingyun / Rui / john** silently went nowhere: they aren't members of that channel. A memory note ('use #dev for contributors') is *discipline* — and it already failed in practice (2026-07-27). This makes the mis-route **impossible by construction**.

## Fix

- **`resolve_channel_for_recipient(access, recipient_id)`** — returns a channel whose `allowFrom` contains the recipient (deterministic lowest-id pick when they're in several; any reaches them). Returns `None` when the recipient is in no channel.
- **`main` with `--to`** now derives the channel from the recipient and **refuses (exits) rather than dead-letter** when `resolve_channel_for_recipient` is `None`. Also guards the bot-vs-human-owner id confusion (a bot and its human owner are different ids → different channels, or a refusal).
- No-`--to` stays a fleet broadcast to the `role:bot2bot` channel (unchanged).

## Tests

`tests/bot2bot-post.test.py` (new): contributor→#dev, fleet→#bot2bot, unknown→None (no dead-letter), multi-channel deterministic pick, int/str id coercion, legacy `role:bot2bot` resolution. All green; `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rq18tfPmFcgzHQFgoSpsUN