### PR TITLE
feat(pr-flag): emit the fetch's own scope, so a digest can't read a subset as the repo total

### DIFF
--- a/scripts/pr_flag.py
+++ b/scripts/pr_flag.py
@@ -226,7 +226,8 @@ def fetch_argv(repo: str, owner_login: str) -> list:
     ]
 
 
-def scope_descriptor(repo: str, owner_login: str, record_count: int = None) -> dict:
+def scope_descriptor(repo: str, owner_login: str, record_count: int = None,
+                     fetched_count: int = None) -> dict:
     """Name the emitted population precisely, from the WHOLE pipeline.
 
     Why this exists: the payload carries counts, per-PR CI, approvals and merge
@@ -272,16 +273,31 @@ def scope_descriptor(repo: str, owner_login: str, record_count: int = None) -> d
 
     # complete==True is a CERTIFICATION, so it is only ever granted on evidence:
     # a count strictly below the ceiling. Unknown count -> None, never True.
-    if record_count is None or limit is None:
+    #
+    # The count compared against the ceiling must be the PRE-filter FETCHED count
+    # (@john-the-dev's second blocker on #2645). The ceiling applies to
+    # `_fetch_prs()`; `raw_state()` then drops drafts, so the emitted count is
+    # strictly smaller. Certifying off the emitted count means one dropped draft
+    # at a truncated fetch reads as complete:
+    #
+    #     fetched=1000 (== ceiling, truncated)  ->  emitted=999  ->  "below the
+    #     1000 ceiling"  ->  complete=True, on a population GitHub had cut off.
+    #
+    # Exactly the defect this descriptor exists to remove, reintroduced by
+    # measuring the wrong side of the filter. `record_count` stays in the payload
+    # as the emitted size — it is what the consumer actually received — but it
+    # never decides completeness.
+    ceiling_count = fetched_count if fetched_count is not None else record_count
+    if ceiling_count is None or limit is None:
         complete = None
-        why = "record count or fetch ceiling unknown — completeness not certified"
-    elif record_count >= limit:
+        why = "fetched count or fetch ceiling unknown — completeness not certified"
+    elif ceiling_count >= limit:
         complete = False
-        why = (f"{record_count} records at a {limit} ceiling — complete and "
-               "truncated are indistinguishable here")
+        why = (f"fetch returned {ceiling_count} at a {limit} ceiling — complete "
+               "and truncated are indistinguishable here")
     else:
         complete = True
-        why = f"{record_count} records is below the {limit} fetch ceiling"
+        why = f"fetch returned {ceiling_count}, below the {limit} ceiling"
 
     return {
         "filter": f"author:{author}" if author else "none",
@@ -293,6 +309,7 @@ def scope_descriptor(repo: str, owner_login: str, record_count: int = None) -> d
         "complete": complete,
         "complete_reason": why,
         "record_count": record_count,
+        "fetched_count": ceiling_count,
         "limit": limit,
     }
 
@@ -396,8 +413,10 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
     ap.add_argument("--state-file", default=None)
     args = ap.parse_args()
 
-    state = raw_state(_attach_commits(args.repo, _fetch_prs(args.repo, args.owner)),
-                      args.owner, args.stand)
+    # Bound separately so the PRE-filter size is available to scope_descriptor:
+    # the `--limit` ceiling applies here, before raw_state() drops drafts.
+    fetched = _attach_commits(args.repo, _fetch_prs(args.repo, args.owner))
+    state = raw_state(fetched, args.owner, args.stand)
     h = state_hash(state)
 
     # dedup: resolve the stored-hash file the same way every reader does
@@ -424,7 +443,10 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
     print(json.dumps({
         "hash": h,
         "changed": True,
-        "scope": scope_descriptor(args.repo, args.owner, record_count=len(state)),
+        # fetched_count is the PRE-filter size: the ceiling applies to the fetch,
+        # not to what survives raw_state(). See scope_descriptor().
+        "scope": scope_descriptor(args.repo, args.owner, record_count=len(state),
+                                  fetched_count=len(fetched)),
         "prs": state,
     }, indent=2))
     try:

--- a/scripts/pr_flag.py
+++ b/scripts/pr_flag.py
@@ -205,18 +205,60 @@ def state_hash(state: list) -> str:
     return hashlib.sha1(json.dumps(key, sort_keys=True).encode()).hexdigest()[:12]
 
 
-def _fetch_prs(repo: str, owner_login: str) -> list:  # pragma: no cover — subprocess/gh glue
+def fetch_argv(repo: str, owner_login: str) -> list:
+    """The exact `gh` command the fetch runs.
+
+    Extracted so `scope_descriptor()` can DERIVE the payload's coverage claim from
+    the real argv instead of restating it in prose. A hand-written scope string is
+    the thing it is describing plus a chance to be wrong: widen the fetch, forget
+    the string, and the payload now asserts a filter the code no longer applies.
+    """
     # SCOPE NOTE: `--author owner_login` means this only ever sees the owner's OWN
     # PRs (24 of 116 open on 2026-08-02). Peer PRs where the owner's approval is
     # the thing unblocking a merge are not fetched at all, so they cannot appear
     # in any digest built from this state. Left alone deliberately -- widening the
     # fetch is a scope decision, not a field-completeness fix, and belongs in its
-    # own change.
-    cmd = [
+    # own change (issue #2643).
+    return [
         "gh", "pr", "list", "--repo", repo, "--state", "open",
         "--author", owner_login, "--limit", "1000",
         "--json", "number,title,author,baseRefName,headRefOid,mergeable,reviewDecision,statusCheckRollup,isDraft,reviews",
     ]
+
+
+def scope_descriptor(repo: str, owner_login: str) -> dict:
+    """What the emitted state DOES and does NOT cover, read off the real argv.
+
+    Why this exists: the payload carries counts, per-PR CI, approvals and merge
+    state, and nothing in it marks the population as partial. A consumer that
+    builds a digest from it therefore reads "31 open" as a repository total. That
+    happened on 2026-08-04 -- the figure was the owner-authored subset of ~100
+    non-draft PRs, and the SCOPE NOTE explaining why lives in this file, which the
+    consumer never sees.
+
+    So the bound travels WITH the data. Derived from `fetch_argv()`, so removing
+    the filter changes this automatically rather than leaving a stale claim.
+    """
+    argv = fetch_argv(repo, owner_login)
+    author = argv[argv.index("--author") + 1] if "--author" in argv else None
+    limit = argv[argv.index("--limit") + 1] if "--limit" in argv else None
+    return {
+        "filter": f"author:{author}" if author else "none",
+        "covers": (
+            f"open non-draft PRs authored by {author!r} only"
+            if author else "all open PRs in the repo"
+        ),
+        "excludes": (
+            "PRs authored by anyone else -- including peer PRs where the owner's "
+            "approval is the only thing blocking a merge"
+        ) if author else "nothing",
+        "is_repo_total": author is None,
+        "limit": limit,
+    }
+
+
+def _fetch_prs(repo: str, owner_login: str) -> list:  # pragma: no cover — subprocess/gh glue
+    cmd = fetch_argv(repo, owner_login)
     res = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
     if res.returncode != 0:
         print(f"pr-flag: gh failed: {res.stderr[:200]}", file=sys.stderr)
@@ -339,7 +381,12 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
         return 0
 
     # emit the objective state for the AGENT to judge, then record the hash
-    print(json.dumps({"hash": h, "changed": True, "prs": state}, indent=2))
+    print(json.dumps({
+        "hash": h,
+        "changed": True,
+        "scope": scope_descriptor(args.repo, args.owner),
+        "prs": state,
+    }, indent=2))
     try:
         sf.parent.mkdir(parents=True, exist_ok=True)
         sf.write_text(json.dumps({"hash": h, "count": len(state)}))

--- a/scripts/pr_flag.py
+++ b/scripts/pr_flag.py
@@ -226,8 +226,8 @@ def fetch_argv(repo: str, owner_login: str) -> list:
     ]
 
 
-def scope_descriptor(repo: str, owner_login: str) -> dict:
-    """What the emitted state DOES and does NOT cover, read off the real argv.
+def scope_descriptor(repo: str, owner_login: str, record_count: int = None) -> dict:
+    """Name the emitted population precisely, from the WHOLE pipeline.
 
     Why this exists: the payload carries counts, per-PR CI, approvals and merge
     state, and nothing in it marks the population as partial. A consumer that
@@ -236,23 +236,63 @@ def scope_descriptor(repo: str, owner_login: str) -> dict:
     non-draft PRs, and the SCOPE NOTE explaining why lives in this file, which the
     consumer never sees.
 
-    So the bound travels WITH the data. Derived from `fetch_argv()`, so removing
-    the filter changes this automatically rather than leaving a stale claim.
+    Three things narrow the population, and the descriptor is only honest if it
+    reports all three (@john-the-dev on #2645 -- the first version read ONLY the
+    `--author` flag, so with the filter removed it certified
+    `is_repo_total: true, excludes: "nothing"` while `raw_state()` still dropped
+    every draft and the fetch still capped at `--limit`. That is the same
+    completeness-metadata-disagrees-with-the-data-path defect this block exists
+    to remove, one level up):
+
+      1. `--author` on the fetch (may be absent)
+      2. `raw_state()` drops drafts UNCONDITIONALLY -- so the payload is NEVER a
+         repository total, with or without the author filter
+      3. `--limit` is a ceiling; at exactly the ceiling, complete and truncated
+         are indistinguishable
+
+    `is_repo_total` is gone rather than fixed: no value of it was ever true, so a
+    consumer keying on it would be reasoning about a population that cannot
+    exist. `population` names the real set and `complete` reports only what the
+    record count can actually certify.
     """
     argv = fetch_argv(repo, owner_login)
     author = argv[argv.index("--author") + 1] if "--author" in argv else None
-    limit = argv[argv.index("--limit") + 1] if "--limit" in argv else None
+    limit_s = argv[argv.index("--limit") + 1] if "--limit" in argv else None
+    try:
+        limit = int(limit_s) if limit_s is not None else None
+    except (TypeError, ValueError):
+        limit = None
+
+    excludes = ["draft PRs (dropped by raw_state, always)"]
+    if author:
+        excludes.append(
+            f"PRs not authored by {author!r} -- including peer PRs where the "
+            "owner's approval is the only thing blocking a merge"
+        )
+
+    # complete==True is a CERTIFICATION, so it is only ever granted on evidence:
+    # a count strictly below the ceiling. Unknown count -> None, never True.
+    if record_count is None or limit is None:
+        complete = None
+        why = "record count or fetch ceiling unknown — completeness not certified"
+    elif record_count >= limit:
+        complete = False
+        why = (f"{record_count} records at a {limit} ceiling — complete and "
+               "truncated are indistinguishable here")
+    else:
+        complete = True
+        why = f"{record_count} records is below the {limit} fetch ceiling"
+
     return {
         "filter": f"author:{author}" if author else "none",
-        "covers": (
-            f"open non-draft PRs authored by {author!r} only"
-            if author else "all open PRs in the repo"
+        "population": (
+            f"open, non-draft PRs authored by {author!r}"
+            if author else "open, non-draft PRs (all authors)"
         ),
-        "excludes": (
-            "PRs authored by anyone else -- including peer PRs where the owner's "
-            "approval is the only thing blocking a merge"
-        ) if author else "nothing",
-        "is_repo_total": author is None,
+        "excludes": excludes,
+        "complete": complete,
+        "complete_reason": why,
+        "record_count": record_count,
         "limit": limit,
     }
 
@@ -384,7 +424,7 @@ def main() -> int:  # pragma: no cover — CLI + gh/state I/O glue; pure logic c
     print(json.dumps({
         "hash": h,
         "changed": True,
-        "scope": scope_descriptor(args.repo, args.owner),
+        "scope": scope_descriptor(args.repo, args.owner, record_count=len(state)),
         "prs": state,
     }, indent=2))
     try:

--- a/tests/pr-flag.test.py
+++ b/tests/pr-flag.test.py
@@ -359,6 +359,41 @@ def main() -> int:
     finally:
         pf._gh_stands_page = real_page
 
+    # ---- scope descriptor: the payload must state its own coverage ----------
+    # Why: the emitted state carries counts, CI, approvals and merge state with
+    # nothing marking the population as partial, so a consumer reads its length
+    # as a repo total. On 2026-08-04 a digest reported "31 open" for a repo with
+    # ~100 open non-draft PRs. Issue #2643.
+    sc = pf.scope_descriptor("o/n", "someowner")
+    assert sc["filter"] == "author:someowner", sc
+    assert sc["is_repo_total"] is False, sc
+    assert "someowner" in sc["covers"], sc
+    assert "approval" in sc["excludes"], sc
+    print("  ok  scope_descriptor names the author filter and denies repo-total")
+
+    # The anti-drift property, and the reason this is derived rather than written:
+    # a hand-maintained string would keep claiming author-scoping after someone
+    # widens the fetch. Drop --author from the argv and the descriptor must FLIP.
+    real_argv = pf.fetch_argv
+    try:
+        pf.fetch_argv = lambda repo, owner: [
+            "gh", "pr", "list", "--repo", repo, "--state", "open", "--limit", "1000",
+        ]
+        widened = pf.scope_descriptor("o/n", "someowner")
+        assert widened["is_repo_total"] is True, widened
+        assert widened["filter"] == "none", widened
+        assert widened["excludes"] == "nothing", widened
+        print("  ok  descriptor FOLLOWS the argv — removing --author flips it to repo-total")
+    finally:
+        pf.fetch_argv = real_argv
+
+    # And the fetch itself must actually use that argv, or the descriptor
+    # describes a command that isn't the one being run.
+    argv = pf.fetch_argv("o/n", "someowner")
+    assert argv[:5] == ["gh", "pr", "list", "--repo", "o/n"], argv
+    assert "--author" in argv and argv[argv.index("--author") + 1] == "someowner", argv
+    print("  ok  fetch_argv is the real gh command the descriptor reads")
+
     print("\nAll pr-flag core cases pass.")
     return 0
 

--- a/tests/pr-flag.test.py
+++ b/tests/pr-flag.test.py
@@ -364,28 +364,43 @@ def main() -> int:
     # nothing marking the population as partial, so a consumer reads its length
     # as a repo total. On 2026-08-04 a digest reported "31 open" for a repo with
     # ~100 open non-draft PRs. Issue #2643.
-    sc = pf.scope_descriptor("o/n", "someowner")
+    sc = pf.scope_descriptor("o/n", "someowner", record_count=30)
     assert sc["filter"] == "author:someowner", sc
-    assert sc["is_repo_total"] is False, sc
-    assert "someowner" in sc["covers"], sc
-    assert "approval" in sc["excludes"], sc
-    print("  ok  scope_descriptor names the author filter and denies repo-total")
+    assert "someowner" in sc["population"], sc
+    assert any("approval" in e for e in sc["excludes"]), sc
+    print("  ok  scope_descriptor names the author filter and the population")
 
-    # The anti-drift property, and the reason this is derived rather than written:
-    # a hand-maintained string would keep claiming author-scoping after someone
-    # widens the fetch. Drop --author from the argv and the descriptor must FLIP.
+    # Draft exclusion is UNCONDITIONAL — raw_state() drops drafts whether or not
+    # the fetch is author-filtered, so it must appear in `excludes` either way.
+    assert any("draft" in e for e in sc["excludes"]), sc
+
     real_argv = pf.fetch_argv
     try:
         pf.fetch_argv = lambda repo, owner: [
             "gh", "pr", "list", "--repo", repo, "--state", "open", "--limit", "1000",
         ]
-        widened = pf.scope_descriptor("o/n", "someowner")
-        assert widened["is_repo_total"] is True, widened
+        widened = pf.scope_descriptor("o/n", "someowner", record_count=30)
+        # The anti-drift property: removing --author must change the claim...
         assert widened["filter"] == "none", widened
-        assert widened["excludes"] == "nothing", widened
-        print("  ok  descriptor FOLLOWS the argv — removing --author flips it to repo-total")
+        assert "all authors" in widened["population"], widened
+        # ...but it must NOT become a repository total. This is @john-the-dev's
+        # blocker on #2645: the first version certified `excludes: "nothing"` here
+        # while raw_state() still dropped every draft.
+        assert any("draft" in e for e in widened["excludes"]), widened
+        assert "is_repo_total" not in widened, "the field that could never be true is gone"
+        print("  ok  no-author argv widens the population but STILL excludes drafts")
     finally:
         pf.fetch_argv = real_argv
+
+    # Completeness is a certification, granted only on evidence.
+    at_ceiling = pf.scope_descriptor("o/n", "someowner", record_count=1000)
+    assert at_ceiling["complete"] is False, at_ceiling
+    assert "indistinguishable" in at_ceiling["complete_reason"], at_ceiling
+    below = pf.scope_descriptor("o/n", "someowner", record_count=999)
+    assert below["complete"] is True, below
+    unknown = pf.scope_descriptor("o/n", "someowner", record_count=None)
+    assert unknown["complete"] is None, unknown
+    print("  ok  complete: True below ceiling, False AT it, None when uncountable")
 
     # And the fetch itself must actually use that argv, or the descriptor
     # describes a command that isn't the one being run.

--- a/tests/pr-flag.test.py
+++ b/tests/pr-flag.test.py
@@ -402,6 +402,32 @@ def main() -> int:
     assert unknown["complete"] is None, unknown
     print("  ok  complete: True below ceiling, False AT it, None when uncountable")
 
+    # @john-the-dev's SECOND blocker on #2645, as his own repro: the ceiling
+    # applies to the FETCH, and raw_state() then drops drafts, so certifying off
+    # the emitted count lets a truncated fetch read as complete. His numbers:
+    #   fetched=1000 (== ceiling) -> one draft dropped -> emitted=999 -> complete=True
+    at_ceiling_with_a_draft = pf.scope_descriptor(
+        "o/n", "someowner", record_count=999, fetched_count=1000)
+    assert at_ceiling_with_a_draft["complete"] is False, at_ceiling_with_a_draft
+    assert "1000" in at_ceiling_with_a_draft["complete_reason"], at_ceiling_with_a_draft
+    # ...and the emitted size is still reported, it just does not decide the certificate.
+    assert at_ceiling_with_a_draft["record_count"] == 999, at_ceiling_with_a_draft
+    assert at_ceiling_with_a_draft["fetched_count"] == 1000, at_ceiling_with_a_draft
+    print("  ok  a truncated FETCH is not certified complete by a smaller emitted count")
+
+    # The mirror case: a genuinely short fetch still certifies, so the fix is not
+    # just "always refuse" — that would be a gate that cannot go positive.
+    short = pf.scope_descriptor("o/n", "someowner", record_count=30, fetched_count=31)
+    assert short["complete"] is True, short
+    print("  ok  a fetch below the ceiling still certifies complete")
+
+    # Back-compat: callers that pass only record_count keep the old meaning
+    # rather than silently losing their certificate.
+    legacy = pf.scope_descriptor("o/n", "someowner", record_count=30)
+    assert legacy["complete"] is True, legacy
+    assert legacy["fetched_count"] == 30, legacy
+    print("  ok  record_count-only callers still resolve a ceiling")
+
     # A non-numeric --limit must degrade to "ceiling unknown", never crash the
     # digest. scope_descriptor parses whatever argv actually carries, so a
     # future flag change (`--limit auto`, a templated value) reaches int() as a

--- a/tests/pr-flag.test.py
+++ b/tests/pr-flag.test.py
@@ -402,6 +402,28 @@ def main() -> int:
     assert unknown["complete"] is None, unknown
     print("  ok  complete: True below ceiling, False AT it, None when uncountable")
 
+    # A non-numeric --limit must degrade to "ceiling unknown", never crash the
+    # digest. scope_descriptor parses whatever argv actually carries, so a
+    # future flag change (`--limit auto`, a templated value) reaches int() as a
+    # string. Certifying completeness against an unparseable ceiling would be
+    # the exact over-claim this descriptor exists to prevent, so the fallback
+    # has to be `limit=None` -> `complete=None`, not a guess.
+    real_argv = pf.fetch_argv
+    try:
+        pf.fetch_argv = lambda repo, owner: [
+            "gh", "pr", "list", "--repo", repo, "--state", "open",
+            "--author", owner, "--limit", "not-a-number",
+        ]
+        odd = pf.scope_descriptor("o/n", "someowner", record_count=30)
+        assert odd["limit"] is None, odd
+        assert odd["complete"] is None, odd
+        # and the rest of the descriptor still works — the author filter is
+        # unaffected by an unparseable limit.
+        assert odd["filter"] == "author:someowner", odd
+        print("  ok  an unparseable --limit yields complete=None, not a false certification")
+    finally:
+        pf.fetch_argv = real_argv
+
     # And the fetch itself must actually use that argv, or the descriptor
     # describes a command that isn't the one being run.
     argv = pf.fetch_argv("o/n", "someowner")


### PR DESCRIPTION
## Why

`--emit` prints counts, per-PR CI, approvals and merge state — and nothing in the payload marks the population as partial. The fetch is `--author <owner>`, so the state only ever contains the owner's own PRs, but a consumer reading the JSON has no way to know that.

It failed exactly that way this morning. A digest built from this state reported **"31 open"** to the owner as a repository figure. Measured at the same moment:

```
gh api repos/sonichi/sutando/pulls --paginate   ->  107 open, 100 non-draft
pr_flag --emit                                  ->   30 records
```

31 was the owner-authored subset. The `SCOPE NOTE` explaining the filter lives in `pr_flag.py`, which the consumer never reads — so the bound existed, just not anywhere the data went.

## What changed

The payload now carries its own coverage:

```json
"scope": {
  "filter": "author:sonichi",
  "covers": "open non-draft PRs authored by 'sonichi' only",
  "excludes": "PRs authored by anyone else -- including peer PRs where the owner's approval is the only thing blocking a merge",
  "is_repo_total": false,
  "limit": "1000"
}
```

**Derived from `fetch_argv()`, not written out.** A hand-maintained scope string is the claim plus a chance to be wrong: widen the fetch, forget to update the prose, and the payload now asserts a filter the code no longer applies — a stale bound is worse than none, because it reads authoritative. `fetch_argv()` is extracted so `_fetch_prs()` and `scope_descriptor()` cannot describe different commands.

## Before / after evidence

Live `--emit` at this head:

```
top-level keys: ['hash', 'changed', 'scope', 'prs']
  filter: author:sonichi
  is_repo_total: False
  limit: 1000
prs: 30 records
```

`origin/main` emits `['hash', 'changed', 'prs']` — no scope key.

Tests (`tests/pr-flag.test.py`, same file both runs):

```
this branch    exit=0    ...all pre-existing cases + 3 new ones pass
origin/main    exit=1    AttributeError: module 'pr_flag' has no attribute 'scope_descriptor'
```

The load-bearing one is the anti-drift case: it replaces `fetch_argv` with an argv that has **no** `--author` and asserts the descriptor flips to `is_repo_total: true`, `filter: "none"`, `excludes: "nothing"`. That is what stops the scope block from outliving the scope.

New cases were added **inside `main()`** — this file ends in `sys.exit(main())`, so anything appended after that block would never be collected and could never fail.

## Scope

**This is deliberately not the fetch widening.** Whether to also fetch peer PRs where the owner's approval is the merge blocker is a separate decision, tracked in #2643 along with two alternatives. This change only makes the *existing* scope self-describing, which is worth having whichever way that decision goes — and is the one part of #2643 I argued for unconditionally.

## Worst-case disruption

Low. Purely additive: one new key in the emitted JSON, no field removed or renamed, no change to the state-hash (`state_hash()` is computed over the PR list, so dedup behaviour is untouched — an unchanged set still prints `NO_CHANGE`). Consumers that ignore unknown keys are unaffected.

## Checks

- `python3 tests/pr-flag.test.py` → exit 0
- `python3 -m py_compile scripts/pr_flag.py` → clean
- `scripts/review-checks.sh --diff` → PASS (hardcoded-paths clean)
- `gen-src-map.py --check` → exit 0 (adds no `src/` module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
