### PR TITLE
fix(health-check): a merged skill fix that was never pulled is invisible

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1801,6 +1801,29 @@ def _behind_warn_threshold(repo: "Path") -> int:
     return raw if raw > 0 else _BEHIND_WARN_DEFAULT   # zero/negative would false-alarm
 
 
+def _behind_commits_touching(repo: "Path", branch: str, prefix: str,
+                             git_bin: str = "git") -> "list[str]":
+    """Subjects of not-yet-pulled commits that change files under ``prefix``.
+
+    Same last-fetched-ref, no-network contract as `_commits_behind` — and the
+    same honest consequence: a stale local ref makes this UNDER-report, never
+    cry wolf. Returns `[]` on any failure for the same reason: this is an
+    additional signal layered on a probe that must not become the thing that
+    breaks the health run.
+    """
+    try:
+        out = subprocess.run(
+            [git_bin, "-C", str(repo), "log", "--no-merges", "--format=%s",
+             f"HEAD..origin/{branch}", "--", prefix],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if out.returncode != 0:
+        return []
+    return [ln.strip() for ln in out.stdout.splitlines() if ln.strip()]
+
+
 def _commits_behind(repo: "Path", branch: str, git_bin: str = "git") -> "int | None":
     """Commits on origin/<branch> that HEAD lacks, or None if unanswerable.
 
@@ -1925,6 +1948,36 @@ def check_live_checkout_branch(repo_dir: "Path | None" = None) -> dict:
                           "silence reads as health). Refresh with "
                           f"`git -C {repo} pull --ff-only` + restart. Count is against the "
                           "last-fetched ref; this probe does not fetch."}
+    # Count is the wrong instrument for BEHAVIORAL staleness, and the threshold
+    # above is deliberately 10 to avoid alert fatigue — correctly, since `main`
+    # moves several times a day. But one commit that rewrites a skill outranks
+    # nine that touch docs, and a count cannot tell them apart.
+    #
+    # Skills are the case with no other detector. `src/` needs a restart to take
+    # effect, so the `*-stale` probes catch it by comparing a running process
+    # against its source. A skill has no process: the agent reads the markdown
+    # from THIS checkout on every invocation, so a merged skill fix that has not
+    # been pulled is simply not in effect, with nothing anywhere to compare.
+    #
+    # Observed 2026-08-03 on this node: exactly ONE commit behind — far under the
+    # threshold, so this probe reported ok — while the live `context-reconstruct`
+    # still instructed writing `state/current-track.md`, the shared flat path
+    # whose two-writer collision had destroyed a peer's anchor hours earlier
+    # (#2567/#2568). The running skill and the merged skill disagreed, and both
+    # looked correct from where anyone was standing.
+    stale_skills = _behind_commits_touching(repo, expected, "skills/", git_bin)
+    if stale_skills:
+        return {"name": name, "status": "warn",
+                "detail": f"live checkout is on {expected!r} and only {behind} commit(s) behind "
+                          f"origin/{expected} — under the {_behind_warn_threshold(repo)}-commit "
+                          f"nag threshold — but {len(stale_skills)} of them change `skills/`, "
+                          "which the agent re-reads from this checkout on EVERY invocation. "
+                          "Those merged skill fixes are not in effect here, and no "
+                          "restart-staleness probe can see it: a skill has no running process "
+                          f"to compare against. ({'; '.join(stale_skills[:3])}"
+                          f"{'; …' if len(stale_skills) > 3 else ''}) Refresh with "
+                          f"`git -C {repo} pull --ff-only`. Measured against the last-fetched "
+                          "ref; this probe does not fetch, so it can only under-report."}
     return {"name": name, "status": "ok",
             "detail": f"live checkout on {expected!r}"
                       + (f", {behind} commits behind" if behind else "")}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1801,16 +1801,42 @@ def _behind_warn_threshold(repo: "Path") -> int:
     return raw if raw > 0 else _BEHIND_WARN_DEFAULT   # zero/negative would false-alarm
 
 
-def _behind_commits_touching(repo: "Path", branch: str, prefix: str,
+def _behind_commits_changing(repo: "Path", branch: str, prefix: str,
                              git_bin: str = "git") -> "list[str]":
-    """Subjects of not-yet-pulled commits that change files under ``prefix``.
+    """Subjects of not-yet-pulled commits that EFFECTIVELY change ``prefix``.
 
-    Same last-fetched-ref, no-network contract as `_commits_behind` — and the
+    Two different questions, and the first cut answered the wrong one. "Did a
+    not-yet-pulled commit TOUCH this path" is commit-path history; "would
+    pulling change any bytes here" is a tree diff. They diverge whenever history
+    is reversible: upstream adds `skills/demo/SKILL.md` and removes it in the
+    next commit, a clone sits two commits behind, and
+    `git log HEAD..origin/main -- skills/` lists both commits while
+    `git diff --name-only HEAD..origin/main -- skills/` is EMPTY. Pulling would
+    change no skill bytes, yet the probe warned — a false behavioral-staleness
+    alarm, which is precisely the alert fatigue this check argues against.
+    Reproduced independently by qingyun-wu and john-the-dev on #2573.
+
+    So the TREE DIFF is the gate and history is only the message: if nothing
+    under ``prefix`` differs, return nothing; only when it does differ, name the
+    commits so the warning is actionable.
+
+    Same last-fetched-ref, no-network contract as `_commits_behind`, and the
     same honest consequence: a stale local ref makes this UNDER-report, never
-    cry wolf. Returns `[]` on any failure for the same reason: this is an
+    cry wolf. Returns `[]` on any failure for the same reason — this is an
     additional signal layered on a probe that must not become the thing that
     breaks the health run.
     """
+    try:
+        changed = subprocess.run(
+            [git_bin, "-C", str(repo), "diff", "--name-only",
+             f"HEAD..origin/{branch}", "--", prefix],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if changed.returncode != 0 or not changed.stdout.strip():
+        return []
+
     try:
         out = subprocess.run(
             [git_bin, "-C", str(repo), "log", "--no-merges", "--format=%s",
@@ -1965,7 +1991,7 @@ def check_live_checkout_branch(repo_dir: "Path | None" = None) -> dict:
     # whose two-writer collision had destroyed a peer's anchor hours earlier
     # (#2567/#2568). The running skill and the merged skill disagreed, and both
     # looked correct from where anyone was standing.
-    stale_skills = _behind_commits_touching(repo, expected, "skills/", git_bin)
+    stale_skills = _behind_commits_changing(repo, expected, "skills/", git_bin)
     if stale_skills:
         return {"name": name, "status": "warn",
                 "detail": f"live checkout is on {expected!r} and only {behind} commit(s) behind "

--- a/tests/health-check-live-checkout-branch.test.py
+++ b/tests/health-check-live-checkout-branch.test.py
@@ -327,6 +327,38 @@ def main() -> int:
         check("3 commit(s) behind" in r["detail"],
               f"v4) must still report the TOTAL behind count, got {r['detail'][:130]}")
 
+    # v5) git unrunnable -> no skill warning, and no exception either. This is the
+    #     branch that decides what happens when the MEASUREMENT fails, and an
+    #     uncaught raise here would take down the whole health run from inside the
+    #     probe that exists to report on it. Degrade closed: say nothing extra
+    #     rather than invent a warning from a failed read.
+    with tempfile.TemporaryDirectory() as td:
+        work = _mk_clone_behind_paths(Path(td), ["skills/s/SKILL.md"])
+        real_run = hc.subprocess.run
+
+        def _boom_on_log(argv, *a, **kw):
+            if "log" in argv:
+                raise OSError("git vanished mid-run")
+            return real_run(argv, *a, **kw)
+
+        hc.subprocess.run = _boom_on_log
+        try:
+            got = hc._behind_commits_touching(work, "main", "skills/")
+            r = hc.check_live_checkout_branch(work)
+        finally:
+            hc.subprocess.run = real_run
+        check(got == [], f"v5) a failed measurement yields no commits, got {got}")
+        check(r["status"] == "ok",
+              f"v5) and must not invent a warning from it, got {r['status']}")
+
+    # v6) git present but the log call FAILS (bad ref, renamed remote) -> same
+    #     degrade. Distinct from v5: there the call raised, here it returns
+    #     non-zero, and the two are different lines in the function.
+    with tempfile.TemporaryDirectory() as td:
+        work = _mk_clone_behind_paths(Path(td), ["skills/s/SKILL.md"])
+        got = hc._behind_commits_touching(work, "no-such-branch-xyz", "skills/")
+        check(got == [], f"v6) non-zero rc yields no commits, got {got}")
+
     # m) No remote ref at all (fresh init, renamed remote) -> degrade to ok.
     #    A probe that cannot answer must not invent an alarm.
     with tempfile.TemporaryDirectory() as td:

--- a/tests/health-check-live-checkout-branch.test.py
+++ b/tests/health-check-live-checkout-branch.test.py
@@ -257,6 +257,76 @@ def main() -> int:
         check(r["status"] == "ok" and "behind" not in r["detail"],
               f"l) up-to-date -> clean ok, got {r}")
 
+    # Behavioral staleness (added 2026-08-03). The count threshold above is
+    # deliberately 10 and case k) pins that 1 behind stays ok — both correct for
+    # alert fatigue. But a count cannot distinguish one commit that rewrites a
+    # skill from nine that touch docs, and skills are the one case with no other
+    # detector: `src/` needs a restart, so the `*-stale` probes catch it by
+    # comparing a running process to its source; a skill has no process, since
+    # the agent re-reads the markdown from this checkout on every invocation.
+    #
+    # Observed on this node: exactly ONE commit behind, this probe reporting ok,
+    # while the live `context-reconstruct` still instructed writing the shared
+    # flat `state/current-track.md` whose two-writer collision had destroyed a
+    # peer's anchor hours earlier (#2567/#2568).
+    def _mk_clone_behind_paths(td: Path, paths: "list[str]") -> Path:
+        """A clone on `main`, one commit behind per entry in `paths`."""
+        up = _mk_repo(td, "main")
+        work = td / "work"
+        subprocess.run(["git", "clone", "-q", str(up), str(work)],
+                       check=True, capture_output=True)
+        for i, rel in enumerate(paths):
+            f = up / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(f"{i}\n")
+            _git(up, "add", rel)
+            _git(up, "commit", "-q", "-m", f"touch {rel}")
+        _git(work, "fetch", "-q", "origin")
+        return work
+
+    # v1) THE GAP: one commit behind — under the nag threshold, so case k) says
+    #     ok — but it changes a skill the agent reads every invocation.
+    with tempfile.TemporaryDirectory() as td:
+        work = _mk_clone_behind_paths(Path(td), ["skills/context-reconstruct/SKILL.md"])
+        r = hc.check_live_checkout_branch(work)
+        check(r["status"] == "warn",
+              f"v1) 1 behind but it changes skills/ -> warn, got {r['status']}")
+        check("skills/" in r["detail"],
+              f"v1) must name skills/ as the reason, got {r['detail'][:110]}")
+        check("touch skills/context-reconstruct/SKILL.md" in r["detail"],
+              f"v1) must name the actual commit so it is actionable, got {r['detail'][:150]}")
+
+    # v2) Over-trigger control: the same one-commit drift in a path the agent
+    #     does NOT read live must stay ok, or this re-creates the alert fatigue
+    #     the threshold exists to prevent.
+    with tempfile.TemporaryDirectory() as td:
+        work = _mk_clone_behind_paths(Path(td), ["docs/whatever.md"])
+        r = hc.check_live_checkout_branch(work)
+        check(r["status"] == "ok",
+              f"v2) 1 behind touching docs only -> still ok, got {r['status']} / {r['detail'][:90]}")
+
+    # v3) Only NOT-YET-PULLED commits count. A checkout that already contains
+    #     the skill change is current — history is not drift.
+    with tempfile.TemporaryDirectory() as td:
+        work = _mk_clone_behind_paths(Path(td), ["skills/s/SKILL.md"])
+        _git(work, "pull", "-q", "--ff-only")
+        r = hc.check_live_checkout_branch(work)
+        check(r["status"] == "ok",
+              f"v3) skill change already pulled -> ok, got {r['status']} / {r['detail'][:90]}")
+
+    # v4) A mixed drift still names only the skill commits, and the count in the
+    #     message is the TOTAL — conflating the two would misstate how far behind
+    #     the checkout actually is.
+    with tempfile.TemporaryDirectory() as td:
+        work = _mk_clone_behind_paths(
+            Path(td), ["docs/a.md", "skills/one/SKILL.md", "docs/b.md"])
+        r = hc.check_live_checkout_branch(work)
+        check(r["status"] == "warn", f"v4) mixed drift with a skill -> warn, got {r['status']}")
+        check("1 of them change" in r["detail"],
+              f"v4) must count only the skill commits, got {r['detail'][:130]}")
+        check("3 commit(s) behind" in r["detail"],
+              f"v4) must still report the TOTAL behind count, got {r['detail'][:130]}")
+
     # m) No remote ref at all (fresh init, renamed remote) -> degrade to ok.
     #    A probe that cannot answer must not invent an alarm.
     with tempfile.TemporaryDirectory() as td:

--- a/tests/health-check-live-checkout-branch.test.py
+++ b/tests/health-check-live-checkout-branch.test.py
@@ -343,7 +343,7 @@ def main() -> int:
 
         hc.subprocess.run = _boom_on_log
         try:
-            got = hc._behind_commits_touching(work, "main", "skills/")
+            got = hc._behind_commits_changing(work, "main", "skills/")
             r = hc.check_live_checkout_branch(work)
         finally:
             hc.subprocess.run = real_run
@@ -356,8 +356,85 @@ def main() -> int:
     #     non-zero, and the two are different lines in the function.
     with tempfile.TemporaryDirectory() as td:
         work = _mk_clone_behind_paths(Path(td), ["skills/s/SKILL.md"])
-        got = hc._behind_commits_touching(work, "no-such-branch-xyz", "skills/")
+        got = hc._behind_commits_changing(work, "no-such-branch-xyz", "skills/")
         check(got == [], f"v6) non-zero rc yields no commits, got {got}")
+
+    # v7) NET-ZERO history must stay quiet. Upstream adds a skill and removes it
+    #     in the next commit; the clone fetches and sits two commits behind.
+    #     Commit-path history lists BOTH commits, but the tree diff is empty —
+    #     pulling would change no skill bytes. Warning here is a false
+    #     behavioral-staleness alarm, i.e. exactly the alert fatigue this check
+    #     exists to argue against. Reproduced independently by qingyun-wu and
+    #     john-the-dev on #2573; this pins the tree-diff gate that fixes it.
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        up = _mk_repo(td, "main")
+        work = td / "work"
+        subprocess.run(["git", "clone", "-q", str(up), str(work)],
+                       check=True, capture_output=True)
+        (up / "skills" / "demo").mkdir(parents=True)
+        (up / "skills" / "demo" / "SKILL.md").write_text("y\n")
+        _git(up, "add", "-A"); _git(up, "commit", "-q", "-m", "add skills/demo")
+        _git(up, "rm", "-q", "skills/demo/SKILL.md")
+        _git(up, "commit", "-q", "-m", "remove skills/demo")
+        _git(work, "fetch", "-q", "origin")
+
+        # The two questions must genuinely disagree here, or this fixture proves
+        # nothing — assert the disagreement before asserting the verdict.
+        hist = subprocess.run(["git", "-C", str(work), "log", "--no-merges",
+                               "--format=%s", "HEAD..origin/main", "--", "skills/"],
+                              capture_output=True, text=True).stdout.split()
+        tree = subprocess.run(["git", "-C", str(work), "diff", "--name-only",
+                               "HEAD..origin/main", "--", "skills/"],
+                              capture_output=True, text=True).stdout.strip()
+        check(len(hist) > 0 and tree == "",
+              f"v7) fixture must have history-yes/tree-no, got hist={len(hist)} tree={tree!r}")
+
+        got = hc._behind_commits_changing(work, "main", "skills/")
+        check(got == [], f"v7) net-zero skill history yields no drift, got {got}")
+        r = hc.check_live_checkout_branch(work)
+        check(r["status"] == "ok",
+              f"v7) and must not warn on reversible history, got {r['status']} / {r['detail'][:100]}")
+
+    # v7b) The TREE-DIFF call has its own failure branch, distinct from the log
+    #      call's (v5). It runs FIRST and is the gate, so if it raises and the
+    #      code fell through to history, the net-zero false positive would come
+    #      straight back on any host where the diff happens to fail. Degrade
+    #      closed: no diff answer, no drift claim.
+    with tempfile.TemporaryDirectory() as td:
+        work = _mk_clone_behind_paths(Path(td), ["skills/s/SKILL.md"])
+        real_run = hc.subprocess.run
+
+        def _boom_on_diff(argv, *a, **kw):
+            if "diff" in argv:
+                raise OSError("git vanished before the tree diff")
+            return real_run(argv, *a, **kw)
+
+        hc.subprocess.run = _boom_on_diff
+        try:
+            got = hc._behind_commits_changing(work, "main", "skills/")
+        finally:
+            hc.subprocess.run = real_run
+        check(got == [], f"v7b) a failed TREE DIFF yields no drift claim, got {got}")
+
+    # v8) Over-trigger control for v7: a skill change that is NOT reverted must
+    #     still warn, or the tree-diff gate would have silenced the real case
+    #     along with the false one.
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        up = _mk_repo(td, "main")
+        work = td / "work"
+        subprocess.run(["git", "clone", "-q", str(up), str(work)],
+                       check=True, capture_output=True)
+        (up / "skills" / "demo").mkdir(parents=True)
+        (up / "skills" / "demo" / "SKILL.md").write_text("y\n")
+        _git(up, "add", "-A"); _git(up, "commit", "-q", "-m", "add skills/demo")
+        _git(work, "fetch", "-q", "origin")
+        got = hc._behind_commits_changing(work, "main", "skills/")
+        check(got == ["add skills/demo"], f"v8) a real skill change still reports, got {got}")
+        r = hc.check_live_checkout_branch(work)
+        check(r["status"] == "warn",
+              f"v8) and still warns, got {r['status']}")
 
     # m) No remote ref at all (fresh init, renamed remote) -> degrade to ok.
     #    A probe that cannot answer must not invent an alarm.

--- a/tests/health-check-live-checkout-branch.test.py
+++ b/tests/health-check-live-checkout-branch.test.py
@@ -417,6 +417,30 @@ def main() -> int:
             hc.subprocess.run = real_run
         check(got == [], f"v7b) a failed TREE DIFF yields no drift claim, got {got}")
 
+    # v7c) The LOG call's non-zero branch. Adding the tree-diff gate made this
+    #      unreachable from v6: a bad ref now fails at the DIFF and returns
+    #      early, so the log call is never issued. The branch is still live in
+    #      production though — the diff can succeed while the log fails — and it
+    #      must degrade the same way rather than return a half-answer. Reaching
+    #      it needs the diff to SUCCEED with output and only the log to fail.
+    with tempfile.TemporaryDirectory() as td:
+        work = _mk_clone_behind_paths(Path(td), ["skills/s/SKILL.md"])
+        real_run = hc.subprocess.run
+
+        def _log_fails(argv, *a, **kw):
+            if "log" in argv:
+                class _Bad:
+                    returncode, stdout, stderr = 128, "", "fatal"
+                return _Bad()
+            return real_run(argv, *a, **kw)
+
+        hc.subprocess.run = _log_fails
+        try:
+            got = hc._behind_commits_changing(work, "main", "skills/")
+        finally:
+            hc.subprocess.run = real_run
+        check(got == [], f"v7c) diff succeeds but log fails -> no drift claim, got {got}")
+
     # v8) Over-trigger control for v7: a skill change that is NOT reverted must
     #     still warn, or the tree-diff gate would have silenced the real case
     #     along with the false one.


### PR DESCRIPTION
A checkout **one commit behind** `main` reported `ok` while the agent was executing a skill whose merged fix it did not have. Found by living it on the 24/7 node today.

## Why the existing signal can't catch this

`live-checkout-branch` already warns at `>= 10` commits behind, and that threshold is right — `main` moves several times a day and warning on any delta trains the reader to ignore the check. The problem is that **a count cannot distinguish one commit that rewrites a skill from nine that touch docs.**

Skills are the one case with no other detector:

| layer | how staleness surfaces today |
|---|---|
| `src/` | needs a restart, so `web-client` / `sutando-app` `*-stale` probes compare a **running process** to its source |
| `skills/` | **nothing.** The agent re-reads the markdown from this checkout on *every* invocation — there is no process to compare against |

So a merged skill fix that hasn't been pulled is simply not in effect, and every cheap signal says healthy.

## What actually happened

This node sat at `0c92c8e8`, two commits behind — well under the threshold, probe green. One of those two was #2568, which moved the current-track anchor off the shared flat path. So the live `context-reconstruct` **still instructed writing `state/current-track.md`** — the shared path whose two-writer collision had destroyed a peer's 1056-line anchor hours earlier (#2567/#2568). The running skill and the merged skill disagreed, and both looked correct from where anyone was standing.

The peer independently flagged the same shape: *"worth re-checking after any merge that touches `skills/`."* This makes that structural instead of a habit.

## The change

Warn when any not-yet-pulled commit touches `skills/`, regardless of count. Same no-network, last-fetched-ref contract as `_commits_behind`, with the same honest consequence stated in the text: it can only **under-report, never cry wolf**.

## Evidence — real repo history, not fixtures

Replaying this node's actual state at the moment it was wrong, and its state now:

```
HEAD=0c92c8e8 (this node at 12:48Z today)
  behind count  : 2                     <- under the threshold; old probe said ok
  skill commits : ['fix(vault): move the per-host anchor off a shared flat path
                    that let hosts clobber each other (#2568)']
  new verdict   : WARN

live checkout now (1 behind; that commit is src/ only)
  new verdict   : OK — "live checkout on 'main', 1 commits behind"
```

The second line is the one that matters for noise: the mechanism stays quiet on ordinary drift.

```
new cases at parent : 5 FAIL
new cases at HEAD   : 8 ok
whole suite         : live-checkout-branch probe invariants hold
67 suites referencing health-check / git_binary : 67 pass, 0 fail
py_compile clean · review-checks PASS (hardcoded-paths clean)
```

Cases `v2` (one commit behind touching `docs/` only → still `ok`) and `v3` (skill change already pulled → `ok`) are **over-trigger controls** — they pass at parent too, by design. The witnesses are `v1` and `v4`.

Case `k` (1 behind → `ok`) is unchanged and still passes: its fixture commits at the repo root, so ordinary drift keeps the same verdict it had.

Stand: Echo Act IV Mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)
