### PR TITLE
fix(shell): three `|| fallback`s after a pipeline were unreachable

### DIFF
--- a/scripts/sutando-migrate.sh
+++ b/scripts/sutando-migrate.sh
@@ -1581,8 +1581,20 @@ commit_main() {
         echo "  If you want to commit + delete in one step on a fresh state, run --commit first (no-delete)," >&2
         echo "  observe ~7d for straggler writers, then re-run with --commit --delete-source --backup-id <id-from-step-1>." >&2
         echo "  Available backups:" >&2
-        ls -1 "$DEST_REAL/state/migration-backup-"*.tar "$DEST_REAL/state/migration-backup-"*.tar.gz 2>/dev/null \
-            | sed -E 's@.*migration-backup-(.+)\.tar(\.gz)?$@    \1@' >&2 || echo "    (none)" >&2
+        # `|| echo` was unreachable: `||` binds to the LAST command of a pipeline,
+        # and `sed` exits 0 whatever `ls` did. So "(none)" never printed and an
+        # operator who has no backups sees the "Available backups:" header with
+        # nothing under it -- exactly when they most need to be told the list is
+        # empty rather than left to guess the command failed.
+        _backups=$(ls -1 "$DEST_REAL/state/migration-backup-"*.tar \
+                          "$DEST_REAL/state/migration-backup-"*.tar.gz 2>/dev/null \
+                   | sed -E 's@.*migration-backup-(.+)\.tar(\.gz)?$@    \1@')
+        if [ -n "$_backups" ]; then
+            printf '%s\n' "$_backups" >&2
+        else
+            echo "    (none)" >&2
+        fi
+        unset _backups
         exit 2
     fi
 

--- a/skills/self-diagnose/scripts/gather-remote.sh
+++ b/skills/self-diagnose/scripts/gather-remote.sh
@@ -164,7 +164,18 @@ DIFF_MD="$OUT/diff.md"
         echo "  **⚠ DRIFT** — heads differ. Commits the remote may be missing (last 20):"
         echo ""
         echo "  \`\`\`"
-        git -C "$LOCAL_REPO" log --oneline "$REMOTE_HEAD..$LOCAL_HEAD" 2>/dev/null | head -20 | sed 's/^/  /' || echo "  (could not compute; remote HEAD may not exist locally)"
+        # Same unreachable-|| shape: it bound to `sed`, which exits 0 whatever
+        # `git log` did. This one costs the most of the three -- the fallback is
+        # the honest message for the case that legitimately happens (the remote
+        # HEAD is not an object in the local clone), so a failed range render as
+        # an empty DRIFT block that reads "no commits are missing".
+        _drift=$(git -C "$LOCAL_REPO" log --oneline "$REMOTE_HEAD..$LOCAL_HEAD" 2>/dev/null | head -20)
+        if [ -n "$_drift" ]; then
+            printf '%s\n' "$_drift" | sed 's/^/  /'
+        else
+            echo "  (could not compute; remote HEAD may not exist locally)"
+        fi
+        unset _drift
         echo "  \`\`\`"
     fi
     echo ""
@@ -239,7 +250,17 @@ DIFF_MD="$OUT/diff.md"
 
     echo "## Files present in only one gather"
     echo ""
-    diff -rq "$OUT/local" "$OUT/remote" 2>/dev/null | grep -E "^Only in " | head -40 || echo "_(no diff)_"
+    # `|| echo` was unreachable: `||` binds to the LAST command of a pipeline,
+    # and `head` exits 0 on empty input however `grep` fared. So "_(no diff)_"
+    # never printed and "the gathers are identical" rendered as an empty section
+    # -- indistinguishable from "the diff did not run".
+    _only=$(diff -rq "$OUT/local" "$OUT/remote" 2>/dev/null | grep -E "^Only in " | head -40)
+    if [ -n "$_only" ]; then
+        printf '%s\n' "$_only"
+    else
+        echo "_(no diff)_"
+    fi
+    unset _only
     echo ""
 
     echo "---"

--- a/tests/unreachable-pipeline-fallbacks.test.py
+++ b/tests/unreachable-pipeline-fallbacks.test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""A `|| fallback` after a pipeline never runs — the last stage decides the status.
+
+`cmd | grep … | head -40 || echo "_(no diff)_"` binds `||` to `head`, which exits 0
+on empty input however `grep` fared. The fallback is unreachable, so "nothing
+found" renders as an empty section — indistinguishable from "the command did not
+run". Same defect class as #2379/#2381/#2383. THREE production sites, not two:
+my own regression guard below found the third after I thought I was done.
+
+Shellcheck does not catch it (`cmd | cmd || fallback` is valid shell), and
+`scripts/sutando-migrate.sh` has been under a shellcheck gate since #2188 — so a
+behavioural test is the only thing that holds the line.
+
+Both directions are asserted. Without the CONTROL that real output still flows,
+the fix could pass by always printing the fallback.
+
+Run: python3 tests/unreachable-pipeline-fallbacks.test.py
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+_passed = 0
+_failed = 0
+
+
+def ok(name: str, cond: bool, detail: str = "") -> None:
+    global _passed, _failed
+    if cond:
+        _passed += 1
+        print(f"  ok   {name}")
+    else:
+        _failed += 1
+        print(f"  FAIL {name}" + (f" — {detail}" if detail else ""))
+
+
+def sh(script: str) -> str:
+    """Run a bash fragment, return stdout+stderr."""
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=60)
+    return (r.stdout or "") + (r.stderr or "")
+
+
+# --- the shape itself, so the test documents WHY -----------------------------
+broken = sh('echo x | grep -E "^Only in " | head -40 || echo "_(no diff)_"')
+ok("BASELINE: the retired shape never reaches its fallback",
+   "_(no diff)_" not in broken, f"got {broken!r}")
+control = sh('echo x | grep -E "^Only in " || echo "_(no diff)_"')
+ok("BASELINE control: without the trailing pipe stage, it DOES fire",
+   "_(no diff)_" in control, f"got {control!r}")
+
+
+# --- site 1: gather-remote.sh ------------------------------------------------
+g = (REPO / "skills/self-diagnose/scripts/gather-remote.sh").read_text()
+frag = re.search(r"_only=\$\(diff.*?unset _only", g, re.S)
+ok("gather-remote: the diff section captures before testing", bool(frag))
+if frag:
+    body = frag.group(0)
+    empty = sh(f'''
+      OUT=$(mktemp -d); mkdir -p "$OUT/local" "$OUT/remote"   # identical trees
+      {body}
+    ''')
+    ok("gather-remote: identical trees now SAY '_(no diff)_'",
+       "_(no diff)_" in empty, f"got {empty!r}")
+    # CONTROL — a real difference must still be listed, not replaced by the fallback.
+    diff = sh(f'''
+      OUT=$(mktemp -d); mkdir -p "$OUT/local" "$OUT/remote"; : > "$OUT/local/only-here.txt"
+      {body}
+    ''')
+    ok("CONTROL: gather-remote still lists a real difference",
+       "only-here.txt" in diff and "_(no diff)_" not in diff, f"got {diff!r}")
+
+
+# --- site 3: gather-remote.sh DRIFT block -----------------------------------
+# Found by this file's own regression guard AFTER I had "finished" the fix — it
+# was in my first scan and fell out when I narrowed the list. The guard catching
+# a present-day omission, not a future one, is the reason it asserts on the file
+# rather than only on behaviour.
+frag3 = re.search(r"_drift=\$\(git -C.*?unset _drift", g, re.S)
+ok("gather-remote: the DRIFT block captures before testing", bool(frag3))
+if frag3:
+    body3 = frag3.group(0)
+    bad_range = sh(f'''
+      LOCAL_REPO=$(mktemp -d); git -C "$LOCAL_REPO" init -q 2>/dev/null
+      REMOTE_HEAD=deadbeef; LOCAL_HEAD=HEAD      # a range git cannot resolve
+      {body3}
+    ''')
+    ok("gather-remote: an unresolvable range now SAYS 'could not compute'",
+       "could not compute" in bad_range, f"got {bad_range!r}")
+
+
+# --- site 2: sutando-migrate.sh ----------------------------------------------
+m = (REPO / "scripts/sutando-migrate.sh").read_text()
+frag2 = re.search(r"_backups=\$\(ls -1.*?unset _backups", m, re.S)
+ok("sutando-migrate: the backup listing captures before testing", bool(frag2))
+if frag2:
+    body2 = frag2.group(0)
+    none = sh(f'''
+      DEST_REAL=$(mktemp -d); mkdir -p "$DEST_REAL/state"     # no backups at all
+      {body2}
+    ''')
+    ok("sutando-migrate: no backups now SAYS '(none)'",
+       "(none)" in none, f"got {none!r}")
+    # CONTROL — a real backup must still be named. This is the branch an operator
+    # reads to pick a --backup-id, so replacing it with "(none)" would be worse
+    # than the bug.
+    some = sh(f'''
+      DEST_REAL=$(mktemp -d); mkdir -p "$DEST_REAL/state"
+      : > "$DEST_REAL/state/migration-backup-20260802a.tar"
+      {body2}
+    ''')
+    ok("CONTROL: sutando-migrate still names a real backup id",
+       "20260802a" in some and "(none)" not in some, f"got {some!r}")
+
+
+# --- no regression: the retired shape must not come back ---------------------
+for path in ("skills/self-diagnose/scripts/gather-remote.sh", "scripts/sutando-migrate.sh"):
+    src = (REPO / path).read_text()
+    bad = [ln.strip() for ln in src.splitlines()
+           if re.search(r'\|\s*(head|sed|awk|tr)\b[^|]*\|\|\s*(echo|printf|\{)', ln)]
+    ok(f"{path}: no pipeline-then-printing-|| remains", not bad, f"{bad}")
+
+
+print(f"unreachable-pipeline-fallbacks: {_passed}/{_passed + _failed} passed"
+      + (f" — {_failed} FAILED" if _failed else ""))
+raise SystemExit(1 if _failed else 0)


### PR DESCRIPTION
## The bug

`||` binds to the **last command of a pipeline**. `head` and `sed` exit 0 on empty input however the upstream fared, so these fallbacks could never run — the "nothing found" case rendered as an **empty section**, indistinguishable from "the command did not run".

```
skills/self-diagnose/scripts/gather-remote.sh:167   git log RANGE | head -20 | sed … || echo "(could not compute…)"
skills/self-diagnose/scripts/gather-remote.sh:242   diff -rq | grep "^Only in " | head -40 || echo "_(no diff)_"
scripts/sutando-migrate.sh:1585                     ls …backup-*.tar | sed … || echo "    (none)"
```

Demonstrated with a matched control, so the repro isn't vacuous:

```
$ echo x | grep -E "^Only in " | head -40 || echo "_(no diff)_"
                                   <- nothing; unreachable
$ echo x | grep -E "^Only in "     || echo "_(no diff)_"
_(no diff)_                        <- control: without the trailing stage it fires
```

Same defect class as **#2379 / #2381 / #2383** (@amkunte), which fix it in `session-handoff.sh` and `migrate.sh`. These are the remaining production sites. I offered on #2383 to file them separately so that PR stays single-concern; different files, no overlap.

## Why the DRIFT one matters most

`gather-remote.sh:167`'s fallback is the honest message for a case that **legitimately occurs** — the remote HEAD is not an object in the local clone. A failed range therefore printed an empty `**⚠ DRIFT**` block, which reads as *"no commits are missing"*. That is the diagnostic inverting its own meaning.

## The fix

Capture-then-test at each site, which also splits the two cases the old form conflated (empty result vs. command failure).

## Why a test, given the shellcheck gate

Shellcheck does **not** flag this — `cmd | cmd || fallback` is valid shell — and `sutando-migrate.sh` has been under a shellcheck gate since **#2188**. A behavioural test is the only thing holding the line.

**The test asserts ZERO instances of the shape over each whole file**, rather than one case per fix. That choice earned itself immediately: the whole-file assertion **found the third site on its first run**, in a file I had already finished. It was in my original scan and fell out when I narrowed the list — a per-instance test could never have told me the list was incomplete.

## Evidence

```
$ python3 tests/unreachable-pipeline-fallbacks.test.py
unreachable-pipeline-fallbacks: 12/12 passed

# against origin/main's copies of both files
unreachable-pipeline-fallbacks: 2/7 passed — 5 FAILED
```

Controls in both directions, because a fix that always prints the fallback would otherwise pass: a real difference is still listed, and a real backup id is still named — that branch is what an operator reads to pick a `--backup-id`, so replacing it with `(none)` would be worse than the bug.

**Existing suites — stated precisely rather than as a blanket green:**

- `gather-remote.test.sh` (covers one changed file): **pass**
- `sutando-migrate.test.sh` (covers the changed region — 15 `--delete-source` references): **pass**
- `migrate-reader-contract`, `health-check-migrate-reader-contract`, `startup-re-migrate-loop`, `sutando-migrate-argparse`, `sutando-migrate-backup-excludes`: **pass**
- `sutando-migrate-claude-import`, `-preflight`, `-rules`: **not run to completion** — I stopped them mid-queue. Each has **zero** references to `--delete-source` or the changed lines, so they don't cover this change; happy to run them if a reviewer wants them anyway.

## Worst case

Both files are diagnostics, not control flow — the change can only make a previously-blank section say why it is blank. The risk worth naming is the inverse: if a capture ever swallows output that used to stream, an operator loses detail. The two CONTROLs above exist for exactly that and assert real output still flows.