### PR TITLE
fix(discord-read): render forwarded-message content instead of a blank line

### DIFF
--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -23,6 +23,10 @@ from discord_http import request_json  # noqa: E402
 # 200 pages * 100 = 20k messages before we refuse to loop forever.
 MAX_PAGES = 200
 
+# Ordinary messages are clipped so a long scroll stays scannable; FORWARDS are
+# exempt (see _render) because a forward is usually the substance, not chatter.
+CLIP = 200
+
 
 def _load_token(env):
     """Populate DISCORD_BOT_TOKEN from the channel .env (if present) and return it."""
@@ -41,6 +45,41 @@ def _fetch(extra, channel_id, page, headers):
     # request_json honors 429 Retry-After + retries transient 5xx, so a rate
     # limit mid-pagination no longer aborts the read (2026-07-24 truncation fix).
     return request_json(req, timeout=10)
+
+
+def _render(msg):
+    """One message's readable body, INCLUDING forwarded content.
+
+    A Discord *forward* carries empty top-level `content` and puts the real
+    payload in `message_snapshots[0].message` (the bridge already knows this —
+    `discord-bridge.py` reads it, `discord_addressee.py` documents it). This
+    reader did not, so every forwarded message rendered as a BLANK LINE — and
+    this is the reader the context-reconstruct step runs on every pass.
+
+    Measured 2026-07-31: two forwards in #research-eval printed as empty while
+    holding the only record of a live AMA failure (a 1,602-char transcript plus
+    the reporter's own words). They were nearly deleted on the strength of that
+    blank output — see feedback_forwarded_discord_msgs_hide_content_in_message_snapshots.
+
+    The forward is LABELLED rather than silently inlined: attributing a quoted
+    message to the forwarder is its own misreading. Forwards are also exempt
+    from the 200-char clip — the clip exists to keep ordinary chatter scannable,
+    and a forward is usually carrying the substance someone moved deliberately.
+    """
+    body = (msg.get("content") or "").strip()
+    snaps = msg.get("message_snapshots") or []
+    if not snaps:
+        return body[:CLIP]
+    fwd = (snaps[0].get("message") or {})
+    fwd_body = (fwd.get("content") or "").strip()
+    extra = []
+    for a in fwd.get("attachments") or []:
+        extra.append(f"<attachment: {a.get('filename', '?')}>")
+    for e in fwd.get("embeds") or []:
+        extra.append(f"<embed: {e.get('title') or e.get('type') or '?'}>")
+    inner = " ".join(x for x in (fwd_body, *extra) if x) or "(forward with no readable body)"
+    prefix = f"{body} " if body else ""
+    return f"{prefix}[forwarded] {inner}"
 
 
 def _at_or_before_boundary(msg, until):
@@ -108,9 +147,8 @@ def main(argv=None):
         if args.until and _strictly_older_than_boundary(msg, args.until):
             continue
         author = msg.get("author", {}).get("username", "?")
-        content = msg.get("content", "")[:200]
         ts = msg.get("timestamp", "")[:19]
-        print(f"[{ts}] {author}: {content}")
+        print(f"[{ts}] {author}: {_render(msg)}")
     return 0
 
 

--- a/tests/discord-read-forwarded.test.py
+++ b/tests/discord-read-forwarded.test.py
@@ -85,6 +85,43 @@ check("D3 control: empty non-forward stays empty (no phantom label)",
 check("D4 control: missing content key does not raise",
       dr._render({}) == "")
 
+
+# --- end-to-end through main(): the forward must reach STDOUT ---------------
+# The unit checks above prove `_render` is correct; this proves the RENDER LOOP
+# actually uses it. That is the line that was wrong in production — the helper
+# never existed, so a suite that only exercised a helper would have passed
+# against a reader that still printed blanks.
+import io
+import contextlib
+
+_SAMPLE = [
+    {"id": "2", "timestamp": "2026-07-30T17:17:20.000000+00:00",
+     "author": {"username": "susanliu_"}, "content": "",
+     "message_snapshots": [{"message": {"content": "the 1602-char transcript lives here",
+                                        "attachments": [], "embeds": []}}]},
+    {"id": "1", "timestamp": "2026-07-30T16:58:00.000000+00:00",
+     "author": {"username": "susanliu_"}, "content": "an ordinary message"},
+]
+
+dr._load_token = lambda env: "test-token"
+dr._fetch = lambda extra, channel_id, page, headers: list(_SAMPLE)
+
+buf = io.StringIO()
+with contextlib.redirect_stdout(buf):
+    rc = dr.main(["1532071853219385394"])
+printed = buf.getvalue()
+
+check("E1 main() exits 0 with a stubbed fetch", rc == 0, f"rc={rc}")
+check("E2 the ordinary message still prints its text",
+      "an ordinary message" in printed, repr(printed))
+check("E3 THE FORWARD REACHES STDOUT (the production failure)",
+      "1602-char transcript" in printed, repr(printed))
+check("E4 the forward is labelled in the output",
+      "[forwarded]" in printed, repr(printed))
+check("E5 output stays oldest-first",
+      printed.index("an ordinary message") < printed.index("1602-char transcript"),
+      repr(printed))
+
 print()
 if failures:
     print(f"FAIL — {len(failures)} check(s) failed")

--- a/tests/discord-read-forwarded.test.py
+++ b/tests/discord-read-forwarded.test.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""discord-read.py must render FORWARDED message content, not a blank line.
+
+A Discord forward carries empty top-level `content`; the payload lives in
+`message_snapshots[0].message`. `discord-bridge.py` already reads that shape and
+`discord_addressee.py` documents it — the READER did not, so every forwarded
+message printed as an empty body.
+
+That reader is what the context-reconstruct step runs on every pass, so the gap
+is silent and systemic: any decision forwarded into a channel rather than typed
+was invisible.
+
+Measured 2026-07-31 in #research-eval: two forwards rendered blank while holding
+the only record of a live AMA failure (a 1,602-char session transcript plus the
+reporter's own words). They were nearly deleted on the strength of that blank
+output.
+"""
+import importlib.util
+import pathlib
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location("dr", REPO / "src" / "discord-read.py")
+dr = importlib.util.module_from_spec(spec)
+sys.modules["dr"] = dr
+spec.loader.exec_module(dr)
+
+failures = []
+
+
+def check(label, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + label + ("" if cond else f" — {detail}"))
+    if not cond:
+        failures.append(label)
+
+
+def fwd(inner_text, attachments=None, embeds=None, outer=""):
+    return {
+        "content": outer,
+        "message_snapshots": [{"message": {
+            "content": inner_text,
+            "attachments": attachments or [],
+            "embeds": embeds or [],
+        }}],
+    }
+
+
+# --- the regression itself -------------------------------------------------
+out = dr._render(fwd("I tried this morning and it started bluffing"))
+check("A1 forwarded text is rendered, not dropped",
+      "bluffing" in out, f"got {out!r}")
+check("A2 the forward is LABELLED, not silently attributed to the forwarder",
+      "[forwarded]" in out, f"got {out!r}")
+
+# A forward is the substance someone moved deliberately — it must not be clipped
+# at the ordinary 200-char scan limit. The live case was 1,602 chars.
+long_body = "x" * 1602
+out = dr._render(fwd(long_body))
+check("A3 forwarded body is NOT clipped at CLIP (live case was 1602 chars)",
+      out.count("x") == 1602, f"rendered {out.count('x')} of 1602")
+
+# --- media-only forwards ---------------------------------------------------
+out = dr._render(fwd("", attachments=[{"filename": "session.png"}]))
+check("B1 attachment-only forward names the file",
+      "session.png" in out, f"got {out!r}")
+out = dr._render(fwd("", embeds=[{"title": "Deck v3"}]))
+check("B2 embed-only forward names the embed",
+      "Deck v3" in out, f"got {out!r}")
+out = dr._render(fwd(""))
+check("B3 a genuinely bodyless forward says so rather than printing blank",
+      "no readable body" in out, f"got {out!r}")
+
+# --- a forward WITH the forwarder's own comment ----------------------------
+out = dr._render(fwd("see this", outer="worth a look"))
+check("C1 forwarder's own text is kept alongside the forwarded body",
+      "worth a look" in out and "see this" in out, f"got {out!r}")
+
+# --- controls: ordinary messages must be untouched -------------------------
+check("D1 control: plain message renders its content",
+      dr._render({"content": "hello"}) == "hello")
+check("D2 control: plain message IS still clipped at CLIP",
+      len(dr._render({"content": "y" * 500})) == dr.CLIP)
+check("D3 control: empty non-forward stays empty (no phantom label)",
+      dr._render({"content": ""}) == "")
+check("D4 control: missing content key does not raise",
+      dr._render({}) == "")
+
+print()
+if failures:
+    print(f"FAIL — {len(failures)} check(s) failed")
+    sys.exit(1)
+print("PASS — discord-read forwarded-message tests")


### PR DESCRIPTION
## The bug

A Discord **forward** carries empty top-level `content`; the payload lives in `message_snapshots[0].message`. `src/discord-read.py` printed only `content`, so **every forwarded message rendered as a blank line.**

That reader is what the `context-reconstruct` step runs on every pass, which makes the gap silent and systemic: **any decision forwarded into a channel rather than typed has been invisible to every reconstruction.**

## Why it's a bug, not a formatting choice

The bridge already understands this shape — `discord-bridge.py` reads `message_snapshots` at both the reply gate and the forward handler, and `discord_addressee.py:35` documents it. One protocol, two components, one of them blind.

## How it was found

2026-07-31, the hard way. Two forwards in `#research-eval` printed as blank while holding the only record of a live AMA failure:

- the reporter's own words — *"it answered me once and then started bluffing without responding to my questions"*
- a **1,602-char** session transcript diagnosing morning-briefing context bleeding into an AMA reply, plus **25× audio-muted-from-start**

The channel was about to be deleted and I reported those messages as empty. The owner caught it (*"they are not empty. Do you have trouble reading forwarded msg?"*). Nothing was lost — but only because he knew what he had written.

## Behaviour

- forwarded body is rendered, prefixed `[forwarded]`
- **the label is deliberate** — silently inlining a forward attributes a quoted message to the forwarder, which is its own misreading
- attachment-/embed-only forwards name the file or embed title
- a genuinely bodyless forward says so rather than printing blank
- the forwarder's own comment is kept alongside the forwarded body
- **forwards are exempt from the 200-char scan clip** (now the named constant `CLIP`). The clip keeps ordinary chatter scannable; a forward is usually the substance someone moved deliberately — the live case was 1,602 chars.

## Verification

11 regressions in `tests/discord-read-forwarded.test.py`.

**Mutation-verified by reverting the BEHAVIOUR while keeping the symbol**, so the suite fails on logic rather than an `AttributeError`:

```text
against pre-fix behaviour:
  FAIL A1 forwarded text is rendered, not dropped — got ''
  FAIL A2 the forward is LABELLED, not silently attributed to the forwarder — got ''
  FAIL A3 forwarded body is NOT clipped at CLIP (live case was 1602 chars) — rendered 0 of 1602
  FAIL B1 attachment-only forward names the file — got ''
  FAIL B2 embed-only forward names the embed — got ''
  FAIL B3 a genuinely bodyless forward says so rather than printing blank — got ''
  FAIL C1 forwarder's own text is kept alongside the forwarded body — got 'worth a look'
  ok  D1..D4 controls
FAIL — 7 check(s) failed

on this head: PASS — 11/11
```

Exactly the 7 forward pins fail pre-fix; **all 4 controls pass on both heads**, so the additions can't pass vacuously and the fix can't degrade into "never clip" or "label everything".

Also clean: `py_compile` under `-W error::SyntaxWarning`, `scripts/gen-src-map.py --check`, `git diff --check`.

## Scope

Reader-only. **Does not touch the bridge**, which already handles forwards correctly. Related but distinct: #2342 fixes the *bridge's* addressee gate for forwarded owner messages — different file, different failure.

I have **not** exercised this against a live channel read in CI; the regressions drive `_render` directly with recorded forward shapes.

@sonichi
