### PR TITLE
feat(tests): fail a test that writes into the live workspace

### DIFF
--- a/scripts/hermetic-workspace-guard.py
+++ b/scripts/hermetic-workspace-guard.py
@@ -59,7 +59,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
+REPO = Path(__file__).resolve().parent.parent  # lint-workspace-resolution: allow-repo-root
 sys.path.insert(0, str(REPO / "src"))
 
 EXEMPTIONS = REPO / "tests" / "hermetic-workspace-exemptions.txt"

--- a/scripts/hermetic-workspace-guard.py
+++ b/scripts/hermetic-workspace-guard.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Fail a test that writes into the resolved live workspace.
+
+WHY
+---
+Six fixes for this one class landed on `main` in a single day, each found after
+the fact by damage on someone's machine:
+
+    #2617 cron-runner makes a real network POST per tick
+    #2615 tofu-enroll overwrote the live owner-presence signal
+    #2614 slack-allowlist left fixtures in the live workspace
+    #2619 reply-directive fixture wrote to the owner's live workspace
+    #2620 dm-result-multipart-upload appended to the outbox log
+    #2618 dm-result-send-dm appended to the live outbox log
+
+The suite has **prevention without detection**. Tests achieve isolation by
+redirecting `WORKSPACE_DIR`/`RESULTS_DIR` to a tmpdir; ~35 files describe
+themselves as hermetic on that basis. Almost none verify afterwards that the
+real workspace is unchanged, so a redirect that is forgotten, partial, or
+restored too early fails **silently**. @Sutando-Pro's per-suite guard in #2601
+caught exactly that within one run — two calls left outside the redirect
+context — which is the proof this shape works. This is the floor under the
+files that never got one.
+
+WHY CI AND NOT LOCALLY
+----------------------
+Measured on a live host: **62 files in the workspace changed in two minutes**
+from the core, the bridges and the heartbeat writing normally. A
+snapshot-and-compare there fires on every invocation, and no allowlist
+separates the test's write from that churn without also blinding the guard to
+`state/`, where two of the six bugs landed. CI has no core, no bridges and no
+heartbeat, and `workspace/` exists on disk despite being gitignored — so a
+write is an unambiguous diff. Detection belongs where the signal is clean; the
+damage is still local, which is what makes detecting it upstream worthwhile.
+
+EXEMPTIONS
+----------
+Per @Sutando-Pro, and both constraints matter:
+
+  * an exemption **names the path** it may write, never a bare flag — the same
+    token-specific discipline `REVIEW.md` already requires of hardcoded-path
+    fixture exclusions, so one exemption cannot quietly cover a second real
+    violation;
+  * an exemption whose path is **not** written FAILS. An unused exemption is a
+    stale exemption, and stale exemptions are what make the next real one
+    invisible.
+
+Format, one per line in `tests/hermetic-workspace-exemptions.txt`:
+
+    <test-file-basename>  <workspace-relative-path>   # why
+
+Usage:
+    python3 scripts/hermetic-workspace-guard.py run tests/foo.test.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+EXEMPTIONS = REPO / "tests" / "hermetic-workspace-exemptions.txt"
+
+
+def resolved_workspace() -> Path:
+    """The workspace the test will actually resolve — not a guess at it."""
+    from workspace_default import resolve_workspace  # noqa: E402
+
+    return Path(resolve_workspace())
+
+
+def snapshot(root: Path) -> dict:
+    """Map every file under `root` to (size, mtime_ns).
+
+    Not a content hash: the point is to notice that a file was created,
+    removed, appended to, or rewritten, and size+mtime catches all four at a
+    fraction of the cost. A same-size same-mtime rewrite is possible in
+    principle and is not the failure mode this exists for — the six real cases
+    were appends and creations.
+    """
+    if not root.exists():
+        return {}
+    out: dict = {}
+    for p in root.rglob("*"):
+        try:
+            if p.is_file():
+                st = p.stat()
+                out[str(p.relative_to(root))] = (st.st_size, st.st_mtime_ns)
+        except OSError:
+            # A file that vanished mid-walk is itself churn; record it as absent
+            # rather than crashing the guard on a race.
+            continue
+    return out
+
+
+def diff(before: dict, after: dict) -> list[str]:
+    """Workspace-relative paths that were created, removed, or changed."""
+    changed = [p for p in after if p not in before or before[p] != after[p]]
+    changed += [p for p in before if p not in after]
+    return sorted(set(changed))
+
+
+def exemptions_for(test_file: str) -> list[str]:
+    """Paths this specific test file is permitted to write."""
+    if not EXEMPTIONS.exists():
+        return []
+    name = Path(test_file).name
+    allowed = []
+    for line in EXEMPTIONS.read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) >= 2 and parts[0] == name:
+            allowed.append(parts[1])
+    return allowed
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if len(argv) < 2 or argv[0] != "run":
+        print("usage: hermetic-workspace-guard.py run <testfile> [args...]", file=sys.stderr)
+        return 2
+    test_file = argv[1]
+
+    ws = resolved_workspace()
+    before = snapshot(ws)
+
+    proc = subprocess.run([sys.executable, test_file, *argv[2:]])
+
+    after = snapshot(ws)
+    touched = diff(before, after)
+    allowed = exemptions_for(test_file)
+
+    violations = [p for p in touched if p not in allowed]
+    unused = [p for p in allowed if p not in touched]
+
+    rc = proc.returncode
+    if violations:
+        print(f"\n::error::{test_file} wrote into the LIVE workspace ({ws})", flush=True)
+        for p in violations:
+            print(f"    {p}", flush=True)
+        print("  A test must redirect WORKSPACE_DIR/RESULTS_DIR to a tmpdir. If this write",
+              flush=True)
+        print("  is genuinely required, add `<test> <path>` to "
+              f"{EXEMPTIONS.relative_to(REPO)} with a reason.", flush=True)
+        rc = rc or 1
+    if unused:
+        # An exemption that never fires is the mechanism by which this class
+        # comes back: it stays in the file, reads as sanctioned, and hides the
+        # next real violation of the same path.
+        print(f"\n::error::{test_file} has STALE exemption(s) — the path was not written:",
+              flush=True)
+        for p in unused:
+            print(f"    {p}", flush=True)
+        print("  Remove it. An unused exemption makes the next real one invisible.", flush=True)
+        rc = rc or 1
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint-workspace-resolution.sh
+++ b/scripts/lint-workspace-resolution.sh
@@ -74,13 +74,21 @@ PATTERN_DOC_ENV_PATH='\$SUTANDO_WORKSPACE/'
 # __file__ when git is unavailable. Listed here rather than reworded to
 # `parents[1]`, per the note above — dodging the regex would defeat the lint.
 #
+# scripts/hermetic-workspace-guard.py is the same category once more, and the
+# distinction is worth stating because the file's NAME suggests otherwise: it
+# resolves the REPO root only to locate `tests/hermetic-workspace-exemptions.txt`
+# and to put `src/` on sys.path. The workspace it actually cares about is obtained
+# THROUGH the loader (`from workspace_default import resolve_workspace`) — which is
+# the contract this lint exists to enforce, so the guard already complies where it
+# counts. Listed here rather than reworded to `parents[1]`, per the note above.
+#
 # scripts/gen-src-map.py uses PATTERN_REPO_WALK to resolve the REPO ROOT
 # (to read tracked files under src/ and write docs/), NOT a workspace — same
 # category as scripts/check-utc-z-strftime.py and scripts/dedup-conversation-store.py,
 # which predate this --diff lint and are grandfathered. A repo-tooling script has
 # no workspace to go through the wrapper for; the wrapper resolves the workspace,
 # which is the wrong directory here.
-ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|scripts/gen-src-map\.py|scripts/check-python39-compat\.py|scripts/review-preflight\.py|tests/[^/]+\.(test\.)?(py|ts|sh)|packages/ag2-sparrow/.*\.py)$'
+ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|scripts/gen-src-map\.py|scripts/check-python39-compat\.py|scripts/review-preflight\.py|scripts/hermetic-workspace-guard\.py|tests/[^/]+\.(test\.)?(py|ts|sh)|packages/ag2-sparrow/.*\.py)$'
 
 # Allowed .md files — legitimate uses of `$SUTANDO_WORKSPACE/path` in
 # prose, e.g. the workspace contract docs that DESCRIBE the legacy form

--- a/scripts/lint-workspace-resolution.sh
+++ b/scripts/lint-workspace-resolution.sh
@@ -43,6 +43,15 @@ PATTERN_ENV='(process\.env|process\.env\[)["'\'']?SUTANDO_WORKSPACE|os\.environ(
 PATTERN_HARDCODED_HOME='\.sutando/workspace'
 PATTERN_REPO_WALK='Path\(__file__\)\.resolve\(\)\.parent\.parent'
 
+# LINE-scoped opt-out. A file-level ALLOWED entry excuses the WHOLE file, which is a
+# blind spot rather than an exemption: @john-the-dev demonstrated it on #2639 by adding a
+# real `Path(__file__).resolve().parent.parent / "workspace"` to an allowlisted file and
+# watching this lint exit 0. Every explicitly-listed repo-tooling script carries the same
+# hole. A trailing pragma exempts ONE line and leaves every other line in that file
+# visible — the token-specific discipline REVIEW.md already requires of fixture
+# exclusions, so one exemption cannot hide a second real offender.
+PRAGMA_ALLOW_REPO_ROOT='lint-workspace-resolution: allow-repo-root'
+
 # Doc-notation pattern (markdown + SKILL.md only). Flags the legacy
 # env-var-as-path form `$SUTANDO_WORKSPACE/<anything>` in user-facing
 # docs — the canonical form post-M0 is `<workspace>/path` with the
@@ -88,7 +97,7 @@ PATTERN_DOC_ENV_PATH='\$SUTANDO_WORKSPACE/'
 # which predate this --diff lint and are grandfathered. A repo-tooling script has
 # no workspace to go through the wrapper for; the wrapper resolves the workspace,
 # which is the wrong directory here.
-ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|scripts/gen-src-map\.py|scripts/check-python39-compat\.py|scripts/review-preflight\.py|scripts/hermetic-workspace-guard\.py|tests/[^/]+\.(test\.)?(py|ts|sh)|packages/ag2-sparrow/.*\.py)$'
+ALLOWED='^(src/sutando_config\.(py|ts)|src/workspace_default\.(py|ts)|src/util_paths\.py|src/startup\.sh|src/migration_safety_helpers\.sh|scripts/lint-workspace-resolution\.sh|scripts/lint-sutando-home-path\.sh|scripts/install-git-hooks\.sh|scripts/sutando-config\.sh|scripts/sync-memory\.sh|scripts/sutando-migrate\.sh|scripts/sweep-stranded-claims\.sh|scripts/gen-src-map\.py|scripts/check-python39-compat\.py|scripts/review-preflight\.py|tests/[^/]+\.(test\.)?(py|ts|sh)|packages/ag2-sparrow/.*\.py)$'
 
 # Allowed .md files — legitimate uses of `$SUTANDO_WORKSPACE/path` in
 # prose, e.g. the workspace contract docs that DESCRIBE the legacy form
@@ -144,14 +153,22 @@ for f in $files; do
 
   if [[ "$mode" == "--diff" ]]; then
     # Only flag lines ADDED in the diff (begin with `+` but not `+++`).
-    added="$(git diff "$base"...HEAD -- "$f" | grep -E '^\+[^+]' || true)"
+    # A pragma'd line is exempt from the REPO-ROOT walk ONLY, and only when it does
+    # not also derive a workspace — otherwise the pragma becomes a way to hide the very
+    # thing this lint exists to catch, which is the file-level blind spot again at line
+    # granularity. Keep the line whenever it mentions a workspace, so a spoofed pragma
+    # still fails. The pragma text itself contains "workspace", so it is stripped
+    # before that test — otherwise the marker always matches its own guard.
+    added="$(git diff "$base"...HEAD -- "$f" | grep -E '^\+[^+]' \
+      | awk -v p="$PRAGMA_ALLOW_REPO_ROOT" '{ rest=$0; sub(p,"",rest); if (index($0,p)==0 || tolower(rest) ~ /workspace/) print }' || true)"
     if grep -E -q "$PATTERN_ENV|$PATTERN_HARDCODED_HOME|$PATTERN_REPO_WALK" <<< "$added"; then
       hits="$(grep -E -n "$PATTERN_ENV|$PATTERN_HARDCODED_HOME|$PATTERN_REPO_WALK" <<< "$added" | head -3 || true)"
       offenders+="  • $f"$'\n'"$hits"$'\n'
     fi
   else
-    if grep -E -l "$PATTERN_ENV|$PATTERN_HARDCODED_HOME|$PATTERN_REPO_WALK" "$f" >/dev/null 2>&1; then
-      hits="$(grep -E -n "$PATTERN_ENV|$PATTERN_HARDCODED_HOME|$PATTERN_REPO_WALK" "$f" | head -3 || true)"
+    _scan="$(awk -v p="$PRAGMA_ALLOW_REPO_ROOT" '{ rest=$0; sub(p,"",rest); if (index($0,p)==0 || tolower(rest) ~ /workspace/) print }' "$f" || true)"
+    if grep -E -q "$PATTERN_ENV|$PATTERN_HARDCODED_HOME|$PATTERN_REPO_WALK" <<< "$_scan"; then
+      hits="$(grep -E -n "$PATTERN_ENV|$PATTERN_HARDCODED_HOME|$PATTERN_REPO_WALK" <<< "$_scan" | head -3 || true)"
       offenders+="  • $f"$'\n'"$hits"$'\n'
     fi
   fi

--- a/tests/hermetic-workspace-exemptions.txt
+++ b/tests/hermetic-workspace-exemptions.txt
@@ -1,0 +1,15 @@
+# Tests permitted to write named paths inside the resolved workspace.
+#
+# Format:  <test-file-basename>  <workspace-relative-path>   # why
+#
+# Two rules, both enforced by scripts/hermetic-workspace-guard.py:
+#
+#   1. An exemption NAMES THE PATH. Never a bare per-file flag — the same
+#      token-specific discipline REVIEW.md requires of hardcoded-path fixture
+#      exclusions, so one entry cannot quietly cover a second real violation.
+#   2. An exemption whose path is NOT written FAILS. An unused exemption is a
+#      stale exemption, and stale exemptions are what make the next real one
+#      invisible. Delete rather than keep "just in case".
+#
+# Empty on purpose: every test currently isolates, or should. Adding a line
+# here is a claim that a live-workspace write is genuinely required — say why.

--- a/tests/hermetic-workspace-guard.test.py
+++ b/tests/hermetic-workspace-guard.test.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""The guard must be able to FAIL, and that has to be asserted, not demonstrated.
+
+@Sutando-Pro on #2639, about the per-suite shape: *"assert the redirect target
+GREW — otherwise deleting the `append()` call entirely turns the guard green,
+live file unchanged, redirect file unchanged, both assertions satisfied, and
+you've proven nothing about whether the write happened at all."*
+
+Translated to this wrapper, the equivalent hole is worse: if
+`resolved_workspace()` returns a path that does not exist, or the walk silently
+yields nothing, then **every test passes vacuously** and the guard reports a
+clean suite forever. That is the same broken-instrument failure the guard exists
+to catch, one level up — a negative from something never shown able to produce a
+positive.
+
+So the guard's own detection ability is pinned here rather than demonstrated
+once in a shell:
+
+  * a fixture that writes into the resolved workspace MUST fail (exit 1)
+  * a fixture that writes nothing MUST pass (exit 0)  <- without this, a guard
+    hardwired to fail also satisfies the case above
+  * the snapshot must actually see files — an empty walk is a broken instrument,
+    not a clean workspace
+
+Run: python3 tests/hermetic-workspace-guard.test.py
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+GUARD = REPO / "scripts" / "hermetic-workspace-guard.py"
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        FAILURES.append(f"{name}{(' — ' + detail) if detail else ''}")
+        print(f"  FAIL {name} {detail}")
+
+
+def _run_guard(workdir: Path, test_file: Path, exemptions: str = "") -> subprocess.CompletedProcess:
+    """Run the guard in a repo copy whose workspace points at a temp dir."""
+    (workdir / "tests").mkdir(parents=True, exist_ok=True)
+    (workdir / "tests" / "hermetic-workspace-exemptions.txt").write_text(exemptions)
+    return subprocess.run(
+        [sys.executable, str(workdir / "scripts" / "hermetic-workspace-guard.py"),
+         "run", str(test_file)],
+        capture_output=True, text=True, cwd=str(workdir),
+    )
+
+
+def _fixture_repo(tmp: Path, ws: Path) -> Path:
+    """A minimal repo whose `resolve_workspace()` lands on `ws`."""
+    repo = tmp / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "src").mkdir(parents=True)
+    (repo / "tests").mkdir(parents=True)
+    for rel in ("scripts/hermetic-workspace-guard.py", "src/workspace_default.py",
+                "src/sutando_config.py", "sutando.config.json"):
+        src = REPO / rel
+        if src.exists():
+            (repo / rel).parent.mkdir(parents=True, exist_ok=True)
+            (repo / rel).write_bytes(src.read_bytes())
+    (repo / "sutando.config.local.json").write_text(
+        json.dumps({"workspace": {"path": str(ws)}, "vault": {"enabled": False}}))
+    return repo
+
+
+def main() -> int:
+    print("hermetic workspace guard — can it fail?")
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        ws = tmp / "ws"
+        (ws / "state").mkdir(parents=True)
+        (ws / "state" / "preexisting.json").write_text("{}")   # so the walk is non-empty
+        repo = _fixture_repo(tmp, ws)
+
+        offender = tmp / "offender.test.py"
+        offender.write_text(
+            "import sys, pathlib\n"
+            f"sys.path.insert(0, {str(repo / 'src')!r})\n"
+            "from workspace_default import resolve_workspace\n"
+            "(pathlib.Path(resolve_workspace())/'state'/'leaked.log').write_text('x')\n"
+            "print('offender: my own assertions passed')\n"
+        )
+        clean = tmp / "clean.test.py"
+        clean.write_text("print('clean: touched nothing')\n")
+
+        # --- THE POINT: a green test that pollutes must still be failed -------
+        r = _run_guard(repo, offender)
+        check("a test that PASSES but writes to the live workspace is FAILED",
+              r.returncode != 0, f"exit={r.returncode}")
+        check("...and the offending path is NAMED, not just counted",
+              "state/leaked.log" in (r.stdout + r.stderr),
+              (r.stdout + r.stderr)[-200:])
+
+        # --- POSITIVE CONTROL -------------------------------------------------
+        # Without this, a guard hardwired to `return 1` satisfies the case above.
+        r = _run_guard(repo, clean)
+        check("POSITIVE CONTROL — a clean test passes", r.returncode == 0,
+              f"exit={r.returncode} {(r.stdout + r.stderr)[-200:]}")
+
+        # --- exemptions: named, and self-expiring ----------------------------
+        r = _run_guard(repo, offender, "offender.test.py state/leaked.log\n")
+        check("a NAMED exemption permits exactly that path", r.returncode == 0,
+              f"exit={r.returncode}")
+
+        r = _run_guard(repo, offender, "offender.test.py state/some-other-path.log\n")
+        out = r.stdout + r.stderr
+        check("an exemption aimed ELSEWHERE does not cover the real write",
+              r.returncode != 0 and "state/leaked.log" in out, out[-200:])
+        check("...and that mis-aimed exemption is ALSO reported stale",
+              "STALE" in out, out[-200:])
+
+        r = _run_guard(repo, clean, "clean.test.py state/never-written.log\n")
+        check("an UNUSED exemption fails (self-expiring, @Sutando-Pro)",
+              r.returncode != 0 and "STALE" in (r.stdout + r.stderr),
+              f"exit={r.returncode}")
+
+        # --- the instrument itself -------------------------------------------
+        sys.path.insert(0, str(REPO / "scripts"))
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("hwg", GUARD)
+        hwg = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(hwg)
+        snap = hwg.snapshot(ws)
+        check("the snapshot SEES files — an empty walk is a broken instrument, "
+              "not a clean workspace", len(snap) > 0, f"snapshot had {len(snap)} entries")
+        check("a missing workspace yields an empty snapshot rather than a crash",
+              hwg.snapshot(tmp / "does-not-exist") == {})
+
+    print()
+    if FAILURES:
+        print(f"FAILED ({len(FAILURES)}):")
+        for f in FAILURES:
+            print(f"  - {f}")
+        return 1
+    print("hermetic workspace guard: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/hermetic-workspace-guard.test.py
+++ b/tests/hermetic-workspace-guard.test.py
@@ -164,6 +164,67 @@ def main() -> int:
         check("exemptions_for() returns [] for a file with no entry, in-process",
               hwg.exemptions_for("no-such-file.test.py") == [])
 
+        # ...and the PARSE body, which the call above never reaches: the repo's
+        # own exemptions file is currently all comments, so the loop `continue`s
+        # on every line. Only the subprocess controls above ever parsed a real
+        # entry, and the gate cannot see a child interpreter — so those lines
+        # read as untested. Pin the constant instead of relying on repo content,
+        # which would make this coverage hostage to an unrelated file's edits.
+        _real_ex = hwg.EXEMPTIONS
+        try:
+            hwg.EXEMPTIONS = tmp / "no-such-exemptions.txt"
+            check("exemptions_for() returns [] when the file is ABSENT, in-process",
+                  hwg.exemptions_for("anything.test.py") == [])
+
+            ex = tmp / "ex.txt"
+            ex.write_text(
+                "# a comment\n"
+                "\n"
+                "mine.test.py state/mine.log   # trailing comment\n"
+                "mine.test.py state/second.log\n"
+                "other.test.py state/theirs.log\n"
+                "single-token-line\n"
+            )
+            hwg.EXEMPTIONS = ex
+            check("exemptions_for() collects EVERY entry naming this file",
+                  hwg.exemptions_for("mine.test.py") == ["state/mine.log", "state/second.log"],
+                  str(hwg.exemptions_for("mine.test.py")))
+            check("...and another file's entries do not leak in",
+                  hwg.exemptions_for("other.test.py") == ["state/theirs.log"],
+                  str(hwg.exemptions_for("other.test.py")))
+            check("...and a malformed single-token line is ignored, not crashed on",
+                  hwg.exemptions_for("single-token-line") == [])
+        finally:
+            hwg.EXEMPTIONS = _real_ex
+
+        # snapshot(): the vanished-mid-walk branch. The race is not reproducible,
+        # so it is forced — is_file() says yes, the stat() that follows raises.
+        # Patching stat ALONE would not do it: pathlib swallows OSError inside
+        # is_file() and returns False, so the file would be skipped one line
+        # earlier and the except branch would stay unexecuted while the
+        # assertion below still passed. That is the shape of a test that proves
+        # nothing. [[feedback_a_control_that_returns_a_plausible_number_is_not_a_validated_control]]
+        (ws / "state" / "vanishing.json").write_text("{}")
+        _real_stat, _real_is_file = Path.stat, Path.is_file
+        Path.is_file = lambda self, *a, **k: (
+            True if self.name == "vanishing.json" else _real_is_file(self, *a, **k))
+
+        def _stat_racing(self, *a, **k):
+            if self.name == "vanishing.json":
+                raise OSError(2, "vanished mid-walk")
+            return _real_stat(self, *a, **k)
+
+        Path.stat = _stat_racing
+        try:
+            snap_race = hwg.snapshot(ws)
+        finally:
+            Path.stat, Path.is_file = _real_stat, _real_is_file
+        check("snapshot() SKIPS a file that vanishes mid-walk instead of crashing",
+              "state/vanishing.json" not in snap_race)
+        check("...and still records the files that did NOT vanish",
+              "state/preexisting.json" in snap_race, str(sorted(snap_race))[:140])
+        (ws / "state" / "vanishing.json").unlink()
+
         # diff(): created / changed / removed, in-process
         check("diff() reports created, changed and removed paths",
               hwg.diff({"a": (1, 1), "b": (1, 1)}, {"a": (2, 2), "c": (1, 1)})
@@ -192,6 +253,26 @@ def main() -> int:
             out2 = buf2.getvalue()
             check("main() FAILS a polluting test and NAMES the path, in-process",
                   rc_viol != 0 and "state/leaked.log" in out2, f"rc={rc_viol} {out2[-160:]}")
+
+            # The stale-exemption report, in-process. A clean test plus an
+            # exemption for a path it never writes: rc must go non-zero on the
+            # exemption alone, with no violation anywhere in the run.
+            _real_ex2 = hwg.EXEMPTIONS
+            stale_ex = tmp / "stale-ex.txt"
+            stale_ex.write_text(f"{clean.name} state/never-written.log\n")
+            hwg.EXEMPTIONS = stale_ex
+            try:
+                buf3 = io.StringIO()
+                with contextlib.redirect_stdout(buf3), contextlib.redirect_stderr(buf3):
+                    rc_stale = hwg.main(["run", str(clean)])
+                out3 = buf3.getvalue()
+            finally:
+                hwg.EXEMPTIONS = _real_ex2
+            check("main() FAILS on a STALE exemption and names the path, in-process",
+                  rc_stale != 0 and "STALE" in out3 and "state/never-written.log" in out3,
+                  f"rc={rc_stale} {out3[-160:]}")
+            check("...on the exemption alone — the run itself wrote nothing",
+                  "wrote into the LIVE workspace" not in out3, out3[-160:])
         finally:
             hwg.resolved_workspace = _real_rw
 

--- a/tests/hermetic-workspace-guard.test.py
+++ b/tests/hermetic-workspace-guard.test.py
@@ -132,6 +132,69 @@ def main() -> int:
         spec = importlib.util.spec_from_file_location("hwg", GUARD)
         hwg = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(hwg)
+        # --- IN-PROCESS drive of main() + helpers -----------------------------
+        # The subprocess controls above prove BEHAVIOUR but are invisible to the
+        # coverage gate: `scripts/coverage-gate.sh` runs each test under `coverage
+        # run` with no subprocess instrumentation, so a child interpreter's lines
+        # stay red. This PR's first cut measured 31.9% for exactly that reason.
+        # These calls re-exercise the same paths in THIS interpreter, so the gate
+        # sees them. [[reference_coverage_gate_needs_inprocess_tests]]
+        import contextlib, io
+
+        # resolved_workspace(): reads the loader, so point it at our fixture repo
+        _saved = sys.path[:]
+        sys.path.insert(0, str(repo / "src"))
+        try:
+            import importlib as _il
+            _wd = _il.import_module("workspace_default")
+            _orig = _wd.resolve_workspace
+            _wd.resolve_workspace = lambda *a, **k: str(ws)
+            try:
+                check("resolved_workspace() returns the loader's answer, in-process",
+                      hwg.resolved_workspace() == ws, str(hwg.resolved_workspace()))
+            finally:
+                _wd.resolve_workspace = _orig
+        except Exception as exc:                      # loader unavailable in fixture
+            print(f"    (note: resolved_workspace in-process skipped: {type(exc).__name__})")
+        finally:
+            sys.path[:] = _saved
+
+        # exemptions_for(): both branches — file present, and name-not-matched
+        _ex = REPO / "tests" / "hermetic-workspace-exemptions.txt"
+        check("exemptions_for() returns [] for a file with no entry, in-process",
+              hwg.exemptions_for("no-such-file.test.py") == [])
+
+        # diff(): created / changed / removed, in-process
+        check("diff() reports created, changed and removed paths",
+              hwg.diff({"a": (1, 1), "b": (1, 1)}, {"a": (2, 2), "c": (1, 1)})
+              == ["a", "b", "c"])
+
+        # main(): usage error, clean run, and the violation report — all in-process.
+        #
+        # `hwg` was loaded from the REAL repo, so its resolved_workspace() answers the
+        # REAL workspace. Left alone, main() would snapshot the operator's live tree
+        # (the exact thing this guard forbids) AND compare it against a fixture write
+        # that lands in the temp ws — no diff, so the violation assertion would pass
+        # for the wrong reason. Pin the resolver to the fixture for these calls.
+        _real_rw = hwg.resolved_workspace
+        hwg.resolved_workspace = lambda: ws
+        try:
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+                rc_usage = hwg.main([])
+                rc_clean = hwg.main(["run", str(clean)])
+            check("main() with no args is a usage error (2), in-process", rc_usage == 2, f"rc={rc_usage}")
+            check("main() on a clean test returns the child's rc, in-process", rc_clean == 0, f"rc={rc_clean}")
+
+            buf2 = io.StringIO()
+            with contextlib.redirect_stdout(buf2), contextlib.redirect_stderr(buf2):
+                rc_viol = hwg.main(["run", str(offender)])
+            out2 = buf2.getvalue()
+            check("main() FAILS a polluting test and NAMES the path, in-process",
+                  rc_viol != 0 and "state/leaked.log" in out2, f"rc={rc_viol} {out2[-160:]}")
+        finally:
+            hwg.resolved_workspace = _real_rw
+
         snap = hwg.snapshot(ws)
         check("the snapshot SEES files — an empty walk is a broken instrument, "
               "not a clean workspace", len(snap) > 0, f"snapshot had {len(snap)} entries")

--- a/tests/hermetic-workspace-guard.test.py
+++ b/tests/hermetic-workspace-guard.test.py
@@ -139,7 +139,8 @@ def main() -> int:
         # stay red. This PR's first cut measured 31.9% for exactly that reason.
         # These calls re-exercise the same paths in THIS interpreter, so the gate
         # sees them. [[reference_coverage_gate_needs_inprocess_tests]]
-        import contextlib, io
+        import contextlib
+        import io
 
         # resolved_workspace(): reads the loader, so point it at our fixture repo
         _saved = sys.path[:]
@@ -159,8 +160,7 @@ def main() -> int:
         finally:
             sys.path[:] = _saved
 
-        # exemptions_for(): both branches — file present, and name-not-matched
-        _ex = REPO / "tests" / "hermetic-workspace-exemptions.txt"
+        # exemptions_for(): the no-entry branch
         check("exemptions_for() returns [] for a file with no entry, in-process",
               hwg.exemptions_for("no-such-file.test.py") == [])
 

--- a/tests/lint-workspace-resolution-pragma.test.sh
+++ b/tests/lint-workspace-resolution-pragma.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# The line-scoped `allow-repo-root` pragma must EXEMPT one line and BLIND nothing else.
+#
+# @john-the-dev on #2639 showed why a file-level ALLOWED entry is not an exemption but a
+# blind spot: they added a real `Path(__file__).resolve().parent.parent / "workspace"`
+# into an allowlisted file and the lint still exited 0. The positive control shipped with
+# that commit only proved a DIFFERENT, non-allowlisted file was still visible — it never
+# exercised the hole introduced for the allowlisted one.
+#
+# So the controls here are deliberately about the SAME file the pragma appears in:
+#
+#   1. the pragma'd repo-root line passes                        (the exemption works)
+#   2. a second prohibited expression in that same file FAILS    (john's exact experiment)
+#   3. a SPOOFED pragma on a workspace derivation FAILS          (the pragma cannot hide
+#                                                                 what the lint exists for)
+#   4. an unrelated non-allowlisted file still FAILS             (nothing globally broken)
+#
+# Control 3 is the one that caught a real defect in the first cut of this fix: the pragma
+# excused any line carrying it, so it could have hidden a genuine workspace resolution —
+# the file-level blind spot rebuilt at line granularity.
+#
+# Run: bash tests/lint-workspace-resolution-pragma.test.sh
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LINT="$REPO/scripts/lint-workspace-resolution.sh"
+PRAGMA='lint-workspace-resolution: allow-repo-root'
+fails=0
+ok()  { printf '  ok   %s\n' "$1"; }
+bad() { printf '  FAIL %s %s\n' "$1" "${2:-}"; fails=$((fails+1)); }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# A throwaway git repo so `--diff` has a base to compare against.
+scaffold() {
+  rm -rf "$TMP/r"; mkdir -p "$TMP/r/scripts" "$TMP/r/src"
+  cp "$LINT" "$TMP/r/scripts/lint-workspace-resolution.sh"
+  cd "$TMP/r" || exit 9
+  git init -q . && git config user.email t@t && git config user.name t
+  printf 'placeholder\n' > README.md
+  git add -A && git commit -qm base
+  git branch -qM main
+  # The probe commit MUST live on a branch other than the base ref, or
+  # `git diff main...HEAD` is empty and every control passes vacuously — which is
+  # exactly what control 4 caught in the first draft of this harness.
+  git checkout -q -b probe
+}
+
+# Run the lint over a candidate file added on top of `main`; echo its exit code.
+verdict() {  # $1 = repo-relative path, $2 = file body
+  printf '%s' "$2" > "$TMP/r/$1"
+  ( cd "$TMP/r" && git add -A && git commit -qm probe >/dev/null 2>&1 )
+  ( cd "$TMP/r" && BASE_REF=main bash scripts/lint-workspace-resolution.sh --diff >/dev/null 2>&1; echo $? )
+}
+
+echo "lint-workspace-resolution: line-scoped pragma"
+
+# The pragma is only honoured for files the ALLOWED regex does not already cover, so use
+# the real guard path — that is the file the exemption was created for.
+GUARD="scripts/hermetic-workspace-guard.py"
+
+scaffold
+rc="$(verdict "$GUARD" "from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent  # $PRAGMA
+")"
+[ "$rc" = 0 ] && ok "1. a pragma'd repo-root anchor is exempt" \
+              || bad "1. a pragma'd repo-root anchor is exempt" "exit=$rc"
+
+scaffold
+rc="$(verdict "$GUARD" "from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent  # $PRAGMA
+_TMP = Path(__file__).resolve().parent.parent / \"workspace\"
+")"
+[ "$rc" != 0 ] && ok "2. a SECOND prohibited expression in the same file still fails" \
+               || bad "2. a SECOND prohibited expression in the same file still fails" \
+                      "lint exited 0 — the file is blind, which is the #2639 defect"
+
+scaffold
+rc="$(verdict "$GUARD" "from pathlib import Path
+_WS = Path(__file__).resolve().parent.parent / \"workspace\"  # $PRAGMA
+")"
+[ "$rc" != 0 ] && ok "3. a SPOOFED pragma cannot excuse a workspace derivation" \
+               || bad "3. a SPOOFED pragma cannot excuse a workspace derivation" \
+                      "the pragma became a way to hide the thing being linted"
+
+scaffold
+rc="$(verdict "src/zz_unrelated.py" "from pathlib import Path
+REPO = Path(__file__).resolve().parent.parent
+")"
+[ "$rc" != 0 ] && ok "4. POSITIVE CONTROL — an unrelated file is still caught" \
+               || bad "4. POSITIVE CONTROL — an unrelated file is still caught" \
+                      "the lint can no longer produce a positive at all"
+
+echo
+if [ "$fails" -ne 0 ]; then echo "FAILED ($fails)"; exit 1; fi
+echo "line-scoped pragma: all checks passed"


### PR DESCRIPTION
## Six fixes for one class landed on `main` today

```
#2617 cron-runner makes a real network POST per tick
#2615 tofu-enroll overwrote the live owner-presence signal
#2614 slack-allowlist left fixtures in the live workspace
#2619 reply-directive fixture wrote to the owner's live workspace
#2620 dm-result-multipart-upload appended to the outbox log
#2618 dm-result-send-dm appended to the live outbox log
```

Each was found *after the fact*, by damage on someone's machine. That's whack-a-mole; this is the guard.

### The gap: prevention without detection

Tests isolate by **redirecting** `WORKSPACE_DIR`/`RESULTS_DIR` to a tmpdir — ~35 files describe themselves as hermetic on that basis. Almost none **verify afterwards** that the real workspace is unchanged. So a redirect that is forgotten, partial, or restored too early fails **silently**.

@Sutando-Pro's per-suite guard in #2601 caught exactly that within one run (two calls left outside `with _outbox_redirected():`), which is the proof the shape works. This is the floor under the files that never got one.

### It found a seventh instance on its first sampled run

`tests/cron-notify.test.py` **passes its own assertions** and leaves two files behind:

```
workspace before: 0 files in state/
test exit=0        (it passes)
workspace after:   2 files in state/
    cron-notify-cooldown.json
    cron-notify-cooldown.json.lock
```

Most of that file redirects correctly; one path through it doesn't — the partial-redirect mode that reading cannot reliably catch. **Not fixed here.** Detection and repair are separate concerns, and I'd rather this PR be judged on the guard than carry an unrelated fix.

### CI, not local — and I had this backwards at first

I first told @Sutando-Pro the guard had to run locally "because the damage is local". Measured, on a live host:

```
files in the LIVE workspace modified in the last 2 min: 62
  build_log.md · state/core-status.json · state/result-audit.log
  state/quota-burn-history.json · state/core-supervisor.json …
```

The core, bridges and heartbeat write continuously. A snapshot there fires on **every** invocation, and no allowlist separates the test's write from that churn without also blinding the guard to `state/` — where two of the six actually landed.

CI has **no** concurrent writer, and `workspace/` exists on disk despite being gitignored, so a write is an unambiguous diff. Damage is local; **detection belongs where the signal is clean**, and CI would in fact have caught all six.

### Exemptions — @Sutando-Pro's design, both constraints enforced

- an exemption **names the path** it may write, never a bare flag — the token-specific discipline `REVIEW.md` already requires of hardcoded-path fixture exclusions
- an exemption that is **never used FAILS** — self-expiring, so the file cannot accumulate into the thing that hides the next real violation

That second one isn't mine and it's the better half: it's the difference between a guard and a formality.

### Verified

```
offender (exits 0 on its own asserts) -> guard exit 1, names state/outbox.log
clean                                 -> exit 0
named exemption                       -> exit 0
exemption aimed at a DIFFERENT path   -> exit 1, BOTH errors (violation + stale)
unused exemption                      -> exit 1, STALE
```

The fourth line is the one to check: a mis-aimed exemption cannot silently cover a real write.

Dry-run over 12 workspace-touching tests: **11 clean, 1 dirty** — the `cron-notify` case above.

### Not in this PR

Wiring it into `ci.yml`. The script and its contract land first so the sweep can be reviewed on its own evidence, and so the adoption cost is a separate, visible decision.

Stand: Echo Act IV Mini