### PR TITLE
fix(secret-vault): `env … -- CMD` forked instead of exec'ing, leaving a live wrapper over CMD

### DIFF
--- a/skills/secret-vault/secret-vault.py
+++ b/skills/secret-vault/secret-vault.py
@@ -16,7 +16,6 @@ Examples:
 """
 
 import os
-import subprocess
 import sys
 
 # Allow running from any directory by adding src/ to path
@@ -71,8 +70,29 @@ def cmd_env(keys: list[str], cmd: list[str]) -> None:
         except KeyError:
             print(f"vault env: key '{k}' not found — aborting", file=sys.stderr)
             sys.exit(1)
-    result = subprocess.run(cmd, env=env)
-    sys.exit(result.returncode)
+    # exec, don't fork-and-wait — `env`-style wrappers replace themselves.
+    #
+    # With subprocess.run() this process lingers as a parent for the whole life of
+    # CMD, which costs three things for a long-running service:
+    #   1. Two processes carry CMD's name in their argv, so any `ps`-based probe
+    #      counts double. health-check's telegram-bridge probe reported "multiple
+    #      processes (2 PIDs)" for a single bridge launched this way (2026-08-04).
+    #   2. A signal sent to the wrapper (SIGTERM from a supervisor, launchd, or a
+    #      stop script) is delivered to the WRAPPER, not to CMD, so the service it
+    #      is meant to stop keeps running.
+    #   3. If the wrapper dies, CMD is orphaned rather than exiting with it.
+    # execvpe replaces this image with CMD, so CMD's pid, signals and exit status
+    # are the wrapper's by construction — the same contract /usr/bin/env provides.
+    # sys.exit(returncode) is no longer needed: after a successful exec there is
+    # no code here to run, and CMD's own status is what the caller sees.
+    try:
+        os.execvpe(cmd[0], cmd, env)
+    except OSError as e:
+        # Reached only when exec itself fails (command not found, not executable).
+        # subprocess.run() raised here too, so this stays a non-zero exit — but say
+        # which command failed rather than surfacing a bare traceback.
+        print(f"vault env: cannot execute {cmd[0]!r}: {e}", file=sys.stderr)
+        sys.exit(127)
 
 
 def main() -> None:

--- a/tests/vault-skill.test.py
+++ b/tests/vault-skill.test.py
@@ -289,14 +289,38 @@ class TestVaultCliMainDispatch(unittest.TestCase):
 
 
 class TestVaultCliEnv(unittest.TestCase):
-    def test_injects_env_and_runs(self):
+    def test_injects_env_and_execs(self):
+        # execvpe REPLACES the process, so on success there is no exit to assert
+        # here — the contract is "we handed CMD the right argv and environment".
         with patch("vault.get_vault_key", return_value="val"), \
-             patch("vault.subprocess.run", return_value=MagicMock(returncode=0)) as mock_run:
-            with self.assertRaises(SystemExit) as cm:
-                vault_cli.cmd_env(["MY_KEY"], ["echo", "hi"])
-        self.assertEqual(cm.exception.code, 0)
-        env_passed = mock_run.call_args[1]["env"]
+             patch("vault.os.execvpe") as mock_exec:
+            vault_cli.cmd_env(["MY_KEY"], ["echo", "hi"])
+        file_arg, argv, env_passed = mock_exec.call_args[0]
+        self.assertEqual(file_arg, "echo")
+        self.assertEqual(argv, ["echo", "hi"])
         self.assertEqual(env_passed["MY_KEY"], "val")
+
+    def test_does_not_fork_a_child(self):
+        # The regression this guards: subprocess.run() left the wrapper alive as a
+        # parent, so `ps` showed two processes carrying CMD's name and a SIGTERM to
+        # the wrapper never reached CMD. Assert we exec rather than spawn.
+        with patch("vault.get_vault_key", return_value="val"), \
+             patch("vault.os.execvpe") as mock_exec:
+            vault_cli.cmd_env(["MY_KEY"], ["echo", "hi"])
+        self.assertTrue(mock_exec.called, "cmd_env must exec, not spawn a child")
+        self.assertFalse(
+            hasattr(vault_cli, "subprocess"),
+            "secret-vault.py should no longer import subprocess for `env`",
+        )
+
+    def test_exits_127_when_exec_fails(self):
+        # Command missing / not executable: exec itself raises. Stay non-zero and
+        # name the command instead of surfacing a bare traceback.
+        with patch("vault.get_vault_key", return_value="val"), \
+             patch("vault.os.execvpe", side_effect=OSError(2, "No such file")):
+            with self.assertRaises(SystemExit) as cm:
+                vault_cli.cmd_env(["MY_KEY"], ["definitely-not-a-real-binary"])
+        self.assertEqual(cm.exception.code, 127)
 
     def test_exits_1_on_missing_key(self):
         with patch("vault.get_vault_key", side_effect=KeyError("x")):
@@ -308,6 +332,41 @@ class TestVaultCliEnv(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             vault_cli.cmd_env(["KEY"], [])
         self.assertEqual(cm.exception.code, 1)
+
+
+class TestVaultCliEnvActivated(unittest.TestCase):
+    """End-to-end proof, no mocks: the CLI process BECOMES the command.
+
+    Passing zero keys means no Keychain access, so this is hermetic — it exercises
+    the real `env ... -- CMD` path without a stored secret. On the old
+    subprocess.run() implementation the child reports a different pid than the
+    process we launched; after exec they are the same pid, which is the whole
+    point of the change.
+    """
+
+    def _run(self, argv):
+        return subprocess.run(
+            [sys.executable, _SV_PATH, "env", "--"] + argv,
+            capture_output=True, text=True, timeout=60,
+        )
+
+    def test_process_image_is_replaced(self):
+        proc = subprocess.Popen(
+            [sys.executable, _SV_PATH, "env", "--",
+             sys.executable, "-c", "import os; print(os.getpid())"],
+            stdout=subprocess.PIPE, text=True,
+        )
+        out, _ = proc.communicate(timeout=60)
+        child_pid = int(out.strip())
+        self.assertEqual(
+            child_pid, proc.pid,
+            "the command should have REPLACED the wrapper (same pid); a differing "
+            "pid means the wrapper forked and is still sitting around as a parent",
+        )
+
+    def test_exit_status_is_the_commands_own(self):
+        r = self._run(["sh", "-c", "exit 42"])
+        self.assertEqual(r.returncode, 42)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

`secret-vault.py env KEY -- CMD` ran CMD with `subprocess.run()` and then exited with its status, so the wrapper stayed alive as CMD's parent for the whole run. An `env`-style wrapper should replace itself, the way `/usr/bin/env` does.

I hit this for real today. Telegram's token had to come from the vault, so the bridge was launched as `secret-vault.py env TELEGRAM_BOT_TOKEN -- python3 src/telegram-bridge.py`, and `health-check.py` immediately reported:

```
⚠ telegram-bridge   warn   multiple processes (2 PIDs: 27538,27541)
```

One bridge, two processes. That is the cosmetic symptom; the two that matter are signals and orphaning.

## What changed

`cmd_env` now calls `os.execvpe(cmd[0], cmd, env)`. `sys.exit(result.returncode)` is gone — after a successful exec there is no code left to run, and CMD's own status is what the caller sees. A failing exec (missing / non-executable command) still exits non-zero, now **127** with the command named rather than a bare traceback. `import subprocess` is dropped; it had no other use in the file.

## Before / after evidence

**Process tree, scoped to the launched pid** (not a name grep — a name grep counts unrelated processes, which is how I first mis-measured this):

```
$ python3 skills/secret-vault/secret-vault.py env -- sleep 5 &
$ ps -eo pid,ppid | awk -v p=$! '$2==p {c++} END{print c+0}'   # direct children
$ ps -p $! -o command=                                          # what that pid IS

origin/main   direct children = 1   pid's command = python3 …/secret-vault.py env -- sleep 5
this branch   direct children = 0   pid's command = sleep 5
```

On `main` the wrapper is still there with `sleep 5` hanging off it. On this branch the launched pid **is** `sleep 5`.

**Test suite** — `tests/vault-skill.test.py`, same file both runs:

```
origin/main   Ran 34 tests   FAILED (failures=1, errors=3)
this branch   Ran 34 tests   OK
```

The three errors are the mocked contract (`vault.os.execvpe` is never reached, and `vault.subprocess` still exists). The **failure** is the one that matters — `test_process_image_is_replaced` is a no-mock, end-to-end check that the child's `os.getpid()` equals the pid we launched. It fails on `main` because the pids genuinely differ, and passes here.

That activated test is hermetic: it passes **zero keys**, so `cmd_env` never touches the Keychain and the test needs no stored secret.

## Worst-case disruption

Low, and the blast radius is small. `env` has no production callers today — `grep -rn "secret-vault.py env"` finds only `CLAUDE.md`, `AGENTS.md`, and the script's own usage string. The behaviour change is that the wrapper no longer survives the call; nothing depended on it surviving, and anything that did would have been relying on the bug. Exit-status propagation is preserved (`test_exit_status_is_the_commands_own` asserts `exit 42` still surfaces as 42).

## Checks

- `python3 tests/vault-skill.test.py` → 34/34 OK
- `python3 -m py_compile skills/secret-vault/secret-vault.py` → clean
- `scripts/review-checks.sh --diff` → PASS (hardcoded-paths clean)
- **All three red checks on this PR trace to one pre-existing cause: main's stale `docs/src-map.md`** (193 committed vs 194 generated). Verified in the job logs rather than assumed:

```
tsc + tests (clean install)     FAIL docs/src-map.md matches generated output   -> Results: 1 failed, 24 passed
diff coverage >= 95% (python)   ✖ test failed under instrumentation: tests/src-map.test.py
                                FAIL docs/src-map.md matches generated output   -> Results: 1 failed, 24 passed
refuse docs/src-map.md stale    the same check, directly
```

The coverage job never reached a coverage measurement — it aborts on that failing test. So none of the three is evidence about this diff. All clear when #2635 merges. This PR adds no `src/` module and does not touch generated docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

