### PR TITLE
fix(health-check): a heartbeat restart reported every live cron as gone

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -887,10 +887,15 @@ def check_session_cron_registration(
     2026-07-23 on a peer instance as 2/18 registered. The script-visible signal:
     /schedule-crons writes
     `hosts/<hostname>/schedule-crons-stamp.json` when it finishes; if that
-    host-owned stamp predates the running core's `started_at` (from the
-    heartbeat payload), the current session never completed registration.
-    Stamp AGE alone is deliberately not used — long-lived sessions would
-    false-warn.
+    host-owned stamp predates the CURRENT SESSION'S LAUNCH
+    (`_last_core_launch_at`, from `state/session-starts.log`), the current
+    session never completed registration. Stamp AGE alone is deliberately not
+    used — long-lived sessions would false-warn.
+
+    The boundary is deliberately NOT `.alive.started_at`: that field tracks the
+    heartbeat writer, which is retained across launches, so restarting the
+    heartbeat under a live session made this probe report every still-registered
+    cron as gone. Same field, same mistake, same fix as #2446.
     """
     workspace = Path(workspace_dir or WORKSPACE_DIR)
     host = host_label or _host_label()
@@ -931,14 +936,28 @@ def check_session_cron_registration(
         # story); zero expected → nothing to verify.
         return {"name": name, "status": "ok", "detail": "no session-owned schedules expected"}
 
-    alive_file = workspace / "state" / "cores" / f"{host}.alive"
-    started_at = None
-    try:
-        alive = json.loads(alive_file.read_text())
-        if isinstance(alive, dict):
-            started_at = float(alive.get("started_at"))
-    except (OSError, ValueError, TypeError, json.JSONDecodeError):
-        pass  # no heartbeat → can't anchor to a boot; fall through to stamp-only
+    # The SESSION boundary, not the heartbeat's age. `.alive.started_at` is
+    # `core_heartbeat._STARTED_AT`, stamped once at module load, and both launch
+    # paths RETAIN an existing heartbeat process — so it tracks the heartbeat
+    # writer, not the session that owns the crons. #2446 established exactly that
+    # for `_marker_predates_running_core`, and `_last_core_launch_at` is the
+    # boundary it introduced; this probe was still comparing against the field
+    # that PR ruled out, for the same staleness question.
+    #
+    # Observed on Chis-Mac-mini 2026-08-04T03:0xZ, all nine expected crons live:
+    #     core      pid 30961  started 11:32:30   <- .alive "pid" (the core)
+    #     heartbeat pid 72981  started 16:13:56   <- .alive "heartbeat_pid"
+    #     .alive started_at    16:13:56           <- tracks the WRITER
+    #     stamp ts             11:37:21           <- 5 min after the core booted
+    # The stamp was written for this very boot and got reported as predating it
+    # by 16595s, telling the operator to re-run /schedule-crons against a session
+    # whose crons were all present.
+    #
+    # None keeps its meaning from #2446: "no evidence", never "stale" — so a host
+    # with no session-starts.log falls through to the stamp-only checks below
+    # rather than warning.
+    launch = _last_core_launch_at(workspace)
+    started_at = launch[0] if launch else None
 
     stamp_file = workspace / "hosts" / host / "schedule-crons-stamp.json"
     try:
@@ -963,7 +982,7 @@ def check_session_cron_registration(
             "name": name,
             "status": "warn",
             "detail": (
-                f"stamp predates this core boot ({int(started_at - stamp_ts)}s older) — "
+                f"stamp predates this session's launch ({int(started_at - stamp_ts)}s older) — "
                 f"session crons are gone with the old session; re-run /schedule-crons"
             ),
         }
@@ -3020,7 +3039,7 @@ def _local_host_labels() -> "set[str]":
     return {x for x in labels if x}
 
 
-def _last_core_launch_at() -> "tuple[float, str | None] | None":
+def _last_core_launch_at(workspace_dir: Optional[Path] = None) -> "tuple[float, str | None] | None":
     """When the CURRENT core was launched, from `state/session-starts.log`.
 
     Returns `(timestamp, runtime)`, where `runtime` is the identity the launcher
@@ -3060,7 +3079,7 @@ def _last_core_launch_at() -> "tuple[float, str | None] | None":
     "stale".
     """
     try:
-        raw = (status_read_path("session-starts.log", WORKSPACE_DIR)).read_text()
+        raw = (status_read_path("session-starts.log", workspace_dir or WORKSPACE_DIR)).read_text()
     except OSError:
         return None
     for line in reversed(raw.splitlines()):

--- a/tests/health-check-session-cron-stamp.test.py
+++ b/tests/health-check-session-cron-stamp.test.py
@@ -15,6 +15,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO = Path(__file__).resolve().parent.parent
 SCRIPT = REPO / "src" / "health-check.py"
@@ -32,7 +33,17 @@ SESSION_ENTRIES = [
 
 
 class SessionCronStampTest(unittest.TestCase):
-    def _workspace(self, root: Path, entries, stamp=None, started_at=None) -> Path:
+    def _workspace(self, root: Path, entries, stamp=None, started_at=None,
+                   alive_started_at=None) -> Path:
+        """`started_at` is the SESSION LAUNCH boundary and is written where the
+        probe now reads it: `state/session-starts.log`.
+
+        `alive_started_at` writes the heartbeat's `.alive` field INSTEAD, which
+        the probe must no longer consult — see
+        `test_alive_started_at_alone_does_not_warn`. Before this split the helper
+        wrote only `.alive`, so every case here silently exercised the wrong
+        source and the probe's real-world false alarm was unreachable in tests.
+        """
         workspace = root / "workspace"
         config = workspace / "hosts" / "test-host" / "crons.json"
         config.parent.mkdir(parents=True)
@@ -42,12 +53,25 @@ class SessionCronStampTest(unittest.TestCase):
         if stamp is not None:
             (config.parent / "schedule-crons-stamp.json").write_text(json.dumps(stamp))
         if started_at is not None:
+            (state / "session-starts.log").write_text(
+                json.dumps({"host": "test-host", "session_started_at": started_at}) + "\n"
+            )
+        if alive_started_at is not None:
             cores = state / "cores"
             cores.mkdir(exist_ok=True)
-            (cores / "test-host.alive").write_text(json.dumps({"started_at": started_at}))
+            (cores / "test-host.alive").write_text(
+                json.dumps({"started_at": alive_started_at})
+            )
         return workspace
 
     def _check(self, workspace, **kw):
+        # `_last_core_launch_at` skips launch records belonging to another host,
+        # so the fixture's label has to read as local or every boundary is None.
+        with mock.patch.object(health, "_local_host_labels",
+                               return_value={"test-host"}):
+            return self._check_unpatched(workspace, **kw)
+
+    def _check_unpatched(self, workspace, **kw):
         return health.check_session_cron_registration(
             workspace, host_label="test-host", runtime=kw.pop("runtime", "claude"), **kw
         )
@@ -84,7 +108,49 @@ class SessionCronStampTest(unittest.TestCase):
             )
             check = self._check(ws)
             self.assertEqual(check["status"], "warn")
-            self.assertIn("predates this core boot", check["detail"])
+            self.assertIn("predates this session's launch", check["detail"])
+
+    def test_alive_started_at_alone_does_not_warn(self):
+        """THE regression. `.alive.started_at` is the HEARTBEAT writer's age,
+        not the session's — both launch paths retain an existing heartbeat
+        process, so restarting it under a live session moved that field hours
+        forward while every cron stayed registered. Reading it as the boot
+        boundary reported all of them gone.
+
+        Observed on Chis-Mac-mini 2026-08-04 with all 9 expected crons live:
+        core pid 30961 up since 11:32:30, heartbeat pid 72981 restarted at
+        16:13:56, `.alive.started_at` = 16:13:56, stamp written 11:37:21 ->
+        "stamp predates this core boot (16595s older)".
+
+        Same field and same mistake as #2446, which established
+        `_last_core_launch_at` as the boundary for exactly this reason.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            ws = self._workspace(
+                Path(td), SESSION_ENTRIES,
+                stamp={"ts": 1000.0, "registered": 2},
+                alive_started_at=5000.0,   # heartbeat restarted AFTER the stamp
+            )                              # and NO session-starts.log
+            check = self._check(ws)
+            self.assertNotEqual(
+                check["status"], "warn",
+                f"a heartbeat restart must not read as a lost session: {check['detail']}")
+            self.assertNotIn("predates", check["detail"])
+
+    def test_session_launch_still_warns_when_both_are_present(self):
+        """Control for the case above: with a real launch record present, a
+        genuinely pre-launch stamp must still warn. Without this, the fix could
+        have disabled the check rather than corrected its input."""
+        with tempfile.TemporaryDirectory() as td:
+            ws = self._workspace(
+                Path(td), SESSION_ENTRIES,
+                stamp={"ts": 1000.0, "registered": 2},
+                started_at=5000.0,        # the authoritative boundary
+                alive_started_at=200.0,   # older heartbeat: must not soften it
+            )
+            check = self._check(ws)
+            self.assertEqual(check["status"], "warn")
+            self.assertIn("predates this session's launch", check["detail"])
 
     def test_fresh_stamp_ok(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## A standing warning that told the operator to fix a thing that wasn't broken

`check_session_cron_registration` (#2373) anchors its staleness comparison to `.alive.started_at`. That field is `core_heartbeat._STARTED_AT` — stamped once at module load — and **both launch paths retain an existing heartbeat process**, so it tracks the heartbeat *writer*, not the session that owns the crons. Restart the heartbeat under a live session and the boundary jumps forward, so a stamp written **for that same session** reads as predating it.

## `health-check.py` already knew this

`_marker_predates_running_core` says so in its own docstring:

> The heartbeat was the obvious candidate and is WRONG: `core_heartbeat.py` stamps `_STARTED_AT` once at module load and both launch paths RETAIN an existing heartbeat process, so `.alive.started_at` is the heartbeat process's age, not the session's. … which made the staleness comparison silently useless (john-the-dev, #2446).

#2446 introduced `_last_core_launch_at()` for exactly that reason. This probe was still comparing against the field that PR ruled out, for the same staleness question. **Same field, same mistake, same fix.**

## Live evidence

Measured on this host with all nine expected crons registered *and firing* (confirmed against `CronList`, not inferred):

```
core      pid 30961  started 11:32:30    <- .alive "pid" (the core)
heartbeat pid 72981  started 16:13:56    <- .alive "heartbeat_pid"
.alive started_at    16:13:56            <- tracks the WRITER
stamp ts             11:37:21            <- 5 min after the core booted
```

Before / after, same live workspace, same host label:

```
BEFORE  warn  stamp predates this core boot (16595s older) — session crons are
              gone with the old session; re-run /schedule-crons
AFTER   ok    9 session cron(s) stamped registered this boot
```

The stamp itself records `{"registered": 9, "config_total": 10}` — nine expected (the tenth is the DISABLED wire entry on `0 0 31 2 *`, excluded by the probe's own parked-and-unregistrable rule) and nine live.

**Why this is worse than noise:** the remedy it prescribes is to re-run `/schedule-crons` against a session whose crons are all present, and the skill documents a mid-session re-invocation inline-firing every entry (2026-06-03, which drowned a session and left owner DMs unprocessed).

## Changes

- Boundary comes from `_last_core_launch_at(workspace)`. `None` keeps its #2446 meaning — *"no evidence", never "stale"* — so a host without `session-starts.log` falls through to the stamp-only checks rather than warning.
- `_last_core_launch_at` gains an optional `workspace_dir` defaulting to the global, so the existing caller is untouched. Without it the probe's injected workspace could not reach the log and every fixture would read `None`.
- Message now says **"predates this session's launch"**. "core boot" was the ambiguity that made the wrong field look right.

## Tests

The fixture wrote **only** `.alive`, so every existing case exercised the wrong source — which is why a probe that misfires in production had a green suite. It now writes `state/session-starts.log` for the launch boundary, with `.alive` behind a separate argument so the regression can assert the field is no longer consulted.

```
parent  FAILED (failures=3)   <- both new cases + the message assertion
HEAD    Ran 22 tests, OK
```

Same test file at both commits; parent is a real worktree at `dab9c998`, not a synthesized tree.

`test_session_launch_still_warns_when_both_are_present` is the control: with a real launch record, a genuinely pre-launch stamp must **still** warn — otherwise this would have disabled the check rather than corrected its input. It fails on the parent too.

59 suites reference `health-check.py`; all 59 green. Added-line host-path scan clean (control fires on an injected `/Users/...`).

cc @sonichi @john-the-dev — John, this is the second consumer of the field #2446 ruled out; you may want to check whether any others remain.


---

## The file already knew this, for a different probe (added 2026-08-04)

The strongest argument for this change isn't the symptom — it's that **`health-check.py` already
documents `.alive.started_at` as the wrong anchor, and has since #2446**, while
`check_session_cron_registration` at :961 kept using it. From the same file, ~:3051:

> The heartbeat was the obvious candidate and is **WRONG**: `core_heartbeat.py` stamps `_STARTED_AT`
> once at module load and both launch paths RETAIN an existing heartbeat process, so
> `.alive.started_at` is the heartbeat process's age, not the session's. After a Codex → Claude
> switch it can be far older than a freshly-written marker, which made the staleness comparison
> silently useless (john-the-dev, #2446).

So one probe in this file learned the lesson and the other did not. **This PR makes the file
self-consistent with a rule it already states** — which is a merge argument that doesn't depend on
anyone reproducing a symptom.

Credit: john-the-dev established it in #2446; Sutando-Pro spotted that :961 had not adopted it.

## Confirmed on a second host, and it fails OPEN there

Pro measured the same probe on their host, where it reports **`ok`** — and the accepted-but-wrong
window is **59.6 hours wide**:

```
real boot (pane pid 6648)   2026-08-02T03:59:25Z
.alive started_at           2026-07-30T16:24:39Z   <- 59.6 h earlier
stamp                       2026-08-02T04:00:50Z   (85 s after the real boot)
.alive pid 83753 IS core_heartbeat.py, up 4d14h — it outlived the Aug-2 restart
```

Any stamp landing inside `boot − started_at` is accepted as "this boot" while actually predating it.
So on that host **a restart with no `/schedule-crons` re-run would report `ok` with the crons gone**,
for up to 59.6 h.

That is the direction that matters: on my host the wrong anchor is merely **noisy**; on Pro's it is
**inert**, in exactly the scenario #2373 built this probe to catch. Two hosts, opposite symptoms,
one root cause.
