### PR TITLE
refactor(room-ops): gateway() delegates to the credential contract (PR2 of #2668)

### DIFF
--- a/skills/agent-room-ops/_gateway.py
+++ b/skills/agent-room-ops/_gateway.py
@@ -112,42 +112,52 @@ def _token_from_vault(vault_get=None):
     return ""
 
 
+def _credential_contract():
+    """Import the vendored shared credential contract (generated from
+    shared/ag2_gateway_credentials.py — see #2668). Flat sibling import with
+    a skill-dir sys.path assist for importlib-loaded contexts (tests load
+    this module by file path). This is import plumbing, NOT a fallback
+    resolver — there is exactly one parsing implementation."""
+    try:
+        import gateway_credentials as _gc
+    except ImportError:
+        d = os.path.dirname(os.path.abspath(__file__))
+        if d not in sys.path:
+            sys.path.insert(0, d)
+        import gateway_credentials as _gc
+    return _gc
+
+
 def gateway():
     """Return (base_url, headers). base is '' when no gateway is configured.
 
-    Honors the one-token onboarding contract used by remote-gateway-bridge.py:
-    `REMOTE_TASK_TOKEN` may be the COMBINED `"https://<gateway>|<secret>"` form
-    (the URL travels inside the token) or a bare secret. Precedence:
-      - explicit GATEWAY_URL (alias RELAY_URL/REMOTE_TASK_URL) > URL-from-combined-token
-      - explicit GATEWAY_TOKEN (alias RELAY_TOKEN)     > secret-from-combined-token
-    Without this, a standard combined-token install would get base='' (every op
-    degrades "no gateway") or send the whole `url|secret` as the bearer.
+    PR2 of the credential-contract migration (#2668): parsing/precedence now
+    delegates to the vendored shared contract; this facade keeps only the
+    room-ops runtime pieces (the vault tier and header shape). Named
+    behavior change vs the legacy resolver (enabling-only, ratified in
+    #2668): combined onboarding tokens now also split on `%7C`/`%7c` and
+    with a case-insensitive scheme — tokens that previously failed auth on
+    room-ops (sent whole as the bearer) now work, matching sparrow.
+
+    Env chain is DELIBERATELY unchanged: GATEWAY_TOKEN > RELAY_TOKEN >
+    REMOTE_TASK_TOKEN (room-ops has never read AG2_REMOTE_TOKEN from env —
+    the vault tier still tries it), URL: GATEWAY_URL > RELAY_URL >
+    REMOTE_TASK_URL > url-from-token. Vault stays last so a stored value
+    never shadows a fresher env token.
     """
-    # GATEWAY_* is the primary name; RELAY_* and REMOTE_TASK_* are honored as
-    # transition aliases so nothing breaks mid-migration.
-    explicit_token = os.environ.get("GATEWAY_TOKEN") or os.environ.get("RELAY_TOKEN")
-    raw = explicit_token or os.environ.get("REMOTE_TASK_TOKEN") or ""
+    gc = _credential_contract()
+    raw, _name = gc.resolve_alias_precedence(
+        os.environ, ("GATEWAY_TOKEN", "RELAY_TOKEN", "REMOTE_TASK_TOKEN"))
     if not raw:
-        # Env is empty — try the Keychain vault last (parity with sonichi#2638).
-        # Vault last means a stored value can never override a fresher env token.
         raw = _token_from_vault()
-    url_from_token = ""
-    # The combined onboarding string is "https://<gateway>|<secret>" — the URL
-    # travels inside the token. Detect it by the leading URL scheme (NOT a bare
-    # "|"), so this splits even an EXPLICIT combined token while leaving an
-    # explicit bearer that merely contains "|" intact. Without the split, a
-    # `GATEWAY_TOKEN=https://…|secret` was sent whole as the bearer → auth
-    # failure → a 401 the client used to mis-report as "not a joined member".
-    if "|" in raw and raw.split("|", 1)[0].startswith(("http://", "https://")):
-        url_from_token, token = raw.split("|", 1)
-    else:
-        token = raw  # bare secret, or an explicit bearer that isn't combined
-    base = (os.environ.get("GATEWAY_URL") or os.environ.get("RELAY_URL")
-            or os.environ.get("REMOTE_TASK_URL") or url_from_token or "").rstrip("/")
+    explicit_url, _ = gc.resolve_alias_precedence(
+        os.environ, ("GATEWAY_URL", "RELAY_URL", "REMOTE_TASK_URL"))
+    creds = gc.normalize_credentials(raw, explicit_url=explicit_url,
+                                     source="resolved" if raw else "none")
     headers = {"User-Agent": "sutando-room-ops/1"}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return base, headers
+    if creds.token:
+        headers["Authorization"] = f"Bearer {creds.token}"
+    return creds.base_url, headers
 
 
 def http_request(method, url, headers=None, data=None, max_bytes=None):

--- a/tests/credential-contract-golden.test.py
+++ b/tests/credential-contract-golden.test.py
@@ -135,19 +135,20 @@ golden("bearer containing '|' without scheme stays intact",
 golden("trailing slash normalized identically",
        {"GATEWAY_URL": "https://gw.example/", "GATEWAY_TOKEN": "sek4"})
 
-# The KNOWN divergence, frozen explicitly (contract=sparrow semantics):
-golden("%7C combined: legacy room-ops does NOT split (frozen divergence)",
-       {"REMOTE_TASK_TOKEN": "https://gw.example%7Csek5"}, expect_same=False)
+# The former divergence, CONVERGED by PR2 (the named enabling-only change
+# ratified in #2668): room-ops' facade now delegates to the contract, so
+# %7C and uppercase-scheme combined tokens split identically on both sides.
+golden("%7C combined: room-ops now MATCHES the contract (PR2 convergence)",
+       {"REMOTE_TASK_TOKEN": "https://gw.example%7Csek5"})
 with env_scenario({"REMOTE_TASK_TOKEN": "https://gw.example%7Csek5"}):
     base, headers = legacy.gateway()
-check("  legacy %7C behavior pinned: whole value is the bearer, no base URL",
-      base == "" and headers.get("Authorization", "").removeprefix("Bearer ")
-      == "https://gw.example%7Csek5")
-check("  contract %7C behavior pinned: splits into URL + verbatim secret",
+check("  converged %7C behavior: splits into URL + verbatim secret",
+      base == "https://gw.example"
+      and headers.get("Authorization", "").removeprefix("Bearer ") == "sek5")
+check("  contract %7C behavior unchanged",
       parse_onboarding_token("https://gw.example%7Csek5") == ("https://gw.example", "sek5"))
-golden("uppercase-scheme combined: legacy case-sensitive check misses (frozen divergence)",
-       {"REMOTE_TASK_TOKEN": "HTTPS://gw.example|sek6", "GATEWAY_URL": "https://gw.example"},
-       expect_same=False)
+golden("uppercase-scheme combined: converged (PR2)",
+       {"REMOTE_TASK_TOKEN": "HTTPS://gw.example|sek6", "GATEWAY_URL": "https://gw.example"})
 check("  contract is case-insensitive on scheme",
       parse_onboarding_token("HTTPS://gw.example|sek6") == ("HTTPS://gw.example", "sek6"))
 check("  bare secret containing %7C never touched",


### PR DESCRIPTION
## What
Step 5 of the migration order ratified in #2668 (merged): `skills/agent-room-ops/_gateway.py`'s `gateway()` becomes a thin facade over the vendored shared contract (`gateway_credentials.py`) — parsing/precedence delegated, the duplicated implementation deleted. The facade retains ONLY room-ops runtime pieces: the Keychain-vault tier (still last — a stored value never shadows a fresher env token; still trying all four names via `channel_token`) and the header shape. The env chain is deliberately unchanged (`GATEWAY_TOKEN > RELAY_TOKEN > REMOTE_TASK_TOKEN`; room-ops has never read `AG2_REMOTE_TOKEN` from env and still doesn't — adding it would be an unnamed behavior change).

## The named behavior change (enabling-only, pre-ratified)
Combined onboarding tokens now split on `%7C`/`%7c` and with a case-insensitive scheme — the divergence #2668's goldens froze with explicit `expect_same=False`. A `%7C`-encoded token that previously failed auth on room-ops (sent whole as the bearer → 401) now works, matching sparrow (the onboarding-format author's semantics). The two goldens flip to `expect_same=True` at this PR, with the convergence documented at the flip site — the change is explicit, not smuggled.

## Evidence
- `tests/credential-contract-golden.test.py`: **32/32**, including the converged pair asserting the NEW room-ops behavior (`%7C` splits → base `https://gw.example`, bearer `sek5`).
- `skills/agent-room-ops/test_room_ops.py`: **114/114** (`Ran 114 tests ... OK`) — the full room-ops behavior surface is unchanged apart from the named convergence.
- `tools/sync_gateway_credentials.py --check`: clean (no contract drift; this PR does not touch the contract, only the consumer).
- Import mechanics: flat sibling import with a skill-dir `sys.path` assist for importlib-by-path contexts (how the tests load this module) — import plumbing, not a fallback resolver; there is exactly one parsing implementation.

## Sequencing
Parent: #2668 (merged). Next: PR3 (sparrow's parse/precedence delegates; runtime adapters — device-env discovery, rotation, token file, networking — stay sparrow-owned), then the duplicated pure logic there is deleted per the same order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)