### PR TITLE
fix(health-check): a non-object .alive must not crash the cron re-arm path

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -4524,7 +4524,17 @@ def _live_core_socket(workspace: Optional[Path] = None) -> str:
             mtime = alive_file.stat().st_mtime
             if now - mtime >= 90.0:
                 continue  # stale heartbeat — not a live core
-            sock = json.loads(alive_file.read_text()).get("socket")
+            payload = json.loads(alive_file.read_text())
+            # A heartbeat that decodes to a NON-OBJECT (`null`, `[]`, `"x"`, `3`)
+            # raises AttributeError on `.get`, which this handler does not catch —
+            # so one junk file takes down the caller. That caller is
+            # `_rearm_core_crons()`, a RECOVERY path, so it fails exactly when
+            # something is already wrong. The writer is atomic (tmp + replace in
+            # core_heartbeat.py), but this globs `*.alive` for EVERY host, so the
+            # file may come from another machine running different code.
+            if not isinstance(payload, dict):
+                continue
+            sock = payload.get("socket")
         except (OSError, ValueError):
             continue
         if isinstance(sock, str) and sock and (best_mtime is None or mtime > best_mtime):

--- a/tests/health-check-recover-cron.test.py
+++ b/tests/health-check-recover-cron.test.py
@@ -386,11 +386,33 @@ def case_l_socket_resolution_fallbacks() -> list[str]:
             corrupt.write_text("not json{")
             if hc._live_core_socket(ws) != "/tmp/env-default.sock":
                 fails.append("l) corrupt heartbeat must not crash or supply the socket")
+            # NON-OBJECT heartbeat (fresh mtime, VALID json that isn't a mapping).
+            # Distinct from the garbage case above: `null` / `[]` / `"x"` / `3` all
+            # decode fine and then raise AttributeError on `.get`, which the
+            # (OSError, ValueError) handler does NOT catch — one junk file took the
+            # whole call down, and its caller `_rearm_core_crons()` is a RECOVERY path.
+            nonobj = cores / "nonobject.alive"
+            for raw in ("null", "[]", '"sock"', "3"):
+                nonobj.write_text(raw)
+                try:
+                    got = hc._live_core_socket(ws)
+                except Exception as exc:  # noqa: BLE001 — a crash IS the failure
+                    fails.append(f"l) non-object heartbeat {raw!r} crashed: {type(exc).__name__}")
+                    continue
+                if got != "/tmp/env-default.sock":
+                    fails.append(f"l) non-object heartbeat {raw!r} should fall back, got {got}")
+            nonobj.unlink()
             # Fresh heartbeat with a socket beats the fallbacks.
             good = cores / "good.alive"
             good.write_text(json.dumps({"socket": "/tmp/live.sock"}))
             if hc._live_core_socket(ws) != "/tmp/live.sock":
                 fails.append("l) fresh heartbeat socket should win over the default")
+            # A junk PEER file must not hide a good one. This glob reads *.alive for
+            # EVERY host, so one machine writing an unexpected shape must not blind
+            # this host to its own live core.
+            (cores / "peerjunk.alive").write_text("null")
+            if hc._live_core_socket(ws) != "/tmp/live.sock":
+                fails.append("l) a junk peer heartbeat must not mask a good one")
     finally:
         hc.WORKSPACE_DIR = saved_ws
         if saved_env is None:


### PR DESCRIPTION
**Deliberately tiny — one line of behaviour plus test cases.** I know the queue is ~60 deep and that review capacity, not code, is the constraint right now; this is written to be checkable in a minute.

## The bug, executed against `origin/main`

`_live_core_socket()` globs every `*.alive` and calls `.get("socket")` on the decoded value under `except (OSError, ValueError)`. That handler does not catch `AttributeError`, so a heartbeat that is **valid JSON but not a mapping** takes the call down:

```
null      -> AttributeError: 'NoneType' object has no attribute 'get'
[]        -> AttributeError: 'list' object has no attribute 'get'
"sock"    -> AttributeError: 'str' object has no attribute 'get'
3         -> AttributeError: 'int' object has no attribute 'get'
```

The existing `case_l` already covers a "corrupt heartbeat" — but with `"not json{"`, which raises `ValueError` and **is** caught. Valid-but-not-an-object is a different shape, and it slipped through a test that reads as though it covers this.

## Severity — stated honestly, because it is low

I would not open this on its own if it were only "a crash on a malformed file." Two things make it worth a guard:

- the caller is **`_rearm_core_crons()`, a recovery path** — it fails precisely when something is already wrong;
- the glob reads `*.alive` for **every host**, so the file may come from another machine running different code. Our own writer is atomic (`tmp` + `replace` in `core_heartbeat.py`), which is why this is unlikely *from us* — but "our writer is careful" isn't a property of a file other machines also write.

## Tests

Extended the existing `case_l` rather than adding a case. Four non-object shapes must fall back rather than raise, and — the assertion I actually care about — **a junk peer heartbeat must not mask a good one**, so one machine writing an unexpected shape can't blind this host to its own live core. Removing the guard turns `case l` red.

## Provenance

Found by grepping for the shape after three rounds of the same class on #2446. Of the three `json.loads(...).get(...)` chains in `src/`, the other two — `event_log.py:73` and `discord-bridge.py:532` — are already inside `except Exception` and are fine. I checked both rather than assuming, and am not touching them.

Checks: cron-liveness suite passes · `py_compile` clean · `git diff --check` clean · `review-checks.sh` PASS.

@sonichi — no urgency on this one; it's a defensive one-liner, not a live defect.

Stand: Echo Act IV Pro
