### PR TITLE
docs: delete the hardcoded lesson count rather than incrementing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ When you review a PR (including another agent's), you MUST follow `CONTRIBUTING.
 - Once a requested change is verified fixed, dismiss or replace the stale REQUEST_CHANGES state. If it remains, cite the exact unresolved behavior.
 - Merge only when the current head is mergeable, required CI + CLA are green, and two maintainers have recorded formal approvals. Never substitute a comment, bot recommendation, stale approval, or admin bypass.
 
-**Review criteria live in `REVIEW.md` (single source of truth).** Don't duplicate the 7 lessons here — read them from `REVIEW.md`. When you review, `review-preflight.py` reads `REVIEW.md` and prints the criteria inline so you see them on every preflight run; `scripts/review-checks.sh` runs the machine-readable `checks:` block (hardcoded-path scan) in CI; and Codex's managed GitHub-App reviewer reads `REVIEW.md` directly. Adding or editing a lesson is a PR to `REVIEW.md` only.
+**Review criteria live in `REVIEW.md` (single source of truth).** Don't duplicate the lessons here — read them from `REVIEW.md`. When you review, `review-preflight.py` reads `REVIEW.md` and prints the criteria inline so you see them on every preflight run; `scripts/review-checks.sh` runs the machine-readable `checks:` block (hardcoded-path scan) in CI; and Codex's managed GitHub-App reviewer reads `REVIEW.md` directly. Adding or editing a lesson is a PR to `REVIEW.md` only.
 
 ## Workspace contract
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ When you review a PR (including another agent's), you MUST follow `CONTRIBUTING.
 - Once a requested change is verified fixed, dismiss or replace the stale REQUEST_CHANGES state. If it remains, cite the exact unresolved behavior.
 - Merge only when the current head is mergeable, required CI + CLA are green, and two maintainers have recorded formal approvals. Never substitute a comment, bot recommendation, stale approval, or admin bypass.
 
-**Review criteria live in `REVIEW.md` (single source of truth).** Don't duplicate the 7 lessons here — read them from `REVIEW.md`. When you review, `review-preflight.py` reads `REVIEW.md` and prints the criteria inline so you see them on every preflight run; `scripts/review-checks.sh` runs the machine-readable `checks:` block (hardcoded-path scan) in CI; and Claude Code's managed GitHub-App reviewer reads `REVIEW.md` directly. Adding or editing a lesson is a PR to `REVIEW.md` only.
+**Review criteria live in `REVIEW.md` (single source of truth).** Don't duplicate the lessons here — read them from `REVIEW.md`. When you review, `review-preflight.py` reads `REVIEW.md` and prints the criteria inline so you see them on every preflight run; `scripts/review-checks.sh` runs the machine-readable `checks:` block (hardcoded-path scan) in CI; and Claude Code's managed GitHub-App reviewer reads `REVIEW.md` directly. Adding or editing a lesson is a PR to `REVIEW.md` only.
 
 ## Workspace contract
 


### PR DESCRIPTION
`CLAUDE.md:82` and `AGENTS.md:82` both say *"Don't duplicate the **7** lessons here"*. `main` has **8**. The number has been wrong since lesson 8 landed.

Incrementing it to 8 would be correct today and wrong at lesson 9 — which is not hypothetical, #2611 adds one. **A reference that cannot drift beats one that happens to be right**, so the count is removed rather than corrected.

## Why it's a separate PR

Split out of #2611 at @qingyun-wu's request. I had folded it in there because that PR takes the count from 8 to 9 — but the drift is **pre-existing**: 7-vs-8 predates that branch entirely, so "it belongs with the change that causes it" doesn't hold, and CONTRIBUTING's single-concern rule does.

## Scope

This does **not** touch the rule that lesson changes are *"a PR to `REVIEW.md` only"*. REVIEW.md stays the single source of truth and no lesson text lives outside it — this deletes a **count** that duplicated state REVIEW.md owns.

Both files edited identically so the mirror stays canonical. Verified rather than eyeballed:

```
scripts/agents-md-sync.sh --check   agents-md-sync: AGENTS.md is up to date
tests/agents-md-sync.test.py        rc=0
```

One note for anyone checking this by hand: a raw `diff` of line 82 between the two files reports a **mismatch**, and that is the wrong instrument — the residual difference is the intended Claude↔Codex substitution, because `AGENTS.md` is a *transformed* mirror, not a copy. Use the sync script.
