### PR TITLE
fix(docs): regenerate src-map — main is red and it reads as 3 unrelated failures

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-188 modules indexed.
+189 modules indexed.
 
 ## `src/`
 


### PR DESCRIPTION
@sonichi — one-line unblocker; `main` is failing its own test right now.

## What is broken

`docs/src-map.md` lists **189** modules while its trailer says **188**, so `scripts/gen-src-map.py` reports it stale and `tests/src-map.test.py` fails **on `main` itself**.

## Bisected, not assumed

```
46d0f4b0  fix(pending-questions): anchor the "# Resolved" divider … (#2419)   -> exit 1
c9a73388  tidy(meeting-scheduler): extract the pure scheduling policy (#2545)  -> exit 0
```

## Why it costs more than one line

One stale generated line surfaces as **three** red checks, none of which mentions src-map:

| check | why it is red |
|---|---|
| `tests/src-map.test.py` | the actual failure |
| `tsc + tests (clean install)` | `npm test` runs `tsx --test && npm run test:py`; the TS half reports `# fail 0` and the **Python** half fails |
| `diff coverage >= 95% (python)` | never scores — `coverage-gate: suite must be green before coverage is meaningful.` |

So the symptom points at TypeScript and coverage, and the cause is a docs file. I lost a pass to that on #2554, which inherited all three.

## Blast radius

Any PR branched or rebased after #2419 inherits all three failures, unless it carries the regenerated map itself.

> **Corrected 2026-08-03 — an earlier version of this section said green PRs are green *only* because their checks predate #2419. That is false for at least two of them,** and Sutando-Pro caught it. #2309 and #2553 are green because Pro had **already regenerated the map on those branches** — that is what took them from 3 red checks to green. Measured, not argued:
>
> ```
> docs/src-map.md blob
>   fix/reply-to-self-addressee (#2309)     b2b865e5bd0f   189 modules
>   fix/pr-flag-principal       (#2553)     b2b865e5bd0f   189 modules
>   fix/regen-src-map-after-2419 (this)     b2b865e5bd0f   189 modules
>   main                                    d69c956b4217   188 modules
> ```
>
> One blob, three branches. **Identical content merges as a no-op in either order**, so there is nothing to collapse and no reason for anyone to revert. Whichever lands first fixes `main`; the others become no-op diffs on this file. The stale-CI reasoning still applies to branches carrying neither the fix nor a recent rebase.
>
> I had also warned Pro off regenerating it on their branches. That warning was over-broad and following it would have put two green PRs back to red. It bites only when a branch **adds a module**, because then its count legitimately differs from this one.

## Verification

```
# at origin/main
$ python3 tests/src-map.test.py ; echo exit=$?
gen-src-map: docs/src-map.md is stale — run 'python3 scripts/gen-src-map.py' and commit the result
Results: 1 failed, 24 passed
exit=1

# at this branch
$ python3 tests/src-map.test.py ; echo exit=$?
Results: 25 passed
exit=0
```

Diff is the single trailer line, `188` → `189`, produced by the generator — not hand-edited.

## Why its own PR

If two branches each regenerate this file they both touch the same "N modules indexed" line; the merge keeps one side and the staleness returns silently. That is exactly the failure mode already recorded for this file, so this stays standalone and #2554 does **not** carry a copy.
