### PR TITLE
fix(check-pending-tasks): the Stop hook watched <repo>/tasks/, so it never blocked

### DIFF
--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -1,9 +1,26 @@
 #!/bin/bash
 # Stop hook: blocks Claude from finishing when unprocessed tasks exist.
 # Skips tasks that already have a corresponding result file.
+#
+# The queue lives under the WORKSPACE, not the repo (CLAUDE.md "Workspace
+# contract"). This hook used to resolve `$(dirname "$0")/..` — the repo root —
+# so it watched <repo>/tasks/ while every producer and consumer used
+# <workspace>/tasks/. That directory is empty on a normal install, so the hook
+# emitted `{}` on every Stop and never blocked on anything: a guard that cannot
+# fire is a guard that is switched off.
+#
+# Resolve through the same helper every other service uses, so a configured
+# workspace (sutando.config.local.json) is honored rather than assumed.
 
-TASKS_DIR="$(cd "$(dirname "$0")/.." && pwd)/tasks"
-RESULTS_DIR="$(cd "$(dirname "$0")/.." && pwd)/results"
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WORKSPACE="$(bash "$REPO_DIR/scripts/sutando-config.sh" workspace 2>/dev/null)"
+# Fall back to the documented default, never to the repo root: a resolver
+# failure must still leave this pointed at a real queue rather than silently
+# re-disabling the hook the way the old path did.
+[ -n "$WORKSPACE" ] || WORKSPACE="$REPO_DIR/workspace"
+
+TASKS_DIR="$WORKSPACE/tasks"
+RESULTS_DIR="$WORKSPACE/results"
 
 UNPROCESSED=""
 shopt -s nullglob 2>/dev/null

--- a/tests/check-pending-tasks-workspace.test.sh
+++ b/tests/check-pending-tasks-workspace.test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# The Stop hook must watch the WORKSPACE queue, not <repo>/tasks/.
+#
+# THE DEFECT. src/check-pending-tasks.sh resolved its queue as
+# `$(dirname "$0")/../tasks` — the repo root. Every producer (voice, Discord,
+# Telegram, Slack, chat) and every consumer writes <workspace>/tasks/. On a
+# default install those are different directories, so the hook read an empty
+# one, emitted `{}` on every Stop, and never blocked on anything. It is the
+# fail-silent shape: the guard reports success in the only way it can, and a
+# guard that cannot fire is one that has been switched off.
+#
+# WHY BOTH DIRECTIONS ARE PINNED. "Blocks when a task exists" is satisfied by a
+# hook that blocks on either directory, and "does not block when the queue is
+# empty" is satisfied by the broken version. The case that separates them is
+# the third: a file in the LEGACY <repo>/tasks/ must NOT block, because reading
+# that directory is the bug. Without it, a fix that watched both paths would
+# pass and would keep resurrecting pre-migration leftovers.
+#
+# Run: bash tests/check-pending-tasks-workspace.test.sh
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$REPO/src/check-pending-tasks.sh"
+WS="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)"
+[ -n "$WS" ] || WS="$REPO/workspace"
+
+# A name no real producer emits, so cleanup can never touch a live task.
+PROBE="task-zz-hooktest-$$.txt"
+FAILED=0
+
+cleanup() {
+  rm -f "$WS/tasks/$PROBE" "$WS/results/$PROBE" "$REPO/tasks/$PROBE"
+}
+trap cleanup EXIT
+
+ok()   { printf '  ok   %s\n' "$1"; }
+bad()  { printf '  FAIL %s\n     %s\n' "$1" "$2"; FAILED=1; }
+
+mkdir -p "$WS/tasks" "$WS/results"
+
+# 1. A task in the workspace queue must block. FAILS against the old path.
+printf 'id: probe\ntask: probe\n' > "$WS/tasks/$PROBE"
+OUT="$(bash "$HOOK" 2>&1)"
+case "$OUT" in
+  *'"decision":"block"'*) ok "workspace task blocks" ;;
+  *) bad "workspace task blocks" "got: ${OUT:0:120}" ;;
+esac
+
+# 2. ...and the blocked payload must name the task, not just block generically.
+case "$OUT" in
+  *"$PROBE"*) ok "block payload names the task" ;;
+  *) bad "block payload names the task" "payload omits $PROBE" ;;
+esac
+
+# 3. A task with a matching result is already handled — must not block.
+printf 'done\n' > "$WS/results/$PROBE"
+OUT="$(bash "$HOOK" 2>&1)"
+case "$OUT" in
+  '{}') ok "result present suppresses the block" ;;
+  *) bad "result present suppresses the block" "got: ${OUT:0:120}" ;;
+esac
+rm -f "$WS/tasks/$PROBE" "$WS/results/$PROBE"
+
+# 4. THE DIRECTION CASE. A file in the legacy <repo>/tasks/ must NOT block.
+#    Guarded: if the workspace IS the repo (a non-default config), this case
+#    cannot distinguish the two and is skipped rather than reported as passing.
+if [ "$(cd "$WS" && pwd)" = "$REPO" ]; then
+  printf '  skip workspace resolves to the repo root; direction case is not decidable here\n'
+else
+  mkdir -p "$REPO/tasks"
+  printf 'id: probe\ntask: legacy\n' > "$REPO/tasks/$PROBE"
+  OUT="$(bash "$HOOK" 2>&1)"
+  case "$OUT" in
+    '{}') ok "legacy <repo>/tasks/ does not block" ;;
+    *) bad "legacy <repo>/tasks/ does not block" "hook still reads the repo: ${OUT:0:120}" ;;
+  esac
+  rm -f "$REPO/tasks/$PROBE"
+fi
+
+# 5. Empty queue stays quiet — the control that proves case 1 measured something.
+OUT="$(bash "$HOOK" 2>&1)"
+case "$OUT" in
+  '{}') ok "empty queue emits {}" ;;
+  *) bad "empty queue emits {}" "got: ${OUT:0:120}" ;;
+esac
+
+if [ "$FAILED" -eq 0 ]; then echo "PASS"; else echo "FAIL"; fi
+exit "$FAILED"

--- a/tests/check-pending-tasks-workspace.test.sh
+++ b/tests/check-pending-tasks-workspace.test.sh
@@ -6,35 +6,76 @@
 # Telegram, Slack, chat) and every consumer writes <workspace>/tasks/. On a
 # default install those are different directories, so the hook read an empty
 # one, emitted `{}` on every Stop, and never blocked on anything. It is the
-# fail-silent shape: the guard reports success in the only way it can, and a
-# guard that cannot fire is one that has been switched off.
+# fail-silent shape: a broken hook and an empty queue emit the same `{}`, and
+# the queue is empty most of the time anyone looks.
+#
+# ISOLATION (@john-the-dev's blocker on d1767d43). The first version of this
+# test resolved the workspace from the host config and wrote its probe into the
+# caller's REAL queue — the directory `watch-tasks-stream.sh` is concurrently
+# watching. The watcher could claim and execute the probe as a live owner task
+# before the EXIT trap removed it, and cleanup cannot retract a reply already
+# delivered. A synthetic filename lowers collision odds; it does not isolate a
+# live consumer.
+#
+# So this test builds its own workspace and pins it: `SUTANDO_TEST_MODE=1` plus
+# `SUTANDO_WORKSPACE` is the repo's supported escape hatch (src/sutando_config.py
+# ~line 336 — the env var alone is ignored post-v0.8/#1440). Passing a temp dir
+# is NOT isolation on its own, so the resolved path is ASSERTED before anything
+# is written: if the hatch ever regresses, this aborts instead of quietly
+# writing to the live queue.
 #
 # WHY BOTH DIRECTIONS ARE PINNED. "Blocks when a task exists" is satisfied by a
-# hook that blocks on either directory, and "does not block when the queue is
-# empty" is satisfied by the broken version. The case that separates them is
-# the third: a file in the LEGACY <repo>/tasks/ must NOT block, because reading
-# that directory is the bug. Without it, a fix that watched both paths would
-# pass and would keep resurrecting pre-migration leftovers.
+# hook that watches EITHER directory, and "stays quiet when empty" is satisfied
+# by the broken version. The case that separates them is the legacy one: a file
+# in <repo>/tasks/ must NOT block, because reading that directory is the bug.
+# Without it, a fix watching both paths passes — and reintroduces the defect in
+# the other direction, since a stale legacy file would then block forever.
 #
 # Run: bash tests/check-pending-tasks-workspace.test.sh
 set -u
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 HOOK="$REPO/src/check-pending-tasks.sh"
+
+# --- Build and PIN an isolated workspace before resolving anything ----------
+TMPWS="$(mktemp -d "${TMPDIR:-/tmp}/sutando-hooktest.XXXXXX")"
+export SUTANDO_TEST_MODE=1
+export SUTANDO_WORKSPACE="$TMPWS"
+
+LIVE_WS="$(env -u SUTANDO_TEST_MODE -u SUTANDO_WORKSPACE \
+             bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)"
 WS="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)"
-[ -n "$WS" ] || WS="$REPO/workspace"
 
-# A name no real producer emits, so cleanup can never touch a live task.
+# Compare resolved paths, not the strings we passed in — mktemp may hand back a
+# symlinked prefix (/tmp -> /private/tmp on macOS).
+_real() { (cd "$1" 2>/dev/null && pwd -P) || echo "$1"; }
+if [ "$(_real "$WS")" != "$(_real "$TMPWS")" ]; then
+  echo "FAIL: workspace did not resolve to the test dir — refusing to run."
+  echo "      wanted: $TMPWS"
+  echo "      got:    $WS"
+  echo "      The SUTANDO_TEST_MODE escape hatch (src/sutando_config.py) has changed."
+  rm -rf "$TMPWS"
+  exit 1
+fi
+if [ -n "$LIVE_WS" ] && [ "$(_real "$WS")" = "$(_real "$LIVE_WS")" ]; then
+  echo "FAIL: test workspace is the live workspace — refusing to run."
+  rm -rf "$TMPWS"
+  exit 1
+fi
+
+# The legacy probe (case 4) must go where the BUG reads, so it is the one write
+# outside the temp tree. It is safe: watch-tasks-stream.sh resolves its
+# TASKS_DIR from `sutando-config.sh workspace` (line 38), so <repo>/tasks/ has
+# no consumer — and the guard below refuses if the two are ever the same dir.
 PROBE="task-zz-hooktest-$$.txt"
-FAILED=0
+LEGACY_DIR="$REPO/tasks"
 
-cleanup() {
-  rm -f "$WS/tasks/$PROBE" "$WS/results/$PROBE" "$REPO/tasks/$PROBE"
-}
+cleanup() { rm -rf "$TMPWS"; rm -f "$LEGACY_DIR/$PROBE"; }
 trap cleanup EXIT
 
-ok()   { printf '  ok   %s\n' "$1"; }
-bad()  { printf '  FAIL %s\n     %s\n' "$1" "$2"; FAILED=1; }
+FAILED=0
+ok()  { printf '  ok   %s\n' "$1"; }
+bad() { printf '  FAIL %s\n     %s\n' "$1" "$2"; FAILED=1; }
 
 mkdir -p "$WS/tasks" "$WS/results"
 
@@ -46,7 +87,7 @@ case "$OUT" in
   *) bad "workspace task blocks" "got: ${OUT:0:120}" ;;
 esac
 
-# 2. ...and the blocked payload must name the task, not just block generically.
+# 2. ...and the payload must name the task, not just block generically.
 case "$OUT" in
   *"$PROBE"*) ok "block payload names the task" ;;
   *) bad "block payload names the task" "payload omits $PROBE" ;;
@@ -62,19 +103,17 @@ esac
 rm -f "$WS/tasks/$PROBE" "$WS/results/$PROBE"
 
 # 4. THE DIRECTION CASE. A file in the legacy <repo>/tasks/ must NOT block.
-#    Guarded: if the workspace IS the repo (a non-default config), this case
-#    cannot distinguish the two and is skipped rather than reported as passing.
-if [ "$(cd "$WS" && pwd)" = "$REPO" ]; then
-  printf '  skip workspace resolves to the repo root; direction case is not decidable here\n'
+if [ "$(_real "$LEGACY_DIR")" = "$(_real "$WS/tasks")" ]; then
+  printf '  skip legacy dir IS the resolved queue here; direction is not decidable\n'
 else
-  mkdir -p "$REPO/tasks"
-  printf 'id: probe\ntask: legacy\n' > "$REPO/tasks/$PROBE"
+  mkdir -p "$LEGACY_DIR"
+  printf 'id: probe\ntask: legacy\n' > "$LEGACY_DIR/$PROBE"
   OUT="$(bash "$HOOK" 2>&1)"
   case "$OUT" in
     '{}') ok "legacy <repo>/tasks/ does not block" ;;
     *) bad "legacy <repo>/tasks/ does not block" "hook still reads the repo: ${OUT:0:120}" ;;
   esac
-  rm -f "$REPO/tasks/$PROBE"
+  rm -f "$LEGACY_DIR/$PROBE"
 fi
 
 # 5. Empty queue stays quiet — the control that proves case 1 measured something.


### PR DESCRIPTION
## The bug

`src/check-pending-tasks.sh` is the Stop hook whose whole job is to keep a session from finishing while tasks are unprocessed. It resolved its queue as the repo root:

```
TASKS_DIR="$(cd "$(dirname "$0")/.." && pwd)/tasks"
RESULTS_DIR="$(cd "$(dirname "$0")/.." && pwd)/results"
```

Every producer and consumer uses `<workspace>/tasks/`. On a default install that is `<repo>/workspace/tasks/`, a different directory — so the hook read an empty one, emitted `{}` on every Stop, and never blocked on anything.

## Proof, both directions, at `origin/main`

Same probe file, same hook, only the directory differs:

```
$ printf 'id: task-probe\ntask: probe\n' > "$WORKSPACE/tasks/task-9999999999999.txt"
$ bash src/check-pending-tasks.sh
{}                                          <- the real queue. no block.

$ printf 'id: task-probe\ntask: probe\n' > "$REPO/tasks/task-9999999999999.txt"
$ bash src/check-pending-tasks.sh
{"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:
--- task-9999999999999.txt --- id: task-probe task: probe   "
```

The second is the positive control: the hook works. It is correct code pointed at a directory nothing writes. This is the fail-silent shape — the only output a broken run can produce is the same `{}` a healthy empty queue produces, so nothing distinguishes "no work pending" from "not looking."

## The fix

Resolve through `scripts/sutando-config.sh workspace`, the helper every other service uses, so a configured workspace (`sutando.config.local.json`) is honored rather than assumed.

The fallback is deliberate: **on resolver failure it uses `<repo>/workspace`, never `<repo>`.** Falling back to the repo root is exactly the failure being fixed, and it would re-disable the hook silently.

## Test

`tests/check-pending-tasks-workspace.test.sh` — 5 cases, and the fourth is the one that matters:

```
AT HEAD                                   BROKEN PATH (hook reverted, test kept)
  ok   workspace task blocks                FAIL workspace task blocks  -> got: {}
  ok   block payload names the task         FAIL block payload names the task
  ok   result present suppresses the block  ok   result present suppresses the block
  ok   legacy <repo>/tasks/ does not block  FAIL hook still reads the repo
  ok   empty queue emits {}                 ok   empty queue emits {}
PASS  exit=0                              FAIL  exit=1
```

"Blocks when a task exists" is satisfied by a hook that watches *either* directory, and "stays quiet when empty" is satisfied by the broken version — so neither separates them. The **legacy-directory case does**: a file in `<repo>/tasks/` must NOT block, because reading that directory is the bug. Without it, a fix that watched both paths would pass and would keep resurrecting pre-migration leftovers. It is guarded — if the workspace resolves to the repo root the case cannot distinguish the two and is skipped rather than reported as passing.

Case 5 is the control for case 1: if the empty queue also blocked, case 1 would be measuring nothing.

## Existing suites

```
32 suites naming this file / hooks / workspace paths:   pass=32 fail=0
scripts/review-checks.sh --diff (both files):           PASS (hardcoded-paths clean)
git diff --check:                                       clean
```

## Provenance — this was found, fixed, approved, and parked

PR #1272 fixed this in May and was approved (*"Both are real #1149-class silent failures"*), then closed unmerged on 2026-05-29:

> Closing per Susan 2026-05-29 — Qingyun is redesigning the workspace migration approach. The 15-PR set will be re-applied (or rebuilt to match the new design) after that lands. Branch is preserved; can be reopened or cherry-picked when ready.

That redesign has since landed (M0 #1395, M1 #1403, v0.8 #1440). **This is a rebuild, not a cherry-pick, and the difference is load-bearing:** #1272 used `${SUTANDO_WORKSPACE:-$HOME/.sutando/workspace}`, and both halves are now wrong — `$SUTANDO_WORKSPACE` is no longer honored for resolution as of v0.8/#1440, and the literal home path is the hardcoded-path class REVIEW.md lesson 6 rejects. Cherry-picking would have landed an anti-pattern that passes its own tests.

## Worst-case disruption

The hook goes from never blocking to blocking whenever `<workspace>/tasks/` holds a `.txt` with no matching result — its documented purpose, but a behavior change for anyone who has been finishing sessions over a non-empty queue without noticing. Two mitigations are already in the code: the result-file skip means a normally-drained queue is unaffected, and orphan recovery (`/task-orphan-check`) archives stale tasks at startup, so a crash backlog does not become a permanent block. Hosts where the hook is not registered are unaffected either way — including the one I tested on, so my evidence is direct exercise of the script, not an observed missed block in production.

## Scope

One file plus its test. I found it while checking whether the parked `[workspace-migration]` set still applies to `main`: measured against `origin/main`, **12 of 17 unmerged PRs in that set still have their exact removed lines present**. I am deliberately not batching them. Most of the rest are dead code — `results-health.sh`, `tail-events.sh`, `query-conversation.sh`, `deal-finder/scan.py`, `notify.sh`, 0 callers each — or a rename-only refactor (#1333, where `REPO = resolve_workspace()` already resolves correctly and only the name lies, so its 57 "still present" lines are not defects). This one is the live path and the one that ships as a registered hook.

@sonichi — flagging you directly. The parked-set finding is the part I would want your read on beyond this PR; the rest of that list is real but none of it is urgent the way a dead Stop hook is.

Stand: Echo Act IV Mini
