### PR TITLE
test(github-webhook): disable telemetry in the access-tier suite

### DIFF
--- a/tests/github-webhook-access-tier.test.py
+++ b/tests/github-webhook-access-tier.test.py
@@ -21,6 +21,30 @@ Exit: 0 on pass, 1 on fail.
 
 from __future__ import annotations
 
+import os
+
+# This suite drives real task-accept handlers but does not test telemetry. Keep it
+# hermetic: since #2274 the task-accepting paths emit `task_processed`, and
+# `src/github-webhook.py:_emit_github_telemetry()` lazily imports it. With
+# flush=False the production emitter starts a DAEMON urllib thread, which can still
+# be inside OpenSSL while this short-lived interpreter finalizes — observed in
+# clean-install CI as `double free or corruption (out)` + SIGSEGV AFTER the suite
+# reports `31/31 passed`. A CI runner has no telemetry opt-out marker, so
+# `enabled()` is True there.
+#
+# Same fix and same reason as #2388, which did this for
+# tests/agent-api-task-field-injection.test.py. That PR closed exactly one suite;
+# this is a second suite with the identical mechanism.
+#
+# Set BEFORE the regular imports so nothing can import `telemetry` first, and after
+# `from __future__` because that must lead the file.
+#
+# Verified locally that this is the right lever — macOS cannot reproduce the glibc
+# double-free, so the CRASH is not reproducible here, only its cause:
+#   SUTANDO_TELEMETRY unset -> enabled()=True,  task_processed spawns 1 thread
+#   SUTANDO_TELEMETRY=0     -> enabled()=False, task_processed spawns 0 threads
+os.environ["SUTANDO_TELEMETRY"] = "0"
+
 import hashlib
 import hmac
 import importlib.util


### PR DESCRIPTION
`main` currently paints `tsc + tests (clean install)` red on every PR based on it. **Nothing under test is broken** — it is a post-success interpreter crash:

```
github-webhook-access-tier: 31/31 passed
double free or corruption (out)
Segmentation fault (core dumped)
##[error]Process completed with exit code 1.
```

Every test passes, then the process segfaults during interpreter *teardown*.

## Mechanism

Diagnosed by @liususan091219 (on an unrelated PR whose red she traced to this). Since #2274 the task-accepting paths emit `task_processed`, and `src/github-webhook.py:_emit_github_telemetry()` lazily imports it. With `flush=False` the production emitter starts a **daemon urllib thread**, which can still be inside OpenSSL while this short-lived interpreter finalizes. A CI runner has no telemetry opt-out marker, so `enabled()` is True there.

**#2388 fixed exactly one suite this way** (`tests/agent-api-task-field-injection.test.py`). This is a **second suite with the identical mechanism** — same one-line lever, so the two stay consistent. No open PR covers it; I checked the telemetry/webhook PRs (#2367, #2366, #2165, #2148) and closed ones before writing this.

## What is and is not verified — stated separately

**Not reproducible on macOS.** The glibc double-free does not occur there, so **I cannot show the crash stopping.** Saying that plainly rather than implying otherwise.

What **is** verified is the precondition the crash requires, and that this change removes it. Running the real suite under a probe that inspects threads at interpreter exit, on current `main` (`3e1dd21e`):

```
unpatched:  telemetry_env=None  lingering_threads=['Thread-1']
patched:    telemetry_env=0     lingering_threads=[]
```

And the lever itself:

```
SUTANDO_TELEMETRY unset -> enabled()=True,  task_processed spawns 1 thread
SUTANDO_TELEMETRY=0     -> enabled()=False, task_processed spawns 0 threads
```

So a live daemon thread survives to finalization without this and does not with it. That is the documented cause, eliminated. The crash itself only Linux CI can confirm — **this PR's own run is that confirmation**, so please read the check result here as the real evidence.

Bug confirmed still present on `main` before opening: `lingering_threads=['Thread-1']`, and `grep -c SUTANDO_TELEMETRY tests/github-webhook-access-tier.test.py` on `main` = **0**.

## Scope

One file, test-only, insertions only. Suite still `31/31 passed`. Placed after `from __future__ import annotations` (which must lead the file) and before every regular import, so nothing can import `telemetry` first.

## Why it is worth landing

It does **not** gate merges — `tsc + tests (clean install)` is not a required check (required = `license/cla` + the CLAUDE_CONFIG_DIR guard). But it paints CI red on every `main`-based PR, so the cost falls on everyone reading those checks rather than on any one author.