### PR TITLE
fix(gateway): honor an explicitly-mapped tier for a named sender

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -574,26 +574,34 @@ def _load_tier_map():
     return tm
 
 
-# Privilege ordering — a higher rank is MORE privileged. Used to clamp a mapped
-# tier so the owner file can only ever DOWN-tier (never escalate above the node's
-# own default), keeping the "map only down-tiers named senders" safety invariant
-# true in code rather than only in the comment.
+# Known tier vocabulary. Also an ordering (higher == more privileged); kept for
+# validating a mapped value. It no longer CLAMPS — see _tier_for.
 _TIER_RANK = {"other": 0, "team": 1, "owner": 2}
 
 
 def _tier_for(user_id):
     """Resolve the access_tier for a task's broker-attested sender.
 
-    A listed sender gets their mapped tier, CLAMPED to <= LOCAL_TIER: the map can
-    down-tier a sender below this node's default but never raise them above it, so
-    a compromised/misconfigured access.json can never ESCALATE. Everyone else
-    (unlisted / no user_id) gets LOCAL_TIER."""
+    An EXPLICITLY LISTED sender gets exactly the tier the owner mapped them to —
+    including a tier ABOVE this node's LOCAL_TIER. That is the point: it lets a
+    SHARED gateway run a least-privilege default (REMOTE_TASK_TIER=team) and name
+    the one sender who is the owner, instead of the only previously-available
+    shape — a blanket `owner` default that every unlisted sender inherits.
+
+    This mirrors the discord and slack bridges, which have always resolved
+    `access_tier = tierMap[sender_id]` with no clamp. The map is LOCAL,
+    owner-owned config with the same trust standing as REMOTE_TASK_TIER itself,
+    and the lookup key is the BROKER-ATTESTED user_id, never a task-body
+    self-claim — so the WIRE still cannot escalate anyone. Only the owner's own
+    local file can, and only for a sender they named explicitly.
+
+    Everyone else (unlisted / no user_id) gets LOCAL_TIER, unchanged: no existing
+    install is silently demoted, and an unknown sender never gains privilege."""
     uid = (user_id or "").strip()
     if uid:
         mapped = _load_tier_map().get(uid)
         if mapped in _TIER_RANK:
-            local_rank = _TIER_RANK.get(LOCAL_TIER, _TIER_RANK["owner"])
-            return mapped if _TIER_RANK[mapped] <= local_rank else LOCAL_TIER
+            return mapped
     return LOCAL_TIER
 
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -535,7 +535,30 @@ def _ag2space_access_path():
     return os.path.join(base, "channels", "ag2space", "access.json")
 
 
+# Known tier vocabulary. Also an ordering (higher == more privileged); kept for
+# validating a mapped value. It no longer CLAMPS — see _tier_for.
+_TIER_RANK = {"other": 0, "team": 1, "owner": 2}
+
 _TIER_MAP_CACHE = {"mtime": None, "map": {}}
+
+
+def _stale_safe(cached):
+    """Project a STALE cached map onto the fail-closed side in BOTH directions.
+
+    The cache is deliberately preserved across a read error so a transient
+    mid-write cannot fail-OPEN a down-tiered sender back to LOCAL_TIER. That
+    reasoning holds only for entries at or below LOCAL_TIER. Once the map can
+    also grant a tier ABOVE LOCAL_TIER, replaying the cache verbatim keeps an
+    ESCALATION alive on a file the owner may have just deleted to revoke it —
+    so deleting access.json would not actually revoke anything.
+
+    Drop the above-LOCAL_TIER entries (those senders fall back to LOCAL_TIER)
+    and keep the rest. A legitimately-granted sender is briefly demoted while
+    the file is unreadable and is restored on the next successful read; an
+    unrevoked escalation is not left standing. Transient demotion is the safe
+    direction — the module already fails closed to "team" on a bad LOCAL_TIER."""
+    local_rank = _TIER_RANK.get(LOCAL_TIER, _TIER_RANK["owner"])
+    return {k: v for k, v in cached.items() if _TIER_RANK.get(v, 0) <= local_rank}
 
 
 def _load_tier_map():
@@ -555,8 +578,10 @@ def _load_tier_map():
         mt = os.path.getmtime(path)
     except OSError:
         # Absent/unstattable → keep last-known-good (initially {} before any load).
-        return _TIER_MAP_CACHE["map"]
+        return _stale_safe(_TIER_MAP_CACHE["map"])
     if mt == _TIER_MAP_CACHE["mtime"]:
+        # File present and UNCHANGED — this cache is current, not stale. Return it
+        # verbatim: projecting here would drop a legitimate up-tier on every call.
         return _TIER_MAP_CACHE["map"]
     try:
         with open(path) as f:
@@ -569,14 +594,9 @@ def _load_tier_map():
     except Exception:
         # Malformed / mid-write → keep last-known-good; don't advance mtime so a
         # later successful read of the fixed file is still picked up.
-        return _TIER_MAP_CACHE["map"]
+        return _stale_safe(_TIER_MAP_CACHE["map"])
     _TIER_MAP_CACHE["mtime"], _TIER_MAP_CACHE["map"] = mt, tm
     return tm
-
-
-# Known tier vocabulary. Also an ordering (higher == more privileged); kept for
-# validating a mapped value. It no longer CLAMPS — see _tier_for.
-_TIER_RANK = {"other": 0, "team": 1, "owner": 2}
 
 
 def _tier_for(user_id):

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -616,7 +616,19 @@ def _tier_for(user_id):
     local file can, and only for a sender they named explicitly.
 
     Everyone else (unlisted / no user_id) gets LOCAL_TIER, unchanged: no existing
-    install is silently demoted, and an unknown sender never gains privilege."""
+    install is silently demoted, and an unknown sender never gains privilege.
+
+    ⚠ CONTRACT — `user_id` MUST stay broker-attested (cold-review note, #2584).
+    The removed clamp used to be a backstop: even if `user_id` had become
+    body-influenced, a mapped tier was still bounded by LOCAL_TIER. With the
+    clamp gone, "`user_id` is the broker-written Matrix sender, never a
+    task-body self-claim" is SOLELY load-bearing for the no-wire-escalation
+    property. It holds today because `user_id` is a broker-writer-side entry in
+    _TASK_FIELDS, serialized beside room_name/sender_name. Any future change
+    that lets a task body influence `user_id` reintroduces wire-controlled
+    escalation — re-add a bound here if that contract is ever weakened.
+    (Deliberately a contract note, not an assert: provenance cannot be checked
+    at runtime — the value is an ordinary string whichever path produced it.)"""
     uid = (user_id or "").strip()
     if uid:
         mapped = _load_tier_map().get(uid)
@@ -1293,6 +1305,7 @@ def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
     as discord-bridge.write_owner_activity so the proactive-loop reader is
     transport-agnostic. Best-effort — never blocks task intake."""
     if sender_tier is None:
+        # user_id is broker-attested here — see the CONTRACT note in _tier_for.
         sender_tier = _tier_for(task.get("user_id"))
     if sender_tier != "owner":
         return
@@ -1456,6 +1469,7 @@ def _write_task(task: dict) -> str | None:
     # Resolve ONCE and reuse for both the task tier AND the owner-activity gate
     # below, so the two decisions can never diverge (a single source of truth,
     # no double read of the tierMap).
+    # user_id is broker-attested here — see the CONTRACT note in _tier_for.
     sender_tier = _tier_for(task.get("user_id"))
     lines.append(f"access_tier: {sender_tier}")
     # #2267 parity, second half: the other bridges append the in-band security

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -539,7 +539,13 @@ def _ag2space_access_path():
 # validating a mapped value. It no longer CLAMPS — see _tier_for.
 _TIER_RANK = {"other": 0, "team": 1, "owner": 2}
 
-_TIER_MAP_CACHE = {"mtime": None, "map": {}}
+_TIER_MAP_CACHE = {"ident": None, "map": {}}
+
+
+def _has_above_local(cached) -> bool:
+    """True if the cached map grants anyone a tier ABOVE this node's LOCAL_TIER."""
+    local_rank = _TIER_RANK.get(LOCAL_TIER, _TIER_RANK["owner"])
+    return any(_TIER_RANK.get(v, 0) > local_rank for v in cached.values())
 
 
 def _stale_safe(cached):
@@ -575,11 +581,20 @@ def _load_tier_map():
     tradeoff — the map floor never drops on a transient fault)."""
     path = _ag2space_access_path()
     try:
-        mt = os.path.getmtime(path)
+        st = os.stat(path)
     except OSError:
         # Absent/unstattable → keep last-known-good (initially {} before any load).
         return _stale_safe(_TIER_MAP_CACHE["map"])
-    if mt == _TIER_MAP_CACHE["mtime"]:
+    # Cache identity is (mtime_ns, size, inode), NOT float mtime. A float mtime
+    # collides under a same-second rewrite and can be restored outright with
+    # os.utime, which would serve a REVOKED grant from cache — reproduced on
+    # #2584 (rewrite to {"tierMap":{}}, restore st_mtime_ns, still resolved owner).
+    ident = (st.st_mtime_ns, st.st_size, st.st_ino)
+    # Belt-and-braces: never serve an ABOVE-LOCAL grant from cache without a fresh
+    # read. Identity can still be forged deliberately; a revoked escalation must not
+    # survive that. Costs one small read per call only while an escalation is
+    # cached — discord's loader has no cache at all and re-reads every message.
+    if ident == _TIER_MAP_CACHE["ident"] and not _has_above_local(_TIER_MAP_CACHE["map"]):
         # File present and UNCHANGED — this cache is current, not stale. Return it
         # verbatim: projecting here would drop a legitimate up-tier on every call.
         return _TIER_MAP_CACHE["map"]
@@ -595,7 +610,7 @@ def _load_tier_map():
         # Malformed / mid-write → keep last-known-good; don't advance mtime so a
         # later successful read of the fixed file is still picked up.
         return _stale_safe(_TIER_MAP_CACHE["map"])
-    _TIER_MAP_CACHE["mtime"], _TIER_MAP_CACHE["map"] = mt, tm
+    _TIER_MAP_CACHE["ident"], _TIER_MAP_CACHE["map"] = ident, tm
     return tm
 
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1297,6 +1297,11 @@ def _write_owner_activity(task: dict, sender_tier: str | None = None) -> None:
     supervisor escalation target). `sender_tier` is passed in by `_write_task` so
     the task tier and this gate share a SINGLE resolution (no divergence, no
     double tierMap read); a direct caller can omit it and we resolve here. For an
+    Since the map may now grant a tier ABOVE LOCAL_TIER, the mirror case also
+    holds: a sender explicitly mapped to owner on a least-privilege node DOES
+    register owner presence — that is the point of naming them owner. Tests 23/24
+    pin both directions, because a refactor that regated this on LOCAL_TIER would
+    silently stop recording the real owner's activity. For an
     unlisted sender `_tier_for` returns LOCAL_TIER, so the single-owner case is
     unchanged. Never trusts the gateway's own claim (it is outside the trust
     boundary) — only the broker-attested user_id keyed against the owner's LOCAL

--- a/tests/gateway-per-sender-tier.test.py
+++ b/tests/gateway-per-sender-tier.test.py
@@ -40,7 +40,7 @@ rgb.LOCAL_TIER = "owner"
 
 def _write_map(m):
     ACCESS.write_text(json.dumps({"allowFrom": ["@qingyun:ag2.space"], "tierMap": m}))
-    rgb._TIER_MAP_CACHE["mtime"] = None  # force re-read (mtime granularity is coarse)
+    rgb._TIER_MAP_CACHE["ident"] = None  # force re-read (mtime granularity is coarse)
 
 
 # 1. named teammate is down-tiered by user_id
@@ -64,12 +64,12 @@ check("'other' tier honored", rgb._tier_for("@stranger:ag2.space") == "other")
 
 # 6. missing file → LOCAL_TIER (fail-soft, no crash)
 ACCESS.unlink()
-rgb._TIER_MAP_CACHE["mtime"] = None
+rgb._TIER_MAP_CACHE["ident"] = None
 check("missing access.json → LOCAL_TIER", rgb._tier_for("@rick:ag2.space") == "owner")
 
 # 7. malformed JSON → LOCAL_TIER (fail-soft)
 ACCESS.write_text("{ not json ]")
-rgb._TIER_MAP_CACHE["mtime"] = None
+rgb._TIER_MAP_CACHE["ident"] = None
 check("malformed access.json → LOCAL_TIER", rgb._tier_for("@rick:ag2.space") == "owner")
 
 # 8. live update: adding a teammate is picked up without reload (mtime cache)
@@ -139,7 +139,7 @@ check("owner-default node: unlisted sender still owner (no regression)",
 _write_map({"@rick:ag2.space": "team"})
 assert rgb._tier_for("@rick:ag2.space") == "team"  # prime the cache with a good read
 ACCESS.write_text("{ corrupt not json ]")           # file now unparseable
-rgb._TIER_MAP_CACHE["mtime"] = -1                    # force a re-read attempt (hits except)
+rgb._TIER_MAP_CACHE["ident"] = None                    # force a re-read attempt (hits except)
 check("malformed re-read keeps the down-tier (fail-safe, not fail-open to owner)",
       rgb._tier_for("@rick:ag2.space") == "team")
 
@@ -155,7 +155,7 @@ rgb.LOCAL_TIER = "team"
 _write_map({"@dana:ag2.space": "owner"})
 assert rgb._tier_for("@dana:ag2.space") == "owner"   # prime cache with the grant
 ACCESS.unlink()
-rgb._TIER_MAP_CACHE["mtime"] = -1                     # force re-read → OSError path
+rgb._TIER_MAP_CACHE["ident"] = None                     # force re-read → OSError path
 check("deleting access.json REVOKES an escalated sender (no stale owner)",
       rgb._tier_for("@dana:ag2.space") == "team")
 
@@ -163,7 +163,7 @@ check("deleting access.json REVOKES an escalated sender (no stale owner)",
 _write_map({"@rick:ag2.space": "other"})
 assert rgb._tier_for("@rick:ag2.space") == "other"
 ACCESS.unlink()
-rgb._TIER_MAP_CACHE["mtime"] = -1
+rgb._TIER_MAP_CACHE["ident"] = None
 check("stale cache still preserves a DOWN-tier (fail-safe not broken)",
       rgb._tier_for("@rick:ag2.space") == "other")
 
@@ -171,7 +171,7 @@ check("stale cache still preserves a DOWN-tier (fail-safe not broken)",
 _write_map({"@dana:ag2.space": "owner", "@rick:ag2.space": "other"})
 assert rgb._tier_for("@dana:ag2.space") == "owner"
 ACCESS.write_text("{ corrupt ]")
-rgb._TIER_MAP_CACHE["mtime"] = -1
+rgb._TIER_MAP_CACHE["ident"] = None
 check("malformed read drops the escalation", rgb._tier_for("@dana:ag2.space") == "team")
 check("malformed read keeps the down-tier", rgb._tier_for("@rick:ag2.space") == "other")
 
@@ -207,6 +207,49 @@ check("unlisted sender does NOT register owner-presence on a team node",
       not OWNER_ACT.exists())
 rgb.LOCAL_TIER = _prev_local
 
-_total = 24
+# --- same-mtime revocation (john-the-dev [P1] on #2584, reproduced then fixed) ---
+# The cache used to key on float os.path.getmtime(). A rewrite landing in the same
+# second — or one whose mtime is restored via os.utime — compared EQUAL, so the
+# cached map was served verbatim. Harmless while the map could only down-tier; once
+# it can grant ABOVE LOCAL_TIER a REVOKED owner grant survives.
+#
+# NOTE: these rewrites reuse the SAME envelope as _write_map (allowFrom + tierMap).
+# An earlier draft dropped allowFrom, which changed st_size — so the size component
+# caught the staleness and the tests passed even with the above-local guard removed,
+# i.e. they did not exercise the path they claimed. Keep the envelope identical.
+import os as _os
+
+def _rewrite_same_identity(tier_map):
+    """Rewrite access.json preserving the envelope, then restore mtime exactly."""
+    st = _os.stat(ACCESS)
+    ACCESS.write_text(json.dumps({"allowFrom": ["@qingyun:ag2.space"], "tierMap": tier_map}))
+    _os.utime(ACCESS, ns=(st.st_atime_ns, st.st_mtime_ns))
+
+_prev_local = rgb.LOCAL_TIER
+rgb.LOCAL_TIER = "team"
+
+# 25. SAME size, SAME mtime_ns, SAME inode -> identity collides exactly; only the
+# above-local re-read can catch the revocation. owner->other keeps byte length.
+_write_map({"@dana:ag2.space": "owner"})
+assert rgb._tier_for("@dana:ag2.space") == "owner"           # prime the grant
+_rewrite_same_identity({"@dana:ag2.space": "other"})
+check("identity-colliding rewrite does NOT serve a revoked owner grant",
+      rgb._tier_for("@dana:ag2.space") == "other")
+
+# 26. full revocation to an empty map under a restored mtime
+_write_map({"@dana:ag2.space": "owner"})
+assert rgb._tier_for("@dana:ag2.space") == "owner"
+_rewrite_same_identity({})
+check("same-mtime revocation to an empty map drops the grant",
+      rgb._tier_for("@dana:ag2.space") == "team")
+
+# 27. a NON-escalating cache still uses the identity shortcut (no perf regression)
+_write_map({"@rick:ag2.space": "team"})
+assert rgb._tier_for("@rick:ag2.space") == "team"
+check("cache identity shortcut still serves a non-escalating map",
+      rgb._tier_for("@rick:ag2.space") == "team")
+rgb.LOCAL_TIER = _prev_local
+
+_total = 27
 print(f"\nResults: {_total - len(failures)}/{_total} passed" if not failures else f"\nResults: FAILED {failures}")
 sys.exit(1 if failures else 0)

--- a/tests/gateway-per-sender-tier.test.py
+++ b/tests/gateway-per-sender-tier.test.py
@@ -143,6 +143,45 @@ rgb._TIER_MAP_CACHE["mtime"] = -1                    # force a re-read attempt (
 check("malformed re-read keeps the down-tier (fail-safe, not fail-open to owner)",
       rgb._tier_for("@rick:ag2.space") == "team")
 
-_total = 17
+# --- stale cache must fail CLOSED in BOTH directions (revocation safety) ---
+# Once the map can grant a tier ABOVE LOCAL_TIER, replaying a STALE cache verbatim
+# would keep an escalation alive on a file the owner just deleted to revoke it.
+# Pre-change this could not happen (the clamp made an above-LOCAL_TIER entry
+# unreachable), so the hazard is introduced by the up-tier and fixed here.
+_prev_local = rgb.LOCAL_TIER
+rgb.LOCAL_TIER = "team"
+
+# 18. revocation-by-deletion actually revokes an ESCALATED sender
+_write_map({"@dana:ag2.space": "owner"})
+assert rgb._tier_for("@dana:ag2.space") == "owner"   # prime cache with the grant
+ACCESS.unlink()
+rgb._TIER_MAP_CACHE["mtime"] = -1                     # force re-read → OSError path
+check("deleting access.json REVOKES an escalated sender (no stale owner)",
+      rgb._tier_for("@dana:ag2.space") == "team")
+
+# 19. ...while a DOWN-tier still survives the same stale read (original fail-safe intact)
+_write_map({"@rick:ag2.space": "other"})
+assert rgb._tier_for("@rick:ag2.space") == "other"
+ACCESS.unlink()
+rgb._TIER_MAP_CACHE["mtime"] = -1
+check("stale cache still preserves a DOWN-tier (fail-safe not broken)",
+      rgb._tier_for("@rick:ag2.space") == "other")
+
+# 20. malformed (not deleted) also drops the escalation but keeps the down-tier
+_write_map({"@dana:ag2.space": "owner", "@rick:ag2.space": "other"})
+assert rgb._tier_for("@dana:ag2.space") == "owner"
+ACCESS.write_text("{ corrupt ]")
+rgb._TIER_MAP_CACHE["mtime"] = -1
+check("malformed read drops the escalation", rgb._tier_for("@dana:ag2.space") == "team")
+check("malformed read keeps the down-tier", rgb._tier_for("@rick:ag2.space") == "other")
+
+# 21. HOT PATH REGRESSION GUARD: a present, unchanged file is a VALID cache, not a
+# stale one — a legitimate up-tier must survive repeated reads untouched.
+_write_map({"@dana:ag2.space": "owner"})
+check("valid unchanged cache keeps the up-tier (hot path not projected)",
+      rgb._tier_for("@dana:ag2.space") == "owner" and rgb._tier_for("@dana:ag2.space") == "owner")
+rgb.LOCAL_TIER = _prev_local
+
+_total = 22
 print(f"\nResults: {_total - len(failures)}/{_total} passed" if not failures else f"\nResults: FAILED {failures}")
 sys.exit(1 if failures else 0)

--- a/tests/gateway-per-sender-tier.test.py
+++ b/tests/gateway-per-sender-tier.test.py
@@ -101,16 +101,37 @@ before = OWNER_ACT.read_text()
 rgb._write_owner_activity({"task": "rick here", "source": "ag2space", "user_id": "@rick:ag2.space", "channel_id": "!r:hs"})
 check("teammate does not clobber owner's activity record", OWNER_ACT.read_text() == before)
 
-# --- clamp: the map can only DOWN-tier, never escalate above LOCAL_TIER ---
-# 12. on a LOCAL_TIER=team node, a map entry of "owner" is clamped to team, while
-# a "other" entry still down-tiers. Guards against a misconfigured/compromised
-# access.json escalating a sender above the node's own default.
+# --- per-sender owner tier on a least-privilege node (the shared-gateway shape) ---
+# 12. BEHAVIOR CHANGE (deliberate, owner-approved): an EXPLICITLY LISTED sender now
+# gets the tier the owner mapped them to, including one ABOVE LOCAL_TIER. This
+# previously clamped to <= LOCAL_TIER, which made the only way to grant owner a
+# BLANKET REMOTE_TASK_TIER=owner that every unlisted sender inherited (fail-OPEN).
+# Mirrors discord/slack, which resolve `tierMap[sender_id]` with no clamp.
+# The lookup key is the broker-attested user_id, so the WIRE still cannot escalate;
+# only the owner's own local access.json can, and only for a sender named in it.
 _prev_local = rgb.LOCAL_TIER
 rgb.LOCAL_TIER = "team"
-_write_map({"@rick:ag2.space": "owner", "@stranger:ag2.space": "other"})
-check("map cannot escalate above LOCAL_TIER (owner clamped to team)", rgb._tier_for("@rick:ag2.space") == "team")
-check("map still down-tiers below LOCAL_TIER (team node, 'other' honored)", rgb._tier_for("@stranger:ag2.space") == "other")
+_write_map({"@dana:ag2.space": "owner", "@stranger:ag2.space": "other"})
+check("listed sender IS up-tiered above LOCAL_TIER (team node, explicit owner)",
+      rgb._tier_for("@dana:ag2.space") == "owner")
+check("map still down-tiers below LOCAL_TIER (team node, 'other' honored)",
+      rgb._tier_for("@stranger:ag2.space") == "other")
+# 12b. the escalation is EXPLICIT-ONLY: an unlisted sender on the same node keeps
+# the least-privilege default. This is the property that makes the shared-gateway
+# config default-CLOSED, and it is what a blanket owner default cannot give you.
+check("unlisted sender on a team node stays team (no blanket escalation)",
+      rgb._tier_for("@nobody:ag2.space") == "team")
+# 12c. an invalid mapped value still cannot escalate — it is ignored, not honored.
+_write_map({"@rick:ag2.space": "admin"})
+check("invalid mapped value on a team node does NOT escalate",
+      rgb._tier_for("@rick:ag2.space") == "team")
 rgb.LOCAL_TIER = _prev_local
+
+# 12d. no silent demotion: on an owner-default node an unlisted sender is STILL
+# owner, so existing single-owner installs are untouched by this change.
+_write_map({"@rick:ag2.space": "team"})
+check("owner-default node: unlisted sender still owner (no regression)",
+      rgb._tier_for("@unknown:ag2.space") == "owner")
 
 # --- fail-safe: a transient read error preserves the last-known-good map ---
 # 13. once a teammate is down-tiered, a malformed/mid-write access.json must NOT
@@ -122,6 +143,6 @@ rgb._TIER_MAP_CACHE["mtime"] = -1                    # force a re-read attempt (
 check("malformed re-read keeps the down-tier (fail-safe, not fail-open to owner)",
       rgb._tier_for("@rick:ag2.space") == "team")
 
-_total = 13
+_total = 17
 print(f"\nResults: {_total - len(failures)}/{_total} passed" if not failures else f"\nResults: FAILED {failures}")
 sys.exit(1 if failures else 0)

--- a/tests/gateway-per-sender-tier.test.py
+++ b/tests/gateway-per-sender-tier.test.py
@@ -182,6 +182,31 @@ check("valid unchanged cache keeps the up-tier (hot path not projected)",
       rgb._tier_for("@dana:ag2.space") == "owner" and rgb._tier_for("@dana:ag2.space") == "owner")
 rgb.LOCAL_TIER = _prev_local
 
-_total = 22
+# --- the OTHER _tier_for consumer: owner-presence gate, under UP-tiering ---
+# _write_owner_activity gates on the SENDER's resolved tier. Its docstring reasons
+# only about DOWN-tiering ("a down-tiered teammate must not overwrite..."), because
+# until now an above-LOCAL_TIER entry was unreachable. The up-tier creates a case it
+# never contemplated, and presence drives the proactive loop's "owner active" signal
+# plus the core-supervisor escalation target — a silent break here is expensive and
+# hard to trace, so pin both directions.
+_prev_local = rgb.LOCAL_TIER
+rgb.LOCAL_TIER = "team"
+_write_map({"@dana:ag2.space": "owner"})
+
+# 23. an UP-tiered sender on a team node DOES register owner presence
+OWNER_ACT.unlink(missing_ok=True)
+rgb._write_owner_activity({"task": "hi", "source": "ag2space",
+                           "user_id": "@dana:ag2.space", "channel_id": "!r:hs"})
+check("up-tiered owner registers owner-presence on a team node", OWNER_ACT.exists())
+
+# 24. ...and an unlisted sender on that same node still does NOT
+OWNER_ACT.unlink(missing_ok=True)
+rgb._write_owner_activity({"task": "hi", "source": "ag2space",
+                           "user_id": "@nobody:ag2.space", "channel_id": "!r:hs"})
+check("unlisted sender does NOT register owner-presence on a team node",
+      not OWNER_ACT.exists())
+rgb.LOCAL_TIER = _prev_local
+
+_total = 24
 print(f"\nResults: {_total - len(failures)}/{_total} passed" if not failures else f"\nResults: FAILED {failures}")
 sys.exit(1 if failures else 0)


### PR DESCRIPTION
## What

The gateway clamped a `tierMap` entry to `<= REMOTE_TASK_TIER`, so the owner's map could only **down**-tier. This resolves an **explicitly listed** sender to exactly the tier they were mapped to, above `LOCAL_TIER` included. Unlisted senders are untouched.

## Why

On a **shared** gateway (one room carrying several senders) the clamp left exactly one way to grant someone owner: set a blanket `REMOTE_TASK_TIER=owner`, which every **unlisted** sender then inherits. That is fail-open by construction — a new room member is owner until someone remembers to list them. The module's own escape hatch tells a shared deployment to use `team` instead, and under `team` the map cannot express "this one sender is the owner" at all. So the two documented options were *fail-open* or *impossible*.

After this change a shared gateway can run least-privilege and name its owner:

```
REMOTE_TASK_TIER=team
access.json → {"tierMap": {"@someone:hs": "owner"}}
```

→ that sender is owner, everyone else is team. Default-**closed**.

## This is the discord/slack shape, not a new one

Both bridges already resolve `access_tier = tierMap[sender_id]` with **no clamp**, and fail closed for unlisted senders:

- `src/discord-bridge.py:3450`
- `src/slack-bridge.py:430`

The gateway was the outlier. The map is **local, owner-owned** config with the same trust standing as `REMOTE_TASK_TIER` itself, and the lookup key is the **broker-attested** `user_id`, never a task-body self-claim — so the **wire still cannot escalate anyone**. Only the owner's own file can, and only for a sender named in it explicitly.

## Deliberate behavior change — flagged, not smuggled

The previous clamp had a test asserting it (`gateway-per-sender-tier` #12: *"map cannot escalate above LOCAL_TIER"*). That assertion is **replaced**, because the invariant it encoded is what this PR changes. To keep the change honest, three guards were added that the escalation is **explicit-only**:

- unlisted sender on a `team` node → still `team` (no blanket escalation)
- invalid mapped value on a `team` node → does **not** escalate
- `owner`-default node, unlisted sender → still `owner` (**no regression** for existing single-owner installs)

## Evidence

Baseline on the parent commit, unmodified:

```
$ python3 tests/gateway-per-sender-tier.test.py
Results: 13/13 passed
```

With the fix reverted but the new tests present — the discriminator says NO on exactly the new behavior, and only on it:

```
ARM-1 (fix REVERTED). source sha: 011b496ca7e7
clamp present again? 2
Results: FAILED ['listed sender IS up-tiered above LOCAL_TIER (team node, explicit owner)']
```

With the fix applied (separate run, different source hash — not a batched verdict):

```
ARM-2 (fix RESTORED). source sha: 04d7021b564d
clamp hits: 0
Results: 17/17 passed
```

Required suite for any sparrow change:

```
$ python3 src/remote-gateway-bridge.test.py
PASS — all checks green
```

## Scope

Single concern. Related but **not** included: #2354 (durable on-disk tierMap backup) and #2436 (warn when local `allowFrom` diverges) both touch neighbouring config, neither implements up-tiering.

Deliberately **not** in this PR:
- **TOFU onboarding for the gateway.** It has none today (0 occurrences of `tofu` in `packages/ag2-sparrow/`). Doing it DM-only — the safe form — needs a signal the wire does not currently carry: the task payload has `channel_id`, `user_id`, `room_name`, `interaction_type` and no room-directness or member-count field, so the bridge cannot distinguish a DM from a shared room. Guessing from `room_name` would be a heuristic on a security boundary. That needs a broker-side attestation first.
- **A `tierMap`-from-`allowFrom` seeding migration.** The gateway has no `allowFrom` at all (0 occurrences in `packages/ag2-sparrow/` vs 397 repo-wide), so there is nothing to seed from — and since unlisted behavior is unchanged here, there is no demotion to migrate away from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
