### PR TITLE
feat(scripts): reconstruct posthog-usage-report.py in-repo (durable home)

### DIFF
--- a/scripts/posthog-usage-report.py
+++ b/scripts/posthog-usage-report.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Daily Sutando usage report from PostHog project 504955 (headless).
+
+Reconstructed 2026-07-28: the original lived behind `workspace/scripts/`, which
+is a SYMLINK into the Sutando.app bundle — every app update wiped it. Code
+belongs in the repo (workspace contract), so this lives at `scripts/` and the
+`posthog-usage-daily` cron invokes it repo-relative.
+
+Reads the personal API key from the secret vault — tries POSTHOG_PERSONAL_APIKEY
+then POSTHOG_PERSONAL_API_KEY (both names appear in operational records).
+Prints a plaintext report, or a single line starting with `unavailable:` when
+the read path is down (the cron DMs that line verbatim).
+
+Metric definitions (verified against live event schema 2026-07-28; events are
+`core_started` / `task_processed` / `feature_used` — the older `morning_briefing`
+definition no longer exists in the stream):
+- installs (all-time) = distinct person_id over all events. person_id churns
+  across reinstalls/anonymous sessions, so absolute counts are UPPER BOUNDS;
+  trends are the signal (memory: reference_posthog_dau_inflated_id_churn).
+- DAU = per-day distinct persons, last 7 days; WAU = 7d distinct persons
+- new installs/day = persons whose first-ever event landed that day
+- returning 24h = persons active in the last day whose first event is older
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+PROJECT = "504955"
+API = f"https://us.posthog.com/api/projects/{PROJECT}/query/"
+
+
+def _repo_root() -> Path | None:
+    for p in Path(__file__).resolve().parents:
+        if (p / "src" / "vault_intercept.py").is_file():
+            return p
+    return None
+
+
+def _vault_key() -> str | None:
+    repo = _repo_root()
+    for name in ("POSTHOG_PERSONAL_APIKEY", "POSTHOG_PERSONAL_API_KEY"):
+        if repo is not None:
+            try:
+                out = subprocess.run(
+                    [sys.executable, str(repo / "skills/secret-vault/secret-vault.py"), "get", name],
+                    capture_output=True, text=True, timeout=15)
+                if out.returncode == 0 and out.stdout.strip():
+                    return out.stdout.strip()
+            except Exception:
+                pass
+    return None
+
+
+def _q(key: str, query: str):
+    req = urllib.request.Request(
+        API,
+        data=json.dumps({"query": {"kind": "HogQLQuery", "query": query}}).encode(),
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"})
+    return json.load(urllib.request.urlopen(req, timeout=45))["results"]
+
+
+def main() -> int:
+    key = _vault_key()
+    if not key:
+        print("unavailable: no POSTHOG_PERSONAL_APIKEY in vault")
+        return 1
+    try:
+        installs = _q(key, "select count(distinct person_id) from events")[0][0]
+        wau = _q(key, "select count(distinct person_id) from events where timestamp > now() - interval 7 day")[0][0]
+        dau_rows = _q(key, (
+            "select toDate(timestamp) d, count(distinct person_id) from events "
+            "where timestamp > now() - interval 7 day group by d order by d"))
+        new_rows = _q(key, (
+            "select first_day, count() from ("
+            "select person_id, toDate(min(timestamp)) first_day from events group by person_id) "
+            "where first_day > today() - interval 7 day group by first_day order by first_day"))
+        returning = _q(key, (
+            "select count() from ("
+            "select person_id, min(timestamp) first_ts, max(timestamp) last_ts from events group by person_id) "
+            "where last_ts > now() - interval 1 day and first_ts < now() - interval 1 day"))[0][0]
+        breakdown = _q(key, (
+            "select event, count(), count(distinct person_id) from events "
+            "where timestamp > now() - interval 7 day group by event order by count() desc limit 10"))
+    except urllib.error.HTTPError as e:
+        print(f"unavailable: PostHog API {e.code} — {e.read().decode()[:120]}")
+        return 1
+    except Exception as e:  # noqa: BLE001 — network/timeout paths all end in the same line
+        print(f"unavailable: {e}")
+        return 1
+
+    print("Sutando usage (PostHog 504955, headless)")
+    print(f"- installs all-time (distinct persons; churn-inflated upper bound): {installs}")
+    print(f"- WAU (7d distinct persons): {wau}")
+    print(f"- returning in last 24h (seen before): {returning}")
+    print("- DAU last 7 days:")
+    for d, n in dau_rows:
+        print(f"    {d}: {n}")
+    print("- new installs/day (first-ever event):")
+    for d, n in new_rows:
+        print(f"    {d}: {n}")
+    print("- event breakdown 7d (event / count / persons):")
+    for ev, n, p in breakdown:
+        print(f"    {ev:32s} {n:<8} {p}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/posthog-usage-report.test.py
+++ b/tests/posthog-usage-report.test.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Unit tests for the headless PostHog usage reporter.
+
+All vault and network access is mocked. These tests deliberately exercise the
+operator-visible unavailable messages and report shape without reading a real
+credential or querying PostHog.
+"""
+import importlib.util
+import io
+import subprocess
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest.mock import call, patch
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "posthog-usage-report.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("posthog_usage_report", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _completed(stdout="", returncode=0):
+    return subprocess.CompletedProcess(
+        args=["secret-vault.py"], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+class TestVaultLookup(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+
+    def test_repo_root_finds_checkout(self):
+        self.assertEqual(self.mod._repo_root(), REPO)
+
+    def test_no_repo_or_vault_key_returns_none(self):
+        with patch.object(self.mod, "_repo_root", return_value=None), \
+             patch.object(self.mod.subprocess, "run") as run:
+            self.assertIsNone(self.mod._vault_key())
+        run.assert_not_called()
+
+    def test_primary_vault_key_wins(self):
+        with patch.object(self.mod, "_repo_root", return_value=REPO), \
+             patch.object(
+                 self.mod.subprocess, "run", return_value=_completed("primary\n")
+             ) as run:
+            self.assertEqual(self.mod._vault_key(), "primary")
+        self.assertIn("POSTHOG_PERSONAL_APIKEY", run.call_args.args[0])
+        self.assertEqual(run.call_count, 1)
+
+    def test_falls_back_to_alternate_vault_key_after_failure(self):
+        with patch.object(self.mod, "_repo_root", return_value=REPO), \
+             patch.object(
+                 self.mod.subprocess,
+                 "run",
+                 side_effect=[OSError("vault unavailable"), _completed("fallback\n")],
+             ) as run:
+            self.assertEqual(self.mod._vault_key(), "fallback")
+        self.assertEqual(run.call_count, 2)
+        self.assertIn("POSTHOG_PERSONAL_API_KEY", run.call_args.args[0])
+
+    def test_nonzero_and_empty_vault_results_are_ignored(self):
+        with patch.object(self.mod, "_repo_root", return_value=REPO), \
+             patch.object(
+                 self.mod.subprocess,
+                 "run",
+                 side_effect=[_completed(returncode=1), _completed("  ")],
+             ):
+            self.assertIsNone(self.mod._vault_key())
+
+
+class TestQuery(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+
+    def test_query_builds_authenticated_hogql_request(self):
+        response = io.BytesIO(b'{"results":[["ok"]]}')
+        with patch.object(
+            self.mod.urllib.request, "urlopen", return_value=response
+        ) as urlopen:
+            self.assertEqual(self.mod._q("secret", "select 1"), [["ok"]])
+
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.full_url, self.mod.API)
+        self.assertEqual(request.headers["Authorization"], "Bearer secret")
+        self.assertEqual(urlopen.call_args.kwargs["timeout"], 45)
+        self.assertIn(b'"query": "select 1"', request.data)
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self.mod = _load()
+
+    def test_missing_key_is_unavailable(self):
+        with patch.object(self.mod, "_vault_key", return_value=None), \
+             patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            self.assertEqual(self.mod.main(), 1)
+        self.assertEqual(
+            stdout.getvalue(),
+            "unavailable: no POSTHOG_PERSONAL_APIKEY in vault\n",
+        )
+
+    def test_http_error_is_unavailable(self):
+        error = urllib.error.HTTPError(
+            self.mod.API,
+            403,
+            "Forbidden",
+            {},
+            io.BytesIO(b"denied by PostHog"),
+        )
+        with patch.object(self.mod, "_vault_key", return_value="secret"), \
+             patch.object(self.mod, "_q", side_effect=error), \
+             patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            self.assertEqual(self.mod.main(), 1)
+        self.assertEqual(
+            stdout.getvalue(),
+            "unavailable: PostHog API 403 — denied by PostHog\n",
+        )
+
+    def test_generic_error_is_unavailable(self):
+        with patch.object(self.mod, "_vault_key", return_value="secret"), \
+             patch.object(self.mod, "_q", side_effect=TimeoutError("timed out")), \
+             patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            self.assertEqual(self.mod.main(), 1)
+        self.assertEqual(stdout.getvalue(), "unavailable: timed out\n")
+
+    def test_happy_path_formats_complete_report(self):
+        query_results = [
+            [[42]],
+            [[7]],
+            [["2026-07-27", 3], ["2026-07-28", 4]],
+            [["2026-07-27", 1]],
+            [[5]],
+            [["task_processed", 12, 4], ["core_started", 7, 3]],
+        ]
+        with patch.object(self.mod, "_vault_key", return_value="secret"), \
+             patch.object(self.mod, "_q", side_effect=query_results) as query, \
+             patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            self.assertEqual(self.mod.main(), 0)
+
+        self.assertEqual(query.call_count, 6)
+        self.assertEqual(query.call_args_list[0], call("secret", unittest.mock.ANY))
+        output = stdout.getvalue()
+        self.assertIn("Sutando usage (PostHog 504955, headless)", output)
+        self.assertIn("churn-inflated upper bound): 42", output)
+        self.assertIn("- WAU (7d distinct persons): 7", output)
+        self.assertIn("- returning in last 24h (seen before): 5", output)
+        self.assertIn("2026-07-28: 4", output)
+        self.assertIn("task_processed", output)
+        self.assertIn("core_started", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
Reconstructs the missing `posthog-usage-report.py` in the repo's `scripts/` (durable) instead of `workspace/scripts/`.

## Why
`workspace/scripts` is a **symlink into the Sutando.app bundle** — every app update wiped the script, which is why the `posthog-usage-daily` cron kept reporting it missing (confirmed on this host: symlink dated Jul 27 21:11 → EPERM on write, target read-only). Code belongs in the repo per the workspace contract.

## Evidence
Before (parent): `scripts/posthog-usage-report.py` absent from the tree; cron fails with 'No such file'. After (HEAD): ran live 2026-07-28 against project 504955 with the re-scoped vault key — full report produced (installs 5861, WAU 1394, per-day DAU/new-install tables, event breakdown); `unavailable:` single-line contract verified earlier the same day against the under-scoped key (403 path). Metric definitions verified against the live event schema; churn caveat documented inline.

Host cron config updated separately (per-host crons.json prompt now calls the repo-relative path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)