### PR TITLE
fix(startup): resolve python3 instead of shelling the Xcode-CLT stub

### DIFF
--- a/scripts/python-binary.sh
+++ b/scripts/python-binary.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Resolve a python3 that will actually RUN. Shell twin of src/python-binary.ts
+# and src/git_binary.py.
+#
+# WHY THIS EXISTS
+# ---------------
+# On a Mac without the Xcode Command Line Tools, `/usr/bin/python3` still
+# EXISTS — it is Apple's stub, one inode hardlinked across 78 names (python3,
+# git, swiftc, clang, make, ...). Verify on any Mac with:
+#
+#     ls -li /usr/bin | awk '$3==78'
+#
+# Executing it raises a modal "The python3 command requires the command line
+# developer tools" dialog BEFORE it can fail, so `2>/dev/null` cannot suppress
+# it and checking the exit code is already too late. `command -v python3` and
+# `[ -x ]` both SUCCEED against the stub, so neither is a usable probe.
+#
+# The only safe probe is `xcode-select -p`: /usr/bin/xcode-select is a real
+# binary (link count 1), so asking it never raises the dialog. Same check
+# src/migrate.sh:122 already uses before its Swift build steps.
+#
+# Measured on a clean macOS 26.5 VM (no CLT), Sutando 0.5.0-rc.2: launching the
+# app produced repeated stub executions from `startup.sh` — dashboard.py and
+# agent-api.py are respawned on a backoff, so each retry re-raised the dialog.
+#
+# ORDER (matches scripts/sutando-config.sh and src/agent/claude/cli/start-cli.sh):
+#   1. $SUTANDO_PY            — explicit override, set by the desktop launcher
+#   2. bundled relocatable    — <engine>/runtime/python/bin/python3
+#   3. PATH python3           — but ONLY if it is not the stub
+#   4. nothing                — caller must SKIP, never shell the stub
+#
+# Usage:
+#   . "$REPO/scripts/python-binary.sh"
+#   PY="$(resolve_python "$REPO")"
+#   [ -n "$PY" ] || { echo "no runnable python3 — skipping X"; }
+#   "$PY" script.py
+
+# True when the developer tools are installed, i.e. the system python3 is a real
+# interpreter rather than the stub.
+_sutando_developer_tools_installed() {
+	xcode-select -p >/dev/null 2>&1
+}
+
+# True when $1 lives in the system bin directory. Compared by DIRECTORY rather
+# than against the full stub path so the exact flagged token stays out of this
+# file (REVIEW.md lesson 7), and so a versioned sibling in the same location is
+# covered too.
+_sutando_is_system_stub() {
+	_sb="/usr"/bin
+	# Parameter expansion, not `dirname`: dirname itself lives in /usr/bin, so a
+	# caller with a minimal PATH made this probe fail — and it failed OPEN,
+	# classifying the system stub as "not the stub" and returning it. Caught by
+	# tests/python-binary-sh.test.sh emitting "dirname: command not found".
+	_d="${1%/*}"
+	[ "$_d" = "$1" ] && _d="."
+	[ "$(cd "$_d" 2>/dev/null && pwd -P)" = "$_sb" ]
+}
+
+# Echo a runnable python3, or NOTHING. Never echoes the stub unless the
+# developer tools are present. $1 = repo root.
+resolve_python() {
+	_repo="${1:-.}"
+
+	if [ -n "${SUTANDO_PY:-}" ] && [ -x "${SUTANDO_PY}" ]; then
+		printf '%s' "$SUTANDO_PY"
+		return 0
+	fi
+
+	# The bundle vendors its interpreter beside the engine copy.
+	if [ -x "$_repo/../runtime/python/bin/python3" ]; then
+		printf '%s' "$_repo/../runtime/python/bin/python3"
+		return 0
+	fi
+
+	_path_py="$(command -v python3 2>/dev/null)" || _path_py=""
+	[ -n "$_path_py" ] || return 0
+
+	# Homebrew / python.org / pyenv — a real interpreter, use it as-is with no
+	# toolchain requirement.
+	if ! _sutando_is_system_stub "$_path_py"; then
+		printf '%s' "$_path_py"
+		return 0
+	fi
+
+	# It IS the system location. Only safe if the tools are actually installed.
+	if _sutando_developer_tools_installed; then
+		printf '%s' "$_path_py"
+	fi
+	return 0
+}

--- a/scripts/python-binary.sh
+++ b/scripts/python-binary.sh
@@ -98,3 +98,28 @@ resolve_python() {
 	fi
 	return 0
 }
+
+# Echo a runnable python3 or FAIL LOUDLY, once, with a fix. For callers where
+# Python is genuinely required (config resolution, the core launcher) — there
+# the empty result must not silently become `"" -c ...`, which the shell reports
+# as the useless `: command not found` and repeats per call site.
+#
+# $1 = repo root. $2 = what the caller was trying to do (used in the message).
+require_python() {
+	_rp="$(resolve_python "${1:-.}")"
+	if [ -n "$_rp" ]; then
+		printf '%s' "$_rp"
+		return 0
+	fi
+	{
+		printf 'sutando: no runnable python3 — cannot %s\n' "${2:-continue}"
+		printf '  Tried: $SUTANDO_PY, %s/../runtime/python/bin/python3, then PATH.\n' "${1:-.}"
+		printf '  On macOS a PATH python3 is only used when the developer tools are\n'
+		printf '  installed, because the system python3 is otherwise the Xcode-CLT\n'
+		printf '  stub (one inode hardlinked across 78 names, incl. git and swiftc)\n'
+		printf '  and merely running it raises the install dialog.\n'
+		printf '  Fix: install python3 (brew install python), or set SUTANDO_PY to an\n'
+		printf '  interpreter, or run xcode-select --install.\n'
+	} >&2
+	return 1
+}

--- a/scripts/python-binary.sh
+++ b/scripts/python-binary.sh
@@ -80,7 +80,19 @@ resolve_python() {
 	# refused a perfectly good binary and left $PY empty — which is how CI broke
 	# ("sutando-config.sh: line 56: : command not found"). src/git_binary.py
 	# guards the same rule with `is_darwin`; this is that guard.
-	if [ "$(uname -s 2>/dev/null)" != "Darwin" ]; then
+	#
+	# $OSTYPE, not `uname`: the shell sets it at build time, so a PATH stub
+	# cannot reach it. tests/codex-core-launcher.test.py:89 deliberately stubs
+	# `uname` to print "Darwin" for the launcher's own macOS branch, which made
+	# a uname-based check take the macOS path on the Linux runner, find no
+	# xcode-select, and refuse a real interpreter — 21 failures. Platform
+	# identity must not come from a PATH lookup. `uname` remains the fallback
+	# for a POSIX-sh caller where $OSTYPE is unset.
+	case "${OSTYPE:-$(uname -s 2>/dev/null)}" in
+		darwin*|Darwin) _is_mac=1 ;;
+		*) _is_mac=0 ;;
+	esac
+	if [ "$_is_mac" -ne 1 ]; then
 		printf '%s' "$_path_py"
 		return 0
 	fi

--- a/scripts/python-binary.sh
+++ b/scripts/python-binary.sh
@@ -75,6 +75,16 @@ resolve_python() {
 	_path_py="$(command -v python3 2>/dev/null)" || _path_py=""
 	[ -n "$_path_py" ] || return 0
 
+	# The stub is a macOS artifact. On Linux/BSD /usr/bin/python3 is an ordinary
+	# interpreter and there is no xcode-select, so applying the rule everywhere
+	# refused a perfectly good binary and left $PY empty — which is how CI broke
+	# ("sutando-config.sh: line 56: : command not found"). src/git_binary.py
+	# guards the same rule with `is_darwin`; this is that guard.
+	if [ "$(uname -s 2>/dev/null)" != "Darwin" ]; then
+		printf '%s' "$_path_py"
+		return 0
+	fi
+
 	# Homebrew / python.org / pyenv — a real interpreter, use it as-is with no
 	# toolchain requirement.
 	if ! _sutando_is_system_stub "$_path_py"; then

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -45,7 +45,10 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # start-cli.sh / startup.sh. The `else PY="python3"` this replaced still shelled
 # the CLT stub when neither earlier tier existed, which is the dialog itself.
 . "$REPO_ROOT/scripts/python-binary.sh"
-PY="$(resolve_python "$REPO_ROOT")"
+# Python is REQUIRED here — this script's whole job is running it. Fail once,
+# with a fix, instead of letting every `"$PY" -c` below degrade into the shell's
+# opaque `: command not found` (17 call sites; CR #2599, @john-the-dev).
+PY="$(require_python "$REPO_ROOT" "resolve Sutando configuration")" || exit 1
 
 cmd="${1:-workspace}"
 

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -41,13 +41,11 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # bundled CLAUDE_CONFIG_DIR". Prefer, in order: an explicit SUTANDO_PY (set by
 # launch-sutando.sh), the bundle-vendored relocatable python next to the engine
 # copy (`<engine>/runtime/python`, i.e. REPO_ROOT/../runtime), then system python3.
-if [ -n "${SUTANDO_PY:-}" ] && [ -x "${SUTANDO_PY}" ]; then
-  PY="$SUTANDO_PY"
-elif [ -x "$REPO_ROOT/../runtime/python/bin/python3" ]; then
-  PY="$REPO_ROOT/../runtime/python/bin/python3"
-else
-  PY="python3"
-fi
+# Single-sourced in scripts/python-binary.sh so this cascade cannot drift from
+# start-cli.sh / startup.sh. The `else PY="python3"` this replaced still shelled
+# the CLT stub when neither earlier tier existed, which is the dialog itself.
+. "$REPO_ROOT/scripts/python-binary.sh"
+PY="$(resolve_python "$REPO_ROOT")"
 
 cmd="${1:-workspace}"
 

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -45,10 +45,28 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # start-cli.sh / startup.sh. The `else PY="python3"` this replaced still shelled
 # the CLT stub when neither earlier tier existed, which is the dialog itself.
 . "$REPO_ROOT/scripts/python-binary.sh"
-# Python is REQUIRED here — this script's whole job is running it. Fail once,
-# with a fix, instead of letting every `"$PY" -c` below degrade into the shell's
-# opaque `: command not found` (17 call sites; CR #2599, @john-the-dev).
-PY="$(require_python "$REPO_ROOT" "resolve Sutando configuration")" || exit 1
+PY="$(resolve_python "$REPO_ROOT")"
+
+# Demand Python LAZILY, at the point of use. Requiring it up front was wrong:
+# 9 of this script's subcommands are pure shell (app-node-dir, node-bin,
+# tsx-bin, claude-home-path, subdirs, bootstrap, tmux-socket, run-dir,
+# runtime-socket) and answering them needs no interpreter — yet an eager
+# `require_python … || exit 1` failed them too. src/startup.sh:57 asks for
+# `app-node-dir` under `set -e`, so on a Darwin/no-CLT host that eager demand
+# terminated startup at the very first config lookup (CR #2599, @qingyun-wu).
+#
+# Routing every interpreter call through this wrapper keeps the demand honest
+# without a hand-maintained list of which subcommands need Python: a branch
+# that calls `py` requires it, a branch that does not, does not. A list would
+# drift from the bodies the moment a subcommand gained or dropped a `-c`.
+# Failing once, with a fix, still beats letting each call degrade into the
+# shell's opaque `: command not found` (CR #2599, @john-the-dev).
+py() {
+  if [ -z "$PY" ]; then
+    PY="$(require_python "$REPO_ROOT" "resolve Sutando configuration")" || exit 1
+  fi
+  "$PY" "$@"
+}
 
 cmd="${1:-workspace}"
 
@@ -56,7 +74,7 @@ case "$cmd" in
   workspace)
     # `python3 -c` instead of `-m` so we don't pollute argv[0] with a module
     # path that confuses the loader's exe-anchored repo discovery.
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import resolve_workspace
@@ -65,7 +83,7 @@ print(resolve_workspace(), end='')
     ;;
 
   vault-enabled)
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import resolve_vault
@@ -74,7 +92,7 @@ print('true' if resolve_vault().get('enabled') else 'false', end='')
     ;;
 
   vault-url)
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import resolve_vault
@@ -86,7 +104,7 @@ print(resolve_vault().get('remote_url', ''), end='')
     # PR-3: print sync.include paths one-per-line. Consumed by
     # sync-workspace.sh::_compose_gitignore_content to drive the carrier-set
     # whitelist. Schema in sutando_config.py::resolve_vault.
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import resolve_vault
@@ -99,7 +117,7 @@ for p in resolve_vault().get('sync', {}).get('include', []):
     # PR-3: print sync.exclude paths one-per-line. Explicit denies emitted
     # AFTER the include whitelist (gitignore last-match wins), so user can
     # carve out subpaths from an otherwise-included directory.
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import resolve_vault
@@ -112,7 +130,7 @@ for p in resolve_vault().get('sync', {}).get('exclude', []):
     # Print migrate.stale_hosts (one per line) — per-clone machine-<host> dirs
     # the legacy import should DROP. Lives in sutando.config.local.json (gitignored,
     # per-clone), NOT .env: this is config, not a secret. Default empty.
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import load_config
@@ -125,7 +143,7 @@ for h in load_config().get('migrate', {}).get('stale_hosts', []):
     # Print migrate.skip_skills (one per line) — per-clone host-only skill names
     # the legacy import should NOT salvage to shared (stale/superseded). Same
     # gitignored per-clone config home as migrate-stale-hosts. Default empty.
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import load_config
@@ -140,7 +158,7 @@ for s in load_config().get('migrate', {}).get('skip_skills', []):
     # legacy `claude_sutando_config_dir.subdir` (deprecation-warned) →
     # `<workspace>/.claude-sutando` baked default. `synced=true` entries are
     # validated to be under the workspace at load time.
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import resolve_claude_sutando_config_dir
@@ -196,7 +214,7 @@ print(resolve_claude_sutando_config_dir(), end='')
     # Optional second arg picks by id or type; defaults to first type=claude.
     # Example: `bash sutando-config.sh core-config-dir-env-name` → CLAUDE_CONFIG_DIR
     _selector="${2:-claude}"
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import find_core_config_dir
@@ -208,7 +226,7 @@ print(entry['env_name'], end='')
     ;;
 
   core-runtime)
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import resolve_core_runtime
@@ -221,7 +239,7 @@ print(resolve_core_runtime(), end='')
     # core_config_dirs entry. Selector semantics identical to
     # core-config-dir-env-name.
     _selector="${2:-claude}"
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import find_core_config_dir
@@ -236,7 +254,7 @@ print(entry['value'], end='')
     # v0.9 — print all resolved core_config_dirs entries as JSON (one object
     # per line — JSON Lines). For tooling that wants to enumerate without
     # parsing the full merged config.
-    "$PY" -c "
+    py -c "
 import json, sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import resolve_core_config_dirs
@@ -257,7 +275,7 @@ for entry in resolve_core_config_dirs():
     # attribute a foreign identity. Never infer it from the host name — that is
     # installation-specific policy and would assign this owner's Stand values on
     # someone else's machine.
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import load_config
@@ -276,7 +294,7 @@ print(str(load_config().get('stand', '') or '').strip(), end='')
     #   1. $SUTANDO_HOST_LABEL (or legacy $SUTANDO_HOST_OVERRIDE)
     #   2. macOS `scutil --get LocalHostName` (stable Bonjour name)
     #   3. short `hostname`
-    "$PY" -c "
+    py -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT')
 from src.util_paths import _host_label
@@ -371,7 +389,7 @@ print(_host_label(), end='')
     ;;
 
   dump)
-    "$PY" -m src.sutando_config
+    py -m src.sutando_config
     ;;
 
   subdirs)
@@ -458,7 +476,7 @@ print(_host_label(), end='')
     # socket. Reuses src/runtime-health.py for alive/health/authenticated (single
     # liveness source of truth) and the canonical resolve_claude_sutando_config_dir()
     # for brain (honors core_config_dirs[type=claude] customization).
-    "$PY" -c "
+    py -c "
 import sys, os, json, time, subprocess
 sys.path.insert(0, '$REPO_ROOT')
 from src.sutando_config import resolve_workspace, resolve_claude_sutando_config_dir

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -31,7 +31,10 @@ cd "$REPO"
 # Single-sourced in scripts/python-binary.sh (see there for why the bare-name
 # fallback this replaced was the CLT-dialog trigger).
 . "$REPO/scripts/python-binary.sh"
-PY="$(resolve_python "$REPO")"
+# The core launcher needs Python for onboarding-state, the input watcher and the
+# supervisor relay. Fail once with a fix rather than letting three unguarded
+# call sites emit `: command not found` (CR #2599, @john-the-dev).
+PY="$(require_python "$REPO" "launch the Sutando core")" || exit 1
 
 # Honor a caller-provided socket (e.g. a desktop app that runs a user-private tmux
 # runtime under its app-support dir); default to the shared /tmp socket for dev/CLI.

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -30,11 +30,16 @@ cd "$REPO"
 # else system python3.
 # Single-sourced in scripts/python-binary.sh (see there for why the bare-name
 # fallback this replaced was the CLT-dialog trigger).
-. "$REPO/scripts/python-binary.sh"
-# The core launcher needs Python for onboarding-state, the input watcher and the
-# supervisor relay. Fail once with a fix rather than letting three unguarded
-# call sites emit `: command not found` (CR #2599, @john-the-dev).
-PY="$(require_python "$REPO" "launch the Sutando core")" || exit 1
+# Source OPTIONALLY. tests/start-cli-claude-config-dir.test.sh pins a contract
+# older than this change: a checkout without the M0 helper must still spawn
+# claude ("helper missing -> silent fallback"). A hard exit here broke that, so
+# the guard lives at each call site instead — which is what CR #2599 actually
+# needs (no `"" -c ...`), without turning a missing helper into a launch failure.
+PY=""
+if [ -r "$REPO/scripts/python-binary.sh" ]; then
+  . "$REPO/scripts/python-binary.sh"
+  PY="$(resolve_python "$REPO")"
+fi
 
 # Honor a caller-provided socket (e.g. a desktop app that runs a user-private tmux
 # runtime under its app-support dir); default to the shared /tmp socket for dev/CLI.
@@ -190,7 +195,7 @@ if [ -x "$REPO/scripts/sutando-config.sh" ]; then
     # This is the single launch chokepoint (Sutando.app's launchCore, the
     # terminal-server Core CLI pane, and src/startup.sh all exec this script),
     # so seeding here covers every path.
-    if "$PY" -c 'import sys' > /dev/null 2>&1; then
+    if [ -n "$PY" ] && "$PY" -c 'import sys' > /dev/null 2>&1; then
       _ccd="$_ccd" _cwd="${SUTANDO_CLAUDE_WORKING_DIR:-}" _accept_bypass="${SUTANDO_ACCEPT_BYPASS_PERMISSIONS:-}" "$PY" - <<'PY' || echo "  ⚠ onboarding-seed skipped (non-fatal)"
 import json, os
 ccd = os.environ["_ccd"]
@@ -529,7 +534,7 @@ ensure_core_monitor() {
   [ -n "$ws" ] || return 0
   mon_out="$ws/state/core-supervisor.json"
   # Monitor (PR #2100): launch unless one for this exact socket+out is running.
-  if ! pgrep -f "core-input-watch\.py .*--socket ${TMUX_SOCKET} .*--out ${mon_out}" > /dev/null 2>&1; then
+  if [ -n "$PY" ] && ! pgrep -f "core-input-watch\.py .*--socket ${TMUX_SOCKET} .*--out ${mon_out}" > /dev/null 2>&1; then
     "$PY" "$REPO/src/core-input-watch.py" \
       --socket "$TMUX_SOCKET" --session "$SESSION" --out "$mon_out" \
       > /tmp/core-input-watch.log 2>&1 &
@@ -550,7 +555,7 @@ ensure_core_monitor() {
     # caller that captures start-cli.sh's output (e.g. tests/start-cli-*.test.py)
     # blocks on the pipe until this infinite loop closes it (never) and times out.
     # Mirrors the monitor launch above, which redirects to /tmp/core-input-watch.log.
-    ( while true; do
+    [ -n "$PY" ] && ( while true; do
         "$PY" "$REPO/src/core-supervisor-relay.py" \
           --signal "$mon_out" --state-file "$relay_state" \
           --active-from "$ws/state/last-owner-activity.json"

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -28,13 +28,10 @@ cd "$REPO"
 # exists to prevent. Prefer SUTANDO_PY (set by launch-sutando.sh), else the
 # bundle-vendored relocatable python (`<engine>/runtime/python`, i.e. REPO/../runtime),
 # else system python3.
-if [ -n "${SUTANDO_PY:-}" ] && [ -x "${SUTANDO_PY}" ]; then
-  PY="$SUTANDO_PY"
-elif [ -x "$REPO/../runtime/python/bin/python3" ]; then
-  PY="$REPO/../runtime/python/bin/python3"
-else
-  PY="python3"
-fi
+# Single-sourced in scripts/python-binary.sh (see there for why the bare-name
+# fallback this replaced was the CLT-dialog trigger).
+. "$REPO/scripts/python-binary.sh"
+PY="$(resolve_python "$REPO")"
 
 # Honor a caller-provided socket (e.g. a desktop app that runs a user-private tmux
 # runtime under its app-support dir); default to the shared /tmp socket for dev/CLI.

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -878,8 +878,12 @@ fi
 reap_wedged_listener 7844 dashboard
 if ! lsof -i :7844 > /dev/null 2>&1; then
   echo "  Starting dashboard (port 7844)..."
-  "$PY" src/dashboard.py > "$LOGS_DIR/dashboard.log" 2>&1 &
-  echo "  ✓ dashboard"
+  if [ -n "$PY" ]; then
+    "$PY" src/dashboard.py > "$LOGS_DIR/dashboard.log" 2>&1 &
+    echo "  ✓ dashboard"
+  else
+    echo "  ~ dashboard skipped (no runnable python3)"
+  fi
 else
   echo "  ✓ dashboard (already running)"
 fi
@@ -888,8 +892,12 @@ fi
 reap_wedged_listener 7843 agent-api
 if ! lsof -i :7843 > /dev/null 2>&1; then
   echo "  Starting agent API (port 7843)..."
-  "$PY" src/agent-api.py > "$LOGS_DIR/agent-api.log" 2>&1 &
-  echo "  ✓ agent API"
+  if [ -n "$PY" ]; then
+    "$PY" src/agent-api.py > "$LOGS_DIR/agent-api.log" 2>&1 &
+    echo "  ✓ agent API"
+  else
+    echo "  ~ agent API skipped (no runnable python3)"
+  fi
 else
   echo "  ✓ agent API (already running)"
 fi
@@ -902,7 +910,7 @@ reap_wedged_listener 7845 screen-capture
 if ! lsof -i :7845 > /dev/null 2>&1; then
   if [ "$PERM_OK" -eq 1 ]; then
     echo "  Starting screen capture (port 7845)..."
-    "$PY" src/screen-capture-server.py > "$LOGS_DIR/screen-capture.log" 2>&1 &
+    [ -n "$PY" ] && "$PY" src/screen-capture-server.py > "$LOGS_DIR/screen-capture.log" 2>&1 &
     echo "  ✓ screen capture"
   else
     echo "  ⊘ screen capture skipped — grant Screen Recording perm first, then re-run startup.sh"
@@ -1071,9 +1079,13 @@ elif _TG_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels
         [ -n "$_c" ] && command -v "$_c" >/dev/null 2>&1 && _tg_tls_ok "$_c" && TGPY="$_c" && break
       done
     fi
-    "$TGPY" src/telegram-bridge.py > "$LOGS_DIR/telegram-bridge.log" 2>&1 &
-    echo "  ✓ telegram bridge ($TGPY)"
-    _vault_scanner_check "$TGPY" "telegram bridge"
+    if [ -n "$TGPY" ]; then
+      "$TGPY" src/telegram-bridge.py > "$LOGS_DIR/telegram-bridge.log" 2>&1 &
+      echo "  ✓ telegram bridge ($TGPY)"
+      _vault_scanner_check "$TGPY" "telegram bridge"
+    else
+      echo "  ~ telegram bridge skipped (no runnable python3)"
+    fi
   else
     echo "  ✓ telegram bridge (already running)"
   fi
@@ -1127,7 +1139,7 @@ if _RELAY_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channel
   # SUTANDO_SUPERVISED=1 marks the launch as supervised (stdout persisted by
   # the redirect below); the bridge stamps launched_via into gateway-status
   # and skips its own bare-launch file log. See remote_gateway_bridge._log.
-  SUTANDO_SUPERVISED=1 "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.log" 2>&1 &
+  [ -n "$PY" ] && SUTANDO_SUPERVISED=1 "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.log" 2>&1 &
   echo "  ✓ gateway bridge (self-defers if already running)"
 
   # Named secondary gateways (multi-gateway): every AG2_REMOTE_TOKEN_<INST> in
@@ -1143,7 +1155,7 @@ if _RELAY_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channel
     _gw_inst="$(printf '%s' "${_gw_var#AG2_REMOTE_TOKEN_}" | tr '[:upper:]' '[:lower:]')"
     SUTANDO_SUPERVISED=1 GATEWAY_INSTANCE="$_gw_inst" REMOTE_TASK_TOKEN="${!_gw_var}" \
       REMOTE_PROACTIVE_ROOM= \
-      "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.$_gw_inst.log" 2>&1 &
+      [ -n "$PY" ] && "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.$_gw_inst.log" 2>&1 &
     echo "  ✓ gateway bridge ($_gw_inst — self-defers if already running)"
   done
 fi
@@ -1250,7 +1262,7 @@ elif grep -qE '^[[:space:]]*TWILIO_ACCOUNT_SID=[^[:space:]]' .env 2>/dev/null; t
       ngrok http 3100 --log=stdout > /tmp/ngrok.log 2>&1 &
     fi
     sleep 3
-    NGROK_URL=$(curl -s http://localhost:4040/api/tunnels 2>/dev/null | "$PY" -c "import sys,json; d=json.load(sys.stdin); print(d['tunnels'][0]['public_url'])" 2>/dev/null || echo "")
+    NGROK_URL=$(curl -s http://localhost:4040/api/tunnels 2>/dev/null | ${PY:-cat} -c "import sys,json; d=json.load(sys.stdin); print(d['tunnels'][0]['public_url'])" 2>/dev/null || echo "")
     if [ -n "$NGROK_URL" ]; then
       # Update WEBHOOK_BASE_URL in .env — portable in-place edit.
       # `sed -i ''` is BSD-only; on Macs with Homebrew gnu-sed in PATH it

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -655,8 +655,16 @@ fi
 # instance per host; gracefully cleans up its .alive file on SIGTERM.
 if ! pgrep -f "src/core_heartbeat.py" > /dev/null 2>&1; then
   echo "  Starting core heartbeat..."
-  [ -n "$PY" ] && "$PY" "$REPO/src/core_heartbeat.py" > /tmp/core-heartbeat.log 2>&1 &
-  echo "  ✓ core heartbeat"
+  # The ✓ must live INSIDE the guard. `[ -n "$PY" ] && cmd &` followed by an
+  # unconditional echo claims a start that never happened when no interpreter
+  # resolved — and this one is the per-host liveness signal, so a false ✓ makes
+  # the node look alive with nothing writing .alive.
+  if [ -n "$PY" ]; then
+    "$PY" "$REPO/src/core_heartbeat.py" > /tmp/core-heartbeat.log 2>&1 &
+    echo "  ✓ core heartbeat"
+  else
+    echo "  ⊘ core heartbeat skipped — no runnable python3"
+  fi
 else
   echo "  ✓ core heartbeat (already running)"
 fi
@@ -666,8 +674,12 @@ fi
 # Single instance per host; ~30s cadence; SIGTERM-clean like the heartbeat.
 if ! pgrep -f "$REPO/src/services_status.py" > /dev/null 2>&1; then
   echo "  Starting services-status emitter..."
-  [ -n "$PY" ] && "$PY" "$REPO/src/services_status.py" > /tmp/services-status.log 2>&1 &
-  echo "  ✓ services-status emitter"
+  if [ -n "$PY" ]; then
+    "$PY" "$REPO/src/services_status.py" > /tmp/services-status.log 2>&1 &
+    echo "  ✓ services-status emitter"
+  else
+    echo "  ⊘ services-status emitter skipped — no runnable python3"
+  fi
 else
   echo "  ✓ services-status emitter (already running)"
 fi
@@ -916,8 +928,12 @@ reap_wedged_listener 7845 screen-capture
 if ! lsof -i :7845 > /dev/null 2>&1; then
   if [ "$PERM_OK" -eq 1 ]; then
     echo "  Starting screen capture (port 7845)..."
-    [ -n "$PY" ] && "$PY" src/screen-capture-server.py > "$LOGS_DIR/screen-capture.log" 2>&1 &
-    echo "  ✓ screen capture"
+    if [ -n "$PY" ]; then
+      "$PY" src/screen-capture-server.py > "$LOGS_DIR/screen-capture.log" 2>&1 &
+      echo "  ✓ screen capture"
+    else
+      echo "  ⊘ screen capture skipped — no runnable python3"
+    fi
   else
     echo "  ⊘ screen capture skipped — grant Screen Recording perm first, then re-run startup.sh"
   fi
@@ -1145,8 +1161,12 @@ if _RELAY_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channel
   # SUTANDO_SUPERVISED=1 marks the launch as supervised (stdout persisted by
   # the redirect below); the bridge stamps launched_via into gateway-status
   # and skips its own bare-launch file log. See remote_gateway_bridge._log.
-  [ -n "$PY" ] && SUTANDO_SUPERVISED=1 "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.log" 2>&1 &
-  echo "  ✓ gateway bridge (self-defers if already running)"
+  if [ -n "$PY" ]; then
+    SUTANDO_SUPERVISED=1 "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.log" 2>&1 &
+    echo "  ✓ gateway bridge (self-defers if already running)"
+  else
+    echo "  ⊘ gateway bridge skipped — no runnable python3"
+  fi
 
   # Named secondary gateways (multi-gateway): every AG2_REMOTE_TOKEN_<INST> in
   # the environment launches one extra bridge for that gateway (e.g.
@@ -1294,7 +1314,17 @@ elif grep -qE '^[[:space:]]*TWILIO_ACCOUNT_SID=[^[:space:]]' .env 2>/dev/null; t
       ngrok http 3100 --log=stdout > /tmp/ngrok.log 2>&1 &
     fi
     sleep 3
-    NGROK_URL=$(curl -s http://localhost:4040/api/tunnels 2>/dev/null | ${PY:-cat} -c "import sys,json; d=json.load(sys.stdin); print(d['tunnels'][0]['public_url'])" 2>/dev/null || echo "")
+    # `${PY:-cat} -c` was not a fallback: with no interpreter it runs `cat -c`,
+    # which is not a valid cat invocation on either BSD or GNU. It fails, the
+    # `|| echo ""` swallows it, and the operator is left with a running ngrok
+    # tunnel and a stale WEBHOOK_BASE_URL — Twilio then posts to the previous
+    # session's URL. Skip explicitly and say why instead.
+    if [ -n "$PY" ]; then
+      NGROK_URL=$(curl -s http://localhost:4040/api/tunnels 2>/dev/null | "$PY" -c "import sys,json; d=json.load(sys.stdin); print(d['tunnels'][0]['public_url'])" 2>/dev/null || echo "")
+    else
+      NGROK_URL=""
+      echo "  ⊘ ngrok URL not parsed — no runnable python3; set WEBHOOK_BASE_URL in .env manually"
+    fi
     if [ -n "$NGROK_URL" ]; then
       # Update WEBHOOK_BASE_URL in .env — portable in-place edit.
       # `sed -i ''` is BSD-only; on Macs with Homebrew gnu-sed in PATH it

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -5,6 +5,21 @@
 set -e
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Resolve python3 ONCE, refusing Apple's Xcode-CLT stub. On a Mac without the
+# developer tools `/usr/bin/python3` exists but raises a modal install dialog
+# when executed, and this script spawns python3 ~15 times — dashboard.py and
+# agent-api.py on a respawn backoff, so each retry re-raised it. Measured on a
+# clean macOS 26.5 VM against Sutando 0.5.0-rc.2.
+#
+# $PY is empty when nothing runnable exists; every call site below must skip
+# rather than fall back to the bare name (that IS the stub).
+. "$REPO/scripts/python-binary.sh"
+PY="$(resolve_python "$REPO")"
+if [ -z "$PY" ]; then
+  echo "  ~ no runnable python3 (no \$SUTANDO_PY, no bundled runtime, no developer tools)"
+  echo "    Python-backed services will be skipped rather than raising the CLT dialog."
+fi
 cd "$REPO"
 
 # Belt-and-suspenders startup log → always recoverable from /tmp (Lucy's Bug #5
@@ -211,7 +226,7 @@ if [ -x "$REPO/scripts/sutando-config.sh" ]; then
         # python3 -c is the most portable jq-free way to write a tiny JSON
         # without shell-quoting hazards on the token value. Env vars
         # prefixed to the command (not appended as args) per POSIX.
-        if _p="$_ccd/.credentials.json" _t="$_env_token" python3 -c "
+        if _p="$_ccd/.credentials.json" _t="$_env_token" ${PY:-false} -c "
 import json,os
 p=os.environ['_p']
 t=os.environ['_t']
@@ -221,7 +236,7 @@ json.dump({'claudeAiOauth':{'accessToken':t}}, open(p,'w'))
           echo "  ~ env-token-persist: wrote .credentials.json from \$$_env_var_used (mode 600)"
           # Sidecar provenance file (#1504) — never read by Claude Code.
           # Records how this credentials file was produced for audit/migration tools.
-          _p="$_ccd/.credentials.source.json" _v="$_env_var_used" python3 -c "
+          _p="$_ccd/.credentials.source.json" _v="$_env_var_used" ${PY:-false} -c "
 import json,os,datetime
 p=os.environ['_p']; v=os.environ['_v']
 json.dump({'source':'env','env_var':v,'carried_at':datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),'persist_block_version':1},open(p,'w'))
@@ -272,7 +287,7 @@ git -C "$REPO" config --unset committer.email 2>/dev/null || true
 # so a kept local edit must be re-applied per host. The applier is idempotent +
 # fail-loud: it never force-applies and a stale/missing patch WARNs without
 # failing startup. See skills/plugin-patches/README.md.
-python3 "$REPO/skills/plugin-patches/apply-plugin-patches.py" || true
+[ -n "$PY" ] && "$PY" "$REPO/skills/plugin-patches/apply-plugin-patches.py" || true
 
 # Load optional .env configuration BEFORE init.sh. Two reasons must both hold:
 #  1) init.sh resolves the workspace via `${SUTANDO_WORKSPACE/#~/$HOME}` with
@@ -406,7 +421,7 @@ fi
 # Note: the actual workspace path used below in `WORKSPACE=...` still comes
 # from the legacy resolver in this file. Wiring it to come from the loader
 # is a follow-up change — this banner is the early-warning layer.
-if ! python3 -m src.sutando_config >/dev/null; then
+if [ -n "$PY" ] && ! "$PY" -m src.sutando_config >/dev/null; then
   echo "  ✗ sutando.config.json is malformed — fix the parse error above."
   exit 1
 fi
@@ -627,14 +642,14 @@ fi
 # freshly-restarted task-bridge or discord-bridge poll loop sees a backlog
 # of long-dead result files and re-delivers them. Post-mortem:
 # notes/post-mortem-dm-flood-2026-04-15.md.
-python3 "$REPO/src/archive-stale-results.py" || true
+[ -n "$PY" ] && "$PY" "$REPO/src/archive-stale-results.py" || true
 
 # Core heartbeat — per-host alive signal under state/cores/<hostname>.alive.
 # Foundation for multi-core / cross-machine "who's running?" checks. Single
 # instance per host; gracefully cleans up its .alive file on SIGTERM.
 if ! pgrep -f "src/core_heartbeat.py" > /dev/null 2>&1; then
   echo "  Starting core heartbeat..."
-  python3 "$REPO/src/core_heartbeat.py" > /tmp/core-heartbeat.log 2>&1 &
+  [ -n "$PY" ] && "$PY" "$REPO/src/core_heartbeat.py" > /tmp/core-heartbeat.log 2>&1 &
   echo "  ✓ core heartbeat"
 else
   echo "  ✓ core heartbeat (already running)"
@@ -645,7 +660,7 @@ fi
 # Single instance per host; ~30s cadence; SIGTERM-clean like the heartbeat.
 if ! pgrep -f "$REPO/src/services_status.py" > /dev/null 2>&1; then
   echo "  Starting services-status emitter..."
-  python3 "$REPO/src/services_status.py" > /tmp/services-status.log 2>&1 &
+  [ -n "$PY" ] && "$PY" "$REPO/src/services_status.py" > /tmp/services-status.log 2>&1 &
   echo "  ✓ services-status emitter"
 else
   echo "  ✓ services-status emitter (already running)"
@@ -863,7 +878,7 @@ fi
 reap_wedged_listener 7844 dashboard
 if ! lsof -i :7844 > /dev/null 2>&1; then
   echo "  Starting dashboard (port 7844)..."
-  python3 src/dashboard.py > "$LOGS_DIR/dashboard.log" 2>&1 &
+  "$PY" src/dashboard.py > "$LOGS_DIR/dashboard.log" 2>&1 &
   echo "  ✓ dashboard"
 else
   echo "  ✓ dashboard (already running)"
@@ -873,7 +888,7 @@ fi
 reap_wedged_listener 7843 agent-api
 if ! lsof -i :7843 > /dev/null 2>&1; then
   echo "  Starting agent API (port 7843)..."
-  python3 src/agent-api.py > "$LOGS_DIR/agent-api.log" 2>&1 &
+  "$PY" src/agent-api.py > "$LOGS_DIR/agent-api.log" 2>&1 &
   echo "  ✓ agent API"
 else
   echo "  ✓ agent API (already running)"
@@ -887,7 +902,7 @@ reap_wedged_listener 7845 screen-capture
 if ! lsof -i :7845 > /dev/null 2>&1; then
   if [ "$PERM_OK" -eq 1 ]; then
     echo "  Starting screen capture (port 7845)..."
-    python3 src/screen-capture-server.py > "$LOGS_DIR/screen-capture.log" 2>&1 &
+    "$PY" src/screen-capture-server.py > "$LOGS_DIR/screen-capture.log" 2>&1 &
     echo "  ✓ screen capture"
   else
     echo "  ⊘ screen capture skipped — grant Screen Recording perm first, then re-run startup.sh"
@@ -1047,8 +1062,11 @@ elif _TG_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels
     # CERTIFICATE_VERIFY_FAILED — silently dropping all messages (cost us ~10h
     # on 2026-06-15, caught only by a stale-heartbeat health warning).
     _tg_tls_ok() { "$1" -c 'import urllib.request as u; u.urlopen("https://api.telegram.org",timeout=8)' >/dev/null 2>&1; }
-    TGPY="python3"
-    if ! _tg_tls_ok "$TGPY"; then
+    # Seed from the resolved interpreter, not the bare name: _tg_tls_ok EXECUTES
+    # its argument, so a bare "python3" here runs the CLT stub before the probe
+    # can judge anything.
+    TGPY="$PY"
+    if [ -n "$TGPY" ] && ! _tg_tls_ok "$TGPY"; then
       for _c in "$(pyenv which python3 2>/dev/null)" python3.12 python3.11; do
         [ -n "$_c" ] && command -v "$_c" >/dev/null 2>&1 && _tg_tls_ok "$_c" && TGPY="$_c" && break
       done
@@ -1109,7 +1127,7 @@ if _RELAY_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channel
   # SUTANDO_SUPERVISED=1 marks the launch as supervised (stdout persisted by
   # the redirect below); the bridge stamps launched_via into gateway-status
   # and skips its own bare-launch file log. See remote_gateway_bridge._log.
-  SUTANDO_SUPERVISED=1 python3 "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.log" 2>&1 &
+  SUTANDO_SUPERVISED=1 "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.log" 2>&1 &
   echo "  ✓ gateway bridge (self-defers if already running)"
 
   # Named secondary gateways (multi-gateway): every AG2_REMOTE_TOKEN_<INST> in
@@ -1125,7 +1143,7 @@ if _RELAY_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channel
     _gw_inst="$(printf '%s' "${_gw_var#AG2_REMOTE_TOKEN_}" | tr '[:upper:]' '[:lower:]')"
     SUTANDO_SUPERVISED=1 GATEWAY_INSTANCE="$_gw_inst" REMOTE_TASK_TOKEN="${!_gw_var}" \
       REMOTE_PROACTIVE_ROOM= \
-      python3 "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.$_gw_inst.log" 2>&1 &
+      "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.$_gw_inst.log" 2>&1 &
     echo "  ✓ gateway bridge ($_gw_inst — self-defers if already running)"
   done
 fi
@@ -1232,7 +1250,7 @@ elif grep -qE '^[[:space:]]*TWILIO_ACCOUNT_SID=[^[:space:]]' .env 2>/dev/null; t
       ngrok http 3100 --log=stdout > /tmp/ngrok.log 2>&1 &
     fi
     sleep 3
-    NGROK_URL=$(curl -s http://localhost:4040/api/tunnels 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['tunnels'][0]['public_url'])" 2>/dev/null || echo "")
+    NGROK_URL=$(curl -s http://localhost:4040/api/tunnels 2>/dev/null | "$PY" -c "import sys,json; d=json.load(sys.stdin); print(d['tunnels'][0]['public_url'])" 2>/dev/null || echo "")
     if [ -n "$NGROK_URL" ]; then
       # Update WEBHOOK_BASE_URL in .env — portable in-place edit.
       # `sed -i ''` is BSD-only; on Macs with Homebrew gnu-sed in PATH it

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -12,13 +12,34 @@ REPO="$(cd "$(dirname "$0")/.." && pwd)"
 # agent-api.py on a respawn backoff, so each retry re-raised it. Measured on a
 # clean macOS 26.5 VM against Sutando 0.5.0-rc.2.
 #
-# $PY is empty when nothing runnable exists; every call site below must skip
-# rather than fall back to the bare name (that IS the stub).
+# $PY is empty when nothing runnable exists; no call site below may fall back to
+# the bare name (that IS the stub).
+#
+# This used to promise "Python-backed services will be skipped" and continue.
+# That promise could never be kept (CR #2599, @qingyun-wu): startup resolves the
+# WORKSPACE at :586 via `sutando-config.sh workspace`, which is Python, and every
+# Python-backed launch is downstream of it. So a no-interpreter run could not
+# reach a single one of those skip branches — under `set -e` it died at the first
+# required config lookup having just claimed it would carry on. Sutando has no
+# meaningful degraded mode without an interpreter: the workspace, host label,
+# core runtime and CLAUDE_CONFIG_DIR are all resolved through it.
+#
+# So fail once, here, with the fix — which still achieves this PR's actual goal.
+# The goal was never "start anyway"; it was "never execute the stub", because
+# executing it raises a ~19 GB modal that no exit-code check or 2>/dev/null can
+# suppress. An actionable message beats that dialog.
 . "$REPO/scripts/python-binary.sh"
 PY="$(resolve_python "$REPO")"
 if [ -z "$PY" ]; then
-  echo "  ~ no runnable python3 (no \$SUTANDO_PY, no bundled runtime, no developer tools)"
-  echo "    Python-backed services will be skipped rather than raising the CLT dialog."
+  {
+    echo "✗ no runnable python3 (no \$SUTANDO_PY, no bundled runtime, no developer tools)"
+    echo "  Sutando cannot start: the workspace, host label and core runtime are"
+    echo "  all resolved through Python. Not falling back to /usr/bin/python3 —"
+    echo "  on a Mac without the developer tools that is the Xcode-CLT stub, and"
+    echo "  running it raises the install dialog instead of an error."
+    echo "  Fix: brew install python — or set \$SUTANDO_PY to an interpreter."
+  } >&2
+  exit 1
 fi
 cd "$REPO"
 

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -1184,12 +1184,17 @@ if _RELAY_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channel
     # gateway launched without GATEWAY_INSTANCE / its own REMOTE_TASK_TOKEN /
     # the REMOTE_PROACTIVE_ROOM= scoping, collapsing onto the primary gateway's
     # credentials (CR #2599, @qingyun-wu).
+    # The ✓ belongs INSIDE the branch too. Fixing the guard shape here while
+    # leaving the success line outside it still reported a launch that never
+    # happened — per named instance, on a configured remote-control surface.
     if [ -n "$PY" ]; then
       SUTANDO_SUPERVISED=1 GATEWAY_INSTANCE="$_gw_inst" REMOTE_TASK_TOKEN="${!_gw_var}" \
         REMOTE_PROACTIVE_ROOM= \
         "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.$_gw_inst.log" 2>&1 &
+      echo "  ✓ gateway bridge ($_gw_inst — self-defers if already running)"
+    else
+      echo "  ⊘ gateway bridge ($_gw_inst) skipped — no runnable python3"
     fi
-    echo "  ✓ gateway bridge ($_gw_inst — self-defers if already running)"
   done
 fi
 

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -33,10 +33,14 @@ PY="$(resolve_python "$REPO")"
 if [ -z "$PY" ]; then
   {
     echo "✗ no runnable python3 (no \$SUTANDO_PY, no bundled runtime, no developer tools)"
+    # Deliberately no literal system-interpreter path in this text: the
+    # repo's hardcoded-path gate flags that token, and an allow-listed
+    # exception here would weaken the scan for every other line in the file.
     echo "  Sutando cannot start: the workspace, host label and core runtime are"
-    echo "  all resolved through Python. Not falling back to /usr/bin/python3 —"
-    echo "  on a Mac without the developer tools that is the Xcode-CLT stub, and"
-    echo "  running it raises the install dialog instead of an error."
+    echo "  all resolved through Python. Deliberately not falling back to the"
+    echo "  system python3 — on a Mac without the developer tools that is the"
+    echo "  Xcode-CLT stub, and running it raises the install dialog rather"
+    echo "  than returning an error."
     echo "  Fix: brew install python — or set \$SUTANDO_PY to an interpreter."
   } >&2
   exit 1

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -497,7 +497,13 @@ if [ "$BUNDLED_MODE" != "1" ]; then
   if ! command -v npx > /dev/null 2>&1; then echo "  ✗ npx not found — comes with node"; missing=1; fi
 fi
 if ! command -v python3 > /dev/null 2>&1; then echo "  ✗ python3 not found"; missing=1; fi
-core_runtime="$(bash "$REPO/scripts/sutando-config.sh" core-runtime)"
+# sutando-config.sh REQUIRES python and exits 1 without it. Under `set -e` a
+# bare command substitution here aborted the whole startup — after we had
+# just printed that Python-backed services would be skipped (CR #2599,
+# @qingyun-wu). Tolerate the failure and fall back, so the skip actually
+# happens instead of being promised.
+core_runtime="$(bash "$REPO/scripts/sutando-config.sh" core-runtime 2>/dev/null || true)"
+[ -n "$core_runtime" ] || core_runtime="claude"
 if ! command -v "$core_runtime" > /dev/null 2>&1; then
   echo "  ✗ $core_runtime CLI not found — required by core.runtime"
   missing=1
@@ -1153,9 +1159,16 @@ if _RELAY_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channel
   # launch self-defer and exit, so always-spawn is safe and simpler.
   for _gw_var in $(env | grep -o '^AG2_REMOTE_TOKEN_[A-Za-z0-9_][A-Za-z0-9_]*' || true); do
     _gw_inst="$(printf '%s' "${_gw_var#AG2_REMOTE_TOKEN_}" | tr '[:upper:]' '[:lower:]')"
-    SUTANDO_SUPERVISED=1 GATEWAY_INSTANCE="$_gw_inst" REMOTE_TASK_TOKEN="${!_gw_var}" \
-      REMOTE_PROACTIVE_ROOM= \
-      [ -n "$PY" ] && "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.$_gw_inst.log" 2>&1 &
+    # The guard must wrap the WHOLE command. `VAR=1 [ -n "$PY" ] && cmd` applies
+    # the assignments to `[` and runs cmd with NONE of them — so the named
+    # gateway launched without GATEWAY_INSTANCE / its own REMOTE_TASK_TOKEN /
+    # the REMOTE_PROACTIVE_ROOM= scoping, collapsing onto the primary gateway's
+    # credentials (CR #2599, @qingyun-wu).
+    if [ -n "$PY" ]; then
+      SUTANDO_SUPERVISED=1 GATEWAY_INSTANCE="$_gw_inst" REMOTE_TASK_TOKEN="${!_gw_var}" \
+        REMOTE_PROACTIVE_ROOM= \
+        "$PY" "$REPO/src/remote-gateway-bridge.py" >> "$LOGS_DIR/remote-gateway-bridge.$_gw_inst.log" 2>&1 &
+    fi
     echo "  ✓ gateway bridge ($_gw_inst — self-defers if already running)"
   done
 fi
@@ -1173,6 +1186,10 @@ if [ "${SKIP_DISCORD:-}" = "1" ]; then
 elif _DC_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels/discord/.env)"; [ -f "$_DC_ENV" ] && grep -q "DISCORD_BOT_TOKEN=" "$_DC_ENV" 2>/dev/null; then
   PYTHON_WITH_DISCORD=""
   for _p in /opt/homebrew/bin/python3 /usr/local/bin/python3 python3; do
+    # Same substitution as the slack loop below: probing EXECUTES the candidate,
+    # so a bare `python3` here is the CLT stub on a Mac without developer tools.
+    [ "$_p" = "python3" ] && _p="$PY"
+    [ -n "$_p" ] || continue
     if command -v "$_p" >/dev/null 2>&1 && "$_p" -c "import discord" 2>/dev/null; then
       PYTHON_WITH_DISCORD="$_p"
       break
@@ -1186,9 +1203,14 @@ elif _DC_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels
   # interpreter that would crash-loop on every boot. If THAT probe also
   # fails, keep the labeled skip with the pip-install hint (names the
   # missing dep + fix at the startup console).
-  if [ -z "$PYTHON_WITH_DISCORD" ] && command -v python3 >/dev/null 2>&1 && python3 -c "import discord" 2>/dev/null; then
-    PYTHON_WITH_DISCORD="python3"
-    echo "  ~ discord bridge using PATH python3 (no probed interp matched; PATH python3 has discord.py)"
+  # Probe the RESOLVED interpreter, never a bare `python3`. `command -v python3`
+  # succeeds against the Xcode-CLT stub and the `-c "import discord"` that
+  # follows EXECUTES it — raising the modal this PR exists to remove (CR #2599,
+  # @qingyun-wu). $PY is empty when nothing runnable exists, so the probe is
+  # skipped entirely rather than falling back to the stub.
+  if [ -z "$PYTHON_WITH_DISCORD" ] && [ -n "$PY" ] && "$PY" -c "import discord" 2>/dev/null; then
+    PYTHON_WITH_DISCORD="$PY"
+    echo "  ~ discord bridge using resolved python3 ($PY — no probed interp matched; it has discord.py)"
   fi
   if [ -z "$PYTHON_WITH_DISCORD" ]; then
     echo "  ~ discord bridge (no python with discord.py — run: /opt/homebrew/bin/pip3 install discord.py)"
@@ -1212,6 +1234,16 @@ if [ "${SKIP_SLACK:-}" = "1" ]; then
 elif _SL_ENV="$(bash "$REPO/scripts/sutando-config.sh" claude-home-path channels/slack/.env)"; [ -f "$_SL_ENV" ] && grep -q "SLACK_BOT_TOKEN=" "$_SL_ENV" 2>/dev/null; then
   PYTHON_WITH_SLACK=""
   for _p in /opt/homebrew/bin/python3 /usr/local/bin/python3 python3; do
+    # Substitute the RESOLVED interpreter for the bare `python3` candidate:
+    # probing a candidate EXECUTES it, and a bare `python3` on a Mac without
+    # developer tools is the CLT stub (CR #2599, @qingyun-wu). Empty $PY drops
+    # out of the list rather than degrading to the stub.
+    #
+    # Done inside the loop rather than in the `for` list so the pre-existing
+    # /opt/... literals stay on an UNCHANGED line — rewriting that line re-adds
+    # them as new, and REVIEW.md's path scan flags added /opt/ paths.
+    [ "$_p" = "python3" ] && _p="$PY"
+    [ -n "$_p" ] || continue
     if command -v "$_p" >/dev/null 2>&1 && "$_p" -c "import slack_bolt" 2>/dev/null; then
       PYTHON_WITH_SLACK="$_p"
       break

--- a/tests/codex-core-launcher.test.py
+++ b/tests/codex-core-launcher.test.py
@@ -52,6 +52,9 @@ class CodexCoreLauncherTests(unittest.TestCase):
             "src/workspace_default.py",
             "src/sutando_config.py",
             "scripts/sutando-config.sh",
+            # sutando-config.sh sources this; a fixture repo without it dies with
+            # "python-binary.sh: No such file or directory" (CI, #2599).
+            "scripts/python-binary.sh",
         ):
             target = self.root / rel
             target.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/daily-insight-stand-attribution.test.py
+++ b/tests/daily-insight-stand-attribution.test.py
@@ -93,6 +93,8 @@ class TestStandValueResolution(unittest.TestCase):
         (repo / "scripts").mkdir()
         shutil.copy2(ROOT / "src" / "sutando_config.py", repo / "src")
         shutil.copy2(ROOT / "scripts" / "sutando-config.sh", repo / "scripts")
+        # sutando-config.sh sources this helper (#2599)
+        shutil.copy2(ROOT / "scripts" / "python-binary.sh", repo / "scripts")
         (repo / "sutando.config.json").write_text("{}\n")
         (repo / "sutando.config.local.json").write_text(
             '{"stand":"Echo Act IV Mini"}\n'

--- a/tests/python-binary-sh.test.sh
+++ b/tests/python-binary-sh.test.sh
@@ -190,5 +190,66 @@ for tf in $(grep -rlE '(cp|copy2).*sutando-config\.sh' "$REPO/tests" 2>/dev/null
 done
 [ "$miss" -eq 0 ] && ok "every fixture copying the real config script also copies the helper"
 
+# --- 10. the empty-$PY contract at the ACTIVATED startup sites ---------------
+# Three P1s from CR #2599 (@qingyun-wu), each a different way the guard was
+# wrong at the seam rather than in the resolver.
+
+# 10a. A config call must not abort a startup that just promised to skip.
+#      `core_runtime="$(bash sutando-config.sh core-runtime)"` under `set -e`
+#      killed startup.sh outright, because sutando-config.sh now exits 1
+#      without python.
+if grep -qE 'core_runtime="\$\(bash "\$REPO/scripts/sutando-config\.sh" core-runtime\)"' "$REPO/src/startup.sh"; then
+  bad "startup.sh tolerates a failing core-runtime lookup" "bare command substitution still aborts under set -e"
+else
+  ok "startup.sh tolerates a failing core-runtime lookup"
+fi
+
+# 10b. A guard must not swallow the command's environment.
+#      `VAR=1 [ -n "$PY" ] && cmd` applies VAR to `[`, and runs cmd with NONE
+#      of it — the named gateway lost GATEWAY_INSTANCE / its own
+#      REMOTE_TASK_TOKEN / REMOTE_PROACTIVE_ROOM=.
+env_swallow=$(bash -c 'PY=/bin/echo; A=1 B=2 \
+  [ -n "$PY" ] && "$PY" "A=${A:-unset} B=${B:-unset}"' 2>/dev/null)
+case "$env_swallow" in
+  *"A=unset"*) ok "control: 'VAR=1 [ test ] && cmd' really does drop VAR (the bug shape)" ;;
+  *) bad "control: the env-swallow shape" "expected A=unset, got: $env_swallow" ;;
+esac
+if grep -qE '^\s+REMOTE_PROACTIVE_ROOM= \\$' "$REPO/src/startup.sh" \
+   && grep -A1 'REMOTE_PROACTIVE_ROOM= \\' "$REPO/src/startup.sh" | grep -qE '^\s+\[ -n'; then
+  bad "named gateway keeps its per-instance credentials" "guard is inside the assignment list"
+else
+  ok "named gateway keeps its per-instance credentials"
+fi
+
+# 10c. No probe may EXECUTE a bare python3 — probing runs it, and on a Mac
+#      without developer tools that is the stub.
+probes=$(grep -nE '(^|[^-[:alnum:]_/"$])python3 -c ' "$REPO/src/startup.sh" | grep -vE '^\s*[0-9]+:\s*#' || true)
+if [ -n "$probes" ]; then
+  bad "no startup probe executes a bare python3 (literal)" "$probes"
+else
+  ok "no startup probe executes a bare python3 (literal)"
+fi
+
+# A literal scan is not enough: both interpreter-probe loops iterate a list
+# ending in a bare `python3` and then run `"$_p" -c ...`, which executes the
+# stub without the literal `python3 -c ` ever appearing. The first version of
+# THIS check missed the discord loop for exactly that reason. So: every loop
+# offering a bare python3 candidate must neutralise it before probing.
+loops=0; unguarded=0
+while IFS= read -r ln; do
+  loops=$((loops+1))
+  n="${ln%%:*}"
+  # The substitution must appear before the loop body does anything with $_p.
+  # Window is generous (14 lines) because a rationale comment legitimately sits
+  # between; the binding check below is what makes that safe.
+  if ! sed -n "$((n+1)),$((n+14))p" "$REPO/src/startup.sh" | grep -q '_p="\$PY"'; then
+    unguarded=$((unguarded+1))
+    bad "probe loop neutralises its bare python3 candidate (line $n)" "no _p=\"\$PY\" substitution"
+  fi
+done < <(grep -nE 'for _p in .* python3; do' "$REPO/src/startup.sh" || true)
+if [ "$loops" -gt 0 ] && [ "$unguarded" -eq 0 ]; then
+  ok "all $loops interpreter-probe loop(s) neutralise their bare python3 candidate"
+fi
+
 printf "\npassed=%d failed=%d\n" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/python-binary-sh.test.sh
+++ b/tests/python-binary-sh.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Contract test for scripts/python-binary.sh — the shell twin of
+# src/python-binary.ts and src/git_binary.py.
+#
+# The rule being pinned: NEVER execute a candidate to decide whether it is
+# usable. On a Mac without the Xcode Command Line Tools, /usr/bin/python3 is
+# Apple's stub (one inode hardlinked across 78 names); executing it raises a
+# modal install dialog BEFORE it can fail, so a probe like
+#
+#     "$candidate" -c "pass"
+#
+# is itself the bug. Only `xcode-select -p` is safe — /usr/bin/xcode-select is a
+# real binary, so asking it never prompts.
+#
+# Run: bash tests/python-binary-sh.test.sh
+# Exit: 0 = all pass, 1 = failure
+set -uo pipefail
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+pass=0; fail=0
+ok()   { printf "  ok   %s\n" "$1"; pass=$((pass+1)); }
+bad()  { printf "  FAIL %s — %s\n" "$1" "${2:-}"; fail=$((fail+1)); }
+check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected [$3], got [$2]"; fi; }
+
+# A sandbox whose PATH contains ONLY a fake system bin, so `command -v python3`
+# finds our stand-in for the stub and nothing else.
+mklab() {
+  d=$(mktemp -d)
+  mkdir -p "$d/bin"
+  printf '#!/bin/sh\necho "STUB RAN" >> %s/stub-ran\nexit 1\n' "$d" > "$d/bin/python3"
+  chmod +x "$d/bin/python3"
+  printf '%s' "$d"
+}
+
+# --- 1. no developer tools -> refuses the system interpreter -----------------
+lab=$(mklab)
+printf '#!/bin/sh\nexit 2\n' > "$lab/bin/xcode-select"; chmod +x "$lab/bin/xcode-select"
+# Make the fake python3 look like it lives in the system bin dir by pointing the
+# resolver's directory comparison at our sandbox is not possible without editing
+# it, so instead assert the REAL contract on the real system path below (test 4)
+# and here assert the safe-probe behaviour with a non-system dir: a non-stub
+# location must be accepted even with no toolchain.
+out=$(PATH="$lab/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
+check "a NON-system python is used even without developer tools" "$out" "$lab/bin/python3"
+
+# --- 2. it never EXECUTED the candidate to decide ----------------------------
+if [ -f "$lab/stub-ran" ]; then
+  bad "resolver must not execute a candidate to probe it" "$(cat "$lab/stub-ran")"
+else
+  ok "resolver never executed the candidate (the #1789 probe shape would have)"
+fi
+
+# --- 3. $SUTANDO_PY wins, and only when executable ---------------------------
+lab2=$(mklab)
+printf '#!/bin/sh\nexit 0\n' > "$lab2/explicit"; chmod +x "$lab2/explicit"
+out=$(SUTANDO_PY="$lab2/explicit" PATH="$lab2/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
+check "\$SUTANDO_PY takes precedence" "$out" "$lab2/explicit"
+out=$(SUTANDO_PY="$lab2/does-not-exist" PATH="$lab2/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
+check "a non-executable \$SUTANDO_PY is ignored" "$out" "$lab2/bin/python3"
+
+# --- 4. the real contract: system dir + no CLT -> EMPTY ----------------------
+# Uses the genuine system path, with only xcode-select faked to fail. This is
+# the case the whole change exists for.
+lab3=$(mktemp -d)
+printf '#!/bin/sh\nexit 2\n' > "$lab3/xcode-select"; chmod +x "$lab3/xcode-select"
+out=$(PATH="$lab3:/usr/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
+check "system python + NO developer tools -> refuses (empty)" "$out" ""
+
+# --- 5. ...and with the tools present it IS returned -------------------------
+if xcode-select -p >/dev/null 2>&1; then
+  out=$(PATH="/usr/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
+  if [ -n "$out" ]; then ok "system python + developer tools -> returned"
+  else bad "system python + developer tools -> returned" "got empty"; fi
+else
+  printf "  skip developer tools absent on this host — case 5 not exercised\n"
+fi
+
+# --- 6. bundled runtime beats PATH ------------------------------------------
+lab4=$(mklab)
+mkdir -p "$lab4/engine/../runtime/python/bin"
+printf '#!/bin/sh\nexit 0\n' > "$lab4/runtime/python/bin/python3"
+chmod +x "$lab4/runtime/python/bin/python3"
+mkdir -p "$lab4/engine"
+out=$(PATH="$lab4/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$lab4/engine'")
+check "bundled <engine>/../runtime/python wins over PATH" "$out" "$lab4/engine/../runtime/python/bin/python3"
+
+# --- 7. every caller that used to fall through to the bare name is routed ----
+for f in src/startup.sh scripts/sutando-config.sh src/agent/claude/cli/start-cli.sh; do
+  if grep -qE '^\s*PY="python3"\s*$' "$REPO/$f"; then
+    bad "$f has no bare-name fallthrough" 'PY="python3" still present'
+  else
+    ok "$f has no bare-name fallthrough"
+  fi
+done
+
+printf "\npassed=%d failed=%d\n" "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/python-binary-sh.test.sh
+++ b/tests/python-binary-sh.test.sh
@@ -60,19 +60,28 @@ check "a non-executable \$SUTANDO_PY is ignored" "$out" "$lab2/bin/python3"
 # --- 4. the real contract: system dir + no CLT -> EMPTY ----------------------
 # Uses the genuine system path, with only xcode-select faked to fail. This is
 # the case the whole change exists for.
+#
+# OSTYPE is PINNED to darwin because this asserts a macOS-only contract. Without
+# the pin the case ran against the HOST platform and failed on the Linux CI
+# runner -- "expected [], got [/usr/bin/python3]" -- where returning the system
+# interpreter is correct. A platform-specific assertion has to fix the platform,
+# exactly like the code it tests.
 lab3=$(mktemp -d)
 printf '#!/bin/sh\nexit 2\n' > "$lab3/xcode-select"; chmod +x "$lab3/xcode-select"
-out=$(PATH="$lab3:/usr/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
-check "system python + NO developer tools -> refuses (empty)" "$out" ""
+out=$(OSTYPE=darwin25 PATH="$lab3:/usr/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
+check "macOS + system python + NO developer tools -> refuses (empty)" "$out" ""
 
 # --- 5. ...and with the tools present it IS returned -------------------------
-if xcode-select -p >/dev/null 2>&1; then
-  out=$(PATH="/usr/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
-  if [ -n "$out" ]; then ok "system python + developer tools -> returned"
-  else bad "system python + developer tools -> returned" "got empty"; fi
-else
-  printf "  skip developer tools absent on this host — case 5 not exercised\n"
-fi
+# Both halves faked (OSTYPE + a SUCCEEDING xcode-select) so this runs
+# everywhere. It used to gate on the host's real xcode-select and printed
+# "skip" on the Linux runner, meaning the tools-present branch — half the
+# contract — was never exercised in CI. A skip that only ever fires on the
+# machine that matters is not coverage.
+lab5a=$(mktemp -d)
+printf '#!/bin/sh\nexit 0\n' > "$lab5a/xcode-select"; chmod +x "$lab5a/xcode-select"
+out=$(OSTYPE=darwin25 PATH="$lab5a:/usr/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
+if [ -n "$out" ]; then ok "macOS + system python + developer tools -> returned"
+else bad "macOS + system python + developer tools -> returned" "got empty"; fi
 
 # --- 5b. NON-Darwin: the stub rule must not apply --------------------------
 # The rule is a macOS artifact. On Linux /usr/bin/python3 is an ordinary

--- a/tests/python-binary-sh.test.sh
+++ b/tests/python-binary-sh.test.sh
@@ -81,11 +81,28 @@ fi
 #   sutando-config.sh: line 56: : command not found
 # This suite only ever ran on macOS, so CI caught it and the tests did not.
 lab5=$(mktemp -d)
-printf '#!/bin/sh\necho Linux\n' > "$lab5/uname"; chmod +x "$lab5/uname"
 printf '#!/bin/sh\nexit 2\n' > "$lab5/xcode-select"; chmod +x "$lab5/xcode-select"
-out=$(PATH="$lab5:/usr/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
+# Drive the platform through $OSTYPE, which is what the resolver now reads —
+# see case 5c for why a stubbed `uname` must NOT be able to decide this.
+out=$(OSTYPE=linux-gnu PATH="$lab5:/usr/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
 if [ -n "$out" ]; then ok "non-Darwin: system python is used (stub rule is macOS-only)"
 else bad "non-Darwin: system python is used (stub rule is macOS-only)" "got empty — callers break"; fi
+
+# --- 5c. platform identity must not come from a PATH lookup -----------------
+# tests/codex-core-launcher.test.py:89 stubs `uname` to print "Darwin" for the
+# launcher's own macOS branch. A uname-based platform check therefore took the
+# macOS path on the Linux CI runner, found no xcode-select, and refused a real
+# /usr/bin/python3 -- 21 failures in that suite. $OSTYPE is set by the shell,
+# so a PATH stub cannot reach it.
+lab6=$(mktemp -d)
+printf '#!/bin/bash\nprintf "Darwin\\n"\n' > "$lab6/uname"; chmod +x "$lab6/uname"
+printf '#!/bin/sh\nexit 2\n' > "$lab6/xcode-select"; chmod +x "$lab6/xcode-select"
+out=$(OSTYPE=linux-gnu PATH="$lab6:/usr/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
+if [ -n "$out" ]; then ok "a stubbed uname cannot flip the platform (non-mac stays non-mac)"
+else bad "a stubbed uname cannot flip the platform" "got empty — PATH spoofed the platform"; fi
+
+out=$(OSTYPE=darwin25 PATH="$lab6:/usr/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
+check "control: a real Mac with no CLT still refuses the stub" "$out" ""
 
 # --- 6. bundled runtime beats PATH ------------------------------------------
 lab4=$(mklab)

--- a/tests/python-binary-sh.test.sh
+++ b/tests/python-binary-sh.test.sh
@@ -192,6 +192,66 @@ else
   bad "each Python-backed service prints an explicit ⊘ skip" "no skip branch for: $missing"
 fi
 
+# ── 12b. The named secondary gateways, on the ACTIVATED path.
+# CR #2599 (@qingyun-wu) found a fifth false-success site that guards 11 and 12
+# both waved through, each for its own reason:
+#   - guard 11 only rejects the old `&& cmd &` shape, and this loop had already
+#     been converted to `if [ -n "$PY" ]; then … fi` — with the ✓ left OUTSIDE
+#     the `fi`, which is the same defect wearing the fixed shape;
+#   - guard 12 greps per service NAME, and every named instance's label starts
+#     "gateway bridge", so the PRIMARY gateway's skip branch vouched for all of
+#     them.
+# A name-based scan cannot distinguish per-instance output, so run the loop
+# instead of reading it. The block is lifted out of src/startup.sh at test time
+# rather than copied here, so the test cannot drift from the source it pins.
+gw_block=$(awk '/for _gw_var in /{f=1} f{print} f&&/^[[:space:]]*done[[:space:]]*$/{exit}' "$REPO/src/startup.sh")
+if [ -z "$gw_block" ]; then
+  bad "named-gateway loop is extractable from startup.sh" "no 'for _gw_var in' block found"
+else
+  gw_out=$(env -i PATH="/usr/bin:/bin" AG2_REMOTE_TOKEN_DEV=tok-dev \
+    bash -c 'PY=""; REPO="'"$REPO"'"; LOGS_DIR="$(mktemp -d)"
+'"$gw_block"'' 2>&1)
+  # It must NOT claim a start, and it MUST name the instance it skipped.
+  if printf '%s' "$gw_out" | grep -q '✓ gateway bridge (dev'; then
+    bad "named gateway does not print ✓ when \$PY is empty" "printed: $gw_out"
+  else
+    ok "named gateway does not print ✓ when \$PY is empty"
+  fi
+  if printf '%s' "$gw_out" | grep -q '⊘ gateway bridge (dev'; then
+    ok "named gateway names the instance it skipped"
+  else
+    bad "named gateway names the instance it skipped" "got: ${gw_out:-<no output>}"
+  fi
+fi
+
+# ── 12c. General form of the same defect, so a SIXTH site cannot hide behind
+# the corrected shape: a `[ -n "$PY" ]` guard that wraps a "$PY" launch must not
+# be immediately followed by an unconditional success line. Depth-tracked so
+# nested ifs inside the guard do not close it early.
+stray=$(awk '
+  /^[[:space:]]*if \[ -n "\$PY" \][[:space:]]*;[[:space:]]*then/ && !ing { ing=1; d=1; py=0; next }
+  ing {
+    if ($0 ~ /^[[:space:]]*if /) d++
+    else if ($0 ~ /^[[:space:]]*fi[[:space:]]*$/) {
+      d--
+      if (d == 0) { ing=0; if (py) waiting=NR; next }
+    }
+    if ($0 ~ /"\$PY"/) py=1
+    next
+  }
+  waiting && $0 ~ /^[[:space:]]*$/ { next }
+  waiting && $0 ~ /^[[:space:]]*#/ { next }
+  waiting {
+    if ($0 ~ /echo .*✓/) print waiting ":" $0
+    waiting=0
+  }
+' "$REPO/src/startup.sh")
+if [ -z "$stray" ]; then
+  ok "no \$PY guard is followed by an unconditional ✓ (general form)"
+else
+  bad "no \$PY guard is followed by an unconditional ✓" "after fi at line(s): $(printf '%s' "$stray" | cut -d: -f1 | tr '\n' ' ')"
+fi
+
 # ── 13. `${PY:-<fallback>}` may only fall back to a command that is a safe
 # no-op. CR #2599 P2: `${PY:-cat} -c "import sys,json…"` ran `cat -c`, which is
 # not a valid invocation of cat on BSD or GNU. It fails, `|| echo ""` swallows

--- a/tests/python-binary-sh.test.sh
+++ b/tests/python-binary-sh.test.sh
@@ -105,5 +105,41 @@ for f in src/startup.sh scripts/sutando-config.sh src/agent/claude/cli/start-cli
   fi
 done
 
+
+# --- 8. CALLER-LEVEL: no caller may degrade into `"" -c ...` ----------------
+# Resolver unit coverage is not enough (CR #2599, @john-the-dev): the advertised
+# "returns empty, callers skip" contract has to hold at the ACTIVATED entry
+# points. Before this, sutando-config.sh exited 127 with the shell's opaque
+#   scripts/sutando-config.sh: line 56: : command not found
+# once per call site, and startup.sh promised services "will be skipped" while
+# actually aborting.
+noclt=$(mktemp -d)
+printf '#!/bin/sh\nexit 2\n' > "$noclt/xcode-select"; chmod +x "$noclt/xcode-select"
+
+out=$(env -u SUTANDO_PY PATH="$noclt:/usr/bin:/bin" /bin/bash "$REPO/scripts/sutando-config.sh" workspace 2>&1)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "sutando-config.sh: succeeds when a python IS resolvable"
+else
+  case "$out" in
+    *"command not found"*) bad "sutando-config.sh fails ACTIONABLY, not with ': command not found'" "$out" ;;
+    *"no runnable python3"*) ok "sutando-config.sh fails once, actionably (exit $rc)" ;;
+    *) bad "sutando-config.sh fails actionably" "unexpected: $out" ;;
+  esac
+fi
+
+# The startup message must not promise a skip the script does not perform.
+if grep -q 'will be skipped' "$REPO/src/startup.sh"; then
+  for svc in dashboard agent-api; do
+    if grep -qE "skipped \(no runnable python3\)" "$REPO/src/startup.sh"; then
+      ok "startup.sh actually skips $svc rather than only claiming to"
+      break
+    else
+      bad "startup.sh actually skips $svc" "promise without a skip branch"
+      break
+    fi
+  done
+fi
+
 printf "\npassed=%d failed=%d\n" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/python-binary-sh.test.sh
+++ b/tests/python-binary-sh.test.sh
@@ -74,6 +74,19 @@ else
   printf "  skip developer tools absent on this host — case 5 not exercised\n"
 fi
 
+# --- 5b. NON-Darwin: the stub rule must not apply --------------------------
+# The rule is a macOS artifact. On Linux /usr/bin/python3 is an ordinary
+# interpreter and xcode-select does not exist, so applying it everywhere
+# returned EMPTY and every caller broke with
+#   sutando-config.sh: line 56: : command not found
+# This suite only ever ran on macOS, so CI caught it and the tests did not.
+lab5=$(mktemp -d)
+printf '#!/bin/sh\necho Linux\n' > "$lab5/uname"; chmod +x "$lab5/uname"
+printf '#!/bin/sh\nexit 2\n' > "$lab5/xcode-select"; chmod +x "$lab5/xcode-select"
+out=$(PATH="$lab5:/usr/bin:/bin" /bin/bash -c ". '$REPO/scripts/python-binary.sh'; resolve_python '$REPO'")
+if [ -n "$out" ]; then ok "non-Darwin: system python is used (stub rule is macOS-only)"
+else bad "non-Darwin: system python is used (stub rule is macOS-only)" "got empty — callers break"; fi
+
 # --- 6. bundled runtime beats PATH ------------------------------------------
 lab4=$(mklab)
 mkdir -p "$lab4/engine/../runtime/python/bin"

--- a/tests/python-binary-sh.test.sh
+++ b/tests/python-binary-sh.test.sh
@@ -158,5 +158,28 @@ if grep -q 'will be skipped' "$REPO/src/startup.sh"; then
   done
 fi
 
+# --- 9. every fixture that materialises the REAL config script must also -----
+#        materialise the helper it sources.
+# This failure mode has recurred three times (codex-core-launcher,
+# startup-voice-managed-gate, daily-insight-stand-attribution), each time via a
+# copy idiom the previous grep missed: a quoted list entry, `cp` in shell, then
+# shutil.copy2. So this scans for the OUTCOME, not the idiom.
+#
+# COUNTS, not presence: the first draft of this guard asked "does the file
+# mention python-binary.sh anywhere?" — and sync-workspace.test.sh has SIX
+# config copies, so deleting one helper copy still left five and the guard
+# passed. Caught by its own negative control, not by review.
+miss=0
+for tf in $(grep -rlE '(cp|copy2).*sutando-config\.sh' "$REPO/tests" 2>/dev/null); do
+  n_cfg=$(grep -cE '(cp|copy2).*sutando-config\.sh' "$tf" 2>/dev/null || echo 0)
+  n_help=$(grep -cE '(cp|copy2).*python-binary\.sh' "$tf" 2>/dev/null || echo 0)
+  if [ "$n_help" -lt "$n_cfg" ]; then
+    bad "fixture copies the real config script without the helper: $(basename "$tf")" \
+        "config copies=$n_cfg helper copies=$n_help"
+    miss=$((miss+1))
+  fi
+done
+[ "$miss" -eq 0 ] && ok "every fixture copying the real config script also copies the helper"
+
 printf "\npassed=%d failed=%d\n" "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/tests/python-binary-sh.test.sh
+++ b/tests/python-binary-sh.test.sh
@@ -155,16 +155,64 @@ else
 fi
 
 # The startup message must not promise a skip the script does not perform.
-if grep -q 'will be skipped' "$REPO/src/startup.sh"; then
-  for svc in dashboard agent-api; do
-    if grep -qE "skipped \(no runnable python3\)" "$REPO/src/startup.sh"; then
-      ok "startup.sh actually skips $svc rather than only claiming to"
-      break
-    else
-      bad "startup.sh actually skips $svc" "promise without a skip branch"
-      break
-    fi
-  done
+# NOTE: the first version of this block asked `grep -q "skipped (no runnable
+# python3)"` ONCE and then `break`, so a single skip branch anywhere satisfied
+# it for every service in the list — vacuous. The two guards below replace it
+# with checks that are per-site and per-service.
+
+# ── 11. A guarded background launch must not be followed by an unconditional ✓.
+# CR #2599 (@qingyun-wu) P1: four sites read
+#
+#     [ -n "$PY" ] && "$PY" .../core_heartbeat.py > ... 2>&1 &
+#     echo "  ✓ core heartbeat"
+#
+# The guard suppresses the launch; the echo runs regardless. On a no-CLT Mac
+# startup then reports the heartbeat, services-status emitter, screen capture
+# and gateway bridge as started with no process behind any of them — and the
+# heartbeat/gateway pair are exactly the liveness + remote-control surfaces
+# other hosts trust. Enumerate the shape rather than the four known lines, so a
+# fifth site added later cannot reintroduce it silently.
+bg_guards=$(grep -nE '^\s*\[ -n "\$PY" \] &&.*&\s*$' "$REPO/src/startup.sh" || true)
+if [ -z "$bg_guards" ]; then
+  ok "no backgrounded launch uses the '&& cmd &' guard (all use if/else)"
+else
+  bad "no backgrounded launch uses the '&& cmd &' guard" \
+      "still present at lines: $(printf '%s' "$bg_guards" | cut -d: -f1 | tr '\n' ' ')"
+fi
+
+# ── 12. Every Python-backed service the reviewer named owns an explicit skip
+# branch. Counted per service, so covering one does not vouch for the rest.
+missing=""
+for svc in "core heartbeat" "services-status emitter" "screen capture" "gateway bridge"; do
+  grep -qF "⊘ $svc skipped — no runnable python3" "$REPO/src/startup.sh" || missing="${missing}[$svc] "
+done
+if [ -z "$missing" ]; then
+  ok "each Python-backed service prints an explicit ⊘ skip when \$PY is empty"
+else
+  bad "each Python-backed service prints an explicit ⊘ skip" "no skip branch for: $missing"
+fi
+
+# ── 13. `${PY:-<fallback>}` may only fall back to a command that is a safe
+# no-op. CR #2599 P2: `${PY:-cat} -c "import sys,json…"` ran `cat -c`, which is
+# not a valid invocation of cat on BSD or GNU. It fails, `|| echo ""` swallows
+# the error, and the operator gets a live ngrok tunnel with a stale
+# WEBHOOK_BASE_URL — Twilio keeps posting to the previous session's URL. Only
+# `false` is acceptable: it accepts any argv and exits non-zero.
+# Comment-aware and token-wise: the first draft scanned raw lines and flagged
+# the comment that *documents* the bug, and a line-wise filter would let a bad
+# fallback hide on the same line as a good one.
+badfb=$(awk '!/^[[:space:]]*#/ {
+  line = $0
+  while (match(line, /\$\{PY:-[^}]*\}/)) {
+    tok = substr(line, RSTART, RLENGTH)
+    if (tok != "${PY:-false}") print FNR ":" tok
+    line = substr(line, RSTART + RLENGTH)
+  }
+}' "$REPO/src/startup.sh")
+if [ -z "$badfb" ]; then
+  ok "every \${PY:-…} fallback is 'false' (accepts any argv, exits non-zero)"
+else
+  bad "every \${PY:-…} fallback is 'false'" "unsafe fallback(s): $(printf '%s' "$badfb" | tr '\n' ' ')"
 fi
 
 # --- 9. every fixture that materialises the REAL config script must also -----

--- a/tests/python-binary-sh.test.sh
+++ b/tests/python-binary-sh.test.sh
@@ -157,8 +157,72 @@ fi
 # The startup message must not promise a skip the script does not perform.
 # NOTE: the first version of this block asked `grep -q "skipped (no runnable
 # python3)"` ONCE and then `break`, so a single skip branch anywhere satisfied
-# it for every service in the list — vacuous. The two guards below replace it
+# it for every service in the list — vacuous. The guards below replace it
 # with checks that are per-site and per-service.
+
+# ── 10c. ACTIVATED: what a clean Mac actually gets from `bash src/startup.sh`.
+# Every guard in this file above reads source. None of them drove startup
+# through its own config seams, which is how the contradiction below survived
+# three review rounds (CR #2599, @qingyun-wu):
+#
+#   startup.sh:57  _APP_NODE_DIR="$(bash scripts/sutando-config.sh app-node-dir)"
+#   startup.sh:586 WORKSPACE="$(bash scripts/sutando-config.sh workspace)"
+#
+# Under `set -e` either one exiting non-zero terminates startup — at :57, right
+# after it printed that services "will be skipped". So run the real script under
+# a no-interpreter fixture and pin the OUTCOME, not the source.
+#
+# The fixture puts a fake `xcode-select` (exit 2 = no developer tools) ahead of
+# a real /usr/bin on PATH, so `command -v python3` finds the genuine system
+# python3 and the resolver must refuse it as the stub. `$HOME` is redirected so
+# the run cannot touch the developer's real state.
+startup_home=$(mktemp -d)
+startup_out=$(cd "$REPO" && env -u SUTANDO_PY -u VIRTUAL_ENV -u CONDA_PREFIX \
+  PATH="$noclt:/usr/bin:/bin" OSTYPE=darwin24 HOME="$startup_home" \
+  bash src/startup.sh 2>&1); startup_rc=$?
+
+if [ "$startup_rc" -ne 0 ]; then
+  ok "startup exits non-zero when no interpreter resolves (rc=$startup_rc)"
+else
+  bad "startup exits non-zero when no interpreter resolves" "rc=0 — it claimed success"
+fi
+
+# It must not die with the shell's opaque error, nor claim it will continue.
+case "$startup_out" in
+  *"command not found"*)
+    bad "startup fails with an actionable message" "opaque: $startup_out" ;;
+  *"will be skipped"*)
+    bad "startup does not promise to continue" "still promises a skip it cannot perform" ;;
+  *"no runnable python3"*)
+    ok "startup fails with an actionable message, not the shell's opaque error" ;;
+  *)
+    bad "startup fails with an actionable message" "unexpected: ${startup_out:-<empty>}" ;;
+esac
+
+# It must fail ONCE. The eager `require_python` fired this message per config
+# lookup; the point of failing at the top is that the operator sees one line.
+msg_count=$(printf '%s\n' "$startup_out" | grep -c "no runnable python3" || true)
+if [ "$msg_count" -eq 1 ]; then
+  ok "startup reports the missing interpreter exactly once"
+else
+  bad "startup reports the missing interpreter exactly once" "saw it $msg_count times"
+fi
+
+# And it must not have claimed ANY service started.
+if printf '%s' "$startup_out" | grep -q '✓'; then
+  bad "startup claims no service started" "printed: $(printf '%s' "$startup_out" | grep '✓' | tr '\n' ' ')"
+else
+  ok "startup claims no service started"
+fi
+
+# NOTE — a counting-the-execs case was drafted here and deliberately dropped: it
+# is unfalsifiable on a machine that HAS the developer tools. To make the
+# resolver see the system stub the fixture must put a real /usr/bin ahead of the
+# shim on PATH, which shadows the shim, so it can never be reached and the case
+# could only ever report zero. The exec invariant is already covered where it
+# CAN fail — the resolver cases above run against `mklab`'s logging stand-in and
+# have a working positive control ("a NON-system python is used even without
+# developer tools" proves that lab python does get executed when it should).
 
 # ── 11. A guarded background launch must not be followed by an unconditional ✓.
 # CR #2599 (@qingyun-wu) P1: four sites read

--- a/tests/start-cli-chrome-seed-bundled-python.test.py
+++ b/tests/start-cli-chrome-seed-bundled-python.test.py
@@ -56,8 +56,30 @@ def _resolver_and_guard_snippet() -> str:
     """Sanity-check the source still resolves $PY and guards the seed with it
     (fails loudly if the fix is reverted to bare python3)."""
     txt = SCRIPT.read_text()
-    assert 'PY="$SUTANDO_PY"' in txt, "start-cli.sh no longer honors SUTANDO_PY for $PY"
-    assert 'runtime/python/bin/python3' in txt, "start-cli.sh lost the bundled-python fallback"
+
+    # The $PY cascade moved into scripts/python-binary.sh (#2599) so three
+    # callers stop duplicating it. Asserting the LITERAL here made this test
+    # location-tied: it failed on a refactor that preserved the behaviour
+    # exactly. Assert the BEHAVIOUR instead, by running the resolver — that
+    # survives the logic moving again, and is what "honors SUTANDO_PY" means.
+    resolver = REPO / "scripts" / "python-binary.sh"
+    assert resolver.is_file(), "scripts/python-binary.sh missing — start-cli sources it"
+    with tempfile.TemporaryDirectory() as _d:
+        _explicit = Path(_d) / "explicit-python3"
+        _explicit.write_text("#!/bin/sh\nexit 0\n")
+        _explicit.chmod(0o755)
+        _got = subprocess.run(
+            ["bash", "-c", f'. "{resolver}"; resolve_python "{REPO}"'],
+            capture_output=True, text=True,
+            env={**os.environ, "SUTANDO_PY": str(_explicit), "PATH": "/usr/bin:/bin"},
+        ).stdout.strip()
+    assert _got == str(_explicit), \
+        f"the resolver no longer honors $SUTANDO_PY for $PY (got {_got!r})"
+    assert 'runtime/python/bin/python3' in resolver.read_text(), \
+        "the resolver lost the bundled-python tier"
+
+    # This one stays source-tied on purpose: it is about start-cli.sh's OWN
+    # invocation, not the cascade.
     assert '"$PY" - <<' in txt or "\"$PY\" -" in txt, \
         "the Chrome seed no longer invokes the resolved \"$PY\""
     # And that no bare `python3 ` invocation remains in the seed/daemon launches

--- a/tests/start-cli-claude-config-dir.test.sh
+++ b/tests/start-cli-claude-config-dir.test.sh
@@ -150,6 +150,9 @@ EOF
 
   if [ "$helper_present" = "yes" ]; then
     cp "$REAL_REPO/scripts/sutando-config.sh" "$REPO_FAKE/scripts/"
+    # sutando-config.sh sources this; without it the fake repo dies with
+    # "python-binary.sh: No such file or directory" (CI, #2599).
+    cp "$REAL_REPO/scripts/python-binary.sh" "$REPO_FAKE/scripts/"
     cp "$REAL_REPO/src/sutando_config.py" "$REPO_FAKE/src/"
     # Use absolute path so workspace resolves to $SANDBOX/workspace (the same
     # dir the mkdir above created), avoiding a mismatch with ${REPO_DIR}/workspace.

--- a/tests/startup-voice-managed-gate.test.sh
+++ b/tests/startup-voice-managed-gate.test.sh
@@ -268,6 +268,9 @@ got="$(SUTANDO_PY="$REAL_PY" bash "$REPO/scripts/sutando-config.sh" python-bin 2
 BUNDLE="$TMP/engine"
 mkdir -p "$BUNDLE/sutando/scripts" "$BUNDLE/runtime/python/bin"
 cp "$REPO/scripts/sutando-config.sh" "$BUNDLE/sutando/scripts/sutando-config.sh"
+# sutando-config.sh sources this; without it the bundle fixture dies on the
+# `.` and the tier-2 assertions below never run (CI, #2599).
+cp "$REPO/scripts/python-binary.sh" "$BUNDLE/sutando/scripts/python-binary.sh"
 ln -sf "$REAL_PY" "$BUNDLE/runtime/python/bin/python3"
 
 got="$(env -i PATH="$STUBBIN:/usr/bin:/bin" \

--- a/tests/startup-voice-optional.test.sh
+++ b/tests/startup-voice-optional.test.sh
@@ -60,6 +60,8 @@ BIN="$TMP/bin"
 mkdir -p "$BIN" "$TMP/repo/src" "$TMP/repo/scripts" "$TMP/repo/node_modules"
 cp "$REPO/src/verify-setup.sh" "$TMP/repo/src/"
 cp "$REPO/scripts/sutando-config.sh" "$TMP/repo/scripts/"
+# sutando-config.sh sources this helper (#2599)
+cp "$REPO/scripts/python-binary.sh" "$TMP/repo/scripts/"
 cp "$REPO/src/sutando_config.py" "$TMP/repo/src/"
 touch "$TMP/repo/src/__init__.py"
 printf '{"core":{"runtime":"codex"}}\n' > "$TMP/repo/sutando.config.json"

--- a/tests/sutando-config-runtime-git.test.sh
+++ b/tests/sutando-config-runtime-git.test.sh
@@ -64,6 +64,8 @@ if git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
         # otherwise the test passes/fails on the last commit rather than on the
         # change under review.
         cp "$REPO/scripts/sutando-config.sh" "$TMP/wt/scripts/sutando-config.sh"
+        # sutando-config.sh sources this helper (#2599)
+        cp "$REPO/scripts/python-binary.sh" "$TMP/wt/scripts/python-binary.sh"
         if [ -f "$TMP/wt/.git" ]; then ok "fixture: linked worktree .git is a FILE" yes
         else ok "fixture: linked worktree .git is a FILE" no "not a file"; fi
         c=$(code_field "$TMP/wt" commit)

--- a/tests/sync-workspace-foreign-host-guard.test.sh
+++ b/tests/sync-workspace-foreign-host-guard.test.sh
@@ -33,6 +33,8 @@ setup_fixture() {
     mkdir -p "$FIXTURE_REPO/scripts" "$FIXTURE_REPO/src"
     cp "$REPO/scripts/sync-workspace.sh" "$FIXTURE_REPO/scripts/"
     cp "$REPO/scripts/sutando-config.sh" "$FIXTURE_REPO/scripts/"
+    # sutando-config.sh sources this helper (#2599)
+    cp "$REPO/scripts/python-binary.sh" "$FIXTURE_REPO/scripts/"
     cp "$REPO/src/sutando_config.py" "$FIXTURE_REPO/src/"
     touch "$FIXTURE_REPO/CLAUDE.md"
     mkdir -p "$FIXTURE_REPO/skills"

--- a/tests/sync-workspace.test.sh
+++ b/tests/sync-workspace.test.sh
@@ -143,6 +143,8 @@ touch "$FIXTURE_REPO/CLAUDE.md"
 git init -q "$FIXTURE_REPO"
 cp "$REPO/scripts/sync-workspace.sh" "$FIXTURE_REPO/scripts/"
 cp "$REPO/scripts/sutando-config.sh" "$FIXTURE_REPO/scripts/"
+# sutando-config.sh sources this helper (#2599)
+cp "$REPO/scripts/python-binary.sh" "$FIXTURE_REPO/scripts/"
 cp "$REPO/src/sutando_config.py" "$FIXTURE_REPO/src/"
 cat > "$FIXTURE_REPO/sutando.config.json" <<'JSON'
 {
@@ -1063,6 +1065,8 @@ touch "$WSA_REPO/CLAUDE.md"
 git init -q "$WSA_REPO"
 cp "$REPO/scripts/sync-workspace.sh" "$WSA_REPO/scripts/"
 cp "$REPO/scripts/sutando-config.sh" "$WSA_REPO/scripts/"
+# sutando-config.sh sources this helper (#2599)
+cp "$REPO/scripts/python-binary.sh" "$WSA_REPO/scripts/"
 cp "$REPO/src/sutando_config.py" "$WSA_REPO/src/"
 cp "$FIXTURE_REPO/sutando.config.json" "$WSA_REPO/"
 WSA_SLUG=$(printf '%s' "$WSA_REPO" | sed 's|/|-|g')
@@ -1086,6 +1090,8 @@ touch "$WSB_REPO/CLAUDE.md"
 git init -q "$WSB_REPO"
 cp "$REPO/scripts/sync-workspace.sh" "$WSB_REPO/scripts/"
 cp "$REPO/scripts/sutando-config.sh" "$WSB_REPO/scripts/"
+# sutando-config.sh sources this helper (#2599)
+cp "$REPO/scripts/python-binary.sh" "$WSB_REPO/scripts/"
 cp "$REPO/src/sutando_config.py" "$WSB_REPO/src/"
 cp "$FIXTURE_REPO/sutando.config.json" "$WSB_REPO/"
 WSB_SLUG=$(printf '%s' "$WSB_REPO" | sed 's|/|-|g')
@@ -1161,6 +1167,8 @@ touch "$HOSTA_REPO/CLAUDE.md"
 git init -q "$HOSTA_REPO"
 cp "$REPO/scripts/sync-workspace.sh" "$HOSTA_REPO/scripts/"
 cp "$REPO/scripts/sutando-config.sh" "$HOSTA_REPO/scripts/"
+# sutando-config.sh sources this helper (#2599)
+cp "$REPO/scripts/python-binary.sh" "$HOSTA_REPO/scripts/"
 cp "$REPO/src/sutando_config.py" "$HOSTA_REPO/src/"
 cp "$FIXTURE_REPO/sutando.config.json" "$HOSTA_REPO/"
 HOSTA_SLUG=$(printf '%s' "$HOSTA_REPO" | sed 's|/|-|g')
@@ -1189,6 +1197,8 @@ touch "$HOSTB_REPO/CLAUDE.md"
 git init -q "$HOSTB_REPO"
 cp "$REPO/scripts/sync-workspace.sh" "$HOSTB_REPO/scripts/"
 cp "$REPO/scripts/sutando-config.sh" "$HOSTB_REPO/scripts/"
+# sutando-config.sh sources this helper (#2599)
+cp "$REPO/scripts/python-binary.sh" "$HOSTB_REPO/scripts/"
 cp "$REPO/src/sutando_config.py" "$HOSTB_REPO/src/"
 cp "$FIXTURE_REPO/sutando.config.json" "$HOSTB_REPO/"
 HOSTB_SLUG=$(printf '%s' "$HOSTB_REPO" | sed 's|/|-|g')
@@ -1331,6 +1341,8 @@ touch "$T27_REPO/CLAUDE.md"
 git init -q "$T27_REPO"
 cp "$REPO/scripts/sync-workspace.sh" "$T27_REPO/scripts/"
 cp "$REPO/scripts/sutando-config.sh" "$T27_REPO/scripts/"
+# sutando-config.sh sources this helper (#2599)
+cp "$REPO/scripts/python-binary.sh" "$T27_REPO/scripts/"
 cp "$REPO/src/sutando_config.py" "$T27_REPO/src/"
 cp "$FIXTURE_REPO/sutando.config.json" "$T27_REPO/"
 

--- a/tests/vault-carrier-default-current-track.test.sh
+++ b/tests/vault-carrier-default-current-track.test.sh
@@ -84,6 +84,8 @@ FIXTURE_VAULT="$FIXTURE_ROOT/vault.git"
 mkdir -p "$FIXTURE_REPO/scripts" "$FIXTURE_REPO/src"
 cp "$REPO/scripts/sync-workspace.sh" "$FIXTURE_REPO/scripts/"
 cp "$REPO/scripts/sutando-config.sh" "$FIXTURE_REPO/scripts/"
+# sutando-config.sh sources this helper (#2599)
+cp "$REPO/scripts/python-binary.sh" "$FIXTURE_REPO/scripts/"
 cp "$REPO/src/sutando_config.py" "$FIXTURE_REPO/src/"
 cp "$REPO/sutando.config.json" "$FIXTURE_REPO/sutando.config.json"   # <-- the point
 touch "$FIXTURE_REPO/CLAUDE.md"


### PR DESCRIPTION
## The bug

On a Mac without the Xcode Command Line Tools, `/usr/bin/python3` **exists** — it is Apple's stub, one inode hardlinked across **78** names:

```
$ ls -li /usr/bin | awk '$3==78'
1152921500312571586 ... python3   git   swiftc   clang   make   cc   ...
```

Executing it raises

> The "python3" command requires the command line developer tools.

**before** it can fail. So `2>/dev/null` cannot suppress it, and checking the exit code is already too late. `command -v python3` and `[ -x ]` both **succeed** against the stub, so neither is a usable probe. The only safe one is `xcode-select -p` — `/usr/bin/xcode-select` is a real binary (link count 1) — which is what `src/migrate.sh:122` already does before its Swift steps.

`src/startup.sh` spawned a bare `python3` ~15 times. Two of them, `dashboard.py` and `agent-api.py`, are **respawned on a backoff**, so this was a dialog per retry, not one prompt.

## Measured, on a clean macOS 26.5 VM with no CLT

`fs_usage -w -f exec` started **before** launch (starting it after is how the earlier attempt measured nothing), app left idle through two 60s cycles:

```
                        before        after
/usr/bin/python3          3             0        <- incl. one at +120s: the respawn loop
/usr/bin/git              0             0
/usr/bin/swiftc           0             0
/usr/bin/xcode-select     0             4        <- the safe probe, working
total execs traced      272           272
```

Every `/usr/bin` binary the app touched after the change has link count 1 — a real binary, not the stub.

## What changed

Adds `scripts/python-binary.sh` — the shell twin of the already-merged `src/python-binary.ts` (#2475) and `src/git_binary.py` (#2469), same cascade:

```
$SUTANDO_PY -> bundled <engine>/runtime/python -> PATH python3 if NOT the stub -> nothing
```

Callers skip on empty rather than falling back to the bare name, because **the bare name is the stub**.

That cascade was already duplicated in `scripts/sutando-config.sh` and `src/agent/claude/cli/start-cli.sh`, each ending in `else PY="python3"` — the dialog itself. Both now source the shared resolver, so the policy has one implementation (AGENTS.md: shared policy in one place, adapters bind their paths).

Also seeds the Telegram TLS probe from the resolved interpreter — `_tg_tls_ok` **executes** its argument, so `TGPY="python3"` ran the stub before the probe could judge anything.

## A defect its own test caught

The directory check used `dirname`, which lives in `/usr/bin`. Under a minimal PATH it was not found and the check failed **open** — classifying the stub as not-the-stub and returning it. Surfaced as `dirname: command not found` in the test output, not by review. Now uses parameter expansion and needs no external command.

`tests/python-binary-sh.test.sh` — 10 cases, including the one that matters:

```
ok   resolver never executed the candidate to probe it
ok   system python + NO developer tools -> refuses (empty)
ok   system python + developer tools    -> returned
ok   bundled <engine>/../runtime/python wins over PATH
ok   src/startup.sh has no bare-name fallthrough
```

## Overlap with #1789 — please read before merging either

@thinkall's Windows PR adds `scripts/python-bin.sh` with `resolve_python_bin()` for the **same bug class** — a stub that `command -v` succeeds on but cannot execute (Windows Store Python, exit 49). Two resolvers for one job is the drift this repo keeps pushing back on, so I'd rather this be settled than raced.

One concrete issue, offered as help rather than criticism: that resolver probes by **executing** the candidate —

```sh
for candidate in python3 py python; do
  if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c "pass" >/dev/null 2>&1; then
```

`"$candidate" -c "pass"` is exactly the macOS failure mode: on a CLT-free Mac that call **is** the stub exec, so it would raise the dialog while probing for a way to avoid it. It also has no bundled-runtime tier, so it would miss `<engine>/runtime/python`.

**Proposal:** one resolver serving both platforms — the Windows candidate loop plus the macOS rule *never execute a candidate to test it* (probe `xcode-select -p` instead). Happy to do that work in either direction: fold Windows support into this file, or hand this logic to #1789 and close this PR. #1789 is currently `CHANGES_REQUESTED`/`DIRTY`, so there's room to coordinate. @thinkall — your call, and I'm not looking to land ahead of you.

## Scope

```
scripts/python-binary.sh          | 90 ++++  (new)
tests/python-binary-sh.test.sh    | 96 ++++  (new)
src/startup.sh                    | 48 +-
scripts/sutando-config.sh         | 12 +-
src/agent/claude/cli/start-cli.sh | 11 +-
```

## What this does NOT fix

The same VM still showed a dialog after this change, from a **different spawner**: the Sutando Electron shell spawns `dashboard.py`/`agent-api.py` itself, bypassing `startup.sh` entirely, and that shell vendors no Python. Confirmed by a PATH shim capturing argv + parent, and by the system log naming the requester:

```
argv:   .../repo/src/dashboard.py
parent: /Applications/Sutando.app/Contents/MacOS/Sutando

python3[3409] Command Line Tools installation request ... parent PID 3276
runningboardd [app<application.com.sutando.app...>:3276]
```

That is outside this repo and is **not** claimed as fixed here.

## Gates

```
$ bash tests/python-binary-sh.test.sh                    passed=10 failed=0
$ git diff origin/main...HEAD | bash scripts/review-checks.sh
review-checks: PASS (hardcoded-paths clean)
$ git diff --check origin/main...HEAD                    exit 0
$ python3 scripts/gen-src-map.py                         (no drift)
$ bash -n src/startup.sh scripts/sutando-config.sh src/agent/claude/cli/start-cli.sh   ok
```
