### PR TITLE
feat(g8): Python credential_resolver twin — capability-not-key for the bundled core

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -10,7 +10,7 @@ loaded into every session (see CLAUDE.md's note on context budget).
 If an entry reads wrong, the file's header comment is wrong: fix the header
 and re-run `python3 scripts/gen-src-map.py`.
 
-192 modules indexed.
+193 modules indexed.
 
 ## `src/`
 
@@ -38,6 +38,7 @@ and re-run `python3 scripts/gen-src-map.py`.
 - **`core_heartbeat.py`** — Per-host heartbeat for sutando-core sessions.
 - **`core_restart_intent.py`** — core_restart_intent.py — the owner's easy-restart intent file (sonichi#2401).
 - **`credential-resolver.ts`** — Credential resolver — capability, not key (G8, desktop-parity plan).
+- **`credential_resolver.py`** — Credential resolver — capability, not key (G8, desktop-parity plan).
 - **`cron-runner.py`** — OS-supervised cron runner — emits task files for due crons.json entries.
 - **`daily-insight.py`** — Daily insight generator for Sutando's behavioral flywheel.
 - **`dashboard.py`** — Sutando dashboard — current system status for the local agent.

--- a/src/credential_resolver.py
+++ b/src/credential_resolver.py
@@ -1,0 +1,105 @@
+"""Credential resolver — capability, not key (G8, desktop-parity plan).
+
+Python twin of ``src/credential-resolver.ts`` (#2197). SAME contract, SAME
+canaries: the desktop bundle runs both a TS surface (voice-agent.ts et al.)
+and a Python core, so credential resolution must decide identically in both
+languages. The shared test vectors (``tests/credential-resolver.test.py`` mirrors
+``tests/credential-resolver.test.ts`` one-for-one) are what keep a latent defect
+from surviving in only one twin (the policy-twin lesson from #2516).
+
+Consumers ask for a CAPABILITY ('gemini-voice', 'gemini-text') and the resolver
+decides which credential satisfies it, walking tiers in order:
+
+  1. managed — desktop/AU-provisioned ``<workspace>/state/auth/managed-credentials.json``
+               (per-host durable install state, same never-wiped contract as
+               cloud-auth.json).
+  2. env     — BYO keys from the environment (GEMINI_VOICE_API_KEY /
+               GEMINI_API_KEY — today's behavior).
+
+Within each tier a voice capability falls back to the text credential, mirroring
+the existing GEMINI_VOICE_API_KEY -> GEMINI_API_KEY chain, so a single-key setup
+keeps working unchanged at every tier. With no managed file present, resolution
+is byte-for-byte identical to the legacy env chain — this module changes where
+the decision lives, not what it decides. ``source`` surfaces WHICH tier satisfied
+the capability so managed-vs-BYO drop-in is observable (Settings / health-check).
+
+Managed-file schema (version 1):
+  {"version": 1, "capabilities": {"gemini-voice": {"key": "..."}, ...}}
+Malformed or unreadable files skip the managed tier — never raise. ``version`` is
+reserved for future schema changes and is NOT yet enforced (matches the TS twin).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import NamedTuple, Optional, Union
+
+from workspace_default import resolve_workspace
+
+# Literal capability names (kept as plain strings for py3.8+ compatibility).
+Capability = str  # 'gemini-voice' | 'gemini-text'
+CredentialSource = str  # 'managed' | 'env' | 'none'
+
+
+class ResolvedCredential(NamedTuple):
+    key: str
+    source: CredentialSource
+
+
+# Per-capability lookup order within a tier (voice falls back to text).
+_CAPABILITY_FALLBACKS = {
+    "gemini-voice": ["gemini-voice", "gemini-text"],
+    "gemini-text": ["gemini-text"],
+}
+
+# Env-var names per capability slot, in existing-chain order.
+_ENV_VARS = {
+    "gemini-voice": "GEMINI_VOICE_API_KEY",
+    "gemini-text": "GEMINI_API_KEY",
+}
+
+
+def managed_credentials_path() -> Path:
+    return resolve_workspace() / "state" / "auth" / "managed-credentials.json"
+
+
+def _read_managed(path: Union[os.PathLike, str]) -> dict:
+    """Return the managed file's ``capabilities`` mapping, or {} on any problem.
+
+    Never raises: missing/unreadable/malformed/wrong-shape all skip the tier.
+    Mirrors the TS ``readManaged`` — a non-dict ``capabilities`` (list, etc.)
+    yields {}.
+    """
+    try:
+        with open(path, encoding="utf-8") as fh:
+            parsed = json.load(fh)
+        caps = parsed.get("capabilities") if isinstance(parsed, dict) else None
+        return caps if isinstance(caps, dict) else {}
+    except (OSError, ValueError, TypeError):
+        return {}
+
+
+def resolve_credential(
+    capability: Capability,
+    managed_path: Optional[Union[os.PathLike, str]] = None,
+) -> ResolvedCredential:
+    """Resolve a capability to a credential + its source tier.
+
+    Managed tier (walking the capability's fallback slots) wins over env; within
+    each tier voice falls back to text. Tier order beats slot order — a managed
+    TEXT key beats an env VOICE key. Byte-identical to the TS twin.
+    """
+    slots = _CAPABILITY_FALLBACKS[capability]
+    managed = _read_managed(managed_path if managed_path is not None else managed_credentials_path())
+    for slot in slots:
+        entry = managed.get(slot)
+        key = entry.get("key") if isinstance(entry, dict) else None
+        if isinstance(key, str) and key:
+            return ResolvedCredential(key=key, source="managed")
+    for slot in slots:
+        key = os.environ.get(_ENV_VARS[slot])
+        if key:
+            return ResolvedCredential(key=key, source="env")
+    return ResolvedCredential(key="", source="none")

--- a/tests/credential-resolver.test.py
+++ b/tests/credential-resolver.test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Python twin of tests/credential-resolver.test.ts — SAME vectors, one-for-one.
+
+The twins share canaries so a latent defect can't survive in only one language
+(the policy-twin lesson from #2516). Any change to the resolver contract must be
+reflected in BOTH suites with identical inputs/outputs.
+
+  1. No managed file -> resolution IDENTICAL to the legacy env chain
+     (GEMINI_VOICE_API_KEY -> GEMINI_API_KEY -> ''), source 'env'/'none'.
+  2. Managed tier wins over env; voice falls back to the managed TEXT credential
+     BEFORE dropping to env (tier order beats slot order).
+  3. Malformed / wrong-shape managed files skip the tier — never raise.
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO / "src"))
+
+from credential_resolver import resolve_credential, ResolvedCredential  # noqa: E402
+
+_ENV_KEYS = ("GEMINI_VOICE_API_KEY", "GEMINI_API_KEY")
+_failures = []
+_dir = Path(tempfile.mkdtemp(prefix="credresolver-"))
+
+
+def _reset_env():
+    for k in _ENV_KEYS:
+        os.environ.pop(k, None)
+
+
+def _missing() -> str:
+    return str(_dir / "does-not-exist.json")
+
+
+def _write_managed(caps: dict) -> str:
+    p = _dir / "managed-credentials.json"
+    p.write_text(json.dumps({"version": 1, "capabilities": caps}))
+    return str(p)
+
+
+def check(name, got, expected):
+    exp = ResolvedCredential(key=expected["key"], source=expected["source"])
+    if tuple(got) != tuple(exp):
+        _failures.append(f"{name}: got {tuple(got)} expected {tuple(exp)}")
+        print(f"  FAIL {name}: got {tuple(got)} expected {tuple(exp)}")
+    else:
+        print(f"  ok   {name}")
+
+
+# 1. legacy equivalence: no managed file, VOICE key wins
+_reset_env(); os.environ["GEMINI_VOICE_API_KEY"] = "vk"; os.environ["GEMINI_API_KEY"] = "mk"
+check("legacy: no managed, VOICE key wins", resolve_credential("gemini-voice", _missing()), {"key": "vk", "source": "env"})
+
+# 2. legacy equivalence: no managed file, MAIN-key fallback for voice
+_reset_env(); os.environ["GEMINI_API_KEY"] = "mk"
+check("legacy: no managed, MAIN-key fallback for voice", resolve_credential("gemini-voice", _missing()), {"key": "mk", "source": "env"})
+
+# 3. legacy equivalence: nothing set -> empty key, source none
+_reset_env()
+check("legacy: nothing set -> none", resolve_credential("gemini-voice", _missing()), {"key": "", "source": "none"})
+
+# 4. text capability never reads the voice env var
+_reset_env(); os.environ["GEMINI_VOICE_API_KEY"] = "vk"
+check("text never reads voice env", resolve_credential("gemini-text", _missing()), {"key": "", "source": "none"})
+
+# 5. managed tier beats env
+_reset_env(); os.environ["GEMINI_VOICE_API_KEY"] = "vk"
+check("managed tier beats env", resolve_credential("gemini-voice", _write_managed({"gemini-voice": {"key": "managed-v"}})), {"key": "managed-v", "source": "managed"})
+
+# 6. tier order beats slot order: managed TEXT beats env VOICE
+_reset_env(); os.environ["GEMINI_VOICE_API_KEY"] = "vk"
+check("tier order beats slot order (managed TEXT > env VOICE)", resolve_credential("gemini-voice", _write_managed({"gemini-text": {"key": "managed-t"}})), {"key": "managed-t", "source": "managed"})
+
+# 7. empty managed key falls through to env
+_reset_env(); os.environ["GEMINI_API_KEY"] = "mk"
+check("empty managed key falls through to env", resolve_credential("gemini-voice", _write_managed({"gemini-voice": {"key": ""}})), {"key": "mk", "source": "env"})
+
+# 8. malformed JSON skips managed tier, never raises
+_reset_env(); os.environ["GEMINI_API_KEY"] = "mk"
+_bad = _dir / "malformed.json"; _bad.write_text("{not json")
+check("malformed JSON skips managed, never raises", resolve_credential("gemini-voice", str(_bad)), {"key": "mk", "source": "env"})
+
+# 9. wrong-shape capabilities (array / non-string key) skip managed tier
+_reset_env(); os.environ["GEMINI_API_KEY"] = "mk"
+_arr = _dir / "arr.json"; _arr.write_text(json.dumps({"version": 1, "capabilities": []}))
+check("wrong-shape (array capabilities) skips managed", resolve_credential("gemini-voice", str(_arr)), {"key": "mk", "source": "env"})
+check("wrong-shape (non-string key) skips managed", resolve_credential("gemini-voice", _write_managed({"gemini-voice": {"key": 42}})), {"key": "mk", "source": "env"})
+
+if _failures:
+    print(f"\nFAIL — {len(_failures)} check(s) failed")
+    sys.exit(1)
+print("\nPASS — credential-resolver Python twin matches the TS canaries")


### PR DESCRIPTION
## What
Phase-2 of **G8** (credential resolution by capability, not key — desktop-parity plan). Adds `src/credential_resolver.py`, the Python twin of `src/credential-resolver.ts` (#2197, merged). The desktop bundle runs **both** a TS surface (voice-agent.ts et al.) and a Python core, so credential resolution must decide **identically** in both languages.

## Contract (mirrors the TS twin exactly)
- Tier order: **managed** (`state/auth/managed-credentials.json`) → **env** (`GEMINI_VOICE_API_KEY`/`GEMINI_API_KEY`).
- In-tier fallback: voice → text (the existing chain, generalized).
- `source` surfaced (`managed`/`env`/`none`) so managed-vs-BYO is observable.
- Malformed / unreadable / wrong-shape managed files **skip the tier, never raise**.
- `version` reserved, **not yet enforced** (same as TS — a follow-up on both twins).
- With no managed file present: **byte-for-byte identical to the legacy env chain.**

## Why a twin, with shared vectors
`tests/credential-resolver.test.py` mirrors `tests/credential-resolver.test.ts` **one-for-one** — the twins share canaries so a latent defect can't survive in only one language (the policy-twin lesson from #2516).

## Evidence
```
$ python3 tests/credential-resolver.test.py
  ok   legacy: no managed, VOICE key wins
  ok   legacy: no managed, MAIN-key fallback for voice
  ok   legacy: nothing set -> none
  ok   text never reads voice env
  ok   managed tier beats env
  ok   tier order beats slot order (managed TEXT > env VOICE)
  ok   empty managed key falls through to env
  ok   malformed JSON skips managed, never raises
  ok   wrong-shape (array capabilities) skips managed
  ok   wrong-shape (non-string key) skips managed
PASS — credential-resolver Python twin matches the TS canaries
$ ruff check src/credential_resolver.py tests/credential-resolver.test.py
All checks passed!
```
`docs/src-map.md` regenerated for the new module (193).

## Follow-up (NOT this PR)
Sweep the Python `GEMINI_*_API_KEY` readers to route through `resolve_credential` (mirrors #2197's TS reader sweep). This PR lands the resolver + twin-canaries first; the reader migration is the next, larger slice.

Spec: `design-credential-capability-resolver.md` (#2533). Implementing TS PR: #2197 (merged).