### PR TITLE
fix(discord-bridge): our own DMs never advanced the catch-up checkpoint

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -2796,6 +2796,34 @@ async def _handle_restart_command(message, text, access_tier, username, workspac
 
 async def _handle_discord_message(message, force=False):
     if message.author == client.user:
+        # Advance the DM checkpoint for our OWN messages before dropping them.
+        #
+        # The checkpoint's contract is "REST catch-up should not re-fetch this
+        # id", which is about having SEEN the message, not about processing it.
+        # The main advance below already says so explicitly and applies it to
+        # out-of-allowlist / out-of-tier DMs — but this return sits above it, so
+        # self-authored DMs were the one class that never advanced it.
+        #
+        # `channel.history()` returns our own replies, and in a DM channel with
+        # the owner most messages ARE ours. So the checkpoint freezes at the last
+        # message we did not write, and every reconnect re-fetches the same
+        # window. Observed on two hosts: `[dm-catchup] replayed N missed DM(s)`
+        # logging an identical N across consecutive restarts — 27 on
+        # Chis-Mac-mini, and 4 here with all 4 self-authored, checkpoint stuck at
+        # 10:22:32 while the channel had moved to 12:03:21.
+        #
+        # Latent today (the return means nothing is re-processed and no duplicate
+        # task or DM is produced), but it is a real starvation path: the catch-up
+        # fetch is `limit=50, oldest_first=True`. Once more than 50 messages sit
+        # after a frozen checkpoint, an owner DM at position 51+ is never fetched
+        # — and since the checkpoint still cannot advance, no later restart
+        # reaches it either. That is silent, permanent loss of exactly the
+        # message this catch-up exists to rescue.
+        if isinstance(message.channel, discord.DMChannel) and hasattr(message, "id"):
+            try:
+                _update_dm_checkpoint(message.channel.id, message.id)
+            except Exception as e:
+                print(f"  [dm-checkpoint] self-message update failed: {e}", flush=True)
         return
     # Auto-mod LLM-judge observation hook (per-guild opt-in via access.json
     # `mod_active`). Pure observe — never blocks the rest of the function.

--- a/tests/discord-bridge-dm-catchup.test.py
+++ b/tests/discord-bridge-dm-catchup.test.py
@@ -272,6 +272,90 @@ def test_self_authored_dms_advance_the_checkpoint():
     )
 
 
+# --- behavioural: the fix must EXECUTE, not merely be present in the source ---
+# The two tests above parse the source. They fail correctly against the unfixed
+# bridge, but they never run the branch, so they cannot catch a wiring change
+# that leaves the call textually intact — and diff-coverage reported the fix at
+# 0%, which is that gap stated as a number. These drive the real handler.
+
+
+class _FakeDM(sys.modules["discord"].DMChannel):
+    """A real subclass, so `isinstance(ch, discord.DMChannel)` is genuinely true
+    rather than patched true."""
+
+    def __init__(self, cid):
+        self.id = cid
+
+
+def _drive_self_authored(channel, msg_id=99999):
+    """Run _handle_discord_message on a message the bot itself wrote."""
+    import asyncio
+    me = object()
+    fake_client = type("_C", (), {"user": me})()
+    msg = types.SimpleNamespace(author=me, channel=channel, id=msg_id)
+    real_client = getattr(bridge, "client", None)
+    bridge.client = fake_client
+    try:
+        asyncio.run(bridge._handle_discord_message(msg))
+    finally:
+        bridge.client = real_client
+
+
+def _read_checkpoint() -> dict:
+    """Checkpoint contents, or {} when the file was never written.
+
+    Deliberately not `read_text()` directly: in the BROKEN state no file exists
+    at all, and letting that surface as FileNotFoundError aborts the whole run
+    (main() only catches AssertionError) so the diagnostic below never prints.
+    A missing file is a legitimate outcome to assert against, not a crash.
+    """
+    f = bridge.DM_CHECKPOINT_FILE
+    if not f.exists():
+        return {}
+    try:
+        return json.loads(f.read_text())
+    except (ValueError, OSError):
+        return {}
+
+
+def test_self_authored_dm_actually_advances_the_checkpoint():
+    """The starvation fix, exercised end-to-end through the handler."""
+    _clear_checkpoint()
+    _drive_self_authored(_FakeDM(4242), msg_id=99999)
+    data = _read_checkpoint()
+    assert data.get("4242") == "99999", (
+        f"a self-authored DM must advance the checkpoint; got {data!r}. "
+        "Without this the catch-up fetch (limit=50, oldest_first) permanently "
+        "strands an owner DM once 50 messages sit past the frozen checkpoint."
+    )
+
+
+def test_self_authored_guild_message_leaves_checkpoint_untouched():
+    """Same path, non-DM channel: the checkpoint is per-DM-channel."""
+    _clear_checkpoint()
+    _drive_self_authored(type("_Guild", (), {"id": 4242})(), msg_id=99999)
+    assert _read_checkpoint() == {}, (
+        "a guild message must not write into the DM checkpoint; got "
+        f"{_read_checkpoint()!r}"
+    )
+
+
+def test_checkpoint_write_failure_does_not_break_the_handler():
+    """The update is best-effort: a failing write must not raise out of the
+    handler, or a checkpoint problem becomes a message-handling outage."""
+    _clear_checkpoint()
+    orig = bridge._update_dm_checkpoint
+
+    def boom(*a, **kw):
+        raise OSError("disk full")
+
+    bridge._update_dm_checkpoint = boom
+    try:
+        _drive_self_authored(_FakeDM(4242), msg_id=99999)  # must not raise
+    finally:
+        bridge._update_dm_checkpoint = orig
+
+
 def main():
     failures = []
     for fn in (
@@ -286,6 +370,9 @@ def main():
         test_source_wires_catchup_into_on_ready,
         test_source_wires_checkpoint_update_into_handler,
         test_self_authored_dms_advance_the_checkpoint,
+        test_self_authored_dm_actually_advances_the_checkpoint,
+        test_self_authored_guild_message_leaves_checkpoint_untouched,
+        test_checkpoint_write_failure_does_not_break_the_handler,
     ):
         try:
             fn()

--- a/tests/discord-bridge-dm-catchup.test.py
+++ b/tests/discord-bridge-dm-catchup.test.py
@@ -212,6 +212,66 @@ def test_source_wires_checkpoint_update_into_handler():
     )
 
 
+def test_self_authored_dms_advance_the_checkpoint():
+    """The SELF-AUTHOR early return must advance the checkpoint before dropping.
+
+    `test_source_wires_checkpoint_update_into_handler` above greps the whole
+    handler body, so it passes as long as *any* call exists — and it did, while
+    this branch still returned without one. That is why this test is scoped to
+    the branch rather than the function.
+
+    Why it matters: `channel.history()` returns our own replies, and in a DM
+    channel with the owner most messages ARE ours. `if message.author ==
+    client.user: return` sits ABOVE the main checkpoint advance, so the
+    checkpoint froze at the last message we did not write and every reconnect
+    re-fetched the same window. Observed on two hosts as
+    `[dm-catchup] replayed N missed DM(s)` with an identical N across restarts.
+
+    The starvation this guards: catch-up fetches `limit=50, oldest_first=True`.
+    Once >50 messages sit after a frozen checkpoint, an owner DM at position 51+
+    is never fetched, and the checkpoint still cannot advance, so no later
+    restart reaches it — silent permanent loss of the exact message catch-up
+    exists to rescue.
+    """
+    # Parsed by INDENT, not regex. A non-greedy regex here silently over-matches
+    # past this branch's `return` and swallows the legitimate checkpoint advance
+    # further down the function — which makes the assertion pass on the very code
+    # it is supposed to reject. (That is not hypothetical: the first version of
+    # this test did exactly that and passed against the unfixed bridge.)
+    lines = (REPO / "src" / "discord-bridge.py").read_text().splitlines()
+    start = next(
+        (i for i, l in enumerate(lines)
+         if l.strip() == "if message.author == client.user:"),
+        None,
+    )
+    assert start is not None, "could not locate the self-author early-return branch"
+    if_indent = len(lines[start]) - len(lines[start].lstrip())
+    branch_lines = []
+    for l in lines[start + 1:]:
+        if not l.strip():
+            branch_lines.append(l)
+            continue
+        indent = len(l) - len(l.lstrip())
+        if indent <= if_indent:          # dedented out of the branch
+            break
+        branch_lines.append(l)
+        if l.strip() == "return":        # the branch's own exit — stop here
+            break
+    branch = "\n".join(branch_lines)
+    assert branch.rstrip().endswith("return"), (
+        f"branch extraction did not terminate on the early return; got:\n{branch}"
+    )
+    assert "_update_dm_checkpoint" in branch, (
+        "the self-authored-DM branch returns WITHOUT advancing the checkpoint — "
+        "our own replies then pin the checkpoint forever and catch-up re-fetches "
+        "the same window on every restart (see docstring for the starvation path)."
+    )
+    assert "DMChannel" in branch, (
+        "the self-author checkpoint advance must be gated on DMChannel — the "
+        "checkpoint is per-DM-channel and guild messages have no place in it."
+    )
+
+
 def main():
     failures = []
     for fn in (
@@ -225,6 +285,7 @@ def main():
         test_load_filters_malformed_entries,
         test_source_wires_catchup_into_on_ready,
         test_source_wires_checkpoint_update_into_handler,
+        test_self_authored_dms_advance_the_checkpoint,
     ):
         try:
             fn()


### PR DESCRIPTION
## Why

`_handle_discord_message` drops self-authored messages at its first line, and that return sits **above** the checkpoint advance:

```python
async def _handle_discord_message(message, force=False):
    if message.author == client.user:
        return                                    # <- line 2798
    ...
    if is_dm and hasattr(message, "id"):
        _update_dm_checkpoint(...)                # <- line 2830, never reached for our own DMs
```

`channel.history()` returns our own replies, and in a DM channel with the owner **most messages are ours**. So the checkpoint freezes at the last message we did not write, and every reconnect re-fetches the same window.

Found by @Sutando-Mini during the #2626 capture: `[dm-catchup] replayed 27 missed DM(s)` logged with an **identical count across two consecutive restarts** — a replay count that never decreases is a checkpoint that never advances.

## Evidence

Confirmed independently on this host against the live checkpoint:

```
checkpoint (state/discord-dm-checkpoint.json)   1534250200540119120  -> 10:22:32
messages after it (Discord REST)                4
  authored by Sutando-Pro [BOT]                 4     <- all of them
newest message in channel                       12:03:21
```

Every one of the four hits the line-2798 return before reaching the advance. Two hosts, two different counts, same mechanism.

## Why it is worth fixing rather than noting

Latent today: the return means nothing is re-processed, so no duplicate task and no duplicate DM.

But it is a live **starvation** path. Catch-up fetches `limit=50, oldest_first=True`. Once more than 50 messages accumulate after a frozen checkpoint, an owner DM at position 51+ is never fetched — and the checkpoint still cannot advance, so no later restart reaches it either. That is silent, permanent loss of exactly the message this catch-up exists to rescue: the 2026-05-21 incident quoted in the test's own docstring ("B + A in that order", lost across a 75-minute disconnect).

The main advance already states this contract and applies it to out-of-allowlist and out-of-tier DMs. Self-authored messages were the one class that escaped it.

## Before / after

```
tests/discord-bridge-dm-catchup.test.py, same file both runs
  origin/main    exit=1   ✗ test_self_authored_dms_advance_the_checkpoint
                          "the self-authored-DM branch returns WITHOUT advancing the checkpoint"
  this branch    exit=0   11/11 pass
```

All 31 `tests/discord-bridge-*.test.py` suites pass at this head. `review-checks --diff` PASS.

## A note on the test itself

The existing `test_source_wires_checkpoint_update_into_handler` greps the **whole handler body**, so it passed throughout the bug's life — any call anywhere satisfies it. The new guard is scoped to the branch.

It parses by **indent, not regex**, and that was not a style preference: my first version used a non-greedy regex, which over-matched past this branch's `return` and swallowed the legitimate advance below it — so it **passed against the unfixed bridge**. The control caught it. The test now asserts its own extraction terminated on the early return before asserting anything about the contents.

## Worst-case disruption

Low. The change adds a checkpoint write on a path that previously returned immediately; it is gated on `DMChannel` so guild messages are untouched, wrapped in try/except so a write failure logs rather than breaks message handling, and `_update_dm_checkpoint` is already forward-only. Effect is that the checkpoint tracks what we have seen, which is what its docstring says it is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
