### PR TITLE
docs(gateway): retire three comments that #2584 made false

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -527,9 +527,13 @@ if LOCAL_TIER not in ("owner", "team", "other"):
 # We key the lookup on the BROKER-attested `user_id` (Matrix sender the broker
 # writes into the task, not a task-body self-claim), so this stays a LOCAL trust
 # decision — same principle as LOCAL_TIER. Only listed senders are re-tiered;
-# everyone else keeps LOCAL_TIER, so an unknown sender can never ESCALATE (the
-# map only DOWN-tiers named senders; owner stays owner by being absent from it).
-# Hot: re-read on mtime change so the owner can add teammates without a restart.
+# everyone else keeps LOCAL_TIER, so an UNLISTED sender can never escalate. A LISTED
+# sender gets exactly the tier the owner mapped them to — including one ABOVE
+# LOCAL_TIER, which is how a least-privilege node names its owner. See the CONTRACT
+# note on _tier_for for why that cannot be driven from the wire.
+# Hot: the cache keys on (st_mtime_ns, st_size, st_ino) and never serves an
+# above-LOCAL_TIER grant without a fresh read, so the owner can add teammates AND
+# revoke them without a restart.
 def _ag2space_access_path():
     base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
     return os.path.join(base, "channels", "ag2space", "access.json")

--- a/tests/gateway-per-sender-tier.test.py
+++ b/tests/gateway-per-sender-tier.test.py
@@ -40,7 +40,7 @@ rgb.LOCAL_TIER = "owner"
 
 def _write_map(m):
     ACCESS.write_text(json.dumps({"allowFrom": ["@qingyun:ag2.space"], "tierMap": m}))
-    rgb._TIER_MAP_CACHE["ident"] = None  # force re-read (mtime granularity is coarse)
+    rgb._TIER_MAP_CACHE["ident"] = None  # force re-read (cache keys on mtime_ns+size+inode)
 
 
 # 1. named teammate is down-tiered by user_id


### PR DESCRIPTION
Comments only — **no code changed**. Stripping trailing comments from the diff leaves it byte-identical:

```
$ git diff -U0 | grep '^[+-]' | grep -v '^[+-][+-]' | grep -v '^[+-]\s*#' | sed -E 's/[[:space:]]*#.*$//' | sort -u
    rgb._TIER_MAP_CACHE["ident"] = None      # one unique line -> both sides identical
```

#2584 (merged in `dab9c99`) let the `tierMap` grant a tier **above** `LOCAL_TIER`, and re-keyed the cache on `(st_mtime_ns, st_size, st_ino)` with a forced fresh read whenever an above-local grant is cached. Three comments still describe the pre-#2584 world:

| # | comment | why it is now false |
|---|---|---|
| 1 | *"the map only DOWN-tiers named senders; owner stays owner by being absent from it"* | @john-the-dev's non-blocking nit on #2584. A listed sender can now be granted `owner` on a `team` node. |
| 2 | *"Hot: re-read on mtime change"* | The key is no longer a float mtime, and revocation no longer waits on one. |
| 3 | `tests/gateway-per-sender-tier.test.py:43` *"mtime granularity is coarse"* | That was the rationale for a float mtime. |

**On (1) — I kept the true half.** The line above it, *"an unknown sender can never ESCALATE"*, is **still correct** and is retained, now scoped explicitly to **unlisted** senders. Deleting the whole block would have thrown away an accurate invariant along with the stale one.

**On (2) — nobody flagged this.** I found it while locating john's nit, and it was **my own** #2584 change that invalidated it. A reviewer's nit list is a starting point, not an inventory; the adjacent line was stale for a reason only the author was positioned to see.

**On timing.** This was deliberately held until #2584 merged. Before that, all three comments were *correct on `main`* — opening this earlier would have documented behaviour that had not shipped. It was also kept off #2584 itself, where a comment-only push would have staled two current-head approvals on a PR that was one click from merge.

Suites on this branch: **27/27** tier, **6/6** owner-presence, `src/remote-gateway-bridge.test.py` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
