### PR TITLE
fix(quota-tracker): the passes-left forecast projects only the 5h window, so it reports runway the account does not have

### DIFF
--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -84,52 +84,113 @@ def _save_burn_history(h: dict) -> None:
         pass
 
 
-def _update_burn_rate(current_util_5h: float) -> dict | None:
-    """Update burn-rate EWMA with the current 5h utilization sample.
+def _advance_ewma(prev, per_pass: float, samples: int):
+    """Fold one per-pass sample into an EWMA. Returns (ewma, samples)."""
+    if prev is None:
+        return per_pass, 1
+    return _EWMA_ALPHA * per_pass + (1 - _EWMA_ALPHA) * prev, min(samples + 1, 99)
 
-    Returns a dict with burn_rate_pct_per_pass and estimated_passes_left
-    if enough history exists, else None.
+
+def _window_horizon(ewma, util, reset_epoch):
+    """Passes until `util` reaches 1.0 at `ewma`/pass — or None if it never does.
+
+    None means "this window does not bind": either there is no usable rate, or
+    the forecast runs past the window's own reset, at which point it refills and
+    the projection is void. A window cannot constrain you beyond its refill, so
+    reporting a number larger than the time to that refill is not a conservative
+    estimate — it is an unreachable one.
+    """
+    if not ewma or ewma <= 0:
+        return None
+    passes = ((1 - util) * 100) / (ewma * 100)
+    if reset_epoch is not None:
+        passes_until_reset = max(0.0, (reset_epoch - time.time()) / 300.0)
+        if passes > passes_until_reset:
+            return None
+    return passes
+
+
+def _update_burn_rate(current_util_5h: float, current_util_7d=None,
+                      reset_5h_epoch=None, reset_7d_epoch=None) -> dict | None:
+    """Update the burn-rate EWMAs and forecast the BINDING window.
+
+    Both rolling limits are tracked, because either can be the one that stops
+    the loop and they run out at different times. The 5h window refills every
+    five hours; the 7d window can be days from its reset, so a 5h-only forecast
+    reports headroom that the account does not actually have. Observed
+    2026-08-05 on Chis-Mac-mini: 5h at 89% remaining and 7d at 27%, and the
+    5h-only forecast printed 615 minutes left when the 5h window it was
+    projecting refilled in 212 — a number 403 minutes past its own reset, while
+    the window that could not refill for another four days went unmentioned.
+
+    `estimated_passes_left` keeps its name and its meaning of "passes until the
+    loop is stopped"; what changes is that it now considers every window that
+    can stop it. `binding_window` names which one it came from, and is None when
+    no window runs out before its own reset.
     """
     now = time.time()
     h = _load_burn_history()
     last_ts = h.get("last_read_ts")
-    last_util = h.get("last_util_5h")
-    ewma = h.get("burn_rate_5h_ewma")
-    samples = h.get("burn_samples", 0)
 
     new_h = dict(h)
     new_h["last_read_ts"] = now
     new_h["last_util_5h"] = current_util_5h
-    new_h["schema_version"] = 1
+    if current_util_7d is not None:
+        new_h["last_util_7d"] = current_util_7d
+    new_h["schema_version"] = 2
 
-    result = None
-    if last_ts is not None and last_util is not None:
+    ewma_5h = h.get("burn_rate_5h_ewma")
+    ewma_7d = h.get("burn_rate_7d_ewma")
+    samples_5h = h.get("burn_samples", 0)
+    samples_7d = h.get("burn_samples_7d", 0)
+
+    if last_ts is not None:
         gap = now - last_ts
-        delta = current_util_5h - last_util
-        if _MIN_GAP_S <= gap <= _MAX_GAP_S and delta >= 0:
-            # Normalise delta to a "per 5-min pass" rate regardless of actual gap
-            per_pass = delta * (300.0 / gap)
-            if ewma is None:
-                ewma = per_pass
-                samples = 1
-            else:
-                ewma = _EWMA_ALPHA * per_pass + (1 - _EWMA_ALPHA) * ewma
-                samples = min(samples + 1, 99)
-            new_h["burn_rate_5h_ewma"] = ewma
-            new_h["burn_samples"] = samples
+        if _MIN_GAP_S <= gap <= _MAX_GAP_S:
+            scale = 300.0 / gap
+            # `burn_samples` keeps its pre-existing meaning — 5h samples — so a
+            # v1 history file carries over without reinterpretation.
+            last_5h = h.get("last_util_5h")
+            if last_5h is not None and current_util_5h - last_5h >= 0:
+                ewma_5h, samples_5h = _advance_ewma(
+                    ewma_5h, (current_util_5h - last_5h) * scale, samples_5h)
+                new_h["burn_rate_5h_ewma"] = ewma_5h
+                new_h["burn_samples"] = samples_5h
+            # 7d is folded on its OWN counter. The windows reset independently:
+            # a 5h reset zeroes that delta while 7d keeps climbing, so a shared
+            # counter would suppress the 7d forecast for exactly the readings
+            # taken across a 5h reset — the moments the 7d number matters most.
+            last_7d = h.get("last_util_7d")
+            if (current_util_7d is not None and last_7d is not None
+                    and current_util_7d - last_7d >= 0):
+                ewma_7d, samples_7d = _advance_ewma(
+                    ewma_7d, (current_util_7d - last_7d) * scale, samples_7d)
+                new_h["burn_rate_7d_ewma"] = ewma_7d
+                new_h["burn_samples_7d"] = samples_7d
 
     _save_burn_history(new_h)
 
-    ewma_final = new_h.get("burn_rate_5h_ewma")
-    if ewma_final and ewma_final > 0 and new_h.get("burn_samples", 0) >= 2:
-        remaining_pct = (1 - current_util_5h) * 100
-        passes_left = remaining_pct / (ewma_final * 100)
-        result = {
-            "burn_rate_pct_per_pass": round(ewma_final * 100, 2),
-            "burn_samples": new_h["burn_samples"],
-            "estimated_passes_left": round(passes_left, 1),
-            "estimated_minutes_left": round(passes_left * 5),
-        }
+    horizons = {}
+    if new_h.get("burn_samples", 0) >= 2:
+        horizons["5h"] = _window_horizon(
+            new_h.get("burn_rate_5h_ewma"), current_util_5h, reset_5h_epoch)
+    if current_util_7d is not None and new_h.get("burn_samples_7d", 0) >= 2:
+        horizons["7d"] = _window_horizon(
+            new_h.get("burn_rate_7d_ewma"), current_util_7d, reset_7d_epoch)
+    if not horizons:
+        return None
+    binding = min((w for w in horizons if horizons[w] is not None),
+                  key=lambda w: horizons[w], default=None)
+
+    result = {
+        "burn_rate_pct_per_pass": round((new_h.get("burn_rate_5h_ewma") or 0) * 100, 2),
+        "burn_samples": new_h.get("burn_samples", 0),
+        "binding_window": binding,
+        "estimated_passes_left": round(horizons[binding], 1) if binding else None,
+        "estimated_minutes_left": round(horizons[binding] * 5) if binding else None,
+    }
+    if new_h.get("burn_rate_7d_ewma"):
+        result["burn_rate_7d_pct_per_pass"] = round(new_h["burn_rate_7d_ewma"] * 100, 2)
     return result
 
 
@@ -167,7 +228,11 @@ def main():
         result["reset_7d"] = datetime.fromtimestamp(int(reset_7d)).isoformat()
 
     if "--gate" not in sys.argv:
-        burn = _update_burn_rate(util_5h)
+        burn = _update_burn_rate(
+            util_5h, util_7d,
+            int(reset_5h) if reset_5h else None,
+            int(reset_7d) if reset_7d else None,
+        )
         if burn:
             result["burn"] = burn
 
@@ -192,7 +257,11 @@ def main():
     if result.get("burn"):
         b = result["burn"]
         print(f"Burn rate: {b['burn_rate_pct_per_pass']}%/pass ({b['burn_samples']} samples)")
-        print(f"Est. passes left: {b['estimated_passes_left']} (~{b['estimated_minutes_left']}m)")
+        if b.get("binding_window"):
+            print(f"Est. passes left: {b['estimated_passes_left']} "
+                  f"(~{b['estimated_minutes_left']}m, {b['binding_window']} window binds)")
+        else:
+            print("Est. passes left: no window runs out before its own reset")
 
 
 if __name__ == "__main__":

--- a/skills/quota-tracker/scripts/read-quota.py
+++ b/skills/quota-tracker/scripts/read-quota.py
@@ -61,6 +61,8 @@ _EWMA_ALPHA = 0.3
 # Sample inclusion window: skip deltas from outside [MIN_GAP_S, MAX_GAP_S].
 _MIN_GAP_S = 120     # 2 min — same-pass double-reads shouldn't count
 _MAX_GAP_S = 7200    # 2 h — stale gap yields unreliable per-pass rate
+# A window needs this many of its OWN samples before it can be forecast.
+_MIN_SAMPLES = 2
 
 
 def _load_burn_history() -> dict:
@@ -170,15 +172,34 @@ def _update_burn_rate(current_util_5h: float, current_util_7d=None,
 
     _save_burn_history(new_h)
 
-    horizons = {}
-    if new_h.get("burn_samples", 0) >= 2:
-        horizons["5h"] = _window_horizon(
-            new_h.get("burn_rate_5h_ewma"), current_util_5h, reset_5h_epoch)
-    if current_util_7d is not None and new_h.get("burn_samples_7d", 0) >= 2:
-        horizons["7d"] = _window_horizon(
-            new_h.get("burn_rate_7d_ewma"), current_util_7d, reset_7d_epoch)
+    # A window is EXPECTED whenever the caller supplied its utilization, and
+    # FORECAST only once it has two samples of its own. Keeping those separate
+    # is the whole point: every pre-existing v1 history already satisfies the 5h
+    # gate and carries NO 7d counter, so for the first reads after an upgrade
+    # the 7d window is expected-but-unforecast. Folding that into "no window
+    # binds" prints an all-clear over a window nobody measured — the same
+    # could-not-measure-reported-as-a-result this change exists to remove, one
+    # layer up. Reproduced against a real v1 history with 7d at 95%: it returned
+    # binding_window null and the human path said "no window runs out".
+    # The same guard covers a 7d stream that never matures; omission is never
+    # read as safety.
+    expected = ["5h"] + (["7d"] if current_util_7d is not None else [])
+    samples = {"5h": new_h.get("burn_samples", 0),
+               "7d": new_h.get("burn_samples_7d", 0)}
+    utils = {"5h": current_util_5h, "7d": current_util_7d}
+    ewmas = {"5h": new_h.get("burn_rate_5h_ewma"),
+             "7d": new_h.get("burn_rate_7d_ewma")}
+    resets = {"5h": reset_5h_epoch, "7d": reset_7d_epoch}
+
+    horizons, unforecast = {}, []
+    for w in expected:
+        if samples[w] >= _MIN_SAMPLES:
+            horizons[w] = _window_horizon(ewmas[w], utils[w], resets[w])
+        else:
+            unforecast.append(w)
     if not horizons:
         return None
+
     binding = min((w for w in horizons if horizons[w] is not None),
                   key=lambda w: horizons[w], default=None)
 
@@ -188,6 +209,9 @@ def _update_burn_rate(current_util_5h: float, current_util_7d=None,
         "binding_window": binding,
         "estimated_passes_left": round(horizons[binding], 1) if binding else None,
         "estimated_minutes_left": round(horizons[binding] * 5) if binding else None,
+        # Non-empty means the verdict is INCOMPLETE, not clear. A consumer that
+        # reads `binding_window: null` on its own cannot tell those apart.
+        "unforecast_windows": unforecast,
     }
     if new_h.get("burn_rate_7d_ewma"):
         result["burn_rate_7d_pct_per_pass"] = round(new_h["burn_rate_7d_ewma"] * 100, 2)
@@ -257,9 +281,20 @@ def main():
     if result.get("burn"):
         b = result["burn"]
         print(f"Burn rate: {b['burn_rate_pct_per_pass']}%/pass ({b['burn_samples']} samples)")
+        # An unforecast window taints BOTH outcomes, not just the empty one: a
+        # binding number is only the minimum over the windows actually measured,
+        # so printing it bare while another window is unmeasured asserts more
+        # than was checked. Caveat first, verdict second.
+        pending = b.get("unforecast_windows") or []
+        caveat = (f" [INCOMPLETE: no history yet for {', '.join(pending)} — "
+                  f"not forecast]") if pending else ""
         if b.get("binding_window"):
             print(f"Est. passes left: {b['estimated_passes_left']} "
-                  f"(~{b['estimated_minutes_left']}m, {b['binding_window']} window binds)")
+                  f"(~{b['estimated_minutes_left']}m, {b['binding_window']} window binds)"
+                  + caveat)
+        elif pending:
+            print(f"Est. passes left: INCOMPLETE — no history yet for "
+                  f"{', '.join(pending)}; those windows are not forecast")
         else:
             print("Est. passes left: no window runs out before its own reset")
 

--- a/tests/quota-forecast-binding-window.test.py
+++ b/tests/quota-forecast-binding-window.test.py
@@ -35,7 +35,9 @@ Exit: 0 on pass, 1 on fail.
 Python 3.9 compatible (CI floor).
 """
 from __future__ import annotations
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import shutil
@@ -45,6 +47,7 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 REPO = Path(__file__).resolve().parent.parent
 _SCRIPT = REPO / "skills" / "quota-tracker" / "scripts" / "read-quota.py"
@@ -265,6 +268,62 @@ class TestV1HistoryWarmUp(BindingWindowBase):
         self.assertNotIn("no window runs out", out)
         self.assertIn("INCOMPLETE", out)
         self.assertIn("7d", out.split("Est. passes left:")[-1])
+
+
+class TestHumanOutputBranches(BindingWindowBase):
+    """All three `Est. passes left:` renderings, in-process.
+
+    The subprocess test above is the honest end-to-end proof — it asserts on
+    exactly the bytes a human reads — but a subprocess is invisible to the
+    parent's coverage run, so `main()`'s print branches counted as untested and
+    CI's diff-coverage gate failed at 88.1% (missing 288-299). Both forms earn
+    their place: the subprocess one proves the real path, these prove each
+    branch. Deleting either would leave a gap the other does not cover.
+    """
+
+    def render(self, burn):
+        """Run main()'s output path with a stubbed burn result, capture stdout."""
+        (self.tmp / "state" / "quota-state.json").write_text(json.dumps({"headers": {
+            "anthropic-ratelimit-unified-status": "allowed",
+            "anthropic-ratelimit-unified-5h-utilization": "0.10",
+            "anthropic-ratelimit-unified-7d-utilization": "0.73",
+        }}))
+        buf = io.StringIO()
+        with patch.object(self.mod, "_update_burn_rate", return_value=burn), \
+                patch.object(sys, "argv", ["read-quota.py"]), \
+                contextlib.redirect_stdout(buf):
+            self.mod.main()
+        return buf.getvalue()
+
+    BASE = {"burn_rate_pct_per_pass": 0.5, "burn_samples": 99}
+
+    def test_binding_window_renders_the_number(self):
+        out = self.render(dict(self.BASE, binding_window="7d", estimated_passes_left=19.3,
+                               estimated_minutes_left=96, unforecast_windows=[]))
+        self.assertIn("19.3", out)
+        self.assertIn("7d window binds", out)
+        self.assertNotIn("INCOMPLETE", out)
+
+    def test_binding_window_still_carries_the_caveat(self):
+        # The second instance of the bug: a number is only the minimum over the
+        # windows measured, so it may not be stated bare while one is unforecast.
+        out = self.render(dict(self.BASE, binding_window="5h", estimated_passes_left=161.0,
+                               estimated_minutes_left=805, unforecast_windows=["7d"]))
+        self.assertIn("161.0", out)
+        self.assertIn("INCOMPLETE", out)
+        self.assertIn("7d", out)
+
+    def test_incomplete_with_no_binding_window(self):
+        out = self.render(dict(self.BASE, binding_window=None, estimated_passes_left=None,
+                               estimated_minutes_left=None, unforecast_windows=["7d"]))
+        self.assertIn("INCOMPLETE", out)
+        self.assertNotIn("no window runs out", out)
+
+    def test_all_measured_and_nothing_binds_is_the_only_all_clear(self):
+        out = self.render(dict(self.BASE, binding_window=None, estimated_passes_left=None,
+                               estimated_minutes_left=None, unforecast_windows=[]))
+        self.assertIn("no window runs out before its own reset", out)
+        self.assertNotIn("INCOMPLETE", out)
 
 
 class TestBackCompat(BindingWindowBase):

--- a/tests/quota-forecast-binding-window.test.py
+++ b/tests/quota-forecast-binding-window.test.py
@@ -39,6 +39,7 @@ import importlib.util
 import json
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -202,8 +203,85 @@ class TestObservedReading(BindingWindowBase):
             self.assertLessEqual(r["estimated_minutes_left"], cap)
 
 
+class TestV1HistoryWarmUp(BindingWindowBase):
+    """An expected window with no history of its own is INCOMPLETE, not clear.
+
+    Blocking review finding (qingyun-wu, at `c326df8a`). Every pre-existing v1
+    history already satisfies the 5h sample gate and carries no `burn_samples_7d`
+    at all, so for the first reads after the upgrade the 7d window is
+    expected-but-unforecast. Folding that into `binding_window: null` made the
+    human path print "no window runs out before its own reset" over a 7d window
+    sitting at 95% — an all-clear on a window nobody measured, which is the exact
+    failure this whole change removes, one layer up.
+    """
+
+    def v1_history(self):
+        """A real pre-upgrade history: warm 5h EWMA, no 7d fields whatsoever."""
+        self.mod.BURN_HISTORY_FILE.write_text(json.dumps({
+            "last_read_ts": time.time() - PASS_S,
+            "last_util_5h": 0.09,
+            "schema_version": 1,
+            "burn_rate_5h_ewma": 0.0037,
+            "burn_samples": 99,
+        }))
+
+    def test_7d_without_history_is_reported_unforecast(self):
+        self.v1_history()
+        r = self.mod._update_burn_rate(
+            0.10, 0.95, time.time() + self.RESET_5H_S, time.time() + self.RESET_7D_S)
+        self.assertEqual(r["unforecast_windows"], ["7d"])
+
+    def test_incomplete_is_not_reported_as_a_binding_number(self):
+        self.v1_history()
+        r = self.mod._update_burn_rate(
+            0.10, 0.95, time.time() + self.RESET_5H_S, time.time() + self.RESET_7D_S)
+        self.assertIsNone(r["binding_window"])
+        self.assertIsNone(r["estimated_passes_left"])
+
+    def test_a_7d_stream_that_never_matures_stays_unforecast(self):
+        # One 7d sample is not two. Omission must never age into safety.
+        self.v1_history()
+        r = self.mod._update_burn_rate(
+            0.10, 0.95, time.time() + self.RESET_5H_S, time.time() + self.RESET_7D_S)
+        h = json.loads(self.mod.BURN_HISTORY_FILE.read_text())
+        h["last_read_ts"] = time.time() - PASS_S
+        self.mod.BURN_HISTORY_FILE.write_text(json.dumps(h))
+        r = self.mod._update_burn_rate(
+            0.11, 0.96, time.time() + self.RESET_5H_S, time.time() + self.RESET_7D_S)
+        self.assertEqual(r["unforecast_windows"], ["7d"])
+
+    def test_human_output_does_not_state_an_all_clear(self):
+        # End-to-end through the real script: the printed line is what a human
+        # acts on, and it is the thing that was wrong.
+        self.v1_history()
+        (self.tmp / "state" / "quota-state.json").write_text(json.dumps({"headers": {
+            "anthropic-ratelimit-unified-status": "allowed",
+            "anthropic-ratelimit-unified-5h-utilization": "0.10",
+            "anthropic-ratelimit-unified-7d-utilization": "0.95",
+        }}))
+        env = dict(os.environ, SUTANDO_WORKSPACE=str(self.tmp), SUTANDO_TEST_MODE="1")
+        out = subprocess.run([sys.executable, str(_SCRIPT)], env=env,
+                             capture_output=True, text=True).stdout
+        self.assertNotIn("no window runs out", out)
+        self.assertIn("INCOMPLETE", out)
+        self.assertIn("7d", out.split("Est. passes left:")[-1])
+
+
 class TestBackCompat(BindingWindowBase):
     """The pre-existing single-argument call keeps working."""
+
+    def test_a_5h_only_caller_does_not_expect_7d(self):
+        # No 7d utilization supplied -> 7d is not an expected window, so it
+        # cannot be "unforecast". Otherwise every legacy caller reads INCOMPLETE
+        # forever over a window it never asked about.
+        r = None
+        for i, u5 in enumerate((0.10, 0.20, 0.30)):
+            if i:
+                h = json.loads(self.mod.BURN_HISTORY_FILE.read_text())
+                h["last_read_ts"] = time.time() - PASS_S
+                self.mod.BURN_HISTORY_FILE.write_text(json.dumps(h))
+            r = self.mod._update_burn_rate(u5)
+        self.assertEqual(r["unforecast_windows"], [])
 
     def test_5h_only_call_still_forecasts(self):
         r = None

--- a/tests/quota-forecast-binding-window.test.py
+++ b/tests/quota-forecast-binding-window.test.py
@@ -10,12 +10,22 @@ class each:
   * a 5h projection longer than the time to the 5h reset is unreachable,
     because the window refills first.
 
-All 8 fail against the pre-fix implementation, but be precise about why: 7 raise
-`TypeError: _update_burn_rate() takes 1 positional argument but 4 were given`
-and one raises `KeyError: 'binding_window'`. That is a signature/shape failure,
-not a value comparison — the old function cannot be asked these questions at
-all. The behavioural evidence is the live before/after in the PR body, where the
-unmodified binary reports a horizon longer than its own window's reset.
+Running these against the pre-fix script is a weak control and should not be
+quoted as a strong one: `_update_burn_rate` gained three parameters, so every
+case dies on `TypeError` before an assertion runs. That proves coupling to the
+signature, not that a logic regression would be caught.
+
+The real control is mutation, at the new signature — each mutation must fail the
+cases that guard it, on a VALUE, and leave the rest untouched:
+
+  remove the reset clamp in `_window_horizon`
+      -> 3 failures, all AssertionError, all in the two clamp classes
+  never forecast 7d (`if False` on its horizon branch)
+      -> 3 failures, all AssertionError, all in TestSevenDayCanBind
+
+`seed()` asserts the result is non-None precisely so those land on values rather
+than on a downstream `NoneType` TypeError. A control that dies on a type error
+proves less than one that dies on a value.
 
 Module loading mirrors tests/quota-burn-rate.test.py.
 
@@ -81,7 +91,11 @@ class BindingWindowBase(unittest.TestCase):
     def seed(self, samples):
         """Feed (util_5h, util_7d) pairs one pass apart, back-dating history.
 
-        Three samples satisfy the >= 2 sample gate for both windows.
+        Three samples satisfy the >= 2 sample gate for both windows. The result
+        is asserted non-None here so that a regression which drops the forecast
+        entirely fails on the assertion below rather than on a downstream
+        `NoneType` TypeError — a control that dies on a type error proves less
+        than one that dies on a value.
         """
         result = None
         for i, (u5, u7) in enumerate(samples):
@@ -94,6 +108,7 @@ class BindingWindowBase(unittest.TestCase):
                 time.time() + self.RESET_5H_S,
                 time.time() + self.RESET_7D_S,
             )
+        self.assertIsNotNone(result, "no forecast produced at all")
         return result
 
 
@@ -108,6 +123,7 @@ class TestSevenDayCanBind(BindingWindowBase):
 
     def test_reported_horizon_is_the_smaller_of_the_two(self):
         r = self.seed(self.SAMPLES)
+        self.assertIsNotNone(r["estimated_passes_left"], "no horizon reported")
         five_h_only = ((1 - 0.06) * 100) / r["burn_rate_pct_per_pass"]
         self.assertLess(r["estimated_passes_left"], five_h_only)
         self.assertLessEqual(r["estimated_passes_left"], 7.0)
@@ -122,6 +138,30 @@ class TestSevenDayCanBind(BindingWindowBase):
         # delta is skipped; the 7d reading must still be folded in.
         r = self.seed([(0.80, 0.90), (0.90, 0.91), (0.02, 0.92)])
         self.assertIn("burn_rate_7d_pct_per_pass", r)
+
+
+class TestPastResetSuppressesTheForecast(BindingWindowBase):
+    """A reset already in the past means the state file is stale.
+
+    Found by Sutando-Pro on a node whose `quota-state.json` had not been
+    refreshed for 56.8 h (the core was not routed through the credential proxy,
+    sonichi/sutando#2417). Both reset epochs were then in the past, and the
+    pre-fix script forecast ~9,836 passes — 34 days — from three-day-old data.
+
+    The clamp suppresses this for free: `passes_until_reset` floors at 0.0 for a
+    past reset, so no projection can be less than it and every window returns
+    None. Pinned here because it is a second, independently-reachable defect
+    that this guard closes, and nothing else in the suite covers it.
+    """
+
+    RESET_5H_S = -3 * HOUR
+    RESET_7D_S = -56 * HOUR
+
+    def test_no_window_forecasts_from_a_past_reset(self):
+        r = self.seed([(0.09, 0.71), (0.10, 0.72), (0.11, 0.73)])
+        self.assertIsNone(r["binding_window"])
+        self.assertIsNone(r["estimated_passes_left"])
+        self.assertIsNone(r["estimated_minutes_left"])
 
 
 class TestForecastCannotOutrunItsOwnReset(BindingWindowBase):

--- a/tests/quota-forecast-binding-window.test.py
+++ b/tests/quota-forecast-binding-window.test.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Tests for read-quota's binding-window forecast.
+
+The forecast answers "how many passes until the loop is stopped". Before this,
+it answered a narrower question — "until the 5h window is exhausted" — and
+printed the answer under the broader label. Two ways that misleads, one test
+class each:
+
+  * the 7d window can be the scarcer pool, and was not projected at all;
+  * a 5h projection longer than the time to the 5h reset is unreachable,
+    because the window refills first.
+
+All 8 fail against the pre-fix implementation, but be precise about why: 7 raise
+`TypeError: _update_burn_rate() takes 1 positional argument but 4 were given`
+and one raises `KeyError: 'binding_window'`. That is a signature/shape failure,
+not a value comparison — the old function cannot be asked these questions at
+all. The behavioural evidence is the live before/after in the PR body, where the
+unmodified binary reports a horizon longer than its own window's reset.
+
+Module loading mirrors tests/quota-burn-rate.test.py.
+
+Run: python3 tests/quota-forecast-binding-window.test.py
+Exit: 0 on pass, 1 on fail.
+
+Python 3.9 compatible (CI floor).
+"""
+from __future__ import annotations
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_SCRIPT = REPO / "skills" / "quota-tracker" / "scripts" / "read-quota.py"
+
+HOUR = 3600.0
+PASS_S = 300.0
+
+
+def _load_module(workspace: Path):
+    """Load read-quota.py with a controlled workspace and a dummy quota-state.json."""
+    os.environ["SUTANDO_WORKSPACE"] = str(workspace)
+    os.environ["SUTANDO_TEST_MODE"] = "1"  # v0.8: opt-in env-honor
+    sys.modules.pop("read_quota_binding_under_test", None)
+
+    state_dir = workspace / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    quota_file = state_dir / "quota-state.json"
+    if not quota_file.exists():
+        quota_file.write_text(json.dumps({"headers": {
+            "anthropic-ratelimit-unified-status": "allowed",
+            "anthropic-ratelimit-unified-5h-utilization": "0.1",
+            "anthropic-ratelimit-unified-7d-utilization": "0.7",
+        }}))
+
+    spec = importlib.util.spec_from_file_location(
+        "read_quota_binding_under_test", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(REPO / "src"))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class BindingWindowBase(unittest.TestCase):
+    # Far enough out that neither window refills first; overridden per class.
+    RESET_5H_S = 4 * HOUR
+    RESET_7D_S = 90 * HOUR
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="quota-binding-test-"))
+        self.mod = _load_module(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def seed(self, samples):
+        """Feed (util_5h, util_7d) pairs one pass apart, back-dating history.
+
+        Three samples satisfy the >= 2 sample gate for both windows.
+        """
+        result = None
+        for i, (u5, u7) in enumerate(samples):
+            if i:
+                h = json.loads(self.mod.BURN_HISTORY_FILE.read_text())
+                h["last_read_ts"] = time.time() - PASS_S
+                self.mod.BURN_HISTORY_FILE.write_text(json.dumps(h))
+            result = self.mod._update_burn_rate(
+                u5, u7,
+                time.time() + self.RESET_5H_S,
+                time.time() + self.RESET_7D_S,
+            )
+        return result
+
+
+class TestSevenDayCanBind(BindingWindowBase):
+    """The 7d window is projected, and wins when it is the scarcer pool."""
+
+    SAMPLES = [(0.04, 0.92), (0.05, 0.93), (0.06, 0.94)]
+
+    def test_7d_is_named_as_the_binding_window(self):
+        r = self.seed(self.SAMPLES)
+        self.assertEqual(r["binding_window"], "7d")
+
+    def test_reported_horizon_is_the_smaller_of_the_two(self):
+        r = self.seed(self.SAMPLES)
+        five_h_only = ((1 - 0.06) * 100) / r["burn_rate_pct_per_pass"]
+        self.assertLess(r["estimated_passes_left"], five_h_only)
+        self.assertLessEqual(r["estimated_passes_left"], 7.0)
+
+    def test_7d_burn_rate_is_reported_separately(self):
+        r = self.seed(self.SAMPLES)
+        self.assertIn("burn_rate_7d_pct_per_pass", r)
+        self.assertGreater(r["burn_rate_7d_pct_per_pass"], 0)
+
+    def test_a_7d_sample_survives_a_5h_reset(self):
+        # util_5h drops (window reset) while util_7d keeps climbing. The 5h
+        # delta is skipped; the 7d reading must still be folded in.
+        r = self.seed([(0.80, 0.90), (0.90, 0.91), (0.02, 0.92)])
+        self.assertIn("burn_rate_7d_pct_per_pass", r)
+
+
+class TestForecastCannotOutrunItsOwnReset(BindingWindowBase):
+    """A window that refills before it empties does not constrain anything."""
+
+    RESET_5H_S = 10 * PASS_S      # refills in 10 passes
+    # 7d held flat so it contributes no rate — this class is about the 5h clamp.
+    SAMPLES = [(0.04, 0.10), (0.05, 0.10), (0.06, 0.10)]
+
+    def test_unreachable_5h_projection_does_not_bind(self):
+        # ~1pp/pass with 94% left projects ~94 passes, but the window refills
+        # in 10 — so the 5h window is not what will stop the loop.
+        r = self.seed(self.SAMPLES)
+        self.assertNotEqual(r["binding_window"], "5h")
+
+    def test_no_binding_window_reports_none_rather_than_a_number(self):
+        r = self.seed(self.SAMPLES)
+        self.assertIsNone(r["binding_window"])
+        self.assertIsNone(r["estimated_passes_left"])
+        self.assertIsNone(r["estimated_minutes_left"])
+
+
+class TestObservedReading(BindingWindowBase):
+    """The 2026-08-05 reading that motivated the change.
+
+    5h 89% remaining resetting in 212 min; 7d 27% remaining resetting in 5702.
+    The old code printed 615 minutes left — 403 past the 5h reset. Whatever is
+    reported now may not exceed the time until the window it came from resets.
+    """
+
+    RESET_5H_S = 212 * 60
+    RESET_7D_S = 5702 * 60
+
+    def test_horizon_never_exceeds_its_own_windows_reset(self):
+        r = self.seed([(0.09, 0.71), (0.10, 0.72), (0.11, 0.73)])
+        cap = {"5h": 212, "7d": 5702}.get(r["binding_window"])
+        if cap is not None:
+            self.assertLessEqual(r["estimated_minutes_left"], cap)
+
+
+class TestBackCompat(BindingWindowBase):
+    """The pre-existing single-argument call keeps working."""
+
+    def test_5h_only_call_still_forecasts(self):
+        r = None
+        for i, u5 in enumerate((0.10, 0.20, 0.30)):
+            if i:
+                h = json.loads(self.mod.BURN_HISTORY_FILE.read_text())
+                h["last_read_ts"] = time.time() - PASS_S
+                self.mod.BURN_HISTORY_FILE.write_text(json.dumps(h))
+            r = self.mod._update_burn_rate(u5)
+        self.assertEqual(r["binding_window"], "5h")
+        self.assertGreater(r["estimated_passes_left"], 0)
+        self.assertEqual(r["estimated_minutes_left"],
+                         round(r["estimated_passes_left"] * 5))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`_update_burn_rate` tracks one window and answers with it. The label says **"Est. passes left"** — passes until the loop is stopped — but the number is *passes until the 5h window is exhausted*. Those differ in two ways, both live on this host at 2026-08-05T09:5xZ:

```
reported estimated_minutes_left : 615 min
minutes until the 5h RESETS     : 212 min   <- the projected window refills here
minutes until the 7d RESETS     : 5702 min  <- 27% left, and not projected at all
```

The forecast ran **403 minutes past the reset that voids it**, while the only window that could not refill for another four days went unmentioned. A loop pacing itself on that number can exhaust the 7d pool and go dark for days — the failure the forecast exists to prevent. `#1319` added the forecast; it read 5h only, and nothing since has revisited it.

## Before / after — same state, same seeded history, same interpreter

Both arms get a copy of the live `quota-state.json` and an identical starting `quota-burn-history.json`, read twice 300s apart so both windows reach two samples.

```
=== BEFORE — origin/main 052a14a7 ===
5h window: 12% used, 88% remaining     Resets: 06:30 Aug 05
7d window: 73% used, 27% remaining     Resets: 02:00 Aug 09
Burn rate: 0.77%/pass (99 samples)
Est. passes left: 113.9 (~569m)

=== AFTER — this branch ===
5h window: 12% used, 88% remaining     Resets: 06:30 Aug 05
7d window: 73% used, 27% remaining     Resets: 02:00 Aug 09
Burn rate: 0.77%/pass (99 samples)
Est. passes left: 19.3 (~96m, 7d window binds)
```

**Read `19.3` as a demonstration, not a calibrated forecast.** The 7d rate there comes from a two-sample synthetic seed; a real one needs accumulated history. What the run proves is structural: the 7d window is now projected, it can bind, and the 5h number is no longer reported past its own reset.

## The change

- Both windows tracked; each projected against **its own** reset.
- A window whose projection outlives its reset **does not bind** — it refills first, so a number larger than the time to that refill is unreachable, not conservative.
- `estimated_passes_left` keeps its name and its meaning. What changes is that it now considers every window that can stop the loop. `binding_window` names the source, and is `None` when nothing runs out first (human output then reads `no window runs out before its own reset`).
- 7d samples ride their **own** counter. The windows reset independently, so a shared counter would suppress the 7d forecast for exactly the readings taken across a 5h reset — the moments the 7d number matters most. `burn_samples` keeps its existing meaning (5h), so a v1 history file carries over unchanged.

## Tests

`tests/quota-forecast-binding-window.test.py` — 8 tests, and the **existing** `tests/quota-burn-rate.test.py` (15) still passes unchanged, including its assertions on `estimated_passes_left`.

```
new      3.9.6  OK (8)      3.14.5  OK (8)
existing 3.9.6  OK (15)     3.14.5  OK (15)
```

**Be precise about the parent-commit run.** All 8 new tests fail at `052a14a7`, but 7 raise `TypeError: _update_burn_rate() takes 1 positional argument but 4 were given` and one raises `KeyError: 'binding_window'`. That is a signature/shape failure — the old function cannot be *asked* these questions — not a value comparison. The behavioural evidence is the before/after above, where the unmodified binary reports a horizon longer than its own window's reset. The test file says so too, rather than implying stronger evidence than it has.

`uvx ruff check .` clean over the whole repo.

## Not in scope

Whether the loop should *act* on the binding window (throttle, widen the cron interval) is a pacing decision for `proactive-loop`, not this script. This change only makes the number report the constraint that actually binds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
