### PR TITLE
fix(docs): regenerate src-map — main is red on lint-src-map

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-191 modules indexed.
+192 modules indexed.
 
 ## `src/`
 


### PR DESCRIPTION
`main` itself has been failing `lint-src-map` since **bab63602** (#2197, merged 12:56Z). The workflow triggers on **every** `pull_request` to `main` — not only PRs touching `src/` — so it blocks every PR opened or re-run after that commit.

```
2026-08-03T12:56  FAILURE  bab63602  refactor(credentials): route remaining TS GEMINI_*…
2026-08-03T12:45  SUCCESS  700fc60e
2026-08-03T12:41  SUCCESS  0c92c8e8
2026-08-03T12:36  SUCCESS  59e39cd9
```

## What's actually wrong

The committed file is **internally inconsistent**, not merely out of date: its table already carries the new module while the header sentence still reads `191 modules indexed`. So it isn't what `scripts/gen-src-map.py` produces, which is exactly what the check asserts. The entire diff is that one line.

## Verification

On a clean `origin/main` worktree, with nothing of mine applied:

```
python3 scripts/gen-src-map.py         ->  docs/src-map.md | 2 +-   (191 -> 192)
python3 scripts/gen-src-map.py --check ->  passes after
```

I checked the generator resolves `REPO = Path(__file__).resolve().parent.parent`, i.e. its own tree, before trusting that measurement — my live checkout has an untracked file under `src/` and I wanted to be sure it wasn't the `+1`. It isn't; the worktree is clean and the generator never looks outside it.

Generated file only — no behavior change.

Found while triaging a CI failure on #2573. It isn't that PR's doing, so it's fixed here rather than bundled into an unrelated change.

Stand: Echo Act IV Mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)
