### PR TITLE
feat(proactive-loop): add self-development policy gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,12 @@ PORT=9900
 # OPTIONAL — add these when you need specific features
 # ============================================================
 
+# Autonomous self-development is ON by default. Product deployments can turn
+# it off while keeping owner tasks, health checks, and task delivery active.
+# Invalid values fail closed (self-development disabled). Restart the core
+# after changing this value.
+# SUTANDO_SELF_DEVELOPMENT_ENABLED=0
+
 # Call your agent from another device (Tier 2b — same Wi-Fi or your tailnet).
 # The voice WS (PORT above) binds loopback only, so another device can't reach
 # it directly. These opt you into a LAN-reachable /ws proxy on the webUI port.

--- a/README.md
+++ b/README.md
@@ -324,6 +324,13 @@ The binary auto-compiles on `startup.sh` if missing. To compile manually: `cd sr
 
 It consumes API quota proportional to how much work it finds to do.
 
+Autonomous self-development is enabled by default. To run Sutando in a stable
+product context without idle-time code evolution, set
+`SUTANDO_SELF_DEVELOPMENT_ENABLED=0` in `.env` and restart the core. Sutando
+continues to process owner requests, monitor health, and deliver tasks; it only
+stops choosing and executing autonomous improvement work. An explicit
+owner-requested code change is still allowed.
+
 ---
 
 ## Security

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -80,6 +80,25 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
 
 3. **Check system health.** Run `python3 src/health-check.py`. If issues found, fix what you can (`--fix` flag), note what you can't.
 
+3.5. **Apply the self-development policy gate.** Run:
+
+   ```bash
+   python3 skills/proactive-loop/scripts/self-development-enabled.py
+   ```
+
+   The command prints `enabled` or `disabled`. It reads
+   `SUTANDO_SELF_DEVELOPMENT_ENABLED` first, then the default declared in this
+   skill's `manifest.json`. The shipped default is enabled (`1`). Product
+   deployments can set the environment variable to `0`.
+
+   If disabled, **do not select or execute autonomous improvement work**:
+   skip steps 4–8, 10, and 11; ensure the streaming watcher is running per
+   step 9; write the idle core status; then end this pass. Owner-requested
+   tasks handled in step 1, pending questions, and health/service recovery
+   remain active. Disabling self-development does not turn Sutando off and
+   does not prevent the owner from explicitly asking it to change code.
+   Manual `/proactive-loop` invocation does not override the policy.
+
 4. **Read the build log** (`$WORKSPACE/build_log.md`) — understand what exists. Do not rebuild what works.
 
 5. **Pick the highest-ROI available work.** Priority order when choosing from step 6's menu:

--- a/skills/proactive-loop/manifest.json
+++ b/skills/proactive-loop/manifest.json
@@ -1,10 +1,13 @@
 {
   "name": "proactive-loop",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "owner": "github:sonichi/sutando",
   "license": "MIT",
   "stability": "stable",
   "description": "Start Sutando's autonomous proactive loop. Monitors tasks, runs health checks, and builds missing capabilities on a recurring schedule.",
+  "config": {
+    "SUTANDO_SELF_DEVELOPMENT_ENABLED": "1"
+  },
   "provenance": {
     "source_repo": "https://github.com/sonichi/sutando"
   }

--- a/skills/proactive-loop/scripts/self-development-enabled.py
+++ b/skills/proactive-loop/scripts/self-development-enabled.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Resolve the proactive loop's autonomous self-development policy.
+
+Precedence follows the skill-config convention:
+
+    environment override > manifest.json config default
+
+The shipped manifest defaults to enabled. An invalid value fails closed so a
+misconfigured product deployment never silently enables autonomous code work.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Mapping, Optional
+
+ENV_NAME = "SUTANDO_SELF_DEVELOPMENT_ENABLED"
+TRUE_VALUES = frozenset({"1", "true", "yes", "on", "enabled"})
+FALSE_VALUES = frozenset({"0", "false", "no", "off", "disabled"})
+MANIFEST_PATH = Path(__file__).resolve().parents[1] / "manifest.json"
+
+
+def _manifest_default(manifest_path: Path = MANIFEST_PATH) -> Optional[str]:
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        config = manifest.get("config", {})
+        if not isinstance(config, dict):
+            return None
+        value = config.get(ENV_NAME)
+    except (OSError, ValueError, TypeError):
+        return None
+    return str(value) if value is not None else None
+
+
+def self_development_enabled(
+    environ: Optional[Mapping[str, str]] = None,
+    manifest_path: Path = MANIFEST_PATH,
+) -> bool:
+    """Return whether autonomous improvement work is allowed.
+
+    Missing configuration uses the manifest default. Missing/broken manifest
+    data and unrecognized values fail closed.
+    """
+
+    env = os.environ if environ is None else environ
+    raw = env.get(ENV_NAME)
+    if raw is None:
+        raw = _manifest_default(manifest_path)
+    normalized = (raw or "").strip().lower()
+    if normalized in TRUE_VALUES:
+        return True
+    if normalized in FALSE_VALUES:
+        return False
+    return False
+
+
+def main() -> int:
+    enabled = self_development_enabled()
+    print("enabled" if enabled else "disabled")
+    raw = os.environ.get(ENV_NAME)
+    if raw is not None and raw.strip().lower() not in TRUE_VALUES | FALSE_VALUES:
+        print(
+            f"{ENV_NAME}={raw!r} is invalid; self-development is disabled",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -44,6 +44,10 @@ CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1 -e SUTANDO_CORE_RUNTIME=claude)
 # where the two watch different tasks/ dirs. Companion to the resolver change
 # (#2094); conditional so non-bundled/OSS installs are untouched.
 [ -n "${SUTANDO_DEFAULT_WORKSPACE:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_DEFAULT_WORKSPACE=$SUTANDO_DEFAULT_WORKSPACE")
+# Product deployments can disable autonomous repo development while keeping
+# owner tasks, health checks, and the task watcher active. Explicitly forward
+# the override because tmux may use an older server environment.
+[ -n "${SUTANDO_SELF_DEVELOPMENT_ENABLED:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_SELF_DEVELOPMENT_ENABLED=$SUTANDO_SELF_DEVELOPMENT_ENABLED")
 
 tmux_available() {
   command -v tmux > /dev/null 2>&1

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -47,7 +47,9 @@ CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1 -e SUTANDO_CORE_RUNTIME=claude)
 # Product deployments can disable autonomous repo development while keeping
 # owner tasks, health checks, and the task watcher active. Explicitly forward
 # the override because tmux may use an older server environment.
-[ -n "${SUTANDO_SELF_DEVELOPMENT_ENABLED:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_SELF_DEVELOPMENT_ENABLED=$SUTANDO_SELF_DEVELOPMENT_ENABLED")
+if [ "${SUTANDO_SELF_DEVELOPMENT_ENABLED+x}" = x ]; then
+  CORE_ENV_ARGS+=(-e "SUTANDO_SELF_DEVELOPMENT_ENABLED=$SUTANDO_SELF_DEVELOPMENT_ENABLED")
+fi
 
 tmux_available() {
   command -v tmux > /dev/null 2>&1

--- a/src/agent/codex/cli/start-cli.sh
+++ b/src/agent/codex/cli/start-cli.sh
@@ -57,6 +57,9 @@ WORKING_DIR="$(cd "$WORKING_DIR" && pwd -P)"
 CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1 -e SUTANDO_CORE_RUNTIME=codex)
 [ -n "${SUTANDO_DEFAULT_WORKSPACE:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_DEFAULT_WORKSPACE=$SUTANDO_DEFAULT_WORKSPACE")
 [ -n "${CODEX_HOME:-}" ] && CORE_ENV_ARGS+=(-e "CODEX_HOME=$CODEX_HOME")
+# tmux's server environment can predate the product-mode override, so forward
+# the self-development policy explicitly into the persistent core session.
+[ -n "${SUTANDO_SELF_DEVELOPMENT_ENABLED:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_SELF_DEVELOPMENT_ENABLED=$SUTANDO_SELF_DEVELOPMENT_ENABLED")
 
 CODEX_ARGS=(
   -C "$WORKING_DIR"

--- a/src/agent/codex/cli/start-cli.sh
+++ b/src/agent/codex/cli/start-cli.sh
@@ -60,7 +60,9 @@ CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1 -e SUTANDO_CORE_RUNTIME=codex)
 [ -n "${CODEX_HOME:-}" ] && CORE_ENV_ARGS+=(-e "CODEX_HOME=$CODEX_HOME")
 # tmux's server environment can predate the product-mode override, so forward
 # the self-development policy explicitly into the persistent core session.
-[ -n "${SUTANDO_SELF_DEVELOPMENT_ENABLED:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_SELF_DEVELOPMENT_ENABLED=$SUTANDO_SELF_DEVELOPMENT_ENABLED")
+if [ "${SUTANDO_SELF_DEVELOPMENT_ENABLED+x}" = x ]; then
+  CORE_ENV_ARGS+=(-e "SUTANDO_SELF_DEVELOPMENT_ENABLED=$SUTANDO_SELF_DEVELOPMENT_ENABLED")
+fi
 
 CODEX_ARGS=(
   -C "$WORKING_DIR"

--- a/src/agent/start-cli.sh
+++ b/src/agent/start-cli.sh
@@ -8,11 +8,24 @@ REPO="$(cd "$(dirname "$0")/../.." && pwd)"
 # Direct restarts (menu bar, health-check recovery, and manual --restart) do
 # not pass through startup.sh. Load the same repo configuration here so policy
 # switches such as SUTANDO_SELF_DEVELOPMENT_ENABLED survive every launch path.
+# Preserve an explicit ambient override (including an empty/invalid value): the
+# skill-config contract puts process env above .env, and invalid values must
+# reach the policy helper so it can fail closed instead of using the enabled
+# manifest default.
 if [ -f "$REPO/.env" ]; then
+  _self_dev_was_set=0
+  if [ "${SUTANDO_SELF_DEVELOPMENT_ENABLED+x}" = x ]; then
+    _self_dev_was_set=1
+    _self_dev_ambient="$SUTANDO_SELF_DEVELOPMENT_ENABLED"
+  fi
   set -a
   # shellcheck disable=SC1091
   source "$REPO/.env"
   set +a
+  if [ "$_self_dev_was_set" = 1 ]; then
+    export SUTANDO_SELF_DEVELOPMENT_ENABLED="$_self_dev_ambient"
+  fi
+  unset _self_dev_was_set _self_dev_ambient
 fi
 
 runtime="$(bash "$REPO/scripts/sutando-config.sh" core-runtime)" || {

--- a/src/agent/start-cli.sh
+++ b/src/agent/start-cli.sh
@@ -4,6 +4,17 @@
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# Direct restarts (menu bar, health-check recovery, and manual --restart) do
+# not pass through startup.sh. Load the same repo configuration here so policy
+# switches such as SUTANDO_SELF_DEVELOPMENT_ENABLED survive every launch path.
+if [ -f "$REPO/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "$REPO/.env"
+  set +a
+fi
+
 runtime="$(bash "$REPO/scripts/sutando-config.sh" core-runtime)" || {
   echo "start-cli: failed to resolve core runtime" >&2
   exit 1

--- a/tests/codex-core-launcher.test.py
+++ b/tests/codex-core-launcher.test.py
@@ -174,6 +174,17 @@ exit 0
         self.assertLess(calls.index("kill-session -t =sutando-core-watcher"),
                         calls.index("new-session -d -s sutando-core"))
 
+    def test_restart_loads_self_development_policy_from_dotenv(self):
+        (self.root / ".env").write_text("SUTANDO_SELF_DEVELOPMENT_ENABLED=0\n")
+        result = self.run_launcher("--restart", env_extra={
+            "SUTANDO_SELF_DEVELOPMENT_ENABLED": "",
+        })
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "-e SUTANDO_SELF_DEVELOPMENT_ENABLED=0",
+            self.log.read_text(),
+        )
+
     def test_dispatcher_restarts_when_active_runtime_differs(self):
         result = self.run_launcher(env_extra={"TMUX_ACTIVE_RUNTIME": "claude"})
         self.assertEqual(result.returncode, 0, result.stderr)

--- a/tests/codex-core-launcher.test.py
+++ b/tests/codex-core-launcher.test.py
@@ -100,6 +100,7 @@ exit 0
 
     def run_launcher(self, *args, env_extra=None):
         env = dict(os.environ)
+        env.pop("SUTANDO_SELF_DEVELOPMENT_ENABLED", None)
         env.update({
             "PATH": f"{self.bin}:/usr/bin:/bin",
             "TMUX_LOG": str(self.log),
@@ -119,6 +120,7 @@ exit 0
 
     def run_launcher_with_tty(self, *args, env_extra=None):
         env = dict(os.environ)
+        env.pop("SUTANDO_SELF_DEVELOPMENT_ENABLED", None)
         env.update({
             "PATH": f"{self.bin}:/usr/bin:/bin",
             "TMUX_LOG": str(self.log),
@@ -208,12 +210,40 @@ exit 0
 
     def test_restart_loads_self_development_policy_from_dotenv(self):
         (self.root / ".env").write_text("SUTANDO_SELF_DEVELOPMENT_ENABLED=0\n")
+        result = self.run_launcher("--restart", env_extra={})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "-e SUTANDO_SELF_DEVELOPMENT_ENABLED=0",
+            self.log.read_text(),
+        )
+
+    def test_ambient_self_development_policy_overrides_dotenv(self):
+        (self.root / ".env").write_text("SUTANDO_SELF_DEVELOPMENT_ENABLED=1\n")
+        result = self.run_launcher("--restart", env_extra={
+            "SUTANDO_SELF_DEVELOPMENT_ENABLED": "0",
+        })
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "-e SUTANDO_SELF_DEVELOPMENT_ENABLED=0",
+            self.log.read_text(),
+        )
+        self.assertNotIn(
+            "-e SUTANDO_SELF_DEVELOPMENT_ENABLED=1",
+            self.log.read_text(),
+        )
+
+    def test_empty_ambient_self_development_policy_reaches_core_to_fail_closed(self):
+        (self.root / ".env").write_text("SUTANDO_SELF_DEVELOPMENT_ENABLED=1\n")
         result = self.run_launcher("--restart", env_extra={
             "SUTANDO_SELF_DEVELOPMENT_ENABLED": "",
         })
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn(
-            "-e SUTANDO_SELF_DEVELOPMENT_ENABLED=0",
+            "-e SUTANDO_SELF_DEVELOPMENT_ENABLED=",
+            self.log.read_text(),
+        )
+        self.assertNotIn(
+            "-e SUTANDO_SELF_DEVELOPMENT_ENABLED=1",
             self.log.read_text(),
         )
 

--- a/tests/codex-core-launcher.test.py
+++ b/tests/codex-core-launcher.test.py
@@ -140,7 +140,10 @@ exit 0
                 os.close(slave)
 
     def test_launches_codex_and_managed_task_notifier(self):
-        result = self.run_launcher(env_extra={"SUTANDO_CORE_MODEL": "gpt-test"})
+        result = self.run_launcher(env_extra={
+            "SUTANDO_CORE_MODEL": "gpt-test",
+            "SUTANDO_SELF_DEVELOPMENT_ENABLED": "0",
+        })
         self.assertEqual(result.returncode, 0, result.stderr)
         calls = self.log.read_text()
         self.assertIn("new-session -d -s sutando-core", calls)
@@ -152,6 +155,7 @@ exit 0
         self.assertIn("new-session -d -s sutando-core-watcher", calls)
         self.assertIn("task-notifier.sh", calls)
         self.assertIn("CODEX_HOME=", calls)
+        self.assertIn("-e SUTANDO_SELF_DEVELOPMENT_ENABLED=0", calls)
         self.assertIn("has-session -t =sutando-core", calls)
         self.assertIn("has-session -t =sutando-core-watcher", calls)
 

--- a/tests/proactive-loop-self-development.test.py
+++ b/tests/proactive-loop-self-development.test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Regression tests for the proactive-loop self-development policy gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "skills/proactive-loop/scripts/self-development-enabled.py"
+MANIFEST = REPO / "skills/proactive-loop/manifest.json"
+ENV_NAME = "SUTANDO_SELF_DEVELOPMENT_ENABLED"
+
+spec = importlib.util.spec_from_file_location("self_development_gate", SCRIPT)
+assert spec and spec.loader
+gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gate)
+
+failures = []
+
+
+def check(label: str, condition: bool) -> None:
+    if condition:
+        print(f"PASS  {label}")
+    else:
+        print(f"FAIL  {label}")
+        failures.append(label)
+
+
+manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+check("manifest declares the feature flag", ENV_NAME in manifest.get("config", {}))
+check("shipped manifest default is enabled", gate.self_development_enabled({}))
+
+for value in ("1", "true", "YES", "on", "enabled"):
+    check(f"truthy override {value!r}", gate.self_development_enabled({ENV_NAME: value}))
+
+for value in ("0", "false", "NO", "off", "disabled"):
+    check(f"false override {value!r}", not gate.self_development_enabled({ENV_NAME: value}))
+
+check("invalid override fails closed", not gate.self_development_enabled({ENV_NAME: "maybe"}))
+
+with tempfile.TemporaryDirectory() as td:
+    missing = Path(td) / "missing-manifest.json"
+    check(
+        "missing manifest fails closed",
+        not gate.self_development_enabled({}, manifest_path=missing),
+    )
+    malformed = Path(td) / "malformed-manifest.json"
+    malformed.write_text('{"config": []}', encoding="utf-8")
+    check(
+        "malformed manifest config fails closed",
+        not gate.self_development_enabled({}, manifest_path=malformed),
+    )
+
+disabled = subprocess.run(
+    ["python3", str(SCRIPT)],
+    env={ENV_NAME: "0"},
+    capture_output=True,
+    text=True,
+    check=True,
+)
+check("CLI reports disabled", disabled.stdout.strip() == "disabled")
+
+invalid = subprocess.run(
+    ["python3", str(SCRIPT)],
+    env={ENV_NAME: "surprise"},
+    capture_output=True,
+    text=True,
+    check=True,
+)
+check("CLI invalid value reports disabled", invalid.stdout.strip() == "disabled")
+check("CLI invalid value warns", "invalid" in invalid.stderr)
+
+skill_text = (REPO / "skills/proactive-loop/SKILL.md").read_text(encoding="utf-8")
+check("loop invokes the gate", "self-development-enabled.py" in skill_text)
+check("disabled loop still handles owner tasks", "Owner-requested" in skill_text)
+check("manual invocation cannot bypass", "does not override the policy" in skill_text)
+
+for launcher in (
+    REPO / "src/agent/claude/cli/start-cli.sh",
+    REPO / "src/agent/codex/cli/start-cli.sh",
+):
+    text = launcher.read_text(encoding="utf-8")
+    check(
+        f"{launcher.parent.parent.name} launcher forwards override",
+        f'-e "{ENV_NAME}=${ENV_NAME}"' in text,
+    )
+
+if failures:
+    raise SystemExit(f"{len(failures)} failure(s): {', '.join(failures)}")
+print("\nall tests passed")

--- a/tests/proactive-loop-self-development.test.py
+++ b/tests/proactive-loop-self-development.test.py
@@ -112,6 +112,10 @@ for launcher in (
         f"{launcher.parent.parent.name} launcher forwards override",
         f'-e "{ENV_NAME}=${ENV_NAME}"' in text,
     )
+    check(
+        f"{launcher.parent.parent.name} launcher preserves an explicit empty override",
+        f'"${{{ENV_NAME}+x}}" = x' in text,
+    )
 
 if failures:
     raise SystemExit(f"{len(failures)} failure(s): {', '.join(failures)}")

--- a/tests/proactive-loop-self-development.test.py
+++ b/tests/proactive-loop-self-development.test.py
@@ -4,10 +4,14 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
+import os
 import subprocess
 import tempfile
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "skills/proactive-loop/scripts/self-development-enabled.py"
@@ -73,6 +77,26 @@ invalid = subprocess.run(
 )
 check("CLI invalid value reports disabled", invalid.stdout.strip() == "disabled")
 check("CLI invalid value warns", "invalid" in invalid.stderr)
+
+
+def run_main(value: str) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with patch.dict(os.environ, {ENV_NAME: value}, clear=True):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            result = gate.main()
+    return result, stdout.getvalue(), stderr.getvalue()
+
+
+rc, stdout, stderr = run_main("1")
+check("main enabled path", rc == 0 and stdout.strip() == "enabled" and not stderr)
+rc, stdout, stderr = run_main("0")
+check("main disabled path", rc == 0 and stdout.strip() == "disabled" and not stderr)
+rc, stdout, stderr = run_main("unexpected")
+check(
+    "main invalid path fails closed with warning",
+    rc == 0 and stdout.strip() == "disabled" and "invalid" in stderr,
+)
 
 skill_text = (REPO / "skills/proactive-loop/SKILL.md").read_text(encoding="utf-8")
 check("loop invokes the gate", "self-development-enabled.py" in skill_text)


### PR DESCRIPTION
## What changed, and why?

Adds `SUTANDO_SELF_DEVELOPMENT_ENABLED`, a product-policy gate for Sutando's autonomous improvement work.

- Shipped default: `1` (current OSS behavior is unchanged).
- Product mode: set `SUTANDO_SELF_DEVELOPMENT_ENABLED=0`.
- Disabled mode still processes owner tasks, pending questions, health/service recovery, and watcher events; it only stops choosing and executing idle-time self-improvement work.
- Explicit owner-requested code changes remain allowed.
- Invalid values and broken/missing manifest config fail closed.

The owner requested this so commercial deployments can make a reliability promise that the running product will not autonomously evolve its own code.

## Review first

1. `skills/proactive-loop/SKILL.md` — exact disabled-mode boundary.
2. `skills/proactive-loop/scripts/self-development-enabled.py` — env > manifest policy resolution.
3. `src/agent/{claude,codex}/cli/start-cli.sh` — explicit tmux propagation into persistent cores.
4. `tests/proactive-loop-self-development.test.py` — policy matrix and source wiring.

The feature-specific default is declared in `skills/proactive-loop/manifest.json`, following the skill config convention rather than inventing an undeclared environment lookup.

## Before / after evidence

Parent `origin/main` has no self-development policy or persistent-core override:

```text
$ git grep -n 'SUTANDO_SELF_DEVELOPMENT_ENABLED' origin/main -- skills/proactive-loop src/agent .env.example README.md
(no output; exit 1)
```

HEAD resolves the shipped default, accepted true/false spellings, malformed config, and invalid product values:

```text
$ PYTHONDONTWRITEBYTECODE=1 python3 tests/proactive-loop-self-development.test.py
PASS  manifest declares the feature flag
PASS  shipped manifest default is enabled
PASS  truthy override '1'
PASS  truthy override 'true'
PASS  truthy override 'YES'
PASS  truthy override 'on'
PASS  truthy override 'enabled'
PASS  false override '0'
PASS  false override 'false'
PASS  false override 'NO'
PASS  false override 'off'
PASS  false override 'disabled'
PASS  invalid override fails closed
PASS  missing manifest fails closed
PASS  malformed manifest config fails closed
PASS  CLI reports disabled
PASS  CLI invalid value reports disabled
PASS  CLI invalid value warns
PASS  loop invokes the gate
PASS  disabled loop still handles owner tasks
PASS  manual invocation cannot bypass
PASS  claude launcher forwards override
PASS  codex launcher forwards override

all tests passed
```

The Codex launcher integration also observes the actual tmux `-e SUTANDO_SELF_DEVELOPMENT_ENABLED=0` argument.

## Tests

```text
$ PYTHONDONTWRITEBYTECODE=1 python3 tests/codex-core-launcher.test.py
...........
----------------------------------------------------------------------
Ran 11 tests in 7.283s

OK

$ bash tests/start-cli-claude-config-dir.test.sh
PASSED: 4
FAILED: 0

$ PYTHONDONTWRITEBYTECODE=1 python3 tests/start-cli-model-pin.test.py
✓ case default
✓ case env-set
start-cli.sh model-pin threading is correct.

$ python3 scripts/lint-skill.py skills/proactive-loop
lint-skill: 1 manifest(s), 0 error(s), 0 warning(s)

$ PYTHONDONTWRITEBYTECODE=1 python3 tests/ci-covers-every-python-test.test.py
Ran 4 tests in 0.023s
OK

$ bash -n src/agent/claude/cli/start-cli.sh src/agent/codex/cli/start-cli.sh
(exit 0)

$ shellcheck src/agent/claude/cli/start-cli.sh src/agent/codex/cli/start-cli.sh
(exit 0)

$ python3 -m ruff check skills/proactive-loop/scripts/self-development-enabled.py tests/proactive-loop-self-development.test.py tests/codex-core-launcher.test.py
(exit 0)

$ git diff --check origin/main...HEAD
(exit 0)
```

Local `diff-cover` was unavailable; remote coverage CI will provide the authoritative diff-coverage result.

## Live-path evidence

Not run against the canonical live core: restarting it from inside the task that creates this PR would terminate the in-flight task. The launcher behavior is covered through hermetic tmux integration, including the exact disabled override. Before merge, a controlled product-context restart should confirm one disabled proactive pass handles a queued owner task and health check but performs no step-6 autonomous work.

## Edge cases and risks

- Unset → manifest default `1`; OSS behavior is unchanged.
- Recognized false spellings disable the feature.
- Invalid values or malformed/missing manifest config fail closed.
- A manual `/proactive-loop` invocation cannot bypass the gate.
- Disabled mode intentionally does **not** disable owner-directed coding.
- Both Claude and Codex persistent tmux cores receive the setting; no-tmux launches inherit it normally.
- Added-line hardcoded-host-path scan is clean.
- No migration or permissions change.
- Rollback: unset the variable (returns to the shipped default) or revert this PR.

## Known gap / follow-up

This is a policy boundary in the autonomous loop, not an OS sandbox against all possible source writes. If a future commercial tier needs to prohibit even explicit owner-requested code changes, that is a separate, stronger execution-policy feature.
