### PR TITLE
fix(dm-result): tell the recipient when an attachment is blocked

### DIFF
--- a/src/dm-result.py
+++ b/src/dm-result.py
@@ -305,14 +305,44 @@ def send_dm(text: str) -> bool:
     sendable_files = [p for p in expanded_files if _is_path_sendable(p)]
     rejected_files = [p for p in expanded_files if not _is_path_sendable(p)]
     if rejected_files:
-        # Same security signal as discord-bridge: rejected paths log
-        # but don't leak the failure to the user.
         print(
             f"dm-result: {len(rejected_files)} file marker(s) rejected by "
             f"allowlist (would deliver via [file:] but path is outside "
             f"_SEND_ALLOWED_ROOTS / _SEND_ALLOWED_PREFIXES): {rejected_files}",
             file=sys.stderr,
         )
+
+    # Tell the RECIPIENT, not just the log. The comment that used to sit here
+    # claimed "same security signal as discord-bridge", and that parity did not
+    # exist: discord-bridge.py sends `(file not allowed: <path>)` into the
+    # channel, while this path logged to stderr only. So an attachment could
+    # silently never arrive — body delivered, task archived, nothing anywhere
+    # telling the recipient a file was meant to be there.
+    #
+    # Worst exactly here: dm-result is the REST FALLBACK, used when the live
+    # bridge is down, so its stderr is the least-watched output in the system.
+    #
+    # Split the same way discord-bridge does, because the two cases mean
+    # different things:
+    #   * path does not exist  -> almost always a `[file:/path]` substring
+    #     inside prose (a quoted example). discord-bridge logs it and
+    #     deliberately does NOT surface it; a notice here would fire on
+    #     ordinary text that merely mentions a path.
+    #   * path EXISTS but is outside the allowlist -> a real file the author
+    #     meant to attach and the policy refused. That one the recipient needs.
+    blocked = [p for p in rejected_files if os.path.isfile(p)]
+    if blocked:
+        # The path itself is NOT echoed. discord-bridge prints it, but a
+        # rejected marker is by definition outside the allowlist and could be
+        # attacker-chosen if a marker ever reaches a result body from untrusted
+        # input. The count plus the reason tells the recipient an attachment was
+        # dropped without echoing an arbitrary string back out; paths stay in
+        # stderr above.
+        plural = "" if len(blocked) == 1 else "s"
+        notice = ("_({} attachment{} not sent — outside the send allowlist; "
+                  "path{} in the dm-result log)_").format(
+                      len(blocked), plural, plural)
+        clean_text = f"{clean_text}\n\n{notice}" if clean_text else notice
 
     # An all-marker / all-whitespace body becomes empty after strip.
     # Sending `""` to Discord returns 400 ("Cannot send an empty

--- a/tests/dm-result-send-dm.test.py
+++ b/tests/dm-result-send-dm.test.py
@@ -359,6 +359,86 @@ def test_suite_never_appends_to_the_live_outbox_log(live, before):
     print("  OK: live outbox.log untouched; audit rows went to the redirect")
 
 
+def test_blocked_attachment_is_announced_to_the_recipient():
+    """A file that EXISTS but sits outside the allowlist must produce a
+    user-visible notice, not stderr alone.
+
+    dm-result is the REST FALLBACK — it runs when the live bridge is down — and
+    it used to log the rejection only, so the attachment silently never arrived:
+    body delivered, task archived, nothing telling the recipient a file was
+    meant to be there. discord-bridge.py has always sent
+    `(file not allowed: <path>)` into the channel; the comment here claimed
+    parity with it and did not have it.
+
+    The fixture file is REAL (tempfile), so a pass can only come from the
+    allowlist decision and never from "no such file" — which is the separate
+    branch asserted below.
+    """
+    import tempfile
+    fd, real_but_blocked = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    try:
+        transport = _FakeTransport({
+            ("POST", "/users/@me/channels"): {"id": "dm-6"},
+            ("POST", "/channels/dm-6/messages"): {"id": "msg-6"},
+        })
+        original_urlopen = dm.urllib.request.urlopen
+
+        def run():
+            _install_transport(transport)
+            try:
+                ok = dm.send_dm(f"Here you go: [file: {real_but_blocked}]")
+            finally:
+                _restore_transport(original_urlopen)
+            assert ok is True
+            msg_calls = [c for c in transport.calls if "/messages" in c["url"]]
+            assert len(msg_calls) == 1
+            body = msg_calls[0]["body"]["content"]
+            assert "not sent" in body, (
+                f"a blocked attachment must be announced; body was {body!r}")
+            assert "Here you go:" in body, "the real body must survive"
+            assert real_but_blocked not in body, (
+                "the rejected path must NOT be echoed back to the recipient")
+
+        _with_access_json(
+            {"allowFrom": ["human-id"], "tierMap": {"human-id": "owner"}}, run)
+    finally:
+        os.unlink(real_but_blocked)
+
+
+def test_missing_path_stays_silent_like_discord_bridge():
+    """The OTHER half of the parity, and the reason the notice is split.
+
+    A `[file:/path]` substring inside prose (a quoted example) resolves to no
+    file. discord-bridge logs those and deliberately does not surface them
+    (`elif not os.path.isfile(fpath)`), because a notice would then fire on
+    ordinary text that merely mentions a path. Without this case the fix would
+    look correct while making every prose mention of a path produce a spurious
+    "attachment not sent" line.
+    """
+    transport = _FakeTransport({
+        ("POST", "/users/@me/channels"): {"id": "dm-7"},
+        ("POST", "/channels/dm-7/messages"): {"id": "msg-7"},
+    })
+    original_urlopen = dm.urllib.request.urlopen
+
+    def run():
+        _install_transport(transport)
+        try:
+            ok = dm.send_dm("Use the marker like [file: /tmp/sutando-nope.png] to attach.")
+        finally:
+            _restore_transport(original_urlopen)
+        assert ok is True
+        msg_calls = [c for c in transport.calls if "/messages" in c["url"]]
+        assert len(msg_calls) == 1
+        body = msg_calls[0]["body"]["content"]
+        assert "not sent" not in body, (
+            f"a non-existent path is a prose quotation — no notice; got {body!r}")
+
+    _with_access_json(
+        {"allowFrom": ["human-id"], "tierMap": {"human-id": "owner"}}, run)
+
+
 def main():
     # Baseline taken before ANY test runs, so the final assertion covers every
     # send in this file — not just the ones the regression itself makes.
@@ -371,6 +451,8 @@ def main():
         test_file_markers_stripped_from_body()
         test_empty_body_after_marker_strip_does_not_post_messages()
         test_env_override_skips_access_json_entirely()
+        test_blocked_attachment_is_announced_to_the_recipient()
+        test_missing_path_stays_silent_like_discord_bridge()
 
     test_suite_never_appends_to_the_live_outbox_log(live, before)
     print("All send_dm integration tests passed.")


### PR DESCRIPTION
## The claim in the code was wrong

`src/dm-result.py` had this comment at the rejection site:

```python
# Same security signal as discord-bridge: rejected paths log
# but don't leak the failure to the user.
```

That parity does not exist. `src/discord-bridge.py:4589`:

```python
await channel.send(f"(file not allowed: {fpath})")
```

discord-bridge tells the channel. dm-result printed to stderr and stopped.

## Why it matters most in this file

`dm-result.py` is the **REST fallback** — it runs when the live WS bridge is down. Its stderr is the least-watched output in the system, so "logged it" means nobody finds out. The failure is completely silent from every angle available to the sender: body delivered, task archived, exit 0.

This is not hypothetical. On 2026-08-04 three videos were reported as sent through the sibling path and **none arrived**; it only surfaced by fetching the channel and reading `attachments`. The owner found it, not the agent.

## The change

Announce a blocked attachment in the message body — split the same way discord-bridge splits it, because the two rejection causes are different things:

| cause | discord-bridge | dm-result (before) | dm-result (after) |
| --- | --- | --- | --- |
| path does not exist | log only | stderr only | log only |
| path exists, outside allowlist | `(file not allowed: …)` **to channel** | stderr only | notice in body |

The missing-path half is load-bearing: a `[file:/path]` substring inside prose is a quoted example, and without that branch every ordinary sentence mentioning a path would produce a spurious "attachment not sent" line.

**The path is not echoed back.** discord-bridge prints it, but a rejected marker is by definition outside the allowlist and could be attacker-chosen if a marker ever reaches a result body from untrusted input. The count and the reason convey the loss; full paths stay in stderr.

## Evidence

The two regressions are a **pair on purpose** — the fixture in the first is a real `tempfile`, so a pass can only come from the allowlist decision and never from "no such file", which is exactly what the second asserts stays silent.

At the parent:
```
$ git stash push src/dm-result.py && python3 tests/dm-result-send-dm.test.py
AssertionError: a blocked attachment must be announced; body was 'Here you go:'
```

At HEAD, including all four pre-existing dm-result suites unchanged:
```
$ python3 tests/dm-result-send-dm.test.py
All send_dm integration tests passed.
$ python3 tests/dm-result-skip-markers.test.py     -> OK
$ python3 tests/dm-result-multipart-upload.test.py -> All dm-result multipart-upload tests passed.
$ python3 tests/dm-result-cli.test.py              -> passes
```

## Credit / relation to #2551

Found by Sutando-Mini while reviewing @marklysze's #2551. That PR drops dm-result's private regex in favour of the canonical parser, which **widens** what this path matches (relative paths, and paths containing a colon) — so it makes the silent branch reachable for strictly more inputs. This fix is independent of #2551 and makes that widening safe either way.

Related: #2596 (author-time guard for unsendable markers) and #2598 (size-limit rejections, also silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)