### PR TITLE
feat(health-check): warn when the credential proxy injects a DIFFERENT account than this core

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2885,7 +2885,7 @@ def _resolved_credential_service(config_dir: Optional[str]) -> Optional[str]:
     return None
 
 
-def check_quota_account_identity(proxy_status: str) -> dict:
+def check_quota_account_identity(proxy_status: str, core_env_prober=None) -> dict:
     """Does the proxy inject THIS core's login, or a different account's?
 
     `check_quota_telemetry` above answers "is quota-state fresh, and does it
@@ -2925,16 +2925,36 @@ def check_quota_account_identity(proxy_status: str) -> dict:
     if _runtime_may_skip_proxy():
         return {"name": name, "status": "ok",
                 "detail": "core runtime is not proxy-routed — its credential is not this proxy's"}
-    # Positive confirmation only. health-check runs as a child of the core, so it
-    # inherits the core's environment; ANTHROPIC_BASE_URL present is direct
-    # evidence the core routes. Absent, we cannot show it routes — and an
-    # unprovable premise must silence the check rather than license a warning
-    # whose every clause depends on it.
-    if not os.environ.get("ANTHROPIC_BASE_URL"):
+    # Probe the RUNNING CORE's environment, not this process's.
+    #
+    # The first version of this gate read `os.environ` on the theory that
+    # health-check runs as a child of the core and inherits it. True on the
+    # proactive-loop path, and false on the app / fallback-launchd / manual
+    # paths, which this file already documents do not carry the core's env
+    # (see the launchd notes around line 1417). On those a routed core with a
+    # genuine account mismatch would read "comparison inactive" and stay
+    # silent — the check disabled exactly where nobody is watching.
+    #
+    # `core_env_has_proxy_url` is TRI-STATE and its contract is that None must
+    # never collapse into False. Applied here:
+    #   True  -> the core routes; the comparison below is meaningful.
+    #   False -> demonstrably NOT routed; the proxy's account is irrelevant to
+    #            it, so every clause of the warning would be false. Silent.
+    #   None  -> undeterminable (no tmux, ambiguous session, unreadable env).
+    #            Silent, and says so — an unprovable premise licenses nothing.
+    # `core_env_prober` is the same injectable seam check_quota_telemetry uses:
+    # without it a fixture escapes into the developer's live tmux and reports on
+    # the real core, which is how 3 of that suite's 39 cases once flipped.
+    probe = core_env_prober or core_env_has_proxy_url
+    routed = probe()
+    if routed is False:
         return {"name": name, "status": "ok",
-                "detail": ("cannot confirm this core routes through the proxy "
-                           "(no ANTHROPIC_BASE_URL in the inherited environment) — "
-                           "identity comparison inactive here")}
+                "detail": ("the running core has no ANTHROPIC_BASE_URL — it is not routed "
+                           "through this proxy, so whose login the proxy holds is moot")}
+    if routed is None:
+        return {"name": name, "status": "ok",
+                "detail": ("could not read the running core's environment — identity "
+                           "comparison inactive here (not evidence either way)")}
 
     core_cfg = os.environ.get("CLAUDE_CONFIG_DIR")
     if not core_cfg:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -2915,6 +2915,27 @@ def check_quota_account_identity(proxy_status: str) -> dict:
         return {"name": name, "status": "ok",
                 "detail": "credential proxy not up — nothing to compare"}
 
+    # Whose account only matters if THIS core's requests go through that proxy.
+    # A proxy can be up while the running core bypasses it entirely — a Codex or
+    # direct runtime, or a supervisor-launched core that never got
+    # ANTHROPIC_BASE_URL. Warning there would assert "requests bill that account"
+    # and "/login here will not reach the proxy", neither of which is true of a
+    # core that does not route. check_quota_telemetry needed the same gate for
+    # the same class, so reuse its runtime marker.
+    if _runtime_may_skip_proxy():
+        return {"name": name, "status": "ok",
+                "detail": "core runtime is not proxy-routed — its credential is not this proxy's"}
+    # Positive confirmation only. health-check runs as a child of the core, so it
+    # inherits the core's environment; ANTHROPIC_BASE_URL present is direct
+    # evidence the core routes. Absent, we cannot show it routes — and an
+    # unprovable premise must silence the check rather than license a warning
+    # whose every clause depends on it.
+    if not os.environ.get("ANTHROPIC_BASE_URL"):
+        return {"name": name, "status": "ok",
+                "detail": ("cannot confirm this core routes through the proxy "
+                           "(no ANTHROPIC_BASE_URL in the inherited environment) — "
+                           "identity comparison inactive here")}
+
     core_cfg = os.environ.get("CLAUDE_CONFIG_DIR")
     if not core_cfg:
         return {"name": name, "status": "ok",
@@ -2926,10 +2947,30 @@ def check_quota_account_identity(proxy_status: str) -> dict:
                 "detail": "credential proxy is not launchd-managed on this host"}
     try:
         rendered = plistlib.loads(plist.read_bytes())
-        proxy_cfg = (rendered.get("EnvironmentVariables") or {}).get("CLAUDE_CONFIG_DIR")
     except (OSError, ValueError) as exc:
         return {"name": name, "status": "warn",
                 "detail": f"cannot read the credential-proxy plist ({exc})"}
+    # A plist can PARSE and still be the wrong shape — `EnvironmentVariables`
+    # encoded as a string, say. `.get` on that raises AttributeError, which is
+    # not caught above and would abort the whole health run, taking every later
+    # check with it. Validate both containers as mappings; a parseable file of
+    # the wrong shape is a warn, never an exception.
+    if not isinstance(rendered, dict):
+        return {"name": name, "status": "warn",
+                "detail": (f"credential-proxy plist parsed but its root is "
+                           f"{type(rendered).__name__}, not a dict — cannot read its environment")}
+    env_block = rendered.get("EnvironmentVariables")
+    if env_block is None:
+        env_block = {}
+    if not isinstance(env_block, dict):
+        return {"name": name, "status": "warn",
+                "detail": (f"credential-proxy plist has EnvironmentVariables as "
+                           f"{type(env_block).__name__}, not a dict — cannot read CLAUDE_CONFIG_DIR")}
+    proxy_cfg = env_block.get("CLAUDE_CONFIG_DIR")
+    if proxy_cfg is not None and not isinstance(proxy_cfg, str):
+        return {"name": name, "status": "warn",
+                "detail": (f"credential-proxy plist has CLAUDE_CONFIG_DIR as "
+                           f"{type(proxy_cfg).__name__}, not a string — cannot resolve its keychain item")}
 
     core_service = _resolved_credential_service(core_cfg)
     proxy_service = _resolved_credential_service(proxy_cfg)

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -23,6 +23,7 @@ import hashlib
 import json
 import os
 import re
+import plistlib
 import shlex
 import shutil
 import tempfile
@@ -2853,6 +2854,112 @@ def check_quota_telemetry(proxy_status: str, core_env_prober=None) -> dict:
     return check
 
 
+def _scoped_keychain_service(config_dir: Optional[str]) -> Optional[str]:
+    """Mirror of credential-proxy.ts `scopedKeychainService`.
+
+    Empty/whitespace -> None, so the caller falls back to the vanilla item —
+    the same contract the proxy implements.
+    """
+    dir_ = (config_dir or "").strip()
+    if not dir_:
+        return None
+    digest = hashlib.sha256(dir_.encode()).hexdigest()[:8]
+    return f"Claude Code-credentials-{digest}"
+
+
+def _keychain_service_exists(service: str) -> bool:
+    try:
+        return subprocess.run(
+            ["security", "find-generic-password", "-s", service],
+            capture_output=True, timeout=5,
+        ).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _resolved_credential_service(config_dir: Optional[str]) -> Optional[str]:
+    """First EXISTING item of [scoped(config_dir), vanilla] — the proxy's order."""
+    for service in (_scoped_keychain_service(config_dir), "Claude Code-credentials"):
+        if service and _keychain_service_exists(service):
+            return service
+    return None
+
+
+def check_quota_account_identity(proxy_status: str) -> dict:
+    """Does the proxy inject THIS core's login, or a different account's?
+
+    `check_quota_telemetry` above answers "is quota-state fresh, and does it
+    exist" — both are questions about WHEN, and neither can see the failure
+    this check exists for: a proxy that is up, routing, and writing a
+    seconds-old file **for someone else's account**.
+
+    Observed 2026-08-03. The owner's login showed 7% of the 7d window used
+    while every routed request billed a different account at 88%; the core
+    throttled itself to near-idle for an hour against a ceiling that was not
+    his. `quota-state.json` was never stale, so no existing branch fired.
+
+    Mechanism: the proxy picks its credential by preferring the keychain item
+    scoped to its own CLAUDE_CONFIG_DIR, falling back to vanilla. launchd does
+    not inherit the installing shell's environment, so if the plist omits
+    CLAUDE_CONFIG_DIR the proxy can only ever resolve the vanilla item — while
+    an interactive `/login` in a namespaced core writes the SCOPED one. It does
+    not self-heal: the proxy re-reads per request, but re-reads the wrong item
+    and refreshes that token back into itself.
+
+    Compares the item the CORE would resolve against the item the PROXY would,
+    reading only the plist and keychain ITEM NAMES. No token, and no secret
+    material of any kind, is read or logged.
+    """
+    name = "quota-account-identity"
+    if proxy_status != "ok":
+        return {"name": name, "status": "ok",
+                "detail": "credential proxy not up — nothing to compare"}
+
+    core_cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+    if not core_cfg:
+        return {"name": name, "status": "ok",
+                "detail": "core has no CLAUDE_CONFIG_DIR — both sides resolve the vanilla item"}
+
+    plist = Path.home() / "Library/LaunchAgents/com.sutando.credential-proxy.plist"
+    if not plist.is_file():
+        return {"name": name, "status": "ok",
+                "detail": "credential proxy is not launchd-managed on this host"}
+    try:
+        rendered = plistlib.loads(plist.read_bytes())
+        proxy_cfg = (rendered.get("EnvironmentVariables") or {}).get("CLAUDE_CONFIG_DIR")
+    except (OSError, ValueError) as exc:
+        return {"name": name, "status": "warn",
+                "detail": f"cannot read the credential-proxy plist ({exc})"}
+
+    core_service = _resolved_credential_service(core_cfg)
+    proxy_service = _resolved_credential_service(proxy_cfg)
+
+    if core_service is None or proxy_service is None:
+        # No readable credential on one side (locked keychain, fresh host).
+        # Say so rather than returning a bare ok that looks like agreement.
+        return {"name": name, "status": "ok",
+                "detail": "no readable credential on one side — comparison inactive here"}
+
+    if core_service == proxy_service:
+        return {"name": name, "status": "ok",
+                "detail": f"proxy injects this core's login ({core_service})"}
+
+    return {
+        "name": name,
+        "status": "warn",
+        "detail": (
+            f"the credential proxy injects a DIFFERENT login than this core's: proxy "
+            f"resolves '{proxy_service}', core would resolve '{core_service}'. Quota "
+            f"numbers describe the proxy's account, not yours, and requests bill it — "
+            f"a `/login` here will not reach the proxy. Cause is almost always the "
+            f"launchd plist omitting CLAUDE_CONFIG_DIR (launchd inherits no shell env): "
+            f"proxy plist has {'no' if not proxy_cfg else repr(proxy_cfg)} value. "
+            f"Fix: pin CLAUDE_CONFIG_DIR in "
+            f"~/Library/LaunchAgents/com.sutando.credential-proxy.plist, then reload it."
+        ),
+    }
+
+
 def check_bodhi_dist() -> dict:
     """Verify the installed bodhi-realtime-agent dist has the Gemini 3.1
     wire-format fixes applied. Greps the Gemini sendAudio/sendFile bodies
@@ -4336,6 +4443,10 @@ def run_all_checks() -> list[dict]:
 
     # Quota telemetry — only meaningful when the proxy is actually up.
     checks.append(check_quota_telemetry(proxy_check["status"]))
+    # ...and WHOSE account those numbers describe. The check above answers
+    # "fresh?"; this one answers "ours?" — a fresh file for a foreign account
+    # passes every branch above (observed 2026-08-03).
+    checks.append(check_quota_account_identity(proxy_check["status"]))
 
     # G1.5: which Node would JS services resolve to (bundled/app-bundle/
     # system), red when none — the silent-dead-services failure class.

--- a/tests/health-check-quota-account-identity.test.py
+++ b/tests/health-check-quota-account-identity.test.py
@@ -149,6 +149,39 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         self.assertIsNone(hc._scoped_keychain_service("   "))
         self.assertIsNone(hc._scoped_keychain_service(None))
 
+    # ---- degraded environments: never crash the whole health run ----------
+
+    def test_missing_plist_is_ok_not_an_error(self):
+        """Proxy running but not launchd-managed (dev host, manual launch).
+        There is no plist to compare against; that is not a fault."""
+        core = "/Users/x/ws/.claude-sutando"
+        with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": core}, clear=False), \
+             mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)):
+            out = hc.check_quota_account_identity("ok")   # no plist written
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("launchd", out["detail"])
+
+    def test_corrupt_plist_warns_rather_than_raising(self):
+        """A truncated/garbage plist must degrade to a warn, not propagate an
+        exception into the health run and take every later check with it."""
+        core = "/Users/x/ws/.claude-sutando"
+        path = self.home / "Library/LaunchAgents/com.sutando.credential-proxy.plist"
+        path.write_bytes(b"\x00not a plist\x00")
+        with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": core}, clear=False), \
+             mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)):
+            out = hc.check_quota_account_identity("ok")
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("cannot read", out["detail"])
+
+    def test_keychain_probe_failure_is_swallowed(self):
+        """`security` missing or the keychain locked must read as 'no such
+        item', not raise. Non-macOS CI hits this path."""
+        with mock.patch.object(hc.subprocess, "run", side_effect=OSError("no security binary")):
+            self.assertFalse(hc._keychain_service_exists(VANILLA))
+        with mock.patch.object(hc.subprocess, "run",
+                               side_effect=hc.subprocess.SubprocessError("timeout")):
+            self.assertFalse(hc._keychain_service_exists(VANILLA))
+
     def test_reads_no_secret_material(self):
         """The check must never invoke `security ... -w` (the flag that prints
         the password). Item-existence only."""

--- a/tests/health-check-quota-account-identity.test.py
+++ b/tests/health-check-quota-account-identity.test.py
@@ -63,16 +63,98 @@ class TestQuotaAccountIdentity(unittest.TestCase):
                                          "EnvironmentVariables": env}))
         return path
 
-    def _run(self, core_cfg, plist_cfg, existing_services, proxy_status="ok"):
+    def _run(self, core_cfg, plist_cfg, existing_services, proxy_status="ok",
+             routed=True, codex_runtime=False):
+        """`routed` controls the ANTHROPIC_BASE_URL the core would have inherited;
+        every case must state it, because the check is gated on it."""
         self._write_plist(plist_cfg)
         env = {"CLAUDE_CONFIG_DIR": core_cfg} if core_cfg else {}
+        if routed:
+            env["ANTHROPIC_BASE_URL"] = "http://localhost:7846"
         with mock.patch.dict(os.environ, env, clear=False), \
              mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
+             mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=codex_runtime), \
              mock.patch.object(hc, "_keychain_service_exists",
                                side_effect=lambda s: s in existing_services):
             if not core_cfg:
                 os.environ.pop("CLAUDE_CONFIG_DIR", None)
+            if not routed:
+                os.environ.pop("ANTHROPIC_BASE_URL", None)
             return hc.check_quota_account_identity(proxy_status)
+
+    # ---- routing gate: the false-positive class qingyun-wu blocked on --------
+
+    def test_proxy_up_but_core_not_routed_does_not_warn(self):
+        """THE routing-gate pin. Divergent keychain items AND a live proxy, but
+        this core has no ANTHROPIC_BASE_URL — it does not send requests through
+        that proxy at all. Every clause of the warning ("requests bill that
+        account", "/login here will not reach the proxy") would be false, so the
+        check must stay silent rather than describe a relationship that does not
+        exist."""
+        core = "/Users/x/ws/.claude-sutando"
+        out = self._run(core_cfg=core, plist_cfg=None,
+                        existing_services={_scoped(core), VANILLA}, routed=False)
+        self.assertEqual(out["status"], "ok",
+                         "an unrouted core must not be told the proxy is billing its requests")
+        self.assertIn("cannot confirm", out["detail"])
+
+    def test_non_proxy_runtime_does_not_warn(self):
+        """Same divergence, but the runtime marker says this core is not
+        proxy-routed (Codex). check_quota_telemetry gates on the same marker."""
+        core = "/Users/x/ws/.claude-sutando"
+        out = self._run(core_cfg=core, plist_cfg=None,
+                        existing_services={_scoped(core), VANILLA}, codex_runtime=True)
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("not proxy-routed", out["detail"])
+
+    # ---- parseable-but-wrong-shape plists: must warn, never raise -----------
+
+    def test_env_block_wrong_type_warns_not_raises(self):
+        """A plist that PARSES with `EnvironmentVariables` as a string. `.get` on
+        a str raises AttributeError, which the OSError/ValueError handler does not
+        catch — it would abort the entire health run and take every later check
+        with it. Reproduced by qingyun-wu on d208c539."""
+        core = "/Users/x/ws/.claude-sutando"
+        path = self.home / "Library/LaunchAgents/com.sutando.credential-proxy.plist"
+        path.write_bytes(plistlib.dumps({"EnvironmentVariables": "not-a-dict"}))
+        with mock.patch.dict(os.environ,
+                             {"CLAUDE_CONFIG_DIR": core,
+                              "ANTHROPIC_BASE_URL": "http://localhost:7846"}, clear=False), \
+             mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
+             mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
+            out = hc.check_quota_account_identity("ok")   # must not raise
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("EnvironmentVariables", out["detail"])
+
+    def test_plist_root_wrong_type_warns_not_raises(self):
+        """Widening the same axis rather than patching the one case found: a
+        plist whose ROOT is an array parses fine and has no `.get` either."""
+        core = "/Users/x/ws/.claude-sutando"
+        path = self.home / "Library/LaunchAgents/com.sutando.credential-proxy.plist"
+        path.write_bytes(plistlib.dumps(["not", "a", "dict"]))
+        with mock.patch.dict(os.environ,
+                             {"CLAUDE_CONFIG_DIR": core,
+                              "ANTHROPIC_BASE_URL": "http://localhost:7846"}, clear=False), \
+             mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
+             mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
+            out = hc.check_quota_account_identity("ok")
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("root", out["detail"])
+
+    def test_config_dir_wrong_type_warns_not_raises(self):
+        """Third point on the axis: the key exists but holds an integer, so it
+        cannot be hashed into a keychain service name."""
+        core = "/Users/x/ws/.claude-sutando"
+        path = self.home / "Library/LaunchAgents/com.sutando.credential-proxy.plist"
+        path.write_bytes(plistlib.dumps({"EnvironmentVariables": {"CLAUDE_CONFIG_DIR": 42}}))
+        with mock.patch.dict(os.environ,
+                             {"CLAUDE_CONFIG_DIR": core,
+                              "ANTHROPIC_BASE_URL": "http://localhost:7846"}, clear=False), \
+             mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
+             mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
+            out = hc.check_quota_account_identity("ok")
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("CLAUDE_CONFIG_DIR", out["detail"])
 
     # ---- THE regression pin: fails on the parent commit -------------------
 

--- a/tests/health-check-quota-account-identity.test.py
+++ b/tests/health-check-quota-account-identity.test.py
@@ -52,6 +52,36 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         (self.home / "Library/LaunchAgents").mkdir(parents=True)
         self.addCleanup(self._tmp.cleanup)
 
+    def _routed_env(self, core_cfg, routed=True):
+        """Env context that is HERMETIC about the routing gate.
+
+        `mock.patch.dict(..., clear=False)` inherits the ambient environment, so
+        on a developer host whose core IS proxy-routed these cases silently
+        inherited a real ANTHROPIC_BASE_URL and passed for the wrong reason —
+        green locally, red on CI, which is exactly what happened on 211b97a1.
+        Every case must state its own routing premise rather than borrow the
+        host's.
+        """
+        env = {"CLAUDE_CONFIG_DIR": core_cfg} if core_cfg else {}
+        if routed:
+            env["ANTHROPIC_BASE_URL"] = "http://localhost:7846"
+        ctx = mock.patch.dict(os.environ, env, clear=False)
+        if routed:
+            return ctx
+        # Not-routed must be asserted, not assumed: strip any inherited value.
+        outer = mock.patch.dict(os.environ, env, clear=False)
+
+        class _Unrouted:
+            def __enter__(self_inner):
+                outer.__enter__()
+                os.environ.pop("ANTHROPIC_BASE_URL", None)
+                return self_inner
+
+            def __exit__(self_inner, *exc):
+                return outer.__exit__(*exc)
+
+        return _Unrouted()
+
     def _write_plist(self, config_dir):
         """Render a credential-proxy plist. config_dir=None omits the key —
         the pre-fix shape, which is the whole point of the divergence case."""
@@ -68,18 +98,13 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         """`routed` controls the ANTHROPIC_BASE_URL the core would have inherited;
         every case must state it, because the check is gated on it."""
         self._write_plist(plist_cfg)
-        env = {"CLAUDE_CONFIG_DIR": core_cfg} if core_cfg else {}
-        if routed:
-            env["ANTHROPIC_BASE_URL"] = "http://localhost:7846"
-        with mock.patch.dict(os.environ, env, clear=False), \
+        with self._routed_env(core_cfg, routed=routed), \
              mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
              mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=codex_runtime), \
              mock.patch.object(hc, "_keychain_service_exists",
                                side_effect=lambda s: s in existing_services):
             if not core_cfg:
                 os.environ.pop("CLAUDE_CONFIG_DIR", None)
-            if not routed:
-                os.environ.pop("ANTHROPIC_BASE_URL", None)
             return hc.check_quota_account_identity(proxy_status)
 
     # ---- routing gate: the false-positive class qingyun-wu blocked on --------
@@ -117,9 +142,7 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         core = "/Users/x/ws/.claude-sutando"
         path = self.home / "Library/LaunchAgents/com.sutando.credential-proxy.plist"
         path.write_bytes(plistlib.dumps({"EnvironmentVariables": "not-a-dict"}))
-        with mock.patch.dict(os.environ,
-                             {"CLAUDE_CONFIG_DIR": core,
-                              "ANTHROPIC_BASE_URL": "http://localhost:7846"}, clear=False), \
+        with self._routed_env(core), \
              mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
              mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
             out = hc.check_quota_account_identity("ok")   # must not raise
@@ -132,9 +155,7 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         core = "/Users/x/ws/.claude-sutando"
         path = self.home / "Library/LaunchAgents/com.sutando.credential-proxy.plist"
         path.write_bytes(plistlib.dumps(["not", "a", "dict"]))
-        with mock.patch.dict(os.environ,
-                             {"CLAUDE_CONFIG_DIR": core,
-                              "ANTHROPIC_BASE_URL": "http://localhost:7846"}, clear=False), \
+        with self._routed_env(core), \
              mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
              mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
             out = hc.check_quota_account_identity("ok")
@@ -147,9 +168,7 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         core = "/Users/x/ws/.claude-sutando"
         path = self.home / "Library/LaunchAgents/com.sutando.credential-proxy.plist"
         path.write_bytes(plistlib.dumps({"EnvironmentVariables": {"CLAUDE_CONFIG_DIR": 42}}))
-        with mock.patch.dict(os.environ,
-                             {"CLAUDE_CONFIG_DIR": core,
-                              "ANTHROPIC_BASE_URL": "http://localhost:7846"}, clear=False), \
+        with self._routed_env(core), \
              mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
              mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
             out = hc.check_quota_account_identity("ok")
@@ -237,8 +256,9 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         """Proxy running but not launchd-managed (dev host, manual launch).
         There is no plist to compare against; that is not a fault."""
         core = "/Users/x/ws/.claude-sutando"
-        with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": core}, clear=False), \
-             mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)):
+        with self._routed_env(core), \
+             mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
+             mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
             out = hc.check_quota_account_identity("ok")   # no plist written
         self.assertEqual(out["status"], "ok")
         self.assertIn("launchd", out["detail"])
@@ -249,8 +269,9 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         core = "/Users/x/ws/.claude-sutando"
         path = self.home / "Library/LaunchAgents/com.sutando.credential-proxy.plist"
         path.write_bytes(b"\x00not a plist\x00")
-        with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": core}, clear=False), \
-             mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)):
+        with self._routed_env(core), \
+             mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
+             mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
             out = hc.check_quota_account_identity("ok")
         self.assertEqual(out["status"], "warn")
         self.assertIn("cannot read", out["detail"])

--- a/tests/health-check-quota-account-identity.test.py
+++ b/tests/health-check-quota-account-identity.test.py
@@ -105,7 +105,9 @@ class TestQuotaAccountIdentity(unittest.TestCase):
                                side_effect=lambda s: s in existing_services):
             if not core_cfg:
                 os.environ.pop("CLAUDE_CONFIG_DIR", None)
-            return hc.check_quota_account_identity(proxy_status)
+            # The PROBE is what the gate consults — never this process's env.
+            return hc.check_quota_account_identity(
+                proxy_status, core_env_prober=lambda: routed)
 
     # ---- routing gate: the false-positive class qingyun-wu blocked on --------
 
@@ -121,7 +123,46 @@ class TestQuotaAccountIdentity(unittest.TestCase):
                         existing_services={_scoped(core), VANILLA}, routed=False)
         self.assertEqual(out["status"], "ok",
                          "an unrouted core must not be told the proxy is billing its requests")
-        self.assertIn("cannot confirm", out["detail"])
+        self.assertIn("not routed", out["detail"])
+
+    def test_probes_the_CORE_env_not_this_process(self):
+        """THE qingyun-wu P1 pin: health-check's OWN environment lacks
+        ANTHROPIC_BASE_URL while the probed running core HAS it.
+
+        The first gate read `os.environ`, on the theory that health-check is a
+        child of the core and inherits it. That holds on the proactive-loop path
+        and fails on the app / fallback-launchd / manual paths, which this file
+        documents do not carry the core's env. There, a routed core with a real
+        account mismatch would read "comparison inactive" and go silent — the
+        check disabled precisely where no human is watching.
+
+        So: subprocess env stripped, prober says True, and the comparison must
+        still run to a WARN on divergent items."""
+        core = "/Users/x/ws/.claude-sutando"
+        self._write_plist(None)                      # proxy resolves vanilla
+        env = {"CLAUDE_CONFIG_DIR": core}
+        with mock.patch.dict(os.environ, env, clear=False), \
+             mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
+             mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False), \
+             mock.patch.object(hc, "_keychain_service_exists",
+                               side_effect=lambda s: s in {_scoped(core), VANILLA}):
+            os.environ.pop("ANTHROPIC_BASE_URL", None)   # THIS process is unrouted
+            out = hc.check_quota_account_identity("ok", core_env_prober=lambda: True)
+        self.assertEqual(out["status"], "warn",
+                         "a routed CORE must be compared even when health-check's own "
+                         "env lacks the variable")
+        self.assertIn(_scoped(core), out["detail"])
+
+    def test_undeterminable_core_env_is_silent_and_says_so(self):
+        """`core_env_has_proxy_url` is tri-state and None must NEVER collapse to
+        False. Undeterminable (no tmux, ambiguous session) is not evidence of a
+        bypass — stay silent, and state the no-op rather than returning a bare
+        ok indistinguishable from a real comparison."""
+        core = "/Users/x/ws/.claude-sutando"
+        out = self._run(core_cfg=core, plist_cfg=None,
+                        existing_services={_scoped(core), VANILLA}, routed=None)
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("inactive", out["detail"])
 
     def test_non_proxy_runtime_does_not_warn(self):
         """Same divergence, but the runtime marker says this core is not
@@ -145,7 +186,8 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         with self._routed_env(core), \
              mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
              mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
-            out = hc.check_quota_account_identity("ok")   # must not raise
+            out = hc.check_quota_account_identity(
+                "ok", core_env_prober=lambda: True)   # must not raise
         self.assertEqual(out["status"], "warn")
         self.assertIn("EnvironmentVariables", out["detail"])
 
@@ -158,7 +200,7 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         with self._routed_env(core), \
              mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
              mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
-            out = hc.check_quota_account_identity("ok")
+            out = hc.check_quota_account_identity("ok", core_env_prober=lambda: True)
         self.assertEqual(out["status"], "warn")
         self.assertIn("root", out["detail"])
 
@@ -171,7 +213,7 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         with self._routed_env(core), \
              mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
              mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
-            out = hc.check_quota_account_identity("ok")
+            out = hc.check_quota_account_identity("ok", core_env_prober=lambda: True)
         self.assertEqual(out["status"], "warn")
         self.assertIn("CLAUDE_CONFIG_DIR", out["detail"])
 
@@ -259,7 +301,8 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         with self._routed_env(core), \
              mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
              mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
-            out = hc.check_quota_account_identity("ok")   # no plist written
+            out = hc.check_quota_account_identity(
+                "ok", core_env_prober=lambda: True)   # no plist written
         self.assertEqual(out["status"], "ok")
         self.assertIn("launchd", out["detail"])
 
@@ -272,7 +315,7 @@ class TestQuotaAccountIdentity(unittest.TestCase):
         with self._routed_env(core), \
              mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
              mock.patch.object(hc, "_runtime_may_skip_proxy", return_value=False):
-            out = hc.check_quota_account_identity("ok")
+            out = hc.check_quota_account_identity("ok", core_env_prober=lambda: True)
         self.assertEqual(out["status"], "warn")
         self.assertIn("cannot read", out["detail"])
 

--- a/tests/health-check-quota-account-identity.test.py
+++ b/tests/health-check-quota-account-identity.test.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""check_quota_account_identity — does the proxy inject THIS core's login?
+
+Pins the failure observed 2026-08-03: the credential proxy was up, routing, and
+writing a seconds-old quota-state.json **for a different account**. The owner's
+login showed 7% of the 7d window used while every routed request billed an
+account at 88%, and the core throttled itself for an hour against a ceiling that
+was not his. `check_quota_telemetry` never fired, because every one of its
+branches asks WHEN (stale? never written?) and none asks WHOSE.
+
+The load-bearing case here is `test_divergent_config_dirs_warn`: it FAILS on the
+parent commit, where no such check exists. The agreeing cases would pass against
+any implementation, including one that always returns ok, so on their own they
+prove nothing.
+
+Keychain access is stubbed — these tests never touch the real keychain and never
+read a token. The production code compares keychain ITEM NAMES only.
+"""
+import hashlib
+import importlib.util
+import os
+import plistlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parent.parent
+VANILLA = "Claude Code-credentials"
+
+
+def _load_health_check():
+    spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["health_check"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hc = _load_health_check()
+
+
+def _scoped(config_dir: str) -> str:
+    return f"{VANILLA}-{hashlib.sha256(config_dir.encode()).hexdigest()[:8]}"
+
+
+class TestQuotaAccountIdentity(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name)
+        (self.home / "Library/LaunchAgents").mkdir(parents=True)
+        self.addCleanup(self._tmp.cleanup)
+
+    def _write_plist(self, config_dir):
+        """Render a credential-proxy plist. config_dir=None omits the key —
+        the pre-fix shape, which is the whole point of the divergence case."""
+        env = {"HOME": str(self.home), "PATH": "/usr/bin"}
+        if config_dir is not None:
+            env["CLAUDE_CONFIG_DIR"] = config_dir
+        path = self.home / "Library/LaunchAgents/com.sutando.credential-proxy.plist"
+        path.write_bytes(plistlib.dumps({"Label": "com.sutando.credential-proxy",
+                                         "EnvironmentVariables": env}))
+        return path
+
+    def _run(self, core_cfg, plist_cfg, existing_services, proxy_status="ok"):
+        self._write_plist(plist_cfg)
+        env = {"CLAUDE_CONFIG_DIR": core_cfg} if core_cfg else {}
+        with mock.patch.dict(os.environ, env, clear=False), \
+             mock.patch.object(hc.Path, "home", staticmethod(lambda: self.home)), \
+             mock.patch.object(hc, "_keychain_service_exists",
+                               side_effect=lambda s: s in existing_services):
+            if not core_cfg:
+                os.environ.pop("CLAUDE_CONFIG_DIR", None)
+            return hc.check_quota_account_identity(proxy_status)
+
+    # ---- THE regression pin: fails on the parent commit -------------------
+
+    def test_divergent_config_dirs_warn(self):
+        """Core is namespaced and its scoped item exists; the plist omits
+        CLAUDE_CONFIG_DIR so the proxy can only reach the vanilla item. Both
+        exist, so the two sides resolve DIFFERENT logins — exactly the live
+        2026-08-03 failure. Must warn."""
+        core = "/Users/x/ws/.claude-sutando"
+        out = self._run(core_cfg=core, plist_cfg=None,
+                        existing_services={_scoped(core), VANILLA})
+        self.assertEqual(out["status"], "warn", "divergent logins must not read ok")
+        self.assertIn(_scoped(core), out["detail"], "must name the core's item")
+        self.assertIn(VANILLA, out["detail"], "must name the proxy's item")
+        self.assertIn("CLAUDE_CONFIG_DIR", out["detail"], "must name the cause")
+
+    def test_warn_names_a_concrete_remedy(self):
+        """A warning an operator cannot act on is a warning they will learn to
+        ignore — the detail must name the plist and the reload."""
+        core = "/Users/x/ws/.claude-sutando"
+        out = self._run(core_cfg=core, plist_cfg=None,
+                        existing_services={_scoped(core), VANILLA})
+        self.assertIn("com.sutando.credential-proxy.plist", out["detail"])
+        self.assertIn("reload", out["detail"].lower())
+
+    # ---- agreement cases: must NOT warn -----------------------------------
+
+    def test_matching_config_dirs_ok(self):
+        """Plist pins the same config dir the core uses — the post-fix state."""
+        core = "/Users/x/ws/.claude-sutando"
+        out = self._run(core_cfg=core, plist_cfg=core,
+                        existing_services={_scoped(core), VANILLA})
+        self.assertEqual(out["status"], "ok")
+        self.assertIn(_scoped(core), out["detail"])
+
+    def test_no_scoped_item_means_both_fall_back_to_vanilla(self):
+        """Core is namespaced but has never logged in there, so its scoped item
+        does not exist and it falls back to vanilla — same as the proxy. Not a
+        divergence, and must not warn: this is the ordinary single-login host."""
+        out = self._run(core_cfg="/Users/x/ws/.claude-sutando", plist_cfg=None,
+                        existing_services={VANILLA})
+        self.assertEqual(out["status"], "ok")
+
+    def test_core_without_config_dir_is_ok(self):
+        """Vanilla core: both sides resolve the vanilla item by definition."""
+        out = self._run(core_cfg=None, plist_cfg=None, existing_services={VANILLA})
+        self.assertEqual(out["status"], "ok")
+
+    def test_proxy_down_is_not_a_divergence(self):
+        """Nothing is being injected, so there is nothing to disagree about.
+        Reporting a mismatch here would be noise on every proxy-less host."""
+        core = "/Users/x/ws/.claude-sutando"
+        out = self._run(core_cfg=core, plist_cfg=None,
+                        existing_services={_scoped(core), VANILLA}, proxy_status="warn")
+        self.assertEqual(out["status"], "ok")
+
+    def test_no_readable_credential_states_the_no_op(self):
+        """Locked keychain / fresh host: an unqualified ok would be
+        indistinguishable from a check that actually compared something."""
+        core = "/Users/x/ws/.claude-sutando"
+        out = self._run(core_cfg=core, plist_cfg=None, existing_services=set())
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("inactive", out["detail"])
+
+    # ---- the mirror of the proxy's own contract ---------------------------
+
+    def test_scoped_service_matches_the_proxy_algorithm(self):
+        """`_scoped_keychain_service` must mirror credential-proxy.ts exactly:
+        sha256(dir)[0:8], and empty/whitespace -> None (vanilla fallback). If
+        these drift, the check silently compares the wrong names."""
+        d = "/Users/x/ws/.claude-sutando"
+        self.assertEqual(hc._scoped_keychain_service(d), _scoped(d))
+        self.assertIsNone(hc._scoped_keychain_service(""))
+        self.assertIsNone(hc._scoped_keychain_service("   "))
+        self.assertIsNone(hc._scoped_keychain_service(None))
+
+    def test_reads_no_secret_material(self):
+        """The check must never invoke `security ... -w` (the flag that prints
+        the password). Item-existence only."""
+        core = "/Users/x/ws/.claude-sutando"
+        with mock.patch.object(hc.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=0)
+            hc._resolved_credential_service(core)
+        for call in run.call_args_list:
+            self.assertNotIn("-w", call.args[0], "must not read the secret value")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`check_quota_telemetry` has exactly two warn branches: quota-state **stale** while the agent works, and **never written**. Both ask *when*. Neither can see a proxy that is up, routing, and writing a seconds-old file **for somebody else's account**.

This adds `check_quota_account_identity`, which asks *whose*.

## Why — this cost an hour on a live host

The owner refreshed his login and reported ~7% of the 7d window used. The core reported **88%** and throttled itself to near-idle because of it. Both were correct, about different accounts:

```
SESSION  "Claude Code-credentials-b0888206"   expires 09:13Z   <- /login wrote here
PROXY    "Claude Code-credentials"            expires 03:01Z   <- on the wire
```

`quota-state.json` was seconds old throughout, so every existing branch reported `ok`.

**Mechanism.** The proxy prefers the keychain item scoped to its own `CLAUDE_CONFIG_DIR`, falling back to vanilla. launchd inherits no shell environment, so a plist without `CLAUDE_CONFIG_DIR` can only resolve the vanilla item — while an interactive `/login` in a namespaced core writes the **scoped** one. It does not self-heal: `readCred()` runs per request, but re-reads the wrong item and refreshes that token back into itself.

## Relationship to #1887

#1887 fixes the *cause* (pins `CLAUDE_CONFIG_DIR` into the plist template). This makes the *class* visible on any host that regresses — including a hand-patched plist, which `startup.sh`/`restart.sh` regenerate away via `sed "$TEMPLATE" > "$DEST"`. Complementary and independent; neither blocks the other. I wrote #1887's template change independently before finding it existed, and deleted it undeployed rather than open a duplicate.

## Evidence

All output below is pasted verbatim from this host at head `d208c539`.

**1. The pre-fix plist used below is genuinely pre-fix** (backup taken before tonight's repair):

```
$ plutil -p credential-proxy.plist.bak | grep -c CLAUDE_CONFIG_DIR
0
```

**2. LIVE — that real pre-fix plist, against the real keychain → WARN:**

```
$ python3 -c "<load health-check.py; Path.home -> temp home holding the pre-fix plist>"
WARN: the credential proxy injects a DIFFERENT login than this core's: proxy resolves 'Claude
Code-credentials', core would resolve 'Claude Code-credentials-b0888206'. Quota numbers describe
the proxy's account, not yours, and requests bill it — a `/login` here will not reach the proxy.
Cause is almost always the launchd plist omitting CLAUDE_CONFIG_DIR (launchd inherits no shell
env): proxy plist has no value. Fix: pin CLAUDE_CONFIG_DIR in
~/Library/LaunchAgents/com.sutando.credential-proxy.plist, then reload it.
```

**3. LIVE — the current, repaired plist, same code → ok:**

```
$ python3 -c "<same loader, real ~/Library/LaunchAgents plist>"
OK: proxy injects this core's login (Claude Code-credentials-b0888206)
```

Same code, opposite inputs, opposite verdicts. This pair is the behavioural proof.

**4. Suite on this branch:**

```
$ python3 tests/health-check-quota-account-identity.test.py
----------------------------------------------------------------------
Ran 12 tests in 0.008s

OK
```

**5. Same suite against `origin/main`** (`git show origin/main:src/health-check.py > src/health-check.py`):

```
----------------------------------------------------------------------
Ran 12 tests in 0.008s

FAILED (errors=12)
```

Stated plainly: those are `AttributeError` — the symbols do not exist on main. For a brand-new check that is the only possible parent outcome, so **this proves novelty, not behavioural divergence**. The behavioural evidence is the §2/§3 pair.

**6. Regression — every existing health-check suite:**

```
$ for t in tests/health-check-*.test.py; do python3 "$t"; done
  PASS=44 FAIL=0
```

## Safety

Reads the plist and keychain **item names only**. No token or other secret material is read or logged — pinned by a test asserting `security` is never invoked with `-w`.

## Quiet by construction

Returns `ok` where there is nothing to compare: proxy down; core without `CLAUDE_CONFIG_DIR`; no scoped item (both sides fall back to vanilla — the ordinary single-login host); no readable credential; proxy not launchd-managed. A corrupt plist warns rather than raising, so one bad file cannot abort the health run. The no-readable-credential branch **states its no-op** rather than returning a bare `ok` indistinguishable from a real comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
