### PR TITLE
fix(tests): sync-workspace suite must not be able to reach a REAL memory repo

### DIFF
--- a/tests/lib/real-clone-guard.sh
+++ b/tests/lib/real-clone-guard.sh
@@ -28,6 +28,12 @@
 _rcg_content_digest() {
   local dir="$1"
   {
+    # THE INDEX IS A THIRD SURFACE. `git diff HEAD` compares the WORKTREE to HEAD and
+    # ignores staged content entirely, so on an already-`MM` path the staged blob can
+    # be replaced while status, worktree bytes and this diff all stay identical.
+    # Verified: before_index=index-before -> after_index=index-after, guard passed.
+    # `--cached` (index vs HEAD) is the missing comparison.
+    git -C "$dir" diff --cached 2>/dev/null
     git -C "$dir" diff HEAD 2>/dev/null
     git -C "$dir" ls-files --others --exclude-standard -z 2>/dev/null \
       | while IFS= read -r -d "" f; do

--- a/tests/lib/real-clone-guard.sh
+++ b/tests/lib/real-clone-guard.sh
@@ -14,8 +14,30 @@
 #
 # Compare BEFORE vs AFTER rather than asserting clean: the operator's clone may
 # legitimately be dirty already, and demanding cleanliness would fail on a real box.
+#
+# STATUS CODES ARE NOT CONTENT. `git status --porcelain` reports an already-modified
+# tracked file as " M path" both before and after the suite overwrites it, and an
+# existing untracked file as "?? path" either way — so a write that CLOBBERS the
+# operator's own uncommitted work leaves the status output byte-identical and the
+# guard green. Fingerprint the actual bytes too: the tracked diff against HEAD, plus
+# a hash per untracked file.
 
-# rcg_snapshot <dir> — record HEAD + porcelain status into RCG_* globals.
+# _rcg_content_digest <dir> — bytes-level fingerprint of the working tree's dirt.
+# Tracked modifications come from `git diff HEAD` (covers staged AND unstaged
+# content); untracked files are hashed individually, since no diff covers them.
+_rcg_content_digest() {
+  local dir="$1"
+  {
+    git -C "$dir" diff HEAD 2>/dev/null
+    git -C "$dir" ls-files --others --exclude-standard -z 2>/dev/null \
+      | while IFS= read -r -d "" f; do
+          printf '%s ' "$f"
+          shasum -a 256 "$dir/$f" 2>/dev/null | awk '{print $1}'
+        done
+  } | shasum -a 256 | awk '{print $1}'
+}
+
+# rcg_snapshot <dir> — record HEAD + porcelain status + content digest into RCG_* globals.
 rcg_snapshot() {
   local dir="$1"
   RCG_DIR="$dir"
@@ -27,6 +49,7 @@ rcg_snapshot() {
     # -uall so a file inside an untracked DIRECTORY is listed individually rather
     # than collapsed to the directory name (which would hide a second write).
     RCG_STATUS_BEFORE="$(git -C "$dir" status --porcelain -uall 2>/dev/null || echo '')"
+    RCG_CONTENT_BEFORE="$(_rcg_content_digest "$dir")"
     RCG_TAKEN=1
   fi
 }
@@ -34,10 +57,13 @@ rcg_snapshot() {
 # rcg_assert — print the harm and return 1 if the clone changed; 0 otherwise.
 rcg_assert() {
   [ -n "$RCG_TAKEN" ] || return 0
-  local after_head after_status
+  local after_head after_status after_content
   after_head="$(git -C "$RCG_DIR" rev-parse HEAD 2>/dev/null || echo '')"
   after_status="$(git -C "$RCG_DIR" status --porcelain -uall 2>/dev/null || echo '')"
-  if [ "$after_head" = "$RCG_HEAD_BEFORE" ] && [ "$after_status" = "$RCG_STATUS_BEFORE" ]; then
+  after_content="$(_rcg_content_digest "$RCG_DIR")"
+  if [ "$after_head" = "$RCG_HEAD_BEFORE" ] \
+     && [ "$after_status" = "$RCG_STATUS_BEFORE" ] \
+     && [ "$after_content" = "$RCG_CONTENT_BEFORE" ]; then
     return 0
   fi
   echo ""
@@ -52,6 +78,10 @@ rcg_assert() {
     echo "      index/worktree CHANGED. New or altered entries:"
     diff <(printf '%s\n' "$RCG_STATUS_BEFORE") <(printf '%s\n' "$after_status") \
       | sed -n 's/^> /        /p' | head -20
+  fi
+  if [ "$after_content" != "$RCG_CONTENT_BEFORE" ] && [ "$after_status" = "$RCG_STATUS_BEFORE" ]; then
+    echo "      status codes UNCHANGED but CONTENT changed — an already-dirty file"
+    echo "      was overwritten. This is the clobber case status alone cannot see."
   fi
   echo "      A test reached a real repo. FAILURE even if every check passed."
   return 1

--- a/tests/lib/real-clone-guard.sh
+++ b/tests/lib/real-clone-guard.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Guard: prove a test suite did not write into a REAL git clone.
+#
+# Extracted from tests/sync-workspace.test.sh so the guard itself is testable.
+# It was previously inline, which meant the only way to check it was to mutate the
+# operator's own clone by hand — so its blind spot went unnoticed: it compared only
+# `rev-parse HEAD`.
+#
+# HEAD ALONE IS NOT THE HARM. A reached clone can be left dirty without HEAD moving:
+# an untracked probe file, a staged-but-uncommitted write, or a commit that failed
+# after `git add`. Each leaves HEAD identical. An untracked file in the operator's
+# clone is then carried by the next legitimate sync — the two-hop leak the suite
+# exists to stop. So snapshot the index/worktree as well.
+#
+# Compare BEFORE vs AFTER rather than asserting clean: the operator's clone may
+# legitimately be dirty already, and demanding cleanliness would fail on a real box.
+
+# rcg_snapshot <dir> — record HEAD + porcelain status into RCG_* globals.
+rcg_snapshot() {
+  local dir="$1"
+  RCG_DIR="$dir"
+  RCG_HEAD_BEFORE=""
+  RCG_STATUS_BEFORE=""
+  RCG_TAKEN=""
+  if [ -d "$dir/.git" ]; then
+    RCG_HEAD_BEFORE="$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo '')"
+    # -uall so a file inside an untracked DIRECTORY is listed individually rather
+    # than collapsed to the directory name (which would hide a second write).
+    RCG_STATUS_BEFORE="$(git -C "$dir" status --porcelain -uall 2>/dev/null || echo '')"
+    RCG_TAKEN=1
+  fi
+}
+
+# rcg_assert — print the harm and return 1 if the clone changed; 0 otherwise.
+rcg_assert() {
+  [ -n "$RCG_TAKEN" ] || return 0
+  local after_head after_status
+  after_head="$(git -C "$RCG_DIR" rev-parse HEAD 2>/dev/null || echo '')"
+  after_status="$(git -C "$RCG_DIR" status --porcelain -uall 2>/dev/null || echo '')"
+  if [ "$after_head" = "$RCG_HEAD_BEFORE" ] && [ "$after_status" = "$RCG_STATUS_BEFORE" ]; then
+    return 0
+  fi
+  echo ""
+  echo "  ✖ TRIPWIRE: the suite wrote to the REAL memory clone $RCG_DIR"
+  if [ "$after_head" != "$RCG_HEAD_BEFORE" ]; then
+    echo "      HEAD before: $RCG_HEAD_BEFORE"
+    echo "      HEAD after : $after_head"
+  else
+    echo "      HEAD unchanged ($after_head) — the write did not commit."
+  fi
+  if [ "$after_status" != "$RCG_STATUS_BEFORE" ]; then
+    echo "      index/worktree CHANGED. New or altered entries:"
+    diff <(printf '%s\n' "$RCG_STATUS_BEFORE") <(printf '%s\n' "$after_status") \
+      | sed -n 's/^> /        /p' | head -20
+  fi
+  echo "      A test reached a real repo. FAILURE even if every check passed."
+  return 1
+}

--- a/tests/lib/real-clone-guard.sh
+++ b/tests/lib/real-clone-guard.sh
@@ -34,8 +34,29 @@ _rcg_content_digest() {
           printf '%s ' "$f"
           shasum -a 256 "$dir/$f" 2>/dev/null | awk '{print $1}'
         done
+    # THE REPO'S OWN CONTROL SURFACE. `git status` and `git diff` describe the
+    # WORKING TREE; they say nothing about .git/ itself. Found by shape-hunt after
+    # the HEAD and status-code rounds: a suite could drop a post-commit HOOK into
+    # the operator's clone (arbitrary code on their next commit) or repoint
+    # remote.origin.url (redirecting where the vault pushes) and this guard
+    # returned success. Both are worse than the data write it was built to catch.
+    #
+    # Only config + hooks are covered, deliberately. The rest of .git/ churns on
+    # ordinary reads (index mtime, logs/HEAD, packed refs), so hashing it wholesale
+    # would produce false positives and the guard would be disabled within a week.
+    shasum -a 256 "$dir/.git/config" 2>/dev/null | awk '{print $1}'
+    find "$dir/.git/hooks" -type f 2>/dev/null | LC_ALL=C sort | while IFS= read -r h; do
+      printf '%s ' "${h#$dir/}"
+      shasum -a 256 "$h" 2>/dev/null | awk '{print $1}'
+    done
   } | shasum -a 256 | awk '{print $1}'
 }
+
+# KNOWN, NAMED LIMITATION — a write to a path matching .gitignore is NOT detected.
+# `ls-files --others --exclude-standard` skips ignored files by design, and dropping
+# --exclude-standard would walk node_modules-scale trees on a real clone: slow, and
+# noisy enough that the guard would get switched off. Recorded rather than silently
+# accepted, because "the guard covers every write" would be false.
 
 # rcg_snapshot <dir> — record HEAD + porcelain status + content digest into RCG_* globals.
 rcg_snapshot() {

--- a/tests/real-clone-guard.test.sh
+++ b/tests/real-clone-guard.test.sh
@@ -75,6 +75,50 @@ D="$(mktemp -d -t rcg-nogit.XXXXXX)"; rcg_snapshot "$D"; rcg_assert >/dev/null 2
 check "non-repo path is inert" 0 $?
 rm -rf "$D"
 
+# --- Review 2 (qingyun, #2440): status codes are not content -------------------
+# `git status --porcelain` prints " M path" for an already-modified tracked file
+# both before and after it is overwritten, and "?? path" for an existing untracked
+# file either way. So a write that CLOBBERS the operator's own uncommitted work left
+# the status output byte-identical and the guard returned success. These two cases
+# FAIL against a status-only guard and pass against the content-digest one.
+
+# 7. DISCRIMINATING: overwrite an ALREADY-MODIFIED tracked file (status unchanged)
+D="$(mkfixture)"
+echo "operator work" > "$D/seed.txt"          # dirty BEFORE the snapshot
+rcg_snapshot "$D"
+S_BEFORE="$(git -C "$D" status --porcelain -uall)"
+echo "clobbered by the suite" > "$D/seed.txt"  # same status code, different bytes
+S_AFTER="$(git -C "$D" status --porcelain -uall)"
+out="$(rcg_assert 2>&1)"; rc=$?
+check "overwriting an already-MODIFIED tracked file fails" 1 $rc
+[ "$S_BEFORE" = "$S_AFTER" ] \
+  && { echo "  ok  ...and porcelain status was IDENTICAL (status-only guard would pass)"; pass=$((pass+1)); } \
+  || { echo "  FAIL status changed — not a discriminating case"; fail=$((fail+1)); }
+case "$out" in *"CONTENT changed"*) echo "  ok  ...and the message names the clobber case"; pass=$((pass+1));;
+  *) echo "  FAIL clobber case not explained"; fail=$((fail+1));; esac
+rm -rf "$D"
+
+# 8. DISCRIMINATING: overwrite an EXISTING untracked file (status unchanged)
+D="$(mkfixture)"
+echo "operator scratch" > "$D/scratch.txt"     # untracked BEFORE the snapshot
+rcg_snapshot "$D"
+S_BEFORE="$(git -C "$D" status --porcelain -uall)"
+echo "clobbered" > "$D/scratch.txt"
+S_AFTER="$(git -C "$D" status --porcelain -uall)"
+rcg_assert >/dev/null 2>&1
+check "overwriting an existing UNTRACKED file fails" 1 $?
+[ "$S_BEFORE" = "$S_AFTER" ] \
+  && { echo "  ok  ...and porcelain status was IDENTICAL"; pass=$((pass+1)); } \
+  || { echo "  FAIL status changed"; fail=$((fail+1)); }
+rm -rf "$D"
+
+# 9. an untouched already-dirty clone is STILL not a false positive
+D="$(mkfixture)"
+echo "operator work" > "$D/seed.txt"; touch "$D/scratch.txt"
+rcg_snapshot "$D"; rcg_assert >/dev/null 2>&1
+check "already-dirty clone left alone is not a false positive" 0 $?
+rm -rf "$D"
+
 echo "===================="
 echo "Total: $((pass+fail)) — pass: $pass, fail: $fail"
 [ "$fail" -eq 0 ] || exit 1

--- a/tests/real-clone-guard.test.sh
+++ b/tests/real-clone-guard.test.sh
@@ -165,6 +165,28 @@ echo "      (asserted as 0 on purpose — pins the limitation so it stays visibl
 
 rm -rf "$D"
 
+# 14. DISCRIMINATING (qingyun, round 3): the INDEX is a third surface. `git diff HEAD`
+#     compares WORKTREE to HEAD and ignores staged content, so on an already-`MM` path
+#     the staged blob can be swapped while status, worktree bytes and that diff are all
+#     byte-identical. Fails against a guard without `git diff --cached`.
+D="$(mkfixture)"
+echo index-before > "$D/seed.txt"; git -C "$D" add seed.txt      # staged change
+echo worktree-before > "$D/seed.txt"                              # + unstaged -> MM
+rcg_snapshot "$D"
+S_BEFORE="$(git -C "$D" status --porcelain -uall)"
+W_BEFORE="$(cat "$D/seed.txt")"
+blob=$(printf 'index-after\n' | git -C "$D" hash-object -w --stdin)
+git -C "$D" update-index --cacheinfo 100644,"$blob",seed.txt      # ONLY the index moves
+rcg_assert >/dev/null 2>&1
+check "replacing ONLY the staged blob fails" 1 $?
+[ "$S_BEFORE" = "$(git -C "$D" status --porcelain -uall)" ] \
+  && { echo "  ok  ...and porcelain status was IDENTICAL (MM either way)"; pass=$((pass+1)); } \
+  || { echo "  FAIL status changed — not discriminating"; fail=$((fail+1)); }
+[ "$W_BEFORE" = "$(cat "$D/seed.txt")" ] \
+  && { echo "  ok  ...and the WORKTREE bytes never changed"; pass=$((pass+1)); } \
+  || { echo "  FAIL worktree changed — not discriminating"; fail=$((fail+1)); }
+rm -rf "$D"
+
 echo "===================="
 echo "Total: $((pass+fail)) — pass: $pass, fail: $fail"
 [ "$fail" -eq 0 ] || exit 1

--- a/tests/real-clone-guard.test.sh
+++ b/tests/real-clone-guard.test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Regression for tests/lib/real-clone-guard.sh — the tripwire that proves
+# sync-workspace.test.sh did not write into a real clone.
+#
+# Why this file exists (john-the-dev, #2440): the guard originally compared only
+# `git rev-parse HEAD`. A reached clone can be left dirty with HEAD unchanged —
+# untracked probe file, staged-but-uncommitted write, or a commit that failed after
+# `git add` — and the guard returned success. An untracked file in the operator's
+# clone is carried by the next legitimate sync: the two-hop leak the suite exists to
+# stop. Case 2 and case 3 below are the discriminating cases: they FAIL against the
+# HEAD-only guard and PASS against the current one.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/lib/real-clone-guard.sh"
+
+pass=0; fail=0
+check() { # <name> <expected 0|1> <actual>
+  if [ "$2" = "$3" ]; then echo "  ok  $1"; pass=$((pass+1));
+  else echo "  FAIL $1 (expected rc=$2, got rc=$3)"; fail=$((fail+1)); fi
+}
+mkfixture() {
+  local d; d="$(mktemp -d -t rcg-fixture.XXXXXX)"
+  git -C "$d" init -q
+  git -C "$d" config user.email t@invalid; git -C "$d" config user.name t
+  echo seed > "$d/seed.txt"; git -C "$d" add seed.txt
+  git -C "$d" commit -qm seed
+  printf '%s' "$d"
+}
+
+# 1. untouched clone -> guard passes
+D="$(mkfixture)"; rcg_snapshot "$D"; rcg_assert >/dev/null 2>&1
+check "untouched clone passes" 0 $?
+rm -rf "$D"
+
+# 2. DISCRIMINATING: untracked write, HEAD unchanged -> guard must FAIL
+D="$(mkfixture)"; rcg_snapshot "$D"
+H_BEFORE="$(git -C "$D" rev-parse HEAD)"
+touch "$D/.probe-untracked"
+out="$(rcg_assert 2>&1)"; rc=$?
+check "untracked write (same HEAD) fails" 1 $rc
+[ "$(git -C "$D" rev-parse HEAD)" = "$H_BEFORE" ] \
+  && { echo "  ok  ...and HEAD really was unchanged (HEAD-only guard would pass)"; pass=$((pass+1)); } \
+  || { echo "  FAIL HEAD moved — not a discriminating case"; fail=$((fail+1)); }
+case "$out" in *".probe-untracked"*) echo "  ok  ...names the offending entry"; pass=$((pass+1));;
+  *) echo "  FAIL did not name the entry"; fail=$((fail+1));; esac
+rm -rf "$D"
+
+# 3. DISCRIMINATING: staged write, HEAD unchanged -> guard must FAIL
+D="$(mkfixture)"; rcg_snapshot "$D"
+H_BEFORE="$(git -C "$D" rev-parse HEAD)"
+echo p > "$D/.probe-staged"; git -C "$D" add .probe-staged
+rcg_assert >/dev/null 2>&1
+check "staged write (same HEAD) fails" 1 $?
+[ "$(git -C "$D" rev-parse HEAD)" = "$H_BEFORE" ] \
+  && { echo "  ok  ...and HEAD really was unchanged"; pass=$((pass+1)); } \
+  || { echo "  FAIL HEAD moved"; fail=$((fail+1)); }
+rm -rf "$D"
+
+# 4. a commit still fails (the original HEAD signal is not lost)
+D="$(mkfixture)"; rcg_snapshot "$D"
+echo more >> "$D/seed.txt"; git -C "$D" add seed.txt; git -C "$D" commit -qm probe
+rcg_assert >/dev/null 2>&1
+check "commit fails (HEAD signal preserved)" 1 $?
+rm -rf "$D"
+
+# 5. a clone ALREADY dirty before the snapshot is not a false positive —
+#    the guard compares before-vs-after, it does not demand cleanliness.
+D="$(mkfixture)"; touch "$D/pre-existing-untracked"
+rcg_snapshot "$D"; rcg_assert >/dev/null 2>&1
+check "pre-existing dirt is not a false positive" 0 $?
+rm -rf "$D"
+
+# 6. no .git -> guard is inert rather than erroring
+D="$(mktemp -d -t rcg-nogit.XXXXXX)"; rcg_snapshot "$D"; rcg_assert >/dev/null 2>&1
+check "non-repo path is inert" 0 $?
+rm -rf "$D"
+
+echo "===================="
+echo "Total: $((pass+fail)) — pass: $pass, fail: $fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/tests/real-clone-guard.test.sh
+++ b/tests/real-clone-guard.test.sh
@@ -119,6 +119,52 @@ rcg_snapshot "$D"; rcg_assert >/dev/null 2>&1
 check "already-dirty clone left alone is not a false positive" 0 $?
 rm -rf "$D"
 
+# --- Shape-hunt round (self-audit, not review) ---------------------------------
+# After HEAD-only and status-code-only, I went looking for the same SHAPE — a proxy
+# for "the clone changed" rather than the change itself — instead of waiting for the
+# next review. Three hypotheses, all three hit. Two are fixed below; the third is a
+# named limitation, pinned here so it cannot be quietly forgotten.
+
+# 10. DISCRIMINATING: a hook dropped into .git/hooks (arbitrary code on next commit)
+D="$(mkfixture)"; rcg_snapshot "$D"
+S_BEFORE="$(git -C "$D" status --porcelain -uall)"
+printf '#!/bin/sh\necho pwned\n' > "$D/.git/hooks/post-commit"; chmod +x "$D/.git/hooks/post-commit"
+rcg_assert >/dev/null 2>&1
+check "a hook written into .git/hooks fails" 1 $?
+[ "$S_BEFORE" = "$(git -C "$D" status --porcelain -uall)" ] \
+  && { echo "  ok  ...and git status reported NOTHING (working-tree checks are blind here)"; pass=$((pass+1)); } \
+  || { echo "  FAIL status changed — not a discriminating case"; fail=$((fail+1)); }
+rm -rf "$D"
+
+# 11. DISCRIMINATING: remote.origin.url repointed — redirects where a sync PUSHES
+D="$(mkfixture)"; rcg_snapshot "$D"
+git -C "$D" config remote.origin.url "https://elsewhere.invalid/x.git"
+rcg_assert >/dev/null 2>&1
+check "repointing remote.origin.url fails" 1 $?
+rm -rf "$D"
+
+# 12. ordinary git reads must NOT trip it (the false-positive that would get the
+#     guard switched off — .git/ churns on index refresh, logs/HEAD, packed refs)
+D="$(mkfixture)"; rcg_snapshot "$D"
+git -C "$D" status >/dev/null 2>&1; git -C "$D" log -1 >/dev/null 2>&1
+git -C "$D" diff >/dev/null 2>&1; git -C "$D" rev-parse HEAD >/dev/null 2>&1
+rcg_assert >/dev/null 2>&1
+check "read-only git commands are not a false positive" 0 $?
+rm -rf "$D"
+
+# 13. NAMED LIMITATION (documented, not a defect to be surprised by later): a write
+#     to a .gitignore-matched path is NOT detected. --exclude-standard skips ignored
+#     files by design, and dropping it would walk node_modules-scale trees.
+D="$(mkfixture)"
+echo "secrets/" > "$D/.gitignore"; git -C "$D" add .gitignore; git -C "$D" commit -qm ignore
+rcg_snapshot "$D"
+mkdir -p "$D/secrets"; echo leaked > "$D/secrets/probe.txt"
+rcg_assert >/dev/null 2>&1
+check "KNOWN GAP: a write to an ignored path is not detected" 0 $?
+echo "      (asserted as 0 on purpose — pins the limitation so it stays visible)"
+
+rm -rf "$D"
+
 echo "===================="
 echo "Total: $((pass+fail)) — pass: $pass, fail: $fail"
 [ "$fail" -eq 0 ] || exit 1

--- a/tests/sync-workspace.test.sh
+++ b/tests/sync-workspace.test.sh
@@ -26,6 +26,47 @@ set -euo pipefail
 # environment. Clear it once here so the shim can actually take effect.
 unset SUTANDO_HOST_LABEL
 
+# ── REAL-REPO DENY-BY-DEFAULT + TRIPWIRE (incident 2026-07-30, Mini second-host) ──
+# This suite drives the REAL sync scripts 17 times. Neutralising ONE case (Test 18)
+# was not enough — another path also resolved the operator's real memory repo.
+#
+# Capture the real target FIRST, from the INHERITED env, resolved the way the scripts
+# resolve it. That capture is what the tripwire checks.
+#
+# Two things the first fix got wrong, both surfaced only by running on a second host:
+#   * GIT_ALLOW_PROTOCOL=none does NOT stop a FILE-PATH remote, and a core can carry
+#     SUTANDO_MEMORY_REPO=/Users/.../.sutando/memory-sync — a path, not a URL.
+#   * The leak is TWO-HOP: test -> real LOCAL CLONE -> origin on the next legit sync.
+#     "origin unchanged" therefore proves nothing. The first hop is the harm, so the
+#     tripwire watches the LOCAL CLONE.
+_REAL_SYNC_DIR="${SUTANDO_MEMORY_SYNC_DIR:-$HOME/.sutando/memory-sync}"
+_REAL_HEAD_BEFORE=""
+if [ -d "$_REAL_SYNC_DIR/.git" ]; then
+  _REAL_HEAD_BEFORE="$(git -C "$_REAL_SYNC_DIR" rev-parse HEAD 2>/dev/null || echo '')"
+fi
+
+# Deny by default. Per-test fixtures still set these explicitly per invocation.
+_DENIED_SYNC_DIR="$(mktemp -d -t sync-ws-denied.XXXXXX)"
+export SUTANDO_MEMORY_REPO=
+export SUTANDO_MEMORY_SYNC_DIR="$_DENIED_SYNC_DIR"
+
+_assert_real_clone_untouched() {
+  # Runs on EXIT regardless of pass/fail. The suite can be 89/89 green and still have
+  # written to the operator's clone — that is precisely what happened. Assert the HARM,
+  # not the absence of the particular paths we thought of.
+  [ -n "$_REAL_HEAD_BEFORE" ] || return 0
+  local after
+  after="$(git -C "$_REAL_SYNC_DIR" rev-parse HEAD 2>/dev/null || echo '')"
+  if [ "$after" != "$_REAL_HEAD_BEFORE" ]; then
+    echo ""
+    echo "  ✖ TRIPWIRE: the suite wrote to the REAL memory clone $_REAL_SYNC_DIR"
+    echo "      HEAD before: $_REAL_HEAD_BEFORE"
+    echo "      HEAD after : $after"
+    echo "      A test reached a real repo. FAILURE even if every check passed."
+    exit 1
+  fi
+}
+
 # Same class, second inheritance: the suite makes real git commits in its
 # fixtures, so it also depends on the CALLER having a git identity. On a dev box
 # that is set globally and the dependency is invisible; on the ubuntu-latest
@@ -41,7 +82,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 TEST_ROOT="$(mktemp -d -t sync-workspace-test.XXXXXX)"
-trap "rm -rf '$TEST_ROOT'" EXIT
+# bash traps REPLACE rather than stack, so the tripwire must run from the SAME EXIT
+# trap as the cleanup or a later trap silently discards it.
+trap '_assert_real_clone_untouched; rm -rf "$TEST_ROOT" "$_DENIED_SYNC_DIR"' EXIT
 
 fail=0
 pass=0

--- a/tests/sync-workspace.test.sh
+++ b/tests/sync-workspace.test.sh
@@ -39,11 +39,21 @@ unset SUTANDO_HOST_LABEL
 #   * The leak is TWO-HOP: test -> real LOCAL CLONE -> origin on the next legit sync.
 #     "origin unchanged" therefore proves nothing. The first hop is the harm, so the
 #     tripwire watches the LOCAL CLONE.
+#   * HEAD ALONE IS NOT THE HARM. A reached clone can be left dirty without HEAD
+#     moving at all — an untracked probe file, a staged-but-uncommitted write, or a
+#     commit that failed after `git add`. Each leaves `rev-parse HEAD` identical and
+#     the guard green, and an untracked file in the operator's clone is carried by
+#     the next legitimate sync: exactly the two-hop leak this suite exists to stop.
+#     So snapshot the index/worktree too. Compare BEFORE vs AFTER rather than
+#     asserting clean — the operator's clone may legitimately be dirty already.
 _REAL_SYNC_DIR="${SUTANDO_MEMORY_SYNC_DIR:-$HOME/.sutando/memory-sync}"
-_REAL_HEAD_BEFORE=""
-if [ -d "$_REAL_SYNC_DIR/.git" ]; then
-  _REAL_HEAD_BEFORE="$(git -C "$_REAL_SYNC_DIR" rev-parse HEAD 2>/dev/null || echo '')"
-fi
+# The guard lives in tests/lib/real-clone-guard.sh so it is itself testable —
+# see tests/real-clone-guard.test.sh. Keeping it inline is why its HEAD-only
+# blind spot survived review: the only way to exercise it was to dirty the
+# operator's own clone by hand.
+# shellcheck source=lib/real-clone-guard.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/real-clone-guard.sh"
+rcg_snapshot "$_REAL_SYNC_DIR"
 
 # Deny by default. Per-test fixtures still set these explicitly per invocation.
 _DENIED_SYNC_DIR="$(mktemp -d -t sync-ws-denied.XXXXXX)"
@@ -51,20 +61,9 @@ export SUTANDO_MEMORY_REPO=
 export SUTANDO_MEMORY_SYNC_DIR="$_DENIED_SYNC_DIR"
 
 _assert_real_clone_untouched() {
-  # Runs on EXIT regardless of pass/fail. The suite can be 89/89 green and still have
-  # written to the operator's clone — that is precisely what happened. Assert the HARM,
-  # not the absence of the particular paths we thought of.
-  [ -n "$_REAL_HEAD_BEFORE" ] || return 0
-  local after
-  after="$(git -C "$_REAL_SYNC_DIR" rev-parse HEAD 2>/dev/null || echo '')"
-  if [ "$after" != "$_REAL_HEAD_BEFORE" ]; then
-    echo ""
-    echo "  ✖ TRIPWIRE: the suite wrote to the REAL memory clone $_REAL_SYNC_DIR"
-    echo "      HEAD before: $_REAL_HEAD_BEFORE"
-    echo "      HEAD after : $after"
-    echo "      A test reached a real repo. FAILURE even if every check passed."
-    exit 1
-  fi
+  # Runs on EXIT regardless of pass/fail. The suite can be 89/89 green and still
+  # have written to the operator's clone — that is precisely what happened.
+  rcg_assert || exit 1
 }
 
 # Same class, second inheritance: the suite makes real git commits in its

--- a/tests/sync-workspace.test.sh
+++ b/tests/sync-workspace.test.sh
@@ -773,9 +773,30 @@ SYNC_MEM="$FIXTURE_REPO/scripts/sync-memory.sh"
 
 # Invoke with a flag that triggers early exit (e.g. SUTANDO_MEMORY_REPO unset
 # → script bails). We just want to see if the banner emits.
+# NEUTRALISE the REAL memory-repo resolution before invoking (incident 2026-07-30).
+# The comment above assumed "SUTANDO_MEMORY_REPO unset -> script bails". On a host
+# where it IS set (from .env or sutando.config.local.json) the script does NOT bail:
+# it rsyncs the operator's real memory tree into ~/.sutando/memory-sync and PUSHES
+# to the real remote. That happened — commit 8de3582 landed on
+# github.com/sonichi/sutando-memory authored `sync-workspace-test@invalid`, 360
+# files, while this suite reported 89/89 PASS.
+#
+# It was previously masked: the push died on "Author identity unknown". Pinning a git
+# identity for CI (#2438) removed that accidental brake and turned a hard failure into
+# a silent successful push. The identity pin is correct; relying on its ABSENCE as a
+# safety net was the latent bug.
+#
+# So: override every input the script uses to find a real repo — the URL, the local
+# clone dir, and HOME (which the default clone path is derived from). A test must not
+# be able to reach a real remote even when the host is fully configured.
+_t18_home="$(mktemp -d)"
 out_banner=$(env \
     SUTANDO_REPO_DIR="$FIXTURE_REPO" \
     SUTANDO_WORKSPACE="$FIXTURE_WS" \
+    HOME="$_t18_home" \
+    SUTANDO_MEMORY_REPO= \
+    SUTANDO_MEMORY_SYNC_DIR="$_t18_home/memory-sync" \
+    GIT_ALLOW_PROTOCOL=none \
     bash "$SYNC_MEM" 2>&1 || true)
 
 case "$out_banner" in


### PR DESCRIPTION
## Incident

`tests/sync-workspace.test.sh` **pushed to a real shared repo while reporting 89/89 PASS.**

Commit `8de3582` on `github.com/sonichi/sutando-memory`, authored `sync-workspace-test <sync-workspace-test@invalid>`, 18:23 PT, syncing 360 files of a live memory tree. Found by @Sutando-Mini's post-merge check; I verified it independently by fetching the remote rather than taking the report on trust.

Severity is low — zero deletions, the content was the intended data at the intended path — but a test suite that can write to a shared repo is a defect regardless of what it wrote.

## Cause

Test 18 invokes the **real** `scripts/sync-memory.sh`, overriding only `SUTANDO_REPO_DIR` and `SUTANDO_WORKSPACE`. Its own comment records the assumption:

> `# Invoke with a flag that triggers early exit (e.g. SUTANDO_MEMORY_REPO unset → script bails).`

On a host where `SUTANDO_MEMORY_REPO` **is** set — from `.env` or `sutando.config.local.json` — the script does not bail. It rsyncs the operator's real memory tree into `~/.sutando/memory-sync` and pushes.

## Why it surfaced now — this is mine

It was **masked, not absent**. The push previously died on `Author identity unknown`. **#2438 (mine) pinned a git identity so the suite could run in CI, which removed that accidental brake and converted a hard failure into a silent successful push.**

The identity pin is correct and stays. Depending on its *absence* as a safety net was the latent bug, and my change is what exposed it.

## Fix

Override every input the script uses to locate a real repo — `SUTANDO_MEMORY_REPO=`, `SUTANDO_MEMORY_SYNC_DIR`, and `HOME` (the default clone path derives from it) — plus `GIT_ALLOW_PROTOCOL=none` as a belt.

**A test must not be able to reach a real remote even when the host is fully configured.**

## Evidence

Exercised the leak condition rather than asserting the fix — full suite on a fully-configured host, remote checked either side:

```
origin/main before   8de35820
suite                Total: 89 — pass: 89, fail: 0
origin/main after    8de35820      (unchanged)
```

## Pattern

Third instance today of this suite inheriting the caller's environment — `SUTANDO_HOST_LABEL`, then git identity, now the memory-repo URL — and the first to cause an actual **write**. The assertions were green in all three: **the check passed because the harm was outside what it checks.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkcAxdb5YmqrhNb7sLor7H
