### PR TITLE
fix(vault): retire the shared flat anchor path from the shipped carrier set

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -1084,7 +1084,16 @@ _resolve_conflicts_keep_ours() {
 # add ITS OWN `hosts/<label>/current-track.md`, which is not the puller's anchor.
 # The guarantee therefore has to be local and to run BEFORE the fetch/merge —
 # each host rescues its own copy. Same placement and contract as
-# `_migrate_flat_branch` above. Idempotent: a no-op once the per-host file
+# `_migrate_flat_branch` above.
+#
+# Called from BOTH entry points, and the reason is worth stating because the
+# pull-side rationale above does not imply it. The hazard is not the merge; it
+# is `_enforce_carrier_set_pre`, which untracks newly-excluded files and lets
+# the caller commit that deletion. `--push-only` runs that enforcement without
+# ever passing through `_pull_only_impl`, so a pull-only call site leaves the
+# explicit push mode able to delete the sole carried copy of an anchor it never
+# replaced. Idempotent, so calling it twice in the default bidirectional path
+# costs one `[ -e ]`. Idempotent: a no-op once the per-host file
 # exists, so it costs one `[ -e ]` per tick thereafter.
 _migrate_flat_anchor() {
     local _flat _dest
@@ -1280,6 +1289,14 @@ _push_only_impl() {
     # access.json) into hosts/<host>/ before staging, so it's carried + survives
     # a rebuild. Non-fatal: never blocks the push.
     _snapshot_per_host_config || color_warn "sync-workspace: per-host config snapshot failed (non-fatal); push continues"
+    # Rescue this host's anchor BEFORE carrier enforcement can untrack it
+    # (#2567/#2607). `--push-only` never reaches `_pull_only_impl`, so without
+    # this call the enforcement below regenerates the exclude, untracks the
+    # now-uncarried flat `state/current-track.md`, and COMMITS that deletion —
+    # on a host whose anchor exists only at the flat path that removes the sole
+    # carried copy and writes no replacement. Pull-side placement alone is not
+    # enough: the hazard is carrier enforcement, and both entry points run it.
+    _migrate_flat_anchor
     _enforce_carrier_set_pre
     git add -A
     _refuse_staged_secrets

--- a/sutando.config.json
+++ b/sutando.config.json
@@ -28,8 +28,7 @@
       "include": [
         "notes/",
         "hosts/*/",
-        ".claude-sutando/projects/*/memory/",
-        "state/current-track.md"
+        ".claude-sutando/projects/*/memory/"
       ],
       "exclude": [
         "tasks/",

--- a/tests/sync-workspace-anchor-migration.test.sh
+++ b/tests/sync-workspace-anchor-migration.test.sh
@@ -92,12 +92,36 @@ git init -q "$PO_REPO"; git init -q --bare "$PO_VAULT"
 printf '{"workspace": {"path": "%s"}}\n' "$PO_WS" > "$PO_REPO/sutando.config.local.json"
 # Pre-#2607 world: the anchor exists ONLY at the flat path, and no per-host copy.
 printf 'the only anchor\n' > "$PO_WS/state/current-track.md"
-PO_ENV=(SUTANDO_HOST_OVERRIDE=pushonly-host SUTANDO_WS_ID_OVERRIDE=po1
+# Set the PRIMARY var, not the legacy SUTANDO_HOST_OVERRIDE alias. Both are
+# honored (util_paths.py:113), so the alias is not dead — but it is LOWER
+# precedence, and this harness inherits the caller's environment. A shell that
+# already exports SUTANDO_HOST_LABEL (a real core session does) silently
+# outranks the alias we set here, so the fixture builds under the developer's
+# own host label instead of `pushonly-host` and the assertions below then look
+# like the FIX failing. Diagnosed by Sutando-Pro 2026-08-04, whose session
+# exported SUTANDO_HOST_LABEL=Chis-MacBook-Pro. Setting the top-precedence name
+# explicitly makes the fixture immune to whatever the caller exports.
+PO_ENV=(SUTANDO_HOST_LABEL=pushonly-host SUTANDO_WS_ID_OVERRIDE=po1
         SUTANDO_SYNC_LOCK_DIR="$PO_ROOT/lock"
         GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@e GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@e)
-env "${PO_ENV[@]}" bash "$PO_REPO/scripts/sync-workspace.sh" \
-    --vault-url "$PO_VAULT" --init >/dev/null 2>&1 || true
-env "${PO_ENV[@]}" bash "$PO_REPO/scripts/sync-workspace.sh" --push-only >/dev/null 2>&1 || true
+
+# SETUP FAILURES MUST BE LOUD. These two commands build the fixture the three
+# assertions below measure; when they were `>/dev/null 2>&1 || true` a broken
+# setup was indistinguishable from a broken FIX, and the assertions reported
+# "the anchor was not carried" — which reads as the change under test failing.
+# That cost a reviewer an hour on 2026-08-04. Capture and surface instead.
+_po_run() {  # $1 = label, rest = args to sync-workspace.sh
+    local _label="$1"; shift
+    local _out _rc
+    _out=$(env "${PO_ENV[@]}" bash "$PO_REPO/scripts/sync-workspace.sh" "$@" 2>&1); _rc=$?
+    if [ "$_rc" -ne 0 ]; then
+        echo "FAIL: push-only fixture setup ($_label) exited $_rc — the assertions below measure a fixture that was never built:"
+        printf '%s\n' "$_out" | sed 's/^/      /'
+        fail=$((fail+1))
+    fi
+}
+_po_run "--init" --vault-url "$PO_VAULT" --init
+_po_run "--push-only" --push-only
 
 chk "push-only wrote the per-host anchor on disk" \
     "[ -f '$PO_WS/hosts/pushonly-host/current-track.md' ]"

--- a/tests/sync-workspace-anchor-migration.test.sh
+++ b/tests/sync-workspace-anchor-migration.test.sh
@@ -72,3 +72,45 @@ ref "without the helper, no per-host copy exists after the deletion" \
     "[ -f '$WS2/hosts/test-host/current-track.md' ]"
 
 echo; echo "Total: $((pass+fail)) — pass: $pass, fail: $fail"; [ "$fail" -eq 0 ]
+
+# --- PHASE 2 REGRESSION (#2607, qingyun-wu review): --push-only must migrate too.
+#     `_migrate_flat_anchor` was called only from `_pull_only_impl`, but the hazard
+#     is `_enforce_carrier_set_pre` — which `--push-only` also runs. On a host whose
+#     anchor exists ONLY at the flat path, push-only untracked and committed the
+#     deletion and wrote no replacement: the sole carried copy, gone.
+#     Drives the REAL script end to end rather than calling the helper, because a
+#     direct-call test is what missed this the first time.
+PO_ROOT="$(mktemp -d -t anchor-pushonly.XXXXXX)"
+PO_REPO="$PO_ROOT/repo"; PO_WS="$PO_ROOT/ws"; PO_VAULT="$PO_ROOT/v.git"
+mkdir -p "$PO_REPO/scripts" "$PO_REPO/src" "$PO_WS/state" "$PO_REPO/skills"
+cp "$REPO/scripts/sync-workspace.sh" "$PO_REPO/scripts/"
+cp "$REPO/scripts/sutando-config.sh" "$PO_REPO/scripts/"
+cp "$REPO/src/sutando_config.py"     "$PO_REPO/src/"
+cp "$REPO/sutando.config.json"       "$PO_REPO/"
+touch "$PO_REPO/CLAUDE.md"
+git init -q "$PO_REPO"; git init -q --bare "$PO_VAULT"
+printf '{"workspace": {"path": "%s"}}\n' "$PO_WS" > "$PO_REPO/sutando.config.local.json"
+# Pre-#2607 world: the anchor exists ONLY at the flat path, and no per-host copy.
+printf 'the only anchor\n' > "$PO_WS/state/current-track.md"
+PO_ENV=(SUTANDO_HOST_OVERRIDE=pushonly-host SUTANDO_WS_ID_OVERRIDE=po1
+        SUTANDO_SYNC_LOCK_DIR="$PO_ROOT/lock"
+        GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@e GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@e)
+env "${PO_ENV[@]}" bash "$PO_REPO/scripts/sync-workspace.sh" \
+    --vault-url "$PO_VAULT" --init >/dev/null 2>&1 || true
+env "${PO_ENV[@]}" bash "$PO_REPO/scripts/sync-workspace.sh" --push-only >/dev/null 2>&1 || true
+
+chk "push-only wrote the per-host anchor on disk" \
+    "[ -f '$PO_WS/hosts/pushonly-host/current-track.md' ]"
+chk "push-only CARRIED the per-host anchor (this is the durability claim)" \
+    "git -C '$PO_WS' ls-files --error-unmatch hosts/pushonly-host/current-track.md"
+chk "the rescued copy has the original content, not an empty placeholder" \
+    "grep -qFx 'the only anchor' '$PO_WS/hosts/pushonly-host/current-track.md'"
+# Control: the flat path is genuinely retired by this PR, so the test above is
+# proving a RESCUE and not merely that nothing changed.
+ref "flat state/current-track.md is no longer carried" \
+    "git -C '$PO_WS' ls-files --error-unmatch state/current-track.md"
+rm -rf "$PO_ROOT"
+
+echo
+echo "Total: $((pass + fail)) — pass: $pass, fail: $fail"
+[ "$fail" -eq 0 ]

--- a/tests/vault-carrier-default-current-track.test.sh
+++ b/tests/vault-carrier-default-current-track.test.sh
@@ -1,25 +1,35 @@
 #!/usr/bin/env bash
-# Regression: the SHIPPED default carrier set must carry state/current-track.md,
-# and must NOT thereby carry its transient state/ siblings.
+# Regression: the SHIPPED default carrier set must back up each host's anchor at
+# the PER-HOST path `hosts/<label>/current-track.md`, must NOT carry it at the
+# shared flat path `state/current-track.md`, and must NOT thereby carry its
+# transient `state/` siblings.
 #
-# Why this file exists, and why the two suites cited on the original PR were not
-# enough. `sync-workspace-foreign-host-guard.test.sh` builds its own fixture
-# `sutando.config.json`, and `sutando-config.test.py` exercises merge semantics
-# with synthetic dicts. Neither one reads the committed default, so deleting the
-# `state/current-track.md` entry from sutando.config.json leaves both suites
-# green while restoring the exact defect: the anchor that context-reconstruct
-# reads first every pass silently stops being backed up, and sync keeps
-# reporting success. A test that cannot fail when the fix is removed is not yet
-# a test.
+# This file used to assert the opposite direction — that the shipped default
+# lists `state/current-track.md`. That was right when it was written and is now
+# the defect. The flat path is not host-qualified while the file is per-host
+# state (its own first line names the host), so one host's anchor is delivered
+# onto another host at the identical local path. #2567/#2568 host-qualified it;
+# this is the carrier-set half of that migration.
+#
+# The PROTECTION is unchanged and is why this is a rewrite, not a deletion: the
+# anchor `context-reconstruct` reads first every pass must be backed up, and a
+# suite that goes green when that stops being true is not a test. Only the path
+# it is backed up AT has moved. `hosts/*/` was already in the shipped default,
+# so the anchor is carried before and after — measured on the live vault at the
+# time of this change: `hosts/Chis-Mac-mini/current-track.md` and
+# `hosts/Chis-MacBook-Pro/current-track.md` both TRACKED, `state/current-track.md`
+# tracked on 0 of 6 refs. The flat entry was carrying nothing.
 #
 # So this drives the SHIPPED config through the SHIPPED composer and asserts
 # both directions:
-#   positive — the entry is in the default list, and the generated rules
-#              un-ignore `state/` (ancestor) + `state/current-track.md` (file);
-#   negative — the rules do NOT contain `!state/**`, and transient siblings
+#   positive — `hosts/*/` is in the default list, the generated rules un-ignore
+#              `hosts/` (ancestor) + the per-host anchor, and git tracks it;
+#   negative — the flat `state/current-track.md` is NOT in the list, the rules
+#              do NOT un-ignore it or `state/**`, and transient siblings
 #              (core-status.json, voice-state.json, *.pid) stay untracked.
-# The negative half matters as much: widening this to `state/` would carry
-# per-run churn and secrets-adjacent files into the vault.
+# The negative half matters as much: re-adding the flat path resumes the
+# cross-host delivery, and widening to `state/` would carry per-run churn and
+# secrets-adjacent files into the vault.
 
 set -euo pipefail
 
@@ -57,11 +67,18 @@ refute() {
 # 1. The shipped default list itself. Read sutando.config.json directly — this
 #    is the assertion whose absence let the entry be removed silently.
 # ---------------------------------------------------------------------------
-check "shipped sutando.config.json lists state/current-track.md in vault.sync.include" \
+check "shipped sutando.config.json carries the per-host anchor dir (hosts/*/)" \
     python3 -c "
 import json, pathlib, sys
 inc = json.loads(pathlib.Path('$REPO/sutando.config.json').read_text())['vault']['sync']['include']
-sys.exit(0 if 'state/current-track.md' in inc else 1)
+sys.exit(0 if 'hosts/*/' in inc else 1)
+"
+
+check "...and does NOT carry the anchor at the shared flat state/current-track.md" \
+    python3 -c "
+import json, pathlib, sys
+inc = json.loads(pathlib.Path('$REPO/sutando.config.json').read_text())['vault']['sync']['include']
+sys.exit(1 if 'state/current-track.md' in inc else 0)
 "
 
 check "...and does NOT blanket-include state/ (which would carry transient churn)" \
@@ -92,8 +109,9 @@ git init -q "$FIXTURE_REPO"
 git init -q --bare "$FIXTURE_VAULT"
 
 # Point the workspace at the fixture and populate the discriminating files.
-mkdir -p "$FIXTURE_WS/state" "$FIXTURE_WS/notes"
-printf 'pinned track\n'  > "$FIXTURE_WS/state/current-track.md"
+mkdir -p "$FIXTURE_WS/state" "$FIXTURE_WS/notes" "$FIXTURE_WS/hosts/carrier-host"
+printf 'pinned track\n'  > "$FIXTURE_WS/hosts/carrier-host/current-track.md"
+printf 'stale flat\n'    > "$FIXTURE_WS/state/current-track.md"
 printf '{"status":"idle"}\n' > "$FIXTURE_WS/state/core-status.json"
 printf '{"v":1}\n'       > "$FIXTURE_WS/state/voice-state.json"
 printf '12345\n'         > "$FIXTURE_WS/state/watch-tasks-stream.pid"
@@ -119,9 +137,13 @@ env "${SYNC_ENV[@]}" bash "$SYNC" \
 
 RULES="$FIXTURE_WS/.git/info/exclude"
 
-check "generated rules un-ignore the state/ ancestor" \
-    grep -qFx '!state/' "$RULES"
-check "generated rules un-ignore state/current-track.md itself" \
+check "generated rules un-ignore the hosts/ ancestor" \
+    grep -qFx '!hosts/' "$RULES"
+check "generated rules un-ignore the per-host subtree (glob, not per-label)" \
+    grep -qFx '!hosts/*/' "$RULES"
+check "...including its contents, which is what carries the anchor file" \
+    grep -qFx '!hosts/*/**' "$RULES"
+refute "generated rules do NOT un-ignore the flat state/current-track.md" \
     grep -qFx '!state/current-track.md' "$RULES"
 refute "generated rules do NOT contain !state/** (would carry transient churn)" \
     grep -qFx '!state/**' "$RULES"
@@ -132,7 +154,9 @@ refute "generated rules do NOT contain !state/** (would carry transient churn)" 
 # ---------------------------------------------------------------------------
 git -C "$FIXTURE_WS" add -A >/dev/null 2>&1 || true
 
-check "git tracks state/current-track.md" \
+check "git tracks the PER-HOST anchor (the protection this file exists for)" \
+    git -C "$FIXTURE_WS" ls-files --error-unmatch hosts/carrier-host/current-track.md
+refute "git does NOT track the flat state/current-track.md" \
     git -C "$FIXTURE_WS" ls-files --error-unmatch state/current-track.md
 check "git tracks notes/ (default carrier set still intact)" \
     git -C "$FIXTURE_WS" ls-files --error-unmatch notes/a.md


### PR DESCRIPTION
Phase 2 of #2567 — the carrier-set half that #2568 assumed had already happened.

`state/current-track.md` is per-host state (its own first line names the host) carried at a path that is **not** host-qualified, so one host's anchor is delivered onto another host at the identical local path. #2568 host-qualified it to `hosts/<label>/current-track.md`. The shipped default still lists the flat path.

Three places in the tree already say this step is owed:

| where | text |
|---|---|
| `health-check.py` | *"Clears when phase 2 of #2567 drops the entry"* |
| `health-check.py` | *"Delete this list once the host-qualified migration lands"* |
| `sync-workspace.sh` | *"that path is removed from the carrier set **in this change**"* |

The last is load-bearing: `_migrate_flat_anchor` was written specifically to make this removal safe, and its comment describes the removal as already done. It never happened.

## This flips a purpose-built guard — so it is rewritten, not deleted

`tests/vault-carrier-default-current-track.test.sh` exists to assert the flat entry **is** in the shipped default, and its header says *"a test that cannot fail when the fix is removed is not yet a test"*. I take that seriously, which is why deleting it was not an option.

The protection it provides is **the anchor being backed up** — not the path it sits at. `hosts/*/` was already in the shipped default, so the anchor is carried before and after. The guard now asserts the same invariant at the correct path, and additionally pins that the flat path is *not* carried.

## Measured on the live vault, not argued

```
hosts/Chis-Mac-mini/current-track.md      TRACKED
hosts/Chis-MacBook-Pro/current-track.md   TRACKED
state/current-track.md                    tracked on 0 of 6 refs
full history of the flat path             2 commits — added, then removed
```

(The 0-of-6 is a full ref scan with a control: the same loop finds `hosts/` on 6 of 6, so the scan reaches.)

**The entry being removed is carrying nothing**, while the anchors it was meant to protect are already backed up at the per-host path. Nothing stops being backed up; a delivery hazard stops being shipped. And since no ref tracks the flat path, the deletion-propagation hazard `_migrate_flat_anchor` guards against cannot fire on this vault at all.

## Worst-case disruption (REVIEW.md lesson 5)

A host whose anchor exists **only** at the flat path would stop having it carried. `Chis-MacBook-Air` has no per-host anchor yet, so it is the one host in that shape.

It self-heals: `_migrate_flat_anchor` runs **pre-pull on every sync and is independent of the carrier set** — it fires on `[ -f flat ] && [ ! -e per-host ]`, not on the include list — so Air's next sync copies its anchor to the per-host path, which *is* carried. The flat file is untracked everywhere, so nothing deletes it in the meantime.

## Behaviour verified end to end

```
BEFORE  ⚠ carrier-set  3 configured carrier path(s) un-ignored; ... the shipped
                       default still lists it ... Clears when phase 2 of #2567
                       drops the entry
AFTER   ✓ carrier-set  all 3 configured carrier path(s) un-ignored
```

Run against the **live** workspace with `workspace.path` pinned — a worktree otherwise resolves to its own empty `workspace/` and reports clean regardless of the code.

## The rewritten guard cannot pass vacuously

Controlled in both directions:

```
HEAD                     14/14 pass
re-add the flat entry     3 FAIL   config, generated rule, and tracking
remove hosts/*/           5 FAIL   incl. "git tracks the PER-HOST anchor"
```

## Suites — all rc=0

```
tests/vault-carrier-default-current-track.test.sh   14/14
tests/sync-workspace-anchor-migration.test.sh        8/8
tests/sync-workspace-foreign-host-guard.test.sh     21/21
tests/health-check-carrier-set-enforced.test.py     rc=0
tests/sutando-config.test.py                        rc=0
```

## Follow-up, deliberately not bundled

`health-check.py`'s `UNSAFE_TO_READD` becomes dead once the flat path stops being shipped — its own comment says to delete it then. Five call sites, and removing it changes operator-facing message splitting, so it is a separate change and should land after #2605 to avoid churn in the same function.
