### PR TITLE
docs: python-binary.ts has landed — split the resolver note by status

### DIFF
--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -6,7 +6,7 @@
       "audience": ["users", "operators", "contributors", "maintainers"],
       "status": "canonical",
       "canonical_for": "external tool and package requirements, and what to vendor when embedding Sutando",
-      "last_verified": "2026-08-01"
+      "last_verified": "2026-08-02"
     },
     "docs/README.md": {
       "title": "Sutando documentation",

--- a/docs/runtime-dependencies.md
+++ b/docs/runtime-dependencies.md
@@ -96,12 +96,16 @@ Two consequences when packaging, or when adding a call to any of these:
 its stated limit: the gate matches explicit `/usr/bin/…` tokens only, so a bare
 `git` or `python3` resolved through PATH is invisible to it.
 
-> **Not yet on `main`.** Shared resolvers that prefer a real install and degrade
-> instead of prompting are still under review: `src/git_binary.py` (#2469),
-> `src/python-binary.ts` (#2475), `SutandoConfig.resolvePython` (#2473), and the
-> runtime-descriptor guard in `scripts/sutando-config.sh` (#2478). Until those
-> land, several call sites still invoke the stub directly on a host without
-> developer tools.
+> **Resolver rollout, partially landed.** Shared resolvers prefer a real install
+> and degrade instead of prompting, rather than invoking the stub directly.
+>
+> On `main`: `src/python-binary.ts` (#2475) — used by `skills/zoom/tools.ts` and
+> `src/meeting-tools.ts`.
+>
+> Still under review: `src/git_binary.py` (#2469), `SutandoConfig.resolvePython`
+> (#2473), and the runtime-descriptor guard in `scripts/sutando-config.sh`
+> (#2478). Until those land, the call sites they cover still invoke the stub
+> directly on a host without developer tools.
 
 ## Embedding Sutando in another application
 


### PR DESCRIPTION
## What changed, and why?

#2475 merged, so `docs/runtime-dependencies.md` now carries a claim that is wrong. Its note lists four resolvers as "not yet on `main`" — one of them is.

Verified against current `main`:

```
PRESENT  src/python-binary.ts                (#2475, merged)
ABSENT   src/git_binary.py                   (#2469, open)
ABSENT   SutandoConfig.resolvePython         (#2473, open)
ABSENT   sutando-config.sh runtime guard     (#2478, open)
```

The note now separates landed from pending, and names the call sites the landed resolver covers — `skills/zoom/tools.ts` and `src/meeting-tools.ts` — so a reader can tell *which paths are already safe* rather than reading the set as all-or-nothing. That distinction matters for anyone using this page to decide whether a clean-Mac install will prompt.

## What should reviewers look at first?

The single changed block in `docs/runtime-dependencies.md`. `catalog.json` moves `last_verified` 2026-08-01 → 2026-08-02 and nothing else.

## What user behavior / bug does this prove?

No code change. It stops the canonical setup page from understating what has shipped — a reader following it today would believe the TypeScript call sites still invoke the CLT stub, which they no longer do.

## Feature / documentation consistency

This **is** the documentation change; `docs/runtime-dependencies.md` is the canonical document (per `docs/catalog.json`) and its `last_verified` is bumped. No navigation change, so `docs/README.md` is untouched.

## Before / after evidence

**BEFORE** — on `main`:

```
> **Not yet on `main`.** Shared resolvers … are still under review:
> `src/git_binary.py` (#2469), `src/python-binary.ts` (#2475),
> `SutandoConfig.resolvePython` (#2473), and the runtime-descriptor guard …
```

…while `git show origin/main:src/python-binary.ts` resolves. The claim and the tree disagree.

**AFTER** — at HEAD:

```
> **Resolver rollout, partially landed.** …
>
> On `main`: `src/python-binary.ts` (#2475) — used by `skills/zoom/tools.ts` and
> `src/meeting-tools.ts`.
>
> Still under review: `src/git_binary.py` (#2469), `SutandoConfig.resolvePython`
> (#2473), and the runtime-descriptor guard in `scripts/sutando-config.sh` (#2478).
```

## Tests run

| Command | Result |
|---|---|
| `python3 skills/release/scripts/docs_audit.py` | PASS (25 indexed, 28 files) |
| `bash scripts/review-checks.sh --diff docs.diff` | `PASS (hardcoded-paths clean)` |
| catalog JSON parse | 25 documents, `last_verified: 2026-08-02` |
| `git show origin/main:<each resolver>` | presence table above |

Documentation-only, so no unit tests apply.

## Related — the decay mode this is an instance of

@sonichi flagged when reviewing #2477 that this document has a silent failure mode: it pins claims and line numbers in files it does not modify, so it goes quietly wrong as those files move, *while still advertising checkability*. Here the trigger was visible (a merge I was watching), but that is luck rather than design — nothing would have caught it otherwise.

Their proposed durable fix — a citation check folded into `scripts/review-checks.sh`, asserting each `file:line` in the doc still matches a recorded token — remains worth doing and is deliberately **not** in this PR, which is a content correction. Happy to open it separately if wanted.

## Hardcoded-path check

No production code touched; no path literals added. Gate passes over the diff.

## Stacked PR?

**N/A** — independent, branched from current `origin/main` (which includes #2475 and #2477). It will need one more touch-up when #2469 / #2473 / #2478 land; that is inherent to the note and is exactly what the citation check above would make self-policing.
