### PR TITLE
test(agent-api): prevent telemetry teardown segfault

### DIFF
--- a/tests/agent-api-task-field-injection.test.py
+++ b/tests/agent-api-task-field-injection.test.py
@@ -31,9 +31,16 @@ Move `task:` last and wrap body/text in confine_user_content().
 """
 
 import importlib.util
+import os
 import re
 import sys
 from pathlib import Path
+
+# This suite drives real task-accept handlers but does not test telemetry.
+# Keep it hermetic: the production emitter otherwise starts daemon urllib
+# threads, which can still be inside OpenSSL while this short-lived interpreter
+# shuts down (observed as a post-success Linux segfault in clean-install CI).
+os.environ["SUTANDO_TELEMETRY"] = "0"
 
 REPO = Path(__file__).resolve().parent.parent
 


### PR DESCRIPTION
## What changed, and why?

`tests/agent-api-task-field-injection.test.py` now disables product telemetry before loading and driving the real agent API handlers. This suite tests task-file confinement, not telemetry; after #2274 landed, its three handler calls started real daemon `urllib` threads. On Linux clean-install runners the interpreter can exit while those threads are still inside the network/OpenSSL stack, producing a segmentation fault *after* every assertion passes.

The production telemetry behavior is unchanged. The dedicated telemetry suite still covers enabled, opt-out, async, flush, CLI, persistence, and payload behavior.

## Review first

- `tests/agent-api-task-field-injection.test.py:34-41`

## User-visible behavior

No product behavior changes. This removes a nondeterministic required-CI failure that currently blocks unrelated #2370 and #2373.

## Documentation consistency

N/A — test isolation only; no feature, config, or public behavior changed.

## Before / after evidence

The refreshed #2373 clean-install job on parent `c71a637d` ended with:

```text
All task-field injection tests passed.
Segmentation fault (core dumped)
Process completed with exit code 1.
```

The same unchanged test produced the same post-success failure twice on #2370.

A local debug run against the parent test proves the three real emitters are enabled:

```text
[telemetry] task_processed {'source': 'twilio_voice'} (enabled=True)
[telemetry] task_processed {'source': 'twilio_sms'} (enabled=True)
[telemetry] task_processed {'source': 'twilio_voicemail'} (enabled=True)
All task-field injection tests passed.
```

At HEAD, the exact same command proves the test-local opt-out prevents thread creation:

```text
[telemetry] task_processed {'source': 'twilio_voice'} (enabled=False)
[telemetry] task_processed {'source': 'twilio_sms'} (enabled=False)
[telemetry] task_processed {'source': 'twilio_voicemail'} (enabled=False)
All task-field injection tests passed.
```

Repeated short-process exit check at HEAD:

```text
100/100 clean exits
```

## Tests

```text
python3 tests/agent-api-task-field-injection.test.py
All task-field injection tests passed.

for i in $(seq 1 100); do python3 tests/agent-api-task-field-injection.test.py >/dev/null || exit 1; done
100/100 clean exits

python3 tests/telemetry.test.py
ALL PASS (24 checks)

python3 -m py_compile tests/agent-api-task-field-injection.test.py src/agent-api.py src/telemetry.py
# exit 0

git diff --check
# exit 0

bash scripts/review-checks.sh --diff <combined diff>
review-checks: PASS (hardcoded-paths clean)
```

## Live path

N/A — production bridge/network/startup code is unchanged. The test intentionally stops exercising live PostHog I/O; telemetry's dedicated tests continue to exercise the dispatch contract with controlled fakes.

## Edge cases / risk / rollback

- The opt-out is process-local and set before `agent-api.py` can lazily import `telemetry`.
- It is unconditional, so a developer's ambient telemetry opt-in cannot make this test perform external network writes.
- Rollback is the one test-file commit; no migration or runtime risk.
