### PR TITLE
fix(health-check): a carrier path that must NOT be carried is correct, not a failure

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1207,14 +1207,33 @@ def check_carrier_set_enforced(workspace_dir=None) -> "dict | None":
     stale = [e for e in stale if e not in UNSAFE_TO_READD]
 
     if not stale and not dropped and not unmeasured:
-        detail = f"all {len(resolved)} configured carrier path(s) un-ignored in the vault"
-        if stale_expected:
-            detail = (
+        if not stale_expected:
+            return {
+                "name": name,
+                "status": "ok",
+                "detail": f"all {len(resolved)} configured carrier path(s) un-ignored in the vault",
+            }
+        # NOT `ok`: this host is in the correct state, but it got there by DIVERGING
+        # from the shipped default, which still ships the flat path in
+        # `vault.sync.include` and still re-carries it on `--force-gitignore` or in a
+        # fresh workspace. Reporting `ok` would claim the default is safe when only
+        # this host is (qingyun-wu on #2570). `warn` is the honest level: `main()`
+        # excludes it from `issues`, so it never alerts and never reaches the --fix
+        # loop that would re-add the path — but it stays visible until phase 2 of
+        # #2567 removes the entry from the default, at which point the path stops
+        # being configured at all and this branch stops being reachable.
+        return {
+            "name": name,
+            "status": "warn",
+            "detail": (
                 f"{len(resolved) - len(stale_expected)} configured carrier path(s) un-ignored; "
-                f"{', '.join(stale_expected)} correctly NOT carried (shipped at a flat, shared path — "
-                f"do not `--force-gitignore` it back until #2567 lands)"
-            )
-        return {"name": name, "status": "ok", "detail": detail}
+                f"{', '.join(stale_expected)} correctly NOT carried on this host — but the shipped "
+                f"default still lists it in `vault.sync.include`, so a fresh workspace or "
+                f"`--force-gitignore` re-carries it at the flat, SHARED path and can resume the "
+                f"cross-host overwrite. This host is right and the default is not; do not "
+                f"`--force-gitignore` it back. Clears when phase 2 of #2567 drops the entry"
+            ),
+        }
 
     parts = []
     if unmeasured:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1217,14 +1217,25 @@ def check_carrier_set_enforced(workspace_dir=None) -> "dict | None":
         # from the shipped default, which still ships the flat path in
         # `vault.sync.include` and still re-carries it on `--force-gitignore` or in a
         # fresh workspace. Reporting `ok` would claim the default is safe when only
-        # this host is (qingyun-wu on #2570). `warn` is the honest level: `main()`
-        # excludes it from `issues`, so it never alerts and never reaches the --fix
-        # loop that would re-add the path — but it stays visible until phase 2 of
-        # #2567 removes the entry from the default, at which point the path stops
-        # being configured at all and this branch stops being reachable.
+        # this host is (qingyun-wu on #2570).
+        #
+        # `warn` + an EXPLICIT `alerting: False`. The first cut set `warn` alone and
+        # claimed in this comment that it "never alerts" because `main()` excludes
+        # warn from `issues` — which was simply false. `issues` is a local list used
+        # to print a summary; `--emit-task`, `--notify-on-fail` and `--notify-slack`
+        # each consume the FULL checks list and treat a plain warn as a failure, so
+        # this state still fired a task and a notification on first transition
+        # (qingyun-wu again, with a one-check witness). The claim was tested against
+        # the list I happened to have named rather than the surfaces that enforce.
+        #
+        # Suppression is right HERE specifically: the owner cannot act on it. Phase 2
+        # of #2567 is gated on migration evidence, so paging about it would repeat a
+        # non-actionable message until that lands, and this branch stops being
+        # reachable once the flat path leaves the shipped default.
         return {
             "name": name,
             "status": "warn",
+            "alerting": False,
             "detail": (
                 f"{len(resolved) - len(stale_expected)} configured carrier path(s) un-ignored; "
                 f"{', '.join(stale_expected)} correctly NOT carried on this host — but the shipped "
@@ -5173,6 +5184,29 @@ def _any_core_alive(workspace: Optional[Path] = None, max_age_s: float = 90.0) -
     return False
 
 
+def _alerts_suppressed(check: dict) -> bool:
+    """True when a check must NOT wake anyone, whatever its status says.
+
+    `main()` computes a local `issues` list, and it is tempting to treat that as
+    "what alerts". It is not. `--emit-task`, `--notify-on-fail` and
+    `--notify-slack` each consume the FULL `checks` list through their own
+    filters, and all three count a plain `warn` as a failure. A carve-out tested
+    only against `issues` therefore still fires a task and a macOS notification
+    on the first transition (qingyun-wu, #2570 — verified on the exact head with
+    a one-check witness: notification written, 1 Slack message, 1 task file).
+
+    So suppression has to be an explicit property of the CHECK, honored at every
+    surface that can wake someone, rather than a status the reader hopes is
+    benign. A probe sets `"alerting": False` when its result is genuinely
+    informational — visible on the dashboard, never a page.
+
+    Deliberately narrow: only an explicit `False` suppresses. A missing key
+    alerts, so no existing check changes behavior by omission, and a typo cannot
+    silence a real failure.
+    """
+    return check.get("alerting") is False
+
+
 def emit_task_for_failures(checks: list[dict], state_file: Optional[Path] = None, tasks_dir: Optional[Path] = None) -> None:
     """Emit a task file describing health-check failures so the proactive
     loop's CLI session sees them via the watcher and can decide what to do
@@ -5204,7 +5238,9 @@ def emit_task_for_failures(checks: list[dict], state_file: Optional[Path] = None
     # watchdog catches the bug class that motivated this PR. Excluding
     # would have missed Mini's discord-bridge issue this morning. Per
     # her PR review note 2026-05-05.
-    failures = [c for c in checks if c["status"] in ("down", "missing", "not_loaded", "fail", "stale", "warn")]
+    failures = [c for c in checks
+                if c["status"] in ("down", "missing", "not_loaded", "fail", "stale", "warn")
+                and not _alerts_suppressed(c)]
     if not failures:
         return
 
@@ -5289,7 +5325,9 @@ def notify_for_failures(
     defaults to `osascript` driving `display notification`. Tests inject a
     fake to avoid spamming the developer's own notification center.
     """
-    failures = [c for c in checks if c["status"] in ("down", "missing", "not_loaded", "fail", "stale", "warn")]
+    failures = [c for c in checks
+                if c["status"] in ("down", "missing", "not_loaded", "fail", "stale", "warn")
+                and not _alerts_suppressed(c)]
     if not failures:
         return
 
@@ -5354,9 +5392,12 @@ def _slack_failures(checks: list[dict]) -> list[dict]:
     out = []
     for c in checks:
         st = c["status"]
+        if _alerts_suppressed(c):
+            continue
         if st in ("down", "missing", "not_loaded", "fail", "stale"):
             out.append(c)
-        elif st == "warn" and "on-demand" not in (c.get("detail") or ""):
+        elif st == "warn" and "on-demand" not in (c.get("detail") or "") \
+                and not _alerts_suppressed(c):
             out.append(c)
     return out
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1195,9 +1195,26 @@ def check_carrier_set_enforced(workspace_dir=None) -> "dict | None":
     unsafe = [e for e in dropped if e in UNSAFE_TO_READD]
     safe = [e for e in dropped if e not in UNSAFE_TO_READD]
 
+    # The same carve-out has to reach the STALE branch, and there it inverts the
+    # verdict rather than just softening the wording. A path that must not be
+    # carried and is NOT being carried is in its CORRECT state — reporting that as
+    # a failure whose remedy is `--force-gitignore` would walk the operator into
+    # re-carrying it, which is the cross-host overwrite this carve-out exists to
+    # prevent. Found by running the merged probe on a live host that had
+    # deliberately un-carried the path: it said `fail` and named the exact command
+    # that resumes the incident.
+    stale_expected = [e for e in stale if e in UNSAFE_TO_READD]
+    stale = [e for e in stale if e not in UNSAFE_TO_READD]
+
     if not stale and not dropped and not unmeasured:
-        return {"name": name, "status": "ok",
-                "detail": f"all {len(resolved)} configured carrier path(s) un-ignored in the vault"}
+        detail = f"all {len(resolved)} configured carrier path(s) un-ignored in the vault"
+        if stale_expected:
+            detail = (
+                f"{len(resolved) - len(stale_expected)} configured carrier path(s) un-ignored; "
+                f"{', '.join(stale_expected)} correctly NOT carried (shipped at a flat, shared path — "
+                f"do not `--force-gitignore` it back until #2567 lands)"
+            )
+        return {"name": name, "status": "ok", "detail": detail}
 
     parts = []
     if unmeasured:

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -351,20 +351,72 @@ class CarrierSetProbe(unittest.TestCase):
         self.assertNotIn("fix with `bash scripts/sync-workspace.sh --force-gitignore`", r["detail"],
                          "must never hand back the command that resumes the overwrite")
 
-    def test_the_UNSAFE_carve_out_never_reaches_the_alerting_issue_list(self):
-        # The carve-out's whole safety property is that it does not alert and does
-        # not reach the --fix loop, because that loop's remedy is the command that
-        # resumes the overwrite. `main()` computes `issues` as everything whose
-        # status is not ok/warn, so this pins the classification rather than the
-        # string — if a later change moves the verdict to any other status, this
-        # fails even though the wording still looks right.
+    def _carve_out_result(self):
         ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
                           ["notes/a.md", "state/current-track.md"])
         self._patch_resolved(["notes/", "state/current-track.md"])
         self._patch_shipped(["notes/", "state/current-track.md"])
-        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
-        self.assertIn(r["status"], ("ok", "warn"),
-                      "must stay out of main()'s issues list, which drives alerts and --fix")
+        return self.hc.check_carrier_set_enforced(workspace_dir=ws)
+
+    def test_the_UNSAFE_carve_out_stays_out_of_the_issues_list(self):
+        # Necessary but NOWHERE NEAR sufficient — see the three tests below. This
+        # only pins that the summary/--fix path treats it as a non-issue.
+        r = self._carve_out_result()
+        self.assertIn(r["status"], ("ok", "warn"))
+
+    def test_the_carve_out_does_not_EMIT_A_TASK(self):
+        # The first version of this carve-out asserted "never alerts" and tested
+        # main()'s local `issues` list — which is not what alerts. `--emit-task`
+        # consumes the FULL checks list and counted a plain warn as a failure, so
+        # the state still queued a task for the agent (qingyun-wu, #2570).
+        # Exercise the helper itself.
+        r = self._carve_out_result()
+        tasks = self.tmp / "emit-tasks"
+        tasks.mkdir(exist_ok=True)
+        self.hc.emit_task_for_failures(
+            [r], state_file=self.tmp / "emit-state.json", tasks_dir=tasks)
+        self.assertEqual(sorted(p.name for p in tasks.glob("*.txt")), [],
+                         "a non-actionable transitional state must not queue owner work")
+
+    def test_the_carve_out_does_not_NOTIFY_or_reach_the_owner_DM(self):
+        # notify_for_failures shells out to osascript; record the invocation
+        # instead of firing a real notification at whoever runs the suite. It
+        # also writes its dedup state file only when it actually alerts, so the
+        # absence of that file is a second, independent witness.
+        r = self._carve_out_result()
+        calls = []
+        real_run = self.hc.subprocess.run
+        self.hc.subprocess.run = lambda *a, **kw: calls.append(a) or real_run(
+            ["/usr/bin/true"], capture_output=True)
+        state = self.tmp / "notify-state.json"
+        try:
+            self.hc.notify_for_failures([r], state_file=state)
+        finally:
+            self.hc.subprocess.run = real_run
+        self.assertEqual(calls, [], "a suppressed check must not fire a notification")
+        self.assertFalse(state.exists(), "and must not record an alert transition")
+        self.assertNotIn(r, self.hc._slack_failures([r]),
+                         "nor reach the remote owner DM")
+
+    def test_an_ORDINARY_warn_still_alerts(self):
+        # Over-trigger control. The suppression must be narrow: if it muted every
+        # warn, this fix would trade a false page for a silent failure, which is
+        # strictly worse in a probe whose job is catching silent non-backup.
+        ordinary = {"name": "something-else", "status": "warn", "detail": "a real problem"}
+        tasks = self.tmp / "ordinary-tasks"
+        tasks.mkdir(exist_ok=True)
+        self.hc.emit_task_for_failures(
+            [ordinary], state_file=self.tmp / "ordinary-state.json", tasks_dir=tasks)
+        self.assertEqual(len(list(tasks.glob("*.txt"))), 1,
+                         "an ordinary warn must still reach the owner")
+        self.assertIn(ordinary, self.hc._slack_failures([ordinary]))
+
+    def test_suppression_requires_an_explicit_False(self):
+        # A missing key must alert, so no existing check changes behavior by
+        # omission and a typo cannot silence a real failure.
+        self.assertFalse(self.hc._alerts_suppressed({"status": "warn"}))
+        self.assertFalse(self.hc._alerts_suppressed({"status": "warn", "alerting": True}))
+        self.assertTrue(self.hc._alerts_suppressed({"status": "warn", "alerting": False}))
 
     def test_a_genuinely_stale_SAFE_path_still_fails_with_its_remedy(self):
         # Over-trigger control. The carve-out must not blind the stale branch to

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -84,14 +84,16 @@ class CarrierSetProbe(unittest.TestCase):
         # THE REGRESSION. Config lists state/current-track.md; the on-disk
         # exclude predates it, so git still ignores the file and the vault is
         # not backing it up. This must fail loudly, not read healthy.
+        # Uses `hosts/*/`, not `state/current-track.md`: this test is about STALE
+        # DETECTION, and that path now routes to the must-not-be-carried carve-out.
         ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
-                          ["notes/a.md", "state/current-track.md"])
-        self._patch_resolved(["notes/", "state/current-track.md"])
-        self._patch_shipped(["notes/", "state/current-track.md"])
+                          ["notes/a.md", "hosts/h/pending-questions.md"])
+        self._patch_resolved(["notes/", "hosts/*/"])
+        self._patch_shipped(["notes/", "hosts/*/"])
         r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
         self.assertIsNotNone(r, "probe returned None on a genuinely stale carrier set")
         self.assertEqual(r["status"], "fail")
-        self.assertIn("state/current-track.md", r["detail"])
+        self.assertIn("hosts/*/", r["detail"])
         self.assertIn("--force-gitignore", r["detail"], "must name the remedy")
 
     def test_a_TRACKED_file_with_a_stale_exclude_is_still_reported(self):
@@ -101,18 +103,20 @@ class CarrierSetProbe(unittest.TestCase):
         # host that carried the file once, then had its exclude go stale, read
         # healthy forever — the probe was blind to precisely the population it
         # was written for. `--no-index` is what makes the answer about the RULES.
+        # Safe path for the same reason as above — the assertion is about
+        # --no-index, not about which file is involved.
         ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
-                          ["notes/a.md", "state/current-track.md"])
-        subprocess.run(["git", "-C", str(ws), "add", "-f", "state/current-track.md"],
+                          ["notes/a.md", "hosts/h/pending-questions.md"])
+        subprocess.run(["git", "-C", str(ws), "add", "-f", "hosts/h/pending-questions.md"],
                        check=True, capture_output=True)
-        self._patch_resolved(["notes/", "state/current-track.md"])
-        self._patch_shipped(["notes/", "state/current-track.md"])
+        self._patch_resolved(["notes/", "hosts/*/"])
+        self._patch_shipped(["notes/", "hosts/*/"])
         r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
         self.assertIsNotNone(r)
         self.assertEqual(r["status"], "fail",
                          "a tracked file with a stale exclude must still report — "
                          "check-ignore without --no-index answers about the index, not the rules")
-        self.assertIn("state/current-track.md", r["detail"])
+        self.assertIn("hosts/*/", r["detail"])
 
     def test_an_enforced_carrier_set_reads_ok(self):
         # Over-trigger control. If this ever fails, the probe cries wolf on every
@@ -310,6 +314,46 @@ class CarrierSetProbe(unittest.TestCase):
         self.assertIn("hosts/*/", r["detail"])
         self.assertIn("add them to the local list", r["detail"])
         self.assertNotIn("must NOT be re-added", r["detail"])
+
+    def test_an_UNSAFE_path_that_is_NOT_carried_is_correct_not_a_failure(self):
+        # Found by running the merged probe on a live host. That host had
+        # deliberately un-carried `state/current-track.md` to stop overwriting a
+        # peer's anchor — the RIGHT state — and the probe reported `fail` with the
+        # remedy `--force-gitignore`, i.e. the exact command that re-carries it and
+        # resumes the cross-host overwrite.
+        #
+        # #2566 gave the dropped branch this carve-out; the stale branch never got
+        # it. Here it must INVERT the verdict, not just soften the wording: not
+        # carrying a path that must not be carried is success.
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
+                          ["notes/a.md", "state/current-track.md"])
+        self._patch_resolved(["notes/", "state/current-track.md"])
+        self._patch_shipped(["notes/", "state/current-track.md"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "ok",
+                         "an unsafe-to-carry path that is not carried is the correct state")
+        self.assertIn("correctly NOT carried", r["detail"])
+        # The command name legitimately appears as a PROHIBITION ("do not
+        # `--force-gitignore` it back"). Asserting its mere absence would forbid
+        # the warning as well as the instruction — what must never appear is the
+        # INSTRUCTIONAL form the stale branch hands out.
+        self.assertIn("do not `--force-gitignore`", r["detail"])
+        self.assertNotIn("fix with `bash scripts/sync-workspace.sh --force-gitignore`", r["detail"],
+                         "must never hand back the command that resumes the overwrite")
+
+    def test_a_genuinely_stale_SAFE_path_still_fails_with_its_remedy(self):
+        # Over-trigger control. The carve-out must not blind the stale branch to
+        # the case the whole probe exists for.
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
+                          ["notes/a.md", "hosts/h/pending-questions.md"])
+        self._patch_resolved(["notes/", "hosts/*/"])
+        self._patch_shipped(["notes/", "hosts/*/"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "fail")
+        self.assertIn("hosts/*/", r["detail"])
+        self.assertIn("--force-gitignore", r["detail"], "the real remedy must survive")
 
     def test_the_probe_is_registered_in_the_run_list(self):
         # A probe nobody calls cannot report anything. This is the assertion

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -315,7 +315,7 @@ class CarrierSetProbe(unittest.TestCase):
         self.assertIn("add them to the local list", r["detail"])
         self.assertNotIn("must NOT be re-added", r["detail"])
 
-    def test_an_UNSAFE_path_that_is_NOT_carried_is_correct_not_a_failure(self):
+    def test_an_UNSAFE_path_that_is_NOT_carried_is_not_a_failure(self):
         # Found by running the merged probe on a live host. That host had
         # deliberately un-carried `state/current-track.md` to stop overwriting a
         # peer's anchor — the RIGHT state — and the probe reported `fail` with the
@@ -323,17 +323,26 @@ class CarrierSetProbe(unittest.TestCase):
         # resumes the cross-host overwrite.
         #
         # #2566 gave the dropped branch this carve-out; the stale branch never got
-        # it. Here it must INVERT the verdict, not just soften the wording: not
-        # carrying a path that must not be carried is success.
+        # it. Here it must move the verdict off `fail` — not carrying a path that
+        # must not be carried is not a failure.
+        #
+        # But NOT to `ok` either (qingyun-wu, #2570): this host is only right
+        # because it DIVERGED from the shipped default, which still lists the flat
+        # path and still re-carries it in a fresh workspace. `warn` is the honest
+        # level — visible, but `main()` excludes it from `issues`, so it neither
+        # alerts nor reaches the --fix loop that would re-add the path.
         ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
                           ["notes/a.md", "state/current-track.md"])
         self._patch_resolved(["notes/", "state/current-track.md"])
         self._patch_shipped(["notes/", "state/current-track.md"])
         r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
         self.assertIsNotNone(r)
-        self.assertEqual(r["status"], "ok",
-                         "an unsafe-to-carry path that is not carried is the correct state")
+        self.assertEqual(r["status"], "warn",
+                         "correct on this host, but the shipped default still re-carries it")
         self.assertIn("correctly NOT carried", r["detail"])
+        # The detail must name the DEFAULT as the thing still unsafe, or the warn
+        # reads as a local nit rather than a live gap in the shipped contract.
+        self.assertIn("default", r["detail"])
         # The command name legitimately appears as a PROHIBITION ("do not
         # `--force-gitignore` it back"). Asserting its mere absence would forbid
         # the warning as well as the instruction — what must never appear is the
@@ -341,6 +350,21 @@ class CarrierSetProbe(unittest.TestCase):
         self.assertIn("do not `--force-gitignore`", r["detail"])
         self.assertNotIn("fix with `bash scripts/sync-workspace.sh --force-gitignore`", r["detail"],
                          "must never hand back the command that resumes the overwrite")
+
+    def test_the_UNSAFE_carve_out_never_reaches_the_alerting_issue_list(self):
+        # The carve-out's whole safety property is that it does not alert and does
+        # not reach the --fix loop, because that loop's remedy is the command that
+        # resumes the overwrite. `main()` computes `issues` as everything whose
+        # status is not ok/warn, so this pins the classification rather than the
+        # string — if a later change moves the verdict to any other status, this
+        # fails even though the wording still looks right.
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
+                          ["notes/a.md", "state/current-track.md"])
+        self._patch_resolved(["notes/", "state/current-track.md"])
+        self._patch_shipped(["notes/", "state/current-track.md"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIn(r["status"], ("ok", "warn"),
+                      "must stay out of main()'s issues list, which drives alerts and --fix")
 
     def test_a_genuinely_stale_SAFE_path_still_fails_with_its_remedy(self):
         # Over-trigger control. The carve-out must not blind the stale branch to


### PR DESCRIPTION
Follow-up to #2566, found by running the merged probe on a live host.

## The bug

That host had deliberately un-carried `state/current-track.md` to stop overwriting a peer's anchor — **the correct state**. The merged probe said:

```
✗ carrier-set  fail  1 configured carrier path(s) are STILL GIT-IGNORED …
                     fix with `bash scripts/sync-workspace.sh --force-gitignore`
```

It named the exact command that re-carries the path and **resumes the cross-host overwrite** (#2567).

@qingyun-wu caught this class on #2566's `dropped` branch and I added `UNSAFE_TO_READD` there. **The `stale` branch never got the carve-out** — so the same instruction survived in the branch nobody examined. Fixing the reported instance rather than the class.

## The fix

In the stale branch the carve-out **inverts the verdict** rather than softening wording — not carrying a path that must not be carried is success:

```
ok  3 configured carrier path(s) un-ignored; state/current-track.md correctly NOT
    carried (shipped at a flat, shared path — do not `--force-gitignore` it back
    until #2567 lands)
```

## Notes

Two existing tests used that path as their example while actually testing **stale detection** and the `--no-index` contract. Re-pointed at `hosts/*/` so the mechanism and the carve-out stop colliding — same move as the dormant-override test in #2566.

One of my own new assertions was wrong and the suite caught it: I asserted `--force-gitignore` was absent, but it legitimately appears as a *prohibition*. Sharpened to forbid only the instructional form — otherwise the test would have banned the warning along with the instruction.

```
parent 0c92c8e8 : 18 tests, FAILED (failures=1)
HEAD            : 18 tests, OK
60 suites touching health-check / git_binary : 60 pass, 0 fail
diff coverage 100%
```

Stand: Echo Act IV Mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)