### PR TITLE
fix(ci): job cancels at its 10-min cap and renders as `fail`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,16 @@ jobs:
   typecheck-and-test:
     name: tsc + tests (clean install)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 20, not 10: measured 2026-08-03, this job is at capacity on legitimate work,
+    # not hanging. Run 30801403218 spent 3.9 min (node tests) + 3.2 min (python) +
+    # 1.5 min (shell, cut off) + ~1.4 min setup = 10.0 min and was CANCELED mid-step.
+    # Three of the last four canceled runs are this job at exactly 10.2 min.
+    # A canceled job renders as `fail` in `gh pr checks`, so PRs read red for a
+    # reason that has nothing to do with their code (#1414, #2561 both hit this).
+    # Safe to raise only because every suite loop is now individually bounded at
+    # 120s (shell already was; the python loop is bounded in this same PR) — so a
+    # genuine hang still surfaces in ~2 min, not in 20.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -163,7 +172,13 @@ jobs:
             # shell-test step below already uses this idiom for exactly this reason;
             # this step was missed. (Observed on a real CI run: a failure printed no
             # output at all, making it undiagnosable from the log.)
-            output=$(python3 "$f" 2>&1) && rc=0 || rc=$?
+            # `timeout -k 5 120` mirrors the shell loop below. Without it a single
+            # hanging Python suite burns the job's whole timeout-minutes budget and
+            # gets the job CANCELED mid-suite — the exact failure the shell loop's
+            # comment says its own bound exists to prevent. This loop never had one,
+            # so the guard was asymmetric. On overrun timeout SIGTERMs (SIGKILL after
+            # 5s) and returns 124, failing that suite loudly and in isolation.
+            output=$(timeout -k 5 120 python3 "$f" 2>&1) && rc=0 || rc=$?
             # Always show FAIL lines and summary
             echo "$output" | grep -E 'FAIL|^Results:' || true
             if [ "$rc" -ne 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,16 @@ jobs:
       # discover it — wire both explicitly here. `--all --strict` validates every
       # skills/*/manifest.json (the path skills/MANIFEST.md documents) and fails on
       # warnings (e.g. a network permission that doesn't match the code).
+      # Each call is wrapped in `timeout -k 5 120` for the same reason as the
+      # discovered-suite loops below: this job's timeout-minutes is the only
+      # other bound, so an unbounded hang here burns the whole job budget and
+      # the job is CANCELED mid-step — which renders as `fail` and hides which
+      # suite hung. These two steps are hand-wired lists rather than loops, so
+      # they were missed when the loops were bounded.
       - name: Lint skill manifests
         run: |
-          python3 scripts/lint-skill.test.py
-          python3 scripts/lint-skill.py --all --strict
+          timeout -k 5 120 python3 scripts/lint-skill.test.py
+          timeout -k 5 120 python3 scripts/lint-skill.py --all --strict
 
       # Python tests that live OUTSIDE tests/ and so are invisible to the
       # `find tests -name '*.test.py'` step below. Same reason the skill-manifest
@@ -123,20 +129,20 @@ jobs:
       # which is the guard against src/ and the package silently diverging.
       - name: Run out-of-tree Python tests
         run: |
-          python3 src/remote-gateway-bridge.test.py
-          python3 packages/ag2-sparrow/tests/test_gateway_status.py
-          python3 packages/ag2-sparrow/tests/test_dns_timeout.py
-          python3 packages/ag2-sparrow/tests/test_ack_retry.py
-          python3 packages/ag2-sparrow/tests/test_inflight_recovery.py
-          python3 packages/ag2-sparrow/tests/test_write_task_atomic.py
-          python3 packages/ag2-sparrow/tests/test_event_inbox_channel.py
-          python3 packages/ag2-sparrow/tests/test_event_consumer.py
-          python3 packages/ag2-sparrow/tests/test_event_wiring.py
-          python3 packages/ag2-sparrow/tests/test_human_action.py
-          python3 packages/ag2-sparrow/tests/test_launch_diagnostics.py
-          python3 packages/ag2-sparrow/tools/test_no_drift.py
-          python3 skills/agent-room-ops/test_room_ops.py
-          python3 skills/make-viral-video/scripts/test_source_tag.py
+          timeout -k 5 120 python3 src/remote-gateway-bridge.test.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_gateway_status.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_dns_timeout.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_ack_retry.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_inflight_recovery.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_write_task_atomic.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_event_inbox_channel.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_event_consumer.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_event_wiring.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_human_action.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_launch_diagnostics.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tools/test_no_drift.py
+          timeout -k 5 120 python3 skills/agent-room-ops/test_room_ops.py
+          timeout -k 5 120 python3 skills/make-viral-video/scripts/test_source_tag.py
 
       - name: Run tests
         run: npm test


### PR DESCRIPTION
@sonichi — CI infrastructure, no product code. Found while triaging why two PRs looked red.

## The symptom

`tsc + tests (clean install)` hits `timeout-minutes: 10` and is **CANCELED** mid-step. `gh pr checks` renders a canceled job as `fail`, so a PR reads red for a reason that has nothing to do with its code.

It has already cost two: **#1414** (looked broken immediately after a rebase — obvious story, wrong story; a plain re-run went green with no code change) and **#2561** (currently shows `fail` with 2 approvals; conclusion is `CANCELLED`).

## It is capacity, not a hang

Step timings from canceled run `30801403218`:

```
Run tests (node)             3.9 min
Run Python standalone tests  3.2 min
Run shell standalone tests   1.5 min   <- canceled here
setup + checkout + typecheck ~1.4 min
                             ----------
                             10.0 min
```

Three of the last four canceled workflow runs are this job at **exactly 10.2 min** — three identical durations is a time bound, not flakiness. Cancellation is otherwise rare (**4 of the last 100 runs**), so this isn't burning the queue; it just mislabels whatever it lands on.

## Why the fix is two changes, not one

Raising the budget alone would be **wrong** — it would double how long a genuine hang stays hidden.

The shell loop already guards against that with `timeout -k 5 120` per suite, and its own comment (`:221`) says the bound exists precisely so one suite cannot *"burn the whole job's timeout-minutes budget and get the job \*canceled\* mid-suite"*.

**The Python loop never had that bound.** The guard was asymmetric — a hanging Python suite could do exactly what the shell loop was written to prevent. So this PR bounds each Python suite the same way, *then* raises the job budget.

They're causally linked rather than bundled: **the bound is what makes the headroom safe.** After this, a hanging suite still surfaces in ~2 min, not in 20.

## Verification, and its limit

- `yaml.safe_load` parses; `timeout-minutes` reads back as `20`.
- Diff is one file, +17/−2.
- **Not validated by local execution.** GNU `timeout` isn't on macOS and `gtimeout` isn't installed on this host, so I could not run the idiom here. The evidence it works on the runner is **precedent**: the shell loop at `:226` already runs the identical `timeout -k 5 120` on `ubuntu-latest` with CI green. I'd rather state that than imply I tested it.
- The real proof is this PR's own CI run — if the idiom were broken, the Python step would fail here.

## Note on the number

20 is judgement, not measurement: current legitimate work is 10.0 min and the suite count grows (46 shell suites, 15 in the known-failures allowlist). Happy to take 15 if you'd rather keep the pressure on.