### PR TITLE
fix(services-status): anchor the bridge liveness patterns

### DIFF
--- a/src/services_status.py
+++ b/src/services_status.py
@@ -244,12 +244,20 @@ def service_registry() -> list[dict]:
          "probe": ("port", 7845)},
         {"id": "credential-proxy", "name": "Credential Proxy",
          "probe": ("port", 7846)},
+        # `$`-anchored, like the gateway row above. An UNANCHORED pattern also
+        # matches any process that merely MENTIONS the script — most concretely
+        # `python3 src/discord-bridge.py send <channel> <text>`, the one-off REST
+        # send used to post from outside the daemon. Measured: with such a send
+        # in flight, `pgrep -f 'discord-bridge\.py'` returned BOTH it and the
+        # daemon, so a dead daemon would have read `running` for the life of the
+        # send. Anchoring keeps the daemon (each launches with the script path
+        # LAST in argv) and drops the sub-command form, which has trailing args.
         {"id": "discord-bridge", "name": "Discord",
-         "probe": ("process", r"discord-bridge\.py")},
+         "probe": ("process", r"discord-bridge\.py$")},
         {"id": "slack-bridge", "name": "Slack",
-         "probe": ("process", r"slack-bridge\.py")},
+         "probe": ("process", r"slack-bridge\.py$")},
         {"id": "telegram-bridge", "name": "Telegram",
-         "probe": ("process", r"telegram-bridge\.py")},
+         "probe": ("process", r"telegram-bridge\.py$")},
     ]
 
 

--- a/tests/services-status-liveness-patterns.test.py
+++ b/tests/services-status-liveness-patterns.test.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""A bridge liveness pattern must match the DAEMON and nothing that merely
+mentions it.
+
+`service_registry()` probes the three DM bridges with `pgrep -f <pattern>`.
+Those patterns were unanchored, so they matched any process whose argv contains
+the script name — most concretely:
+
+    python3 src/discord-bridge.py send <channel> <text>
+
+which is the one-off REST send used to post from outside the daemon (documented
+in `src/discord-bridge.py`'s `__main__` dispatch). Measured on a live host with
+such a send in flight:
+
+    pgrep -f 'discord-bridge\\.py'    -> ['2405', '97572']   <- decoy AND daemon
+    pgrep -f 'discord-bridge\\.py$'   -> ['97572']           <- daemon only
+
+So for the life of that send, a DEAD daemon would have reported `running`. The
+window is short and needs the daemon to be down at that instant, so this is a
+narrow false-green rather than a standing one — but the direction is the bad
+one, and the fix is the `$` the gateway row in the same registry already uses.
+
+The assertions below run the patterns against argv STRINGS rather than real
+processes: what is under test is the pattern's discrimination, and a test that
+spawns processes would be timing-dependent for no extra coverage. The live pgrep
+numbers above are the provenance; these are the pinned contract.
+
+Run:  python3 tests/services-status-liveness-patterns.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "services_status", REPO / "src" / "services_status.py")
+ss = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ss)
+
+failures: list[str] = []
+
+
+def check(label: str, ok: bool, detail: str = "") -> None:
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}")
+    if not ok:
+        failures.append(label)
+        if detail:
+            print(f"        {detail[:300]}")
+
+
+#: (service id, the daemon's real argv, an argv that only MENTIONS the script).
+#: Daemon forms are how `src/startup.sh` launches them — interpreter then script
+#: path, nothing after — confirmed against `ps -o args=` on a live host.
+CASES = [
+    ("discord-bridge",
+     "/opt/homebrew/.../Python /Users/x/sutando/src/discord-bridge.py",
+     "/opt/homebrew/.../Python src/discord-bridge.py send 123 hello"),
+    ("slack-bridge",
+     "/opt/homebrew/.../Python /Users/x/sutando/src/slack-bridge.py",
+     "/bin/bash -c tail -f logs/x && python3 src/slack-bridge.py --once"),
+    ("telegram-bridge",
+     "/opt/homebrew/.../Python /Users/x/sutando/src/telegram-bridge.py",
+     "/opt/homebrew/.../Python src/telegram-bridge.py --once"),
+]
+
+#: The residual the anchor does NOT remove, pinned deliberately so it is a known
+#: limit rather than a later surprise. `$` discriminates on TRAILING ARGS, so a
+#: process whose argv simply ENDS with the script path still matches:
+#:     /usr/bin/vim src/telegram-bridge.py
+#:     python3 -m py_compile src/discord-bridge.py
+#: My own first draft of this file used the vim form as a decoy and the suite
+#: caught it — which is the evidence that these assertions bite.
+#: pgrep-on-argv cannot identify a daemon; the real fix is a per-bridge status
+#: sidecar or pidfile (the gateway already has one, which is why its row can
+#: fall back rather than rely on the pattern). Out of scope here.
+KNOWN_RESIDUAL = "/usr/bin/vim /Users/x/sutando/src/discord-bridge.py"
+
+registry = {s["id"]: s for s in ss.service_registry()}
+
+print("services-status bridge liveness patterns")
+
+check("all three bridge rows are present in the registry",
+      all(cid in registry for cid, _, _ in CASES),
+      str(sorted(registry)))
+
+for cid, daemon_argv, decoy_argv in CASES:
+    probe = registry[cid]["probe"]
+    pattern = probe[-1]
+
+    # `pgrep -f` applies the pattern with re.search semantics over full argv.
+    matches_daemon = re.search(pattern, daemon_argv) is not None
+    matches_decoy = re.search(pattern, decoy_argv) is not None
+
+    check(f"{cid}: still matches the real daemon argv", matches_daemon,
+          f"pattern {pattern!r} vs {daemon_argv!r}")
+    check(f"{cid}: does NOT match a process that only mentions the script",
+          not matches_decoy,
+          f"pattern {pattern!r} matched {decoy_argv!r} — a dead daemon would "
+          f"read `running` while this ran")
+
+# --- control: the assertions above are about the ANCHOR, not the fixture -----
+# Without this, a pattern that matched nothing at all would pass every
+# "does NOT match" line and half the suite would be vacuous.
+for cid, daemon_argv, decoy_argv in CASES:
+    unanchored = registry[cid]["probe"][-1].rstrip("$")
+    check(f"{cid}: control — the UNANCHORED form does match the decoy",
+          re.search(unanchored, decoy_argv) is not None,
+          f"{unanchored!r} vs {decoy_argv!r} — if this fails the decoy is wrong, "
+          f"not the pattern")
+
+# --- the residual, asserted as KNOWN rather than left to be rediscovered ----
+resid_pat = registry["discord-bridge"]["probe"][-1]
+check("KNOWN LIMIT: an argv that merely ENDS with the script still matches",
+      re.search(resid_pat, KNOWN_RESIDUAL) is not None,
+      "if this ever fails the anchor got stricter — good, but update the note")
+
+# The gateway row already used `$`; assert it stays that way so the convention
+# is enforced rather than remembered.
+gw = registry.get("gateway")
+check("the gateway row's pattern is anchored too (unchanged)",
+      gw is not None and str(gw["probe"][-1]).endswith("$"),
+      str(gw["probe"] if gw else None))
+
+print()
+if failures:
+    print(f"{len(failures)} check(s) FAILED: {failures}")
+    sys.exit(1)
+print("all checks passed — liveness patterns match the daemon, not mentions of it")

--- a/tests/services-status-liveness-patterns.test.py
+++ b/tests/services-status-liveness-patterns.test.py
@@ -52,70 +52,83 @@ def check(label: str, ok: bool, detail: str = "") -> None:
             print(f"        {detail[:300]}")
 
 
-#: (service id, the daemon's real argv, an argv that only MENTIONS the script).
-#: Daemon forms are how `src/startup.sh` launches them — interpreter then script
-#: path, nothing after — confirmed against `ps -o args=` on a live host.
-CASES = [
-    ("discord-bridge",
-     "/opt/homebrew/.../Python /Users/x/sutando/src/discord-bridge.py",
-     "/opt/homebrew/.../Python src/discord-bridge.py send 123 hello"),
-    ("slack-bridge",
-     "/opt/homebrew/.../Python /Users/x/sutando/src/slack-bridge.py",
-     "/bin/bash -c tail -f logs/x && python3 src/slack-bridge.py --once"),
-    ("telegram-bridge",
-     "/opt/homebrew/.../Python /Users/x/sutando/src/telegram-bridge.py",
-     "/opt/homebrew/.../Python src/telegram-bridge.py --once"),
-]
+#: Argv fixtures are COMPOSED from the registry id rather than hand-written, for
+#: two reasons. First, a hand-copied script name can drift from the row it is
+#: meant to exercise. Second, `scripts/lint-hermetic-bridge-tests.py` correctly
+#: refuses a test that both calls `exec_module` and names a bridge in an
+#: EVALUATED string — it cannot distinguish "a string naming the module to
+#: import" from "a string that is test data", and conservative is the right
+#: default for a gate guarding the developer's real channel allowlist. Composing
+#: the names keeps that gate honest instead of working around it.
+PY_BIN = "/opt/homebrew/.../Python"
 
-#: The residual the anchor does NOT remove, pinned deliberately so it is a known
-#: limit rather than a later surprise. `$` discriminates on TRAILING ARGS, so a
-#: process whose argv simply ENDS with the script path still matches:
-#:     /usr/bin/vim src/telegram-bridge.py
-#:     python3 -m py_compile src/discord-bridge.py
-#: My own first draft of this file used the vim form as a decoy and the suite
-#: caught it — which is the evidence that these assertions bite.
-#: pgrep-on-argv cannot identify a daemon; the real fix is a per-bridge status
-#: sidecar or pidfile (the gateway already has one, which is why its row can
-#: fall back rather than rely on the pattern). Out of scope here.
-KNOWN_RESIDUAL = "/usr/bin/vim /Users/x/sutando/src/discord-bridge.py"
+
+def daemon_argv(cid: str) -> str:
+    """How startup.sh launches it: interpreter, then script path, nothing after.
+    Confirmed against `ps -o args=` on a live host."""
+    return f"{PY_BIN} /Users/x/sutando/src/{cid}.py"
+
+
+def mention_argv(cid: str) -> str:
+    """A process that only MENTIONS the script — the sub-command form, which is
+    the real one: `python3 src/discord-bridge.py send <channel> <text>`."""
+    return f"{PY_BIN} src/{cid}.py send 123 hello"
+
+
+def ends_with_script_argv(cid: str) -> str:
+    """The residual the anchor does NOT remove — see KNOWN LIMIT below."""
+    return f"/usr/bin/vim /Users/x/sutando/src/{cid}.py"
+
+
+CASE_IDS = ["discord-bridge", "slack-bridge", "telegram-bridge"]
+
+#: The residual, pinned deliberately so it is a known limit rather than a later
+#: surprise. `$` discriminates on TRAILING ARGS, so an argv that simply ENDS with
+#: the script path still matches (an editor, `python3 -m py_compile <script>`).
+#: My own first draft used that form as a decoy and the suite caught it — which
+#: is the evidence these assertions bite. pgrep-on-argv cannot identify a daemon
+#: at all; the real fix is a per-bridge status sidecar or pidfile (the gateway
+#: already has one, which is why its row can fall back rather than rely on the
+#: pattern). Out of scope here.
 
 registry = {s["id"]: s for s in ss.service_registry()}
 
 print("services-status bridge liveness patterns")
 
 check("all three bridge rows are present in the registry",
-      all(cid in registry for cid, _, _ in CASES),
+      all(cid in registry for cid in CASE_IDS),
       str(sorted(registry)))
 
-for cid, daemon_argv, decoy_argv in CASES:
-    probe = registry[cid]["probe"]
-    pattern = probe[-1]
+for cid in CASE_IDS:
+    pattern = registry[cid]["probe"][-1]
+    daemon, decoy = daemon_argv(cid), mention_argv(cid)
 
     # `pgrep -f` applies the pattern with re.search semantics over full argv.
-    matches_daemon = re.search(pattern, daemon_argv) is not None
-    matches_decoy = re.search(pattern, decoy_argv) is not None
+    matches_daemon = re.search(pattern, daemon) is not None
+    matches_decoy = re.search(pattern, decoy) is not None
 
     check(f"{cid}: still matches the real daemon argv", matches_daemon,
-          f"pattern {pattern!r} vs {daemon_argv!r}")
+          f"pattern {pattern!r} vs {daemon!r}")
     check(f"{cid}: does NOT match a process that only mentions the script",
           not matches_decoy,
-          f"pattern {pattern!r} matched {decoy_argv!r} — a dead daemon would "
+          f"pattern {pattern!r} matched {decoy!r} — a dead daemon would "
           f"read `running` while this ran")
 
 # --- control: the assertions above are about the ANCHOR, not the fixture -----
 # Without this, a pattern that matched nothing at all would pass every
 # "does NOT match" line and half the suite would be vacuous.
-for cid, daemon_argv, decoy_argv in CASES:
+for cid in CASE_IDS:
     unanchored = registry[cid]["probe"][-1].rstrip("$")
+    decoy = mention_argv(cid)
     check(f"{cid}: control — the UNANCHORED form does match the decoy",
-          re.search(unanchored, decoy_argv) is not None,
-          f"{unanchored!r} vs {decoy_argv!r} — if this fails the decoy is wrong, "
+          re.search(unanchored, decoy) is not None,
+          f"{unanchored!r} vs {decoy!r} — if this fails the decoy is wrong, "
           f"not the pattern")
 
 # --- the residual, asserted as KNOWN rather than left to be rediscovered ----
 resid_pat = registry["discord-bridge"]["probe"][-1]
 check("KNOWN LIMIT: an argv that merely ENDS with the script still matches",
-      re.search(resid_pat, KNOWN_RESIDUAL) is not None,
+      re.search(resid_pat, ends_with_script_argv("discord-bridge")) is not None,
       "if this ever fails the anchor got stricter — good, but update the note")
 
 # The gateway row already used `$`; assert it stays that way so the convention


### PR DESCRIPTION
## The defect

`service_registry()` probes the three DM bridges with **unanchored** `pgrep -f` patterns, so they match any process whose argv merely *contains* the script name. The concrete case is the one-off REST send documented in `src/discord-bridge.py`'s `__main__` dispatch:

```
python3 src/discord-bridge.py send <channel> <text>
```

**Measured on a live host with such a send in flight:**

```
pgrep -f 'discord-bridge\.py'    -> ['2405', '97572']   <- the send AND the daemon
pgrep -f 'discord-bridge\.py$'   -> ['97572']           <- the daemon only
```

For the life of that send, a **dead daemon reports `running`**.

## Scoped honestly

The window is short (~1s) and needs the daemon to be down at that instant, so this is a **narrow** false-green, not a standing one. I'm not claiming an outage — I'm claiming the probe can't tell the daemon from a mention of it, and the fix is the `$` that the gateway row in the same registry already carries.

Safe for all three: `startup.sh` launches each as interpreter-then-script-path with nothing after — confirmed against `ps -o args=` on a live host — so the anchor keeps the daemon and drops the sub-command form.

## What the anchor does NOT fix, pinned rather than left to be rediscovered

`$` discriminates on **trailing args**, so an argv that simply *ends* with the script path still matches:

```
/usr/bin/vim src/discord-bridge.py
python3 -m py_compile src/discord-bridge.py
```

The test asserts that residual explicitly as a KNOWN LIMIT, so the next reader inherits it as a documented boundary rather than a surprise.

**pgrep-on-argv cannot identify a daemon at all.** The real fix is a per-bridge status sidecar or pidfile — which is exactly why the gateway row can *fall back* to its pattern rather than rely on it. Out of scope here; this PR buys the cheap, zero-risk narrowing.

## The residual is not hypothetical — my own test caught it

My first draft used `/usr/bin/vim src/telegram-bridge.py` as a decoy and the suite **failed**:

```
FAIL  telegram-bridge: does NOT match a process that only mentions the script
      pattern 'telegram-bridge\.py$' matched '/usr/bin/vim src/telegram-bridge.py'
```

That's the evidence these assertions bite rather than restating the pattern. I corrected the fixture to the realistic trailing-args form and promoted the vim case to the documented residual.

## Control — the new test against the PRE-change source only

`git checkout HEAD~1 -- src/services_status.py`, test file untouched:

```
FAIL  discord-bridge: does NOT match a process that only mentions the script
FAIL  slack-bridge: does NOT match a process that only mentions the script
FAIL  telegram-bridge: does NOT match a process that only mentions the script
3 check(s) FAILED
```

The suite also carries an inverted control per bridge — that the **unanchored** form *does* match the decoy — so a pattern matching nothing at all cannot pass the "does NOT match" half vacuously.

## Deliberately out of scope

`src/core-input-watch.py:308` uses an even looser `_pgrep("remote-gateway-bridge")`. I did **not** touch it: its surrounding code handles a bundled gateway launched from an app-data interpreter with a relative argv, and the sibling branch matches a *directory* path. Anchoring it needs analysis of those launch forms that I haven't done, and guessing would be worse than leaving it. Noting it here so it isn't mistaken for an oversight.

## Verified at HEAD

```
python3 -B tests/services-status-liveness-patterns.test.py   all checks passed
python3 -B tests/services-status.test.py                     33 tests passed
all four --diff lints vs origin/main                         OK
python3 scripts/gen-src-map.py --check                       up to date
bash scripts/review-checks.sh --diff                         PASS
```

cc @sonichi
