### PR TITLE
fix(startup): harden state/auth/ to 0700/0600 on boot — owner-secret perms, not incidental

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,13 +10,14 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-165 modules indexed.
+166 modules indexed.
 
 ## `src/`
 
 - **`agent-api.py`** — Sutando agent API — simple HTTP endpoint for agent-to-agent communication.
 - **`archive-stale-results.py`** — Archive stale `results/*.txt` files to `results/archive-YYYY-MM-DD/`.
 - **`artifact-cache-tools.ts`** — Active artifact cache — load a file once, answer repeated queries from in-process memory.
+- **`auth_hardening.sh`** — auth_hardening.sh — harden per-host install-state secrets under state/auth/.
 - **`browser-tools.ts`** — Browser & screen tools — Chrome tab control, scrolling, screenshots, and vision descriptions.
 - **`browser.mjs`** — Sutando browser automation — lightweight Playwright wrapper.
 - **`call-stats.py`** — Call statistics — summarize phone call activity over a time window.

--- a/src/auth_hardening.sh
+++ b/src/auth_hardening.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# auth_hardening.sh — harden per-host install-state secrets under state/auth/.
+#
+# Sourced by src/startup.sh so the logic can be unit-tested directly
+# (tests/auth-hardening.test.sh) instead of driving the whole boot sequence.
+#
+# state/auth/ holds cloud-auth.json / device.json / ag2space.json — per-host
+# auth + identity. Under the documented default workspace (<repo>/workspace/)
+# these inherit the checkout's 0755/0644, NOT the 0700 that ~/Library/Application
+# Support would give — so the owner-only protection has to be OURS, not an
+# incidental filesystem default (2026-07-28).
+
+# harden_auth_dir <workspace-dir>
+# Tighten <workspace>/state/auth to 0700 and its *.json files to 0600.
+# Idempotent + fail-safe: only ever tightens (never widens), a missing dir is a
+# no-op, and every error is swallowed so a perms quirk can't block boot.
+harden_auth_dir() {
+  local ws="$1"
+  [ -n "$ws" ] || return 0
+  local auth_dir="$ws/state/auth"
+  [ -d "$auth_dir" ] || return 0
+  chmod 700 "$auth_dir" 2>/dev/null || true
+  find "$auth_dir" -maxdepth 1 -type f -name '*.json' -exec chmod 600 {} + 2>/dev/null || true
+  return 0
+}

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -204,13 +204,17 @@ python3 "$REPO/skills/plugin-patches/apply-plugin-patches.py" || true
 source "$REPO/src/startup-runtime.sh"
 configure_startup_runtime
 
-# Harden per-host install-state secrets (state/auth/) on every boot. Factored to
+# Harden per-host install-state secrets (state/auth/). Factored to
 # src/auth_hardening.sh so the logic is unit-testable (tests/auth-hardening.test.sh)
 # without driving the whole boot. See that file for the why (workspace default is
 # not under ~/Library/Application Support, so 0700 must be ours, not incidental).
+# NOTE: the CALL is deliberately placed AFTER the migration block below, not here
+# — the migration is what CREATES state/auth/{cloud-auth,device}.json on a fresh
+# install (via `cp -p`, preserving loose source modes), so hardening it before the
+# files exist is a no-op (#2363 review, john-the-dev). Source the helper now; call
+# it once the migration has run.
 # shellcheck source=auth_hardening.sh
 source "$REPO/src/auth_hardening.sh"
-harden_auth_dir "$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null || true)"
 
 # v0.8 auto-migration helpers (PR #1440 safety hardening — Mini review).
 # Sourced from a sibling file so the four guard functions (_realpath,
@@ -318,6 +322,14 @@ if [ -n "${SUTANDO_WORKSPACE:-}" ]; then
   # the resolver's deprecation nag stops firing on every subprocess spawn.
   unset SUTANDO_WORKSPACE
 fi
+
+# Harden state/auth/ AFTER the migration above — the migration is the creator of
+# cloud-auth.json / device.json on a fresh install (cp -p preserves the loose
+# source modes), so the tightening must run once the files exist, not before
+# (#2363 review, john-the-dev: pre-migration it was a no-op on a fresh box).
+# Idempotent + fail-safe (only tightens, never blocks boot); the every-boot run
+# also catches auth material a prior boot wrote after this point.
+harden_auth_dir "$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null || true)"
 
 # Exercise the new config loader as a startup banner. Surfaces:
 #   • $SUTANDO_WORKSPACE legacy-escape-hatch warning (if env is set)

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -204,6 +204,14 @@ python3 "$REPO/skills/plugin-patches/apply-plugin-patches.py" || true
 source "$REPO/src/startup-runtime.sh"
 configure_startup_runtime
 
+# Harden per-host install-state secrets (state/auth/) on every boot. Factored to
+# src/auth_hardening.sh so the logic is unit-testable (tests/auth-hardening.test.sh)
+# without driving the whole boot. See that file for the why (workspace default is
+# not under ~/Library/Application Support, so 0700 must be ours, not incidental).
+# shellcheck source=auth_hardening.sh
+source "$REPO/src/auth_hardening.sh"
+harden_auth_dir "$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null || true)"
+
 # v0.8 auto-migration helpers (PR #1440 safety hardening — Mini review).
 # Sourced from a sibling file so the four guard functions (_realpath,
 # _same_inode, _is_unsafe_for_migration, _color_warn) can be unit-tested

--- a/tests/auth-hardening.test.sh
+++ b/tests/auth-hardening.test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Test for src/auth_hardening.sh::harden_auth_dir — the boot-time hardening of
+# per-host secrets under state/auth/. Calls the REAL sourced function (not a
+# re-implementation) so it tests what startup.sh actually runs.
+set -u
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=../src/auth_hardening.sh
+source "$REPO/src/auth_hardening.sh"
+
+fails=0
+check() { if [ "$2" = "$3" ]; then echo "  ok  $1"; else echo "  FAIL $1 — want $3 got $2"; fails=$((fails+1)); fi; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/state/auth"
+# Seed loose modes — the exact exposure found on 2026-07-28 (0755 dir, 0644 secrets).
+chmod 755 "$TMP/state/auth"
+printf '{}' > "$TMP/state/auth/cloud-auth.json";  chmod 644 "$TMP/state/auth/cloud-auth.json"
+printf '{}' > "$TMP/state/auth/device.json";      chmod 644 "$TMP/state/auth/device.json"
+
+harden_auth_dir "$TMP"
+
+check "state/auth dir tightened to 0700" "$(stat -f '%Lp' "$TMP/state/auth")" "700"
+check "cloud-auth.json tightened to 0600" "$(stat -f '%Lp' "$TMP/state/auth/cloud-auth.json")" "600"
+check "device.json tightened to 0600"     "$(stat -f '%Lp' "$TMP/state/auth/device.json")" "600"
+
+# Idempotent: a second run leaves them 0700/0600 (never widens).
+harden_auth_dir "$TMP"
+check "idempotent — dir stays 0700"  "$(stat -f '%Lp' "$TMP/state/auth")" "700"
+
+# Fail-safe: a missing workspace / missing auth dir is a clean no-op (rc 0).
+harden_auth_dir "$TMP/does-not-exist"; check "missing auth dir is a no-op (rc 0)" "$?" "0"
+harden_auth_dir ""; check "empty workspace arg is a no-op (rc 0)" "$?" "0"
+
+if [ "$fails" -eq 0 ]; then echo "PASS — auth-hardening"; else echo "FAIL — $fails"; exit 1; fi

--- a/tests/auth-hardening.test.sh
+++ b/tests/auth-hardening.test.sh
@@ -9,6 +9,10 @@ source "$REPO/src/auth_hardening.sh"
 
 fails=0
 check() { if [ "$2" = "$3" ]; then echo "  ok  $1"; else echo "  FAIL $1 — want $3 got $2"; fails=$((fails+1)); fi; }
+# Portable octal-mode reader: GNU/Linux `stat -c '%a'` (CI runs on ubuntu),
+# BSD/macOS `stat -f '%Lp'` as the fallback. `-f` on Linux means something else,
+# so the earlier macOS-only form failed the whole suite under CI (#2363).
+mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"; }
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -20,13 +24,13 @@ printf '{}' > "$TMP/state/auth/device.json";      chmod 644 "$TMP/state/auth/dev
 
 harden_auth_dir "$TMP"
 
-check "state/auth dir tightened to 0700" "$(stat -f '%Lp' "$TMP/state/auth")" "700"
-check "cloud-auth.json tightened to 0600" "$(stat -f '%Lp' "$TMP/state/auth/cloud-auth.json")" "600"
-check "device.json tightened to 0600"     "$(stat -f '%Lp' "$TMP/state/auth/device.json")" "600"
+check "state/auth dir tightened to 0700" "$(mode_of "$TMP/state/auth")" "700"
+check "cloud-auth.json tightened to 0600" "$(mode_of "$TMP/state/auth/cloud-auth.json")" "600"
+check "device.json tightened to 0600"     "$(mode_of "$TMP/state/auth/device.json")" "600"
 
 # Idempotent: a second run leaves them 0700/0600 (never widens).
 harden_auth_dir "$TMP"
-check "idempotent — dir stays 0700"  "$(stat -f '%Lp' "$TMP/state/auth")" "700"
+check "idempotent — dir stays 0700"  "$(mode_of "$TMP/state/auth")" "700"
 
 # Fail-safe: a missing workspace / missing auth dir is a clean no-op (rc 0).
 harden_auth_dir "$TMP/does-not-exist"; check "missing auth dir is a no-op (rc 0)" "$?" "0"


### PR DESCRIPTION
## What
`state/auth/` holds per-host install secrets — `cloud-auth.json`, `device.json`, `ag2space.json`. Under the documented default workspace (`<repo>/workspace/`) they inherit the checkout's **0755 dir / 0644 files**, NOT the 0700 that `~/Library/Application Support` would give. On this host they were verified **world-readable** (0755 dir, 0644 secrets). The owner-only protection was resting on an incidental filesystem default the default workspace layout doesn't provide (found by @qingyun-air.agent, 2026-07-28).

## Fix
`harden_auth_dir()` in a new `src/auth_hardening.sh`, sourced + called by `startup.sh` right after `configure_startup_runtime`: tightens `state/auth` to 0700 and its `*.json` to 0600 on every boot. **Idempotent, only-tightens** (never widens), **fail-safe** — a missing dir is a no-op and errors are swallowed so a perms quirk can't block boot. Factored into a sourceable helper specifically so the test calls the **real** function, not a re-implementation.

## Evidence
`tests/auth-hardening.test.sh` seeds the exact 0755/0644 exposure and asserts the tightening + idempotence + no-op safety:
```
  ok  state/auth dir tightened to 0700
  ok  cloud-auth.json tightened to 0600
  ok  device.json tightened to 0600
  ok  idempotent — dir stays 0700
  ok  missing auth dir is a no-op (rc 0)
  ok  empty workspace arg is a no-op (rc 0)
PASS — auth-hardening
```
Disable-the-repair: neutering the two `chmod`s fails the guards (`dir stays 755 / files stay 644`), so the test provably catches a regression.

Defense-in-depth; complements #2354's born-0700 sparrow tier-map backup by hardening the dir itself across all writers/hosts. Live exposure on this host already closed out-of-band; this makes it durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)