### PR TITLE
tidy: centralize optional bridge script execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Be concise and direct. Prefer action over explanation. Default to the smallest a
 - **Skills** (`skills/`) contain feature-specific logic. Each skill is self-contained and optional — core services work without any skill installed. When implementing new capabilities, start as a skill.
 - **Inline tools** are only for tools that need instant response from Gemini. Prefer skill scripts for complex logic. Only promote to inline if the user says the skill approach is too slow.
 - **Skill config goes in the skill's `manifest.json` `config` block — not ad-hoc env vars.** See [`skills/MANIFEST.md`](skills/MANIFEST.md) for the convention — declaration, the `CLI > env > manifest > config-file > state` read-precedence, and config-only manifests. Don't invent an undocumented env var (Chi 2026-06-16).
+- **Optional capability discovery stays at the adapter edge.** Shared runners may standardize provider-neutral execution behavior, but adapters must inject script or capability paths. Core helpers must not name, locate, or import a concrete skill. Add direct contract tests for the runner and wiring tests for every adapter that delegates to it.
 - When refactoring, do NOT change prompts or tool behavior. Prompts are tuned through testing and must be preserved exactly.
 
 ### Where does new code belong? (decision guide — issue #222)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Be concise and direct. Prefer action over explanation. Default to the smallest a
 - **Skills** (`skills/`) contain feature-specific logic. Each skill is self-contained and optional — core services work without any skill installed. When implementing new capabilities, start as a skill.
 - **Inline tools** are only for tools that need instant response from Gemini. Prefer skill scripts for complex logic. Only promote to inline if the user says the skill approach is too slow.
 - **Skill config goes in the skill's `manifest.json` `config` block — not ad-hoc env vars.** See [`skills/MANIFEST.md`](skills/MANIFEST.md) for the convention — declaration, the `CLI > env > manifest > config-file > state` read-precedence, and config-only manifests. Don't invent an undocumented env var (Chi 2026-06-16).
+- **Optional capability discovery stays at the adapter edge.** Shared runners may standardize provider-neutral execution behavior, but adapters must inject script or capability paths. Core helpers must not name, locate, or import a concrete skill. Add direct contract tests for the runner and wiring tests for every adapter that delegates to it.
 - When refactoring, do NOT change prompts or tool behavior. Prompts are tuned through testing and must be preserved exactly.
 
 ### Where does new code belong? (decision guide — issue #222)

--- a/docs/architecture-boundaries.md
+++ b/docs/architecture-boundaries.md
@@ -105,6 +105,14 @@ Disallowed:
 Shared behavior needed by multiple adapters belongs in core only when it is
 provider-neutral. Otherwise it belongs in an adapter library.
 
+### Optional adapter capabilities
+
+Optional capability discovery also remains at the adapter edge. A generic
+core helper may run an injected script path and standardize timeout/failure
+semantics, but it must not name, locate, or import a concrete skill. This keeps
+the dependency direction adapter → helper while preserving the rule that core
+does not depend on installed skills.
+
 ## Current repository classification
 
 This is the ownership intent for today's paths. Several rows contain known

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-181 modules indexed.
+182 modules indexed.
 
 ## `src/`
 
@@ -70,6 +70,7 @@ and re-run `python3 scripts/gen-src-map.py`.
 - **`morning-briefing.py`** — Morning briefing for Sutando.
 - **`notify.sh`** — Sutando: notify the user across available channels
 - **`obsidian-mirror.py`** — Obsidian sync — one-shot sweep of agent state into the Sutando vault.
+- **`optional_script.py`** — Dependency-light runner for optional script-backed capabilities.
 - **`outbox_log.py`** — Outbox visibility log — single append-only sink for outbound messages.
 - **`overlay-manager-ui.ts`** — Overlay Manager view for the Sutando web UI.
 - **`personal-claude-compact-hint.sh`** — SessionStart(compact) hook — re-inject PERSONAL_CLAUDE.md after context compaction.

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -75,6 +75,7 @@ from single_instance import acquire as _single_instance_acquire  # noqa: E402
 import discord_config  # noqa: E402  — Sutando workspace-local discord config (#1147)
 from util_paths import channel_access_path, claude_home_path, personal_path, shared_personal_path, write_private_text  # noqa: E402
 from task_priority import default_priority_for_source  # noqa: E402
+from optional_script import run_optional_script as _run_optional_script_shared  # noqa: E402
 
 # Observability: emit channel.discord.<in|out> into the local obs spine
 # (src/observability). Guarded so a missing module never crashes the bridge.
@@ -428,20 +429,16 @@ def _transcribe_via_skill(local_path: str) -> str | None:
     Optional — if the skill is absent the caller falls back to [File attached:].
     Errors are swallowed; transcription failure must never block task delivery.
     """
-    import subprocess
     skill_script = Path(__file__).parent.parent / "skills" / "audio-transcribe" / "scripts" / "transcribe.py"
-    if not skill_script.exists():
-        return None
-    try:
-        result = subprocess.run(
-            [sys.executable, str(skill_script), local_path],
-            capture_output=True, text=True, timeout=25,
-        )
-        if result.returncode == 0:
-            return result.stdout.strip() or None
-    except Exception as e:
-        print(f"  [stt] skill call failed for {os.path.basename(local_path)}: {e}", flush=True)
-    return None
+    return _run_optional_script_shared(
+        skill_script,
+        [local_path],
+        timeout=25,
+        on_error=lambda exc: print(
+            f"  [stt] skill call failed for {os.path.basename(local_path)}: {exc}",
+            flush=True,
+        ),
+    )
 
 
 def _safe_attachment_basename(filename: str) -> str:

--- a/src/optional_script.py
+++ b/src/optional_script.py
@@ -1,0 +1,46 @@
+"""Dependency-light runner for optional script-backed capabilities.
+
+Callers own capability discovery and inject the script path. This module only
+standardizes the fail-open subprocess contract, so core infrastructure does not
+need to know which skills or adapter features are installed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+
+ErrorHandler = Callable[[Exception], None]
+
+
+def run_optional_script(
+    script_path: Path,
+    args: Sequence[str],
+    *,
+    timeout: float,
+    on_error: Optional[ErrorHandler] = None,
+) -> Optional[str]:
+    """Run an installed script and return non-empty stdout on success.
+
+    A missing script, non-zero exit, empty stdout, or execution failure returns
+    ``None``. The caller may log execution failures through ``on_error``;
+    missing and ordinary non-zero outcomes remain silent.
+    """
+    if not script_path.exists():
+        return None
+    try:
+        result = subprocess.run(
+            [sys.executable, str(script_path), *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip() or None
+    except Exception as exc:
+        if on_error is not None:
+            on_error(exc)
+    return None

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -60,6 +60,7 @@ sys.stderr.reconfigure(line_buffering=True)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from task_priority import default_priority_for_source  # noqa: E402
+from optional_script import run_optional_script as _run_optional_script_shared  # noqa: E402
 
 # Observability: emit channel.slack.<in|out> into the local obs spine
 # (src/observability). Guarded so a missing module never crashes the bridge.
@@ -667,20 +668,16 @@ def _transcribe_via_skill(local_path: str) -> str | None:
     [File attached:] line unchanged. Any error from the subprocess is swallowed;
     transcription failure must never block task delivery.
     """
-    import subprocess
     skill_script = Path(os.path.realpath(__file__)).parent.parent / "skills" / "audio-transcribe" / "scripts" / "transcribe.py"
-    if not skill_script.exists():
-        return None
-    try:
-        result = subprocess.run(
-            [sys.executable, str(skill_script), local_path],
-            capture_output=True, text=True, timeout=25,
-        )
-        if result.returncode == 0:
-            return result.stdout.strip() or None
-    except Exception as e:
-        print(f"  [stt] skill call failed for {os.path.basename(local_path)}: {e}", flush=True)
-    return None
+    return _run_optional_script_shared(
+        skill_script,
+        [local_path],
+        timeout=25,
+        on_error=lambda exc: print(
+            f"  [stt] skill call failed for {os.path.basename(local_path)}: {exc}",
+            flush=True,
+        ),
+    )
 
 
 # When a sender ADDRESSES the bot (a DM, or an @mention — every _write_task call

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -44,6 +44,7 @@ except Exception:  # pragma: no cover — bridge must keep running
     def _push_vision_image(path: str, source: str = "telegram") -> bool:  # type: ignore
         return False
 from task_priority import default_priority_for_source  # noqa: E402
+from optional_script import run_optional_script as _run_optional_script_shared  # noqa: E402
 
 # Observability: emit channel.telegram.<in|out> into the local obs spine
 # (src/observability). Guarded so a missing module never crashes the bridge.
@@ -365,20 +366,16 @@ def _transcribe_via_skill(local_path: str) -> str | None:
     Optional — if the skill is absent the caller falls back to [Voice note attached:].
     Errors are swallowed; transcription failure must never block task delivery.
     """
-    import subprocess
     skill_script = Path(os.path.realpath(__file__)).parent.parent / "skills" / "audio-transcribe" / "scripts" / "transcribe.py"
-    if not skill_script.exists():
-        return None
-    try:
-        result = subprocess.run(
-            [sys.executable, str(skill_script), local_path],
-            capture_output=True, text=True, timeout=25,
-        )
-        if result.returncode == 0:
-            return result.stdout.strip() or None
-    except Exception as e:
-        print(f"  [stt] skill call failed for {os.path.basename(local_path)}: {e}", flush=True)
-    return None
+    return _run_optional_script_shared(
+        skill_script,
+        [local_path],
+        timeout=25,
+        on_error=lambda exc: print(
+            f"  [stt] skill call failed for {os.path.basename(local_path)}: {exc}",
+            flush=True,
+        ),
+    )
 
 
 def download_file(file_id, name_hint="file"):

--- a/tests/audio-transcribe-skill.test.py
+++ b/tests/audio-transcribe-skill.test.py
@@ -19,6 +19,8 @@ from unittest.mock import MagicMock, patch
 
 REPO = Path(__file__).parent.parent
 SKILL_SCRIPT = REPO / "skills" / "audio-transcribe" / "scripts" / "transcribe.py"
+sys.path.insert(0, str(REPO / "src"))
+from optional_script import run_optional_script  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -44,7 +46,13 @@ def _load_bridge_helper(bridge_name: str) -> types.ModuleType:
         end += 1
     func_src = "\n".join(lines[start:end])
     # Inject __file__ so Path(__file__).parent.parent resolves correctly.
-    ns: dict = {"Path": Path, "os": os, "sys": sys, "__file__": str(bridge_path)}
+    ns: dict = {
+        "Path": Path,
+        "os": os,
+        "sys": sys,
+        "__file__": str(bridge_path),
+        "_run_optional_script_shared": run_optional_script,
+    }
     exec(func_src, ns)  # noqa: S102
     mod = types.SimpleNamespace(_transcribe_via_skill=ns["_transcribe_via_skill"])
     return mod
@@ -136,6 +144,60 @@ class TestSkillCLI(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # Bridge helper tests
 # ---------------------------------------------------------------------------
+
+class TestOptionalScriptRunner(unittest.TestCase):
+    def test_success_preserves_interpreter_args_and_timeout(self):
+        script = Path("/tmp/optional-script.py")
+        result = MagicMock(returncode=0, stdout="  transcript text\n")
+        with patch.object(Path, "exists", return_value=True), \
+             patch("optional_script.subprocess.run", return_value=result) as run:
+            output = run_optional_script(
+                script, ["/tmp/voice.m4a"], timeout=25
+            )
+        self.assertEqual(output, "transcript text")
+        run.assert_called_once_with(
+            [sys.executable, str(script), "/tmp/voice.m4a"],
+            capture_output=True,
+            text=True,
+            timeout=25,
+        )
+
+    def test_exception_is_fail_open_and_reported(self):
+        errors = []
+        with patch.object(Path, "exists", return_value=True), \
+             patch("optional_script.subprocess.run", side_effect=TimeoutError("slow")):
+            output = run_optional_script(
+                Path("/tmp/optional-script.py"),
+                ["input"],
+                timeout=25,
+                on_error=errors.append,
+            )
+        self.assertIsNone(output)
+        self.assertEqual(str(errors[0]), "slow")
+
+    def test_bridges_delegate_but_keep_capability_discovery_at_the_edge(self):
+        shared_source = (REPO / "src" / "optional_script.py").read_text()
+        self.assertNotIn("audio-transcribe", shared_source)
+        self.assertNotIn(' / "skills"', shared_source)
+
+        for bridge_name in ("discord", "slack", "telegram"):
+            bridge_source = (
+                REPO / "src" / f"{bridge_name}-bridge.py"
+            ).read_text()
+            lines = bridge_source.splitlines()
+            start = next(
+                i
+                for i, line in enumerate(lines)
+                if "def _transcribe_via_skill" in line
+            )
+            end = start + 1
+            while end < len(lines) and (
+                lines[end].startswith("    ") or lines[end] == ""
+            ):
+                end += 1
+            helper_source = "\n".join(lines[start:end])
+            self.assertIn("_run_optional_script_shared(", helper_source)
+            self.assertNotIn("subprocess.run", helper_source)
 
 class TestBridgeHelperSlack(unittest.TestCase):
     def test_skill_absent_returns_none(self):
@@ -230,7 +292,13 @@ class TestBridgeHelperSymlinkResolve(unittest.TestCase):
         while end < len(lines) and (lines[end].startswith("    ") or lines[end] == ""):
             end += 1
         func_src = "\n".join(lines[start:end])
-        ns: dict = {"Path": Path, "os": os, "sys": sys, "__file__": symlink_path}
+        ns: dict = {
+            "Path": Path,
+            "os": os,
+            "sys": sys,
+            "__file__": symlink_path,
+            "_run_optional_script_shared": run_optional_script,
+        }
         exec(func_src, ns)  # noqa: S102
         return ns
 
@@ -270,16 +338,21 @@ class TestRealModuleResolveLineCoverage(unittest.TestCase):
         """telegram-bridge.py has no hard import-time dependency on a live
         token (see tests/telegram-writeside-attachments.test.py), so it can
         be imported directly."""
-        os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token-not-real")
-        spec = importlib.util.spec_from_file_location(
-            "telegrambridge_realcov", REPO / "src" / "telegram-bridge.py")
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
+        with tempfile.TemporaryDirectory() as tmp_ws, patch.dict(os.environ, {
+            "CLAUDE_CONFIG_DIR": str(Path(tmp_ws) / "claude"),
+            "SUTANDO_WORKSPACE": tmp_ws,
+            "SUTANDO_TEST_MODE": "1",
+            "TELEGRAM_BOT_TOKEN": "test-token-not-real",
+        }):
+            spec = importlib.util.spec_from_file_location(
+                "telegrambridge_realcov", REPO / "src" / "telegram-bridge.py")
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
 
-        mock_result = MagicMock(returncode=0, stdout="resolved via real module\n")
-        with patch("subprocess.run", return_value=mock_result):
-            result = mod._transcribe_via_skill("/tmp/voice.ogg")
-        self.assertEqual(result, "resolved via real module")
+            mock_result = MagicMock(returncode=0, stdout="resolved via real module\n")
+            with patch("subprocess.run", return_value=mock_result):
+                result = mod._transcribe_via_skill("/tmp/voice.ogg")
+            self.assertEqual(result, "resolved via real module")
 
     def test_slack_bridge_real_module(self):
         """slack-bridge.py's module-level `App(token=BOT_TOKEN)` hits the
@@ -309,25 +382,31 @@ class TestRealModuleResolveLineCoverage(unittest.TestCase):
         _socket = types.ModuleType("slack_bolt.adapter.socket_mode")
         _socket.SocketModeHandler = type(
             "SocketModeHandler", (), {"__init__": lambda self, *a, **k: None})
-        with patch.dict(sys.modules, {
-            "slack_bolt": _bolt,
-            "slack_bolt.adapter": _adapter,
-            "slack_bolt.adapter.socket_mode": _socket,
-        }), tempfile.TemporaryDirectory() as tmp_ws, patch.dict(os.environ, {
-            "SUTANDO_WORKSPACE": tmp_ws,
-            "SUTANDO_TEST_MODE": "1",
-            "SLACK_BOT_TOKEN": "xoxb-test-not-real",
-            "SLACK_APP_TOKEN": "xapp-test-not-real",
-        }):
-            spec = importlib.util.spec_from_file_location(
-                "slackbridge_realcov", REPO / "src" / "slack-bridge.py")
-            mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(mod)
+        with tempfile.TemporaryDirectory() as tmp_ws:
+            claude_dir = Path(tmp_ws) / "claude"
+            access_file = claude_dir / "channels" / "slack" / "access.json"
+            access_file.parent.mkdir(parents=True)
+            access_file.write_text('{"allowFrom": []}')
+            with patch.dict(sys.modules, {
+                "slack_bolt": _bolt,
+                "slack_bolt.adapter": _adapter,
+                "slack_bolt.adapter.socket_mode": _socket,
+            }), patch.dict(os.environ, {
+                "CLAUDE_CONFIG_DIR": str(claude_dir),
+                "SUTANDO_WORKSPACE": tmp_ws,
+                "SUTANDO_TEST_MODE": "1",
+                "SLACK_BOT_TOKEN": "xoxb-test-not-real",
+                "SLACK_APP_TOKEN": "xapp-test-not-real",
+            }):
+                spec = importlib.util.spec_from_file_location(
+                    "slackbridge_realcov", REPO / "src" / "slack-bridge.py")
+                mod = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(mod)
 
-            mock_result = MagicMock(returncode=0, stdout="resolved via real module\n")
-            with patch("subprocess.run", return_value=mock_result):
-                result = mod._transcribe_via_skill("/tmp/voice.m4a")
-            self.assertEqual(result, "resolved via real module")
+                mock_result = MagicMock(returncode=0, stdout="resolved via real module\n")
+                with patch("subprocess.run", return_value=mock_result):
+                    result = mod._transcribe_via_skill("/tmp/voice.m4a")
+                self.assertEqual(result, "resolved via real module")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed, and why?

Centralizes the provider-neutral subprocess behavior used when Discord, Slack,
and Telegram invoke the optional `audio-transcribe` skill.

`src/optional_script.py` now owns the shared interpreter selection, argument
construction, timeout, output normalization, and fail-open behavior. Each
bridge still discovers the skill at its existing adapter-specific path and
retains its existing `_transcribe_via_skill` API and log wording.

`CLAUDE.md` / `AGENTS.md` now keep optional capability discovery at the adapter
edge, while `docs/architecture-boundaries.md` records the dependency direction.

## Review first

1. `src/optional_script.py`
2. `_transcribe_via_skill` in the three bridge adapters
3. `TestOptionalScriptRunner` and the real-module coverage cases in
   `tests/audio-transcribe-skill.test.py`
4. the architecture rule in `CLAUDE.md`

## User behavior or bug proved

N/A — this is a behavior-preserving `tidy:` refactor. The tests pin the
existing missing-script, success, non-zero exit, exception, 25-second timeout,
stdout trimming, interpreter, symlink-resolution, and fail-open contracts.

## Feature/documentation consistency

No user-visible capability changed. The architecture boundary is documented in
`docs/architecture-boundaries.md`; `CLAUDE.md` was updated and `AGENTS.md`
regenerated. `docs/src-map.md` was regenerated for the new source module.

## Before / after evidence

Parent `a9fb5bbc7bc7bf820c76e1a34494b1a1abf9e959` contained the same subprocess
command in three bridge-private helpers:

```text
$ git grep -n -F '[sys.executable, str(skill_script), local_path]' origin/main -- 'src/*-bridge.py'
origin/main:src/discord-bridge.py:437:            [sys.executable, str(skill_script), local_path],
origin/main:src/slack-bridge.py:676:            [sys.executable, str(skill_script), local_path],
origin/main:src/telegram-bridge.py:374:            [sys.executable, str(skill_script), local_path],
```

HEAD has one runner and three thin adapter delegations:

```text
$ git grep -n -F '_run_optional_script_shared(' HEAD -- 'src/*-bridge.py'
HEAD:src/discord-bridge.py:433:    return _run_optional_script_shared(
HEAD:src/slack-bridge.py:672:    return _run_optional_script_shared(
HEAD:src/telegram-bridge.py:370:    return _run_optional_script_shared(

$ git grep -n -F '[sys.executable, str(script_path), *args]' HEAD -- src/optional_script.py
HEAD:src/optional_script.py:36:            [sys.executable, str(script_path), *args],
```

## Tests

```text
$ python3 tests/audio-transcribe-skill.test.py
Ran 22 tests in 0.129s
OK

$ python3 scripts/lint-hermetic-bridge-tests.py --diff
lint-hermetic-bridge-tests: ok (1 bridge-importing tests scanned, 59 grandfathered, 0 mitigated)

$ bash scripts/agents-md-sync.sh --check
agents-md-sync: AGENTS.md is up to date

$ python3 scripts/gen-src-map.py --check
gen-src-map: docs/src-map.md is up to date

$ git diff origin/main...HEAD | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths clean)
```

```text
$ npm run test:py
...
PASS — 18/18 write-calendar-cache producer tests
[exit 0]
```

The first sandboxed full-suite attempt stopped at the repository's loopback
HTTP fixture with `PermissionError: [Errno 1] Operation not permitted`; the
identical suite was rerun with local test-server permission and completed with
exit 0. The existing optional `secret-scanner.test.py` and
`vault-intercept.test.py` skips reported that `detect_secrets` is not installed
in this interpreter.

## Live post-restart round trip

Discord was restarted directly from HEAD with the normal runtime environment.
The owner sent a real Discord mobile voice message; the patched bridge
downloaded the `.ogg`, invoked the shared runner, and wrote the transcript into
an owner-tier task:

```text
Discord bridge ready: mark-sutando#4497
  [msg] #DM @msze_:  (mentions: [], is_dm: True, embeds: 0, type: MessageType.default, ref: False)
  @msze_:
[Voice transcript: Central Runner Live test.]
  [task-write] wrote task-1785625426427.txt (@msze_, #DM, tier=owner)
```

The task recorded `source: discord`, `interaction_type: message`,
`content_modalities: audio`, `media_form: attachment`, `access_tier: owner`,
the downloaded `.ogg` attachment metadata, and the expected transcript. A
result then completed the return path:

```text
  Replied: PR #2495 live test passed: the patched bridge downloaded your Discord voice mess...
```

An earlier Slack attempt reached its unchanged file-download guard but the
configured Slack token returned an HTML sign-in page for `audio_message.m4a`
(`files:read` scope/reinstall is required), so no Slack transcript was claimed.
The Discord pass exercises the shared runner end to end.

## Stacking

N/A — standalone PR based directly on current `main`. It does not depend on
#2492.

## Hardcoded-path check

```text
$ git diff origin/main...HEAD | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths clean)
```

No production host path or fallback was added. Skill discovery remains in each
adapter; only the discovered `Path` is passed into the generic runner.

## Edge cases checked

- optional skill path absent;
- successful output with surrounding whitespace;
- empty successful output;
- non-zero subprocess exit;
- subprocess timeout/exception with adapter-specific logging;
- exact `sys.executable`, argument order, and 25-second timeout;
- app-bundle/symlink path resolution remains at the adapter edge;
- shared runner contains no `skills/` or `audio-transcribe` dependency;
- real Slack and Telegram module execution uses hermetic channel config.

## Migration, config, permissions, rollback, and risk

No migration, config, prompt, protocol, or permission change. Rollback is a
single commit revert. The main risk is adapter wiring drift; direct runner
contracts plus source-wiring and real-module tests cover that boundary.

## Known gaps / follow-up

Slack voice-note validation on this host requires adding `files:read` to the
Slack app and reinstalling it. That configuration issue occurs before the code
changed here; Slack's downloader is byte-identical to `main`. No code follow-up
is bundled into this concern.
