### PR TITLE
fix(health-check): a deliberate vault carve-out read as a broken backup

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1168,6 +1168,47 @@ def _carrier_probe_files(rep: "Path") -> "list[Path]":
     return sorted(f for f in rep.rglob("*") if f.is_file())
 
 
+# The one rule file the carrier set is written to. `check-ignore -v` reports
+# the deciding rule's SOURCE, and only rules from here speak to whether the
+# vault is carrying a path.
+CARRIER_EXCLUDE_SOURCE = ".git/info/exclude"
+
+
+def _carrier_carveout_patterns() -> "set[str]":
+    """Every gitignore pattern the generator emits that is SUPPOSED to ignore a
+    file inside a carried parent.
+
+    Two sources, both from `sync-workspace.sh:_compose_exclude_content`:
+
+      * `vault.sync.exclude` -> `_emit_exclude_lines` (`:371`): a trailing-slash
+        entry emits `path/` AND `path/**`; anything else is emitted verbatim.
+      * the unconditional hard-deny block (`:461-482`) — credentials, transient
+        state and secret material are denied "regardless of carrier set", so a
+        file caught by one of those is correctly not backed up.
+
+    Mirrored rather than parsed out of the live `.git/info/exclude`, because the
+    file on disk is the very artifact under test: reading the rules from it
+    would make any stale or hand-edited rule self-justifying, which is the
+    failure mode #2566 was opened for.
+    """
+    patterns = {
+        # Hard-deny block — keep in step with sync-workspace.sh:461-482.
+        ".env*", "*.heartbeat", "*.alive", "*.sentinel", "*.pid",
+        "id_rsa", "id_dsa", "id_ecdsa", "id_ed25519",
+        "*.pem", "*.key", "*.p12", "*.pfx", "*.ppk", "*.keystore", "*.jks",
+    }
+    for entry in ((_resolved_vault().get("sync") or {}).get("exclude") or []):
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        e = entry.strip()
+        if e.endswith("/"):
+            patterns.add(e)
+            patterns.add(e + "**")
+        else:
+            patterns.add(e)
+    return patterns
+
+
 def _carrier_target_verdict(workspace: Path, rep: Path) -> str:
     """`"carried"` | `"dropped"` | `"unmeasured"` for ONE materialized path.
 
@@ -1222,19 +1263,65 @@ def _carrier_target_verdict(workspace: Path, rep: Path) -> str:
     rels = "\0".join(str(t.relative_to(workspace)) for t in targets)
     try:
         proc = subprocess.run(
-            git_argv("-C", str(workspace), "check-ignore", "--no-index", "-z", "--stdin"),
+            git_argv("-C", str(workspace), "check-ignore", "--no-index", "-v", "-z", "--stdin"),
             input=rels, capture_output=True, text=True, timeout=60,
         )
     except (GitUnavailable, OSError, subprocess.SubprocessError):
         return "unmeasured"
-    # check-ignore's contract, unchanged by --stdin: 0 = at least one path is
-    # ignored, 1 = none are, anything else = it failed. Folding "not 0" into
-    # healthy would count exit 128 as carried.
-    if proc.returncode == 0:
+    # `-v` names the RULE that decided each path, and that is the whole point:
+    # "some file under here is ignored" is NOT the same question as "is this
+    # entry being carried". `vault.sync.exclude` deliberately ignores files
+    # INSIDE an included parent (`_emit_exclude_lines`, sync-workspace.sh:371),
+    # so on any real workspace the carve-outs fire constantly:
+    #
+    #     notes/    9970 of 11369 files ignored  (*.mp4, .DS_Store, node_modules/)
+    #     hosts/       9 of    67 files ignored  (data/)
+    #
+    # The pre-`-v` version condemned an entry when ANY file beneath it was
+    # ignored, so both read `dropped` while the vault was demonstrably backing
+    # them up (1400 and 58 files tracked, synced minutes earlier, zero diff).
+    # It survived because the one entry with no carve-out beneath it —
+    # `.claude-sutando/projects/*/memory/`, 1322 files, 0 ignored — passed, so
+    # the probe looked like it discriminated. The prescribed remedy made it
+    # permanent: `--force-gitignore` regenerates a byte-identical file (eight
+    # consecutive syncs logged `existing exclude matches; no-op`), so the
+    # failure could never clear no matter how often it was obeyed.
+    #
+    # NOTE `-v` also CHANGES THE EXIT-CODE CONTRACT the old code relied on: a
+    # path matching a negation (`!notes/**`, i.e. carried) is still reported and
+    # still exits 0. Verified before depending on it:
+    #
+    #     notes/a.md   -> !notes/**  exit 0   (NOT ignored)
+    #     notes/b.mp4  -> *.mp4      exit 0   (ignored, deliberately)
+    #     other/c.txt  -> *          exit 0   (ignored — genuinely dropped)
+    #
+    # So the verdict now comes from the parsed patterns; only a hard failure
+    # (neither 0 nor 1) is still read off the exit code.
+    if proc.returncode not in (0, 1):
+        return "unmeasured"
+    allowed = _carrier_carveout_patterns()
+    fields = proc.stdout.split("\0")
+    # Records are 4 NUL-separated fields: source, linenum, pattern, pathname.
+    for i in range(0, len(fields) - 3, 4):
+        source, pattern = fields[i], fields[i + 2]
+        if pattern.startswith("!"):
+            continue          # un-ignored by the carrier rule — carried
+        if source != CARRIER_EXCLUDE_SOURCE:
+            # A nested `.gitignore` committed inside a carried tree, or a global
+            # core.excludesFile. Not the vault carrier mechanism, so not this
+            # probe's question — and condemning on it would make every vendored
+            # project a permanent failure. Real instance: a Remotion app under
+            # `notes/` ignores its own `out/` build dir, which is correct.
+            continue
+        if pattern in allowed:
+            continue          # a configured carve-out — deliberate, not a defect
+        # Ignored by `.git/info/exclude` via something that is NOT a carve-out:
+        # either the whitelist catch-all `*` (this entry's un-ignore never took
+        # effect) or an operator-authored rule that `generate_exclude`'s refusal
+        # guard left standing because `_enforce_carrier_set_pre` swallows the
+        # refusal. Both mean the entry is genuinely not being backed up.
         return "dropped"
-    if proc.returncode == 1:
-        return "carried"
-    return "unmeasured"
+    return "carried"
 
 
 def _carrier_representative(workspace: Path, entry: str) -> "Path | None":

--- a/tests/health-check-carrier-set-enforced.test.py
+++ b/tests/health-check-carrier-set-enforced.test.py
@@ -46,7 +46,14 @@ def _load():
     return m
 
 
-def _mkworkspace(tmp: Path, carrier_lines: list[str], files: list[str]) -> Path:
+def _mkworkspace(tmp: Path, carrier_lines: list[str], files: list[str],
+                 extra_lines: "list[str] | None" = None,
+                 nested_ignores: "dict[str, str] | None" = None) -> Path:
+    """`extra_lines` are appended to `.git/info/exclude` VERBATIM (no `!`), which
+    is how the generator emits `vault.sync.exclude` carve-outs and the hard-deny
+    block. `nested_ignores` writes `.gitignore` files INSIDE the tree, the way a
+    vendored project committed under `notes/` carries its own rules.
+    """
     ws = tmp / "workspace"
     ws.mkdir(parents=True)
     subprocess.run(["git", "init", "-q", str(ws)], check=True, capture_output=True)
@@ -54,9 +61,17 @@ def _mkworkspace(tmp: Path, carrier_lines: list[str], files: list[str]) -> Path:
         f = ws / rel
         f.parent.mkdir(parents=True, exist_ok=True)
         f.write_text("x\n")
+    for rel, body in (nested_ignores or {}).items():
+        f = ws / rel
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(body)
     info = ws / ".git" / "info"
     info.mkdir(parents=True, exist_ok=True)
-    (info / "exclude").write_text(EXCLUDE_HEAD + "".join(f"!{l}\n" for l in carrier_lines))
+    (info / "exclude").write_text(
+        EXCLUDE_HEAD
+        + "".join(f"!{l}\n" for l in carrier_lines)
+        + "".join(f"{l}\n" for l in (extra_lines or []))
+    )
     return ws
 
 
@@ -69,8 +84,10 @@ class CarrierSetProbe(unittest.TestCase):
     def tearDown(self):
         self._tmp.cleanup()
 
-    def _patch_resolved(self, include: list[str]):
-        self.hc._resolved_vault = lambda: {"sync": {"include": include}}
+    def _patch_resolved(self, include: list[str], exclude: "list[str] | None" = None):
+        self.hc._resolved_vault = lambda: {
+            "sync": {"include": include, "exclude": exclude or []}
+        }
 
     def _patch_shipped(self, include: list[str]):
         root = self.tmp / "repo"
@@ -79,6 +96,105 @@ class CarrierSetProbe(unittest.TestCase):
             json.dumps({"vault": {"sync": {"include": include}}})
         )
         self.hc.REPO_DIR = root
+
+    # ---- carve-outs are DELIBERATE, not evidence of a broken backup --------
+    #
+    # The probe condemned an entry when ANY file beneath it was ignored. But
+    # `vault.sync.exclude` exists precisely to ignore files inside a carried
+    # parent, so on a real workspace it fires constantly:
+    #
+    #     notes/  9970 of 11369 files ignored (*.mp4, .DS_Store, node_modules/)
+    #     hosts/     9 of    67 files ignored (data/)
+    #
+    # Both read `dropped` while the vault was demonstrably carrying them —
+    # 1400 and 58 files tracked, synced minutes earlier, zero diff vs HEAD. The
+    # remedy it printed made the failure permanent: `--force-gitignore`
+    # regenerates a byte-identical file (eight consecutive syncs logged
+    # `existing exclude matches; no-op`), so obeying it changed nothing.
+    #
+    # It looked like it discriminated because the ONE entry with no carve-out
+    # beneath it — `.claude-sutando/projects/*/memory/`, 1322 files, 0 ignored —
+    # passed. A probe with exactly one passing case is not a validated probe.
+
+    def test_a_carve_out_file_does_not_condemn_the_entry_carrying_it(self):
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
+                          ["notes/a.md", "notes/talk.mp4"],
+                          extra_lines=["*.mp4"])
+        self._patch_resolved(["notes/"], exclude=["*.mp4"])
+        self._patch_shipped(["notes/"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "ok", f"carve-out read as data loss: {r['detail']}")
+
+    def test_a_carve_out_DIRECTORY_does_not_condemn_the_entry(self):
+        # `data/` emits `data/` AND `data/**` — the shape that condemned
+        # `hosts/` on the reporting host via `hosts/<h>/data/*.jsonl`.
+        ws = _mkworkspace(self.tmp, ["hosts/", "hosts/**"],
+                          ["hosts/h/pending-questions.md", "hosts/h/data/voice.jsonl"],
+                          extra_lines=["data/", "data/**"])
+        self._patch_resolved(["hosts/"], exclude=["data/"])
+        self._patch_shipped(["hosts/"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "ok", f"carve-out dir read as data loss: {r['detail']}")
+
+    def test_a_hard_denied_credential_does_not_condemn_the_entry(self):
+        # The hard-deny block is unconditional ("regardless of carrier set"), so
+        # a key under a carried path is correctly not backed up — and must not be
+        # reported as the carrier set failing.
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
+                          ["notes/a.md", "notes/id_rsa"],
+                          extra_lines=["id_rsa"])
+        self._patch_resolved(["notes/"], exclude=[])
+        self._patch_shipped(["notes/"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "ok", f"hard-deny read as data loss: {r['detail']}")
+
+    def test_a_nested_gitignore_inside_a_carried_tree_does_not_condemn_it(self):
+        # A vendored project committed under `notes/` ignoring its own build
+        # output. Real instance: a Remotion app whose `.gitignore` names `out/`.
+        # That is git working normally, not the vault carrier failing — and
+        # condemning on it would make every vendored project a permanent FAIL.
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
+                          ["notes/a.md", "notes/app/out/bundle.js"],
+                          nested_ignores={"notes/app/.gitignore": "out/\n"})
+        self._patch_resolved(["notes/"], exclude=[])
+        self._patch_shipped(["notes/"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "ok", f"nested .gitignore read as data loss: {r['detail']}")
+
+    def test_an_operator_added_rule_in_the_exclude_STILL_condemns(self):
+        # The other direction, and the reason this cannot just skip every
+        # non-`*` pattern. `generate_exclude` refuses to overwrite an
+        # operator-edited exclude and `_enforce_carrier_set_pre` swallows the
+        # refusal, so a hand-added rule blocking a carried file survives
+        # silently. It is not in `vault.sync.exclude`, so it must still fail.
+        ws = _mkworkspace(self.tmp, ["notes/", "notes/**"],
+                          ["notes/a.md", "notes/secret.md"],
+                          extra_lines=["notes/secret.md"])
+        self._patch_resolved(["notes/"], exclude=["*.mp4"])
+        self._patch_shipped(["notes/"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "fail",
+                         "an operator-authored block must still be reported")
+        self.assertIn("--force-gitignore", r["detail"])
+
+    def test_carve_out_tolerance_does_not_mask_a_genuinely_stale_exclude(self):
+        # The guard against fixing a false alarm by making the probe agreeable:
+        # carve-outs present AND the carrier rule missing must still be `fail`.
+        # `!notes/` alone un-ignores the directory but not its contents.
+        ws = _mkworkspace(self.tmp, ["notes/"],
+                          ["notes/a.md", "notes/talk.mp4"],
+                          extra_lines=["*.mp4"])
+        self._patch_resolved(["notes/"], exclude=["*.mp4"])
+        self._patch_shipped(["notes/"])
+        r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["status"], "fail",
+                         "a stale carrier rule must still be caught when carve-outs exist")
 
     def test_a_configured_path_that_git_still_ignores_is_REPORTED(self):
         # THE REGRESSION. Config lists state/current-track.md; the on-disk
@@ -232,8 +348,11 @@ class CarrierSetProbe(unittest.TestCase):
         self._patch_shipped(["notes/", "state/current-track.md"])
         class R:
             returncode = 128
-            stdout = b""
-            stderr = b"fatal: not a git repository"
+            # str, not bytes: the probe runs git with text=True. These stubs said
+            # bytes and passed only because nothing read stdout until the probe
+            # started parsing `check-ignore -v` output.
+            stdout = ""
+            stderr = "fatal: not a git repository"
         self._with_run(lambda *a, **k: R())
         r = self.hc.check_carrier_set_enforced(workspace_dir=ws)
         self.assertIsNotNone(r)
@@ -252,8 +371,8 @@ class CarrierSetProbe(unittest.TestCase):
         seen = []
         class R:
             returncode = 1
-            stdout = b""
-            stderr = b""
+            stdout = ""     # text=True — see the note on the stub above
+            stderr = ""
         def spy(argv, *a, **k):
             seen.append(list(argv))
             return R()


### PR DESCRIPTION
## The bug

`carrier-set` condemns a carrier entry when **any** file beneath it is git-ignored. But `vault.sync.exclude` exists precisely to ignore files *inside* a carried parent (`sync-workspace.sh:_emit_exclude_lines`), so on a real workspace the carve-outs fire constantly:

```
notes/   9970 of 11369 files ignored   (*.mp4, .DS_Store, node_modules/)
hosts/      9 of    67 files ignored   (data/)
```

Both report `fail` — while the vault is demonstrably backing them up.

## Before (at the parent, `dab9c998`)

```
✗ carrier-set  fail  2 configured carrier path(s) are STILL GIT-IGNORED so the vault is not
                     backing them up (notes/, hosts/) — the exclude file is stale and sync
                     refused to regenerate it; fix with `bash scripts/sync-workspace.sh
                     --force-gitignore`
   notes/                              -> dropped
   hosts/                              -> dropped
   .claude-sutando/projects/*/memory/  -> carried,carried,carried
```

**Every claim in that line is false**, checked against the vault rather than argued:

```
$ git -C <workspace> ls-tree -r --name-only HEAD -- notes | wc -l     1400
$ git -C <workspace> ls-tree -r --name-only HEAD -- hosts | wc -l       58
$ git -C <workspace> log -1 --format='%h %ad' -- hosts/<h>/pending-questions.md
  c3e67671 2026-08-03 21:07:18 -0700
$ git -C <workspace> diff --stat HEAD -- hosts/<h>/pending-questions.md
  (empty — no drift)
```

And the exclude file is **not** stale, so the remedy it names is a no-op:

```
$ grep generate_exclude $TMPDIR/sync-workspace.log | tail -3
[2026-08-03 20:52:15] generate_exclude: existing …/.git/info/exclude matches; no-op
[2026-08-03 20:54:55] generate_exclude: existing …/.git/info/exclude matches; no-op
[2026-08-03 21:07:18] generate_exclude: existing …/.git/info/exclude matches; no-op
```

`--force-gitignore` regenerates a byte-identical file, so **obeying the instruction can never clear the failure**. It is a permanent false FAIL that also pushes the operator toward a destructive-looking command for no reason.

## Why it survived three prior rounds (#2566, #2570, #2576)

The one entry with no carve-out beneath it — `.claude-sutando/projects/*/memory/`, 1322 files, 0 ignored — passes. So the probe *appeared* to discriminate. A probe with exactly one passing case is not a validated probe.

## After (this branch)

```
✓ carrier-set  ok    all 3 configured carrier path(s) un-ignored in the vault
   notes/                              -> carried
   hosts/                              -> carried
   .claude-sutando/projects/*/memory/  -> carried,carried,carried
```

## The fix

Ask `check-ignore -v` for the rule that **decided** each path, and condemn only when that rule
- comes from `.git/info/exclude` (the carrier mechanism), **and**
- is not a negation, not a configured carve-out, and not a hard-deny.

Two things this turned up that the reported symptom did not contain:

1. **A nested `.gitignore` committed inside a carried tree also condemned the entry.** A Remotion app under `notes/` ignores its own `out/` (12 files). That is git working normally; condemning on it would make every vendored project a permanent FAIL. Hence the source-file check, not just the pattern check.
2. **`-v` silently changes the exit-code contract the old code read.** A path matching a *negation* — i.e. carried — is still reported and still exits 0:

```
notes/a.md   -> !notes/**  exit 0   (NOT ignored)
notes/b.mp4  -> *.mp4      exit 0   (ignored, deliberately)
other/c.txt  -> *          exit 0   (ignored — genuinely dropped)
```

So the verdict now comes from the parsed patterns; only a hard failure (neither 0 nor 1) is still read off the exit code. Verified before depending on it rather than assumed.

Carve-out patterns are **mirrored** from `vault.sync.exclude` + the hard-deny block rather than parsed out of the live exclude file — that file is the artifact under test, and reading the rules from it would make a stale or hand-edited rule self-justifying, which is the failure #2566 was opened for.

## Tests

6 new cases in `tests/health-check-carrier-set-enforced.test.py`. Run at the parent commit, carrying this branch's test file:

```
test_a_carve_out_file_does_not_condemn_the_entry_carrying_it ... FAIL
test_a_carve_out_DIRECTORY_does_not_condemn_the_entry        ... FAIL
test_a_hard_denied_credential_does_not_condemn_the_entry     ... FAIL
test_a_nested_gitignore_inside_a_carried_tree_...            ... FAIL
test_an_operator_added_rule_in_the_exclude_STILL_condemns    ... ok
test_carve_out_tolerance_does_not_mask_a_genuinely_stale_... ... ok
Ran 45 tests — FAILED (failures=4)
```

At HEAD: `Ran 45 tests ... OK`.

The last two pass in **both** directions on purpose — they are the guard that this fix is a narrower question, not a softer one. An operator-authored rule in the exclude file (which `generate_exclude`'s refusal guard leaves standing because `_enforce_carrier_set_pre` swallows the refusal) still fails, and a genuinely stale carrier rule still fails *even when carve-outs are present*.

One incidental fix: two `subprocess.run` stubs declared `stdout = b""` while the probe runs git with `text=True`. They passed only because nothing read stdout until now.

@sonichi
