### PR TITLE
test(bridge-audit-wiring): isolate CLAUDE_CONFIG_DIR so the import stops reading host config

### DIFF
--- a/tests/bridge-audit-wiring.test.py
+++ b/tests/bridge-audit-wiring.test.py
@@ -38,6 +38,26 @@ os.environ["SUTANDO_WORKSPACE"] = _WS
 os.environ["SUTANDO_TEST_MODE"] = "1"
 AUDIT = Path(_WS) / "state" / "result-audit.log"
 
+# Isolate the CONFIG dir too, and seed the canonical access file inside it.
+#
+# Setting DISCORD_BOT_TOKEN below stops the `.env` read, but it does NOT stop the
+# module-load-time access resolution: discord-bridge calls channel_access_path("discord"),
+# which resolves under $CLAUDE_CONFIG_DIR and falls back to the LEGACY real-home
+# ~/.claude/channels/discord/access.json when the canonical path is missing. With
+# CLAUDE_CONFIG_DIR unset the test inherits whatever the developer happens to have, so the
+# same defect shows up differently per machine — on a clean host it hits the legacy fallback
+# and prints `[util_paths] DEPRECATION: using legacy …`; on an operator host it silently
+# imports that operator's REAL Discord allowlist. Green everywhere, trustworthy nowhere.
+#
+# Pointing CLAUDE_CONFIG_DIR at a temp root and writing an empty allowlist makes the import
+# hermetic: no host state, no real file, no deprecation warning. Same shape as the telegram
+# fix in tests/bridge-timeout-guards.test.py. (qingyun, #1886 / #2426.)
+_CFG = tempfile.mkdtemp()
+os.environ["CLAUDE_CONFIG_DIR"] = _CFG
+_cfg_discord = Path(_CFG) / "channels" / "discord"
+_cfg_discord.mkdir(parents=True, exist_ok=True)
+(_cfg_discord / "access.json").write_text('{"allowFrom": []}')
+
 failures = []
 
 
@@ -72,6 +92,19 @@ except ImportError:
 os.environ["DISCORD_BOT_TOKEN"] = "test-token-not-real"
 
 db = _load("dbridge_audit", REPO / "src" / "discord-bridge.py")
+
+# Assert the isolation actually held, rather than trusting that it did. Without these the
+# test still passes while reading host config — which is exactly how this went unnoticed.
+# Checked against the real home explicitly so an inherited CLAUDE_CONFIG_DIR can't satisfy it.
+_REAL_HOME_CFG = Path.home() / ".claude"
+for _attr in ("ACCESS_FILE", "channels_env"):
+    _resolved = getattr(db, _attr, None)
+    check(f"hermetic: {_attr} is confined to the temp config root",
+          _resolved is not None and Path(_resolved).is_relative_to(_CFG),
+          f"{_attr}={_resolved} (temp root={_CFG})")
+    check(f"hermetic: {_attr} does not touch the real ~/.claude",
+          _resolved is not None and not Path(_resolved).is_relative_to(_REAL_HOME_CFG),
+          f"{_attr}={_resolved} resolved inside {_REAL_HOME_CFG}")
 
 db._mark_delivered("task-disc-1")
 check("discord: _mark_delivered writes a delivered audit line",


### PR DESCRIPTION
## Problem

`tests/bridge-audit-wiring.test.py` declared itself hermetic (comment, lines 69–72) and was not.

Setting `DISCORD_BOT_TOKEN` stops the `.env` read, but `discord-bridge.py` **also** resolves `channel_access_path("discord")` at module-load time. That reads `$CLAUDE_CONFIG_DIR` and falls back to the legacy real-home `~/.claude/channels/discord/access.json` when the canonical path is missing. The test **never set `CLAUDE_CONFIG_DIR` at all**, so it inherited whatever the developer happened to have.

That's why it read green everywhere — the symptom is machine-dependent:

| host | what the test actually read |
|---|---|
| clean | legacy fallback + `[util_paths] DEPRECATION: using legacy …` |
| operator | that operator's **real Discord allowlist**, silently |

Reproduced on an operator host: `ACCESS_FILE` resolved to `workspace/.claude-sutando/channels/discord/access.json` — the live production allowlist.

## Fix

Point `CLAUDE_CONFIG_DIR` at a temp root and seed an empty canonical `access.json` there **before `exec_module`** (token hardening *and* access resolution both run at import, so anything after the load is too late). Then **assert** the containment instead of assuming it.

Four checks — `ACCESS_FILE` and `channels_env`, each verified both confined-to-temp **and** not-under-real-`~/.claude`. Two are needed, not one: on a clean host the legacy-fallback check catches it; on an operator host the confinement check does.

## Evidence

**Before** — isolation removed, assertions kept (simulates pre-fix state), run in-tree:

```
  FAIL hermetic: ACCESS_FILE is confined to the temp config root — ACCESS_FILE=/Users/…/workspace/.claude-sutando/channels/discord/access.json (temp root=/var/folders/…/tmp9oxv58k2)
  ok   hermetic: ACCESS_FILE does not touch the real ~/.claude
  FAIL hermetic: channels_env is confined to the temp config root — channels_env=/Users/…/workspace/.claude-sutando/channels/discord/.env
  ok   hermetic: channels_env does not touch the real ~/.claude
exit=1
```

**After** — at this PR's head:

```
  ok  hermetic: ACCESS_FILE is confined to the temp config root
  ok  hermetic: ACCESS_FILE does not touch the real ~/.claude
  ok  hermetic: channels_env is confined to the temp config root
  ok  hermetic: channels_env does not touch the real ~/.claude
  … 12 existing checks …
PASS — discord audit-wiring tests
exit=0
```

Note the second assertion passes even unfixed *on this host* — that is the machine-dependence itself, and why both assertions exist.

## Scope

Test-only; no production code touched. Not a live-path change, so no restart round trip applies.

Third instance of this pattern (`bridge-timeout-guards`, `progress-stream` #2426, this one). A shared helper is the right follow-up — filed separately to keep this single-concern, per @Sutando-Mini's suggestion in #bot2bot.

Credit: @qingyun-wu found the class on #1886/#2426; @Sutando-Mini flagged this third instance and explicitly left it for a separate PR.
