### PR TITLE
fix(onboarding): seed hasCompletedClaudeInChromeOnboarding for headless core

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -183,9 +183,23 @@ try:
 except Exception:
     pass
 changed = False
+chrome_seeded = False
 if cfg.get("hasCompletedOnboarding") is not True:
     cfg["hasCompletedOnboarding"] = True
     changed = True
+# Claude-in-Chrome onboarding seed. The core launches with --chrome (see the
+# CORE_CMD below), which on first run in a fresh scoped config shows a "Claude
+# in Chrome" acknowledgement prompt ("Enter to confirm · Esc to cancel").
+# --dangerously-skip-permissions does NOT bypass it, so a detached no-TTY core
+# hangs there — process alive but never reaching /schedule-crons, and the
+# desktop onboarding "Say hello" local probe times out with no reply
+# (owner-hit 2026-07-28, fresh install). Pre-accept it the same way as
+# hasCompletedOnboarding: Claude Code records acceptance as
+# hasCompletedClaudeInChromeOnboarding=true in .claude.json.
+if cfg.get("hasCompletedClaudeInChromeOnboarding") is not True:
+    cfg["hasCompletedClaudeInChromeOnboarding"] = True
+    changed = True
+    chrome_seeded = True
 if cfg.get("theme") is None and glob.get("theme") is not None:
     cfg["theme"] = glob["theme"]
     changed = True
@@ -241,6 +255,8 @@ if changed:
         json.dump(cfg, f, indent=2)
     os.replace(tmp, target)
     print("  ✓ onboarding-seed: hasCompletedOnboarding set in .claude.json")
+    if chrome_seeded:
+        print("  ✓ chrome-seed: hasCompletedClaudeInChromeOnboarding set in .claude.json")
     if trusted_dir:
         print("  ✓ trust-seed: hasTrustDialogAccepted set for %s" % trusted_dir)
 PY


### PR DESCRIPTION
## Problem

The detached desktop core launches with `--chrome` (4 call sites in `start-cli.sh`). On a **fresh scoped config**, Claude Code shows an interactive *"Claude in Chrome"* acknowledgement prompt (`Enter to confirm · Esc to cancel`). `--dangerously-skip-permissions` does **not** bypass it, so the headless no-TTY core **hangs at the prompt** — process alive but never reaching `/schedule-crons`.

In the desktop split-onboarding wizard this surfaces as the **"Say hello" local probe timing out with no reply** (`SETUP-HELLO-TIMEOUT`), owner-hit 2026-07-28 on a genuine fresh install.

This joins the existing family of first-run prompts the engine already seeds for a headless core: `hasCompletedOnboarding`, folder-trust (`hasTrustDialogAccepted`), and bypass-permissions (`skipDangerousModePermissionPrompt`). The Chrome prompt is the one that was missing.

## Fix

One addition to the existing `onboarding-seed` python block: set `hasCompletedClaudeInChromeOnboarding = True` in `.claude.json`, mirroring the adjacent `hasCompletedOnboarding` seed (Claude Code records acceptance under that exact key). Idempotent, atomic (via the same `changed` + temp-file-rename path), and adds a `✓ chrome-seed` confirmation log line.

## Evidence

**Before** — fresh core parks at the prompt (captured from the running `sutando-core` tmux pane):
```
  Claude in Chrome
  Claude in Chrome works with the Chrome extension to let you control your browser...
  Enter to confirm · Esc to cancel
```
→ core never reaches `/schedule-crons`; onboarding "Say hello" probe returns `SETUP-HELLO-TIMEOUT · no answer before timeout · 91s elapsed`. Two probe tasks consumed, zero result files written (core was blocked, not processing).

**After** — same fresh-install path, engine boot log:
```
sutando-engine:   ✓ onboarding-seed: hasCompletedOnboarding set in .claude.json
sutando-engine:   ✓ chrome-seed: hasCompletedClaudeInChromeOnboarding set in .claude.json
sutando-engine:   ✓ trust-seed: hasTrustDialogAccepted set for ...
```
→ core boots straight through to its ready prompt (`sutando-core ❯`), runs `/schedule-crons`, registers crons. Pane scan for `"Claude in Chrome"` → not present. A manual probe round-trip on the now-idle core returns a reply in ~12s.

## Scope

- Single file, single concern (`src/agent/claude/cli/start-cli.sh`, +16 lines).
- Env-gating unchanged; no behavior change for an already-seeded config (idempotent guard).
- Rebased onto `e611f89` (the commit desktop `main` pins for this submodule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)