### PR TITLE
fix(daily-insight): dev-activity saw 0 commits on a 2-PR day, so it fell back to "you made N notes"

### DIFF
--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -244,6 +244,26 @@ for entry in resolve_core_config_dirs():
 "
     ;;
 
+  stand)
+    # This instance's `Stand:` commit-trailer value, from the per-clone config
+    # key `stand` (sutando.config.local.json). Empty when unset.
+    #
+    # Both fleet instances commit under the owner's GH-mapped email (CLA), so no
+    # git field distinguishes them; the trailer is the only discriminator, and
+    # consumers need it WITHOUT an environment (the scheduled cron exports
+    # nothing — john-the-dev, sutando#2484). Deliberately has NO fallback guess:
+    # an unset key must read as "unknown" so callers decline rather than
+    # attribute a foreign identity. Never infer it from the host name — that is
+    # installation-specific policy and would assign this owner's Stand values on
+    # someone else's machine.
+    "$PY" -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT')
+from src.sutando_config import load_config
+print(str(load_config().get('stand', '') or '').strip(), end='')
+"
+    ;;
+
   host-label)
     # Per-host directory label for hosts/<host>/ paths, mirroring
     # src/util_paths.py:_host_label() for shell callers. Use this instead of the

--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -147,6 +147,32 @@ def _git_author_identity(repo_root):
     return ""
 
 
+def _own_stand_value(env=None):
+    """This instance's `Stand:` trailer value, or "" when it cannot be determined.
+
+    Both Sutando instances commit under the owner's GH-mapped email (required for
+    CLA), so `--author` cannot tell them apart — on 2026-08-01 a local-branch scan
+    on Mini returned 17 `Echo Act IV Mini` commits alongside 16 `Echo Act IV Pro`
+    ones, the latter pulled in only because worktrees had been created at the
+    peer's PR heads. Attributing those to "you shipped N" is the exact misleading
+    personal metric this insight exists to avoid (CR #2257).
+
+    Returns "" if no host label resolves, in which case the caller counts every
+    commit by the author — the pre-existing behaviour, never a wrong attribution
+    dressed up as a right one.
+    """
+    env = os.environ if env is None else env
+    label = (env.get("SUTANDO_STAND") or "").strip()
+    if label:
+        return label
+    host = (env.get("SUTANDO_HOST_LABEL") or "").strip()
+    if "mac-mini" in host.lower() or host.lower().startswith("chis-mac-mini"):
+        return "Echo Act IV Mini"
+    if "macbook" in host.lower():
+        return "Echo Act IV Pro"
+    return ""
+
+
 def analyze_dev_activity(repo_root=SRC_DIR, now=None):
     """Real code output in the last 24h, straight from git.
 
@@ -171,20 +197,29 @@ def analyze_dev_activity(repo_root=SRC_DIR, now=None):
         return None
     try:
         out = subprocess.run(
-            ["git", "-C", str(repo_root), "log", "--since=24 hours ago",
-             f"--author={author}", "--pretty=format:C:%H", "--name-only"],
+            ["git", "-C", str(repo_root), "log", "--branches", "--since=24 hours ago",
+             f"--author={author}",
+             "--pretty=format:C:%H\x1f%(trailers:key=Stand,valueonly)", "--name-only"],
             capture_output=True, text=True, timeout=10,
         )
     except (OSError, subprocess.SubprocessError):
         return None
     if out.returncode != 0:
         return None
+    stand = _own_stand_value()
     commits = 0
     dirs = Counter()
+    counting = False
     for line in out.stdout.splitlines():
         if line.startswith("C:"):
-            commits += 1
-        elif line.strip() and "/" in line:
+            # "C:<sha>\x1f<Stand trailer value>" — the trailer is the ONLY thing
+            # that separates this instance from its peer, because both commit
+            # under the owner's GH-mapped email (see _own_stand_value).
+            trailer = line.split("\x1f", 1)[1].strip() if "\x1f" in line else ""
+            counting = (not stand) or (trailer == stand)
+            if counting:
+                commits += 1
+        elif counting and line.strip() and "/" in line:
             dirs[line.split("/", 1)[0]] += 1
     if commits == 0:
         return None

--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -174,8 +174,17 @@ def _own_stand_value(env=None, repo_root=None):
     explicit = (env.get("SUTANDO_STAND") or "").strip()
     if explicit:
         return explicit
-    root = Path(repo_root) if repo_root else SRC_DIR
-    script = root / "scripts" / "sutando-config.sh"
+    inside_repo = Path(repo_root) if repo_root else SRC_DIR
+    try:
+        top = subprocess.run(
+            ["git", "-C", str(inside_repo), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if top.returncode != 0 or not top.stdout.strip():
+        return ""
+    script = Path(top.stdout.strip()) / "scripts" / "sutando-config.sh"
     if not script.is_file():
         return ""
     try:
@@ -250,7 +259,7 @@ def analyze_dev_activity(repo_root=SRC_DIR, now=None):
         return None
     if commits == 0:
         return None
-    return {"commits_24h": commits, "top_dirs": dirs.most_common(3)}
+    return {"commits_24h": commits, "top_dirs": dirs.most_common(3), "stand": stand}
 
 
 def dev_activity_insight(dev):
@@ -260,9 +269,11 @@ def dev_activity_insight(dev):
     n = dev["commits_24h"]
     where = ", ".join(f"{d}/" for d, _ in dev["top_dirs"]) or "the codebase"
     plural = "s" if n != 1 else ""
+    stand = (dev.get("stand") or "").strip()
+    subject = f"Sutando's {stand} instance" if stand else "Sutando"
     return (
-        f"You shipped {n} commit{plural} in the last 24h, mostly in {where}. "
-        f"That's the real headline of your day — steady build velocity."
+        f"{subject} shipped {n} commit{plural} in the last 24h, mostly in {where}. "
+        f"That's the real headline — steady build velocity."
     )
 
 

--- a/src/daily-insight.py
+++ b/src/daily-insight.py
@@ -147,30 +147,43 @@ def _git_author_identity(repo_root):
     return ""
 
 
-def _own_stand_value(env=None):
+def _own_stand_value(env=None, repo_root=None):
     """This instance's `Stand:` trailer value, or "" when it cannot be determined.
 
-    Both Sutando instances commit under the owner's GH-mapped email (required for
-    CLA), so `--author` cannot tell them apart — on 2026-08-01 a local-branch scan
-    on Mini returned 17 `Echo Act IV Mini` commits alongside 16 `Echo Act IV Pro`
-    ones, the latter pulled in only because worktrees had been created at the
-    peer's PR heads. Attributing those to "you shipped N" is the exact misleading
-    personal metric this insight exists to avoid (CR #2257).
+    Both Sutando instances commit under the owner's GH-mapped email (CLA requires
+    it), so `--author` cannot separate them — a local-branch scan on one host
+    returned 17 `Echo Act IV Mini` commits beside 16 `Echo Act IV Pro` ones, the
+    peer's present only because worktrees had been created at its PR heads.
 
-    Returns "" if no host label resolves, in which case the caller counts every
-    commit by the author — the pre-existing behaviour, never a wrong attribution
-    dressed up as a right one.
+    Resolution order, all canonical — no host-name guessing:
+      1. ``SUTANDO_STAND`` (explicit override)
+      2. ``bash scripts/sutando-config.sh stand`` — the per-clone config key,
+         which resolves with NO environment and is therefore what the scheduled
+         cron actually sees (john-the-dev, #2484: the activated path exports
+         neither env var, so an env-only reader silently returns "").
+
+    An earlier revision mapped host labels containing ``mac-mini``/``macbook`` to
+    this owner's Stand names. That is installation-specific policy in shared
+    code: on another user's machine it would assign a foreign identity and filter
+    out all of their legitimate commits. Removed.
+
+    Returns "" when nothing resolves — and the CALLER must then decline to report,
+    not count everything (see analyze_dev_activity).
     """
     env = os.environ if env is None else env
-    label = (env.get("SUTANDO_STAND") or "").strip()
-    if label:
-        return label
-    host = (env.get("SUTANDO_HOST_LABEL") or "").strip()
-    if "mac-mini" in host.lower() or host.lower().startswith("chis-mac-mini"):
-        return "Echo Act IV Mini"
-    if "macbook" in host.lower():
-        return "Echo Act IV Pro"
-    return ""
+    explicit = (env.get("SUTANDO_STAND") or "").strip()
+    if explicit:
+        return explicit
+    root = Path(repo_root) if repo_root else SRC_DIR
+    script = root / "scripts" / "sutando-config.sh"
+    if not script.is_file():
+        return ""
+    try:
+        r = subprocess.run(["bash", str(script), "stand"],
+                           capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return r.stdout.strip() if r.returncode == 0 else ""
 
 
 def analyze_dev_activity(repo_root=SRC_DIR, now=None):
@@ -206,21 +219,35 @@ def analyze_dev_activity(repo_root=SRC_DIR, now=None):
         return None
     if out.returncode != 0:
         return None
-    stand = _own_stand_value()
+    stand = _own_stand_value(repo_root=repo_root)
     commits = 0
     dirs = Counter()
     counting = False
+    seen_stands = set()
     for line in out.stdout.splitlines():
         if line.startswith("C:"):
             # "C:<sha>\x1f<Stand trailer value>" — the trailer is the ONLY thing
             # that separates this instance from its peer, because both commit
             # under the owner's GH-mapped email (see _own_stand_value).
             trailer = line.split("\x1f", 1)[1].strip() if "\x1f" in line else ""
+            if trailer:
+                seen_stands.add(trailer)
             counting = (not stand) or (trailer == stand)
             if counting:
                 commits += 1
         elif counting and line.strip() and "/" in line:
             dirs[line.split("/", 1)[0]] += 1
+    if not stand and len(seen_stands) > 1:
+        # No resolvable instance AND the scan spans MORE THAN ONE — we cannot say
+        # which commits are ours, and counting them all would credit the peer's
+        # work as this instance's (john-the-dev, #2484). Decline.
+        #
+        # Deliberately narrower than "decline whenever identity is unknown": that
+        # also silences every single-instance install which has never set the
+        # config key, producing the other failure john named — "reports no work
+        # despite real commits". Ambiguity, not ignorance, is what makes a count
+        # unsafe.
+        return None
     if commits == 0:
         return None
     return {"commits_24h": commits, "top_dirs": dirs.most_common(3)}

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -57,6 +57,7 @@ _KNOWN_TOP_LEVEL_KEYS = {
     "core_config_dirs",
     "vault",
     "migrate",
+    "stand",          # this instance's `Stand:` commit-trailer value
 }
 
 _SUPPORTED_CORE_RUNTIMES = {"claude", "codex"}

--- a/tests/daily-insight-dev-activity.test.py
+++ b/tests/daily-insight-dev-activity.test.py
@@ -149,6 +149,15 @@ class TestInsightPriority(unittest.TestCase):
         self.assertIn("1 commit in the last 24h", insight)
         self.assertNotIn("1 commits", insight)
 
+    def test_agent_output_is_not_attributed_to_owner(self):
+        insight = self.mod.dev_activity_insight({
+            "commits_24h": 2,
+            "top_dirs": [("src", 2)],
+            "stand": "Echo Act IV Mini",
+        })
+        self.assertIn("Sutando's Echo Act IV Mini instance shipped 2 commits", insight)
+        self.assertNotIn("You shipped", insight)
+
 
 if __name__ == "__main__":
     import os

--- a/tests/daily-insight-stand-attribution.test.py
+++ b/tests/daily-insight-stand-attribution.test.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""dev-activity must count THIS instance's commits — not the peer's.
+
+Both Sutando instances commit under the owner's GH-mapped email (CLA requires
+it), so `--author` carries zero information about which bot shipped what. The
+`Stand:` trailer is the only discriminator. Measured on Mini 2026-08-01, a
+local-branch scan returned 17 `Echo Act IV Mini` commits beside 16
+`Echo Act IV Pro` ones — the peer's arrived purely because worktrees had been
+created at their PR heads.
+
+Run: python3 tests/daily-insight-stand-attribution.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location("di", ROOT / "src" / "daily-insight.py")
+di = importlib.util.module_from_spec(_spec)
+sys.modules["di"] = di
+try:
+    _spec.loader.exec_module(di)
+except SystemExit:
+    pass
+
+EMAIL = "4250911+sonichi@users.noreply.github.com"
+
+
+def build_repo(commits) -> Path:
+    """commits = [(filename, stand_or_None), ...] on a NON-default local branch."""
+    d = Path(tempfile.mkdtemp())
+    run = lambda *a: subprocess.run(["git", "-C", str(d), *a], capture_output=True, text=True)
+    subprocess.run(["git", "init", "-q", str(d)], capture_output=True)
+    run("config", "user.email", EMAIL)
+    run("config", "user.name", "Chi Wang")
+    for name, stand in commits:
+        p = d / "src"; p.mkdir(exist_ok=True)
+        (p / name).write_text(name)
+        run("add", "-A")
+        msg = f"feat: {name}" + (f"\n\nStand: {stand}" if stand else "")
+        run("commit", "-q", "-m", msg)
+    return d
+
+
+class TestStandValueResolution(unittest.TestCase):
+    def test_explicit_override_wins(self):
+        self.assertEqual(di._own_stand_value({"SUTANDO_STAND": "Echo Act IV Mini"}),
+                         "Echo Act IV Mini")
+
+    def test_mac_mini_host_maps_to_mini(self):
+        self.assertEqual(di._own_stand_value({"SUTANDO_HOST_LABEL": "Chis-Mac-mini"}),
+                         "Echo Act IV Mini")
+
+    def test_macbook_host_maps_to_pro(self):
+        self.assertEqual(di._own_stand_value({"SUTANDO_HOST_LABEL": "Chis-MacBook-Pro"}),
+                         "Echo Act IV Pro")
+
+    def test_unknown_host_returns_empty_not_a_guess(self):
+        """Empty means 'do not filter' — never attribute on a guess."""
+        self.assertEqual(di._own_stand_value({"SUTANDO_HOST_LABEL": "some-other-box"}), "")
+
+    def test_no_env_returns_empty(self):
+        self.assertEqual(di._own_stand_value({}), "")
+
+
+class TestCountsOnlyOwnCommits(unittest.TestCase):
+    def setUp(self):
+        self.repo = build_repo([
+            ("a.py", "Echo Act IV Mini"),
+            ("b.py", "Echo Act IV Pro"),
+            ("c.py", "Echo Act IV Mini"),
+            ("d.py", None),
+        ])
+
+    def test_filters_to_this_instance(self):
+        import os
+        os.environ["SUTANDO_STAND"] = "Echo Act IV Mini"
+        try:
+            got = di.analyze_dev_activity(self.repo)
+        finally:
+            os.environ.pop("SUTANDO_STAND", None)
+        self.assertIsNotNone(got)
+        self.assertEqual(got["commits_24h"], 2, got)
+
+    def test_peer_only_repo_reports_nothing(self):
+        """The bug this fixes in reverse: never credit the peer's day as yours."""
+        import os
+        repo = build_repo([("x.py", "Echo Act IV Pro"), ("y.py", "Echo Act IV Pro")])
+        os.environ["SUTANDO_STAND"] = "Echo Act IV Mini"
+        try:
+            self.assertIsNone(di.analyze_dev_activity(repo))
+        finally:
+            os.environ.pop("SUTANDO_STAND", None)
+
+    def test_unknown_stand_counts_everything(self):
+        """Control: with no resolvable instance we keep the old behaviour."""
+        import os
+        for k in ("SUTANDO_STAND", "SUTANDO_HOST_LABEL"):
+            os.environ.pop(k, None)
+        os.environ["SUTANDO_HOST_LABEL"] = "some-other-box"
+        try:
+            got = di.analyze_dev_activity(self.repo)
+        finally:
+            os.environ.pop("SUTANDO_HOST_LABEL", None)
+        self.assertEqual(got["commits_24h"], 4, got)
+
+
+class TestSeesWorkOnBranches(unittest.TestCase):
+    def test_counts_commits_not_reachable_from_HEAD(self):
+        """The original defect: `git log` without --branches saw 0 on a 2-PR day."""
+        import os
+        repo = build_repo([("a.py", "Echo Act IV Mini")])
+        subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", "feature"],
+                       capture_output=True)
+        (repo / "src" / "e.py").write_text("e")
+        subprocess.run(["git", "-C", str(repo), "add", "-A"], capture_output=True)
+        subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m",
+                        "feat: on a branch\n\nStand: Echo Act IV Mini"], capture_output=True)
+        subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-"], capture_output=True)
+        os.environ["SUTANDO_STAND"] = "Echo Act IV Mini"
+        try:
+            got = di.analyze_dev_activity(repo)
+        finally:
+            os.environ.pop("SUTANDO_STAND", None)
+        self.assertEqual(got["commits_24h"], 2, "branch commit must be counted")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/daily-insight-stand-attribution.test.py
+++ b/tests/daily-insight-stand-attribution.test.py
@@ -13,6 +13,7 @@ Run: python3 tests/daily-insight-stand-attribution.test.py
 from __future__ import annotations
 
 import importlib.util
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -90,14 +91,11 @@ class TestStandValueResolution(unittest.TestCase):
         subprocess.run(["git", "init", "-q", str(repo)], check=True)
         (repo / "src").mkdir()
         (repo / "scripts").mkdir()
+        shutil.copy2(ROOT / "src" / "sutando_config.py", repo / "src")
+        shutil.copy2(ROOT / "scripts" / "sutando-config.sh", repo / "scripts")
+        (repo / "sutando.config.json").write_text("{}\n")
         (repo / "sutando.config.local.json").write_text(
             '{"stand":"Echo Act IV Mini"}\n'
-        )
-        (repo / "scripts" / "sutando-config.sh").write_text(
-            "#!/bin/bash\n"
-            "ROOT=$(cd \"$(dirname \"$0\")/..\" && pwd)\n"
-            "python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[\"stand\"], end=\"\")' "
-            "\"$ROOT/sutando.config.local.json\"\n"
         )
         self.assertEqual(
             di._own_stand_value({}, repo_root=repo / "src"),

--- a/tests/daily-insight-stand-attribution.test.py
+++ b/tests/daily-insight-stand-attribution.test.py
@@ -69,6 +69,26 @@ class TestStandValueResolution(unittest.TestCase):
         """The REAL cron shape: neither env var exported, no config key."""
         self.assertEqual(di._own_stand_value({}, repo_root=Path(tempfile.mkdtemp())), "")
 
+    def test_config_resolves_when_activated_call_starts_inside_src(self):
+        """The scheduled default passes <repo>/src, not the checkout root."""
+        repo = Path(tempfile.mkdtemp())
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        (repo / "src").mkdir()
+        (repo / "scripts").mkdir()
+        (repo / "sutando.config.local.json").write_text(
+            '{"stand":"Echo Act IV Mini"}\n'
+        )
+        (repo / "scripts" / "sutando-config.sh").write_text(
+            "#!/bin/bash\n"
+            "ROOT=$(cd \"$(dirname \"$0\")/..\" && pwd)\n"
+            "python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[\"stand\"], end=\"\")' "
+            "\"$ROOT/sutando.config.local.json\"\n"
+        )
+        self.assertEqual(
+            di._own_stand_value({}, repo_root=repo / "src"),
+            "Echo Act IV Mini",
+        )
+
 
 class TestUnknownIdentityDeclinesRatherThanMisattributing(unittest.TestCase):
     """The activated-path blocker: "" must mean DECLINE, never count-everything."""

--- a/tests/daily-insight-stand-attribution.test.py
+++ b/tests/daily-insight-stand-attribution.test.py
@@ -18,6 +18,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parent.parent
 _spec = importlib.util.spec_from_file_location("di", ROOT / "src" / "daily-insight.py")
@@ -68,6 +69,20 @@ class TestStandValueResolution(unittest.TestCase):
     def test_no_env_and_no_config_returns_empty(self):
         """The REAL cron shape: neither env var exported, no config key."""
         self.assertEqual(di._own_stand_value({}, repo_root=Path(tempfile.mkdtemp())), "")
+
+    def test_git_root_resolution_failure_returns_empty(self):
+        with patch.object(di.subprocess, "run", side_effect=OSError("git missing")):
+            self.assertEqual(di._own_stand_value({}, repo_root=Path("/tmp/inside")), "")
+
+    def test_config_command_failure_returns_empty(self):
+        repo = Path(tempfile.mkdtemp())
+        (repo / "scripts").mkdir()
+        (repo / "scripts" / "sutando-config.sh").write_text("#!/bin/bash\n")
+        top = subprocess.CompletedProcess(
+            args=["git"], returncode=0, stdout=f"{repo}\n", stderr=""
+        )
+        with patch.object(di.subprocess, "run", side_effect=[top, OSError("bash failed")]):
+            self.assertEqual(di._own_stand_value({}, repo_root=repo), "")
 
     def test_config_resolves_when_activated_call_starts_inside_src(self):
         """The scheduled default passes <repo>/src, not the checkout root."""

--- a/tests/daily-insight-stand-attribution.test.py
+++ b/tests/daily-insight-stand-attribution.test.py
@@ -52,20 +52,34 @@ class TestStandValueResolution(unittest.TestCase):
         self.assertEqual(di._own_stand_value({"SUTANDO_STAND": "Echo Act IV Mini"}),
                          "Echo Act IV Mini")
 
-    def test_mac_mini_host_maps_to_mini(self):
-        self.assertEqual(di._own_stand_value({"SUTANDO_HOST_LABEL": "Chis-Mac-mini"}),
-                         "Echo Act IV Mini")
+    def test_host_label_is_NOT_mapped_to_an_owner_stand(self):
+        """Installation-specific policy must not live in shared code.
 
-    def test_macbook_host_maps_to_pro(self):
-        self.assertEqual(di._own_stand_value({"SUTANDO_HOST_LABEL": "Chis-MacBook-Pro"}),
-                         "Echo Act IV Pro")
+        An earlier revision mapped any label containing `mac-mini`/`macbook` to
+        THIS owner's Stand values — on another user's machine that assigns a
+        foreign identity and filters out all their commits (john-the-dev, #2484).
+        """
+        for label in ("Chis-Mac-mini", "Chis-MacBook-Pro", "Someone-Else-MacBook"):
+            with self.subTest(label=label):
+                got = di._own_stand_value({"SUTANDO_HOST_LABEL": label},
+                                          repo_root=Path(tempfile.mkdtemp()))
+                self.assertEqual(got, "", f"{label} must not resolve a Stand by host name")
 
-    def test_unknown_host_returns_empty_not_a_guess(self):
-        """Empty means 'do not filter' — never attribute on a guess."""
-        self.assertEqual(di._own_stand_value({"SUTANDO_HOST_LABEL": "some-other-box"}), "")
+    def test_no_env_and_no_config_returns_empty(self):
+        """The REAL cron shape: neither env var exported, no config key."""
+        self.assertEqual(di._own_stand_value({}, repo_root=Path(tempfile.mkdtemp())), "")
 
-    def test_no_env_returns_empty(self):
-        self.assertEqual(di._own_stand_value({}), "")
+
+class TestUnknownIdentityDeclinesRatherThanMisattributing(unittest.TestCase):
+    """The activated-path blocker: "" must mean DECLINE, never count-everything."""
+
+    def test_no_stand_returns_None_not_a_count(self):
+        import os
+        repo = build_repo([("a.py", "Echo Act IV Mini"), ("b.py", "Echo Act IV Pro")])
+        for k in ("SUTANDO_STAND", "SUTANDO_HOST_LABEL"):
+            os.environ.pop(k, None)
+        got = di.analyze_dev_activity(repo)
+        self.assertIsNone(got, "unknown identity must decline, not credit the peer")
 
 
 class TestCountsOnlyOwnCommits(unittest.TestCase):
@@ -97,17 +111,12 @@ class TestCountsOnlyOwnCommits(unittest.TestCase):
         finally:
             os.environ.pop("SUTANDO_STAND", None)
 
-    def test_unknown_stand_counts_everything(self):
-        """Control: with no resolvable instance we keep the old behaviour."""
+    def test_unknown_stand_declines(self):
+        """Was 'counts everything' — inverted after #2484: that credited the peer."""
         import os
         for k in ("SUTANDO_STAND", "SUTANDO_HOST_LABEL"):
             os.environ.pop(k, None)
-        os.environ["SUTANDO_HOST_LABEL"] = "some-other-box"
-        try:
-            got = di.analyze_dev_activity(self.repo)
-        finally:
-            os.environ.pop("SUTANDO_HOST_LABEL", None)
-        self.assertEqual(got["commits_24h"], 4, got)
+        self.assertIsNone(di.analyze_dev_activity(self.repo))
 
 
 class TestSeesWorkOnBranches(unittest.TestCase):


### PR DESCRIPTION
## Symptom and parent evidence

`daily-insight.py` produced a 342-note fallback on a day that shipped two PRs because its unscoped `git log` saw only commits reachable from `HEAD`:

```text
parent/main, same checkout, last 24h
HEAD only      0 commits   <- previous production query
--branches    47 commits
--all         60 commits
```

Both Sutando instances use the owner's GH-mapped author identity, so widening to `--branches` alone is unsafe. The 47 branch commits split into 17 `Echo Act IV Mini`, 16 `Echo Act IV Pro`, and untrailed commits; worktrees had brought peer PR heads into the local ref set.

## Fix

- Scan local branches so worktree/PR output is visible.
- Filter by the `Stand:` trailer, the only discriminator between instances sharing the owner author identity.
- Resolve the instance canonically: explicit `SUTANDO_STAND`, then the per-clone `stand` key via `scripts/sutando-config.sh stand`; never infer identity from a hostname.
- Resolve the checkout root with `git -C <inside-repo> rev-parse --show-toplevel`, so the scheduled default call from `<repo>/src` reaches the root config command.
- If no Stand is configured, count a single/no-trailer installation but decline an ambiguous multi-Stand scan rather than credit peer work.
- Render agent output as `Sutando's <Stand> instance shipped ...` (or `Sutando shipped ...`), never `You shipped`.

## Before/after activated evidence

Exact-head positive configured control:

```text
input path:              <configured-checkout>/src
sutando.config.local:    {"stand":"Echo Act IV Mini"}
resolved Stand:          Echo Act IV Mini
mixed repo result:       2 Mini commits (Pro + untrailed work excluded)
peer-only repo result:   None
```

The same helper called from the checkout root and from `<repo>/src` now resolves the same configured instance. A no-config scan spanning Mini and Pro returns `None`; unrelated MacBook/Mac-mini hostnames resolve no identity.

Owner-facing regression:

```text
before: You shipped 2 commits in the last 24h ...
after:  Sutando's Echo Act IV Mini instance shipped 2 commits in the last 24h ...
```

## Verification at current implementation

```text
python3 tests/daily-insight-stand-attribution.test.py  # 11/11 pass
python3 tests/daily-insight-dev-activity.test.py      # 12/12 pass
python3 tests/sutando-config.test.py                  # 40/40 pass
bash tests/sutando-config-runtime.test.sh             # 11/11 pass
python3 -m py_compile ...                             # pass
bash -n scripts/sutando-config.sh                     # pass
git diff --check                                      # pass
git diff origin/main...HEAD | bash scripts/review-checks.sh  # pass
```

The first coverage run exposed only two fail-closed exception branches; `df712e2e` adds discriminating tests for both. `e3da564c` strengthens the configured default-path regression by executing the real canonical config command and loader inside an isolated configured checkout.

## Scope and risk

This changes only the local daily-insight query/config getter and its owner-facing sentence. It does not alter prompts, delivery routing, or external services. Unknown/ambiguous identity fails closed, and rollback is a normal revert.

🤖 Generated with Sutando
