### PR TITLE
chore(brand): retire chat.ag2.space — relay examples and fixtures use ag2.space

### DIFF
--- a/packages/ag2-sparrow/README.md
+++ b/packages/ag2-sparrow/README.md
@@ -19,7 +19,7 @@ pipx install ag2-sparrow        # or: pip install ag2-sparrow
 
 ```sh
 REMOTE_TASK_TOKEN=<your relay token from the AG2 Space Agent Portal> \
-REMOTE_TASK_URL=https://chat.ag2.space/relay \
+REMOTE_TASK_URL=https://ag2.space/relay \
 ag2-sparrow
 ```
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -58,7 +58,7 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
-# Prefer IPv4 for gateway/relay connections. The relay host (e.g. chat.ag2.space)
+# Prefer IPv4 for gateway/relay connections. The relay host (e.g. ag2.space)
 # publishes AAAA records, but some hosts have IPv6 black-holed at the network
 # (the SYN is silently dropped, not refused). Python's getaddrinfo returns v6
 # first, so each fresh urllib connection — this bridge opens one per long-poll

--- a/src/remote-gateway-bridge.test.py
+++ b/src/remote-gateway-bridge.test.py
@@ -572,14 +572,14 @@ def main() -> int:
     # %7C token must decode so URL is populated — otherwise it parses as a bare
     # secret with empty URL and FATALs at startup (the Vidhu "connected but not
     # responding" failure, 2026-07-24).
-    check(rtc._parse_onboarding_token("https://chat.ag2.space/relay|deadbeef")
-          == ("https://chat.ag2.space/relay", "deadbeef"),
+    check(rtc._parse_onboarding_token("https://ag2.space/relay|deadbeef")
+          == ("https://ag2.space/relay", "deadbeef"),
           "token parse: literal | splits into (url, secret)")
-    check(rtc._parse_onboarding_token("https://chat.ag2.space/relay%7Cdeadbeef")
-          == ("https://chat.ag2.space/relay", "deadbeef"),
+    check(rtc._parse_onboarding_token("https://ag2.space/relay%7Cdeadbeef")
+          == ("https://ag2.space/relay", "deadbeef"),
           "token parse: %7C-encoded separator decodes to (url, secret)")
-    check(rtc._parse_onboarding_token("https://chat.ag2.space/relay%7cdeadbeef")
-          == ("https://chat.ag2.space/relay", "deadbeef"),
+    check(rtc._parse_onboarding_token("https://ag2.space/relay%7cdeadbeef")
+          == ("https://ag2.space/relay", "deadbeef"),
           "token parse: lowercase %7c also decodes")
     check(rtc._parse_onboarding_token("baresecret") == ("", "baresecret"),
           "token parse: bare secret yields empty url (REMOTE_TASK_URL supplies it)")


### PR DESCRIPTION
## Summary

The AG2 Space homeserver apex is now **https://ag2.space**; chat.ag2.space is retired. This sweeps the three remaining references — the ag2-sparrow README's `REMOTE_TASK_URL` example, an IPv4-preference comment, and the onboarding-token parse-test fixtures. No behavior change: the relay URL always arrives via `REMOTE_TASK_URL` / the onboarding token at runtime.

## Verification

`python3 src/remote-gateway-bridge.test.py` — PASS, all checks green.

Part of the ag2space cross-repo domain consolidation (webapp ag2-space/cinny-webclient#334, backend ag2-space/ag2space-backend#217).

🤖 Generated with [Claude Code](https://claude.com/claude-code)