### PR TITLE
feat(proactive-loop): add Codex quota-aware cadence gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ state.
                                 (spoken via voice/phone,
                                  text via Telegram/Discord)
 
-    ↻ = a cron job fires the `/proactive-loop` skill every 5 minutes
-        (`*/5 * * * *` in `skills/schedule-crons/crons.json`). The skill
+    ↻ = a cron job fires the `/proactive-loop` skill every 15 minutes
+        (`*/15 * * * *` in the per-host `crons.json`). The skill
         runs as a 10-minute pass that keeps a persistent watcher on
         `tasks/` via Claude Code's `Monitor` tool — pending tasks are
         processed the moment they arrive, not just on the cron tick.

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -48,13 +48,22 @@ Each pass, in order:
 
    **`step` is an owner-facing live message, not internal telemetry.** With `SUTANDO_PROGRESS_STREAM=1` (ON in the running bridge) the Discord bridge renders it to the owner verbatim as `⏳ <step> (Ns)` while he waits on an owner task, via `progress_stream.format_progress`. A generic placeholder ("Starting pass...", "running") shows up in his DM as noise; when processing an owner task, `step` should say what he is waiting on. Rewrite it on every pivot — a stale `step` actively lies to him. See memory `feedback_rich_core_status_step`. (This template previously read `"Starting pass..."` — the exact string that memory names as the anti-pattern, which is why the mistake kept recurring across compactions: this file is loaded every pass, the memory only when recalled.)
 
-0.5. **Check quota.** For Codex core, run `python3 skills/proactive-loop/scripts/codex-quota-gate.py --json`. It reads the Codex CLI's weekly rate-limit snapshots, not the Claude-only `quota-tracker` state. The script conservatively uses the least remaining percentage among recorded weekly limit lanes; missing or entirely stale telemetry fails closed to `LIGHT`.
+0.5. **Check quota (runtime-conditional — pick the branch for the core you are).**
+
+   **Claude core** — run `python3 $CLAUDE_CONFIG_DIR/skills/quota-tracker/scripts/read-quota.py`. Note remaining % and exact reset time.
+   - **Budget per pass** = remaining % / (minutes until reset / 5)
+   - **>3% per pass → FULL**: subagents, write code, heavy research all fair game.
+   - **1-3% per pass → MEDIUM**: code fixes, monitoring, no subagents.
+   - **<1% per pass → LIGHT**: task processing + health checks only.
+   - **0% remaining → MINIMAL**: process owner tasks + health + update log.
+
+   **Codex core** — run `python3 skills/proactive-loop/scripts/codex-quota-gate.py --json` (the Claude-only `quota-tracker` state is not a Codex signal). It reads the Codex CLI's weekly rate-limit snapshots and conservatively uses the least remaining percentage among recorded weekly limit lanes; missing or entirely stale telemetry fails closed to `LIGHT`.
    - **>20% remaining → FULL**: subagents, code, and heavier research are fair game.
    - **5–20% remaining → MEDIUM**: monitoring and bounded code fixes; no subagents.
    - **1–<5% remaining → LIGHT**: task processing, pending questions, and health checks only.
    - **0% remaining or unavailable/stale → LIGHT**: owner tasks, health, and the build-log update only.
 
-   When the gate is `LIGHT`, skip autonomous self-development/research in step 6 even if the self-development policy is enabled. Owner-requested tasks, pending questions, health/service recovery, watcher maintenance, and the build-log update remain active. Budget informs the **depth** of step 6 — not whether to do it when quota permits. "Ran out of ideas" is never a valid skip; the work menu is infinite by design. See **Skip conditions** below for the other legitimate reasons step 6 may be skipped.
+   Either way: budget informs the **depth** of step 6 — not whether to do it when quota permits. When the branch resolves to `LIGHT`/`MINIMAL`, skip autonomous self-development/research in step 6 even if the self-development policy is enabled; owner-requested tasks, pending questions, health/service recovery, watcher maintenance, and the build-log update remain active. "Ran out of ideas" is never a valid skip; the work menu is infinite by design. See **Skip conditions** below for the other legitimate reasons step 6 may be skipped.
 
 0.7. **Reconstruct context (every pass — don't recall, read).** Before interpreting the queue or acting on anything that depends on earlier context, **invoke the `context-reconstruct` skill** (an actual Skill-tool invocation — a "see X" reference does not load it). It reads `<workspace>/hosts/<hostname>/current-track.md` first (the pinned main-track goal + active sub-task + open decisions), then — as the situation needs — the live owner thread (`src/discord-read.py <channel_id>`), per-host `pending-questions.md`, the latest `relay/relay-*.md`, and the `build_log.md` tail. Where the record differs from what you *think* is true, **trust the record**. Then **maintain** `<workspace>/hosts/<hostname>/current-track.md`: create it if absent, rewrite it when the track moves (owner redirected / thing shipped / decision resolved). This step is the load-bearing anti-erosion hook — over long/compacted sessions, felt confidence is confidently wrong; the fix is reading the durable record, not remembering it. (Restored 2026-07-13 after being dropped in the ~Jun 30 workspace-revamp SKILL.md rewrite; originally added 2026-06-25 — see the context-reconstruct skill's Practice log.)
 

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -48,14 +48,13 @@ Each pass, in order:
 
    **`step` is an owner-facing live message, not internal telemetry.** With `SUTANDO_PROGRESS_STREAM=1` (ON in the running bridge) the Discord bridge renders it to the owner verbatim as `⏳ <step> (Ns)` while he waits on an owner task, via `progress_stream.format_progress`. A generic placeholder ("Starting pass...", "running") shows up in his DM as noise; when processing an owner task, `step` should say what he is waiting on. Rewrite it on every pivot — a stale `step` actively lies to him. See memory `feedback_rich_core_status_step`. (This template previously read `"Starting pass..."` — the exact string that memory names as the anti-pattern, which is why the mistake kept recurring across compactions: this file is loaded every pass, the memory only when recalled.)
 
-0.5. **Check quota.** Run `python3 $CLAUDE_CONFIG_DIR/skills/quota-tracker/scripts/read-quota.py`. Note remaining % and exact reset time.
-   - **Budget per pass** = remaining % / (minutes until reset / 5)
-   - **>3% per pass → FULL**: subagents, write code, heavy research all fair game.
-   - **1-3% per pass → MEDIUM**: code fixes, monitoring, no subagents.
-   - **<1% per pass → LIGHT**: task processing + health checks only.
-   - **0% remaining → MINIMAL**: process owner tasks + health + update log.
+0.5. **Check quota.** For Codex core, run `python3 skills/proactive-loop/scripts/codex-quota-gate.py --json`. It reads the Codex CLI's weekly rate-limit snapshots, not the Claude-only `quota-tracker` state. The script conservatively uses the least remaining percentage among recorded weekly limit lanes; missing or entirely stale telemetry fails closed to `LIGHT`.
+   - **>20% remaining → FULL**: subagents, code, and heavier research are fair game.
+   - **5–20% remaining → MEDIUM**: monitoring and bounded code fixes; no subagents.
+   - **1–<5% remaining → LIGHT**: task processing, pending questions, and health checks only.
+   - **0% remaining or unavailable/stale → LIGHT**: owner tasks, health, and the build-log update only.
 
-   Budget informs the **depth** of step 6 — not whether to do it. "Ran out of ideas" is never a valid skip; the work menu is infinite by design. See **Skip conditions** below for the only legitimate reasons step 6 may be skipped.
+   When the gate is `LIGHT`, skip autonomous self-development/research in step 6 even if the self-development policy is enabled. Owner-requested tasks, pending questions, health/service recovery, watcher maintenance, and the build-log update remain active. Budget informs the **depth** of step 6 — not whether to do it when quota permits. "Ran out of ideas" is never a valid skip; the work menu is infinite by design. See **Skip conditions** below for the other legitimate reasons step 6 may be skipped.
 
 0.7. **Reconstruct context (every pass — don't recall, read).** Before interpreting the queue or acting on anything that depends on earlier context, **invoke the `context-reconstruct` skill** (an actual Skill-tool invocation — a "see X" reference does not load it). It reads `<workspace>/hosts/<hostname>/current-track.md` first (the pinned main-track goal + active sub-task + open decisions), then — as the situation needs — the live owner thread (`src/discord-read.py <channel_id>`), per-host `pending-questions.md`, the latest `relay/relay-*.md`, and the `build_log.md` tail. Where the record differs from what you *think* is true, **trust the record**. Then **maintain** `<workspace>/hosts/<hostname>/current-track.md`: create it if absent, rewrite it when the track moves (owner redirected / thing shipped / decision resolved). This step is the load-bearing anti-erosion hook — over long/compacted sessions, felt confidence is confidently wrong; the fix is reading the durable record, not remembering it. (Restored 2026-07-13 after being dropped in the ~Jun 30 workspace-revamp SKILL.md rewrite; originally added 2026-06-25 — see the context-reconstruct skill's Practice log.)
 

--- a/skills/proactive-loop/scripts/codex-quota-gate.py
+++ b/skills/proactive-loop/scripts/codex-quota-gate.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import sys
 import time
@@ -57,6 +58,15 @@ def _rate_limits(payload: dict[str, Any]) -> Optional[dict[str, Any]]:
     return None
 
 
+def _finite_number(value: Any) -> bool:
+    """True only for a real finite int/float (not bool, not NaN/±inf). The cache
+    is JSON parsed with json.loads(), which accepts NaN/Infinity tokens, so a
+    telemetry field can be a non-finite float that passes an isinstance check but
+    breaks int()/comparisons (qingyun CR #2676)."""
+    return (isinstance(value, (int, float)) and not isinstance(value, bool)
+            and math.isfinite(value))
+
+
 def _weekly_window(limits: dict[str, Any]) -> Optional[dict[str, Any]]:
     """The weekly rate-limit window from one ``rate_limits`` snapshot, or None.
 
@@ -72,11 +82,15 @@ def _weekly_window(limits: dict[str, Any]) -> Optional[dict[str, Any]]:
         window = limits.get(key)
         if not isinstance(window, dict):
             continue
-        used = window.get("used_percent")
-        if not isinstance(used, (int, float)) or isinstance(used, bool):
+        # Require FINITE numerics: json.loads() accepts NaN/Infinity tokens by
+        # default, and a NaN is a float that passes an isinstance check but then
+        # poisons everything — int(NaN) raises ValueError (qingyun CR #2676), and
+        # a NaN used_percent would sail through the used-clamp as NaN. A malformed
+        # window must drop out so the gate fails closed to unavailable/LIGHT.
+        if not _finite_number(window.get("used_percent")):
             continue
         window_minutes = window.get("window_minutes")
-        if not isinstance(window_minutes, (int, float)) or isinstance(window_minutes, bool):
+        if not _finite_number(window_minutes):
             continue
         if int(window_minutes) < WEEKLY_MINUTES:
             continue
@@ -188,5 +202,5 @@ def main() -> int:
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())

--- a/skills/proactive-loop/scripts/codex-quota-gate.py
+++ b/skills/proactive-loop/scripts/codex-quota-gate.py
@@ -25,6 +25,7 @@ from typing import Any, Optional
 
 STALE_AFTER_SECONDS = 30 * 60
 LOOKBACK_SECONDS = 14 * 24 * 60 * 60
+WEEKLY_MINUTES = 7 * 24 * 60  # the quota window this gate protects (10080 min)
 
 
 def _codex_home() -> Path:
@@ -54,6 +55,35 @@ def _rate_limits(payload: dict[str, Any]) -> Optional[dict[str, Any]]:
     if isinstance(info, dict) and isinstance(info.get("rate_limits"), dict):
         return info["rate_limits"]
     return None
+
+
+def _weekly_window(limits: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """The weekly rate-limit window from one ``rate_limits`` snapshot, or None.
+
+    Codex does NOT always put the weekly quota in ``primary``: when a shorter
+    (e.g. 300-minute) window is also being reported it lands in ``primary`` and
+    the 10,080-minute weekly window is in ``secondary`` (qingyun CR #2676).  So
+    select the weekly window by ``window_minutes`` (>= 7 days) across BOTH keys
+    rather than assuming a fixed slot; assuming ``primary`` silently drops the
+    whole snapshot and reports LIGHT even though usable weekly telemetry exists.
+    When both windows qualify, take the longest (the true weekly)."""
+    candidates: list[tuple[int, dict[str, Any]]] = []
+    for key in ("primary", "secondary"):
+        window = limits.get(key)
+        if not isinstance(window, dict):
+            continue
+        used = window.get("used_percent")
+        if not isinstance(used, (int, float)) or isinstance(used, bool):
+            continue
+        window_minutes = window.get("window_minutes")
+        if not isinstance(window_minutes, (int, float)) or isinstance(window_minutes, bool):
+            continue
+        if int(window_minutes) < WEEKLY_MINUTES:
+            continue
+        candidates.append((int(window_minutes), window))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda c: c[0])[1]
 
 
 def _snapshots(home: Path) -> list[tuple[float, dict[str, Any]]]:
@@ -91,28 +121,26 @@ def _snapshots(home: Path) -> list[tuple[float, dict[str, Any]]]:
 
 def read_quota(home: Optional[Path] = None, now: Optional[float] = None) -> dict[str, Any]:
     now = time.time() if now is None else now
-    latest: dict[str, tuple[float, dict[str, Any]]] = {}
+    latest: dict[str, tuple[float, dict[str, Any], dict[str, Any]]] = {}
     for stamp, limits in _snapshots(home or _codex_home()):
-        primary = limits.get("primary")
-        if not isinstance(primary, dict) or not isinstance(primary.get("used_percent"), (int, float)):
-            continue
-        # The weekly window is the quota this gate is intended to protect.
-        if int(primary.get("window_minutes", 0)) < 7 * 24 * 60:
+        # The weekly window is the quota this gate protects — find it in either
+        # `primary` or `secondary` by window length, don't assume the slot.
+        weekly = _weekly_window(limits)
+        if weekly is None:
             continue
         lane = str(limits.get("limit_id") or limits.get("limit_name") or "unknown")
         if lane not in latest or stamp >= latest[lane][0]:
-            latest[lane] = (stamp, limits)
+            latest[lane] = (stamp, limits, weekly)
 
     rows = []
-    for lane, (stamp, limits) in latest.items():
-        primary = limits["primary"]
-        used = max(0.0, min(100.0, float(primary["used_percent"])))
+    for lane, (stamp, limits, weekly) in latest.items():
+        used = max(0.0, min(100.0, float(weekly["used_percent"])))
         rows.append({
             "limit_id": lane,
             "limit_name": limits.get("limit_name"),
             "used_percent": round(used, 1),
             "remaining_percent": round(100.0 - used, 1),
-            "resets_at": primary.get("resets_at"),
+            "resets_at": weekly.get("resets_at"),
             "sample_age_seconds": max(0, round(now - stamp)),
         })
 

--- a/skills/proactive-loop/scripts/codex-quota-gate.py
+++ b/skills/proactive-loop/scripts/codex-quota-gate.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Read Codex weekly rate-limit telemetry and choose proactive-loop depth.
+
+Codex CLI writes ``rate_limits`` snapshots into JSONL session transcripts.  A
+single transcript can contain several limit lanes (for example, the normal
+Codex lane and Spark), so the gate uses the most-utilized weekly lane as a
+conservative bound.  Missing or entirely stale telemetry fails closed to
+LIGHT.
+
+The output is intentionally small and machine-readable with ``--json`` so the
+proactive-loop skill can make a quota decision without pretending that the
+Claude-only quota tracker is a Codex signal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+STALE_AFTER_SECONDS = 30 * 60
+LOOKBACK_SECONDS = 14 * 24 * 60 * 60
+
+
+def _codex_home() -> Path:
+    configured = os.environ.get("CODEX_HOME")
+    if configured:
+        return Path(configured).expanduser()
+    repo = Path(__file__).resolve().parents[3]
+    sys.path.insert(0, str(repo / "src"))
+    try:
+        from sutando_config import resolve_core_config_dirs
+
+        for entry in resolve_core_config_dirs(repo):
+            if entry.get("type") == "codex" and entry.get("value"):
+                return Path(str(entry["value"])).expanduser()
+    except (ImportError, OSError, RuntimeError, ValueError):
+        pass
+    return Path()
+
+
+def _rate_limits(payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return None
+    direct = payload.get("rate_limits")
+    if isinstance(direct, dict):
+        return direct
+    info = payload.get("info")
+    if isinstance(info, dict) and isinstance(info.get("rate_limits"), dict):
+        return info["rate_limits"]
+    return None
+
+
+def _snapshots(home: Path) -> list[tuple[float, dict[str, Any]]]:
+    root = home / "sessions"
+    if not root.exists():
+        return []
+    cutoff = time.time() - LOOKBACK_SECONDS
+    found: list[tuple[float, dict[str, Any]]] = []
+    for path in root.rglob("*.jsonl"):
+        try:
+            if path.stat().st_mtime < cutoff:
+                continue
+            with path.open(encoding="utf-8", errors="replace") as stream:
+                for line in stream:
+                    try:
+                        event = json.loads(line)
+                    except (TypeError, ValueError):
+                        continue
+                    limits = _rate_limits(event.get("payload", event))
+                    if not limits:
+                        continue
+                    raw_ts = event.get("timestamp")
+                    try:
+                        if isinstance(raw_ts, (int, float)):
+                            stamp = float(raw_ts)
+                        else:
+                            stamp = datetime.fromisoformat(str(raw_ts).replace("Z", "+00:00")).timestamp()
+                    except (TypeError, ValueError, OverflowError):
+                        stamp = path.stat().st_mtime
+                    found.append((stamp, limits))
+        except OSError:
+            continue
+    return found
+
+
+def read_quota(home: Optional[Path] = None, now: Optional[float] = None) -> dict[str, Any]:
+    now = time.time() if now is None else now
+    latest: dict[str, tuple[float, dict[str, Any]]] = {}
+    for stamp, limits in _snapshots(home or _codex_home()):
+        primary = limits.get("primary")
+        if not isinstance(primary, dict) or not isinstance(primary.get("used_percent"), (int, float)):
+            continue
+        # The weekly window is the quota this gate is intended to protect.
+        if int(primary.get("window_minutes", 0)) < 7 * 24 * 60:
+            continue
+        lane = str(limits.get("limit_id") or limits.get("limit_name") or "unknown")
+        if lane not in latest or stamp >= latest[lane][0]:
+            latest[lane] = (stamp, limits)
+
+    rows = []
+    for lane, (stamp, limits) in latest.items():
+        primary = limits["primary"]
+        used = max(0.0, min(100.0, float(primary["used_percent"])))
+        rows.append({
+            "limit_id": lane,
+            "limit_name": limits.get("limit_name"),
+            "used_percent": round(used, 1),
+            "remaining_percent": round(100.0 - used, 1),
+            "resets_at": primary.get("resets_at"),
+            "sample_age_seconds": max(0, round(now - stamp)),
+        })
+
+    if not rows:
+        return {"available": False, "tier": "LIGHT", "reason": "missing-or-stale", "limits": rows}
+
+    # Keep stale lanes in the conservative bound when a fresh lane exists: a
+    # lane can be quiet simply because the current turn used another model,
+    # while its weekly limit is still real.  If every lane is stale, fail
+    # closed to LIGHT instead of making a confident decision from old data.
+    if all(row["sample_age_seconds"] > STALE_AFTER_SECONDS for row in rows):
+        return {"available": False, "tier": "LIGHT", "reason": "missing-or-stale", "limits": rows}
+
+    worst = min(rows, key=lambda row: row["remaining_percent"])
+    remaining = worst["remaining_percent"]
+    if remaining > 20:
+        tier = "FULL"
+    elif remaining >= 5:
+        tier = "MEDIUM"
+    else:
+        tier = "LIGHT"
+    return {
+        "available": True,
+        "tier": tier,
+        "remaining_percent": remaining,
+        "stale_lanes": [row["limit_id"] for row in rows if row["sample_age_seconds"] > STALE_AFTER_SECONDS],
+        "limits": rows,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    result = read_quota()
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        if not result["available"]:
+            print("Codex quota: unavailable/stale; gate=LIGHT")
+        else:
+            print(f"Codex quota: {result['remaining_percent']}% remaining; gate={result['tier']}")
+        for row in result.get("limits", []):
+            print(f"  {row['limit_id']}: {row['remaining_percent']}% remaining ({row['sample_age_seconds']}s old)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/schedule-crons/crons.example.json
+++ b/skills/schedule-crons/crons.example.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "main-loop",
-    "cron": "*/5 * * * *",
+    "cron": "*/15 * * * *",
     "prompt_skill": "proactive-loop"
   },
   {

--- a/tests/proactive-loop-codex-quota-gate.test.py
+++ b/tests/proactive-loop-codex-quota-gate.test.py
@@ -67,6 +67,54 @@ with tempfile.TemporaryDirectory() as td:
     result = gate.read_quota(only_stale, now=now)
     check("entirely stale telemetry fails closed", result["tier"] == "LIGHT" and not result["available"])
 
+    # qingyun CR #2676: the weekly window is not always `primary`. When a shorter
+    # (300-min) window occupies `primary` and the 10,080-min weekly window is in
+    # `secondary`, the gate must still read the weekly telemetry — not drop the
+    # snapshot and report unavailable/LIGHT.
+    dual = Path(td) / "dual-window-root"
+    dpath = dual / "sessions" / "fixture" / "codex.jsonl"
+    dpath.parent.mkdir(parents=True, exist_ok=True)
+    dpath.write_text(json.dumps({
+        "timestamp": datetime.fromtimestamp(now, timezone.utc).isoformat().replace("+00:00", "Z"),
+        "payload": {
+            "type": "token_count",
+            "rate_limits": {
+                "limit_id": "codex",
+                "primary": {"used_percent": 25, "window_minutes": 300, "resets_at": 111},
+                "secondary": {"used_percent": 90, "window_minutes": 10080, "resets_at": 222},
+            },
+        },
+    }) + "\n", encoding="utf-8")
+    result = gate.read_quota(dual, now=now)
+    check("weekly window read from secondary when primary is a short window",
+          result["available"] and len(result["limits"]) == 1)
+    check("secondary weekly used_percent (90) drives remaining, not primary (25)",
+          result["remaining_percent"] == 10.0)
+    check("10% remaining from the weekly secondary is MEDIUM", result["tier"] == "MEDIUM")
+    check("the weekly window's resets_at is surfaced (222, not the 300-min 111)",
+          result["limits"][0]["resets_at"] == 222)
+
+# _weekly_window branch coverage: every non-weekly shape degrades to None so the
+# snapshot is dropped (and the gate fails closed) rather than mis-read.
+check("no weekly window when only a short window is present",
+      gate._weekly_window({"primary": {"used_percent": 25, "window_minutes": 300}}) is None)
+check("non-dict window is ignored",
+      gate._weekly_window({"primary": "nope",
+                           "secondary": {"used_percent": 90, "window_minutes": 10080}})
+      is not None)
+check("non-numeric used_percent is ignored",
+      gate._weekly_window({"primary": {"used_percent": "x", "window_minutes": 10080}}) is None)
+check("boolean used_percent is not treated as numeric",
+      gate._weekly_window({"primary": {"used_percent": True, "window_minutes": 10080}}) is None)
+check("missing/non-numeric window_minutes is ignored",
+      gate._weekly_window({"primary": {"used_percent": 10}}) is None)
+check("empty snapshot yields no weekly window", gate._weekly_window({}) is None)
+check("longest qualifying window wins when both are weekly-length",
+      gate._weekly_window({
+          "primary": {"used_percent": 10, "window_minutes": 10080},
+          "secondary": {"used_percent": 20, "window_minutes": 20160},
+      })["window_minutes"] == 20160)
+
 if failures:
     raise SystemExit(f"{len(failures)} failure(s): {', '.join(failures)}")
 print("\nall tests passed")

--- a/tests/proactive-loop-codex-quota-gate.test.py
+++ b/tests/proactive-loop-codex-quota-gate.test.py
@@ -3,10 +3,15 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import json
+import os
+import sys
 import tempfile
 import time
+import types
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -114,6 +119,123 @@ check("longest qualifying window wins when both are weekly-length",
           "primary": {"used_percent": 10, "window_minutes": 10080},
           "secondary": {"used_percent": 20, "window_minutes": 20160},
       })["window_minutes"] == 20160)
+
+# qingyun CR #2676 (round 3): json.loads() accepts NaN/Infinity tokens, so a
+# non-finite window field is a float that passes isinstance but then crashes
+# int()/comparisons. It must drop out (fail closed), never raise.
+check("NaN window_minutes is rejected, not crashed on",
+      gate._weekly_window(json.loads('{"primary":{"used_percent":10,"window_minutes":NaN}}')) is None)
+check("Infinity window_minutes is rejected",
+      gate._weekly_window(json.loads('{"primary":{"used_percent":10,"window_minutes":Infinity}}')) is None)
+check("NaN used_percent is rejected",
+      gate._weekly_window(json.loads('{"primary":{"used_percent":NaN,"window_minutes":10080}}')) is None)
+check("_finite_number rejects NaN/inf/bool, accepts real numbers",
+      not gate._finite_number(float("nan")) and not gate._finite_number(float("inf"))
+      and not gate._finite_number(True) and gate._finite_number(10) and gate._finite_number(3.5))
+
+# ---- _codex_home: env override + config-dir resolution + fallback ----
+_saved_home = os.environ.get("CODEX_HOME")
+os.environ["CODEX_HOME"] = "/tmp/x-codex-home"
+check("_codex_home honors CODEX_HOME env", str(gate._codex_home()) == "/tmp/x-codex-home")
+os.environ.pop("CODEX_HOME", None)
+_saved_mod = sys.modules.get("sutando_config")
+_fake = types.ModuleType("sutando_config")
+_fake.resolve_core_config_dirs = lambda repo: [
+    {"type": "claude", "value": "/nope"}, {"type": "codex", "value": "/tmp/codex-cfg"}]
+sys.modules["sutando_config"] = _fake
+check("_codex_home reads the codex config dir", str(gate._codex_home()) == "/tmp/codex-cfg")
+def _raise(repo):
+    raise RuntimeError("boom")
+_fake2 = types.ModuleType("sutando_config")
+_fake2.resolve_core_config_dirs = _raise
+sys.modules["sutando_config"] = _fake2
+check("_codex_home falls back to Path() on resolver error", isinstance(gate._codex_home(), Path))
+if _saved_mod is not None:
+    sys.modules["sutando_config"] = _saved_mod
+else:
+    sys.modules.pop("sutando_config", None)
+if _saved_home is not None:
+    os.environ["CODEX_HOME"] = _saved_home
+
+# ---- _rate_limits: direct / info-nested / absent / non-dict ----
+check("_rate_limits None for non-dict payload", gate._rate_limits("x") is None)
+check("_rate_limits reads info.rate_limits nesting",
+      gate._rate_limits({"info": {"rate_limits": {"primary": {}}}}) == {"primary": {}})
+check("_rate_limits None when rate_limits absent", gate._rate_limits({"foo": 1}) is None)
+
+# ---- _snapshots: missing dir, stale skip, bad json, no-limits, numeric/bad ts ----
+with tempfile.TemporaryDirectory() as td2:
+    root2 = Path(td2)
+    check("_snapshots empty when no sessions dir", gate._snapshots(root2) == [])
+    sess = root2 / "sessions" / "s"
+    sess.mkdir(parents=True)
+    stale_f = sess / "stale.jsonl"
+    stale_f.write_text(json.dumps({
+        "timestamp": "2020-01-01T00:00:00Z",
+        "payload": {"rate_limits": {"limit_id": "old", "primary": {"used_percent": 1, "window_minutes": 10080}}},
+    }) + "\n", encoding="utf-8")
+    os.utime(stale_f, (0, 0))  # mtime at epoch -> older than the 14d cutoff
+    mix = sess / "mix.jsonl"
+    mix.write_text(
+        "{ not valid json\n"
+        + json.dumps({"payload": {"no": "limits"}}) + "\n"
+        + json.dumps({"timestamp": 1785000000,
+                      "payload": {"rate_limits": {"limit_id": "numts",
+                                                  "primary": {"used_percent": 5, "window_minutes": 10080}}}}) + "\n"
+        + json.dumps({"timestamp": "not-a-date",
+                      "payload": {"rate_limits": {"limit_id": "badts",
+                                                  "primary": {"used_percent": 5, "window_minutes": 10080}}}}) + "\n",
+        encoding="utf-8")
+    snaps = gate._snapshots(root2)
+    ids = {s[1].get("limit_id") for s in snaps}
+    check("_snapshots skips the stale file", "old" not in ids)
+    check("_snapshots parses numeric + bad timestamps, skips bad-json/no-limits lines",
+          {"numts", "badts"} <= ids and len(snaps) == 2)
+
+# ---- read_quota tier branches: FULL / LIGHT / no-weekly-window ----
+with tempfile.TemporaryDirectory() as tf:
+    rf = Path(tf); nowf = time.time(); write_snapshot(rf, 5, stamp=nowf)  # remaining 95
+    check("remaining >20 -> FULL", gate.read_quota(rf, now=nowf)["tier"] == "FULL")
+with tempfile.TemporaryDirectory() as tl:
+    rl = Path(tl); nowl = time.time(); write_snapshot(rl, 98, stamp=nowl)  # remaining 2
+    check("remaining <5 -> LIGHT", gate.read_quota(rl, now=nowl)["tier"] == "LIGHT")
+with tempfile.TemporaryDirectory() as tsh:
+    rsh = Path(tsh); nowsh = time.time()
+    sp = rsh / "sessions" / "f" / "short.jsonl"; sp.parent.mkdir(parents=True)
+    sp.write_text(json.dumps({
+        "timestamp": datetime.fromtimestamp(nowsh, timezone.utc).isoformat().replace("+00:00", "Z"),
+        "payload": {"rate_limits": {"primary": {"used_percent": 10, "window_minutes": 300}}},
+    }) + "\n", encoding="utf-8")
+    res = gate.read_quota(rsh, now=nowsh)
+    check("a snapshot with only a short window -> unavailable/LIGHT",
+          res["tier"] == "LIGHT" and not res["available"])
+
+# ---- main(): --json, text-available, text-unavailable ----
+def _run_main(argv, codex_home):
+    saved_argv, saved_home = sys.argv, os.environ.get("CODEX_HOME")
+    sys.argv = argv
+    os.environ["CODEX_HOME"] = str(codex_home)
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            rc = gate.main()
+    finally:
+        sys.argv = saved_argv
+        if saved_home is None:
+            os.environ.pop("CODEX_HOME", None)
+        else:
+            os.environ["CODEX_HOME"] = saved_home
+    return rc, buf.getvalue()
+
+with tempfile.TemporaryDirectory() as tm:
+    rm = Path(tm); write_snapshot(rm, 40, stamp=time.time())  # fresh, available
+    rc, out = _run_main(["g", "--json"], rm)
+    check("main --json returns 0 and emits JSON", rc == 0 and '"available": true' in out)
+    rc, out = _run_main(["g"], rm)
+    check("main text mode prints the gate tier", "gate=" in out and "remaining" in out)
+with tempfile.TemporaryDirectory() as tu:
+    rc, out = _run_main(["g"], Path(tu))  # empty -> unavailable
+    check("main text mode reports unavailable when no telemetry", "unavailable" in out)
 
 if failures:
     raise SystemExit(f"{len(failures)} failure(s): {', '.join(failures)}")

--- a/tests/proactive-loop-codex-quota-gate.test.py
+++ b/tests/proactive-loop-codex-quota-gate.test.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Regression tests for the Codex proactive-loop quota gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "skills/proactive-loop/scripts/codex-quota-gate.py"
+spec = importlib.util.spec_from_file_location("codex_quota_gate", SCRIPT)
+assert spec and spec.loader
+gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gate)
+
+failures = []
+
+
+def check(label: str, condition: bool) -> None:
+    if condition:
+        print(f"PASS  {label}")
+    else:
+        print(f"FAIL  {label}")
+        failures.append(label)
+
+
+def write_snapshot(root: Path, used: float, *, lane: str = "codex", stamp: Optional[float] = None) -> None:
+    path = root / "sessions" / "fixture" / f"{lane}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc)
+    event = {
+        "timestamp": (now if stamp is None else datetime.fromtimestamp(stamp, timezone.utc)).isoformat().replace("+00:00", "Z"),
+        "payload": {
+            "type": "token_count",
+            "rate_limits": {
+                "limit_id": lane,
+                "primary": {"used_percent": used, "window_minutes": 10080, "resets_at": 9999999999},
+            },
+        },
+    }
+    path.write_text(json.dumps(event) + "\n", encoding="utf-8")
+
+
+with tempfile.TemporaryDirectory() as td:
+    root = Path(td)
+    now = time.time()
+    write_snapshot(root, 89, stamp=now)
+    write_snapshot(root, 0, lane="codex_bengalfox", stamp=now)
+    result = gate.read_quota(root, now=now)
+    check("weekly lanes are read", len(result["limits"]) == 2)
+    check("worst lane determines remaining", result["remaining_percent"] == 11.0)
+    check("10% remaining is MEDIUM", result["tier"] == "MEDIUM")
+
+    stale = root / "sessions" / "stale"
+    stale.mkdir(parents=True, exist_ok=True)
+    old = now - gate.STALE_AFTER_SECONDS - 1
+    write_snapshot(root, 89, lane="only-stale", stamp=old)
+    # A root with only stale telemetry fails closed, while a fresh lane keeps
+    # the stale lane in the conservative worst-case bound.
+    only_stale = Path(td) / "only-stale-root"
+    write_snapshot(only_stale, 89, lane="codex", stamp=old)
+    result = gate.read_quota(only_stale, now=now)
+    check("entirely stale telemetry fails closed", result["tier"] == "LIGHT" and not result["available"])
+
+if failures:
+    raise SystemExit(f"{len(failures)} failure(s): {', '.join(failures)}")
+print("\nall tests passed")


### PR DESCRIPTION
"## What changed, and why?\n\nThis is distinct from open PR #2673, which repairs the Claude quota-tracker's 7-day pace-tier binding; this PR supplies the Codex telemetry adapter and scheduler policy.\n\nThe Codex core's autonomous main loop was waking every five minutes even when no owner task was waiting. That is a credible quota burn source because each turn reloads a large persistent context. This PR makes the default autonomous cadence 15 minutes and adds a Codex-native weekly quota gate. The streaming watcher remains the immediate owner-task path.\n\n## Files to review first\n\n- `skills/proactive-loop/scripts/codex-quota-gate.py` \u2014 reads Codex JSONL rate-limit snapshots and selects FULL/MEDIUM/LIGHT depth.\n- `skills/proactive-loop/SKILL.md` \u2014 applies the gate to autonomous work.\n- `skills/schedule-crons/crons.example.json` and `README.md` \u2014 document the 15-minute default.\n- `tests/proactive-loop-codex-quota-gate.test.py` \u2014 multi-lane and stale-telemetry controls.\n\n## Before / after evidence\n\nAt the parent (`origin/main`, `bb834e15`):\n\n```text\n$ grep -n '\"cron\"' skills/schedule-crons/crons.example.json | head -1\n4:    \"cron\": \"*/5 * * * *\",\n$ python3 skills/proactive-loop/scripts/codex-quota-gate.py --json\npython3: can't open file '/tmp/sutando-quota-before/skills/proactive-loop/scripts/codex-quota-gate.py': [Errno 2] No such file or directory\nbefore_gate_exit=2\n```\n\nAt this PR head (`2b31c68b`):\n\n```text\n$ grep -n '\"cron\"' skills/schedule-crons/crons.example.json | head -1\n4:    \"cron\": \"*/15 * * * *\",\n$ python3 tests/proactive-loop-codex-quota-gate.test.py\nPASS  weekly lanes are read\nPASS  worst lane determines remaining\nPASS  10% remaining is MEDIUM\nPASS  entirely stale telemetry fails closed\n\nall tests passed\n```\n\nLive host verification after the change:\n\n```text\n$ jq -r '.[0].cron' \"$WORKSPACE/hosts/Ruis-Mac-mini/crons.json\"\n*/15 * * * *\n$ python3 skills/proactive-loop/scripts/codex-quota-gate.py --json\n{\n  \"available\": true,\n  \"limits\": [\n    {\"limit_id\": \"codex\", \"limit_name\": null, \"remaining_percent\": 10.0, \"resets_at\": 1786160101, \"sample_age_seconds\": 15562, \"used_percent\": 90.0},\n    {\"limit_id\": \"codex_bengalfox\", \"limit_name\": \"GPT-5.3-Codex-Spark\", \"remaining_percent\": 100.0, \"resets_at\": 1786545960, \"sample_age_seconds\": 8, \"used_percent\": 0.0}\n  ],\n  \"remaining_percent\": 10.0,\n  \"stale_lanes\": [\"codex\"],\n  \"tier\": \"MEDIUM\"\n}\n$ jq '{last_tick_at,main_loop:.jobs[\"main-loop\"]}' \"$WORKSPACE/state/schedules/codex-scheduler.json\"\n{\n  \"last_tick_at\": \"2026-08-05T14:46:01Z\",\n  \"main_loop\": {\n    \"current\": {\"slot\": \"2026-08-05T14:45:00Z\", \"task_id\": \"task-cron-main-loop-1785941100\"},\n    \"last_scheduled_slot\": \"2026-08-05T14:45:00Z\"\n  }\n}\n```\n\nThis is a real scheduler run on the live host: after the config change, the durable Codex scheduler emitted the 14:45 pass at the new 15-minute cadence. The gate conservatively retained the stale normal Codex lane at 10% while also observing a fresh Spark lane, rather than ignoring a possibly still-valid weekly limit.\n\n## Tests run\n\n- `python3 -m py_compile skills/proactive-loop/scripts/codex-quota-gate.py tests/proactive-loop-codex-quota-gate.test.py`\n- `python3 tests/proactive-loop-codex-quota-gate.test.py` (all controls passed)\n- `python3 -m json.tool skills/schedule-crons/crons.example.json`\n- `git diff --check`\n\n## Edge cases\n\nThe test covers multiple weekly limit lanes, the least-remaining lane winning, and entirely stale telemetry failing closed to LIGHT. The reader ignores non-weekly windows and malformed JSONL lines.\n\n## Documentation / migration / rollback\n\nREADME and the shipped cron example are updated. No migration is required. Rollback is a one-line cadence revert plus reverting the skill/script commit; the existing watcher and owner-task path are unaffected.\n\n## Known gaps\n\nCodex telemetry is local CLI session data rather than a public quota API, so a future Codex JSONL schema change needs a parser update. Per-task token attribution remains a follow-up; this gate intentionally chooses a conservative lane-wide bound.\n\nStacked PR: N/A.\n"