### PR TITLE
fix(tests): reply-directive fixture wrote to the owner's live workspace

### DIFF
--- a/tests/discord-bridge-reply-directive.test.py
+++ b/tests/discord-bridge-reply-directive.test.py
@@ -341,13 +341,32 @@ def test_no_writes_reach_the_live_workspace(live_ws) -> int:
     """
     now = _workspace_fingerprint(live_ws)
     before = _LIVE_BASELINE
-    changed = sorted(k for k in now if before.get(k) != now[k])
-    if changed:
-        print(f"  \u2717 live workspace was written to \u2014 {len(changed)} path(s):", file=sys.stderr)
-        for c in changed[:8]:
-            print(f"      {c}", file=sys.stderr)
+
+    # Compare the UNION of keys. Iterating `now` alone cannot see a DELETION:
+    # a path in `before` and absent from `now` never comes up, so the loop
+    # finds nothing and the guard certifies "untouched".
+    #
+    # john-the-dev reproduced exactly that on #2619 \u2014 seed
+    # results/test-task-{a,b,c}.txt, drop RESULTS_DIR from the rebind, run:
+    # exit 0 and "live workspace untouched (0 paths compared)" while all three
+    # files were GONE. The `0` was the tell; it counted `now`, which was empty
+    # precisely BECAUSE everything had been deleted.
+    #
+    # Deletion of the owner's staged results is the worst case this guard
+    # exists for, so it is reported as its own category rather than folded in.
+    deleted = sorted(k for k in before if k not in now)
+    added = sorted(k for k in now if k not in before)
+    modified = sorted(k for k in (set(before) & set(now)) if before[k] != now[k])
+
+    if deleted or added or modified:
+        print(f"  \u2717 live workspace was written to \u2014 {len(deleted)} deleted, "
+              f"{len(modified)} modified, {len(added)} added:", file=sys.stderr)
+        for label, group in (("DELETED", deleted), ("MODIFIED", modified), ("ADDED", added)):
+            for c in group[:5]:
+                print(f"      {label}: {c}", file=sys.stderr)
         return 1
-    print(f"  \u2713 live workspace untouched ({len(now)} paths compared, whole tree)")
+    print(f"  \u2713 live workspace untouched "
+          f"({len(set(before) | set(now))} paths compared, union of before+after)")
     return 0
 
 

--- a/tests/discord-bridge-reply-directive.test.py
+++ b/tests/discord-bridge-reply-directive.test.py
@@ -93,57 +93,91 @@ def load_bridge():
 bridge = load_bridge()
 
 # Set by main() before any case runs; read by the live-workspace regression.
-_LIVE_BASELINE = (None, [])
+_LIVE_BASELINE = {}
 
 
 @contextlib.contextmanager
 def _bridge_writes_redirected():
     """Point every filesystem write this fixture triggers at a throwaway tree.
 
-    Three separate escapes, all to the OWNER's live workspace, and the old
-    comment at `_run_one_poll_iteration` ("RESULTS_DIR is shared with prod")
-    treated the first as acceptable rather than as the defect it is:
+    SIX escapes, all to the OWNER's live workspace, and the old comment at
+    `_run_one_poll_iteration` ("RESULTS_DIR is shared with prod") signed off on
+    the first as acceptable rather than treating it as the defect it is:
 
-      1. the staged result files             -> <workspace>/results/
-      2. `archive_file()` moving them        -> <workspace>/results/archive/<ym>/
-      3. `poll_results` -> outbox_log.append -> <workspace>/state/outbox.log
+      results/…                      staged result files
+      results/archive/<ym>/…         archive_file() moving them
+      state/outbox.log               poll_results -> outbox_log.append
+      state/result-audit.log         result_audit
+      state/discord-bridge.heartbeat the bridge's own heartbeat
+      logs/events-<date>.jsonl       event_log
 
-    (3) is the one that matters most: `state/outbox.log` is the delivery audit
-    log the dashboard's Outbox card shows the owner. Measured on this host
-    before the fix, the fixtures had been landing in the real log since
-    2026-05-28 — `discord_channel` rows whose `recipient` is `111222333` /
-    `444555666` / `777888999` rather than a Discord snowflake.
+    `state/outbox.log` is the one that matters most — the delivery audit log the
+    dashboard's Outbox card shows the owner. Measured on this host before the
+    fix, fixtures had been landing in the real log since 2026-05-28:
+    `discord_channel` rows whose `recipient` is `111222333` / `444555666` /
+    `777888999` rather than a Discord snowflake.
 
-    `outbox_log._outbox_path` is swapped rather than `resolve_workspace`
-    because `append()` re-resolves per call; the sibling fix in #2615 had to
-    rebind a constant instead because that one was bound at import. Which seam
-    works is a property of the module, so the regression proves it by exercise.
+    I found three of the six by fixing and re-measuring, not by reading — each
+    round the whole-tree regression named what the previous fix had missed.
+    That is why the redirect is now structural (patch the resolver everywhere it
+    is BOUND, plus the import-time constants) rather than an enumerated list of
+    the paths I happened to know about.
 
     Restores in a `finally` so a mid-run assertion cannot leave the globals
     patched for whatever runs next in the same interpreter (#2614).
     """
-    import outbox_log
+    import workspace_default
 
-    orig_results = bridge.RESULTS_DIR
-    orig_archive = bridge.ARCHIVE_RESULTS_DIR
-    orig_path = outbox_log._outbox_path
     tmp = Path(tempfile.mkdtemp(prefix="reply-directive-test-"))
-    redirected = tmp / "state" / "outbox.log"
-    redirected.parent.mkdir(parents=True, exist_ok=True)
-    bridge.RESULTS_DIR = tmp / "results"
-    bridge.RESULTS_DIR.mkdir(parents=True, exist_ok=True)
-    # `archive_file()` does NOT derive from RESULTS_DIR — `ARCHIVE_RESULTS_DIR`
-    # is its own module constant (discord-bridge.py:248), so redirecting only
-    # RESULTS_DIR moves the staging write and leaves the ARCHIVE write in the
-    # owner's tree. Caught by the regression below, not by reading the code.
-    bridge.ARCHIVE_RESULTS_DIR = tmp / "results" / "archive"
-    outbox_log._outbox_path = lambda: redirected
+    for sub in ("results", "state", "tasks", "logs"):
+        (tmp / sub).mkdir(parents=True, exist_ok=True)
+
+    # ONE patch covers every helper that resolves at CALL time — outbox_log,
+    # result_audit and event_log all call `resolve_workspace()` per write, so
+    # patching the resolver redirects all three and any future sibling. Chasing
+    # them individually is what let two of them slip: my first pass redirected
+    # RESULTS_DIR + outbox only, and `state/result-audit.log`,
+    # `state/discord-bridge.heartbeat` and `logs/events-*.jsonl` still escaped.
+    orig_resolve = workspace_default.resolve_workspace
+    _fake = lambda: tmp
+
+    # Patch the name in EVERY module that holds it, not just where it is defined.
+    # `from workspace_default import resolve_workspace` binds the function into
+    # the IMPORTER's namespace, so replacing `workspace_default.resolve_workspace`
+    # alone leaves every already-imported consumer pointing at the original.
+    # Measured: with only the source module patched, `state/result-audit.log` and
+    # `logs/events-*.jsonl` still escaped, because `result_audit` and `event_log`
+    # each hold their own binding. The whole-tree regression caught it; the
+    # enumerated one had not.
+    _patched = []
+    for _mod in list(sys.modules.values()):
+        if getattr(_mod, "resolve_workspace", None) is orig_resolve:
+            _patched.append(_mod)
+            _mod.resolve_workspace = _fake
+    workspace_default.resolve_workspace = _fake
+
+    # The bridge's own constants are computed AT IMPORT from `REPO`
+    # (discord-bridge.py:244-248, 3991, 4099, 4214), so patching the resolver
+    # cannot reach them — they must be rebound explicitly. This is the same
+    # import-time-vs-call-time split as #2615 vs #2618, in one file.
+    _consts = ("REPO", "TASKS_DIR", "RESULTS_DIR", "STATE_DIR",
+               "ARCHIVE_TASKS_DIR", "ARCHIVE_RESULTS_DIR",
+               "DM_CHECKPOINT_FILE", "DELIVERED_DIR", "PENDING_REPLIES_FILE")
+    saved = {}
+    for name in _consts:
+        if hasattr(bridge, name):
+            saved[name] = getattr(bridge, name)
+            rel = Path(str(saved[name])).relative_to(orig_resolve()) \
+                if str(saved[name]).startswith(str(orig_resolve())) else None
+            setattr(bridge, name, tmp / rel if rel is not None else tmp)
     try:
-        yield tmp, redirected
+        yield tmp, tmp / "state" / "outbox.log"
     finally:
-        bridge.RESULTS_DIR = orig_results
-        bridge.ARCHIVE_RESULTS_DIR = orig_archive
-        outbox_log._outbox_path = orig_path
+        workspace_default.resolve_workspace = orig_resolve
+        for _mod in _patched:
+            _mod.resolve_workspace = orig_resolve
+        for name, val in saved.items():
+            setattr(bridge, name, val)
         shutil.rmtree(tmp, ignore_errors=True)
 
 
@@ -261,6 +295,29 @@ def case_c_directive_only_first_chunk():
     return fails
 
 
+def _workspace_fingerprint(ws) -> dict:
+    """(size, mtime) for EVERY file under the workspace.
+
+    Deliberately whole-tree rather than an enumerated list of the directories
+    this fixture is known to touch. The first version of this regression
+    checked only `results/` and `state/outbox.log`, PASSED, and three writes
+    escaped anyway — `state/result-audit.log`, `state/discord-bridge.heartbeat`
+    and `logs/events-*.jsonl`. An assertion only catches what it looks at, so
+    it must look at everything.
+    """
+    out = {}
+    if not ws.is_dir():
+        return out
+    for f in ws.rglob("*"):
+        if f.is_file():
+            try:
+                st = f.stat()
+                out[str(f)] = (st.st_size, st.st_mtime)
+            except OSError:
+                pass
+    return out
+
+
 def test_no_writes_reach_the_live_workspace(live_ws) -> int:
     """THE regression: a run must not touch the owner's results/ or outbox log.
 
@@ -271,21 +328,15 @@ def test_no_writes_reach_the_live_workspace(live_ws) -> int:
     Asserts on the RESOLVED live workspace rather than a fixture path, because
     the defect was precisely that the fixture escaped to wherever that resolves.
     """
-    outbox = live_ws / "state" / "outbox.log"
-    results = live_ws / "results"
-    now_outbox = outbox.stat().st_size if outbox.is_file() else None
-    now_results = sorted(str(p) for p in results.rglob("*")) if results.is_dir() else []
-    before_outbox, before_results = _LIVE_BASELINE
-    bad = []
-    if now_outbox != before_outbox:
-        bad.append(f"outbox.log size {before_outbox} -> {now_outbox}")
-    new_files = set(now_results) - set(before_results)
-    if new_files:
-        bad.append(f"{len(new_files)} new file(s) under results/: {sorted(new_files)[:3]}")
-    if bad:
-        print("  \u2717 live workspace was written to: " + "; ".join(bad), file=sys.stderr)
+    now = _workspace_fingerprint(live_ws)
+    before = _LIVE_BASELINE
+    changed = sorted(k for k in now if before.get(k) != now[k])
+    if changed:
+        print(f"  \u2717 live workspace was written to \u2014 {len(changed)} path(s):", file=sys.stderr)
+        for c in changed[:8]:
+            print(f"      {c}", file=sys.stderr)
         return 1
-    print("  \u2713 live workspace untouched (results/ and state/outbox.log)")
+    print(f"  \u2713 live workspace untouched ({len(now)} paths compared, whole tree)")
     return 0
 
 
@@ -296,12 +347,7 @@ def main():
 
     global _LIVE_BASELINE
     live_ws = resolve_workspace()
-    _outbox = live_ws / "state" / "outbox.log"
-    _results = live_ws / "results"
-    _LIVE_BASELINE = (
-        _outbox.stat().st_size if _outbox.is_file() else None,
-        sorted(str(p) for p in _results.rglob("*")) if _results.is_dir() else [],
-    )
+    _LIVE_BASELINE = _workspace_fingerprint(live_ws)
 
     cases = [
         ("a-directive-present-constructs-reference", case_a_directive_present_constructs_reference),

--- a/tests/discord-bridge-reply-directive.test.py
+++ b/tests/discord-bridge-reply-directive.test.py
@@ -312,6 +312,33 @@ def case_c_directive_only_first_chunk():
     return fails
 
 
+def test_resolver_bindings_restored_after_the_context() -> int:
+    """Protect the late-import restore sweep with an activated assertion.
+
+    Raised on the sibling #2620 by john-the-dev and qingyun-wu: the sweep
+    works, but deleting it leaves the suite green while the lazily-imported
+    consumers stay bound to the throwaway stub and resolve into a REMOVED
+    temp tree. Same code shape here (`result_audit` and `event_log` are both
+    lazily imported), so the same assertion belongs here — added without
+    waiting to be told twice.
+    """
+    import workspace_default
+    bad = []
+    for name in ("outbox_log", "result_audit", "event_log"):
+        mod = sys.modules.get(name)
+        if mod is None:
+            continue
+        if getattr(mod, "resolve_workspace", None) is not workspace_default.resolve_workspace:
+            bad.append(name)
+    if bad:
+        print(f"  ✗ resolver binding NOT restored in: {', '.join(bad)} — later writes "
+              f"in this interpreter would land in a deleted throwaway tree", file=sys.stderr)
+        return 1
+    print("  ✓ resolver bindings restored after the context "
+          f"({len([n for n in ('outbox_log','result_audit','event_log') if n in sys.modules])} lazy consumers checked)")
+    return 0
+
+
 def _workspace_fingerprint(ws) -> dict:
     """(size, mtime) for EVERY file under the workspace.
 
@@ -426,6 +453,8 @@ def main():
             print(f"  ✓ observability event redirected into the throwaway tree "
                   f"({_events[0].name})")
 
+    if test_resolver_bindings_restored_after_the_context():
+        failures.append(("resolver-restored", "lazy consumer left bound to the stub"))
     if test_no_writes_reach_the_live_workspace(live_ws):
         failures.append(("live-workspace-untouched", "fixture escaped to the live workspace"))
 

--- a/tests/discord-bridge-reply-directive.test.py
+++ b/tests/discord-bridge-reply-directive.test.py
@@ -340,6 +340,64 @@ def test_no_writes_reach_the_live_workspace(live_ws) -> int:
     return 0
 
 
+def test_pre_existing_archive_files_are_not_overwritten() -> int:
+    """Collision case: the three fixture task ids are FIXED, so on a host this
+    PR is repairing the archive paths already exist with the owner's bytes.
+
+    Requested by john-the-dev on #2619 after showing that the first head's
+    name-only comparison certified "untouched" while all three hashes changed.
+    Their control was run by hand; this makes it permanent.
+
+    Runs entirely inside a throwaway "pretend live" workspace — seeding the real
+    one to test anti-pollution would itself be pollution — and asserts EXACT
+    BYTES rather than (size, mtime), because bytes are the property that matters
+    when the claim is "the owner's archived evidence survived".
+    """
+    import workspace_default
+
+    pretend = Path(tempfile.mkdtemp(prefix="reply-directive-collision-"))
+    arch = pretend / "results" / "archive" / "2026-08"
+    arch.mkdir(parents=True, exist_ok=True)
+    seeded = {
+        "test-task-a.txt": b"OWNER-A-original-archived-evidence",
+        "test-task-b.txt": b"OWNER-B",
+        "test-task-c.txt": b"OWNER-C-longer-original-evidence-block",
+    }
+    for name, blob in seeded.items():
+        (arch / name).write_bytes(blob)
+
+    orig_resolve = workspace_default.resolve_workspace
+    patched = [m for m in list(sys.modules.values())
+               if getattr(m, "resolve_workspace", None) is orig_resolve]
+    fake = lambda: pretend
+    for m in patched:
+        m.resolve_workspace = fake
+    workspace_default.resolve_workspace = fake
+    try:
+        with _bridge_writes_redirected():
+            for fn in (case_a_directive_present_constructs_reference,
+                       case_b_no_directive_no_reference,
+                       case_c_directive_only_first_chunk):
+                fn()
+        bad = []
+        for name, blob in seeded.items():
+            now = (arch / name).read_bytes() if (arch / name).is_file() else None
+            if now != blob:
+                bad.append(f"{name}: {len(blob)}B -> "
+                           f"{'MISSING' if now is None else str(len(now)) + 'B'}")
+        if bad:
+            print("  \u2717 pre-existing archive files were overwritten: " + "; ".join(bad),
+                  file=sys.stderr)
+            return 1
+        print("  \u2713 pre-existing archive files byte-identical (collision case)")
+        return 0
+    finally:
+        workspace_default.resolve_workspace = orig_resolve
+        for m in patched:
+            m.resolve_workspace = orig_resolve
+        shutil.rmtree(pretend, ignore_errors=True)
+
+
 def main():
     # Baseline BEFORE any case runs, so the final check covers every write this
     # file triggers — not just the ones the regression itself makes.
@@ -368,6 +426,8 @@ def main():
 
     if test_no_writes_reach_the_live_workspace(live_ws):
         failures.append(("live-workspace-untouched", "fixture escaped to the live workspace"))
+    if test_pre_existing_archive_files_are_not_overwritten():
+        failures.append(("archive-collision", "pre-existing archive files were overwritten"))
 
     if failures:
         print(f"\n{len(failures)} failure(s)")

--- a/tests/discord-bridge-reply-directive.test.py
+++ b/tests/discord-bridge-reply-directive.test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import importlib.util
+import hashlib
 import shutil
 import sys
 import tempfile
@@ -309,12 +310,22 @@ def _workspace_fingerprint(ws) -> dict:
     if not ws.is_dir():
         return out
     for f in ws.rglob("*"):
-        if f.is_file():
-            try:
+        if not f.is_file():
+            continue
+        try:
+            # CONTENT hash under results/ — that subtree holds the owner's
+            # archived task evidence, and the fixture task ids are FIXED
+            # (test-task-a/b/c), so a destructive OVERWRITE of an existing file
+            # is the realistic collision (john-the-dev, #2619). A same-size
+            # rewrite is exactly what a name-only or size-only check misses.
+            # (size, mtime) elsewhere keeps a whole-workspace scan cheap.
+            if "results" in f.parts:
+                out[str(f)] = ("sha", hashlib.sha256(f.read_bytes()).hexdigest())
+            else:
                 st = f.stat()
                 out[str(f)] = (st.st_size, st.st_mtime)
-            except OSError:
-                pass
+        except OSError:
+            pass
     return out
 
 
@@ -338,64 +349,6 @@ def test_no_writes_reach_the_live_workspace(live_ws) -> int:
         return 1
     print(f"  \u2713 live workspace untouched ({len(now)} paths compared, whole tree)")
     return 0
-
-
-def test_pre_existing_archive_files_are_not_overwritten() -> int:
-    """Collision case: the three fixture task ids are FIXED, so on a host this
-    PR is repairing the archive paths already exist with the owner's bytes.
-
-    Requested by john-the-dev on #2619 after showing that the first head's
-    name-only comparison certified "untouched" while all three hashes changed.
-    Their control was run by hand; this makes it permanent.
-
-    Runs entirely inside a throwaway "pretend live" workspace — seeding the real
-    one to test anti-pollution would itself be pollution — and asserts EXACT
-    BYTES rather than (size, mtime), because bytes are the property that matters
-    when the claim is "the owner's archived evidence survived".
-    """
-    import workspace_default
-
-    pretend = Path(tempfile.mkdtemp(prefix="reply-directive-collision-"))
-    arch = pretend / "results" / "archive" / "2026-08"
-    arch.mkdir(parents=True, exist_ok=True)
-    seeded = {
-        "test-task-a.txt": b"OWNER-A-original-archived-evidence",
-        "test-task-b.txt": b"OWNER-B",
-        "test-task-c.txt": b"OWNER-C-longer-original-evidence-block",
-    }
-    for name, blob in seeded.items():
-        (arch / name).write_bytes(blob)
-
-    orig_resolve = workspace_default.resolve_workspace
-    patched = [m for m in list(sys.modules.values())
-               if getattr(m, "resolve_workspace", None) is orig_resolve]
-    fake = lambda: pretend
-    for m in patched:
-        m.resolve_workspace = fake
-    workspace_default.resolve_workspace = fake
-    try:
-        with _bridge_writes_redirected():
-            for fn in (case_a_directive_present_constructs_reference,
-                       case_b_no_directive_no_reference,
-                       case_c_directive_only_first_chunk):
-                fn()
-        bad = []
-        for name, blob in seeded.items():
-            now = (arch / name).read_bytes() if (arch / name).is_file() else None
-            if now != blob:
-                bad.append(f"{name}: {len(blob)}B -> "
-                           f"{'MISSING' if now is None else str(len(now)) + 'B'}")
-        if bad:
-            print("  \u2717 pre-existing archive files were overwritten: " + "; ".join(bad),
-                  file=sys.stderr)
-            return 1
-        print("  \u2713 pre-existing archive files byte-identical (collision case)")
-        return 0
-    finally:
-        workspace_default.resolve_workspace = orig_resolve
-        for m in patched:
-            m.resolve_workspace = orig_resolve
-        shutil.rmtree(pretend, ignore_errors=True)
 
 
 def main():
@@ -426,8 +379,6 @@ def main():
 
     if test_no_writes_reach_the_live_workspace(live_ws):
         failures.append(("live-workspace-untouched", "fixture escaped to the live workspace"))
-    if test_pre_existing_archive_files_are_not_overwritten():
-        failures.append(("archive-collision", "pre-existing archive files were overwritten"))
 
     if failures:
         print(f"\n{len(failures)} failure(s)")

--- a/tests/discord-bridge-reply-directive.test.py
+++ b/tests/discord-bridge-reply-directive.test.py
@@ -14,7 +14,9 @@ Run: python3 tests/discord-bridge-reply-directive.test.py
 
 from __future__ import annotations
 import asyncio
+import contextlib
 import importlib.util
+import shutil
 import sys
 import tempfile
 import types
@@ -90,6 +92,60 @@ def load_bridge():
 
 bridge = load_bridge()
 
+# Set by main() before any case runs; read by the live-workspace regression.
+_LIVE_BASELINE = (None, [])
+
+
+@contextlib.contextmanager
+def _bridge_writes_redirected():
+    """Point every filesystem write this fixture triggers at a throwaway tree.
+
+    Three separate escapes, all to the OWNER's live workspace, and the old
+    comment at `_run_one_poll_iteration` ("RESULTS_DIR is shared with prod")
+    treated the first as acceptable rather than as the defect it is:
+
+      1. the staged result files             -> <workspace>/results/
+      2. `archive_file()` moving them        -> <workspace>/results/archive/<ym>/
+      3. `poll_results` -> outbox_log.append -> <workspace>/state/outbox.log
+
+    (3) is the one that matters most: `state/outbox.log` is the delivery audit
+    log the dashboard's Outbox card shows the owner. Measured on this host
+    before the fix, the fixtures had been landing in the real log since
+    2026-05-28 — `discord_channel` rows whose `recipient` is `111222333` /
+    `444555666` / `777888999` rather than a Discord snowflake.
+
+    `outbox_log._outbox_path` is swapped rather than `resolve_workspace`
+    because `append()` re-resolves per call; the sibling fix in #2615 had to
+    rebind a constant instead because that one was bound at import. Which seam
+    works is a property of the module, so the regression proves it by exercise.
+
+    Restores in a `finally` so a mid-run assertion cannot leave the globals
+    patched for whatever runs next in the same interpreter (#2614).
+    """
+    import outbox_log
+
+    orig_results = bridge.RESULTS_DIR
+    orig_archive = bridge.ARCHIVE_RESULTS_DIR
+    orig_path = outbox_log._outbox_path
+    tmp = Path(tempfile.mkdtemp(prefix="reply-directive-test-"))
+    redirected = tmp / "state" / "outbox.log"
+    redirected.parent.mkdir(parents=True, exist_ok=True)
+    bridge.RESULTS_DIR = tmp / "results"
+    bridge.RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    # `archive_file()` does NOT derive from RESULTS_DIR — `ARCHIVE_RESULTS_DIR`
+    # is its own module constant (discord-bridge.py:248), so redirecting only
+    # RESULTS_DIR moves the staging write and leaves the ARCHIVE write in the
+    # owner's tree. Caught by the regression below, not by reading the code.
+    bridge.ARCHIVE_RESULTS_DIR = tmp / "results" / "archive"
+    outbox_log._outbox_path = lambda: redirected
+    try:
+        yield tmp, redirected
+    finally:
+        bridge.RESULTS_DIR = orig_results
+        bridge.ARCHIVE_RESULTS_DIR = orig_archive
+        outbox_log._outbox_path = orig_path
+        shutil.rmtree(tmp, ignore_errors=True)
+
 
 # ---------------------------------------------------------------------------
 # Mock channel that captures send() calls
@@ -127,7 +183,8 @@ async def _run_one_poll_iteration(task_id, channel, result_text):
     bridge.client.is_ready = lambda: True
     # Stub save_pending_replies so we don't write to disk during tests
     bridge.save_pending_replies = lambda: None
-    # archive_file uses real fs; let it run — RESULTS_DIR is shared with prod
+    # archive_file uses real fs; RESULTS_DIR is redirected to a throwaway tree by
+    # `_bridge_writes_redirected`, so this no longer touches the owner's results/.
     # but the file we wrote is fully synthetic and gets archived
 
     # Run poll_results with a tight timeout — we only need 1 iteration
@@ -204,22 +261,68 @@ def case_c_directive_only_first_chunk():
     return fails
 
 
+def test_no_writes_reach_the_live_workspace(live_ws) -> int:
+    """THE regression: a run must not touch the owner's results/ or outbox log.
+
+    Baseline is taken by `main()` BEFORE any case runs, not here — taking it
+    here would only cover this function's own activity, so removing the
+    redirect from the cases would still pass.
+
+    Asserts on the RESOLVED live workspace rather than a fixture path, because
+    the defect was precisely that the fixture escaped to wherever that resolves.
+    """
+    outbox = live_ws / "state" / "outbox.log"
+    results = live_ws / "results"
+    now_outbox = outbox.stat().st_size if outbox.is_file() else None
+    now_results = sorted(str(p) for p in results.rglob("*")) if results.is_dir() else []
+    before_outbox, before_results = _LIVE_BASELINE
+    bad = []
+    if now_outbox != before_outbox:
+        bad.append(f"outbox.log size {before_outbox} -> {now_outbox}")
+    new_files = set(now_results) - set(before_results)
+    if new_files:
+        bad.append(f"{len(new_files)} new file(s) under results/: {sorted(new_files)[:3]}")
+    if bad:
+        print("  \u2717 live workspace was written to: " + "; ".join(bad), file=sys.stderr)
+        return 1
+    print("  \u2713 live workspace untouched (results/ and state/outbox.log)")
+    return 0
+
+
 def main():
+    # Baseline BEFORE any case runs, so the final check covers every write this
+    # file triggers — not just the ones the regression itself makes.
+    from workspace_default import resolve_workspace
+
+    global _LIVE_BASELINE
+    live_ws = resolve_workspace()
+    _outbox = live_ws / "state" / "outbox.log"
+    _results = live_ws / "results"
+    _LIVE_BASELINE = (
+        _outbox.stat().st_size if _outbox.is_file() else None,
+        sorted(str(p) for p in _results.rglob("*")) if _results.is_dir() else [],
+    )
+
     cases = [
         ("a-directive-present-constructs-reference", case_a_directive_present_constructs_reference),
         ("b-no-directive-no-reference", case_b_no_directive_no_reference),
         ("c-directive-only-first-chunk", case_c_directive_only_first_chunk),
     ]
     failures = []
-    for label, fn in cases:
-        fs = fn()
-        if fs:
-            failures.extend([(label, msg) for msg in fs])
-            print(f"  ✗ case {label}")
-            for f in fs:
-                print(f"      {f}")
-        else:
-            print(f"  ✓ case {label}")
+    with _bridge_writes_redirected():
+        for label, fn in cases:
+            fs = fn()
+            if fs:
+                failures.extend([(label, msg) for msg in fs])
+                print(f"  ✗ case {label}")
+                for f in fs:
+                    print(f"      {f}")
+            else:
+                print(f"  ✓ case {label}")
+
+    if test_no_writes_reach_the_live_workspace(live_ws):
+        failures.append(("live-workspace-untouched", "fixture escaped to the live workspace"))
+
     if failures:
         print(f"\n{len(failures)} failure(s)")
         return 1

--- a/tests/discord-bridge-reply-directive.test.py
+++ b/tests/discord-bridge-reply-directive.test.py
@@ -140,7 +140,14 @@ def _bridge_writes_redirected():
     # RESULTS_DIR + outbox only, and `state/result-audit.log`,
     # `state/discord-bridge.heartbeat` and `logs/events-*.jsonl` still escaped.
     orig_resolve = workspace_default.resolve_workspace
-    _fake = lambda: tmp
+    # Accept and IGNORE any args: `observability.config.load_observability_config()`
+    # and `observability.sink.JsonlFileSink.write()` call
+    # `resolve_workspace(migrate=False)`. A zero-arg stub raises TypeError there,
+    # and the best-effort observability facade SWALLOWS it — so the redirect
+    # silently DISABLED the write path instead of redirecting it, and the suite
+    # stayed green while `_emit_channel` was never exercised (qingyun-wu, #2619).
+    # Preserving the resolver's signature is what keeps this a redirect.
+    _fake = lambda *a, **kw: tmp
 
     # Patch the name in EVERY module that holds it, not just where it is defined.
     # `from workspace_default import resolve_workspace` binds the function into
@@ -177,6 +184,15 @@ def _bridge_writes_redirected():
         workspace_default.resolve_workspace = orig_resolve
         for _mod in _patched:
             _mod.resolve_workspace = orig_resolve
+        # ALSO restore anything that bound `_fake` DURING the context. `_patched`
+        # is built before the body runs, so a module imported lazily inside it
+        # (outbox_log, result_audit, event_log all are) picks up `_fake` and was
+        # never in the list — leaving it pointed at a deleted temp dir for the
+        # rest of the interpreter. qingyun-wu found this on the sibling #2620;
+        # it is the same code shape here, so it is fixed in both.
+        for _m in list(sys.modules.values()):
+            if getattr(_m, "resolve_workspace", None) is _fake:
+                _m.resolve_workspace = orig_resolve
         for name, val in saved.items():
             setattr(bridge, name, val)
         shutil.rmtree(tmp, ignore_errors=True)
@@ -385,7 +401,7 @@ def main():
         ("c-directive-only-first-chunk", case_c_directive_only_first_chunk),
     ]
     failures = []
-    with _bridge_writes_redirected():
+    with _bridge_writes_redirected() as (_tmp, _redirected):
         for label, fn in cases:
             fs = fn()
             if fs:
@@ -395,6 +411,20 @@ def main():
                     print(f"      {f}")
             else:
                 print(f"  ✓ case {label}")
+
+        # POSITIVE CONTROL for the redirect itself: an outbound observability
+        # event must actually LAND inside the throwaway tree. Without this, a
+        # redirect that DISABLES the write path (the zero-arg-lambda TypeError
+        # qingyun-wu found) looks identical to one that redirects it — the
+        # facade swallows the error and every other assertion still passes.
+        _events = sorted((_tmp / "logs").glob("events-*.jsonl")) if (_tmp / "logs").is_dir() else []
+        if not _events or not any(f.stat().st_size for f in _events):
+            print("  ✗ no observability event landed in the throwaway tree — the "
+                  "redirect is disabling the write path, not redirecting it", file=sys.stderr)
+            failures.append(("observability-redirected", "no events-*.jsonl in tmp/logs"))
+        else:
+            print(f"  ✓ observability event redirected into the throwaway tree "
+                  f"({_events[0].name})")
 
     if test_no_writes_reach_the_live_workspace(live_ws):
         failures.append(("live-workspace-untouched", "fixture escaped to the live workspace"))


### PR DESCRIPTION
## What

`tests/discord-bridge-reply-directive.test.py` wrote to the owner's live workspace three ways. Third and last of the polluters catalogued in #2616 (siblings: #2615, #2618).

```
1. staged result files               -> <workspace>/results/
2. archive_file() moving them        -> <workspace>/results/archive/<ym>/
3. poll_results -> outbox_log.append -> <workspace>/state/outbox.log
```

(3) is the consequential one — `state/outbox.log` is the delivery audit log the dashboard's Outbox card shows the owner. The fixture's own comment had signed off on (1): *"archive_file uses real fs; let it run — RESULTS_DIR is shared with prod"*.

## How it was found — retroactively, without re-running anything

@Sutando-Mini derived a structural fingerprint from the artifact rather than from the code: for `channel_type` starting `discord`, `recipient` must be a Discord snowflake `^\d{17,20}$`. They validated it **both directions** before trusting it — 0/338 false positives on their live log, 4/4 on known-bad rows.

Applied to this host:

```
entries parsed       4379
fingerprint hits       40
fixture recipients   111222333(5) 444555666(5) 777888999(5)
                     human-id(15) tier-owner-id(5) env-override-id(5)
contamination began  2026-05-28 (3 rows) · 2026-05-29 (12) · 2026-08-04 (25)
```

So this had been landing in the real audit log since **May 28**, not just today.

## Which test — decided behaviourally, because the grep was wrong

Three tests textually contain those fixture ids. Run individually in a workspace pinned to a throwaway tree:

```
task-progress-skill.test.py              clean
local-task-protocol.test.py              clean
discord-bridge-reply-directive.test.py   POLLUTES (3 outbox entries)
```

A static grep would have accused two innocent tests. Same reason the census in #2618 selects behaviourally rather than textually.

## Before / after

```
origin/main   outbox 3 entries · results 3 files (archive/2026-08/test-task-{a,b,c}.txt)
this head     outbox 0         · results 0
```

## One thing worth calling out for reviewers

`ARCHIVE_RESULTS_DIR` had to be redirected **as well as** `RESULTS_DIR`. `archive_file()` does not derive from `RESULTS_DIR` — `discord-bridge.py:248` is its own module constant — so redirecting only `RESULTS_DIR` moves the staging write and silently leaves the *archive* write in the owner's tree. I did not spot that by reading; the regression caught it on the first run after the partial fix.

## Regression

`test_no_writes_reach_the_live_workspace` takes its baseline in `main()` **before any case runs**, so it covers every write the file triggers rather than only its own — with the baseline taken inside, removing the redirect from the cases would still pass.

Mutation-verified, since an assertion that cannot fail is decoration:

```
drop the ARCHIVE_RESULTS_DIR redirect -> FAIL "live workspace was written to: 5 new file(s) under results/"
restored                              -> PASS, exit 0
```

## Scope

One test file. No production code. `git diff --check` clean.

Part of #2616.
