### PR TITLE
fix(health-check): a cron parked on an impossible date warned forever

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -786,6 +786,26 @@ def _cron_can_never_fire(expr: str) -> bool:
     return not any(d <= _MONTH_MAX_DAYS[m] for m in months for d in doms)
 
 
+def _entry_marked_parked(entry: dict) -> bool:
+    """True when the entry carries an explicit "deliberately disabled" signal.
+
+    An impossible date alone must NOT qualify. `0 0 31 2 *` is equally the
+    signature of a parked job and of an active typo — someone meaning "the 31st,
+    monthly" and writing February. Excluding on the date alone would let a
+    mistyped ACTIVE schedule vanish from `expected`, so CronCreate silently
+    omits it and this guard reports green forever: the precise silent-miss class
+    the check exists to surface.
+
+    Two accepted signals: an explicit `disabled: true` field, and the
+    established convention of DISABLED in the entry name (used by this host's
+    `wire-newsroom-nightly-DISABLED-2026-06-09-...`, which also records why).
+    """
+    if entry.get("disabled") is True:
+        return True
+    name = entry.get("name")
+    return isinstance(name, str) and "DISABLED" in name
+
+
 def check_session_cron_registration(
     workspace_dir: Optional[Path] = None,
     host_label: Optional[str] = None,
@@ -826,9 +846,15 @@ def check_session_cron_registration(
         cron_expr = entry.get("cron")
         if entry.get("loop") == "dynamic" or not cron_expr:
             return False
-        if isinstance(cron_expr, str) and _cron_can_never_fire(cron_expr):
-            # Parked-on-purpose (e.g. `0 0 31 2 *`): /schedule-crons cannot
-            # register it, so counting it as expected warns forever.
+        if (
+            _entry_marked_parked(entry)
+            and isinstance(cron_expr, str)
+            and _cron_can_never_fire(cron_expr)
+        ):
+            # BOTH signals required. Marked-disabled AND unregistrable (e.g.
+            # `0 0 31 2 *`): /schedule-crons cannot register it, so counting it
+            # as expected warns forever. An impossible date WITHOUT a disabled
+            # marker is an active typo and must still warn.
             return False
         return True
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -718,6 +718,74 @@ def check_cron_runner(
     }
 
 
+_MONTH_MAX_DAYS = {1: 31, 2: 29, 3: 31, 4: 30, 5: 31, 6: 30,
+                   7: 31, 8: 31, 9: 30, 10: 31, 11: 30, 12: 31}
+
+
+def _cron_field_values(field: str, lo: int, hi: int) -> "set[int] | None":
+    """Expand one numeric cron field to its value set, or None if not understood.
+
+    None means "do not reason about this expression" — every caller below treats
+    an unparseable field as schedulable, so a parser gap can never invent a
+    never-fires verdict.
+    """
+    out: "set[int]" = set()
+    for part in field.split(","):
+        part = part.strip()
+        if not part:
+            return None
+        step = 1
+        if "/" in part:
+            part, _, raw_step = part.partition("/")
+            if not raw_step.isdigit() or int(raw_step) < 1:
+                return None
+            step = int(raw_step)
+        if part in ("*", "?"):
+            start, end = lo, hi
+        elif "-" in part.lstrip("-"):
+            start_s, _, end_s = part.partition("-")
+            if not (start_s.isdigit() and end_s.isdigit()):
+                return None
+            start, end = int(start_s), int(end_s)
+        elif part.isdigit():
+            start = end = int(part)
+        else:
+            return None  # names (JAN/MON), L, W, # — not our business
+        if start > end or start < lo or end > hi:
+            return None
+        out.update(range(start, end + 1, step))
+    return out or None
+
+
+def _cron_can_never_fire(expr: str) -> bool:
+    """True only when a 5-field cron's day-of-month/month pair is impossible.
+
+    A deliberately-parked entry is the real case: this host carries
+    `wire-newsroom-nightly-DISABLED-...` at `0 0 31 2 *` — February 31st, which
+    is syntactically valid and can never occur. /schedule-crons cannot register
+    it, so it was counted as expected-but-missing and the session-crons guard
+    warned on every run, permanently. A guard that always warns is a guard
+    nobody reads, and this one exists to catch a SILENT failure (a peer
+    instance registered 2/18 with no error) — so a standing false positive
+    disables exactly the signal it was built to raise.
+
+    Deliberately conservative: day-of-week must be unrestricted, because cron
+    ORs day-of-month with day-of-week — `0 0 31 2 MON` still fires on Mondays.
+    Anything unparseable returns False (schedulable).
+    """
+    parts = expr.split()
+    if len(parts) != 5:
+        return False
+    _, _, dom_f, month_f, dow_f = parts
+    if dow_f.strip() not in ("*", "?"):
+        return False  # OR-semantics with day-of-week — it can still fire
+    doms = _cron_field_values(dom_f, 1, 31)
+    months = _cron_field_values(month_f, 1, 12)
+    if doms is None or months is None:
+        return False
+    return not any(d <= _MONTH_MAX_DAYS[m] for m in months for d in doms)
+
+
 def check_session_cron_registration(
     workspace_dir: Optional[Path] = None,
     host_label: Optional[str] = None,
@@ -755,7 +823,12 @@ def check_session_cron_registration(
     def session_owned(entry: dict) -> bool:
         if entry.get("launchd") is True or entry.get("execution") == "codex-task":
             return False
-        if entry.get("loop") == "dynamic" or not entry.get("cron"):
+        cron_expr = entry.get("cron")
+        if entry.get("loop") == "dynamic" or not cron_expr:
+            return False
+        if isinstance(cron_expr, str) and _cron_can_never_fire(cron_expr):
+            # Parked-on-purpose (e.g. `0 0 31 2 *`): /schedule-crons cannot
+            # register it, so counting it as expected warns forever.
             return False
         return True
 

--- a/tests/health-check-session-cron-stamp.test.py
+++ b/tests/health-check-session-cron-stamp.test.py
@@ -187,6 +187,74 @@ class SessionCronStampTest(unittest.TestCase):
             (cores / "test-host.alive").write_text(json.dumps([]))
             self.assertEqual(self._check(ws)["status"], "ok")
 
+class ParkedCronNotExpectedTest(unittest.TestCase):
+    """A cron parked on an impossible date must not count toward `expected`.
+
+    Observed on Chis-Mac-mini 2026-08-01: crons.json carries
+    `wire-newsroom-nightly-DISABLED-...` at `0 0 31 2 *` (February 31st).
+    /schedule-crons registers the other 8 and cannot register that one, so the
+    stamp reads 8/9 and the guard warned on every health-check run, forever.
+    It can only be cleared by re-enabling the parked job (owner's call alone) or
+    by deleting the disabled record — so the guard was permanently crying wolf
+    while existing to catch a SILENT failure.
+    """
+
+    def _check(self, workspace):
+        return health.check_session_cron_registration(
+            workspace, host_label="test-host", runtime="claude"
+        )
+
+    def _workspace(self, root: Path, entries, registered: int) -> Path:
+        workspace = root / "workspace"
+        config = workspace / "hosts" / "test-host" / "crons.json"
+        config.parent.mkdir(parents=True)
+        config.write_text(json.dumps(entries))
+        (workspace / "state").mkdir(parents=True, exist_ok=True)
+        (config.parent / "schedule-crons-stamp.json").write_text(
+            json.dumps({"ts": 2000, "registered": registered, "config_total": len(entries)})
+        )
+        return workspace
+
+    def test_parked_entry_is_not_expected(self):
+        """The real host shape: 1 live + 1 parked, 1 registered -> ok, not 1/2."""
+        entries = [
+            {"name": "main-loop", "cron": "*/3 * * * *", "prompt_skill": "proactive-loop"},
+            {"name": "wire-nightly-DISABLED", "cron": "0 0 31 2 *", "prompt": "x"},
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            res = self._check(self._workspace(Path(td), entries, registered=1))
+        self.assertEqual(res["status"], "ok", res["detail"])
+        self.assertIn("1 session cron", res["detail"])
+
+    def test_a_genuinely_missing_cron_still_warns(self):
+        """The guard must keep its teeth — a real shortfall still warns."""
+        entries = [
+            {"name": "main-loop", "cron": "*/3 * * * *", "prompt": "x"},
+            {"name": "digest", "cron": "2 6 * * *", "prompt": "y"},
+            {"name": "parked", "cron": "0 0 31 2 *", "prompt": "z"},
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            res = self._check(self._workspace(Path(td), entries, registered=1))
+        self.assertEqual(res["status"], "warn")
+        self.assertIn("1/2", res["detail"])  # parked one excluded from BOTH sides
+
+    def test_never_fires_predicate(self):
+        never = ["0 0 31 2 *", "0 0 30 2 *", "0 0 31 4,6 *", "0 0 31 2 ?"]
+        for e in never:
+            self.assertTrue(health._cron_can_never_fire(e), e)
+        fires = [
+            "*/3 * * * *", "57 6 * * *", "0 0 29 2 *",     # Feb 29 exists in leap years
+            "0 0 31 1 *", "0 0 31 2 MON",                   # day-of-week ORs it back in
+            "0 0 31 2 1", "0 0 * * *", "13 3 * * 1",
+        ]
+        for e in fires:
+            self.assertFalse(health._cron_can_never_fire(e), e)
+
+    def test_unparseable_is_treated_as_schedulable(self):
+        """A parser gap must never invent a never-fires verdict."""
+        for e in ["0 0 31 FEB *", "not a cron", "0 0 31 2", "0 0 L 2 *", "0 0 31 2 * *", "0 0 /0 2 *"]:
+            self.assertFalse(health._cron_can_never_fire(e), e)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=1)

--- a/tests/health-check-session-cron-stamp.test.py
+++ b/tests/health-check-session-cron-stamp.test.py
@@ -219,7 +219,7 @@ class ParkedCronNotExpectedTest(unittest.TestCase):
         """The real host shape: 1 live + 1 parked, 1 registered -> ok, not 1/2."""
         entries = [
             {"name": "main-loop", "cron": "*/3 * * * *", "prompt_skill": "proactive-loop"},
-            {"name": "wire-nightly-DISABLED", "cron": "0 0 31 2 *", "prompt": "x"},
+            {"name": "wire-newsroom-nightly-DISABLED-2026-06-09", "cron": "0 0 31 2 *", "prompt": "x"},
         ]
         with tempfile.TemporaryDirectory() as td:
             res = self._check(self._workspace(Path(td), entries, registered=1))
@@ -231,12 +231,55 @@ class ParkedCronNotExpectedTest(unittest.TestCase):
         entries = [
             {"name": "main-loop", "cron": "*/3 * * * *", "prompt": "x"},
             {"name": "digest", "cron": "2 6 * * *", "prompt": "y"},
-            {"name": "parked", "cron": "0 0 31 2 *", "prompt": "z"},
+            {"name": "parked-DISABLED", "cron": "0 0 31 2 *", "prompt": "z"},
         ]
         with tempfile.TemporaryDirectory() as td:
             res = self._check(self._workspace(Path(td), entries, registered=1))
         self.assertEqual(res["status"], "warn")
         self.assertIn("1/2", res["detail"])  # parked one excluded from BOTH sides
+
+    def test_active_impossible_schedule_still_warns(self):
+        """qingyun-wu #2498: an impossible date with NO disabled marker is a typo.
+
+        Someone means "the 31st, monthly" and writes February. CronCreate omits
+        it; if `expected` dropped it too, health-check would read green forever
+        — the silent miss this guard exists to catch.
+        """
+        entries = [
+            {"name": "main-loop", "cron": "*/3 * * * *", "prompt": "x"},
+            {"name": "monthly-report", "cron": "0 0 31 2 *", "prompt": "y"},
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            res = self._check(self._workspace(Path(td), entries, registered=1))
+        self.assertEqual(res["status"], "warn", res["detail"])
+        self.assertIn("1/2", res["detail"])
+
+    def test_parked_signal_matrix(self):
+        """Exclusion needs BOTH a parked marker AND an unregistrable date.
+
+        Axis, not just the reviewer's case: {DISABLED-name, disabled:true field,
+        no marker} x {impossible cron, valid cron}.
+        """
+        live = {"name": "main-loop", "cron": "*/3 * * * *", "prompt": "x"}
+        IMPOSSIBLE, VALID = "0 0 31 2 *", "0 4 * * *"
+        cases = [
+            ({"name": "wire-DISABLED-2026", "cron": IMPOSSIBLE}, True,  "parked name + impossible"),
+            ({"name": "parked", "disabled": True, "cron": IMPOSSIBLE}, True,  "disabled field + impossible"),
+            ({"name": "monthly-report", "cron": IMPOSSIBLE},      False, "NO marker + impossible = typo"),
+            ({"name": "wire-DISABLED-2026", "cron": VALID},       False, "parked name + registrable"),
+            ({"name": "parked", "disabled": True, "cron": VALID}, False, "disabled field + registrable"),
+            ({"name": "ordinary", "cron": VALID},                 False, "plain active entry"),
+        ]
+        for entry, excluded, label in cases:
+            entry = {**entry, "prompt": "y"}
+            with tempfile.TemporaryDirectory() as td:
+                ws = self._workspace(Path(td), [live, entry], registered=1)
+                res = self._check(ws)
+            if excluded:
+                self.assertEqual(res["status"], "ok", f"{label}: {res['detail']}")
+            else:
+                self.assertEqual(res["status"], "warn", f"{label}: {res['detail']}")
+                self.assertIn("1/2", res["detail"], label)
 
     def test_never_fires_predicate(self):
         never = ["0 0 31 2 *", "0 0 30 2 *", "0 0 31 4,6 *", "0 0 31 2 ?"]
@@ -249,6 +292,31 @@ class ParkedCronNotExpectedTest(unittest.TestCase):
         ]
         for e in fires:
             self.assertFalse(health._cron_can_never_fire(e), e)
+
+    def test_cron_field_expansion_branches(self):
+        """Every branch of the field expander, incl. the ones a bare `31 2 *` skips.
+
+        Ranges, valid steps, empty list segments and out-of-range bounds were all
+        unexercised — CI measured the diff at 83.7% (missing 736, 742, 746-749,
+        755). Each case below names the branch it drives.
+        """
+        # range branch + valid step, and genuinely impossible (Feb has <30 days)
+        self.assertTrue(health._cron_can_never_fire("0 0 30-31 2 *"))   # range, both > Feb max
+        self.assertTrue(health._cron_can_never_fire("0 0 30-31/1 2 *")) # + valid step
+        # range that reaches a real day -> schedulable
+        self.assertFalse(health._cron_can_never_fire("0 0 28-31 2 *"))  # 28 and 29 exist
+        self.assertFalse(health._cron_can_never_fire("0 0 1-31/5 2 *")) # step lands on 1,6,...
+        # unparseable / malformed -> schedulable, never a never-fires verdict
+        for expr, why in [
+            ("0 0 31, 2 *",    "empty list segment"),
+            ("0 0 31/0 2 *",   "step below 1"),
+            ("0 0 31/x 2 *",   "non-numeric step"),
+            ("0 0 a-b 2 *",    "non-numeric range bounds"),
+            ("0 0 40 2 *",     "day-of-month above the field max"),
+            ("0 0 20-10 2 *",  "inverted range"),
+            ("0 0 0 2 *",      "day-of-month below the field min"),
+        ]:
+            self.assertFalse(health._cron_can_never_fire(expr), why)
 
     def test_unparseable_is_treated_as_schedulable(self):
         """A parser gap must never invent a never-fires verdict."""


### PR DESCRIPTION
## The bug

`check_session_cron_registration` counts every entry with a `cron` string toward `expected`. That includes an entry parked on a date that can never occur.

This host's `crons.json` carries `wire-newsroom-nightly-DISABLED-2026-06-09-1425Z-...` at `0 0 31 2 *` — **February 31st**. `/schedule-crons` registers the other 8 and cannot register that one, so the stamp reads 8/9 and the guard warns on every single run.

It cannot clear on its own. The only exits are re-enabling the parked job (the owner's call alone) or deleting the disabled record along with the reason embedded in its name.

## Why this is worth fixing rather than tolerating

The guard exists to catch a **silent** failure — a peer instance registered 2/18 crons with no error, config intact on disk, zero live crons. A probe that always warns is a probe nobody reads. The standing false positive disables precisely the signal it was built to raise.

## Before / after — actual output on this host

Live state, unchanged by this PR:

```
$ cat workspace/hosts/Chis-Mac-mini/schedule-crons-stamp.json
{"ts": 1785607670, "registered": 8, "config_total": 9}
```

`CronList` shows 8 registered; the single absentee is the `0 0 31 2 *` entry.

**At `origin/main` (badd2a64)** — the new tests run against unmodified code:

```
FAIL: test_parked_entry_is_not_expected
AssertionError: 'warn' != 'ok' : only 1/2 session cron(s) registered at last /schedule-crons

Ran 17 tests
FAILED (failures=2, errors=2)
```

The failure text reproduces the production symptom verbatim.

**At this head:**

```
Ran 17 tests
OK
```

Full health-check suite, judged by exit code (43 files): **0 failures**.

## The fix

`session_owned()` drops an entry only when its day-of-month/month pair is genuinely impossible. Conservative in both directions:

- **Day-of-week must be unrestricted.** cron ORs day-of-month with day-of-week, so `0 0 31 2 MON` still fires on Mondays and is correctly kept.
- **Anything unparseable is schedulable.** Names (`FEB`), `L`/`W`, wrong field counts, bad steps all return "can fire", so a parser gap can never invent a never-fires verdict.
- **A real shortfall still warns** — covered by its own test, where the parked entry is excluded from both sides of the ratio and a genuine 1/2 still trips.

Feb 29 is treated as reachable (leap years), so only truly impossible pairs are excluded.

## Scope

One function plus a module-level helper in `src/health-check.py`, and tests. Touches no other probe.

Four of my open PRs also edit `src/health-check.py` (#2494, #2471, #2316, #2160). I checked their hunk ranges before writing: they land at lines ~43, ~1371–1511, ~1579–1655, and ~2487–2840. This change sits at ~720–818 and overlaps none of them.

## Note on the test file

The new cases were initially appended after the file's `if __name__ == "__main__": unittest.main()` block, where they were defined but never collected — 13 ran while 17 were defined, and the suite looked green against both fixed and unfixed code. Caught by the two-identical-outputs check and relocated above the guard. The failing-at-`main` output above is from the corrected file.

@sonichi flagging you per usual.
