### PR TITLE
fix(health-check): a stale quota-state.json reads green forever

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1816,6 +1816,37 @@ def check_voice_transport(voice_check: dict) -> dict:
     return check
 
 
+# Quota headers land on every proxied upstream response, so a core that is
+# working routes several per loop pass. Six hours is far outside any plausible
+# gap between passes on a host that is actually wired, and matches the "down"
+# tier the comm-sweep freshness probe already uses.
+QUOTA_STATE_STALE_SEC = 6 * 60 * 60
+# core-status.json is rewritten at the start and end of every loop pass, so a
+# half-hour-old one means a pass is either in flight or just finished.
+AGENT_ACTIVE_SEC = 30 * 60
+
+
+def _agent_activity_age() -> "float | None":
+    """Seconds since the agent last recorded loop activity, or None if unknown.
+
+    None is the honest answer for "no evidence either way" and must stay
+    distinct from a large number: absent core-status.json means this host does
+    not tell us whether the agent is working, and a check that cannot rule out
+    the quiet-core explanation must not warn.
+
+    Only the MTIME is read, never the `status` field. A pass that ends by
+    writing `{"status": "idle"}` still ran — the write itself is the evidence,
+    and reading the value would make a pass count only while mid-flight.
+    """
+    try:
+        p = status_read_path("core-status.json", WORKSPACE_DIR)
+        if not p.exists():
+            return None
+        return time.time() - p.stat().st_mtime
+    except OSError:
+        return None
+
+
 def check_quota_telemetry(proxy_status: str) -> dict:
     """Warn when the credential proxy is up but producing no quota state.
 
@@ -1835,11 +1866,28 @@ def check_quota_telemetry(proxy_status: str) -> dict:
     Deliberately narrow to stay quiet in the legitimate cases:
       - proxy not up          -> silent. Not every host routes through it,
                                  and its own check already says so.
-      - file present          -> ok, with its age. NOT stale-checked: a quiet
-                                 core legitimately writes nothing for a long
-                                 time, so an age threshold would fire on
-                                 healthy idle hosts. Absence is the signal
-                                 that actually distinguishes broken wiring.
+      - file present          -> ok, with its age. A bare age threshold is
+                                 still refused: a quiet core legitimately
+                                 writes nothing for a long time, and firing on
+                                 healthy idle hosts is how a check gets muted.
+
+    ...but PRESENCE ALONE IS SATISFIED BY A HISTORICAL WRITE. This check exists
+    to catch "the proxy is up and nothing routes through it", and it detects
+    only the *never-wired* case. A host that WAS wired, wrote quota-state.json
+    once, and then lost the wiring keeps a file on disk forever and reads green
+    forever — the exact condition this check was written to make loud, in the
+    one shape it cannot see. Observed on this fleet: quota-state.json 323h old,
+    credential-proxy `ok`, quota-telemetry `ok`, and the proactive loop's
+    per-pass budget gate quoting 13-day-old percentages as current.
+
+    Staleness only becomes evidence when the "quiet core" explanation is ruled
+    OUT, so the stale branch is gated on the agent being demonstrably at work:
+    core-status.json is rewritten by the agent on every loop pass, and each of
+    those writes belongs to a turn that spent tokens. Fresh core-status plus
+    stale quota-state means requests are flowing while quota headers are not
+    landing — wiring, not quiet. An idle host has a stale core-status too, so
+    it stays silent, and a host that never wired at all still takes the
+    absent-file branch below.
     """
     check = {"name": "quota-telemetry", "status": "ok"}
     if proxy_status != "ok":
@@ -1848,10 +1896,26 @@ def check_quota_telemetry(proxy_status: str) -> dict:
     path = status_read_path("quota-state.json", WORKSPACE_DIR)
     if path.exists():
         try:
-            age_min = int((time.time() - path.stat().st_mtime) / 60)
+            quota_age = time.time() - path.stat().st_mtime
+            age_min = int(quota_age / 60)
             check["detail"] = f"quota state present (updated {age_min}m ago)"
         except OSError:
+            # Degrade to the less precise detail rather than raising — and with
+            # no age there is nothing to call stale, so never warn from here.
             check["detail"] = "quota state present"
+            return check
+        agent_age = _agent_activity_age()
+        if quota_age > QUOTA_STATE_STALE_SEC and agent_age is not None \
+                and agent_age < AGENT_ACTIVE_SEC:
+            check["status"] = "warn"
+            check["detail"] = (
+                f"quota state is {int(quota_age / 3600)}h stale while the agent is "
+                f"working ({int(agent_age / 60)}m since the last loop pass) — the proxy "
+                "is up but nothing is routing through it any more, so the file on disk "
+                "is a leftover from when it was. Quota-based budgeting is quoting stale "
+                "numbers as current. Check ANTHROPIC_BASE_URL on the running core "
+                "(exported by src/startup.sh; a supervisor-launched core never runs it)."
+            )
         return check
     check["status"] = "warn"
     check["detail"] = (

--- a/tests/health-check-quota-telemetry.test.py
+++ b/tests/health-check-quota-telemetry.test.py
@@ -84,11 +84,102 @@ class TestQuotaTelemetryCheck(unittest.TestCase):
         """Deliberate: a quiet core legitimately writes nothing for a long
         time. An age threshold would fire on healthy idle hosts, so absence —
         not staleness — is the signal. Pin it so nobody 'improves' this into
-        a flaky check later."""
+        a flaky check later.
+
+        Still true, and deliberately left byte-identical: age ALONE never
+        warns. The stale branch added below fires only when a second signal
+        rules the quiet-core explanation out."""
         self._write_quota(mtime_age_sec=60 * 60 * 24 * 3)
         r = self.hc.check_quota_telemetry("ok")
         self.assertEqual(r["status"], "ok")
         self.assertIn("4320m ago", r["detail"])
+
+    # --- presence is satisfied by a HISTORICAL write ------------------------
+    # The check exists to catch "proxy up, nothing routing through it". It sees
+    # only the never-wired shape: a host that WAS wired, wrote the file once and
+    # then lost the wiring keeps that file forever and reads green forever.
+
+    def _write_core_status(self, mtime_age_sec: float = 0.0) -> Path:
+        p = self.ws / "state" / "core-status.json"
+        p.write_text('{"status": "running"}')
+        if mtime_age_sec:
+            past = time.time() - mtime_age_sec
+            os.utime(p, (past, past))
+        return p
+
+    def test_stale_quota_while_agent_is_working_warns(self):
+        """The uncaught shape: wiring lost after the first write.
+
+        Observed on this fleet — quota-state 323h old, credential-proxy ok,
+        quota-telemetry ok, and the loop's budget gate quoting 13-day-old
+        percentages as current."""
+        self._write_quota(mtime_age_sec=60 * 60 * 24 * 13)
+        self._write_core_status(mtime_age_sec=60)
+        r = self.hc.check_quota_telemetry("ok")
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("stale", r["detail"])
+        # Name the cause and both ages, or the reader cannot act on it.
+        self.assertIn("ANTHROPIC_BASE_URL", r["detail"])
+        self.assertIn("312h", r["detail"])
+        self.assertIn("1m", r["detail"])
+
+    def test_idle_host_with_stale_quota_stays_silent(self):
+        """The false positive the original decision was protecting against,
+        now pinned explicitly: nothing has run, so nothing SHOULD have written
+        quota headers. A stale core-status is what makes 'quiet' evidence."""
+        self._write_quota(mtime_age_sec=60 * 60 * 24 * 13)
+        self._write_core_status(mtime_age_sec=60 * 60 * 9)
+        r = self.hc.check_quota_telemetry("ok")
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    def test_unknown_agent_activity_stays_silent(self):
+        """No core-status.json = no evidence either way. 'Unknown' must not
+        collapse into 'idle' OR 'working' — a check that cannot rule out the
+        quiet-core explanation has not earned a warning."""
+        self._write_quota(mtime_age_sec=60 * 60 * 24 * 13)
+        r = self.hc.check_quota_telemetry("ok")
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    def test_fresh_quota_with_active_agent_is_ok(self):
+        """The healthy wired host — the case that must never be warned at."""
+        self._write_quota(mtime_age_sec=5 * 60)
+        self._write_core_status(mtime_age_sec=10)
+        r = self.hc.check_quota_telemetry("ok")
+        self.assertEqual(r["status"], "ok", r["detail"])
+        self.assertIn("present", r["detail"])
+
+    def test_just_under_the_stale_threshold_is_ok(self):
+        """Boundary, so the threshold is a decision rather than an accident."""
+        self._write_quota(mtime_age_sec=self.hc.QUOTA_STATE_STALE_SEC - 120)
+        self._write_core_status(mtime_age_sec=10)
+        r = self.hc.check_quota_telemetry("ok")
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    def test_unreadable_core_status_is_unknown_not_idle(self):
+        """A core-status.json that exists but cannot be stat'd is UNKNOWN, so
+        the stale branch must stay closed. Treating a read error as 'the agent
+        is working' would turn one unlucky race into a spurious warning."""
+        self._write_quota(mtime_age_sec=60 * 60 * 24 * 13)
+        self._write_core_status(mtime_age_sec=60)
+        real_stat = Path.stat
+
+        def _boom(self, *a, **kw):
+            if self.name == "core-status.json":
+                raise OSError("boom")
+            return real_stat(self, *a, **kw)
+
+        with mock.patch.object(Path, "stat", _boom):
+            r = self.hc.check_quota_telemetry("ok")
+        self.assertEqual(r["status"], "ok", r["detail"])
+
+    def test_stale_quota_with_proxy_down_stays_silent(self):
+        """Proxy-down short-circuits before any staleness reasoning: its own
+        check already reports it, and warning twice for one cause is noise."""
+        self._write_quota(mtime_age_sec=60 * 60 * 24 * 13)
+        self._write_core_status(mtime_age_sec=60)
+        for status in ("warn", "down"):
+            r = self.hc.check_quota_telemetry(status)
+            self.assertEqual(r["status"], "ok", f"status={status}")
 
     def test_stat_failure_still_reports_present(self):
         """`exists()` true but `stat()` raising is rare (file removed mid-check,


### PR DESCRIPTION
## What's wrong

`check_quota_telemetry` exists to catch **"the credential proxy is up and nothing is routing through it."** Its evidence is `path.exists()` — and **presence is satisfied by a HISTORICAL write.**

So it detects only the *never-wired* shape. A host that WAS wired, wrote `quota-state.json` once, and then lost the wiring keeps that file on disk forever and reports `ok` forever: the exact condition the check was built to make loud, in the one shape it cannot see.

## Evidence — live on Echo Act IV Pro, same host, same moment

**Before** (`origin/main` `src/health-check.py`):

```
  quota-state.json  : 323h old
  core-status.json  : 3m old
  -> status=ok
  -> quota state present (updated 19399m ago)
```

**After** (this branch):

```
  -> status=warn
  -> quota state is 323h stale while the agent is working (3m since the last loop
     pass) — the proxy is up but nothing is routing through it any more, so the
     file on disk is a leftover from when it was. Quota-based budgeting is quoting
     stale numbers as current. Check ANTHROPIC_BASE_URL on the running core
     (exported by src/startup.sh; a supervisor-launched core never runs it).
```

Both produced by importing each version of the module against the real workspace and calling `check_quota_telemetry("ok")`.

**Why it matters, concretely.** For the last 13 days the proactive loop's step-0.5 budget gate has been reading that file and quoting *"96% remaining, resets 16:40 Jul 17"* as current — driving the FULL / MEDIUM / LIGHT decision on every pass — while health-check reported `credential-proxy ok` and `quota-telemetry ok` the whole time.

## Why not just add an age threshold

Refusing one was **deliberate** in #2212 and pinned by `test_old_quota_state_does_not_warn`: a quiet core legitimately writes nothing for a long time, so a bare age threshold fires on healthy idle hosts. That reasoning is correct and is **preserved — age alone still never warns.**

Staleness only becomes evidence once the quiet-core explanation is ruled **out**, so the new branch is gated on the agent being demonstrably at work. `core-status.json` is rewritten on every loop pass, and each of those writes belongs to a turn that spent tokens. Fresh core-status + stale quota-state means requests are flowing while quota headers are not landing — wiring, not quiet. An idle host has a stale core-status too, so it stays silent.

Only the **mtime** is read, never the `status` field: a pass that ends by writing `{"status": "idle"}` still ran, and reading the value would count a pass only while mid-flight.

**The clearest proof the pinned decision survives: `test_old_quota_state_does_not_warn` passes byte-identical.** Its 3-day-old file with no agent-activity evidence still reads `ok`, because "unknown" is kept distinct from both "idle" and "working".

## Tests

+7 cases. The one that matters (`test_stale_quota_while_agent_is_working_warns`) **fails on the parent commit and passes here.** The other six pin every direction this must stay silent, so it cannot become the flaky check #2212 was right to avoid:

| case | expected |
|---|---|
| stale quota **+ agent working** | **warn** ← the bug |
| stale quota + idle host (stale core-status) | ok |
| stale quota + no core-status (unknown) | ok |
| stale quota + unreadable core-status | ok |
| fresh quota + agent working | ok |
| just under the 6h threshold | ok |
| proxy down (short-circuits first) | ok |

## Checks

- `python3 tests/health-check-quota-telemetry.test.py` — 12 tests, OK (5 pre-existing unchanged + 7 new)
- diff coverage **100%, 0 missing of 17 changed lines** (`diff-cover` vs `origin/main`, from the targeted test alone — a lower bound, so the full suite can only match or exceed it)
- `git diff --check` clean; `scripts/review-checks.sh` PASS (hardcoded-paths clean); `py_compile` ok

## Scope

Single concern, 2 files, no behavior change outside this one check. Related but **not** included: #2417 (routing the core through the proxy) is the *fix* for the underlying wiring on this host; this PR is only about the check no longer lying while that's broken.

@sonichi — flagging you: this touches a decision you merged in #2212, and the argument is that the decision was right but its evidence (`exists()`) was too weak for its own stated purpose. The pinned test passing unchanged is the thing to check if you want one signal.

Stand: Echo Act IV Pro
