### PR TITLE
perf(local-task-protocol): scan the archive with scandir, not sorted(iterdir())

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -53,6 +53,7 @@ task-last; until then both parsers exist and are named for their trust model.
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -478,17 +479,43 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
     """Locate a task file across the live dir, the legacy flat archive, and
     the month-partitioned archive — the same candidate set task-bridge's
     `_isVoiceTask` walks. Returns the first existing path or None. Rejects
-    malformed ids rather than globbing with them (traversal gate)."""
+    malformed ids rather than globbing with them (traversal gate).
+
+    The month scan uses `os.scandir` and filters on the NAME before asking
+    whether the entry is a directory. The archive root holds one file per
+    archived task and only a handful of `YYYY-MM/` dirs, so it grows without
+    bound while the thing being looked for stays tiny — on a live host it was
+    5,716 entries to find 3 month dirs, and this lookup cost 182 ms. Measured
+    there, per call:
+
+        sorted(iterdir())                 121 ms   <- Path.__lt__ on 5,716 objects
+        iterdir() + is_dir() on every one  88 ms   <- one stat syscall each
+        scandir() + is_dir() on every one  11 ms   <- dirent type is already cached
+
+    Both halves of the old cost were avoidable: `sorted()` paid to order 5,716
+    Path objects when only the matching month names need ordering, and
+    `Path.is_dir()` stat'd every entry when `os.DirEntry.is_dir()` reads the
+    type the kernel already returned. Sorting the handful of matched NAMES
+    preserves the previous candidate order exactly.
+
+    This is not micro-optimisation for its own sake: `agent-api.py` calls this
+    once per result file in a loop of up to 10 (`_remember_done_result_file`),
+    so the old cost showed up as ~1.8 s of directory scanning on a single
+    dashboard poll.
+    """
     if not valid_archive_lookup_id(task_id):
         return None
     fname = f"{task_id}.txt"
     candidates = [tasks_dir / fname, tasks_dir / "processed" / fname,
                   tasks_dir / "archive" / fname]
     archive_root = tasks_dir / "archive"
-    if archive_root.is_dir():
-        for entry in sorted(archive_root.iterdir()):
-            if entry.is_dir() and _MONTH_DIR_RE.match(entry.name):
-                candidates.append(entry / fname)
+    try:
+        with os.scandir(archive_root) as entries:
+            months = sorted(e.name for e in entries
+                            if _MONTH_DIR_RE.match(e.name) and e.is_dir())
+    except (OSError, ValueError):
+        months = []          # missing/unreadable archive is "no months", not an error
+    candidates.extend(archive_root / m / fname for m in months)
     for p in candidates:
         if p.exists():
             return p

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -53,6 +53,7 @@ task-last; until then both parsers exist and are named for their trust model.
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -478,17 +479,43 @@ def find_archived_task(tasks_dir: Path, task_id: str) -> Path | None:
     """Locate a task file across the live dir, the legacy flat archive, and
     the month-partitioned archive — the same candidate set task-bridge's
     `_isVoiceTask` walks. Returns the first existing path or None. Rejects
-    malformed ids rather than globbing with them (traversal gate)."""
+    malformed ids rather than globbing with them (traversal gate).
+
+    The month scan uses `os.scandir` and filters on the NAME before asking
+    whether the entry is a directory. The archive root holds one file per
+    archived task and only a handful of `YYYY-MM/` dirs, so it grows without
+    bound while the thing being looked for stays tiny — on a live host it was
+    5,716 entries to find 3 month dirs, and this lookup cost 182 ms. Measured
+    there, per call:
+
+        sorted(iterdir())                 121 ms   <- Path.__lt__ on 5,716 objects
+        iterdir() + is_dir() on every one  88 ms   <- one stat syscall each
+        scandir() + is_dir() on every one  11 ms   <- dirent type is already cached
+
+    Both halves of the old cost were avoidable: `sorted()` paid to order 5,716
+    Path objects when only the matching month names need ordering, and
+    `Path.is_dir()` stat'd every entry when `os.DirEntry.is_dir()` reads the
+    type the kernel already returned. Sorting the handful of matched NAMES
+    preserves the previous candidate order exactly.
+
+    This is not micro-optimisation for its own sake: `agent-api.py` calls this
+    once per result file in a loop of up to 10 (`_remember_done_result_file`),
+    so the old cost showed up as ~1.8 s of directory scanning on a single
+    dashboard poll.
+    """
     if not valid_archive_lookup_id(task_id):
         return None
     fname = f"{task_id}.txt"
     candidates = [tasks_dir / fname, tasks_dir / "processed" / fname,
                   tasks_dir / "archive" / fname]
     archive_root = tasks_dir / "archive"
-    if archive_root.is_dir():
-        for entry in sorted(archive_root.iterdir()):
-            if entry.is_dir() and _MONTH_DIR_RE.match(entry.name):
-                candidates.append(entry / fname)
+    try:
+        with os.scandir(archive_root) as entries:
+            months = sorted(e.name for e in entries
+                            if _MONTH_DIR_RE.match(e.name) and e.is_dir())
+    except (OSError, ValueError):
+        months = []          # missing/unreadable archive is "no months", not an error
+    candidates.extend(archive_root / m / fname for m in months)
     for p in candidates:
         if p.exists():
             return p

--- a/tests/local-task-protocol-archive-lookup.test.py
+++ b/tests/local-task-protocol-archive-lookup.test.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Tests for find_archived_task()'s month-partition scan.
+
+The scan was rewritten from `sorted(archive_root.iterdir())` + `Path.is_dir()`
+to `os.scandir()` with a name filter applied BEFORE the directory test. That is
+a performance change to a lookup on the live task path, so what these tests
+actually pin is that it is a PURE REFACTOR: the reference implementation below
+is the pre-change algorithm verbatim, and every layout is asserted to produce
+an identical result from both. Ordering is part of the contract — the first
+existing candidate wins, so a reordered month list would silently change which
+file is returned when the same task id exists in two months.
+
+Run: python3 tests/local-task-protocol-archive-lookup.test.py
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location(
+    "local_task_protocol", REPO / "src" / "local_task_protocol.py")
+ltp = importlib.util.module_from_spec(spec)
+sys.modules["local_task_protocol"] = ltp
+spec.loader.exec_module(ltp)
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def reference_find(tasks_dir: Path, task_id: str):
+    """The PRE-CHANGE implementation, kept verbatim as the equivalence oracle."""
+    if not ltp.valid_archive_lookup_id(task_id):
+        return None
+    fname = f"{task_id}.txt"
+    candidates = [tasks_dir / fname, tasks_dir / "processed" / fname,
+                  tasks_dir / "archive" / fname]
+    archive_root = tasks_dir / "archive"
+    if archive_root.is_dir():
+        for entry in sorted(archive_root.iterdir()):
+            if entry.is_dir() and ltp._MONTH_DIR_RE.match(entry.name):
+                candidates.append(entry / fname)
+    for p in candidates:
+        if p.exists():
+            return p
+    return None
+
+
+def build(layout):
+    """layout: list of relative paths; a trailing '/' means make a directory."""
+    root = Path(tempfile.mkdtemp()) / "tasks"
+    root.mkdir()
+    for rel in layout:
+        p = root / rel.rstrip("/")
+        if rel.endswith("/"):
+            p.mkdir(parents=True, exist_ok=True)
+        else:
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("id: task-X\ntask: hi\n")
+    return root
+
+
+TID = "task-X"
+F = f"{TID}.txt"
+
+LAYOUTS = {
+    "live dir wins": [F, f"processed/{F}", f"archive/{F}", f"archive/2026-07/{F}"],
+    "processed when no live": [f"processed/{F}", f"archive/2026-07/{F}"],
+    "flat archive when no live/processed": [f"archive/{F}"],
+    "month-partitioned only": [f"archive/2026-07/{F}"],
+    "EARLIEST month wins across two": [f"archive/2026-05/{F}", f"archive/2026-07/{F}"],
+    "three months, only latest holds it": ["archive/2026-05/", "archive/2026-06/", f"archive/2026-07/{F}"],
+    "absent everywhere": ["archive/2026-07/"],
+    "no archive dir at all": [f"processed/{F}"],
+    "empty tasks dir": [],
+    "non-month dirs ignored": [f"archive/scratch/{F}", "archive/2026-07/"],
+    "month-shaped FILE is not a month dir": ["archive/2026-08", f"archive/2026-07/{F}"],
+    "month-shaped file only": ["archive/2026-08"],
+    "nested deeper than one month level": [f"archive/2026-07/nested/{F}"],
+    "malformed month names": [f"archive/26-07/{F}", f"archive/2026-7/{F}", f"archive/2026-077/{F}"],
+}
+
+for name, layout in LAYOUTS.items():
+    root = build(layout)
+    got = ltp.find_archived_task(root, TID)
+    want = reference_find(root, TID)
+    check(f"equivalence: {name}", got == want, f"new={got} old={want}")
+
+# Traversal gate. Comparing against reference_find() alone is NOT sufficient
+# here: reference_find() calls the same gate, and a forged id normally resolves
+# to a path that does not exist, so both sides return None and the assertion
+# holds whether or not the gate ran. (Verified: deleting the gate leaves that
+# weaker form green.) So plant a file that traversal WOULD actually reach, and
+# assert None — which is only true if the id was rejected before the lookup.
+for bad in ("../evil", "../../evil"):
+    root = build([f"archive/2026-07/{F}"])
+    reachable = (root / f"{bad}.txt").resolve()
+    reachable.parent.mkdir(parents=True, exist_ok=True)
+    reachable.write_text("id: evil\ntask: should never be reachable\n")
+    check(f"traversal gate rejects {bad!r} even when the target EXISTS",
+          ltp.find_archived_task(root, bad) is None,
+          f"reached {reachable}")
+
+for bad in ("", "task X", "task-X\n", "task-X/../../y"):
+    root = build([f"archive/2026-07/{F}"])
+    check(f"traversal gate rejects {bad!r}",
+          ltp.find_archived_task(root, bad) == reference_find(root, bad))
+
+# A missing archive root must be "no months", not an exception — os.scandir
+# raises where the old `archive_root.is_dir()` guard simply returned False.
+root = build([f"processed/{F}"])
+try:
+    got = ltp.find_archived_task(root, TID)
+    check("missing archive root does not raise", got == root / "processed" / F, str(got))
+except OSError as exc:
+    check("missing archive root does not raise", False, f"raised {exc!r}")
+
+# An unreadable archive root must degrade to "no months", not propagate.
+if os.getuid() != 0:
+    root = build([f"processed/{F}", "archive/2026-07/"])
+    (root / "archive").chmod(0o000)
+    try:
+        got = ltp.find_archived_task(root, TID)
+        check("unreadable archive root degrades to no-months",
+              got == root / "processed" / F, str(got))
+    except OSError as exc:
+        check("unreadable archive root degrades to no-months", False, f"raised {exc!r}")
+    finally:
+        (root / "archive").chmod(0o755)
+
+# The ordering contract, stated directly rather than only via the oracle:
+# months are ascending, so the earliest month holding the id is returned.
+root = build([f"archive/2026-05/{F}", f"archive/2026-06/{F}", f"archive/2026-07/{F}"])
+check("months are searched in ascending order",
+      ltp.find_archived_task(root, TID) == root / "archive" / "2026-05" / F)
+
+if failures:
+    print(f"\n{len(failures)} failure(s): {failures}")
+    sys.exit(1)
+print("PASS — find_archived_task archive-lookup equivalence + edge cases")


### PR DESCRIPTION
## Summary

`find_archived_task()` scanned the archive root with `sorted(archive_root.iterdir())` and then `Path.is_dir()` on every entry, to locate a handful of `YYYY-MM/` directories. The archive root holds one file per archived task, so it grows without bound while the thing being looked for stays tiny. On this host that is **5,716 entries to find 3 month dirs, at 179 ms per lookup**.

**This is a live path today, not a hypothetical.** `src/agent-api.py` (`_remember_done_result_file`) calls it once per result file in a loop of up to 10, so a single dashboard poll could spend **~1.8 s** inside directory scanning.

## Where the time actually went

Measured per call on the real 5,716-entry archive:

| | cost |
|---|---|
| `sorted(iterdir())` | **121 ms** — `Path.__lt__` over 5,716 objects |
| `iterdir()` + `is_dir()` on every entry | 88 ms — one stat syscall each |
| `scandir()` + `is_dir()` on every entry | **11 ms** — dirent type already cached |

The larger half was the **sort**, not the stats — worth stating because the obvious guess is the syscalls. Only the matching month *names* need ordering. Filtering on the name before asking whether the entry is a directory, and sorting just those names, preserves candidate order exactly.

**Result on the same host: 179 ms → 13.8 ms (13x), identical return value.** The `agent-api` loop of 10 goes 1.79 s → 0.14 s.

`os.scandir` raises where the old `archive_root.is_dir()` guard quietly returned `False`, so a missing or unreadable archive root is caught and degrades to "no months" rather than propagating. Both cases are pinned by tests.

## Test plan

- [x] New `tests/local-task-protocol-archive-lookup.test.py` is an **equivalence** suite: it keeps the pre-change implementation verbatim as an oracle and asserts both agree across 14 layouts — live/processed/flat/month precedence, multi-month ordering, non-month dirs, month-shaped *files*, malformed month names, missing archive, nested dirs. Ordering is part of the contract: the first existing candidate wins, so a reordered month list would silently change which file is returned when an id exists in two months.
- [x] **Mutation-tested, not assumed.** Reversing the month sort → RED. Dropping the name filter → RED. Swallowing the traversal gate → RED.
- [x] That last one **only goes red after strengthening the test.** Comparing against the oracle alone was vacuous there: the oracle calls the same gate, and a forged id resolves to a nonexistent path, so both sides returned `None` whether or not the gate ran. It now plants a file that traversal would genuinely reach and asserts `None`.
- [x] **One surviving mutant, reported rather than papered over:** dropping `is_dir()` stays green. It is an *equivalent* mutant — `Path("<file>/child").exists()` is `False` on POSIX (ENOTDIR is caught), so the check cannot change the result, only avoid wasted work. Kept for intent.
- [x] `packages/ag2-sparrow` copy regenerated via its own `tools/sync_from_src.py`, not hand-edited; `tests/ag2-sparrow-drift.test.py` passes.
- [x] Existing `tests/local-task-protocol.test.py` and `tests/agent-api-task-display-text.test.py` (the live caller) pass unchanged.
- [x] `py_compile`, `git diff --check`, `scripts/review-checks.sh` all pass.
- [ ] **`ruff` is not installed on this host**, so the CI lint job is the first real run of it — flagging rather than claiming it green.

## Provenance / no-race note

Found while reviewing #2223, which adds a second caller of this helper in a `sleep(1)` loop. I offered that PR's author the option to own this fix. Opening it separately because it is **not** in their lane — `local_task_protocol` + `agent-api` are shared infra with an existing live caller on `main`, and this stands alone whether or not #2223 lands. @bassilkhilo-ag2, say the word and I will close this in favour of yours.

Also correcting myself: my review comment on #2223 attributed the whole cost to the `is_dir()` stat calls. That was wrong — the sort is the bigger half. Corrected there too.
