### PR TITLE
tidy: centralize task archive policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Be concise and direct. Prefer action over explanation. Default to the smallest a
 
 - **HTTP handlers centralize transport mechanics.** Put repeated authentication gates, status/header emission, and JSON encoding in handler helpers. Dispatch methods route only; named endpoint methods own behavior. Protect delegation, status codes, headers, and payload shapes with direct contract tests when refactoring handlers.
 - **HTTP route methods are dispatch layers.** Move filesystem reconciliation and response assembly into named module functions; route methods should parse the request, call one unit, and emit its result. Test the extracted behavior directly plus one route-wiring path.
+- **Archive through `task_archive.archive_file`.** Monthly destination selection and failed-move cleanup are one task/result protocol policy. Bridge wrappers may supply provider log formatting, but must not rebuild archive paths or move/unlink fallback behavior.
 - When refactoring, do NOT change prompts or tool behavior. Prompts are tuned through testing and must be preserved exactly.
 - **Code comments: at most 2 lines, and only what the code cannot state itself.** Give the constraint or the non-obvious reason. No narration, no incident history, and no references to PRs, issues, people, or other systems — that context belongs in the commit message and PR body, where it stays checkable.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Be concise and direct. Prefer action over explanation. Default to the smallest a
 
 - **HTTP handlers centralize transport mechanics.** Put repeated authentication gates, status/header emission, and JSON encoding in handler helpers. Dispatch methods route only; named endpoint methods own behavior. Protect delegation, status codes, headers, and payload shapes with direct contract tests when refactoring handlers.
 - **HTTP route methods are dispatch layers.** Move filesystem reconciliation and response assembly into named module functions; route methods should parse the request, call one unit, and emit its result. Test the extracted behavior directly plus one route-wiring path.
+- **Archive through `task_archive.archive_file`.** Monthly destination selection and failed-move cleanup are one task/result protocol policy. Bridge wrappers may supply provider log formatting, but must not rebuild archive paths or move/unlink fallback behavior.
 - When refactoring, do NOT change prompts or tool behavior. Prompts are tuned through testing and must be preserved exactly.
 - **Code comments: at most 2 lines, and only what the code cannot state itself.** Give the constraint or the non-obvious reason. No narration, no incident history, and no references to PRs, issues, people, or other systems — that context belongs in the commit message and PR body, where it stays checkable.
 

--- a/docs/architecture-boundaries.md
+++ b/docs/architecture-boundaries.md
@@ -147,6 +147,12 @@ and retain only provider-specific delivery. For example,
 crash, while Discord, Slack, and Telegram decide how the recovered result is
 sent. Copying the filesystem state machine into each adapter is not permitted.
 
+Monthly task/result archival is part of that same protocol. The shared
+`task_archive.archive_file` operation owns destination selection and the
+established failed-move cleanup rule. Adapters inject their archive roots and
+provider-specific error logger rather than rebuilding the path/move/unlink
+sequence.
+
 ### HTTP transport handlers
 
 HTTP handlers are transport adapters, not the owner of feature policy. Repeated

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -131,7 +131,7 @@ and re-run `python3 scripts/gen-src-map.py`.
 - **`sutando_config.ts`** — Canonical loader for `sutando.config.json` / `sutando.config.local.json`.
 - **`task-bridge.ts`** — Voice → Claude Code session bridge.
 - **`task-delegation.ts`** — TaskDelegationService — step 4 of the interaction-planes refactor (issue #1947, built under the architecture names per design R3).
-- **`task_archive.py`** — Task-file locator for archive calls (#933).
+- **`task_archive.py`** — Task/result archive policy and claimed-task locator (#933).
 - **`task_body_guard.py`** — Confine untrusted user message content before embedding it in a task file.
 - **`task_priority.py`** — Task priority taxonomy + readers.
 - **`task_workstreams.py`** — Durable inferred-workstream index and archive-backed task history.

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -51,6 +51,18 @@ def archive_file(
     the stale live source, matching the adapters' established fail-open policy.
     ``False`` means the source was absent or the move failed.
     """
+    # Validate BEFORE the try. `base = tasks if kind == "tasks" else results`
+    # routed every other value — "task", "Tasks", a typo — silently to results,
+    # misfiling the archive rather than raising. Latent today (all three
+    # adapters pass literals) but this is shared policy with three callers and
+    # gravity toward more (review nit, @sonichi #2505).
+    #
+    # OUTSIDE the try on purpose: the fail-open handler below catches
+    # Exception, so a guard placed inside it is swallowed and ALSO unlinks the
+    # source — turning a caller's typo into silent data loss. A programming
+    # error is not the failure mode fail-open exists for.
+    if kind not in ("tasks", "results"):
+        raise ValueError(f"archive_file: kind must be 'tasks' or 'results', got {kind!r}")
     if not src.exists():
         return False
     try:

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -51,16 +51,8 @@ def archive_file(
     the stale live source, matching the adapters' established fail-open policy.
     ``False`` means the source was absent or the move failed.
     """
-    # Validate BEFORE the try. `base = tasks if kind == "tasks" else results`
-    # routed every other value — "task", "Tasks", a typo — silently to results,
-    # misfiling the archive rather than raising. Latent today (all three
-    # adapters pass literals) but this is shared policy with three callers and
-    # gravity toward more (review nit, @sonichi #2505).
-    #
-    # OUTSIDE the try on purpose: the fail-open handler below catches
-    # Exception, so a guard placed inside it is swallowed and ALSO unlinks the
-    # source — turning a caller's typo into silent data loss. A programming
-    # error is not the failure mode fail-open exists for.
+    # Outside the try on purpose: the fail-open handler below catches Exception,
+    # so a guard inside it would be swallowed and would also unlink the source.
     if kind not in ("tasks", "results"):
         raise ValueError(f"archive_file: kind must be 'tasks' or 'results', got {kind!r}")
     if not src.exists():

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -1,4 +1,4 @@
-"""Task-file locator for archive calls (#933).
+"""Task/result archive policy and claimed-task locator (#933).
 
 claim_task.py (#884) renames task-{id}.txt → task-{id}.claimed-core-N.txt
 when a core claims work. Bridge archive calls that hard-code the bare
@@ -14,7 +14,10 @@ Usage:
 """
 from __future__ import annotations
 
+import shutil
+from datetime import datetime
 from pathlib import Path
+from typing import Callable, Optional
 
 
 def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
@@ -30,3 +33,41 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
         return bare
     matches = sorted(tasks_dir.glob(f"{task_id}.claimed-core-*.txt"))
     return matches[0] if matches else None
+
+
+def archive_file(
+    src: Path,
+    kind: str,
+    task_id: str,
+    archive_tasks_dir: Path,
+    archive_results_dir: Path,
+    *,
+    now: Optional[datetime] = None,
+    on_error: Optional[Callable[[Exception], None]] = None,
+) -> bool:
+    """Move a live task/result into its monthly archive.
+
+    Archival is cleanup, not a delivery gate. A failed move therefore removes
+    the stale live source, matching the adapters' established fail-open policy.
+    ``False`` means the source was absent or the move failed.
+    """
+    if not src.exists():
+        return False
+    try:
+        month = (now or datetime.now()).strftime("%Y-%m")
+        base = archive_tasks_dir if kind == "tasks" else archive_results_dir
+        destination_dir = base / month
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(destination_dir / f"{task_id}.txt"))
+        return True
+    except Exception as exc:
+        if on_error is not None:
+            try:
+                on_error(exc)
+            except Exception:
+                pass
+        try:
+            src.unlink(missing_ok=True)
+        except Exception:
+            pass
+        return False

--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -132,7 +132,7 @@ try:
 except Exception:  # pragma: no cover — best-effort telemetry
     def _emit_channel(*_a, **_k):  # type: ignore
         return None
-from task_archive import find_task_file  # noqa: E402
+from task_archive import archive_file as _archive_file_shared, find_task_file  # noqa: E402
 from orphan_result_routes import orphan_result_routes  # noqa: E402
 
 
@@ -474,34 +474,18 @@ def _dedup_recover(task_id: str, holder_id, channel_id):
         return "honour", None
 
 
-def archive_path(kind: str, task_id: str) -> "Path":
-    """Return archive destination for a task or result file, partitioned by
-    year-month so the archive stays browsable.
-
-    kind: "tasks" or "results". task_id: e.g. "task-1776538911450"."""
-    from datetime import datetime
-    ym = datetime.now().strftime("%Y-%m")
-    base = ARCHIVE_TASKS_DIR if kind == "tasks" else ARCHIVE_RESULTS_DIR
-    month_dir = base / ym
-    month_dir.mkdir(parents=True, exist_ok=True)
-    return month_dir / f"{task_id}.txt"
-
-
 def archive_file(src: "Path", kind: str, task_id: str) -> None:
-    """Move src into the archive. Silent on failure — archive is for later
-    analysis, not critical path. Chi's 2026-04-18 ask: "instead of deleting
-    we should archive the tasks. It can be useful for self-improving"."""
-    try:
-        if src.exists():
-            import shutil
-            shutil.move(str(src), str(archive_path(kind, task_id)))
-    except Exception as e:
-        print(f"  archive_file({kind}, {task_id}) failed: {e}", flush=True)
-        # Fall back to unlink so we don't leave stale files.
-        try:
-            src.unlink(missing_ok=True)
-        except Exception:
-            pass
+    """Archive through the shared task/result filesystem policy."""
+    _archive_file_shared(
+        src,
+        kind,
+        task_id,
+        ARCHIVE_TASKS_DIR,
+        ARCHIVE_RESULTS_DIR,
+        on_error=lambda exc: print(
+            f"  archive_file({kind}, {task_id}) failed: {exc}", flush=True
+        ),
+    )
 
 
 def notify_agent_api_task_done(task_id: str, result: str) -> None:

--- a/src/slack-bridge.py
+++ b/src/slack-bridge.py
@@ -81,7 +81,7 @@ import local_task_protocol  # noqa: E402
 from task_body_guard import confine_user_content  # noqa: E402
 from util_paths import channel_access_path, claude_home_path, write_private_text  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
-from task_archive import find_task_file  # noqa: E402
+from task_archive import archive_file as _archive_file_shared, find_task_file  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
 from vault_intercept import intercept_vault_commands, redact_vault_commands  # noqa: E402
 from chat_secret_filter import filter_chat_secrets, secret_handling_instruction  # noqa: E402
@@ -183,24 +183,17 @@ def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
 
 
 def archive_file(src: Path, kind: str, task_id: str) -> None:
-    """Move src into archive/<tasks|results>/YYYY-MM/ instead of deleting.
-    Matches the behavior of telegram-bridge.py / discord-bridge.py."""
-    try:
-        if not src.exists():
-            return
-        from datetime import datetime
-        import shutil
-        ym = datetime.now().strftime("%Y-%m")
-        base = ARCHIVE_TASKS_DIR if kind == "tasks" else ARCHIVE_RESULTS_DIR
-        dest_dir = base / ym
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
-    except Exception as e:
-        print(f"[Slack] archive_file({kind}, {task_id}) failed: {e}", flush=True)
-        try:
-            src.unlink(missing_ok=True)
-        except Exception:
-            pass
+    """Archive through the shared task/result filesystem policy."""
+    _archive_file_shared(
+        src,
+        kind,
+        task_id,
+        ARCHIVE_TASKS_DIR,
+        ARCHIVE_RESULTS_DIR,
+        on_error=lambda exc: print(
+            f"[Slack] archive_file({kind}, {task_id}) failed: {exc}", flush=True
+        ),
+    )
 
 
 ACCESS_FILE = channel_access_path("slack")

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -51,6 +51,18 @@ def archive_file(
     the stale live source, matching the adapters' established fail-open policy.
     ``False`` means the source was absent or the move failed.
     """
+    # Validate BEFORE the try. `base = tasks if kind == "tasks" else results`
+    # routed every other value — "task", "Tasks", a typo — silently to results,
+    # misfiling the archive rather than raising. Latent today (all three
+    # adapters pass literals) but this is shared policy with three callers and
+    # gravity toward more (review nit, @sonichi #2505).
+    #
+    # OUTSIDE the try on purpose: the fail-open handler below catches
+    # Exception, so a guard placed inside it is swallowed and ALSO unlinks the
+    # source — turning a caller's typo into silent data loss. A programming
+    # error is not the failure mode fail-open exists for.
+    if kind not in ("tasks", "results"):
+        raise ValueError(f"archive_file: kind must be 'tasks' or 'results', got {kind!r}")
     if not src.exists():
         return False
     try:

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -51,16 +51,8 @@ def archive_file(
     the stale live source, matching the adapters' established fail-open policy.
     ``False`` means the source was absent or the move failed.
     """
-    # Validate BEFORE the try. `base = tasks if kind == "tasks" else results`
-    # routed every other value — "task", "Tasks", a typo — silently to results,
-    # misfiling the archive rather than raising. Latent today (all three
-    # adapters pass literals) but this is shared policy with three callers and
-    # gravity toward more (review nit, @sonichi #2505).
-    #
-    # OUTSIDE the try on purpose: the fail-open handler below catches
-    # Exception, so a guard placed inside it is swallowed and ALSO unlinks the
-    # source — turning a caller's typo into silent data loss. A programming
-    # error is not the failure mode fail-open exists for.
+    # Outside the try on purpose: the fail-open handler below catches Exception,
+    # so a guard inside it would be swallowed and would also unlink the source.
     if kind not in ("tasks", "results"):
         raise ValueError(f"archive_file: kind must be 'tasks' or 'results', got {kind!r}")
     if not src.exists():

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -1,4 +1,4 @@
-"""Task-file locator for archive calls (#933).
+"""Task/result archive policy and claimed-task locator (#933).
 
 claim_task.py (#884) renames task-{id}.txt → task-{id}.claimed-core-N.txt
 when a core claims work. Bridge archive calls that hard-code the bare
@@ -14,7 +14,10 @@ Usage:
 """
 from __future__ import annotations
 
+import shutil
+from datetime import datetime
 from pathlib import Path
+from typing import Callable, Optional
 
 
 def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
@@ -30,3 +33,41 @@ def find_task_file(tasks_dir: Path, task_id: str) -> Path | None:
         return bare
     matches = sorted(tasks_dir.glob(f"{task_id}.claimed-core-*.txt"))
     return matches[0] if matches else None
+
+
+def archive_file(
+    src: Path,
+    kind: str,
+    task_id: str,
+    archive_tasks_dir: Path,
+    archive_results_dir: Path,
+    *,
+    now: Optional[datetime] = None,
+    on_error: Optional[Callable[[Exception], None]] = None,
+) -> bool:
+    """Move a live task/result into its monthly archive.
+
+    Archival is cleanup, not a delivery gate. A failed move therefore removes
+    the stale live source, matching the adapters' established fail-open policy.
+    ``False`` means the source was absent or the move failed.
+    """
+    if not src.exists():
+        return False
+    try:
+        month = (now or datetime.now()).strftime("%Y-%m")
+        base = archive_tasks_dir if kind == "tasks" else archive_results_dir
+        destination_dir = base / month
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(destination_dir / f"{task_id}.txt"))
+        return True
+    except Exception as exc:
+        if on_error is not None:
+            try:
+                on_error(exc)
+            except Exception:
+                pass
+        try:
+            src.unlink(missing_ok=True)
+        except Exception:
+            pass
+        return False

--- a/src/telegram-bridge.py
+++ b/src/telegram-bridge.py
@@ -64,7 +64,7 @@ from util_paths import channel_access_path, claude_home_path, write_private_text
 
 from workspace_default import resolve_workspace  # noqa: E402
 from presenter_mode import presenter_mode_active  # noqa: E402
-from task_archive import find_task_file  # noqa: E402
+from task_archive import archive_file as _archive_file_shared, find_task_file  # noqa: E402
 from single_instance import acquire as _single_instance_acquire  # noqa: E402
 import progress_stream  # noqa: E402  (opt-in owner progress streaming, SUTANDO_PROGRESS_STREAM=1)
 from vault_intercept import intercept_vault_commands, redact_vault_commands  # noqa: E402
@@ -189,25 +189,17 @@ def write_owner_activity(channel: str, summary: str, channel_id=None) -> None:
 
 
 def archive_file(src: "Path", kind: str, task_id: str) -> None:
-    """Move src into archive/<tasks|results>/YYYY-MM/ instead of deleting.
-    Silent on failure. Chi's ask 2026-04-18: archive tasks + results for
-    later pattern-mining / self-improvement analysis."""
-    try:
-        if not src.exists():
-            return
-        from datetime import datetime
-        import shutil
-        ym = datetime.now().strftime("%Y-%m")
-        base = ARCHIVE_TASKS_DIR if kind == "tasks" else ARCHIVE_RESULTS_DIR
-        dest_dir = base / ym
-        dest_dir.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
-    except Exception as e:
-        print(f"[Telegram] archive_file({kind}, {task_id}) failed: {e}")
-        try:
-            src.unlink(missing_ok=True)
-        except Exception:
-            pass
+    """Archive through the shared task/result filesystem policy."""
+    _archive_file_shared(
+        src,
+        kind,
+        task_id,
+        ARCHIVE_TASKS_DIR,
+        ARCHIVE_RESULTS_DIR,
+        on_error=lambda exc: print(
+            f"[Telegram] archive_file({kind}, {task_id}) failed: {exc}"
+        ),
+    )
 
 # Load access config
 ACCESS_FILE = channel_access_path("telegram")

--- a/tests/task-archive-policy.test.py
+++ b/tests/task-archive-policy.test.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Contract and adapter-wiring tests for shared task/result archival."""
+from __future__ import annotations
+
+import atexit
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+from task_archive import archive_file  # noqa: E402
+
+# telegram-bridge resolves access control at import time. Isolate that lookup
+# from the operator's real config before exec_module. The static adapter test
+# below names all three bridges, so the hermetic contract requires every
+# canonical channel path to be seeded.
+os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp(
+    prefix="task-archive-policy-config-"
+)
+_TMP_CONFIG = os.environ["CLAUDE_CONFIG_DIR"]
+atexit.register(lambda: shutil.rmtree(_TMP_CONFIG, ignore_errors=True))
+os.environ["HOME"] = _TMP_CONFIG
+os.environ["TELEGRAM_BOT_TOKEN"] = "test-token-not-real"
+_ACCESS_DIR = (
+    Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "telegram"
+)
+_ACCESS_DIR.mkdir(parents=True, exist_ok=True)
+(_ACCESS_DIR / "access.json").write_text('{"allowFrom": []}\n')
+_DISCORD_ACCESS_DIR = (
+    Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "discord"
+)
+_DISCORD_ACCESS_DIR.mkdir(parents=True, exist_ok=True)
+(_DISCORD_ACCESS_DIR / "access.json").write_text('{"allowFrom": []}\n')
+_SLACK_ACCESS_DIR = Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "slack"
+_SLACK_ACCESS_DIR.mkdir(parents=True, exist_ok=True)
+(_SLACK_ACCESS_DIR / "access.json").write_text('{"allowFrom": []}\n')
+
+_TELEGRAM_SPEC = importlib.util.spec_from_file_location(
+    "telegram_bridge_archive_policy",
+    REPO / "src" / "telegram-bridge.py",
+)
+_TELEGRAM_MODULE = importlib.util.module_from_spec(_TELEGRAM_SPEC)
+_TELEGRAM_SPEC.loader.exec_module(_TELEGRAM_MODULE)
+
+
+class TaskArchivePolicyTests(unittest.TestCase):
+    def test_tasks_and_results_use_injected_monthly_roots(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            tasks = root / "tasks-archive"
+            results = root / "results-archive"
+            fixed = datetime(2026, 8, 2)
+
+            task = root / "task-live.txt"
+            task.write_text("task body")
+            self.assertTrue(
+                archive_file(task, "tasks", "task-1", tasks, results, now=fixed)
+            )
+            self.assertEqual(
+                (tasks / "2026-08" / "task-1.txt").read_text(), "task body"
+            )
+
+            result = root / "result-live.txt"
+            result.write_text("result body")
+            self.assertTrue(
+                archive_file(result, "results", "task-2", tasks, results, now=fixed)
+            )
+            self.assertEqual(
+                (results / "2026-08" / "task-2.txt").read_text(), "result body"
+            )
+
+    def test_missing_source_is_a_noop(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self.assertFalse(
+                archive_file(
+                    root / "missing.txt",
+                    "tasks",
+                    "task-missing",
+                    root / "ta",
+                    root / "ra",
+                )
+            )
+            self.assertFalse((root / "ta").exists())
+
+    def test_failed_move_logs_and_removes_stale_live_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            source = root / "live.txt"
+            source.write_text("stale")
+            errors = []
+            with patch("task_archive.shutil.move", side_effect=OSError("disk")):
+                self.assertFalse(
+                    archive_file(
+                        source,
+                        "tasks",
+                        "task-3",
+                        root / "ta",
+                        root / "ra",
+                        on_error=errors.append,
+                    )
+                )
+            self.assertFalse(source.exists())
+            self.assertEqual(str(errors[0]), "disk")
+
+    def test_failed_move_contains_logger_and_unlink_failures(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            source = root / "live.txt"
+            source.write_text("stale")
+
+            def broken_logger(_exc):
+                raise RuntimeError("logger unavailable")
+
+            with patch("task_archive.shutil.move", side_effect=OSError("disk")):
+                with patch.object(Path, "unlink", side_effect=OSError("busy")):
+                    self.assertFalse(
+                        archive_file(
+                            source,
+                            "tasks",
+                            "task-4",
+                            root / "ta",
+                            root / "ra",
+                            on_error=broken_logger,
+                        )
+                    )
+            self.assertTrue(source.exists())
+
+    def test_telegram_adapter_executes_the_shared_writer(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _TELEGRAM_MODULE.ARCHIVE_TASKS_DIR = root / "tasks-archive"
+            _TELEGRAM_MODULE.ARCHIVE_RESULTS_DIR = root / "results-archive"
+            source = root / "result.txt"
+            source.write_text("delivered")
+            _TELEGRAM_MODULE.archive_file(source, "results", "task-telegram")
+            archived = list((root / "results-archive").glob("*/task-telegram.txt"))
+            self.assertEqual(len(archived), 1)
+            self.assertEqual(archived[0].read_text(), "delivered")
+
+    def test_python_adapters_delegate_instead_of_copying_policy(self):
+        for filename in (
+            "discord-bridge.py",
+            "slack-bridge.py",
+            "telegram-bridge.py",
+        ):
+            source = (REPO / "src" / filename).read_text()
+            self.assertIn(
+                "from task_archive import archive_file as _archive_file_shared",
+                source,
+            )
+            self.assertNotIn("shutil.move(str(src)", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/task-archive-policy.test.py
+++ b/tests/task-archive-policy.test.py
@@ -77,6 +77,25 @@ class TaskArchivePolicyTests(unittest.TestCase):
                 (results / "2026-08" / "task-2.txt").read_text(), "result body"
             )
 
+    def test_unknown_kind_raises_instead_of_misfiling(self):
+        """Review nit (@sonichi, #2505): `tasks if kind == "tasks" else results`
+        routed EVERY other value to results, so "task"/"Tasks"/a typo silently
+        misfiled the archive. Latent today (all three adapters pass literals)
+        but this is shared policy with three callers and gravity toward more."""
+        with tempfile.TemporaryDirectory() as d:
+            src = Path(d) / "x.txt"
+            src.write_text("x")
+            tasks = Path(d) / "at"
+            results = Path(d) / "ar"
+            with self.assertRaises(ValueError) as ctx:
+                archive_file(src, "task", "task-1", tasks, results)  # singular typo
+            msg = str(ctx.exception)
+            self.assertIn("tasks", msg)
+            self.assertIn("results", msg)
+            # and it must not have written anywhere
+            self.assertFalse(tasks.exists())
+            self.assertFalse(results.exists())
+
     def test_missing_source_is_a_noop(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
## What changed, and why?

Moves the shared task/result monthly archive policy into the existing
`src/task_archive.py` owner. Discord, Slack, and Telegram retain their adapter
function names and provider-specific log messages, but no longer maintain three
move/fallback recipes. The required AG2 Sparrow bundled copy is regenerated from
`src/` in the same commit.

## Review first

1. `src/task_archive.py::archive_file`
2. the three adapter wrappers
3. `tests/task-archive-policy.test.py`
4. the generated `packages/ag2-sparrow` mirror

## User behavior or bug proved

N/A — behavior-preserving `tidy:` refactor. Tests pin monthly destinations,
task/result root selection, missing sources, failed-move cleanup, and fail-open
logging.

## Feature/documentation consistency

No user-visible feature changed. `CLAUDE.md`, `AGENTS.md`,
`docs/architecture-boundaries.md`, and the generated source map document the
ownership rule.

## Before / after evidence

The content-dependency head had three archive move recipes:

```text
$ git grep -n 'shutil.move(str(src)' 35279a0a^ -- 'src/*bridge.py'
35279a0a^:src/discord-bridge.py:369:            shutil.move(str(src), str(archive_path(kind, task_id)))
35279a0a^:src/slack-bridge.py:213:        shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
35279a0a^:src/telegram-bridge.py:216:        shutil.move(str(src), str(dest_dir / f"{task_id}.txt"))
```

HEAD has one policy owner and three delegations:

```text
$ git grep -n '_archive_file_shared' 35279a0a -- 'src/*bridge.py'
35279a0a:src/discord-bridge.py:90:from task_archive import archive_file as _archive_file_shared, find_task_file  # noqa: E402
35279a0a:src/discord-bridge.py:351:    _archive_file_shared(
35279a0a:src/slack-bridge.py:81:from task_archive import archive_file as _archive_file_shared, find_task_file  # noqa: E402
35279a0a:src/slack-bridge.py:203:    _archive_file_shared(
35279a0a:src/telegram-bridge.py:64:from task_archive import archive_file as _archive_file_shared, find_task_file  # noqa: E402
35279a0a:src/telegram-bridge.py:205:    _archive_file_shared(
```

## Tests

```text
$ python3 tests/task-archive-policy.test.py
Ran 6 tests in 0.005s
OK

$ python3 tests/task-archive.test.py
Ran 5 tests in 0.010s
OK

$ python3 tests/ag2-sparrow-drift.test.py
PASS — ag2-sparrow bundled utils in sync with src/

$ python3 scripts/lint-hermetic-bridge-tests.py
lint-hermetic-bridge-tests: ok (64 bridge-importing tests scanned, 59 grandfathered, 0 mitigated)

$ git diff 35279a0a^ 35279a0a | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths clean)
```

The cumulative stack at `27b6e979` also completed `npm test` with exit 0:
657 TypeScript tests passed, followed by the complete Python suite.

## Live path

This PR remains draft while content-dependent changes are still open. After
#2504 and #2492 land, manually rebase onto `main` and run a real post-restart
bridge result round trip at the new exact head; that round trip exercises result
delivery followed by both result/task archival.

## Dependency / merge order

Content dependency: #2492. Both PRs target `main`; GitHub will not retarget this
PR automatically when #2492 lands.

Merge order: **#2504 → #2492 → this PR**. After each dependency lands, manually
rebase the next PR, rerun its full checks and live round trip, and request fresh
exact-head review.

## Edge cases and risk

- absent source returns false without creating directories;
- task and result archives use their respective roots;
- month selection is injectable and directly tested;
- a failed move removes the stale live file and cannot break delivery cleanup;
- an error logger that itself raises remains fail-open.

No migration, config, permission, prompt, or protocol change. Rollback is one
commit. No known follow-up within this concern.
