### PR TITLE
docs: state the external runtime requirements (README + canonical reference)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,23 @@ Voice agent and conversation server handle conversation-scope actions with **inl
 
 ## Quick start
 
-**Prerequisites:**
+**Prerequisites** — required; `bash src/startup.sh` refuses to boot without these:
 - macOS 15+
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) or [Codex CLI](https://developers.openai.com/codex/cli/) (sign in to the CLI you select)
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) or [Codex CLI](https://developers.openai.com/codex/cli/) — **signed in** to the CLI you select
 - Node.js 22+ (`brew install node`)
-- fswatch (`brew install fswatch`)
-- [Gemini API key](https://ai.google.dev) for voice (optional for text/core-only use)
-- *(optional, for phone calls)* [Twilio account](https://www.twilio.com/) + [ngrok](https://ngrok.com/) — Sutando can answer inbound calls and make outbound calls; you can run the browser + Telegram + Discord paths without them.
-- *(optional, for video/audio)* ffmpeg (`brew install ffmpeg`) — used by subtitle-burn, video-concat, and recording handoff.
+- Python 3 (`brew install python3`) — plus the bridge packages:
+  `pip3 install google-genai discord.py python-telegram-bot slack_bolt Pillow`
+- fswatch (`brew install fswatch`) and tmux (`brew install tmux`) — both auto-install via Homebrew on first start
+
+**Optional** — each unlocks one feature; absent means only that feature is unavailable:
+- [Gemini API key](https://ai.google.dev) — voice (text/core paths work without it)
+- ffmpeg (`brew install ffmpeg`) — subtitle-burn, video-concat, recording handoff
+- git — vault sync, self-upgrade, commit provenance
+- [Twilio account](https://www.twilio.com/) + [ngrok](https://ngrok.com/) — phone calls and SMS; the browser, Telegram and Discord paths run without them
+
+Full list, including what to vendor when embedding Sutando in another
+application: **[External runtime dependencies](docs/runtime-dependencies.md)**.
+Check a host with `bash src/verify-setup.sh`.
 
 ```bash
 # Clone

--- a/README.md
+++ b/README.md
@@ -127,14 +127,17 @@ Voice agent and conversation server handle conversation-scope actions with **inl
 
 ## Quick start
 
-**Prerequisites** — `bash src/startup.sh` refuses to boot without these:
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) or [Codex CLI](https://developers.openai.com/codex/cli/) — **signed in** to the CLI you select
+**Prerequisites** — `bash src/startup.sh` checks that these are **installed** and refuses to boot otherwise:
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) or [Codex CLI](https://developers.openai.com/codex/cli/) — whichever you select
 - Node.js (`brew install node`)
 - Python 3 (`brew install python3`)
 - fswatch (`brew install fswatch`) — auto-installs via Homebrew on first start
 
-**Also expected, but not checked at boot** — a host can pass the checks above and still fail at runtime:
-- macOS 15+, Node.js 22+ — `bash src/verify-setup.sh` checks the Node version and whether your CLI is actually authenticated
+**Also required, but *not* checked at boot** — startup tests only that a command exists, so a host can pass every check above and still fail once running:
+- **Sign in to your agent CLI.** An unauthenticated CLI passes the presence check and then fails when the core starts.
+- macOS 15+, Node.js 22+.
+
+`bash src/verify-setup.sh` covers this second list — it checks the Node version and whether your CLI is actually authenticated. Run it if startup succeeds but the core doesn't.
 
 **Optional** — each unlocks one feature and degrades alone:
 - [Gemini API key](https://ai.google.dev) — voice (text/core paths work without it)

--- a/README.md
+++ b/README.md
@@ -127,23 +127,24 @@ Voice agent and conversation server handle conversation-scope actions with **inl
 
 ## Quick start
 
-**Prerequisites** — required; `bash src/startup.sh` refuses to boot without these:
-- macOS 15+
+**Prerequisites** — `bash src/startup.sh` refuses to boot without these:
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) or [Codex CLI](https://developers.openai.com/codex/cli/) — **signed in** to the CLI you select
-- Node.js 22+ (`brew install node`)
-- Python 3 (`brew install python3`) — plus the bridge packages:
-  `pip3 install google-genai discord.py python-telegram-bot slack_bolt Pillow`
-- fswatch (`brew install fswatch`) and tmux (`brew install tmux`) — both auto-install via Homebrew on first start
+- Node.js (`brew install node`)
+- Python 3 (`brew install python3`)
+- fswatch (`brew install fswatch`) — auto-installs via Homebrew on first start
 
-**Optional** — each unlocks one feature; absent means only that feature is unavailable:
+**Also expected, but not checked at boot** — a host can pass the checks above and still fail at runtime:
+- macOS 15+, Node.js 22+ — `bash src/verify-setup.sh` checks the Node version and whether your CLI is actually authenticated
+
+**Optional** — each unlocks one feature and degrades alone:
 - [Gemini API key](https://ai.google.dev) — voice (text/core paths work without it)
+- `pip3 install discord.py` / `slack_bolt` — Discord / Slack bridges (Telegram needs no package)
 - ffmpeg (`brew install ffmpeg`) — subtitle-burn, video-concat, recording handoff
+- tmux (`brew install tmux`) — Sutando.app watcher auto-restart; the core starts without it
 - git — vault sync, self-upgrade, commit provenance
-- [Twilio account](https://www.twilio.com/) + [ngrok](https://ngrok.com/) — phone calls and SMS; the browser, Telegram and Discord paths run without them
+- [Twilio account](https://www.twilio.com/) + [ngrok](https://ngrok.com/) — phone calls and SMS
 
-Full list, including what to vendor when embedding Sutando in another
-application: **[External runtime dependencies](docs/runtime-dependencies.md)**.
-Check a host with `bash src/verify-setup.sh`.
+Full list with the line enforcing each, plus what to vendor when embedding Sutando in another application: **[External runtime dependencies](docs/runtime-dependencies.md)**.
 
 ```bash
 # Clone

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ Machine-readable ownership and lifecycle metadata lives in
   resolver APIs.
 - [Run Codex as the core](codex-core.md) — core selection, setup, and rollback.
 - [Use built-in tools](built-in-tools.md) — authoritative capability catalog.
+- [External runtime dependencies](runtime-dependencies.md) — what must be
+  installed, what only a feature needs, and what to vendor when embedding.
 
 ## Guides and examples
 

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -1,6 +1,13 @@
 {
   "schema_version": 1,
   "documents": {
+    "docs/runtime-dependencies.md": {
+      "title": "External runtime dependencies",
+      "audience": ["users", "operators", "contributors", "maintainers"],
+      "status": "canonical",
+      "canonical_for": "external tool and package requirements, and what to vendor when embedding Sutando",
+      "last_verified": "2026-08-01"
+    },
     "docs/README.md": {
       "title": "Sutando documentation",
       "audience": ["users", "operators", "contributors", "maintainers"],

--- a/docs/runtime-dependencies.md
+++ b/docs/runtime-dependencies.md
@@ -1,0 +1,122 @@
+# External runtime dependencies
+
+What Sutando needs installed on the host, what it only needs for particular
+features, and what it never needs because macOS already ships it.
+
+Two audiences: someone setting up a checkout (see [Quick start](../README.md#quick-start)
+first — this page is the complete list behind it), and anyone **embedding
+Sutando in another application**, who needs to know exactly what to vendor.
+
+Verify a host with:
+
+```bash
+bash src/verify-setup.sh      # per-dependency pass/fail
+python3 src/health-check.py   # service-level health once running
+```
+
+## Required — the core will not start without these
+
+`src/startup.sh` refuses to boot and prints `✗ …` for each of these.
+
+| Dependency | Install | Enforced at |
+|---|---|---|
+| macOS 15+ | — | — |
+| Node.js 22+ | `brew install node` | `src/startup.sh:478` |
+| `npx` | ships with Node | `src/startup.sh:479` |
+| `python3` | `brew install python3` | `src/startup.sh:481` |
+| `claude` **or** `codex` CLI | [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) / [Codex CLI](https://developers.openai.com/codex/cli/) — whichever `core.runtime` names, **signed in** | `src/startup.sh:483` |
+| `fswatch` | `brew install fswatch` (startup auto-installs when Homebrew is present) | `src/startup.sh:497` |
+| `tmux` | `brew install tmux` (auto-installed by `start-cli.sh:597`) | not in the startup check, but the core runs inside a tmux session and Sutando.app's watcher-auto-restart depends on it |
+
+The agent CLI is the one dependency that cannot be worked around: **Sutando is a
+harness around Claude Code or Codex.** It must be installed *and authenticated* —
+`verify-setup.sh` checks authentication separately from presence, because an
+unauthenticated CLI passes a `command -v` test and then fails at runtime.
+
+### Python packages
+
+A bare interpreter is not enough — the bridges import third-party packages and
+exit without them.
+
+```bash
+pip3 install google-genai discord.py python-telegram-bot slack_bolt Pillow
+```
+
+Also imported by parts of the tree: `anthropic`, `aiohttp`, `python-dotenv`.
+`detect-secrets` is a **test-only** dependency (the vault soft-imports it and
+degrades when absent), so it is not needed at runtime.
+
+If you vendor an interpreter, these must be installed **into that interpreter**.
+A vendored python with an empty `site-packages` starts nothing.
+
+## Required per feature — absent means that feature degrades
+
+None of these block startup. Each one's absence disables its own surface and
+nothing else.
+
+| Dependency | Unlocks | Without it |
+|---|---|---|
+| `ffmpeg` / `ffprobe` | recording, subtitle burn, video concat | recording features unavailable |
+| `git` | vault sync (`sync-workspace.sh`), self-upgrade, commit provenance in dashboard/activity | those features unavailable; everything else runs |
+| `gh` | agent-authored PR workflows | PR flows unavailable |
+| `tesseract` | OCR on screen captures | OCR unavailable |
+| `ngrok` / `tailscale` | inbound phone calls, remote access | local-only |
+| Swift toolchain (Xcode CLT) | **building** `Sutando.app` from source | not needed if a prebuilt binary ships |
+| Gemini API key | voice | text/core paths still work |
+| Twilio account | phone calls, SMS | browser + Telegram + Discord paths still work |
+
+### A note on the Xcode Command Line Tools
+
+On macOS, `/usr/bin/{git,python3,swift,swiftc,clang,cc,gcc,make,…}` are **one
+inode hardlinked 78 ways** — the CLT *stub*, not those tools. The file exists
+whether or not the tools are installed; invoking it without them raises a modal
+"install command line developer tools" dialog and returns nothing.
+
+Two consequences worth knowing when packaging:
+
+- **Existence is not a usable probe.** `command -v`, `test -x`,
+  `shutil.which` and `FileManager.fileExists` all succeed against the stub.
+  `xcode-select -p` is the only check that does not prompt.
+- **Sutando does not require the CLT.** Interpreter and git lookup go through
+  `src/git_binary.py`, `src/python-binary.ts` and `SutandoConfig.resolvePython`,
+  which prefer a real install and degrade rather than prompt. See `REVIEW.md`
+  lesson 7 before adding a call to any of those tools.
+
+## Not required — macOS ships these
+
+Nothing to install: `osascript`, `open`, `pgrep`, `lsof`, `ps`, `sips`,
+`launchctl`, `security`, `screencapture`, `pbcopy`, `pbpaste`, `say`, `which`.
+
+## Embedding Sutando in another application
+
+`scripts/build-bundle.mjs` compiles the TypeScript entrypoints to `dist/*.js`
+(esbuild, ESM, `platform: 'node'`) with only `bufferutil` and `utf-8-validate`
+left external. **It vendors no runtimes** — no node, no python, no ffmpeg, no
+git. A host application that embeds Sutando is responsible for providing them.
+
+To make an embedded install self-contained, vendor:
+
+| Vendor | Notes |
+|---|---|
+| Node.js | the `dist/*.js` bundles need a node to run |
+| `python3` **+ the packages above** | the interpreter alone is not sufficient |
+| `fswatch` | file watcher |
+| `tmux` | core session and watcher-auto-restart |
+| `ffmpeg` / `ffprobe` | only if recording features are wanted |
+
+Two conventions the code already follows, so a vendored layout is picked up
+with no further change:
+
+- **Python** — place it at `<engine>/../runtime/python/bin/python3`, or export
+  `$SUTANDO_PY` pointing at it. Both are checked ahead of anything on PATH by
+  `scripts/sutando-config.sh`, `src/agent/claude/cli/start-cli.sh`,
+  `src/python-binary.ts` and `SutandoConfig.resolvePython`.
+- **ffmpeg** — placed beside the running node binary is found by
+  `src/recording-tools.ts`.
+
+`git` is **deliberately not vendored**. Development use runs from a checkout
+where git already exists; an embedded install degrades on the git-backed
+features listed above rather than shipping and maintaining a git distribution.
+
+The agent CLI still has to be installed and authenticated by the host
+application — it is not something that can be vendored transparently.

--- a/docs/runtime-dependencies.md
+++ b/docs/runtime-dependencies.md
@@ -1,122 +1,138 @@
 # External runtime dependencies
 
-What Sutando needs installed on the host, what it only needs for particular
-features, and what it never needs because macOS already ships it.
+What Sutando needs installed on the host, what only a particular feature needs,
+and what to vendor when embedding Sutando in another application.
 
-Two audiences: someone setting up a checkout (see [Quick start](../README.md#quick-start)
-first — this page is the complete list behind it), and anyone **embedding
-Sutando in another application**, who needs to know exactly what to vendor.
-
-Verify a host with:
+Every claim below is tied to the line that enforces it, so the list can be
+checked rather than trusted. Verify a host with:
 
 ```bash
-bash src/verify-setup.sh      # per-dependency pass/fail
+bash src/verify-setup.sh      # per-dependency pass/fail, including CLI auth
 python3 src/health-check.py   # service-level health once running
 ```
 
-## Required — the core will not start without these
+## Required to boot
 
-`src/startup.sh` refuses to boot and prints `✗ …` for each of these.
+`src/startup.sh` sets `missing=1` and refuses to start for exactly these:
 
 | Dependency | Install | Enforced at |
 |---|---|---|
-| macOS 15+ | — | — |
-| Node.js 22+ | `brew install node` | `src/startup.sh:478` |
+| `node` | `brew install node` | `src/startup.sh:478` |
 | `npx` | ships with Node | `src/startup.sh:479` |
 | `python3` | `brew install python3` | `src/startup.sh:481` |
-| `claude` **or** `codex` CLI | [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) / [Codex CLI](https://developers.openai.com/codex/cli/) — whichever `core.runtime` names, **signed in** | `src/startup.sh:483` |
-| `fswatch` | `brew install fswatch` (startup auto-installs when Homebrew is present) | `src/startup.sh:497` |
-| `tmux` | `brew install tmux` (auto-installed by `start-cli.sh:597`) | not in the startup check, but the core runs inside a tmux session and Sutando.app's watcher-auto-restart depends on it |
+| `claude` **or** `codex` CLI | whichever `core.runtime` names | `src/startup.sh:483-485` |
+| `fswatch` | `brew install fswatch` (startup auto-installs when Homebrew is present) | `src/startup.sh:494,497` |
 
-The agent CLI is the one dependency that cannot be worked around: **Sutando is a
-harness around Claude Code or Codex.** It must be installed *and authenticated* —
-`verify-setup.sh` checks authentication separately from presence, because an
-unauthenticated CLI passes a `command -v` test and then fails at runtime.
+That is the whole hard gate. Nothing else stops a boot.
 
-### Python packages
+### Strongly recommended, but not enforced at boot
 
-A bare interpreter is not enough — the bridges import third-party packages and
-exit without them.
+`startup.sh` checks only that these commands *exist*. It does not check versions
+or authentication, so a host can pass the boot gate and still fail at runtime:
 
-```bash
-pip3 install google-genai discord.py python-telegram-bot slack_bolt Pillow
-```
+- **macOS 15+** — not checked anywhere.
+- **Node.js 22+** — checked by `src/verify-setup.sh:22-26`, which is advisory.
+- **A signed-in agent CLI.** `startup.sh` only tests presence; an
+  unauthenticated CLI passes `command -v` and then fails when the core starts.
+  `src/verify-setup.sh:36` checks authentication separately — run it.
 
-Also imported by parts of the tree: `anthropic`, `aiohttp`, `python-dotenv`.
-`detect-secrets` is a **test-only** dependency (the vault soft-imports it and
-degrades when absent), so it is not needed at runtime.
+The agent CLI is the one dependency nothing can work around: **Sutando is a
+harness around Claude Code or Codex.**
 
-If you vendor an interpreter, these must be installed **into that interpreter**.
-A vendored python with an empty `site-packages` starts nothing.
-
-## Required per feature — absent means that feature degrades
+## Required per feature
 
 None of these block startup. Each one's absence disables its own surface and
 nothing else.
 
-| Dependency | Unlocks | Without it |
+| Feature | Needs | Without it |
 |---|---|---|
-| `ffmpeg` / `ffprobe` | recording, subtitle burn, video concat | recording features unavailable |
-| `git` | vault sync (`sync-workspace.sh`), self-upgrade, commit provenance in dashboard/activity | those features unavailable; everything else runs |
-| `gh` | agent-authored PR workflows | PR flows unavailable |
-| `tesseract` | OCR on screen captures | OCR unavailable |
-| `ngrok` / `tailscale` | inbound phone calls, remote access | local-only |
-| Swift toolchain (Xcode CLT) | **building** `Sutando.app` from source | not needed if a prebuilt binary ships |
-| Gemini API key | voice | text/core paths still work |
-| Twilio account | phone calls, SMS | browser + Telegram + Discord paths still work |
+| Discord bridge | `pip3 install discord.py` | bridge skipped (gated on the token *and* the import) |
+| Slack bridge | `pip3 install slack_bolt` | bridge skipped |
+| Telegram bridge | — *(standard library only)* | — |
+| Image generation | `pip3 install google-genai Pillow` | `skills/image-generation` unavailable |
+| Voice | Gemini API key | text/core paths still work (`src/startup.sh:755`) |
+| Phone calls, SMS | Twilio account + ngrok | browser, Telegram and Discord paths still work |
+| Recording, subtitle burn, video concat | `ffmpeg` / `ffprobe` | those features unavailable |
+| Vault sync, self-upgrade, commit provenance | `git` | those features unavailable; everything else runs |
+| Agent-authored PR workflows | `gh` | unavailable |
+| OCR on screen captures | `tesseract` | unavailable |
+| Sutando.app watcher auto-restart | `tmux` | **core still starts** — `src/agent/claude/cli/start-cli.sh:613` falls back to a bare `exec claude`; only the auto-restart is lost |
+| Building `Sutando.app` from source | Xcode Command Line Tools | not needed if a prebuilt binary ships |
 
-### A note on the Xcode Command Line Tools
+Two entries worth calling out, because both have been overstated before:
 
-On macOS, `/usr/bin/{git,python3,swift,swiftc,clang,cc,gcc,make,…}` are **one
-inode hardlinked 78 ways** — the CLT *stub*, not those tools. The file exists
-whether or not the tools are installed; invoking it without them raises a modal
-"install command line developer tools" dialog and returns nothing.
+- **`tmux` is not a boot requirement.** `start-cli.sh:597` auto-installs it via
+  Homebrew when available, and `:613` falls back cleanly when it is missing.
+- **`python-telegram-bot` is not required.** `src/telegram-bridge.py` imports
+  only the standard library (`urllib.request`). It appears in
+  `src/migrate.sh:308`'s convenience `pip3 install`, but nothing imports it.
 
-Two consequences worth knowing when packaging:
-
-- **Existence is not a usable probe.** `command -v`, `test -x`,
-  `shutil.which` and `FileManager.fileExists` all succeed against the stub.
-  `xcode-select -p` is the only check that does not prompt.
-- **Sutando does not require the CLT.** Interpreter and git lookup go through
-  `src/git_binary.py`, `src/python-binary.ts` and `SutandoConfig.resolvePython`,
-  which prefer a real install and degrade rather than prompt. See `REVIEW.md`
-  lesson 7 before adding a call to any of those tools.
+Install only the packages for the surfaces you actually use. A text/core install
+needs none of them.
 
 ## Not required — macOS ships these
 
 Nothing to install: `osascript`, `open`, `pgrep`, `lsof`, `ps`, `sips`,
 `launchctl`, `security`, `screencapture`, `pbcopy`, `pbpaste`, `say`, `which`.
 
+## A note on the Xcode Command Line Tools
+
+On macOS `/usr/bin/{git,python3,swift,swiftc,clang,cc,gcc,make,…}` are **one
+inode hardlinked 78 ways** — the CLT *stub*, not those tools
+(`ls -li /usr/bin | awk '$3==78'`). The file exists whether or not the tools are
+installed; invoking it without them raises a modal "install command line
+developer tools" dialog and returns nothing.
+
+Two consequences when packaging, or when adding a call to any of these:
+
+- **Existence is not a usable probe.** `command -v`, `test -x`,
+  `shutil.which` and `FileManager.fileExists` all succeed against the stub.
+  `xcode-select -p` is the only check that reports CLT status without
+  prompting — see `src/migrate.sh:122` for the pattern.
+- **The stub cannot be shadowed by an absolute path.** Hardcoding
+  `/usr/bin/git` pins the stub, so a user who installs a real git never wins.
+
+`REVIEW.md` lesson 7 carries the review criterion and the machine check. Note
+its stated limit: the gate matches explicit `/usr/bin/…` tokens only, so a bare
+`git` or `python3` resolved through PATH is invisible to it.
+
+> **Not yet on `main`.** Shared resolvers that prefer a real install and degrade
+> instead of prompting are still under review: `src/git_binary.py` (#2469),
+> `src/python-binary.ts` (#2475), `SutandoConfig.resolvePython` (#2473), and the
+> runtime-descriptor guard in `scripts/sutando-config.sh` (#2478). Until those
+> land, several call sites still invoke the stub directly on a host without
+> developer tools.
+
 ## Embedding Sutando in another application
 
 `scripts/build-bundle.mjs` compiles the TypeScript entrypoints to `dist/*.js`
 (esbuild, ESM, `platform: 'node'`) with only `bufferutil` and `utf-8-validate`
 left external. **It vendors no runtimes** — no node, no python, no ffmpeg, no
-git. A host application that embeds Sutando is responsible for providing them.
+git. A host application that embeds Sutando supplies them.
 
 To make an embedded install self-contained, vendor:
 
 | Vendor | Notes |
 |---|---|
 | Node.js | the `dist/*.js` bundles need a node to run |
-| `python3` **+ the packages above** | the interpreter alone is not sufficient |
+| `python3` **+ the per-feature packages above** | an interpreter with an empty `site-packages` starts nothing |
 | `fswatch` | file watcher |
-| `tmux` | core session and watcher-auto-restart |
+| `tmux` | optional — buys Sutando.app watcher auto-restart, not core start |
 | `ffmpeg` / `ffprobe` | only if recording features are wanted |
 
 Two conventions the code already follows, so a vendored layout is picked up
-with no further change:
+without further change:
 
 - **Python** — place it at `<engine>/../runtime/python/bin/python3`, or export
-  `$SUTANDO_PY` pointing at it. Both are checked ahead of anything on PATH by
-  `scripts/sutando-config.sh`, `src/agent/claude/cli/start-cli.sh`,
-  `src/python-binary.ts` and `SutandoConfig.resolvePython`.
+  `$SUTANDO_PY`. Both are checked ahead of PATH by
+  `scripts/sutando-config.sh:44` and `src/agent/claude/cli/start-cli.sh:30`.
 - **ffmpeg** — placed beside the running node binary is found by
   `src/recording-tools.ts`.
 
-`git` is **deliberately not vendored**. Development use runs from a checkout
-where git already exists; an embedded install degrades on the git-backed
-features listed above rather than shipping and maintaining a git distribution.
+`git` is **deliberately not vendored** by this repo. Development runs from a
+checkout where git already exists; an embedded install degrades on the
+git-backed features above rather than shipping and maintaining a git
+distribution.
 
 The agent CLI still has to be installed and authenticated by the host
-application — it is not something that can be vendored transparently.
+application — it cannot be vendored transparently.


### PR DESCRIPTION
## What changed, and why?

The Quick start prerequisites were wrong in two directions, and both fail *late* — a user satisfies the stated contract, boots, and then something breaks.

**Too strict.** They listed things as required that are not:

- **`tmux`** — `src/agent/claude/cli/start-cli.sh:613` falls back to a bare `exec claude` when it is missing. Only Sutando.app's watcher auto-restart is lost; the core starts.
- **Five Python packages** — the bridges are gated per-feature on their token *and* their import. A text/core install needs none of them. `python-telegram-bot` is not required **at all**: `src/telegram-bridge.py` imports only the standard library (`urllib.request`), and nothing anywhere imports the package. It appears in `src/migrate.sh:308`'s convenience `pip3` line, which is where I originally took it from.

**Too loose.** They implied `startup.sh` enforces things it does not. It sets `missing=1` for exactly five items — `node`, `npx`, `python3`, the `core.runtime` CLI, `fswatch` — and tests only that each command *exists*. It does not check macOS version, Node version, or **CLI authentication**:

```
src/startup.sh:483   if ! command -v "$core_runtime" > /dev/null 2>&1; then
```

An unauthenticated CLI passes that and fails when the core starts. `src/verify-setup.sh:33-39` is what actually probes authentication.

## What should reviewers look at first?

1. **README's three-way split** — installed-and-checked / required-but-unchecked / optional-per-feature. The middle section is the one that did not exist before and is where sign-in now lives.
2. **`docs/runtime-dependencies.md`** (new, canonical) — every hard requirement cites the line that enforces it, so the list is checkable rather than trusted. The required/optional boundary is the part most worth disagreeing with.
3. **The embedding section** — `scripts/build-bundle.mjs` vendors **no runtimes**. A host application supplies node, python3 + the per-feature packages, and fswatch; `tmux` is listed as optional there too, since it buys watcher auto-restart rather than core start. It documents the two conventions the code already follows — `<engine>/../runtime/python/bin/python3` or `$SUTANDO_PY`, and ffmpeg beside the node binary — so a vendored layout is picked up with no code change.

## What user behavior / bug does this prove?

No code change. It closes a documentation gap that produces a failure *after* the user believes setup is complete — either an unnecessary install, or a boot that succeeds and a core that then dies unauthenticated.

## Feature / documentation consistency

This **is** the documentation change. `docs/catalog.json` gains an entry (`status: canonical`, `last_verified: 2026-08-01`) and `docs/README.md` a "Start here" link, per CONTRIBUTING.

The catalog edit is a 7-line textual insert rather than a JSON round-trip — the file keeps `audience` arrays inline, so re-serialising would have reformatted all 24 existing entries into an unreviewable diff.

## Before / after evidence

```
$ python3 skills/release/scripts/docs_audit.py        # catalog/nav at origin/main
docs-audit: ERROR: docs/README.md: unindexed document: docs/runtime-dependencies.md
docs-audit: ERROR: docs/catalog.json: missing metadata for docs/runtime-dependencies.md
docs-audit: FAIL

$ python3 skills/release/scripts/docs_audit.py        # at HEAD
docs-audit: PASS (25 indexed docs; 28 Markdown files checked)
```

Catalog stays minimal and parses:

```
$ git diff --stat docs/catalog.json
 docs/catalog.json | 7 +++++++
$ python3 -c "import json; print(len(json.load(open('docs/catalog.json'))['documents']))"
25
```

## Tests run

| Command | Result |
|---|---|
| `python3 skills/release/scripts/docs_audit.py` | **PASS** (25 indexed, 28 files) — FAIL at parent |
| `bash scripts/review-checks.sh --diff docs.diff` | `PASS (hardcoded-paths clean)` |
| catalog JSON parse | 25 documents |

Documentation-only, so no unit tests apply. Every claim was derived by reading the enforcing code — `startup.sh`, `start-cli.sh`, `verify-setup.sh`, `migrate.sh`, `build-bundle.mjs`, and the actual import sites of each package — and each hard requirement carries its line so a reviewer can check it directly.

**Not verified:** I did not stand up a host missing each dependency in turn. The required/optional split comes from reading the checks and their fallbacks, not from observing every failure.

## Review history worth knowing

Two rounds of corrections, both mine, both the same root cause — writing from the boot *checks* without reading the fallbacks underneath them:

1. Classified `tmux` and five Python packages as hard requirements; described resolver behaviour (`src/git_binary.py`, `src/python-binary.ts`, `SutandoConfig.resolvePython`) that is **not on `main`**. Fixed: per-feature table, and a marked "not yet on `main`" note naming #2469 / #2473 / #2475 / #2478 so the page is true on the day it lands.
2. README still said startup "refuses to boot without" a **signed-in** CLI while the next section said authentication is not checked. Fixed: hard gate is presence-only; sign-in moved to the unchecked list.

## Hardcoded-path check

No production code touched. The new document mentions `/usr/bin/...` paths in prose while explaining the CLT stub; `.md` files are skipped by the scanner's `SKIP` pattern, and the gate passes over the full diff.

## Stacked PR?

**N/A** — independent, branched from `origin/main`, documentation only. Related in subject to #2469 / #2473 / #2474 / #2475 / #2478, and it links `REVIEW.md` lesson 7, but it has no code dependency and can merge in any order — which is why the resolver behaviour is described as pending rather than current.
