### PR TITLE
fix(ci): stop discarding the output of a failing Python test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,16 @@ jobs:
           failed=0
           while IFS= read -r f; do
             echo "→ $f"
-            output=$(python3 "$f" 2>&1)
-            rc=$?
+            # `if ! assignment=$(...)` exempts the command from `bash -e` (GitHub's
+            # default for run: steps) while still capturing output + status. A bare
+            # `output=$(python3 "$f")` aborts the whole step the instant a test
+            # fails — before the `echo "$output"` below ever runs — so the failing
+            # test's traceback is DISCARDED, every later test is skipped, and the
+            # log shows only the bare `→ <file>` line. The shell-test step below
+            # already uses this idiom for exactly this reason; this step was
+            # missed. (Observed on a real CI run: a failure printed no output at
+            # all, making it undiagnosable from the log.)
+            if ! output=$(python3 "$f" 2>&1); then rc=1; else rc=0; fi
             # Always show FAIL lines and summary
             echo "$output" | grep -E 'FAIL|^Results:' || true
             if [ $rc -ne 0 ]; then


### PR DESCRIPTION
## Why

The **Run Python standalone tests** step goes to the trouble of capturing each test's output so it can print the full traceback on failure:

```bash
output=$(python3 "$f" 2>&1)
rc=$?
echo "$output" | grep -E 'FAIL|^Results:' || true
if [ $rc -ne 0 ]; then
  echo "$output"      # <-- unreachable
  failed=1
fi
```

Under `bash -e` — GitHub's default shell for `run:` steps, visible as `shell: /usr/bin/bash -e {0}` in any job log — a bare `output=$(python3 "$f")` **exits the step the instant a test fails**, before `rc=$?` and before that `echo`.

Three silent consequences:
- the failing test's traceback is **discarded**;
- every later test file is **skipped**, so you only ever learn about the first failure;
- `exit "$failed"` is unreachable — the step exits via `set -e` instead.

The log of a real failure therefore contains nothing but the bare `→ <file>` line. That is not enough to diagnose it, which is how I found this: a red run on another PR gave me no output to work from.

## This exact trap is already documented in the same file

The sibling **Run shell standalone tests** step uses the correct idiom and its comment spells out the reason:

> `if ! assignment=$(...)` exempts the command from `bash -e` (GitHub's default for run: steps) while still capturing output + status. A bare `output=$(bash "$f")` would abort the whole step on the first failing suite — losing this step's diagnostics and masking every later suite.

That step was fixed; the Python step was missed. This PR applies the same idiom.

## Before / after

Reduced to the same loop, two files, first one failing, run under `bash -e`:

**Before**
```
→ tests/a.test.py
  exit=1
```
The error text is gone and `b.test.py` never ran.

**After**
```
→ tests/a.test.py
THE REAL ERROR
→ tests/b.test.py
THE REAL ERROR
  exit=1
```

Exit status is **1 in both cases** — this changes only what you can see, never whether CI fails.

## Scope

One line plus a comment. No test-selection, ordering, or pass/fail semantics change; success paths are byte-identical. `ci.yml` parses (`yaml.safe_load`).

Worth noting the failure mode is self-concealing: because it only triggers *when a test fails*, a green pipeline looks identical either way — which is presumably how it survived in the Python step after being fixed in the shell one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Etoj87Vi5gWCswkGUAiiuz