### PR TITLE
fix(room-ops): a small read limit reported an empty room

### DIFF
--- a/skills/agent-room-ops/read.py
+++ b/skills/agent-room-ops/read.py
@@ -14,6 +14,29 @@ from _gateway import (gate_allows, load_gate, gateway, http_request, degrade_rea
 
 DEFAULT_LIMIT = 20
 MAX_LIMIT = 100
+# How many times the raw-event window may widen before we stop. Small and FIXED so the
+# widening below is a bounded `for` rather than a resident loop: the room-ops skill bans
+# new ones outright (tests/events-plane-boundary.test.py freezes the allowlist to two
+# grandfathered entries and shrinks it monotonically). The widening was always finite —
+# it is capped by MAX_LIMIT — so the bounded ladder is the honest shape too, not merely
+# the one that satisfies the gate.
+#
+# NB the guard regexes every LINE, comments included, so spelling the banned construct
+# out here — even inside backticks — would itself trip it.
+_MAX_WIDENINGS = 6
+
+
+def _windows(start, cap):
+    """Raw-event window sizes to try, smallest first. Precomputed and bounded."""
+    out, raw = [], max(1, min(int(start), cap))
+    for _ in range(_MAX_WIDENINGS):
+        out.append(raw)
+        if raw >= cap:
+            break
+        raw = min(cap, max(raw * 3, raw + 10))
+    if out[-1] != cap:
+        out.append(cap)
+    return out
 
 
 def _result(ok, messages=None, reason=None, room_id=None, complete=None):
@@ -86,20 +109,22 @@ def read_room(room_id, agent_mxid=None, limit=DEFAULT_LIMIT, *, gate=None, befor
         items = parsed.get("messages") if isinstance(parsed, dict) else parsed
         return _normalize(items)
 
-    raw = limit
-    messages, previous, exhausted = [], -1, False
+    messages, previous, exhausted = [], None, False
     try:
-        while True:
+        for raw in _windows(limit, MAX_LIMIT):
             messages = _fetch(raw)
             if len(messages) >= limit:
                 break
-            if len(messages) == previous:
-                exhausted = True          # a wider window returned nothing new
-                break
-            if raw >= MAX_LIMIT:
+            # A WIDER window that surfaced nothing new means the history is exhausted —
+            # but ONLY once we have actually seen a message. Two consecutive ZEROS mean
+            # the opposite: the window has not yet cleared the leading run of non-message
+            # events, which is the very condition this function exists to survive. Caught
+            # live: windows 1 and 11 both returned 0 on a room holding fourteen, and
+            # treating that as exhaustion reproduced the empty-room bug one layer down.
+            if previous is not None and len(messages) == previous and messages:
+                exhausted = True
                 break
             previous = len(messages)
-            raw = min(MAX_LIMIT, max(raw * 3, raw + 10))
     except HTTPError as e:
         return _result(False, reason=degrade_reason(e.code), room_id=room_id)
     except (URLError, TimeoutError) as e:

--- a/skills/agent-room-ops/read.py
+++ b/skills/agent-room-ops/read.py
@@ -109,22 +109,25 @@ def read_room(room_id, agent_mxid=None, limit=DEFAULT_LIMIT, *, gate=None, befor
         items = parsed.get("messages") if isinstance(parsed, dict) else parsed
         return _normalize(items)
 
-    messages, previous, exhausted = [], None, False
+    # NO EARLY STOP ON A REPEATED COUNT. An unchanged message count across a wider raw
+    # window looks like "history exhausted" and is not: the extra raw events may all be
+    # non-messages, with older messages just past the wall. Both reviewers of #2678
+    # produced the control independently — a 20-event front gap makes windows [3, 13]
+    # return zero twice, and stopping there rebuilds the exact false-empty this function
+    # exists to remove. Guarding the check on "we have seen a message" was MY first
+    # attempt and only moves the wall: one message ahead of a 60-event gap still returned
+    # 1 of 5 with complete=True. There is no safe repeated-count inference.
+    #
+    # The gateway offers no genuine exhaustion signal either — this endpoint returns only
+    # message-type items, so a short page is indistinguishable from a noisy window. So the
+    # only sound stop conditions are "we have what was asked for" and "we have looked as
+    # far as the API allows", and `complete` means strictly the former.
+    messages = []
     try:
         for raw in _windows(limit, MAX_LIMIT):
             messages = _fetch(raw)
             if len(messages) >= limit:
                 break
-            # A WIDER window that surfaced nothing new means the history is exhausted —
-            # but ONLY once we have actually seen a message. Two consecutive ZEROS mean
-            # the opposite: the window has not yet cleared the leading run of non-message
-            # events, which is the very condition this function exists to survive. Caught
-            # live: windows 1 and 11 both returned 0 on a room holding fourteen, and
-            # treating that as exhaustion reproduced the empty-room bug one layer down.
-            if previous is not None and len(messages) == previous and messages:
-                exhausted = True
-                break
-            previous = len(messages)
     except HTTPError as e:
         return _result(False, reason=degrade_reason(e.code), room_id=room_id)
     except (URLError, TimeoutError) as e:
@@ -132,8 +135,10 @@ def read_room(room_id, agent_mxid=None, limit=DEFAULT_LIMIT, *, gate=None, befor
     except ValueError as e:
         return _result(False, reason=f"parse error: {e}", room_id=room_id)
 
-    # `complete` is the half that makes a short result readable. Without it, "3 messages"
-    # cannot be told apart from "3 messages AND we stopped looking", which is the same
-    # ambiguity that made the zero above so misleading.
-    complete = exhausted or len(messages) >= limit
-    return _result(True, messages[:limit], room_id=room_id, complete=complete)
+    # `complete` is the half that makes a short result readable, and it UNDER-claims on
+    # purpose: short-of-limit is reported False even for a room that may genuinely hold
+    # nothing more, because from here those two cases are indistinguishable. A caller that
+    # sees complete=False knows only "do not treat this as the whole story", which is the
+    # safe direction for a function whose failure mode is a confident empty.
+    return _result(True, messages[:limit], room_id=room_id,
+                   complete=len(messages) >= limit)

--- a/skills/agent-room-ops/read.py
+++ b/skills/agent-room-ops/read.py
@@ -16,8 +16,12 @@ DEFAULT_LIMIT = 20
 MAX_LIMIT = 100
 
 
-def _result(ok, messages=None, reason=None, room_id=None):
-    return {"ok": bool(ok), "room_id": room_id, "reason": reason, "messages": messages or []}
+def _result(ok, messages=None, reason=None, room_id=None, complete=None):
+    # `complete` is False when the raw-event window was still growing when we stopped, so a
+    # caller can tell "this room is quiet" from "I did not look far enough". None on error
+    # paths, where the question does not arise.
+    return {"ok": bool(ok), "room_id": room_id, "reason": reason, "messages": messages or [],
+            "complete": complete}
 
 
 def _normalize(items):
@@ -52,20 +56,59 @@ def read_room(room_id, agent_mxid=None, limit=DEFAULT_LIMIT, *, gate=None, befor
     base, headers = gateway()
     if not base:
         return _result(False, reason="no gateway configured", room_id=room_id)
-    params = {"limit": limit}
-    if before:
-        params["before"] = before
-    url = f"{base}/v1/rooms/{quote(room_id)}/messages?" + urlencode(params)
-    try:
+    # `limit` here means MESSAGES, but the gateway applies its limit to RAW TIMELINE
+    # EVENTS and only some of those are messages — reactions, receipts, membership and
+    # media events all consume the budget. Measured on a live room 2026-08-05:
+    #
+    #     limit=  4 ->  0 messages      <- ok:true, no error, reads as an empty room
+    #     limit= 10 ->  1
+    #     limit= 20 ->  8
+    #     limit= 40 -> 14
+    #     limit=100 -> 14               <- history exhausted
+    #
+    # Nine non-message events sat in front of the newest message, so a caller asking for
+    # the last few messages got a confident, silent ZERO. That is the dangerous shape: a
+    # small limit is exactly what a cheap "has anyone replied yet?" probe passes, and the
+    # answer it gets back is indistinguishable from a genuinely quiet room.
+    #
+    # So widen the raw window until we actually hold `limit` messages, the server stops
+    # producing new ones (history exhausted), or MAX_LIMIT is reached. Each response is a
+    # superset of the previous one — the window only grows — so the last one is the answer.
+    import json
+
+    def _fetch(raw_limit):
+        params = {"limit": raw_limit}
+        if before:
+            params["before"] = before
+        url = f"{base}/v1/rooms/{quote(room_id)}/messages?" + urlencode(params)
         _, body, _h = http_request("GET", url, headers)
+        parsed = json.loads(body.decode("utf-8") or "{}")
+        items = parsed.get("messages") if isinstance(parsed, dict) else parsed
+        return _normalize(items)
+
+    raw = limit
+    messages, previous, exhausted = [], -1, False
+    try:
+        while True:
+            messages = _fetch(raw)
+            if len(messages) >= limit:
+                break
+            if len(messages) == previous:
+                exhausted = True          # a wider window returned nothing new
+                break
+            if raw >= MAX_LIMIT:
+                break
+            previous = len(messages)
+            raw = min(MAX_LIMIT, max(raw * 3, raw + 10))
     except HTTPError as e:
         return _result(False, reason=degrade_reason(e.code), room_id=room_id)
     except (URLError, TimeoutError) as e:
         return _result(False, reason=f"network error: {e}", room_id=room_id)
-    import json
-    try:
-        parsed = json.loads(body.decode("utf-8") or "{}")
     except ValueError as e:
         return _result(False, reason=f"parse error: {e}", room_id=room_id)
-    items = parsed.get("messages") if isinstance(parsed, dict) else parsed
-    return _result(True, _normalize(items), room_id=room_id)
+
+    # `complete` is the half that makes a short result readable. Without it, "3 messages"
+    # cannot be told apart from "3 messages AND we stopped looking", which is the same
+    # ambiguity that made the zero above so misleading.
+    complete = exhausted or len(messages) >= limit
+    return _result(True, messages[:limit], room_id=room_id, complete=complete)

--- a/skills/agent-room-ops/test_room_ops.py
+++ b/skills/agent-room-ops/test_room_ops.py
@@ -176,14 +176,20 @@ class ReadTests(EnvCase):
         self.assertEqual(len(res["messages"]), 10)
         self.assertTrue(res["complete"])
 
-    def test_short_room_is_marked_complete_not_truncated(self):
-        """Fewer messages than asked for is fine — but say WHICH kind of short it is."""
+    def test_short_room_under_claims_completeness(self):
+        """Short of `limit` never claims complete — the client cannot tell why it is short.
+
+        Updated per the #2678 review: a repeated message count across a wider window is
+        NOT proof of exhausted history (the extra raw events may all be non-messages), and
+        this endpoint returns only message-type items, so a short page is indistinguishable
+        from a noisy one. Under-claiming is the safe direction here.
+        """
         os.environ["RELAY_URL"] = "https://r"
         with mock.patch.object(rd, "http_request",
                                side_effect=self._raw_window_gateway(total_messages=2)):
             res = rd.read_room(ROOM, HS, limit=20, gate=None)
         self.assertEqual(len(res["messages"]), 2)
-        self.assertTrue(res["complete"], "history exhausted -> complete, not truncated")
+        self.assertFalse(res["complete"], "short of limit -> never claim complete")
 
     def test_success_parses(self):
         os.environ["RELAY_URL"] = "https://r"

--- a/skills/agent-room-ops/test_room_ops.py
+++ b/skills/agent-room-ops/test_room_ops.py
@@ -131,6 +131,60 @@ class ReadTests(EnvCase):
             rd.read_room(ROOM, HS, limit=9999, gate=None)
         self.assertIn(f"limit={rd.MAX_LIMIT}", cap["url"])
 
+    def _raw_window_gateway(self, total_messages=14, noise_per_message=2):
+        """A gateway whose `limit` bounds RAW EVENTS, of which only some are messages.
+
+        This is what the live ag2.space gateway does. Reproduced here because the failure
+        it causes is silent: fewer messages than asked for, ok:true, and no error.
+        """
+        import urllib.parse as _up
+
+        def _http(_m, url, _h):
+            raw = int(dict(_up.parse_qsl(_up.urlparse(url).query))["limit"])
+            # Newest-first timeline: every message preceded by `noise` non-message events,
+            # so the first `noise` slots of any window contain no messages at all.
+            msgs, consumed = [], 0
+            for i in range(total_messages):
+                consumed += noise_per_message
+                if consumed >= raw:
+                    break
+                consumed += 1
+                msgs.append({"sender": "@a:hs", "ts": 1000 - i, "body": f"m{i}"})
+                if consumed >= raw:
+                    break
+            return (200, json.dumps({"messages": msgs}).encode(), {})
+        return _http
+
+    def test_small_limit_does_not_report_an_empty_room(self):
+        """limit=3 must not return zero messages from a room that has fourteen.
+
+        REGRESSION (measured live 2026-08-05): the gateway's limit counts raw timeline
+        events, so `--limit 3` returned `ok:true` with an EMPTY message list on a busy
+        room. A cheap "did anyone reply?" probe is exactly what passes a small limit, and
+        the false empty is indistinguishable from silence. Before the fix this asserts 0.
+        """
+        os.environ["RELAY_URL"] = "https://r"
+        with mock.patch.object(rd, "http_request", side_effect=self._raw_window_gateway()):
+            res = rd.read_room(ROOM, HS, limit=3, gate=None)
+        self.assertTrue(res["ok"])
+        self.assertEqual(len(res["messages"]), 3, "a small limit must still yield messages")
+
+    def test_limit_counts_messages_not_raw_events(self):
+        os.environ["RELAY_URL"] = "https://r"
+        with mock.patch.object(rd, "http_request", side_effect=self._raw_window_gateway()):
+            res = rd.read_room(ROOM, HS, limit=10, gate=None)
+        self.assertEqual(len(res["messages"]), 10)
+        self.assertTrue(res["complete"])
+
+    def test_short_room_is_marked_complete_not_truncated(self):
+        """Fewer messages than asked for is fine — but say WHICH kind of short it is."""
+        os.environ["RELAY_URL"] = "https://r"
+        with mock.patch.object(rd, "http_request",
+                               side_effect=self._raw_window_gateway(total_messages=2)):
+            res = rd.read_room(ROOM, HS, limit=20, gate=None)
+        self.assertEqual(len(res["messages"]), 2)
+        self.assertTrue(res["complete"], "history exhausted -> complete, not truncated")
+
     def test_success_parses(self):
         os.environ["RELAY_URL"] = "https://r"
         body = (200, json.dumps({"messages": [{"sender": "@a:hs", "ts": 1, "body": "hi"}]}).encode(), {})

--- a/tests/room_ops_read_limit.test.py
+++ b/tests/room_ops_read_limit.test.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""read_room limit semantics — coverage-gate home.
+
+The room-ops suite lives under `skills/agent-room-ops/`, but the diff-coverage gate
+discovers only `tests/*.test.py` (`scripts/coverage-gate.sh` -> `find tests -name
+'*.test.py'`). So changed lines in `read.py` are RUN by the functional job and
+INVISIBLE to the coverage job — a passing test the gate never sees. Same reachability
+trap, and the same remedy, as `tests/room_ops_gateway_vault.test.py`.
+
+What is pinned here: `limit` counts MESSAGES, not raw timeline events.
+
+The gateway applies its limit to raw events — reactions, receipts, membership and media
+all consume the budget — so a small limit could return an EMPTY list with ok:true and no
+error, on a room that was not empty. Measured live 2026-08-05 against ag2.space:
+
+    limit=4 -> 0 messages, limit=10 -> 1, limit=20 -> 8, limit=40 -> 14, limit=100 -> 14
+
+Nine non-message events sat ahead of the newest message. A small limit is exactly what a
+cheap "has anyone replied?" probe passes, so the false empty lands precisely on polling.
+
+Run: python3 tests/room_ops_read_limit.test.py
+"""
+import json
+import os
+import pathlib
+import sys
+import unittest
+import urllib.parse
+from unittest import mock
+
+_ROOM_OPS = pathlib.Path(__file__).resolve().parents[1] / "skills" / "agent-room-ops"
+sys.path.insert(0, str(_ROOM_OPS))
+import read as rd  # noqa: E402
+
+HS = "@a:hs"
+ROOM = "!r:hs"
+_ENVK = ("GATEWAY_URL", "GATEWAY_TOKEN", "RELAY_URL", "REMOTE_TASK_URL",
+         "RELAY_TOKEN", "REMOTE_TASK_TOKEN", "AG2_REMOTE_TOKEN", "AG2_REMOTE_URL")
+
+
+def raw_window_gateway(total_messages=14, noise_per_message=2, seen=None):
+    """A gateway whose `limit` bounds RAW EVENTS, only some of which are messages.
+
+    Reproduces the live ag2.space behaviour rather than asserting the new shape into
+    existence — so this fails if the client stops widening, instead of merely pinning
+    whatever the code does today.
+    """
+    def _http(_method, url, _headers):
+        raw = int(dict(urllib.parse.parse_qsl(urllib.parse.urlparse(url).query))["limit"])
+        if seen is not None:
+            seen.append(raw)
+        msgs, consumed = [], 0
+        for i in range(total_messages):
+            consumed += noise_per_message          # non-message events come first
+            if consumed >= raw:
+                break
+            consumed += 1
+            msgs.append({"sender": HS, "ts": 1000 - i, "body": f"m{i}"})
+            if consumed >= raw:
+                break
+        return (200, json.dumps({"messages": msgs}).encode(), {})
+    return _http
+
+
+class ReadLimitCountsMessages(unittest.TestCase):
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in _ENVK}
+        for k in _ENVK:
+            os.environ.pop(k, None)
+        os.environ["RELAY_URL"] = "https://r"
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is not None:
+                os.environ[k] = v
+            else:
+                os.environ.pop(k, None)
+
+    def test_small_limit_does_not_report_an_empty_room(self):
+        """The regression: limit=3 returned ZERO from a room holding fourteen."""
+        with mock.patch.object(rd, "http_request", side_effect=raw_window_gateway()):
+            res = rd.read_room(ROOM, HS, limit=3, gate=None)
+        self.assertTrue(res["ok"])
+        self.assertEqual(len(res["messages"]), 3)
+
+    def test_limit_counts_messages_not_raw_events(self):
+        with mock.patch.object(rd, "http_request", side_effect=raw_window_gateway()):
+            res = rd.read_room(ROOM, HS, limit=10, gate=None)
+        self.assertEqual(len(res["messages"]), 10)
+        self.assertTrue(res["complete"])
+
+    def test_widens_the_window_until_satisfied(self):
+        seen = []
+        with mock.patch.object(rd, "http_request",
+                               side_effect=raw_window_gateway(seen=seen)):
+            rd.read_room(ROOM, HS, limit=5, gate=None)
+        self.assertGreater(len(seen), 1, "must widen when the first window is short")
+        self.assertEqual(seen, sorted(seen), "the raw window must only grow")
+
+    def test_short_room_is_complete_not_truncated(self):
+        with mock.patch.object(rd, "http_request",
+                               side_effect=raw_window_gateway(total_messages=2)):
+            res = rd.read_room(ROOM, HS, limit=20, gate=None)
+        self.assertEqual(len(res["messages"]), 2)
+        self.assertTrue(res["complete"], "history exhausted -> complete")
+
+    def test_stops_at_max_limit(self):
+        seen = []
+        with mock.patch.object(rd, "http_request",
+                               side_effect=raw_window_gateway(total_messages=500,
+                                                              noise_per_message=9,
+                                                              seen=seen)):
+            res = rd.read_room(ROOM, HS, limit=rd.MAX_LIMIT, gate=None)
+        self.assertLessEqual(max(seen), rd.MAX_LIMIT, "never request beyond MAX_LIMIT")
+        self.assertFalse(res["complete"], "stopped early -> NOT complete")
+
+    def test_never_returns_more_than_requested(self):
+        with mock.patch.object(rd, "http_request", side_effect=raw_window_gateway()):
+            res = rd.read_room(ROOM, HS, limit=2, gate=None)
+        self.assertEqual(len(res["messages"]), 2)
+
+    # ---- error paths keep degrading, and stay reportable ---- #
+    def test_http_error_degrades(self):
+        import urllib.error
+        err = urllib.error.HTTPError("u", 404, "nf", {}, None)
+        with mock.patch.object(rd, "http_request", side_effect=err):
+            res = rd.read_room(ROOM, HS, gate=None)
+        self.assertFalse(res["ok"])
+        self.assertIsNone(res["complete"], "no completeness claim on an error")
+
+    def test_network_error_degrades(self):
+        import urllib.error
+        with mock.patch.object(rd, "http_request",
+                               side_effect=urllib.error.URLError("boom")):
+            res = rd.read_room(ROOM, HS, gate=None)
+        self.assertFalse(res["ok"])
+        self.assertIn("network error", res["reason"])
+
+    def test_bad_json_degrades(self):
+        with mock.patch.object(rd, "http_request",
+                               return_value=(200, b"not json", {})):
+            res = rd.read_room(ROOM, HS, gate=None)
+        self.assertFalse(res["ok"])
+        self.assertIn("parse error", res["reason"])
+
+    def test_bare_list_body_is_accepted(self):
+        body = (200, json.dumps([{"sender": HS, "ts": 1, "body": "hi"}]).encode(), {})
+        with mock.patch.object(rd, "http_request", return_value=body):
+            res = rd.read_room(ROOM, HS, limit=1, gate=None)
+        self.assertEqual(res["messages"][0]["body"], "hi")
+
+    def test_before_is_forwarded(self):
+        seen_urls = []
+
+        def _http(_m, url, _h):
+            seen_urls.append(url)
+            return (200, json.dumps({"messages": [{"sender": HS, "ts": 1, "body": "x"}]}).encode(), {})
+        with mock.patch.object(rd, "http_request", side_effect=_http):
+            rd.read_room(ROOM, HS, limit=1, gate=None, before="$evt")
+        self.assertIn("before=", seen_urls[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/room_ops_read_limit.test.py
+++ b/tests/room_ops_read_limit.test.py
@@ -114,6 +114,22 @@ class ReadLimitCountsMessages(unittest.TestCase):
         self.assertLessEqual(max(seen), rd.MAX_LIMIT, "never request beyond MAX_LIMIT")
         self.assertFalse(res["complete"], "stopped early -> NOT complete")
 
+    def test_leading_noise_wider_than_the_first_windows(self):
+        """Two consecutive ZERO windows must not be read as an empty room.
+
+        REGRESSION, caught live 2026-08-05: raw windows 1 and 11 both returned 0 messages
+        on a room holding fourteen, because a long run of reactions/receipts sat in front
+        of the newest message. Stopping there — "a wider window returned nothing new" —
+        reproduced the exact empty-room bug this module exists to prevent, one layer down.
+        Exhaustion may only be inferred once at least one message has been seen.
+        """
+        with mock.patch.object(rd, "http_request",
+                               side_effect=raw_window_gateway(total_messages=14,
+                                                              noise_per_message=12)):
+            res = rd.read_room(ROOM, HS, limit=1, gate=None)
+        self.assertEqual(len(res["messages"]), 1,
+                         "leading noise must be walked past, not mistaken for an empty room")
+
     def test_never_returns_more_than_requested(self):
         with mock.patch.object(rd, "http_request", side_effect=raw_window_gateway()):
             res = rd.read_room(ROOM, HS, limit=2, gate=None)

--- a/tests/room_ops_read_limit.test.py
+++ b/tests/room_ops_read_limit.test.py
@@ -97,12 +97,65 @@ class ReadLimitCountsMessages(unittest.TestCase):
         self.assertGreater(len(seen), 1, "must widen when the first window is short")
         self.assertEqual(seen, sorted(seen), "the raw window must only grow")
 
-    def test_short_room_is_complete_not_truncated(self):
+    def test_short_room_under_claims_completeness(self):
+        """Short of `limit` reports complete=False even if the room may hold no more.
+
+        Deliberate under-claim (#2678 review): from the client those two cases are
+        indistinguishable — this endpoint returns only message-type items, so a short page
+        looks identical to a noisy window. A caller seeing complete=False learns only "do
+        not treat this as the whole story", the safe direction for a function whose
+        failure mode is a confident empty.
+        """
         with mock.patch.object(rd, "http_request",
                                side_effect=raw_window_gateway(total_messages=2)):
             res = rd.read_room(ROOM, HS, limit=20, gate=None)
         self.assertEqual(len(res["messages"]), 2)
-        self.assertTrue(res["complete"], "history exhausted -> complete")
+        self.assertFalse(res["complete"], "short of limit -> never claim complete")
+
+    def _front_gap_gateway(self, gap, total=14, before=0):
+        """`before` messages, then a wall of `gap` non-message events, then the rest."""
+        import urllib.parse as _up
+
+        def _http(_m, url, _h):
+            raw = int(dict(_up.parse_qsl(_up.urlparse(url).query))["limit"])
+            msgs, consumed = [], 0
+            for _ in range(before):
+                consumed += 1
+                if consumed > raw:
+                    break
+                msgs.append({"sender": HS, "ts": 1, "body": f"pre{len(msgs)}"})
+            consumed += gap
+            while consumed < raw and len(msgs) < total:
+                consumed += 1
+                msgs.append({"sender": HS, "ts": 1, "body": f"m{len(msgs)}"})
+            return (200, json.dumps({"messages": msgs}).encode(), {})
+        return _http
+
+    def test_front_gap_is_not_exhausted_history(self):
+        """Both #2678 reviewers' control: a 20-event front gap is not an empty room.
+
+        Windows [3, 13] both return zero because neither clears the wall. Inferring
+        exhaustion from that repeated count rebuilds the exact false-empty this module
+        exists to remove, for rooms with a larger front gap.
+        """
+        with mock.patch.object(rd, "http_request",
+                               side_effect=self._front_gap_gateway(gap=20)):
+            res = rd.read_room(ROOM, HS, limit=3, gate=None)
+        self.assertEqual(len(res["messages"]), 3)
+        self.assertTrue(res["complete"])
+
+    def test_a_wall_after_the_first_message_is_not_exhausted_either(self):
+        """Guarding the plateau on "we have seen a message" only MOVES the wall.
+
+        That was the author's first attempt at the fix; one message ahead of a 60-event
+        gap still returned 1 of 5 with complete=True. There is no safe repeated-count
+        inference, which is why the check is gone rather than conditioned.
+        """
+        with mock.patch.object(rd, "http_request",
+                               side_effect=self._front_gap_gateway(gap=60, before=1)):
+            res = rd.read_room(ROOM, HS, limit=5, gate=None)
+        self.assertGreaterEqual(len(res["messages"]), 5)
+        self.assertTrue(res["complete"])
 
     def test_stops_at_max_limit(self):
         seen = []


### PR DESCRIPTION
`read_room(limit=N)` reads as "give me N messages". The gateway applies its limit to **raw timeline events**, and only some of those are messages — reactions, receipts, membership and media events all consume the budget. So a small limit can return an **empty list with `ok:true` and no error**, on a room that is not empty.

## The bug, measured live against ag2.space (one busy room)

```
limit=  4 ->  0 messages     <- ok:true, no error, reads as an empty room
limit= 10 ->  1
limit= 20 ->  8
limit= 40 -> 14
limit=100 -> 14              <- history exhausted
```

Nine non-message events sat in front of the newest message.

That is the dangerous shape: **a small limit is exactly what a cheap "has anyone replied yet?" probe passes**, and a false empty is indistinguishable from a genuinely quiet room. I hit it as a caller — a `limit=3` poll returned nothing twenty minutes after the same call returned five messages, and a room cannot lose history. That contradiction is the only reason I noticed.

## The fix

Widen the raw window until we hold `limit` messages, the server stops producing new ones, or `MAX_LIMIT` is reached. Each response is a superset of the last, so the final one is the answer.

Also returns **`complete`**. Without it, "3 messages" cannot be told apart from "3 messages AND I stopped looking" — the same ambiguity that made the zero misleading in the first place.

## Before / after, live round trip, same room

```
limit   unpatched   patched
    1      0          1   complete=True
    3      0          3   complete=True
    4      0          4   complete=True
   10      1         10   complete=True
```

## Tests

Three added, and **each fails against the current `read.py`** — 2 failures + 1 error on the unmodified file:

```
FAIL:  test_small_limit_does_not_report_an_empty_room
FAIL:  test_limit_counts_messages_not_raw_events
ERROR: test_short_room_is_marked_complete_not_truncated
```

The fixture reproduces the real gateway's raw-event windowing rather than asserting the new shape into existence, so it would catch a regression rather than just pinning today's code.

Full existing suite after the fix: **`Ran 117 tests ... OK`**.

## Cost, stated plainly

For a room genuinely holding fewer messages than `limit`, this spends **one extra request** to confirm history is exhausted. The gateway offers no exhaustion flag, so one confirming probe is the minimum honest price for telling "quiet" apart from "truncated". No extra request when the first window already satisfies the limit.

## Scope

`skills/agent-room-ops/read.py` + its tests only. Checked for collisions first: #2670, #2602 and #2432 touch `agent-room-ops`, but none touches `read.py` (`_gateway.py`, `test_room_ops.py`, `events_acceptance.py` respectively).

@sonichi flagging you directly — this one is worth knowing about even before review, because **every existing caller passing a small limit has been getting silent false empties**, and that includes my own reply-polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
