### PR TITLE
feat(health-check): a quarantined proactive DM is preserved and unread

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -4634,6 +4634,72 @@ def check_orphaned_results(threshold_age_sec: int = 900) -> dict:
     }
 
 
+def check_proactive_quarantine() -> dict:
+    """Report proactive bodies that were SAVED from deletion and then forgotten.
+
+    `poll_proactive` used to `unlink()` a DM that Discord rejected, so a message
+    the owner never saw was also destroyed — observed live here as
+    `413 Payload Too Large (error code: 40005)`. The fix (#2626) moves the body
+    to `results/undelivered/` instead of deleting it, which is strictly better
+    and still ends with nobody being told: a scan of the whole tree at that
+    change's head finds the writer and **no reader at all**. The nearest
+    candidate, `friction-detector.check_stale_results()`, is a stub that returns
+    `[]` and is never called.
+
+    That is the shape this probe exists to close. Preservation without a reader
+    is a message that exists on disk and reaches no one — the same failure as
+    deletion from the owner's side, minus the recoverability. Losing it loudly
+    at least surfaces; losing it quietly does not.
+
+    Deliberately NOT a failure: quarantine is the correct end state for a body
+    Discord will never accept (a 413 never becomes a 200). The action is for a
+    human to read it and decide, so `warn` — visible, not alarming.
+
+    Silent before #2626 lands: the directory is created only by that writer, so
+    an absent dir reports ok rather than inventing a problem.
+    """
+    name = "proactive-quarantine"
+    quarantine = WORKSPACE_DIR / "results" / "undelivered"
+    if not quarantine.is_dir():
+        return {"name": name, "status": "ok",
+                "detail": "no quarantined proactive bodies (undelivered/ absent)"}
+    now = time.time()
+    try:
+        entries = list(quarantine.iterdir())
+    except OSError as e:  # noqa: BLE001 — a probe failure must not fail the check
+        return {"name": name, "status": "warn",
+                "detail": f"could not scan results/undelivered/: {e}"}
+    kept: list[tuple[str, int]] = []
+    unreadable = 0
+    for path in entries:
+        # Per-file isolation, same reason as check_orphaned_results: one
+        # unreadable entry must not decide the answer for the directory.
+        try:
+            if not path.is_file():
+                continue
+            age = now - path.stat().st_mtime
+        except OSError:
+            unreadable += 1
+            continue
+        kept.append((path.name, int(age)))
+    partial = (f" ({unreadable} entr{'y' if unreadable == 1 else 'ies'} unreadable)"
+               if unreadable else "")
+    if not kept:
+        status = "warn" if unreadable else "ok"
+        return {"name": name, "status": status,
+                "detail": f"no quarantined proactive bodies{partial}"}
+    kept.sort(key=lambda item: -item[1])
+    oldest_name, oldest_age = kept[0]
+    return {
+        "name": name,
+        "status": "warn",
+        "detail": (f"{len(kept)} proactive message(s) kept in results/undelivered/ that Discord "
+                   f"refused — preserved, but nothing reads this directory, so nobody has been "
+                   f"told; oldest {oldest_name} ({oldest_age // 3600}h{oldest_age % 3600 // 60}m)"
+                   f"{partial}"),
+    }
+
+
 def _proc_argv(pid: int) -> str:
     """argv of `pid`, or "" if no such process.
 
@@ -6021,6 +6087,7 @@ def run_all_checks() -> list[dict]:
     checks.append(check_core_supervisor())
     checks.append(check_task_queue(threshold_count=queue_count, threshold_age_sec=queue_age_sec))
     checks.append(check_orphaned_results())
+    checks.append(check_proactive_quarantine())
     checks.append(check_task_watcher())
     checks.append(check_codex_task_notifier())
     checks.append(check_skill_symlinks())

--- a/tests/health-check-proactive-quarantine.test.py
+++ b/tests/health-check-proactive-quarantine.test.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Tests for health-check.py's check_proactive_quarantine.
+
+#2626 stops `poll_proactive` from deleting a proactive DM that Discord refused,
+moving the body to `results/undelivered/` instead. That is strictly better than
+destroying it and still leaves nobody informed: at that change's head the only
+code touching the directory is the writer. This probe is the reader.
+
+The controls that matter here are the ones that would let the probe report a
+clean host while a message sits unread:
+
+  * a NON-EMPTY quarantine must warn      <- the whole point; must fail if the
+                                             probe is neutered to always-ok
+  * an ABSENT directory must be ok        <- silent before #2626 lands, so it
+                                             cannot invent a problem
+  * an EMPTY directory must be ok         <- without this, "warns on non-empty"
+                                             is satisfied by warning always
+  * an unreadable entry must be COUNTED, not rounded down into a clean verdict
+  * a sub-DIRECTORY is not a message      <- it must not inflate the count
+
+Hermetic: WORKSPACE_DIR is rebound to a tmpdir for every case, and the last
+test asserts the operator's real workspace was never touched.
+
+Run: python3 tests/health-check-proactive-quarantine.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.join(_HERE, "..", "src", "health-check.py")
+_spec = importlib.util.spec_from_file_location("health_check", _SRC)
+hc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hc)
+
+
+class TestProactiveQuarantine(unittest.TestCase):
+    def _run(self, td):
+        with mock.patch.object(hc, "WORKSPACE_DIR", pathlib.Path(td)):
+            return hc.check_proactive_quarantine()
+
+    def _quarantine(self, td):
+        q = pathlib.Path(td) / "results" / "undelivered"
+        q.mkdir(parents=True, exist_ok=True)
+        return q
+
+    # --- the point ------------------------------------------------------
+    def test_a_kept_body_warns_and_is_named(self):
+        with tempfile.TemporaryDirectory() as td:
+            q = self._quarantine(td)
+            body = q / "proactive-1785870055.txt"
+            body.write_text("[file: /tmp/sutando-oversize.bin]")
+            old = time.time() - 2 * 3600 - 15 * 60
+            os.utime(body, (old, old))
+            r = self._run(td)
+            self.assertEqual(r["status"], "warn", r)
+            self.assertIn("proactive-1785870055.txt", r["detail"])
+            self.assertIn("2h15m", r["detail"])
+            # The verdict must say WHY it matters, not just that a file exists.
+            self.assertIn("nothing reads this directory", r["detail"])
+
+    def test_every_kept_body_is_counted(self):
+        with tempfile.TemporaryDirectory() as td:
+            q = self._quarantine(td)
+            for i in range(3):
+                (q / f"proactive-{i}.txt").write_text("x")
+            r = self._run(td)
+            self.assertEqual(r["status"], "warn", r)
+            self.assertIn("3 proactive message(s)", r["detail"])
+
+    # --- the controls that stop "warn" from being free -------------------
+    def test_absent_directory_is_ok(self):
+        """Silent before #2626 lands. A probe that warns on a directory nothing
+        creates yet is noise that trains its reader to ignore it."""
+        with tempfile.TemporaryDirectory() as td:
+            r = self._run(td)
+            self.assertEqual(r["status"], "ok", r)
+            self.assertIn("absent", r["detail"])
+
+    def test_empty_directory_is_ok(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._quarantine(td)
+            r = self._run(td)
+            self.assertEqual(r["status"], "ok", r)
+
+    def test_a_subdirectory_is_not_a_message(self):
+        with tempfile.TemporaryDirectory() as td:
+            q = self._quarantine(td)
+            (q / "somedir").mkdir()
+            r = self._run(td)
+            self.assertEqual(r["status"], "ok", r)
+
+    # --- coverage is part of the verdict ---------------------------------
+    def test_an_unreadable_entry_is_reported_not_rounded_down(self):
+        """An entry we cannot stat must appear in the detail. Rounding it into
+        'no quarantined bodies' is how a probe reports clean while blind."""
+        with tempfile.TemporaryDirectory() as td:
+            q = self._quarantine(td)
+            boom = q / "unstattable.txt"
+            boom.write_text("x")
+            real_stat = pathlib.Path.stat
+            real_is_file = pathlib.Path.is_file
+
+            def _is_file(self, *a, **k):
+                if self.name == "unstattable.txt":
+                    return True
+                return real_is_file(self, *a, **k)
+
+            def _stat(self, *a, **k):
+                if self.name == "unstattable.txt":
+                    raise OSError(5, "I/O error")
+                return real_stat(self, *a, **k)
+
+            # is_file() must be patched too: pathlib swallows OSError inside it
+            # and returns False, so patching stat alone would skip the entry one
+            # line earlier and the "unreadable" branch would never execute while
+            # the assertion still passed.
+            with mock.patch.object(pathlib.Path, "is_file", _is_file), \
+                 mock.patch.object(pathlib.Path, "stat", _stat):
+                r = self._run(td)
+            self.assertEqual(r["status"], "warn", r)
+            self.assertIn("1 entry unreadable", r["detail"])
+
+    def test_a_scan_failure_warns_rather_than_raising(self):
+        with tempfile.TemporaryDirectory() as td:
+            self._quarantine(td)
+            with mock.patch.object(pathlib.Path, "iterdir",
+                                   side_effect=OSError(13, "denied")):
+                r = self._run(td)
+            self.assertEqual(r["status"], "warn", r)
+            self.assertIn("could not scan", r["detail"])
+
+    # --- hermetic ---------------------------------------------------------
+    def test_the_operators_real_workspace_is_never_touched(self):
+        before = None
+        real = hc.WORKSPACE_DIR / "results" / "undelivered"
+        if real.is_dir():
+            before = sorted(p.name for p in real.iterdir())
+        with tempfile.TemporaryDirectory() as td:
+            self._quarantine(td)
+            (pathlib.Path(td) / "results" / "undelivered" / "x.txt").write_text("x")
+            self._run(td)
+        after = sorted(p.name for p in real.iterdir()) if real.is_dir() else None
+        self.assertEqual(before, after)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
@sonichi — flagging you as the author, per my standing rule.

## What's wrong

#2626 stops `poll_proactive` from deleting a proactive DM that Discord refused, moving the body to `results/undelivered/` instead. That is strictly better than destroying it — and it still ends with nobody being told.

I walked every `.py`/`.ts`/`.sh`/`.swift` file at #2626's head. The only code touching that directory is the **writer**, `src/discord-bridge.py:5018-5031`. There is no reader. The two other matches for `undelivered` are false friends:

- `src/health-check.py:2361` — a comment about mobile DMs
- `src/friction-detector.py:208` — `check_stale_results()`, whose body is `# Not critical — skip for now` / `return []`. Grep finds exactly one occurrence of that name in the file: its own `def`. It is never called either.

Preservation without a reader is a message that exists on disk and reaches no one. From the owner's side that is deletion, minus the recoverability.

**This is not hypothetical on this host.** Running the #2626 live capture put a real body in `results/undelivered/` at 12:00 today, and `python3 src/health-check.py` says nothing about it.

## What this does

Adds `check_proactive_quarantine()`. `warn`, never `fail` — quarantine is the *correct* end state for a body Discord will never accept (a 413 never becomes a 200); the action is for a human to read it and decide, which is what a warn asks for.

Silent before #2626 lands: the directory is created only by that writer, so an absent dir reports `ok` rather than inventing a problem. This is deliberately a reader for a producer that is still in review — if #2626 does not land, this probe is inert rather than wrong.

## Evidence

Before, on this host, with a body sitting in the directory:

```
  ✓ orphaned-results               ok           no undeliverable results
  (no line for the quarantined body — nothing looks)
```

After:

```
  ⚠ proactive-quarantine           warn         1 proactive message(s) kept in results/undelivered/ that Discord refused — preserved, but nothing reads this directory, so nobody has been told; oldest proactive-2626capture-1785870055.txt (0h21m)
```

*(Corrected after opening: this block first read `(8h0m)`. The wording was verbatim but I composed
the age instead of copying it, in a fenced block a reviewer would reasonably read as pasted output.
Both blocks above are now the real thing, captured by driving `check_orphaned_results` and
`check_proactive_quarantine` against this host's live workspace.)*

**Verified by mutation, not by watching 8 assertions pass:**

```
BASELINE                          rc=0
always-ok                         rc=1, 5 failures
drop the `unreadable` accounting  rc=1, 1 failure
RESTORED                          rc=0
```

The second mutant is worth a note for whoever reviews this. That accounting block is **byte-identical** to one in `check_orphaned_results` earlier in the file, so a naive `replace(..., 1)` mutates the wrong function and the suite stays green — which is exactly what my first run reported. I only have a real control because the second attempt sliced the file at this function's `def` first. A mutation that silently lands somewhere else is indistinguishable from a test that doesn't cover the branch.

Controls in the suite are chosen so `warn` is never free: absent dir → ok, empty dir → ok, sub-directory is not a message, an unstattable entry is **counted** rather than rounded down into a clean verdict, and a scan failure warns instead of raising. The unreadable case patches `is_file` as well as `stat`, because pathlib swallows `OSError` inside `is_file` and returns False — patching `stat` alone skips the entry one line earlier while the assertion still passes.

Hermetic: `WORKSPACE_DIR` is rebound per case, and the last test asserts the operator's real `results/undelivered/` was untouched.

## Worst case

A host that quarantines many bodies gets one persistent warn line until someone empties the directory. That is the intended cost — the alternative is the current silence. No file is read, moved, or deleted by this probe.

