### PR TITLE
fix(health-check): the carrier warning claims data loss that never happened

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1232,12 +1232,26 @@ def check_carrier_set_enforced(workspace_dir=None) -> "dict | None":
         dropped = []
 
     # A shipped entry can be one this host must NOT carry. `state/current-track.md`
-    # is per-host state that #2534 added at a flat, SHARED vault path: two cores write
-    # the same path, and on 2026-08-03 that overwrote a peer's 1056-line anchor.
-    # Telling an operator to re-add it walks them back into that incident, so the
-    # REMEDY is split rather than the entry hidden — silently filtering it would
-    # suppress a real divergence. Delete this list once the host-qualified migration
-    # (#2567/#2568) lands: the flat path stops being shipped and stops appearing here.
+    # is per-host state that #2534 added at a flat, SHARED vault path, so two cores
+    # write the same file and each host's sync resolves the resulting conflict in its
+    # own favour — a peer's anchor lands in your working copy, and neither side's
+    # merge keeps the other's.
+    #
+    # This comment previously said that "overwrote a peer's 1056-line anchor". It did
+    # not, and the correction matters because I wrote the original from a misread of
+    # the sync code rather than from the vault. The vault uses PER-HOST branches
+    # (`host/<host>/<wsid>`); a host only ever merges a peer INTO its own branch and
+    # never writes to the peer's. Checked afterwards: both branches were byte-identical
+    # and this host's index referenced 263 memory files against the discarded copy's
+    # 262 — a strict superset, nothing missing. Chi corrected the claim; Sutando-Pro
+    # independently confirmed it from `state/current-track.md`'s own two-commit history.
+    #
+    # The guidance is unchanged — do not re-add it — but the reason is cross-host
+    # CONTENT DELIVERY on a shared path, not data loss. Telling an operator to re-add
+    # walks them back into that, so the REMEDY is split rather than the entry hidden;
+    # silently filtering it would suppress a real divergence. Delete this list once the
+    # host-qualified migration (#2567/#2568) lands: the flat path stops being shipped
+    # and stops appearing here.
     UNSAFE_TO_READD = ("state/current-track.md",)
     unsafe = [e for e in dropped if e in UNSAFE_TO_READD]
     safe = [e for e in dropped if e not in UNSAFE_TO_READD]
@@ -1319,8 +1333,9 @@ def check_carrier_set_enforced(workspace_dir=None) -> "dict | None":
         parts.append(
             f"{len(unsafe)} shipped carrier path(s) are missing here and must NOT be re-added "
             f"({', '.join(unsafe)}) — per-host state carried at a flat, SHARED vault path, so "
-            f"re-adding re-creates the cross-host overwrite that destroyed a peer's anchor "
-            f"(#2567). Leave them out until the host-qualified migration lands"
+            f"re-adding puts two hosts on one file: a peer's copy lands in yours and each "
+            f"sync keeps its own side (#2567). Leave them out until the host-qualified "
+            f"migration lands"
         )
     return {"name": name, "status": "fail", "detail": "; ".join(parts)}
 

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -284,8 +284,14 @@ class CarrierSetProbe(unittest.TestCase):
         # qingyun-wu, P1 on e73e2597. The remedy said "add them to the local list"
         # for EVERY missing shipped entry — including `state/current-track.md`,
         # which #2534 ships at a flat, SHARED vault path. Following that advice
-        # re-tracks per-host state at a path a peer also writes, which is exactly
-        # the incident that destroyed a peer's 1056-line anchor on 2026-08-03.
+        # re-tracks per-host state at a path a peer also writes, so a peer's copy
+        # lands in yours and each sync keeps its own side.
+        #
+        # This comment previously called that "the incident that destroyed a
+        # peer's 1056-line anchor". Nothing was destroyed — the vault uses
+        # per-host branches and a host never writes to a peer's. Corrected here
+        # as well as in the source, because a retraction that fixes only the
+        # passage in front of you leaves the wrong version alive somewhere else.
         #
         # It must still be REPORTED — silently filtering it would hide a real
         # divergence, which is the failure this whole probe exists to prevent.
@@ -301,7 +307,19 @@ class CarrierSetProbe(unittest.TestCase):
         self.assertIn("must NOT be re-added", r["detail"])
         self.assertIn("#2567", r["detail"], "must name why")
         self.assertNotIn("add them to the local list", r["detail"],
-                         "the data-loss instruction must not accompany this entry")
+                         "the re-add instruction must not accompany this entry")
+        # The warning must not claim data loss. It shipped saying re-adding
+        # "destroyed a peer's anchor"; nothing was destroyed, and an operator who
+        # later discovers that discounts the whole warning — including the part
+        # that is true. Asserting the absence of the claim is the point here:
+        # the reason may be reworded, the false severity must not come back.
+        for overclaim in ("destroyed", "destroy", "data loss"):
+            self.assertNotIn(overclaim, r["detail"].lower(),
+                             f"the warning must not claim {overclaim!r} — the hazard is a "
+                             "peer's copy landing in yours on a shared path, not loss")
+        # …and it must still say enough to act on, so the correction cannot be
+        # satisfied by simply deleting the reason.
+        self.assertIn("SHARED", r["detail"], "must still name why the path is unsafe")
 
     def test_a_SAFE_dropped_entry_still_gets_the_add_it_remedy(self):
         # Over-trigger control: the unsafe carve-out must not swallow the ordinary


### PR DESCRIPTION
I shipped a false claim into a user-facing health warning in #2570. @Sutando-Pro flagged it; Chi had already corrected the underlying premise.

## What was wrong

The warning said re-adding `state/current-track.md` *"re-creates the cross-host overwrite that **destroyed** a peer's anchor"*. **Nothing was destroyed.**

The vault uses **per-host branches** (`host/<host>/<wsid>`). A host only ever merges a peer *into* its own branch and never writes to the peer's, and `_resolve_conflicts_keep_ours` resolves on the local branch's merge result. I checked this rather than argued it:

- both branches byte-identical (24,897 B / 185 lines)
- this host's index referenced **263** memory files against the discarded copy's **262** — a strict superset, nothing missing
- Pro independently confirmed from that file's own two-commit history: added `+459` by one sync, removed `-459` by the other

## What changed

The **guidance is unchanged** — do not re-add it. Only the reason is corrected, because the real hazard is cross-host *content delivery* on a shared path, not data loss:

```
before  … re-creates the cross-host overwrite that destroyed a peer's anchor
after   … puts two hosts on one file: a peer's copy lands in yours and each
          sync keeps its own side
```

This matters beyond accuracy: an operator who later discovers the severity was invented discounts the **whole** warning, including the part that is true — and a health check trades entirely on being believed.

## Three places, not one

The warning text, the comment above it, and the test comment that repeated the claim. A retraction that fixes only the passage in front of you leaves the wrong version alive somewhere else — which is exactly how this survived my earlier retraction in chat, in `pending-questions.md` and in the peer channel. Pro found the one copy I'd missed.

The new assertion forbids the false severity (`destroyed` / `data loss`) **and** requires the warning still name why the path is unsafe, so the correction can't be satisfied by deleting the reason instead of fixing it.

```
new assertion against main's wording : FAILED (failures=1)
HEAD                                 : 23 tests, OK
67 suites referencing health-check / git_binary : 67 pass, 0 fail
py_compile clean · gen-src-map up to date · review-checks PASS
```

Comment/string only — no behavior change, and `check_carrier_set_enforced`'s verdicts are untouched.

Stand: Echo Act IV Mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)
