### PR TITLE
fix(hooks): install hooks pointing at THIS clone, not ~/Desktop/sutando

### DIFF
--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -126,36 +126,60 @@ ADDED=0
 SKIPPED=0
 REMOVED=0
 
-# Phase 0: remove STALE VARIANTS of hooks we own — any command carrying our
-# marker for this event that is not byte-identical to the command we are about
-# to install. This is what makes a re-run a real migration rather than an
-# add-only pass:
+# Escape a literal string so it can be embedded in a jq (Oniguruma) regex.
+re_escape() { printf '%s' "$1" | sed 's/[][\\^$.*+?(){}|]/\\&/g'; }
+
+# Phase 0: remove STALE VARIANTS of hooks we own. This is what makes a re-run a
+# real migration rather than an add-only pass:
 #   * legacy "$HOME/Desktop/sutando/src/session-handoff.sh" entries;
 #   * the UNQUOTED form written by earlier revisions of this very script, which
 #     an exact-string comparison in phase 1 can never match (so both the broken
 #     and the fixed hook would fire);
 #   * an entry left behind by a different clone of this repo.
 # It runs BEFORE phase 1 so the freshly-added current command is never swept.
-# Scoped by marker, so a hook the operator added by hand is untouched.
+#
+# OWNERSHIP TEST — the load-bearing part. "Carries our marker" is NOT ownership:
+# an operator hook that invokes the same script (say, with an extra flag) also
+# contains it, and an earlier revision of this sweep deleted exactly those. We
+# therefore sweep only commands matching the SHAPE THIS INSTALLER WRITES: the
+# current command with the repo path replaced by a wildcard, anchored at both
+# ends, compared with quotes normalized away so the quoted and unquoted forms
+# both match. A customized command has extra text and fails the trailing anchor,
+# so it survives. Sweeping a *different clone's* entry is intended — that shape
+# is installer-generated, just not by this checkout.
 for entry in "${HOOKS[@]}"; do
   EVENT="${entry%%|*}"
   REST="${entry#*|}"
   MARKER="${REST%%|*}"
   CMD="${REST#*|}"
 
-  if ! jq -e --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" \
+  # Quotes are stripped for MATCHING ONLY; nothing is ever rewritten from this.
+  CMD_NQ="$(printf '%s' "$CMD" | tr -d "\"'")"
+  if [ "${CMD_NQ#*"$REPO_DIR"}" != "$CMD_NQ" ]; then
+    SHAPE="^$(re_escape "${CMD_NQ%%"$REPO_DIR"*}").*$(re_escape "${CMD_NQ#*"$REPO_DIR"}")\$"
+  else
+    # No repo path in this command (e.g. the $HOME transcript archive) — the
+    # only variant we own is a pure quoting difference.
+    SHAPE="^$(re_escape "$CMD_NQ")\$"
+  fi
+
+  if ! jq -e --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" --arg shape "$SHAPE" \
       '(.hooks // {})[$event] // [] | map(.hooks // []) | flatten | map(.command // "")
-       | map(contains($marker) and (. != $cmd)) | any' \
+       | map(contains($marker) and (. != $cmd) and ((gsub("[\"'"'"']"; "")) | test($shape)))
+       | any' \
       "$SETTINGS" >/dev/null 2>&1; then
     continue
   fi
 
   TMP="$(mktemp "${SETTINGS}.XXXXXX")"
-  jq --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" '
+  jq --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" --arg shape "$SHAPE" '
     if (.hooks // {})[$event] then
       .hooks[$event] |= map(
         .hooks |= map(select(
-          ((.command // "") | contains($marker)) and ((.command // "") != $cmd) | not
+          ((.command // "") | contains($marker))
+          and ((.command // "") != $cmd)
+          and (((.command // "") | gsub("[\"'"'"']"; "")) | test($shape))
+          | not
         ))
       )
       | .hooks[$event] |= map(select((.hooks // []) | length > 0))

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -139,14 +139,26 @@ re_escape() { printf '%s' "$1" | sed 's/[][\\^$.*+?(){}|]/\\&/g'; }
 # It runs BEFORE phase 1 so the freshly-added current command is never swept.
 #
 # OWNERSHIP TEST — the load-bearing part. "Carries our marker" is NOT ownership:
-# an operator hook that invokes the same script (say, with an extra flag) also
-# contains it, and an earlier revision of this sweep deleted exactly those. We
-# therefore sweep only commands matching the SHAPE THIS INSTALLER WRITES: the
-# current command with the repo path replaced by a wildcard, anchored at both
-# ends, compared with quotes normalized away so the quoted and unquoted forms
-# both match. A customized command has extra text and fails the trailing anchor,
-# so it survives. Sweeping a *different clone's* entry is intended — that shape
-# is installer-generated, just not by this checkout.
+# an operator hook that invokes the same script also contains it, and an earlier
+# revision of this sweep deleted exactly those. We sweep only commands matching
+# the SHAPE THIS INSTALLER WRITES, which is three conditions, each added after a
+# real false positive:
+#
+#   1. the hook must EMBED THE REPO PATH at all — otherwise nothing about it can
+#      go stale, so there is nothing to migrate (see the skip below);
+#   2. the region between the command word and the marker must START LIKE A PATH
+#      — optional quote, then a non-space, non-`-` character — so a flag or
+#      wrapper before the path (`bash -x …`) is not swallowed by the wildcard;
+#   3. the text after the marker must match EXACTLY, so customization after the
+#      path fails the trailing anchor.
+#
+# Matching is done on the RAW command. An earlier revision normalized by
+# stripping quote characters; that was lossy — `shq` rewrites `'` as `'\''`, so
+# stripping leaves a stray backslash and the shape stops matching its own output
+# on a path containing an apostrophe. Nothing here pre-processes the candidate.
+#
+# Sweeping a *different clone's* entry is intended — that shape is
+# installer-generated, just not by this checkout.
 for entry in "${HOOKS[@]}"; do
   EVENT="${entry%%|*}"
   REST="${entry#*|}"

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -57,11 +57,20 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SETTINGS="$REPO_DIR/.claude/settings.json"
 
 # Hook specs: each line is "<event>|<command>".  Order = install order.
+# $REPO_DIR is expanded HERE, at install time, so the command written into
+# settings.json carries this clone's absolute path. It used to hardcode
+# $HOME/Desktop/sutando — escaped, so it landed in settings.json literally and
+# was expanded at HOOK-RUN time, resolving to that one path on every host. This
+# clone is at "Library/Application Support/space.ag2.app/engine/sutando" and a
+# sibling is at "Documents/github/sutando"; neither is ~/Desktop, so every hook
+# installed by this script would point at a directory that does not exist and
+# fail silently on each fire. REPO_DIR was already derived correctly on the line
+# above and simply was not used.
 HOOKS=(
   "PreCompact|cp \"\$TRANSCRIPT_PATH\" \"\$HOME/Desktop/sutando-conversations/\$(date +%Y-%m-%dT%H-%M-%S).jsonl\""
-  "PreCompact|bash \$HOME/Desktop/sutando/src/session-handoff.sh \"\$TRANSCRIPT_PATH\""
-  "SessionEnd|bash \$HOME/Desktop/sutando/src/session-handoff.sh \"\$TRANSCRIPT_PATH\""
-  "Stop|bash \$HOME/Desktop/sutando/src/check-pending-tasks.sh"
+  "PreCompact|bash $REPO_DIR/src/session-handoff.sh \"\$TRANSCRIPT_PATH\""
+  "SessionEnd|bash $REPO_DIR/src/session-handoff.sh \"\$TRANSCRIPT_PATH\""
+  "Stop|bash $REPO_DIR/src/check-pending-tasks.sh"
 )
 
 # Deprecated hooks to uninstall on re-run.  Each line: "<event>|<substring>".

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -66,11 +66,38 @@ SETTINGS="$REPO_DIR/.claude/settings.json"
 # installed by this script would point at a directory that does not exist and
 # fail silently on each fire. REPO_DIR was already derived correctly on the line
 # above and simply was not used.
+
+# Single-quote a string for safe embedding in a stored shell command.
+# REPO_DIR is expanded at install time, so its literal text lands in
+# settings.json and is re-parsed by a shell at hook-run time. Unquoted, a clone
+# under "Library/Application Support/..." is split on the space and the hook
+# dies with `bash: /Users/you/Library: No such file or directory` — the exact
+# path this fix targets. Single quotes (with '\'' escaping) are metacharacter-
+# proof, unlike double quotes which would still interpolate $ and `.
+shq() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+# Hook specs: each line is "<event>|<marker>|<command>".  Order = install order.
+#
+# <marker> is a stable substring identifying a hook THIS script owns, used by
+# the stale-variant sweep below. It must not match a sibling hook: note
+# "src/session-handoff.sh" cannot match the archive hook's
+# "sutando-conversations/", so migrating one never disturbs the other.
+#
+# $REPO_DIR is expanded HERE, at install time, so the command written into
+# settings.json carries this clone's absolute path — quoted via shq(). It used
+# to hardcode $HOME/Desktop/sutando escaped, so it landed in settings.json
+# literally and was expanded at HOOK-RUN time, resolving to that one path on
+# every host. This clone is at "Library/Application Support/space.ag2.app/
+# engine/sutando" and a sibling is at "Documents/github/sutando"; neither is
+# ~/Desktop, so every hook installed by the old script pointed at a directory
+# that does not exist and failed silently on each fire.
 HOOKS=(
-  "PreCompact|cp \"\$TRANSCRIPT_PATH\" \"\$HOME/Desktop/sutando-conversations/\$(date +%Y-%m-%dT%H-%M-%S).jsonl\""
-  "PreCompact|bash $REPO_DIR/src/session-handoff.sh \"\$TRANSCRIPT_PATH\""
-  "SessionEnd|bash $REPO_DIR/src/session-handoff.sh \"\$TRANSCRIPT_PATH\""
-  "Stop|bash $REPO_DIR/src/check-pending-tasks.sh"
+  "PreCompact|sutando-conversations/|cp \"\$TRANSCRIPT_PATH\" \"\$HOME/Desktop/sutando-conversations/\$(date +%Y-%m-%dT%H-%M-%S).jsonl\""
+  "PreCompact|src/session-handoff.sh|bash $(shq "$REPO_DIR/src/session-handoff.sh") \"\$TRANSCRIPT_PATH\""
+  "SessionEnd|src/session-handoff.sh|bash $(shq "$REPO_DIR/src/session-handoff.sh") \"\$TRANSCRIPT_PATH\""
+  "Stop|src/check-pending-tasks.sh|bash $(shq "$REPO_DIR/src/check-pending-tasks.sh")"
 )
 
 # Deprecated hooks to uninstall on re-run.  Each line: "<event>|<substring>".
@@ -99,10 +126,50 @@ ADDED=0
 SKIPPED=0
 REMOVED=0
 
+# Phase 0: remove STALE VARIANTS of hooks we own — any command carrying our
+# marker for this event that is not byte-identical to the command we are about
+# to install. This is what makes a re-run a real migration rather than an
+# add-only pass:
+#   * legacy "$HOME/Desktop/sutando/src/session-handoff.sh" entries;
+#   * the UNQUOTED form written by earlier revisions of this very script, which
+#     an exact-string comparison in phase 1 can never match (so both the broken
+#     and the fixed hook would fire);
+#   * an entry left behind by a different clone of this repo.
+# It runs BEFORE phase 1 so the freshly-added current command is never swept.
+# Scoped by marker, so a hook the operator added by hand is untouched.
+for entry in "${HOOKS[@]}"; do
+  EVENT="${entry%%|*}"
+  REST="${entry#*|}"
+  MARKER="${REST%%|*}"
+  CMD="${REST#*|}"
+
+  if ! jq -e --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" \
+      '(.hooks // {})[$event] // [] | map(.hooks // []) | flatten | map(.command // "")
+       | map(contains($marker) and (. != $cmd)) | any' \
+      "$SETTINGS" >/dev/null 2>&1; then
+    continue
+  fi
+
+  TMP="$(mktemp "${SETTINGS}.XXXXXX")"
+  jq --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" '
+    if (.hooks // {})[$event] then
+      .hooks[$event] |= map(
+        .hooks |= map(select(
+          ((.command // "") | contains($marker)) and ((.command // "") != $cmd) | not
+        ))
+      )
+      | .hooks[$event] |= map(select((.hooks // []) | length > 0))
+    else . end
+  ' "$SETTINGS" > "$TMP" || { echo "error: jq stale-variant sweep failed on $EVENT" >&2; rm -f "$TMP"; exit 1; }
+  mv "$TMP" "$SETTINGS"
+  REMOVED=$((REMOVED + 1))
+done
+
 # Phase 1: install missing current hooks.
 for entry in "${HOOKS[@]}"; do
   EVENT="${entry%%|*}"
-  CMD="${entry#*|}"
+  REST="${entry#*|}"
+  CMD="${REST#*|}"
 
   # Detect existing entry by command-string match within this event's hooks list.
   if jq -e --arg event "$EVENT" --arg cmd "$CMD" \

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -153,6 +153,37 @@ for entry in "${HOOKS[@]}"; do
   MARKER="${REST%%|*}"
   CMD="${REST#*|}"
 
+  # PHASE 0 ONLY APPLIES TO HOOKS THAT EMBED THE REPO PATH.
+  #
+  # The whole point of the sweep is migrating entries whose *path* is stale — a
+  # legacy $HOME/Desktop clone, an unquoted form, another checkout. A hook with no
+  # repo path in it has nothing that can go stale, so there is nothing to migrate
+  # and sweeping can only ever destroy someone else's command.
+  #
+  # The transcript-archive hook is exactly that case: its marker is only
+  # `sutando-conversations/` and its command is all $HOME. With a wildcard shape,
+  # the `.*` spans the SOURCE ARGUMENT rather than a path, so an operator's
+  #     cp "$CUSTOM_TRANSCRIPT_PATH" "$HOME/Desktop/sutando-conversations/…"
+  # differed from ours only inside the wildcard and was deleted and replaced on
+  # re-run — silently discarding their archival policy. Reproduced on b21d2bf.
+  #
+  # An earlier revision of this file handled this with an explicit "no repo path
+  # → exact match" branch. Rewriting the shape structurally dropped that branch
+  # and applied the wildcard uniformly; this restores the case as a skip, which
+  # states the intent instead of encoding it as an unreachable pattern.
+  # Compare against the ESCAPED body, not the raw path. `shq` wraps in single
+  # quotes and rewrites an internal `'` as `'\''`, so on a checkout at
+  # /repo'quote the command embeds `/repo'\''quote` and a raw `$REPO_DIR` test
+  # never matches — the guard would then skip the sweep for the very hooks it
+  # must run on. That is the same raw-vs-escaped confusion that produced the
+  # apostrophe bug this file already fixed once; it is a property of shq, so
+  # every comparison against an embedded path has to go through it.
+  ESC="$(shq "$REPO_DIR")"; ESC="${ESC#\'}"; ESC="${ESC%\'}"
+  case "$CMD" in
+    *"$ESC"*) ;;
+    *) continue ;;
+  esac
+
   # Build the shape from the command's STRUCTURE, never by stripping quotes.
   #
   # Quote-stripping was lossy and wrong: `shq` escapes an apostrophe in the repo

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -163,14 +163,25 @@ for entry in "${HOOKS[@]}"; do
   # apostrophe is legal in a path, so this is a real checkout, not a curiosity.
   #
   # Instead: anchor on the command word, the marker (already the stable
-  # structural token), and the literal tail that follows the marker. The path
-  # region is a wildcard and the closing quote is optional, so the quoted and
-  # unquoted forms both match while a customized command — extra flags, extra
-  # words — fails the trailing anchor and survives.
+  # structural token), and the literal tail that follows the marker.
+  #
+  # The region between the command word and the marker is THE PATH AND NOTHING
+  # ELSE. A bare `.*` there was too permissive in one direction: customization
+  # *after* the path fails the trailing anchor and survives, but customization
+  # *before* it — `bash -x <path>/src/session-handoff.sh "$TRANSCRIPT_PATH"` —
+  # was swallowed by the wildcard and swept as installer-owned. Reproduced:
+  # before rerun 2, after rerun 1, operator's `-x` hook gone.
+  #
+  # So the path region must START like a path: an optional opening quote, then a
+  # character that is neither a space nor `-`. That admits every form we write or
+  # have written — `/abs/...`, `'/quoted path/...'`, `'/repo'\''quote/...'`, and
+  # the legacy `$HOME/Desktop/...` — while a flag or wrapper token before the
+  # path fails immediately. Requiring a literal `/` would have been wrong: it
+  # rejects the legacy `$HOME/...` entries this sweep exists to migrate.
   CMD_WORD="${CMD%% *}"
   CMD_TAIL="${CMD#*"$MARKER"}"
   CMD_TAIL="${CMD_TAIL#[\"\']}"       # drop shq's closing quote, if present
-  SHAPE="^$(re_escape "$CMD_WORD") .*$(re_escape "$MARKER")[\"']?$(re_escape "$CMD_TAIL")\$"
+  SHAPE="^$(re_escape "$CMD_WORD") [\"']?[^ -].*$(re_escape "$MARKER")[\"']?$(re_escape "$CMD_TAIL")\$"
 
   if ! jq -e --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" --arg shape "$SHAPE" \
       '(.hooks // {})[$event] // [] | map(.hooks // []) | flatten | map(.command // "")

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -153,19 +153,28 @@ for entry in "${HOOKS[@]}"; do
   MARKER="${REST%%|*}"
   CMD="${REST#*|}"
 
-  # Quotes are stripped for MATCHING ONLY; nothing is ever rewritten from this.
-  CMD_NQ="$(printf '%s' "$CMD" | tr -d "\"'")"
-  if [ "${CMD_NQ#*"$REPO_DIR"}" != "$CMD_NQ" ]; then
-    SHAPE="^$(re_escape "${CMD_NQ%%"$REPO_DIR"*}").*$(re_escape "${CMD_NQ#*"$REPO_DIR"}")\$"
-  else
-    # No repo path in this command (e.g. the $HOME transcript archive) — the
-    # only variant we own is a pure quoting difference.
-    SHAPE="^$(re_escape "$CMD_NQ")\$"
-  fi
+  # Build the shape from the command's STRUCTURE, never by stripping quotes.
+  #
+  # Quote-stripping was lossy and wrong: `shq` escapes an apostrophe in the repo
+  # path as `'\''`, so deleting quote characters leaves a stray backslash. On a
+  # checkout at `/repo'quote` the stripped command and the stripped repo path
+  # then disagree, the split finds nothing, SHAPE collapses to an exact match,
+  # and the stale unquoted entry is never swept — both hooks keep firing. An
+  # apostrophe is legal in a path, so this is a real checkout, not a curiosity.
+  #
+  # Instead: anchor on the command word, the marker (already the stable
+  # structural token), and the literal tail that follows the marker. The path
+  # region is a wildcard and the closing quote is optional, so the quoted and
+  # unquoted forms both match while a customized command — extra flags, extra
+  # words — fails the trailing anchor and survives.
+  CMD_WORD="${CMD%% *}"
+  CMD_TAIL="${CMD#*"$MARKER"}"
+  CMD_TAIL="${CMD_TAIL#[\"\']}"       # drop shq's closing quote, if present
+  SHAPE="^$(re_escape "$CMD_WORD") .*$(re_escape "$MARKER")[\"']?$(re_escape "$CMD_TAIL")\$"
 
   if ! jq -e --arg event "$EVENT" --arg marker "$MARKER" --arg cmd "$CMD" --arg shape "$SHAPE" \
       '(.hooks // {})[$event] // [] | map(.hooks // []) | flatten | map(.command // "")
-       | map(contains($marker) and (. != $cmd) and ((gsub("[\"'"'"']"; "")) | test($shape)))
+       | map(contains($marker) and (. != $cmd) and test($shape))
        | any' \
       "$SETTINGS" >/dev/null 2>&1; then
     continue
@@ -178,7 +187,7 @@ for entry in "${HOOKS[@]}"; do
         .hooks |= map(select(
           ((.command // "") | contains($marker))
           and ((.command // "") != $cmd)
-          and (((.command // "") | gsub("[\"'"'"']"; "")) | test($shape))
+          and ((.command // "") | test($shape))
           | not
         ))
       )

--- a/tests/github-webhook-access-tier.test.py
+++ b/tests/github-webhook-access-tier.test.py
@@ -21,6 +21,30 @@ Exit: 0 on pass, 1 on fail.
 
 from __future__ import annotations
 
+import os
+
+# This suite drives real task-accept handlers but does not test telemetry. Keep it
+# hermetic: since #2274 the task-accepting paths emit `task_processed`, and
+# `src/github-webhook.py:_emit_github_telemetry()` lazily imports it. With
+# flush=False the production emitter starts a DAEMON urllib thread, which can still
+# be inside OpenSSL while this short-lived interpreter finalizes — observed in
+# clean-install CI as `double free or corruption (out)` + SIGSEGV AFTER the suite
+# reports `31/31 passed`. A CI runner has no telemetry opt-out marker, so
+# `enabled()` is True there.
+#
+# Same fix and same reason as #2388, which did this for
+# tests/agent-api-task-field-injection.test.py. That PR closed exactly one suite;
+# this is a second suite with the identical mechanism.
+#
+# Set BEFORE the regular imports so nothing can import `telemetry` first, and after
+# `from __future__` because that must lead the file.
+#
+# Verified locally that this is the right lever — macOS cannot reproduce the glibc
+# double-free, so the CRASH is not reproducible here, only its cause:
+#   SUTANDO_TELEMETRY unset -> enabled()=True,  task_processed spawns 1 thread
+#   SUTANDO_TELEMETRY=0     -> enabled()=False, task_processed spawns 0 threads
+os.environ["SUTANDO_TELEMETRY"] = "0"
+
 import hashlib
 import hmac
 import importlib.util

--- a/tests/install-claude-hooks.test.sh
+++ b/tests/install-claude-hooks.test.sh
@@ -126,6 +126,64 @@ ok "unquoted stale variant swept on re-run" \
 ok "the surviving SessionEnd hook is the QUOTED one that runs" \
    "$([ "$(TRANSCRIPT_PATH=/dev/null bash -c "$(cmds SessionEnd | grep session-handoff)" 2>&1)" = "HANDOFF-RAN" ] && echo 0 || echo 1)"
 
+# --- 7. the sweep must not eat hooks it does not own -------------------------
+# Carrying our marker is NOT ownership: an operator hook that invokes the same
+# script with an extra flag also contains it. An earlier revision of the sweep
+# deleted exactly those — silently, since a removed hook leaves no trace. These
+# are the negative controls: without them the sweep only ever demonstrates what
+# it CAN delete, never what it must refuse to.
+python3 - "$SETTINGS" "$REPO" <<'PY'
+import json, sys
+p, repo = sys.argv[1], sys.argv[2]
+d = json.load(open(p))
+d["hooks"]["SessionEnd"][0]["hooks"] += [
+    # (a) same script, operator-customized with a trailing flag.
+    {"type": "command",
+     "command": f'bash {repo}/src/session-handoff.sh "$TRANSCRIPT_PATH" --verbose'},
+    # (b) same marker, entirely different command shape.
+    {"type": "command",
+     "command": f'echo custom && bash {repo}/src/session-handoff.sh'},
+    # (c) same script under a path that is not this clone, wrapped by the operator.
+    {"type": "command",
+     "command": 'env FOO=1 bash "/somewhere else/src/session-handoff.sh" "$TRANSCRIPT_PATH"'},
+]
+json.dump(d, open(p, "w"), indent=2)
+PY
+bash "$REPO/src/install-claude-hooks.sh" >/dev/null 2>&1
+SURVIVORS="$(cmds SessionEnd)"
+ok "operator hook with a trailing flag survives the sweep" \
+   "$(echo "$SURVIVORS" | grep -q -- '--verbose' && echo 0 || echo 1)"
+ok "operator hook with a different command shape survives the sweep" \
+   "$(echo "$SURVIVORS" | grep -q 'echo custom' && echo 0 || echo 1)"
+ok "operator-wrapped hook for another path survives the sweep" \
+   "$(echo "$SURVIVORS" | grep -q 'env FOO=1' && echo 0 || echo 1)"
+# Ours = the session-handoff commands that are not one of the three operator
+# fixtures. Counted by subtraction rather than by matching $REPO literally: the
+# installer normalizes its stored path (mktemp can yield a `//`), so a literal
+# comparison against the fixture path fails for a reason that has nothing to do
+# with the sweep.
+ok "our own hook is still installed exactly once alongside them" \
+   "$([ "$(( $(echo "$SURVIVORS" | grep -c session-handoff) - $(echo "$SURVIVORS" | grep -cE -- '--verbose|echo custom|env FOO=1') ))" = 1 ] && echo 0 || echo 1)"
+ok "and ours is still the one that actually executes" \
+   "$([ "$(TRANSCRIPT_PATH=/dev/null bash -c "$(echo "$SURVIVORS" | grep session-handoff | grep -vE -- '--verbose|echo custom|env FOO=1')" 2>&1)" = "HANDOFF-RAN" ] && echo 0 || echo 1)"
+
+# A stale INSTALLER-SHAPED entry from a different clone must still be swept —
+# the fix must not be "stop sweeping", it must be "sweep only our own shapes".
+python3 - "$SETTINGS" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d["hooks"]["SessionEnd"][0]["hooks"].append(
+    {"type": "command",
+     "command": 'bash /a different clone/src/session-handoff.sh "$TRANSCRIPT_PATH"'})
+json.dump(d, open(p, "w"), indent=2)
+PY
+bash "$REPO/src/install-claude-hooks.sh" >/dev/null 2>&1
+ok "another clone's installer-shaped entry is still swept" \
+   "$(cmds SessionEnd | grep -q 'a different clone' && echo 1 || echo 0)"
+ok "sweeping it did not take the operator hooks with it" \
+   "$([ "$(cmds SessionEnd | grep -cE -- '--verbose|echo custom|env FOO=1')" = 3 ] && echo 0 || echo 1)"
+
 rm -rf "$ROOT"
 echo "---"
 if [ "$fail" -gt 0 ]; then

--- a/tests/install-claude-hooks.test.sh
+++ b/tests/install-claude-hooks.test.sh
@@ -231,6 +231,60 @@ ok "apostrophe path: the surviving command actually executes" \
    "$([ "$(TRANSCRIPT_PATH=/dev/null bash -c "$A_SURVIVOR" 2>&1)" = "HANDOFF-RAN" ] && echo 0 || echo 1)"
 rm -rf "$AROOT"
 
+# --- 9. customization BEFORE the path (flags / wrappers) ---------------------
+# The trailing anchor protects customization that comes AFTER the script path.
+# It says nothing about customization BEFORE it: a bare wildcard between the
+# command word and the marker swallows `-x`, so an operator's `bash -x <path>/…`
+# was classified installer-owned and deleted (reproduced: before 2, after 1).
+# The path region must START like a path, so a flag token fails immediately —
+# while `$HOME/…`, which the legacy migration depends on, still qualifies.
+BROOT="$(mktemp -d "${TMPDIR:-/tmp}/sutando hooks flag.XXXXXX")"
+BREPO="$BROOT/repo with spaces"
+mkdir -p "$BREPO/src" "$BREPO/.claude"
+cp "$INSTALLER" "$BREPO/src/install-claude-hooks.sh"
+printf '#!/bin/bash\necho "HANDOFF-RAN"\n' > "$BREPO/src/session-handoff.sh"
+printf '#!/bin/bash\necho "PENDING-RAN"\n' > "$BREPO/src/check-pending-tasks.sh"
+chmod +x "$BREPO/src/"*.sh
+echo '{}' > "$BREPO/.claude/settings.json"
+bash "$BREPO/src/install-claude-hooks.sh" >/dev/null 2>&1
+
+export B_SETTINGS="$BREPO/.claude/settings.json" B_REPO="$BREPO"
+python3 - <<'PY'
+import json, os
+p = os.environ['B_SETTINGS']; repo = os.environ['B_REPO']
+d = json.load(open(p))
+d['hooks']['SessionEnd'][0]['hooks'] += [
+    # (a) operator ran the same script under a shell flag — must SURVIVE.
+    {'type': 'command',
+     'command': 'bash -x ' + repo + '/src/session-handoff.sh "$TRANSCRIPT_PATH"'},
+    # (b) legacy installer entry — must still be SWEPT (it starts with `$`,
+    #     so a naive "path must start with /" rule would wrongly spare it).
+    {'type': 'command',
+     'command': 'bash $HOME/Desktop/sutando/src/session-handoff.sh "$TRANSCRIPT_PATH"'},
+]
+json.dump(d, open(p, 'w'), indent=2)
+PY
+bcount() { python3 -c "
+import json, os
+d = json.load(open(os.environ['B_SETTINGS']))
+print(sum(1 for g in d['hooks']['SessionEnd'] for h in g['hooks'] if 'session-handoff' in h['command']))
+"; }
+ok "flag fixture: 3 session-handoff hooks before re-run (sanity)" \
+   "$([ "$(bcount)" = 3 ] && echo 0 || echo 1)"
+bash "$BREPO/src/install-claude-hooks.sh" >/dev/null 2>&1
+BSURV="$(python3 -c "
+import json, os
+d = json.load(open(os.environ['B_SETTINGS']))
+print(chr(10).join(h['command'] for g in d['hooks']['SessionEnd'] for h in g['hooks']))
+")"
+ok "operator hook with a flag BEFORE the path survives (bash -x)" \
+   "$(echo "$BSURV" | grep -q -- 'bash -x ' && echo 0 || echo 1)"
+ok "legacy \$HOME entry is still swept (rule must not require a literal /)" \
+   "$(echo "$BSURV" | grep -q 'Desktop/sutando/src/session-handoff' && echo 1 || echo 0)"
+ok "exactly 2 session-handoff hooks remain (ours + the operator's)" \
+   "$([ "$(bcount)" = 2 ] && echo 0 || echo 1)"
+rm -rf "$BROOT"
+
 rm -rf "$ROOT"
 echo "---"
 if [ "$fail" -gt 0 ]; then

--- a/tests/install-claude-hooks.test.sh
+++ b/tests/install-claude-hooks.test.sh
@@ -184,6 +184,53 @@ ok "another clone's installer-shaped entry is still swept" \
 ok "sweeping it did not take the operator hooks with it" \
    "$([ "$(cmds SessionEnd | grep -cE -- '--verbose|echo custom|env FOO=1')" = 3 ] && echo 0 || echo 1)"
 
+# --- 8. a checkout path containing an APOSTROPHE ----------------------------
+# An apostrophe is legal in a path, and `shq` escapes it as '\'' — so any
+# matching scheme that "normalizes" by deleting quote characters leaves a stray
+# backslash and silently stops recognising its own output. The symptom is not a
+# crash: the stale entry simply survives and BOTH hooks fire forever.
+# Fixture path has a space AND an apostrophe on purpose.
+AROOT="$(mktemp -d "${TMPDIR:-/tmp}/sutando hooks apos.XXXXXX")"
+AREPO="$AROOT/repo'quote with spaces"
+mkdir -p "$AREPO/src" "$AREPO/.claude"
+cp "$INSTALLER" "$AREPO/src/install-claude-hooks.sh"
+printf '#!/bin/bash\necho "HANDOFF-RAN"\n' > "$AREPO/src/session-handoff.sh"
+printf '#!/bin/bash\necho "PENDING-RAN"\n' > "$AREPO/src/check-pending-tasks.sh"
+chmod +x "$AREPO/src/"*.sh
+echo '{}' > "$AREPO/.claude/settings.json"
+bash "$AREPO/src/install-claude-hooks.sh" >/dev/null 2>&1
+
+export A_SETTINGS="$AREPO/.claude/settings.json" A_REPO="$AREPO"
+# Seed the prior UNQUOTED installer variant, exactly as an older revision wrote it.
+python3 - <<'PY'
+import json, os
+p = os.environ['A_SETTINGS']
+d = json.load(open(p))
+d['hooks']['SessionEnd'][0]['hooks'].append(
+    {'type': 'command',
+     'command': 'bash ' + os.environ['A_REPO'] + '/src/session-handoff.sh "$TRANSCRIPT_PATH"'})
+json.dump(d, open(p, 'w'), indent=2)
+PY
+acount() { python3 -c "
+import json, os
+d = json.load(open(os.environ['A_SETTINGS']))
+print(sum(1 for g in d['hooks']['SessionEnd'] for h in g['hooks'] if 'session-handoff' in h['command']))
+"; }
+ok "apostrophe fixture: stale variant present before re-run (sanity)" \
+   "$([ "$(acount)" = 2 ] && echo 0 || echo 1)"
+bash "$AREPO/src/install-claude-hooks.sh" >/dev/null 2>&1
+ok "apostrophe path: stale variant IS swept on re-run" \
+   "$([ "$(acount)" = 1 ] && echo 0 || echo 1)"
+A_SURVIVOR="$(python3 -c "
+import json, os
+d = json.load(open(os.environ['A_SETTINGS']))
+print([h['command'] for g in d['hooks']['SessionEnd'] for h in g['hooks']
+       if 'session-handoff' in h['command']][0])
+")"
+ok "apostrophe path: the surviving command actually executes" \
+   "$([ "$(TRANSCRIPT_PATH=/dev/null bash -c "$A_SURVIVOR" 2>&1)" = "HANDOFF-RAN" ] && echo 0 || echo 1)"
+rm -rf "$AROOT"
+
 rm -rf "$ROOT"
 echo "---"
 if [ "$fail" -gt 0 ]; then

--- a/tests/install-claude-hooks.test.sh
+++ b/tests/install-claude-hooks.test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Tests for src/install-claude-hooks.sh.
+#
+# The bug this guards: REPO_DIR is expanded at INSTALL time and its literal text
+# is re-parsed by a shell at HOOK-RUN time. Unquoted, a clone under
+# "Library/Application Support/..." splits on the space and every hook dies with
+# `bash: /Users/you/Library: No such file or directory` — silently, because a
+# hook's exit code is not surfaced. So the load-bearing assertion here is not
+# "the JSON contains the path", it is "the stored command STRING, executed by a
+# shell, actually runs the intended script". Every fixture path below contains a
+# space on purpose.
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="$HERE/../src/install-claude-hooks.sh"
+
+pass=0; fail=0
+ok() {  # ok <name> <condition-rc>
+    if [ "$2" = 0 ]; then echo "ok   $1"; pass=$((pass+1))
+    else echo "FAIL $1"; fail=$((fail+1)); fi
+}
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP — jq not installed"; exit 0; }
+
+# --- build a fake clone whose path contains spaces ---------------------------
+ROOT="$(mktemp -d "${TMPDIR:-/tmp}/sutando hooks test.XXXXXX")"
+REPO="$ROOT/repo with spaces"
+mkdir -p "$REPO/src" "$REPO/.claude"
+cp "$INSTALLER" "$REPO/src/install-claude-hooks.sh"
+# Stub the hook targets so an executed command can prove WHICH file it reached.
+printf '#!/bin/bash\necho "HANDOFF-RAN"\n'      > "$REPO/src/session-handoff.sh"
+printf '#!/bin/bash\necho "PENDING-RAN"\n'      > "$REPO/src/check-pending-tasks.sh"
+chmod +x "$REPO/src/"*.sh
+SETTINGS="$REPO/.claude/settings.json"
+
+# Seed the legacy state a real install would have: Desktop-hardcoded hooks plus
+# the transcript-archive hook, which must SURVIVE (it legitimately points at
+# ~/Desktop/sutando-conversations and is not a repo path).
+cat > "$SETTINGS" <<'JSON'
+{
+  "hooks": {
+    "PreCompact": [{"matcher": "", "hooks": [
+      {"type": "command", "command": "cp \"$TRANSCRIPT_PATH\" \"$HOME/Desktop/sutando-conversations/$(date +%Y-%m-%dT%H-%M-%S).jsonl\""},
+      {"type": "command", "command": "bash $HOME/Desktop/sutando/src/session-handoff.sh \"$TRANSCRIPT_PATH\""}
+    ]}],
+    "SessionEnd": [{"matcher": "", "hooks": [
+      {"type": "command", "command": "bash $HOME/Desktop/sutando/src/session-handoff.sh \"$TRANSCRIPT_PATH\""}
+    ]}],
+    "Stop": [{"matcher": "", "hooks": [
+      {"type": "command", "command": "bash $HOME/Desktop/sutando/src/check-pending-tasks.sh"},
+      {"type": "command", "command": "echo operator-added-keepme"}
+    ]}]
+  }
+}
+JSON
+
+OUT1="$(bash "$REPO/src/install-claude-hooks.sh" 2>&1)"; RC1=$?
+ok "installer exits 0 on a path with spaces" "$([ $RC1 = 0 ] && echo 0 || echo 1)"
+
+cmds() {  # cmds <event> -> one command per line
+    jq -r --arg e "$1" '(.hooks // {})[$e] // [] | map(.hooks // []) | flatten | map(.command) | .[]' "$SETTINGS"
+}
+
+# --- 1. the stored command must EXECUTE the intended script ------------------
+# This is the assertion that fails on an unquoted path. Run the exact string.
+SE_CMD="$(cmds SessionEnd | grep session-handoff || true)"
+RUN_OUT="$(TRANSCRIPT_PATH=/dev/null bash -c "$SE_CMD" 2>&1)"
+ok "SessionEnd stored command executes the intended script" \
+   "$([ "$RUN_OUT" = "HANDOFF-RAN" ] && echo 0 || echo 1)"
+[ "$RUN_OUT" = "HANDOFF-RAN" ] || echo "     got: $RUN_OUT"
+
+ST_CMD="$(cmds Stop | grep check-pending-tasks || true)"
+RUN_OUT2="$(bash -c "$ST_CMD" 2>&1)"
+ok "Stop stored command executes the intended script" \
+   "$([ "$RUN_OUT2" = "PENDING-RAN" ] && echo 0 || echo 1)"
+[ "$RUN_OUT2" = "PENDING-RAN" ] || echo "     got: $RUN_OUT2"
+
+PC_CMD="$(cmds PreCompact | grep session-handoff || true)"
+RUN_OUT3="$(TRANSCRIPT_PATH=/dev/null bash -c "$PC_CMD" 2>&1)"
+ok "PreCompact handoff stored command executes the intended script" \
+   "$([ "$RUN_OUT3" = "HANDOFF-RAN" ] && echo 0 || echo 1)"
+
+# --- 2. legacy Desktop repo hooks are migrated away -------------------------
+ok "legacy Desktop session-handoff hook removed (PreCompact)" \
+   "$(cmds PreCompact | grep -q 'Desktop/sutando/src/session-handoff.sh' && echo 1 || echo 0)"
+ok "legacy Desktop session-handoff hook removed (SessionEnd)" \
+   "$(cmds SessionEnd | grep -q 'Desktop/sutando/src/session-handoff.sh' && echo 1 || echo 0)"
+ok "legacy Desktop check-pending-tasks hook removed (Stop)" \
+   "$(cmds Stop | grep -q 'Desktop/sutando/src/check-pending-tasks.sh' && echo 1 || echo 0)"
+
+# --- 3. things that must SURVIVE the sweep ----------------------------------
+ok "transcript-archive hook preserved (different marker)" \
+   "$(cmds PreCompact | grep -q 'sutando-conversations/' && echo 0 || echo 1)"
+ok "operator-added unrelated hook preserved" \
+   "$(cmds Stop | grep -q 'operator-added-keepme' && echo 0 || echo 1)"
+
+# --- 4. exactly one of each hook we own -------------------------------------
+ok "exactly one SessionEnd handoff hook (no old+new double-fire)" \
+   "$([ "$(cmds SessionEnd | grep -c session-handoff)" = 1 ] && echo 0 || echo 1)"
+ok "exactly one Stop pending-tasks hook" \
+   "$([ "$(cmds Stop | grep -c check-pending-tasks)" = 1 ] && echo 0 || echo 1)"
+
+# --- 5. re-run is idempotent ------------------------------------------------
+BEFORE="$(cat "$SETTINGS")"
+OUT2="$(bash "$REPO/src/install-claude-hooks.sh" 2>&1)"
+AFTER="$(cat "$SETTINGS")"
+ok "second run adds nothing (added=0)" "$(echo "$OUT2" | grep -q 'added=0' && echo 0 || echo 1)"
+ok "second run leaves settings.json byte-identical" \
+   "$([ "$BEFORE" = "$AFTER" ] && echo 0 || echo 1)"
+
+# --- 6. an UNQUOTED entry from an earlier revision is swept ------------------
+# Phase 1 compares exact strings, so without the marker sweep this stale broken
+# hook would survive alongside the fixed one and both would fire.
+python3 - "$SETTINGS" "$REPO" <<'PY'
+import json, sys
+p, repo = sys.argv[1], sys.argv[2]
+d = json.load(open(p))
+d["hooks"]["SessionEnd"][0]["hooks"].append(
+    {"type": "command", "command": f'bash {repo}/src/session-handoff.sh "$TRANSCRIPT_PATH"'})
+json.dump(d, open(p, "w"), indent=2)
+PY
+ok "unquoted stale variant is present before re-run (fixture sanity)" \
+   "$([ "$(cmds SessionEnd | grep -c session-handoff)" = 2 ] && echo 0 || echo 1)"
+bash "$REPO/src/install-claude-hooks.sh" >/dev/null 2>&1
+ok "unquoted stale variant swept on re-run" \
+   "$([ "$(cmds SessionEnd | grep -c session-handoff)" = 1 ] && echo 0 || echo 1)"
+ok "the surviving SessionEnd hook is the QUOTED one that runs" \
+   "$([ "$(TRANSCRIPT_PATH=/dev/null bash -c "$(cmds SessionEnd | grep session-handoff)" 2>&1)" = "HANDOFF-RAN" ] && echo 0 || echo 1)"
+
+rm -rf "$ROOT"
+echo "---"
+if [ "$fail" -gt 0 ]; then
+    echo "FAILED — $fail of $((pass+fail)) checks"; exit 1
+fi
+echo "PASS — install-claude-hooks ($pass checks)"

--- a/tests/install-claude-hooks.test.sh
+++ b/tests/install-claude-hooks.test.sh
@@ -285,6 +285,40 @@ ok "exactly 2 session-handoff hooks remain (ours + the operator's)" \
    "$([ "$(bcount)" = 2 ] && echo 0 || echo 1)"
 rm -rf "$BROOT"
 
+# --- 10. a hook with NO repo path must never be swept ------------------------
+# Phase 0 exists to migrate entries whose PATH went stale. The transcript-archive
+# hook embeds no repo path at all ($HOME only), so nothing about it can go stale
+# and sweeping it can only destroy someone else's command. With a wildcard shape
+# the `.*` spanned the SOURCE ARGUMENT, so an operator archiving from a different
+# variable matched "our shape" and was deleted and replaced on re-run.
+CROOT="$(mktemp -d "${TMPDIR:-/tmp}/sutando hooks archive.XXXXXX")"
+CREPO="$CROOT/repo with spaces"
+mkdir -p "$CREPO/src" "$CREPO/.claude"
+cp "$INSTALLER" "$CREPO/src/install-claude-hooks.sh"
+printf '#!/bin/bash\necho "HANDOFF-RAN"\n' > "$CREPO/src/session-handoff.sh"
+printf '#!/bin/bash\necho "PENDING-RAN"\n' > "$CREPO/src/check-pending-tasks.sh"
+chmod +x "$CREPO/src/"*.sh
+export C_SETTINGS="$CREPO/.claude/settings.json"
+python3 - <<'PY'
+import json, os
+json.dump({"hooks": {"PreCompact": [{"hooks": [{"type": "command", "command":
+    'cp "$CUSTOM_TRANSCRIPT_PATH" "$HOME/Desktop/sutando-conversations/$(date +%Y-%m-%dT%H-%M-%S).jsonl"'
+}]}]}}, open(os.environ["C_SETTINGS"], "w"), indent=2)
+PY
+bash "$CREPO/src/install-claude-hooks.sh" >/dev/null 2>&1
+CCMDS="$(python3 -c "
+import json, os
+d = json.load(open(os.environ['C_SETTINGS']))
+print(chr(10).join(h['command'] for g in d['hooks'].get('PreCompact', []) for h in g['hooks']))
+")"
+ok "operator's custom transcript-archive command survives re-run" \
+   "$(echo "$CCMDS" | grep -q 'CUSTOM_TRANSCRIPT_PATH' && echo 0 || echo 1)"
+ok "our archive hook is still installed alongside it" \
+   "$(echo "$CCMDS" | grep -q '"\$TRANSCRIPT_PATH".*sutando-conversations' && echo 0 || echo 1)"
+ok "and the repo-path hook is still installed on the same event" \
+   "$(echo "$CCMDS" | grep -q 'session-handoff' && echo 0 || echo 1)"
+rm -rf "$CROOT"
+
 rm -rf "$ROOT"
 echo "---"
 if [ "$fail" -gt 0 ]; then


### PR DESCRIPTION
`install-claude-hooks.sh` derives `REPO_DIR` on line 56 — then doesn't use it. The three script hooks hardcode `$HOME/Desktop/sutando`. The `$` is escaped, so that path lands in `settings.json` **literally** and is expanded at *hook-run* time, resolving to the same directory on every host regardless of where the repo actually is.

On this machine the clone is at `Library/Application Support/space.ag2.app/engine/sutando`, with a sibling at `Documents/github/sutando`. Neither is `~/Desktop`. So running the installer here wires four hooks whose scripts don't exist — and **hooks fail silently**, so the absence is indistinguishable from "the feature is off".

## Before / after on this host

```
before (what main installs here):
  MISSING ~/Desktop/sutando/src/session-handoff.sh      <- fires, fails, silent
  MISSING ~/Desktop/sutando/src/check-pending-tasks.sh

after (expanded at install time from the derived REPO_DIR):
  bash <clone>/src/session-handoff.sh "$TRANSCRIPT_PATH"
  bash <clone>/src/check-pending-tasks.sh
  EXISTS both
```

`$HOME` is deliberately left alone in the transcript-archive hook — `~/Desktop/sutando-conversations` is a user-chosen destination, not a repo path, so deriving it would be wrong.

## How it surfaced

Root-causing a dead relay pipeline: `workspace/relay/` holds **124 notes**, `relay/processed/` is **empty**, and there's no `session-state.md` — because `session-handoff.sh` has never run here. It's invoked only by the `PreCompact`/`SessionEnd` hooks, and no hooks are configured at all.

**Scoping that claim honestly:** this does *not* prove the hardcoded path caused the dead pipeline. Neither clone has a repo-local `.claude/settings.json`, so the installer appears never to have been run at all. What it does establish is that following the documented install path could not have fixed it.

## Not run here

I haven't run the installer on this host — wiring hooks changes the owner's live environment and is their call. This fixes the script so that wiring works when they choose to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZ5eEAmPuFnSA2TkqtQhzZ
