### PR TITLE
docs(proactive-loop): step 0's own template was the anti-pattern it warns about

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -44,7 +44,9 @@ This resolves through `bash scripts/sutando-config.sh workspace`, which reads `s
 
 Each pass, in order:
 
-0. **Signal loop start.** Write `{"status":"running","step":"Starting pass...","ts":DATE_NOW}` to `$WORKSPACE/state/core-status.json` (with `WORKSPACE` resolved as above). The session cwd is the repo, so a bare `core-status.json` lands in `<repo>/` where no reader looks (`health-check.py` and the web UI resolve `<workspace>/state/core-status.json` via `status_read_path`). Update the `step` field as you progress through each step; write `{"status":"idle","ts":DATE_NOW}` when the pass ends.
+0. **Signal loop start.** Write `{"status":"running","step":"<short description of what you are actually doing>","ts":DATE_NOW}` to `$WORKSPACE/state/core-status.json` (with `WORKSPACE` resolved as above). The session cwd is the repo, so a bare `core-status.json` lands in `<repo>/` where no reader looks (`health-check.py` and the web UI resolve `<workspace>/state/core-status.json` via `status_read_path`). Update the `step` field as you progress through each step; write `{"status":"idle","ts":DATE_NOW}` when the pass ends.
+
+   **`step` is an owner-facing live message, not internal telemetry.** With `SUTANDO_PROGRESS_STREAM=1` (ON in the running bridge) the Discord bridge renders it to the owner verbatim as `⏳ <step> (Ns)` while he waits on an owner task, via `progress_stream.format_progress`. A generic placeholder ("Starting pass...", "running") shows up in his DM as noise; when processing an owner task, `step` should say what he is waiting on. Rewrite it on every pivot — a stale `step` actively lies to him. See memory `feedback_rich_core_status_step`. (This template previously read `"Starting pass..."` — the exact string that memory names as the anti-pattern, which is why the mistake kept recurring across compactions: this file is loaded every pass, the memory only when recalled.)
 
 0.5. **Check quota.** Run `python3 $CLAUDE_CONFIG_DIR/skills/quota-tracker/scripts/read-quota.py`. Note remaining % and exact reset time.
    - **Budget per pass** = remaining % / (minutes until reset / 5)


### PR DESCRIPTION
## The problem

`core-status.step` is **not internal telemetry**. With `SUTANDO_PROGRESS_STREAM=1` (on in the running bridge) the Discord bridge renders it to the owner verbatim as `⏳ <step> (Ns)` while he waits on a task, via `progress_stream.format_progress`.

Step 0 told every pass to write:

```json
{"status":"running","step":"Starting pass...","ts":DATE_NOW}
```

`"Starting pass..."` is the exact string that memory `feedback_rich_core_status_step` names as the anti-pattern — it reaches the owner's DM as noise precisely while he's waiting to learn what's happening. **The skill was instructing the behavior the memory exists to prevent.**

## Why it kept recurring

This file is loaded **every pass**. The memory is loaded **only when recalled**. A rule that lives only in memory loses to a template that ships in the prompt — which is why the same correction has had to be made repeatedly across compactions.

## The change

Replaces the placeholder with `"<short description of what you are actually doing>"`, and states at the point of use that `step` is owner-facing, should name what he's waiting on, and must be rewritten on every pivot — because a stale `step` actively misinforms him.

Docs only. 4 changed lines, no code.

## How it surfaced

## Why this needs a PR at all — the fix was already written once, and LOST

`workspace/.claude-sutando/skills/proactive-loop` is a **symlink into `skills/proactive-loop`**, so editing the "workspace copy" edits the tracked repo file directly. That is not a footnote; it is the mechanism this class of fix dies by.

This exact amendment was written on **2026-07-31 through that symlink** and never survived:

```text
git log --full-history -S'<short description of what you are actually doing>'   -> no commit, ever
main:47                                                                        -> still the placeholder
git status                                                                     -> clean
git reflog                                                                     -> a reset right after the 06:17Z ff-pull
```

A workspace-side skill edit lands as an **uncommitted modification to a tracked file** on `main`, invisible unless someone runs `git status`, and the next reset or pull silently discards it. So the change looks done — the running agent even picks it up, because the symlink means the live skill file *is* the edited one — while nothing is committed and the next sync erases it.

**That is why the same anti-pattern recurred after being "fixed": it was never in the repo.** This PR is the first copy that can actually survive. (Corroborated independently by Sutando-Pro, 2026-08-01, who traced the loss on their host.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
