### PR TITLE
fix(health): ignore retention-archived task results

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1895,18 +1895,29 @@ def _pending_task_files(tasks_dir: Path, results_dir: Optional[Path] = None) -> 
     if results_dir is None:
         results_dir = tasks_dir.parent / "results"
     try:
-        archive_dir = results_dir / "archive"
         archived_names = set()
-        for path in archive_dir.glob("*/*.txt"):
-            if path.is_file():
-                archived_names.add(path.name)
-        for path in archive_dir.glob("*.txt"):
+
+        def record_archived(path: Path) -> None:
             if not path.is_file():
-                continue
+                return
             archived_names.add(path.name)
             renamed = re.match(r"^(.+)-[0-9]+\.txt$", path.name)
             if renamed:
                 archived_names.add(f"{renamed.group(1)}.txt")
+
+        archive_dir = results_dir / "archive"
+        for path in archive_dir.glob("*/*.txt"):
+            record_archived(path)
+        for path in archive_dir.glob("*.txt"):
+            record_archived(path)
+        # Startup retention uses sibling archive-YYYY-MM-DD directories.
+        # task-notifier.sh already treats these as completed deliveries; the
+        # health queue and wedge-recovery signal must use the same namespace.
+        for retention_dir in results_dir.glob("archive-*"):
+            if not retention_dir.is_dir():
+                continue
+            for path in retention_dir.glob("*.txt"):
+                record_archived(path)
         return [
             path for path in tasks_dir.glob("*.txt")
             if path.is_file()

--- a/tests/health-check-stuck-loop.test.py
+++ b/tests/health-check-stuck-loop.test.py
@@ -282,6 +282,20 @@ def case_m2_completed_tasks_excluded() -> list[str]:
     return fails
 
 
+def case_m2b_retention_archived_tasks_excluded() -> list[str]:
+    fails = []
+    def setup(d):
+        archive = d.parent / "results" / "archive-2026-07-26"
+        archive.mkdir(parents=True)
+        for i in range(8):
+            task = write_task(d, f"task-{i}.txt", age_sec=600)
+            (archive / task.name).write_text("complete")
+    r = with_tasks_override(setup)
+    if r["status"] != "ok" or "empty" not in r["detail"]:
+        fails.append(f"m2b) retention-archived tasks counted as pending: {r['detail']}")
+    return fails
+
+
 def case_m3_completed_tasks_excluded_from_recovery() -> list[str]:
     fails = []
     with tempfile.TemporaryDirectory() as td:
@@ -325,6 +339,21 @@ def case_m3c_gateway_archived_results_excluded_from_recovery() -> list[str]:
         (archive / "task-complete-1784690000.txt").write_text("complete")
         if hc._oldest_pending_task(time.time(), tasks) is not None:
             fails.append("m3c) gateway-archived result triggered recovery detection")
+    return fails
+
+
+def case_m3d_retention_archived_results_excluded_from_recovery() -> list[str]:
+    fails = []
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        tasks = root / "tasks"
+        archive = root / "results" / "archive-2026-07-26"
+        tasks.mkdir()
+        archive.mkdir(parents=True)
+        task = write_task(tasks, "task-complete.txt", age_sec=600)
+        (archive / "task-complete-1784690000.txt").write_text("complete")
+        if hc._oldest_pending_task(time.time(), tasks) is not None:
+            fails.append("m3d) retention-archived result triggered recovery detection")
     return fails
 
 
@@ -471,9 +500,11 @@ def main() -> int:
         ("l", case_l_pileup),
         ("m", case_m_archive_excluded),
         ("m2", case_m2_completed_tasks_excluded),
+        ("m2b", case_m2b_retention_archived_tasks_excluded),
         ("m3", case_m3_completed_tasks_excluded_from_recovery),
         ("m3b", case_m3b_archived_results_excluded_from_recovery),
         ("m3c", case_m3c_gateway_archived_results_excluded_from_recovery),
+        ("m3d", case_m3d_retention_archived_results_excluded_from_recovery),
         ("m4", case_m4_task_scan_error_fails_open),
         ("n", case_n_notify_empty_no_call),
         ("o", case_o_dedup_within_cooldown),

--- a/tests/health-check-stuck-loop.test.py
+++ b/tests/health-check-stuck-loop.test.py
@@ -285,8 +285,13 @@ def case_m2_completed_tasks_excluded() -> list[str]:
 def case_m2b_retention_archived_tasks_excluded() -> list[str]:
     fails = []
     def setup(d):
-        archive = d.parent / "results" / "archive-2026-07-26"
+        results = d.parent / "results"
+        archive = results / "archive-2026-07-26"
         archive.mkdir(parents=True)
+        # Non-file *.txt entries and non-directory archive-* entries are
+        # ignored without affecting the completed-task set.
+        (archive / "ignored.txt").mkdir()
+        (results / "archive-not-a-directory").write_text("fixture")
         for i in range(8):
             task = write_task(d, f"task-{i}.txt", age_sec=600)
             (archive / task.name).write_text("complete")


### PR DESCRIPTION
## What changed

Make `health-check.py` treat result files under startup-retention directories (`results/archive-YYYY-MM-DD/`) as completed deliveries, matching `task-notifier.sh`.

The shared pending-task helper now recognizes both exact task filenames and remote-gateway timestamped filenames in canonical and retention archives. This fixes both the health warning and the automatic wedge-recovery input.

Review first:
- `src/health-check.py::_pending_task_files`
- retention archive cases in `tests/health-check-stuck-loop.test.py`

## Bug proved

The production workspace contains completed results under `results/archive-2026-07-26/`. The notifier skips them, but health-check counted their retained task files as pending.

Parent (`289996c0`):

```text
{'name': 'task-queue', 'status': 'warn', 'detail': '26 tasks queued, oldest 826065s — watcher or core may be stuck'}
```

HEAD (`217b199c`), same workspace:

```text
{'name': 'task-queue', 'status': 'ok', 'detail': '1 task(s), oldest 171s'}
```

## Tests

```text
$ python3 tests/health-check-stuck-loop.test.py
  ✓ case m2b
  ✓ case m3d
All stuck-loop / queue-pileup invariants hold.

$ python3 -m py_compile src/health-check.py
[exit 0]

$ git diff origin/main...HEAD | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths clean)
```

The new cases cover exact retained result names for queue health and timestamped retained result names for wedge recovery.

## Risk / deployment

- No migration, config, permission, or live-path restart is required.
- Worst-case disruption: a file in a directory named `archive-*` could suppress a same-named task from health/recovery. This is constrained to top-level `.txt` files under the existing results retention namespace, exactly matching notifier completion semantics.
- Rollback is a single commit revert.
- Stacked PR: N/A.
- Known gaps: N/A.
