### PR TITLE
fix: stop the 'git requires Command Line Tools' dialog on fresh Macs (two boot-path callers)

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -543,7 +543,27 @@ except Exception:
 # independent); dirty flags uncommitted edits. A stronger working-tree
 # 'source_sha' (hashes uncommitted + untracked behavior files) is a documented
 # follow-up alongside the identity block.
+# Skip git entirely on a fresh consumer Mac with no Xcode Command Line Tools.
+# There /usr/bin/git is an Apple shim that pops a GUI 'install the developer
+# tools?' dialog the instant it is invoked -- BEFORE git runs, so the try/except
+# below cannot suppress it -- and this descriptor is probed at app boot, so the
+# dialog fires on the first onboarding screen. The code identity is a no-op there
+# anyway: the bundled engine is an rsync copy with no .git, so every field is
+# None. Gate on a REAL git resolving without invoking the shim: CLT dir present,
+# or the repo actually has a .git. os.path checks never trigger the shim (unlike
+# a bare 'git' or shutil.which('git'), which can).
+def _git_available():
+    if os.path.isdir(os.path.join(repo, '.git')) or os.path.isfile(os.path.join(repo, '.git')):
+        return True
+    for p in ('/Library/Developer/CommandLineTools/usr/bin/git',
+              '/usr/local/bin/git', '/opt/homebrew/bin/git'):
+        if os.path.exists(p):
+            return True
+    return False
+_HAVE_GIT = _git_available()
 def _git(*a):
+    if not _HAVE_GIT:
+        return None
     try:
         r = subprocess.run(['git', '-C', repo, *a], capture_output=True, text=True, timeout=5)
         return (r.stdout.strip() or None) if r.returncode == 0 else None

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -261,8 +261,20 @@ fi
 #
 # Actively clear any stale committer.* a prior startup wrote, so every
 # fleet host self-heals on its next boot.
-git -C "$REPO" config --unset committer.name 2>/dev/null || true
-git -C "$REPO" config --unset committer.email 2>/dev/null || true
+#
+# Guard on Xcode CLT presence: on a fresh consumer Mac (no Command Line Tools),
+# /usr/bin/git is an Apple SHIM that pops a GUI "install the developer tools?"
+# dialog the instant it's invoked — BEFORE git runs, so `2>/dev/null` can't
+# suppress it — and startup runs on every core boot, so the dialog reappears
+# every launch. The self-heal is a no-op there anyway: the bundled engine is an
+# rsync copy with no .git, so there's no stale committer.* to unset. Skip it
+# unless real git is available. `xcode-select -p` is the shim-safe probe (returns
+# non-zero without prompting; same pattern as migrate.sh) — do NOT use
+# `command -v git`, which can itself trigger the shim.
+if xcode-select -p >/dev/null 2>&1; then
+  git -C "$REPO" config --unset committer.name 2>/dev/null || true
+  git -C "$REPO" config --unset committer.email 2>/dev/null || true
+fi
 
 # Re-apply tracked plugin-cache patches (skills/plugin-patches/). Plugin caches
 # are managed like node_modules — clobbered on update + invisible to git/sync —


### PR DESCRIPTION
## Problem

On a fresh consumer Mac with **no Xcode Command Line Tools**, the packaged app pops macOS's *"The 'git' command requires the command line developer tools. Install now?"* dialog — **on every core launch**, and for signed-in users, not just onboarding.

The trigger is `src/startup.sh` (the committer.* self-heal):
```sh
git -C "$REPO" config --unset committer.name  2>/dev/null || true
git -C "$REPO" config --unset committer.email 2>/dev/null || true
```
On a Mac without CLT, `/usr/bin/git` is an Apple **shim** that pops the install dialog *the moment git is invoked* — **before** git runs — so the existing `2>/dev/null` cannot suppress it (it's a GUI prompt, not git's stderr). `startup.sh` runs on every core boot, so it reappears every launch.

## Why the self-heal is a no-op there anyway

This block only clears a stale `committer.*` a prior fleet startup wrote. In the **packaged app** the engine is an rsync copy with **no `.git`**, so there is nothing to unset — the call does no useful work; it only leaks the dialog.

## Fix

Guard the two calls behind `xcode-select -p` — the **shim-safe** presence probe (returns non-zero *without prompting* when CLT is absent). This is the same pattern already used in `src/migrate.sh`. Not `command -v git`, which can itself trigger the shim.

```sh
if xcode-select -p >/dev/null 2>&1; then
  git -C "$REPO" config --unset committer.name 2>/dev/null || true
  git -C "$REPO" config --unset committer.email 2>/dev/null || true
fi
```

Developer / fleet hosts with real git → **unaffected** (guard passes, self-heal runs as before). Consumer Macs without CLT → **skip it, no dialog**.

## Scope

Runtime startup **only**. The genuine git dependencies are intentionally **untouched**:
- `src/migrate.sh` `git clone` — the dev install-from-source path (really needs git)
- `src/agent/claude/cli/sutando-shell-setup.sh` `git rev-parse` — dev shell helper for working inside a checkout

## Verification

```
$ bash -n src/startup.sh
syntax OK

$ bash tests/startup-stand-identity-self-heal.test.sh
OK — all 4 self-heal cases pass
```

Draft: a real post-restart round trip on a fresh Mac (CLT absent → no dialog; CLT present → self-heal still runs) is pending a clean-VM run; will attach that evidence before marking ready.