### PR TITLE
fix(tests): cron-runner suite makes a real network POST per tick

### DIFF
--- a/tests/cron-runner.test.py
+++ b/tests/cron-runner.test.py
@@ -24,6 +24,30 @@ import tempfile
 import time
 from pathlib import Path
 
+# This suite drives the real `run()` tick, which emits cron telemetry via
+# `_emit_cron_telemetry` -> `task_processed(..., flush=True)`. The flush path is
+# a BLOCKING `urlopen` to the PostHog host, so without this every tick here
+# makes a real network request and the suite's timing becomes a function of an
+# external service. `test_run_acquires_shared_state_lock` gives the worker
+# `join(2)`; a tick measured at 0.72-0.82s against that 2s ceiling is a ~2x
+# margin, which holds on an idle laptop and intermittently does not on a shared
+# clean-install runner:
+#
+#   0.716s run()
+#    └─ 0.713s _emit_cron_telemetry
+#        └─ 0.678s urllib.request.urlopen        <- real network
+#
+# Opting out drops the tick to 0.001-0.002s (~1100x margin) and makes the suite
+# hermetic. `opted_out()` is re-read on every capture and never cached, so
+# setting it here covers every test in the file. Same lever, and the same
+# clean-install motivation, as agent-api-task-field-injection.test.py and
+# github-webhook-access-tier.test.py.
+#
+# The two tests that assert telemetry DOES fire are unaffected: one replaces
+# `telemetry.task_processed` wholesale, the other runs a subprocess against a
+# fake `telemetry.py` that never consults the opt-out.
+os.environ["SUTANDO_TELEMETRY"] = "0"
+
 REPO = Path(__file__).resolve().parent.parent
 _spec = importlib.util.spec_from_file_location("cron_runner", REPO / "src" / "cron-runner.py")
 assert _spec and _spec.loader


### PR DESCRIPTION
## What

`tests/cron-runner.test.py` drives the real `run()`, which emits cron telemetry via `_emit_cron_telemetry` → `task_processed(..., flush=True)`. The flush path is a **blocking `urlopen`** to the PostHog host, so every tick in this suite makes a real HTTPS request and the suite's timing becomes a function of an external service.

One line at module scope makes it hermetic.

## Why — the failure this causes

`test_run_acquires_shared_state_lock` gives the worker `join(2)`. cProfile on one tick:

```
0.716s run()
 └─ 0.713s _emit_cron_telemetry
     └─ 0.678s urllib.request.urlopen      <- real network, 94% of the tick
```

That is a **2.4x** margin against the 2s ceiling. It holds on an idle machine and intermittently does not on a contended clean-install runner. Seen on #2599's head as:

```
FAIL: run() completes once the shared lock is released
FAILED (1): run() completes once the shared lock is released
```

The tell that it is a timing failure and not a logic failure: the *next* assertion — that the tick still emitted its task file — **passed** in the same run. The work completed; it just didn't complete inside the window.

That PR touches no Python and nothing cron-related, which is what sent me looking here.

## Before / after

`run()` alone, 5 runs each. The env is toggled **after** importing the test module, so the BEFORE arm is exactly the pre-fix file:

| | `run()` | margin vs `join(2)` |
|---|---|---|
| before | 0.713–0.816s | **2.4x** |
| after | 0.001–0.001s | 1370.9x |

I could not force a deterministic failure locally — 40/40 on an idle laptop — which is the point: the variable is the runner, not the code. The defensible claim is the one above, that the tick's duration is dominated by an external HTTP call.

## Why this line, and why it is safe

`opted_out()` is re-read on every capture and never cached (deliberately — see its docstring), so setting it at module scope covers every test in the file.

The two tests that assert telemetry **does** fire are unaffected and still pass:
- `test_emit_task_emits_cron_telemetry` replaces `telemetry.task_processed` wholesale
- `test_cron_telemetry_survives_runner_exit` runs a subprocess against a fake `telemetry.py` that never consults the opt-out

This is the same lever, for the same clean-install reason, as `tests/agent-api-task-field-injection.test.py` and `tests/github-webhook-access-tier.test.py`. This file just never got the treatment.

## Verification

- `python3 tests/cron-runner.test.py` → **ALL PASSED**
- `test_run_acquires_shared_state_lock` in isolation → **30/30**
- `ruff check tests/cron-runner.test.py` → All checks passed
- `python3 scripts/review-checks.py` → clean · `git diff --check` → clean

## Scope

One line plus its explanation, in one test file. No production code. Deliberately not bundled into #2599, whose concern is python resolution.