### PR TITLE
fix(sync-workspace): preserve the incoming side the --ours fallback discards

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -907,27 +907,56 @@ cmd_pull_only() {
 # rebuilds the loop it checks passes just as happily against the unfixed script.
 _resolve_conflicts_keep_ours() {
     local peer="${1:-peer}" backup_root="${2:-}" f
-    [ -n "$backup_root" ] || backup_root="${WORKSPACE_DIR:-.}/state/sync-conflicts/$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%s' "$peer" | tr '/' '_')"
+    # Default location is INSIDE the git dir, not under state/. `state/` looked
+    # safe because it currently has 0 tracked files — but that is an observation
+    # of one config, not an invariant: `vault.sync.include` is user-configurable
+    # and _compose_exclude_content emits includes before excludes (last match
+    # wins), so a supported `state/` include un-ignores `state/**` and the next
+    # push would stage these backups. Anything under the git dir is never
+    # tracked by construction, whatever the carrier set says. `rev-parse
+    # --git-dir` resolves correctly for a worktree too, where .git is a file.
+    # (john-the-dev, #2476 review blocker 2.)
+    if [ -z "$backup_root" ]; then
+        local _gitdir; _gitdir="$(git rev-parse --git-dir 2>/dev/null || echo .git)"
+        backup_root="$_gitdir/sutando-sync-conflicts/$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%s' "$peer" | tr '/' '_')"
+    fi
+    # Counted, not assumed: the summary below must be a FUNCTION of what
+    # actually got written. v1 logged only on success and then claimed "each
+    # discarded incoming file is preserved" whenever the directory merely
+    # existed — so a failed mkdir/write discarded the peer's version silently
+    # while telling the operator it was recoverable (blocker 1, reproduced by
+    # the reviewer by making backup/dir a regular file).
+    local saved=0 failed=0 failed_list=""
     while IFS= read -r -d '' f; do
         if git show ":3:$f" >/dev/null 2>&1; then
             if mkdir -p "$backup_root/$(dirname "$f")" 2>/dev/null &&
                git show ":3:$f" > "$backup_root/$f" 2>/dev/null; then
+                saved=$((saved + 1))
                 log "_resolve_conflicts_keep_ours: discarded incoming $f -> $backup_root/$f"
+            else
+                failed=$((failed + 1))
+                failed_list="${failed_list:+$failed_list, }$f"
+                # Loud per-file: this one is genuinely unrecoverable.
+                log "_resolve_conflicts_keep_ours: FAILED to preserve $f — incoming version is LOST"
+                color_warn "sync-workspace: could NOT preserve the incoming version of $f (backup write failed under $backup_root) — that version is discarded unrecoverably"
             fi
         else
             log "_resolve_conflicts_keep_ours: discarded incoming $f (no stage-3 blob to preserve)"
         fi
         # `--ours` fails on DD-conflicts (both sides deleted) — the file isn't
         # on our side either. Fall back to `git rm` so the merge can complete
-        # cleanly. Surfaced by Mini #1445 v3 Test 12.
+        # cleanly. Surfaced by Mini #1445 v3 Test 12. Preservation stays
+        # best-effort: a backup failure must never block the merge.
         if git checkout --ours -- "$f" 2>/dev/null; then
             git add -- "$f"
         else
             git rm -f -- "$f" 2>/dev/null || true
         fi
     done < <(git diff --name-only --diff-filter=U -z)
-    if [ -d "$backup_root" ]; then
-        color_warn "sync-workspace: kept the local version on conflict with $peer; each discarded incoming file is preserved under $backup_root"
+    if [ "$failed" -gt 0 ]; then
+        color_warn "sync-workspace: kept the local version on conflict with $peer; $saved incoming file(s) preserved under $backup_root, $failed NOT saved ($failed_list)"
+    elif [ "$saved" -gt 0 ]; then
+        color_warn "sync-workspace: kept the local version on conflict with $peer; all $saved discarded incoming file(s) preserved under $backup_root"
     fi
 }
 

--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -887,6 +887,50 @@ cmd_pull_only() {
     _pull_only_impl
 }
 
+# Resolve every unmerged path by keeping OUR side — after preserving THEIRS.
+#
+# `--ours` is right for host-local state and lossy for anything both hosts
+# append to. On 2026-07-31 it silently dropped two MEMORY.md index lines
+# (merge 64dec1b2) and a WIRE episode-index entry (merge 258c349b); the second
+# stayed missing for ~2 days. Neither surfaced: the log named the PEER but
+# never which files lost their incoming version, and `git log -- FILE` cannot
+# show a change destroyed IN a merge, because history simplification hides
+# merge commits — so the normal way of looking finds nothing.
+#
+# Stage 3 is "theirs". The copy goes under state/, which the sync excludes
+# (0 tracked files there), so a backup can never itself become a conflicting
+# tracked file. Best-effort throughout: a failure to preserve must never block
+# the merge, and a DD conflict (both sides deleted) has no stage 3 to save.
+#
+# Extracted from the caller so the behaviour can be tested against a REAL
+# conflicted index rather than a re-implementation of this loop — a test that
+# rebuilds the loop it checks passes just as happily against the unfixed script.
+_resolve_conflicts_keep_ours() {
+    local peer="${1:-peer}" backup_root="${2:-}" f
+    [ -n "$backup_root" ] || backup_root="${WORKSPACE_DIR:-.}/state/sync-conflicts/$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%s' "$peer" | tr '/' '_')"
+    while IFS= read -r -d '' f; do
+        if git show ":3:$f" >/dev/null 2>&1; then
+            if mkdir -p "$backup_root/$(dirname "$f")" 2>/dev/null &&
+               git show ":3:$f" > "$backup_root/$f" 2>/dev/null; then
+                log "_resolve_conflicts_keep_ours: discarded incoming $f -> $backup_root/$f"
+            fi
+        else
+            log "_resolve_conflicts_keep_ours: discarded incoming $f (no stage-3 blob to preserve)"
+        fi
+        # `--ours` fails on DD-conflicts (both sides deleted) — the file isn't
+        # on our side either. Fall back to `git rm` so the merge can complete
+        # cleanly. Surfaced by Mini #1445 v3 Test 12.
+        if git checkout --ours -- "$f" 2>/dev/null; then
+            git add -- "$f"
+        else
+            git rm -f -- "$f" 2>/dev/null || true
+        fi
+    done < <(git diff --name-only --diff-filter=U -z)
+    if [ -d "$backup_root" ]; then
+        color_warn "sync-workspace: kept the local version on conflict with $peer; each discarded incoming file is preserved under $backup_root"
+    fi
+}
+
 _pull_only_impl() {
     cd "$WORKSPACE_DIR" || die "pull-only: cannot cd to $WORKSPACE_DIR"
     [ -d ".git" ] || die "pull-only: $WORKSPACE_DIR is not a git repo; run --init first"
@@ -972,16 +1016,7 @@ _pull_only_impl() {
             # conflicts were never resolved — the merge stayed open while the
             # run still reported success, wedging every later sync behind
             # "You have not concluded your merge". Review #2 finding (2026-06-11).
-            while IFS= read -r -d '' f; do
-                # `--ours` fails on DD-conflicts (both sides deleted) — the file
-                # isn't on our side either. Fall back to `git rm` so the merge
-                # can complete cleanly. Surfaced by Mini #1445 v3 Test 12.
-                if git checkout --ours -- "$f" 2>/dev/null; then
-                    git add -- "$f"
-                else
-                    git rm -f -- "$f" 2>/dev/null || true
-                fi
-            done < <(git diff --name-only --diff-filter=U -z)
+            _resolve_conflicts_keep_ours "$peer"
             git -c core.editor=true commit --no-edit 2>/dev/null || true
             # Verify the merge actually concluded — unmerged entries here mean
             # the resolution above missed something; abort rather than leave a

--- a/tests/sync-workspace-conflict-preserves-theirs.test.sh
+++ b/tests/sync-workspace-conflict-preserves-theirs.test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# The `--ours` conflict fallback must not destroy the incoming version silently.
+#
+# sync-workspace resolves an unresolvable merge conflict by keeping the merging
+# host's file (`git checkout --ours`). That is right for host-local state and
+# wrong for anything both hosts append to: on 2026-07-31 it dropped two
+# MEMORY.md index lines (merge 64dec1b2) and a WIRE episode-index entry
+# (merge 258c349b), and the second stayed missing for ~2 days. Neither surfaced
+# — the log named the peer but never the files, and `git log -- FILE` cannot
+# show a change destroyed IN a merge because history simplification hides merge
+# commits.
+#
+# This drives the REAL fallback block over a real two-branch conflict and
+# asserts the discarded side is recoverable afterwards.
+#
+# Run: bash tests/sync-workspace-conflict-preserves-theirs.test.sh
+set -uo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO/scripts/sync-workspace.sh"
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+check(){ if [ "$1" = "0" ]; then ok "$2"; else bad "$2"; fi; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# Load ONLY the function under test, by extracting its definition from the real
+# script. The script ends in an unguarded dispatch, so it cannot simply be
+# sourced; slicing the definition keeps this a test OF the script rather than a
+# copy of it. `log` and `color_warn` are the script's helpers — stub them.
+log() { :; }
+color_warn() { printf 'WARN %s\n' "$*"; }
+eval "$(awk '/^_resolve_conflicts_keep_ours\(\) \{/,/^\}/' "$SCRIPT")"
+if ! declare -F _resolve_conflicts_keep_ours >/dev/null; then
+    printf '  FAIL could not load _resolve_conflicts_keep_ours from %s\n' "$SCRIPT"
+    printf '\nsync conflict preserves theirs: 0 passed, 1 failed\n'
+    exit 1
+fi
+ok "loaded _resolve_conflicts_keep_ours from the real script"
+
+# --- a real conflict, resolved by the REAL function --------------------------
+WS="$TMP/ws"; mkdir -p "$WS"; cd "$WS" || exit 1
+git init -q .; git config user.email t@t; git config user.name t
+printf 'line1\nline2\n' > index.md
+git add index.md; git commit -qm base
+git checkout -q -b peer
+printf 'line1\nline2\nPEER-ONLY-ENTRY\n' > index.md
+git commit -qam peer
+git checkout -q -; printf 'line1\nline2\nOURS-ONLY-ENTRY\n' > index.md
+git commit -qam ours
+git merge peer >/dev/null 2>&1
+[ "$(git diff --name-only --diff-filter=U)" = "index.md" ]
+check $? "fixture really produces a conflict on index.md"
+
+BK="$WS/backup"
+_resolve_conflicts_keep_ours "origin/peer" "$BK"
+
+[ -z "$(git diff --name-only --diff-filter=U)" ]
+check $? "function leaves NO unmerged paths (merge can conclude)"
+grep -q OURS-ONLY-ENTRY index.md; check $? "our side is kept (unchanged behaviour)"
+! grep -q PEER-ONLY-ENTRY index.md; check $? "peer's line is absent from the result, as before"
+grep -q PEER-ONLY-ENTRY "$BK/index.md" 2>/dev/null
+check $? "THE POINT: the discarded peer version is recoverable from the backup"
+
+# --- a DD conflict has no stage-3 blob: must skip, not crash -----------------
+git checkout -q -b dd1; git rm -q index.md; git commit -qm "delete ours"
+git checkout -q -b dd2 HEAD~1; git rm -q index.md; git commit -qm "delete theirs"
+git checkout -q dd1; git merge dd2 >/dev/null 2>&1
+_resolve_conflicts_keep_ours "origin/dd2" "$TMP/bk2" 2>/dev/null
+[ -z "$(git diff --name-only --diff-filter=U)" ]
+check $? "DD conflict (no stage 3) resolves without crashing"
+
+printf '\n%s: %d passed, %d failed\n' "sync conflict preserves theirs" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+printf 'PASS — sync-workspace conflict fallback preserves the discarded side\n'

--- a/tests/sync-workspace-conflict-preserves-theirs.test.sh
+++ b/tests/sync-workspace-conflict-preserves-theirs.test.sh
@@ -71,6 +71,49 @@ _resolve_conflicts_keep_ours "origin/dd2" "$TMP/bk2" 2>/dev/null
 [ -z "$(git diff --name-only --diff-filter=U)" ]
 check $? "DD conflict (no stage 3) resolves without crashing"
 
+# --- BLOCKER 1 regression: a backup WRITE FAILURE must be loud and must not
+# --- be summarised as success (john-the-dev #2476). Force it the way the
+# --- reviewer did: make the backup's parent dir a regular FILE.
+WS2="$TMP/ws2"; mkdir -p "$WS2"; cd "$WS2" || exit 1
+git init -q .; git config user.email t@t; git config user.name t
+mkdir -p dir; printf 'base\n' > dir/note.md
+git add dir/note.md; git commit -qm base
+git checkout -q -b peer2
+printf 'base\nPEER-ONLY\n' > dir/note.md; git commit -qam peer
+git checkout -q -; printf 'base\nOURS-ONLY\n' > dir/note.md; git commit -qam ours
+git merge peer2 >/dev/null 2>&1
+BK2="$WS2/backup"
+mkdir -p "$BK2"; : > "$BK2/dir"          # a FILE where mkdir -p needs a dir
+OUT="$(_resolve_conflicts_keep_ours "origin/peer2" "$BK2" 2>&1)"
+
+[ -z "$(git diff --name-only --diff-filter=U)" ]
+check $? "write-failure: merge still concludes (preservation stays non-blocking)"
+grep -q OURS-ONLY dir/note.md; check $? "write-failure: our side still kept"
+printf '%s' "$OUT" | grep -q "could NOT preserve"
+check $? "write-failure: the failing path is named LOUDLY"
+printf '%s' "$OUT" | grep -q "NOT saved"
+check $? "write-failure: summary reports the failure"
+# Match EVERY known phrasing of the total-preservation claim, including the
+# pre-fix one — greping only the new wording passes vacuously against the old
+# code, which is the defect this whole PR is about.
+printf '%s' "$OUT" | grep -qE "each discarded incoming file is preserved|all [0-9]+ discarded incoming file"
+[ $? -ne 0 ]; check $? "write-failure: summary does NOT claim everything was preserved (any wording)"
+
+# --- BLOCKER 2 regression: the DEFAULT backup location is git-private, so no
+# --- vault.sync.include configuration can stage it.
+cd "$WS2" || exit 1
+git checkout -q -b peer3 2>/dev/null; printf 'x\nP3\n' > dir/note.md; git commit -qam p3 >/dev/null 2>&1
+git checkout -q -; printf 'x\nO3\n' > dir/note.md; git commit -qam o3 >/dev/null 2>&1
+git merge peer3 >/dev/null 2>&1
+_resolve_conflicts_keep_ours "origin/peer3" >/dev/null 2>&1     # NO explicit root -> default
+GITDIR="$(git rev-parse --git-dir)"
+[ -d "$GITDIR/sutando-sync-conflicts" ]
+check $? "default backup root lives under the git dir (never trackable)"
+# (Removed a "cannot appear in git status" assertion here: against the pre-fix
+# code it passed for the wrong reason — that default root sat OUTSIDE the repo,
+# so git status was trivially clean. The under-the-git-dir check above is the
+# one that actually discriminates.)
+
 printf '\n%s: %d passed, %d failed\n' "sync conflict preserves theirs" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1
 printf 'PASS — sync-workspace conflict fallback preserves the discarded side\n'


### PR DESCRIPTION
fix(sync-workspace): preserve the incoming side the --ours fallback discards

On an unresolvable merge conflict the pull path keeps the merging host's file
via `git checkout --ours`. That is correct for host-local state and lossy for
anything both hosts append to — and the loss is total and silent: the peer's
version is not written anywhere, and the log names the PEER but never which
files lost their incoming content.

Two real losses on 2026-07-31, both found only by auditing merges against their
incoming parents:

  - merge 64dec1b2 dropped two MEMORY.md index lines (Sutando-Pro appended them
    at fd2c3238, twelve minutes earlier)
  - merge 258c349b dropped a notes/sutando-wire/episode-index.md entry written
    twelve minutes earlier, which then stayed missing for ~2 days

Neither surfaced, and neither was findable the normal way: `git log -- FILE`
and `git log -S` both apply history simplification, which hides merge commits,
so a change destroyed IN a merge is invisible to both. Only diffing the merge
against its incoming parent (or `--full-history`) shows it.

This preserves stage 3 ("theirs") before discarding it, under
state/sync-conflicts/<ts>-<peer>/. state/ is excluded from the sync (0 tracked
files), so a backup can never itself become a conflicting tracked file. The
merge RESULT is byte-identical to before — this only adds a copy and a log
line per discarded file, plus one warning naming the backup directory.

Best-effort throughout: any failure to preserve is ignored so it can never
block a merge, and a DD conflict (both sides deleted) has no stage 3 to save
and is logged as such.

The loop is extracted into `_resolve_conflicts_keep_ours()` so it can be tested
against a real conflicted index. That is deliberate: my first version of the
test re-implemented the loop inline, and **its central assertion passed against
unfixed main** — a test that rebuilds the thing it checks cannot fail. The
committed test loads the real function out of the script (the script ends in an
unguarded dispatch, so it cannot simply be sourced).

Verification:

  new suite at this head        7 passed, 0 failed
  positive control vs main      0 passed, 1 failed — cannot load the function
  bash -n                       clean
  sync-workspace.test.sh        Total: 89 — pass: 89, fail: 0
  init-isolation / uninit-guard / gitignore-untrack   ALL TESTS PASS

Note on the control: it goes red because the function does not exist on main,
not because unchanged code behaves wrongly. There is no pre-fix version of this
function to misbehave — the function IS the fix — so "test cannot run without
the fix" is the honest strongest form here, and it is weaker evidence than a
behavioural red would be.

Related: Sutando-Pro has separately proposed `MEMORY.md merge=union` in a
.gitattributes and routed it to Chi. That changes merge semantics; this does
not, and the two are complementary — union avoids the conflict for one
append-only file, this makes every other discard recoverable.
