### PR TITLE
fix(telemetry): emit task_processed from the workstream session worker (restores cron metric)

### DIFF
--- a/skills/task-workstream-sessions/scripts/session-worker.py
+++ b/skills/task-workstream-sessions/scripts/session-worker.py
@@ -326,6 +326,25 @@ def probe(runtime: str, workspace: Path, task_file: Path) -> int:
     return 0
 
 
+def _emit_task_processed(repo: Path, task_file: Path) -> None:
+    """Count a worker-handled task in telemetry, mirroring the live-core path.
+
+    #2274 emits ``task_processed(<source>)`` when the live core handles a task,
+    but tasks routed to this isolated worker (#2603) never reached that call, so
+    cron/other worker-handled tasks silently dropped out of the metric. Emit it
+    here on success. Best-effort: telemetry must NEVER break task handling.
+    """
+    try:
+        src_dir = str((repo / "src").resolve())
+        if src_dir not in sys.path:
+            sys.path.insert(0, src_dir)
+        import telemetry  # noqa: E402
+        source = _headers(task_file).get("source") or "unknown"
+        telemetry.task_processed(source)
+    except Exception:
+        pass
+
+
 def handle(runtime: str, workspace: Path, task_file: Path, results_dir: Path, repo: Path) -> int:
     if probe(runtime, workspace, task_file) != 0:
         return UNHANDLED
@@ -348,6 +367,7 @@ def handle(runtime: str, workspace: Path, task_file: Path, results_dir: Path, re
             if not body.strip():
                 raise RuntimeError(f"{runtime} returned an empty result")
             _publish_result(result_path, body)
+            _emit_task_processed(repo, task_file)
             return 0
     except Exception as exc:
         print(f"workstream session worker: {exc}", file=sys.stderr)

--- a/tests/task-workstream-session-worker.test.py
+++ b/tests/task-workstream-session-worker.test.py
@@ -9,6 +9,7 @@ import json
 import os
 import signal
 import subprocess
+import sys
 import tempfile
 import time
 from collections import Counter
@@ -818,6 +819,47 @@ def test_runtime_wiring_is_optional_and_adapter_injected() -> None:
     assert 'NOTIFIER_ENV_ARGS+=(-e "SUTANDO_SELF_DEVELOPMENT_ENABLED=' in codex
 
 
+
+
+def test_worker_emits_task_processed_mirroring_the_live_path():
+    """#2603 routed tasks to this worker but never emitted the task_processed
+    telemetry #2274 added on the live-core path — cron/worker-handled tasks
+    silently dropped out of the metric. The worker must now emit it, keyed on
+    the task's source, best-effort (a broken telemetry must not break handling).
+    """
+    import types
+    with tempfile.TemporaryDirectory() as td:
+        tf = Path(td) / "task-cron-x.txt"
+        tf.write_text("id: task-cron-x\nsource: cron\naccess_tier: owner\ntask: do it\n", encoding="utf-8")
+
+        captured = []
+        fake = types.ModuleType("telemetry")
+        fake.task_processed = lambda source: captured.append(source)
+        saved = sys.modules.get("telemetry")
+        sys.modules["telemetry"] = fake
+        try:
+            worker._emit_task_processed(REPO, tf)
+            assert captured == ["cron"], f"expected ['cron'], got {captured}"
+
+            # no source header -> 'unknown', still emitted (never dropped)
+            tf2 = Path(td) / "task-y.txt"
+            tf2.write_text("id: task-y\ntask: do it\n", encoding="utf-8")
+            captured.clear()
+            worker._emit_task_processed(REPO, tf2)
+            assert captured == ["unknown"], f"expected ['unknown'], got {captured}"
+
+            # a telemetry that raises must be swallowed (best-effort), not propagate
+            def _boom(source):
+                raise RuntimeError("posthog down")
+            fake.task_processed = _boom
+            worker._emit_task_processed(REPO, tf)  # must not raise
+        finally:
+            if saved is not None:
+                sys.modules["telemetry"] = saved
+            else:
+                sys.modules.pop("telemetry", None)
+
+
 if __name__ == "__main__":
     test_resolution_is_owner_only_and_fail_open()
     test_claude_creates_then_resumes_the_same_durable_session()
@@ -836,4 +878,5 @@ if __name__ == "__main__":
     test_codex_notifier_dispatches_each_isolated_task_once_without_waiting()
     test_codex_notifier_never_submits_a_watcher_claim_to_live_core()
     test_runtime_wiring_is_optional_and_adapter_injected()
+    test_worker_emits_task_processed_mirroring_the_live_path()
     print("task workstream session worker tests passed")


### PR DESCRIPTION
## The regression
**#2603** (isolate core sessions by workstream, merged today) routes eligible tasks — including crons — to the isolated workstream `session-worker.py` instead of the live core. But that worker never emitted the `task_processed` telemetry **#2274** added on the live-core path, so cron-sourced tasks stopped being counted the moment #2603 shipped:

```
cron-sourced task_processed/day (PostHog, same 00:00-14:00 UTC window):
  08-02  5,774   08-03 10,492   08-04 5,901   08-05  115   <- ~98% drop
```
**Blind spot, not an outage** — crons still run and process fine; they just weren't counted.

## The fix
Emit `task_processed(<task.source>)` after a successful publish in the worker's `handle()`, keyed on the task file's own `source:` header. Best-effort: swallowed on any error (telemetry must never break task handling), and `telemetry._dispatch` is already an async daemon thread, so it adds **no** handling latency (verified — that's why this can't regress the worker's timing tests).

## Live test results
Ran the real `_emit_task_processed` against a **real archived cron task file** on this host, telemetry captured:
```
using real cron task file: task-cron-weekly-release-suggest-….txt
captured task_processed calls: ['cron']   -> source parsed as 'cron'
PASS: worker now emits task_processed for a cron task
```
Unit test added to `tests/task-workstream-session-worker.test.py`: source='cron' → emits 'cron'; no source header → 'unknown' (never dropped); a telemetry that raises is swallowed (best-effort). Passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
