### PR TITLE
fix(discord-bridge): a forwarded message was classified as a reply and skipped

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -87,7 +87,7 @@ except Exception:  # pragma: no cover — best-effort telemetry
         return None
 from task_archive import find_task_file  # noqa: E402
 from result_markers import parse_markers, dedup_cross_channel_target, dedup_requeue_count, build_requeued_task  # noqa: E402
-from discord_addressee import is_addressed_in_shared_channel  # noqa: E402  # pragma: no cover — bridge not unit-imported; addressee logic is covered in discord_addressee.py
+from discord_addressee import is_addressed_in_shared_channel, reference_is_reply  # noqa: E402  # pragma: no cover — bridge not unit-imported; addressee logic is covered in discord_addressee.py
 from reply_chain import format_reply_chain, format_reply_chain_ids, format_reply_chain_truncation, walk_reply_chain  # noqa: E402  # pragma: no cover — bridge not unit-imported; chain formatting is covered in reply_chain.py
 
 # Cap the reply-chain CONTENT walk (a fetch per level; the immediate parent is
@@ -3013,11 +3013,16 @@ async def _handle_discord_message(message, force=False):
             _ref = getattr(message, "reference", None)
             _ref_resolved = getattr(_ref, "resolved", None) if _ref is not None else None
             _ref_author = getattr(_ref_resolved, "author", None)
+            # A forward also sets message.reference (type=forward) but is NOT a
+            # reply — its payload is in message_snapshots. Treat only a genuine
+            # reply as is_reply, else an owner's forward is skipped here as a
+            # "reply not addressed to me" and the forward-handler never runs.
+            _is_reply = reference_is_reply(_ref is not None, getattr(_ref, "type", None))
             if not is_addressed_in_shared_channel(
                 author_is_bot=bool(getattr(message.author, "bot", False)),
                 bot_mentioned=bot_mentioned,
                 role_mentioned=role_mentioned,
-                is_reply=_ref is not None,
+                is_reply=_is_reply,
                 reply_author_id=(getattr(_ref_author, "id", None) if _ref_author is not None else None),
                 self_id=getattr(client.user, "id", None),
             ):

--- a/src/discord_addressee.py
+++ b/src/discord_addressee.py
@@ -26,6 +26,30 @@ resolves the concrete discord objects into these primitives and gates on
 from __future__ import annotations
 
 
+def reference_is_reply(has_reference: bool, reference_type_name) -> bool:
+    """Return True iff a `message.reference` denotes a genuine REPLY.
+
+    Discord sets `message.reference` for two distinct features:
+      * a reply — `reference.type == default` (enum name ``"default"``);
+      * a forward — `reference.type == forward` (enum name ``"forward"``), whose
+        payload lives in `message.message_snapshots` with empty top-level content.
+
+    The addressee gate must not treat a forward as a reply: an owner's forwarded
+    message has no `reply.resolved.author`, so classifying it as `is_reply=True`
+    made `is_addressed_in_shared_channel` see a "reply not addressed to me" and
+    skip it — the forward-handler that extracts the snapshot never ran (owner-
+    reported 2026-07-27: "did you receive this" -> forwarded #2336 msg dropped).
+
+    Version-robust: matches on the enum member NAME so it holds even if the
+    numeric values change. A missing/None type is treated as a reply (the
+    pre-forward default), preserving existing reply behavior.
+    """
+    if not has_reference:
+        return False
+    name = getattr(reference_type_name, "name", reference_type_name)
+    return name != "forward"
+
+
 def is_addressed_in_shared_channel(
     *,
     author_is_bot: bool,

--- a/tests/discord-bridge-shared-channel-addressee.test.py
+++ b/tests/discord-bridge-shared-channel-addressee.test.py
@@ -26,7 +26,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "src"))
 
-from discord_addressee import is_addressed_in_shared_channel  # noqa: E402
+from discord_addressee import is_addressed_in_shared_channel, reference_is_reply  # noqa: E402
 
 ME = 1512984771305799792          # this bot
 PRO = 1504316176686120980         # another agent
@@ -82,6 +82,35 @@ def main() -> int:
     assert '_channel_role(str(message.channel.id)) != "bot2bot"' in bridge, \
         "discord-bridge.py does not carve out role:'bot2bot' channels"
     print("  ok  bridge carves out bot2bot channels")
+
+
+    # --- reference_is_reply: a FORWARD is not a REPLY (owner-reported 2026-07-27) ---
+    class _T:                      # mimics discord.MessageReferenceType members
+        def __init__(self, name): self.name = name
+
+    assert reference_is_reply(True, _T("default")) is True, "reply -> is a reply"
+    print("  ok  reference.type=default is a reply")
+
+    assert reference_is_reply(True, _T("forward")) is False, "forward -> NOT a reply"
+    print("  ok  reference.type=forward is NOT a reply")
+
+    assert reference_is_reply(False, None) is False, "no reference -> not a reply"
+    print("  ok  no reference at all is not a reply")
+
+    assert reference_is_reply(True, None) is True, "missing type -> pre-forward default"
+    print("  ok  missing reference.type keeps the pre-forward default")
+
+    assert reference_is_reply(True, "forward") is False, "raw string name also handled"
+    print("  ok  raw string type name handled (not just enum members)")
+
+    # --- the actual bug: an owner FORWARD in a shared channel must not be skipped ---
+    # Before the fix the bridge passed is_reply=True for a forward; a forward has no
+    # reply.resolved.author, so reply_author_id is None and the gate skipped it.
+    _fwd_is_reply = reference_is_reply(True, _T("forward"))
+    assert _fwd_is_reply is False, (
+        "an owner's forward must reach the gate as is_reply=False, else it is "
+        "classified as a reply-not-addressed-to-us and the forward handler never runs")
+    print("  ok  owner FORWARD is not classified as a reply-to-someone-else")
 
     print("\nAll addressee-gate cases pass.")
     return 0


### PR DESCRIPTION
## What

Discord sets `message.reference` for **two** different features:

| feature | `reference.type` | payload |
|---|---|---|
| reply | `default` | `reply.resolved` |
| **forward** | `forward` | `message_snapshots`, top-level content empty |

The bridge computed `is_reply = reference is not None`, so a forward arrived at `is_addressed_in_shared_channel()` as a reply. A forward has no `reply.resolved.author`, so `reply_author_id` was `None` — the gate read "a reply, not addressed to me", skipped the message, and **the forward-handler that extracts the snapshot never ran**.

Owner-reported 2026-07-27: a forwarded message ("did you receive this") was silently dropped in a shared channel.

## The fix

`reference_is_reply(has_reference, reference_type_name)` in `discord_addressee.py`, called by the bridge instead of the `is not None` test. It matches on the enum member **name**, so it survives a change in numeric values, and treats a missing/None type as a reply — the pre-forward default, leaving existing reply behaviour untouched.

## Evidence

**The tests fail against the old behaviour.** That is the part worth checking, since a new symbol's tests otherwise only prove novelty. Replacing the body with the old logic (`return True`) and re-running:

```
AssertionError: forward -> NOT a reply
  tests/discord-bridge-shared-channel-addressee.test.py:94
```

Restored, the suite is green again:

```
  ok  reference.type=default is a reply
  ok  reference.type=forward is NOT a reply
  ok  no reference at all is not a reply
  ok  missing reference.type keeps the pre-forward default
  ok  raw string type name handled (not just enum members)
  ok  owner FORWARD is not classified as a reply-to-someone-else

All addressee-gate cases pass.        (6 pre-existing cases + 6 new)
```

Both suites that import the module pass, and `py_compile` is clean on both changed files:

```
tests/discord-bridge-shared-channel-addressee.test.py   PASS
tests/discord-read-forwarded.test.py                    PASS — discord-read forwarded-message tests
```

## Provenance

This change existed **uncommitted in the live checkout** and was blocking that host from pulling 17 commits, because #2499 also modifies `discord-bridge.py`. Authored from a worktree on current `origin/main` by applying the diff — not by copying the files across, which would have reverted #2499. Verified after applying: `Path(__file__).resolve()` still present in `discord-bridge.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)