### PR TITLE
fix(gateway): warn the owner when local allowFrom diverges from the broker registry

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -504,7 +504,10 @@ def _tier_for(user_id):
 # (qingyun CR 2026-07-30: protocol-compatibility regression + log spam).
 ALLOWDIV_UNSUPPORTED_COOLDOWN = int(
     os.environ.get("REMOTE_ALLOWDIV_RETRY_COOLDOWN") or "300")
-_ALLOWDIV_STATE = {"mtime": None, "warned_hash": None, "unsupported_until": 0.0}
+ALLOWDIV_POLL_INTERVAL = int(
+    os.environ.get("REMOTE_ALLOWDIV_POLL_INTERVAL") or "300")
+_ALLOWDIV_STATE = {"mtime": None, "warned_hash": None, "unsupported_until": 0.0,
+                   "next_poll": 0.0}
 
 
 def allowlist_divergence(local_allow, broker_allow, agent_id):
@@ -594,7 +597,7 @@ def _broker_allow_for(agent_id):
 
 
 def _maybe_warn_allowlist_divergence():
-    """Cheap per-loop hook: does work only on first run / access.json change."""
+    """Cheap per-loop hook: local-mtime change, or a bounded broker re-poll."""
     agent_id = _agent_id()
     if not agent_id:
         return
@@ -602,12 +605,16 @@ def _maybe_warn_allowlist_divergence():
         mt = os.path.getmtime(_ag2space_access_path())
     except OSError:
         return  # no local access.json → nothing to diverge
-    if mt == _ALLOWDIV_STATE["mtime"]:
+    # The remedy this warning prints changes the BROKER registry, which touches no
+    # local mtime — so an mtime-only trigger can never clear or re-arm the warning.
+    now = time.time()
+    if mt == _ALLOWDIV_STATE["mtime"] and now < _ALLOWDIV_STATE["next_poll"]:
         return
     broker = _broker_allow_for(agent_id)
     if broker is None:
-        return  # read failed — mtime unmarked, retried next loop
+        return  # read failed — mtime/next_poll unmarked, retried next loop
     _ALLOWDIV_STATE["mtime"] = mt
+    _ALLOWDIV_STATE["next_poll"] = now + ALLOWDIV_POLL_INTERVAL
     body = allowlist_divergence(_local_allow_from(), broker, agent_id)
     if body is None:
         _ALLOWDIV_STATE["warned_hash"] = None  # aligned again → future divergence re-warns

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -486,28 +486,17 @@ def _tier_for(user_id):
 
 
 # ── allowlist divergence warning (local access.json vs broker registry) ──────
-# TWO layers gate a sender: the BROKER's agent registry decides whose room
-# messages become tasks AT ALL; the local access.json above only re-tiers tasks
-# that already arrived. An owner who adds a teammate locally (the natural place
-# to look) gets silent message-drop at the broker — live incident 2026-07-30:
-# @mark added to local allowFrom, his @-mentions never generated tasks. Agents
-# cannot edit their OWN broker record (relay's anti-self-escalation rule), so
-# the best the bridge can do is DETECT the divergence and hand the owner the
-# exact fleet-sibling command. Checked on startup and whenever access.json
-# changes (mtime); warned once per distinct divergence set.
+# The BROKER registry decides whose messages become tasks; local access.json only
+# re-tiers ones that arrived, so a local-only add drops silently at the broker.
 
-# /v1/agents is a registry endpoint newer than the core bridge protocol
-# (tasks/ack/results/heartbeat) — an older gateway answers 404/405. Mirror the
-# /ack pattern: time-gated cooldown rather than a permanent latch, so a broker
-# that GAINS the endpoint (deploy) is picked up without a worker restart, and a
-# broker that lacks it is asked once per cooldown, not once per poll loop
-# (qingyun CR 2026-07-30: protocol-compatibility regression + log spam).
+# 404/405 means a gateway older than /v1/agents. Time-gated, not latched, so a
+# broker that gains the endpoint is picked up without restarting the worker.
 ALLOWDIV_UNSUPPORTED_COOLDOWN = int(
     os.environ.get("REMOTE_ALLOWDIV_RETRY_COOLDOWN") or "300")
 ALLOWDIV_POLL_INTERVAL = int(
     os.environ.get("REMOTE_ALLOWDIV_POLL_INTERVAL") or "300")
 _ALLOWDIV_STATE = {"mtime": None, "warned_hash": None, "unsupported_until": 0.0,
-                   "next_poll": 0.0}
+                   "next_poll": 0.0, "fail_log_until": 0.0}
 
 
 def allowlist_divergence(local_allow, broker_allow, agent_id):
@@ -564,21 +553,25 @@ def _local_allow_from():
         return []
 
 
-def _broker_allow_for(agent_id):
-    """GET /v1/agents (own bearer → the owner's fleet, safe metadata only) →
-    this agent's allowFrom, or None when unreadable. None is fail-OPEN for the
-    warning (no divergence spam off a flaky read) — the mtime is left unmarked
-    so the next loop retries.
+def _log_transient_failure(exc):
+    """One line per cooldown, not per loop: retries stay every-loop, so an
+    unbounded log would be the only cost of a gateway that is down for hours."""
+    now = time.time()
+    if now < _ALLOWDIV_STATE["fail_log_until"]:
+        return
+    _ALLOWDIV_STATE["fail_log_until"] = now + ALLOWDIV_UNSUPPORTED_COOLDOWN
+    _log(f"allowlist-divergence: broker read failed ({exc}) — retrying every loop; "
+         f"further failures silent for {ALLOWDIV_UNSUPPORTED_COOLDOWN}s")
 
-    Unsupported endpoint (404/405 = pre-registry gateway) is NOT transient:
-    it enters a time-gated cooldown with ONE log line, so existing onboarded
-    clients see one request + one line per cooldown window instead of a
-    failing call after every long-poll. Any other failure stays transient
-    (silent retry next loop, mtime unmarked)."""
+
+def _broker_allow_for(agent_id):
+    """This agent's broker allowFrom, or None when unreadable. None fails OPEN and
+    leaves the mtime unmarked, so a flaky read retries instead of warning."""
     if time.time() < _ALLOWDIV_STATE["unsupported_until"]:
         return None
     try:
         resp = _req("GET", "/v1/agents", timeout=15)
+        _ALLOWDIV_STATE["fail_log_until"] = 0.0  # recovered: the next outage logs at once
         for rec in (resp or {}).get("agents", []):
             if str(rec.get("id", "")).strip().lower() == str(agent_id).strip().lower():
                 return [str(x) for x in rec.get("allowFrom") or []]
@@ -590,9 +583,9 @@ def _broker_allow_for(agent_id):
             _log(f"allowlist-divergence: /v1/agents unsupported by this gateway "
                  f"({e.code}) — cooling down {ALLOWDIV_UNSUPPORTED_COOLDOWN}s")
         else:
-            _log(f"allowlist-divergence: broker read failed ({e}) — will retry")
+            _log_transient_failure(e)
     except Exception as e:  # noqa: BLE001 — diagnostics only; never disturb the task loop
-        _log(f"allowlist-divergence: broker read failed ({e}) — will retry")
+        _log_transient_failure(e)
     return None
 
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -496,7 +496,15 @@ def _tier_for(user_id):
 # exact fleet-sibling command. Checked on startup and whenever access.json
 # changes (mtime); warned once per distinct divergence set.
 
-_ALLOWDIV_STATE = {"mtime": None, "warned_hash": None}
+# /v1/agents is a registry endpoint newer than the core bridge protocol
+# (tasks/ack/results/heartbeat) — an older gateway answers 404/405. Mirror the
+# /ack pattern: time-gated cooldown rather than a permanent latch, so a broker
+# that GAINS the endpoint (deploy) is picked up without a worker restart, and a
+# broker that lacks it is asked once per cooldown, not once per poll loop
+# (qingyun CR 2026-07-30: protocol-compatibility regression + log spam).
+ALLOWDIV_UNSUPPORTED_COOLDOWN = int(
+    os.environ.get("REMOTE_ALLOWDIV_RETRY_COOLDOWN") or "300")
+_ALLOWDIV_STATE = {"mtime": None, "warned_hash": None, "unsupported_until": 0.0}
 
 
 def allowlist_divergence(local_allow, broker_allow, agent_id):
@@ -557,13 +565,29 @@ def _broker_allow_for(agent_id):
     """GET /v1/agents (own bearer → the owner's fleet, safe metadata only) →
     this agent's allowFrom, or None when unreadable. None is fail-OPEN for the
     warning (no divergence spam off a flaky read) — the mtime is left unmarked
-    so the next loop retries."""
+    so the next loop retries.
+
+    Unsupported endpoint (404/405 = pre-registry gateway) is NOT transient:
+    it enters a time-gated cooldown with ONE log line, so existing onboarded
+    clients see one request + one line per cooldown window instead of a
+    failing call after every long-poll. Any other failure stays transient
+    (silent retry next loop, mtime unmarked)."""
+    if time.time() < _ALLOWDIV_STATE["unsupported_until"]:
+        return None
     try:
         resp = _req("GET", "/v1/agents", timeout=15)
         for rec in (resp or {}).get("agents", []):
             if str(rec.get("id", "")).strip().lower() == str(agent_id).strip().lower():
                 return [str(x) for x in rec.get("allowFrom") or []]
         _log(f"allowlist-divergence: own record {agent_id} not in /v1/agents — skipping")
+    except urllib.error.HTTPError as e:
+        if e.code in (404, 405):
+            _ALLOWDIV_STATE["unsupported_until"] = (
+                time.time() + ALLOWDIV_UNSUPPORTED_COOLDOWN)
+            _log(f"allowlist-divergence: /v1/agents unsupported by this gateway "
+                 f"({e.code}) — cooling down {ALLOWDIV_UNSUPPORTED_COOLDOWN}s")
+        else:
+            _log(f"allowlist-divergence: broker read failed ({e}) — will retry")
     except Exception as e:  # noqa: BLE001 — diagnostics only; never disturb the task loop
         _log(f"allowlist-divergence: broker read failed ({e}) — will retry")
     return None

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import atexit
 import base64
+import hashlib
 import json
 import os
 import uuid
@@ -482,6 +483,123 @@ def _tier_for(user_id):
             local_rank = _TIER_RANK.get(LOCAL_TIER, _TIER_RANK["owner"])
             return mapped if _TIER_RANK[mapped] <= local_rank else LOCAL_TIER
     return LOCAL_TIER
+
+
+# ── allowlist divergence warning (local access.json vs broker registry) ──────
+# TWO layers gate a sender: the BROKER's agent registry decides whose room
+# messages become tasks AT ALL; the local access.json above only re-tiers tasks
+# that already arrived. An owner who adds a teammate locally (the natural place
+# to look) gets silent message-drop at the broker — live incident 2026-07-30:
+# @mark added to local allowFrom, his @-mentions never generated tasks. Agents
+# cannot edit their OWN broker record (relay's anti-self-escalation rule), so
+# the best the bridge can do is DETECT the divergence and hand the owner the
+# exact fleet-sibling command. Checked on startup and whenever access.json
+# changes (mtime); warned once per distinct divergence set.
+
+_ALLOWDIV_STATE = {"mtime": None, "warned_hash": None}
+
+
+def allowlist_divergence(local_allow, broker_allow, agent_id):
+    """Owner-warning body when LOCAL allowFrom names senders the BROKER
+    registry lacks (their room messages silently never become tasks); None when
+    aligned. Pure — no I/O. Only the local-minus-broker direction warns: that
+    is the silent-drop case; broker-extra senders still get tasks and are
+    tier-clamped locally by _tier_for."""
+    local = {str(x).strip() for x in (local_allow or []) if str(x).strip()}
+    broker = {str(x).strip() for x in (broker_allow or []) if str(x).strip()}
+    missing = sorted(m for m in local - broker if m != str(agent_id).strip())
+    if not missing:
+        return None
+    adds = " ".join(f"--allow-add {m}" for m in missing)
+    return (
+        "[dm-only] ⚠️ AG2 Space allowlist divergence: local access.json allows "
+        f"{', '.join(missing)}, but the BROKER registry for {agent_id} does not — "
+        "their room messages (including @-mentions) are dropped before this agent "
+        "ever sees them. Agents can't edit their own broker record; run from a "
+        "fleet sibling (its bearer in env):\n"
+        f"  agent_access.py set {agent_id} {adds}"
+    )
+
+
+def _agent_id():
+    """This agent's mxid: $AGENT_ID, else the same channel .env files the token
+    reader uses. '' when unknowable (divergence check silently disabled)."""
+    env_id = (os.environ.get("AGENT_ID") or "").strip()
+    if env_id:
+        return env_id
+    candidates = [os.environ.get("AG2_DEVICE_ENV")]
+    _cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+    if _cfg:
+        candidates.append(os.path.join(_cfg, "channels", "ag2space", ".env"))
+    for path in candidates:
+        if not path:
+            continue
+        try:
+            with open(path, encoding="utf-8") as fh:
+                for ln in fh.read().splitlines():
+                    ln = ln.strip()
+                    if ln.startswith("AGENT_ID="):
+                        return ln.split("=", 1)[1].strip().strip('"').strip("'")
+        except OSError:
+            continue
+    return ""
+
+
+def _local_allow_from():
+    try:
+        with open(_ag2space_access_path(), encoding="utf-8") as f:
+            return [str(x) for x in (json.load(f) or {}).get("allowFrom") or []]
+    except Exception:
+        return []
+
+
+def _broker_allow_for(agent_id):
+    """GET /v1/agents (own bearer → the owner's fleet, safe metadata only) →
+    this agent's allowFrom, or None when unreadable. None is fail-OPEN for the
+    warning (no divergence spam off a flaky read) — the mtime is left unmarked
+    so the next loop retries."""
+    try:
+        resp = _req("GET", "/v1/agents", timeout=15)
+        for rec in (resp or {}).get("agents", []):
+            if str(rec.get("id", "")).strip().lower() == str(agent_id).strip().lower():
+                return [str(x) for x in rec.get("allowFrom") or []]
+        _log(f"allowlist-divergence: own record {agent_id} not in /v1/agents — skipping")
+    except Exception as e:  # noqa: BLE001 — diagnostics only; never disturb the task loop
+        _log(f"allowlist-divergence: broker read failed ({e}) — will retry")
+    return None
+
+
+def _maybe_warn_allowlist_divergence():
+    """Cheap per-loop hook: does work only on first run / access.json change."""
+    agent_id = _agent_id()
+    if not agent_id:
+        return
+    try:
+        mt = os.path.getmtime(_ag2space_access_path())
+    except OSError:
+        return  # no local access.json → nothing to diverge
+    if mt == _ALLOWDIV_STATE["mtime"]:
+        return
+    broker = _broker_allow_for(agent_id)
+    if broker is None:
+        return  # read failed — mtime unmarked, retried next loop
+    _ALLOWDIV_STATE["mtime"] = mt
+    body = allowlist_divergence(_local_allow_from(), broker, agent_id)
+    if body is None:
+        _ALLOWDIV_STATE["warned_hash"] = None  # aligned again → future divergence re-warns
+        return
+    h = hashlib.sha1(body.encode()).hexdigest()
+    if h == _ALLOWDIV_STATE["warned_hash"]:
+        return
+    _ALLOWDIV_STATE["warned_hash"] = h
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    # uuid suffix: two distinct warnings inside one second must not collide on
+    # the epoch filename (os.replace would silently clobber the first).
+    out = RESULTS_DIR / f"proactive-allowdiv-{int(time.time())}-{uuid.uuid4().hex[:6]}.txt"
+    tmp = out.with_suffix(".tmp")
+    tmp.write_text(body + "\n", encoding="utf-8")
+    os.replace(tmp, out)  # atomic — the proactive drain never sees a torn file
+    _log(f"allowlist-divergence: owner warned → {out.name}")
 
 
 # ── inbound media fetch (owner screenshots, file uploads) ────────────────────
@@ -1595,6 +1713,9 @@ def main() -> None:
             _post_heartbeat(inflight)
             backoff = 1  # healthy round-trip → reset backoff
             _emit_gateway_status(True)
+            # Diagnostics only, after the healthy round-trip so a broken
+            # gateway never turns a task-loop error into divergence spam.
+            _maybe_warn_allowlist_divergence()
         except urllib.error.HTTPError as e:
             if e.code in (401, 403):
                 _emit_gateway_status(False, error=f"auth rejected HTTP {e.code}")

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -500,11 +500,8 @@ _ALLOWDIV_STATE = {"mtime": None, "warned_hash": None, "unsupported_until": 0.0,
 
 
 def allowlist_divergence(local_allow, broker_allow, agent_id):
-    """Owner-warning body when LOCAL allowFrom names senders the BROKER
-    registry lacks (their room messages silently never become tasks); None when
-    aligned. Pure — no I/O. Only the local-minus-broker direction warns: that
-    is the silent-drop case; broker-extra senders still get tasks and are
-    tier-clamped locally by _tier_for."""
+    """Only local-minus-broker warns: that is the silent-drop direction.
+    Broker-extra senders still get tasks, tier-clamped locally by _tier_for."""
     local = {str(x).strip() for x in (local_allow or []) if str(x).strip()}
     broker = {str(x).strip() for x in (broker_allow or []) if str(x).strip()}
     missing = sorted(m for m in local - broker if m != str(agent_id).strip())

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -485,7 +485,6 @@ def _tier_for(user_id):
     return LOCAL_TIER
 
 
-# ── allowlist divergence warning (local access.json vs broker registry) ──────
 # The BROKER registry decides whose messages become tasks; local access.json only
 # re-tiers ones that arrived, so a local-only add drops silently at the broker.
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -593,7 +593,7 @@ def _maybe_warn_allowlist_divergence():
     try:
         mt = os.path.getmtime(_ag2space_access_path())
     except OSError:
-        return  # no local access.json → nothing to diverge
+        return
     # The remedy this warning prints changes the BROKER registry, which touches no
     # local mtime — so an mtime-only trigger can never clear or re-arm the warning.
     now = time.time()

--- a/tests/gateway-allowlist-divergence.test.py
+++ b/tests/gateway-allowlist-divergence.test.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
 """Allowlist-divergence warning in the ag2-sparrow gateway bridge.
 
-TWO layers gate an AG2 Space sender: the broker registry decides whose room
-messages become tasks at all; the local access.json only re-tiers arrived
-tasks. Adding a teammate locally therefore silently drops their messages at
-the broker (live incident 2026-07-30: @mark's @-mentions never became tasks).
-Agents can't edit their own broker record, so the bridge now DETECTS the
-divergence and warns the owner with the exact fleet-sibling command.
+The broker registry decides whose room messages become tasks; local access.json
+only re-tiers ones that arrived. A local-only add therefore drops silently at
+the broker, and the bridge detects that divergence and warns the owner.
 
 Hermetic — no network: _req is monkeypatched; config/state under temp roots
 (CLAUDE_CONFIG_DIR seeded BEFORE import per the #2429 isolation rule).
@@ -18,6 +15,7 @@ Covers:
   4. dedup: unchanged divergence never warns twice; a NEW divergence re-warns
   5. broker read failure → no warning, no mtime consumption (retries next loop)
   6. realignment clears the warned-hash (future divergence warns again)
+  7. a persistently failing broker keeps retrying but logs once per cooldown
 
 Run: python3 tests/gateway-allowlist-divergence.test.py   (exit 0 / 1)
 """
@@ -133,10 +131,8 @@ try:
     rgb._maybe_warn_allowlist_divergence()
     check("same set after touch not re-warned (hash dedup)", len(proactive_files(tmp)) == 1)
 
-    # 4b-bis. BROKER-ONLY transitions, access.json untouched throughout. This is
-    # the case the mtime-only trigger could not see: the remedy the warning prints
-    # changes the broker, not the local file, so clear and re-warn must not depend
-    # on a local write. Each pass forces the poll due rather than sleeping.
+    # 4b-bis. BROKER-ONLY transitions with access.json untouched — the case an
+    # mtime-only trigger cannot see. Each pass forces the poll due, not sleeps.
     def _due():
         rgb._ALLOWDIV_STATE["next_poll"] = 0.0
 
@@ -265,13 +261,21 @@ def fake_500(method, path, payload=None, timeout=35):
 
 
 rgb._req = fake_500
-rgb._log = lambda msg: None
+_500_logs = []
+rgb._log = _500_logs.append
 try:
-    rgb._maybe_warn_allowlist_divergence()
-    rgb._maybe_warn_allowlist_divergence()
-    check("500: stays transient — both loops retry, no cooldown",
-          _500_calls["n"] == 2 and rgb._ALLOWDIV_STATE["unsupported_until"] == 0.0,
+    for _ in range(5):
+        rgb._maybe_warn_allowlist_divergence()
+    check("500: stays transient — every loop retries, no cooldown",
+          _500_calls["n"] == 5 and rgb._ALLOWDIV_STATE["unsupported_until"] == 0.0,
           f"calls={_500_calls['n']} state={rgb._ALLOWDIV_STATE}")
+    # Retries are every-loop by design, so the log is what has to be bounded.
+    check("500: five failures log ONCE, not five times",
+          len(_500_logs) == 1, f"logs={_500_logs}")
+    rgb._ALLOWDIV_STATE["fail_log_until"] = 0.0
+    rgb._maybe_warn_allowlist_divergence()
+    check("500: a failure after the window logs again",
+          len(_500_logs) == 2, f"logs={_500_logs}")
 finally:
     rgb._req = _orig_req
     rgb._log = _orig_log

--- a/tests/gateway-allowlist-divergence.test.py
+++ b/tests/gateway-allowlist-divergence.test.py
@@ -133,10 +133,39 @@ try:
     rgb._maybe_warn_allowlist_divergence()
     check("same set after touch not re-warned (hash dedup)", len(proactive_files(tmp)) == 1)
 
-    # 4c. a NEW divergence (another sender) → second warning
+    # 4b-bis. BROKER-ONLY transitions, access.json untouched throughout. This is
+    # the case the mtime-only trigger could not see: the remedy the warning prints
+    # changes the broker, not the local file, so clear and re-warn must not depend
+    # on a local write. Each pass forces the poll due rather than sleeping.
+    def _due():
+        rgb._ALLOWDIV_STATE["next_poll"] = 0.0
+
+    before = len(proactive_files(tmp))
+    mtime_before = os.path.getmtime(rgb._ag2space_access_path())
+
+    # broker realigns (adds the missing sender) — warned_hash must clear
+    rgb._req = fake_req_factory([{"id": AGENT, "allowFrom": ["@rui:hs", "@mark:hs"]}])
+    _due(); rgb._maybe_warn_allowlist_divergence()
+    check("broker-only realignment writes no new warning",
+          len(proactive_files(tmp)) == before)
+    check("broker-only realignment CLEARED the warned hash",
+          rgb._ALLOWDIV_STATE["warned_hash"] is None)
+
+    # broker diverges again — must re-warn without any local change
+    rgb._req = fake_req_factory([{"id": AGENT, "allowFrom": ["@rui:hs"]}])
+    _due(); rgb._maybe_warn_allowlist_divergence()
+    check("broker-only re-divergence re-warns", len(proactive_files(tmp)) == before + 1,
+          repr(proactive_files(tmp)))
+    check("access.json was never touched across the three passes",
+          os.path.getmtime(rgb._ag2space_access_path()) == mtime_before)
+
+    # 4c. a NEW divergence (another sender) → one more warning. Counted relative
+    # to the prior state: an absolute count silently breaks when a case is inserted
+    # above, which is a stale assertion rather than a real regression.
+    n_before = len(proactive_files(tmp))
     write_access(["@rui:hs", "@mark:hs", "@sam:hs"])
     rgb._maybe_warn_allowlist_divergence()
-    check("new divergence set re-warns", len(proactive_files(tmp)) == 2,
+    check("new divergence set re-warns", len(proactive_files(tmp)) == n_before + 1,
           repr(proactive_files(tmp)))
 finally:
     rgb._req = _orig_req

--- a/tests/gateway-allowlist-divergence.test.py
+++ b/tests/gateway-allowlist-divergence.test.py
@@ -221,6 +221,32 @@ finally:
     rgb._log = _orig_log
     rgb._ALLOWDIV_STATE["unsupported_until"] = 0.0
 
+# 7b. a non-404/405 HTTP error (e.g. 500) stays TRANSIENT: no cooldown is
+# entered, so the very next loop retries — only the unsupported-endpoint
+# shape gets the time gate.
+tmp = fresh()
+rgb._ALLOWDIV_STATE["unsupported_until"] = 0.0
+write_access(["@rui:hs", "@mark:hs"])
+_500_calls = {"n": 0}
+
+
+def fake_500(method, path, payload=None, timeout=35):
+    _500_calls["n"] += 1
+    raise urllib.error.HTTPError("/v1/agents", 500, "boom", {}, io.BytesIO(b""))
+
+
+rgb._req = fake_500
+rgb._log = lambda msg: None
+try:
+    rgb._maybe_warn_allowlist_divergence()
+    rgb._maybe_warn_allowlist_divergence()
+    check("500: stays transient — both loops retry, no cooldown",
+          _500_calls["n"] == 2 and rgb._ALLOWDIV_STATE["unsupported_until"] == 0.0,
+          f"calls={_500_calls['n']} state={rgb._ALLOWDIV_STATE}")
+finally:
+    rgb._req = _orig_req
+    rgb._log = _orig_log
+
 # agent-id resolution from the seeded .env (no $AGENT_ID in env)
 check("agent id read from channel .env", rgb._agent_id() == AGENT, rgb._agent_id())
 

--- a/tests/gateway-allowlist-divergence.test.py
+++ b/tests/gateway-allowlist-divergence.test.py
@@ -170,6 +170,57 @@ try:
 finally:
     rgb._req = _orig_req
 
+# 7. unsupported endpoint (404/405 = pre-registry gateway): mirror the /ack
+# cooldown (qingyun CR 2026-07-30). Two consecutive loops must make exactly ONE
+# /v1/agents attempt and ONE log line; after the cooldown expires the request
+# is retried (self-healing, no worker restart needed). mtime stays unmarked so
+# a gateway that gains the endpoint still gets the real divergence check.
+import io
+import urllib.error
+
+tmp = fresh()
+rgb._ALLOWDIV_STATE["unsupported_until"] = 0.0
+write_access(["@rui:hs", "@mark:hs"])
+_404_calls = {"n": 0}
+_404_logs: list[str] = []
+
+
+def fake_404(method, path, payload=None, timeout=35):
+    _404_calls["n"] += 1
+    raise urllib.error.HTTPError("/v1/agents", 404, "Not Found", {}, io.BytesIO(b""))
+
+
+_orig_log = rgb._log
+rgb._req = fake_404
+rgb._log = lambda msg: _404_logs.append(msg)
+try:
+    rgb._maybe_warn_allowlist_divergence()
+    rgb._maybe_warn_allowlist_divergence()
+    check("404: two loops make exactly one /v1/agents attempt",
+          _404_calls["n"] == 1, f"calls={_404_calls['n']}")
+    check("404: exactly one log line (no per-loop spam)",
+          len([m for m in _404_logs if "unsupported" in m]) == 1
+          and len(_404_logs) == 1, repr(_404_logs))
+    check("404: no warning files written", len(proactive_files(tmp)) == 0,
+          repr(proactive_files(tmp)))
+    check("404: mtime left unmarked (endpoint may appear later)",
+          rgb._ALLOWDIV_STATE["mtime"] is None, repr(rgb._ALLOWDIV_STATE))
+    # cooldown expiry → retried exactly once more
+    rgb._ALLOWDIV_STATE["unsupported_until"] = time.time() - 1
+    rgb._maybe_warn_allowlist_divergence()
+    check("404: retried after the cooldown (self-healing)",
+          _404_calls["n"] == 2, f"calls={_404_calls['n']}")
+    # broker later GAINS the endpoint → divergence detection works immediately
+    rgb._ALLOWDIV_STATE["unsupported_until"] = 0.0
+    rgb._req = fake_req_factory([{"id": AGENT, "allowFrom": ["@rui:hs"]}])
+    rgb._maybe_warn_allowlist_divergence()
+    check("gained endpoint after cooldown: divergence warns",
+          len(proactive_files(tmp)) == 1, repr(proactive_files(tmp)))
+finally:
+    rgb._req = _orig_req
+    rgb._log = _orig_log
+    rgb._ALLOWDIV_STATE["unsupported_until"] = 0.0
+
 # agent-id resolution from the seeded .env (no $AGENT_ID in env)
 check("agent id read from channel .env", rgb._agent_id() == AGENT, rgb._agent_id())
 

--- a/tests/gateway-allowlist-divergence.test.py
+++ b/tests/gateway-allowlist-divergence.test.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Allowlist-divergence warning in the ag2-sparrow gateway bridge.
+
+TWO layers gate an AG2 Space sender: the broker registry decides whose room
+messages become tasks at all; the local access.json only re-tiers arrived
+tasks. Adding a teammate locally therefore silently drops their messages at
+the broker (live incident 2026-07-30: @mark's @-mentions never became tasks).
+Agents can't edit their own broker record, so the bridge now DETECTS the
+divergence and warns the owner with the exact fleet-sibling command.
+
+Hermetic — no network: _req is monkeypatched; config/state under temp roots
+(CLAUDE_CONFIG_DIR seeded BEFORE import per the #2429 isolation rule).
+
+Covers:
+  1. pure divergence body: missing sender named + exact fix command; None when aligned
+  2. own agent-id / blank entries never count as divergence
+  3. hook end-to-end: local access.json + fake broker → ONE [dm-only] proactive file
+  4. dedup: unchanged divergence never warns twice; a NEW divergence re-warns
+  5. broker read failure → no warning, no mtime consumption (retries next loop)
+  6. realignment clears the warned-hash (future divergence warns again)
+
+Run: python3 tests/gateway-allowlist-divergence.test.py   (exit 0 / 1)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Isolate channel config BEFORE the bridge import (#2429 rule): access path +
+# agent identity both resolve under this temp root, never the operator's real one.
+_CFG = Path(tempfile.mkdtemp(prefix="allowdiv-cfg-"))
+os.environ["CLAUDE_CONFIG_DIR"] = str(_CFG)
+_CH = _CFG / "channels" / "ag2space"
+_CH.mkdir(parents=True, exist_ok=True)
+(_CH / ".env").write_text("AGENT_ID=@sutando-test:ag2.space\n")
+os.environ.pop("AGENT_ID", None)
+os.environ.pop("AG2_DEVICE_ENV", None)
+
+sys.path.insert(0, str(REPO / "packages" / "ag2-sparrow"))
+import ag2_sparrow.remote_gateway_bridge as rgb  # noqa: E402
+from ag2_sparrow._dirs import set_dirs  # noqa: E402
+
+failures: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    print(("ok   " if cond else "FAIL ") + name + ("" if cond else f" — {detail}"))
+    if not cond:
+        failures.append(name)
+
+
+AGENT = "@sutando-test:ag2.space"
+
+# ---------------------------------------------------------------------------
+# 1–2. pure body
+# ---------------------------------------------------------------------------
+body = rgb.allowlist_divergence(["@rui:hs", "@mark:hs"], ["@rui:hs"], AGENT)
+check("divergence names the missing sender", body is not None and "@mark:hs" in body, repr(body)[:80])
+check("divergence carries the exact fix command",
+      body is not None and f"agent_access.py set {AGENT} --allow-add @mark:hs" in body, repr(body)[-120:])
+check("divergence is dm-only", body is not None and body.startswith("[dm-only]"))
+check("aligned → None", rgb.allowlist_divergence(["@rui:hs"], ["@rui:hs"], AGENT) is None)
+check("broker superset → None (only silent-drop direction warns)",
+      rgb.allowlist_divergence(["@rui:hs"], ["@rui:hs", "@extra:hs"], AGENT) is None)
+check("own id/blank entries ignored",
+      rgb.allowlist_divergence([AGENT, "  ", "@rui:hs"], ["@rui:hs"], AGENT) is None)
+
+# ---------------------------------------------------------------------------
+# hook end-to-end with fake broker + temp dirs
+# ---------------------------------------------------------------------------
+def fresh():
+    tmp = Path(tempfile.mkdtemp(prefix="allowdiv-ws-"))
+    set_dirs(task_dir=tmp / "tasks", result_dir=tmp / "results", state_dir=tmp / "state")
+    rgb.RESULTS_DIR = tmp / "results"
+    rgb._ALLOWDIV_STATE["mtime"] = None
+    rgb._ALLOWDIV_STATE["warned_hash"] = None
+    return tmp
+
+
+def write_access(allow):
+    p = Path(rgb._ag2space_access_path())
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"allowFrom": allow}))
+    # mtime granularity is coarse — force a distinct value per write
+    t = time.time() + write_access._bump
+    write_access._bump += 2
+    os.utime(p, (t, t))
+
+
+write_access._bump = 0
+
+_orig_req = rgb._req
+
+
+def fake_req_factory(agents_payload=None, fail=False):
+    def _fake(method, path, payload=None, timeout=35):
+        if path == "/v1/agents":
+            if fail:
+                raise OSError("broker down")
+            return {"agents": agents_payload or []}
+        raise AssertionError(f"unexpected {method} {path}")
+    return _fake
+
+
+def proactive_files(tmp):
+    return sorted((tmp / "results").glob("proactive-allowdiv-*.txt"))
+
+
+# 3. divergence → exactly one [dm-only] proactive file
+tmp = fresh()
+write_access(["@rui:hs", "@mark:hs"])
+rgb._req = fake_req_factory([{"id": AGENT, "allowFrom": ["@rui:hs"]}])
+try:
+    rgb._maybe_warn_allowlist_divergence()
+    files = proactive_files(tmp)
+    check("hook writes one proactive warning", len(files) == 1, repr(files))
+    body = files[0].read_text() if files else ""
+    check("warning body has sender + command",
+          "@mark:hs" in body and "agent_access.py set" in body, body[:100])
+
+    # 4a. same divergence, another loop pass → no second file
+    rgb._maybe_warn_allowlist_divergence()
+    check("unchanged divergence not re-warned", len(proactive_files(tmp)) == 1)
+
+    # 4b. access.json touched but SAME divergence set → still no second file
+    write_access(["@rui:hs", "@mark:hs"])
+    rgb._maybe_warn_allowlist_divergence()
+    check("same set after touch not re-warned (hash dedup)", len(proactive_files(tmp)) == 1)
+
+    # 4c. a NEW divergence (another sender) → second warning
+    write_access(["@rui:hs", "@mark:hs", "@sam:hs"])
+    rgb._maybe_warn_allowlist_divergence()
+    check("new divergence set re-warns", len(proactive_files(tmp)) == 2,
+          repr(proactive_files(tmp)))
+finally:
+    rgb._req = _orig_req
+
+# 5. broker read failure → no warning, retried (mtime not consumed)
+tmp = fresh()
+write_access(["@rui:hs", "@mark:hs"])
+rgb._req = fake_req_factory(fail=True)
+try:
+    rgb._maybe_warn_allowlist_divergence()
+    check("broker failure → no warning", len(proactive_files(tmp)) == 0)
+    # now broker comes back — same mtime must be retried
+    rgb._req = fake_req_factory([{"id": AGENT, "allowFrom": ["@rui:hs"]}])
+    rgb._maybe_warn_allowlist_divergence()
+    check("retry after broker recovery warns", len(proactive_files(tmp)) == 1)
+finally:
+    rgb._req = _orig_req
+
+# 6. realignment clears warned-hash → later divergence warns again
+tmp = fresh()
+write_access(["@rui:hs", "@mark:hs"])
+rgb._req = fake_req_factory([{"id": AGENT, "allowFrom": ["@rui:hs"]}])
+try:
+    rgb._maybe_warn_allowlist_divergence()
+    write_access(["@rui:hs"])                      # aligned now
+    rgb._maybe_warn_allowlist_divergence()
+    write_access(["@rui:hs", "@mark:hs"])          # diverges again
+    rgb._maybe_warn_allowlist_divergence()
+    check("realign then re-diverge warns twice total", len(proactive_files(tmp)) == 2,
+          repr(proactive_files(tmp)))
+finally:
+    rgb._req = _orig_req
+
+# agent-id resolution from the seeded .env (no $AGENT_ID in env)
+check("agent id read from channel .env", rgb._agent_id() == AGENT, rgb._agent_id())
+
+print()
+if failures:
+    print(f"{len(failures)} FAILURE(S): {failures}")
+    sys.exit(1)
+print("All gateway allowlist-divergence checks passed.")

--- a/tests/gateway-allowlist-divergence.test.py
+++ b/tests/gateway-allowlist-divergence.test.py
@@ -37,9 +37,7 @@ def check(name: str, cond: bool, detail: str = "") -> None:
 
 AGENT = "@sutando-test:ag2.space"
 
-# ---------------------------------------------------------------------------
 # 1–2. pure body
-# ---------------------------------------------------------------------------
 body = rgb.allowlist_divergence(["@rui:hs", "@mark:hs"], ["@rui:hs"], AGENT)
 check("divergence names the missing sender", body is not None and "@mark:hs" in body, repr(body)[:80])
 check("divergence carries the exact fix command",
@@ -51,9 +49,7 @@ check("broker superset → None (only silent-drop direction warns)",
 check("own id/blank entries ignored",
       rgb.allowlist_divergence([AGENT, "  ", "@rui:hs"], ["@rui:hs"], AGENT) is None)
 
-# ---------------------------------------------------------------------------
 # hook end-to-end with fake broker + temp dirs
-# ---------------------------------------------------------------------------
 def fresh():
     tmp = Path(tempfile.mkdtemp(prefix="allowdiv-ws-"))
     set_dirs(task_dir=tmp / "tasks", result_dir=tmp / "results", state_dir=tmp / "state")
@@ -137,9 +133,8 @@ try:
     check("access.json was never touched across the three passes",
           os.path.getmtime(rgb._ag2space_access_path()) == mtime_before)
 
-    # 4c. a NEW divergence (another sender) → one more warning. Counted relative
-    # to the prior state: an absolute count silently breaks when a case is inserted
-    # above, which is a stale assertion rather than a real regression.
+    # 4c. Counted relative to the prior state: an absolute count silently breaks
+    # when a case is inserted above, reading as a regression rather than staleness.
     n_before = len(proactive_files(tmp))
     write_access(["@rui:hs", "@mark:hs", "@sam:hs"])
     rgb._maybe_warn_allowlist_divergence()
@@ -177,11 +172,8 @@ try:
 finally:
     rgb._req = _orig_req
 
-# 7. unsupported endpoint (404/405 = pre-registry gateway): mirror the /ack
-# cooldown (qingyun CR 2026-07-30). Two consecutive loops must make exactly ONE
-# /v1/agents attempt and ONE log line; after the cooldown expires the request
-# is retried (self-healing, no worker restart needed). mtime stays unmarked so
-# a gateway that gains the endpoint still gets the real divergence check.
+# 7. 404/405 means a pre-registry gateway: cooldown, then retry. mtime stays
+# unmarked so a gateway that later gains the endpoint still gets checked.
 import io
 import urllib.error
 
@@ -228,9 +220,8 @@ finally:
     rgb._log = _orig_log
     rgb._ALLOWDIV_STATE["unsupported_until"] = 0.0
 
-# 7b. a non-404/405 HTTP error (e.g. 500) stays TRANSIENT: no cooldown is
-# entered, so the very next loop retries — only the unsupported-endpoint
-# shape gets the time gate.
+# 7b. A non-404/405 error stays TRANSIENT: no cooldown, so the next loop
+# retries — only the unsupported-endpoint shape gets the time gate.
 tmp = fresh()
 rgb._ALLOWDIV_STATE["unsupported_until"] = 0.0
 write_access(["@rui:hs", "@mark:hs"])

--- a/tests/gateway-allowlist-divergence.test.py
+++ b/tests/gateway-allowlist-divergence.test.py
@@ -1,24 +1,6 @@
 #!/usr/bin/env python3
-"""Allowlist-divergence warning in the ag2-sparrow gateway bridge.
-
-The broker registry decides whose room messages become tasks; local access.json
-only re-tiers ones that arrived. A local-only add therefore drops silently at
-the broker, and the bridge detects that divergence and warns the owner.
-
-Hermetic — no network: _req is monkeypatched; config/state under temp roots
-(CLAUDE_CONFIG_DIR seeded BEFORE import per the #2429 isolation rule).
-
-Covers:
-  1. pure divergence body: missing sender named + exact fix command; None when aligned
-  2. own agent-id / blank entries never count as divergence
-  3. hook end-to-end: local access.json + fake broker → ONE [dm-only] proactive file
-  4. dedup: unchanged divergence never warns twice; a NEW divergence re-warns
-  5. broker read failure → no warning, no mtime consumption (retries next loop)
-  6. realignment clears the warned-hash (future divergence warns again)
-  7. a persistently failing broker keeps retrying but logs once per cooldown
-
-Run: python3 tests/gateway-allowlist-divergence.test.py   (exit 0 / 1)
-"""
+"""Hermetic: `_req` is monkeypatched and CLAUDE_CONFIG_DIR must be seeded BEFORE
+import — the module reads it at import time, so a later setenv is too late."""
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## What

Live incident (2026-07-30): the owner added a teammate (@mark) to the local ag2space `access.json` allowFrom — the natural place to look — and the teammate's room messages, **including @-mentions of the agent, silently never became tasks**. Root cause: TWO layers gate a sender. The **broker's agent registry** decides whose room messages become tasks at all; the local `access.json` only re-tiers tasks that already arrived. The layers can silently diverge, and nothing said so.

Agents can't edit their own broker record (the relay's deliberate anti-self-escalation rule — `POST /v1/agents/<id>/access` requires a fleet-sibling's bearer), so the bridge can't self-heal. What it CAN do — and now does — is **detect the divergence and hand the owner the exact fix**:

- On startup and on every `access.json` mtime change (checked after a healthy poll round-trip, so a broken gateway never turns task-loop errors into divergence spam), the bridge GETs `/v1/agents` (own bearer, safe metadata) and diffs its record's `allowFrom` against the local one.
- Divergence → ONE `[dm-only]` proactive result naming the dropped senders and the exact command: `agent_access.py set <agent> --allow-add <sender> …`
- sha1-deduped per divergence set; realignment re-arms; uuid-suffixed filenames (same-second warnings must not clobber — caught by the test suite); broker read failure → silent retry, never a false warning.
- Only the local-minus-broker direction warns: broker-extra senders still get tasks and are tier-clamped locally by `_tier_for` (that direction can't silently drop anything).

## Evidence (at head)

```
$ python3 tests/gateway-allowlist-divergence.test.py
All gateway allowlist-divergence checks passed.   # 15 hermetic checks, no network:
  pure body + exact fix command · [dm-only] · broker-superset/self-id no-ops ·
  e2e hook (monkeypatched _req) writes exactly one proactive file ·
  hash dedup / touch-no-rewarn / new-set re-warns · broker-failure retry ·
  realign re-arms · agent-id resolved from the channel .env
  (CLAUDE_CONFIG_DIR isolated BEFORE import, incl. seeded channel .env)

$ for t in tests/gateway-*.test.py tests/remote-gateway-*.test.py tests/sparrow-*.test.py; do …
ALL GATEWAY SUITES PASS

$ git diff origin/main...HEAD | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths clean)
```

Live verification plan: after merge + bridge restart on my host, the current real divergence (@mark locally allowed, broker-unaware) should produce exactly one owner-DM warning naming him with the sibling command — I'll post that DM here as the live round-trip. (The owner is separately running the sibling command to fix the underlying record; if that lands first, I'll re-create a harmless divergence to capture the warning.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vXW4jZyEySfbo1UGUZmm7


## Test coverage (moved out of the test file's docstring)

`tests/gateway-allowlist-divergence.test.py` covers:

1. pure divergence body — missing sender named + exact fix command; `None` when aligned
2. own agent-id / blank entries never count as divergence
3. hook end-to-end: local `access.json` + fake broker → ONE `[dm-only]` proactive file
4. dedup: unchanged divergence never warns twice; a NEW divergence re-warns
5. broker read failure → no warning, no mtime consumption (retries next loop)
6. realignment clears the warned-hash, so a future divergence warns again
7. a persistently failing broker keeps retrying but logs once per cooldown

Run: `python3 tests/gateway-allowlist-divergence.test.py` (exit 0 / 1). Hermetic — no network.
