### PR TITLE
feat(youtube-live): new skill — stream a source to YouTube Live via ffmpeg RTMP

### DIFF
--- a/skills/youtube-live/SKILL.md
+++ b/skills/youtube-live/SKILL.md
@@ -40,7 +40,11 @@ python3 skills/youtube-live/scripts/go_live.py start --source test --dry-run
 
 That's all the skill needs to go live. The key is read as
 `--stream-key` > `$YOUTUBE_STREAM_KEY` > vault `YOUTUBE_STREAM_KEY`, and is
-**never printed** — logs and the `--dry-run` command are redacted to `<STREAM_KEY>`.
+**never printed** — the `--dry-run` command and the `ffmpeg_stderr` failure
+diagnostics are redacted to `<STREAM_KEY>` before anything reaches stdout.
+Known limitation: the raw ffmpeg log at `<workspace>/state/youtube-live.ffmpeg.log`
+retains unredacted output at rest (the state dir is `0700`, owner-only); scrub or
+delete it if you share diagnostics from that file directly.
 
 ## Sources
 

--- a/skills/youtube-live/SKILL.md
+++ b/skills/youtube-live/SKILL.md
@@ -1,0 +1,65 @@
+# YouTube Live
+
+Stream a source to **YouTube Live** over RTMP using `ffmpeg`. No camera or Google
+API call is required for a basic broadcast — a persistent YouTube **stream key**
+(plus auto-start enabled on the stream) is enough to go live.
+
+**Usage**: `/youtube-live start [--source ...]` · `/youtube-live stop` · `/youtube-live status`
+
+## On activation
+
+```bash
+# Go live with a test pattern + tone (no assets/camera — best for a first e2e test):
+python3 skills/youtube-live/scripts/go_live.py start --source test
+
+# Other sources:
+python3 skills/youtube-live/scripts/go_live.py start --source file:/path/clip.mp4 --loop
+python3 skills/youtube-live/scripts/go_live.py start --source image:/path/slate.png
+python3 skills/youtube-live/scripts/go_live.py start --source screen
+
+python3 skills/youtube-live/scripts/go_live.py stop
+python3 skills/youtube-live/scripts/go_live.py status
+
+# See the exact ffmpeg command without streaming (key redacted):
+python3 skills/youtube-live/scripts/go_live.py start --source test --dry-run
+```
+
+## Enabling it (one-time setup)
+
+1. On the YouTube channel you want to stream to, enable live streaming
+   (studio.youtube.com → **Create → Go live**; first-time activation can take ~24h).
+2. Create a stream and copy its **Stream key** (Studio → Go live → **Stream** tab →
+   *Stream key*). Enable **auto-start / auto-stop** on that stream so pushing the
+   RTMP feed goes live automatically.
+3. Store the key in the vault (never on disk):
+   ```
+   vault set YOUTUBE_STREAM_KEY <your-stream-key>
+   ```
+   Send that via the Slack/Discord `vault set …` path — the bridge intercepts it
+   into macOS Keychain before it touches disk.
+
+That's all the skill needs to go live. The key is read as
+`--stream-key` > `$YOUTUBE_STREAM_KEY` > vault `YOUTUBE_STREAM_KEY`, and is
+**never printed** — logs and the `--dry-run` command are redacted to `<STREAM_KEY>`.
+
+## Sources
+
+| `--source`      | What it streams                                              |
+| --------------- | ----------------------------------------------------------- |
+| `test`          | `lavfi` test pattern + 1 kHz tone. No assets — ideal for e2e |
+| `file:<path>`   | A media file (`--loop` to repeat forever)                   |
+| `image:<path>`  | A static image "slate" + silent audio                       |
+| `screen`        | macOS `avfoundation` screen capture (+ default audio)       |
+
+Encoding is fixed to YouTube-compatible H.264 + AAC; resolution/fps/bitrate come
+from the manifest `config` block (override via env, e.g. `YOUTUBE_INGEST_BASE`).
+
+## Notes / limitations (v0.1)
+
+- **Stream-key MVP only.** This drives the RTMP push. Programmatic broadcast
+  lifecycle (create/schedule/transition/end via the **YouTube Live Streaming API**,
+  OAuth `youtube.force-ssl`) is a planned follow-up — it would let the skill
+  create and end broadcasts without touching Studio. Filed as a TODO in the PR.
+- macOS `screen` capture needs Screen Recording permission for the launching app.
+- If the YouTube stream shows "offline" while ffmpeg is pushing, auto-start isn't
+  enabled — either enable it on the stream or click **Go live** in Studio.

--- a/skills/youtube-live/manifest.json
+++ b/skills/youtube-live/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "youtube-live",
+  "version": "0.1.0",
+  "owner": "github:sonichi/sutando",
+  "license": "MIT",
+  "stability": "experimental",
+  "description": "Stream a source (test pattern, media file, image slate, or screen) to YouTube Live over RTMP via ffmpeg.",
+  "provenance": {
+    "source_repo": "https://github.com/sonichi/sutando"
+  },
+  "config": {
+    "ingest_base": "rtmp://a.rtmp.youtube.com/live2",
+    "resolution": "1280x720",
+    "fps": 30,
+    "video_bitrate": "4500k",
+    "audio_bitrate": "128k",
+    "buffer_size": "9000k",
+    "avf_screen_spec": "1:0"
+  }
+}

--- a/skills/youtube-live/scripts/go_live.py
+++ b/skills/youtube-live/scripts/go_live.py
@@ -42,17 +42,14 @@ def _log(event, **kw):
 
 
 def _ffmpeg_bin():
-    """Resolve the ffmpeg binary robustly across hosts (Homebrew arm/intel, PATH)."""
-    for cand in ("ffmpeg", "/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg"):
-        found = shutil.which(cand) if "/" not in cand else (cand if os.path.exists(cand) else None)
-        if found:
-            return found
-    return None
+    """Resolve the ffmpeg binary from PATH (Homebrew installs land on PATH)."""
+    return shutil.which("ffmpeg")
 
 
 def _load_manifest_config():
     """Read the skill manifest's `config` block for defaults (bitrate, resolution, etc.)."""
-    manifest = Path(__file__).resolve().parent.parent / "manifest.json"
+    # manifest.json sits one level up from this scripts/ dir (the skill root).
+    manifest = Path(__file__).resolve().parents[1] / "manifest.json"
     try:
         data = json.loads(manifest.read_text())
         return data.get("config", {}) or {}

--- a/skills/youtube-live/scripts/go_live.py
+++ b/skills/youtube-live/scripts/go_live.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Stream a source to YouTube Live over RTMP via ffmpeg.
+
+MVP: push a chosen source to YouTube's RTMP ingest using a stream key.
+No Google API call is required for a basic broadcast — a persistent
+YouTube "stream key" plus auto-start enabled on the stream is enough to go
+live. (Programmatic broadcast lifecycle via the YouTube Live Streaming API is
+a documented follow-up; see SKILL.md.)
+
+Commands:
+    start   Begin streaming (backgrounds ffmpeg, writes a PID file).
+    stop    Stop the running stream.
+    status  Report whether a stream is running.
+
+Sources (--source):
+    test              lavfi test pattern + 1 kHz tone (no assets/camera needed — best for e2e).
+    file:<path>       stream a media file (add --loop to repeat).
+    image:<path>      a static image "slate" + silent audio.
+    screen            macOS avfoundation screen capture (+ default audio if present).
+
+The stream key is read with this precedence (per skills/MANIFEST.md):
+    --stream-key  >  $YOUTUBE_STREAM_KEY  >  vault YOUTUBE_STREAM_KEY
+The key is NEVER printed — logs and the ffmpeg command are redacted.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+PID_FILE = "/tmp/sutando-youtube-live.pid"
+DEFAULT_INGEST_BASE = "rtmp://a.rtmp.youtube.com/live2"
+_REDACTION = "<STREAM_KEY>"
+
+
+def _log(event, **kw):
+    print(json.dumps({"_log": event, **kw}), file=sys.stderr)
+
+
+def _ffmpeg_bin():
+    """Resolve the ffmpeg binary robustly across hosts (Homebrew arm/intel, PATH)."""
+    for cand in ("ffmpeg", "/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg"):
+        found = shutil.which(cand) if "/" not in cand else (cand if os.path.exists(cand) else None)
+        if found:
+            return found
+    return None
+
+
+def _load_manifest_config():
+    """Read the skill manifest's `config` block for defaults (bitrate, resolution, etc.)."""
+    manifest = Path(__file__).resolve().parent.parent / "manifest.json"
+    try:
+        data = json.loads(manifest.read_text())
+        return data.get("config", {}) or {}
+    except Exception:
+        return {}
+
+
+def _resolve_stream_key(cli_key):
+    """CLI > env > vault. Returns the key string or None (never logs it)."""
+    if cli_key:
+        return cli_key
+    env_key = os.environ.get("YOUTUBE_STREAM_KEY")
+    if env_key:
+        return env_key
+    # Vault is optional at import time — only reach for it if needed.
+    try:
+        repo = next(
+            p for p in Path(__file__).resolve().parents
+            if (p / "src" / "vault_intercept.py").is_file()
+        )
+        sys.path.insert(0, str(repo / "src"))
+        from vault_intercept import get_vault_key  # type: ignore
+        return get_vault_key("YOUTUBE_STREAM_KEY")
+    except (StopIteration, KeyError, ImportError):
+        return None
+
+
+def build_ffmpeg_cmd(source, stream_key, cfg, ingest_base=DEFAULT_INGEST_BASE, loop=False):
+    """Construct the ffmpeg argv for a source. `stream_key` may be the redaction
+    placeholder for dry-run/printing. Returns a list[str]."""
+    ffmpeg = _ffmpeg_bin() or "ffmpeg"
+    res = str(cfg.get("resolution", "1280x720"))
+    fps = str(cfg.get("fps", 30))
+    vbitrate = str(cfg.get("video_bitrate", "4500k"))
+    abitrate = str(cfg.get("audio_bitrate", "128k"))
+    # YouTube wants a keyframe every ~2s → gop = 2 * fps.
+    gop = str(int(float(fps)) * 2)
+
+    cmd = [ffmpeg, "-hide_banner", "-loglevel", "warning"]
+
+    if source == "test":
+        cmd += ["-re", "-f", "lavfi", "-i", f"testsrc2=size={res}:rate={fps}",
+                "-f", "lavfi", "-i", "sine=frequency=1000:sample_rate=44100"]
+    elif source.startswith("file:"):
+        path = source[len("file:"):]
+        if loop:
+            cmd += ["-stream_loop", "-1"]
+        cmd += ["-re", "-i", path]
+    elif source.startswith("image:"):
+        path = source[len("image:"):]
+        cmd += ["-loop", "1", "-framerate", fps, "-i", path,
+                "-f", "lavfi", "-i", "anullsrc=channel_layout=stereo:sample_rate=44100"]
+    elif source == "screen":
+        # macOS avfoundation: "<video_index>:<audio_index>". "1:0" = main display + default mic;
+        # ":none" style is not portable, so callers without audio should pass --source test.
+        screen_spec = str(cfg.get("avf_screen_spec", "1:0"))
+        cmd += ["-f", "avfoundation", "-framerate", fps, "-i", screen_spec]
+    else:
+        raise ValueError(f"unknown source: {source!r}")
+
+    # Encode: H.264 + AAC, YouTube-compatible.
+    cmd += [
+        "-c:v", "libx264", "-preset", "veryfast", "-pix_fmt", "yuv420p",
+        "-b:v", vbitrate, "-maxrate", vbitrate, "-bufsize", str(cfg.get("buffer_size", "9000k")),
+        "-g", gop, "-keyint_min", gop,
+        "-c:a", "aac", "-b:a", abitrate, "-ar", "44100",
+    ]
+    cmd += ["-f", "flv", f"{ingest_base}/{stream_key}"]
+    return cmd
+
+
+def _redacted_str(cmd, real_key):
+    out = []
+    for a in cmd:
+        if real_key and real_key in a:
+            a = a.replace(real_key, _REDACTION)
+        out.append(a)
+    return " ".join(out)
+
+
+def _running_pid():
+    if not os.path.exists(PID_FILE):
+        return None
+    try:
+        pid = int(Path(PID_FILE).read_text().strip())
+    except (ValueError, OSError):
+        return None
+    try:
+        os.kill(pid, 0)
+        return pid
+    except OSError:
+        return None
+
+
+def cmd_start(args):
+    if _running_pid():
+        print(json.dumps({"ok": False, "error": "a stream is already running; stop it first",
+                          "pid": _running_pid()}))
+        return 1
+    if _ffmpeg_bin() is None:
+        print(json.dumps({"ok": False, "error": "ffmpeg not found on PATH"}))
+        return 1
+    cfg = _load_manifest_config()
+    ingest_base = os.environ.get("YOUTUBE_INGEST_BASE") or cfg.get("ingest_base", DEFAULT_INGEST_BASE)
+    key = _resolve_stream_key(args.stream_key)
+    if not key:
+        print(json.dumps({"ok": False, "error": "no stream key — set it with "
+                          "`vault set YOUTUBE_STREAM_KEY <key>` (or pass --stream-key / $YOUTUBE_STREAM_KEY)"}))
+        return 1
+    try:
+        cmd = build_ffmpeg_cmd(args.source, key, cfg, ingest_base=ingest_base, loop=args.loop)
+    except ValueError as e:
+        print(json.dumps({"ok": False, "error": str(e)}))
+        return 1
+
+    if args.dry_run:
+        print(json.dumps({"ok": True, "dry_run": True, "command": _redacted_str(cmd, key),
+                          "source": args.source, "ingest_base": ingest_base}))
+        return 0
+
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    Path(PID_FILE).write_text(str(proc.pid))
+    _log("youtube_live_started", pid=proc.pid, source=args.source)
+    print(json.dumps({"ok": True, "started": True, "pid": proc.pid, "source": args.source,
+                      "note": "streaming to YouTube; if the stream shows offline, confirm auto-start is "
+                              "enabled on the YouTube stream or start the broadcast in Studio"}))
+    return 0
+
+
+def cmd_stop(_args):
+    pid = _running_pid()
+    if not pid:
+        if os.path.exists(PID_FILE):
+            os.remove(PID_FILE)
+        print(json.dumps({"ok": True, "stopped": False, "note": "no stream was running"}))
+        return 0
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError as e:
+        print(json.dumps({"ok": False, "error": f"failed to stop pid {pid}: {e}"}))
+        return 1
+    if os.path.exists(PID_FILE):
+        os.remove(PID_FILE)
+    _log("youtube_live_stopped", pid=pid)
+    print(json.dumps({"ok": True, "stopped": True, "pid": pid}))
+    return 0
+
+
+def cmd_status(_args):
+    pid = _running_pid()
+    print(json.dumps({"ok": True, "running": bool(pid), "pid": pid}))
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Stream a source to YouTube Live via ffmpeg.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_start = sub.add_parser("start", help="Begin streaming to YouTube Live.")
+    p_start.add_argument("--source", default="test",
+                         help="test | file:<path> | image:<path> | screen (default: test)")
+    p_start.add_argument("--loop", action="store_true", help="Loop a file source forever.")
+    p_start.add_argument("--stream-key", default=None,
+                         help="Override the stream key (else $YOUTUBE_STREAM_KEY, else vault).")
+    p_start.add_argument("--dry-run", action="store_true",
+                         help="Print the (key-redacted) ffmpeg command without streaming.")
+    p_start.set_defaults(func=cmd_start)
+
+    sub.add_parser("stop", help="Stop the running stream.").set_defaults(func=cmd_stop)
+    sub.add_parser("status", help="Report whether a stream is running.").set_defaults(func=cmd_status)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/youtube-live/scripts/go_live.py
+++ b/skills/youtube-live/scripts/go_live.py
@@ -73,7 +73,9 @@ def _resolve_stream_key(cli_key):
         sys.path.insert(0, str(repo / "src"))
         from vault_intercept import get_vault_key  # type: ignore
         return get_vault_key("YOUTUBE_STREAM_KEY")
-    except (StopIteration, KeyError, ImportError):
+    except Exception:
+        # Any vault/keyring failure (missing key, no backend, import error) →
+        # treat as "no key"; the caller emits a clear vault-set hint.
         return None
 
 

--- a/skills/youtube-live/scripts/go_live.py
+++ b/skills/youtube-live/scripts/go_live.py
@@ -151,9 +151,6 @@ def cmd_start(args):
         print(json.dumps({"ok": False, "error": "a stream is already running; stop it first",
                           "pid": _running_pid()}))
         return 1
-    if _ffmpeg_bin() is None:
-        print(json.dumps({"ok": False, "error": "ffmpeg not found on PATH"}))
-        return 1
     cfg = _load_manifest_config()
     ingest_base = os.environ.get("YOUTUBE_INGEST_BASE") or cfg.get("ingest_base", DEFAULT_INGEST_BASE)
     key = _resolve_stream_key(args.stream_key)
@@ -171,6 +168,11 @@ def cmd_start(args):
         print(json.dumps({"ok": True, "dry_run": True, "command": _redacted_str(cmd, key),
                           "source": args.source, "ingest_base": ingest_base}))
         return 0
+
+    # Only a real stream needs ffmpeg on PATH — dry-run above just prints the command.
+    if _ffmpeg_bin() is None:
+        print(json.dumps({"ok": False, "error": "ffmpeg not found on PATH"}))
+        return 1
 
     proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     Path(PID_FILE).write_text(str(proc.pid))

--- a/skills/youtube-live/scripts/go_live.py
+++ b/skills/youtube-live/scripts/go_live.py
@@ -30,9 +30,40 @@ import shutil
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
-PID_FILE = "/tmp/sutando-youtube-live.pid"
+
+def _state_dir() -> Path:
+    """Sutando's scoped, per-user state dir (never world-shared /tmp).
+
+    Prefers ``<workspace>/state`` (resolved via the repo helper); falls back to a
+    uid-scoped tmp dir if the workspace can't be resolved. Created 0700 so a
+    peer user can't drop a pid file we'd act on.
+    """
+    d = None
+    try:
+        repo = next(p for p in Path(__file__).resolve().parents
+                    if (p / "src" / "workspace_default.py").is_file())
+        sys.path.insert(0, str(repo / "src"))
+        from workspace_default import resolve_workspace  # type: ignore
+        d = Path(resolve_workspace()) / "state"
+    except Exception:
+        base = os.environ.get("TMPDIR") or "/tmp"
+        d = Path(base) / f"sutando-{os.getuid()}"
+    d.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(d, 0o700)
+    except OSError:
+        pass
+    return d
+
+
+# Resolved once at import; tests override PID_FILE directly. Scoped to the
+# workspace state area (owner-only) instead of a world-writable /tmp path so a
+# stale or planted pid file can't make `stop` signal an unrelated process.
+PID_FILE = str(_state_dir() / "youtube-live.pid")
+FFMPEG_LOG = str(_state_dir() / "youtube-live.ffmpeg.log")
 DEFAULT_INGEST_BASE = "rtmp://a.rtmp.youtube.com/live2"
 _REDACTION = "<STREAM_KEY>"
 
@@ -146,6 +177,35 @@ def _running_pid():
         return None
 
 
+def _proc_looks_like_our_stream(pid) -> bool:
+    """True only if `pid`'s command line looks like the ffmpeg→RTMP stream this
+    skill starts. Guards `stop` against a stale/reused/planted pid pointing at an
+    unrelated process — we refuse to SIGTERM anything that isn't our ffmpeg."""
+    try:
+        out = subprocess.run(["ps", "-p", str(pid), "-o", "command="],
+                             capture_output=True, text=True, timeout=5).stdout
+    except Exception:
+        return False
+    return "ffmpeg" in out and "rtmp://" in out
+
+
+def _write_pidfile(pid) -> None:
+    """Write the pid owner-only (0600) so a peer can't tamper with it."""
+    path = Path(PID_FILE)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(str(pid))
+
+
+def _log_tail(path, limit: int = 800) -> str:
+    """Last `limit` chars of a log file, for surfacing ffmpeg's failure reason."""
+    try:
+        data = Path(path).read_text(errors="replace")
+    except OSError:
+        return ""
+    return data[-limit:].strip()
+
+
 def cmd_start(args):
     if _running_pid():
         print(json.dumps({"ok": False, "error": "a stream is already running; stop it first",
@@ -174,10 +234,25 @@ def cmd_start(args):
         print(json.dumps({"ok": False, "error": "ffmpeg not found on PATH"}))
         return 1
 
-    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    Path(PID_FILE).write_text(str(proc.pid))
+    # Keep ffmpeg's stderr for diagnostics instead of discarding it — otherwise a
+    # broadcast that dies on bad args/network leaves no trace.
+    log_fh = open(FFMPEG_LOG, "wb")
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=log_fh)
+
+    # Don't claim "started" if ffmpeg exited immediately (bad key, bad source,
+    # network refused). Give it a moment, then confirm it's still alive.
+    time.sleep(args.startup_grace)
+    if proc.poll() is not None:
+        log_fh.close()
+        tail = _log_tail(FFMPEG_LOG)
+        print(json.dumps({"ok": False, "error": "ffmpeg exited immediately "
+                          f"(rc={proc.returncode}) — stream not started", "ffmpeg_stderr": tail}))
+        return 1
+
+    _write_pidfile(proc.pid)
     _log("youtube_live_started", pid=proc.pid, source=args.source)
     print(json.dumps({"ok": True, "started": True, "pid": proc.pid, "source": args.source,
+                      "log": FFMPEG_LOG,
                       "note": "streaming to YouTube; if the stream shows offline, confirm auto-start is "
                               "enabled on the YouTube stream or start the broadcast in Studio"}))
     return 0
@@ -190,6 +265,14 @@ def cmd_stop(_args):
             os.remove(PID_FILE)
         print(json.dumps({"ok": True, "stopped": False, "note": "no stream was running"}))
         return 0
+    # Never SIGTERM a pid that isn't our ffmpeg stream — after a reuse/tamper the
+    # recorded pid can belong to an unrelated process. Refuse and clear the file.
+    if not _proc_looks_like_our_stream(pid):
+        os.remove(PID_FILE) if os.path.exists(PID_FILE) else None
+        print(json.dumps({"ok": False, "stopped": False, "pid": pid,
+                          "error": "recorded pid is not our ffmpeg stream (stale/reused) — "
+                                   "refusing to kill it; cleared the stale pid file"}))
+        return 1
     try:
         os.kill(pid, signal.SIGTERM)
     except OSError as e:
@@ -220,6 +303,9 @@ def main(argv=None):
                          help="Override the stream key (else $YOUTUBE_STREAM_KEY, else vault).")
     p_start.add_argument("--dry-run", action="store_true",
                          help="Print the (key-redacted) ffmpeg command without streaming.")
+    p_start.add_argument("--startup-grace", type=float, default=0.5,
+                         help="Seconds to wait after spawning ffmpeg before confirming it "
+                              "didn't exit immediately (default 0.5).")
     p_start.set_defaults(func=cmd_start)
 
     sub.add_parser("stop", help="Stop the running stream.").set_defaults(func=cmd_stop)

--- a/skills/youtube-live/scripts/go_live.py
+++ b/skills/youtube-live/scripts/go_live.py
@@ -197,12 +197,22 @@ def _write_pidfile(pid) -> None:
         f.write(str(pid))
 
 
-def _log_tail(path, limit: int = 800) -> str:
-    """Last `limit` chars of a log file, for surfacing ffmpeg's failure reason."""
+def _log_tail(path, limit: int = 800, redact=None) -> str:
+    """Last `limit` chars of a log file, for surfacing ffmpeg's failure reason.
+
+    `redact` scrubs the stream key from the surfaced content: ffmpeg echoes
+    the full rtmp target (key included) into stderr on connect failures — the
+    exact content this helper forwards to stdout JSON, which must honor the
+    key-is-never-printed contract (bassil CR 2026-07-31). Redaction happens
+    BEFORE the tail slice so a key straddling the boundary can't leak a
+    fragment.
+    """
     try:
         data = Path(path).read_text(errors="replace")
     except OSError:
         return ""
+    if redact:
+        data = data.replace(redact, _REDACTION)
     return data[-limit:].strip()
 
 
@@ -244,7 +254,7 @@ def cmd_start(args):
     time.sleep(args.startup_grace)
     if proc.poll() is not None:
         log_fh.close()
-        tail = _log_tail(FFMPEG_LOG)
+        tail = _log_tail(FFMPEG_LOG, redact=key)
         print(json.dumps({"ok": False, "error": "ffmpeg exited immediately "
                           f"(rc={proc.returncode}) — stream not started", "ffmpeg_stderr": tail}))
         return 1

--- a/tests/youtube-live-skill.test.py
+++ b/tests/youtube-live-skill.test.py
@@ -132,6 +132,7 @@ class _Args:
         self.loop = kw.get("loop", False)
         self.stream_key = kw.get("stream_key", None)
         self.dry_run = kw.get("dry_run", False)
+        self.startup_grace = kw.get("startup_grace", 0.0)
 
 
 def _capture(fn, *a):
@@ -149,10 +150,13 @@ class CmdStartBranchTests(unittest.TestCase):
         import tempfile
         self._tmp = tempfile.mkdtemp()
         self._orig_pid_file = go_live.PID_FILE
+        self._orig_log = go_live.FFMPEG_LOG
         go_live.PID_FILE = os.path.join(self._tmp, "pid")
+        go_live.FFMPEG_LOG = os.path.join(self._tmp, "ffmpeg.log")
 
     def tearDown(self):
         go_live.PID_FILE = self._orig_pid_file
+        go_live.FFMPEG_LOG = self._orig_log
 
     def test_start_refuses_when_already_running(self):
         from unittest import mock
@@ -197,6 +201,9 @@ class CmdStartBranchTests(unittest.TestCase):
         class FakeProc:
             pid = 9999
 
+            def poll(self):
+                return None  # still alive after the grace window
+
         with mock.patch.object(go_live, "_running_pid", return_value=None), \
              mock.patch.object(go_live, "_ffmpeg_bin", return_value="/x/ffmpeg"), \
              mock.patch.object(go_live, "_resolve_stream_key", return_value="K"), \
@@ -207,6 +214,35 @@ class CmdStartBranchTests(unittest.TestCase):
         self.assertEqual(out["pid"], 9999)
         popen.assert_called_once()
         self.assertEqual(Path(go_live.PID_FILE).read_text().strip(), "9999")
+        # pid file is owner-only (0600)
+        import stat
+        self.assertEqual(stat.S_IMODE(os.stat(go_live.PID_FILE).st_mode), 0o600)
+
+    def test_start_fails_if_ffmpeg_exits_immediately(self):
+        from unittest import mock
+
+        class DeadProc:
+            pid = 4242
+            returncode = 1
+
+            def poll(self):
+                return 1  # already exited
+
+        def fake_popen(*a, **k):
+            # ffmpeg emits an error to its stderr log, then dies immediately.
+            Path(go_live.FFMPEG_LOG).write_text("Connection refused to rtmp ingest")
+            return DeadProc()
+
+        with mock.patch.object(go_live, "_running_pid", return_value=None), \
+             mock.patch.object(go_live, "_ffmpeg_bin", return_value="/x/ffmpeg"), \
+             mock.patch.object(go_live, "_resolve_stream_key", return_value="K"), \
+             mock.patch.object(go_live.subprocess, "Popen", side_effect=fake_popen):
+            rc, out = _capture(go_live.cmd_start, _Args())
+        self.assertEqual(rc, 1)
+        self.assertFalse(out["ok"])
+        self.assertIn("exited immediately", out["error"])
+        self.assertIn("Connection refused", out["ffmpeg_stderr"])
+        self.assertFalse(os.path.exists(go_live.PID_FILE))  # no pid written for a dead stream
 
 
 class CmdStopStatusTests(unittest.TestCase):
@@ -228,12 +264,40 @@ class CmdStopStatusTests(unittest.TestCase):
         from unittest import mock
         Path(go_live.PID_FILE).write_text("5555")
         with mock.patch.object(go_live, "_running_pid", return_value=5555), \
+             mock.patch.object(go_live, "_proc_looks_like_our_stream", return_value=True), \
              mock.patch.object(go_live.os, "kill") as kill:
             rc, out = _capture(go_live.cmd_stop, None)
         self.assertEqual(rc, 0)
         self.assertTrue(out["stopped"])
         kill.assert_called_once()
         self.assertFalse(os.path.exists(go_live.PID_FILE))
+
+    def test_stop_refuses_foreign_process(self):
+        # Recorded pid is live but ISN'T our ffmpeg (stale/reused) → never kill it.
+        from unittest import mock
+        Path(go_live.PID_FILE).write_text("5555")
+        with mock.patch.object(go_live, "_running_pid", return_value=5555), \
+             mock.patch.object(go_live, "_proc_looks_like_our_stream", return_value=False), \
+             mock.patch.object(go_live.os, "kill") as kill:
+            rc, out = _capture(go_live.cmd_stop, None)
+        self.assertEqual(rc, 1)
+        self.assertFalse(out["stopped"])
+        kill.assert_not_called()  # crucial: we did NOT signal the foreign pid
+        self.assertFalse(os.path.exists(go_live.PID_FILE))  # cleared the stale file
+
+    def test_proc_looks_like_our_stream(self):
+        from unittest import mock
+
+        class R:
+            stdout = "/x/ffmpeg -i rtmp://a.rtmp.youtube.com/live2/KEY"
+
+        class R2:
+            stdout = "/usr/bin/vim notes.txt"
+
+        with mock.patch.object(go_live.subprocess, "run", return_value=R()):
+            self.assertTrue(go_live._proc_looks_like_our_stream(123))
+        with mock.patch.object(go_live.subprocess, "run", return_value=R2()):
+            self.assertFalse(go_live._proc_looks_like_our_stream(123))
 
     def test_status_running(self):
         from unittest import mock
@@ -300,6 +364,7 @@ class MiscBranchTests(unittest.TestCase):
         try:
             Path(go_live.PID_FILE).write_text("444")
             with mock.patch.object(go_live, "_running_pid", return_value=444), \
+                 mock.patch.object(go_live, "_proc_looks_like_our_stream", return_value=True), \
                  mock.patch.object(go_live.os, "kill", side_effect=OSError("nope")):
                 rc, out = _capture(go_live.cmd_stop, None)
             self.assertEqual(rc, 1)

--- a/tests/youtube-live-skill.test.py
+++ b/tests/youtube-live-skill.test.py
@@ -163,8 +163,11 @@ class CmdStartBranchTests(unittest.TestCase):
         self.assertIn("already running", out["error"])
 
     def test_start_errors_when_ffmpeg_missing(self):
+        # ffmpeg is only checked for a real stream (after key + build + dry-run),
+        # so provide a key and a non-dry-run Args to reach that gate.
         from unittest import mock
         with mock.patch.object(go_live, "_running_pid", return_value=None), \
+             mock.patch.object(go_live, "_resolve_stream_key", return_value="K"), \
              mock.patch.object(go_live, "_ffmpeg_bin", return_value=None):
             rc, out = _capture(go_live.cmd_start, _Args())
         self.assertEqual(rc, 1)

--- a/tests/youtube-live-skill.test.py
+++ b/tests/youtube-live-skill.test.py
@@ -126,5 +126,194 @@ class StatusTests(unittest.TestCase):
         self.assertFalse(out["running"])
 
 
+class _Args:
+    def __init__(self, **kw):
+        self.source = kw.get("source", "test")
+        self.loop = kw.get("loop", False)
+        self.stream_key = kw.get("stream_key", None)
+        self.dry_run = kw.get("dry_run", False)
+
+
+def _capture(fn, *a):
+    import io
+    import json
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = fn(*a)
+    return rc, json.loads(buf.getvalue())
+
+
+class CmdStartBranchTests(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+        self._tmp = tempfile.mkdtemp()
+        self._orig_pid_file = go_live.PID_FILE
+        go_live.PID_FILE = os.path.join(self._tmp, "pid")
+
+    def tearDown(self):
+        go_live.PID_FILE = self._orig_pid_file
+
+    def test_start_refuses_when_already_running(self):
+        from unittest import mock
+        with mock.patch.object(go_live, "_running_pid", return_value=4321):
+            rc, out = _capture(go_live.cmd_start, _Args())
+        self.assertEqual(rc, 1)
+        self.assertFalse(out["ok"])
+        self.assertIn("already running", out["error"])
+
+    def test_start_errors_when_ffmpeg_missing(self):
+        from unittest import mock
+        with mock.patch.object(go_live, "_running_pid", return_value=None), \
+             mock.patch.object(go_live, "_ffmpeg_bin", return_value=None):
+            rc, out = _capture(go_live.cmd_start, _Args())
+        self.assertEqual(rc, 1)
+        self.assertIn("ffmpeg", out["error"])
+
+    def test_start_errors_when_no_key(self):
+        from unittest import mock
+        with mock.patch.object(go_live, "_running_pid", return_value=None), \
+             mock.patch.object(go_live, "_ffmpeg_bin", return_value="/x/ffmpeg"), \
+             mock.patch.object(go_live, "_resolve_stream_key", return_value=None):
+            rc, out = _capture(go_live.cmd_start, _Args())
+        self.assertEqual(rc, 1)
+        self.assertIn("stream key", out["error"])
+
+    def test_start_errors_on_unknown_source(self):
+        from unittest import mock
+        with mock.patch.object(go_live, "_running_pid", return_value=None), \
+             mock.patch.object(go_live, "_ffmpeg_bin", return_value="/x/ffmpeg"), \
+             mock.patch.object(go_live, "_resolve_stream_key", return_value="K"):
+            rc, out = _capture(go_live.cmd_start, _Args(source="bogus"))
+        self.assertEqual(rc, 1)
+        self.assertIn("unknown source", out["error"])
+
+    def test_start_spawns_and_writes_pidfile(self):
+        from unittest import mock
+
+        class FakeProc:
+            pid = 9999
+
+        with mock.patch.object(go_live, "_running_pid", return_value=None), \
+             mock.patch.object(go_live, "_ffmpeg_bin", return_value="/x/ffmpeg"), \
+             mock.patch.object(go_live, "_resolve_stream_key", return_value="K"), \
+             mock.patch.object(go_live.subprocess, "Popen", return_value=FakeProc()) as popen:
+            rc, out = _capture(go_live.cmd_start, _Args())
+        self.assertEqual(rc, 0)
+        self.assertTrue(out["started"])
+        self.assertEqual(out["pid"], 9999)
+        popen.assert_called_once()
+        self.assertEqual(Path(go_live.PID_FILE).read_text().strip(), "9999")
+
+
+class CmdStopStatusTests(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+        self._tmp = tempfile.mkdtemp()
+        self._orig = go_live.PID_FILE
+        go_live.PID_FILE = os.path.join(self._tmp, "pid")
+
+    def tearDown(self):
+        go_live.PID_FILE = self._orig
+
+    def test_stop_when_nothing_running(self):
+        rc, out = _capture(go_live.cmd_stop, None)
+        self.assertEqual(rc, 0)
+        self.assertFalse(out["stopped"])
+
+    def test_stop_kills_running_pid(self):
+        from unittest import mock
+        Path(go_live.PID_FILE).write_text("5555")
+        with mock.patch.object(go_live, "_running_pid", return_value=5555), \
+             mock.patch.object(go_live.os, "kill") as kill:
+            rc, out = _capture(go_live.cmd_stop, None)
+        self.assertEqual(rc, 0)
+        self.assertTrue(out["stopped"])
+        kill.assert_called_once()
+        self.assertFalse(os.path.exists(go_live.PID_FILE))
+
+    def test_status_running(self):
+        from unittest import mock
+        with mock.patch.object(go_live, "_running_pid", return_value=7777):
+            rc, out = _capture(go_live.cmd_status, None)
+        self.assertTrue(out["running"])
+        self.assertEqual(out["pid"], 7777)
+
+    def test_running_pid_detects_self(self):
+        Path(go_live.PID_FILE).write_text(str(os.getpid()))
+        self.assertEqual(go_live._running_pid(), os.getpid())
+
+    def test_running_pid_none_for_dead(self):
+        Path(go_live.PID_FILE).write_text("999999")  # almost certainly not a live pid
+        self.assertIsNone(go_live._running_pid())
+
+
+class MiscBranchTests(unittest.TestCase):
+    def test_manifest_config_returns_empty_on_error(self):
+        from unittest import mock
+        with mock.patch.object(go_live.json, "loads", side_effect=ValueError):
+            self.assertEqual(go_live._load_manifest_config(), {})
+
+    def test_resolve_stream_key_vault_path_returns_none_when_unset(self):
+        # No CLI, no env → falls through to the vault branch. In CI there's no
+        # YOUTUBE_STREAM_KEY in any vault/keyring, so it must resolve to None
+        # (the broad except swallows any backend error).
+        os.environ.pop("YOUTUBE_STREAM_KEY", None)
+        self.assertIsNone(go_live._resolve_stream_key(None))
+
+    def test_running_pid_malformed_file(self):
+        import tempfile
+        orig = go_live.PID_FILE
+        tmp = tempfile.mkdtemp()
+        go_live.PID_FILE = os.path.join(tmp, "pid")
+        try:
+            Path(go_live.PID_FILE).write_text("not-an-int")
+            self.assertIsNone(go_live._running_pid())
+        finally:
+            go_live.PID_FILE = orig
+
+    def test_stop_removes_stale_pidfile_when_not_running(self):
+        import tempfile
+        from unittest import mock
+        orig = go_live.PID_FILE
+        tmp = tempfile.mkdtemp()
+        go_live.PID_FILE = os.path.join(tmp, "pid")
+        try:
+            Path(go_live.PID_FILE).write_text("123")
+            with mock.patch.object(go_live, "_running_pid", return_value=None):
+                rc, out = _capture(go_live.cmd_stop, None)
+            self.assertEqual(rc, 0)
+            self.assertFalse(out["stopped"])
+            self.assertFalse(os.path.exists(go_live.PID_FILE))
+        finally:
+            go_live.PID_FILE = orig
+
+    def test_stop_reports_error_when_kill_fails(self):
+        import tempfile
+        from unittest import mock
+        orig = go_live.PID_FILE
+        tmp = tempfile.mkdtemp()
+        go_live.PID_FILE = os.path.join(tmp, "pid")
+        try:
+            Path(go_live.PID_FILE).write_text("444")
+            with mock.patch.object(go_live, "_running_pid", return_value=444), \
+                 mock.patch.object(go_live.os, "kill", side_effect=OSError("nope")):
+                rc, out = _capture(go_live.cmd_stop, None)
+            self.assertEqual(rc, 1)
+            self.assertFalse(out["ok"])
+        finally:
+            go_live.PID_FILE = orig
+
+
+class MainDispatchTests(unittest.TestCase):
+    def test_main_status(self):
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = go_live.main(["status"])
+        self.assertEqual(rc, 0)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/youtube-live-skill.test.py
+++ b/tests/youtube-live-skill.test.py
@@ -244,6 +244,39 @@ class CmdStartBranchTests(unittest.TestCase):
         self.assertIn("Connection refused", out["ffmpeg_stderr"])
         self.assertFalse(os.path.exists(go_live.PID_FILE))  # no pid written for a dead stream
 
+    def test_start_failure_redacts_stream_key_from_ffmpeg_stderr(self):
+        # bassil CR 2026-07-31: ffmpeg echoes the full rtmp target (key
+        # included) into stderr on connect failures, and the ffmpeg_stderr
+        # diagnostics path surfaced it raw — the key-is-never-printed
+        # contract must hold on the failure path, not just --dry-run.
+        import json as _json
+        from unittest import mock
+
+        class DeadProc:
+            pid = 4242
+            returncode = 1
+
+            def poll(self):
+                return 1
+
+        secret = "sk-live-STREAMKEY-4242"
+
+        def fake_popen(*a, **k):
+            Path(go_live.FFMPEG_LOG).write_text(
+                f"[tcp] rtmp://a.rtmp.youtube.com/live2/{secret}: Connection refused\n"
+                + "x" * 900  # push the first mention past the 800-char tail slice
+                + f" retry rtmp://a.rtmp.youtube.com/live2/{secret} failed")
+            return DeadProc()
+
+        with mock.patch.object(go_live, "_running_pid", return_value=None), \
+             mock.patch.object(go_live, "_ffmpeg_bin", return_value="/x/ffmpeg"), \
+             mock.patch.object(go_live, "_resolve_stream_key", return_value=secret), \
+             mock.patch.object(go_live.subprocess, "Popen", side_effect=fake_popen):
+            rc, out = _capture(go_live.cmd_start, _Args())
+        self.assertEqual(rc, 1)
+        self.assertNotIn(secret, _json.dumps(out))  # nowhere in the emitted JSON
+        self.assertIn(go_live._REDACTION, out["ffmpeg_stderr"])  # scrubbed, not dropped
+
 
 class CmdStopStatusTests(unittest.TestCase):
     def setUp(self):

--- a/tests/youtube-live-skill.test.py
+++ b/tests/youtube-live-skill.test.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Unit tests for the youtube-live skill. CI-safe: no network, no ffmpeg spawn."""
+
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+
+_SCRIPT = (
+    Path(__file__).resolve().parent.parent
+    / "skills" / "youtube-live" / "scripts" / "go_live.py"
+)
+_spec = importlib.util.spec_from_file_location("go_live", _SCRIPT)
+go_live = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(go_live)
+
+CFG = {"resolution": "1280x720", "fps": 30, "video_bitrate": "4500k",
+       "audio_bitrate": "128k", "buffer_size": "9000k", "avf_screen_spec": "1:0"}
+
+
+class BuildCmdTests(unittest.TestCase):
+    def test_test_source_has_lavfi_video_and_audio(self):
+        cmd = go_live.build_ffmpeg_cmd("test", "KEY123", CFG)
+        joined = " ".join(cmd)
+        self.assertIn("testsrc2=size=1280x720:rate=30", joined)
+        self.assertIn("sine=frequency=1000", joined)
+        # YouTube-compatible codecs
+        self.assertIn("libx264", cmd)
+        self.assertIn("aac", cmd)
+        self.assertIn("yuv420p", cmd)
+        # gop = 2 * fps
+        gi = cmd.index("-g")
+        self.assertEqual(cmd[gi + 1], "60")
+
+    def test_ends_with_flv_to_ingest_and_key(self):
+        cmd = go_live.build_ffmpeg_cmd("test", "SECRET", CFG,
+                                       ingest_base="rtmp://x/live2")
+        self.assertEqual(cmd[-3:], ["-f", "flv", "rtmp://x/live2/SECRET"])
+
+    def test_file_source_loop(self):
+        cmd = go_live.build_ffmpeg_cmd("file:/tmp/a.mp4", "K", CFG, loop=True)
+        self.assertIn("-stream_loop", cmd)
+        self.assertIn("/tmp/a.mp4", cmd)
+
+    def test_file_source_no_loop(self):
+        cmd = go_live.build_ffmpeg_cmd("file:/tmp/a.mp4", "K", CFG, loop=False)
+        self.assertNotIn("-stream_loop", cmd)
+
+    def test_image_source_has_still_and_silent_audio(self):
+        cmd = go_live.build_ffmpeg_cmd("image:/tmp/s.png", "K", CFG)
+        joined = " ".join(cmd)
+        self.assertIn("-loop", cmd)
+        self.assertIn("/tmp/s.png", cmd)
+        self.assertIn("anullsrc", joined)
+
+    def test_screen_source_uses_avfoundation(self):
+        cmd = go_live.build_ffmpeg_cmd("screen", "K", CFG)
+        self.assertIn("avfoundation", cmd)
+        self.assertIn("1:0", cmd)
+
+    def test_unknown_source_raises(self):
+        with self.assertRaises(ValueError):
+            go_live.build_ffmpeg_cmd("bogus", "K", CFG)
+
+
+class RedactionTests(unittest.TestCase):
+    def test_key_is_redacted_in_printed_command(self):
+        cmd = go_live.build_ffmpeg_cmd("test", "SUPERSECRETKEY", CFG)
+        printed = go_live._redacted_str(cmd, "SUPERSECRETKEY")
+        self.assertNotIn("SUPERSECRETKEY", printed)
+        self.assertIn("<STREAM_KEY>", printed)
+
+
+class KeyResolutionTests(unittest.TestCase):
+    def test_cli_beats_env(self):
+        os.environ["YOUTUBE_STREAM_KEY"] = "envkey"
+        try:
+            self.assertEqual(go_live._resolve_stream_key("clikey"), "clikey")
+        finally:
+            del os.environ["YOUTUBE_STREAM_KEY"]
+
+    def test_env_used_when_no_cli(self):
+        os.environ["YOUTUBE_STREAM_KEY"] = "envkey"
+        try:
+            self.assertEqual(go_live._resolve_stream_key(None), "envkey")
+        finally:
+            del os.environ["YOUTUBE_STREAM_KEY"]
+
+
+class DryRunTests(unittest.TestCase):
+    def test_dry_run_does_not_stream_and_redacts(self):
+        import io
+        import json
+        from contextlib import redirect_stdout
+
+        class Args:
+            source = "test"
+            loop = False
+            stream_key = "TOPSECRET"
+            dry_run = True
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = go_live.cmd_start(Args())
+        self.assertEqual(rc, 0)
+        out = json.loads(buf.getvalue())
+        self.assertTrue(out["dry_run"])
+        self.assertNotIn("TOPSECRET", out["command"])
+        self.assertIn("<STREAM_KEY>", out["command"])
+
+
+class StatusTests(unittest.TestCase):
+    def test_status_not_running(self):
+        import io
+        import json
+        from contextlib import redirect_stdout
+
+        # Ensure no stale pid file interferes.
+        if os.path.exists(go_live.PID_FILE):
+            self.skipTest("a real stream pid file exists; skip to avoid touching it")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            go_live.cmd_status(None)
+        out = json.loads(buf.getvalue())
+        self.assertFalse(out["running"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

New self-contained skill **`skills/youtube-live/`** that streams a source to **YouTube Live** over RTMP via `ffmpeg`. `start` / `stop` / `status`, sources = `test` (lavfi pattern+tone), `file:<path>` (`--loop`), `image:<path>` slate, or macOS `screen`.

## Why

Owner asked whether Sutando can do YouTube Live — it couldn't (no RTMP/livestream capability existed; nearest skills were make-viral-video, screen-record, zoom). This adds the capability as an optional skill (core boots fine without it), per the architecture rule "new capability starts as a skill."

## Design

- **Stream-key MVP.** No Google API call is needed for a basic broadcast — a persistent YouTube stream key + auto-start is enough. Key precedence `--stream-key > $YOUTUBE_STREAM_KEY > vault YOUTUBE_STREAM_KEY`; **never printed** (logs + `--dry-run` redact to `<STREAM_KEY>`).
- Encoding fixed to YouTube-compatible H.264+AAC; resolution/fps/bitrate in the manifest `config` block (per skills/MANIFEST.md — no ad-hoc env vars).
- Programmatic broadcast lifecycle (YouTube Live Streaming API, OAuth) is a documented **follow-up**, not in this PR (single concern).

## Evidence

`--dry-run` at HEAD (key redacted), showing a well-formed YouTube-compatible command:
```
$ YOUTUBE_STREAM_KEY=abcd-1234-secret python3 skills/youtube-live/scripts/go_live.py start --source test --dry-run
{"ok": true, "dry_run": true, "command": "/usr/local/bin/ffmpeg -hide_banner -loglevel warning -re -f lavfi -i testsrc2=size=1280x720:rate=30 -f lavfi -i sine=frequency=1000:sample_rate=44100 -c:v libx264 -preset veryfast -pix_fmt yuv420p -b:v 4500k -maxrate 4500k -bufsize 9000k -g 60 -keyint_min 60 -c:a aac -b:a 128k -ar 44100 -f flv rtmp://a.rtmp.youtube.com/live2/<STREAM_KEY>", "source": "test", "ingest_base": "rtmp://a.rtmp.youtube.com/live2"}
```
- `tests/youtube-live-skill.test.py` — **12/12 pass** (command construction per source, key redaction, precedence, dry-run, status; CI-safe, no network/ffmpeg spawn).
- `ruff check` clean; `py_compile` clean.

## Enablement (for the e2e test)

1. Enable live streaming on the target YouTube channel (Studio → Go live; first activation can take ~24h).
2. Create a stream, copy its **Stream key**, enable **auto-start/auto-stop**.
3. `vault set YOUTUBE_STREAM_KEY <key>` (via the Slack/Discord vault path).
4. `python3 skills/youtube-live/scripts/go_live.py start --source test` → the channel goes live with a test pattern.

## Notes

- Draft — opened for review; e2e (real go-live) pending the owner enabling a stream key.
- macOS `screen` source needs Screen Recording permission for the launching app.