### PR TITLE
fix(core-heartbeat): a versioned Claude binary makes pgrep -x miss, so a LIVE core reads dead

### DIFF
--- a/src/core_heartbeat.py
+++ b/src/core_heartbeat.py
@@ -204,6 +204,40 @@ def core_pid(socket_path: str | None = None, session: str | None = None) -> int 
     except Exception:
         pass
 
+    # The executable's accounting NAME is not a reliable handle for the core.
+    # Claude Code installs a version-named binary
+    # (`~/.local/share/claude/versions/<ver>`), and `pgrep -x` matches the
+    # kernel accounting name (`ps -o ucomm=`), which is then `<ver>` — NOT
+    # `claude`. So on a versioned install the branch above matches nothing for a
+    # perfectly healthy core, the `runtime == "claude"` bail below returns None
+    # forever, and `.alive` is never written at all. Measured on a live host:
+    # `ps -o comm=` said `claude` (that is argv[0]) while `ps -o ucomm=` said
+    # `2.1.220`, and a core alive for ten minutes read as dead to every reader.
+    # That is the exact inverse of the bug #2488 fixed, reached through the same
+    # gate — and it is the more dangerous direction, because a consumer that
+    # relaunches a "dead" core would then relaunch a live one in a loop.
+    #
+    # Fix the pid ENUMERATION rather than the identity test: ask tmux for the
+    # panes of THIS exact session and apply the same `--name <sess>` argv check
+    # to them. Both #2488 guards survive — the candidates are scoped to the
+    # exact session (never "any pane on the socket"), and identity still comes
+    # from argv, never from the pane's foreground command. Strictly stronger
+    # than the non-Claude fallback below, so it runs for every runtime.
+    try:
+        lp = _tmux(sock, "list-panes", "-t", f"={sess}", "-F", "#{pane_pid}")
+        if lp is not None and lp.returncode == 0:
+            for pid_s in lp.stdout.split():
+                if not pid_s.isdigit():
+                    continue
+                ps = subprocess.run(["ps", "-o", "args=", "-p", pid_s],
+                                    capture_output=True, text=True, timeout=5)
+                if ps.returncode != 0:
+                    continue
+                if _argv_names_session(ps.stdout.strip(), sess):
+                    return int(pid_s)
+    except Exception:
+        pass
+
     # A Claude session with no matching `claude --name <sess>` process is DEAD,
     # not "fall back to whatever pane is left" (review-caught, john-the-dev on
     # #2488). The pane fallback exists for NON-Claude runtimes; applied to a

--- a/src/core_heartbeat.py
+++ b/src/core_heartbeat.py
@@ -223,8 +223,29 @@ def core_pid(socket_path: str | None = None, session: str | None = None) -> int 
     # exact session (never "any pane on the socket"), and identity still comes
     # from argv, never from the pane's foreground command. Strictly stronger
     # than the non-Claude fallback below, so it runs for every runtime.
+    # `-s` = every pane in the SESSION. WITHOUT it, `list-panes -t "={sess}"`
+    # resolves to that session's CURRENT WINDOW only — and this repo deliberately
+    # keeps sibling windows (gateway, monitor) in the core's session, healing
+    # window-scoped so they survive (`src/agent/claude/cli/start-cli.sh`). Select
+    # a sibling and this branch inspects only that sibling, misses the live core
+    # in another window, and returns None again — the very failure being fixed.
+    #
+    # `src/health-check.py` already learned this and says so in its own docstring
+    # ("the first version of this helper targeted the session ... which tmux
+    # resolves to that session's current window"), landing on
+    # `list-panes -s -t "={session}"` plus the argv identity check. This is the
+    # same resolver problem, so it gets the same shape rather than a second
+    # answer. Note that file also records why window NAME is no discriminator:
+    # on a versioned install the core's window is auto-named after the version —
+    # the same `ucomm` fact that motivates this PR.
+    #
+    # Review-caught, qingyun-wu, with an exact-head canary: gateway window
+    # current, real core pane in a sibling window -> `core_pid` returned None.
+    # `-t "={sess}"` still pins the exact session, so #2488's "never any pane on
+    # the socket" guard is untouched — `-s` widens across windows WITHIN this
+    # session, never across sessions.
     try:
-        lp = _tmux(sock, "list-panes", "-t", f"={sess}", "-F", "#{pane_pid}")
+        lp = _tmux(sock, "list-panes", "-s", "-t", f"={sess}", "-F", "#{pane_pid}")
         if lp is not None and lp.returncode == 0:
             for pid_s in lp.stdout.split():
                 if not pid_s.isdigit():
@@ -251,8 +272,12 @@ def core_pid(socket_path: str | None = None, session: str | None = None) -> int 
     if (_session_runtime(sock, sess) or "").lower() == "claude":
         return None
 
-    # Non-Claude runtime: panes of THIS session only (never `-a`).
-    lp = _tmux(sock, "list-panes", "-t", f"={sess}", "-F", "#{pane_pid}")
+    # Non-Claude runtime: panes of THIS session only (never `-a`), across all its
+    # windows (`-s`) for the same reason as the branch above — without it, a core
+    # in a non-selected window is invisible and this returns None for a live
+    # core. Same one-token correction under the same guard: `-t "={sess}"` keeps
+    # it pinned to the exact session.
+    lp = _tmux(sock, "list-panes", "-s", "-t", f"={sess}", "-F", "#{pane_pid}")
     if lp is None or lp.returncode != 0:
         return None
     for line in lp.stdout.split():

--- a/tests/core-heartbeat-pgrep-portability.test.py
+++ b/tests/core-heartbeat-pgrep-portability.test.py
@@ -113,20 +113,39 @@ check(".alive removed once death is confirmed", not alive.exists())
 # identification skips the fallback — unknown must keep the old behaviour, so a
 # healthy non-Claude host can never be turned into a permanent false death.
 
-def _farm(runtime_line: str, claude_alive: bool, kill_config: bool = False):
-    """Fake toolchain: tmux answers has-session / show-environment / list-panes."""
+def _farm(runtime_line: str, claude_alive: bool, kill_config: bool = False,
+          pane_pid: int = 7777):
+    """Fake toolchain: tmux answers has-session / show-environment / list-panes.
+
+    `ps` is deliberately PID-AWARE. It used to echo the core's argv for every
+    pid, which made the fixture unable to express the difference between "this
+    pane IS the core" and "this pane is a leftover shell in the core's session"
+    — the two cases the `--name <sess>` argv test exists to separate. With a
+    blanket stub, any pane-scoped lookup trivially "finds" a core, so a change
+    that resurrects a corpse and a change that correctly identifies a live core
+    are indistinguishable. Only 4242 is the core here; every other pid is a
+    shell, which is what a surviving sibling pane actually looks like.
+    """
     d = Path(tempfile.mkdtemp(prefix="ch-rt-"))
     tmux = "\n".join([
         'case "$*" in',
         '  *has-session*)      exit 0 ;;',
         f'  *show-environment*) {runtime_line}; exit 0 ;;',
-        '  *list-panes*)       echo 7777; exit 0 ;;',
+        f'  *list-panes*)       echo {pane_pid}; exit 0 ;;',
         'esac',
         'exit 0',
     ])
     _bin(d, "tmux", tmux)
     _bin(d, "pgrep", "echo 4242\nexit 0" if claude_alive else "exit 1")
-    _bin(d, "ps", f'echo "claude --name {SESSION} --resume"')
+    _bin(d, "ps", "\n".join([
+        'last=""',
+        'for a in "$@"; do last="$a"; done',
+        'case "$last" in',
+        f'  4242) echo "claude --name {SESSION} --resume" ;;',
+        '  *)    echo "-zsh" ;;',
+        'esac',
+        'exit 0',
+    ]))
     if kill_config:
         # Truly-undeterminable runtime: the session env is unset AND the config
         # fallback cannot answer. Without this the config in THIS repo says
@@ -171,6 +190,10 @@ def _restore_config(token):
         sys.modules["sutando_config"] = saved
 
 
+# The `alive` column is "does `pgrep -x claude` match?", NOT "is the core
+# running?". Conflating the two is what hid the versioned-binary case below:
+# every pre-existing row set pgrep to answer, so no row could express a host
+# where the core is healthy but its executable is not NAMED `claude`.
 CASES = [
     ("claude session + claude process   -> the claude pid",
      'echo SUTANDO_CORE_RUNTIME=claude', True,  4242),
@@ -180,11 +203,22 @@ CASES = [
      'echo SUTANDO_CORE_RUNTIME=codex',  False, 7777),
     ("UNKNOWN runtime + no claude proc  -> pane fallback preserved",
      'echo "-SUTANDO_CORE_RUNTIME"',     False, 7777, True),
+    # Versioned install: Claude Code runs from `~/.local/share/claude/versions/
+    # <ver>`, so the kernel accounting name that `pgrep -x` matches is `<ver>`,
+    # not `claude` — pgrep matches NOTHING for a perfectly healthy core. The
+    # core is the session's own pane, and its argv still names the session, so
+    # the pane-scoped argv check must resolve it. Before the fix this returned
+    # None, `.alive` was never written, and a live core read dead to every
+    # reader — the inverse of #2488 and the more dangerous direction, since a
+    # consumer that relaunches a dead core would relaunch a live one in a loop.
+    ("versioned binary (pgrep -x misses) -> pane argv still identifies the core",
+     'echo SUTANDO_CORE_RUNTIME=claude', False, 4242, False, 4242),
 ]
 for case in CASES:
     label, rt, alive, want = case[:4]
     _kill = bool(len(case) > 4 and case[4])
-    box = _farm(rt, alive, kill_config=_kill)
+    _pane = case[5] if len(case) > 5 else 7777
+    box = _farm(rt, alive, kill_config=_kill, pane_pid=_pane)
     _op = os.environ["PATH"]
     os.environ["PATH"] = f"{box}:{_op}"
     _tok = _blind_config() if _kill else None

--- a/tests/core-heartbeat-pgrep-portability.test.py
+++ b/tests/core-heartbeat-pgrep-portability.test.py
@@ -114,7 +114,7 @@ check(".alive removed once death is confirmed", not alive.exists())
 # healthy non-Claude host can never be turned into a permanent false death.
 
 def _farm(runtime_line: str, claude_alive: bool, kill_config: bool = False,
-          pane_pid: "int | str" = 7777):
+          pane_pid: "int | str" = 7777, other_window_pid: "int | None" = None):
     """Fake toolchain: tmux answers has-session / show-environment / list-panes.
 
     `ps` is deliberately PID-AWARE. It used to echo the core's argv for every
@@ -134,6 +134,15 @@ def _farm(runtime_line: str, claude_alive: bool, kill_config: bool = False,
         # Unquoted on purpose: a multi-token `pane_pid` becomes one line per
         # token, which is how `list-panes -F '#{pane_pid}'` reports >1 pane and
         # how a non-pid token (tmux noise, a blank line) reaches the parser.
+        # Two cases, because tmux distinguishes them and the resolver must too:
+        #   `list-panes -s -t =sess` -> every pane in the SESSION (all windows)
+        #   `list-panes    -t =sess` -> only the CURRENT WINDOW's panes
+        # `other_window_pid` is a pane in the session but NOT in the selected
+        # window, so it is reachable only via `-s`. Modelling it is the
+        # difference between "several tokens on one result" and "several
+        # WINDOWS" — the axis that let a core in a sibling window read as absent.
+        f"  *list-panes*-s*|*-s*list-panes*)  printf '%s\\n' {other_window_pid} {pane_pid}; exit 0 ;;"
+        if other_window_pid else "",
         f"  *list-panes*)       printf '%s\\n' {pane_pid}; exit 0 ;;",
         'esac',
         'exit 0',
@@ -223,12 +232,26 @@ CASES = [
     # `if not pid_s.isdigit(): continue` guard is never executed by any test.
     ("noisy list-panes (non-pid token first) -> skipped, core still found",
      'echo SUTANDO_CORE_RUNTIME=claude', False, 4242, False, "- 4242"),
+    # TWO WINDOWS. `list-panes -t =sess` reports only the CURRENT window, so a
+    # core in a non-selected sibling window is invisible to this branch and the
+    # resolver returns None for a LIVE core — the same failure this PR fixes,
+    # reached through a different door. Sibling windows (gateway, monitor) are
+    # kept deliberately in the core's session by start-cli.sh, so whichever
+    # window is selected decided whether the core could be found.
+    #
+    # Here the selected window holds only pane 7777 (a shell) and the core 4242
+    # lives in another window of the same session — reachable only via `-s`.
+    # Review-caught, qingyun-wu, exact-head canary: gateway window current, real
+    # core pane in a sibling -> core_pid returned None.
+    ("core in a NON-SELECTED window of the same session is still found (-s)",
+     'echo SUTANDO_CORE_RUNTIME=claude', False, 4242, False, 7777, 4242),
 ]
 for case in CASES:
     label, rt, alive, want = case[:4]
     _kill = bool(len(case) > 4 and case[4])
     _pane = case[5] if len(case) > 5 else 7777
-    box = _farm(rt, alive, kill_config=_kill, pane_pid=_pane)
+    _otherw = case[6] if len(case) > 6 else None
+    box = _farm(rt, alive, kill_config=_kill, pane_pid=_pane, other_window_pid=_otherw)
     _op = os.environ["PATH"]
     os.environ["PATH"] = f"{box}:{_op}"
     _tok = _blind_config() if _kill else None

--- a/tests/core-heartbeat-pgrep-portability.test.py
+++ b/tests/core-heartbeat-pgrep-portability.test.py
@@ -114,7 +114,7 @@ check(".alive removed once death is confirmed", not alive.exists())
 # healthy non-Claude host can never be turned into a permanent false death.
 
 def _farm(runtime_line: str, claude_alive: bool, kill_config: bool = False,
-          pane_pid: int = 7777):
+          pane_pid: "int | str" = 7777):
     """Fake toolchain: tmux answers has-session / show-environment / list-panes.
 
     `ps` is deliberately PID-AWARE. It used to echo the core's argv for every
@@ -131,7 +131,10 @@ def _farm(runtime_line: str, claude_alive: bool, kill_config: bool = False,
         'case "$*" in',
         '  *has-session*)      exit 0 ;;',
         f'  *show-environment*) {runtime_line}; exit 0 ;;',
-        f'  *list-panes*)       echo {pane_pid}; exit 0 ;;',
+        # Unquoted on purpose: a multi-token `pane_pid` becomes one line per
+        # token, which is how `list-panes -F '#{pane_pid}'` reports >1 pane and
+        # how a non-pid token (tmux noise, a blank line) reaches the parser.
+        f"  *list-panes*)       printf '%s\\n' {pane_pid}; exit 0 ;;",
         'esac',
         'exit 0',
     ])
@@ -213,6 +216,13 @@ CASES = [
     # consumer that relaunches a dead core would relaunch a live one in a loop.
     ("versioned binary (pgrep -x misses) -> pane argv still identifies the core",
      'echo SUTANDO_CORE_RUNTIME=claude', False, 4242, False, 4242),
+    # Same host shape, but `list-panes` emits a NON-PID token before the real
+    # pane. Real tmux can put a blank line or a warning on stdout, and a
+    # non-numeric token must be skipped rather than crash the resolver or abort
+    # the scan — the core is still found on the next token. Without this row the
+    # `if not pid_s.isdigit(): continue` guard is never executed by any test.
+    ("noisy list-panes (non-pid token first) -> skipped, core still found",
+     'echo SUTANDO_CORE_RUNTIME=claude', False, 4242, False, "- 4242"),
 ]
 for case in CASES:
     label, rt, alive, want = case[:4]


### PR DESCRIPTION
## The defect

#2488 correctly stopped a dead core from reading healthy, by gating the beat on `core_pid()` resolving the core. On this host that gate **never passes for a healthy core**, so `.alive` is never written at all and the inverse bug is live: a core up for ten minutes, draining tasks normally, reads **DEAD** to every reader (health-check, dashboard, peers, the scheduler).

`core_pid()` enumerates candidates with `pgrep -x claude`. `pgrep -x` matches the kernel accounting name, and Claude Code runs from a version-named binary:

```
exe   : ~/.local/share/claude/versions/<ver>
ucomm : <ver>        <- what pgrep -x matches
comm  : claude       <- argv[0], what ps -o comm= shows
```

`pgrep -x claude` therefore matches nothing. The `runtime == "claude"` bail then returns `None` **without** the pane fallback — deliberately, because for a Claude session "no matching process" is supposed to mean dead. Here it means "the binary is not named what we grepped for."

`_argv_names_session()` itself is fine — given the core's argv it returns `True`. Only the pid **enumeration** is broken.

## Evidence

Before (at `origin/main`, core pid alive and processing tasks):

```
$ core_pid() at origin/main -> None
  (core pid 30961 is alive: True )
```

The predicate `#2160` consumes, with a **positive control** so the negative means something — same function, given a synthetic `.alive` in an isolated tmp workspace (resolved path asserted inside the tmpdir), returns the record:

```
=== NEGATIVE: live workspace, core pid 30961 provably running ===
  _fresh_local_core_record() -> None
  => predicate alive = False

=== POSITIVE CONTROL: isolated tmp workspace ===
  inside the tmpdir? : True
  _fresh_local_core_record(ws=tmp) -> RECORD, pid 30961
  => predicate alive = True
```

After, same host, same live core:

```
core_pid() WITH FIX -> 30961
expected            -> 30961 (the live core)
MATCH               -> True
```

## The fix

Fix the **enumeration**, not the identity test: ask tmux for the panes of THIS exact session and apply the same `--name <sess>` argv check to them.

Both #2488 guards survive:

1. **Never accept any pane on the socket** — candidates are scoped to `-t =<sess>`, the exact session, so the Codex `${SESSION}-watcher` and preserved sibling windows are still excluded.
2. **Never gate on the pane's foreground command** — identity still comes from argv (`--name <sess>`), never from the pane cmd, so a core mid-tool showing `bash`/`node` is unaffected.

It is strictly stronger than the non-Claude pane fallback below it (that one takes the first pane unconditionally), so it runs for every runtime, and it removes the dependency on the executable's accounting name entirely.

## Why the tests did not catch it

The fixture, not the assertions. `ps` echoed the core's argv for **every** pid, so it could not distinguish "this pane IS the core" from "this pane is a leftover shell" — under a blanket stub, a change that resurrects a corpse and a change that correctly identifies a live core look identical. And every existing row set `pgrep` to answer, so no row could express a host whose core is healthy but not *named* `claude`.

So `ps` is now pid-aware (only 4242 is the core; anything else is a shell, which is what a surviving sibling pane actually looks like) and the versioned-binary axis is added.

**The new case fails against unfixed src** — that is the part worth checking:

```
# src reverted to origin/main, test file KEEPS the new case
  ok   claude session + claude process   -> the claude pid
  ok   CLAUDE session + NO claude proc   -> None (NOT pane 7777)
  ok   codex session + no claude proc    -> pane fallback still works
  ok   UNKNOWN runtime + no claude proc  -> pane fallback preserved
  FAIL versioned binary (pgrep -x misses) -> pane argv still identifies the core — got None, want 4242
```

All four pre-existing cases still pass, **including the corpse guard** that must keep returning `None`. With the fix restored, all five pass.

Full suite for the changed file:

```
tests/core-heartbeat-pgrep-portability.test.py   PASS (exit 0)
tests/core-heartbeat.test.py                     PASS
tests/core-heartbeat-core-pid.test.py            PASS
tests/codex-core-launcher.test.py                PASS
tests/state-paths-adoption.test.py               PASS
tests/hostname-resolution-resilience.test.py     PASS
tests/health-check-quota-telemetry.test.py       PASS
tests/sutando-config-runtime.test.sh             PASS
scripts/review-checks.sh                         PASS (hardcoded-paths clean)
```

## Why this direction is the dangerous one

A consumer that relaunches a core it believes dead would relaunch a **live** one, kill the session and its in-flight task, then find no heartbeat again on the next pass and do it again. That is #2246's restart-storm, reached through the very signal offered as the reason it could not happen.

**#2160** consumes exactly this predicate (`dead = (not alive) and (not just_booted_fn())`). I have flagged it there and withdrawn the "it keys off the heartbeat, which is a materially stronger signal" argument I made on 2026-07-31 — that was true when written and stopped being true when #2488 landed.

## A design point I think outlives this bug (not in this PR)

Absent `.alive` currently conflates two states: (1) the core died, and (2) the heartbeat writer never started, crashed, or cannot identify the core. Only (1) should ever trigger a relaunch. Relaunching on (2) converts a broken *observer* into a destructive *actuator*. Whatever lands here, I think the dead-core branch wants independent confirmation that the core is genuinely gone before it acts — that would have made this host's failure inert instead of destructive. Raised on #2160 rather than bundled here.

@sonichi flagging for visibility — this is live on `main` and silently disables the per-host liveness signal on any versioned Claude Code install, which is the default install shape.
