### PR TITLE
fix(tests): tofu-enroll overwrote the live owner-presence signal

### DIFF
--- a/tests/slack-bridge-tofu-enroll.test.py
+++ b/tests/slack-bridge-tofu-enroll.test.py
@@ -111,11 +111,36 @@ class _TempBridgeState:
         ws = Path(self._td) / "workspace"
         ws.mkdir()
         BRIDGE.WORKSPACE = str(ws)
+
+        # …and redirect the path write_owner_activity ACTUALLY writes.
+        #
+        # Two symbols, and only the second one matters. `STATE_DIR = REPO/"state"`
+        # (slack-bridge.py:98) is where you'd expect the write to resolve, but
+        # line 102 binds `OWNER_ACTIVITY_FILE = STATE_DIR / "last-owner-activity.json"`
+        # **at import time**, and :177/:179 write through that constant. Rebinding
+        # STATE_DIR afterwards does not retroactively re-derive it — so patching
+        # STATE_DIR alone leaves the write pointed at the operator's real file
+        # (bassilkhilo-ag2, #2615). Both are rebound here; STATE_DIR because
+        # `mkdir(parents=True)` in the writer uses it, OWNER_ACTIVITY_FILE because
+        # it is the destination.
+        #
+        # Why it matters: that file is the presence signal the proactive loop
+        # reads to decide whether the owner is mid-conversation. Stamping it with
+        # `ts: now` made an idle machine look like the owner had just messaged —
+        # observed live, and it put a loop pass into conversation mode before it
+        # was traced back here.
+        self._orig_state = BRIDGE.STATE_DIR
+        self._orig_owner_file = BRIDGE.OWNER_ACTIVITY_FILE
+        BRIDGE.STATE_DIR = Path(self._td) / "state"
+        BRIDGE.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        BRIDGE.OWNER_ACTIVITY_FILE = BRIDGE.STATE_DIR / "last-owner-activity.json"
         return self
 
     def __exit__(self, *_):
         BRIDGE.ACCESS_FILE = self._orig_access
         BRIDGE.TASKS_DIR = self._orig_tasks
+        BRIDGE.STATE_DIR = self._orig_state
+        BRIDGE.OWNER_ACTIVITY_FILE = self._orig_owner_file
         BRIDGE._TOFU_ENROLLMENT_CODE = None
 
 


### PR DESCRIPTION
## The bug

The test fixture tries to isolate and patches the wrong symbol:

```python
# Ensure the workspace path used by write_owner_activity exists.
ws = Path(self._td) / "workspace"
BRIDGE.WORKSPACE = str(ws)
```

`write_owner_activity` does not use `WORKSPACE`. It writes through **`STATE_DIR`** (`= REPO / "state"`, `src/slack-bridge.py:98`), which the override never touches. So every run of this test stamps the operator's real file:

```json
{"ts": <now>, "channel": "slack", "summary": "code keep42", "channel_id": "D_TEST"}
```

The comment is the trap — it asserts an isolation that isn't in place, so the file reads as already-handled.

## Why this one matters more than a stray fixture

`state/last-owner-activity.json` is the **presence signal the proactive loop reads every pass** to decide whether the owner is mid-conversation. Because the test stamps `ts: now`, a test run makes an idle machine look like the owner messaged seconds ago.

**Observed live, not hypothesised.** After a full-suite run, the loop read `owner: 5 min ago` and entered conversation mode. The owner had actually been away **93 minutes**; his real last message was `"Restart on mini"` at 21:46 PDT. The `D_TEST` channel id is what gave it away — no real Slack DM looks like that.

So the failure isn't cosmetic: it changes agent behaviour, and it does so in the direction of *suppressing* work, which is the quiet direction.

## Before / after

```
FIXED     All 7 TOFU enrollment gate tests passed
          live presence file: mtime unchanged, content unchanged

CONTROL   (origin/main, same command)
          live presence file REWRITTEN ->
          {"ts": 1785824568, "channel": "slack", "summary": "code keep42", "channel_id": "D_TEST"}
```

The fix redirects `STATE_DIR` alongside the existing overrides and restores it in `__exit__` with the others — `__exit__` previously restored `ACCESS_FILE` and `TASKS_DIR` but not this.

## Scope — and a gap in my own earlier sweep

I found this while widening the test-pollution search from #2612 and #2614. Both of those came from a sweep of `.claude-sutando/projects`, `hosts/` and `notes/` — **`state/` was never in that snapshot**, which is exactly why this one survived it. A negative is only as strong as the tree you looked at.

Re-running with `state/` included, against a measured live-churn control (6 files change with no tests running at all — heartbeats, `.alive`, gateway/services status), the test-attributable writes are:

```
state/last-owner-activity.json    <- slack-bridge-tofu-enroll   (this PR)
state/cron-notify-cooldown.json   <- cron-notify
state/outbox.log                  <- dm-result-send-dm
```

This PR fixes only the first — it is the one with a behavioural consequence, and the other two are separate concerns. I'll file the class separately rather than bundle them.

Tests-only change; no production code touched.

@sonichi
