### PR TITLE
fix(proactive-loop): the pace tier is a constant on the 7d window, so every state reads LIGHT

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -49,21 +49,20 @@ Each pass, in order:
    **`step` is an owner-facing live message, not internal telemetry.** With `SUTANDO_PROGRESS_STREAM=1` (ON in the running bridge) the Discord bridge renders it to the owner verbatim as `⏳ <step> (Ns)` while he waits on an owner task, via `progress_stream.format_progress`. A generic placeholder ("Starting pass...", "running") shows up in his DM as noise; when processing an owner task, `step` should say what he is waiting on. Rewrite it on every pivot — a stale `step` actively lies to him. See memory `feedback_rich_core_status_step`. (This template previously read `"Starting pass..."` — the exact string that memory names as the anti-pattern, which is why the mistake kept recurring across compactions: this file is loaded every pass, the memory only when recalled.)
 
 0.5. **Check quota.** Run `python3 $CLAUDE_CONFIG_DIR/skills/quota-tracker/scripts/read-quota.py`. Note remaining % and exact reset time.
-   **Compute BOTH windows, then take the MOST RESTRICTIVE result.** `read-quota.py` reports two
-   (5h and 7d). Score each with the formulas below and adopt the **lower `headroom`** — do NOT pick
-   the window with the larger `burn`. Those select differently: a short window can show a huge `burn`
+   **Tier EACH window by its OWN rule, then take the MOST RESTRICTIVE TIER.** `read-quota.py`
+   reports two windows and they are scored differently — do not apply one window's thresholds to the
+   other, and do not pick a window by largest `burn`. Those select differently: a short window can show a huge `burn`
    from one early burst while still holding more headroom than the window that actually limits you.
    `5h` at 19% used / 2% elapsed gives `burn 9.50, headroom 0.827` (MEDIUM); `7d` at 90% used / 70%
    elapsed gives `burn 1.29, headroom 0.333` (LIGHT). Selecting on `burn` picks the 5h window and
    authorises MEDIUM work while the 7d pool — which cannot refill for days — is already LIGHT.
    `burn` explains *how you got here*; `headroom` is what constrains what you may still do.
 
-   **Pace against that window's OWN even pace, as a ratio.** Do NOT apply the absolute
-   per-pass thresholds below to the 7d window: they are calibrated to the 5h window and on 7d they
-   are a *constant*. Every reachable 7d input yields LIGHT — 100% remaining over a full week gives
-   0.0496%/pass, 1% remaining gives 0.0005%/pass, and even 1% remaining with one hour to reset gives
-   0.083%/pass. Reaching MEDIUM would require 2016% remaining. A rule whose best case and worst case
-   agree is not measuring anything.
+   **Why 7d needs its own rule:** the absolute per-pass thresholds are a *constant* on it. Every
+   reachable 7d input yields LIGHT — 100% remaining over a full week gives 0.0496%/pass, 1% remaining
+   gives 0.0005%/pass, and even 1% remaining with one hour to reset gives 0.083%/pass. Reaching
+   MEDIUM would require 2016% remaining. A rule whose best case and worst case agree is not
+   measuring anything. So 7d is paced against its own even pace, as a ratio:
 
    ```
    elapsed  = (now - window_start) / (window_reset - window_start)
@@ -71,16 +70,21 @@ Each pass, in order:
    headroom = remaining% / (1 - elapsed)  # <1 means the rest must be slower than even pace
    sustainable_vs_current = headroom / burn
    ```
+   **7d window — tier by `headroom`:**
    - **headroom ≥ 1.5 → FULL**: subagents, write code, heavy research all fair game.
    - **headroom 0.8–1.5 → MEDIUM**: code fixes, monitoring, no subagents.
    - **headroom < 0.8 → LIGHT**: task processing + health checks only.
-   - **0% remaining → MINIMAL**: process owner tasks + health + update log.
+
+   **5h window — tier by its retained absolute budget**, `remaining % / (minutes to reset / 5)`:
+   >3% FULL / 1–3% MEDIUM / <1% LIGHT. These were calibrated for this window; they are NOT
+   interchangeable with the headroom bands and must not be applied to 7d (there they are a constant).
+
+   **Then adopt the more restrictive of the two tiers** (FULL > MEDIUM > LIGHT), and name which
+   window bound it. **0% remaining on either window → MINIMAL**: owner tasks + health + log only.
 
    Quote `sustainable_vs_current` when reporting pace, and **name the denominator** — "0.45x even
    pace" and "0.27x current pace" are the same state and differ by 1.67x.
 
-   The absolute thresholds below remain valid for the **5h** window only:
-   `budget = remaining % / (minutes until reset / 5)`; >3% FULL / 1-3% MEDIUM / <1% LIGHT.
 
    Budget informs the **depth** of step 6 — not whether to do it. "Ran out of ideas" is never a valid skip; the work menu is infinite by design. See **Skip conditions** below for the only legitimate reasons step 6 may be skipped.
 

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -49,11 +49,32 @@ Each pass, in order:
    **`step` is an owner-facing live message, not internal telemetry.** With `SUTANDO_PROGRESS_STREAM=1` (ON in the running bridge) the Discord bridge renders it to the owner verbatim as `⏳ <step> (Ns)` while he waits on an owner task, via `progress_stream.format_progress`. A generic placeholder ("Starting pass...", "running") shows up in his DM as noise; when processing an owner task, `step` should say what he is waiting on. Rewrite it on every pivot — a stale `step` actively lies to him. See memory `feedback_rich_core_status_step`. (This template previously read `"Starting pass..."` — the exact string that memory names as the anti-pattern, which is why the mistake kept recurring across compactions: this file is loaded every pass, the memory only when recalled.)
 
 0.5. **Check quota.** Run `python3 $CLAUDE_CONFIG_DIR/skills/quota-tracker/scripts/read-quota.py`. Note remaining % and exact reset time.
-   - **Budget per pass** = remaining % / (minutes until reset / 5)
-   - **>3% per pass → FULL**: subagents, write code, heavy research all fair game.
-   - **1-3% per pass → MEDIUM**: code fixes, monitoring, no subagents.
-   - **<1% per pass → LIGHT**: task processing + health checks only.
+   **Pick the BINDING window first.** `read-quota.py` reports two (5h and 7d). The binding one is
+   whichever is further ahead of even pace — usually 7d, because it cannot refill for days.
+
+   **Pace against that window's OWN even pace, as a ratio.** Do NOT apply the absolute
+   per-pass thresholds below to the 7d window: they are calibrated to the 5h window and on 7d they
+   are a *constant*. Every reachable 7d input yields LIGHT — 100% remaining over a full week gives
+   0.0496%/pass, 1% remaining gives 0.0005%/pass, and even 1% remaining with one hour to reset gives
+   0.083%/pass. Reaching MEDIUM would require 2016% remaining. A rule whose best case and worst case
+   agree is not measuring anything.
+
+   ```
+   elapsed  = (now - window_start) / (window_reset - window_start)
+   burn     = used% / elapsed           # >1 means ahead of even pace
+   headroom = remaining% / (1 - elapsed)  # <1 means the rest must be slower than even pace
+   sustainable_vs_current = headroom / burn
+   ```
+   - **headroom ≥ 1.5 → FULL**: subagents, write code, heavy research all fair game.
+   - **headroom 0.8–1.5 → MEDIUM**: code fixes, monitoring, no subagents.
+   - **headroom < 0.8 → LIGHT**: task processing + health checks only.
    - **0% remaining → MINIMAL**: process owner tasks + health + update log.
+
+   Quote `sustainable_vs_current` when reporting pace, and **name the denominator** — "0.45x even
+   pace" and "0.27x current pace" are the same state and differ by 1.67x.
+
+   The absolute thresholds below remain valid for the **5h** window only:
+   `budget = remaining % / (minutes until reset / 5)`; >3% FULL / 1-3% MEDIUM / <1% LIGHT.
 
    Budget informs the **depth** of step 6 — not whether to do it. "Ran out of ideas" is never a valid skip; the work menu is infinite by design. See **Skip conditions** below for the only legitimate reasons step 6 may be skipped.
 

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -49,8 +49,14 @@ Each pass, in order:
    **`step` is an owner-facing live message, not internal telemetry.** With `SUTANDO_PROGRESS_STREAM=1` (ON in the running bridge) the Discord bridge renders it to the owner verbatim as `⏳ <step> (Ns)` while he waits on an owner task, via `progress_stream.format_progress`. A generic placeholder ("Starting pass...", "running") shows up in his DM as noise; when processing an owner task, `step` should say what he is waiting on. Rewrite it on every pivot — a stale `step` actively lies to him. See memory `feedback_rich_core_status_step`. (This template previously read `"Starting pass..."` — the exact string that memory names as the anti-pattern, which is why the mistake kept recurring across compactions: this file is loaded every pass, the memory only when recalled.)
 
 0.5. **Check quota.** Run `python3 $CLAUDE_CONFIG_DIR/skills/quota-tracker/scripts/read-quota.py`. Note remaining % and exact reset time.
-   **Pick the BINDING window first.** `read-quota.py` reports two (5h and 7d). The binding one is
-   whichever is further ahead of even pace — usually 7d, because it cannot refill for days.
+   **Compute BOTH windows, then take the MOST RESTRICTIVE result.** `read-quota.py` reports two
+   (5h and 7d). Score each with the formulas below and adopt the **lower `headroom`** — do NOT pick
+   the window with the larger `burn`. Those select differently: a short window can show a huge `burn`
+   from one early burst while still holding more headroom than the window that actually limits you.
+   `5h` at 19% used / 2% elapsed gives `burn 9.50, headroom 0.827` (MEDIUM); `7d` at 90% used / 70%
+   elapsed gives `burn 1.29, headroom 0.333` (LIGHT). Selecting on `burn` picks the 5h window and
+   authorises MEDIUM work while the 7d pool — which cannot refill for days — is already LIGHT.
+   `burn` explains *how you got here*; `headroom` is what constrains what you may still do.
 
    **Pace against that window's OWN even pace, as a ratio.** Do NOT apply the absolute
    per-pass thresholds below to the 7d window: they are calibrated to the 5h window and on 7d they
@@ -84,7 +90,7 @@ Each pass, in order:
 
 Skip step 6 (end the pass early after step 3) if and only if one of these applies:
 
-- **(a) Quota**: per-pass budget is below the LIGHT threshold (<1%).
+- **(a) Quota**: the selected tier from step 0.5 is MINIMAL (i.e. the most-restrictive window has 0% remaining). A LIGHT tier does NOT skip step 6 — it caps its depth.
 - **(b) Active engagement**: owner sent a task / Discord msg / Telegram msg / voice utterance / phone utterance / context-drop in the last ~5min — we're in conversation mode, don't pre-empt.
 - **(c) Presenter/meeting mode**: `state/presenter-mode.sentinel` is active (set via `bash scripts/presenter-mode.sh start N`).
 - **(d) Explicit pause**: `state/loop-paused-until.sentinel` is active (future-dated).


### PR DESCRIPTION
## The defect

Step 0.5's `budget = remaining % / (minutes until reset / 5)` dates from when `read-quota.py` reported **one** window. It now reports two, and the loop must choose. Applied to the **7d** window, the thresholds are not a conservative reading — they are a **constant**:

```
100% remaining, full week ahead ->  0.0496%/pass  LIGHT
 25% remaining (this host today)->  0.0223%/pass  LIGHT
  1% remaining                  ->  0.0005%/pass  LIGHT
  1% remaining, ONE HOUR to reset -> 0.0833%/pass LIGHT
MEDIUM would require 2016% remaining.
```

The best possible state and the worst possible state produce the same verdict, including the alarming one. That is the signature of a rule that measures nothing — and it measures nothing on **the window that actually binds**, since 7d cannot refill for days while 5h refills hourly.

**This is not theoretical, it is what I did.** At 2026-08-05T11:44Z I computed `25% / ~1120 passes = 0.022%/pass = LIGHT`, published it as a pace signal to a peer node, and it was adopted as that node's cadence. The number could not have come out any other way.

## After

Pace against the window's own even pace, as a ratio:

```
elapsed  = (now - window_start) / (window_reset - window_start)
burn     = used% / elapsed              # >1 = ahead of even pace
headroom = remaining% / (1 - elapsed)   # <1 = the rest must be slower than even pace
sustainable_vs_current = headroom / burn
```

Verified it discriminates — the check the old rule fails:

```
state (7d window)                     burn  headroom  tier     sust_vs_current
0% used,  10% elapsed                 0.00      1.11  MEDIUM   —
50% used, 50% elapsed                 1.00      1.00  MEDIUM   1.00x
75% used, 44.8% elapsed  (this host)  1.67      0.45  LIGHT    0.27x
95% used, 50% elapsed                 1.90      0.10  LIGHT    0.05x
99% used, 20% elapsed                 4.95      0.01  LIGHT    0.00x
20% used, 60% elapsed                 0.33      2.00  FULL     6.00x
```

Distinct tiers reachable: FULL / MEDIUM / LIGHT. On this host's real state it returns LIGHT at `0.27x current pace` — i.e. cut ~73%, which is actionable, where the old rule's LIGHT was vacuous.

It also requires **naming the denominator**. `0.45x even pace` and `0.27x current pace` are the same state and differ by 1.67x; I published the first while labelling it the second, and a peer caught it. Both numbers sit in 0.3–1.7 and neither looks wrong alone.

## What this does NOT claim

- **Early-window states cluster near `headroom` 1.0 by construction** — an untouched window at 10% elapsed reads 1.11 (MEDIUM), not FULL, because 100% spread over the remaining 90% *is* only 1.11x even pace. That is arithmetic, not a bug, but it does mean the metric is least informative in a window's first hours. Stated rather than smoothed over.
- The `5h` absolute thresholds are **retained**, explicitly scoped to the 5h window, where they were calibrated and remain correct. This does not touch them.
- No code path changes — this is the loop's own decision rule, which is prose an agent follows. There is no function to unit-test; the evidence is the arithmetic above, reproducible from the formulas.

## Relationship to #2672

Complementary, and neither subsumes the other:

| | producer | consumer |
|---|---|---|
| **#2672** (Mini) | `read-quota.py` forecast projected only 5h | — |
| **this PR** | — | step 0.5 applied 5h-calibrated thresholds to whichever window |

After #2672 lands, an agent reading the corrected 7d numbers and applying the *old* step 0.5 still gets a constant LIGHT. Either can merge first; they touch disjoint files (`skills/quota-tracker/scripts/read-quota.py` vs `skills/proactive-loop/SKILL.md`).

cc @sonichi
