### PR TITLE
fix(discord-bridge): honest outage copy in progress placeholders — frozen-status + queue depth (closes #2398)

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -4387,6 +4387,36 @@ async def poll_results():
 _progress_msgs: dict = {}
 
 
+def _newest_alive_mtime():
+    """Newest per-host core heartbeat mtime (state/cores/*.alive), or None
+    when no heartbeat file exists (graceful shutdown unlinks it)."""
+    try:
+        return max((p.stat().st_mtime for p in (STATE_DIR / "cores").glob("*.alive")),
+                   default=None)
+    except Exception:
+        return None
+
+
+def _queued_task_count():
+    """Live (unarchived) task files waiting in tasks/."""
+    try:
+        return sum(1 for _ in TASKS_DIR.glob("task-*.txt"))
+    except Exception:
+        return 0
+
+
+def _render_progress_content(now, elapsed):
+    """Placeholder body for poll_progress: the live core step normally, or the
+    honest outage copy (frozen status + stale heartbeat + queue depth) when the
+    core looks dead (sonichi#2398 — the 2026-07-30 'restart in flight (1625s)'
+    class: never narrate progress the core is not making)."""
+    status = progress_stream.read_core_status(STATE_DIR)
+    if progress_stream.core_looks_down(status, _newest_alive_mtime(), now):
+        return progress_stream.format_outage(
+            progress_stream.status_age_s(status, now), _queued_task_count())
+    return progress_stream.format_progress(progress_stream.current_step(status), elapsed)
+
+
 async def poll_progress():
     """Hermes-style streaming tool output (2026-06-05).
 
@@ -4444,12 +4474,9 @@ async def poll_progress():
                         _progress_msgs[task_id] = {"expired": True}  # terminal
                         continue
                     if progress_stream.should_edit(now, info["last_edit"]):
-                        step = progress_stream.current_step(
-                            progress_stream.read_core_status(STATE_DIR)
-                        )
                         try:
                             await info["msg"].edit(
-                                content=progress_stream.format_progress(step, elapsed)
+                                content=_render_progress_content(now, elapsed)
                             )
                             info["last_edit"] = now
                         except Exception:
@@ -4477,12 +4504,9 @@ async def poll_progress():
                     created = now
                 elapsed = now - created
                 if progress_stream.should_post_placeholder(elapsed):
-                    step = progress_stream.current_step(
-                        progress_stream.read_core_status(STATE_DIR)
-                    )
                     try:
                         msg = await channel.send(
-                            progress_stream.format_progress(step, elapsed)
+                            _render_progress_content(now, elapsed)
                         )
                         _progress_msgs[task_id] = {
                             "msg": msg,

--- a/src/progress_stream.py
+++ b/src/progress_stream.py
@@ -138,3 +138,74 @@ def format_progress(step: Optional[str], elapsed_s: float, max_len: int = 180) -
     shown = step if (isinstance(step, str) and step.strip()) else "working…"
     shown = _truncate(shown.strip(), max_len)
     return "⏳ {} ({}s)".format(shown, secs)
+
+
+# ---- outage-aware placeholder (sonichi#2398) -------------------------------
+# During the 2026-07-30 outage the placeholder faithfully re-posted a FROZEN
+# core-status step for 100 minutes ("SESSION RESTART in flight … (1625s)") —
+# the copy claimed progress while the core was dead, and nothing surfaced the
+# growing task queue. These helpers let the bridge detect that state and
+# switch to honest down-copy. Both signals must agree (frozen status AND stale
+# heartbeat) so a legitimately long single step never false-alarms.
+
+# A non-idle core updates core-status.json at every pass/step transition; a
+# non-idle status older than this is frozen, not slow.
+STATUS_STALE_AFTER_S = 180
+
+# Mirror of the documented .alive liveness threshold (CLAUDE.md "Core
+# liveness signal": younger than ~90s → alive).
+HEARTBEAT_STALE_AFTER_S = 90
+
+
+def status_age_s(status: Optional[dict], now_s: float) -> Optional[float]:
+    """Seconds since the status dict's ``ts`` stamp; None when unknowable
+    (missing/malformed ts) — callers must treat None as 'cannot judge'."""
+    if not isinstance(status, dict):
+        return None
+    ts = status.get("ts")
+    if not isinstance(ts, (int, float)) or isinstance(ts, bool):
+        return None
+    return max(0.0, float(now_s) - float(ts))
+
+
+def status_is_stale(status: Optional[dict], now_s: float,
+                    stale_after_s: int = STATUS_STALE_AFTER_S) -> bool:
+    """True when a NON-idle status has frozen (ts older than the threshold).
+
+    Idle statuses are never stale (an idle core writes once and rests — that
+    is healthy), and an unknowable age is not stale (never cry down on a
+    parse gap).
+    """
+    if current_step(status) is None:
+        return False
+    age = status_age_s(status, now_s)
+    return age is not None and age >= stale_after_s
+
+
+def heartbeat_is_stale(alive_mtime_s: Optional[float], now_s: float,
+                       stale_after_s: int = HEARTBEAT_STALE_AFTER_S) -> bool:
+    """True when the newest core .alive file is older than the documented
+    liveness threshold — or absent entirely (None), which during an outage is
+    exactly the graceful-shutdown/unlinked case."""
+    if alive_mtime_s is None:
+        return True
+    return (float(now_s) - float(alive_mtime_s)) >= stale_after_s
+
+
+def core_looks_down(status: Optional[dict], alive_mtime_s: Optional[float],
+                    now_s: float) -> bool:
+    """The #2398 gate: BOTH a frozen non-idle status AND a stale/absent
+    heartbeat. A long-running legit step keeps a fresh heartbeat → normal
+    copy; an idle-then-killed core has no step to misreport → normal copy."""
+    return status_is_stale(status, now_s) and heartbeat_is_stale(alive_mtime_s, now_s)
+
+
+def format_outage(age_s: Optional[float], queued: int, max_len: int = 300) -> str:
+    """Honest down-copy replacing the frozen-step placeholder: how long the
+    status has been frozen, how many tasks wait, and the restart remedy."""
+    mins = "?" if age_s is None else str(max(1, int(age_s // 60)))
+    n = max(0, int(queued))
+    body = ("⚠️ core unresponsive — status frozen for {}m; {} task(s) queued, "
+            "will process on restart. Restart: Sutando.app → Restart Core, or "
+            "`bash src/restart.sh` in a Terminal on the host.").format(mins, n)
+    return _truncate(body, max_len)

--- a/tests/progress-stream.test.py
+++ b/tests/progress-stream.test.py
@@ -143,3 +143,87 @@ if _fails:
     print(f"{len(_fails)} test(s) FAILED: {_fails}")
     sys.exit(1)
 print("outage-block tests passed")
+
+
+# --- bridge-side wiring (in-process, covers the discord-bridge helpers) ---
+# Same load pattern as tests/bridge-audit-wiring.test.py: stub `discord`,
+# hermetic token via env, spec_from_file_location for the hyphenated module.
+# The three helpers under test are pure over module-level dirs, which we
+# repoint at a temp workspace after load.
+import importlib.util  # noqa: E402
+import time  # noqa: E402
+import types  # noqa: E402
+
+try:
+    import discord  # noqa: F401
+except ImportError:
+    stub = types.ModuleType("discord")
+    stub.Intents = type("Intents", (), {"default": staticmethod(lambda: type("I", (), {"message_content": False})())})
+    stub.Client = type("Client", (), {"__init__": lambda self, **kw: None, "event": staticmethod(lambda fn: fn)})
+    stub.File = type("File", (), {})
+    stub.Message = type("Message", (), {})
+    stub.DMChannel = type("DMChannel", (), {})
+    sys.modules["discord"] = stub
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
+os.environ.setdefault("SUTANDO_TEST_MODE", "1")
+
+_REPO = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location("dbridge_outage", _REPO / "src" / "discord-bridge.py")
+_db = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_db)
+
+with tempfile.TemporaryDirectory() as d:
+    ws = Path(d)
+    (ws / "state" / "cores").mkdir(parents=True)
+    (ws / "tasks").mkdir()
+    _db.STATE_DIR = ws / "state"
+    _db.TASKS_DIR = ws / "tasks"
+    now = time.time()
+
+    # _newest_alive_mtime
+    check("bridge: no .alive files -> None", _db._newest_alive_mtime() is None)
+    a = ws / "state" / "cores" / "hostA.alive"
+    a.write_text("{}")
+    os.utime(a, (now - 200, now - 200))
+    b = ws / "state" / "cores" / "hostB.alive"
+    b.write_text("{}")
+    os.utime(b, (now - 20, now - 20))
+    got = _db._newest_alive_mtime()
+    check("bridge: newest .alive mtime wins", got is not None and abs(got - (now - 20)) < 2)
+
+    # _queued_task_count
+    check("bridge: empty tasks dir -> 0", _db._queued_task_count() == 0)
+    (ws / "tasks" / "task-1.txt").write_text("x")
+    (ws / "tasks" / "task-2.txt").write_text("x")
+    (ws / "tasks" / "not-a-task.log").write_text("x")
+    check("bridge: counts only task-*.txt", _db._queued_task_count() == 2)
+
+    # _render_progress_content — live core → normal progress copy
+    (ws / "state" / "core-status.json").write_text(
+        json.dumps({"status": "running", "step": "building", "ts": now - 10}))
+    out_live = _db._render_progress_content(now, 42)
+    check("bridge: live core renders progress copy", out_live.startswith("⏳") and "building" in out_live and "(42s)" in out_live)
+
+    # _render_progress_content — frozen status + only-stale heartbeats → outage copy
+    (ws / "state" / "core-status.json").write_text(
+        json.dumps({"status": "running", "step": "processing task", "ts": now - 300}))
+    b.unlink()  # newest remaining .alive is 200s old -> stale
+    out_down = _db._render_progress_content(now, 42)
+    check("bridge: down core renders outage copy", out_down.startswith("⚠️") and "unresponsive" in out_down)
+    check("bridge: outage copy carries live queue depth", "2 task(s) queued" in out_down)
+    check("bridge: outage copy never claims progress", "in flight" not in out_down and "(42s)" not in out_down)
+
+    # Fail-soft branches: helper errors must degrade, never raise into the
+    # gateway loop (a broken dirs object stands in for any resolution failure).
+    _db.STATE_DIR = None
+    _db.TASKS_DIR = None
+    check("bridge: alive-mtime fail-soft -> None", _db._newest_alive_mtime() is None)
+    check("bridge: queue-count fail-soft -> 0", _db._queued_task_count() == 0)
+    _db.STATE_DIR = ws / "state"
+    _db.TASKS_DIR = ws / "tasks"
+
+if _fails:
+    print(f"{len(_fails)} test(s) FAILED: {_fails}")
+    sys.exit(1)
+print("bridge-wiring tests passed")

--- a/tests/progress-stream.test.py
+++ b/tests/progress-stream.test.py
@@ -101,3 +101,45 @@ if _fails:
     print(f"{len(_fails)} test(s) FAILED: {_fails}")
     sys.exit(1)
 print("all tests passed")
+
+
+# --- outage-aware placeholder (sonichi#2398) ---
+NOW = 1_000_000.0
+_run = {"status": "running", "step": "SESSION RESTART in flight", "ts": NOW - 300}
+_fresh_run = {"status": "running", "step": "building", "ts": NOW - 30}
+_idle_old = {"status": "idle", "ts": NOW - 9999}
+
+check("status_age_s computes age", ps.status_age_s(_run, NOW) == 300)
+check("status_age_s None on missing ts", ps.status_age_s({"status": "running", "step": "x"}, NOW) is None)
+check("status_age_s None on bool ts", ps.status_age_s({"status": "running", "step": "x", "ts": True}, NOW) is None)
+check("status_age_s None on non-dict", ps.status_age_s(None, NOW) is None)
+
+check("frozen non-idle status is stale", ps.status_is_stale(_run, NOW))
+check("fresh non-idle status not stale", not ps.status_is_stale(_fresh_run, NOW))
+check("old IDLE status never stale", not ps.status_is_stale(_idle_old, NOW))
+check("unknowable age never stale", not ps.status_is_stale({"status": "running", "step": "x"}, NOW))
+
+check("absent heartbeat is stale", ps.heartbeat_is_stale(None, NOW))
+check("old heartbeat is stale", ps.heartbeat_is_stale(NOW - 120, NOW))
+check("fresh heartbeat not stale", not ps.heartbeat_is_stale(NOW - 30, NOW))
+
+check("down = frozen status AND stale heartbeat", ps.core_looks_down(_run, None, NOW))
+check("long step + fresh heartbeat NOT down", not ps.core_looks_down(_run, NOW - 10, NOW))
+check("fresh status + dead heartbeat NOT down", not ps.core_looks_down(_fresh_run, None, NOW))
+check("idle + dead heartbeat NOT down (nothing to misreport)", not ps.core_looks_down(_idle_old, None, NOW))
+
+_out = ps.format_outage(300, 35)
+check("outage copy names frozen minutes", "5m" in _out)
+check("outage copy names queue depth", "35 task(s) queued" in _out)
+check("outage copy names the restart remedy", "restart.sh" in _out and "Restart Core" in _out)
+check("outage copy warns, not progress", _out.startswith("⚠️") and "in flight" not in _out)
+check("outage copy unknown age renders ?", "frozen for ?m" in ps.format_outage(None, 0))
+check("outage copy sub-minute clamps to 1m", "frozen for 1m" in ps.format_outage(45, 1))
+check("outage copy caps length", len(ps.format_outage(300, 10**9, max_len=120)) <= 120)
+
+# Re-gate: the block above runs after the original summary, so it needs its
+# own exit check — otherwise a failing outage-test could still exit 0.
+if _fails:
+    print(f"{len(_fails)} test(s) FAILED: {_fails}")
+    sys.exit(1)
+print("outage-block tests passed")

--- a/tests/progress-stream.test.py
+++ b/tests/progress-stream.test.py
@@ -177,15 +177,29 @@ _cfg_root = tempfile.mkdtemp(prefix="progress-stream-test-cfg-")
 os.environ["CLAUDE_CONFIG_DIR"] = _cfg_root
 os.environ["CLAUDE_HOME"] = _cfg_root
 
+# Seed a canonical access.json under the temp root BEFORE import (qingyun P1
+# round 2 on #2426): channel_access_path falls back to the operator's real
+# ~/.claude/channels/discord/access.json (30-day legacy reader-fallback, with
+# a deprecation warning) when the temp root lacks the file — which imports the
+# operator's live allowlist and makes the test machine-dependent. A present
+# file pins resolution inside the temp root.
+_chan_dir = Path(_cfg_root) / "channels" / "discord"
+_chan_dir.mkdir(parents=True)
+(_chan_dir / "access.json").write_text(json.dumps(
+    {"dmPolicy": "pairing", "allowFrom": ["0"], "groups": {}}))
+
 _REPO = Path(__file__).resolve().parents[1]
 _spec = importlib.util.spec_from_file_location("dbridge_outage", _REPO / "src" / "discord-bridge.py")
 _db = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_db)
 
-# Assert the isolation actually took — the module's resolved token-file path
-# must live under the temp root, never the operator's real config dir.
+# Assert the isolation actually took — every config path the module resolved
+# at import time must live under the temp root, never the operator's real
+# config dir (token file AND access file).
 check("bridge: channels_env confined to temp config root",
       str(_db.channels_env).startswith(_cfg_root))
+check("bridge: ACCESS_FILE confined to temp config root",
+      str(_db.ACCESS_FILE).startswith(_cfg_root))
 
 with tempfile.TemporaryDirectory() as d:
     ws = Path(d)

--- a/tests/progress-stream.test.py
+++ b/tests/progress-stream.test.py
@@ -168,10 +168,24 @@ except ImportError:
 os.environ.setdefault("DISCORD_BOT_TOKEN", "test-token-not-real")
 os.environ.setdefault("SUTANDO_TEST_MODE", "1")
 
+# Hermetic config isolation (qingyun P1 on #2426): the bridge's import-time
+# token hardening resolves claude_home_path("channels", "discord", ".env") and
+# chmods it if it exists. Without isolation that touches the OPERATOR'S REAL
+# token file. Point both resolution env vars at a temp root BEFORE exec_module
+# so every config path the module computes stays inside it.
+_cfg_root = tempfile.mkdtemp(prefix="progress-stream-test-cfg-")
+os.environ["CLAUDE_CONFIG_DIR"] = _cfg_root
+os.environ["CLAUDE_HOME"] = _cfg_root
+
 _REPO = Path(__file__).resolve().parents[1]
 _spec = importlib.util.spec_from_file_location("dbridge_outage", _REPO / "src" / "discord-bridge.py")
 _db = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_db)
+
+# Assert the isolation actually took — the module's resolved token-file path
+# must live under the temp root, never the operator's real config dir.
+check("bridge: channels_env confined to temp config root",
+      str(_db.channels_env).startswith(_cfg_root))
 
 with tempfile.TemporaryDirectory() as d:
     ws = Path(d)


### PR DESCRIPTION
Closes #2398.

## What

When the discord-bridge's progress placeholder is live for a pending owner task but the core is actually DOWN, stop narrating fake progress ("⏳ working… (Ns)" / "SESSION RESTART in flight") and render the honest outage copy: frozen-status duration, live queue depth, and the restart remedy.

Detection (pure, unit-tested, `src/progress_stream.py`): `core-status.json` frozen — non-idle and older than 180s (mirrors the documented status-staleness threshold) — AND newest `state/cores/*.alive` heartbeat older than 90s (the documented liveness threshold) or absent (graceful shutdown unlinks it). Queue depth = live `tasks/task-*.txt` count. The bridge's `poll_progress` swaps only its render call (`_render_progress_content`); owner-tier-only streaming and the fail-closed unknown-tier guard are untouched.

## Why

2026-07-30 06:36Z incident class: a blocked boot left the core down while the placeholder kept claiming "SESSION RESTART in flight (1625s)" — 35 tasks piled up behind copy that promised progress the core was not making. The owner's only honest signals (frozen status, dead heartbeat, growing queue) were all on disk and unrendered.

## Evidence — live post-restart round trip (owner-authorized window, 2026-07-30 17:47–18:05Z, Chi's "Go" 17:44:55Z)

**Before (production code, same day, real incident):** placeholder read `⏳ working… (103s)` / historical `SESSION RESTART in flight (1625s)` while core-status was frozen and the heartbeat stale.

**After (this branch's bridge, live on Discord):** message `1532442425228792008`-thread, placeholder `1532447627151409243` in #bot2bot (Sutando-private), posted 17:59:45Z for the owner task from `sonichi`'s 17:59:35Z message, then edited in place to:

> ⚠️ core unresponsive — status frozen for 5m; 3 task(s) queued, will process on restart. Restart: Sutando.app → Restart Core, or `bash src/restart.sh` in a Terminal on the host.

Signals at render (verified with this branch's own functions immediately before the edit): `status age: 301s`, `alive: None`, `core_looks_down: True`; queue depth 3 = the actual pending task files.

**Guards verified live in the same window:**
- Owner-only streaming: two team-tier pings from Sutando-Pro (`1532445795901509664`, `1532446xxx`) were ingested as tasks but correctly never received placeholders.
- Fail-closed tier recovery: the owner task recovered from disk after a bridge restart had no in-memory tier entry and was correctly excluded (red-team #2 behavior observed, not just unit-tested).
- Full restore: production bridge relaunched (pid 92757) and delivered the completion reply through the normal path; heartbeat resumed; health check green.

**Unit tests:** `tests/progress-stream.test.py` — outage copy for unknown age, sub-minute clamp, length cap — pass at head.

## Operational note for reviewers

During the window the worktree-run bridge resolved `<worktree>/workspace/` (repo `sutando.config.local.json` carries no `workspace.path` override), so staged signals and ingested tasks initially landed in a parallel workspace. This is the documented worktree-bridge trap, now with the sharper lesson: pinning the config file is insufficient — the pin must include an explicit absolute `workspace.path`. Not addressed in this PR (single concern); noted for the workspace-config docs.

cc @sonichi

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJT4zUGJa6xm83p85Fjoxy
