### PR TITLE
fix(health-check): warn before MEMORY.md outgrows the session read limit

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -140,8 +140,18 @@ def _index_effective_text(text: str) -> str:
     fence_char = ""
     fence_len = 0
     in_comment = False
+    def _fence_indent_ok(raw: str) -> bool:
+        # CommonMark bounds a fence marker to at most THREE spaces of
+        # indentation; at four it is an indented code line, not a fence. A bare
+        # lstrip() accepted any indent, so a 4-space ```html was treated as a
+        # fence and the comment inside it was PRESERVED — a false `fail` on an
+        # index that loads fine (qingyun-wu, #2449). Applies to opener AND
+        # closer: an over-indented closer must not close a real fence either.
+        return len(raw) - len(raw.lstrip(" ")) <= 3
+
     for line in text.splitlines(keepends=True):
         stripped = line.lstrip()
+        indent_ok = _fence_indent_ok(line)
         if in_fence:
             out.append(line)
             # CommonMark: a fence closes only on the SAME character, repeated at
@@ -150,7 +160,7 @@ def _index_effective_text(text: str) -> str:
             # fence early — the comment after it then fell outside any fence, was
             # stripped, and a 28KB file measured 39 bytes: false `ok`
             # (rui-sutando-codex, #2449).
-            if (stripped[:1] == fence_char
+            if (indent_ok and stripped[:1] == fence_char
                     and re.fullmatch(re.escape(fence_char) + "{%d,}" % fence_len,
                                      stripped.rstrip())):
                 in_fence = False
@@ -159,7 +169,7 @@ def _index_effective_text(text: str) -> str:
             if "-->" in line:
                 in_comment = False
             continue
-        m = re.match(r"(`{3,}|~{3,})", stripped)
+        m = re.match(r"(`{3,}|~{3,})", stripped) if indent_ok else None
         if m:
             in_fence = True
             fence_char = m.group(1)[0]

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -126,9 +126,41 @@ def _index_effective_text(text: str) -> str:
         m = re.match(r"^---\r?\n.*?\r?\n---[ \t]*\r?\n?", text, re.DOTALL)
         if m:
             text = text[m.end():]
-    # Block-level HTML comments only — a comment sharing a line with visible
-    # content is not block-level, so leave that line alone.
-    return re.sub(r"(?ms)^[ \t]*<!--.*?-->[ \t]*\r?\n?", "", text)
+
+    # Block-level HTML comments only, and NOT inside a fenced code block: the
+    # runtime strips block comments but PRESERVES them inside code fences, so a
+    # regex that ignores fence state under-reports. A 28KB comment wrapped in
+    # ```html measured as 37 bytes here and returned a false `ok` while the
+    # entry after it was genuinely past the cut (john-the-dev, #2449).
+    #
+    # Line-oriented rather than one regex, because fence state and multi-line
+    # comment state both have to be tracked, and a regex cannot carry either.
+    out: list[str] = []
+    in_fence = False
+    fence_marker = ""
+    in_comment = False
+    for line in text.splitlines(keepends=True):
+        stripped = line.lstrip()
+        if in_fence:
+            out.append(line)
+            if stripped.startswith(fence_marker):
+                in_fence = False
+            continue
+        if in_comment:
+            if "-->" in line:
+                in_comment = False
+            continue
+        m = re.match(r"(```+|~~~+)", stripped)
+        if m:
+            in_fence, fence_marker = True, m.group(1)[:3]
+            out.append(line)
+            continue
+        if stripped.startswith("<!--"):
+            if "-->" not in line:
+                in_comment = True
+            continue                      # whole-line block comment: dropped
+        out.append(line)
+    return "".join(out)
 
 
 def _index_loaded_prefix(text: str) -> "tuple[str, int, int]":
@@ -146,6 +178,17 @@ def _index_loaded_prefix(text: str) -> "tuple[str, int, int]":
             break
         nbytes = len(line.encode("utf-8"))
         if total + nbytes > MEMORY_INDEX_LOAD_BYTES:
+            # The limit is a BYTE prefix, not a line count — the session reads
+            # the bytes up to the cut, so a line that STARTS inside the budget
+            # is partially read. Dropping it whole marked an entry whose
+            # filename sat comfortably before the cut as unreadable, failing an
+            # index that loads fine (qingyun-wu, #2449). Keep the bytes that fit.
+            room = MEMORY_INDEX_LOAD_BYTES - total
+            if room > 0:
+                # errors="ignore" so a cut through a multi-byte character
+                # yields the readable prefix instead of raising.
+                kept.append(line.encode("utf-8")[:room].decode("utf-8", errors="ignore"))
+                total += room
             break
         kept.append(line)
         total += nbytes

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -92,36 +92,64 @@ def _default_memory_dir() -> str:
 # redirecting.
 MEMORY_DIR = Path(os.environ.get("SUTANDO_MEMORY_DIR", _default_memory_dir()))
 
-# MEMORY.md is read whole into every session. Past the runtime's read limit it
-# is not truncated — it is skipped — so EVERY indexed memory stops loading at
-# once, silently, while each memory file still looks fine on disk.
-# Env-overridable on purpose: the limit belongs to the session runtime, not to
-# this repo, so a deployment that measures a different one can declare it
-# rather than patch code. Defaults encode what was observed on this fleet
-# 2026-07-31 (index hit 22.0KB against a 24.4KB limit, uncaught).
-def _positive_int_env(name: str, default: int) -> int:
-    """Read a positive-int env override, falling back to `default` if unusable.
+# How much of MEMORY.md a session actually loads. These are the RUNTIME's
+# documented numbers, not this repo's guess:
+#
+#   "Claude Code reads the first 200 lines or 25KB of a memory file, whichever
+#    comes first" — content BEYOND that point is dropped; the prefix still
+#    loads. YAML frontmatter and block-level HTML comments are stripped before
+#    those limits are measured.
+#   https://code.claude.com/docs/en/memory#how-it-works
+#
+# Earlier revisions of this check encoded a measured-by-eye ~24KB cutoff and
+# claimed the WHOLE index stops loading past it. Both were wrong (john-the-dev,
+# #2449): the limit is line-OR-byte, and truncation is a suffix drop, not total
+# loss. They are plain constants rather than env knobs on purpose — they mirror
+# a documented external contract, so a deployment that "tunes" them is just
+# lying to itself about what its runtime does. Undeclared env vars are also
+# forbidden by AGENTS.md (qingyun-wu, #2449).
+MEMORY_INDEX_LOAD_LINES = 200
+MEMORY_INDEX_LOAD_BYTES = 25 * 1024
+# Warn while there is still room to compact deliberately rather than in a panic.
+MEMORY_INDEX_NEAR_LIMIT = 0.9
 
-    These are parsed at IMPORT time, so a bare `int(os.environ[...])` turns a
-    typo into an exception that takes the ENTIRE health check down — a tuning
-    mistake would cost all monitoring, which is strictly worse than the stale
-    index this threshold exists to catch (qingyun-wu, #2449). `24k`, ``, `0`
-    and `-1` all fall back rather than raise.
+
+def _index_effective_text(text: str) -> str:
+    """Drop what the runtime strips BEFORE it measures the 200-line/25KB limits.
+
+    Counting raw bytes over-reports: a file whose bulk is frontmatter or a block
+    HTML comment measures large here but small to the runtime. That produced a
+    false `fail` on a 25.6KB fixture whose visible content was one line
+    (john-the-dev, #2449).
     """
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    try:
-        value = int(raw)
-    except (TypeError, ValueError):
-        return default
-    return value if value > 0 else default
+    if text.startswith("---"):
+        m = re.match(r"^---\r?\n.*?\r?\n---[ \t]*\r?\n?", text, re.DOTALL)
+        if m:
+            text = text[m.end():]
+    # Block-level HTML comments only — a comment sharing a line with visible
+    # content is not block-level, so leave that line alone.
+    return re.sub(r"(?ms)^[ \t]*<!--.*?-->[ \t]*\r?\n?", "", text)
 
 
-MEMORY_INDEX_FAIL_BYTES = _positive_int_env("SUTANDO_MEMORY_INDEX_FAIL_BYTES", 24 * 1024)
-# Warn with enough headroom to compact deliberately rather than in a panic —
-# a few more filed memories is all the margin there is at the default.
-MEMORY_INDEX_WARN_BYTES = _positive_int_env("SUTANDO_MEMORY_INDEX_WARN_BYTES", 19 * 1024)
+def _index_loaded_prefix(text: str) -> "tuple[str, int, int]":
+    """Return (prefix_that_loads, bytes_loaded, lines_loaded) per the contract.
+
+    Whichever of the two limits is reached first stops the read. A line that
+    would straddle the byte limit is treated as not loaded — the conservative
+    reading, and the one that matters here since a half-read index line cannot
+    be relied on to name its memory file.
+    """
+    kept: list[str] = []
+    total = 0
+    for i, line in enumerate(text.splitlines(keepends=True)):
+        if i >= MEMORY_INDEX_LOAD_LINES:
+            break
+        nbytes = len(line.encode("utf-8"))
+        if total + nbytes > MEMORY_INDEX_LOAD_BYTES:
+            break
+        kept.append(line)
+        total += nbytes
+    return "".join(kept), total, len(kept)
 
 
 def _resolve_dotenv() -> Path:
@@ -794,21 +822,44 @@ def check_memory_index_integrity() -> "dict | None":
     ``*-BACKUP`` tree (created by scripts/sutando-migrate.sh) that never made it
     into the live index — so the rule it carried was written yet never recalled.
 
-    Warn (never fail) listing the orphaned/stranded files so the divergence is
-    visible instead of silently dropping the memory. Returns None on a clean
-    index or when the memory dir does not exist yet.
+    A third mode has the same consequence: the entry EXISTS but sits past the
+    point a session stops reading (200 lines or 25KB of post-strip content,
+    whichever comes first — see MEMORY_INDEX_LOAD_*). Truncation drops the
+    suffix, not the file, so this is measured by asking whether each memory is
+    named in the prefix that actually loads.
+
+    Fails only when a memory is demonstrably lost that way; warns for orphaned/
+    stranded files and for an index merely approaching the limit. Returns None
+    on a clean index or when the memory dir does not exist yet.
     """
     if not MEMORY_DIR.exists():
         return None
     index = MEMORY_DIR / "MEMORY.md"
     index_text = index.read_text(errors="ignore") if index.exists() else ""
 
+    # What the session actually sees: strip what the runtime strips, then keep
+    # only the prefix that fits inside 200 lines / 25KB.
+    effective_text = _index_effective_text(index_text)
+    loaded_text, loaded_bytes, loaded_lines = _index_loaded_prefix(effective_text)
+    truncated = len(loaded_text) < len(effective_text)
+
+    def _referenced_in(hay: str, name: str) -> bool:
+        return name in hay or name[:-3] in hay
+
     # (a) live memory files not referenced anywhere in MEMORY.md → won't load.
-    unindexed = [
-        p.name for p in sorted(MEMORY_DIR.glob("*.md"))
-        if p.name != "MEMORY.md"
-        and p.name not in index_text and p.name[:-3] not in index_text
-    ]
+    # (c) referenced, but ONLY beyond the load cut → equally won't load. Same
+    #     consequence, different cause, so they are found the same way: ask the
+    #     prefix that actually loads, not the whole file. Testing the whole file
+    #     reported an index entry parked on line 201 as healthy (john-the-dev,
+    #     #2449) because the bytes were on disk — just never read.
+    unindexed: list[str] = []
+    beyond_cut: list[str] = []
+    for p in sorted(MEMORY_DIR.glob("*.md")):
+        if p.name == "MEMORY.md":
+            continue
+        if _referenced_in(loaded_text, p.name):
+            continue
+        (beyond_cut if _referenced_in(effective_text, p.name) else unindexed).append(p.name)
 
     # (b) memories stranded in a sibling *-BACKUP tree, absent from the live dir.
     stranded: list[str] = []
@@ -825,55 +876,40 @@ def check_memory_index_integrity() -> "dict | None":
     except Exception:  # pragma: no cover — best-effort backup scan; never break the health check
         pass
 
-    # (c) the INDEX ITSELF outgrowing the per-session read limit. This is the
-    # same failure the check already exists for — "a memory that will never
-    # load" — but at the largest possible blast radius: past the limit the
-    # index file is not truncated, it simply is not read, so EVERY indexed
-    # memory stops loading at once. Modes (a) and (b) lose one memory each;
-    # this one loses all of them, and it arrives silently while every
-    # individual memory file still looks perfectly healthy on disk.
-    #
-    # Observed on this fleet 2026-07-31: MEMORY.md reached 22.0KB against a
-    # 24.4KB limit — roughly 2KB, or a few more filed memories, from dropping
-    # a 250-entry index with no warning anywhere. Nothing caught it.
-    #
-    # The thresholds are env-overridable because the limit is a property of the
-    # session runtime, not of this repo: the default encodes what was observed
-    # rather than a documented constant, so a deployment that measures a
-    # different limit can say so instead of editing code.
-    index_bytes = len(index_text.encode("utf-8")) if index.exists() else 0
-    oversized = index_bytes >= MEMORY_INDEX_FAIL_BYTES
-    outgrowing = index_bytes >= MEMORY_INDEX_WARN_BYTES
+    # (c) the index outgrowing what a session reads. Truncation is a SUFFIX
+    # drop, so the damage is exactly the entries past the cut — reported above
+    # as `beyond_cut`. What is left to say here is whether the index is close
+    # enough to the cut to be worth compacting before entries start falling off.
+    effective_bytes = len(effective_text.encode("utf-8"))
+    effective_lines = len(effective_text.splitlines())
+    near_limit = (
+        effective_bytes >= MEMORY_INDEX_LOAD_BYTES * MEMORY_INDEX_NEAR_LIMIT
+        or effective_lines >= MEMORY_INDEX_LOAD_LINES * MEMORY_INDEX_NEAR_LIMIT
+    )
 
-    # Both size conditions gate the healthy return, not just `outgrowing`.
-    # They are independent env overrides, so they can invert: a runtime that
-    # measures a SMALLER read limit sets only ..._FAIL_BYTES and leaves the warn
-    # default alone, giving fail < warn. An index between them is then over the
-    # fail limit while `outgrowing` is still False — and testing `outgrowing`
-    # alone returned `ok` at exactly the point the index had stopped loading
-    # (qingyun-wu's repro, #2449: bytes=150, fail=100, warn=200 -> ok).
-    #
-    # Checking both explicitly is preferred over normalising warn to
-    # min(warn, fail): normalisation would make the branches agree but changes
-    # no observable verdict here (the `if oversized` branch already wins), so
-    # it would add a silent rewrite of operator-declared config for no gain.
-    if not unindexed and not stranded and not outgrowing and not oversized:
+    def _size_note() -> str:
+        return (f"{effective_bytes / 1024:.1f}KB / {effective_lines} lines of loadable "
+                f"content vs the {MEMORY_INDEX_LOAD_BYTES / 1024:.0f}KB / "
+                f"{MEMORY_INDEX_LOAD_LINES}-line session read limit")
+
+    if not unindexed and not stranded and not beyond_cut and not near_limit:
         return {"name": "memory-index", "status": "ok",
-                "detail": ("all memory files present in the MEMORY.md index "
-                           f"({index_bytes / 1024:.1f}KB index)")}
+                "detail": f"all memory files present in the loaded MEMORY.md index ({_size_note()})"}
     parts = []
-    if oversized:
+    if beyond_cut:
         parts.append(
-            f"MEMORY.md is {index_bytes / 1024:.1f}KB, at/over the "
-            f"{MEMORY_INDEX_FAIL_BYTES / 1024:.1f}KB session read limit — the WHOLE index "
-            "stops loading, not part of it. Compact it now: one line per entry, "
-            "detail belongs in the topic files"
+            f"{len(beyond_cut)} memory file(s) ARE indexed but sit past the load cut "
+            f"(index stops at line {loaded_lines} / {loaded_bytes / 1024:.1f}KB), so the "
+            f"session never reads their entry: {', '.join(beyond_cut[:6])}"
+            f"{'…' if len(beyond_cut) > 6 else ''}. Compact the index — the prefix still "
+            f"loads, only the tail is dropped ({_size_note()})"
         )
-    elif outgrowing:
+    elif near_limit:
         parts.append(
-            f"MEMORY.md is {index_bytes / 1024:.1f}KB, approaching the "
-            f"{MEMORY_INDEX_FAIL_BYTES / 1024:.1f}KB session read limit — compact it "
-            "before it crosses; past the limit EVERY indexed memory stops loading"
+            f"MEMORY.md is approaching the session read limit ({_size_note()})"
+            + (" and is already truncated" if truncated else "")
+            + " — compact it now; entries past the cut are dropped silently while "
+              "every memory file still looks fine on disk"
         )
     if unindexed:
         parts.append(
@@ -885,10 +921,13 @@ def check_memory_index_integrity() -> "dict | None":
             f"{len(stranded)} memory file(s) stranded in a *-BACKUP tree, absent from the live dir: "
             + ", ".join(sorted(set(stranded))[:6]) + ("…" if len(set(stranded)) > 6 else "")
         )
-    # An index that is already over the limit is not "up but degraded" — it is
-    # not loading at all, so it reports as a failure rather than a warning.
+    # `fail` only for demonstrated loss: named memory files whose index entry is
+    # past the cut and therefore never read. Everything else — orphans, strays,
+    # merely approaching the limit — is degradation, not loss, so it warns.
+    # (Earlier revisions failed on a raw-byte threshold, which fired on indexes
+    # that still loaded fine once frontmatter/comments were excluded.)
     return {"name": "memory-index",
-            "status": "fail" if oversized else "warn",
+            "status": "fail" if beyond_cut else "warn",
             "detail": "; ".join(parts)}
 
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -99,10 +99,29 @@ MEMORY_DIR = Path(os.environ.get("SUTANDO_MEMORY_DIR", _default_memory_dir()))
 # this repo, so a deployment that measures a different one can declare it
 # rather than patch code. Defaults encode what was observed on this fleet
 # 2026-07-31 (index hit 22.0KB against a 24.4KB limit, uncaught).
-MEMORY_INDEX_FAIL_BYTES = int(os.environ.get("SUTANDO_MEMORY_INDEX_FAIL_BYTES", str(24 * 1024)))
+def _positive_int_env(name: str, default: int) -> int:
+    """Read a positive-int env override, falling back to `default` if unusable.
+
+    These are parsed at IMPORT time, so a bare `int(os.environ[...])` turns a
+    typo into an exception that takes the ENTIRE health check down — a tuning
+    mistake would cost all monitoring, which is strictly worse than the stale
+    index this threshold exists to catch (qingyun-wu, #2449). `24k`, ``, `0`
+    and `-1` all fall back rather than raise.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+MEMORY_INDEX_FAIL_BYTES = _positive_int_env("SUTANDO_MEMORY_INDEX_FAIL_BYTES", 24 * 1024)
 # Warn with enough headroom to compact deliberately rather than in a panic —
 # a few more filed memories is all the margin there is at the default.
-MEMORY_INDEX_WARN_BYTES = int(os.environ.get("SUTANDO_MEMORY_INDEX_WARN_BYTES", str(19 * 1024)))
+MEMORY_INDEX_WARN_BYTES = _positive_int_env("SUTANDO_MEMORY_INDEX_WARN_BYTES", 19 * 1024)
 
 
 def _resolve_dotenv() -> Path:
@@ -826,7 +845,19 @@ def check_memory_index_integrity() -> "dict | None":
     oversized = index_bytes >= MEMORY_INDEX_FAIL_BYTES
     outgrowing = index_bytes >= MEMORY_INDEX_WARN_BYTES
 
-    if not unindexed and not stranded and not outgrowing:
+    # Both size conditions gate the healthy return, not just `outgrowing`.
+    # They are independent env overrides, so they can invert: a runtime that
+    # measures a SMALLER read limit sets only ..._FAIL_BYTES and leaves the warn
+    # default alone, giving fail < warn. An index between them is then over the
+    # fail limit while `outgrowing` is still False — and testing `outgrowing`
+    # alone returned `ok` at exactly the point the index had stopped loading
+    # (qingyun-wu's repro, #2449: bytes=150, fail=100, warn=200 -> ok).
+    #
+    # Checking both explicitly is preferred over normalising warn to
+    # min(warn, fail): normalisation would make the branches agree but changes
+    # no observable verdict here (the `if oversized` branch already wins), so
+    # it would add a silent rewrite of operator-declared config for no gain.
+    if not unindexed and not stranded and not outgrowing and not oversized:
         return {"name": "memory-index", "status": "ok",
                 "detail": ("all memory files present in the MEMORY.md index "
                            f"({index_bytes / 1024:.1f}KB index)")}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -140,18 +140,33 @@ def _index_effective_text(text: str) -> str:
     fence_char = ""
     fence_len = 0
     in_comment = False
-    def _fence_indent_ok(raw: str) -> bool:
-        # CommonMark bounds a fence marker to at most THREE spaces of
-        # indentation; at four it is an indented code line, not a fence. A bare
-        # lstrip() accepted any indent, so a 4-space ```html was treated as a
-        # fence and the comment inside it was PRESERVED — a false `fail` on an
-        # index that loads fine (qingyun-wu, #2449). Applies to opener AND
-        # closer: an over-indented closer must not close a real fence either.
-        return len(raw) - len(raw.lstrip(" ")) <= 3
+    def _block_indent_ok(raw: str) -> bool:
+        # CommonMark bounds a block-level marker to at most THREE columns of
+        # indentation; at four the line is indented CODE, not a marker. This
+        # gates BOTH markers we track:
+        #   fence  — a 4-space ```html is not a fence, so the comment inside it
+        #            must be stripped, not preserved (false `fail`; qingyun-wu).
+        #   <!--   — a 4-space or TAB indented comment is code CONTENT and must
+        #            count toward the 25KB prefix, not be stripped (false `ok`
+        #            on a 30KB fixture that measured 18 bytes; qingyun-wu).
+        # Counted in COLUMNS, not characters: a bare lstrip(" ") ignored tabs, and
+        # one tab already reaches the 4-column stop. Applies to a fence closer
+        # too — an over-indented closer must not close a real fence.
+        n = 0
+        for ch in raw:
+            if ch == " ":
+                n += 1
+            elif ch == "\t":
+                n += 4 - (n % 4)          # advance to the next 4-column tab stop
+            else:
+                break
+            if n >= 4:
+                return False
+        return True
 
     for line in text.splitlines(keepends=True):
         stripped = line.lstrip()
-        indent_ok = _fence_indent_ok(line)
+        indent_ok = _block_indent_ok(line)
         if in_fence:
             out.append(line)
             # CommonMark: a fence closes only on the SAME character, repeated at
@@ -170,13 +185,23 @@ def _index_effective_text(text: str) -> str:
                 in_comment = False
             continue
         m = re.match(r"(`{3,}|~{3,})", stripped) if indent_ok else None
+        if m and m.group(1)[0] == "`" and "`" in stripped[m.end():]:
+            # CommonMark: a BACKTICK fence's info string may not contain a
+            # backtick (it would be ambiguous with inline code). ```bad`info is
+            # therefore an ordinary paragraph line, not an opener. Accepting it
+            # opened a phantom fence, so the block comment that followed was
+            # PRESERVED and a 31KB fixture measured 31KB: a false `fail` telling
+            # the operator to compact an index that loads fine (john-the-dev,
+            # #2449). Tilde fences have no such rule — ~~~a`b IS a valid opener.
+            out.append(line)
+            continue
         if m:
             in_fence = True
             fence_char = m.group(1)[0]
             fence_len = len(m.group(1))     # FULL length — see the close check above
             out.append(line)
             continue
-        if stripped.startswith("<!--"):
+        if indent_ok and stripped.startswith("<!--"):
             if "-->" not in line:
                 in_comment = True
             continue                      # whole-line block comment: dropped

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -137,22 +137,33 @@ def _index_effective_text(text: str) -> str:
     # comment state both have to be tracked, and a regex cannot carry either.
     out: list[str] = []
     in_fence = False
-    fence_marker = ""
+    fence_char = ""
+    fence_len = 0
     in_comment = False
     for line in text.splitlines(keepends=True):
         stripped = line.lstrip()
         if in_fence:
             out.append(line)
-            if stripped.startswith(fence_marker):
+            # CommonMark: a fence closes only on the SAME character, repeated at
+            # least as many times as the opener, alone on its line. Truncating the
+            # marker to three characters let an inner ``` line close a ````
+            # fence early — the comment after it then fell outside any fence, was
+            # stripped, and a 28KB file measured 39 bytes: false `ok`
+            # (rui-sutando-codex, #2449).
+            if (stripped[:1] == fence_char
+                    and re.fullmatch(re.escape(fence_char) + "{%d,}" % fence_len,
+                                     stripped.rstrip())):
                 in_fence = False
             continue
         if in_comment:
             if "-->" in line:
                 in_comment = False
             continue
-        m = re.match(r"(```+|~~~+)", stripped)
+        m = re.match(r"(`{3,}|~{3,})", stripped)
         if m:
-            in_fence, fence_marker = True, m.group(1)[:3]
+            in_fence = True
+            fence_char = m.group(1)[0]
+            fence_len = len(m.group(1))     # FULL length — see the close check above
             out.append(line)
             continue
         if stripped.startswith("<!--"):

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -92,6 +92,18 @@ def _default_memory_dir() -> str:
 # redirecting.
 MEMORY_DIR = Path(os.environ.get("SUTANDO_MEMORY_DIR", _default_memory_dir()))
 
+# MEMORY.md is read whole into every session. Past the runtime's read limit it
+# is not truncated — it is skipped — so EVERY indexed memory stops loading at
+# once, silently, while each memory file still looks fine on disk.
+# Env-overridable on purpose: the limit belongs to the session runtime, not to
+# this repo, so a deployment that measures a different one can declare it
+# rather than patch code. Defaults encode what was observed on this fleet
+# 2026-07-31 (index hit 22.0KB against a 24.4KB limit, uncaught).
+MEMORY_INDEX_FAIL_BYTES = int(os.environ.get("SUTANDO_MEMORY_INDEX_FAIL_BYTES", str(24 * 1024)))
+# Warn with enough headroom to compact deliberately rather than in a panic —
+# a few more filed memories is all the margin there is at the default.
+MEMORY_INDEX_WARN_BYTES = int(os.environ.get("SUTANDO_MEMORY_INDEX_WARN_BYTES", str(19 * 1024)))
+
 
 def _resolve_dotenv() -> Path:
     """Resolve the `.env` path via the canonical resolver.
@@ -794,10 +806,44 @@ def check_memory_index_integrity() -> "dict | None":
     except Exception:  # pragma: no cover — best-effort backup scan; never break the health check
         pass
 
-    if not unindexed and not stranded:
+    # (c) the INDEX ITSELF outgrowing the per-session read limit. This is the
+    # same failure the check already exists for — "a memory that will never
+    # load" — but at the largest possible blast radius: past the limit the
+    # index file is not truncated, it simply is not read, so EVERY indexed
+    # memory stops loading at once. Modes (a) and (b) lose one memory each;
+    # this one loses all of them, and it arrives silently while every
+    # individual memory file still looks perfectly healthy on disk.
+    #
+    # Observed on this fleet 2026-07-31: MEMORY.md reached 22.0KB against a
+    # 24.4KB limit — roughly 2KB, or a few more filed memories, from dropping
+    # a 250-entry index with no warning anywhere. Nothing caught it.
+    #
+    # The thresholds are env-overridable because the limit is a property of the
+    # session runtime, not of this repo: the default encodes what was observed
+    # rather than a documented constant, so a deployment that measures a
+    # different limit can say so instead of editing code.
+    index_bytes = len(index_text.encode("utf-8")) if index.exists() else 0
+    oversized = index_bytes >= MEMORY_INDEX_FAIL_BYTES
+    outgrowing = index_bytes >= MEMORY_INDEX_WARN_BYTES
+
+    if not unindexed and not stranded and not outgrowing:
         return {"name": "memory-index", "status": "ok",
-                "detail": "all memory files present in the MEMORY.md index"}
+                "detail": ("all memory files present in the MEMORY.md index "
+                           f"({index_bytes / 1024:.1f}KB index)")}
     parts = []
+    if oversized:
+        parts.append(
+            f"MEMORY.md is {index_bytes / 1024:.1f}KB, at/over the "
+            f"{MEMORY_INDEX_FAIL_BYTES / 1024:.1f}KB session read limit — the WHOLE index "
+            "stops loading, not part of it. Compact it now: one line per entry, "
+            "detail belongs in the topic files"
+        )
+    elif outgrowing:
+        parts.append(
+            f"MEMORY.md is {index_bytes / 1024:.1f}KB, approaching the "
+            f"{MEMORY_INDEX_FAIL_BYTES / 1024:.1f}KB session read limit — compact it "
+            "before it crosses; past the limit EVERY indexed memory stops loading"
+        )
     if unindexed:
         parts.append(
             f"{len(unindexed)} memory file(s) not in MEMORY.md (won't load): "
@@ -808,7 +854,11 @@ def check_memory_index_integrity() -> "dict | None":
             f"{len(stranded)} memory file(s) stranded in a *-BACKUP tree, absent from the live dir: "
             + ", ".join(sorted(set(stranded))[:6]) + ("…" if len(set(stranded)) > 6 else "")
         )
-    return {"name": "memory-index", "status": "warn", "detail": "; ".join(parts)}
+    # An index that is already over the limit is not "up but degraded" — it is
+    # not loading at all, so it reports as a failure rather than a warning.
+    return {"name": "memory-index",
+            "status": "fail" if oversized else "warn",
+            "detail": "; ".join(parts)}
 
 
 def check_memory_sync() -> dict:

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -177,10 +177,10 @@ _os.environ.pop("_TEST_MEM_IDX", None)
 check("unset env → default", hc._positive_int_env("_TEST_MEM_IDX_UNSET", 777) == 777)
 
 # The property that actually matters: the module still IMPORTS with a bad value.
-import subprocess as _sp, sys as _sys
+import subprocess as _sp   # `sys` is already imported at the top of this file
 _env = dict(_os.environ, SUTANDO_MEMORY_INDEX_FAIL_BYTES="24k",
             SUTANDO_MEMORY_INDEX_WARN_BYTES="oops")
-_r = _sp.run([_sys.executable, "-c",
+_r = _sp.run([sys.executable, "-c",
               "import importlib.util;s=importlib.util.spec_from_file_location('hc',%r);"
               "m=importlib.util.module_from_spec(s);s.loader.exec_module(m);"
               "print(m.MEMORY_INDEX_FAIL_BYTES, m.MEMORY_INDEX_WARN_BYTES)" % str(HC)],

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -203,6 +203,27 @@ _mem_with("```\n<!--\n-->\n```\n" + _ENTRY)
 check("control: a fence still CLOSES (small fenced comment stays ok)",
       (hc.check_memory_index_integrity() or {}).get("status") == "ok")
 
+# qingyun-wu: CommonMark bounds a fence marker to at most THREE spaces of
+# indentation. At four it is an indented code line, so a comment after it is NOT
+# fenced and must still be stripped — treating it as a fence produced a false
+# `fail` on an index that loads fine. Pinned in both directions plus the closer.
+_BIGC2 = "<!--\n" + ("padding padding padding\n" * 1200) + "-->\n"
+for _label, _body, _want in (
+    ("4-space opener is NOT a fence (comment strips)",
+     "    ```html\n" + _BIGC2 + "    ```\n" + _ENTRY, "ok"),
+    ("4-space tilde opener is NOT a fence",
+     "    ~~~\n" + _BIGC2 + "    ~~~\n" + _ENTRY, "ok"),
+    ("3-space opener IS a fence (comment preserved)",
+     "   ```html\n" + _BIGC2 + "   ```\n" + _ENTRY, "fail"),
+    ("0-space opener IS a fence (regression)",
+     "```html\n" + _BIGC2 + "```\n" + _ENTRY, "fail"),
+    ("a 4-space CLOSER must not close a real fence",
+     "```html\n" + _BIGC2 + "    ```\n" + _ENTRY, "fail"),
+):
+    _mem_with(_body)
+    r = hc.check_memory_index_integrity()
+    check(f"fence indent: {_label}", r and r["status"] == _want, f"got {r and r['status']} :: {r}")
+
 # qingyun-wu: the byte limit cuts THROUGH a line; the filename before the cut is
 # still read, so the memory loads and must not be reported lost.
 _mem_with(("x" * (25 * 1024 - 100)) + "\n- [Good](good-memory.md) " + ("d" * 4000) + "\n")

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -224,6 +224,37 @@ for _label, _body, _want in (
     r = hc.check_memory_index_integrity()
     check(f"fence indent: {_label}", r and r["status"] == _want, f"got {r and r['status']} :: {r}")
 
+# qingyun-wu: the SAME 0-3-column bound governs the comment marker, not just the
+# fence marker. A four-space- or TAB-indented `<!--` is indented CODE CONTENT and
+# counts toward the runtime's 25KB prefix; stripping it made a 30KB fixture
+# measure 18 bytes and report `ok` while the entry began past the real cut.
+for _label, _body, _want in (
+    ("4-space indented comment is CONTENT (counts)", "    " + _BIGC2 + _ENTRY, "fail"),
+    ("TAB indented comment is CONTENT (counts)",     "\t" + _BIGC2 + _ENTRY,   "fail"),
+    ("3-space indented comment is still a comment",  "   " + _BIGC2 + _ENTRY,  "ok"),
+    ("control: unindented comment still strips",     _BIGC2 + _ENTRY,          "ok"),
+):
+    _mem_with(_body)
+    r = hc.check_memory_index_integrity()
+    check(f"comment indent: {_label}", r and r["status"] == _want, f"got {r and r['status']} :: {r}")
+
+# john-the-dev: a BACKTICK fence's info string may not contain a backtick, so
+# ```bad`info is an ordinary paragraph line rather than an opener. Accepting it
+# opened a phantom fence that preserved the comment after it — a 31KB fixture
+# measured 31KB and reported `fail`, telling the operator to compact an index
+# that loads fine. Tilde fences carry no such restriction.
+for _label, _body, _want in (
+    ("backtick in a BACKTICK info string is not an opener",
+     "```bad`info\n" + _BIGC2 + "```\n" + _ENTRY, "ok"),
+    ("control: a valid backtick info string IS an opener",
+     "```py\n" + _BIGC2 + "```\n" + _ENTRY, "fail"),
+    ("control: backtick in a TILDE info string IS still an opener",
+     "~~~a`b\n" + _BIGC2 + "~~~\n" + _ENTRY, "fail"),
+):
+    _mem_with(_body)
+    r = hc.check_memory_index_integrity()
+    check(f"info string: {_label}", r and r["status"] == _want, f"got {r and r['status']} :: {r}")
+
 # qingyun-wu: the byte limit cuts THROUGH a line; the filename before the cut is
 # still read, so the memory loads and must not be reported lost.
 _mem_with(("x" * (25 * 1024 - 100)) + "\n- [Good](good-memory.md) " + ("d" * 4000) + "\n")

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -154,6 +154,44 @@ t = tempfile.mkdtemp(); mem = make_tree(Path(t))
 r = hc.check_memory_index_integrity()
 check("no MEMORY.md at all → not a size failure", r and r["status"] != "fail", str(r))
 
+# --- round-5 findings: both are "model the contract precisely" refinements ---
+# The runtime strips block HTML comments, but PRESERVES them inside code fences;
+# and its limit is a BYTE prefix, so a line straddling the cut is partially read.
+# Getting either wrong reintroduces exactly the false verdicts this check exists
+# to prevent — one in each direction.
+
+# john-the-dev: a big comment INSIDE a fence is real content to the runtime.
+_FENCED = "```html\n<!--\n" + ("padding padding padding\n" * 1200) + "-->\n```\n" + _ENTRY
+_mem_with(_FENCED)
+r = hc.check_memory_index_integrity()
+check("28KB HTML comment inside a ```fence is NOT stripped → entry is past the cut",
+      r and r["status"] != "ok", str(r))
+check("...and the fenced comment still counts toward the measured size",
+      len(hc._index_effective_text(_FENCED).encode()) > 25 * 1024,
+      f"effective={len(hc._index_effective_text(_FENCED).encode())}")
+# Discriminating control: the SAME comment unfenced must still be stripped, so
+# this is fence-awareness rather than "stop stripping comments".
+_UNFENCED = "<!--\n" + ("padding padding padding\n" * 1200) + "-->\n" + _ENTRY
+_mem_with(_UNFENCED)
+r = hc.check_memory_index_integrity()
+check("the SAME comment UNfenced is still stripped → still ok", r and r["status"] == "ok", str(r))
+check("...and measures small once stripped",
+      len(hc._index_effective_text(_UNFENCED).encode()) < 1024,
+      f"effective={len(hc._index_effective_text(_UNFENCED).encode())}")
+check("~~~ fences are honoured too, not just backticks",
+      len(hc._index_effective_text("~~~\n<!--\n" + ("p\n" * 500) + "-->\n~~~\n").encode()) > 500)
+
+# qingyun-wu: the byte limit cuts THROUGH a line; the filename before the cut is
+# still read, so the memory loads and must not be reported lost.
+_mem_with(("x" * (25 * 1024 - 100)) + "\n- [Good](good-memory.md) " + ("d" * 4000) + "\n")
+r = hc.check_memory_index_integrity()
+check("entry starting just BEFORE the 25KB cut is read → not a failure",
+      r and r["status"] != "fail", str(r))
+# Discriminating control: an entry starting AFTER the cut is genuinely lost.
+_mem_with(("x" * (25 * 1024 + 50)) + "\n" + _ENTRY)
+r = hc.check_memory_index_integrity()
+check("entry starting AFTER the cut is still a failure", r and r["status"] == "fail", str(r))
+
 # --- the undeclared env knobs are GONE ------------------------------------
 # AGENTS.md forbids inventing undocumented env vars, and these mirrored a
 # documented external contract that a deployment cannot legitimately retune

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -64,6 +64,72 @@ with tempfile.TemporaryDirectory() as t:
     check("backup-stranded memory → warn", r and r["status"] == "warn", str(r))
     check("warn names the stranded file", r and "gmail-imap-capability.md" in r["detail"], str(r))
 
+# --- (c) the index itself outgrowing the session read limit --------------
+# Modes (a) and (b) each lose ONE memory. This one loses the whole index at
+# once, silently, while every memory file on disk still looks healthy — so it
+# is tested at the boundary rather than with a single comfortable value.
+# Thresholds are pinned to explicit test values so the assertions do not drift
+# when the shipped defaults are retuned.
+_FAIL = hc.MEMORY_INDEX_FAIL_BYTES
+_WARN = hc.MEMORY_INDEX_WARN_BYTES
+check("shipped defaults leave real headroom (warn strictly below fail)", _WARN < _FAIL,
+      f"warn={_WARN} fail={_FAIL}")
+
+def _index_of(mem: Path, nbytes: int) -> None:
+    """Write a MEMORY.md of exactly nbytes that indexes one real memory."""
+    head = "# Index\n- [Good](good-memory.md) — "
+    (mem / "good-memory.md").write_text("body")
+    pad = "x" * max(0, nbytes - len(head.encode()) - 1)
+    (mem / "MEMORY.md").write_text(head + pad + "\n")
+
+for label, size, want in (
+    ("well under warn        → ok",   _WARN - 2048, "ok"),
+    ("one byte under warn    → ok",   _WARN - 1,    "ok"),
+    ("exactly at warn        → warn", _WARN,        "warn"),
+    ("between warn and fail  → warn", (_WARN + _FAIL) // 2, "warn"),
+    ("one byte under fail    → warn", _FAIL - 1,    "warn"),
+    ("exactly at fail        → fail", _FAIL,        "fail"),
+    ("far over fail          → fail", _FAIL + 8192, "fail"),
+):
+    with tempfile.TemporaryDirectory() as t:
+        mem = make_tree(Path(t))
+        _index_of(mem, size)
+        hc.MEMORY_DIR = mem
+        r = hc.check_memory_index_integrity()
+        check(f"index size: {label}", r and r["status"] == want,
+              f"size={size} got={r and r['status']} want={want} :: {r and r['detail'][:90]}")
+
+# The ok path should still report the size, so the number is visible BEFORE it
+# becomes a problem — a threshold you only see once it trips is a threshold you
+# cannot plan around.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    _index_of(mem, 1024)
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("ok detail states the index size", r and "KB index" in r["detail"], str(r))
+
+# Size and the pre-existing modes are independent: an oversized index must
+# still name the orphan, and must not be downgraded to warn by its presence.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    _index_of(mem, _FAIL + 512)
+    (mem / "orphan-memory.md").write_text("stranded rule that never loads")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("oversized + orphan → still fail", r and r["status"] == "fail", str(r))
+    check("oversized + orphan → still names the orphan",
+          r and "orphan-memory.md" in r["detail"], str(r))
+
+# An absent MEMORY.md is 0 bytes, not "oversized" — a fresh install must not
+# trip the size guard.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    (mem / "good-memory.md").write_text("body")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("no MEMORY.md at all → not a size failure", r and r["status"] != "fail", str(r))
+
 # 4) Missing memory dir → None (no false alarm on fresh installs).
 with tempfile.TemporaryDirectory() as t:
     hc.MEMORY_DIR = Path(t) / "does-not-exist" / "memory"

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -181,6 +181,28 @@ check("...and measures small once stripped",
 check("~~~ fences are honoured too, not just backticks",
       len(hc._index_effective_text("~~~\n<!--\n" + ("p\n" * 500) + "-->\n~~~\n").encode()) > 500)
 
+# rui-sutando-codex: a 4-backtick fence containing an inner ``` line. The marker
+# was truncated to three characters, so the inner line closed the fence early and
+# the comment after it was stripped as if unfenced — a 28KB file measured 39
+# bytes and returned a false `ok`. CommonMark closes a fence only on the SAME
+# character, at least as long as the opener, alone on its line.
+_BIGC = "<!--\n" + ("padding padding padding\n" * 1200) + "-->\n"
+for _label, _body in (
+    ("4-backtick fence with an inner ``` line", "````\n```\n" + _BIGC + "````\n" + _ENTRY),
+    ("4-tilde fence with an inner ~~~ line",    "~~~~\n~~~\n" + _BIGC + "~~~~\n" + _ENTRY),
+    ("4-backtick fence carrying an info string", "````html\n" + _BIGC + "````\n" + _ENTRY),
+):
+    _mem_with(_body)
+    r = hc.check_memory_index_integrity()
+    check(f"{_label} → comment is NOT stripped", r and r["status"] != "ok", str(r))
+# Controls: the fix must not simply stop stripping, and must not stop closing.
+_mem_with("<!--\n" + ("padding padding padding\n" * 1200) + "-->\n" + _ENTRY)
+check("control: an UNfenced comment is still stripped",
+      (hc.check_memory_index_integrity() or {}).get("status") == "ok")
+_mem_with("```\n<!--\n-->\n```\n" + _ENTRY)
+check("control: a fence still CLOSES (small fenced comment stays ok)",
+      (hc.check_memory_index_integrity() or {}).get("status") == "ok")
+
 # qingyun-wu: the byte limit cuts THROUGH a line; the filename before the cut is
 # still read, so the memory loads and must not be reported lost.
 _mem_with(("x" * (25 * 1024 - 100)) + "\n- [Good](good-memory.md) " + ("d" * 4000) + "\n")

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -130,6 +130,66 @@ with tempfile.TemporaryDirectory() as t:
     r = hc.check_memory_index_integrity()
     check("no MEMORY.md at all → not a size failure", r and r["status"] != "fail", str(r))
 
+# --- threshold OVERRIDES: the two limits are independent and can invert ----
+# qingyun-wu (#2449): a runtime measuring a SMALLER read limit sets only
+# ..._FAIL_BYTES and leaves the warn default alone, so fail < warn. An index
+# between them is over the fail limit while `outgrowing` is still False.
+# Gating the healthy return on `outgrowing` alone returned `ok` at exactly the
+# moment the index had stopped loading. Her exact repro is the first row.
+_shipped_fail, _shipped_warn = hc.MEMORY_INDEX_FAIL_BYTES, hc.MEMORY_INDEX_WARN_BYTES
+try:
+    for label, nbytes, fail, warn, want in (
+        ("her repro: fail<warn, between them   ", 150, 100, 200, "fail"),
+        ("fail<warn, under both                ",  50, 100, 200, "ok"),
+        ("fail<warn, over both                 ", 250, 100, 200, "fail"),
+        ("fail<warn, exactly at fail           ", 100, 100, 200, "fail"),
+        ("one-sided: only FAIL lowered         ", 150, 100, _shipped_warn, "fail"),
+        ("one-sided: only WARN raised past fail", 150, _shipped_fail, 999999, "ok"),
+        ("equal thresholds, at the boundary    ", 100, 100, 100, "fail"),
+        ("equal thresholds, just below         ",  99, 100, 100, "ok"),
+    ):
+        with tempfile.TemporaryDirectory() as t_:
+            mem = make_tree(Path(t_))
+            _index_of(mem, nbytes)
+            hc.MEMORY_DIR = mem
+            hc.MEMORY_INDEX_FAIL_BYTES, hc.MEMORY_INDEX_WARN_BYTES = fail, warn
+            r = hc.check_memory_index_integrity()
+            check(f"override {label} → {want}", r and r["status"] == want,
+                  f"bytes={nbytes} fail={fail} warn={warn} got={r and r['status']}")
+finally:
+    hc.MEMORY_INDEX_FAIL_BYTES, hc.MEMORY_INDEX_WARN_BYTES = _shipped_fail, _shipped_warn
+
+check("shipped thresholds restored after override tests",
+      (hc.MEMORY_INDEX_FAIL_BYTES, hc.MEMORY_INDEX_WARN_BYTES) == (_shipped_fail, _shipped_warn))
+
+# --- env parsing happens at IMPORT: a typo must not take health-check down ---
+# A bare int(os.environ[...]) raised ValueError during module import, so one
+# mistyped tuning variable removed ALL monitoring — worse than the problem the
+# threshold exists to catch.
+import os as _os
+for raw, want in (("24k", 24 * 1024), ("", 24 * 1024), ("0", 24 * 1024),
+                  ("-1", 24 * 1024), ("  ", 24 * 1024), ("12.5", 24 * 1024),
+                  ("8192", 8192), (" 8192 ", 8192)):
+    _os.environ["_TEST_MEM_IDX"] = raw
+    got = hc._positive_int_env("_TEST_MEM_IDX", 24 * 1024)
+    check(f"env {raw!r:9} → {want}", got == want, f"got {got}")
+_os.environ.pop("_TEST_MEM_IDX", None)
+check("unset env → default", hc._positive_int_env("_TEST_MEM_IDX_UNSET", 777) == 777)
+
+# The property that actually matters: the module still IMPORTS with a bad value.
+import subprocess as _sp, sys as _sys
+_env = dict(_os.environ, SUTANDO_MEMORY_INDEX_FAIL_BYTES="24k",
+            SUTANDO_MEMORY_INDEX_WARN_BYTES="oops")
+_r = _sp.run([_sys.executable, "-c",
+              "import importlib.util;s=importlib.util.spec_from_file_location('hc',%r);"
+              "m=importlib.util.module_from_spec(s);s.loader.exec_module(m);"
+              "print(m.MEMORY_INDEX_FAIL_BYTES, m.MEMORY_INDEX_WARN_BYTES)" % str(HC)],
+             capture_output=True, text=True, env=_env)
+check("health-check still imports with unparseable thresholds",
+      _r.returncode == 0, (_r.stderr or "")[-160:])
+check("and falls back to the shipped defaults",
+      _r.stdout.strip() == f"{24 * 1024} {19 * 1024}", _r.stdout.strip())
+
 # 4) Missing memory dir → None (no false alarm on fresh installs).
 with tempfile.TemporaryDirectory() as t:
     hc.MEMORY_DIR = Path(t) / "does-not-exist" / "memory"

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -64,131 +64,105 @@ with tempfile.TemporaryDirectory() as t:
     check("backup-stranded memory → warn", r and r["status"] == "warn", str(r))
     check("warn names the stranded file", r and "gmail-imap-capability.md" in r["detail"], str(r))
 
-# --- (c) the index itself outgrowing the session read limit --------------
-# Modes (a) and (b) each lose ONE memory. This one loses the whole index at
-# once, silently, while every memory file on disk still looks healthy — so it
-# is tested at the boundary rather than with a single comfortable value.
-# Thresholds are pinned to explicit test values so the assertions do not drift
-# when the shipped defaults are retuned.
-_FAIL = hc.MEMORY_INDEX_FAIL_BYTES
-_WARN = hc.MEMORY_INDEX_WARN_BYTES
-check("shipped defaults leave real headroom (warn strictly below fail)", _WARN < _FAIL,
-      f"warn={_WARN} fail={_FAIL}")
+# --- (c) the index outgrowing what a SESSION ACTUALLY READS ---------------
+# Claude Code loads the first 200 lines or 25KB of a memory file, whichever
+# comes first; content beyond that is dropped (the prefix still loads), and
+# YAML frontmatter + block-level HTML comments are stripped BEFORE the limits
+# are measured. https://code.claude.com/docs/en/memory#how-it-works
+#
+# These expectations are written as LITERALS from that document, deliberately
+# not as `hc.MEMORY_INDEX_LOAD_*`. An earlier revision derived its assertions
+# from the shipped constants, so the suite agreed with whatever the code said
+# and could not detect a wrong cutoff at all (qingyun-wu, #2449).
+check("shipped line limit matches the documented 200", hc.MEMORY_INDEX_LOAD_LINES == 200,
+      f"got {hc.MEMORY_INDEX_LOAD_LINES}")
+check("shipped byte limit matches the documented 25KB", hc.MEMORY_INDEX_LOAD_BYTES == 25 * 1024,
+      f"got {hc.MEMORY_INDEX_LOAD_BYTES}")
 
-def _index_of(mem: Path, nbytes: int) -> None:
-    """Write a MEMORY.md of exactly nbytes that indexes one real memory."""
-    head = "# Index\n- [Good](good-memory.md) — "
-    (mem / "good-memory.md").write_text("body")
-    pad = "x" * max(0, nbytes - len(head.encode()) - 1)
-    (mem / "MEMORY.md").write_text(head + pad + "\n")
-
-for label, size, want in (
-    ("well under warn        → ok",   _WARN - 2048, "ok"),
-    ("one byte under warn    → ok",   _WARN - 1,    "ok"),
-    ("exactly at warn        → warn", _WARN,        "warn"),
-    ("between warn and fail  → warn", (_WARN + _FAIL) // 2, "warn"),
-    ("one byte under fail    → warn", _FAIL - 1,    "warn"),
-    ("exactly at fail        → fail", _FAIL,        "fail"),
-    ("far over fail          → fail", _FAIL + 8192, "fail"),
-):
-    with tempfile.TemporaryDirectory() as t:
-        mem = make_tree(Path(t))
-        _index_of(mem, size)
-        hc.MEMORY_DIR = mem
-        r = hc.check_memory_index_integrity()
-        check(f"index size: {label}", r and r["status"] == want,
-              f"size={size} got={r and r['status']} want={want} :: {r and r['detail'][:90]}")
-
-# The ok path should still report the size, so the number is visible BEFORE it
-# becomes a problem — a threshold you only see once it trips is a threshold you
-# cannot plan around.
-with tempfile.TemporaryDirectory() as t:
-    mem = make_tree(Path(t))
-    _index_of(mem, 1024)
-    hc.MEMORY_DIR = mem
-    r = hc.check_memory_index_integrity()
-    check("ok detail states the index size", r and "KB index" in r["detail"], str(r))
-
-# Size and the pre-existing modes are independent: an oversized index must
-# still name the orphan, and must not be downgraded to warn by its presence.
-with tempfile.TemporaryDirectory() as t:
-    mem = make_tree(Path(t))
-    _index_of(mem, _FAIL + 512)
-    (mem / "orphan-memory.md").write_text("stranded rule that never loads")
-    hc.MEMORY_DIR = mem
-    r = hc.check_memory_index_integrity()
-    check("oversized + orphan → still fail", r and r["status"] == "fail", str(r))
-    check("oversized + orphan → still names the orphan",
-          r and "orphan-memory.md" in r["detail"], str(r))
-
-# An absent MEMORY.md is 0 bytes, not "oversized" — a fresh install must not
-# trip the size guard.
-with tempfile.TemporaryDirectory() as t:
+def _mem_with(index_body: str, extra=()):
+    """A memory tree whose MEMORY.md is exactly `index_body`."""
+    t = tempfile.mkdtemp()
     mem = make_tree(Path(t))
     (mem / "good-memory.md").write_text("body")
+    for name in extra:
+        (mem / name).write_text("body")
+    (mem / "MEMORY.md").write_text(index_body)
     hc.MEMORY_DIR = mem
-    r = hc.check_memory_index_integrity()
-    check("no MEMORY.md at all → not a size failure", r and r["status"] != "fail", str(r))
+    return mem
 
-# --- threshold OVERRIDES: the two limits are independent and can invert ----
-# qingyun-wu (#2449): a runtime measuring a SMALLER read limit sets only
-# ..._FAIL_BYTES and leaves the warn default alone, so fail < warn. An index
-# between them is over the fail limit while `outgrowing` is still False.
-# Gating the healthy return on `outgrowing` alone returned `ok` at exactly the
-# moment the index had stopped loading. Her exact repro is the first row.
-_shipped_fail, _shipped_warn = hc.MEMORY_INDEX_FAIL_BYTES, hc.MEMORY_INDEX_WARN_BYTES
-try:
-    for label, nbytes, fail, warn, want in (
-        ("her repro: fail<warn, between them   ", 150, 100, 200, "fail"),
-        ("fail<warn, under both                ",  50, 100, 200, "ok"),
-        ("fail<warn, over both                 ", 250, 100, 200, "fail"),
-        ("fail<warn, exactly at fail           ", 100, 100, 200, "fail"),
-        ("one-sided: only FAIL lowered         ", 150, 100, _shipped_warn, "fail"),
-        ("one-sided: only WARN raised past fail", 150, _shipped_fail, 999999, "ok"),
-        ("equal thresholds, at the boundary    ", 100, 100, 100, "fail"),
-        ("equal thresholds, just below         ",  99, 100, 100, "ok"),
-    ):
-        with tempfile.TemporaryDirectory() as t_:
-            mem = make_tree(Path(t_))
-            _index_of(mem, nbytes)
-            hc.MEMORY_DIR = mem
-            hc.MEMORY_INDEX_FAIL_BYTES, hc.MEMORY_INDEX_WARN_BYTES = fail, warn
-            r = hc.check_memory_index_integrity()
-            check(f"override {label} → {want}", r and r["status"] == want,
-                  f"bytes={nbytes} fail={fail} warn={warn} got={r and r['status']}")
-finally:
-    hc.MEMORY_INDEX_FAIL_BYTES, hc.MEMORY_INDEX_WARN_BYTES = _shipped_fail, _shipped_warn
+_ENTRY = "- [Good](good-memory.md)\n"
 
-check("shipped thresholds restored after override tests",
-      (hc.MEMORY_INDEX_FAIL_BYTES, hc.MEMORY_INDEX_WARN_BYTES) == (_shipped_fail, _shipped_warn))
+# john-the-dev's fixture 1: the ONLY index entry sits on line 201. The runtime
+# drops that line, so the memory never loads — reading the whole file instead
+# of the loaded prefix reported this as healthy.
+r = hc.check_memory_index_integrity() if _mem_with(
+    "".join(f"- filler {i}\n" for i in range(200)) + _ENTRY) else None
+check("entry parked on line 201 → fail", r and r["status"] == "fail", str(r))
+check("...and names the memory that will not load",
+      r and "good-memory.md" in r["detail"], str(r))
+check("...and does NOT claim the whole index stops loading",
+      r and "WHOLE index" not in r["detail"] and "whole index" not in r["detail"], str(r))
 
-# --- env parsing happens at IMPORT: a typo must not take health-check down ---
-# A bare int(os.environ[...]) raised ValueError during module import, so one
-# mistyped tuning variable removed ALL monitoring — worse than the problem the
-# threshold exists to catch.
-import os as _os
-for raw, want in (("24k", 24 * 1024), ("", 24 * 1024), ("0", 24 * 1024),
-                  ("-1", 24 * 1024), ("  ", 24 * 1024), ("12.5", 24 * 1024),
-                  ("8192", 8192), (" 8192 ", 8192)):
-    _os.environ["_TEST_MEM_IDX"] = raw
-    got = hc._positive_int_env("_TEST_MEM_IDX", 24 * 1024)
-    check(f"env {raw!r:9} → {want}", got == want, f"got {got}")
-_os.environ.pop("_TEST_MEM_IDX", None)
-check("unset env → default", hc._positive_int_env("_TEST_MEM_IDX_UNSET", 777) == 777)
+# john-the-dev's fixture 2: one visible entry plus a 25KiB block-level HTML
+# comment. The runtime strips the comment before measuring, so the index is
+# tiny in practice — counting raw bytes reported a hard failure.
+_mem_with(_ENTRY + "<!--\n" + ("padding padding padding\n" * 1100) + "-->\n")
+r = hc.check_memory_index_integrity()
+check("25KiB block HTML comment → not a failure", r and r["status"] != "fail", str(r))
 
-# The property that actually matters: the module still IMPORTS with a bad value.
-import subprocess as _sp   # `sys` is already imported at the top of this file
-_env = dict(_os.environ, SUTANDO_MEMORY_INDEX_FAIL_BYTES="24k",
-            SUTANDO_MEMORY_INDEX_WARN_BYTES="oops")
-_r = _sp.run([sys.executable, "-c",
-              "import importlib.util;s=importlib.util.spec_from_file_location('hc',%r);"
-              "m=importlib.util.module_from_spec(s);s.loader.exec_module(m);"
-              "print(m.MEMORY_INDEX_FAIL_BYTES, m.MEMORY_INDEX_WARN_BYTES)" % str(HC)],
-             capture_output=True, text=True, env=_env)
-check("health-check still imports with unparseable thresholds",
-      _r.returncode == 0, (_r.stderr or "")[-160:])
-check("and falls back to the shipped defaults",
-      _r.stdout.strip() == f"{24 * 1024} {19 * 1024}", _r.stdout.strip())
+# Same idea for YAML frontmatter.
+_mem_with("---\n" + ("meta: x\n" * 900) + "---\n" + _ENTRY)
+r = hc.check_memory_index_integrity()
+check("large YAML frontmatter → not a failure", r and r["status"] != "fail", str(r))
+
+# The BYTE limit binds too, not just the line limit: few lines, but the entry
+# is pushed past 25KB.
+_mem_with(("x" * 4000 + "\n") * 7 + _ENTRY)
+r = hc.check_memory_index_integrity()
+check("entry pushed past the 25KB byte limit → fail", r and r["status"] == "fail", str(r))
+
+# ...and "whichever comes first" means the LINE limit can bind while the file
+# is nowhere near 25KB.
+_mem_with("".join(f"- f{i}\n" for i in range(400)) + _ENTRY)
+r = hc.check_memory_index_integrity()
+check("line limit binds well under 25KB → fail", r and r["status"] == "fail", str(r))
+
+# Approaching the limit warns while everything still loads, so there is room to
+# compact deliberately rather than after entries have already been dropped.
+_mem_with(_ENTRY + "".join(f"- f{i}\n" for i in range(185)))
+r = hc.check_memory_index_integrity()
+check("near the line limit, nothing dropped yet → warn", r and r["status"] == "warn", str(r))
+check("...and the warn is about approaching, not loss",
+      r and "approaching" in r["detail"], str(r))
+
+# A comfortable index stays quiet and still reports its size.
+_mem_with(_ENTRY)
+r = hc.check_memory_index_integrity()
+check("small clean index → ok", r and r["status"] == "ok", str(r))
+check("ok detail states the loadable size", r and "session read limit" in r["detail"], str(r))
+
+# Loss and the pre-existing modes are independent.
+_mem_with("".join(f"- filler {i}\n" for i in range(200)) + _ENTRY, extra=("orphan-memory.md",))
+r = hc.check_memory_index_integrity()
+check("dropped entry + orphan → still fail", r and r["status"] == "fail", str(r))
+check("dropped entry + orphan → still names the orphan",
+      r and "orphan-memory.md" in r["detail"], str(r))
+
+# An absent MEMORY.md is not a size failure — a fresh install must stay quiet.
+t = tempfile.mkdtemp(); mem = make_tree(Path(t))
+(mem / "good-memory.md").write_text("body"); hc.MEMORY_DIR = mem
+r = hc.check_memory_index_integrity()
+check("no MEMORY.md at all → not a size failure", r and r["status"] != "fail", str(r))
+
+# --- the undeclared env knobs are GONE ------------------------------------
+# AGENTS.md forbids inventing undocumented env vars, and these mirrored a
+# documented external contract that a deployment cannot legitimately retune
+# (qingyun-wu, #2449). Asserted structurally so they cannot quietly return.
+for _gone in ("MEMORY_INDEX_FAIL_BYTES", "MEMORY_INDEX_WARN_BYTES", "_positive_int_env"):
+    check(f"removed: hc.{_gone}", not hasattr(hc, _gone), f"{_gone} is back")
+_src = HC.read_text()
+for _var in ("SUTANDO_MEMORY_INDEX_FAIL_BYTES", "SUTANDO_MEMORY_INDEX_WARN_BYTES"):
+    check(f"no undeclared env var {_var}", _var not in _src)
 
 # 4) Missing memory dir → None (no false alarm on fresh installs).
 with tempfile.TemporaryDirectory() as t:


### PR DESCRIPTION
## The gap

`check_memory_index_integrity` exists to catch **"a memory that will never load."** It covers two modes — a file not referenced in `MEMORY.md`, and one stranded in a `*-BACKUP` tree — and misses the third, which has by far the largest blast radius: **the index itself outgrowing the per-session read limit.**

Past that point the file isn't truncated, it's *skipped* — so every indexed memory stops loading at once. Modes (a) and (b) lose one memory each. This one loses all of them.

It also arrives silently: every memory file on disk still looks healthy, the probe still emits its usual warn, and nothing anywhere mentions the size.

## Why now

Observed on this fleet **2026-07-31: MEMORY.md reached 22.0KB against a 24.4KB limit** — a few more filed memories from dropping a 250-entry index — and nothing caught it. It was found by accident while compacting, not by a check.

Reconstructing that exact size against this patch:

```
22.0KB index -> warn | MEMORY.md is 22.0KB, approaching the 24.0KB session read
limit — compact it before it crosses; past the limit EVERY indexed memory stops loading
```

On this host's current 16.9KB index the size guard correctly stays quiet.

## Design notes

- **Thresholds are env-overridable** (`SUTANDO_MEMORY_INDEX_WARN_BYTES` / `_FAIL_BYTES`) because the limit is a property of the **session runtime, not of this repo**. The defaults encode what was *measured* here rather than a documented constant, so a deployment that observes a different limit can declare it instead of patching code.
- **Warn at 19KB, fail at 24KB.** The gap is deliberate headroom — enough to compact on purpose rather than in a panic.
- **Over the limit reports `fail`, not `warn`** — it isn't "up but degraded", it isn't loading at all.
- **The ok path now states the index size**, so the number is visible *before* it becomes a problem. A threshold you only see once it trips is one you can't plan around.

## Test plan

- [x] Tested **at the boundary**, not with one comfortable value: below warn · one byte under warn · exactly at warn · between warn and fail · one byte under fail · exactly at fail · far over.
- [x] Interactions that matter: an oversized index **still names an orphaned memory** and is **not** downgraded to warn by its presence; an absent `MEMORY.md` is 0 bytes rather than "oversized", so a fresh install stays clean.
- [x] Thresholds are read from the module inside the test, so assertions don't drift when the shipped defaults are retuned.
- [x] **Mutation-tested, not assumed** — every one goes RED: `>=`→`>` at the fail boundary · same at warn · never escalating to fail · dropping size from the ok detail · letting the size branch swallow the unindexed report.
- [x] `health-check-quota-telemetry` and `health-check-recover-cron` still pass · `py_compile` · `git diff --check` · `review-checks` PASS.

## Known interaction — stated rather than hidden

On a vault-union node the pre-existing 900+ `unindexed` warn (**#2392** / **#2407**, which are duplicates of each other) shares this check's detail string, so a size warning would appear *appended to that noise*. This PR deliberately does **not** change that behaviour — it's the subject of those two open issues — but it is the reason the size condition also sets `fail`, which is visually distinct from the permanent warn.

Happy to fold this into whoever takes #2392/#2407 if a reviewer would rather see the probe reworked in one go.
