### PR TITLE
fix(friction-detector): a check it defines but never runs reads as coverage

### DIFF
--- a/src/friction-detector.py
+++ b/src/friction-detector.py
@@ -204,12 +204,6 @@ def check_overdue_reminders():
     return issues
 
 
-def check_stale_results():
-    """Find undelivered results (no corresponding task completion)."""
-    # Not critical — skip for now
-    return []
-
-
 def check_notes_without_follow_up():
     """Find notes tagged 'action' or 'todo' that are >7 days old."""
     issues = []

--- a/tests/friction-detector-every-check-is-registered.test.py
+++ b/tests/friction-detector-every-check-is-registered.test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""The set of checks friction-detector DEFINES must equal the set it RUNS.
+
+Two failures live in the gap between those sets, and this file exists because
+both were real in `src/friction-detector.py` at the same time:
+
+  * a check defined and never called — `check_stale_results()` carried the
+    docstring "Find undelivered results (no corresponding task completion)"
+    and a body of `return []`. It was never in `main()`. On 2026-08-04 it cost
+    a real investigation: asking "does anything cover undelivered results?"
+    finds that name, reads as coverage, and is dead.
+  * a check dropped from `main()` — measured, not assumed: deleting
+    `all_issues.extend(check_pending_questions())` broke **zero** of the two
+    existing friction suites. A live check can be silently unregistered and
+    the detector keeps reporting a clean run.
+
+The second is why "the suites still pass" was not evidence that removing the
+stub was safe. A negative from a set of tests never shown able to produce a
+positive says nothing, so the equality below is asserted structurally rather
+than trusted to the existing suites.
+
+Deliberately an equality, not two one-way checks: either direction alone is
+satisfiable by the other's bug.
+
+Run: python3 tests/friction-detector-every-check-is-registered.test.py
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.join(_HERE, "..", "src", "friction-detector.py")
+
+
+def _module_tree() -> ast.Module:
+    with open(_SRC) as fh:
+        return ast.parse(fh.read())
+
+
+def _defined_checks(tree: ast.Module) -> set[str]:
+    return {
+        node.name
+        for node in tree.body                      # module level only
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("check_")
+    }
+
+
+def _checks_called_in_main(tree: ast.Module) -> set[str]:
+    main = next(
+        (n for n in tree.body
+         if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == "main"),
+        None,
+    )
+    if main is None:
+        raise AssertionError("friction-detector.py has no main() — the registration site moved")
+    called: set[str] = set()
+    for node in ast.walk(main):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                and node.func.id.startswith("check_"):
+            called.add(node.func.id)
+    return called
+
+
+class TestEveryCheckIsRegistered(unittest.TestCase):
+    def test_defined_and_run_sets_are_equal(self):
+        tree = _module_tree()
+        defined = _defined_checks(tree)
+        called = _checks_called_in_main(tree)
+
+        # Guard the instrument itself: an empty set on either side would make
+        # the equality trivially true and this test permanently green.
+        self.assertTrue(defined, "no check_* functions found — the parse is broken, not the file")
+        self.assertTrue(called, "main() calls no check_* function — the parse is broken")
+
+        dead = sorted(defined - called)
+        self.assertFalse(
+            dead,
+            f"defined but never run by main(): {dead}. A check that is never called reads as "
+            f"coverage to anyone grepping for its name. Register it or delete it.",
+        )
+        missing = sorted(called - defined)
+        self.assertFalse(
+            missing,
+            f"called by main() but not defined at module level: {missing}",
+        )
+
+    def test_the_known_dead_stub_has_not_come_back(self):
+        """Named explicitly: this one shipped, sat unused, and misled a search
+        for 'undelivered results'. The equality above would catch it anyway;
+        this asserts the specific regression by name so the reason survives."""
+        self.assertNotIn("check_stale_results", _defined_checks(_module_tree()))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
@sonichi — flagging you as the author.

## What's wrong

`src/friction-detector.py` defined `check_stale_results()`:

```python
def check_stale_results():
    """Find undelivered results (no corresponding task completion)."""
    # Not critical — skip for now
    return []
```

`main()` never called it. Grep for the name finds exactly two hits: its own `def`, and a docstring I wrote in #2649 an hour ago having tripped over it.

**It cost a real investigation today.** While checking whether anything reads `results/undelivered/` (the directory #2626 introduces), this is what a search for "undelivered results" surfaces. The name and docstring read as coverage; the function is dead.

## Why this isn't just a deletion

I first wanted to justify the removal with "the existing friction suites still pass." That is not evidence, so I measured whether those suites *can* fail: I deleted `all_issues.extend(check_pending_questions())` — a **live** check — and **zero of the two** friction suites broke.

So the real gap is that nothing pins the set of checks this file runs. A live check can be silently unregistered and the detector keeps reporting a clean run, which is the same class of failure as the dead stub, pointing the other way.

## The guard

An **equality** between the checks defined at module level and the checks called in `main()`. Either direction alone is satisfiable by the other's bug:

- *every defined check is called* — met by deleting the call site and the def together
- *every called check is defined* — says nothing about dead code

The instrument guards itself: an empty set on either side would make the equality trivially true and the test permanently green, so both sides are asserted non-empty before comparing. There's also a named assertion for `check_stale_results` specifically, so the reason survives even if someone later rewrites the general check.

## Evidence

```
BASELINE (stub removed)            rc=0
dead stub restored                 rc=1
a LIVE check unregistered          rc=1   <- the case the existing suites miss
RESTORED                           rc=0
```

Module still imports and exposes the five real checks:

```
check_github_issues, check_notes_without_follow_up, check_overdue_reminders,
check_pending_questions, check_stale_tasks
```

## Worst case

If someone deliberately wants a defined-but-unregistered helper in this file, this test now blocks it. That seems right for a file whose entire job is reporting what needs attention — but it is a real constraint, so naming it rather than burying it.

Related to #2649 (same investigation, different subsystem) but independent: neither depends on the other, and this one touches no health-check code.
