### PR TITLE
fix(voice-agent): break the orphaned crash-handler CPU loop (throw-safe logging + breaker + orphan watchdog)

### DIFF
--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -239,6 +239,59 @@ let sessionRef: VoiceSession | null = null;
 function ts(): string { return new Date().toISOString().slice(11, 23); }
 
 // =============================================================================
+// Crash-handler safety
+// =============================================================================
+//
+// If the supervising process dies (app quit/crash), this orphaned voice-agent
+// loses its stdout/stderr pipes — every console.* call then throws, and a
+// "log the error and stay alive" crash handler becomes an infinite
+// throw→log→throw loop pinned at 100% CPU (observed 2026-07-29: an orphan
+// with fds 0-2 closed burned 18h of CPU while its stale pidfile blocked every
+// replacement instance). Three layers prevent a recurrence:
+//   1. stdout/stderr get no-op 'error' handlers — a dead pipe degrades to
+//      silent log loss instead of an uncaught 'error' event.
+//   2. All logging from crash/shutdown paths goes through safeLog/safeError,
+//      which can never throw; the uncaughtException/unhandledRejection
+//      handlers also trip a rate-limit breaker that exits the process when
+//      exceptions arrive faster than any real workload produces them.
+//   3. An orphan watchdog (wired next to the signal handlers in main())
+//      shuts down cleanly when the spawning parent dies.
+process.stdout.on('error', () => {});
+process.stderr.on('error', () => {});
+
+function safeLog(...args: unknown[]): void {
+	try { console.log(...args); } catch { /* dead pipe — drop the line */ }
+}
+function safeError(...args: unknown[]): void {
+	try { console.error(...args); } catch { /* dead pipe — drop the line */ }
+}
+
+const CRASH_LOOP_WINDOW_MS = 5_000;
+const CRASH_LOOP_LIMIT = 25;
+let crashWindowStart = 0;
+let crashWindowCount = 0;
+/** Exit if crash-handler invocations arrive in a tight loop. Called BEFORE
+ * the handler logs, so a logging path that itself throws still hits the
+ * breaker on the next iteration instead of recursing forever. */
+function crashLoopBreaker(kind: string): void {
+	const now = Date.now();
+	if (now - crashWindowStart > CRASH_LOOP_WINDOW_MS) {
+		crashWindowStart = now;
+		crashWindowCount = 0;
+	}
+	if (++crashWindowCount < CRASH_LOOP_LIMIT) return;
+	// Last gasp goes to the workspace log file — stdout may be the very thing
+	// that's broken. Best effort only.
+	try {
+		appendFileSync(
+			join(WORKSPACE_DIR, 'logs', 'voice-agent.log'),
+			`${ts()} [FATAL] ${kind} storm: ${crashWindowCount} in ${CRASH_LOOP_WINDOW_MS}ms — exiting to break the loop\n`,
+		);
+	} catch { /* best effort */ }
+	process.exit(1);
+}
+
+// =============================================================================
 // Pending tool call tracker
 // =============================================================================
 
@@ -988,7 +1041,7 @@ async function main() {
 	session.eventBus.subscribe('turn.interrupted', () => _duck('off'));
 
 	const shutdown = async () => {
-		console.log(`\n${ts()} Shutting down...`);
+		safeLog(`\n${ts()} Shutting down...`);
 		recorder.flush();
 		setVisionSession(null);
 		setSessionToolUpdater(null, []);
@@ -999,6 +1052,7 @@ async function main() {
 	process.on('SIGINT', shutdown);
 	process.on('SIGTERM', shutdown);
 	process.on('uncaughtException', (err) => {
+		crashLoopBreaker('uncaughtException');
 		// EADDRINUSE on the WS port means another voice-agent (typically the
 		// launchd-managed one) already owns it. The existing process is the
 		// one with the live Gemini transport — the duplicate that tripped
@@ -1008,15 +1062,34 @@ async function main() {
 		// control port and exit so the launchd voice-agent (or the next
 		// restart) can claim 7847 with a live session.
 		if ((err as NodeJS.ErrnoException)?.code === 'EADDRINUSE') {
-			console.error(`${ts()} [FATAL] EADDRINUSE on :${PORT} — another voice-agent is listening; exiting so the live one keeps the vision control port.`);
+			safeError(`${ts()} [FATAL] EADDRINUSE on :${PORT} — another voice-agent is listening; exiting so the live one keeps the vision control port.`);
 			try { stopVisionControlServer(); } catch {}
 			process.exit(1);
 		}
-		console.error(`${ts()} [FATAL] uncaught exception (staying alive):`, err);
+		safeError(`${ts()} [FATAL] uncaught exception (staying alive):`, err);
 	});
 	process.on('unhandledRejection', (err) => {
-		console.error(`${ts()} [FATAL] unhandled rejection (staying alive):`, err);
+		crashLoopBreaker('unhandledRejection');
+		safeError(`${ts()} [FATAL] unhandled rejection (staying alive):`, err);
 	});
+
+	// Orphan watchdog — when the spawning parent (backend supervisor / app)
+	// dies, this process gets reparented (macOS: to launchd, ppid 1). An
+	// orphan has no log sink and no supervisor, but still holds the pidfile
+	// and ports :9900/:7847, blocking every replacement instance. Detect the
+	// reparent and shut down cleanly. Skipped when we STARTED under pid 1 —
+	// that's the legitimate launchd-managed deployment.
+	const initialPpid = process.ppid;
+	if (initialPpid !== 1) {
+		setInterval(() => {
+			if (process.ppid === initialPpid) return;
+			safeError(`${ts()} [Orphan] Parent ${initialPpid} is gone (ppid now ${process.ppid}) — shutting down to release pidfile and ports`);
+			// shutdown() awaits session.close(); if the transport hangs, force
+			// the exit — an orphan has nothing left to lose.
+			setTimeout(() => process.exit(1), 10_000).unref();
+			void shutdown();
+		}, 30_000).unref();
+	}
 
 	voiceSessionRef = session;
 

--- a/tests/voice-agent-crash-loop-guard.test.ts
+++ b/tests/voice-agent-crash-loop-guard.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Guards against the 2026-07-29 orphan incident: a voice-agent whose spawning
+// parent died lost its stdout/stderr; every console.* then raised, and the
+// "log and stay alive" uncaughtException handler became an infinite
+// throw→log→throw loop at 100% CPU while its pidfile blocked replacements.
+// voice-agent.ts has import-time side effects (credential resolution,
+// process.exit on missing keys), so like voice-agent-key-format.test.ts this
+// asserts on source shape rather than importing the module.
+const SRC = readFileSync(
+	join(import.meta.dirname ?? '.', '..', 'src/voice-agent.ts'),
+	'utf8',
+);
+
+describe('voice-agent crash-loop guards', () => {
+	it('absorbs stdout/stderr stream errors instead of letting them go uncaught', () => {
+		assert.match(SRC, /process\.stdout\.on\('error',\s*\(\)\s*=>\s*\{\}\)/);
+		assert.match(SRC, /process\.stderr\.on\('error',\s*\(\)\s*=>\s*\{\}\)/);
+	});
+
+	it('rate-limits crash-handler invocations with a loop breaker', () => {
+		assert.match(SRC, /function crashLoopBreaker\(/);
+		// Breaker must fire before the handler logs, so a throwing log path
+		// still trips it on the next iteration.
+		const uncaught = SRC.match(/process\.on\('uncaughtException',[\s\S]*?\n\t\}\);/)?.[0];
+		assert.ok(uncaught, 'uncaughtException handler present');
+		const rejection = SRC.match(/process\.on\('unhandledRejection',[\s\S]*?\n\t\}\);/)?.[0];
+		assert.ok(rejection, 'unhandledRejection handler present');
+		for (const [name, body] of [['uncaughtException', uncaught], ['unhandledRejection', rejection]] as const) {
+			assert.match(body, /crashLoopBreaker\(/, `${name} handler must call crashLoopBreaker`);
+			assert.ok(
+				body.indexOf('crashLoopBreaker(') < body.search(/safeError\(/),
+				`${name} handler must call crashLoopBreaker before logging`,
+			);
+		}
+	});
+
+	it('crash handlers and shutdown log via throw-safe helpers, never bare console', () => {
+		assert.match(SRC, /function safeLog\(/);
+		assert.match(SRC, /function safeError\(/);
+		const uncaught = SRC.match(/process\.on\('uncaughtException',[\s\S]*?\n\t\}\);/)?.[0] ?? '';
+		const rejection = SRC.match(/process\.on\('unhandledRejection',[\s\S]*?\n\t\}\);/)?.[0] ?? '';
+		const shutdown = SRC.match(/const shutdown = async \(\) => \{[\s\S]*?\n\t\};/)?.[0] ?? '';
+		assert.ok(shutdown, 'shutdown present');
+		for (const [name, body] of [['uncaughtException', uncaught], ['unhandledRejection', rejection], ['shutdown', shutdown]] as const) {
+			assert.doesNotMatch(
+				body,
+				/(?<!safeError\(.*)\bconsole\.(log|error)\(/,
+				`${name} must not call bare console.* — it throws when the parent's pipe is gone`,
+			);
+		}
+	});
+
+	it('shuts down when orphaned (reparented away from its spawning parent)', () => {
+		assert.match(SRC, /const initialPpid = process\.ppid/);
+		assert.match(SRC, /process\.ppid === initialPpid/);
+		// launchd-managed deployments legitimately start with ppid 1 — the
+		// watchdog must not fire for them.
+		assert.match(SRC, /initialPpid !== 1/);
+	});
+});


### PR DESCRIPTION
## What changed, and why?

When the supervising parent (backend supervisor / desktop app) dies, the orphaned voice-agent loses its stdout/stderr pipes. Every `console.*` call then raises an async stream error with no listener, which lands in the `uncaughtException` handler — whose response is another `console.error`. The result is an infinite throw→log→throw loop pinned at 100% CPU with unbounded memory growth, while the orphan's pidfile and ports `:9900`/`:7847` block every replacement instance.

This PR adds three guard layers to `src/voice-agent.ts`:

1. **No-op `'error'` handlers on `process.stdout`/`process.stderr`** — a dead pipe degrades to silent log loss instead of an uncaught `'error'` event (this breaks the loop's fuel source).
2. **Throw-safe logging + rate breaker in the crash handlers** — `safeLog`/`safeError` wrap `console.*` in try/catch; `crashLoopBreaker()` exits the process if >25 uncaught exceptions/rejections land within 5s, called *before* the handler logs so even a throwing log path trips it on the next iteration. The last-gasp line goes to `workspace/logs/voice-agent.log` via `appendFileSync`, bypassing the possibly-dead stdout. `shutdown()` also logs via `safeLog` so SIGTERM works with dead fds (previously its first line was a throwing `console.log`, so only SIGKILL worked).
3. **Orphan watchdog** — records `process.ppid` at startup; if the parent changes (macOS reparents orphans to launchd), shut down cleanly with a 10s hard-exit fallback, releasing the pidfile and ports so the replacement can start. Skipped when started under pid 1 (legitimate launchd-managed deployment).

## What files / sections should reviewers look at first?

- `src/voice-agent.ts` — new "Crash-handler safety" section after `ts()` (stream error handlers, `safeLog`/`safeError`, `crashLoopBreaker`), the hardened `uncaughtException`/`unhandledRejection` handlers, and the orphan watchdog right below them.
- `tests/voice-agent-crash-loop-guard.test.ts` — source-shape guards (same style as `voice-agent-key-format.test.ts`, since `voice-agent.ts` has import-time side effects).

## What user behavior or bug does this prove?

Production incident 2026-07-29: an orphaned voice-agent (ppid 1, fds 0-2 fully closed — `lsof -p` showed no fd 0/1/2) burned **18.5 hours of CPU at 97–99%** and grew to **926MB RSS**. A native `sample` showed ~76% of main-thread time inside V8 uncaught-exception reporting + `Error` stack capture, driven off the `setImmediate` check phase, with heavy GC scavenging from the churn:

```
$ ps aux | grep voice-agent
john  3743  97.1  2.8 454394704 926624  ??  Rs  4:22PM 1109:05.93 .../node .../dist/voice-agent.js

$ sample 3743 5   # dominant main-thread path
uv__run_check → CheckImmediate → InternalMakeCallback
  → Isolate::ReportPendingMessages → node::errors::TriggerUncaughtException   (2772/3626 samples)
    → [JS uncaughtException handler] → InspectorConsoleCall (console.error)   (2648 samples)
      → Builtin_ErrorConstructor → CaptureAndSetErrorStack                    (981 samples)
```

Meanwhile the workspace log filled with every restart attempt failing against the zombie's pidfile:

```
08:45:30.283 [Startup] FATAL: voice-agent already running (pid 3743) for .../workspace
08:45:30.283 [Startup] Kill it first or remove .../workspace/.voice-agent.pid. Exiting.
```

So the user-visible symptom was both a pinned CPU core **and** voice being down (no replacement could start).

## Feature/documentation consistency

N/A — no user-visible feature or capability change; this is crash-path hardening with no config surface (breaker thresholds are internal constants).

## Before/after evidence

**Scripted repro of the mechanism** (harness spawns a child with piped stdio, then destroys the pipe read ends to simulate parent death; measures the child at 6s — scripts in the details block below):

```
$ node harness.mjs old-pattern.mjs   # parent-commit handler shape: bare console.error, no guards
old-pattern.mjs: alive-after-6s=true exitCode=null cpu=98.9% rss=94544KB

$ node harness.mjs new-pattern.mjs   # HEAD handler shape: stream error handlers + safeError + breaker
new-pattern.mjs: alive-after-6s=true exitCode=null cpu=0.4% rss=42976KB
```

**Guard test at parent commit** (`c71a637`, with `src/voice-agent.ts` stashed back to parent state) vs HEAD:

```
# parent commit
$ npx tsx --test --test-force-exit tests/voice-agent-crash-loop-guard.test.ts
not ok 1 - voice-agent crash-loop guards
# pass 0
# fail 4

# HEAD
$ npx tsx --test --test-force-exit tests/voice-agent-crash-loop-guard.test.ts
# pass 4
# fail 0
```

<details>
<summary>Repro scripts (harness + old/new pattern children)</summary>

`harness.mjs`:

```js
import { spawn, execSync } from 'node:child_process';
const script = process.argv[2];
const child = spawn(process.execPath, [script], { stdio: ['ignore', 'pipe', 'pipe'] });
// Simulate parent death: close the read ends of both pipes.
setTimeout(() => { child.stdout.destroy(); child.stderr.destroy(); }, 500);
setTimeout(() => {
  let cpu = 'exited', rss = '';
  try {
    cpu = execSync(`ps -o %cpu= -p ${child.pid}`).toString().trim();
    rss = execSync(`ps -o rss= -p ${child.pid}`).toString().trim();
  } catch {}
  const alive = child.exitCode === null && child.signalCode === null;
  console.log(`${script}: alive-after-6s=${alive} exitCode=${child.exitCode} cpu=${cpu}% rss=${rss}KB`);
  child.kill('SIGKILL'); process.exit(0);
}, 6000);
```

`old-pattern.mjs` (parent-commit handler shape):

```js
process.on('uncaughtException', (err) => { console.error('[FATAL] uncaught exception (staying alive):', err); });
process.on('unhandledRejection', (err) => { console.error('[FATAL] unhandled rejection (staying alive):', err); });
setInterval(() => console.log('heartbeat'), 50);   // like the [Health] ticker
setTimeout(() => process.exit(0), 8000);
```

`new-pattern.mjs` (HEAD handler shape):

```js
process.stdout.on('error', () => {});
process.stderr.on('error', () => {});
function safeError(...args) { try { console.error(...args); } catch {} }
let winStart = 0, winCount = 0;
function crashLoopBreaker() {
  const now = Date.now();
  if (now - winStart > 5000) { winStart = now; winCount = 0; }
  if (++winCount >= 25) process.exit(1);
}
process.on('uncaughtException', (err) => { crashLoopBreaker(); safeError('[FATAL] uncaught exception (staying alive):', err); });
process.on('unhandledRejection', (err) => { crashLoopBreaker(); safeError('[FATAL] unhandled rejection (staying alive):', err); });
setInterval(() => { try { console.log('heartbeat'); } catch {} }, 50);
setTimeout(() => process.exit(0), 8000);
```

</details>

## What tests did you run?

```
$ npm run typecheck
> tsc --noEmit          # clean

$ npx eslint src/voice-agent.ts tests/voice-agent-crash-loop-guard.test.ts
✖ 16 problems (0 errors, 16 warnings)   # all 16 are pre-existing no-explicit-any warnings on untouched lines

$ npx tsx --test --test-force-exit tests/voice-agent-crash-loop-guard.test.ts tests/voice-agent-key-format.test.ts
# pass 6
# fail 0
```

## Touching a live path (startup)?

The change touches voice-agent startup wiring but is inert in the healthy path: the stream error handlers and breaker only observe; the watchdog only fires on reparent. I could not run a live post-restart round trip on the affected host — the production zombie (pid 3743) still held `:9900`/`:7847` at time of writing and is being killed by the owner; the scripted repro above exercises the exact failure path (pipe death → handler loop) end-to-end. Happy to add a live voice round-trip transcript after the next engine bundle deploy if reviewers want it.

## Stacked PR?

N/A — standalone.

## Hardcoded-path check

Added lines use `join(WORKSPACE_DIR, 'logs', 'voice-agent.log')` (workspace resolved via the existing `resolveWorkspace()` helper); no host-specific paths. Test file uses `import.meta.dirname`-relative paths like its siblings.

## Voice / phone / audio manual test

N/A for a transcript — the change never executes during a live conversation turn; it only runs in crash/orphan paths. Mechanism evidence is the scripted repro above plus the production forensics.

## Edge cases checked

- **launchd-managed deployment (starts with ppid 1):** watchdog is skipped (`initialPpid !== 1` guard) — reparenting can't false-positive there.
- **Breaker vs legitimate exception bursts:** threshold is 25 in 5s; real workloads produce isolated exceptions (the EADDRINUSE duplicate-start path exits on the first one). A storm that fast is only ever a loop.
- **`shutdown()` hanging on a dead transport in the orphan path:** 10s unref'd hard-exit fallback.
- **Breaker's own logging failing:** last-gasp uses `appendFileSync` to the workspace log inside try/catch; `process.exit(1)` runs regardless.
- **Timers holding the loop open:** the watchdog interval is `unref()`'d.

## Migrations, config, permissions, rollback, deployment risks?

None. No config surface, no schema changes. Rollback is a straight revert. Behavior change to be aware of: a process that previously spun forever now exits under exception storm or orphaning — which is the desired outcome, and the supervisor/launchd restart path already handles process exit.

## Known gaps / follow-up

- The desktop app's engine bundle (`dist/voice-agent.js`) needs a rebuild/redeploy to pick this up.
- `src/task-bridge.ts` and other long-lived services log via bare `console.*` too; they don't have stay-alive crash handlers (so no loop), but a shared `safeLog` util could be a follow-up if maintainers want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
