### PR TITLE
fix(self-diagnose): gather.sh read logs and results from the repo, not the workspace

### DIFF
--- a/skills/self-diagnose/scripts/gather.sh
+++ b/skills/self-diagnose/scripts/gather.sh
@@ -145,7 +145,12 @@ cp "$NOTES_DIR/cold-review-log.md" "$OUT/cold-review-log.md" 2>/dev/null || true
 
 # 4) Voice-agent log — filter to window, grep for signal lines, keep it bounded.
 # Signals: transport closes (1006/1011/1007/1008), errors, GoAway, setup complete, 1006/1011 numeric.
-VLOG="$REPO/logs/voice-agent.log"
+# Logs live under the WORKSPACE, not the repo (CLAUDE.md "Workspace contract").
+# `$REPO/logs` does not exist, so the `[ -f ]` guard below went false and this
+# whole block was skipped with no error — the diagnose report then read as
+# "no transport events" when nothing had been looked at. `WS` is already
+# resolved at the top of this script via `sutando-config.sh workspace`.
+VLOG="$WS/logs/voice-agent.log"
 if [ -f "$VLOG" ]; then
 	awk -v since="$SINCE_ISO" '
 		# Approximate filter: log lines start with HH:MM:SS — we can'"'"'t easily compare dates,
@@ -158,7 +163,7 @@ if [ -f "$VLOG" ]; then
 fi
 
 # 5) Discord bridge log — last 200 non-dm-fallback lines
-DLOG="$REPO/logs/discord-bridge.log"
+DLOG="$WS/logs/discord-bridge.log"
 if [ -f "$DLOG" ]; then
 	grep -v "\[dm-fallback\]" "$DLOG" 2>/dev/null | tail -200 > "$OUT/discord-bridge-recent.txt" || true
 fi
@@ -172,7 +177,7 @@ fi
 # Use -mmin against SECONDS_AGO (not `-newer meta.txt` — meta.txt was created
 # at gather-start, so that would only match files written DURING the gather,
 # not files in the last $WINDOW).
-find "$REPO/results" -maxdepth 1 -type f -name "*.txt" -mmin "-$((SECONDS_AGO/60))" 2>/dev/null | head -20 > "$OUT/results-recent-paths.txt" || true
+find "$WS/results" -maxdepth 1 -type f -name "*.txt" -mmin "-$((SECONDS_AGO/60))" 2>/dev/null | head -20 > "$OUT/results-recent-paths.txt" || true
 
 # 8) Quota state
 _QUOTA_SCRIPT="$(bash "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts/sutando-config.sh" claude-home-path skills/quota-tracker/scripts/read-quota.py)"

--- a/skills/self-diagnose/scripts/test-gather.sh
+++ b/skills/self-diagnose/scripts/test-gather.sh
@@ -8,6 +8,15 @@ cd "$(dirname "$0")/../../.."
 
 PASS=0
 FAIL=0
+# Resolve REPO/WS exactly as gather.sh does, including its SUTANDO_ROOT-first
+# precedence (gather.sh:19-20). Defined once and shared by every assertion that
+# needs to know where gather will look — resolving differently in two places is
+# how the results fixture and the collector silently disagreed.
+_TG_REPO="${SUTANDO_ROOT:-$PWD}"
+[ -f "$_TG_REPO/CLAUDE.md" ] || _TG_REPO="$PWD"
+_TG_WS="$(bash "$_TG_REPO/scripts/sutando-config.sh" workspace)"
+_TG_HOST="$(bash "$_TG_REPO/scripts/sutando-config.sh" host-label 2>/dev/null || echo unknown)"
+
 pass() { echo "  ✅ $1"; PASS=$((PASS + 1)); }
 fail() { echo "  ❌ $1"; FAIL=$((FAIL + 1)); }
 
@@ -23,9 +32,31 @@ fi
 
 # Test 2: expected files present
 if [ -n "$OUT" ]; then
-	for f in meta.txt git-log.txt git-status.txt build_log-tail.md pending-questions.md health.txt quota.txt; do
+	for f in meta.txt git-log.txt git-status.txt build_log-tail.md health.txt quota.txt; do
 		[ -f "$OUT/$f" ] && pass "expected file exists: $f" || fail "missing file: $f"
 	done
+	# pending-questions.md is OPTIONAL: gather.sh:140-143 probes hosts/<host>/,
+	# then the workspace root, then the repo root, and `cp … || true` produces
+	# nothing when all three are absent. Requiring it unconditionally made this
+	# suite non-hermetic — green only on a host that happens to have the file,
+	# red in a clean worktree for behaviour the collector got right. The header
+	# already states the contract: "non-empty when source exists". Asserted BOTH
+	# ways so a genuinely missed copy still fails.
+	_pq_src=""
+	for _c in "$_TG_WS/hosts/$_TG_HOST/pending-questions.md" \
+	          "$_TG_WS/pending-questions.md" \
+	          "$_TG_REPO/pending-questions.md"; do
+		[ -f "$_c" ] && { _pq_src="$_c"; break; }
+	done
+	if [ -n "$_pq_src" ]; then
+		[ -f "$OUT/pending-questions.md" ] \
+			&& pass "pending-questions.md copied (source: ${_pq_src#"$_TG_WS/"})" \
+			|| fail "pending-questions.md MISSING despite a source at $_pq_src"
+	else
+		[ -f "$OUT/pending-questions.md" ] \
+			&& fail "pending-questions.md present but NO source exists — where did it come from?" \
+			|| pass "pending-questions.md absent, correctly: no source in any of the 3 probed locations"
+	fi
 fi
 
 # Test 3: meta.txt contains window + repo
@@ -75,9 +106,7 @@ fi
 # instead silently points the fixture at a different checkout's workspace than
 # the one gather reads — which is exactly what happens when this test runs from
 # a git worktree while SUTANDO_ROOT names the primary checkout.
-_FIX_REPO="${SUTANDO_ROOT:-$PWD}"
-[ -f "$_FIX_REPO/CLAUDE.md" ] || _FIX_REPO="$PWD"
-_WS_FOR_FIXTURE="$(bash "$_FIX_REPO/scripts/sutando-config.sh" workspace)"
+_WS_FOR_FIXTURE="$_TG_WS"
 mkdir -p "$_WS_FOR_FIXTURE/results" 2>/dev/null
 FAKE_RESULT="$_WS_FOR_FIXTURE/results/sutando-test-recent-$(date +%s).txt"
 echo "fake" > "$FAKE_RESULT"

--- a/skills/self-diagnose/scripts/test-gather.sh
+++ b/skills/self-diagnose/scripts/test-gather.sh
@@ -66,8 +66,20 @@ fi
 # Test 8: results-recent-paths captures files mtime-newer than SINCE_EPOCH.
 # This catches the "-newer meta.txt" bug that made this file empty on every run.
 # Touch a fake result file to 1 hour old, then gather with 24h window.
-mkdir -p results 2>/dev/null
-FAKE_RESULT="results/sutando-test-recent-$(date +%s).txt"
+# The fixture must live where gather.sh actually LOOKS. results/ is
+# workspace-owned, so a fixture under the repo made this assertion test the
+# retired layout — it passed only while gather.sh was reading the wrong place,
+# and started failing the moment gather.sh was corrected.
+# Resolve the workspace the SAME WAY gather.sh does, including its
+# SUTANDO_ROOT-first precedence (gather.sh:19-20). Resolving cwd-relative here
+# instead silently points the fixture at a different checkout's workspace than
+# the one gather reads — which is exactly what happens when this test runs from
+# a git worktree while SUTANDO_ROOT names the primary checkout.
+_FIX_REPO="${SUTANDO_ROOT:-$PWD}"
+[ -f "$_FIX_REPO/CLAUDE.md" ] || _FIX_REPO="$PWD"
+_WS_FOR_FIXTURE="$(bash "$_FIX_REPO/scripts/sutando-config.sh" workspace)"
+mkdir -p "$_WS_FOR_FIXTURE/results" 2>/dev/null
+FAKE_RESULT="$_WS_FOR_FIXTURE/results/sutando-test-recent-$(date +%s).txt"
 echo "fake" > "$FAKE_RESULT"
 # Backdate to 1 hour ago (BSD touch on macOS, GNU touch on linux — support both)
 if date -v -1H >/dev/null 2>&1; then

--- a/tests/self-diagnose-reads-workspace-paths.test.sh
+++ b/tests/self-diagnose-reads-workspace-paths.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# gather.sh read logs and results from the REPO, but both live under the WORKSPACE.
+#
+# `<repo>/logs` does not exist post-#1454 (the workspace-revamp rollup moved
+# logs/ and results/ under the workspace). So `VLOG="$REPO/logs/voice-agent.log"`
+# made the `[ -f "$VLOG" ]` guard false and the entire voice-agent block was
+# skipped with NO error, and the same for the discord-bridge block; the
+# `find "$REPO/results"` produced an empty file. A /self-diagnose run therefore
+# reported "no transport events" for a log nobody had opened — the collector was
+# dead and a healthy system looks identical.
+#
+# Observed 2026-08-03: voice-agent-signals.txt, voice-agent-size.txt and
+# discord-bridge-recent.txt were all absent from the run directory, and
+# results-recent-paths.txt was 0 bytes, while the real workspace logs held
+# 431/226/7/6 matching lines.
+#
+# The existing scripts/lint-workspace-resolution.sh cannot catch this class: it
+# refuses $SUTANDO_WORKSPACE reads, hardcoded ~/.sutando/workspace, and
+# Path(__file__).parent.parent repo-walks — not a CORRECTLY-resolved $REPO
+# pointed at a workspace-owned subdirectory.
+#
+# Run: bash tests/self-diagnose-reads-workspace-paths.test.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATHER="$REPO_ROOT/skills/self-diagnose/scripts/gather.sh"
+fails=0
+checks=0
+
+check() {
+	local desc="$1"; shift
+	checks=$((checks + 1))
+	if "$@"; then
+		echo "  ok   $desc"
+	else
+		echo "  FAIL $desc"
+		fails=$((fails + 1))
+	fi
+}
+
+[ -f "$GATHER" ] || { echo "FATAL: $GATHER not found"; exit 1; }
+
+# Strip comments and blank lines: prose may legitimately DISCUSS the old path
+# (the fix's own comment does). Only executable lines are in scope.
+CODE="$(mktemp)"; trap 'rm -f "$CODE"' EXIT
+sed -e 's/[[:space:]]*#.*$//' -e '/^[[:space:]]*$/d' "$GATHER" > "$CODE"
+
+# The workspace-owned directories, per CLAUDE.md's Workspace contract.
+for dir in logs results tasks state notes; do
+	# `notes` has a DOCUMENTED $REPO fallback with a dated TODO — exempt it by
+	# name rather than by loosening the pattern, so the exemption is visible.
+	[ "$dir" = "notes" ] && continue
+	check "no executable line reads \$REPO/$dir (it lives under the workspace)" \
+		bash -c '! grep -qE "\\\$\{?REPO(_DIR)?\}?/'"$dir"'" "$1"' _ "$CODE"
+done
+
+# Positive control: the check above is only meaningful if the pattern CAN match.
+# Without this, a typo'd regex would report a clean pass forever.
+SENTINEL="$(mktemp)"; trap 'rm -f "$CODE" "$SENTINEL"' EXIT
+printf 'VLOG="$REPO/logs/voice-agent.log"\n' > "$SENTINEL"
+check "CONTROL: the pattern actually matches the defect it is written to catch" \
+	bash -c 'grep -qE "\\\$\{?REPO(_DIR)?\}?/logs" "$1"' _ "$SENTINEL"
+
+# The script must resolve the workspace through the canonical shim, not invent it.
+check "gather.sh resolves the workspace via sutando-config.sh" \
+	grep -qE 'WS="\$\(bash "\$REPO/scripts/sutando-config.sh" workspace\)"' "$GATHER"
+
+# And the three repointed reads must now be workspace-relative.
+for pat in 'VLOG="\$WS/logs/voice-agent.log"' 'DLOG="\$WS/logs/discord-bridge.log"' 'find "\$WS/results"'; do
+	check "reads via \$WS: $pat" grep -qE "$pat" "$GATHER"
+done
+
+echo
+if [ "$fails" -eq 0 ]; then
+	echo "PASS ($checks checks)"
+	exit 0
+fi
+echo "FAILED: $fails/$checks"
+exit 1

--- a/tests/self-diagnose-reads-workspace-paths.test.sh
+++ b/tests/self-diagnose-reads-workspace-paths.test.sh
@@ -15,9 +15,11 @@
 # 431/226/7/6 matching lines.
 #
 # The existing scripts/lint-workspace-resolution.sh cannot catch this class: it
-# refuses $SUTANDO_WORKSPACE reads, hardcoded ~/.sutando/workspace, and
+# refuses $SUTANDO_WORKSPACE reads, the legacy hardcoded install path, and
 # Path(__file__).parent.parent repo-walks — not a CORRECTLY-resolved $REPO
-# pointed at a workspace-owned subdirectory.
+# pointed at a workspace-owned subdirectory. (Describing that legacy path by
+# name here would itself trip scripts/lint-sutando-home-path.sh, which is
+# correct: this file does not own install-path resolution.)
 #
 # Run: bash tests/self-diagnose-reads-workspace-paths.test.sh
 set -uo pipefail


### PR DESCRIPTION
## The bug

`logs/` and `results/` moved under the workspace in #1454 (the workspace-revamp rollup). `gather.sh` kept reading them from the repo:

```bash
VLOG="$REPO/logs/voice-agent.log"      # :148
DLOG="$REPO/logs/discord-bridge.log"   # :161
find "$REPO/results" -maxdepth 1 …     # :175
```

`<repo>/logs` does not exist, so `[ -f "$VLOG" ]` and `[ -f "$DLOG" ]` are false and both blocks are skipped **with no error**; the `find` writes an empty file.

**The failure inverts the report's meaning.** A `/self-diagnose` run reads "no transport events, no recent results" for logs nobody opened. A dead collector and a healthy system produce identical output — which is exactly the class of defect this repo has been fixing all week.

## Evidence, on a live host

```
$ REPO=/Users/wangchi/stando-ui/sutando
$ WS=$(bash scripts/sutando-config.sh workspace)  ->  …/sutando/workspace

# the guard gather.sh evaluates, at the OLD path:
$ [ -f "$REPO/logs/voice-agent.log" ]  ->  NOT FOUND -> block skipped silently
# the same guard at the NEW path:
$ [ -f "$WS/logs/voice-agent.log" ]    ->  FOUND (3818 lines)

repo results/:       DOES NOT EXIST
workspace results/:  exists

# outputs actually produced by today's /self-diagnose run:
 ABSENT  voice-agent-signals.txt
 ABSENT  voice-agent-size.txt
 ABSENT  discord-bridge-recent.txt
      0B  results-recent-paths.txt
```

Meanwhile the real workspace logs held 431 / 226 / 7 / 6 lines matching the error patterns. The report produced from that run stated "voice-agent.log has 0 error hits" — true only because the file was never read.

## The fix

Three reads repointed at `$WS`. gather.sh **already** resolves it at `:51` via `sutando-config.sh workspace`; the block simply used the wrong variable. `$REPO/notes` is deliberately left alone — it is a documented fallback with a dated TODO.

## The test, and why it has a control

`tests/self-diagnose-reads-workspace-paths.test.sh` asserts no **executable** line reads `$REPO/{logs,results,tasks,state}`. Comments are stripped first, because the fix's own comment discusses the old path — a naive grep would fail on the explanation of the bug it is guarding.

It also carries a positive control asserting the pattern matches the defect in a sentinel string. Without that, a typo'd regex reports a clean pass forever — **the same silent-zero failure mode as the bug itself**, which felt worth not repeating inside the regression test for it.

```
HEAD:              PASS (9 checks)
parent (c9f18570): FAILED: 5/9
```

The control passes at both commits, as a control should; the 5 failures are the three `$WS` reads plus the two `$REPO/{logs,results}` refusals.

## Follow-up, deliberately not in this PR

`scripts/lint-workspace-resolution.sh` cannot catch this class. It refuses `$SUTANDO_WORKSPACE` reads, hardcoded `~/.sutando/workspace`, and `Path(__file__).parent.parent` repo-walks — but not a *correctly-resolved* `$REPO` pointed at a workspace-owned subdirectory. Other instances exist, e.g. `src/notify.sh:23` writes `$REPO_DIR/results/proactive-*.txt` so its voice channel silently no-ops; that one is also **unreferenced repo-wide** (control: `health-check.py` appears in 15 files), so it is recorded rather than fixed here. Widening the linter is a separate concern and would flag pre-existing sites.

Stand: Echo Act IV Mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)
