### PR TITLE
fix(health-check): the dropped branch tests coverage, not config strings

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1207,10 +1207,22 @@ def _carrier_target_verdict(workspace: Path, rep: Path) -> str:
         # callers, which report an entry with no representatives at all.
         return "carried"
 
-    rels = "\n".join(str(t.relative_to(workspace)) for t in targets)
+    # NUL-delimited, not newline. A filename may CONTAIN a newline, and
+    # `"\n".join(...)` then splits one real path into two bogus ones — both of
+    # which are typically un-ignored, so the genuinely ignored carrier file reads
+    # as carried. Reproduced on a real tree (john-the-dev, #2572):
+    #
+    #     notes/z\nx.md  check-ignore -q  -> 0  (IGNORED, not backed up)
+    #     split halves   notes/z, x.md    -> 1, 1 (both un-ignored)
+    #     newline-joined batch            -> 1  -> reads CARRIED, false green
+    #     NUL-joined with -z              -> 0  -> dropped, correct
+    #
+    # `-z` makes git read NUL-separated input, which is the only delimiter a
+    # POSIX filename cannot contain.
+    rels = "\0".join(str(t.relative_to(workspace)) for t in targets)
     try:
         proc = subprocess.run(
-            git_argv("-C", str(workspace), "check-ignore", "--no-index", "--stdin"),
+            git_argv("-C", str(workspace), "check-ignore", "--no-index", "-z", "--stdin"),
             input=rels, capture_output=True, text=True, timeout=60,
         )
     except (GitUnavailable, OSError, subprocess.SubprocessError):

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1116,24 +1116,45 @@ def check_memory_dir_siblings() -> "dict | None":
     }
 
 
-def _carrier_representative(workspace: Path, entry: str) -> "Path | None":
-    """Resolve one existing concrete path for a carrier-set entry, or None.
+def _carrier_representatives(workspace: Path, entry: str) -> "list[Path]":
+    """EVERY existing concrete path a carrier-set entry matches.
 
     Entries are gitignore-style and may be globs (`hosts/*/`), directories
-    (`notes/`) or plain files (`state/current-track.md`). We only need ONE
-    materialized path per entry to ask git whether the entry is being carried;
-    an entry with nothing on disk yet is not evidence of anything, so it is
-    skipped rather than reported.
+    (`notes/`) or plain files (`state/current-track.md`).
+
+    Deliberately ALL matches, not the first. Sampling one is sound for the stale
+    branch (which asks "is the entry this host configured actually in effect" —
+    one witness settles it), but not for judging whether a *local* rule covers a
+    *shipped* one: a narrower local rule can cover one child of a shipped
+    wildcard while leaving its siblings ignored, and a first-hit check that
+    happened to land on the covered child would report the vault healthy while a
+    whole host subtree went unbacked (qingyun-wu P1 on #2572).
+
+    Enumeration is bounded by construction: glob matches are the entry's own
+    direct matches (`hosts/*/` -> one path per host), never a recursive walk of
+    their contents.
     """
     rel = entry.strip().lstrip("/").rstrip("/")
     if not rel:
-        return None
+        return []
     if any(ch in rel for ch in "*?["):
-        for hit in sorted(workspace.glob(rel)):
-            return hit
-        return None
+        return sorted(workspace.glob(rel))
     candidate = workspace / rel
-    return candidate if candidate.exists() else None
+    return [candidate] if candidate.exists() else []
+
+
+def _carrier_representative(workspace: Path, entry: str) -> "Path | None":
+    """One existing concrete path for a carrier-set entry, or None.
+
+    The single-witness form, kept for the stale branch: that branch asks whether
+    the entry THIS host configured is in effect, and one materialized path
+    answers it. An entry with nothing on disk yet is not evidence of anything,
+    so it is skipped rather than reported. Use `_carrier_representatives` when
+    the question is coverage of a *different* (shipped) entry — see its
+    docstring for why one witness is not enough there.
+    """
+    reps = _carrier_representatives(workspace, entry)
+    return reps[0] if reps else None
 
 
 def check_carrier_set_enforced(workspace_dir=None) -> "dict | None":
@@ -1226,39 +1247,65 @@ def check_carrier_set_enforced(workspace_dir=None) -> "dict | None":
     try:
         shipped_cfg = json.loads((Path(REPO_DIR) / "sutando.config.json").read_text())
         shipped = ((shipped_cfg.get("vault") or {}).get("sync") or {}).get("include")
-        if isinstance(shipped, list):
-            missing = [e for e in shipped if isinstance(e, str) and e not in resolved]
-            # String inequality is not absence of coverage. A local entry can be
-            # strictly BROADER than the shipped one it replaces — `hosts/` covers
-            # everything `hosts/*/` does — and the whole point of this probe is to
-            # judge by outcome, not by config text. The `stale` branch above already
-            # asks git; this branch used to revert to string equality, so it reported
-            # a fully-carried subtree as missing and advised "add them to the local
-            # list", i.e. told the operator to NARROW a config that was already
-            # correct (#2571, reported against #2566 by Sutando-Pro).
-            #
-            # So an entry only counts as dropped once git agrees nothing under it is
-            # carried. An entry with nothing materialized yet stays reported: there is
-            # no outcome to measure, but the divergence is real and becomes silent
-            # data loss the moment the first file lands under it.
-            for entry in missing:
-                rep = _carrier_representative(workspace, entry)
-                if rep is None:
-                    dropped.append(entry)
-                    continue
-                proc = subprocess.run(
-                    git_argv("-C", str(workspace), "check-ignore", "--no-index", "-q",
-                             str(rep.relative_to(workspace))),
-                    capture_output=True, timeout=10,
-                )
-                # Same contract as the stale branch: 0 = ignored (so genuinely not
-                # carried), 1 = not ignored (covered by some broader local rule).
-                # Anything else is a failed measurement — keep reporting it rather
-                # than let an unmeasured read count as covered.
+    except (OSError, json.JSONDecodeError, AttributeError):
+        # The shipped config itself is unreadable, so there is no comparison to
+        # make. This except must stay narrow and must NOT wrap the measurement
+        # loop below: the first cut did, so one entry's git timeout jumped here
+        # and reset `dropped = []`, erasing findings already collected — a
+        # fail-OPEN that turned a failed measurement into a green report, three
+        # lines under a comment promising the opposite (qingyun-wu P1 on #2572).
+        shipped = None
+
+    if isinstance(shipped, list):
+        missing = [e for e in shipped if isinstance(e, str) and e not in resolved]
+        # String inequality is not absence of coverage. A local entry can be
+        # strictly BROADER than the shipped one it replaces — `hosts/` covers
+        # everything `hosts/*/` does — and the whole point of this probe is to
+        # judge by outcome, not by config text. The `stale` branch above already
+        # asks git; this branch used to revert to string equality, so it reported
+        # a fully-carried subtree as missing and advised "add them to the local
+        # list", i.e. told the operator to NARROW a config that was already
+        # correct (#2571, reported against #2566 by Sutando-Pro).
+        #
+        # EVERY materialized match must be covered, not one sampled witness. A
+        # narrower local rule (`hosts/a/`) covers one child of a shipped wildcard
+        # (`hosts/*/`) while its siblings stay ignored, and first-hit sampling
+        # that landed on the covered child reported the vault healthy with a host
+        # subtree silently unbacked.
+        #
+        # An entry with nothing materialized yet stays reported: there is no
+        # outcome to measure, but the divergence is real and becomes silent data
+        # loss the moment the first file lands under it.
+        for entry in missing:
+            reps = _carrier_representatives(workspace, entry)
+            if not reps:
+                dropped.append(entry)
+                continue
+            verdict = "covered"
+            for rep in reps:
+                try:
+                    proc = subprocess.run(
+                        git_argv("-C", str(workspace), "check-ignore", "--no-index", "-q",
+                                 str(rep.relative_to(workspace))),
+                        capture_output=True, timeout=10,
+                    )
+                except (GitUnavailable, OSError, subprocess.SubprocessError):
+                    verdict = "unmeasured"
+                    break
+                # Same contract as the stale branch: 0 = ignored (so this match is
+                # genuinely not carried), 1 = not ignored (covered by a broader
+                # local rule). Anything else is a failed measurement, which is
+                # UNKNOWN — never "covered".
+                if proc.returncode == 0:
+                    verdict = "dropped"
+                    break
                 if proc.returncode != 1:
-                    dropped.append(entry)
-    except (OSError, json.JSONDecodeError, AttributeError, GitUnavailable, subprocess.SubprocessError):
-        dropped = []
+                    verdict = "unmeasured"
+                    break
+            if verdict == "dropped":
+                dropped.append(entry)
+            elif verdict == "unmeasured":
+                unmeasured.append(entry)
 
     # A shipped entry can be one this host must NOT carry. `state/current-track.md`
     # is per-host state that #2534 added at a flat, SHARED vault path: two cores write

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1286,8 +1286,19 @@ def check_carrier_set_enforced(workspace_dir=None) -> "dict | None":
     stale: "list[str]" = []
     unmeasured: "list[str]" = []
     for entry in resolved:
-        rep = _carrier_representative(workspace, entry)
-        if rep is None:
+        # EVERY materialized match, not one. `_carrier_representative()` (singular)
+        # collapses `hosts/*/` to its first match, so a two-host workspace whose
+        # exclude carries host A but not host B reported `ok` while B's subtree
+        # was ignored and unbacked — the same false green the dropped branch was
+        # fixed for, on the OTHER axis.
+        #
+        # The previous round shared the directory-vs-file instrument across both
+        # branches and stopped there. Coverage has two independent axes — WHICH
+        # paths you probe, and WHAT you ask about each — and generalizing one of
+        # them left the other singular here. Both branches now enumerate.
+        # (john-the-dev and qingyun-wu, independently, on cf059ca8.)
+        reps = _carrier_representatives(workspace, entry)
+        if not reps:
             continue
         # `git_argv` rather than a bare "git": on macOS the stock /usr/bin/git is
         # an Xcode-CLT shim that pops an install dialog when the tools are absent,
@@ -1301,7 +1312,12 @@ def check_carrier_set_enforced(workspace_dir=None) -> "dict | None":
         # Caught by restoring this host's real pre-fix exclude and watching the
         # probe still say OK. Both that and the directory/contents distinction now
         # live in `_carrier_target_verdict` so the two branches cannot drift.
-        verdict = _carrier_target_verdict(workspace, rep)
+        verdict = "carried"
+        for rep in reps:
+            got = _carrier_target_verdict(workspace, rep)
+            if got != "carried":
+                verdict = got
+                break
         if verdict == "dropped":
             stale.append(entry)
         elif verdict == "unmeasured":

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1227,8 +1227,37 @@ def check_carrier_set_enforced(workspace_dir=None) -> "dict | None":
         shipped_cfg = json.loads((Path(REPO_DIR) / "sutando.config.json").read_text())
         shipped = ((shipped_cfg.get("vault") or {}).get("sync") or {}).get("include")
         if isinstance(shipped, list):
-            dropped = [e for e in shipped if isinstance(e, str) and e not in resolved]
-    except (OSError, json.JSONDecodeError, AttributeError):
+            missing = [e for e in shipped if isinstance(e, str) and e not in resolved]
+            # String inequality is not absence of coverage. A local entry can be
+            # strictly BROADER than the shipped one it replaces — `hosts/` covers
+            # everything `hosts/*/` does — and the whole point of this probe is to
+            # judge by outcome, not by config text. The `stale` branch above already
+            # asks git; this branch used to revert to string equality, so it reported
+            # a fully-carried subtree as missing and advised "add them to the local
+            # list", i.e. told the operator to NARROW a config that was already
+            # correct (#2571, reported against #2566 by Sutando-Pro).
+            #
+            # So an entry only counts as dropped once git agrees nothing under it is
+            # carried. An entry with nothing materialized yet stays reported: there is
+            # no outcome to measure, but the divergence is real and becomes silent
+            # data loss the moment the first file lands under it.
+            for entry in missing:
+                rep = _carrier_representative(workspace, entry)
+                if rep is None:
+                    dropped.append(entry)
+                    continue
+                proc = subprocess.run(
+                    git_argv("-C", str(workspace), "check-ignore", "--no-index", "-q",
+                             str(rep.relative_to(workspace))),
+                    capture_output=True, timeout=10,
+                )
+                # Same contract as the stale branch: 0 = ignored (so genuinely not
+                # carried), 1 = not ignored (covered by some broader local rule).
+                # Anything else is a failed measurement — keep reporting it rather
+                # than let an unmeasured read count as covered.
+                if proc.returncode != 1:
+                    dropped.append(entry)
+    except (OSError, json.JSONDecodeError, AttributeError, GitUnavailable, subprocess.SubprocessError):
         dropped = []
 
     # A shipped entry can be one this host must NOT carry. `state/current-track.md`

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1143,32 +1143,29 @@ def _carrier_representatives(workspace: Path, entry: str) -> "list[Path]":
     return [candidate] if candidate.exists() else []
 
 
-# How many materialized files under a directory representative to ask git about.
-# Bounded because a carrier entry can name a large subtree and this runs from a
-# background health check. The bound is honest about its direction: past the cap
-# the probe can UNDER-report (an ignored file beyond it goes unseen), never
-# over-report — the same failure direction as the no-network ref staleness.
-_PROBE_FILES_PER_DIR = 25
-
-
 def _carrier_probe_files(rep: "Path") -> "list[Path]":
-    """The concrete files to ask git about for one materialized representative.
+    """Every concrete file a materialized representative stands for.
 
-    A file represents itself. A DIRECTORY is represented by the files beneath
-    it, sorted for determinism (an unsorted walk would make the probe's verdict
-    depend on filesystem order) and capped at `_PROBE_FILES_PER_DIR`.
+    A file represents itself; a DIRECTORY is represented by every file beneath
+    it, sorted for determinism.
+
+    Deliberately EXHAUSTIVE. The first cut sampled the first 25 and said so in a
+    comment — "past the cap the probe can UNDER-report" — which treated a stated
+    caveat as an acceptable conclusion rather than a defect. john-the-dev built
+    the obvious counterexample on that head: 26 files with only the 26th ignored
+    read `ok`, so a stale exclude left a real carrier file unbacked while health
+    certified the subtree. In a probe whose entire purpose is catching silent
+    non-backup, a sample is not proof of coverage.
+
+    Cost is bounded by asking git ONCE for the whole list (`check-ignore
+    --stdin`) rather than once per file, so exhaustiveness costs a filesystem
+    walk plus a single process — not N processes. See `_carrier_target_verdict`.
     """
     if rep.is_file():
         return [rep]
     if not rep.is_dir():
         return []
-    out = []
-    for f in sorted(rep.rglob("*")):
-        if f.is_file():
-            out.append(f)
-            if len(out) >= _PROBE_FILES_PER_DIR:
-                break
-    return out
+    return sorted(f for f in rep.rglob("*") if f.is_file())
 
 
 def _carrier_target_verdict(workspace: Path, rep: Path) -> str:
@@ -1183,8 +1180,10 @@ def _carrier_target_verdict(workspace: Path, rep: Path) -> str:
     backed up. Reproduced independently by john-the-dev and qingyun-wu on
     a958d06f, and confirmed here before changing anything.
 
-    So a directory is probed through the FILES beneath it, bounded by
-    `_PROBE_FILES_PER_DIR`, and any ignored one condemns the entry.
+    So a directory is probed through EVERY file beneath it, and any ignored one
+    condemns the entry. Exhaustive rather than sampled: a 26-file directory whose
+    26th file alone was ignored read `ok` under the old 25-file cap
+    (john-the-dev, #2572), which is the exact silent non-backup this exists for.
 
     `--no-index` stays load-bearing and the instrument stays `check-ignore` for
     a reason worth recording: the obvious alternative,
@@ -1208,22 +1207,22 @@ def _carrier_target_verdict(workspace: Path, rep: Path) -> str:
         # callers, which report an entry with no representatives at all.
         return "carried"
 
-    for target in targets:
-        try:
-            proc = subprocess.run(
-                git_argv("-C", str(workspace), "check-ignore", "--no-index", "-q",
-                         str(target.relative_to(workspace))),
-                capture_output=True, timeout=10,
-            )
-        except (GitUnavailable, OSError, subprocess.SubprocessError):
-            return "unmeasured"
-        # check-ignore's contract: 0 = ignored, 1 = NOT ignored, anything else =
-        # it failed. Folding "not 0" into healthy would count exit 128 as carried.
-        if proc.returncode == 0:
-            return "dropped"
-        if proc.returncode != 1:
-            return "unmeasured"
-    return "carried"
+    rels = "\n".join(str(t.relative_to(workspace)) for t in targets)
+    try:
+        proc = subprocess.run(
+            git_argv("-C", str(workspace), "check-ignore", "--no-index", "--stdin"),
+            input=rels, capture_output=True, text=True, timeout=60,
+        )
+    except (GitUnavailable, OSError, subprocess.SubprocessError):
+        return "unmeasured"
+    # check-ignore's contract, unchanged by --stdin: 0 = at least one path is
+    # ignored, 1 = none are, anything else = it failed. Folding "not 0" into
+    # healthy would count exit 128 as carried.
+    if proc.returncode == 0:
+        return "dropped"
+    if proc.returncode == 1:
+        return "carried"
+    return "unmeasured"
 
 
 def _carrier_representative(workspace: Path, entry: str) -> "Path | None":

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1143,6 +1143,89 @@ def _carrier_representatives(workspace: Path, entry: str) -> "list[Path]":
     return [candidate] if candidate.exists() else []
 
 
+# How many materialized files under a directory representative to ask git about.
+# Bounded because a carrier entry can name a large subtree and this runs from a
+# background health check. The bound is honest about its direction: past the cap
+# the probe can UNDER-report (an ignored file beyond it goes unseen), never
+# over-report — the same failure direction as the no-network ref staleness.
+_PROBE_FILES_PER_DIR = 25
+
+
+def _carrier_probe_files(rep: "Path") -> "list[Path]":
+    """The concrete files to ask git about for one materialized representative.
+
+    A file represents itself. A DIRECTORY is represented by the files beneath
+    it, sorted for determinism (an unsorted walk would make the probe's verdict
+    depend on filesystem order) and capped at `_PROBE_FILES_PER_DIR`.
+    """
+    if rep.is_file():
+        return [rep]
+    if not rep.is_dir():
+        return []
+    out = []
+    for f in sorted(rep.rglob("*")):
+        if f.is_file():
+            out.append(f)
+            if len(out) >= _PROBE_FILES_PER_DIR:
+                break
+    return out
+
+
+def _carrier_target_verdict(workspace: Path, rep: Path) -> str:
+    """`"carried"` | `"dropped"` | `"unmeasured"` for ONE materialized path.
+
+    A DIRECTORY and the files inside it are different questions for git, and the
+    first cut asked the wrong one. `*` + `!hosts/` + `!hosts/*/` un-ignores the
+    directories while every file beneath stays ignored — `!hosts/**` is what
+    carries the contents. So `check-ignore` on `hosts/a` answered "not ignored"
+    while `hosts/a/current-track.md` was ignored and unbacked, and the probe
+    reported the vault healthy with the very file it exists to protect not being
+    backed up. Reproduced independently by john-the-dev and qingyun-wu on
+    a958d06f, and confirmed here before changing anything.
+
+    So a directory is probed through the FILES beneath it, bounded by
+    `_PROBE_FILES_PER_DIR`, and any ignored one condemns the entry.
+
+    `--no-index` stays load-bearing and the instrument stays `check-ignore` for
+    a reason worth recording: the obvious alternative,
+    `ls-files --others --ignored`, is index-AWARE, so it calls a tracked file
+    carried. That silently reverses a documented behavior —
+    `test_a_TRACKED_file_with_a_stale_exclude_is_still_reported` exists because a
+    host that carried a file once and then let its exclude go stale read healthy
+    forever while nothing NEW under that entry was being carried. I wrote the
+    ls-files version first and that test failed; it was right and I was wrong.
+
+    Used by BOTH the stale and dropped branches. The stale branch probes a
+    directory representative too and had the same blindness; fixing only the
+    branch that was reported would have left the identical defect one step to
+    the left, which is how this class of bug has survived three rounds here.
+    """
+    targets = _carrier_probe_files(rep)
+    if not targets:
+        # A materialized directory with no files under it yet. Nothing to
+        # measure — treated as carried so an empty `hosts/<label>/` cannot
+        # manufacture a failure; the "nothing on disk" case is handled by the
+        # callers, which report an entry with no representatives at all.
+        return "carried"
+
+    for target in targets:
+        try:
+            proc = subprocess.run(
+                git_argv("-C", str(workspace), "check-ignore", "--no-index", "-q",
+                         str(target.relative_to(workspace))),
+                capture_output=True, timeout=10,
+            )
+        except (GitUnavailable, OSError, subprocess.SubprocessError):
+            return "unmeasured"
+        # check-ignore's contract: 0 = ignored, 1 = NOT ignored, anything else =
+        # it failed. Folding "not 0" into healthy would count exit 128 as carried.
+        if proc.returncode == 0:
+            return "dropped"
+        if proc.returncode != 1:
+            return "unmeasured"
+    return "carried"
+
+
 def _carrier_representative(workspace: Path, entry: str) -> "Path | None":
     """One existing concrete path for a carrier-set entry, or None.
 
@@ -1206,36 +1289,23 @@ def check_carrier_set_enforced(workspace_dir=None) -> "dict | None":
         rep = _carrier_representative(workspace, entry)
         if rep is None:
             continue
-        try:
-            proc = subprocess.run(
-                git_argv("-C", str(workspace), "check-ignore", "--no-index", "-q",
-                         str(rep.relative_to(workspace))),
-                capture_output=True, timeout=10,
-            )
-        except (GitUnavailable, OSError, subprocess.SubprocessError):
-            # Could not run the measurement at all. NOT the same as "carried".
-            unmeasured.append(entry)
-            continue
         # `git_argv` rather than a bare "git": on macOS the stock /usr/bin/git is
         # an Xcode-CLT shim that pops an install dialog when the tools are absent,
         # and this probe runs from a BACKGROUND health check where nobody is there
         # to dismiss it. The resolver refuses that shim instead of spawning it.
         #
-        # `--no-index` is LOAD-BEARING (sync-workspace.sh says so at its own
-        # check-ignore call): without it, git reports an ALREADY-TRACKED file as
-        # not-ignored regardless of the rules, so a host whose file was carried
-        # once and whose exclude later went stale reads healthy forever. Caught
-        # by restoring this host's real pre-fix exclude and watching the probe
-        # still say OK.
-        #
-        # check-ignore's contract is 0 = ignored, 1 = NOT ignored, anything else
-        # = it failed. Treating "not 0" as healthy folded exit 128 in with exit 1,
-        # so a git that could not run reported the carrier set as fine — the exact
-        # unmeasured-reads-as-healthy failure this probe exists to catch, in the
-        # probe itself.
-        if proc.returncode == 0:
+        # `--no-index` is LOAD-BEARING on the file path (sync-workspace.sh says so
+        # at its own check-ignore call): without it, git reports an ALREADY-TRACKED
+        # file as not-ignored regardless of the rules, so a host whose file was
+        # carried once and whose exclude later went stale reads healthy forever.
+        # Caught by restoring this host's real pre-fix exclude and watching the
+        # probe still say OK. Both that and the directory/contents distinction now
+        # live in `_carrier_target_verdict` so the two branches cannot drift.
+        verdict = _carrier_target_verdict(workspace, rep)
+        if verdict == "dropped":
             stale.append(entry)
-        elif proc.returncode != 1:
+        elif verdict == "unmeasured":
+            # Could not run the measurement at all. NOT the same as "carried".
             unmeasured.append(entry)
 
     # Read the SHIPPED file directly rather than through load_config(), which
@@ -1283,24 +1353,13 @@ def check_carrier_set_enforced(workspace_dir=None) -> "dict | None":
                 continue
             verdict = "covered"
             for rep in reps:
-                try:
-                    proc = subprocess.run(
-                        git_argv("-C", str(workspace), "check-ignore", "--no-index", "-q",
-                                 str(rep.relative_to(workspace))),
-                        capture_output=True, timeout=10,
-                    )
-                except (GitUnavailable, OSError, subprocess.SubprocessError):
-                    verdict = "unmeasured"
-                    break
-                # Same contract as the stale branch: 0 = ignored (so this match is
-                # genuinely not carried), 1 = not ignored (covered by a broader
-                # local rule). Anything else is a failed measurement, which is
-                # UNKNOWN — never "covered".
-                if proc.returncode == 0:
-                    verdict = "dropped"
-                    break
-                if proc.returncode != 1:
-                    verdict = "unmeasured"
+                # Same instrument as the stale branch, deliberately shared: a
+                # DIRECTORY representative and the files under it are different
+                # questions for git, and asking about the directory reported a
+                # subtree healthy while its carrier file was ignored.
+                got = _carrier_target_verdict(workspace, rep)
+                if got != "carried":
+                    verdict = got
                     break
             if verdict == "dropped":
                 dropped.append(entry)

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -394,6 +394,42 @@ class CarrierSetProbe(unittest.TestCase):
                             "a measurement that failed is UNKNOWN, never a pass")
         self.assertIn("data/", r["detail"], "the entry we could not measure must be named")
 
+    def test_an_ODD_EXIT_CODE_is_also_unmeasured_not_covered(self):
+        # The other half of "the measurement failed", and a separate line: the
+        # test above makes check-ignore RAISE, this makes it RETURN an exit code
+        # that is neither 0 (ignored) nor 1 (not ignored) — a git that ran and
+        # could not answer, e.g. 128 on a broken repo.
+        #
+        # Worth its own case because the tempting shape is `if rc != 0: covered`,
+        # which silently folds 128 in with 1 and reports a path as carried on the
+        # strength of a failed read. That is the same defect this probe exists to
+        # catch, and #2566 shipped it in the stale branch before review found it.
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
+                          ["notes/x.md", "data/f.md"])
+        self._patch_resolved(["notes/"])
+        self._patch_shipped(["notes/", "data/"])
+        real = self.hc.subprocess.run
+
+        class _Odd:
+            returncode = 128
+            stdout = b""
+            stderr = b"fatal: not a git repository"
+
+        def odd_exit(argv, *a, **kw):
+            if any("data" in str(x) for x in argv):
+                return _Odd()
+            return real(argv, *a, **kw)
+
+        self.hc.subprocess.run = odd_exit
+        try:
+            r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        finally:
+            self.hc.subprocess.run = real
+        self.assertIsNotNone(r)
+        self.assertNotEqual(r["status"], "ok",
+                            "exit 128 is a git that could not answer, not a pass")
+        self.assertIn("data/", r["detail"])
+
     def test_a_shipped_entry_with_nothing_on_disk_is_still_reported(self):
         # The coverage test can only speak when something is materialized. An entry
         # the local config omits and that has NOTHING under it yet has no outcome to

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -332,6 +332,68 @@ class CarrierSetProbe(unittest.TestCase):
         self.assertNotIn("hosts/*/", r["detail"])
         self.assertNotIn("add them to the local list", r["detail"])
 
+    def test_a_NARROWER_local_rule_covering_one_child_is_not_coverage(self):
+        # qingyun-wu P1 on #2572. `_carrier_representative` returned the FIRST
+        # glob match, so a shipped wildcard matching several paths was judged on
+        # one sampled witness. A narrower local rule covers one child while its
+        # siblings stay ignored — and if the sample landed on the covered child,
+        # the probe reported the vault healthy with a whole host subtree unbacked.
+        #
+        # This is the exact inverse of the case the previous test pins, and one
+        # host cannot tell them apart: with a single match, first-hit coverage and
+        # full coverage are indistinguishable. Two hosts is the minimum fixture
+        # that can fail.
+        #
+        # The `!hosts/` line is load-bearing. gitignore cannot re-include a path
+        # whose PARENT directory is excluded, so `!hosts/a/` under a leading `*`
+        # leaves hosts/a ignored too — and the first cut of this fixture did
+        # exactly that, making BOTH hosts ignored. The assertion still passed,
+        # because first-hit sampling then landed on an ignored path and reported
+        # it dropped for the right verdict via the wrong mechanism. A fixture that
+        # passes at the broken head is not a witness.
+        ws = _mkworkspace(self.tmp,
+                          ["notes/", "notes/**",
+                           "hosts/", "hosts/a/", "hosts/a/**"],   # carries a, NOT b
+                          ["notes/x.md", "hosts/a/current-track.md", "hosts/b/current-track.md"])
+        self._patch_resolved(["notes/", "hosts/a/"])     # narrower than shipped
+        self._patch_shipped(["notes/", "hosts/*/"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertNotEqual(r["status"], "ok",
+                            "hosts/b is ignored and unbacked — sampling hosts/a must not pass it")
+        self.assertIn("hosts/*/", r["detail"])
+
+    def test_a_measurement_failure_never_erases_findings(self):
+        # qingyun-wu P1 on #2572, and the sharper half: the code said one thing
+        # and did the other. A comment promised a failed measurement "keeps being
+        # reported", while the enclosing `except` reset `dropped = []` — so one
+        # entry's git timeout erased findings already collected and returned ok.
+        # Fail-OPEN in the probe whose entire purpose is catching silent
+        # non-backup.
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
+                          ["notes/x.md", "data/f.md"])
+        self._patch_resolved(["notes/"])
+        self._patch_shipped(["notes/", "data/"])
+        real = self.hc.subprocess.run
+
+        def flaky(argv, *a, **kw):
+            # Succeed for the resolved entry's stale-branch probe, fail only on
+            # the shipped entry's coverage probe — the exact mixed case where the
+            # old code discarded the finding it already had.
+            if any("data" in str(x) for x in argv):
+                raise self.hc.subprocess.SubprocessError("timed out")
+            return real(argv, *a, **kw)
+
+        self.hc.subprocess.run = flaky
+        try:
+            r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        finally:
+            self.hc.subprocess.run = real
+        self.assertIsNotNone(r)
+        self.assertNotEqual(r["status"], "ok",
+                            "a measurement that failed is UNKNOWN, never a pass")
+        self.assertIn("data/", r["detail"], "the entry we could not measure must be named")
+
     def test_a_shipped_entry_with_nothing_on_disk_is_still_reported(self):
         # The coverage test can only speak when something is materialized. An entry
         # the local config omits and that has NOTHING under it yet has no outcome to

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -290,7 +290,14 @@ class CarrierSetProbe(unittest.TestCase):
         # It must still be REPORTED — silently filtering it would hide a real
         # divergence, which is the failure this whole probe exists to prevent.
         # What had to go is the instruction, not the information.
-        ws = _mkworkspace(self.tmp, ["notes/", "notes/**", "state/", "state/current-track.md"],
+        #
+        # The exclude must NOT un-ignore `state/current-track.md` here. This fixture
+        # originally did, which made the entry carried BY OUTCOME while the test
+        # asserted it was dropped — it only passed because the dropped branch
+        # compared config strings and never looked at disk. Once that branch asks
+        # git (#2571), an over-specified fixture like that stops describing the
+        # state it claims to test.
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
                           ["notes/a.md", "state/current-track.md"])
         self._patch_resolved(["notes/"])                                   # host dropped it
         self._patch_shipped(["notes/", "state/current-track.md"])          # shipped still has it
@@ -302,6 +309,42 @@ class CarrierSetProbe(unittest.TestCase):
         self.assertIn("#2567", r["detail"], "must name why")
         self.assertNotIn("add them to the local list", r["detail"],
                          "the data-loss instruction must not accompany this entry")
+
+    def test_a_BROADER_local_entry_is_coverage_not_a_dropped_entry(self):
+        # #2571, reported by Sutando-Pro against #2566 within minutes of merge.
+        # Their host's local config carries `hosts/` where the shipped default says
+        # `hosts/*/` — strictly BROADER, and the whole subtree is demonstrably
+        # carried. The dropped branch compared strings, so it reported `hosts/*/`
+        # missing and advised "add them to the local list", i.e. told the operator
+        # to narrow a config that was already right.
+        #
+        # The irony is the point: this probe exists to catch "config claims carried,
+        # reality says not". This is the inverse — reality says carried, the config
+        # string says not — and it fired anyway.
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/**", "hosts/", "hosts/**"],
+                          ["notes/a.md", "hosts/h/current-track.md"])
+        self._patch_resolved(["notes/", "hosts/"])       # broader than shipped
+        self._patch_shipped(["notes/", "hosts/*/"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "ok",
+                         "a broader local rule carries the subtree; nothing is dropped")
+        self.assertNotIn("hosts/*/", r["detail"])
+        self.assertNotIn("add them to the local list", r["detail"])
+
+    def test_a_shipped_entry_with_nothing_on_disk_is_still_reported(self):
+        # The coverage test can only speak when something is materialized. An entry
+        # the local config omits and that has NOTHING under it yet has no outcome to
+        # measure — but the divergence is real and turns into silent data loss the
+        # moment the first file lands there. Report it rather than let "no evidence
+        # of harm yet" read as covered.
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/**"], ["notes/a.md"])
+        self._patch_resolved(["notes/"])
+        self._patch_shipped(["notes/", "data/"])         # data/ does not exist yet
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertIn("data/", r["detail"])
+        self.assertIn("add them to the local list", r["detail"])
 
     def test_a_SAFE_dropped_entry_still_gets_the_add_it_remedy(self):
         # Over-trigger control: the unsafe carve-out must not swallow the ordinary

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -411,7 +411,11 @@ class CarrierSetProbe(unittest.TestCase):
         real = self.hc.subprocess.run
 
         def flaky(argv, *a, **kw):
-            if any("hosts/b" in str(x) for x in argv):
+            # Paths travel via STDIN now (one `check-ignore --stdin` call per
+            # representative), not argv — so key on the input. Keying on argv
+            # silently stopped matching when the instrument changed, and the test
+            # passed by never firing its own stub.
+            if "hosts/b" in (kw.get("input") or ""):
                 raise self.hc.subprocess.SubprocessError("probe failed on host b")
             return real(argv, *a, **kw)
 
@@ -424,19 +428,57 @@ class CarrierSetProbe(unittest.TestCase):
         self.assertNotEqual(r["status"], "ok",
                             "a host we could not measure is UNKNOWN, not carried")
 
-    def test_the_directory_probe_is_actually_BOUNDED(self):
-        # The cap is the whole reason this walk is safe to run from a background
-        # health check, and an unenforced cap is just a slow unbounded walk. Pin
-        # the bound itself rather than trusting the constant to be wired up.
-        d = self.tmp / "many"
-        d.mkdir()
-        for i in range(self.hc._PROBE_FILES_PER_DIR + 12):
-            (d / f"f{i:03d}.md").write_text("x\n")
-        got = self.hc._carrier_probe_files(d)
-        self.assertEqual(len(got), self.hc._PROBE_FILES_PER_DIR)
-        # Sorted, so the verdict cannot depend on filesystem walk order — an
-        # unsorted sample would make the probe answer differently run to run.
-        self.assertEqual(got, sorted(got))
+    def _dir_with_n_files(self, carried: int, total: int):
+        """A workspace whose `notes/` holds `total` files, the first `carried`
+        un-ignored. Used for the pair below."""
+        lines = ["notes/"] + [f"notes/f{i:03d}.md" for i in range(carried)]
+        files = [f"notes/f{i:03d}.md" for i in range(total)]
+        ws = _mkworkspace(self.tmp, lines, files)
+        self._patch_resolved(["notes/"])
+        self._patch_shipped(["notes/"])
+        return ws
+
+    def test_the_26th_file_being_ignored_is_NOT_ok(self):
+        # john-the-dev on e146c2b3. The probe sampled the first 25 files and a
+        # comment admitted it could "UNDER-report past the cap" — a stated caveat
+        # treated as an acceptable conclusion. 26 files with only the 26th
+        # ignored therefore read `ok`, leaving a real carrier file unbacked while
+        # health certified the subtree. A sample is not proof of coverage.
+        ws = self._dir_with_n_files(carried=25, total=26)
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertNotEqual(r["status"], "ok",
+                            "the 26th file is ignored; sampling the first 25 hides it")
+
+    def test_all_26_carried_still_reads_ok(self):
+        # The paired control. Failing closed on COUNT would have satisfied the
+        # test above and broken this one — which is why the fix is an exhaustive
+        # single `check-ignore --stdin` call rather than a bound that gives up.
+        ws = self._dir_with_n_files(carried=26, total=26)
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "ok", r.get("detail"))
+
+    def test_the_probe_asks_git_ONCE_per_representative(self):
+        # Exhaustiveness must not cost one process per file: that is what made a
+        # cap tempting in the first place. Pin the call count so a future refactor
+        # cannot quietly reintroduce the per-file loop and the pressure to sample.
+        ws = self._dir_with_n_files(carried=26, total=26)
+        real = self.hc.subprocess.run
+        calls = []
+
+        def counting(argv, *a, **kw):
+            if any("check-ignore" in str(x) for x in argv):
+                calls.append(argv)
+            return real(argv, *a, **kw)
+
+        self.hc.subprocess.run = counting
+        try:
+            self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        finally:
+            self.hc.subprocess.run = real
+        self.assertEqual(len(calls), 1,
+                         f"26 files must cost ONE check-ignore call, got {len(calls)}")
 
     def test_an_EMPTY_carrier_directory_does_not_manufacture_a_failure(self):
         # `hosts/<label>/` exists but nothing has been written under it yet.

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -541,11 +541,20 @@ class CarrierSetProbe(unittest.TestCase):
         self._patch_shipped(["notes/", "data/"])
         real = self.hc.subprocess.run
 
+        fired = []
+
         def flaky(argv, *a, **kw):
             # Succeed for the resolved entry's stale-branch probe, fail only on
             # the shipped entry's coverage probe — the exact mixed case where the
             # old code discarded the finding it already had.
-            if any("data" in str(x) for x in argv):
+            #
+            # Keyed on STDIN, not argv: paths travel through `check-ignore
+            # --stdin` now. The argv form stopped matching when the instrument
+            # changed and this test kept passing, because `data/` is dropped for
+            # an ordinary reason anyway — vacuous, and silently so. `fired` is
+            # asserted below so it can never go vacuous quietly again.
+            if "data" in (kw.get("input") or ""):
+                fired.append(1)
                 raise self.hc.subprocess.SubprocessError("timed out")
             return real(argv, *a, **kw)
 
@@ -555,9 +564,12 @@ class CarrierSetProbe(unittest.TestCase):
         finally:
             self.hc.subprocess.run = real
         self.assertIsNotNone(r)
+        self.assertTrue(fired, "the stub never fired — this test proves nothing")
         self.assertNotEqual(r["status"], "ok",
                             "a measurement that failed is UNKNOWN, never a pass")
         self.assertIn("data/", r["detail"], "the entry we could not measure must be named")
+        self.assertIn("could NOT measure", r["detail"],
+                      "must land in unmeasured, not be mistaken for an ordinary drop")
 
     def test_an_ODD_EXIT_CODE_is_also_unmeasured_not_covered(self):
         # The other half of "the measurement failed", and a separate line: the
@@ -577,11 +589,14 @@ class CarrierSetProbe(unittest.TestCase):
 
         class _Odd:
             returncode = 128
-            stdout = b""
-            stderr = b"fatal: not a git repository"
+            stdout = ""
+            stderr = "fatal: not a git repository"
+
+        fired = []
 
         def odd_exit(argv, *a, **kw):
-            if any("data" in str(x) for x in argv):
+            if "data" in (kw.get("input") or ""):
+                fired.append(1)
                 return _Odd()
             return real(argv, *a, **kw)
 
@@ -591,9 +606,12 @@ class CarrierSetProbe(unittest.TestCase):
         finally:
             self.hc.subprocess.run = real
         self.assertIsNotNone(r)
+        self.assertTrue(fired, "the stub never fired — this test proves nothing")
         self.assertNotEqual(r["status"], "ok",
                             "exit 128 is a git that could not answer, not a pass")
         self.assertIn("data/", r["detail"])
+        self.assertIn("could NOT measure", r["detail"],
+                      "must land in unmeasured, not be mistaken for an ordinary drop")
 
     def test_a_shipped_entry_with_nothing_on_disk_is_still_reported(self):
         # The coverage test can only speak when something is materialized. An entry

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -332,6 +332,40 @@ class CarrierSetProbe(unittest.TestCase):
         self.assertNotIn("hosts/*/", r["detail"])
         self.assertNotIn("add them to the local list", r["detail"])
 
+    def test_a_DIRECTORY_un_ignored_while_its_FILES_are_ignored_is_not_carried(self):
+        # john-the-dev and qingyun-wu, independently, on a958d06f. A directory
+        # and the files inside it are different questions for git: `!hosts/` and
+        # `!hosts/*/` un-ignore the DIRECTORIES while every file beneath stays
+        # ignored — `!hosts/**` is what carries the contents.
+        #
+        #   check-ignore --no-index hosts/a                  -> 1  (not ignored)
+        #   check-ignore --no-index hosts/a/current-track.md -> 0  (IGNORED)
+        #
+        # so probing the representative directory reported `ok — all configured
+        # carrier path(s) un-ignored` while the actual carrier file was unbacked.
+        # A false GREEN in the probe whose only job is catching silent non-backup.
+        ws = _mkworkspace(self.tmp, ["hosts/", "hosts/*/"],       # note: no hosts/**
+                          ["hosts/a/current-track.md"])
+        self._patch_resolved(["hosts/*/"])
+        self._patch_shipped(["hosts/*/"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertNotEqual(r["status"], "ok",
+                            "the directory is un-ignored but its carrier file is not")
+        self.assertIn("hosts/*/", r["detail"])
+
+    def test_the_SAME_tree_with_contents_carried_reads_ok(self):
+        # Over-trigger control, and the line that isolates the cause: identical
+        # except for `!hosts/**`. Without it this fix would just make every
+        # directory entry fail.
+        ws = _mkworkspace(self.tmp, ["hosts/", "hosts/*/", "hosts/**"],
+                          ["hosts/a/current-track.md"])
+        self._patch_resolved(["hosts/*/"])
+        self._patch_shipped(["hosts/*/"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "ok", r.get("detail"))
+
     def test_a_NARROWER_local_rule_covering_one_child_is_not_coverage(self):
         # qingyun-wu P1 on #2572. `_carrier_representative` returned the FIRST
         # glob match, so a shipped wildcard matching several paths was judged on

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -366,6 +366,64 @@ class CarrierSetProbe(unittest.TestCase):
         self.assertIsNotNone(r)
         self.assertEqual(r["status"], "ok", r.get("detail"))
 
+    def test_SAME_config_two_hosts_partially_carried_is_not_ok(self):
+        # john-the-dev and qingyun-wu, independently, on cf059ca8. The STALE
+        # branch still collapsed `hosts/*/` to `_carrier_representative()`
+        # (singular), so a workspace whose exclude carries host A but not host B
+        # reported `ok` while B's subtree was ignored and unbacked.
+        #
+        # Note resolved == shipped here: this is NOT the dropped/override branch.
+        # The previous round shared the directory-vs-file instrument across both
+        # branches and stopped, but coverage has TWO independent axes — which
+        # paths you probe, and what you ask about each — so generalizing one left
+        # the other singular. This pins the axis that was missed.
+        ws = _mkworkspace(self.tmp,
+                          ["hosts/", "hosts/a/", "hosts/a/**", "hosts/b/"],   # b's files not carried
+                          ["hosts/a/current-track.md", "hosts/b/current-track.md"])
+        self._patch_resolved(["hosts/*/"])
+        self._patch_shipped(["hosts/*/"])          # same config — stale branch
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertNotEqual(r["status"], "ok",
+                            "host b's subtree is ignored; judging only host a hides it")
+        self.assertIn("hosts/*/", r["detail"])
+
+    def test_SAME_config_two_hosts_FULLY_carried_reads_ok(self):
+        # The control that keeps the fix from simply failing every wildcard:
+        # identical except host b's contents are carried too.
+        ws = _mkworkspace(self.tmp,
+                          ["hosts/", "hosts/a/", "hosts/a/**", "hosts/b/", "hosts/b/**"],
+                          ["hosts/a/current-track.md", "hosts/b/current-track.md"])
+        self._patch_resolved(["hosts/*/"])
+        self._patch_shipped(["hosts/*/"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "ok", r.get("detail"))
+
+    def test_an_unmeasurable_second_host_stays_fail_closed(self):
+        # Enumerating must not weaken the unmeasured contract: if host a answers
+        # cleanly and host b's probe fails, the entry is UNKNOWN, never carried.
+        ws = _mkworkspace(self.tmp,
+                          ["hosts/", "hosts/a/", "hosts/a/**", "hosts/b/", "hosts/b/**"],
+                          ["hosts/a/current-track.md", "hosts/b/current-track.md"])
+        self._patch_resolved(["hosts/*/"])
+        self._patch_shipped(["hosts/*/"])
+        real = self.hc.subprocess.run
+
+        def flaky(argv, *a, **kw):
+            if any("hosts/b" in str(x) for x in argv):
+                raise self.hc.subprocess.SubprocessError("probe failed on host b")
+            return real(argv, *a, **kw)
+
+        self.hc.subprocess.run = flaky
+        try:
+            r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        finally:
+            self.hc.subprocess.run = real
+        self.assertIsNotNone(r)
+        self.assertNotEqual(r["status"], "ok",
+                            "a host we could not measure is UNKNOWN, not carried")
+
     def test_the_directory_probe_is_actually_BOUNDED(self):
         # The cap is the whole reason this walk is safe to run from a background
         # health check, and an unenforced cap is just a slow unbounded walk. Pin

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -366,6 +366,37 @@ class CarrierSetProbe(unittest.TestCase):
         self.assertIsNotNone(r)
         self.assertEqual(r["status"], "ok", r.get("detail"))
 
+    def test_the_directory_probe_is_actually_BOUNDED(self):
+        # The cap is the whole reason this walk is safe to run from a background
+        # health check, and an unenforced cap is just a slow unbounded walk. Pin
+        # the bound itself rather than trusting the constant to be wired up.
+        d = self.tmp / "many"
+        d.mkdir()
+        for i in range(self.hc._PROBE_FILES_PER_DIR + 12):
+            (d / f"f{i:03d}.md").write_text("x\n")
+        got = self.hc._carrier_probe_files(d)
+        self.assertEqual(len(got), self.hc._PROBE_FILES_PER_DIR)
+        # Sorted, so the verdict cannot depend on filesystem walk order — an
+        # unsorted sample would make the probe answer differently run to run.
+        self.assertEqual(got, sorted(got))
+
+    def test_an_EMPTY_carrier_directory_does_not_manufacture_a_failure(self):
+        # `hosts/<label>/` exists but nothing has been written under it yet.
+        # There is no outcome to measure, and inventing one would fail a host
+        # that has done nothing wrong. The genuinely-absent case (no
+        # representative at all) is reported by the callers instead.
+        empty = self.tmp / "empty-dir"
+        empty.mkdir()
+        self.assertEqual(self.hc._carrier_probe_files(empty), [])
+        self.assertEqual(self.hc._carrier_target_verdict(self.tmp, empty), "carried")
+
+    def test_a_representative_that_is_neither_file_nor_directory_yields_nothing(self):
+        # A dangling symlink resolves to a path that exists() says nothing useful
+        # about; probing it would ask git about something that is not there.
+        link = self.tmp / "dangling"
+        link.symlink_to(self.tmp / "does-not-exist")
+        self.assertEqual(self.hc._carrier_probe_files(link), [])
+
     def test_a_NARROWER_local_rule_covering_one_child_is_not_coverage(self):
         # qingyun-wu P1 on #2572. `_carrier_representative` returned the FIRST
         # glob match, so a shipped wildcard matching several paths was judged on

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -438,6 +438,42 @@ class CarrierSetProbe(unittest.TestCase):
         self._patch_shipped(["notes/"])
         return ws
 
+    def test_a_filename_containing_a_NEWLINE_is_still_measured(self):
+        # john-the-dev on 73a91671. The batch joined paths with "\n", but a
+        # filename may CONTAIN a newline — so one real path became two bogus
+        # ones, and because both halves are typically un-ignored, the genuinely
+        # ignored carrier file read as carried.
+        #
+        # Reproduced before fixing, on a tree built to separate the two answers:
+        #     notes/z\nx.md          -> rc 0  (IGNORED, not backed up)
+        #     halves notes/z, x.md   -> rc 1, rc 1  (both un-ignored)
+        #     newline-joined batch   -> rc 1  -> ok, FALSE GREEN
+        #     NUL-joined with -z     -> rc 0  -> dropped, correct
+        #
+        # NUL is the only delimiter a POSIX filename cannot contain, which is
+        # why the fix is the delimiter rather than an escaping scheme.
+        weird = "notes/z\nx.md"
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/z", "x.md"], [weird])
+        self._patch_resolved(["notes/"])
+        self._patch_shipped(["notes/"])
+
+        # The fixture only proves something if the two answers genuinely differ:
+        # the real file ignored, both split halves not. Assert that first, or a
+        # future gitignore nuance could make this pass without discriminating.
+        def rc(path):
+            return subprocess.run(["git", "-C", str(ws), "check-ignore",
+                                   "--no-index", "-q", path],
+                                  capture_output=True).returncode
+        self.assertEqual(rc(weird), 0, "fixture: the real file must be IGNORED")
+        self.assertEqual(rc("notes/z"), 1, "fixture: split half must be un-ignored")
+        self.assertEqual(rc("x.md"), 1, "fixture: split half must be un-ignored")
+
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertNotEqual(r["status"], "ok",
+                            "a newline in a filename must not split one ignored path "
+                            "into two un-ignored ones")
+
     def test_the_26th_file_being_ignored_is_NOT_ok(self):
         # john-the-dev on e146c2b3. The probe sampled the first 25 files and a
         # comment admitted it could "UNDER-report past the cap" — a stated caveat


### PR DESCRIPTION
Closes #2571 — reported by @Sutando-Pro against #2566 minutes after it merged. My code, my fix.

> **Stacked on #2570 — merge that first.** Base is `fix/carrier-unsafe-path-is-not-a-failure`; both touch `check_carrier_set_enforced()`. Once #2570 lands I will rebase this onto main and rerun the full checks.

## The bug

`dropped` compared include **strings**:

```python
dropped = [e for e in shipped if isinstance(e, str) and e not in resolved]
```

A local entry can be strictly **broader** than the shipped one it replaces. On the reporting host:

```
shipped : [... 'hosts/*/' ...]
local   : [... 'hosts/'   ...]      <- broader; whole subtree demonstrably carried
```

So the probe reported `hosts/*/` missing and advised *"add them to the local list"* — telling the operator to **narrow a config that was already correct**.

The irony is the useful part: this probe exists to catch *"config claims carried, reality says not."* This is the inverse — **reality says carried, the config string says not** — and it fired anyway. The `stale` branch already gets this right by asking git via `check-ignore --no-index`; only `dropped` reverted to string equality, and `_carrier_representative()` already did the resolution needed.

## The fix

An entry counts as dropped only once git agrees nothing under it is carried. Same exit-code contract as the stale branch: `1` = not ignored = covered, `0` = ignored = genuinely dropped, anything else = a failed measurement that keeps being reported rather than counting as covered.

An entry with **nothing materialized yet** stays reported. There is no outcome to measure, but the divergence is real and becomes silent data loss the moment the first file lands under it — pinned by its own test.

## One fixture was wrong, not just inconvenient

`test_the_KNOWN_UNSAFE_entry_is_reported_but_never_recommended` built an exclude that **un-ignored** `state/current-track.md` while asserting the entry was dropped. By outcome it was carried. It only passed because the branch never looked at disk; once the branch asks git, the fixture stopped describing the state it claims to test. Corrected rather than accommodated.

## Evidence

```
parent (#2570 head) : 21 tests, FAILED (failures=1)   <- broader-entry witness
HEAD                : 21 tests, OK
66 suites referencing health-check / git_binary : 66 pass, 0 fail
live host           : WARN (unchanged by this PR — that verdict is #2570's)
```

Honest note on the second new test (`…nothing_on_disk_is_still_reported`): it passes at the parent too. It pins existing behavior that this change could easily have broken, so it is a regression pin, not a witness. The witness is `test_a_BROADER_local_entry_is_coverage_not_a_dropped_entry`.

cc @qingyun-wu

Stand: Echo Act IV Mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)
