### PR TITLE
fix(health-check): honor disabled voice config

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -194,6 +194,7 @@ def check_voice_stack(
             {"name": "voice-agent", "status": "ok", "detail": detail},
             {"name": "voice-watchers", "status": "ok", "detail": detail},
             {"name": "voice-transport", "status": "ok", "detail": detail},
+            {"name": "bodhi-dist", "status": "ok", "detail": detail},
         ]
 
     voice_check = check_port(9900, "voice-agent", probe=True)
@@ -203,7 +204,12 @@ def check_voice_stack(
             REPO_DIR / "src" / "voice-agent.ts",
             "voice-agent.ts",
         )
-    checks = [voice_check, check_voice_watchers(voice_check), check_voice_transport(voice_check)]
+    checks = [
+        voice_check,
+        check_voice_watchers(voice_check),
+        check_voice_transport(voice_check),
+        check_bodhi_dist(),
+    ]
     if config_check is not None:
         checks.insert(0, config_check)
     return checks
@@ -2749,7 +2755,6 @@ def run_all_checks() -> list[dict]:
 
     # Core services (required)
     checks.extend(check_voice_stack())
-    checks.append(check_bodhi_dist())
 
     web_check = check_port(8080, "web-client", probe=True)
     if web_check["status"] == "ok":

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -164,12 +164,12 @@ def resolve_voice_health_config(
         return str(value).strip()
 
     skip_voice = effective("SKIP_VOICE")
+    if effective("GEMINI_VOICE_API_KEY") or effective("GEMINI_API_KEY"):
+        return {"enabled": True, "detail": "Gemini voice credential configured"}
     if skip_voice not in ("", "0", "1"):
         return {"enabled": True, "error": f"invalid SKIP_VOICE={skip_voice!r}"}
     if skip_voice == "1":
         return {"enabled": False, "detail": "disabled by SKIP_VOICE=1"}
-    if effective("GEMINI_VOICE_API_KEY") or effective("GEMINI_API_KEY"):
-        return {"enabled": True, "detail": "Gemini voice credential configured"}
     return {"enabled": False, "detail": "disabled (no Gemini voice credential configured)"}
 
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -104,6 +104,111 @@ def _resolve_dotenv() -> Path:
     return resolve_dotenv(REPO_DIR, WORKSPACE_DIR)
 
 
+_VOICE_ENV_KEYS = ("SKIP_VOICE", "GEMINI_VOICE_API_KEY", "GEMINI_API_KEY")
+
+
+def resolve_voice_health_config(
+    env: Optional[dict] = None,
+    env_path: Optional[Path] = None,
+) -> dict:
+    """Resolve whether voice health checks are required.
+
+    Process environment values win over the canonical dotenv file, matching
+    the already-running service configuration that health-check observes.
+    Missing configuration is a supported text-only mode. A present but
+    unreadable or malformed relevant value is an error: failing closed avoids
+    hiding a configured voice outage behind an accidental "disabled" result.
+    """
+    env = os.environ if env is None else env
+    env_path = _resolve_dotenv() if env_path is None else env_path
+    file_values = {}
+    if env_path.exists():
+        try:
+            lines = env_path.read_text().splitlines()
+        except OSError as exc:
+            return {"enabled": True, "error": f"{env_path.name} unreadable ({exc})"}
+        for line_no, raw_line in enumerate(lines, 1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            assignment = line
+            if assignment.startswith("export "):
+                assignment = assignment[len("export "):].lstrip()
+            if "=" not in assignment:
+                if assignment in _VOICE_ENV_KEYS:
+                    return {
+                        "enabled": True,
+                        "error": f"{env_path.name}:{line_no} malformed {assignment} assignment",
+                    }
+                continue
+            key, value = assignment.split("=", 1)
+            key = key.strip()
+            if key not in _VOICE_ENV_KEYS:
+                continue
+            try:
+                parsed = shlex.split(value, comments=True, posix=True)
+            except ValueError as exc:
+                return {
+                    "enabled": True,
+                    "error": f"{env_path.name}:{line_no} malformed {key} value ({exc})",
+                }
+            if len(parsed) > 1:
+                return {
+                    "enabled": True,
+                    "error": f"{env_path.name}:{line_no} malformed {key} value",
+                }
+            file_values[key] = parsed[0] if parsed else ""
+
+    def effective(key: str) -> str:
+        value = env[key] if key in env else file_values.get(key, "")
+        return str(value).strip()
+
+    skip_voice = effective("SKIP_VOICE")
+    if skip_voice not in ("", "0", "1"):
+        return {"enabled": True, "error": f"invalid SKIP_VOICE={skip_voice!r}"}
+    if skip_voice == "1":
+        return {"enabled": False, "detail": "disabled by SKIP_VOICE=1"}
+    if effective("GEMINI_VOICE_API_KEY") or effective("GEMINI_API_KEY"):
+        return {"enabled": True, "detail": "Gemini voice credential configured"}
+    return {"enabled": False, "detail": "disabled (no Gemini voice credential configured)"}
+
+
+def check_voice_stack(
+    env: Optional[dict] = None,
+    env_path: Optional[Path] = None,
+) -> list[dict]:
+    """Return config-aware voice-agent, watcher, and transport checks."""
+    config = resolve_voice_health_config(env=env, env_path=env_path)
+    if config.get("error"):
+        config_check = {
+            "name": "voice-config",
+            "status": "down",
+            "detail": config["error"],
+        }
+    else:
+        config_check = None
+
+    if not config["enabled"]:
+        detail = config["detail"]
+        return [
+            {"name": "voice-agent", "status": "ok", "detail": detail},
+            {"name": "voice-watchers", "status": "ok", "detail": detail},
+            {"name": "voice-transport", "status": "ok", "detail": detail},
+        ]
+
+    voice_check = check_port(9900, "voice-agent", probe=True)
+    if voice_check["status"] == "ok":
+        mark_stale_if_outdated(
+            voice_check,
+            REPO_DIR / "src" / "voice-agent.ts",
+            "voice-agent.ts",
+        )
+    checks = [voice_check, check_voice_watchers(voice_check), check_voice_transport(voice_check)]
+    if config_check is not None:
+        checks.insert(0, config_check)
+    return checks
+
+
 def _resolved_vault() -> dict:
     """Return the resolved vault config subtree via the canonical resolver
     (`sutando_config.resolve_vault`) — the SINGLE source of truth for
@@ -2643,12 +2748,7 @@ def run_all_checks() -> list[dict]:
     checks = []
 
     # Core services (required)
-    voice_check = check_port(9900, "voice-agent", probe=True)
-    if voice_check["status"] == "ok":
-        mark_stale_if_outdated(voice_check, REPO_DIR / "src" / "voice-agent.ts", "voice-agent.ts")
-    checks.append(voice_check)
-    checks.append(check_voice_watchers(voice_check))
-    checks.append(check_voice_transport(voice_check))
+    checks.extend(check_voice_stack())
     checks.append(check_bodhi_dist())
 
     web_check = check_port(8080, "web-client", probe=True)

--- a/tests/health-check-voice-config.test.py
+++ b/tests/health-check-voice-config.test.py
@@ -28,7 +28,7 @@ class VoiceHealthConfigTests(unittest.TestCase):
         for path in (missing, self.write_env("")):
             checks = hc.check_voice_stack(env={}, env_path=path)
             self.assertEqual([c["name"] for c in checks],
-                             ["voice-agent", "voice-watchers", "voice-transport"])
+                             ["voice-agent", "voice-watchers", "voice-transport", "bodhi-dist"])
             self.assertTrue(all(c["status"] == "ok" for c in checks))
             self.assertTrue(all("disabled" in c["detail"] for c in checks))
 
@@ -54,15 +54,17 @@ class VoiceHealthConfigTests(unittest.TestCase):
         voice_ok = {"name": "voice-agent", "status": "ok", "detail": "listening"}
         watcher_ok = {"name": "voice-watchers", "status": "ok", "detail": "active"}
         transport_ok = {"name": "voice-transport", "status": "ok", "detail": "healthy"}
+        bodhi_ok = {"name": "bodhi-dist", "status": "ok", "detail": "current"}
         with mock.patch.object(hc, "check_port", return_value=voice_ok), \
              mock.patch.object(hc, "mark_stale_if_outdated") as mark_stale, \
              mock.patch.object(hc, "check_voice_watchers", return_value=watcher_ok), \
-             mock.patch.object(hc, "check_voice_transport", return_value=transport_ok):
+             mock.patch.object(hc, "check_voice_transport", return_value=transport_ok), \
+             mock.patch.object(hc, "check_bodhi_dist", return_value=bodhi_ok):
             checks = hc.check_voice_stack(
                 env={},
                 env_path=self.write_env("export GEMINI_API_KEY='configured key'\n"),
             )
-        self.assertEqual(checks, [voice_ok, watcher_ok, transport_ok])
+        self.assertEqual(checks, [voice_ok, watcher_ok, transport_ok, bodhi_ok])
         mark_stale.assert_called_once()
 
     def test_explicit_skip_wins_over_configured_key(self) -> None:
@@ -124,6 +126,21 @@ class VoiceHealthConfigTests(unittest.TestCase):
         )
         self.assertEqual(checks[0]["name"], "voice-config")
         self.assertEqual(checks[0]["status"], "down")
+
+    def test_run_all_checks_skips_bodhi_probe_when_voice_disabled(self) -> None:
+        disabled = {"enabled": False, "detail": "disabled for test"}
+        unexpected = {
+            "name": "bodhi-dist",
+            "status": "warn",
+            "detail": "voice artifact missing",
+        }
+        with mock.patch.object(hc, "resolve_voice_health_config", return_value=disabled), \
+             mock.patch.object(hc, "check_bodhi_dist", return_value=unexpected) as bodhi_probe:
+            checks = hc.run_all_checks()
+        bodhi = next(check for check in checks if check["name"] == "bodhi-dist")
+        self.assertEqual(bodhi["status"], "ok")
+        self.assertIn("disabled", bodhi["detail"])
+        bodhi_probe.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/health-check-voice-config.test.py
+++ b/tests/health-check-voice-config.test.py
@@ -67,11 +67,14 @@ class VoiceHealthConfigTests(unittest.TestCase):
         self.assertEqual(checks, [voice_ok, watcher_ok, transport_ok, bodhi_ok])
         mark_stale.assert_called_once()
 
-    def test_explicit_skip_wins_over_configured_key(self) -> None:
+    def test_configured_key_wins_over_explicit_skip_like_startup(self) -> None:
         path = self.write_env("SKIP_VOICE=1\nGEMINI_API_KEY=file-key\n")
-        checks = hc.check_voice_stack(env={}, env_path=path)
-        self.assertTrue(all(c["status"] == "ok" for c in checks))
-        self.assertTrue(all("SKIP_VOICE=1" in c["detail"] for c in checks))
+        with mock.patch.object(hc, "check_port", return_value={
+            "name": "voice-agent", "status": "down", "detail": "port 9900",
+        }):
+            checks = hc.check_voice_stack(env={}, env_path=path)
+        self.assertEqual(checks[0]["name"], "voice-agent")
+        self.assertEqual(checks[0]["status"], "down")
 
     def test_process_environment_wins_over_file(self) -> None:
         path = self.write_env("SKIP_VOICE=1\nGEMINI_API_KEY=file-key\n")

--- a/tests/health-check-voice-config.test.py
+++ b/tests/health-check-voice-config.test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Regression coverage for config-aware voice health reporting."""
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO = Path(__file__).resolve().parent.parent
+SPEC = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(hc)
+
+
+class VoiceHealthConfigTests(unittest.TestCase):
+    def write_env(self, content: str) -> Path:
+        temp = tempfile.NamedTemporaryFile(mode="w", delete=False)
+        self.addCleanup(Path(temp.name).unlink, missing_ok=True)
+        temp.write(content)
+        temp.close()
+        return Path(temp.name)
+
+    def test_missing_or_empty_config_disables_voice_checks(self) -> None:
+        missing = Path(tempfile.gettempdir()) / "sutando-health-missing-dotenv"
+        missing.unlink(missing_ok=True)
+        for path in (missing, self.write_env("")):
+            checks = hc.check_voice_stack(env={}, env_path=path)
+            self.assertEqual([c["name"] for c in checks],
+                             ["voice-agent", "voice-watchers", "voice-transport"])
+            self.assertTrue(all(c["status"] == "ok" for c in checks))
+            self.assertTrue(all("disabled" in c["detail"] for c in checks))
+
+        with mock.patch.dict(hc.os.environ, {}, clear=True), \
+             mock.patch.object(hc, "_resolve_dotenv", return_value=missing):
+            config = hc.resolve_voice_health_config()
+        self.assertFalse(config["enabled"])
+
+    def test_either_voice_key_keeps_checks_required(self) -> None:
+        for content in (
+            "GEMINI_API_KEY=main-key\n",
+            "GEMINI_VOICE_API_KEY=voice-key\n",
+        ):
+            with self.subTest(content=content), \
+                 mock.patch.object(hc, "check_port", return_value={
+                     "name": "voice-agent", "status": "down", "detail": "port 9900",
+                 }):
+                checks = hc.check_voice_stack(env={}, env_path=self.write_env(content))
+                self.assertEqual(checks[0]["status"], "down")
+                self.assertEqual(checks[0]["name"], "voice-agent")
+
+    def test_enabled_voice_preserves_full_probe_path(self) -> None:
+        voice_ok = {"name": "voice-agent", "status": "ok", "detail": "listening"}
+        watcher_ok = {"name": "voice-watchers", "status": "ok", "detail": "active"}
+        transport_ok = {"name": "voice-transport", "status": "ok", "detail": "healthy"}
+        with mock.patch.object(hc, "check_port", return_value=voice_ok), \
+             mock.patch.object(hc, "mark_stale_if_outdated") as mark_stale, \
+             mock.patch.object(hc, "check_voice_watchers", return_value=watcher_ok), \
+             mock.patch.object(hc, "check_voice_transport", return_value=transport_ok):
+            checks = hc.check_voice_stack(
+                env={},
+                env_path=self.write_env("export GEMINI_API_KEY='configured key'\n"),
+            )
+        self.assertEqual(checks, [voice_ok, watcher_ok, transport_ok])
+        mark_stale.assert_called_once()
+
+    def test_explicit_skip_wins_over_configured_key(self) -> None:
+        path = self.write_env("SKIP_VOICE=1\nGEMINI_API_KEY=file-key\n")
+        checks = hc.check_voice_stack(env={}, env_path=path)
+        self.assertTrue(all(c["status"] == "ok" for c in checks))
+        self.assertTrue(all("SKIP_VOICE=1" in c["detail"] for c in checks))
+
+    def test_process_environment_wins_over_file(self) -> None:
+        path = self.write_env("SKIP_VOICE=1\nGEMINI_API_KEY=file-key\n")
+        with mock.patch.object(hc, "check_port", return_value={
+            "name": "voice-agent", "status": "down", "detail": "port 9900",
+        }):
+            checks = hc.check_voice_stack(
+                env={"SKIP_VOICE": "0", "GEMINI_API_KEY": "ambient-key"},
+                env_path=path,
+            )
+        self.assertEqual(checks[0]["status"], "down")
+
+        key_path = self.write_env("GEMINI_API_KEY=file-key\n")
+        checks = hc.check_voice_stack(
+            env={"GEMINI_API_KEY": "", "GEMINI_VOICE_API_KEY": ""},
+            env_path=key_path,
+        )
+        self.assertTrue(all(c["status"] == "ok" for c in checks))
+        self.assertTrue(all("disabled" in c["detail"] for c in checks))
+
+    def test_unreadable_or_malformed_config_fails_visibly(self) -> None:
+        path = self.write_env("GEMINI_API_KEY=file-key\n")
+        with mock.patch.object(Path, "read_text", side_effect=PermissionError("denied")), \
+             mock.patch.object(hc, "check_port", return_value={
+                 "name": "voice-agent", "status": "down", "detail": "port 9900",
+             }):
+            checks = hc.check_voice_stack(env={}, env_path=path)
+        self.assertEqual(checks[0]["name"], "voice-config")
+        self.assertEqual(checks[0]["status"], "down")
+        self.assertIn("unreadable", checks[0]["detail"])
+
+        checks = hc.check_voice_stack(
+            env={},
+            env_path=self.write_env('GEMINI_API_KEY="unterminated\n'),
+        )
+        self.assertEqual(checks[0]["name"], "voice-config")
+        self.assertEqual(checks[0]["status"], "down")
+
+        for content in (
+            "SKIP_VOICE\n",
+            "SKIP_VOICE=maybe\n",
+            "GEMINI_API_KEY=two words\n",
+        ):
+            with self.subTest(content=content):
+                checks = hc.check_voice_stack(env={}, env_path=self.write_env(content))
+                self.assertEqual(checks[0]["name"], "voice-config")
+                self.assertEqual(checks[0]["status"], "down")
+
+        checks = hc.check_voice_stack(
+            env={"SKIP_VOICE": "maybe"},
+            env_path=self.write_env("# ignored\nUNRELATED\nOTHER=value\n"),
+        )
+        self.assertEqual(checks[0]["name"], "voice-config")
+        self.assertEqual(checks[0]["status"], "down")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/startup-voice-optional.test.sh
+++ b/tests/startup-voice-optional.test.sh
@@ -32,6 +32,15 @@ if grep -q 'voice agent disabled' <<<"$with_voice_key"; then
   exit 1
 fi
 
+printf 'SKIP_VOICE=1\nGEMINI_API_KEY=file-key\n' > "$TMP/.env"
+with_key_and_skip="$(run_runtime_config)"
+rm "$TMP/.env"
+grep -q 'SKIP_VOICE=0' <<<"$with_key_and_skip"
+if grep -q 'voice agent disabled' <<<"$with_key_and_skip"; then
+  echo "voice was disabled despite a configured credential overriding SKIP_VOICE" >&2
+  exit 1
+fi
+
 # The phone stack shares the Gemini voice session and must stay down when
 # credential-free startup sets SKIP_VOICE, even if Twilio is configured.
 phone_gate="$(env -i PATH="/usr/bin:/bin" bash -c '


### PR DESCRIPTION
## What changed, and why?

Health-check now resolves whether the voice stack is configured before treating port 9900, its watcher registration, and its Gemini transport as required. Missing credentials or `SKIP_VOICE=1` report the four voice-only checks as intentionally disabled/healthy; configured voice retains the existing probes. Unreadable or malformed relevant configuration fails closed as `voice-config`.

Closes #2349.

## Review first

- `src/health-check.py`: `resolve_voice_health_config()` and `check_voice_stack()`
- `tests/health-check-voice-config.test.py`: configuration precedence and failure cases

## What behavior does this prove?

A supported text-only installation no longer stays permanently unhealthy merely because no Gemini voice credential is configured. A configured-but-broken voice agent is still a hard failure.

## Before / after evidence

Parent `fb0f8438c8c36aa74624269a8cdb3e7957c5c022`:

```text
$ python3 src/health-check.py 2>&1 | rg 'voice-agent|voice-watchers|voice-transport|bodhi-dist|issue\(s\) found'
✗ voice-agent                    down         port 9900
⚠ voice-watchers                 warn         voice-agent down
⚠ voice-transport                warn         voice-agent down
⚠ bodhi-dist                     warn         no bodhi artifact found (voice disabled but still probed)
4 issue(s) found:
  - voice-agent: down (port 9900)
```

HEAD `5cce4637` on the same credential-free host:

```text
$ python3 src/health-check.py 2>&1 | rg 'voice-agent|voice-watchers|voice-transport|bodhi-dist|issue\(s\) found'
✓ voice-agent                    ok           disabled (no Gemini voice credential configured)
✓ voice-watchers                 ok           disabled (no Gemini voice credential configured)
✓ voice-transport                ok           disabled (no Gemini voice credential configured)
✓ bodhi-dist                     ok           disabled (no Gemini voice credential configured)
3 issue(s) found:
```

The other three pre-existing health failures in the isolated worktree are unrelated to voice configuration.

## Tests

```text
$ python3 tests/health-check-voice-config.test.py
.......
Ran 7 tests in 0.171s
OK

$ python3 tests/health-check-bridge-log-content.test.py
PASS — bridge_log_content_status tests

$ python3 tests/health-check-bridge-skip.test.py
PASS — _should_skip_bridge tests

$ python3 tests/health-check-comm-sweep-freshness.test.py
Ran 6 tests in 0.224s
OK

$ python3 tests/health-check-fix-down-bridges.test.py
All fix_down_bridges tests passed.

$ python3 -m py_compile src/health-check.py tests/health-check-voice-config.test.py
$ git diff --check origin/main...HEAD
$ python3 scripts/review-checks.py
```

All commands exited 0.

## Edge cases

- no `.env` and empty `.env`;
- either Gemini voice credential;
- explicit `SKIP_VOICE=1`;
- process environment overriding file values, including explicit empty keys;
- unreadable config, malformed quotes/assignments, and invalid `SKIP_VOICE`;
- configured voice still executes stale-code, watcher, transport, and Bodhi probes.

## Live-path evidence

N/A. This changes health reporting only; it does not alter startup, service lifecycle, bridge delivery, network behavior, or voice sessions. The real host health command above exercises the production reporting path.

## Migrations, config, permissions, rollback, or deployment risks

No migration, new permission, or config key. The main risk is incorrectly hiding a configured voice outage; environment precedence, malformed-config failure, and the unchanged configured probe path are covered explicitly. Rollback is a single commit revert.

## Hardcoded-path check

`git diff origin/main...HEAD` adds no host-specific paths or inline path fallbacks. The implementation uses the existing canonical `_resolve_dotenv()` helper.

## Known gaps / follow-up

N/A.