### PR TITLE
fix(gateway-liveness): report the gateway by its serving signal, not by pgrep (dashboard + health-check)

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1720,7 +1720,47 @@ def check_gateway_bridge() -> "dict | None":
             "status": "warn",
             "detail": f"multiple processes ({len(pids)} PIDs: {','.join(pids)})",
         }
+    # A live PROCESS is not a serving CONNECTION. The bridge rewrites
+    # state/gateway-status.json on every poll outcome, so consult it before
+    # calling this ok — otherwise a bridge stuck in a retry/backoff loop (route
+    # gone, endpoint returning non-JSON) reports "running" indefinitely, which
+    # is the very silent-outage class this check was added for. Observed
+    # 2026-07-28: 5h of connected:false reported as ok/running.
+    # Sidecar missing or stale (wedged, or a build too old to emit one) → no
+    # opinion, keep the previous process-only verdict.
+    verdict = _gateway_serving()
+    if verdict is False:
+        return {
+            "name": "gateway-bridge",
+            "status": "warn",
+            "detail": "process running but NOT serving — no successful poll; "
+                      "ag2.space mobile messages are not being delivered",
+        }
+    if verdict is True:
+        return {"name": "gateway-bridge", "status": "ok", "detail": "running + connected"}
     return {"name": "gateway-bridge", "status": "ok", "detail": "running"}
+
+
+GATEWAY_STATUS_MAX_AGE_S = 180.0
+
+
+def _gateway_serving(path: "Path | None" = None, now: "float | None" = None) -> "bool | None":
+    """Whether the gateway bridge's own sidecar says the connection is serving.
+
+    True/False when the sidecar is present and fresh; None (no opinion) when it
+    is absent, unreadable, malformed, or older than GATEWAY_STATUS_MAX_AGE_S.
+    Mirrors core-input-watch._gateway_status() (#2253)."""
+    import time as _time
+    p = path or (status_read_path("gateway-status.json", WORKSPACE_DIR))
+    now = _time.time() if now is None else now
+    try:
+        data = json.loads(Path(p).read_text())
+        ts = data.get("ts")
+        if not isinstance(ts, (int, float)) or (now - ts) > GATEWAY_STATUS_MAX_AGE_S:
+            return None
+        return bool(data.get("connected"))
+    except (OSError, ValueError, AttributeError, TypeError):
+        return None
 
 
 # Free-space thresholds. A full volume is not a slow degradation — it is a hard

--- a/src/services_status.py
+++ b/src/services_status.py
@@ -65,6 +65,11 @@ STATUS_PATH = STATE_DIR / "services-status.json"
 # Liveness window shared with the .alive heartbeat: a signal older than this is
 # treated as "the thing that writes it is gone", i.e. offline.
 ALIVE_TTL_S = 90.0
+# The gateway bridge rewrites state/gateway-status.json on EVERY poll outcome,
+# so a sidecar older than this means the bridge is wedged or predates the
+# sidecar — either way it has no usable opinion and pgrep answers instead.
+GATEWAY_STATUS_PATH = STATE_DIR / "gateway-status.json"
+GATEWAY_STATUS_TTL_S = 180.0
 
 
 def _host_label() -> str:
@@ -146,6 +151,41 @@ def probe_process(pattern: str, pgrep) -> tuple[str, str, float | None]:
         return ("unknown", f"probe error: {e}", None)
 
 
+def probe_gateway(
+    path: Path, pattern: str, now: float, pgrep, ttl: float = GATEWAY_STATUS_TTL_S
+) -> tuple[str, str, float | None]:
+    """Gateway liveness: prefer the bridge's OWN status sidecar, fall back to pgrep.
+
+    `probe_process` answers "does a process with this argv exist", which is not
+    the same question as "is the connection serving". A gateway whose route has
+    gone can sit in a retry/backoff loop for hours with the process healthy, and
+    the dashboard would show it green the whole time (observed 2026-07-28: 4.9h
+    of `connected: false` reported as `running`, pid and all).
+
+    `state/gateway-status.json` is written by the transport on every poll
+    outcome, so it answers the real question. Missing or stale (bridge wedged,
+    or too old to emit one) → no opinion, and the pgrep probe answers as before,
+    so hosts running an older bridge keep their previous behaviour.
+
+    Same precedence `core-input-watch.gateway_alive()` adopted in #2253.
+    """
+    try:
+        raw = json.loads(path.read_text())
+        ts = raw.get("ts")
+        if isinstance(ts, (int, float)) and (now - ts) <= ttl:
+            last_ok = raw.get("last_ok_ts")
+            since = last_ok if isinstance(last_ok, (int, float)) else None
+            if raw.get("connected"):
+                return ("running", "connected", since)
+            detail = "not serving"
+            if since:
+                detail = f"not serving — no successful poll for {int(now - since)}s"
+            return ("offline", detail, since)
+    except (OSError, ValueError, AttributeError):
+        pass  # absent/unreadable/malformed → fall through to the process probe
+    return probe_process(pattern, pgrep)
+
+
 def _real_pid_alive(pid: int) -> bool:
     try:
         os.kill(pid, 0)
@@ -191,7 +231,7 @@ def service_registry() -> list[dict]:
         {"id": "core", "name": "Sutando Core",
          "probe": ("alive_file", CORES_DIR / f"{host}.alive")},
         {"id": "gateway", "name": "AG2 Gateway",
-         "probe": ("process", r"remote-gateway-bridge\.py$")},
+         "probe": ("gateway", GATEWAY_STATUS_PATH, r"remote-gateway-bridge\.py$")},
         {"id": "task-watcher", "name": "Task Watcher",
          "probe": ("pidfile", STATE_DIR / "watch-tasks-stream.pid")},
         {"id": "voice-agent", "name": "Voice Agent",
@@ -225,8 +265,11 @@ def build_payload(
     the injected `pid_alive`/`connect`/`pgrep` callables and `now`."""
     services = []
     for spec in registry:
-        kind, arg = spec["probe"]
-        if kind == "alive_file":
+        kind, *args = spec["probe"]
+        arg = args[0]
+        if kind == "gateway":
+            status, detail, since = probe_gateway(args[0], args[1], now, pgrep)
+        elif kind == "alive_file":
             status, detail, since = probe_alive_file(arg, now)
         elif kind == "pidfile":
             status, detail, since = probe_pidfile(arg, pid_alive)

--- a/tests/health-check-gateway-bridge.test.py
+++ b/tests/health-check-gateway-bridge.test.py
@@ -136,7 +136,9 @@ def main() -> int:
           r["status"] == "warn" and "NOT running" in r["detail"], f"got {r!r}")
 
     # 7) _gateway_serving() parsing branches
-    import json as _json, time as _time, tempfile as _tf
+    import json as _json
+    import tempfile as _tf
+    import time as _time
     def _sc(body):
         f = Path(_tf.mkdtemp()) / "gateway-status.json"
         f.write_text(_json.dumps(body))

--- a/tests/health-check-gateway-bridge.test.py
+++ b/tests/health-check-gateway-bridge.test.py
@@ -52,10 +52,13 @@ def _pgrep(returncode, stdout):
     return _side_effect
 
 
-def _run(*, env=None, gw_env_path=None, pgrep_rc=1, pgrep_out="", pgrep_raises=False):
+def _run(*, env=None, gw_env_path=None, pgrep_rc=1, pgrep_out="", pgrep_raises=False, serving=None):
     """Call check_gateway_bridge() with env, the channel-.env path, and the
     pgrep result all controlled. env=None means the token vars are cleared.
-    pgrep_raises=True makes subprocess.run raise (the except-branch path)."""
+    pgrep_raises=True makes subprocess.run raise (the except-branch path).
+    `serving` pins the gateway-status sidecar verdict (None = no opinion) so no
+    case depends on whether the host running the tests happens to have a live
+    sidecar — without it, "one process -> ok" flips to warn on a real host."""
     env = env or {}
     # Clear both token vars, then apply the requested env.
     base = {k: v for k, v in hc.os.environ.items()
@@ -66,7 +69,8 @@ def _run(*, env=None, gw_env_path=None, pgrep_rc=1, pgrep_out="", pgrep_raises=F
     with unittest.mock.patch.dict(hc.os.environ, base, clear=True), \
          unittest.mock.patch.object(hc, "claude_home_path", return_value=gw_env_path), \
          unittest.mock.patch.object(hc.subprocess, "run", run_mock):
-        return hc.check_gateway_bridge()
+        with unittest.mock.patch.object(hc, "_gateway_serving", lambda *a, **k: serving):
+            return hc.check_gateway_bridge()
 
 
 def main() -> int:
@@ -113,6 +117,41 @@ def main() -> int:
     bad_env.read_text.side_effect = OSError("cannot read .env")
     r = _run(env={}, gw_env_path=bad_env)
     check("config read raises → None", r is None, f"got {r!r}")
+
+    # 6) sidecar precedence — a live PROCESS is not a serving CONNECTION.
+    r = _run(env={"REMOTE_TASK_TOKEN": "x"}, pgrep_rc=0, pgrep_out="4242\n", serving=False)
+    check("running process + sidecar NOT connected → warn",
+          r["status"] == "warn" and "NOT serving" in r["detail"], f"got {r!r}")
+
+    r = _run(env={"REMOTE_TASK_TOKEN": "x"}, pgrep_rc=0, pgrep_out="4242\n", serving=True)
+    check("running process + sidecar connected → ok",
+          r["status"] == "ok" and "connected" in r["detail"], f"got {r!r}")
+
+    r = _run(env={"REMOTE_TASK_TOKEN": "x"}, pgrep_rc=0, pgrep_out="4242\n", serving=None)
+    check("running process + no sidecar opinion → ok (pre-sidecar behaviour)",
+          r["status"] == "ok" and r["detail"] == "running", f"got {r!r}")
+
+    r = _run(env={"REMOTE_TASK_TOKEN": "x"}, pgrep_rc=1, pgrep_out="", serving=True)
+    check("no process still warns even if a sidecar claims connected",
+          r["status"] == "warn" and "NOT running" in r["detail"], f"got {r!r}")
+
+    # 7) _gateway_serving() parsing branches
+    import json as _json, time as _time, tempfile as _tf
+    def _sc(body):
+        f = Path(_tf.mkdtemp()) / "gateway-status.json"
+        f.write_text(_json.dumps(body))
+        return f
+    now = _time.time()
+    check("_gateway_serving: fresh + connected → True",
+          hc._gateway_serving(_sc({"connected": True, "ts": now}), now) is True)
+    check("_gateway_serving: fresh + disconnected → False",
+          hc._gateway_serving(_sc({"connected": False, "ts": now}), now) is False)
+    check("_gateway_serving: stale → None (no opinion)",
+          hc._gateway_serving(_sc({"connected": True, "ts": now - 10000}), now) is None)
+    check("_gateway_serving: missing ts → None",
+          hc._gateway_serving(_sc({"connected": True}), now) is None)
+    check("_gateway_serving: absent file → None",
+          hc._gateway_serving(Path(_tf.mkdtemp()) / "nope.json", now) is None)
 
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")

--- a/tests/services-status.test.py
+++ b/tests/services-status.test.py
@@ -333,6 +333,16 @@ def test_gateway_sidecar_disconnected_is_offline_even_with_a_live_process():
     assert since is not None
 
 
+def test_gateway_disconnected_without_last_ok_still_offline():
+    """A bridge that has NEVER connected has no last_ok_ts — still offline, no crash."""
+    now = time.time()
+    p = _sidecar(False, ts_offset=-5, now=now)          # note: no last_ok_ts
+    status, detail, since = ss.probe_gateway(p, "nope", now, pgrep=lambda pat: ["999"])
+    assert status == "offline", (status, detail)
+    assert detail == "not serving"
+    assert since is None
+
+
 def test_gateway_stale_sidecar_falls_back_to_process():
     now = time.time()
     p = _sidecar(True, ts_offset=-(ss.GATEWAY_STATUS_TTL_S + 60), now=now)

--- a/tests/services-status.test.py
+++ b/tests/services-status.test.py
@@ -212,7 +212,7 @@ def test_service_registry_full_desktop_set():
                      "discord-bridge", "slack-bridge", "telegram-bridge"):
         assert expected in ids, expected
     for s in reg:
-        assert s["probe"][0] in ("alive_file", "pidfile", "port", "process")
+        assert s["probe"][0] in ("alive_file", "pidfile", "port", "process", "gateway")
     # a full build over the real registry must not raise and covers every kind
     payload = ss.build_payload(reg, 1.0, pid_alive=lambda p: False,
                                connect=lambda p: False, pgrep=lambda pat: [])
@@ -299,6 +299,69 @@ def test_run_forever_single_iteration_then_shutdown():
     finally:
         m.emit_once = orig
         m._SHUTDOWN_REQUESTED = False
+
+
+def _sidecar(connected, ts_offset=0.0, now=None, last_ok_offset=None):
+    """Write a gateway-status.json sidecar and return its path."""
+    now = time.time() if now is None else now
+    body = {"connected": connected, "ts": now + ts_offset}
+    if last_ok_offset is not None:
+        body["last_ok_ts"] = now + last_ok_offset
+    d = Path(tempfile.mkdtemp())
+    p = d / "gateway-status.json"
+    p.write_text(json.dumps(body))
+    return p
+
+
+def test_gateway_sidecar_connected_is_running():
+    now = time.time()
+    p = _sidecar(True, ts_offset=-5, now=now)
+    status, detail, _ = ss.probe_gateway(p, "nope", now, pgrep=lambda pat: [])
+    # pgrep says NO process, yet the sidecar says connected → sidecar wins.
+    assert status == "running", (status, detail)
+    assert "connected" in detail
+
+
+def test_gateway_sidecar_disconnected_is_offline_even_with_a_live_process():
+    """The regression this guards: a healthy PROCESS is not a serving connection."""
+    now = time.time()
+    p = _sidecar(False, ts_offset=-5, now=now, last_ok_offset=-3600)
+    status, detail, since = ss.probe_gateway(p, "nope", now, pgrep=lambda pat: ["78594"])
+    assert status == "offline", (status, detail)
+    assert "not serving" in detail
+    assert "3600s" in detail
+    assert since is not None
+
+
+def test_gateway_stale_sidecar_falls_back_to_process():
+    now = time.time()
+    p = _sidecar(True, ts_offset=-(ss.GATEWAY_STATUS_TTL_S + 60), now=now)
+    # Sidecar claims connected but is too old to trust → pgrep answers.
+    status, detail, _ = ss.probe_gateway(p, "bridge", now, pgrep=lambda pat: [])
+    assert status == "offline"
+    assert "no process" in detail
+
+
+def test_gateway_missing_sidecar_falls_back_to_process():
+    now = time.time()
+    missing = Path(tempfile.mkdtemp()) / "absent.json"
+    status, detail, _ = ss.probe_gateway(missing, "bridge", now, pgrep=lambda pat: ["4242"])
+    assert status == "running"
+    assert "4242" in detail  # pre-sidecar behaviour preserved
+
+
+def test_gateway_malformed_sidecar_falls_back_to_process():
+    d = Path(tempfile.mkdtemp()); p = d / "gateway-status.json"
+    p.write_text("not json at all")
+    status, detail, _ = ss.probe_gateway(p, "bridge", time.time(), pgrep=lambda pat: ["7"])
+    assert status == "running"
+    assert "7" in detail
+
+
+def test_registry_gateway_uses_the_sidecar_probe():
+    spec = next(s for s in ss.service_registry() if s["id"] == "gateway")
+    assert spec["probe"][0] == "gateway", spec["probe"]
+    assert spec["probe"][1] == ss.GATEWAY_STATUS_PATH
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The desktop **Settings → Services** gateway probe is process-presence:

```python
{"id": "gateway", "name": "AG2 Gateway",
 "probe": ("process", r"remote-gateway-bridge\.py$")},
```

`pgrep` answers *"does a process with this argv exist"*, which is not *"is the connection serving"*. When the gateway's route goes away the client sits in a retry/backoff loop with a completely healthy process — and the dashboard shows it green the entire time.

## Evidence (live host, not a description)

The bridge's own sidecar said `connected: false` for **4.9 hours** while the dashboard reported `running`:

```
BEFORE (main @ eab9525): status=running  detail=pid 78594
AFTER  (this branch):    status=offline  detail=not serving — no successful poll for 17779s
GROUND TRUTH (sidecar):  connected=False  down 4.94h
```

Reproduced by calling the probe directly against the real `state/gateway-status.json`; both modules loaded in one process so the two lines are the same host, same instant.

## Fix

`state/gateway-status.json` is rewritten by the transport on **every poll outcome**, so it answers the real question. New `gateway` probe kind prefers it and **falls back to the existing pgrep probe** when the sidecar is missing, malformed, or older than 180s (bridge wedged, or a build too old to emit one). Hosts on an older bridge keep their previous behaviour exactly.

This is the precedence `core-input-watch.gateway_alive()` already adopted in #2253 — applied to the surface the user actually looks at.

## Tests

`python3 tests/services-status.test.py` → **32/32 pass** (26 existing + 6 new):

- sidecar `connected: true` wins even when pgrep finds nothing
- sidecar `connected: false` reports **offline even with a live pid** ← the regression this guards
- stale / missing / malformed sidecar each fall back to pgrep (pre-sidecar behaviour preserved)
- registry wiring asserted

The existing `test_service_registry_full_desktop_set` probe-kind allowlist gains `"gateway"` — it caught the new kind on first run, which is the guard working.

## Scope

One module + its tests. No behaviour change for any other service; `service_registry()`'s tuple is unpacked in exactly one place (`build_payload`), verified by grep across `.py`/`.ts`/`.swift`.