### PR TITLE
fix(telegram-bridge-test): hermetic-isolate to green the lint gate on main

### DIFF
--- a/tests/telegram-bridge-orphaned-routing-recovery.test.py
+++ b/tests/telegram-bridge-orphaned-routing-recovery.test.py
@@ -57,6 +57,18 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 
+# --- Hermetic isolation (scripts/lint-hermetic-bridge-tests.py) --------------
+# src/telegram-bridge.py resolves channel config at MODULE level during
+# exec_module (ACCESS_FILE = channel_access_path("telegram")). Without a seeded
+# temp CLAUDE_CONFIG_DIR, channel_access_path() falls back to the developer's
+# real ~/.claude/channels/telegram/access.json. Point it at a seeded temp dir
+# BEFORE any _load_bridge() import below.
+os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp(prefix="ccd-tg-routing-recovery-")
+_cfg = Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "telegram"
+_cfg.mkdir(parents=True, exist_ok=True)
+(_cfg / "access.json").write_text('{"allowFrom": []}')
+# -----------------------------------------------------------------------------
+
 
 def _load_bridge(workspace: Path):
     """Load telegram-bridge.py with a temp workspace. Each call does a fresh


### PR DESCRIPTION
## Main is red — this greens it

`scripts/lint-hermetic-bridge-tests.py` (the required **refuse bridge tests that read host config** check) is **failing on main** (`46ee056c`). One violator:

```
lint-hermetic-bridge-tests: FAIL — test imports a bridge without isolating CLAUDE_CONFIG_DIR
  tests/telegram-bridge-orphaned-routing-recovery.test.py
```

That test was added by **#2223** (merged today). It `exec_module`s `src/telegram-bridge.py`, which resolves `ACCESS_FILE = channel_access_path("telegram")` at **module level** — but the test set no `CLAUDE_CONFIG_DIR`, so `channel_access_path()` falls back to the developer's real `~/.claude/channels/telegram/access.json`. The lint (correctly) refuses that.

**Impact:** a required check red on main blocks the merge of *every* open PR once it pulls latest main (auto-merge queues stall at BLOCKED).

## The fix

The lint's own documented canonical shape (module-level, before the import):

```python
os.environ["CLAUDE_CONFIG_DIR"] = tempfile.mkdtemp(prefix="ccd-tg-routing-recovery-")
_cfg = Path(os.environ["CLAUDE_CONFIG_DIR"]) / "channels" / "telegram"
_cfg.mkdir(parents=True, exist_ok=True)
(_cfg / "access.json").write_text('{"allowFrom": []}')
```

Additive only — the routing-recovery test logic is untouched. Verified against the real `classify()` from `lint-hermetic-bridge-tests.py`: **violation → clean**.

## Verification
- `classify(tests/telegram-bridge-orphaned-routing-recovery.test.py)` = `clean` after the change (was `violation`).
- Change is the same isolation pattern already used across the hermetic-clean bridge tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)