### PR TITLE
fix(health-check): comm-sweep probe warned forever on hosts that don't own comm handling

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-188 modules indexed.
+189 modules indexed.
 
 ## `src/`
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -4440,25 +4440,75 @@ def bridge_log_content_status(name: str, status: str, tail: list[str]) -> Option
     return None
 
 
-def check_comm_sweep_freshness() -> dict:
+def _host_runs_comm_sweep(
+    workspace_dir: Optional[Path] = None, host_label: Optional[str] = None
+) -> bool:
+    """True when THIS host has a comm-sweep driver wired, i.e. its own crons.json
+    schedules one.
+
+    Comm handling is a SINGLE-OWNER lane: exactly one host in the fleet runs the
+    sweep, because a second cron would duplicate sweeps over the owner's real
+    comms. So "no stamp here" is only a defect on the host that actually owns it.
+    """
+    workspace = Path(workspace_dir or WORKSPACE_DIR)
+    host = host_label or _host_label()
+    try:
+        crons = json.loads((workspace / "hosts" / host / "crons.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(crons, list):
+        return False
+    for entry in crons:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("prompt_skill") == "comm-sweep":
+            return True
+        # A prompt-body entry that invokes the skill or its script counts too —
+        # matching how the driver is actually scheduled, not one spelling of it.
+        if "comm-sweep" in f"{entry.get('name', '')} {entry.get('prompt', '')}":
+            return True
+    return False
+
+
+def check_comm_sweep_freshness(
+    workspace_dir: Optional[Path] = None, host_label: Optional[str] = None
+) -> dict:
     """Comm-handling liveness (P1 of the comm-handling overhaul).
 
     The comm-sweep driver stamps state/last-comm-sweep.json every run. A stale
     stamp means comm handling has silently STOPPED — the exact failure that let
     the inbox-score loop die 2026-07-21 and owner-comm sweeps lapse for days
     with nobody alerted (comm handling was a *discipline*, not a *mechanism*).
-    This probe makes that loud instead of silent: warn past ~2h, down past ~6h,
-    warn (not down) when the stamp is absent — a host that never wired the
-    driver isn't "broken", it just hasn't adopted P1 yet.
+    This probe makes that loud instead of silent: warn past ~2h, down past ~6h.
+
+    LANE-AWARENESS (2026-08-03). The absent-stamp branch used to warn on every
+    host, with the detail "driver not wired on this host yet (P1)". That wording
+    asserted a per-host adoption gap and was wrong twice over: comm handling is a
+    single-owner lane (the driver lives in sonichi/sutando-personal and runs on
+    ONE host by design — a second cron would duplicate sweeps over the owner's
+    comms), so a non-owning host has nothing to adopt and warns FOREVER. A
+    permanent warn is how a health output gets ignored, which would have cost the
+    very alarm this probe exists to raise. So absence is now judged against
+    whether this host actually schedules the driver.
+
+    Deliberately gated on the ABSENT branch ONLY: once a stamp exists, the age
+    thresholds apply unconditionally. Gating those on config too would mean
+    deleting the cron entry silently disarms a real stall — failing in the
+    dangerous direction.
 
     Age-checked (unlike quota-telemetry, which is absence-only): comm handling
     is expected to run on a fixed cadence, so a lengthening age IS the signal.
     """
-    path = status_read_path("last-comm-sweep.json", WORKSPACE_DIR)
+    path = status_read_path("last-comm-sweep.json", workspace_dir or WORKSPACE_DIR)
     name = "comm-sweep"
     if not path.exists():
+        if not _host_runs_comm_sweep(workspace_dir, host_label):
+            return {"name": name, "status": "ok",
+                    "detail": "comm-sweep not scheduled on this host — single-owner lane, "
+                              "probe N/A here"}
         return {"name": name, "status": "warn",
-                "detail": "no last-comm-sweep.json — comm-sweep driver not wired on this host yet (P1)"}
+                "detail": "comm-sweep is scheduled on this host but has never stamped "
+                          "last-comm-sweep.json — driver wired but not producing"}
     try:
         age_h = (time.time() - path.stat().st_mtime) / 3600
     except OSError as exc:

--- a/tests/health-check-comm-sweep-freshness.test.py
+++ b/tests/health-check-comm-sweep-freshness.test.py
@@ -13,6 +13,7 @@ Exit: 0 on pass, 1 on fail.
 """
 from __future__ import annotations
 import importlib.util
+import json
 import os
 import tempfile
 import time
@@ -51,11 +52,57 @@ class TestCommSweepFreshness(unittest.TestCase):
             os.utime(p, (t, t))
         return p
 
-    def test_missing_stamp_warns_not_down(self):
+    def _schedule_comm_sweep(self, entry: dict | None = None) -> None:
+        """Wire a comm-sweep cron into THIS fake host's crons.json."""
+        host = self.hc._host_label()
+        d = self.ws / "hosts" / host
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "crons.json").write_text(json.dumps([
+            {"name": "main-loop", "cron": "*/3 * * * *", "prompt_skill": "proactive-loop"},
+            entry if entry is not None
+            else {"name": "comm-sweep", "cron": "26 * * * *", "prompt_skill": "comm-sweep"},
+        ]))
+
+    def test_missing_stamp_on_non_owning_host_is_ok_not_a_permanent_warn(self):
+        # Comm handling is a SINGLE-OWNER lane: the driver runs on one host by
+        # design (a second cron would duplicate sweeps over the owner's comms).
+        # A host that does not schedule it has nothing to adopt, so warning here
+        # warns forever — and a permanent warn is how a health output gets
+        # ignored, taking this probe's real alarms down with it.
         out = self.hc.check_comm_sweep_freshness()
         self.assertEqual(out["name"], "comm-sweep")
+        self.assertEqual(out["status"], "ok")
+        self.assertIn("N/A", out["detail"])
+
+    def test_missing_stamp_on_the_OWNING_host_still_warns(self):
+        # The alarm must survive on the host that actually schedules the driver:
+        # cron present + never stamped = wired but not producing. If this went
+        # quiet too, the lane-awareness fix would have silenced the whole probe.
+        self._schedule_comm_sweep()
+        out = self.hc.check_comm_sweep_freshness()
         self.assertEqual(out["status"], "warn")
-        self.assertIn("not wired", out["detail"])
+        self.assertIn("not producing", out["detail"])
+
+    def test_prompt_body_scheduling_counts_as_wired(self):
+        # The driver may be scheduled as a prompt body rather than prompt_skill.
+        # Keying only on prompt_skill would read the owning host as non-owning
+        # and silence its alarm — the exact failure direction to avoid.
+        self._schedule_comm_sweep(
+            {"name": "sweep", "cron": "26 * * * *",
+             "prompt": "Run bash skills/comm-sweep/scripts/comm-sweep.sh collect"}
+        )
+        self.assertEqual(self.hc.check_comm_sweep_freshness()["status"], "warn")
+
+    def test_stalled_stays_down_even_when_no_cron_is_configured(self):
+        # THE DANGEROUS DIRECTION. Lane-gating is applied to the ABSENT branch
+        # only. If the age thresholds were gated on config too, deleting the
+        # cron entry would silently disarm a real stall — turning a "comm
+        # handling stopped" page into silence. A stamp that EXISTS proves the
+        # driver ran here, so its staleness is judged unconditionally.
+        self._stamp(7.0)
+        out = self.hc.check_comm_sweep_freshness()
+        self.assertEqual(out["status"], "down")
+        self.assertIn("silently stopped", out["detail"])
 
     def test_fresh_is_ok(self):
         self._stamp(0.1)


### PR DESCRIPTION
@sonichi — small, single-concern fix to a permanent health warn. Read the "why absence, not age" note before merging; it is the part that could be got wrong later.

## The defect

`check_comm_sweep_freshness`'s absent-stamp branch warned on **every** host:

> `no last-comm-sweep.json — comm-sweep driver not wired on this host yet (P1)`

Comm handling is a **single-owner lane**. The driver (`skills/comm-sweep/scripts/comm-sweep.sh`) lives in `sonichi/sutando-personal` (PR #3, merged 2026-07-29, `3ced176`) and runs on exactly ONE host by design — a second cron would duplicate sweeps over the owner's real comms. So a non-owning host has **nothing to adopt** and warns forever, and a permanent warn is how a health output gets ignored, taking this probe's real alarms down with it.

The wording compounded it: *"not wired on this host **yet**"* asserts a per-host adoption gap, which sends the reader looking for local config that does not exist. It cost exactly that: I reported to the owner — twice — that the driver had never been built, when it had been merged four days earlier in a repo I searched at the wrong path.

## The fix

Absence is judged against whether **this host actually schedules the driver** (its own `hosts/<label>/crons.json`), matching the file's existing not-applicable precedent (`cron-runner`, `tcc-documents-access`, `codex-task-notifier`):

| state | before | after |
|---|---|---|
| not scheduled here | `warn` (forever) | `ok` — "single-owner lane, probe N/A here" |
| scheduled, never stamped | `warn` "not wired yet" | `warn` — "driver wired but not producing" |
| stamp >2h / >6h | `warn` / `down` | **unchanged** |

## Why absence, and NOT age, is gated

Deliberately gated on the **absent branch only**. Once a stamp exists, the >2h/>6h thresholds apply unconditionally — a stamp existing proves the driver ran here, so its staleness is judged on its own. Gating those on config too would mean **deleting a cron entry silently disarms a real stall**, converting a "comm handling has stopped" page into silence. That is the dangerous direction, and `test_stalled_stays_down_even_when_no_cron_is_configured` pins it.

## Evidence — actual output, this host (does not own comm handling)

Parent commit (`origin/main`):
```
warn  no last-comm-sweep.json — comm-sweep driver not wired on this host yet (P1)
```
This branch:
```
ok    comm-sweep not scheduled on this host — single-owner lane, probe N/A here
```

**The new tests fail at the parent**, i.e. they test the fix rather than the code:
```
$ python3 tests/health-check-comm-sweep-freshness.test.py     # at origin/main, new test file
FAIL: test_missing_stamp_on_non_owning_host_is_ok_not_a_permanent_warn
      AssertionError: 'warn' != 'ok'
FAIL: test_missing_stamp_on_the_OWNING_host_still_warns
      AssertionError: 'not producing' not found in 'no last-comm-sweep.json — ... not wired on this host yet (P1)'
Ran 9 tests — FAILED (failures=2)

$ python3 tests/health-check-comm-sweep-freshness.test.py     # at this head
Ran 9 tests — OK
```

Full suite for the changed file — every `tests/*.test.py` mentioning `health-check`: **59 of 60 pass.** The one failure is `tests/quota-telemetry-core-env.test.py` and is **pre-existing and unrelated** — established by isolation rather than assumed: the same code passes in a fresh worktree and fails in the live checkout, so it is the environment, not this diff. It is not hermetic: `_live_core_socket()` globs the real workspace's `state/cores/*.alive`, and a host with a running core supplies `socket: /tmp/sutando-tmux.sock`, defeating the test's "no local socket -> None" case. Filed separately rather than bundled here.

## Scope

Health-check only. No behaviour change on the owning host: with its cron present, an absent stamp still warns and the age thresholds are untouched. No driver is added or wired — Pro owns comm handling and Mini must not schedule a second sweep.
