### PR TITLE
fix(health-check): a fresh quota-state.json was read as proof the CORE is routed

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2562,6 +2562,49 @@ def _marker_predates_running_core(marker: dict) -> bool:
     return started < launched - margin
 
 
+def _local_core_socket(workspace: Optional[Path] = None) -> Optional[str]:
+    """This HOST's core tmux socket, or None if this host has no live heartbeat.
+
+    Deliberately NOT `_live_core_socket()`. That resolver globs every synced
+    `state/cores/*.alive` and takes the freshest, which the workspace contract
+    permits to be ANOTHER MACHINE's — the vault carries one heartbeat per host.
+    A reviewer reproduced it with two fresh records: the local one at mtime N-1
+    and a peer at N, and the probe targeted `/tmp/peer-core.sock`. That socket
+    does not exist locally, so the tri-state correctly degraded to None — which
+    silently suppresses the very warning this check exists to raise. Correct
+    behaviour, wrong target, false green.
+
+    Host matching uses `_local_host_labels()` rather than one label, because the
+    reader and the launchers do not share a host-label contract (see that
+    function). Returning None when this host has no fresh heartbeat is right:
+    "no local core is running" is not evidence that a core bypasses the proxy.
+    """
+    if workspace is None:
+        workspace = WORKSPACE_DIR
+    cores_dir = workspace / "state" / "cores"
+    if not cores_dir.is_dir():
+        return None
+    labels = _local_host_labels()
+    now = time.time()
+    best_mtime, best_socket = None, None
+    for alive_file in cores_dir.glob("*.alive"):
+        if alive_file.stem not in labels:
+            continue                      # another machine's heartbeat
+        try:
+            mtime = alive_file.stat().st_mtime
+            if now - mtime >= 90.0:
+                continue                  # stale — not a live core
+            payload = json.loads(alive_file.read_text())
+            if not isinstance(payload, dict):
+                continue
+            sock = payload.get("socket")
+        except (OSError, ValueError):
+            continue
+        if isinstance(sock, str) and sock and (best_mtime is None or mtime > best_mtime):
+            best_mtime, best_socket = mtime, sock
+    return best_socket
+
+
 def core_env_has_proxy_url(
     socket_path: Optional[str] = None,
     session: str = "sutando-core",
@@ -2614,7 +2657,9 @@ def core_env_has_proxy_url(
                 ["ps", "eww", "-o", "command=", "-p", str(pid)],
                 capture_output=True, text=True, timeout=15,
             )
-    sock = socket_path or _live_core_socket()
+    sock = socket_path or _local_core_socket()
+    if not sock:
+        return None                       # no live LOCAL core -> unknown, not a bypass
     # `-s` = every pane in the SESSION, not just the current window's.
     panes = tmux_runner(sock, "list-panes", "-s", "-t", f"={session}", "-F", "#{pane_pid}")
     if panes is None or getattr(panes, "returncode", 1) != 0:
@@ -2624,7 +2669,22 @@ def core_env_has_proxy_url(
         return None
     # Identify the core by argv, not by position: `--name <session>` is what
     # start-cli.sh passes and no sibling window carries it.
-    marker = f"--name {session}"
+    #
+    # TOKEN equality, never substring. `f"--name {session}" in argv` also matches
+    # `--name sutando-core-watcher`, so a prefix-named sibling in the same session
+    # was accepted as the core (john-the-dev, reproduced on a sole pane: returned
+    # True where the contract is None). This is the SAME lookalike class as the
+    # `ANTHROPIC_BASE_URL_OLD` control already in the suite — I guarded the env-var
+    # axis and then introduced the identical hole on the session-name axis.
+    def _names_this_session(argv: str) -> bool:
+        toks = argv.split()
+        for i, t in enumerate(toks):
+            if t == "--name" and i + 1 < len(toks) and toks[i + 1] == session:
+                return True
+            if t == f"--name={session}":  # the =-joined spelling
+                return True
+        return False
+
     matches = []
     for pid in pids:
         try:
@@ -2634,7 +2694,7 @@ def core_env_has_proxy_url(
         if proc is None or getattr(proc, "returncode", 1) != 0:
             continue                      # this pane vanished; keep looking
         out = proc.stdout or ""
-        if marker in out:
+        if _names_this_session(out):
             matches.append(out)
     # Zero matches: the core is not in this session (or ps could not read any pane).
     # More than one: ambiguous, and an ambiguous session is not evidence of a bypass.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2562,6 +2562,69 @@ def _marker_predates_running_core(marker: dict) -> bool:
     return started < launched - margin
 
 
+def core_env_has_proxy_url(
+    socket_path: Optional[str] = None,
+    session: str = "sutando-core",
+    tmux_runner=None,
+    ps_runner=None,
+) -> Optional[bool]:
+    """Whether the RUNNING core process carries ANTHROPIC_BASE_URL in its environment.
+
+    ``True``  -> the core is routed through the credential proxy.
+    ``False`` -> it demonstrably is NOT (its environment was read, and the var is absent).
+    ``None``  -> could not be determined. **Never collapse None into False**: an
+                 unreadable environment is not evidence of a bypass, and a warning
+                 manufactured from it would be the same defect this check is fixing,
+                 pointed the other way.
+
+    Why this exists: ``quota-state.json`` is written by the credential proxy, not by
+    the core, so a FRESH file only proves *something* routed through the proxy — not
+    that the core did. Measured on 2026-08-02: one throwaway ``claude -p`` run with
+    the variable set refreshed the file and flipped this check from a truthful
+    ``warn`` (18h stale) to ``ok`` for the whole 6h staleness window, while the
+    production core was exactly as unrouted as before. Freshness is a property of the
+    artifact; routing is a property of the process.
+
+    The pid comes from ``tmux list-panes -F '#{pane_pid}'`` rather than ``pgrep``.
+    ``pgrep -f claude`` matches any argv containing the string — including the shell
+    running the check — and macOS ``pgrep -a`` lists ancestors, not argv. The pane pid
+    is the process tmux actually launched: verified on this host as pid 6648 ==
+    ``claude --name sutando-core``.
+
+    Both subprocess calls are injectable so the contract is testable without a live
+    core; production passes neither.
+    """
+    tmux_runner = tmux_runner or (lambda sock, *a: _run_tmux(sock, *a))
+    if ps_runner is None:
+        def ps_runner(pid):
+            return subprocess.run(
+                ["ps", "eww", "-o", "command=", "-p", str(pid)],
+                capture_output=True, text=True, timeout=15,
+            )
+    sock = socket_path or _live_core_socket()
+    panes = tmux_runner(sock, "list-panes", "-t", f"={session}", "-F", "#{pane_pid}")
+    if panes is None or getattr(panes, "returncode", 1) != 0:
+        return None                       # no such session / tmux unavailable
+    pid = (panes.stdout or "").split()
+    if not pid or not pid[0].isdigit():
+        return None
+    try:
+        proc = ps_runner(pid[0])
+    except Exception:                     # noqa: BLE001 — a probe failure is "unknown"
+        return None
+    if proc is None or getattr(proc, "returncode", 1) != 0:
+        return None
+    tokens = (proc.stdout or "").split()
+    # `ps eww` prints argv THEN the environment. On a process whose env we are not
+    # permitted to read it prints argv alone, which contains no KEY=VALUE pairs — and
+    # "no pairs" is indistinguishable from "an empty environment". Requiring at least
+    # one pair is what keeps an unreadable env reporting None instead of False.
+    env_pairs = [t for t in tokens if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", t)]
+    if not env_pairs:
+        return None
+    return any(t.startswith("ANTHROPIC_BASE_URL=") for t in env_pairs)
+
+
 def _agent_activity_age() -> "float | None":
     """Seconds since the agent last recorded loop activity, or None if unknown.
 
@@ -2635,6 +2698,21 @@ def check_quota_telemetry(proxy_status: str) -> dict:
             quota_age = time.time() - path.stat().st_mtime
             age_min = int(quota_age / 60)
             check["detail"] = f"quota state present (updated {age_min}m ago)"
+            # A FRESH file is not proof the CORE routed — the proxy writes this file
+            # for whatever talks to it. Only a demonstrated absence downgrades; None
+            # (env unreadable) leaves the fresh reading alone.
+            if quota_age <= QUOTA_STATE_STALE_SEC and not _runtime_may_skip_proxy() \
+                    and core_env_has_proxy_url() is False:
+                check["status"] = "warn"
+                check["detail"] = (
+                    f"quota state is fresh ({age_min}m) but the RUNNING core has no "
+                    "ANTHROPIC_BASE_URL in its environment, so the core is not routed "
+                    "through the proxy — something else produced that file (a one-off "
+                    "`claude -p`, another core, a manual probe). Quota-based budgeting "
+                    "is reading numbers this core did not generate. Relaunch the core "
+                    "via src/agent/start-cli.sh with the proxy listening on 7846."
+                )
+                return check
         except OSError:
             # Degrade to the less precise detail rather than raising — and with
             # no age there is nothing to call stale, so never warn from here.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2585,11 +2585,24 @@ def core_env_has_proxy_url(
     production core was exactly as unrouted as before. Freshness is a property of the
     artifact; routing is a property of the process.
 
-    The pid comes from ``tmux list-panes -F '#{pane_pid}'`` rather than ``pgrep``.
-    ``pgrep -f claude`` matches any argv containing the string — including the shell
-    running the check — and macOS ``pgrep -a`` lists ancestors, not argv. The pane pid
-    is the process tmux actually launched: verified on this host as pid 6648 ==
-    ``claude --name sutando-core``.
+    The pid comes from tmux rather than ``pgrep``: ``pgrep -f claude`` matches any argv
+    containing the string — including the shell running this check — and macOS
+    ``pgrep -a`` lists ancestors, not argv.
+
+    But a pane pid is only useful if it is the CORE's pane. The first version of this
+    helper targeted the session (``list-panes -t =sutando-core``), which tmux resolves
+    to that session's **current window** — and this repo deliberately keeps sibling
+    windows (gateway, monitor) in the same session, healing window-scoped precisely so
+    they survive (`src/agent/claude/cli/start-cli.sh`). A reviewer built the case and it
+    reproduced: with the ``gateway`` window active, the production command returned the
+    gateway's pid, so the helper would report on a sibling's environment — false green or
+    false warning, independent of the real core. Window NAME is no discriminator either;
+    on this host the core's window is auto-named ``2.1.220`` after the claude version.
+
+    So enumerate EVERY pane in the session (``list-panes -s``) and identify the core by
+    what it actually is: the process whose argv carries ``--name <session>``, which is
+    exactly how `start-cli.sh` launches it. Zero matches or more than one -> ``None``;
+    an ambiguous session is not evidence of a bypass.
 
     Both subprocess calls are injectable so the contract is testable without a live
     core; production passes neither.
@@ -2602,19 +2615,32 @@ def core_env_has_proxy_url(
                 capture_output=True, text=True, timeout=15,
             )
     sock = socket_path or _live_core_socket()
-    panes = tmux_runner(sock, "list-panes", "-t", f"={session}", "-F", "#{pane_pid}")
+    # `-s` = every pane in the SESSION, not just the current window's.
+    panes = tmux_runner(sock, "list-panes", "-s", "-t", f"={session}", "-F", "#{pane_pid}")
     if panes is None or getattr(panes, "returncode", 1) != 0:
         return None                       # no such session / tmux unavailable
-    pid = (panes.stdout or "").split()
-    if not pid or not pid[0].isdigit():
+    pids = [p for p in (panes.stdout or "").split() if p.isdigit()]
+    if not pids:
         return None
-    try:
-        proc = ps_runner(pid[0])
-    except Exception:                     # noqa: BLE001 — a probe failure is "unknown"
+    # Identify the core by argv, not by position: `--name <session>` is what
+    # start-cli.sh passes and no sibling window carries it.
+    marker = f"--name {session}"
+    matches = []
+    for pid in pids:
+        try:
+            proc = ps_runner(pid)
+        except Exception:                 # noqa: BLE001 — a probe failure is "unknown"
+            return None
+        if proc is None or getattr(proc, "returncode", 1) != 0:
+            continue                      # this pane vanished; keep looking
+        out = proc.stdout or ""
+        if marker in out:
+            matches.append(out)
+    # Zero matches: the core is not in this session (or ps could not read any pane).
+    # More than one: ambiguous, and an ambiguous session is not evidence of a bypass.
+    if len(matches) != 1:
         return None
-    if proc is None or getattr(proc, "returncode", 1) != 0:
-        return None
-    tokens = (proc.stdout or "").split()
+    tokens = matches[0].split()
     # `ps eww` prints argv THEN the environment. On a process whose env we are not
     # permitted to read it prints argv alone, which contains no KEY=VALUE pairs — and
     # "no pairs" is indistinguishable from "an empty environment". Requiring at least
@@ -2646,7 +2672,7 @@ def _agent_activity_age() -> "float | None":
         return None
 
 
-def check_quota_telemetry(proxy_status: str) -> dict:
+def check_quota_telemetry(proxy_status: str, core_env_prober=None) -> dict:
     """Warn when the credential proxy is up but producing no quota state.
 
     quota-state.json is written by the proxy from the quota headers on
@@ -2688,6 +2714,13 @@ def check_quota_telemetry(proxy_status: str) -> dict:
     it stays silent, and a host that never wired at all still takes the
     absent-file branch below.
     """
+    # `core_env_prober` is an injectable seam, defaulting to the real probe. It exists
+    # because the first version of this branch called `core_env_has_proxy_url()`
+    # unconditionally: the existing 39-case suite overrides WORKSPACE_DIR but had no way
+    # to override THAT, so its fixtures escaped into the developer's live tmux, observed
+    # the real (unrouted) core, and 3 of 39 flipped to `warn`. A required suite whose
+    # result depends on ambient host state is worse than the bug it guards -- and CI,
+    # having no live core, would have stayed green while developer hosts failed.
     check = {"name": "quota-telemetry", "status": "ok"}
     if proxy_status != "ok":
         check["detail"] = "credential proxy not running — quota telemetry not expected"
@@ -2701,8 +2734,9 @@ def check_quota_telemetry(proxy_status: str) -> dict:
             # A FRESH file is not proof the CORE routed — the proxy writes this file
             # for whatever talks to it. Only a demonstrated absence downgrades; None
             # (env unreadable) leaves the fresh reading alone.
+            probe = core_env_prober or core_env_has_proxy_url
             if quota_age <= QUOTA_STATE_STALE_SEC and not _runtime_may_skip_proxy() \
-                    and core_env_has_proxy_url() is False:
+                    and probe() is False:
                 check["status"] = "warn"
                 check["detail"] = (
                     f"quota state is fresh ({age_min}m) but the RUNNING core has no "

--- a/tests/health-check-quota-telemetry.test.py
+++ b/tests/health-check-quota-telemetry.test.py
@@ -47,6 +47,16 @@ class TestQuotaTelemetryCheck(unittest.TestCase):
         self.ws = Path(self._tmp.name)
         (self.ws / "state").mkdir(parents=True, exist_ok=True)
         self.hc.WORKSPACE_DIR = self.ws
+        # ISOLATE THE HOST. The fresh-file branch consults the RUNNING core's
+        # environment, so without this every fixture below escapes its tmpdir into
+        # the developer's live tmux and its verdict depends on whether that machine
+        # happens to have a routed core. Three cases failed exactly that way on a
+        # host with a running unrouted core while CI — which has no live core —
+        # stayed green. `None` is the neutral answer ("could not determine"), which
+        # by contract changes no existing result, so these 39 cases keep testing
+        # what they were written to test. The True/False/None branch itself is
+        # covered explicitly in TestCoreEnvBranch below.
+        self.hc.core_env_has_proxy_url = lambda *a, **k: None
 
     def tearDown(self):
         self._tmp.cleanup()
@@ -696,6 +706,61 @@ class TestQuotaTelemetryCheck(unittest.TestCase):
             r = self.hc.check_quota_telemetry("ok")
         self.assertEqual(r["status"], "ok")
         self.assertEqual(r["detail"], "quota state present")
+
+
+
+
+class TestCoreEnvBranch(unittest.TestCase):
+    """The fresh-quota branch, driven through the injectable prober.
+
+    A fresh `quota-state.json` used to be read as proof the core was routed. It is
+    not: the proxy writes that file for whatever talks to it, so one throwaway
+    `claude -p` refreshes it and buys a full staleness window of false green over a
+    core that never routed. These three cases pin the only correct mapping, and the
+    None case is the one that matters most — an unreadable environment must leave
+    the existing verdict untouched rather than manufacture a warning.
+    """
+
+    def setUp(self):
+        self.hc = _load_health_check()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+        (self.ws / "state").mkdir(parents=True, exist_ok=True)
+        self.hc.WORKSPACE_DIR = self.ws
+        (self.ws / "state" / "quota-state.json").write_text('{"remaining_pct": 42}')
+        self.hc.core_env_has_proxy_url = lambda *a, **k: None  # never reached; guards escape
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_probe_false_downgrades_a_fresh_file_to_warn(self):
+        r = self.hc.check_quota_telemetry("ok", core_env_prober=lambda: False)
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("ANTHROPIC_BASE_URL", r["detail"])
+        # The detail must say WHOSE environment, or the reader cannot act on it.
+        self.assertIn("RUNNING core", r["detail"])
+
+    def test_probe_true_leaves_a_fresh_file_ok(self):
+        r = self.hc.check_quota_telemetry("ok", core_env_prober=lambda: True)
+        self.assertEqual(r["status"], "ok")
+        self.assertNotIn("not routed", r["detail"])
+
+    def test_probe_none_leaves_a_fresh_file_ok(self):
+        """Unknown is not a bypass. This is the guard against the mirror-image bug."""
+        r = self.hc.check_quota_telemetry("ok", core_env_prober=lambda: None)
+        self.assertEqual(r["status"], "ok")
+        self.assertNotIn("not routed", r["detail"])
+
+    def test_a_stale_file_is_unaffected_by_the_probe(self):
+        """The probe gates the FRESH branch only — a stale file still warns on its own."""
+        p = self.ws / "state" / "quota-state.json"
+        past = time.time() - (self.hc.QUOTA_STATE_STALE_SEC + 60)
+        os.utime(p, (past, past))
+        status_p = self.hc.status_read_path("core-status.json", self.ws)
+        status_p.write_text('{"status": "idle"}')
+        r = self.hc.check_quota_telemetry("ok", core_env_prober=lambda: True)
+        self.assertEqual(r["status"], "warn")
+        self.assertIn("stale", r["detail"])
 
 
 if __name__ == "__main__":

--- a/tests/quota-telemetry-core-env.test.py
+++ b/tests/quota-telemetry-core-env.test.py
@@ -127,6 +127,57 @@ check("control: the pane pid is passed through to ps, not hardcoded",
                                 ps_runner=lambda pid: R(0, f"{ARGV} {ENV_WITH_PROXY}")
                                 if str(pid) == "424242" else R(0, ARGV)) is True)
 
+# --- the sibling-window case (PR #2530 review, john-the-dev P1) ---------------
+# `list-panes -t =<session>` resolves to the session's CURRENT WINDOW, and this repo
+# deliberately keeps sibling windows (gateway, monitor) in the core's session — it heals
+# window-scoped so they survive. With `gateway` active, the original code returned the
+# GATEWAY's pid and reported on its environment. The reviewer built that case on a real
+# tmux and it reproduced. Window NAME is no discriminator either: on this host the core's
+# window is auto-named after the claude version (`2.1.220`).
+GATEWAY_ARGV = "node /Users/x/sutando/src/remote-gateway-bridge.js"
+
+def multi_pane(order, core_env=ENV_NO_PROXY, gw_env=ENV_WITH_PROXY):
+    """order = list of 'core'/'gateway'; the FIRST is what the old code would have read."""
+    pids = {"core": "6648", "gateway": "7777"}
+    listing = R(0, "\n".join(pids[k] for k in order) + "\n")
+    def ps(pid):
+        if str(pid) == pids["core"]:
+            return R(0, f"{ARGV} {core_env}")
+        return R(0, f"{GATEWAY_ARGV} {gw_env}")
+    return hc.core_env_has_proxy_url(socket_path="/tmp/probe.sock",
+                                     tmux_runner=lambda sock, *a: listing,
+                                     ps_runner=ps)
+
+check("sibling window listed FIRST does not hijack the verdict",
+      multi_pane(["gateway", "core"]) is False,
+      "the gateway carries ANTHROPIC_BASE_URL and the core does not; answering True "
+      "would be reporting on a sibling's environment")
+
+check("same session, core listed first — still the core's answer",
+      multi_pane(["core", "gateway"]) is False)
+
+check("and it is the CORE's value that is returned, not merely 'not the gateway's'",
+      multi_pane(["gateway", "core"], core_env=ENV_WITH_PROXY, gw_env=ENV_NO_PROXY) is True)
+
+check("no pane carries the --name marker -> None (core not in this session)",
+      hc.core_env_has_proxy_url(socket_path="/tmp/probe.sock",
+                                tmux_runner=lambda sock, *a: R(0, "7777\n"),
+                                ps_runner=lambda pid: R(0, f"{GATEWAY_ARGV} {ENV_WITH_PROXY}")) is None)
+
+check("TWO panes both claiming the marker -> None (ambiguous is not evidence)",
+      hc.core_env_has_proxy_url(socket_path="/tmp/probe.sock",
+                                tmux_runner=lambda sock, *a: R(0, "6648\n6649\n"),
+                                ps_runner=lambda pid: R(0, f"{ARGV} {ENV_NO_PROXY}")) is None)
+
+# control: the tmux call must enumerate the whole SESSION, not the active window.
+_seen_args = {}
+hc.core_env_has_proxy_url(socket_path="/tmp/probe.sock",
+                          tmux_runner=lambda sock, *a: (_seen_args.setdefault("a", a), R(0, "6648\n"))[1],
+                          ps_runner=lambda pid: R(0, f"{ARGV} {ENV_NO_PROXY}"))
+check("control: tmux is invoked with -s (every pane in the session)",
+      "-s" in _seen_args.get("a", ()),
+      f"args were {_seen_args.get('a')!r} — without -s tmux returns only the current window")
+
 print()
 if failures:
     print(f"{len(failures)} check(s) FAILED: {failures}")

--- a/tests/quota-telemetry-core-env.test.py
+++ b/tests/quota-telemetry-core-env.test.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""A fresh `quota-state.json` is not evidence that the CORE is proxy-routed.
+
+`check_quota_telemetry` warned only when the file was STALE. But the file is written
+by the credential proxy on behalf of whatever talks to it — not by the core — so a
+fresh file proves only that *something* routed. Measured on this host 2026-08-02:
+
+    before a one-off `ANTHROPIC_BASE_URL=... claude -p ...`
+        quota-telemetry  warn  "quota state is 18h stale while the agent is working"
+    after that single throwaway request
+        quota-telemetry  ok    "quota state present (updated 3m ago)"
+
+The production core was equally unrouted in both readings, and `QUOTA_STATE_STALE_SEC`
+is 6h, so one probe bought six hours of false green. `core_env_has_proxy_url()` closes
+that by asking the running process instead of the artifact.
+
+The tri-state is the whole design, so it is what these assertions pin:
+
+    True   env read, variable present   -> routed
+    False  env read, variable absent    -> NOT routed (the only downgrading answer)
+    None   env not readable at all      -> unknown; must NEVER become False
+
+`ps eww` prints argv and then the environment, and prints argv ALONE for a process
+whose environment this user may not read. "No KEY=VALUE tokens" is therefore
+indistinguishable from "an empty environment", which is why the helper requires at
+least one pair before it will answer False. Without that gate a permission failure
+would manufacture exactly the false warning this check exists to remove — the same
+defect, pointed the other way.
+
+Run:  python3 tests/quota-telemetry-core-env.test.py
+Exit: 0 on pass, 1 on fail.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hc)
+
+failures: list[str] = []
+
+
+def check(label: str, ok: bool, detail: str = "") -> None:
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}")
+    if not ok:
+        failures.append(label)
+        if detail:
+            print(f"        {detail[:300]}")
+
+
+class R:
+    """Minimal CompletedProcess stand-in (returncode + stdout is the whole contract)."""
+
+    def __init__(self, returncode=0, stdout=""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+#: A real `ps eww` line: argv first, then the environment. Taken from this host's own
+#: core (pid 6648) and trimmed — the shape is what matters, not the values.
+ARGV = "claude --name sutando-core --model opus --remote-control Sutando"
+ENV_NO_PROXY = "SUTANDO_CORE_SESSION=1 SUTANDO_CORE_RUNTIME=claude SUTANDO_HOST_LABEL=Chis-MacBook-Pro"
+ENV_WITH_PROXY = ENV_NO_PROXY + " ANTHROPIC_BASE_URL=http://localhost:7846"
+
+
+def probe(panes: R | None, ps: R | None):
+    return hc.core_env_has_proxy_url(
+        socket_path="/tmp/probe.sock",
+        tmux_runner=lambda sock, *a: panes,
+        ps_runner=lambda pid: ps,
+    )
+
+
+print("quota-telemetry: core env probe (tri-state)")
+
+check("env carries ANTHROPIC_BASE_URL -> True",
+      probe(R(0, "6648\n"), R(0, f"{ARGV} {ENV_WITH_PROXY}")) is True)
+
+check("env read and variable ABSENT -> False (the only downgrading answer)",
+      probe(R(0, "6648\n"), R(0, f"{ARGV} {ENV_NO_PROXY}")) is False)
+
+# --- every unknown must be None, never False -------------------------------------
+check("argv only, no KEY=VALUE at all (env not readable) -> None, NOT False",
+      probe(R(0, "6648\n"), R(0, ARGV)) is None,
+      "a permission failure prints argv alone; treating that as False would "
+      "manufacture the false warning this check exists to remove")
+
+check("tmux session missing (rc!=0) -> None",
+      probe(R(1, ""), R(0, f"{ARGV} {ENV_WITH_PROXY}")) is None)
+
+check("tmux unavailable (runner returns None) -> None",
+      probe(None, R(0, f"{ARGV} {ENV_WITH_PROXY}")) is None)
+
+check("pane pid not numeric -> None",
+      probe(R(0, "not-a-pid\n"), R(0, f"{ARGV} {ENV_NO_PROXY}")) is None)
+
+check("empty pane output -> None",
+      probe(R(0, "\n"), R(0, f"{ARGV} {ENV_NO_PROXY}")) is None)
+
+check("ps fails (rc!=0) -> None",
+      probe(R(0, "6648\n"), R(1, "")) is None)
+
+check("ps raises -> None",
+      hc.core_env_has_proxy_url(socket_path="/tmp/probe.sock",
+                                tmux_runner=lambda sock, *a: R(0, "6648\n"),
+                                ps_runner=lambda pid: (_ for _ in ()).throw(OSError("boom"))) is None)
+
+# --- discrimination controls ------------------------------------------------------
+# Without these, a helper that returned None for everything would pass every
+# "-> None" line above and half this suite would be vacuous.
+check("control: the True and False cases differ (helper is not constant)",
+      probe(R(0, "6648\n"), R(0, f"{ARGV} {ENV_WITH_PROXY}"))
+      is not probe(R(0, "6648\n"), R(0, f"{ARGV} {ENV_NO_PROXY}")))
+
+check("control: a LOOKALIKE var does not satisfy the check",
+      probe(R(0, "6648\n"),
+            R(0, f"{ARGV} {ENV_NO_PROXY} ANTHROPIC_BASE_URL_OLD=http://x")) is False,
+      "prefix matching on 'ANTHROPIC_BASE_URL' without the '=' would wrongly say True")
+
+check("control: the pane pid is passed through to ps, not hardcoded",
+      hc.core_env_has_proxy_url(socket_path="/tmp/probe.sock",
+                                tmux_runner=lambda sock, *a: R(0, "424242\n"),
+                                ps_runner=lambda pid: R(0, f"{ARGV} {ENV_WITH_PROXY}")
+                                if str(pid) == "424242" else R(0, ARGV)) is True)
+
+print()
+if failures:
+    print(f"{len(failures)} check(s) FAILED: {failures}")
+    sys.exit(1)
+print("all checks passed — unknown stays unknown; only a read environment can say False")

--- a/tests/quota-telemetry-core-env.test.py
+++ b/tests/quota-telemetry-core-env.test.py
@@ -318,15 +318,24 @@ finally:
     hc.WORKSPACE_DIR = _saved
 
 # and the caller's guard: no local socket -> unknown, never a default-socket probe
+# `is None or True` was the first spelling here and it is ALWAYS TRUE — a test that
+# cannot fail, inside a PR whose whole subject is checks that cannot fail. Caught by
+# both reviewers. Capture the result, then assert the contract on it.
 _probed = []
-check("no local socket -> None WITHOUT probing tmux",
-      hc.core_env_has_proxy_url(
-          tmux_runner=lambda sock, *a: _probed.append(sock) or R(0, "6648\n"),
-          ps_runner=lambda pid: R(0, f"{ARGV} {ENV_WITH_PROXY}")) is None
-      or True)
+_no_sock = hc.core_env_has_proxy_url(
+    tmux_runner=lambda sock, *a: _probed.append(sock) or R(0, "6648\n"),
+    ps_runner=lambda pid: R(0, f"{ARGV} {ENV_WITH_PROXY}"))
+check("no local socket -> None (the tri-state contract, not merely 'did not crash')",
+      _no_sock is None,
+      f"returned {_no_sock!r}; a False here would be a bypass claim built on no evidence, "
+      f"and a True would be a routing claim built on none")
 check("control: and tmux was never called (no fallback to a default socket)",
       _probed == [],
       f"tmux was invoked with {_probed!r} — the guard let a default socket through")
+
+# Both halves are needed and neither implies the other: the first pins WHAT is
+# returned, the second pins that nothing was probed to get there. A helper that
+# probed a default socket and happened to return None would pass the first alone.
 
 print()
 if failures:

--- a/tests/quota-telemetry-core-env.test.py
+++ b/tests/quota-telemetry-core-env.test.py
@@ -270,6 +270,64 @@ check("no LOCAL heartbeat -> None, not a default socket",
       hc._local_core_socket(workspace=_ws) is None,
       "falling back to the default socket would probe a session this host may not run")
 
+# --- _local_core_socket's own edge paths (CI named these seven lines) -------------
+# Every case above passes `workspace=`, so the default-arg path and all four skip
+# branches never ran. Same shape as the default-`ps_runner` gap two commits ago:
+# the seam is exercised, the code behind it is not.
+_ws2 = _pl.Path(_tf.mkdtemp())
+
+check("no state/cores directory at all -> None",
+      hc._local_core_socket(workspace=_ws2) is None)
+
+_c2 = _ws2 / "state" / "cores"; _c2.mkdir(parents=True)
+_lbl = sorted(hc._local_host_labels())[0]
+
+# stale: local label, valid payload, but the heartbeat is older than the 90s window
+(_c2 / f"{_lbl}.alive").write_text(_json.dumps({"socket": "/tmp/stale.sock"}))
+_old = _t.time() - 600
+_os.utime(_c2 / f"{_lbl}.alive", (_old, _old))
+check("a STALE local heartbeat is skipped -> None",
+      hc._local_core_socket(workspace=_ws2) is None,
+      "a heartbeat older than 90s is not a live core")
+
+# control: the SAME file, freshened, must now resolve — otherwise the line above
+# passes for the wrong reason (e.g. the label never matched at all).
+_now2 = _t.time()
+_os.utime(_c2 / f"{_lbl}.alive", (_now2, _now2))
+check("control: freshening that exact file makes it resolve",
+      hc._local_core_socket(workspace=_ws2) == "/tmp/stale.sock")
+
+# non-dict payload: `null` decodes fine and would raise AttributeError on .get
+(_c2 / f"{_lbl}.alive").write_text("null")
+check("a heartbeat decoding to a NON-OBJECT is skipped, not raised",
+      hc._local_core_socket(workspace=_ws2) is None)
+
+# malformed JSON -> ValueError branch
+(_c2 / f"{_lbl}.alive").write_text("{not json")
+check("malformed JSON is skipped, not raised",
+      hc._local_core_socket(workspace=_ws2) is None)
+
+# default-arg path: workspace=None must fall back to WORKSPACE_DIR
+_saved = hc.WORKSPACE_DIR
+try:
+    hc.WORKSPACE_DIR = _ws2
+    check("workspace=None falls back to WORKSPACE_DIR (default-arg path)",
+          hc._local_core_socket() is None,
+          "that tree's only heartbeat is malformed, so None is the right answer here")
+finally:
+    hc.WORKSPACE_DIR = _saved
+
+# and the caller's guard: no local socket -> unknown, never a default-socket probe
+_probed = []
+check("no local socket -> None WITHOUT probing tmux",
+      hc.core_env_has_proxy_url(
+          tmux_runner=lambda sock, *a: _probed.append(sock) or R(0, "6648\n"),
+          ps_runner=lambda pid: R(0, f"{ARGV} {ENV_WITH_PROXY}")) is None
+      or True)
+check("control: and tmux was never called (no fallback to a default socket)",
+      _probed == [],
+      f"tmux was invoked with {_probed!r} — the guard let a default socket through")
+
 print()
 if failures:
     print(f"{len(failures)} check(s) FAILED: {failures}")

--- a/tests/quota-telemetry-core-env.test.py
+++ b/tests/quota-telemetry-core-env.test.py
@@ -206,6 +206,68 @@ _dead = hc.core_env_has_proxy_url(
 check("control: the default runner reaches a real `ps` (dead pid also -> None)",
       _dead is None)
 
+# --- the lookalike SESSION NAME (PR #2530 review, john-the-dev) -------------------
+# `f"--name {session}" in argv` is a SUBSTRING test, so `--name sutando-core-watcher`
+# satisfied it and a prefix-named sibling was accepted as the core. The reviewer
+# reproduced it on a sole pane: returned True where the contract answer is None.
+#
+# This is the SAME lookalike class as the `ANTHROPIC_BASE_URL_OLD` control already in
+# this file. I wrote the guard for the env-var axis and then opened the identical hole
+# on the session-name axis — which is why both axes now get an assertion.
+WATCHER_ARGV = "claude --name sutando-core-watcher --model opus"
+
+check("a PREFIX-named sibling is not the core (--name sutando-core-watcher)",
+      probe(R(0, "6648\n"), R(0, f"{WATCHER_ARGV} {ENV_WITH_PROXY}")) is None,
+      "substring matching on '--name sutando-core' accepts the watcher and returns True")
+
+check("a SUFFIX-named sibling is not the core either",
+      probe(R(0, "6648\n"), R(0, f"claude --name x-sutando-core {ENV_WITH_PROXY}")) is None)
+
+check("the =-joined spelling IS accepted (--name=sutando-core)",
+      probe(R(0, "6648\n"), R(0, f"claude --name=sutando-core {ENV_WITH_PROXY}")) is True)
+
+check("control: exact --name still matches (the fix did not over-tighten)",
+      probe(R(0, "6648\n"), R(0, f"{ARGV} {ENV_WITH_PROXY}")) is True)
+
+check("a watcher and the real core in one session -> the CORE's answer",
+      hc.core_env_has_proxy_url(
+          socket_path="/tmp/probe.sock",
+          tmux_runner=lambda sock, *a: R(0, "7777\n6648\n"),
+          ps_runner=lambda pid: R(0, f"{ARGV} {ENV_NO_PROXY}") if str(pid) == "6648"
+                                else R(0, f"{WATCHER_ARGV} {ENV_WITH_PROXY}")) is False)
+
+# --- the socket must come from THIS host (PR #2530 review, qingyun-wu) ------------
+# `_live_core_socket()` globs every synced state/cores/*.alive and takes the freshest,
+# which the workspace contract permits to be another MACHINE's. The reviewer built two
+# fresh records (local at N-1, peer at N) and the probe targeted the peer's socket;
+# that socket is absent locally so the tri-state degraded to None — correct behaviour,
+# wrong target, and it suppresses the warning this check exists to raise.
+import json as _json, tempfile as _tf, time as _t, pathlib as _pl
+
+_ws = _pl.Path(_tf.mkdtemp())
+_cores = _ws / "state" / "cores"
+_cores.mkdir(parents=True)
+_local_label = sorted(hc._local_host_labels())[0]
+(_cores / f"{_local_label}.alive").write_text(_json.dumps({"socket": "/tmp/local-core.sock"}))
+(_cores / "PeerHost.alive").write_text(_json.dumps({"socket": "/tmp/peer-core.sock"}))
+# make the PEER strictly newer, which is the case that used to win
+_now = _t.time()
+import os as _os
+_os.utime(_cores / f"{_local_label}.alive", (_now - 5, _now - 5))
+_os.utime(_cores / "PeerHost.alive", (_now, _now))
+
+check("a NEWER peer heartbeat does not win — the local socket is chosen",
+      hc._local_core_socket(workspace=_ws) == "/tmp/local-core.sock",
+      "the freshest *.alive belongs to PeerHost; resolving by mtime alone picks it")
+
+check("control: the OLD resolver does pick the peer (the bug is real, not theoretical)",
+      hc._live_core_socket(workspace=_ws) == "/tmp/peer-core.sock")
+
+_os.remove(_cores / f"{_local_label}.alive")
+check("no LOCAL heartbeat -> None, not a default socket",
+      hc._local_core_socket(workspace=_ws) is None,
+      "falling back to the default socket would probe a session this host may not run")
+
 print()
 if failures:
     print(f"{len(failures)} check(s) FAILED: {failures}")

--- a/tests/quota-telemetry-core-env.test.py
+++ b/tests/quota-telemetry-core-env.test.py
@@ -242,7 +242,10 @@ check("a watcher and the real core in one session -> the CORE's answer",
 # fresh records (local at N-1, peer at N) and the probe targeted the peer's socket;
 # that socket is absent locally so the tri-state degraded to None — correct behaviour,
 # wrong target, and it suppresses the warning this check exists to raise.
-import json as _json, tempfile as _tf, time as _t, pathlib as _pl
+import json as _json
+import pathlib as _pl
+import tempfile as _tf
+import time as _t
 
 _ws = _pl.Path(_tf.mkdtemp())
 _cores = _ws / "state" / "cores"
@@ -252,7 +255,6 @@ _local_label = sorted(hc._local_host_labels())[0]
 (_cores / "PeerHost.alive").write_text(_json.dumps({"socket": "/tmp/peer-core.sock"}))
 # make the PEER strictly newer, which is the case that used to win
 _now = _t.time()
-import os as _os
 _os.utime(_cores / f"{_local_label}.alive", (_now - 5, _now - 5))
 _os.utime(_cores / "PeerHost.alive", (_now, _now))
 

--- a/tests/quota-telemetry-core-env.test.py
+++ b/tests/quota-telemetry-core-env.test.py
@@ -178,6 +178,34 @@ check("control: tmux is invoked with -s (every pane in the session)",
       "-s" in _seen_args.get("a", ()),
       f"args were {_seen_args.get('a')!r} — without -s tmux returns only the current window")
 
+# --- the DEFAULT ps_runner, which every case above injects past ------------------
+# CI reported exactly two uncovered changed lines: the default `ps_runner` closure.
+# Every assertion above supplies its own, so the real one never ran — the shape of
+# "tested the seam, never the thing behind it" that this PR's review already caught
+# once. Exercised here against THIS test process's own pid: `ps eww -p <self>` is
+# available on both macOS and the Linux CI runner, always returns a live process, and
+# its argv cannot contain `--name sutando-core`, so the contract answer is None.
+# Deterministic and hermetic — no live core required.
+import os as _os
+
+_default_ps = hc.core_env_has_proxy_url(
+    socket_path="/tmp/probe.sock",
+    tmux_runner=lambda sock, *a: R(0, f"{_os.getpid()}\n"),
+)  # ps_runner deliberately omitted -> the production closure runs
+check("the DEFAULT ps_runner executes and yields the contract answer",
+      _default_ps is None,
+      "this process is not the core, so `--name sutando-core` is absent -> None")
+
+# control: the default path really did SHELL OUT rather than short-circuiting. A pid
+# that cannot exist makes `ps` exit non-zero; if that is indistinguishable from the
+# line above, the test proves nothing about the closure.
+_dead = hc.core_env_has_proxy_url(
+    socket_path="/tmp/probe.sock",
+    tmux_runner=lambda sock, *a: R(0, "2147483647\n"),
+)
+check("control: the default runner reaches a real `ps` (dead pid also -> None)",
+      _dead is None)
+
 print()
 if failures:
     print(f"{len(failures)} check(s) FAILED: {failures}")


### PR DESCRIPTION
@sonichi — the detector for the fault #2417 fixes could not see the fault. Independent of #2417; correct whether or not that lands.

## What's wrong

`check_quota_telemetry` warns only when `quota-state.json` is **stale**. But the credential proxy writes that file on behalf of *whatever* talks to it — not the core — so a fresh file proves only that **something** routed through the proxy.

## Before — measured on this host today, by accident

While answering the live-path review on #2417 I ran one throwaway `ANTHROPIC_BASE_URL=... claude -p ...`. That single request refreshed the file:

```
before   ⚠ quota-telemetry  warn  "quota state is 18h stale while the agent is working"
after    ✓ quota-telemetry  ok    "quota state present (updated 3m ago)"
```

**The production core was equally unrouted in both readings.** `QUOTA_STATE_STALE_SEC` is 6h, so one probe bought six hours of false green over a core whose budget governor was reading numbers it had never generated. I did not construct this case — I caused it, then noticed.

## After — same host, real workspace

```
quota-state.json age 82m, threshold 6h  ->  FRESH

BEFORE (origin/main)   ok    "quota state present (updated 82m ago)"
AFTER  (this branch)   warn  "quota state is fresh (82m) but the RUNNING core has no
                              ANTHROPIC_BASE_URL in its environment, so the core is not
                              routed through the proxy — something else produced that file"

live core_env_has_proxy_url()  ->  False
```

**A first attempt at this evidence was void and discarded:** run from the worktree, `WORKSPACE_DIR` resolved to the worktree's own empty `workspace/`, so *both* branches took the file-absent path and neither exercised the new code. The numbers above come from re-running against the real workspace.

## The design: a tri-state, and why None must never become False

```
True   env read, ANTHROPIC_BASE_URL present  ->  routed
False  env read, variable absent             ->  NOT routed  (the only downgrading answer)
None   env not readable                      ->  unknown; changes nothing
```

`ps eww` prints argv **and then** the environment — but prints argv **alone** for a process whose environment this user may not read. "No `KEY=VALUE` tokens" is therefore indistinguishable from "an empty environment", so the helper requires at least one pair before it will answer `False`. Collapsing `None` into `False` would manufacture exactly the false warning this check exists to remove, pointed the other way.

The pid comes from `tmux list-panes -F '#{pane_pid}'`, **not pgrep**: `pgrep -f claude` matches any argv containing the string (including the shell running the check), and macOS `pgrep -a` lists ancestors rather than argv. Verified here — the pane pid is `6648`, which is `claude --name sutando-core`.

## Tests

`tests/quota-telemetry-core-env.test.py` — **12/12**. Both subprocess calls are injectable, which is what makes the contract testable without a live core.

Nine of the twelve pin unknown-stays-unknown (session missing, tmux unavailable, non-numeric pid, empty pane output, `ps` non-zero, `ps` raising, argv-only). Three are **discrimination controls**, without which a helper that returned `None` for everything would pass the other nine and the suite would be half vacuous:

- the True and False cases differ (the helper is not constant)
- a lookalike `ANTHROPIC_BASE_URL_OLD=` does **not** satisfy it — prefix matching without the `=` would wrongly say True
- the pane pid is passed through to `ps` rather than hardcoded

Eight existing health-check suites still pass. `scripts/review-checks.sh` PASS; `lint-hermetic-bridge-tests.py` ok (63 scanned).

## Note on the seam

`pending-questions.md` recorded on 2026-08-01 that the bridge probes *"take no injectable target, so a violating input can't be built without touching production"* — which is why I could not prove those checks would fail if a bridge died. This adds that seam for this one check. It does not address the bridge probes; that's a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
