### PR TITLE
feat(core): easy human-triggered core restart/stop — app menu + chat command (#2401)

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-174 modules indexed.
+176 modules indexed.
 
 ## `src/`
 
@@ -32,6 +32,7 @@ and re-run `python3 scripts/gen-src-map.py`.
 - **`core-input-watch.py`** — core-input-watch.py — the core supervisor MONITOR (M1).
 - **`core-supervisor-relay.py`** — core-supervisor-relay.py — the COMMUNICATOR (outbound ESCALATE).
 - **`core_heartbeat.py`** — Per-host heartbeat for sutando-core sessions.
+- **`core_restart_intent.py`** — core_restart_intent.py — the owner's easy-restart intent file (sonichi#2401).
 - **`cron-runner.py`** — OS-supervised cron runner — emits task files for due crons.json entries.
 - **`daily-insight.py`** — Daily insight generator for Sutando's behavioral flywheel.
 - **`dashboard.py`** — Sutando dashboard — current system status for the local agent.
@@ -142,6 +143,7 @@ and re-run `python3 scripts/gen-src-map.py`.
 ## `src/agent/`
 
 - **`start-cli.sh`** — Canonical persistent-core launcher.
+- **`stop-core.sh`** — src/agent/stop-core.sh — stop ONLY the core CLI tmux session (sonichi#2401).
 
 ## `src/agent/claude/cli/`
 

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -2527,12 +2527,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Consume <workspace>/state/core-restart-requested.json and perform the
     /// requested action in THIS (GUI) session. Mirrors core_restart_intent.py:
-    /// delete-before-act, unknown/malformed/stale (>600s) intents dropped.
+    /// delete-before-act, unknown/malformed/stale (>600s) intents dropped —
+    /// and the delete must SUCCEED before any dispatch: an undeletable file
+    /// would re-fire the same action every 5s poll, so fail closed instead
+    /// (qingyun review, #2408).
     func pollRestartIntent() {
         let path = workspace + "/state/core-restart-requested.json"
         guard FileManager.default.fileExists(atPath: path) else { return }
         let raw = try? String(contentsOfFile: path, encoding: .utf8)
-        try? FileManager.default.removeItem(atPath: path)  // consume FIRST
+        do {
+            try FileManager.default.removeItem(atPath: path)  // consume FIRST
+        } catch {
+            notify("Sutando", "Restart request file couldn't be consumed — NOT acting (would loop). Remove it manually: \(path)")
+            return
+        }
         guard let raw = raw,
               let data = raw.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -343,6 +343,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem(title: "Resume Loop", action: #selector(resumeLoop), keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Restart Core CLI", action: #selector(restartCore), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: "Stop Core CLI", action: #selector(stopCore), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Restart All Services", action: #selector(restartServices), keyEquivalent: "r"))
         menu.addItem(NSMenuItem(title: "Stop All Services", action: #selector(stopServices), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Restart Sutando App", action: #selector(restartSelf), keyEquivalent: ""))
@@ -410,6 +411,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // rather than waiting 30min.
         DispatchQueue.global(qos: .background).async { [weak self] in
             self?.runHealthCheck()
+        }
+
+        // Easy-restart intent poller (sonichi#2401): every 5s, consume
+        // <workspace>/state/core-restart-requested.json (written by a bridge
+        // on the owner's "restart core" / "stop core" chat command — bridges
+        // survive core death, which is exactly when this matters) and run the
+        // action HERE, in the GUI login session, so the relaunch comes up
+        // authenticated (no SSH keychain wall — the 2026-07-29 outage class).
+        // Human-triggered only: nothing writes this file autonomously, and a
+        // consumed "stop" has no auto-restart anywhere. Consume-before-act +
+        // 10-min staleness drop mirror core_restart_intent.py exactly.
+        Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            self?.pollRestartIntent()
         }
 
         // Presenter mode: poll iclr-highlight server for on/off state.
@@ -2469,6 +2483,71 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 let preview = String(errStr.prefix(200))
                 self?.notify("Sutando", "Core restart failed (exit \(proc.terminationStatus)): \(preview)")
             }
+        }
+    }
+
+    /// Stop ONLY the core CLI session (sonichi#2401 "stop means stop"):
+    /// bridges and services keep running, and nothing relaunches the core
+    /// until the user asks (menu or chat command).
+    @objc func stopCore() {
+        notify("Sutando", "Stopping Core CLI…")
+        runCoreAction(script: repoRoot + "/src/agent/stop-core.sh", args: [],
+                      okMessage: "Core stopped. It stays stopped until you restart it.",
+                      failVerb: "Core stop")
+    }
+
+    /// Shared runner for core start/stop scripts: detached bash, stderr
+    /// surfaced via notify on failure (same contract as restartCore).
+    private func runCoreAction(script: String, args: [String],
+                               okMessage: String, failVerb: String) {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/bash")
+        proc.arguments = [script] + args
+        let errPipe = Pipe()
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = errPipe
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            do {
+                try proc.run()
+            } catch {
+                self?.notify("Sutando", "\(failVerb) failed to start: \(error.localizedDescription)")
+                return
+            }
+            proc.waitUntilExit()
+            if proc.terminationStatus == 0 {
+                self?.notify("Sutando", okMessage)
+            } else {
+                let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+                let errStr = String(data: errData, encoding: .utf8) ?? ""
+                let preview = String(errStr.prefix(200))
+                self?.notify("Sutando", "\(failVerb) failed (exit \(proc.terminationStatus)): \(preview)")
+            }
+        }
+    }
+
+    /// Consume <workspace>/state/core-restart-requested.json and perform the
+    /// requested action in THIS (GUI) session. Mirrors core_restart_intent.py:
+    /// delete-before-act, unknown/malformed/stale (>600s) intents dropped.
+    func pollRestartIntent() {
+        let path = workspace + "/state/core-restart-requested.json"
+        guard FileManager.default.fileExists(atPath: path) else { return }
+        let raw = try? String(contentsOfFile: path, encoding: .utf8)
+        try? FileManager.default.removeItem(atPath: path)  // consume FIRST
+        guard let raw = raw,
+              let data = raw.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let action = obj["action"] as? String,
+              let requestedAt = obj["requested_at"] as? Double,
+              Date().timeIntervalSince1970 - requestedAt <= 600 else { return }
+        switch action {
+        case "restart":
+            notify("Sutando", "Chat-requested core restart — relaunching…")
+            restartCore()
+        case "stop":
+            notify("Sutando", "Chat-requested core stop.")
+            stopCore()
+        default:
+            return
         }
     }
 

--- a/src/agent/stop-core.sh
+++ b/src/agent/stop-core.sh
@@ -9,15 +9,17 @@
 # Stop means stop (owner decision on #2401): nothing anywhere relaunches a
 # stopped core automatically. Idempotent — exits 0 when no session exists.
 #
-# Socket resolution matches start-cli.sh: $SUTANDO_TMUX_SOCKET, else the
-# default socket path.
+# Socket + session resolution match start-cli.sh: $SUTANDO_TMUX_SOCKET /
+# $SUTANDO_TMUX_SESSION, else the defaults. Selectors use tmux exact-match
+# (=name) so a similarly-prefixed session (e.g. sutando-core-debug) is never
+# probe-matched or killed (john-the-dev review, #2408).
 
 set -e
 
-SESSION="sutando-core"
+SESSION="${SUTANDO_TMUX_SESSION:-sutando-core}"
 TMUX_SOCKET="${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}"
 
-if ! tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null; then
+if ! tmux -S "$TMUX_SOCKET" has-session -t "=$SESSION" 2>/dev/null; then
   echo "stop-core: no $SESSION session on $TMUX_SOCKET — nothing to stop"
   exit 0
 fi
@@ -25,5 +27,5 @@ fi
 # Kill the watcher sibling first if present (same cleanup start-cli.sh does on
 # --restart), then the core session itself.
 tmux -S "$TMUX_SOCKET" kill-session -t "=${SESSION}-watcher" 2>/dev/null || true
-tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION"
+tmux -S "$TMUX_SOCKET" kill-session -t "=$SESSION"
 echo "stop-core: $SESSION stopped (socket $TMUX_SOCKET)"

--- a/src/agent/stop-core.sh
+++ b/src/agent/stop-core.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# src/agent/stop-core.sh — stop ONLY the core CLI tmux session (sonichi#2401).
+#
+# The core-only counterpart to `start-cli.sh --restart`: kills the
+# sutando-core session and nothing else (bridges, dashboard, proxy all keep
+# running — that separation is what made chat-triggered restart possible in
+# the 2026-07-29 outage, and "Stop All Services" already exists for the rest).
+#
+# Stop means stop (owner decision on #2401): nothing anywhere relaunches a
+# stopped core automatically. Idempotent — exits 0 when no session exists.
+#
+# Socket resolution matches start-cli.sh: $SUTANDO_TMUX_SOCKET, else the
+# default socket path.
+
+set -e
+
+SESSION="sutando-core"
+TMUX_SOCKET="${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}"
+
+if ! tmux -S "$TMUX_SOCKET" has-session -t "$SESSION" 2>/dev/null; then
+  echo "stop-core: no $SESSION session on $TMUX_SOCKET — nothing to stop"
+  exit 0
+fi
+
+# Kill the watcher sibling first if present (same cleanup start-cli.sh does on
+# --restart), then the core session itself.
+tmux -S "$TMUX_SOCKET" kill-session -t "=${SESSION}-watcher" 2>/dev/null || true
+tmux -S "$TMUX_SOCKET" kill-session -t "$SESSION"
+echo "stop-core: $SESSION stopped (socket $TMUX_SOCKET)"

--- a/src/core_restart_intent.py
+++ b/src/core_restart_intent.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""core_restart_intent.py — the owner's easy-restart intent file (sonichi#2401).
+
+The single hand-off between "the owner asked for a core restart/stop from
+chat" and "the GUI-session executor performs it". A bridge (which survives
+core death) writes the intent; Sutando.app's poller consumes it and runs the
+action in the GUI login session — so the relaunch comes up authenticated with
+no SSH, no Terminal, no keychain wall (the 2026-07-29 outage class).
+
+Human-triggered ONLY, by owner decision on #2401: nothing in this module (or
+anywhere else) writes an intent on its own. Stop means stop — a consumed
+"stop" has no corresponding auto-restart anywhere.
+
+File: <workspace>/state/core-restart-requested.json
+Schema: {"action": "restart"|"stop", "requested_at": <epoch>, "source": "..."}
+
+Consume semantics: read-and-delete BEFORE acting (a crash mid-action must not
+replay the intent on the next poll). Intents older than STALE_SEC are consumed
+and dropped — an ancient file left by a dead executor must not fire a surprise
+restart when the app next boots.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+
+INTENT_BASENAME = "core-restart-requested.json"
+STALE_SEC = 600
+_ACTIONS = ("restart", "stop")
+
+# Owner chat commands → action. Exact-match after lowercase/strip so ordinary
+# prose mentioning a restart ("we should restart core tomorrow") never triggers.
+_COMMANDS = {
+    "restart core": "restart",
+    "restart the core": "restart",
+    "core restart": "restart",
+    "stop core": "stop",
+    "stop the core": "stop",
+    "core stop": "stop",
+}
+
+
+def parse_restart_command(text) -> str | None:
+    """Return "restart"/"stop" when ``text`` IS an owner restart command
+    (exact match modulo case/whitespace/trailing punctuation), else None."""
+    if not text:
+        return None
+    t = " ".join(text.lower().split()).rstrip(".!")
+    return _COMMANDS.get(t)
+
+
+def intent_path(workspace: str) -> str:
+    return os.path.join(workspace, "state", INTENT_BASENAME)
+
+
+def write_intent(workspace: str, action: str, source: str) -> str:
+    """Atomically write the intent file; returns its path. Raises ValueError
+    on an unknown action — callers never write arbitrary strings."""
+    if action not in _ACTIONS:
+        raise ValueError(f"unknown intent action: {action!r}")
+    path = intent_path(workspace)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump({"action": action, "requested_at": time.time(), "source": source}, f)
+    os.replace(tmp, path)
+    return path
+
+
+def consume_intent(workspace: str, now: float | None = None) -> str | None:
+    """Read-and-DELETE the intent; return its action, or None.
+
+    None when: no file, malformed JSON, unknown action, or stale
+    (requested_at older than STALE_SEC). All of those consume (delete) the
+    file too — a bad or ancient intent must never linger and re-fire.
+    """
+    path = intent_path(workspace)
+    try:
+        with open(path) as f:
+            raw = f.read()
+    except OSError:
+        return None
+    try:
+        os.unlink(path)  # consume FIRST — crash mid-action must not replay
+    except OSError:
+        pass
+    try:
+        d = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(d, dict) or d.get("action") not in _ACTIONS:
+        return None
+    age = (now if now is not None else time.time()) - float(d.get("requested_at") or 0)
+    if age > STALE_SEC:
+        return None
+    return d["action"]

--- a/src/core_restart_intent.py
+++ b/src/core_restart_intent.py
@@ -25,6 +25,11 @@ import json
 import os
 import time
 
+# Canonical workspace resolution (state-paths adoption lint): callers may pass
+# an explicit workspace (bridges already hold one; tests pass temp dirs), and
+# omitting it falls back to the resolver — never a hand-rolled path.
+from workspace_default import resolve_workspace
+
 INTENT_BASENAME = "core-restart-requested.json"
 STALE_SEC = 600
 _ACTIONS = ("restart", "stop")
@@ -50,11 +55,12 @@ def parse_restart_command(text) -> str | None:
     return _COMMANDS.get(t)
 
 
-def intent_path(workspace: str) -> str:
-    return os.path.join(workspace, "state", INTENT_BASENAME)
+def intent_path(workspace: str | None = None) -> str:
+    ws = workspace if workspace is not None else str(resolve_workspace())
+    return os.path.join(ws, "state", INTENT_BASENAME)
 
 
-def write_intent(workspace: str, action: str, source: str) -> str:
+def write_intent(workspace: str | None, action: str, source: str) -> str:
     """Atomically write the intent file; returns its path. Raises ValueError
     on an unknown action — callers never write arbitrary strings."""
     if action not in _ACTIONS:
@@ -68,7 +74,7 @@ def write_intent(workspace: str, action: str, source: str) -> str:
     return path
 
 
-def consume_intent(workspace: str, now: float | None = None) -> str | None:
+def consume_intent(workspace: str | None, now: float | None = None) -> str | None:
     """Read-and-DELETE the intent; return its action, or None.
 
     None when: no file, malformed JSON, unknown action, or stale

--- a/src/core_restart_intent.py
+++ b/src/core_restart_intent.py
@@ -15,8 +15,10 @@ File: <workspace>/state/core-restart-requested.json
 Schema: {"action": "restart"|"stop", "requested_at": <epoch>, "source": "..."}
 
 Consume semantics: read-and-delete BEFORE acting (a crash mid-action must not
-replay the intent on the next poll). Intents older than STALE_SEC are consumed
-and dropped — an ancient file left by a dead executor must not fire a surprise
+replay the intent on the next poll), and the delete must SUCCEED before any
+action — an undeletable file means the next poll would replay it, so the
+consumer fails closed and does nothing. Intents older than STALE_SEC are
+consumed and dropped — an ancient file left by a dead executor must not fire a surprise
 restart when the app next boots.
 """
 from __future__ import annotations
@@ -90,7 +92,10 @@ def consume_intent(workspace: str | None, now: float | None = None) -> str | Non
     try:
         os.unlink(path)  # consume FIRST — crash mid-action must not replay
     except OSError:
-        pass
+        # FAIL CLOSED (qingyun review, #2408): if the file can't be removed,
+        # the next 5s poll would see it again — acting now would replay the
+        # same restart every poll. No positive consume → no action.
+        return None
     try:
         d = json.loads(raw)
     except ValueError:

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -88,6 +88,7 @@ import local_task_protocol  # noqa: E402
 from task_body_guard import confine_user_content  # noqa: E402
 import progress_stream  # noqa: E402  — pure helpers for the progress-streamer (poll_progress)
 from vault_intercept import intercept_vault_commands, redact_vault_commands  # noqa: E402
+from core_restart_intent import parse_restart_command, write_intent  # noqa: E402
 from chat_secret_filter import filter_chat_secrets, secret_handling_instruction  # noqa: E402
 REPO = resolve_workspace()
 
@@ -3251,6 +3252,31 @@ async def _handle_discord_message(message, force=False):
     if access_tier != "owner" and TEAM_TIER_OWNER and LOCAL_MACHINE != TEAM_TIER_OWNER:
         print(f"  [tier-ownership] dropping {access_tier}-tier task from @{username} — owner is {TEAM_TIER_OWNER}, this node is {LOCAL_MACHINE or 'unknown'}")
         return
+
+    # Owner easy-restart command (sonichi#2401): "restart core" / "stop core"
+    # is handled by the BRIDGE, not the core — the whole point is that it works
+    # while the core is dead. Write the intent file for the GUI-session
+    # executor (Sutando.app poller) and ack; no task file is created. Owner
+    # tier only — never team/other, and parse is exact-match so prose that
+    # merely mentions restarting can't trigger it.
+    if text and access_tier == "owner":
+        _restart_action = parse_restart_command(text)
+        if _restart_action:
+            try:
+                write_intent(str(REPO), _restart_action, "discord")
+                _ack = ("Restart requested — the app will relaunch the core in a few "
+                        "seconds (authenticated, GUI session). I'll be back once it's up."
+                        if _restart_action == "restart" else
+                        "Stop requested — the app will stop the core in a few seconds. "
+                        "It stays stopped until you say `restart core`.")
+            except Exception as _ri_exc:
+                _ack = f"Couldn't write the {_restart_action} request ({type(_ri_exc).__name__}) — not queued."
+            print(f"  [core-restart] owner {_restart_action} command from @{username}", flush=True)
+            try:
+                await message.channel.send(_ack)
+            except Exception as _ri_send_exc:
+                print(f"  [core-restart] ack send failed: {_ri_send_exc}", flush=True)
+            return
 
     # Write as task
     ts = int(time.time() * 1000)

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2569,6 +2569,36 @@ def select_rulebook_key(access_tier, is_collaborator):
     return "team-collaborator" if is_collaborator else access_tier
 
 
+async def _handle_restart_command(message, text, access_tier, username, workspace) -> bool:
+    """Owner easy-restart command (sonichi#2401): "restart core" / "stop core"
+    is handled by the BRIDGE, not the core — the whole point is that it works
+    while the core is dead. Writes the intent file for the GUI-session
+    executor (Sutando.app poller) and acks in-channel; no task file. Returns
+    True when the message was a restart command (caller stops processing).
+    Owner tier only — never team/other — and parse is exact-match so prose
+    that merely mentions restarting can't trigger it."""
+    if not text or access_tier != "owner":
+        return False
+    action = parse_restart_command(text)
+    if not action:
+        return False
+    try:
+        write_intent(workspace, action, "discord")
+        ack = ("Restart requested — the app will relaunch the core in a few "
+               "seconds (authenticated, GUI session). I'll be back once it's up."
+               if action == "restart" else
+               "Stop requested — the app will stop the core in a few seconds. "
+               "It stays stopped until you say `restart core`.")
+    except Exception as exc:
+        ack = f"Couldn't write the {action} request ({type(exc).__name__}) — not queued."
+    print(f"  [core-restart] owner {action} command from @{username}", flush=True)
+    try:
+        await message.channel.send(ack)
+    except Exception as send_exc:
+        print(f"  [core-restart] ack send failed: {send_exc}", flush=True)
+    return True
+
+
 async def _handle_discord_message(message, force=False):
     if message.author == client.user:
         return
@@ -3253,30 +3283,9 @@ async def _handle_discord_message(message, force=False):
         print(f"  [tier-ownership] dropping {access_tier}-tier task from @{username} — owner is {TEAM_TIER_OWNER}, this node is {LOCAL_MACHINE or 'unknown'}")
         return
 
-    # Owner easy-restart command (sonichi#2401): "restart core" / "stop core"
-    # is handled by the BRIDGE, not the core — the whole point is that it works
-    # while the core is dead. Write the intent file for the GUI-session
-    # executor (Sutando.app poller) and ack; no task file is created. Owner
-    # tier only — never team/other, and parse is exact-match so prose that
-    # merely mentions restarting can't trigger it.
-    if text and access_tier == "owner":
-        _restart_action = parse_restart_command(text)
-        if _restart_action:
-            try:
-                write_intent(str(REPO), _restart_action, "discord")
-                _ack = ("Restart requested — the app will relaunch the core in a few "
-                        "seconds (authenticated, GUI session). I'll be back once it's up."
-                        if _restart_action == "restart" else
-                        "Stop requested — the app will stop the core in a few seconds. "
-                        "It stays stopped until you say `restart core`.")
-            except Exception as _ri_exc:
-                _ack = f"Couldn't write the {_restart_action} request ({type(_ri_exc).__name__}) — not queued."
-            print(f"  [core-restart] owner {_restart_action} command from @{username}", flush=True)
-            try:
-                await message.channel.send(_ack)
-            except Exception as _ri_send_exc:
-                print(f"  [core-restart] ack send failed: {_ri_send_exc}", flush=True)
-            return
+    # Owner easy-restart command (sonichi#2401) — see _handle_restart_command.
+    if await _handle_restart_command(message, text, access_tier, username, str(REPO)):
+        return
 
     # Write as task
     ts = int(time.time() * 1000)

--- a/tests/bridge-restart-intercept.test.py
+++ b/tests/bridge-restart-intercept.test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Tests for discord-bridge's owner easy-restart intercept (sonichi#2401,
+PR #2408): `_handle_restart_command` — the bridge-side seam of the
+chat-triggered restart. Hermetic real-module import (discord SDK stubbed,
+temp workspace via SUTANDO_TEST_MODE) per the bridge-audit-wiring pattern,
+so the production lines execute under the diff-coverage gate.
+
+Covers: owner command → intent written + ack sent + True (handled);
+non-command prose → False; team tier → False (never writes); write failure
+→ error ack, still handled; ack-send failure swallowed (bridge never
+crashes on a Discord hiccup).
+
+Run: python3 tests/bridge-restart-intercept.test.py
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+_WS = tempfile.mkdtemp()
+os.environ["SUTANDO_WORKSPACE"] = _WS
+os.environ["SUTANDO_TEST_MODE"] = "1"
+os.environ["DISCORD_BOT_TOKEN"] = "test-token-not-real"
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + name + ((" — " + detail) if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+# Stub `discord` so module load needs no SDK/network (bridge-audit-wiring recipe).
+try:
+    import discord  # noqa: F401
+except ImportError:
+    stub = types.ModuleType("discord")
+    stub.Intents = type("Intents", (), {"default": staticmethod(
+        lambda: type("I", (), {"message_content": False})())})
+    stub.Client = type("Client", (), {"__init__": lambda self, **kw: None,
+                                      "event": staticmethod(lambda fn: fn)})
+    stub.File = type("File", (), {})
+    stub.Message = type("Message", (), {})
+    stub.DMChannel = type("DMChannel", (), {})
+    sys.modules["discord"] = stub
+
+spec = importlib.util.spec_from_file_location("dbridge_restart", REPO / "src" / "discord-bridge.py")
+db = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(db)
+
+
+class _Chan:
+    def __init__(self, fail=False):
+        self.sent, self.fail = [], fail
+
+    async def send(self, text):
+        if self.fail:
+            raise RuntimeError("discord hiccup")
+        self.sent.append(text)
+
+
+class _Msg:
+    def __init__(self, chan):
+        self.channel = chan
+
+
+def _run(text, tier="owner", ws=None, chan=None):
+    chan = chan if chan is not None else _Chan()
+    handled = asyncio.run(
+        db._handle_restart_command(_Msg(chan), text, tier, "tester", ws or tempfile.mkdtemp()))
+    return handled, chan
+
+
+# --- owner restart command: intent written, ack sent, handled ---
+ws = tempfile.mkdtemp()
+handled, chan = _run("restart core", ws=ws)
+intent_file = os.path.join(ws, "state", "core-restart-requested.json")
+check("owner 'restart core' → handled=True", handled is True)
+check("intent file written with action=restart",
+      os.path.exists(intent_file) and json.load(open(intent_file))["action"] == "restart",
+      intent_file)
+check("ack sent mentions relaunch", len(chan.sent) == 1 and "Restart requested" in chan.sent[0])
+
+# --- owner stop command ---
+ws2 = tempfile.mkdtemp()
+handled, chan = _run("Stop core.", ws=ws2)
+check("owner 'Stop core.' → handled + action=stop",
+      handled and json.load(open(os.path.join(ws2, "state", "core-restart-requested.json")))["action"] == "stop")
+check("stop ack says stays stopped", "stays stopped" in chan.sent[0])
+
+# --- prose and non-owner never trigger ---
+handled, chan = _run("we should restart core tomorrow")
+check("prose → handled=False, nothing sent", handled is False and chan.sent == [])
+ws3 = tempfile.mkdtemp()
+handled, chan = _run("restart core", tier="team", ws=ws3)
+check("team tier → handled=False, no intent written",
+      handled is False and not os.path.exists(os.path.join(ws3, "state", "core-restart-requested.json")))
+handled, chan = _run("", ws=tempfile.mkdtemp())
+check("empty text → handled=False", handled is False)
+
+# --- write failure → error ack, still handled (no task-file fallthrough) ---
+ro = tempfile.mkdtemp()
+blocker = os.path.join(ro, "state")
+open(blocker, "w").close()  # 'state' exists as a FILE → makedirs raises
+handled, chan = _run("restart core", ws=ro)
+check("write failure → still handled, error ack",
+      handled is True and len(chan.sent) == 1 and "Couldn't write" in chan.sent[0], str(chan.sent))
+
+# --- ack-send failure swallowed ---
+ws4 = tempfile.mkdtemp()
+handled, chan = _run("restart core", ws=ws4, chan=_Chan(fail=True))
+check("ack send failure swallowed, still handled + intent written",
+      handled is True and os.path.exists(os.path.join(ws4, "state", "core-restart-requested.json")))
+
+print()
+if failures:
+    print(f"{len(failures)} check(s) FAILED: {failures}")
+    sys.exit(1)
+print("all checks passed — bridge restart intercept")

--- a/tests/core-restart-intent.test.py
+++ b/tests/core-restart-intent.test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for src/core_restart_intent.py — the easy-restart intent hand-off
+(sonichi#2401): owner chat command parsing (exact-match, no prose triggers),
+atomic write, consume-before-act semantics, and the stale/malformed drops
+that keep an ancient or corrupt intent from firing a surprise restart.
+
+Run: python3 tests/core-restart-intent.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import time
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.join(_HERE, "..", "src", "core_restart_intent.py")
+_spec = importlib.util.spec_from_file_location("core_restart_intent", _SRC)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+class TestParseRestartCommand(unittest.TestCase):
+    def test_commands_match(self):
+        for text, action in [("restart core", "restart"), ("Restart Core", "restart"),
+                             ("  restart the core  ", "restart"), ("core restart", "restart"),
+                             ("restart core!", "restart"), ("stop core", "stop"),
+                             ("Stop the core.", "stop"), ("core stop", "stop")]:
+            self.assertEqual(_mod.parse_restart_command(text), action, text)
+
+    def test_prose_never_triggers(self):
+        for text in ["we should restart core tomorrow", "the restart core question",
+                     "restart", "core", "restart the core when convenient",
+                     "please restart core now", "", None]:
+            self.assertIsNone(_mod.parse_restart_command(text), repr(text))
+
+
+class TestWriteConsume(unittest.TestCase):
+    def test_roundtrip_restart(self):
+        with tempfile.TemporaryDirectory() as ws:
+            p = _mod.write_intent(ws, "restart", "test")
+            self.assertTrue(os.path.exists(p))
+            self.assertEqual(_mod.consume_intent(ws), "restart")
+            self.assertFalse(os.path.exists(p))  # consumed = deleted
+
+    def test_consume_is_once(self):
+        with tempfile.TemporaryDirectory() as ws:
+            _mod.write_intent(ws, "stop", "test")
+            self.assertEqual(_mod.consume_intent(ws), "stop")
+            self.assertIsNone(_mod.consume_intent(ws))  # replay impossible
+
+    def test_no_file_is_none(self):
+        with tempfile.TemporaryDirectory() as ws:
+            self.assertIsNone(_mod.consume_intent(ws))
+
+    def test_unknown_action_rejected_at_write(self):
+        with tempfile.TemporaryDirectory() as ws:
+            with self.assertRaises(ValueError):
+                _mod.write_intent(ws, "reboot-the-universe", "test")
+
+    def test_stale_intent_dropped_and_consumed(self):
+        with tempfile.TemporaryDirectory() as ws:
+            p = _mod.write_intent(ws, "restart", "test")
+            self.assertIsNone(_mod.consume_intent(ws, now=time.time() + _mod.STALE_SEC + 1))
+            self.assertFalse(os.path.exists(p))  # stale file still consumed
+
+    def test_malformed_json_dropped_and_consumed(self):
+        with tempfile.TemporaryDirectory() as ws:
+            p = _mod.intent_path(ws)
+            os.makedirs(os.path.dirname(p))
+            with open(p, "w") as f:
+                f.write("{not json")
+            self.assertIsNone(_mod.consume_intent(ws))
+            self.assertFalse(os.path.exists(p))
+
+    def test_unknown_action_in_file_dropped(self):
+        with tempfile.TemporaryDirectory() as ws:
+            p = _mod.intent_path(ws)
+            os.makedirs(os.path.dirname(p))
+            with open(p, "w") as f:
+                json.dump({"action": "explode", "requested_at": time.time()}, f)
+            self.assertIsNone(_mod.consume_intent(ws))
+
+    def test_non_dict_payload_dropped(self):
+        with tempfile.TemporaryDirectory() as ws:
+            p = _mod.intent_path(ws)
+            os.makedirs(os.path.dirname(p))
+            with open(p, "w") as f:
+                json.dump(["restart"], f)
+            self.assertIsNone(_mod.consume_intent(ws))
+
+    def test_missing_requested_at_is_stale(self):
+        with tempfile.TemporaryDirectory() as ws:
+            p = _mod.intent_path(ws)
+            os.makedirs(os.path.dirname(p))
+            with open(p, "w") as f:
+                json.dump({"action": "restart"}, f)  # requested_at absent → epoch 0 → stale
+            self.assertIsNone(_mod.consume_intent(ws))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/core-restart-intent.test.py
+++ b/tests/core-restart-intent.test.py
@@ -93,6 +93,18 @@ class TestWriteConsume(unittest.TestCase):
                 json.dump(["restart"], f)
             self.assertIsNone(_mod.consume_intent(ws))
 
+    def test_unlink_failure_still_returns_action(self):
+        # Consume-first delete failing (e.g. permissions race) must not lose
+        # the action — the read already succeeded; delete is best-effort.
+        with tempfile.TemporaryDirectory() as ws:
+            _mod.write_intent(ws, "restart", "test")
+            orig = os.unlink
+            os.unlink = lambda p: (_ for _ in ()).throw(OSError("locked"))
+            try:
+                self.assertEqual(_mod.consume_intent(ws), "restart")
+            finally:
+                os.unlink = orig
+
     def test_missing_requested_at_is_stale(self):
         with tempfile.TemporaryDirectory() as ws:
             p = _mod.intent_path(ws)

--- a/tests/core-restart-intent.test.py
+++ b/tests/core-restart-intent.test.py
@@ -93,17 +93,23 @@ class TestWriteConsume(unittest.TestCase):
                 json.dump(["restart"], f)
             self.assertIsNone(_mod.consume_intent(ws))
 
-    def test_unlink_failure_still_returns_action(self):
-        # Consume-first delete failing (e.g. permissions race) must not lose
-        # the action — the read already succeeded; delete is best-effort.
+    def test_unlink_failure_fails_closed(self):
+        # qingyun #2408 P1: if the delete fails, the file survives and the
+        # next 5s poll would replay the same action — a restart LOOP. No
+        # positive consume → NO action, ever.
         with tempfile.TemporaryDirectory() as ws:
-            _mod.write_intent(ws, "restart", "test")
+            p = _mod.write_intent(ws, "restart", "test")
             orig = os.unlink
-            os.unlink = lambda p: (_ for _ in ()).throw(OSError("locked"))
+            os.unlink = lambda pth: (_ for _ in ()).throw(OSError("locked"))
             try:
-                self.assertEqual(_mod.consume_intent(ws), "restart")
+                self.assertIsNone(_mod.consume_intent(ws))   # fail closed
+                self.assertIsNone(_mod.consume_intent(ws))   # and stays closed
             finally:
                 os.unlink = orig
+            self.assertTrue(os.path.exists(p))  # file intact for manual removal
+            # once deletable again, the (non-stale) intent acts exactly once
+            self.assertEqual(_mod.consume_intent(ws), "restart")
+            self.assertIsNone(_mod.consume_intent(ws))
 
     def test_missing_requested_at_is_stale(self):
         with tempfile.TemporaryDirectory() as ws:

--- a/tests/core-restart-intent.test.py
+++ b/tests/core-restart-intent.test.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import sys
 import tempfile
 import time
 import unittest
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))  # sibling workspace_default import
 _SRC = os.path.join(_HERE, "..", "src", "core_restart_intent.py")
 _spec = importlib.util.spec_from_file_location("core_restart_intent", _SRC)
 _mod = importlib.util.module_from_spec(_spec)

--- a/tests/stop-core.test.sh
+++ b/tests/stop-core.test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Tests for src/agent/stop-core.sh — exact-selector + session-env contract
+# (john-the-dev review on #2408: prefix matching killed sutando-core-debug;
+# SUTANDO_TMUX_SESSION was ignored). Runs real tmux on an ISOLATED private
+# socket; skips cleanly (exit 0) when tmux is unavailable.
+#
+# Run: bash tests/stop-core.test.sh   (exit 0 pass/skip, 1 fail)
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO/src/agent/stop-core.sh"
+command -v tmux >/dev/null 2>&1 || { echo "SKIP: tmux not available"; exit 0; }
+
+SOCK="$(mktemp -d)/t.sock"
+fails=0
+say() { echo "$1  $2"; [ "$1" = "FAIL" ] && fails=$((fails+1)); }
+cleanup() { tmux -S "$SOCK" kill-server 2>/dev/null; }
+trap cleanup EXIT
+
+# --- 1. prefix-survival: only sutando-core-debug exists → script must NOT
+#        match it, must report nothing-to-stop, and the session must survive.
+tmux -S "$SOCK" new-session -d -s sutando-core-debug sleep 60
+out="$(SUTANDO_TMUX_SOCKET="$SOCK" bash "$SCRIPT" 2>&1)"; rc=$?
+if [ $rc -eq 0 ] && echo "$out" | grep -q "nothing to stop" \
+   && tmux -S "$SOCK" has-session -t "=sutando-core-debug" 2>/dev/null; then
+  say ok "prefix session survives; script reports nothing-to-stop"
+else
+  say FAIL "prefix session: rc=$rc out=$out"
+fi
+
+# --- 2. exact stop: sutando-core AND sutando-core-debug both exist → script
+#        kills exactly sutando-core; the debug sibling survives.
+tmux -S "$SOCK" new-session -d -s sutando-core sleep 60
+out="$(SUTANDO_TMUX_SOCKET="$SOCK" bash "$SCRIPT" 2>&1)"; rc=$?
+if [ $rc -eq 0 ] && ! tmux -S "$SOCK" has-session -t "=sutando-core" 2>/dev/null \
+   && tmux -S "$SOCK" has-session -t "=sutando-core-debug" 2>/dev/null; then
+  say ok "kills exactly sutando-core; debug sibling survives"
+else
+  say FAIL "exact stop: rc=$rc out=$out"
+fi
+
+# --- 3. SUTANDO_TMUX_SESSION honored (launcher contract parity): custom-core
+#        configured → script stops it.
+tmux -S "$SOCK" new-session -d -s custom-core sleep 60
+out="$(SUTANDO_TMUX_SOCKET="$SOCK" SUTANDO_TMUX_SESSION=custom-core bash "$SCRIPT" 2>&1)"; rc=$?
+if [ $rc -eq 0 ] && ! tmux -S "$SOCK" has-session -t "=custom-core" 2>/dev/null; then
+  say ok "SUTANDO_TMUX_SESSION=custom-core is stopped"
+else
+  say FAIL "custom session: rc=$rc out=$out"
+fi
+
+# --- 4. watcher sibling cleanup: sutando-core + sutando-core-watcher →
+#        both killed; unrelated debug session still survives.
+tmux -S "$SOCK" new-session -d -s sutando-core sleep 60
+tmux -S "$SOCK" new-session -d -s sutando-core-watcher sleep 60
+out="$(SUTANDO_TMUX_SOCKET="$SOCK" bash "$SCRIPT" 2>&1)"; rc=$?
+if [ $rc -eq 0 ] && ! tmux -S "$SOCK" has-session -t "=sutando-core" 2>/dev/null \
+   && ! tmux -S "$SOCK" has-session -t "=sutando-core-watcher" 2>/dev/null \
+   && tmux -S "$SOCK" has-session -t "=sutando-core-debug" 2>/dev/null; then
+  say ok "watcher sibling killed with core; debug survives"
+else
+  say FAIL "watcher cleanup: rc=$rc out=$out"
+fi
+
+echo
+if [ $fails -gt 0 ]; then echo "$fails test(s) FAILED"; exit 1; fi
+echo "all tests passed — stop-core exact-selector contract"


### PR DESCRIPTION
## What (owner-confirmed scope on #2401: easy restart, human-triggered, stop means stop)

1. **Menu**: new **"Stop Core CLI"** item beside the existing Restart Core CLI — core-only stop via new `src/agent/stop-core.sh` (kills only the `sutando-core` tmux session + its watcher sibling; bridges/dashboard/proxy keep running; idempotent). Nothing anywhere relaunches a stopped core.
2. **Chat**: owner-tier DM `restart core` / `stop core` (exact-match, prose-safe) is intercepted by the **bridge** — the component that survives core death, which is exactly when this matters — writing `<workspace>/state/core-restart-requested.json` via new `src/core_restart_intent.py` and acking in-channel. No task file, so it works with the core dead.
3. **Executor**: Sutando.app polls the intent file every 5s and performs the action **in the GUI login session**, so the relaunch comes up authenticated — the 2026-07-29 outage's SSH/keychain/Terminal dance becomes one chat message.

## Intent-file semantics (the safety core)

Atomic write · **consume-before-act** (a crash mid-action can never replay a restart) · consume-once (second poll = no-op) · stale intents (>600s) and malformed/unknown payloads consumed-and-dropped (an ancient file can't fire a surprise restart at app boot). Swift consume mirrors the Python module exactly.

## Evidence

`tests/core-restart-intent.test.py` — 11/11 (in-process): exact-match parsing incl. prose-never-triggers, write/consume round-trip, consume-once, stale/malformed/unknown/non-dict drops, unknown-action write rejection.

Module round-trip transcript (temp workspace):
```
owner types 'Restart core!': parsed → restart
bridge wrote: core-restart-requested.json {'action': 'restart', 'requested_at': ..., 'source': 'discord'}
app poll #1 consumes → restart | file exists after: False
app poll #2 (replay check) → None
prose 'we should restart core tomorrow' → None
```

Swift: full `swiftc -O` compile with the repo's exact startup.sh flags — clean. Bridge: py_compile clean; intercept is 20 lines placed at the same pre-task-write point as the vault intercept, owner-tier only.

**Live-path caveat (named, not hidden):** the full chat→bridge→app→relaunch round trip requires the merged bridge + rebuilt app running as the live services — I can't restart my own live bridge onto a branch checkout to demo it (that's the never-run-services-off-a-PR-branch rule). Committed follow-through: immediately after merge + service restart on the Pro node, I'll run the real `restart core` DM round trip and post the transcript on this PR. Until then the live chain is verified at the seam level above.

## Worst-case disruption

- Bridge intercept is **owner-tier + exact-match only**: team/other tiers can never reach it; the only false positive is the owner sending literally "restart core" while meaning prose — and the effect is a visible ack + a restart he can decline to repeat, never silent.
- The poller consumes only `<workspace>/state/core-restart-requested.json`; no file → pure no-op every 5s (one stat call). Existing installs without the new bridge simply never have the file.
- `stop-core.sh` touches exactly the `sutando-core`/`sutando-core-watcher` tmux sessions; exits 0 when absent.
- No config, no migration, no new deps; `docs/src-map.md` regenerated for the new module.

## Relationship

Implements the redirected #2401 (owner: "we just need an easy way to restart the core cli"). Composes with Mini's #2405 auth-preflight (the executor can gate on it later) and #2403 (alert copy pointing at restart.sh). Not stacked — based on main `e43781d7`.

cc @sonichi — this is the "y"-confirmed build from tonight's thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rq18tfPmFcgzHQFgoSpsUN