### PR TITLE
fix(health-check): count sibling hub indexes, so the memory-index warn names only real losses

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -932,20 +932,6 @@ def check_memory_index_integrity() -> "dict | None":
     index = MEMORY_DIR / "MEMORY.md"
     index_text = index.read_text(errors="ignore") if index.exists() else ""
 
-    # MEMORY.md is not the only index. Once a corpus outgrows the load budget the
-    # overflow moves to sibling HUB indexes (MEMORY-reference.md, MEMORY-wire.md,
-    # …) that MEMORY.md links to. A hub entry deliberately does not auto-load — it
-    # only has to be findable — so it is not a loss and must not be reported as
-    # one. Discovered by glob, not hardcoded, so a host that adds its own hub gets
-    # the same treatment without editing this probe.
-    index_names = {"MEMORY.md"}
-    hub_text = ""
-    for hub in sorted(MEMORY_DIR.glob("MEMORY*.md")):
-        if hub.name == "MEMORY.md":
-            continue
-        index_names.add(hub.name)
-        hub_text += "\n" + hub.read_text(errors="ignore")
-
     # What the session actually sees: strip what the runtime strips, then keep
     # only the prefix that fits inside 200 lines / 25KB.
     effective_text = _index_effective_text(index_text)
@@ -954,6 +940,30 @@ def check_memory_index_integrity() -> "dict | None":
 
     def _referenced_in(hay: str, name: str) -> bool:
         return name in hay or name[:-3] in hay
+
+    # MEMORY.md is not the only index. Once a corpus outgrows the load budget the
+    # overflow moves to sibling HUB indexes (MEMORY-reference.md, MEMORY-wire.md,
+    # …). A hub entry deliberately does not auto-load — it only has to be findable
+    # — so it is not a loss.
+    #
+    # But a hub is only findable if the LOADED prefix of MEMORY.md links to it.
+    # Trusting every MEMORY*.md glob match instead lets an unlinked file (a stale
+    # copy, a backup, an ordinary memory that happens to match the glob) launder
+    # itself AND every filename it mentions into a false green — inside the one
+    # probe that exists to prevent silent loss. A hub linked only PAST the cut is
+    # equally unreachable, so `loaded_text` is the correct gate, not `index_text`.
+    # (john-the-dev, #2483: an earlier revision of this change trusted the glob
+    # and its test suite explicitly blessed the unlinked case.)
+    #
+    # An untrusted MEMORY*.md is therefore not an index at all: it falls through
+    # to the classification below and is reported like any other unindexed file.
+    index_names = {"MEMORY.md"}
+    hub_text = ""
+    for hub in sorted(MEMORY_DIR.glob("MEMORY*.md")):
+        if hub.name == "MEMORY.md" or not _referenced_in(loaded_text, hub.name):
+            continue
+        index_names.add(hub.name)
+        hub_text += "\n" + hub.read_text(errors="ignore")
 
     # (a) live memory files not referenced anywhere in MEMORY.md → won't load.
     # (c) referenced, but ONLY beyond the load cut → equally won't load. Same

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -917,6 +917,12 @@ def check_memory_index_integrity() -> "dict | None":
     suffix, not the file, so this is measured by asking whether each memory is
     named in the prefix that actually loads.
 
+    Not every absence from MEMORY.md is a loss, though: overflow entries live in
+    sibling HUB indexes (``MEMORY-reference.md``, ``MEMORY-wire.md``, …) which
+    MEMORY.md links to. Those are grep-reachable by design and are counted
+    separately — lumping them in produced a 1010-file warn on this host whose
+    real content was 906, and a warn nobody can read is a warn nobody reads.
+
     Fails only when a memory is demonstrably lost that way; warns for orphaned/
     stranded files and for an index merely approaching the limit. Returns None
     on a clean index or when the memory dir does not exist yet.
@@ -925,6 +931,20 @@ def check_memory_index_integrity() -> "dict | None":
         return None
     index = MEMORY_DIR / "MEMORY.md"
     index_text = index.read_text(errors="ignore") if index.exists() else ""
+
+    # MEMORY.md is not the only index. Once a corpus outgrows the load budget the
+    # overflow moves to sibling HUB indexes (MEMORY-reference.md, MEMORY-wire.md,
+    # …) that MEMORY.md links to. A hub entry deliberately does not auto-load — it
+    # only has to be findable — so it is not a loss and must not be reported as
+    # one. Discovered by glob, not hardcoded, so a host that adds its own hub gets
+    # the same treatment without editing this probe.
+    index_names = {"MEMORY.md"}
+    hub_text = ""
+    for hub in sorted(MEMORY_DIR.glob("MEMORY*.md")):
+        if hub.name == "MEMORY.md":
+            continue
+        index_names.add(hub.name)
+        hub_text += "\n" + hub.read_text(errors="ignore")
 
     # What the session actually sees: strip what the runtime strips, then keep
     # only the prefix that fits inside 200 lines / 25KB.
@@ -941,14 +961,25 @@ def check_memory_index_integrity() -> "dict | None":
     #     prefix that actually loads, not the whole file. Testing the whole file
     #     reported an index entry parked on line 201 as healthy (john-the-dev,
     #     #2449) because the bytes were on disk — just never read.
+    # (d) reachable only from a sibling hub index → by design, NOT a loss. Kept
+    #     separate so the genuinely-lost names stay readable: on this host 104
+    #     by-design entries were mixed into a single 1010-file warn, which is
+    #     unreadable and therefore unread — 8 truly dark memories sat inside it
+    #     for months while the probe "warned" about them on every run.
     unindexed: list[str] = []
     beyond_cut: list[str] = []
+    hub_only: list[str] = []
     for p in sorted(MEMORY_DIR.glob("*.md")):
-        if p.name == "MEMORY.md":
+        if p.name in index_names:  # an index is not a memory it indexes
             continue
         if _referenced_in(loaded_text, p.name):
             continue
-        (beyond_cut if _referenced_in(effective_text, p.name) else unindexed).append(p.name)
+        if _referenced_in(effective_text, p.name):
+            beyond_cut.append(p.name)
+        elif _referenced_in(hub_text, p.name):
+            hub_only.append(p.name)
+        else:
+            unindexed.append(p.name)
 
     # (b) memories stranded in a sibling *-BACKUP tree, absent from the live dir.
     stranded: list[str] = []
@@ -981,9 +1012,15 @@ def check_memory_index_integrity() -> "dict | None":
                 f"content vs the {MEMORY_INDEX_LOAD_BYTES / 1024:.0f}KB / "
                 f"{MEMORY_INDEX_LOAD_LINES}-line session read limit")
 
+    def _hub_note() -> str:
+        return (f"; {len(hub_only)} reachable via a sibling hub index "
+                f"({', '.join(sorted(index_names - {'MEMORY.md'}))}) — by design, not loaded"
+                if hub_only else "")
+
     if not unindexed and not stranded and not beyond_cut and not near_limit:
         return {"name": "memory-index", "status": "ok",
-                "detail": f"all memory files present in the loaded MEMORY.md index ({_size_note()})"}
+                "detail": (f"all memory files reachable from the loaded MEMORY.md index"
+                           f"{_hub_note()} ({_size_note()})")}
     parts = []
     if beyond_cut:
         parts.append(
@@ -1002,8 +1039,10 @@ def check_memory_index_integrity() -> "dict | None":
         )
     if unindexed:
         parts.append(
-            f"{len(unindexed)} memory file(s) not in MEMORY.md (won't load): "
+            f"{len(unindexed)} memory file(s) in NO index — neither MEMORY.md nor any "
+            f"sibling hub — so they never load and cannot be found: "
             + ", ".join(unindexed[:6]) + ("…" if len(unindexed) > 6 else "")
+            + _hub_note()
         )
     if stranded:
         parts.append(

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -324,19 +324,51 @@ with tempfile.TemporaryDirectory() as t:
     check("warn does NOT name the hub entry", r and "hub-entry.md" not in r["detail"], str(r))
     check("warn counts 1 lost, not 2", r and "1 memory file(s) in NO index" in r["detail"], str(r))
 
-# 6c) A hub file MEMORY.md forgot to link is still not a "memory" — otherwise the
-#     probe reports its own index as a lost memory.
+# 6c) FAIL-SAFE: a MEMORY*.md the loaded index does NOT link is not a hub. If it
+#     were trusted, a stale/backup file would launder itself AND everything it
+#     names into a false green — inside the probe whose whole job is catching
+#     silent loss. (john-the-dev, #2483 P1: an earlier revision of this change
+#     trusted the glob, and this very test blessed it.)
 with tempfile.TemporaryDirectory() as t:
     mem = make_tree(Path(t))
     (mem / "MEMORY.md").write_text("# Index\n")          # deliberately does not link the hub
-    (mem / "MEMORY-wire.md").write_text("# WIRE\n- [w](wire-note.md)\n")
-    (mem / "wire-note.md").write_text("x")
+    (mem / "MEMORY-stale.md").write_text("# stale copy\n- [hidden](hidden.md)\n")
+    (mem / "hidden.md").write_text("a real memory, reachable from nowhere that loads")
     hc.MEMORY_DIR = mem
     r = hc.check_memory_index_integrity()
-    # The ok detail DOES name which hub was consulted; what must never happen is
-    # the hub file being counted among the losses.
-    check("unlinked hub file is not reported as a lost memory",
-          r and r["status"] == "ok" and "in NO index" not in r["detail"], str(r))
+    check("unlinked MEMORY*.md cannot launder a dark memory into ok",
+          r and r["status"] == "warn", str(r))
+    check("the laundered memory is still named", r and "hidden.md" in r["detail"], str(r))
+    check("the unlinked file is itself reported", r and "MEMORY-stale.md" in r["detail"], str(r))
+    check("nothing is credited to a hub here",
+          r and "reachable via a sibling hub" not in r["detail"], str(r))
+
+# 6c-2) A hub linked ONLY past the load cut is equally unreachable, so it must not
+#       be trusted either — `loaded_text` is the gate, not the whole file.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    filler = "\n".join(f"- filler line {i}" for i in range(hc.MEMORY_INDEX_LOAD_LINES + 10))
+    (mem / "MEMORY.md").write_text("# Index\n" + filler + "\n- [ref](MEMORY-late.md)\n")
+    (mem / "MEMORY-late.md").write_text("# Lookups\n- [buried](buried.md)\n")
+    (mem / "buried.md").write_text("named only by a hub the session never reaches")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("hub linked only beyond the cut is not trusted",
+          r and "buried.md" in r["detail"], str(r))
+    check("beyond-cut hub credits nothing as reachable",
+          r and "reachable via a sibling hub" not in r["detail"], str(r))
+
+# 6c-3) Control: the SAME shape, but linked inside the loaded prefix → trusted.
+#       Without this, 6c/6c-2 would pass even if hub support were removed entirely.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    (mem / "MEMORY.md").write_text("# Index\n- lookups: [MEMORY-late.md](MEMORY-late.md)\n")
+    (mem / "MEMORY-late.md").write_text("# Lookups\n- [buried](buried.md)\n")
+    (mem / "buried.md").write_text("same file, now reachable")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("linked hub IS trusted (control for 6c/6c-2)",
+          r and r["status"] == "ok" and "1 reachable via a sibling hub" in r["detail"], str(r))
 
 # 6d) Positive control on SCOPE: the #2449 fail path is untouched. A memory whose
 #     only index entry sits past the load cut is still a demonstrated loss, and a

--- a/tests/memory-index-integrity.test.py
+++ b/tests/memory-index-integrity.test.py
@@ -290,6 +290,67 @@ with tempfile.TemporaryDirectory() as t:
     names = [c.get("name") for c in hc.run_all_checks()]
     check("run_all_checks() includes memory-index", "memory-index" in names, str(names))
 
+# 6) Sibling HUB indexes. Overflow entries live in MEMORY-reference.md /
+#    MEMORY-wire.md, which MEMORY.md links to. They are grep-reachable by
+#    design, so they are NOT losses — but counting them as such buried 104
+#    by-design entries inside a 1010-file warn on the live host.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    (mem / "MEMORY.md").write_text(
+        "# Index\n- Lookups live in [MEMORY-reference.md](MEMORY-reference.md)\n")
+    (mem / "MEMORY-reference.md").write_text("# Lookups\n- [Hub entry](hub-entry.md)\n")
+    (mem / "hub-entry.md").write_text("a lookup that is found by grepping the hub")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    # Fails against the pre-change probe, which called this a warn.
+    check("hub-only memory → ok, not a loss", r and r["status"] == "ok", str(r))
+    check("ok detail counts the hub entry", r and "1 reachable via a sibling hub" in r["detail"],
+          str(r))
+    check("hub entry is never listed as lost",
+          r and "in NO index" not in r["detail"] and "won't load" not in r["detail"], str(r))
+
+# 6b) A genuine orphan alongside a hub entry: the orphan is named, the hub entry
+#     is only counted — that separation is the whole point of the change.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    (mem / "MEMORY.md").write_text("# Index\n- [ref](MEMORY-reference.md)\n")
+    (mem / "MEMORY-reference.md").write_text("# Lookups\n- [Hub](hub-entry.md)\n")
+    (mem / "hub-entry.md").write_text("findable")
+    (mem / "truly-dark.md").write_text("in no index at all — this is the real loss")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("orphan alongside hub entry → warn", r and r["status"] == "warn", str(r))
+    check("warn names the truly-dark file", r and "truly-dark.md" in r["detail"], str(r))
+    check("warn does NOT name the hub entry", r and "hub-entry.md" not in r["detail"], str(r))
+    check("warn counts 1 lost, not 2", r and "1 memory file(s) in NO index" in r["detail"], str(r))
+
+# 6c) A hub file MEMORY.md forgot to link is still not a "memory" — otherwise the
+#     probe reports its own index as a lost memory.
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    (mem / "MEMORY.md").write_text("# Index\n")          # deliberately does not link the hub
+    (mem / "MEMORY-wire.md").write_text("# WIRE\n- [w](wire-note.md)\n")
+    (mem / "wire-note.md").write_text("x")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    # The ok detail DOES name which hub was consulted; what must never happen is
+    # the hub file being counted among the losses.
+    check("unlinked hub file is not reported as a lost memory",
+          r and r["status"] == "ok" and "in NO index" not in r["detail"], str(r))
+
+# 6d) Positive control on SCOPE: the #2449 fail path is untouched. A memory whose
+#     only index entry sits past the load cut is still a demonstrated loss, and a
+#     hub must not launder it into "fine".
+with tempfile.TemporaryDirectory() as t:
+    mem = make_tree(Path(t))
+    filler = "\n".join(f"- filler line {i}" for i in range(hc.MEMORY_INDEX_LOAD_LINES + 10))
+    (mem / "MEMORY.md").write_text("# Index\n" + filler + "\n- [Past cut](past-cut.md)\n")
+    (mem / "past-cut.md").write_text("entry exists but is never read")
+    hc.MEMORY_DIR = mem
+    r = hc.check_memory_index_integrity()
+    check("beyond-the-cut entry still FAILS (scope unchanged)",
+          r and r["status"] == "fail", str(r))
+
 print()
 if _failed:
     print(f"FAIL — {_failed} check(s) failed"); sys.exit(1)


### PR DESCRIPTION
## What

`check_memory_index_integrity()` reads `MEMORY.md` and nothing else. But once a memory corpus outgrows MEMORY.md's load budget, the overflow deliberately moves to **sibling hub indexes** (`MEMORY-reference.md`, `MEMORY-wire.md`) that MEMORY.md links to. Those entries are grep-reachable by design and are *not* meant to auto-load.

Counting them as `"won't load"` folded **104 by-design entries into a single 1010-file warn**.

## Why it matters

A warn that lists a thousand filenames is unreadable, so it goes unread. That is not hypothetical: this week I recovered **8 memories that had been written, never indexed, and never loaded** — while this probe had been "warning" about them on every single run for months. The signal was present and structurally unusable.

## Before / after — real corpus (1266 memory files)

Same probe, same memory dir, only the branch differs:

```
BEFORE (origin/main): status=warn
  … 1010 memory file(s) not in MEMORY.md (won't load): conversa…

AFTER  (this branch): status=warn
  … 906 memory file(s) in NO index — neither MEMORY.md nor any sibling hub …
    ; 104 reachable via a sibling hub index (MEMORY-reference.md, MEMORY-wire.md) — by design, not loaded
```

Cross-checked against an independent tier count over the same dir — `256` in MEMORY.md, `104` hub-only, `906` in no index. Two different methods, same numbers.

The 906 is the number worth acting on (624 of them `feedback_*`). The old 1010 was not.

## Change

- Discover indexes by glob (`MEMORY*.md`), not a hardcoded name — a host that adds its own hub gets the same treatment with no edit here.
- Three-way classify what is not in the loaded prefix: **beyond the cut** (unchanged), **hub-reachable** (counted, never named), **in no index** (named — the real loss).
- An index file is no longer treated as a memory it indexes. Previously, a hub file that MEMORY.md failed to link was itself reported as a lost memory.

## Scope

`beyond_cut` — the #2449 fail path — is deliberately untouched, and there is a positive control asserting it still fails.

## Tests

`tests/memory-index-integrity.test.py`, 6 new cases. They are verified to **fail against `origin/main`** — an existence assertion that passes either way proves nothing:

```
=== NEW tests vs OLD probe ===
  FAIL hub-only memory → ok, not a loss
  FAIL ok detail counts the hub entry
  FAIL hub entry is never listed as lost
  FAIL warn does NOT name the hub entry
  FAIL warn counts 1 lost, not 2
  FAIL unlinked hub file is not reported as a lost memory
  ok   beyond-the-cut entry still FAILS (scope unchanged)   <- passes on BOTH, by design
```

Full health-check + memory suite at HEAD: **51 files, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
