### PR TITLE
fix(tests): start-cli config-dir stubs must model the core lifecycle

### DIFF
--- a/tests/shell-ci-known-failures.txt
+++ b/tests/shell-ci-known-failures.txt
@@ -9,7 +9,6 @@
 tests/codex-bounded.test.sh
 tests/cron-gate.test.sh
 tests/migration-safety-helpers.test.sh
-tests/start-cli-claude-config-dir.test.sh
 tests/startup-env-token-persist.test.sh
 tests/startup-self-log-tmp.test.sh
 tests/sutando-migrate.test.sh

--- a/tests/start-cli-claude-config-dir.test.sh
+++ b/tests/start-cli-claude-config-dir.test.sh
@@ -67,15 +67,41 @@ exit 0
 EOF
   chmod +x "$BIN_STUB/claude"
 
-  # Stub `pgrep` — start-cli's L34/L48 use pgrep to detect an existing
-  # sutando-core session and short-circuit to "already running". The TEST
-  # runner itself IS a claude process, so real pgrep would match and the
-  # spawn path never runs. Stub returns exit 1 (no matches found).
-  cat > "$BIN_STUB/pgrep" << 'EOF'
+  # Stubs must model the core LIFECYCLE, not a fixed "nothing is running".
+  # #2418 added a post-launch liveness verify (tmux_core_session_running: session
+  # exists AND a live `claude --name $SESSION` under it) that exits non-zero when
+  # the core does not come up. Stubs that always report "not running" satisfy the
+  # pre-launch short-circuit but can never satisfy that verify, so start-cli
+  # correctly exits 1 and every case here failed on the exit code before reaching
+  # its real assertions. A marker file, written by the new-session stub, is the
+  # before/after discriminator.
+  CORE_UP_MARKER="$SANDBOX/.core-up"
+  export CORE_UP_MARKER
+
+  # Stub `pgrep` — before launch: no match (so the "already running"
+  # short-circuit is not taken; the test runner is itself a claude process, so
+  # real pgrep would match). After launch: report the fake core pid.
+  cat > "$BIN_STUB/pgrep" << EOF
 #!/bin/bash
-exit 1
+[ -f "$CORE_UP_MARKER" ] || exit 1
+echo "424242 claude"
 EOF
   chmod +x "$BIN_STUB/pgrep"
+
+  # Stub `ps` — core_claude_pids cross-checks each pgrep pid against
+  # \\`ps -p <pid> -o args=\\` and keeps only those whose args carry
+  # "--name \$SESSION". Faking pgrep alone is not enough.
+  cat > "$BIN_STUB/ps" << EOF
+#!/bin/bash
+case " \$* " in
+  *" 424242 "*)
+    [ -f "$CORE_UP_MARKER" ] || exit 1
+    echo "claude --name sutando-core --dangerously-skip-permissions"
+    ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$BIN_STUB/ps"
 
   # Stub `tmux` — start-cli sometimes calls into tmux to wrap the claude
   # spawn. Stub it to exec claude directly, bypassing the tmux layer.
@@ -90,15 +116,18 @@ case "\$1" in
 esac
 case "\$1" in
   new-session)
+    # The core is now "up" for every later liveness probe in this run.
+    touch "$CORE_UP_MARKER"
     # find the trailing claude command
     while [ "\$#" -gt 0 ] && [ "\$1" != "claude" ]; do shift; done
     if [ "\$1" = "claude" ]; then exec "\$@"; fi
     ;;
   has-session)
-    # The sandbox starts without a managed session. Returning success here
-    # sends the current launcher down its orphaned-session healing path
-    # (new-window) instead of the new-session path this test exercises.
-    exit 1
+    # Before new-session the sandbox has no managed session (returning success
+    # here would send the launcher down its orphaned-session healing path
+    # instead of the new-session path this test exercises). After new-session
+    # it must report the session so #2418's post-launch verify can pass.
+    [ -f "$CORE_UP_MARKER" ] || exit 1
     ;;
   kill-session|start-server|set-option|bind|attach)
     :  # no-op


### PR DESCRIPTION
## What

`tests/start-cli-claude-config-dir.test.sh` has been failing on `main` since **#2418 (`920c472a`)** — my own PR — and nothing caught it because **no CI job runs `tests/*.test.sh` at all**.

## Why it broke

#2418 added a post-launch liveness verify: after `tmux new-session`, `start-cli` polls `tmux_core_session_running` (session exists **and** a live `claude --name $SESSION` under it) and exits non-zero if the core never comes up, so a failed launch can no longer report success. That is correct behavior and stays.

The stubs in this test report "nothing is running" **unconditionally**. That satisfies the *pre*-launch short-circuit but can never satisfy the *post*-launch verify — so `start-cli` correctly exits 1, and cases 1–2 failed on the exit code before reaching their real assertions.

**The config-dir behavior under test was fine the whole time.** Case 2 was printing the correct value while failing:

```
✓ CLAUDE_CONFIG_DIR=/private/var/folders/.../workspace/.claude-sutando
  ⚠ sutando-core did not come up within ~5s of launch — start FAILED.
```

## Fix

Make the stubs model the core **lifecycle** rather than a fixed state. `new-session` writes a marker; `has-session`, `pgrep`, and a new `ps` stub honor it — so the core reads as down before launch and up after.

The `ps` stub is required, not incidental: `core_claude_pids` cross-checks every pgrep pid against `ps -p <pid> -o args=` for `--name $SESSION`, so faking `pgrep` alone is not enough. `start-cli.sh` has exactly one `ps` call, so the stub is narrow.

## Evidence

**Before** — clean `origin/main` worktree, and identically on this branch's parent:

```
1. helper missing → silent fallback       FAIL: start-cli exit 1
2. helper + valid config → env exported   FAIL: start-cli exit 1
3. helper + invalid config → refuses      ok
4. source-tied guard                      ok
PASSED: 2  FAILED: 2
```

**After:**

```
PASSED: 4  FAILED: 0
```

**Proof it is repaired, not neutered** — removed the marker write (core launches but never lives) and re-ran:

```
PASSED: 2  FAILED: 2      <- same failure as before the fix
```

So the test still catches a genuinely dead core; only stub fidelity changed. `bash -n` clean.

## Related finding — deliberately NOT fixed here

`npm test` runs `tests/**/*.test.ts` and `tests/*.test.py`. **All 41 `tests/*.test.sh` are unrun by CI.** I ran the whole set on clean `main`: **38 pass, 3 fail** — this one, plus `sutando-config-tsx-resolution` and `sync-workspace`.

The other two are **environment-sensitive** (nvm presence; local vault state), so wiring `*.test.sh` into CI would be flaky until they are made hermetic. That is a separate concern and a separate PR; I did not bundle it. Flagging the measurement so the gap is visible rather than rediscovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkcAxdb5YmqrhNb7sLor7H
