### PR TITLE
fix(health-check): gateway-down warned on every host with no gateway configured

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2840,7 +2840,19 @@ def _gateway_configured() -> bool:
                 # class this PR closes. (Caught in review by Sutando-Pro.)
                 for ln in gw_env.read_text(errors="replace").splitlines()
             )
-    except Exception:
+    except OSError:
+        # EXPECTED failures only: the env file is unreadable / the path is bad.
+        # Those genuinely mean "cannot confirm a gateway here" -> unconfigured.
+        #
+        # Deliberately NOT `except Exception`. A resolver contract bug (e.g.
+        # claude_home_path raising ValueError) would be swallowed into False,
+        # check_core_supervisor would then report a real `gateway-down` as OK,
+        # and check_gateway_bridge would vanish -- a CONFIGURED gateway's outage
+        # goes silent. That is the same fail-open direction this PR exists to
+        # close, one layer up. An unexpected exception propagates instead, which
+        # is loud; a programming error in a health probe should not be absorbed
+        # by the probe that is supposed to be reporting faults.
+        # (Caught in review by john-the-dev.)
         pass
     return False
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2833,7 +2833,12 @@ def _gateway_configured() -> bool:
         if gw_env.exists():
             return any(
                 ln.startswith(("REMOTE_TASK_TOKEN=", "AG2_REMOTE_TOKEN="))
-                for ln in gw_env.read_text().splitlines()
+                # errors="replace" is load-bearing, not cosmetic: without it a
+                # single non-UTF-8 byte raises, the except below swallows it, and a
+                # CONFIGURED gateway reads as unconfigured — which now also silences
+                # the gateway-down warn. Fail-open on a decode error is exactly the
+                # class this PR closes. (Caught in review by Sutando-Pro.)
+                for ln in gw_env.read_text(errors="replace").splitlines()
             )
     except Exception:
         pass

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2802,11 +2802,42 @@ def check_core_supervisor() -> dict:
         detail = f"{state} — {str(prompt).splitlines()[0][:60]}"
     needs_user = {"blocked-human", "logged-out"}
     degraded = {"crashed", "hung", "gateway-down"}
+    # `gateway-down` means "core up, relay gateway not running". On a host with no
+    # gateway configured that is the DESIGNED state — startup.sh never launches the
+    # bridge and says so ("deliberately silent when unconfigured"), and the dedicated
+    # probe below returns None for exactly this case. Treating it as degraded here
+    # made every Sutando-only install carry a permanent warn it could not clear,
+    # which is how a status tool teaches its reader to skip the warn line.
+    if state == "gateway-down" and not _gateway_configured():
+        return {"name": name, "status": "ok",
+                "detail": "core up; ag2.space gateway not configured on this host"}
     if state in needs_user:
         return {"name": name, "status": "warn", "detail": f"core needs you: {detail}"}
     if state in degraded:
         return {"name": name, "status": "warn", "detail": f"core degraded: {detail}"}
     return {"name": name, "status": "ok", "detail": detail}
+
+
+def _gateway_configured() -> bool:
+    """Is the ag2.space mobile gateway configured on this host?
+
+    `startup.sh` is deliberately silent when it is not — "a Sutando-only user
+    never sees it" — so absence of the bridge is the EXPECTED state, not a fault.
+    Shared by the two probes that must agree about that; they did not, which is
+    the bug this helper exists to close.
+    """
+    try:
+        if os.environ.get("REMOTE_TASK_TOKEN") or os.environ.get("AG2_REMOTE_TOKEN"):
+            return True
+        gw_env = claude_home_path("channels", "ag2space", ".env")
+        if gw_env.exists():
+            return any(
+                ln.startswith(("REMOTE_TASK_TOKEN=", "AG2_REMOTE_TOKEN="))
+                for ln in gw_env.read_text().splitlines()
+            )
+    except Exception:
+        pass
+    return False
 
 
 def check_gateway_bridge() -> "dict | None":
@@ -2824,16 +2855,7 @@ def check_gateway_bridge() -> "dict | None":
     nothing reported it, so mobile messages stranded in the cloud invisibly. This
     check makes that state visible on the dashboard.
     """
-    try:
-        gw_env = claude_home_path("channels", "ag2space", ".env")
-        configured = bool(os.environ.get("REMOTE_TASK_TOKEN") or os.environ.get("AG2_REMOTE_TOKEN"))
-        if not configured and gw_env.exists():
-            configured = any(
-                ln.startswith(("REMOTE_TASK_TOKEN=", "AG2_REMOTE_TOKEN="))
-                for ln in gw_env.read_text(errors="replace").splitlines()
-            )
-    except OSError:
-        configured = False
+    configured = _gateway_configured()
     if not configured:
         return None
     try:

--- a/tests/health-check-core-supervisor.test.py
+++ b/tests/health-check-core-supervisor.test.py
@@ -67,10 +67,32 @@ class TestCheckCoreSupervisor(unittest.TestCase):
 
     def test_degraded_states_warn(self):
         with tempfile.TemporaryDirectory() as td:
-            for st in ("crashed", "hung", "gateway-down"):
+            for st in ("crashed", "hung"):
                 r = self._run(td, json.dumps({"state": st}))
                 self.assertEqual(r["status"], "warn", st)
                 self.assertIn("degraded", r["detail"])
+
+    def test_gateway_down_warns_WHEN_THE_GATEWAY_IS_CONFIGURED(self):
+        """The half that must keep warning: a configured gateway that is not running
+        really does mean undelivered mobile messages."""
+        with tempfile.TemporaryDirectory() as td:
+            with mock.patch.object(hc, "_gateway_configured", return_value=True):
+                r = self._run(td, json.dumps({"state": "gateway-down"}))
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("degraded", r["detail"])
+
+    def test_gateway_down_is_OK_when_no_gateway_is_configured(self):
+        """A Sutando-only host never launches the bridge — startup.sh is
+        "deliberately silent when unconfigured" — so its absence is the designed
+        state, not a degradation. Warning here gave every such install a permanent
+        warn it could not clear, and check_gateway_bridge() already returns None
+        for exactly this case; the two probes disagreed."""
+        with tempfile.TemporaryDirectory() as td:
+            with mock.patch.object(hc, "_gateway_configured", return_value=False):
+                r = self._run(td, json.dumps({"state": "gateway-down"}))
+        self.assertEqual(r["status"], "ok")
+        self.assertNotIn("degraded", r["detail"])
+        self.assertIn("not configured", r["detail"])
 
     def test_healthy_states_ok(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/health-check-gateway-bridge.test.py
+++ b/tests/health-check-gateway-bridge.test.py
@@ -202,6 +202,12 @@ def main() -> int:
         check("_gateway_configured: token only in a COMMENT → False",
               _configured(gw_env_path=_gw) is False)
 
+        # A non-UTF-8 byte must NOT turn a configured host into an unconfigured
+        # one: that would silence BOTH the bridge probe and the gateway-down warn.
+        _gw.write_bytes(b"REMOTE_TASK_TOKEN=abc\n\xff\xfe not utf-8\n")
+        check("_gateway_configured: token + invalid UTF-8 byte → still True",
+              _configured(gw_env_path=_gw) is True)
+
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1

--- a/tests/health-check-gateway-bridge.test.py
+++ b/tests/health-check-gateway-bridge.test.py
@@ -73,6 +73,23 @@ def _run(*, env=None, gw_env_path=None, pgrep_rc=1, pgrep_out="", pgrep_raises=F
             return hc.check_gateway_bridge()
 
 
+def _configured(*, env=None, gw_env_path=None):
+    """Call _gateway_configured() directly, with env + the channel-.env path pinned.
+
+    It is the single source of truth BOTH probes now consult (check_gateway_bridge
+    here, check_core_supervisor for the gateway-down mapping). The core-supervisor
+    suite mocks it out, so without these cases the logic that decides the whole
+    question would ship untested.
+    """
+    env = env or {}
+    base = {k: v for k, v in hc.os.environ.items()
+            if k not in ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN")}
+    base.update(env)
+    with unittest.mock.patch.dict(hc.os.environ, base, clear=True), \
+         unittest.mock.patch.object(hc, "claude_home_path", return_value=gw_env_path):
+        return hc._gateway_configured()
+
+
 def main() -> int:
     # 1) NOT configured (no env token, channel .env absent) → None
     missing = Path(tempfile.gettempdir()) / "sutando-gw-nonexistent-xyz" / ".env"
@@ -155,10 +172,41 @@ def main() -> int:
     check("_gateway_serving: absent file → None",
           hc._gateway_serving(Path(_tf.mkdtemp()) / "nope.json", now) is None)
 
+    # --- _gateway_configured(): the shared predicate itself -----------------
+    with _tf.TemporaryDirectory() as _td:
+        _gw = Path(_td) / "ag2space" / ".env"
+        _gw.parent.mkdir(parents=True, exist_ok=True)
+        _absent = Path(_td) / "nope" / ".env"
+
+        check("_gateway_configured: REMOTE_TASK_TOKEN in env → True",
+              _configured(env={"REMOTE_TASK_TOKEN": "t"}, gw_env_path=_absent) is True)
+        check("_gateway_configured: AG2_REMOTE_TOKEN in env → True",
+              _configured(env={"AG2_REMOTE_TOKEN": "t"}, gw_env_path=_absent) is True)
+        check("_gateway_configured: no token, no file → False",
+              _configured(gw_env_path=_absent) is False)
+
+        _gw.write_text("REMOTE_TASK_TOKEN=abc\n")
+        check("_gateway_configured: token in the .env file → True",
+              _configured(gw_env_path=_gw) is True)
+
+        _gw.write_text("OTHER=1\n")
+        check("_gateway_configured: file with unrelated keys → False",
+              _configured(gw_env_path=_gw) is False)
+
+        _gw.write_text("")
+        check("_gateway_configured: empty file → False",
+              _configured(gw_env_path=_gw) is False)
+
+        # startswith, not substring: a commented-out token is not configuration.
+        _gw.write_text("#REMOTE_TASK_TOKEN=abc\n")
+        check("_gateway_configured: token only in a COMMENT → False",
+              _configured(gw_env_path=_gw) is False)
+
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1
     print("\nall check_gateway_bridge cases passed")
+
     return 0
 
 

--- a/tests/health-check-gateway-bridge.test.py
+++ b/tests/health-check-gateway-bridge.test.py
@@ -208,6 +208,40 @@ def main() -> int:
         check("_gateway_configured: token + invalid UTF-8 byte → still True",
               _configured(gw_env_path=_gw) is True)
 
+    # --- failure CLASSIFICATION (john-the-dev, review of 2328fbe9) ---------
+    # The catch was `except Exception`, so ANY error became False = "no gateway
+    # configured here". check_core_supervisor then reports a real `gateway-down`
+    # as OK and check_gateway_bridge returns None — a CONFIGURED gateway's outage
+    # goes silent. Fail-open in the one direction this probe must not fail.
+    #
+    # These pin the classification itself, so narrowing cannot be undone quietly.
+    base = {k: v for k, v in hc.os.environ.items()
+            if k not in ("REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN")}
+
+    # 1) UNEXPECTED exception must NOT be classified as unconfigured. The
+    #    reviewer's exact repro: a resolver contract bug.
+    raised = None
+    with unittest.mock.patch.dict(hc.os.environ, base, clear=True), \
+         unittest.mock.patch.object(hc, "claude_home_path",
+                                    side_effect=ValueError("resolver contract bug")):
+        try:
+            got = hc._gateway_configured()
+        except ValueError:
+            raised = True
+        else:
+            raised = False
+    check("_gateway_configured: unexpected exception propagates, is NOT False",
+          raised is True,
+          "a resolver bug was swallowed into 'unconfigured' — that silences a real gateway-down")
+
+    # 2) EXPECTED I/O failure still means unconfigured (the narrowing must not
+    #    break the case the catch legitimately exists for).
+    with unittest.mock.patch.dict(hc.os.environ, base, clear=True), \
+         unittest.mock.patch.object(hc, "claude_home_path",
+                                    side_effect=OSError("unreadable")):
+        check("_gateway_configured: OSError → False (expected I/O failure)",
+              hc._gateway_configured() is False)
+
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         return 1


### PR DESCRIPTION
## What broke

`check_core_supervisor` puts `gateway-down` in `degraded` unconditionally. That state means *"core up, relay gateway not running"* — which on a host with no ag2.space gateway configured is the **designed** state. `startup.sh` never launches the bridge there, and says so in the source:

> Deliberately silent when unconfigured — a Sutando-only user never sees it.

**Two probes in the same file disagreed about it.** `check_gateway_bridge()` already returns `None` when unconfigured, for exactly this reason. `check_core_supervisor` had no such guard — so every Sutando-only install, which is the default OSS case, carries a permanent `core degraded: gateway-down` warn that no user action can clear.

## Observed

On `Chis-Mac-mini`, with nothing configured:

```
channels/ag2space/.env            absent
REMOTE_TASK_TOKEN / AG2_REMOTE_TOKEN   unset
remote-gateway-bridge processes   0
state/gateway-status.json         absent

check_gateway_bridge     -> silent (correct)
check_core_supervisor    -> "core degraded: gateway-down"   <- the bug
```

## Fix

Extract the configured-check into `_gateway_configured()` so the two probes cannot drift apart again, and gate the degraded mapping on it. **Configured-but-down still warns** — that half is real, and undelivered mobile messages are the consequence.

## Before / after, same host, same state file

```
before   core-supervisor  warn  core degraded: gateway-down
after    core-supervisor  ok    core up; ag2.space gateway not configured on this host
```

## Tests

`test_degraded_states_warn` pinned the old contract. I changed it deliberately rather than working around it, and split it so **both** branches stay covered:

```
gateway-down + configured    -> warn   (unchanged, still asserted)
gateway-down + unconfigured  -> ok     (new)
```

Non-vacuity, exercised rather than asserted — with the fix reverted, the new case fails and the configured case still passes:

```
FAIL: test_gateway_down_is_OK_when_no_gateway_is_configured
Ran 9 tests — FAILED (failures=1)
```

All **43** health-check suites pass, not only the two I touched.

## Why it is worth fixing

A status tool whose warn list always contains the same unclearable line trains its reader to skip the warn line — which costs the warns that matter. Same argument the `checkout_behind_warn` default of 10 is documented on.
